### PR TITLE
fix(#1169g): IR slice 8a — destructuring + static spread

### DIFF
--- a/plan/issues/sprints/45/1169g.md
+++ b/plan/issues/sprints/45/1169g.md
@@ -2,7 +2,7 @@
 id: 1169g
 title: "IR Phase 4 Slice 8 — destructuring and rest/spread through the IR path"
 sprint: 45
-status: ready
+status: in-progress
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -944,3 +944,67 @@ the most common patterns in modern JS.
 ## Sub-issue of
 
 \#1169 — IR Phase 4: full compiler migration
+
+## Implementation Summary (slice 8a — initial PR)
+
+This PR ships **slice 8a only** — the compile-time-rewriting subset of slice 8
+that decomposes patterns and expands static spreads without introducing any
+new IR primitives or runtime helpers. Steps D–H from the architect spec
+(spread-in-literals, object spread, rest collection, iterator-protocol
+destructuring) remain on legacy and ship in follow-up issues (slice 8b).
+
+### Surface widened
+
+| AST shape | Selector arm | Lowering |
+|-----------|--------------|----------|
+| `const { a, b } = obj` | `isPhase1VarDecl` → `isPhase1BindingPattern` (object) | `lowerObjectPattern` → one `object.get` per leaf |
+| `const { a: x } = obj` | same (renamed properties accepted) | same — `propertyName` ≠ `localName` |
+| `const [x, y] = arr` | `isPhase1VarDecl` → `isPhase1BindingPattern` (array) | `lowerArrayPattern` → one `vec.get` per index |
+| `const [a, , c] = arr` | accepts `OmittedExpression` slots | index counter advances over the gap |
+| `f(...[1, 2, 3])` | `isPhase1Expr` call arm → `isStaticSpreadSource` | `expandStaticSpreadArgs` inlines literal elements |
+| `f(10, ...[1, 2, 3])` | mixed leading + spread | same — out-of-order arg positions preserved |
+| `f(...[1, 2], ...[3, 4])` | multiple spreads | concatenated at compile time |
+
+### Surface deferred to slice 8b (kept on legacy)
+
+- Rest patterns (`const [a, ...rest] = arr`, `const { a, ...rest } = obj`)
+- Object / array literal spread (`[...a, ...b]`, `{ ...obj, k: v }`)
+- Default values (`const { a = 1 } = obj`)
+- Nested binding patterns (`const { a: { b } } = obj`)
+- `let`-bound destructuring (needs TDZ tracking)
+- Iterator-protocol destructuring (`const [x, y] = generatorFn()`)
+- Function parameter destructuring (`function f({ a, b }) { }`)
+- Dynamic-length spread in calls (`f(...arr)` where `arr` is an identifier)
+- Method-call spread args (`obj.m(...args)`)
+
+### Files changed
+
+- `src/ir/select.ts` — `isPhase1VarDecl` accepts binding patterns;
+  new `isPhase1BindingPattern`, `collectPatternNames`,
+  `isStaticSpreadSource`; call-arm of `isPhase1Expr` accepts
+  `SpreadElement` whose source is a Phase-1 array literal.
+- `src/ir/from-ast.ts` — `lowerVarDecl` dispatches to new
+  `lowerBindingPattern` / `lowerObjectPattern` / `lowerArrayPattern`;
+  `lowerCall` runs `expandStaticSpreadArgs` over its arguments before
+  the 1:1 lowering loop.
+- `tests/issue-1169g.test.ts` — 36 dual-run tests covering each
+  accepted shape. Selector tests verify the IR claims the function;
+  IR-vs-legacy parity tests verify result equivalence (with an opt-out
+  for spread-call cases where legacy has a pre-existing
+  "not enough arguments on stack" instantiate bug that slice 8a's
+  IR widening sidesteps).
+
+### Acceptance check
+
+1. ✅ `planIrCompilation` claims object-destructuring + array-destructuring
+   functions (verified by 8 selector tests in `issue-1169g.test.ts`).
+2. ✅ New tests cover steps A, B, C from the architect spec; D–H deferred.
+3. ✅ All 7 prior IR slice tests (182 cases total) continue to pass.
+   `equivalence/destructuring-extended` and
+   `equivalence/computed-property-names` failures verified pre-existing
+   (failed identically with `git stash` of these changes).
+4. ⏳ Test262 delta deferred to CI.
+5. ✅ `isPhase1BindingPattern` carries a header comment documenting
+   the accepted slice-8a shapes.
+6. ✅ Legacy `destructuring.ts` path unchanged — selector rejects the
+   wider shapes and they fall through to legacy unchanged.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -601,6 +601,22 @@ function collectMutatedLetNamesFromBlock(body: ts.Block): Set<string> {
 function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
   const isConst = !!(stmt.declarationList.flags & ts.NodeFlags.Const);
   for (const d of stmt.declarationList.declarations) {
+    // Slice 8a (#1169g): destructuring binding patterns (selector restricts
+    // to const, no rest, no defaults, no nesting). Lower the initializer
+    // ONCE into an SSA value, then walk the pattern emitting one
+    // `object.get` (object pattern) or `vec.get` (array pattern) per leaf
+    // and binding each leaf as a `local` ScopeBinding.
+    if (ts.isObjectBindingPattern(d.name) || ts.isArrayBindingPattern(d.name)) {
+      if (!d.initializer) {
+        throw new Error(`ir/from-ast: binding pattern requires an initializer (${cx.funcName})`);
+      }
+      // Hint: pass an externref so the initializer's actual IrType (object,
+      // class, vec ref, etc.) flows through unchanged. The pattern lowerer
+      // dispatches on the inferred IrType.
+      const initValue = lowerExpr(d.initializer, cx, irVal({ kind: "externref" }));
+      lowerBindingPattern(d.name, initValue, cx);
+      continue;
+    }
     if (!ts.isIdentifier(d.name)) {
       throw new Error(`ir/from-ast: destructuring declarations not supported in Phase 1 (${cx.funcName})`);
     }
@@ -683,6 +699,153 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
       // landing the function back on the legacy path.
     }
     cx.scope.set(name, { kind: "local", value, type: inferred });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Binding pattern lowering (slice 8a — #1169g)
+// ---------------------------------------------------------------------------
+//
+// Destructuring patterns decompose at compile time into a sequence of
+// single-name bindings. Object pattern leaves emit `object.get`; array
+// pattern leaves emit `vec.get` (when the source is a vec ref).
+//
+// Slice 8a scope: identifier-leaf, no-default, no-rest, no-nested patterns.
+// Anything wider is rejected by the selector and stays on the legacy
+// destructuring path. Mixed array/object patterns over generic iterables
+// (Map, Set) require iter.next protocol and are deferred to slice 8b.
+//
+// Why hint with externref for the initializer in `lowerVarDecl`? The
+// pattern's source type isn't known until lowering — it could be
+// IrType.object, IrType.class (for class instances treated like objects
+// — out of scope), or `(ref $vec_*)`. The externref hint is advisory;
+// `lowerExpr`'s producers inspect their own type rather than coercing
+// to the hint, so an object literal stays IrType.object and a vec ref
+// stays `(ref $vec_*)`.
+
+/**
+ * Slice 8a (#1169g): walk a destructuring binding pattern and emit one
+ * field/index read per leaf, binding each name as a `local` ScopeBinding.
+ *
+ * The source SSA value is read once per leaf. The IR's CSE / DCE passes
+ * coalesce repeated reads when safe; even without that, struct.get and
+ * array.get are pure ops cheap enough that a single-store tee isn't
+ * required for correctness.
+ */
+function lowerBindingPattern(pattern: ts.BindingPattern, source: IrValueId, cx: LowerCtx): void {
+  if (ts.isObjectBindingPattern(pattern)) {
+    lowerObjectPattern(pattern, source, cx);
+    return;
+  }
+  lowerArrayPattern(pattern, source, cx);
+}
+
+/**
+ * Slice 8a (#1169g): decompose `const { a, b: x } = obj` into per-leaf
+ * `object.get` reads. The source must lower to an IrType.object; class
+ * instances and externref-typed sources fall through to a clean throw,
+ * landing the function back on legacy.
+ */
+function lowerObjectPattern(pattern: ts.ObjectBindingPattern, source: IrValueId, cx: LowerCtx): void {
+  const sourceType = cx.builder.typeOf(source);
+  if (sourceType.kind !== "object") {
+    throw new Error(
+      `ir/from-ast: object destructuring source must be IrType.object (got ${describeIrType(sourceType)}) in ${cx.funcName}`,
+    );
+  }
+  for (const elem of pattern.elements) {
+    // Selector enforces no rest / no default / identifier-leaf only;
+    // defensive checks here surface selector regressions as clean throws
+    // rather than silent miscompiles.
+    if (elem.dotDotDotToken) {
+      throw new Error(`ir/from-ast: object rest pattern not in slice 8a (${cx.funcName})`);
+    }
+    if (elem.initializer) {
+      throw new Error(`ir/from-ast: pattern default values not in slice 8a (${cx.funcName})`);
+    }
+    if (!ts.isIdentifier(elem.name)) {
+      throw new Error(`ir/from-ast: nested binding patterns not in slice 8a (${cx.funcName})`);
+    }
+    // The property name being read out of the source. `propertyName`
+    // is set when the pattern uses renaming (`{ a: x }` — propName is
+    // "a", localName is "x"); shorthand patterns leave it null.
+    const propName = elem.propertyName
+      ? ts.isIdentifier(elem.propertyName)
+        ? elem.propertyName.text
+        : ts.isStringLiteral(elem.propertyName)
+          ? elem.propertyName.text
+          : null
+      : elem.name.text;
+    if (propName === null) {
+      throw new Error(`ir/from-ast: object pattern property name must be Identifier or StringLiteral (${cx.funcName})`);
+    }
+    const localName = elem.name.text;
+    if (cx.scope.has(localName)) {
+      throw new Error(`ir/from-ast: redeclaration of '${localName}' in pattern in ${cx.funcName}`);
+    }
+    const field = sourceType.shape.fields.find((f) => f.name === propName);
+    if (!field) {
+      throw new Error(
+        `ir/from-ast: object pattern reads unknown field "${propName}" (shape: ${describeIrType(sourceType)}) in ${cx.funcName}`,
+      );
+    }
+    const v = cx.builder.emitObjectGet(source, propName, field.type);
+    cx.scope.set(localName, { kind: "local", value: v, type: field.type });
+  }
+}
+
+/**
+ * Slice 8a (#1169g): decompose `const [x, y, z] = arr` into per-index
+ * `vec.get` reads on a vec source. `vec.get` traps on out-of-bounds at
+ * runtime — same semantics as legacy destructuring's array path
+ * (legacy uses array.get without a bounds check too).
+ *
+ * The source must lower to a `(ref|ref_null) $vec_*` IrType.val. Anything
+ * else (string, externref, class) routes to legacy via a clean throw.
+ */
+function lowerArrayPattern(pattern: ts.ArrayBindingPattern, source: IrValueId, cx: LowerCtx): void {
+  const sourceType = cx.builder.typeOf(source);
+  const valTy = asVal(sourceType);
+  if (!valTy || (valTy.kind !== "ref" && valTy.kind !== "ref_null")) {
+    throw new Error(
+      `ir/from-ast: array destructuring source must be vec ref (got ${describeIrType(sourceType)}) in ${cx.funcName}`,
+    );
+  }
+  // Recover the element ValType. We need a resolver thread-through —
+  // matches the slice-6 vec for-of pattern. If the resolver is absent
+  // or doesn't recognize the ref as a vec, fall back to legacy.
+  const vec = cx.resolver?.resolveVec?.(valTy);
+  if (!vec) {
+    throw new Error(
+      `ir/from-ast: array destructuring source is not a recognisable vec ref (${describeIrType(sourceType)}) in ${cx.funcName}`,
+    );
+  }
+  const elemValType = vec.elementValType;
+  const elemIrType: IrType = irVal(elemValType);
+
+  let i = 0;
+  for (const elem of pattern.elements) {
+    if (ts.isOmittedExpression(elem)) {
+      i++;
+      continue;
+    }
+    if (elem.dotDotDotToken) {
+      throw new Error(`ir/from-ast: array rest pattern not in slice 8a (${cx.funcName})`);
+    }
+    if (elem.initializer) {
+      throw new Error(`ir/from-ast: pattern default values not in slice 8a (${cx.funcName})`);
+    }
+    if (!ts.isIdentifier(elem.name)) {
+      throw new Error(`ir/from-ast: nested binding patterns not in slice 8a (${cx.funcName})`);
+    }
+    const localName = elem.name.text;
+    if (cx.scope.has(localName)) {
+      throw new Error(`ir/from-ast: redeclaration of '${localName}' in pattern in ${cx.funcName}`);
+    }
+    const idx = cx.builder.emitConst({ kind: "i32", value: i }, irVal({ kind: "i32" }));
+    const v = cx.builder.emitVecGet(source, idx, elemIrType);
+    cx.scope.set(localName, { kind: "local", value: v, type: elemIrType });
+    i++;
   }
 }
 
@@ -1129,14 +1292,19 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx): IrValueId {
   if (!calleeSig) {
     throw new Error(`ir/from-ast: call to unknown function "${calleeName}" in ${cx.funcName}`);
   }
-  if (expr.arguments.length !== calleeSig.params.length) {
+  // Slice 8a (#1169g): spread args with statically-known sources
+  // (ArrayLiteralExpression with no nested spread). Expand at compile
+  // time to one IR arg per literal element. The pre-expansion arity
+  // check below counts spread elements as their literal element count.
+  const expandedArgExprs = expandStaticSpreadArgs(expr.arguments, cx);
+  if (expandedArgExprs.length !== calleeSig.params.length) {
     throw new Error(
-      `ir/from-ast: call to ${calleeName} has ${expr.arguments.length} args, expected ${calleeSig.params.length} in ${cx.funcName}`,
+      `ir/from-ast: call to ${calleeName} has ${expandedArgExprs.length} args, expected ${calleeSig.params.length} in ${cx.funcName}`,
     );
   }
   const args: IrValueId[] = [];
-  for (let i = 0; i < expr.arguments.length; i++) {
-    const argExpr = expr.arguments[i]!;
+  for (let i = 0; i < expandedArgExprs.length; i++) {
+    const argExpr = expandedArgExprs[i]!;
     const expected = calleeSig.params[i]!;
     const argVal = lowerExpr(argExpr, cx, expected);
     const argType = cx.builder.typeOf(argVal);
@@ -1152,6 +1320,45 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx): IrValueId {
     throw new Error(`ir/from-ast: call to ${calleeName} returned void used as expression in ${cx.funcName}`);
   }
   return result;
+}
+
+/**
+ * Slice 8a (#1169g): expand spread args at compile time. The selector
+ * (`isStaticSpreadSource`) restricts spread sources to
+ * `ArrayLiteralExpression` with no nested SpreadElement, so each spread
+ * arg has a known element count and we can inline its elements as
+ * additional 1:1 args. Non-spread args pass through unchanged.
+ *
+ * The result is a parallel `Expression[]` whose length equals the
+ * post-expansion arity. The caller's existing 1:1 `lowerExpr`-per-arg
+ * loop runs against the returned array.
+ *
+ * Defensive: any spread whose source isn't an ArrayLiteral throws
+ * (selector should have rejected, but a clean throw routes to legacy
+ * if a regression slips in).
+ */
+function expandStaticSpreadArgs(args: readonly ts.Expression[], cx: LowerCtx): ts.Expression[] {
+  const out: ts.Expression[] = [];
+  for (const a of args) {
+    if (ts.isSpreadElement(a)) {
+      if (!ts.isArrayLiteralExpression(a.expression)) {
+        throw new Error(
+          `ir/from-ast: dynamic-length spread args not in slice 8a (${ts.SyntaxKind[a.expression.kind]} in ${cx.funcName})`,
+        );
+      }
+      for (const e of a.expression.elements) {
+        if (ts.isSpreadElement(e) || ts.isOmittedExpression(e)) {
+          throw new Error(
+            `ir/from-ast: nested spread / sparse element inside spread arg not in slice 8a (${cx.funcName})`,
+          );
+        }
+        out.push(e);
+      }
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
 }
 
 /**

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -524,6 +524,27 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
   if (stmt.modifiers && stmt.modifiers.length > 0) return false;
   const isConst = !!(flags & ts.NodeFlags.Const);
   for (const d of stmt.declarationList.declarations) {
+    // Slice 8a (#1169g): destructuring binding patterns for `const`-bound
+    // declarations only. Object pattern: identifier-only properties with
+    // optional renaming, no defaults, no nesting, no rest. Array pattern:
+    // identifier-only positional bindings, no defaults, no nesting, no
+    // rest. Anything wider (rest, defaults, nested patterns) defers to
+    // slice 8.5+ — the legacy `destructuring.ts` path remains for those.
+    if (ts.isObjectBindingPattern(d.name) || ts.isArrayBindingPattern(d.name)) {
+      if (!isConst) return false;
+      if (!d.initializer) return false;
+      if (!isPhase1BindingPattern(d.name, scope)) return false;
+      // Initializer must be Phase-1 expressible. The lowerer inspects
+      // its IrType to decide between object.get (object pattern) and
+      // vec.get (array pattern); if the resolved IrType isn't compatible
+      // with the pattern shape, lowering throws and the function falls
+      // back to legacy.
+      if (!isPhase1Expr(d.initializer, scope, localClasses)) return false;
+      // Pre-add every leaf identifier to scope so subsequent statements
+      // see the new names.
+      collectPatternNames(d.name, scope);
+      continue;
+    }
     if (!ts.isIdentifier(d.name)) return false;
     if (scope.has(d.name.text)) return false;
     if (!d.initializer) return false;
@@ -546,6 +567,75 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
     scope.add(d.name.text);
   }
   return true;
+}
+
+/**
+ * Slice 8a (#1169g): shape-check a destructuring binding pattern. Only
+ * identifier-leaf, no-default, no-rest, no-nested patterns are accepted
+ * — the lowerer expands these into a sequence of single-name `object.get`
+ * / `vec.get` reads at compile time. Wider shapes (rest, defaults,
+ * nested) defer to slice 8.5; the function falls back to legacy.
+ *
+ * Object patterns:
+ *   - { a, b }                   — shorthand
+ *   - { a: x, b: y }             — renaming (computed key rejected)
+ *
+ * Array patterns:
+ *   - [a, b, c]
+ *   - [, b, , d]                 — omitted slots (sparse) accepted
+ */
+function isPhase1BindingPattern(p: ts.BindingPattern, scope: ReadonlySet<string>): boolean {
+  if (ts.isObjectBindingPattern(p)) {
+    if (p.elements.length === 0) return false; // empty pattern — nothing to bind
+    const localNames = new Set<string>();
+    for (const elem of p.elements) {
+      // Rest deferred — slice 8b adds object spread/rest collection.
+      if (elem.dotDotDotToken) return false;
+      // Default value `{ a = 1 }` deferred — needs runtime undefined check.
+      if (elem.initializer) return false;
+      // Property name must be Identifier or StringLiteral (no computed).
+      if (elem.propertyName) {
+        if (!ts.isIdentifier(elem.propertyName) && !ts.isStringLiteral(elem.propertyName)) return false;
+      }
+      // Binding target must be a plain identifier (no nested patterns).
+      if (!ts.isIdentifier(elem.name)) return false;
+      const name = elem.name.text;
+      if (scope.has(name) || localNames.has(name)) return false;
+      localNames.add(name);
+    }
+    return true;
+  }
+  if (ts.isArrayBindingPattern(p)) {
+    if (p.elements.length === 0) return false; // empty `[] = expr` — defer
+    const localNames = new Set<string>();
+    for (const elem of p.elements) {
+      // Omitted (sparse) slots are allowed — `[a, , c]` skips index 1.
+      if (ts.isOmittedExpression(elem)) continue;
+      // Rest deferred — slice 8b adds vec slice / iter drain.
+      if (elem.dotDotDotToken) return false;
+      // Default value deferred.
+      if (elem.initializer) return false;
+      // Binding target must be a plain identifier (no nested patterns).
+      if (!ts.isIdentifier(elem.name)) return false;
+      const name = elem.name.text;
+      if (scope.has(name) || localNames.has(name)) return false;
+      localNames.add(name);
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Slice 8a (#1169g): collect every identifier name introduced by a binding
+ * pattern (the leaves) into the given scope. Mirrors the Phase-1 var-decl
+ * scope-tracking machinery.
+ */
+function collectPatternNames(p: ts.BindingPattern, scope: Set<string>): void {
+  for (const elem of p.elements) {
+    if (ts.isOmittedExpression(elem)) continue;
+    if (ts.isIdentifier(elem.name)) scope.add(elem.name.text);
+  }
 }
 
 /**
@@ -728,12 +818,27 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       if (!ts.isIdentifier(expr.expression.name)) return false;
       if (!isPhase1Expr(expr.expression.expression, scope, localClasses)) return false;
       for (const arg of expr.arguments) {
+        // Slice 8a (#1169g): spread args restricted to method calls is
+        // out of scope — methods on classes have known signatures and
+        // expanding spread would blur them. Reject for now.
+        if (ts.isSpreadElement(arg)) return false;
         if (!isPhase1Expr(arg, scope, localClasses)) return false;
       }
       return true;
     }
     if (!ts.isIdentifier(expr.expression)) return false;
     for (const arg of expr.arguments) {
+      // Slice 8a (#1169g): accept `f(...source)` where the spread source
+      // is an ArrayLiteralExpression with no nested spread. The lowerer
+      // expands this at compile time into individual call arguments
+      // (matches the legacy `expandSpreadCallArgs` fast path). Spread
+      // sources of dynamic length (e.g. an arbitrary identifier of vec
+      // type) are deferred — they'd require runtime arity expansion
+      // which the IR doesn't model in slice 8a.
+      if (ts.isSpreadElement(arg)) {
+        if (!isStaticSpreadSource(arg.expression, scope, localClasses)) return false;
+        continue;
+      }
       if (!isPhase1Expr(arg, scope, localClasses)) return false;
     }
     return true;
@@ -805,6 +910,31 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     return isPhase1Expr(expr.expression, scope, localClasses);
   }
   return false;
+}
+
+/**
+ * Slice 8a (#1169g) — does this expression have a statically-known length
+ * suitable for compile-time spread expansion in a call? Restricted to
+ * `ArrayLiteralExpression` with no nested SpreadElement: the lowerer
+ * inlines each element verbatim, so the call's arity is the literal's
+ * `elements.length`. Other shapes (vec-typed identifiers, function
+ * results) need runtime length introspection and are deferred.
+ *
+ * Each element of the literal must itself be a Phase-1 expression so the
+ * lowerer can lower it in argument position.
+ */
+function isStaticSpreadSource(
+  expr: ts.Expression,
+  scope: ReadonlySet<string>,
+  localClasses: ReadonlySet<string>,
+): boolean {
+  if (!ts.isArrayLiteralExpression(expr)) return false;
+  for (const elem of expr.elements) {
+    if (ts.isSpreadElement(elem)) return false; // nested spread defer
+    if (ts.isOmittedExpression(elem)) return false; // sparse defer
+    if (!isPhase1Expr(elem, scope, localClasses)) return false;
+  }
+  return true;
 }
 
 /**

--- a/tests/issue-1169g.test.ts
+++ b/tests/issue-1169g.test.ts
@@ -1,0 +1,372 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1169g — IR Phase 4 Slice 8a: destructuring + spread (compile-time
+// rewrite subset).
+//
+// Slice 8a covers the cases that decompose to existing IR primitives at
+// compile time WITHOUT new runtime helpers:
+//
+//   - `const { a, b } = obj` / `const { a: x } = obj` — object pattern,
+//     identifier-leaf only, no rest, no defaults, no nesting. Lowers
+//     to one `object.get` per leaf.
+//   - `const [x, y] = arr`                              — array pattern,
+//     identifier-leaf only, no rest, no defaults, no nesting. Source
+//     must be a vec ref (`Array<number>` etc.). Lowers to one `vec.get`
+//     per leaf.
+//   - `f(...[1, 2, 3])`                                  — call args spread
+//     where the spread source is an ArrayLiteralExpression with no
+//     nested spread. Lowers to one direct argument per literal element.
+//
+// Wider shapes (rest collection, object spread, defaults, nested
+// patterns, dynamic-length spread) are deferred to slice 8b/8.5+ — the
+// selector rejects them and the function falls back to legacy.
+//
+// The dual-run harness compiles every source twice (legacy + IR) and
+// asserts identical results so any miscompile inside slice-8a lowering
+// surfaces as a failed parity check rather than corrupting test262.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+type Outcome =
+  | { kind: "ok"; value: unknown }
+  | { kind: "compile_fail"; firstMessage: string }
+  | { kind: "instantiate_fail" }
+  | { kind: "invoke_fail" };
+
+async function runOnce(
+  source: string,
+  fnName: string,
+  args: ReadonlyArray<number | boolean | string>,
+  experimentalIR: boolean,
+): Promise<Outcome> {
+  const r = compile(source, { experimentalIR });
+  if (!r.success) {
+    return { kind: "compile_fail", firstMessage: r.errors[0]?.message ?? "" };
+  }
+  let instance: WebAssembly.Instance;
+  try {
+    const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+    // Use the production instantiator so wasm:js-string builtins resolve
+    // — bare `WebAssembly.instantiate` doesn't supply the polyfill and
+    // any test that returns a string-typed value (or destructures one)
+    // would otherwise spuriously fail with an Import error.
+    ({ instance } = await instantiateWasm(r.binary, built.env, built.string_constants));
+  } catch {
+    return { kind: "instantiate_fail" };
+  }
+  try {
+    const fn = instance.exports[fnName] as (...a: unknown[]) => unknown;
+    return { kind: "ok", value: fn(...args) };
+  } catch {
+    return { kind: "invoke_fail" };
+  }
+}
+
+async function dualRun(
+  source: string,
+  fnName: string,
+  args: ReadonlyArray<number | boolean | string>,
+): Promise<{ legacy: Outcome; ir: Outcome }> {
+  const [legacy, ir] = await Promise.all([runOnce(source, fnName, args, false), runOnce(source, fnName, args, true)]);
+  return { legacy, ir };
+}
+
+function selectionFor(source: string): Set<string> {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  const sel = planIrCompilation(sf, { experimentalIR: true });
+  return new Set(sel.funcs);
+}
+
+interface Case {
+  name: string;
+  source: string;
+  fn: string;
+  args: ReadonlyArray<number | boolean | string>;
+  /** Names the IR selector should claim under `experimentalIR: true`. */
+  expectedClaimed?: string[];
+  /**
+   * Expected return value for the IR path. Slice 8a's spread-call lowering
+   * actually correctly handles cases where the existing legacy spread path
+   * has a longstanding instantiation bug (`f(...[1,2,3])` validates as
+   * "not enough arguments on the stack"). For those cases we don't assert
+   * legacy parity — instead we assert the IR produces the correct value.
+   */
+  expectedValue: number;
+  /**
+   * If set to false, skip the legacy parity check. Used for spread-call
+   * cases where the legacy path has a pre-existing instantiate bug that
+   * slice 8a's IR widening sidesteps. The IR's correctness is still
+   * verified via the absolute `expectedValue` check above.
+   */
+  parity?: boolean;
+}
+
+const CASES: Case[] = [
+  // -------------------------------------------------------------------------
+  // Step A: object destructuring — shorthand, renamed, multi-field
+  // -------------------------------------------------------------------------
+  {
+    name: "object destructuring — shorthand single field",
+    source: `
+      export function f(): number {
+        const o = { x: 42 };
+        const { x } = o;
+        return x;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 42,
+  },
+  {
+    name: "object destructuring — two fields summed",
+    source: `
+      export function f(): number {
+        const o = { a: 5, b: 7 };
+        const { a, b } = o;
+        return a + b;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 12,
+  },
+  {
+    name: "object destructuring — renamed property",
+    source: `
+      export function f(): number {
+        const o = { a: 99, b: 1 };
+        const { a: x } = o;
+        return x;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 99,
+  },
+  {
+    name: "object destructuring — mixed shorthand and renamed",
+    source: `
+      export function f(): number {
+        const o = { foo: 10, bar: 20 };
+        const { foo, bar: y } = o;
+        return foo + y;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 30,
+  },
+  {
+    name: "object destructuring — composes with slice-1 string ops",
+    source: `
+      export function f(): number {
+        const o = { greeting: "hello" };
+        const { greeting } = o;
+        return greeting.length;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 5,
+  },
+
+  // -------------------------------------------------------------------------
+  // Step B: array destructuring from vec
+  // -------------------------------------------------------------------------
+  {
+    name: "array destructuring — first two elements",
+    source: `
+      export function f(arr: Array<number>): number {
+        const [x, y] = arr;
+        return x + y;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 30,
+  },
+  {
+    name: "array destructuring — three elements",
+    source: `
+      export function f(arr: Array<number>): number {
+        const [a, b, c] = arr;
+        return a + b + c;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 6,
+  },
+  {
+    name: "array destructuring — sparse (omitted slot)",
+    source: `
+      export function f(arr: Array<number>): number {
+        const [a, , c] = arr;
+        return a + c;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 150,
+  },
+  {
+    name: "array destructuring — single binding",
+    source: `
+      export function f(arr: Array<number>): number {
+        const [head] = arr;
+        return head;
+      }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f"],
+    expectedValue: 42,
+  },
+
+  // -------------------------------------------------------------------------
+  // Step C: spread in call args (static array literal)
+  // -------------------------------------------------------------------------
+  {
+    name: "spread call args — single spread of literal",
+    source: `
+      function add3(a: number, b: number, c: number): number { return a + b + c; }
+      export function f(): number { return add3(...[1, 2, 3]); }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f", "add3"],
+    expectedValue: 6,
+    parity: false, // legacy has a pre-existing instantiate bug for this shape
+  },
+  {
+    name: "spread call args — mixed leading + spread",
+    source: `
+      function sum4(a: number, b: number, c: number, d: number): number {
+        return a + b + c + d;
+      }
+      export function f(): number { return sum4(10, ...[1, 2, 3]); }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f", "sum4"],
+    expectedValue: 16,
+    parity: false,
+  },
+  {
+    name: "spread call args — multiple spreads concatenated",
+    source: `
+      function add4(a: number, b: number, c: number, d: number): number {
+        return a + b + c + d;
+      }
+      export function f(): number { return add4(...[1, 2], ...[3, 4]); }
+    `,
+    fn: "f",
+    args: [],
+    expectedClaimed: ["f", "add4"],
+    expectedValue: 10,
+    parity: false,
+  },
+];
+
+// Cases that exercise vec destructuring need an actual array passed in.
+// Drive them through a JS array (the host marshalling boundary handles
+// the externref-to-vec coercion via the runtime's `__JsArray_to_vec_*`
+// path on entry).
+const ARRAY_INPUT_CASES = new Map<string, ReadonlyArray<number>>([
+  ["array destructuring — first two elements", [10, 20]],
+  ["array destructuring — three elements", [1, 2, 3]],
+  ["array destructuring — sparse (omitted slot)", [100, 999, 50]],
+  ["array destructuring — single binding", [42]],
+]);
+
+describe("#1169g — IR slice 8a destructuring + spread", () => {
+  describe("selector claims slice-8a function shapes", () => {
+    for (const tc of CASES) {
+      if (!tc.expectedClaimed) continue;
+      it(`claims [${tc.expectedClaimed.join(", ")}]: ${tc.name}`, () => {
+        const claimed = selectionFor(tc.source);
+        for (const name of tc.expectedClaimed) {
+          expect(claimed.has(name), `selector should claim ${name}; claimed = ${[...claimed].join(",")}`).toBe(true);
+        }
+      });
+    }
+  });
+
+  describe("IR path produces correct values (and matches legacy when parity expected)", () => {
+    for (const tc of CASES) {
+      it(tc.name, async () => {
+        // Tests that take an array param need a proxy: wrap the function
+        // under test in a `__driver` that constructs the array literal
+        // inline. For slice 8a the array tests pass the input through a
+        // builder helper because vitest can't marshal an `Array<number>`
+        // param directly across the wasm boundary.
+        const arrInput = ARRAY_INPUT_CASES.get(tc.name);
+        let source = tc.source;
+        let fnName = tc.fn;
+        let callArgs: ReadonlyArray<number | boolean | string> = tc.args;
+        if (arrInput) {
+          const literal = `[${arrInput.join(", ")}]`;
+          source = `
+            ${tc.source}
+            export function __driver(): number { return f(${literal}); }
+          `;
+          fnName = "__driver";
+          callArgs = [];
+        }
+        const { legacy, ir } = await dualRun(source, fnName, callArgs);
+        // IR must always produce the correct value.
+        expect(ir).toStrictEqual({ kind: "ok", value: tc.expectedValue });
+        // Legacy parity: only assert when the case opts in (most cases).
+        // Spread-of-literal call args have a pre-existing legacy bug
+        // ("not enough arguments on the stack" wasm validation error)
+        // that slice 8a's IR widening sidesteps — the IR's correctness
+        // is verified by the absolute check above.
+        if (tc.parity !== false) {
+          expect(ir).toStrictEqual(legacy);
+        }
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coverage / no-fallback assertions
+//
+// Every slice-8a source compiles under `experimentalIR: true` without
+// emitting an "IR path failed" diagnostic — i.e. the IR didn't silently
+// fall through to legacy.
+// ---------------------------------------------------------------------------
+
+describe("#1169g — slice 8a functions reach the IR path without errors", () => {
+  for (const tc of CASES) {
+    if (!tc.expectedClaimed) continue;
+    it(`no IR-path errors: ${tc.name}`, () => {
+      const r = compile(tc.source, { experimentalIR: true });
+      expect(r.success).toBe(true);
+      const irErrors = r.errors.filter(
+        (e) => e.message.startsWith("IR path failed") || e.message.startsWith("IR path: could not resolve"),
+      );
+      expect(irErrors).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Slice 8a of #1169 — widens the IR claim to functions whose bodies use:

- `const { a, b } = obj` / `const { a: x } = obj` — object destructuring (shorthand, rename, multi-field). Lowers to per-leaf `object.get`.
- `const [x, y] = arr` / `const [a, , c] = arr` — array destructuring from a vec ref. Lowers to per-index `vec.get` via `resolver.resolveVec`. Sparse slots accepted.
- `f(...[1, 2, 3])` — call args spread where source is an `ArrayLiteralExpression`. Compile-time expansion to one IR arg per literal element.

Pure compile-time rewriting — **no new IR primitives or runtime helpers**. Steps D–H from the architect spec (literal/object spread, rest collection, iterator-protocol destructuring) defer to slice 8b.

The legacy `destructuring.ts` path is unchanged. Wider shapes (rest, defaults, nested patterns, `let`-destructuring, function-param destructuring, dynamic-length spread, method-call spread) stay on legacy via selector rejection.

## Files changed

- `src/ir/select.ts` — `isPhase1VarDecl` accepts binding patterns; new `isPhase1BindingPattern`, `collectPatternNames`, `isStaticSpreadSource`. Call arm of `isPhase1Expr` accepts `SpreadElement` whose source passes `isStaticSpreadSource`.
- `src/ir/from-ast.ts` — `lowerVarDecl` dispatches to new `lowerBindingPattern` / `lowerObjectPattern` / `lowerArrayPattern`. `lowerCall` runs `expandStaticSpreadArgs` before its 1:1 lowering loop.
- `tests/issue-1169g.test.ts` — 36 dual-run tests covering steps A–C.

## Test plan

- [x] All 36 new slice-8a tests pass (selector + IR-vs-legacy parity).
- [x] All 7 prior IR slice tests pass — 182 cases (issue-1169a/b/c/d, 1169e-bridge, 1169f-7a/b).
- [x] Pre-existing equivalence failures (`destructuring-extended` — function-param defaults; `computed-property-names` — number-to-string) verified pre-existing via `git stash`.
- [ ] CI runs full equivalence + test262 suites.

## Spread-call legacy bug note

`f(...[1, 2, 3])` triggers a pre-existing legacy bug — wasm validation fails with "not enough arguments on the stack for call". The IR's compile-time spread expansion sidesteps this. Tests assert the IR produces the correct value AND opt out of legacy parity for these specific spread cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)