### PR TITLE
fix(#42): test262 runner preserves yield in static * priv() generators

### DIFF
--- a/tests/test262-runner-static-gen-yield.test.ts
+++ b/tests/test262-runner-static-gen-yield.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { wrapTest } from "./test262-runner.js";
+
+describe("test262-runner: static generator method `yield` renaming (Task #42)", () => {
+  it("preserves `yield` inside `static *gen()` (no private name)", () => {
+    const src = `
+class C {
+  static *gen(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    // `yield` should remain `yield` inside the generator body
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("preserves `yield` inside `static * #priv()` private generator (52-fail cluster)", () => {
+    const src = `
+class C {
+  static * #priv(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("preserves `yield` inside `static *#unicode()` with `\\u{...}` escapes in name", () => {
+    const src = `
+class C {
+  static * #\\u{6F}(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("preserves `yield` inside `static * #non-ascii()` with `℘` (U+2118) in name", () => {
+    const src = `
+class C {
+  static * #℘(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("preserves `yield` inside `static * #ZWNJ_name()` with zero-width-non-joiner in name", () => {
+    const src = `
+class C {
+  static * #ZW_‌_NJ(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("preserves `yield` inside multiple stacked `static * #priv()` methods (real test262 pattern)", () => {
+    // Mirrors test/language/expressions/class/elements/multiple-stacked-definitions-rs-static-generator-method-privatename-identifier.js
+    const src = `
+var C = class {
+  static * #$(value) {
+    yield * value;
+  }
+  static * #_(value) {
+    yield * value;
+  }
+  static * #\\u{6F}(value) {
+    yield * value;
+  }
+  foo = "foobar"
+  bar = "barbaz";
+};
+    `;
+    const { source } = wrapTest(src);
+    // None of the three generator bodies should have been mangled
+    const yieldCount = (source.match(/\byield\s*\*/g) || []).length;
+    const _yieldCount = (source.match(/_yield\s*\*/g) || []).length;
+    expect(_yieldCount).toBe(0);
+    expect(yieldCount).toBe(3);
+  });
+
+  it("regression: still renames `yield` to `_yield` outside generator context", () => {
+    // Module-mode strict makes `yield` a reserved word; renaming to `_yield`
+    // is the original purpose of `renameYieldOutsideGenerators`.
+    const src = `
+const yield = 1;
+console.log(yield);
+    `;
+    const { source } = wrapTest(src);
+    // `yield` is module-mode reserved → must be renamed
+    expect(source).toMatch(/_yield/);
+  });
+
+  it("regression: non-static `* gen()` method still preserves yield", () => {
+    const src = `
+class C {
+  *gen(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("regression: non-static `* #priv()` private generator still preserves yield (#1162)", () => {
+    const src = `
+class C {
+  *#priv(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+
+  it("regression: `static async * gen()` (async generator) still preserves yield", () => {
+    const src = `
+class C {
+  static async *gen(value) {
+    yield * value;
+  }
+}
+    `;
+    const { source } = wrapTest(src);
+    expect(source).toContain("yield * value");
+    expect(source).not.toMatch(/_yield\s*\*/);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -870,13 +870,15 @@ function renameYieldOutsideGenerators(source: string): string {
   // If no generator functions (neither `function*` nor `*method()` syntax),
   // just rename all yield identifiers.
   const hasGeneratorFunction = /\bfunction\s*\*/.test(source);
-  // #1162: include `#` in the identifier class so private generator methods
-  // like `*#gen()` / `async *#gen()` register as generators — otherwise
-  // `yield` inside their body gets renamed to `_yield`, producing
-  // `_yield* obj;` which parses as multiplication and crashes the compiler
-  // with "unexpected undefined AST node in compileExpression" when the
-  // surrounding test is later compiled.
-  const hasGeneratorMethod = /(?:^|[,{;)\s])\s*\*\s*(?:[\w$#]+|\[[\s\S]*?\])\s*\(/.test(source);
+  // #1162 / Task #42: include the same broad identifier class as the
+  // detail-pass `methodRegex` below so the fast-path doesn't misclassify
+  // private/Unicode-named generator methods. Without parity here the
+  // fast path falls through to "rename ALL yield identifiers", clobbering
+  // `yield` inside `static * #\u{6F}()` / `static * #℘()` etc.
+  const hasGeneratorMethod =
+    /(?:^|[,{;)\s])\s*\*\s*(?:(?:[\w$#]|\\u\{[^}]*\}|\\u[0-9a-fA-F]{4}|[\u0080-\uFFFF])+|\[[\s\S]*?\])\s*\(/.test(
+      source,
+    );
   if (!hasGeneratorFunction && !hasGeneratorMethod) {
     return source.replace(/\byield\b/g, "_yield");
   }
@@ -986,13 +988,26 @@ function renameYieldOutsideGenerators(source: string): string {
   }
 
   // Find `*method()` generator method syntax (not caught by function regex).
-  // `[\w$#]+` matches private method names like `#gen` — without `#`,
-  // `*#gen()` isn't recognized as a generator and `yield` inside its body
-  // is incorrectly renamed to `_yield`. (#1162)
-  const methodRegex = /\*\s*(?:[\w$#]+|\[[\s\S]*?\])\s*\(/g;
+  // The identifier class covers the four ways a method name can be written:
+  //   - ASCII identifier chars (`\w$#`) — common case incl. `#gen` private
+  //     names per #1162
+  //   - non-ASCII identifier chars (Unicode letters like `℘`, `ZWNJ`/`ZWJ`
+  //     joiners) — covered by `[\u0080-\uFFFF]`
+  //   - long-form Unicode escape `\u{XXXX}` — covered explicitly
+  //   - short-form Unicode escape `\uXXXX` — covered explicitly
+  // Without these, methods like `static * #\u{6F}(...)` or `static * #℘(...)`
+  // skip the regex match and `yield` in their bodies is incorrectly
+  // renamed to `_yield`, hitting the same 52-test class/elements
+  // ReferenceError cluster as the missing `static` prefix below.
+  const methodRegex = /\*\s*(?:(?:[\w$#]|\\u\{[^}]*\}|\\u[0-9a-fA-F]{4}|[\u0080-\uFFFF])+|\[[\s\S]*?\])\s*\(/g;
   let methodMatch: RegExpExecArray | null;
   while ((methodMatch = methodRegex.exec(source)) !== null) {
-    // Distinguish from multiply operator: check preceding context
+    // Distinguish from multiply operator: check preceding context.
+    // `static` is needed for `static * gen()` / `static * #gen()` class
+    // members — without it, `static * #_(value)` is classified as a
+    // multiply expression and `yield` inside the body is incorrectly
+    // renamed to `_yield`, producing the "_yield is not defined"
+    // ReferenceError at runtime in 52 class/elements test262 cases.
     const before = source.substring(Math.max(0, methodMatch.index - 20), methodMatch.index).trimEnd();
     if (
       !(
@@ -1001,6 +1016,7 @@ function renameYieldOutsideGenerators(source: string): string {
         before.endsWith(";") ||
         before.endsWith(")") ||
         before.endsWith("async") ||
+        before.endsWith("static") ||
         before.length === 0
       )
     ) {


### PR DESCRIPTION
## Summary
Two regex gaps in `renameYieldOutsideGenerators` (test262-runner.ts) caused 52 class/elements tests to fail with `ReferenceError: _yield is not defined`:

1. **Missing `static` prefix** in the method-context check (line ~1003). The allowed-prefix list for `*method()` syntax included `,` `{` `;` `)` `async` and empty — but not `static`. So `static * #_(value)` was misclassified as a multiply expression.

2. **Identifier class too narrow** (lines 879 and 1000) — `[\w$#]+` only matches ASCII word chars, so methods like `static * #\u{6F}(value)` (Unicode escape), `static * #℘(value)` (non-ASCII), or `static * #ZW_‌_NJ(value)` (zero-width chars) skipped the regex match entirely. Fast-path then bailed to "rename all yields" globally.

Fix: add `static` to allowed prefixes; broaden identifier class to `(?:[\w$#]|\\u\{[^}]*\}|\\u[0-9a-fA-F]{4}|[-￿])+`.

## Test plan
- [x] New `tests/test262-runner-static-gen-yield.test.ts` — 10 tests pass (basic static gen, private name, Unicode escape, non-ASCII, zero-width, multiple-stacked, plus 4 regression guards for non-generator and async-generator paths)
- [x] 89 real test262 files matching the failing pattern — all wrap correctly with `yield` preserved (0 false `_yield`)
- [x] `tests/equivalence/private-class-members.test.ts` and `tests/equivalence/generator-methods.test.ts` continue to pass — no regressions
- [ ] CI: full test262 + sharded run (expected +52 passes per task brief)

Refs Task #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)