### PR TITLE
feat(#1376): IR fallback telemetry gate — CI prevents bypass regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      - name: IR fallback gate (#1376)
+        run: pnpm run check:ir-fallbacks
+
       - name: Fetch runs/index.json from baselines repo
         if: github.event_name == 'push'
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,35 @@ The committed JSONL must be kept in sync with the JSON; otherwise the dev-self-m
 
 To validate the committed JSONL on demand, run `pnpm run test:262:validate-baseline` (uses a deterministic seed; pass `PR_NUMBER=N` to reproduce a specific CI run, or `SAMPLE_SIZE=10 SEED=12345` for a quicker check). Set `SAMPLE_SIZE=50` to match CI exactly. The validator fails fast on the first 5 most-affected entries with a pointer to `refresh-committed-baseline.yml`.
 
+## IR Fallback Budget (#1376)
+
+The IR retirement gate `pnpm run check:ir-fallbacks` walks every `.ts` file
+under `playground/examples/` with `trackFallbacks: true` and aggregates
+rejection reasons against `scripts/ir-fallback-baseline.json`. CI fails when
+any **unintended** bucket grows.
+
+| Reason                       | Category   | Reduces with                         |
+|------------------------------|------------|--------------------------------------|
+| `body-shape-rejected`        | unintended | #1370 (class methods), #1373 (async) |
+| `external-call`              | unintended | #1371 (whitelist Math.* / parseInt)  |
+| `call-graph-closure`         | unintended | #1370, #1373                         |
+| `param-shape-rejected`       | unintended | #1372 (destructuring params)         |
+| `param-type-not-resolvable`  | unintended | better TypeMap propagation           |
+| `return-type-not-resolvable` | unintended | better TypeMap propagation           |
+| `type-resolution-failure`    | unintended | better TypeMap propagation           |
+| `async-generator`            | deferred   | (out of scope long-term)             |
+| `deferred-feature`           | deferred   | (eval / Proxy / with — wont-fix)     |
+| `type-parameters`            | deferred   | (generics specialisation, future)    |
+| `non-export-modifier`        | deferred   | (`async` / declare-only — narrow)    |
+| `unnamed`                    | deferred   | (anonymous default exports)          |
+
+Refresh the baseline on PRs that intentionally retire a bypass:
+
+```bash
+pnpm run check:ir-fallbacks -- --update
+git add scripts/ir-fallback-baseline.json
+```
+
 ## CLI Flags
 - `--target wasi` — emit WASI imports (fd_write, proc_exit) instead of JS host
 - `--optimize` / `-O` — run Binaryen wasm-opt on compiled binary

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:watch": "node node_modules/vitest/dist/cli.js",
     "test:262": "bash scripts/run-test262-vitest.sh",
     "test:262:validate-baseline": "npx tsx scripts/validate-test262-baseline.ts",
+    "check:ir-fallbacks": "npx tsx scripts/check-ir-fallbacks.ts",
     "test:diff": "npx tsx scripts/diff-test.ts",
     "test:diff:triage": "npx tsx scripts/diff-triage.ts",
     "test:diff:gate": "npx tsx scripts/diff-test-gate.ts",

--- a/plan/issues/sprints/51/1376-ir-fallback-telemetry-gate.md
+++ b/plan/issues/sprints/51/1376-ir-fallback-telemetry-gate.md
@@ -2,7 +2,7 @@
 id: 1376
 sprint: 51
 title: "IR: fallback telemetry gate — CI fails when unintended legacy bypasses exceed threshold"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: high
 feasibility: easy

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1376 — IR fallback telemetry gate.
+ *
+ * Compiles a fixed corpus of `.ts` files, calls `planIrCompilation` with
+ * `trackFallbacks: true`, and aggregates rejection reasons by category.
+ *
+ * Compares against the committed baseline at `scripts/ir-fallback-baseline.json`.
+ * Fails the CI quality job when an `unintended` fallback bucket increases vs.
+ * baseline. Decreases (or equal counts) succeed and (when run with `--update`)
+ * refresh the committed baseline.
+ *
+ * Categories — see `IrFallbackReason` in `src/ir/select.ts`:
+ *
+ *   unintended (must not increase, target = 0):
+ *     - body-shape-rejected   — Phase-1 statement-shape gate
+ *     - external-call         — call to non-local identifier
+ *     - call-graph-closure    — caller/callee not claimed
+ *     - param-shape-rejected  — optional/rest/initializer/non-identifier
+ *     - type-resolution-failure
+ *     - return-type-not-resolvable
+ *     - param-type-not-resolvable
+ *
+ *   deferred (allowed; tracked but not gated):
+ *     - async-generator
+ *     - type-parameters
+ *     - non-export-modifier
+ *     - unnamed
+ *
+ * Usage:
+ *   pnpm run check:ir-fallbacks            # gate against baseline
+ *   pnpm run check:ir-fallbacks -- --update # refresh the committed baseline
+ *   pnpm run check:ir-fallbacks -- --json   # emit JSON only (machine-readable)
+ *
+ * Corpus: every `.ts` file under `playground/examples/` (excluding `.d.ts`).
+ */
+import { readFileSync, writeFileSync, existsSync, statSync, readdirSync } from "node:fs";
+import { join, dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { planIrCompilation, type IrFallbackReason } from "../src/ir/select.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const BASELINE_PATH = join(REPO_ROOT, "scripts/ir-fallback-baseline.json");
+const CORPUS_ROOTS = [join(REPO_ROOT, "playground/examples")];
+
+/** Reasons that must NOT increase vs. baseline. */
+const UNINTENDED: ReadonlySet<IrFallbackReason> = new Set([
+  "body-shape-rejected",
+  "external-call",
+  "call-graph-closure",
+  "param-shape-rejected",
+  "type-resolution-failure",
+  "return-type-not-resolvable",
+  "param-type-not-resolvable",
+]);
+
+/** Reasons that are expected until their corresponding slices land. */
+const DEFERRED: ReadonlySet<IrFallbackReason> = new Set([
+  "async-generator",
+  "deferred-feature",
+  "type-parameters",
+  "non-export-modifier",
+  "unnamed",
+]);
+
+interface Baseline {
+  readonly generated: string;
+  readonly unintended: Partial<Record<IrFallbackReason, number>>;
+  readonly deferred: Partial<Record<IrFallbackReason, number>>;
+}
+
+function listTsFiles(root: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name);
+      const s = statSync(p);
+      if (s.isDirectory()) {
+        stack.push(p);
+      } else if (s.isFile() && name.endsWith(".ts") && !name.endsWith(".d.ts")) {
+        out.push(p);
+      }
+    }
+  }
+  return out.sort();
+}
+
+function aggregate(): {
+  unintended: Partial<Record<IrFallbackReason, number>>;
+  deferred: Partial<Record<IrFallbackReason, number>>;
+  perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }>;
+} {
+  const corpus = CORPUS_ROOTS.flatMap(listTsFiles);
+
+  // One in-memory program per file is fine for a 10-file corpus and keeps the
+  // checker scope local. Each file's TypeMap is independent.
+  const unintended: Partial<Record<IrFallbackReason, number>> = {};
+  const deferred: Partial<Record<IrFallbackReason, number>> = {};
+  const perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }> = [];
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    skipLibCheck: true,
+    noEmit: true,
+  };
+
+  for (const filePath of corpus) {
+    const source = readFileSync(filePath, "utf-8");
+    const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.ES2022, true);
+
+    // Build a tiny program over just this file so we can derive a checker
+    // for the type-propagation pass. Use an in-memory host that returns the
+    // file source for `filePath` and falls back to the disk for libs.
+    const host: ts.CompilerHost = {
+      getSourceFile: (name) => {
+        if (name === filePath) return sf;
+        if (existsSync(name)) {
+          return ts.createSourceFile(name, readFileSync(name, "utf-8"), ts.ScriptTarget.ES2022, true);
+        }
+        return undefined;
+      },
+      writeFile: () => {},
+      getDefaultLibFileName: () => "lib.d.ts",
+      getCurrentDirectory: () => REPO_ROOT,
+      getCanonicalFileName: (n) => n,
+      useCaseSensitiveFileNames: () => true,
+      getNewLine: () => "\n",
+      fileExists: (n) => existsSync(n),
+      readFile: (n) => (existsSync(n) ? readFileSync(n, "utf-8") : undefined),
+    };
+    const program = ts.createProgram([filePath], compilerOptions, host);
+    const checker = program.getTypeChecker();
+    const sourceFile = program.getSourceFile(filePath) ?? sf;
+
+    let typeMap;
+    try {
+      typeMap = buildTypeMap(sourceFile, checker);
+    } catch {
+      // If type propagation fails for an example file, skip it. The point of
+      // the gate is to catch IR-claim-shape regressions in the compiler, not
+      // to gate on TS type-checker quirks for example code.
+      continue;
+    }
+
+    const selection = planIrCompilation(sourceFile, { experimentalIR: true, trackFallbacks: true }, typeMap);
+    const fileReasons: Partial<Record<IrFallbackReason, number>> = {};
+    for (const fb of selection.fallbacks ?? []) {
+      const bucket = UNINTENDED.has(fb.reason) ? unintended : deferred;
+      bucket[fb.reason] = (bucket[fb.reason] ?? 0) + 1;
+      fileReasons[fb.reason] = (fileReasons[fb.reason] ?? 0) + 1;
+    }
+    perFile.push({ file: relative(REPO_ROOT, filePath), reasons: fileReasons });
+  }
+  return { unintended, deferred, perFile };
+}
+
+function loadBaseline(): Baseline | undefined {
+  if (!existsSync(BASELINE_PATH)) return undefined;
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, "utf-8")) as Baseline;
+  } catch {
+    return undefined;
+  }
+}
+
+function diffTable(
+  base: Partial<Record<IrFallbackReason, number>>,
+  cur: Partial<Record<IrFallbackReason, number>>,
+): { rows: Array<{ reason: string; base: number; cur: number; delta: number }>; anyIncrease: boolean } {
+  const reasons = new Set<string>([...Object.keys(base), ...Object.keys(cur)]);
+  const rows: Array<{ reason: string; base: number; cur: number; delta: number }> = [];
+  let anyIncrease = false;
+  for (const reason of [...reasons].sort()) {
+    const b = base[reason as IrFallbackReason] ?? 0;
+    const c = cur[reason as IrFallbackReason] ?? 0;
+    const delta = c - b;
+    rows.push({ reason, base: b, cur: c, delta });
+    if (delta > 0) anyIncrease = true;
+  }
+  return { rows, anyIncrease };
+}
+
+function formatTable(label: string, rows: Array<{ reason: string; base: number; cur: number; delta: number }>): string {
+  if (rows.length === 0) return `\n${label}: (none)\n`;
+  const max = Math.max(label.length, ...rows.map((r) => r.reason.length));
+  const lines = [
+    `\n${label}:`,
+    `  ${"reason".padEnd(max)}  baseline   current     delta`,
+    `  ${"-".repeat(max)}  --------  --------  --------`,
+    ...rows.map(
+      (r) =>
+        `  ${r.reason.padEnd(max)}  ${String(r.base).padStart(8)}  ${String(r.cur).padStart(8)}  ${(r.delta > 0 ? "+" + r.delta : String(r.delta)).padStart(8)}`,
+    ),
+  ];
+  return lines.join("\n");
+}
+
+function main(): void {
+  const args = new Set(process.argv.slice(2));
+  const mode: "gate" | "update" | "json" = args.has("--update") ? "update" : args.has("--json") ? "json" : "gate";
+
+  const { unintended, deferred } = aggregate();
+
+  if (mode === "json") {
+    process.stdout.write(JSON.stringify({ unintended, deferred }, null, 2) + "\n");
+    return;
+  }
+
+  const generated = new Date().toISOString().slice(0, 10);
+  const next: Baseline = { generated, unintended, deferred };
+
+  if (mode === "update") {
+    writeFileSync(BASELINE_PATH, JSON.stringify(next, null, 2) + "\n", "utf-8");
+    process.stdout.write(`Updated ${relative(REPO_ROOT, BASELINE_PATH)}\n`);
+    process.stdout.write(formatTable("Unintended (target = 0)", diffTable({}, unintended).rows));
+    process.stdout.write(formatTable("Deferred (informational)", diffTable({}, deferred).rows) + "\n");
+    return;
+  }
+
+  const baseline = loadBaseline();
+  if (!baseline) {
+    process.stdout.write(`No baseline at ${relative(REPO_ROOT, BASELINE_PATH)}. Run with --update to create it.\n`);
+    process.exit(1);
+  }
+
+  const unDiff = diffTable(baseline.unintended, unintended);
+  const defDiff = diffTable(baseline.deferred, deferred);
+  process.stdout.write(formatTable("Unintended (gated; must not increase)", unDiff.rows));
+  process.stdout.write(formatTable("Deferred (informational)", defDiff.rows) + "\n");
+
+  if (unDiff.anyIncrease) {
+    process.stderr.write(
+      `\nIR fallback gate: at least one unintended bucket grew vs. baseline.\n` +
+        `If the change was intentional (e.g. new IR-claimable feature added in a separate PR), ` +
+        `run \`pnpm run check:ir-fallbacks -- --update\` and commit the refreshed baseline.\n`,
+    );
+    process.exit(1);
+  }
+
+  // All decreases or equal — silently refresh on local runs is unsafe (would
+  // cause main to drift). Just succeed; CI doesn't auto-update either.
+  process.stdout.write("\nIR fallback gate: OK (no unintended increases vs. baseline).\n");
+}
+
+main();

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,0 +1,9 @@
+{
+  "generated": "2026-05-08",
+  "unintended": {
+    "body-shape-rejected": 22,
+    "param-type-not-resolvable": 1,
+    "call-graph-closure": 6
+  },
+  "deferred": {}
+}


### PR DESCRIPTION
## Summary

Adds a CI quality gate that prevents the IR fallback set from silently growing as new code is added. The IR retirement plan is "once the count of unintended fallbacks is zero against the corpus, the legacy emitters can be retired" — this gate makes that count visible and enforced.

## How it works

- **`scripts/check-ir-fallbacks.ts`** walks every `.ts` file under `playground/examples/`, parses each into a TypeScript program with a per-file checker, runs `buildTypeMap` and `planIrCompilation` with `trackFallbacks: true`, and aggregates the rejection reasons.
- Reasons split into **UNINTENDED** (must not increase, target = 0) and **DEFERRED** (allowed; informational).
- **`scripts/ir-fallback-baseline.json`** is the committed baseline.
- `pnpm run check:ir-fallbacks` exits non-zero when any unintended bucket grows vs. baseline.
- PRs that intentionally retire a bypass run `pnpm run check:ir-fallbacks -- --update` and commit the new baseline.

Wired into the CI quality job (`.github/workflows/ci.yml`) alongside `tsc --noEmit` and `biome lint`. Runs in a few seconds.

## Initial baseline (where the bypass mass lives today)

| reason                       | count | retires with |
|------------------------------|-------|--------------|
| `body-shape-rejected`        | 22    | #1370 (class methods), #1373 (async) |
| `call-graph-closure`         | 6     | #1370, #1373 |
| `param-type-not-resolvable`  | 1     | better TypeMap propagation |

These will tick down as #1370–#1375 land. Documents the budget table in CLAUDE.md so the next dev sees what a green PR diff in this gate should look like.

## Acceptance criteria met

1. `pnpm run check:ir-fallbacks` exits 0 on main ✓
2. CI quality job runs the gate ✓
3. `ir-fallback-baseline.json` is committed ✓
4. PRs that reduce unintended fallbacks will see a `delta` of -N in the gate output (or `--update` refreshes the file) ✓

## Test plan

- [x] `pnpm run check:ir-fallbacks` exits 0 against the new baseline locally
- [x] `pnpm run check:ir-fallbacks -- --update` regenerates the baseline correctly
- [x] `tsc --noEmit` passes (script is type-clean)
- [ ] CI quality job runs the new gate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)