### PR TITLE
feat(#1375): IR optional-chain TS-narrowing fast-path (Slice A)

### DIFF
--- a/plan/issues/sprints/51/1375-ir-optional-chain-full.md
+++ b/plan/issues/sprints/51/1375-ir-optional-chain-full.md
@@ -2,10 +2,10 @@
 id: 1375
 sprint: 51
 title: "IR: full optional-chain support (?. and ?.[]) without resolver fallback"
-status: ready
+status: blocked
 created: 2026-05-08
 priority: medium
-feasibility: medium
+feasibility: hard
 reasoning_effort: high
 task_type: feature
 area: ir, codegen
@@ -96,3 +96,104 @@ Ensure `isPhase1Expr` in select.ts accepts `ElementAccessExpression` with option
 - `src/ir/select.ts` — optional-chain `isPhase1Expr` completeness
 - `src/ir/from-ast.ts` — `?.[]` lowering
 - `src/ir/integration.ts` — `nullCheck` externref case
+
+## Architectural finding (dev-1389, 2026-05-08)
+
+The original spec references IR primitives that **do not exist** in the
+current codebase. Verified on origin/main HEAD `5076ca504`:
+
+- `IrLowerResolver.nullCheck` field — does not exist anywhere in `src/`
+  (`grep -rn "nullCheck\b" src/` returns 0 results). The original spec
+  text "extend `makeIrLowerResolver` to handle the case where the
+  receiver is `externref`" describes a method that was never wired up.
+- `IrNode.if` / `IrNode.ifNull` / value-producing if-expr — does not
+  exist. The IR has only `IrInstrSelect` (`kind: "select"`), which
+  lowers to **Wasm `select`** — eager-eval of both arms. That's
+  unsuitable for `?.` semantics, since the non-null arm (`obj.prop`)
+  traps when `obj` is null.
+- `ref.is_null` — present in `src/ir/types.ts:229` (the **legacy**
+  codegen Wasm op enum), but **NOT** present in the IR's `IrUnop` type
+  (`src/ir/nodes.ts:503` — only `f64.neg`, `i32.eqz`,
+  `i32.trunc_sat_f64_s`, `f64.abs`, `f64.sqrt`, `f64.floor`,
+  `f64.ceil`, `f64.trunc`).
+
+`from-ast.ts:1452` confirms the gap explicitly: "the IR has no
+short-circuit primitive yet — throw so the function falls back to
+legacy". The legacy `compileOptionalPropertyAccess`
+(`src/codegen/property-access.ts:739`) uses Wasm `if`/`else` block —
+the structured value-producing control flow the IR doesn't have for
+expressions.
+
+**To fully implement** this issue's Acceptance Criteria (1–3), the IR
+must gain:
+
+1. A new `ref.is_null` `IrUnop` (one-line addition to `IrUnop` type +
+   wiring in `lower.ts` to emit the Wasm op).
+2. A value-producing `IrInstrIfExpr` with `cond`, `then` body, `else`
+   body, and `result` — analogous to the existing statement-level
+   `IrInstrWhileLoop` / `IrInstrTry` patterns but with a result.
+3. Lowering through `lower.ts` (Wasm `if` block with result type),
+   `verify.ts` (verify result types match across arms), `propagate.ts`
+   (propagate types into both arms), and `constant-fold.ts` (fold when
+   cond is constant).
+4. Block-restructuring or new emit helpers in `lowerPropertyAccess`,
+   `lowerElementAccess`, and `lowerCall` to use the new branching for
+   `?.`, `?.[]`, and `?.()`.
+
+Each is tractable in isolation but the combined surface is genuinely
+`feasibility: hard`. Re-ranked from `medium` accordingly. Status set to
+`blocked` until an architect spec for the new IR primitives lands.
+
+## Implementation notes (Slice A: TS-narrowing fast-path, dev-1389, 2026-05-08)
+
+### Slice A scope
+
+**~25 LoC** — extends `lowerPropertyAccess` to consult TypeScript
+narrowing before throwing the legacy-fallback for `?.` on an
+IR-nullable receiver. When TS proves the expression's type is
+non-null (`getNonNullableType(t) === t` by identity), skip the throw
+and fall through to ordinary `.` access — this mirrors how the
+existing slice 11 (#1281) handles non-null IR types.
+
+### Why this is a real win (despite being narrow)
+
+The IR's `isIrTypeNullable` is conservative: it flags **all** `extern`
+host-class values as nullable because at the Wasm level they're
+`externref`. But `m: Map<string, number>` (no `| undefined`) is
+TS-proven non-null in well-typed code. This slice recognizes that
+case and keeps the function on the IR path instead of falling back to
+legacy.
+
+### Files changed
+
+- `src/ir/from-ast.ts`:
+  - `IrFromAstResolver` interface — added optional method
+    `isExpressionTsNonNullable(expr: ts.Expression): boolean | undefined`.
+  - `lowerPropertyAccess` — when the existing `?.` throw guard fires,
+    consult the resolver method first; skip the throw on TS-proven
+    non-null.
+- `src/ir/integration.ts`:
+  - `makeFromAstResolver` — implementation using
+    `ctx.checker.getNonNullableType()` with strict identity comparison
+    (TS interns Type objects; identical identity ⇒ stripping null was
+    a no-op ⇒ already non-null).
+
+### Tests
+
+`tests/issue-1375.test.ts` — 6 tests:
+- Map (non-null TS type): `m?.get(k)` — exercises the new fast-path
+- Map | undefined (genuinely nullable): still works via legacy fallback
+- object literal `o?.x` — existing non-null IR path (regression guard)
+- class instance `c?.field` — existing non-null IR path (regression guard)
+- nullable receiver actually undefined at runtime — legacy returns undefined
+- RegExp `r?.source` — extern with non-null TS type via fast-path
+
+All pass. `tests/issue-1281.test.ts` (predecessor for non-null TS narrowing)
+also passes — no regression.
+
+### Estimated impact (Slice A)
+
+Narrow — 5–10 hot functions retire from legacy fallback, mostly Map/Set
+property access patterns where TS guarantees non-null. The full
+acceptance criteria (1–3) require the IR primitive work outlined in
+"Architectural finding" above.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -110,6 +110,20 @@ export interface IrFromAstResolver {
    * `undefined` if no such class is registered.
    */
   getExternClassInfo?(className: string): IrExternClassMeta | undefined;
+  /**
+   * #1375 narrow slice — TS-narrowing fast-path for optional chaining.
+   * Returns `true` when the TypeScript type of `expr` is provably non-null
+   * (i.e. `getNonNullableType(t) === t`). Used by `lowerPropertyAccess`
+   * to skip the `?.`-on-nullable-receiver throw when TS has already
+   * narrowed away null/undefined — the IR's `isIrTypeNullable` is more
+   * conservative (treats `extern` as always nullable), so this gate
+   * recovers a small set of well-typed `m?.x` cases where `m: Map<...>`
+   * (no `| undefined`) is genuinely non-null at TS level.
+   *
+   * When unimplemented or returns `undefined`, `lowerPropertyAccess`
+   * keeps the existing throw → legacy fallback.
+   */
+  isExpressionTsNonNullable?(expr: ts.Expression): boolean | undefined;
 }
 
 export interface AstToIrOptions {
@@ -1449,8 +1463,21 @@ function lowerPropertyAccess(expr: ts.PropertyAccessExpression, cx: LowerCtx): I
   // externref) the IR has no short-circuit primitive yet — throw so the
   // function falls back to legacy, where `compileOptionalPropertyAccess`
   // already emits the null-guarded `if/else` block.
+  //
+  // #1375 narrow slice — before throwing, consult the TS-narrowing
+  // fast-path. Some receivers' IrType is conservatively flagged as
+  // nullable (notably `extern`, which is `externref` at the Wasm level
+  // and could carry null at the JS host) but TypeScript's type narrowing
+  // proves them non-null in the calling context (e.g. `m: Map<string,
+  // number>` with no `| undefined`). When TS proves non-null, treat the
+  // `?.` as a redundant safety syntax and fall through to the regular
+  // `.` access path — exactly mirroring the non-null IrType case above.
   if (expr.questionDotToken && isIrTypeNullable(recvType)) {
-    throw new Error(`ir/from-ast: optional chaining (?.) on nullable receiver not in slice 11 (${cx.funcName})`);
+    const tsNonNull = cx.resolver?.isExpressionTsNonNullable?.(expr.expression) === true;
+    if (!tsNonNull) {
+      throw new Error(`ir/from-ast: optional chaining (?.) on nullable receiver not in slice 11 (${cx.funcName})`);
+    }
+    // Fall through: TS-proven non-null → lower as ordinary `.prop` access.
   }
 
   if (recvType.kind === "string") {

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -796,6 +796,22 @@ function makeFromAstResolver(ctx: CodegenContext): IrFromAstResolver {
         elementValType: arrayDef.element,
       };
     },
+    // #1375 narrow slice — TS-narrowing fast-path for optional chaining.
+    // The IR's `isIrTypeNullable` flags `extern` (host class) values as
+    // always nullable because at the Wasm level they're `externref`. But
+    // TS narrowing often proves the receiver is non-null in context
+    // (e.g. `m: Map<string, number>` without `| undefined`). When TS
+    // confirms non-null, `lowerPropertyAccess` skips the `?.`-on-nullable
+    // throw and lowers as a regular `.` access. Otherwise (genuinely
+    // nullable, or no narrowing), legacy fallback continues.
+    isExpressionTsNonNullable(expr: ts.Expression): boolean | undefined {
+      const t = ctx.checker.getTypeAtLocation(expr);
+      const nonNull = ctx.checker.getNonNullableType(t);
+      // TS's `Type` objects are interned by the checker, so a strict
+      // identity comparison is sound: equal identity ⇒ stripping null/
+      // undefined was a no-op ⇒ the type was already non-null.
+      return t === nonNull;
+    },
   };
 }
 

--- a/tests/issue-1375.test.ts
+++ b/tests/issue-1375.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+describe("#1375 — IR optional-chain TS-narrowing fast-path", () => {
+  async function runTest(src: string): Promise<{ pass: boolean; ret?: unknown; error?: string }> {
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    if (!result.success) return { pass: false, error: result.error };
+    const importObj = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
+    if (typeof (importObj as any).setExports === "function") {
+      (importObj as any).setExports(instance.exports);
+    }
+    try {
+      const ret = (instance.exports as any).test();
+      return { pass: ret === 1, ret };
+    } catch (e: any) {
+      return { pass: false, error: String(e) };
+    }
+  }
+
+  it("Map (non-null TS type): m?.get(k) works via TS-narrowing fast-path", async () => {
+    const src = `
+      export function test(): number {
+        const m = new Map<string, number>();
+        m.set("x", 42);
+        const v = m?.get("x") ?? -1;
+        return v === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("Map | undefined (nullable): m?.get(k) still works via legacy fallback", async () => {
+    const src = `
+      export function test(): number {
+        let m: Map<string, number> | undefined = new Map();
+        m?.set("x", 42);
+        const v = m?.get("x") ?? -1;
+        return v === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("object literal o?.x continues to work (existing non-null IR path)", async () => {
+    const src = `
+      export function test(): number {
+        const o = { x: 42 };
+        return o?.x === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("class instance c?.field continues to work (existing non-null IR path)", async () => {
+    const src = `
+      class C { x: number = 42; }
+      export function test(): number {
+        const c = new C();
+        return c?.x === 42 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("nullable receiver (truly undefined at runtime) still returns undefined via legacy", async () => {
+    // m typed as Map | undefined and actually undefined at runtime.
+    // Legacy fallback handles the null guard correctly.
+    const src = `
+      export function test(): number {
+        let m: Map<string, number> | undefined = undefined;
+        const v = m?.get("x") ?? -1;
+        return v === -1 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("RegExp instance: r?.source works via TS-narrowing fast-path", async () => {
+    const src = `
+      export function test(): number {
+        const r = /hello/;
+        const src = r?.source ?? "";
+        return src === "hello" ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- The IR's `isIrTypeNullable` conservatively flags all `extern` host-class values as nullable (because at the Wasm level they're `externref`). Before this change, well-typed `m?.x` on `m: Map<...>` (no `| undefined`) fell back to legacy codegen on every access.
- New resolver method `isExpressionTsNonNullable` consults `ctx.checker.getNonNullableType(t)` with strict identity comparison. When TS proves non-null, `lowerPropertyAccess` skips the legacy-fallback throw and lowers as ordinary `.` access — mirroring how the existing #1281 slice handles non-null IR types.
- **NOT delivered** by this slice: chained `?.b?.c`, `?.[]`, `?.()`, or genuinely-nullable receivers short-circuited in the IR. Those need new IR primitives (`ref.is_null` IrUnop, value-producing if-expr) that don't yet exist. Issue file's "Architectural finding" section documents the gap; status set to `blocked`, feasibility re-ranked to `hard`.

## Test plan
- [x] New `tests/issue-1375.test.ts` — 6 tests, all pass:
  - Map (non-null TS type): `m?.get(k)` via fast-path
  - Map | undefined: still works via legacy fallback
  - object literal `o?.x` — existing non-null IR path (regression guard)
  - class instance `c?.field` — existing non-null IR path (regression guard)
  - nullable receiver actually undefined at runtime — legacy returns undefined
  - RegExp `r?.source` — extern with non-null TS type via fast-path
- [x] `tests/issue-1281.test.ts` (predecessor) passes — no regression
- [ ] CI: full test262 + sharded run

Estimated impact: narrow — 5–10 hot functions retire from legacy fallback, mostly Map/Set/RegExp property access patterns where TS guarantees non-null.

Refs #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)