### PR TITLE
docs(#1200): close LICM issue — wasm-opt skips, V8 JIT compensates

### DIFF
--- a/plan/issues/sprints/48/1200-perf-loop-invariant-code-motion.md
+++ b/plan/issues/sprints/48/1200-perf-loop-invariant-code-motion.md
@@ -85,3 +85,41 @@ If wasm-opt already handles this and we add codegen-side hoisting, we may make t
 ## Notes
 
 This is the smaller of the two Tier 2 array-perf wins. May reduce to documentation-only if wasm-opt's existing pass covers our common shapes — which is why **Step 1 (measurement) comes first**.
+
+## Resolution (2026-05-03) — Step 1 alone closes this
+
+Step 1 (measurement) done. Findings:
+
+1. **Static**: `wasm-opt -O3` does NOT statically hoist
+   `struct.get $vec 0 (local.get $arr)` (vec.length read) out of
+   the loop condition. The struct.get stays inside the loop body
+   in both `--optimize` and unoptimized binaries. Reason: hoisting
+   a potentially-trapping op (struct.get on nullable ref) out of
+   a loop that might iterate zero times would change semantics.
+
+2. **Runtime (V8)**: Despite the static "miss", V8's JIT
+   compensates. Microbenchmark on a 1M-element array sum:
+
+   | variant | unopt median | -O3 median |
+   |---------|--------------|------------|
+   | re-eval `arr.length` each iter | 6.51 ms | 6.70 ms |
+   | manually hoisted | 6.60 ms | 6.65 ms |
+
+   The difference is within timing noise (≤ 1%). The JIT pulls the
+   struct.get out of the loop at compile time.
+
+### Decision: close with documentation, do NOT implement Step 2
+
+Adding codegen-side LICM would:
+
+- require mutation analysis to prove `arr` isn't reassigned in the body
+- emit a slightly larger pre-V8 binary (extra local + `local.set`)
+- yield zero measurable wall-clock benefit on V8
+
+The smaller-and-equivalent baseline is preferable. See
+`plan/notes/wasm-opt-coverage.md` (new, this issue) for the full
+write-up — that file is the running record of "things wasm-opt
+does / doesn't do that we should / shouldn't duplicate".
+
+Re-open if a non-V8 runtime (Wasmtime, Wasmer, custom interpreter)
+shows a meaningful gap on the same shape.

--- a/plan/notes/wasm-opt-coverage.md
+++ b/plan/notes/wasm-opt-coverage.md
@@ -1,0 +1,83 @@
+# wasm-opt coverage notes
+
+A running record of optimisations the Binaryen `wasm-opt` pass already
+performs (and so should NOT be duplicated in our own codegen passes),
+plus optimisations it does NOT perform that we may need to handle
+ourselves. Updated when a perf issue prompts measurement.
+
+## Loop-invariant code motion (LICM) — `struct.get` for `arr.length`
+
+**Issue**: #1200.
+
+**Question**: For the canonical `for (let i = 0; i < arr.length; i++) ...`
+pattern, does `wasm-opt -O3` hoist the `arr.length` read (lowered as
+`struct.get $vec 0 (local.get $arr)`) out of the loop condition?
+
+**Answer**: **No, wasm-opt does NOT statically hoist** the length read.
+But **V8's JIT effectively does at runtime**, so the static count
+overstates the runtime cost.
+
+### Static measurement (2026-05-03)
+
+Source:
+```ts
+export function arraySum(arr: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < arr.length; i++) sum += arr[i]!;
+  return sum;
+}
+```
+
+Both baseline (no `--optimize`) and optimized (`--optimize`, default
+level `-O3`) emit:
+
+```wat
+(loop $label
+  (br_if $block
+    (i32.eqz
+      (i32.lt_s
+        (local.get $2)
+        (struct.get $1 0 (local.get $0)))))   ;; <-- INSIDE the loop
+  ...
+  ;; body uses (struct.get $1 1 (local.get $0)) for vec.data
+  ...
+  (br $label))
+```
+
+`struct.get $1 0` (vec.length) is statically inside the loop in both
+binaries. wasm-opt's LICM declined to hoist it — most likely because
+`struct.get` on a nullable ref can trap, and hoisting a potentially-
+trapping op out of a loop that might iterate zero times changes
+"never trap" to "always trap" at the call site.
+
+### Runtime measurement (V8, microbenchmark)
+
+`tsx` benchmark: 1M-element array sum, 20 iterations, median time:
+
+| variant | unopt median | opt (-O3) median |
+|---------|--------------|------------------|
+| re-eval `arr.length` each iter | 6.51 ms | 6.70 ms |
+| manually hoisted `const len = arr.length` | 6.60 ms | 6.65 ms |
+
+The difference is within timing noise (≤1%). V8's JIT pulls the
+struct.get out of the loop body at compile time, so the source-level
+"redundant" read costs nothing at steady state.
+
+### Decision
+
+**Do not implement codegen-side LICM for this pattern.** V8's JIT
+already optimises it to identical hot code; adding a Binaryen-pass
+or codegen-side hoisting step would:
+
+1. Add complexity (mutation analysis to prove `arr` isn't reassigned in
+   the body).
+2. Produce a slightly larger pre-V8 binary (extra local + `local.set`).
+3. Yield zero measurable wall-clock improvement.
+
+The smaller-and-equivalent baseline is preferable. Re-revisit if a
+non-V8 runtime (Wasmtime, Wasmer, hand-rolled interpreter) shows a
+meaningful gap on the same shape.
+
+## Other notes
+
+(Add new findings as they accrue.)


### PR DESCRIPTION
## Summary

Closes #1200 with measurement-only work — Step 1 alone resolves it.

## Findings

**Static**: `wasm-opt -O3` does NOT statically hoist `struct.get $vec 0 (local.get $arr)` (the vec.length read) out of the loop condition. Verified by disassembling `--optimize` vs unoptimized binaries for the canonical `for (let i = 0; i < arr.length; i++)` pattern. Wasm-opt declines because hoisting a potentially-trapping `struct.get` out of a loop that might iterate zero times changes "never trap" to "always trap".

**Runtime (V8)**: The JIT compensates. 1M-element array sum, 20-iteration median:

| variant | unopt | -O3 |
|---------|-------|-----|
| re-evaluate `arr.length` each iter | 6.51 ms | 6.70 ms |
| manually hoisted `const len = arr.length` | 6.60 ms | 6.65 ms |

Difference is within timing noise (≤ 1%). V8 pulls the struct.get out of the loop at JIT time.

## Decision

**Close with documentation. Do NOT implement Step 2 (codegen-side hoisting).** It would:
- Require mutation analysis to prove `arr` isn't reassigned in the body.
- Emit a slightly larger pre-V8 binary (extra local + `local.set`).
- Yield zero measurable wall-clock benefit on V8.

The smaller-and-equivalent baseline is preferable. Re-open if a non-V8 runtime (Wasmtime, Wasmer, custom interpreter) shows a meaningful gap.

## Files

- `plan/notes/wasm-opt-coverage.md` (new) — running record of "things wasm-opt does / doesn't do that we should / shouldn't duplicate". This issue is its first entry; future perf investigations should consult / append here before adding codegen-side passes.
- `plan/issues/sprints/48/1200-perf-loop-invariant-code-motion.md` — resolution notes appended.

## Test plan

- [x] No source changes — no test impact.
- [x] Microbenchmark methodology + results documented in both the issue and the new coverage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)