### PR TITLE
feat(#1217): test262 smoke-canary for engine determinism drift

### DIFF
--- a/.github/workflows/test262-canary.yml
+++ b/.github/workflows/test262-canary.yml
@@ -1,0 +1,210 @@
+name: Test262 canary (drift detector)
+
+# Runs main HEAD's test262 conformance suite TWICE with fresh caches and
+# diffs the two results. The diff = "flip count" — tests that flipped
+# pass↔non-pass between two identical runs of the same compiler. Any
+# non-zero flip count is engine non-determinism (vitest concurrency,
+# wasmtime/V8 jitter, host import races, GC scheduler noise, etc.) — NOT
+# a compiler regression.
+#
+# Why: after #1171 / #1192 / #1191 closed the major drift sources, residual
+# non-deterministic flips still cause false positives in the dev-self-merge
+# regression gate (PR #104 audit found 48 non-CT regressions on a docs-only
+# change). We don't have a continuous mechanism to know whether drift
+# is getting WORSE — a future change to vitest config, node version, or
+# test infrastructure could silently regress determinism without anyone
+# noticing until the gate starts producing more false positives.
+#
+# This canary closes that observability gap.
+#
+# Cost: 2 × 16 chunks ≈ 32 parallel runners, ~5–10 min wall-clock,
+# ~160 CPU-min per run. Acceptable for nightly.
+#
+# Threshold rationale:
+#   N=10 initial. Picked deliberately above the floor we expect on a
+#   well-behaved run (~0–5 flips driven by wasmtime startup jitter and
+#   vitest worker non-determinism) but below the sprint-45-era drift
+#   levels (~30–50 flips). Tune after the first 2–3 nightly runs once
+#   we have a real distribution. See acceptance criteria of #1217.
+
+on:
+  workflow_dispatch:
+    inputs:
+      flip_threshold:
+        description: "Fail the run if flip count exceeds this. Default 10."
+        required: false
+        default: "10"
+        type: string
+  schedule:
+    # Daily at 03:30 UTC — picked to land before the workday starts and
+    # avoid colliding with the test262-nightly schedule (which runs the
+    # main suite, not the canary).
+    - cron: "30 3 * * *"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FLIP_THRESHOLD: ${{ inputs.flip_threshold || '10' }}
+
+concurrency:
+  group: test262-canary
+  cancel-in-progress: false
+
+jobs:
+  canary-shard:
+    name: canary run ${{ matrix.run }} chunk ${{ matrix.chunk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two independent runs of the same SHA, each sharded across 16 chunks.
+        run: [a, b]
+        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+
+    env:
+      COMPILER_POOL_SIZE: "4"
+      TEST262_INCLUDE_PROPOSALS: "1"
+      RUN_TIMESTAMP: ${{ github.run_id }}-${{ matrix.run }}-chunk${{ matrix.chunk }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Deliberately NO `actions/cache` step here — the whole point of the
+      # canary is to measure non-determinism on a cold cache, so each run
+      # must compile every test from scratch.
+
+      - name: Build compiler bundles
+        run: |
+          pnpm run build:compiler-bundle
+          ./node_modules/.bin/esbuild src/runtime.ts --bundle --platform=node --format=esm \
+            --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
+
+      - name: Run shard
+        run: |
+          mkdir -p vitest-blob
+          set +e
+          node node_modules/vitest/dist/cli.js run tests/test262-chunk${{ matrix.chunk }}.test.ts \
+            --reporter=blob \
+            --outputFile=vitest-blob/blob-${{ matrix.run }}-${{ matrix.chunk }}.json
+          exit_code=$?
+          set -e
+          # Vitest exit codes 0 (all-pass) and 1 (any test failure) are both
+          # success signals for the canary — we only care about producing a
+          # JSONL artifact. Any other code (crash, OOM, etc.) is a real fail.
+          if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 1 ]; then
+            echo "Vitest exited with unexpected code $exit_code"
+            exit "$exit_code"
+          fi
+
+      - name: Upload shard artifact
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: canary-${{ matrix.run }}-shard-${{ matrix.chunk }}
+          path: |
+            benchmarks/results/test262-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+  compare:
+    name: canary compare runs
+    needs: canary-shard
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Download canary run-a shards
+        uses: actions/download-artifact@v7
+        with:
+          path: shards/run-a
+          pattern: canary-a-shard-*
+          merge-multiple: false
+
+      - name: Download canary run-b shards
+        uses: actions/download-artifact@v7
+        with:
+          path: shards/run-b
+          pattern: canary-b-shard-*
+          merge-multiple: false
+
+      - name: Merge run-a JSONL
+        run: |
+          mkdir -p merged
+          find shards/run-a -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged/run-a.jsonl
+          test -s merged/run-a.jsonl
+
+      - name: Merge run-b JSONL
+        run: |
+          find shards/run-b -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged/run-b.jsonl
+          test -s merged/run-b.jsonl
+
+      - name: Compute flip count
+        id: diff
+        run: |
+          npx tsx scripts/test262-canary-diff.ts merged/run-a.jsonl merged/run-b.jsonl > canary-report.txt
+          cat canary-report.txt
+          # Extract the flip count for the gate step (last line is "FLIP_COUNT=N")
+          flip=$(grep '^FLIP_COUNT=' canary-report.txt | tail -1 | cut -d= -f2)
+          echo "flip_count=$flip" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canary report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test262-canary-report
+          path: |
+            canary-report.txt
+            merged/run-a.jsonl
+            merged/run-b.jsonl
+          if-no-files-found: error
+
+      - name: Fail if flip count exceeds threshold
+        if: steps.diff.outputs.flip_count != ''
+        run: |
+          flip="${{ steps.diff.outputs.flip_count }}"
+          threshold="${FLIP_THRESHOLD}"
+          if [ "$flip" -gt "$threshold" ]; then
+            echo "::error::test262 canary detected $flip flips between two identical runs (threshold: $threshold)"
+            echo "This indicates engine non-determinism above the acceptable baseline."
+            echo "See canary-report artifact for which tests flipped, and #1217 for context."
+            exit 1
+          else
+            echo "::notice::test262 canary detected $flip flips (threshold: $threshold) — within tolerance"
+          fi

--- a/plan/issues/sprints/46/1217.md
+++ b/plan/issues/sprints/46/1217.md
@@ -2,7 +2,7 @@
 id: 1217
 title: "ci(test262): smoke-canary — re-run main HEAD twice with fresh cache, fail if flip rate > 0"
 sprint: 46
-status: ready
+status: in-progress
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,7 +11,7 @@ area: ci
 language_feature: n/a
 goal: ci-stability
 created: 2026-04-30
-updated: 2026-04-30
+updated: 2026-05-01
 es_edition: n/a
 depends_on: []
 related: [1190, 1191, 1192, 1189]
@@ -81,3 +81,41 @@ Without the canary, we're flying blind.
   per-test status differences. Similar to `scripts/regression-diff.mjs`
   but symmetric (no baseline/candidate distinction).
 - CPU budget: ~80 CPU-min × 2 = 160 CPU-min/run. Acceptable for nightly.
+
+## Implementation notes (2026-05-01)
+
+Shipped:
+
+- `.github/workflows/test262-canary.yml` — daily-scheduled (03:30 UTC)
+  + `workflow_dispatch` trigger. Two jobs:
+  - `canary-shard` with a 2D matrix `run: [a, b] × chunk: [1..16]` =
+    32 parallel shards. **No `actions/cache` step** — every chunk
+    compiles cold so the canary measures cold-start non-determinism.
+  - `compare` depends on `canary-shard`, downloads both runs'
+    artifacts, merges per-run, runs the diff script, fails the
+    workflow if flip count exceeds the threshold (default 10, override
+    via `workflow_dispatch.inputs.flip_threshold`).
+- `scripts/test262-canary-diff.ts` — symmetric diff. Categorises tests
+  as match / flip / noise / missing. "Flip" = `pass <-> non-pass` —
+  the headline metric. Last line is `FLIP_COUNT=N` for cheap CI grep.
+- Smoke-tested locally with synthetic JSONLs: correctly identifies
+  1 flip, 1 noise, 2 missing, 2 match.
+
+### Threshold rationale (initial)
+
+- `N=10` initial. Picked deliberately above the floor we expect on a
+  well-behaved run (~0–5 flips driven by wasmtime startup jitter and
+  vitest worker non-determinism) but below the sprint-45-era drift
+  levels (~30–50 flips).
+- Tune after the first 2–3 nightly runs once we have a real
+  distribution. Initial-baseline measurement is acceptance criterion
+  #6 — capture in this issue's notes after the first run lands.
+
+### Cost / observability
+
+- Cost: 2 × 16 chunks ≈ 32 parallel runners, ~5–10 min wall-clock,
+  ~160 CPU-min per run. One nightly = ~5,000 CPU-min/month — fine.
+- Observability: when the canary fails, the `test262-canary-report`
+  artifact has the full diff (flip list, noise list, missing list).
+  The PR-author or on-call dev can then decide whether to triage as
+  flap-worthy or shrug it off as transient.

--- a/scripts/test262-canary-diff.ts
+++ b/scripts/test262-canary-diff.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env -S npx tsx
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1217 — Test262 canary diff. Symmetric (no baseline/candidate concept):
+// counts tests that flipped pass↔non-pass between two runs of the same SHA.
+//
+// Usage:
+//   npx tsx scripts/test262-canary-diff.ts <run-a.jsonl> <run-b.jsonl>
+//
+// The script writes a human-readable summary to stdout, and on the LAST
+// line writes `FLIP_COUNT=<N>` so a CI step can grep it cheaply.
+
+import { readFileSync } from "node:fs";
+
+interface Entry {
+  file: string;
+  status: string;
+}
+
+function loadResults(path: string): Map<string, string> {
+  const raw = readFileSync(path, "utf-8");
+  const out = new Map<string, string>();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const d = JSON.parse(line) as Partial<Entry>;
+      if (typeof d.file === "string" && typeof d.status === "string") {
+        // Last write wins — JSONL may contain duplicates from re-runs.
+        out.set(d.file, d.status);
+      }
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const [, , aPath, bPath] = process.argv;
+  if (!aPath || !bPath) {
+    console.error("usage: test262-canary-diff.ts <run-a.jsonl> <run-b.jsonl>");
+    process.exit(2);
+  }
+
+  const a = loadResults(aPath);
+  const b = loadResults(bPath);
+
+  // Walk the union of file paths.
+  const files = new Set<string>([...a.keys(), ...b.keys()]);
+
+  // Categorise each test:
+  //   - "match"    — same status in both runs
+  //   - "flip"     — pass in one, non-pass in the other (the headline metric)
+  //   - "noise"    — different non-pass statuses (e.g. fail↔compile_error);
+  //                  meaningful only insofar as it shows non-determinism in
+  //                  the failure path, separate from the pass↔fail metric
+  //   - "missing"  — only in one of the two runs (probably a shard that
+  //                  failed to upload an artifact; counted but reported)
+  let match = 0;
+  let flip = 0;
+  let noise = 0;
+  let missing = 0;
+  const flippedFiles: { file: string; a: string; b: string }[] = [];
+  const missingFiles: { file: string; only: "a" | "b"; status: string }[] = [];
+  const noiseFiles: { file: string; a: string; b: string }[] = [];
+
+  for (const file of files) {
+    const sa = a.get(file);
+    const sb = b.get(file);
+    if (sa === undefined || sb === undefined) {
+      missing++;
+      missingFiles.push({
+        file,
+        only: sa === undefined ? "b" : "a",
+        status: (sa ?? sb) as string,
+      });
+      continue;
+    }
+    if (sa === sb) {
+      match++;
+      continue;
+    }
+    const aPass = sa === "pass";
+    const bPass = sb === "pass";
+    if (aPass !== bPass) {
+      flip++;
+      flippedFiles.push({ file, a: sa, b: sb });
+    } else {
+      noise++;
+      noiseFiles.push({ file, a: sa, b: sb });
+    }
+  }
+
+  console.log("# Test262 canary diff");
+  console.log("");
+  console.log(`Run A: ${a.size} entries`);
+  console.log(`Run B: ${b.size} entries`);
+  console.log(`Union: ${files.size} unique test paths`);
+  console.log("");
+  console.log(`  Match (same status):                 ${match}`);
+  console.log(`  Flip (pass <-> non-pass):            ${flip}    <-- THIS IS THE HEADLINE`);
+  console.log(`  Noise (different non-pass statuses): ${noise}`);
+  console.log(`  Missing (only in one run):           ${missing}`);
+  console.log("");
+
+  if (flip > 0) {
+    console.log("## Flipped tests (top 20)");
+    console.log("");
+    for (const f of flippedFiles.slice(0, 20)) {
+      console.log(`  ${f.file}: ${f.a} <-> ${f.b}`);
+    }
+    if (flippedFiles.length > 20) console.log(`  ... ${flippedFiles.length - 20} more`);
+    console.log("");
+  }
+
+  if (noise > 0) {
+    console.log("## Noise (different non-pass statuses, top 10)");
+    console.log("");
+    for (const f of noiseFiles.slice(0, 10)) {
+      console.log(`  ${f.file}: ${f.a} <-> ${f.b}`);
+    }
+    if (noiseFiles.length > 10) console.log(`  ... ${noiseFiles.length - 10} more`);
+    console.log("");
+  }
+
+  if (missing > 0) {
+    console.log("## Missing in one run (top 10)");
+    console.log("");
+    for (const f of missingFiles.slice(0, 10)) {
+      console.log(`  ${f.file}: only in run-${f.only === "a" ? "b" : "a"} (${f.status})`);
+    }
+    if (missingFiles.length > 10) console.log(`  ... ${missingFiles.length - 10} more`);
+    console.log("");
+  }
+
+  // Last line — the CI step greps for this.
+  console.log(`FLIP_COUNT=${flip}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes #1217.

Daily-scheduled (03:30 UTC) + `workflow_dispatch` CI workflow that runs the test262 conformance suite TWICE on the same SHA with FRESH caches and diffs the two results. The diff = "flip count" — tests that flipped `pass ↔ non-pass` between two identical runs of the same compiler. Any non-zero flip count is engine non-determinism (vitest concurrency, wasmtime/V8 jitter, host-import races, GC scheduler noise, etc.) — NOT a compiler regression.

## Why now

After #1171 / #1192 / #1191 closed the major drift sources, residual non-deterministic flips still cause false positives in the dev-self-merge regression gate (PR #104 audit found 48 non-CT regressions on a docs-only change — same pattern we hit on every PR today). We don't have a continuous mechanism to know whether drift is getting **worse** — a future vitest/node/test-infra change could silently regress determinism. This canary closes that gap.

## What ships

- **`.github/workflows/test262-canary.yml`** — two jobs:
  - `canary-shard` with 2D matrix `run: [a, b] × chunk: [1..16]` = 32 parallel shards. **No `actions/cache` step** — every chunk compiles cold so the canary measures cold-start non-determinism.
  - `compare` depends on `canary-shard`, downloads both runs' artifacts, merges per-run, runs the diff script, fails the workflow if flip count exceeds the threshold (default 10, overridable via `workflow_dispatch.inputs.flip_threshold`).
- **`scripts/test262-canary-diff.ts`** — symmetric diff tool. Categorises tests as match / flip / noise / missing. "Flip" = `pass ↔ non-pass`, the headline metric. Last line is `FLIP_COUNT=N` for cheap CI grep. Smoke-tested locally.

## Threshold rationale (initial N=10)

Picked deliberately above the floor we expect on a well-behaved run (~0–5 flips from wasmtime startup jitter + vitest worker non-determinism) but below the sprint-45-era drift levels (~30–50). Tune after the first 2–3 nightly runs land and we have a real distribution.

## Cost

2 × 16 chunks × ~5–10 min wall-clock × 1 run/day ≈ ~5,000 CPU-min/month. Acceptable.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Diff script smoke-tested with synthetic JSONLs (correctly identified 1 flip, 1 noise, 2 missing, 2 match; output `FLIP_COUNT=1`)
- [x] Workflow YAML reviewed against `test262-sharded.yml` for matrix correctness
- [ ] First nightly run lands → measure baseline flip rate, document in issue notes

## Acceptance criteria

- [x] AC #1 — new workflow at `test262-canary.yml`, runs on schedule + workflow_dispatch
- [x] AC #2 — `actions/cache` step omitted (cold-start runs)
- [x] AC #3 — flip count distinct from regression count (it's labeled "flip" — only counts pass↔non-pass)
- [x] AC #4 — fails the workflow if flip count > N
- [x] AC #5 — threshold N=10 documented in workflow with rationale
- [ ] AC #6 — initial baseline of flip count measured (after first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)