### PR TITLE
fix(#1361): TypeError on non-callable Array.sort comparator

### DIFF
--- a/plan/issues/sprints/51/1361-spec-gap-array-sort-comparator-stability.md
+++ b/plan/issues/sprints/51/1361-spec-gap-array-sort-comparator-stability.md
@@ -2,7 +2,7 @@
 id: 1361
 sprint: 51
 title: "spec gap: Array.prototype.sort — comparator validation, stability, ToString fallback (~46 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: medium

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4862,11 +4862,34 @@ function compileArraySort(
   ctx: CodegenContext,
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
-  _callExpr: ts.CallExpression,
+  callExpr: ts.CallExpression,
   vecTypeIdx: number,
   arrTypeIdx: number,
   elemType: ValType,
 ): ValType | null {
+  // #1361: Spec §23.1.3.30 step 1 — if comparefn is provided and is not a
+  // function, throw TypeError BEFORE any sort work begins. Fires only when
+  // the argument is known statically to be non-callable (null, number,
+  // string, etc.); `undefined` is explicitly allowed as "no comparator".
+  if (callExpr.arguments.length >= 1) {
+    const cbArg = callExpr.arguments[0]!;
+    const isExplicitUndefined =
+      cbArg.kind === ts.SyntaxKind.UndefinedKeyword || (ts.isIdentifier(cbArg) && cbArg.text === "undefined");
+    if (!isExplicitUndefined && isKnownNonCallable(ctx, cbArg)) {
+      // Compile the receiver and arg for side effects, then throw. The receiver
+      // expression may have getters that mutate state — spec evaluation order
+      // is "evaluate receiver, evaluate args, validate arg, then sort". Doing
+      // both keeps user code observable.
+      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      if (recvType) fctx.body.push({ op: "drop" });
+      const cbType = compileExpression(ctx, fctx, cbArg);
+      if (cbType) fctx.body.push({ op: "drop" });
+      emitThrowString(ctx, fctx, "TypeError: Array.prototype.sort comparator is not a function");
+      fctx.body.push({ op: "unreachable" } as unknown as Instr);
+      return { kind: "ref_null", typeIdx: vecTypeIdx };
+    }
+  }
+
   const elemKind = elemType.kind as "i32" | "f64";
   const timsortIdx = ensureTimsortHelper(ctx, vecTypeIdx, arrTypeIdx, elemKind);
 

--- a/tests/issue-1361.test.ts
+++ b/tests/issue-1361.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1361 — Array.prototype.sort comparator validation.
+//
+// Spec §23.1.3.30 step 1 mandates that a non-callable comparator (other than
+// undefined) throws TypeError before any sort work begins. The compiler now
+// emits an early TypeError throw when the comparator argument is known
+// statically to be non-callable (null, number, string, boolean).
+//
+// `undefined` is explicitly allowed as "no comparator" (default ToString
+// ordering). Default ordering correctness is out-of-scope here — tracked
+// in the larger #1361 plan items (B + C).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndCall<T>(src: string, fnName = "test"): Promise<T> {
+  const r = compile(src, { fileName: "test.ts" });
+  const errs = r.errors.filter((e) => e.severity === "error");
+  if (errs.length) {
+    throw new Error(`compile failed: ${errs.map((e) => `L${e.line}:${e.column} ${e.message}`).join(" | ")}`);
+  }
+  const env = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, env);
+  if (env.setExports) env.setExports(instance.exports as Record<string, Function>);
+  const fn = (instance.exports as Record<string, () => T>)[fnName]!;
+  return fn();
+}
+
+describe("issue #1361 — Array.prototype.sort comparator validation", () => {
+  describe("non-callable comparator throws TypeError", () => {
+    it("sort(null) throws TypeError", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          var caught = 0;
+          try {
+            arr.sort(null);
+          } catch (e: any) {
+            caught = 1;
+          }
+          return caught;
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("sort(42) throws TypeError", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          var caught = 0;
+          try {
+            arr.sort(42);
+          } catch (e: any) {
+            caught = 1;
+          }
+          return caught;
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("sort('foo') throws TypeError", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          var caught = 0;
+          try {
+            arr.sort("foo");
+          } catch (e: any) {
+            caught = 1;
+          }
+          return caught;
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("sort(true) throws TypeError", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          var caught = 0;
+          try {
+            arr.sort(true);
+          } catch (e: any) {
+            caught = 1;
+          }
+          return caught;
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+  });
+
+  describe("undefined / no-arg / callable comparator does NOT throw", () => {
+    it("sort() with no args succeeds", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          arr.sort();
+          // ascending order: [1, 2, 3] -> first element 1
+          return arr[0];
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("sort(undefined) succeeds (treated as no comparator)", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          arr.sort(undefined);
+          return arr[0];
+        }`,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("sort(arrowFn) does not throw", async () => {
+      const ret = await compileAndCall<number>(
+        `export function test(): number {
+          var arr: any = [3, 1, 2] as number[];
+          var threw = 0;
+          try {
+            arr.sort((a, b) => a - b);
+          } catch (e: any) {
+            threw = 1;
+          }
+          return threw;
+        }`,
+      );
+      expect(ret).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes architect plan §A of #1361. `Array.prototype.sort` previously
ignored its comparator argument entirely — both the value and the type.
Spec §23.1.3.30 step 1 requires throwing TypeError before any sort
work when the comparator is provided and not callable.

This PR emits an early TypeError throw when the comparator argument
is statically known to be non-callable: null, numeric literal, string
literal, boolean literal, or a TS type that resolves to one of those
primitives. `undefined` (literal or global identifier) is allowed per
spec and falls through to the default sort.

## Out of scope (still tracked under #1361)

- §B Default = ToString comparison (timsort hardcodes f64.lt).
- §C NaN-in-comparator → 0 (depends on actual comparator routing).
- §D Stability for comparator path (depends on §1382 closure bridge).
- §E Undefined/sparse partitioning.

## Test plan

- [x] tests/issue-1361.test.ts — 7 cases (4 throw, 3 no-throw). All pass locally.
- [x] tests/equivalence/array-prototype-methods.test.ts — 13/13 pass; no regression.
- [ ] CI test262 — confirms net improvement on `built-ins/Array/prototype/sort/comparefn-nonfunction-*`.