### PR TITLE
chore(sprint-45): file js2wasm benchmark crashes as #1173, #1174, #1175

### DIFF
--- a/plan/issues/sprints/45/1173.md
+++ b/plan/issues/sprints/45/1173.md
@@ -1,0 +1,128 @@
+---
+id: 1173
+title: "js2wasm output uses 'exact' reference types that wasmtime 44 rejects (array-sum benchmark crash)"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays
+goal: compilable
+origin: surfaced by `#1125` competitive benchmark verification (2026-04-27)
+---
+
+# #1173 — js2wasm emits 'exact' reference types that wasmtime 44 rejects on `--target wasi`
+
+## Problem
+
+The `array-sum` benchmark program (a basic array fill + sum kernel) compiles
+successfully in js2wasm but the resulting Wasm fails `wasmtime compile`:
+
+```
+Error: failed to compile: wasm[0]::function[0]
+
+Caused by:
+    0: WebAssembly translation error
+    1: Invalid input WebAssembly code at offset 77: custom descriptors required for exact reference types
+```
+
+The js2wasm output is using "exact" reference types — a recent WasmGC
+proposal feature that requires the `custom-descriptors` proposal to be
+enabled in wasmtime. wasmtime 44.0.0 (latest stable) does not enable
+`custom-descriptors` by default and its `-W` config does not yet expose
+it as a stable flag, so the emitted Wasm cannot be loaded.
+
+## Reproduction
+
+Source program (from `benchmarks/competitive/programs/array-sum.js`):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const values = [];
+  for (let i = 0; i < n; i++) {
+    values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+  }
+
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum = (sum + values[i]) | 0;
+  }
+  return sum | 0;
+}
+```
+
+Compile path (matches what `benchmarks/compare-runtimes.ts` does for the
+js2wasm → Wasmtime lane):
+
+```ts
+import { compile } from './src/index.ts';
+const result = compile(source, {
+  fileName: 'array-sum.js',
+  allowJs: true,
+  target: 'wasi',
+  optimize: 4,
+});
+// result.success is true — js2wasm thinks it's done
+// then: wasm-opt --all-features -O4
+// then: wasmtime compile -W gc=y,function-references=y,component-model=y,exceptions=y -O opt-level=2
+//       -> FAILS with "custom descriptors required for exact reference types"
+```
+
+A 30-line standalone repro lives in `.tmp/repro-array-sum.mjs` from the
+benchmark verification work (PR #51 / PR #52). The js2wasm-stage compile
+succeeds; the failure is in `wasmtime compile`.
+
+## Root cause hypothesis
+
+js2wasm appears to be emitting `(ref exact $T)` somewhere in the array
+codegen path. The WasmGC "exact reference types" proposal allows the
+producer to assert that a reference is exactly of type `$T` (not a
+subtype), which can enable better cast elimination — but it is gated
+behind the `custom-descriptors` proposal.
+
+Likely culprits:
+- `src/codegen/expressions.ts` — array-literal / `[]` lowering, especially
+  the `__vec_*` struct emission
+- `src/codegen/type-coercion.ts` — vec → ref widening
+- `src/codegen/index.ts` — type-import emission for vec structs
+
+The fix is to either:
+1. **Stop emitting `exact`** in the relevant codegen paths (drop the
+   `exact` modifier from the type encodings, falling back to plain
+   `(ref $T)`). This is the conservative path and matches what the
+   wasm-opt → wasmtime 44 chain accepts today.
+2. Keep `exact` but conditionally only when an opt-in flag enables the
+   `custom-descriptors` proposal, and pass `-W custom-descriptors=y`
+   through to `wasmtime compile`. wasmtime 44 doesn't yet expose this
+   as a stable `-W` key, so option 1 is the realistic fix until the
+   proposal stabilizes.
+
+## Scope of impact
+
+Any program that constructs an array via `[]` and writes to it with
+`values[i] = ...` style assignment. The benchmark surfaces this on a
+trivially-shaped kernel; real user programs that use plain JS arrays
+will hit the same wall. This blocks all js2wasm `--target wasi` builds
+that touch array codegen on wasmtime ≥ 44.
+
+## Acceptance criteria
+
+- `array-sum` benchmark program compiles and runs end-to-end through
+  `wasmtime compile` + `wasmtime run --invoke "run(2000)"` with the
+  default flag set used by `benchmarks/compare-runtimes.ts`.
+- The benchmark JSON shows `js2wasm-wasmtime` lane `status: ok` for
+  `array-sum` (matching `fib` / `fib-recursive`, which already work).
+- A new `tests/issue-1173.test.ts` reproduces the bug on the current
+  failing version and passes after the fix.
+- No regression on `fib` / `fib-recursive` js2wasm-wasmtime perf
+  numbers (they should not depend on this codegen change).
+
+## Key files
+
+- `src/codegen/expressions.ts` — array literal + indexed assignment
+- `src/codegen/type-coercion.ts` — vec/ref widening
+- `src/codegen/index.ts` — type-import / struct definitions for `__vec_*`
+- `benchmarks/competitive/programs/array-sum.js` — the canonical repro

--- a/plan/issues/sprints/45/1174.md
+++ b/plan/issues/sprints/45/1174.md
@@ -1,0 +1,132 @@
+---
+id: 1174
+title: "js2wasm emits `string_constants` host import on `--target wasi` builds (object-ops benchmark crash)"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: compilable
+origin: surfaced by `#1125` competitive benchmark verification (2026-04-27)
+---
+
+# #1174 — Object-literal property keys leak `string_constants` host import on `--target wasi`
+
+## Problem
+
+The `object-ops` benchmark program (a basic object-literal field-write
+loop) compiles and `wasmtime compile` succeeds, but `wasmtime run` fails
+to instantiate the resulting cwasm:
+
+```
+Error: Error: failed to run main module `/tmp/.../object-ops.cwasm`
+
+Caused by:
+    0: failed to instantiate "/tmp/.../object-ops.cwasm"
+    1: unknown import: `string_constants::a,b,c` has not been defined
+```
+
+The js2wasm emit is using a `string_constants` host import to deliver
+the property names `"a"`, `"b"`, `"c"` (the keys of the object literal)
+into the Wasm module. That import is part of the JS-host runtime that
+gets satisfied by `buildImports(...)` when running through Node. In
+`--target wasi` mode, the module is supposed to be standalone — there
+is no JS host, so the import is unsatisfiable and instantiation fails.
+
+## Reproduction
+
+Source program (from `benchmarks/competitive/programs/object-ops.js`):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  let acc = 0;
+  for (let i = 0; i < n; i++) {
+    const record = {
+      a: i | 0,
+      b: (i * 3) | 0,
+      c: (i ^ 0x55aa) | 0,
+    };
+    acc = (acc + record.a + record.b - record.c) | 0;
+  }
+  return acc | 0;
+}
+```
+
+Compile path:
+
+```ts
+const result = compile(source, {
+  fileName: 'object-ops.js',
+  allowJs: true,
+  target: 'wasi',
+  optimize: 4,
+});
+// js2wasm reports success and result.imports STILL contains
+//   { module: 'string_constants', name: 'a,b,c', ... }
+// despite target: 'wasi'
+```
+
+The benchmark harness explicitly checks `compileResult.imports` for
+non-WASI imports and bails with `status: 'blocked'` if any are present
+(`benchmarks/compare-runtimes.ts`, the `nonWasiImports` block around
+line 1514). The `string_constants::a,b,c` import slips through that
+check (the harness flagged it as a runtime-error rather than a blocked
+state — this issue tracks fixing the codegen, not the harness).
+
+## Root cause hypothesis
+
+When `nativeStrings` is enabled (auto-on for WASI targets, see
+`src/codegen/index.ts`), string literals should be lowered to either
+inline `(array i16)` constants or compile-time-baked string-pool
+entries — not to a `string_constants` host import.
+
+Object-literal property keys are a separate code path from "regular"
+string literals. They flow through `getOrCreatePropertyKey` /
+`compileObjectLiteral` and the lookup table that backs property
+accesses. That path may not yet be wired through the `nativeStrings` /
+WASI pivot, so it still emits the legacy `string_constants` import.
+
+Suspected files:
+- `src/codegen/expressions.ts` — `compileObjectLiteralExpression` and
+  the property-key emission for object literal members
+- `src/codegen/index.ts` — `addUnionImports` / late-import path,
+  `nativeStrings` decision logic
+- `src/runtime.ts` — `string_constants` host-side resolver (currently
+  exists as a JS-host fallback)
+
+## Scope of impact
+
+Any program that uses object literals with string property keys built
+for `--target wasi`. That includes essentially every non-trivial JS
+program: framework state, configuration objects, JSON-shaped values,
+record patterns. Without this fix, `--target wasi` builds will fail
+to instantiate for almost any real-world program. It's blocking for
+the standalone-Wasm story in general.
+
+## Acceptance criteria
+
+- `object-ops` benchmark program runs end-to-end through `wasmtime
+  compile` + `wasmtime run --invoke "run(1000)"`, returning the same
+  numeric result as the Node baseline.
+- Benchmark JSON shows `js2wasm-wasmtime` lane `status: ok` for
+  `object-ops`.
+- `compileResult.imports` is empty (or contains only WASI-prefixed
+  imports) for the `object-ops` source under `--target wasi`.
+- Larger smoke-test: a new `tests/issue-1174.test.ts` covers a few
+  shapes of object literal (string keys, numeric keys, computed keys
+  with string-constant values) under WASI mode and verifies no
+  `string_constants` import is emitted.
+- No regression on JS-host-mode (default target) — the host-import
+  path can stay as the fallback when WASI is not selected.
+
+## Key files
+
+- `src/codegen/expressions.ts` — `compileObjectLiteralExpression`
+- `src/codegen/index.ts` — `nativeStrings` flag wiring + import emission
+- `src/runtime.ts` — current `string_constants` host-side handler (for
+  the JS-host fallback)
+- `benchmarks/competitive/programs/object-ops.js` — the canonical repro

--- a/plan/issues/sprints/45/1175.md
+++ b/plan/issues/sprints/45/1175.md
@@ -1,0 +1,162 @@
+---
+id: 1175
+title: "String concatenation emits type-mismatched call args (`__str_flatten`, `concat`) failing wasm-validator"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: strings
+goal: compilable
+origin: surfaced by `#1125` competitive benchmark verification (2026-04-27)
+---
+
+# #1175 — String `+=` codegen passes wrong-typed args to `__str_flatten` / `concat`
+
+## Problem
+
+The `string-hash` benchmark program (a basic string-build + char-code-hash
+kernel) fails Wasm validation in js2wasm itself — the produced Wasm does
+not pass `wasm-validator` because the emitted `call` instructions have
+mismatched argument types:
+
+```
+[wasm-validator error in function run] call param types must match, on
+(call $__str_flatten
+ (i32.trunc_sat_f64_s
+  (f64.convert_i32_s
+   (local.get $7)
+  )
+ )
+)
+(on argument 0)
+[wasm-validator error in function run] call param types must match, on
+(call $concat
+ (call $length
+  (extern.convert_an...
+```
+
+The codegen is round-tripping a value through `f64.convert_i32_s` →
+`i32.trunc_sat_f64_s` (a no-op widening + narrowing) and ending up with
+the wrong Wasm-level type for the callee's signature. Two distinct
+calls fail validation:
+
+1. `call $__str_flatten` — argument 0 has the wrong type
+2. `call $concat` — first argument (the result of `call $length`) has
+   the wrong type at the callee boundary
+
+Both happen inside the `text += alphabet.charAt(a)` chain in the
+benchmark program. The string concatenation operator desugars into
+`__str_flatten` / `concat` calls, and the type-coercion logic between
+those calls is producing values whose Wasm-level type doesn't match
+the function signature.
+
+## Reproduction
+
+Source program (from `benchmarks/competitive/programs/string-hash.js`):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz012345";
+  let text = "";
+  for (let i = 0; i < n; i++) {
+    const a = (i * 13) & 31;
+    const b = (a + 7) & 31;
+    text += alphabet.charAt(a);
+    text += alphabet.charAt(b);
+    text += ";";
+  }
+
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    hash = (hash * 31 + text.charCodeAt(i)) | 0;
+  }
+  return hash | 0;
+}
+```
+
+Compile path: same as the other js2wasm-wasmtime lane (`compile` with
+`target: 'wasi'`, `optimize: 4`, then `wasm-opt`, then `wasmtime
+compile`). The validator error fires during the js2wasm `compile`
+itself (status `compile-error`, not `runtime-error`), so it's caught
+before wasm-opt or wasmtime ever see the binary.
+
+## Root cause hypothesis
+
+Inspecting the offending fragment:
+
+```wat
+(call $__str_flatten
+ (i32.trunc_sat_f64_s
+  (f64.convert_i32_s
+   (local.get $7)
+  )
+ )
+)
+```
+
+This pattern is the signature of a coercion chain that fired in both
+directions (i32→f64→i32) and dropped a critical type-conversion step in
+the middle. `__str_flatten` likely expects an `externref` (or a vec/
+struct ref), not an `i32`. Somewhere in the `text += <expr>` lowering,
+a string-typed value is being coerced through the numeric type-coercion
+path instead of the string/ref path.
+
+Suspected files:
+- `src/codegen/expressions.ts` — binary-operator codegen for `+=`,
+  string-concat detection
+- `src/codegen/type-coercion.ts` — the `coerceType` logic that emits
+  `f64.convert_i32_s` / `i32.trunc_sat_f64_s` for numeric coercion;
+  string coercion should not pass through here
+- `src/codegen/index.ts` — `__str_flatten` import signature and the
+  `concat` builtin's type signature
+
+The fix likely involves correctly classifying the right-hand side of
+`text += ...` as a string and routing it through the string-coercion
+path (which should produce an `externref` or vec-ref), not the numeric
+path. The fact that we see `f64.convert_i32_s` followed immediately
+by `i32.trunc_sat_f64_s` is the smoking gun — that's the no-op pair
+the type-coercion machinery emits when it has been told "convert to
+numeric, then back to integer", which makes no sense for a string
+operand.
+
+## Scope of impact
+
+Any program that uses string concatenation inside a loop where the
+right-hand side flows through certain coercion paths. String building
+is one of the most common JS patterns — log messages, generated SQL,
+HTML/JSX-style template construction, JSON serialization, hashing.
+This crash blocks any js2wasm program that builds strings dynamically
+in a hot loop.
+
+The benchmark uses a particularly compact pattern (`text += alphabet
+.charAt(a)`) that triggers the bug reliably; the larger family of
+"string built with `+=`" programs almost certainly hits it.
+
+## Acceptance criteria
+
+- `string-hash` benchmark program compiles via js2wasm without
+  wasm-validator errors.
+- Runs end-to-end through `wasmtime compile` + `wasmtime run --invoke
+  "run(100)"`, returning the same numeric result as the Node baseline.
+- Benchmark JSON shows `js2wasm-wasmtime` lane `status: ok` for
+  `string-hash`.
+- A new `tests/issue-1175.test.ts` covers a few shapes of string
+  concatenation:
+  - `let s = ""; for (let i = 0; i < n; i++) s += chars[i];`
+  - `s += someFn(...)` where `someFn` returns a string
+  - `s += "literal" + dynamicVar` (mixed literal + dynamic)
+  - mixed string+number coercion: `s += i` (where `i` is a number)
+- No regression on existing string tests.
+
+## Key files
+
+- `src/codegen/expressions.ts` — binary-op `+=` lowering, string-concat
+  detection
+- `src/codegen/type-coercion.ts` — coercion path classification (the
+  numeric vs string vs ref decision tree)
+- `src/codegen/index.ts` — `__str_flatten` and `concat` import sigs
+- `benchmarks/competitive/programs/string-hash.js` — the canonical repro

--- a/plan/issues/sprints/45/sprint.md
+++ b/plan/issues/sprints/45/sprint.md
@@ -25,6 +25,13 @@ Absorb the overflow from sprint 44. Headline themes:
 1. **Drain the performance / numeric-inference queue** — #1120, #1121, #1122,
    #1126 form a coherent int32-fast-path block; pair them with benchmarking
    infrastructure (#1005, #1125) so improvements are measurable.
+   - **Crash bucket surfaced by #1125 verification (added 2026-04-27, high
+     priority):** #1173 (array-sum: 'exact' ref types reject by wasmtime 44),
+     #1174 (object-ops: `string_constants` host import leaks on `--target
+     wasi`), #1175 (string-hash: `__str_flatten` / `concat` type-mismatch in
+     wasm-validator). All three are basic JS patterns (array fill, object
+     literals, string concat) that crash js2wasm today and block the
+     competitive-benchmark `js2wasm → Wasmtime` lane on 3 of 5 programs.
 2. **CI baseline-drift hardening** — the 5-issue set (#1076, #1077, #1078,
    #1079, #1080) that was held back from sprint 44 because the IR work could
    not tolerate CI turbulence.
@@ -108,6 +115,9 @@ _Generated from issue frontmatter. Update issue `sprint` / `status`, then rerun 
 | #1169g | IR Phase 4 Slice 8 — destructuring and rest/spread through the IR path | high | ready |
 | #1169h | IR Phase 4 Slice 9 — try/catch/finally and throw through the IR path | high | ready |
 | #1169i | IR Phase 4 Slice 10 — remaining builtins (RegExp, TypedArray, DataView) through the IR path | high | ready |
+| #1173 | js2wasm output uses 'exact' reference types that wasmtime 44 rejects (array-sum benchmark crash) | high | ready |
+| #1174 | js2wasm emits `string_constants` host import on `--target wasi` builds (object-ops benchmark crash) | high | ready |
+| #1175 | String concatenation emits type-mismatched call args (`__str_flatten`, `concat`) failing wasm-validator | high | ready |
 
 ### Done
 


### PR DESCRIPTION
## Summary

Files three issues for the js2wasm crashes surfaced by the competitive runtime benchmark verification work (#1125, PR #51 + PR #52). All three fail on basic JS patterns (array fill, object-literal access, string concatenation) and block the `js2wasm → Wasmtime` lane on 3 of 5 benchmark programs.

| Issue | Program | Failure mode |
| --- | --- | --- |
| **#1173** | `array-sum` | `wasmtime compile`: *Invalid input WebAssembly code: custom descriptors required for exact reference types* |
| **#1174** | `object-ops` | `wasmtime run`: *unknown import: \`string_constants::a,b,c\`* (host-import leaks on `--target wasi`) |
| **#1175** | `string-hash` | `wasm-validator`: *call param types must match* on `__str_flatten` / `concat` |

All three are filed at `priority: high`, `status: ready`, `goal: compilable`, with concrete reproducers, root-cause hypotheses, suspected files, and acceptance criteria including a `tests/issue-{1173,1174,1175}.test.ts` per issue.

The sprint-45 goal section is updated to surface these three as a "crash bucket" beneath the performance / benchmarking theme so they're visible to the next dev claiming a task.

## Why these matter

The patterns that crash are not edge cases — they're foundational JS shapes:
- **`array-sum`**: `const a = []; for (...) { a[i] = ... }` — basic array fill
- **`object-ops`**: `{ a: x, b: y, c: z }` — object literals with string keys
- **`string-hash`**: `s += chars.charAt(i)` — string concatenation in a loop

Real-world programs hit all three constantly. Without these fixes, `--target wasi` builds will fail to instantiate for almost any non-trivial program. Fixing them is also what unlocks an honest js2wasm-vs-everything-else comparison in the competitive benchmark — currently 3 of 5 lanes are blocked at the js2wasm side.

## Files

- `plan/issues/sprints/45/1173.md` — array-sum / 'exact' reference types
- `plan/issues/sprints/45/1174.md` — object-ops / `string_constants` host import on WASI
- `plan/issues/sprints/45/1175.md` — string-hash / `__str_flatten` / `concat` type mismatch
- `plan/issues/sprints/45/sprint.md` — goal section + auto-regenerated issue table

No `src/` or `tests/` changes — this is a planning-artifact PR only.

## Test plan

- [x] `node scripts/sync-sprint-issue-tables.mjs` regenerates the table cleanly with all three issues in the Ready list at high priority
- [x] Each issue file has the four required structural sections: Problem, Reproduction, Root cause hypothesis, Acceptance criteria
- [x] Each issue file references the canonical reproducer source (`benchmarks/competitive/programs/{array-sum,object-ops,string-hash}.js`)
- [x] Verified the issue numbers (1173, 1174, 1175) don't collide with anything in `plan/issues/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)