### PR TITLE
feat(#1198): pre-size dense arrays at the const a = [] allocation site

### DIFF
--- a/plan/issues/sprints/47/1198.md
+++ b/plan/issues/sprints/47/1198.md
@@ -2,7 +2,7 @@
 id: 1198
 title: "perf: pre-size dense arrays at allocation site (`const a = []; for ... a[i] = ...` → `new Array(n)`)"
 sprint: 47
-status: ready
+status: in-progress
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -11,12 +11,74 @@ area: codegen
 language_feature: arrays
 goal: performance
 created: 2026-04-27
-updated: 2026-04-27
+updated: 2026-05-01
 es_edition: n/a
 depends_on: []
 related: [1126, 1179, 1195, 1196, 1197]
 origin: 2026-04-27 array-sum perf analysis — Tier 1 win #1, simplest of the three (~1 day). Avoids quadratic grow-on-write.
 ---
+
+## Implementation status (2026-05-01, dev-2)
+
+Implemented in `src/codegen/literals.ts` as a sibling of the existing
+`detectCountedPushLoopSize` matcher (#1001). The new
+`detectCountedFillLoopBound` returns a `ts.Expression` (the loop bound)
+when the canonical fill pattern matches, or `null` otherwise.
+
+When matched, `compileArrayLiteral` emits both the vec struct's
+`length` field AND the `array.new_default` size from the same bound,
+so the post-allocation observable state (`arr.length === N`,
+`arr[0..N-1] === 0`) matches the post-loop state the unoptimised
+grow-on-write path would have produced.
+
+**Conservative match guards** — bodies whose pre-sizing would change
+observable semantics fall back to grow-on-write:
+
+- Body must be exactly one expression statement (rejects two-statement
+  bodies, accidentally-extra `a.push(...)`, `if (...) { ... }` etc.).
+- LHS must be `arr[loopVar]` literally (rejects `arr[i + 1]`,
+  `arr[other]`, sparse writes).
+- RHS must be "pure" — only NumericLiteral, Identifier, parenthesized,
+  PrefixUnary `+ - ~ !`, BinaryExpression composing the above.
+  Rejects calls / property access / element access (any of which can
+  throw and would leave a partial-fill `arr.length` mismatching the
+  pre-sized value).
+- The bound expression and the body's RHS must not reference the
+  array under construction (rules out `a.length` reads, which would
+  observe the pre-sized length immediately instead of grow-as-you-go).
+
+Both literal-bound and identifier/expression-bound loops are
+supported. Identifier bounds compile through the normal expression
+path with an i32 hint and are stashed in a temp local so the same
+value feeds both struct fields.
+
+## Test coverage
+
+`tests/issue-1192.test.ts` (8 cases, all passing) — name retained
+from the issue's original cross-reference.
+
+Matching:
+- (a) parameter-bound fill returns correct length (n=0, 10, 1000).
+- (b) parameter-bound fill returns correct slot values
+  (verified by sum-loop: i*2 for i in 0..n-1).
+- (c) literal-bound fill (the static-N cousin of #1001 push-prealloc).
+- (d) array-sum benchmark shape — bitwise body
+  `((i * 17) ^ (i >>> 3)) & 1023`.
+
+Non-matching (fall back to grow-on-write):
+- (e) reading `arr.length` inside the body inhibits pre-size.
+- (f) two-statement body inhibits pre-size.
+- (g) non-canonical loop shape (`while`) inhibits pre-size.
+- (h) writing to `arr[i + 1]` (different from loopVar) inhibits
+  pre-size.
+
+## Files changed
+
+- `src/codegen/literals.ts` — new `detectCountedFillLoopBound`,
+  `isPureFillRhs`, `isExprFreeOfReference` helpers; new
+  `fillBoundExpr` branch in `compileArrayLiteral`'s empty-array
+  arm. New imports for `allocTempLocal` / `releaseTempLocal`.
+- `tests/issue-1192.test.ts` — 8 regression cases.
 
 # #1198 — Pre-size dense arrays at allocation site
 

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -19,7 +19,7 @@ import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction } from "../i
 import { emitMethodParamDefaults, promoteAccessorCapturesToGlobals } from "./closures.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
-import { allocLocal } from "./context/locals.js";
+import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
@@ -1350,6 +1350,201 @@ function detectCountedPushLoopSize(expr: ts.ArrayLiteralExpression): number {
   return tripCount;
 }
 
+/**
+ * Detect a counted dense-fill loop pattern after an empty array literal (#1198):
+ *   const arr = [];
+ *   for (let i = 0; i < N; i++) arr[i] = <pure expr involving i and outer locals>;
+ *
+ * This is the cousin of `detectCountedPushLoopSize` for `a[i] = …` instead of
+ * `a.push(…)`. The match unlocks pre-sizing the WasmGC backing array to N up
+ * front, eliminating O(n²) grow-and-copy churn that the per-write
+ * grow-on-demand path emits.
+ *
+ * Returns the loop-bound `ts.Expression` if the pattern matches, `null`
+ * otherwise. The caller compiles the expression to i32 at allocation time
+ * (literal `N` is constant-folded into `i32.const N`; an identifier compiles
+ * via the normal expression path with an i32 hint).
+ *
+ * **Conservative checks** — the matcher rejects shapes whose pre-sizing
+ * would change observable semantics:
+ *
+ * - Loop body must be **exactly** `arr[i] = expr` (one expression statement
+ *   wrapping a single assignment).
+ * - The RHS must be "non-throwing" — only NumericLiteral, Identifier,
+ *   PrefixUnary on the above, BinaryExpression composing the above. This
+ *   excludes calls, property access, and element access (any of which can
+ *   throw in JS, which would leave a partial-fill `arr.length` that doesn't
+ *   match the pre-sized value).
+ * - LHS must be `arr[i]` exactly — no `arr[i+1]`, no `arr[other]`, no
+ *   `arr.field` in the RHS that could read the array under construction.
+ * - The loop body must not reference `arr` anywhere else (rules out `arr
+ *   .length` reads, which would observe the pre-sized length immediately
+ *   instead of the grow-as-you-go length).
+ */
+function detectCountedFillLoopBound(expr: ts.ArrayLiteralExpression): ts.Expression | null {
+  // Same outer-walk as detectCountedPushLoopSize: literal must be the
+  // initializer of a single variable declaration whose next sibling
+  // statement is the for-loop.
+  const varDecl = expr.parent;
+  if (!varDecl || !ts.isVariableDeclaration(varDecl) || !ts.isIdentifier(varDecl.name)) return null;
+  const arrName = varDecl.name.text;
+
+  const declList = varDecl.parent;
+  if (!declList || !ts.isVariableDeclarationList(declList)) return null;
+  const varStmt = declList.parent;
+  if (!varStmt || !ts.isVariableStatement(varStmt)) return null;
+
+  const block = varStmt.parent;
+  if (!block) return null;
+  let stmts: ts.NodeArray<ts.Statement>;
+  if (ts.isBlock(block)) stmts = block.statements;
+  else if (ts.isSourceFile(block)) stmts = block.statements;
+  else return null;
+
+  const idx = stmts.indexOf(varStmt);
+  if (idx < 0 || idx + 1 >= stmts.length) return null;
+  const nextStmt = stmts[idx + 1]!;
+  if (!ts.isForStatement(nextStmt)) return null;
+
+  // Initializer: `let i = 0` (or var). Single declaration, init === 0.
+  const init = nextStmt.initializer;
+  if (!init || !ts.isVariableDeclarationList(init)) return null;
+  if (init.declarations.length !== 1) return null;
+  const loopDecl = init.declarations[0]!;
+  if (!ts.isIdentifier(loopDecl.name)) return null;
+  const loopVar = loopDecl.name.text;
+  if (!loopDecl.initializer || !ts.isNumericLiteral(loopDecl.initializer) || loopDecl.initializer.text !== "0") {
+    return null;
+  }
+
+  // Condition: `i < BOUND` where BOUND is any expression. We capture it for
+  // the caller to compile; we never evaluate it here.
+  const cond = nextStmt.condition;
+  if (!cond || !ts.isBinaryExpression(cond)) return null;
+  if (cond.operatorToken.kind !== ts.SyntaxKind.LessThanToken) return null;
+  if (!ts.isIdentifier(cond.left) || cond.left.text !== loopVar) return null;
+  const boundExpr = cond.right;
+
+  // BOUND may not reference the array under construction — that would
+  // observe the pre-sized length and change semantics.
+  if (!isExprFreeOfReference(boundExpr, arrName)) return null;
+
+  // Incrementor: `i++` or `++i`.
+  const inc = nextStmt.incrementor;
+  if (!inc) return null;
+  if (ts.isPostfixUnaryExpression(inc) || ts.isPrefixUnaryExpression(inc)) {
+    if (inc.operator !== ts.SyntaxKind.PlusPlusToken) return null;
+    if (!ts.isIdentifier(inc.operand) || inc.operand.text !== loopVar) return null;
+  } else {
+    return null;
+  }
+
+  // Body: exactly one expression statement of shape `arr[loopVar] = pureExpr`.
+  const bodyStmtNode = nextStmt.statement;
+  let bodyStmt: ts.Statement;
+  if (ts.isBlock(bodyStmtNode)) {
+    if (bodyStmtNode.statements.length !== 1) return null;
+    bodyStmt = bodyStmtNode.statements[0]!;
+  } else {
+    bodyStmt = bodyStmtNode;
+  }
+  if (!ts.isExpressionStatement(bodyStmt)) return null;
+  const assign = bodyStmt.expression;
+  if (!ts.isBinaryExpression(assign)) return null;
+  if (assign.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return null;
+
+  // LHS: `arr[loopVar]`.
+  const lhs = assign.left;
+  if (!ts.isElementAccessExpression(lhs)) return null;
+  if (!ts.isIdentifier(lhs.expression) || lhs.expression.text !== arrName) return null;
+  if (!ts.isIdentifier(lhs.argumentExpression) || lhs.argumentExpression.text !== loopVar) return null;
+
+  // RHS must be pure (non-throwing) AND must not reference the array.
+  if (!isPureFillRhs(assign.right, arrName)) return null;
+
+  return boundExpr;
+}
+
+/**
+ * Is `expr` a "pure" fill RHS — guaranteed non-throwing and free of any read
+ * of `arrName`? Conservative: only literals, identifier reads, parenthesized
+ * versions of those, and unary / binary compositions of the above.
+ */
+function isPureFillRhs(expr: ts.Expression, arrName: string): boolean {
+  if (ts.isParenthesizedExpression(expr)) return isPureFillRhs(expr.expression, arrName);
+  if (ts.isNumericLiteral(expr)) return true;
+  if (expr.kind === ts.SyntaxKind.TrueKeyword || expr.kind === ts.SyntaxKind.FalseKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return true;
+  if (ts.isStringLiteral(expr)) return true;
+  if (ts.isIdentifier(expr)) {
+    // Plain identifier read is pure (variable access doesn't throw); but we
+    // must reject reads of the array under construction.
+    return expr.text !== arrName;
+  }
+  if (ts.isPrefixUnaryExpression(expr)) {
+    const op = expr.operator;
+    // Only allow safely-pure unary ops. `++`/`--` are mutations (could
+    // touch the array if the operand is a complex thing); we keep it
+    // simple and allow `+` `-` `~` `!` only.
+    if (
+      op === ts.SyntaxKind.PlusToken ||
+      op === ts.SyntaxKind.MinusToken ||
+      op === ts.SyntaxKind.TildeToken ||
+      op === ts.SyntaxKind.ExclamationToken
+    ) {
+      return isPureFillRhs(expr.operand, arrName);
+    }
+    return false;
+  }
+  if (ts.isBinaryExpression(expr)) {
+    // Reject assignment / compound-assignment.
+    const k = expr.operatorToken.kind;
+    if (
+      k === ts.SyntaxKind.EqualsToken ||
+      k === ts.SyntaxKind.PlusEqualsToken ||
+      k === ts.SyntaxKind.MinusEqualsToken ||
+      k === ts.SyntaxKind.AsteriskEqualsToken ||
+      k === ts.SyntaxKind.SlashEqualsToken ||
+      k === ts.SyntaxKind.PercentEqualsToken ||
+      k === ts.SyntaxKind.AmpersandEqualsToken ||
+      k === ts.SyntaxKind.BarEqualsToken ||
+      k === ts.SyntaxKind.CaretEqualsToken ||
+      k === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+      k === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+      k === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+      k === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+      k === ts.SyntaxKind.QuestionQuestionEqualsToken ||
+      k === ts.SyntaxKind.BarBarEqualsToken ||
+      k === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
+      k === ts.SyntaxKind.CommaToken
+    ) {
+      return false;
+    }
+    return isPureFillRhs(expr.left, arrName) && isPureFillRhs(expr.right, arrName);
+  }
+  return false;
+}
+
+/**
+ * Cheap walk that returns true iff `expr` doesn't textually reference
+ * the identifier `name`. We scan the AST and reject any Identifier whose
+ * text matches; PropertyAccessExpression names (the `.foo` part) are
+ * skipped because they are not variable references.
+ */
+function isExprFreeOfReference(expr: ts.Node, name: string): boolean {
+  if (ts.isIdentifier(expr)) return expr.text !== name;
+  if (ts.isPropertyAccessExpression(expr)) {
+    return isExprFreeOfReference(expr.expression, name);
+    // expr.name is a property *name*, not a variable reference — skipped.
+  }
+  let ok = true;
+  expr.forEachChild((child) => {
+    if (!ok) return;
+    if (!isExprFreeOfReference(child, name)) ok = false;
+  });
+  return ok;
+}
+
 export function compileArrayLiteral(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1406,6 +1601,13 @@ export function compileArrayLiteral(
   if (expr.elements.length === 0) {
     // Detect counted push loop pattern and preallocate (#1001)
     const prealloc = detectCountedPushLoopSize(expr);
+    // Detect counted dense-fill loop pattern (#1198) — sister of the
+    // push-loop matcher. When the array is followed by a
+    // `for (let i = 0; i < N; i++) arr[i] = pureExpr` loop, we know the
+    // final length is exactly N and we can pre-size both the data buffer
+    // and the vec.length field, eliminating the O(n²) grow-and-copy cost
+    // the per-write grow-on-demand path otherwise pays.
+    const fillBoundExpr = prealloc > 0 ? null : detectCountedFillLoopBound(expr);
 
     // Empty array — try to determine element type from contextual type (e.g. number[])
     let emptyElemKind = "externref";
@@ -1429,6 +1631,44 @@ export function compileArrayLiteral(
       reportError(ctx, expr, "Empty array literal: invalid vec type");
       return null;
     }
+
+    if (fillBoundExpr !== null) {
+      // Dense-fill prealloc (#1198): emit `vec.length = N` AND
+      // `vec.data = array.new_default(N)`. Setting length=N up front
+      // matches the post-loop observable state — `arr.length === N`
+      // after every iteration writes its slot — so the optimization
+      // preserves semantics for the canonical pattern detected.
+      //
+      // For a literal-numeric bound, fold to `i32.const N`.
+      // Otherwise compile the bound expression with an i32 hint and
+      // tee into a temp local so we can use it for both the struct's
+      // length field and the array.new_default size.
+      if (ts.isNumericLiteral(fillBoundExpr)) {
+        const n = Number(fillBoundExpr.text);
+        if (Number.isFinite(n) && n >= 0 && n <= 1_000_000_000) {
+          fctx.body.push({ op: "i32.const", value: n }); // length field
+          fctx.body.push({ op: "i32.const", value: n }); // size for array.new_default
+          fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+          fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
+          return { kind: "ref_null", typeIdx: vecTypeIdx };
+        }
+        // Fall through to the empty-allocation path on out-of-range
+        // literals; preserves grow-on-write semantics for pathological
+        // cases without changing observable behaviour.
+      } else {
+        // Identifier or expression bound. Compile with i32 hint and
+        // stash in a temp local so we can re-emit it for both fields.
+        const tmpN = allocTempLocal(fctx, { kind: "i32" });
+        compileExpression(ctx, fctx, fillBoundExpr, { kind: "i32" });
+        fctx.body.push({ op: "local.tee", index: tmpN }); // length field (top of stack)
+        fctx.body.push({ op: "local.get", index: tmpN }); // size for array.new_default
+        fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+        fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
+        releaseTempLocal(fctx, tmpN);
+        return { kind: "ref_null", typeIdx: vecTypeIdx };
+      }
+    }
+
     fctx.body.push({ op: "i32.const", value: 0 }); // length field (field 0)
     fctx.body.push({ op: "i32.const", value: prealloc > 0 ? prealloc : 0 }); // size for array.new_default (#1001: preallocate if counted push loop detected)
     fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx }); // data field (field 1)

--- a/tests/issue-1192.test.ts
+++ b/tests/issue-1192.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Regression tests for #1198 — pre-size dense arrays at allocation site.
+//
+// The codegen detects the canonical fill pattern
+//   const arr = []; for (let i = 0; i < N; i++) arr[i] = pureExpr;
+// and pre-sizes both the WasmGC backing array AND vec.length to N up
+// front. Both literal and identifier loop bounds are supported. The
+// matcher is conservative: bodies that could throw, references to
+// `arr` outside the indexed write, and non-canonical loop shapes all
+// fall back to the existing grow-on-write path.
+//
+// These tests verify behavioural equivalence (matching cases produce
+// the same array contents and length as the unoptimised path; non-
+// matching cases still work because they fall back). The performance
+// win is tracked by the competitive benchmark and is out of scope here.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function compileAndRun(source: string, fnName: string, args: ReadonlyArray<number>): Promise<unknown> {
+  // Compile as JS so empty `[]` initializers don't get inferred as `never[]`
+  // by the strict TS checker — matches the canonical `array-sum.js` shape
+  // the issue motivates.
+  const r = compile(source, { fileName: "t.js", allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports);
+  const fn = instance.exports[fnName] as (...a: number[]) => unknown;
+  return fn(...args);
+}
+
+describe("#1198 — pre-size dense arrays at allocation site", () => {
+  describe("matching patterns (pre-size triggers)", () => {
+    it("(a) parameter-bound fill returns correct length", async () => {
+      const source = `
+        export function run(n) {
+          const a = [];
+          for (let i = 0; i < n; i++) {
+            a[i] = i * 2;
+          }
+          return a.length;
+        }
+      `;
+      expect(await compileAndRun(source, "run", [10])).toBe(10);
+      expect(await compileAndRun(source, "run", [0])).toBe(0);
+      expect(await compileAndRun(source, "run", [1000])).toBe(1000);
+    });
+
+    it("(b) parameter-bound fill returns correct slot values", async () => {
+      const source = `
+        export function run(n) {
+          const a = [];
+          for (let i = 0; i < n; i++) {
+            a[i] = i * 2;
+          }
+          let sum = 0;
+          for (let j = 0; j < n; j++) {
+            sum = sum + a[j];
+          }
+          return sum;
+        }
+      `;
+      // Sum of i*2 for i in 0..9 = 2*(0+1+…+9) = 90
+      expect(await compileAndRun(source, "run", [10])).toBe(90);
+      // Sum of i*2 for i in 0..99 = 2*(99*100/2) = 9900
+      expect(await compileAndRun(source, "run", [100])).toBe(9900);
+    });
+
+    it("(c) literal-bound fill — original #1001 push pattern's static-N cousin", async () => {
+      const source = `
+        export function run() {
+          const a = [];
+          for (let i = 0; i < 100; i++) {
+            a[i] = i + 1;
+          }
+          return a[99];
+        }
+      `;
+      expect(await compileAndRun(source, "run", [])).toBe(100);
+    });
+
+    it("(d) array-sum benchmark shape — bitwise body", async () => {
+      const source = `
+        export function run(n) {
+          const values = [];
+          for (let i = 0; i < n; i++) {
+            values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+          }
+          let sum = 0;
+          for (let j = 0; j < n; j++) {
+            sum = (sum + values[j]) | 0;
+          }
+          return sum | 0;
+        }
+      `;
+      // Same shape as benchmarks/competitive/programs/array-sum.js. The
+      // important property is that the IR-claim path and the legacy
+      // path produce identical results — we can't test that here, but
+      // we can at least verify the result is deterministic.
+      const v10 = await compileAndRun(source, "run", [10]);
+      // For n=10, manually computed:
+      //   i=0:  0  ^ 0 & 1023 = 0
+      //   i=1:  17 ^ 0 & 1023 = 17
+      //   i=2:  34 ^ 0 & 1023 = 34
+      //   i=3:  51 ^ 0 & 1023 = 51
+      //   i=4:  68 ^ 0 & 1023 = 68
+      //   i=5:  85 ^ 0 & 1023 = 85
+      //   i=6:  102 ^ 0 & 1023 = 102
+      //   i=7:  119 ^ 0 & 1023 = 119
+      //   i=8:  136 ^ 1 & 1023 = 137
+      //   i=9:  153 ^ 1 & 1023 = 152
+      // sum = 0+17+34+51+68+85+102+119+137+152 = 765
+      expect(v10).toBe(765);
+    });
+  });
+
+  describe("non-matching patterns (fall back to grow-on-write)", () => {
+    it("(e) reading arr.length inside the body inhibits pre-size", async () => {
+      const source = `
+        export function run(n) {
+          const a = [];
+          for (let i = 0; i < n; i++) {
+            a[i] = a.length;
+          }
+          return a[5];
+        }
+      `;
+      // a.length grows-as-you-go: at iteration 5, a.length === 5 (a[0..4]
+      // already filled). Pre-sizing would make a.length === n on the very
+      // first iteration, so a[5] would equal n (10) instead of 5.
+      // The matcher rejects this shape, so behaviour is the grow-on-write
+      // value.
+      expect(await compileAndRun(source, "run", [10])).toBe(5);
+    });
+
+    it("(f) two-statement body inhibits pre-size", async () => {
+      // Body has a write followed by a no-op statement — the matcher
+      // rejects "more than one statement" before even inspecting them,
+      // so the pattern falls back to grow-on-write for the indexed
+      // write. The matcher's job is to stay conservative, not to be
+      // clever about which extra statements are safe.
+      const source = `
+        export function run(n) {
+          const a = [];
+          for (let i = 0; i < n; i++) {
+            a[i] = i;
+            let unused = i;
+          }
+          return a.length;
+        }
+      `;
+      // a[0..n-1] are filled by grow-on-write; final length === n.
+      expect(await compileAndRun(source, "run", [5])).toBe(5);
+    });
+
+    it("(g) non-canonical loop shape (while) inhibits pre-size", async () => {
+      const source = `
+        export function run(n) {
+          const a = [];
+          let i = 0;
+          while (i < n) {
+            a[i] = i;
+            i = i + 1;
+          }
+          return a.length;
+        }
+      `;
+      expect(await compileAndRun(source, "run", [5])).toBe(5);
+    });
+
+    it("(h) writing to a different index than loopVar inhibits pre-size", async () => {
+      const source = `
+        export function run(n) {
+          const a = [];
+          for (let i = 0; i < n; i++) {
+            a[i + 1] = i;
+          }
+          return a.length;
+        }
+      `;
+      // Writes go to index 1..n; a.length = n+1 in grow-on-write mode.
+      expect(await compileAndRun(source, "run", [5])).toBe(6);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `detectCountedFillLoopBound` matcher in `src/codegen/literals.ts` — sibling of the existing #1001 `detectCountedPushLoopSize`. When the canonical fill pattern follows the empty-array literal:

\`\`\`js
const arr = [];
for (let i = 0; i < N; i++) arr[i] = pureExpr;
\`\`\`

the codegen emits both the vec struct's `length` field AND `array.new_default`'s size from the same bound, so the post-allocation state matches the post-loop state the existing grow-on-write path would have produced. This eliminates the **O(n²) churn of growing the data buffer on every indexed write**.

Identifier/expression bounds (the array-sum benchmark shape `for (let i = 0; i < n; i++)`) are supported via a temp local that feeds both struct fields without re-evaluating the bound.

## Conservative match guards

The matcher rejects shapes whose pre-sizing would change observable semantics:

- Body must be **exactly one expression statement** — rejects two-statement bodies, `a.push(...)`, `if (...) { ... }` etc.
- LHS must be `arr[loopVar]` literally — rejects `arr[i+1]`, `arr[other]`, sparse writes.
- RHS must be **"pure"** — only NumericLiteral, Identifier, parenthesized, PrefixUnary `+ - ~ !`, BinaryExpression composing the above. Rejects calls / property access / element access (each could throw and leave a partial-fill length mismatching the pre-sized value).
- Neither the bound expression nor the RHS may reference the array under construction — rules out `a.length` reads, which would observe the pre-sized length immediately instead of grow-as-you-go.

## Test coverage

`tests/issue-1192.test.ts` (8 cases, all passing). Name retained from the issue's original cross-reference.

**Matching (pre-size triggers):**
- (a) parameter-bound fill returns correct length (n=0, 10, 1000)
- (b) parameter-bound fill returns correct slot values (sum of i*2)
- (c) literal-bound fill — static-N cousin of #1001 push-prealloc
- (d) array-sum benchmark shape — `((i * 17) ^ (i >>> 3)) & 1023`

**Non-matching (fall back to grow-on-write):**
- (e) reading `arr.length` inside body inhibits pre-size
- (f) two-statement body inhibits pre-size
- (g) non-canonical loop shape (`while`) inhibits pre-size
- (h) `arr[i + 1]` (different from loopVar) inhibits pre-size

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | array-sum 2× improvement target | Matcher fires on the benchmark shape; perf gain validated by competitive benchmark CI |
| 2 | `f(n) { const a = []; for (let i = 0; i < n; i++) a[i] = i*2; }` works | ✅ Tests (a) + (b) |
| 3 | Non-matching patterns fall back to grow-on-write | ✅ Tests (e)–(h) |
| 4 | New equivalence test `tests/issue-1192.test.ts` | ✅ 8 cases passing |
| 5 | CI test262 net delta ≥ 0 | ⏳ verified via this PR's CI |

## Out of scope (per issue notes)

- Sparse arrays (`a[100] = x` with no fill before) — matcher rejects.
- Two-loop fusion (#1195 escape analysis territory).
- Mixed-type arrays (#1197 territory).
- Throwing-body partial-fill semantics — handled by RHS-purity guard rejecting any body that could throw, so the pre-size optimization only fires on bodies whose grow-on-write semantics are equivalent.

## Test plan

- [x] `npx vitest run tests/issue-1192.test.ts` → 8/8 pass.
- [ ] Test262 sharded CI gate (this PR triggers it).
- [ ] Competitive benchmark verifies 2× improvement on array-sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)