### PR TITLE
feat(ir): slice 6 part 4 — string fast path through IR (#1183)

### DIFF
--- a/plan/issues/ready/1183.md
+++ b/plan/issues/ready/1183.md
@@ -1,0 +1,255 @@
+---
+id: 1183
+title: "IR Phase 4 Slice 6 part 4 — string fast path through the IR (`for (c of \"hello\")`)"
+sprint: 46
+status: ready
+priority: medium
+feasibility: medium
+reasoning_effort: high
+goal: compiler-architecture
+task_type: implementation
+area: codegen
+language_feature: compiler-internals
+depends_on: [1181]
+created: 2026-04-27
+origin: surfaced from #1169e foundation PR (#63) — slice 6 step D from the spec, deferred from #1181 (vec fast path) and #1182 (iterator protocol)
+related: [1169e, 1181, 1182]
+---
+
+# #1183 — Slice 6 part 4: string fast path through IR
+
+## Goal
+
+Land slice 6 step D (per the #1169e spec): for-of over a
+`string`-typed expression. In native-strings mode, iterate via
+`__str_charAt` per code unit; in host-strings mode, fall through to
+the iterator protocol path (#1182).
+
+Depends on #1181 (vec fast path) for the loop-body machinery, and
+optionally on #1182 if the host-strings fallback is to use the
+iterator protocol.
+
+## What this issue needs to land
+
+### 1. `lowerForOfString` in `src/ir/from-ast.ts`
+
+A third arm of the `lowerForOfStatement` strategy switch. Mirrors
+the legacy `compileForOfString` (`src/codegen/statements/loops.ts:1483`):
+
+```ts
+function lowerForOfString(
+  strV: IrValueId,
+  loopVarName: string,
+  stmt: ts.ForOfStatement,
+  cx: LowerCtx,
+): void {
+  // Mode dispatch: native-strings → counter loop with __str_charAt.
+  // Host-strings → fall through to iter-host path (#1182). The decision
+  // happens at lowering time via cx.resolver?.nativeStrings?.() — a
+  // new optional method on IrLowerResolver returning whether we're in
+  // native-strings mode.
+  if (!cx.resolver?.nativeStrings?.()) {
+    return lowerForOfIter(coerceStringToExternref(strV, cx), loopVarName, stmt, cx);
+  }
+
+  // Allocate slots: counter (i32), length (i32), str (string ref),
+  // element (string — single-char string).
+  const counterSlot = cx.builder.declareSlot("__forof_si", { kind: "i32" });
+  const lengthSlot  = cx.builder.declareSlot("__forof_slen", { kind: "i32" });
+  const strSlot     = cx.builder.declareSlot("__forof_str", cx.resolver.resolveString!());
+  const elemSlot    = cx.builder.declareSlot("__forof_selem", cx.resolver.resolveString!());
+
+  // Bind loopVarName as a slot binding. Body collected via
+  // collectBodyInstrs into a forof.string declarative instr.
+  // Lowerer emits the wasm pattern below.
+}
+```
+
+### 2. New `forof.string` declarative IR instr (in `src/ir/nodes.ts`)
+
+Parallel to `forof.vec` from #1169e. Carries:
+- `str: IrValueId` (the string SSA value, IrType.string)
+- pre-allocated slots: counter, length, str, element
+- `body: readonly IrInstr[]`
+
+Result: void.
+
+### 3. Lowering — Wasm pattern for native-strings mode
+
+```wasm
+;; str on stack
+local.set $str_slot
+local.get $str_slot
+struct.get $AnyString $len            ;; length
+local.set $len_slot
+i32.const 0
+local.set $counter_slot
+block
+  loop
+    local.get $counter_slot
+    local.get $len_slot
+    i32.ge_s
+    br_if 1
+    ;; element = __str_charAt(str, counter)
+    local.get $str_slot
+    local.get $counter_slot
+    call $__str_charAt
+    local.set $elem_slot
+    <body>
+    local.get $counter_slot
+    i32.const 1
+    i32.add
+    local.set $counter_slot
+    br 0
+  end
+end
+```
+
+Need to confirm `__str_charAt` is registered by the
+`registerNativeStringTypes` family in `src/codegen/native-strings.ts`
+and that its signature is `(string-ref, i32) → string-ref`.
+
+### 4. Strategy dispatch update
+
+Extend `chooseForOfStrategy` from #1182:
+
+```ts
+function chooseForOfStrategy(iterableType: IrType, cx: LowerCtx): "vec" | "string-native" | "iter-host" {
+  if (iterableType.kind === "val") {
+    const vt = iterableType.val;
+    if (vt.kind === "ref" || vt.kind === "ref_null") {
+      const vec = cx.resolver?.resolveVec?.(vt);
+      if (vec) return "vec";
+    }
+  }
+  if (iterableType.kind === "string") {
+    return cx.resolver?.nativeStrings?.() ? "string-native" : "iter-host";
+  }
+  return "iter-host";
+}
+```
+
+### 5. `cx.resolver.nativeStrings()` accessor
+
+A new optional method on `IrLowerResolver`. Implementation in
+`integration.ts` returns `ctx.nativeStrings`.
+
+## Out of scope
+
+- Per-grapheme iteration (the JS spec iterates over code points, not
+  code units; legacy uses `__str_charAt` which iterates code units —
+  match legacy for now and surface a follow-up if test262 exposes
+  the discrepancy).
+- For-await over async string-emitting iterables — slice 7.
+
+## Acceptance criteria
+
+1. `for (const c of "hello") { ... }` IR-claims in native-strings
+   mode and produces the same Wasm length and behavior as legacy
+   (verified via a one-shot `wasm-objdump` diff of the function body).
+2. New equivalence-test cases in `tests/issue-1169e-string.test.ts`:
+   - empty string
+   - single-char string
+   - multi-char string with simple body
+   - string concatenation inside body (mixes slice-1 string ops with
+     slice-6 for-of)
+3. No regressions in existing IR tests.
+4. CI test262 net delta ≥ 0.
+
+## Sub-issue of
+
+\#1169 — IR Phase 4: full compiler migration
+
+---
+
+## Implementation Notes (senior-developer, 2026-04-27)
+
+### Strategy dispatch (third arm in `lowerForOfStatement`)
+
+The from-ast layer now dispatches:
+  - `(val) ref|ref_null` → vec arm (#1181)
+  - `IrType.string` + `cx.nativeStrings === true` → string arm (this slice)
+  - `IrType.string` + host-strings mode → falls through to iter-host (#1182)
+    (no coercion needed — IrType.string lowers to externref in host mode)
+  - `(val) externref` / class / object → iter-host (#1182)
+  - else → throw (legacy fallback)
+
+The native-strings fast path uses a new `forof.string` declarative
+instr (parallel to `forof.vec` and `forof.iter`) carrying the str SSA
+value, four slot indices (counter / length / str / element), and the
+body buffer. The lowerer emits the documented `block { loop { ... } }`
+counter pattern with `__str_charAt(str, i)` per iteration.
+
+### Threading `nativeStrings` + `anyStrTypeIdx` (no full resolver)
+
+The spec suggested adding `cx.resolver.nativeStrings()` to the IR
+resolver. We instead thread two narrowly-scoped fields through
+`AstToIrOptions` → `LowerCtx`:
+  - `nativeStrings: boolean` — drives the strategy dispatch
+  - `anyStrTypeIdx: number` — used to declare slot ValTypes
+    `(ref $AnyString)` for str/element without round-tripping through
+    a `LowerResolver`
+
+This is the same pattern slice 6 part 2 (#1181) used for vec
+inference and avoids a full resolver thread-through.
+
+### Loop variable type (slot binding)
+
+The loop var binds as `(slot, type=irVal((ref $AnyString)))`. Reads
+emit `slot.read` returning `irVal((ref $AnyString))`. In native mode
+`IrType.string` lowers to the SAME ValType, so the SSA values are
+interchangeable at the Wasm level — but the IR's string-op surface
+dispatches on `IrType.string` (not the underlying ValType), so body
+code that does `c + "world"` against the loop var would fail the
+type-equality check. Slice 6 part 4 accepts this gap; a follow-up can
+let slot bindings carry an "as IrType" widening.
+
+### Pre-existing legacy bug (NOT fixed in this slice)
+
+While testing, I discovered a pre-existing bug in the legacy path:
+`for (const c of s)` with `nativeStrings: true` produces invalid Wasm.
+Root cause: legacy captures `__str_charAt`'s funcIdx from
+`ctx.nativeStrHelpers` at registration time, but late-import shifts
+move `__str_charAt`'s actual position in the module — the captured
+index becomes stale and at runtime points to `__is_truthy` instead.
+
+The bug is reproducible on `main` without any IR changes:
+```
+compile(source, { experimentalIR: false, nativeStrings: true })
+→ wasm-validate fails: "call[0] expected externref, found i32"
+```
+
+The IR path SIDESTEPS this bug by re-resolving funcref names via
+`ctx.mod.functions[i].name` at lowering time (post-shift safe). The
+fallback was added in `IrLowerResolver.resolveFunc`. The legacy bug
+itself is out of scope — should be filed separately for legacy
+`compileForOfString` to use the same re-resolution pattern.
+
+### Tests
+
+`tests/issue-1183.test.ts`:
+  - 5 native-strings cases (count chars: 'hello', '', 'z', compound
+    assignment, 'café' BMP unicode). Asserted against JS-computed
+    expected values rather than dual-running because the legacy path
+    is broken in nativeStrings mode for string for-of.
+  - 1 host-strings case (falls through to iter-host) — dual-run
+    legacy↔IR equivalence works here.
+  - Selector + IR-error-free-compile suites.
+  - vec + iter-host regression checks.
+
+### Files touched
+
+  1. `src/ir/nodes.ts` — `IrInstrForOfString` + union update.
+  2. `src/ir/builder.ts` — `emitForOfString`.
+  3. `src/ir/from-ast.ts` — string arm + `lowerForOfString` +
+     `lowerForOfIterFromExternrefValue` factor-out + LowerCtx fields.
+  4. `src/ir/lower.ts` — `forof.string` lowering case + def-walk +
+     uses fixes.
+  5. `src/ir/verify.ts` — collectUses case.
+  6. `src/ir/passes/dead-code.ts` — side-effect classification + uses.
+  7. `src/ir/passes/inline-small.ts` — operand renaming.
+  8. `src/ir/passes/monomorphize.ts` — uses + body recursion.
+  9. `src/ir/integration.ts` — thread nativeStrings/anyStrTypeIdx;
+     `preregisterNativeStringHelpers`; resolveFunc fallback to
+     `ctx.mod.functions` for native helpers.
+  10. `tests/issue-1183.test.ts` — new equivalence cases.

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -749,6 +749,36 @@ export class IrFunctionBuilder {
       resultType: null,
     });
   }
+
+  // --- string for-of (slice 6 part 4 — #1183) -----------------------------
+
+  /**
+   * Emit a `forof.string` declarative instr — the native-strings counter
+   * loop over a string. Caller pre-allocates all four slots and passes
+   * the body buffer collected via `collectBodyInstrs`. The lowerer is
+   * responsible for emitting the `__str_charAt` calls + counter
+   * arithmetic; this builder method just records the structured node.
+   */
+  emitForOfString(args: {
+    str: IrValueId;
+    counterSlot: number;
+    lengthSlot: number;
+    strSlot: number;
+    elementSlot: number;
+    body: readonly IrInstr[];
+  }): void {
+    this.pushInstr({
+      kind: "forof.string",
+      str: args.str,
+      counterSlot: args.counterSlot,
+      lengthSlot: args.lengthSlot,
+      strSlot: args.strSlot,
+      elementSlot: args.elementSlot,
+      body: args.body,
+      result: null,
+      resultType: null,
+    });
+  }
 }
 
 // Convenience: value-id brand with no underlying type map — useful for tests

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -84,6 +84,24 @@ export interface AstToIrOptions {
    * throw, falling back to legacy.
    */
   readonly classShapes?: ReadonlyMap<string, IrClassShape>;
+  /**
+   * Slice 6 part 4 (#1183): true when the compiler is emitting native
+   * WasmGC strings (`(ref $AnyString)`) and the `__str_charAt` helper
+   * is available. Consulted by `lowerForOfStatement` to dispatch
+   * string iterables to the native counter loop (`forof.string`)
+   * versus falling through to the host iterator protocol
+   * (`forof.iter`). Defaults to `false` when omitted, matching the
+   * legacy host-strings behavior.
+   */
+  readonly nativeStrings?: boolean;
+  /**
+   * Slice 6 part 4 (#1183): the Wasm `typeIdx` of the `$AnyString`
+   * struct in native-strings mode. Required when `nativeStrings` is
+   * true so the from-ast layer can declare slot types as
+   * `(ref $AnyString)` for the string for-of loop without round-
+   * tripping through a `LowerResolver`. Ignored in host-strings mode.
+   */
+  readonly anyStrTypeIdx?: number;
 }
 
 /**
@@ -145,6 +163,8 @@ export function lowerFunctionAstToIr(fn: ts.FunctionDeclaration, options: AstToI
     returnType,
     calleeTypes: options.calleeTypes,
     classShapes: options.classShapes,
+    nativeStrings: options.nativeStrings ?? false,
+    anyStrTypeIdx: options.anyStrTypeIdx,
     lifted,
     liftedCounter,
     mutatedLets,
@@ -363,6 +383,20 @@ interface LowerCtx {
   readonly calleeTypes?: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType }>;
   /** Slice 4 (#1169d) — class shape registry, keyed by className. */
   readonly classShapes?: ReadonlyMap<string, IrClassShape>;
+  /**
+   * Slice 6 part 4 (#1183) — true when the compiler is in
+   * native-strings mode. Drives the for-of strategy switch for
+   * `string`-typed iterables: native → `forof.string` (counter loop
+   * with `__str_charAt`); host → fall through to `forof.iter`.
+   */
+  readonly nativeStrings: boolean;
+  /**
+   * Slice 6 part 4 (#1183) — Wasm `typeIdx` of the `$AnyString` struct
+   * when `nativeStrings` is true. Used by `lowerForOfString` to set
+   * slot types (`(ref $AnyString)`) for the str / element slots
+   * without threading the full resolver into LowerCtx.
+   */
+  readonly anyStrTypeIdx?: number;
   /** Slice 3 — output bin for lifted closures / nested funcs. */
   readonly lifted: IrFunction[];
   /** Slice 3 — mutable counter for synthesizing lifted-func names. */
@@ -1266,13 +1300,33 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
   //                                    shape; if it isn't a vec, lowering
   //                                    throws and the function falls back
   //                                    to legacy.
-  //   - `(val) externref`           → iter-host (this slice — #1182).
+  //   - `string` (native mode)      → string fast path (slice 6 part 4 — #1183).
+  //                                    Counter loop with `__str_charAt`.
+  //   - `string` (host mode)         → fall through to iter-host. The
+  //                                    string IR value is already
+  //                                    externref-backed in host mode, so
+  //                                    no coercion is needed.
+  //   - `(val) externref`           → iter-host (slice 6 part 3 — #1182).
   //   - `class` / `object`           → iter-host (with extern.convert_any
   //                                    coercion).
   //   - anything else                → throw, fall back to legacy.
   const valTy = asVal(iterableT);
   if (valTy && (valTy.kind === "ref" || valTy.kind === "ref_null")) {
     lowerForOfVec(stmt, cx, iterableV, valTy, loopVarName);
+    return;
+  }
+  if (iterableT.kind === "string") {
+    if (cx.nativeStrings) {
+      lowerForOfString(stmt, cx, iterableV, loopVarName);
+      return;
+    }
+    // Host-strings mode: fall through to iter-host. The string's
+    // underlying ValType is already externref, so no coercion is
+    // needed — the iter-host arm passes `iterableV` straight to
+    // `__iterator`. We bind the loop variable as externref (host
+    // strings only have host-side string semantics; the iter-host
+    // element is opaque externref by design).
+    lowerForOfIterFromExternrefValue(stmt, cx, iterableV, loopVarName, /* alreadyExternref */ true);
     return;
   }
 
@@ -1283,37 +1337,101 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
       `ir/from-ast: for-of iterable type ${describeIrType(iterableT)} not supported in slice 6 (${cx.funcName})`,
     );
   }
+  lowerForOfIterFromExternrefValue(stmt, cx, iterableV, loopVarName, valTy?.kind === "externref");
+}
 
-  // Coerce to externref if not already. extern.convert_any is a Wasm
-  // 1-arg op that re-tags any reference as externref.
+/**
+ * Slice 6 part 3 (#1182) iter-host emit helper, factored out of
+ * `lowerForOfStatement` so the string-arm host-strings fall-through can
+ * reuse it. `alreadyExternref` skips the `extern.convert_any` coercion
+ * when the input value is already externref-typed at the Wasm level
+ * (true for `(val) externref` and for `IrType.string` in host mode).
+ */
+function lowerForOfIterFromExternrefValue(
+  stmt: ts.ForOfStatement,
+  cx: LowerCtx,
+  iterableV: IrValueId,
+  loopVarName: string,
+  alreadyExternref: boolean,
+): void {
   let iterableExt = iterableV;
-  if (valTy?.kind !== "externref") {
+  if (!alreadyExternref) {
     iterableExt = cx.builder.emitCoerceToExternref(iterableV);
   }
 
-  // Allocate the three iter-host slots — all externref. The element
-  // slot's IR type is `irVal({ kind: "externref" })`; the loop-var
-  // binding inherits this.
   const iterSlot = cx.builder.declareSlot("__forof_iter", { kind: "externref" });
   const resultSlot = cx.builder.declareSlot("__forof_result", { kind: "externref" });
   const elementSlot = cx.builder.declareSlot("__forof_elem", { kind: "externref" });
 
-  // Bind the loop variable as a `slot` ScopeBinding (externref-typed).
   const elemIrT: IrType = irVal({ kind: "externref" });
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
   const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
 
-  // Collect body instrs.
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
   });
 
-  // Emit the declarative iter-host for-of instr.
   cx.builder.emitForOfIter({
     iterable: iterableExt,
     iterSlot,
     resultSlot,
+    elementSlot,
+    body,
+  });
+}
+
+/**
+ * Slice 6 part 4 (#1183) — native-strings string for-of. Iterates code
+ * units via `__str_charAt(str, i)`. The element IR type is `string`
+ * (single-char string ref); body code can compose with slice-1 string
+ * ops. The slot ValType is `(ref $AnyString)`, supplied by
+ * `nativeStringRefValType` (the lowering-time resolver shape — we
+ * synthesize the same shape here so from-ast doesn't need a resolver
+ * thread-through). The lowerer cross-checks the slot type against
+ * `resolver.resolveString()` at emit time.
+ */
+function lowerForOfString(stmt: ts.ForOfStatement, cx: LowerCtx, strV: IrValueId, loopVarName: string): void {
+  // Native-strings mode requires the AnyString typeIdx threaded
+  // through `LowerCtx.anyStrTypeIdx`. Without it we can't declare
+  // the slot ValTypes for the str/element refs, so the function
+  // falls back to legacy via the generic throw.
+  if (cx.anyStrTypeIdx === undefined) {
+    throw new Error(`ir/from-ast: native-strings for-of needs anyStrTypeIdx in LowerCtx (${cx.funcName})`);
+  }
+  const strRef: ValType = { kind: "ref", typeIdx: cx.anyStrTypeIdx };
+
+  const counterSlot = cx.builder.declareSlot("__forof_si", { kind: "i32" });
+  const lengthSlot = cx.builder.declareSlot("__forof_slen", { kind: "i32" });
+  const strSlot = cx.builder.declareSlot("__forof_str", strRef);
+  const elementSlot = cx.builder.declareSlot("__forof_selem", strRef);
+
+  // The loop variable is bound as a slot of `(ref $AnyString)`. In
+  // native-strings mode the `IrType.string` lowering also produces
+  // `(ref $AnyString)`, so as a Wasm value the slot read result and a
+  // string-typed SSA value are interchangeable. We record the binding
+  // type as `irVal(strRef)` (matching what `emitSlotRead` returns) so
+  // identifier reads against the loop var lower to `slot.read` cleanly.
+  // For body code that wants string ops on the loop var (e.g.
+  // `c + "world"`), the IR's string-op surface dispatches on
+  // `IrType.string`. Slice 6 part 4 doesn't yet upcast the slot read
+  // result to `IrType.string`; that's a follow-up. Body code that
+  // doesn't compose with string ops (concatenation in a temp before
+  // using the loop var, etc.) works today.
+  const elemIrT: IrType = irVal(strRef);
+  const bodyScope = new Map(cx.scope);
+  bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+
+  const body = cx.builder.collectBodyInstrs(() => {
+    lowerStmt(stmt.statement, bodyCx);
+  });
+
+  cx.builder.emitForOfString({
+    str: strV,
+    counterSlot,
+    lengthSlot,
+    strSlot,
     elementSlot,
     body,
   });
@@ -1951,6 +2069,8 @@ function liftNestedFunction(
     returnType: signature.returnType,
     calleeTypes: cx.calleeTypes,
     classShapes: cx.classShapes,
+    nativeStrings: cx.nativeStrings,
+    anyStrTypeIdx: cx.anyStrTypeIdx,
     lifted: cx.lifted,
     liftedCounter: cx.liftedCounter,
     // Slice 6 part 2 (#1181) — nested-function bodies have their own
@@ -2020,6 +2140,8 @@ function liftClosureBody(
     returnType: signature.returnType,
     calleeTypes: cx.calleeTypes,
     classShapes: cx.classShapes,
+    nativeStrings: cx.nativeStrings,
+    anyStrTypeIdx: cx.anyStrTypeIdx,
     lifted: cx.lifted,
     liftedCounter: cx.liftedCounter,
     // Slice 6 part 2 (#1181) — closure-body mutated lets are scanned

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -25,6 +25,7 @@
 import ts from "typescript";
 
 import { addIteratorImports, addStringImports } from "../codegen/index.js";
+import { ensureNativeStringHelpers } from "../codegen/native-strings.js";
 import { addStringConstantGlobal } from "../codegen/registry/imports.js";
 import { addFuncType, getOrRegisterRefCellType } from "../codegen/registry/types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
@@ -148,6 +149,12 @@ export function compileIrPathFunctions(
         returnTypeOverride: o?.returnType,
         calleeTypes,
         classShapes,
+        // Slice 6 part 4 (#1183): thread the nativeStrings flag and
+        // AnyString typeIdx so `lowerForOfStatement`'s string arm can
+        // pick the native counter loop and declare slot ValTypes
+        // without round-tripping through a full LowerResolver.
+        nativeStrings: ctx.nativeStrings,
+        anyStrTypeIdx: ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : undefined,
       });
       const mainErrors = verifyIrFunction(result.main);
       if (mainErrors.length > 0) {
@@ -331,6 +338,17 @@ export function compileIrPathFunctions(
   // matches `preregisterStringSupport`'s rationale.
   // -------------------------------------------------------------------------
   preregisterIteratorSupport(ctx, readyForLower);
+
+  // -------------------------------------------------------------------------
+  // Slice 6 part 4 (#1183) — native-string helpers (notably __str_charAt).
+  //
+  // Walk every IR function for any `forof.string` instr; if found, call
+  // `ensureNativeStringHelpers(ctx)` so `__str_charAt` (and the rest of
+  // the native-string helper family) is registered before the lowerer
+  // resolves the funcref. The helper itself is idempotent, but calling
+  // it eagerly avoids late-import shifts during Phase 3 emission.
+  // -------------------------------------------------------------------------
+  preregisterNativeStringHelpers(ctx, readyForLower);
 
   // -------------------------------------------------------------------------
   // Phase 3 — Lower: translate each IrFunction to Wasm and install in ctx.
@@ -527,8 +545,25 @@ function makeResolver(
   return {
     resolveFunc(ref: IrFuncRef): number {
       const idx = ctx.funcMap.get(ref.name);
-      if (idx === undefined) throw new Error(`ir/integration: unknown function ref "${ref.name}"`);
-      return idx;
+      if (idx !== undefined) return idx;
+      // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,
+      // `__str_concat`, `__str_equals`, `__str_flatten`, etc.) are
+      // registered in `ctx.nativeStrHelpers`, not `ctx.funcMap`. The
+      // helper map captures funcIdx at registration time and does NOT
+      // get re-shifted by late-import passes, so we re-resolve by name
+      // against the post-shift `ctx.mod.functions` (parallel to
+      // `computeStringBackend`'s rationale for the host string ops).
+      for (let i = 0; i < ctx.mod.functions.length; i++) {
+        if (ctx.mod.functions[i]!.name === ref.name) {
+          return ctx.numImportFuncs + i;
+        }
+      }
+      // Last fallback: the (potentially stale) helpers map. Used when
+      // a name doesn't appear in `ctx.mod.functions` because it's a
+      // host import rather than a defined helper.
+      const helperIdx = ctx.nativeStrHelpers.get(ref.name);
+      if (helperIdx !== undefined) return helperIdx;
+      throw new Error(`ir/integration: unknown function ref "${ref.name}"`);
     },
     resolveGlobal(ref: IrGlobalRef): number {
       const localIdx = ctx.mod.globals.findIndex((g) => g.name === ref.name);
@@ -777,6 +812,49 @@ function preregisterIteratorSupport(ctx: CodegenContext, fns: readonly BuiltFnRe
       for (const instr of block.instrs) {
         if (usesIter(instr)) {
           addIteratorImports(ctx);
+          return;
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Native-string helper pre-registration (#1183)
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice 6 part 4 (#1183): pre-register native-string helpers
+ * (`__str_charAt`, `__str_concat`, `__str_equals`, `__str_flatten`, …)
+ * if any IR function emits a `forof.string` instr. Same rationale as
+ * `preregisterStringSupport` and `preregisterIteratorSupport` —
+ * idempotent helper, called eagerly so Phase 3's funcref resolution
+ * sees stable indices.
+ *
+ * `forof.string` is only produced by from-ast in native-strings mode,
+ * so the helper call here is a no-op in host-strings mode.
+ */
+function preregisterNativeStringHelpers(ctx: CodegenContext, fns: readonly BuiltFnRef[]): void {
+  if (!ctx.nativeStrings) return;
+  const usesForOfString = (instr: IrInstr): boolean => {
+    switch (instr.kind) {
+      case "forof.string":
+        return true;
+      case "forof.vec":
+      case "forof.iter":
+        for (const sub of instr.body) {
+          if (usesForOfString(sub)) return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  };
+  for (const entry of fns) {
+    for (const block of entry.fn.blocks) {
+      for (const instr of block.instrs) {
+        if (usesForOfString(instr)) {
+          ensureNativeStringHelpers(ctx);
           return;
         }
       }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -318,7 +318,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       defBy.set(instr.result, instr);
       defBlockOf.set(instr.result, blockId);
     }
-    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter" || instr.kind === "forof.string") {
       for (const sub of instr.body) registerInstrDefs(sub, blockId);
     }
   };
@@ -375,7 +375,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       // execution makes ANY outer-defined value's use a candidate for
       // cross-block materialisation. Mark uses with a synthetic block
       // ID (-1 for "inside-body") so the cross-block test always fires.
-      if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
+      if (instr.kind === "forof.vec" || instr.kind === "forof.iter" || instr.kind === "forof.string") {
         for (const u of collectForOfBodyUses(instr.body)) recordUse(u, -1);
       }
     }
@@ -419,7 +419,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
       locals.push({ name: `$ir${instr.result}`, type: lowerIrTypeToValType(instr.resultType, resolver, func.name) });
       localIdx.set(instr.result, idx);
     }
-    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter" || instr.kind === "forof.string") {
       for (const sub of instr.body) allocLocalForInstr(sub);
     }
   };
@@ -1017,6 +1017,89 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         out.push({ op: "call", funcIdx: iteratorReturnIdx });
         return;
       }
+      // Slice 6 part 4 (#1183) — string for-of (native-strings mode).
+      // Counter loop with `__str_charAt(str, i)`. The from-ast layer
+      // ensures this case only runs in native-strings mode (host-strings
+      // mode falls through to forof.iter).
+      case "forof.string": {
+        const charAtIdx = resolver.resolveFunc({ kind: "func", name: "__str_charAt" });
+        // The AnyString struct's `len` field is at index 0 (matches
+        // `nativeStringType` in src/codegen/native-strings.ts).
+        // We recover the typeIdx from the SSA value's IrType — must be
+        // string-typed (resolveString() produces (ref $AnyString) in
+        // native mode). The lowerer reads the resultType off the
+        // defining instr or param.
+        const strIrT = typeOf(instr.str);
+        if (strIrT.kind !== "string") {
+          throw new Error(`ir/lower: forof.string str must be IrType.string, got ${strIrT.kind} (${func.name})`);
+        }
+        const strRef = resolver.resolveString?.();
+        if (!strRef || strRef.kind !== "ref") {
+          throw new Error(`ir/lower: forof.string requires native-strings (resolveString()=ref) (${func.name})`);
+        }
+        const anyStrTypeIdx = (strRef as { typeIdx: number }).typeIdx;
+
+        // <emit str>; local.set <strSlot>
+        emitValue(instr.str, out);
+        out.push({ op: "local.set", index: slotWasmIdx(instr.strSlot) });
+
+        // length = str.len  (struct field 0)
+        out.push({ op: "local.get", index: slotWasmIdx(instr.strSlot) });
+        out.push({ op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 });
+        out.push({ op: "local.set", index: slotWasmIdx(instr.lengthSlot) });
+
+        // counter = 0
+        out.push({ op: "i32.const", value: 0 });
+        out.push({ op: "local.set", index: slotWasmIdx(instr.counterSlot) });
+
+        // Build loop body Wasm ops.
+        const loopBody: Instr[] = [];
+        // if (counter >= length) br 1 (exit)
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.counterSlot) });
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.lengthSlot) });
+        loopBody.push({ op: "i32.ge_s" });
+        loopBody.push({ op: "br_if", depth: 1 });
+
+        // element = __str_charAt(str, counter)
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.strSlot) });
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.counterSlot) });
+        loopBody.push({ op: "call", funcIdx: charAtIdx });
+        loopBody.push({ op: "local.set", index: slotWasmIdx(instr.elementSlot) });
+
+        // Body instrs (same materialisation pattern as forof.vec/forof.iter).
+        for (const bodyInstr of instr.body) {
+          if (bodyInstr.result === null) {
+            emitInstrTree(bodyInstr, loopBody);
+          } else if (crossBlock.has(bodyInstr.result)) {
+            emitInstrTree(bodyInstr, loopBody);
+            loopBody.push({ op: "local.set", index: localIdx.get(bodyInstr.result)! });
+            materialized.add(bodyInstr.result);
+          }
+        }
+
+        // counter = counter + 1
+        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.counterSlot) });
+        loopBody.push({ op: "i32.const", value: 1 });
+        loopBody.push({ op: "i32.add" });
+        loopBody.push({ op: "local.set", index: slotWasmIdx(instr.counterSlot) });
+
+        // br 0 (continue)
+        loopBody.push({ op: "br", depth: 0 });
+
+        // block { loop { ... } }
+        out.push({
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: loopBody,
+            },
+          ],
+        });
+        return;
+      }
     }
   };
 
@@ -1203,6 +1286,9 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "forof.iter":
       // Same rationale as forof.vec — body uses surfaced separately.
       return [instr.iterable];
+    // Slice 6 part 4 (#1183) — string for-of.
+    case "forof.string":
+      return [instr.str];
   }
 }
 
@@ -1216,7 +1302,7 @@ export function collectForOfBodyUses(body: readonly IrInstr[]): IrValueId[] {
   const uses: IrValueId[] = [];
   for (const instr of body) {
     for (const u of collectIrUses(instr)) uses.push(u);
-    if (instr.kind === "forof.vec" || instr.kind === "forof.iter") {
+    if (instr.kind === "forof.vec" || instr.kind === "forof.iter" || instr.kind === "forof.string") {
       for (const u of collectForOfBodyUses(instr.body)) uses.push(u);
     }
   }

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1075,6 +1075,74 @@ export interface IrInstrForOfIter extends IrInstrBase {
   readonly body: readonly IrInstr[];
 }
 
+// ---------------------------------------------------------------------------
+// String for-of (#1183 — IR Phase 4 Slice 6 part 4)
+// ---------------------------------------------------------------------------
+//
+// Slice 6 part 4 adds the string fast path. When `iterableType.kind ===
+// "string"` and the compiler is in native-strings mode, the for-of loop
+// iterates code units via `__str_charAt(str, i)` — a counter loop with
+// a `(ref $AnyString, i32) -> (ref $AnyString)` host helper. In host-
+// strings mode the dispatch falls through to `forof.iter` (#1182).
+//
+// `forof.string` is a STATEMENT-level declarative instr that mirrors
+// `forof.vec` and `forof.iter`. Carries the string SSA value, the four
+// slot indices (counter / length / str / element), and the body buffer.
+
+/**
+ * Statement-level `for (const c of <string>) <body>` loop using the
+ * native-strings counter pattern. Emitted only when the resolver
+ * reports `nativeStrings(): true` — host-strings mode falls through
+ * to `forof.iter` upstream in `lowerForOfStatement`.
+ *
+ * The lowerer emits:
+ *   <emit str>
+ *   local.set <strSlot>
+ *   local.get <strSlot>
+ *   struct.get $AnyString $len
+ *   local.set <lengthSlot>
+ *   i32.const 0
+ *   local.set <counterSlot>
+ *   block
+ *     loop
+ *       local.get <counterSlot>
+ *       local.get <lengthSlot>
+ *       i32.ge_s
+ *       br_if 1
+ *       local.get <strSlot>
+ *       local.get <counterSlot>
+ *       call $__str_charAt
+ *       local.set <elementSlot>
+ *       <body instrs>
+ *       local.get <counterSlot>
+ *       i32.const 1
+ *       i32.add
+ *       local.set <counterSlot>
+ *       br 0
+ *     end
+ *   end
+ *
+ * Slot types (set by from-ast):
+ *   counterSlot — i32
+ *   lengthSlot  — i32
+ *   strSlot     — `(ref $AnyString)` (resolver.resolveString())
+ *   elementSlot — `(ref $AnyString)` — each iteration produces a
+ *                 single-char string
+ *
+ * Result: void (`result: null`).
+ */
+export interface IrInstrForOfString extends IrInstrBase {
+  readonly kind: "forof.string";
+  /** SSA value of the string (IrType.string). */
+  readonly str: IrValueId;
+  readonly counterSlot: number;
+  readonly lengthSlot: number;
+  readonly strSlot: number;
+  readonly elementSlot: number;
+  /** Body instrs emitted inside the loop. */
+  readonly body: readonly IrInstr[];
+}
+
 export type IrInstr =
   | IrInstrConst
   | IrInstrCall
@@ -1115,7 +1183,8 @@ export type IrInstr =
   | IrInstrIterDone
   | IrInstrIterValue
   | IrInstrIterReturn
-  | IrInstrForOfIter;
+  | IrInstrForOfIter
+  | IrInstrForOfString;
 
 // ---------------------------------------------------------------------------
 // Slot definitions (#1169e — IR Phase 4 Slice 6)

--- a/src/ir/passes/dead-code.ts
+++ b/src/ir/passes/dead-code.ts
@@ -204,7 +204,11 @@ function isSideEffecting(i: IrInstr): boolean {
     i.kind === "iter.new" ||
     i.kind === "iter.next" ||
     i.kind === "iter.return" ||
-    i.kind === "forof.iter"
+    i.kind === "forof.iter" ||
+    // Slice 6 part 4 (#1183): forof.string is statement-level (result:
+    // null) so the generic null-result rule already keeps it; explicit
+    // listing for clarity.
+    i.kind === "forof.string"
   );
 }
 
@@ -291,7 +295,7 @@ function collectInstrUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectInstrUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
         }
       };
       walk(instr.body);
@@ -315,7 +319,19 @@ function collectInstrUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectInstrUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
+        }
+      };
+      walk(instr.body);
+      return result;
+    }
+    // Slice 6 part 4 (#1183) — string for-of.
+    case "forof.string": {
+      const result: IrValueId[] = [instr.str];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectInstrUses(sub)) result.push(u);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
         }
       };
       walk(instr.body);

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -536,6 +536,19 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       if (!bodyChanged) return inst;
       return { ...inst, iterable: v, body: newBody };
     }
+    // Slice 6 part 4 (#1183) — string for-of.
+    case "forof.string": {
+      const v = mapId(rename, inst.str);
+      let bodyChanged = v !== inst.str;
+      const newBody: IrInstr[] = [];
+      for (const sub of inst.body) {
+        const renamed = renameInstrOperands(sub, rename);
+        if (renamed !== sub) bodyChanged = true;
+        newBody.push(renamed);
+      }
+      if (!bodyChanged) return inst;
+      return { ...inst, str: v, body: newBody };
+    }
   }
 }
 

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -674,7 +674,7 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
         }
       };
       walk(instr.body);
@@ -698,7 +698,19 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       const walk = (instrs: readonly IrInstr[]): void => {
         for (const sub of instrs) {
           for (const u of collectUses(sub)) result.push(u);
-          if (sub.kind === "forof.vec" || sub.kind === "forof.iter") walk(sub.body);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
+        }
+      };
+      walk(instr.body);
+      return result;
+    }
+    // Slice 6 part 4 (#1183) — string for-of.
+    case "forof.string": {
+      const result: IrValueId[] = [instr.str];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectUses(sub)) result.push(u);
+          if (sub.kind === "forof.vec" || sub.kind === "forof.iter" || sub.kind === "forof.string") walk(sub.body);
         }
       };
       walk(instr.body);

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -253,6 +253,9 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       // Same rationale as forof.vec: body is loop-internal, only the
       // iterable surfaces in the straight-line walk.
       return [instr.iterable];
+    // Slice 6 part 4 (#1183) — string for-of.
+    case "forof.string":
+      return [instr.str];
   }
 }
 

--- a/tests/issue-1183.test.ts
+++ b/tests/issue-1183.test.ts
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1183 — IR Phase 4 Slice 6 part 4: string fast path through IR.
+//
+// Activates the third arm of `lowerForOfStatement`: `for (const c of
+// <string>)`. In native-strings mode the loop lowers through the new
+// `forof.string` declarative IR instr (counter loop with
+// `__str_charAt`); in host-strings mode it falls through to the
+// iter-host arm (#1182).
+//
+// Each test compiles the same source twice — once with the legacy
+// path (`experimentalIR: false`) and once through the IR
+// (`experimentalIR: true`) — and asserts the exported function returns
+// the same value through both paths.
+//
+// Note: in nativeStrings mode the user function CANNOT take a `string`
+// param directly from JS (the JS string isn't auto-coerced to a
+// `(ref $AnyString)`). Tests for native-strings mode use a wrapper
+// function that materialises the string literal inline. Host-strings
+// mode tests can take the string as a param since the param IR type
+// lowers to externref.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import ts from "typescript";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+type Outcome =
+  | { kind: "ok"; value: unknown }
+  | { kind: "compile_fail"; firstMessage: string }
+  | { kind: "instantiate_fail"; reason?: string }
+  | { kind: "invoke_fail"; reason?: string };
+
+async function runOnce(
+  source: string,
+  fnName: string,
+  experimentalIR: boolean,
+  nativeStrings: boolean,
+): Promise<Outcome> {
+  const r = compile(source, { experimentalIR, nativeStrings });
+  if (!r.success) {
+    return { kind: "compile_fail", firstMessage: r.errors[0]?.message ?? "" };
+  }
+  let instance: WebAssembly.Instance;
+  try {
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    ({ instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    }));
+  } catch (e: unknown) {
+    return { kind: "instantiate_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+  try {
+    const fn = instance.exports[fnName] as () => unknown;
+    return { kind: "ok", value: fn() };
+  } catch (e: unknown) {
+    return { kind: "invoke_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function dualRun(
+  source: string,
+  fnName: string,
+  nativeStrings: boolean,
+): Promise<{ legacy: Outcome; ir: Outcome }> {
+  const [legacy, ir] = await Promise.all([
+    runOnce(source, fnName, false, nativeStrings),
+    runOnce(source, fnName, true, nativeStrings),
+  ]);
+  return { legacy, ir };
+}
+
+interface Case {
+  name: string;
+  source: string;
+  fn: string;
+  /** Names of IR-claimable functions in the source. */
+  expectedClaimed: string[];
+  nativeStrings: boolean;
+  /**
+   * For native-strings cases, the legacy path has a pre-existing bug
+   * that produces invalid Wasm for `for (const c of s)` (the captured
+   * `__str_charAt` funcIdx becomes stale after late-import shifts —
+   * tracked separately, out of scope for #1183). Assert against an
+   * expected JS-computed value instead of dual-running. The IR path
+   * fixes the bug for itself by re-resolving by name in
+   * `resolver.resolveFunc` (see `src/ir/integration.ts`).
+   */
+  expectedValue: number;
+}
+
+// Native-strings cases — string is a literal inside the function body
+// so we don't need to pass a string from JS.
+const NATIVE_CASES: Case[] = [
+  // ---- 1. count chars in a 5-char string --------------------------------
+  {
+    name: "native: count chars in 'hello' (5 chars)",
+    source: `
+      export function fn(): number {
+        const s = "hello";
+        let count = 0;
+        for (const c of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: true,
+    expectedValue: 5,
+  },
+
+  // ---- 2. empty string ---------------------------------------------------
+  {
+    name: "native: empty string returns 0",
+    source: `
+      export function fn(): number {
+        const s = "";
+        let count = 0;
+        for (const c of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: true,
+    expectedValue: 0,
+  },
+
+  // ---- 3. single-char string ---------------------------------------------
+  {
+    name: "native: single-char string",
+    source: `
+      export function fn(): number {
+        const s = "z";
+        let count = 0;
+        for (const c of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: true,
+    expectedValue: 1,
+  },
+
+  // ---- 4. compound assignment in body ------------------------------------
+  {
+    name: "native: count chars via compound assignment",
+    source: `
+      export function fn(): number {
+        const s = "abcdef";
+        let count = 0;
+        for (const c of s) {
+          count += 2;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: true,
+    expectedValue: 12,
+  },
+
+  // ---- 5. BMP unicode (counts code units) --------------------------------
+  {
+    name: "native: count code units in 'café' (4 BMP units)",
+    source: `
+      export function fn(): number {
+        const s = "café";
+        let count = 0;
+        for (const c of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: true,
+    expectedValue: 4,
+  },
+];
+
+// Host-strings case: falls through to iter-host. The legacy path also
+// works here, so we keep dual-run (legacy↔IR equivalence).
+const HOST_CASES: Case[] = [
+  {
+    name: "host: count chars (falls through to iter-host)",
+    source: `
+      export function fn(): number {
+        const s = "hello";
+        let count = 0;
+        for (const c of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `,
+    fn: "fn",
+    expectedClaimed: ["fn"],
+    nativeStrings: false,
+    expectedValue: 5,
+  },
+];
+
+describe("#1183 — string for-of through IR (slice 6 part 4) — native mode", () => {
+  // Legacy path has a pre-existing bug in nativeStrings mode for string
+  // for-of (stale `__str_charAt` funcIdx after late-import shifts). The
+  // IR path resolves funcref names by walking `ctx.mod.functions`, which
+  // is post-shift safe. So we only assert IR output against a known
+  // expected value here, not dual-run.
+  for (const tc of NATIVE_CASES) {
+    it(tc.name, async () => {
+      const ir = await runOnce(tc.source, tc.fn, true, tc.nativeStrings);
+      if (ir.kind !== "ok") {
+        throw new Error(`ir run failed: ${JSON.stringify(ir)}`);
+      }
+      expect(ir.value).toBe(tc.expectedValue);
+    });
+  }
+});
+
+describe("#1183 — string for-of through IR (slice 6 part 4) — host-strings fall-through", () => {
+  for (const tc of HOST_CASES) {
+    it(tc.name, async () => {
+      const { legacy, ir } = await dualRun(tc.source, tc.fn, tc.nativeStrings);
+      if (legacy.kind !== "ok") {
+        throw new Error(`legacy run failed: ${JSON.stringify(legacy)}`);
+      }
+      if (ir.kind !== "ok") {
+        throw new Error(`ir run failed: ${JSON.stringify(ir)}`);
+      }
+      expect(ir.value).toBe(legacy.value);
+    });
+  }
+});
+
+describe("#1183 — selector claims string-for-of-shaped functions", () => {
+  for (const tc of [...NATIVE_CASES, ...HOST_CASES]) {
+    it(`selector claims ${tc.fn} from "${tc.name}"`, () => {
+      const sf = ts.createSourceFile("test.ts", tc.source, ts.ScriptTarget.ES2022, true);
+      const sel = planIrCompilation(sf, { experimentalIR: true });
+      for (const name of tc.expectedClaimed) {
+        expect([...sel.funcs]).toContain(name);
+      }
+    });
+  }
+});
+
+describe("#1183 — IR compile produces no IR-fallback errors", () => {
+  for (const tc of [...NATIVE_CASES, ...HOST_CASES]) {
+    it(`compiles "${tc.name}" cleanly under experimentalIR`, () => {
+      const r = compile(tc.source, { experimentalIR: true, nativeStrings: tc.nativeStrings });
+      expect(r.success).toBe(true);
+      const irErrors = r.errors.filter(
+        (e) =>
+          e.message.startsWith("IR path failed") ||
+          e.message.startsWith("ir/from-ast") ||
+          e.message.startsWith("ir/lower"),
+      );
+      expect(irErrors).toEqual([]);
+    });
+  }
+});
+
+describe("#1183 — vec / iter-host arms still work alongside string arm", () => {
+  it("array iteration still routes through forof.vec", async () => {
+    const source = `
+      export function builder(): number[] { return [1, 2, 3, 4, 5]; }
+      export function fn(arr: number[]): number {
+        let sum = 0;
+        for (const x of arr) {
+          sum += x;
+        }
+        return sum;
+      }
+    `;
+    const r = compile(source, { experimentalIR: true });
+    expect(r.success).toBe(true);
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    });
+    const arr = (instance.exports.builder as () => unknown)();
+    const result = (instance.exports.fn as (a: unknown) => unknown)(arr);
+    expect(result).toBe(15);
+  });
+
+  it("Set iteration still routes through forof.iter (host iterator protocol)", async () => {
+    const source = `
+      export function fn(s: Set<number>): number {
+        let count = 0;
+        for (const x of s) {
+          count = count + 1;
+        }
+        return count;
+      }
+    `;
+    const r = compile(source, { experimentalIR: true });
+    expect(r.success).toBe(true);
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    });
+    const result = (instance.exports.fn as (a: unknown) => unknown)(new Set([1, 2, 3]));
+    expect(result).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1183** — slice 6 part 4 of the IR migration. The third arm of `lowerForOfStatement` lands: `for (const c of <string>)`. In native-strings mode it lowers through a new `forof.string` declarative IR instr (counter loop with `__str_charAt`); in host-strings mode it falls through to the iter-host arm shipped in #1182.

- New `forof.string` declarative instr (parallel to `forof.vec` and `forof.iter`).
- Strategy dispatch in `lowerForOfStatement`: vec → vec arm; string + nativeStrings → string arm; string + host → iter-host fall-through; externref/class/object → iter-host.
- `LowerCtx` / `AstToIrOptions` get `nativeStrings` + `anyStrTypeIdx` fields, threaded from `compileIrPathFunctions`.
- `IrLowerResolver.resolveFunc` falls back to `ctx.mod.functions` name walk for native helpers (sidesteps a pre-existing legacy bug where `ctx.nativeStrHelpers` caches stale funcIdx after late-import shifts).
- Pre-registers native-string helpers when any IR function emits `forof.string`.

## Test plan

- [x] New equivalence tests `tests/issue-1183.test.ts` — 20/20 pass (5 native-mode char-counts, 1 host-mode dual-run, selector claims, IR-error-free compile, vec+iter-host regression).
- [x] Prior IR slice tests (`tests/issue-1169d.test.ts`, `tests/issue-1169e-bridge.test.ts`, `tests/issue-1182.test.ts`, `tests/ir/`) — 108/108 pass.
- [x] `npx tsc --noEmit` — 0 errors.
- [x] Local equivalence test suite (`tests/equivalence/**`) — exit 0.
- [ ] CI (GitHub Actions) — wait for `.claude/ci-status/pr-<N>.json` then self-merge per dev protocol.

## Notes

- A pre-existing bug in the **legacy** path produces invalid Wasm for `for (const c of s)` with `nativeStrings: true` (stale `__str_charAt` funcIdx after late-import shifts). The IR sidesteps this by re-resolving funcref names against `ctx.mod.functions`. The legacy fix is out of scope here — file as a separate issue.

## Out of scope

- Per-grapheme iteration (legacy + IR both iterate code units; matches legacy).
- For-await over async string-emitting iterables — slice 7 (#1169f).
- Loop var "as IrType.string" upcast — body string ops on the loop var would currently fail type-equality; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)