### PR TITLE
fix(#1381): pad missing endsWith/lastIndexOf position with JS undefined

### DIFF
--- a/plan/issues/sprints/51/1381-spec-gap-string-prototype-substring-slice-index-accessors.md
+++ b/plan/issues/sprints/51/1381-spec-gap-string-prototype-substring-slice-index-accessors.md
@@ -2,7 +2,7 @@
 id: 1381
 sprint: 51
 title: "spec gap: String.prototype.{substring,slice,indexOf,search,charAt,charCodeAt,codePointAt,at,includes,startsWith,endsWith,trim,concat} edge cases (~128 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: easy

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4468,6 +4468,18 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         }
         // Pad missing optional args with defaults (e.g. indexOf 2nd arg)
         if (paramTypes && args.length + 1 < paramTypes.length) {
+          // #1381 — `endsWith`/`startsWith`/`includes`/`lastIndexOf` distinguish
+          // null vs undefined for the position arg (endsWith(s) ⇒ pos defaults
+          // to length, but endsWith(s, null) ⇒ ToInteger(null)=0 ⇒ "" check).
+          // Pad missing externref position args with JS undefined (via
+          // `__get_undefined`) so the host sees the spec-correct "not passed"
+          // value instead of `null`.
+          const padsUndefined = method === "endsWith" || method === "lastIndexOf";
+          let undefIdx: number | undefined;
+          if (padsUndefined) {
+            undefIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
+            flushLateImportShifts(ctx, fctx);
+          }
           for (let pi = args.length + 1; pi < paramTypes.length; pi++) {
             const pt = paramTypes[pi]!;
             if (needsLengthDefault && pi === 2 && savedReceiverLocal !== undefined && pt.kind === "f64") {
@@ -4481,8 +4493,13 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
                 // Fallback if length import is unavailable for some reason
                 fctx.body.push({ op: "f64.const", value: 0x7fffffff });
               }
-            } else if (pt.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
-            else if (pt.kind === "f64") fctx.body.push({ op: "f64.const", value: 0 });
+            } else if (pt.kind === "externref") {
+              if (padsUndefined && undefIdx !== undefined) {
+                fctx.body.push({ op: "call", funcIdx: undefIdx });
+              } else {
+                fctx.body.push({ op: "ref.null.extern" });
+              }
+            } else if (pt.kind === "f64") fctx.body.push({ op: "f64.const", value: 0 });
             else if (pt.kind === "i32") fctx.body.push({ op: "i32.const", value: 0 });
           }
         }

--- a/tests/issue-1381.test.ts
+++ b/tests/issue-1381.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #1381 (slice B): String.prototype.lastIndexOf — pad missing
+ * fromIndex with JS `undefined` (not `null`) so the host sees the
+ * spec-correct "not passed" semantics. Per §22.1.3.10 step 4: when
+ * fromIndex is undefined, the spec uses +Infinity (clamped to length).
+ *
+ * Previous behaviour: missing externref args were padded with
+ * `ref.null.extern`. JS `"abcabc".lastIndexOf("a", null)` calls
+ * ToInteger(null)=0 ⇒ search range up to and including index 0 only ⇒
+ * returns 0 instead of the correct 3.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.ts";
+
+describe("#1381 String.prototype.lastIndexOf default fromIndex", () => {
+  it("lastIndexOf with no fromIndex defaults to +Infinity (returns last match)", async () => {
+    const src = `
+export function test(): number {
+  // "abcabc".lastIndexOf("a") — last 'a' is at index 3 (not 0).
+  return "abcabc".lastIndexOf("a");
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(3);
+  });
+
+  it("lastIndexOf with explicit fromIndex still works (no regression)", async () => {
+    const src = `
+export function test(): number {
+  // "abcabc".lastIndexOf("a", 2) — last 'a' at or before index 2 is at index 0.
+  return "abcabc".lastIndexOf("a", 2);
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(0);
+  });
+
+  it("lastIndexOf with not-found search returns -1", async () => {
+    const src = `
+export function test(): number {
+  return "abcabc".lastIndexOf("z");
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(-1);
+  });
+
+  it("indexOf with no fromIndex still works (no regression)", async () => {
+    const src = `
+export function test(): number {
+  return "abcabc".indexOf("a");
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses cluster B of #1381 — `endsWith`/`lastIndexOf` need their missing `position` arg padded with JS `undefined`, not `null`.

Per §22.1.3.{7,10}, when the position arg is missing the spec-mandated behaviour differs from null: `endsWith(s)` defaults to `length` and `lastIndexOf(s)` searches from `+∞` (last occurrence). The generic externref-arg padding pushes `ref.null.extern`, so the host sees JS `null` ⇒ `ToInteger(null) = 0` ⇒ `lastIndexOf("hello")` returned 0 instead of the last index.

Per-method padding rule: for `endsWith` and `lastIndexOf`, fill the missing externref position arg with `__get_undefined()` (real JS undefined). Other methods continue to use the existing null-padding (their semantics don't distinguish the two).

The position-arg extension for `startsWith`/`endsWith`/`includes` (cluster C of the issue) requires deeper STRING_METHODS table changes than fit cleanly in this PR — out of scope; documented as follow-up.

## Test plan

- [x] `tests/issue-1381.test.ts` — 4/4 pass (lastIndexOf default = +∞, lastIndexOf with explicit fromIndex no-regression, lastIndexOf not-found, indexOf no-regression)
- [x] `tests/equivalence/string-methods.test.ts` — 42/42 pass (previously 41 pass + 1 fail; the lastIndexOf-finds-last-occurrence regression is now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)