### PR TITLE
feat(date #1343): time-of-day setters (Slice 2 of 5)

### DIFF
--- a/plan/issues/sprints/50/1343-spec-gap-date-prototype-formatters.md
+++ b/plan/issues/sprints/50/1343-spec-gap-date-prototype-formatters.md
@@ -74,3 +74,109 @@ env var. Some tests also call `Date.prototype[Symbol.toPrimitive]` directly; we 
 - `test262/test/built-ins/Date/prototype/toISOString/15.9.5.43-0-1.js`
 - `test262/test/built-ins/Date/prototype/Symbol.toPrimitive/this-val-non-obj.js`
 - `test262/test/built-ins/Date/prototype/toJSON/invoke-tojson-result-throws.js`
+
+## Investigation Findings (senior-dev, 2026-05-08)
+
+**Issue file's premise was wrong** — Date is NOT a host externref forwarder.
+It's a Wasm-native struct (`__Date` with `i64 timestamp` field) implemented
+in `src/codegen/expressions/builtins.ts::compileDateMethodCall` (line 440)
+using Howard Hinnant's civil_from_days algorithm
+(`ensureDateCivilHelper`, line 105). All getters and `setTime` are
+implemented purely in Wasm i64 arithmetic. There is no host import for
+Date methods at runtime; the `date_method` runtime fallback exists but
+is unreachable for `__Date` struct values.
+
+**Real failure breakdown** (174 fails in `built-ins/Date/prototype`):
+
+| Method | Fails | Reason |
+|--------|------:|--------|
+| `setHours` | 17 | not implemented in `compileDateMethodCall` |
+| `setFullYear` | 14 | not implemented |
+| `setMinutes` | 12 | not implemented |
+| `setMonth` | 11 | not implemented |
+| `setSeconds` | 11 | not implemented |
+| `setMilliseconds` | 8 | not implemented |
+| `setDate` | 8 | not implemented |
+| `setUTCHours` | 7 | not implemented |
+| `setUTC{Month,Seconds,Date,Milliseconds,Minutes,FullYear}` | 23 | not implemented |
+| `toISOString` | 8 | RangeError on Invalid Date not thrown |
+| `toJSON` | 7 | `Cannot convert object to primitive value` — Symbol.toPrimitive not called on Date |
+| `Symbol.toPrimitive` | 6 | method not exposed as Date.prototype member |
+| `toUTCString` | 5 | format mismatch |
+| `toString`, `toDateString`, `toTimeString` | 8 | format mismatch on edge years |
+| `toTemporalInstant` | 6 | Temporal proposal — already in skip filters |
+| `getDay`/`getMinutes`/`getHours`/`getSeconds`/`getTimezoneOffset` | 7 | NaN propagation broken: `new Date(NaN).getX()` returns 0 not NaN |
+
+**Root cause**: the `DATE_METHODS` allowlist in `compileDateMethodCall`
+(line 451) excludes ALL setters except `setTime`. When `date.setHours(...)` is
+called, the function returns `undefined`, control flow falls through to
+generic externref dispatch which fails because `__Date` is not externref.
+This explains ~110 of the 174 fails directly; the remainder are formatter
+edge cases and Symbol.toPrimitive plumbing.
+
+## Implementation Plan (senior-dev, revised)
+
+### Slice 1: NaN-propagating getters (~7 fails, low risk)
+For each getter in `compileDateMethodCall`, when the timestamp is `i64.MIN`
+(our representation of NaN — confirm this), emit `f64.const NaN` instead of
+the modulo computation. Test with `new Date(NaN).getDay()` etc.
+
+### Slice 2: time-of-day setters (~50 fails)
+`setMilliseconds`, `setSeconds`, `setMinutes`, `setHours` and UTC variants.
+Time-of-day setters don't need calendar recomputation — adjust timestamp
+by delta:
+```
+ms_of_day = ((timestamp mod 86400000) + 86400000) mod 86400000  // floor-mod
+day_of_epoch_ms = timestamp - ms_of_day
+new_ms_of_day = newH*3600000 + newM*60000 + newS*1000 + newMs
+new_timestamp = day_of_epoch_ms + new_ms_of_day
+struct.set timestamp; return f64.convert_i64_s
+```
+For partial setters (e.g. `setMinutes(m)` keeps current s, ms), compute
+existing components first.
+
+### Slice 3: calendar setters (~36 fails)
+`setDate`, `setMonth`, `setFullYear` and UTC variants. Need:
+1. Decompose current timestamp → (y, mo, d, h, mi, s, ms) via
+   `__date_civil_from_days`.
+2. Replace the relevant field(s) with argument(s).
+3. Recompose timestamp via `__date_days_from_civil`.
+4. Write back, return f64.
+
+May want a new helper `__date_components_from_timestamp` returning a
+packed i64 (year * 10000 + month * 100 + day) plus a separate
+time-of-day extractor.
+
+### Slice 4: Invalid Date / Symbol.toPrimitive (~13 fails)
+- `toISOString` should throw RangeError when timestamp == NaN sentinel.
+- `toJSON` per §21.4.4.42: ToPrimitive(this, "number"); if !isFinite,
+  return null; else call toISOString.
+- `Date.prototype[Symbol.toPrimitive]`: register in classAccessorSet so
+  `date[Symbol.toPrimitive]("string")` dispatches to Wasm helper.
+
+### Slice 5: format polish (~16 fails)
+- Negative years: `-000001` 6-digit padded.
+- 5-digit years: `+002025` 7-digit prefixed.
+- `toUTCString`: `DDD, dd MMM YYYY HH:mm:ss GMT` exactly (no tz suffix).
+
+### Skip: `toTemporalInstant` (6 fails)
+Temporal proposal — already in skip filters.
+
+### Estimate
+- Slice 1 + Slice 2: ~1.5h, ~57 fails fixed.
+- Slice 3: ~2.5h, ~36 fails.
+- Slice 4 + Slice 5: ~2h, ~29 fails.
+- **Total: ~6h senior-dev for ~80% of fails (target ≥85% pass-rate).**
+
+### Files
+- `src/codegen/expressions/builtins.ts::compileDateMethodCall` — add setter cases, NaN guards, Symbol.toPrimitive
+- `tests/issue-1343.test.ts` — per-slice equivalence tests
+
+## Status (2026-05-08, senior-dev-2)
+
+Started investigation in worktree
+`/workspace/.claude/worktrees/issue-1343-date-formatters` while PR #264
+(#1311 fix) CI was running. Did not push code; this issue requires a
+focused multi-hour effort and shouldn't be rushed during CI-wait. Worktree
+is clean — only this issue file is modified. Ready for re-claim by next dev
+or for me to resume after #264 self-merges.

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -460,6 +460,14 @@ function compileDateMethodCall(
     "getMilliseconds",
     "getDay",
     "setTime",
+    "setMilliseconds",
+    "setSeconds",
+    "setMinutes",
+    "setHours",
+    "setUTCMilliseconds",
+    "setUTCSeconds",
+    "setUTCMinutes",
+    "setUTCHours",
     "getTimezoneOffset",
     "getUTCFullYear",
     "getUTCMonth",
@@ -539,6 +547,230 @@ function compileDateMethodCall(
     return { kind: "f64" };
   }
 
+  // Constants used by both setters and getters below.
+  const MS_PER_DAY = 86400000n;
+  const MS_PER_HOUR = 3600000n;
+  const MS_PER_MINUTE = 60000n;
+  const MS_PER_SECOND = 1000n;
+
+  // ── Time-of-day setters (#1343 Slice 2) ──────────────────────────────
+  // setMilliseconds(ms), setSeconds(s, ms?), setMinutes(m, s?, ms?),
+  // setHours(h, m?, s?, ms?), and UTC variants. We're already in UTC so
+  // there's no DST adjustment — UTC variants share implementations.
+  //
+  // Strategy: keep day-of-epoch portion fixed, rebuild ms_of_day from
+  // either the user-supplied arg or the current component value.
+  //   ms_of_day = ((ts mod 86400000) + 86400000) mod 86400000   (floor-mod)
+  //   day_ms    = ts - ms_of_day                                (whole days)
+  //   curMs     = ms_of_day mod 1000
+  //   curS      = (ms_of_day / 1000) mod 60
+  //   curM      = (ms_of_day / 60000) mod 60
+  //   curH      = ms_of_day / 3600000
+  //   newMsOfDay = newH*3600000 + newM*60000 + newS*1000 + newMs
+  //   newTs     = day_ms + newMsOfDay
+  // Components larger than the leftmost setter argument are kept as-is;
+  // missing trailing args fall through to the current value (per §21.4.4
+  // SetSeconds/SetMinutes/SetHours partial-arg rules).
+  //
+  // NOTE on NaN: this implementation does not yet propagate NaN args via
+  // an Invalid Date sentinel (Slice 1). f64.NaN args saturate to 0 via
+  // i64.trunc_sat_f64_s — observable for tests that pass NaN explicitly.
+  const TIME_OF_DAY_SETTERS: Record<string, "ms" | "s" | "m" | "h"> = {
+    setMilliseconds: "ms",
+    setUTCMilliseconds: "ms",
+    setSeconds: "s",
+    setUTCSeconds: "s",
+    setMinutes: "m",
+    setUTCMinutes: "m",
+    setHours: "h",
+    setUTCHours: "h",
+  };
+  if (methodName in TIME_OF_DAY_SETTERS) {
+    const startUnit = TIME_OF_DAY_SETTERS[methodName]!;
+    const args = callExpr.arguments;
+    // Stack: [dateRef]
+    const tempRef = allocTempLocal(fctx, dateRefType);
+    fctx.body.push({ op: "local.set", index: tempRef } as Instr);
+    // Stack: []
+
+    // Read curTs into a temp.
+    const tempCurTs = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push({ op: "local.get", index: tempRef } as Instr);
+    fctx.body.push({
+      op: "struct.get",
+      typeIdx: dateTypeIdx,
+      fieldIdx: 0,
+    } as unknown as Instr);
+    fctx.body.push({ op: "local.set", index: tempCurTs } as Instr);
+
+    // ms_of_day = ((curTs mod MS_PER_DAY) + MS_PER_DAY) mod MS_PER_DAY
+    const tempMsOfDay = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push(
+      { op: "local.get", index: tempCurTs } as Instr,
+      { op: "i64.const", value: MS_PER_DAY } as Instr,
+      { op: "i64.rem_s" } as Instr,
+      { op: "i64.const", value: MS_PER_DAY } as Instr,
+      { op: "i64.add" } as Instr,
+      { op: "i64.const", value: MS_PER_DAY } as Instr,
+      { op: "i64.rem_s" } as Instr,
+      { op: "local.set", index: tempMsOfDay } as Instr,
+    );
+
+    // day_ms = curTs - ms_of_day
+    const tempDayMs = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push(
+      { op: "local.get", index: tempCurTs } as Instr,
+      { op: "local.get", index: tempMsOfDay } as Instr,
+      { op: "i64.sub" } as Instr,
+      { op: "local.set", index: tempDayMs } as Instr,
+    );
+
+    // Helper: push current component (h/m/s/ms) extracted from tempMsOfDay.
+    const pushCurrentComponent = (unit: "ms" | "s" | "m" | "h") => {
+      fctx.body.push({ op: "local.get", index: tempMsOfDay } as Instr);
+      if (unit === "ms") {
+        // ms = msOfDay mod 1000
+        fctx.body.push({ op: "i64.const", value: MS_PER_SECOND } as Instr, { op: "i64.rem_s" } as Instr);
+      } else if (unit === "s") {
+        // s = (msOfDay / 1000) mod 60
+        fctx.body.push(
+          { op: "i64.const", value: MS_PER_SECOND } as Instr,
+          { op: "i64.div_s" } as Instr,
+          { op: "i64.const", value: 60n } as Instr,
+          { op: "i64.rem_s" } as Instr,
+        );
+      } else if (unit === "m") {
+        // m = (msOfDay / 60000) mod 60
+        fctx.body.push(
+          { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+          { op: "i64.div_s" } as Instr,
+          { op: "i64.const", value: 60n } as Instr,
+          { op: "i64.rem_s" } as Instr,
+        );
+      } else {
+        // h = msOfDay / 3600000
+        fctx.body.push({ op: "i64.const", value: MS_PER_HOUR } as Instr, { op: "i64.div_s" } as Instr);
+      }
+    };
+
+    // Push a component from the user arg (ToInteger via i64.trunc_sat_f64_s)
+    // or fall back to current.
+    const pushComponentArgOrCurrent = (argIdx: number, unit: "ms" | "s" | "m" | "h") => {
+      if (args.length > argIdx) {
+        compileExpression(ctx, fctx, args[argIdx]!, { kind: "f64" });
+        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+      } else {
+        pushCurrentComponent(unit);
+      }
+    };
+
+    // Build new component values based on which setter was called. The
+    // left-most argument is required; later args are optional and
+    // fall through to current values when omitted.
+    //   setMilliseconds(ms)              → newMs = arg0
+    //   setSeconds(s, ms?)               → newS = arg0, newMs = arg1 ?? curMs
+    //   setMinutes(m, s?, ms?)           → newM = arg0, newS = arg1 ?? curS, newMs = arg2 ?? curMs
+    //   setHours(h, m?, s?, ms?)         → newH = arg0, newM = arg1 ?? curM, newS = arg2 ?? curS, newMs = arg3 ?? curMs
+    // Components above the start unit are kept (cur).
+    const tempNewH = allocTempLocal(fctx, { kind: "i64" });
+    const tempNewM = allocTempLocal(fctx, { kind: "i64" });
+    const tempNewS = allocTempLocal(fctx, { kind: "i64" });
+    const tempNewMs = allocTempLocal(fctx, { kind: "i64" });
+
+    // Hours
+    if (startUnit === "h") {
+      pushComponentArgOrCurrent(0, "h");
+    } else {
+      pushCurrentComponent("h");
+    }
+    fctx.body.push({ op: "local.set", index: tempNewH } as Instr);
+
+    // Minutes
+    if (startUnit === "h") {
+      pushComponentArgOrCurrent(1, "m");
+    } else if (startUnit === "m") {
+      pushComponentArgOrCurrent(0, "m");
+    } else {
+      pushCurrentComponent("m");
+    }
+    fctx.body.push({ op: "local.set", index: tempNewM } as Instr);
+
+    // Seconds
+    if (startUnit === "h") {
+      pushComponentArgOrCurrent(2, "s");
+    } else if (startUnit === "m") {
+      pushComponentArgOrCurrent(1, "s");
+    } else if (startUnit === "s") {
+      pushComponentArgOrCurrent(0, "s");
+    } else {
+      pushCurrentComponent("s");
+    }
+    fctx.body.push({ op: "local.set", index: tempNewS } as Instr);
+
+    // Milliseconds
+    if (startUnit === "h") {
+      pushComponentArgOrCurrent(3, "ms");
+    } else if (startUnit === "m") {
+      pushComponentArgOrCurrent(2, "ms");
+    } else if (startUnit === "s") {
+      pushComponentArgOrCurrent(1, "ms");
+    } else {
+      // ms
+      pushComponentArgOrCurrent(0, "ms");
+    }
+    fctx.body.push({ op: "local.set", index: tempNewMs } as Instr);
+
+    // newMsOfDay = newH*MS_PER_HOUR + newM*MS_PER_MINUTE + newS*MS_PER_SECOND + newMs
+    fctx.body.push(
+      { op: "local.get", index: tempNewH } as Instr,
+      { op: "i64.const", value: MS_PER_HOUR } as Instr,
+      { op: "i64.mul" } as Instr,
+      { op: "local.get", index: tempNewM } as Instr,
+      { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+      { op: "i64.mul" } as Instr,
+      { op: "i64.add" } as Instr,
+      { op: "local.get", index: tempNewS } as Instr,
+      { op: "i64.const", value: MS_PER_SECOND } as Instr,
+      { op: "i64.mul" } as Instr,
+      { op: "i64.add" } as Instr,
+      { op: "local.get", index: tempNewMs } as Instr,
+      { op: "i64.add" } as Instr,
+    );
+    // Stack: [newMsOfDay]
+
+    // newTs = day_ms + newMsOfDay
+    fctx.body.push({ op: "local.get", index: tempDayMs } as Instr, { op: "i64.add" } as Instr);
+    // Stack: [newTs]
+
+    const tempNewTs = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push({ op: "local.set", index: tempNewTs } as Instr);
+
+    // Write back: struct.set timestamp = newTs
+    fctx.body.push(
+      { op: "local.get", index: tempRef } as Instr,
+      { op: "local.get", index: tempNewTs } as Instr,
+      {
+        op: "struct.set",
+        typeIdx: dateTypeIdx,
+        fieldIdx: 0,
+      } as unknown as Instr,
+    );
+
+    // Return value: newTs as f64 (per spec, set* returns the new TimeValue)
+    fctx.body.push({ op: "local.get", index: tempNewTs } as Instr, { op: "f64.convert_i64_s" } as Instr);
+
+    releaseTempLocal(fctx, tempRef);
+    releaseTempLocal(fctx, tempCurTs);
+    releaseTempLocal(fctx, tempMsOfDay);
+    releaseTempLocal(fctx, tempDayMs);
+    releaseTempLocal(fctx, tempNewH);
+    releaseTempLocal(fctx, tempNewM);
+    releaseTempLocal(fctx, tempNewS);
+    releaseTempLocal(fctx, tempNewMs);
+    releaseTempLocal(fctx, tempNewTs);
+    return { kind: "f64" };
+  }
+
   // For all time-component getters, we need the i64 timestamp
   // Stack: [dateRef]
   fctx.body.push({
@@ -547,12 +779,6 @@ function compileDateMethodCall(
     fieldIdx: 0,
   } as unknown as Instr);
   // Stack: [i64 timestamp]
-
-  // Time-of-day getters (no civil calendar needed)
-  const MS_PER_DAY = 86400000n;
-  const MS_PER_HOUR = 3600000n;
-  const MS_PER_MINUTE = 60000n;
-  const MS_PER_SECOND = 1000n;
 
   if (methodName === "getHours" || methodName === "getUTCHours") {
     // hours = ((timestamp % 86400000) + 86400000) % 86400000 / 3600000

--- a/tests/issue-1343-date-setters.test.ts
+++ b/tests/issue-1343-date-setters.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #1343 Slice 2 — time-of-day setters
+ *
+ * Adds Wasm-native implementations of:
+ *   - setMilliseconds(ms) / setUTCMilliseconds(ms)
+ *   - setSeconds(s, ms?) / setUTCSeconds(s, ms?)
+ *   - setMinutes(m, s?, ms?) / setUTCMinutes(m, s?, ms?)
+ *   - setHours(h, m?, s?, ms?) / setUTCHours(h, m?, s?, ms?)
+ *
+ * Strategy: keep the day-of-epoch portion of the timestamp fixed, rebuild
+ * the ms-of-day portion from either the user-supplied argument (ToInteger
+ * via i64.trunc_sat_f64_s) or the current component value when an arg is
+ * omitted. UTC variants share implementations because the Wasm Date is
+ * already represented in UTC (no DST adjustment).
+ *
+ * Pre-fix behavior: these setter method names weren't in the
+ * `DATE_METHODS` allowlist, so calls fell through to externref dispatch
+ * which failed at runtime. ~58 of the 174 `built-ins/Date/prototype`
+ * test262 fails are in this slice.
+ *
+ * Slice 1 (NaN propagation / Invalid Date sentinel) and Slice 3 (calendar
+ * setters: setDate / setMonth / setFullYear) are tracked in the issue
+ * file and will land in follow-up PRs.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("issue #1343 Slice 2 — Date time-of-day setters", () => {
+  it("setMilliseconds replaces just the ms component", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setMilliseconds(789);
+  return d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(789);
+  });
+
+  it("setMilliseconds preserves h/m/s and updates ms", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setMilliseconds(500);
+  return d.getHours() * 1000000 + d.getMinutes() * 10000 + d.getSeconds() * 100 + Math.floor(d.getMilliseconds() / 10);
+}
+`;
+    const exports = await compileToWasm(source);
+    // 12*1e6 + 30*1e4 + 45*100 + 50 = 12,304,550
+    expect(exports.test!()).toBe(12304550);
+  });
+
+  it("setSeconds(s, ms?) replaces s and ms when both provided", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setSeconds(20, 999);
+  return d.getSeconds() * 1000 + d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(20999);
+  });
+
+  it("setSeconds(s) preserves ms when omitted", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setSeconds(20);
+  return d.getSeconds() * 1000 + d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(20123);
+  });
+
+  it("setMinutes(m, s, ms) replaces all three", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setMinutes(50, 10, 5);
+  return d.getMinutes() * 1000000 + d.getSeconds() * 1000 + d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(50010005);
+  });
+
+  it("setHours(h, m, s, ms) — full four-arg form", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setHours(7, 8, 9, 10);
+  return d.getHours() * 1000000000 + d.getMinutes() * 1000000 + d.getSeconds() * 1000 + d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    // 7e9 + 8e6 + 9e3 + 10 = 7,008,009,010
+    expect(exports.test!()).toBe(7008009010);
+  });
+
+  it("setHours(h) preserves m/s/ms when only h provided", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setHours(7);
+  return d.getHours() * 1000000000 + d.getMinutes() * 1000000 + d.getSeconds() * 1000 + d.getMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(7030045123);
+  });
+
+  it("setHours overflow rolls into the next day", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 0, 0, 0);
+  d.setHours(36);  // 36h = 1 day + 12h
+  return d.getDate();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(16);
+  });
+
+  it("setUTCHours behaves identically (Wasm Date is UTC)", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  d.setUTCHours(7, 8, 9, 10);
+  return d.getUTCHours() * 1000000000 + d.getUTCMinutes() * 1000000 + d.getUTCSeconds() * 1000 + d.getUTCMilliseconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(7008009010);
+  });
+
+  it("setMilliseconds returns the new TimeValue", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 45, 123);
+  const ts = d.setMilliseconds(456);
+  return ts === d.getTime() ? 1 : 0;
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
+
+  it("setSeconds with negative seconds underflows correctly (floor-mod)", async () => {
+    const source = `
+export function test(): number {
+  const d = new Date(2026, 0, 15, 12, 30, 0, 0);
+  d.setSeconds(-30);  // -30s before 12:30:00 = 12:29:30
+  return d.getMinutes() * 100 + d.getSeconds();
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(2930);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements pure Wasm `Date.prototype.{setMilliseconds, setSeconds, setMinutes, setHours}` and matching UTC variants. These method names weren't in the `DATE_METHODS` allowlist in `compileDateMethodCall` so calls fell through to externref dispatch and failed.
- Strategy: keep day-of-epoch portion of i64 timestamp fixed, rebuild ms-of-day from user args (ToInteger via i64.trunc_sat_f64_s) or current component values when args are omitted. UTC variants share impls (Wasm Date is already UTC).
- Per §21.4.4 partial-arg rules: components above leftmost arg kept; trailing missing args fall through to current.
- Expected to recover ~58 of the 174 `built-ins/Date/prototype` test262 fails.

## Test plan

- [x] tests/issue-1343-date-setters.test.ts — 11 cases (single-arg, multi-arg, partial-arg, overflow into next day, negative-arg underflow, UTC parity, return value equals new TimeValue)
- [x] tests/equivalence/date-basic.test.ts — 12 existing tests still pass
- [ ] CI: baseline-validate + sharded test262 (expect Date.prototype pass-rate to rise from 64% toward ~75%)

## Slicing

This is Slice 2 of a 5-slice plan documented in the issue file. Remaining slices in follow-up PRs:
- **Slice 1** — NaN propagation / Invalid Date sentinel (~7 fails)
- **Slice 3** — calendar setters (setDate/setMonth/setFullYear) (~36 fails)
- **Slice 4** — Symbol.toPrimitive / toJSON Invalid Date handling (~13 fails)
- **Slice 5** — toString/toUTCString format polish for edge years (~16 fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)