### PR TITLE
fix(#1312): pre-register nested fn so self-reference resolves to its own closure

### DIFF
--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2755,7 +2755,22 @@ export function emitFuncRefAsClosure(
 
     // Emit: struct.new with fields: func, cap0, cap1, ..., __tdz_*..., ...
     fctx.body.push({ op: "ref.func", funcIdx: trampolineFuncIdx });
-    for (const cap of nestedCaptures) {
+    // (#1312) Self-reference inside the lifted body of `funcName` itself —
+    // e.g. `function next() { return call(next); }`. The captures are
+    // already in scope as the leading params [0..numCaptures-1] of the
+    // lifted fn (mutable captures arrive as boxed ref cells, immutable as
+    // raw values). We re-push them by param index instead of trying to
+    // dereference `cap.outerLocalIdx`, which points into a different
+    // (outer) scope and yields garbage / null when reused inside the
+    // current lifted body.
+    const isSelfRef = fctx.name === funcName;
+    for (let i = 0; i < nestedCaptures.length; i++) {
+      const cap = nestedCaptures[i]!;
+      if (isSelfRef) {
+        // Captures arrive at param index `i` in the lifted fn (#1312).
+        fctx.body.push({ op: "local.get", index: i });
+        continue;
+      }
       if (cap.mutable && cap.valType) {
         const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
         if (fctx.boxedCaptures?.has(cap.name)) {
@@ -2786,7 +2801,15 @@ export function emitFuncRefAsClosure(
     // or cross-fctx transitive) push `i32.const 1` (treat as initialized) —
     // matches pre-#1205 behavior where the lifted body had no flag check.
     if (numTdzFlags > 0) {
-      for (const cap of tdzFlaggedNested) {
+      for (let ti = 0; ti < tdzFlaggedNested.length; ti++) {
+        const cap = tdzFlaggedNested[ti]!;
+        if (isSelfRef) {
+          // (#1312) Self-reference inside the lifted body — the TDZ-flag
+          // boxed refs arrive as params at index `numCaptures + ti` (after
+          // all value captures). Re-push from there.
+          fctx.body.push({ op: "local.get", index: numCaptures + ti });
+          continue;
+        }
         const existingBox = fctx.boxedTdzFlags?.get(cap.name);
         if (existingBox) {
           fctx.body.push({ op: "local.get", index: existingBox.localIdx });

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -321,6 +321,21 @@ export function compileNestedFunctionDeclaration(
     if (savedFunc) ctx.funcStack.push(savedFunc);
     ctx.currentFunc = liftedFctx;
 
+    // (#1312) Pre-register funcMap before body compile so self-references
+    // inside the body (e.g. `function f() { return f; }` returning itself)
+    // resolve to the correct funcRefIdx via identifiers.ts:478. Same pattern
+    // as the with-captures branch below.
+    const reservedFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const reservedEntry = {
+      name: funcName,
+      typeIdx: funcTypeIdx,
+      locals: [] as Array<{ name: string; type: ValType }>,
+      body: [] as Instr[],
+      exported: false,
+    };
+    ctx.mod.functions.push(reservedEntry);
+    ctx.funcMap.set(funcName, reservedFuncIdx);
+
     // Emit default-value initialization for parameters with initializers
     emitDefaultParamInit(ctx, liftedFctx, stmt, paramTypes, 0);
 
@@ -408,15 +423,9 @@ export function compileNestedFunctionDeclaration(
     if (savedFunc) ctx.parentBodiesStack.pop();
     ctx.currentFunc = savedFunc;
 
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
-      name: funcName,
-      typeIdx: funcTypeIdx,
-      locals: liftedFctx.locals,
-      body: liftedFctx.body,
-      exported: false,
-    });
-    ctx.funcMap.set(funcName, funcIdx);
+    // (#1312) Fill in the body/locals of the slot we reserved above.
+    reservedEntry.locals = liftedFctx.locals;
+    reservedEntry.body = liftedFctx.body;
   } else {
     // Has captures — lift with captures as leading parameters, use direct call
     // For mutable captures, use ref cell types so writes propagate back
@@ -518,6 +527,44 @@ export function compileNestedFunctionDeclaration(
     if (savedFunc) ctx.funcStack.push(savedFunc);
     ctx.currentFunc = liftedFctx;
 
+    // (#1312) Pre-register `funcMap` + `nestedFuncCaptures` BEFORE compiling
+    // the body so self-references inside the body resolve correctly. Without
+    // this, `function next() { return call(next); }` falls through to the
+    // graceful `ref.null.extern` fallback in identifiers.ts because the
+    // funcMap lookup misses — and the recursive `call_ref` then null-derefs
+    // at runtime ("TypeError: Cannot access property on null or undefined").
+    //
+    // The funcIdx slot is claimed up-front by pushing a placeholder mod
+    // entry; the body and locals are filled in below after compilation.
+    // Any nested function/wrapper added during body compile pushes AFTER
+    // this slot, so the slot's POSITION in mod.functions is stable.
+    // We remember the position by saving the `mod.functions[]` entry
+    // reference itself — that's the only thing that survives unchanged
+    // across `addUnionImports` (which can grow `numImportFuncs` and so
+    // shift the absolute funcIdx, but the array entry's identity is
+    // preserved). funcMap auto-shifts during addUnionImports.
+    const reservedFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const reservedEntry = {
+      name: funcName,
+      typeIdx: funcTypeIdx,
+      locals: [] as Array<{ name: string; type: ValType }>,
+      body: [] as Instr[],
+      exported: false,
+    };
+    ctx.mod.functions.push(reservedEntry);
+    ctx.funcMap.set(funcName, reservedFuncIdx);
+    ctx.nestedFuncCaptures.set(
+      funcName,
+      captures.map((c) => ({
+        name: c.name,
+        outerLocalIdx: c.localIdx,
+        mutable: c.mutable,
+        valType: c.type,
+        hasTdzFlag: c.hasTdzFlag,
+        outerTdzFlagIdx: c.tdzFlagIdx,
+      })),
+    );
+
     // Emit default-value initialization for parameters with initializers
     // (offset by number of captures since they are prepended as leading params)
     emitDefaultParamInit(ctx, liftedFctx, stmt, paramTypes, captures.length);
@@ -607,30 +654,13 @@ export function compileNestedFunctionDeclaration(
     if (savedFunc) ctx.parentBodiesStack.pop();
     ctx.currentFunc = savedFunc;
 
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
-      name: funcName,
-      typeIdx: funcTypeIdx,
-      locals: liftedFctx.locals,
-      body: liftedFctx.body,
-      exported: false,
-    });
-    ctx.funcMap.set(funcName, funcIdx);
-
-    // Store capture info so call sites prepend captured values
-    ctx.nestedFuncCaptures.set(
-      funcName,
-      captures.map((c) => ({
-        name: c.name,
-        outerLocalIdx: c.localIdx,
-        mutable: c.mutable,
-        valType: c.type,
-        // #1205 Stage 3: capture-time TDZ-flag metadata so the call site can
-        // mirror the construct-time flag-prepend (see calls.ts cap-prepend loop).
-        hasTdzFlag: c.hasTdzFlag,
-        outerTdzFlagIdx: c.tdzFlagIdx,
-      })),
-    );
+    // (#1312) Fill in the body/locals of the slot we reserved above. funcMap
+    // and nestedFuncCaptures were already registered before body compile so
+    // self-references inside the body resolved correctly. Use the saved
+    // entry reference instead of recomputing the index — `addUnionImports`
+    // may have shifted `ctx.numImportFuncs` since registration.
+    reservedEntry.locals = liftedFctx.locals;
+    reservedEntry.body = liftedFctx.body;
   }
 }
 

--- a/tests/issue-1312.test.ts
+++ b/tests/issue-1312.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1312 — recursive function passed as a parameter (compose pattern) failed
+// with "TypeError: Cannot access property on null or undefined" in the inner
+// recursive call.
+//
+// Root cause: nested function declarations were registered in `funcMap` AFTER
+// their body finished compiling. References to the function inside its own
+// body (e.g. `function next() { return call(next); }`) reached the funcMap
+// lookup in `compileIdentifier`, missed (because the entry didn't exist yet),
+// and fell through to the graceful `ref.null.extern` fallback. The compiled
+// wasm then called `call(ref.null extern)`, which null-derefed.
+//
+// In the captures-having branch, even after pre-registering, the closure
+// materialization at `emitFuncRefAsClosure` would try to source captures via
+// `cap.outerLocalIdx` — a local index in the OUTER (declaring) scope. From
+// inside the lifted function's own body that index points to a different
+// local, producing garbage / null captures.
+//
+// Fix (src/codegen/statements/nested-declarations.ts +
+// src/codegen/closures.ts):
+// 1. Pre-register `funcMap` and `nestedFuncCaptures` BEFORE compiling the
+//    nested function's body, by reserving a placeholder `mod.functions[]`
+//    entry up-front and filling in `body`/`locals` after the compile.
+// 2. In `emitFuncRefAsClosure`, when materializing a self-reference (i.e.
+//    `fctx.name === funcName`), source captures from the lifted fn's own
+//    leading params (indices `[0..numCaptures-1]` for value captures and
+//    `[numCaptures..]` for TDZ-flag boxes) instead of `cap.outerLocalIdx`.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface RunResult {
+  exports: Record<string, Function>;
+}
+
+async function run(source: string): Promise<RunResult> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  new WebAssembly.Module(r.binary);
+  const imports: any = buildImports(r.imports as never, undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(inst.instance.exports);
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+describe("#1312 — recursive nested fn passed-as-param self-references its own closure", () => {
+  /**
+   * Tier 5c-shaped sync compose. `next` captures `i` (mutable ref-cell),
+   * recursively passes itself through `mw(c, next)`. The middleware
+   * receives `next` and calls it again. Each call advances `i` and the
+   * pipeline terminates at `i >= length`. Output is constructed by
+   * string concatenation across the recursion levels.
+   */
+  it("sync compose with two arrow middlewares produces ordered output", async () => {
+    const { exports } = await run(`
+      class Context {
+        path: string;
+        constructor(p: string) { this.path = p; }
+      }
+      type N = () => string;
+      type Mw = (c: Context, n: N) => string;
+
+      function compose(mws: Mw[]): (c: Context) => string {
+        return (c: Context) => {
+          let i = 0;
+          function next(): string {
+            const idx = i;
+            i = i + 1;
+            if (idx >= mws.length) return "end";
+            const mw = mws[idx];
+            return mw(c, next);
+          }
+          return next();
+        };
+      }
+
+      export function test(): string {
+        const mws: Mw[] = [
+          (c, n) => "[A]" + n(),
+          (c, n) => "[B]" + n(),
+        ];
+        return compose(mws)(new Context("/x"));
+      }
+    `);
+    expect(exports.test!()).toBe("[A][B]end");
+  });
+
+  /**
+   * Async version of the same compose pattern. Each middleware awaits
+   * `next()` so the recursion threads through Promise resolution.
+   */
+  it("async compose with two arrow middlewares produces ordered output", async () => {
+    const { exports } = await run(`
+      class Context {
+        path: string;
+        constructor(p: string) { this.path = p; }
+      }
+      type N = () => Promise<string>;
+      type Mw = (c: Context, n: N) => Promise<string>;
+
+      function compose(mws: Mw[]): (c: Context) => Promise<string> {
+        return async (c: Context) => {
+          let i = 0;
+          async function next(): Promise<string> {
+            const idx = i;
+            i = i + 1;
+            if (idx >= mws.length) return "end";
+            const mw = mws[idx];
+            return await mw(c, next);
+          }
+          return await next();
+        };
+      }
+
+      export async function test(): Promise<string> {
+        const mws: Mw[] = [
+          async (c, n) => "[A]" + await n(),
+          async (c, n) => "[B]" + await n(),
+        ];
+        return await compose(mws)(new Context("/x"));
+      }
+    `);
+    const v = await exports.test!();
+    expect(v).toBe("[A][B]end");
+  });
+
+  /**
+   * Minimal async self-recursion that DOES NOT pass `next` as a parameter
+   * (named recursion via direct call). This already worked pre-fix and
+   * must keep working.
+   */
+  it("regression guard: direct named async recursion still works", async () => {
+    const { exports } = await run(`
+      async function f(n: number): Promise<number> {
+        if (n <= 0) return 0;
+        return n + await f(n - 1);
+      }
+      export async function test(): Promise<number> {
+        return await f(3);
+      }
+    `);
+    const v = await exports.test!();
+    expect(v).toBe(6);
+  });
+
+  /**
+   * Inner recursive function with mutable ref-cell capture, passed as
+   * parameter to a sibling function that calls it. This is the synchronous
+   * sibling of the compose pattern; before #1312 it returned 0 because
+   * the recursion's closure had a stale (zero-initialised) ref-cell
+   * instead of the live outer one.
+   */
+  it("sync inner recursion via param with mutable ref-cell capture", async () => {
+    const { exports } = await run(`
+      type N = () => number;
+      function call(fn: N): number {
+        return fn();
+      }
+      export function test(): number {
+        let counter = 3;
+        function next(): number {
+          counter = counter - 1;
+          if (counter < 0) return 0;
+          return 1 + call(next);
+        }
+        return next();
+      }
+    `);
+    // counter: 3 → 2 → 1 → 0 → -1; recurses 3 times before base case
+    // returns 1 + 1 + 1 + 0 = 3
+    expect(exports.test!()).toBe(3);
+  });
+
+  /**
+   * Same shape as the previous case but async (the headline #1312
+   * reproducer minus the middleware indirection). Verifies the bug isn't
+   * reintroduced via the async lowering.
+   */
+  it("async inner recursion via param with mutable ref-cell capture", async () => {
+    const { exports } = await run(`
+      type N = () => Promise<number>;
+      async function call(fn: N): Promise<number> {
+        return await fn();
+      }
+      export async function test(): Promise<number> {
+        let counter = 3;
+        async function next(): Promise<number> {
+          counter = counter - 1;
+          if (counter < 0) return 0;
+          return 1 + await call(next);
+        }
+        return await next();
+      }
+    `);
+    const v = await exports.test!();
+    expect(v).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Recursive nested function declarations passed as a parameter (the Hono `compose` pattern's `function next() { ... return mw(c, next); }`) failed with `TypeError: Cannot access property on null or undefined`. The recursive `next` self-reference inside `next`'s own body fell through to the graceful `ref.null.extern` fallback in `identifiers.ts` — and the compiled wasm called `call(ref.null extern)` which null-derefed.

Two converging gaps:

1. **`funcMap` registered too late.** `compileNestedFunctionDeclaration` (nested-declarations.ts) registered `funcMap[funcName]` and `nestedFuncCaptures[funcName]` AFTER compiling the body. References to the function inside its own body missed the lookup at `identifiers.ts:478` and emitted `ref.null.extern`.

2. **Self-reference captures sourced from wrong scope.** Even after pre-registering, `emitFuncRefAsClosure` (closures.ts:2647) materialized the closure struct's capture fields by reading `local.get cap.outerLocalIdx` — a local index in the OUTER (declaring) scope. From inside the lifted function's own body that index points to a different local, so recursive calls saw a stale (zero-initialised) ref-cell instead of the live outer one. Probe10 (`let counter = 3; function next() { counter = counter - 1; ...; return 1 + call(next); }`) returned 0 instead of 3.

## Fix

- Reserve a placeholder `mod.functions[]` entry for the nested function BEFORE compiling its body. Set `funcMap` + `nestedFuncCaptures` immediately. Fill in `body`/`locals` after the compile via the saved entry reference (so `addUnionImports`' index-shift doesn't desync the slot). Symmetrical change in both branches of `compileNestedFunctionDeclaration` (with-captures + no-captures).
- In `emitFuncRefAsClosure`, when the lifted fn's own body references itself (`fctx.name === funcName`), source captures from the leading params at indices `[0..numCaptures-1]` for value captures and `[numCaptures..numCaptures+numTdzFlags-1]` for TDZ-flag boxes — matching the lifted fn's parameter layout. The captures arrive as boxed ref-cells / raw values that can be re-pushed unchanged into the new self-closure struct, preserving the live mutation state.

## Test plan

- [x] `tests/issue-1312.test.ts` — 5 cases all pass:
  - sync compose with two arrow middlewares produces `"[A][B]end"`
  - async compose with two arrow middlewares produces `"[A][B]end"`
  - regression guard: direct named async recursion still works
  - sync inner-recursion via param with mutable ref-cell capture returns 3
  - async inner-recursion via param with mutable ref-cell capture returns 3
- [x] Non-regression sweep (30 / 30 pass): `tests/stress/hono-tier5.test.ts`, `tests/stress/hono-tier6.test.ts`, `tests/stress/lodash-tier2.test.ts`, `tests/issue-1283.test.ts`, `tests/issue-1306.test.ts`, `tests/issue-1308.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)