### PR TITLE
fix(#1352b): test262 wrapper handles single-quoted + identifier RHS in __expected.input

### DIFF
--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1746,9 +1746,24 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   // Our Wasm arrays can't store extra properties, so extract these to separate variables.
   // Transform: __expected.index = N; → var __expected_index: number = N;
   // Transform: __expected.input = "S"; → var __expected_input: string = "S";
-  // Then replace __expected.index → __expected_index, __expected.input → __expected_input
+  // Then replace __expected.index → __expected_index, __expected.input → __expected_input.
+  //
+  // (#1352b) The original regex only matched double-quoted RHS. Many S15.10.2.*
+  // tests use single-quoted strings (e.g. `__expected.input = 'alice said: "don\'t"';`)
+  // which fell through unmodified — leaving `__expected.input` references on later
+  // lines pointing at `__expected_input` (which never got declared) and producing
+  // `ReferenceError: __expected_input is not defined`. Extended to handle both
+  // quote styles. The `("(?:...)"|'(?:...)')` alternation captures the entire
+  // quoted literal so the replacement preserves whichever style the source used.
   body = body.replace(/__expected\.index\s*=\s*(\d+)\s*;/g, "var __expected_index: number = $1;");
-  body = body.replace(/__expected\.input\s*=\s*("(?:[^"\\]|\\.)*")\s*;/g, "var __expected_input: string = $1;");
+  // (#1352b) Match double-quoted, single-quoted, or identifier RHS — many tests
+  // assign `__expected.input = __string` where `__string` is a previously-declared
+  // local. The identifier branch lets the var-decl carry through any string-typed
+  // value, not just literals.
+  body = body.replace(
+    /__expected\.input\s*=\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[A-Za-z_$][\w$]*)\s*;/g,
+    "var __expected_input: string = $1;",
+  );
   // Replace property accesses with the extracted variables
   body = body.replace(/__expected\.index\b(?!\s*=)/g, "__expected_index");
   body = body.replace(/__expected\.input\b(?!\s*=)/g, "__expected_input");


### PR DESCRIPTION
## Summary

The test262 runner pre-processes RegExp exec-result tests by transforming `__expected.input = "S"` into `var __expected_input: string = "S"` and replacing later `__expected.input` references with `__expected_input`. The original regex only matched **double-quoted** string literals on the RHS.

Many `built-ins/RegExp/S15.10.2.*` tests use:
- Single-quoted strings (`'alice said: "don\\'t"'`) — 14 tests
- Identifier RHS (`__expected.input = __string`) — 11 tests

For both, the var-decl rewrite skipped, leaving `__expected_input` undefined on later lines and producing `ReferenceError: __expected_input is not defined` at runtime.

Fix: extend the regex alternation to match double-quoted, single-quoted, AND identifier RHS.

## Note on the original task description

The task was filed as `__host_eq` runtime fix for wasmGC string struct vs externref JS string. After investigation, the actual cluster failure is a wrapper-regex completeness gap, not a host-side equality issue. The host-side equality is correct for this cluster — the test values arrive as JS-side strings on both sides via the wrapper-extracted variables. Reframed accordingly in the commit message.

## Test plan

- [x] Sweep over 43 currently-failing `built-ins/RegExp/S15.10.2.*` tests: **43/43 now pass** (was 0)
- [x] `tests/equivalence/{regexp-methods,string-methods}.test.ts` — 58/58 (no regressions)
- [x] Wrapper rewrite verified via `wrapTest()` probe: `__expected.input = 'alice said...'` and `__expected.input = __string` both now produce `var __expected_input: string = ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)