### PR TITLE
fix(#1383): typeof-gated strict-equality fallback for cross-type comparisons

### DIFF
--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1566,6 +1566,23 @@ export function compileBinaryExpression(
             // Strict equality: __host_eq (JS ===) for reference identity.
             // If that returns false, fall through to numeric unboxing for
             // boxed numbers that differ in identity but have the same value. (#1065)
+            //
+            // (#1383) Gate the numeric-unbox fallback on a runtime typeof
+            // check — only fire it when BOTH operands are typeof === "number".
+            // The fallback was load-bearing for genuinely-different-identity
+            // boxed numbers (V8 sometimes returns different externref ids for
+            // numerically-equal JS numbers), but it incorrectly succeeded for
+            // cross-type strict comparisons too: `null === 0` produced
+            // `__unbox_number(null) === 0`, `__unbox_number(0) === 0`, true.
+            // Spec §7.2.16 says strict equality between values of different
+            // types is always false.
+            //
+            // Earlier PR #272 tried to drop the fallback entirely and caused
+            // -12 net test262 — the fallback was masking unrelated mismatches
+            // (boolean / undefined externrefs that also happen to land in
+            // the externref-vs-externref path). Gating with a typeof check
+            // preserves the load-bearing same-type case AND fixes the
+            // cross-type leak.
             const hostEqIdx = ensureLateImport(
               ctx,
               "__host_eq",
@@ -1573,6 +1590,7 @@ export function compileBinaryExpression(
               [{ kind: "i32" }],
             );
             flushLateImportShifts(ctx, fctx);
+            const typeofNumIdx = ctx.funcMap.get("__typeof_number")!;
             return [
               { op: "local.get", index: tmpLeft },
               { op: "local.get", index: tmpRight },
@@ -1582,11 +1600,31 @@ export function compileBinaryExpression(
                 blockType: { kind: "val", type: { kind: "i32" } },
                 then: [{ op: "i32.const", value: isNeqOp ? 0 : 1 } as Instr],
                 else: [
+                  // Both operands must be JS numbers for the numeric-unbox
+                  // fallback to be sound. Otherwise host_eq's `false` is
+                  // definitive (cross-type strict equality is always false).
                   { op: "local.get", index: tmpLeft },
-                  { op: "call", funcIdx: unboxIdx },
+                  { op: "call", funcIdx: typeofNumIdx } as Instr,
                   { op: "local.get", index: tmpRight },
-                  { op: "call", funcIdx: unboxIdx },
-                  { op: isEqOp ? "f64.eq" : "f64.ne" } as Instr,
+                  { op: "call", funcIdx: typeofNumIdx } as Instr,
+                  { op: "i32.and" } as Instr,
+                  {
+                    op: "if",
+                    blockType: { kind: "val", type: { kind: "i32" } },
+                    then: [
+                      // Both numbers: numeric-unbox compare is safe and
+                      // recovers same-value-different-identity cases.
+                      { op: "local.get", index: tmpLeft },
+                      { op: "call", funcIdx: unboxIdx },
+                      { op: "local.get", index: tmpRight },
+                      { op: "call", funcIdx: unboxIdx },
+                      { op: isEqOp ? "f64.eq" : "f64.ne" } as Instr,
+                    ] as Instr[],
+                    else: [
+                      // Cross-type or non-number: host_eq's false is final.
+                      { op: "i32.const", value: isNeqOp ? 1 : 0 } as Instr,
+                    ] as Instr[],
+                  } as Instr,
                 ] as Instr[],
               } as Instr,
             ] as Instr[];

--- a/tests/equivalence/issue-1383.test.ts
+++ b/tests/equivalence/issue-1383.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./helpers.js";
+
+// #1383 — typeof-gated strict-equality fallback (follow-up to #1380 / closed PR #272).
+//
+// The strict-equality codegen for two externref operands had this shape:
+//
+//   if host_eq(a, b)        // JS ===
+//     return true
+//   else
+//     return unbox(a) === unbox(b)   // <-- unsound for cross-type
+//
+// The fallback was load-bearing for V8's same-value-different-identity case
+// (V8 sometimes returns different externref ids for numerically-equal JS
+// numbers), but it incorrectly produced `true` for cross-type comparisons:
+// `null === 0` became `unbox(null) === unbox(0)` → `0 === 0` → true.
+// Spec §7.2.16 says strict equality between values of different types is
+// always false.
+//
+// Earlier PR #272 dropped the fallback entirely and caused -12 net test262
+// because the fallback was masking unrelated mismatches in non-numeric
+// comparisons. This PR keeps the fallback but **gates it on a runtime typeof
+// check** — the numeric-unbox path only fires when both operands are
+// `typeof === "number"`. Otherwise host_eq's `false` is final.
+
+describe("#1383 — typeof-gated strict equality fallback", () => {
+  it("null === 0 returns false (cross-type)", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = null;
+        let b: any = 0;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(0);
+  });
+
+  it("undefined === 0 returns false (cross-type)", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = undefined;
+        let b: any = 0;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(0);
+  });
+
+  it("null !== 0 returns true", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = null;
+        let b: any = 0;
+        return (a !== b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+
+  it("null === null returns true (same type)", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = null;
+        let b: any = null;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+
+  it("regression: same-value-different-identity numbers compare equal (load-bearing fallback)", async () => {
+    // The numeric-unbox fallback exists to handle V8 representing the same
+    // numeric value as different externref ids (e.g. 0 boxed twice with
+    // different boxes). The typeof gate must preserve this case.
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = 1 + 0;
+        let b: any = 1.0;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+
+  it("regression: 42 === 42 still works (same-type same-value)", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = 42;
+        let b: any = 42;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+
+  it("undefined === undefined returns true", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = undefined;
+        let b: any = undefined;
+        return (a === b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+
+  it("regression: null !== undefined for strict (despite loose ==)", async () => {
+    const exp = await compileToWasm(`
+      export function test(): number {
+        let a: any = null;
+        let b: any = undefined;
+        return (a !== b) ? 1 : 0;
+      }
+    `);
+    expect(exp.test!()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

The strict-equality codegen for two externref operands had this shape:

```
if host_eq(a, b)        // JS ===
  return true
else
  return unbox(a) === unbox(b)   // <-- unsound for cross-type
```

The `unbox` fallback was load-bearing for V8's same-value-different-identity case (V8 sometimes returns different externref ids for numerically-equal JS numbers), but it incorrectly produced `true` for cross-type comparisons: `null === 0` became `unbox(null) === unbox(0)` → `0 === 0` → true. Spec §7.2.16 says strict equality between values of different types is always false.

Earlier PR #272 dropped the fallback entirely and caused **-12 net test262** because the fallback was masking unrelated mismatches in non-numeric comparisons. This PR keeps the fallback but **gates it on a runtime typeof check** — the numeric-unbox path only fires when both operands are `typeof === "number"`. Otherwise host_eq's `false` is final.

## Test plan

- [x] `tests/equivalence/issue-1383.test.ts` — 8 cases covering: `null === 0`, `undefined === 0`, `null !== 0`, same-type-pos cases (`null === null`, `undefined === undefined`), same-value-different-identity load-bearing fallback, `null !== undefined` for strict
- [x] Wider equality suite — 60/60 tests across `strict-equality-edge-cases`, `loose-equality`, `equality-mixed-types`, `comparison-coercion`, `issue-1134`, `issue-1134-string-number`, `issue-1383` preserves existing pass rate
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)