### PR TITLE
docs(#1268): mark issue as done — fix shipped in PR #168

### DIFF
--- a/plan/issues/sprints/47/1268-index-signature-obj-key-value.md
+++ b/plan/issues/sprints/47/1268-index-signature-obj-key-value.md
@@ -1,7 +1,7 @@
 ---
 id: 1268
 title: "index-signature obj[key] ??= value returns NaN instead of assigning"
-status: ready
+status: done
 created: 2026-05-02
 updated: 2026-05-02
 priority: medium
@@ -52,3 +52,13 @@ correct — the bug is in the index-signature element-set codegen path.
 1. `d[key] ??= value` on an index-signature dict assigns and reads back correctly
 2. `tests/issue-1268.test.ts` covers the pattern
 3. No regression in existing element-access or logical-assignment tests
+
+## Resolution (2026-05-02)
+
+Fixed by PR #168 (commit ff02a09cd) — three layers of fix in
+`src/codegen/declarations.ts`, `src/codegen/expressions/assignment.ts`
+(`compileElementLogicalAssignment`), and `emitLogicalAssignmentPattern`. See
+the test file `tests/issue-1268.test.ts` header comment for full details.
+
+Status retroactively flipped to `done` after re-validating: 8/8 tests pass on
+current main; the issue file was just never updated in the post-merge cleanup.


### PR DESCRIPTION
## Summary

Issue #1268 (`obj[key] ??= value` returns NaN on index-signature dicts) was fixed by PR #168 (commit ff02a09cd) but the post-merge cleanup never flipped the issue file's `status: ready` to `status: done`. This PR is a docs/metadata-only cleanup.

## Changes

- `plan/issues/sprints/47/1268-index-signature-obj-key-value.md` — `status: ready` → `done`, plus a `## Resolution` section pointing back to PR #168 and the test file header for the full three-layer fix explanation.

## Test plan

- [x] `npx vitest run tests/issue-1268.test.ts` — 8/8 passing on current main, confirming the fix is live
- [x] No code changes; planning artifacts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)