### PR TITLE
feat(#1292): lodash Tier 2 stress test — memoize, flow, partial, negate

### DIFF
--- a/plan/issues/sprints/48/1292-lodash-tier2-stress-test.md
+++ b/plan/issues/sprints/48/1292-lodash-tier2-stress-test.md
@@ -2,7 +2,7 @@
 id: 1292
 sprint: 48
 title: "lodash Tier 2 stress test — memoize, flow, partial application"
-status: ready
+status: in-progress
 created: 2026-05-03
 updated: 2026-05-03
 priority: medium
@@ -66,3 +66,75 @@ If any tier fails at compile or instantiate, mark with `it.skip` and an issue re
 - `_.memoize` uses `Map` internally (not `WeakMap`). If `Map` iteration fails,
   document the gap.
 - `_.flow` with a typed `fn[]` array exercises IR Array methods (#1233).
+
+## Test Results (2026-05-03)
+
+`tests/stress/lodash-tier2.test.ts` — 5 cases total, 2 pass + 3 skip
+(stress-test scope only — gaps documented as follow-up issues, not fixed
+inline).
+
+### Tier 2a — memoize ✓ (compile path), ⏳ (instantiate)
+
+- ✓ `compileProject` succeeds, binary validates
+- ✓ Wasm exports `memoize` and `default` as functions
+- ✓ Every Wasm import is satisfied by `buildImports` (none missing)
+- ⏳ Instantiation throws `WebAssembly.Exception` from start function —
+  same gap as Tier 1's clamp/add (lodash transitive feature-detection
+  init throws). Tracked under #1295 on the start-function side.
+
+### Tier 2b — flow ✗ (Wasm validation fails) → **#1302**
+
+```
+Compiling function #945:"__closure_837" failed:
+Invalid global index: 266 @+117088
+```
+
+`compileProject` succeeds, but `new WebAssembly.Module(...)` rejects
+because `__closure_837` references a global slot past the declared
+range. Likely closure-env / global-index allocation bug for modules
+with hundreds of closures. Filed as #1302.
+
+### Tier 2c — partial ✗ (Wasm validation fails) → **#1303**
+
+```
+Compiling function #94:"mergeData" failed:
+f64.trunc[0] expected type f64, found global.get of type externref @+36700
+```
+
+Codegen emits `f64.trunc` on an externref operand without unboxing.
+`coerceType` (in `type-coercion.ts`) is missing on this code path.
+Filed as #1303.
+
+### Tier 2d — negate ✓ (compile + instantiate), ⏳ (call from JS) → **#1304**
+
+- ✓ `compileProject` succeeds, validates, instantiates (no start-function
+  exception — negate has no transitive feature-detection deps)
+- ✓ Exports `negate` and `default` as functions
+- ⏳ Calling `negate(jsPredicate)` throws lodash's own `TypeError:
+  Expected a function`: the compiled `typeof predicate != 'function'`
+  guard receives an externref-wrapped JS callable and classifies it
+  as `"object"`, not `"function"`. Filed as #1304 (related to existing
+  #1275 typeof-guard-narrowing).
+
+### Stress-test ladder progression
+
+| Tier | Compile | Validate | Imports | Instantiate | Callable | Status |
+|------|---------|----------|---------|-------------|----------|--------|
+| 1 identity | ✓ | ✓ | ✓ | ✓ | ✓ | full pass |
+| 1 clamp | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
+| 1 add | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
+| 2 memoize | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
+| 2 flow | ✓ | ✗ #1302 | — | — | — | validation gap |
+| 2 partial | ✓ | ✗ #1303 | — | — | — | validation gap |
+| 2 negate | ✓ | ✓ | ✓ | ✓ | ✗ #1304 | call-surface gap |
+
+negate is the furthest any lodash module has progressed in the ladder.
+
+### Filed follow-up issues (stress-test scope — not fixed inline)
+
+- **#1302** — flow.js: closure references invalid global index past
+  declared range
+- **#1303** — partial.js: f64.trunc emitted on externref operand without
+  coerceType
+- **#1304** — typeof externref-wrapped JS function returns `"object"`
+  instead of `"function"`

--- a/plan/issues/sprints/49/1302-flow-closure-invalid-global-index.md
+++ b/plan/issues/sprints/49/1302-flow-closure-invalid-global-index.md
@@ -1,0 +1,81 @@
+---
+id: 1302
+sprint: 49
+title: "Wasm validation: closure references invalid global index when compiling lodash flow.js"
+status: ready
+created: 2026-05-03
+updated: 2026-05-03
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: closures, globals
+goal: npm-library-support
+depends_on: []
+related: [1292, 1295]
+---
+# #1302 — Wasm validation: closure references invalid global index past declared range
+
+## Background
+
+Surfaced in #1292 (lodash Tier 2 stress test) compiling
+`node_modules/lodash-es/flow.js`:
+
+```
+WebAssembly.Module(): Compiling function #945:"__closure_837" failed:
+Invalid global index: 266 @+117088
+```
+
+`compileProject` returns `success: true` and emits a binary, but
+`new WebAssembly.Module(binary)` throws synchronously because
+`__closure_837` issues a `global.get 266` referring to a global slot
+that is past the declared global range (declared global count is
+< 266).
+
+## Hypothesis
+
+`flow.js` (and its transitive dep graph in lodash-es) creates ~837+
+closures. The compiler allocates a fresh global slot per closure env
+or per externref capture. Likely causes:
+
+1. The global table size is computed before all closures are emitted;
+   late-emitted closures get global indices past the declared limit.
+2. A closure-environment cache is keyed by source location and the
+   second hit re-uses an index that was reset between compilation
+   passes, but the corresponding global declaration is skipped.
+3. `addUnionImports` (or sibling late-import passes) shifts function
+   indices and was supposed to also shift global indices but missed
+   `__closure_*` references.
+
+## Reproduction
+
+```bash
+npx tsx -e "
+import { compileProject } from './src/index.ts';
+const r = compileProject('node_modules/lodash-es/flow.js', {allowJs:true});
+console.log('compile success:', r.success);
+new WebAssembly.Module(r.binary); // throws
+"
+```
+
+## Fix scope
+
+- Audit global-index allocation in closure env emission
+- Ensure declared-global count >= max referenced global index
+- Verify late shifts (addUnionImports etc.) propagate to closure body
+  global references
+
+## Files
+
+- `src/codegen/index.ts` — closure env + global allocation
+- `src/codegen/expressions.ts` — closure body emission
+
+## Acceptance criteria
+
+1. `compileProject('node_modules/lodash-es/flow.js')` produces a binary
+   that passes `new WebAssembly.Module(...)` validation
+2. No regression in #1295 / Tier 1 / Tier 2 stress tests
+3. Test262 net delta ≥ 0
+4. `tests/stress/lodash-tier2.test.ts` Tier 2b case can flip from `it.skip`
+   to `it`

--- a/plan/issues/sprints/49/1303-partial-mergedata-f64-trunc-externref.md
+++ b/plan/issues/sprints/49/1303-partial-mergedata-f64-trunc-externref.md
@@ -1,0 +1,83 @@
+---
+id: 1303
+sprint: 49
+title: "Wasm validation: f64.trunc emitted on externref operand when compiling lodash partial.js"
+status: ready
+created: 2026-05-03
+updated: 2026-05-03
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: type-coercion, externref
+goal: npm-library-support
+depends_on: []
+related: [1292, 1180]
+---
+# #1303 — Wasm validation: `f64.trunc` operand is `externref`, not `f64`
+
+## Background
+
+Surfaced in #1292 (lodash Tier 2 stress test) compiling
+`node_modules/lodash-es/partial.js`:
+
+```
+WebAssembly.Module(): Compiling function #94:"mergeData" failed:
+f64.trunc[0] expected type f64, found global.get of type externref @+36700
+```
+
+`mergeData` (a lodash internal called from partial's HOF) emits an
+`f64.trunc` whose argument is a `global.get` of an externref-typed
+global. The codegen is missing an `extern.convert_any` + unbox to f64
+before the trunc.
+
+## Hypothesis
+
+The arithmetic-on-externref code path likely:
+
+1. Reads a captured numeric variable that was promoted to externref
+   storage (because it crossed a closure boundary or got widened to
+   union type)
+2. Performs an integer truncation (`Math.floor` / `| 0` / spread-arg
+   length probably) that the compiler maps to `f64.trunc`
+3. Forgets to emit the externref→f64 unbox between the load and the
+   trunc
+
+`type-coercion.ts` has the `coerceType` helper for these conversions
+(externref → f64 via `__unbox_number` import). It's not being invoked
+on this code path.
+
+## Reproduction
+
+```bash
+npx tsx -e "
+import { compileProject } from './src/index.ts';
+const r = compileProject('node_modules/lodash-es/partial.js', {allowJs:true});
+console.log('compile success:', r.success);
+new WebAssembly.Module(r.binary); // throws
+"
+```
+
+## Fix scope
+
+- Identify the codegen path for `mergeData`'s `f64.trunc` emission
+- Insert `coerceType(target=f64)` before the trunc when the operand is
+  externref
+- Verify the same gap doesn't exist for sibling integer truncation ops
+  (`f64.nearest`, `f64.floor`, `f64.ceil`, `i32.trunc_sat_*`)
+
+## Files
+
+- `src/codegen/expressions.ts` — `f64.trunc` emission site
+- `src/codegen/type-coercion.ts` — `coerceType` helper
+
+## Acceptance criteria
+
+1. `compileProject('node_modules/lodash-es/partial.js')` produces a
+   binary that passes `new WebAssembly.Module(...)` validation
+2. Sibling truncation ops (`Math.floor`, `Math.ceil`, etc.) on externref
+   operands also coerce correctly — add a focused unit test
+3. No regression in #1180 (env-unbox-number rules) or Tier 1/2 stress
+4. `tests/stress/lodash-tier2.test.ts` Tier 2c case can flip from
+   `it.skip` to `it`

--- a/plan/issues/sprints/49/1304-typeof-externref-function-classification.md
+++ b/plan/issues/sprints/49/1304-typeof-externref-function-classification.md
@@ -1,0 +1,116 @@
+---
+id: 1304
+sprint: 49
+title: "typeof on externref-wrapped JS function returns 'object' instead of 'function'"
+status: ready
+created: 2026-05-03
+updated: 2026-05-03
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: typeof, externref, functions
+goal: npm-library-support
+depends_on: []
+related: [1292, 1275, 1248]
+---
+# #1304 — `typeof predicate != 'function'` mis-classifies externref-wrapped JS callable
+
+## Background
+
+Surfaced in #1292 (lodash Tier 2 stress test) calling the compiled
+`negate(predicate)` from JS:
+
+```
+TypeError: Expected a function
+  at member (src/runtime.ts:1587:18)
+  at fn (src/runtime.ts:4243:27)
+  at negate (wasm://wasm/8147e4ae:wasm-function[10]:0x53e)
+```
+
+lodash's `negate.js` does an explicit guard:
+
+```js
+function negate(predicate) {
+  if (typeof predicate != 'function') {
+    throw new TypeError(FUNC_ERROR_TEXT);
+  }
+  // ...
+}
+```
+
+When called from JS as `exports.negate(jsFn)`, the JS function arrives
+in Wasm as an externref. The compiled `typeof` operation classifies
+that externref as `"object"` rather than `"function"`, so the guard
+fires and lodash's TypeError is thrown.
+
+## Hypothesis
+
+`runtime.ts` `typeof_extern` (or the inlined codegen for `typeof x`) has
+a branch table for externref classification. JavaScript's spec for
+`typeof fn` returns `"function"` only when the value's
+`[[IsCallable]]` slot is true. The current implementation likely:
+
+1. Checks for `null` → `"object"` ✓
+2. Checks for boxed-number / boxed-string / boxed-bool → those types
+3. Falls back to `"object"` for everything else (including callables)
+
+The fix is to add a callable check (likely via host import that does
+`typeof x === 'function'` on the JS side and returns a sentinel) before
+the fallback.
+
+## Reproduction
+
+```bash
+npx tsx -e "
+import { compileProject } from './src/index.ts';
+import { buildImports } from './src/runtime.ts';
+const r = compileProject('node_modules/lodash-es/negate.js', {allowJs:true});
+const imps = buildImports(r.imports, undefined, r.stringPool);
+const inst = await WebAssembly.instantiate(r.binary, imps);
+try {
+  const negated = inst.instance.exports.negate((n) => n % 2 === 0);
+  console.log('OK:', negated);
+} catch (e) {
+  console.log('ERR:', e.message); // 'undefined' (Wasm Exception)
+  if (e instanceof WebAssembly.Exception) {
+    console.log('payload:', e.getArg(inst.instance.exports.__exn_tag, 0));
+    // → TypeError: Expected a function
+  }
+}
+"
+```
+
+## Fix scope
+
+- Audit `typeof_extern` (or inline codegen path) for the function
+  classification branch
+- Add a host import that returns `1` if the JS value is callable, `0`
+  otherwise; route that through the `typeof` codegen
+- Or: tag externref-wrapped functions at the WrapFn import site so the
+  classifier can read the tag without a host call
+
+## Files
+
+- `src/runtime.ts` — `typeof_extern` (around line 1587)
+- `src/codegen/expressions.ts` — `typeof x` emission for externref operand
+
+## Acceptance criteria
+
+1. `typeof jsFunctionAsExternref` returns `"function"` from compiled
+   Wasm
+2. lodash `negate(jsFn)` returns a callable closure that flips the
+   predicate's boolean
+3. `tests/stress/lodash-tier2.test.ts` Tier 2d-call case can flip from
+   `it.skip` to `it`
+4. No regression in #1275 (typeof guard narrowing) or #1248 (typeof
+   string guard)
+5. test262 net delta ≥ 0
+
+## Why this matters
+
+Almost every reasonable JS library does typeof guards on function
+arguments. Without correct externref→function classification, the JS
+host cannot pass a callback into Wasm — a hard limit on practical
+interop.

--- a/tests/stress/lodash-tier2.test.ts
+++ b/tests/stress/lodash-tier2.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1292 — lodash Tier 2 stress test: memoize, flow, partial, negate.
+//
+// Tier 1 (`tests/stress/lodash-tier1.test.ts`) covered identity / add / clamp
+// at the function-compilation level. Tier 2 lifts the floor to higher-order
+// patterns: memoize closes over a Map cache, flow composes an array of
+// functions via reduce, partial captures a leading argument, negate wraps a
+// predicate in a !-flipping closure.
+//
+// As with Tier 1, each tier is a probe — failing tiers document specific
+// compiler gaps as follow-up issues, marked with `it.skip` + issue refs,
+// rather than blocking the whole file.
+
+import { existsSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { compileProject } from "../../src/index.js";
+
+const lodashEsInstalled = existsSync("node_modules/lodash-es/memoize.js");
+const runIfInstalled = lodashEsInstalled ? it : it.skip;
+
+describe("#1292 lodash Tier 2 stress test — memoize, flow, partial, negate", () => {
+  /**
+   * Tier 2a — `memoize.js`: HOF that captures a `Map`-backed cache via
+   * closure. The compiled module passes Wasm validation, exports `memoize`
+   * + `default` as functions, and every Wasm import is satisfied by
+   * `buildImports`. Instantiation throws a `WebAssembly.Exception` from
+   * the start function — same pattern as Tier 1's `clamp` / `add`
+   * (lodash's transitive feature-detection deps run at module init and
+   * fail). Tracked under #1295 on the start-function side.
+   */
+  runIfInstalled(
+    "Tier 2a memoize — compiles, validates, all imports satisfied; start function throws (#1295)",
+    async () => {
+      const result = compileProject("node_modules/lodash-es/memoize.js", { allowJs: true });
+      expect(result.success).toBe(true);
+
+      const mod = new WebAssembly.Module(result.binary);
+      const exports = WebAssembly.Module.exports(mod);
+      const funcNames = exports.filter((e) => e.kind === "function").map((e) => e.name);
+      expect(funcNames).toContain("memoize");
+      expect(funcNames).toContain("default");
+
+      const buildImports = (await import("../../src/runtime.ts")).buildImports;
+      const imports = buildImports(result.imports, undefined, result.stringPool);
+      const wasmImports = WebAssembly.Module.imports(mod);
+      const missing = wasmImports.filter((w) => {
+        const m = (imports as Record<string, Record<string, unknown>>)[w.module];
+        return m === undefined || !(w.name in m);
+      });
+      expect(missing).toEqual([]);
+
+      let caught: unknown;
+      try {
+        await WebAssembly.instantiate(result.binary, imports);
+      } catch (e) {
+        caught = e;
+      }
+      // Same start-function gap as Tier 1's clamp/add. NOT a LinkError
+      // (proves "missing import" is not the cause).
+      expect(caught).toBeInstanceOf(WebAssembly.Exception);
+      expect(caught).not.toBeInstanceOf(WebAssembly.LinkError);
+    },
+  );
+
+  /**
+   * Tier 2b — `flow.js`: composes an array of functions via reduce. The
+   * compiled module fails Wasm VALIDATION (not instantiation) with:
+   *   "Compiling function #945:\"__closure_837\" failed:
+   *    Invalid global index: 266 @+117088"
+   * The compiler emits a closure that references a global index past the
+   * declared range. Probably a global-index allocation issue when many
+   * closures (lodash has hundreds in the transitive graph) compete for the
+   * same global table. Tracked as **#1302**.
+   */
+  it.skip("Tier 2b flow — closure references invalid global index, fails Wasm validation (#1302)", async () => {
+    const result = compileProject("node_modules/lodash-es/flow.js", { allowJs: true });
+    expect(result.success).toBe(true);
+    // Currently throws synchronously from `new WebAssembly.Module(...)`:
+    //   "Invalid global index: 266 @+117088"
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  /**
+   * Tier 2c — `partial.js`: partial application via closure capture. The
+   * compiled module fails Wasm VALIDATION with:
+   *   "Compiling function #94:\"mergeData\" failed:
+   *    f64.trunc[0] expected type f64, found global.get of type externref @+36700"
+   * The codegen for `mergeData` emits an `f64.trunc` whose operand is a
+   * global of type externref instead of f64 — likely a missing externref→f64
+   * unbox before a numeric op in the lodash internals. Tracked as **#1303**.
+   */
+  it.skip("Tier 2c partial — f64.trunc emitted on externref operand, fails Wasm validation (#1303)", async () => {
+    const result = compileProject("node_modules/lodash-es/partial.js", { allowJs: true });
+    expect(result.success).toBe(true);
+    // Currently throws:
+    //   "f64.trunc[0] expected type f64, found global.get of type externref"
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  /**
+   * Tier 2d — `negate.js`: returns a closure that wraps a predicate.
+   * Compiles, validates, instantiates, AND exports `negate` + `default`
+   * as callable functions. This is the furthest any lodash module has
+   * progressed in the stress-test ladder.
+   *
+   * The compile + instantiate path is fully exercised here (criterion
+   * passes). Calling `negate(jsFunction)` throws a `TypeError: Expected
+   * a function` because lodash's own `typeof predicate != 'function'`
+   * guard fires — the runtime returns `"object"` for an externref
+   * wrapping a JS function instead of `"function"`. That's a separate
+   * runtime/typeof gap tracked as **#1304** (related to existing #1275
+   * `typeof guard narrowing for any`). Skipped pending #1304.
+   */
+  runIfInstalled("Tier 2d negate — compiles, validates, instantiates, exports negate + default", async () => {
+    const result = compileProject("node_modules/lodash-es/negate.js", { allowJs: true });
+    expect(result.success).toBe(true);
+
+    const mod = new WebAssembly.Module(result.binary);
+    const funcNames = WebAssembly.Module.exports(mod)
+      .filter((e) => e.kind === "function")
+      .map((e) => e.name);
+    expect(funcNames).toContain("negate");
+    expect(funcNames).toContain("default");
+
+    const buildImports = (await import("../../src/runtime.ts")).buildImports;
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const wasmImports = WebAssembly.Module.imports(mod);
+    const missing = wasmImports.filter((w) => {
+      const m = (imports as Record<string, Record<string, unknown>>)[w.module];
+      return m === undefined || !(w.name in m);
+    });
+    expect(missing).toEqual([]);
+
+    // Instantiation succeeds — start function returns cleanly. negate
+    // has no transitive feature-detection deps that throw at init.
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    const exports = instance.exports as Record<string, Function>;
+    expect(typeof exports.negate).toBe("function");
+    expect(typeof exports.default).toBe("function");
+  });
+
+  /**
+   * Tier 2d-call — passing a JS predicate to negate currently throws
+   * because lodash's `typeof predicate != 'function'` guard fires:
+   * the runtime classifies an externref-wrapped JS function as
+   * `"object"`, not `"function"`. Tracked as **#1304**.
+   */
+  it.skip("Tier 2d negate(jsFn) — typeof externref returns wrong category (#1304)", async () => {
+    const result = compileProject("node_modules/lodash-es/negate.js", { allowJs: true });
+    const buildImports = (await import("../../src/runtime.ts")).buildImports;
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    const exports = instance.exports as Record<string, Function>;
+
+    const isEven = (n: number) => n % 2 === 0;
+    const negated = exports.negate(isEven);
+    expect(typeof negated).toBe("function");
+    expect((negated as (n: number) => boolean)(2)).toBe(false);
+    expect((negated as (n: number) => boolean)(3)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lifts the lodash stress-test ladder from Tier 1 (identity / add / clamp)
to higher-order patterns: `memoize` (Map-backed cache via closure),
`flow` (function composition over an array), `partial` (closure capture
of a leading argument), and `negate` (predicate flip). Per task scope:
**stress-test only** — gaps documented as follow-up issues, not fixed
inline.

5 cases — 2 pass + 3 skip:

### Passing

- **Tier 2a memoize** — `compileProject` succeeds, binary validates,
  exports `memoize`+`default` as functions, and every Wasm import is
  satisfied by `buildImports`. Instantiation throws
  `WebAssembly.Exception` from the start function — same gap as Tier 1's
  clamp/add (`#1295` territory). Asserts `Exception` (not `LinkError`)
  to keep "missing import" theory ruled out.
- **Tier 2d negate (compile path)** — compiles, validates, AND
  instantiates cleanly. negate has no transitive feature-detection deps
  that throw at init — **first lodash module to clear the start function**.
  Exports `negate`+`default` as callable functions.

### Skipped (gap → follow-up issue)

- **Tier 2b flow → #1302** — Wasm validation rejects:
  `Compiling function #945:"__closure_837" failed: Invalid global index: 266 @+117088`.
  Closure references a global slot past the declared range. Likely
  closure-env / global-index allocation bug for modules with hundreds
  of closures.
- **Tier 2c partial → #1303** — Wasm validation rejects:
  `Compiling function #94:"mergeData" failed: f64.trunc[0] expected type f64, found global.get of type externref @+36700`.
  `f64.trunc` operand is externref instead of f64 — missing
  `coerceType(target=f64)` before the trunc.
- **Tier 2d-call negate(jsFn) → #1304** — `typeof` on an externref-wrapped
  JS callable returns `"object"` instead of `"function"`. lodash's
  `typeof predicate != 'function'` guard fires and throws lodash's own
  `TypeError: Expected a function`. Related to existing `#1275`
  typeof-guard-narrowing.

### Stress-test ladder progression

| Tier | Compile | Validate | Imports | Instantiate | Callable | Status |
|------|---------|----------|---------|-------------|----------|--------|
| 1 identity | ✓ | ✓ | ✓ | ✓ | ✓ | full pass |
| 1 clamp | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
| 1 add | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
| 2 memoize | ✓ | ✓ | ✓ | ✗ #1295 | — | start-fn gap |
| 2 flow | ✓ | ✗ #1302 | — | — | — | validation gap |
| 2 partial | ✓ | ✗ #1303 | — | — | — | validation gap |
| 2 negate | ✓ | ✓ | ✓ | ✓ | ✗ #1304 | call-surface gap |

`negate` is the furthest any lodash module has progressed.

## Test plan

- [x] `npm test -- tests/stress/lodash-tier2.test.ts` — 2 pass / 3 skip
- [x] No `src/` changes; pure test + plan additions
- [x] Tier 1 lodash tests untouched (no regression risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)