### PR TITLE
fix(#1247): skip Array/container types in ensureStructForType so vec/array-method dispatch fires

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -10,7 +10,7 @@ import ts from "typescript";
 import { isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
-import { allocLocal } from "./context/locals.js";
+import { allocLocal, getLocalType } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { addArrayIteratorImports, addStringImports, resolveWasmType } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
@@ -1811,7 +1811,13 @@ export function compileArrayMethodCall(
       const name = receiverExpr.text;
       const localIdx = fctx.localMap.get(name);
       if (localIdx !== undefined) {
-        actualType = fctx.locals[localIdx]?.type;
+        // #1247: localIdx is the wasm-level index (params + locals);
+        // `fctx.locals` indexes only locals (no params). Use getLocalType
+        // to handle the offset correctly. Without this, in functions with
+        // params, `paths.shift()` looks up the wrong local and dispatches
+        // through a stale vec type idx, producing struct-type mismatches
+        // at instantiation.
+        actualType = getLocalType(fctx, localIdx);
       } else {
         const gIdx = ctx.moduleGlobals.get(name);
         if (gIdx !== undefined) {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5505,6 +5505,41 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
   if (isExternalDeclaredClass(tsType, ctx.checker)) return;
   // Tuple types are handled by getOrRegisterTupleType, not as anonymous structs
   if (isTupleType(tsType)) return;
+  // #1247: Array types compile to vec structs (length+data) via getOrRegisterVecType,
+  // not anonymous structs that pull in every Array.prototype method as a field. Without
+  // this guard, `string[]` registers an anonymous struct named after Array.prototype's
+  // shape, and `paths.shift()` resolves through compileCallablePropertyCall (a
+  // callable-field dispatch) instead of compileArrayMethodCall — producing
+  // struct-type mismatches at instantiation when the local was allocated via the
+  // vec path but the callable-property dispatch reads through the anon struct.
+  {
+    const sym = (tsType as ts.TypeReference).symbol ?? (tsType as ts.Type).symbol;
+    if (
+      sym?.name === "Array" ||
+      sym?.name === "ReadonlyArray" ||
+      sym?.name === "Int8Array" ||
+      sym?.name === "Uint8Array" ||
+      sym?.name === "Uint8ClampedArray" ||
+      sym?.name === "Int16Array" ||
+      sym?.name === "Uint16Array" ||
+      sym?.name === "Int32Array" ||
+      sym?.name === "Uint32Array" ||
+      sym?.name === "Float32Array" ||
+      sym?.name === "Float64Array" ||
+      sym?.name === "Promise" ||
+      sym?.name === "Date" ||
+      sym?.name === "Map" ||
+      sym?.name === "Set" ||
+      sym?.name === "WeakMap" ||
+      sym?.name === "WeakSet" ||
+      sym?.name === "RegExp" ||
+      sym?.name === "Number" ||
+      sym?.name === "String" ||
+      sym?.name === "Boolean"
+    ) {
+      return;
+    }
+  }
   // Callable types (functions) are compiled as closures, not structs
   if (tsType.getCallSignatures().length > 0) return;
   // Guard against infinite recursion on circular/self-referencing types.

--- a/tests/issue-1247.test.ts
+++ b/tests/issue-1247.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1247 — typed string[] local with String.prototype.split initializer
+// triggers struct-type mismatch.
+//
+// Root cause: `ensureStructForType` registered `string[]` (an Array<string>
+// reference type) as an anonymous struct that pulled in every Array.prototype
+// method as a callable field. When `paths.shift()` was compiled, the dispatch
+// in compileCallExpression at calls.ts:3666 found the anon struct via
+// resolveStructName and routed `shift` through compileCallablePropertyCall
+// (treating it as a callable struct field) — bypassing the array-method
+// dispatch at calls.ts:3803 entirely. Since the anon struct's vec type idx
+// differed from the local's (vec_externref) idx, struct.get on the wrong
+// type idx failed wasm validation at instantiation.
+//
+// Fix: skip Array (and other built-in container types like TypedArrays,
+// Promise, Date, Map, Set, RegExp, wrapper objects) in ensureStructForType.
+// These types have their own dedicated codegen paths (vec types, externref
+// classes, etc.) and must not be re-registered as anonymous structs.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1247 — typed string[] with split initializer", () => {
+  // The minimal repro from the issue file: splitPath as a separate function
+  // that types its local as string[] and mutates it via shift().
+  it("splitPath: typed string[] local + split initializer + shift mutation", async () => {
+    const src = `
+      export function splitPath(path: string): string[] {
+        const paths: string[] = path.split("/");
+        if (paths[0] === "") {
+          paths.shift();
+        }
+        return paths;
+      }
+      export function test(): number {
+        const r = splitPath("/a/b/c");
+        return r.length;
+      }
+    `;
+    expect(await runTest(src)).toBe(3); // "/a/b/c".split("/") → ["", "a", "b", "c"], shift → ["a", "b", "c"]
+  });
+
+  // Without the leading "/" — the if branch shouldn't fire, paths.length === 3
+  it("splitPath: no leading slash leaves length unchanged", async () => {
+    const src = `
+      export function splitPath(path: string): string[] {
+        const paths: string[] = path.split("/");
+        if (paths[0] === "") {
+          paths.shift();
+        }
+        return paths;
+      }
+      export function test(): number {
+        const r = splitPath("a/b/c");
+        return r.length;
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+
+  // Direct typed-string[] local with split + push (another mutating method)
+  it("typed string[] + split + push works in a function with params", async () => {
+    const src = `
+      export function process(s: string): string[] {
+        const parts: string[] = s.split(",");
+        parts.push("end");
+        return parts;
+      }
+      export function test(): number {
+        return process("a,b,c").length; // 3 + 1 = 4
+      }
+    `;
+    expect(await runTest(src)).toBe(4);
+  });
+
+  // Typed string[] passed as parameter and returned — exercises both directions
+  // of the vec/anon-struct mismatch.
+  it("typed string[] parameter + array methods", async () => {
+    const src = `
+      export function tail(arr: string[]): number {
+        if (arr.length > 0) {
+          arr.shift();
+        }
+        return arr.length;
+      }
+      export function test(): number {
+        const a: string[] = "x,y,z".split(",");
+        return tail(a);
+      }
+    `;
+    expect(await runTest(src)).toBe(2); // ["x","y","z"], shift → ["y","z"], length 2
+  });
+
+  // Sanity: untyped local (inferred type) still works — this was the existing
+  // workaround.
+  it("untyped paths via split still works (regression check)", async () => {
+    const src = `
+      export function test(): number {
+        const paths = "/a/b".split("/");
+        return paths.length; // 3 (extern path)
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the typed-`string[]` + `split` + `shift` struct-type mismatch surfaced by Hono's `splitPath`.

## Root cause
`ensureStructForType` registered ANY object type — including \`string[]\` / \`Array<T>\` / TypedArrays / Promise / Date / Map / Set / RegExp / wrapper objects — as an anonymous struct, pulling in every \`Array.prototype\` method as a callable field. When \`paths.shift()\` was compiled:

1. \`resolveStructName(receiverType)\` returned the anon struct name (e.g. \`__anon_1\`).
2. The struct-method dispatch at \`calls.ts:3666\` found \`shift\` via \`compileCallablePropertyCall\` — treating it as a callable field on the anon struct.
3. The array-method dispatch at \`calls.ts:3803\` was **bypassed entirely**.
4. The anon struct's vec type idx differed from the local's actual \`ref_null vec_externref\` idx → struct.get on the wrong type idx → wasm validation failure at instantiation:
   \`struct.get[0] expected type (ref null 6), found local.get of type (ref null 1) @+1995\`

## Fix
In \`ensureStructForType\` (\`src/codegen/index.ts\`), skip the built-in container/wrapper types that have dedicated codegen paths:
- \`Array\`, \`ReadonlyArray\` (vec types via \`getOrRegisterVecType\`)
- \`Int8Array\`/\`Uint8Array\`/\`Uint8ClampedArray\`/\`Int16Array\`/\`Uint16Array\`/\`Int32Array\`/\`Uint32Array\`/\`Float32Array\`/\`Float64Array\` (vec_f64)
- \`Promise\` (unwrapped to inner T)
- \`Date\` (WasmGC struct with i64 timestamp)
- \`Map\`, \`Set\`, \`WeakMap\`, \`WeakSet\`, \`RegExp\` (externref host objects)
- \`Number\`, \`String\`, \`Boolean\` (wrapper objects → externref)

Also fixed an adjacent bug in \`compileArrayMethodCall\`'s fast-path local-type lookup (\`array-methods.ts:1820\`): \`fctx.locals[localIdx]\` was wrong because \`localIdx\` is the wasm-level index (params + locals) while \`fctx.locals\` indexes only locals. Now uses \`getLocalType(fctx, localIdx)\`.

## Test plan
- [x] tests/issue-1247.test.ts — 5/5 pass (new: splitPath canonical repro, splitPath no-slash, typed-string[] + push, typed param + methods, untyped regression)
- [x] tests/issue-1238.test.ts — 15/15 pass (pseudo-ExternClassInfo)
- [x] tests/issue-1234.test.ts — 3/3 pass (sparse Array methods)
- [x] Full equivalence test suite — exit 0
- [ ] CI sharded test262 — net ≥ 0, no bucket > 50

## Unblocks
Hono stress test (#1244) Tier 1a — the natural typed \`splitPath\` signature now compiles without the \`: any\` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)