### PR TITLE
test(#1273): regression tests for instanceof across compilation boundaries

### DIFF
--- a/plan/issues/sprints/47/1273-instanceof-across-compilation-boundaries.md
+++ b/plan/issues/sprints/47/1273-instanceof-across-compilation-boundaries.md
@@ -1,7 +1,7 @@
 ---
 id: 1273
 title: "instanceof across compilation boundaries"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: medium
@@ -13,6 +13,37 @@ language_feature: instanceof, classes
 goal: npm-library-support
 related: [1244]
 ---
+
+## Implementation note (2026-05-02, dev-1245)
+
+Same stale-issue pattern as #1250, #1271, #1272, #1275, #1276 — the
+documented acceptance criteria already pass on origin/main:
+
+```
+class Foo {}; new Foo() instanceof Foo            → true ✓
+class Bar extends Foo {}; new Bar() instanceof Foo → true ✓
+{} instanceof Foo                                  → false ✓
+new Bar() instanceof Bar                           → true ✓
+new Baz() instanceof Foo (unrelated class)         → false ✓
+multi-level: new C() instanceof A (C ⊂ B ⊂ A)      → true ✓
+new Foo() instanceof Bar (parent NOT instanceof child) → false ✓
+```
+
+The compiler routes instanceof through struct-tag / ref.test-style
+dispatch on compiled classes — the approach the issue spec proposes.
+
+PR is therefore test-only. Adds `tests/issue-1273.test.ts` with 7
+regression tests covering:
+1. instanceof same class
+2. instanceof inheritance (one-level)
+3. instanceof non-class object → false
+4. instanceof on fresh instance of own class
+5. instanceof unrelated class → false
+6. multi-level inheritance: deep subclass instance is instance of root parent
+7. Reverse direction: parent instance is NOT instance of subclass
+
+---
+
 # #1273 — `instanceof` across compilation boundaries
 
 ## Problem

--- a/tests/issue-1273.test.ts
+++ b/tests/issue-1273.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1273 — instanceof across compilation boundaries.
+//
+// Investigation finding (2026-05-02): the issue's claim that
+// `f instanceof Foo` "either returns false always or throws" is
+// **stale**. Smoke-testing on origin/main shows all three acceptance
+// criteria already pass:
+//
+//   1. `class Foo {}; new Foo() instanceof Foo` → true ✓
+//   2. `class Bar extends Foo {}; new Bar() instanceof Foo` → true ✓
+//   3. `{} instanceof Foo` → false ✓
+//
+// The compiler appears to use struct-tag / ref.test-style dispatch
+// for instanceof on compiled classes. Same approach the issue spec
+// proposes.
+//
+// This file locks in the working behavior. Treats #1273 as test-only
+// fix similar to #1250, #1271, #1272, #1275, #1276.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true, allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1273 — instanceof across compilation boundaries", () => {
+  // Acceptance 1: same-class instanceof
+  it("instanceof returns true for an instance of its class", async () => {
+    const src = `
+      class Foo { x: number = 0; }
+      export function test(): number {
+        const f = new Foo();
+        return f instanceof Foo ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  // Acceptance 2: inheritance
+  it("instanceof returns true for a subclass instance against the parent", async () => {
+    const src = `
+      class Foo { x: number = 0; }
+      class Bar extends Foo { y: number = 0; }
+      export function test(): number {
+        const b = new Bar();
+        return b instanceof Foo ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  // Acceptance 3: non-class object
+  it("instanceof returns false for a plain object", async () => {
+    const src = `
+      class Foo { x: number = 0; }
+      export function test(): number {
+        const o: any = { x: 1 };
+        return o instanceof Foo ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  // Sanity: same-instance check after multiple object creations
+  it("instanceof returns true on a fresh instance of its own class", async () => {
+    const src = `
+      class Bar { y: number = 0; }
+      export function test(): number {
+        const b = new Bar();
+        return b instanceof Bar ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  // Sanity: unrelated class returns false
+  it("instanceof returns false for an instance of an unrelated class", async () => {
+    const src = `
+      class Foo { x: number = 0; }
+      class Baz { z: number = 0; }
+      export function test(): number {
+        const baz = new Baz();
+        return baz instanceof Foo ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  // Multi-level inheritance (Bar extends Foo, Baz extends Bar)
+  it("multi-level inheritance: deep subclass instance is instance of root parent", async () => {
+    const src = `
+      class A { a: number = 0; }
+      class B extends A { b: number = 0; }
+      class C extends B { c: number = 0; }
+      export function test(): number {
+        const c = new C();
+        return c instanceof A ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  // Reverse direction: parent instance is NOT instance of subclass
+  it("parent instance is NOT instance of subclass", async () => {
+    const src = `
+      class Foo { x: number = 0; }
+      class Bar extends Foo { y: number = 0; }
+      export function test(): number {
+        const f = new Foo();
+        return f instanceof Bar ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
All three acceptance criteria from #1273 already pass on main. This PR adds 7 regression tests to lock in the working behavior. Same pattern as #1250, #1271, #1272, #1275, #1276.

## What works on main today
- \`new Foo() instanceof Foo\` → true ✓
- \`new Bar() instanceof Foo\` (Bar extends Foo) → true ✓
- \`{} instanceof Foo\` → false ✓

The compiler routes instanceof through struct-tag / ref.test-style dispatch on compiled classes — exactly the approach the issue spec proposes.

## Test coverage (7/7 pass)
- instanceof same class
- instanceof inheritance (one-level)
- instanceof non-class object → false
- instanceof on fresh instance of own class
- instanceof unrelated class → false
- multi-level inheritance: deep subclass instance is instance of root parent
- parent instance is NOT instance of subclass (asymmetry)

## Test plan
- [x] tests/issue-1273.test.ts — 7/7 pass
- [x] regression: tests/issue-1272.test.ts — 6/6 pass
- [ ] CI: test-only PR, no test262 sharded run expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)