### PR TITLE
ci: use PR base SHA as differential cache key

### DIFF
--- a/.github/workflows/test262-differential.yml
+++ b/.github/workflows/test262-differential.yml
@@ -95,6 +95,12 @@ jobs:
       - name: Compute main src/ tree hash
         id: tree
         run: |
+          # Use the PR's base commit rather than current origin/main tip.
+          # This prevents cache busting when other PRs land between push
+          # and CI start, which caused ~14 consistent drift regressions
+          # (different wasm SHAs across runs, wasm_identical filter can't help).
+          # workflow_dispatch falls back to origin/main tip.
+          #
           # The cache key is the content hash of main's src/ directory,
           # NOT the commit SHA. This is what makes the cache content-
           # addressable: after a normal --merge merge, main's src/ tree
@@ -102,9 +108,15 @@ jobs:
           # cache entry serves both. Workflow-side commits (e.g.
           # `chore: refresh baseline [skip ci]`) don't change src/ and
           # don't bust the cache.
-          git fetch origin main:refs/remotes/origin/main --depth=1
-          MAIN_TREE=$(git rev-parse origin/main:src)
-          MAIN_SHA=$(git rev-parse origin/main)
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            git fetch origin main:refs/remotes/origin/main --depth=1
+            BASE_SHA=$(git rev-parse origin/main)
+          fi
+          git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || true
+          MAIN_TREE=$(git rev-parse ${BASE_SHA}:src)
+          MAIN_SHA=${BASE_SHA}
           echo "sha=${MAIN_TREE}" >> "$GITHUB_OUTPUT"
           echo "commit=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
           echo "main src/ tree: ${MAIN_TREE} (commit ${MAIN_SHA})"
@@ -509,7 +521,7 @@ jobs:
             else
               echo "- **main results: cache MISS** for src/ tree \`${{ needs.check-main-cache.outputs.main_tree }}\` — main shards ran in parallel with branch."
             fi
-            echo "- main HEAD commit: \`${{ needs.check-main-cache.outputs.main_sha }}\`"
+            echo "- comparison base commit: \`${{ needs.check-main-cache.outputs.main_sha }}\` (PR base, not tip)"
             echo "- branch tip commit: \`${{ github.event.pull_request.head.sha || github.sha }}\`"
             echo ""
             echo "<details><summary>diff output</summary>"


### PR DESCRIPTION
## Summary

The `check-main-cache` job in `.github/workflows/test262-differential.yml` derived the cache key from the **current** `origin/main` tip at CI start. If another PR landed between branch push and CI start, the src tree hash changed, the cache missed, and main shards re-ran under different runner conditions — flipping ~14 tests due to runner variance.

Those flipped tests had different wasm hashes (branch was merged against old main, fresh main shards were compiled from new main), so the `wasm_identical` drift filter in `diff-test262.ts` couldn't suppress them. Result: consistent ~14 false-positive regressions across PRs.

## Fix

Switch to `github.event.pull_request.base.sha` — the commit the PR was opened against. That SHA is stable for the life of the PR and doesn't drift when other PRs merge. `workflow_dispatch` falls back to the `origin/main` tip for ad-hoc runs.

- **Cache hit path**: behavior is identical (same key derivation when src trees match).
- **Cache miss path**: main shards now build from the exact src the branch was rebased against, so wasm hashes match across runs and the `wasm_identical` filter neutralizes residual runner variance.

Also updates the GitHub Step Summary annotation: `main HEAD commit` → `comparison base commit (PR base, not tip)` to make the new semantics explicit.

## Test plan

- [ ] CI on this PR produces zero regressions (workflow change only — no source diff)
- [ ] Spot-check next 2-3 PRs that follow this merge: regression count should drop to near zero on no-source-change PRs
- [ ] If a future PR has a stale base (`base.sha` is N commits behind `origin/main`), main shards rebuild against that older src — acceptable trade-off vs. drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)