### PR TITLE
feat(#1318): surface assert source line + raise truncation limits

### DIFF
--- a/scripts/test262-worker-esm.mjs
+++ b/scripts/test262-worker-esm.mjs
@@ -1,23 +1,27 @@
-import { register } from 'node:module';
-register('tsx', import.meta.url);
+import { register } from "node:module";
+register("tsx", import.meta.url);
 
-const { workerData, parentPort } = await import('worker_threads');
-const { runTest262File } = await import('../tests/test262-runner.ts');
+const { workerData, parentPort } = await import("worker_threads");
+const { runTest262File } = await import("../tests/test262-runner.ts");
 
 const { filePath, category } = workerData;
-const relPath = filePath.replace(/.*test262\/test\//, '');
+const relPath = filePath.replace(/.*test262\/test\//, "");
 
 try {
   const result = await runTest262File(filePath, category);
   parentPort.postMessage({
-    file: result.file, category: result.category, status: result.status,
-    ...(result.error ? { error: result.error.substring(0, 300) } : {}),
+    file: result.file,
+    category: result.category,
+    status: result.status,
+    ...(result.error ? { error: result.error.substring(0, 2000) } : {}),
     ...(result.reason ? { reason: result.reason } : {}),
     ...(result.timing ? { timing: result.timing } : {}),
   });
 } catch (e) {
   parentPort.postMessage({
-    file: relPath, category, status: 'compile_error',
-    error: String(e).substring(0, 300),
+    file: relPath,
+    category,
+    status: "compile_error",
+    error: String(e).substring(0, 2000),
   });
 }

--- a/tests/issue-1318.test.ts
+++ b/tests/issue-1318.test.ts
@@ -1,0 +1,102 @@
+// #1318 — Verify the test262 runner surfaces enough context on assertion
+// failures: the source line of the failing assert, its line number, and a
+// raised truncation limit so descriptive `assert.sameValue(actual, expected,
+// "message...")` calls aren't cut mid-line.
+
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function withTempTest<T>(source: string, name: string, fn: (path: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "issue-1318-"));
+  try {
+    const path = join(dir, name);
+    // Test262 runner expects the full test262/test path prefix to derive
+    // a relative path; provide a path that contains it so output looks right.
+    await writeFile(path, source);
+    return await fn(path);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("#1318 — test262 runner error context", () => {
+  it("captures full assert source line on failure (no 160-char truncation)", async () => {
+    // Construct a test that fails on the third assert — the line is intentionally
+    // long enough that the previous 160-char limit would have truncated it.
+    const longMessage =
+      "this is a deliberately verbose descriptive assertion message used to verify that the runner does not truncate diagnostic context below 500 characters";
+    const source = `
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/*---
+description: probe — 3rd assert fails with a long message
+---*/
+assert.sameValue(1, 1);
+assert.sameValue(2, 2);
+assert.sameValue(3, 4, "${longMessage}");
+`;
+    await withTempTest(source, "issue-1318-long-assert.js", async (path) => {
+      const result = await runTest262File(path, "smoke");
+      expect(result.status).toBe("fail");
+      // The error must contain the full long message — verifies the 160→600
+      // bump in test262-runner.ts AND no downstream 300-char cut on the
+      // worker (handled by test262-worker-esm.mjs separately).
+      expect(result.error).toContain(longMessage);
+      // The error must include the line number (an explicit format change
+      // in the #1318 fix: `assert #N at L<line>: <source>`).
+      expect(result.error).toMatch(/at L\d+:/);
+    });
+  });
+
+  it("preserves the Test262Error message text in the error field", async () => {
+    // A test that fails by throwing Test262Error directly. The runner's
+    // replaceThrowTest262Error pipeline routes the throw value through to
+    // the captured `error` field — verify the descriptive message survives
+    // without being truncated below the new 2000-char downstream limit.
+    const source = `
+/*---
+description: probe — throws Test262Error directly
+---*/
+function check(x) {
+  if (x !== 99) throw new Test262Error("custom message about " + x);
+}
+check(99);
+check(100);
+`;
+    await withTempTest(source, "issue-1318-throw.js", async (path) => {
+      const result = await runTest262File(path, "smoke");
+      expect(result.status).toBe("fail");
+      // The Test262Error message was captured — the actual interpolated
+      // value (`100`) reached the error field intact.
+      expect(result.error).toContain("custom message about 100");
+    });
+  }, 30_000);
+
+  it("includes line number in the assert context (new format)", async () => {
+    // Verify the new `at L<n>:` format is present (added in #1318 alongside
+    // the truncation bump). Pre-fix the format was `assert #N: <line>` with
+    // no L<n> prefix.
+    const source = `
+/*---
+description: probe — line number in assert context
+---*/
+assert.sameValue(1, 1);
+// some
+// padding
+// to make
+// the failing
+// assert appear
+// on a
+// non-trivial
+// line
+assert.sameValue(2, 3);
+`;
+    await withTempTest(source, "issue-1318-line.js", async (path) => {
+      const result = await runTest262File(path, "smoke");
+      expect(result.status).toBe("fail");
+      expect(result.error).toMatch(/at L1[0-9]:/); // line 14-ish
+    });
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2871,6 +2871,15 @@ export async function runTest262File(
     //   (__assert_count starts at 1, incremented before check, so first assert → 2)
     // ret == -1: uncaught exception (not from an assert)
     // ret == 0: legacy (should not happen with new shims)
+    //
+    // #1318 — surface enough of the assert source line to diagnose the
+    // failure. Previously we truncated to 160 chars which cut off most
+    // assertion messages. Most assert lines fit comfortably in 600 chars
+    // (the longest legitimate assert.sameValue with a descriptive message
+    // and a multi-arg comparison stays well under that). The downstream
+    // worker still caps the full error string at 2000 chars so this won't
+    // bloat the JSONL beyond what fits a single test result.
+    const ASSERT_LINE_MAX = 600;
     let assertCtx = "";
     if (typeof ret === "number" && ret >= 2) {
       const assertIdx = ret - 1; // 1-based index into assert calls
@@ -2885,15 +2894,40 @@ export async function runTest262File(
           const lineStart = source.lastIndexOf("\n", m.index) + 1;
           const lineEnd = source.indexOf("\n", m.index);
           const line = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd).trim();
-          assertCtx = ` | assert #${assertIdx}: ${line.slice(0, 160)}`;
+          // 1-based line number for the user (matches editor display).
+          const lineNumber = (source.slice(0, m.index).match(/\n/g)?.length ?? 0) + 1;
+          const truncated = line.length > ASSERT_LINE_MAX ? `${line.slice(0, ASSERT_LINE_MAX - 3)}...` : line;
+          assertCtx = ` | assert #${assertIdx} at L${lineNumber}: ${truncated}`;
           break;
         }
       }
       if (!assertCtx) {
-        assertCtx = ` | assert #${assertIdx} of ${nth} total`;
+        // #1318 — Nth assert not found via regex (e.g. test uses Test262Error
+        // throws or a custom helper that doesn't match `\bassert\b...`).
+        // Look for a bare `throw new Test262Error(...)` to surface its
+        // message — that's a common test262 failure idiom that the regex
+        // above misses.
+        const throwRegex = /throw\s+new\s+Test262Error\s*\(([^)]*)\)/g;
+        let throwMatch: RegExpExecArray | null;
+        let nthThrow = 0;
+        while ((throwMatch = throwRegex.exec(source)) !== null) {
+          nthThrow++;
+          if (nthThrow === assertIdx) {
+            const lineStart = source.lastIndexOf("\n", throwMatch.index) + 1;
+            const lineEnd = source.indexOf("\n", throwMatch.index);
+            const line = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd).trim();
+            const lineNumber = (source.slice(0, throwMatch.index).match(/\n/g)?.length ?? 0) + 1;
+            const truncated = line.length > ASSERT_LINE_MAX ? `${line.slice(0, ASSERT_LINE_MAX - 3)}...` : line;
+            assertCtx = ` | Test262Error #${assertIdx} at L${lineNumber}: ${truncated}`;
+            break;
+          }
+        }
+        if (!assertCtx) {
+          assertCtx = ` | assert #${assertIdx} of ${nth} total`;
+        }
       }
     } else if (ret === -1) {
-      assertCtx = " | uncaught exception";
+      assertCtx = " | uncaught exception (no assert tracked)";
     }
     return {
       file: relPath,


### PR DESCRIPTION
## Summary
- Bump JSONL `error` field truncation in `scripts/test262-worker-esm.mjs` from 300 → 2000 chars (the dominant source of ~8.9k truncated assertion failures).
- In `tests/test262-runner.ts` `assertCtx` builder: bump per-line truncation 160 → 600 chars and add line numbers to the assert context (`assert #N at L<line>: <source>`).
- New fallback path: when the assert regex doesn't match (test uses `throw new Test262Error(...)` directly), surface the Nth Test262Error throw's source line + line number — pre-fix this produced "assert #N of M total" with no usable context.

## Tests
- New `tests/issue-1318.test.ts` (3 cases): long-message capture, Test262Error message preservation, line-number format.
- Existing `tests/issue-{1316,1158,1157}.test.ts` (25 tests) stay green — no regression.

## Test plan
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] New unit tests pass (3/3)
- [x] Adjacent runner tests pass (25/25)
- [ ] CI test262 — should show diagnostic detail in regression bucket text without changing pass/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)