### PR TITLE
fix(#1378): catch destructuring uses iterator protocol

### DIFF
--- a/plan/issues/sprints/51/1378-spec-gap-try-catch-finally-completion-and-error-fidelity.md
+++ b/plan/issues/sprints/51/1378-spec-gap-try-catch-finally-completion-and-error-fidelity.md
@@ -2,7 +2,7 @@
 id: 1378
 sprint: 51
 title: "spec gap: try/catch/finally — error type fidelity, finally completion override, dstr-binding (~85 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: medium
@@ -138,3 +138,48 @@ destructuring emitter on the bound name.
 
 +60 passes; cleaner foundation for #1347 (for-of IteratorClose) and async error
 handling.
+
+## Implementation Notes — sub-issue C only (2026-05-08)
+
+This PR addresses **only sub-issue C — catch destructuring iterator semantics**.
+The remaining sub-issues (finally completion override, error type fidelity)
+are tracked but not addressed here.
+
+### Root cause (catch destructure)
+
+`compileExternrefCatchDestructure` in `src/codegen/statements/exceptions.ts`
+emitted property access (`__extern_get(exn, idx)`) for `catch ([x, y, ...])`
+patterns. Per spec §13.3.3.6 IteratorBindingInitialization, array destructure
+must invoke `GetIterator(value)` which calls `value[Symbol.iterator]()` —
+property access silently misses `Symbol.iterator` and any throws from it.
+
+### Fix
+
+For `catch ([elements])`, emit `__array_from_iter(exn)` once, store the
+materialised array in a fresh local, and read elements from the materialised
+array via `__extern_get`. `__array_from_iter` (already used by parameter
+destructure) walks the iterator protocol and propagates any throws from
+`Symbol.iterator()` / `.next()` so spec-compliant tests like
+`statements/try/dstr/ary-init-iter-get-err.js` see the inner Test262Error.
+
+Empty-pattern `catch ([])` short-circuits with no materialisation per
+§13.3.3.6 (no IteratorBindingInitialization steps).
+
+## Test Results
+
+- `tests/issue-1378.test.ts` — 4/4 pass
+- `test/language/statements/try/dstr/ary-init-iter-get-err.js` — fail → pass
+- No regressions on `try-catch-throw`, `try-catch-finally-extended`,
+  `null-destructuring`, `global-index-shift-trycatch` test suites.
+
+## Out of scope (filed as follow-ups)
+
+- Finally completion override: `try { return 1 } finally { return 2 }` should
+  return 2. Requires `try_table`-level lowering changes in
+  `compileTryStatement` to track and conditionally override try-block
+  completion based on finally completion type.
+- Error type fidelity: `catch (e) { e instanceof Test262Error }` requires
+  prototype-chain preservation when constructing user-defined error classes.
+  Likely shares machinery with #1366 (subclass prototype chain).
+- `completion-values-fn-finally-normal.js` null_deref: needs separate
+  investigation of the `assert_throws` host shim.

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -113,7 +113,18 @@ function compileExternrefCatchDestructure(
       fctx.body.push({ op: "local.set", index: localIdx });
     }
   } else if (ts.isArrayBindingPattern(pattern)) {
-    // Array destructuring: use __extern_get(obj, box(index))
+    // Array destructuring follows the iterator protocol per
+    // §13.3.3.6 IteratorBindingInitialization: GetIterator(value) is called
+    // first, and any throw from `value[Symbol.iterator]()` (or the iterator's
+    // .next()) propagates out of the destructuring. Property-access on the
+    // raw value would silently miss those throws and bind `undefined` instead
+    // (#1378 — `catch ([x]) {}` on a thrown iterable that throws from
+    // `Symbol.iterator`).
+    //
+    // Empty pattern `[]` is a no-op per spec — skip materialization entirely
+    // (matches the param-destructure short-circuit at #1158/#1159).
+    if (pattern.elements.length === 0) return;
+
     addUnionImports(ctx);
     let getIdx = ensureLateImport(
       ctx,
@@ -121,8 +132,24 @@ function compileExternrefCatchDestructure(
       [{ kind: "externref" }, { kind: "externref" }],
       [{ kind: "externref" }],
     );
+    let fromIterIdx = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
     flushLateImportShifts(ctx, fctx);
     const boxIdx = ctx.funcMap.get("__box_number");
+
+    // Materialize the thrown value into an iterated array via
+    // __array_from_iter — this invokes the iterator protocol and propagates
+    // any throws from Symbol.iterator() / .next().
+    const matLocal = allocLocal(fctx, `__catch_iter_${fctx.locals.length}`, { kind: "externref" });
+    fromIterIdx = ctx.funcMap.get("__array_from_iter") ?? fromIterIdx;
+    if (fromIterIdx !== undefined) {
+      fctx.body.push({ op: "local.get", index: exnLocalIdx });
+      fctx.body.push({ op: "call", funcIdx: fromIterIdx });
+      fctx.body.push({ op: "local.set", index: matLocal });
+    } else {
+      // Fallback: use the raw exception directly (no iterator protocol).
+      fctx.body.push({ op: "local.get", index: exnLocalIdx });
+      fctx.body.push({ op: "local.set", index: matLocal });
+    }
 
     let idx = 0;
     for (const element of pattern.elements) {
@@ -148,8 +175,11 @@ function compileExternrefCatchDestructure(
 
       getIdx = ctx.funcMap.get("__extern_get")!;
 
-      // __extern_get(exnLocal, box(index)) -> externref
-      fctx.body.push({ op: "local.get", index: exnLocalIdx });
+      // __extern_get(matLocal, box(index)) -> externref. The matLocal holds
+      // the iterator-materialized array, so indexed access reads spec-correct
+      // values (with no extra side effects beyond GetIterator's already-run
+      // protocol calls).
+      fctx.body.push({ op: "local.get", index: matLocal });
       fctx.body.push({ op: "f64.const", value: idx });
       if (boxIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx: boxIdx });

--- a/tests/issue-1378.test.ts
+++ b/tests/issue-1378.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Issue #1378 — try/catch/finally semantics.
+ *
+ * This PR addresses sub-issue #C: catch destructuring (`catch ([x])` and
+ * variants) must follow the §13.3.3.6 iterator protocol on the thrown value.
+ * The previous emitter used direct property access (`exn[0]`), which silently
+ * skipped Symbol.iterator and missed throws from the iterable.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.ts";
+import { runTest262File } from "./test262-runner.ts";
+
+describe("#1378 catch destructuring iterator protocol", () => {
+  it("catch ([x]) on plain array binds first elem", async () => {
+    const src = `
+export function test(): number {
+  try {
+    throw [10, 20, 30];
+  } catch ([a, b, c]) {
+    return (a as number) + (b as number) + (c as number);
+  }
+  return -1;
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(60);
+  });
+
+  it("catch ({x}) still uses property access (not iterator protocol)", async () => {
+    const src = `
+export function test(): number {
+  try {
+    throw { x: 42, y: 100 };
+  } catch ({ x, y }) {
+    return (x as number) + (y as number);
+  }
+  return -1;
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(142);
+  });
+
+  it("catch ([]) empty pattern is a no-op (no iterator invocation)", async () => {
+    const src = `
+let iterCalled = 0;
+export function test(): number {
+  const bad: any = {
+    [Symbol.iterator]() {
+      iterCalled = 1;
+      throw "should-not-fire";
+    },
+  };
+  try {
+    throw bad;
+  } catch ([]) {
+    // Empty pattern: spec says no IteratorBindingInitialization steps.
+  }
+  return iterCalled;
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(0);
+  });
+
+  it("test262: ary-init-iter-get-err.js — catch [x] propagates iter throw", async () => {
+    const result = await runTest262File(
+      "/workspace/test262/test/language/statements/try/dstr/ary-init-iter-get-err.js",
+      "language",
+    );
+    expect(result.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

Addresses sub-issue C of #1378 — catch array destructuring (`catch ([x, y])`) must follow the §13.3.3.6 iterator protocol on the thrown value.

`compileExternrefCatchDestructure` previously emitted property access (`exn[0]`) for array catch patterns, silently missing `value[Symbol.iterator]()` and any throws from it.

For `catch ([elements])`, the emitter now calls `__array_from_iter(exn)` (which walks the iterator protocol and propagates inner throws), stores the materialised array, and reads elements via `__extern_get`. Empty `catch ([])` short-circuits with no materialisation per spec.

Sub-issues A (finally completion override) and B (error class fidelity / prototype chain) are out of scope and documented as follow-ups in the issue file.

## Test plan

- [x] `tests/issue-1378.test.ts` — 4/4 pass (3 standalone catch-destructure cases + 1 test262 file regression)
- [x] `test/language/statements/try/dstr/ary-init-iter-get-err.js` — fail → pass (catch `[x]` propagates inner Test262Error)
- [x] `tests/equivalence/{try-catch-throw,try-catch-finally-extended,global-index-shift-trycatch,null-destructuring}.test.ts` — same pre-existing failures as main, no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)