### PR TITLE
feat(#1370 Phase B): wire IR integration for class instance methods

### DIFF
--- a/plan/issues/sprints/51/1370-ir-class-methods-constructors.md
+++ b/plan/issues/sprints/51/1370-ir-class-methods-constructors.md
@@ -706,3 +706,200 @@ Test results:
   resolution differences). If the guard fires for many cases, the
   `IrClassShape` projection in `buildIrClassShapes` (`src/codegen/index.ts:480`)
   may need to align more closely with `resolveWasmType`'s output.
+
+---
+
+## Phase C Notes (from constructor reading, 2026-05-08)
+
+These findings are from reading the legacy constructor-body compilation
+ahead of Phase C implementation. **The architect spec referenced a
+`compileConstructorBody` function — that doesn't exist as a separate
+function; constructor body compilation is INLINE in `compileClassBodies`
+(`src/codegen/class-bodies.ts:658-951`).** The next agent should not
+search for `compileConstructorBody`.
+
+### Legacy constructor body recipe
+
+Lines below refer to `src/codegen/class-bodies.ts`:
+
+1. **Allocate `__self` local** (line 731-734):
+   ```ts
+   const selfLocal = allocLocal(fctx, "__self", { kind: "ref", typeIdx: structTypeIdx });
+   ```
+2. **Push default values for ALL fields including `__tag`** (line 737-758):
+   - `__tag` → `ctx.classTagMap.get(className) ?? 0` (instanceof discrimination value)
+   - f64 → `f64.const 0`, i32 → `i32.const 0`
+   - ref → `ref.null typeIdx`, ref_null → `ref.null typeIdx`
+   - externref → `ref.null.extern`, eqref → `ref.null.eq`, i64 → `i64.const 0n`
+   - Fallback for anything else: `i32.const 0`
+3. **`struct.new $structTypeIdx`** (line 759).
+4. **`local.set $__self`** (line 760).
+5. **Bind `this` → `__self` in localMap** (line 765):
+   `fctx.localMap.set("this", selfLocal);`
+6. **Optional param defaults** (line 772-846) — null/zero/NaN sentinel
+   checks. **OUT OF PHASE C SCOPE** — Phase A's selector already rejects
+   params with initializers, so this complexity isn't needed in the IR
+   lowerer until a separate slice loosens the selector.
+7. **PropertyDeclaration initializers** (line 914-926) — for each
+   `field: type = expr` (no `static`):
+   ```
+   local.get $__self
+   <compile init expr>
+   struct.set $structTypeIdx fieldIdx
+   ```
+   Field index is from `legacyFields.findIndex` — note `__tag` is at
+   index 0, user fields at 1+.
+8. **Constructor body statements** (line 928-941) — compile each via
+   `compileStatement`. `this.field = expr` is already handled by the
+   assignment compilation looking up `this` in `localMap` (which
+   resolves to `selfLocal`). `super(...)` calls get special handling
+   (line 932-938) — **OUT OF PHASE C SCOPE** (Phase E for inheritance).
+9. **Tail return** (line 944): `local.get $__self` as the final instr.
+   Function signature has return type `(ref $structTypeIdx)`, so the
+   bare `local.get` is the return value.
+
+### Critical detail — `__tag` field
+
+- `__tag` is at field **index 0** in `legacyFields`. User fields start
+  at index 1 (or higher with parent chains, but Phase C doesn't handle
+  inheritance).
+- `ctx.classTagMap.get(className)` returns the unique tag value used
+  by `instanceof` to discriminate this class from others.
+- The IR's `IrClassShape.fields` strips `__tag` (`buildIrClassShapes:524`
+  in `src/codegen/index.ts`), but `ClassRegistry.resolve` in
+  `integration.ts:1387-1390` builds `fieldIdxByName` from `legacyFields`
+  WHICH INCLUDES `__tag`. Therefore `class.set <userFieldName>` in IR
+  already maps to the post-`__tag` index correctly — no Phase C work
+  needed there.
+- **Phase C's `class.new` IR lowering MUST push `__tag`'s value** when
+  allocating. Either:
+  - Extend `IrClassLowering` (in `integration.ts:1394`) with a new
+    `tagValue` accessor that returns `ctx.classTagMap.get(className)`,
+    OR
+  - Have the lowerer reach into the resolver to get the class's tag
+    value via a new resolver method.
+
+### Field initialization order (subtle correctness issue)
+
+Legacy emits in this exact order:
+1. Zero-fill all fields via `struct.new` (line 737-760)
+2. PropertyDeclaration initializers (line 914-926)
+3. Constructor body statements (line 928-941)
+
+Phase C must match. Otherwise:
+```ts
+class C {
+  x: number = 1;
+  constructor() {
+    this.x = this.x + 10;  // legacy result: 11. wrong order: 10.
+  }
+}
+```
+The PropertyDeclaration initializer must run BEFORE the constructor
+body so the body sees the initialized value.
+
+### `this` MUST be a slot, not an SSA local
+
+Constructor bodies may contain branches that conditionally write to
+`this` (and the IR's slice 4+ supports `if`/`else`):
+```ts
+constructor(flag: boolean) {
+  if (flag) {
+    this.x = 1;
+  } else {
+    this.x = 2;
+  }
+}
+```
+
+In SSA form, the two branches produce different values. If `this` is
+bound as a `local` (kind: "local") with a fixed SSA value, the writes
+on each arm wouldn't merge correctly. **Bind `this` as a `slot`
+binding** (kind: "slot") so cross-branch writes propagate via
+`slot.write` / `slot.read` — the existing pattern for mutated lets.
+The Phase B `selfParam` injection used `kind: "local"`; Phase C needs
+to differentiate constructor-mode and use `kind: "slot"` instead.
+
+For Phase B (instance methods), `this` is read-only inside the body
+(callers can't reassign `this`), so `kind: "local"` is fine. Phase C's
+constructor binding must be `kind: "slot"` because user code can
+freely mutate `this.field` across branches AND the post-`class.new`
+default fields fill the slot before any user code runs.
+
+Wait — `slot` is for mutated identifier writes (`x = expr`). For
+`this.field = expr` writes, the `this` SSA value itself doesn't
+change; only its struct fields do (via `class.set`). So `this` can
+be a `local` kind even in constructors — only the `struct.set` to the
+field changes state.
+
+**REVISED**: Either kind should work for `this` in a constructor. Use
+`local` (matches Phase B) for consistency unless a use case surfaces
+that requires slot semantics (e.g. `if (cond) { this = makeOther(); }`,
+which is JS-illegal — `this` is read-only).
+
+The slot vs. local question matters more for the ALLOCATION pattern:
+the `class.new` result must be stored somewhere stable so subsequent
+`class.set` ops can reference it. A `local` SSA binding is fine: the
+SSA value is the struct ref, and `class.set selfV "x" expr` doesn't
+change `selfV` (only the struct it references).
+
+### Phase C — recommended implementation approach
+
+**Approach 1: new IR primitive `IrInstr.classNew { className }`**:
+
+1. Add a new node-kind in `src/ir/nodes.ts`:
+   - `class.new { className }` → produces `IrType.class { shape }`.
+2. Lower it in the resolver (`src/ir/integration.ts`):
+   - Look up `IrClassLowering` via `ClassRegistry.resolve`.
+   - Get `tagValue` (new accessor on `IrClassLowering`).
+   - For each field in `legacyFields` (indexed 0..n):
+     - Push the appropriate zero / tag value (mirror lines 740-757).
+   - Emit `struct.new $structTypeIdx`.
+   - Result is `(ref $structTypeIdx)`; coerce to `IrType.class` at the
+     IR level.
+3. Add a `constructorOf?: { className: string }` option to
+   `lowerFunctionAstToIr`:
+   - When set, emit `class.new` at body entry; bind `this` (kind:
+     local) to the result.
+   - Walk class.members for non-static `PropertyDeclaration`s with an
+     initializer; emit `class.set this fieldName <init>` for each.
+   - Lower constructor body statements via the existing slice-4 path
+     (`this.field = expr` and `this.method()` already work).
+   - Tail: emit `return this` automatically (since constructors don't
+     write an explicit return).
+4. The function's `returnType` should be `IrType.class { shape }`.
+5. Integration loop in `compileIrPathFunctions`:
+   - Detect `ConstructorDeclaration` in the class-member walk.
+   - Pass `constructorOf: { className }` instead of `selfParam`.
+   - Same parity check before slot patch — Phase C-emitted typeIdx
+     must equal legacy `${className}_new_type` typeIdx.
+
+**Approach 2: reuse lowerNewExpression** — REJECTED. The existing
+`lowerNewExpression` lowers `new ClassName(args)` as a CALL to the
+legacy ctor func; Phase C is lowering the BODY of that ctor. Different
+problem.
+
+### Risk for Phase C
+
+1. **Typeidx parity** — same as Phase B. The constructor's legacy
+   typeIdx is `${className}_new_type` from `class-bodies.ts:251`
+   (params from typed source + return `(ref $structTypeIdx)`). The IR
+   must match exactly; the parity guard from Phase B catches the rest.
+2. **Field count drift** — `legacyFields.length` is the source of truth
+   for `struct.new`. If the IR's `class.new` pushes fewer values, Wasm
+   validation rejects the module. Test with classes that have fields
+   spanning all the legacy default-value cases (f64, i32, ref, ref_null,
+   externref, eqref).
+3. **PropertyDeclaration order** — emit before body statements (legacy
+   line 914 runs before line 928).
+4. **Default param handling** — Phase A selector rejects params with
+   `initializer`, so Phase C doesn't need lines 772-846. Defensive
+   check: assert `member.parameters.every(p => !p.initializer)` before
+   accepting.
+5. **Inheritance** — Phase A selector rejects classes with `extends`,
+   so the parent-chain field initializers (line 851-912) and `super(...)`
+   handling (line 932-938) are out of Phase C scope. Phase E.
+6. **Mutable `this` invariant** — JS makes `this` read-only inside a
+   constructor (you can't reassign `this`, only mutate its fields).
+   Bind as `kind: "local"` mirroring Phase B; document this in the
+   commit so the next slice doesn't re-bikeshed.

--- a/plan/issues/sprints/51/1370-ir-class-methods-constructors.md
+++ b/plan/issues/sprints/51/1370-ir-class-methods-constructors.md
@@ -595,3 +595,114 @@ This requires either:
 - Run `tests/classes.test.ts` — expect the env failures unchanged from Phase A.
 - IR fallback baseline: should DROP for `class-method` bucket as Phase B claims
   more methods. Run `pnpm run check:ir-fallbacks -- --update` and commit.
+
+---
+
+## Phase B — Implementation Notes (2026-05-08, senior-dev-1370)
+
+PR: https://github.com/loopdive/js2wasm/pull/295
+
+Phase B wires the IR integration loop for class **instance methods**.
+Static methods and constructors are deferred (see scope notes below).
+
+### What landed
+
+1. **`lowerFunctionAstToIr` widened** (`src/ir/from-ast.ts`):
+   - Param type: `FunctionDeclaration | MethodDeclaration | ConstructorDeclaration`.
+   - New `options.funcName` for caller-supplied names (MethodDeclaration's
+     `.name` is `PropertyName`, not Identifier; ConstructorDeclaration has
+     no name node).
+   - New `options.selfParam: { type: IrType }` injects a synthetic `__self`
+     first param. Mirrors `class-bodies.ts:301`'s `[(ref $structTypeIdx),
+     ...userParams]` layout exactly so legacy callers' `call` ops still
+     match the typeIdx after the patch.
+   - Binds `this` in the body's scope to the `__self` SSA value. Existing
+     slice-4 `class.get` / `class.set` / `class.method` lowerings handle
+     `this.field` / `this.method()` via the `IrType.class` shape carried
+     on the binding.
+   - `lowerExpr` accepts `ts.SyntaxKind.ThisKeyword` and returns the
+     `this` SSA value from scope.
+   - `collectMutatedLetNames` widened to the same union.
+   - ConstructorDeclaration is rejected at the lowerer with a clean
+     error (Phase C work).
+
+2. **Class-member walk in `compileIrPathFunctions`** (`src/ir/integration.ts`):
+   - New parallel loop after the FunctionDeclaration loop. Walks
+     `sourceFile.statements` for `ClassDeclaration`, filters to
+     non-static `MethodDeclaration` whose synthetic name is in
+     `selected.classMembers`. Looks up `classShapes.get(className)`,
+     builds the `IrType.class` self-param, calls `lowerFunctionAstToIr`.
+   - Skip branches: classes with `extends` (defensive — selector already
+     rejects), missing class shape, static modifier, abstract modifier,
+     computed/private member name.
+   - `BuiltFn` gains `classMember?: boolean` flag. Threaded through
+     hygiene/inline/mono pipeline stages.
+
+3. **Funcidx allocation skip** (`src/ir/integration.ts`):
+   - Class members already have a funcIdx pre-allocated by
+     `class-bodies.ts`. The new `if (entry.classMember) continue;`
+     prevents the integration's clone-allocation step from registering
+     a duplicate slot.
+
+4. **Signature parity guard** (`src/ir/integration.ts`):
+   - Before patching the slot, compares `wasmFunc.typeIdx` (IR-lowered)
+     to `existing.typeIdx` (legacy pre-allocated). On mismatch:
+     - Don't patch — legacy body stays in place.
+     - Emit a `severity: warning` diagnostic: `"class-method typeIdx
+       parity mismatch: IR=N, legacy=M — keeping legacy body"`.
+   - Top-level FunctionDeclarations DON'T need this guard — their
+     pre-allocated body was empty and no legacy callers depend on the
+     slot's prior typeIdx.
+
+5. **Early-return short-circuit relaxed** (`src/ir/integration.ts:93`):
+   - Old: `if (selected.funcs.size === 0) return EMPTY;`
+   - New: `if (selected.funcs.size === 0 && (!selected.classMembers || selected.classMembers.size === 0)) return EMPTY;`
+   - A source file with only a class (no top-level functions) can now
+     reach the class-member walk.
+
+6. **`safeSelection` threads `classMembers`** (`src/codegen/index.ts:854`):
+   - The class-method override map isn't built (class methods are typed
+     via the class shape, not TypeMap propagation). Pass the
+     `classMembers` set through unchanged.
+
+### Phase B verification
+
+- `.tmp/probe-1370-phaseB.mts` — `class Calc { add(a,b); mul(a,b); }` →
+  `run()` returns 25 in both legacy and IR. Values match.
+- `.tmp/probe-1370-phaseB-trace.mts` — confirms `Calc_add` body is the
+  IR-lowered shape (`local.get 1`, `local.get 2`, `f64.add`, `return`)
+  and not the legacy `$name`-prefixed form.
+- `.tmp/probe-1370-phaseB-this-method.mts` — `class Counter { next();
+  nextNext() }` with `this.next()` cross-method call → both methods
+  IR-compiled, returns 7.
+
+Test results:
+- Class equivalence tests (6 files): 22/22 pass (incl.
+  `ir-slice4-classes.test.ts` exercising slice-4 class instance use
+  patterns from outer functions).
+- IR test suite (14 files): 327/327 pass.
+- TypeScript clean.
+- IR fallback budget gate: no regression.
+
+### Out of scope (Phase B deferred)
+
+- **Static methods** — funcMap key shape is the same
+  (`${className}_${methodName}`) but no `self` injection. Could be a
+  small follow-up — just skip the `selfParam` option when
+  `hasStaticModifier(member)`. The selector already claims them in
+  Phase A.
+- **Constructors** — Phase C builds the `struct.new $ClassName` allocation
+  + `__self` SSA binding + `return $self` epilogue. Phase B's lowerer
+  rejects ConstructorDeclaration with a clear error.
+- **Inheritance / `super`** — Phase E. Phase A's selector already
+  rejects classes with `extends`.
+
+### Risk notes
+
+- The signature parity guard will surface as a warning in CI if any
+  test triggers a mismatch. Watch the Phase B PR's test262 output for
+  `class-method typeIdx parity mismatch` warnings — they indicate
+  classes whose methods can't be claimed safely yet (likely f64-vs-i32
+  resolution differences). If the guard fires for many cases, the
+  `IrClassShape` projection in `buildIrClassShapes` (`src/codegen/index.ts:480`)
+  may need to align more closely with `resolveWasmType`'s output.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -851,8 +851,15 @@ export function generateModule(
       // Only request IR compilation for functions we successfully built
       // overrides for (the selector may have claimed more, but if we
       // couldn't map types safely we leave them to legacy).
+      //
+      // #1370 Phase B: thread `classMembers` through to the integration
+      // loop. Class methods don't go through `overrideMap` (they're
+      // typed via the class shape, not the TypeMap-derived overrides);
+      // the integration's class-member walk consults `classShapes`
+      // directly. Pass the set unmodified.
       const safeSelection = {
         funcs: new Set<string>([...selection.funcs].filter((n) => overrideMap.has(n))),
+        classMembers: selection.classMembers,
       };
       const report = compileIrPathFunctions(ctx, ast.sourceFile, safeSelection, overrideMap, classShapes);
       // Slice 12 (#1169o) — IR-path failures are NOT compile errors. The

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -114,6 +114,32 @@ export interface IrFromAstResolver {
 export interface AstToIrOptions {
   readonly exported?: boolean;
   /**
+   * #1370 Phase B: explicit name for the lowered function. Required for
+   * MethodDeclaration (where `.name` is `PropertyName`, not Identifier)
+   * and ConstructorDeclaration (which has no name node at all). For
+   * top-level FunctionDeclaration this can be omitted; the caller's
+   * `fn.name.text` is used as a fallback.
+   */
+  readonly funcName?: string;
+  /**
+   * #1370 Phase B: when set, the lowered function gets an implicit
+   * `__self` parameter as its FIRST parameter, and `this` is bound in
+   * the body's scope to that parameter's SSA value. Pass when lowering
+   * an instance method — the legacy `class-bodies.ts` pre-allocates
+   * instance method signatures as `[(ref $structTypeIdx), ...userParams]`
+   * (see `class-bodies.ts:301`); the IR-lowered body must mirror that
+   * layout exactly so existing legacy callers' `call $methodFuncIdx`
+   * ops route to the correct typeIdx.
+   *
+   * The `IrType` should be `{ kind: "class"; shape }` so `this.field`
+   * accesses resolve via `class.get` / `class.set` against the shape's
+   * field list.
+   *
+   * Static methods don't get a `selfParam`; constructors don't either —
+   * Phase C synthesises `struct.new + __self` inside the body.
+   */
+  readonly selfParam?: { readonly type: IrType };
+  /**
    * If present, overrides the IR types for the function's own parameters.
    * Indexed by parameter position. Used when the AST lacks explicit TS
    * type annotations and the Phase-2 propagation pass has inferred types.
@@ -179,15 +205,36 @@ export interface LoweredFunctionResult {
   readonly lifted: readonly IrFunction[];
 }
 
-export function lowerFunctionAstToIr(fn: ts.FunctionDeclaration, options: AstToIrOptions = {}): LoweredFunctionResult {
-  if (!fn.name) {
-    throw new Error("ir/from-ast: function declaration without a name");
+export function lowerFunctionAstToIr(
+  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration,
+  options: AstToIrOptions = {},
+): LoweredFunctionResult {
+  // #1370 Phase B: name resolution.
+  //
+  // FunctionDeclaration: prefer `fn.name.text`, fall back to options.funcName.
+  // MethodDeclaration: use options.funcName (its `.name` is PropertyName).
+  // ConstructorDeclaration: use options.funcName (no `.name` node).
+  const astName = ts.isFunctionDeclaration(fn) ? fn.name?.text : undefined;
+  const name = options.funcName ?? astName;
+  if (!name) {
+    throw new Error("ir/from-ast: function declaration without a name (and no options.funcName supplied)");
   }
   if (!fn.body) {
-    throw new Error(`ir/from-ast: function ${fn.name.text} has no body`);
+    throw new Error(`ir/from-ast: function ${name} has no body`);
   }
 
-  const name = fn.name.text;
+  // #1370 Phase B: ConstructorDeclaration has no `asteriskToken` field,
+  // and a method/function may have one. Type-narrow before access.
+  const isGenerator = (ts.isFunctionDeclaration(fn) || ts.isMethodDeclaration(fn)) && !!fn.asteriskToken;
+
+  // ConstructorDeclaration has no `.type` field (return type is implicit
+  // — the constructed instance). Phase B doesn't lower constructor bodies
+  // (Phase C handles `struct.new + __self`); the integration loop should
+  // skip ConstructorDeclaration. Defensive guard here in case it slips
+  // through.
+  if (ts.isConstructorDeclaration(fn)) {
+    throw new Error(`ir/from-ast: constructor body lowering is Phase C, not B (${name})`);
+  }
 
   // Slice 7a (#1169f): `function*` produces a Generator-like externref
   // regardless of the source-level return type annotation
@@ -199,7 +246,6 @@ export function lowerFunctionAstToIr(fn: ts.FunctionDeclaration, options: AstToI
   // `fn.type?.kind === VoidKeyword` indicates a void-returning function.
   // The IR builder is constructed with `[]` results; lowerTail accepts
   // bare `return;` / fall-through tails.
-  const isGenerator = !!fn.asteriskToken;
   const isVoidReturn =
     !isGenerator &&
     (options.returnTypeOverride === null ||
@@ -226,6 +272,16 @@ export function lowerFunctionAstToIr(fn: ts.FunctionDeclaration, options: AstToI
   // Single scope map for both params and let/const locals. Phase 1 forbids
   // shadowing (enforced by the selector) so there is no nesting to track.
   const scope = new Map<string, ScopeBinding>();
+  // #1370 Phase B: synthetic `__self` for instance methods. Must be added
+  // FIRST so its SSA index matches the legacy `local 0` slot the
+  // pre-allocated typeIdx expects (see `class-bodies.ts:301`). `this` is
+  // bound in scope to this SSA value; subsequent `this.field` /
+  // `this.method()` accesses route through the existing class.get /
+  // class.set / class.method lowerings (slice 4 #1169d).
+  if (options.selfParam) {
+    const selfV = builder.addParam("__self", options.selfParam.type);
+    scope.set("this", { kind: "local", value: selfV, type: options.selfParam.type });
+  }
   for (const p of params) {
     const v = builder.addParam(p.name, p.type);
     scope.set(p.name, { kind: "local", value: v, type: p.type });
@@ -665,7 +721,9 @@ interface LowerCtx {
  * We DON'T descend into nested function-likes — their writes are local
  * to their own scope and don't influence the outer's slot decisions.
  */
-function collectMutatedLetNames(fn: ts.FunctionDeclaration): Set<string> {
+function collectMutatedLetNames(
+  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration,
+): Set<string> {
   const writes = new Set<string>();
   if (!fn.body) return writes;
   return collectMutatedLetNamesFromBlock(fn.body);
@@ -1077,6 +1135,21 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
   // closure.
   if (ts.isArrayLiteralExpression(expr)) {
     throw new Error(`ir/from-ast: ArrayLiteralExpression not in slice 12 (${cx.funcName})`);
+  }
+  // #1370 Phase B: `this` reference inside an instance method body.
+  // The integration loop binds `this` in scope to the synthetic
+  // `__self` parameter's SSA value before lowering the body. Outside
+  // of class-method bodies the keyword never enters scope, so this
+  // branch only fires for IR-claimed instance methods.
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) {
+    const p = cx.scope.get("this");
+    if (!p) {
+      throw new Error(`ir/from-ast: 'this' reference outside an instance method body (${cx.funcName})`);
+    }
+    if (p.kind !== "local") {
+      throw new Error(`ir/from-ast: unexpected 'this' binding kind ${p.kind} in ${cx.funcName}`);
+    }
+    return p.value;
   }
   if (ts.isIdentifier(expr)) {
     const p = cx.scope.get(expr.text);

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -90,7 +90,10 @@ export function compileIrPathFunctions(
   classShapes?: ReadonlyMap<string, IrClassShape>,
 ): IrIntegrationReport {
   const selected = selection ?? planIrCompilation(sourceFile, { experimentalIR: true });
-  if (selected.funcs.size === 0) {
+  // #1370 Phase B: don't short-circuit when only class members are claimed —
+  // a source file may declare a class with IR-eligible methods but no
+  // top-level FunctionDeclarations.
+  if (selected.funcs.size === 0 && (!selected.classMembers || selected.classMembers.size === 0)) {
     return { compiled: [], errors: [] };
   }
 
@@ -152,6 +155,18 @@ export function compileIrPathFunctions(
      * (mirrors the monomorphize-clone path).
      */
     readonly synthesized?: boolean;
+    /**
+     * #1370 Phase B: marks instance class methods. The legacy
+     * `class-bodies.ts` already pre-allocated a typeIdx + signature for
+     * the slot; before patching the body, the Phase 3 loop verifies the
+     * IR-lowered typeIdx matches the existing one. On mismatch it skips
+     * the patch — the legacy body stays in place, callers' `call $...`
+     * ops keep working, and a warning is logged so the divergence is
+     * visible. This guard is unnecessary for top-level FunctionDeclarations
+     * where the slot's pre-allocated typeIdx is whatever the integration
+     * lowerer chose (no legacy callers depending on it).
+     */
+    readonly classMember?: boolean;
   }
   const built: BuiltFn[] = [];
   for (const stmt of sourceFile.statements) {
@@ -198,6 +213,106 @@ export function compileIrPathFunctions(
     }
   }
 
+  // -------------------------------------------------------------------------
+  // #1370 Phase B — Build IR functions for class members claimed by the
+  // selector. Mirrors the FunctionDeclaration loop above:
+  //
+  //   1. Walk class declarations from sourceFile.statements.
+  //   2. Filter to MethodDeclarations whose synthetic name is in
+  //      `selected.classMembers`.
+  //   3. Currently restricted to NON-static instance methods. Static
+  //      methods stay on legacy (no `self` injection complication; can
+  //      be added in a follow-up). Constructors stay on legacy (Phase C
+  //      handles their `struct.new + __self` epilogue).
+  //   4. For each eligible method:
+  //      - Look up the class's `IrClassShape` from the resolver-supplied
+  //        `classShapes` map. Skip if absent (legacy class shape couldn't
+  //        be projected — leave on legacy).
+  //      - Call `lowerFunctionAstToIr(member, { funcName, selfParam: { type:
+  //        IrType.class }, classShapes, resolver, calleeTypes })`. The
+  //        widened lowerFunctionAstToIr (Phase B in from-ast.ts) injects
+  //        a `__self` first param matching the legacy struct-ref slot.
+  //      - Verify the IrFunction.
+  //      - Push to `built` with `classMember: true`. The Phase 3 slot
+  //        patch performs a typeIdx parity check before overwriting.
+  // -------------------------------------------------------------------------
+  if (selected.classMembers && selected.classMembers.size > 0) {
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isClassDeclaration(stmt) || !stmt.name) continue;
+      const className = stmt.name.text;
+      // Phase A's selector already excluded classes with `extends`; defensive
+      // re-check here so a future selector loosening doesn't silently flow
+      // unsupported shapes into Phase B.
+      if (stmt.heritageClauses?.some((h) => h.token === ts.SyntaxKind.ExtendsKeyword)) continue;
+
+      const classShape = classShapes?.get(className);
+      // The IR class shape registry only seeds non-extends classes today
+      // (see `buildIrClassShapes` in `src/codegen/index.ts`). Without a
+      // shape we can't form a valid `IrType.class` for the `__self` param,
+      // so the methods stay on legacy.
+      if (!classShape) continue;
+
+      for (const member of stmt.members) {
+        if (!ts.isMethodDeclaration(member) || !member.name) continue;
+        // Phase B v1 — instance methods only. Static methods skip `self`
+        // injection and use a different funcMap entry shape; defer to a
+        // follow-up. Abstract methods have no body — Phase A already
+        // rejected them as `class-method`.
+        const isStatic = member.modifiers?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword) ?? false;
+        if (isStatic) continue;
+        if (member.modifiers?.some((m) => m.kind === ts.SyntaxKind.AbstractKeyword)) continue;
+
+        // Phase A's `phase1MemberName` admits identifier / string-literal /
+        // numeric-literal — replicate the dispatch here without re-importing
+        // the helper (it's selector-private). The synthetic name format
+        // mirrors `class-bodies.ts:275` exactly.
+        let methodNameRaw: string;
+        if (ts.isIdentifier(member.name)) methodNameRaw = member.name.text;
+        else if (ts.isStringLiteral(member.name) || ts.isNumericLiteral(member.name)) {
+          methodNameRaw = member.name.text;
+        } else continue; // computed / private name — skipped by selector
+
+        const memberName = `${className}_${methodNameRaw}`;
+        if (!selected.classMembers.has(memberName)) continue;
+
+        try {
+          const result = lowerFunctionAstToIr(member, {
+            exported: false, // class methods are not directly exported
+            funcName: memberName,
+            selfParam: { type: { kind: "class", shape: classShape } as IrType },
+            calleeTypes,
+            classShapes,
+            resolver: fromAstResolver,
+          });
+          const mainErrors = verifyIrFunction(result.main);
+          if (mainErrors.length > 0) {
+            for (const e of mainErrors) errors.push({ func: memberName, message: e.message });
+            continue;
+          }
+          // Class method bodies should not produce lifted closures in Phase B
+          // (Phase 1 shape doesn't allow nested function decls inside method
+          // bodies that capture `this`). Defensive re-verify if any appear.
+          let anyLiftedFailed = false;
+          for (const lifted of result.lifted) {
+            const liftedErrors = verifyIrFunction(lifted);
+            if (liftedErrors.length > 0) {
+              for (const e of liftedErrors) errors.push({ func: lifted.name, message: e.message });
+              anyLiftedFailed = true;
+            }
+          }
+          if (anyLiftedFailed) continue;
+
+          built.push({ name: memberName, fn: result.main, classMember: true });
+          for (const lifted of result.lifted) {
+            built.push({ name: lifted.name, fn: lifted, synthesized: true });
+          }
+        } catch (e) {
+          errors.push({ func: memberName, message: e instanceof Error ? e.message : String(e) });
+        }
+      }
+    }
+  }
+
   if (built.length === 0) return { compiled, errors };
 
   // -------------------------------------------------------------------------
@@ -216,7 +331,12 @@ export function compileIrPathFunctions(
       }
       continue;
     }
-    afterHygiene.push({ name: entry.name, fn: optimized, synthesized: entry.synthesized });
+    afterHygiene.push({
+      name: entry.name,
+      fn: optimized,
+      synthesized: entry.synthesized,
+      classMember: entry.classMember,
+    });
   }
 
   if (afterHygiene.length === 0) return { compiled, errors };
@@ -239,7 +359,12 @@ export function compileIrPathFunctions(
       }
       continue;
     }
-    afterInline.push({ name: before.name, fn: final, synthesized: before.synthesized });
+    afterInline.push({
+      name: before.name,
+      fn: final,
+      synthesized: before.synthesized,
+      classMember: before.classMember,
+    });
   }
 
   if (afterInline.length === 0) return { compiled, errors };
@@ -294,6 +419,7 @@ export function compileIrPathFunctions(
       name: fn.name,
       fn: final,
       synthesized: before?.synthesized || wasCloned,
+      classMember: before?.classMember,
     });
   }
 
@@ -309,6 +435,10 @@ export function compileIrPathFunctions(
     // Top-level (non-synthesized) functions already have a funcIdx
     // allocated by `compileDeclarations`. Skip them.
     if (originalNames.has(entry.name) && !entry.synthesized) continue;
+    // #1370 Phase B: class members have funcIdx pre-allocated by the
+    // legacy `class-bodies.ts` pass (`ctorFuncIdx` / `methodFuncIdx`).
+    // Don't allocate a new slot — Phase 3 will patch the existing one.
+    if (entry.classMember) continue;
     if (ctx.funcMap.has(entry.name)) continue; // already registered (defensive)
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.mod.functions.push({
@@ -466,6 +596,31 @@ export function compileIrPathFunctions(
       const { func: wasmFunc } = lowerIrFunctionToWasm(entry.fn, resolver);
 
       const existing = ctx.mod.functions[localIdx];
+      // #1370 Phase B: signature parity guard for class methods.
+      //
+      // The legacy `class-bodies.ts` pass pre-allocated this method's
+      // typeIdx, and any legacy-compiled caller already emitted
+      // `call $methodFuncIdx` ops that route through that typeIdx. If
+      // the IR-lowered body's typeIdx differs (e.g. f64 vs i32 for the
+      // same TS `number`), patching would leave callers calling through
+      // a stale type — Wasm validation fails, or worse, runtime UB.
+      //
+      // `addFuncType` deduplicates on signature, so identical sigs
+      // produce identical typeIdx. A mismatch here means the IR resolved
+      // a different ValType than legacy. Skip the patch — the legacy
+      // body stays in place; the IR's effort goes uncommitted but no
+      // regression occurs.
+      //
+      // Top-level FunctionDeclarations don't need this check — their
+      // pre-allocated body was empty and no legacy callers depend on
+      // the slot's prior typeIdx.
+      if (entry.classMember && wasmFunc.typeIdx !== existing.typeIdx) {
+        errors.push({
+          func: name,
+          message: `class-method typeIdx parity mismatch: IR=${wasmFunc.typeIdx}, legacy=${existing.typeIdx} — keeping legacy body`,
+        });
+        continue;
+      }
       ctx.mod.functions[localIdx] = {
         name: existing.name,
         typeIdx: wasmFunc.typeIdx,


### PR DESCRIPTION
## Summary

Builds on Phase A (PR #293, merged) to actually compile **class instance methods** through the IR path. The legacy `class-bodies.ts` pre-allocates a `funcMap` entry + typeIdx + empty body per method; Phase B's integration loop now patches those slots with IR-lowered bodies. Static methods and constructors stay on legacy (deferred to follow-ups / Phase C).

### What changes

**`src/ir/from-ast.ts`**
- `lowerFunctionAstToIr` parameter widened to `FunctionDeclaration | MethodDeclaration | ConstructorDeclaration`.
- New options: `funcName` (caller-supplied name for nodes without one) and `selfParam` (injects synthetic `__self` first param + binds `this` in scope to its SSA value).
- `lowerExpr` accepts `ts.SyntaxKind.ThisKeyword` and returns the `this` SSA value.
- `collectMutatedLetNames` widened to the same union.
- `ConstructorDeclaration` is rejected with a clear error (Phase C work).

**`src/ir/integration.ts`**
- `BuiltFn` gains `classMember?: boolean` flag, threaded through hygiene/inline/mono stages.
- New class-member walk in `compileIrPathFunctions` after the FunctionDeclaration loop: iterates `selected.classMembers`, builds `IrType.class` `selfParam` from `classShapes`, calls the widened `lowerFunctionAstToIr`, threads the result through the existing Phase 2 + 3 pipeline.
- Skip-funcIdx-allocation branch for class members (their slot is pre-allocated by `class-bodies.ts`).
- **Signature parity guard** before patching the slot — refuses to overwrite if `wasmFunc.typeIdx !== existing.typeIdx`, leaving the legacy body in place. Diagnostic surfaces as a warning so divergence is visible. Top-level FunctionDeclarations don't need this since their pre-allocated body was empty.
- Early-return short-circuit relaxed: doesn't bail when `funcs` is empty if `classMembers` is non-empty.

**`src/codegen/index.ts`**
- `safeSelection` threads `classMembers` through to the integration layer.

### Out of scope

- **Static methods** — deferred (no `self` complication but separate funcMap path).
- **Constructors** — Phase C (need `struct.new + __self` epilogue).
- **Classes with `extends`** — Phase A's selector already rejects them; Phase E handles inheritance + `super`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Phase B probe: `class Calc { add; mul }` — `run()` returns 25 in both legacy and IR; values match
- [x] Trace probe: `Calc_add` body confirmed as IR-lowered shape (numeric `local.get N`, not `$name` legacy form)
- [x] `this.method()` probe: `class Counter { next; nextNext }` with `this.next()` chains — both methods IR-compiled, return 7
- [x] Class equivalence tests (6 files): 22/22 pass (incl. `ir-slice4-classes` exercising IR-callable class instances)
- [x] IR test suite (14 files): 327/327 pass
- [x] IR fallback baseline gate: no regression
- [ ] CI — wait for `.claude/ci-status/pr-N.json`

## Phase progress

- [x] **Phase A** (#293, merged) — selector claims class methods + constructors
- [x] **Phase B** (this PR) — IR integration patches instance method bodies
- [ ] **Phase C** — constructor body lowering (`struct.new + __self`)
- [ ] **Phase D** — async/generator methods
- [ ] **Phase E** — inheritance + `super.method()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)