### PR TITLE
feat(#1322): wire Math.random() to WASI random_get in standalone mode

### DIFF
--- a/plan/issues/sprints/50/1322-math-random-wasi-random-get.md
+++ b/plan/issues/sprints/50/1322-math-random-wasi-random-get.md
@@ -2,7 +2,7 @@
 id: 1322
 sprint: 50
 title: "Math.random() has no standalone fallback — requires JS host import in WASI/standalone mode"
-status: ready
+status: in-progress
 created: 2026-05-07
 updated: 2026-05-07
 priority: low
@@ -46,3 +46,45 @@ from a module-level global is acceptable.
 - WASI import already present: `fd_write` etc. are in `src/codegen/index.ts` around the
   WASI import block; add `random_get` alongside them
 - `tests/issue-1322.test.ts` — basic range + non-constant check
+
+## Implementation (dev-a)
+
+Three files touched:
+1. `src/codegen/index.ts` — `registerWasiImports`: scan source for
+   `Math.random()` calls; if found, register `wasi_snapshot_preview1.random_get`
+   import EARLY (before any defined helpers) so the late-import shift bug
+   doesn't break `__str_*` indices.
+2. `src/codegen/index.ts` + `src/codegen/declarations.ts` — `collectMathImports`
+   finalize: in WASI mode, route `random` to `pendingMathMethods` (so
+   `emitInlineMathFunctions` emits `Math_random` as a defined function).
+   In JS-host mode, keep the `env.Math_random` host import unchanged.
+3. `src/codegen/math-helpers.ts` — `emitInlineMathFunctions`: emit
+   `Math_random` as a defined function. Calls `random_get(64, 8)`,
+   reads back two `i32.load`s (low + high), combines via
+   `i64.extend_i32_u + i64.shl + i64.or`, shifts right 11 to mask to
+   53 unsigned bits, converts via `f64.convert_i64_s` (the value
+   already fits in 53 bits, so `_s` is correct), and multiplies by 2⁻⁵³.
+
+The IR doesn't include `i64.load` or `f64.convert_i64_u`, hence the
+two-`i32.load` decomposition and the `_s` convert. Memory offset 64
+is used for the entropy buffer — well within the 1024-byte reserved
+prefix that `registerWasiImports` already sets up via the bump pointer
+initial value.
+
+The xorshift64 fallback for "non-WASI standalone" is deferred — there
+is no separate non-WASI standalone target today (`gc`/`linear`/`wasi`
+are the three targets, and only `wasi` is JS-host-free). When a
+genuine pure-Wasm-no-WASI mode lands, the same `Math_random` function
+slot can be filled with the xorshift64 body.
+
+## Test Results
+
+`tests/issue-1322.test.ts` — 6 tests, all pass:
+
+- returns a float in [0, 1) (50 samples)
+- repeated calls return distinct values (>15 unique in 20 samples)
+- `Math.floor(Math.random() * 6)` covers all 6 dice faces in 600 trials
+- WASI binary imports `wasi_snapshot_preview1.random_get` (NOT `env.Math_random`)
+- JS-host regression guard: `env.Math_random` remains the host import path
+- regression guard: `Math.random` alongside `Math.sin`/`Math.cos` doesn't
+  break the shared `pendingMathMethods` collection

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -906,8 +906,17 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // ── collectMathImports finalize ──
   for (const method of state.mathNeeded) {
     if (method === "random") {
-      const typeIdx = addFuncType(ctx, [], [{ kind: "f64" }]);
-      addImport(ctx, "env", `Math_${method}`, { kind: "func", typeIdx });
+      // #1322: in WASI/standalone mode, emit a Wasm `Math_random` that calls
+      // WASI `random_get(ptr, 8)` for entropy. The `random_get` import was
+      // already registered EARLY by registerWasiImports (before any defined
+      // functions) so adding it here doesn't shift indices of helpers like
+      // `__str_copy_tree`.
+      if (ctx.wasi) {
+        ctx.pendingMathMethods.add(method);
+      } else {
+        const typeIdx = addFuncType(ctx, [], [{ kind: "f64" }]);
+        addImport(ctx, "env", `Math_${method}`, { kind: "func", typeIdx });
+      }
     } else {
       ctx.pendingMathMethods.add(method);
     }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2754,6 +2754,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // Check if source uses console.log/warn/error, process.exit, or node:fs functions
   let needsFdWrite = false;
   let needsProcExit = false;
+  let needsRandomGet = false;
 
   // ctx.wasiNodeFsFuncs is populated from the original source before import preprocessing
   // (see detectNodeFsImports in compiler.ts)
@@ -2775,6 +2776,14 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
         propAccess.name.text === "exit"
       ) {
         needsProcExit = true;
+      }
+      // #1322: Math.random() in WASI mode uses random_get for entropy
+      if (
+        ts.isIdentifier(propAccess.expression) &&
+        propAccess.expression.text === "Math" &&
+        propAccess.name.text === "random"
+      ) {
+        needsRandomGet = true;
       }
     }
     forEachChild(node, visit);
@@ -2801,6 +2810,15 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     const procExitType = addFuncType(ctx, [{ kind: "i32" }], [], "$wasi_proc_exit");
     addImport(ctx, "wasi_snapshot_preview1", "proc_exit", { kind: "func", typeIdx: procExitType });
     ctx.wasiProcExitIdx = ctx.funcMap.get("proc_exit")!;
+  }
+
+  // #1322: random_get(buf_ptr: i32, buf_len: i32) -> errno (i32)
+  // Used by `Math_random` (emitted in math-helpers.ts:emitInlineMathFunctions).
+  // Registered HERE — before any defined helpers — so the late-import shift
+  // bug (CLAUDE.md "addUnionImports" note) doesn't break `__str_*` indices.
+  if (needsRandomGet) {
+    const randomGetType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], "$wasi_random_get");
+    addImport(ctx, "wasi_snapshot_preview1", "random_get", { kind: "func", typeIdx: randomGetType });
   }
 
   // path_open(fd: i32, dirflags: i32, path: i32, path_len: i32, oflags: i32,
@@ -3719,9 +3737,15 @@ function collectMathImports(ctx: CodegenContext, sourceFile: ts.SourceFile): voi
 
   for (const method of needed) {
     if (method === "random") {
-      // Math.random requires entropy — must remain a host import
-      const typeIdx = addFuncType(ctx, [], [{ kind: "f64" }]);
-      addImport(ctx, "env", `Math_${method}`, { kind: "func", typeIdx });
+      // #1322: in WASI/standalone mode, route random through WASI random_get
+      // (the import is registered early by registerWasiImports). In JS-host
+      // mode keep the host import.
+      if (ctx.wasi) {
+        ctx.pendingMathMethods.add(method);
+      } else {
+        const typeIdx = addFuncType(ctx, [], [{ kind: "f64" }]);
+        addImport(ctx, "env", `Math_${method}`, { kind: "func", typeIdx });
+      }
     } else {
       // All other math methods get pure Wasm implementations
       ctx.pendingMathMethods.add(method);

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -127,6 +127,73 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
     return idx;
   }
 
+  // ─── Math.random ──────────────────────────────────────────────────
+  // #1322: WASI/standalone path. Uses `wasi_snapshot_preview1.random_get`
+  // (registered as an import in declarations.ts:collectMathImports finalize)
+  // to fill 8 bytes of linear memory, reads them as i64, masks to 53 bits,
+  // and multiplies by 2^-53 to produce a float in [0, 1).
+  //
+  // The scratch buffer lives at memory offset 64 — well inside the
+  // 1024-byte reserved area registerWasiImports sets aside via the
+  // bump pointer (which initialises to 1024). offsets 0..15 are used by
+  // __wasi_write_string for iovec/nwritten; we pick 64 to stay clear of
+  // any future stdout/stderr work.
+  if (needed.has("random")) {
+    const randomGetIdx = ctx.funcMap.get("random_get");
+    if (randomGetIdx === undefined) {
+      // collectMathImports / collectMathImports-finalize should have registered
+      // it before we got here. If missing, fall back to a constant 0 — better
+      // than crashing in instantiation, and the test suite will catch it.
+      addMathFunc({
+        name: "Math_random",
+        params: [],
+        results: f64Result,
+        locals: [],
+        body: [f64c(0)],
+      });
+    } else {
+      // The IR doesn't include `i64.load`, so we read 8 bytes as TWO `i32.load`s
+      // (low half at offset 0, high half at offset 4), zero-extend each to i64,
+      // and combine as `(hi << 32) | lo`. Then shift right 11 to keep the upper
+      // 53 significant bits and multiply by 2^-53 → uniform float in [0, 1).
+      addMathFunc({
+        name: "Math_random",
+        params: [],
+        results: f64Result,
+        locals: [],
+        body: [
+          // random_get(ptr=64, len=8) — fills memory[64..72] with entropy
+          i32const(64),
+          i32const(8),
+          { op: "call", funcIdx: randomGetIdx } as Instr,
+          { op: "drop" } as Instr, // ignore errno (best-effort)
+          // Low 32 bits: i64.extend_i32_u(i32.load offset=0 align=2)
+          i32const(64),
+          { op: "i32.load", offset: 0, align: 2 } as Instr,
+          { op: "i64.extend_i32_u" } as Instr,
+          // High 32 bits: i64.extend_i32_u(i32.load offset=4) << 32
+          i32const(64),
+          { op: "i32.load", offset: 4, align: 2 } as Instr,
+          { op: "i64.extend_i32_u" } as Instr,
+          { op: "i64.const", value: 32n } as Instr,
+          { op: "i64.shl" } as Instr,
+          // OR low + high
+          { op: "i64.or" } as Instr,
+          // Shift right 11 → keep upper 53 bits in unsigned i64
+          { op: "i64.const", value: 11n } as Instr,
+          { op: "i64.shr_u" } as Instr,
+          // Convert to f64 and multiply by 2^-53. After `shr_u 11` the value
+          // fits in 53 unsigned bits (max ~9e15), so `convert_i64_s` (which the
+          // backend supports — `convert_i64_u` is not in the IR union) gives
+          // an identical result.
+          { op: "f64.convert_i64_s" } as Instr,
+          f64c(1 / 9007199254740992), // 2^-53
+          mul,
+        ],
+      });
+    }
+  }
+
   // Determine which core functions we need based on what's requested
   const needSinCos = needed.has("sin") || needed.has("cos") || needed.has("tan");
   const needExp =

--- a/tests/issue-1322.test.ts
+++ b/tests/issue-1322.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1322 — `Math.random()` has no standalone fallback.
+ *
+ * Pre-fix `Math.random` was always emitted as a `(import "env" "Math_random"
+ * (func ... result f64))` host import. In `--target wasi` mode this either
+ * crashed at instantiation (if the import was missing) or returned the
+ * stub host's `0` (when a host did provide a default). Neither outcome is
+ * spec-conformant.
+ *
+ * Fix: in `--target wasi` mode, emit a Wasm `Math_random` function that:
+ *   1. calls `wasi_snapshot_preview1.random_get(ptr=64, len=8)` to fill 8
+ *      bytes of linear memory with entropy
+ *   2. reads the bytes back as a `(hi << 32) | lo` i64 pair
+ *   3. shifts right 11 to keep the upper 53 significant bits
+ *   4. multiplies by 2⁻⁵³ to land in `[0, 1)`
+ *
+ * The `random_get` import is registered EARLY (in `registerWasiImports`)
+ * before any defined helper functions are emitted, so the late-import
+ * shift bug (CLAUDE.md "addUnionImports" note) doesn't reorder
+ * `__str_*` indices and break their `call N` instructions.
+ *
+ * JS-host mode (no `--target wasi`) is unchanged — `env.Math_random` is
+ * still the host-import path.
+ */
+
+/**
+ * Compile in WASI mode and instantiate with a Node-side `random_get`
+ * implementation that fills the requested buffer with PRNG bytes derived
+ * from `Math.random` (sufficient for spec-conformance — the JS-side PRNG
+ * stands in for the OS entropy source a real WASI runtime would use).
+ */
+async function runWasi(src: string): Promise<{ exports: Record<string, unknown>; memory: WebAssembly.Memory }> {
+  const r = compile(src, { fileName: "t.ts", target: "wasi" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // Allow the import callback to look up the exported memory after
+  // instantiation (JS scope binding — the closure captures `state`,
+  // not the not-yet-existent `instance.exports.memory`).
+  const state: { memory: WebAssembly.Memory | null } = { memory: null };
+  const imports = {
+    wasi_snapshot_preview1: {
+      random_get: (ptr: number, len: number): number => {
+        const view = new Uint8Array(state.memory!.buffer);
+        for (let i = 0; i < len; i++) view[ptr + i] = Math.floor(Math.random() * 256);
+        return 0;
+      },
+    },
+  };
+  const m = await WebAssembly.compile(r.binary);
+  const inst = await WebAssembly.instantiate(m, imports);
+  state.memory = inst.exports.memory as WebAssembly.Memory;
+  return { exports: inst.exports as Record<string, unknown>, memory: state.memory };
+}
+
+describe("#1322 — Math.random() in WASI mode uses random_get", () => {
+  it("returns a float in [0, 1)", async () => {
+    const { exports } = await runWasi(`
+      export function r(): number { return Math.random(); }
+    `);
+    for (let i = 0; i < 50; i++) {
+      const v = (exports.r as () => number)();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("repeated calls return different values (not constant 0)", async () => {
+    const { exports } = await runWasi(`
+      export function r(): number { return Math.random(); }
+    `);
+    const seen = new Set<number>();
+    for (let i = 0; i < 20; i++) seen.add((exports.r as () => number)());
+    // With ~53 bits of entropy each call, all 20 should be distinct
+    expect(seen.size).toBeGreaterThan(15);
+  });
+
+  it("Math.floor(Math.random() * N) lands in [0, N)", async () => {
+    const { exports } = await runWasi(`
+      export function dice(): number { return Math.floor(Math.random() * 6); }
+    `);
+    const counts = new Array(6).fill(0);
+    for (let i = 0; i < 600; i++) {
+      const v = (exports.dice as () => number)();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(6);
+      expect(Number.isInteger(v)).toBe(true);
+      counts[v]++;
+    }
+    // Each face should hit at least once over 600 trials (extremely
+    // conservative; the expected hit count per face is ~100).
+    for (const c of counts) expect(c).toBeGreaterThan(0);
+  });
+
+  it("WASI binary imports `wasi_snapshot_preview1.random_get` (not `env.Math_random`)", async () => {
+    const r = compile(
+      `
+      export function r(): number { return Math.random(); }
+    `,
+      { fileName: "t.ts", target: "wasi" },
+    );
+    expect(r.success).toBe(true);
+    const m = await WebAssembly.compile(r.binary);
+    const decls = WebAssembly.Module.imports(m);
+    const names = decls.map((d) => `${d.module}.${d.name}`);
+    expect(names).toContain("wasi_snapshot_preview1.random_get");
+    // The host import must NOT be present in WASI mode
+    expect(names).not.toContain("env.Math_random");
+  });
+
+  it("JS-host mode regression guard: env.Math_random remains the path (no random_get)", async () => {
+    // Default target (gc) keeps the host import. Don't instantiate — just
+    // verify the import shape is unchanged from pre-fix behavior.
+    const r = compile(
+      `
+      export function r(): number { return Math.random(); }
+    `,
+      { fileName: "t.ts" },
+    );
+    expect(r.success).toBe(true);
+    const m = await WebAssembly.compile(r.binary);
+    const decls = WebAssembly.Module.imports(m);
+    const names = decls.map((d) => `${d.module}.${d.name}`);
+    expect(names).toContain("env.Math_random");
+    expect(names).not.toContain("wasi_snapshot_preview1.random_get");
+  });
+
+  it("Math.random alongside other Math methods (regression guard for shared registry)", async () => {
+    // Verify that the shared `pendingMathMethods` collection is not
+    // disturbed when `random` is added — sin/cos still inline correctly.
+    const { exports } = await runWasi(`
+      export function trig(x: number): number { return Math.sin(x) + Math.cos(x); }
+      export function r(): number { return Math.random(); }
+    `);
+    // sin(0) + cos(0) = 0 + 1 = 1
+    expect((exports.trig as (x: number) => number)(0)).toBeCloseTo(1, 10);
+    const v = (exports.r as () => number)();
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Eliminates the only remaining `env.Math_*` host import in `--target wasi` mode
- `Math.random()` in WASI mode now calls `wasi_snapshot_preview1.random_get` for entropy and produces a uniform float in `[0, 1)`
- JS-host mode (default) is unchanged — `env.Math_random` remains the host import

## Implementation

Three files touched:
1. `src/codegen/index.ts` — `registerWasiImports` now scans the source for `Math.random()` calls and registers `wasi_snapshot_preview1.random_get` early (BEFORE any defined helpers). This avoids the late-import-shift bug described in CLAUDE.md's `addUnionImports` note (which broke `__str_*` `call N` indices in my first attempt).
2. `src/codegen/index.ts` + `src/codegen/declarations.ts` — `collectMathImports` finalize: in WASI mode, route `random` to `pendingMathMethods` (so `emitInlineMathFunctions` emits `Math_random` as a defined function). In JS-host mode, keep the `env.Math_random` import.
3. `src/codegen/math-helpers.ts` — `emitInlineMathFunctions` emits `Math_random`:
   - calls `random_get(64, 8)` to fill 8 bytes at memory[64..72]
   - reads back via two `i32.load`s + `i64.extend_i32_u + i64.shl + i64.or` (the IR has no `i64.load`)
   - shifts right 11 to keep upper 53 unsigned bits
   - converts via `f64.convert_i64_s` (the IR has no `convert_i64_u`; the value already fits in 53 bits, so `_s` is correct)
   - multiplies by 2⁻⁵³

The xorshift64 fallback for "non-WASI standalone" mentioned in the issue is deferred — there is no separate non-WASI standalone target today; only `gc`, `linear`, and `wasi` exist, and only `wasi` is JS-host-free.

## Test plan

- [x] `tests/issue-1322.test.ts` (6 tests, all pass):
  - value in [0, 1) over 50 samples
  - distinct values across 20 calls (>15 unique)
  - `Math.floor(Math.random() * 6)` covers all 6 dice faces in 600 trials
  - WASI binary contains `wasi_snapshot_preview1.random_get`, NOT `env.Math_random`
  - JS-host regression guard: `env.Math_random` remains
  - `Math.random` alongside `Math.sin`/`Math.cos` doesn't disturb the shared registry
- [x] `tests/issue-1210.test.ts` (10 tests, all pass) — WASI string-builder regression coverage
- [x] `tests/issue-1270.test.ts`, `tests/issue-258.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)