### PR TITLE
fix(#1248): substring/slice with single arg defaults missing end to s.length, not 0

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4023,9 +4023,31 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       const importName = `string_${method}`;
       const funcIdx = ctx.funcMap.get(importName);
       if (funcIdx !== undefined) {
-        compileExpression(ctx, fctx, propAccess.expression);
-        const paramTypes = getFuncParamTypes(ctx, funcIdx);
+        // #1248: substring/slice with a single argument default the missing
+        // `end` to `s.length`, NOT 0. Without this, the generic padding loop
+        // below pushes f64.const 0, and the host import calls
+        // `s.substring(start, 0)` — which JS spec swaps to `substring(0, start)`,
+        // returning the wrong prefix instead of the suffix from `start`.
+        // Save the receiver into a temp local so we can re-compute its length
+        // when padding the missing `end` arg.
         const args = expr.arguments;
+        const paramTypes = getFuncParamTypes(ctx, funcIdx);
+        const needsLengthDefault =
+          (method === "substring" || method === "slice") &&
+          args.length === 1 &&
+          paramTypes !== undefined &&
+          paramTypes.length === 3;
+        let savedReceiverLocal: number | undefined;
+        if (needsLengthDefault) {
+          // Ensure wasm:js-string.length is registered so we can compute s.length below.
+          addStringImports(ctx);
+          // Compile receiver, save to temp, leave on stack for the call.
+          compileExpression(ctx, fctx, propAccess.expression);
+          savedReceiverLocal = allocLocal(fctx, `__substr_recv_${fctx.locals.length}`, { kind: "externref" });
+          fctx.body.push({ op: "local.tee", index: savedReceiverLocal });
+        } else {
+          compileExpression(ctx, fctx, propAccess.expression);
+        }
         // Cap at declared param count (excluding self) to avoid pushing extra values
         const userParamCount = paramTypes ? paramTypes.length - 1 : args.length;
         for (let ai = 0; ai < args.length; ai++) {
@@ -4051,7 +4073,18 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         if (paramTypes && args.length + 1 < paramTypes.length) {
           for (let pi = args.length + 1; pi < paramTypes.length; pi++) {
             const pt = paramTypes[pi]!;
-            if (pt.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
+            if (needsLengthDefault && pi === 2 && savedReceiverLocal !== undefined && pt.kind === "f64") {
+              // #1248: For substring/slice missing-end, push s.length instead of 0.
+              const lenIdx = ctx.jsStringImports.get("length");
+              if (lenIdx !== undefined) {
+                fctx.body.push({ op: "local.get", index: savedReceiverLocal });
+                fctx.body.push({ op: "call", funcIdx: lenIdx });
+                fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+              } else {
+                // Fallback if length import is unavailable for some reason
+                fctx.body.push({ op: "f64.const", value: 0x7fffffff });
+              }
+            } else if (pt.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
             else if (pt.kind === "f64") fctx.body.push({ op: "f64.const", value: 0 });
             else if (pt.kind === "i32") fctx.body.push({ op: "i32.const", value: 0 });
           }

--- a/tests/issue-1248.test.ts
+++ b/tests/issue-1248.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1248 — `typeof x === "string"` guard breaks `substring(start)`
+// (single-arg form returns a single character instead of the suffix).
+//
+// Root cause: when a value is type-narrowed to `string` via `typeof`, the
+// dispatch in compileCallExpression takes the `isStringType(receiverType)`
+// path which calls the host import `string_substring(self, start, end)`.
+// The generic missing-arg padding loop (calls.ts:4051-4058) pushed
+// `f64.const 0` for the missing `end`, so the host call became
+// `s.substring(start, 0)`. Per ECMA-262 §22.1.3.21, `substring(a, b)`
+// swaps args when `a > b` — so `s.substring(1, 0)` returns `s.substring(0, 1)`,
+// the FIRST character, not the suffix from `start`.
+//
+// Fix: special-case `substring` and `slice` when `args.length === 1`. Save
+// the receiver to a temp local, then pad the missing `end` with the actual
+// `s.length` (computed via wasm:js-string.length) instead of `0`.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStringTest(source: string, fn = "test"): Promise<string> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as Record<string, () => string>)[fn]!();
+}
+
+describe("Issue #1248 — substring(start) under typeof guard", () => {
+  // Canonical repro from the issue file.
+  it("withGuard: typeof-narrowed string + substring(1) returns suffix not single char", async () => {
+    const src = `
+      export function withGuard(seg: any): any {
+        if (typeof seg === "string" && seg.charAt(0) === ":") {
+          return seg.substring(1);
+        }
+        return null;
+      }
+      export function test(): string {
+        const r = withGuard(":id");
+        return typeof r === "string" ? r : "(non-string)";
+      }
+    `;
+    expect(await runStringTest(src)).toBe("id"); // was ":" before fix
+  });
+
+  // Sanity: without the typeof guard, the fix should not affect behavior.
+  it("noGuard: any-typed receiver + substring(1) still works", async () => {
+    const src = `
+      export function noGuard(seg: any): any {
+        if (seg.charAt(0) === ":") {
+          return seg.substring(1);
+        }
+        return null;
+      }
+      export function test(): string {
+        const r = noGuard(":id");
+        return typeof r === "string" ? r : "(non-string)";
+      }
+    `;
+    expect(await runStringTest(src)).toBe("id");
+  });
+
+  // Two-arg substring still works (regression check on the padding logic).
+  it("two-arg substring is unchanged by the fix", async () => {
+    const src = `
+      export function test(): string {
+        const s: string = "hello";
+        return s.substring(1, 4); // "ell"
+      }
+    `;
+    expect(await runStringTest(src)).toBe("ell");
+  });
+
+  // Single-arg substring on a directly-typed string also goes through the
+  // same dispatch.
+  it("string-typed receiver + substring(start) returns suffix", async () => {
+    const src = `
+      export function test(): string {
+        const s: string = "hello world";
+        return s.substring(6); // "world"
+      }
+    `;
+    expect(await runStringTest(src)).toBe("world");
+  });
+
+  // slice has the same single-arg semantics — single arg defaults to length.
+  it("string-typed receiver + slice(start) returns suffix", async () => {
+    const src = `
+      export function test(): string {
+        const s: string = "hello world";
+        return s.slice(6); // "world"
+      }
+    `;
+    expect(await runStringTest(src)).toBe("world");
+  });
+
+  // Edge case: substring(0) — should return the full string.
+  it("substring(0) returns the full string", async () => {
+    const src = `
+      export function test(): string {
+        const s: string = "abc";
+        return s.substring(0);
+      }
+    `;
+    expect(await runStringTest(src)).toBe("abc");
+  });
+
+  // Edge case: substring(length) — returns empty string.
+  it("substring(length) returns empty string", async () => {
+    const src = `
+      export function test(): string {
+        const s: string = "abc";
+        return s.substring(3);
+      }
+    `;
+    expect(await runStringTest(src)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the typeof-narrowed `substring(start)` bug surfaced by Hono. When a value is type-narrowed to `string` via `typeof seg === "string"`, calling `seg.substring(1)` returned `":"` (the first char) instead of `"id"` (the suffix).

## Root cause
The dispatch in \`compileCallExpression\` takes the \`isStringType(receiverType)\` path which calls the host import \`string_substring(self, start, end)\`. The generic missing-arg padding loop at \`calls.ts:4051\` pushed \`f64.const 0\` for the missing \`end\` arg.

Per ECMA-262 §22.1.3.21, \`substring(a, b)\` swaps args when \`a > b\`. So \`s.substring(1, 0)\` was equivalent to \`s.substring(0, 1)\` — returning the first character instead of the suffix from \`start\`.

The bug was masked when the receiver was untyped (\`any\`) because the dispatch took a different path (proto-method-call host import) that defaulted args correctly. As soon as a typeof narrowing fired, the bug surfaced.

## Fix
At the start of the \`string_${method}\` dispatch in \`calls.ts\`, detect \`substring\`/\`slice\` with \`args.length === 1\`. Save the receiver to a temp local before consuming it on the stack, then in the padding loop push \`(saved_receiver).length\` (via \`wasm:js-string.length\` + \`f64.convert_i32_u\`) for the missing \`end\` arg instead of the generic \`f64.const 0\`.

Only \`substring\` and \`slice\` are special-cased; other methods (\`indexOf\`, \`lastIndexOf\`, etc.) keep their existing 0-default behavior, which is correct per spec for those methods.

## Test plan
- [x] tests/issue-1248.test.ts — 7/7 pass (new):
  - withGuard canonical repro (returns "id" not ":")
  - noGuard regression check (still works)
  - two-arg substring unchanged
  - single-arg substring on directly-typed string
  - single-arg slice (parallel semantics)
  - substring(0) returns full string
  - substring(length) returns empty string
- [x] tests/equivalence/string-methods.test.ts: **41/42 pass** (was 39/42 on main → my fix improved 2 tests; remaining 1 failure is pre-existing in \`lastIndexOf\`, unrelated)
- [ ] CI sharded test262 — net ≥ 0, no bucket > 50

## Unblocks
Hono stress test (#1244) Tier 1c — the natural \`typeof seg === "string"\` guard now compiles to correct substring semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)