### PR TITLE
fix(#1388-regression): revert prototype-method handler — recover 478 class/elements identity tests

### DIFF
--- a/plan/issues/sprints/51/1388-null-next-yield-star-async-gen-class-methods.md
+++ b/plan/issues/sprints/51/1388-null-next-yield-star-async-gen-class-methods.md
@@ -163,3 +163,80 @@ Acceptance-criterion tests:
 Regression test added: `tests/equivalence/issue-1388.test.ts` (7 cases
 covering static / class-expression / prototype / arg-passing / async-
 generator-iteration / typeof-function paths).
+
+## Senior Dev Investigation Notes (2026-05-08, PR #305 follow-up)
+
+**Hypothesis under investigation:** Tech-lead suggested ~143 net regressions
+remained after the partial revert (commit 883032e64), attributed to
+`emitFuncRefAsClosure` having an index-shifting side-effect via
+`addUnionImports` that corrupts already-emitted function bodies.
+
+**Finding:** The hypothesis is incorrect. Tracing `emitFuncRefAsClosure`
+in `src/codegen/closures.ts:2712`:
+
+1. The no-captures branch (lines 2914–2946) calls
+   `getOrCreateFuncRefWrapperTypes`, which only pushes to
+   `ctx.mod.types[]` and `addFuncType` (also types-only). **Type
+   additions do not shift function indices.**
+2. The trampoline is appended to `ctx.mod.functions` at the next
+   available `funcIdx = ctx.numImportFuncs + ctx.mod.functions.length`.
+   **Appending at the end shifts no existing function index.**
+3. `emitFuncRefAsClosure` does NOT call `addUnionImports` or
+   `ensureLateImport`. There is no path through it that adds imports.
+4. If `addUnionImports` is invoked later in compilation, its shift loop
+   (`src/codegen/index.ts:4693-4742`) walks every function in
+   `ctx.mod.functions` (including freshly-added trampolines) and every
+   live FunctionContext body in `ctx.liveBodies`, `ctx.parentBodiesStack`,
+   `ctx.funcStack`, `ctx.currentFunc.savedBodies`, plus `ctx.mod.elements`,
+   `ctx.mod.declaredFuncRefs`, and `ctx.mod.startFuncIdx`. The shift is
+   complete; no body — including the trampoline body just created — is
+   missed.
+
+**Conclusion:** The static-method-handler path in `compilePropertyAccess`
+(lines 1191–1203) is structurally safe. Approach A (pre-registering the
+wrapper struct at class-compilation time) would not change observable
+behavior because the wrapper types are already cache-keyed by signature
+in `ctx.funcRefWrapperCache`; the same struct type is reused on every
+access of any static method with a matching signature.
+
+**Re-analysis of the "143 regressions" attribution:**
+
+CI status snapshots show the post-PR-294 chain as:
+
+| PR  | head_branch                          | pass    | net  |
+|-----|--------------------------------------|---------|------|
+| 294 | issue-1388-null-next-yield-star      | 27,036  | -140 |
+| 295 | issue-1370-ir-phase-b                | 27,210  | +174 |
+| 296 | issue-1389-var-fn-redecl             | 27,221  |  +11 |
+| 297 | issue-1390-import-defer-skip         | 27,216  |   -5 |
+| 298 | issue-1384-async-arity               | 27,312  |  +96 |
+| 299 | issue-1377-array-mutation-spec       | 27,070  | -242 |
+| 300 | issue-1371-ir-extern-whitelist       | 27,070  |    0 |
+| 301 | issue-1372-ir-destructuring-params   | 27,068  |   -2 |
+
+The dominant negative event is **PR #299**, which dropped pass count
+from 27,312 → 27,070 (−242). PR #294's own −140 was already largely
+recovered by subsequent improvement PRs. The "−143 versus
+pre-#294 baseline (27,211)" the tech-lead cited is dominated by PR #299,
+not by the residual static-method-handler effect.
+
+The async-generator/destructuring failure cluster cited
+(`language/expressions/async-generator/dstr/dflt-ary-ptrn-*`) inspects
+top-level `async function*([…] = […])` patterns with no class involvement
+at all. These are destructuring-default-value spec compliance failures
+and do not exercise the static-method-extraction path that PR #294
+modified. They should not be attributable to property-access.ts.
+
+**Action taken:** Keep the branch's existing partial revert (commit
+883032e64) as the right balance: +232 static-method wins preserved, 478
+prototype-method-identity regressions recovered. Cherry-picked tech-lead
+typecheck fix `db2ee79ad` so PR #305 CI quality gate passes (the fix is
+unrelated to #1388 but was blocking CI on every open PR). No further
+changes to property-access.ts are warranted by the actual regression
+data.
+
+Slice 2 (deferred) — the prototype-method-extraction win is still
+recoverable once method-closure caching lands. That would let
+`C.prototype.m` return the same closure ref on every access, preserving
+`c.m === C.prototype.m`. Tracked via `.todo` cases in the regression
+test. Out of scope for this PR.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -15,7 +15,7 @@ import { popBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { emitFuncRefAsClosure, emitObjectMethodAsClosure } from "./closures.js";
+import { emitFuncRefAsClosure } from "./closures.js";
 import { emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import { patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
@@ -1223,42 +1223,15 @@ export function compilePropertyAccess(
     }
   }
 
-  // (#1388) ClassName.prototype.<method> — return a callable closure-struct
-  // externref for the instance method. Mirrors the static-method handler
-  // above but uses `emitObjectMethodAsClosure` so the trampoline drops the
-  // closure-self and supplies a sentinel for the instance-method's `this`
-  // parameter.
-  //
-  // Failing tests like `var gen = C.prototype.gen; gen()` expect `gen()` to
-  // dispatch to the instance method without a real receiver. The yield-star
-  // tests under `language/{expressions,statements}/class/async-gen-method`
-  // rely on this extraction pattern; without it, `gen` was previously
-  // resolved to a stale externref and `iter.next` on the result was null.
-  if (
-    ts.isPropertyAccessExpression(expr.expression) &&
-    ts.isIdentifier(expr.expression.expression) &&
-    expr.expression.name.text === "prototype"
-  ) {
-    const rawName = expr.expression.expression.text;
-    const className = ctx.classExprNameMap.get(rawName) ?? rawName;
-    if (ctx.classSet.has(className)) {
-      const fullName = `${className}_${propName}`;
-      // Only intercept actual instance methods. Skip static methods (they
-      // live on the constructor, not the prototype) and accessors (handled
-      // below by the existing accessor path on element access).
-      if (ctx.classMethodSet.has(fullName) && !ctx.staticMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
-        const structTypeIdx = ctx.structMap.get(className);
-        if (funcIdx !== undefined && structTypeIdx !== undefined) {
-          const closureRef = emitObjectMethodAsClosure(ctx, fctx, fullName, funcIdx, structTypeIdx);
-          if (closureRef) {
-            fctx.body.push({ op: "extern.convert_any" });
-            return { kind: "externref" };
-          }
-        }
-      }
-    }
-  }
+  // (#1388 regression fix) The earlier `ClassName.prototype.<method>` handler
+  // emitted a freshly-allocated closure struct on every access, which broke
+  // method identity: `c.m === C.prototype.m` failed (each side returned a
+  // different closure ref). 478 tests under `language/{expressions,statements}/
+  // class/elements/*` exercise this exact assertion via `verifyProperty` and
+  // turned pass→fail after the original PR landed. The handler is intentionally
+  // omitted here until method-closure caching is implemented (slice 2). Until
+  // then, `C.prototype.<method>` falls through to the legacy generic externref
+  // path, restoring the previous null-externref behaviour and the 478 wins.
 
   // Handle Math.<method>.length — static function arity
   if (

--- a/src/ir/passes/constant-fold.ts
+++ b/src/ir/passes/constant-fold.ts
@@ -249,6 +249,8 @@ function foldUnary(op: IrUnop, rand: IrConst): IrConst | null {
       if (v <= -2147483648) return { kind: "i32", value: -2147483648 };
       return { kind: "i32", value: Math.trunc(v) };
     }
+    default:
+      return null;
   }
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2742,14 +2742,14 @@ assert._isSameValue = isSameValue;
             const isObjWasm = _isWasmStruct(obj);
             const sDescs = isObjWasm ? _getSidecarDescs(obj) : null;
             for (const key of keys) {
-              const rawDesc = getField(descsObj, key);
+              const rawDesc = getField(descsObj, key as string);
               const desc = _toPropertyDescriptorValidate(rawDesc, getField);
               if (isObjWasm) {
-                const nKey = _normalizeDescKey(key);
-                const existingVal2 = _sidecarGet(obj, key);
+                const nKey = _normalizeDescKey(key as string);
+                const existingVal2 = _sidecarGet(obj, key as string);
                 const newFlags = _validatePropertyDescriptor(sDescs!, nKey, desc, existingVal2);
                 sDescs!.set(nKey, newFlags);
-                if (desc.value !== undefined) _sidecarSet(obj, key, desc.value);
+                if (desc.value !== undefined) _sidecarSet(obj, key as string, desc.value);
               } else {
                 Object.defineProperty(obj, key, desc);
               }
@@ -2768,9 +2768,9 @@ assert._isSameValue = isSameValue;
                 const keys = getKeys(descsObj);
                 const validated: { key: string; desc: PropertyDescriptor }[] = [];
                 for (const key of keys) {
-                  const rawDesc = getField(descsObj, key);
+                  const rawDesc = getField(descsObj, key as string);
                   const desc = _toPropertyDescriptorValidate(rawDesc, getField);
-                  validated.push({ key, desc });
+                  validated.push({ key: key as string, desc });
                 }
                 for (const { key, desc } of validated) {
                   const nKey = _normalizeDescKey(key);
@@ -2787,10 +2787,10 @@ assert._isSameValue = isSameValue;
               // Non-TypeError — apply via sidecar
               const keys = getKeys(descsObj);
               for (const key of keys) {
-                const rawDesc = getField(descsObj, key);
+                const rawDesc = getField(descsObj, key as string);
                 if (rawDesc && typeof rawDesc === "object") {
                   const val = getField(rawDesc, "value");
-                  if (val !== undefined) _sidecarSet(obj, key, val);
+                  if (val !== undefined) _sidecarSet(obj, key as string, val);
                 }
               }
             }

--- a/tests/equivalence/issue-1388.test.ts
+++ b/tests/equivalence/issue-1388.test.ts
@@ -84,27 +84,11 @@ describe("#1388 — detached class method extraction", () => {
     expect(exp.test!()).toBe(7);
   });
 
-  it("instance method, detached via prototype", async () => {
-    const exp = await compileToWasm(`
-      class C { method() { return 99; } }
-      export function test(): number {
-        const f = C.prototype.method;
-        return f();
-      }
-    `);
-    expect(exp.test!()).toBe(99);
-  });
+  it.todo(
+    "instance method, detached via prototype — regressed slice 2 (needs method-closure caching to preserve `c.m === C.prototype.m`)",
+  );
 
-  it("instance method with arg, detached via prototype", async () => {
-    const exp = await compileToWasm(`
-      class C { triple(x: number) { return x * 3; } }
-      export function test(): number {
-        const f = C.prototype.triple;
-        return f(14);
-      }
-    `);
-    expect(exp.test!()).toBe(42);
-  });
+  it.todo("instance method with arg, detached via prototype — same slice 2 dependency");
 
   it("static method extracted, typeof reports 'function'", async () => {
     const exp = await compileToWasm(`


### PR DESCRIPTION
## Summary

Reverts the `ClassName.prototype.<method>` handler from PR #294 that broke method identity (`c.m === C.prototype.m`), turning 478 tests under `language/{expressions,statements}/class/elements/*` from pass → fail.

The static-method handler from PR #294 is **preserved** — the +232 win on detached static-method extraction (`const f = C.staticMethod; f()`) is unaffected by the identity issue and stays.

## Investigation (senior dev, PR follow-up)

Tech-lead asked whether `emitFuncRefAsClosure` had an index-shifting side-effect (via `addUnionImports`) that corrupted already-emitted bodies and caused additional regressions. **Hypothesis disproven** — see `plan/issues/sprints/51/1388-null-next-yield-star-async-gen-class-methods.md` for the full trace. Summary:

- `emitFuncRefAsClosure` only pushes to `ctx.mod.types[]` (types-only) and appends a trampoline to `ctx.mod.functions` (end-append, no existing index shifts).
- It does NOT call `addUnionImports` / `ensureLateImport`. No imports are added.
- If `addUnionImports` runs later, its shift loop walks every function body including the freshly-added trampoline.

The "143 regressions vs pre-PR-294" the tech-lead cited is dominated by **PR #299** (`issue-1377-array-mutation-spec`, −242 net per CI), not by property-access.ts. The async-gen/destructuring failures referenced exercise top-level `async function*([…] = […])` patterns with no class involvement.

## Changes

- `src/codegen/property-access.ts` — drop the `ClassName.prototype.<method>` handler + `emitObjectMethodAsClosure` import. Static-method handler preserved.
- `tests/equivalence/issue-1388.test.ts` — convert two prototype-method tests to `.todo` (slice 2; needs method-closure caching to preserve identity).
- `src/ir/passes/constant-fold.ts` + `src/runtime.ts` — typecheck fix cherry-picked from local main `db2ee79ad` to unblock CI quality gate (the fix was blocking every open PR).
- `plan/issues/sprints/51/1388-null-next-yield-star-async-gen-class-methods.md` — investigation notes.

## Trade-off

Loses ~120 `class/async-gen-method` prototype-extraction wins (reverted to legacy null-externref path). Net swing vs main with PR #294 unfixed: **+358** (478 recovered − 120 lost). Slice 2 (deferred) needs a method-closure cache so repeated `C.prototype.m` returns the same closure ref; without that, any reintroduction of the prototype-method handler will re-break the class/elements identity assertions.

## Test plan

- [x] `tests/equivalence/issue-1388.test.ts` — 5 active + 2 .todo, all pass
- [x] `pnpm run typecheck` — passes
- [ ] CI test262 differential — should show net positive vs main (recovers 478 class/elements regressions)
- [ ] CI quality gate — typecheck fix included; should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
