### PR TITLE
fix(#1295): rethrow WebAssembly.Exception in compiler.ts + restart fork on restoreBuiltins failure

### DIFF
--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -602,6 +602,20 @@ function restoreBuiltins() {
     }
   }
 
+  // Validate restore — if any method is still not the original, the descriptor
+  // is non-configurable and the fork is poisoned. Restart so the next test
+  // gets a clean environment. (#1295)
+  for (const { obj, values } of _methodOrig) {
+    for (const [key, orig] of values) {
+      if (obj[key] !== orig) {
+        console.error(
+          `[unified-worker pid=${process.pid}] FATAL: prototype method ${String(key)} not restored (non-configurable poison) — exiting for restart (#1295)`,
+        );
+        process.exit(1);
+      }
+    }
+  }
+
   // Restore static/namespace methods on constructors.
   for (const { obj, values } of _staticOrig) {
     for (const [key, orig, origDesc] of values) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -374,6 +374,12 @@ export function compileSource(
       }
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       ast.sourceFile,
@@ -433,6 +439,12 @@ export function compileSource(
       binary = emitBinary(mod);
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       ast.sourceFile,
@@ -647,6 +659,12 @@ export function compileMultiSource(
       }
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       multiAst.entryFile,
@@ -698,6 +716,12 @@ export function compileMultiSource(
       binary = emitBinary(mod);
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       multiAst.entryFile,
@@ -878,6 +902,12 @@ export function compileFilesSource(entryPath: string, options: CompileOptions = 
       }
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       multiAst.entryFile,
@@ -923,6 +953,12 @@ export function compileFilesSource(entryPath: string, options: CompileOptions = 
       binary = emitBinary(mod);
     }
   } catch (e) {
+    if (
+      typeof WebAssembly !== "undefined" &&
+      (WebAssembly as unknown as { Exception?: Function }).Exception &&
+      e instanceof (WebAssembly as unknown as { Exception: Function }).Exception
+    )
+      throw e;
     pushSourceAnchoredDiagnostic(
       errors,
       multiAst.entryFile,


### PR DESCRIPTION
## Summary

Eliminates the residual ~568 `[object WebAssembly.Exception]` compile_error rows in test262 left over after #1294. Two coordinated fixes:

1. **`src/compiler.ts`** — adds a re-throw guard at the top of all 6 codegen / binary-emit catch blocks. `WebAssembly.Exception` is not `instanceof Error`, so the previous code stringified it as `"[object WebAssembly.Exception]"` and returned a bad diagnostic. Re-throwing lets it propagate to the worker's outer catch (#1294), which sends `fail` and exits for fork restart.

2. **`scripts/test262-worker.mjs`** — after the `_methodOrig` restore loop in `restoreBuiltins()`, adds a validation pass: if any method is still not its original (non-configurable poison), `process.exit(1)` so the worker pool spawns a clean fork before the next test's compile runs.

## Notes

- TypeScript's `lib.dom` doesn't include `WebAssembly.Exception`, so the guard accesses it via a narrow cast: `(WebAssembly as unknown as { Exception?: Function }).Exception`. The `typeof` and existence checks keep this safe across runtimes that don't expose the API.
- 6 catch blocks were guarded (the spec called out 4; the file has 6 — single-file codegen/binary-emit + 2 multi-file paths × {codegen, binary-emit}).
- Local smoke test: `compileSource('export function test(): number { return 42; }')` still emits a 110-byte binary, no errors.
- The pre-existing failure in `tests/equivalence/optional-direct-closure-call.test.ts` also fails on `origin/main`, so it is not a regression introduced here.

## Test plan

- [x] Type-check passes (`tsc --noEmit -p tsconfig.json`)
- [x] Compiler still emits binaries for normal sources
- [x] CI test262 sharded: confirms `compile_error: [object WebAssembly.Exception]` cluster drops to ~0 and reclassifies as `fail`/`pass`
- [x] No regression in equivalence suite (sample run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)