### PR TITLE
feat(ir): slice 6 part 3 — host iterator protocol through IR (#1182)

### DIFF
--- a/plan/issues/ready/1182.md
+++ b/plan/issues/ready/1182.md
@@ -1,0 +1,314 @@
+---
+id: 1182
+title: "IR Phase 4 Slice 6 part 3 — host iterator protocol through the IR (`iter.*` instrs, Map/Set/generator iteration)"
+sprint: 46
+status: ready
+priority: medium
+feasibility: hard
+reasoning_effort: max
+goal: compiler-architecture
+task_type: implementation
+area: codegen
+language_feature: compiler-internals
+depends_on: [1181]
+created: 2026-04-27
+origin: surfaced from #1169e foundation PR (#63) — slice 6 step C from the spec, deferred from #1181 (vec fast path)
+related: [1169e, 1181]
+---
+
+# #1182 — Slice 6 part 3: host iterator protocol through IR
+
+## Goal
+
+Land slice 6 step C (per the #1169e spec): host iterator protocol
+support for `for (const x of <iterable>)` where the iterable is
+anything other than a known WasmGC vec struct or a `string`-typed
+expression in native-strings mode. Covers `Map`, `Set`, generator
+objects, and user iterables with a `[Symbol.iterator]` method.
+
+Depends on #1181 (vec fast path) for the loop-body lowering machinery
+(slot bindings, statement-level dispatch, `for-of` selector
+acceptance). This issue adds the **iterator-protocol arm** of the
+strategy switch in `lowerForOfStatement` plus the `iter.*` IR nodes.
+
+## What this issue needs to land
+
+### 1. New `IrInstr` variants in `src/ir/nodes.ts`
+
+```ts
+export interface IrInstrIterNew extends IrInstrBase {
+  readonly kind: "iter.new";
+  readonly iterable: IrValueId;
+  readonly async: boolean;     // false for slice 6; true reserved for #1169f
+}
+
+export interface IrInstrIterNext extends IrInstrBase {
+  readonly kind: "iter.next";
+  readonly iter: IrValueId;
+}
+
+export interface IrInstrIterDone extends IrInstrBase {
+  readonly kind: "iter.done";
+  readonly result: IrValueId;
+}
+
+export interface IrInstrIterValue extends IrInstrBase {
+  readonly kind: "iter.value";
+  readonly result: IrValueId;
+}
+
+export interface IrInstrIterReturn extends IrInstrBase {
+  readonly kind: "iter.return";
+  readonly iter: IrValueId;
+}
+```
+
+Result types: `iter.new` / `iter.next` / `iter.value` produce
+`externref`; `iter.done` produces `i32`; `iter.return` is void.
+
+Update the `IrInstr` union, `collectIrUses`, `verify.ts`, the DCE
+pass (mark `iter.next` / `iter.return` side-effecting), and the
+inline-small operand-rewriter.
+
+### 2. Builder helpers in `src/ir/builder.ts`
+
+`emitIterNew`, `emitIterNext`, `emitIterDone`, `emitIterValue`,
+`emitIterReturn` — parallel structure to the slice-3
+`emitClosureNew` pattern.
+
+### 3. `lowerForOfIter` in `src/ir/from-ast.ts`
+
+A second arm of the `lowerForOfStatement` strategy switch. Mirrors
+the legacy `compileForOfIterator` (`src/codegen/statements/loops.ts:2334`):
+
+```ts
+function lowerForOfIter(
+  iterable: IrValueId,
+  loopVarName: string,
+  stmt: ts.ForOfStatement,
+  cx: LowerCtx,
+): void {
+  // Coerce iterable to externref (extern.convert_any if not already
+  // externref-typed; this depends on the `coerce` IR primitive being
+  // available — slice 6 might add a small `convert.to_externref`
+  // helper instr OR emit a raw.wasm shim).
+  const iterableExt = cx.builder.emitCoerceToExternref(iterable);
+
+  // Null guard — emit a raw.wasm `ref.is_null; if; throw` block.
+  emitNullGuardThrow(iterableExt, cx);
+
+  // iter = __iterator(iterableExt)
+  const iter = cx.builder.emitIterNew(iterableExt, /* async */ false);
+
+  // Allocate slots for cross-iteration state.
+  const iterSlot   = cx.builder.declareSlot("__forof_iter", { kind: "externref" });
+  const elemSlot   = cx.builder.declareSlot("__forof_elem", { kind: "externref" });
+  cx.builder.emitSlotWrite(iterSlot, iter);
+
+  // Bind loopVarName as a slot binding pointing to elemSlot.
+  // Body collected via collectBodyInstrs into a forof.iter declarative
+  // instr (parallel to forof.vec). The lowerer emits the
+  //   block { loop { iter.next; iter.done; br_if 1; iter.value; <body>; br 0 } }
+  // pattern documented in the spec.
+}
+```
+
+This needs a parallel **declarative** `forof.iter` IR instr (mirrors
+`forof.vec`). The lowerer emits the iterator-loop Wasm pattern from
+the spec:
+
+```wasm
+local.get $iter
+call $__iterator
+local.set $iter_slot
+block
+  loop
+    local.get $iter_slot
+    call $__iterator_next
+    local.tee $result
+    call $__iterator_done
+    br_if 1
+    local.get $result
+    call $__iterator_value
+    local.set $elem_slot
+    <body>
+    br 0
+  end
+end
+;; normal-exit close
+local.get $iter_slot
+call $__iterator_return
+```
+
+### 4. Lazy import wiring in `src/ir/integration.ts`
+
+Before phase 3 lowering, walk every IR function looking for any
+`iter.*` instr. If found, call the existing
+`addIteratorImports(ctx)` (`src/codegen/index.ts:4238`) so the
+resolver can map `__iterator` / `__iterator_next` / etc. to
+funcIdx values.
+
+```ts
+let needsIteratorImports = false;
+for (const b of built) {
+  for (const block of b.fn.blocks) {
+    for (const instr of block.instrs) {
+      if (instr.kind === "iter.new" || instr.kind === "iter.next" ||
+          instr.kind === "iter.done" || instr.kind === "iter.value" ||
+          instr.kind === "iter.return") {
+        needsIteratorImports = true;
+        break;
+      }
+    }
+    if (needsIteratorImports) break;
+  }
+  if (needsIteratorImports) break;
+}
+if (needsIteratorImports) addIteratorImports(ctx);
+```
+
+### 5. Strategy dispatch
+
+The `lowerForOfStatement` strategy chooser becomes:
+
+```ts
+function chooseForOfStrategy(iterableType: IrType, cx: LowerCtx): "vec" | "iter-host" {
+  // Vec: IrType.val with ref/ref_null typeIdx that resolves via
+  // resolver.resolveVec to a known vec struct.
+  if (iterableType.kind === "val") {
+    const vt = iterableType.val;
+    if (vt.kind === "ref" || vt.kind === "ref_null") {
+      const vec = cx.resolver?.resolveVec?.(vt);
+      if (vec) return "vec";
+    }
+  }
+  // Iter-host: anything else (objects, externrefs, etc.).
+  return "iter-host";
+}
+```
+
+The `cx.resolver` field doesn't yet exist on `LowerCtx`; it'll need
+to be threaded through from `lowerFunctionAstToIr` (currently the
+resolver is only available at the integration layer). Alternatively,
+the strategy decision can be deferred to lowering time via a
+`forof.dynamic` IR instr that the lowerer dispatches based on the
+runtime type — but that's heavier.
+
+## Out of scope
+
+- `for await` — slice 7 (#1169f).
+- Iterator-close on abrupt exit (`break` / `return` from a host
+  iterator loop) — slice 6 step E, depends on try/finally (#1169h).
+- String fast path (`__str_charAt` counter loop) — slice 6 step D
+  (separate follow-up if not bundled into this issue).
+
+## Acceptance criteria
+
+1. `planIrCompilation` claims a function in `tests/equivalence/`
+   whose body iterates a `Map` or `Set`.
+2. New equivalence-test cases in `tests/issue-1169e-iter.test.ts`:
+   - `for (const k of new Set([1, 2, 3])) { ... }`
+   - `for (const [k, v] of map.entries()) { ... }` (deferred to
+     slice 8 if destructuring-binding is required; otherwise use
+     `for (const entry of map.entries())`)
+3. No regressions in existing IR tests.
+4. CI test262 net delta ≥ 0; `language/statements/for-of/**` pass
+   count strictly increases for the iterator-protocol subset.
+
+## Sub-issue of
+
+\#1169 — IR Phase 4: full compiler migration
+
+---
+
+## Implementation Notes (senior-developer, 2026-04-27)
+
+### Why a `forof.iter` declarative instr (mirrors `forof.vec`)
+
+The five `iter.*` SSA-style nodes (`iter.new`, `iter.next`, `iter.done`,
+`iter.value`, `iter.return`) describe primitive iterator-protocol
+operations. By themselves they aren't enough: a `for-of` loop needs a
+loop header that re-runs `iter.next/done` every iteration, and the IR's
+basic-block machinery only models tail-shaped programs (no Wasm `loop`
+construct). The slice-6 design solved this for vec by adding a single
+declarative `forof.vec` instr the lowerer translates into the
+`block { loop { ... } }` Wasm pattern. We follow the same recipe with
+`forof.iter`: it carries the iterable SSA value, slot indices for the
+iterator/result/element externrefs, and the body instr buffer.
+
+The five `iter.*` SSA nodes are still emitted as standalone variants
+because the lowerer needs a way to represent the per-step host calls
+inside the loop, and because future slices (slice 7 — `for await`) want
+to share `iter.next/done/value` with a different loop driver. The
+spec's expected use is for the lowerer to expand `forof.iter` into a
+Wasm pattern that calls the iter.* implementations.
+
+### Strategy dispatch (no resolver thread-through)
+
+The spec's "thread the resolver through `LowerCtx`" suggestion is an
+invasive change. Slice 6 part 2 already lives with this gap by
+assuming every `(ref|ref_null)` is a vec — `inferVecElementValType`
+hardcodes `f64`. We extend the dispatch in `lowerForOfStatement`:
+
+  - `iterableT` is `(val) externref`     → iter-host
+  - `iterableT.kind === "class"`          → iter-host (coerce to externref)
+  - `iterableT.kind === "object"`         → iter-host (coerce; [Symbol.iterator] heaps)
+  - `iterableT` is `(val) ref|ref_null`  → vec path (existing behavior)
+  - else                                  → throw (fall back to legacy)
+
+Because Map/Set don't lower to vec or class IrTypes — the codegen
+`resolvePositionType` rejects them today — we extend `resolvePositionType`
+to recognise the builtin generic names (`Set`, `Map`, `WeakSet`, `WeakMap`,
+`Iterable`, `Iterator`, `Generator`, `AsyncIterable`, `AsyncIterator`,
+`AsyncGenerator`) as `externref`, so the IR can claim functions with
+those parameter types. The IR treats them as opaque host values; the
+iter-host loop yields externref elements.
+
+### Import registration (lazy, post-build / pre-lower)
+
+`addIteratorImports` shifts function indices when called late, but the
+IR integration phase already pre-registers other late imports (string
+support, in `preregisterStringSupport`). We add the same pattern for
+iterator imports: walk every built IR function looking for an `iter.*`
+or `forof.iter` instr; if any are found, call `addIteratorImports`
+before Phase 3 lowering. By that point the IR's `IrFuncRef` symbolic
+names have not yet been resolved to indices, so the shift is a no-op
+on the IR path.
+
+### Slot allocation for iter-host
+
+Three slots survive across iterations:
+  - `__forof_iter`   — `externref`, the iterator value
+  - `__forof_result` — `externref`, the latest IteratorResult struct
+  - `__forof_elem`   — `externref`, the loop variable (the element)
+
+The result slot is needed because both `__iterator_done` and
+`__iterator_value` consume the IteratorResult; we save it once and
+read it twice.
+
+### Out-of-scope for this issue
+
+  - Iterator close on abrupt exit — the slice-6 body grammar forbids
+    `break` / `return` inside a for-of, so abrupt exit is impossible
+    structurally. Normal-exit close (`__iterator_return` after the
+    loop) is emitted unconditionally; the legacy path's try/catch
+    wrapper for thrown-exit close is deferred to slice E (#1169h).
+  - Async iteration (`for await`) — slice 7 (#1169f).
+  - Element-typed loop variable — every iter-host loop binds the
+    element as `externref`.
+
+### Files touched
+
+  1. `src/ir/nodes.ts` — 5 iter.* + 1 forof.iter variant; union update.
+  2. `src/ir/builder.ts` — emit helpers; `emitForOfIter`.
+  3. `src/ir/from-ast.ts` — strategy dispatch in `lowerForOfStatement`.
+  4. `src/ir/lower.ts` — case arms for iter.* and forof.iter; def-walk;
+     `collectForOfBodyUses` recurses into forof.iter.
+  5. `src/ir/verify.ts` — collectIrUses cases.
+  6. `src/ir/passes/dead-code.ts` — side-effect classification, uses.
+  7. `src/ir/passes/inline-small.ts` — operand renaming.
+  8. `src/ir/passes/monomorphize.ts` — uses + body recursion.
+  9. `src/ir/integration.ts` — pre-walk + `addIteratorImports`.
+  10. `src/codegen/index.ts` — recognise builtin generics in
+      `resolvePositionType`.
+  11. `tests/issue-1182.test.ts` — new equivalence cases.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -300,6 +300,31 @@ function resolvePositionType(
           return irVal({ kind: "ref_null", typeIdx: vecIdx });
         }
       }
+      // Slice 6 part 3 (#1182) — built-in generic iterables (Map / Set /
+      // WeakMap / WeakSet / Iterable / Iterator / Generator / Async*).
+      // These all have host-managed runtime representations and the IR
+      // doesn't model their internal structure; treat them as opaque
+      // externref values. The IR's iter-host arm of `lowerForOfStatement`
+      // accepts externref iterables and routes them through the
+      // `__iterator` host import.
+      if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
+        const name = node.typeName.text;
+        if (
+          name === "Map" ||
+          name === "Set" ||
+          name === "WeakMap" ||
+          name === "WeakSet" ||
+          name === "Iterable" ||
+          name === "Iterator" ||
+          name === "IterableIterator" ||
+          name === "Generator" ||
+          name === "AsyncIterable" ||
+          name === "AsyncIterator" ||
+          name === "AsyncGenerator"
+        ) {
+          return irVal({ kind: "externref" });
+        }
+      }
       const tsType = ctx.checker.getTypeFromTypeNode(node);
       const ir = objectIrTypeFromTsType(ctx, tsType);
       if (ir) return ir;

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -667,6 +667,88 @@ export class IrFunctionBuilder {
       resultType: null,
     });
   }
+
+  // --- coercion + iterator protocol (slice 6 part 3 — #1182) -----------
+
+  /**
+   * Coerce a reference-typed IR value to externref. Caller is responsible
+   * for ensuring `value` has a reference IrType — numeric ValTypes
+   * (i32/f64) cannot be coerced and produce an invalid Wasm body.
+   */
+  emitCoerceToExternref(value: IrValueId): IrValueId {
+    const result = this.allocator.fresh();
+    const resultType: IrType = irVal({ kind: "externref" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "coerce.to_externref", value, result, resultType });
+    return result;
+  }
+
+  /**
+   * Construct a host iterator handle from an externref iterable.
+   * `async: false` calls `__iterator`; `async: true` calls
+   * `__async_iterator` (reserved for #1169f, slice 7).
+   */
+  emitIterNew(iterable: IrValueId, async: boolean): IrValueId {
+    const result = this.allocator.fresh();
+    const resultType: IrType = irVal({ kind: "externref" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "iter.new", iterable, async, result, resultType });
+    return result;
+  }
+
+  /**
+   * Advance the iterator (`iter.next()`). Result is the iterator-result
+   * object as externref. Side-effecting — DCE must not eliminate.
+   */
+  emitIterNext(iter: IrValueId): IrValueId {
+    const result = this.allocator.fresh();
+    const resultType: IrType = irVal({ kind: "externref" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "iter.next", iter, result, resultType });
+    return result;
+  }
+
+  /** Read `.done` off an iterator-result object. Returns i32 (bool). */
+  emitIterDone(resultObj: IrValueId): IrValueId {
+    const result = this.allocator.fresh();
+    const resultType: IrType = irVal({ kind: "i32" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "iter.done", resultObj, result, resultType });
+    return result;
+  }
+
+  /** Read `.value` off an iterator-result object. Returns externref. */
+  emitIterValue(resultObj: IrValueId): IrValueId {
+    const result = this.allocator.fresh();
+    const resultType: IrType = irVal({ kind: "externref" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "iter.value", resultObj, result, resultType });
+    return result;
+  }
+
+  /** Call `iter.return()`. Void result. */
+  emitIterReturn(iter: IrValueId): void {
+    this.pushInstr({ kind: "iter.return", iter, result: null, resultType: null });
+  }
+
+  emitForOfIter(args: {
+    iterable: IrValueId;
+    iterSlot: number;
+    resultSlot: number;
+    elementSlot: number;
+    body: readonly IrInstr[];
+  }): void {
+    this.pushInstr({
+      kind: "forof.iter",
+      iterable: args.iterable,
+      iterSlot: args.iterSlot,
+      resultSlot: args.resultSlot,
+      elementSlot: args.elementSlot,
+      body: args.body,
+      result: null,
+      resultType: null,
+    });
+  }
 }
 
 // Convenience: value-id brand with no underlying type map — useful for tests

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1244,26 +1244,10 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
   //    is inferred from the lowered value.
   const iterableV = lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
   const iterableT = cx.builder.typeOf(iterableV);
-  const valTy = asVal(iterableT);
-  if (!valTy || (valTy.kind !== "ref" && valTy.kind !== "ref_null")) {
-    throw new Error(
-      `ir/from-ast: for-of iterable must lower to a vec ref (got ${describeIrType(iterableT)}) in ${cx.funcName}`,
-    );
-  }
 
-  // 2. Recover the element ValType from the vec struct definition. The
-  //    legacy `getOrRegisterVecType` always shapes a vec as
-  //      { length: i32, data: (ref $arr_<elem>) }
-  //    so we walk into the struct here. If the shape doesn't match,
-  //    throw and fall back to legacy.
-  const elemValType = inferVecElementValTypeFromContext(valTy, cx);
-  if (!elemValType) {
-    throw new Error(`ir/from-ast: for-of iterable's IR type is not a recognisable vec in ${cx.funcName}`);
-  }
-  const elemIrT = irVal(elemValType);
-
-  // 3. Resolve the loop-variable name. The selector enforces a single
-  //    Identifier-named decl in `(const|let)` form.
+  // 2. Resolve the loop-variable name. The selector enforces a single
+  //    Identifier-named decl in `(const|let)` form. Shared between vec
+  //    and iter-host arms.
   const init = stmt.initializer;
   if (!ts.isVariableDeclarationList(init) || init.declarations.length !== 1) {
     throw new Error(`ir/from-ast: for-of init shape unexpected (${cx.funcName})`);
@@ -1274,10 +1258,84 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
   }
   const loopVarName = decl.name.text;
 
-  // 4. Allocate the five slots the forof.vec lowerer expects. Slot
-  //    types match the lowerer's emit pattern in `src/ir/lower.ts`:
-  //      counter: i32, length: i32, vec: <vec ref>, data: <arr ref>,
-  //      element: <elem ValType>.
+  // 3. Strategy dispatch.
+  //
+  //   - `(val) ref|ref_null`        → vec path (slice 6 part 2 — #1181).
+  //                                    The lowerer's resolveVec validates
+  //                                    the struct's `{ length, data }`
+  //                                    shape; if it isn't a vec, lowering
+  //                                    throws and the function falls back
+  //                                    to legacy.
+  //   - `(val) externref`           → iter-host (this slice — #1182).
+  //   - `class` / `object`           → iter-host (with extern.convert_any
+  //                                    coercion).
+  //   - anything else                → throw, fall back to legacy.
+  const valTy = asVal(iterableT);
+  if (valTy && (valTy.kind === "ref" || valTy.kind === "ref_null")) {
+    lowerForOfVec(stmt, cx, iterableV, valTy, loopVarName);
+    return;
+  }
+
+  // Iter-host arm: externref / class / object iterables.
+  const isIterHostEligible = valTy?.kind === "externref" || iterableT.kind === "class" || iterableT.kind === "object";
+  if (!isIterHostEligible) {
+    throw new Error(
+      `ir/from-ast: for-of iterable type ${describeIrType(iterableT)} not supported in slice 6 (${cx.funcName})`,
+    );
+  }
+
+  // Coerce to externref if not already. extern.convert_any is a Wasm
+  // 1-arg op that re-tags any reference as externref.
+  let iterableExt = iterableV;
+  if (valTy?.kind !== "externref") {
+    iterableExt = cx.builder.emitCoerceToExternref(iterableV);
+  }
+
+  // Allocate the three iter-host slots — all externref. The element
+  // slot's IR type is `irVal({ kind: "externref" })`; the loop-var
+  // binding inherits this.
+  const iterSlot = cx.builder.declareSlot("__forof_iter", { kind: "externref" });
+  const resultSlot = cx.builder.declareSlot("__forof_result", { kind: "externref" });
+  const elementSlot = cx.builder.declareSlot("__forof_elem", { kind: "externref" });
+
+  // Bind the loop variable as a `slot` ScopeBinding (externref-typed).
+  const elemIrT: IrType = irVal({ kind: "externref" });
+  const bodyScope = new Map(cx.scope);
+  bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+
+  // Collect body instrs.
+  const body = cx.builder.collectBodyInstrs(() => {
+    lowerStmt(stmt.statement, bodyCx);
+  });
+
+  // Emit the declarative iter-host for-of instr.
+  cx.builder.emitForOfIter({
+    iterable: iterableExt,
+    iterSlot,
+    resultSlot,
+    elementSlot,
+    body,
+  });
+}
+
+/**
+ * Slice 6 part 2 (#1181) vec fast-path — extracted into a helper so
+ * `lowerForOfStatement` can dispatch between vec and iter-host arms.
+ */
+function lowerForOfVec(
+  stmt: ts.ForOfStatement,
+  cx: LowerCtx,
+  iterableV: IrValueId,
+  valTy: ValType,
+  loopVarName: string,
+): void {
+  const elemValType = inferVecElementValTypeFromContext(valTy, cx);
+  if (!elemValType) {
+    throw new Error(`ir/from-ast: for-of iterable's IR type is not a recognisable vec in ${cx.funcName}`);
+  }
+  const elemIrT = irVal(elemValType);
+
   const dataValType = inferVecDataValTypeFromContext(valTy, cx);
   if (!dataValType) {
     throw new Error(`ir/from-ast: for-of vec has unexpected data field shape (${cx.funcName})`);
@@ -1288,21 +1346,14 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
   const dataSlot = cx.builder.declareSlot("__forof_data", dataValType);
   const elementSlot = cx.builder.declareSlot("__forof_elem", elemValType);
 
-  // 5. Bind the loop variable as a `slot` ScopeBinding inside the body
-  //    scope. The body's reads of `<id>` go through `slot.read`.
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
   const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
 
-  // 6. Collect body instrs into the forof.vec body buffer. The builder
-  //    routes all subsequent `pushInstr` calls into the buffer until
-  //    the callback returns.
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
   });
 
-  // 7. Emit the declarative for-of instr. The lowerer in `src/ir/lower.ts`
-  //    emits the `block { loop { ... } }` Wasm pattern.
   cx.builder.emitForOfVec({
     vec: iterableV,
     elementType: elemIrT,

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -24,7 +24,7 @@
 
 import ts from "typescript";
 
-import { addStringImports } from "../codegen/index.js";
+import { addIteratorImports, addStringImports } from "../codegen/index.js";
 import { addStringConstantGlobal } from "../codegen/registry/imports.js";
 import { addFuncType, getOrRegisterRefCellType } from "../codegen/registry/types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
@@ -319,6 +319,18 @@ export function compileIrPathFunctions(
   // resolver path uniform.
   // -------------------------------------------------------------------------
   preregisterStringSupport(ctx, readyForLower);
+
+  // -------------------------------------------------------------------------
+  // Slice 6 part 3 (#1182) — iterator host imports.
+  //
+  // Walk every IR function for any `iter.*` / `forof.iter` / coercion-to-
+  // externref instruction; if found, call `addIteratorImports(ctx)` so the
+  // resolver can map `__iterator` / `__iterator_next` / `__iterator_done` /
+  // `__iterator_value` / `__iterator_return` to concrete funcIdx values
+  // BEFORE Phase 3 resolves IrFuncRef symbols. This pre-registration
+  // matches `preregisterStringSupport`'s rationale.
+  // -------------------------------------------------------------------------
+  preregisterIteratorSupport(ctx, readyForLower);
 
   // -------------------------------------------------------------------------
   // Phase 3 — Lower: translate each IrFunction to Wasm and install in ctx.
@@ -716,6 +728,60 @@ function instrUsesStrings(instr: IrInstr): boolean {
     instr.kind === "string.eq" ||
     instr.kind === "string.len"
   );
+}
+
+// ---------------------------------------------------------------------------
+// Iterator pre-registration (#1182)
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice 6 part 3 (#1182): pre-register the iterator host imports if any
+ * IR function emits an `iter.*` or `forof.iter` instr. Same pattern and
+ * rationale as `preregisterStringSupport`: late import registration
+ * shifts function indices, and we want the shift to be a no-op on the
+ * IR path's `IrFuncRef` resolution.
+ *
+ * `addIteratorImports` is idempotent on `ctx.funcMap.has("__iterator")`,
+ * so it's safe to call repeatedly.
+ */
+function preregisterIteratorSupport(ctx: CodegenContext, fns: readonly BuiltFnRef[]): void {
+  const usesIter = (instr: IrInstr): boolean => {
+    switch (instr.kind) {
+      case "iter.new":
+      case "iter.next":
+      case "iter.done":
+      case "iter.value":
+      case "iter.return":
+        return true;
+      case "forof.iter": {
+        // forof.iter is itself an iter user, but ALSO walk the body in
+        // case the IR ever materialises iter.* directly inside.
+        for (const sub of instr.body) {
+          if (usesIter(sub)) return true;
+        }
+        return true;
+      }
+      case "forof.vec": {
+        // A vec for-of body can syntactically contain nested iter ops.
+        for (const sub of instr.body) {
+          if (usesIter(sub)) return true;
+        }
+        return false;
+      }
+      default:
+        return false;
+    }
+  };
+  for (const entry of fns) {
+    for (const block of entry.fn.blocks) {
+      for (const instr of block.instrs) {
+        if (usesIter(instr)) {
+          addIteratorImports(ctx);
+          return;
+        }
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -318,7 +318,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       defBy.set(instr.result, instr);
       defBlockOf.set(instr.result, blockId);
     }
-    if (instr.kind === "forof.vec") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
       for (const sub of instr.body) registerInstrDefs(sub, blockId);
     }
   };
@@ -375,7 +375,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       // execution makes ANY outer-defined value's use a candidate for
       // cross-block materialisation. Mark uses with a synthetic block
       // ID (-1 for "inside-body") so the cross-block test always fires.
-      if (instr.kind === "forof.vec") {
+      if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
         for (const u of collectForOfBodyUses(instr.body)) recordUse(u, -1);
       }
     }
@@ -419,7 +419,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       locals.push({ name: `$ir${instr.result}`, type: lowerIrTypeToValType(instr.resultType, resolver, func.name) });
       localIdx.set(instr.result, idx);
     }
-    if (instr.kind === "forof.vec") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
       for (const sub of instr.body) allocLocalForInstr(sub);
     }
   };
@@ -912,6 +912,111 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         });
         return;
       }
+      // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+      case "coerce.to_externref": {
+        // Push the value, then convert any (ref) → externref. If the
+        // input is already externref, the convert is a wasm validation
+        // no-op (it's permitted on already-externref values). For all
+        // ref-typed inputs the wasm engine simply re-tags the reference
+        // so it can flow into externref-typed positions.
+        emitValue(instr.value, out);
+        out.push({ op: "extern.convert_any" } as unknown as Instr);
+        return;
+      }
+      case "iter.new": {
+        const fnName = instr.async ? "__async_iterator" : "__iterator";
+        const funcIdx = resolver.resolveFunc({ kind: "func", name: fnName });
+        emitValue(instr.iterable, out);
+        out.push({ op: "call", funcIdx });
+        return;
+      }
+      case "iter.next": {
+        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_next" });
+        emitValue(instr.iter, out);
+        out.push({ op: "call", funcIdx });
+        return;
+      }
+      case "iter.done": {
+        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_done" });
+        emitValue(instr.resultObj, out);
+        out.push({ op: "call", funcIdx });
+        return;
+      }
+      case "iter.value": {
+        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_value" });
+        emitValue(instr.resultObj, out);
+        out.push({ op: "call", funcIdx });
+        return;
+      }
+      case "iter.return": {
+        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_return" });
+        emitValue(instr.iter, out);
+        out.push({ op: "call", funcIdx });
+        return;
+      }
+      case "forof.iter": {
+        // Mirror of forof.vec but using the iterator protocol. The lowerer
+        // emits the `block { loop { ... } }` Wasm pattern documented on
+        // `IrInstrForOfIter` in `nodes.ts`.
+        const iteratorIdx = resolver.resolveFunc({ kind: "func", name: "__iterator" });
+        const iteratorNextIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_next" });
+        const iteratorDoneIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_done" });
+        const iteratorValueIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_value" });
+        const iteratorReturnIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_return" });
+
+        // iter = __iterator(iterable)
+        emitValue(instr.iterable, out);
+        out.push({ op: "call", funcIdx: iteratorIdx });
+        out.push({ op: "local.set", index: slotWasmIdx(instr.iterSlot) });
+
+        // Build loop body Wasm ops.
+        const loopBody: Instr[] = [];
+        // result = iter.next(iter)
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.iterSlot) });
+        loopBody.push({ op: "call", funcIdx: iteratorNextIdx });
+        loopBody.push({ op: "local.tee", index: slotWasmIdx(instr.resultSlot) });
+        // if (iter.done(result)) br 1 (exit)
+        loopBody.push({ op: "call", funcIdx: iteratorDoneIdx });
+        loopBody.push({ op: "br_if", depth: 1 });
+        // element = iter.value(result)
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.resultSlot) });
+        loopBody.push({ op: "call", funcIdx: iteratorValueIdx });
+        loopBody.push({ op: "local.set", index: slotWasmIdx(instr.elementSlot) });
+
+        // Body instrs (same materialisation pattern as forof.vec).
+        for (const bodyInstr of instr.body) {
+          if (bodyInstr.result === null) {
+            emitInstrTree(bodyInstr, loopBody);
+          } else if (crossBlock.has(bodyInstr.result)) {
+            emitInstrTree(bodyInstr, loopBody);
+            loopBody.push({ op: "local.set", index: localIdx.get(bodyInstr.result)! });
+            materialized.add(bodyInstr.result);
+          }
+        }
+
+        // br 0 (continue)
+        loopBody.push({ op: "br", depth: 0 });
+
+        // block { loop { ... } }
+        out.push({
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: loopBody,
+            },
+          ],
+        });
+
+        // Normal-exit close: iter.return(iter). Note this runs only on
+        // normal loop exit (done=true). Abrupt exits (break/return)
+        // would need a try/finally — slice 6 step E (#1169h dependency).
+        out.push({ op: "local.get", index: slotWasmIdx(instr.iterSlot) });
+        out.push({ op: "call", funcIdx: iteratorReturnIdx });
+        return;
+      }
     }
   };
 
@@ -1082,6 +1187,22 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
       // Body uses are collected separately and merged in by
       // `lowerIrFunctionToWasm`.
       return [instr.vec];
+    // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+    case "coerce.to_externref":
+      return [instr.value];
+    case "iter.new":
+      return [instr.iterable];
+    case "iter.next":
+      return [instr.iter];
+    case "iter.done":
+      return [instr.resultObj];
+    case "iter.value":
+      return [instr.resultObj];
+    case "iter.return":
+      return [instr.iter];
+    case "forof.iter":
+      // Same rationale as forof.vec — body uses surfaced separately.
+      return [instr.iterable];
   }
 }
 
@@ -1095,7 +1216,7 @@ export function collectForOfBodyUses(body: readonly IrInstr[]): IrValueId[] {
   const uses: IrValueId[] = [];
   for (const instr of body) {
     for (const u of collectIrUses(instr)) uses.push(u);
-    if (instr.kind === "forof.vec") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
       for (const u of collectForOfBodyUses(instr.body)) uses.push(u);
     }
   }

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -915,6 +915,166 @@ export interface IrInstrForOfVec extends IrInstrBase {
   readonly body: readonly IrInstr[];
 }
 
+// ---------------------------------------------------------------------------
+// Coercion + iterator protocol (#1182 — IR Phase 4 Slice 6 part 3)
+// ---------------------------------------------------------------------------
+//
+// Slice 6 part 3 widens the for-of bridge to the host iterator protocol
+// — `for (const x of <set>)`, `for (const x of <map>)`, generators, and
+// any other JS iterable that responds to `Symbol.iterator`. A new
+// declarative `forof.iter` instr (parallel to `forof.vec`) carries the
+// loop's state slots and body buffer; the lowerer emits the
+// `block { loop { ... } }` Wasm pattern with calls to the existing
+// `__iterator` / `__iterator_next` / `__iterator_done` /
+// `__iterator_value` / `__iterator_return` host imports (registered
+// lazily by `addIteratorImports`).
+//
+// The granular `iter.*` instrs (iter.new / iter.next / iter.done /
+// iter.value / iter.return) are part of the IR surface even though
+// `forof.iter` doesn't decompose into them at the body-buffer level.
+// Future passes that want to reason about iterator manipulation
+// outside a for-of loop (e.g., a generator's next() inlined into a
+// caller, or async-iter in slice 7) can produce these directly.
+
+/**
+ * Coerce a reference-typed IR value to externref. Used by the iterator-
+ * protocol arm of `lowerForOfStatement` to feed an arbitrary iterable
+ * into the externref-typed `__iterator` host import.
+ *
+ * The input value must have a reference IrType (val/ref, val/ref_null,
+ * val/externref, object, class, closure, or string). Numeric values
+ * (i32, f64, etc.) cannot be coerced — the from-ast layer rejects them
+ * upstream.
+ *
+ * Lowering:
+ *   - val/externref input → no-op (input already externref)
+ *   - any other ref input → `extern.convert_any` after pushing the value.
+ *
+ * Result type: `irVal({ kind: "externref" })`.
+ */
+export interface IrInstrCoerceToExternref extends IrInstrBase {
+  readonly kind: "coerce.to_externref";
+  readonly value: IrValueId;
+}
+
+/**
+ * Slice 6 part 3 (#1182) — opaque iterator handle for the host iterator
+ * protocol. Calls `__iterator(iterable)` to obtain the iterator object.
+ *
+ * Lowering:
+ *   <emit iterable>           ;; pushes externref
+ *   call $__iterator           ;; -> externref (the iterator)
+ *
+ * Result type: `irVal({ kind: "externref" })`.
+ */
+export interface IrInstrIterNew extends IrInstrBase {
+  readonly kind: "iter.new";
+  readonly iterable: IrValueId;
+  /** True if this is a `for await` loop — calls `__async_iterator` instead. False for slice 6. */
+  readonly async: boolean;
+}
+
+/**
+ * Call iter.next() and return the result object handle (externref).
+ * The result is later split into `done` / `value` via separate instrs
+ * so the optimizer can decide whether to evaluate `value` (skip if done).
+ *
+ * Lowering: <emit iter>; call $__iterator_next  -> externref
+ *
+ * Result type: `irVal({ kind: "externref" })`. Side-effecting (advances
+ * the iterator) — DCE must not eliminate it.
+ */
+export interface IrInstrIterNext extends IrInstrBase {
+  readonly kind: "iter.next";
+  readonly iter: IrValueId;
+}
+
+/**
+ * Test whether an iterator-result object's `.done` is true.
+ *
+ * Lowering: <emit resultObj>; call $__iterator_done -> i32
+ *
+ * Result type: `irVal({ kind: "i32" })`. The operand field is named
+ * `resultObj` (not `result`) to avoid colliding with the SSA-def
+ * `result` field inherited from `IrInstrBase`.
+ */
+export interface IrInstrIterDone extends IrInstrBase {
+  readonly kind: "iter.done";
+  readonly resultObj: IrValueId;
+}
+
+/**
+ * Read the `.value` slot of an iterator-result object.
+ *
+ * Lowering: <emit resultObj>; call $__iterator_value -> externref
+ *
+ * Result type: `irVal({ kind: "externref" })`. See `IrInstrIterDone`
+ * for the `resultObj` naming rationale.
+ */
+export interface IrInstrIterValue extends IrInstrBase {
+  readonly kind: "iter.value";
+  readonly resultObj: IrValueId;
+}
+
+/**
+ * Call `iter.return()` if defined. Used by the iterator-close try/finally
+ * so abrupt exits notify the iterator (slice 6 step E, deferred to a
+ * try/finally-aware follow-up).
+ *
+ * Lowering: <emit iter>; call $__iterator_return
+ *
+ * Result type: void (`result: null`). Side-effecting.
+ */
+export interface IrInstrIterReturn extends IrInstrBase {
+  readonly kind: "iter.return";
+  readonly iter: IrValueId;
+}
+
+/**
+ * Statement-level `for (const <bind> of <iterable>) <body>` loop using
+ * the host iterator protocol. The lowerer emits:
+ *
+ *   <emit iterable>
+ *   call $__iterator
+ *   local.set <iterSlot>
+ *   block
+ *     loop
+ *       local.get <iterSlot>
+ *       call $__iterator_next
+ *       local.tee <resultSlot>
+ *       call $__iterator_done
+ *       br_if 1                  ;; exit loop on done=true
+ *       local.get <resultSlot>
+ *       call $__iterator_value
+ *       local.set <elementSlot>
+ *       <body instrs>
+ *       br 0                     ;; continue
+ *     end
+ *   end
+ *   local.get <iterSlot>
+ *   call $__iterator_return       ;; normal-exit close
+ *
+ * The iterable must be an IR value of externref type (the from-ast
+ * layer inserts a `coerce.to_externref` if the source value isn't
+ * already externref). Slot indices are pre-allocated via
+ * `IrFunctionBuilder.declareSlot`.
+ *
+ * Result: void (`result: null`).
+ */
+export interface IrInstrForOfIter extends IrInstrBase {
+  readonly kind: "forof.iter";
+  /** SSA value of the iterable as externref (caller pre-coerces). */
+  readonly iterable: IrValueId;
+  /** Pre-allocated externref slot for the iterator handle. */
+  readonly iterSlot: number;
+  /** Pre-allocated externref slot for the iterator-result object. */
+  readonly resultSlot: number;
+  /** Pre-allocated externref slot for the current element value. */
+  readonly elementSlot: number;
+  /** Body instrs emitted inside the loop. */
+  readonly body: readonly IrInstr[];
+}
+
 export type IrInstr =
   | IrInstrConst
   | IrInstrCall
@@ -948,7 +1108,14 @@ export type IrInstr =
   | IrInstrSlotWrite
   | IrInstrVecLen
   | IrInstrVecGet
-  | IrInstrForOfVec;
+  | IrInstrForOfVec
+  | IrInstrCoerceToExternref
+  | IrInstrIterNew
+  | IrInstrIterNext
+  | IrInstrIterDone
+  | IrInstrIterValue
+  | IrInstrIterReturn
+  | IrInstrForOfIter;
 
 // ---------------------------------------------------------------------------
 // Slot definitions (#1169e — IR Phase 4 Slice 6)

--- a/src/ir/passes/dead-code.ts
+++ b/src/ir/passes/dead-code.ts
@@ -193,7 +193,18 @@ function isSideEffecting(i: IrInstr): boolean {
     // slot.read is pure (load a Wasm local) but always-keep to avoid
     // breaking the for-of body's load/use pattern.
     i.kind === "slot.write" ||
-    i.kind === "forof.vec"
+    i.kind === "forof.vec" ||
+    // Slice 6 part 3 (#1182): host-iterator protocol ops mutate iterator
+    // state (advance pointer, dispose). DCE must not eliminate them
+    // even when their results are unused — a `iter.next` whose value is
+    // dropped still has the side effect of advancing the iterator.
+    // forof.iter is statement-level (result: null) and is kept by the
+    // generic null-result rule, but the explicit listing makes the
+    // intent obvious.
+    i.kind === "iter.new" ||
+    i.kind === "iter.next" ||
+    i.kind === "iter.return" ||
+    i.kind === "forof.iter"
   );
 }
 
@@ -280,7 +291,31 @@ function collectInstrUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectInstrUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+        }
+      };
+      walk(instr.body);
+      return result;
+    }
+    // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+    case "coerce.to_externref":
+      return [instr.value];
+    case "iter.new":
+      return [instr.iterable];
+    case "iter.next":
+      return [instr.iter];
+    case "iter.done":
+      return [instr.resultObj];
+    case "iter.value":
+      return [instr.resultObj];
+    case "iter.return":
+      return [instr.iter];
+    case "forof.iter": {
+      const result: IrValueId[] = [instr.iterable];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectInstrUses(sub)) result.push(u);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
         }
       };
       walk(instr.body);

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -497,6 +497,45 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       if (!bodyChanged) return inst;
       return { ...inst, vec: v, body: newBody };
     }
+    // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+    case "coerce.to_externref": {
+      const v = mapId(rename, inst.value);
+      if (v === inst.value) return inst;
+      return { ...inst, value: v };
+    }
+    case "iter.new": {
+      const v = mapId(rename, inst.iterable);
+      if (v === inst.iterable) return inst;
+      return { ...inst, iterable: v };
+    }
+    case "iter.next": {
+      const v = mapId(rename, inst.iter);
+      if (v === inst.iter) return inst;
+      return { ...inst, iter: v };
+    }
+    case "iter.done":
+    case "iter.value": {
+      const v = mapId(rename, inst.resultObj);
+      if (v === inst.resultObj) return inst;
+      return { ...inst, resultObj: v };
+    }
+    case "iter.return": {
+      const v = mapId(rename, inst.iter);
+      if (v === inst.iter) return inst;
+      return { ...inst, iter: v };
+    }
+    case "forof.iter": {
+      const v = mapId(rename, inst.iterable);
+      let bodyChanged = v !== inst.iterable;
+      const newBody: IrInstr[] = [];
+      for (const sub of inst.body) {
+        const renamed = renameInstrOperands(sub, rename);
+        if (renamed !== sub) bodyChanged = true;
+        newBody.push(renamed);
+      }
+      if (!bodyChanged) return inst;
+      return { ...inst, iterable: v, body: newBody };
+    }
   }
 }
 

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -674,7 +674,31 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+        }
+      };
+      walk(instr.body);
+      return result;
+    }
+    // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+    case "coerce.to_externref":
+      return [instr.value];
+    case "iter.new":
+      return [instr.iterable];
+    case "iter.next":
+      return [instr.iter];
+    case "iter.done":
+      return [instr.resultObj];
+    case "iter.value":
+      return [instr.resultObj];
+    case "iter.return":
+      return [instr.iter];
+    case "forof.iter": {
+      const result: IrValueId[] = [instr.iterable];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectUses(sub)) result.push(u);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
         }
       };
       walk(instr.body);

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -236,6 +236,23 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       // its def→use relation is tracked by the verifier and by the
       // cross-block use counter in the lowerer.
       return [instr.vec];
+    // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
+    case "coerce.to_externref":
+      return [instr.value];
+    case "iter.new":
+      return [instr.iterable];
+    case "iter.next":
+      return [instr.iter];
+    case "iter.done":
+      return [instr.resultObj];
+    case "iter.value":
+      return [instr.resultObj];
+    case "iter.return":
+      return [instr.iter];
+    case "forof.iter":
+      // Same rationale as forof.vec: body is loop-internal, only the
+      // iterable surfaces in the straight-line walk.
+      return [instr.iterable];
   }
 }
 

--- a/tests/issue-1182.test.ts
+++ b/tests/issue-1182.test.ts
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1182 — IR Phase 4 Slice 6 part 3: host iterator protocol through IR.
+//
+// Activates the iter-host arm of the AST→IR for-of bridge. Functions
+// that iterate a non-vec value (Map, Set, generator, custom iterable)
+// now lower through the IR's `forof.iter` declarative instr instead of
+// falling through to legacy.
+//
+// Each test compiles the same source twice — once with the legacy path
+// (`experimentalIR: false`) and once through the IR
+// (`experimentalIR: true`) — and asserts the exported function returns
+// the same value when called through both paths. The selector suite
+// confirms the IR actually CLAIMS the test function (so we'd catch a
+// future regression that silently routes back to legacy).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import ts from "typescript";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+type Outcome =
+  | { kind: "ok"; value: unknown }
+  | { kind: "compile_fail"; firstMessage: string }
+  | { kind: "instantiate_fail"; reason?: string }
+  | { kind: "invoke_fail"; reason?: string };
+
+async function runOnce(source: string, fnName: string, arg: unknown, experimentalIR: boolean): Promise<Outcome> {
+  const r = compile(source, { experimentalIR });
+  if (!r.success) {
+    return { kind: "compile_fail", firstMessage: r.errors[0]?.message ?? "" };
+  }
+  let instance: WebAssembly.Instance;
+  try {
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    ({ instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    }));
+  } catch (e: unknown) {
+    return { kind: "instantiate_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+  try {
+    const fn = instance.exports[fnName] as (a: unknown) => unknown;
+    return { kind: "ok", value: fn(arg) };
+  } catch (e: unknown) {
+    return { kind: "invoke_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function dualRun(source: string, fnName: string, arg: unknown): Promise<{ legacy: Outcome; ir: Outcome }> {
+  const [legacy, ir] = await Promise.all([runOnce(source, fnName, arg, false), runOnce(source, fnName, arg, true)]);
+  return { legacy, ir };
+}
+
+interface Case {
+  name: string;
+  source: string;
+  fn: string;
+  arg: unknown;
+  /** Names of IR-claimable functions in the source. */
+  expectedClaimed: string[];
+}
+
+// Each case has ONE function `fn(iterable)` — IR-claimed via the
+// iter-host arm. The iterable is constructed in JS (Map/Set/generator)
+// so we don't need IR-side construction support; the test feeds the
+// host object straight into the Wasm export.
+const CASES: Case[] = [
+  // ---- 1. Set<number> (canonical iter-host case) --------------------------
+  {
+    name: "Set<number>: count elements",
+    source: `
+      export function fn(s: Set<number>): number {
+        let count = 0;
+        for (const x of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    arg: new Set([1, 2, 3, 4, 5]),
+    expectedClaimed: ["fn"],
+  },
+
+  // ---- 2. Set<number>: empty set -----------------------------------------
+  {
+    name: "Set<number>: empty set returns 0",
+    source: `
+      export function fn(s: Set<number>): number {
+        let count = 0;
+        for (const x of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    arg: new Set<number>(),
+    expectedClaimed: ["fn"],
+  },
+
+  // ---- 3. Map<K,V>: count entries (each entry is a [k,v] tuple externref) -
+  {
+    name: "Map<string,number>: count entries",
+    source: `
+      export function fn(m: Map<string, number>): number {
+        let count = 0;
+        for (const entry of m) {
+          count += 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    arg: new Map<string, number>([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]),
+    expectedClaimed: ["fn"],
+  },
+
+  // ---- 4. Set<number> with sum-counter pattern ---------------------------
+  // Mixes the iter-host loop variable (externref, unused in arithmetic)
+  // with a slot-bound outer accumulator.
+  {
+    name: "Set<number>: incremented counter via plain assignment",
+    source: `
+      export function fn(s: Set<number>): number {
+        let count = 0;
+        for (const x of s) {
+          count = count + 2;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    arg: new Set([1, 2, 3]),
+    expectedClaimed: ["fn"],
+  },
+
+  // ---- 5. Map<K,V>: empty map ---------------------------------------------
+  {
+    name: "Map<string,number>: empty map returns 0",
+    source: `
+      export function fn(m: Map<string, number>): number {
+        let count = 0;
+        for (const entry of m) {
+          count += 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    arg: new Map<string, number>(),
+    expectedClaimed: ["fn"],
+  },
+];
+
+describe("#1182 — iter-host for-of through IR (slice 6 part 3)", () => {
+  for (const tc of CASES) {
+    it(tc.name, async () => {
+      const { legacy, ir } = await dualRun(tc.source, tc.fn, tc.arg);
+      // Both outcomes must be `ok` and produce the same value.
+      if (legacy.kind !== "ok") {
+        throw new Error(`legacy run failed: ${JSON.stringify(legacy)}`);
+      }
+      if (ir.kind !== "ok") {
+        throw new Error(`ir run failed: ${JSON.stringify(ir)}`);
+      }
+      expect(ir.value).toBe(legacy.value);
+    });
+  }
+});
+
+describe("#1182 — selector claims iter-host-shaped functions", () => {
+  for (const tc of CASES) {
+    it(`selector claims ${tc.fn} from "${tc.name}"`, () => {
+      const sf = ts.createSourceFile("test.ts", tc.source, ts.ScriptTarget.ES2022, true);
+      const sel = planIrCompilation(sf, { experimentalIR: true });
+      for (const name of tc.expectedClaimed) {
+        expect([...sel.funcs]).toContain(name);
+      }
+    });
+  }
+});
+
+describe("#1182 — IR compile produces no IR-fallback errors for iter-host cases", () => {
+  for (const tc of CASES) {
+    it(`compiles "${tc.name}" cleanly under experimentalIR`, () => {
+      const r = compile(tc.source, { experimentalIR: true });
+      expect(r.success).toBe(true);
+      const irErrors = r.errors.filter(
+        (e) =>
+          e.message.startsWith("IR path failed") ||
+          e.message.startsWith("ir/from-ast") ||
+          e.message.startsWith("ir/lower"),
+      );
+      expect(irErrors).toEqual([]);
+    });
+  }
+});
+
+describe("#1182 — vec fast path still works alongside iter-host", () => {
+  // Ensures the dispatch in `lowerForOfStatement` still routes vec
+  // iterables to the vec arm — adding the iter-host fallback didn't
+  // accidentally divert all for-of traffic.
+  it("array iteration still routes through forof.vec", async () => {
+    const source = `
+      export function fn(arr: number[]): number {
+        let sum = 0;
+        for (const x of arr) {
+          sum += x;
+        }
+        return sum;
+      }
+    `;
+    const r = compile(source, { experimentalIR: true });
+    expect(r.success).toBe(true);
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    });
+    // The IR takes a vec ref directly — call via a builder helper.
+    // For this smoke test we use the compiled module's array-builder
+    // surface (legacy path materialises the array).
+    // Easier: write a separate builder.
+    const source2 = `
+      export function builder(): number[] { return [1, 2, 3, 4, 5]; }
+      export function fn(arr: number[]): number {
+        let sum = 0;
+        for (const x of arr) {
+          sum += x;
+        }
+        return sum;
+      }
+    `;
+    const r2 = compile(source2, { experimentalIR: true });
+    expect(r2.success).toBe(true);
+    const b2 = buildImports(r2.imports, ENV_STUB, r2.stringPool);
+    const { instance: i2 } = await WebAssembly.instantiate(r2.binary, {
+      env: b2.env,
+      string_constants: b2.string_constants,
+    });
+    const arr = (i2.exports.builder as () => unknown)();
+    const result = (i2.exports.fn as (a: unknown) => unknown)(arr);
+    expect(result).toBe(15);
+    void instance; // silence unused-var; keeps the first compile in the snapshot
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1182** — slice 6 part 3 of the IR migration. The iter-host arm of `lowerForOfStatement` lands: `for (const x of <iter>)` where the iterable is anything other than a known WasmGC vec struct now lowers through the IR's new `forof.iter` declarative instr, calling the existing `__iterator*` host imports.

Map, Set, generators, and any other built-in `Iterable<T>` parameter type now compile through the IR path instead of falling back to legacy.

- 5 SSA-style `iter.*` IR nodes + statement-level `forof.iter` declarative instr (mirrors `forof.vec`) + `coerce.to_externref`.
- Strategy dispatch: `(ref|ref_null)` → vec arm (existing); `externref`/`class`/`object` IrTypes → iter-host arm.
- `preregisterIteratorSupport` wires `addIteratorImports` lazily, before Phase 3 lowering.
- `resolvePositionType` recognises `Map`/`Set`/`WeakMap`/`WeakSet`/`Iterable`/`Iterator`/`IterableIterator`/`Generator`/`AsyncIterable`/`AsyncIterator`/`AsyncGenerator` as opaque externref so the IR can claim functions parameterised by those types.

## Test plan

- [x] New equivalence tests `tests/issue-1182.test.ts` — 16/16 pass (Set count, empty Set, Map entries, Set-with-counter pattern, empty Map; selector-claims + IR-error-free-compile + vec-fast-path regression).
- [x] Prior IR slice tests (`tests/issue-1169d.test.ts`, `tests/issue-1169e-bridge.test.ts`, `tests/ir/`) — 92/92 pass.
- [x] `npx tsc --noEmit` — 0 errors.
- [x] Local equivalence test suite (`tests/equivalence/**`) — exit 0, no failures observed.
- [ ] CI (GitHub Actions) — wait for `.claude/ci-status/pr-<N>.json` then self-merge per dev protocol.

## Out of scope

- Iterator close on abrupt exit (slice 6 step E, depends on try/finally — #1169h).
- Async iteration (`for await`) — slice 7 (#1169f).
- Element-typed loop variable (currently always externref in the iter-host arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)