### PR TITLE
test(#1242): WeakSet tests; WeakMap deferred to #1283 (sprint 48)

### DIFF
--- a/plan/issues/sprints/47/1242-weakmap-weakset-backed-by-strong.md
+++ b/plan/issues/sprints/47/1242-weakmap-weakset-backed-by-strong.md
@@ -1,7 +1,7 @@
 ---
 id: 1242
 title: "WeakMap / WeakSet backed by strong references (lodash memoize / cloneDeep)"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: high
@@ -11,8 +11,37 @@ task_type: feature
 area: codegen, runtime
 language_feature: WeakMap, WeakSet
 goal: spec-completeness
-related: [1101, 1103]
+related: [1101, 1103, 1283]
 ---
+
+## Implementation note (2026-05-02, dev-1245)
+
+Split scope per tech-lead direction.
+
+**WeakSet works on main today** — all documented patterns pass:
+  - `new WeakSet()` + `add`/`has`/`delete` round-trip ✓
+  - `add()` returns the WeakSet (chainable) ✓
+  - Multiple objects coexist correctly ✓
+  - New instance is empty ✓
+
+**WeakMap FAILS** with wasm validation errors at instantiation for
+every documented `set/get/has/delete` pattern:
+  - `wm.set(k, 42); wm.get(k)` → "call[0] expected externref, found f64"
+  - `wm.set(k, v); wm.has(k)` → "call[2] expected f64, found externref"
+  - cycle-detection (`seen.set(a, a); seen.has(a) ? 1 : 0`) → similar
+  - memoize-style → similar
+
+Tech lead approved a partial PR landing only the WeakSet portion as
+test-only. The WeakMap host-import dispatch needs a proper
+investigation pass (not a rushed end-of-sprint fix). Filed as #1283
+in sprint 48 with the four exact error patterns as repros.
+
+This PR therefore covers WeakSet only via `tests/issue-1242.test.ts`
+(5/5 pass). #1283 will land WeakMap once the type-mismatch wiring is
+properly investigated and fixed.
+
+---
+
 # #1242 — WeakMap / WeakSet backed by strong references
 
 ## Problem

--- a/plan/issues/sprints/48/1283.md
+++ b/plan/issues/sprints/48/1283.md
@@ -1,0 +1,133 @@
+---
+id: 1283
+title: "WeakMap host-import dispatch: type-mismatch on set/get/has/delete (carved off from #1242)"
+status: ready
+created: 2026-05-02
+updated: 2026-05-02
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, runtime
+language_feature: WeakMap
+goal: spec-completeness
+related: [1242, 1244]
+---
+
+# #1283 — WeakMap host-import dispatch: type-mismatch on set/get/has/delete
+
+## Background
+
+Carved off from #1242 (WeakMap/WeakSet backed by strong refs). #1242 was
+mostly stale-issue (WeakSet works on main today), but **WeakMap fails
+with wasm validation errors at instantiation** for every documented
+acceptance pattern. Tech lead approved a partial PR (test-only for
+WeakSet) and filed this issue to fix the WeakMap path properly.
+
+## Reproductions on origin/main (2026-05-02)
+
+All run through `compile()` + `WebAssembly.instantiate()`:
+
+```js
+// CASE A: set/get with primitive value
+const wm = new WeakMap();
+const k = { id: 1 };
+wm.set(k, 42);
+return wm.get(k);
+```
+→ `call[0] expected type externref, found call of type f64 @+340`
+
+```js
+// CASE B: set/has after set
+const wm = new WeakMap();
+const k = { id: 1 };
+wm.set(k, 99);
+return wm.has(k) ? 1 : 0;
+```
+→ `call[2] expected type f64, found call of type externref @+318`
+
+```js
+// CASE C: cycle-detection (lodash cloneDeep style)
+const seen = new WeakMap();
+const a = { id: 1 };
+seen.set(a, a);
+return seen.has(a) ? 1 : 0;
+```
+→ `call[2] expected type f64, found local.get of type externref @+285`
+
+```js
+// CASE D: memoize style (lodash memoize)
+const cache = new WeakMap();
+function memo(arg) {
+  if (cache.has(arg)) return cache.get(arg);
+  const result = { value: 42 };
+  cache.set(arg, result);
+  return result;
+}
+```
+→ `call[0] expected type externref, found call of type f64 @+734`
+
+**WeakSet works fine** with the same `externMethod()` helper — so the
+issue is specific to the WeakMap host-import wiring.
+
+## Root cause hypothesis
+
+`src/codegen/index.ts:5770-5784` registers WeakMap as an extern class
+with `externMethod(N)` signatures (all-externref params, externref
+result). That mirrors WeakSet (line 5787-5802) which works.
+
+The dispatch in `src/codegen/expressions/extern.ts:39
+compileExternMethodCall` calls
+`compileExpression(ctx, fctx, callExpr.arguments[i]!, hint)` with the
+extern-method param hint (externref). The hint should drive coercion to
+externref, but the wasm validator says f64 leaks through for WeakMap
+specifically.
+
+Possibilities:
+1. The hint isn't being honored for the second `set` argument when the
+   value is a numeric literal — compileExpression returns f64 regardless.
+2. The result-type wiring claims externref but the actual host import
+   has a different signature (returns f64?), causing the validator to
+   complain at the call's downstream consumer.
+3. WeakMap's host-import resolution ends up at a different runtime
+   helper than expected (Map's helper?), with mismatched signature.
+4. The class-tag dispatch routes WeakMap to a different `externMethod`
+   table than the one registered, so the runtime sees Map-shaped args
+   while the codegen emits WeakMap-shaped ones.
+
+## Investigation steps
+
+1. Add a unit test that compiles `new WeakMap(); wm.set(k, 42); wm.get(k)`
+   and dumps the wasm function for `set`/`get` with `wasm-dis`. Compare
+   to the equivalent `new Map(); m.set(...)` which works.
+2. Inspect the host-import name registered for `WeakMap_set` /
+   `WeakMap_get` and confirm its function-type matches the
+   `externMethod(N)` registration.
+3. Check `src/runtime.ts:buildImports` to see if there's a
+   WeakMap-specific resolver that returns a function with a different
+   signature than expected.
+4. If the hint coercion is the bug: instrument `compileExpression` with
+   `{ kind: "externref" }` hint on a numeric literal and check whether
+   it boxes via `__box_number`.
+
+## Acceptance criteria
+
+1. All four CASE A–D reproductions above compile and run correctly.
+2. `_.memoize(fn)(arg)` returns the correct cached result on repeat calls.
+3. `_.cloneDeep` on `a.self = a` does not infinite-loop and returns a
+   structurally correct clone.
+4. `tests/issue-1283.test.ts` covers all four CASE patterns.
+5. No regression in WeakSet (already-working) or Map/Set tests.
+
+## Out of scope
+
+- Wasm-native WeakMap (separate issue #1103).
+- WeakRef / FinalizationRegistry (separate issue #1101).
+
+## Related
+
+- #1242 — Original WeakMap/WeakSet issue; partial PR landed WeakSet
+  tests, deferred WeakMap to this issue.
+- #1244 — Hono stress test that also surfaces lodash-shaped WeakMap
+  use.
+- #1101, #1103 — Stronger Wasm-native variants.

--- a/tests/issue-1242.test.ts
+++ b/tests/issue-1242.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1242 — WeakMap / WeakSet backed by strong references.
+//
+// Investigation finding (2026-05-02): split scope.
+//
+// **WeakSet works on main today** — all 4 documented patterns pass:
+//   - new WeakSet() + add/has + delete
+//   - add returns the WeakSet (chainable)
+//
+// **WeakMap FAILS** with wasm validation errors at instantiation for
+// every documented set/get/has/delete pattern:
+//   - `wm.set(k, 42); wm.get(k)` → "call[0] expected externref, found f64"
+//   - `wm.set(k, v); wm.has(k)` → "call[2] expected f64, found externref"
+//
+// Tech lead approved a partial test PR landing the WeakSet portion,
+// with WeakMap deferred to a dedicated follow-up issue (#1283 in
+// sprint 48). The WeakMap host-import dispatch needs proper
+// investigation that wasn't feasible at end-of-sprint.
+//
+// This file therefore covers WeakSet only. WeakMap tests are in
+// `tests/issue-1283.test.ts` once that fix lands.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number> {
+  const r = compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true, allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("Issue #1242 — WeakSet (WeakMap deferred to #1283)", () => {
+  it("WeakSet basic add + has on object value", async () => {
+    const src = `
+      export function test(): number {
+        const ws: any = new WeakSet();
+        const v: any = { id: 1 };
+        ws.add(v);
+        return ws.has(v) ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("WeakSet has returns false for object never added", async () => {
+    const src = `
+      export function test(): number {
+        const ws: any = new WeakSet();
+        const v: any = { id: 1 };
+        return ws.has(v) ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  it("WeakSet delete removes the value", async () => {
+    const src = `
+      export function test(): number {
+        const ws: any = new WeakSet();
+        const v: any = { id: 1 };
+        ws.add(v);
+        ws.delete(v);
+        return ws.has(v) ? 1 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+
+  it("WeakSet handles multiple distinct objects", async () => {
+    const src = `
+      export function test(): number {
+        const ws: any = new WeakSet();
+        const a: any = { id: 1 };
+        const b: any = { id: 2 };
+        ws.add(a);
+        ws.add(b);
+        // Both must be present
+        return (ws.has(a) ? 1 : 0) + (ws.has(b) ? 10 : 0);
+      }
+    `;
+    expect(await runTest(src)).toBe(11);
+  });
+
+  it("WeakSet new instance is empty", async () => {
+    const src = `
+      export function test(): number {
+        const ws: any = new WeakSet();
+        const v: any = { id: 1 };
+        return ws.has(v) ? 99 : 0;
+      }
+    `;
+    expect(await runTest(src)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Tech-lead-approved partial PR after escalation. Lands WeakSet regression tests and files the WeakMap type-mismatch bug as a follow-up issue (#1283 in sprint 48).

## What works on main today (5/5 tests pass)
- \`new WeakSet()\` + \`add\` + \`has\` round-trip
- \`has\` returns false for object never added
- \`delete\` removes the value
- Multiple distinct objects coexist
- New instance is empty

## What does NOT work — deferred to #1283
WeakMap fails with wasm validation errors at instantiation for every documented set/get/has/delete pattern:
- \`wm.set(k, 42); wm.get(k)\` → "call[0] expected externref, found f64"
- \`wm.set(k, v); wm.has(k)\` → "call[2] expected f64, found externref"
- cycle-detection (lodash cloneDeep style) → similar
- memoize-style → similar

WeakSet uses the same \`externMethod()\` helper and works fine, so the bug is specific to WeakMap's host-import dispatch wiring. Not a rushed end-of-sprint fix — needs proper investigation pass. #1283 documents the four exact error patterns as repros and points at \`compileExternMethodCall\` and host-import signature wiring as the investigation surface.

## Acceptance criteria for #1242 (split per tech-lead approval)
- [x] new WeakSet() / ws.add(v) / ws.has(v) / ws.delete(v) work
- [ ] new WeakMap() set/get/has/delete — deferred to #1283
- [ ] _.memoize / _.cloneDeep — deferred to #1283
- [x] tests/issue-1242.test.ts — 5/5 pass (WeakSet)
- [x] No regression in WeakSet tests

## Test plan
- [x] tests/issue-1242.test.ts — 5/5 pass
- [ ] CI: test-only PR, no test262 sharded run expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)