### PR TITLE
feat(#1163): static eval inlining (~208 tests)

### DIFF
--- a/plan/issues/sprints/44/1163.md
+++ b/plan/issues/sprints/44/1163.md
@@ -2,7 +2,7 @@
 id: 1163
 title: "Static eval inlining — compile eval(\"fixed string\") at compile time (~208 tests)"
 sprint: 44
-status: ready
+status: review
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -68,3 +68,49 @@ global-scope inlining (no caller-scope variable access).
 
 - [§19.2.1 eval(x)](https://tc39.es/ecma262/#sec-eval-x) — step 2: if x is not a String, return x
 - [§19.2.1.1 PerformEval](https://tc39.es/ecma262/#sec-performeval) — steps 3–10: parse Script, create eval context, evaluate
+
+## Implementation Notes
+
+Landed in `src/codegen/expressions/eval-inline.ts` and wired into the
+`isEvalCallExpression` branch of `compileCallExpression` (`src/codegen/expressions/calls.ts`).
+
+Flow:
+
+1. `resolveConstantString` walks the first argument and folds
+   string-literal / no-substitution-template-literal / `"a" + "b"` chains
+   into a single JS source string. Anything else → fall through.
+2. `ts.createSourceFile("<eval>.ts", src, Latest, setParentNodes=true, JS)`
+   parses the source. If `sf.parseDiagnostics` is non-empty we bail out so
+   the host eval can signal the SyntaxError correctly.
+3. An AST pre-scan (`allNodesInlineSupported`) rejects node kinds that need
+   type-checker bindings we can't provide for foreign nodes — function /
+   arrow / class declarations and expressions, for-of / for-in,
+   yield / await, import/export. These fall through to `__extern_eval`.
+4. `hoistVarDeclarations` / `hoistLetConstWithTdz` /
+   `hoistFunctionDeclarations` run over the parsed statement list just
+   like in a normal function body.
+5. All but the last statement go through `compileStatement`. If the last
+   statement is an `ExpressionStatement`, its expression becomes the
+   call result (coerced to `externref`). Otherwise we emit it and push
+   `undefined`.
+6. Additional `eval(...)` arguments are still evaluated for side effects
+   and dropped.
+
+The existing `__extern_eval` host path (#1006) is unchanged and serves as
+the fallback for every case the static inliner rejects. In standalone /
+WASI builds the host import is absent, so a fallthrough will still trap;
+that matches the pre-existing behavior.
+
+## Test Results
+
+- New tests: `tests/issue-1163.test.ts` — 8 / 8 pass (arithmetic, string
+  concat, `var` + identifier, `throw new TypeError(...)`, compile-time
+  `+` concat, template literal, indirect `(0, eval)(...)`, zero-arg
+  fallback).
+- Existing `tests/issue-1006.test.ts` (dynamic eval host) — 7 / 7 pass,
+  confirming the fallback path still works for non-literal arguments,
+  malformed sources, and IIFEs.
+- Full `tests/equivalence/*.test.ts` suite: 1185 / 1291 pass, identical
+  to pre-change baseline on the same worktree (106 failures are
+  pre-existing on main @ 3954b7821 — verified by re-running with the
+  change stashed). No new equivalence regressions.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -74,6 +74,7 @@ import {
   tryExternClassMethodOnAny,
 } from "./calls-closures.js";
 import { compileOptionalCallExpression } from "./calls-optional.js";
+import { tryStaticEvalInline } from "./eval-inline.js";
 import { compileExternMethodCall, compileSpreadCallArgs, emitLazyProtoGet } from "./extern.js";
 import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
 import { analyzeTdzAccessByPos, emitLocalTdzCheck, emitStaticTdzThrow } from "./identifiers.js";
@@ -497,11 +498,16 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     return compileOptionalDirectCall(ctx, fctx, expr);
   }
 
-  // eval(...) — route to __extern_eval JS-host import (#1006).
+  // eval(...) — first try static inlining (#1163): if the source argument is
+  // a compile-time-constant string, parse it and splice the AST inline at the
+  // call site.  This is the zero-runtime-cost path.  If the argument is not
+  // a constant (or parsing fails), fall through to __extern_eval (#1006).
   // Covers direct `eval(src)` and indirect `(0, eval)(src)` / `(0,eval)(src)`.
   // In standalone/WASI mode the host import is unavailable and will trap at
   // instantiation time — callers that need eval must use a JS host.
   if (isEvalCallExpression(expr)) {
+    const inlined = tryStaticEvalInline(ctx, fctx, expr);
+    if (inlined !== undefined) return inlined;
     let evalIdx = ctx.funcMap.get("__extern_eval");
     if (evalIdx === undefined) {
       const importsBefore = ctx.numImportFuncs;

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Static eval inlining (#1163).
+ *
+ * When the argument to `eval(...)` is a compile-time-constant string (a string
+ * literal, template literal with no substitutions, or a `+` concatenation of
+ * the above), we parse that string as a Script and splice its statements into
+ * the current function at compile time — no runtime eval is required.
+ *
+ * This replaces the dynamic `__extern_eval` host-import call (#1006) for the
+ * common literal-argument case.  Per ECMA-262 §19.2.1 PerformEval, the last
+ * value produced by the evaluated script becomes the result of the call; if
+ * the script does not produce a value (e.g., a var declaration only),
+ * `undefined` is returned.
+ *
+ * Non-literal arguments and parse failures fall through to the existing
+ * dynamic-eval path.
+ */
+import ts from "typescript";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { hoistFunctionDeclarations } from "../statements/nested-declarations.js";
+import { hoistLetConstWithTdz, hoistVarDeclarations } from "../index.js";
+import type { InnerResult } from "../shared.js";
+import { coerceType, compileExpression, compileStatement } from "../shared.js";
+import { emitUndefined } from "./late-imports.js";
+
+/**
+ * Recursively resolve a compile-time-constant string from an expression.
+ * Returns the string value, or null if the expression is not a constant.
+ */
+export function resolveConstantString(expr: ts.Expression): string | null {
+  // Unwrap parentheses: ("foo") / (("foo"))
+  let e: ts.Expression = expr;
+  while (ts.isParenthesizedExpression(e)) e = e.expression;
+
+  if (ts.isStringLiteral(e) || ts.isNoSubstitutionTemplateLiteral(e)) {
+    return e.text;
+  }
+
+  // String-literal concatenation: "a" + "b", possibly chained.
+  if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = resolveConstantString(e.left);
+    if (left === null) return null;
+    const right = resolveConstantString(e.right);
+    if (right === null) return null;
+    return left + right;
+  }
+
+  return null;
+}
+
+/**
+ * Try to inline `eval("<constant>")` at compile time.
+ *
+ * Returns:
+ *   - InnerResult (ValType or null) on success — caller treats this as the
+ *     compiled call result and does NOT invoke the dynamic-eval fallback.
+ *   - undefined if the call is not eligible (non-literal arg, parse errors,
+ *     etc.) — caller should fall through to the dynamic-eval path.
+ *
+ * On success we always push a single externref value onto the stack (the
+ * result of the inlined script, coerced to externref to match eval's `any`
+ * return type).  When the inlined code is statically unreachable (the last
+ * statement is a throw, etc.) we return `null` so the caller knows no value
+ * was produced.
+ */
+export function tryStaticEvalInline(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (expr.arguments.length === 0) return undefined;
+
+  const src = resolveConstantString(expr.arguments[0]!);
+  if (src === null) return undefined;
+
+  // Evaluate any additional arguments for side effects, then drop them.
+  // Per §19.2.1, eval only looks at its first argument, but extra args must
+  // still be evaluated (they could throw).
+  for (let ai = 1; ai < expr.arguments.length; ai++) {
+    const t = compileExpression(ctx, fctx, expr.arguments[ai]!);
+    if (t !== null) fctx.body.push({ op: "drop" });
+  }
+
+  // Parse the eval source as a Script with parent pointers set so the
+  // nested codegen paths (which walk upward via node.parent) work.
+  const sf = ts.createSourceFile("<eval>.ts", src, ts.ScriptTarget.Latest, /* setParentNodes */ true, ts.ScriptKind.JS);
+
+  // If the parse produced diagnostics we're looking at malformed eval source.
+  // Real JS would throw SyntaxError at runtime — for now, fall through to the
+  // dynamic path so the host can signal the error correctly.  `parseDiagnostics`
+  // is an internal field on SourceFile, so access it through a cast.
+  const parseDiag = (sf as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiag && parseDiag.length > 0) {
+    return undefined;
+  }
+
+  const stmts = sf.statements;
+
+  // Empty program — eval returns undefined.
+  if (stmts.length === 0) {
+    emitUndefined(ctx, fctx);
+    return { kind: "externref" };
+  }
+
+  // Scan the parsed AST for node kinds we cannot safely lower from a foreign
+  // SourceFile.  The TypeScript checker has no bindings for nodes created via
+  // `ts.createSourceFile`, so anything that requires static type information
+  // to compile correctly (function/arrow/class expressions, for-of loops that
+  // need iterator types, etc.) would silently mis-compile.  When we detect
+  // such a node we bail out and let the dynamic `__extern_eval` path handle
+  // the call — correctness first, inlining is a best-effort fast path.
+  if (!allNodesInlineSupported(sf)) {
+    return undefined;
+  }
+
+  // Hoist var / function declarations into the enclosing function scope
+  // before compiling any statements.  `let`/`const` enter the block scope
+  // in source order (handled by compileVariableStatement itself).
+  try {
+    hoistVarDeclarations(ctx, fctx, stmts);
+    hoistLetConstWithTdz(ctx, fctx, stmts);
+    hoistFunctionDeclarations(ctx, fctx, stmts);
+  } catch {
+    // If hoisting blows up (e.g. the checker can't type a foreign node),
+    // fall back to the dynamic-eval path.
+    return undefined;
+  }
+
+  // Compile all but the last statement for side effects.
+  const lastIdx = stmts.length - 1;
+  for (let i = 0; i < lastIdx; i++) {
+    compileStatement(ctx, fctx, stmts[i]!);
+  }
+
+  const last = stmts[lastIdx]!;
+
+  // ExpressionStatement — the expression's value is the eval result.
+  if (ts.isExpressionStatement(last)) {
+    const t = compileExpression(ctx, fctx, last.expression);
+    if (t === null) {
+      // Unreachable (e.g. the expression compiled to a throw).
+      return null;
+    }
+    if (t.kind !== "externref") {
+      coerceType(ctx, fctx, t, { kind: "externref" });
+    }
+    return { kind: "externref" };
+  }
+
+  // Non-expression last statement (throw, var, if, etc.) — compile it and
+  // push `undefined` as the eval result.  A throw statement compiles to a
+  // `throw` op which leaves the block polymorphic, so the trailing
+  // `undefined` push is still well-formed (it's dead code after throw, but
+  // keeps the stack types consistent from the caller's perspective).
+  compileStatement(ctx, fctx, last);
+  emitUndefined(ctx, fctx);
+  return { kind: "externref" };
+}
+
+/**
+ * Walk the parsed eval AST and return false if it contains any node kind that
+ * requires TypeScript checker bindings (or binding analysis) we can't provide
+ * for foreign nodes.  Currently: function/arrow/class expressions and
+ * declarations, for-of loops, yield/await, and dynamic import.  The check is
+ * conservative — unsupported constructs simply fall through to runtime eval.
+ */
+function allNodesInlineSupported(node: ts.Node): boolean {
+  let ok = true;
+  const visit = (n: ts.Node): void => {
+    if (!ok) return;
+    switch (n.kind) {
+      case ts.SyntaxKind.FunctionDeclaration:
+      case ts.SyntaxKind.FunctionExpression:
+      case ts.SyntaxKind.ArrowFunction:
+      case ts.SyntaxKind.ClassDeclaration:
+      case ts.SyntaxKind.ClassExpression:
+      case ts.SyntaxKind.ForOfStatement:
+      case ts.SyntaxKind.ForInStatement:
+      case ts.SyntaxKind.YieldExpression:
+      case ts.SyntaxKind.AwaitExpression:
+      case ts.SyntaxKind.ImportDeclaration:
+      case ts.SyntaxKind.ExportDeclaration:
+      case ts.SyntaxKind.ExportAssignment:
+        ok = false;
+        return;
+      default:
+        n.forEachChild(visit);
+    }
+  };
+  node.forEachChild(visit);
+  return ok;
+}

--- a/tests/issue-1163.test.ts
+++ b/tests/issue-1163.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+describe("#1163 — static eval inlining (compile-time eval of string literal)", () => {
+  async function runTest(src: string): Promise<{ pass: boolean; ret?: unknown; error?: string }> {
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    if (!result.success) return { pass: false, error: result.error };
+    const importObj = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
+    if (typeof (importObj as any).setExports === "function") {
+      (importObj as any).setExports(instance.exports);
+    }
+    try {
+      const ret = (instance.exports as any).test();
+      return { pass: ret === 1, ret };
+    } catch (e: any) {
+      return { pass: false, error: String(e) };
+    }
+  }
+
+  it("eval of arithmetic expression returns value", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = eval("1 + 2");
+        return r === 3 ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval of string concatenation returns string", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = eval('"foo" + "bar"');
+        return r === "foobar" ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval with var declaration + identifier returns declared value", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = eval("var x = 42; x");
+        return r === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval of throw TypeError propagates as catchable TypeError", async () => {
+    const src = `
+      export function test(): number {
+        try {
+          eval("throw new TypeError('boom')");
+          return 0;
+        } catch (e: any) {
+          return e instanceof TypeError ? 1 : 0;
+        }
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval of string literal concatenated at source level (compile-time) inlines", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = eval("1 + " + "2");
+        return r === 3 ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval of template literal with no substitutions inlines", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = eval(\`10 * 4\`);
+        return r === 40 ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("indirect (0, eval)(literal) inlines", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = (0, eval)("100 - 58");
+        return r === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+
+  it("eval with no arguments still returns undefined (non-literal fallback path)", async () => {
+    const src = `
+      export function test(): number {
+        const r: any = (eval as any)();
+        return r === undefined ? 1 : 0;
+      }
+    `;
+    const { pass, error, ret } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass, `got ret=${String(ret)}`).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Inlines `eval("constant string")` at compile time by parsing the argument with the TypeScript parser and splicing the resulting AST into the call site — no runtime eval / JS-host import needed for this fast path.
- Falls through to the existing `__extern_eval` host path (#1006) whenever the call is not inlineable (non-literal argument, parse errors, or AST shapes requiring type-checker bindings we can't provide for foreign nodes: function / arrow / class / for-of / yield / await / import / export).
- Supports direct `eval(...)`, indirect `(0, eval)(...)`, string-literal `+` concatenations that fold to a constant, and no-substitution template literals.

## Implementation

New `src/codegen/expressions/eval-inline.ts` with `resolveConstantString` (fold constant strings) and `tryStaticEvalInline` (parse + hoist + lower). `src/codegen/expressions/calls.ts` calls it first at the eval branch; on `undefined` it falls through to the existing `__extern_eval` path unchanged.

Hoists `var` / `let` / `const` / function declarations in the parsed program into the enclosing function scope, then compiles statements normally. The last expression's value becomes the eval result (coerced to `externref`); otherwise we push `undefined`.

## Acceptance criteria (all pass)

- `eval("1 + 2")` → `3`
- `eval("var x = 42; x")` → `42`
- `eval("throw new TypeError('msg')")` → propagates `TypeError`

## Test plan

- [x] `npm test -- tests/issue-1163.test.ts` — 8/8 pass
- [x] `npm test -- tests/issue-1006.test.ts` — 7/7 pass (dynamic eval fallback path intact)
- [x] `npm test -- tests/equivalence/` — 1185/1291, identical to pre-change baseline on the same worktree (106 failures are pre-existing on main @ 3954b7821, verified by re-running with the change stashed)
- [ ] CI test262 — expected to convert the ~208 `eval(literal)` tests from FAIL to PASS

Spec: ECMA-262 §19.2.1 PerformEval — ParseText Script, evaluate, return completion value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)