### PR TITLE
plan(#1212): follow-up issue for Promise/TypedArray regressions from #1211

### DIFF
--- a/plan/issues/sprints/46/1212.md
+++ b/plan/issues/sprints/46/1212.md
@@ -1,0 +1,108 @@
+---
+id: 1212
+title: "fix: Promise resolve/reject edge cases regress after #1211 any-boxing fix"
+sprint: 46
+status: ready
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: promises
+goal: compilable
+origin: surfaced by test262 regression-gate on PR #95 (#1211 codegen fix)
+---
+
+# #1212 — Promise resolve/reject paths regress after `compileAnyBinaryDispatch` boxing fix
+
+## Problem
+
+After landing #1211 (`compileAnyBinaryDispatch` now boxes operands to
+`ref $AnyValue` before calling `__any_add` / `__any_eq` / etc.), the
+test262 regression-gate on PR #95 surfaced a cluster of 15 Promise
+regressions and 5 TypedArray compile_errors. The PR landed by
+tech-lead override (net_per_test = +79, ratio 11.2% / 10% threshold)
+with this issue filed as the follow-up.
+
+## Affected tests (22 real regressions on PR #95)
+
+### Promise cluster (15)
+
+```
+test/built-ins/Promise/any/invoke-resolve-get-once-no-calls.js          pass → fail
+test/built-ins/Promise/any/invoke-then-get-error-reject.js              pass → fail
+test/built-ins/Promise/any/invoke-then-on-promises-every-iteration.js   pass → fail
+test/built-ins/Promise/prototype/finally/is-a-method.js                 pass → fail
+test/built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T1.js              pass → fail
+test/built-ins/Promise/prototype/then/ctor-poisoned.js                  pass → fail
+test/built-ins/Promise/prototype/then/rxn-handler-identity.js           pass → fail
+test/built-ins/Promise/race/S25.4.4.3_A7.1_T2.js                        pass → fail
+test/built-ins/Promise/race/invoke-resolve-get-error.js                 pass → fail
+test/built-ins/Promise/race/invoke-resolve-get-once-no-calls.js         pass → fail
+test/built-ins/Promise/race/iter-returns-string-reject.js               pass → fail
+test/built-ins/Promise/reject-via-fn-deferred-queue.js                  pass → fail
+test/built-ins/Promise/resolve-prms-cstm-then-immed.js                  pass → fail
+```
+
+(Two more Promise/race tests with similar shapes.)
+
+### TypedArray cluster (5, compile_error)
+
+```
+test/built-ins/TypedArray/prototype/byteOffset/invoked-as-accessor.js                  pass → compile_error
+test/built-ins/TypedArray/prototype/findLastIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
+test/built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
+test/built-ins/TypedArray/prototype/slice/detached-buffer-get-ctor.js
+test/built-ins/TypedArrayConstructors/internals/Delete/BigInt/key-is-symbol.js
+```
+
+### Isolated (2)
+
+```
+test/built-ins/Array/prototype/reduceRight/call-with-boolean.js
+test/built-ins/Function/prototype/caller-arguments/accessor-properties.js
+test/built-ins/Object/defineProperty/15.2.3.6-4-589.js
+test/language/block-scope/syntax/for-in/acquire-properties-from-array.js
+```
+
+## Likely cause
+
+#1211 added an unconditional `coerceType(operand, ref null $AnyValue)`
+to every operand of `compileAnyBinaryDispatch` whose natural type is
+not already AnyValue. The Promise regressions look like cases where
+the resolve/reject paths previously relied on `__any_add` /
+`__any_eq` accepting raw f64 / i32 (which was technically a Wasm
+validator violation but happened to "work" because Promise internals
+never exercised the validator's strict checking on those paths in the
+test runner).
+
+The 5 TypedArray `compile_error` regressions are a different shape —
+they suggest a TypedArray codegen path now fails to find an expected
+helper or imports types in the wrong order. Possibly an
+`addUnionImports` / late-import shift interaction with the new
+`coerceType` calls.
+
+## Investigation steps
+
+1. Pick one Promise/race test (e.g.
+   `invoke-resolve-get-once-no-calls.js`) and one TypedArray test
+   (e.g. `byteOffset/invoked-as-accessor.js`) and reproduce locally
+   against `main` (post-#1211 land).
+2. Diff the generated Wasm against pre-#1211 to see exactly which
+   `__any_box_*` call(s) the new path inserts.
+3. Check whether `compileAnyBinaryDispatch` is called from a path
+   where the operand is already on a different stack discipline
+   (e.g. inside a `block` whose result type pre-decides the
+   non-AnyValue form).
+4. For TypedArray: confirm whether the `compile_error` is from
+   `addUnionImports` shifting indices that an earlier `coerceType`
+   already captured. The `addUnionImports` notes in CLAUDE.md flag
+   this as a known sharp edge.
+
+## Acceptance criteria
+
+- [ ] All 15 Promise regressions return to `pass`.
+- [ ] All 5 TypedArray compile_error regressions return to `pass`.
+- [ ] No new regressions introduced.
+- [ ] Net per-test on the regression-gate is ≥ 0.
+- [ ] #1211 regression test (`tests/issue-1211.test.ts`) still passes.


### PR DESCRIPTION
## Summary

Files the follow-up issue for the 22 real test262 regressions
surfaced by the regression-gate on PR #95 (the #1211 codegen fix).

The PR #95 landed by tech-lead override (net_per_test = +79, ratio
11.2% vs 10% threshold by 1.2 pp overshoot) on the strength of:
- +79 net pass count
- max single-bucket = 3 (well under 50)
- the underlying fix (compileBooleanBinaryOp's `default:` arm
  swallowing arithmetic ops) is unambiguously correct

The remaining 22 real regressions cluster as:
- **15 Promise tests** (resolve/reject paths likely interacting with
  the new `compileAnyBinaryDispatch` boxing)
- **5 TypedArray compile_errors** (possibly an `addUnionImports` /
  late import shift interaction)
- **2 isolated tests**

This issue tracks rooting out and fixing those clusters so
net_per_test on a follow-up PR closes back to ≥ 0 while preserving
the #1211 fix.

## Test plan

Planning artifact only — no code changes, no tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)