### PR TITLE
fix(#1367): Iterator.prototype helpers via Iterator.prototype bridge

### DIFF
--- a/plan/issues/sprints/51/1367-spec-gap-iterator-helpers-protocol-invariants.md
+++ b/plan/issues/sprints/51/1367-spec-gap-iterator-helpers-protocol-invariants.md
@@ -164,3 +164,80 @@ This connects to #1347 (for-of IteratorClose on throw) and reinforces it.
 ### Estimated impact
 
 +170 passes. §27.1 lifts from 31% to ~65%.
+
+## Implementation notes (senior-dev, 2026-05-08)
+
+### Bridge approach (replaces architect's `$IteratorHelper` struct plan)
+
+**Insight**: Modern V8 (Node 22+) ships full spec-compliant
+`Iterator.prototype` with `.drop`, `.take`, `.map`, `.filter`, `.some`,
+`.every`, `.find`, `.reduce`, `.toArray`, `.forEach`, `.flatMap`. These
+already implement `[[AlreadyCalled]]`, `IteratorClose`, non-constructible,
+RangeError on bad limit, etc. — every invariant the architect's plan
+proposed re-implementing.
+
+**Fix** (~30 LoC, two callsites): make synthesized iterators inherit
+from `Iterator.prototype`, so helpers dispatch to the host engine's
+spec-compliant impls.
+
+Concrete changes:
+
+1. **`src/runtime.ts:3397-3437`** (`__create_generator`): generator
+   objects are now built via `Object.create(Iterator.prototype)` instead
+   of plain object literal, so `.drop`/`.take`/etc. resolve through the
+   prototype chain.
+
+2. **`src/runtime.ts:3556-3580`** (`__iterator` vec fallback): wasm
+   array/vec iterators are likewise built atop `Iterator.prototype`.
+
+Both callsites detect `Iterator` global presence at runtime — fall back
+to plain object on older runtimes (no regression, no hard dependency on
+ES2024 Iterator).
+
+### Probe results (4 of 5 cases solved by this single change)
+
+| Case | Before | After |
+|------|--------|-------|
+| `arr[Symbol.iterator]().drop(2)` | "drop is not a function" | 3 (correct) |
+| `gen().drop(2)` | "drop is not a function" | 3 (correct) |
+| `it.take(-1)` (RangeError) | TypeError "take is not a function" | RangeError ✓ |
+| `gen().some(p)` short-circuit | "some is not a function" | true ✓ |
+| `new it.drop()` non-constructible | (host throw) wasm doesn't catch | Investigation needed |
+
+The `new`-throws case (test 3 in probe) needs separate codegen work — our
+`new` operator doesn't propagate the host's TypeError. Tracking as a
+follow-up; not blocking this slice.
+
+### Why the architect's `$IteratorHelper` struct isn't needed
+
+The architect proposed a Wasm struct holding cached `.next`, `.args`,
+`.kind`, `.idx`, `.done`. That's ~300 LoC. But:
+
+1. V8's `Iterator.prototype.drop` ALREADY caches `.next` once per spec.
+2. V8 ALREADY validates limits (RangeError on negative).
+3. V8 ALREADY forwards `.return()`.
+4. V8's helpers ARE non-constructible (built-in methods).
+
+By inheriting from `Iterator.prototype`, we get all of this for free.
+The only requirement is that our synthesized iterators have a callable
+`.next` method (they do).
+
+### Tests
+
+- `tests/issue-1367.test.ts` — 7 unit tests covering drop/take/map/some/every/find/toArray on both array iterators and generators.
+- All 7 pass locally.
+
+### Estimated impact (revised down)
+
++50–100 net (vs architect's +170). Reasoning: the +170 estimate assumed
+solving non-constructible and `new`-throw semantics, which need separate
+codegen work. The bridge fix delivers most-but-not-all of the Iterator
+prototype invariants.
+
+### Standalone-mode caveat
+
+This bridge fix only works when the JS host is present (`globalThis.Iterator`
+defined). In standalone mode (WASI / no JS host), iterator helpers will
+still fail. The architect's `$IteratorHelper` struct approach IS still
+needed for full standalone parity. Tracking that as a follow-up; this
+slice unblocks JS-host conformance immediately.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3397,32 +3397,40 @@ assert._isSameValue = isSameValue;
       if (name === "__create_generator")
         return (buf: any[], pendingThrow: any) => {
           let index = 0;
-          return {
-            next() {
-              if (index < buf.length) {
-                return { value: buf[index++], done: false };
-              }
-              // If the generator body threw before yielding all values,
-              // re-throw on the first next() call after buffer is exhausted.
-              if (pendingThrow !== null && pendingThrow !== undefined) {
-                const e = pendingThrow;
-                pendingThrow = null;
-                throw e;
-              }
-              return { value: undefined, done: true };
-            },
-            return(value: any) {
-              index = buf.length;
-              return { value, done: true };
-            },
-            throw(e: any) {
-              index = buf.length;
+          // (#1367) Generator objects must inherit from Iterator.prototype so
+          // helpers like .drop, .take, .map, .filter, .some, .every, .find,
+          // .reduce, .toArray, .forEach, .flatMap work without extra plumbing
+          // (Iterator.prototype methods are spec-compliant in the host engine
+          // including AlreadyCalled / IteratorClose semantics).
+          const proto = (
+            typeof (globalThis as any).Iterator === "function" ? ((globalThis as any).Iterator as any).prototype : null
+          ) as any;
+          const obj: any = proto ? Object.create(proto) : {};
+          obj.next = function () {
+            if (index < buf.length) {
+              return { value: buf[index++], done: false };
+            }
+            // If the generator body threw before yielding all values,
+            // re-throw on the first next() call after buffer is exhausted.
+            if (pendingThrow !== null && pendingThrow !== undefined) {
+              const e = pendingThrow;
+              pendingThrow = null;
               throw e;
-            },
-            [Symbol.iterator]() {
-              return this;
-            },
+            }
+            return { value: undefined, done: true };
           };
+          obj.return = function (value: any) {
+            index = buf.length;
+            return { value, done: true };
+          };
+          obj.throw = function (e: any) {
+            index = buf.length;
+            throw e;
+          };
+          obj[Symbol.iterator] = function () {
+            return this;
+          };
+          return obj;
         };
       if (name === "__create_async_generator")
         return (buf: any[], pendingThrow: any) => {
@@ -3552,17 +3560,24 @@ assert._isSameValue = isSameValue;
               const len = vecLen(obj);
               if (typeof len === "number" && len >= 0) {
                 let i = 0;
-                return {
-                  next() {
-                    if (i >= len) return { value: undefined, done: true };
-                    const val = vecGet(obj, i);
-                    i++;
-                    return { value: val, done: false };
-                  },
-                  [Symbol.iterator]() {
-                    return this;
-                  },
+                // (#1367) Synthesized iterators MUST inherit from
+                // Iterator.prototype so .drop/.take/.map/.filter etc. resolve.
+                const iterProto = (
+                  typeof (globalThis as any).Iterator === "function"
+                    ? ((globalThis as any).Iterator as any).prototype
+                    : null
+                ) as any;
+                const iterObj: any = iterProto ? Object.create(iterProto) : {};
+                iterObj.next = function () {
+                  if (i >= len) return { value: undefined, done: true };
+                  const val = vecGet(obj, i);
+                  i++;
+                  return { value: val, done: false };
                 };
+                iterObj[Symbol.iterator] = function () {
+                  return this;
+                };
+                return iterObj;
               }
             }
           }

--- a/tests/issue-1367.test.ts
+++ b/tests/issue-1367.test.ts
@@ -1,0 +1,119 @@
+// #1367 — Iterator.prototype helpers: bridge to host Iterator.prototype.
+//
+// Synthesized iterators (vec/array fallback in __iterator and generator
+// objects in __create_generator) now inherit from `Iterator.prototype`, so
+// helpers like .drop, .take, .map, .filter, .some, .every, .find, .reduce,
+// .toArray, .forEach, .flatMap dispatch to the host engine's spec-compliant
+// implementations — including AlreadyCalled / IteratorClose / non-
+// constructible / argument-validation invariants.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<WebAssembly.Exports> {
+  const r = compile(src);
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const m = await WebAssembly.instantiate(r.binary, imports);
+  const setExports = (imports as any).setExports;
+  if (typeof setExports === "function") setExports(m.instance.exports);
+  return m.instance.exports;
+}
+
+describe("#1367 — Iterator helpers via Iterator.prototype bridge", () => {
+  it("array-iterator drop(2) drops first 2 elements", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr = [1, 2, 3, 4, 5] as any[];
+        const it = arr[Symbol.iterator]();
+        const dropped = (it as any).drop(2);
+        let count = 0;
+        for (const _ of dropped) count++;
+        return count;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(3);
+  });
+
+  it("generator drop(2) drops first 2 elements", async () => {
+    const ex = await instantiate(`
+      function* g(): Generator<number> {
+        yield 1; yield 2; yield 3; yield 4; yield 5;
+      }
+      export function main(): number {
+        const it = g() as any;
+        const dropped = it.drop(2);
+        let count = 0;
+        for (const _ of dropped) count++;
+        return count;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(3);
+  });
+
+  it("array-iterator take(-1) throws RangeError (spec arg validation)", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr = [1, 2, 3] as any[];
+        const it = arr[Symbol.iterator]();
+        try {
+          (it as any).take(-1);
+          return 0;
+        } catch (e: any) {
+          if (e && e.constructor && e.constructor.name === "RangeError") return 1;
+          return 2;
+        }
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("generator some() short-circuits on first truthy match", async () => {
+    const ex = await instantiate(`
+      function* g(): Generator<number> { yield 1; yield 2; yield 3; }
+      export function main(): number {
+        const it = g() as any;
+        const result = (it as any).some((x: number) => x === 2);
+        return result ? 1 : 0;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("generator every() returns true for all matching", async () => {
+    const ex = await instantiate(`
+      function* g(): Generator<number> { yield 1; yield 2; yield 3; }
+      export function main(): number {
+        const it = g() as any;
+        const result = (it as any).every((x: number) => x > 0);
+        return result ? 1 : 0;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("generator find() returns first matching value", async () => {
+    const ex = await instantiate(`
+      function* g(): Generator<number> { yield 1; yield 2; yield 3; }
+      export function main(): number {
+        const it = g() as any;
+        const result = (it as any).find((x: number) => x === 2);
+        return result;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(2);
+  });
+
+  it("array-iterator map() and toArray() chain", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr = [1, 2, 3] as any[];
+        const it = arr[Symbol.iterator]();
+        const mapped = (it as any).map((x: number) => x * 2);
+        const result = (mapped as any).toArray();
+        return result.length;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Bridge fix for #1367 — synthesized iterators (`__create_generator` and `__iterator` vec fallback) now inherit from `Iterator.prototype` so helpers like `.drop`, `.take`, `.map`, `.filter`, `.some`, `.every`, `.find`, `.reduce`, `.toArray`, `.forEach`, `.flatMap` dispatch to the host engine's spec-compliant implementations.

This replaces the architect's `$IteratorHelper` Wasm struct plan (~300 LoC). V8 (Node 22+) already ships full spec-compliant Iterator.prototype with `[[AlreadyCalled]]`, `IteratorClose`, non-constructible, and RangeError-on-bad-limit invariants — re-implementing those in Wasm is unnecessary effort that this 30-LoC bridge fix short-circuits.

## Test plan

- [x] `tests/issue-1367.test.ts` — 7 unit tests covering drop/take/map/some/every/find/toArray on both array iterators and generators. All pass.
- [x] Probe shows 4/5 cases solved.
- [ ] CI test262 — expecting +50–100 net (vs architect's +170; constructibility cases need separate codegen work, see issue file).

## Notes

- Detect `globalThis.Iterator` presence at runtime; fall back to plain object on older runtimes (no hard ES2024 dependency).
- Standalone-mode (no JS host) still needs full `$IteratorHelper` struct for parity — tracked as follow-up.
- `new it.drop()` non-constructible test still fails because wasm `new` operator doesn't propagate host's TypeError — separate codegen issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)