### PR TITLE
fix(#1306): dispatch element-access calls on closure-typed arrays

### DIFF
--- a/plan/issues/sprints/50/1306-mws-idx-call-on-closure-array-drops-call.md
+++ b/plan/issues/sprints/50/1306-mws-idx-call-on-closure-array-drops-call.md
@@ -2,9 +2,9 @@
 id: 1306
 sprint: 50
 title: "ElementAccessExpression call on closure-typed array drops call: mws[idx](c, next) emits ref.null"
-status: ready
+status: in-progress
 created: 2026-05-03
-updated: 2026-05-03
+updated: 2026-05-07
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -108,3 +108,72 @@ candidates in `src/codegen/expressions/calls.ts`:
 The middleware-compose pattern is the entire `koa`/`hono` core abstraction.
 With #1301 fixed, this is the last gap blocking real array-of-closures
 dispatch end-to-end.
+
+## Test Results (2026-05-07, branch `issue-1306-elem-call`)
+
+The dispatch fix landed: `compileCallableElementAccessCall` now handles
+`fns[idx](args)` shapes by loading the element through the existing
+element-access codegen, unboxing externref → `__fn_wrap_N_struct`, and
+emitting `call_ref` against the wrapper's lifted func type.
+
+`tests/issue-1306.test.ts` — 7/7 PASS:
+- literal index: `fns[0]("hi")` → `"hi!"`
+- const-bound index: `fns[i]("hi")` with `const i = 1` → `"hi?"`
+- runtime index: `for (i; i<n; i++) acc += fns[i]("x")` → `"xAxBxC"`
+- two-arg call with top-level callable: `mws[0](0, term)` → `"[A]end"`
+- runtime index picks the right element: `fns[2]("ok")` → `"third:ok"`
+- multi-arg call signature: `ops[i](10, 3)` summed → `50`
+- non-callable arrays still compile (`number[].length`) — fallback
+  unchanged when callSigs is empty.
+
+**Acceptance #1 — DONE.** Element-access call on a closure-typed array
+now dispatches via `call_ref` to the closure stored at `idx`.
+
+**Acceptance #2 / #3 — partially blocked by an orthogonal bug:**
+The Tier 5c case `mws[idx](c, next)` and the single-mw `[A]end` case
+both expose a separate, pre-existing issue: passing an inner function
+declaration that has captures (`next`) as a value FROM INSIDE its own
+body compiles to `ref.null.extern`. Verified by running
+`compose([(c, n) => "[A]" + n()])(0)` — the dispatch IS now correct,
+but `next` is passed as null, so the middleware's `n()` raises
+TypeError. Reproduced with the fix reverted (same `THROW`), confirming
+the throw is independent of #1306's element-access dispatch.
+
+The smaller repro that isolates the orthogonal bug:
+
+```typescript
+function outer(): string {
+  let x = "/";
+  function next(): string {
+    return helper((n) => "[A]" + n(), next, x);
+    //                                  ^^^^ compiles to ref.null.extern
+  }
+  return next();
+}
+```
+
+The buggy path is in `emitFuncRefAsClosure` (`src/codegen/closures.ts`)
+— for unboxed captures it pushes `local.get cap.outerLocalIdx`, where
+`outerLocalIdx` is the index in the function's *parent* scope. From
+inside `next`'s own body those indices don't apply, but a previous
+`localMap.get(cap.name) ?? cap.outerLocalIdx` change (#1177 Stage 1)
+caused 100+ test262 regressions in async fns and was reverted (see
+the comment at calls.ts:5390-5395). Solving it cleanly likely needs
+a narrower lookup that detects "inside-self body" specifically.
+
+Filed as a follow-up: see new issue file (TBD) — Tier 5c remains
+skipped until that lands. The #1306 dispatch fix is independently
+valuable (3 of 5 acceptance scenarios pass; the npm-library
+groundwork is unblocked for top-level callable arrays).
+
+## Files changed
+
+- `src/codegen/expressions/calls-closures.ts` — added
+  `compileCallableElementAccessCall` helper (mirrors externref-field
+  branch of `compileCallablePropertyCall`).
+- `src/codegen/expressions/calls.ts` — wired the helper into the two
+  fallback paths inside the `ElementAccessExpression` block (resolved-
+  no-method @ ~6371; unresolved-index @ ~6389) and added the import.
+- `tests/issue-1306.test.ts` — 7 new tests covering literal/const/
+  runtime-index dispatch, multi-arg signatures, and a non-regression
+  guard for native primitive arrays.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -649,6 +649,109 @@ export function compileCallablePropertyCall(
 }
 
 /**
+ * Handle calls where the callee is an element-access expression on a value
+ * whose element type has TS call signatures: `arr[i](args)`, `arr[const](args)`,
+ * `arr["0"](args)`. This mirrors the externref-field branch of
+ * `compileCallablePropertyCall` but routes through the existing element-access
+ * codegen for the receiver, so it works for vec-of-callable, ref-of-callable,
+ * tuple-of-callable, and any other element-access shape.
+ *
+ * Returns undefined when the element type has no call signature (e.g. native
+ * `i32[]` / `f64[]`), letting the caller fall through to the historical
+ * `ref.null.extern; drop` fallback.
+ *
+ * #1306: `mws[idx](c, next)` on a closure-typed array previously dropped the
+ * call. With this helper the value is loaded via __vec_get / array.get, unboxed
+ * (externref → __fn_wrap struct) and dispatched via call_ref.
+ */
+export function compileCallableElementAccessCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  elemAccess: ts.ElementAccessExpression,
+): InnerResult | undefined {
+  // 1. Resolve element type's call signatures (with NonNullable fallback)
+  const elemTsType = ctx.checker.getTypeAtLocation(elemAccess);
+  let callSigs = elemTsType.getCallSignatures?.();
+  if (!callSigs || callSigs.length === 0) {
+    const nn = ctx.checker.getNonNullableType(elemTsType);
+    callSigs = nn.getCallSignatures?.();
+  }
+  if (!callSigs || callSigs.length === 0) return undefined;
+
+  const sig = callSigs[0]!;
+  const sigParamCount = sig.parameters.length;
+  const sigRetType = ctx.checker.getReturnTypeOfSignature(sig);
+  const sigRetWasm = isVoidType(sigRetType) ? null : resolveWasmType(ctx, sigRetType);
+  const sigParamWasmTypes: ValType[] = [];
+  for (let i = 0; i < sigParamCount; i++) {
+    const paramType = ctx.checker.getTypeOfSymbol(sig.parameters[i]!);
+    sigParamWasmTypes.push(resolveWasmType(ctx, paramType));
+  }
+
+  // 2. Eagerly create / find the wrapper struct (signature-keyed cache)
+  const resultTypes = sigRetWasm ? [sigRetWasm] : [];
+  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, sigParamWasmTypes, resultTypes);
+  if (!wrapperTypes) return undefined;
+  const { structTypeIdx: wrapperStructIdx, closureInfo } = wrapperTypes;
+
+  // 3. Compile elemAccess to push the element value. For an `Mw[]` (vec of
+  //    callables) the element will be externref (boxed __fn_wrap). For a
+  //    structurally-typed `(Mw, Mw)` tuple it may already be a closure
+  //    struct ref. For native primitive arrays callSigs is empty above,
+  //    so we never get here.
+  const elemResult = compileExpression(ctx, fctx, elemAccess);
+  if (!elemResult) return undefined;
+
+  // 4. Coerce to closure-struct ref (mirror calls-closures.ts:507-519)
+  const closureRefType: ValType = { kind: "ref_null", typeIdx: wrapperStructIdx };
+  const closureLocal = allocLocal(fctx, `__cea_${fctx.locals.length}`, closureRefType);
+  if (elemResult.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" });
+    emitGuardedRefCast(fctx, wrapperStructIdx);
+  } else if (elemResult.kind === "ref" || elemResult.kind === "ref_null") {
+    // Already a struct ref — guard cast if the shape differs from the
+    // wrapper we resolved by signature.
+    if ((elemResult as { typeIdx: number }).typeIdx !== wrapperStructIdx) {
+      emitGuardedRefCast(fctx, wrapperStructIdx);
+    }
+  } else {
+    // Primitive element type with call signatures shouldn't happen — bail
+    // to the historical fallback which drops everything for side effects.
+    return undefined;
+  }
+  fctx.body.push({ op: "local.set", index: closureLocal });
+
+  // 5. Push self (closureRef) as first lifted-fn arg, null-check throw
+  fctx.body.push({ op: "local.get", index: closureLocal });
+  emitNullCheckThrow(ctx, fctx, closureRefType);
+
+  // 6. Compile call args (clamped/padded — copy lines 462-478 of
+  //    compileCallablePropertyCall)
+  const cpParamCount = closureInfo.paramTypes.length;
+  for (let i = 0; i < Math.min(expr.arguments.length, cpParamCount); i++) {
+    compileExpression(ctx, fctx, expr.arguments[i]!, closureInfo.paramTypes[i]);
+  }
+  for (let i = cpParamCount; i < expr.arguments.length; i++) {
+    const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
+    if (extraType !== null) fctx.body.push({ op: "drop" });
+  }
+  for (let i = expr.arguments.length; i < cpParamCount; i++) {
+    pushDefaultValue(fctx, closureInfo.paramTypes[i]!, ctx);
+  }
+
+  // 7. Extract funcref + call_ref (mirror lines 543-557)
+  fctx.body.push({ op: "local.get", index: closureLocal });
+  emitNullCheckThrow(ctx, fctx, closureRefType);
+  fctx.body.push({ op: "struct.get", typeIdx: wrapperStructIdx, fieldIdx: 0 });
+  emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
+  emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureInfo.funcTypeIdx });
+  fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });
+
+  return closureInfo.returnType ?? VOID_RESULT;
+}
+
+/**
  * Try to resolve a method call on an `any`-typed receiver through registered extern classes.
  * When the type checker resolves the receiver as `any` (e.g. when lib files aren't loaded
  * in ESM/bundled contexts), we dispatch known collection methods (Set.union, Map.get, etc.)

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -67,6 +67,7 @@ import {
   wasiAllocStringData,
 } from "./builtins.js";
 import {
+  compileCallableElementAccessCall,
   compileCallablePropertyCall,
   compileClosureCall,
   compileGetterCallable,
@@ -6368,6 +6369,14 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         if (arrMethodResult !== undefined) return arrMethodResult;
       }
 
+      // ELEM ACCESS RESOLVED, NO METHOD MATCHED — try callable element type
+      // (#1306). Covers `fns[0](args)` and `fns[ConstKey](args)` where
+      // `fns` is an array (or other element-access-able value) of callables.
+      {
+        const cea = compileCallableElementAccessCall(ctx, fctx, expr, elemAccess);
+        if (cea !== undefined) return cea;
+      }
+
       // Fallback for resolved element access calls that didn't match any known method:
       // compile receiver, discard; compile each argument for side effects; return externref.
       {
@@ -6384,6 +6393,14 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         fctx.body.push({ op: "ref.null.extern" });
         return { kind: "externref" };
       }
+    }
+
+    // ELEM ACCESS UNRESOLVED — try callable element type (#1306) before
+    // falling through to the drop-everything path. Covers
+    // `mws[idx](c, next)` where `idx` is a runtime variable.
+    {
+      const cea = compileCallableElementAccessCall(ctx, fctx, expr, elemAccess);
+      if (cea !== undefined) return cea;
     }
 
     // Fallback for element access calls where the key couldn't be resolved statically:

--- a/tests/issue-1306.test.ts
+++ b/tests/issue-1306.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #1306 — `mws[idx](c, next)` on a closure-typed array compiles to `ref.null
+ * extern; drop`, dropping the call.
+ *
+ * Two `compileCallExpression` fallback paths inside the
+ * `ts.isElementAccessExpression(expr.expression)` branch (calls.ts:5927)
+ * previously ended in `ref.null.extern`:
+ *   1. Resolved-but-unmatched-method (line 6371-6386)
+ *   2. Unresolved-index (line 6389-6409)
+ *
+ * Neither handled the case where the receiver is a vec/array of values whose
+ * element type has TS call signatures. The fix adds a new helper
+ * `compileCallableElementAccessCall` (calls-closures.ts) that loads the
+ * element via the existing element-access codegen, unboxes the externref
+ * to a `__fn_wrap_N_struct` ref, and dispatches via `call_ref`.
+ *
+ * Mirrors the externref-field branch of `compileCallablePropertyCall`
+ * (calls-closures.ts:500-560).
+ */
+async function run(src: string): Promise<{ exports: Record<string, unknown> }> {
+  const r = compile(src, { fileName: "test.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return { exports: instance.exports as Record<string, unknown> };
+}
+
+describe("#1306 — element-access call on callable array dispatches via call_ref", () => {
+  it("literal index: fns[0](args)", async () => {
+    const { exports } = await run(`
+      export function test(): string {
+        const fns: ((s: string) => string)[] = [(s) => s + "!"];
+        return fns[0]("hi");
+      }
+    `);
+    expect((exports.test as () => string)()).toBe("hi!");
+  });
+
+  it("const-bound index: const I = 1; fns[I](args)", async () => {
+    const { exports } = await run(`
+      export function test(): string {
+        const fns: ((s: string) => string)[] = [(s) => s + "!", (s) => s + "?"];
+        const i = 1;
+        return fns[i]("hi");
+      }
+    `);
+    expect((exports.test as () => string)()).toBe("hi?");
+  });
+
+  it("runtime index: for (i=0; i<n; i++) acc += fns[i](x)", async () => {
+    // The central #1306 case — runtime variable index. Pre-fix this dropped
+    // every iteration's call to `ref.null extern`, so `acc` stayed `""`.
+    const { exports } = await run(`
+      export function test(): string {
+        const fns: ((s: string) => string)[] = [(s) => s + "A", (s) => s + "B", (s) => s + "C"];
+        let acc = "";
+        for (let i = 0; i < fns.length; i++) {
+          acc = acc + fns[i]("x");
+        }
+        return acc;
+      }
+    `);
+    expect((exports.test as () => string)()).toBe("xAxBxC");
+  });
+
+  it("two-arg call through array element: mws[i](c, term)", async () => {
+    // Mirrors the middleware-compose dispatch shape (Mw = (c, n) => string),
+    // but with `term` as a top-level function — sidesteps the orthogonal
+    // self-recursive function-as-arg bug that blocks the full Tier 5c case.
+    const { exports } = await run(`
+      type N = () => string;
+      type Mw = (c: number, next: N) => string;
+
+      function term(): string { return "end"; }
+
+      function call0(mws: Mw[]): string {
+        return mws[0](0, term);
+      }
+
+      export function test(): string {
+        const mws: Mw[] = [(c, n: N) => "[A]" + n()];
+        return call0(mws);
+      }
+    `);
+    expect((exports.test as () => string)()).toBe("[A]end");
+  });
+
+  it("dispatch picks the right element by runtime index", async () => {
+    const { exports } = await run(`
+      export function test(): string {
+        const fns: ((s: string) => string)[] = [
+          (s) => "first:" + s,
+          (s) => "second:" + s,
+          (s) => "third:" + s,
+        ];
+        let i = 2;
+        return fns[i]("ok");
+      }
+    `);
+    expect((exports.test as () => string)()).toBe("third:ok");
+  });
+
+  it("call signature with multiple args dispatches each element", async () => {
+    const { exports } = await run(`
+      type Op = (a: number, b: number) => number;
+      export function test(): number {
+        const ops: Op[] = [(a, b) => a + b, (a, b) => a - b, (a, b) => a * b];
+        let acc = 0;
+        for (let i = 0; i < ops.length; i++) {
+          acc = acc + ops[i](10, 3);
+        }
+        return acc; // (10+3) + (10-3) + (10*3) = 13 + 7 + 30 = 50
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(50);
+  });
+
+  it("compilation doesn't regress for native primitive arrays", async () => {
+    // Sanity guard: arrays with no call-signature element type must still
+    // compile via the existing fallback (helper returns undefined).
+    const { exports } = await run(`
+      export function test(): number {
+        const xs: number[] = [1, 2, 3];
+        // String element access on a number[] — shouldn't try to dispatch via call_ref
+        return xs.length;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `compileCallableElementAccessCall` helper in `src/codegen/expressions/calls-closures.ts` (+103 lines) — mirrors the externref-field branch of `compileCallablePropertyCall`
- Wire into `calls.ts` ElementAccessExpression resolved-no-method fallback (~line 6371) and unresolved-index fallback (~line 6389)
- Both paths previously emitted `ref.null; drop`; now unbox `externref → __fn_wrap_N_struct → struct.get $func → call_ref`

7/7 tests pass in `tests/issue-1306.test.ts`. Acceptance #1 lands. Acceptance #2/#3 reveal orthogonal pre-existing bug (passing inner fn-decl with captures as value from inside its own body emits `ref.null.extern`) — documented in issue, follow-up needed.

## Test plan
- `npm test -- tests/issue-1306.test.ts`
- No regressions in `tests/issue-1300/1301/1303/1304.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)