### PR TITLE
fix(report): share and stabilize the edition timeline UI

### DIFF
--- a/components/t262-charts.js
+++ b/components/t262-charts.js
@@ -11,34 +11,123 @@
 
 class T262Donut extends HTMLElement {
   static get observedAttributes() {
-    return ["pass", "fail", "ce", "skip", "total", "src", "include-sloppy"];
+    return ["pass", "fail", "ce", "skip", "total", "src", "include-sloppy", "caption-main", "caption-sub"];
   }
 
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+    this._renderQueued = false;
+    this._renderToken = 0;
+    this._raf = 0;
+    this._observer = null;
+    this._displayState = { deg: 0, pct: 0, passCount: 0 };
+    this._hasCompletedIntroAnimation = false;
+    this._introMsPerDeg = null;
   }
 
   connectedCallback() {
-    this._render();
+    this._queueRender();
   }
 
   attributeChangedCallback() {
-    this._render();
+    this._queueRender();
+  }
+
+  disconnectedCallback() {
+    if (this._raf) {
+      cancelAnimationFrame(this._raf);
+      this._raf = 0;
+    }
+    this._observer?.disconnect();
+    this._observer = null;
+  }
+
+  _queueRender() {
+    if (this._renderQueued) return;
+    this._renderQueued = true;
+    queueMicrotask(() => {
+      this._renderQueued = false;
+      this._render();
+    });
+  }
+
+  _applyGaugeState({ tick, valueEl, wrap, glow, passCountEl }, current, target) {
+    const safeDeg = Math.max(0, Number(current?.deg ?? 0));
+    const safePct = Number(current?.pct ?? 0);
+    const safePassCount = Math.max(0, Number(current?.passCount ?? 0));
+    const failDeg = Number(target?.failDeg ?? 0);
+    const ceDeg = Number(target?.ceDeg ?? 0);
+
+    tick.style.transform = `rotate(${safeDeg}deg)`;
+    valueEl.textContent = `${safePct.toFixed(1)}%`;
+    if (passCountEl) {
+      passCountEl.textContent = Math.round(safePassCount).toLocaleString();
+    }
+
+    wrap.style.background =
+      "conic-gradient(" +
+      "var(--_bg) 0deg 1deg," +
+      "rgba(255,255,255,0.06) 1deg," +
+      "rgba(255,255,255,0.9) " +
+      safeDeg +
+      "deg," +
+      "rgba(255,255,255,0.06) " +
+      safeDeg +
+      "deg " +
+      (failDeg - 1) +
+      "deg," +
+      "var(--_bg) " +
+      (failDeg - 1) +
+      "deg " +
+      (failDeg + 1) +
+      "deg," +
+      "rgba(255,255,255,0.06) " +
+      (failDeg + 1) +
+      "deg " +
+      (ceDeg - 1) +
+      "deg," +
+      "var(--_bg) " +
+      (ceDeg - 1) +
+      "deg " +
+      (ceDeg + 1) +
+      "deg," +
+      "rgba(255,255,255,0.06) " +
+      (ceDeg + 1) +
+      "deg 359deg," +
+      "var(--_bg) 359deg 360deg)";
+
+    if (glow) {
+      glow.style.background =
+        "conic-gradient(" +
+        "rgba(255,255,255,0) 0deg," +
+        "rgba(255,255,255,0.25) " +
+        safeDeg +
+        "deg," +
+        "rgba(255,255,255,0) " +
+        (safeDeg + 1) +
+        "deg 360deg)";
+    }
+
+    this._displayState = { deg: safeDeg, pct: safePct, passCount: safePassCount };
   }
 
   async _render() {
+    const renderToken = ++this._renderToken;
     let pass = Number(this.getAttribute("pass") || 0);
     let fail = Number(this.getAttribute("fail") || 0);
     let ce = Number(this.getAttribute("ce") || 0);
     let skip = Number(this.getAttribute("skip") || 0);
     let total = Number(this.getAttribute("total") || 0);
+    const captionMain = this.getAttribute("caption-main") || "ECMAScript";
+    const captionSub = this.getAttribute("caption-sub") || "conformance";
 
     // Auto-fetch from report JSON if no attributes given
     if (pass === 0 && fail === 0 && ce === 0 && skip === 0) {
       const src = this.getAttribute("src") || "./benchmarks/results/test262-report.json";
       try {
         const resp = await fetch(src);
+        if (renderToken !== this._renderToken) return;
         if (!resp.ok) return;
         const report = await resp.json();
         // Default: exclude sloppy-mode-only tests (noStrict).
@@ -333,8 +422,8 @@ class T262Donut extends HTMLElement {
             <div class="gauge-center">
               <div class="gauge-value">0.0%</div>
               <div class="gauge-caption">
-                <div class="gauge-caption-main">ECMAScript</div>
-                <div class="gauge-caption-sub">conformance</div>
+                <div class="gauge-caption-main">${captionMain}</div>
+                <div class="gauge-caption-sub">${captionSub}</div>
               </div>
             </div>
           </div>
@@ -346,7 +435,13 @@ class T262Donut extends HTMLElement {
       </div>
     `;
 
-    // Animate: sweep tick from 0 to passDeg, count up percentage
+    if (this._raf) {
+      cancelAnimationFrame(this._raf);
+      this._raf = 0;
+    }
+    this._observer?.disconnect();
+    this._observer = null;
+
     const tick = this.shadowRoot.querySelector(".pass-tick");
     const valueEl = this.shadowRoot.querySelector(".gauge-value");
     const wrap = this.shadowRoot.querySelector(".gauge-wrap");
@@ -354,9 +449,27 @@ class T262Donut extends HTMLElement {
     const passCountEl = this.shadowRoot.querySelector('[data-stat="pass"]');
     if (!tick || !valueEl || !wrap) return;
 
-    const duration = 3293;
-    const targetPct = parseFloat(pct);
-    const targetDeg = passDeg;
+    const targetState = {
+      deg: passDeg,
+      pct: parseFloat(pct),
+      passCount: pass,
+      failDeg,
+      ceDeg,
+    };
+    const startState = {
+      deg: this._displayState?.deg ?? 0,
+      pct: this._displayState?.pct ?? 0,
+      passCount: this._displayState?.passCount ?? 0,
+    };
+    this._applyGaugeState({ tick, valueEl, wrap, glow, passCountEl }, startState, targetState);
+
+    const INTRO_DURATION_MS = 3293;
+    const angleDelta = Math.abs(targetState.deg - startState.deg);
+    const effectiveIntroMsPerDeg =
+      this._introMsPerDeg ?? (INTRO_DURATION_MS / Math.max(Math.abs(targetState.deg), 1));
+    const duration = this._hasCompletedIntroAnimation
+      ? angleDelta * effectiveIntroMsPerDeg
+      : INTRO_DURATION_MS;
     let start = null;
 
     const ease = (t) => 1 - (1 - t) * (1 - t); // ease-out quad
@@ -367,86 +480,904 @@ class T262Donut extends HTMLElement {
       const progress = Math.min(elapsed / duration, 1);
       const t = ease(progress);
 
-      const curDeg = t * targetDeg;
-      const curPct = (t * targetPct).toFixed(1);
-
-      // Update tick rotation
-      tick.style.transform = "rotate(" + curDeg + "deg)";
-
-      // Update percentage and pass count
-      valueEl.textContent = curPct + "%";
-      if (passCountEl) {
-        passCountEl.textContent = Math.round(t * pass).toLocaleString();
-      }
-
-      // Update conic-gradient to reveal pass segment up to curDeg
-      wrap.style.background =
-        "conic-gradient(" +
-        "var(--_bg) 0deg 1deg," +
-        "rgba(255,255,255,0.06) 1deg," +
-        "rgba(255,255,255,0.9) " +
-        curDeg +
-        "deg," +
-        "rgba(255,255,255,0.06) " +
-        curDeg +
-        "deg " +
-        (failDeg - 1) +
-        "deg," +
-        "var(--_bg) " +
-        (failDeg - 1) +
-        "deg " +
-        (failDeg + 1) +
-        "deg," +
-        "rgba(255,255,255,0.06) " +
-        (failDeg + 1) +
-        "deg " +
-        (ceDeg - 1) +
-        "deg," +
-        "var(--_bg) " +
-        (ceDeg - 1) +
-        "deg " +
-        (ceDeg + 1) +
-        "deg," +
-        "rgba(255,255,255,0.06) " +
-        (ceDeg + 1) +
-        "deg 359deg," +
-        "var(--_bg) 359deg 360deg)";
-
-      // Update glow to follow the needle
-      if (glow) {
-        glow.style.background =
-          "conic-gradient(" +
-          "rgba(255,255,255,0) 0deg," +
-          "rgba(255,255,255,0.25) " +
-          curDeg +
-          "deg," +
-          "rgba(255,255,255,0) " +
-          (curDeg + 1) +
-          "deg 360deg)";
-      }
+      const currentState = {
+        deg: startState.deg + (targetState.deg - startState.deg) * t,
+        pct: startState.pct + (targetState.pct - startState.pct) * t,
+        passCount: startState.passCount + (targetState.passCount - startState.passCount) * t,
+      };
+      this._applyGaugeState({ tick, valueEl, wrap, glow, passCountEl }, currentState, targetState);
 
       if (progress < 1) {
-        requestAnimationFrame(animate);
+        this._raf = requestAnimationFrame(animate);
+      } else {
+        this._raf = 0;
+        if (!this._hasCompletedIntroAnimation) {
+          this._introMsPerDeg = INTRO_DURATION_MS / Math.max(angleDelta, 1);
+        }
+        this._hasCompletedIntroAnimation = true;
       }
     };
 
+    if (
+      Math.abs(targetState.deg - startState.deg) < 0.01 &&
+      Math.abs(targetState.pct - startState.pct) < 0.01 &&
+      Math.abs(targetState.passCount - startState.passCount) < 0.5
+    ) {
+      this._applyGaugeState({ tick, valueEl, wrap, glow, passCountEl }, targetState, targetState);
+      return;
+    }
+
     // Start animation when element enters viewport
-    const observer = new IntersectionObserver(
+    this._observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
-            observer.disconnect();
-            requestAnimationFrame(animate);
+            this._observer?.disconnect();
+            this._observer = null;
+            this._raf = requestAnimationFrame(animate);
           }
         }
       },
       { threshold: 0.3 },
     );
-    observer.observe(this);
+    this._observer.observe(this);
   }
 }
 
 customElements.define("t262-donut", T262Donut);
+
+/* ── Shared edition timeline helpers ──────────────────────────── */
+
+const T262_PROPOSAL_LABEL = "Proposals";
+const T262_EDITION_SCOPE_RANK = new Map([
+  ["ES1", 0],
+  ["ES2", 1],
+  ["ES3 / Core", 2],
+  ["ES5", 3],
+  ["ES2015", 4],
+  ["ES2016", 5],
+  ["ES2017", 6],
+  ["ES2018", 7],
+  ["ES2019", 8],
+  ["ES2020", 9],
+  ["ES2021", 10],
+  ["ES2022", 11],
+  ["ES2023", 12],
+  ["ES2024", 13],
+  ["ES2025", 14],
+  ["ES2026", 15],
+]);
+const T262_EDITION_RELEASE_YEAR = new Map([
+  ["ES1", 1997],
+  ["ES2", 1998],
+  ["ES3 / Core", 1999],
+  ["ES5", 2009],
+  ["ES2015", 2015],
+  ["ES2016", 2016],
+  ["ES2017", 2017],
+  ["ES2018", 2018],
+  ["ES2019", 2019],
+  ["ES2020", 2020],
+  ["ES2021", 2021],
+  ["ES2022", 2022],
+  ["ES2023", 2023],
+  ["ES2024", 2024],
+  ["ES2025", 2025],
+  ["ES2026", 2026],
+]);
+const T262_PUBLISHED_EDITION_RELEASE_MONTH = 6;
+
+function t262IsEditionScope(edition) {
+  return (
+    edition === "ES1" ||
+    edition === "ES2" ||
+    edition === "ES3" ||
+    edition === "≤ ES3" ||
+    edition === "ES5" ||
+    /^ES20\d{2}$/.test(edition)
+  );
+}
+
+function t262NormalizeEditionLabel(edition) {
+  return edition === "≤ ES3" || edition === "ES3" ? "ES3 / Core" : edition;
+}
+
+function t262EditionReleaseYear(edition) {
+  return T262_EDITION_RELEASE_YEAR.get(t262NormalizeEditionLabel(edition)) ?? null;
+}
+
+function t262BuildTimelineLayout(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { segments: [], totalSpan: 0, hasExplicitLegacyBreakdown: false };
+  }
+
+  const hasExplicitLegacyBreakdown = rows.some((row) => row.edition === "ES1" || row.edition === "ES2");
+  const segments = rows.map((row, index) => {
+    const normalizedEdition = t262NormalizeEditionLabel(row.edition);
+    const releaseYear = t262EditionReleaseYear(normalizedEdition);
+    const startYear = normalizedEdition === "ES3 / Core" && !hasExplicitLegacyBreakdown ? 1997 : (releaseYear ?? index);
+    const nextEdition = rows[index + 1]?.edition ?? null;
+    const nextReleaseYear = nextEdition ? t262EditionReleaseYear(nextEdition) : null;
+    const endYear = Math.max(nextReleaseYear ?? ((releaseYear ?? startYear) + 1), startYear + 1);
+    return {
+      row,
+      startYear,
+      endYear,
+      span: Math.max(endYear - startYear, 1),
+    };
+  });
+
+  return {
+    segments,
+    totalSpan: segments.reduce((sum, segment) => sum + segment.span, 0),
+    hasExplicitLegacyBreakdown,
+  };
+}
+
+function t262LegacyStopDefinitions(layout, firstRow) {
+  if (!layout || layout.hasExplicitLegacyBreakdown || !firstRow || firstRow.edition !== "ES3 / Core") {
+    return [];
+  }
+  const legacySegment = layout.segments[0];
+  if (!legacySegment) return [];
+  const start = legacySegment.startYear;
+  return [
+    { label: "ES1", value: "ES1", position: 0, rawEdition: "ES1" },
+    { label: "ES2", value: "ES2", position: Math.max(1998 - start, 0), rawEdition: "ES2" },
+    { label: "ES3 / Core", value: firstRow.rawEdition, position: Math.max(1999 - start, 0), rawEdition: firstRow.rawEdition },
+  ];
+}
+
+function t262LegacyActiveEdition(scope, rows, hasExplicitLegacyBreakdown) {
+  if (
+    !hasExplicitLegacyBreakdown &&
+    rows?.[0]?.edition === "ES3 / Core" &&
+    (scope === "ES1" || scope === "ES2")
+  ) {
+    return "ES3 / Core";
+  }
+  return null;
+}
+
+function t262LegacyLimitRank(scope, rows, hasExplicitLegacyBreakdown) {
+  if (
+    !hasExplicitLegacyBreakdown &&
+    rows?.[0]?.edition === "ES3 / Core" &&
+    (scope === "ES1" || scope === "ES2")
+  ) {
+    return T262_EDITION_SCOPE_RANK.get("ES3 / Core") ?? null;
+  }
+  return null;
+}
+
+function t262LatestPublishedEditionYear(referenceDate = new Date()) {
+  const date =
+    referenceDate instanceof Date && Number.isFinite(referenceDate.getTime()) ? referenceDate : new Date();
+  return date.getUTCMonth() + 1 >= T262_PUBLISHED_EDITION_RELEASE_MONTH
+    ? date.getUTCFullYear()
+    : date.getUTCFullYear() - 1;
+}
+
+function t262ResolveLatestPublishedEdition(rows, referenceDate = new Date()) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const publishedYear = t262LatestPublishedEditionYear(referenceDate);
+  const publishedRows = rows.filter((row) => {
+    const match = /^ES(\d{4})$/.exec(row.edition || "");
+    return match ? Number(match[1]) <= publishedYear : false;
+  });
+  return publishedRows.at(-1) || rows.at(-1) || null;
+}
+
+function t262ConformanceCaptionMain(edition) {
+  if (edition === "ES1") return "ECMAScript 1";
+  if (edition === "ES2") return "ECMAScript 2";
+  if (edition === "ES3" || edition === "≤ ES3") return "ECMAScript 3";
+  const match = /^ES(\d+)$/.exec(edition || "");
+  return match ? `ECMAScript ${match[1]}` : "ECMAScript";
+}
+
+function t262DisplayEditionLabel(edition) {
+  if (edition === "ES1") return "ES1 1997";
+  if (edition === "ES2") return "ES2 1998";
+  if (edition === "ES3 / Core" || edition === "ES3") return "ES3 1999";
+  if (edition === "ES5") return "ES5 2009";
+  if (edition === "ES2015") return "ES 6 2015";
+  return edition;
+}
+
+/* ── <t262-edition-timeline> ──────────────────────────────────── */
+
+class T262EditionTimeline extends HTMLElement {
+  static get observedAttributes() {
+    return ["src", "reference-timestamp", "value", "show-proposals"];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._renderQueued = false;
+    this._dataPromise = null;
+    this._data = null;
+    this._currentScope = this.getAttribute("value") || "overall";
+    this._lastEmittedScope = null;
+    this._sliderListener = () => this._handleSliderInput();
+    this._ensureRoot();
+  }
+
+  connectedCallback() {
+    this._queueRender();
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "value") {
+      this._setScope(newValue || "overall", { emit: true, reflect: false });
+      return;
+    }
+    if (name === "src") {
+      this._dataPromise = null;
+      this._data = null;
+    }
+    this._queueRender();
+  }
+
+  get value() {
+    return this._currentScope;
+  }
+
+  set value(next) {
+    this._setScope(next || "overall", { emit: true, reflect: true });
+  }
+
+  _ensureRoot() {
+    if (this._root) return;
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          width: 100%;
+          color: var(--t262-edition-text, currentColor);
+          --_text: var(--t262-edition-text, currentColor);
+          --_text-muted: var(--t262-edition-text-muted, rgba(255, 255, 255, 0.46));
+        }
+        .section {
+          width: 100%;
+        }
+        .head {
+          display: flex;
+          align-items: baseline;
+          justify-content: space-between;
+          gap: 1rem;
+          margin-bottom: 1rem;
+        }
+        .title {
+          display: block;
+          margin-bottom: 0;
+          font-family: var(--t262-edition-font-mono, inherit);
+          font-size: 11px;
+          font-weight: 500;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--_text-muted);
+        }
+        .value {
+          font-family: var(--t262-edition-font-mono, inherit);
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--_text);
+          font-variant-numeric: tabular-nums;
+        }
+        .track {
+          position: relative;
+          height: 92px;
+          --edition-slider-thumb-size: 16px;
+          --edition-track-bleed: calc(var(--edition-slider-thumb-size) / 2);
+          --edition-progress-scale: 0;
+        }
+        .slider {
+          appearance: none;
+          position: absolute;
+          left: calc(var(--edition-track-bleed) * -1);
+          top: 24px;
+          width: calc(100% + (var(--edition-track-bleed) * 2));
+          height: 28px;
+          margin: 0;
+          outline: none;
+          border: 0;
+          background: transparent;
+          z-index: 3;
+          cursor: pointer;
+        }
+        .slider::-webkit-slider-runnable-track {
+          height: 28px;
+          border: 0;
+          background: transparent;
+        }
+        .slider::-webkit-slider-thumb {
+          appearance: none;
+          width: var(--edition-slider-thumb-size);
+          height: var(--edition-slider-thumb-size);
+          margin-top: 6px;
+          border-radius: 50%;
+          border: 1px solid rgba(255, 255, 255, 0.22);
+          background: #ffffff;
+          box-shadow:
+            0 2px 10px rgba(0, 0, 0, 0.28),
+            0 0 0 4px rgba(255, 255, 255, 0.08);
+          cursor: pointer;
+        }
+        .slider::-moz-range-thumb {
+          width: var(--edition-slider-thumb-size);
+          height: var(--edition-slider-thumb-size);
+          border-radius: 50%;
+          border: 1px solid rgba(255, 255, 255, 0.22);
+          background: #ffffff;
+          box-shadow:
+            0 2px 10px rgba(0, 0, 0, 0.28),
+            0 0 0 4px rgba(255, 255, 255, 0.08);
+          cursor: pointer;
+        }
+        .slider::-moz-range-track {
+          height: 28px;
+          background: transparent;
+        }
+        .slider:focus {
+          outline: none;
+        }
+        .slider:focus-visible::-webkit-slider-thumb {
+          box-shadow:
+            0 2px 10px rgba(0, 0, 0, 0.28),
+            0 0 0 4px rgba(255, 255, 255, 0.08),
+            0 0 0 6px rgba(255, 255, 255, 0.12);
+        }
+        .slider:focus-visible::-moz-range-thumb {
+          box-shadow:
+            0 2px 10px rgba(0, 0, 0, 0.28),
+            0 0 0 4px rgba(255, 255, 255, 0.08),
+            0 0 0 6px rgba(255, 255, 255, 0.12);
+        }
+        .slider:disabled {
+          opacity: 0.5;
+          cursor: wait;
+        }
+        .progress-glow,
+        .progress {
+          position: absolute;
+          left: 0;
+          width: 100%;
+          border-radius: 999px;
+          pointer-events: none;
+          transform-origin: left center;
+          transform: scaleX(var(--edition-progress-scale));
+        }
+        .progress-glow {
+          top: 30px;
+          height: 18px;
+          background: linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 56%,
+            rgba(255, 255, 255, 0.03) 72%,
+            rgba(255, 255, 255, 0.14) 88%,
+            rgba(255, 255, 255, 0.5) 100%
+          );
+          filter: blur(10px);
+          opacity: 1;
+          z-index: 1;
+        }
+        .progress {
+          display: none;
+        }
+        .timeline {
+          position: absolute;
+          left: 0;
+          right: 0;
+          top: 33px;
+          display: flex;
+          height: 10px;
+          overflow: hidden;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.14);
+          border: 1px solid rgba(255, 255, 255, 0.06);
+          pointer-events: none;
+        }
+        .segment {
+          position: relative;
+          min-width: 10px;
+          background: transparent;
+        }
+        .segment.active {
+          box-shadow:
+            inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+            0 0 0 1px rgba(255, 255, 255, 0.06);
+        }
+        .segment.dimmed {
+          background: rgba(0, 0, 0, 0.34);
+        }
+        .segment + .segment::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          width: 1px;
+          background: rgba(255, 255, 255, 0.06);
+        }
+        .scale {
+          position: absolute;
+          left: 0;
+          top: 0;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+        }
+        .marker {
+          position: absolute;
+          transform: translateX(-50%);
+          pointer-events: none;
+        }
+        .line {
+          position: absolute;
+          left: 50%;
+          transform: translateX(-50%);
+          width: 1px;
+          height: 10px;
+          background: rgba(255, 255, 255, 0.18);
+        }
+        .marker.above {
+          top: 0;
+        }
+        .marker.above .line {
+          top: 23px;
+        }
+        .marker.below {
+          top: 0;
+        }
+        .marker.below .line {
+          top: 43px;
+        }
+        .label {
+          position: relative;
+          font-family: var(--t262-edition-font-mono, inherit);
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+          color: var(--_text-muted);
+          white-space: nowrap;
+        }
+        .marker.above .label {
+          position: absolute;
+          top: 0;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+        .marker.below .label {
+          position: absolute;
+          top: 54px;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+        .marker.active .line {
+          background: rgba(255, 255, 255, 0.42);
+        }
+        .marker.active .label {
+          color: rgba(255, 255, 255, 0.92);
+        }
+        .marker.dimmed .line {
+          background: rgba(255, 255, 255, 0.08);
+        }
+        .marker.dimmed .label {
+          color: rgba(255, 255, 255, 0.2);
+        }
+        .copy {
+          min-height: 1.2rem;
+          margin: 0.7rem 0 0;
+          font-size: 12px;
+          line-height: 1.6;
+          color: var(--_text-muted);
+          text-align: left;
+        }
+      </style>
+      <div class="section">
+        <div class="head">
+          <div class="title">ECMAScript Editions</div>
+          <div class="value">Loading…</div>
+        </div>
+        <div class="track">
+          <div class="progress-glow"></div>
+          <div class="progress"></div>
+          <input class="slider" type="range" min="0" max="1" step="any" value="0" disabled aria-label="ECMAScript edition timeline filter" />
+        </div>
+        <p class="copy">Drag to snap to the nearest ECMAScript edition.</p>
+      </div>
+    `;
+
+    this._root = {
+      value: this.shadowRoot.querySelector(".value"),
+      track: this.shadowRoot.querySelector(".track"),
+      slider: this.shadowRoot.querySelector(".slider"),
+      copy: this.shadowRoot.querySelector(".copy"),
+    };
+    this._root.slider.addEventListener("input", this._sliderListener);
+    this._root.slider.addEventListener("change", this._sliderListener);
+  }
+
+  _queueRender() {
+    if (this._renderQueued) return;
+    this._renderQueued = true;
+    queueMicrotask(async () => {
+      this._renderQueued = false;
+      await this._render();
+    });
+  }
+
+  async _loadData() {
+    if (!this._dataPromise) {
+      const src = this.getAttribute("src") || "./benchmarks/results/test262-editions.json";
+      this._dataPromise = (async () => {
+        const resp = await fetch(src);
+        if (!resp.ok) throw new Error("edition data unavailable");
+        const editions = await resp.json();
+        if (!Array.isArray(editions) || editions.length === 0) {
+          throw new Error("edition data unavailable");
+        }
+
+        const rows = editions
+          .filter((edition) => t262IsEditionScope(String(edition?.edition || "")))
+          .map((edition) => {
+            const rawEdition = String(edition.edition || "");
+            const normalizedEdition = t262NormalizeEditionLabel(rawEdition);
+            return {
+              rawEdition,
+              edition: normalizedEdition,
+              displayLabel: t262DisplayEditionLabel(normalizedEdition),
+              pass: Number(edition.pass ?? 0),
+              fail: Number(edition.fail ?? 0),
+              ce: Number(edition.ce ?? 0),
+              skip: Number(edition.skip ?? 0),
+              total: Number(edition.total ?? 0),
+              rate: Number(edition.pct ?? 0),
+              rank: T262_EDITION_SCOPE_RANK.get(normalizedEdition) ?? Number.MAX_SAFE_INTEGER,
+            };
+          });
+
+        const cumulativeScopes = [];
+        const running = { pass: 0, fail: 0, ce: 0, skip: 0, total: 0 };
+        rows.forEach((row) => {
+          running.pass += row.pass;
+          running.fail += row.fail;
+          running.ce += row.ce;
+          running.skip += row.skip;
+          running.total += row.total;
+          cumulativeScopes.push({
+            value: row.rawEdition,
+            label: row.edition,
+            captionMain: t262ConformanceCaptionMain(row.rawEdition),
+            summary: { ...running },
+          });
+        });
+
+        return { rows, cumulativeScopes };
+      })();
+    }
+    return this._dataPromise;
+  }
+
+  async _render() {
+    try {
+      this._data = await this._loadData();
+      this._syncUI();
+      this.dispatchEvent(
+        new CustomEvent("edition-ready", {
+          detail: this._detail(),
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      this._emitChange(true);
+    } catch {
+      this._data = null;
+      this._renderTimeline([]);
+      this._root.slider.disabled = true;
+      this._root.slider.value = "0";
+      this._root.track.style.setProperty("--edition-progress-scale", "0");
+      this._root.value.textContent = "Unavailable";
+      this._root.copy.textContent = "No ECMAScript edition data available.";
+    }
+  }
+
+  _setScope(nextScope, { emit = true, reflect = false } = {}) {
+    this._currentScope = nextScope || "overall";
+    if (reflect && this.getAttribute("value") !== this._currentScope) {
+      this.setAttribute("value", this._currentScope);
+    }
+    if (this._data) {
+      this._syncUI();
+      this._emitChange(emit);
+    }
+  }
+
+  _detail() {
+    if (!this._data) {
+      return {
+        scope: this._currentScope,
+        rows: [],
+        cumulativeScopes: [],
+        publishedStop: null,
+        proposalStop: null,
+        publishedLimitRank: null,
+        proposalEditionLabels: new Set(),
+        activeEdition: null,
+        limitRank: null,
+        displayValue: "Unavailable",
+        copy: "No ECMAScript edition data available.",
+        captionMain: "ECMAScript",
+      };
+    }
+
+    const rows = this._data.rows;
+    const cumulativeScopes = this._data.cumulativeScopes;
+    const referenceTimestamp = this.getAttribute("reference-timestamp");
+    const referenceDate = referenceTimestamp ? new Date(referenceTimestamp) : new Date();
+    const layout = t262BuildTimelineLayout(rows);
+    const { hasExplicitLegacyBreakdown } = layout;
+    const latestPublishedEdition = t262ResolveLatestPublishedEdition(rows, referenceDate);
+    const publishedLimitRank = latestPublishedEdition
+      ? (T262_EDITION_SCOPE_RANK.get(latestPublishedEdition.edition) ?? Number.MAX_SAFE_INTEGER)
+      : Number.MAX_SAFE_INTEGER;
+    const fullLayout = t262BuildTimelineLayout(rows);
+    const publishedRows = rows.filter((row) => row.rank <= publishedLimitRank);
+    const publishedLayout = t262BuildTimelineLayout(publishedRows);
+    const proposalEditionLabels = new Set(rows.filter((row) => row.rank > publishedLimitRank).map((row) => row.edition));
+    let cumulativeWeight = 0;
+    const editionSliderStops = publishedRows.flatMap((row, index) => {
+      if (index === 0) {
+        const legacyStops = t262LegacyStopDefinitions(publishedLayout, row);
+        if (legacyStops.length) {
+          cumulativeWeight += publishedLayout.segments[0]?.span ?? 1;
+          return legacyStops;
+        }
+      }
+      const segment = publishedLayout.segments.find((candidate) => candidate.row === row);
+      const position = cumulativeWeight;
+      cumulativeWeight += segment?.span ?? 1;
+      return [
+        {
+          label: row.edition,
+          value: row.rawEdition,
+          position,
+          rawEdition: row.rawEdition,
+        },
+      ];
+    });
+    const publishedStop = editionSliderStops.at(-1)
+      ? {
+          ...editionSliderStops.at(-1),
+          rawEdition: latestPublishedEdition?.rawEdition || editionSliderStops.at(-1).value,
+        }
+      : null;
+    const totalTimelineWeight = fullLayout.totalSpan;
+    const showProposals = this.hasAttribute("show-proposals");
+    const proposalStop =
+      showProposals && proposalEditionLabels.size
+        ? {
+            label: T262_PROPOSAL_LABEL,
+            value: "overall+proposal",
+            position: totalTimelineWeight,
+          }
+        : null;
+    const scopeMap = new Map(cumulativeScopes.map((scope) => [scope.value, scope]));
+    if (!hasExplicitLegacyBreakdown && rows[0]?.edition === "ES3 / Core") {
+      const firstScope = cumulativeScopes[0];
+      if (firstScope) {
+        scopeMap.set("ES1", { ...firstScope, value: "ES1", label: "ES1", captionMain: "ECMAScript 1" });
+        scopeMap.set("ES2", { ...firstScope, value: "ES2", label: "ES2", captionMain: "ECMAScript 2" });
+      }
+    }
+    const activeStop = editionSliderStops.find((stop) => stop.value === this._currentScope) || null;
+    const limitRank =
+      this._currentScope && this._currentScope !== "overall" && this._currentScope !== "overall+proposal"
+        ? (t262LegacyLimitRank(this._currentScope, rows, hasExplicitLegacyBreakdown) ??
+          (T262_EDITION_SCOPE_RANK.get(t262NormalizeEditionLabel(this._currentScope)) ?? null))
+        : publishedStop
+          ? (T262_EDITION_SCOPE_RANK.get(publishedStop.label) ?? null)
+          : null;
+    const activeEdition =
+      this._currentScope === "overall+proposal"
+        ? (rows.at(-1)?.edition ?? publishedStop?.label ?? null)
+        : this._currentScope && this._currentScope !== "overall"
+          ? (t262LegacyActiveEdition(this._currentScope, rows, hasExplicitLegacyBreakdown) ??
+            t262NormalizeEditionLabel(this._currentScope))
+          : (publishedStop?.label ?? rows.at(-1)?.edition ?? null);
+
+    let displayValue = publishedStop ? t262DisplayEditionLabel(publishedStop.label) : "Unavailable";
+    let copy = "Drag to snap to the nearest ECMAScript edition.";
+    let captionMain = publishedStop?.rawEdition ? t262ConformanceCaptionMain(publishedStop.rawEdition) : "ECMAScript";
+
+    if (this._currentScope === "overall") {
+      copy = proposalStop
+        ? "Drag to snap through published ECMAScript editions, then move slightly past the latest published edition to include proposals."
+        : "Drag to snap through published ECMAScript editions. The final stop is the latest published edition.";
+    } else if (this._currentScope === "overall+proposal") {
+      displayValue = T262_PROPOSAL_LABEL;
+      copy = "Move past the latest published edition to include proposals.";
+      captionMain = "ECMAScript + proposals";
+    } else if (activeStop) {
+      displayValue = t262DisplayEditionLabel(activeStop.label);
+      copy = `Showing cumulative conformance through ${t262DisplayEditionLabel(activeStop.label)}.`;
+      captionMain = t262ConformanceCaptionMain(activeStop.value);
+    }
+
+    return {
+      scope: this._currentScope,
+      rows,
+      cumulativeScopes,
+      scopeMap,
+      publishedStop,
+      proposalStop,
+      publishedLimitRank,
+      proposalEditionLabels,
+      activeEdition,
+      limitRank,
+      displayValue,
+      copy,
+      captionMain,
+      editionSliderStops,
+    };
+  }
+
+  _emitChange(force = false) {
+    if (!force && this._lastEmittedScope === this._currentScope) return;
+    this._lastEmittedScope = this._currentScope;
+    this.dispatchEvent(
+      new CustomEvent("edition-change", {
+        detail: this._detail(),
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  _renderTimeline(rows, activeEdition = null, dimAfterRank = null, proposalEditionLabels = new Set(), activeScope = null) {
+    this._root.track.querySelectorAll(".timeline, .scale").forEach((node) => node.remove());
+    if (!rows || rows.length === 0) return;
+
+    const timeline = document.createElement("div");
+    timeline.className = "timeline";
+    const scale = document.createElement("div");
+    scale.className = "scale";
+    const layout = t262BuildTimelineLayout(rows);
+    const { segments, totalSpan, hasExplicitLegacyBreakdown } = layout;
+    if (!segments.length || totalSpan <= 0) return;
+    let cumulativeWeight = 0;
+
+    const scaleLabelFor = (edition) => {
+      const displayLabel = proposalEditionLabels.has(edition) ? T262_PROPOSAL_LABEL : t262DisplayEditionLabel(edition);
+      return /^ES20\d{2}$/.test(displayLabel) ? displayLabel.slice(2) : displayLabel;
+    };
+    const appendMarker = (label, leftPercent, placement, isActive = false, isDimmed = false) => {
+      const marker = document.createElement("div");
+      marker.className = "marker " + placement + (isActive ? " active" : "") + (isDimmed ? " dimmed" : "");
+      marker.style.left = `${leftPercent}%`;
+      const line = document.createElement("div");
+      line.className = "line";
+      const text = document.createElement("div");
+      text.className = "label";
+      text.textContent = label;
+      marker.appendChild(line);
+      marker.appendChild(text);
+      scale.appendChild(marker);
+    };
+
+    segments.forEach((timelineSegment, index) => {
+      const { row, startYear, span } = timelineSegment;
+      const segmentEl = document.createElement("div");
+      segmentEl.className = "segment";
+      const isActive = row.edition === activeEdition;
+      const isMarkerDimmed = dimAfterRank !== null && row.rank > dimAfterRank;
+      const isSegmentDimmed = dimAfterRank !== null && row.rank > dimAfterRank;
+      if (isActive) segmentEl.classList.add("active");
+      if (isSegmentDimmed) segmentEl.classList.add("dimmed");
+      segmentEl.style.flex = String(span);
+      timeline.appendChild(segmentEl);
+
+      const segmentStartWeight = cumulativeWeight;
+      const segmentStartPercent = (segmentStartWeight / totalSpan) * 100;
+      cumulativeWeight += span;
+      const segmentEndPercent = (cumulativeWeight / totalSpan) * 100;
+      const yearPercent = (year) => ((segmentStartWeight + Math.max(0, Math.min(year - startYear, span))) / totalSpan) * 100;
+
+      if (row.edition === "ES3 / Core" && !hasExplicitLegacyBreakdown) {
+        const normalizedScope = t262NormalizeEditionLabel(activeScope || "");
+        appendMarker("ES1 1997", segmentStartPercent, "below", activeScope === "ES1");
+        appendMarker("ES2 1998", yearPercent(1998), "above", activeScope === "ES2");
+        appendMarker(
+          "ES3 1999",
+          yearPercent(1999),
+          "below",
+          normalizedScope === "ES3 / Core" || activeScope === row.rawEdition || isActive,
+          isMarkerDimmed,
+        );
+      } else {
+        const isProposalTail = proposalEditionLabels.has(row.edition) && index === segments.length - 1;
+        appendMarker(
+          scaleLabelFor(row.edition),
+          isProposalTail ? segmentEndPercent : segmentStartPercent,
+          index % 2 === 0 ? "below" : "above",
+          isActive,
+          isMarkerDimmed,
+        );
+      }
+    });
+
+    this._root.track.appendChild(timeline);
+    this._root.track.appendChild(scale);
+  }
+
+  _syncUI() {
+    const detail = this._detail();
+    if (!detail.publishedStop) {
+      this._root.slider.disabled = true;
+      this._root.slider.value = "0";
+      this._root.track.style.setProperty("--edition-progress-scale", "0");
+      this._root.value.textContent = "Unavailable";
+      this._root.copy.textContent = "No ECMAScript edition data available.";
+      this._renderTimeline([]);
+      return;
+    }
+
+    if (detail.scope === "overall+proposal" && !detail.proposalStop) {
+      this._currentScope = "overall";
+      return this._syncUI();
+    }
+
+    const maxStop = detail.proposalStop?.position ?? detail.publishedStop.position ?? 1;
+    const activeStop = detail.editionSliderStops.find((stop) => stop.value === this._currentScope) || null;
+    const sliderPosition =
+      this._currentScope === "overall+proposal"
+        ? (detail.proposalStop?.position ?? detail.publishedStop.position)
+        : this._currentScope === "overall"
+          ? detail.publishedStop.position
+          : (activeStop?.position ?? detail.publishedStop.position);
+
+    this._root.slider.disabled = false;
+    this._root.slider.min = "0";
+    this._root.slider.max = String(maxStop);
+    this._root.slider.value = String(sliderPosition);
+    const progressScale = maxStop > 0 ? Math.max(0, Math.min(1, sliderPosition / maxStop)) : 0;
+    this._root.track.style.setProperty("--edition-progress-scale", String(progressScale));
+    this._root.value.textContent = detail.displayValue;
+    this._root.copy.textContent = detail.copy;
+    this._renderTimeline(detail.rows, detail.activeEdition, detail.limitRank, detail.proposalEditionLabels, detail.scope);
+  }
+
+  _handleSliderInput() {
+    const detail = this._detail();
+    const allStops = detail.proposalStop ? [...detail.editionSliderStops, detail.proposalStop] : [...detail.editionSliderStops];
+    if (!allStops.length) return;
+    const rawValue = Number(this._root.slider.value || 0);
+    let nearestStop = allStops[0];
+    let nearestDistance = Math.abs(rawValue - nearestStop.position);
+    for (const stop of allStops.slice(1)) {
+      const distance = Math.abs(rawValue - stop.position);
+      if (distance < nearestDistance) {
+        nearestStop = stop;
+        nearestDistance = distance;
+      }
+    }
+    this._root.slider.value = String(nearestStop.position);
+    if (detail.proposalStop && nearestStop.value === detail.proposalStop.value) {
+      this._setScope("overall+proposal", { emit: true, reflect: true });
+      return;
+    }
+    if (detail.publishedStop && nearestStop.value === detail.publishedStop.value) {
+      this._setScope("overall", { emit: true, reflect: true });
+      return;
+    }
+    this._setScope(nearestStop.value, { emit: true, reflect: true });
+  }
+}
+
+customElements.define("t262-edition-timeline", T262EditionTimeline);
 
 /* ── <t262-edition-bars> ──────────────────────────────────────── */
 

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
       }
 
       .hero-sub {
-        max-width: 560px;
+        max-width: 620px;
         font-size: 18px;
         line-height: 1.7;
         color: var(--fg-soft);
@@ -402,6 +402,13 @@
         text-transform: uppercase;
         color: var(--fg-faint);
         margin: 0 0 28px;
+      }
+      .edition-timeline-section {
+        width: 100%;
+        margin: 28px 0 0;
+        --t262-edition-font-mono: var(--mono);
+        --t262-edition-text: var(--fg);
+        --t262-edition-text-muted: var(--fg-faint);
       }
       .diagram-legend {
         display: flex;
@@ -1099,6 +1106,11 @@
         padding-bottom: 2px;
         line-height: 1.4;
       }
+      .feat-section[data-generated-edition] .feat-note {
+        display: block;
+        padding: 12px 24px 18px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      }
 
       .feat-badge {
         font-size: 24px;
@@ -1150,9 +1162,10 @@
             </span>
           </h1>
           <p class="hero-sub">
-            The JS
+            JS
             <sup>2</sup>
-            compiler is a Loopdive project focused on ahead-of-time compilation of real JavaScript to WebAssembly.
+            is an open source compiler focused on compiling JavaScript to WebAssembly ahead of time, based on research
+            at Loopdive.
           </p>
           <div class="hero-actions">
             <a class="btn-solid" href="./playground/">Playground</a>
@@ -1171,27 +1184,33 @@
             JavaScript and npm packages, running modules without embedding a JS runtime and enabling more secure,
             flexible dependency management.
           </p>
+          <p>
+            The project is motivated by the idea that JavaScript, despite being a dynamic language, can be compiled
+            efficiently ahead of time without limiting it to an incompatible subset or shipping a full JS runtime like
+            V8 or SpiderMonkey.
+          </p>
+          <p>The project is guided by the following goals:</p>
         </div>
         <div class="features-grid">
           <article class="feature-card">
             <div class="feature-icon"><img src="./javascript-logo-white.svg" alt="JavaScript logo" /></div>
-            <h3>Not a New Language</h3>
+            <h3>JS Ecosystem Compatible</h3>
             <p>
-              Compile existing JavaScript and TypeScript without rewriting into a new language or restricted subset.
-              Target compatibility with the JavaScript ecosystem.
+              Compile existing code without rewriting it into a restricted subset, and stay compatible with the full JS
+              ecosystem, the web, and NPM. Access Web APIs without writing glue code.
             </p>
           </article>
           <article class="feature-card">
             <div class="feature-icon"><img src="./wasm-logo-white.svg" alt="WebAssembly logo" /></div>
-            <h3>JS Host or Standalone</h3>
+            <h3>No Embedded Runtime</h3>
             <p>
-              Deploy compiled modules across JavaScript hosts and standalone WebAssembly runtimes without embedding a JS
-              engine in the module or hand-writing glue code.
+              Deploy compiled JavaScript modules in standalone WebAssembly runtimes such as Wasmtime without embedding a
+              JS engine or interpreter, reducing module size and runtime overhead.
             </p>
           </article>
           <article class="feature-card">
             <div class="feature-icon">🔒</div>
-            <h3>Module Sandboxing</h3>
+            <h3>Sandbox Untrusted Code</h3>
             <p>
               Reduce supply chain attack surface by isolating JavaScript modules from each other inside the same
               application and keeping filesystem, network, DOM, and globals behind explicit imports.
@@ -1200,10 +1219,10 @@
 
           <article class="feature-card">
             <div class="feature-icon">🧩</div>
-            <h3>Dependency Injection</h3>
+            <h3>Plug &amp; Play</h3>
             <p>
-              Link modules through explicit imports so consumers can choose implementations, control upgrades, and swap
-              dependencies for each environment.
+              Dynamic module linking allows to make code more modular so consumers can choose implementations, control
+              upgrades, and swap dependencies for each environment.
             </p>
           </article>
         </div>
@@ -1245,10 +1264,12 @@
 
         <div class="conformance-diagrams">
           <div class="diagram-panel">
-            <t262-donut
-              src="./benchmarks/results/test262-report.json"
-              style="--t262-bg: var(--bg, #060a14)"
-            ></t262-donut>
+            <div id="conformance-donut-slot">
+              <t262-donut
+                src="./benchmarks/results/test262-report.json"
+                style="--t262-bg: var(--bg, #060a14)"
+              ></t262-donut>
+            </div>
           </div>
           <div class="diagram-panel">
             <h3 class="diagram-title">ECMAScript Conformance Pass Rate Over Time</h3>
@@ -1268,6 +1289,12 @@
               </span>
             </div>
           </div>
+        </div>
+        <div class="edition-timeline-section">
+          <t262-edition-timeline
+            id="conformance-edition-timeline"
+            src="./benchmarks/results/test262-editions.json"
+          ></t262-edition-timeline>
         </div>
 
         <div class="feat-filter">
@@ -2857,7 +2884,7 @@ match (value) {
 
       <section class="section-pad" id="wasm-hosts">
         <div class="intro">
-          <h2>Tiny modules that start and run fast.</h2>
+          <h2>Lean modules that load and run fast.</h2>
           <p>
             When running outside of a JS engine like found in browsers or Node.js, compatibility today typically means
             embedding a JS interpreter inside the WebAssembly module. This increases module size and slows execution.
@@ -2893,10 +2920,25 @@ match (value) {
           <h3 class="host-bench-title">Wasmtime</h3>
           <p class="host-bench-subcopy">
             Compare direct AOT WebAssembly output against interpreter-bundling approaches in a standalone WebAssembly
-            runtime. Benchmark data is collected when Wasmtime is available in the CI environment.
+            runtime. The landing page shows whichever Wasmtime benchmark datasets are currently available.
           </p>
           <div class="conformance-diagrams">
-            <div class="diagram-panel">
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-compute-only.json"
+              style="display: none"
+            >
+              <perf-benchmark-chart
+                src="./benchmarks/results/wasm-host-wasmtime-compute-only.json"
+                title="Compute Runtime"
+                legend="Wasm runtime speed relative to JS in Wasmtime (larger is better)"
+              ></perf-benchmark-chart>
+            </div>
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-coldstart.json"
+              style="display: none"
+            >
               <perf-benchmark-chart
                 src="./benchmarks/results/wasm-host-wasmtime-coldstart.json"
                 mode="absolute-lower-better"
@@ -2905,7 +2947,11 @@ match (value) {
                 legend="Median startup time for standalone Wasmtime execution, with JS-host baseline marker (lower is better)"
               ></perf-benchmark-chart>
             </div>
-            <div class="diagram-panel">
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
+              style="display: none"
+            >
               <perf-benchmark-chart
                 src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
                 mode="absolute-lower-better"
@@ -2914,7 +2960,11 @@ match (value) {
                 legend="Median amortized runtime per call after one module load in Wasmtime, with JS-host baseline marker (lower is better)"
               ></perf-benchmark-chart>
             </div>
-            <div class="diagram-panel">
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-module-size.json"
+              style="display: none"
+            >
               <perf-benchmark-chart
                 src="./benchmarks/results/wasm-host-wasmtime-module-size.json"
                 mode="absolute-lower-better"
@@ -3139,14 +3189,33 @@ console.log(instance.exports.run()); // &rarr; 55</pre
     <script type="module" src="./components/t262-charts.js"></script>
     <script type="module" src="./components/perf-benchmark-chart.js"></script>
     <script>
-      fetch("./benchmarks/results/wasm-host-wasmtime-coldstart.json")
-        .then((r) => r.json())
-        .then((d) => {
-          if (Array.isArray(d) && d.length > 0) {
-            document.getElementById("wasmtime-bench-group").style.display = "";
-          }
-        })
-        .catch(() => {});
+      (async () => {
+        const group = document.getElementById("wasmtime-bench-group");
+        if (!(group instanceof HTMLElement)) return;
+        const panels = Array.from(group.querySelectorAll("[data-benchmark-src]"));
+        let visibleCount = 0;
+        await Promise.all(
+          panels.map(async (panel) => {
+            if (!(panel instanceof HTMLElement)) return;
+            const src = panel.dataset.benchmarkSrc;
+            if (!src) return;
+            try {
+              const resp = await fetch(src);
+              if (!resp.ok) return;
+              const data = await resp.json();
+              if (Array.isArray(data) && data.length > 0) {
+                panel.style.display = "";
+                visibleCount += 1;
+              }
+            } catch {
+              // Leave unavailable benchmark panels hidden.
+            }
+          }),
+        );
+        if (visibleCount > 0) {
+          group.style.display = "";
+        }
+      })();
     </script>
     <script src="./components/trend-chart.js"></script>
 
@@ -3832,6 +3901,257 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         }
       })();
 
+      const PROPOSAL_LABEL = "Proposals";
+      const isEditionScope = (edition) =>
+        edition === "ES1" ||
+        edition === "ES2" ||
+        edition === "ES3" ||
+        edition === "≤ ES3" ||
+        edition === "ES5" ||
+        /^ES20\d{2}$/.test(edition);
+      const normalizeEditionLabel = (edition) => (edition === "≤ ES3" || edition === "ES3" ? "ES3 / Core" : edition);
+      const PUBLISHED_EDITION_RELEASE_MONTH = 6;
+      const latestPublishedEditionYear = (referenceDate = new Date()) => {
+        const date =
+          referenceDate instanceof Date && Number.isFinite(referenceDate.getTime()) ? referenceDate : new Date();
+        return date.getUTCMonth() + 1 >= PUBLISHED_EDITION_RELEASE_MONTH
+          ? date.getUTCFullYear()
+          : date.getUTCFullYear() - 1;
+      };
+      const loadEditionBuckets = (() => {
+        let pending;
+        return async () => {
+          if (!pending) {
+            pending = (async () => {
+              const editionsResp = await fetch("./benchmarks/results/test262-editions.json");
+              if (!editionsResp.ok) throw new Error("edition data unavailable");
+              const editions = await editionsResp.json();
+              if (!Array.isArray(editions) || editions.length === 0) {
+                throw new Error("edition data unavailable");
+              }
+
+              const editionList = editions
+                .filter((edition) => isEditionScope(String(edition?.edition || "")))
+                .map((edition) => ({
+                  ...edition,
+                  rawEdition: String(edition.edition || ""),
+                  normalizedEdition: normalizeEditionLabel(String(edition.edition || "")),
+                }));
+              const proposalBucket = editions.find((edition) => String(edition?.edition || "") === PROPOSAL_LABEL) ?? null;
+
+              return {
+                editionList,
+                editionMap: new Map(editionList.map((edition) => [edition.normalizedEdition, edition])),
+                proposalBucket,
+              };
+            })();
+          }
+          return pending;
+        };
+      })();
+
+      (async function hydrateConformanceEditionFilter() {
+        const donutSlot = document.getElementById("conformance-donut-slot");
+        const editionTimeline = document.getElementById("conformance-edition-timeline");
+        if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
+
+        const donutStyle = "--t262-bg: var(--bg, #060a14)";
+        const renderDonut = (summary, captionMain = "ECMAScript") => {
+          const pass = Number(summary?.pass ?? 0);
+          const fail = Number(summary?.fail ?? 0);
+          const ce = Number(summary?.ce ?? 0);
+          const skip = Number(summary?.skip ?? 0);
+          const total = Number(summary?.total ?? pass + fail + ce + skip);
+          let donut = donutSlot.querySelector("t262-donut");
+          if (!(donut instanceof HTMLElement)) {
+            donut = document.createElement("t262-donut");
+            donutSlot.replaceChildren(donut);
+          }
+          donut.setAttribute("pass", String(pass));
+          donut.setAttribute("fail", String(fail));
+          donut.setAttribute("ce", String(ce));
+          donut.setAttribute("skip", String(skip));
+          donut.setAttribute("total", String(total));
+          donut.setAttribute("caption-main", captionMain);
+          donut.setAttribute("caption-sub", "conformance");
+          donut.setAttribute("style", donutStyle);
+        };
+
+        try {
+          const reportResp = await fetch("./benchmarks/results/test262-report.json");
+          if (!reportResp.ok) throw new Error("conformance data unavailable");
+
+          const report = await reportResp.json();
+          const overallSummary = report?.summary;
+          if (!overallSummary) throw new Error("overall summary unavailable");
+
+          const overall = {
+            pass: Number(overallSummary.pass ?? 0),
+            fail: Number(overallSummary.fail ?? 0),
+            ce: Number(overallSummary.compile_error ?? 0) + Number(overallSummary.compile_timeout ?? 0),
+            skip: Number(overallSummary.skip ?? 0),
+            total: Number(overallSummary.total ?? 0),
+          };
+          const fullSummary = report?.full_summary ?? overallSummary;
+          const withProposal = {
+            pass: Number(fullSummary.pass ?? overall.pass ?? 0),
+            fail: Number(fullSummary.fail ?? overall.fail ?? 0),
+            ce: Number(fullSummary.compile_error ?? 0) + Number(fullSummary.compile_timeout ?? 0),
+            skip: Number(fullSummary.skip ?? overall.skip ?? 0),
+            total: Number(fullSummary.total ?? overall.total ?? 0),
+          };
+          const proposalDiffers =
+            withProposal.pass !== overall.pass ||
+            withProposal.fail !== overall.fail ||
+            withProposal.ce !== overall.ce ||
+            withProposal.skip !== overall.skip ||
+            withProposal.total !== overall.total;
+
+          const applyScopeFromDetail = (detail) => {
+            if (!detail) return;
+            if (Number.isFinite(detail.publishedLimitRank)) {
+              window.__conformancePublishedLimitRank = detail.publishedLimitRank;
+            }
+
+            const currentScope = detail.scope || "overall";
+            window.__conformanceEditionScope = currentScope;
+            if (currentScope === "overall") {
+              renderDonut(overall);
+              applyFeatureEditionScope("overall");
+              return;
+            }
+            if (currentScope === "overall+proposal") {
+              renderDonut(withProposal, "ECMAScript + proposals");
+              applyFeatureEditionScope("overall+proposal");
+              return;
+            }
+
+            const scope = detail.scopeMap instanceof Map ? detail.scopeMap.get(currentScope) : null;
+            if (!scope) return;
+            renderDonut(scope.summary, scope.captionMain);
+            applyFeatureEditionScope(currentScope);
+          };
+
+          editionTimeline.addEventListener("edition-change", (event) => {
+            applyScopeFromDetail(event.detail);
+          });
+
+          if (report.timestamp) {
+            editionTimeline.setAttribute("reference-timestamp", report.timestamp);
+          } else {
+            editionTimeline.removeAttribute("reference-timestamp");
+          }
+          if (proposalDiffers) {
+            editionTimeline.setAttribute("show-proposals", "");
+          } else {
+            editionTimeline.removeAttribute("show-proposals");
+          }
+          editionTimeline.setAttribute("value", "overall");
+        } catch {
+          window.__conformanceEditionScope = "overall";
+        }
+      })();
+
+      const featureEditionRank = new Map([
+        ["ES1", 0],
+        ["ES2", 1],
+        ["ES3 / Core", 2],
+        ["ES5", 3],
+        ["ES2015", 4],
+        ["ES2016", 5],
+        ["ES2017", 6],
+        ["ES2018", 7],
+        ["ES2019", 8],
+        ["ES2020", 9],
+        ["ES2021", 10],
+        ["ES2022", 11],
+        ["ES2023", 12],
+        ["ES2024", 13],
+        ["ES2025", 14],
+        ["ES2026", 15],
+        ["Legacy / Deprecated", 98],
+        ["Proposals", 99],
+      ]);
+
+      const getFeatureSectionLabel = (section) =>
+        section.querySelector(".feat-edition-label")?.textContent?.trim() ||
+        section.querySelector(".feat-edition")?.textContent?.trim() ||
+        "";
+      const isStandardFeatureEditionLabel = (label) => {
+        const rank = featureEditionRank.get(label);
+        return typeof rank === "number" && rank < 98;
+      };
+      const getFeatureScopeLimitRank = (scopeValue) => {
+        if (!scopeValue || scopeValue === "overall" || scopeValue === "overall+proposal") return null;
+        return featureEditionRank.get(normalizeEditionLabel(scopeValue)) ?? null;
+      };
+      const getPublishedFeatureLimitRank = () => {
+        const explicit = Number(window.__conformancePublishedLimitRank);
+        if (Number.isFinite(explicit)) return explicit;
+        const fallbackLabel = normalizeEditionLabel(`ES${latestPublishedEditionYear(new Date())}`);
+        return featureEditionRank.get(fallbackLabel) ?? Number.MAX_SAFE_INTEGER;
+      };
+      const applyFeatureEditionScope = (scopeValue = "overall") => {
+        if (scopeValue === "overall+proposal") {
+          document.querySelectorAll(".feat-section").forEach((section) => {
+            section.hidden = false;
+          });
+          return;
+        }
+        if (scopeValue === "overall") {
+          const publishedLimitRank = getPublishedFeatureLimitRank();
+          document.querySelectorAll(".feat-section").forEach((section) => {
+            const label = getFeatureSectionLabel(section);
+            const rank = featureEditionRank.get(label);
+            if (label === "Proposals") {
+              section.hidden = true;
+              return;
+            }
+            if (typeof rank === "number" && isStandardFeatureEditionLabel(label)) {
+              section.hidden = rank > publishedLimitRank;
+              return;
+            }
+            section.hidden = false;
+          });
+          return;
+        }
+        const limitRank = getFeatureScopeLimitRank(scopeValue);
+        document.querySelectorAll(".feat-section").forEach((section) => {
+          const label = getFeatureSectionLabel(section);
+          const rank = featureEditionRank.get(label);
+          if (typeof rank !== "number") {
+            section.hidden = true;
+            return;
+          }
+          if (!isStandardFeatureEditionLabel(label)) {
+            section.hidden = true;
+            return;
+          }
+          section.hidden = rank > limitRank;
+        });
+      };
+
+      const sortFeatureSectionsChronologically = () => {
+        document.querySelectorAll(".feat-panel").forEach((panel) => {
+          const sections = Array.from(panel.children).filter(
+            (child) => child instanceof HTMLElement && child.classList.contains("feat-section"),
+          );
+          if (sections.length < 2) return;
+
+          sections
+            .slice()
+            .sort(
+              (a, b) =>
+                (featureEditionRank.get(getFeatureSectionLabel(a)) ?? Number.MAX_SAFE_INTEGER) -
+                (featureEditionRank.get(getFeatureSectionLabel(b)) ?? Number.MAX_SAFE_INTEGER),
+            )
+            .forEach((section) => panel.appendChild(section));
+        });
+      };
+
+      sortFeatureSectionsChronologically();
+      applyFeatureEditionScope();
+
       (function hydrateEditionPassBars() {
         const strictToggle = document.getElementById("strict-only-toggle");
         const hostToggle = document.getElementById("host-support-toggle");
@@ -3846,36 +4166,45 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           return 0;
         };
 
-        const updateEditionPassBars = () => {
+        const ensureEditionLabel = (section) => {
+          const el = section.querySelector(".feat-edition");
+          if (!(el instanceof HTMLElement)) return null;
+          let labelSpan = el.querySelector(".feat-edition-label");
+          if (!labelSpan) {
+            const label = (el.textContent || "").trim();
+            labelSpan = document.createElement("span");
+            labelSpan.className = "feat-edition-label";
+            labelSpan.textContent = label;
+            el.textContent = "";
+            el.appendChild(labelSpan);
+          }
+          return { el, labelSpan };
+        };
+
+        const ensureEditionPassBar = (header) => {
+          let bar = header.querySelector(".feat-edition-passbar");
+          if (!bar) {
+            bar = document.createElement("span");
+            bar.className = "feat-edition-passbar";
+            bar.innerHTML = `
+              <span class="feat-edition-passbar-track">
+                <span class="feat-edition-passbar-fill"></span>
+              </span>
+              <span class="feat-edition-passbar-text"></span>
+            `;
+            header.appendChild(bar);
+          }
+          return bar;
+        };
+
+        const renderHeuristicEditionPassBars = () => {
           const strictOnly = strictToggle ? strictToggle.checked : true;
           const hostEnabled = hostToggle ? hostToggle.checked : true;
 
           document.querySelectorAll(".feat-section").forEach((section) => {
-            const el = section.querySelector(".feat-edition");
-            if (!el) return;
-
-            let labelSpan = el.querySelector(".feat-edition-label");
-            if (!labelSpan) {
-              const label = (el.textContent || "").trim();
-              labelSpan = document.createElement("span");
-              labelSpan.className = "feat-edition-label";
-              labelSpan.textContent = label;
-              el.textContent = "";
-              el.appendChild(labelSpan);
-            }
-
-            let bar = el.querySelector(".feat-edition-passbar");
-            if (!bar) {
-              bar = document.createElement("span");
-              bar.className = "feat-edition-passbar";
-              bar.innerHTML = `
-                <span class="feat-edition-passbar-track">
-                  <span class="feat-edition-passbar-fill"></span>
-                </span>
-                <span class="feat-edition-passbar-text"></span>
-              `;
-              el.appendChild(bar);
-            }
+            const header = ensureEditionLabel(section)?.el;
+            if (!header) return;
+            const bar = ensureEditionPassBar(header);
 
             const rows = Array.from(section.querySelectorAll(".feat-row")).filter((row) => {
               if (strictOnly && row.hasAttribute("data-sloppy")) return false;
@@ -3890,6 +4219,69 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             if (fill) fill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
             if (text) text.textContent = `${pct}%`;
           });
+        };
+
+        const ensureGeneratedEditionSection = (panel, label) => {
+          const existing = Array.from(panel.querySelectorAll(".feat-section")).find(
+            (section) => getFeatureSectionLabel(section) === label,
+          );
+          if (existing) return existing;
+
+          const section = document.createElement("div");
+          section.className = "feat-section";
+          section.dataset.generatedEdition = "true";
+          section.innerHTML = `
+            <div class="feat-edition">${label}</div>
+            <div class="feat-note">
+              Tracked via the current Test262 edition buckets. Curated landing-page feature examples for this edition are not listed yet.
+            </div>
+          `;
+          panel.appendChild(section);
+          return section;
+        };
+
+        const updateEditionPassBars = async () => {
+          try {
+            const { editionList, editionMap, proposalBucket } = await loadEditionBuckets();
+            const panel = document.querySelector(".feat-panel");
+            if (panel instanceof HTMLElement) {
+              editionList.forEach((edition) => {
+                ensureGeneratedEditionSection(panel, edition.normalizedEdition);
+              });
+              sortFeatureSectionsChronologically();
+              applyFeatureEditionScope(window.__conformanceEditionScope || "overall");
+            }
+
+            document.querySelectorAll(".feat-section").forEach((section) => {
+              const ensured = ensureEditionLabel(section);
+              if (!ensured) return;
+              const label = ensured.labelSpan.textContent?.trim() || "";
+              const bucket = label === "Proposals" ? proposalBucket : editionMap.get(label);
+              const existingBar = ensured.el.querySelector(".feat-edition-passbar");
+
+              if (!bucket) {
+                existingBar?.remove();
+                return;
+              }
+
+              const bar = ensureEditionPassBar(ensured.el);
+              const fill = bar.querySelector(".feat-edition-passbar-fill");
+              const text = bar.querySelector(".feat-edition-passbar-text");
+              const pct = Math.max(0, Math.min(100, Number(bucket.pct ?? 0)));
+              const title = `${bucket.pass.toLocaleString()} pass, ${bucket.fail.toLocaleString()} fail, ${bucket.ce.toLocaleString()} CE, ${bucket.skip.toLocaleString()} skip (${bucket.total.toLocaleString()} total)`;
+              if (fill instanceof HTMLElement) {
+                fill.style.width = `${pct}%`;
+                fill.title = title;
+              }
+              if (text instanceof HTMLElement) {
+                text.textContent = `${pct}%`;
+                text.title = title;
+              }
+              bar.title = title;
+            });
+          } catch {
+            renderHeuristicEditionPassBars();
+          }
         };
 
         updateEditionPassBars();

--- a/playground/vite-plugin-test262.ts
+++ b/playground/vite-plugin-test262.ts
@@ -388,6 +388,12 @@ export function test262Plugin(): Plugin {
           return;
         }
 
+        if (url.pathname === "/api/test262-source-status") {
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ available: existsSync(testBase) }));
+          return;
+        }
+
         // Lightweight summary: categories with counts only, no file lists (~2KB vs ~500KB)
         if (url.pathname === "/api/test262-index-summary") {
           const index = getIndex();

--- a/public/benchmarks/report.html
+++ b/public/benchmarks/report.html
@@ -78,6 +78,32 @@
         margin-bottom: 2rem;
         position: relative;
       }
+      .summary-visuals {
+        display: grid;
+        grid-template-columns: minmax(320px, 390px) minmax(0, 1fr);
+        gap: 3rem;
+        align-items: start;
+      }
+      .summary-visual-panel {
+        min-width: 0;
+      }
+      .summary-donut-panel {
+        display: grid;
+        gap: 1rem;
+        align-content: start;
+      }
+      .summary-donut-panel t262-donut {
+        width: 100%;
+        justify-self: stretch;
+      }
+      .summary-history-panel {
+        display: grid;
+        gap: 0.875rem;
+        align-content: start;
+      }
+      .summary-history-chart {
+        min-height: 260px;
+      }
       .summary-meta {
         position: absolute;
         right: 0;
@@ -104,100 +130,47 @@
         color: var(--text-muted);
       }
       /* Donut chart handled by <t262-donut> web component */
-      .edition-timeline-section {
-        margin: -0.35rem 0 2rem;
-      }
-      .edition-track {
-        position: relative;
-        height: 92px;
-      }
-      .edition-timeline {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 31px;
-        display: flex;
-        height: 14px;
-        overflow: hidden;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.03);
-        border: 1px solid rgba(255, 255, 255, 0.06);
-      }
-      .edition-segment {
-        position: relative;
-        min-width: 10px;
-        background: rgba(248, 81, 73, 0.12);
-      }
-      .edition-segment + .edition-segment::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 1px;
-        background: rgba(255, 255, 255, 0.06);
-      }
-      .edition-segment::after {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        width: var(--segment-fill);
-        background: var(--pass);
-      }
-      .edition-scale {
-        position: absolute;
-        inset: 0 1px;
-      }
-      .edition-scale-label {
-        position: relative;
+      .diagram-title {
         font-size: 0.68rem;
-        letter-spacing: 0.04em;
+        font-weight: 600;
+        letter-spacing: 0.1em;
         text-transform: uppercase;
         color: var(--text-muted);
-        white-space: nowrap;
+        margin: 0 0 1.25rem;
       }
-      .edition-scale-marker {
-        position: absolute;
-        transform: translateX(-50%);
-        pointer-events: none;
+      .diagram-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        font-family: var(--mono);
+        font-size: 0.68rem;
+        color: var(--text-muted);
+        letter-spacing: 0.04em;
       }
-      .edition-scale-line {
-        position: absolute;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 1px;
-        height: 10px;
-        background: rgba(255, 255, 255, 0.18);
+      .diagram-legend-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
       }
-      .edition-scale-marker.above {
-        top: 0;
+      .diagram-legend-line {
+        width: 18px;
+        height: 0;
+        border-top: 2px solid rgba(255, 255, 255, 0.9);
       }
-      .edition-scale-marker.above .edition-scale-line {
-        top: 21px;
+      .diagram-legend-line.total {
+        border-top-width: 1px;
+        border-top-color: rgba(141, 154, 184, 1);
+        border-top-style: dotted;
       }
-      .edition-scale-marker.below {
-        top: 0;
+      .diagram-legend-line.passed {
+        border-top-width: 1px;
+        border-top-color: rgba(255, 255, 255, 0.82);
       }
-      .edition-scale-marker.below .edition-scale-line {
-        top: 45px;
-      }
-      .edition-scale-marker.above .edition-scale-label {
-        position: absolute;
-        top: 0;
-        left: 50%;
-        transform: translateX(-50%);
-      }
-      .edition-scale-marker.below .edition-scale-label {
-        position: absolute;
-        top: 58px;
-        left: 50%;
-        transform: translateX(-50%);
-      }
-      .edition-scale-label::before {
-        content: "";
-        display: none;
+      .edition-section {
+        margin: -0.35rem 0 2rem;
+        --t262-edition-font-mono: var(--mono);
+        --t262-edition-text: var(--text);
+        --t262-edition-text-muted: var(--text-muted);
       }
       .edition-legend-grid {
         display: grid;
@@ -210,6 +183,20 @@
         gap: 0.12rem;
         min-width: 0;
       }
+      .edition-legend-item.active .edition-legend-name,
+      .edition-legend-item.active .edition-legend-rate,
+      .edition-legend-item.active .edition-legend-ratio {
+        color: rgba(255, 255, 255, 0.98);
+      }
+      .edition-legend-item.dimmed .edition-legend-name {
+        color: rgba(255, 255, 255, 0.26);
+      }
+      .edition-legend-item.dimmed .edition-legend-rate {
+        color: rgba(255, 255, 255, 0.4);
+      }
+      .edition-legend-item.dimmed .edition-legend-ratio {
+        color: rgba(255, 255, 255, 0.32);
+      }
       .edition-legend-name {
         font-size: 0.72rem;
         letter-spacing: 0.06em;
@@ -217,7 +204,7 @@
         color: var(--text-muted);
       }
       .edition-legend-rate {
-        color: var(--pass);
+        color: rgba(255, 255, 255, 0.92);
         font-weight: 700;
         font-variant-numeric: tabular-nums;
         text-align: left;
@@ -395,37 +382,64 @@
         gap: 0.5rem;
         flex-wrap: wrap;
         width: 100%;
-        justify-content: flex-end;
+        justify-content: flex-start;
+        align-items: flex-end;
       }
       .filter-toggle {
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        gap: 0.375rem;
-        padding: 0.375rem 0.75rem;
-        border-radius: 6px;
-        border: 1px solid var(--border);
-        background: var(--surface);
+        gap: 0.625rem;
+        min-height: 44px;
+        padding: 0 0.95rem;
+        border-radius: 10px;
+        border: 1px solid transparent;
+        background: transparent;
         color: var(--text-muted);
+        font-family: var(--mono);
         font-size: 0.75rem;
         cursor: pointer;
         user-select: none;
         transition:
           border-color 0.15s,
-          background 0.15s;
+          background 0.15s,
+          color 0.15s,
+          transform 0.15s;
       }
       .filter-toggle:hover {
-        border-color: var(--text-muted);
+        color: rgba(255, 255, 255, 0.72);
+      }
+      .filter-toggle:focus-within {
+        border-color: transparent;
+        box-shadow: none;
       }
       .filter-toggle.active {
-        border-color: var(--accent);
-        background: var(--surface-hover);
+        border-color: transparent;
+        background: transparent;
         color: var(--text);
       }
-      .filter-toggle .dot {
-        width: 8px;
-        height: 8px;
-        border-radius: 2px;
-        flex-shrink: 0;
+      .filter-toggle input {
+        appearance: none;
+        width: 12px;
+        height: 12px;
+        margin: 0;
+        border-radius: 3px;
+        border: 1px solid rgba(255, 255, 255, 0.24);
+        background: rgba(255, 255, 255, 0.02);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        transition:
+          border-color 0.15s,
+          background 0.15s,
+          box-shadow 0.15s;
+      }
+      .filter-toggle.active input {
+        border-color: rgba(255, 255, 255, 0.9);
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow:
+          0 0 0 2px rgba(255, 255, 255, 0.08),
+          inset 0 0 0 1px rgba(6, 10, 20, 0.16);
+      }
+      .filter-toggle span {
+        white-space: nowrap;
       }
       .card.filter-card {
         cursor: pointer;
@@ -538,6 +552,12 @@
       .trend-delta.neutral {
         color: var(--text-muted);
       }
+      @media (max-width: 980px) {
+        .summary-visuals {
+          grid-template-columns: 1fr;
+          gap: 2rem;
+        }
+      }
     </style>
   </head>
   <body>
@@ -545,9 +565,14 @@
     <h1 class="brand">ECMAScript conformance</h1>
     <div id="app"><div class="no-data">Loading report data…</div></div>
 
+    <script type="module" src="../components/perf-benchmark-chart.js"></script>
+    <script src="../components/site-nav.js"></script>
+    <script type="module" src="../components/t262-charts.js"></script>
+    <script src="../components/trend-chart.js"></script>
     <script>
       const REPORT_JSON = "results/test262-report.json";
       const RESULTS_JSONL = "results/test262-results.jsonl";
+      const PROPOSAL_LABEL = "Proposals";
       const BENCH_SUITE_FILES = [
         "benchmarks/suites/strings.ts",
         "benchmarks/suites/arrays.ts",
@@ -667,213 +692,6 @@
         }
       }
 
-      function makeCounts() {
-        return { pass: 0, fail: 0, compile_error: 0, compile_timeout: 0, skip: 0, total: 0 };
-      }
-
-      function classifyEdition(file, scope) {
-        if (!file || scope === "proposal") return null;
-        if (scope === "annex_b" || file.includes("/annexB/")) return "LEGACY";
-
-        const rules = [
-          [
-            "ES2024",
-            [
-              "Object/groupBy",
-              "Map/groupBy",
-              "Promise/withResolvers",
-              "ArrayBuffer/prototype/transfer",
-              "ArrayBuffer/prototype/resizable",
-              "ArrayBuffer/prototype/resize",
-              "resizable-buffer",
-              "growable-sharedarraybuffer",
-            ],
-          ],
-          [
-            "ES2023",
-            ["/toSorted/", "/toReversed/", "/toSpliced/", "/findLast/", "/findLastIndex/", "/with/", "/hashbang/"],
-          ],
-          [
-            "ES2022",
-            [
-              "/at/",
-              "/Object/hasOwn/",
-              "/static-init",
-              "/static-block",
-              "/private-",
-              "/class-fields/",
-              "/Error/cause/",
-              "/match-indices/",
-            ],
-          ],
-          [
-            "ES2021",
-            [
-              "WeakRef",
-              "FinalizationRegistry",
-              "/Promise/any/",
-              "/replaceAll/",
-              "logical-assignment",
-              "numeric-separator-literal",
-            ],
-          ],
-          [
-            "ES2020",
-            [
-              "optional-chaining",
-              "/coalesce/",
-              "dynamic-import",
-              "import.meta",
-              "BigInt",
-              "globalThis",
-              "/matchAll/",
-              "/allSettled/",
-            ],
-          ],
-          [
-            "ES2019",
-            [
-              "optional-catch-binding",
-              "/flat/",
-              "/flatMap/",
-              "/fromEntries/",
-              "/trimStart/",
-              "/trimEnd/",
-              "Symbol/prototype/description",
-              "json-superset",
-            ],
-          ],
-          [
-            "ES2018",
-            [
-              "async-generator",
-              "for-await-of",
-              "async-iteration",
-              "regexp-dotall",
-              "lookbehind",
-              "named-groups",
-              "/Promise/prototype/finally/",
-              "object-rest",
-              "object-spread",
-            ],
-          ],
-          [
-            "ES2017",
-            [
-              "async-function",
-              "SharedArrayBuffer",
-              "/Atomics/",
-              "/Object/values/",
-              "/Object/entries/",
-              "/padStart/",
-              "/padEnd/",
-            ],
-          ],
-          ["ES2016", ["/includes/", "exponentiation"]],
-          [
-            "ES2015",
-            [
-              "block-scope",
-              "computed-property-names",
-              "rest-parameters",
-              "/module-code/",
-              "/import/",
-              "/export/",
-              "/class/",
-              "template-literal",
-              "for-of",
-              "destructuring",
-              "Map/",
-              "Set/",
-              "WeakMap/",
-              "WeakSet/",
-              "Promise/",
-              "Proxy/",
-              "Reflect/",
-              "Symbol/",
-              "TypedArray",
-              "ArrayBuffer",
-              "DataView",
-              "Generator",
-              "arrow-function",
-              "new.target",
-              "/super/",
-            ],
-          ],
-          [
-            "ES5",
-            [
-              "/strict-mode/",
-              "/JSON/",
-              "/Object/keys/",
-              "/Object/create/",
-              "/Object/defineProperty/",
-              "/Object/getOwnPropertyDescriptor/",
-              "/Object/preventExtensions/",
-              "/Object/seal/",
-              "/Object/freeze/",
-              "/Array/isArray/",
-              "/String/prototype/trim/",
-              "/Date/prototype/toISOString/",
-              "/Function/prototype/bind/",
-              "getter",
-              "reserved-words",
-              "property-definitions",
-            ],
-          ],
-        ];
-
-        for (const [edition, patterns] of rules) {
-          if (patterns.some((pattern) => file.includes(pattern))) return edition;
-        }
-
-        return "ES3";
-      }
-
-      async function loadEditionSummaries() {
-        try {
-          const resp = await fetch(RESULTS_JSONL);
-          if (!resp.ok) return null;
-          const text = await resp.text();
-          const byEdition = new Map();
-          for (const line of text.split("\n")) {
-            if (!line.trim()) continue;
-            const entry = JSON.parse(line);
-            if (entry.scope_official === false || entry.scope === "proposal") continue;
-            const edition = classifyEdition(entry.file, entry.scope);
-            if (!edition) continue;
-            if (!byEdition.has(edition)) byEdition.set(edition, makeCounts());
-            const counts = byEdition.get(edition);
-            counts.total++;
-            counts[entry.status] = (counts[entry.status] || 0) + 1;
-          }
-          const order = [
-            "LEGACY",
-            "ES3",
-            "ES5",
-            "ES2015",
-            "ES2016",
-            "ES2017",
-            "ES2018",
-            "ES2019",
-            "ES2020",
-            "ES2021",
-            "ES2022",
-            "ES2023",
-            "ES2024",
-          ];
-          return order
-            .filter((edition) => byEdition.has(edition))
-            .map((edition) => ({
-              edition,
-              ...byEdition.get(edition),
-              rate: pct(byEdition.get(edition).pass, byEdition.get(edition).total),
-            }));
-        } catch {
-          return null;
-        }
-      }
-
       async function loadJSON(url) {
         try {
           const r = await fetch(url);
@@ -881,6 +699,175 @@
         } catch {
           return null;
         }
+      }
+
+      const CONFORMANCE_PROJECT_START = new Date("2026-02-27T00:00:00Z");
+
+      function parseConformanceRunTimestamp(value) {
+        const raw = String(value || "");
+        if (!raw) return null;
+        const isoDate = new Date(raw);
+        if (Number.isFinite(isoDate.getTime())) return isoDate;
+        const compact = raw.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+        if (compact) {
+          const [, y, m, d, hh, mm, ss] = compact;
+          return new Date(`${y}-${m}-${d}T${hh}:${mm}:${ss}Z`);
+        }
+        return null;
+      }
+
+      function formatConformanceHistoryLabel(date) {
+        return `${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+      }
+
+      function buildConformanceHistoryPoints(runs) {
+        const comparableRuns = Array.isArray(runs)
+          ? runs
+              .filter((run) => Number(run?.total ?? 0) > 1 && Number(run?.pass ?? 0) >= 0)
+              .sort((a, b) => {
+                const ta = parseConformanceRunTimestamp(a.timestamp)?.getTime() ?? Number.POSITIVE_INFINITY;
+                const tb = parseConformanceRunTimestamp(b.timestamp)?.getTime() ?? Number.POSITIVE_INFINITY;
+                return ta - tb;
+              })
+          : [];
+
+        const rawPoints = comparableRuns
+          .map((run) => {
+            const total = Number(run.total || 0);
+            const pass = Number(run.pass || 0);
+            const ts = String(run.timestamp || "");
+            const date = parseConformanceRunTimestamp(ts);
+            return {
+              label: date ? formatConformanceHistoryLabel(date) : "",
+              timestamp: ts,
+              time: date?.getTime() ?? 0,
+              pass,
+              total,
+              rate: total > 0 ? (pass / total) * 100 : 0,
+            };
+          })
+          .filter((point) => point.total > 0 && point.rate >= 5);
+
+        const points = [];
+        for (const point of rawPoints) {
+          const prev = points.at(-1);
+          if (prev && point.total < prev.total * 0.75) continue;
+          points.push(point);
+        }
+
+        const firstPoint = points[0];
+        if (firstPoint?.timestamp) {
+          const firstDate = new Date(firstPoint.timestamp);
+          if (
+            Number.isFinite(firstDate.getTime()) &&
+            firstDate.getTime() - CONFORMANCE_PROJECT_START.getTime() > 12 * 60 * 60 * 1000
+          ) {
+            points.unshift({
+              label: formatConformanceHistoryLabel(CONFORMANCE_PROJECT_START),
+              timestamp: CONFORMANCE_PROJECT_START.toISOString(),
+              time: CONFORMANCE_PROJECT_START.getTime(),
+              pass: 0,
+              total: 0,
+              rate: 0,
+            });
+          }
+        }
+
+        const lastRun = comparableRuns.at(-1);
+        if (lastRun) {
+          const ts = String(lastRun.timestamp || "");
+          const total = Number(lastRun.total || 0);
+          const pass = Number(lastRun.pass || 0);
+          const lastRate = total > 0 ? (pass / total) * 100 : 0;
+          const lastDate = ts ? new Date(ts) : null;
+          const now = new Date();
+          if (
+            Number.isFinite(lastRate) &&
+            lastRate >= 5 &&
+            lastDate instanceof Date &&
+            Number.isFinite(lastDate.getTime()) &&
+            now.getTime() - lastDate.getTime() > 12 * 60 * 60 * 1000
+          ) {
+            points.push({
+              label: formatConformanceHistoryLabel(now),
+              timestamp: now.toISOString(),
+              time: now.getTime(),
+              pass,
+              total,
+              rate: lastRate,
+            });
+          }
+        }
+
+        if (points.length === 0) {
+          const now = new Date();
+          points.push(
+            {
+              label: formatConformanceHistoryLabel(CONFORMANCE_PROJECT_START),
+              timestamp: CONFORMANCE_PROJECT_START.toISOString(),
+              time: CONFORMANCE_PROJECT_START.getTime(),
+              pass: 0,
+              total: 0,
+              rate: 0,
+            },
+            {
+              label: formatConformanceHistoryLabel(now),
+              timestamp: now.toISOString(),
+              time: now.getTime(),
+              pass: 0,
+              total: 0,
+              rate: 0,
+            },
+          );
+        }
+
+        return points.length >= 2 ? points : null;
+      }
+
+      function configureConformanceHistoryChart(chart, runs) {
+        const points = buildConformanceHistoryPoints(runs);
+        if (!(chart instanceof HTMLElement) || !points) return;
+
+        chart.setAttribute("labels-key", "label");
+        chart.setAttribute(
+          "series",
+          JSON.stringify([
+            {
+              key: "rate",
+              color: "#ffffff",
+              fill: true,
+            },
+            {
+              key: "pass",
+              color: "rgba(255,255,255,0.82)",
+              axis: "right",
+              lineWidth: 1,
+              lineOpacity: 0.5,
+            },
+            {
+              key: "total",
+              color: "rgba(141, 154, 184, 1)",
+              axis: "right",
+              lineWidth: 1,
+              lineOpacity: 1,
+              dasharray: "1 3",
+            },
+          ]),
+        );
+
+        const applyData = () => {
+          chart.data = points;
+        };
+
+        if (customElements.get("trend-chart")) {
+          applyData();
+          return;
+        }
+
+        customElements
+          .whenDefined("trend-chart")
+          .then(applyData)
+          .catch(() => {});
       }
 
       let prettierBundlePromise = null;
@@ -965,58 +952,20 @@
         return cat;
       }
 
-      function renderEditionCoverage(rows, container) {
+      function renderEditionLegend(rows, legendHost, activeEdition = null, dimAfterRank = null, proposalEditionLabels = new Set()) {
+        legendHost.textContent = "";
         if (!rows || rows.length === 0) return;
-        container.appendChild(el("div", { className: "label" }, "ECMAScript Editions"));
-        const weights = {
-          LEGACY: 4,
-          ES3: 10,
-          ES5: 6,
-          ES2015: 1,
-          ES2016: 1,
-          ES2017: 1,
-          ES2018: 1,
-          ES2019: 1,
-          ES2020: 1,
-          ES2021: 1,
-          ES2022: 1,
-          ES2023: 1,
-          ES2024: 1,
-        };
-        const track = el("div", { className: "edition-track" });
-        const timeline = el("div", { className: "edition-timeline" });
-        const scale = el("div", { className: "edition-scale" });
-        const legend = el("div", { className: "edition-legend-grid" });
-        const scaleLabelFor = (edition) => (/^ES20\d{2}$/.test(edition) ? edition.slice(2) : edition);
-        const totalWeight = rows.reduce((sum, row) => sum + (weights[row.edition] || 1), 0);
-        let cumulativeWeight = 0;
-        rows.forEach((row, index) => {
-          const weight = String(weights[row.edition] || 1);
-          const numericWeight = weights[row.edition] || 1;
-          const segment = el("div", { className: "edition-segment" });
-          segment.style.flex = weight;
-          segment.style.setProperty("--segment-fill", `${row.rate}%`);
-          timeline.appendChild(segment);
+        rows.forEach((row) => {
+          const rowRank = Number.isFinite(row.rank) ? row.rank : Number.MAX_SAFE_INTEGER;
+          const isActive = row.edition === activeEdition;
+          const isDimmed = dimAfterRank !== null && rowRank > dimAfterRank;
+          const label = proposalEditionLabels.has(row.edition) ? PROPOSAL_LABEL : row.displayLabel || row.edition;
 
-          cumulativeWeight += numericWeight;
-          const marker = el(
-            "div",
-            {
-              className: "edition-scale-marker " + (index % 2 === 0 ? "below" : "above"),
-              style: {
-                left: `${(cumulativeWeight / totalWeight) * 100}%`,
-              },
-            },
-            el("div", { className: "edition-scale-line" }),
-            el("div", { className: "edition-scale-label" }, scaleLabelFor(row.edition)),
-          );
-          scale.appendChild(marker);
-
-          legend.appendChild(
+          legendHost.appendChild(
             el(
               "div",
-              { className: "edition-legend-item" },
-              el("div", { className: "edition-legend-name" }, row.edition),
+              { className: "edition-legend-item" + (isActive ? " active" : "") + (isDimmed ? " dimmed" : "") },
+              el("div", { className: "edition-legend-name" }, label),
               el("div", { className: "edition-legend-rate" }, `${row.rate}%`),
               el(
                 "div",
@@ -1026,10 +975,6 @@
             ),
           );
         });
-        track.appendChild(timeline);
-        track.appendChild(scale);
-        container.appendChild(track);
-        container.appendChild(legend);
       }
 
       function isProposalSkipReason(reason) {
@@ -1061,6 +1006,34 @@
       const _srcQueue = [];
       let _srcFetching = 0;
       const MAX_CONCURRENT_FETCHES = 6;
+      let _srcAvailable = null;
+      let _srcAvailabilityPromise = null;
+
+      function sourceBasePath() {
+        return window.location.pathname.replace(/\/benchmarks\/.*$/, "");
+      }
+
+      function ensureSourceAvailability() {
+        if (_srcAvailable !== null) return Promise.resolve(_srcAvailable);
+        if (_srcAvailabilityPromise) return _srcAvailabilityPromise;
+
+        _srcAvailabilityPromise = fetch(sourceBasePath() + "/api/test262-source-status")
+          .then((r) => {
+            if (!r.ok) throw new Error(r.status);
+            return r.json();
+          })
+          .then((payload) => {
+            _srcAvailable = payload?.available !== false;
+            return _srcAvailable;
+          })
+          .catch(() => {
+            // Preserve legacy behavior when the status endpoint is unavailable.
+            _srcAvailable = true;
+            return true;
+          });
+
+        return _srcAvailabilityPromise;
+      }
 
       // Returns a placeholder div that will be filled with source context when ready
       function fetchSourceLines(filePath, errText) {
@@ -1094,17 +1067,19 @@
           return placeholder;
         }
 
-        const base = window.location.pathname.replace(/\/benchmarks\/.*$/, "");
-        const url = base + "/test262/" + normalized;
-        _srcQueue.push({
-          normalized,
-          url,
-          rawLineNo,
-          errText,
-          searchText,
-          placeholder,
+        ensureSourceAvailability().then((available) => {
+          if (!available) return;
+          const url = sourceBasePath() + "/test262/" + normalized;
+          _srcQueue.push({
+            normalized,
+            url,
+            rawLineNo,
+            errText,
+            searchText,
+            placeholder,
+          });
+          _drainSrcQueue();
         });
-        _drainSrcQueue();
         return placeholder;
       }
 
@@ -1294,13 +1269,6 @@
         return summary;
       }
 
-      function scopeLabel(includeLegacy, includeProposals) {
-        const parts = ["Standard"];
-        if (includeLegacy) parts.push("Annex B");
-        if (includeProposals) parts.push("Proposals");
-        return parts.join(" + ");
-      }
-
       function toggleDetail(row, catName, statusFilter) {
         const existing = row.nextElementSibling;
         if (existing && existing.classList.contains("detail-row")) {
@@ -1366,15 +1334,16 @@
         });
       }
 
-      function renderConformance(data, container) {
+      function renderConformance(data, container, conformanceRuns) {
         const scopeSummaries = data.scope_summaries || {};
         const standardSummary = scopeSummaries.standard || data.summary;
         const legacySummary = scopeSummaries.annex_b || null;
-        const proposalSummary = scopeSummaries.proposal || null;
+        const fullSummary = data.full_summary || data.summary;
         const scoreState = {
           includeLegacy: true,
-          includeProposals: false,
+          editionScope: "overall",
         };
+        let editionDetail = null;
 
         let summaryStamp = null;
         if (data.timestamp) {
@@ -1384,16 +1353,12 @@
         }
 
         const summary = el("div", { className: "summary" });
+        const summaryVisuals = el("div", { className: "summary-visuals" });
+        const donutPanel = el("div", { className: "summary-visual-panel summary-donut-panel" });
         const donutEl = document.createElement("t262-donut");
         donutEl.id = "donut-chart";
         donutEl.style.setProperty("--t262-bg", "#060a14");
         const controlsHost = el("div", { className: "filter-toggles", style: { marginTop: "1rem" } });
-        const legacyToggle = el("label", { className: "filter-toggle" });
-        const legacyCheckbox = el("input", { type: "checkbox", checked: "checked" });
-        legacyToggle.appendChild(legacyCheckbox);
-        legacyToggle.appendChild(el("span", null, "legacy (Annex B)"));
-        controlsHost.appendChild(legacyToggle);
-
         // Strict mode toggle — checked by default, persisted in localStorage
         const strictToggle = el("label", { className: "filter-toggle" });
         const strictDefault = localStorage.getItem("t262-strict-only") !== "false";
@@ -1402,28 +1367,94 @@
         strictCheckbox.checked = strictDefault;
         strictToggle.appendChild(strictCheckbox);
         strictToggle.appendChild(el("span", null, "strict mode"));
+        const legacyToggle = el("label", { className: "filter-toggle" });
+        const legacyCheckbox = el("input", { type: "checkbox", checked: "checked" });
+        legacyToggle.appendChild(legacyCheckbox);
+        legacyToggle.appendChild(el("span", null, "legacy (Annex B)"));
         controlsHost.appendChild(strictToggle);
+        controlsHost.appendChild(legacyToggle);
+        const editionSection = el("div", { className: "edition-section" });
+        const editionTimeline = document.createElement("t262-edition-timeline");
+        editionTimeline.setAttribute("src", "results/test262-editions.json");
+        if (data.timestamp) {
+          editionTimeline.setAttribute("reference-timestamp", data.timestamp);
+        }
+        const editionLegendHost = el("div", { className: "edition-legend-grid" });
+        editionSection.appendChild(editionTimeline);
+        editionSection.appendChild(editionLegendHost);
 
         function syncToggleStyles() {
+          const editionFiltered = scoreState.editionScope !== "overall";
           legacyToggle.classList.toggle("active", legacyCheckbox.checked);
           strictToggle.classList.toggle("active", strictCheckbox.checked);
-          // Hide legacy toggle in strict mode (strict_summary already includes Annex B strict tests)
-          legacyToggle.style.display = strictCheckbox.checked ? "none" : "";
+          strictToggle.style.display = editionFiltered ? "none" : "";
+          legacyToggle.style.display = editionFiltered || strictCheckbox.checked ? "none" : "";
+        }
+
+        function setDonutSummary(summary, captionMain = "ECMAScript") {
+          const ce =
+            Number(summary?.ce ?? 0) + Number(summary?.compile_error ?? 0) + Number(summary?.compile_timeout ?? 0);
+          donutEl.setAttribute("pass", String(summary?.pass || 0));
+          donutEl.setAttribute("fail", String(summary?.fail || 0));
+          donutEl.setAttribute("ce", String(ce));
+          donutEl.setAttribute("skip", String(summary?.skip || 0));
+          donutEl.setAttribute("total", String(summary?.total || 0));
+          donutEl.setAttribute("caption-main", captionMain);
+          donutEl.setAttribute("caption-sub", "conformance");
+        }
+
+        function renderEditionSection() {
+          if (!editionDetail?.rows?.length) {
+            editionLegendHost.style.display = "none";
+            editionLegendHost.textContent = "";
+            return;
+          }
+          editionLegendHost.style.display = "grid";
+          renderEditionLegend(
+            editionDetail.rows,
+            editionLegendHost,
+            editionDetail.activeEdition,
+            editionDetail.limitRank,
+            editionDetail.proposalEditionLabels,
+          );
+        }
+
+        function applyEditionScope(detail = editionDetail) {
+          if (detail) {
+            editionDetail = detail;
+          }
+          scoreState.editionScope = detail?.scope || "overall";
+          syncToggleStyles();
+          renderSummaryCard();
+          renderEditionSection();
         }
 
         function renderSummaryCard() {
-          let s;
-          if (strictCheckbox.checked && data.strict_summary) {
-            s = data.strict_summary;
-          } else {
-            s = makeScopeSummary(standardSummary, scoreState.includeLegacy ? legacySummary : null);
+          if (scoreState.editionScope === "overall") {
+            const overallCaption = editionDetail?.captionMain || "ECMAScript";
+            if (strictCheckbox.checked && data.strict_summary) {
+              setDonutSummary(data.strict_summary, overallCaption);
+            } else {
+              setDonutSummary(
+                makeScopeSummary(standardSummary, scoreState.includeLegacy ? legacySummary : null),
+                overallCaption,
+              );
+            }
+            return;
           }
-          const ce = (s.compile_error || 0) + (s.compile_timeout || 0);
-          donutEl.setAttribute("pass", s.pass || 0);
-          donutEl.setAttribute("fail", s.fail || 0);
-          donutEl.setAttribute("ce", ce);
-          donutEl.setAttribute("skip", s.skip || 0);
-          donutEl.setAttribute("total", s.total || 0);
+          if (scoreState.editionScope === "overall+proposal") {
+            setDonutSummary(fullSummary, PROPOSAL_LABEL);
+            return;
+          }
+          const scope = editionDetail?.scopeMap instanceof Map ? editionDetail.scopeMap.get(scoreState.editionScope) : null;
+          if (!scope) {
+            setDonutSummary(
+              makeScopeSummary(standardSummary, scoreState.includeLegacy ? legacySummary : null),
+              editionDetail?.captionMain || "ECMAScript",
+            );
+            return;
+          }
+          setDonutSummary(scope.summary, scope.captionMain);
         }
 
         legacyCheckbox.addEventListener("change", () => {
@@ -1439,8 +1470,50 @@
 
         syncToggleStyles();
         renderSummaryCard();
-        summary.appendChild(donutEl);
-        summary.appendChild(controlsHost);
+        renderEditionSection();
+        donutPanel.appendChild(donutEl);
+        donutPanel.appendChild(controlsHost);
+        summaryVisuals.appendChild(donutPanel);
+
+        const historyPanel = el("div", { className: "summary-visual-panel summary-history-panel" });
+        historyPanel.appendChild(
+          el("h3", { className: "diagram-title" }, "Test Pass Rate Over Time"),
+        );
+        const historyChart = el("trend-chart", {
+          className: "summary-history-chart",
+          mode: "step",
+          height: "260",
+          "x-key": "time",
+        });
+        historyPanel.appendChild(historyChart);
+        historyPanel.appendChild(
+          el(
+            "div",
+            { className: "diagram-legend" },
+            el(
+              "span",
+              { className: "diagram-legend-item" },
+              el("span", { className: "diagram-legend-line" }),
+              el("span", null, "Pass rate"),
+            ),
+            el(
+              "span",
+              { className: "diagram-legend-item" },
+              el("span", { className: "diagram-legend-line passed" }),
+              el("span", null, "Tests passed"),
+            ),
+            el(
+              "span",
+              { className: "diagram-legend-item" },
+              el("span", { className: "diagram-legend-line total" }),
+              el("span", null, "Total tests run"),
+            ),
+          ),
+        );
+        configureConformanceHistoryChart(historyChart, conformanceRuns);
+        summaryVisuals.appendChild(historyPanel);
+
+        summary.appendChild(summaryVisuals);
         if (summaryStamp) summary.appendChild(summaryStamp);
 
         // Stale results indicator
@@ -1456,18 +1529,24 @@
           summary.appendChild(staleCard);
         }
 
-        const editionSection = el("div", {
-          className: "edition-timeline-section",
+        const officialSummary = makeScopeSummary(standardSummary, scoreState.includeLegacy ? legacySummary : null);
+        const ceValue = (summary) =>
+          Number(summary?.ce ?? 0) + Number(summary?.compile_error ?? 0) + Number(summary?.compile_timeout ?? 0);
+        const proposalDiffers =
+          Number(fullSummary?.pass ?? 0) !== Number(officialSummary?.pass ?? 0) ||
+          Number(fullSummary?.fail ?? 0) !== Number(officialSummary?.fail ?? 0) ||
+          Number(fullSummary?.skip ?? 0) !== Number(officialSummary?.skip ?? 0) ||
+          ceValue(fullSummary) !== ceValue(officialSummary) ||
+          Number(fullSummary?.total ?? 0) !== Number(officialSummary?.total ?? 0);
+        if (proposalDiffers) {
+          editionTimeline.setAttribute("show-proposals", "");
+        } else {
+          editionTimeline.removeAttribute("show-proposals");
+        }
+        editionTimeline.addEventListener("edition-change", (event) => {
+          applyEditionScope(event.detail);
         });
-
-        loadEditionSummaries().then((rows) => {
-          editionSection.innerHTML = "";
-          if (!rows || rows.length === 0) {
-            editionSection.appendChild(el("div", { className: "pct" }, "No edition data available."));
-            return;
-          }
-          renderEditionCoverage(rows, editionSection);
-        });
+        editionTimeline.setAttribute("value", "overall");
 
         function applyFilters() {
           const query = searchInput.value.toLowerCase().trim();
@@ -2048,16 +2127,17 @@
       }
 
       async function main() {
-        const [conformance, history, snippets] = await Promise.all([
+        const [conformance, benchmarkHistory, snippets, conformanceRuns] = await Promise.all([
           loadReportWithFallback(),
           loadJSON(assetPath("benchmarks/results/history.json")),
           loadBenchmarkSnippets(),
+          loadJSON(assetPath("benchmarks/results/runs/index.json")),
         ]);
         const app = document.getElementById("app");
         app.textContent = "";
 
         if (conformance) {
-          renderConformance(conformance, app);
+          renderConformance(conformance, app, conformanceRuns);
         } else {
           app.appendChild(
             el("div", { className: "no-data" }, "No test262 report found. Run: npx vitest run tests/test262.test.ts"),
@@ -2067,8 +2147,8 @@
         renderBenchmarks(snippets, app);
         await highlightReportCode();
 
-        if (history && history.length >= 2) {
-          renderTrends(history, app);
+        if (benchmarkHistory && benchmarkHistory.length >= 2) {
+          renderTrends(benchmarkHistory, app);
         }
 
         // Timestamp is now rendered inside renderConformance
@@ -2076,8 +2156,5 @@
 
       main();
     </script>
-    <script type="module" src="../components/perf-benchmark-chart.js"></script>
-    <script src="../components/site-nav.js"></script>
-    <script src="../components/t262-charts.js"></script>
   </body>
 </html>

--- a/scripts/serve-report.ts
+++ b/scripts/serve-report.ts
@@ -18,6 +18,7 @@ import { join, extname } from "node:path";
 const PORT = parseInt(process.argv[2] ?? "8080", 10);
 const ROOT = join(import.meta.dirname ?? __dirname, "..");
 const PUBLIC_ROOT = join(ROOT, "public");
+const TEST262_ROOT = join(ROOT, "test262", "test");
 
 const MIME: Record<string, string> = {
   ".html": "text/html",
@@ -41,6 +42,15 @@ const server = createServer((req, res) => {
   if (url.includes("..")) {
     res.writeHead(403);
     res.end("Forbidden");
+    return;
+  }
+
+  if (url === "/api/test262-source-status") {
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(JSON.stringify({ available: existsSync(TEST262_ROOT) }));
     return;
   }
 


### PR DESCRIPTION
## Summary
- move the landing page and report page onto the shared `t262-edition-timeline` component
- stabilize the edition slider behavior, labels, proposal handling, and glow/track rendering across both pages
- add a test262 source-availability endpoint to the Vite and standalone report servers so the report stops issuing broken source fetches when the submodule is missing

## Verification
- parsed `components/t262-charts.js`
- parsed inline scripts in `index.html`
- parsed inline scripts in `public/benchmarks/report.html`

## Notes
- this branch intentionally includes only the code/UI migration and not a benchmark artifact replay