### PR TITLE
fix(#1304): Function-typed params in static typeof folding

### DIFF
--- a/plan/issues/sprints/49/1304-typeof-externref-function-classification.md
+++ b/plan/issues/sprints/49/1304-typeof-externref-function-classification.md
@@ -2,7 +2,7 @@
 id: 1304
 sprint: 49
 title: "typeof on externref-wrapped JS function returns 'object' instead of 'function'"
-status: ready
+status: in-progress
 created: 2026-05-03
 updated: 2026-05-03
 priority: medium
@@ -114,3 +114,52 @@ Almost every reasonable JS library does typeof guards on function
 arguments. Without correct externref→function classification, the JS
 host cannot pass a callback into Wasm — a hard limit on practical
 interop.
+
+## Root cause (2026-05-03)
+
+The bug is NOT in the runtime `__typeof_function` host import — that
+function correctly returns `1` for callable JS values. The bug is at
+*compile time* in `staticTypeofForType`
+(`src/codegen/typeof-delete.ts`).
+
+When TypeScript compiles `lodash-es/negate.js`, it infers the type of
+the `predicate` parameter as the global `Function` interface (because
+the function body uses `predicate.call(this, ...)` and
+`predicate.apply(this, args)`). `staticTypeofForType` checks for the
+`String/Number/Boolean` wrapper symbol names but does NOT check for
+`Function` — so the type falls through to the externref/Object branch
+which returns `"object"`.
+
+The compiled `if (typeof predicate != 'function')` then folds at
+compile time:
+- `staticTypeof = "object"` (wrong)
+- `stringLiteral = "function"`
+- `matches = false` → `result = isNeq ? 1 : 0` = `1`
+
+The compiler emits `i32.const 1` for the if condition, so the
+`throw new TypeError(...)` runs unconditionally on every call.
+
+Fix: add a `Function` symbol check in the `Object` flag branch that
+returns `"function"` directly, mirroring the existing
+`String/Number/Boolean` wrapper logic.
+
+## Test Results
+
+`tests/issue-1304.test.ts` — 5/5 pass:
+- typeof === 'function' on a JS function passed as externref
+- typeof !== 'function' is false for a JS function
+- typeof === 'object' on a plain object
+- typeof === 'number' on a JS number
+- Function-typed param doesn't fold typeof guard to always-throw
+  (lodash negate idiom — captures the original repro)
+
+End-to-end with lodash:
+- `compileProject('lodash-es/negate.js', {allowJs:true})` previously
+  threw `TypeError: Expected a function` on every call. After fix,
+  `negate(jsFn)` returns the wrapped negated callable.
+
+Regression check: identical pass/fail counts to main on
+`tests/typeof-comparison.test.ts`, `tests/typeof-expression.test.ts`,
+`tests/typeof-member-expression.test.ts`, `tests/null-narrowing.test.ts`,
+`tests/union-narrowing.test.ts`. Hono Tier 1-5 + lodash Tier 1 stress
+tests: 35/35 active pass (4 unrelated skipped) — no regressions.

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -495,6 +495,14 @@ function staticTypeofForType(ctx: CodegenContext, tsType: ts.Type): string | nul
     if (sym && (sym.name === "String" || sym.name === "Number" || sym.name === "Boolean")) {
       return "object";
     }
+    // (#1304) Global `Function` interface — TS infers this for params used
+    // as `p.call(...)` / `p.apply(...)` etc. Without this branch the value
+    // falls into the generic "Object flag → object" path below and idiomatic
+    // guards like `if (typeof predicate != 'function')` const-fold to
+    // unconditional throws (lodash `negate`, `bind`, similar).
+    if (sym && sym.name === "Function") {
+      return "function";
+    }
   }
   // Check string before wasm type mapping (native strings map to ref)
   if (isStringType(tsType)) return "string";

--- a/tests/issue-1304.test.ts
+++ b/tests/issue-1304.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1304 — typeof on externref-wrapped JS function returns "object" instead
+// of "function". Surfaced in lodash Tier 2 calling negate(predicate) from JS.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface RunResult {
+  exports: Record<string, Function>;
+}
+
+async function run(src: string): Promise<RunResult> {
+  const result = compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(result.imports as never, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as never);
+  if (typeof (importResult as { setExports?: Function }).setExports === "function") {
+    (importResult as { setExports: Function }).setExports(inst.instance.exports);
+  }
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+describe("#1304 typeof on externref-wrapped function", () => {
+  /**
+   * Canonical repro: JS passes a function into Wasm, and the compiled
+   * `typeof` operation classifies that externref. lodash's `negate`
+   * does this exact `typeof predicate != 'function'` guard.
+   */
+  it("typeof === 'function' on a JS function passed as externref", async () => {
+    const { exports } = await run(`
+      export function checkFn(p: any): number {
+        if (typeof p === "function") return 1;
+        return 0;
+      }
+    `);
+    // pass a real JS function
+    expect(exports.checkFn!((n: number) => n + 1)).toBe(1);
+  });
+
+  /**
+   * Negated form — `typeof p != 'function'` should be FALSE for a JS
+   * function (matches the lodash idiom that triggered the bug).
+   */
+  it("typeof !== 'function' is false for a JS function", async () => {
+    const { exports } = await run(`
+      export function isNotFn(p: any): number {
+        return typeof p !== "function" ? 1 : 0;
+      }
+    `);
+    expect(exports.isNotFn!((n: number) => n + 1)).toBe(0);
+  });
+
+  /**
+   * Plain object should still classify as "object" — guard against
+   * over-broad fix.
+   */
+  it("typeof === 'object' on a plain object", async () => {
+    const { exports } = await run(`
+      export function checkObj(p: any): number {
+        if (typeof p === "object") return 1;
+        return 0;
+      }
+    `);
+    expect(exports.checkObj!({ a: 1 })).toBe(1);
+    expect(exports.checkObj!((x: number) => x)).toBe(0); // function is not "object"
+  });
+
+  /**
+   * Number should still classify as "number".
+   */
+  it("typeof === 'number' on a JS number", async () => {
+    const { exports } = await run(`
+      export function checkNum(p: any): number {
+        if (typeof p === "number") return 1;
+        return 0;
+      }
+    `);
+    expect(exports.checkNum!(42)).toBe(1);
+    expect(exports.checkNum!((x: number) => x)).toBe(0);
+  });
+
+  /**
+   * Reproduces the lodash `negate` constant-folding bug: TypeScript
+   * infers `predicate`'s type as the global `Function` interface (from
+   * usage like `predicate.call(this, ...)`). Before the fix,
+   * `staticTypeofForType` returned `"object"` for `Function`-typed
+   * values, so the guard `if (typeof predicate != 'function') throw ...`
+   * folded to an unconditional throw at compile time. The fix maps the
+   * `Function` symbol to `"function"` so the guard short-circuits the
+   * way idiomatic JS code expects.
+   */
+  it("Function-typed param doesn't fold typeof guard to always-throw (lodash negate idiom)", async () => {
+    const { exports } = await run(`
+      // Mirror lodash negate: param used as a callable, no annotation.
+      export function negate(predicate: Function): number {
+        if (typeof predicate !== "function") {
+          // Throwing would fire the start-function trap if folded incorrectly.
+          throw new TypeError("Expected a function");
+        }
+        return 42;
+      }
+    `);
+    // If the compile-time fold was wrong, this would throw at runtime
+    // (the WAT would have an i32.const 1 + throw before any runtime
+    // typeof check). Passing means the guard correctly classifies the
+    // JS function as "function".
+    expect(exports.negate!((n: number) => n + 1)).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: `staticTypeofForType` checked the Object-flag branch for `String/Number/Boolean` wrapper symbols but missed the global `Function` interface. When TypeScript inferred a parameter's type as `Function` (e.g. lodash `negate`'s `predicate` used as `predicate.call(this, ...)`), the lookup fell through to the externref/Object branch and returned `"object"` — folding `if (typeof predicate != 'function') throw …` to an unconditional `i32.const 1` + throw.
- **Fix**: Add a `Function` symbol check in `staticTypeofForType` (`src/codegen/typeof-delete.ts`) that returns `"function"` directly, mirroring the existing wrapper-symbol logic.
- **Repro fixed**: `compileProject('lodash-es/negate.js', {allowJs:true})` now successfully round-trips a JS callback through Wasm; previously every call threw `TypeError: Expected a function` from the start function.

## Files changed

- `src/codegen/typeof-delete.ts` — `Function` symbol → `"function"` (~8 lines)
- `tests/issue-1304.test.ts` — 5 cases (4 unit + 1 lodash-negate idiom regression)
- `plan/issues/sprints/49/1304-…md` — root cause + test results

## Test plan

- [x] `npm test -- tests/issue-1304.test.ts` — 5/5 pass
- [x] `npm test -- tests/typeof-comparison.test.ts tests/typeof-expression.test.ts tests/typeof-member-expression.test.ts tests/null-narrowing.test.ts tests/union-narrowing.test.ts` — same pass/fail counts as main
- [x] `npm test -- tests/stress/{lodash-tier1,hono-tier{1..5}}.test.ts` — 35/35 active
- [x] CI test262 conformance (await result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)