### PR TITLE
fix(ci): materialize runs history before baseline updates

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -210,6 +210,9 @@ jobs:
           cp merged-reports/test262-report-merged.json public/benchmarks/results/test262-report.json
           cp merged-reports/test262-results-merged.jsonl public/benchmarks/results/test262-results.jsonl
 
+      - name: Materialize runs history from LFS
+        run: git lfs pull --include="benchmarks/results/runs/index.json"
+
       - name: Append to runs/index.json
         run: |
           node -e "

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -305,6 +305,9 @@ jobs:
       - name: Regenerate edition buckets
         run: node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
 
+      - name: Materialize runs history from LFS
+        run: git lfs pull --include="benchmarks/results/runs/index.json"
+
       - name: Append to runs/index.json (trend graph data)
         run: |
           node -e "


### PR DESCRIPTION
Fetch the LFS-backed runs history before appending trend entries in the sharded baseline promotion and emergency baseline refresh workflows.

Without that targeted LFS pull, those jobs can try to JSON.parse an LFS pointer file instead of the actual runs index and fail before committing updated baselines.