### PR TITLE
feat(#1382 Phase 2): wire Array.from(typedArr, mapFn) through host bridge

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1815,8 +1815,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     ) {
       const argTsType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
       const argWasmType = resolveWasmType(ctx, argTsType);
+      // (#1382 Phase 2) The native fast-path applies only when there's
+      // NO mapFn. With a mapFn, route to the host fallback below — the
+      // runtime's `__array_from` materializes the wasm vec via
+      // `__vec_len`/`__vec_get` and wraps the mapFn closure via
+      // `_wrapWasmClosure`. The fast path's `array.copy` would silently
+      // drop the mapFn.
+      const hasMapFn = expr.arguments.length >= 2;
       // Only handle array arguments — create a shallow copy
-      if (argWasmType.kind === "ref" || argWasmType.kind === "ref_null") {
+      if (!hasMapFn && (argWasmType.kind === "ref" || argWasmType.kind === "ref_null")) {
         const arrInfo = resolveArrayInfo(ctx, argTsType);
         if (arrInfo) {
           const { vecTypeIdx, arrTypeIdx, elemType } = arrInfo;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -313,6 +313,47 @@ function _wrapWasmClosure(
   };
 }
 
+/**
+ * (#1382) Materialize a Wasm vec into a real JS array via the `__vec_len`
+ * + `__vec_get` exports. Non-vec values pass through:
+ *   - JS arrays returned as-is.
+ *   - JS-iterable objects (anything with `Symbol.iterator`) returned as-is.
+ *   - null / non-object values returned as-is (caller handles the type check).
+ *
+ * Used by `__array_from` so `Array.from(wasmVec, mapFn)` sees a real
+ * iterable instead of an opaque WasmGC struct ref. Same machinery the
+ * Promise combinators use (#1368).
+ */
+function _materializeIterable(
+  iter: any,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): any {
+  if (iter == null) return iter;
+  if (Array.isArray(iter)) return iter;
+  if (typeof iter !== "object") return iter;
+  // (#1382) Check `_isWasmStruct` BEFORE `Symbol.iterator in iter` —
+  // the `in` operator on an opaque WasmGC struct throws "WebAssembly
+  // objects are opaque", aborting the host call. `_isWasmStruct`
+  // handles the throw internally and returns true for opaque structs.
+  if (_isWasmStruct(iter)) {
+    const exports = callbackState?.getExports();
+    if (!exports) return iter;
+    const vecLen = exports.__vec_len;
+    const vecGet = exports.__vec_get;
+    if (typeof vecLen !== "function" || typeof vecGet !== "function") return iter;
+    const len = vecLen(iter) as number;
+    if (typeof len !== "number" || len < 0) return iter;
+    const result: any[] = new Array(len);
+    for (let i = 0; i < len; i++) {
+      result[i] = vecGet(iter, i);
+    }
+    return result;
+  }
+  // Plain JS object — pass through if it has Symbol.iterator, else as-is.
+  if (Symbol.iterator in iter) return iter;
+  return iter;
+}
+
 function _getSidecar(obj: object): Record<string | symbol, any> {
   if (!_canBeWeakKey(obj)) return Object.create(null) as Record<string | symbol, any>;
   let sc = _wasmStructProps.get(obj);
@@ -3389,22 +3430,24 @@ assert._isSameValue = isSameValue;
       if (name === "__arraybuffer_isView") return (arg: any): number => (ArrayBuffer.isView(arg) ? 1 : 0);
       // Array.from(iterable, mapFn?) — creates array from iterable (#965).
       //
-      // (#1382) When `mapFn` is a Wasm closure struct (rather than a JS
-      // function), the host's `Array.from` invocation `mapFn(value, index)`
-      // would fail with "object is not a function" because closure structs
-      // lack a `[[Call]]` internal method. Detect this case and wrap the
-      // closure in a JS Function that dispatches into Wasm via the
-      // `__call_fn_2` export. Plain JS callers (e.g. `Array.from(arr,
-      // (x) => x * 2)` in JS host code calling into Wasm) still pass a
-      // real `function`, so the wrapping is a no-op for them.
+      // (#1382) Two interop hazards:
+      //   1. `iterable` may be an opaque Wasm vec struct (no JS iterator)
+      //      — materialize via `__vec_len` + `__vec_get` so `Array.from`
+      //      sees a real iterable. Plain JS arrays / iterables pass
+      //      through unchanged.
+      //   2. `mapFn` may be a Wasm closure struct (no `[[Call]]`) — wrap
+      //      in a JS Function via `_wrapWasmClosure` so `Array.from`
+      //      can invoke it as `mapFn(value, index)`. Plain JS callers
+      //      pass a real `function`, so the wrap is a no-op.
       if (name === "__array_from")
         return (iterable: any, mapFn: any): any[] => {
-          if (mapFn == null) return Array.from(iterable);
+          const iter = _materializeIterable(iterable, callbackState);
+          if (mapFn == null) return Array.from(iter);
           if (_isWasmStruct(mapFn)) {
             const wrapped = _wrapWasmClosure(mapFn, 2, callbackState);
-            if (wrapped) return Array.from(iterable, wrapped);
+            if (wrapped) return Array.from(iter, wrapped);
           }
-          return Array.from(iterable, mapFn);
+          return Array.from(iter, mapFn);
         };
       // Array.of(...items) — creates array from arguments (#965)
       if (name === "__array_of") return (items: any[]): any[] => items;


### PR DESCRIPTION
## Summary

Phase 2 of #1382 — wires the Phase 1 closure bridge ($PR #320, merged) to the canonical `Array.from(items, mapFn)` call site that motivated the issue.

## Two bugs fixed

### 1. Native Array.from fast path silently dropped mapFn (`calls.ts`)

The native fast path applied `array.copy` for typed-array source but ignored `arguments[1]`. With mapFn present, route to host fallback so the runtime can apply the function to each element.

```diff
- if (argWasmType.kind === "ref" || argWasmType.kind === "ref_null") {
+ const hasMapFn = expr.arguments.length >= 2;
+ if (!hasMapFn && (argWasmType.kind === "ref" || argWasmType.kind === "ref_null")) {
```

### 2. Host `__array_from` couldn't iterate Wasm vec source (`runtime.ts`)

Previously the host received an opaque WasmGC struct with no `Symbol.iterator`. New `_materializeIterable` helper detects opaque Wasm structs and materializes them via `__vec_len`/`__vec_get` exports (mirrors the Promise combinator pattern at #1368).

Combined with Phase 1's `_wrapWasmClosure` (which handles the case where mapFn itself is a Wasm closure), this fully fixes `Array.from(typedArr, jsArrowMapFn)` and lays groundwork for `Array.from(wasmIter, wasmClosureMapFn)`.

## Edge case

`_isWasmStruct` check moved BEFORE `Symbol.iterator in iter` because the `in` operator on opaque WebAssembly objects throws "WebAssembly objects are opaque". `_isWasmStruct` already handles the throw internally.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `.tmp/probe-1382-arrayfrom.mts` — 3 cases:
  - `Array.from([1,2,3], (x) => x * 2)` → 12 ✓
  - `Array.from([1,2,3], (x) => x * factor)` (capturing closure) → 18 ✓
  - `Array.from([10,20,30], (x, i) => x + i)` → 63 ✓
- [x] 23/23 array equivalence tests pass
- [ ] CI — wait for `.claude/ci-status/pr-N.json`

## Out of scope (follow-up sub-issues)

- **`Array.prototype.{filter,map,...}.call(obj, cb, thisArg)` (#1358)** — Option C: thread thisArg as Wasm param.
- **`Function.prototype.bind` LHS coerce (#1338)** — closure-struct cast at assignment sites.
- **IR external-call whitelist bridge (#1371)** — IR fn passed as callback to whitelisted external.

Each call site has different shape complications. The Phase 1 `_wrapWasmClosure` + `__call_fn_2` primitives are available for them to consume when work begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)