### PR TITLE
docs(wasi): add examples/wasi/README.md and close #1035

### DIFF
--- a/examples/wasi/README.md
+++ b/examples/wasi/README.md
@@ -1,0 +1,226 @@
+# WASI hello-world: TypeScript → standalone native executable
+
+This example shows how to compile a small TypeScript program that writes to
+**stdout** *and* the **filesystem** down to a single self-contained WASI
+binary — no Node, no JS host, no runtime dependencies on the consumer's
+machine.
+
+## The source
+
+[`hello-fs.ts`](./hello-fs.ts):
+
+```ts
+import { writeFileSync } from "node:fs";
+
+console.log("hello world");
+writeFileSync("hello.txt", "hello world\n");
+```
+
+It uses two of the most common Node.js APIs (`console.log` and
+`fs.writeFileSync`). With `--target wasi`, js2wasm rewrites both to WASI
+syscalls:
+
+| TypeScript                         | WASI primitives                           |
+| ---------------------------------- | ----------------------------------------- |
+| `console.log(s)`                   | `fd_write` (fd=1)                         |
+| `writeFileSync(path, contents)`    | `path_open` → `fd_write` → `fd_close`     |
+
+The compiled module imports only from `wasi_snapshot_preview1` — there are
+**no `env.*` imports**, so the binary runs on any standards-compliant WASI
+runtime.
+
+## Compile to `.wasm`
+
+```bash
+mkdir -p out
+npx js2wasm examples/wasi/hello-fs.ts --target wasi -o out
+```
+
+This produces `out/hello-fs.wasm` (~4 KB), `out/hello-fs.wat` (text
+format), and a `out/hello-fs.d.ts`.
+
+> The `-o` flag is the **output directory**, not a filename. js2wasm uses
+> the input basename for the output (`hello-fs.wasm`).
+
+## Run on a WASI runtime
+
+The compiled `.wasm` runs anywhere WASI preview1 is supported. The
+working directory must be `--dir`-mapped into the sandbox so
+`writeFileSync` can create the file.
+
+### wasmtime
+
+```bash
+wasmtime --dir=. out/hello-fs.wasm
+cat hello.txt   # → hello world
+```
+
+### wasmer
+
+```bash
+wasmer run --mapdir=.:. out/hello-fs.wasm
+cat hello.txt   # → hello world
+```
+
+### wazero (CLI)
+
+```bash
+wazero run -mount=.:/ out/hello-fs.wasm
+```
+
+### Node.js (built-in WASI)
+
+```bash
+node --experimental-wasi-unstable-preview1 - <<'EOF'
+import { WASI } from "node:wasi";
+import { readFile } from "node:fs/promises";
+const wasi = new WASI({ version: "preview1", preopens: { ".": process.cwd() } });
+const bytes = await readFile("out/hello-fs.wasm");
+const module = await WebAssembly.compile(bytes);
+const instance = await WebAssembly.instantiate(module, wasi.getImportObject());
+wasi.start(instance);
+EOF
+```
+
+## Wrap as a native executable
+
+`hello-fs.wasm` is portable, but it still requires a WASI runtime to run.
+The next step is wrapping it as a single self-contained native binary so
+end-users don't need to install anything. Three approaches, in order of
+simplicity:
+
+### 1. `wasmer create-exe` (recommended)
+
+`wasmer create-exe` produces a real, statically-linked native binary that
+embeds the Wasm module + the wasmer runtime. No runtime install needed on
+the consumer machine — just a single executable file.
+
+```bash
+wasmer create-exe out/hello-fs.wasm -o hello-fs
+./hello-fs
+cat hello.txt
+```
+
+**Pros:**
+
+- Single self-contained file (~10–20 MB)
+- Cross-platform: Linux, macOS, Windows
+- Zero install on the target machine
+- No JIT — fully AOT compiled
+
+**Caveats:**
+
+- Build-time dependency on the wasmer toolchain
+- The wasmer runtime is statically linked, so the binary is bigger than
+  the raw `.wasm` would suggest.
+
+### 2. `wasmtime compile` (precompiled `.cwasm`)
+
+`wasmtime compile` AOT-compiles the Wasm to a `.cwasm` artifact that
+skips JIT at startup. It still requires `wasmtime` to be installed on the
+target machine.
+
+```bash
+wasmtime compile out/hello-fs.wasm -o hello-fs.cwasm
+wasmtime run --allow-precompiled hello-fs.cwasm
+```
+
+**Pros:**
+
+- Smallest output (just the precompiled module)
+- Fast startup (skips JIT)
+
+**Caveats:**
+
+- Requires wasmtime installed on the target machine
+- Per-platform: a `.cwasm` built on Linux x86_64 only runs on Linux x86_64
+
+### 3. wazero embedded in a Go binary
+
+[wazero](https://github.com/tetratelabs/wazero) is a pure-Go WebAssembly
+runtime with zero CGo dependencies. Embed the `.wasm` into a tiny Go
+program and `go build` it into a single static binary.
+
+```go
+// run.go
+package main
+
+import (
+    "context"
+    _ "embed"
+    "github.com/tetratelabs/wazero"
+    "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+//go:embed out/hello-fs.wasm
+var helloFs []byte
+
+func main() {
+    ctx := context.Background()
+    r := wazero.NewRuntime(ctx)
+    defer r.Close(ctx)
+    wasi_snapshot_preview1.MustInstantiate(ctx, r)
+    cfg := wazero.NewModuleConfig().
+        WithStdout(os.Stdout).
+        WithStderr(os.Stderr).
+        WithFSConfig(wazero.NewFSConfig().WithDirMount(".", "/"))
+    if _, err := r.InstantiateWithConfig(ctx, helloFs, cfg); err != nil {
+        panic(err)
+    }
+}
+```
+
+```bash
+go build -o hello-fs run.go
+./hello-fs
+```
+
+**Pros:**
+
+- Pure Go: cross-compile for any Go-supported target
+- No CGo: no toolchain hassles
+- Statically linked by default
+
+**Caveats:**
+
+- Requires Go toolchain at build time
+- Wazero is interpret + tier-up: not as fast as wasmer/wasmtime AOT
+
+## Dual-target story
+
+The same `hello-fs.ts` source compiles cleanly under **both** targets
+without source changes:
+
+```bash
+# WASI mode → standalone .wasm, runs anywhere
+npx js2wasm examples/wasi/hello-fs.ts --target wasi -o out
+
+# JS-host mode → .wasm + imports.js helper, runs in Node/browser
+npx js2wasm examples/wasi/hello-fs.ts -o out
+```
+
+This demonstrates js2wasm's **dual-mode** principle (same source, two
+targets — see [`#679`](../../plan/issues/done/679.md) /
+[`#682`](../../plan/issues/done/682.md)) applied to filesystem I/O. The
+import resolver routes `node:fs` to the JS host's `fs` module in JS-host
+mode, and to WASI syscalls (`path_open`/`fd_write`/`fd_close`) in WASI
+mode.
+
+## Limitations / follow-ups
+
+The current implementation is the minimum viable cut for a hello-world
+filesystem demo. Known limitations:
+
+- **Hardcoded preopen dirfd = 3.** Most WASI runtimes assign fd=3 to the
+  first `--dir` mount, so this works in practice. A full preopen-table
+  walk via `fd_prestat_get` / `fd_prestat_dir_name` is tracked in
+  [`#1041`](../../plan/issues/blocked/1041.md).
+- **`writeFileSync` only.** `readFileSync` (#1036), `existsSync` (#1037),
+  `mkdirSync` (#1038), `unlinkSync` (#1039), `readdirSync` (#1040), and
+  `node:fs/promises` (#1042) are follow-up issues.
+- **String literal paths preferred.** Dynamic-path support exists for
+  `const path = '...'` style, but a true runtime GC-string → linear-memory
+  encoder is still pending.
+
+See [`plan/issues/sprints/45/1035.md`](../../plan/issues/done/1035.md) for
+the design notes and full follow-up list.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -167,7 +167,7 @@ and [#998](../sprints/40/998.md); [#848](../sprints/30/848.md) is already comple
 | # | Priority | Issue | Impact | Status |
 |---|----------|-------|--------|--------|
 | [1099](../sprints/42/1099.md) | High | Standalone execution demo — FizzBuzz on Wasmtime, zero JS host | Production/infra credibility | Ready (depends on #1094) |
-| [1035](../sprints/42/1035.md) | High | WASI hello-fs: console.log + node:fs → WASI fd_write | Standalone FS proof | Ready |
+| [1035](../done/1035.md) | High | WASI hello-fs: console.log + node:fs → WASI fd_write | Standalone FS proof | Done |
 | [1100](1100.md) | Medium | Wasm-native Proxy: meta-object protocol without JS host | Standalone Proxy | Ready |
 | [1101](1101.md) | Low | Wasm-native WeakRef / FinalizationRegistry via WasmGC | Standalone weak refs | Ready |
 | [1102](1102.md) | Medium | Wasm-native eval: ahead-of-time compilation strategy | Standalone eval | Ready |

--- a/plan/issues/done/1035.md
+++ b/plan/issues/done/1035.md
@@ -2,12 +2,15 @@
 id: 1035
 title: "WASI hello-world: compile console.log + node:fs write to a standalone native executable"
 sprint: 45
-status: ready
+status: done
+created: 2026-04-15
+updated: 2026-04-26
 priority: high
 feasibility: medium
 reasoning_effort: high
 goal: async-model
 depends_on: []
+task_type: feature
 ---
 
 # #1035 — WASI hello-world with node:fs translated to WASI
@@ -280,3 +283,88 @@ Both produce the same stdout and the same `hello.txt`. This demonstrates that js
 - Depends on existing `--target wasi` fd_write support for `console.log`
 - Enables the native-executable benchmark thread: compile a small TS program to a native binary and measure cold-start, memory, and execution time against `node hello-fs.ts`
 - Parallel in spirit to #1032's "Node builtins as host imports in JS-host mode" — the distinction is that for WASI mode, the same Node builtin imports are re-routed to WASI syscalls rather than externref host imports
+
+## Implementation summary
+
+Landed in two parts:
+
+1. **Compiler core** (`50a8caba3` — `feat(wasi): map node:fs writeFileSync to WASI path_open + fd_write + fd_close`):
+   - `src/compiler.ts:detectNodeFsImports` — scans the original source for
+     named imports from `node:fs` / `fs` *before* `preprocessImports` strips
+     them, returning the set of imported function names. Result is stored
+     on `ctx.wasiNodeFsFuncs`.
+   - `src/codegen/index.ts:registerWasiImports` — when `writeFileSync` is
+     in `wasiNodeFsFuncs`, registers `wasi_snapshot_preview1.path_open`
+     and `wasi_snapshot_preview1.fd_close` imports in addition to the
+     existing `fd_write` / `proc_exit`. Linear memory + bump-pointer global
+     are reserved (page 0, scratch area 0..1023, data segments above).
+   - `src/codegen/index.ts:emitWasiWriteFileSyncHelper` — emits a
+     `__wasi_write_file_sync(pathPtr, pathLen, dataPtr, dataLen)` helper
+     that:
+       1. Calls `path_open(dirfd=3, dirflags=0, path, path_len, oflags=O_CREAT|O_TRUNC=9, rights_base=FD_WRITE=64, rights_inheriting=0, fdflags=0, fd_out=12)`
+       2. Loads the opened fd from `memory[12]`
+       3. Writes the data via `fd_write` with an iovec at `memory[0..7]` and the nwritten output at `memory[8]`
+       4. Calls `fd_close(fd)`
+   - `src/codegen/expressions/calls.ts` — at `writeFileSync(path, data)`
+     call sites in WASI mode, emits the path/data string bytes via
+     `wasiAllocStringData` (compile-time data segment) for string literals
+     and via `compileWasiStringArgToLinearMemory` for `const x = '...'`
+     style references, then calls `__wasi_write_file_sync`.
+   - Also fixed a pre-existing bug where the unified import collector
+     registered `console_log_string` JS host imports even in WASI mode,
+     causing invalid binaries with conflicting externref/i32 types.
+
+2. **Example + documentation** (this commit):
+   - `examples/wasi/README.md` — explains the three native-executable
+     wrapping approaches (`wasmer create-exe`, `wasmtime compile`,
+     wazero-in-Go) with commands, pros/cons, and caveats.
+   - Documents the dual-target story (same source compiles in both WASI
+     and JS-host modes without changes).
+
+The hardcoded `dirfd = 3` matches the convention of `wasmtime --dir=.`
+(first preopen gets fd 3). A proper preopen-table walk via
+`fd_prestat_get`/`fd_prestat_dir_name` is tracked as #1041.
+
+## Test Results
+
+`tests/issue-1035.test.ts` — **5/5 passing** (verified 2026-04-26 on
+worktree `issue-1035-wasi-fs-writefilesync`):
+
+1. `compiles writeFileSync to WASI imports (no JS host imports)` — module
+   only imports from `wasi_snapshot_preview1`, includes `fd_write`,
+   `path_open`, `fd_close`; exports `memory` and `_start`.
+2. `console.log only — no path_open/fd_close imports` — without
+   `writeFileSync`, the path_open/fd_close imports are not emitted.
+3. `end-to-end: writes hello.txt via WASI runtime` — runs the compiled
+   `.wasm` under Node's `node:wasi` with a temp preopen, asserts
+   stdout = `hello world` and the written file content matches.
+4. `node:fs import without writeFileSync does not add path_open` — only
+   `readFileSync` import → no path_open.
+5. `bare fs module also detected` — `import { writeFileSync } from 'fs'`
+   triggers the same WASI rewrite as `node:fs`.
+
+End-to-end smoke (manual, 2026-04-26):
+
+```
+$ npx js2wasm examples/wasi/hello-fs.ts --target wasi -o /tmp/wasi-out
+/tmp/wasi-out/hello-fs.wasm  (4431 bytes)
+$ node --experimental-wasi-unstable-preview1 ... # via node:wasi
+hello world
+$ cat /tmp/wasi-test-1035/hello.txt
+hello world
+```
+
+Stretch goal (dual-target): the same source also compiles cleanly in
+JS-host mode (`compile(src)` returns `success: true` with `writeFileSync`
++ `console_log_string` as host imports).
+
+## Acceptance criteria
+
+- [x] `examples/wasi/hello-fs.ts` exists and uses `console.log` + `writeFileSync` from `node:fs`
+- [x] `npx js2wasm examples/wasi/hello-fs.ts --target wasi -o <dir>` succeeds (note: `-o` is the output **directory**)
+- [x] Running `wasmtime --dir=. hello-fs.wasm` (or Node's `node:wasi`) prints `hello world` to stdout
+- [x] Running creates `hello.txt` containing `hello world\n`
+- [x] `tests/issue-1035.test.ts` added and passes (5/5)
+- [x] At least one native-executable wrapping approach documented (`wasmer create-exe`)
+- [x] The example's README explains all three wrapping options with commands and caveats
+- [x] **Stretch:** same source compiles in JS-host mode (without `--target wasi`)

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -273,7 +273,7 @@ All independent — can run in parallel.
 
 ```
 #1094 (shrink runtime.ts) ──→ #1099 (standalone demo on Wasmtime, zero JS host)
-#1035 (WASI hello-fs) -- independent but related
+#1035 (WASI hello-fs) -- DONE (sprint 45)
 #680 (pure Wasm generators) -- enables broader standalone coverage
 #681 (pure Wasm iterators) -- enables broader standalone coverage
 #682 (RegExp standalone) ──→ #1105 Tier 2 string methods (match, replace, search)


### PR DESCRIPTION
## Summary

Closes [#1035](../plan/issues/done/1035.md) (WASI hello-world: console.log + node:fs → standalone native executable).

The compiler change — translating `import { writeFileSync } from 'node:fs'` to WASI `path_open` + `fd_write` + `fd_close` syscalls in `--target wasi` mode — was already implemented and merged in commit 50a8caba3. This PR closes the remaining documentation/example debt:

- **`examples/wasi/README.md`** — explains all three native-executable wrapping approaches (`wasmer create-exe`, `wasmtime compile`, wazero in Go) with commands, pros, cons, and caveats. Also documents the dual-target story: same source compiles in both WASI and JS-host modes without changes.
- Moves `plan/issues/sprints/45/1035.md` → `plan/issues/done/1035.md` with status `done`, an implementation summary, and test results.
- Updates `plan/issues/backlog/backlog.md` and `plan/log/dependency-graph.md` to mark the issue done.

## Verification

- `npm run build` — succeeds (4.4 KB hello-fs.wasm, ~34 KB WAT)
- `tests/issue-1035.test.ts` — **5/5 pass** locally
  - `compiles writeFileSync to WASI imports (no JS host imports)`
  - `console.log only — no path_open/fd_close imports`
  - `end-to-end: writes hello.txt via WASI runtime` (uses Node's `node:wasi`)
  - `node:fs import without writeFileSync does not add path_open`
  - `bare fs module also detected`
- Manual end-to-end smoke: `npx js2wasm examples/wasi/hello-fs.ts --target wasi -o /tmp/wasi-out` → run via Node WASI → `hello world` on stdout + `/tmp/wasi-test-1035/hello.txt` contains `hello world\n`
- Stretch goal: same `hello-fs.ts` source compiles cleanly in JS-host mode (`writeFileSync` + `console_log_string` resolve as JS host imports)

## Test plan

- [ ] CI builds the project successfully
- [ ] CI runs `tests/issue-1035.test.ts` — all 5 tests pass
- [ ] CI test262 baseline: no regressions (`net_per_test >= 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)