### PR TITLE
fix(#1211): fast-mode recursive arithmetic miscompile + AnyValue boxing

### DIFF
--- a/plan/issues/sprints/46/1211.md
+++ b/plan/issues/sprints/46/1211.md
@@ -2,7 +2,7 @@
 id: 1211
 title: "js2wasm hosted fib-recursive: Wasm validator — call param types must match"
 sprint: 46
-status: ready
+status: in-progress
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -60,8 +60,79 @@ than `externref` in hosted mode.
 
 ## Acceptance criteria
 
-- [ ] `fib-recursive` compiles without Wasm validation errors in hosted mode
-- [ ] The computed result matches Node.js baseline (`run(25) === 75025`)
-- [ ] No regression in equivalence tests
-- [ ] `js2wasm -> Node.js (hosted)` lane for `fib-recursive` shows timing numbers
-  in the competitive benchmark
+- [x] `fib-recursive` compiles without Wasm validation errors in hosted mode
+- [x] The computed result matches Node.js baseline (`run(25) === 75025`)
+- [x] No regression in equivalence tests (focused i32-fast-path suites all pass)
+- [x] `js2wasm -> Node.js (hosted)` lane for `fib-recursive` shows timing numbers
+  in the competitive benchmark (separately tracked under #1209)
+
+## Root cause
+
+There were two compounding bugs in the fast-mode codegen for an
+`any`-typed recursive function whose body contains
+`fib(n - 1) + fib(n - 2)`:
+
+### Bug A — `compileBooleanBinaryOp` silently swallows arithmetic ops
+
+`compileBinaryExpression` in `src/codegen/binary-ops.ts` dispatches to
+`compileBooleanBinaryOp` whenever `(isBooleanType(leftTsType) ||
+leftType.kind === "i32") && both operand types not externref`. That
+helper only handles comparison/equality operators; the `default:` arm
+returns `{ kind: "i32" }` without emitting any combining instruction.
+
+For `fib(n - 1)` with `n` typed as `any` and the binary op `MinusToken`,
+the i32-arithmetic path at line 1202 doesn't fire (its guard requires
+`isNumberType(leftTsType)` which is false for `any`). The dispatch
+falls into `compileBooleanBinaryOp(MinusToken)` → default arm → no
+`i32.sub` emitted. Net effect: `n - 1` compiles to "push `n`; push 1"
+with no subtraction; the call to `fib` consumes the literal `1` and
+leaves `n` orphaned on the stack. The recursion silently degenerates to
+`fib(1)` for every n > 1.
+
+### Bug B — `compileAnyBinaryDispatch` doesn't box operands
+
+`compileAnyBinaryDispatch` calls helpers like `__any_add(ref $AnyValue,
+ref $AnyValue)`, but its operand-compilation path was:
+
+```ts
+const leftType = compileExpression(ctx, fctx, expr.left);
+const rightType = compileExpression(ctx, fctx, expr.right);
+fctx.body.push({ op: "call", funcIdx });
+```
+
+It assumed `compileExpression` would naturally produce a `ref $AnyValue`,
+but in fast mode `fib(n - 1)` returns f64 (or the orphan i32 from Bug A).
+The validator rejected the resulting binary with
+`[wasm-validator error in function fib] call param types must match`.
+
+## Fix
+
+`src/codegen/binary-ops.ts`:
+
+1. In the `isBooleanType / leftType.kind === "i32"` branch, route
+   arithmetic ops on two i32 operands to `compileI32BinaryOp` (which
+   emits `i32.add` / `i32.sub` / …) instead of the comparison-only
+   `compileBooleanBinaryOp`. Falls through to `compileBooleanBinaryOp`
+   only for comparison/equality ops where it actually emits something.
+
+2. In `compileAnyBinaryDispatch`, after each operand is compiled, call
+   `coerceType(ctx, fctx, operandType, anyValueTarget)` if it isn't
+   already a `ref $AnyValue`. The existing `coerceType` boxing path
+   uses the `__any_box_i32`, `__any_box_f64`, `__any_box_ref` helpers
+   already registered by `ensureAnyHelpers`.
+
+## Verification
+
+- New regression test `tests/issue-1211.test.ts` covers:
+  - recursive `fib(n - 1) + fib(n - 2)` returns the right Fibonacci
+    value for n ∈ {0, 1, 2, 5, 10, 15};
+  - simple recursive `1 + countdown(n - 1)` doesn't drop `i32.sub`
+    (was being miscompiled to a constant);
+  - `run_hot` wrapper that forces AnyValue return type still produces
+    a valid Wasm binary.
+- Focused suites pass: 53 tests in `issue-1120`, `issue-1179`,
+  `issue-1182`, `issue-1183`, `issue-1211`, `equivalence/binary-arithmetic`;
+  59 tests in `issue-1128`, `issue-1160-1164`, `issue-138/139`.
+- Competitive benchmark `js2wasm -> Node.js (hosted)` lane reports
+  `173.9 / 44.0 / 2.2` ms for `fib-recursive` (previously
+  `compile-error: [wasm-validator error in function fib]`).

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -13,6 +13,7 @@ import {
   isWrapperObjectType,
 } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
+import { isAnyValue } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -1276,6 +1277,18 @@ export function compileBinaryExpression(
       releaseTempLocal(fctx, tmpR);
       return compileNumericBinaryOp(ctx, fctx, op, expr);
     }
+    // For arithmetic / bitwise ops on two i32 operands, use compileI32BinaryOp
+    // which emits the matching i32 instruction (i32.add, i32.sub, …).
+    // compileBooleanBinaryOp only handles comparison/equality — its `default:`
+    // arm falls through silently on `+ - * %` etc., leaving both operands on
+    // the stack with no combining op (#1211: caused recursive `f(n - 1)` in
+    // any-typed fast-mode functions to be miscompiled into `f(1)` because the
+    // TS-checker types the recursive param as `any`, so the i32-arith guard at
+    // line ~1202 above (which requires `isNumberType(leftTsType)`) doesn't
+    // fire and the dispatch falls into this branch instead).
+    if (leftType.kind === "i32" && rightType.kind === "i32" && isNumericOp) {
+      return compileI32BinaryOp(ctx, fctx, op, expr);
+    }
     return compileBooleanBinaryOp(ctx, fctx, op);
   }
 
@@ -1667,10 +1680,24 @@ function compileAnyBinaryDispatch(
   const funcIdx = ctx.funcMap.get(helperName);
   if (funcIdx === undefined) return null;
 
-  // Compile both operands without numeric hint so they produce ref $AnyValue
+  // Compile both operands. The helpers (`__any_add`, `__any_eq`, …) all take
+  // `(ref null $AnyValue, ref null $AnyValue)` parameters, so any operand
+  // that didn't naturally produce an AnyValue must be boxed before the call.
+  // Without this coercion, recursive `any`-typed functions whose body
+  // contains `f(...) + f(...)` validate as "call param types must match"
+  // because the recursive call returns f64 (or i32) while the helper
+  // expects ref $AnyValue (#1211).
+  const anyValueTarget: ValType = { kind: "ref_null", typeIdx: ctx.anyValueTypeIdx };
   const leftType = compileExpression(ctx, fctx, expr.left);
+  if (!leftType) return null;
+  if (!isAnyValue(leftType, ctx)) {
+    coerceType(ctx, fctx, leftType, anyValueTarget);
+  }
   const rightType = compileExpression(ctx, fctx, expr.right);
-  if (!leftType || !rightType) return null;
+  if (!rightType) return null;
+  if (!isAnyValue(rightType, ctx)) {
+    coerceType(ctx, fctx, rightType, anyValueTarget);
+  }
 
   fctx.body.push({ op: "call", funcIdx });
 

--- a/tests/issue-1211.test.ts
+++ b/tests/issue-1211.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+/**
+ * Regression test for #1211 — fast-mode codegen of `f(n - 1) + f(n - 2)`
+ * inside a recursive `any`-typed function (untyped JS) used to drop the
+ * `i32.sub` operation entirely, miscompiling the recursion to a constant.
+ *
+ * Symptoms before the fix:
+ * - `function fib(n) { if (n <= 1) return n; return fib(n-1) + fib(n-2); }`
+ *   compiled to `fib(1) + fib(2)` for any input n > 1, returning 2 instead
+ *   of the correct Fibonacci value.
+ * - When the bundle source surrounded the function with `run_hot` (which
+ *   forces the return type to AnyValue), wasm-opt rejected the binary
+ *   with `[wasm-validator error in function fib] call param types must
+ *   match` because `__any_add` was called with raw f64/i32 args instead
+ *   of boxed AnyValue refs.
+ *
+ * The fix in `compileBinaryExpression` routes arithmetic ops on i32-typed
+ * operands (where the TS-checker reports `any` due to recursive inference)
+ * to `compileI32BinaryOp` instead of the comparison-only
+ * `compileBooleanBinaryOp`, which silently fell through on `+ - * %`.
+ *
+ * The companion fix in `compileAnyBinaryDispatch` boxes the operands to
+ * AnyValue refs before calling the helper so the call validates regardless
+ * of the natural operand types.
+ */
+async function run(src: string, exportName: string, ...args: number[]): Promise<number> {
+  const r = compile(src, { fileName: "t.ts", allowJs: true, target: "gc", fast: true, optimize: 0 });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await instantiateWasm(r.binary, imports.env, imports.string_constants);
+  if (imports.setExports) imports.setExports(instance.exports);
+  const fn = instance.exports[exportName] as (...a: number[]) => unknown;
+  if (typeof fn !== "function") {
+    throw new Error(`export ${exportName} is not a function`);
+  }
+  return Number(fn(...args));
+}
+
+describe("#1211 — fast-mode recursive arithmetic", () => {
+  it("recursive fib(n - 1) + fib(n - 2) returns correct values", async () => {
+    const src = `
+      function fib(n) {
+        if (n <= 1) return n;
+        return fib(n - 1) + fib(n - 2);
+      }
+      export function run(n) { return fib(n); }
+    `;
+    expect(await run(src, "run", 0)).toBe(0);
+    expect(await run(src, "run", 1)).toBe(1);
+    expect(await run(src, "run", 2)).toBe(1);
+    expect(await run(src, "run", 5)).toBe(5);
+    expect(await run(src, "run", 10)).toBe(55);
+    expect(await run(src, "run", 15)).toBe(610);
+  });
+
+  it("simple recursive call with `n - 1` does not drop `i32.sub`", async () => {
+    // Reduces to test the codegen path: in the fast-mode untyped recursion,
+    // the compiler used to emit `local.get; drop; i32.const 1; call $bar`
+    // instead of `local.get; i32.const 1; i32.sub; call $bar`.
+    const src = `
+      function countdown(n) {
+        if (n <= 0) return 0;
+        return 1 + countdown(n - 1);
+      }
+      export function run(n) { return countdown(n); }
+    `;
+    expect(await run(src, "run", 0)).toBe(0);
+    expect(await run(src, "run", 1)).toBe(1);
+    expect(await run(src, "run", 5)).toBe(5);
+    expect(await run(src, "run", 100)).toBe(100);
+  });
+
+  it("recursive function with run_hot wrapper compiles to a valid Wasm binary", async () => {
+    // The bundled benchmark source wraps the body in a `run_hot` helper
+    // whose loop re-assignment forces `result` (and therefore the
+    // recursive function's return type) to AnyValue. Without the boxing
+    // fix in compileAnyBinaryDispatch, wasm-opt rejected the binary
+    // with "call param types must match".
+    //
+    // We assert the binary instantiates cleanly (i.e. validates) and
+    // that the simple `run(n)` entry still produces the right value.
+    // The `run_hot` boxed-result path returns an AnyValue struct that
+    // would require an unboxer to inspect from JS — out of scope for
+    // this regression test.
+    const src = `
+      function fib(n) {
+        if (n <= 1) return n;
+        return fib(n - 1) + fib(n - 2);
+      }
+      export function run(n) { return fib(n); }
+      export function run_hot(iterations, input) {
+        let result = run(input);
+        for (let i = 0; i < iterations; i++) { result = run(input); }
+        return result;
+      }
+    `;
+    const r = compile(src, { fileName: "t.ts", allowJs: true, target: "gc", fast: true, optimize: 0 });
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const imports = buildImports(r.imports, {}, r.stringPool);
+    const { instance } = await instantiateWasm(r.binary, imports.env, imports.string_constants);
+    if (imports.setExports) imports.setExports(instance.exports);
+    expect(typeof instance.exports.run).toBe("function");
+    expect(typeof instance.exports.run_hot).toBe("function");
+    // `run` returns f64 directly, so this remains a primitive number.
+    expect(Number((instance.exports.run as (n: number) => unknown)(25))).toBe(75025);
+  });
+});


### PR DESCRIPTION
## Summary

Two compounding codegen bugs in `src/codegen/binary-ops.ts` caused
recursive `any`-typed functions whose body contains `f(n - 1) + f(n - 2)`
to be silently miscompiled in fast mode, producing a Wasm binary that
wasm-opt rejected with `[wasm-validator error in function fib] call
param types must match`.

### Bug A — `compileBooleanBinaryOp` swallows arithmetic ops

`compileBinaryExpression` dispatches to `compileBooleanBinaryOp` when
`(isBooleanType(leftTsType) || leftType.kind === "i32") && both
operands not externref`. That helper only handles
comparison/equality; its `default:` arm returns `i32` without emitting
any combining instruction.

For `fib(n - 1)` with `n` typed as `any` (recursive untyped param) and
op `MinusToken`, the i32-arithmetic path at line ~1202 doesn't fire
(its guard `isNumberType(leftTsType)` is false for `any`), so the
dispatch falls into `compileBooleanBinaryOp(MinusToken)` → default
arm → no `i32.sub` emitted. The literal `1` is consumed as the call's
only arg, leaving `n` orphaned on the stack — `fib(n-1)` silently
degenerates to `fib(1)` for every n > 1.

**Fix:** route arithmetic ops on two i32 operands to
`compileI32BinaryOp` (which handles `+ - * %` etc.) instead of
`compileBooleanBinaryOp`.

### Bug B — `compileAnyBinaryDispatch` doesn't box operands

The dispatcher emitted helpers like `__any_add(ref null $AnyValue,
ref null $AnyValue)` but pushed whatever `compileExpression` produced
for each operand (often f64 or i32). When the recursive call's return
type is f64 / i32, the validator rejected the param mismatch.

**Fix:** after each operand is compiled, call `coerceType` to box
non-AnyValue results to `ref null $AnyValue`. The existing coerceType
boxing path uses `__any_box_i32` / `__any_box_f64` / `__any_box_ref`
helpers already registered by `ensureAnyHelpers`.

## Test plan

- [x] New regression test `tests/issue-1211.test.ts` (3 cases)
      passes: recursive fib with arithmetic, simple recursive `n - 1`
      not dropping `i32.sub`, and run_hot-wrapped recursion producing
      a valid Wasm binary.
- [x] 53 tests in `issue-1120`, `issue-1179`, `issue-1182`,
      `issue-1183`, `issue-1211`,
      `equivalence/binary-arithmetic` pass.
- [x] 59 tests in `issue-1128`, `issue-1160-1164`,
      `issue-138/139` pass.
- [ ] Test262 sharded CI gate (this PR triggers it).
- Competitive benchmark hosted lane (verified separately on labs)
  reports `fib-recursive: 173.9 / 44.0 / 2.2` instead of
  `compile-error: [wasm-validator error]`.

Surfaced by competitive-benchmark run 2026-04-29. Companion fix for
the labs-only path bug (#1209) goes to a separate PR on the labs repo
per `labs/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)