### PR TITLE
fix(dstr-assign): emit TypeError on null/undefined source per §13.15.5.5 (#1260)

### DIFF
--- a/plan/issues/sprints/47/1260.md
+++ b/plan/issues/sprints/47/1260.md
@@ -1,7 +1,7 @@
 ---
 id: 1260
 title: "Destructuring of null/undefined must throw TypeError per §13.15.5.5"
-status: ready
+status: review
 created: 2026-05-02
 updated: 2026-05-02
 priority: high
@@ -118,3 +118,60 @@ What's missing:
 - #1177 — TDZ propagation (Stage 1 blocked on this)
 - #1225 — emitExternrefDestructureGuard (top-level loop element)
 - #1245 — Investigation finding
+
+## Implementation summary
+
+Patched `src/codegen/expressions/assignment.ts` with two targeted fixes:
+
+1. **`emitObjectDestructureFromLocal`** — when the source struct of an
+   object destructure is statically `ref T` (non-nullable) but the runtime
+   value can be null (e.g. `[{x}] = [null]`: `[null]` is typed `null[]`,
+   element-extracted as ref but the runtime value is null), the previous
+   guard at line 1492 was gated on `srcType.kind === "ref_null"` and
+   silently skipped for `ref`. struct.get on the null reference produced
+   a Wasm null_deref instead of the spec-required TypeError. Fix: widen
+   the source local to nullable via `widenLocalToNullable` and always emit
+   the `ref.is_null` → throw guard for non-empty patterns. Mirrors the
+   pre-existing widening in `emitArrayDestructureFromLocal` (#1225).
+
+2. **`compileDestructuringAssignment` no-struct fallback** — when the RHS
+   of `({...} = expr)` is externref / `ref_null` and no struct type can
+   be resolved, the previous fallback only checked `ref.is_null`,
+   silently allowing JS-undefined sentinels through (per §13.15.5.5
+   RequireObjectCoercible, both null AND undefined must throw). Fix:
+   route externref through `emitExternrefAssignDestructureGuard` which
+   emits both `ref.is_null` AND `__extern_is_undefined` checks.
+
+`tests/issue-1260.test.ts` covers 7 cases:
+- `[{x}] = [null]` (typed-array path, was null_deref → now TypeError)
+- `[{x}] = [null]` with `any[]` (externref path)
+- `[[a]] = [null]` (regression sanity — already worked)
+- `[[_]] = [,]` (sparse hole = undefined → TypeError)
+- `({x: [x]} = {x: undefined})` (object source, undefined property)
+- Regression sanity: non-null `[a, b] = [10, 20]`
+- Regression sanity: nested `[{x: a}, {y: b}] = [{x:1}, {y:2}]`
+
+The test262 case `array-elem-nested-obj-null.js` (assignment-expression
+form) now passes — previously failed with `dereferencing a null pointer`
+instead of TypeError.
+
+## Out-of-scope (deferred follow-ups)
+
+Identified during investigation but left for separate issues (the
+ref/ref_null encoding cannot distinguish JS null from undefined in
+struct fields, requiring runtime infrastructure changes):
+
+- **`emitNestedBindingDefault` ref/ref_null path** (destructuring.ts:215)
+  — when a function param has shape `{w: {x,y,z} = D}` and is called with
+  `{w: null}`, the default branch fires on `ref.is_null` (treating both
+  null and undefined as triggers). Per spec, default fires only on
+  undefined; null should throw TypeError. Affects ~5 test262 cases:
+  - `expressions/class/dstr/gen-meth-obj-ptrn-prop-obj-value-null.js`
+  - `expressions/object/dstr/gen-meth-obj-ptrn-prop-obj-value-null.js`
+  - `expressions/object/dstr/async-gen-meth-obj-ptrn-prop-obj-value-null.js`
+  - `statements/class/dstr/gen-meth-obj-ptrn-prop-obj-value-null.js`
+
+- **For-of typed-struct path with nested array/object property targets**
+  (loops.ts:1181-1230) — `for ({x: [x]} of [{x: undefined}])` doesn't
+  dispatch on nested array/object property initializers; only handles
+  identifier targets. Affects ~2 for-of test262 cases.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -491,20 +491,31 @@ function compileDestructuringAssignment(
   // patterns the bindings stay at their defaults (mimics JS behaviour for
   // destructuring primitives — the properties simply do not exist). (#379)
   if (!typeName || !ctx.structMap.has(typeName) || !ctx.structFields.get(typeName)) {
-    // Null/undefined check — throw TypeError (#783).
-    // In JS, `{...} = null` and `{...} = undefined` always throw TypeError.
+    // Null/undefined check — throw TypeError (#783, #1260).
+    // In JS, `{...} = null` and `{...} = undefined` always throw TypeError per
+    // §13.15.5.5 RequireObjectCoercible. Use emitExternrefAssignDestructureGuard
+    // which checks BOTH ref.is_null (catches null) AND __extern_is_undefined
+    // (catches the JS undefined sentinel). The bare ref.is_null check missed
+    // undefined-encoded externrefs (#1260).
     // Skip for empty `{} = val` patterns (#225) — only fire on real property accesses.
     if ((resultType.kind === "externref" || resultType.kind === "ref_null") && target.properties.length > 0) {
-      const throwInstrs = buildDestructureNullThrow(ctx, fctx);
       const tmpNullChk = allocLocal(fctx, `__destruct_null_chk_${fctx.locals.length}`, resultType);
-      fctx.body.push({ op: "local.tee", index: tmpNullChk });
-      fctx.body.push({ op: "ref.is_null" } as Instr);
-      fctx.body.push({
-        op: "if",
-        blockType: { kind: "empty" },
-        then: throwInstrs,
-        else: [],
-      });
+      fctx.body.push({ op: "local.set", index: tmpNullChk });
+      if (resultType.kind === "externref") {
+        emitExternrefAssignDestructureGuard(ctx, fctx, tmpNullChk);
+      } else {
+        // ref_null source: only ref.is_null is meaningful (no undefined sentinel
+        // for typed-struct refs).
+        const throwInstrs = buildDestructureNullThrow(ctx, fctx);
+        fctx.body.push({ op: "local.get", index: tmpNullChk });
+        fctx.body.push({ op: "ref.is_null" } as Instr);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: throwInstrs,
+          else: [],
+        });
+      }
       // Restore value on stack
       fctx.body.push({ op: "local.get", index: tmpNullChk });
     }
@@ -1407,6 +1418,15 @@ function emitObjectDestructureFromLocal(
   const fields = ctx.structFields.get(structName);
   if (!fields) return;
 
+  // The compiler may declare the local as non-nullable `ref T` even though
+  // the value at runtime can be null (e.g. `[{x}] = [null]` element-extracts
+  // a ref_null whose runtime value is null but whose static type is `ref T`).
+  // Widen the local so `ref.is_null` is valid below (#1260, mirrors #1225).
+  const needsNullGuard = pattern.properties.length > 0;
+  if (needsNullGuard) {
+    widenLocalToNullable(fctx, srcLocal);
+  }
+
   // Null guard for ref_null types
   const savedBodyODFL = fctx.body;
   const odflInstrs: Instr[] = [];
@@ -1486,10 +1506,11 @@ function emitObjectDestructureFromLocal(
     }
   }
 
-  // Close null guard — throw TypeError if null/undefined (#730).
+  // Close null guard — throw TypeError if null/undefined (#730, #1260).
   // Skip for empty `{} = val` nested patterns (#225).
+  // Apply to both ref and ref_null sources (we widened above, so ref.is_null is valid).
   fctx.body = savedBodyODFL;
-  if (srcType.kind === "ref_null" && pattern.properties.length > 0) {
+  if (needsNullGuard) {
     const throwInstrs = buildDestructureNullThrow(ctx, fctx);
     fctx.body.push({ op: "local.get", index: srcLocal });
     fctx.body.push({ op: "ref.is_null" } as Instr);

--- a/tests/issue-1260.test.ts
+++ b/tests/issue-1260.test.ts
@@ -1,0 +1,135 @@
+/**
+ * #1260 — Destructuring null/undefined must throw TypeError per
+ * ECMA-262 §13.15.5.5 (RequireObjectCoercible) / §8.4.2 (GetIterator).
+ *
+ * Two bugs were fixed in `src/codegen/expressions/assignment.ts`:
+ *
+ * 1. `emitObjectDestructureFromLocal` (typed-array path) — when the source
+ *    of an object destructure is a struct field statically typed `ref T`
+ *    (non-nullable), the runtime value can still be null (e.g.
+ *    `[{x}] = [null]` types the inner element as `ref null T` but the
+ *    static field type may be widened to `ref`). Pre-fix, the null guard
+ *    was gated on `srcType.kind === "ref_null"` and silently skipped for
+ *    `ref`, causing struct.get on a null reference and a Wasm null_deref
+ *    instead of the spec-required TypeError. The fix widens the local to
+ *    nullable and always emits the guard for non-empty patterns.
+ *
+ * 2. `compileDestructuringAssignment` no-struct fallback — when the RHS
+ *    is externref (e.g. `({x} = anyExpr)`) and the type-checker can't
+ *    resolve a struct, the fallback only checked `ref.is_null` and
+ *    silently allowed JS undefined sentinels through. The fix routes
+ *    through `emitExternrefAssignDestructureGuard` which checks BOTH
+ *    `ref.is_null` AND `__extern_is_undefined`.
+ *
+ * The test262 case `array-elem-nested-obj-null.js` (assignment expression
+ * variant) now passes — previously failed with `dereferencing a null
+ * pointer` instead of TypeError.
+ *
+ * Out-of-scope (deferred follow-ups identified during this PR):
+ * - `emitNestedBindingDefault` cannot distinguish null from undefined in
+ *   ref/ref_null struct-field encoding, so `function f({w: {x} = D})`
+ *   called with `{w: null}` incorrectly applies the default instead of
+ *   throwing. Requires runtime undefined-vs-null distinction.
+ * - `for ({x: [x]} of [{x: undefined}])` — the typed-struct for-of path
+ *   doesn't dispatch on nested array/object property targets.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<{ exports: Record<string, Function> }> {
+  const result = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(result.imports as any, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as any);
+  if (typeof (importResult as any).setExports === "function") {
+    (importResult as any).setExports(inst.instance.exports as any);
+  }
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+describe("Issue #1260 — destructuring null/undefined throws TypeError", () => {
+  it("[{x}] = [null] throws TypeError (typed-array nested object)", async () => {
+    // test262: language/expressions/assignment/dstr/array-elem-nested-obj-null.js
+    // Pre-fix: dereferencing a null pointer (Wasm trap, not TypeError).
+    const { exports } = await run(`
+      export function test(): number {
+        let x: any;
+        try { [{x}] = [null]; return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("[{x}] = [null] explicit any[] (externref path) throws", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        let x: any;
+        let arr: any[] = [null];
+        try { [{x}] = arr; return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("[[a]] = [null] throws TypeError (regression: still works)", async () => {
+    // test262: language/expressions/assignment/dstr/array-elem-nested-array-null.js
+    const { exports } = await run(`
+      export function test(): number {
+        let a: any;
+        try { [[a]] = [null]; return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("[[_]] = [,] (sparse hole) throws TypeError", async () => {
+    // test262: language/expressions/assignment/dstr/array-elem-nested-array-undefined-hole.js
+    const { exports } = await run(`
+      export function test(): number {
+        let _: any;
+        try { [[_]] = [,]; return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("({x: [x]} = {x: undefined}) throws TypeError (object source extracts undefined)", async () => {
+    // test262: language/expressions/assignment/dstr/obj-prop-nested-array-undefined-own.js
+    const { exports } = await run(`
+      export function test(): number {
+        let x: any;
+        try { ({ x: [x] } = { x: undefined }); return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("non-null sources still destructure normally (regression sanity)", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        let a: any;
+        let b: any;
+        [a, b] = [10, 20];
+        if (a !== 10 || b !== 20) return 0;
+        let c: any;
+        ({ x: c } = { x: 42 });
+        return c === 42 ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("nested non-null sources destructure correctly (regression sanity)", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        let a: any, b: any;
+        [{x: a}, {y: b}] = [{x: 1}, {y: 2}];
+        return a === 1 && b === 2 ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two targeted fixes in `src/codegen/expressions/assignment.ts` for spec-violating destructuring of null/undefined per ECMA-262 §13.15.5.5 (RequireObjectCoercible) / §8.4.2 (GetIterator).

1. **`emitObjectDestructureFromLocal`** — when the source struct is statically typed `ref T` (non-nullable) but the runtime value can be null (e.g. `[{x}] = [null]` types `[null]` as `null[]`, element-extracts as ref but the runtime value is null), the previous null guard at line 1492 was gated on `srcType.kind === "ref_null"` and silently skipped for `ref`. struct.get on the null reference produced a Wasm null_deref instead of the spec-required TypeError. Fix: widen via `widenLocalToNullable` and always emit the guard for non-empty patterns. Mirrors `emitArrayDestructureFromLocal`'s pre-existing widening (#1225).

2. **`compileDestructuringAssignment` no-struct fallback** — when the RHS of `({...} = expr)` is externref and no struct type can be resolved, the fallback only checked `ref.is_null`, silently allowing JS undefined sentinels through. Fix: route externref through `emitExternrefAssignDestructureGuard` which checks both `ref.is_null` AND `__extern_is_undefined`.

The test262 case `array-elem-nested-obj-null.js` (assignment-expression form) now passes — previously failed with `dereferencing a null pointer` instead of TypeError.

## Test plan
- [x] `tests/issue-1260.test.ts` — 7/7 pass (covers both fixes + regression sanity)
- [x] `tests/issue-1225.test.ts` — 4/4 still pass (related null-guard tests)
- [x] `tests/issue-1258.test.ts` — 5/5 still pass (#1258 didn't regress)
- [x] `npx tsc --noEmit -p .` clean
- [ ] CI test262 — expect modest net improvement on `language/expressions/assignment/dstr/*-nested-*`

## Out-of-scope (deferred)

The ref/ref_null encoding cannot distinguish JS null from undefined in struct fields, requiring runtime infrastructure changes:
- `emitNestedBindingDefault` treats `ref.is_null` as "apply default" for both null and undefined (~5 gen-meth test262 cases like `expressions/class/dstr/gen-meth-obj-ptrn-prop-obj-value-null.js`).
- For-of typed-struct path doesn't dispatch nested array/object property targets in `for ({x: [x]} of [...])` (~2 for-of test262 cases).

Filed as follow-ups if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)