### PR TITLE
fix(#1389): allow var+function-decl with same name at top-level scope

### DIFF
--- a/plan/issues/sprints/51/1389-false-ce-var-function-same-name-top-level.md
+++ b/plan/issues/sprints/51/1389-false-ce-var-function-same-name-top-level.md
@@ -2,7 +2,7 @@
 id: 1389
 sprint: 51
 title: "fix: false CE — var + function-declaration same name at top-level scope"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: medium
 feasibility: easy
@@ -70,3 +70,17 @@ In `checkVarLexicalConflicts` (`src/compiler/validation.ts:2601`), only add func
 ## Files
 
 - `src/compiler/validation.ts:2601` — one-line fix
+
+## Test Results
+
+Probe `tests/issue-1389.test.ts` (6 cases) all pass:
+- ✓ `var x; function x(){}` at SourceFile scope compiles (script-level: var-scoped)
+- ✓ `function x(){}; var x;` at SourceFile scope (other order) also compiles
+- ✓ `let x; var x;` at SourceFile scope STILL errors (let is genuinely lexical)
+- ✓ `class X{}; var X;` at SourceFile scope STILL errors (class is lexical)
+- ✓ `{ function x(){}; var x; }` inside a Block STILL errors (block-scoped function is lexical)
+- ✓ `{ let x; var x; }` inside a Block STILL errors
+
+Real test262 file `nested-function-script-code-valid.js` containing `var smoosh; function smoosh() {}` now compiles cleanly (previously: `Cannot redeclare block-scoped variable 'smoosh'`).
+
+`tests/ts-wasm-equivalence.test.ts` and `tests/tdz-reference-error.test.ts` still pass (no regressions in scope-related tests).

--- a/src/compiler/validation.ts
+++ b/src/compiler/validation.ts
@@ -2599,7 +2599,12 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
           }
         }
       } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
-        lexicalNames.add(stmt.name.text);
+        // At SourceFile scope, function declarations are var-scoped — no conflict with var
+        // (LexicallyDeclaredNames does not include VarDeclaredNames per ES §13.1.1).
+        // Only inside a Block are function declarations lexically scoped (ES §B.3.2).
+        if (ts.isBlock(block)) {
+          lexicalNames.add(stmt.name.text);
+        }
       } else if (ts.isClassDeclaration(stmt) && stmt.name) {
         lexicalNames.add(stmt.name.text);
       }

--- a/tests/issue-1389.test.ts
+++ b/tests/issue-1389.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+
+describe("#1389 — false CE: var + function-decl same name at top-level", () => {
+  it("var + function-decl at SourceFile scope compiles (script-level: var-scoped)", () => {
+    const src = `
+      var smoosh;
+      function smoosh() {}
+      export function test(): number {
+        return typeof smoosh === "function" ? 1 : 0;
+      }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(true);
+  });
+
+  it("function-decl + var at SourceFile scope (other order) also compiles", () => {
+    const src = `
+      function smoosh() {}
+      var smoosh;
+      export function test(): number {
+        return 1;
+      }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(true);
+  });
+
+  it("let + var at SourceFile scope STILL errors (let is genuinely lexical)", () => {
+    const src = `
+      let smoosh;
+      var smoosh;
+      export function test(): number { return 1; }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(false);
+  });
+
+  it("class + var at SourceFile scope STILL errors (class is lexical)", () => {
+    const src = `
+      class Smoosh {}
+      var Smoosh;
+      export function test(): number { return 1; }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(false);
+  });
+
+  it("function + var inside a Block STILL errors (block-scoped function is lexical)", () => {
+    // Block-scoped function declaration (ES §B.3.2) — lexically scoped.
+    const src = `
+      export function test(): number {
+        {
+          function x() {}
+          var x = 2;
+        }
+        return 1;
+      }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(false);
+  });
+
+  it("let + var inside a Block STILL errors", () => {
+    const src = `
+      export function test(): number {
+        {
+          let x = 1;
+          var x = 2;
+        }
+        return 1;
+      }
+    `;
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- At SourceFile scope, function declarations are var-scoped, not lexical (ES §13.1.1). The validator was incorrectly adding all function-decl names to `lexicalNames`, which produced a false `Cannot redeclare block-scoped variable` CE for `var x; function x(){}`.
- One-line fix: in `checkVarLexicalConflicts` (`src/compiler/validation.ts:2601`), gate `lexicalNames.add(stmt.name.text)` behind `ts.isBlock(block)`, so function declarations only count as lexical inside a Block (ES §B.3.2).
- Estimated test262 yield: ~60 tests previously blocked by this false positive.

## Test plan
- [x] New probe `tests/issue-1389.test.ts` (6 cases) — all pass:
  - `var x; function x(){}` at SourceFile scope compiles (both orderings)
  - `let x; var x;` and `class X{}; var X;` at SourceFile scope STILL error (genuinely lexical)
  - `{ function x(){}; var x; }` and `{ let x; var x; }` inside Block STILL error
- [x] Real test262 file `nested-function-script-code-valid.js` containing `var smoosh; function smoosh() {}` now compiles cleanly
- [x] `tests/ts-wasm-equivalence.test.ts` and `tests/tdz-reference-error.test.ts` pass (no regressions in scope-related tests)
- [ ] CI: full test262 + sharded run

Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)