### PR TITLE
fix(ci #1213): refresh-benchmarks looks for sidebar baseline at canonical committed path

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -52,8 +52,17 @@ jobs:
 
       - name: Snapshot current performance baseline
         run: |
+          # Canonical committed location is `benchmarks/results/`
+          # (see scripts/generate-playground-benchmark-sidebar.mjs RESULTS_PATH).
+          # The `public/` and `playground/public/` copies are derived artifacts —
+          # they were LFS-tracked until commit 616a7a528 (#1170 LFS migration,
+          # 2026-04-25), which untracked all `public/benchmarks/results/*.json`.
+          # Prefer the committed location; fall back to derived copies in case
+          # someone has them locally (no functional difference — same payload).
           mkdir -p benchmark-baseline
-          if [ -f public/benchmarks/results/playground-benchmark-sidebar.json ]; then
+          if [ -f benchmarks/results/playground-benchmark-sidebar.json ]; then
+            cp benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json
+          elif [ -f public/benchmarks/results/playground-benchmark-sidebar.json ]; then
             cp public/benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json
           elif [ -f playground/public/benchmarks/results/playground-benchmark-sidebar.json ]; then
             cp playground/public/benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json

--- a/plan/issues/sprints/46/1213.md
+++ b/plan/issues/sprints/46/1213.md
@@ -3,6 +3,7 @@ id: 1213
 title: "ci: refresh-benchmarks workflow fails on every PR — looks for sidebar baseline at gitignored path"
 sprint: 46
 status: in-progress
+pr: 105
 priority: medium
 feasibility: easy
 reasoning_effort: low

--- a/plan/issues/sprints/46/1213.md
+++ b/plan/issues/sprints/46/1213.md
@@ -1,0 +1,88 @@
+---
+id: 1213
+title: "ci: refresh-benchmarks workflow fails on every PR — looks for sidebar baseline at gitignored path"
+sprint: 46
+status: in-progress
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: ci
+area: ci
+language_feature: n/a
+goal: ci-stability
+created: 2026-04-30
+updated: 2026-04-30
+es_edition: n/a
+depends_on: []
+related: [1170]
+origin: noticed during PR #104 (#1201) post-merge — `refresh-benchmarks` job has been failing with "Missing committed playground benchmark baseline" on every PR since the 2026-04-25 LFS migration.
+---
+
+# #1213 — `refresh-benchmarks` workflow expects sidebar baseline at gitignored location
+
+## Symptom
+
+Every PR's `refresh-benchmarks` GitHub Actions job fails at the **"Snapshot current performance baseline"** step with:
+
+```
+Missing committed playground benchmark baseline.
+##[error]Process completed with exit code 2.
+```
+
+Confirmed on PR #104 (Apr 30, 2026, run [25187412611](https://github.com/loopdive/js2wasm/actions/runs/25187412611)).
+
+## Root cause
+
+Commit `616a7a528` (`chore(lfs): migrate JSONL and benchmark runs out of LFS`, 2026-04-25) untracked `public/benchmarks/results/*.json` from git as part of the LFS quota cleanup. After this migration:
+
+- **Committed (canonical)**: `benchmarks/results/playground-benchmark-sidebar.json` ✅
+- **Gitignored (derived)**: `public/benchmarks/results/playground-benchmark-sidebar.json` ❌
+- **Gitignored (derived)**: `playground/public/benchmarks/results/playground-benchmark-sidebar.json` ❌
+
+But `.github/workflows/benchmark-refresh.yml` (introduced in commit `8bd1c0142`, before the LFS migration) only checks the two **derived** locations:
+
+```yaml
+if [ -f public/benchmarks/results/playground-benchmark-sidebar.json ]; then
+  cp ...
+elif [ -f playground/public/benchmarks/results/playground-benchmark-sidebar.json ]; then
+  cp ...
+else
+  echo "Missing committed playground benchmark baseline."
+  exit 2
+fi
+```
+
+Neither file is in a fresh CI checkout post-LFS-migration → workflow fails.
+
+The canonical source per `scripts/generate-playground-benchmark-sidebar.mjs` (`RESULTS_PATH`) and per `scripts/build-pages.js` (line ~316: "canonical source lives in benchmarks/results/ (committed)") is `benchmarks/results/`. The two `public/` copies are generated as build-time mirrors.
+
+## Fix
+
+Add `benchmarks/results/playground-benchmark-sidebar.json` as the **first** candidate in the snapshot step. Keep the existing fallbacks in case someone has local-only `public/` copies — same payload, no functional difference.
+
+```yaml
+mkdir -p benchmark-baseline
+if [ -f benchmarks/results/playground-benchmark-sidebar.json ]; then
+  cp benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json
+elif [ -f public/benchmarks/results/playground-benchmark-sidebar.json ]; then
+  cp public/benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json
+elif [ -f playground/public/benchmarks/results/playground-benchmark-sidebar.json ]; then
+  cp playground/public/benchmarks/results/playground-benchmark-sidebar.json benchmark-baseline/playground-benchmark-sidebar.json
+else
+  echo "Missing committed playground benchmark baseline."
+  exit 2
+fi
+```
+
+The diff step's candidate path (`public/benchmarks/results/playground-benchmark-sidebar.json`) doesn't need changes — it's written by `pnpm run refresh:benchmarks` (via `generate-playground-benchmark-sidebar.mjs` line ~159 `copyFileSync(RESULTS_PATH, PUBLIC_PATH)`) before the diff runs.
+
+## Acceptance criteria
+
+- [ ] `refresh-benchmarks` job passes on PR CI
+- [ ] No regression in regression-detection behavior (same baseline content, just sourced from the committed location)
+- [ ] Comment in the workflow explains why three fallback paths exist
+
+## Implementation notes
+
+- **Why not just fix the LFS migration?** The migration was intentional — `*.json` benchmark artifacts shouldn't bloat LFS. The committed `benchmarks/results/` location is the right one; the workflow just needs to follow the move.
+- **Why a comment block instead of removing the fallbacks?** Some local dev workflows (e.g. running `refresh:benchmarks` locally without committing) leave the `public/` copies behind. Keeping the fallbacks means CI works in both fresh-checkout and local-iteration scenarios. The canonical-first ordering ensures fresh CI always picks the committed payload.


### PR DESCRIPTION
## Summary

- `refresh-benchmarks` job has been failing on every PR since the 2026-04-25 LFS migration (`616a7a528`) — it checks `public/benchmarks/results/` and `playground/public/benchmarks/results/`, both gitignored after that migration.
- The canonical committed location is `benchmarks/results/playground-benchmark-sidebar.json`. This PR adds it as the first candidate; existing fallbacks remain for local dev iterations (same payload).
- Inline comment in the workflow explains the LFS-migration history so the bug isn't reintroduced.

## Files changed

- `.github/workflows/benchmark-refresh.yml` — add canonical committed path as first candidate in the "Snapshot current performance baseline" step
- `plan/issues/sprints/46/1213.md` — new issue file documenting symptom, root cause, fix, acceptance

## Test plan

- [x] **CI on this PR will validate**: `refresh-benchmarks` should now pass at the snapshot step (no more "Missing committed playground benchmark baseline" error)
- [x] Diff step's candidate path (`public/benchmarks/results/playground-benchmark-sidebar.json`) is unchanged — written by `pnpm run refresh:benchmarks` before the diff runs (verified in `scripts/generate-playground-benchmark-sidebar.mjs` line ~159)
- [x] Zero compiler source touched — cannot affect test262 outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)