### PR TITLE
ci(#1217): test262 smoke-canary — fresh-cache double-run flip detector

### DIFF
--- a/.github/workflows/test262-canary.yml
+++ b/.github/workflows/test262-canary.yml
@@ -1,0 +1,279 @@
+name: Test262 Canary (engine determinism)
+
+# Smoke-canary for test262 engine determinism (#1217).
+#
+# Runs `Test262 Sharded` twice on `main` HEAD with **fresh cache** (no
+# restore-keys, no incremental cache hits) and reports the flip count —
+# the number of tests whose status differs between the two runs.
+#
+# A non-zero flip count means the test262 result is non-deterministic:
+# could be timing-sensitive `compile_timeout`s under runner load,
+# Promise micro-task ordering nondeterminism, or something more
+# substantive. The threshold is documented inline; tune it from the
+# initial baseline run before flipping the workflow into a hard gate.
+#
+# This workflow is purely OBSERVATIONAL — it never blocks PRs, never
+# touches the baseline, never refreshes any reports. It is the cheapest
+# mechanism to detect future drift regressions; downstream concerns
+# (flake quarantine, runner-pool isolation) are out of scope here.
+#
+# Triggered manually via `workflow_dispatch` and on a nightly schedule.
+# Acceptance criterion checklist for the issue lives in
+# plan/issues/sprints/46/1217.md.
+
+on:
+  schedule:
+    # Nightly at 04:00 UTC — outside peak runner-pool load so the flip
+    # count reflects engine determinism rather than CI runner contention.
+    # Adjust if it overlaps with other heavy workflows.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      flip_threshold:
+        description: "Flip count threshold (workflow fails if exceeded). Suggested: 10."
+        required: false
+        default: "10"
+        type: string
+      include_proposals:
+        description: "Include proposal tests (matches Test262 Sharded default)"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  # Serialize canary runs against themselves only — they don't conflict
+  # with the main `Test262 Sharded` workflow's cache (we use a fresh
+  # cache key) but two canary runs in flight would double the runner
+  # spend without adding signal.
+  group: test262-canary-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Two parallel runs of the same `main` HEAD. We mirror the matrix
+  # shape from `test262-sharded.yml` so the two runs use the same
+  # 16-shard parallel decomposition and produce JSONLs that
+  # `test262-canary-flip-count.ts` can compare directly.
+  test262-shard-run-a:
+    name: run A — shard ${{ matrix.chunk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    env:
+      COMPILER_POOL_SIZE: "4"
+      TEST262_INCLUDE_PROPOSALS: ${{ github.event_name != 'workflow_dispatch' && '1' || (inputs.include_proposals && '1' || '0') }}
+      RUN_TIMESTAMP: ${{ github.run_id }}-A-chunk${{ matrix.chunk }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      # NOTE: deliberately NO `actions/cache` step — fresh cache is the
+      # whole point of the canary. The key would otherwise let runs A
+      # and B share the same cached `.test262-cache` and produce
+      # artificially identical results.
+      - name: Build compiler bundles
+        run: |
+          pnpm run build:compiler-bundle
+          ./node_modules/.bin/esbuild src/runtime.ts --bundle --platform=node --format=esm \
+            --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
+      - name: Run shard (A)
+        run: |
+          mkdir -p vitest-blob
+          set +e
+          node node_modules/vitest/dist/cli.js run tests/test262-chunk${{ matrix.chunk }}.test.ts \
+            --reporter=blob \
+            --outputFile=vitest-blob/blob-A-${{ matrix.chunk }}.json
+          exit_code=$?
+          set -e
+          if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 1 ]; then
+            echo "Vitest exited with unexpected code $exit_code"
+            exit "$exit_code"
+          fi
+      - name: Upload run-A shard
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test262-canary-A-${{ matrix.chunk }}
+          path: |
+            benchmarks/results/test262-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+  test262-shard-run-b:
+    name: run B — shard ${{ matrix.chunk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    env:
+      COMPILER_POOL_SIZE: "4"
+      TEST262_INCLUDE_PROPOSALS: ${{ github.event_name != 'workflow_dispatch' && '1' || (inputs.include_proposals && '1' || '0') }}
+      RUN_TIMESTAMP: ${{ github.run_id }}-B-chunk${{ matrix.chunk }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      # No cache step — see run A for the rationale.
+      - name: Build compiler bundles
+        run: |
+          pnpm run build:compiler-bundle
+          ./node_modules/.bin/esbuild src/runtime.ts --bundle --platform=node --format=esm \
+            --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
+      - name: Run shard (B)
+        run: |
+          mkdir -p vitest-blob
+          set +e
+          node node_modules/vitest/dist/cli.js run tests/test262-chunk${{ matrix.chunk }}.test.ts \
+            --reporter=blob \
+            --outputFile=vitest-blob/blob-B-${{ matrix.chunk }}.json
+          exit_code=$?
+          set -e
+          if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 1 ]; then
+            echo "Vitest exited with unexpected code $exit_code"
+            exit "$exit_code"
+          fi
+      - name: Upload run-B shard
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test262-canary-B-${{ matrix.chunk }}
+          path: |
+            benchmarks/results/test262-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+  flip-count:
+    name: count flips
+    needs: [test262-shard-run-a, test262-shard-run-b]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+
+      - name: Download run A shards
+        uses: actions/download-artifact@v7
+        with:
+          path: shard-artifacts-A
+          pattern: test262-canary-A-*
+          merge-multiple: false
+      - name: Download run B shards
+        uses: actions/download-artifact@v7
+        with:
+          path: shard-artifacts-B
+          pattern: test262-canary-B-*
+          merge-multiple: false
+
+      - name: Merge shard JSONLs
+        run: |
+          mkdir -p canary-merged
+          find shard-artifacts-A -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > canary-merged/run-a.jsonl
+          find shard-artifacts-B -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > canary-merged/run-b.jsonl
+          # Sanity: both must have a substantial number of rows. A 0-row
+          # merge usually means a shard upload regressed silently.
+          A_LINES=$(wc -l < canary-merged/run-a.jsonl)
+          B_LINES=$(wc -l < canary-merged/run-b.jsonl)
+          echo "Run A lines: $A_LINES"
+          echo "Run B lines: $B_LINES"
+          if [ "$A_LINES" -lt 40000 ] || [ "$B_LINES" -lt 40000 ]; then
+            echo "::error::canary merge produced too few rows — refusing to compare"
+            exit 1
+          fi
+
+      # Threshold rationale (#1217 acceptance criterion #5):
+      #
+      # The initial value of 10 is conservative — it catches a meaningful
+      # determinism regression (e.g. a config change that doubles
+      # compile_timeout flap from ~5 to ~50) without false-firing on
+      # routine ~5–8 timeout-flap rounds we already observe (PR #104 saw
+      # 48 such rounds, all `compile_timeout` transitions). After the
+      # first few canary runs land their numbers in the issue comments,
+      # tune up or down based on observed median + p95.
+      #
+      # Override at dispatch time via the `flip_threshold` input.
+      - name: Run flip-count diff
+        id: flip
+        run: |
+          THRESHOLD="${{ github.event_name == 'workflow_dispatch' && inputs.flip_threshold || '10' }}"
+          set +e
+          npx tsx scripts/test262-canary-flip-count.ts \
+            canary-merged/run-a.jsonl \
+            canary-merged/run-b.jsonl \
+            --threshold "$THRESHOLD" \
+            > canary-merged/flip-report.txt
+          exit_code=$?
+          set -e
+          # The script always prints a JSON summary on the last line.
+          tail -n1 canary-merged/flip-report.txt > canary-merged/flip-summary.json
+          cat canary-merged/flip-report.txt
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          # Don't `exit $exit_code` here — let the next step decide
+          # whether a non-zero is a hard fail or a warning.
+
+      - name: Upload canary report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test262-canary-report
+          path: |
+            canary-merged/run-a.jsonl
+            canary-merged/run-b.jsonl
+            canary-merged/flip-report.txt
+            canary-merged/flip-summary.json
+          if-no-files-found: warn
+
+      - name: Annotate workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Test262 Canary — engine determinism"
+            echo
+            echo '```json'
+            cat canary-merged/flip-summary.json
+            echo '```'
+            echo
+            echo '### Flip report'
+            echo
+            echo '```'
+            cat canary-merged/flip-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on excessive flips
+        if: steps.flip.outputs.exit_code == '1'
+        run: |
+          echo "::error::test262 canary flip count exceeds threshold — engine determinism has regressed"
+          cat canary-merged/flip-report.txt
+          exit 1

--- a/plan/issues/sprints/46/1217.md
+++ b/plan/issues/sprints/46/1217.md
@@ -2,7 +2,7 @@
 id: 1217
 title: "ci(test262): smoke-canary — re-run main HEAD twice with fresh cache, fail if flip rate > 0"
 sprint: 46
-status: ready
+status: in-progress
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,12 +11,80 @@ area: ci
 language_feature: n/a
 goal: ci-stability
 created: 2026-04-30
-updated: 2026-04-30
+updated: 2026-05-01
 es_edition: n/a
 depends_on: []
 related: [1190, 1191, 1192, 1189]
 origin: split from #1190 acceptance criterion #5 — "Land a canary mechanism to detect future drift regressions". Sprint 46 closed #1190 by splitting open work into sub-issues; this is the canary one.
 ---
+
+## Implementation status (2026-05-01, dev-2)
+
+Implemented as a new GitHub Actions workflow plus a small flip-count
+diff script. The canary is **purely observational** — it never blocks
+PRs, never touches the baseline, never refreshes any reports.
+
+### Files
+
+- `.github/workflows/test262-canary.yml` — runs `Test262 Sharded`
+  twice on `main` HEAD with **no** `actions/cache` step (the whole
+  point of the canary is fresh-cache reproducibility). Two parallel
+  matrix jobs (`test262-shard-run-a` / `test262-shard-run-b`) emit
+  the per-shard JSONLs; a third job (`flip-count`) merges and diffs.
+- `scripts/test262-canary-flip-count.ts` — symmetric JSONL diff that
+  counts flips (any test whose status differs between runs A and B).
+  Bucketizes flips into `flips_real` (excluding `compile_timeout`
+  transitions, which are timing noise) and `flips_compile_timeout`.
+  Emits a JSON summary on stdout's last line for downstream parsing.
+  Exits 0 on flips ≤ threshold, 1 otherwise, 2 on IO/invocation
+  errors.
+
+### Triggers
+
+- Nightly cron at `0 4 * * *` UTC (outside peak runner-pool load).
+- `workflow_dispatch` with overridable `flip_threshold` and
+  `include_proposals` inputs.
+
+### Threshold rationale
+
+Initial threshold: **10** (set in the workflow's `flip_threshold`
+input default). Documented inline. Captures meaningful determinism
+regressions (e.g. a config change that doubles flap count) without
+false-firing on the routine 5–8 timeout-flap baseline we already
+observe (PR #104 saw 48 such transitions, mostly `compile_timeout`).
+
+After the first few canary runs land their numbers in the workflow
+summary, tune up or down based on observed median + p95.
+
+### Acceptance criteria
+
+- [x] New workflow `.github/workflows/test262-canary.yml` runs on
+      schedule (nightly) and on `workflow_dispatch`.
+- [x] Workflow runs main HEAD twice with no `actions/cache` step
+      (fresh build per run).
+- [x] Workflow output reports flip count distinctly from regression
+      count via `flips`, `flips_real`, `flips_compile_timeout` fields
+      in the JSON summary.
+- [x] If flip count > threshold, workflow fails with a high-priority
+      `::error::` annotation plus a step summary.
+- [x] Threshold value and rationale documented in the workflow file
+      inline comment.
+- [ ] Initial baseline of flip count measured in the issue's comments
+      after first run — **pending first scheduled run**.
+
+### Local smoke test
+
+```bash
+$ npx tsx scripts/test262-canary-flip-count.ts /tmp/run-a.jsonl /tmp/run-b.jsonl --threshold 10
+…
+  Flips:                  3
+  Real (excl. timeouts):  1
+  Compile-timeout flips:  2
+  Threshold: 10    Result: PASS
+{"total_a":6,…,"flips":3,"flips_real":1,"flips_compile_timeout":2,…}
+$ echo $?
+0
+```
 
 # #1217 — Smoke-canary: detect future test262 drift regressions
 

--- a/scripts/test262-canary-flip-count.ts
+++ b/scripts/test262-canary-flip-count.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env npx tsx
+/**
+ * test262-canary-flip-count.ts — Compare two test262 JSONL result files
+ * symmetrically and count "flips" (any test whose status differs between
+ * the two runs).
+ *
+ * Used by the .github/workflows/test262-canary.yml workflow (#1217) to
+ * measure engine determinism: when we run main HEAD twice with no cache,
+ * a non-zero flip count means the test262 result is non-deterministic
+ * (timing-sensitive compile_timeouts, runner load flap, etc.). The
+ * workflow fails if the flip count exceeds a documented threshold.
+ *
+ * Unlike `diff-test262.ts` (which has a baseline/candidate distinction
+ * and reports regressions vs improvements), this script is symmetric:
+ * any pair of differing statuses counts as a single flip. Compile_timeout
+ * transitions are flagged separately so we can see whether the noise is
+ * runner-load timing or something more substantive.
+ *
+ * Usage:
+ *   npx tsx scripts/test262-canary-flip-count.ts <run-a.jsonl> <run-b.jsonl> [--quiet] [--threshold N]
+ *
+ * Exit codes:
+ *   0  flip count <= threshold
+ *   1  flip count > threshold
+ *   2  invocation / IO error
+ *
+ * Output (JSON, last line of stdout):
+ *   {"total_a":N,"total_b":M,"common":K,"flips":F,"flips_real":FR,
+ *    "flips_compile_timeout":CT,"top_buckets":[...],"threshold":T}
+ */
+
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
+
+interface TestResult {
+  file: string;
+  status: string;
+}
+
+type StatusMap = Map<string, string>;
+
+async function loadJsonl(path: string): Promise<StatusMap> {
+  const map: StatusMap = new Map();
+  const rl = createInterface({ input: createReadStream(path) });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line) as TestResult;
+      if (entry.file && typeof entry.status === "string") {
+        map.set(entry.file, entry.status);
+      }
+    } catch {
+      // skip malformed lines — keep best-effort parsing parity with diff-test262.ts
+    }
+  }
+  return map;
+}
+
+function bucketPath(file: string, depth: number = 5): string {
+  return file.split("/").slice(0, depth).join("/");
+}
+
+interface FlipReport {
+  total_a: number;
+  total_b: number;
+  common: number;
+  flips: number;
+  flips_real: number;
+  flips_compile_timeout: number;
+  flips_only_in_a: number;
+  flips_only_in_b: number;
+  top_buckets: Array<[string, number]>;
+  threshold: number;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const quiet = args.includes("--quiet") || args.includes("-q");
+  const thresholdArg = args.indexOf("--threshold");
+  const threshold = thresholdArg >= 0 ? Math.max(0, parseInt(args[thresholdArg + 1] ?? "10", 10)) : 10;
+  const positional = args.filter((a, i) => {
+    if (a === "--quiet" || a === "-q") return false;
+    if (a === "--threshold") return false;
+    if (i > 0 && args[i - 1] === "--threshold") return false;
+    return true;
+  });
+
+  if (positional.length < 2 || positional.includes("--help") || positional.includes("-h")) {
+    process.stderr.write(
+      `Usage: npx tsx scripts/test262-canary-flip-count.ts <run-a.jsonl> <run-b.jsonl> [--quiet] [--threshold N]\n`,
+    );
+    process.stderr.write(`\nCompare two test262 result JSONLs symmetrically; report flip count.\n`);
+    process.stderr.write(`Exit code 1 if flip count exceeds --threshold (default: 10).\n`);
+    process.exit(2);
+  }
+
+  const aPath = positional[0]!;
+  const bPath = positional[1]!;
+
+  let runA: StatusMap;
+  let runB: StatusMap;
+  try {
+    [runA, runB] = await Promise.all([loadJsonl(aPath), loadJsonl(bPath)]);
+  } catch (err) {
+    process.stderr.write(`Error reading inputs: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+    return;
+  }
+
+  // Collect flips. A "flip" is any test that appears in both runs with
+  // different statuses. We bucket compile_timeout transitions separately
+  // so the workflow can tell engine determinism from runner-load noise.
+  const flippedFiles: string[] = [];
+  const flippedCompileTimeoutFiles: string[] = [];
+  const seen = new Set<string>();
+
+  for (const [file, statusA] of runA) {
+    seen.add(file);
+    const statusB = runB.get(file);
+    if (statusB === undefined) continue; // only-in-a, counted separately
+    if (statusA === statusB) continue;
+    flippedFiles.push(file);
+    if (statusA === "compile_timeout" || statusB === "compile_timeout") {
+      flippedCompileTimeoutFiles.push(file);
+    }
+  }
+
+  const onlyInA: string[] = [];
+  const onlyInB: string[] = [];
+  for (const file of runA.keys()) if (!runB.has(file)) onlyInA.push(file);
+  for (const file of runB.keys()) if (!runA.has(file)) onlyInB.push(file);
+
+  // Bucket flips by path prefix for at-a-glance inspection of which
+  // areas drift the most. Mirrors the bucket-by-path analysis used by
+  // `/dev-self-merge`.
+  const bucketCounts = new Map<string, number>();
+  for (const f of flippedFiles) {
+    const b = bucketPath(f);
+    bucketCounts.set(b, (bucketCounts.get(b) ?? 0) + 1);
+  }
+  const topBuckets = [...bucketCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+  const report: FlipReport = {
+    total_a: runA.size,
+    total_b: runB.size,
+    common: runA.size - onlyInA.length,
+    flips: flippedFiles.length,
+    flips_real: flippedFiles.length - flippedCompileTimeoutFiles.length,
+    flips_compile_timeout: flippedCompileTimeoutFiles.length,
+    flips_only_in_a: onlyInA.length,
+    flips_only_in_b: onlyInB.length,
+    top_buckets: topBuckets,
+    threshold,
+  };
+
+  if (!quiet) {
+    process.stdout.write(`============================================================\n`);
+    process.stdout.write(`  test262 canary flip-count\n`);
+    process.stdout.write(`============================================================\n\n`);
+    process.stdout.write(`  Run A: ${aPath}  (${report.total_a} tests)\n`);
+    process.stdout.write(`  Run B: ${bPath}  (${report.total_b} tests)\n`);
+    process.stdout.write(`  Common: ${report.common} tests\n\n`);
+    process.stdout.write(`  Flips:                  ${report.flips}\n`);
+    process.stdout.write(`  Real (excl. timeouts):  ${report.flips_real}\n`);
+    process.stdout.write(`  Compile-timeout flips:  ${report.flips_compile_timeout}\n`);
+    if (report.flips_only_in_a > 0 || report.flips_only_in_b > 0) {
+      process.stdout.write(`  Only-in-A: ${report.flips_only_in_a}    Only-in-B: ${report.flips_only_in_b}\n`);
+    }
+    if (topBuckets.length > 0) {
+      process.stdout.write(`\n  Top flip buckets (by path prefix, len 5):\n`);
+      for (const [path, count] of topBuckets) {
+        process.stdout.write(`    ${count.toString().padStart(4)}  ${path}\n`);
+      }
+    }
+    if (report.flips_real > 0 || report.flips_compile_timeout > 0) {
+      process.stdout.write(`\n  Sample flipped files (first 10):\n`);
+      for (const f of flippedFiles.slice(0, 10)) {
+        process.stdout.write(`    ${runA.get(f)} ↔ ${runB.get(f)}    ${f}\n`);
+      }
+    }
+    process.stdout.write(`\n  Threshold: ${threshold}    Result: `);
+    process.stdout.write(report.flips > threshold ? "FAIL\n" : "PASS\n");
+    process.stdout.write(`\n`);
+  }
+
+  // Always emit the JSON summary on the last line so callers can
+  // capture it with `tee` + `tail -n1` even when the human-readable
+  // section is enabled.
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+
+  process.exit(report.flips > threshold ? 1 : 0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

New nightly + workflow_dispatch workflow that runs `Test262 Sharded` twice on `main` HEAD with **no `actions/cache` step** (fresh build per run) and reports flip count: the number of tests whose status differs between runs A and B. Purely **observational** — never blocks PRs, never touches the baseline.

Closes the observability gap from #1190 acceptance criterion #5: detect future drift regressions before they start producing false positives at the merge-gate.

## Implementation

- **`.github/workflows/test262-canary.yml`** — two parallel matrix jobs (`test262-shard-run-a` / `test262-shard-run-b`) emit per-shard JSONLs; a third job (`flip-count`) merges and diffs. Mirrors the `test262-sharded.yml` matrix shape but without any cache step (the whole point — without fresh cache the two runs would replay each other).
- **`scripts/test262-canary-flip-count.ts`** — symmetric JSONL diff that bucketises flips into `flips_real` (excluding `compile_timeout` transitions, which are timing noise) and `flips_compile_timeout`. Emits a JSON summary on stdout's last line for downstream parsing. Exits 0 on `flips ≤ threshold`, 1 otherwise, 2 on IO errors.

### Threshold rationale

Initial value: **10** (documented inline). Captures meaningful determinism regressions (e.g. a config change that doubles flap count) without false-firing on the routine 5–8 timeout-flap baseline (PR #104 saw 48 transitions, mostly `compile_timeout`). Override at dispatch time via `flip_threshold` input. Tune up/down after the first few canary runs land their numbers in the workflow summary.

### Triggers

- `cron: 0 4 * * *` UTC (outside peak runner-pool load)
- `workflow_dispatch` with overridable `flip_threshold` and `include_proposals`

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | New workflow runs on schedule + workflow_dispatch | ✅ |
| 2 | Workflow runs main HEAD twice with no `actions/cache` step | ✅ |
| 3 | Workflow output reports flip count distinctly from regression count | ✅ JSON summary fields: `flips`, `flips_real`, `flips_compile_timeout` |
| 4 | Workflow fails with `::error::` if flip count > threshold | ✅ |
| 5 | Threshold value + rationale documented inline | ✅ |
| 6 | Initial flip baseline measured | ⏳ pending first scheduled run |

## Out of scope (per issue notes)

- Statistical merge-gate metric (#1190 Q2 — separate concern, deferred).
- Per-test flake quarantine list (would solve the symptom but not the observability problem).
- Cross-Node-version flap detection (separate concern).

## Test plan

- [x] Local smoke-test of `scripts/test262-canary-flip-count.ts` with synthetic JSONLs:
      - threshold=10, 3 flips → exit 0, PASS reported.
      - threshold=2, 3 flips → exit 1, FAIL reported.
      - JSON summary on stdout's last line for both.
      - Compile_timeout transitions correctly classified out of `flips_real`.
- [ ] First nightly run will land flip count baseline in the issue's comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)