### PR TITLE
fix(#1384): walk ctx.currentFunc.body in shiftLateImportIndices

### DIFF
--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1571,6 +1571,14 @@ export function compileArrowAsClosure(
     isGenerator,
   };
 
+  // (#1384) Track liftedFctx.body in liveBodies BEFORE any emission so
+  // addUnionImports / shiftLateImportIndices can shift any `call funcIdx`
+  // instructions that get emitted during the captures-extraction prologue
+  // (lines 1589-1635) and the TDZ-flag-extraction prologue (lines 1648-1660),
+  // BOTH of which run BEFORE the savedFunc swap below that would otherwise
+  // expose liftedFctx.body via ctx.currentFunc / funcStack to the shifter.
+  ctx.liveBodies.add(liftedFctx.body);
+
   for (let i = 0; i < liftedFctx.params.length; i++) {
     liftedFctx.localMap.set(liftedFctx.params[i]!.name, i);
   }
@@ -2120,6 +2128,9 @@ export function compileArrowAsClosure(
     body: liftedFctx.body,
     exported: false,
   });
+  // (#1384) liftedFctx.body is now reachable via ctx.mod.functions[].body —
+  // remove from liveBodies to keep it tight (the regular walker dedupes anyway).
+  ctx.liveBodies.delete(liftedFctx.body);
   ctx.funcMap.set(closureName, liftedFuncIdx);
 
   // 7. At the creation site, emit struct.new with funcref + captured values
@@ -2379,6 +2390,13 @@ export function compileArrowAsCallback(
     enclosingClassName: fctx.enclosingClassName ?? resolveEnclosingClassName(fctx),
   };
 
+  // (#1384) Track cbFctx.body in liveBodies BEFORE any emission so addUnionImports
+  // / shiftLateImportIndices can shift any `call funcIdx` instructions that get
+  // emitted into it during the captures-extraction (step 4) and param-coercion
+  // (step 4b) phases — both run BEFORE the savedFunc swap at step 5 that would
+  // otherwise expose cbFctx via ctx.currentFunc / funcStack to the shifter.
+  ctx.liveBodies.add(cbFctx.body);
+
   // Register params as locals (param 0 = __captures, [1 = __this if needsThis], then arrow params)
   for (let i = 0; i < cbFctx.params.length; i++) {
     cbFctx.localMap.set(cbFctx.params[i]!.name, i);
@@ -2529,6 +2547,11 @@ export function compileArrowAsCallback(
     body: cbFctx.body,
     exported: true,
   });
+  // (#1384) cbFctx.body is now reachable via ctx.mod.functions[].body — the
+  // regular shifter walker covers it from here on. Remove from liveBodies to
+  // avoid double-traversal (the walker dedupes via its `shifted` set anyway,
+  // but keeping liveBodies tight is cheaper).
+  ctx.liveBodies.delete(cbFctx.body);
   ctx.funcMap.set(cbName, cbFuncIdx);
   ctx.mod.exports.push({
     name: cbName,

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -115,6 +115,7 @@ export function createCodegenContext(
     inlinableFunctions: new Map(),
     symbolCounterGlobalIdx: -1,
     parentBodiesStack: [],
+    liveBodies: new Set(),
     anonStructHash: new Map(),
     funcTypeCache: new Map(),
     pendingLateImportShift: null,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -518,6 +518,13 @@ export interface CodegenContext {
   symbolCounterGlobalIdx: number;
   /** Stack of in-progress parent function bodies for index shifting during closure compilation */
   parentBodiesStack: Instr[][];
+  /** All live (allocated but not yet attached to ctx.mod.functions) FunctionContext bodies.
+   *  Walked by addUnionImports / shiftLateImportIndices to ensure call-funcIdx values
+   *  in nested function bodies under construction (e.g. `cbFctx.body` in
+   *  compileArrowAsCallback during its captures-extraction / param-coercion setup
+   *  phase, BEFORE the savedFunc swap puts it on funcStack) are still shifted on
+   *  late import addition. (#1384) */
+  liveBodies: Set<Instr[]>;
   /** Hash-based lookup for anonymous struct deduplication */
   anonStructHash: Map<string, string>;
   /** Pending late import shift state */

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -56,6 +56,20 @@ export function shiftLateImportIndices(
   for (const sb of fctx.savedBodies) {
     shiftInstrs(sb);
   }
+  // (#1384) Walk ctx.currentFunc.body too. When fctx ≠ ctx.currentFunc — which
+  // happens during compileArrowAsCallback's param-coercion phase (closures.ts
+  // line 2470) where fctx=cbFctx but ctx.currentFunc=outer-fctx — the outer
+  // function's body would otherwise be missed (it's not yet reachable via
+  // funcStack because the savedFunc swap hasn't happened, and `func.body =
+  // fctx.body` in compileFunctionBody only runs AFTER compilation completes,
+  // so ctx.mod.functions[outer].body is still the empty initial array). The
+  // `shifted` Set dedupes when fctx === ctx.currentFunc.
+  if (ctx.currentFunc) {
+    shiftInstrs(ctx.currentFunc.body);
+    for (const sb of ctx.currentFunc.savedBodies) {
+      shiftInstrs(sb);
+    }
+  }
   for (const parentFctx of ctx.funcStack) {
     shiftInstrs(parentFctx.body);
     for (const sb of parentFctx.savedBodies) {
@@ -64,6 +78,13 @@ export function shiftLateImportIndices(
   }
   for (const pb of ctx.parentBodiesStack) {
     shiftInstrs(pb);
+  }
+  // (#1384) Walk all live (allocated but not yet attached to mod.functions)
+  // FunctionContext bodies — covers cbFctx.body / liftedFctx.body during
+  // their captures-extraction + param-coercion setup phases, BEFORE the
+  // savedFunc swap puts them on funcStack/parentBodiesStack.
+  for (const lb of ctx.liveBodies) {
+    shiftInstrs(lb);
   }
   if (ctx.pendingInitBody) {
     shiftInstrs(ctx.pendingInitBody);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3377,6 +3377,12 @@ export function addStringImports(ctx: CodegenContext): void {
     for (const pb of ctx.parentBodiesStack) {
       shiftFuncIndices(pb);
     }
+    // (#1384) Walk all live (allocated but not yet attached to mod.functions)
+    // FunctionContext bodies — covers cbFctx.body / liftedFctx.body during
+    // their captures-extraction + param-coercion setup phases.
+    for (const lb of ctx.liveBodies) {
+      shiftFuncIndices(lb);
+    }
     for (const elem of ctx.mod.elements) {
       if (elem.funcIndices) {
         for (let i = 0; i < elem.funcIndices.length; i++) {
@@ -4696,6 +4702,13 @@ export function addUnionImports(ctx: CodegenContext): void {
     }
     for (const pb of ctx.parentBodiesStack) {
       shiftFuncIndices(pb);
+    }
+    // (#1384) Walk all live (allocated but not yet attached to mod.functions)
+    // FunctionContext bodies — covers cbFctx.body / liftedFctx.body during
+    // their captures-extraction + param-coercion setup phases, BEFORE the
+    // savedFunc swap puts them on funcStack/parentBodiesStack.
+    for (const lb of ctx.liveBodies) {
+      shiftFuncIndices(lb);
     }
     if (ctx.pendingInitBody) {
       shiftFuncIndices(ctx.pendingInitBody);

--- a/tests/issue-1384.test.ts
+++ b/tests/issue-1384.test.ts
@@ -1,0 +1,68 @@
+// #1384: Wasm validation failure when an arrow callback's param type
+// (resolved to a struct ref) triggers `coerceType` BEFORE the savedFunc swap
+// in `compileArrowAsCallback`. The late-import shifter was walking
+// `fctx.body` (= cbFctx.body) but not `ctx.currentFunc.body` (the OUTER
+// fctx whose body holds the already-emitted `call $userFunc` instruction).
+// After my fix, shiftLateImportIndices walks ctx.currentFunc.body too,
+// preventing stale funcIdx values that produce CE: "not enough arguments
+// on the stack for call".
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileAndValidate(src: string) {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message}`);
+  return WebAssembly.compile(r.binary);
+}
+
+describe("#1384 — async chain + arrow callback arity bug", () => {
+  it("Promise.all([asyncCall()]).then(r => r) compiles and validates", async () => {
+    const src = `
+      async function f(): Promise<any> { return 1; }
+      export function test(): number {
+        Promise.all([f()]).then(r => r);
+        return 1;
+      }
+    `;
+    await compileAndValidate(src);
+  });
+
+  it("Promise.race + .then with untyped callback compiles", async () => {
+    const src = `
+      async function f(): Promise<any> { return 1; }
+      export function test(): number {
+        Promise.race([f()]).then(r => r);
+        return 1;
+      }
+    `;
+    await compileAndValidate(src);
+  });
+
+  it("class with static async method (PrivateName-style fixture) compiles", async () => {
+    // Mirrors the structure of the test262 class-element fixtures (#1384 issue
+    // title). The class instantiation + static async dispatch path goes through
+    // the same arrow-callback compilation route as the minimum reproducer.
+    const src = `
+      class C {
+        static async f(v: any): Promise<any> { return v; }
+      }
+      export function test(): number {
+        Promise.all([C.f(1)]).then(r => r);
+        return 1;
+      }
+    `;
+    await compileAndValidate(src);
+  });
+
+  it("nested .then with chained await-shaped values compiles", async () => {
+    const src = `
+      async function f(): Promise<any> { return 1; }
+      async function g(): Promise<any> { return 2; }
+      export function test(): number {
+        Promise.all([f(), g()]).then(r => r).then(r => r);
+        return 1;
+      }
+    `;
+    await compileAndValidate(src);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1384 — Wasm validation CE "not enough arguments on the stack for call" affecting 249 test262 class-element tests + the 6-line `Promise.all([asyncCall()]).then(r => r)` minimum reproducer.
- Root cause: `shiftLateImportIndices` walked `fctx.body` (parameter) but not `ctx.currentFunc.body`. They diverge during `compileArrowAsCallback`'s param-coercion phase (`coerceType(ctx, cbFctx, ...)` while `ctx.currentFunc=outer`); the outer fctx is also not yet in `mod.functions[].body` because `func.body = fctx.body` runs at the END of `compileFunctionBody`. Outer's `call $userFunc` instructions stayed at stale funcIdx values.
- Two-prong fix: (Prong 1) shifter walks `ctx.currentFunc.body` too; (Prong 2) new `ctx.liveBodies: Set<Instr[]>` registry tracks newly-allocated cbFctx/liftedFctx body arrays before they're attached to `mod.functions`, walked by all three shifters (`addUnionImports`, `addStringImports`, `shiftLateImportIndices`).

Net: +133 lines across 5 source files + 1 new test file. No deletions.

## Test plan

- [x] 6-line reproducer compiles + Wasm-validates (`.tmp/probe-1384-min.mts`)
- [x] 3 representative test262 class-element fixtures pass: `new-no-sc-line-method-rs-static-async-method-privatename-identifier.js`, `new-sc-line-method-rs-...`, `wrapped-in-sc-rs-...`
- [x] `tests/issue-1384.test.ts` (4 cases) — Promise.all+then, Promise.race+then, static-class-method dispatch, chained `.then(...).then(...)`
- [x] Pre-existing equivalence failures (tagged-template, promise-chains async-as-Promise, #1197 peephole) verified unchanged on this branch by stashing the fix
- [ ] CI: test262 sharded run — expect ≥+200 net (issue acceptance criterion)
- [ ] CI: PR validation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)