### PR TITLE
fix(#1377): Array.pop/shift on empty array returns undefined (Slice A)

### DIFF
--- a/plan/issues/sprints/51/1377-spec-gap-array-prototype-pop-shift-unshift-push-fill-mutating.md
+++ b/plan/issues/sprints/51/1377-spec-gap-array-prototype-pop-shift-unshift-push-fill-mutating.md
@@ -163,3 +163,57 @@ expectations for ALL three cases.
 ### Estimated impact
 
 +50 passes. Cleanup of common Array mutation paths.
+
+## Implementation notes (senior-dev, 2026-05-08)
+
+### Slice A: empty-array pop/shift returns undefined (not null)
+
+**Scope**: 30 LoC in `src/codegen/array-methods.ts`. Initialize result
+local to `__get_undefined()` for externref/anyref element types so
+empty-array `arr.pop()` and `arr.shift()` return JS `undefined` per
+spec §23.1.3.20.5 and §23.1.3.27.5 instead of `ref.null.extern` (which
+JS sees as `null`).
+
+The bug: `compileArrayPop` and `compileArrayShift` had
+`if (length > 0) { ... pop logic; result = data[i]; }` with no else.
+On empty array, the if didn't fire and `result` stayed at its wasm
+default (ref.null.extern → JS null). Fix: explicitly initialize result
+to `emitUndefined(...)` BEFORE the if, so the empty case yields
+spec-compliant undefined.
+
+Targeted at externref/anyref element types only — f64-element arrays
+keep their NaN default (acceptable; numeric callers use length checks),
+and i32 keeps 0.
+
+### Other gaps (deferred)
+
+| Gap | Pattern | Status |
+|-----|---------|--------|
+| Length-NaN coercion | `obj.length = NaN; obj.push(x)` should set length=1 | Deferred — array-like dispatch path |
+| MaxSafeInteger overflow | `arr.push` when length=2^53-1 should throw RangeError | Deferred — needs i64 length checks |
+| Frozen-receiver TypeError | `Object.freeze(arr); arr.push(x)` should throw | Deferred — needs frozen-bit |
+| `new Array().unshift(1)` returns 0 | new Array() length tracking | Deferred — constructor path |
+| `Array.prototype.push.call(obj, x)` with arbitrary obj | Some edge cases fail | Deferred — overlaps with #1358 |
+| `pop` reset on NaN length | `obj.length=NaN; obj.pop()` should set length=0 | Deferred — host path |
+
+These all need either new codegen emitters or runtime bridge fixes that
+are out of scope for Slice A's focused 30-LoC fix.
+
+### Tests
+
+- `tests/issue-1377.test.ts` — 7 unit tests covering pop/shift on empty,
+  non-empty, length tracking, repeated drain, f64-element no-crash. All pass.
+
+### Pre-existing failures
+
+`tests/array-methods.test.ts` has 2 tests (`pop > returns last element`,
+`shift > returns first element`) that fail on origin/main with TS strict
+type errors — verified by stashing my changes. Test sources have
+`return arr.pop()` against a `: number` return type, triggering
+"Type 'number | undefined' is not assignable to type 'number'". Unrelated.
+
+### Estimated impact (revised)
+
++5–15 net (vs architect's +50). The +50 estimate assumed solving all
+7 method gaps; Slice A solves only the empty-array undefined gap.
+Realistic for a focused, low-risk PR.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -23,6 +23,7 @@ import {
   registerEmitBoundsCheckedArrayGet,
   VOID_RESULT,
 } from "./shared.js";
+import { emitUndefined } from "./expressions/late-imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ensureTimsortHelper } from "./timsort.js";
 import { coerceType, coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
@@ -3129,6 +3130,17 @@ function compileArrayPop(
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
   const lenTmp = allocLocal(fctx, `__arr_pop_len_${fctx.locals.length}`, { kind: "i32" });
 
+  // (#1377) Initialize result to JS `undefined` for externref/anyref element
+  // types so empty-array `arr.pop()` returns spec-compliant undefined (not
+  // the wasm default `ref.null.extern`, which JS sees as `null`). f64 keeps
+  // its NaN default (matches `[].pop()` returning undefined which coerces
+  // to NaN in numeric context). i32 keeps 0 (best-effort; never mixed with
+  // null arrays).
+  if (elemType.kind === "externref" || elemType.kind === "anyref") {
+    emitUndefined(ctx, fctx);
+    fctx.body.push({ op: "local.set", index: resultTmp });
+  }
+
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);
   fctx.body.push({ op: "local.tee", index: vecTmp });
@@ -3138,7 +3150,7 @@ function compileArrayPop(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: lenTmp });
 
-  // Guard: if length > 0, do pop; else result stays default (0/NaN/null)
+  // Guard: if length > 0, do pop; else result stays as initialized above (undefined for ref types).
   fctx.body.push({ op: "local.get", index: lenTmp });
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "i32.gt_s" });
@@ -3187,6 +3199,13 @@ function compileArrayShift(
   const resultTmp = allocLocal(fctx, `__arr_sft_res_${fctx.locals.length}`, elemType);
 
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
+
+  // (#1377) Initialize result to JS `undefined` for externref/anyref so
+  // empty-array `arr.shift()` returns spec-compliant undefined.
+  if (elemType.kind === "externref" || elemType.kind === "anyref") {
+    emitUndefined(ctx, fctx);
+    fctx.body.push({ op: "local.set", index: resultTmp });
+  }
 
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);

--- a/tests/issue-1377.test.ts
+++ b/tests/issue-1377.test.ts
@@ -1,0 +1,113 @@
+// #1377 — Array.prototype.pop/shift on empty array: return JS undefined.
+//
+// Slice A: fix the wasm-default-value bug where `arr.pop()` and `arr.shift()`
+// on an empty array left `result` as ref.null.extern (which JS sees as `null`)
+// instead of JS `undefined`. Per spec §23.1.3.20.5 (pop) and §23.1.3.27.5
+// (shift), both return undefined when the array is empty.
+//
+// Other gaps in #1377 (length-NaN coercion, frozen-receiver TypeErrors,
+// MaxSafeInteger overflow checks, primitive-receiver dispatch, custom-this
+// .call patterns) require deeper codegen work and are deferred to follow-up
+// slices.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<WebAssembly.Exports> {
+  const r = compile(src);
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const m = await WebAssembly.instantiate(r.binary, imports);
+  const setExports = (imports as any).setExports;
+  if (typeof setExports === "function") setExports(m.instance.exports);
+  return m.instance.exports;
+}
+
+describe("#1377 — Array pop/shift undefined on empty (Slice A)", () => {
+  it("[].pop() returns undefined (not null)", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr: any[] = [];
+        const v = arr.pop();
+        // v should be undefined, not null
+        if (v === undefined) return 1;
+        if (v === null) return 0;
+        return 2;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("[].shift() returns undefined (not null)", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr: any[] = [];
+        const v = arr.shift();
+        if (v === undefined) return 1;
+        if (v === null) return 0;
+        return 2;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("non-empty pop still returns the popped value", async () => {
+    const ex = await instantiate(`
+      export function main(): any {
+        const arr: any[] = [10, 20, 30];
+        return arr.pop();
+      }
+    `);
+    expect((ex.main as () => any)()).toBe(30);
+  });
+
+  it("non-empty shift still returns the shifted value", async () => {
+    const ex = await instantiate(`
+      export function main(): any {
+        const arr: any[] = [10, 20, 30];
+        return arr.shift();
+      }
+    `);
+    expect((ex.main as () => any)()).toBe(10);
+  });
+
+  it("pop on empty leaves length 0", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr: any[] = [];
+        arr.pop();
+        return arr.length;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(0);
+  });
+
+  it("repeated pop drains array, then returns undefined", async () => {
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr: any[] = [1, 2];
+        arr.pop();
+        arr.pop();
+        const v = arr.pop();  // empty now
+        if (v === undefined) return 1;
+        return 0;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+
+  it("number array pop on empty still works (NaN default for f64)", async () => {
+    // For f64-element arrays, the wasm default is 0/NaN; this is acceptable
+    // because callers comparing `v === undefined` get false and need to use
+    // length checks anyway. The fix targets externref/anyref element types.
+    const ex = await instantiate(`
+      export function main(): number {
+        const arr: number[] = [];
+        const v = arr.pop();
+        // Don't assert specific behavior here — just that no crash.
+        return 1;
+      }
+    `);
+    expect((ex.main as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

30 LoC fix in \`src/codegen/array-methods.ts\` — \`compileArrayPop\` and \`compileArrayShift\` initialize the result local to \`emitUndefined(...)\` for externref/anyref element types, so empty-array \`arr.pop()\` and \`arr.shift()\` return JS \`undefined\` instead of \`ref.null.extern\` (which JS sees as \`null\`).

Per spec §23.1.3.20.5 (pop) and §23.1.3.27.5 (shift): both return \`undefined\` when array is empty.

## Test plan

- [x] \`tests/issue-1377.test.ts\` — 7 cases covering pop/shift on empty, non-empty, length tracking, repeated drain, f64-element no-crash. All pass.
- [x] Type-check clean.
- [x] Pre-existing \`array-methods.test.ts\` failures (unrelated TS strict typing) verified on origin/main with my changes stashed.
- [ ] CI test262 — expect +5–15 net.

## Other #1377 gaps deferred

Architect's +50 estimate assumed solving all 7 method gaps; Slice A solves only the empty-array undefined case. Other gaps (length-NaN coercion, MaxSafeInteger overflow, frozen-receiver TypeError, array-like dispatch, \`new Array().unshift\` etc.) need separate codegen work. Tracked in issue file as follow-up slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)