### PR TITLE
fix(ci): raise test262 testTimeout to 35s and bust cache on config change (#1171)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -116,9 +116,12 @@ jobs:
           path: |
             .test262-cache
             benchmarks/results/test262-cache.json
-          key: test262-cache-v2-${{ hashFiles('src/**/*.ts', 'scripts/test262-worker.mjs', 'scripts/compiler-fork-worker.mjs') }}-chunk-${{ matrix.chunk }}
+          # vitest.config.ts is part of the hash so any change to concurrency,
+          # timeouts, or pool config busts the cache and forces a clean run
+          # instead of replaying stale `compile_timeout` results (issue #1171).
+          key: test262-cache-v2-${{ hashFiles('src/**/*.ts', 'scripts/test262-worker.mjs', 'scripts/compiler-fork-worker.mjs', 'vitest.config.ts') }}-chunk-${{ matrix.chunk }}
           restore-keys: |
-            test262-cache-v2-${{ hashFiles('src/**/*.ts', 'scripts/test262-worker.mjs', 'scripts/compiler-fork-worker.mjs') }}-
+            test262-cache-v2-${{ hashFiles('src/**/*.ts', 'scripts/test262-worker.mjs', 'scripts/compiler-fork-worker.mjs', 'vitest.config.ts') }}-
 
       - name: Build compiler bundles
         run: |

--- a/plan/issues/sprints/45/1171.md
+++ b/plan/issues/sprints/45/1171.md
@@ -1,7 +1,7 @@
 ---
 id: 1171
 title: "Fix test262 timeout non-determinism — raise testTimeout to 30s, bust CI cache on config change"
-status: ready
+status: review
 sprint: 45
 created: 2026-04-24
 updated: 2026-04-24
@@ -79,3 +79,37 @@ a clean run rather than replaying stale cached results.
 - No compiler source changes needed
 - The combined effect: CI cache busts on this PR's merge, first clean run after
   establishes a deterministic new baseline
+
+## Implementation Summary (2026-04-24)
+
+Two minimal edits, exactly as specified:
+
+1. **`vitest.config.ts`** — raised `testTimeout` from `10000` → `35000`
+   (35s), with a comment explaining that the value must sit above the
+   compiler's internal 30s timeout so `compile_timeout` status can be
+   recorded before vitest force-kills the test. The 10s ceiling caused
+   pass→compile_timeout flips under `describe.concurrent` CPU contention
+   since PR #14.
+2. **`.github/workflows/test262-sharded.yml`** — added `vitest.config.ts`
+   to the `hashFiles(...)` input of both `key:` and the `restore-keys:`
+   fallback for the `test262-cache-v2-*` cache. Any change to
+   concurrency/timeout/pool config now busts the cache, preventing stale
+   `compile_timeout` replays from pre-#1171 runs.
+
+## Test Results (2026-04-24)
+
+- YAML parses cleanly; jobs preserved (`test262-shards`, `merge-report`,
+  `regression-gate`, `promote-baseline`).
+- `vitest.config.ts` still valid — vitest loads without error on a small
+  sanity test.
+- No compiler source touched — cannot cause test regressions. The CI cache
+  bust is the intended side-effect.
+
+## Acceptance criteria — status
+
+- [x] `testTimeout` is 35000 in `vitest.config.ts`
+- [x] `vitest.config.ts` is included in the CI cache key hash (both `key:`
+      and `restore-keys:` fallback)
+- [ ] Two consecutive local test262 runs stability — to be validated on
+      PR CI. Local full test262 is out of scope for dev workflow.
+- [x] No equivalence test regressions (no compiler source changed)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     // Without this, vitest runs it() blocks within a describe() sequentially,
     // leaving pool workers idle and stretching test262 runs to 150+ minutes.
     maxConcurrency: 32,
-    testTimeout: 10000, // 10s per test — prevents infinite compilation loops from blocking the run
+    // 35s — must sit above the compiler's internal 30s timeout so that
+    // `compile_timeout` status can be recorded before vitest force-kills the
+    // test. With describe.concurrent (see PR #14), a 10s ceiling flipped
+    // tests from pass→compile_timeout under CPU contention (issue #1171).
+    testTimeout: 35000,
   },
 });


### PR DESCRIPTION
## Summary

Closes #1171 — two-line follow-up to PR #14's `describe.concurrent` rollout.

- **`vitest.config.ts`**: raise `testTimeout` from 10000 → 35000. The 10s ceiling was below the compiler's internal 30s timeout, so tests near the edge flipped between `pass` and `compile_timeout` under CPU contention from 9 concurrent compilations. 35s lets the compiler's internal timeout fire and record `compile_timeout` cleanly; vitest's limit becomes a backstop for truly stuck tests.
- **`.github/workflows/test262-sharded.yml`**: add `vitest.config.ts` to the `hashFiles(...)` input of the `test262-cache-v2-*` cache key (both `key:` and `restore-keys:` fallback). Any change to concurrency / timeout / pool config now busts the cache instead of replaying stale `compile_timeout` results from pre-PR-#14 runs.

Combined effect: cache busts on this PR's merge; the first clean run after establishes a deterministic new baseline, eliminating the ~224-test inter-run variance observed on identical compiler state.

No compiler source touched.

## Test plan

- [x] Vitest loads the new config without errors — sanity run on `tests/ir-ternary-equivalence.test.ts` passes.
- [x] YAML workflow parses cleanly; four jobs preserved.
- [x] `hashFiles(...)` contains `vitest.config.ts` in both `key:` and `restore-keys:` (grep-verified).
- [ ] CI on this PR should bust the test262 cache and run all shards fresh — the first run after merge becomes the new deterministic baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)