### PR TITLE
docs(#1369): triage — most cases pass, three distinct codegen bugs remain

### DIFF
--- a/plan/issues/sprints/51/1369-spec-gap-string-split-replace-replaceall-limit-symbol-protocol.md
+++ b/plan/issues/sprints/51/1369-spec-gap-string-split-replace-replaceall-limit-symbol-protocol.md
@@ -2,7 +2,7 @@
 id: 1369
 sprint: 51
 title: "spec gap: String.prototype.{split,replace,replaceAll,match,matchAll} — limit, @@split/@@replace/@@match protocol (~150 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: medium
@@ -198,3 +198,118 @@ no fix needed. If we have a Wasm-native fast path, verify the arg order in
 ### Estimated impact
 
 +90 passes. §22.1 climbs from 63% to ~70%.
+
+## 2026-05-08 investigation notes (dev-incr)
+
+Probed acceptance criteria locally on `origin/main` HEAD `192b03eb1`.
+**Most acceptance-criteria cases already pass** — the remaining
+failures cluster in three distinct codegen bugs that need careful
+coordinated changes (not appropriate for a single PR per the
+dev-self-merge regression-rate gate).
+
+### Already passes
+
+- `"abc".split(undefined)` → `["abc"]` ✓
+- `"abc".split("")` → `["a","b","c"]` ✓
+- `"a,b,c".split(/,/)` → `["a","b","c"]` ✓
+- `"abc".replaceAll(/b/, "x")` throws TypeError on non-global RegExp ✓
+- `"abcabc".replaceAll(/b/g, "x")` → `"axcaxc"` ✓
+- `"abc".replaceAll("", "x")` → `"xaxbxcx"` ✓
+- `"abc".match(/b/)` returns `["b", index, ...]` ✓
+- `"abc".match(/x/)` returns `null` ✓
+- `"aabbab".matchAll(/a/g)` iterates correctly ✓
+- `"abc".matchAll(/a/)` (non-global) throws TypeError ✓
+- `"abc".replace(/(b)/, "[$1]")` → `"a[b]c"` (capture refs) ✓
+- `String.prototype.split.call(null, ",")` → TypeError (receiver
+  coercion) ✓
+
+### Three remaining clusters
+
+#### Cluster 1 — `split(separator, limit)` drops the limit argument
+
+```ts
+"a,b,c,d".split(",", 2);  // returns ["a","b","c","d"], not ["a","b"]
+"abc".split("b", 0);       // returns ["a","c"], not []
+```
+
+WAT shows the limit is compiled as `f64.const N` then dropped before
+the host call:
+
+```
+global.get $abcd
+global.get $comma
+f64.const 2
+drop                    ;; <-- limit dropped
+call $string_split_import
+```
+
+The `STRING_METHODS` table at `src/codegen/index.ts:3140` declares
+`split: { params: [externref], result: externref }` — only the
+separator. Need to extend to `params: [externref, externref]` so the
+call site emits the limit, and update the padding rule for missing
+limit to use `__get_undefined()` (NOT `ref.null.extern` — `null` would
+ToUint32 to 0, not the spec default 2^32-1). Affects ~30+ split tests.
+
+#### Cluster 2 — `replace(re, fn)` callback args off-by-one
+
+```ts
+"abc".replace(/b/, function(this: any, m, off, str) {
+  // expected: m="b", off=1, str="abc"
+  // actual:   m=1,   off="abc", str=undefined
+});
+```
+
+The Wasm callback function type has 5 params (cap + 4) but the JS
+host wrapper passes only 3 actual args (match, offset, string), so
+the trailing `str` is undefined and the rest are shifted. The offset
+mismatch suggests the wrapper passes args starting at param index 1
+instead of 2 — possibly the `this` slot is being conflated. Needs
+inspection of `__make_callback` and the closure-bridge layer.
+
+This bug is closely related to #1382 (Wasm closures not JS-callable
+from host imports — bridge gap). Likely the same root cause: the JS
+host wrapper around Wasm closures has an arg-passing convention
+mismatch.
+
+Affected: every `replace(re, fn)` test that inspects the callback
+arguments. Likely ~15 fails.
+
+#### Cluster 3 — `Symbol.split` / `Symbol.replace` / `Symbol.match`
+            custom-method dispatch missing
+
+The current pipeline always routes through `string_split` /
+`string_replace` host imports. If a user passes an object with a
+custom `Symbol.split` method, the spec says we must call
+`obj[Symbol.split](S, limit)`. Today we coerce the separator to a
+string and split on its toString — which works for RegExp (since
+RegExp.prototype.@@split is special-cased on the host) but not for
+user-defined separator objects.
+
+This is a narrow population in test262 (a handful of tests). Spec
+work but low impact.
+
+### Why this isn't safe to fix in one PR
+
+#1380 (PR #272) showed that adding new params to host-imported
+methods can mask existing bugs and trigger regressions in unrelated
+test buckets when the stack-balance fixup pass interacts with the
+shifted call signature. The fix needs:
+
+1. Add `limit` as the 2nd `split` param in `STRING_METHODS`.
+2. Add a per-method padding rule so missing `limit` becomes
+   `__get_undefined()`, not `ref.null.extern`.
+3. Audit the Wasm callback wrapper argument convention (cluster 2).
+4. Run a full Test262 sharded CI to catch cascade regressions.
+
+The first two items are coordinated changes to two files
+(string-ops.ts/index.ts + property-access.ts call site). The third
+item is structural and overlaps with #1382. Suggest splitting:
+
+- **#1369a** — `split` limit (Cluster 1, contained codegen change).
+- **#1369b** — `replace` callback args (Cluster 2, depends on #1382
+  closure bridge).
+- **#1369c** — `Symbol.split`/`@@replace`/`@@match` dispatch
+  (Cluster 3, runtime helper additions).
+
+Releasing the task back to the queue with this triage so the next
+dev / architect can resume cleanly with focused sub-issues.


### PR DESCRIPTION
## Summary

Triage of #1369 (~150 String split/replace/replaceAll/match/matchAll fails). Probed
acceptance criteria locally on `origin/main` HEAD `192b03eb1`.

**Most #1369 acceptance cases already pass on main**:

- `split` with empty / regex / undefined separator
- `replaceAll` on global RegExp; throws TypeError on non-global
- `match` / `matchAll` iteration + null result
- `replace` with capture refs (`\$1`)
- `split.call(null)` → TypeError (receiver coercion)

**Three remaining clusters** that need coordinated changes (not safe in one omnibus PR):

1. **`split(sep, limit)` drops the limit arg** — `STRING_METHODS` table declares
   only one externref param; the user-passed limit gets compiled then dropped.
   Same architectural pattern as #1381 cluster-3. Fix needs:
   - Extend `params` to 2 externref slots
   - Per-method padding rule: `__get_undefined()` for missing limit (NOT
     `ref.null.extern`, since `null` → `ToUint32(null) = 0`, not the spec default
     `2^32 - 1`)
   - ~30+ test262 tests affected

2. **`replace(re, fn)` callback args off-by-one** — fn receives `(offset, string)`
   instead of `(match, offset, string)`. Wasm callback type has 5 params but the
   host wrapper passes only 3 actual args, shifting the offsets. Closely
   related to **#1382** (closure bridge). ~15 tests affected.

3. **`Symbol.split` / `Symbol.replace` / `Symbol.match` custom-method dispatch
   bypassed** — we always route through `string_<method>` host imports. Narrow
   impact (~5 tests).

## Why this isn't a single-PR fix

PR #272 (#1380 strict-eq fix, just escalated) showed that adding params or
changing host-import dispatch can cascade into unrelated test buckets via the
stack-balance fixup pass, producing net-negative test262 deltas. This issue
needs three focused sub-PRs (#1369a/b/c) — see issue file for details.

## Test plan

- [x] No source changes (docs-only PR) — only the issue file is touched.
- [ ] CI: basic checks only (Test262 Sharded skipped — no `src/**` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)