### PR TITLE
fix(#1208): ADR dev plugin degrades to 503 when marked missing — don't crash dev server

### DIFF
--- a/playground/vite-plugin-adr.ts
+++ b/playground/vite-plugin-adr.ts
@@ -57,7 +57,8 @@ function urlToAdrSourceName(url: string, adrDir: string): string | null {
 export function adrPlugin(): Plugin {
   // Lazily import the build helpers — they live in scripts/ which uses ESM,
   // and we don't want their side effects (the build IIFE) to run on import.
-  let renderAdrPage: (filename: string, source: string) => string;
+  let renderAdrPage: ((filename: string, source: string) => string) | null = null;
+  let renderUnavailableReason: string | null = null;
   const projectRoot = resolve(import.meta.dirname, "..");
   const adrDir = join(projectRoot, "docs", "adr");
 
@@ -66,13 +67,29 @@ export function adrPlugin(): Plugin {
     apply: "serve", // dev only — production uses scripts/build-adr-html.mjs
 
     async configureServer(server) {
-      // Import once when the dev server starts.
-      ({ renderAdrPage } = await import(
-        // Relative path from playground/ → scripts/.
-        new URL("../scripts/build-adr-html.mjs", import.meta.url).href
-      ));
+      // Import once when the dev server starts. Wrap in try/catch so a
+      // missing transitive dep (e.g. `marked` not yet installed after a
+      // pull that added it) degrades to a useful 503 instead of crashing
+      // the whole dev server. The dev server hosts the playground +
+      // dashboard too — losing those over a docs feature would be a bad
+      // trade.
+      try {
+        ({ renderAdrPage } = await import(
+          // Relative path from playground/ → scripts/.
+          new URL("../scripts/build-adr-html.mjs", import.meta.url).href
+        ));
+      } catch (err) {
+        renderUnavailableReason = (err as Error).message ?? String(err);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[adr-dev-server] disabled — failed to load renderer (${renderUnavailableReason}). ` +
+            `Run \`pnpm install\` to refresh deps; ADR routes will return 503 until then.`,
+        );
+      }
 
-      // Reload any open tab when an ADR markdown source changes.
+      // Reload any open tab when an ADR markdown source changes. Safe to
+      // wire up even when rendering is unavailable — the watcher just
+      // becomes a no-op for ADR edits.
       server.watcher.add(adrDir);
       server.watcher.on("change", (changedPath) => {
         if (!changedPath.startsWith(adrDir)) return;
@@ -84,6 +101,16 @@ export function adrPlugin(): Plugin {
         if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
         const sourceName = urlToAdrSourceName(req.url, adrDir);
         if (!sourceName) return next();
+
+        if (!renderAdrPage) {
+          res.statusCode = 503;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end(
+            `[adr-dev-server] ADR renderer is unavailable: ${renderUnavailableReason ?? "unknown reason"}.\n` +
+              "Run `pnpm install` and restart the dev server.\n",
+          );
+          return;
+        }
 
         try {
           const source = readFileSync(join(adrDir, sourceName), "utf-8");


### PR DESCRIPTION
## Summary

After a pull that adds a transitive dep (e.g. \`marked\` from #1208), running the dev server before \`pnpm install\` would crash:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'marked' imported from .../scripts/build-adr-html.mjs
\`\`\`

That killed the **whole** Vite dev server — playground and dashboard went down with it. Bad trade for a docs feature.

## Fix

Wrap the lazy import in try/catch. On failure:
- Log a clear warning at startup naming the missing dep and the fix (\`pnpm install\`)
- Mark the renderer as unavailable (no crash)
- Let the dev server start normally so playground/dashboard keep working
- Have ADR routes return **HTTP 503** with a one-line remediation message instead of 404 (misleading) or 500 (opaque)

## Test plan

- [x] With \`marked\` installed: \`GET /docs/adr/0008-dual-string-backend.html\` → **200**, rendered HTML
- [x] Without \`marked\` (\`mv node_modules/marked /tmp/...\`): dev server **boots cleanly**, warning logged, \`GET /docs/adr/*\` → **503** with body \`Run \\\`pnpm install\\\` and restart the dev server\`
- [x] Other routes (e.g. playground) unaffected in the failure case
- [x] No \`src/\` changes — test262-sharded correctly skipped via path filter

## Note for users hitting 404 on dev right now

This **is** the marked-missing case. Run \`pnpm install\` in your local checkout and restart \`pnpm dev\`. After this PR, the failure mode is **503** with the remediation hint baked into the response body, instead of the dev server crashing.