### PR TITLE
feat(ir): slice 7b — non-numeric yields, bare yield, yield* delegation (#1169f)

### DIFF
--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -605,6 +605,20 @@ export class IrFunctionBuilder {
     return result;
   }
 
+  /**
+   * Slice 7b (#1169f): emit a `gen.yieldStar` instr — drain the inner
+   * iterable into the outer generator's buffer via
+   * `__gen_yield_star(buf, inner)`. The caller MUST coerce `inner` to
+   * externref upstream (e.g. via `emitCoerceToExternref`) — the host
+   * import expects an externref in arg position 1.
+   */
+  emitGenYieldStar(inner: IrValueId): void {
+    if (this.funcKind !== "generator") {
+      throw new Error(`IrFunctionBuilder: emitGenYieldStar requires funcKind=generator (${this.name})`);
+    }
+    this.pushInstr({ kind: "gen.yieldStar", inner, result: null, resultType: null });
+  }
+
   private requireBlock(): OpenBlock {
     if (this.current === null) {
       throw new Error(`IrFunctionBuilder: no open block (func ${this.name})`);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -314,32 +314,34 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
  */
 function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
   if (ts.isReturnStatement(stmt)) {
-    // Slice 7a (#1169f): generator return. Match the legacy semantics
+    // Slice 7a/7b (#1169f): generator return. Match the legacy semantics
     // (`compileReturnStatement` in `codegen/statements/control-flow.ts`
     // line 89-123): a `return <value>` inside a `function*` pushes
     // `<value>` onto the eager buffer as a final yielded value, then
     // wraps the buffer with `__create_generator` to produce the
     // externref Generator object. This is non-spec — JS spec says the
     // return value lands in `IteratorResult.value` with `done:true` —
-    // but matching legacy is the correctness target for slice 7a so
-    // existing test262 coverage doesn't drift.
+    // but matching legacy is the correctness target so existing
+    // test262 coverage doesn't drift.
     //
-    // Slice 7a only supports numeric (f64) return values — same scope
-    // as `lowerYield`. Non-numeric returns throw and the function
-    // falls back to legacy.
+    // Slice 7b widens the return type: we accept any Phase-1 expression
+    // and route it through the same `lowerYield`-style dispatch
+    // (f64/i32 stay native; ref/string/object/class coerce to
+    // externref → __gen_push_ref). Same dispatch logic as `lowerYield`
+    // except we get a `ts.Expression` already, not a YieldExpression.
     if (cx.funcKind === "generator") {
       if (stmt.expression) {
-        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "f64" }));
+        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
         const vt = cx.builder.typeOf(v);
-        if (asVal(vt)?.kind !== "f64") {
-          throw new Error(
-            `ir/from-ast: generator return must be f64 in slice 7a (got ${describeIrType(vt)}) (${cx.funcName})`,
-          );
+        const valTy = asVal(vt);
+        if (valTy?.kind === "f64" || valTy?.kind === "i32") {
+          cx.builder.emitGenPush(v);
+        } else {
+          // Reference-shaped — coerce to externref upstream so the
+          // lowerer's `__gen_push_ref` arm sees the right Wasm type.
+          const vExt = coerceYieldValueToExternref(v, cx);
+          cx.builder.emitGenPush(vExt);
         }
-        // Push the return value onto the buffer so consumers see it
-        // as a final `done:false` next() result, mirroring legacy
-        // (`__gen_push_f64(buf, val)`).
-        cx.builder.emitGenPush(v);
       }
       const generatorObj = cx.builder.emitGenEpilogue();
       cx.builder.terminate({ kind: "return", values: [generatorObj] });
@@ -1354,12 +1356,26 @@ function lowerPropertyAssignment(expr: ts.BinaryExpression, cx: LowerCtx): void 
 // ---------------------------------------------------------------------------
 
 /**
- * Slice 7a (#1169f): lower a `yield <expr>;` statement. The yielded
+ * Slice 7a/7b (#1169f): lower a yield expression-statement. The yielded
  * value is pushed onto the generator's `__gen_buffer` Wasm-local slot
- * via `gen.push`, which the lowerer expands to a typed
- * `__gen_push_*` host call (slice 7a only emits `__gen_push_f64`,
- * since the selector restricts yield operands to Phase-1 numeric
- * expressions).
+ * via `gen.push`, which the lowerer expands to a typed `__gen_push_*`
+ * host call dispatched on the value's IrType (f64 → push_f64,
+ * i32 → push_i32, otherwise externref → push_ref).
+ *
+ * Slice 7b adds three extensions:
+ *   - **Bare `yield;`** — emits a null-externref const + `gen.push`,
+ *     matching legacy's "yield with no value" semantics (every
+ *     consumer sees `IteratorResult { value: undefined, done: false }`
+ *     for that step).
+ *   - **`yield <non-numeric>`** — strings, booleans-as-i32 stay native;
+ *     ref/object/class/closure values coerce to externref via
+ *     `coerce.to_externref` (the `extern.convert_any` Wasm op), then
+ *     flow through `__gen_push_ref(buf, externref)`.
+ *   - **`yield* <iterable>`** — coerces the iterable to externref and
+ *     emits `gen.yieldStar`, which lowers to
+ *     `__gen_yield_star(buf, iterable)`. The host iterator-protocol
+ *     drains every value from the inner iterable into the outer
+ *     buffer (see `runtime.ts:2999`).
  *
  * Defensive: throws if the enclosing function isn't a generator. The
  * selector should have rejected the function in that case, but a
@@ -1370,22 +1386,102 @@ function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
   if (cx.funcKind !== "generator") {
     throw new Error(`ir/from-ast: yield outside generator function in ${cx.funcName}`);
   }
+
+  // ---------------------------------------------------------------
+  // `yield* <iterable>` — slice 7b.
+  // ---------------------------------------------------------------
   if (expr.asteriskToken) {
-    // `yield* <iterable>` — slice 7b.
-    throw new Error(`ir/from-ast: yield* delegation not in slice 7a (${cx.funcName})`);
+    if (!expr.expression) {
+      // TS parser enforces this; keep as defense-in-depth.
+      throw new Error(`ir/from-ast: yield* requires an iterable in ${cx.funcName}`);
+    }
+    // Lower the iterable with an externref hint; the iterable's
+    // actual IrType might be vec/string/object/externref. Coerce to
+    // externref via the slice-6-part-3 helper so the host
+    // `__gen_yield_star(externref, externref)` import sees the
+    // right Wasm value type.
+    const inner = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
+    const innerExt = coerceYieldValueToExternref(inner, cx);
+    cx.builder.emitGenYieldStar(innerExt);
+    return;
   }
+
+  // ---------------------------------------------------------------
+  // Bare `yield;` (no value) — slice 7b.
+  // ---------------------------------------------------------------
   if (!expr.expression) {
-    // `yield;` (no value) — slice 7b.
-    throw new Error(`ir/from-ast: bare yield (no value) not in slice 7a (${cx.funcName})`);
-  }
-  const value = lowerExpr(expr.expression, cx, irVal({ kind: "f64" }));
-  const valueType = cx.builder.typeOf(value);
-  if (asVal(valueType)?.kind !== "f64") {
-    throw new Error(
-      `ir/from-ast: yield expression must lower to f64 (got ${describeIrType(valueType)}) in slice 7a (${cx.funcName})`,
+    // Materialize a null externref and push as ref. Legacy emits
+    // the same shape (`__gen_push_ref(buf, ref.null.extern)`) when
+    // a `yield;` statement appears in a generator body.
+    const nullExt = cx.builder.emitConst(
+      { kind: "null", ty: irVal({ kind: "externref" }) },
+      irVal({ kind: "externref" }),
     );
+    cx.builder.emitGenPush(nullExt);
+    return;
   }
-  cx.builder.emitGenPush(value);
+
+  // ---------------------------------------------------------------
+  // `yield <expr>` — slice 7a (numeric) and 7b (any Phase-1 type).
+  // ---------------------------------------------------------------
+  // Lower with an externref hint as a fallback shape; the IR type
+  // recovered via `typeOf` drives the dispatch below. For numeric
+  // and bool yields the lowerer's downstream typing keeps them as
+  // f64/i32 — `lowerExpr`'s `hint` is advisory, not authoritative.
+  const value = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
+  const valueType = cx.builder.typeOf(value);
+  const valTy = asVal(valueType);
+  if (valTy?.kind === "f64" || valTy?.kind === "i32") {
+    // Native primitive yield — `gen.push` lowerer dispatches to
+    // `__gen_push_f64` / `__gen_push_i32` directly.
+    cx.builder.emitGenPush(value);
+    return;
+  }
+  // Reference-shaped yield — coerce to externref so the lowerer's
+  // `__gen_push_ref(buf, externref)` arm sees the right Wasm type.
+  const valueExt = coerceYieldValueToExternref(value, cx);
+  cx.builder.emitGenPush(valueExt);
+}
+
+/**
+ * Slice 7b helper: coerce a yielded SSA value to externref for the
+ * `__gen_push_ref` / `__gen_yield_star` arms. Skips the coerce when
+ * the value's underlying Wasm valtype is ALREADY externref —
+ * emitting `extern.convert_any` on an already-externref operand is
+ * actually a Wasm validation error (the op expects an `anyref`
+ * subtype, and `externref` is NOT a subtype of `anyref`).
+ *
+ * Cases that skip the coerce:
+ *   - `IrType.val` with `val.kind === "externref"` — directly externref.
+ *   - `IrType.string` in HOST-strings mode — `resolveString()` returns
+ *     externref for the host backend (the wasm:js-string imports take
+ *     externref), so the value flowing through is already externref.
+ *
+ * Cases that DO coerce:
+ *   - `IrType.string` in NATIVE-strings mode — value is `(ref $AnyString)`,
+ *     a struct ref subtype of anyref, so `extern.convert_any` re-tags it.
+ *   - `IrType.val` with `val.kind === "ref"` / `"ref_null"` —
+ *     struct/array refs are anyref subtypes; coerce is valid.
+ *   - `IrType.object` / `class` / `closure` — all backed by struct refs,
+ *     anyref subtypes; coerce is valid.
+ *
+ * Reuses `coerce.to_externref` (#1182) so the generator path and the
+ * iter-host for-of path share one IR primitive — the lowerer emits
+ * `extern.convert_any` for both.
+ */
+function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId {
+  const t = cx.builder.typeOf(value);
+  if (t.kind === "val" && t.val.kind === "externref") {
+    return value;
+  }
+  // Host-strings mode: `IrType.string` flows as externref through Wasm.
+  // Skip the coerce so we don't emit a validation-rejected
+  // `extern.convert_any` over a global.get of externref-typed string
+  // global.
+  if (t.kind === "string" && !cx.nativeStrings) {
+    return value;
+  }
+  return cx.builder.emitCoerceToExternref(value);
 }
 
 /**

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1352,132 +1352,48 @@ function lowerPropertyAssignment(expr: ts.BinaryExpression, cx: LowerCtx): void 
 // ---------------------------------------------------------------------------
 
 /**
- * Slice 7a/7b (#1169f): lower a yield expression-statement. The yielded
+ * Slice 7a (#1169f): lower a `yield <expr>;` statement. The yielded
  * value is pushed onto the generator's `__gen_buffer` Wasm-local slot
- * via `gen.push`, which the lowerer expands to a typed `__gen_push_*`
- * host call dispatched on the value's IrType (f64 → push_f64,
- * i32 → push_i32, otherwise externref → push_ref).
- *
- * Slice 7b adds three extensions:
- *   - **Bare `yield;`** — emits a null-externref const + `gen.push`,
- *     matching legacy's "yield with no value" semantics (every
- *     consumer sees `IteratorResult { value: undefined, done: false }`
- *     for that step).
- *   - **`yield <non-numeric>`** — strings, booleans-as-i32 stay native;
- *     ref/object/class/closure values coerce to externref via
- *     `coerce.to_externref` (the `extern.convert_any` Wasm op), then
- *     flow through `__gen_push_ref(buf, externref)`.
- *   - **`yield* <iterable>`** — coerces the iterable to externref and
- *     emits `gen.yieldStar`, which lowers to
- *     `__gen_yield_star(buf, iterable)`. The host iterator-protocol
- *     drains every value from the inner iterable into the outer
- *     buffer (see `runtime.ts:2999`).
+ * via `gen.push`, which the lowerer expands to a typed
+ * `__gen_push_*` host call (slice 7a only emits `__gen_push_f64`,
+ * since the selector restricts yield operands to Phase-1 numeric
+ * expressions).
  *
  * Defensive: throws if the enclosing function isn't a generator. The
  * selector should have rejected the function in that case, but a
  * defensive check here surfaces selector regressions as a clean
  * fall-back to legacy rather than malformed Wasm.
+ *
+ * (Slice 7b retrospective: an attempted widening to bare `yield;`,
+ * `yield* <iterable>`, and non-numeric yields was reverted in
+ * commit `<this commit>` after PR #73 CI showed ~240 test262
+ * regressions clustered in `eval-code` / TypedArray / WeakMap test
+ * directories. The IR scaffolding for `gen.yieldStar` is preserved
+ * in `nodes.ts` / `builder.ts` / the lower+pass dispatch arms, so a
+ * future slice can re-attempt the widening with a localized fix.)
  */
 function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
   if (cx.funcKind !== "generator") {
     throw new Error(`ir/from-ast: yield outside generator function in ${cx.funcName}`);
   }
-
-  // ---------------------------------------------------------------
-  // `yield* <iterable>` — slice 7b.
-  // ---------------------------------------------------------------
   if (expr.asteriskToken) {
-    if (!expr.expression) {
-      // TS parser enforces this; keep as defense-in-depth.
-      throw new Error(`ir/from-ast: yield* requires an iterable in ${cx.funcName}`);
-    }
-    // Lower the iterable with an externref hint; the iterable's
-    // actual IrType might be vec/string/object/externref. Coerce to
-    // externref via the slice-6-part-3 helper so the host
-    // `__gen_yield_star(externref, externref)` import sees the
-    // right Wasm value type.
-    const inner = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
-    const innerExt = coerceYieldValueToExternref(inner, cx);
-    cx.builder.emitGenYieldStar(innerExt);
-    return;
+    // `yield* <iterable>` — slice 7b (deferred — IR scaffolding present
+    // via `gen.yieldStar` but not wired here; throw triggers fallback
+    // to legacy).
+    throw new Error(`ir/from-ast: yield* delegation not in slice 7a (${cx.funcName})`);
   }
-
-  // ---------------------------------------------------------------
-  // Bare `yield;` (no value) — slice 7b.
-  // ---------------------------------------------------------------
   if (!expr.expression) {
-    // Materialize a null externref and push as ref. Legacy emits
-    // the same shape (`__gen_push_ref(buf, ref.null.extern)`) when
-    // a `yield;` statement appears in a generator body.
-    const nullExt = cx.builder.emitConst(
-      { kind: "null", ty: irVal({ kind: "externref" }) },
-      irVal({ kind: "externref" }),
-    );
-    cx.builder.emitGenPush(nullExt);
-    return;
+    // `yield;` (no value) — slice 7b (deferred for the same reason).
+    throw new Error(`ir/from-ast: bare yield (no value) not in slice 7a (${cx.funcName})`);
   }
-
-  // ---------------------------------------------------------------
-  // `yield <expr>` — slice 7a (numeric) and 7b (any Phase-1 type).
-  // ---------------------------------------------------------------
-  // Lower with an externref hint as a fallback shape; the IR type
-  // recovered via `typeOf` drives the dispatch below. For numeric
-  // and bool yields the lowerer's downstream typing keeps them as
-  // f64/i32 — `lowerExpr`'s `hint` is advisory, not authoritative.
-  const value = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
+  const value = lowerExpr(expr.expression, cx, irVal({ kind: "f64" }));
   const valueType = cx.builder.typeOf(value);
-  const valTy = asVal(valueType);
-  if (valTy?.kind === "f64" || valTy?.kind === "i32") {
-    // Native primitive yield — `gen.push` lowerer dispatches to
-    // `__gen_push_f64` / `__gen_push_i32` directly.
-    cx.builder.emitGenPush(value);
-    return;
+  if (asVal(valueType)?.kind !== "f64") {
+    throw new Error(
+      `ir/from-ast: yield expression must lower to f64 (got ${describeIrType(valueType)}) in slice 7a (${cx.funcName})`,
+    );
   }
-  // Reference-shaped yield — coerce to externref so the lowerer's
-  // `__gen_push_ref(buf, externref)` arm sees the right Wasm type.
-  const valueExt = coerceYieldValueToExternref(value, cx);
-  cx.builder.emitGenPush(valueExt);
-}
-
-/**
- * Slice 7b helper: coerce a yielded SSA value to externref for the
- * `__gen_push_ref` / `__gen_yield_star` arms. Skips the coerce when
- * the value's underlying Wasm valtype is ALREADY externref —
- * emitting `extern.convert_any` on an already-externref operand is
- * actually a Wasm validation error (the op expects an `anyref`
- * subtype, and `externref` is NOT a subtype of `anyref`).
- *
- * Cases that skip the coerce:
- *   - `IrType.val` with `val.kind === "externref"` — directly externref.
- *   - `IrType.string` in HOST-strings mode — `resolveString()` returns
- *     externref for the host backend (the wasm:js-string imports take
- *     externref), so the value flowing through is already externref.
- *
- * Cases that DO coerce:
- *   - `IrType.string` in NATIVE-strings mode — value is `(ref $AnyString)`,
- *     a struct ref subtype of anyref, so `extern.convert_any` re-tags it.
- *   - `IrType.val` with `val.kind === "ref"` / `"ref_null"` —
- *     struct/array refs are anyref subtypes; coerce is valid.
- *   - `IrType.object` / `class` / `closure` — all backed by struct refs,
- *     anyref subtypes; coerce is valid.
- *
- * Reuses `coerce.to_externref` (#1182) so the generator path and the
- * iter-host for-of path share one IR primitive — the lowerer emits
- * `extern.convert_any` for both.
- */
-function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId {
-  const t = cx.builder.typeOf(value);
-  if (t.kind === "val" && t.val.kind === "externref") {
-    return value;
-  }
-  // Host-strings mode: `IrType.string` flows as externref through Wasm.
-  // Skip the coerce so we don't emit a validation-rejected
-  // `extern.convert_any` over a global.get of externref-typed string
-  // global.
-  if (t.kind === "string" && !cx.nativeStrings) {
-    return value;
-  }
-  return cx.builder.emitCoerceToExternref(value);
+  cx.builder.emitGenPush(value);
 }
 
 /**

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -319,29 +319,25 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
     // line 89-123): a `return <value>` inside a `function*` pushes
     // `<value>` onto the eager buffer as a final yielded value, then
     // wraps the buffer with `__create_generator` to produce the
-    // externref Generator object. This is non-spec — JS spec says the
-    // return value lands in `IteratorResult.value` with `done:true` —
-    // but matching legacy is the correctness target so existing
-    // test262 coverage doesn't drift.
+    // externref Generator object.
     //
-    // Slice 7b widens the return type: we accept any Phase-1 expression
-    // and route it through the same `lowerYield`-style dispatch
-    // (f64/i32 stay native; ref/string/object/class coerce to
-    // externref → __gen_push_ref). Same dispatch logic as `lowerYield`
-    // except we get a `ts.Expression` already, not a YieldExpression.
+    // Slice 7b note: we conservatively keep slice 7a's strict f64-only
+    // return-value rule here even though `lowerYield` widens to
+    // i32/ref. Generators with non-f64 returns are RARE in practice,
+    // and the strict rule lets such generators fall back to legacy
+    // (the throw is caught by the integration phase's per-function
+    // try/catch). Bare `return;` is allowed by the selector (slice
+    // 7b widening) and emits the epilogue without a final push.
     if (cx.funcKind === "generator") {
       if (stmt.expression) {
-        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
+        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "f64" }));
         const vt = cx.builder.typeOf(v);
-        const valTy = asVal(vt);
-        if (valTy?.kind === "f64" || valTy?.kind === "i32") {
-          cx.builder.emitGenPush(v);
-        } else {
-          // Reference-shaped — coerce to externref upstream so the
-          // lowerer's `__gen_push_ref` arm sees the right Wasm type.
-          const vExt = coerceYieldValueToExternref(v, cx);
-          cx.builder.emitGenPush(vExt);
+        if (asVal(vt)?.kind !== "f64") {
+          throw new Error(
+            `ir/from-ast: generator return must be f64 in slice 7b (got ${describeIrType(vt)}) (${cx.funcName})`,
+          );
         }
+        cx.builder.emitGenPush(v);
       }
       const generatorObj = cx.builder.emitGenEpilogue();
       cx.builder.terminate({ kind: "return", values: [generatorObj] });

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -319,25 +319,29 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
     // line 89-123): a `return <value>` inside a `function*` pushes
     // `<value>` onto the eager buffer as a final yielded value, then
     // wraps the buffer with `__create_generator` to produce the
-    // externref Generator object.
+    // externref Generator object. This is non-spec — JS spec says the
+    // return value lands in `IteratorResult.value` with `done:true` —
+    // but matching legacy is the correctness target so existing
+    // test262 coverage doesn't drift.
     //
-    // Slice 7b note: we conservatively keep slice 7a's strict f64-only
-    // return-value rule here even though `lowerYield` widens to
-    // i32/ref. Generators with non-f64 returns are RARE in practice,
-    // and the strict rule lets such generators fall back to legacy
-    // (the throw is caught by the integration phase's per-function
-    // try/catch). Bare `return;` is allowed by the selector (slice
-    // 7b widening) and emits the epilogue without a final push.
+    // Slice 7b widens the return type: we accept any Phase-1 expression
+    // and route it through the same `lowerYield`-style dispatch
+    // (f64/i32 stay native; ref/string/object/class coerce to
+    // externref → __gen_push_ref). Same dispatch logic as `lowerYield`
+    // except we get a `ts.Expression` already, not a YieldExpression.
     if (cx.funcKind === "generator") {
       if (stmt.expression) {
-        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "f64" }));
+        const v = lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
         const vt = cx.builder.typeOf(v);
-        if (asVal(vt)?.kind !== "f64") {
-          throw new Error(
-            `ir/from-ast: generator return must be f64 in slice 7b (got ${describeIrType(vt)}) (${cx.funcName})`,
-          );
+        const valTy = asVal(vt);
+        if (valTy?.kind === "f64" || valTy?.kind === "i32") {
+          cx.builder.emitGenPush(v);
+        } else {
+          // Reference-shaped — coerce to externref upstream so the
+          // lowerer's `__gen_push_ref` arm sees the right Wasm type.
+          const vExt = coerceYieldValueToExternref(v, cx);
+          cx.builder.emitGenPush(vExt);
         }
-        cx.builder.emitGenPush(v);
       }
       const generatorObj = cx.builder.emitGenEpilogue();
       cx.builder.terminate({ kind: "return", values: [generatorObj] });
@@ -1352,48 +1356,132 @@ function lowerPropertyAssignment(expr: ts.BinaryExpression, cx: LowerCtx): void 
 // ---------------------------------------------------------------------------
 
 /**
- * Slice 7a (#1169f): lower a `yield <expr>;` statement. The yielded
+ * Slice 7a/7b (#1169f): lower a yield expression-statement. The yielded
  * value is pushed onto the generator's `__gen_buffer` Wasm-local slot
- * via `gen.push`, which the lowerer expands to a typed
- * `__gen_push_*` host call (slice 7a only emits `__gen_push_f64`,
- * since the selector restricts yield operands to Phase-1 numeric
- * expressions).
+ * via `gen.push`, which the lowerer expands to a typed `__gen_push_*`
+ * host call dispatched on the value's IrType (f64 → push_f64,
+ * i32 → push_i32, otherwise externref → push_ref).
+ *
+ * Slice 7b adds three extensions:
+ *   - **Bare `yield;`** — emits a null-externref const + `gen.push`,
+ *     matching legacy's "yield with no value" semantics (every
+ *     consumer sees `IteratorResult { value: undefined, done: false }`
+ *     for that step).
+ *   - **`yield <non-numeric>`** — strings, booleans-as-i32 stay native;
+ *     ref/object/class/closure values coerce to externref via
+ *     `coerce.to_externref` (the `extern.convert_any` Wasm op), then
+ *     flow through `__gen_push_ref(buf, externref)`.
+ *   - **`yield* <iterable>`** — coerces the iterable to externref and
+ *     emits `gen.yieldStar`, which lowers to
+ *     `__gen_yield_star(buf, iterable)`. The host iterator-protocol
+ *     drains every value from the inner iterable into the outer
+ *     buffer (see `runtime.ts:2999`).
  *
  * Defensive: throws if the enclosing function isn't a generator. The
  * selector should have rejected the function in that case, but a
  * defensive check here surfaces selector regressions as a clean
  * fall-back to legacy rather than malformed Wasm.
- *
- * (Slice 7b retrospective: an attempted widening to bare `yield;`,
- * `yield* <iterable>`, and non-numeric yields was reverted in
- * commit `<this commit>` after PR #73 CI showed ~240 test262
- * regressions clustered in `eval-code` / TypedArray / WeakMap test
- * directories. The IR scaffolding for `gen.yieldStar` is preserved
- * in `nodes.ts` / `builder.ts` / the lower+pass dispatch arms, so a
- * future slice can re-attempt the widening with a localized fix.)
  */
 function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
   if (cx.funcKind !== "generator") {
     throw new Error(`ir/from-ast: yield outside generator function in ${cx.funcName}`);
   }
+
+  // ---------------------------------------------------------------
+  // `yield* <iterable>` — slice 7b.
+  // ---------------------------------------------------------------
   if (expr.asteriskToken) {
-    // `yield* <iterable>` — slice 7b (deferred — IR scaffolding present
-    // via `gen.yieldStar` but not wired here; throw triggers fallback
-    // to legacy).
-    throw new Error(`ir/from-ast: yield* delegation not in slice 7a (${cx.funcName})`);
+    if (!expr.expression) {
+      // TS parser enforces this; keep as defense-in-depth.
+      throw new Error(`ir/from-ast: yield* requires an iterable in ${cx.funcName}`);
+    }
+    // Lower the iterable with an externref hint; the iterable's
+    // actual IrType might be vec/string/object/externref. Coerce to
+    // externref via the slice-6-part-3 helper so the host
+    // `__gen_yield_star(externref, externref)` import sees the
+    // right Wasm value type.
+    const inner = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
+    const innerExt = coerceYieldValueToExternref(inner, cx);
+    cx.builder.emitGenYieldStar(innerExt);
+    return;
   }
+
+  // ---------------------------------------------------------------
+  // Bare `yield;` (no value) — slice 7b.
+  // ---------------------------------------------------------------
   if (!expr.expression) {
-    // `yield;` (no value) — slice 7b (deferred for the same reason).
-    throw new Error(`ir/from-ast: bare yield (no value) not in slice 7a (${cx.funcName})`);
-  }
-  const value = lowerExpr(expr.expression, cx, irVal({ kind: "f64" }));
-  const valueType = cx.builder.typeOf(value);
-  if (asVal(valueType)?.kind !== "f64") {
-    throw new Error(
-      `ir/from-ast: yield expression must lower to f64 (got ${describeIrType(valueType)}) in slice 7a (${cx.funcName})`,
+    // Materialize a null externref and push as ref. Legacy emits
+    // the same shape (`__gen_push_ref(buf, ref.null.extern)`) when
+    // a `yield;` statement appears in a generator body.
+    const nullExt = cx.builder.emitConst(
+      { kind: "null", ty: irVal({ kind: "externref" }) },
+      irVal({ kind: "externref" }),
     );
+    cx.builder.emitGenPush(nullExt);
+    return;
   }
-  cx.builder.emitGenPush(value);
+
+  // ---------------------------------------------------------------
+  // `yield <expr>` — slice 7a (numeric) and 7b (any Phase-1 type).
+  // ---------------------------------------------------------------
+  // Lower with an externref hint as a fallback shape; the IR type
+  // recovered via `typeOf` drives the dispatch below. For numeric
+  // and bool yields the lowerer's downstream typing keeps them as
+  // f64/i32 — `lowerExpr`'s `hint` is advisory, not authoritative.
+  const value = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
+  const valueType = cx.builder.typeOf(value);
+  const valTy = asVal(valueType);
+  if (valTy?.kind === "f64" || valTy?.kind === "i32") {
+    // Native primitive yield — `gen.push` lowerer dispatches to
+    // `__gen_push_f64` / `__gen_push_i32` directly.
+    cx.builder.emitGenPush(value);
+    return;
+  }
+  // Reference-shaped yield — coerce to externref so the lowerer's
+  // `__gen_push_ref(buf, externref)` arm sees the right Wasm type.
+  const valueExt = coerceYieldValueToExternref(value, cx);
+  cx.builder.emitGenPush(valueExt);
+}
+
+/**
+ * Slice 7b helper: coerce a yielded SSA value to externref for the
+ * `__gen_push_ref` / `__gen_yield_star` arms. Skips the coerce when
+ * the value's underlying Wasm valtype is ALREADY externref —
+ * emitting `extern.convert_any` on an already-externref operand is
+ * actually a Wasm validation error (the op expects an `anyref`
+ * subtype, and `externref` is NOT a subtype of `anyref`).
+ *
+ * Cases that skip the coerce:
+ *   - `IrType.val` with `val.kind === "externref"` — directly externref.
+ *   - `IrType.string` in HOST-strings mode — `resolveString()` returns
+ *     externref for the host backend (the wasm:js-string imports take
+ *     externref), so the value flowing through is already externref.
+ *
+ * Cases that DO coerce:
+ *   - `IrType.string` in NATIVE-strings mode — value is `(ref $AnyString)`,
+ *     a struct ref subtype of anyref, so `extern.convert_any` re-tags it.
+ *   - `IrType.val` with `val.kind === "ref"` / `"ref_null"` —
+ *     struct/array refs are anyref subtypes; coerce is valid.
+ *   - `IrType.object` / `class` / `closure` — all backed by struct refs,
+ *     anyref subtypes; coerce is valid.
+ *
+ * Reuses `coerce.to_externref` (#1182) so the generator path and the
+ * iter-host for-of path share one IR primitive — the lowerer emits
+ * `extern.convert_any` for both.
+ */
+function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId {
+  const t = cx.builder.typeOf(value);
+  if (t.kind === "val" && t.val.kind === "externref") {
+    return value;
+  }
+  // Host-strings mode: `IrType.string` flows as externref through Wasm.
+  // Skip the coerce so we don't emit a validation-rejected
+  // `extern.convert_any` over a global.get of externref-typed string
+  // global.
+  if (t.kind === "string" && !cx.nativeStrings) {
+    return value;
+  }
+  return cx.builder.emitCoerceToExternref(value);
 }
 
 /**

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -834,24 +834,45 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         out.push({ op: "array.get", typeIdx: vec.arrayTypeIdx } as unknown as Instr);
         return;
       }
-      // Slice 7a (#1169f): generator ops.
+      // Slice 7a/7b (#1169f): generator ops.
       case "gen.push": {
         // Dispatch on the value's IrType to pick the typed
-        // `__gen_push_*` host import. Slice 7a only emits f64 (the
-        // selector restricts yield operands to numeric expressions);
-        // i32 / externref / string variants land in 7b.
-        const valueT = asVal(typeOf(instr.value));
-        if (!valueT || valueT.kind !== "f64") {
-          throw new Error(
-            `ir/lower: gen.push value must be f64 in slice 7a (got ${valueT?.kind ?? "non-val"}) (${func.name})`,
-          );
-        }
+        // `__gen_push_*` host import. Slice 7b widens the dispatch:
+        //
+        //   { kind: "val", val.kind: "f64" }       → __gen_push_f64
+        //   { kind: "val", val.kind: "i32" }       → __gen_push_i32  (booleans)
+        //   anything else (externref / ref /
+        //     ref_null / string / object / class)  → __gen_push_ref
+        //
+        // The from-ast lowerer (`lowerYield`) is responsible for
+        // ensuring non-primitive yield values are coerced to externref
+        // BEFORE reaching `gen.push`. The lowerer here trusts that
+        // contract: any non-(f64/i32) value-IrType is presumed to be
+        // a reference type that the host can tag via
+        // `__gen_push_ref(buf, externref)`. The `extern.convert_any`
+        // operation embedded in the upstream `coerce.to_externref`
+        // takes any reference-shaped value and yields an externref
+        // suitable for the import's signature.
         if (func.generatorBufferSlot === undefined) {
           throw new Error(`ir/lower: gen.push requires func.generatorBufferSlot (${func.name})`);
         }
-        const importName = "__gen_push_f64";
+        const valueT = asVal(typeOf(instr.value));
+        let importName: string;
+        if (valueT?.kind === "f64") {
+          importName = "__gen_push_f64";
+        } else if (valueT?.kind === "i32") {
+          importName = "__gen_push_i32";
+        } else {
+          // ref / ref_null / externref / IrType.string / object / class
+          // / closure all land here. The from-ast lowerer must have
+          // coerced to externref upstream — `coerce.to_externref`
+          // emits an `extern.convert_any` so the value flowing in
+          // has the right Wasm type for the import signature
+          // `(externref, externref) → void`.
+          importName = "__gen_push_ref";
+        }
         const fnIdx = resolver.resolveFunc({ kind: "func", name: importName });
-        // Stack: buffer, value → (void); call __gen_push_f64.
+        // Stack: buffer, value → (void); call __gen_push_*.
         out.push({ op: "local.get", index: slotWasmIdx(func.generatorBufferSlot) });
         emitValue(instr.value, out);
         out.push({ op: "call", funcIdx: fnIdx });
@@ -868,6 +889,23 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         const fnIdx = resolver.resolveFunc({ kind: "func", name: "__create_generator" });
         out.push({ op: "local.get", index: slotWasmIdx(func.generatorBufferSlot) });
         out.push({ op: "ref.null.extern" } as unknown as Instr);
+        out.push({ op: "call", funcIdx: fnIdx });
+        return;
+      }
+      // Slice 7b (#1169f): yield* delegation.
+      case "gen.yieldStar": {
+        // Emit `__gen_yield_star(buffer, inner)`. The `inner` SSA
+        // value MUST be externref-typed by upstream coercion (the
+        // from-ast layer inserts `coerce.to_externref` before this
+        // instr). The host helper iterates `inner` via
+        // `Symbol.iterator` and pushes each yielded value into the
+        // outer buffer (see `runtime.ts:2999`).
+        if (func.generatorBufferSlot === undefined) {
+          throw new Error(`ir/lower: gen.yieldStar requires func.generatorBufferSlot (${func.name})`);
+        }
+        const fnIdx = resolver.resolveFunc({ kind: "func", name: "__gen_yield_star" });
+        out.push({ op: "local.get", index: slotWasmIdx(func.generatorBufferSlot) });
+        emitValue(instr.inner, out);
         out.push({ op: "call", funcIdx: fnIdx });
         return;
       }
@@ -1330,6 +1368,9 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
       // No SSA operand uses — buffer + pendingThrow are read from Wasm
       // locals (slot indices stored on the IrFunction).
       return [];
+    // Slice 7b (#1169f): yield* delegation.
+    case "gen.yieldStar":
+      return [instr.inner];
     // Slice 6 part 4 (#1183) — string for-of.
     case "forof.string":
       return [instr.str];
@@ -1490,7 +1531,16 @@ function emitConst(instr: Extract<IrInstr, { kind: "const" }>, out: Instr[], fun
         out.push({ op: "ref.null", typeIdx: (valTy as { typeIdx: number }).typeIdx } as unknown as Instr);
         return;
       }
-      throw new Error(`ir/lower: const null must have ref_null resultType (${funcName})`);
+      // Slice 7b (#1169f): bare `yield;` lowers to a `gen.push` of
+      // a null externref. The IrConst `{ kind: "null", ty:
+      // irVal({ kind: "externref" }) }` materializes here as a
+      // `ref.null.extern` Wasm op. Same shape the legacy generator
+      // path uses for the "no value" yield (see misc.ts:212-215).
+      if (valTy && valTy.kind === "externref") {
+        out.push({ op: "ref.null.extern" } as unknown as Instr);
+        return;
+      }
+      throw new Error(`ir/lower: const null must have ref_null or externref resultType (${funcName})`);
     }
     case "undefined":
       throw new Error(`ir/lower: Phase 1 does not materialize 'undefined' constants (${funcName})`);

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1126,6 +1126,37 @@ export interface IrInstrGenEpilogue extends IrInstrBase {
   readonly kind: "gen.epilogue";
 }
 
+/**
+ * Slice 7b (#1169f) — `yield* <iterable>` delegation. Drains the inner
+ * iterable into the outer generator's `__gen_buffer` by calling the
+ * `__gen_yield_star(buf, iterable)` host import (signature
+ * `(externref, externref) → void`; the host iterates the inner via
+ * `Symbol.iterator` and pushes each value).
+ *
+ * The `inner` operand MUST already be coerced to externref by the
+ * caller (`lowerYield` in `from-ast.ts` inserts a `coerce.to_externref`
+ * upstream). The lowerer just emits the buffer-load, value, and call.
+ *
+ * Result is void. Only valid inside `funcKind === "generator"`. The
+ * lowerer reads `IrFunction.generatorBufferSlot` for the buffer
+ * `local.get`.
+ *
+ * Lowering pattern:
+ *   local.get $__gen_buffer
+ *   <emit inner>          ;; already externref
+ *   call $__gen_yield_star
+ *
+ * Spec divergence note: ECMA-262 §27.5.3.7 says `yield*` evaluates to
+ * the inner iterator's `return` value (the `IteratorResult.value` when
+ * `done` becomes true). Under the eager-buffer model this is discarded;
+ * `yield*` evaluates to `undefined`. Matches the legacy compiler's
+ * behaviour (`misc.ts:177-202`).
+ */
+export interface IrInstrGenYieldStar extends IrInstrBase {
+  readonly kind: "gen.yieldStar";
+  readonly inner: IrValueId;
+}
+
 // ---------------------------------------------------------------------------
 // String for-of (#1183 — IR Phase 4 Slice 6 part 4)
 // ---------------------------------------------------------------------------
@@ -1237,6 +1268,7 @@ export type IrInstr =
   | IrInstrForOfIter
   | IrInstrGenPush
   | IrInstrGenEpilogue
+  | IrInstrGenYieldStar
   | IrInstrForOfString;
 
 // ---------------------------------------------------------------------------

--- a/src/ir/passes/dead-code.ts
+++ b/src/ir/passes/dead-code.ts
@@ -216,6 +216,12 @@ function isSideEffecting(i: IrInstr): boolean {
     // SSA reference that the verifier rejects.
     i.kind === "gen.push" ||
     i.kind === "gen.epilogue" ||
+    // Slice 7b (#1169f): gen.yieldStar drains every value from the
+    // inner iterable onto the buffer — observable through __gen_next
+    // downstream. Pin for the same reason as gen.push: the operand
+    // (`inner`) must stay live, but DCE's propagation only flows
+    // through `result`-bearing instrs.
+    i.kind === "gen.yieldStar" ||
     // Slice 6 part 4 (#1183): forof.string is statement-level (result:
     // null) so the generic null-result rule already keeps it; explicit
     // listing for clarity.
@@ -353,6 +359,9 @@ function collectInstrUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "gen.epilogue":
       return [];
+    // Slice 7b (#1169f): yield* delegation.
+    case "gen.yieldStar":
+      return [instr.inner];
   }
 }
 

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -545,6 +545,12 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
     case "gen.epilogue":
       // No operands to rewrite.
       return inst;
+    // Slice 7b (#1169f): yield* delegation.
+    case "gen.yieldStar": {
+      const v = mapId(rename, inst.inner);
+      if (v === inst.inner) return inst;
+      return { ...inst, inner: v };
+    }
     // Slice 6 part 4 (#1183) — string for-of.
     case "forof.string": {
       const v = mapId(rename, inst.str);

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -721,5 +721,8 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "gen.epilogue":
       return [];
+    // Slice 7b (#1169f): yield* delegation.
+    case "gen.yieldStar":
+      return [instr.inner];
   }
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -220,7 +220,7 @@ function isIrClaimable(
 
   const body = fn.body;
   if (!body) return false;
-  return isPhase1StatementList(body.statements, scope, localClasses);
+  return isPhase1StatementList(body.statements, scope, localClasses, isGenerator);
 }
 
 /**
@@ -284,6 +284,13 @@ function isPhase1StatementList(
   stmts: ReadonlyArray<ts.Statement>,
   scope: Set<string>,
   localClasses: ReadonlySet<string>,
+  // Slice 7b (#1169f): when true, the enclosing function is a
+  // `function*` and bare `return;` (no expression) is allowed in tail
+  // position. Threaded down to `isPhase1Tail` to relax the "tail must
+  // have expression" rule for generators only — non-generators with
+  // bare returns continue to be rejected (their return type wouldn't
+  // resolve to a primitive anyway).
+  isGenerator: boolean = false,
 ): boolean {
   if (stmts.length < 1) return false;
   for (let i = 0; i < stmts.length - 1; i++) {
@@ -314,23 +321,33 @@ function isPhase1StatementList(
         if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
         continue;
       }
-      // Slice 7a (#1169f): `yield <expr>;` as a statement. Only valid
-      // when the enclosing function is a generator — that check is
-      // enforced by the lowerer (`lowerYield` throws when
+      // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` as a
+      // statement. Only valid when the enclosing function is a generator
+      // — that check is enforced by the lowerer (`lowerYield` throws when
       // `cx.funcKind !== "generator"`). The selector accepts the shape
       // unconditionally because functions that nest a yield in a
       // non-generator are ill-typed and would have failed TS source
       // checking before reaching us.
+      //
+      // Slice 7b accepts:
+      //   - `yield;`              — bare yield, lowered as gen.push of a
+      //                             null externref (matches legacy
+      //                             "yield with no value" semantics).
+      //   - `yield <phase1-expr>` — any Phase-1 expression body. The
+      //                             from-ast lowerer dispatches by IrType:
+      //                             f64/i32 use the typed __gen_push_*
+      //                             import; everything else coerces to
+      //                             externref and uses __gen_push_ref.
+      //   - `yield* <iterable>`   — delegation; lowered as
+      //                             gen.yieldStar(coerced_iterable).
       if (ts.isYieldExpression(s.expression)) {
-        // `yield;` (no expression) and `yield* <expr>` are deferred to
-        // 7b; slice 7a only accepts `yield <numeric expr>`.
-        // (Slice 7b kept this strictness — see PR #73 retrospective:
-        // the IR widening for non-numeric/star/bare yields caused
-        // ~240 test262 regressions in CI; the IR scaffolding remains
-        // for a future slice.)
-        if (s.expression.asteriskToken) return false;
-        if (!s.expression.expression) return false;
-        if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
+        if (s.expression.expression) {
+          if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
+        } else if (s.expression.asteriskToken) {
+          // `yield*` MUST have an expression — TS parser enforces this,
+          // but be defensive.
+          return false;
+        }
         continue;
       }
       if (
@@ -353,9 +370,9 @@ function isPhase1StatementList(
     // reinterpret as `if (cond) <tail> else { <rest> }`.
     if (ts.isIfStatement(s) && !s.elseStatement) {
       if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
-      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses)) return false;
+      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
       const rest = stmts.slice(i + 1);
-      return isPhase1StatementList(rest, new Set(scope), localClasses);
+      return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator);
     }
     // Slice 6 part 2 (#1181) — for-of statement (always non-tail). The
     // body is itself shape-checked. The bridge in `from-ast.ts` lowers
@@ -368,7 +385,7 @@ function isPhase1StatementList(
     }
     return false;
   }
-  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses);
+  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses, isGenerator);
 }
 
 /**
@@ -426,13 +443,15 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
     if (ts.isCallExpression(stmt.expression)) {
       return isPhase1Expr(stmt.expression, scope, localClasses);
     }
-    // Slice 7a (#1169f): `yield <expr>` inside a for-of body. Same
-    // semantics as the top-level form — only valid when the enclosing
-    // function is a generator (lowerer-enforced).
+    // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` inside
+    // a for-of body. Same semantics as the top-level form — only valid
+    // when the enclosing function is a generator (lowerer-enforced).
     if (ts.isYieldExpression(stmt.expression)) {
+      if (stmt.expression.expression) {
+        return isPhase1Expr(stmt.expression.expression, scope, localClasses);
+      }
       if (stmt.expression.asteriskToken) return false;
-      if (!stmt.expression.expression) return false;
-      return isPhase1Expr(stmt.expression.expression, scope, localClasses);
+      return true; // bare `yield;`
     }
     if (ts.isBinaryExpression(stmt.expression)) {
       const op = stmt.expression.operatorToken.kind;
@@ -470,19 +489,30 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
   return false;
 }
 
-function isPhase1Tail(stmt: ts.Statement, scope: Set<string>, localClasses: ReadonlySet<string>): boolean {
+function isPhase1Tail(
+  stmt: ts.Statement,
+  scope: Set<string>,
+  localClasses: ReadonlySet<string>,
+  isGenerator: boolean = false,
+): boolean {
   if (ts.isReturnStatement(stmt)) {
-    if (!stmt.expression) return false;
+    // Slice 7b (#1169f): bare `return;` (no expression) is allowed in
+    // generator tails — the lowerer's `lowerTail` generator branch
+    // handles the no-expression case by emitting the epilogue without
+    // a final push. Non-generator bare returns continue to be rejected
+    // (they'd type as void, which the selector's return-type gate
+    // already rules out anyway).
+    if (!stmt.expression) return isGenerator;
     return isPhase1Expr(stmt.expression, scope, localClasses);
   }
   if (ts.isBlock(stmt)) {
-    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses);
+    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses, isGenerator);
   }
   if (ts.isIfStatement(stmt)) {
     if (!stmt.elseStatement) return false;
     if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses)) return false;
-    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses)) return false;
+    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
+    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses, isGenerator)) return false;
     return true;
   }
   return false;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -220,7 +220,7 @@ function isIrClaimable(
 
   const body = fn.body;
   if (!body) return false;
-  return isPhase1StatementList(body.statements, scope, localClasses, isGenerator);
+  return isPhase1StatementList(body.statements, scope, localClasses);
 }
 
 /**
@@ -284,13 +284,6 @@ function isPhase1StatementList(
   stmts: ReadonlyArray<ts.Statement>,
   scope: Set<string>,
   localClasses: ReadonlySet<string>,
-  // Slice 7b (#1169f): when true, the enclosing function is a
-  // `function*` and bare `return;` (no expression) is allowed in tail
-  // position. Threaded down to `isPhase1Tail` to relax the "tail must
-  // have expression" rule for generators only — non-generators with
-  // bare returns continue to be rejected (their return type wouldn't
-  // resolve to a primitive anyway).
-  isGenerator: boolean = false,
 ): boolean {
   if (stmts.length < 1) return false;
   for (let i = 0; i < stmts.length - 1; i++) {
@@ -321,33 +314,23 @@ function isPhase1StatementList(
         if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
         continue;
       }
-      // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` as a
-      // statement. Only valid when the enclosing function is a generator
-      // — that check is enforced by the lowerer (`lowerYield` throws when
+      // Slice 7a (#1169f): `yield <expr>;` as a statement. Only valid
+      // when the enclosing function is a generator — that check is
+      // enforced by the lowerer (`lowerYield` throws when
       // `cx.funcKind !== "generator"`). The selector accepts the shape
       // unconditionally because functions that nest a yield in a
       // non-generator are ill-typed and would have failed TS source
       // checking before reaching us.
-      //
-      // Slice 7b accepts:
-      //   - `yield;`              — bare yield, lowered as gen.push of a
-      //                             null externref (matches legacy
-      //                             "yield with no value" semantics).
-      //   - `yield <phase1-expr>` — any Phase-1 expression body. The
-      //                             from-ast lowerer dispatches by IrType:
-      //                             f64/i32 use the typed __gen_push_*
-      //                             import; everything else coerces to
-      //                             externref and uses __gen_push_ref.
-      //   - `yield* <iterable>`   — delegation; lowered as
-      //                             gen.yieldStar(coerced_iterable).
       if (ts.isYieldExpression(s.expression)) {
-        if (s.expression.expression) {
-          if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
-        } else if (s.expression.asteriskToken) {
-          // `yield*` MUST have an expression — TS parser enforces this,
-          // but be defensive.
-          return false;
-        }
+        // `yield;` (no expression) and `yield* <expr>` are deferred to
+        // 7b; slice 7a only accepts `yield <numeric expr>`.
+        // (Slice 7b kept this strictness — see PR #73 retrospective:
+        // the IR widening for non-numeric/star/bare yields caused
+        // ~240 test262 regressions in CI; the IR scaffolding remains
+        // for a future slice.)
+        if (s.expression.asteriskToken) return false;
+        if (!s.expression.expression) return false;
+        if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
         continue;
       }
       if (
@@ -370,9 +353,9 @@ function isPhase1StatementList(
     // reinterpret as `if (cond) <tail> else { <rest> }`.
     if (ts.isIfStatement(s) && !s.elseStatement) {
       if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
-      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
+      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses)) return false;
       const rest = stmts.slice(i + 1);
-      return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator);
+      return isPhase1StatementList(rest, new Set(scope), localClasses);
     }
     // Slice 6 part 2 (#1181) — for-of statement (always non-tail). The
     // body is itself shape-checked. The bridge in `from-ast.ts` lowers
@@ -385,7 +368,7 @@ function isPhase1StatementList(
     }
     return false;
   }
-  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses, isGenerator);
+  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses);
 }
 
 /**
@@ -443,15 +426,13 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
     if (ts.isCallExpression(stmt.expression)) {
       return isPhase1Expr(stmt.expression, scope, localClasses);
     }
-    // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` inside
-    // a for-of body. Same semantics as the top-level form — only valid
-    // when the enclosing function is a generator (lowerer-enforced).
+    // Slice 7a (#1169f): `yield <expr>` inside a for-of body. Same
+    // semantics as the top-level form — only valid when the enclosing
+    // function is a generator (lowerer-enforced).
     if (ts.isYieldExpression(stmt.expression)) {
-      if (stmt.expression.expression) {
-        return isPhase1Expr(stmt.expression.expression, scope, localClasses);
-      }
       if (stmt.expression.asteriskToken) return false;
-      return true; // bare `yield;`
+      if (!stmt.expression.expression) return false;
+      return isPhase1Expr(stmt.expression.expression, scope, localClasses);
     }
     if (ts.isBinaryExpression(stmt.expression)) {
       const op = stmt.expression.operatorToken.kind;
@@ -489,30 +470,19 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
   return false;
 }
 
-function isPhase1Tail(
-  stmt: ts.Statement,
-  scope: Set<string>,
-  localClasses: ReadonlySet<string>,
-  isGenerator: boolean = false,
-): boolean {
+function isPhase1Tail(stmt: ts.Statement, scope: Set<string>, localClasses: ReadonlySet<string>): boolean {
   if (ts.isReturnStatement(stmt)) {
-    // Slice 7b (#1169f): bare `return;` (no expression) is allowed in
-    // generator tails — the lowerer's `lowerTail` generator branch
-    // handles the no-expression case by emitting the epilogue without
-    // a final push. Non-generator bare returns continue to be rejected
-    // (they'd type as void, which the selector's return-type gate
-    // already rules out anyway).
-    if (!stmt.expression) return isGenerator;
+    if (!stmt.expression) return false;
     return isPhase1Expr(stmt.expression, scope, localClasses);
   }
   if (ts.isBlock(stmt)) {
-    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses, isGenerator);
+    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses);
   }
   if (ts.isIfStatement(stmt)) {
     if (!stmt.elseStatement) return false;
     if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
-    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses, isGenerator)) return false;
+    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses)) return false;
+    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses)) return false;
     return true;
   }
   return false;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -220,7 +220,7 @@ function isIrClaimable(
 
   const body = fn.body;
   if (!body) return false;
-  return isPhase1StatementList(body.statements, scope, localClasses);
+  return isPhase1StatementList(body.statements, scope, localClasses, isGenerator);
 }
 
 /**
@@ -284,6 +284,13 @@ function isPhase1StatementList(
   stmts: ReadonlyArray<ts.Statement>,
   scope: Set<string>,
   localClasses: ReadonlySet<string>,
+  // Slice 7b (#1169f): when true, the enclosing function is a
+  // `function*` and bare `return;` (no expression) is allowed in tail
+  // position. Threaded down to `isPhase1Tail` to relax the "tail must
+  // have expression" rule for generators only — non-generators with
+  // bare returns continue to be rejected (their return type wouldn't
+  // resolve to a primitive anyway).
+  isGenerator: boolean = false,
 ): boolean {
   if (stmts.length < 1) return false;
   for (let i = 0; i < stmts.length - 1; i++) {
@@ -314,19 +321,33 @@ function isPhase1StatementList(
         if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
         continue;
       }
-      // Slice 7a (#1169f): `yield <expr>;` as a statement. Only valid
-      // when the enclosing function is a generator — that check is
-      // enforced by the lowerer (`lowerYield` throws when
+      // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` as a
+      // statement. Only valid when the enclosing function is a generator
+      // — that check is enforced by the lowerer (`lowerYield` throws when
       // `cx.funcKind !== "generator"`). The selector accepts the shape
       // unconditionally because functions that nest a yield in a
       // non-generator are ill-typed and would have failed TS source
       // checking before reaching us.
+      //
+      // Slice 7b accepts:
+      //   - `yield;`              — bare yield, lowered as gen.push of a
+      //                             null externref (matches legacy
+      //                             "yield with no value" semantics).
+      //   - `yield <phase1-expr>` — any Phase-1 expression body. The
+      //                             from-ast lowerer dispatches by IrType:
+      //                             f64/i32 use the typed __gen_push_*
+      //                             import; everything else coerces to
+      //                             externref and uses __gen_push_ref.
+      //   - `yield* <iterable>`   — delegation; lowered as
+      //                             gen.yieldStar(coerced_iterable).
       if (ts.isYieldExpression(s.expression)) {
-        // `yield;` (no expression) and `yield* <expr>` are deferred to
-        // 7b; slice 7a only accepts `yield <numeric expr>`.
-        if (s.expression.asteriskToken) return false;
-        if (!s.expression.expression) return false;
-        if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
+        if (s.expression.expression) {
+          if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
+        } else if (s.expression.asteriskToken) {
+          // `yield*` MUST have an expression — TS parser enforces this,
+          // but be defensive.
+          return false;
+        }
         continue;
       }
       if (
@@ -349,9 +370,9 @@ function isPhase1StatementList(
     // reinterpret as `if (cond) <tail> else { <rest> }`.
     if (ts.isIfStatement(s) && !s.elseStatement) {
       if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
-      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses)) return false;
+      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
       const rest = stmts.slice(i + 1);
-      return isPhase1StatementList(rest, new Set(scope), localClasses);
+      return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator);
     }
     // Slice 6 part 2 (#1181) — for-of statement (always non-tail). The
     // body is itself shape-checked. The bridge in `from-ast.ts` lowers
@@ -364,7 +385,7 @@ function isPhase1StatementList(
     }
     return false;
   }
-  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses);
+  return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses, isGenerator);
 }
 
 /**
@@ -422,13 +443,15 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
     if (ts.isCallExpression(stmt.expression)) {
       return isPhase1Expr(stmt.expression, scope, localClasses);
     }
-    // Slice 7a (#1169f): `yield <expr>` inside a for-of body. Same
-    // semantics as the top-level form — only valid when the enclosing
-    // function is a generator (lowerer-enforced).
+    // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` inside
+    // a for-of body. Same semantics as the top-level form — only valid
+    // when the enclosing function is a generator (lowerer-enforced).
     if (ts.isYieldExpression(stmt.expression)) {
+      if (stmt.expression.expression) {
+        return isPhase1Expr(stmt.expression.expression, scope, localClasses);
+      }
       if (stmt.expression.asteriskToken) return false;
-      if (!stmt.expression.expression) return false;
-      return isPhase1Expr(stmt.expression.expression, scope, localClasses);
+      return true; // bare `yield;`
     }
     if (ts.isBinaryExpression(stmt.expression)) {
       const op = stmt.expression.operatorToken.kind;
@@ -466,19 +489,30 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
   return false;
 }
 
-function isPhase1Tail(stmt: ts.Statement, scope: Set<string>, localClasses: ReadonlySet<string>): boolean {
+function isPhase1Tail(
+  stmt: ts.Statement,
+  scope: Set<string>,
+  localClasses: ReadonlySet<string>,
+  isGenerator: boolean = false,
+): boolean {
   if (ts.isReturnStatement(stmt)) {
-    if (!stmt.expression) return false;
+    // Slice 7b (#1169f): bare `return;` (no expression) is allowed in
+    // generator tails — the lowerer's `lowerTail` generator branch
+    // handles the no-expression case by emitting the epilogue without
+    // a final push. Non-generator bare returns continue to be rejected
+    // (they'd type as void, which the selector's return-type gate
+    // already rules out anyway).
+    if (!stmt.expression) return isGenerator;
     return isPhase1Expr(stmt.expression, scope, localClasses);
   }
   if (ts.isBlock(stmt)) {
-    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses);
+    return isPhase1StatementList(stmt.statements, new Set(scope), localClasses, isGenerator);
   }
   if (ts.isIfStatement(stmt)) {
     if (!stmt.elseStatement) return false;
     if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses)) return false;
-    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses)) return false;
+    if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses, isGenerator)) return false;
+    if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses, isGenerator)) return false;
     return true;
   }
   return false;

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -260,6 +260,9 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       // No SSA operand uses — buffer + pendingThrow are read from Wasm
       // locals (slot indices stored on the IrFunction).
       return [];
+    // Slice 7b (#1169f): yield* delegation.
+    case "gen.yieldStar":
+      return [instr.inner];
     // Slice 6 part 4 (#1183) — string for-of.
     case "forof.string":
       return [instr.str];

--- a/tests/issue-1169f-7b.test.ts
+++ b/tests/issue-1169f-7b.test.ts
@@ -1,254 +1,147 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
-// #1169f slice 7b — IR Phase 4 generator widening.
+// #1169f slice 7b — IR scaffolding for `yield*` delegation.
 //
-// Builds on slice 7a (PR #70) which wired `function*` + numeric `yield`
-// through the IR. Slice 7b extends the surface to:
+// **Behavior status:** the original slice-7b widening (bare `yield;`,
+// `yield* <iterable>`, non-numeric `yield <expr>`, bare `return;`)
+// was REVERTED on this branch after PR #73 CI showed ~240 test262
+// regressions clustered in `eval-code` / TypedArray / WeakMap
+// directories that did not reproduce locally. The selector and
+// `lowerYield` are both back to slice 7a's strict shape.
 //
-//   1. **Non-numeric yield values** — strings, booleans, refs. The IR
-//      `gen.push` lowerer dispatches on the operand's IrType:
-//        - f64                → __gen_push_f64
-//        - i32                → __gen_push_i32 (booleans)
-//        - everything else    → coerce.to_externref → __gen_push_ref
-//   2. **Bare `yield;`** — emits a null-externref const + gen.push,
-//      matching legacy "yield with no value" semantics.
-//   3. **`yield* <iterable>`** — coerces the iterable to externref and
-//      emits the new `gen.yieldStar` IR instr (lowered to
-//      `__gen_yield_star(buffer, iterable)`). The host helper drains
-//      the inner iterable into the outer buffer via Symbol.iterator
-//      (see `runtime.ts:2999`).
+// **What this slice ships:** the IR-node scaffolding for
+// `gen.yieldStar`, ready for a future slice to wire from
+// `lowerYield` once the regression source is pinpointed (see PR #73
+// retrospective in plan/log/diary.md).
 //
-// Each test compiles the same source under `experimentalIR: false`
-// (legacy) and `experimentalIR: true` (IR claims the `function*`)
-// then drains the exported generator with `iter.next()` and asserts
-// identical sequences. A separate "selector" suite verifies the IR
-// actually CLAIMS the test function so a future regression that
-// silently routes back to legacy would be caught.
+// **Scaffolding under test (builder API only — no AST→IR path):**
+//   1. `IrInstrGenYieldStar` interface in `nodes.ts`, with `inner:
+//      IrValueId` operand.
+//   2. `IrFunctionBuilder.emitGenYieldStar(inner)` method enforces
+//      `funcKind === "generator"` precondition.
+//   3. Verifier accepts `gen.yieldStar` and counts `inner` as a use
+//      (covered transitively here — the verify pass runs as part of
+//      the lowering pipeline below).
+//   4. Lowerer emits `local.get $__gen_buffer; <inner>; call
+//      $__gen_yield_star` when it encounters a `gen.yieldStar`
+//      instr.
+//   5. DCE pins `gen.yieldStar` as side-effecting (covered by the
+//      first end-to-end lower below — the inner SSA value's
+//      producer must survive).
+//   6. inline-small + monomorphize have arms for the new instr
+//      (compile-time exhaustiveness — the typecheck guarantees it).
+//
+// A future slice (7c?) will replace these unit tests with dual-run
+// equivalence tests once the AST→IR wiring lands.
 
-import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
-import { compile } from "../src/index.js";
-import { planIrCompilation } from "../src/ir/select.js";
-import { buildImports } from "../src/runtime.js";
-
-const ENV_STUB = {
-  console_log_number: () => {},
-  console_log_string: () => {},
-  console_log_bool: () => {},
-};
-
-interface InstantiateResult {
-  instance: WebAssembly.Instance;
-  exports: Record<string, unknown>;
-}
-
-async function compileAndInstantiate(source: string, experimentalIR: boolean): Promise<InstantiateResult> {
-  const r = compile(source, { experimentalIR });
-  if (!r.success) {
-    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
-  }
-  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
-  const { instance } = await WebAssembly.instantiate(r.binary, {
-    env: built.env,
-    string_constants: built.string_constants,
-  });
-  return { instance, exports: instance.exports as Record<string, unknown> };
-}
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { irVal } from "../src/ir/nodes.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import type { FuncTypeDef } from "../src/ir/types.js";
 
 /**
- * Drive a JS-iterator-shaped object through `.next()` until done; collect
- * the yielded values. The returned generator object from a wasm export
- * uses the runtime's `__create_generator` shape (next / return / throw /
- * Symbol.iterator), so explicit `.next()` works directly.
+ * Stub resolver suitable for lowering a tiny generator IR fragment.
+ * Maps the generator host imports to placeholder funcIdx values that
+ * survive Wasm validation as long as the emitted body is structurally
+ * correct (signatures unchecked here — we only walk the lowered body
+ * for the expected ops).
  */
-function drain(it: { next: () => { value: unknown; done: boolean } }): unknown[] {
-  const out: unknown[] = [];
-  for (let step = 0; step < 1024; step++) {
-    const r = it.next();
-    if (r.done) return out;
-    out.push(r.value);
-  }
-  throw new Error("drain: generator exceeded 1024 yields (likely infinite loop)");
+function makeStubResolver(): IrLowerResolver {
+  let nextTypeIdx = 0;
+  return {
+    resolveFunc: (ref) => {
+      // Map host-import names to stable indices in the order the
+      // lowerer is expected to ask for them.
+      switch (ref.name) {
+        case "__gen_create_buffer":
+          return 0;
+        case "__gen_push_f64":
+          return 1;
+        case "__gen_yield_star":
+          return 2;
+        case "__create_generator":
+          return 3;
+        default:
+          throw new Error(`stub resolveFunc: unknown ${ref.name}`);
+      }
+    },
+    resolveGlobal: () => 0,
+    resolveType: () => 0,
+    internFuncType: (_t: FuncTypeDef) => nextTypeIdx++,
+  };
 }
 
-function selectionFor(source: string): Set<string> {
-  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
-  const sel = planIrCompilation(sf, { experimentalIR: true });
-  return new Set(sel.funcs);
-}
-
-interface Case {
-  name: string;
-  source: string;
-  /** Names the IR selector should claim under `experimentalIR: true`. */
-  expectedClaimed: string[];
-  /** Name of the exported generator entry point (zero-arg if no builder). */
-  fn: string;
-  /** Optional builder export for tests that need an array param. */
-  builder?: { name: string };
-  /** Expected yielded values, in order. */
-  expectedYields: unknown[];
-}
-
-const CASES: Case[] = [
-  // ---- 1. boolean (i32) yields ------------------------------------------
-  //
-  // Legacy emits __gen_push_i32(buf, 1|0); the host pushes the integer
-  // value as-is into the buffer. Consumers see numeric 1/0, NOT JS
-  // booleans (this is a known eager-buffer-model quirk — booleans
-  // round-trip through Wasm as integers). Slice 7b mirrors legacy.
-  {
-    name: "boolean yields dispatch through __gen_push_i32",
-    source: `
-      export function* gen(): Generator<boolean> {
-        yield true;
-        yield false;
-        yield true;
-        return false;
-      }
-    `,
-    expectedClaimed: ["gen"],
-    fn: "gen",
-    expectedYields: [1, 0, 1, 0],
-  },
-
-  // ---- 2. string (ref) yields ------------------------------------------
-  //
-  // Strings dispatch through __gen_push_ref. In host-strings mode the
-  // value is already externref so the from-ast lowerer skips the
-  // `extern.convert_any` coerce; in native-strings mode the AnyString
-  // struct ref is converted via the slice-6-part-3 helper.
-  {
-    name: "string yields dispatch through __gen_push_ref",
-    source: `
-      export function* gen(): Generator<string> {
-        yield "alpha";
-        yield "beta";
-        yield "gamma";
-        return "end";
-      }
-    `,
-    expectedClaimed: ["gen"],
-    fn: "gen",
-    expectedYields: ["alpha", "beta", "gamma", "end"],
-  },
-
-  // ---- 3. bare yield (no value) ----------------------------------------
-  //
-  // `yield;` lowers as gen.push of `ref.null.extern`. The host receives
-  // a JS `null` from the wasm engine's externref-null marshalling (NOT
-  // `undefined` — `ref.null.extern` round-trips through wasm-js-strings
-  // engine plumbing as `null` per the WebAssembly spec). Legacy and IR
-  // both produce this shape. Bare `return;` is allowed in generator
-  // tail position (slice 7b widens the selector) and pushes no final
-  // value — the buffer just terminates after the explicit yields.
-  {
-    name: "bare yield emits null externref",
-    source: `
-      export function* gen(): Generator<undefined> {
-        yield;
-        yield;
-        return;
-      }
-    `,
-    expectedClaimed: ["gen"],
-    fn: "gen",
-    expectedYields: [null, null],
-  },
-
-  // ---- 4. yield* delegation over another generator's output ------------
-  //
-  // The inner iterable must be a JS-iterable on the host side
-  // (it's consumed by `__gen_yield_star`'s `for (const v of iterable)`
-  // loop). Wasm vec values don't carry `[Symbol.iterator]` directly,
-  // so we use a generator's externref Generator object — the runtime's
-  // `__create_generator` shape includes Symbol.iterator. Both inner
-  // and outer get IR-claimed (call-graph closure: outer calls inner;
-  // inner has no callers; both are generator functions and thus
-  // individually claimable).
-  {
-    name: "yield* delegation drains an inner iterable into the outer buffer",
-    source: `
-      export function* inner(): Generator<number> {
-        yield 1;
-        yield 2;
-        yield 3;
-        return 0;
-      }
-      export function* outer(): Generator<number> {
-        yield 0;
-        yield* inner();
-        yield 99;
-        return -1;
-      }
-    `,
-    expectedClaimed: ["inner", "outer"],
-    fn: "outer",
-    // 0, then drained inner [1, 2, 3, 0 (inner's return)], then 99,
-    // then -1 (outer's return). Legacy pushes inner's return value
-    // because legacy's `return <expr>` semantics push to buffer; the
-    // host's `__gen_yield_star` then drains all of those onto outer.
-    expectedYields: [0, 1, 2, 3, 0, 99, -1],
-  },
-
-  // ---- 5. mixed (numeric + bool) yields in the same generator ----------
-  {
-    name: "mixed numeric and boolean yields — dispatch picks the right import per-yield",
-    source: `
-      export function* gen(): Generator<number | boolean> {
-        yield 42;
-        yield true;
-        yield 7;
-        yield false;
-        return 0;
-      }
-    `,
-    expectedClaimed: ["gen"],
-    fn: "gen",
-    expectedYields: [42, 1, 7, 0, 0],
-  },
-];
-
-describe("#1169f slice 7b — generator IR widening (non-numeric + bare + yield*)", () => {
-  describe("selector claims function* with extended yield shapes", () => {
-    for (const tc of CASES) {
-      it(`claims [${tc.expectedClaimed.join(", ")}] in: ${tc.name}`, () => {
-        const claimed = selectionFor(tc.source);
-        for (const name of tc.expectedClaimed) {
-          expect(claimed.has(name), `selector should claim ${name}; claimed = ${[...claimed].join(",")}`).toBe(true);
-        }
-      });
-    }
+describe("#1169f slice 7b — gen.yieldStar IR scaffolding", () => {
+  it("builder.emitGenYieldStar throws when funcKind is not generator", () => {
+    const b = new IrFunctionBuilder("nonGen", [irVal({ kind: "f64" })], false);
+    b.openBlock();
+    const v = b.emitConst({ kind: "f64", value: 0 }, irVal({ kind: "f64" }));
+    expect(() => b.emitGenYieldStar(v)).toThrow(/funcKind=generator/);
   });
 
-  describe("legacy and IR paths produce the same yield sequence", () => {
-    for (const tc of CASES) {
-      it(tc.name, async () => {
-        const [legacy, ir] = await Promise.all([
-          compileAndInstantiate(tc.source, false),
-          compileAndInstantiate(tc.source, true),
-        ]);
+  it("builder.emitGenYieldStar accepts an SSA value when funcKind is generator", () => {
+    const b = new IrFunctionBuilder("gen", [irVal({ kind: "externref" })], false);
+    b.setFuncKind("generator");
+    const slotIdx = b.declareSlot("__gen_buffer", { kind: "externref" });
+    b.setGeneratorBufferSlot(slotIdx);
+    b.openBlock();
+    // Materialise the buffer (so the prologue is well-formed).
+    const buf = b.emitCall({ kind: "func", name: "__gen_create_buffer" }, [], irVal({ kind: "externref" }));
+    if (buf === null) throw new Error("buf must be non-null");
+    b.emitSlotWrite(slotIdx, buf);
 
-        const drive = (mod: InstantiateResult): unknown[] => {
-          let arg: unknown = undefined;
-          if (tc.builder) {
-            const builder = mod.exports[tc.builder.name] as () => unknown;
-            arg = builder();
-          }
-          const fn = mod.exports[tc.fn] as ((arg?: unknown) => unknown) | (() => unknown);
-          const it = (tc.builder ? (fn as (a: unknown) => unknown)(arg) : (fn as () => unknown)()) as {
-            next: () => { value: unknown; done: boolean };
-          };
-          return drain(it);
-        };
+    // Inner iterable: pretend we have an externref param. We don't
+    // need the AST→IR layer for this — addParam supplies a usable
+    // SSA value typed as externref.
+    const inner = b.emitConst({ kind: "null", ty: irVal({ kind: "externref" }) }, irVal({ kind: "externref" }));
 
-        const legacyValues = drive(legacy);
-        const irValues = drive(ir);
-        expect(legacyValues).toEqual(tc.expectedYields);
-        expect(irValues).toEqual(tc.expectedYields);
-        expect(irValues).toEqual(legacyValues);
-      });
-    }
+    // The instr we want to test.
+    b.emitGenYieldStar(inner);
+
+    // Generator epilogue + return so the function is well-formed.
+    const result = b.emitGenEpilogue();
+    b.terminate({ kind: "return", values: [result] });
+
+    const fn = b.finish();
+    expect(fn.funcKind).toBe("generator");
+    expect(fn.generatorBufferSlot).toBe(slotIdx);
+
+    // Verifier accepts the function.
+    expect(verifyIrFunction(fn)).toEqual([]);
+
+    // Lower to Wasm and confirm a `__gen_yield_star` call appears.
+    const { func } = lowerIrFunctionToWasm(fn, makeStubResolver());
+    const callOps = func.body.filter((op): op is { op: "call"; funcIdx: number } => op.op === "call");
+    const callTargets = callOps.map((c) => c.funcIdx);
+    expect(callTargets).toContain(2); // __gen_yield_star
+    expect(callTargets).toContain(0); // __gen_create_buffer (prologue)
+    expect(callTargets).toContain(3); // __create_generator (epilogue)
+  });
+
+  it("verifier counts gen.yieldStar.inner as a use of its operand", () => {
+    // A function that produces an SSA value, never uses it directly,
+    // and feeds it through gen.yieldStar — DCE must keep the producer
+    // alive because gen.yieldStar is flagged side-effecting.
+    const b = new IrFunctionBuilder("gen", [irVal({ kind: "externref" })], false);
+    b.setFuncKind("generator");
+    const slotIdx = b.declareSlot("__gen_buffer", { kind: "externref" });
+    b.setGeneratorBufferSlot(slotIdx);
+    b.openBlock();
+    const buf = b.emitCall({ kind: "func", name: "__gen_create_buffer" }, [], irVal({ kind: "externref" }));
+    if (buf === null) throw new Error("buf must be non-null");
+    b.emitSlotWrite(slotIdx, buf);
+    const inner = b.emitConst({ kind: "null", ty: irVal({ kind: "externref" }) }, irVal({ kind: "externref" }));
+    b.emitGenYieldStar(inner);
+    const result = b.emitGenEpilogue();
+    b.terminate({ kind: "return", values: [result] });
+
+    const fn = b.finish();
+    // Verifier sees `inner` as a defined SSA value used by
+    // gen.yieldStar — no errors.
+    const errors = verifyIrFunction(fn);
+    expect(errors.map((e) => e.message)).toEqual([]);
   });
 });

--- a/tests/issue-1169f-7b.test.ts
+++ b/tests/issue-1169f-7b.test.ts
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1169f slice 7b — IR Phase 4 generator widening.
+//
+// Builds on slice 7a (PR #70) which wired `function*` + numeric `yield`
+// through the IR. Slice 7b extends the surface to:
+//
+//   1. **Non-numeric yield values** — strings, booleans, refs. The IR
+//      `gen.push` lowerer dispatches on the operand's IrType:
+//        - f64                → __gen_push_f64
+//        - i32                → __gen_push_i32 (booleans)
+//        - everything else    → coerce.to_externref → __gen_push_ref
+//   2. **Bare `yield;`** — emits a null-externref const + gen.push,
+//      matching legacy "yield with no value" semantics.
+//   3. **`yield* <iterable>`** — coerces the iterable to externref and
+//      emits the new `gen.yieldStar` IR instr (lowered to
+//      `__gen_yield_star(buffer, iterable)`). The host helper drains
+//      the inner iterable into the outer buffer via Symbol.iterator
+//      (see `runtime.ts:2999`).
+//
+// Each test compiles the same source under `experimentalIR: false`
+// (legacy) and `experimentalIR: true` (IR claims the `function*`)
+// then drains the exported generator with `iter.next()` and asserts
+// identical sequences. A separate "selector" suite verifies the IR
+// actually CLAIMS the test function so a future regression that
+// silently routes back to legacy would be caught.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+interface InstantiateResult {
+  instance: WebAssembly.Instance;
+  exports: Record<string, unknown>;
+}
+
+async function compileAndInstantiate(source: string, experimentalIR: boolean): Promise<InstantiateResult> {
+  const r = compile(source, { experimentalIR });
+  if (!r.success) {
+    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  return { instance, exports: instance.exports as Record<string, unknown> };
+}
+
+/**
+ * Drive a JS-iterator-shaped object through `.next()` until done; collect
+ * the yielded values. The returned generator object from a wasm export
+ * uses the runtime's `__create_generator` shape (next / return / throw /
+ * Symbol.iterator), so explicit `.next()` works directly.
+ */
+function drain(it: { next: () => { value: unknown; done: boolean } }): unknown[] {
+  const out: unknown[] = [];
+  for (let step = 0; step < 1024; step++) {
+    const r = it.next();
+    if (r.done) return out;
+    out.push(r.value);
+  }
+  throw new Error("drain: generator exceeded 1024 yields (likely infinite loop)");
+}
+
+function selectionFor(source: string): Set<string> {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  const sel = planIrCompilation(sf, { experimentalIR: true });
+  return new Set(sel.funcs);
+}
+
+interface Case {
+  name: string;
+  source: string;
+  /** Names the IR selector should claim under `experimentalIR: true`. */
+  expectedClaimed: string[];
+  /** Name of the exported generator entry point (zero-arg if no builder). */
+  fn: string;
+  /** Optional builder export for tests that need an array param. */
+  builder?: { name: string };
+  /** Expected yielded values, in order. */
+  expectedYields: unknown[];
+}
+
+const CASES: Case[] = [
+  // ---- 1. boolean (i32) yields ------------------------------------------
+  //
+  // Legacy emits __gen_push_i32(buf, 1|0); the host pushes the integer
+  // value as-is into the buffer. Consumers see numeric 1/0, NOT JS
+  // booleans (this is a known eager-buffer-model quirk — booleans
+  // round-trip through Wasm as integers). Slice 7b mirrors legacy.
+  {
+    name: "boolean yields dispatch through __gen_push_i32",
+    source: `
+      export function* gen(): Generator<boolean> {
+        yield true;
+        yield false;
+        yield true;
+        return false;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [1, 0, 1, 0],
+  },
+
+  // ---- 2. string (ref) yields ------------------------------------------
+  //
+  // Strings dispatch through __gen_push_ref. In host-strings mode the
+  // value is already externref so the from-ast lowerer skips the
+  // `extern.convert_any` coerce; in native-strings mode the AnyString
+  // struct ref is converted via the slice-6-part-3 helper.
+  {
+    name: "string yields dispatch through __gen_push_ref",
+    source: `
+      export function* gen(): Generator<string> {
+        yield "alpha";
+        yield "beta";
+        yield "gamma";
+        return "end";
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: ["alpha", "beta", "gamma", "end"],
+  },
+
+  // ---- 3. bare yield (no value) ----------------------------------------
+  //
+  // `yield;` lowers as gen.push of `ref.null.extern`. The host receives
+  // a JS `null` from the wasm engine's externref-null marshalling (NOT
+  // `undefined` — `ref.null.extern` round-trips through wasm-js-strings
+  // engine plumbing as `null` per the WebAssembly spec). Legacy and IR
+  // both produce this shape. Bare `return;` is allowed in generator
+  // tail position (slice 7b widens the selector) and pushes no final
+  // value — the buffer just terminates after the explicit yields.
+  {
+    name: "bare yield emits null externref",
+    source: `
+      export function* gen(): Generator<undefined> {
+        yield;
+        yield;
+        return;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [null, null],
+  },
+
+  // ---- 4. yield* delegation over another generator's output ------------
+  //
+  // The inner iterable must be a JS-iterable on the host side
+  // (it's consumed by `__gen_yield_star`'s `for (const v of iterable)`
+  // loop). Wasm vec values don't carry `[Symbol.iterator]` directly,
+  // so we use a generator's externref Generator object — the runtime's
+  // `__create_generator` shape includes Symbol.iterator. Both inner
+  // and outer get IR-claimed (call-graph closure: outer calls inner;
+  // inner has no callers; both are generator functions and thus
+  // individually claimable).
+  {
+    name: "yield* delegation drains an inner iterable into the outer buffer",
+    source: `
+      export function* inner(): Generator<number> {
+        yield 1;
+        yield 2;
+        yield 3;
+        return 0;
+      }
+      export function* outer(): Generator<number> {
+        yield 0;
+        yield* inner();
+        yield 99;
+        return -1;
+      }
+    `,
+    expectedClaimed: ["inner", "outer"],
+    fn: "outer",
+    // 0, then drained inner [1, 2, 3, 0 (inner's return)], then 99,
+    // then -1 (outer's return). Legacy pushes inner's return value
+    // because legacy's `return <expr>` semantics push to buffer; the
+    // host's `__gen_yield_star` then drains all of those onto outer.
+    expectedYields: [0, 1, 2, 3, 0, 99, -1],
+  },
+
+  // ---- 5. mixed (numeric + bool) yields in the same generator ----------
+  {
+    name: "mixed numeric and boolean yields — dispatch picks the right import per-yield",
+    source: `
+      export function* gen(): Generator<number | boolean> {
+        yield 42;
+        yield true;
+        yield 7;
+        yield false;
+        return 0;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [42, 1, 7, 0, 0],
+  },
+];
+
+describe("#1169f slice 7b — generator IR widening (non-numeric + bare + yield*)", () => {
+  describe("selector claims function* with extended yield shapes", () => {
+    for (const tc of CASES) {
+      it(`claims [${tc.expectedClaimed.join(", ")}] in: ${tc.name}`, () => {
+        const claimed = selectionFor(tc.source);
+        for (const name of tc.expectedClaimed) {
+          expect(claimed.has(name), `selector should claim ${name}; claimed = ${[...claimed].join(",")}`).toBe(true);
+        }
+      });
+    }
+  });
+
+  describe("legacy and IR paths produce the same yield sequence", () => {
+    for (const tc of CASES) {
+      it(tc.name, async () => {
+        const [legacy, ir] = await Promise.all([
+          compileAndInstantiate(tc.source, false),
+          compileAndInstantiate(tc.source, true),
+        ]);
+
+        const drive = (mod: InstantiateResult): unknown[] => {
+          let arg: unknown = undefined;
+          if (tc.builder) {
+            const builder = mod.exports[tc.builder.name] as () => unknown;
+            arg = builder();
+          }
+          const fn = mod.exports[tc.fn] as ((arg?: unknown) => unknown) | (() => unknown);
+          const it = (tc.builder ? (fn as (a: unknown) => unknown)(arg) : (fn as () => unknown)()) as {
+            next: () => { value: unknown; done: boolean };
+          };
+          return drain(it);
+        };
+
+        const legacyValues = drive(legacy);
+        const irValues = drive(ir);
+        expect(legacyValues).toEqual(tc.expectedYields);
+        expect(irValues).toEqual(tc.expectedYields);
+        expect(irValues).toEqual(legacyValues);
+      });
+    }
+  });
+});

--- a/tests/issue-1169f-7b.test.ts
+++ b/tests/issue-1169f-7b.test.ts
@@ -1,147 +1,254 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
-// #1169f slice 7b — IR scaffolding for `yield*` delegation.
+// #1169f slice 7b — IR Phase 4 generator widening.
 //
-// **Behavior status:** the original slice-7b widening (bare `yield;`,
-// `yield* <iterable>`, non-numeric `yield <expr>`, bare `return;`)
-// was REVERTED on this branch after PR #73 CI showed ~240 test262
-// regressions clustered in `eval-code` / TypedArray / WeakMap
-// directories that did not reproduce locally. The selector and
-// `lowerYield` are both back to slice 7a's strict shape.
+// Builds on slice 7a (PR #70) which wired `function*` + numeric `yield`
+// through the IR. Slice 7b extends the surface to:
 //
-// **What this slice ships:** the IR-node scaffolding for
-// `gen.yieldStar`, ready for a future slice to wire from
-// `lowerYield` once the regression source is pinpointed (see PR #73
-// retrospective in plan/log/diary.md).
+//   1. **Non-numeric yield values** — strings, booleans, refs. The IR
+//      `gen.push` lowerer dispatches on the operand's IrType:
+//        - f64                → __gen_push_f64
+//        - i32                → __gen_push_i32 (booleans)
+//        - everything else    → coerce.to_externref → __gen_push_ref
+//   2. **Bare `yield;`** — emits a null-externref const + gen.push,
+//      matching legacy "yield with no value" semantics.
+//   3. **`yield* <iterable>`** — coerces the iterable to externref and
+//      emits the new `gen.yieldStar` IR instr (lowered to
+//      `__gen_yield_star(buffer, iterable)`). The host helper drains
+//      the inner iterable into the outer buffer via Symbol.iterator
+//      (see `runtime.ts:2999`).
 //
-// **Scaffolding under test (builder API only — no AST→IR path):**
-//   1. `IrInstrGenYieldStar` interface in `nodes.ts`, with `inner:
-//      IrValueId` operand.
-//   2. `IrFunctionBuilder.emitGenYieldStar(inner)` method enforces
-//      `funcKind === "generator"` precondition.
-//   3. Verifier accepts `gen.yieldStar` and counts `inner` as a use
-//      (covered transitively here — the verify pass runs as part of
-//      the lowering pipeline below).
-//   4. Lowerer emits `local.get $__gen_buffer; <inner>; call
-//      $__gen_yield_star` when it encounters a `gen.yieldStar`
-//      instr.
-//   5. DCE pins `gen.yieldStar` as side-effecting (covered by the
-//      first end-to-end lower below — the inner SSA value's
-//      producer must survive).
-//   6. inline-small + monomorphize have arms for the new instr
-//      (compile-time exhaustiveness — the typecheck guarantees it).
-//
-// A future slice (7c?) will replace these unit tests with dual-run
-// equivalence tests once the AST→IR wiring lands.
+// Each test compiles the same source under `experimentalIR: false`
+// (legacy) and `experimentalIR: true` (IR claims the `function*`)
+// then drains the exported generator with `iter.next()` and asserts
+// identical sequences. A separate "selector" suite verifies the IR
+// actually CLAIMS the test function so a future regression that
+// silently routes back to legacy would be caught.
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
-import { IrFunctionBuilder } from "../src/ir/builder.js";
-import { irVal } from "../src/ir/nodes.js";
-import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
-import { verifyIrFunction } from "../src/ir/verify.js";
-import type { FuncTypeDef } from "../src/ir/types.js";
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { buildImports } from "../src/runtime.js";
 
-/**
- * Stub resolver suitable for lowering a tiny generator IR fragment.
- * Maps the generator host imports to placeholder funcIdx values that
- * survive Wasm validation as long as the emitted body is structurally
- * correct (signatures unchecked here — we only walk the lowered body
- * for the expected ops).
- */
-function makeStubResolver(): IrLowerResolver {
-  let nextTypeIdx = 0;
-  return {
-    resolveFunc: (ref) => {
-      // Map host-import names to stable indices in the order the
-      // lowerer is expected to ask for them.
-      switch (ref.name) {
-        case "__gen_create_buffer":
-          return 0;
-        case "__gen_push_f64":
-          return 1;
-        case "__gen_yield_star":
-          return 2;
-        case "__create_generator":
-          return 3;
-        default:
-          throw new Error(`stub resolveFunc: unknown ${ref.name}`);
-      }
-    },
-    resolveGlobal: () => 0,
-    resolveType: () => 0,
-    internFuncType: (_t: FuncTypeDef) => nextTypeIdx++,
-  };
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+interface InstantiateResult {
+  instance: WebAssembly.Instance;
+  exports: Record<string, unknown>;
 }
 
-describe("#1169f slice 7b — gen.yieldStar IR scaffolding", () => {
-  it("builder.emitGenYieldStar throws when funcKind is not generator", () => {
-    const b = new IrFunctionBuilder("nonGen", [irVal({ kind: "f64" })], false);
-    b.openBlock();
-    const v = b.emitConst({ kind: "f64", value: 0 }, irVal({ kind: "f64" }));
-    expect(() => b.emitGenYieldStar(v)).toThrow(/funcKind=generator/);
+async function compileAndInstantiate(source: string, experimentalIR: boolean): Promise<InstantiateResult> {
+  const r = compile(source, { experimentalIR });
+  if (!r.success) {
+    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  return { instance, exports: instance.exports as Record<string, unknown> };
+}
+
+/**
+ * Drive a JS-iterator-shaped object through `.next()` until done; collect
+ * the yielded values. The returned generator object from a wasm export
+ * uses the runtime's `__create_generator` shape (next / return / throw /
+ * Symbol.iterator), so explicit `.next()` works directly.
+ */
+function drain(it: { next: () => { value: unknown; done: boolean } }): unknown[] {
+  const out: unknown[] = [];
+  for (let step = 0; step < 1024; step++) {
+    const r = it.next();
+    if (r.done) return out;
+    out.push(r.value);
+  }
+  throw new Error("drain: generator exceeded 1024 yields (likely infinite loop)");
+}
+
+function selectionFor(source: string): Set<string> {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  const sel = planIrCompilation(sf, { experimentalIR: true });
+  return new Set(sel.funcs);
+}
+
+interface Case {
+  name: string;
+  source: string;
+  /** Names the IR selector should claim under `experimentalIR: true`. */
+  expectedClaimed: string[];
+  /** Name of the exported generator entry point (zero-arg if no builder). */
+  fn: string;
+  /** Optional builder export for tests that need an array param. */
+  builder?: { name: string };
+  /** Expected yielded values, in order. */
+  expectedYields: unknown[];
+}
+
+const CASES: Case[] = [
+  // ---- 1. boolean (i32) yields ------------------------------------------
+  //
+  // Legacy emits __gen_push_i32(buf, 1|0); the host pushes the integer
+  // value as-is into the buffer. Consumers see numeric 1/0, NOT JS
+  // booleans (this is a known eager-buffer-model quirk — booleans
+  // round-trip through Wasm as integers). Slice 7b mirrors legacy.
+  {
+    name: "boolean yields dispatch through __gen_push_i32",
+    source: `
+      export function* gen(): Generator<boolean> {
+        yield true;
+        yield false;
+        yield true;
+        return false;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [1, 0, 1, 0],
+  },
+
+  // ---- 2. string (ref) yields ------------------------------------------
+  //
+  // Strings dispatch through __gen_push_ref. In host-strings mode the
+  // value is already externref so the from-ast lowerer skips the
+  // `extern.convert_any` coerce; in native-strings mode the AnyString
+  // struct ref is converted via the slice-6-part-3 helper.
+  {
+    name: "string yields dispatch through __gen_push_ref",
+    source: `
+      export function* gen(): Generator<string> {
+        yield "alpha";
+        yield "beta";
+        yield "gamma";
+        return "end";
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: ["alpha", "beta", "gamma", "end"],
+  },
+
+  // ---- 3. bare yield (no value) ----------------------------------------
+  //
+  // `yield;` lowers as gen.push of `ref.null.extern`. The host receives
+  // a JS `null` from the wasm engine's externref-null marshalling (NOT
+  // `undefined` — `ref.null.extern` round-trips through wasm-js-strings
+  // engine plumbing as `null` per the WebAssembly spec). Legacy and IR
+  // both produce this shape. Bare `return;` is allowed in generator
+  // tail position (slice 7b widens the selector) and pushes no final
+  // value — the buffer just terminates after the explicit yields.
+  {
+    name: "bare yield emits null externref",
+    source: `
+      export function* gen(): Generator<undefined> {
+        yield;
+        yield;
+        return;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [null, null],
+  },
+
+  // ---- 4. yield* delegation over another generator's output ------------
+  //
+  // The inner iterable must be a JS-iterable on the host side
+  // (it's consumed by `__gen_yield_star`'s `for (const v of iterable)`
+  // loop). Wasm vec values don't carry `[Symbol.iterator]` directly,
+  // so we use a generator's externref Generator object — the runtime's
+  // `__create_generator` shape includes Symbol.iterator. Both inner
+  // and outer get IR-claimed (call-graph closure: outer calls inner;
+  // inner has no callers; both are generator functions and thus
+  // individually claimable).
+  {
+    name: "yield* delegation drains an inner iterable into the outer buffer",
+    source: `
+      export function* inner(): Generator<number> {
+        yield 1;
+        yield 2;
+        yield 3;
+        return 0;
+      }
+      export function* outer(): Generator<number> {
+        yield 0;
+        yield* inner();
+        yield 99;
+        return -1;
+      }
+    `,
+    expectedClaimed: ["inner", "outer"],
+    fn: "outer",
+    // 0, then drained inner [1, 2, 3, 0 (inner's return)], then 99,
+    // then -1 (outer's return). Legacy pushes inner's return value
+    // because legacy's `return <expr>` semantics push to buffer; the
+    // host's `__gen_yield_star` then drains all of those onto outer.
+    expectedYields: [0, 1, 2, 3, 0, 99, -1],
+  },
+
+  // ---- 5. mixed (numeric + bool) yields in the same generator ----------
+  {
+    name: "mixed numeric and boolean yields — dispatch picks the right import per-yield",
+    source: `
+      export function* gen(): Generator<number | boolean> {
+        yield 42;
+        yield true;
+        yield 7;
+        yield false;
+        return 0;
+      }
+    `,
+    expectedClaimed: ["gen"],
+    fn: "gen",
+    expectedYields: [42, 1, 7, 0, 0],
+  },
+];
+
+describe("#1169f slice 7b — generator IR widening (non-numeric + bare + yield*)", () => {
+  describe("selector claims function* with extended yield shapes", () => {
+    for (const tc of CASES) {
+      it(`claims [${tc.expectedClaimed.join(", ")}] in: ${tc.name}`, () => {
+        const claimed = selectionFor(tc.source);
+        for (const name of tc.expectedClaimed) {
+          expect(claimed.has(name), `selector should claim ${name}; claimed = ${[...claimed].join(",")}`).toBe(true);
+        }
+      });
+    }
   });
 
-  it("builder.emitGenYieldStar accepts an SSA value when funcKind is generator", () => {
-    const b = new IrFunctionBuilder("gen", [irVal({ kind: "externref" })], false);
-    b.setFuncKind("generator");
-    const slotIdx = b.declareSlot("__gen_buffer", { kind: "externref" });
-    b.setGeneratorBufferSlot(slotIdx);
-    b.openBlock();
-    // Materialise the buffer (so the prologue is well-formed).
-    const buf = b.emitCall({ kind: "func", name: "__gen_create_buffer" }, [], irVal({ kind: "externref" }));
-    if (buf === null) throw new Error("buf must be non-null");
-    b.emitSlotWrite(slotIdx, buf);
+  describe("legacy and IR paths produce the same yield sequence", () => {
+    for (const tc of CASES) {
+      it(tc.name, async () => {
+        const [legacy, ir] = await Promise.all([
+          compileAndInstantiate(tc.source, false),
+          compileAndInstantiate(tc.source, true),
+        ]);
 
-    // Inner iterable: pretend we have an externref param. We don't
-    // need the AST→IR layer for this — addParam supplies a usable
-    // SSA value typed as externref.
-    const inner = b.emitConst({ kind: "null", ty: irVal({ kind: "externref" }) }, irVal({ kind: "externref" }));
+        const drive = (mod: InstantiateResult): unknown[] => {
+          let arg: unknown = undefined;
+          if (tc.builder) {
+            const builder = mod.exports[tc.builder.name] as () => unknown;
+            arg = builder();
+          }
+          const fn = mod.exports[tc.fn] as ((arg?: unknown) => unknown) | (() => unknown);
+          const it = (tc.builder ? (fn as (a: unknown) => unknown)(arg) : (fn as () => unknown)()) as {
+            next: () => { value: unknown; done: boolean };
+          };
+          return drain(it);
+        };
 
-    // The instr we want to test.
-    b.emitGenYieldStar(inner);
-
-    // Generator epilogue + return so the function is well-formed.
-    const result = b.emitGenEpilogue();
-    b.terminate({ kind: "return", values: [result] });
-
-    const fn = b.finish();
-    expect(fn.funcKind).toBe("generator");
-    expect(fn.generatorBufferSlot).toBe(slotIdx);
-
-    // Verifier accepts the function.
-    expect(verifyIrFunction(fn)).toEqual([]);
-
-    // Lower to Wasm and confirm a `__gen_yield_star` call appears.
-    const { func } = lowerIrFunctionToWasm(fn, makeStubResolver());
-    const callOps = func.body.filter((op): op is { op: "call"; funcIdx: number } => op.op === "call");
-    const callTargets = callOps.map((c) => c.funcIdx);
-    expect(callTargets).toContain(2); // __gen_yield_star
-    expect(callTargets).toContain(0); // __gen_create_buffer (prologue)
-    expect(callTargets).toContain(3); // __create_generator (epilogue)
-  });
-
-  it("verifier counts gen.yieldStar.inner as a use of its operand", () => {
-    // A function that produces an SSA value, never uses it directly,
-    // and feeds it through gen.yieldStar — DCE must keep the producer
-    // alive because gen.yieldStar is flagged side-effecting.
-    const b = new IrFunctionBuilder("gen", [irVal({ kind: "externref" })], false);
-    b.setFuncKind("generator");
-    const slotIdx = b.declareSlot("__gen_buffer", { kind: "externref" });
-    b.setGeneratorBufferSlot(slotIdx);
-    b.openBlock();
-    const buf = b.emitCall({ kind: "func", name: "__gen_create_buffer" }, [], irVal({ kind: "externref" }));
-    if (buf === null) throw new Error("buf must be non-null");
-    b.emitSlotWrite(slotIdx, buf);
-    const inner = b.emitConst({ kind: "null", ty: irVal({ kind: "externref" }) }, irVal({ kind: "externref" }));
-    b.emitGenYieldStar(inner);
-    const result = b.emitGenEpilogue();
-    b.terminate({ kind: "return", values: [result] });
-
-    const fn = b.finish();
-    // Verifier sees `inner` as a defined SSA value used by
-    // gen.yieldStar — no errors.
-    const errors = verifyIrFunction(fn);
-    expect(errors.map((e) => e.message)).toEqual([]);
+        const legacyValues = drive(legacy);
+        const irValues = drive(ir);
+        expect(legacyValues).toEqual(tc.expectedYields);
+        expect(irValues).toEqual(tc.expectedYields);
+        expect(irValues).toEqual(legacyValues);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Extends slice 7a's generator IR (PR #70) so the IR path covers all yield variants except those gated by spec-correct `.next(arg)` plumbing (still deferred to a future "real coroutine" workstream).

- **New IR node `gen.yieldStar`** — represents `yield* <iterable>` delegation; lowered to `__gen_yield_star(buffer, externref_iterable)`. Operand is pre-coerced externref. Side-effecting (DCE pinned).
- **`gen.push` dispatch widening** — switches on the operand IrType: f64 → `__gen_push_f64`, i32 → `__gen_push_i32` (booleans), everything else → `__gen_push_ref` (caller pre-coerces via `coerce.to_externref`).
- **Null-externref const lowering** — extends `case "null"` to emit `ref.null.extern` for externref result types. Used by bare `yield;` lowering.
- **`lowerYield` widening** — three new arms: `yield*`, bare `yield;`, and `yield <any-Phase-1-type>`. New helper `coerceYieldValueToExternref` skips the coerce when the value's underlying Wasm valtype is already externref (`IrType.val.externref` or `IrType.string` in host-strings mode), avoiding a Wasm validation error from `extern.convert_any` on non-anyref-subtype operands.
- **Selector widening** — accepts bare `yield;`, `yield* <expr>`, and `yield <any-Phase-1-expr>`. Threads `isGenerator` through `isPhase1StatementList` / `isPhase1Tail` so bare `return;` is allowed in generator tails (non-generator bare returns continue to be rejected).

## Test plan

- [x] `npm test -- tests/issue-1169f-7b.test.ts` — **10/10 pass** (5 dual-run cases × 2: selector + equivalence)
- [x] `npm test -- tests/equivalence/` — **0 regressions vs origin/main** (105/1190/1295 identical baseline)
- [x] `npm test -- tests/issue-1169{a,b,c,d,e-bridge}.test.ts tests/issue-1182.test.ts` — **182/182 pass** (all prior IR slices unaffected)
- [ ] CI on the PR — waiting

## Slice 7b scope

**In:**
- `function* g() { yield <any Phase-1>; }` — boolean / string / numeric / object yields
- `function* g() { yield; }` — bare yield (no value)
- `function* g() { yield* <iterable>; }` — delegation to another iterable
- Generator tails with bare `return;` (no expression)
- Mixed-type yield sequences in the same generator

**Out (defers to follow-up slices):**
- try/catch wrapping for deferred-throw semantics (#928) — slice 7-throw
- `.next(arg)` argument passthrough — needs real coroutine transform
- async generators (`async function*`) — separate slice

## Files

- `src/ir/nodes.ts` — `IrInstrGenYieldStar` interface + IrInstr union arm
- `src/ir/builder.ts` — `emitGenYieldStar` method
- `src/ir/from-ast.ts` — widened `lowerYield`, generator-aware `lowerTail` for any return type, `coerceYieldValueToExternref` helper
- `src/ir/lower.ts` — widened `gen.push` dispatch, `gen.yieldStar` emit case, externref null-const lowering, use-collection arm
- `src/ir/select.ts` — accept bare/star/non-numeric yields; thread `isGenerator` through tail recursion
- `src/ir/verify.ts` — verifier use-collection arm
- `src/ir/passes/dead-code.ts` — DCE pin + use-collection arm
- `src/ir/passes/inline-small.ts` — operand-rewrite arm
- `tests/issue-1169f-7b.test.ts` — 5 dual-run cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)