### PR TITLE
fix(#1359): bail concat fast path on vec-type mismatch / multi-arg

### DIFF
--- a/plan/issues/sprints/51/1359-spec-gap-array-splice-slice-concat-species-and-sparse.md
+++ b/plan/issues/sprints/51/1359-spec-gap-array-splice-slice-concat-species-and-sparse.md
@@ -2,7 +2,7 @@
 id: 1359
 sprint: 51
 title: "spec gap: Array.prototype.{splice,slice,concat,toSpliced,toReversed} — @@species, sparse handling, IsConcatSpreadable (~150 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: high
 feasibility: medium

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3363,11 +3363,26 @@ function compileArrayConcat(
   // Check if argument B is a known WasmGC array type. If not (e.g. `any`, `object`,
   // array-like with Symbol.isConcatSpreadable), struct.get would cause an illegal cast at runtime.
   // Fall back to __extern_method_call("concat") for non-array arguments.
+  //
+  // #1359: Also bail if the arg's vec type differs from the receiver's vec type
+  // (e.g. `[].concat([1, 2])` where the empty receiver is `__vec_externref` and the
+  // arg is `__vec_f64`). The fast path emits `ref.cast` from the arg to the receiver's
+  // vec type, which traps at runtime when the types don't match.
+  //
+  // #1359: Likewise bail when there are 2+ args; the typed fast path only handles a
+  // single arg, but `Array.prototype.concat` accepts variadic args and the host
+  // bridge handles them correctly.
   const argNode = callExpr.arguments[0]!;
   const argTsType = ctx.checker.getTypeAtLocation(argNode);
   const argArrayInfo = resolveArrayInfo(ctx, argTsType);
 
   if (!argArrayInfo) {
+    return compileArrayConcatExtern(ctx, fctx, propAccess, callExpr);
+  }
+  if (argArrayInfo.vecTypeIdx !== vecTypeIdx) {
+    return compileArrayConcatExtern(ctx, fctx, propAccess, callExpr);
+  }
+  if (callExpr.arguments.length > 1) {
     return compileArrayConcatExtern(ctx, fctx, propAccess, callExpr);
   }
 

--- a/tests/issue-1359.test.ts
+++ b/tests/issue-1359.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1359 — Array.prototype.concat: bail to host bridge when the typed fast path
+// can't safely handle the call shape.
+//
+// The typed fast path in `compileArrayConcat` was previously emitting a
+// `struct.get` / `ref.cast` against the arg using the receiver's vec type.
+// That trapped at runtime when:
+//   - the arg's vec type differed from the receiver's (e.g. `[].concat([1,2])`
+//     — receiver inferred as `__vec_externref`, arg as `__vec_f64`).
+//   - there were 2+ args (typed path only handled a single arg).
+//
+// Both cases now route through `compileArrayConcatExtern` which calls
+// `Array.prototype.concat` via the host bridge — handles variadic args,
+// IsConcatSpreadable, and mixed element types correctly per spec §23.1.3.2.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndCall<T>(src: string, fnName = "test"): Promise<T> {
+  const r = compile(src, { fileName: "test.ts" });
+  const errs = r.errors.filter((e) => e.severity === "error");
+  if (errs.length) {
+    throw new Error(`compile failed: ${errs.map((e) => `L${e.line}:${e.column} ${e.message}`).join(" | ")}`);
+  }
+  const env = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, env);
+  if (env.setExports) env.setExports(instance.exports as Record<string, Function>);
+  const fn = (instance.exports as Record<string, () => T>)[fnName]!;
+  return fn();
+}
+
+describe("issue #1359 — Array.concat fast-path safety", () => {
+  describe("vec-type-mismatch falls back to host bridge", () => {
+    it("[].concat([1, 2]) returns length 2 (no illegal cast)", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var item: number[] = [1, 2];
+          var result: number[] = [].concat(item);
+          return result.length;
+        }`,
+      );
+      expect(ret).toBe(2);
+    });
+
+    it("([] as number[]).concat([1, 2]) returns length 2", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var nums: number[] = [10, 20];
+          var result: any[] = ([] as any[]).concat(nums);
+          return result.length;
+        }`,
+      );
+      expect(ret).toBe(2);
+    });
+  });
+
+  describe("multi-arg concat falls back to host bridge", () => {
+    it("[1,2].concat([3,4], [5]) returns length 5", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var a: number[] = [1, 2];
+          var b: number[] = [3, 4];
+          var c: number[] = [5];
+          var result = a.concat(b, c);
+          return result.length;
+        }`,
+      );
+      expect(ret).toBe(5);
+    });
+
+    it("[].concat([1], [2], [3]) returns length 3", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var a: number[] = [1];
+          var b: number[] = [2];
+          var c: number[] = [3];
+          var result = ([] as number[]).concat(a, b, c);
+          return result.length;
+        }`,
+      );
+      expect(ret).toBe(3);
+    });
+  });
+
+  describe("single-arg same-vec-type takes the fast path (no regression)", () => {
+    it("[1, 2].concat([3, 4]) returns length 4", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var a: number[] = [1, 2];
+          var b: number[] = [3, 4];
+          var result = a.concat(b);
+          return result.length;
+        }`,
+      );
+      expect(ret).toBe(4);
+    });
+
+    it("[1, 2].concat([3, 4]) preserves elements", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var a: number[] = [1, 2];
+          var b: number[] = [10, 20];
+          var result = a.concat(b);
+          // sum elements as a checksum
+          var s = 0;
+          for (var i = 0; i < result.length; i++) s = s + result[i];
+          return s;
+        }`,
+      );
+      expect(ret).toBe(33); // 1 + 2 + 10 + 20
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the most regression-prone slice of #1359. The typed fast path in
`compileArrayConcat` previously emitted `ref.cast` against the first arg
using the receiver's vec type; that trapped at runtime in two patterns
that surface in test262:

- `[].concat([1, 2])` — receiver `[]` infers `__vec_externref`, arg
  `[1, 2]` is `__vec_f64`. Cast traps with `illegal cast`.
- `a.concat(b, c, ...)` — multi-arg concat. The fast path only inspected
  `arguments[0]`; the typed cast against the receiver type then trapped
  on subsequent args with mixed types.

Both patterns now route through `compileArrayConcatExtern`, which calls
`Array.prototype.concat` via the host bridge — handles variadic args,
IsConcatSpreadable, and mixed element types correctly per spec
§23.1.3.2.

## Out of scope (still tracked under #1359)

The remaining items need senior-dev attention because they require
spec-heavy infrastructure work:

- @@species via ArraySpeciesCreate (§7.3.24) for slice/splice/concat/toSpliced/toReversed/toSorted
- IsConcatSpreadable (Symbol.isConcatSpreadable) on the receiver/args
- HasProperty gating for sparse holes in slice/splice/concat
- Array brand for `Object.prototype.toString.call(emptySlice)` returning `[object Array]`

## Test plan

- [x] `tests/issue-1359.test.ts` — 6 cases (3 mismatch, 2 fast-path preservation, 1 multi-arg). All pass locally.
- [x] `tests/equivalence/array-prototype-methods.test.ts` — 13/13 pass; no regression on the fast path.
- [ ] CI test262 sharded suite — confirms net improvement.