### PR TITLE
fix(playground): horizontal swipe scrolls tab bar on mobile (#1237)

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -520,7 +520,14 @@
         padding: 0 14px;
         position: relative;
         cursor: grab;
-        touch-action: none;
+        /* #1237 — pan-x lets the tab bar scroll horizontally on touch when it
+         * overflows; the JS pointermove handler still hijacks vertical drags
+         * (dy > dx) into a tab move. With `touch-action: none` the browser
+         * never delivered scroll gestures to the bar, so a horizontal swipe
+         * would always trigger the drag-to-reorder path even when the user
+         * just wanted to scroll among many tabs.
+         */
+        touch-action: pan-x;
         font-size: 12px;
         color: var(--muted-text);
         border-right: 1px solid var(--separator-color);

--- a/playground/layout.ts
+++ b/playground/layout.ts
@@ -477,9 +477,12 @@ export class LayoutManager {
       if (e.pointerType === "mouse") return;
       if ((e.target as HTMLElement).closest(".close-btn")) return;
 
-      e.preventDefault();
-      tabEl.setPointerCapture(e.pointerId);
-
+      // #1237 — do NOT preventDefault or setPointerCapture yet. The tab bar
+      // is `overflow-x: auto`, so horizontal swipes need to reach the
+      // browser as native scroll gestures. We only know whether to claim
+      // the gesture as a tab-drag (vertical pull / non-overflowing bar)
+      // vs let the bar scroll (horizontal swipe on overflow) once the
+      // pointer has moved enough to reveal intent.
       this.touchTabDrag = {
         pointerId: e.pointerId,
         tabId,
@@ -498,6 +501,31 @@ export class LayoutManager {
           const dy = ev.clientY - this.touchTabDrag.startY;
           if (Math.hypot(dx, dy) < 10) return;
 
+          // #1237 — drag-vs-scroll intent gate. Once the user has moved
+          // 10 px, decide: if the tab bar is overflowing (i.e. there's
+          // somewhere to scroll to) AND the gesture is dominantly
+          // horizontal, abandon the drag — the browser's native scroll
+          // takes over via `touch-action: pan-x`. Otherwise (vertical
+          // pull, or a non-overflowing bar where there's nothing to
+          // scroll) commit to the tab-reorder drag. This is the only
+          // place we now call preventDefault / setPointerCapture, so
+          // the bar can scroll naturally on the swipe-rejected path.
+          const tabBar = tabEl.parentElement as HTMLElement | null;
+          const barOverflowing = !!tabBar && tabBar.scrollWidth > tabBar.clientWidth;
+          if (barOverflowing && Math.abs(dx) > Math.abs(dy)) {
+            // Horizontal swipe on an overflowing bar — release the
+            // gesture entirely and let the browser scroll the tab bar.
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+            window.removeEventListener("pointercancel", onCancel);
+            this.touchTabDrag = null;
+            return;
+          }
+
+          ev.preventDefault();
+          if (!tabEl.hasPointerCapture(ev.pointerId)) {
+            tabEl.setPointerCapture(ev.pointerId);
+          }
           this.touchTabDrag.started = true;
           this.dragTabId = tabId;
           this.dragSourcePanelId = panelId;


### PR DESCRIPTION
## Summary

Mobile users with many open tabs couldn't scroll horizontally to reach off-screen tabs — every swipe got hijacked into a tab-reorder drag. Two-part fix that lets the browser's native scroll path handle horizontal swipes when the bar is overflowing, and reserves the drag-to-reorder path for vertical pulls (or any gesture on a non-overflowing bar).

## Changes

**`playground/index.html` (`.panel-tab` CSS):**
- `touch-action: none` → `touch-action: pan-x`. Lets the browser deliver horizontal swipes as native scroll on the parent `.panel-tab-bar` (which is already `overflow-x: auto`).

**`playground/layout.ts:setupTabDrag` (lines 476–499):**
- Defer `preventDefault()` and `setPointerCapture()` until after the existing 10 px movement threshold AND a drag-vs-scroll intent check.
- Intent check: if the bar is overflowing (`scrollWidth > clientWidth`) AND the gesture is dominantly horizontal (`|dx| > |dy|`), abandon the drag entirely — release the pointer, let the browser scroll. Otherwise commit to the tab-drag path.

Mouse pointer events are unaffected (the early `pointerType === "mouse"` bail-out still applies). Close-button taps still short-circuit before any of this.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `pnpm run build:playground` — clean (vite build, 24.5 s)
- [ ] Manual on mobile: open the playground with enough tabs to force the bar to overflow → horizontal swipe scrolls the bar; vertical pull on a tab triggers reorder; tap on close button still closes; mouse drag-to-reorder still works on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)