### PR TITLE
feat(#1391): CI feed baseline staleness detection + dev-self-merge escalation

### DIFF
--- a/.claude/skills/dev-self-merge.md
+++ b/.claude/skills/dev-self-merge.md
@@ -45,7 +45,31 @@ If `test262_skipped: true` in the JSON, this was a test-only / docs-only PR
 
 Extract: `head_sha`, `net_per_test`, `regressions`, `regressions_real`,
 `regressions_wasm_change`, `wasm_identical_noise`, `compile_timeouts`,
-`improvements`, `run_url`.
+`improvements`, `run_url`, `baseline_stale`, `baseline_staleness_commits`.
+
+### Step 1a — baseline staleness short-circuit (#1391)
+
+If `baseline_stale: true` is set on the feed, the regression count is
+contaminated by drift on main (tests that flipped between when the baseline
+was last refreshed and the PR's CI run). Continuing through the criteria
+below would falsely block PRs whose actual same-run-main diff is clean.
+
+```bash
+stale=$(jq -r '.baseline_stale // false' .claude/ci-status/pr-<N>.json)
+if [ "$stale" = "true" ]; then
+  drift=$(jq -r '.baseline_staleness_commits // 0' .claude/ci-status/pr-<N>.json)
+  echo "ESCALATE — baseline is stale ($drift commits behind main HEAD)."
+  exit 1
+fi
+```
+
+Output (when triggered):
+
+> **ESCALATE — baseline is stale (N commits behind main HEAD). The CI feed's regression counts are inflated by drift, not by this PR. Tech lead should sanity-check by diffing branch-merged vs main-merged artifacts from the same CI run before merging.**
+
+Skip the rest of the algorithm. Do not merge. The tech lead may override after
+confirming via artifact comparison; the staleness threshold (50 commits) is
+conservative and most PRs will not be flagged.
 
 `regressions_wasm_change` (added by #1222) = regressions where the
 compiled Wasm binary differs between base and PR (excluding

--- a/.github/workflows/ci-status-feed.yml
+++ b/.github/workflows/ci-status-feed.yml
@@ -104,10 +104,52 @@ jobs:
           wasm_identical_noise=null
           compile_timeouts=null
           improvements=null
+          baseline_sha=null
+          baseline_staleness_commits=null
+          baseline_stale=false
           if [ -f /tmp/merged-report/test262-report-merged.json ]; then
             pass=$(jq '.summary.pass' /tmp/merged-report/test262-report-merged.json)
             fail=$(jq '.summary.fail' /tmp/merged-report/test262-report-merged.json)
             ce=$(jq '.summary.compile_error' /tmp/merged-report/test262-report-merged.json)
+            # (#1391) Surface the baseline SHA the diff was computed against
+            # so the merge gate can detect when it lags current main.
+            baseline_sha=$(jq -r '.baseline_sha // ""' /tmp/merged-report/test262-report-merged.json)
+          fi
+
+          # (#1391) Baseline staleness detection.
+          #
+          # When `baseline_sha` lags `origin/main` HEAD by more than 50 commits,
+          # the regression count is contaminated by drift — tests that flipped
+          # on main since the baseline was last refreshed appear as PR
+          # regressions even when the PR didn't cause them. This is exactly
+          # what tripped PR #294: feed reported `regressions_real = 495` while
+          # branch-vs-same-run-main artifact comparison showed only 7.
+          #
+          # When stale, we emit `baseline_stale: true`. The dev-self-merge
+          # gate sees that and escalates to tech lead instead of hard-blocking
+          # on the inflated regression number.
+          STALE_THRESHOLD=50
+          if [ -n "${baseline_sha:-}" ] && [ "$baseline_sha" != "null" ] && [ "$baseline_sha" != "" ] && [ "$baseline_sha" != "unknown" ]; then
+            # Fetch the baseline commit so the merge-base count is computable
+            # even when the workflow checkout is shallow.
+            git fetch --depth=200 origin "$baseline_sha" 2>/dev/null || true
+            # Count commits in main reachable from main HEAD that aren't
+            # reachable from baseline_sha. If the baseline commit isn't
+            # reachable at all (deleted branch, force-push), we report
+            # `baseline_staleness_commits = null` and skip the flag.
+            if git cat-file -e "${baseline_sha}^{commit}" 2>/dev/null; then
+              baseline_staleness_commits=$(git rev-list --count "${baseline_sha}..HEAD" 2>/dev/null || echo 0)
+              # Coerce to integer for the comparison
+              if [ "$baseline_staleness_commits" -gt "$STALE_THRESHOLD" ] 2>/dev/null; then
+                baseline_stale=true
+                echo "::warning::Baseline drift detected — baseline_sha=${baseline_sha:0:8} is ${baseline_staleness_commits} commits behind main HEAD (threshold ${STALE_THRESHOLD}). Regression count may be inflated; gate will escalate to tech lead."
+              else
+                echo "Baseline freshness OK: ${baseline_staleness_commits} commits behind main HEAD."
+              fi
+            else
+              echo "::warning::Baseline commit ${baseline_sha:0:8} is not reachable from this checkout — staleness undetermined."
+              baseline_staleness_commits=null
+            fi
           fi
 
           # snapshot_delta: absolute pass count vs the committed baseline on main.
@@ -157,6 +199,12 @@ jobs:
             net_per_test=$((improvements - regressions_wasm_change))
           fi
 
+          # Coerce the staleness value to a JSON-friendly form.
+          if [ -z "${baseline_staleness_commits:-}" ] || [ "$baseline_staleness_commits" = "null" ]; then
+            baseline_staleness_arg=null
+          else
+            baseline_staleness_arg="$baseline_staleness_commits"
+          fi
           # Write JSON using jq so nothing is broken by shell quoting
           jq -n \
             --arg pr "$PR" \
@@ -165,6 +213,7 @@ jobs:
             --arg head_sha "$HEAD_SHA" \
             --arg run_url "$RUN_URL" \
             --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg baseline_sha "${baseline_sha:-}" \
             --argjson pass "${pass:-null}" \
             --argjson fail "${fail:-null}" \
             --argjson ce "${ce:-null}" \
@@ -176,6 +225,8 @@ jobs:
             --argjson wasm_identical_noise "${wasm_identical_noise:-null}" \
             --argjson compile_timeouts "${compile_timeouts:-null}" \
             --argjson improvements "${improvements:-null}" \
+            --argjson baseline_staleness_commits "${baseline_staleness_arg}" \
+            --argjson baseline_stale "${baseline_stale}" \
             '{
               pr: ($pr|tonumber),
               conclusion: $conclusion,
@@ -193,9 +244,31 @@ jobs:
               regressions_wasm_change: $regressions_wasm_change,
               wasm_identical_noise: $wasm_identical_noise,
               compile_timeouts: $compile_timeouts,
-              improvements: $improvements
+              improvements: $improvements,
+              baseline_sha: (if ($baseline_sha == "") then null else $baseline_sha end),
+              baseline_staleness_commits: $baseline_staleness_commits,
+              baseline_stale: $baseline_stale
             }' > "$out"
           cat "$out"
+
+          # Surface a GitHub Actions job summary so reviewers see the warning
+          # without digging into the raw feed file.
+          {
+            echo "## CI status feed: PR #$PR"
+            echo ""
+            echo "- conclusion: \`$CONCLUSION\`"
+            echo "- head_sha: \`${HEAD_SHA:0:8}\`"
+            if [ -n "${baseline_sha:-}" ] && [ "$baseline_sha" != "null" ] && [ "$baseline_sha" != "" ]; then
+              echo "- baseline_sha: \`${baseline_sha:0:8}\`"
+            fi
+            if [ -n "${baseline_staleness_commits:-}" ] && [ "$baseline_staleness_commits" != "null" ]; then
+              echo "- baseline_staleness_commits: $baseline_staleness_commits"
+            fi
+            if [ "${baseline_stale:-false}" = "true" ]; then
+              echo ""
+              echo "> ⚠️  **Baseline drift detected** — \`regressions_real\` may be inflated by tests that flipped on main since the baseline was last refreshed. The dev-self-merge gate will escalate to tech lead instead of hard-blocking on the raw count. See #1391."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
 
       - name: Commit and push
         if: ${{ steps.pr.outputs.pr != '' }}

--- a/plan/issues/sprints/51/1391-ci-feed-baseline-staleness-detection.md
+++ b/plan/issues/sprints/51/1391-ci-feed-baseline-staleness-detection.md
@@ -2,7 +2,7 @@
 id: 1391
 sprint: 51
 title: "infra: CI feed baseline staleness detection — warn when baseline_sha diverges from current main"
-status: ready
+status: in-progress
 created: 2026-05-08
 priority: high
 feasibility: medium
@@ -77,3 +77,67 @@ guard:
 - `test262-sharded.yml` — where the regression report is generated
 - `check-cwd.sh` — the merge gate that reads `pr-NNN.json`
 - PR #294 incident: baseline_sha=58e1fee70, actual net=-140 (feed) vs +103 (artifacts)
+
+## Implementation (PR #TBD)
+
+### Note on the actual feed source
+
+The issue file calls out `test262-sharded.yml` and `check-cwd.sh`, but the
+authoritative feed writer is now `.github/workflows/ci-status-feed.yml`,
+triggered on `Test262 Differential` completion (see commit bf62a8998 — wired
+on May 3 2026 specifically to address staleness). The merge gate logic that
+reads the feed lives in `.claude/skills/dev-self-merge.md`, not `check-cwd.sh`
+(which is a per-Bash-call cwd guard, unrelated to merge decisions).
+
+This PR therefore touches:
+
+- `.github/workflows/ci-status-feed.yml` — compute and emit
+  `baseline_sha`, `baseline_staleness_commits`, `baseline_stale`.
+- `.claude/skills/dev-self-merge.md` — short-circuit step 1a that
+  escalates to tech lead when `baseline_stale: true`.
+
+### Workflow changes
+
+After parsing `test262-report-merged.json` (which includes the artifact's
+`baseline_sha`), the feed writer:
+
+1. Reads `baseline_sha` from the merged-report JSON. If absent / unknown,
+   skip the staleness check.
+2. `git fetch --depth=200 origin <baseline_sha>` so the merge-base count is
+   computable from a shallow checkout.
+3. `git rev-list --count baseline_sha..HEAD` → `baseline_staleness_commits`.
+4. If `baseline_staleness_commits > 50`, set `baseline_stale: true` and emit
+   `::warning::` annotation + a job-summary entry with the drift count.
+5. Always include `baseline_sha`, `baseline_staleness_commits`, and
+   `baseline_stale` in the JSON output so downstream tooling has them.
+
+### Gate change
+
+`/dev-self-merge` step 1a (new): if `baseline_stale: true`, emit the
+escalation prompt and stop — do not run the regression-count criteria, which
+would otherwise hard-block on inflated drift numbers.
+
+### Scope notes
+
+- Only `Test262 Differential` triggers `ci-status-feed.yml`. PRs gated by
+  `Test262 Sharded` go through a different artifact path; staleness
+  detection there can be added later if the team re-introduces the Sharded
+  feed writer. (As of bf62a8998 the Sharded path no longer writes the
+  PR-level feed.)
+- `ci-status-basic.yml` (test/docs-only PRs) writes `test262_skipped: true`
+  — no baseline involved, no change needed.
+
+## Acceptance criteria status
+
+- ✅ #1: `pr-NNN.json` includes `baseline_staleness_commits` for every PR
+  whose feed comes from `ci-status-feed.yml` and where the artifact carries
+  a `baseline_sha`.
+- ✅ #2: When `baseline_staleness_commits > 50`, `baseline_stale: true` is
+  set in the feed.
+- ✅ #3: `/dev-self-merge` (the merge gate that reads `pr-NNN.json`)
+  honours `baseline_stale: true` and escalates instead of hard-blocking.
+- ✅ #4: CI summary prints a staleness warning + `::warning::` annotation
+  when the flag is set.
+- (out of scope) #5: `refresh-committed-baseline.yml` already exists and is
+  unchanged by this PR — listed in the issue's acceptance criteria as a
+  reminder that staleness shouldn't accumulate under normal operation.


### PR DESCRIPTION
## Summary

PR #294 hit a CI feed showing `net_per_test=-140` / `regressions_real=495` while the same-run artifact comparison showed `+103` net real. Root cause: the feed compares branch results against a baseline JSONL whose `baseline_sha` lagged current main HEAD; the regression count was inflated by tests that flipped on main since the baseline was last refreshed, **not** by the PR.

This PR adds staleness detection so the merge gate stops false-blocking PRs whose drift is exogenous.

### Changes

1. **`.github/workflows/ci-status-feed.yml`** — read `baseline_sha` from `test262-report-merged.json`, fetch the commit so the merge-base count is computable from a shallow checkout, and emit:
   - `baseline_sha`
   - `baseline_staleness_commits` (`rev-list --count baseline_sha..HEAD`)
   - `baseline_stale` (true if > 50 commits behind)
   
   A `::warning::` annotation and job-summary line surface the drift count when the flag is set.

2. **`.claude/skills/dev-self-merge.md`** — new Step 1a short-circuit. If `baseline_stale: true`, escalate to tech lead immediately rather than running the regression-count criteria which would mis-fire on the inflated number.

### Scope notes

- The issue file mentions `test262-sharded.yml` + `check-cwd.sh`, but the authoritative feed writer is now `ci-status-feed.yml` (commit bf62a8998 wired it to Test262 Differential to avoid the older staleness path). `check-cwd.sh` is a per-Bash cwd guard, unrelated to the merge gate.
- `ci-status-basic.yml` (test/docs-only PRs) writes `test262_skipped: true` and is unchanged — no baseline involved.
- `refresh-committed-baseline.yml` is unchanged; this PR is the failsafe for when it falls behind.
- **No `src/**` changes** — pure infra/workflow PR. Test262 Sharded won't run; basic CI suffices.

## Test plan

- [x] YAML validates via `js-yaml` post-merge
- [x] All acceptance criteria from #1391 covered (see issue file appendix)
- [x] Skill markdown change is purely additive — Step 1a runs before Step 1's body, doesn't alter the existing criteria flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)