### PR TITLE
feat(codegen): iterator protocol on function-declaration binding-pattern params (#862)

### DIFF
--- a/plan/issues/sprints/45/862.md
+++ b/plan/issues/sprints/45/862.md
@@ -2,7 +2,7 @@
 id: 862
 title: "Iterator protocol missing on function-declaration binding-pattern params"
 sprint: 45
-status: ready
+status: review
 priority: medium
 test262_fail: 212
 feasibility: hard
@@ -293,3 +293,83 @@ After the fix, `function f([...r]) {}` called with `f(gen())` where `gen` throws
 - `__array_from_iter(gen)` → `Array.from(gen)` → invokes `.next()` → throws `Test262Error`.
 - Exception propagates out of `f` via `exnTag`. Caller's `assert.throws(Test262Error, ...)` catches it.
 - `iter.next()` after the throw is called by the test — iterator is already closed from the first throw. Spec-compliant.
+
+---
+
+## Implementation Summary (2026-04-25, dev-a)
+
+Three files modified, all scoped as narrowly as the architect spec + tech lead
+directive allowed:
+
+1. **`src/codegen/destructuring-params.ts`** — added a tuple-struct fast path
+   at the top of the externref branch in `destructureParamArray`. Iterates
+   `ctx.mod.types`, and for each Wasm struct with fields named `_0`, `_1`, …
+   (the compiler's tuple-struct naming convention) emits:
+   ```
+   if __dparam_done == 0 {
+     if ref.test anyTmp $tupleN {
+       local.get anyTmp; ref.cast $tupleN; local.set $tup
+       ⟨recursive destructureParamArray emits struct.get walk⟩
+       i32.const 1; local.set __dparam_done
+     }
+   }
+   ```
+   The rest of the externref branch (vec-type try-cast loop, `__array_from_iter`
+   fallback, and the final recursive destructure into `__vec_externref`) is
+   wrapped in `if __dparam_done == 0 { ⟨existing code⟩ }`. This prevents the
+   PR #255 regression pattern where a tuple-struct caller's typed numeric
+   fields would be boxed via `__box_number` through `Array.from` and then
+   return NaN when unboxed.
+
+2. **`src/codegen/declarations.ts`** — added `bindingPatternParamNeedsWiden`
+   helper and applied it in both the generator path (~line 1795) and regular
+   path (~line 1848). Narrowed with `!param.type` so users who wrote explicit
+   type annotations keep the tuple-struct specialization.
+
+3. **`src/codegen/class-bodies.ts`** — same widening in the method-param loop
+   (~line 976-987). **Deliberately did NOT touch the constructor / static
+   constructor path (~line 685-695)** per tech-lead directive — PR #59
+   retrospective showed the class constructor argument path has different
+   null-handling invariants, and fixing one path at a time is mandatory.
+
+### Test file
+
+`tests/issue-862-func-decl-iter.test.ts` — four positive test cases:
+- Iterator throw from `function* gen()` propagates through function-declaration
+  param destructuring.
+- Rest element (`[...r]`) triggers iterator step, throw propagates.
+- Wasm-native array literal caller preserves numeric types (regression
+  guard for the PR #255 NaN pattern).
+- Class method with generator param drives iterator protocol.
+
+All 4 tests pass locally.
+
+### Pre-existing failures NOT caused by this PR
+
+- `tests/equivalence/destructuring-initializer.test.ts` (3 tests),
+  `tests/equivalence/binding-null-guard.test.ts` (1 test),
+  `tests/equivalence/destructuring-extended.test.ts` (1 test) — fail on
+  unmodified `main` with `__throw_type_error: function import requires a
+  callable` (test helper doesn't provide the runtime-only import). Verified
+  by stashing this branch and running the same tests on `origin/main`.
+
+### Acceptance criteria status (see #862 for original)
+
+- [x] All 4 positive test cases in `tests/issue-862-func-decl-iter.test.ts` pass.
+- [x] PR #255's tuple-struct numeric caller regression guarded by the fast
+      path (see third test case).
+- [ ] Zero test262 regressions: to be verified on PR CI.
+- [ ] 212 step-err tests now pass or fail meaningfully: to be verified on
+      PR CI.
+
+### Deviations from architect spec
+
+- **Did not touch the class constructor path** (architect plan mentioned
+  class-bodies.ts:685-695). Tech lead explicitly directed "do NOT touch the
+  class constructor argument path" — PR #59 retrospective shows it's
+  different invariants.
+- **Did not hoist `destructureParamTupleStruct` into a separate helper**.
+  The architect's step 1 was a pure refactor; instead the fast path uses a
+  recursive `destructureParamArray` call into a `ref_null` tuple-struct
+  paramType, which hits the existing tuple-struct walk (lines 797-901)
+  without needing to extract a helper. Shorter and functionally equivalent.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -977,7 +977,16 @@ export function compileClassBodies(
         const param = member.parameters[pi]!;
         const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${pi}`;
         const paramType = ctx.checker.getTypeAtLocation(param);
-        let wasmType = resolveWasmType(ctx, paramType);
+        // Unannotated binding-pattern method params route through the
+        // externref destructure path so the iterator protocol drives element
+        // extraction — same rule as function declarations (#862) and arrows
+        // (closures.ts:905). NOTE: explicitly scoped to methods only; the
+        // constructor path (class-bodies.ts:680-696) is left unchanged.
+        const bindingPatternNeedsWiden =
+          !param.type &&
+          !param.dotDotDotToken &&
+          (ts.isArrayBindingPattern(param.name) || ts.isObjectBindingPattern(param.name));
+        let wasmType = bindingPatternNeedsWiden ? ({ kind: "externref" } as ValType) : resolveWasmType(ctx, paramType);
         // Widen ref to ref_null for params with defaults or optional params
         // (caller passes ref.null as sentinel). Must match collection phase (#702)
         if ((param.initializer || param.questionToken) && wasmType.kind === "ref") {

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1786,15 +1786,30 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         return false;
       };
 
+      // An unannotated binding-pattern parameter — `function f([x, y])` or
+      // `function f({a, b})` — must route through the externref destructure path
+      // so that the iterator protocol drives element extraction (spec
+      // §13.3.3.6 IteratorBindingInitialization). Without this widening the
+      // param compiles to a tuple struct signature and `f(generator)` silently
+      // skips the iterator's `.next()`. Mirrors closures.ts:905 for arrows /
+      // function-expressions. Skip when the user wrote an explicit type
+      // annotation — they asked for the tuple-struct specialization. (#862)
+      const bindingPatternParamNeedsWiden = (p: ts.ParameterDeclaration): boolean => {
+        if (p.type || p.dotDotDotToken) return false;
+        return ts.isArrayBindingPattern(p.name) || ts.isObjectBindingPattern(p.name);
+      };
+
       if (isGenerator) {
         // Generator functions: parameters are compiled normally, return is externref
         params = [];
         for (let i = 0; i < stmt.parameters.length; i++) {
           const param = stmt.parameters[i]!;
           const paramType = ctx.checker.getTypeAtLocation(param);
-          let wasmType: ValType = restBindingOverridesToExternref(param)
+          let wasmType: ValType = bindingPatternParamNeedsWiden(param)
             ? { kind: "externref" }
-            : resolveWasmType(ctx, paramType);
+            : restBindingOverridesToExternref(param)
+              ? { kind: "externref" }
+              : resolveWasmType(ctx, paramType);
           // If the parameter has a default value and is a non-null ref type,
           // widen to ref_null so callers can pass ref.null as a sentinel for "use default"
           if (param.initializer && wasmType.kind === "ref") {
@@ -1845,9 +1860,11 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
             });
           } else {
             const paramType = ctx.checker.getTypeAtLocation(param);
-            let wasmType: ValType = restBindingOverridesToExternref(param)
+            let wasmType: ValType = bindingPatternParamNeedsWiden(param)
               ? { kind: "externref" }
-              : resolveWasmType(ctx, paramType);
+              : restBindingOverridesToExternref(param)
+                ? { kind: "externref" }
+                : resolveWasmType(ctx, paramType);
             // If the parameter has a default value and is a non-null ref type,
             // widen to ref_null so callers can pass ref.null as a sentinel for "use default"
             if (param.initializer && wasmType.kind === "ref") {

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -559,6 +559,83 @@ export function destructureParamArray(
       fctx.body.push({ op: "any.convert_extern" } as Instr);
       fctx.body.push({ op: "local.set", index: anyTmp });
 
+      // Tuple-struct fast path (#862): if the externref wraps a known Wasm-native
+      // tuple struct (fields named _0, _1, …), destructure directly via
+      // struct.get instead of routing through __array_from_iter / boxing — which
+      // would convert typed numeric fields to externref and then silently back
+      // to NaN when assigned to f64 locals (PR #255 regression pattern).
+      //
+      // The sentinel `__dparam_done` is set to 1 if the fast path fires; the
+      // existing externref logic below is gated on it being 0.
+      const dstrDoneLocal = allocLocal(fctx, `__dparam_done_${fctx.locals.length}`, { kind: "i32" });
+      fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+      fctx.body.push({ op: "local.set", index: dstrDoneLocal });
+
+      for (let ti = 0; ti < ctx.mod.types.length; ti++) {
+        const def = ctx.mod.types[ti];
+        if (!def || def.kind !== "struct") continue;
+        if (def.fields.length === 0) continue;
+        // Tuple struct detection: fields must be named _0, _1, _2, ...
+        let isTuple = true;
+        for (let fi = 0; fi < def.fields.length; fi++) {
+          if (def.fields[fi]!.name !== `_${fi}`) {
+            isTuple = false;
+            break;
+          }
+        }
+        if (!isTuple) continue;
+        // Only match when the tuple has at least as many fields as the pattern
+        // consumes — fewer fields can't fulfill the binding element count.
+        if (def.fields.length < pattern.elements.length) continue;
+
+        const tupType: ValType = { kind: "ref_null", typeIdx: ti };
+        const tupleLocal = allocLocal(fctx, `__dparam_tup_${ti}_${fctx.locals.length}`, tupType);
+
+        // Build the fast-path body by swapping fctx.body so a recursive
+        // destructureParamArray call emits into the conditional branch instead
+        // of the outer function.
+        const savedBody = fctx.body;
+        const fastPathInstrs: Instr[] = [];
+        fctx.body = fastPathInstrs;
+        fctx.body.push({ op: "local.get", index: anyTmp } as Instr);
+        fctx.body.push({ op: "ref.cast", typeIdx: ti });
+        fctx.body.push({ op: "local.set", index: tupleLocal });
+        destructureParamArray(ctx, fctx, tupleLocal, pattern, tupType);
+        fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+        fctx.body.push({ op: "local.set", index: dstrDoneLocal });
+        fctx.body = savedBody;
+
+        // Gate on dstrDone == 0 so later tuple-struct checks (and the main
+        // externref logic below) don't re-run once one match has succeeded.
+        const testInstrs: Instr[] = [
+          { op: "local.get", index: anyTmp } as Instr,
+          { op: "ref.test", typeIdx: ti } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: fastPathInstrs,
+            else: [],
+          } as Instr,
+        ];
+
+        fctx.body.push({ op: "local.get", index: dstrDoneLocal } as Instr);
+        fctx.body.push({ op: "i32.eqz" } as Instr);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: testInstrs,
+          else: [],
+        } as Instr);
+      }
+
+      // Gate the existing externref→vec conversion + iter fallback logic on
+      // dstrDone == 0. If the fast path already destructured, skip all of it.
+      // We redirect fctx.body to a buffer; after the existing code finishes, we
+      // wrap the buffer in `if dstrDone == 0 { ... }` and append to the real body.
+      const externrefLegacyBody: Instr[] = [];
+      const realBody = fctx.body;
+      fctx.body = externrefLegacyBody;
+
       // Try direct cast to __vec_externref first (cheapest path)
       fctx.body.push({ op: "local.get", index: anyTmp });
       fctx.body.push({ op: "ref.test", typeIdx: extVecIdx });
@@ -774,6 +851,19 @@ export function destructureParamArray(
 
       // Now destructure from the converted vec_externref.
       destructureParamArray(ctx, fctx, resultLocal, pattern, convertedType);
+
+      // Close the #862 tuple-struct fast-path gate: wrap everything since the
+      // dstrDone sentinel was initialised in `if dstrDone == 0 { ... }` and
+      // splice back into the real body.
+      fctx.body = realBody;
+      fctx.body.push({ op: "local.get", index: dstrDoneLocal } as Instr);
+      fctx.body.push({ op: "i32.eqz" } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: externrefLegacyBody,
+        else: [],
+      } as Instr);
       return;
     }
     // Cannot destructure a non-ref type — register locals with defaults

--- a/tests/issue-862-func-decl-iter.test.ts
+++ b/tests/issue-862-func-decl-iter.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #862 — iterator protocol on function-declaration binding-pattern params.
+ *
+ * Before the fix, `function f([a, b]) {}` and class methods with binding-pattern
+ * params never drove the iterator protocol: `f(generator)` bypassed `.next()`,
+ * skipping any throws from the generator. After the fix, these declaration
+ * forms widen unannotated binding-pattern params to `externref`, which routes
+ * through `__array_from_iter` in `destructureParamArray` — same path as the
+ * arrow/function-expression forms (already working via closures.ts #1151).
+ *
+ * The tuple-struct fast path in `destructureParamArray` prevents Wasm-native
+ * tuple struct callers (`f([1, 2])`) from getting boxed through the iterator
+ * and losing type information (see PR #255 retrospective in #862 issue file).
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("#862 — iterator protocol on function-declaration binding-pattern params", () => {
+  it("function declaration param destructuring calls .next() and propagates throws", async () => {
+    const exports = await compileToWasm(`
+      function* gen(): any { yield 1; throw new Error("stop"); }
+      function f([a, b]: any) { return (a as number) + (b as number); }
+      export function test(): any {
+        try { f(gen()); return "no-throw"; }
+        catch (e: any) { return (e as any).message; }
+      }
+    `);
+    expect(exports.test()).toBe("stop");
+  });
+
+  it("rest element iterator step error propagates", async () => {
+    const exports = await compileToWasm(`
+      function* gen(): any { yield 1; throw new Error("at 2"); }
+      function f([...r]: any) { return (r as any).length; }
+      export function test(): any {
+        try { f(gen()); return "no-throw"; }
+        catch (e: any) { return (e as any).message; }
+      }
+    `);
+    expect(exports.test()).toBe("at 2");
+  });
+
+  it("function declaration accepts Wasm-native array literal preserving types", async () => {
+    // Critical regression test: f([3, 4]) must return 7 (numeric preserved),
+    // not NaN (which happens if the caller's tuple struct is boxed through
+    // Array.from / __extern_get_idx and the result is coerced back to f64).
+    const exports = await compileToWasm(`
+      function f([a, b]: any) { return (a as number) + (b as number); }
+      export function test(): number { return f([3, 4]); }
+    `);
+    expect(exports.test()).toBe(7);
+  });
+
+  it("class method param destructuring drives iterator protocol", async () => {
+    const exports = await compileToWasm(`
+      function* gen(): any { throw new Error("step-err"); }
+      class C { m([x]: any) { return x; } }
+      export function test(): any {
+        try { new C().m(gen()); return "no-throw"; }
+        catch (e: any) { return (e as any).message; }
+      }
+    `);
+    expect(exports.test()).toBe("step-err");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #862 — 212 test262 failures around iterator protocol on function-declaration, generator, and class-method binding-pattern parameters.

- **Widen unannotated binding-pattern params to externref** — `function f([a, b])` and `class C { m([x]) }` now route through `destructureParamArray`'s externref branch, same as the already-working arrow / function-expression path (#1151). Throws from a throwing iterator's `.next()` now propagate through `__array_from_iter`.
- **Tuple-struct fast path** — prevents the PR #255 regression (-181 net, 260 regressions). Before the existing externref logic runs, the function tries `ref.test $tupleN` against each registered Wasm struct with `_0`, `_1`, … naming; on a hit, it destructures directly via `struct.get` and sets a `__dparam_done` sentinel that gates the rest of the externref branch. Typed numeric callers like `f([3, 4])` skip `__box_number` / `Array.from` and preserve their `f64` values.
- **Narrowing per tech-lead directive**:
  - Widening gated on `!param.type` — users with explicit annotations keep the tuple-struct specialization.
  - Class methods widen; **constructor parameters do NOT** (PR #59 retrospective: constructor path has different null-handling invariants, fix one bucket at a time).

## Files changed

- `src/codegen/declarations.ts` — `bindingPatternParamNeedsWiden` helper used in both generator and regular param paths (~25 LoC)
- `src/codegen/class-bodies.ts` — same widening in the method-param loop only (11 LoC)
- `src/codegen/destructuring-params.ts` — tuple-struct fast path + gating of the existing externref logic (90 LoC)
- `tests/issue-862-func-decl-iter.test.ts` — 4 positive test cases (new file, 66 LoC)

## Test plan

- [x] `tests/issue-862-func-decl-iter.test.ts` — 4/4 pass locally (iterator throw propagates, rest-element step error, tuple caller preserves types, class method iterator).
- [x] Sampled equivalence tests (destructuring-initializer, binding-null-guard, destructuring-extended, array-rest-destructuring, externref-array-destructuring, basic-destructuring): the 5 failures observed are pre-existing on `origin/main` (verified via stash+rerun) — `__throw_type_error: function import requires a callable`, a test-helper missing-import issue unrelated to this branch.
- [ ] PR CI test262 to validate the 212-test delta and catch any regressions in the tuple-struct fast path.

## Risk notes

- The tuple-struct fast path emits one `if ref.test $tupleN { ... }` per registered Wasm struct with tuple naming. For large programs this adds a handful of cheap guarded branches to the externref entry sequence. The `__dparam_done` sentinel ensures at most one fast-path body runs.
- PR #59 retrospective warned against monolithic class+function rewrites. This PR touches function declarations, generators, and class *methods* — the class *constructor* path is explicitly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)