### PR TITLE
fix(legacy): re-resolve __str_charAt by name in compileForOfString (#1186)

### DIFF
--- a/plan/issues/ready/1186.md
+++ b/plan/issues/ready/1186.md
@@ -139,3 +139,53 @@ inspect each call site for the capture-vs-walk pattern.
 - A full audit of every `ctx.nativeStrHelpers.get(...)` call site for
   similar bugs — spot-fix the known sites, file follow-ups for any
   others surfaced.
+
+---
+
+## Implementation Notes (senior-developer, 2026-04-27)
+
+### Fix applied
+
+Replaced the funcIdx capture in `compileForOfString`
+(`src/codegen/statements/loops.ts:~1487`) with a name walk against
+`ctx.mod.functions[i].name`. Mirrors the IR resolver pattern from
+#1183 (`src/ir/integration.ts:resolveFunc`'s `ctx.mod.functions`
+fallback). The resolved index is `ctx.numImportFuncs + i` — the
+absolute funcIdx in the post-shift index space.
+
+The change is local to one site (option A from the spec). Other
+`ctx.nativeStrHelpers.get(...)` consumers in the legacy codebase
+were left as-is; if they exhibit the same staleness pattern each
+should be filed as its own issue with a reproducer.
+
+### Verification
+
+  1. Local probe — both legacy and IR modes produce valid Wasm and
+     identical runtime results for 5 representative test cases
+     (count chars, empty string, single-char, `c.length` in body,
+     BMP unicode). All 10 (5 cases × 2 modes) pass.
+  2. New regression test `tests/issue-1186.test.ts` — 11 cases:
+     - 5 legacy+nativeStrings cases asserting expected runtime values
+     - 5 legacy↔IR equivalence cases (re-enabling the dual-run that
+       #1183 had to skip due to this bug)
+     - 1 host-strings sanity check
+  3. Prior IR tests pass unchanged (128/128 across #1169d / #1169e /
+     #1182 / #1183 / `tests/ir/`).
+  4. Local equivalence suite — exit 0.
+
+### Files touched
+
+  - `src/codegen/statements/loops.ts` — name-walk lookup for
+    `__str_charAt`, ~25-line comment block explaining the rationale.
+  - `tests/issue-1186.test.ts` — new regression test (11 cases).
+  - `plan/issues/ready/1186.md` — these implementation notes.
+
+### Related work unblocked
+
+  - #1183's `tests/issue-1183.test.ts` native-mode dual-run cases
+    (currently asserting against JS-computed expected values
+    instead of legacy parity) can be re-enabled in a follow-up
+    after this lands.
+  - #1187 (test-runtime JS↔native-string coercion) becomes more
+    valuable once this lands — broader native-strings test surface
+    flows through dual-run with a coercion helper.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1484,7 +1484,28 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   // Ensure native string helpers are available (provides __str_charAt)
   ensureNativeStringHelpers(ctx);
 
-  const charAtIdx = ctx.nativeStrHelpers.get("__str_charAt");
+  // #1186: re-resolve `__str_charAt` by name against `ctx.mod.functions`
+  // rather than reading the cached index from `ctx.nativeStrHelpers`. The
+  // helpers map captures funcIdx at registration time, but late-import
+  // additions later in the compilation pipeline can shift the index space
+  // (`shiftLateImportIndices` walks `ctx.mod.functions[].body` and
+  // `ctx.funcMap` but does NOT update `ctx.nativeStrHelpers`). The
+  // captured index becomes stale and at runtime resolves to whatever
+  // import landed at that position (typically `__is_truthy`), producing
+  // an invalid Wasm body that fails validation:
+  //
+  //   call[0] expected externref, found local.get of type i32
+  //
+  // The IR path (#1183) sidesteps this by walking
+  // `ctx.mod.functions[i].name` at lowering time. Mirroring that here
+  // for the legacy path:
+  let charAtIdx: number | undefined;
+  for (let i = 0; i < ctx.mod.functions.length; i++) {
+    if (ctx.mod.functions[i]!.name === "__str_charAt") {
+      charAtIdx = ctx.numImportFuncs + i;
+      break;
+    }
+  }
   if (charAtIdx === undefined) {
     reportError(ctx, stmt, "for-of on string: __str_charAt helper not available");
     return;

--- a/tests/issue-1186.test.ts
+++ b/tests/issue-1186.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1186 — Legacy `compileForOfString` produced invalid Wasm in
+// `nativeStrings: true` mode for `for (const c of s)`. Root cause:
+// `ctx.nativeStrHelpers.get("__str_charAt")` captures funcIdx at
+// registration time, but late-import shifts move `__str_charAt`'s
+// position in the module — the captured index becomes stale.
+//
+// Fix: re-resolve `__str_charAt` by name against `ctx.mod.functions`
+// at the call site (mirrors the IR resolver's #1183 pattern).
+//
+// Surface check: dual-run (legacy + IR, with nativeStrings: true) of
+// `for (const c of s)` over inline string literals. Before #1186 the
+// legacy path produced `WebAssembly.CompileError: call[0] expected
+// type externref, found local.get of type i32`. After: both paths
+// produce valid Wasm and identical runtime results.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+type Outcome =
+  | { kind: "ok"; value: unknown }
+  | { kind: "compile_fail"; first: string }
+  | { kind: "instantiate_fail"; reason?: string }
+  | { kind: "invoke_fail"; reason?: string };
+
+async function runOnce(
+  source: string,
+  fnName: string,
+  experimentalIR: boolean,
+  nativeStrings: boolean,
+): Promise<Outcome> {
+  const r = compile(source, { experimentalIR, nativeStrings });
+  if (!r.success) {
+    return { kind: "compile_fail", first: r.errors[0]?.message ?? "" };
+  }
+  let instance: WebAssembly.Instance;
+  try {
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    ({ instance } = await WebAssembly.instantiate(r.binary, {
+      env: built.env,
+      string_constants: built.string_constants,
+    }));
+  } catch (e: unknown) {
+    return { kind: "instantiate_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+  try {
+    const fn = instance.exports[fnName] as () => unknown;
+    return { kind: "ok", value: fn() };
+  } catch (e: unknown) {
+    return { kind: "invoke_fail", reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+interface Case {
+  name: string;
+  source: string;
+  expected: number;
+}
+
+const CASES: Case[] = [
+  // ---- 1. Canonical reproducer for the staleness bug ---------------------
+  {
+    name: "count 5 chars in 'hello'",
+    source: `
+      export function fn(): number {
+        const s = "hello";
+        let n = 0;
+        for (const c of s) { n = n + 1; }
+        return n;
+      }
+    `,
+    expected: 5,
+  },
+
+  // ---- 2. Empty string ---------------------------------------------------
+  {
+    name: "empty string returns 0",
+    source: `
+      export function fn(): number {
+        const s = "";
+        let n = 0;
+        for (const c of s) { n = n + 1; }
+        return n;
+      }
+    `,
+    expected: 0,
+  },
+
+  // ---- 3. Single-char ----------------------------------------------------
+  {
+    name: "single-char string",
+    source: `
+      export function fn(): number {
+        const s = "z";
+        let n = 0;
+        for (const c of s) { n = n + 1; }
+        return n;
+      }
+    `,
+    expected: 1,
+  },
+
+  // ---- 4. Body uses .length on the loop var (exercises the c value) ------
+  {
+    name: "uses c.length in body",
+    source: `
+      export function fn(): number {
+        const s = "abc";
+        let n = 0;
+        for (const c of s) { n = n + c.length; }
+        return n;
+      }
+    `,
+    expected: 3,
+  },
+
+  // ---- 5. BMP unicode (counts code units) --------------------------------
+  {
+    name: "BMP unicode 'café' (4 code units)",
+    source: `
+      export function fn(): number {
+        const s = "café";
+        let n = 0;
+        for (const c of s) { n = n + 1; }
+        return n;
+      }
+    `,
+    expected: 4,
+  },
+];
+
+describe("#1186 — legacy compileForOfString re-resolves __str_charAt post-shift (nativeStrings)", () => {
+  for (const tc of CASES) {
+    it(`legacy + nativeStrings: ${tc.name}`, async () => {
+      const r = await runOnce(tc.source, "fn", false, true);
+      if (r.kind !== "ok") {
+        throw new Error(`legacy run failed: ${JSON.stringify(r)}`);
+      }
+      expect(r.value).toBe(tc.expected);
+    });
+  }
+});
+
+describe("#1186 — legacy ↔ IR equivalence in nativeStrings mode (#1183 dual-run re-enabled)", () => {
+  // Before #1186 these dual-runs were impossible because legacy was broken.
+  // After #1186 the legacy path emits valid Wasm, so we can compare.
+  for (const tc of CASES) {
+    it(`equivalent: ${tc.name}`, async () => {
+      const [legacy, ir] = await Promise.all([
+        runOnce(tc.source, "fn", false, true),
+        runOnce(tc.source, "fn", true, true),
+      ]);
+      if (legacy.kind !== "ok") throw new Error(`legacy run failed: ${JSON.stringify(legacy)}`);
+      if (ir.kind !== "ok") throw new Error(`ir run failed: ${JSON.stringify(ir)}`);
+      expect(legacy.value).toBe(ir.value);
+      expect(legacy.value).toBe(tc.expected);
+    });
+  }
+});
+
+describe("#1186 — host-strings (default) for-of string iteration still works", () => {
+  // Sanity check: the fix should be a no-op in host-strings mode (no
+  // __str_charAt is registered there). Just confirm host-mode still
+  // compiles and runs cleanly.
+  it("host: count chars in 'hello'", async () => {
+    const source = `
+      export function fn(): number {
+        const s = "hello";
+        let n = 0;
+        for (const c of s) { n = n + 1; }
+        return n;
+      }
+    `;
+    const r = await runOnce(source, "fn", false, false);
+    if (r.kind !== "ok") throw new Error(`host run failed: ${JSON.stringify(r)}`);
+    expect(r.value).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1186** — fixes a pre-existing legacy bug where `compile(source, { nativeStrings: true })` produced invalid Wasm for `for (const c of <string>)` patterns.

**Root cause**: `compileForOfString` captured `__str_charAt`'s funcIdx from `ctx.nativeStrHelpers` at registration time, but late-import additions later in the pipeline shift the function index space. `shiftLateImportIndices` walks `ctx.mod.functions[].body` and `ctx.funcMap` but does NOT update `ctx.nativeStrHelpers`. The captured index goes stale and at runtime resolves to whatever import landed at that position (typically `__is_truthy`), causing:

```
WebAssembly.CompileError: call[0] expected externref, found local.get of type i32
```

**Fix**: replace the captured index with a name walk against `ctx.mod.functions[i].name` at the call site. Mirrors the IR resolver pattern from #1183 (`src/ir/integration.ts:resolveFunc`'s `ctx.mod.functions` fallback). Single-site change, ~25-line comment block explaining why.

## Test plan

- [x] New `tests/issue-1186.test.ts` — 11 cases pass:
  - 5 legacy+nativeStrings runtime checks (count chars, empty string, single-char, `c.length` in body, BMP unicode)
  - 5 legacy↔IR equivalence dual-runs in nativeStrings mode (re-enables what #1183 had to skip)
  - 1 host-strings sanity check
- [x] Prior IR tests (128/128: #1169d / #1169e / #1182 / #1183 / `tests/ir/`) — pass.
- [x] `npx tsc --noEmit` — 0 errors.
- [x] Local equivalence suite (`tests/equivalence/**`) — exit 0.
- [ ] CI (GitHub Actions) — wait for `.claude/ci-status/pr-<N>.json`, self-merge per dev protocol.

## Out of scope (follow-ups)

- Full audit of other `ctx.nativeStrHelpers.get(...)` consumers for similar staleness — only `compileForOfString` is known to capture-and-reuse across late shifts.
- Extending `shiftLateImportIndices` to rewrite `ctx.nativeStrHelpers` entries (option B from spec) — kills the bug class once but is more invasive. Defer until another consumer surfaces.
- Re-enabling the native-mode dual-run cases in `tests/issue-1183.test.ts` that currently assert against JS-computed expected values. The new tests in this PR effectively cover that gap, so the cleanup is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)