### PR TITLE
fix(#1268): obj[key] ??=/||=/&&= on index-signature dicts (3 layers)

### DIFF
--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2718,7 +2718,15 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
           opKind === ts.SyntaxKind.CaretEqualsToken ||
           opKind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
           opKind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
-          opKind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken;
+          opKind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+          // #1268 — logical-assignment operators (??=, ||=, &&=) are also
+          // assignment ops with side effects; without these, top-level
+          // statements like `d["x"] ??= 42` were silently dropped from
+          // `__module_init`, leaving the LHS uninitialised and reads
+          // returning NaN/undefined.
+          opKind === ts.SyntaxKind.QuestionQuestionEqualsToken ||
+          opKind === ts.SyntaxKind.BarBarEqualsToken ||
+          opKind === ts.SyntaxKind.AmpersandAmpersandEqualsToken;
         if (!isAssignOp) continue;
         const targetName = getAssignmentRootIdentifier(expr.left);
         if (targetName && ctx.moduleGlobals.has(targetName)) {

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -3052,9 +3052,23 @@ function compileElementLogicalAssignment(
 ): ValType | null {
   // Compile object expression
   const arrType = compileExpression(ctx, fctx, target.expression);
-  if (!arrType || (arrType.kind !== "ref" && arrType.kind !== "ref_null")) {
-    reportError(ctx, target, "Logical assignment on non-array element access");
+  if (!arrType) {
+    reportError(ctx, target, "Logical assignment on undefined element access target");
     return null;
+  }
+
+  // #1268 — index-signature dict (`{ [key: string]: T }`) lowers to
+  // externref (host JS object); other non-ref kinds (f64, i32 — rare,
+  // but possible via boxed primitives) likewise route through the host.
+  // Plain `obj[key] = val` already has a `compileExternSetFallback` arm
+  // for these; the parallel `??=` / `||=` / `&&=` arm was missing and
+  // produced a "Logical assignment on non-array element access" error
+  // that callers silently dropped, leaving the LHS uninitialized — the
+  // subsequent read returned NaN. This routes the logical-assignment
+  // case through the same `__extern_get` / `__extern_set` host imports
+  // the plain assignment uses.
+  if (arrType.kind !== "ref" && arrType.kind !== "ref_null") {
+    return compileElementLogicalAssignmentExternref(ctx, fctx, target, rhs, op, arrType);
   }
 
   const typeIdx = (arrType as { typeIdx: number }).typeIdx;
@@ -3162,6 +3176,129 @@ function compileElementLogicalAssignment(
 }
 
 /**
+ * #1268 — `obj[key] ??= rhs` / `obj[key] ||= rhs` / `obj[key] &&= rhs`
+ * where `obj` is an index-signature dict (lowered to externref) or any
+ * other non-ref / non-ref_null target.
+ *
+ * Mirrors `compileExternSetFallback` for the read+write portions and
+ * `emitLogicalAssignmentPattern` for the short-circuit semantics.
+ *
+ * Layout:
+ *   1. Coerce obj to externref (already on stack), save to `__lelm_obj`
+ *   2. Compute key (externref string), save to `__lelm_key`
+ *   3. emitGet := obj_local; key_local; call $__extern_get → externref
+ *   4. emitSet (after RHS pushed): save val to `__lelm_val`;
+ *      obj_local; key_local; val_local; call $__extern_set;
+ *      val_local (return value)
+ *   5. emitLogicalAssignmentPattern handles the if/else dispatch
+ *
+ * Result type is externref — the host import lives in externref world,
+ * and the caller-visible value is whatever the write/read produced.
+ *
+ * Caveat: `??=` semantics in JS treat `null` AND `undefined` as nullish.
+ * `__extern_get` returns `ref.null.extern` for missing keys (which the
+ * `ref.is_null` check captures correctly) and a boxed `undefined` for
+ * keys present with undefined value. The current `emitLogicalAssignment-
+ * Pattern` only checks `ref.is_null` for the `??=` arm, which matches
+ * the legacy global-scope `??=` behaviour. Distinguishing
+ * `undefined`-vs-other-truthy is the same gap that the global path has
+ * (compiled there too) — leave aligned with the existing convention.
+ */
+function compileElementLogicalAssignmentExternref(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.ElementAccessExpression,
+  rhs: ts.Expression,
+  op: ts.SyntaxKind,
+  objType: ValType,
+): ValType | null {
+  // Coerce obj on stack to externref (mirrors compileExternSetFallback's prelude).
+  if (objType.kind === "externref") {
+    // already externref
+  } else if (objType.kind === "f64") {
+    const boxIdx = ctx.funcMap.get("__box_number");
+    if (boxIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: boxIdx });
+    } else {
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+  } else if (objType.kind === "i32") {
+    fctx.body.push({ op: "f64.convert_i32_s" });
+    const boxIdx = ctx.funcMap.get("__box_number");
+    if (boxIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: boxIdx });
+    } else {
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+  } else {
+    reportError(ctx, target, "Unsupported element logical-assignment target type");
+    return null;
+  }
+
+  // Save obj to a local so we can read it twice (get + set).
+  const objLocal = allocLocal(fctx, `__lelm_obj_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: objLocal });
+
+  // Compute key (always externref string for host imports) and save.
+  const keyType = compileExpression(ctx, fctx, target.argumentExpression, { kind: "externref" });
+  if (!keyType) return null;
+  // Coerce key to externref if needed (string literals already are).
+  if (keyType.kind === "f64") {
+    const boxIdx = ctx.funcMap.get("__box_number");
+    if (boxIdx !== undefined) fctx.body.push({ op: "call", funcIdx: boxIdx });
+  } else if (keyType.kind === "i32") {
+    fctx.body.push({ op: "f64.convert_i32_s" });
+    const boxIdx = ctx.funcMap.get("__box_number");
+    if (boxIdx !== undefined) fctx.body.push({ op: "call", funcIdx: boxIdx });
+  } else if (keyType.kind === "ref" || keyType.kind === "ref_null") {
+    fctx.body.push({ op: "extern.convert_any" });
+  }
+  const keyLocal = allocLocal(fctx, `__lelm_key_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: keyLocal });
+
+  // Ensure host imports are registered.
+  const getIdx = ensureLateImport(
+    ctx,
+    "__extern_get",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  const setIdx = ensureLateImport(
+    ctx,
+    "__extern_set",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (getIdx === undefined || setIdx === undefined) {
+    reportError(ctx, target, "Could not register __extern_get/__extern_set imports");
+    return null;
+  }
+
+  const emitGet = (): void => {
+    fctx.body.push({ op: "local.get", index: objLocal });
+    fctx.body.push({ op: "local.get", index: keyLocal });
+    fctx.body.push({ op: "call", funcIdx: getIdx });
+  };
+  const emitSet = (): void => {
+    // Stack on entry: <rhs value as externref>
+    // We need to: save it, then call __extern_set(obj, key, val), then
+    // re-push val as the result value of the logical assignment.
+    const valLocal = allocLocal(fctx, `__lelm_val_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: valLocal });
+    fctx.body.push({ op: "local.get", index: objLocal });
+    fctx.body.push({ op: "local.get", index: keyLocal });
+    fctx.body.push({ op: "local.get", index: valLocal });
+    fctx.body.push({ op: "call", funcIdx: setIdx });
+    fctx.body.push({ op: "local.get", index: valLocal });
+  };
+
+  return emitLogicalAssignmentPattern(ctx, fctx, rhs, op, { kind: "externref" }, emitGet, emitSet);
+}
+
+/**
  * Check if a ValType is a reference type (can be used with ref.is_null).
  * Value types (i32, i64, f32, f64, v128, i16) are never null/undefined.
  */
@@ -3197,8 +3334,28 @@ function emitLogicalAssignmentPattern(
       emitGet();
       return varType;
     }
+    // For externref-typed targets, host imports return JS `undefined` as
+    // a non-null externref (the WebAssembly type system doesn't equate
+    // them). `ref.is_null` alone misses `undefined`-valued slots — see
+    // the parallel pattern in `compileLogicalAssignment` that uses
+    // `__extern_is_undefined` for variable-scope `??=`. Compose the
+    // two checks via `i32.or` so the then-arm fires for both.
     emitGet();
+    const tmpForUndef = varType.kind === "externref" ? allocTempLocal(fctx, varType) : -1;
+    if (varType.kind === "externref") {
+      fctx.body.push({ op: "local.tee", index: tmpForUndef });
+    }
     fctx.body.push({ op: "ref.is_null" });
+    if (varType.kind === "externref") {
+      const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+      flushLateImportShifts(ctx, fctx);
+      if (undefIdx !== undefined) {
+        fctx.body.push({ op: "local.get", index: tmpForUndef });
+        fctx.body.push({ op: "call", funcIdx: undefIdx });
+        fctx.body.push({ op: "i32.or" } as unknown as Instr);
+      }
+      releaseTempLocal(fctx, tmpForUndef);
+    }
 
     const savedBody = pushBody(fctx);
     const rhsResult = compileExpression(ctx, fctx, rhs, varType);

--- a/tests/issue-1268.test.ts
+++ b/tests/issue-1268.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1268 — `obj[runtimeKey] ??= value` returned NaN on index-signature types.
+//
+// Two bugs surfaced together:
+//
+// 1. **Module-init filter missing logical-assignment operators**.
+//    `src/codegen/declarations.ts` filters top-level expression statements
+//    into `ctx.moduleInitStatements` based on whether the binary op is an
+//    "assignment". The list of recognised assignment ops included `=`,
+//    `+=`, `-=`, ... but NOT `??=`, `||=`, `&&=`. So `d["x"] ??= 42;` at
+//    module scope was silently dropped — never reached codegen. Reads of
+//    `d["x"]` afterwards returned `undefined` (boxed externref), which
+//    `__unbox_number` mapped to NaN.
+//
+// 2. **`compileElementLogicalAssignment` missing externref fallback**.
+//    The function only handled known struct (`obj["fieldName"]`) or vec
+//    (`arr[i]`) targets. For an index-signature dict (lowered to
+//    externref), the target type check (`arrType.kind !== "ref" &&
+//    arrType.kind !== "ref_null"`) hit a `reportError` arm that callers
+//    silently swallowed. The plain `obj[key] = val` path already had a
+//    `compileExternSetFallback` arm — the parallel `??=` arm was missing.
+//
+// 3. **Nullish check on externref needs `__extern_is_undefined`**.
+//    Host imports return JS `undefined` as a non-null externref (the
+//    Wasm type system doesn't conflate `null` and `undefined`). The
+//    `??=` check in `emitLogicalAssignmentPattern` used only
+//    `ref.is_null`, which missed `undefined`-valued slots. Added the
+//    `__extern_is_undefined` host call OR'd with `ref.is_null` for
+//    externref-typed targets — same pattern the variable-scope
+//    `??=` already uses (`compileLogicalAssignment`).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+interface InstantiateResult {
+  exports: Record<string, unknown>;
+}
+
+async function compileAndInstantiate(source: string): Promise<InstantiateResult> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => `L${e.line}:${e.column} ${e.message}`).join(" | ")}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  return { exports: instance.exports as Record<string, unknown> };
+}
+
+describe("#1268 — d[key] ??= value at module scope (acceptance criterion 1)", () => {
+  it("missing key — assigns RHS, reads back", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] ??= 42;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(42);
+  });
+
+  it("existing key with non-null value — keeps existing (??= short-circuits)", async () => {
+    // Note: `const d: Dict = { x: 5 }` doesn't populate dict entries —
+    // index-signature types compile to an empty struct, and the
+    // initializer's named fields aren't propagated. So we set the value
+    // explicitly via `d["x"] = 5` before the ??=.
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] = 5;
+      d["x"] ??= 42;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(5);
+  });
+});
+
+describe("#1268 — d[key] ??= value inside a function", () => {
+  it("missing key — assigns RHS", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      export function run(): number {
+        const d: Dict = {};
+        d["x"] ??= 42;
+        return d["x"];
+      }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(42);
+  });
+});
+
+describe("#1268 — sibling logical-assignment ops on index-signature dicts", () => {
+  it("||= on missing key — assigns RHS (existing was undefined → falsy)", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] ||= 42;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(42);
+  });
+
+  it("||= on existing truthy key — keeps existing", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] = 7;
+      d["x"] ||= 42;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(7);
+  });
+
+  it("&&= on existing truthy key — assigns RHS", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] = 5;
+      d["x"] &&= 42;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(42);
+  });
+});
+
+describe("#1268 — runtime-computed key (Hono pattern)", () => {
+  it("d[runtimeKey] ??= value with computed string key", async () => {
+    const source = `
+      type Dict = { [key: string]: number };
+      export function run(method: string, defaultValue: number): number {
+        const d: Dict = {};
+        d[method] ??= defaultValue;
+        return d[method];
+      }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as (m: string, v: number) => number)("GET", 1)).toBe(1);
+  });
+});
+
+describe("#1268 — module-init filter regression guard", () => {
+  it("plain d[key] = value at module scope still works (was already correct)", async () => {
+    // Sanity: my fix to declarations.ts adds ??=/||=/&&= to the module-
+    // init filter, but mustn't break the existing plain-assign cases.
+    const source = `
+      type Dict = { [key: string]: number };
+      const d: Dict = {};
+      d["x"] = 99;
+      export function run(): number { return d["x"]; }
+    `;
+    const r = await compileAndInstantiate(source);
+    expect((r.exports.run as () => number)()).toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `d[key] ??= value` returning NaN on index-signature types. Three independent bugs converged on this issue:

### 1. Module-init filter missing logical-assignment operators
`src/codegen/declarations.ts` filters top-level expression statements into `ctx.moduleInitStatements` based on whether the binary op is an assignment. The list included `=`, `+=`, `-=`, etc. but **NOT `??=`, `||=`, `&&=`**. So `d["x"] ??= 42;` at module scope was **silently dropped** — never reached codegen.

### 2. `compileElementLogicalAssignment` missing externref fallback
The function only handled struct (`obj["fieldName"]`) and vec (`arr[i]`) targets. For an index-signature dict (lowered to externref), the target check failed and the function returned `null` with a swallowed error. The plain `obj[key] = val` path already had a `compileExternSetFallback` arm — the parallel `??=` arm was missing.

### 3. Nullish check on externref needs `__extern_is_undefined`
Host imports return JS `undefined` as a **non-null** externref. The `??=` check in `emitLogicalAssignmentPattern` used only `ref.is_null`, which missed `undefined`-valued slots. Added the `__extern_is_undefined` host call OR'd with `ref.is_null` for externref-typed targets — same pattern the variable-scope `??=` already uses.

## Fixes

| File | Change |
|------|--------|
| `src/codegen/declarations.ts` | Add `??=`/`\|\|=`/`&&=` to `isAssignOp` |
| `src/codegen/expressions/assignment.ts` | New `compileElementLogicalAssignmentExternref` helper |
| `src/codegen/expressions/assignment.ts` | Extend `emitLogicalAssignmentPattern` `??=` arm with `__extern_is_undefined` |

## Test plan

- [x] tests/issue-1268.test.ts — 8/8 pass (??=/||=/&&= module + function scope, runtime-computed key, plain-assign regression guard)
- [x] Local sweep: 88/88 across issue-1250, 1268, 1267, 1249, 1238, 1232, ir-frontend-widening
- [ ] CI test262 sharded — authoritative

Hono Tier 2 (#1244) needs this for `TrieRouter.add()`'s `this.#children[method] ??= new Node()` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)