### PR TITLE
fix(#1390): skip language/import/import-defer tests unconditionally

### DIFF
--- a/plan/issues/sprints/51/1390-import-defer-no-test-export-ce.md
+++ b/plan/issues/sprints/51/1390-import-defer-no-test-export-ce.md
@@ -2,7 +2,7 @@
 id: 1390
 sprint: 51
 title: "fix: import-defer proposal tests fail as CE (no test export) when TEST262_INCLUDE_PROPOSALS=1"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: low
 feasibility: easy
@@ -62,3 +62,27 @@ harness runner setup should be excluded from compile+run, or recorded as `skip` 
 ## Estimated yield
 
 ~31 CE → skip or fail (net neutral for pass count, but cleaner conformance picture).
+
+## Resolution
+
+Implemented Option A. Added a path-based skip in `shouldSkip` for any
+`language/import/import-defer/` test, *before* the proposal-scope env-var
+check. The skip is unconditional — it fires whether `TEST262_INCLUDE_PROPOSALS`
+is set or not — because every file in this subtree is either a parse-phase
+negative test (`$DONOTEVALUATE`, no test export) or relies on a `import defer`
+namespace runtime that we don't implement.
+
+### Test Results
+
+Local probe across `test262/test/language/import/import-defer/` with
+`TEST262_INCLUDE_PROPOSALS=1`:
+
+- 96 / 96 test files now skip (was: 31 CE + 65 other classifications).
+- Sibling `test262/test/language/import/import-attributes/` unchanged: 12 / 12
+  still run (no false-positive skip).
+- New unit test `tests/issue-1390-import-defer-skip.test.ts` (5 cases) passes:
+  - syntax-negative skipped when proposals excluded
+  - syntax-negative skipped when proposals included
+  - runtime namespace test skipped when proposals included
+  - unrelated import test still runs when proposals included
+  - undefined filePath does not produce a false skip with the import-defer reason

--- a/tests/issue-1390-import-defer-skip.test.ts
+++ b/tests/issue-1390-import-defer-skip.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for issue #1390: import-defer proposal tests show as CE
+ * "no test export" when TEST262_INCLUDE_PROPOSALS=1.
+ *
+ * The fix adds a path-based skip in `shouldSkip` for
+ * `language/import/import-defer/` that runs unconditionally, before the
+ * proposal-scope env-var check, so these syntax-only tests are always
+ * skipped — regardless of TEST262_INCLUDE_PROPOSALS.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseMeta, shouldSkip } from "./test262-runner.js";
+
+describe("issue #1390: import-defer tests are always skipped", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // Mirrors test262/test/language/import/import-defer/syntax/invalid-defer-default.js
+  const SYNTAX_NEGATIVE = `// Copyright (C) 2024 Igalia, S.L. All rights reserved.
+/*---
+esid: sec-imports
+description: \`import defer\` cannot be used with default imports
+features: [import-defer]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+import defer x from "./dep_FIXTURE.js";
+`;
+
+  // Mirrors test262/test/language/import/import-defer/deferred-namespace-object/exotic-object-behavior.js
+  const RUNTIME_TEST = `/*---
+esid: sec-modulenamespacecreate
+description: Deferred namespace objects have the correct MOP implementation
+flags: [module]
+features: [import-defer]
+includes: [propertyHelper.js, compareArray.js]
+---*/
+
+import defer * as ns from "./dep_FIXTURE.js";
+assert.sameValue(typeof ns, "object", "Deferred namespaces are objects");
+`;
+
+  const FILE_PATH_SYNTAX = "test262/test/language/import/import-defer/syntax/invalid-defer-default.js";
+  const FILE_PATH_RUNTIME =
+    "test262/test/language/import/import-defer/deferred-namespace-object/exotic-object-behavior.js";
+
+  it("skips syntax-negative import-defer tests when proposals are EXCLUDED", () => {
+    vi.stubEnv("TEST262_INCLUDE_PROPOSALS", "");
+    const meta = parseMeta(SYNTAX_NEGATIVE);
+    const result = shouldSkip(SYNTAX_NEGATIVE, meta, FILE_PATH_SYNTAX);
+    expect(result.skip).toBe(true);
+  });
+
+  it("skips syntax-negative import-defer tests when proposals are INCLUDED", () => {
+    vi.stubEnv("TEST262_INCLUDE_PROPOSALS", "1");
+    const meta = parseMeta(SYNTAX_NEGATIVE);
+    const result = shouldSkip(SYNTAX_NEGATIVE, meta, FILE_PATH_SYNTAX);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain("import defer");
+  });
+
+  it("skips runtime import-defer namespace tests when proposals are INCLUDED", () => {
+    vi.stubEnv("TEST262_INCLUDE_PROPOSALS", "1");
+    const meta = parseMeta(RUNTIME_TEST);
+    const result = shouldSkip(RUNTIME_TEST, meta, FILE_PATH_RUNTIME);
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain("import defer");
+  });
+
+  it("does NOT skip unrelated import tests when proposals are INCLUDED", () => {
+    vi.stubEnv("TEST262_INCLUDE_PROPOSALS", "1");
+    const source = `/*---
+description: regular import test
+flags: [module]
+---*/
+import { x } from "./dep.js";
+export function test() { return 1; }
+`;
+    const meta = parseMeta(source);
+    const result = shouldSkip(source, meta, "test262/test/language/import/some-other.js");
+    expect(result.skip).toBe(false);
+  });
+
+  it("does NOT skip when filePath is undefined (defensive: no false skip)", () => {
+    const meta = parseMeta(SYNTAX_NEGATIVE);
+    // Without filePath we cannot pattern-match on the path. The proposal
+    // env-var path still applies; with proposals INCLUDED the test would
+    // fall through to the rest of the runner, which is the pre-fix behavior.
+    vi.stubEnv("TEST262_INCLUDE_PROPOSALS", "1");
+    const result = shouldSkip(SYNTAX_NEGATIVE, meta, undefined);
+    // No path-based skip can fire; result depends on other filters but
+    // should NOT be skipped purely because of the import-defer feature.
+    expect(result.reason ?? "").not.toContain("import defer (no test harness)");
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -324,6 +324,22 @@ export function shouldSkip(source: string, meta: Test262Meta, filePath?: string)
     }
   }
 
+  // #1390: import-defer proposal tests are syntax-only — they have no
+  // `export function test()` and rely on either a parse-phase negative check
+  // or a `import defer` namespace runtime that we don't implement. With
+  // TEST262_INCLUDE_PROPOSALS=1 they show as ~31 false `compile_error: no test
+  // export` entries. Skip the whole subtree unconditionally so the conformance
+  // report stays clean regardless of the proposals flag.
+  if (filePath) {
+    const relPath = filePath.replace(/.*test262\//, "");
+    if (relPath.includes("language/import/import-defer/")) {
+      return {
+        skip: true,
+        reason: "proposal feature: import defer (no test harness)",
+      };
+    }
+  }
+
   // #1073: annexB/language/eval-code blanket skip removed. The __extern_eval
   // handler now prepends JS-side harness shims (assert_sameValue, assert_throws,
   // etc.) so Gap 1 (harness visibility, ~107 tests) is resolved. Gap 2 (export


### PR DESCRIPTION
## Summary

Closes #1390. The `import-defer` proposal subtree contains 96 tests that are syntax-only or rely on an unimplemented `import defer` namespace runtime. With `TEST262_INCLUDE_PROPOSALS=1` (CI default for push/PR) ~31 of these surfaced as `compile_error: no test export`, polluting the conformance report.

## What changed

- `tests/test262-runner.ts`: added a path-based skip in `shouldSkip` for `language/import/import-defer/` that fires **before** the proposal env-var check, so the whole subtree is always skipped regardless of `TEST262_INCLUDE_PROPOSALS`.
- `tests/issue-1390-import-defer-skip.test.ts`: 5-case unit test covering proposals-excluded, proposals-included (syntax + runtime), unrelated import not skipped, and undefined-filePath defensive case.

## Local verification

Walked `test262/test/language/import/import-defer/` with `TEST262_INCLUDE_PROPOSALS=1`:
- 96 / 96 files now classified as skip (was: 31 CE + others).
- Sibling `language/import/import-attributes/`: 12 / 12 still run — no false-positive skip.

## Test plan

- [x] `npm test -- tests/issue-1390-import-defer-skip.test.ts` — 5/5 pass
- [x] Manual probe over all 96 import-defer files — all skip
- [x] Sibling subtree `import-attributes` confirmed unaffected
- [ ] CI green; no regressions in other import tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)