### PR TITLE
test(#1271): regression tests for for...in / Object.keys enumeration

### DIFF
--- a/plan/issues/sprints/47/1271-for-in-object-keys-enumeration.md
+++ b/plan/issues/sprints/47/1271-for-in-object-keys-enumeration.md
@@ -1,7 +1,7 @@
 ---
 id: 1271
 title: "for...in / Object.keys enumeration over compiled objects"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: high
@@ -13,6 +13,52 @@ language_feature: for-in, Object.keys, enumeration
 goal: npm-library-support
 related: [1244]
 ---
+
+## Implementation note (2026-05-02, dev-1245)
+
+The issue's "throws a compile error or silently skips all keys" claim is
+**stale**. Smoke-testing on origin/main shows all four documented
+patterns work:
+
+```
+for-in over object literal:    OK
+for-in over any-typed object:  OK
+Object.keys(o).length:          OK
+for-in body sees right keys:    OK
+```
+
+The compiler already implements the issue's proposed approach:
+- `compileForInStatement` (loops.ts:3020) emits `__for_in_keys` /
+  `__for_in_len` / `__for_in_get` host imports.
+- `emitStructFieldNamesExport` (index.ts:1199) generates a
+  `__struct_field_names` Wasm export with comma-separated field names
+  per struct type.
+- The runtime's `__for_in_keys` (runtime.ts:3100) calls
+  `_getStructFieldNames` which dispatches through that export.
+- `Object.keys` is compile-time inlined for known struct shapes
+  (object-ops.ts:2051).
+
+**Required for it to work**: the JS host must call
+`imports.setExports(instance.exports)` after instantiation so the
+runtime can dispatch through `__struct_field_names`. This is documented
+in the runtime contract (`buildImports.setExports`) but easy to miss.
+My initial repro returned 0 because I forgot the `setExports` call;
+once added, the for-in returned correct keys.
+
+This PR adds 8 regression tests (`tests/issue-1271.test.ts`):
+- for-in over object literal (typed)
+- for-in over any-typed object
+- Object.keys length
+- for-in body sees correct key strings
+- for-in over empty object (zero iterations)
+- for-in with break (early termination)
+- Object.keys returns string array of correct length
+- nested object: for-in only iterates top-level keys
+
+Treats #1271 as test-only fix — same approach as #1250, #1275, #1276.
+
+---
+
 # #1271 — `for...in` / `Object.keys` enumeration over compiled objects
 
 ## Problem

--- a/tests/issue-1271.test.ts
+++ b/tests/issue-1271.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1271 — for...in / Object.keys enumeration over compiled objects.
+//
+// Investigation finding (2026-05-02): the issue claim that for-in "throws a
+// compile error or silently skips all keys" is **stale**. The compiler
+// already emits `__for_in_keys`/`__for_in_len`/`__for_in_get` host imports
+// (compileForInStatement at loops.ts:3020) and emits a `__struct_field_names`
+// export that the JS host runtime uses to enumerate WasmGC struct keys.
+// `Object.keys` is compile-time-inlined for known struct shapes
+// (compileObjectKeysOrValues at object-ops.ts:2051).
+//
+// What's required for it to work: the JS host MUST call
+// `imports.setExports(instance.exports)` after instantiation so the runtime
+// `__for_in_keys` helper can dispatch through `__struct_field_names`. This
+// is documented in the runtime contract but easy to miss.
+//
+// All 4 documented patterns work on main:
+//   - `for (const k in {x:1, y:2})` iterates 2 times ✓
+//   - `for (const k in anyTyped)` iterates over enumerable props ✓
+//   - `Object.keys(o).length` returns the right count ✓
+//   - `for (const k in o)` body sees correct key strings ✓
+//
+// This file locks in the working behavior. Treats #1271 as test-only fix
+// similar to #1250, #1275, #1276.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true, allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  // CRITICAL: provide exports back to runtime so __struct_field_names can
+  // dispatch through __for_in_keys for WasmGC struct enumeration.
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1271 — for...in / Object.keys enumeration", () => {
+  it("for...in over object literal iterates each key once", async () => {
+    const src = `
+      export function test(): number {
+        const o = { x: 1, y: 2 };
+        let n: number = 0;
+        for (const k in o) n = n + 1;
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(2);
+  });
+
+  it("for...in over any-typed object iterates all keys", async () => {
+    const src = `
+      export function test(): number {
+        const o: any = { x: 1, y: 2, z: 3 };
+        let n: number = 0;
+        for (const k in o) n = n + 1;
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+
+  it("Object.keys returns correct length", async () => {
+    const src = `
+      export function test(): number {
+        const o = { x: 1, y: 2, z: 3 };
+        return Object.keys(o).length;
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+
+  it("for...in body sees correct key strings", async () => {
+    const src = `
+      export function test(): number {
+        const o = { a: 1, b: 2, c: 3 };
+        let total: number = 0;
+        for (const k in o) {
+          if (k === "a") total = total + 1;
+          if (k === "b") total = total + 10;
+          if (k === "c") total = total + 100;
+        }
+        return total;
+      }
+    `;
+    expect(await runTest(src)).toBe(111);
+  });
+
+  it("for...in over empty object iterates zero times", async () => {
+    const src = `
+      export function test(): number {
+        const o = {} as any;
+        let n: number = 0;
+        for (const k in o) n = n + 1;
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  it("for...in with break terminates early", async () => {
+    const src = `
+      export function test(): number {
+        const o = { a: 1, b: 2, c: 3, d: 4 };
+        let n: number = 0;
+        for (const k in o) {
+          if (n === 2) break;
+          n = n + 1;
+        }
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(2);
+  });
+
+  it("Object.keys on object literal returns string array (length check)", async () => {
+    const src = `
+      export function test(): number {
+        const o = { p: 0, q: 0 };
+        const keys = Object.keys(o);
+        if (keys.length !== 2) return -1;
+        return keys.length;
+      }
+    `;
+    expect(await runTest(src)).toBe(2);
+  });
+
+  it("nested object for...in only iterates top-level keys", async () => {
+    const src = `
+      export function test(): number {
+        const o = { x: { a: 1, b: 2 }, y: 3 };
+        let n: number = 0;
+        for (const k in o) n = n + 1;
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
The for-in / Object.keys enumeration patterns documented in #1271 already work on main. This PR adds 8 regression tests to lock in the working behavior. Same pattern as #1250, #1275, #1276.

## What works on main today
- \`for (const k in { x: 1, y: 2 })\` iterates 2 times ✓
- \`for (const k in anyTyped)\` iterates over enumerable props ✓
- \`Object.keys(o).length\` returns the right count ✓
- for-in body sees correct key strings ✓

## Existing implementation
- \`compileForInStatement\` (loops.ts:3020) emits \`__for_in_keys\` / \`__for_in_len\` / \`__for_in_get\` host imports.
- \`emitStructFieldNamesExport\` (index.ts:1199) emits a \`__struct_field_names\` Wasm export with comma-separated field names per struct type.
- Runtime \`__for_in_keys\` (runtime.ts:3100) dispatches through that export via \`_getStructFieldNames\`.
- \`Object.keys\` is compile-time inlined for known struct shapes (object-ops.ts:2051).

## Required runtime contract
The JS host **must** call \`imports.setExports(instance.exports)\` after instantiation so the runtime helper can dispatch through \`__struct_field_names\`. Documented in \`buildImports.setExports\` but easy to miss — my initial repro returned 0 because I forgot the call; once added, for-in returned correct keys.

## Test plan
- [x] tests/issue-1271.test.ts — 8/8 pass (new):
  - for-in over object literal (typed)
  - for-in over any-typed object
  - Object.keys length
  - for-in body sees correct key strings
  - for-in over empty object (zero iterations)
  - for-in with break (early termination)
  - Object.keys returns string array of correct length
  - nested object: for-in only iterates top-level keys
- [ ] CI: test-only PR, no test262 sharded run expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)