### PR TITLE
fix(#1152): Array.prototype higher-order methods via __get_builtin path (string receivers)

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -354,15 +354,23 @@ export function compileArrayLikePrototypeCall(
     (ts.isIdentifier(receiverArg) && receiverArg.text === "undefined");
   if (isNullReceiver) return undefined;
 
-  // Bail out on primitive literal receivers (boolean, number, string). Our `extern.convert_any`
-  // coercion only works on ref/anyref values; a primitive compiled to i32/f64 would produce
-  // invalid Wasm. The legacy __proto_method_call path handles ToObject(primitive) correctly.
+  // Bail out on boolean / numeric primitive literal receivers. Those compile
+  // to i32/f64, which `extern.convert_any` can't lift — routing them through
+  // the legacy __proto_method_call bridge (which performs ToObject on the JS
+  // side) is the safe path.
+  //
+  // String primitives (StringLiteral, NoSubstitutionTemplateLiteral) are
+  // deliberately NOT bailed out — they compile to externref via
+  // `string_constants` global imports, so the array-like loop's
+  // `__extern_length` + `__extern_get_idx` walks the string's code units
+  // correctly. Sending them to __proto_method_call instead leaked the Wasm
+  // closure callback across the host boundary as an uninvokable externref,
+  // producing "object is not a function" (#1152: Array.prototype.map.call("abc", cb)
+  // and similar patterns).
   if (
     receiverArg.kind === ts.SyntaxKind.TrueKeyword ||
     receiverArg.kind === ts.SyntaxKind.FalseKeyword ||
-    receiverArg.kind === ts.SyntaxKind.NumericLiteral ||
-    receiverArg.kind === ts.SyntaxKind.StringLiteral ||
-    receiverArg.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral
+    receiverArg.kind === ts.SyntaxKind.NumericLiteral
   ) {
     return undefined;
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1726,6 +1726,12 @@ assert._isSameValue = isSameValue;
         return (obj: any, idx: number): number => {
           if (obj == null) return 0;
           const strKey = String(idx);
+          // Primitive strings can't be passed to the `in` operator (TypeError).
+          // `Array.prototype.forEach.call("abc", cb)` must visit index 0..len-1
+          // without that throw. (#1152)
+          if (typeof obj === "string") {
+            return idx >= 0 && idx < obj.length ? 1 : 0;
+          }
           try {
             if (idx in obj) return 1;
           } catch {

--- a/tests/issue-1152.test.ts
+++ b/tests/issue-1152.test.ts
@@ -1,0 +1,107 @@
+// #1152 — Array.prototype higher-order methods applied to string primitive
+// receivers must use the in-Wasm array-like loop, not bridge through
+// __proto_method_call.
+//
+// Background (regression from PR #195, then narrowed by #1140's successor):
+// After PR #195 changed `BuiltinCtor.prototype` access to go through
+// `__get_builtin` + `__extern_get` (both returning externref), calls like
+//   Array.prototype.map.call("abc", cb)
+// fell through `compileArrayLikePrototypeCall` because its primitive-receiver
+// bailout blanket-rejected `StringLiteral` / `NoSubstitutionTemplateLiteral`.
+// The legacy `__proto_method_call` path then passed the Wasm closure callback
+// across the host boundary as a non-callable externref, producing a runtime
+// `TypeError: object is not a function` from V8's native Array.prototype.map.
+//
+// The fix is to keep string primitive literals in the Wasm-native array-like
+// loop — they compile to externref (via `string_constants` globals), so
+// `__extern_length` + `__extern_get_idx` walks the code units directly and
+// the callback stays a Wasm closure invoked via `call_ref`. Numeric and
+// boolean primitive literals still bail out because they compile to
+// i32/f64, which can't flow through `extern.convert_any`.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<any> {
+  const result = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    const msg = result.errors
+      .filter((e) => e.severity === "error")
+      .map((e) => `L${e.line}:${e.column} ${e.message}`)
+      .join("; ");
+    throw new Error(`Compile failed: ${msg}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if (typeof (imports as any).setExports === "function") {
+    (imports as any).setExports(instance.exports);
+  }
+  return (instance.exports as any).test();
+}
+
+describe("#1152 — Array.prototype methods on string primitive receivers", () => {
+  it("Array.prototype.map.call('abc', cb) walks codepoints in Wasm", async () => {
+    const source = `
+      export function test(): number {
+        let count = 0;
+        function cb(val: any, idx: any, obj: any): number {
+          count = count + 1;
+          return 1;
+        }
+        Array.prototype.map.call("abc", cb);
+        return count === 3 ? 1 : 0;
+      }
+    `;
+    const ret = await runTest(source);
+    expect(ret).toBe(1);
+  });
+
+  it("Array.prototype.forEach.call('abc', cb) visits each character", async () => {
+    const source = `
+      export function test(): number {
+        let count = 0;
+        function cb(val: any, idx: any, obj: any): void {
+          count = count + 1;
+        }
+        Array.prototype.forEach.call("abc", cb);
+        return count === 3 ? 1 : 0;
+      }
+    `;
+    const ret = await runTest(source);
+    expect(ret).toBe(1);
+  });
+
+  it("Array.prototype.every.call('abc', cb) invokes callback without 'object is not a function'", async () => {
+    // This is the bug from #1152 — before the fix, the callback was passed
+    // across the host boundary as a Wasm closure externref, and V8's native
+    // Array.prototype.every tried to invoke it and threw.
+    const source = `
+      export function test(): number {
+        function cb(val: any, idx: any, obj: any): number {
+          return 1;
+        }
+        const result: any = Array.prototype.every.call("abc", cb);
+        return result ? 1 : 0;
+      }
+    `;
+    const ret = await runTest(source);
+    expect(ret).toBe(1);
+  });
+
+  it("Array.prototype.some.call with no-substitution template literal receiver", async () => {
+    const source = `
+      export function test(): number {
+        let hit = 0;
+        function cb(val: any, idx: any, obj: any): number {
+          hit = 1;
+          return 1;
+        }
+        Array.prototype.some.call(\`abc\`, cb);
+        return hit === 1 ? 1 : 0;
+      }
+    `;
+    const ret = await runTest(source);
+    expect(ret).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- After PR #195 (`__get_builtin` + `__extern_get` for `BuiltinCtor.prototype`), `Array.prototype.map.call(\"abc\", cb)` and siblings fell through to the `__proto_method_call` host bridge, which then handed the Wasm closure callback across the boundary as an uninvokable externref. V8's native Array.prototype.map threw `TypeError: object is not a function` for every such test.
- Fix keeps string primitives in the in-Wasm array-like loop (they compile to externref, so `__extern_length` + `__extern_get_idx` iterate the code units correctly). Only boolean/numeric primitive literals still bail to the legacy bridge — those compile to i32/f64 and `extern.convert_any` can't lift them.
- `__extern_has_idx` now short-circuits for primitive-string receivers (`idx in \"abc\"` throws TypeError).

## Test plan

- [x] `tests/issue-1152.test.ts` — 4/4 pass (`map`, `forEach`, `every`, `some` with StringLiteral + NoSubstitutionTemplateLiteral receivers).
- [x] `tests/equivalence/array-prototype-methods.test.ts` — 13/13 pass (no regression).
- [x] `tests/equivalence/string-methods.test.ts` — 39/42 pass (3 failures pre-existing on main, unrelated to this change).
- [ ] Full CI test262 run — expect the \"object is not a function\" Array-prototype cluster to drop substantially.

## Out of scope for this PR

Remaining failures in the same cluster:
- Boolean/Number primitive-literal receivers (`Array.prototype.map.call(false, cb)`, `.call(2.5, cb)`) — need primitive → wrapper boxing.
- `flatMap` species tests (`this-value-ctor-object-species*.js`) — need Array.@@species lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)