### PR TITLE
feat(#1126 Stage 1): extend lattice with i32/u32 atoms

### DIFF
--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -162,7 +162,14 @@ export interface IrClassShape {
 }
 
 export type IrType =
-  | { readonly kind: "val"; readonly val: ValType }
+  // The optional `signed` flag (#1126 Stage 1) is a *value-domain* fact, not
+  // a Wasm-storage fact: both `int32` and `uint32` lower to the same Wasm
+  // `i32` storage but are distinguished at op-selection time (`i32.shr_s`
+  // vs `i32.shr_u`, `f64.convert_i32_s` vs `_u`, signed vs unsigned cmp).
+  // Default (undefined) is "signed" for backward compat — every existing
+  // `val: { kind: "i32" }` callsite preserves its current semantics.
+  // Stage 1 only adds the field; producers / consumers come in Stages 2-3.
+  | { readonly kind: "val"; readonly val: ValType; readonly signed?: boolean }
   // Backend-agnostic string marker (#1169a). The actual Wasm representation
   // is decided at lowering time via `IrLowerResolver.resolveString`:
   //   - host-strings backend  → `externref`
@@ -214,6 +221,20 @@ export function irVal(v: ValType): IrType {
 }
 
 /**
+ * Wrap a ValType as an IrType with an explicit signedness fact (#1126 Stage 1).
+ * Use this only for `i32` ValTypes where the value-domain (signed `int32` vs
+ * unsigned `uint32`) is known. For non-i32 ValTypes the `signed` flag is
+ * meaningless; callers should use `irVal()` instead.
+ *
+ * The flag is read by Stage 3 emit decisions (signed vs unsigned shifts,
+ * comparisons, conversions back to f64). For Stage 1 it is purely additive —
+ * no existing emitter consults it yet.
+ */
+export function irValSigned(v: ValType, signed: boolean): IrType {
+  return { kind: "val", val: v, signed };
+}
+
+/**
  * Return the single underlying ValType for a `val`-kind IrType, else `null`.
  * Call sites that previously did `t.kind === "f64"` against an `IrType` now
  * do `asVal(t)?.kind === "f64"`.
@@ -231,7 +252,17 @@ export function asVal(t: IrType): ValType | null {
  */
 export function irTypeEquals(a: IrType, b: IrType): boolean {
   if (a.kind !== b.kind) return false;
-  if (a.kind === "val" && b.kind === "val") return valTypeEquals(a.val, b.val);
+  if (a.kind === "val" && b.kind === "val") {
+    if (!valTypeEquals(a.val, b.val)) return false;
+    // #1126 Stage 1 — `signed` is a domain fact, not a Wasm-storage fact.
+    // Two `val` types differ if they disagree on signedness (e.g. an
+    // i32 inferred as `int32` in one branch vs `uint32` in another would
+    // join to `f64` in the lattice; we never want them to compare equal
+    // here). `undefined` is treated as "signed" (the legacy default).
+    const aSigned = a.signed ?? true;
+    const bSigned = b.signed ?? true;
+    return aSigned === bSigned;
+  }
   if (a.kind === "string" && b.kind === "string") return true;
   if (a.kind === "boxed" && b.kind === "boxed") return valTypeEquals(a.inner, b.inner);
   if (a.kind === "union" && b.kind === "union") {

--- a/src/ir/propagate.ts
+++ b/src/ir/propagate.ts
@@ -108,6 +108,19 @@ import { ts, forEachChild } from "../ts-api.js";
  */
 export type LatticeAtom =
   | { readonly kind: "f64" }
+  // #1126 Stage 1 — integer-domain atoms. Both lower to the same Wasm
+  // `i32` storage, but are distinguished as separate lattice elements so
+  // op selection (signed vs unsigned shifts, comparisons, conversions)
+  // can be made structurally rather than via ad-hoc heuristics.
+  //   `i32` — signed two's-complement, range [-2^31, 2^31)
+  //   `u32` — unsigned, range [0, 2^32)
+  // Producer rules (Stage 2) determine when expressions enter these
+  // domains; preserve/widen rules (also Stage 2) determine when they
+  // collapse back to `f64`. Notably, arithmetic (+,-,*,%) on two `i32`s
+  // widens to `f64` because JS `+` semantics don't wrap on overflow —
+  // see #1236 for the bug this rule structurally prevents.
+  | { readonly kind: "i32" }
+  | { readonly kind: "u32" }
   | { readonly kind: "bool" }
   | { readonly kind: "string" }
   | {
@@ -160,6 +173,8 @@ export type TypeMap = ReadonlyMap<string, TypeMapEntry>;
 
 const UNKNOWN: LatticeType = { kind: "unknown" };
 const F64: LatticeType = { kind: "f64" };
+const I32: LatticeType = { kind: "i32" };
+const U32: LatticeType = { kind: "u32" };
 const BOOL: LatticeType = { kind: "bool" };
 const STRING: LatticeType = { kind: "string" };
 const DYNAMIC: LatticeType = { kind: "dynamic" };
@@ -663,7 +678,14 @@ function objectAtomDepth(a: LatticeAtom): number {
 }
 
 function f64Compatible(t: LatticeType): boolean {
-  return t.kind === "f64" || t.kind === "unknown";
+  // #1126 Stage 1 — `i32` and `u32` are numeric subdomains of `f64`:
+  // a value in either can be widened to f64 with `f64.convert_i32_s/u`
+  // without loss, so any `f64`-shaped expression context (arithmetic,
+  // numeric comparisons) accepts them. The lattice atoms remain
+  // distinct so Stage 3's emitter can pick the narrowed-i32 path
+  // when both operands stay narrow. `unknown` stays compatible so
+  // unresolved-but-not-yet-widened values propagate through fixpoint.
+  return t.kind === "f64" || t.kind === "i32" || t.kind === "u32" || t.kind === "unknown";
 }
 
 function boolCompatible(t: LatticeType): boolean {
@@ -678,6 +700,31 @@ function join(a: LatticeType, b: LatticeType): LatticeType {
   if (a.kind === "dynamic" || b.kind === "dynamic") return DYNAMIC;
   if (a.kind === "unknown") return b;
   if (b.kind === "unknown") return a;
+
+  // #1126 Stage 1 — numeric-domain widening rules. Joining two distinct
+  // numeric atoms (any combination of i32/u32/f64) widens to f64 rather
+  // than forming a union, because:
+  //
+  //   • A union `{i32, f64}` would force a tagged-union representation
+  //     for what is logically still "a JS number" — wasteful, and the
+  //     V1 union lowering doesn't support i32-as-bare-i32 anyway (the
+  //     i32 slot is reserved for bool).
+  //   • `i32 ⊔ u32 = f64` (not a union) because the value `2^31` is
+  //     positive in u32 but negative in i32 — the only domain that
+  //     contains both interpretations losslessly is f64. Encoding that
+  //     as a tagged union would require runtime sign-disambiguation
+  //     which f64 already represents directly.
+  //   • i32/u32 are subdomains of f64 (`f64Compatible` returns true for
+  //     both), so widening preserves every fact a downstream consumer
+  //     could care about.
+  //
+  // Same-kind atom join (i32 ⊔ i32, u32 ⊔ u32) collapses normally via
+  // the atomsEqual fast path below.
+  if (isAtomLattice(a) && isAtomLattice(b)) {
+    const aNumeric = a.kind === "f64" || a.kind === "i32" || a.kind === "u32";
+    const bNumeric = b.kind === "f64" || b.kind === "i32" || b.kind === "u32";
+    if (aNumeric && bNumeric && a.kind !== b.kind) return F64;
+  }
 
   // Atom ⊔ Atom: same kind collapses; different kinds form a union.
   if (isAtomLattice(a) && isAtomLattice(b)) {
@@ -708,7 +755,14 @@ function join(a: LatticeType, b: LatticeType): LatticeType {
 }
 
 function isAtomLattice(t: LatticeType): t is LatticeAtom {
-  return t.kind === "f64" || t.kind === "bool" || t.kind === "string" || t.kind === "object";
+  return (
+    t.kind === "f64" ||
+    t.kind === "i32" ||
+    t.kind === "u32" ||
+    t.kind === "bool" ||
+    t.kind === "string" ||
+    t.kind === "object"
+  );
 }
 
 function atomsEqual(a: LatticeAtom, b: LatticeAtom): boolean {
@@ -728,10 +782,46 @@ function atomsEqual(a: LatticeAtom, b: LatticeAtom): boolean {
   return true;
 }
 
+/**
+ * Pre-pass for `makeUnion` — #1126 Stage 1 numeric collapse.
+ *
+ * If two or more *different* numeric atoms (any combination of f64/i32/u32)
+ * appear in the input, replace all of them with a single f64 atom. This
+ * preserves the invariant established by `join`: a union never simultaneously
+ * holds an integer-domain atom and a wider numeric atom. Rationale matches
+ * `join`'s numeric-widening rule — i32/u32 are subdomains of f64, encoding
+ * them as siblings in a tagged union would force runtime sign-disambiguation
+ * for no semantic gain.
+ *
+ * Returns the input array unchanged when at most one numeric atom is present
+ * (the common case for non-numeric unions like `{string, bool}`).
+ */
+function collapseNumericAtoms(members: readonly LatticeAtom[]): readonly LatticeAtom[] {
+  const distinctNumericKinds = new Set<string>();
+  for (const m of members) {
+    if (m.kind === "f64" || m.kind === "i32" || m.kind === "u32") distinctNumericKinds.add(m.kind);
+  }
+  if (distinctNumericKinds.size <= 1) return members;
+  const out: LatticeAtom[] = [];
+  let f64Added = false;
+  for (const m of members) {
+    if (m.kind === "f64" || m.kind === "i32" || m.kind === "u32") {
+      if (!f64Added) {
+        out.push({ kind: "f64" });
+        f64Added = true;
+      }
+      continue;
+    }
+    out.push(m);
+  }
+  return out;
+}
+
 /** Build a canonical union from a list of atoms (dedupe + sort). */
 function makeUnion(members: readonly LatticeAtom[]): LatticeType {
+  const collapsed = collapseNumericAtoms(members);
   const deduped: LatticeAtom[] = [];
-  for (const m of members) {
+  for (const m of collapsed) {
     if (!deduped.some((d) => atomsEqual(d, m))) deduped.push(m);
   }
   if (deduped.length > LATTICE_UNION_MAX_MEMBERS) return DYNAMIC;
@@ -773,12 +863,21 @@ function atomKindOrder(k: LatticeAtom["kind"]): number {
   switch (k) {
     case "f64":
       return 0;
-    case "bool":
+    // i32/u32 sort right after f64 — they're numeric atoms, so within a
+    // canonical union they cluster together. Order: f64 < i32 < u32 <
+    // bool < string < object. The relative ordering doesn't affect
+    // semantics; it only affects the deterministic canonical form used
+    // by `typesEqual` for fixpoint convergence.
+    case "i32":
       return 1;
-    case "string":
+    case "u32":
       return 2;
-    case "object":
+    case "bool":
       return 3;
+    case "string":
+      return 4;
+    case "object":
+      return 5;
   }
 }
 
@@ -916,6 +1015,17 @@ export function lowerTypeToIrType(t: LatticeType): import("./nodes.js").IrType |
   switch (t.kind) {
     case "f64":
       return { kind: "val", val: { kind: "f64" } };
+    // #1126 Stage 1 — both `i32` and `u32` lattice atoms lower to the same
+    // Wasm `i32` storage but are tagged with the IR `signed` fact so
+    // Stage 3 emit decisions (signed vs unsigned shifts, comparisons,
+    // conversions back to f64) can be made structurally. `bool` still
+    // lowers as i32 with default (signed) semantics — the v1 union
+    // mapping already relies on bool taking the i32 slot, and bool/i32
+    // never co-exist in the same union here.
+    case "i32":
+      return { kind: "val", val: { kind: "i32" }, signed: true };
+    case "u32":
+      return { kind: "val", val: { kind: "i32" }, signed: false };
     case "bool":
       return { kind: "val", val: { kind: "i32" } };
     case "string":
@@ -943,7 +1053,14 @@ export function lowerTypeToIrType(t: LatticeType): import("./nodes.js").IrType |
       for (const m of t.members) {
         if (m.kind === "f64") members.push({ kind: "f64" });
         else if (m.kind === "bool") members.push({ kind: "i32" });
-        else return null; // string/object members not supported in V1 tagged unions
+        // string/object members not supported in V1 tagged unions.
+        // #1126 Stage 1 — i32/u32 atoms also fall through to `return null`
+        // here. They should never reach this case in practice: the lattice
+        // `join` rules collapse `i32 ⊔ f64 = f64` and `i32 ⊔ u32 = f64`,
+        // so a union containing an integer-domain atom only forms when
+        // joining with a non-numeric atom (string/object/bool). That
+        // shape isn't representable in V1 tagged unions either way.
+        else return null;
       }
       if (members.length < 2) return null;
       return { kind: "union", members };
@@ -962,4 +1079,12 @@ export const _internals = {
   tsTypeToLattice,
   typeNodeToLattice,
   makeUnion,
+  // #1126 Stage 1 — lattice atom constants for unit tests.
+  F64,
+  I32,
+  U32,
+  BOOL,
+  STRING,
+  UNKNOWN,
+  DYNAMIC,
 };

--- a/tests/ir-propagate-i32.test.ts
+++ b/tests/ir-propagate-i32.test.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1126 Stage 1 — Lattice extension for integer-domain inference.
+//
+// Pure unit tests for the new `i32` and `u32` lattice atoms, the join-rule
+// numeric-widening behaviour, and the `lowerTypeToIrType` mapping. These
+// tests never compile a TypeScript program — they exercise the lattice
+// algebra directly via `_internals` so a regression in the lattice
+// arithmetic is caught immediately, without going through the heavy
+// IR-builder pipeline.
+//
+// Stage 1 introduces the lattice atoms but no producer rules — every
+// existing compile path still sees only f64/bool/string/object, so this
+// PR cannot affect test262 conformance or any equivalence test. Stages 2+
+// will add producers (literals, bitwise ops, loop counters) and the actual
+// emit-side specialisation.
+
+import { describe, expect, it } from "vitest";
+
+import { irTypeEquals, irVal, irValSigned } from "../src/ir/index.js";
+import { _internals, lowerTypeToIrType, type LatticeType, type LatticeAtom } from "../src/ir/propagate.js";
+
+const { join, F64, I32, U32, BOOL, STRING, UNKNOWN, DYNAMIC, makeUnion } = _internals;
+
+// ---------------------------------------------------------------------------
+// Atom presence — the new kinds exist and are distinct from f64
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — LatticeAtom i32/u32 presence", () => {
+  it("I32 and U32 constants are distinct from F64", () => {
+    expect(I32.kind).toBe("i32");
+    expect(U32.kind).toBe("u32");
+    expect(F64.kind).toBe("f64");
+    expect(I32).not.toBe(F64);
+    expect(U32).not.toBe(F64);
+    expect(I32).not.toBe(U32);
+  });
+
+  it("i32/u32 atoms join with themselves (idempotent)", () => {
+    expect(join(I32, I32)).toEqual(I32);
+    expect(join(U32, U32)).toEqual(U32);
+  });
+
+  it("UNKNOWN ⊔ i32 = i32 (and the symmetric case)", () => {
+    expect(join(UNKNOWN, I32)).toEqual(I32);
+    expect(join(I32, UNKNOWN)).toEqual(I32);
+    expect(join(UNKNOWN, U32)).toEqual(U32);
+    expect(join(U32, UNKNOWN)).toEqual(U32);
+  });
+
+  it("DYNAMIC absorbs i32/u32 (top of lattice)", () => {
+    expect(join(DYNAMIC, I32)).toEqual(DYNAMIC);
+    expect(join(I32, DYNAMIC)).toEqual(DYNAMIC);
+    expect(join(DYNAMIC, U32)).toEqual(DYNAMIC);
+    expect(join(U32, DYNAMIC)).toEqual(DYNAMIC);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Join — the central #1126 rule:
+//   numeric atoms with different kinds widen to f64 instead of forming a
+//   union. This structurally prevents the #1236 saturation bug because
+//   downstream emitters never see an `{i32, f64}` shape that they might
+//   accidentally narrow to i32.
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — numeric-domain join rules", () => {
+  it("i32 ⊔ f64 = f64 (signed integer subdomain widens)", () => {
+    expect(join(I32, F64)).toEqual(F64);
+    expect(join(F64, I32)).toEqual(F64);
+  });
+
+  it("u32 ⊔ f64 = f64 (unsigned integer subdomain widens)", () => {
+    expect(join(U32, F64)).toEqual(F64);
+    expect(join(F64, U32)).toEqual(F64);
+  });
+
+  it("i32 ⊔ u32 = f64 (signed/unsigned mismatch widens — 2^31 differs in sign)", () => {
+    expect(join(I32, U32)).toEqual(F64);
+    expect(join(U32, I32)).toEqual(F64);
+  });
+
+  it("i32 ⊔ bool forms a regular union (bool is non-numeric)", () => {
+    const r = join(I32, BOOL);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["bool", "i32"]);
+  });
+
+  it("i32 ⊔ string forms a regular union (cross-kind, no numeric collapse)", () => {
+    const r = join(I32, STRING);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["i32", "string"]);
+  });
+
+  it("u32 ⊔ string forms a regular union", () => {
+    const r = join(U32, STRING);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["string", "u32"]);
+  });
+
+  it("f64 ⊔ bool still forms the existing {f64, bool} union (no regression)", () => {
+    // Sentinel — pre-existing #1168 union behaviour must not change.
+    const r = join(F64, BOOL);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["bool", "f64"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Union construction — numeric collapse inside makeUnion
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — numeric collapse in makeUnion", () => {
+  it("makeUnion([i32, f64]) collapses to f64", () => {
+    const r = makeUnion([{ kind: "i32" }, { kind: "f64" }]);
+    expect(r).toEqual(F64);
+  });
+
+  it("makeUnion([u32, f64]) collapses to f64", () => {
+    const r = makeUnion([{ kind: "u32" }, { kind: "f64" }]);
+    expect(r).toEqual(F64);
+  });
+
+  it("makeUnion([i32, u32]) collapses to f64", () => {
+    const r = makeUnion([{ kind: "i32" }, { kind: "u32" }]);
+    expect(r).toEqual(F64);
+  });
+
+  it("makeUnion([i32, f64, string]) collapses numerics, keeps string union", () => {
+    const r = makeUnion([{ kind: "i32" }, { kind: "f64" }, { kind: "string" }]);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["f64", "string"]);
+  });
+
+  it("makeUnion([i32, string]) keeps i32 in the union (single numeric, no collapse)", () => {
+    const r = makeUnion([{ kind: "i32" }, { kind: "string" }]);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["i32", "string"]);
+  });
+
+  it("union ⊔ i32 collapses if union already has f64 ({f64, bool} ⊔ i32 = {f64, bool})", () => {
+    const fbUnion = join(F64, BOOL); // {f64, bool}
+    const r = join(fbUnion, I32);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds = r.members.map((m) => m.kind).sort();
+    expect(kinds).toEqual(["bool", "f64"]); // i32 absorbed into existing f64
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LatticeType → IrType lowering
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — lowerTypeToIrType for i32/u32", () => {
+  it("lowerTypeToIrType(I32) = val{i32, signed:true}", () => {
+    const t = lowerTypeToIrType(I32);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("val");
+    if (t!.kind !== "val") return;
+    expect(t!.val).toEqual({ kind: "i32" });
+    expect(t!.signed).toBe(true);
+  });
+
+  it("lowerTypeToIrType(U32) = val{i32, signed:false}", () => {
+    const t = lowerTypeToIrType(U32);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("val");
+    if (t!.kind !== "val") return;
+    expect(t!.val).toEqual({ kind: "i32" });
+    expect(t!.signed).toBe(false);
+  });
+
+  it("lowerTypeToIrType(F64) still produces val{f64} (no signed flag)", () => {
+    const t = lowerTypeToIrType(F64);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("val");
+    if (t!.kind !== "val") return;
+    expect(t!.val).toEqual({ kind: "f64" });
+    expect(t!.signed).toBeUndefined();
+  });
+
+  it("lowerTypeToIrType(BOOL) still produces val{i32} without signed flag (legacy)", () => {
+    // Stage 1 invariant: bool's existing wasm representation is unchanged.
+    // Stage 2 producers must not retro-flag it; signed remains undefined.
+    const t = lowerTypeToIrType(BOOL);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("val");
+    if (t!.kind !== "val") return;
+    expect(t!.val).toEqual({ kind: "i32" });
+    expect(t!.signed).toBeUndefined();
+  });
+
+  it("the i32 and u32 IR types compare unequal under irTypeEquals", () => {
+    const tI = lowerTypeToIrType(I32)!;
+    const tU = lowerTypeToIrType(U32)!;
+    expect(irTypeEquals(tI, tU)).toBe(false);
+  });
+
+  it("plain irVal({i32}) equals irValSigned({i32}, true) — undefined defaults to signed", () => {
+    const a = irVal({ kind: "i32" });
+    const b = irValSigned({ kind: "i32" }, true);
+    expect(irTypeEquals(a, b)).toBe(true);
+  });
+
+  it("irValSigned({i32}, false) is unequal to irVal({i32})", () => {
+    const a = irVal({ kind: "i32" });
+    const b = irValSigned({ kind: "i32" }, false);
+    expect(irTypeEquals(a, b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// f64Compatible — i32/u32 are subdomains
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — f64Compatible accepts i32/u32 as subdomains", () => {
+  // f64Compatible isn't directly exported, but inferExpr's behaviour
+  // observes it indirectly. Use the typed-arithmetic inference path: a
+  // binary `+` of two f64-compatible operands yields f64. With Stage 1's
+  // helpers, an f64 plus an i32 should still produce f64 (not DYNAMIC).
+  // We check this via the join function instead, which now encodes the
+  // same invariant: f64 ⊔ i32 = f64.
+  it("the relation is structurally consistent with join (f64 ⊔ i32 = f64)", () => {
+    expect(join(F64, I32)).toEqual(F64);
+    expect(join(F64, U32)).toEqual(F64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sanity — existing (pre-#1126) lattice behaviour is unchanged
+// ---------------------------------------------------------------------------
+
+describe("#1126 Stage 1 — existing lattice behaviour unchanged (regression sentinel)", () => {
+  it("f64 ⊔ f64 = f64 (idempotence)", () => {
+    expect(join(F64, F64)).toEqual(F64);
+  });
+
+  it("bool ⊔ bool = bool", () => {
+    expect(join(BOOL, BOOL)).toEqual(BOOL);
+  });
+
+  it("string ⊔ string = string", () => {
+    expect(join(STRING, STRING)).toEqual(STRING);
+  });
+
+  it("UNKNOWN ⊔ f64 = f64 (existing rule)", () => {
+    expect(join(UNKNOWN, F64)).toEqual(F64);
+  });
+
+  it("DYNAMIC ⊔ f64 = DYNAMIC (existing rule)", () => {
+    expect(join(DYNAMIC, F64)).toEqual(DYNAMIC);
+  });
+
+  it("f64 ⊔ string forms a {f64, string} union (existing rule)", () => {
+    const r: LatticeType = join(F64, STRING);
+    expect(r.kind).toBe("union");
+    if (r.kind !== "union") return;
+    const kinds: string[] = r.members.map((m: LatticeAtom) => m.kind).sort();
+    expect(kinds).toEqual(["f64", "string"]);
+  });
+
+  it("lowerTypeToIrType(STRING) still produces { kind: 'string' }", () => {
+    const t = lowerTypeToIrType(STRING);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of the six-stage decomposition from PR #204's architect-spec. **Pure additive change** — no producers create i32/u32 atoms yet, so this PR cannot affect any existing compile test, equivalence test, or test262 result. Stages 2+ wire in the producers and emit-side specialisation.

## Changes

### Lattice (`src/ir/propagate.ts`, +139 LoC)

- `LatticeAtom` gains `{kind:"i32"}` and `{kind:"u32"}` — both lower to Wasm `i32` storage but are tracked as distinct lattice elements so op selection (signed/unsigned shifts, comparisons, conversions) can be made structurally rather than via ad-hoc heuristics.
- `join()` encodes the central #1126 rule:
  - `i32 ⊔ i32 = i32`, `u32 ⊔ u32 = u32` (idempotent)
  - `i32 ⊔ f64 = f64`, `u32 ⊔ f64 = f64` (subdomain widens)
  - `i32 ⊔ u32 = f64` (sign mismatch — value 2^31 differs in sign)
  - Cross-kind with non-numerics still forms unions per existing rules
- `makeUnion` gets a `collapseNumericAtoms` pre-pass so a union built up via repeated extension can never simultaneously hold an integer-domain atom and a wider numeric atom.
- `f64Compatible` accepts `i32`/`u32` (both are subdomains of f64).
- `atomKindOrder` updated for canonical union ordering: `f64 < i32 < u32 < bool < string < object`.
- `lowerTypeToIrType` handles the new atoms: `i32 → val{i32, signed:true}`, `u32 → val{i32, signed:false}`.

### IrType (`src/ir/nodes.ts`, +35 LoC)

- `val` variant gains optional `signed?: boolean` — a *value-domain* fact (not Wasm-storage), default `undefined ≡ signed` for backward compat. Stage 3 will read this to pick `i32.shr_s` vs `i32.shr_u` and `f64.convert_i32_s` vs `_u`.
- New `irValSigned(v, signed)` helper for Stage 2+ producers.
- `irTypeEquals` compares signedness for `val` (undefined ≡ true).

### Tests (`tests/ir-propagate-i32.test.ts`, 32 tests)

- Atom presence and idempotence (4 tests)
- All seven join-rule cases from the spec table (7 tests)
- Numeric collapse inside `makeUnion` (6 tests, incl. union-extension)
- `lowerTypeToIrType` mapping for i32/u32/f64/bool/string (8 tests)
- Signed/unsigned `irTypeEquals` discrimination
- Regression sentinel: existing f64/bool/string lattice unchanged (7 tests)

## Verification

- ✅ 32/32 new unit tests pass
- ✅ Existing IR test suite passes (1 pre-existing failure on main: `ir-scaffold.test.ts` "func.params is not iterable" — confirmed identical on `origin/main` HEAD before my changes; unrelated)
- ✅ 10 sampled equivalence tests pass
- ✅ #1236 saturation sentinel passes (9/9) — Stage 1 doesn't disturb the legacy widening that #1236 relies on
- ✅ `npx tsc --noEmit` clean (0 errors)

## What this PR does NOT do

- No producer rules — no expression in any compiled program currently produces an `i32` or `u32` lattice atom. That's Stage 2.
- No emit-side changes — `lower.ts` and the legacy emitter both still see only `f64` / `i32` (bool) / refs. Stage 3 wires in the i32-fast-path emit decisions.
- No boundary conversions — Stage 4 handles cross-function narrowing.

## Test plan

- [x] Stage 1 unit tests pass: `npx vitest run tests/ir-propagate-i32.test.ts`
- [x] Existing IR tests unaffected
- [x] #1236 sentinel unchanged
- [x] Equivalence smoke tests pass
- [x] Typecheck clean
- [ ] CI: differential-gate green (no test262 movement expected — pure addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)