### PR TITLE
fix(ci): upload regressions artifact and harden PR number resolution

### DIFF
--- a/.github/workflows/ci-status-feed.yml
+++ b/.github/workflows/ci-status-feed.yml
@@ -40,18 +40,36 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Download regressions report artifact from triggering run
+        uses: actions/download-artifact@v7
+        with:
+          name: test262-regressions-report
+          path: /tmp/merged-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
       - name: Resolve PR number
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # The workflow_run event provides pull_requests on its payload.
+          # 1. The workflow_run event usually provides pull_requests on its payload.
           pr_num=$(jq -r '.workflow_run.pull_requests[0].number // empty' < "$GITHUB_EVENT_PATH")
+
+          # 2. Fallback: look up by head branch.
           if [ -z "$pr_num" ]; then
-            # Fallback: look up by head branch
             head_branch="${{ github.event.workflow_run.head_branch }}"
-            pr_num=$(gh pr list --state all --head "$head_branch" --json number --jq '.[0].number' || echo "")
+            pr_num=$(gh pr list --state all --head "$head_branch" --json number --jq '.[0].number' 2>/dev/null || echo "")
           fi
+
+          # 3. Last-resort fallback: look up by commit SHA. Most reliable when
+          #    the head_branch lookup misses (forks, deleted refs, etc.).
+          if [ -z "$pr_num" ]; then
+            head_sha="${{ github.event.workflow_run.head_sha }}"
+            pr_num=$(gh pr list --state all --json number,headRefOid --jq --arg sha "$head_sha" '.[] | select(.headRefOid == $sha) | .number' 2>/dev/null | head -1 || echo "")
+          fi
+
           if [ -z "$pr_num" ]; then
             echo "No PR number resolvable — skipping status write"
             echo "pr=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -293,6 +293,14 @@ jobs:
             echo "regressions=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upload regressions report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test262-regressions-report
+          path: merged-reports/test262-regressions.txt
+          if-no-files-found: warn
+
       - name: Fail on regressions
         if: steps.regression_diff.outputs.regressions == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.force_baseline_refresh == true && inputs.confirm_force == 'YES')
         run: |


### PR DESCRIPTION
## Summary

Fixes two systematic bugs in the CI status feed (`.claude/ci-status/pr-N.json`) that left dev agents waiting for a status file that never came, or arrived missing the merge-gate fields.

### Bug 1 — `test262-regressions.txt` never reached the feed

The `regression-gate` job in `test262-sharded.yml` generated `merged-reports/test262-regressions.txt` (line 282), but never uploaded it as an artifact. The `test262-merged-report` artifact came from a different job, so the feed's lookup at `/tmp/merged-report/test262-regressions.txt` (`ci-status-feed.yml` line 100) always missed. Result: every status JSON had `regressions: null`, `improvements: null`, `net_per_test: null` — devs couldn't self-merge from these.

**Fix**: new `Upload regressions report` step in `regression-gate` with `if: always()` so the artifact uploads even when the next step (`Fail on regressions`) exits 1. New matching `Download regressions report artifact` step in the feed writes into `/tmp/merged-report/` — no parsing changes needed.

### Bug 2 — PR number sometimes unresolvable

For PR #35 (`issue-1160-objproto-symbol-leak`), both `workflow_run.pull_requests[0].number` and `gh pr list --head <branch>` returned empty. Status file never written; agents waited hours.

**Fix**: third fallback that looks up the PR by `headRefOid` (commit SHA). SHA is unique per push and survives branch deletions/forks/renames.

## Files changed
- `.github/workflows/test262-sharded.yml` — +8 lines (upload step in `regression-gate`)
- `.github/workflows/ci-status-feed.yml` — +21/−3 lines (download step + SHA fallback)

No compiler / source code changes.

## Test plan
- [ ] After merge, the next PR's `pr-N.json` should have non-null `regressions`, `improvements`, `net_per_test`
- [ ] PRs that previously failed PR-number resolution (e.g., #35-style cases) should now resolve via the SHA fallback
- [ ] `Fail on regressions` still fails the workflow as before (artifact upload runs first because `if: always()`)

CHECKLIST-FOXTROT

🤖 Generated with [Claude Code](https://claude.com/claude-code)