### PR TITLE
fix(#1336): Object.assign respects accessors and Symbol keys on WasmGC sources

### DIFF
--- a/plan/issues/sprints/50/1336-spec-gap-object-assign-getter-iteration.md
+++ b/plan/issues/sprints/50/1336-spec-gap-object-assign-getter-iteration.md
@@ -2,7 +2,7 @@
 id: 1336
 sprint: 50
 title: "spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: medium
@@ -85,3 +85,45 @@ type carries an accessor), pick the slow path.
 - `test262/test/built-ins/Object/assign/source-own-prop-error.js`
 - `test262/test/built-ins/Object/assign/target-set-symbol.js`
 - `test262/test/built-ins/Object/assign/source-own-prop-keys-error.js`
+
+## Implementation Notes (2026-05-08)
+
+### Scope of this PR — runtime-only host-bridge fixes
+
+Two surface fixes in `_wrapForHost`'s Proxy:
+
+1. **Accessor invocation in `safeGetField`** — when a property is reached
+   during host-side `Object.assign`, the Proxy's `get` trap now invokes the
+   stored accessor getter (string key: sidecar `__get_<k>`; symbol key:
+   `_wasmStructAccessors` map). For Wasm-closure getters the call routes
+   through the `__call_fn_0` export so the closure runs inside Wasm, matching
+   the existing pattern at line 1094.
+2. **Symbol-keyed accessor enumeration in `collectKeys`** — Symbol keys
+   defined via `Object.defineProperty(obj, sym, {get/set})` live in
+   `_wasmStructAccessors`, not `_wasmStructProps`. The `ownKeys` trap now
+   enumerates both maps, and the string-key path strips `__get_<k>` /
+   `__set_<k>` accessor sidecar entries (returning the underlying property
+   name) so `Object.assign` and spread copy the correct keys.
+
+### Out of scope
+
+The architect's spec calls for a "slow path" in `compileObjectAssign` that
+loops with Get/Set per key. That requires:
+- Routing `Object.defineProperty(obj, key, {get(){...}})` programmatic calls
+  through the same `__defineProperty_accessor` import that object-literal
+  accessor declarations use today (currently only literal-form `{get x(){…}}`
+  hits `__defineProperty_accessor`; the programmatic form goes via the host
+  fallback, which silently misses the getter for opaque WasmGC targets).
+- A `compileObjectAssign` codegen-level fast/slow path split with shape
+  analysis to gate on accessor-presence.
+
+Both are larger refactors filed against this issue as follow-up work. The
+runtime-level proxy fixes here unblock the symbol-key bucket of test262
+fails without those compiler changes.
+
+## Test Results
+
+- `tests/issue-1336.test.ts` — 2/2 pass (Symbol-keyed accessor copy + plain
+  data property no-regression).
+- `tests/equivalence/{object-define-property,object-mutability,sparse-array-spread}.test.ts`
+  — 32/32 pass, no regressions.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1032,6 +1032,34 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
   const target: Record<string | symbol, any> = Object.create(null);
 
   const safeGetField = (key: any): any => {
+    // #1336 — accessor properties (Object.defineProperty(obj, k, {get})) must
+    // INVOKE the getter, not return a descriptor. Sidecar stores the descriptor
+    // function under `__get_<k>` (string) or in `_wasmStructAccessors` (symbol).
+    // Note: getters defined in a TS object literal compile to a Wasm closure
+    // (typeof === "object"); call those via __call_fn_0 export.
+    const invokeGetter = (g: any): any | undefined => {
+      if (g == null) return undefined;
+      if (typeof g === "function") return (g as Function).call(obj);
+      if (typeof g === "object" && _isWasmStruct(g) && exports) {
+        const callFn0 = exports["__call_fn_0"];
+        if (typeof callFn0 === "function") return callFn0(g);
+      }
+      return undefined;
+    };
+    if (typeof key === "string") {
+      const wasmSc = _wasmStructProps.get(obj);
+      const getter = wasmSc?.[`__get_${key}` as string];
+      if (getter !== undefined) {
+        const v = invokeGetter(getter);
+        if (v !== undefined) return v;
+      }
+    } else if (typeof key === "symbol") {
+      const accessor = _wasmStructAccessors.get(obj)?.get(key);
+      if (accessor?.get !== undefined) {
+        const v = invokeGetter(accessor.get);
+        if (v !== undefined) return v;
+      }
+    }
     // Sidecar first (handles both string and symbol keys)
     const sc = _sidecarGet(obj, key);
     if (sc !== undefined) return sc;
@@ -1072,8 +1100,25 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
     for (const k of fieldNames) keys.add(k);
     const sc = _wasmStructProps.get(obj);
     if (sc) {
-      for (const k of Object.getOwnPropertyNames(sc)) keys.add(k);
+      for (const k of Object.getOwnPropertyNames(sc)) {
+        // #1336 — `__get_x` / `__set_x` are accessor descriptor entries; they
+        // must NOT enumerate as own keys. Surface the underlying property name
+        // (`x`) instead so Object.assign / spread copy honours the accessor.
+        if (k.startsWith("__get_")) {
+          keys.add(k.slice("__get_".length));
+        } else if (k.startsWith("__set_")) {
+          keys.add(k.slice("__set_".length));
+        } else {
+          keys.add(k);
+        }
+      }
       for (const k of Object.getOwnPropertySymbols(sc)) keys.add(k);
+    }
+    // #1336 — Symbol-keyed accessors (set via Object.defineProperty with a
+    // Symbol property name) live in `_wasmStructAccessors`, not `_wasmStructProps`.
+    const accMap = _wasmStructAccessors.get(obj);
+    if (accMap) {
+      for (const k of accMap.keys()) keys.add(k);
     }
     return Array.from(keys);
   };

--- a/tests/issue-1336.test.ts
+++ b/tests/issue-1336.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue #1336 — Object.assign for WasmGC struct sources with accessors / Symbol keys.
+ *
+ * Per §20.1.2.1 CopyDataProperties, Object.assign must INVOKE getters on the
+ * source object (not return descriptors) and must enumerate own enumerable
+ * keys including Symbol keys. The host-side `_wrapForHost` proxy used to back
+ * WasmGC structs missed both: getter invocation for accessor properties and
+ * Symbol keys defined via `_wasmStructAccessors`.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.ts";
+
+describe("#1336 Object.assign accessor + symbol-key fidelity", () => {
+  it("Object.assign copies Symbol-keyed accessor", async () => {
+    const src = `
+export function test(): number {
+  const src: any = {};
+  const k: any = Symbol("k");
+  Object.defineProperty(src, k, {
+    enumerable: true,
+    get() {
+      return 99;
+    },
+  });
+  const target: any = Object.assign({}, src);
+  return target[k] === 99 ? 1 : 0;
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(1);
+  });
+
+  it("Object.assign with plain data property (no regression)", async () => {
+    const src = `
+export function test(): number {
+  const src: any = { a: 1, b: 2, c: 3 };
+  const target: any = Object.assign({}, src);
+  return (target.a as number) + (target.b as number) + (target.c as number);
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

Two surface fixes in `_wrapForHost`'s Proxy that backs WasmGC structs when JS host code (`Object.assign`, spread) reads from them:

- **`safeGetField`** now invokes accessor getters — string keys via sidecar `__get_<k>`, Symbol keys via `_wasmStructAccessors`. Wasm-closure getters route through the `__call_fn_0` export, matching the existing value-property pattern.
- **`collectKeys`** (the `ownKeys` trap) now enumerates both `_wasmStructProps` and `_wasmStructAccessors`, and strips `__get_<k>` / `__set_<k>` accessor sidecar entries so the underlying property name (`x`) shows up in enumeration instead of the descriptor key (`__get_x`).

Together these unblock `Object.assign` / spread copy of Symbol-keyed properties from WasmGC structs (the largest sub-bucket of the 27 fails flagged in #1336). The full §20.1.2.1 CopyDataProperties slow-path requires deeper codegen work — documented as out-of-scope follow-up in the issue file.

## Test plan

- [x] `tests/issue-1336.test.ts` — 2/2 pass (Symbol-keyed accessor copy + plain data property no-regression)
- [x] `tests/equivalence/{object-define-property,object-mutability,sparse-array-spread}.test.ts` — 32/32 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)