### PR TITLE
docs(#1359): re-scoped sub-slice plan + Slice E sparse-hole rationale

### DIFF
--- a/plan/issues/sprints/51/1359-spec-gap-array-splice-slice-concat-species-and-sparse.md
+++ b/plan/issues/sprints/51/1359-spec-gap-array-splice-slice-concat-species-and-sparse.md
@@ -212,3 +212,113 @@ bridge handles it. Document this in a code comment so future work doesn't forget
 ### Estimated impact
 
 +100 net passes. §23.1 climbs further toward 60%.
+
+## Sub-slice decomposition (senior-dev refinement, 2026-05-08)
+
+After reading the failing tests directly (not just the architect's bisect),
+the original 5 sub-slices need re-scoping. Several are **blocked on issues
+deeper than this codegen path** and won't yield wins from changes inside
+`array-methods.ts` alone.
+
+### Slice A — empty-slice "actual: null" — **NOT a slice() bug**
+
+The architect's investigation said `x.slice(5,5)` returns null. Reading
+`slice/S15.4.4.10_A1.1_T4.js`:
+```js
+var arr = x.slice(5, 5);
+arr.getClass = Object.prototype.toString;
+if (arr.getClass() !== "[object Array]") { /* fail with "Actual: null" */ }
+```
+
+The `Actual: null` comes from `arr.getClass()` returning a brand string
+that doesn't match `"[object Array]"`, not from `arr` itself being null.
+This needs `Object.prototype.toString` brand fidelity for `__vec_*` —
+**#1334's territory** (Object.defineProperty descriptor + brand). NOT
+fixable inside `compileArraySlice`.
+
+**Disposition:** mark as blocked on #1334. No code change in this issue.
+
+### Slice B — ArraySpeciesCreate (@@species) — **medium scope, ~150 LoC**
+
+The architect's plan is correct: add `__array_species_create` host
+helper + inline check in `compileArraySlice` / `compileArraySplice` /
+`compileArrayConcat` when the static receiver type isn't `__vec_*`.
+For static-Array-typed receivers (the 95% common case), no change —
+`struct.new` is fast and correct because `Array[@@species] === Array`.
+
+The slow path (subclass receiver, proxy, custom `@@species`) is rare
+in user code; mainly test262. Estimated +10–30 net passes.
+
+**Disposition:** ship as a standalone follow-up. Track as **#1359B**
+(open new issue when ready).
+
+### Slice C — IsConcatSpreadable — **already partially handled**
+
+The existing fast-path `compileArrayConcat` only fires when
+`resolveArrayInfo(ctx, argTsType)` confirms the arg is a known WasmGC
+array type. For `any` / `object` / array-likes with
+`Symbol.isConcatSpreadable`, it falls back to
+`compileArrayConcatExtern` (host helper `__array_concat_any`). That
+host helper calls native `Array.prototype.concat` which respects
+`Symbol.isConcatSpreadable` natively.
+
+So most `is-concat-spreadable-*` tests should already work via the
+fallback. The ones that fail likely fail at the property assignment
+(`item[Symbol.isConcatSpreadable] = undefined`) — a Symbol-key
+indexing issue upstream of concat itself.
+
+**Disposition:** investigate which specific tests fail before adding
+the spreadable check to the typed fast path. Likely yields fewer
+passes than estimated. Track as **#1359C** with concrete failing
+tests after re-investigation.
+
+### Slice D — splice deleteCount=undefined — **already correct**
+
+Walked `compileArraySplice` (lines 3658–3735):
+- 0-arg → empty array, no mutation ✓ matches spec
+- 1-arg → `delCount = len - start` ✓ matches spec
+- 2-arg with `undefined` → compiles to NaN → `i32.trunc_sat_f64_s(NaN) = 0`
+  ✓ matches `ToInteger(undefined) === 0`
+
+The architect's failing test `splice/S15.4.4.12_A6.1_T2.js` is actually
+about `length` being non-writable — needs
+`Object.defineProperty(a, 'length', {writable: false})` and
+TypeError-on-write semantics. **#1334's territory**, not splice
+itself.
+
+**Disposition:** no fix needed in splice. The 25 splice `assertion_fail`
+count needs re-bucketing before any fix is attempted.
+
+### Slice E — Sparse hole preservation — **no-op for typed vecs (THIS PR)**
+
+For `__vec_*` typed receivers, no holes are possible at the WasmGC
+level. For host-array receivers, the existing `__proto_method_call`
+bridge handles sparse holes correctly. This slice is a code comment,
+not a behaviour change. Ship in this PR as documentation so future
+reviewers don't re-investigate the same paths.
+
+### Re-scoped follow-up plan
+
+Given the corrected analysis, the realistic yield from this issue is:
+
+| Slice | Yield | Status |
+|-------|-------|--------|
+| A | 0 (blocked on #1334) | doc-only, no code change |
+| **B** | +10–30 net passes | **track as #1359B follow-up** |
+| C | TBD (likely <10) | **track as #1359C follow-up** |
+| D | 0 (already correct) | doc-only, no code change |
+| **E** | 0 (no-op for typed vecs) | **doc comment THIS PR** |
+
+Total realistic yield from #1359 work alone is closer to **+10–30 net
+passes** (Slice B), not the original +100 estimate. The +100 assumed
+all 5 slices were tractable in `array-methods.ts`; 3 of them require
+fixes elsewhere (#1334 Object brand fidelity + Symbol-key indexing).
+
+### Action items
+
+1. **This PR**: Slice E doc comment + this re-scoped sub-slice plan
+2. **#1359B follow-up**: implement Slice B (@@species), separately
+3. **#1359C follow-up**: re-investigate Slice C with concrete failing
+   tests
+4. **Cross-issue note on #1334**: several Array.prototype tests block
+   on it

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3241,6 +3241,30 @@ function compileArrayShift(
 /**
  * arr.slice(start?, end?) -> create new vec struct with sliced data.
  */
+/**
+ * #1359 Slice E (sparse holes): for `__vec_*` typed receivers, no holes
+ * are possible at the WasmGC level — the underlying typed array is
+ * dense by construction. Spec §23.1.3.x's `HasProperty(O, k)` checks
+ * before `Get(O, k)` are therefore vacuously true for every k in
+ * `[start, end)`. We can `array.copy` the underlying buffer without
+ * iterating per-index. Host-array receivers (sparse, with prototype-
+ * inherited slots) flow through `__proto_method_call` which delegates
+ * to native `Array.prototype.slice` and gets the spec semantics for
+ * free. See sub-slice plan in the issue file for the full rationale.
+ *
+ * #1359 Slice A (empty-slice "actual: null"): NOT a slice() bug. The
+ * vec returned by this function is non-null (struct.new always returns
+ * non-null). The "actual: null" failure observed in
+ * `slice/S15.4.4.10_A1.1_T4.js` is downstream — the test calls
+ * `Object.prototype.toString.call(arr)` which needs the $vec brand to
+ * resolve to "[object Array]". That's #1334 territory.
+ *
+ * #1359 Slice B (@@species): receiver-type-driven dispatch. When the
+ * receiver's static type is a known `__vec_*`, `Array[@@species] ===
+ * Array` so `struct.new $vec` is correct. For subclass / proxy
+ * receivers (rare; mainly test262), needs `__array_species_create`
+ * host helper. Tracked as #1359B follow-up.
+ */
 function compileArraySlice(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3656,6 +3680,19 @@ function compileArrayJoin(
 
 /**
  * arr.splice(start, deleteCount?) -> in-place shift, returns new vec with deleted elements.
+ *
+ * #1359 Slice D (deleteCount=undefined): verified spec-correct in this
+ * function on 2026-05-08:
+ *   - 0-arg splice → empty array, no mutation ✓ §23.1.3.30 step 5
+ *   - 1-arg splice(start) → delCount = len - actualStart ✓ §23.1.3.30 step 11.b
+ *   - 2-arg splice(start, undefined) → compiles undefined as f64 NaN →
+ *     `i32.trunc_sat_f64_s(NaN) = 0` ✓ matches ToInteger(undefined) = 0
+ *
+ * The architect's reference test `splice/S15.4.4.12_A6.1_T2.js` actually
+ * tests TypeError-throw when `length` is non-writable, which needs
+ * Object.defineProperty + writable-attr fidelity (#1334), not a fix
+ * here. The 25 splice `assertion_fail` count in the issue's table
+ * needs re-bucketing before any further splice fix is attempted.
  */
 function compileArraySplice(
   ctx: CodegenContext,


### PR DESCRIPTION
## Summary
Senior-dev investigation of #1359. After reading the failing tests directly (instead of relying on the architect's bisect summary), **3 of the 5 sub-slices need re-scoping** — they're blocked on issues outside `array-methods.ts`:

| Slice | Original estimate | Reality |
|-------|-------------------|---------|
| A (empty-slice null) | bug in slice() | NOT a slice() bug — needs $vec brand fidelity (#1334) |
| B (@@species) | medium scope | Correct; track as #1359B follow-up (~10-30 net) |
| C (IsConcatSpreadable) | concat fix | Mostly handled by existing fallback; few residual fails are upstream Symbol-key indexing |
| D (splice deleteCount=undefined) | bug in splice() | Already spec-correct (verified) — failing test exercises non-writable length (#1334) |
| E (sparse holes) | preserve holes | No-op for typed vecs — doc comment THIS PR |

**Realistic yield from #1359 alone: +10-30 net passes (Slice B), not +100.** The +100 estimate assumed all 5 slices were tractable in array-methods.ts; 3 require fixes elsewhere.

## What's in this PR
- **Doc-only changes**, no behaviour change.
- `plan/issues/sprints/51/1359-spec-gap-array-splice-slice-concat-species-and-sparse.md` — added "Sub-slice decomposition (senior-dev refinement)" section with per-slice disposition, blockers, realistic yield, and follow-up issue placeholders (#1359B / #1359C).
- `src/codegen/array-methods.ts` — added Slice E doc comment on `compileArraySlice` (why typed-vec receivers don't need HasProperty checks) + Slice D verification comment on `compileArraySplice` (verified spec-correct, no fix needed).

## Test plan
- [x] Type-check clean
- [x] Pre-existing pop/shift failures confirmed unrelated (stashed changes, same failures on clean main)
- [ ] CI test262 — should be flat (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)