### PR TITLE
fix(codegen): emit Wasm-native box/unbox/typeof helpers under --target wasi (#1180)

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4246,6 +4246,17 @@ export function addUnionImports(ctx: CodegenContext): void {
   if (ctx.hasUnionImports) return;
   ctx.hasUnionImports = true;
 
+  // Under `--target wasi` (#1180): emit Wasm-native implementations of the
+  // box / unbox / typeof / is_truthy helpers instead of `env::*` host
+  // imports, since wasmtime cannot satisfy the env::* imports without a JS
+  // host. The native impls preserve the same name + signature so existing
+  // call sites (`ctx.funcMap.get("__unbox_number")` etc.) work unchanged.
+  // Same dual-mode pattern as #679 (strings) and #682 (RegExp).
+  if (ctx.wasi) {
+    addUnionImportsAsNativeFuncs(ctx);
+    return;
+  }
+
   // Record the import count before adding, so we can adjust defined-function
   // indices if imports are added after collectDeclarations has run.
   const importsBefore = ctx.numImportFuncs;
@@ -4411,6 +4422,345 @@ export function addUnionImports(ctx: CodegenContext): void {
       ctx.mod.startFuncIdx += delta;
     }
   }
+}
+
+/**
+ * Wasm-native implementation of the union helper functions (#1180).
+ *
+ * Used under `--target wasi`, where the standard `env::*` host imports
+ * cannot be satisfied by wasmtime. Instead of importing the helpers, we
+ * register a small set of WasmGC struct types (`__box_number_struct`,
+ * `__box_boolean_struct`) plus a synthesized function for each helper
+ * with the SAME name and signature as the host-mode import. Existing
+ * call sites that look helpers up via `ctx.funcMap.get("__unbox_number")`
+ * etc. transparently call the native version.
+ *
+ * Semantics mirror the JS host runtime where possible:
+ *   - `__box_number(f64)` wraps the value in a `__box_number_struct` and
+ *     converts to externref via `extern.convert_any`.
+ *   - `__unbox_number(externref)` returns 0 for null (matches `Number(null)`),
+ *     extracts the value if the externref is a `__box_number_struct`,
+ *     otherwise returns `NaN` (matches `Number(opaque host value)`).
+ *   - `__box_boolean(i32)` / `__unbox_boolean(externref)` mirror the
+ *     number variants with an `i32` payload.
+ *   - `__is_truthy(externref)` returns 0 for null and for boxed-zero /
+ *     boxed-NaN / boxed-false; returns 1 for any other ref (any non-null
+ *     reference is truthy in JS).
+ *   - `__typeof_number/string/boolean(externref)` use `ref.test` against
+ *     the appropriate boxed struct (string under wasi/nativeStrings is
+ *     the NativeString struct at `ctx.anyStrTypeIdx`).
+ *   - `__typeof_undefined(externref)` is `ref.is_null`.
+ *   - `__typeof_object/function(externref)` are conservatively 0 — wasi
+ *     binaries don't have a JS-side function or generic object value to
+ *     surface here.
+ *   - `__typeof(externref)` returns null externref. Producing a real
+ *     type-tag string under nativeStrings would require constructing a
+ *     NativeString per tag, which is deferred until a wasi caller
+ *     actually needs the result of `typeof v` as a string. Today's
+ *     callers either pre-fold the typeof at the AST level or compare
+ *     against a string literal (which uses `__typeof_*` instead).
+ *
+ * Why a struct-based box rather than letting the externref carry a raw
+ * f64: externref is opaque at the Wasm level — there's no way to read a
+ * payload back out without going through the WasmGC any.* / ref.cast
+ * machinery against a registered struct type. The struct gives us a
+ * stable shape the unbox helper can pattern-match against, and the
+ * `extern.convert_any` / `any.convert_extern` round-trip is a no-op at
+ * the Wasm engine level.
+ */
+function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
+  // 1. Register the boxed-value struct types. Both are immutable singletons.
+  const boxNumStructIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "__box_number_struct",
+    fields: [{ name: "value", type: { kind: "f64" }, mutable: false }],
+  });
+
+  const boxBoolStructIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "__box_boolean_struct",
+    fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
+  });
+
+  // 2. Pre-compute func types — addFuncType de-dupes by signature so
+  //    repeated calls return the same typeIdx.
+  const externrefToI32 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
+  const externrefToF64 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "f64" }]);
+  const f64ToExternref = addFuncType(ctx, [{ kind: "f64" }], [{ kind: "externref" }]);
+  const i32ToExternref = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "externref" }]);
+  const externrefToExternref = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
+
+  /**
+   * Synthesize a native helper function. The funcIdx is allocated as
+   * `numImportFuncs + mod.functions.length` to match how every other
+   * synthesized function (e.g. `__toUint32` from #1094) gets its slot.
+   */
+  const registerNative = (
+    name: string,
+    typeIdx: number,
+    body: Instr[],
+    locals: { name: string; type: ValType }[] = [],
+  ): void => {
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.funcMap.set(name, funcIdx);
+    ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false });
+  };
+
+  // 3. __box_number(f64) -> externref
+  registerNative("__box_number", f64ToExternref, [
+    { op: "local.get", index: 0 },
+    { op: "struct.new", typeIdx: boxNumStructIdx },
+    { op: "extern.convert_any" } as unknown as Instr,
+  ]);
+
+  // 4. __unbox_number(externref) -> f64
+  //    Local 1 is an anyref temp used to ref.test then ref.cast without
+  //    re-evaluating the parameter (which is fine — it's a local.get —
+  //    but the temp shape mirrors the spec'd structure for symmetry).
+  registerNative(
+    "__unbox_number",
+    externrefToF64,
+    [
+      // if (ref.is_null param) return 0   // Number(null) === 0
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "f64.const", value: 0 }, { op: "return" }],
+      },
+      // any = any.convert_extern(param)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as unknown as Instr,
+      { op: "local.tee", index: 1 },
+      // if (ref.test $box_number_struct any) return any.value
+      { op: "ref.test", typeIdx: boxNumStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxNumStructIdx } as unknown as Instr,
+          { op: "struct.get", typeIdx: boxNumStructIdx, fieldIdx: 0 },
+          { op: "return" },
+        ],
+      },
+      // not a recognized boxed number → NaN (matches Number(opaque))
+      { op: "f64.const", value: NaN },
+    ],
+    [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+  );
+
+  // 5. __box_boolean(i32) -> externref
+  registerNative("__box_boolean", i32ToExternref, [
+    { op: "local.get", index: 0 },
+    { op: "struct.new", typeIdx: boxBoolStructIdx },
+    { op: "extern.convert_any" } as unknown as Instr,
+  ]);
+
+  // 6. __unbox_boolean(externref) -> i32
+  //    Returns the boxed value if it's a __box_boolean_struct, otherwise
+  //    falls back to Boolean-coercion: null → false, any non-null ref
+  //    that isn't a boxed bool → ALSO false (under wasi we don't
+  //    distinguish other truthy refs at the unbox level; the runtime
+  //    fallback in `helpers.ts` does `v ? 1 : 0` which would say true,
+  //    but for unbox-as-typed-call-arg the safe default is false).
+  //    Boxed numbers go through __unbox_number first, then truthy-check.
+  registerNative(
+    "__unbox_boolean",
+    externrefToI32,
+    [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as unknown as Instr,
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxBoolStructIdx } as unknown as Instr,
+          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+          { op: "return" },
+        ],
+      },
+      // not a boxed bool → false (conservative under wasi)
+      { op: "i32.const", value: 0 },
+    ],
+    [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+  );
+
+  // 7. __is_truthy(externref) -> i32
+  //    null → 0; boxed number → value !== 0 && !NaN; boxed bool → value;
+  //    anything else (other refs) → 1 (any non-null ref is truthy in JS).
+  registerNative(
+    "__is_truthy",
+    externrefToI32,
+    [
+      // if (ref.is_null param) return 0
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      // any = any.convert_extern(param)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as unknown as Instr,
+      { op: "local.tee", index: 1 },
+      // boxed number? → value !== 0 && value === value
+      { op: "ref.test", typeIdx: boxNumStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxNumStructIdx } as unknown as Instr,
+          { op: "struct.get", typeIdx: boxNumStructIdx, fieldIdx: 0 },
+          { op: "local.tee", index: 2 },
+          // value !== 0
+          { op: "f64.const", value: 0 },
+          { op: "f64.ne" },
+          { op: "local.get", index: 2 },
+          // value === value (NaN check — NaN !== NaN)
+          { op: "local.get", index: 2 },
+          { op: "f64.eq" },
+          { op: "i32.and" },
+          { op: "return" },
+        ],
+      },
+      // boxed bool? → value
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxBoolStructIdx } as unknown as Instr,
+          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+          { op: "return" },
+        ],
+      },
+      // any other non-null ref → truthy
+      { op: "i32.const", value: 1 },
+    ],
+    [
+      { name: "$any_temp", type: { kind: "anyref" } as ValType },
+      { name: "$f64_temp", type: { kind: "f64" } },
+    ],
+  );
+
+  // 8. __typeof_number(externref) -> i32 — `ref.test $box_number_struct`.
+  registerNative("__typeof_number", externrefToI32, [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as unknown as Instr,
+    { op: "ref.test", typeIdx: boxNumStructIdx },
+  ]);
+
+  // 9. __typeof_boolean(externref) -> i32 — `ref.test $box_boolean_struct`.
+  registerNative("__typeof_boolean", externrefToI32, [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as unknown as Instr,
+    { op: "ref.test", typeIdx: boxBoolStructIdx },
+  ]);
+
+  // 10. __typeof_string(externref) -> i32. Under nativeStrings (auto-on
+  //     for wasi) strings are NativeString structs at `ctx.anyStrTypeIdx`.
+  //     If that type isn't registered, return 0 (no string in scope).
+  if (ctx.anyStrTypeIdx >= 0) {
+    const strTypeIdx = ctx.anyStrTypeIdx;
+    registerNative("__typeof_string", externrefToI32, [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as unknown as Instr,
+      { op: "ref.test", typeIdx: strTypeIdx },
+    ]);
+  } else {
+    registerNative("__typeof_string", externrefToI32, [{ op: "i32.const", value: 0 }]);
+  }
+
+  // 11. __typeof_undefined(externref) -> i32 — `ref.is_null`.
+  registerNative("__typeof_undefined", externrefToI32, [{ op: "local.get", index: 0 }, { op: "ref.is_null" }]);
+
+  // 12. __typeof_object(externref) -> i32 — non-null AND not number AND
+  //     not boolean AND not function. We approximate as "non-null and
+  //     not a boxed primitive" — sufficient for the common typeof
+  //     dispatch use cases. Returns 0 conservatively for boxed numbers
+  //     and boxed booleans.
+  registerNative(
+    "__typeof_object",
+    externrefToI32,
+    [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as unknown as Instr,
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: boxNumStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      // non-null, not a boxed primitive → object
+      { op: "i32.const", value: 1 },
+    ],
+    [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+  );
+
+  // 13. __typeof_function(externref) -> i32 — wasi binaries don't expose
+  //     callable JS functions to the outside, so this is conservatively 0.
+  registerNative("__typeof_function", externrefToI32, [{ op: "i32.const", value: 0 }]);
+
+  // 14. __typeof(externref) -> externref — returns null externref under
+  //     wasi. Producing real type-tag strings would require a NativeString
+  //     per tag; defer until a wasi caller needs the typeof RESULT as a
+  //     string (today's callers compare against literal tags via the
+  //     __typeof_* helpers above).
+  registerNative("__typeof", externrefToExternref, [{ op: "ref.null.extern" } as unknown as Instr]);
 }
 
 /**

--- a/tests/issue-1180.test.ts
+++ b/tests/issue-1180.test.ts
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1180 — `env::__unbox_number` and sibling boxing helpers leak as host
+// imports on `--target wasi`.
+//
+// Regression suite: every helper that the legacy host-mode path imports
+// from `env::*` (box/unbox/typeof/is_truthy) MUST NOT appear as an
+// `env::*` import when compiling under `--target wasi`. The fix
+// (`addUnionImportsAsNativeFuncs` in `src/codegen/index.ts`) emits
+// Wasm-native implementations using a pair of WasmGC structs
+// (`__box_number_struct`, `__box_boolean_struct`).
+//
+// Each test case picks a source that exercises the helper at codegen time
+// (forces it into `funcMap`) and asserts:
+//   1. Compilation succeeds.
+//   2. `result.imports` contains no `env::*` entries.
+//   3. The Wasm binary validates and instantiates with no imports object.
+//
+// JS-host-mode (default `--target gc`) is verified separately in the
+// "host mode unchanged" suite — under host mode the imports SHOULD still
+// appear (they're the fast path when a JS host is present).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+interface CompileResultMinimal {
+  success: boolean;
+  imports: { module: string; name: string }[];
+  binary: Uint8Array;
+  errors: { message: string }[];
+}
+
+function compileWasi(source: string): CompileResultMinimal {
+  return compile(source, { fileName: "test.js", allowJs: true, target: "wasi" });
+}
+
+function envImports(result: CompileResultMinimal): string[] {
+  return result.imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+async function instantiateNoImports(binary: Uint8Array): Promise<WebAssembly.Instance> {
+  const m = await WebAssembly.compile(binary);
+  return await WebAssembly.instantiate(m, {});
+}
+
+describe("#1180 — boxing helpers do not leak as env::* imports under --target wasi", () => {
+  // Each case shapes the source so the legacy codegen path on host mode
+  // would call into the corresponding `env::__*` helper. Under wasi mode
+  // we expect ZERO env imports.
+
+  it("__unbox_number — typed callee receiving externref arg", () => {
+    // Untyped param `x` defaults to externref under JS-frontend semantics.
+    // The call `inner(x)` to a typed callee unboxes externref → f64.
+    const source = `
+      /** @param {number} n @returns {number} */
+      function inner(n) { return n + 1; }
+      export function outer(x) { return inner(x); }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+
+  it("__box_number — f64 result stored into externref slot", () => {
+    // `arr` defaults to externref; `arr[i] = f64` boxes the f64 to fit
+    // the externref element slot.
+    const source = `
+      export function pack(n) {
+        const arr = [];
+        for (let i = 0; i < (n | 0); i++) {
+          arr[i] = i * 2;
+        }
+        return arr;
+      }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+
+  it("__unbox_boolean — typed boolean callee receiving externref", () => {
+    const source = `
+      /** @param {boolean} b @returns {number} */
+      function take(b) { return b ? 1 : 0; }
+      export function f(x) { return take(x); }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+
+  it("__is_truthy — if(externref)", () => {
+    const source = `
+      export function f(x) {
+        if (x) return 1;
+        return 0;
+      }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+
+  it("__typeof_* — typeof comparisons against literal tags", () => {
+    const source = `
+      export function f(x) {
+        if (typeof x === "number") return 1;
+        if (typeof x === "boolean") return 2;
+        if (typeof x === "string") return 3;
+        if (typeof x === "undefined") return 4;
+        return 0;
+      }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+
+  it("array-sum bench shape — the original repro from #1180", () => {
+    // The exact source the benchmark harness produces (createCompileSource
+    // in benchmarks/compare-runtimes.ts) when wrapping array-sum.js.
+    const source = `
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const values = [];
+  for (let i = 0; i < n; i++) {
+    values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+  }
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum = (sum + values[i]) | 0;
+  }
+  return sum | 0;
+}
+
+export function run_hot(iterations, input) {
+  let result = run(input);
+  for (let i = 0; i < iterations; i++) {
+    result = run(input);
+  }
+  return result;
+}
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r)).toEqual([]);
+  });
+});
+
+describe("#1180 — wasi binaries validate and instantiate without an imports object", () => {
+  it("array-sum bench shape — instantiates and run(n) returns the correct sum", async () => {
+    const source = `
+/** @param {number} n @returns {number} */
+export function run(n) {
+  const values = [];
+  for (let i = 0; i < n; i++) {
+    values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+  }
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum = (sum + values[i]) | 0;
+  }
+  return sum | 0;
+}
+
+export function run_hot(iterations, input) {
+  let result = run(input);
+  for (let i = 0; i < iterations; i++) {
+    result = run(input);
+  }
+  return result;
+}
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const instance = await instantiateNoImports(r.binary);
+    const run = instance.exports.run as (n: number) => number;
+    // Pure-JS reference: ((i * 17) ^ (i >>> 3)) & 1023, summed for i=0..n-1
+    let expected = 0;
+    for (let i = 0; i < 50; i++) {
+      expected = (expected + (((i * 17) ^ (i >>> 3)) & 1023)) | 0;
+    }
+    expect(run(50)).toBe(expected);
+  });
+
+  it("__unbox_number(null) — Number(null) === 0", async () => {
+    // run_hot(null, null) inside wasi: __unbox_number(null) returns 0
+    // (matches `Number(null)`), so run(0) returns 0.
+    const source = `
+      /** @param {number} n @returns {number} */
+      export function run(n) {
+        let s = 0;
+        for (let i = 0; i < n; i++) s = (s + i) | 0;
+        return s | 0;
+      }
+      export function run_hot(iterations, input) {
+        let result = run(input);
+        for (let i = 0; i < iterations; i++) {
+          result = run(input);
+        }
+        return result;
+      }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    const instance = await instantiateNoImports(r.binary);
+    const runHot = instance.exports.run_hot as (a: unknown, b: unknown) => number;
+    // null externref input → __unbox_number returns 0 → run(0) returns 0.
+    expect(runHot(null, null)).toBe(0);
+  });
+
+  it("typed `run(n: number)` direct call works under wasi", async () => {
+    const source = `
+      /** @param {number} n @returns {number} */
+      export function run(n) {
+        let s = 0;
+        for (let i = 0; i < n; i++) s = (s + i) | 0;
+        return s | 0;
+      }
+    `;
+    const r = compileWasi(source);
+    expect(r.success).toBe(true);
+    const instance = await instantiateNoImports(r.binary);
+    const run = instance.exports.run as (n: number) => number;
+    expect(run(10)).toBe(45); // 0+1+2+...+9
+    expect(run(0)).toBe(0);
+    expect(run(1)).toBe(0);
+  });
+});
+
+describe("#1180 — host mode (default --target gc) still uses env::* imports as the fast path", () => {
+  // Ensure the dual-mode pattern is preserved: under JS-host mode the
+  // helpers come from `env::*` (where the host has fast native impls);
+  // only wasi mode uses the Wasm-native fallback.
+
+  it("host mode keeps env::__is_truthy import for if(externref)", () => {
+    const source = `
+      export function f(x) {
+        if (x) return 1;
+        return 0;
+      }
+    `;
+    const r = compile(source); // no target → host gc mode
+    expect(r.success).toBe(true);
+    expect(envImports(r as CompileResultMinimal)).toContain("__is_truthy");
+  });
+
+  it("host mode keeps env::__typeof import for bare `typeof x`", () => {
+    const source = `
+      export function f(x) { return typeof x; }
+    `;
+    const r = compile(source);
+    expect(r.success).toBe(true);
+    expect(envImports(r as CompileResultMinimal)).toContain("__typeof");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1180. Same dual-mode pattern as #679 (strings) / #682 (RegExp) / #1174 (string_constants): under `--target wasi`, the union helper functions previously imported from `env::*` are now synthesized as Wasm-native functions, since wasmtime cannot satisfy the `env::*` imports without a JS host.

`addUnionImports` previously registered seven `env::*` host imports (`__unbox_number`, `__box_number`, `__unbox_boolean`, `__box_boolean`, `__is_truthy`, `__typeof_number/string/boolean/undefined/object/function`, `__typeof`) unconditionally. Under `--target wasi`, this caused `array-sum` and any other benchmark with untyped JS parameters to land in `status: blocked` per `benchmarks/compare-runtimes.ts:1514`.

The new `addUnionImportsAsNativeFuncs` registers two WasmGC structs (`__box_number_struct`, `__box_boolean_struct`) and emits a synthesized function for each helper with the same name + signature. Existing call sites that look helpers up via `ctx.funcMap.get("__unbox_number")` etc. transparently call the native version — no changes needed at any call site.

## Semantics

Match the JS-host runtime where possible:
- `__unbox_number(null) === 0` (matches `Number(null)`)
- `__unbox_number(opaque host externref) === NaN`
- `__is_truthy` handles boxed numbers (NaN/0 → false), boxed booleans, null, and any other ref (truthy)
- `__typeof` returns `(ref.null extern)` — generating real type-tag strings under nativeStrings would require constructing a NativeString per tag, deferred until a wasi caller actually needs the typeof RESULT as a string. Today's callers compare against literal tags via the `__typeof_*` helpers above (which DO work under wasi via `ref.test`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 300 IR + #1174 + #1175 tests pass
- [x] New `tests/issue-1180.test.ts` (11 cases) — covers each helper with import-leak check + instantiate-no-imports + invoke assertion
- [x] Original repro from #1180 (array-sum bench shape) compiles with `imports: []` and instantiates cleanly
- [x] `run_hot(null, null)` returns `0` (verifies `__unbox_number(null) === 0` semantics)
- [x] Host mode (default `--target gc`) keeps `env::*` imports as the fast path — no regression
- [ ] CI test262 net delta ≥ 0
- [ ] CI confirms wasi binary instantiates with empty imports object

## Pre-existing test failures (not introduced by this PR)

- `tests/equivalence/destructuring-initializer.test.ts` — 3 failures with `LinkError: __throw_type_error` (reproduces on `origin/main`)
- `tests/equivalence/array-inline-return.test.ts` — 1 failure (reproduces on `origin/main`)

## Pairs with

- #1174 — same pattern for `string_constants` host import (already merged)
- #1173 — exact-ref types fix; cleared the wasm-opt blocker, this PR clears the next layer
- #1131 — middle-end SSA IR; would mostly subsume the need for unbox helpers at this call site once parameter-type inference flows through `_hot`-style wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)