### PR TITLE
fix(#1193): match ci-status-watcher hook by branch, not gh @me

### DIFF
--- a/.claude/hooks/ci-status-watcher.sh
+++ b/.claude/hooks/ci-status-watcher.sh
@@ -8,9 +8,20 @@
 # should react (PR finished and it's theirs); empty otherwise.
 #
 # How the dev "owns" a PR:
-#   The hook looks at `gh pr list --author @me --state open --json number`
-#   and matches against the file name. If the file is for a PR authored
-#   by this dev, react. Otherwise ignore.
+#   The hook reads `head_branch` from the ci-status JSON and compares it
+#   to the session's current git branch (`git rev-parse --abbrev-ref HEAD`
+#   in the hook's cwd, which is the agent's worktree). If they match, the
+#   dev agent owns this PR and the reminder is injected.
+#
+#   In a multi-agent / single-token setup we cannot use `gh pr list
+#   --author @me` here: every PR is GH-authored by the human running the
+#   orchestrator, so `@me` would either match every PR (when run from the
+#   orchestrator's session) or none (in dev sessions where the gh token
+#   is shared but identity is still the human's). See #1193.
+#
+#   The orchestrator session (cwd is the main repo, branch `main` or
+#   `master`) sees notifications for ALL PRs so the human-facing view is
+#   unchanged; dev agents see only their own.
 #
 # Dev protocol on reacting:
 #   - If conclusion=success and net_per_test is positive: no action needed,
@@ -39,24 +50,39 @@ esac
 pr_num=$(basename "$FILE" .json | sed 's/^pr-//')
 [ -z "$pr_num" ] && exit 0
 
-# Is this PR authored by this dev (current git user / gh user)?
-# Use gh api to check the author; match against this environment's gh identity.
-my_prs=$(gh pr list --author @me --state all --limit 30 --json number 2>/dev/null | jq -r '.[].number' 2>/dev/null || echo "")
-is_mine=false
-for n in $my_prs; do
-  if [ "$n" = "$pr_num" ]; then
-    is_mine=true
-    break
-  fi
-done
-
-if [ "$is_mine" = "false" ]; then
-  # Not this dev's PR — skip silently
+# Read the status file content
+if [ ! -f "$FILE" ]; then
   exit 0
 fi
 
-# Read the status file content
-if [ ! -f "$FILE" ]; then
+# Is this PR for this session's branch?
+#
+# Multi-agent / single-token: `@me` matches the human's GH identity, not
+# the agent's. Match by branch name instead — the hook runs in the agent's
+# session cwd, so `git rev-parse` resolves the agent's worktree branch.
+# (See #1193.)
+head_branch=$(jq -r '.head_branch // empty' "$FILE" 2>/dev/null)
+session_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+is_mine=false
+case "$session_branch" in
+  main|master)
+    # Orchestrator session — sees everything (preserves the existing
+    # human-facing view; the orchestrator runs from the main worktree).
+    is_mine=true
+    ;;
+  "")
+    # Not in a git worktree — skip silently.
+    is_mine=false
+    ;;
+  *)
+    if [ -n "$head_branch" ] && [ "$session_branch" = "$head_branch" ]; then
+      is_mine=true
+    fi
+    ;;
+esac
+
+if [ "$is_mine" = "false" ]; then
+  # Not this dev's PR — skip silently
   exit 0
 fi
 

--- a/plan/issues/sprints/45/1193.md
+++ b/plan/issues/sprints/45/1193.md
@@ -1,0 +1,129 @@
+---
+id: 1193
+title: "tooling: ci-status-watcher.sh hook doesn't push notifications to dev agents (uses gh @me which resolves to human, not agent)"
+sprint: 45
+status: in-progress
+priority: medium
+feasibility: easy
+reasoning_effort: low
+goal: developer-experience
+task_type: tooling
+area: infrastructure
+created: 2026-04-27
+updated: 2026-04-28
+es_edition: n/a
+depends_on: []
+related: []
+origin: surfaced 2026-04-27 — dev agents (this session) noticed they were learning about CI completion via team-lead SendMessage rather than via the FileChanged hook. Investigation showed the hook authors-by-GH-token match is wrong for the multi-agent / single-token setup.
+---
+
+# #1193 — `ci-status-watcher.sh` hook doesn't reach dev agents
+
+## Problem
+
+`/workspace/.claude/settings.json` registers a `FileChanged` hook on
+`.claude/ci-status/`:
+
+```json
+"FileChanged": [
+  { "matcher": ".claude/ci-status/", "hooks": [
+      { "command": ".claude/hooks/ci-status-watcher.sh" }
+  ]}
+]
+```
+
+The hook script is supposed to inject a system reminder into the dev's
+agent stream when the dev's own PR's CI status posts. But in this
+session, dev agents (#1185, #1186, #1177 PRs) consistently learned
+about CI status via team-lead `SendMessage`, NOT via the hook.
+
+## Root cause
+
+`ci-status-watcher.sh` matches PR ownership via:
+
+```bash
+gh pr list --author @me --state open --json number
+```
+
+`@me` resolves to the GitHub token holder. In a multi-agent / single-token
+setup (one human's token shared across agents), every PR is
+GH-authored by the same human — so `@me` matches ALL open PRs, but
+the dev agent that did the WORK isn't necessarily the human running
+the orchestrator. The hook fires correctly on the orchestrator's
+session (whose identity matches `@me`) but not on the dev agent's
+session.
+
+Effect: dev agents end up polling via background bash loops
+(`until [ -f .../pr-N.json ]; do sleep 30; done`), which works but is
+30s slower than push and consumes a small steady token cost during
+long PR queues.
+
+## Fix options
+
+### A. Match by branch name, not GH author (recommended)
+
+The dev agent owns a specific worktree with a specific branch. When
+the hook fires for `pr-N.json`, parse `head_branch` from the JSON
+and match against the agent's current worktree branch (or against a
+session-registered branch list).
+
+The dev agent registers its branch on PR-create:
+
+```bash
+echo "$(git rev-parse --abbrev-ref HEAD)" >> ~/.claude/agent-branches/$AGENT_ID.txt
+```
+
+Hook reads:
+```bash
+HEAD_BRANCH=$(jq -r .head_branch < "$FILE")
+if grep -qx "$HEAD_BRANCH" ~/.claude/agent-branches/*.txt; then
+  # inject reminder for the matching agent's session
+fi
+```
+
+### B. Fire for ALL CI status changes, let the agent filter
+
+Drop the ownership match entirely; emit `additionalContext` for every
+change. The agent's existing logic ("is this a PR I care about?") can
+filter. Slightly noisier but completely avoids the identity mismatch.
+
+### C. Use a separate notification channel per-agent
+
+Instead of a global FileChanged hook, dev agents register a watcher
+when they open a PR. The watcher writes to the agent's own task-
+notification file. This is what my session is doing manually with
+`until [ -f ... ]` loops; it could be productized.
+
+I recommend **A** — minimal change, preserves the "fire only on owned
+PRs" intent, and works for the multi-agent / single-token case.
+
+## Acceptance criteria
+
+1. After fix, dev agents that open a PR receive a system-reminder
+   injection within 5 seconds of the CI status JSON appearing.
+2. Manual polling loops in dev sessions (the `until [ -f ...]`
+   pattern) can be removed.
+3. The orchestrator continues to receive notifications for ALL PRs
+   so the human-facing view is unchanged.
+
+## Out of scope
+
+- Changing the CI status feed itself (`ci.yml` /
+  `ci-status-feed.yml`).
+- Multi-token setups (each agent has its own GH PAT) — that would
+  fix the `@me` issue naturally but adds token-management
+  complexity.
+- Migrating off FileChanged to a different push mechanism (e.g.
+  WebSocket); current architecture is fine if the matching is fixed.
+
+## Notes
+
+The hook script's existing comment block already documents the
+intent ("inject a system reminder when a file matching the current
+dev's own PR is created or updated"). The matching mechanism just
+needs to use branch-name instead of GH-author for the multi-agent
+case.
+
+This issue is filed mid-session by the dev agent that observed the
+gap. Effort: trivial (~10 lines in the bash hook + a small dev-
+side branch-registration helper). Time-box: 30 minutes.


### PR DESCRIPTION
## Summary

`.claude/hooks/ci-status-watcher.sh` matched PR ownership via `gh pr list --author @me`. In the multi-agent / single-token setup, `@me` resolves to the human running the orchestrator, so dev agents never received the FileChanged hook injection and had to poll with `until [ -f .claude/ci-status/pr-N.json ]; do sleep 60; done` loops.

This PR switches the match to branch-name:

- Extract `head_branch` from the ci-status JSON
- Compare against the session's current git branch (`git rev-parse --abbrev-ref HEAD` in the hook cwd — which is the agent's worktree)
- Orchestrator sessions on `main`/`master` continue to see notifications for ALL PRs (preserves the human-facing view)
- Sessions outside any git repo silently no-op

All 221 existing `pr-*.json` files already carry `head_branch`, so no backwards-compat shim is needed.

## Manual validation

| Cwd / branch | Trigger | Expected | Result |
| --- | --- | --- | --- |
| `/workspace` (main) | pr-100.json (any PR) | inject reminder | inject reminder |
| `issue-1193-ci-watcher` worktree | pr-100.json (head_branch=issue-1057-…) | silent exit 0 | silent exit 0 |
| `issue-1193-ci-watcher` worktree | fake pr-9999.json (head_branch=issue-1193-ci-watcher) | inject reminder | inject reminder |
| `/tmp` (no git) | pr-100.json | silent exit 0 | silent exit 0 |

## Test plan
- [ ] Once merged, dev agents will get FileChanged injection within seconds of CI status appearing — no more polling loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)