### PR TITLE
chore(sprint-45): file #1180 — env::__unbox_number host import leaks on --target wasi

### DIFF
--- a/plan/issues/sprints/45/1180.md
+++ b/plan/issues/sprints/45/1180.md
@@ -1,0 +1,216 @@
+---
+id: 1180
+title: "js2wasm emits `env::__unbox_number` (and sibling box/unbox helpers) host imports on `--target wasi` builds"
+sprint: 45
+status: ready
+priority: high
+feasibility: medium
+reasoning_effort: high
+created: 2026-04-27
+updated: 2026-04-27
+task_type: bugfix
+area: codegen
+language_feature: number-boxing
+goal: compilable
+es_edition: n/a
+origin: surfaced as follow-up to #1173 during benchmark verification (2026-04-27)
+related: [1174, 1131, 1120, 1121]
+---
+
+# #1180 — `env::__unbox_number` and sibling boxing helpers leak as host imports on `--target wasi`
+
+## Problem
+
+After #1173 fixed the wasm-opt exact-ref injection on `--target wasi`, the
+`array-sum` competitive-benchmark lane still cannot reach `status: ok`
+because the wasi binary emits a `env::__unbox_number` host import that
+wasmtime cannot satisfy:
+
+```
+Error: failed to run main module `array-sum-1173-opt.wasm`
+
+Caused by:
+    0: failed to instantiate "array-sum-1173-opt.wasm"
+    1: unknown import: `env::__unbox_number` has not been defined
+```
+
+The `benchmarks/compare-runtimes.ts` harness explicitly checks
+`compileResult.imports` for non-WASI imports and bails with
+`status: 'blocked'` if any are present (the `nonWasiImports` block around
+line 1522). So the lane is currently `blocked` rather than `ok`, even
+though the exact-ref bug is fixed.
+
+This is a sister issue to **#1174** (`string_constants` host import on
+wasi) — same pattern (an `env::*` host import surviving the wasi pivot),
+different trigger (number boxing, not object-literal property keys).
+
+## Reproduction
+
+Source (the array-sum benchmark wrapped with the harness's `_hot` helper —
+this is how `createCompileSource` in `benchmarks/compare-runtimes.ts:272`
+shapes user code before compiling):
+
+```js
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const values = [];
+  for (let i = 0; i < n; i++) {
+    values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+  }
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum = (sum + values[i]) | 0;
+  }
+  return sum | 0;
+}
+
+export function run_hot(iterations, input) {
+  let result = run(input);
+  for (let i = 0; i < iterations; i++) {
+    result = run(input);
+  }
+  return result;
+}
+```
+
+Compile path:
+
+```ts
+const result = compile(source, {
+  fileName: 'array-sum.js',
+  allowJs: true,
+  target: 'wasi',
+});
+// success: true
+// result.imports:
+//   [{ module: 'env', name: '__unbox_number', kind: 'func',
+//      intent: { type: 'unbox', targetType: 'number' } }]
+```
+
+The `run` function alone (no `_hot` wrapper) compiles with `imports: []`
+— the leak happens specifically because `run_hot` has untyped JS
+parameters (`iterations`, `input`), which default to `externref`, and
+the call `run(input)` inside the loop has to unbox the externref to f64
+to match `run`'s typed signature.
+
+## Root cause hypothesis
+
+`src/codegen/index.ts:4268-4273` adds `env::__unbox_number` (and its
+siblings `__box_number`, `__unbox_boolean`, `__box_boolean`, `__typeof`,
+`__is_truthy`, `__typeof_function`) **unconditionally** to every module:
+
+```ts
+// __unbox_number: (externref) → f64
+const unboxNumType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "f64" }]);
+addImport(ctx, "env", "__unbox_number", {
+  kind: "func",
+  typeIdx: unboxNumType,
+});
+```
+
+None of these are gated on `ctx.wasi`. When codegen needs to coerce
+externref → f64 (typically at a typed-function call site receiving an
+untyped argument), it emits `call $__unbox_number`. Under
+`--target wasi`, the import is unsatisfiable.
+
+`__box_number` is doubly relevant — it would similarly leak as soon as
+any function returning f64 is stored into an externref slot.
+
+## Suggested fix
+
+Two complementary directions, either (a) is sufficient for this issue,
+but (b) is the durable architectural fix:
+
+**(a) Inline Wasm-native impls of the box/unbox helpers when
+`ctx.nativeStrings` (or `ctx.wasi`) is true.** The same pattern #679
+(strings) and #682 (RegExp) and #1174 (string_constants) used:
+
+- Replace the `addImport(ctx, "env", "__unbox_number", …)` call with
+  emission of a synthetic Wasm function `(func $__unbox_number
+  (param externref) (result f64) …)`.
+- Body uses the existing FlatNumber struct (or whatever the native
+  boxed-number representation is) — `extern.convert_any`, `ref.cast`
+  to the boxed-number struct type, `struct.get $value`. NaN + bool
+  fast paths as needed.
+- Same treatment for `__box_number`, `__unbox_boolean`, `__box_boolean`,
+  `__typeof`, `__is_truthy`, `__typeof_function`.
+
+**(b) Tighten parameter-type inference so that `run_hot(iterations,
+input)` is recognized as `(f64, f64) -> f64` from the typed callee
+`run(n: number)`.** This eliminates the unbox at the call site
+entirely. Issue **#1131** (middle-end SSA IR) and **#1120/#1121**
+(int32 loop numeric inference) are already moving in this direction;
+this issue would be mostly subsumed once they fully land. Until then
+(a) is the fast unblock.
+
+The harness check (`benchmarks/compare-runtimes.ts` line 1522) flags
+**any** non-WASI import as `blocked`, so even one leaked helper is
+fatal. The fix needs to clear the *full set* of `env::*` boxing helpers,
+not just `__unbox_number`.
+
+## Scope of impact
+
+Any `--target wasi` program that crosses the typed-function boundary
+with an untyped/externref-shaped value — which is essentially every
+non-trivial JS program. Without this fix, the standalone-Wasm story
+remains broken for any program that:
+
+- Has untyped function parameters (`function f(x) { … }`)
+- Stores f64 results into externref containers (any `any`/untyped slot)
+- Uses `typeof` on an untyped value
+- Uses truthiness checks on an untyped value (`if (x)` where `x: any`)
+
+Pairs with #1174 to close out the broader "host imports on wasi" gap
+that the #1125 benchmark surfaced.
+
+## Acceptance criteria
+
+- The `run_hot` wrapper above compiles with `target: 'wasi'` and
+  `compileResult.imports` is empty (or contains only WASI-prefixed
+  imports).
+- `array-sum` benchmark lane reaches `js2wasm-wasmtime: status: ok` in
+  `benchmarks/results/runtime-compare-latest.json` (joining `fib` /
+  `fib-recursive` / and the post-#1174 `object-ops`).
+- A new `tests/issue-1180.test.ts` covers each of the leaked helpers:
+  - `__unbox_number` (call site: typed callee receiving externref arg)
+  - `__box_number` (call site: f64 result stored into externref slot)
+  - `__unbox_boolean` (call site: typed boolean param receiving externref)
+  - `__box_boolean` (call site: i32 bool stored into externref slot)
+  - `__typeof` (call site: `typeof x` where `x: any`)
+  - `__is_truthy` (call site: `if (x)` where `x: any`)
+  - For each shape, assert `result.imports` contains no `env::*` entry
+    under `--target wasi`.
+- No regression on the JS-host-mode (default `--target gc`) paths —
+  the host imports stay as the fast path when a JS host is present.
+
+## Key files
+
+- `src/codegen/index.ts:4250-4310` — the `env::*` import block that
+  needs to switch to Wasm-native emission under `ctx.nativeStrings` /
+  `ctx.wasi`
+- `src/codegen/type-coercion.ts` — current callers of `__unbox_number`
+  / `__box_number` (the coerce paths that emit the `call` instruction)
+- `src/codegen/binary-ops.ts` — multiple call sites for `__unbox_number`
+  in arithmetic coercion (lines 240, 825, 848, 1168, 1355, 1411, 1443,
+  …) — none need to change if the import is replaced by an inlined
+  function with the same name + signature
+- `src/runtime.ts` — current JS-host implementations of these helpers,
+  which can stay as the JS-host-mode fast path
+- `benchmarks/compare-runtimes.ts:1522` — the `nonWasiImports` gate
+  that turns leaked imports into `status: blocked`
+
+## Related work
+
+- **#1174** — same pattern for `string_constants` host import on wasi
+  (in-progress; provides the template for inlining helpers behind a
+  `nativeStrings` / `wasi` gate)
+- **#1173** — exact-ref types fix; cleared the wasm-opt blocker but
+  exposed this leftover `env::*` import as the next layer
+- **#679** — dual string backend (host import vs Wasm-native);
+  established the dual-mode pattern
+- **#682** — dual RegExp backend; another dual-mode example
+- **#1131** — middle-end SSA IR; would mostly subsume the need for
+  unbox helpers at this call site once parameter-type inference flows
+  through `_hot`-style wrappers
+- **#1120 / #1121** — int32 loop numeric inference; partial coverage
+  for a similar pattern


### PR DESCRIPTION
## Summary

Files **#1180** — a follow-up surfaced during #1173 verification. The `array-sum` competitive-benchmark lane still cannot reach `js2wasm-wasmtime: status: ok` because the wasi binary emits an `env::__unbox_number` host import that wasmtime cannot satisfy. Same pattern as #1174 (`string_constants` host import on wasi), different trigger (number boxing, not object-literal property keys).

The leak is triggered whenever a typed callee receives an untyped/externref-shaped arg — the harness's `_hot(iterations, input)` wrapper is the canonical example, but the issue applies to any program that crosses the typed-function boundary with an untyped value (untyped function params, `any`-typed slots, `typeof x` on `any`, truthiness checks on `any`).

`src/codegen/index.ts:4268-4273` adds `env::__unbox_number` (and siblings `__box_number`, `__unbox_boolean`, `__box_boolean`, `__typeof`, `__is_truthy`, `__typeof_function`) **unconditionally** to every module — none are gated on `ctx.wasi` / `ctx.nativeStrings`. The harness check at `benchmarks/compare-runtimes.ts:1522` flags any non-WASI import as `blocked`, so even one leaked helper is fatal.

Suggested fix paths in the issue file:
- **(a) Inline Wasm-native impls** of the `env::*` boxing helpers when `nativeStrings` / `wasi` is on (the #679/#682/#1174 pattern). Fast unblock.
- **(b) Tighten parameter-type inference** so the unbox is elided at the call site entirely. (#1131 / #1120 / #1121 territory; mostly subsumes (a) once it lands.)

This PR only files the issue — no source changes.

## Test plan

- [x] No source changes, planning artifact only — no tests required
- [x] Issue file follows #1174's structure (sister issue, same root pattern)
- [x] Acceptance criteria, key files, related work, and reproduction script all included
- [ ] CI quality + cla checks (planning-only PR — no test262 impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)