### PR TITLE
feat(#1382 Phase 1): foundational JS-callable closure bridge

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -988,6 +988,12 @@ export function generateModule(
     // Emit __call_fn_1 export for calling one-arg closures from JS (#1090)
     emitClosureCallExport1(ctx);
 
+    // Emit __call_fn_2 export for calling two-arg closures from JS (#1382)
+    // Required for Array.from(iter, mapFn) where mapFn is a Wasm closure —
+    // host `Array.from` invokes mapFn with `(value, index)`, so the JS-side
+    // wrapper needs a 2-arg dispatcher to route into the closure.
+    emitClosureCallExport2(ctx);
+
     // Emit __call_toString/__call_valueOf exports for ToPrimitive dispatch (#866)
     emitToPrimitiveMethodExports(ctx);
 
@@ -1797,6 +1803,255 @@ function emitClosureCallExport1(ctx: CodegenContext): void {
 
   mod.exports.push({
     name: "__call_fn_1",
+    desc: { kind: "func", index: funcIdx },
+  });
+}
+
+/**
+ * Emit __call_fn_2 export (#1382): call a two-arg WasmGC closure from JS.
+ * Takes (externref closure, externref arg0, externref arg1) and returns
+ * externref. Used by `__array_from` (mapFn invoked with (value, index)) and
+ * by future host shims that pass Wasm closures as JS callbacks.
+ *
+ * Same dispatch strategy as __call_fn_0 / __call_fn_1: extract the funcref
+ * from field 0 of the closure struct, then dispatch by funcref TYPE
+ * (struct-type dispatch fails post-V8-isorecursive-canonicalization).
+ *
+ * Locals layout:
+ *   0 = closure externref (param)
+ *   1 = arg0 externref (param)
+ *   2 = arg1 externref (param)
+ *   3 = anyref (__any) — the converted closure externref
+ *   4 = (ref null $baseWrapper) (__struct) — cast struct for self
+ *   5 = funcref (__funcref) — extracted from field 0
+ */
+function emitClosureCallExport2(ctx: CodegenContext): void {
+  const mod = ctx.mod;
+
+  let baseWrapperIdx: number | undefined;
+  const seenFuncTypeIdx = new Set<number>();
+  // (#1382) Each entry tracks how many user args the closure declared
+  // (closureArity). The host (JS-side `Array.from`) always invokes with
+  // 2 args (value, index); when the closure declared fewer, we drop the
+  // extra args at the dispatch arm. This matches JS spec behavior — extra
+  // args beyond a function's declared arity are ignored at call time.
+  const entries: {
+    funcTypeIdx: number;
+    returnType: ValType | null;
+    selfTypeIdx: number;
+    closureArity: 0 | 1 | 2;
+  }[] = [];
+
+  // (#1382) Iterate ALL closures (arity 0, 1, 2) — `__call_fn_2` is the
+  // host-callable wrapper Array.from uses; the host calls with 2 args
+  // regardless of the closure's actual arity.
+  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+    if (info.paramTypes.length > 2) continue;
+
+    const typeDef = mod.types[typeIdx];
+    if (!typeDef || typeDef.kind !== "struct") continue;
+
+    if (typeDef.superTypeIdx === -1 && baseWrapperIdx === undefined) {
+      baseWrapperIdx = typeIdx;
+    }
+
+    if (!seenFuncTypeIdx.has(info.funcTypeIdx)) {
+      seenFuncTypeIdx.add(info.funcTypeIdx);
+      const funcTypeDef = mod.types[info.funcTypeIdx];
+      const selfParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[0] : undefined;
+      const selfTypeIdx =
+        selfParam && (selfParam.kind === "ref" || selfParam.kind === "ref_null")
+          ? (selfParam as { typeIdx: number }).typeIdx
+          : typeIdx;
+      entries.push({
+        funcTypeIdx: info.funcTypeIdx,
+        returnType: info.returnType,
+        selfTypeIdx,
+        closureArity: info.paramTypes.length as 0 | 1 | 2,
+      });
+    }
+  }
+
+  if (entries.length === 0) return;
+
+  // Fallback to any base wrapper if no 2-arg specific one (V8 canonicalizes
+  // single-funcref-field structs to the same type regardless of arity).
+  if (baseWrapperIdx === undefined) {
+    for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+      const typeDef = mod.types[typeIdx];
+      if (typeDef && typeDef.kind === "struct" && typeDef.superTypeIdx === -1) {
+        baseWrapperIdx = typeIdx;
+        break;
+      }
+      void info;
+    }
+  }
+  if (baseWrapperIdx === undefined) {
+    for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
+      if (ctx.closureInfoByTypeIdx.get(typeIdx)!.paramTypes.length === 2) {
+        baseWrapperIdx = typeIdx;
+        break;
+      }
+    }
+  }
+  if (baseWrapperIdx === undefined) return;
+
+  addUnionImports(ctx);
+  const boxNumberIdx = ctx.funcMap.get("__box_number");
+
+  // __call_fn_2(closure: externref, arg0: externref, arg1: externref) → externref
+  const exportFuncTypeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+    "$call_fn_2_type",
+  );
+  const funcIdx = ctx.numImportFuncs + mod.functions.length;
+  const bwIdx = baseWrapperIdx;
+
+  // Locals:
+  //   0 = closure externref (param)
+  //   1 = arg0 externref (param)
+  //   2 = arg1 externref (param)
+  //   3 = anyref (__any)
+  //   4 = (ref null $bw) (__struct)
+  //   5 = funcref (__funcref)
+  const body: Instr[] = [];
+  body.push({ op: "local.get", index: 0 });
+  body.push({ op: "any.convert_extern" } as Instr);
+  body.push({ op: "local.set", index: 3 } as Instr);
+
+  let funcrefDispatch: Instr[] = [{ op: "ref.null.extern" } as Instr];
+
+  for (const entry of entries) {
+    // Funcref signature: (ref $self, ...param_types) → return_type.
+    // The number of user-facing param types depends on `closureArity` —
+    // we only forward as many host args (locals 1, 2) as the closure
+    // declared, dropping the rest. Matches JS spec for "extra args
+    // ignored" semantics on calls with more args than declared params.
+    const funcTypeDef = mod.types[entry.funcTypeIdx];
+    const param0Type =
+      entry.closureArity >= 1 && funcTypeDef?.kind === "func" && funcTypeDef.params.length >= 2
+        ? funcTypeDef.params[1]
+        : undefined;
+    const param1Type =
+      entry.closureArity >= 2 && funcTypeDef?.kind === "func" && funcTypeDef.params.length >= 3
+        ? funcTypeDef.params[2]
+        : undefined;
+
+    // Build per-arg conversion sequence.
+    const buildArgConversion = (argLocalIdx: number, paramType: ValType | undefined): Instr[] => {
+      const ops: Instr[] = [{ op: "local.get", index: argLocalIdx } as Instr];
+      if (paramType) {
+        if (paramType.kind === "f64") {
+          const unboxIdx = ctx.funcMap.get("__unbox_number");
+          if (unboxIdx !== undefined) {
+            ops.push({ op: "call", funcIdx: unboxIdx } as Instr);
+          }
+        } else if (paramType.kind === "i32") {
+          const unboxIdx = ctx.funcMap.get("__unbox_number");
+          if (unboxIdx !== undefined) {
+            ops.push({ op: "call", funcIdx: unboxIdx } as Instr);
+            ops.push({ op: "i32.trunc_f64_s" } as unknown as Instr);
+          }
+        }
+        // externref: no conversion
+      }
+      return ops;
+    };
+
+    // Push self + (optional) arg0 + (optional) arg1 based on the closure's
+    // declared arity. `closureArity === 0` → just self. `1` → self + arg0.
+    // `2` → self + arg0 + arg1.
+    const argInstrs: Instr[] = [];
+    if (entry.closureArity >= 1) argInstrs.push(...buildArgConversion(1, param0Type));
+    if (entry.closureArity >= 2) argInstrs.push(...buildArgConversion(2, param1Type));
+
+    const callBody: Instr[] = [
+      { op: "local.get", index: 3 } as Instr,
+      { op: "ref.cast", typeIdx: entry.selfTypeIdx } as Instr,
+      ...argInstrs,
+      { op: "local.get", index: 5 } as Instr,
+      { op: "ref.cast", typeIdx: entry.funcTypeIdx } as Instr,
+      { op: "call_ref", typeIdx: entry.funcTypeIdx } as Instr,
+    ];
+
+    // Coerce result to externref (mirror __call_fn_1).
+    if (entry.returnType) {
+      if (entry.returnType.kind === "ref" || entry.returnType.kind === "ref_null") {
+        callBody.push({ op: "extern.convert_any" } as Instr);
+      } else if (entry.returnType.kind === "f64") {
+        if (boxNumberIdx !== undefined) {
+          callBody.push({ op: "call", funcIdx: boxNumberIdx } as Instr);
+        } else {
+          callBody.push({ op: "drop" } as Instr);
+          callBody.push({ op: "ref.null.extern" } as Instr);
+        }
+      } else if (entry.returnType.kind === "i32") {
+        if (boxNumberIdx !== undefined) {
+          callBody.push({ op: "f64.convert_i32_s" } as Instr);
+          callBody.push({ op: "call", funcIdx: boxNumberIdx } as Instr);
+        } else {
+          callBody.push({ op: "drop" } as Instr);
+          callBody.push({ op: "ref.null.extern" } as Instr);
+        }
+      } else if (entry.returnType.kind === "i64") {
+        if (boxNumberIdx !== undefined) {
+          callBody.push({ op: "f64.convert_i64_s" } as Instr);
+          callBody.push({ op: "call", funcIdx: boxNumberIdx } as Instr);
+        } else {
+          callBody.push({ op: "drop" } as Instr);
+          callBody.push({ op: "ref.null.extern" } as Instr);
+        }
+      }
+    } else {
+      callBody.push({ op: "ref.null.extern" } as Instr);
+    }
+
+    funcrefDispatch = [
+      { op: "local.get", index: 5 } as Instr,
+      { op: "ref.test", typeIdx: entry.funcTypeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: callBody,
+        else: funcrefDispatch,
+      } as Instr,
+    ];
+  }
+
+  const structExtractAndDispatch: Instr[] = [
+    { op: "local.get", index: 3 } as Instr,
+    { op: "ref.cast", typeIdx: bwIdx } as Instr,
+    { op: "local.tee", index: 4 } as Instr,
+    { op: "struct.get", typeIdx: bwIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: 5 } as Instr,
+    ...funcrefDispatch,
+  ];
+
+  body.push({ op: "local.get", index: 3 } as Instr);
+  body.push({ op: "ref.test", typeIdx: bwIdx } as Instr);
+  body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: structExtractAndDispatch,
+    else: [{ op: "ref.null.extern" } as Instr],
+  } as Instr);
+
+  mod.functions.push({
+    name: "__call_fn_2",
+    typeIdx: exportFuncTypeIdx,
+    locals: [
+      { name: "__any", type: { kind: "anyref" } },
+      { name: "__struct", type: { kind: "ref_null", typeIdx: bwIdx } },
+      { name: "__funcref", type: { kind: "funcref" } },
+    ],
+    body,
+    exported: true,
+  } as WasmFunction);
+
+  mod.exports.push({
+    name: "__call_fn_2",
     desc: { kind: "func", index: funcIdx },
   });
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -270,6 +270,49 @@ function _canBeWeakKey(obj: any): boolean {
   return obj != null && (typeof obj === "object" || typeof obj === "function");
 }
 
+/**
+ * (#1382) Wrap a Wasm closure struct in a JS Function so it can be called
+ * from JS host code (e.g. `Array.from(iter, mapFn)` where mapFn is a Wasm
+ * closure rather than a real `function`).
+ *
+ * Wasm closure structs are externref-typed in JS but lack a `[[Call]]`
+ * internal method, so `mapFn(value, index)` fails with "object is not a
+ * function". The wrapper bridges by dispatching into Wasm via the
+ * `__call_fn_<arity>` exports, which use funcref-type dispatch to invoke
+ * the closure's lifted body.
+ *
+ * Returns `null` if the appropriate `__call_fn_<arity>` export isn't
+ * available — caller falls back to the original (which will throw the
+ * original "not a function" error). That keeps the failure mode visible
+ * rather than silently swallowing it.
+ *
+ * Arity matches the number of JS args the host will pass; the JS wrapper
+ * forwards exactly that count to `__call_fn_N`. Args beyond `arity` are
+ * dropped, matching JS's "extra args ignored" semantics.
+ */
+function _wrapWasmClosure(
+  closure: any,
+  arity: number,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): ((...args: any[]) => any) | null {
+  if (!callbackState) return null;
+  const exports = callbackState.getExports();
+  if (!exports) return null;
+  const callFn = exports[`__call_fn_${arity}`];
+  if (typeof callFn !== "function") return null;
+  // Closure parameter is captured by reference; the wrapper holds it alive
+  // for as long as the JS Function is reachable from the host. JS Function
+  // identity is preserved across multiple invocations (host may capture a
+  // reference, e.g. callbacks stored on plain objects).
+  return function wasmClosureBridge(...args: any[]): any {
+    // Pad with undefined to exactly `arity` positional args. Extra args
+    // dropped (JS spec for fewer/more args than declared params).
+    const padded: any[] = [];
+    for (let i = 0; i < arity; i++) padded.push(args[i]);
+    return callFn(closure, ...padded);
+  };
+}
+
 function _getSidecar(obj: object): Record<string | symbol, any> {
   if (!_canBeWeakKey(obj)) return Object.create(null) as Record<string | symbol, any>;
   let sc = _wasmStructProps.get(obj);
@@ -3280,10 +3323,25 @@ assert._isSameValue = isSameValue;
       if (name === "__symbol_keyFor") return (sym: any): any => Symbol.keyFor(sym);
       // ArrayBuffer.isView(arg) — checks if arg is a TypedArray or DataView (#965)
       if (name === "__arraybuffer_isView") return (arg: any): number => (ArrayBuffer.isView(arg) ? 1 : 0);
-      // Array.from(iterable, mapFn?) — creates array from iterable (#965)
+      // Array.from(iterable, mapFn?) — creates array from iterable (#965).
+      //
+      // (#1382) When `mapFn` is a Wasm closure struct (rather than a JS
+      // function), the host's `Array.from` invocation `mapFn(value, index)`
+      // would fail with "object is not a function" because closure structs
+      // lack a `[[Call]]` internal method. Detect this case and wrap the
+      // closure in a JS Function that dispatches into Wasm via the
+      // `__call_fn_2` export. Plain JS callers (e.g. `Array.from(arr,
+      // (x) => x * 2)` in JS host code calling into Wasm) still pass a
+      // real `function`, so the wrapping is a no-op for them.
       if (name === "__array_from")
-        return (iterable: any, mapFn: any): any[] =>
-          mapFn != null ? Array.from(iterable, mapFn) : Array.from(iterable);
+        return (iterable: any, mapFn: any): any[] => {
+          if (mapFn == null) return Array.from(iterable);
+          if (_isWasmStruct(mapFn)) {
+            const wrapped = _wrapWasmClosure(mapFn, 2, callbackState);
+            if (wrapped) return Array.from(iterable, wrapped);
+          }
+          return Array.from(iterable, mapFn);
+        };
       // Array.of(...items) — creates array from arguments (#965)
       if (name === "__array_of") return (items: any[]): any[] => items;
       // Object.prototype methods for extern class dispatch (#799 WI2)


### PR DESCRIPTION
## Summary

Phase 1 of #1382: foundational infrastructure for invoking Wasm closures from JS host code. Per architect spec **Option A**: a runtime helper `_wrapWasmClosure(closure, arity, callbackState)` that returns a JS Function dispatching into Wasm via `__call_fn_<arity>` exports, plus a new `__call_fn_2` codegen export to support the most common host calling convention (Array.from mapFn `(value, index)`).

This is **infrastructure only** — call-site rewrites that consume this primitive are tracked as follow-up scope.

## Changes

### `src/codegen/index.ts`

New `emitClosureCallExport2` — emits `__call_fn_2(closure: externref, arg0: externref, arg1: externref) → externref` Wasm export. Mirrors the existing `__call_fn_0` / `__call_fn_1` pattern but iterates closures of arity ≤ 2, dropping extra args at the dispatch arm based on each entry's `closureArity`. This matches JS spec's "extra args ignored" semantics so a closure declared as `(x: number) => x * 2` (arity 1) called via Array.from passing 2 args still works correctly.

### `src/runtime.ts`

- New `_wrapWasmClosure(closure, arity, callbackState)` helper — wraps an externref Wasm closure in a JS Function that forwards into Wasm via `__call_fn_<arity>`. Returns null when the export isn't available (closure-less modules), so callers fall through to the original failure mode.
- `__array_from` host import: when `mapFn` is detected as a Wasm closure (via `_isWasmStruct`), wrap it before passing to `Array.from`. Plain JS callers (typical host code calling into Wasm) are unaffected — the wrap only triggers when mapFn is opaque.

## Out of scope (follow-up)

- **`Array.from(typedArr, mapFn)` native fast path** (`calls.ts:1804`) — short-circuits before reaching the host, applying a shallow `array.copy` and silently dropping the mapFn. Fixing requires extending the fast path to apply mapFn via `call_ref` (mirroring `arr.map(fn)`'s native iteration). Independent of this PR's primitive.
- **`Array.prototype.{filter,map,...}.call(obj, cb, thisArg)` (#1358)** — needs a `__call_with_this` host import that doesn't yet exist. Once added, can use `_wrapWasmClosure`.
- **`Function.prototype.bind` LHS coerce (#1338)** — separate.
- **IR external-call whitelist bridge (#1371)** — separate.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 20/20 sample equivalence tests pass (no regression)
- [x] No regression in pre-existing test setup failures
- [x] Probe `.tmp/probe-1382-arrayfrom.mts` exposes the remaining `calls.ts` fast-path issue but doesn't regress no-mapFn behavior
- [ ] CI — wait for `.claude/ci-status/pr-N.json`

## Spec citation

ECMA-262 §7.3.13 — `Call(F, V, argumentsList)`: "If F is not callable, throw a TypeError exception." This bridge ensures Wasm closures satisfy F's `[[Call]]` requirement when crossed into JS host code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)