### PR TITLE
test(#1276): regression tests for HOF-returning-closure (createMathOperation pattern)

### DIFF
--- a/plan/issues/sprints/47/1276-hof-returning-closure-function-valued.md
+++ b/plan/issues/sprints/47/1276-hof-returning-closure-function-valued.md
@@ -1,7 +1,7 @@
 ---
 id: 1276
 title: "HOF returning closure — function-valued module exports (createMathOperation pattern)"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: high
@@ -13,6 +13,57 @@ language_feature: closures, HOF, module-exports
 goal: npm-library-support
 related: [1031, 1107]
 ---
+
+## Implementation note (2026-05-02, dev-1245)
+
+Smoke-testing on origin/main shows the basic HOF-returning-closure
+pattern **works for INTERNAL-WASM use** (the issue's primary use case
+when called from another exported function in the same compilation
+unit):
+
+```
+createMathOp(fn) → add(3, 4)  ✓ returns 7
+HOF with captured defaultValue ✓
+Two HOF-created functions side by side ✓
+Realistic _createMathOperation with NaN handling ✓
+```
+
+What does NOT work and is the **remaining real bug**:
+
+1. `export default add` — exports `add` as an externref Wasm GLOBAL,
+   not a callable function. JS `instance.exports.default(3, 4)`
+   fails with "is not a function".
+   - Existing handling at `declarations.ts:2731-2750` and
+     `index.ts:922-937` exports the variable as a Wasm `global`
+     (ESM semantics for non-function values). Closures need a
+     trampoline-export path: emit a Wasm function `default` that
+     reads the global, struct.get the funcref field, and call_ref
+     through it.
+
+2. Chained calls without intermediate binding: `makeAdd()(3, 4)`
+   returns 0 instead of 7. Same root cause as curried HOFs (closure-
+   of-closure call chain with no binding). The lodash usage pattern
+   does NOT hit this — `var add = createMathOperation(...); add(3,4)`
+   uses an intermediate binding.
+
+This PR addresses the basic-HOF case with regression tests
+(criterion 3) — same approach as #1250 and #1275 where the spec
+title was partially stale. The trampoline-export-of-closure for
+acceptance criterion 2 is a deeper compiler feature requiring its
+own focused effort and is tracked as a follow-up.
+
+Tests added (`tests/issue-1276.test.ts`):
+  - createMathOp basic add(3, 4) → 7
+  - HOF captures both operator and defaultValue
+  - two HOF-created functions side by side (no cross-pollution)
+  - realistic _createMathOperation with NaN handling
+
+Out of scope (filed as follow-ups):
+  - Trampoline-export of closure for `export default <closure-var>`
+  - Chained call `makeAdd()(3, 4)` without intermediate binding
+
+---
+
 # #1276 — HOF returning closure: function-valued module exports
 
 ## Problem

--- a/tests/issue-1276.test.ts
+++ b/tests/issue-1276.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1276 — HOF returning closure (createMathOperation pattern).
+//
+// Investigation finding (2026-05-02): the documented "compiler currently
+// fails" claim is partially stale. The basic HOF-returning-closure pattern
+// works for INTERNAL-WASM use:
+//
+//   - `const add = createMathOperation(fn); add(3, 4)` inside an
+//     `export function test()` returns 7 ✓
+//   - Multi-instance side-by-side (e.g. `add` + `mul`) ✓
+//   - HOF with captured defaultValue ✓
+//
+// What does NOT work and is the actual remaining issue:
+//   - `export default add` exports `add` as an externref GLOBAL, not a
+//     callable function. JS `instance.exports.default(3, 4)` fails with
+//     "is not a function" because Wasm globals aren't directly callable.
+//   - Curried HOFs (closure-returning-closure-returning-closure) — the
+//     inner-most call returns 0 instead of the expected value.
+//
+// Both follow-ups need trampoline-export-of-closure machinery — generate
+// an exported Wasm function that reads the global, struct.get the funcref
+// field, and call_ref through it. Out of scope for this PR; tracked.
+//
+// This file locks in the working internal-call patterns (addressing the
+// issue's primary use case: lodash math ops compiled and called from
+// within the same Wasm module). Treats #1276 as test-only similar to
+// #1250 and #1275.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true, allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1276 — HOF returning closure", () => {
+  // Basic createMathOperation pattern from lodash. The closure captures the
+  // operator and is called from within the wasm module.
+  it("createMathOperation: basic add(3, 4) returns 7", async () => {
+    const src = `
+      function createMathOp(op: any): any {
+        return function(a: any, b: any): any { return op(a, b); };
+      }
+      const add = createMathOp(function(x: any, y: any): any { return x + y; });
+      export function test(): number { return add(3, 4); }
+    `;
+    expect(await runTest(src)).toBe(7);
+  });
+
+  // HOF with a defaultValue captured alongside the operator.
+  it("createMathOperation: HOF captures both operator and defaultValue", async () => {
+    const src = `
+      function createMathOp(op: any, defaultValue: any): any {
+        return function(value: any, other: any): any {
+          if (value === undefined) value = defaultValue;
+          if (other === undefined) other = defaultValue;
+          return op(value, other);
+        };
+      }
+      const sub = createMathOp(function(a: any, b: any): any { return a - b; }, 0);
+      export function test(): number { return sub(10, 3); }
+    `;
+    expect(await runTest(src)).toBe(7);
+  });
+
+  // Two HOF-created functions side by side — each captures its own operator.
+  it("two HOF-created functions share the factory but capture different operators", async () => {
+    const src = `
+      function createMathOp(op: any): any {
+        return function(a: any, b: any): any { return op(a, b); };
+      }
+      const add = createMathOp(function(x: any, y: any): any { return x + y; });
+      const mul = createMathOp(function(x: any, y: any): any { return x * y; });
+      export function test(): number { return add(2, 3) + mul(2, 3); } // 5 + 6 = 11
+    `;
+    expect(await runTest(src)).toBe(11);
+  });
+
+  // Real-ish lodash _createMathOperation pattern with NaN handling.
+  it("realistic createMathOperation with NaN handling", async () => {
+    const src = `
+      function createMathOperation(operator: any, defaultValue: any): any {
+        return function(value: any, other: any): any {
+          if (value === undefined && other === undefined) {
+            return defaultValue;
+          }
+          if (value === undefined) value = other;
+          if (other === undefined) return value;
+          return operator(value, other);
+        };
+      }
+      const add = createMathOperation(function(a: any, b: any): any { return a + b; }, 0);
+      export function test(): number { return add(5, 7); } // 12
+    `;
+    expect(await runTest(src)).toBe(12);
+  });
+
+  // Note: chained call `makeAdd()(3, 4)` (call the HOF result directly
+  // without an intermediate binding) currently returns 0. Same root cause
+  // as the curried-HOF case (chained closure-of-closure call). Tracked as
+  // a follow-up of this issue. The intermediate-binding pattern (the
+  // canonical lodash pattern) works — see tests above.
+});


### PR DESCRIPTION
## Summary
The basic HOF-returning-closure pattern (lodash's \`_createMathOperation\`) already works on main for internal-wasm use. Adds 4 regression tests to lock in the working behavior. Same pattern as #1250 and #1275.

## What works on main today
- \`const add = createMathOp(fn); add(3, 4)\` returns 7 ✓
- HOF with captured \`defaultValue\` ✓
- Two HOF-created functions side by side (each captures own operator) ✓
- Realistic lodash-style \`_createMathOperation\` with NaN handling ✓

## Remaining real bugs (out of scope, documented as follow-ups)
1. **Trampoline-export-of-closure**: \`export default add\` exports \`add\` as a Wasm \`global\` (per existing handling at \`declarations.ts:2731\` and \`index.ts:922\`). JS \`instance.exports.default(3, 4)\` fails with "is not a function" because globals aren't directly callable. Needs a Wasm function trampoline that reads the global, \`struct.get\` the funcref field, and \`call_ref\` through it.
2. **Chained calls**: \`makeAdd()(3, 4)\` (no intermediate binding) returns 0. Same root cause as curried-HOFs. Lodash itself uses intermediate bindings so this doesn't block lodash compilation.

## Acceptance criteria
- [x] \`add(3, 4)\` → \`7\` (when called from inside a wasm function)
- [ ] Wasm exports \`default\` as a callable function — follow-up
- [x] \`tests/issue-1276.test.ts\` covers HOF-created function, captured args, correct result
- [x] No regression in closure tests (test-only PR)

## Test plan
- [x] tests/issue-1276.test.ts — 4/4 pass
- [x] tests/issue-1275.test.ts — 7/7 pass (regression)
- [x] tests/issue-1250.test.ts — 17/17 pass (regression)
- [ ] CI: test-only PR, no test262 sharded run expected per #1251 protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)