### PR TITLE
feat(#1373 Phase A): IR claim-infrastructure for async functions

### DIFF
--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -69,6 +69,11 @@ const UNINTENDED: ReadonlySet<IrFallbackReason> = new Set([
 /** Reasons that are expected until their corresponding slices land. */
 const DEFERRED: ReadonlySet<IrFallbackReason> = new Set([
   "async-generator",
+  // (#1373 Phase A) Tracked separately from `async-generator` so the gate
+  // can flip it from deferred → unintended when Phase B/C wires lowering.
+  // Until then async functions are infrastructurally distinct but still
+  // fall back to legacy.
+  "async-function",
   "deferred-feature",
   "type-parameters",
   "non-export-modifier",

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1764,6 +1764,18 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         });
         return;
       }
+      // (#1373 Phase B) Async / await IR nodes are type-only in this
+      // slice — Phase C (#1373b) wires the CPS lowering. Until then
+      // the selector rejects async functions (returns "async-function"
+      // bucket), so these IrInstrs never reach the lowerer in practice.
+      // Throwing here makes accidental construction surface clearly
+      // rather than silently emitting nothing.
+      case "await":
+      case "async.return":
+      case "async.throw":
+        throw new Error(
+          `ir/lower: ${instr.kind} not yet implemented (#1373 Phase C / #1373b — see issue plan/issues/sprints/51/1373-ir-async-function.md)`,
+        );
     }
   };
 
@@ -2009,6 +2021,16 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [];
+    // (#1373 Phase B) Async / await IR nodes — type-only in this slice.
+    // The lowering Phase C (#1373b) will inflate these into CPS-form
+    // microtask-queue calls; until then they're never emitted by
+    // from-ast and never reach the lowerer.
+    case "await":
+      return [instr.operand];
+    case "async.return":
+      return [instr.value];
+    case "async.throw":
+      return [instr.reason];
   }
 }
 

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -578,6 +578,62 @@ export interface IrInstrIf extends IrInstrBase {
 }
 
 /**
+ * (#1373 Phase B) `await <expr>` — suspend the current async function until
+ * `expr`'s Promise settles, then resume with the resolved value. The IR
+ * node carries the operand whose evaluation produces a Promise (or a
+ * non-Promise value that must be wrapped in `Promise.resolve` before
+ * suspension per spec §27.2.1.4).
+ *
+ * Phase B (this slice) defines the type only — no lowering. Phase C
+ * (CPS transform, follow-up #1373b) splits the function at each await
+ * point, lifts the post-await tail into a continuation closure, and
+ * emits microtask-queue calls (`__promise_then(promise, continuation)`)
+ * to schedule resumption.
+ *
+ * The result IrValueId carries the resolved value. Its IrType must
+ * match the surrounding expression context (typically the unwrapped
+ * `T` from `Promise<T>`).
+ */
+export interface IrInstrAwait extends IrInstrBase {
+  readonly kind: "await";
+  readonly operand: IrValueId;
+}
+
+/**
+ * (#1373 Phase B) `return <value>` from an async function body. UNLIKE
+ * `IrTerminatorReturn`, which produces the bare value, this wraps the
+ * value in `Promise.resolve(value)` per the async function spec
+ * §15.8.5.5. The IR node defines the wrap intent; lowering (Phase C)
+ * emits the wrap via the existing `Promise_resolve` host import in
+ * JS-host mode or via the standalone `$Promise` struct.new in WASI
+ * mode (the latter wired in #1326 Phase 1B).
+ *
+ * Used in tail position only — non-tail `return` inside an async
+ * function flows through the IR's normal block terminator, which the
+ * Phase C lowerer recognises and routes through the same wrap.
+ */
+export interface IrInstrAsyncReturn extends IrInstrBase {
+  readonly kind: "async.return";
+  readonly value: IrValueId;
+}
+
+/**
+ * (#1373 Phase B) Synchronous throw inside an async function body.
+ * UNLIKE `IrInstrThrow`, which propagates as a Wasm exception, this
+ * wraps the thrown value in `Promise.reject(reason)` so the async
+ * function's outer Promise settles in the rejected state. Lowering
+ * (Phase C) emits the wrap via `Promise_reject` (host) or `$Promise`
+ * struct.new with `state = REJECTED` (standalone, #1326 Phase 1B).
+ *
+ * Currently NOT emitted by from-ast — Phase C wires it from
+ * `ts.ThrowStatement` nodes inside async function bodies.
+ */
+export interface IrInstrAsyncThrow extends IrInstrBase {
+  readonly kind: "async.throw";
+  readonly reason: IrValueId;
+}
+
+/**
  * Escape hatch: a raw backend instruction sequence with no SSA structure.
  * Phase 1 uses this as a bridge so we can describe any function without
  * re-encoding the whole Wasm opcode set in IR. Phase 2 will narrow uses.
@@ -1698,7 +1754,12 @@ export type IrInstr =
   | IrInstrRegExpLiteral
   // Slice 12 (#1280) — generic structured loops.
   | IrInstrWhileLoop
-  | IrInstrForLoop;
+  | IrInstrForLoop
+  // (#1373 Phase B) Async / await IR nodes. Currently type-only —
+  // Phase C (CPS transform, follow-up #1373b) wires lowering.
+  | IrInstrAwait
+  | IrInstrAsyncReturn
+  | IrInstrAsyncThrow;
 
 // ---------------------------------------------------------------------------
 // Slot definitions (#1169e — IR Phase 4 Slice 6)

--- a/src/ir/passes/dead-code.ts
+++ b/src/ir/passes/dead-code.ts
@@ -244,7 +244,14 @@ export function isSideEffecting(i: IrInstr): boolean {
     // extern.regex calls RegExp_new which is morally pure (allocates
     // a fresh value), but it may throw on bad pattern syntax — keep
     // the side-effect of the throw observable to user code.
-    i.kind === "extern.regex"
+    i.kind === "extern.regex" ||
+    // (#1373 Phase B) Async / await IR nodes are control-flow with
+    // observable suspension / Promise side effects. DCE must always
+    // preserve them. Phase C lowering (CPS transform) does not change
+    // this — even unused-result awaits need to suspend.
+    i.kind === "await" ||
+    i.kind === "async.return" ||
+    i.kind === "async.throw"
   );
 }
 
@@ -468,6 +475,16 @@ function collectInstrUses(instr: IrInstr): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [instr.condValue];
+    // (#1373 Phase B) Async / await IR nodes — Phase C wires real
+    // analysis. For now, surface the single operand so DCE pins the
+    // SSA def; the wrapping IrInstr is side-effecting (control-flow)
+    // and must always be kept.
+    case "await":
+      return [instr.operand];
+    case "async.return":
+      return [instr.value];
+    case "async.throw":
+      return [instr.reason];
   }
 }
 

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -715,6 +715,24 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       if (cv === inst.condValue) return inst;
       return { ...inst, condValue: cv };
     }
+    // (#1373 Phase B) Async / await IR nodes — rename single operand.
+    // Phase C may need richer renaming (continuation-closure capture
+    // sets); for now the simple operand rename is sufficient.
+    case "await": {
+      const op = mapId(rename, inst.operand);
+      if (op === inst.operand) return inst;
+      return { ...inst, operand: op };
+    }
+    case "async.return": {
+      const v = mapId(rename, inst.value);
+      if (v === inst.value) return inst;
+      return { ...inst, value: v };
+    }
+    case "async.throw": {
+      const r = mapId(rename, inst.reason);
+      if (r === inst.reason) return inst;
+      return { ...inst, reason: r };
+    }
   }
 }
 

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -778,5 +778,12 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [instr.condValue];
+    // (#1373 Phase B) Async / await IR nodes — single operand.
+    case "await":
+      return [instr.operand];
+    case "async.return":
+      return [instr.value];
+    case "async.throw":
+      return [instr.reason];
   }
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -70,6 +70,13 @@ export type IrFallbackReason =
   | "type-parameters"
   | "non-export-modifier"
   | "async-generator"
+  // (#1373) `async function` (without an asterisk) — distinguished from
+  // `async-generator` (`async function*`) and from generic
+  // `non-export-modifier` / `deferred-feature` so the IR-claim gate can
+  // conditionally accept async functions when the standalone
+  // `$Promise` + microtask-queue infra (#1326) is fully wired. Phase A
+  // (this slice) just buckets them; Phase C wires the lowering.
+  | "async-function"
   | "return-type-not-resolvable"
   | "param-type-not-resolvable"
   | "param-shape-rejected" // optional/rest/initializer/non-identifier/duplicate
@@ -447,12 +454,31 @@ function whyNotIrClaimable(
   //     accessor (`get`/`set`) modifiers explicitly so they slot into the
   //     right fallback bucket.
   if (!isMethod) {
-    if (fn.modifiers && fn.modifiers.some((m) => m.kind !== ts.SyntaxKind.ExportKeyword)) return "non-export-modifier";
+    if (fn.modifiers) {
+      // (#1373) Bucket `async` separately from generic non-export modifiers
+      // so the IR-claim gate can conditionally accept async functions once
+      // Phase B/C lowering lands. Async generators (`async function*`)
+      // route into the existing `"async-generator"` bucket; plain async
+      // functions get the new `"async-function"` bucket.
+      const hasAsyncModifier = fn.modifiers.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
+      const isGeneratorFn =
+        (ts.isFunctionDeclaration(fn) || ts.isMethodDeclaration(fn)) && !!(fn as ts.FunctionDeclaration).asteriskToken;
+      if (hasAsyncModifier) {
+        return isGeneratorFn ? "async-generator" : "async-function";
+      }
+      if (fn.modifiers.some((m) => m.kind !== ts.SyntaxKind.ExportKeyword)) return "non-export-modifier";
+    }
   } else {
     if (fn.modifiers) {
       for (const m of fn.modifiers) {
         if (m.kind === ts.SyntaxKind.AbstractKeyword) return "class-method";
-        if (m.kind === ts.SyntaxKind.AsyncKeyword) return "deferred-feature";
+        // (#1373) Same async-function vs async-generator distinction for
+        // class methods. Async generator methods land in the existing
+        // `async-generator` bucket via the post-modifier check below.
+        if (m.kind === ts.SyntaxKind.AsyncKeyword) {
+          const isGeneratorMethod = ts.isMethodDeclaration(fn) && !!fn.asteriskToken;
+          return isGeneratorMethod ? "async-generator" : "async-function";
+        }
       }
     }
   }

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -297,6 +297,15 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [instr.condValue];
+    // (#1373 Phase B) Async / await IR nodes — type-only in this slice.
+    // The verifier sees their operands as plain SSA uses; lowering
+    // (Phase C, #1373b) will define the per-arm SSA scope.
+    case "await":
+      return [instr.operand];
+    case "async.return":
+      return [instr.value];
+    case "async.throw":
+      return [instr.reason];
   }
 }
 

--- a/tests/ir/issue-1373.test.ts
+++ b/tests/ir/issue-1373.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1373 Phase A — IR claim infrastructure for async functions.
+//
+// Phase A scope (this PR):
+//   1. New IrFallbackReason `"async-function"` distinct from
+//      `"async-generator"` (`async function*`) and from generic
+//      `"non-export-modifier"` / `"deferred-feature"`.
+//   2. Selector buckets async functions (no asterisk) into the new
+//      reason. Async generators continue to land in `"async-generator"`.
+//   3. New IrInstr kinds `await` / `async.return` / `async.throw` are
+//      defined as types only — no lowering yet (Phase C / #1373b).
+//
+// Phase A is purely additive: async functions remain rejected by the IR
+// (they fall back to legacy codegen), but their rejection reason is now
+// distinct, which lets Phase C flip the gate from deferred → claimed
+// without touching the bucket name.
+
+import { describe, expect, it } from "vitest";
+import { ts } from "../../src/ts-api.js";
+import { planIrCompilation } from "../../src/ir/select.js";
+
+function parseSource(src: string): ts.SourceFile {
+  return ts.createSourceFile("test.ts", src, ts.ScriptTarget.ES2022, true);
+}
+
+describe("#1373 Phase A — async-function fallback bucket", () => {
+  it("plain `async function f() {}` lands in async-function (not non-export-modifier)", () => {
+    const sf = parseSource(`
+      async function f() { return 1; }
+    `);
+    const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+    const fb = sel.fallbacks?.find((f) => f.name === "f");
+    expect(fb?.reason).toBe("async-function");
+  });
+
+  it("`export async function f() {}` lands in async-function (not non-export-modifier)", () => {
+    const sf = parseSource(`
+      export async function f() { return 1; }
+    `);
+    const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+    const fb = sel.fallbacks?.find((f) => f.name === "f");
+    expect(fb?.reason).toBe("async-function");
+  });
+
+  it("`async function* g() {}` continues to land in async-generator (unchanged)", () => {
+    const sf = parseSource(`
+      async function* g() { yield 1; }
+    `);
+    const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+    const fb = sel.fallbacks?.find((f) => f.name === "g");
+    expect(fb?.reason).toBe("async-generator");
+  });
+
+  it("non-async function unaffected by the new bucket", () => {
+    const sf = parseSource(`
+      export function f(): number { return 1; }
+    `);
+    const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+    // No fallback — the function should be IR-claimable.
+    const fb = sel.fallbacks?.find((f) => f.name === "f");
+    expect(fb).toBeUndefined();
+  });
+
+  it("async-function reason stays distinct from non-export-modifier", () => {
+    // A function with BOTH `declare` (non-export) AND no `async` keyword
+    // should still land in non-export-modifier, not async-function.
+    // (Use a generator to make it a non-export-modifier candidate
+    // distinct from async — `function*` without `async` is a sync
+    // generator and lands in body-shape-rejected, not modifier-rejected.
+    // So just verify that the new bucket only fires for async.)
+    const sf = parseSource(`
+      async function f() { return 1; }
+      export async function g() { return 2; }
+    `);
+    const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+    const fbF = sel.fallbacks?.find((fb) => fb.name === "f");
+    const fbG = sel.fallbacks?.find((fb) => fb.name === "g");
+    expect(fbF?.reason).toBe("async-function");
+    expect(fbG?.reason).toBe("async-function");
+  });
+});


### PR DESCRIPTION
## Summary

Phase A of #1373 (the architect-recommended split). Pure infrastructure — **no behaviour change**. Phase C (CPS lowering, follow-up #1373b) wires the actual claim + lowering.

This PR delivers:

1. **New `IrFallbackReason: \"async-function\"`** — distinct from `\"async-generator\"` (`async function*`) and from generic `\"non-export-modifier\"` / `\"deferred-feature\"`. Plain async functions now bucket separately so the gate can flip them deferred → claimed without touching neighbouring buckets.

2. **Selector update** (`src/ir/select.ts`) — `whyNotIrClaimable` returns the new bucket for both top-level FunctionDeclarations and class methods. Async generators stay in `\"async-generator\"`.

3. **New IR node types in `src/ir/nodes.ts`** (type-only, no factory):
   - `IrInstrAwait` — `await <expr>`.
   - `IrInstrAsyncReturn` — wraps in `Promise.resolve(v)` per spec §15.8.5.5.
   - `IrInstrAsyncThrow` — wraps in `Promise.reject(reason)`.

4. **Switch-arm coverage** in all passes that walk IrInstr (verify, lower, dead-code, monomorphize, inline-small):
   - `verify`/`monomorphize`: surface single operand for use-counting.
   - `dead-code`: mark async kinds as side-effecting (DCE must preserve suspension).
   - `inline-small`: rename single operand.
   - `lower.ts`: throws with a Phase-C marker so accidental construction surfaces cleanly. Until Phase C wires from-ast emission, these IrInstrs are never created in practice.

5. **`scripts/check-ir-fallbacks.ts`** — adds `\"async-function\"` to the DEFERRED set so the new bucket doesn't surface as an unintended fallback.

**Phase C (#1373b) is BLOCKED on #1326 Phase 1C** (microtask queue + `Promise.then` standalone). The architect should re-spec Phase C once #1326 Phase 1C lands — see also the `1326c` issue file for the closure-funcref constraint identified during #1326 Phase 1B implementation.

Net: +251 / -4 lines.

## Test plan

- [x] 5 new unit tests in `tests/ir/issue-1373.test.ts` covering async function / async generator / non-async function bucketing.
- [x] 51/51 IR tests pass.
- [x] `npx tsc --noEmit` clean.
- [x] `pnpm run check:ir-fallbacks` OK — no unintended bucket changes (baselines unchanged: body-shape-rejected=22, call-graph-closure=6, param-type-not-resolvable=1).
- [ ] CI: full validation gate. Expect 0 net change on test262 (no behaviour delta — bucketing change only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)