### PR TITLE
fix(ci): set up node before baseline promotion

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -274,6 +274,11 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
       - name: Download merged reports
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Use the same Node 25 toolchain in the sharded workflow's promote-baseline job that the shard and merge jobs already use.

Without setup-node, the edition-bucket regeneration step falls back to the runner's default node, which rejected the strip-types flag and failed before promotion started.