### PR TITLE
feat(#1277): CJS module.exports={a,b} + ESM export{a,b} discovery

### DIFF
--- a/plan/issues/sprints/47/1277-cjs-module-exports-wasm-export.md
+++ b/plan/issues/sprints/47/1277-cjs-module-exports-wasm-export.md
@@ -1,7 +1,7 @@
 ---
 id: 1277
 title: "CJS module.exports → Wasm export mapping in compileProject"
-status: ready
+status: in-progress
 created: 2026-05-02
 updated: 2026-05-02
 priority: medium
@@ -64,3 +64,41 @@ and does not have this problem. Priority: lodash-es first, CJS as follow-up.
 2. `exports.default(42)` → `42` when instantiated
 3. `tests/issue-1277.test.ts` covers `module.exports = fn` and `module.exports.foo = fn`
 4. No regression in ESM import/export tests
+
+## Resolution
+
+The problem-statement assumption is partially out of date — the existing CJS handler
+at `src/codegen/declarations.ts:2382` (added in #1075) already covers
+`module.exports = <ident>`, `module.exports = function() {}`, `module.exports.foo = X`,
+and `exports.foo = X` shapes. Empirical probes against `lodash/identity.js` show those
+already produce both `identity` and `default` Wasm exports.
+
+Two real gaps remained:
+
+1. **Object-literal RHS** — `module.exports = { a, b: c }` (a common pattern in
+   barrel/aggregator modules) was not recognized. Added a Pattern 1c branch to the
+   existing CJS handler that walks shorthand and named-with-identifier properties
+   and emits each as a Wasm export under the property key, looking up the local
+   binding by name in `ctx.funcMap`. Computed keys, methods, spreads, and
+   non-identifier values are skipped (a future enhancement could route generic
+   expressions through a synthetic global).
+
+2. **ESM `export { foo, bar as baz };`** — pure-ESM named-export declarations
+   (without a `from` specifier) were not recognized either. Added a parallel
+   walker in the same file that resolves `propertyName ?? name` to a local
+   binding and emits the function under the exported alias. Re-exports
+   (`export { x } from "spec"`) are intentionally skipped — those need import
+   resolution + re-export wiring outside this scope.
+
+The CJS rewriter approach proposed in the issue body would have been redundant
+(and actively broke `exports.foo = X` by rewriting it to `export { X };` before the
+existing CJS handler ran); both gaps are filled by extending the export-discovery
+walker directly.
+
+## Test Results
+
+- `tests/issue-1277.test.ts`: 13/13 pass — covers all required acceptance shapes.
+- `tests/issue-1075.test.ts` (CJS module.exports regression guard): 8/8 pass.
+- `tests/issue-1074.test.ts` (export default regression guard): 5/5 pass.
+- `tests/issue-1279.test.ts` (CJS require() regression guard): 18/18 pass.
+- `tests/equivalence/import-meta.test.ts`: 4/4 pass.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2379,6 +2379,33 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     }
   }
 
+  // ESM named-export declaration: `export { foo, bar as baz };` (#1277).
+  // Without this, the rewriter and existing ESM walker only handle
+  // `export function foo() {}` and `export default <ident>`. Re-exports
+  // from another module (`export { x } from "spec"`) are intentionally
+  // skipped here — those need import resolution + re-export wiring that
+  // isn't part of this gap.
+  if (isEntryFile) {
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isExportDeclaration(stmt)) continue;
+      if (!stmt.exportClause || !ts.isNamedExports(stmt.exportClause)) continue;
+      if (stmt.moduleSpecifier) continue; // re-export — handled elsewhere
+      for (const spec of stmt.exportClause.elements) {
+        // `export { foo as bar }` → propertyName=foo, name=bar
+        // `export { foo }`        → propertyName=undefined, name=foo
+        const localName = spec.propertyName?.text ?? spec.name.text;
+        const exportedName = spec.name.text;
+        if (!ctx.funcMap.has(localName)) continue;
+        const funcIdx = ctx.funcMap.get(localName)!;
+        const func = ctx.mod.functions[funcIdx - ctx.numImportFuncs];
+        if (func && !func.exported) func.exported = true;
+        if (!ctx.mod.exports.some((e) => e.name === exportedName)) {
+          ctx.mod.exports.push({ name: exportedName, desc: { kind: "func", index: funcIdx } });
+        }
+      }
+    }
+  }
+
   // CJS exports: recognize `module.exports` / `exports.foo` patterns (#1075).
   // Phase 1 — register CJS function expressions and surface CJS assignments as Wasm exports.
   // This runs after the ESM export-default block so CJS and ESM don't conflict.
@@ -2454,6 +2481,36 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
             if (name !== "default") {
               ctx.mod.exports.push({ name: "default", desc: { kind: "func", index: funcIdx } });
             }
+          }
+        }
+        continue;
+      }
+
+      // Pattern 1c: `module.exports = { a, b: c, d }` — multi-named export via
+      // object literal (#1277). Handles shorthand (`{ a }`) and named-with-
+      // identifier (`{ alias: foo }`) shapes. Skips computed keys, methods,
+      // spreads, and non-identifier RHS — those bail out without exporting
+      // (a future enhancement could route generic-expression values through
+      // a synthetic global).
+      if (isModuleExports(expr.left) && ts.isObjectLiteralExpression(expr.right)) {
+        hasModuleExportsDefault = true;
+        for (const prop of expr.right.properties) {
+          let key: string | undefined;
+          let valName: string | undefined;
+          if (ts.isShorthandPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+            key = prop.name.text;
+            valName = key;
+          } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && ts.isIdentifier(prop.initializer)) {
+            key = prop.name.text;
+            valName = prop.initializer.text;
+          }
+          if (!key || !valName) continue;
+          if (!ctx.funcMap.has(valName)) continue;
+          const funcIdx = ctx.funcMap.get(valName)!;
+          const func = ctx.mod.functions[funcIdx - ctx.numImportFuncs];
+          if (func && !func.exported) func.exported = true;
+          if (!ctx.mod.exports.some((e) => e.name === key)) {
+            ctx.mod.exports.push({ name: key, desc: { kind: "func", index: funcIdx } });
           }
         }
         continue;

--- a/tests/issue-1277.test.ts
+++ b/tests/issue-1277.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1277 — CommonJS `module.exports` / `exports.foo` → Wasm export mapping.
+//
+// The CJS export-discovery walker in `src/codegen/declarations.ts` already
+// handled the simple identifier and function-expression shapes via the existing
+// `module.exports` / `exports.foo` patterns. The fix here adds two missing
+// shapes that real npm packages (lodash, lodash-es shim files) and ESM
+// re-export style modules use:
+//
+//   - `module.exports = { a, b: c }` — multi-named export via object literal.
+//     Each shorthand or named-with-identifier property becomes a Wasm export.
+//   - `export { foo, bar as baz };` — ESM named-export declaration without a
+//     `from` specifier. The export-discovery walker now resolves the local
+//     binding and emits the function under the exported alias.
+//
+// Re-exports (`export { x } from "spec"`) are intentionally NOT covered here
+// — they require import resolution + re-export wiring that's separate from
+// the export-discovery gap.
+
+import { describe, expect, it } from "vitest";
+import { compile, compileMulti } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runExport(source: string, exportName: string, args: unknown[]): Promise<unknown> {
+  const r = compile(source, {
+    fileName: "test.js",
+    skipSemanticDiagnostics: true,
+    allowJs: true,
+  });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  const fn = (instance.exports as Record<string, unknown>)[exportName];
+  if (typeof fn !== "function") {
+    throw new Error(`export '${exportName}' missing. Available: ${Object.keys(instance.exports).join(", ")}`);
+  }
+  return (fn as (...a: unknown[]) => unknown)(...args);
+}
+
+function getExports(source: string): string[] {
+  const r = compile(source, {
+    fileName: "test.js",
+    skipSemanticDiagnostics: true,
+    allowJs: true,
+  });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  // Synchronous parse of WebAssembly module bytes via WebAssembly.Module
+  const m = new WebAssembly.Module(r.binary);
+  return WebAssembly.Module.exports(m).map((e) => e.name);
+}
+
+describe("Issue #1277 — CJS module.exports → Wasm export mapping", () => {
+  // ── Pre-existing behaviour (regression guards for #1075) ─────────
+  it("module.exports = ident — exports both ident and default", async () => {
+    const src = `function identity(value) { return value; }
+module.exports = identity;`;
+    const exps = getExports(src);
+    expect(exps).toContain("identity");
+    expect(exps).toContain("default");
+    expect(await runExport(src, "default", [42])).toBe(42);
+    expect(await runExport(src, "identity", [42])).toBe(42);
+  });
+
+  it("module.exports.foo = ident — exports as foo", async () => {
+    const src = `function double(x) { return x * 2; }
+module.exports.double = double;`;
+    expect(getExports(src)).toContain("double");
+    expect(await runExport(src, "double", [21])).toBe(42);
+  });
+
+  it("exports.foo = ident — exports as foo", async () => {
+    const src = `function add(a, b) { return a + b; }
+exports.add = add;`;
+    expect(getExports(src)).toContain("add");
+    expect(await runExport(src, "add", [2, 3])).toBe(5);
+  });
+
+  it("exports.foo = function expression — exports as foo", async () => {
+    const src = `exports.add = function(a, b) { return a + b; };`;
+    expect(getExports(src)).toContain("add");
+    expect(await runExport(src, "add", [2, 3])).toBe(5);
+  });
+
+  // ── New: object-literal RHS (#1277) ───────────────────────────────
+  it("module.exports = { a, b } — exports both a and b", async () => {
+    const src = `function inc(x) { return x + 1; }
+function dec(x) { return x - 1; }
+module.exports = { inc, dec };`;
+    const exps = getExports(src);
+    expect(exps).toContain("inc");
+    expect(exps).toContain("dec");
+    expect(await runExport(src, "inc", [10])).toBe(11);
+    expect(await runExport(src, "dec", [10])).toBe(9);
+  });
+
+  it("module.exports = { alias: ident } — exports under aliased name", async () => {
+    const src = `function _double(x) { return x * 2; }
+module.exports = { times2: _double };`;
+    expect(getExports(src)).toContain("times2");
+    expect(await runExport(src, "times2", [21])).toBe(42);
+  });
+
+  // ── New: ESM `export { name }` declaration (#1277) ────────────────
+  it("export { ident } — exports as ident (JS mode)", async () => {
+    const src = `function identity(v) { return v; }
+export { identity };`;
+    expect(getExports(src)).toContain("identity");
+    expect(await runExport(src, "identity", [42])).toBe(42);
+  });
+
+  it("export { ident as alias } — exports under alias", async () => {
+    const src = `function identity(v) { return v; }
+export { identity as id };`;
+    expect(getExports(src)).toContain("id");
+    expect(await runExport(src, "id", [99])).toBe(99);
+  });
+
+  it("export { a, b } — multi-spec named export", async () => {
+    const src = `function inc(x) { return x + 1; }
+function dec(x) { return x - 1; }
+export { inc, dec };`;
+    const exps = getExports(src);
+    expect(exps).toContain("inc");
+    expect(exps).toContain("dec");
+    expect(await runExport(src, "inc", [5])).toBe(6);
+    expect(await runExport(src, "dec", [5])).toBe(4);
+  });
+
+  // ── compileMulti routes through generateMultiModule ───────────────
+  it("compileMulti routes module.exports through the same path", async () => {
+    const r = compileMulti(
+      {
+        "./identity.js": `function identity(value) { return value; }
+module.exports = identity;`,
+      },
+      "./identity.js",
+      { allowJs: true, skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const m = new WebAssembly.Module(r.binary);
+    const exps = WebAssembly.Module.exports(m).map((e) => e.name);
+    expect(exps).toContain("identity");
+    expect(exps).toContain("default");
+  });
+
+  it("compileMulti supports module.exports = { a, b } across files", async () => {
+    const r = compileMulti(
+      {
+        "./mod.js": `function inc(x) { return x + 1; }
+function dec(x) { return x - 1; }
+module.exports = { inc, dec };`,
+      },
+      "./mod.js",
+      { allowJs: true, skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const m = new WebAssembly.Module(r.binary);
+    const exps = WebAssembly.Module.exports(m).map((e) => e.name);
+    expect(exps).toContain("inc");
+    expect(exps).toContain("dec");
+  });
+
+  // ── Regression: ESM still works ──────────────────────────────────
+  it("regression guard: export function foo still emits foo export", async () => {
+    const src = `export function foo(x) { return x + 1; }`;
+    expect(getExports(src)).toContain("foo");
+    expect(await runExport(src, "foo", [10])).toBe(11);
+  });
+
+  it("regression guard: export default ident still emits both names", async () => {
+    const src = `function identity(v) { return v; }
+export default identity;`;
+    const exps = getExports(src);
+    expect(exps).toContain("identity");
+    expect(exps).toContain("default");
+  });
+});


### PR DESCRIPTION
## Summary

- The existing CJS handler in `src/codegen/declarations.ts` (added in #1075) already covers `module.exports = <ident>`, `module.exports = function() {}`, `module.exports.foo = X`, and `exports.foo = X`. Real `lodash/identity.js` already produces both `identity` and `default` Wasm exports.
- Two real gaps remained:
  - **`module.exports = { a, b: c }`** (object-literal RHS — common in barrel/aggregator npm modules) was not recognized.
  - **`export { foo, bar as baz };`** (pure-ESM named-export declarations without a `from` specifier) was not recognized either.
- Both gaps are filled by extending the export-discovery walker directly. Re-exports (`export { x } from "spec"`) are intentionally NOT covered — those need import resolution + re-export wiring outside this scope.

The CJS rewriter approach proposed in the issue body would have been redundant (and actively broke `exports.foo = X` by rewriting it to `export { X };` before the existing CJS handler ran).

## Test plan

- [x] `tests/issue-1277.test.ts` — 13 cases covering all required acceptance shapes (object-literal RHS, alias forms, multi-spec named exports, compileMulti routing, regression guards). All pass.
- [x] `tests/issue-1075.test.ts` (CJS regression guard) — 8/8 pass.
- [x] `tests/issue-1074.test.ts` (export default regression guard) — 5/5 pass.
- [x] `tests/issue-1279.test.ts` (CJS require regression guard) — 18/18 pass.
- [x] `tests/equivalence/import-meta.test.ts` — 4/4 pass.
- [ ] CI test262 conformance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)