### PR TITLE
fix(#1251): align validator with sharded runner — skipSemanticDiagnostics:true

### DIFF
--- a/plan/issues/sprints/47/1251.md
+++ b/plan/issues/sprints/47/1251.md
@@ -1,7 +1,7 @@
 ---
 id: 1251
 title: "baseline-validate: TS checker non-determinism causes 19/50 false failures on main JSONL"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: medium
@@ -13,6 +13,64 @@ language_feature: test-infrastructure
 goal: ci-hardening
 related: [1218, 1246]
 ---
+
+## Root cause + fix (2026-05-02, dev-1245)
+
+Not actually TS-checker non-determinism — it's a **flag mismatch** between
+the sharded runner and the validator.
+
+**Discovery**: the sharded test262 runner (`scripts/compiler-fork-worker.mjs`,
+which records the committed JSONL via `precompile-tests.ts`) calls
+`compile()` with `skipSemanticDiagnostics: true`. The validator's
+`runTest262File` (`tests/test262-runner.ts:2457`) does NOT pass this flag.
+
+So when the validator re-checks a sampled "pass" entry, TypeScript runs
+full semantic diagnostics on the wrapped test source. Many test262
+fixtures contain TS-incompatible patterns ("Argument of type '{}' is
+not assignable to parameter of type '[any]'", "Type 'IArguments' is not
+assignable to type 'boolean | undefined'", etc.) that the sharded runner
+ignores via `skipSemanticDiagnostics: true`. The validator rejects them
+as `compile_error` — false-positive corruption signal.
+
+The "non-determinism" symptom was the seed-driven sample landing on
+different counts of TS-incompatible-but-recorded-as-pass tests on
+different PR runs (PR_NUMBER seeds the PRNG).
+
+**Fix**: pass `skipSemanticDiagnostics: true` to `compile()` in
+`runTest262File`. One-line change. Aligns the validator with the
+production sharded runner.
+
+**Verification**: 5 seeds × 50 samples each — all 5 runs report 0
+failures. Previous repro (seed 4967) went from 6 failures to 0.
+
+```
+=== seed 4626 ===  Validated 50 entries in 7.9s. Failures: 0.
+=== seed 12345 === Validated 50 entries in 5.3s. Failures: 0.
+=== seed 67890 === Validated 50 entries in 3.7s. Failures: 0.
+=== seed 11111 === Validated 50 entries in 3.4s. Failures: 0.
+=== seed 99999 === Validated 50 entries in 4.3s. Failures: 0.
+=== seed 4967 (was 6 failures) === Validated 50 entries in 10.2s. Failures: 0.
+```
+
+### Why the original "TS state pollution" hypothesis was wrong
+
+The issue's investigation hypothesised that TS internal cache pollution
+(`createProgram()` reuse, lib loading order, vitest worker pool state)
+caused the false failures. I initially implemented a retry-pass to
+distinguish transient from real failures — but discovered the failures
+were 100% deterministic and persistent on retry (transient: 0, real: 6
+on seed 4967). That ruled out state pollution and pointed at a
+configuration mismatch instead. The retry-pass approach was reverted in
+favour of the one-line flag alignment.
+
+### Acceptance criteria
+
+1. ☑ `pnpm run test:262:validate-baseline` runs 3+ times with different seeds without spurious failures (5/5 seeds clean locally)
+2. ☐ CI `baseline-validate` passes on a clean main PR (validated by this PR's own CI)
+3. ☑ Root cause documented in this issue file
+
+---
+
 # #1251 — baseline-validate: TS checker non-determinism causes false failures in committed JSONL
 
 ## Problem

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2458,6 +2458,16 @@ export async function runTest262File(
       fileName: "test.ts",
       sourceMap: true,
       emitWat: false,
+      // #1251: align with the sharded runner — both `scripts/compiler-fork-worker.mjs`
+      // (the production path that records the committed JSONL) and `tests/test262-vitest.test.ts`
+      // FIXTURE multi-compile pass `skipSemanticDiagnostics: true`. Without this flag,
+      // `runTest262File` ran TypeScript type-checking on the wrapped test source while
+      // the JSONL recorded results from a skipSemanticDiagnostics=true sharded run, so
+      // tests with TS type-incompatible code (Argument of type 'X' is not assignable …)
+      // would pass in the sharded run but fail in `validate-test262-baseline`, producing
+      // 6–19 false-positive `compile_error` failures per validator run depending on the
+      // sample. Aligning the flag eliminates the entire TS-checker non-determinism cluster.
+      skipSemanticDiagnostics: true,
     });
     compileMs = performance.now() - compileStart;
 


### PR DESCRIPTION
## Summary
Fixes the recurring \`baseline-validate\` false-positive failures (4–19/50 per run) by passing \`skipSemanticDiagnostics: true\` to \`compile()\` in \`runTest262File\` — aligning the validator with the production sharded runner that records the committed JSONL.

## Root cause
The "TS-checker non-determinism" reported in the issue was actually a **configuration mismatch**:

- **Sharded runner** (\`scripts/compiler-fork-worker.mjs\`, line 26): calls \`compile()\` with \`skipSemanticDiagnostics: true\`. This is what records the committed JSONL via \`precompile-tests.ts\`.
- **Validator** (\`tests/test262-runner.ts:runTest262File\`, line 2457): did NOT pass the flag. The validator therefore ran TypeScript with full semantic diagnostics on the wrapped test source.

Many test262 fixtures contain TS-incompatible patterns the sharded run silently ignores:
- \`Argument of type '{}' is not assignable to parameter of type '[any]'\`
- \`Type 'IArguments' is not assignable to type 'boolean | undefined'\`
- \`Argument of type 'number' is not assignable to parameter of type 'boolean'\`

The validator rejected these as \`compile_error\` → false "baseline corruption" alarms. The "non-determinism" was the seed-driven sample landing on different counts of these tests on different PR runs.

## Fix
One-line addition: \`skipSemanticDiagnostics: true\` in the \`compile()\` call inside \`runTest262File\`.

## Verification
6 seeds × 50 samples each — all clean (0 failures), including seed 4967 which previously gave 6 failures:

\`\`\`
=== seed 4626 ===  Failures: 0 (50 entries / 7.9s)
=== seed 12345 === Failures: 0 (50 entries / 5.3s)
=== seed 67890 === Failures: 0 (50 entries / 3.7s)
=== seed 11111 === Failures: 0 (50 entries / 3.4s)
=== seed 99999 === Failures: 0 (50 entries / 4.3s)
=== seed 4967 (was 6 fail) === Failures: 0 (50 entries / 10.2s)
\`\`\`

## Why the original hypothesis was wrong
The issue suspected TS internal cache pollution (\`createProgram()\` reuse, lib loading order, vitest worker pool state). I initially implemented a retry-pass to detect transient vs persistent failures — but found failures were 100% deterministic on retry (transient: 0, real: 6 on seed 4967). That ruled out state pollution and pointed at a config mismatch instead. Retry-pass approach was reverted in favour of the one-line flag alignment.

## Test plan
- [x] Local: 6 seeds × 50 samples, 0 failures
- [ ] CI: \`baseline-validate\` passes on this PR (validated by CI on push)
- [ ] CI: full sharded test262 (test-runner code change shouldn't affect sharded path which uses workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)