### PR TITLE
fix(#1188): emit CNAME for js2.loopdive.com custom domain

### DIFF
--- a/plan/issues/sprints/46/1188.md
+++ b/plan/issues/sprints/46/1188.md
@@ -2,7 +2,7 @@
 id: 1188
 title: "Setup js2.loopdive.com custom domain for GitHub Pages"
 sprint: 46
-status: ready
+status: in-progress
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -10,7 +10,7 @@ goal: developer-experience
 task_type: devops
 area: infrastructure
 created: 2026-04-27
-updated: 2026-04-27
+updated: 2026-04-30
 es_edition: n/a
 depends_on: []
 related: []

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -336,6 +336,12 @@ copyFileIfExists(join(ROOT, "frame-nav-sync.js"), join(PAGES_DIST, "frame-nav-sy
 // Disable Jekyll processing so all generated assets are published as-is.
 writeFileSync(join(PAGES_DIST, ".nojekyll"), "");
 
+// Emit CNAME so the GitHub Pages custom domain (js2.loopdive.com) survives
+// every re-deploy. GitHub Pages reads this file from the deployed artifact
+// and points the Pages site at the custom domain. Bare hostname only —
+// no scheme, trailing newline. See plan/issues/sprints/46/1188.md.
+writeFileSync(join(PAGES_DIST, "CNAME"), "js2.loopdive.com\n");
+
 // Copy web components to pages-dist root and dashboard
 const COMPONENTS_DIR = join(ROOT, "components");
 for (const file of ["site-nav.js", "t262-charts.js", "trend-chart.js", "perf-benchmark-chart.js"]) {


### PR DESCRIPTION
## Summary

Closes #1188 (Step 1 of 4 — the only code change in the issue).

Add `writeFileSync(PAGES_DIST/CNAME, "js2.loopdive.com\n")` to `scripts/build-pages.js` so the GitHub Pages custom domain survives every re-deploy. Without it, GitHub Pages would revert to `loopdive.github.io/js2wasm` on each deploy because `actions/deploy-pages` ships the artifact, not the repo's root `CNAME`.

The CNAME is placed alongside the existing `.nojekyll` write so both deploy-side artifacts are emitted in one block.

## Steps still done manually (per issue spec)

- Step 2: DNS CNAME record `js2.loopdive.com → loopdive.github.io.` (Thomas, in DNS provider)
- Step 3: Settings → Pages → Custom domain = `js2.loopdive.com` + Enforce HTTPS
- Step 4: `curl -I https://js2.loopdive.com` to verify

## Test plan

- [x] `node --check scripts/build-pages.js` passes
- [x] Smoke test: `writeFileSync` with the same args produces a file containing `"js2.loopdive.com\n"` exactly
- [ ] CI green (vitest + test262 sharded)
- [ ] Post-deploy: `js2.loopdive.com` resolves and serves the Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)