### PR TITLE
fix(#1162): yield* async abrupt-completion crash (~161 tests)

### DIFF
--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -188,38 +188,64 @@ export function compileGetterCallable(
     if (candidateIdx === undefined) continue;
 
     // Found the underlying method. Call it directly: C___priv_method(receiver, ...args)
+    // or C___priv_method(...args) for static methods (no self parameter).
     const structTypeIdx = ctx.structMap.get(receiverClassName);
     const paramTypes = getFuncParamTypes(ctx, candidateIdx);
-    const recvTypeHint = paramTypes?.[0];
-    const recvType = compileExpression(ctx, fctx, propAccess.expression, recvTypeHint);
+    // Static methods have no self parameter — their Wasm signature starts with
+    // the first user argument. Treating them as instance methods here produced
+    // `methodParamCount = -1` for zero-arg statics, which then iterated
+    // `expr.arguments[-1]` (undefined) through `compileExpression` and
+    // surfaced as "unexpected undefined AST node" during the compile of
+    // static-private-generator getter chains (#1162).
+    const isStatic = ctx.staticMethodSet.has(candidateName);
 
-    // Coerce receiver to match the function's first parameter type
-    if (recvType && recvTypeHint) {
-      if (
+    if (isStatic) {
+      // Evaluate receiver for side effects, then drop — static methods don't
+      // take a self parameter. Matches the isStaticMethod branch in
+      // compileCallExpression (calls.ts #2929 path).
+      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      if (recvType !== null) {
+        fctx.body.push({ op: "drop" });
+      }
+    } else {
+      const recvTypeHint = paramTypes?.[0];
+      const recvType = compileExpression(ctx, fctx, propAccess.expression, recvTypeHint);
+
+      // Coerce receiver to match the function's first parameter type
+      if (recvType && recvTypeHint) {
+        if (
+          recvType.kind === "externref" &&
+          (recvTypeHint.kind === "ref" || recvTypeHint.kind === "ref_null") &&
+          structTypeIdx !== undefined
+        ) {
+          // externref -> struct: convert via any.convert_extern + guarded cast
+          fctx.body.push({ op: "any.convert_extern" } as Instr);
+          emitGuardedRefCast(fctx, structTypeIdx);
+        } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvTypeHint.kind === "externref") {
+          // struct -> externref: convert via extern.convert_any
+          fctx.body.push({ op: "extern.convert_any" } as Instr);
+        } else if (recvType.kind !== recvTypeHint.kind) {
+          // General type mismatch: use coerceType
+          coerceType(ctx, fctx, recvType, recvTypeHint);
+        }
+      } else if (
+        recvType &&
         recvType.kind === "externref" &&
-        (recvTypeHint.kind === "ref" || recvTypeHint.kind === "ref_null") &&
-        structTypeIdx !== undefined
+        structTypeIdx !== undefined &&
+        recvTypeHint === undefined
       ) {
-        // externref -> struct: convert via any.convert_extern + guarded cast
+        // Fallback: no param type info but we know the struct — cast to struct
         fctx.body.push({ op: "any.convert_extern" } as Instr);
         emitGuardedRefCast(fctx, structTypeIdx);
-      } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvTypeHint.kind === "externref") {
-        // struct -> externref: convert via extern.convert_any
-        fctx.body.push({ op: "extern.convert_any" } as Instr);
-      } else if (recvType.kind !== recvTypeHint.kind) {
-        // General type mismatch: use coerceType
-        coerceType(ctx, fctx, recvType, recvTypeHint);
       }
-    } else if (recvType && recvType.kind === "externref" && structTypeIdx !== undefined && recvTypeHint === undefined) {
-      // Fallback: no param type info but we know the struct — cast to struct
-      fctx.body.push({ op: "any.convert_extern" } as Instr);
-      emitGuardedRefCast(fctx, structTypeIdx);
     }
 
-    // Push arguments (skip self at index 0)
-    const methodParamCount = paramTypes ? paramTypes.length - 1 : expr.arguments.length;
+    // For static methods, Wasm params are exactly the user args; for instance
+    // methods, param 0 is self so user args start at paramTypes[1].
+    const selfOffset = isStatic ? 0 : 1;
+    const methodParamCount = paramTypes ? Math.max(0, paramTypes.length - selfOffset) : expr.arguments.length;
     for (let i = 0; i < Math.min(expr.arguments.length, methodParamCount); i++) {
-      compileExpression(ctx, fctx, expr.arguments[i]!, paramTypes?.[i + 1]);
+      compileExpression(ctx, fctx, expr.arguments[i]!, paramTypes?.[i + selfOffset]);
     }
     for (let i = methodParamCount; i < expr.arguments.length; i++) {
       const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
@@ -229,7 +255,7 @@ export function compileGetterCallable(
     }
     // Pad missing arguments
     if (paramTypes) {
-      for (let i = Math.min(expr.arguments.length, methodParamCount) + 1; i < paramTypes.length; i++) {
+      for (let i = Math.min(expr.arguments.length, methodParamCount) + selfOffset; i < paramTypes.length; i++) {
         pushDefaultValue(fctx, paramTypes[i]!, ctx);
       }
     }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3446,10 +3446,16 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             return resultType;
           }
         }
-        // Non-nullable receiver: emit call directly
+        // Non-nullable receiver: emit call directly.
+        // User-visible param count excludes self (param 0). Clamp to ≥ 0 —
+        // when funcMap indirectly points at a stale index (e.g. a zero-arg
+        // constructor entry that wasn't shifted after a late import), the
+        // raw `length - 1` would go negative and the `for` loop would read
+        // `expr.arguments[-1]` → undefined → "unexpected undefined AST node".
+        // Seen in tests that mix static + instance private methods under
+        // the #1162 yield* async-generator cluster.
         const paramTypes = getFuncParamTypes(ctx, funcIdx);
-        // User-visible param count excludes self (param 0)
-        const methodParamCount = paramTypes ? paramTypes.length - 1 : expr.arguments.length;
+        const methodParamCount = paramTypes ? Math.max(0, paramTypes.length - 1) : expr.arguments.length;
         const calleeReadsArgsNn = ctx.funcUsesArguments.has(fullName);
         for (let i = 0; i < Math.min(expr.arguments.length, methodParamCount); i++) {
           compileExpression(ctx, fctx, expr.arguments[i]!, paramTypes?.[i + 1]); // +1 to skip self

--- a/tests/issue-1162.test.ts
+++ b/tests/issue-1162.test.ts
@@ -1,0 +1,117 @@
+// #1162 — static-generator-method and private-method-from-static-method
+// patterns no longer crash the compiler with "unexpected undefined AST node
+// in compileExpression".
+//
+// The 161-test cluster had two independent contributors:
+//
+// 1. `tests/test262-runner.ts#renameYieldOutsideGenerators` didn't recognize
+//    PRIVATE generator methods like `static async *#gen()` as generators,
+//    because the identifier regex `[\w$]+` excluded `#`. `yield` inside the
+//    body was then rewritten to `_yield`, producing `_yield* obj;` which
+//    parses as multiplication and crashed the compiler while processing
+//    surrounding code.
+//
+// 2. `compileGetterCallable` in `src/codegen/expressions/calls-closures.ts`
+//    assumed the resolved candidate method was an instance method (with a
+//    self parameter). For a STATIC private method reached via a getter
+//    chain (`static get gen() { return this.#gen; }`, where `#gen` is
+//    static), paramTypes = [] and `paramTypes.length - 1 = -1`, so the
+//    argument-padding loop read `expr.arguments[-1]` = undefined.
+//
+// 3. The same "clamp length − 1 to ≥ 0" fix is applied to the Non-nullable
+//    receiver path in `compileCallExpression` for defence against parallel
+//    funcMap drift.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+function expectCompiles(source: string): void {
+  const result = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    const msg = result.errors
+      .filter((e) => e.severity === "error")
+      .map((e) => `L${e.line}:${e.column} ${e.message}`)
+      .join("; ");
+    throw new Error("Compile failed: " + msg);
+  }
+}
+
+async function runTest(source: string): Promise<any> {
+  const result = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    const msg = result.errors
+      .filter((e) => e.severity === "error")
+      .map((e) => `L${e.line}:${e.column} ${e.message}`)
+      .join("; ");
+    throw new Error("Compile failed: " + msg);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if (typeof (imports as any).setExports === "function") {
+    (imports as any).setExports(instance.exports);
+  }
+  return (instance.exports as any).test();
+}
+
+describe("#1162 — yield* async / private-method-from-static codegen crashes", () => {
+  it("compiles static async private generator methods without crashing", () => {
+    // Original failure from yield-star-async tests: the parent test262 runner
+    // renamed `yield` inside the private generator body because `#gen` wasn't
+    // recognized as a method name. After the fix, this body compiles cleanly.
+    expectCompiles(`
+      var C = class {
+        static async *#gen() {
+          yield 1;
+          yield 2;
+        }
+        static get gen() { return this.#gen; }
+      }
+      var iter: any = C.gen();
+    `);
+  });
+
+  it("compiles static getter returning a static private method", () => {
+    // Static method reached via a getter — compileGetterCallable previously
+    // assumed instance-method param layout and read arguments[-1].
+    expectCompiles(`
+      class C {
+        static #gen() { return 1; }
+        static get gen() { return this.#gen; }
+      }
+      var iter: any = C.gen();
+    `);
+  });
+
+  it("compiles private method called from static method (this.#f() in static)", () => {
+    // this.#f() inside a static method — the Non-nullable receiver path
+    // in compileCallExpression previously crashed when funcMap lookup
+    // produced an unexpected zero-param paramTypes.
+    expectCompiles(`
+      class C {
+        #f() { return 42; }
+        static g() {
+          return this.#f();
+        }
+      }
+    `);
+  });
+
+  it("compiles yield-star inside static async private generator method body", () => {
+    // This is the exact pattern that procedurally-generated test262
+    // yield-star-async cases emit (static async generator private method
+    // with a yield* delegation). Before the fix, the yield keyword was
+    // renamed to `_yield` inside the body, producing `_yield* obj;` which
+    // parsed as multiplication and crashed the compiler when compiling
+    // surrounding code.
+    expectCompiles(`
+      var obj: any = { [Symbol.asyncIterator]: () => ({ next: () => ({ value: 1, done: true }) }) };
+      var C = class {
+        static async *#gen() {
+          yield* obj;
+        }
+        static get gen() { return this.#gen; }
+      }
+    `);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -773,7 +773,13 @@ function renameYieldOutsideGenerators(source: string): string {
   // If no generator functions (neither `function*` nor `*method()` syntax),
   // just rename all yield identifiers.
   const hasGeneratorFunction = /\bfunction\s*\*/.test(source);
-  const hasGeneratorMethod = /(?:^|[,{;)\s])\s*\*\s*(?:[\w$]+|\[[\s\S]*?\])\s*\(/.test(source);
+  // #1162: include `#` in the identifier class so private generator methods
+  // like `*#gen()` / `async *#gen()` register as generators — otherwise
+  // `yield` inside their body gets renamed to `_yield`, producing
+  // `_yield* obj;` which parses as multiplication and crashes the compiler
+  // with "unexpected undefined AST node in compileExpression" when the
+  // surrounding test is later compiled.
+  const hasGeneratorMethod = /(?:^|[,{;)\s])\s*\*\s*(?:[\w$#]+|\[[\s\S]*?\])\s*\(/.test(source);
   if (!hasGeneratorFunction && !hasGeneratorMethod) {
     return source.replace(/\byield\b/g, "_yield");
   }
@@ -882,8 +888,11 @@ function renameYieldOutsideGenerators(source: string): string {
     });
   }
 
-  // Find `*method()` generator method syntax (not caught by function regex)
-  const methodRegex = /\*\s*(?:[\w$]+|\[[\s\S]*?\])\s*\(/g;
+  // Find `*method()` generator method syntax (not caught by function regex).
+  // `[\w$#]+` matches private method names like `#gen` — without `#`,
+  // `*#gen()` isn't recognized as a generator and `yield` inside its body
+  // is incorrectly renamed to `_yield`. (#1162)
+  const methodRegex = /\*\s*(?:[\w$#]+|\[[\s\S]*?\])\s*\(/g;
   let methodMatch: RegExpExecArray | null;
   while ((methodMatch = methodRegex.exec(source)) !== null) {
     // Distinguish from multiply operator: check preceding context


### PR DESCRIPTION
## Summary

The ~161-test "unexpected undefined AST node in compileExpression" cluster in yield-star-async and private-method-from-static-method tests had three independent contributors:

1. **`tests/test262-runner.ts:renameYieldOutsideGenerators`** — the `*method()` detection regex used `[\w$]+`, excluding `#`. Private generator methods like `static async *#gen()` weren't recognized as generators, so `yield` inside the body was rewritten to `_yield`, producing `_yield* obj;` (multiplication) that blew up codegen while compiling surrounding code. Fix: include `#` in the identifier class.
2. **`compileGetterCallable`** — when a getter returns `this.#privateMethod` and the method is static (no `self` param), the code assumed instance-method param layout. `paramTypes.length - 1 = -1` for zero-arg statics → `expr.arguments[-1]` → undefined. Fix: detect `ctx.staticMethodSet.has(candidateName)`, evaluate-and-drop receiver for side effects, use `selfOffset = 0` for statics.
3. **`compileCallExpression` Non-nullable receiver path** — defence-in-depth clamp of `methodParamCount = Math.max(0, paramTypes.length - 1)`. Exposed the symptom for `this.#f()` from static methods where funcMap returned a stale index pointing at the zero-param constructor.

## Verification

Scripted replay of the 152 test262 files flagged with the error:
- Before: 0 pass, 152 "undefined AST" errors
- After: **148 pass**, 2 "undefined AST" (inheritance-edge cases), 2 unrelated CE

## Test plan

- [x] `tests/issue-1162.test.ts` — 4/4 pass (static async private generator, getter→static-private-method, private-method-from-static-method, yield* delegation in static async private generator body).
- [x] `tests/equivalence/private-fields-extended.test.ts` + `private-class-members.test.ts` — 17/17 pass (no regression on private-member semantics).
- [x] Pre-existing `async-function.test.ts` failures (7 on main) are unchanged.
- [ ] Full CI test262 run — expect the "unexpected undefined AST node" cluster to drop ~150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)