### PR TITLE
fix(#1344): Date(NaN) propagates NaN through getters (slice 1)

### DIFF
--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -5,6 +5,7 @@
 import { ts } from "../../ts-api.js";
 import { isBooleanType, isNumberType, isStringType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
+import { popBody, pushBody } from "../context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { flushLateImportShifts } from "../expressions/late-imports.js";
@@ -497,21 +498,46 @@ function compileDateMethodCall(
   const recvResult = compileExpression(ctx, fctx, propAccess.expression, dateRefType);
   if (!recvResult) return null;
 
-  // getTime / valueOf: read i64 timestamp, convert to f64
+  // getTime / valueOf: read i64 timestamp, convert to f64.
+  // (#1344) Invalid Date (sentinel timestamp) → NaN per spec.
   if (methodName === "getTime" || methodName === "valueOf") {
     fctx.body.push({
       op: "struct.get",
       typeIdx: dateTypeIdx,
       fieldIdx: 0,
     } as unknown as Instr);
-    fctx.body.push({ op: "f64.convert_i64_s" } as Instr);
+    const tsLocal = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push({ op: "local.tee", index: tsLocal } as Instr);
+    fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+    fctx.body.push({ op: "i64.eq" } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: NaN } as Instr],
+      else: [{ op: "local.get", index: tsLocal } as Instr, { op: "f64.convert_i64_s" } as Instr],
+    } as unknown as Instr);
+    releaseTempLocal(fctx, tsLocal);
     return { kind: "f64" };
   }
 
-  // getTimezoneOffset: always 0 (we operate in UTC)
+  // getTimezoneOffset: always 0 for valid Date (we operate in UTC), NaN for invalid.
+  // (#1344) ECMA-262 §21.4.4.7 — NaN propagation through `LocalTime` requires
+  // returning NaN when the timestamp is invalid.
   if (methodName === "getTimezoneOffset") {
-    fctx.body.push({ op: "drop" } as Instr);
-    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+    // Receiver Date ref already on stack from line ~497.
+    fctx.body.push({
+      op: "struct.get",
+      typeIdx: dateTypeIdx,
+      fieldIdx: 0,
+    } as unknown as Instr);
+    fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+    fctx.body.push({ op: "i64.eq" } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: NaN } as Instr],
+      else: [{ op: "f64.const", value: 0 } as Instr],
+    } as unknown as Instr);
     return { kind: "f64" };
   }
 
@@ -771,7 +797,7 @@ function compileDateMethodCall(
     return { kind: "f64" };
   }
 
-  // For all time-component getters, we need the i64 timestamp
+  // For all time-component getters, we need the i64 timestamp.
   // Stack: [dateRef]
   fctx.body.push({
     op: "struct.get",
@@ -780,106 +806,134 @@ function compileDateMethodCall(
   } as unknown as Instr);
   // Stack: [i64 timestamp]
 
+  // (#1344) Save the timestamp to a local so each branch can wrap its
+  // arithmetic in an `if (timestamp === INVALID_SENTINEL) NaN else <arith>`
+  // check. Without this, `new Date(NaN).getDay()` etc. return arithmetic
+  // results from a saturated 0 timestamp instead of the spec-mandated NaN.
+  // The sentinel value is `i64.const -9223372036854775808` (min i64), set
+  // by `new Date(NaN)` in `new-super.ts`. No legitimate JS timestamp can
+  // reach this magnitude (valid range is ±8.64e15 ms).
+  const tsLocalShared = allocTempLocal(fctx, { kind: "i64" });
+  fctx.body.push({ op: "local.set", index: tsLocalShared } as Instr);
+  // Stack: []
+
+  /** Wrap a getter's arithmetic in the invalid-Date NaN guard. The
+   *  callback should emit instructions that consume the i64 timestamp
+   *  on the stack and produce an f64 result. */
+  const wrapWithInvalidDateGuard = (emitArithmetic: () => void): ValType => {
+    fctx.body.push({ op: "local.get", index: tsLocalShared } as Instr);
+    fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+    fctx.body.push({ op: "i64.eq" } as Instr);
+    const savedBody = pushBody(fctx);
+    fctx.body.push({ op: "local.get", index: tsLocalShared } as Instr);
+    emitArithmetic();
+    const elseInstrs = fctx.body;
+    popBody(fctx, savedBody);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: NaN } as Instr],
+      else: elseInstrs,
+    } as unknown as Instr);
+    return { kind: "f64" };
+  };
+
   if (methodName === "getHours" || methodName === "getUTCHours") {
     // hours = ((timestamp % 86400000) + 86400000) % 86400000 / 3600000
-    fctx.body.push(
-      { op: "i64.const", value: MS_PER_DAY } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_DAY } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: MS_PER_DAY } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_HOUR } as Instr,
-      { op: "i64.div_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
+    return wrapWithInvalidDateGuard(() =>
+      fctx.body.push(
+        { op: "i64.const", value: MS_PER_DAY } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_DAY } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: MS_PER_DAY } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_HOUR } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      ),
     );
-    return { kind: "f64" };
   }
 
   if (methodName === "getMinutes" || methodName === "getUTCMinutes") {
     // minutes = ((timestamp % 3600000) + 3600000) % 3600000 / 60000
-    fctx.body.push(
-      { op: "i64.const", value: MS_PER_HOUR } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_HOUR } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: MS_PER_HOUR } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_MINUTE } as Instr,
-      { op: "i64.div_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
+    return wrapWithInvalidDateGuard(() =>
+      fctx.body.push(
+        { op: "i64.const", value: MS_PER_HOUR } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_HOUR } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: MS_PER_HOUR } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      ),
     );
-    return { kind: "f64" };
   }
 
   if (methodName === "getSeconds" || methodName === "getUTCSeconds") {
     // seconds = ((timestamp % 60000) + 60000) % 60000 / 1000
-    fctx.body.push(
-      { op: "i64.const", value: MS_PER_MINUTE } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_MINUTE } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: MS_PER_MINUTE } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_SECOND } as Instr,
-      { op: "i64.div_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
+    return wrapWithInvalidDateGuard(() =>
+      fctx.body.push(
+        { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: MS_PER_MINUTE } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_SECOND } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      ),
     );
-    return { kind: "f64" };
   }
 
   if (methodName === "getMilliseconds" || methodName === "getUTCMilliseconds") {
     // ms = ((timestamp % 1000) + 1000) % 1000
-    fctx.body.push(
-      { op: "i64.const", value: MS_PER_SECOND } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: MS_PER_SECOND } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: MS_PER_SECOND } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
+    return wrapWithInvalidDateGuard(() =>
+      fctx.body.push(
+        { op: "i64.const", value: MS_PER_SECOND } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: MS_PER_SECOND } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: MS_PER_SECOND } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      ),
     );
-    return { kind: "f64" };
   }
 
   // getDay / getUTCDay: day of week (0=Sunday)
   // (floor(timestamp / 86400000) + 4) % 7  (1970-01-01 was Thursday = 4)
   if (methodName === "getDay" || methodName === "getUTCDay") {
-    // We need to handle negative timestamps correctly:
-    // days = floor(ts / 86400000) — for negative, use (ts - 86399999) / 86400000
-    fctx.body.push(
-      { op: "i64.const", value: MS_PER_DAY } as Instr,
-      { op: "i64.div_s" } as Instr,
-      // For negative timestamps, i64.div_s truncates toward zero, but we want floor division
-      // This is fine because we handle the modular arithmetic with the +7 % 7 below
-      { op: "i64.const", value: 4n } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: 7n } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      // Handle negative remainder: ((result % 7) + 7) % 7
-      { op: "i64.const", value: 7n } as Instr,
-      { op: "i64.add" } as Instr,
-      { op: "i64.const", value: 7n } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
+    return wrapWithInvalidDateGuard(() =>
+      fctx.body.push(
+        { op: "i64.const", value: MS_PER_DAY } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "i64.const", value: 4n } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: 7n } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: 7n } as Instr,
+        { op: "i64.add" } as Instr,
+        { op: "i64.const", value: 7n } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      ),
     );
-    return { kind: "f64" };
   }
 
-  // Calendar getters need civil_from_days
-  // Stack: [i64 timestamp]
-  // First compute days: floor(timestamp / 86400000)
-  // For negative timestamps we need floor division, not truncation.
-  // floor_div(a, b) for positive b: (a >= 0) ? a/b : (a - b + 1) / b
+  // Calendar getters need civil_from_days.
+  // (#1344) Each branch is wrapped with the invalid-Date guard. The guard
+  // re-pushes the saved timestamp so the floor-div + civil_from_days
+  // sequence below sees it on the stack.
   const civilIdx = ensureDateCivilHelper(ctx);
 
-  // Compute floor division of timestamp by MS_PER_DAY
-  // Since i64.div_s truncates toward zero, we need to adjust for negative values
-  {
+  /** Emit floor-div(ts, MS_PER_DAY) -> days, then civil_from_days(days). */
+  const emitDaysToCivil = (): void => {
     const tempTs = allocTempLocal(fctx, { kind: "i64" });
     fctx.body.push({ op: "local.set", index: tempTs } as Instr);
-
-    // if (ts >= 0) ts / 86400000 else (ts - 86399999) / 86400000
     fctx.body.push(
       { op: "local.get", index: tempTs } as Instr,
       { op: "i64.const", value: 0n } as Instr,
@@ -902,52 +956,51 @@ function compileDateMethodCall(
       } as unknown as Instr,
     );
     releaseTempLocal(fctx, tempTs);
-  }
-
-  // Stack: [i64 days_since_epoch]
-  fctx.body.push({ op: "call", funcIdx: civilIdx } as Instr);
-  // Stack: [i64 packed = year*10000 + month*100 + day]
+    fctx.body.push({ op: "call", funcIdx: civilIdx } as Instr);
+  };
 
   if (methodName === "getFullYear" || methodName === "getUTCFullYear") {
-    // year = packed / 10000
-    fctx.body.push(
-      { op: "i64.const", value: 10000n } as Instr,
-      { op: "i64.div_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
-    );
-    return { kind: "f64" };
+    return wrapWithInvalidDateGuard(() => {
+      emitDaysToCivil();
+      fctx.body.push(
+        { op: "i64.const", value: 10000n } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      );
+    });
   }
 
   if (methodName === "getMonth" || methodName === "getUTCMonth") {
-    // month = (packed / 100) % 100 - 1  (JS months are 0-indexed)
-    fctx.body.push(
-      { op: "i64.const", value: 100n } as Instr,
-      { op: "i64.div_s" } as Instr,
-      { op: "i64.const", value: 100n } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "i64.const", value: 1n } as Instr,
-      { op: "i64.sub" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
-    );
-    return { kind: "f64" };
+    return wrapWithInvalidDateGuard(() => {
+      emitDaysToCivil();
+      fctx.body.push(
+        { op: "i64.const", value: 100n } as Instr,
+        { op: "i64.div_s" } as Instr,
+        { op: "i64.const", value: 100n } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "i64.const", value: 1n } as Instr,
+        { op: "i64.sub" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      );
+    });
   }
 
   if (methodName === "getDate" || methodName === "getUTCDate") {
-    // day = packed % 100
-    fctx.body.push(
-      { op: "i64.const", value: 100n } as Instr,
-      { op: "i64.rem_s" } as Instr,
-      { op: "f64.convert_i64_s" } as Instr,
-    );
-    return { kind: "f64" };
+    return wrapWithInvalidDateGuard(() => {
+      emitDaysToCivil();
+      fctx.body.push(
+        { op: "i64.const", value: 100n } as Instr,
+        { op: "i64.rem_s" } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+      );
+    });
   }
 
   // toISOString / toJSON: emit a formatted string
   if (methodName === "toISOString" || methodName === "toJSON") {
-    // For now, drop the packed civil date and return a placeholder
-    // A full implementation would format as "YYYY-MM-DDTHH:MM:SS.sssZ"
-    // but that requires string building which is complex. Return the timestamp as a string.
-    fctx.body.push({ op: "drop" } as Instr);
+    // (#1344) Timestamp is in tsLocalShared, not on the stack anymore —
+    // no `drop` needed. Stub implementation; full formatting deferred.
+    releaseTempLocal(fctx, tsLocalShared);
     return compileStringLiteral(ctx, fctx, "1970-01-01T00:00:00.000Z");
   }
 
@@ -965,12 +1018,12 @@ function compileDateMethodCall(
     "toGMTString",
   ]);
   if (STRING_DATE_METHODS.has(methodName)) {
-    fctx.body.push({ op: "drop" } as Instr);
+    releaseTempLocal(fctx, tsLocalShared);
     return compileStringLiteral(ctx, fctx, "Thu Jan 01 1970 00:00:00 GMT+0000");
   }
 
-  // Shouldn't reach here
-  fctx.body.push({ op: "drop" } as Instr);
+  // Shouldn't reach here. Timestamp was saved to a local; nothing to drop.
+  releaseTempLocal(fctx, tsLocalShared);
   fctx.body.push({ op: "f64.const", value: 0 } as Instr);
   return { kind: "f64" };
 }

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1593,9 +1593,25 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
 
     if (args.length === 1) {
-      // new Date(ms) — millisecond timestamp
+      // new Date(ms) — millisecond timestamp.
+      //
+      // (#1344) Detect NaN input and store a sentinel i64 so subsequent getter
+      // calls (getDay, getHours, getTime, …) can return NaN per spec
+      // (`new Date(NaN).getTime() → NaN`). Without this, `i64.trunc_sat_f64_s`
+      // saturates NaN to 0 and the Date silently behaves like the epoch.
       compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
-      fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+      const msLocal = allocTempLocal(fctx, { kind: "f64" });
+      fctx.body.push({ op: "local.tee", index: msLocal } as Instr);
+      // ms != ms is true iff ms is NaN
+      fctx.body.push({ op: "local.get", index: msLocal } as Instr);
+      fctx.body.push({ op: "f64.ne" } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i64" } },
+        then: [{ op: "i64.const", value: -9223372036854775808n } as unknown as Instr],
+        else: [{ op: "local.get", index: msLocal } as Instr, { op: "i64.trunc_sat_f64_s" } as Instr],
+      } as unknown as Instr);
+      releaseTempLocal(fctx, msLocal);
       fctx.body.push({ op: "struct.new", typeIdx: dateTypeIdx } as Instr);
       return { kind: "ref", typeIdx: dateTypeIdx };
     }

--- a/tests/equivalence/issue-1344.test.ts
+++ b/tests/equivalence/issue-1344.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./helpers.js";
+
+// #1344 — Date.prototype invalid-Date NaN propagation (slice 1).
+//
+// Per ECMA-262 §21.4.4.x, every Date.prototype getter and accessor must
+// return NaN when the receiver's internal `[[DateValue]]` is NaN
+// (`new Date(NaN)`). Our compiler stored timestamps as i64 — `i64.trunc_sat_f64_s`
+// saturates NaN to 0, so `new Date(NaN)` silently became the epoch and
+// every getter returned a valid 0-based result. 26 test262 tests under
+// `built-ins/Date/prototype/*/this-value-invalid-date.js` failed for this
+// exact reason.
+//
+// Fix:
+//   1. In `new-super.ts`, `new Date(arg)` checks if `arg` is NaN; if so it
+//      stores the i64 sentinel `i64.const -9223372036854775808` (i64 min,
+//      well outside the spec-valid Date range of ±8.64e15 ms).
+//   2. In `builtins.ts`, every getter (`getTime`, `valueOf`,
+//      `getTimezoneOffset`, `getHours`/UTC, `getMinutes`/UTC,
+//      `getSeconds`/UTC, `getMilliseconds`/UTC, `getDay`/UTC,
+//      `getFullYear`/UTC, `getMonth`/UTC, `getDate`/UTC) wraps its
+//      arithmetic in an `if (timestamp == SENTINEL) NaN else <arith>`
+//      check. The shared `wrapWithInvalidDateGuard` helper reuses one
+//      i64 local for the receiver across all branches.
+//
+// Slice 2 (deferred): setX methods (`setHours`, `setFullYear`, etc.)
+// should also NaN-out when the receiver is invalid (~7 tests). The
+// formatter methods (`toISOString` should throw RangeError on invalid;
+// `toString` should return "Invalid Date") are also slice 2.
+
+describe("#1344 — Date(NaN) returns invalid Date with NaN getters (slice 1)", () => {
+  it("getTime / valueOf return NaN for invalid Date", async () => {
+    const exp = await compileToWasm(`
+      export function getTime(): number { return new Date(NaN).getTime(); }
+      export function valueOf(): number { return new Date(NaN).valueOf(); }
+    `);
+    expect(exp.getTime!()).toBeNaN();
+    expect(exp.valueOf!()).toBeNaN();
+  });
+
+  it("getTimezoneOffset returns NaN for invalid Date, 0 for valid", async () => {
+    const exp = await compileToWasm(`
+      export function inv(): number { return new Date(NaN).getTimezoneOffset(); }
+      export function val(): number { return new Date(0).getTimezoneOffset(); }
+    `);
+    expect(exp.inv!()).toBeNaN();
+    expect(exp.val!()).toBe(0);
+  });
+
+  it("time-component getters return NaN for invalid Date", async () => {
+    const exp = await compileToWasm(`
+      export function hours(): number { return new Date(NaN).getHours(); }
+      export function minutes(): number { return new Date(NaN).getMinutes(); }
+      export function seconds(): number { return new Date(NaN).getSeconds(); }
+      export function ms(): number { return new Date(NaN).getMilliseconds(); }
+      export function day(): number { return new Date(NaN).getDay(); }
+    `);
+    expect(exp.hours!()).toBeNaN();
+    expect(exp.minutes!()).toBeNaN();
+    expect(exp.seconds!()).toBeNaN();
+    expect(exp.ms!()).toBeNaN();
+    expect(exp.day!()).toBeNaN();
+  });
+
+  it("calendar getters return NaN for invalid Date", async () => {
+    const exp = await compileToWasm(`
+      export function year(): number { return new Date(NaN).getFullYear(); }
+      export function month(): number { return new Date(NaN).getMonth(); }
+      export function date(): number { return new Date(NaN).getDate(); }
+    `);
+    expect(exp.year!()).toBeNaN();
+    expect(exp.month!()).toBeNaN();
+    expect(exp.date!()).toBeNaN();
+  });
+
+  it("valid Date(0) getters preserve their existing semantics", async () => {
+    // Regression check: the sentinel guard must not affect the valid path.
+    const exp = await compileToWasm(`
+      export function time(): number { return new Date(0).getTime(); }
+      export function fullYear(): number { return new Date(0).getFullYear(); }
+      export function month(): number { return new Date(0).getMonth(); }
+      export function date(): number { return new Date(0).getDate(); }
+      export function hours(): number { return new Date(0).getHours(); }
+      export function day(): number { return new Date(0).getDay(); }
+    `);
+    expect(exp.time!()).toBe(0);
+    expect(exp.fullYear!()).toBe(1970);
+    expect(exp.month!()).toBe(0); // January (0-indexed)
+    expect(exp.date!()).toBe(1); // first of month
+    expect(exp.hours!()).toBe(0);
+    expect(exp.day!()).toBe(4); // 1970-01-01 was a Thursday
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of #1344 — fix `Date.prototype.*` getters returning wrong values for invalid Dates. Sweep over 26 `built-ins/Date/prototype/*/this-value-invalid-date.js` tests: **18 now pass** (was 0).

### Changes

1. **`src/codegen/expressions/new-super.ts`** — `new Date(arg)` checks if `arg` is NaN at runtime and stores the i64 sentinel `-9223372036854775808n` (i64 min, well outside the spec-valid Date range of ±8.64e15 ms).

2. **`src/codegen/expressions/builtins.ts`** — every Date getter (`getTime`, `valueOf`, `getTimezoneOffset`, `getHours`/UTC, `getMinutes`/UTC, `getSeconds`/UTC, `getMilliseconds`/UTC, `getDay`/UTC, `getFullYear`/UTC, `getMonth`/UTC, `getDate`/UTC) wraps its arithmetic in `if (timestamp == SENTINEL) NaN else <arith>` via a shared `wrapWithInvalidDateGuard` helper.

Valid-Date paths are unchanged — `new Date(0).getFullYear() === 1970` etc. still hold.

### Slice 2 (deferred)

- `setX` methods (`setHours`, `setFullYear`, etc.) should also NaN-out on invalid Date receivers (~7 remaining tests in this cluster).
- Formatter methods (`toISOString` should throw RangeError, `toString` should return "Invalid Date") are stubs today.

## Test plan

- [x] `tests/equivalence/issue-1344.test.ts` — 5 cases, all pass
- [x] Sweep over 26 invalid-date test262 fails: 18 now pass
- [x] `date-basic.test.ts` (12/12) — no regressions
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)