### PR TITLE
fix(#1208): render ADRs to on-origin HTML — fixes 404 on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3115,21 +3115,55 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             linear memory, why ahead-of-time compilation over a JIT, how closures and objects are laid out. Each record
             captures the context, the decision, and its consequences in a few hundred words. Together they make the
             design auditable for external contributors and reviewers.
-            <a href="./docs/adr/README.md">Read the index &rarr;</a>
+            <a href="./docs/adr/">Read the index &rarr;</a>
           </p>
           <ul class="adr-list">
-            <li><a href="./docs/adr/0001-hybrid-compilation-strategy.md">ADR-001 &mdash; Hybrid static&ndash;dynamic compilation strategy</a></li>
-            <li><a href="./docs/adr/0002-architectural-approach.md">ADR-002 &mdash; Architectural approach: AOT + WasmGC</a></li>
-            <li><a href="./docs/adr/0003-wasmgc.md">ADR-003 &mdash; WasmGC over linear memory</a></li>
-            <li><a href="./docs/adr/0004-aot.md">ADR-004 &mdash; AOT compilation over JIT/interpreter</a></li>
-            <li><a href="./docs/adr/0005-object-layout.md">ADR-005 &mdash; Object layout via WasmGC struct types (closed-world)</a></li>
-            <li><a href="./docs/adr/0006-boundary-guards.md">ADR-006 &mdash; Boundary guards at host-import surfaces</a></li>
-            <li><a href="./docs/adr/0007-closure-conversion.md">ADR-007 &mdash; Closure conversion via WasmGC ref-cell structs</a></li>
-            <li><a href="./docs/adr/0008-dual-string-backend.md">ADR-008 &mdash; Dual string backend: wasm:js-string vs WasmGC i16 arrays</a></li>
-            <li><a href="./docs/adr/0009-typescript-annotations.md">ADR-009 &mdash; TypeScript annotations as inference seeds, not ground truth</a></li>
-            <li><a href="./docs/adr/0010-eval-host-import.md">ADR-010 &mdash; Dynamic eval() via host import</a></li>
-            <li><a href="./docs/adr/0011-implementation-language.md">ADR-011 &mdash; Implementation language: TypeScript with the typescript package</a></li>
-            <li><a href="./docs/adr/0012-intermediate-representation.md">ADR-012 &mdash; Intermediate representation: multi-stage typed IR</a></li>
+            <li>
+              <a href="./docs/adr/0001-hybrid-compilation-strategy.html">
+                ADR-001 &mdash; Hybrid static&ndash;dynamic compilation strategy
+              </a>
+            </li>
+            <li>
+              <a href="./docs/adr/0002-architectural-approach.html">
+                ADR-002 &mdash; Architectural approach: AOT + WasmGC
+              </a>
+            </li>
+            <li><a href="./docs/adr/0003-wasmgc.html">ADR-003 &mdash; WasmGC over linear memory</a></li>
+            <li><a href="./docs/adr/0004-aot.html">ADR-004 &mdash; AOT compilation over JIT/interpreter</a></li>
+            <li>
+              <a href="./docs/adr/0005-object-layout.html">
+                ADR-005 &mdash; Object layout via WasmGC struct types (closed-world)
+              </a>
+            </li>
+            <li>
+              <a href="./docs/adr/0006-boundary-guards.html">ADR-006 &mdash; Boundary guards at host-import surfaces</a>
+            </li>
+            <li>
+              <a href="./docs/adr/0007-closure-conversion.html">
+                ADR-007 &mdash; Closure conversion via WasmGC ref-cell structs
+              </a>
+            </li>
+            <li>
+              <a href="./docs/adr/0008-dual-string-backend.html">
+                ADR-008 &mdash; Dual string backend: wasm:js-string vs WasmGC i16 arrays
+              </a>
+            </li>
+            <li>
+              <a href="./docs/adr/0009-typescript-annotations.html">
+                ADR-009 &mdash; TypeScript annotations as inference seeds, not ground truth
+              </a>
+            </li>
+            <li><a href="./docs/adr/0010-eval-host-import.html">ADR-010 &mdash; Dynamic eval() via host import</a></li>
+            <li>
+              <a href="./docs/adr/0011-implementation-language.html">
+                ADR-011 &mdash; Implementation language: TypeScript with the typescript package
+              </a>
+            </li>
+            <li>
+              <a href="./docs/adr/0012-intermediate-representation.html">
+                ADR-012 &mdash; Intermediate representation: multi-stage typed IR
+              </a>
+            </li>
           </ul>
         </div>
       </section>

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lint-staged": "^16.4.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
+    "marked": "^18.0.2",
     "monaco-editor": "^0.55.1",
     "prettier": "^3.8.1",
     "shiki": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
+      marked:
+        specifier: ^18.0.2
+        version: 18.0.2
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -1610,6 +1613,11 @@ packages:
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@18.0.2:
+    resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -3560,6 +3568,8 @@ snapshots:
       pify: 3.0.0
 
   marked@14.0.0: {}
+
+  marked@18.0.2: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/scripts/build-adr-html.mjs
+++ b/scripts/build-adr-html.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+//
+// Render docs/adr/*.md → dist/pages/docs/adr/*.html.
+//
+// Reason this script exists: GitHub Pages does not render .md files. The
+// landing page links to ADRs from the "Architecture" subsection, and those
+// links must resolve on the same origin (loopdive.github.io/js2wasm). So at
+// build time we render each ADR through `marked` and wrap it in a minimal
+// HTML shell whose look matches the rest of the site (dark background, system
+// font stack, soft text colour, tasteful link hover, anchored headings).
+//
+// Inputs:  docs/adr/*.md     (and docs/adr/README.md for the index)
+// Output:  dist/pages/docs/adr/*.html
+//
+// The output template is intentionally self-contained — no external CSS, no
+// JS — so that pages stay fast and survive without the rest of the site
+// being deployed.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { marked } from "marked";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const ADR_SOURCE_DIR = join(ROOT, "docs", "adr");
+const PAGES_DIST = join(ROOT, "dist", "pages");
+const ADR_OUTPUT_DIR = join(PAGES_DIST, "docs", "adr");
+
+// Configure marked for safe-ish defaults. We trust the ADR sources (they live
+// in this repo) but still set `mangle: false` and `headerIds: true` so anchor
+// links work out of the box.
+marked.use({
+  gfm: true,
+  breaks: false,
+  pedantic: false,
+});
+
+function htmlShell({ title, body, backHref }) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)} — js2wasm</title>
+  <link rel="icon" href="/js2wasm/favicon.svg" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #060a14;
+      --fg: #ffffff;
+      --fg-soft: rgba(255, 255, 255, 0.78);
+      --fg-faint: rgba(255, 255, 255, 0.55);
+      --line: rgba(255, 255, 255, 0.14);
+      --surface: rgba(255, 255, 255, 0.04);
+      --link: #8ab4ff;
+      --link-hover: #b8cdff;
+      --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--fg-soft);
+      font-family: var(--font);
+      font-size: 16px;
+      line-height: 1.65;
+    }
+    body {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 56px 28px 96px;
+    }
+    a { color: var(--link); text-decoration: none; border-bottom: 1px solid transparent; transition: color .15s ease, border-color .15s ease; }
+    a:hover { color: var(--link-hover); border-bottom-color: currentColor; }
+    .top-nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 36px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--line);
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      color: var(--fg-faint);
+    }
+    .top-nav a { color: var(--fg-faint); }
+    .top-nav a:hover { color: var(--fg); }
+    .top-nav .brand {
+      font-family: var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+    h1, h2, h3, h4 {
+      color: var(--fg);
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    h1 { font-size: 1.9rem; line-height: 1.25; margin: 0 0 28px; }
+    h2 { font-size: 1.25rem; margin: 36px 0 12px; padding-top: 8px; }
+    h3 { font-size: 1.05rem; margin: 28px 0 10px; }
+    p, li { color: var(--fg-soft); }
+    p { margin: 0 0 16px; }
+    ul, ol { padding-left: 1.4em; margin: 0 0 16px; }
+    li { margin: 4px 0; }
+    strong { color: var(--fg); font-weight: 600; }
+    code {
+      font-family: var(--mono);
+      font-size: 0.92em;
+      background: var(--surface);
+      padding: 1px 6px;
+      border-radius: 4px;
+      color: var(--fg);
+    }
+    pre {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px 18px;
+      overflow-x: auto;
+      font-family: var(--mono);
+      font-size: 0.88em;
+      line-height: 1.55;
+    }
+    pre code { background: none; padding: 0; border-radius: 0; color: var(--fg-soft); }
+    blockquote {
+      margin: 16px 0;
+      padding: 4px 18px;
+      border-left: 3px solid var(--line);
+      color: var(--fg-faint);
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0;
+      font-size: 0.95em;
+    }
+    th, td {
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--line);
+    }
+    th { color: var(--fg); font-weight: 600; }
+    hr { border: 0; border-top: 1px solid var(--line); margin: 32px 0; }
+    .footer {
+      margin-top: 64px;
+      padding-top: 24px;
+      border-top: 1px solid var(--line);
+      font-size: 12px;
+      color: var(--fg-faint);
+      letter-spacing: 0.04em;
+    }
+    .footer a { color: var(--fg-faint); }
+    .footer a:hover { color: var(--fg); }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <a class="brand" href="/js2wasm/#approach">JS² · Approach</a>
+    <a href="${escapeHtml(backHref)}">← back to ADR index</a>
+  </nav>
+  <main>
+    ${body}
+  </main>
+  <div class="footer">
+    Source: <a href="https://github.com/loopdive/js2wasm/tree/main/docs/adr">docs/adr/</a> on GitHub.
+  </div>
+</body>
+</html>
+`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Rewrite intra-ADR links so the rendered HTML pages link to each other
+// instead of the source markdown.
+//   ./0007-closure-conversion.md     → ./0007-closure-conversion.html
+//   0007-closure-conversion.md       → 0007-closure-conversion.html
+function rewriteAdrLinks(htmlBody) {
+  return htmlBody.replace(
+    /(href="(?:\.\/)?)([0-9A-Za-z._-]+)\.md(#[^"]*)?"/g,
+    (_match, prefix, name, hash) => `${prefix}${name}.html${hash ?? ""}"`,
+  );
+}
+
+function renderMarkdownFile(filePath) {
+  const source = readFileSync(filePath, "utf-8");
+  const html = marked.parse(source);
+  return rewriteAdrLinks(html);
+}
+
+function titleFromMarkdown(source) {
+  const heading = source.match(/^#\s+(.+?)\s*$/m);
+  return heading ? heading[1].trim() : "Architecture decision record";
+}
+
+function buildAdrPages() {
+  if (!existsSync(ADR_SOURCE_DIR)) {
+    console.log(`[build-adr-html] no docs/adr directory found at ${ADR_SOURCE_DIR} — skipping`);
+    return;
+  }
+
+  const entries = readdirSync(ADR_SOURCE_DIR)
+    .filter((name) => name.endsWith(".md"))
+    .sort();
+
+  if (entries.length === 0) {
+    console.log("[build-adr-html] no ADR markdown files found — skipping");
+    return;
+  }
+
+  mkdirSync(ADR_OUTPUT_DIR, { recursive: true });
+
+  let writtenCount = 0;
+  for (const entry of entries) {
+    const sourcePath = join(ADR_SOURCE_DIR, entry);
+    const source = readFileSync(sourcePath, "utf-8");
+    const title = titleFromMarkdown(source);
+    const body = rewriteAdrLinks(marked.parse(source));
+    const isIndex = entry === "README.md";
+    const outputName = isIndex ? "index.html" : entry.replace(/\.md$/, ".html");
+    const outputPath = join(ADR_OUTPUT_DIR, outputName);
+    const backHref = isIndex ? "/js2wasm/#approach" : "./";
+
+    const html = htmlShell({ title, body, backHref });
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, html);
+    writtenCount += 1;
+  }
+
+  console.log(`[build-adr-html] rendered ${writtenCount} ADR page(s) to ${ADR_OUTPUT_DIR}`);
+}
+
+buildAdrPages();

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -340,6 +340,10 @@ for (const file of ["site-nav.js", "t262-charts.js", "trend-chart.js", "perf-ben
   copyFileIfExists(join(COMPONENTS_DIR, file), join(PAGES_DIST, "components", file));
 }
 
+// Render ADR markdown → HTML pages so the landing page can link to
+// on-origin /js2wasm/docs/adr/*.html instead of broken raw .md URLs.
+await import("./build-adr-html.mjs");
+
 // Copy sprint-stats.json to dashboard data when dashboard artifacts exist.
 if (hasDashboardBundle) {
   copyFileIfExists(


### PR DESCRIPTION
## Summary

Follow-up to PR #79. The landing page's Architecture subsection linked to `./docs/adr/0NNN-*.md`, but **GitHub Pages does not render Markdown** — those URLs 404 because the `.md` files aren't in the deploy artifact, and even if they were, GH Pages would serve them as raw text.

This PR renders each ADR to an on-origin HTML page at build time so every link from `loopdive.github.io/js2wasm/#approach` resolves to a properly styled HTML view.

## Changes

- **`scripts/build-adr-html.mjs`** (new): walks `docs/adr/*.md`, renders each through `marked`, wraps in a self-contained dark-themed HTML shell that matches the site, rewrites intra-ADR `.md` → `.html` links, writes to `dist/pages/docs/adr/`. `README.md` becomes `index.html` so `/docs/adr/` resolves automatically via GitHub Pages directory routing.
- **`scripts/build-pages.js`**: `await import("./build-adr-html.mjs")` at the end of the pages build so the rendered ADRs land in the deploy artifact.
- **`index.html`**: the 12 ADR links + the index link now point to `.html` (and `./docs/adr/`) instead of `.md`. Same titles, same order — no content change.
- **`package.json` + `pnpm-lock.yaml`**: adds `marked` as a **devDependency** (build-time only, not in any runtime bundle).

## Test plan

- [x] `pnpm build:pages` runs cleanly — `[build-adr-html] rendered 13 ADR page(s) to ...dist/pages/docs/adr` appears at the end of the build
- [x] 13 `.html` files materialise under `dist/pages/docs/adr/`: 12 ADRs + `index.html`
- [x] Rendered index has 12 rewritten links: `grep -c 'href="\./0' dist/pages/docs/adr/index.html` = 12
- [x] Spot-checked `0001-hybrid-compilation-strategy.html`: H1 + sections + code spans + ordered list all render correctly with the dark theme
- [x] No `src/` changes — test262-sharded correctly skipped via path filter
- [x] CI: `quality` lint + format

Closes the 404 follow-up on #1208.