### PR TITLE
chore(sprint-45): file #1178 (string-hash runtime stack-overflow) and #1179 (array-sum perf gap)

### DIFF
--- a/plan/issues/sprints/45/1178.md
+++ b/plan/issues/sprints/45/1178.md
@@ -1,0 +1,143 @@
+---
+id: 1178
+title: "string-hash benchmark hits `wasm trap: call stack exhausted` at runtime after #1175 fix"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: strings
+goal: compilable
+origin: surfaced by competitive-benchmark refresh after #1175 landed (2026-04-27)
+related: [1175]
+---
+
+# #1178 — `string-hash` runtime stack-overflow regression after the #1175 fix
+
+## Problem
+
+The fix for #1175 (`__str_flatten` / `concat` arg-type mismatch in
+string `+=` codegen) made the `string-hash` competitive benchmark
+*compile* successfully — js2wasm's wasm-validator no longer rejects
+the output. However the resulting Wasm now traps at runtime when the
+program runs the inner loop with `runtimeArg = 20000`:
+
+```
+wasm trap: call stack exhausted
+
+  10:     0xd7 - <unknown>!<wasm function 0>
+  11:     0xd7 - <unknown>!<wasm function 0>
+  12:     0xd7 - <unknown>!<wasm function 0>
+  ...
+```
+
+Every recorded frame returns at the same offset (`0xd7`), suggesting
+a single self-recursive call chain that doesn't bottom out for large
+input sizes. With `coldArg = 100` (100 string concatenations) the
+program runs fine; with `runtimeArg = 20000` (20K iterations × 3 string
+appends per iteration ≈ 60K concatenations) Wasmtime's default stack
+exhausts.
+
+## Reproduction
+
+Source program (`labs/benchmarks/competitive/programs/string-hash.js`
+on the labs repo, formerly `benchmarks/competitive/programs/...`
+before the labs/ restructure):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz012345";
+  let text = "";
+  for (let i = 0; i < n; i++) {
+    const a = (i * 13) & 31;
+    const b = (a + 7) & 31;
+    text += alphabet.charAt(a);
+    text += alphabet.charAt(b);
+    text += ";";
+  }
+
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    hash = (hash * 31 + text.charCodeAt(i)) | 0;
+  }
+  return hash | 0;
+}
+```
+
+Compile path matches the competitive benchmark harness (`compile` with
+`target: 'wasi'`, `optimize: 4`, then `wasm-opt --all-features -O4`,
+then `wasmtime compile -O opt-level=2`).
+
+Trigger: `wasmtime run --invoke "run(20000)" string-hash.cwasm` →
+`wasm trap: call stack exhausted`.
+
+`run(100)` succeeds. `run(1000)` may or may not succeed depending on
+where Wasmtime's stack budget lands. The threshold is somewhere
+between 1K and 20K concatenations.
+
+## Root cause hypothesis
+
+The new string-concatenation lowering for `text += <expr>` likely
+emits a per-concatenation Wasm call that does *not* tail-call (or use
+an iterative copy loop), so each `+=` consumes a fresh Wasm stack
+frame. After ~20K successive concatenations the cumulative depth
+exceeds Wasmtime's stack budget.
+
+Suspected files:
+- `src/codegen/string-ops.ts` — `__str_flatten` / `concat` codegen
+- `src/codegen/expressions.ts` — binary-op `+=` lowering when the
+  operand types are strings
+- The new code paths added when fixing #1175 — review whether the
+  fix introduced a recursive helper instead of an iterative one
+
+The fix candidate is to ensure the per-concatenation lowering is
+either:
+1. an iterative copy loop (no recursion, constant stack frames), or
+2. a tail call (`return_call` / `return_call_ref`) so successive
+   concatenations don't accumulate frames.
+
+## Scope of impact
+
+Any program that builds a string with `+=` in a loop of more than a
+few thousand iterations. That's a common pattern in:
+- log/string aggregators
+- HTML / JSON / SQL builders
+- hashing / encoding loops (the `string-hash` benchmark itself)
+
+For low iteration counts (a few hundred), the bug doesn't surface.
+This is why test coverage didn't catch it when #1175 landed — the
+issue-specific tests use small inputs.
+
+## Acceptance criteria
+
+- `string-hash` competitive benchmark compiles AND runs end-to-end
+  through `wasmtime run --invoke "run(20000)"` returning the same
+  numeric hash as the Node.js baseline.
+- A new `tests/issue-1178.test.ts` exercises `text += charAt(i)` (or
+  similar) over at least 50,000 iterations and asserts no trap.
+- `tests/issue-1175.test.ts` continues to pass (the fix here must
+  not regress the original #1175 fix).
+- The competitive benchmark JSON shows `string-hash` lane
+  `status: ok` for js2wasm-wasmtime.
+
+## Key files
+
+- `src/codegen/string-ops.ts` — primary suspect (string concat
+  lowering)
+- `src/codegen/expressions.ts` — binary `+=` operand classification
+- `src/codegen/peephole.ts` — if the fix needs tail-call rewriting,
+  the peephole pass might need to learn the new pattern
+
+## Notes
+
+- The original #1175 was filed after this benchmark surfaced a
+  wasm-validator error (`call param types must match` on
+  `__str_flatten` and `concat`). The fix that landed for #1175 was
+  correct as far as type-coercion is concerned; the stack-overflow
+  is a separate failure mode hiding behind the validator error.
+- The competitive benchmark harness on the private `labs/` repo is
+  what surfaces this; the open-source test suite doesn't exercise
+  high-iteration string concat in a way that reaches the threshold.

--- a/plan/issues/sprints/45/1179.md
+++ b/plan/issues/sprints/45/1179.md
@@ -1,0 +1,197 @@
+---
+id: 1179
+title: "Improve js2wasm `array-sum` hot-runtime perf — currently ~9× slower than Node and behind Javy"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: arrays
+goal: performance
+origin: surfaced by competitive-benchmark refresh after #1173/#1174/#1175 landed (2026-04-27)
+---
+
+# #1179 — `array-sum` hot-runtime is ~9× slower than Node and ~14% slower than Javy
+
+## Problem
+
+After the #1173 fix landed, the `array-sum` competitive benchmark now
+runs end-to-end on js2wasm. The first verified hot-runtime numbers
+(wasmtime 44.0.0, aarch64-linux, median of 5 runs):
+
+| Lane | Hot ms | Compute-only ms |
+| --- | ---: | ---: |
+| Node.js | **17.0** | 12.9 |
+| Javy (Shopify dynamic) → Wasmtime | **134.9** | 104.9 |
+| StarlingMonkey + Componentize (Wizer + Weval) → Wasmtime | 155.9 | 124.2 |
+| **js2wasm → Wasmtime** | **155.8** | 125.4 |
+
+js2wasm is ~9.2× slower than Node on this workload, and ~14% slower
+than Javy's QuickJS bytecode-interpretation lane. Javy edging out
+js2wasm is unexpected — interpreting QuickJS bytecode in Wasm should
+not beat compiled WasmGC array writes for a tight numeric loop.
+
+For comparison, on the *same harness*, js2wasm decisively wins the
+other numeric workloads (`fib` ~77× faster than Javy, `fib-recursive`
+~10× faster, `object-ops` ~14× faster). `array-sum` is the outlier.
+
+## Reproduction
+
+Source program (`labs/benchmarks/competitive/programs/array-sum.js`):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const values = [];
+  for (let i = 0; i < n; i++) {
+    values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+  }
+
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum = (sum + values[i]) | 0;
+  }
+  return sum | 0;
+}
+```
+
+Run via the competitive harness on the labs repo:
+
+```bash
+cd /workspace
+export PATH="$HOME/.local/bin:$PWD/node_modules/.bin:$PATH"
+export STARLINGMONKEY_ADAPTER="$PWD/labs/benchmarks/competitive/sm-componentize-adapter.mjs"
+BENCHMARK_FILTER=array-sum node --experimental-strip-types labs/benchmarks/compare-runtimes.ts
+```
+
+`runtimeArg = 1_000_000` (1M-element array fill + sum), median of 5
+fresh-process runs.
+
+## Root cause hypothesis
+
+The hot loop is two distinct phases:
+
+1. **Fill loop** — `values[i] = ((i * 17) ^ (i >>> 3)) & 1023;`
+   1M iterations of pure i32 arithmetic followed by an indexed array
+   store on a dense array.
+2. **Sum loop** — `sum = (sum + values[i]) | 0;`
+   1M indexed array reads followed by i32 addition.
+
+Likely culprits, in priority order:
+
+- **Per-store overhead in WasmGC array codegen.** Each `values[i] =
+  …` may emit a `array.set` plus a bounds check plus a type tag check
+  on the array element. If the element is an `eqref` / `anyref` /
+  boxed `f64` rather than a direct `i32`, every store boxes and
+  every load unboxes. The `|0`-coerced numeric inference (#1126)
+  should keep the array element domain in i32, but if the array's
+  declared element type is something like `(array (mut anyref))` or
+  `(array (mut f64))` the i32 narrowing happens per-access — that's
+  ~2M extra i32→f64→i32 round-trips per call.
+- **Dynamic-length growth path.** The program writes
+  `values[i] = …` for `i = 0..n-1` against an array initialized as
+  `const values = []`. If js2wasm doesn't pre-size the backing array
+  (and instead grows it incrementally via array-copy or per-write
+  capacity expansion), each store may pay an O(log n) amortized
+  growth cost — over 1M iterations that's billions of bytes copied
+  in aggregate.
+- **Bounds-check redundancy.** Both loops have `i < n` (fill) /
+  `i < values.length` (sum) where `i` and `n`/`length` could be
+  proven monotonically in-range. If the WasmGC array store/load emits
+  per-access bounds checks anyway (i.e. doesn't share the single
+  loop-condition check), that's one extra branch per iteration.
+
+Javy's QuickJS lane, by contrast, runs an indexed-property write on a
+QuickJS native dense-int-array fast path: a `JS_SetPropertyValue` that
+hits the int-indexed dense path with a sealed shape, which is a few
+C instructions per write. For a tight numeric loop with no shape
+changes, QuickJS's interpreter dispatch is small and the inner-loop
+work is a bare integer write — that explains why it's competitive
+with naive WasmGC array writes.
+
+## What "improve" looks like for this issue
+
+The goal is for js2wasm `array-sum` hot runtime to land in the same
+ballpark as Node (within ~2–3×) and to comfortably beat both JS-host
+approaches.
+
+Concrete sub-targets, any of which would be a meaningful improvement:
+
+- Hot runtime under 50 ms on this workload (~3× from current 155.8).
+- Hot runtime under 25 ms (~6×, matching Node within a small factor).
+- Compute-only time under 30 ms.
+
+## Investigation steps
+
+1. **Inspect the emitted Wasm.** Compile `array-sum.js` and run
+   `wasm-tools print` (or `wasm-objdump -d`) on the result. Identify
+   the array element type, the store/load opcode emitted, and whether
+   bounds checks appear per-iteration.
+
+2. **Measure where the time goes.** Profile the cwasm under wasmtime
+   with `--profile=guest` (samples Wasm-frame counts) or with
+   `perf` against a binary built for `--target=native` with
+   guest-profile output. Identify whether time is dominated by
+   `array.set` / `array.get`, by the arithmetic, or by GC overhead.
+
+3. **A/B test.**
+   - Pre-size the array: change the program (locally — not in the
+     committed benchmark) to `const values = new Array(n);` and
+     re-run. If hot runtime drops materially, the issue is array
+     growth.
+   - Use a typed array: `new Int32Array(n)` instead of a generic
+     `[]`. If hot runtime drops, the issue is element-type boxing.
+   - Inline the work: drop `values` entirely and compute
+     `sum += ((i * 17) ^ (i >>> 3)) & 1023;` directly in the same
+     loop. If that runs at fib-loop speeds (~17 ms), the issue is
+     all in array codegen.
+
+4. **Compare to existing fast-mode array benchmarks.** The benchmark
+   harnesses `benchmarks/arrays.bench.ts` and `arrays.ts` should have
+   numbers from the same compiler version. Cross-check whether the
+   competitive `array-sum` shape is in the existing test set; if not,
+   add one.
+
+## Acceptance criteria
+
+- A diagnostic exists for the root cause (one of: element-type
+  boxing, unsized growth, redundant bounds checks, or a fourth thing
+  we haven't anticipated).
+- A fix lands that brings js2wasm `array-sum` hot runtime to under
+  50 ms (≥3× faster than today) without regressing other lanes
+  (`fib`, `fib-recursive`, `object-ops` should stay at or under
+  current numbers).
+- A new `tests/issue-1179.test.ts` covers the array-sum shape and
+  asserts a hot-loop perf budget that the optimised codegen meets.
+- The competitive benchmark numbers update in
+  `labs/benchmarks/results/runtime-compare-latest.json` reflect the
+  improvement.
+
+## Key files
+
+- `src/codegen/expressions.ts` — array literal `[]`, indexed
+  store/load codegen
+- `src/codegen/index.ts` — type assignment for array element types,
+  WasmGC `array` type emission
+- `src/codegen/peephole.ts` — possible bounds-check elision pass
+- `src/codegen/type-coercion.ts` — i32 / f64 / anyref decision for
+  array elements
+- `labs/benchmarks/competitive/programs/array-sum.js` — canonical
+  reproducer (note: lives on the private `labs/` tree per the
+  `loopdive/js2wasm-labs` repo's `labs/` policy; the issue is
+  trackable via this public file)
+
+## Notes
+
+- This is a follow-up to the #1173 fix. The fix was correct (it
+  removed the wasm-validator translation error); the workload now
+  compiles and runs but exposes a perf gap the validator-only test
+  couldn't measure.
+- Related to #1126 (int32/uint32 inference) — this issue is whether
+  that inference reaches into array element types, not just into
+  function-local i32 domain decisions.
+- Related to #1120 (int32 fast path for bitwise-coerced loops) —
+  the `|0` coercions in `array-sum` should be hitting that path in
+  the arithmetic, but the array store/load is a separate question.

--- a/plan/issues/sprints/45/sprint.md
+++ b/plan/issues/sprints/45/sprint.md
@@ -32,6 +32,13 @@ Absorb the overflow from sprint 44. Headline themes:
      wasm-validator). All three are basic JS patterns (array fill, object
      literals, string concat) that crash js2wasm today and block the
      competitive-benchmark `js2wasm → Wasmtime` lane on 3 of 5 programs.
+   - **Follow-ups from the post-fix benchmark refresh (added 2026-04-27,
+     high priority):** #1178 (string-hash hits `wasm trap: call stack
+     exhausted` at runtime after #1175 — fix is correct as compile-time
+     type fix but introduces deep recursion at runtime), #1179 (array-sum
+     hot runtime is ~9× slower than Node and ~14% slower than Javy —
+     need to investigate WasmGC array element-type / bounds-check / growth
+     overhead).
 2. **CI baseline-drift hardening** — the 5-issue set (#1076, #1077, #1078,
    #1079, #1080) that was held back from sprint 44 because the IR work could
    not tolerate CI turbulence.
@@ -115,6 +122,8 @@ _Generated from issue frontmatter. Update issue `sprint` / `status`, then rerun 
 | #1169g | IR Phase 4 Slice 8 — destructuring and rest/spread through the IR path | high | ready |
 | #1169h | IR Phase 4 Slice 9 — try/catch/finally and throw through the IR path | high | ready |
 | #1169i | IR Phase 4 Slice 10 — remaining builtins (RegExp, TypedArray, DataView) through the IR path | high | ready |
+| #1178 | string-hash benchmark hits `wasm trap: call stack exhausted` at runtime after #1175 fix | high | ready |
+| #1179 | Improve js2wasm `array-sum` hot-runtime perf — currently ~9× slower than Node and behind Javy | high | ready |
 
 ### In Progress
 


### PR DESCRIPTION
## Summary

Two follow-up issues surfaced by the post-fix competitive-benchmark refresh after #1173/#1174/#1175 landed earlier today.

### #1178 — `string-hash` runtime stack-overflow regression

The fix for #1175 (`__str_flatten` / `concat` arg-type mismatch in string `+=` codegen) made `string-hash` *compile* successfully, but the resulting Wasm now traps at runtime with `wasm trap: call stack exhausted` when the inner loop runs with `runtimeArg = 20000` (≈ 60K string concatenations).

Backtrace shows a self-recursive call chain at the same offset for every frame — the new string-concat lowering likely uses recursion rather than iteration / tail calls. Below ~1K iterations it's fine; the regression only surfaces at higher iteration counts that the original issue-1175 unit test didn't cover.

### #1179 — `array-sum` hot-runtime perf gap

After the #1173 fix landed, `array-sum` runs end-to-end on js2wasm for the first time. First verified hot numbers (wasmtime 44.0.0, median of 5 runs):

| Lane | Hot ms |
|---|---:|
| Node.js | **17.0** |
| Javy (Shopify dynamic) → Wasmtime | 134.9 |
| StarlingMonkey + Wizer + Weval | 155.9 |
| **js2wasm → Wasmtime** | **155.8** |

js2wasm is ~9.2× slower than Node and ~14% slower than Javy on this workload. js2wasm decisively wins the other numeric workloads in the same run (`fib` ~77× faster than Javy, `fib-recursive` ~10×, `object-ops` ~14×) — `array-sum` is the outlier.

Suspected causes: WasmGC array element-type boxing (i32 vs eqref/anyref/f64), unsized array growth path on `const values = []` with indexed assignment, or redundant per-access bounds checks. Investigation plan + acceptance criteria are in the issue file (target: hot runtime under 50 ms; ideally under 25 ms / matching Node within a small factor).

## Files

- `plan/issues/sprints/45/1178.md` — string-hash runtime regression
- `plan/issues/sprints/45/1179.md` — array-sum perf investigation
- `plan/issues/sprints/45/sprint.md` — goal section reference + auto-regenerated issue table

No `src/`, no `tests/`, no `labs/` paths, no benchmark JSON. Purely planning artifacts on the public repo's `plan/` tree (which is where sprint planning lives).

## Coordination

The canonical reproducers (the `string-hash.js` and `array-sum.js` benchmark programs) now live at `labs/benchmarks/competitive/programs/` on the private `loopdive/js2wasm-labs` repo per the `labs/` restructure (also in flight today). The issue files are public so the work is trackable through the normal sprint flow; the labs-side benchmark harness is what surfaced the bugs.

## Test plan

- [x] Both issue files have the four required sections: Problem, Reproduction, Root cause hypothesis, Acceptance criteria
- [x] Sprint table regenerated cleanly via `node scripts/sync-sprint-issue-tables.mjs` — both issues in Ready at `high` priority
- [x] No `src/` or `tests/` changes
- [x] Hook check passes for `origin` (no labs/ paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)