### PR TITLE
feat(codegen #1269): Phase 3 struct field inference — narrow externref dispatch when struct candidates agree on a primitive

### DIFF
--- a/plan/issues/sprints/48/1269-struct-field-inference-phase-3.md
+++ b/plan/issues/sprints/48/1269-struct-field-inference-phase-3.md
@@ -43,3 +43,64 @@ tracks this in `ExternClassInfo`; Phase 3 just needs to consult it at the consum
 1. `distance(createPoint(3, 4))` emits zero `__unbox_number` calls in WAT output
 2. WAT snapshot test in `tests/issue-1269.test.ts` guards the output
 3. No regression in equivalence or struct tests
+
+## Resolution (2026-05-03)
+
+### Root cause (narrower than the issue body)
+
+For the canonical `distance(createPoint(3, 4))` example with a typed
+`p: { x: number; y: number }` parameter, Phase 1+2 already gave the
+right answer — zero `__unbox_number` calls. The remaining gap was
+specifically the `const p: any = createPoint(...); p.x + p.y`
+pattern, where the externref-receiver dispatch in
+`src/codegen/property-access.ts::compilePropertyAccess` (line ~2105)
+chose `resultWasm` based on `accessWasm` (TS-checker-derived type
+at the access site). For `p: any` → `p.x`, accessWasm is externref
+→ `resultWasm` externref. The struct-then arm then called
+`__box_number` on the struct's `f64` field (via
+`coercionInstrs(f64 → externref)`), and the consumer's first
+arithmetic use immediately called `__unbox_number`.
+
+### Fix
+
+Phase 3 narrows `resultWasm` to the candidates' shared primitive
+when accessWasm is externref but all `findAlternateStructsForField`
+candidates agree on `f64` or `i32`:
+
+```ts
+let resultWasm = accessWasm.kind === "f64" || accessWasm.kind === "i32"
+  ? accessWasm
+  : { kind: "externref" };
+if (resultWasm.kind === "externref" && structCandidates.length > 0) {
+  const fieldKinds = new Set(structCandidates.map((c) => c.fieldType.kind));
+  if (fieldKinds.size === 1) {
+    const k = [...fieldKinds][0];
+    if (k === "f64" || k === "i32") {
+      resultWasm = { kind: k };
+      // Ensure __unbox_number is registered for the extern_get fallback.
+    }
+  }
+}
+```
+
+The struct-then arm reads the field unboxed; the extern_get-else
+arm calls `__unbox_number` once. Box → unbox roundtrip eliminated.
+
+### Test results
+
+- `tests/issue-1269.test.ts` — 8 / 8 passing. Behavioural cases
+  (explicit param, createPoint inferred, any-typed local + add /
+  mul / sqrt) plus structural WAT assertions (`__unbox_number` /
+  `__box_number` call counts).
+- 38-test class / struct / extern / Hono regression sweep —
+  identical pass/fail counts vs main (zero regressions).
+
+### Notes
+
+- Narrowing only fires when ALL Phase-1 struct candidates agree
+  on a single primitive (f64 or i32). Heterogeneous candidates
+  keep the externref fallback type — box / unbox still happens
+  there.
+- This is independent of `experimentalIR`. The fix is in the
+  legacy property-access dispatch; the IR path bypasses this
+  entirely.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2102,8 +2102,32 @@ export function compilePropertyAccess(
           fctx.body.push({ op: "any.convert_extern" } as Instr);
           fctx.body.push({ op: "local.set", index: tmpAnyExt });
 
-          const resultWasm =
-            accessWasm.kind === "f64" || accessWasm.kind === "i32" ? accessWasm : { kind: "externref" as const };
+          // Phase 3 (#1269): consumer-side specialization. When
+          // `accessWasm` is externref (TS `any`-typed receiver) but
+          // every struct candidate has the same Phase-1-inferred
+          // primitive field type, narrow the dispatch result to that
+          // primitive. The struct-then arm reads the field directly
+          // (no `__box_number`); the extern_get-else arm calls
+          // `__unbox_number` once. This eliminates the box→unbox
+          // roundtrip that previously fired on `const p: any =
+          // createPoint(...); p.x + p.y` style code, where Phase 1+2
+          // had already typed the struct's field but Phase 3 had not
+          // taught the consumer-side dispatch to use the typed read.
+          let resultWasm: ValType =
+            accessWasm.kind === "f64" || accessWasm.kind === "i32" ? accessWasm : ({ kind: "externref" } as const);
+          if (resultWasm.kind === "externref") {
+            const fieldKinds = new Set(structCandidates.map((c) => c.fieldType.kind));
+            if (fieldKinds.size === 1) {
+              const k = [...fieldKinds][0];
+              if (k === "f64" || k === "i32") {
+                resultWasm = { kind: k } as ValType;
+                if (unboxIdx === undefined) {
+                  unboxIdx = ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
+                  flushLateImportShifts(ctx, fctx);
+                }
+              }
+            }
+          }
           const resultLocal = allocLocal(fctx, `__sd_res_${fctx.locals.length}`, resultWasm);
 
           // Build the __extern_get fallback instructions
@@ -2153,12 +2177,15 @@ export function compilePropertyAccess(
 
           fctx.body.push(...buildStructDispatch(0));
           fctx.body.push({ op: "local.get", index: resultLocal });
-          if (accessWasm.kind === "f64") {
-            return { kind: "f64" };
-          }
-          if (accessWasm.kind === "i32") {
-            return { kind: "i32" };
-          }
+          // Phase 3 (#1269): when we narrowed `resultWasm` to the
+          // candidates' shared primitive type, return that — caller
+          // sees f64/i32 directly, no enclosing unbox needed. Falls
+          // back to the legacy accessWasm-based return when no
+          // narrowing was possible.
+          if (resultWasm.kind === "f64") return { kind: "f64" };
+          if (resultWasm.kind === "i32") return { kind: "i32" };
+          if (accessWasm.kind === "f64") return { kind: "f64" };
+          if (accessWasm.kind === "i32") return { kind: "i32" };
           return { kind: "externref" };
         }
 

--- a/tests/issue-1269.test.ts
+++ b/tests/issue-1269.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1269 — struct field inference Phase 3: consumer-side direct struct.get
+// (no box→unbox roundtrip).
+//
+// Phase 1+2 (#1231) inferred typed struct fields (e.g. `f64` for
+// `{x: number, y: number}` literals). Phase 3 teaches the consumer-
+// side property-access dispatch in `src/codegen/property-access.ts` to
+// use the typed struct.get directly when the receiver is `any`-typed
+// but every Phase-1 struct candidate for `propName` agrees on a
+// primitive field type. Without Phase 3, the dispatch boxed the
+// f64/i32 result via `__box_number` so the externref-fallback path
+// could fit a uniform externref result type, only to unbox again at
+// the consumer's first f64 use.
+//
+// The fix (in `compilePropertyAccess`'s externref-receiver branch):
+// when accessWasm is externref and all struct candidates for the
+// field share a primitive type, narrow `resultWasm` to that type;
+// the struct-then arm reads the field unboxed; the extern_get-else
+// arm calls `__unbox_number` once.
+
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: Function }).setExports === "function") {
+    (imps as { setExports: Function }).setExports(instance.exports);
+  }
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+function watFor(src: string): string {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const dir = join(tmpdir(), `issue-1269-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  const wasmPath = join(dir, "module.wasm");
+  writeFileSync(wasmPath, r.binary);
+  return execSync(`/workspace/node_modules/.bin/wasm-dis ${wasmPath}`, { encoding: "utf-8" });
+}
+
+/** Count actual `call $X` occurrences (not import declarations). */
+function countCalls(wat: string, importName: string): number {
+  return (wat.match(new RegExp(`call \\$${importName}\\b`, "g")) ?? []).length;
+}
+
+describe("#1269 — struct field inference Phase 3 — consumer-side direct struct.get", () => {
+  // ---------------------------------------------------------------------
+  // Behavioural correctness
+  // ---------------------------------------------------------------------
+
+  it("explicit `{x: number, y: number}` param: distance({3,4}) === 5", async () => {
+    expect(
+      await run(`
+        export function distance(p: { x: number; y: number }): number {
+          return Math.sqrt(p.x * p.x + p.y * p.y);
+        }
+        export function test(): number {
+          return distance({ x: 3, y: 4 });
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("createPoint inferred return: distance(createPoint(3,4)) === 5", async () => {
+    expect(
+      await run(`
+        function createPoint(x: number, y: number) { return { x, y }; }
+        function distance(p: { x: number; y: number }): number {
+          return Math.sqrt(p.x * p.x + p.y * p.y);
+        }
+        export function test(): number {
+          return distance(createPoint(3, 4));
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("any-typed local + addition: createPoint(3,4) → p.x + p.y === 7", async () => {
+    expect(
+      await run(`
+        function createPoint(x: number, y: number) { return { x, y }; }
+        export function test(): number {
+          const p: any = createPoint(3, 4);
+          return p.x + p.y;
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("any-typed local + multiplication: createPoint(3,4) → p.x * p.y === 12", async () => {
+    expect(
+      await run(`
+        function createPoint(x: number, y: number) { return { x, y }; }
+        export function test(): number {
+          const p: any = createPoint(3, 4);
+          return p.x * p.y;
+        }
+      `),
+    ).toBe(12);
+  });
+
+  it("any-typed local + sqrt(p.x² + p.y²) === 5", async () => {
+    expect(
+      await run(`
+        function createPoint(x: number, y: number) { return { x, y }; }
+        export function test(): number {
+          const p: any = createPoint(3, 4);
+          return Math.sqrt(p.x * p.x + p.y * p.y);
+        }
+      `),
+    ).toBe(5);
+  });
+
+  // ---------------------------------------------------------------------
+  // Structural assertions — no box → unbox roundtrip
+  // ---------------------------------------------------------------------
+
+  it("issue example — `distance(createPoint(3,4))` emits zero `__unbox_number` calls", () => {
+    const wat = watFor(`
+      function createPoint(x: number, y: number) { return { x, y }; }
+      export function distance(p: { x: number; y: number }): number {
+        return Math.sqrt(p.x * p.x + p.y * p.y);
+      }
+      export function test(): number { return distance(createPoint(3, 4)); }
+    `);
+    expect(countCalls(wat, "__unbox_number")).toBe(0);
+    expect(countCalls(wat, "__box_number")).toBe(0);
+  });
+
+  it("any-typed local: `__box_number` is NOT called on struct.get result (Phase 3 fix)", () => {
+    // The struct-then path should emit `struct.get` directly (no boxing).
+    // The extern_get-else fallback may still call `__unbox_number` once
+    // per field access, but the box→unbox roundtrip is gone.
+    const wat = watFor(`
+      function createPoint(x: number, y: number) { return { x, y }; }
+      export function test(): number {
+        const p: any = createPoint(3, 4);
+        return p.x + p.y;
+      }
+    `);
+    // No __box_number anywhere — the struct path no longer boxes its
+    // f64 field for the dispatch result.
+    expect(countCalls(wat, "__box_number")).toBe(0);
+  });
+
+  it("any-typed local: `struct.get` reads field directly without intermediate box", () => {
+    const wat = watFor(`
+      function createPoint(x: number, y: number) { return { x, y }; }
+      export function test(): number {
+        const p: any = createPoint(3, 4);
+        return p.x * p.y;
+      }
+    `);
+    // Two struct.get reads (one per field) appear in the WAT.
+    expect(wat).toMatch(/struct\.get \$0 0/);
+    expect(wat).toMatch(/struct\.get \$0 1/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1269. Phase 1+2 (#1231) inferred typed struct fields. Phase 3 teaches the consumer-side property-access dispatch in `src/codegen/property-access.ts` to USE the typed read directly when the receiver is `any`-typed but every Phase-1 struct candidate for the field name shares a primitive type — eliminating the box → unbox roundtrip.

## Before / after

**Before** (for `const p: any = createPoint(3, 4); p.x + p.y`):
```
if (ref.test (ref $0) ...) {
  local.set $5 (call $__box_number (struct.get $0 0 ...))   ;; box f64 → externref
} else {
  local.set $5 (call $__extern_get ...)                       ;; externref already
}
...
call $__unbox_number $5                                       ;; unbox externref → f64
```

**After**:
```
if (ref.test (ref $0) ...) {
  local.set $5 (struct.get $0 0 ...)                          ;; direct f64 read
} else {
  local.set $5 (call $__unbox_number (call $__extern_get ...)) ;; one unbox in fallback
}
;; consumer reads f64 directly from local $5
```

Result: 2 box + 2 unbox per field access → 0 box + 1 unbox (only on the rare extern fallback path).

## Fix

In `compilePropertyAccess` externref-receiver branch (line ~2105):

```ts
let resultWasm = accessWasm.kind === "f64" || accessWasm.kind === "i32"
  ? accessWasm
  : { kind: "externref" };
if (resultWasm.kind === "externref" && structCandidates.length > 0) {
  const fieldKinds = new Set(structCandidates.map((c) => c.fieldType.kind));
  if (fieldKinds.size === 1) {
    const k = [...fieldKinds][0];
    if (k === "f64" || k === "i32") {
      resultWasm = { kind: k };
      // ensure __unbox_number registered for the externref fallback
    }
  }
}
```

The narrowing only fires when ALL Phase-1 struct candidates agree on a single primitive. Heterogeneous candidates keep the externref fallback (box / unbox still happens there). Independent of `experimentalIR` — this is in the legacy property-access dispatch.

## Test plan

- [x] `tests/issue-1269.test.ts` — 8 / 8 passing. Behavioural cases (5 → 5, 7 → 7, 12 → 12, sqrt(25) → 5) plus structural WAT assertions (`__box_number` count = 0, `struct.get` reads field directly).
- [x] 38-test class / struct / extern / Hono regression sweep — identical pass/fail counts vs main (zero regressions).
- [ ] CI (Test262 Sharded) — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)