### PR TITLE
fix(#1303): IR codegen — coerce non-f64 operands to f64 before bitwise ops

### DIFF
--- a/plan/issues/sprints/49/1305-module-var-init-externref-leak.md
+++ b/plan/issues/sprints/49/1305-module-var-init-externref-leak.md
@@ -1,0 +1,122 @@
+---
+id: 1305
+sprint: 49
+title: "Module-level var init leaks externref into bitwise op codegen (legacy path)"
+status: ready
+created: 2026-05-03
+updated: 2026-05-03
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: type-inference, globals, bitwise-ops
+goal: npm-library-support
+depends_on: []
+related: [1303, 1292]
+---
+# #1305 — Module-level `var X = N` leaks externref into bitwise op codegen on the legacy path
+
+## Background
+
+While fixing #1303 (lodash `partial.js` `mergeData` failing with
+`f64.trunc[0] expected type f64, found global.get of type externref`),
+the IR-side defensive coercion in `src/ir/lower.ts` was insufficient
+because `mergeData` compiles via the **legacy codegen path**, not the
+IR path. The IR `coerceToF64ForBitwise` helper landed in #1303 but the
+legacy `compileBitwiseBinaryOp` (`src/codegen/binary-ops.ts:2008`) and
+the wider `compileBinaryExpression` flow still emit broken Wasm.
+
+## Hypothesis
+
+The legacy codegen has an externref → f64 path at
+`binary-ops.ts:1295-1310` that calls `__unbox_number` before
+`compileNumericBinaryOp`. It's gated on `leftType.kind === "externref" || rightType.kind === "externref"`. For lodash's
+`var WRAP_BIND_FLAG = 1` reference, the gate fails to fire because:
+
+- TypeScript types `var X = 1` as `number` (literal-init inference)
+- `isNumberType(leftTsType)` is `true`, so the codepath at
+  `binary-ops.ts:1255` *would* fire — except its same-line guard
+  `leftType.kind !== "externref"` rejects values whose Wasm static
+  type IS externref
+- But somehow neither branch triggers `__unbox_number` for this case;
+  the `global.get` of an externref-typed global is pushed and routed
+  directly into `compileBitwiseBinaryOp` which assumes f64-on-stack
+
+Two candidate root causes:
+
+1. **`leftType` reported wrong**: `compileExpression` for the `Identifier`
+   referencing `WRAP_BIND_FLAG` returns `{ kind: "f64" }` (matching the
+   TS type) even though it pushed an externref onto the Wasm stack
+   (because the global's Wasm type IS externref). Then the
+   line-1295 externref guard fails to fire.
+2. **Module-level `var X = N` should produce an f64 global, not externref**:
+   The bug is in the global emission path — a numeric-init module-level
+   `var` should be lowered to an f64 global, not externref.
+
+(2) is the cleaner fix but a wider blast radius. (1) is a defensive
+patch in `compileBinaryExpression` that mirrors the IR fix from
+#1303.
+
+## Reproduction
+
+```bash
+cd /workspace/.claude/worktrees/issue-1303-partial-f64-trunc
+npx tsx -e "
+import { compileProject } from './src/index.ts';
+const r = compileProject('node_modules/lodash-es/partial.js', {allowJs:true});
+new WebAssembly.Module(r.binary); // throws
+"
+```
+
+Output:
+```
+WebAssembly.Module(): Compiling function #94:'mergeData' failed:
+f64.trunc[0] expected type f64, found global.get of type externref @+36700
+```
+
+A reduced repro could not be derived during #1303 — straightforward
+patterns like `var FLAG = 1; var BIG = 128; function check(x) { return x & (FLAG | BIG); }` validate cleanly. The lodash mergeData function is
+the only known reproducer; possibly the function-graph size or the
+specific interaction with `data[1] | source[1]` followed by
+`newBitmask < (FLAG | KEY_FLAG | ARY_FLAG)` triggers the bug.
+
+## Fix scope
+
+Two layers, in order of preference:
+
+1. **Defensive in `compileBitwiseBinaryOp` / `compileBinaryExpression`**:
+   mirror the IR fix in #1303. Before the bitwise sequence, check
+   the value-on-stack type via stack-balance tracking. If externref,
+   emit `__unbox_number`.
+
+2. **Root cause: module-level `var X = N` global typing**:
+   audit the global-emit path. A numeric-init `var X = N` should be
+   lowered to an f64 global (or a tagged-union global with f64 as
+   one member, depending on whether the var is reassigned to a
+   non-numeric value later in the file). Check
+   `src/codegen/index.ts` global emission and the var-binding
+   handling in `function-body.ts`.
+
+## Files
+
+- `src/codegen/binary-ops.ts` — `compileBinaryExpression`, `compileBitwiseBinaryOp`
+- `src/codegen/index.ts` — module-level global emission
+- `src/codegen/function-body.ts` — var-binding type inference
+
+## Acceptance criteria
+
+1. `compileProject('node_modules/lodash-es/partial.js')` produces a
+   binary that passes `new WebAssembly.Module(...)` validation
+2. `tests/stress/lodash-tier2.test.ts` Tier 2c case can flip from
+   `it.skip` to `it`
+3. No regression in lodash Tier 1, Tier 2 memoize/negate, equivalence
+   tests
+4. test262 net delta ≥ 0
+
+## Why this matters
+
+`partial.js` blocks Hono / koa / express middleware patterns that use
+partial application. The legacy codegen path needs the same defensive
+coercion as the IR path or — better — the root-cause global typing
+fix that obviates both defenses.

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -557,6 +557,47 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
 
   const materialized = new Set<IrValueId>();
 
+  /**
+   * #1303 — Defensive coercion for bitwise op operands.
+   *
+   * Bitwise ops (`&`, `|`, `^`, `<<`, `>>`, `>>>`) require f64 on the
+   * stack — their lowering chain `emitJsToInt32` starts with `f64.trunc`
+   * which traps validation if the operand is not f64. The IR generator's
+   * `requireF64` guard in `from-ast.ts` is supposed to prevent any
+   * non-f64-val IR `binary` instruction from reaching the lowerer, but
+   * on lodash `partial.js`'s `mergeData` the lowered operand still
+   * arrives as externref. Suspected root cause (filed as #1305):
+   * module-level `var WRAP_BIND_FLAG = 1` in JS mode is treated as
+   * `any`; the IR generator types the use as f64-val based on the
+   * literal initializer, but the lowered `global.get` returns externref.
+   *
+   * Defense: after `emitValue(v)` for a bitwise operand, check the IR
+   * type. If it is NOT f64-val (the contract), emit `__unbox_number`
+   * to coerce externref → f64. For correctly-typed values the branch
+   * is never taken and codegen is byte-identical.
+   *
+   * Once #1305 lands the IR contract holds across the board and this
+   * helper can be removed.
+   */
+  const coerceToF64ForBitwise = (v: IrValueId, out: Instr[]): void => {
+    let t: IrType;
+    try {
+      t = typeOf(v);
+    } catch {
+      return; // value type unknown — leave as-is
+    }
+    if (t.kind === "val" && t.val.kind === "f64") return; // already f64
+    // Try to resolve __unbox_number; if absent, leave the value alone
+    // (the legacy validator will then surface the type mismatch and we
+    // haven't masked any other contract violation).
+    try {
+      const idx = resolver.resolveFunc({ kind: "func", name: "__unbox_number" });
+      out.push({ op: "call", funcIdx: idx });
+    } catch {
+      // resolver doesn't know __unbox_number — fall through unchanged
+    }
+  };
+
   const emitValue = (v: IrValueId, out: Instr[]): void => {
     const pi = paramIdx.get(v);
     if (pi !== undefined) {
@@ -599,22 +640,29 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         emitValue(instr.value, out);
         out.push({ op: "global.set", index: resolver.resolveGlobal(instr.target) });
         return;
-      case "binary":
-        emitValue(instr.lhs, out);
-        emitValue(instr.rhs, out);
-        // Slice 11 (#1169n) — JS bitwise composite ops. Each pops two
-        // f64 from the stack, applies JS ToInt32 to each, runs the i32
-        // op, and converts back to f64. We use a per-function scratch
-        // f64 local to stash the right operand while we ToInt32 the
-        // left (Wasm has no general "swap" op).
-        if (
+      case "binary": {
+        const isJsBitwise =
           instr.op === "js.bitand" ||
           instr.op === "js.bitor" ||
           instr.op === "js.bitxor" ||
           instr.op === "js.shl" ||
           instr.op === "js.shr_s" ||
-          instr.op === "js.shr_u"
-        ) {
+          instr.op === "js.shr_u";
+        emitValue(instr.lhs, out);
+        // #1303 — defensive coercion only for JS bitwise ops, where the
+        // lowering's first instruction (`f64.trunc` inside `emitJsToInt32`)
+        // requires f64 on stack. Other binary ops (`f64.add`, `i32.eq`)
+        // are not affected and must NOT be coerced (would break i32
+        // boolean ops). See `coerceToF64ForBitwise` doc + #1305.
+        if (isJsBitwise) coerceToF64ForBitwise(instr.lhs, out);
+        emitValue(instr.rhs, out);
+        if (isJsBitwise) coerceToF64ForBitwise(instr.rhs, out);
+        // Slice 11 (#1169n) — JS bitwise composite ops. Each pops two
+        // f64 from the stack, applies JS ToInt32 to each, runs the i32
+        // op, and converts back to f64. We use a per-function scratch
+        // f64 local to stash the right operand while we ToInt32 the
+        // left (Wasm has no general "swap" op).
+        if (isJsBitwise) {
           const { rhs: rhsSlot, tmp: tmpSlot } = ensureJsBitwiseScratch();
           // Stack: [lhs_f64, rhs_f64]
           out.push({ op: "local.set", index: rhsSlot });
@@ -649,6 +697,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         }
         out.push({ op: instr.op } as unknown as Instr);
         return;
+      }
       case "unary":
         emitValue(instr.rand, out);
         out.push({ op: instr.op } as unknown as Instr);

--- a/tests/issue-1303.test.ts
+++ b/tests/issue-1303.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1303 — IR codegen path: bitwise ops on operands that lower to non-f64
+// types (notably externref). Surfaced compiling lodash partial.js
+// `mergeData` where module-level `var WRAP_BIND_FLAG = 1` references
+// arrive as externref via `global.get`, then feed `&`/`|` whose
+// emitJsToInt32 sequence starts with `f64.trunc` and rejects them.
+//
+// The fix in `src/ir/lower.ts` adds a defensive `coerceToF64ForBitwise`
+// helper invoked only for `js.bitand|bitor|bitxor|shl|shr_s|shr_u` IR
+// instructions. If `typeOf(operand).val.kind` isn't `"f64"`, it emits
+// `call __unbox_number` to coerce externref → f64 before the trunc.
+//
+// The legacy codegen path (binary-ops.ts) is NOT covered by this fix —
+// see #1305 for the legacy / root-cause follow-up. That's why
+// `lodash-es/partial.js` still fails validation after this fix.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndRun(source: string): Promise<unknown> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  // Validate the binary up-front — surface validator errors here rather
+  // than during instantiation so the assertion error message is clean.
+  new WebAssembly.Module(r.binary);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof (imports as { setExports?: Function }).setExports === "function") {
+    (imports as { setExports: Function }).setExports(instance.exports);
+  }
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1303 — IR bitwise ops coerce non-f64 operands to f64 defensively", () => {
+  /**
+   * Baseline: bitwise op on f64 typed parameters compiles and runs.
+   * The `coerceToF64ForBitwise` helper must be a no-op for already-f64
+   * operands — codegen should be byte-identical to before the fix.
+   */
+  it("bitwise op on f64 operands still works (no-op coercion)", async () => {
+    const result = await compileAndRun(`
+      export function test(): number {
+        const x: number = 5;
+        const y: number = 3;
+        return x & y;  // 5 & 3 = 1
+      }
+    `);
+    expect(result).toBe(1);
+  });
+
+  /**
+   * Bitwise OR composition matching mergeData's pattern (chained `|`).
+   * Each intermediate result is f64; both operands are f64. This
+   * verifies the helper doesn't break composed bitwise expressions.
+   */
+  it("chained bitwise ORs (mergeData WRAP_*_FLAG pattern) compose correctly", async () => {
+    const result = await compileAndRun(`
+      const FLAG_BIND = 1;
+      const FLAG_KEY = 2;
+      const FLAG_ARY = 128;
+      export function test(): number {
+        return FLAG_BIND | FLAG_KEY | FLAG_ARY;  // 1 | 2 | 128 = 131
+      }
+    `);
+    expect(result).toBe(131);
+  });
+
+  /**
+   * Bitwise AND combined with comparison — mergeData's pattern of
+   * `srcBitmask & WRAP_BIND_FLAG ? 0 : WRAP_CURRY_BOUND_FLAG`.
+   */
+  it("bitwise AND used as ternary condition (mergeData branch pattern)", async () => {
+    const result = await compileAndRun(`
+      const FLAG_BIND = 1;
+      const FLAG_CURRY_BOUND = 4;
+      export function test(): number {
+        const srcBitmask = 5;  // BIND | (4) — has FLAG_BIND set
+        return (srcBitmask & FLAG_BIND) ? 0 : FLAG_CURRY_BOUND;
+      }
+    `);
+    expect(result).toBe(0);
+  });
+
+  /**
+   * Comparison of bitwise-OR result with a bitwise-OR constant, the
+   * exact shape from mergeData line 39:
+   *   `newBitmask < (WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG | WRAP_ARY_FLAG)`.
+   * The right-hand side composes 3 ORs into a constant, then `<`
+   * against the accumulated bitmask. Validates that bitwise-then-compare
+   * works correctly (both operands stay numeric).
+   */
+  it("bitmask < (FLAG | FLAG | FLAG) composes correctly", async () => {
+    const result = await compileAndRun(`
+      const F1 = 1;
+      const F2 = 2;
+      const F3 = 128;
+      export function test(): number {
+        const newBitmask = 5;  // < 131
+        return newBitmask < (F1 | F2 | F3) ? 1 : 0;
+      }
+    `);
+    expect(result).toBe(1);
+  });
+
+  /**
+   * Shift ops also go through emitJsToInt32 + the per-op scratch
+   * coercion. Verify shifts on f64 operands still work after the
+   * helper landed.
+   */
+  it("shift ops (>>, <<, >>>) still work on f64 operands", async () => {
+    const result = await compileAndRun(`
+      export function test(): number {
+        const a = 256;
+        const b = 3;
+        return (a >> b) + (b << 2) + (a >>> 1);  // 32 + 12 + 128 = 172
+      }
+    `);
+    expect(result).toBe(172);
+  });
+
+  /**
+   * XOR on f64 operands — sibling to AND/OR coverage above.
+   */
+  it("xor on f64 operands still works", async () => {
+    const result = await compileAndRun(`
+      export function test(): number {
+        const a = 0xAA;
+        const b = 0x55;
+        return a ^ b;  // 0xFF = 255
+      }
+    `);
+    expect(result).toBe(255);
+  });
+});


### PR DESCRIPTION
## Summary

JS bitwise ops (`&`, `|`, `^`, `<<`, `>>`, `>>>`) lower through
`emitJsToInt32` which starts with `f64.trunc` — Wasm validation
requires f64 on the stack. The IR generator's `requireF64` guard in
`from-ast.ts` is supposed to keep non-f64-val IR `binary` nodes out
of the lowerer, but on lodash `partial.js`'s `mergeData` the lowered
operand still arrives as externref (the IR thinks f64; the lowered
`global.get` pushes externref).

Adds a defensive `coerceToF64ForBitwise` helper invoked from
`lower.ts case "binary"` only when `instr.op` is one of the JS
bitwise ops. If `typeOf(v).val.kind` isn't `"f64"`, emit
`call __unbox_number` to coerce externref → f64 before the trunc
sequence. For correctly-typed values the helper is a no-op (early
return) and codegen is byte-identical.

## Scope note

**This fixes the IR codegen path. The legacy `compileBitwiseBinaryOp`
path (`src/codegen/binary-ops.ts`) is still affected** —
`lodash-es/partial.js` still fails Wasm validation with the original
`f64.trunc[0] expected type f64` error because mergeData compiles via
the legacy codegen. **Tracked in #1305** (both candidate fixes:
defensive in legacy compileBitwiseBinaryOp + root-cause in
module-level var/global typing).

`tests/stress/lodash-tier2.test.ts` Tier 2c case stays skipped pending
#1305.

## Tests

`tests/issue-1303.test.ts` — 6 cases / 6 pass:

- f64-operand bitwise still works (no-op coercion path)
- chained `|` (mergeData `WRAP_*_FLAG` composition pattern)
- bitwise AND as ternary condition (mergeData branch pattern)
- `bitmask < (FLAG | FLAG | FLAG)` compose-and-compare
- shifts (`>>`, `<<`, `>>>`)
- xor

Plus 21/21 sanity pass on `tests/issue-1126.test.ts` + `tests/issue-1169n.test.ts`
(IR Stage 2 + Slice 11 bitwise op coverage).

## Test plan

- [x] `npm test -- tests/issue-1303.test.ts` — 6/6 pass
- [x] `npm test -- tests/issue-1126.test.ts tests/issue-1169n.test.ts` — 21/21 pass
- [x] No regression in IR-path bitwise codegen (helper is no-op for f64-val IR)
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)