### PR TITLE
fix(#1293): wrap forward-referencing types in WasmGC rec groups

### DIFF
--- a/plan/issues/sprints/48/1293-hono-tier4-string-array-of-arrays.md
+++ b/plan/issues/sprints/48/1293-hono-tier4-string-array-of-arrays.md
@@ -2,7 +2,7 @@
 id: 1293
 sprint: 48
 title: "Hono Tier 4 — string[][] array-of-arrays type support + #segments field"
-status: ready
+status: in-progress
 created: 2026-05-03
 updated: 2026-05-03
 priority: medium
@@ -74,3 +74,51 @@ Once `string[][]` compiles:
 - `number[][]` (matrix) should be covered by the same fix
 - The fix touches the array type registration path, not the IR selector —
   this is a WasmGC type-section change
+
+## Implementation Notes
+
+The bug was not in `resolveWasmType` / `getOrRegisterArrayType` /
+`getOrRegisterVecType` — the IR was already registering nested vec types
+correctly. The actual symptom (`WebAssembly.instantiate(): Type index N is
+out of bounds @+30`) was a **type-section encoding** issue:
+
+1. `collectClassDeclaration` pre-registers a placeholder struct at
+   `mod.types.length` (so self-referencing fields like `next: ListNode | null`
+   resolve to a valid type index). The placeholder slot is reserved
+   *before* field types are resolved.
+2. Resolving a `string[][]` field calls `getOrRegisterVecType` twice —
+   once for the inner `string[]` (already cached) and once for the outer
+   `string[][]`. The outer registration appends a new array type AND a
+   new vec struct *after* the placeholder slot.
+3. The placeholder slot is then overwritten with the real class struct
+   def, whose `rows` field references the newly-appended vec by its
+   actual index — which is *higher* than the class's own index.
+4. The emitter encoded each type as its own implicit rec group of 1.
+   In WasmGC, a singleton-rec type can only reference earlier types or
+   itself. A forward reference (`type idx 3 → type idx 5`) fails
+   validation.
+
+Fix: in `src/emit/binary.ts`, automatically detect forward references in
+the type section and group consecutive types into a single WasmGC rec
+group when needed. `computeRecGroups` walks `mod.types` and extends the
+current group's end whenever an entry references a later index;
+transitively, the group extends to cover all reachable forward refs.
+Singleton groups (no forward refs) are still encoded without a rec
+wrapper, preserving canonical type identity for the common case.
+
+This is a backend-only change. No codegen / IR changes required.
+
+## Test Results
+
+`tests/issue-1293.test.ts` (6/6) — minimal repros for `string[][]`,
+`number[][]`, class field with `string[][]`, length checks.
+
+`tests/stress/hono-tier4.test.ts` (5/5) — Tier 4 trie-router with
+`segments: string[][]` field on Node:
+- Tier 4a: `root.segments.length` tracks all 11 registered routes
+- Tier 4b: per-route inner length matches `split(path)`
+- Tier 4c: nested `node.segments[i][j]` returns the registered segment
+- Tier 4d: 11 routes + 3 misses still resolve (regression check vs Tier 3)
+- Tier 4e: parametric + wildcard routing unaffected by the new field
+
+Tier 1 / 2 / 3 stress tests (3 + 5 + 6) — all green; no regressions.

--- a/src/emit/binary.ts
+++ b/src/emit/binary.ts
@@ -27,6 +27,65 @@ export interface EmitResult {
   sourceMapEntries: SourceMapEntry[];
 }
 
+/**
+ * Collect WASM type indices referenced by a value type.
+ * Recursively descends into rec/sub wrappers via the caller (walkTypeDefRefs).
+ */
+function collectValTypeRefs(t: ValType, refs: Set<number>): void {
+  if (t.kind === "ref" || t.kind === "ref_null") refs.add(t.typeIdx);
+}
+
+/** Collect all type indices that a TypeDef references (excluding itself). */
+function collectTypeDefRefs(t: TypeDef, refs: Set<number>): void {
+  switch (t.kind) {
+    case "func":
+      for (const p of t.params) collectValTypeRefs(p, refs);
+      for (const r of t.results) collectValTypeRefs(r, refs);
+      break;
+    case "struct":
+      if (t.superTypeIdx !== undefined && t.superTypeIdx >= 0) refs.add(t.superTypeIdx);
+      for (const f of t.fields) collectValTypeRefs(f.type, refs);
+      break;
+    case "array":
+      collectValTypeRefs(t.element, refs);
+      break;
+    case "rec":
+      for (const inner of t.types) collectTypeDefRefs(inner, refs);
+      break;
+    case "sub":
+      if (t.superType !== null) refs.add(t.superType);
+      collectTypeDefRefs(t.type, refs);
+      break;
+  }
+}
+
+/**
+ * Compute rec-group boundaries for the type section. Each returned [start, end]
+ * (inclusive) tuple identifies a contiguous run of type definitions that must
+ * be encoded inside a single WasmGC rec group so that forward references between
+ * them validate. Singleton groups (start === end) are emitted without a rec
+ * wrapper, preserving canonical type identity for non-recursive entries.
+ */
+export function computeRecGroups(types: TypeDef[]): Array<[number, number]> {
+  const groups: Array<[number, number]> = [];
+  let i = 0;
+  while (i < types.length) {
+    let end = i;
+    let scan = i;
+    while (scan <= end) {
+      const refs = new Set<number>();
+      collectTypeDefRefs(types[scan]!, refs);
+      for (const r of refs) {
+        if (r > end && r < types.length) end = r;
+      }
+      scan++;
+    }
+    groups.push([i, end]);
+    i = end + 1;
+  }
+  return groups;
+}
+
 /** Emit a complete Wasm binary from an IR module */
 export function emitBinary(mod: WasmModule): Uint8Array {
   return emitBinaryWithSourceMap(mod).binary;
@@ -45,8 +104,27 @@ export function emitBinaryWithSourceMap(mod: WasmModule): EmitResult {
 
   // Type section
   if (mod.types.length > 0) {
+    // Compute rec-group boundaries: any type with a forward reference (typeIdx > self)
+    // must share a rec group with the referenced types so that WasmGC validation
+    // accepts the cross-type reference. Without this, a class struct registered
+    // before its dependent (vec/array) field types — e.g. `class C { rows: string[][] }`
+    // where the `__arr_ref_1`/`__vec_ref_1` types are appended after the class
+    // placeholder — fails with "Type index N is out of bounds" because each
+    // singleton type can only reference earlier types or itself. (#1293)
+    const recGroups = computeRecGroups(mod.types);
     enc.section(SECTION.type, (s) => {
-      s.vector(mod.types, (t, e) => encodeTypeDef(t, e));
+      s.u32(recGroups.length);
+      for (const [start, end] of recGroups) {
+        if (start === end) {
+          encodeTypeDef(mod.types[start]!, s);
+        } else {
+          s.byte(TYPE.rec);
+          s.u32(end - start + 1);
+          for (let i = start; i <= end; i++) {
+            encodeTypeDef(mod.types[i]!, s);
+          }
+        }
+      }
     });
   }
 

--- a/tests/issue-1293.test.ts
+++ b/tests/issue-1293.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1293 — string[][] (array-of-arrays) WasmGC type support
+//
+// Currently the compiler handles `string[]` (array of externrefs) but not
+// `string[][]`. This test checks the minimal repro for nested array typing.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface RunResult {
+  exports: Record<string, Function>;
+}
+
+async function run(src: string): Promise<RunResult> {
+  const result = compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(result.imports as never, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as never);
+  if (typeof (importResult as { setExports?: Function }).setExports === "function") {
+    (importResult as { setExports: Function }).setExports(inst.instance.exports);
+  }
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+describe("#1293 string[][] array-of-arrays type support", () => {
+  it("compiles and indexes a nested string array literal", async () => {
+    const { exports } = await run(`
+      export function test(): string {
+        const arr: string[][] = [["a", "b"], ["c"]];
+        return arr[0][1];
+      }
+    `);
+    expect(exports.test!()).toBe("b");
+  });
+
+  it("compiles and indexes the second row first column", async () => {
+    const { exports } = await run(`
+      export function test(): string {
+        const arr: string[][] = [["a", "b"], ["c"]];
+        return arr[1][0];
+      }
+    `);
+    expect(exports.test!()).toBe("c");
+  });
+
+  it("supports string[][] as a class field with nested access", async () => {
+    const { exports } = await run(`
+      class Holder {
+        rows: string[][] = [];
+      }
+      export function test(): string {
+        const h = new Holder();
+        h.rows = [["x", "y"], ["z"]];
+        return h.rows[0][1];
+      }
+    `);
+    expect(exports.test!()).toBe("y");
+  });
+
+  it("supports number[][] (matrix) as a regression check", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const m: number[][] = [[1, 2, 3], [4, 5, 6]];
+        return m[1][2];
+      }
+    `);
+    expect(exports.test!()).toBe(6);
+  });
+
+  it("returns the correct length of an outer string[][]", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const arr: string[][] = [["a", "b"], ["c"], ["d", "e", "f"]];
+        return arr.length;
+      }
+    `);
+    expect(exports.test!()).toBe(3);
+  });
+
+  it("returns the correct length of inner row", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const arr: string[][] = [["a", "b"], ["c"], ["d", "e", "f"]];
+        return arr[2].length;
+      }
+    `);
+    expect(exports.test!()).toBe(3);
+  });
+});

--- a/tests/stress/hono-tier4.test.ts
+++ b/tests/stress/hono-tier4.test.ts
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1293 — Hono Tier 4 stress test: recursive TrieRouter with class-typed
+// `{ [seg: string]: Node }` children PLUS a real `string[][]` field on
+// the Node class for storing the registered routes' raw segment arrays.
+//
+// Tier 3 (`tests/stress/hono-tier3.test.ts`) covered the recursive
+// trie + per-segment routing but had to work around `string[][]` typing
+// (the Tier 2d workaround packed segments into a single delimiter-joined
+// string and split at lookup time). With #1293 fixed, Tier 4 lifts that
+// workaround: the Node class now carries `segments: string[][]` directly.
+//
+// This Tier additionally validates:
+//
+//   - `string[][]` field on a class compiles, instantiates, and indexes
+//   - Nested-array access via `node.segments[i][j]` works through a
+//     class method (i.e. on a struct-stored ref-typed array of arrays)
+//   - All 11 Tier-3 routes still resolve correctly with the new field
+//     in place — the addition of a `string[][]` field next to existing
+//     class-typed `{ [seg: string]: Node }` children doesn't disturb
+//     either feature
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../../src/index.js";
+import { buildImports } from "../../src/runtime.js";
+
+interface RunResult {
+  exports: Record<string, Function>;
+}
+
+async function run(src: string): Promise<RunResult> {
+  const result = compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(result.imports as never, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as never);
+  if (typeof (importResult as { setExports?: Function }).setExports === "function") {
+    (importResult as { setExports: Function }).setExports(inst.instance.exports);
+  }
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+// Reusable `class Node + class TrieRouter` source. Tier 4 differs from
+// Tier 3 by adding `segments: string[][]` to Node, populated by
+// `TrieRouter.add` at the root, and exposed via two getter methods that
+// exercise nested-array access.
+const ROUTER_SRC = `
+function split(path: string): string[] {
+  if (path.length === 0 || path === "/") return [];
+  let p = path;
+  if (p.charAt(0) === "/") p = p.substring(1);
+  if (p.charAt(p.length - 1) === "/") p = p.substring(0, p.length - 1);
+  return p.split("/");
+}
+
+class Node {
+  children: { [seg: string]: Node } = {};
+  paramName: string = "";
+  paramChild: Node | null = null;
+  wildcardId: number = 0;
+  handlerId: number = 0;
+
+  // Tier 4 — string[][] field. Each entry is one registered route's
+  // split segments. Populated by TrieRouter.add at the root node.
+  segments: string[][] = [];
+
+  insert(segments: string[], at: number, handlerId: number): void {
+    if (at === segments.length) {
+      this.handlerId = handlerId;
+      return;
+    }
+    const head = segments[at];
+    if (head === "*") {
+      this.wildcardId = handlerId;
+      return;
+    }
+    if (head.charAt(0) === ":") {
+      if (this.paramChild == null) {
+        this.paramChild = new Node();
+        this.paramName = head.substring(1);
+      }
+      this.paramChild.insert(segments, at + 1, handlerId);
+      return;
+    }
+    if (this.children[head] == null) {
+      this.children[head] = new Node();
+    }
+    this.children[head].insert(segments, at + 1, handlerId);
+  }
+
+  match(segments: string[], at: number): number {
+    if (at === segments.length) {
+      if (this.handlerId !== 0) return this.handlerId;
+      if (this.wildcardId !== 0) return this.wildcardId;
+      return 0;
+    }
+    const seg = segments[at];
+
+    const c = this.children[seg];
+    if (c != null) {
+      const r = c.match(segments, at + 1);
+      if (r !== 0) return r;
+    }
+
+    if (this.paramChild != null) {
+      const r = this.paramChild.match(segments, at + 1);
+      if (r !== 0) return r;
+    }
+
+    if (this.wildcardId !== 0) return this.wildcardId;
+    return 0;
+  }
+
+  // Tier 4 helpers — exercise nested access on the string[][] field
+  segmentCount(): number { return this.segments.length; }
+  routeSegmentCount(routeIdx: number): number { return this.segments[routeIdx].length; }
+  segmentAt(routeIdx: number, segIdx: number): string { return this.segments[routeIdx][segIdx]; }
+}
+
+class TrieRouter {
+  root: Node = new Node();
+
+  add(path: string, handlerId: number): void {
+    const segs = split(path);
+    // Tier 4 — store the raw segment array on the root Node. This
+    // exercises pushing a string[] into a string[][] field.
+    this.root.segments.push(segs);
+    this.root.insert(segs, 0, handlerId);
+  }
+
+  match(path: string): number {
+    const segs = split(path);
+    return this.root.match(segs, 0);
+  }
+
+  // Forwarders so tests can read root.segments without exposing the
+  // Node directly (return-typed-as-Node would round-trip through
+  // externref and the test would have to cast back).
+  routeCount(): number { return this.root.segmentCount(); }
+  routeLen(routeIdx: number): number { return this.root.routeSegmentCount(routeIdx); }
+  routeSeg(routeIdx: number, segIdx: number): string {
+    return this.root.segmentAt(routeIdx, segIdx);
+  }
+}
+
+function buildRouter(): TrieRouter {
+  const r = new TrieRouter();
+  r.add("/", 1);
+  r.add("/users", 2);
+  r.add("/users/:id", 3);
+  r.add("/users/:id/posts", 4);
+  r.add("/posts/:id/comments/:cid", 5);
+  r.add("/static/foo/bar", 6);
+  r.add("/static/foo/baz", 7);
+  r.add("/api/*", 8);
+  r.add("/health", 9);
+  r.add("/about", 10);
+  r.add("/contact/:name", 11);
+  return r;
+}
+`;
+
+describe("#1293 Hono Tier 4 — recursive TrieRouter + string[][] segments field", () => {
+  /**
+   * Tier 4a — `segments: string[][]` field on the Node compiles and
+   * stores all 11 registered routes. The outer length must match the
+   * registered route count.
+   */
+  it("Tier 4a — root.segments.length tracks all registered routes", async () => {
+    const { exports } = await run(`
+      ${ROUTER_SRC}
+      export function test(): number { return buildRouter().routeCount(); }
+    `);
+    expect(exports.test!()).toBe(11);
+  });
+
+  /**
+   * Tier 4b — inner length per registered route matches `split(path)`.
+   * `/` → 0 segments, `/users` → 1, `/users/:id` → 2, etc. This walks
+   * each row of the string[][] and verifies the inner string[] length.
+   */
+  it("Tier 4b — root.segments[i].length matches each route's split count", async () => {
+    const { exports } = await run(`
+      ${ROUTER_SRC}
+      export function lenAt(i: number): number { return buildRouter().routeLen(i); }
+    `);
+    expect(exports.lenAt!(0)).toBe(0); // "/" → []
+    expect(exports.lenAt!(1)).toBe(1); // "/users" → ["users"]
+    expect(exports.lenAt!(2)).toBe(2); // "/users/:id" → ["users", ":id"]
+    expect(exports.lenAt!(3)).toBe(3); // "/users/:id/posts"
+    expect(exports.lenAt!(4)).toBe(4); // "/posts/:id/comments/:cid"
+    expect(exports.lenAt!(5)).toBe(3); // "/static/foo/bar"
+    expect(exports.lenAt!(7)).toBe(2); // "/api/*"
+    expect(exports.lenAt!(10)).toBe(2); // "/contact/:name"
+  });
+
+  /**
+   * Tier 4c — nested string[][] indexing works through a class method.
+   * `node.segments[i][j]` must round-trip the original raw segment
+   * strings registered via `r.add(...)`.
+   */
+  it("Tier 4c — nested access root.segments[i][j] returns registered segments", async () => {
+    const { exports } = await run(`
+      ${ROUTER_SRC}
+      export function segAt(i: number, j: number): string {
+        return buildRouter().routeSeg(i, j);
+      }
+    `);
+    expect(exports.segAt!(1, 0)).toBe("users"); // "/users"[0]
+    expect(exports.segAt!(2, 0)).toBe("users"); // "/users/:id"[0]
+    expect(exports.segAt!(2, 1)).toBe(":id"); // "/users/:id"[1]
+    expect(exports.segAt!(4, 0)).toBe("posts"); // "/posts/:id/comments/:cid"[0]
+    expect(exports.segAt!(4, 3)).toBe(":cid"); // "/posts/:id/comments/:cid"[3]
+    expect(exports.segAt!(5, 2)).toBe("bar"); // "/static/foo/bar"[2]
+    expect(exports.segAt!(7, 1)).toBe("*"); // "/api/*"[1]
+  });
+
+  /**
+   * Tier 4d — adding the `string[][]` field to Node doesn't break
+   * any existing routing behavior. All 11 Tier-3 routes plus 3 known
+   * misses still resolve. Acceptance criterion 2 in the issue file.
+   */
+  it("Tier 4d — 11 routes registered, all match, 3 misses return 0", async () => {
+    const { exports } = await run(`
+      ${ROUTER_SRC}
+      export function test(): number {
+        const r = buildRouter();
+        let ok = 0;
+        if (r.match("/") === 1) ok++;
+        if (r.match("/users") === 2) ok++;
+        if (r.match("/users/42") === 3) ok++;
+        if (r.match("/users/42/posts") === 4) ok++;
+        if (r.match("/posts/9/comments/8") === 5) ok++;
+        if (r.match("/static/foo/bar") === 6) ok++;
+        if (r.match("/static/foo/baz") === 7) ok++;
+        if (r.match("/api/any") === 8) ok++;
+        if (r.match("/health") === 9) ok++;
+        if (r.match("/about") === 10) ok++;
+        if (r.match("/contact/alice") === 11) ok++;
+        if (r.match("/nope") === 0) ok++;
+        if (r.match("/users/42/extra") === 0) ok++;
+        if (r.match("/static/foo/qux") === 0) ok++;
+        return ok;
+      }
+    `);
+    expect(exports.test!()).toBe(14);
+  });
+
+  /**
+   * Tier 4e — wildcard + parametric routing both still work. Spot-check
+   * the routes whose param/wildcard handling was the main contract of
+   * Tier 3, now that the Node carries an extra ref-typed field.
+   */
+  it("Tier 4e — parametric + wildcard routes still resolve with new field", async () => {
+    const { exports } = await run(`
+      ${ROUTER_SRC}
+      export function p(): number { return buildRouter().match("/contact/alice"); }
+      export function w(): number { return buildRouter().match("/api/v1/anything"); }
+      export function np(): number { return buildRouter().match("/posts/9/comments/8"); }
+    `);
+    expect(exports.p!()).toBe(11);
+    expect(exports.w!()).toBe(8);
+    expect(exports.np!()).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: `class Holder { rows: string[][] }` (and similar class fields whose type registers new dependent types AFTER the class struct's own placeholder slot) failed with `WebAssembly.instantiate(): Type index N is out of bounds @+30`. Root cause: each type was encoded as its own implicit rec group of 1, so the WasmGC validator rejects forward references between singleton-rec types.
- **Fix**: Backend-only change in `src/emit/binary.ts`. At type-section emit time, automatically detect forward references and group consecutive types into a single WasmGC rec group when needed. Singleton groups (no forward refs) are still encoded without a rec wrapper, preserving canonical type identity for the common case. No codegen / IR changes required.
- **Tier 4 stress test**: New `tests/stress/hono-tier4.test.ts` adds a real `segments: string[][]` field to the recursive trie-router Node, replacing the Tier 2/3 packed-string workaround. All 11-route routing assertions still pass.

## Files changed

- `src/emit/binary.ts` — `computeRecGroups` helper + rec-group-aware type-section emit
- `tests/issue-1293.test.ts` — minimal repro (string[][], number[][], class field, length)
- `tests/stress/hono-tier4.test.ts` — Hono Tier 4: trie-router Node with `segments: string[][]`
- `plan/issues/sprints/48/1293-…md` — implementation notes + test results

## Test plan

- [x] `npm test -- tests/issue-1293.test.ts` — 6/6
- [x] `npm test -- tests/stress/hono-tier4.test.ts` — 5/5
- [x] `npm test -- tests/stress/hono-tier{1,2,3}.test.ts` — 14/14 (no regression)
- [x] Spot-checked self-referencing class (`ListNode { next: ListNode | null }`) and mixed (`TreeNode { children: TreeNode[]; paths: string[][] }`) — both work
- [x] CI test262 conformance (await result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)