### PR TITLE
fix(#906): compile away TDZ tracking for definite-assignment top-level let/const

### DIFF
--- a/plan/issues/sprints/45/906.md
+++ b/plan/issues/sprints/45/906.md
@@ -1,7 +1,7 @@
 ---
 id: 906
 title: "Compile away TDZ tracking for definite-assignment top-level numeric locals"
-status: ready
+status: review
 sprint: 45
 priority: high
 feasibility: medium
@@ -81,4 +81,44 @@ Compile away TDZ tracking for top-level/module-init locals when definite-assignm
 - the example above no longer emits `__tdz_result`
 - the example above no longer emits TDZ writes in `__module_init`
 - runtime TDZ checks remain for cases that cannot be proven safe statically
+
+## Implementation notes
+
+- Added `computeElidableTopLevelTdzNames` in `src/codegen/expressions/identifiers.ts`
+  that walks the source file, finds every Identifier resolving to a top-level
+  let/const declaration, and runs `analyzeTdzAccess` on each. If every read
+  returns `"skip"`, the name is elided.
+- `src/codegen/declarations.ts` calls this helper just before allocating the
+  TDZ flag globals and removes elidable names from `ctx.tdzLetConstNames`.
+  The downstream code paths (`emitTdzInit`, `emitTdzCheck`, the read-site
+  analysis at `expressions/identifiers.ts:340`) all already short-circuit
+  when `tdzGlobals.get(name)` is undefined, so no other call sites needed
+  changes.
+- Conservative behaviour preserved: hoisted function declarations that read
+  a top-level let/const, forward references, closures captured before init,
+  and reads inside a loop that wraps the declaration all still emit runtime
+  TDZ tracking (because `analyzeTdzAccess` returns `"throw"` or `"check"`
+  for those cases).
+
+## Test results
+
+- `tests/issue-906.test.ts` — 11/11 pass (new). Covers the issue's exact
+  example, multi-decl elision, hoisted-function preserve, forward-reference
+  preserve, arrow-before-init preserve, arrow-after-init elide, loop reads
+  not containing decl elide, unused let elide, end-to-end loop sum.
+- `tests/issue-800.test.ts` — 7/7 pass (existing static TDZ optimization).
+- `tests/issue-899.test.ts` — 7/7 pass (existing closure-capture TDZ).
+- `tests/issue-723-tdz.test.ts` — 7/7 pass (runtime TDZ enforcement).
+- `tests/issue-1053-arguments-global-staleness.test.ts` — 1/1 pass.
+- `tests/equivalence/var-hoisting-scope.test.ts` — 12/12 pass.
+- `tests/equivalence/scope-and-error-handling.test.ts` — 5/5 pass.
+- `tests/equivalence/global-type-checks.test.ts` — 9/9 pass.
+- `tests/equivalence/global-index-shift-trycatch.test.ts` and
+  `multi-file-compilation.test.ts` — 35/35 combined pass.
+- Pre-existing failures (verified to fail on `origin/main` without this
+  change too, unrelated):
+  - `tests/equivalence/tdz-reference-error.test.ts` — 6 fails (validator
+    emits TDZ violations as `severity: "warning"`, tests expect `"error"`).
+  - `tests/issue-790.test.ts` — 4 fails (function-local TDZ runtime
+    behaviour, unrelated to module-level optimization).
 

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -53,6 +53,7 @@ import {
   getOrRegisterTemplateVecType,
   getOrRegisterVecType,
 } from "./registry/types.js";
+import { computeElidableTopLevelTdzNames } from "./expressions/identifiers.js";
 import { compileExpression, compileStatement } from "./shared.js";
 
 /** Accumulated state for the single-pass collector */
@@ -2614,6 +2615,22 @@ export function compileDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   }
 
   compileClassesFromStatements(sourceFile.statements);
+
+  // Compile away TDZ tracking for definite-assignment top-level let/const
+  // variables (#906). If every read of a top-level let/const can be statically
+  // proven to occur after its initializer (analyzeTdzAccess returns "skip"),
+  // we drop the variable from `tdzLetConstNames` so:
+  //   - no `__tdz_<name>` flag global is allocated below,
+  //   - `emitTdzInit` becomes a no-op (no `i32.const 1; global.set` writes
+  //     in `__module_init`),
+  //   - `emitTdzCheck` becomes a no-op (no runtime check at reads).
+  // Genuinely dynamic / ambiguous cases (e.g. function declarations that
+  // could be called before the variable's initializer runs) are preserved
+  // because `analyzeTdzAccess` conservatively returns "check" for them.
+  const elidableTdzNames = computeElidableTopLevelTdzNames(ctx, sourceFile, ctx.tdzLetConstNames);
+  for (const name of elidableTdzNames) {
+    ctx.tdzLetConstNames.delete(name);
+  }
 
   // Create TDZ flag globals for let/const module globals.
   // Each TDZ flag is an i32 global initialized to 0 (uninitialized).

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -105,7 +105,12 @@ export {
 export { compileCallExpression, compileIIFE, compileOptionalCallExpression } from "./expressions/calls.js";
 export { emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 export { emitThrowString, getFuncParamTypes } from "./expressions/helpers.js";
-export { analyzeTdzAccessByPos, compileIdentifier, narrowTypeToUnbox } from "./expressions/identifiers.js";
+export {
+  analyzeTdzAccessByPos,
+  compileIdentifier,
+  computeElidableTopLevelTdzNames,
+  narrowTypeToUnbox,
+} from "./expressions/identifiers.js";
 export {
   emitUndefined,
   ensureExternIsUndefinedImport,

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -193,6 +193,72 @@ function isDescendantOf(node: ts.Node, ancestor: ts.Node): boolean {
 }
 
 /**
+ * Compile-time TDZ elision for top-level let/const variables (#906).
+ *
+ * Returns the subset of `candidates` for which TDZ tracking can be statically
+ * compiled away — i.e. every identifier reference in the source file that
+ * resolves to the candidate's declaration is provably after initialization
+ * (analyzeTdzAccess returns "skip"). For these names, the caller can skip
+ * emitting the `__tdz_<name>` global, the `global.set __tdz_<name>` writes
+ * in the module init body, and the runtime check at every read.
+ *
+ * If a candidate has *any* reference that yields "throw" or "check", it stays
+ * tracked at runtime. This preserves observable semantics for genuinely
+ * dynamic or ambiguous cases (e.g. a function declaration that reads the
+ * variable, since hoisted functions could be called before the variable's
+ * initializer runs).
+ */
+export function computeElidableTopLevelTdzNames(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  candidates: Set<string>,
+): Set<string> {
+  if (candidates.size === 0) return new Set();
+
+  // Build name → declaration map for top-level let/const candidates so we can
+  // verify that an Identifier resolves to OUR declaration (and not a shadowed
+  // local or unrelated symbol with the same name).
+  const declByName = new Map<string, ts.VariableDeclaration>();
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    const isLetOrConst = (stmt.declarationList.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0;
+    if (!isLetOrConst) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (ts.isIdentifier(decl.name) && candidates.has(decl.name.text)) {
+        declByName.set(decl.name.text, decl);
+      }
+    }
+  }
+  if (declByName.size === 0) return new Set();
+
+  const elidable = new Set(declByName.keys());
+
+  function walk(node: ts.Node): void {
+    if (elidable.size === 0) return;
+    if (ts.isIdentifier(node) && elidable.has(node.text)) {
+      // Skip the identifier of the declaration itself.
+      const isDeclName = ts.isVariableDeclaration(node.parent) && node.parent.name === node;
+      if (!isDeclName) {
+        // Verify this identifier resolves to OUR top-level declaration
+        // (and not a shadowed local with the same name).
+        const symbol = ctx.checker.getSymbolAtLocation(node);
+        const decl = symbol?.valueDeclaration;
+        if (decl === declByName.get(node.text)) {
+          const result = analyzeTdzAccess(ctx, node);
+          if (result !== "skip") {
+            elidable.delete(node.text);
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, walk);
+  }
+  walk(sourceFile);
+
+  return elidable;
+}
+
+/**
  * Position-based TDZ analysis for call-site capture checks.
  * Used when we know the variable name and the call expression position,
  * but don't have an identifier with a resolved symbol (e.g., pushing

--- a/tests/issue-906.test.ts
+++ b/tests/issue-906.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #906: Compile away TDZ tracking for definite-assignment top-level
+ * let/const variables.
+ *
+ * When every read of a top-level let/const can be statically proven to be
+ * after its initializer, the compiler should drop the `__tdz_<name>` global,
+ * the `global.set __tdz_<name>` write in `__module_init`, and the runtime
+ * TDZ check at every read.
+ *
+ * Genuinely dynamic / ambiguous cases (e.g. a hoisted function declaration
+ * that reads the variable, since it could be called before the variable's
+ * initializer runs) must keep TDZ tracking.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function run(src: string): Promise<number> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`CE: ${r.errors[0]?.message}`);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports.test as () => number)();
+}
+
+function compileWat(src: string): string {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`CE: ${r.errors[0]?.message}`);
+  return r.wat;
+}
+
+describe("Issue #906: TDZ elision for top-level definite-assignment let/const", () => {
+  it("issue example: top-level let result, loop body assigns, console.log reads — no __tdz_result", () => {
+    const wat = compileWat(`
+      function squared(n: number): number { return n * n; }
+      let result = 0;
+      for (let i = 0; i < 10000; i++) {
+        result += squared(10);
+      }
+      console.log(result);
+    `);
+    expect(wat).not.toContain("__tdz_result");
+    // Sanity: the value global is still there.
+    expect(wat).toContain("__mod_result");
+  });
+
+  it("issue example runs end-to-end with correct value", async () => {
+    // Using a wrapper called after init — note: this case will keep the TDZ
+    // tracking because `test` is a hoisted function. We just validate the
+    // resulting binary is correct.
+    const result = await run(`
+      function squared(n: number): number { return n * n; }
+      let result = 0;
+      for (let i = 0; i < 10000; i++) {
+        result += squared(10);
+      }
+      export function test(): number { return result; }
+    `);
+    expect(result).toBe(1_000_000);
+  });
+
+  it("simple top-level const with straight-line use — no __tdz_x", () => {
+    const wat = compileWat(`
+      const x: number = 42;
+      console.log(x);
+    `);
+    expect(wat).not.toContain("__tdz_x");
+  });
+
+  it("multiple top-level let/const all definite-assigned — no __tdz_* globals", () => {
+    const wat = compileWat(`
+      let a = 1;
+      let b = 2;
+      const c = a + b;
+      console.log(c);
+    `);
+    expect(wat).not.toContain("__tdz_a");
+    expect(wat).not.toContain("__tdz_b");
+    expect(wat).not.toContain("__tdz_c");
+  });
+
+  it("module-level let read inside hoisted function declaration — preserves TDZ", () => {
+    // Function declarations are hoisted; they could be called before the
+    // variable's initializer runs. analyzeTdzAccess returns "check" for
+    // function-declaration access, so we conservatively keep TDZ tracking.
+    const wat = compileWat(`
+      export function getResult(): number { return result; }
+      let result: number = 42;
+    `);
+    expect(wat).toContain("__tdz_result");
+  });
+
+  it("forward reference inside hoisted function — preserves TDZ", () => {
+    const wat = compileWat(`
+      function early(): number { return result; }
+      const before: number = early();
+      let result: number = 42;
+    `);
+    expect(wat).toContain("__tdz_result");
+  });
+
+  it("arrow function captured before init — preserves TDZ", () => {
+    // The arrow function definition is at position before `let x = 0;`,
+    // so the closure-deferred-call optimization in analyzeTdzAccess won't
+    // apply (closureStart < declEnd) — the result is "check", not "skip".
+    const wat = compileWat(`
+      let cb: () => number = () => x;
+      let x = 0;
+      cb();
+    `);
+    // cb captures x before x is initialized. TDZ tracking must remain.
+    expect(wat).toContain("__tdz_x");
+  });
+
+  it("arrow function defined after init reads safely — TDZ elided", () => {
+    const wat = compileWat(`
+      let x = 42;
+      const f = () => x;
+      console.log(f());
+    `);
+    // x's only references are: f's body (closureStart > declEnd, not in
+    // loop containing decl) and the call inside console.log.
+    expect(wat).not.toContain("__tdz_x");
+  });
+
+  it("read inside a for-loop that does not contain the declaration — TDZ elided", () => {
+    const wat = compileWat(`
+      let total = 0;
+      for (let i = 0; i < 5; i++) {
+        total = total + i;
+      }
+      console.log(total);
+    `);
+    // The for loop contains reads of `total` but does NOT contain the decl
+    // of `total`, so isInsideLoopContaining returns false → "skip".
+    expect(wat).not.toContain("__tdz_total");
+  });
+
+  it("definite-assigned let unused after init — no __tdz_unused", () => {
+    const wat = compileWat(`
+      let unused = 5;
+      console.log("ok");
+    `);
+    expect(wat).not.toContain("__tdz_unused");
+  });
+
+  it("end-to-end: top-level loop with elided TDZ yields correct sum", async () => {
+    const result = await run(`
+      let sum = 0;
+      for (let i = 1; i <= 100; i++) {
+        sum += i;
+      }
+      export function test(): number { return sum; }
+    `);
+    expect(result).toBe(5050);
+  });
+});


### PR DESCRIPTION
## Summary
- When every read of a top-level `let`/`const` can be statically proven to occur after its initializer, drop the variable from `tdzLetConstNames` so no `__tdz_<name>` global is allocated, no `i32.const 1; global.set` write is emitted in `__module_init`, and no runtime TDZ check fires at every read.
- Conservatively preserves runtime TDZ tracking for cases where `analyzeTdzAccess` returns `"throw"` or `"check"` (hoisted function declarations that read the variable, forward references, closures captured before init, reads inside a loop that wraps the declaration).
- Issue example WAT before: `(global \$__tdz_result (mut i32) ...)` plus `i32.const 1; global.set 3` in module init. After: gone — only `(global \$__mod_result (mut f64) ...)` remains.

## Implementation
- New helper `computeElidableTopLevelTdzNames` in `src/codegen/expressions/identifiers.ts` walks the source file once, finds Identifiers resolving to top-level let/const declarations (filtered via `checker.getSymbolAtLocation`), and runs the existing `analyzeTdzAccess` on each.
- `src/codegen/declarations.ts` calls the helper just before allocating TDZ flag globals; downstream `emitTdzInit` / `emitTdzCheck` already short-circuit when the name isn't in `ctx.tdzGlobals`, so no other call sites changed.
- Spec refs in commit body: §14.3.1, §9.1.1.1.4, §9.1.1.1.2.

## Test plan
- [x] `tests/issue-906.test.ts` — 11/11 new regression tests pass (issue example WAT shape, end-to-end run, hoisted-function preserve, forward-reference preserve, arrow-before-init preserve, arrow-after-init elide, loop-reads-not-containing-decl elide, unused let elide).
- [x] `tests/issue-800.test.ts` — 7/7 pass (existing static TDZ optimization).
- [x] `tests/issue-899.test.ts` — 7/7 pass (existing closure-capture TDZ elimination).
- [x] `tests/issue-723-tdz.test.ts` — 7/7 pass (runtime TDZ enforcement).
- [x] `tests/issue-1053-arguments-global-staleness.test.ts` — 1/1 pass.
- [x] `tests/equivalence/{var-hoisting-scope,scope-and-error-handling,global-type-checks,global-index-shift-trycatch,multi-file-compilation}.test.ts` — 35/35 pass.
- [x] `tdz-reference-error` (6 fail) and `issue-790` (4 fail) confirmed pre-existing failures on `origin/main` (verified via `git stash` round-trip), unrelated to this change.
- [ ] CI test262 run for full conformance check.

CHECKLIST-FOXTROT