### PR TITLE
fix(ci): guard runs/index.json against LFS pointer in emergency baseline refresh

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -222,7 +222,11 @@ jobs:
             : 'benchmarks/results/test262-current.json';
           const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
           const indexPath = 'benchmarks/results/runs/index.json';
-          const idx = fs.existsSync(indexPath) ? JSON.parse(fs.readFileSync(indexPath, 'utf8')) : [];
+          // Guard against LFS pointer file (Materialize step uses continue-on-error)
+          const idx = (() => {
+            if (!fs.existsSync(indexPath)) return [];
+            try { return JSON.parse(fs.readFileSync(indexPath, 'utf8')); } catch { return []; }
+          })();
           const entry = {
             timestamp: new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').substring(0, 15),
             pass: report.summary.pass,


### PR DESCRIPTION
## Summary
- The `Materialize runs history from LFS` step uses `continue-on-error: true`, so if LFS pull fails, `benchmarks/results/runs/index.json` stays as an LFS pointer
- The `Append to runs/index.json` step then calls `JSON.parse` on the pointer text → `SyntaxError: Unexpected token 'v'`
- This caused the emergency baseline refresh to fail at the final commit step despite all 16 shards completing successfully

## Fix
Wrap the `runs/index.json` read in a try-catch that falls back to `[]`, so the append step succeeds even when LFS materialization is unavailable. A fresh index is written with just the current run's entry.

## Test plan
- [ ] CI quality check passes (no src/ changes)
- [ ] Re-trigger emergency baseline refresh after merge — all 16 shards + promote step should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)