### PR TITLE
test(#1249): regression guards for class private fields/methods (already implemented)

### DIFF
--- a/plan/issues/sprints/47/1249.md
+++ b/plan/issues/sprints/47/1249.md
@@ -62,4 +62,38 @@ level, not at the Wasm level. The `#name` identifier just needs to be treated as
 ## Related
 
 - #1244 — Hono stress test; Tier 2 blocked on this
-- #1250 — logical assignment operators `||=`, `&&=`, `??=` (also Tier 2 blockers)
+- #1250 — logical assignment operators (Tier 2 blockers)
+
+## Resolution
+
+Investigation showed that the support is **already implemented**
+end-to-end. Codegen layers (`binary-ops`, `class-bodies`, `expressions`,
+`expressions/assignment`, `typeof-delete`, `property-access`) all
+consult `ts.isPrivateIdentifier` and mangle `#foo` -> `__priv_foo`
+consistently before lowering to struct fields or method dispatch.
+
+This PR formalizes the support with regression-guard tests in
+`tests/issue-1249.test.ts`:
+
+- Private field read after default init
+- Private field write then read
+- Private + public field side-by-side (no name collision via mangling)
+- Private method called from public method (`this.#m()`)
+- Chained private method calls (`this.#a(this.#b(x))`)
+- Private array field with `.push()` / `.length` (Hono Node-like pattern)
+- Multiple private fields used together (state encapsulation)
+
+All 7 tests pass against the existing implementation; no codegen
+changes needed.
+
+## Side findings (separate follow-up to file)
+
+While writing the tests, I discovered an unrelated optimizer bug:
+**method calls in expression-statement position get dropped** when
+the result is unused, even when the method has side effects (e.g.
+mutates `this.#count`). Reproduces with both public and private
+fields, so it's not specific to private-field support. The third
+call's return shows up as the FIRST call's result; the WAT confirms
+only one `call` instruction is emitted for the body. This affects
+#1244 (Hono) patterns where method side-effects matter and merits
+its own issue.

--- a/tests/issue-1249.test.ts
+++ b/tests/issue-1249.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1249 — Class private fields and methods (`#name` syntax).
+//
+// Status when this PR was opened: investigation showed the support is
+// **already implemented** end-to-end. The codegen layers (binary-ops,
+// class-bodies, expressions, expressions/assignment, typeof-delete,
+// property-access) all consult `ts.isPrivateIdentifier` and mangle
+// `#foo` → `__priv_foo` consistently before lowering to struct fields
+// or method dispatch. The wasm-level storage model is identical to
+// regular fields — private semantics are a TS/JS language-level
+// concept enforced before codegen runs.
+//
+// This test file formalizes that support so future regressions surface
+// in CI rather than via Hono Tier 2 stress tests (#1244). It covers:
+//   - Private field read / write
+//   - Private method call
+//   - Private + public field side-by-side (no name collision via mangle)
+//   - Private array field with .push() / .length (Hono Node-like pattern)
+//   - Private field default initializer
+//   - Self-referential private state (a method that writes #x and
+//     a separate method that reads it)
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+interface InstantiateResult {
+  exports: Record<string, unknown>;
+}
+
+async function compileAndInstantiate(source: string): Promise<InstantiateResult> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => `L${e.line}:${e.column} ${e.message}`).join(" | ")}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  return { exports: instance.exports as Record<string, unknown> };
+}
+
+describe("#1249 — class private fields (#name syntax)", () => {
+  it("private field — read after default init", async () => {
+    const source = `
+      class C {
+        #v: number = 42;
+        getV(): number { return this.#v; }
+      }
+      export function run(): number { return new C().getV(); }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(42);
+  });
+
+  it("private field — write then read", async () => {
+    const source = `
+      class C {
+        #x: number = 0;
+        set(v: number): void { this.#x = v; }
+        get(): number { return this.#x; }
+      }
+      export function run(): number {
+        const c = new C();
+        c.set(99);
+        return c.get();
+      }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(99);
+  });
+
+  it("private + public field side-by-side — no name collision via mangling", async () => {
+    // Both `foo` and `#foo` are valid simultaneously per TC39 Class Fields
+    // spec. The codegen mangles `#foo` → `__priv_foo` so the struct has
+    // two distinct fields.
+    const source = `
+      class C {
+        foo: number = 1;
+        #foo: number = 2;
+        getPublic(): number { return this.foo; }
+        getPrivate(): number { return this.#foo; }
+      }
+      export function runPublic(): number { return new C().getPublic(); }
+      export function runPrivate(): number { return new C().getPrivate(); }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.runPublic as () => number)()).toBe(1);
+    expect((r.exports.runPrivate as () => number)()).toBe(2);
+  });
+});
+
+describe("#1249 — class private methods (#name syntax)", () => {
+  it("private method — called from a public method on the same class", async () => {
+    const source = `
+      class C {
+        #compute(x: number): number { return x * 2; }
+        go(x: number): number { return this.#compute(x); }
+      }
+      export function run(x: number): number { return new C().go(x); }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as (x: number) => number)(5)).toBe(10);
+  });
+
+  it("private method — chained calls within the class", async () => {
+    const source = `
+      class C {
+        #double(x: number): number { return x * 2; }
+        #triple(x: number): number { return x * 3; }
+        process(x: number): number { return this.#double(this.#triple(x)); }
+      }
+      export function run(x: number): number { return new C().process(x); }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as (x: number) => number)(4)).toBe(24);
+  });
+});
+
+describe("#1249 — Hono Node-like pattern (acceptance criterion 3)", () => {
+  it("private array field with push() + length", async () => {
+    // Mirrors the structural pattern from Hono's TrieRouter Node class:
+    //   class Node { #methods: number[] = []; addRoute(m: number) { this.#methods.push(m); } }
+    // The exact Hono uses `Array<Readonly<Result<T>>>` which involves
+    // generics and Readonly utility types — those are orthogonal to
+    // private-field support. This test pins the private-field-with-array
+    // pattern.
+    const source = `
+      class Node {
+        #methods: number[] = [];
+        addRoute(method: number): void {
+          this.#methods.push(method);
+        }
+        size(): number {
+          return this.#methods.length;
+        }
+        hasAny(): boolean {
+          return this.#methods.length > 0;
+        }
+      }
+      export function runEmpty(): boolean { return new Node().hasAny(); }
+      export function runAfterAdd(): number {
+        const n = new Node();
+        n.addRoute(1);
+        n.addRoute(2);
+        n.addRoute(3);
+        return n.size();
+      }
+    `;
+    const r = await compileAndInstantiate(source);
+    // hasAny() returns boolean; export value is i32 (0/1).
+    expect((r.exports.runEmpty as () => number)()).toBe(0);
+    expect((r.exports.runAfterAdd as () => number)()).toBe(3);
+  });
+
+  it("multiple private fields used together (state encapsulation)", async () => {
+    // Avoid the unrelated optimizer-elision bug for repeated method
+    // calls (filed as a follow-up — affects both public AND private
+    // class methods in IR-claimed top-level functions). Instead we
+    // accumulate via direct field reads/writes inside a single method
+    // body, which exercises the same #count/#step state but doesn't
+    // depend on expression-statement preservation across multiple
+    // method calls from the entry function.
+    const source = `
+      class Counter {
+        #count: number = 0;
+        #step: number;
+        constructor(step: number) {
+          this.#step = step;
+        }
+        runThreeTicks(): number {
+          this.#count = this.#count + this.#step;
+          this.#count = this.#count + this.#step;
+          this.#count = this.#count + this.#step;
+          return this.#count;
+        }
+      }
+      export function run(): number {
+        return new Counter(7).runThreeTicks();
+      }
+    `;
+    const r = await compileAndInstantiate(source);
+    // 0 + 7 + 7 + 7 = 21
+    expect((r.exports.run as () => number)()).toBe(21);
+  });
+});


### PR DESCRIPTION
## Summary

Class private fields (\`#name\` syntax) are **already implemented** end-to-end — the codegen layers (\`binary-ops\`, \`class-bodies\`, \`expressions\`, \`expressions/assignment\`, \`typeof-delete\`, \`property-access\`) all consult \`ts.isPrivateIdentifier\` and mangle \`#foo\` → \`__priv_foo\` consistently before lowering to struct fields or method dispatch.

This PR formalizes the support with **regression-guard tests** so future changes that break private fields surface in CI rather than via Hono Tier 2 stress tests (#1244).

## Tests added (7 cases, all green)

- Private field read after default init
- Private field write then read
- Private + public field side-by-side (no name collision via mangling)
- Private method called from public method (\`this.#m()\`)
- Chained private method calls (\`this.#a(this.#b(x))\`)
- Private array field with \`.push()\` / \`.length\` (Hono Node-like pattern)
- Multiple private fields used together (state encapsulation)

## Acceptance criteria from issue

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Minimal class with #field compiles + accesses correctly | ✅ already works |
| 2 | tests/issue-1249.test.ts covers private field r/w + private method call | ✅ this PR |
| 3 | Hono's Node class with #methods/#children gets past compile error | ✅ confirmed via Node-like test |
| 4 | No regression in tests/equivalence/ class tests | TBD — CI verifies |

## Side finding (separate follow-up to file)

While writing the tests I found an unrelated optimizer bug: **method calls in expression-statement position get dropped** when the result is unused, even when the method has side effects. Reproduces with public AND private fields, so not specific to this issue. The third \`tick()\` in \`c.tick(); c.tick(); return c.tick();\` returns the value from the FIRST call — emitted WAT confirms only ONE \`call\` for the body. Affects #1244 (Hono) patterns where method side-effects matter; merits its own issue (will file).

The state-encapsulation test in this PR works around it by accumulating inside a single method body rather than across multiple top-level method calls.

## Test plan

- [x] tests/issue-1249.test.ts — 7/7 pass
- [ ] CI test262 sharded — confirm no regression in equivalence/class tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)