### PR TITLE
fix(#1362): Object.defineProperties — TypeError on null/undefined props + Symbol-key enumeration

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2623,17 +2623,33 @@ assert._isSameValue = isSameValue;
           if (obj == null || (typeof obj !== "object" && typeof obj !== "function")) {
             throw new TypeError("Object.defineProperties called on non-object");
           }
-          if (descsObj == null) return obj;
-          // Helper to get keys from plain or opaque objects
-          const getKeys = (o: any): string[] => {
+          // #1362 — §20.1.2.3 step 2: `props = ToObject(Properties)` throws
+          // TypeError on null/undefined. Previously the runtime silently
+          // returned obj for null/undefined props, masking
+          // `Object.defineProperties(o, undefined)` test262 negative tests.
+          if (descsObj == null) {
+            throw new TypeError("Object.defineProperties: Properties argument cannot be null or undefined");
+          }
+          // Helper to get keys from plain or opaque objects.
+          // #1362 — include Symbol keys per §20.1.2.3 step 3 (uses
+          // [[OwnPropertyKeys]] which spans both string and Symbol keys);
+          // previously only string keys were enumerated, dropping any
+          // Symbol-keyed descriptor entries silently.
+          const getKeys = (o: any): (string | symbol)[] => {
             if (_isWasmStruct(o)) {
               const exps = callbackState?.getExports();
-              const fieldNames = _getStructFieldNames(o, exps) ?? [];
+              const fieldNames: (string | symbol)[] = _getStructFieldNames(o, exps) ?? [];
               const sc = _wasmStructProps.get(o);
-              if (sc) for (const k of Object.keys(sc)) if (!fieldNames.includes(k)) fieldNames.push(k);
+              if (sc) {
+                for (const k of Object.keys(sc)) if (!fieldNames.includes(k)) fieldNames.push(k);
+                for (const k of Object.getOwnPropertySymbols(sc)) fieldNames.push(k);
+              }
+              const accMap = _wasmStructAccessors.get(o);
+              if (accMap) for (const k of accMap.keys()) if (!fieldNames.includes(k)) fieldNames.push(k);
               return fieldNames;
             }
-            return Object.keys(o);
+            // Reflect.ownKeys spans string + symbol keys per spec.
+            return Reflect.ownKeys(o);
           };
           // Helper to get a field value from plain or opaque object
           const getField = (o: any, field: string): any => {

--- a/tests/issue-1362.test.ts
+++ b/tests/issue-1362.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #1362 — Object.defineProperties spec fixes.
+ *
+ * §20.1.2.3 (Object.defineProperties):
+ *   - Step 2: ToObject(Properties) throws TypeError on null/undefined.
+ *   - Step 3: Iterate [[OwnPropertyKeys]] — includes Symbol keys.
+ *
+ * Previous host impl silently returned obj for null/undefined Properties
+ * and only iterated `Object.keys` (string keys).
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.ts";
+
+describe("#1362 Object.defineProperties spec gaps", () => {
+  it("throws TypeError when Properties is undefined", async () => {
+    const src = `
+export function test(): number {
+  const o: any = {};
+  try {
+    Object.defineProperties(o, undefined as any);
+    return 0;
+  } catch (e) {
+    return e instanceof TypeError ? 1 : 2;
+  }
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(1);
+  });
+
+  it("throws TypeError when Properties is null", async () => {
+    const src = `
+export function test(): number {
+  const o: any = {};
+  try {
+    Object.defineProperties(o, null as any);
+    return 0;
+  } catch (e) {
+    return e instanceof TypeError ? 1 : 2;
+  }
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(1);
+  });
+
+  it("throws TypeError when target is null", async () => {
+    const src = `
+export function test(): number {
+  try {
+    Object.defineProperties(null as any, { x: { value: 1 } });
+    return 0;
+  } catch (e) {
+    return e instanceof TypeError ? 1 : 2;
+  }
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(1);
+  });
+
+  it("applies multiple data descriptors (no regression)", async () => {
+    const src = `
+export function test(): number {
+  const o: any = {};
+  Object.defineProperties(o, {
+    a: { value: 1, enumerable: true, writable: true, configurable: true },
+    b: { value: 2, enumerable: true, writable: true, configurable: true },
+  });
+  return (o.a as number) + (o.b as number);
+}
+`;
+    const r = await compileToWasm(src);
+    expect((r as any).test()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Two §20.1.2.3 spec gaps in the `__defineProperties` host import:

1. **Step 2 — `props = ToObject(Properties)`** throws TypeError on null/undefined. Previously the runtime silently returned `obj` when descsObj was null/undefined, masking `Object.defineProperties(o, undefined)` test262 negative tests.
2. **Step 3 — `[[OwnPropertyKeys]]`** spans both string and Symbol keys. The WasmGC-struct fast path was using `Object.keys` (string-only); Symbol-keyed descriptor entries were silently dropped.

After: throw TypeError for null/undefined props; the WasmGC `getKeys` helper also enumerates `_wasmStructProps` symbol keys and `_wasmStructAccessors`; the native path uses `Reflect.ownKeys` to span symbols.

Out of scope (documented as follow-up):
- Two-phase commit ordering (§20.1.2.3 step 5 — collect all descriptors first, only apply if every read succeeds)
- Full ToPropertyDescriptor receiver-side validation chain

## Test plan

- [x] `tests/issue-1362.test.ts` — 4/4 pass (TypeError on undefined / null Properties / null target; multi-data-descriptor no-regression)
- [x] `tests/equivalence/{object-define-property,object-mutability}.test.ts` — 13/13 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)