### PR TITLE
fix(codegen #1311): class-method param forwarding loses closure-struct identity

### DIFF
--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1000,9 +1000,51 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
         // Fall through to host-callback path on any checker error
       }
     }
-    // For method calls (property access), check if the method is known array HOF
-    // (filter, map, etc.) — those have dedicated inline compilation and ARE handled
-    // as closure calls. For other property accesses, treat as host callback.
+    // For method calls (property access), check if the method is on a
+    // user-defined class. User-defined methods receive the closure as the
+    // GC-struct shape (`__fn_wrap_N_struct`) and may store it for later
+    // dispatch (e.g. `app.routes.set(path, handler)`). Routing through
+    // `__make_callback` here produces a JS-wrapped externref that fails the
+    // dispatch-site `ref.cast` and null-derefs at `struct.get`. (#1311)
+    if (ts.isPropertyAccessExpression(parent.expression)) {
+      const propAccess = parent.expression;
+      const methodName = propAccess.name.text;
+      try {
+        const receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
+        // Search the receiver type's symbol chain for a class name that
+        // matches a user-defined method `${ClassName}_${methodName}`. We
+        // check both the receiver's own symbol (instance methods) and the
+        // type itself (handles `(typeof Foo).method` for statics).
+        const candidates = new Set<string>();
+        const recSym = receiverType.getSymbol?.();
+        const recName = recSym?.getName?.();
+        if (recName) candidates.add(recName);
+        // Walk base types so inherited user-defined methods are detected
+        const baseTypes = receiverType.getBaseTypes?.();
+        if (baseTypes) {
+          for (const bt of baseTypes) {
+            const bs = bt.getSymbol?.()?.getName?.();
+            if (bs) candidates.add(bs);
+          }
+        }
+        for (const className of candidates) {
+          const fullName = `${className}_${methodName}`;
+          const funcIdx = ctx.funcMap.get(fullName);
+          if (funcIdx !== undefined && funcIdx >= ctx.numImportFuncs) {
+            // User-defined method on a user-defined class — closure path
+            return false;
+          }
+        }
+        // Note: we deliberately don't fall back to a "param has call sig"
+        // heuristic for non-user-defined methods — host array HOFs
+        // (forEach, map, filter, etc.) have dedicated inline compilation
+        // and other host method callbacks (Promise.then, etc.) need a
+        // JS-callable externref via __make_callback. Only user-defined
+        // methods on user-defined classes get the closure path here.
+      } catch {
+        // Fall through to host-callback path on any checker error
+      }
+    }
     return true;
   }
   // NewExpression: `new Promise(executor)`, `new Map(comparator)`, etc.

--- a/tests/issue-1311.test.ts
+++ b/tests/issue-1311.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #1311 — Class-method param forwarding loses closure-struct identity.
+ *
+ * When an arrow is passed as an argument to a user-defined class method
+ * (e.g. `app.set(() => ...)`), the codegen at the call site lowered the
+ * arrow through the host `__make_callback` path instead of the WasmGC
+ * `__fn_wrap_N_struct` closure path. The receiving method body —
+ * `this.h = handler` — stored that JS-wrapped externref into a field
+ * typed as a function value. A later `this.h()` call site converted the
+ * externref to anyref and tried `ref.test (ref __fn_wrap_*)`. The cast
+ * failed, the result was null, and `return_call_ref` on the null funcref
+ * trapped with "dereferencing a null pointer".
+ *
+ * Bisect found three shapes:
+ *   - free fn `setHandler(obj, fn) { obj.h = fn; }`     → works (closure path)
+ *   - class method literal-assign `set() { this.h = arrow; }` → works
+ *   - class method param-forward `set(fn) { this.h = fn; }` → FAILED
+ *
+ * Surfaced by the Hono Tier 6a probe `Map<string, AsyncHandler>` pattern.
+ *
+ * Fix: in `isHostCallbackArgument` (src/codegen/closures.ts), detect when
+ * the call target is a `PropertyAccessExpression` whose method resolves to
+ * a user-defined class method (via the receiver's static type and base
+ * types), and route to the closure path. Built-in receiver types (Array,
+ * Map, Promise, etc.) won't have entries in `funcMap` so they continue to
+ * use the host-callback path.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("issue #1311 — class method arrow-param forwarding", () => {
+  it("class method assigning function param to field then invoking", async () => {
+    const source = `
+class App {
+  h: (() => number) | null = null;
+  set(handler: () => number): void {
+    this.h = handler;
+  }
+  call(): number {
+    if (this.h == null) return -1;
+    return this.h();
+  }
+}
+
+export function test(): number {
+  const app = new App();
+  app.set(() => 42);
+  return app.call();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(42);
+  });
+
+  it("inherited class method receives arrow argument via closure path", async () => {
+    const source = `
+class Base {
+  h: (() => number) | null = null;
+  set(handler: () => number): void {
+    this.h = handler;
+  }
+}
+
+class Child extends Base {
+  call(): number {
+    if (this.h == null) return -1;
+    return this.h();
+  }
+}
+
+export function test(): number {
+  const c = new Child();
+  c.set(() => 42);
+  return c.call();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(42);
+  });
+
+  it("Map<string, sync handler> via class method", async () => {
+    const source = `
+type Handler = () => number;
+
+class App {
+  routes: Map<string, Handler> = new Map();
+  add(key: string, h: Handler): void {
+    this.routes.set(key, h);
+  }
+  call(key: string): number {
+    const h = this.routes.get(key);
+    if (h == null) return -1;
+    return h();
+  }
+}
+
+export function test(): number {
+  const app = new App();
+  app.add("/hello", () => 42);
+  return app.call("/hello");
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(42);
+  });
+
+  it("Map<string, async handler> Hono-shape", async () => {
+    const source = `
+class Context {
+  path: string;
+  constructor(path: string) { this.path = path; }
+  text(s: string): string { return s; }
+}
+
+type Handler = (c: Context) => Promise<string>;
+
+class App {
+  routes: Map<string, Handler> = new Map();
+
+  get(path: string, handler: Handler): App {
+    this.routes.set(path, handler);
+    return this;
+  }
+
+  async dispatch(path: string): Promise<string> {
+    const handler = this.routes.get(path);
+    if (handler == null) return "404";
+    return await handler(new Context(path));
+  }
+}
+
+export async function test(): Promise<string> {
+  const app = new App();
+  app.get("/hello", async (c: Context) => c.text("world"));
+  return await app.dispatch("/hello");
+}
+`;
+    const exports = await compileToWasm(source);
+    const result = await exports.test!();
+    expect(result).toBe("world");
+  });
+
+  it("mixed sync + async handlers in Map via class method", async () => {
+    const source = `
+type Handler = () => Promise<number>;
+
+class App {
+  routes: Map<string, Handler> = new Map();
+  add(key: string, h: Handler): void { this.routes.set(key, h); }
+  async call(key: string): Promise<number> {
+    const h = this.routes.get(key);
+    if (h == null) return -1;
+    return await h();
+  }
+}
+
+export async function test(): Promise<number> {
+  const app = new App();
+  app.add("a", async () => 1);
+  app.add("b", async () => 2);
+  const a = await app.call("a");
+  const b = await app.call("b");
+  return a + b;
+}
+`;
+    const exports = await compileToWasm(source);
+    const result = await exports.test!();
+    expect(result).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Class methods receiving an arrow argument (`app.set(() => ...)`) lowered the arrow through the host `__make_callback` path. For user-defined class methods that store the param into a field, the dispatch site (`call_ref` against the WasmGC closure-struct shape) null-derefed because the cast failed.
- Detect property-access callees whose method maps to a user-defined function in `funcMap` (with `getBaseTypes()` walk for inheritance) and route to the closure path. Built-in receivers (Array, Map, Promise) keep the host-callback fallthrough.
- Surfaced by the Hono Tier 6a `Map<string, AsyncHandler>` probe (#1309).

## Test plan

- [x] tests/issue-1311.test.ts — 5 new cases: minimal class-method param forwarding, inherited base-type method, Map<string, sync handler>, Hono Map<string, async handler> reproducer, mixed sync+async handlers
- [x] Pre-existing failures (`arrow-call-apply`, `optional-direct-closure-call`, `lastIndexOf`, peephole-i32-fold) confirmed unchanged by stashing the fix and running against `origin/main`
- [ ] CI: baseline-validate (50-sample spot check) + sharded test262 (full conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)