### PR TITLE
docs(#1245): close investigation; create follow-ups #1258 #1259 #1260

### DIFF
--- a/plan/issues/sprints/47/1245.md
+++ b/plan/issues/sprints/47/1245.md
@@ -1,0 +1,278 @@
+---
+id: 1245
+title: "Investigate #1177 Stage 1 regressions — 59 compile_timeouts + 81 real regressions in PR#125"
+status: done
+sprint: 47
+created: 2026-05-02
+updated: 2026-05-02
+completed: 2026-05-02
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: investigation
+area: codegen
+language_feature: closures, TDZ
+goal: test262-conformance
+depends_on: []
+related: [1177, 1205, 1223, 1258, 1259, 1260]
+pr: 155
+---
+
+## Outcome (2026-05-02 close)
+
+Investigation closed as **done** — deliverable is the 252-line writeup below
+plus three follow-up issues:
+
+- **#1258** — `compileForOfAssignDestructuringExternref` box-awareness
+  (~30-test cluster, blocks Stage 1 landing)
+- **#1259** — async-gen yield-star sync-fallback unboxed ref-cell leak
+  (~50-test cluster)
+- **#1260** — destructuring of null/undefined must throw TypeError per §13.15.5.5
+  (~10-test cluster)
+
+PR#155 (type-guarded Stage 1 attempt) was **closed without merge**: CI
+confirmed the type-guard refinement is strictly worse than the unguarded
+form (net −38 vs −16, same 81 real regressions, fewer improvements
+124→76). The refinement cut compile_timeout flap (66→33) but the regressions
+are systematic spec-bugs unmasked by *any* Stage 1, not addressable at the
+substitution site.
+
+Stage 1 of #1177 will be re-attempted only after #1258 (and ideally #1259)
+land. Expected net at that point: ≥ +90.
+
+
+
+## Investigation findings (2026-05-02, dev-1245)
+
+### Finding 1 — the 59 compile_timeouts are CI flakiness, NOT compiler hangs
+
+I cherry-picked PR#125's exact Stage 1 commit (`8b34d909`) onto a fresh branch
+from `origin/main`, then **compiled all 66 pass→compile_timeout tests locally**
+through the same `wrapTest` + `compileMulti` path used by the test262 runner.
+
+**All 66 tests compiled in ≤ 500 ms each** (median ≈ 65 ms). None of them are
+"compiler hangs". They are simple property-existence tests like
+`test/built-ins/Math/abs/length.js` (32 lines, single `verifyProperty` call)
+that should never approach a 30 s compile budget.
+
+**Why CI sees them as `compile_timeout`:** the precompile pool runs
+`availableParallelism() - 2` workers per shard × 16 shards in CI; under
+contention, slow harness compiles (`propertyHelper.js` is 371 lines / 32
+helper functions) occasionally hit the 30 s timer. Each PR run sees a
+*different* set of 50–70 tests timeout. The transition matrix on PR#125 confirms
+this:
+
+```
+pass → compile_timeout: 66    compile_timeout → pass: 24
+fail → compile_timeout: 49    compile_timeout → fail: 25
+                              compile_timeout → compile_error: 8
+                              compile_error → compile_timeout: 4
+                              compile_timeout NET: 156 → 129 = -27 (improvement)
+```
+
+The total `compile_timeout` count *decreased* from 156 to 129 on PR#125. The
+"59 compile_timeout regressions" header is purely the diff direction — it
+counts each individual test that flapped from pass→timeout, not the population
+delta. The acceptance criterion "zero compile_timeouts" cannot be hit in any
+PR; the flap floor is structural.
+
+**Action:** `dev-self-merge` Step 4 should *exclude* `pass → compile_timeout`
+transitions from the regression bucket (or treat them as zero-weight).
+Ratio/bucket gates already give them pass-through if the population is stable.
+
+### Finding 2 — the 81 real regressions are pre-existing spec-bugs unmasked by Stage 1
+
+The 81 non-timeout regressions cluster as:
+
+- ~50× `language/expressions/object/method-definition/async-gen-yield-star-*` —
+  "L60:3 dereferencing a null pointer". `yield*` over an iterator whose
+  `@@asyncIterator` is undefined goes through the sync iterator fallback. The
+  callee fn-decl reads its captured iter via cap-prepend; with the unguarded
+  Stage 1 substitution, `localMap` re-aimed the slot to a boxed/different-type
+  ref cell, and the lifted body unwrapped it as the original value type → null.
+
+- ~20× `language/statements/for-await-of/async-{func,gen}-decl-dstr-*` —
+  "returned 2 — assert #1 ... sameValue(x.y, 4)" or "illegal cast". The
+  destructure-assign-target path (`compileForOfAssignDestructuringExternref`,
+  `loops.ts:1503`) does direct `local.set` on `targetLocal` and **does not
+  route through `boxedCaptures.struct.set`**. When Stage 1 makes the
+  outer-fctx capture flow through a ref cell, the for-await write-back
+  silently writes to a stale value slot rather than mutating the captured
+  object — so the next read sees the pre-write value. This is *exactly* the
+  case the architect spec at `nested-declarations.ts:240–260` already
+  flagged as "out of scope ... `.todo` until that follow-up lands".
+
+- ~10× `language/expressions/assignment/dstr/array-elem-nested-*-null` —
+  "assert.throws(TypeError ...) returned 2". The wrapped function captures the
+  outer test scope; with the wrong-slot read, `null` was `null` and threw on
+  property access (test passed by accident). With the correct slot, the actual
+  destructure source is `null`, but the codegen path doesn't emit the
+  spec-mandated `TypeError`. Pre-existing destructuring-null bug.
+
+- 1× `language/expressions/object/method-definition/name-invoke-fn-strict.js` —
+  function-name binding (the function's own name as a TDZ-tracked self-ref).
+
+### Root cause
+
+The Stage 1 substitution **`fctx.localMap.get(cap.name) ?? cap.outerLocalIdx`**
+is correct *for the specific TDZ-through-arrow case it targets*, but reading
+"the right slot" surfaces three independent pre-existing bugs:
+
+1. The destructure-assign write-back path is not box-aware (architect-noted).
+2. Async-gen yield-star sync-fallback iter capture has an unboxed-ref-cell
+   leak (new finding).
+3. Destructuring `[null]`/`[undefined]` does not emit the spec-mandated
+   TypeError (pre-existing).
+
+Each of these is its own issue. Stage 1 alone cannot land cleanly until at
+least #1 is fixed (largest cluster, ~30 tests).
+
+### Approach for this PR — type-guarded Stage 1
+
+I refined the unguarded `fctx.localMap.get(cap.name) ?? cap.outerLocalIdx` to
+a **type-matched preference**:
+
+```ts
+const candidateIdx = fctx.localMap.get(cap.name);
+let sourceLocalIdx = cap.outerLocalIdx;
+if (candidateIdx !== undefined) {
+  const candidateType = getLocalType(fctx, candidateIdx);
+  if (candidateType && cap.valType && valTypesMatch(candidateType, cap.valType)) {
+    sourceLocalIdx = candidateIdx;
+  }
+}
+```
+
+This guards against the failure mode where `localMap` was re-aimed at a
+boxed/differently-typed slot (which produced the illegal-cast and null-deref
+clusters). When the localMap entry has the *same* type as the capture, the
+substitution applies and recovers the +24-net improvements that Stage 1
+unblocks. When the type differs, we fall back to the legacy `cap.outerLocalIdx`
+read, preserving main's behavior on the surfaced-bug clusters.
+
+Sites updated (4):
+- `src/codegen/expressions/calls.ts:5097` (mutable fresh-box branch)
+- `src/codegen/expressions/calls.ts:5133` (non-mutable branch — also uses
+  `expectedCapType` from `captureParamTypes` for an even stricter guard)
+- `src/codegen/closures.ts:2747` (mutable branch, fn-decl→closure-wrapping)
+- `src/codegen/closures.ts:2765` (non-mutable branch)
+
+### Local validation
+
+- `tests/issue-1177.test.ts` — 7/7 pass (Stage 1's own targeted equivalence)
+- `tests/issue-1016.test.ts` — 4/4 pass (parameter-destructuring closures)
+- `tests/issue-1128-dstr-tdz.test.ts` — 8/8 pass
+- 5 previously-failing async-gen / for-await tests compile cleanly (cannot
+  validate runtime locally without the wasm-exec-worker harness)
+- `tests/equivalence/tdz-reference-error.test.ts` — 3/9 pass; the 6 failures
+  pre-date my changes (verified by `git stash` re-run on cherry-pick HEAD)
+
+### Acceptance criteria progress
+
+1. ☑ The 59 compile_timeouts root cause identified (CI flap, not real hangs)
+2. ☑ The 81 regressions classified into 4 distinct pre-existing bug clusters
+3. ☑ Type-guarded Stage 1 fix proposed (this PR)
+4. ☐ CI net ≥ +90 with no single bucket > 50 (validated by CI on push)
+
+If CI shows net < +90 after the type-guard refinement, the residual gap is
+addressed by follow-up issues:
+- New issue: make `compileForOfAssignDestructuringExternref` box-aware (the
+  ~30-test cluster #1 above)
+- New issue: async-gen yield-star sync-fallback unboxed-ref-cell leak
+- New issue: destructuring null/undefined TypeError emission
+
+---
+
+# #1245 — Investigate #1177 Stage 1 regressions
+
+## Background
+
+#1177 Stage 1 is the capture-index correction in `closures.ts` and `calls.ts`:
+
+```ts
+// Before (stale index):
+fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
+
+// After (correct index):
+const sourceLocalIdx = fctx.localMap.get(cap.name) ?? cap.outerLocalIdx;
+fctx.body.push({ op: "local.get", index: sourceLocalIdx });
+```
+
+This 2-line change appears twice in `calls.ts` and twice in `closures.ts`. It was originally
+reverted (`37d40dae7`) because async-gen bodies hit null_deref without the Stage 2/3
+infrastructure. Stages 2 and 3 landed in #1205. PR#125 re-attempted Stage 1 on top of #1205.
+
+## PR#125 CI results
+
+```
+pass:              25,901  (was 25,785 on main → +116 improvements)
+regressions_real:     81
+compile_timeouts:     59  ← primary signal
+net_per_test:        -16
+```
+
+Expected: +1,159 net. Got: -16. The dev PR description said "safe now that Stages 2&3 are in
+place" — but 59 compile_timeouts say otherwise.
+
+## What needs investigation
+
+**1. Root-cause the 59 compile_timeouts.**
+
+The timeouts are the dominant cost. Compile_timeouts in the test262 runner mean the compiler
+itself hung for > 30s on those test files. This is NOT a runtime infinite loop — it's a
+compiler-phase hang. The localMap substitution should not cause a compile hang; the question
+is whether it interacts with some recursive codegen path (e.g., circular capture chains, or
+triggering a previously-unreachable branch in `emitFuncRefAsClosure` that loops).
+
+Reproduce locally:
+```bash
+cd /workspace/.claude/worktrees/issue-1245-stage1-investigation
+# Cherry-pick just the Stage 1 change from PR#125 (SHA 8b34d909)
+git cherry-pick 8b34d909374997d7d7c8e32cd2e0d0af6f0495f0
+
+# Run with a timeout to find hanging tests:
+TEST262_WORKERS=1 pnpm run test:262 --recheck 2>&1 | grep -E "compile_timeout|TIMEOUT"
+```
+
+Alternatively, reproduce without cherry-pick: apply the 4-line change manually to a fresh
+branch and run targeted tests.
+
+**2. Identify the 81 real regressions.**
+
+81 tests changed from pass → fail (non-wasm-identical). Classify:
+- Are they in the same test category as the 59 timeouts, or different?
+- Do they share a pattern (specific feature, specific codegen path)?
+
+Check the CI run artifact at:
+`https://github.com/loopdive/js2wasm/actions/runs/25219534735`
+
+**3. Form a hypothesis.**
+
+Given the original Stage 1 was safe before `37d40dae7` reverted it, and that reversion
+happened due to async-gen null_deref (now fixed), the question is:
+
+> Is the localMap substitution safe for ALL closure-emit paths, or only for the arrow-wraps-fn
+> path that Stages 2/3 fixed? Are there other paths (e.g., generator closures, method closures,
+> IIFE captures) where the substitution produces wrong output or triggers a compiler loop?
+
+**4. Produce a minimal fix or a staged approach.**
+
+Options:
+- A: Gate the substitution on a specific capture shape (e.g., only for `transitivelyCapturing`
+  arrows) to avoid the timeout-triggering path
+- B: Apply the substitution only in `calls.ts`, not `closures.ts` (separate the risk surface)
+- C: Identify the exact path causing timeouts, fix that path, then re-land Stage 1 whole
+
+## Acceptance criteria
+
+1. The 59 compile_timeouts are reproduced locally and their root cause is identified.
+2. The 81 real regressions are classified by feature/path.
+3. A fix proposal (or staged sub-fix) is written into this issue file.
+4. A new PR re-lands Stage 1 (or a safe subset) with net ≥ +90 and zero compile_timeouts.
+
+## Related
+
+- `plan/issues/sprints/45/1177.md` — full impl spec with Stage 1 diff locations
+- PR#125 CI run: https://github.com/loopdive/js2wasm/actions/runs/25219534735
+- #1205 — Stages 2+3 (already landed, prerequisite)
+- #1223 — blocked on Stage 1 landing

--- a/plan/issues/sprints/47/1258.md
+++ b/plan/issues/sprints/47/1258.md
@@ -1,0 +1,130 @@
+---
+id: 1258
+title: "compileForOfAssignDestructuringExternref must route writes through boxedCaptures.struct.set"
+status: ready
+created: 2026-05-02
+updated: 2026-05-02
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: closures, destructuring, for-of
+goal: test-infrastructure
+related: [1177, 1245, 1205]
+depends_on: []
+test262_fail: 30
+---
+
+# #1258 — Make `compileForOfAssignDestructuringExternref` box-aware (blocks Stage 1 of #1177)
+
+## Background
+
+This issue was identified during the #1245 investigation of why PR#125 / PR#155
+landed with 81 real regressions. It is **the largest blocking cluster** for re-
+landing #1177 Stage 1.
+
+## Problem
+
+`compileForOfAssignDestructuringExternref` in `src/codegen/statements/loops.ts:1503`
+emits the per-iteration write of a for-await-of destructure-assignment:
+
+```ts
+emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
+```
+
+This is a **direct `local.set` on `targetLocal`**. When the destructure target
+is captured into an enclosing closure, `targetLocal` will have been re-aimed
+at a boxed ref-cell (entry exists in `fctx.boxedCaptures`). The direct
+`local.set` then **overwrites the ref-cell ref** with a value, instead of
+storing through `struct.set` into the cell — silently breaking the closure's
+view of the variable.
+
+The architect already flagged this as a deferred follow-up at
+`src/codegen/statements/nested-declarations.ts:240–260`:
+
+> The "writer + reader fn-decl pair sharing a TDZ-flagged outer let" pattern
+> requires Stage 1 of #1177 (`localMap.get(cap.name) ?? cap.outerLocalIdx`)
+> to be re-applied AND the destructure-assign path to be box-aware. Both are
+> out of scope for this PR; the test is marked `.todo` until that follow-up
+> lands.
+
+## Canonical reproduction
+
+```js
+let x = {};
+let iterCount = 0;
+async function * fn() {
+  for await ([x.y] of [[4]]) {
+    assert.sameValue(x.y, 4); // FAILS — x.y is still undefined
+    iterCount += 1;
+  }
+}
+fn().next();
+```
+
+When `x` is captured into `fn`'s lifted body, the for-await write `[x.y] = [4]`
+goes through `compileForOfAssignDestructuringExternref` → direct `local.set`
+on the captured `x` slot → ref-cell ref gets overwritten with the externref
+result of `__extern_get`, instead of going through `struct.set` into the
+cell. Subsequent reads of `x.y` see a stale or null value.
+
+## test262 impact
+
+The CI runs of PR#125 and PR#155 both showed the same ~20 for-await-of
+destructuring tests fail with this signature. Sample paths:
+
+- `language/statements/for-await-of/async-gen-decl-dstr-array-elem-put-prop-ref.js`
+  (assert: `x.y, 4`)
+- `language/statements/for-await-of/async-gen-decl-dstr-obj-prop-put-prop-ref.js`
+- `language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-iter-close.js`
+  (illegal cast)
+- `language/statements/for-await-of/async-func-decl-dstr-obj-prop-put-prop-ref.js`
+
+These tests pass on main today *only because* the wrong-slot read in the
+unrefined cap-prepend (the "stale outer-fctx slot" #1177 Stage 1 was meant
+to fix) happens to throw on a downstream coercion — masking the spec
+violation. Once Stage 1 reads the right slot, the destructure-assign bug
+surfaces directly.
+
+## Fix sketch
+
+In `compileForOfAssignDestructuringExternref` at the `emitCoercedLocalSet`
+call site (and the parallel callsites for object-pattern targets in the
+same function family):
+
+1. Look up `fctx.boxedCaptures?.get(name)` for the destructure-target name.
+2. If present, emit the write as `struct.set` on the cell:
+   - `local.get <boxed_local>` (the ref-cell ref)
+   - the coerced value already on the stack
+   - `struct.set <refCellTypeIdx> 0`
+   - update synced module global if `extSyncGlobalIdx` was set.
+3. Otherwise keep the existing direct `local.set` path.
+
+The same audit must cover `compileForOfAssignDestructuring` (line 1111)
+which handles tuple and ref struct destructuring — anywhere `local.set` is
+emitted on a target that may be in `boxedCaptures`.
+
+## Acceptance criteria
+
+1. The 4 named for-await-of test262 cases above pass.
+2. The full test262 cluster `language/statements/for-await-of/*-put-prop-ref*`
+   shows ≥ 20 net improvements.
+3. No regressions on `language/statements/for-of/*` (non-await variant).
+4. Equivalence test added: `tests/issue-1258.test.ts` reproducing the
+   `let x = {}; for await ([x.y] of [[4]]) { ... }` pattern.
+5. After this lands, re-attempt #1177 Stage 1 — net should swing to ≥ +50.
+
+## Out-of-scope
+
+- Object-rest destructure-assignment (`for await ({...rest} of …)`) is a
+  separate path; cover only if trivial.
+- Sync `for-of` non-externref destructure (the typed-array / tuple paths)
+  is independent of this fix; track separately if it surfaces.
+
+## Related
+
+- #1177 — TDZ propagation through closure captures (Stage 1 blocked on this)
+- #1245 — Investigation of PR#125 / PR#155 regressions (this issue is the
+  primary follow-up identified there)
+- #1205 — TDZ async-gen Stages 2 & 3 (already landed)

--- a/plan/issues/sprints/47/1259.md
+++ b/plan/issues/sprints/47/1259.md
@@ -1,0 +1,149 @@
+---
+id: 1259
+title: "async-gen yield-star sync-fallback leaks unboxed ref-cell into iter capture"
+status: ready
+created: 2026-05-02
+updated: 2026-05-02
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: async-generators, iterator-protocol
+goal: async-model
+related: [1177, 1245, 1205]
+depends_on: []
+test262_fail: 50
+---
+
+# #1259 — `yield*` async sync-fallback unboxes a ref-cell as the original value type
+
+## Background
+
+This issue was identified during the #1245 investigation of why PR#125 / PR#155
+landed with 81 real regressions. It is **the second-largest blocking cluster**
+for re-landing #1177 Stage 1, and the only one rooted in async-generator
+codegen.
+
+## Problem
+
+`yield* obj` inside an async generator goes through the iterator-protocol
+fallback specified in §27.6.3.7 / §7.4.1 (`GetIterator`):
+
+1. Look up `obj[@@asyncIterator]`. If undefined,
+2. Look up `obj[@@iterator]` (the SYNC iterator).
+3. Wrap the sync iterator in a CreateAsyncFromSyncIterator adapter.
+
+In our codegen, the fallback wraps the iter in a closure-style trampoline
+that captures the iter via the call-site cap-prepend (calls.ts:5089–5148). When
+the captured iter has been re-aimed in `fctx.localMap` to a **boxed ref cell**
+(because some earlier closure forced boxing of the value), the cap-prepend
+mutable-branch struct-news the boxed ref as if it were the value:
+
+```ts
+const sourceLocalIdx = fctx.localMap.get(cap.name) ?? cap.outerLocalIdx;
+fctx.body.push({ op: "local.get", index: sourceLocalIdx });   // ref cell ref
+fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx }); // wraps the ref-cell-ref
+```
+
+The lifted iter trampoline then unwraps the outer cell and reads its content
+as the original value type — but the content is itself a `ref __ref_cell_T`
+ref, not the underlying value. The cast emitted to the original type
+produces null, and the next op `null.iter.next()` traps with "dereferencing
+a null pointer".
+
+## Canonical reproduction
+
+From test262
+`language/expressions/object/method-definition/async-gen-yield-star-getiter-async-undefined-sync-get-abrupt.js`:
+
+```js
+var calls = 0;
+var reason = {};
+var obj = {
+  get [Symbol.iterator]() { throw reason; },
+  get [Symbol.asyncIterator]() { calls += 1; return undefined; },
+};
+var gen = { async *method() { yield* obj; throw new Test262Error('…'); } }.method;
+gen().next().then(() => { /* fail */ }, v => {
+  assert.sameValue(v, reason, 'reject reason');
+  assert.sameValue(calls, 1);
+  /* … */
+});
+```
+
+After Stage 1 reads the correct (boxed) slot for the captured iter, the
+sync-fallback codegen receives a ref-cell ref where it expects a value, and
+the trampoline body deref's null on first `.next()`.
+
+## test262 impact
+
+The CI runs of PR#125 and PR#155 both showed ~50 tests fail with the
+"dereferencing a null pointer" signature in the
+`async-gen-yield-star-*` cluster. The full set is in
+`/tmp/pr125-detail.txt` (cherry-picked into worktree investigation). Sample
+paths:
+
+- `async-gen-yield-star-getiter-async-undefined-sync-get-abrupt.js`
+- `async-gen-yield-star-getiter-async-returns-{abrupt,boolean,null,number,string,symbol,undefined}-throw.js`
+- `async-gen-yield-star-getiter-sync-returns-{number,string,symbol,undefined}-throw.js`
+- `async-gen-yield-star-next-then-non-callable-{boolean,null,number,object,string,symbol,undefined}-fulfillpromise.js`
+
+## Fix sketch
+
+The cap-prepend mutable branch in `compileCallExpression` (calls.ts:5089ff)
+currently has two cases:
+
+```ts
+if (fctx.boxedCaptures?.has(cap.name)) {
+  // Already a ref cell — pass the ref cell reference directly
+} else {
+  // Fresh box: read value, struct.new ref cell
+}
+```
+
+The bug is that when `localMap` was re-aimed at a boxed local *but
+`fctx.boxedCaptures` was not synchronously updated* (e.g., the boxing happened
+in a sibling lifted scope whose `boxedCaptures` map was discarded), we hit
+the `else` branch and double-wrap.
+
+Fix options:
+
+- **A.** Audit every site that re-aims `fctx.localMap.set(name, boxedLocal)`
+  to also `fctx.boxedCaptures.set(name, …)` in lockstep.
+- **B.** Detect double-wrap by checking `getLocalType(fctx, sourceLocalIdx)`
+  against `cap.valType`: if the local is a `ref __ref_cell_T` and `cap.valType`
+  is `T`, the entry is already boxed — pass the ref directly without
+  struct.new'ing again.
+- **C.** Make the async-gen yield-star trampoline body box-aware: emit a
+  conditional unwrap based on the runtime type tag.
+
+Recommend **(B)**: it's a localised fix at the cap-prepend site that handles
+the synchronisation gap without auditing every re-aim site. Type-check the
+candidate slot — if it's `ref __ref_cell_T` and `cap.valType` is `T`,
+treat it as `boxedCaptures.has(cap.name) === true` and skip the fresh-box
+struct.new.
+
+## Acceptance criteria
+
+1. The 6 named test262 cases pass.
+2. The full `async-gen-yield-star-*` cluster shows ≥ 30 net improvements.
+3. No regressions in `language/expressions/await/*` or
+   `language/statements/for-await-of/*`.
+4. Equivalence test added: `tests/issue-1259.test.ts` reproducing the
+   "yield* with sync-iter fallback through a captured iter" pattern.
+5. After this AND #1258 land, #1177 Stage 1 should re-land with net ≥ +90.
+
+## Out-of-scope
+
+- Native `Symbol.asyncIterator` codegen (the fallback path is what we fix
+  here). Tracked separately.
+- Async-iterator return-on-abrupt-completion (§27.6.3.7 step 7.b) — already
+  in #1219.
+
+## Related
+
+- #1177 — TDZ propagation (Stage 1 blocked on this)
+- #1245 — Investigation finding
+- #1205 — TDZ async-gen infrastructure (already landed)
+- #1219 — Async iterator close on abrupt completion

--- a/plan/issues/sprints/47/1260.md
+++ b/plan/issues/sprints/47/1260.md
@@ -1,0 +1,120 @@
+---
+id: 1260
+title: "Destructuring of null/undefined must throw TypeError per §13.15.5.5"
+status: ready
+created: 2026-05-02
+updated: 2026-05-02
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring
+goal: test-infrastructure
+related: [1177, 1245, 1225]
+depends_on: []
+test262_fail: 10
+---
+
+# #1260 — Destructuring `null` / `undefined` must throw TypeError
+
+## Background
+
+This issue was identified during the #1245 investigation of why PR#125 / PR#155
+landed with 81 real regressions. It is a **pre-existing spec-bug** that is
+masked on main today by the wrong-slot read in #1177 cap-prepend; once Stage 1
+reads the right slot, the bug surfaces directly.
+
+## Problem
+
+ECMA-262 §13.15.5.5 (`PropertyDestructuringAssignmentEvaluation` →
+`RequireObjectCoercible`) and §13.15.5.4 (`IteratorDestructuringAssignment`)
+both require a `TypeError` when the source of a destructure is `null` or
+`undefined`:
+
+```js
+[a] = null;          // TypeError (not iterable)
+({ a } = null);      // TypeError (RequireObjectCoercible)
+[[a]] = [null];      // inner element is null → TypeError on inner destructure
+```
+
+Our codegen path for assignment-form destructuring does not consistently emit
+the spec-mandated throw — instead, the wrapped function relied on a downstream
+property access throwing on the null receiver. With the right-slot read post
+Stage 1, the source flows correctly through (e.g., as a `null`/`undefined`
+externref) and the destructure proceeds without the spec-mandated throw.
+
+## Canonical reproductions (test262)
+
+- `language/expressions/assignment/dstr/array-elem-nested-array-null.js` —
+  `[[ _ ]] = [null]` expects TypeError; we silently iterate null.
+- `language/expressions/assignment/dstr/array-elem-nested-array-undefined-hole.js` —
+  `[[ _ ]] = [ , ]` (hole-iterated as undefined) expects TypeError.
+- `language/expressions/assignment/dstr/obj-prop-nested-array-undefined-own.js` —
+  `{ x: [ x ] } = { x: undefined }` expects TypeError.
+- `language/statements/for-of/dstr/array-elem-nested-obj-null.js` —
+  `for ([{ x }] of [[null]])` expects TypeError per iteration element.
+- `language/statements/for-of/dstr/obj-rest-val-null.js` —
+  `for ({...rest} of [null])` expects TypeError.
+- `language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-prop-obj-value-null.js`
+- `language/expressions/class/dstr/meth-static-dflt-obj-ptrn-prop-obj-value-null.js`
+- `language/statements/class/dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js`
+- `language/statements/class/dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js`
+- `language/statements/class/dstr/meth-static-dflt-obj-ptrn-prop-obj-value-null.js`
+
+## Existing infrastructure
+
+#1225 added `emitExternrefDestructureGuard` (loops.ts) which emits a
+runtime null-check + TypeError for the for-of element destructure case. The
+guard fires when we destructure a top-level loop element that is null/undefined.
+
+What's missing:
+
+1. **Nested destructure source guards.** When `[[ _ ]] = [null]` decomposes
+   to inner-pattern `[ _ ]` over the inner element `null`, the inner step
+   does not call the guard.
+2. **Object-source RequireObjectCoercible.** The `{ x } = null` path needs a
+   parallel guard before the property-access decomposition.
+3. **Default-value-with-null branch.** The architect path
+   `compileForOfAssignDestructuringExternref` line ~1564 has a `defaultInit`
+   branch that elides the guard when a default is provided — fix to still
+   guard the SOURCE even when the inner has a default (the spec applies the
+   default only when the property is `undefined`, not when the source is
+   `null`).
+
+## Fix sketch
+
+1. Audit destructuring entry points:
+   - `compileObjectDestructuring` — parallel of array path
+   - `compileForOfAssignDestructuringExternref` — already wired for top-level
+   - `compileForOfAssignDestructuring` (tuple branches) — likely already OK
+     since tuple structs cannot be null
+   - `compileArrayLiteralAssignment` (in expressions/assignments)
+2. Hoist `emitExternrefDestructureGuard` to fire on EVERY nested pattern
+   source, not just the top-level loop element.
+3. For object-source guards, add `emitExternrefRequireObjectCoercible(ctx, fctx, srcLocal)`
+   that throws TypeError on null/undefined.
+4. Apply guards before any default-value branch — defaults trigger on
+   `undefined` *property*, not on `null`/`undefined` *source*.
+
+## Acceptance criteria
+
+1. The 10 named test262 cases pass.
+2. Equivalence test added: `tests/issue-1260.test.ts` covering:
+   - `[[a]] = [null]` → TypeError
+   - `({ x: [ x ] } = { x: undefined })` → TypeError
+   - `for ([[ x ]] of [[null]])` → TypeError per iteration element
+3. No regressions on positive destructuring tests.
+4. After this AND #1258, #1259 land, #1177 Stage 1 should re-land cleanly.
+
+## Out-of-scope
+
+- Custom iterator close-on-abrupt for nested destructure (covered by #1219).
+- Object-rest with non-coercible (`{...rest} = undefined`) — same fix
+  surface; cover only if trivial extension.
+
+## Related
+
+- #1177 — TDZ propagation (Stage 1 blocked on this)
+- #1225 — emitExternrefDestructureGuard (top-level loop element)
+- #1245 — Investigation finding


### PR DESCRIPTION
## Summary
Clean docs-only branch from origin/main. Closes the #1245 investigation per tech-lead decision and lands three follow-up issues that block re-landing #1177 Stage 1.

## Background
PR#155 (the type-guarded Stage 1 attempt) was closed without merge. CI confirmed the type-guard is strictly worse than unguarded:

| Metric | PR#125 (unguarded) | PR#155 (type-guarded) |
|---|---|---|
| Net pass | −16 | **−38** |
| Improvements | 124 | 76 |
| Real regressions | 81 | **81 (same)** |

The 81 real regressions are systematic spec-bugs that surface as soon as ANY Stage 1 reads the right slot — not addressable at the substitution site.

## Changes
- \`plan/issues/sprints/47/1245.md\`: 252-line investigation writeup, status: done, completed: 2026-05-02.
- \`plan/issues/sprints/47/1258.md\`: \`compileForOfAssignDestructuringExternref\` box-awareness (~30 tests; architect-noted at \`nested-declarations.ts:240-260\` as deferred).
- \`plan/issues/sprints/47/1259.md\`: async-gen yield-star sync-fallback unboxed ref-cell leak (~50 tests).
- \`plan/issues/sprints/47/1260.md\`: destructure-of-null/undefined TypeError per §13.15.5.5 (~10 tests).

Once #1258 lands (and ideally #1259), #1177 Stage 1 can be re-attempted with expected net ≥ +90.

## Note
PR#156 was opened earlier from \`issue-1245-stage1-investigation\` branch but it carried the closed PR#155 code commits as dead weight. PR#156 has been closed in favour of this clean docs-only PR.

## Test plan
- [x] Docs-only — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)