### PR TITLE
fix(#1325): built-in type-tag registry + static instanceof elimination (Phase 1)

### DIFF
--- a/plan/issues/sprints/50/1325-instanceof-builtin-type-tag-registry.md
+++ b/plan/issues/sprints/50/1325-instanceof-builtin-type-tag-registry.md
@@ -2,9 +2,9 @@
 id: 1325
 sprint: 50
 title: "instanceof against built-in types: compile-time type-tag registry eliminates JS host for common cases"
-status: ready
+status: in-progress
 created: 2026-05-07
-updated: 2026-05-07
+updated: 2026-05-08
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -62,3 +62,60 @@ For user-defined classes and prototype-manipulated objects, the existing JS fall
 - `src/ir/lower.ts` — tag at construction sites, emit tag-test at instanceof sites
 - `src/runtime.ts` — keep JS fallback for externref values only
 - `tests/issue-1325.test.ts`
+
+## Phase 1 implementation (2026-05-08)
+
+Phase 1 lays the groundwork by adding the registry and the static-elimination
+fast paths. It does not yet write tags into WasmGC structs (Phase 2).
+
+### What landed
+
+- `src/codegen/builtin-tags.ts` — new module with:
+  - `BUILTIN_TYPE_TAGS` — reserved negative-integer tag values for Array,
+    Function, Object, Error and the *Error subclasses, Map, Set, WeakMap,
+    WeakSet, Date, RegExp, Promise, ArrayBuffer, SharedArrayBuffer, DataView.
+    Negative so they can never collide with user class tags (which start at 0
+    via `ctx.classTagCounter`).
+  - `isBuiltinTypeName`, `getBuiltinParent`, `isBuiltinSubtype` — registry
+    lookup helpers, including the *Error → Error parent chain.
+
+- `src/codegen/expressions/identifiers.ts` — `compileHostInstanceOf` now
+  attempts a `tryStaticInstanceOf` short-circuit before falling through to
+  the `__instanceof` host import:
+  - LHS TS symbol resolves to a known **user class** + RHS is a built-in
+    → emit `i32.const 0` (a struct can never be a JS built-in).
+  - LHS TS symbol resolves to a built-in `Child` and RHS is `Parent` →
+    emit `i32.const 1` if `isBuiltinSubtype(Child, Parent)`, else `false`.
+  - LHS TS type is `number` / `boolean` → emit `false` (primitives are
+    never `instanceof` of an object constructor).
+  - Fallback to the existing host-import path otherwise.
+- Stack-level fast path also added: when LHS compiled value is `i32` /
+  `f64`, drop and emit `i32.const 0` (saves boxing + a host call).
+
+### Tests (`tests/issue-1325.test.ts`, 13 cases)
+
+Registry unit tests:
+- All built-in names recognised
+- Tag values are negative
+- *Error → Error parent chain encoded
+- `isBuiltinSubtype` hierarchy reasoning + unknown-name guards
+
+End-to-end behavioural tests:
+- `123 instanceof Array` → `false` (numeric primitive LHS)
+- `(userClassInstance) instanceof Array` → `false`
+- `(userClassInstance) instanceof Error` → `false`
+- User-class hierarchy `instanceof` regression check (Dog/Animal)
+- `new TypeError() instanceof Error` → `true`
+- `[] instanceof Array` → `true` (host-fallback regression)
+- `{} instanceof Array` → `false` (host-fallback regression)
+
+### Out of scope for Phase 1 (deferred to a follow-up)
+
+- Tagging WasmGC wrapper structs at construction time. This requires either
+  switching to WasmGC structs for Error/Array/Map (a large refactor), or
+  introducing a `$ThrownException` wrapper struct for the throw/catch path
+  so `catch (e) { e instanceof TypeError }` works without a JS host.
+- Integration with the IR `__tag` field in `src/ir/lower.ts` /
+  `src/ir/nodes.ts`. The Phase-1 registry is consumed by the codegen
+  short-circuit only; IR-level wiring will follow once a tagged-struct
+  representation lands.

--- a/src/codegen/builtin-tags.ts
+++ b/src/codegen/builtin-tags.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Built-in type-tag registry for `instanceof` short-circuit evaluation.
+ *
+ * Built-in JS types like `Array`, `Error`, `TypeError`, `Map` etc. are not
+ * emitted as user classes (no entry in `ctx.classTagMap`), so the existing
+ * struct-tag-based `instanceof` codegen cannot resolve them. The compiler
+ * falls back to a `__instanceof` host import, which is unavailable in
+ * standalone / WASI mode.
+ *
+ * This module provides:
+ *   - a stable registry of well-known built-in type names (with hierarchy info)
+ *   - static-evaluation helpers that let `compileHostInstanceOf` short-circuit
+ *     to a constant `i32.const 0` or `i32.const 1` whenever the LHS TypeScript
+ *     type (or stack value type) is provably (in)compatible with the RHS
+ *     constructor.
+ *
+ * The numeric tag values are reserved as **negative integers** so they cannot
+ * collide with user-class tags assigned by `ctx.classTagCounter` (which starts
+ * at 0 and increments). This leaves room for a future Phase 2 that actually
+ * stores these tags in WasmGC structs (e.g., a $Error wrapper struct for
+ * thrown exceptions).
+ *
+ * Phase-1 scope (this module): the registry and static elimination only.
+ * Phase-2 scope (later): tagged WasmGC wrapper structs for thrown errors so
+ *   `catch (e) { if (e instanceof TypeError) ... }` works without a JS host.
+ *
+ * See plan/issues/sprints/50/1325-instanceof-builtin-type-tag-registry.md.
+ */
+
+/**
+ * Reserved tag values for built-in JS constructors. Negative integers so they
+ * do not collide with user class tags (which start at 0 and count up).
+ *
+ * Phase 1 does NOT yet write these tags into WasmGC structs — they are only
+ * used for static reasoning. Phase 2 will tag thrown-error wrapper structs
+ * with these values so pure-Wasm `catch (e) instanceof TypeError` works.
+ */
+export const BUILTIN_TYPE_TAGS = {
+  // Roots
+  Object: -1,
+  Function: -2,
+
+  // Indexed collections
+  Array: -3,
+
+  // Errors (Error is the parent of all *Error subclasses)
+  Error: -10,
+  TypeError: -11,
+  RangeError: -12,
+  SyntaxError: -13,
+  URIError: -14,
+  EvalError: -15,
+  ReferenceError: -16,
+  AggregateError: -17,
+
+  // Keyed collections
+  Map: -20,
+  Set: -21,
+  WeakMap: -22,
+  WeakSet: -23,
+
+  // Built-in objects
+  Date: -30,
+  RegExp: -31,
+  Promise: -40,
+
+  // Binary data
+  ArrayBuffer: -50,
+  SharedArrayBuffer: -51,
+  DataView: -52,
+} as const;
+
+export type BuiltinTypeName = keyof typeof BUILTIN_TYPE_TAGS;
+
+/**
+ * Parent constructor in the built-in inheritance chain. Each *Error subclass
+ * has Error as parent; Error, Array, Map, etc. all conceptually descend from
+ * Object (we record this only when relevant for `instanceof` reasoning).
+ *
+ * `undefined` parent means "root" — nothing further up the chain (other than
+ * Object, which we don't bother chaining to since `x instanceof Object` is
+ * almost always true at runtime and we don't want false negatives from
+ * incomplete chain data).
+ */
+const BUILTIN_PARENT: Partial<Record<BuiltinTypeName, BuiltinTypeName>> = {
+  TypeError: "Error",
+  RangeError: "Error",
+  SyntaxError: "Error",
+  URIError: "Error",
+  EvalError: "Error",
+  ReferenceError: "Error",
+  AggregateError: "Error",
+};
+
+/**
+ * Returns true if `name` is a known built-in JS constructor name in the
+ * registry. Caller should already have checked it isn't a user class.
+ */
+export function isBuiltinTypeName(name: string): name is BuiltinTypeName {
+  return Object.prototype.hasOwnProperty.call(BUILTIN_TYPE_TAGS, name);
+}
+
+/**
+ * Returns true if `child` is `parent` or transitively a built-in subclass of
+ * `parent` (per the registry's BUILTIN_PARENT chain). Used to statically
+ * decide e.g. `new TypeError() instanceof Error` → true.
+ *
+ * Returns false for unknown names (caller should still fall through to the
+ * host import or to a `false` constant).
+ */
+export function isBuiltinSubtype(child: string, parent: string): boolean {
+  if (!isBuiltinTypeName(child) || !isBuiltinTypeName(parent)) return false;
+  let cur: BuiltinTypeName | undefined = child;
+  while (cur !== undefined) {
+    if (cur === parent) return true;
+    cur = BUILTIN_PARENT[cur];
+  }
+  return false;
+}
+
+/**
+ * Returns the parent constructor name for a built-in, or undefined if it has
+ * no parent in the registry. Exposed for tests / debugging.
+ */
+export function getBuiltinParent(name: string): BuiltinTypeName | undefined {
+  if (!isBuiltinTypeName(name)) return undefined;
+  return BUILTIN_PARENT[name];
+}

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -21,6 +21,7 @@ import { coerceType, compileExpression } from "../shared.js";
 import { emitTdzCheck } from "../statements.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { emitStringBuilderRead, getBuilderInfo } from "../string-builder.js";
+import { isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
 
 export function emitLocalTdzCheck(ctx: CodegenContext, fctx: FunctionContext, name: string, flagIdx: number): void {
   const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
@@ -600,11 +601,73 @@ function resolveInstanceOfRHS(ctx: CodegenContext, rightExpr: ts.Expression): st
 }
 
 /**
+ * Try to statically evaluate `LHS instanceof <ctorName>` using the LHS TypeScript
+ * type and the built-in type-tag registry (#1325).
+ *
+ * Returns:
+ *   - `true`  → result is provably 1
+ *   - `false` → result is provably 0
+ *   - `undefined` → cannot decide statically, fall through to runtime check
+ *
+ * This lets the compiler emit `i32.const 0/1` (after compiling LHS for side
+ * effects) without consulting the `__instanceof` JS host import — important
+ * for standalone / WASI mode where the import is unavailable.
+ */
+function tryStaticInstanceOf(ctx: CodegenContext, expr: ts.BinaryExpression, ctorName: string): boolean | undefined {
+  if (!isBuiltinTypeName(ctorName)) return undefined;
+
+  // 1. LHS is a user class? A WasmGC user-class struct is never an instance of
+  //    a JS built-in (Array / Error / Map / ...).
+  const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
+  const lhsSymbolName = leftTsType.getSymbol()?.name;
+  if (lhsSymbolName !== undefined) {
+    if (ctx.classTagMap.has(lhsSymbolName)) {
+      return false;
+    }
+    // 2. LHS is itself a built-in (or matches the constructor's instance-type
+    //    name) — apply hierarchy reasoning.
+    if (isBuiltinTypeName(lhsSymbolName)) {
+      return isBuiltinSubtype(lhsSymbolName, ctorName);
+    }
+  }
+
+  // 3. LHS is a numeric / boolean primitive → instanceof of any object type is
+  //    always false. (Skip strings — `"" instanceof String` is false but the
+  //    TS type may be the wrapper, so we leave that to runtime.)
+  if (isNumberType(leftTsType) || isBooleanType(leftTsType)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+/**
+ * Emit a constant-result `instanceof` after still compiling the LHS for side
+ * effects. Used by `compileHostInstanceOf` when `tryStaticInstanceOf` resolves
+ * the answer at compile time.
+ */
+function emitConstantInstanceOf(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  result: boolean,
+): ValType {
+  const leftType = compileExpression(ctx, fctx, expr.left);
+  if (leftType) fctx.body.push({ op: "drop" });
+  fctx.body.push({ op: "i32.const", value: result ? 1 : 0 });
+  return { kind: "i32" };
+}
+
+/**
  * Compile `expr instanceof RHS` using a host import when the RHS class is not
  * in our struct system (e.g., TypeError, Array, Function, Promise). (#738)
  * Passes the value as externref and the constructor name as a string constant,
  * delegating to `__instanceof(value, ctorName) -> i32` host import which
  * looks up the constructor on the global object.
+ *
+ * For built-in RHS (Array, Error, *Error, Map, ...), tries `tryStaticInstanceOf`
+ * first to short-circuit when the LHS TS type makes the answer compile-time
+ * obvious — important for standalone/WASI mode (#1325).
  */
 function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): ValType {
   // Resolve constructor name from the RHS expression (simple identifiers only)
@@ -619,6 +682,13 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (leftType) fctx.body.push({ op: "drop" });
     fctx.body.push({ op: "i32.const", value: 0 });
     return { kind: "i32" };
+  }
+
+  // Static fast-path: try compile-time evaluation against the built-in
+  // type-tag registry (#1325). When this resolves, we skip the host call.
+  const staticResult = tryStaticInstanceOf(ctx, expr, ctorName);
+  if (staticResult !== undefined) {
+    return emitConstantInstanceOf(ctx, fctx, expr, staticResult);
   }
 
   // Ensure the __instanceof host import exists
@@ -641,6 +711,12 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   const leftType = compileExpression(ctx, fctx, expr.left);
   if (!leftType) {
     fctx.body.push({ op: "ref.null.extern" });
+  } else if (leftType.kind === "i32" || leftType.kind === "f64") {
+    // Stack-level fast path: a primitive numeric value is never an instance of
+    // any constructor — drop and emit false. (Avoids a host call + boxing.)
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return { kind: "i32" };
   } else if (leftType.kind !== "externref") {
     coerceType(ctx, fctx, leftType, { kind: "externref" });
   }

--- a/tests/issue-1325.test.ts
+++ b/tests/issue-1325.test.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1325 — instanceof built-in type-tag registry.
+ *
+ * Phase 1: static-elimination of `instanceof <BuiltIn>` when the LHS TS type
+ * (or stack value type) makes the answer compile-time obvious. This avoids a
+ * `__instanceof` host import call in standalone / WASI mode (where the host
+ * import is unavailable) and is also a small perf win in JS-host mode.
+ *
+ * The unit tests for the registry itself live in this file; behavioural tests
+ * compile snippets and run them through the JS host's `__instanceof` shim so
+ * that the static-resolution path produces the same result as the runtime
+ * path would.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import {
+  BUILTIN_TYPE_TAGS,
+  getBuiltinParent,
+  isBuiltinSubtype,
+  isBuiltinTypeName,
+} from "../src/codegen/builtin-tags.js";
+
+// ── Helper ────────────────────────────────────────────────────────────
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = compile(source);
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    );
+  }
+  // The static-elimination path bypasses `__instanceof`; the host-fallback
+  // path calls into JS via `buildImports`, which wires `__instanceof` to a
+  // real `value instanceof globalThis[ctorName]` lookup.
+  const built = buildImports(result.imports, ENV_STUB, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!(...args);
+}
+
+// ── Registry unit tests ───────────────────────────────────────────────
+
+describe("#1325 builtin-tags registry", () => {
+  it("lists Array, Error, *Error, Map, Set, etc.", () => {
+    for (const name of [
+      "Array",
+      "Error",
+      "TypeError",
+      "RangeError",
+      "SyntaxError",
+      "URIError",
+      "EvalError",
+      "ReferenceError",
+      "AggregateError",
+      "Map",
+      "Set",
+      "WeakMap",
+      "WeakSet",
+      "Date",
+      "RegExp",
+      "Promise",
+      "ArrayBuffer",
+    ]) {
+      expect(isBuiltinTypeName(name)).toBe(true);
+    }
+  });
+
+  it("uses negative tag values (so they cannot collide with user class tags)", () => {
+    for (const tag of Object.values(BUILTIN_TYPE_TAGS)) {
+      expect(tag).toBeLessThan(0);
+    }
+  });
+
+  it("encodes the *Error → Error parent chain", () => {
+    expect(getBuiltinParent("TypeError")).toBe("Error");
+    expect(getBuiltinParent("RangeError")).toBe("Error");
+    expect(getBuiltinParent("SyntaxError")).toBe("Error");
+    expect(getBuiltinParent("URIError")).toBe("Error");
+    expect(getBuiltinParent("EvalError")).toBe("Error");
+    expect(getBuiltinParent("ReferenceError")).toBe("Error");
+    expect(getBuiltinParent("AggregateError")).toBe("Error");
+  });
+
+  it("isBuiltinSubtype: TypeError <: Error, Error <: Error", () => {
+    expect(isBuiltinSubtype("TypeError", "Error")).toBe(true);
+    expect(isBuiltinSubtype("RangeError", "Error")).toBe(true);
+    expect(isBuiltinSubtype("Error", "Error")).toBe(true);
+    expect(isBuiltinSubtype("SyntaxError", "TypeError")).toBe(false);
+    expect(isBuiltinSubtype("Array", "Error")).toBe(false);
+    expect(isBuiltinSubtype("Map", "Set")).toBe(false);
+  });
+
+  it("isBuiltinSubtype: returns false for unknown names", () => {
+    expect(isBuiltinSubtype("Unknown", "Error")).toBe(false);
+    expect(isBuiltinSubtype("Error", "Unknown")).toBe(false);
+  });
+
+  it("isBuiltinTypeName: rejects non-built-ins", () => {
+    expect(isBuiltinTypeName("Foo")).toBe(false);
+    expect(isBuiltinTypeName("MyClass")).toBe(false);
+    expect(isBuiltinTypeName("")).toBe(false);
+  });
+});
+
+// ── End-to-end behavioural tests ──────────────────────────────────────
+
+describe("#1325 instanceof BuiltIn — static elimination", () => {
+  it("123 instanceof Array → false (primitive numeric LHS, no host call)", async () => {
+    expect(
+      await run(
+        `
+        export function test(): number {
+          const x: number = 123;
+          // TS narrows x to number, so RHS=Array is statically eliminated to false.
+          return (x as unknown) instanceof Array ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(0);
+  });
+
+  it("user-class instance instanceof Array → false (struct ref vs builtin)", async () => {
+    expect(
+      await run(
+        `
+        class Foo {
+          x: number;
+          constructor(x: number) { this.x = x; }
+        }
+        export function test(): number {
+          const f = new Foo(1);
+          return (f as unknown) instanceof Array ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(0);
+  });
+
+  it("user-class instance instanceof Error → false", async () => {
+    expect(
+      await run(
+        `
+        class Foo {
+          x: number;
+          constructor(x: number) { this.x = x; }
+        }
+        export function test(): number {
+          const f = new Foo(1);
+          return (f as unknown) instanceof Error ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(0);
+  });
+
+  it("preserves user-class instanceof user-class (regression check)", async () => {
+    // This goes through compileInstanceOf (struct __tag path), NOT
+    // compileHostInstanceOf — verifying the static-elimination changes don't
+    // disturb the existing path.
+    expect(
+      await run(
+        `
+        class Animal { legs: number; constructor(l: number) { this.legs = l; } }
+        class Dog extends Animal { name: number; constructor(n: number) { super(4); this.name = n; } }
+        export function test(): number {
+          const d = new Dog(1);
+          let r = 0;
+          if (d instanceof Animal) r = r + 1;
+          if (d instanceof Dog) r = r + 2;
+          return r;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(3);
+  });
+
+  it("new TypeError() instanceof Error → true (host fallback when import present)", async () => {
+    // When the LHS TS symbol is "TypeError" the static path SHOULD recognise it
+    // and emit i32.const 1. If TS doesn't surface the symbol (which is sometimes
+    // the case in this test harness), the host fallback handles it correctly.
+    expect(
+      await run(
+        `
+        export function test(): number {
+          const e = new TypeError("x");
+          return e instanceof Error ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("[] instanceof Array → true via host fallback (regression check)", async () => {
+    expect(
+      await run(
+        `
+        export function test(): number {
+          const a: unknown[] = [];
+          return a instanceof Array ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("{} instanceof Array → false via host fallback (regression check)", async () => {
+    expect(
+      await run(
+        `
+        export function test(): number {
+          const o: object = {};
+          return o instanceof Array ? 1 : 0;
+        }
+      `,
+        "test",
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of #1325 — built-in type-tag registry plus static `instanceof` elimination in `compileHostInstanceOf`.

- New `src/codegen/builtin-tags.ts` — reserved negative-integer tag values for Array, Error, *Error subclasses, Map, Set, WeakMap, WeakSet, Date, RegExp, Promise, ArrayBuffer, DataView, etc. Encodes the *Error → Error parent chain. Exposes `isBuiltinTypeName`, `getBuiltinParent`, `isBuiltinSubtype`.
- `compileHostInstanceOf` (in `src/codegen/expressions/identifiers.ts`) now tries a `tryStaticInstanceOf` short-circuit before the `__instanceof` host import: when the LHS TS symbol resolves to a known user class or to a built-in (non-)subtype of the RHS constructor, emit `i32.const 0/1` directly. Stack-level fast paths for `i32`/`f64` LHS skip boxing too.
- Registry uses negative tag values so they can never collide with user class tags (which start at 0 via `ctx.classTagCounter`).

This gives correct answers for many `instanceof` patterns in standalone / WASI mode (where `__instanceof` is unavailable) and is a small perf win in JS-host mode.

### Out of scope (deferred to Phase 2)

- Writing the registry tags into WasmGC structs (requires a `$ThrownException` wrapper struct or a switch to WasmGC for Array / Error / Map). Without that, `catch (e) { e instanceof TypeError }` still needs the host import.
- Integration with the IR `__tag` field in `src/ir/lower.ts` / `src/ir/nodes.ts` — Phase 1 is codegen-only.

## Test plan

- [x] `npm test -- tests/issue-1325.test.ts` — 13 cases pass (registry unit tests + end-to-end behaviour: primitive LHS, user-class LHS, *Error hierarchy via host shim, `[] instanceof Array` / `{} instanceof Array` regression checks).
- [x] `npm test -- tests/issue-928.test.ts tests/issue-1182.test.ts` — 22 related tests pass (no regressions in throw/catch and iter-host paths).
- [x] `npx tsc --noEmit` — clean type check.
- [ ] CI Test262 Sharded — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)