### PR TITLE
fix(#1347): IteratorClose throws TypeError on non-callable return; suppress in throw context

### DIFF
--- a/plan/issues/sprints/50/1347-spec-gap-for-of-iterator-close-on-throw.md
+++ b/plan/issues/sprints/50/1347-spec-gap-for-of-iterator-close-on-throw.md
@@ -97,3 +97,58 @@ point in the cleanup path.
 - `test262/test/language/statements/for-of/iterator-close-throw-error.js`
 - `test262/test/language/statements/for-of/iterator-close-via-break.js`
 - `test262/test/language/statements/for-await-of/iterator-close-throw-error.js`
+
+## Implementation (dev-a)
+
+Surveyed the existing for-of pipeline and the failing tests. Findings:
+
+- The throw-path try/catch_all + the break/continue/return finallyStack
+  cleanup are ALREADY in `compileForOfIterator` (#851). Simple
+  `iterator-close-via-throw.js`, `iterator-close-via-break.js`,
+  `iterator-close-via-continue.js` already pass.
+- The 389 fails are heterogeneous: most are destructuring edge cases
+  (`dstr/...`), harness wrapping issues (return-from-IIFE inside for-of),
+  or downstream Object.create / Function.bind gaps — not the simple
+  IteratorClose flow.
+- ONE clear close-protocol gap: the runtime's `__iterator_return`
+  swallowed the case where `iterator.return` was non-null but
+  non-callable (e.g. `return: 1`). Per ES §7.4.6 IteratorClose +
+  §7.3.11 GetMethod step 4, that should throw TypeError.
+
+Two-part fix in this PR:
+1. **Runtime** (`src/runtime.ts`) — `__iterator_return` now throws
+   `TypeError("Iterator return method is not callable")` when `iter.return`
+   is non-null and non-callable. Functions and WasmGC closures continue
+   to be invoked; null/undefined remain a no-op (GetMethod step 3).
+2. **Compiler** (`src/codegen/statements/loops.ts`) — the throw-path
+   `catchAll` wraps its `__iterator_return` call in a nested
+   try/catch_all so any error from IteratorClose is dropped before
+   `rethrow 0` re-raises the ORIGINAL exception. Per spec §7.4.6
+   step 6, when the outer completion is throw, IteratorClose's error
+   is suppressed. The break/continue/return paths (via `finallyStack`
+   cloned body) call `__iterator_return` directly, so any TypeError
+   from a non-callable `return` propagates to the caller (step 7).
+
+The architect's edge-case note "If `.return()` itself throws → re-raise
+the new error" matches **break/continue/return** semantics. For
+**throw** the spec is the opposite — original error wins. The fix
+applies that distinction correctly.
+
+Full fix for the 389-fail wave will require separate issues for the
+destructuring edge cases, harness wrapping, and downstream gaps.
+
+## Test Results
+
+`tests/issue-1347.test.ts` — 5 tests, all pass:
+
+- close-by-throw with non-callable return → original throw wins
+- close-by-break with non-callable return → TypeError propagates
+- regression: callable return called once on break
+- regression: missing return method is a no-op
+- regression: throw-path with callable return that throws → original wins
+
+Existing iterator/close suites pass: `issue-851.test.ts` (5 tests),
+`issue-859.test.ts` (8 tests). Pre-existing failures in
+`for-of-array-destructuring.test.ts` and `for-of-generator.test.ts`
+are unrelated module-resolution errors (missing `./helpers.js`),
+not regressions from this fix.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -2981,13 +2981,27 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
 
   if (returnIdx !== undefined) {
     // Wrap in try/catch_all: on exception, call iterator.return() then rethrow.
+    //
+    // Per ES §7.4.6 IteratorClose step 6: when the outer completion is
+    // throw, IteratorClose returns the original throw — any error from
+    // GetMethod / iterator.return() is suppressed. We model this by
+    // wrapping the inner __iterator_return call in a nested try/catch_all
+    // whose catchAll is empty (drops any exception). The outer catch_all
+    // then `rethrow 0` re-raises the ORIGINAL exception. (#1347)
+    const innerCloseTry: Instr = {
+      op: "try",
+      blockType: { kind: "empty" },
+      body: [{ op: "local.get", index: iterLocal } as Instr, { op: "call", funcIdx: returnIdx } as Instr],
+      catches: [],
+      catchAll: [], // suppress any error from GetMethod / return() per spec step 6
+    } as unknown as Instr;
     const catchAllBody: Instr[] = [
       { op: "local.get", index: doneFlag } as Instr,
       { op: "i32.eqz" } as Instr,
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "local.get", index: iterLocal } as Instr, { op: "call", funcIdx: returnIdx } as Instr],
+        then: [innerCloseTry],
         else: [],
       } as unknown as Instr,
       { op: "rethrow", depth: 0 } as unknown as Instr,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3582,18 +3582,29 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__iterator_return")
         return (iter: any) => {
-          let ret = iter?.return ?? _sidecarGet(iter, "return");
+          // ES spec 7.4.6 IteratorClose + 7.3.11 GetMethod:
+          //   GetMethod returns undefined for null/undefined `return`.
+          //   GetMethod throws TypeError if `return` exists but is not callable.
+          //   Errors from calling `return()` propagate; non-object results throw.
+          // For close-by-throw, the compiler wraps this call in a nested
+          // try/catch_all that suppresses any exception (per spec step 6:
+          // outer throw wins). For close-by-break/continue/return, the
+          // exception propagates to the user — also per spec (step 7). (#1347)
+          let ret = iter?.return;
+          if (ret === undefined) ret = _sidecarGet(iter, "return");
           if (ret === undefined) {
             const exports = callbackState?.getExports();
             ret = exports?.__sget_return?.(iter);
           }
+          if (ret === undefined || ret === null) return; // GetMethod step 3: no-op
           if (typeof ret === "function") {
             const result = ret.call(iter);
-            // ES spec 7.4.6 IteratorClose: return value must be an Object
             if (result !== null && result !== undefined && typeof result !== "object" && typeof result !== "function") {
               throw new TypeError("Iterator result is not an object");
             }
-          } else if (ret != null && _isWasmStruct(ret)) {
+            return;
+          }
+          if (_isWasmStruct(ret)) {
             // WasmGC closure: call via __call_fn_0
             const exports = callbackState?.getExports();
             const callFn0 = (exports as any)?.__call_fn_0;
@@ -3608,7 +3619,10 @@ assert._isSameValue = isSameValue;
                 throw new TypeError("Iterator result is not an object");
               }
             }
+            return;
           }
+          // ret is non-null, non-callable → GetMethod throws TypeError
+          throw new TypeError("Iterator return method is not callable");
         };
       // Convert a WasmGC vec struct to a real JS array so it's iterable by
       // native JS APIs (Map, Set, spread, for-of, etc.). (#854)

--- a/tests/issue-1347.test.ts
+++ b/tests/issue-1347.test.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #1347 — for-of IteratorClose semantics on abrupt body completion.
+ *
+ * The compiler already emits `__iterator_return` calls on break / continue /
+ * return / throw via `compileForOfIterator`'s `finallyStack` + try/catch_all
+ * (#851). What was missing: spec-conformant behaviour at the **runtime**
+ * layer for the case where `iterator.return` exists but is **not callable**
+ * (e.g. `return: 1`). Per ES §7.4.6 IteratorClose + §7.3.11 GetMethod:
+ *
+ * - GetMethod throws TypeError when `return` is non-null + non-callable.
+ * - For close-by-throw: the outer throw wins (step 6 — IteratorClose's
+ *   error is suppressed).
+ * - For close-by-break/continue/return: the IteratorClose error
+ *   propagates (step 7).
+ *
+ * Two-part fix:
+ * 1. **Runtime** (`src/runtime.ts`) — `__iterator_return` now throws
+ *    TypeError when `iter.return` is non-null and non-callable. Errors
+ *    from calling `iter.return()` itself continue to propagate.
+ * 2. **Compiler** (`src/codegen/statements/loops.ts`) — the throw-path
+ *    `catchAll` wraps its `__iterator_return` call in a nested
+ *    try/catch_all so that any error from IteratorClose is dropped
+ *    before the outer `rethrow 0` re-raises the original exception.
+ *    The break/continue/return paths (via `finallyStack` cloned
+ *    body) call `__iterator_return` directly, so any TypeError from
+ *    a non-callable `return` propagates to the user as required.
+ *
+ * Tests use a host import `getIterable()` to surface a JS iterable
+ * with a deliberately non-callable `return`. Going through a host
+ * import avoids the function-typed-parameter codegen path (which has
+ * unrelated bugs tracked elsewhere) and exercises the iterator
+ * protocol end-to-end.
+ */
+
+interface IterStub {
+  next: () => { done: boolean; value: unknown };
+  return?: unknown;
+}
+
+async function runWithIterable(src: string, iter: IterStub): Promise<{ exports: Record<string, unknown> }> {
+  const r = compile(src, { fileName: "t.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const imports = buildImports(r.imports, undefined, r.stringPool) as any;
+  // Provide getIterable host import that returns a real JS iterable with the
+  // injected stub iterator. (Using a host import keeps the compiled Wasm body
+  // simple — no function-typed param codegen involved.)
+  imports.env = imports.env ?? {};
+  imports.env.getIterable = () => {
+    const it: { [k: string | symbol]: unknown } = {};
+    it[Symbol.iterator] = () => iter;
+    return it;
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(instance.exports);
+  return { exports: instance.exports as Record<string, unknown> };
+}
+
+const STUB_HOST = `declare function getIterable(): any;`;
+
+describe("#1347 — for-of IteratorClose on non-callable return", () => {
+  it("close-by-throw with non-callable return: original throw wins", async () => {
+    // Spec §7.4.6 step 6: when the body throws, IteratorClose returns the
+    // original throw — any error from GetMethod / iterator.return() is
+    // suppressed. The compiler wraps the throw-path `__iterator_return`
+    // call in a nested try/catch_all to drop any exception before
+    // re-raising the original.
+    const { exports } = await runWithIterable(
+      `
+      ${STUB_HOST}
+      export function test(): number {
+        let iterationCount = 0;
+        let caughtMessage = "";
+        try {
+          for (const x of getIterable()) {
+            iterationCount += 1;
+            throw new Error("user-throw");
+          }
+        } catch (e: any) {
+          caughtMessage = e?.message ?? "";
+        }
+        return (iterationCount === 1 && caughtMessage.indexOf("user-throw") >= 0) ? 1 : 0;
+      }
+    `,
+      {
+        next: () => ({ done: false, value: null }),
+        return: "not-callable", // non-callable string
+      },
+    );
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("close-by-break with non-callable return: TypeError propagates", async () => {
+    // Spec §7.4.6 step 7 + §7.3.11 GetMethod step 4: GetMethod throws
+    // TypeError when `iterator.return` is non-null and non-callable.
+    // For close-by-break (non-throw outer completion), the IteratorClose
+    // error propagates to the caller.
+    const { exports } = await runWithIterable(
+      `
+      ${STUB_HOST}
+      export function test(): number {
+        let iterationCount = 0;
+        let caught = 0;
+        try {
+          for (const x of getIterable()) {
+            iterationCount += 1;
+            break;
+          }
+        } catch (e: any) {
+          caught = 1;
+        }
+        return (iterationCount === 1 && caught === 1) ? 1 : 0;
+      }
+    `,
+      {
+        next: () => ({ done: false, value: null }),
+        return: 1, // non-callable number
+      },
+    );
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("regression guard: callable return is still called once on break", async () => {
+    let returnCount = 0;
+    const { exports } = await runWithIterable(
+      `
+      ${STUB_HOST}
+      export function test(): number {
+        let iterationCount = 0;
+        for (const x of getIterable()) {
+          iterationCount += 1;
+          break;
+        }
+        return iterationCount;
+      }
+    `,
+      {
+        next: () => ({ done: false, value: null }),
+        return: () => {
+          returnCount += 1;
+          return {};
+        },
+      },
+    );
+    expect((exports.test as () => number)()).toBe(1);
+    expect(returnCount).toBe(1);
+  });
+
+  it("regression guard: missing return method is a no-op (no error)", async () => {
+    // GetMethod step 3: undefined / null `return` → no-op.
+    const { exports } = await runWithIterable(
+      `
+      ${STUB_HOST}
+      export function test(): number {
+        let iterationCount = 0;
+        for (const x of getIterable()) {
+          iterationCount += 1;
+          break;
+        }
+        return iterationCount;
+      }
+    `,
+      {
+        next: () => ({ done: false, value: null }),
+        // no `return` property at all
+      },
+    );
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("regression guard: throw-path with callable return that itself throws is suppressed", async () => {
+    // Spec §7.4.6 step 6: when outer is throw, ANY error from IteratorClose
+    // is suppressed — including errors from calling iterator.return().
+    const { exports } = await runWithIterable(
+      `
+      ${STUB_HOST}
+      export function test(): number {
+        let iterationCount = 0;
+        let caughtMessage = "";
+        try {
+          for (const x of getIterable()) {
+            iterationCount += 1;
+            throw new Error("body-throw");
+          }
+        } catch (e: any) {
+          caughtMessage = e?.message ?? "";
+        }
+        return (iterationCount === 1 && caughtMessage.indexOf("body-throw") >= 0) ? 1 : 0;
+      }
+    `,
+      {
+        next: () => ({ done: false, value: null }),
+        return: () => {
+          throw new Error("close-throw"); // suppressed per spec
+        },
+      },
+    );
+    expect((exports.test as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Runtime `__iterator_return` now throws TypeError when `iter.return` is non-null and non-callable (per ES §7.4.6 + §7.3.11 GetMethod step 4).
- Compiler wraps the for-of throw-path `__iterator_return` call in a nested try/catch_all to suppress its errors, so the original throw wins (per spec §7.4.6 step 6).
- Break/continue/return paths continue to call `__iterator_return` directly, so the new TypeError propagates to the caller (per spec step 7).

## Root cause

The compiler's IteratorClose plumbing (#851) was already correct for the simple cases — `iterator-close-via-throw.js`, `iterator-close-via-break.js`, `iterator-close-via-continue.js` already pass on main. The gap was in the runtime: `__iterator_return` silently swallowed the case where `iter.return` exists but is non-callable (e.g. `return: 1`), letting tests like `iterator-close-non-throw-get-method-non-callable.js` fail to assert TypeError.

Per ES §7.4.6 IteratorClose:
- step 6 — when outer completion is throw, IteratorClose's errors are SUPPRESSED → original throw wins.
- step 7 — when outer is non-throw (break/continue/return), IteratorClose's errors PROPAGATE.

Adding the TypeError throw to the runtime is necessary but not sufficient: the existing throw-path catchAll would otherwise replace the original throw with the new TypeError. The compiler change wraps the throw-path close call in a nested try/catch_all to drop any IteratorClose error before `rethrow 0` re-raises the original.

## Files changed

- `src/runtime.ts` — `__iterator_return` throws on non-callable, structured null/undefined no-op + function + WasmGC closure paths
- `src/codegen/statements/loops.ts` — wrap throw-path `__iterator_return` in nested try/catch_all (suppresses IteratorClose errors per spec step 6)
- `tests/issue-1347.test.ts` — 5 tests, all pass
- `plan/issues/sprints/50/1347-...md` — implementation notes + Test Results

## Scope note

The issue file estimated ~150 of 304 assertion fails would flip from this fix. Survey found most of the 389 fails are heterogeneous: destructuring edge cases (`dstr/...`), harness wrapping (return-from-IIFE inside for-of), and downstream gaps in Object.create/Function.bind. Those need separate issues. This PR addresses the clear close-protocol gap (non-callable `return`) without touching the unrelated paths.

## Test plan

- [x] `tests/issue-1347.test.ts` (5 tests, all pass): close-by-throw + non-callable, close-by-break + non-callable, callable on break, missing return, throw + callable-return-throws (suppressed)
- [x] `tests/issue-851.test.ts` (5 tests, all pass) — existing iterator-close coverage
- [x] `tests/issue-859.test.ts` (8 tests, all pass) — Map.forEach captures (host callback path)
- Pre-existing failures in `for-of-array-destructuring.test.ts` / `for-of-generator.test.ts` (missing `./helpers.js`) confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)