### PR TITLE
fix(#1221): test262 harness — outer-catch leaks + FIXTURE dupe + iterator probe

### DIFF
--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -415,6 +415,32 @@ function restoreBuiltins() {
       );
       process.exit(1);
     }
+    // #1221: callability probe. The typeof check above only catches
+    // non-callable poison. A test that assigns a Wasm-throwing function
+    // (`Array.prototype[Symbol.iterator] = wasmInstance.exports.thrower`)
+    // and made the descriptor non-configurable bypasses the typeof check
+    // — but the very next `for...of` below (and every for-of in the TS
+    // compiler's internals) would invoke it and throw a
+    // WebAssembly.Exception. Without an exit here, that exception
+    // propagates out of restoreBuiltins → out of doCompile → caught at
+    // the outer try with status:"compile_error", error:"[object
+    // WebAssembly.Exception]" — and EVERY subsequent test in this fork
+    // hits the same trap (the blast radius can be ~100s of tests). Probe
+    // by calling it on an empty array; if it throws, the fork is
+    // unrecoverable — exit so the pool respawns.
+    try {
+      const probeIter = cur.call([]);
+      // Some valid iterators are objects without .next yet — calling
+      // .next() on the probe is the real correctness signal. Wrap so a
+      // throw from .next() also trips the FATAL branch.
+      if (probeIter && typeof probeIter.next === "function") probeIter.next();
+    } catch (probeErr) {
+      const kind = probeErr?.constructor?.name ?? typeof probeErr;
+      console.error(
+        `[unified-worker pid=${process.pid}] FATAL: Array.prototype[Symbol.iterator] throws when called (${kind}) — exiting for restart (#1221)`,
+      );
+      process.exit(1);
+    }
   }
 
   // Remove numeric-indexed accessor properties added to Array.prototype
@@ -968,13 +994,33 @@ process.on("message", async (msg) => {
       });
     }
   } catch (outerErr) {
-    process.send({
-      id,
-      status: "compile_error",
-      error: outerErr.message ?? String(outerErr),
-      compileMs,
-      execMs: performance.now() - execStart,
-    });
+    // #1221: A WebAssembly.Exception that escapes the inner try (e.g. thrown
+    // by `restoreBuiltins` walking a poisoned Symbol.iterator, or by a
+    // microtask resumed at an `await` boundary) is a runtime throw, not a
+    // compile failure. Route it through extractWasmExceptionMessage so the
+    // error text is meaningful instead of "[object WebAssembly.Exception]"
+    // and emit status:"fail" so the dashboard groups it with real runtime
+    // failures. The inner instantiate catch already handles the common case
+    // (#1155) — this closes the remaining outer-catch leak that produced up
+    // to ~1,176 misclassified rows in the test262 baseline.
+    if (outerErr instanceof WebAssembly.Exception) {
+      process.send({
+        id,
+        status: "fail",
+        error: extractWasmExceptionMessage(outerErr, instance ?? null),
+        isException: true,
+        compileMs,
+        execMs: performance.now() - execStart,
+      });
+    } else {
+      process.send({
+        id,
+        status: "compile_error",
+        error: outerErr.message ?? String(outerErr),
+        compileMs,
+        execMs: performance.now() - execStart,
+      });
+    }
   }
 
   // Drop Wasm references

--- a/scripts/wasm-exec-worker.mjs
+++ b/scripts/wasm-exec-worker.mjs
@@ -137,11 +137,29 @@ parentPort.on("message", async (msg) => {
       });
     }
   } catch (outerErr) {
-    reply({
-      ok: false,
-      error: outerErr.message ?? String(outerErr),
-      instantiateError: true,
-    });
+    // #1221: A WebAssembly.Exception escaping the inner tries (e.g. thrown
+    // from `restoreBuiltins` walking a poisoned Symbol.iterator, or a
+    // microtask resumed at an `await` boundary) is a runtime throw — not a
+    // compile/link failure. Stringify via extractWasmExceptionInfo so the
+    // harness records a useful runtime fail instead of compile_error
+    // (instantiateError:true) with text "[object WebAssembly.Exception]".
+    // The inner instantiate catch was fixed in #1155 — this closes the
+    // outer-catch leak that was missed.
+    if (outerErr instanceof WebAssembly.Exception) {
+      const info = extractWasmExceptionInfo(outerErr, instance ?? null);
+      reply({
+        ok: false,
+        error: info.message,
+        isException: true,
+        exceptionPayload: info.stack,
+      });
+    } else {
+      reply({
+        ok: false,
+        error: outerErr.message ?? String(outerErr),
+        instantiateError: true,
+      });
+    }
   } finally {
     // Drop references to Wasm module so GC can collect compiled code
     instance = null;

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -411,6 +411,14 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   }
                 }
               } catch (e: any) {
+                // #1221: recordResult() throws a ConformanceError after
+                // writing the JSONL row whenever status !== "pass". If we
+                // catch THAT and call recordResult again, we double-write
+                // the row (e.g. a "fail" row followed by a "compile_error"
+                // row prefixed "[fail] …"). Re-throw so the inner record
+                // is the only JSONL entry, matching the non-FIXTURE path
+                // which has no outer catch.
+                if (e instanceof ConformanceError) throw e;
                 recordResult(relPath, category, "compile_error", e.message ?? String(e), undefined, scopeInfo);
               }
               return;


### PR DESCRIPTION
## Summary

Three harness-only fixes targeting the ~256-test pass→compile_error flip cluster carrying `error: "[object WebAssembly.Exception]"` in the test262 baseline. Investigation: `plan/notes/wasmexception-flakiness.md`.

- **scripts/test262-worker.mjs** outer catch — branch on `instanceof WebAssembly.Exception` and route through `extractWasmExceptionMessage`, emit `status:"fail"` with meaningful text instead of `compile_error: "[object WebAssembly.Exception]"`. Inner catch was fixed in #1155; outer catch was missed.
- **scripts/wasm-exec-worker.mjs** outer catch — same fix for the legacy `worker_threads` path used by `tests/test262-vitest.test.ts`.
- **scripts/test262-worker.mjs `restoreBuiltins`** — add a callability probe (`Array.prototype[Symbol.iterator].call([]).next()`) and `process.exit(1)` on throw. The existing typeof check only catches non-callable poison; a callable Wasm-throwing function passes typeof and then triggers the `for-of` further down, flipping ~100 subsequent tests in the same fork. The probe caps blast radius to 1 test per fork-respawn.
- **tests/test262-shared.ts FIXTURE branch** — re-throw `ConformanceError` so `recordResult("fail", …)` is the single JSONL row instead of being doubled by the surrounding outer catch (which currently emits `[fail] [object WebAssembly.Exception]` rows alongside the original).

Refs #1155 — parent issue, partially fixed by inner-catch routing. This closes the remaining gap.

## Smoke verification

- `node --check` passes on both worker mjs files.
- `npx tsc --noEmit` clean for `tests/test262-shared.ts`.
- `/tmp/smoke-fixture-rethrow.mjs` confirms FIXTURE branch records exactly one row (`fail`) post-patch vs. two rows (`fail` + `compile_error: "[fail] …"`) pre-patch.
- No `src/codegen` changes — physical-impossibility override available if drift fires on CE-bucket regressions caused purely by reclassification.

## Expected CI signal

- `compile_error` bucket should drop by ~1,176 plain entries + 39 `[fail]`-prefixed entries.
- `fail` bucket may grow by some fraction (the runtime exceptions that were previously misclassified) — net of pass/fail reclassification.
- `pass` bucket should grow by tests where the Wasm exception was the expected behaviour (e.g. runtime-negative tests).
- Overall **net_per_test should be positive** because misclassified `compile_error` rows for runtime-throwing tests will reclassify to either `pass` (if expected) or `fail` (with proper diagnostics).

## Test plan

- [ ] CI test262 sharded run completes
- [ ] `error: "[object WebAssembly.Exception]"` count drops to near zero (target: < 50)
- [ ] No new compile_error buckets > 50
- [ ] net_per_test > 0
- [ ] Equivalence tests unaffected (no compiler-source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)