### PR TITLE
test(#1250): regression tests for ES2021 logical assignment operators (||=, &&=, ??=)

### DIFF
--- a/plan/issues/sprints/47/1250.md
+++ b/plan/issues/sprints/47/1250.md
@@ -1,7 +1,7 @@
 ---
 id: 1250
 title: "logical assignment operators: ||=, &&=, ??= (ES2021)"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: medium
@@ -14,6 +14,46 @@ goal: npm-library-support
 es_edition: ES2021
 related: [1244]
 ---
+
+## Investigation finding (2026-05-02, dev-1245)
+
+**The operators are already implemented.** Smoke-testing on `origin/main`
+shows all three operators (`||=`, `&&=`, `??=`) compile and run correctly
+for identifier, property-access, and element-access targets:
+
+```
+prop ??= externref-null:    OK (5)
+identifier ??= null:        OK (7)
+prop ??= 0 (keep):          OK (0 — 0 is not nullish, spec-correct)
+prop ||= 0 (reassign):      OK (11)
+prop &&= 1 (reassign):      OK (13)
+elem ??= null:              OK (42)
+short-circuit ??=:          OK (RHS not evaluated)
+short-circuit ||=:          OK
+short-circuit &&=:          OK
+number-typed ??= short-cir: OK (i32/f64 can never be nullish)
+```
+
+The implementation is in `src/codegen/expressions/assignment.ts`:
+- `emitLogicalAssignmentPattern` (line 3183) — shared if/else codegen for
+  the three operators with proper short-circuit semantics.
+- Callers wire it from identifier (line 3039), property-access (lines 2817,
+  2858, 2938), and element-access (lines 3096, 3156) targets.
+
+The issue title's claim "cause a compile error today" was stale. PR closes
+the issue by adding regression tests that lock in the working behavior.
+
+### Edge case (out of scope — separate issue)
+
+The Hono-style `obj[runtimeKey] ??= newValue` pattern, where `obj` is a
+TypeScript index signature `{[key: string]: T}` rather than a registered
+struct or vec, returns NaN. This is a property of the index-signature
+codegen path (the `??=` operator dispatches correctly; the underlying
+indexed-set on a dictionary is what fails). Filing as a follow-up
+because it's well outside the ES2021 logical-assignment-operators feature
+scope.
+
+
 # #1250 — Logical assignment operators: `||=`, `&&=`, `??=`
 
 ## Problem

--- a/tests/issue-1250.test.ts
+++ b/tests/issue-1250.test.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1250 — logical assignment operators: ||=, &&=, ??= (ES2021).
+//
+// Investigation finding (2026-05-02): the operators are already implemented
+// in `src/codegen/expressions/assignment.ts:emitLogicalAssignmentPattern`
+// and exercised through the `compileAssignmentExpression` paths for
+// identifier, property-access, and element-access targets. The issue title
+// said they "cause a compile error today" but smoke-testing on origin/main
+// shows all three operators compile and run correctly for the documented
+// targets.
+//
+// This test file locks in the current behavior to prevent regressions and
+// satisfies the issue's acceptance criterion 3 ("tests/issue-1250.test.ts
+// covers all three operators on local and property targets").
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1250 — logical assignment operators on identifiers", () => {
+  // ||= : assigns iff LHS is falsy
+  it("a ||= b assigns when LHS is falsy (number 0)", async () => {
+    const src = `
+      export function test(): number {
+        let a: number = 0;
+        a ||= 5;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(5);
+  });
+
+  it("a ||= b keeps LHS when LHS is truthy", async () => {
+    const src = `
+      export function test(): number {
+        let a: number = 7;
+        a ||= 99;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(7);
+  });
+
+  // &&= : assigns iff LHS is truthy
+  it("a &&= b assigns when LHS is truthy", async () => {
+    const src = `
+      export function test(): number {
+        let a: number = 1;
+        a &&= 13;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(13);
+  });
+
+  it("a &&= b keeps LHS when LHS is falsy", async () => {
+    const src = `
+      export function test(): number {
+        let a: number = 0;
+        a &&= 99;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  // ??= : assigns iff LHS is null/undefined
+  it("a ??= b assigns when LHS is null", async () => {
+    const src = `
+      export function test(): number {
+        let a: any = null;
+        a ??= 7;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(7);
+  });
+
+  it("a ??= b keeps LHS when LHS is non-null", async () => {
+    const src = `
+      export function test(): number {
+        let a: any = 3;
+        a ??= 99;
+        return a;
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+
+  // ??= on number-typed LHS: numbers are never nullish, RHS must NOT execute
+  it("number-typed ??= short-circuits (RHS not evaluated)", async () => {
+    const src = `
+      let counter: number = 0;
+      function inc(): number { counter += 1; return 99; }
+      export function test(): number {
+        let a: number = 5;
+        a ??= inc();
+        return counter; // 0 — inc was never called
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+});
+
+describe("Issue #1250 — short-circuit RHS evaluation", () => {
+  // The RHS must NOT be evaluated when the LHS satisfies the condition.
+  // ??= short-circuits when LHS is non-nullish.
+  it("??= does not evaluate RHS when LHS is non-nullish", async () => {
+    const src = `
+      let counter: number = 0;
+      function inc(): number { counter += 1; return 99; }
+      export function test(): number {
+        let a: any = 5;
+        a ??= inc();
+        return counter;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  // ||= short-circuits when LHS is truthy.
+  it("||= does not evaluate RHS when LHS is truthy", async () => {
+    const src = `
+      let counter: number = 0;
+      function inc(): number { counter += 1; return 99; }
+      export function test(): number {
+        let a: number = 1;
+        a ||= inc();
+        return counter;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  // &&= short-circuits when LHS is falsy.
+  it("&&= does not evaluate RHS when LHS is falsy", async () => {
+    const src = `
+      let counter: number = 0;
+      function inc(): number { counter += 1; return 99; }
+      export function test(): number {
+        let a: number = 0;
+        a &&= inc();
+        return counter;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+});
+
+describe("Issue #1250 — property-access targets", () => {
+  // ??= on a struct field that holds null externref → assigns
+  it("obj.field ??= b assigns when field is null externref", async () => {
+    const src = `
+      type Obj = { x: any };
+      export function test(): number {
+        const o: Obj = { x: null };
+        o.x ??= 5;
+        return o.x;
+      }
+    `;
+    expect(await runTest(src)).toBe(5);
+  });
+
+  // ??= on a struct field that holds non-null externref → keeps
+  it("obj.field ??= b keeps when field is non-null", async () => {
+    const src = `
+      type Obj = { x: any };
+      export function test(): number {
+        const o: Obj = { x: 42 };
+        o.x ??= 99;
+        return o.x;
+      }
+    `;
+    expect(await runTest(src)).toBe(42);
+  });
+
+  // ||= on number field with falsy value → reassigns
+  it("obj.field ||= b reassigns when field is 0", async () => {
+    const src = `
+      type Obj = { x: number };
+      export function test(): number {
+        const o: Obj = { x: 0 };
+        o.x ||= 11;
+        return o.x;
+      }
+    `;
+    expect(await runTest(src)).toBe(11);
+  });
+
+  // &&= on number field with truthy value → reassigns
+  it("obj.field &&= b reassigns when field is truthy", async () => {
+    const src = `
+      type Obj = { x: number };
+      export function test(): number {
+        const o: Obj = { x: 1 };
+        o.x &&= 13;
+        return o.x;
+      }
+    `;
+    expect(await runTest(src)).toBe(13);
+  });
+});
+
+describe("Issue #1250 — element-access targets", () => {
+  // Vec array element ??= when nullable (array of any with null entry)
+  it("arr[i] ??= b assigns when element is null", async () => {
+    const src = `
+      export function test(): number {
+        const a: any[] = [null];
+        a[0] ??= 42;
+        return a[0];
+      }
+    `;
+    expect(await runTest(src)).toBe(42);
+  });
+
+  // Vec array element ||= when falsy
+  it("arr[i] ||= b reassigns when element is 0", async () => {
+    const src = `
+      export function test(): number {
+        const a: number[] = [0];
+        a[0] ||= 7;
+        return a[0];
+      }
+    `;
+    expect(await runTest(src)).toBe(7);
+  });
+
+  // Vec array element &&= when truthy
+  it("arr[i] &&= b reassigns when element is truthy", async () => {
+    const src = `
+      export function test(): number {
+        const a: number[] = [1];
+        a[0] &&= 9;
+        return a[0];
+      }
+    `;
+    expect(await runTest(src)).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary
The three ES2021 logical assignment operators (\`||=\`, \`&&=\`, \`??=\`) are **already implemented** in \`src/codegen/expressions/assignment.ts:emitLogicalAssignmentPattern\`. Smoke-testing on origin/main confirms all three compile and run correctly with proper short-circuit semantics for identifier, property-access, and element-access targets.

The issue title's claim "cause a compile error today" was stale — likely fixed in earlier work without dedicated regression tests. This PR adds 17 regression tests to lock in the behavior and close the issue.

## Changes
- New: \`tests/issue-1250.test.ts\` — 17 tests covering:
  - \`||=\` / \`&&=\` / \`??=\` on identifier (truthy/falsy/null/non-null targets)
  - Short-circuit RHS evaluation for all three operators (RHS NOT evaluated when LHS satisfies the condition)
  - Number-typed \`??=\` short-circuits (numbers cannot be nullish per spec)
  - Property-access \`obj.field\` targets — all three operators
  - Element-access \`arr[i]\` targets — all three operators
- Updated: \`plan/issues/sprints/47/1250.md\` — investigation finding documented; status flipped to in-progress.

## Edge case (out of scope)
\`obj[runtimeKey] ??= v\` where \`obj\` is a TypeScript index signature \`{[key: string]: T}\` returns NaN. This is in the indexed-set dictionary codegen path, not the logical-assignment operator itself. Not part of the issue's acceptance criteria; will file as a separate follow-up if surfaced by Hono Tier 2 work.

## Acceptance criteria
- [x] \`||=\`, \`&&=\`, \`??=\` all compile and produce correct results
- [x] Property access targets work
- [x] tests/issue-1250.test.ts covers all three operators on local + property
- [x] No regression in tests/equivalence/ operator tests (test-only PR — no codegen changes)

## Test plan
- [x] tests/issue-1250.test.ts — 17/17 pass post-merge
- [ ] CI sharded test262 — net should be ≈0 (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)