### PR TITLE
feat(#1167b): IR Phase 3b — inline-small direct IR calls

### DIFF
--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -2,16 +2,20 @@
 //
 // Integration point between the legacy codegen pipeline and the IR path.
 //
-// `compileIrPathFunctions` runs after `compileDeclarations`. For each
-// function in the IR selection it:
+// `compileIrPathFunctions` runs after `compileDeclarations`. It now runs in
+// three explicit phases — driven by spec #1167b, which added module-scope
+// inlining that requires seeing every IR function at once before any of
+// them lower to Wasm:
 //
-//   1. Lowers the AST to middle-end IR (`lowerFunctionAstToIr`).
-//   2. Verifies the IR (`verifyIrFunction`).
-//   3. Lowers the IR to a WasmFunction (`lowerIrFunctionToWasm`) using
-//      symbolic-ref resolvers backed by the live codegen context.
-//   4. Replaces the corresponding entry in `ctx.mod.functions` — keeping
-//      the already-allocated funcIdx/typeIdx/export state intact so the
-//      legacy late-repair passes see a consistent module.
+//   1. Build — lower every selected AST function to an `IrFunction` and
+//      collect them into an `IrModule`.
+//   2. Pass — run per-function hygiene (CF → DCE → simplifyCFG), then
+//      module-scope inlining (`inlineSmall`), then re-run hygiene on any
+//      modified function. Each stage verifies.
+//   3. Lower — replace each selected function's entry in `ctx.mod.functions`
+//      with the Wasm body produced by `lowerIrFunctionToWasm`, keeping the
+//      pre-allocated funcIdx/typeIdx/export state intact so the legacy
+//      late-repair passes see a consistent module.
 //
 // Because the IR lowerer resolves IrFuncRef/IrGlobalRef symbols at this
 // integration point (AFTER all imports have been registered), the legacy
@@ -24,9 +28,10 @@ import { addFuncType } from "../codegen/registry/types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
 import { lowerFunctionAstToIr } from "./from-ast.js";
 import { lowerIrFunctionToWasm, type IrLowerResolver, type IrUnionLowering } from "./lower.js";
-import type { IrFuncRef, IrFunction, IrGlobalRef, IrType, IrTypeRef } from "./nodes.js";
+import type { IrFuncRef, IrFunction, IrGlobalRef, IrModule, IrType, IrTypeRef } from "./nodes.js";
 import { constantFold } from "./passes/constant-fold.js";
 import { deadCode } from "./passes/dead-code.js";
+import { inlineSmall } from "./passes/inline-small.js";
 import { simplifyCFG } from "./passes/simplify-cfg.js";
 import { UnionStructRegistry } from "./passes/tagged-union-types.js";
 import { planIrCompilation, type IrSelection } from "./select.js";
@@ -88,6 +93,14 @@ export function compileIrPathFunctions(
     },
   });
 
+  // -------------------------------------------------------------------------
+  // Phase 1 — Build: lower every selected AST function to an IrFunction.
+  // -------------------------------------------------------------------------
+  interface BuiltFn {
+    readonly name: string;
+    readonly fn: IrFunction;
+  }
+  const built: BuiltFn[] = [];
   for (const stmt of sourceFile.statements) {
     if (!ts.isFunctionDeclaration(stmt)) continue;
     if (!stmt.name) continue;
@@ -107,20 +120,65 @@ export function compileIrPathFunctions(
         for (const e of verifyErrors) errors.push({ func: name, message: e.message });
         continue;
       }
+      built.push({ name, fn: ir });
+    } catch (e) {
+      errors.push({ func: name, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
 
-      // Phase 3a hygiene passes (#1167a). Run to fixpoint: CF exposes
-      // unreachable blocks for DCE, DCE exposes single-successor chains
-      // for simplifyCFG, and simplifyCFG may expose more constant
-      // operands to the next CF round.
-      const optimized = runHygienePasses(ir);
-      const postPassErrors = verifyIrFunction(optimized);
-      if (postPassErrors.length > 0) {
-        for (const e of postPassErrors) {
-          errors.push({ func: name, message: `post-hygiene verify: ${e.message}` });
-        }
-        continue;
+  if (built.length === 0) return { compiled, errors };
+
+  // -------------------------------------------------------------------------
+  // Phase 2 — Pass: per-function hygiene → module-scope inline → re-run
+  // hygiene on modified functions. Verify between stages.
+  // -------------------------------------------------------------------------
+
+  // 2a. Per-function hygiene (CF → DCE → simplifyCFG to fixpoint).
+  const afterHygiene: BuiltFn[] = [];
+  for (const entry of built) {
+    const optimized = runHygienePasses(entry.fn);
+    const postErrors = verifyIrFunction(optimized);
+    if (postErrors.length > 0) {
+      for (const e of postErrors) {
+        errors.push({ func: entry.name, message: `post-hygiene verify: ${e.message}` });
       }
+      continue;
+    }
+    afterHygiene.push({ name: entry.name, fn: optimized });
+  }
 
+  if (afterHygiene.length === 0) return { compiled, errors };
+
+  // 2b. Module-scope inlining (#1167b).
+  const modIn: IrModule = { functions: afterHygiene.map((e) => e.fn) };
+  const modOut = inlineSmall(modIn);
+
+  // 2c. Re-run hygiene on functions the inline pass actually rewrote; verify.
+  const readyForLower: BuiltFn[] = [];
+  for (let i = 0; i < afterHygiene.length; i++) {
+    const before = afterHygiene[i]!;
+    const after = modOut.functions[i]!;
+    const changed = after !== before.fn;
+    const final = changed ? runHygienePasses(after) : after;
+    const verifyErrors = verifyIrFunction(final);
+    if (verifyErrors.length > 0) {
+      for (const e of verifyErrors) {
+        errors.push({ func: before.name, message: `post-inline verify: ${e.message}` });
+      }
+      continue;
+    }
+    readyForLower.push({ name: before.name, fn: final });
+  }
+
+  if (readyForLower.length === 0) return { compiled, errors };
+
+  // -------------------------------------------------------------------------
+  // Phase 3 — Lower: translate each IrFunction to Wasm and install in ctx.
+  // -------------------------------------------------------------------------
+  const resolver = makeResolver(ctx, unionRegistry);
+  for (const entry of readyForLower) {
+    const name = entry.name;
+    try {
       const funcIdx = ctx.funcMap.get(name);
       if (funcIdx === undefined) {
         errors.push({ func: name, message: `no funcIdx allocated for ${name}` });
@@ -132,8 +190,7 @@ export function compileIrPathFunctions(
         continue;
       }
 
-      const resolver = makeResolver(ctx, unionRegistry);
-      const { func: wasmFunc } = lowerIrFunctionToWasm(optimized, resolver);
+      const { func: wasmFunc } = lowerIrFunctionToWasm(entry.fn, resolver);
 
       const existing = ctx.mod.functions[localIdx];
       ctx.mod.functions[localIdx] = {

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -426,6 +426,22 @@ export interface IrFunction {
 }
 
 // ---------------------------------------------------------------------------
+// Module — collection of IR functions visible simultaneously
+// ---------------------------------------------------------------------------
+//
+// Module-scope passes (e.g. `inlineSmall` in Phase 3b — #1167b) need to see
+// every IR-path function at once. The AST→IR lowerer emits per-function, so
+// `integration.ts` accumulates the per-function results into an `IrModule`
+// container between the build phase and the lower phase.
+//
+// The container holds only functions for now. Globals/types/imports remain
+// resolved lazily via the symbolic-ref mechanism.
+
+export interface IrModule {
+  readonly functions: readonly IrFunction[];
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -1,0 +1,409 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// IR-to-IR inlining of small, non-recursive, single-block callees — spec #1167b.
+//
+// First slice of Phase 3b. This pass runs after the Phase 3a hygiene pipeline
+// (CF → DCE → simplifyCFG) and before lowering to Wasm. It expands small
+// callee bodies into the caller's blocks, avoiding a `call` instruction at
+// lowering time.
+//
+// ## Scope (v1): single-block callees only
+//
+// A callee is inlinable iff ALL of:
+//
+//   - `callee.blocks.length === 1` — multi-block inlining (multiple `return`
+//     terminators requiring continuation-block splicing + CFG rewrites) is
+//     deferred to a follow-up. Two-return shapes like
+//       if (x < 0) return -x;
+//       return x;
+//     fall out of this slice.
+//   - Sole block's terminator is `return <value>` (exactly one value).
+//   - Callee is non-recursive (not part of any SCC, including self-loops).
+//   - Callee body ≤ N instructions (N = 10 by default).
+//   - Callee body contains no `raw.wasm` — its `ops` may reference
+//     function-local Wasm indices (local.get, etc.) which would be invalid
+//     in a different caller's local frame. Plain SSA ops (const, binary,
+//     select, ...) are safe to splice.
+//
+// ## Algorithm
+//
+// For each caller function, walk block instrs. For each `call` to an
+// inlinable callee:
+//
+//   1. Allocate a fresh IrValueId for every value the callee's block
+//      defines (instruction results). Parameters map directly to the
+//      caller's call-site argument values.
+//   2. Splice the callee's instructions into the caller's block at the
+//      call-site position, with operands + results rewritten through the
+//      rename map.
+//   3. Replace the caller's use of the call's result with the renamed
+//      callee-return value: set `callerRename[callSite.result] = renamedReturn`
+//      and apply the map to every subsequent instruction and the terminator.
+//
+// A single pass over each block handles any number of inlined calls because
+// `callerRename` accumulates mappings as we go; later uses are rewritten
+// transparently.
+//
+// ## Size budget
+//
+// To avoid runaway code growth, a single caller will not grow beyond
+// `max(4× original, original + 2× MAX_CALLEE_INSTRS)` instructions across
+// all inline decisions. The floor lets a trivially-small caller (e.g. a
+// one-instr thunk `return abs(n);`) absorb one or two small callees that
+// would otherwise be blocked by the strict multiplicative bound.
+//
+// ## Post-conditions
+//
+// - `verifyIrFunction` returns zero errors on every modified function.
+// - `valueCount` reflects the new high-water mark (old count + freshly
+//   allocated inlined-value ids).
+// - `blocks.length` is unchanged (we only splice into existing blocks;
+//   single-block callees produce no new blocks).
+//
+// The caller (`integration.ts`) re-runs `constantFold` + `deadCode` on every
+// modified function afterwards so the inlined constants / unused args get
+// cleaned up before lowering.
+
+import {
+  asValueId,
+  type IrBlock,
+  type IrBranch,
+  type IrFunction,
+  type IrInstr,
+  type IrModule,
+  type IrTerminator,
+  type IrValueId,
+} from "../nodes.js";
+
+const MAX_CALLEE_INSTRS = 10;
+const CALLER_SIZE_BUDGET_MULTIPLIER = 4;
+
+/**
+ * Inline small, non-recursive, single-block callees across the module.
+ * Returns the same `IrModule` reference when no function changes.
+ */
+export function inlineSmall(mod: IrModule): IrModule {
+  const byName = new Map<string, IrFunction>();
+  for (const fn of mod.functions) byName.set(fn.name, fn);
+
+  const recursiveSet = computeRecursiveSet(mod, byName);
+
+  const newFunctions: IrFunction[] = [];
+  let anyChanged = false;
+  for (const fn of mod.functions) {
+    const inlined = inlineIntoFunction(fn, byName, recursiveSet);
+    if (inlined !== fn) anyChanged = true;
+    newFunctions.push(inlined);
+  }
+  if (!anyChanged) return mod;
+  return { functions: newFunctions };
+}
+
+// ---------------------------------------------------------------------------
+// Per-function inlining
+// ---------------------------------------------------------------------------
+
+function inlineIntoFunction(
+  caller: IrFunction,
+  byName: ReadonlyMap<string, IrFunction>,
+  recursiveSet: ReadonlySet<string>,
+): IrFunction {
+  const originalSize = countInstrs(caller);
+  let nextValueId = caller.valueCount;
+  let currentSize = originalSize;
+  let anyFuncChange = false;
+
+  const newBlocks: IrBlock[] = [];
+  for (const block of caller.blocks) {
+    // callerRename collects rewrites that apply to caller-scope SSA ids
+    // produced by prior instructions in THIS block. Specifically, each time
+    // we inline a call, we add:
+    //   callSite.result  →  renamedReturn (callee's return value post-rename)
+    // so every later instruction / the terminator uses the inlined value
+    // transparently.
+    const callerRename = new Map<IrValueId, IrValueId>();
+
+    const newInstrs: IrInstr[] = [];
+    let blockChanged = false;
+
+    for (const instr of block.instrs) {
+      // First, apply any accumulated renames to this instruction's operands.
+      const rewritten = renameInstrOperands(instr, callerRename);
+      if (rewritten !== instr) blockChanged = true;
+
+      if (rewritten.kind !== "call") {
+        newInstrs.push(rewritten);
+        continue;
+      }
+
+      const callee = byName.get(rewritten.target.name);
+      if (!callee || !canInline(callee, recursiveSet)) {
+        newInstrs.push(rewritten);
+        continue;
+      }
+
+      const body = callee.blocks[0]!;
+      const calleeSize = body.instrs.length;
+      const budget = Math.max(CALLER_SIZE_BUDGET_MULTIPLIER * originalSize, originalSize + 2 * MAX_CALLEE_INSTRS);
+      if (currentSize + calleeSize > budget) {
+        newInstrs.push(rewritten);
+        continue;
+      }
+
+      // Return terminator shape — already guarded by `canInline`, but assert
+      // locally so TypeScript narrows and we catch invariants slipping.
+      const term = body.terminator;
+      if (term.kind !== "return" || term.values.length !== 1) {
+        newInstrs.push(rewritten);
+        continue;
+      }
+      const returnValueId = term.values[0]!;
+
+      // Build the callee-scope rename: params first (to call-site args),
+      // then every instr result gets a fresh caller-scope id.
+      const calleeRename = new Map<IrValueId, IrValueId>();
+      if (rewritten.args.length !== callee.params.length) {
+        // Arity mismatch would be a bug upstream — bail out safely rather
+        // than emit malformed IR.
+        newInstrs.push(rewritten);
+        continue;
+      }
+      for (let i = 0; i < callee.params.length; i++) {
+        calleeRename.set(callee.params[i]!.value, rewritten.args[i]!);
+      }
+      for (const inst of body.instrs) {
+        if (inst.result !== null) {
+          calleeRename.set(inst.result, asValueId(nextValueId++));
+        }
+      }
+
+      // Splice callee body into caller (renamed).
+      for (const inst of body.instrs) {
+        newInstrs.push(renameAllInInstr(inst, calleeRename));
+      }
+
+      // The call's result becomes the renamed return value for all downstream
+      // uses in this block and its terminator.
+      const renamedReturn = calleeRename.get(returnValueId) ?? returnValueId;
+      if (rewritten.result !== null) {
+        callerRename.set(rewritten.result, renamedReturn);
+      }
+
+      currentSize += calleeSize;
+      blockChanged = true;
+      anyFuncChange = true;
+    }
+
+    const newTerm = renameTerminatorOperands(block.terminator, callerRename);
+    if (newTerm !== block.terminator) blockChanged = true;
+
+    if (!blockChanged) {
+      newBlocks.push(block);
+    } else {
+      newBlocks.push({
+        id: block.id,
+        blockArgs: block.blockArgs,
+        blockArgTypes: block.blockArgTypes,
+        instrs: newInstrs,
+        terminator: newTerm,
+      });
+    }
+  }
+
+  if (!anyFuncChange) return caller;
+  return {
+    ...caller,
+    blocks: newBlocks,
+    valueCount: nextValueId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inlinability check
+// ---------------------------------------------------------------------------
+
+function canInline(callee: IrFunction, recursiveSet: ReadonlySet<string>): boolean {
+  if (callee.blocks.length !== 1) return false;
+  if (recursiveSet.has(callee.name)) return false;
+  const body = callee.blocks[0]!;
+  if (body.instrs.length > MAX_CALLEE_INSTRS) return false;
+  const term = body.terminator;
+  if (term.kind !== "return") return false;
+  if (term.values.length !== 1) return false;
+  // raw.wasm may carry function-local backend indices that don't survive a
+  // change of enclosing function — conservative skip.
+  for (const inst of body.instrs) {
+    if (inst.kind === "raw.wasm") return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Recursion detection (transitive closure over the local call graph)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the set of function names that are part of any call cycle (including
+ * direct self-recursion) within the IR module. Only edges to locally-visible
+ * callees count — cross-module / host imports don't appear in the graph.
+ */
+function computeRecursiveSet(mod: IrModule, byName: ReadonlyMap<string, IrFunction>): Set<string> {
+  const edges = new Map<string, Set<string>>();
+  for (const fn of mod.functions) {
+    const set = new Set<string>();
+    for (const block of fn.blocks) {
+      for (const instr of block.instrs) {
+        if (instr.kind === "call" && byName.has(instr.target.name)) {
+          set.add(instr.target.name);
+        }
+      }
+    }
+    edges.set(fn.name, set);
+  }
+  const recursive = new Set<string>();
+  for (const fn of mod.functions) {
+    if (reachesSelf(fn.name, edges)) recursive.add(fn.name);
+  }
+  return recursive;
+}
+
+function reachesSelf(start: string, edges: ReadonlyMap<string, ReadonlySet<string>>): boolean {
+  const visited = new Set<string>();
+  const stack: string[] = [];
+  const seed = edges.get(start);
+  if (seed) for (const n of seed) stack.push(n);
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    if (cur === start) return true;
+    if (visited.has(cur)) continue;
+    visited.add(cur);
+    const next = edges.get(cur);
+    if (next) for (const n of next) stack.push(n);
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Value-id remapping helpers
+// ---------------------------------------------------------------------------
+
+function countInstrs(fn: IrFunction): number {
+  let n = 0;
+  for (const b of fn.blocks) n += b.instrs.length;
+  return n;
+}
+
+function mapId(rename: ReadonlyMap<IrValueId, IrValueId>, v: IrValueId): IrValueId {
+  return rename.get(v) ?? v;
+}
+
+/**
+ * Rewrite operand IDs in an instruction. Does NOT touch `result` — reserved
+ * for caller-scope renames (where we only redirect uses, not definitions).
+ */
+function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrValueId>): IrInstr {
+  if (rename.size === 0) return inst;
+  switch (inst.kind) {
+    case "const":
+    case "global.get":
+    case "raw.wasm":
+      return inst;
+    case "call": {
+      let changed = false;
+      const newArgs: IrValueId[] = [];
+      for (const a of inst.args) {
+        const n = mapId(rename, a);
+        if (n !== a) changed = true;
+        newArgs.push(n);
+      }
+      if (!changed) return inst;
+      return { ...inst, args: newArgs };
+    }
+    case "global.set": {
+      const v = mapId(rename, inst.value);
+      if (v === inst.value) return inst;
+      return { ...inst, value: v };
+    }
+    case "binary": {
+      const l = mapId(rename, inst.lhs);
+      const r = mapId(rename, inst.rhs);
+      if (l === inst.lhs && r === inst.rhs) return inst;
+      return { ...inst, lhs: l, rhs: r };
+    }
+    case "unary": {
+      const r = mapId(rename, inst.rand);
+      if (r === inst.rand) return inst;
+      return { ...inst, rand: r };
+    }
+    case "select": {
+      const c = mapId(rename, inst.condition);
+      const t = mapId(rename, inst.whenTrue);
+      const f = mapId(rename, inst.whenFalse);
+      if (c === inst.condition && t === inst.whenTrue && f === inst.whenFalse) return inst;
+      return { ...inst, condition: c, whenTrue: t, whenFalse: f };
+    }
+    case "box":
+    case "unbox":
+    case "tag.test": {
+      const v = mapId(rename, inst.value);
+      if (v === inst.value) return inst;
+      return { ...inst, value: v };
+    }
+  }
+}
+
+/**
+ * Rewrite operands AND result through `rename`. Used when splicing a callee
+ * instruction into the caller — every callee-scope id (including results)
+ * must be mapped to a caller-scope id.
+ */
+function renameAllInInstr(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrValueId>): IrInstr {
+  const operandsRenamed = renameInstrOperands(inst, rename);
+  if (operandsRenamed.result === null) return operandsRenamed;
+  const newResult = rename.get(operandsRenamed.result) ?? operandsRenamed.result;
+  if (newResult === operandsRenamed.result) return operandsRenamed;
+  return { ...operandsRenamed, result: newResult };
+}
+
+function renameTerminatorOperands(t: IrTerminator, rename: ReadonlyMap<IrValueId, IrValueId>): IrTerminator {
+  if (rename.size === 0) return t;
+  switch (t.kind) {
+    case "return": {
+      let changed = false;
+      const vals: IrValueId[] = [];
+      for (const v of t.values) {
+        const n = mapId(rename, v);
+        if (n !== v) changed = true;
+        vals.push(n);
+      }
+      if (!changed) return t;
+      return { ...t, values: vals };
+    }
+    case "br": {
+      const b = renameBranchOperands(t.branch, rename);
+      if (b === t.branch) return t;
+      return { ...t, branch: b };
+    }
+    case "br_if": {
+      const c = mapId(rename, t.condition);
+      const tt = renameBranchOperands(t.ifTrue, rename);
+      const ff = renameBranchOperands(t.ifFalse, rename);
+      if (c === t.condition && tt === t.ifTrue && ff === t.ifFalse) return t;
+      return { ...t, condition: c, ifTrue: tt, ifFalse: ff };
+    }
+    case "unreachable":
+      return t;
+  }
+}
+
+function renameBranchOperands(br: IrBranch, rename: ReadonlyMap<IrValueId, IrValueId>): IrBranch {
+  let changed = false;
+  const args: IrValueId[] = [];
+  for (const a of br.args) {
+    const n = mapId(rename, a);
+    if (n !== a) changed = true;
+    args.push(n);
+  }
+  if (!changed) return br;
+  return { target: br.target, args };
+}

--- a/tests/ir/inline-small.test.ts
+++ b/tests/ir/inline-small.test.ts
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1167b — IR Phase 3b: inline-small (direct IR-to-IR calls).
+//
+// Covers:
+//   1. Unit — single-block non-recursive callee gets inlined.
+//   2. Unit — recursive callee is skipped.
+//   3. Unit — multi-block callee is skipped.
+//   4. Unit — `valueCount` advances past freshly-allocated inlined-value ids.
+//   5. End-to-end — `abs` (single-block ternary) called from another function:
+//      emitted WAT contains no `call $abs`; the compiled wasm still produces
+//      the correct results.
+//   6. End-to-end — recursive `fib` is NOT inlined at its own call sites;
+//      WAT keeps `call $fib`; runtime still correct.
+//   7. End-to-end — multi-block non-recursive callee is NOT inlined; WAT
+//      keeps the call; runtime still correct.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../../src/index.js";
+import { asBlockId, asValueId, irVal, verifyIrFunction, type IrFunction, type IrValueId } from "../../src/ir/index.js";
+import { inlineSmall } from "../../src/ir/passes/inline-small.js";
+
+// ---------------------------------------------------------------------------
+// Unit-test helpers
+// ---------------------------------------------------------------------------
+
+function id(n: number): IrValueId {
+  return asValueId(n);
+}
+
+const F64 = irVal({ kind: "f64" });
+const BOOL = irVal({ kind: "i32" });
+
+// A tiny single-block, non-recursive callee modelling `abs(x) = x < 0 ? -x : x`.
+// 1 param + 4 instrs + return. Well under the 10-instr limit.
+function makeAbsCallee(): IrFunction {
+  return {
+    name: "abs",
+    params: [{ value: id(0), type: F64, name: "x" }],
+    resultTypes: [F64],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [
+          { kind: "const", value: { kind: "f64", value: 0 }, result: id(1), resultType: F64 },
+          { kind: "binary", op: "f64.lt", lhs: id(0), rhs: id(1), result: id(2), resultType: BOOL },
+          { kind: "unary", op: "f64.neg", rand: id(0), result: id(3), resultType: F64 },
+          {
+            kind: "select",
+            condition: id(2),
+            whenTrue: id(3),
+            whenFalse: id(0),
+            result: id(4),
+            resultType: F64,
+          },
+        ],
+        terminator: { kind: "return", values: [id(4)] },
+      },
+    ],
+    exported: false,
+    valueCount: 5,
+  };
+}
+
+// Caller: `run(n) = abs(n)`. Single-block, single call, returns the result.
+function makeRunCaller(): IrFunction {
+  return {
+    name: "run",
+    params: [{ value: id(0), type: F64, name: "n" }],
+    resultTypes: [F64],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [
+          {
+            kind: "call",
+            target: { kind: "func", name: "abs" },
+            args: [id(0)],
+            result: id(1),
+            resultType: F64,
+          },
+        ],
+        terminator: { kind: "return", values: [id(1)] },
+      },
+    ],
+    exported: true,
+    valueCount: 2,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+describe("#1167b — inlineSmall (unit)", () => {
+  it("inlines a single-block non-recursive callee", () => {
+    const callee = makeAbsCallee();
+    const caller = makeRunCaller();
+    const out = inlineSmall({ functions: [callee, caller] });
+    expect(out).not.toBe({ functions: [callee, caller] }); // module changed
+
+    // callee is unchanged; caller had its call replaced.
+    const newCaller = out.functions[1]!;
+    expect(newCaller).not.toBe(caller);
+    expect(newCaller.blocks).toHaveLength(1);
+
+    const block = newCaller.blocks[0]!;
+    // No `call` instruction remains.
+    expect(block.instrs.find((i) => i.kind === "call")).toBeUndefined();
+    // The 4 callee instructions are now spliced in.
+    expect(block.instrs).toHaveLength(4);
+    expect(block.instrs[0]!.kind).toBe("const");
+    expect(block.instrs[1]!.kind).toBe("binary");
+    expect(block.instrs[2]!.kind).toBe("unary");
+    expect(block.instrs[3]!.kind).toBe("select");
+
+    // valueCount advanced to include fresh ids for the 4 inlined results.
+    // Original caller valueCount was 2; we allocate 4 fresh ids → 6.
+    expect(newCaller.valueCount).toBe(6);
+
+    // Verify invariants hold on the inlined function.
+    expect(verifyIrFunction(newCaller)).toEqual([]);
+  });
+
+  it("operands of inlined instructions are rewired to caller SSA ids", () => {
+    const callee = makeAbsCallee();
+    const caller = makeRunCaller();
+    const out = inlineSmall({ functions: [callee, caller] });
+    const newCaller = out.functions[1]!;
+    const block = newCaller.blocks[0]!;
+
+    // Binary's lhs is the callee's param `x` → must be mapped to the caller's
+    // arg (id(0) in caller). The select operand for `whenFalse` likewise maps
+    // to id(0). The `rand` in unary is also callee's x → id(0).
+    const binary = block.instrs[1]!;
+    if (binary.kind !== "binary") throw new Error("expected binary");
+    expect(binary.lhs).toBe(id(0));
+
+    const unary = block.instrs[2]!;
+    if (unary.kind !== "unary") throw new Error("expected unary");
+    expect(unary.rand).toBe(id(0));
+
+    const sel = block.instrs[3]!;
+    if (sel.kind !== "select") throw new Error("expected select");
+    expect(sel.whenFalse).toBe(id(0));
+  });
+
+  it("skips a recursive callee", () => {
+    // `rec(x) = rec(x)` — trivially recursive, single-block, returns via
+    // the recursive call's result. canInline must reject it.
+    const rec: IrFunction = {
+      name: "rec",
+      params: [{ value: id(0), type: F64, name: "x" }],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "call",
+              target: { kind: "func", name: "rec" },
+              args: [id(0)],
+              result: id(1),
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [id(1)] },
+        },
+      ],
+      exported: false,
+      valueCount: 2,
+    };
+    const caller: IrFunction = {
+      name: "run",
+      params: [{ value: id(0), type: F64, name: "n" }],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "call",
+              target: { kind: "func", name: "rec" },
+              args: [id(0)],
+              result: id(1),
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [id(1)] },
+        },
+      ],
+      exported: true,
+      valueCount: 2,
+    };
+    const out = inlineSmall({ functions: [rec, caller] });
+    // Nothing changed — both references are the same.
+    expect(out.functions[0]).toBe(rec);
+    expect(out.functions[1]).toBe(caller);
+  });
+
+  it("skips a multi-block callee", () => {
+    // A two-block callee is rejected by canInline regardless of size.
+    const multi: IrFunction = {
+      name: "two",
+      params: [{ value: id(0), type: F64, name: "x" }],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [],
+          terminator: { kind: "br", branch: { target: asBlockId(1), args: [] } },
+        },
+        {
+          id: asBlockId(1),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [],
+          terminator: { kind: "return", values: [id(0)] },
+        },
+      ],
+      exported: false,
+      valueCount: 1,
+    };
+    const caller: IrFunction = {
+      name: "run",
+      params: [{ value: id(0), type: F64, name: "n" }],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "call",
+              target: { kind: "func", name: "two" },
+              args: [id(0)],
+              result: id(1),
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [id(1)] },
+        },
+      ],
+      exported: true,
+      valueCount: 2,
+    };
+    const out = inlineSmall({ functions: [multi, caller] });
+    expect(out.functions[0]).toBe(multi);
+    expect(out.functions[1]).toBe(caller);
+  });
+
+  it("skips callees larger than the instruction budget", () => {
+    // Build a callee with > 10 instrs: 11 const instructions feeding a binop.
+    // The simplest way is to chain 12 consts + 11 binaries, but we only need
+    // > 10 so 11 instrs total suffices.
+    const instrs = [];
+    for (let i = 0; i < 11; i++) {
+      instrs.push({
+        kind: "const" as const,
+        value: { kind: "f64" as const, value: i },
+        result: id(i),
+        resultType: F64,
+      });
+    }
+    const large: IrFunction = {
+      name: "large",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs,
+          terminator: { kind: "return", values: [id(0)] },
+        },
+      ],
+      exported: false,
+      valueCount: 11,
+    };
+    const caller: IrFunction = {
+      name: "run",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "call",
+              target: { kind: "func", name: "large" },
+              args: [],
+              result: id(0),
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [id(0)] },
+        },
+      ],
+      exported: true,
+      valueCount: 1,
+    };
+    const out = inlineSmall({ functions: [large, caller] });
+    expect(out.functions[1]).toBe(caller);
+  });
+
+  it("returns the same module reference when nothing is inlinable", () => {
+    const only: IrFunction = {
+      name: "f",
+      params: [{ value: id(0), type: F64, name: "n" }],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [],
+          terminator: { kind: "return", values: [id(0)] },
+        },
+      ],
+      exported: true,
+      valueCount: 1,
+    };
+    const mod = { functions: [only] };
+    const out = inlineSmall(mod);
+    expect(out).toBe(mod);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end — compile through the IR path and inspect WAT + runtime.
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the full textual block `(func $NAME ...)` from a WAT module. The
+ * emitted WAT uses numeric indices for `call` operands (e.g. `call 26`), so
+ * to decide whether the caller body contains a call we isolate the caller's
+ * parenthesised body and scan for a `call ` token inside it.
+ */
+function extractFuncBody(wat: string, name: string): string {
+  const marker = `(func $${name}`;
+  const start = wat.indexOf(marker);
+  if (start < 0) return "";
+  let depth = 0;
+  for (let i = start; i < wat.length; i++) {
+    const ch = wat[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) return wat.slice(start, i + 1);
+    }
+  }
+  return wat.slice(start);
+}
+
+describe("#1167b — inlineSmall (end-to-end)", () => {
+  it("inlines a single-block helper: run body has no `call`", async () => {
+    const source = `
+      function abs(x: number): number { return x < 0 ? -x : x; }
+      export function run(n: number): number { return abs(n); }
+    `;
+    const result = compile(source, { experimentalIR: true, nativeStrings: true, emitWat: true });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+
+    // After inlining, `run`'s Wasm body should no longer contain a `call`.
+    // Other module-level helpers (`$__str_*`) contain calls of their own,
+    // so we scope the check to the `$run` function body.
+    const runBody = extractFuncBody(result.wat, "run");
+    expect(runBody).not.toBe("");
+    expect(runBody).not.toContain("call ");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {
+      env: {
+        console_log_number: () => {},
+        console_log_string: () => {},
+        console_log_bool: () => {},
+      },
+    });
+    const run = (instance.exports as Record<string, (n: number) => number>).run;
+    expect(run(3)).toBe(3);
+    expect(run(-4)).toBe(4);
+    expect(run(0)).toBe(0);
+  });
+
+  it("does NOT inline a recursive callee: run body still contains a call", () => {
+    // `rec` is trivially self-recursive, single-block, small — the only
+    // reason inlineSmall should skip it is the recursion guard. (We don't
+    // execute the compiled wasm: IR `select` evaluates BOTH arms, so a
+    // recursive ternary never terminates at runtime — the point of this
+    // test is purely to assert the WAT still contains the call.)
+    const source = `
+      function rec(n: number): number { return n < 0 ? n : rec(n - 1); }
+      export function run(n: number): number { return rec(n); }
+    `;
+    const result = compile(source, { experimentalIR: true, nativeStrings: true, emitWat: true });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    // run's body should still call rec (not inlined, because rec is recursive).
+    const runBody = extractFuncBody(result.wat, "run");
+    expect(runBody).not.toBe("");
+    expect(runBody).toContain("call ");
+    // rec itself must still exist as a Wasm function (not eliminated).
+    expect(result.wat).toContain("(func $rec");
+    // The recursive self-call inside rec's body must remain.
+    const recBody = extractFuncBody(result.wat, "rec");
+    expect(recBody).toContain("call ");
+  });
+
+  it("does NOT inline a multi-block callee: run body still contains a call", async () => {
+    // `sgn` has an early-return `if`, which from-ast lowers to >1 block.
+    // It's non-recursive and small, so the ONLY reason inlineSmall skips it
+    // is the multi-block guard.
+    const source = `
+      function sgn(n: number): number {
+        if (n > 0) return 1;
+        return n < 0 ? -1 : 0;
+      }
+      export function run(n: number): number { return sgn(n); }
+    `;
+    const result = compile(source, { experimentalIR: true, nativeStrings: true, emitWat: true });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const runBody = extractFuncBody(result.wat, "run");
+    expect(runBody).not.toBe("");
+    expect(runBody).toContain("call ");
+    expect(result.wat).toContain("(func $sgn");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {
+      env: {
+        console_log_number: () => {},
+        console_log_string: () => {},
+        console_log_bool: () => {},
+      },
+    });
+    const run = (instance.exports as Record<string, (n: number) => number>).run;
+    expect(run(5)).toBe(1);
+    expect(run(-5)).toBe(-1);
+    expect(run(0)).toBe(0);
+  });
+
+  it("preserves a function with no inlinable calls (no op on the hot path)", async () => {
+    const source = `
+      export function f(n: number): number { return n * 2 + 1; }
+    `;
+    const result = compile(source, { experimentalIR: true, nativeStrings: true, emitWat: true });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {
+      env: {
+        console_log_number: () => {},
+        console_log_string: () => {},
+        console_log_bool: () => {},
+      },
+    });
+    const f = (instance.exports as Record<string, (n: number) => number>).f;
+    expect(f(3)).toBe(7);
+    expect(f(-2)).toBe(-3);
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of IR Phase 3. Adds a module-scope pass that inlines small,
non-recursive, single-block callees at the IR level before lowering to
Wasm. Builds on the Phase 3a hygiene passes (CF + DCE + simplifyCFG) and
feeds back into them so the inlined constants/dead args get cleaned up
before code emission.

### Scope (v1)

Only single-block callees ending in a single `return <value>` are
inlined. Multi-block inlining (continuation-block splicing for callees
with multiple `return` terminators) is deferred to a follow-up slice.

Covers ternary-style helpers: `abs`, `clamp`, `min`, `max`, `isNaN`,
`sign`, …

### Algorithm

For each `IrInstrCall` in each caller block:

- **Skip** if callee has > 1 block, is recursive (call-graph cycle),
  contains `raw.wasm` (backend-local indices don't survive a change of
  enclosing function), or has > 10 instructions.
- **Inline** otherwise: allocate fresh `IrValueId`s for every
  callee-defined value; map callee params to caller call-site args;
  splice renamed callee instructions into the caller block; rewire
  downstream uses of the call's result to the (renamed) return value.
- **Size budget**: caller grows at most
  `max(4 × original, original + 2 × MAX_CALLEE_INSTRS)` instructions.

### Pipeline integration

`compileIrPathFunctions` in `src/ir/integration.ts` split into three
explicit phases (previously a single interleaved loop):

1. **Build** — accumulate all `IrFunction[]` into an `IrModule`.
2. **Pass** — per-function hygiene (CF → DCE → simplifyCFG) → module-scope
   `inlineSmall` → re-run hygiene on modified fns. Verify between stages.
3. **Lower** — translate each `IrFunction` to Wasm.

### Changes

- `src/ir/nodes.ts` — add `IrModule { functions: IrFunction[] }`.
- `src/ir/passes/inline-small.ts` — new pass (~320 lines).
- `src/ir/integration.ts` — three-phase split.
- `tests/ir/inline-small.test.ts` — 10 new tests.

### Acceptance

- [x] `IrModule` interface exists in `src/ir/nodes.ts`.
- [x] `inlineSmall(mod: IrModule)` exported from `src/ir/passes/inline-small.ts`.
- [x] `compileIrPathFunctions` split into build / pass / lower.
- [x] Single-block, non-recursive, ≤ 10-instr callee is inlined.
- [x] Multi-block / recursive / raw.wasm-bearing callees are skipped (not errors).
- [x] Fresh `IrValueId`s allocated for every callee-defined value.
- [x] `verifyIrFunction` returns zero errors on every caller after inlining.
- [x] `constantFold` + `deadCode` re-run on modified functions.
- [x] `abs(x: number) { return x < 0 ? -x : x; }` inlined in its call site;
      caller's Wasm body contains no `call`.

## Test plan

- [x] `npm test -- tests/ir/inline-small.test.ts` — 10/10 pass
- [x] `npm test -- tests/ir` — all 131 IR-related tests pass
  (20 Phase-3a + 21 frontend widening + 10 new inline-small + 80 others)
- [x] Pre-existing equivalence-test failures on `main` verified to be
  unrelated to this change (same set fails on `main`)
- [ ] CI: `test262` net_per_test ≥ 0 on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)