### PR TITLE
fix(#43): externref object-dstr param path for function expressions

### DIFF
--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -25,6 +25,7 @@ import {
   addFuncType,
   destructureParamArray,
   destructureParamObject,
+  destructureParamObjectExternref,
   ensureExnTag,
   ensureStructForType,
   getArrTypeIdxFromVec,
@@ -1891,7 +1892,20 @@ export function compileArrowAsClosure(
     } else if (ts.isObjectBindingPattern(param.name)) {
       // Object destructuring: function({a, b}) { ... }
       let handled = false;
-      if (paramType.kind === "ref" || paramType.kind === "ref_null") {
+
+      // Externref params (e.g. callback from JS host or `: any`-typed) need
+      // the host-import-driven extraction path that mirrors the array case
+      // above. Without this, the object pattern's binding locals get
+      // allocated but never written, so any code reading w/x/y/z sees the
+      // default-zero/null value of the local instead of the property pulled
+      // off the argument object. (#43 cluster — function-expression dstr
+      // on `any` params)
+      if (paramType.kind === "externref") {
+        destructureParamObjectExternref(ctx, liftedFctx, paramIdx, param.name);
+        handled = true;
+      }
+
+      if (!handled && (paramType.kind === "ref" || paramType.kind === "ref_null")) {
         const typeIdx = paramType.typeIdx;
         const typeDef = ctx.mod.types[typeIdx];
         if (typeDef && typeDef.kind === "struct") {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -74,7 +74,11 @@ import {
   finalizeUnifiedCollector,
   unifiedVisitNode,
 } from "./declarations.js";
-import { destructureParamArray, destructureParamObject } from "./destructuring-params.js";
+import {
+  destructureParamArray,
+  destructureParamObject,
+  destructureParamObjectExternref,
+} from "./destructuring-params.js";
 import {
   emitTestRuntimeStringHelpers,
   ensureNativeStringExternBridge,
@@ -90,6 +94,7 @@ export {
   compileClassBodies,
   destructureParamArray,
   destructureParamObject,
+  destructureParamObjectExternref,
   ensureAnyHelpers,
   ensureAnyValueType,
   ensureNativeStringExternBridge,

--- a/tests/issue-43-fexp-obj-dstr.test.ts
+++ b/tests/issue-43-fexp-obj-dstr.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #43 — Function-expression object destructuring on `any`/externref-typed
+ * params previously dropped the binding extraction entirely, so the
+ * destructured locals stayed at their default zero/null value:
+ *
+ *   const f: any = function ({ w, x }: any) { return w; };
+ *   f({ w: 42, x: 99 });   // returned 0/null/undefined, not 42
+ *
+ * `closures.ts` only routed externref array-pattern params through
+ * `destructureParamArray`; the parallel object-pattern branch was missing.
+ * This affected ~64 test262 tests in
+ * `language/expressions/{function,async-generator,object}/dstr/` whose
+ * harness wraps generic `function ({...})` test bodies, plus the
+ * `*-init-skipped` family that verifies defaults DON'T fire when a
+ * non-undefined value (e.g. `null`, `0`, `false`) is supplied.
+ *
+ * Tests use the test262-style harness (wrapTest) because untyped `f({...})`
+ * calls go through a separate (pre-existing) any-call path that traps with
+ * "illegal cast" — unrelated to the dstr fix. The test262 wrap routes the
+ * call through assert harness functions that side-step that bug.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { wrapTest } from "./test262-runner.js";
+
+async function runWrappedJs(jsSource: string): Promise<unknown> {
+  const wrapped = wrapTest(jsSource, {} as any);
+  const r = compile(wrapped.source, { fileName: "test.ts", allowJs: true });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message ?? "?"}`);
+  const importResult = buildImports(r.imports, undefined, r.stringPool, { globalSandbox: {} });
+  const { instance } = await WebAssembly.instantiate(r.binary, importResult as any);
+  importResult.setExports?.(instance.exports as any);
+  return (instance.exports as any).test();
+}
+
+describe("#43 — function expression with object destructuring on `any` param", () => {
+  it("extracts a single named property from a JS-passed object", async () => {
+    // `var f` mirrors the test262 default/func-expr template.
+    const js = `
+      var captured = 999;
+      var f = function ({ w }) { captured = w; };
+      f({ w: 42, x: 99 });
+      assert.sameValue(captured, 42);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("extracts multiple named properties", async () => {
+    const js = `
+      var cw = 0, cx = 0;
+      var f = function ({ w, x }) { cw = w; cx = x; };
+      f({ w: 1, x: 2 });
+      assert.sameValue(cw, 1);
+      assert.sameValue(cx, 2);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("test262 dstr/obj-ptrn-id-init-skipped.js (function-expression form) passes", async () => {
+    // Direct copy of the test262 default/func-expr.template body. Pre-fix
+    // this returned 2 (assert #1 failed: w !== null). After the fix the
+    // closure body actually extracts properties and matches the spec
+    // semantics — the default `counter()` doesn't fire when `null` is
+    // explicitly supplied (per §13.3.3.7 SingleNameBinding step 6: only
+    // `undefined` triggers the initializer).
+    const js = `
+      var initCount = 0;
+      function counter() {
+        initCount += 1;
+      }
+      var callCount = 0;
+      var f;
+      f = function({ w = counter(), x = counter(), y = counter(), z = counter() }) {
+        assert.sameValue(w, null);
+        assert.sameValue(x, 0);
+        assert.sameValue(y, false);
+        assert.sameValue(z, '');
+        assert.sameValue(initCount, 0);
+        callCount = callCount + 1;
+      };
+      f({ w: null, x: 0, y: false, z: '' });
+      assert.sameValue(callCount, 1, 'function invoked exactly once');
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("renamed property binding works (`{ w: alias }`)", async () => {
+    const js = `
+      var f = function ({ w: alias }) {
+        assert.sameValue(alias, 7);
+      };
+      f({ w: 7 });
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`closures.ts` only routed externref array-pattern params through `destructureParamArray`; the parallel object-pattern branch silently fell through to `allocBindingLocals(...)` which allocates locals but never **writes** them. Any `function ({w, x}: any)`-style declaration therefore destructured to default-zero/null locals.

Repro shape (procedurally generated test262 cases under `language/expressions/{function,async-generator,object}/dstr/`):
```js
var f = function ({ w, x }) { /* ... */ };
f({ w: 42, x: 99 });
```
Pre-fix the closure body's locals 5+ were `i32`, never set; assert calls boxed `f64.convert_i32_s(local.get $5)` which always produced `0`.

Fix mirrors the existing externref array branch: when `paramType.kind === "externref"`, call `destructureParamObjectExternref` to emit the host-import-driven extraction (`__extern_get(obj, "w")` / `__sget_${prop}` fallback), then mark the pattern as handled so the fallback `allocBindingLocals` doesn't redundantly create dead locals.

## Test plan

- [x] `language/expressions/{function,async-generator}/dstr/obj-ptrn-id-init-skipped.js` flips fail → pass (verified locally via `wrapTest` + scoped runner)
- [x] `tests/issue-43-fexp-obj-dstr.test.ts` — 4 new cases:
  - single-property extraction
  - multi-property extraction
  - the test262 `default/func-expr` template body (verifying defaults DON'T fire on `null`/`0`/`false`/`''` values per §13.3.3.7 SingleNameBinding step 6)
  - renamed-property bindings (`{ w: alias }`)
- [x] `pnpm run build` clean
- [x] No regressions in existing destructuring suites: 38 passes; the 3 `null-destructure-param-object.test.ts` failures are pre-existing on `origin/main` (verified by stashing and re-running) — unrelated to this fix

## Note

This PR addresses **one** root cause; the broader #43 cluster (~173 assignment/dstr failures) includes other unrelated issues (rest patterns, iterator close, yield-expr targets, `async-gen-meth` synchronous param-throw on extracted prototype methods which is itself blocked on the #1394 method-closure caching gap from the #41 escalation) that need separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)