### PR TITLE
fix(#1319): wasm-struct ToPrimitive falls back to '[object Object]' instead of throwing

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -637,6 +637,17 @@ function _hostToPrimitive(
       }
     }
   }
+  // (#1319) WasmGC structs without any user-defined valueOf / toString /
+  // Symbol.toPrimitive don't inherit Object.prototype.toString the way a
+  // plain JS `{}` does, so they reach this fallback even though V8 would
+  // produce "[object Object]" for an ordinary object in the same shape.
+  // Mirror V8's default toString here instead of throwing — matches the
+  // _toPrimitiveSync fallback at line ~477 and the spec behaviour you'd
+  // observe by hand: `String({})` is "[object Object]", not a TypeError.
+  // The TypeError throw is preserved below for non-wasm-struct objects
+  // whose own valueOf/toString returned non-primitives (genuine spec
+  // violation per ECMA-262 §7.1.1.1 step 6).
+  if (_isWasmStruct(raw)) return "[object Object]";
   throw new TypeError("Cannot convert object to primitive value");
 }
 

--- a/tests/issue-1319.test.ts
+++ b/tests/issue-1319.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1319 — `Cannot convert object to primitive value` cluster.
+//
+// `_hostToPrimitive` in src/runtime.ts implements ECMA-262 §7.1.1 OrdinaryToPrimitive:
+// it walks Symbol.toPrimitive → valueOf → toString and throws TypeError if no chain
+// returns a primitive. That matches the spec — but the spec assumes the operand
+// inherits Object.prototype.toString. WasmGC structs have a null prototype, so a
+// user class that omits all three methods (e.g. our test262 preamble's Test262Error)
+// previously fell off the end and threw, even though the same shape as a plain JS
+// object — `String({})` — V8 handles by inheriting Object.prototype.toString and
+// producing "[object Object]".
+//
+// The fix mirrors the existing fallback in `_toPrimitiveSync` (line ~477):
+// before throwing, if `raw` is a wasm-struct, return "[object Object]" — matches
+// what V8 would produce for an ordinary {}.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<Record<string, Function>> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  new WebAssembly.Module(r.binary);
+  const imports: any = buildImports(r.imports, undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(inst.instance.exports);
+  return inst.instance.exports as Record<string, Function>;
+}
+
+describe("#1319 — ToPrimitive on wasm-structs without valueOf/toString/Symbol.toPrimitive", () => {
+  /**
+   * The headline test262 cluster: a class with NO conversion methods (the
+   * shape of `Test262Error` in our preamble). Previously
+   * `_hostToPrimitive(testError, "string")` threw because the proxy yields
+   * undefined for Symbol.toPrimitive / valueOf / toString and our runtime
+   * has no Object.prototype.toString fallback.
+   */
+  it("Math.floor on a no-method class instance does not throw 'Cannot convert object'", async () => {
+    const exports = await run(`
+      class Bare {
+        x: number = 1;
+      }
+      export function test(): number {
+        const b = new Bare();
+        // Forces ToPrimitive("number") via codegen's ref→f64 path.
+        return Math.floor((b as any) - 0);
+      }
+    `);
+    // [object Object] coerces to NaN under JS Number(); Math.floor(NaN) === NaN.
+    // Either NaN or 0 is acceptable — what matters is that the call does not
+    // throw "Cannot convert object to primitive value".
+    expect(() => exports.test!()).not.toThrow();
+  });
+
+  /**
+   * A class WITH a defined valueOf must still be invoked — the new wasm-struct
+   * fallback only fires when no chain matched.
+   */
+  it("class with valueOf is invoked correctly (regression guard for fix)", async () => {
+    const exports = await run(`
+      class Boxed {
+        v: number;
+        constructor(v: number) { this.v = v; }
+        valueOf(): number { return this.v; }
+      }
+      export function test(): number {
+        const b = new Boxed(42);
+        return ((b as any) - 0) + 1;
+      }
+    `);
+    expect(exports.test!()).toBe(43);
+  });
+
+  /**
+   * A class WITH Symbol.toPrimitive must still go through that path.
+   */
+  it("class with Symbol.toPrimitive is invoked correctly (regression guard)", async () => {
+    const exports = await run(`
+      class Coerce {
+        [Symbol.toPrimitive](hint: string): any {
+          return hint === "number" ? 7 : "STR";
+        }
+      }
+      export function test_num(): number {
+        return ((new Coerce() as any) - 0) + 100;
+      }
+      export function test_str(): string {
+        return \`got \${new Coerce()}\`;
+      }
+      export function test(): number { return 1; }
+    `);
+    expect(exports.test_num!()).toBe(107);
+    expect(exports.test_str!()).toBe("got STR");
+  });
+});


### PR DESCRIPTION
## Summary

`_hostToPrimitive` in `src/runtime.ts` implements ECMA-262 §7.1.1 OrdinaryToPrimitive: Symbol.toPrimitive → valueOf → toString, throwing TypeError if no chain returns a primitive. That matches the spec for plain JS objects — but the spec assumes the operand inherits `Object.prototype.toString`. WasmGC structs have a null prototype, so a user class that omits all three methods (e.g. our test262 preamble's `Test262Error`) reaches the fallback even though the same shape as a plain JS object — `String({})` — V8 handles by inheriting `Object.prototype.toString` and producing `"[object Object]"`.

The fix mirrors the existing fallback in `_toPrimitiveSync` (line ~477): before throwing, if `raw` is a wasm-struct, return `"[object Object]"`. The TypeError throw is preserved for non-wasm JS objects whose own valueOf/toString returned non-primitives (genuine spec violation per §7.1.1.1 step 6).

## Scope

This fix only affects callees of the `__to_primitive` host import — the codegen path at `type-coercion.ts:122` (struct ref → f64 / externref coercion). String concatenation through `wasm:js-string.concat` and template literals goes through V8's native ToPrimitive on the externref operand, which is a separate codepath not addressed here.

The 459 baseline failures cluster around L13:3 in the test262 preamble's `isSameValue` (NaN check on `any`-typed operands). Whether this fix unblocks the cluster depends on which codegen path the failing tests hit at runtime — CI will quantify it.

## Test plan

- [x] `tests/issue-1319.test.ts` adds 3 cases:
  - Bare class with no methods does not throw `Cannot convert object to primitive value` on numeric coercion.
  - Class with `valueOf` is invoked correctly (regression guard for the fix).
  - Class with `Symbol.toPrimitive` is invoked correctly (regression guard).
- [x] All 3 tests pass locally.
- [ ] CI quantifies the test262 net delta on the L13:3 / L41:3 / L55:3 `Cannot convert object to primitive` cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)