### PR TITLE
feat(#1208): serve rendered ADRs in dev too — Vite middleware mirrors the static build

### DIFF
--- a/playground/vite-plugin-adr.ts
+++ b/playground/vite-plugin-adr.ts
@@ -1,0 +1,114 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { Plugin } from "vite";
+
+// Vite dev middleware that renders docs/adr/*.md → HTML on the fly so the
+// landing page's "Architecture" subsection works during `pnpm dev`.
+//
+// Why this is needed:
+// - The static deploy renders ADRs at `pnpm build:pages` time via
+//   `scripts/build-adr-html.mjs`, writing to `dist/pages/docs/adr/*.html`.
+// - The Vite dev server serves files directly from the project root and has
+//   `**/dist/pages/**` in its watch-ignore list, so the pre-built HTML never
+//   reaches the browser.
+// - The source on disk under `docs/adr/` is `.md` only — without this plugin,
+//   any link to `./docs/adr/0NNN-*.html` 404s in dev.
+//
+// This plugin intercepts requests for the rendered ADR URLs and renders them
+// from source through the same `renderAdrPage` helper used by the static
+// build, so dev and prod produce identical pages.
+
+interface RenderedAdr {
+  filename: string; // source filename, e.g. "0007-closure-conversion.md"
+  source: string; // raw markdown contents
+}
+
+/**
+ * Maps an incoming request URL onto an ADR markdown file we know how to
+ * render. Returns the source filename (under `docs/adr/`) or `null` if the
+ * URL isn't an ADR route.
+ *
+ *   /docs/adr/                                   → README.md  (the index)
+ *   /docs/adr/index.html                         → README.md
+ *   /docs/adr/0007-closure-conversion.html       → 0007-closure-conversion.md
+ *   /docs/adr/anything-else                      → null
+ */
+function urlToAdrSourceName(url: string, adrDir: string): string | null {
+  const path = url.split("?")[0].split("#")[0];
+  if (!path.startsWith("/docs/adr/")) return null;
+
+  const tail = path.slice("/docs/adr/".length);
+
+  // /docs/adr/  →  index
+  if (tail === "" || tail === "index.html") {
+    if (existsSync(join(adrDir, "README.md"))) return "README.md";
+    return null;
+  }
+
+  // /docs/adr/0007-foo.html  →  0007-foo.md
+  if (tail.endsWith(".html")) {
+    const candidate = `${tail.slice(0, -".html".length)}.md`;
+    if (existsSync(join(adrDir, candidate))) return candidate;
+  }
+
+  return null;
+}
+
+export function adrPlugin(): Plugin {
+  // Lazily import the build helpers — they live in scripts/ which uses ESM,
+  // and we don't want their side effects (the build IIFE) to run on import.
+  let renderAdrPage: (filename: string, source: string) => string;
+  const projectRoot = resolve(import.meta.dirname, "..");
+  const adrDir = join(projectRoot, "docs", "adr");
+
+  return {
+    name: "js2wasm:adr-dev-server",
+    apply: "serve", // dev only — production uses scripts/build-adr-html.mjs
+
+    async configureServer(server) {
+      // Import once when the dev server starts.
+      ({ renderAdrPage } = await import(
+        // Relative path from playground/ → scripts/.
+        new URL("../scripts/build-adr-html.mjs", import.meta.url).href
+      ));
+
+      // Reload any open tab when an ADR markdown source changes.
+      server.watcher.add(adrDir);
+      server.watcher.on("change", (changedPath) => {
+        if (!changedPath.startsWith(adrDir)) return;
+        // Naive but effective: tell every connected client to do a full reload.
+        server.ws.send({ type: "full-reload", path: "*" });
+      });
+
+      server.middlewares.use((req, res, next) => {
+        if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
+        const sourceName = urlToAdrSourceName(req.url, adrDir);
+        if (!sourceName) return next();
+
+        try {
+          const source = readFileSync(join(adrDir, sourceName), "utf-8");
+          const html = renderAdrPage(sourceName, source);
+          res.setHeader("Content-Type", "text/html; charset=utf-8");
+          res.setHeader("Cache-Control", "no-cache");
+          res.statusCode = 200;
+          res.end(req.method === "HEAD" ? "" : html);
+        } catch (err) {
+          // Surface the error in the response so the user can see what went
+          // wrong instead of getting a silent 500.
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end(`[adr-dev-server] failed to render ${sourceName}: ${(err as Error).message}`);
+        }
+      });
+    },
+
+    // Optional sanity-log during dev startup so it's obvious the plugin loaded
+    // and how many ADRs it can serve.
+    config() {
+      if (!existsSync(adrDir)) return;
+      const count = readdirSync(adrDir).filter((name) => name.endsWith(".md")).length;
+      // eslint-disable-next-line no-console
+      console.log(`[adr-dev-server] serving ${count} ADR(s) from ${adrDir}`);
+    },
+  };
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { test262Plugin } from "./vite-plugin-test262.js";
 import { compilerBundlePlugin } from "./vite-plugin-compiler-bundle.js";
+import { adrPlugin } from "./vite-plugin-adr.js";
 
 const projectRoot = resolve(import.meta.dirname, "..");
 const dashboardPluginPath = resolve(import.meta.dirname, "vite-plugin-dashboard.ts");
@@ -11,7 +12,7 @@ const hasDashboardData =
   existsSync(resolve(projectRoot, "dashboard", "index.html")) && existsSync(resolve(projectRoot, "plan", "issues"));
 
 export default defineConfig(async () => {
-  const plugins = [compilerBundlePlugin(), test262Plugin()];
+  const plugins = [compilerBundlePlugin(), test262Plugin(), adrPlugin()];
   if (hasDashboardData && existsSync(dashboardPluginPath)) {
     const { dashboardPlugin } = await import(pathToFileURL(dashboardPluginPath).href);
     plugins.push(dashboardPlugin());

--- a/scripts/build-adr-html.mjs
+++ b/scripts/build-adr-html.mjs
@@ -18,6 +18,7 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { marked } from "marked";
 
 const ROOT = resolve(import.meta.dirname, "..");
@@ -184,23 +185,37 @@ function escapeHtml(value) {
 // instead of the source markdown.
 //   ./0007-closure-conversion.md     → ./0007-closure-conversion.html
 //   0007-closure-conversion.md       → 0007-closure-conversion.html
-function rewriteAdrLinks(htmlBody) {
+export function rewriteAdrLinks(htmlBody) {
   return htmlBody.replace(
     /(href="(?:\.\/)?)([0-9A-Za-z._-]+)\.md(#[^"]*)?"/g,
     (_match, prefix, name, hash) => `${prefix}${name}.html${hash ?? ""}"`,
   );
 }
 
-function renderMarkdownFile(filePath) {
-  const source = readFileSync(filePath, "utf-8");
-  const html = marked.parse(source);
-  return rewriteAdrLinks(html);
-}
-
-function titleFromMarkdown(source) {
+export function titleFromMarkdown(source) {
   const heading = source.match(/^#\s+(.+?)\s*$/m);
   return heading ? heading[1].trim() : "Architecture decision record";
 }
+
+// Render a single ADR markdown source to a complete HTML document.
+//
+// `filename` is the source filename (e.g. "0007-closure-conversion.md" or
+// "README.md") — used to decide whether the document is the ADR index (which
+// gets a different back-href) and to compute the default `<title>` when the
+// markdown lacks a top-level heading.
+//
+// Used by both the static build (build-pages → dist/pages/docs/adr/*.html)
+// and the Vite dev middleware (playground/vite-plugin-adr.ts) so that
+// localhost and the deployed site render the same way.
+export function renderAdrPage(filename, source) {
+  const title = titleFromMarkdown(source);
+  const body = rewriteAdrLinks(marked.parse(source));
+  const isIndex = filename === "README.md";
+  const backHref = isIndex ? "/js2wasm/#approach" : "./";
+  return htmlShell({ title, body, backHref });
+}
+
+export { htmlShell, escapeHtml };
 
 function buildAdrPages() {
   if (!existsSync(ADR_SOURCE_DIR)) {
@@ -223,14 +238,10 @@ function buildAdrPages() {
   for (const entry of entries) {
     const sourcePath = join(ADR_SOURCE_DIR, entry);
     const source = readFileSync(sourcePath, "utf-8");
-    const title = titleFromMarkdown(source);
-    const body = rewriteAdrLinks(marked.parse(source));
     const isIndex = entry === "README.md";
     const outputName = isIndex ? "index.html" : entry.replace(/\.md$/, ".html");
     const outputPath = join(ADR_OUTPUT_DIR, outputName);
-    const backHref = isIndex ? "/js2wasm/#approach" : "./";
-
-    const html = htmlShell({ title, body, backHref });
+    const html = renderAdrPage(entry, source);
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, html);
     writtenCount += 1;
@@ -239,4 +250,9 @@ function buildAdrPages() {
   console.log(`[build-adr-html] rendered ${writtenCount} ADR page(s) to ${ADR_OUTPUT_DIR}`);
 }
 
-buildAdrPages();
+// Only run the build when this file is the entry point. When the dev plugin
+// imports it (for the helpers above) we don't want a stray build-step run.
+const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (isMainModule) {
+  buildAdrPages();
+}


### PR DESCRIPTION
## Summary

PR #81 fixed ADR rendering on the **deployed** site, but `pnpm dev` still 404'd on `/docs/adr/*.html` links because:

1. The dev server is **Vite**, which doesn't run `scripts/build-adr-html.mjs`.
2. `playground/vite.config.ts` intentionally watch-ignores `**/dist/pages/**`, so pre-running the build wouldn't help even if you tried.

This PR adds a Vite middleware that intercepts `/docs/adr/*.html` and `/docs/adr/` requests in dev mode and renders them on-the-fly using the **same renderer** as the static build, so localhost and the deploy are byte-identical.

## Changes

- **`scripts/build-adr-html.mjs`** (refactor): exports the rendering helpers (`renderAdrPage`, `htmlShell`, `escapeHtml`, `rewriteAdrLinks`, `titleFromMarkdown`). The `buildAdrPages()` side effect is now gated to only fire when the file is invoked as the CLI entry point, so importing the helpers from a Vite plugin won't trigger a stray build.
- **`playground/vite-plugin-adr.ts`** (new): dev-only Vite plugin (`apply: "serve"`). On each request to `/docs/adr/<name>.html` (or `/docs/adr/` → `README.md`), it reads the source markdown, calls `renderAdrPage`, returns the HTML. Includes a watcher that triggers a full reload when any ADR markdown file changes.
- **`playground/vite.config.ts`**: registers `adrPlugin()` alongside `compilerBundlePlugin()` and `test262Plugin()`.

## Test plan

Booted the dev server locally on port 5174 and curl-checked:
- [x] `GET /docs/adr/0001-hybrid-compilation-strategy.html` → **HTTP 200**, dark-themed shell, correct `<title>`
- [x] `GET /docs/adr/` → **HTTP 200**, rendered README index with all 12 ADR links rewritten to `.html`
- [x] `GET /docs/adr/9999-nope.html` → **HTTP 404** (no source file → middleware passes through to Vite)
- [x] `GET /docs/something-else.html` → **HTTP 404** (route not claimed by plugin)
- [x] `node scripts/build-adr-html.mjs` (CLI mode) still emits 13 pages to `dist/pages/docs/adr/` — confirms the refactor didn't break the static build
- [x] No `src/` changes — test262-sharded correctly skipped via path filter

Closes the localhost gap on #1208.