### PR TITLE
fix(#1396): for-of/dstr defaults fire on OOB extern-array reads (Task #50)

### DIFF
--- a/plan/issues/sprints/51/1396-forof-dstr-externref-array-default.md
+++ b/plan/issues/sprints/51/1396-forof-dstr-externref-array-default.md
@@ -1,0 +1,192 @@
+---
+id: 1396
+sprint: 51
+title: "for-of/dstr + assignment/dstr default initializers don't fire on OOB extenref-array reads"
+status: ready
+created: 2026-05-09
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring, iteration
+goal: spec-completeness
+---
+# #1396 — Destructuring defaults skipped for OOB extern-array reads
+
+## Problem
+
+Destructuring with default initializers (`[x = 23]` / `[a, b = 99]`) does
+not fire the default for out-of-bounds reads when the source is an
+`any[]`/extern-typed array. The default fires correctly for typed
+`number[]` arrays.
+
+Affects ~320 test262 fails in `language/statements/for-of/dstr/` (the
+canonical bucket triaged for task #50) and is the same root cause for
+~171 additional `language/expressions/assignment/dstr/` fails.
+
+Sample failing test pattern (sourced from
+`var-ary-ptrn-elem-id-init-exhausted.js`):
+
+```js
+var iterCount = 0;
+for (var [x = 23] of [[]]) {
+  assert.sameValue(x, 23);   // FAILS — x is null/0, not 23
+  iterCount += 1;
+}
+assert.sameValue(iterCount, 1);
+```
+
+Direct-destructuring reproducer (no for-of involved):
+
+```ts
+const arr: any[] = [];
+const [x = 23] = arr;   // x ends up `0` (the f64 default), not `23`
+```
+
+## Root cause
+
+`emitBoundsCheckedArrayGet`
+(`src/codegen/array-methods.ts:180`) emits a Wasm `if` that pushes
+`defaultValueInstrs(elementType)` on the OOB else branch. For
+externref arrays this is `ref.null.extern` — i.e. **JS `null`**.
+
+The destructuring-default check
+(`emitExternrefDefaultCheck`,
+`src/codegen/statements/destructuring.ts:185`) then routes through the
+`__extern_is_undefined` host import, which is implemented as
+`(v) => v === undefined ? 1 : 0` (`src/runtime.ts:2343`). Per spec
+§13.7.5.5, destructuring defaults fire **only** when the value is
+`undefined`, not when it is `null`. The runtime helper is correct;
+however, the OOB sentinel emitted by `emitBoundsCheckedArrayGet` should
+represent the spec's "absent" state (JS `undefined`), not a JS `null`
+value.
+
+A targeted reproducer compiles to (relevant slice from generated WAT):
+
+```wasm
+i32.const 0
+local.get $boundsArr  ;; data array, len=0
+array.len             ;; -> 0
+i32.lt_u              ;; idx < len? -> 0 (false)
+(if (result externref)
+  (then
+    local.get $boundsArr
+    i32.const 0
+    array.get 0
+  )
+  (else
+    ref.null extern   ;; <-- BUG: should be JS undefined, not JS null
+  )
+)
+local.tee $tmp
+call $__extern_is_undefined  ;; null != undefined → returns 0
+(if
+  (then  ;; default branch: x = 23
+    f64.const 23
+    call $__box_number
+    local.set $x
+  )
+  (else  ;; existing-value branch: x = null
+    local.get $tmp
+    local.set $x
+  )
+)
+```
+
+The `__extern_is_undefined` returns 0 for the `ref.null.extern` sentinel
+and the default branch never fires.
+
+## Acceptance criteria
+
+1. `const [x = 23]: any[] = []` produces `x === 23`.
+2. `for (const [x = 23] of [[]] as any[][]) { ... }` produces `x === 23`
+   and runs the body once.
+3. `for (const [a, b = 99] of [[1]] as any[][]) { ... }` produces
+   `a === 1` and `b === 99`.
+4. Object destructuring on missing keys still triggers defaults
+   (`const {a = 1}: {a?: number} = {}` → `a === 1`).
+5. `null` values continue to bypass defaults
+   (`const [x = 23] = [null]` → `x === null`, NOT 23) — spec §13.7.5.5.
+6. No regression in existing array-methods tests that depend on the
+   current `defaultValueInstrs(externref) === ref.null.extern` shape.
+
+## Implementation plan
+
+Two code paths to fix:
+
+### Path A — `emitBoundsCheckedArrayGet` (most general)
+
+Add an optional `ctx` parameter; when present AND `elementType` is
+`externref`/`ref_extern`, emit a `call $__get_undefined` for the OOB
+else-branch instead of `ref.null.extern`. `ensureGetUndefined` already
+exists in `src/codegen/expressions/late-imports.ts:173`.
+
+```ts
+export function emitBoundsCheckedArrayGet(
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: ValType,
+  ctx?: CodegenContext,
+): void {
+  // ... existing setup ...
+  let elseInstrs: Instr[];
+  if (ctx && (elementType.kind === "externref" || elementType.kind === "ref_extern")) {
+    const undefIdx = ensureGetUndefined(ctx);
+    elseInstrs = undefIdx !== undefined
+      ? [{ op: "call", funcIdx: undefIdx } as Instr]
+      : defaultValueInstrs(elementType);
+  } else {
+    elseInstrs = defaultValueInstrs(elementType);
+  }
+  // ... rest unchanged ...
+}
+```
+
+Then update the four call sites in `src/codegen/statements/loops.ts`
+(for-of array destructuring at lines ~1017, ~1090) and
+`src/codegen/statements/destructuring.ts` (plain array destructuring +
+externref-array path) to pass `ctx`.
+
+Other call sites (`array-methods.ts` non-destructuring uses) leave
+`ctx` undefined and keep current behavior.
+
+### Path B (alternative) — runtime fix
+
+Change `__extern_is_undefined` to also return 1 for `null`. Spec-wrong
+but matches the failing pattern. **Not recommended** — would break
+spec compliance for `[x = 23] = [null]`.
+
+### Path A is preferred
+
+It targets the OOB sentinel at the source, leaves runtime
+spec-compliant, and doesn't change behavior for non-OOB null-valued
+elements.
+
+## Test plan
+
+Tests to add in `tests/issue-1396.test.ts`:
+- `const [x = 23]: any[] = []` → `x === 23`
+- `const arr: any[] = []; const [x = 23] = arr` → `x === 23`
+- `for (const [x = 23] of [[]] as any[][])` → `x === 23`, iterates once
+- `for (const [a, b = 99] of [[1]] as any[][])` → `a === 1, b === 99`
+- Regression: `const [x = 23] = [null] as any[]` → `x === null` (spec)
+- Regression: `const [x = 23] = [42] as any[]` → `x === 42`
+
+Then re-run for-of/dstr cluster: target +200 to +320 passes.
+
+## Files to modify
+
+- `src/codegen/array-methods.ts` (line ~180) — add optional `ctx` parameter
+- `src/codegen/statements/loops.ts` (lines ~1017, ~1090) — pass `ctx`
+- `src/codegen/statements/destructuring.ts` (any direct call sites for
+  `emitBoundsCheckedArrayGet` in destructuring paths) — pass `ctx`
+
+## Estimated impact
+
+- ~320 fails in `language/statements/for-of/dstr/` (task #50)
+- ~171 fails in `language/expressions/assignment/dstr/` (related cluster)
+- Possibly more in `for-await-of/dstr` (~similar pattern)
+
+Combined: 400-500 net test262 passes if all extern-array OOB cases
+share this root cause.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -23,7 +23,7 @@ import {
   registerEmitBoundsCheckedArrayGet,
   VOID_RESULT,
 } from "./shared.js";
-import { emitUndefined } from "./expressions/late-imports.js";
+import { emitUndefined, ensureGetUndefined } from "./expressions/late-imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ensureTimsortHelper } from "./timsort.js";
 import { coerceType, coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
@@ -176,14 +176,39 @@ function isReceiverNonNull(expr: ts.Expression, checker: ts.TypeChecker): boolea
  * Emit a bounds-checked array.get.  Stack must contain [arrayref, i32 index].
  * If the index is out of bounds (< 0 or >= array.len), a default value for the
  * element type is produced instead of trapping.
+ *
+ * #1396 — `useUndefinedSentinel` (default false): when true AND `elementType`
+ * is `externref`/`ref_extern`, the OOB else-branch pushes the JS `undefined`
+ * value (via `__get_undefined` host import) instead of `ref.null.extern`.
+ * Required by destructuring callers — JS spec §13.7.5.5 fires defaults only
+ * for `undefined`, not for `null`, and `ref.null.extern` surfaces to JS as
+ * `null` causing `__extern_is_undefined` to return 0 → default never fires
+ * for OOB extern-array reads (~320 fails in `for-of/dstr`, ~171 in
+ * `assignment/dstr`).
  */
-export function emitBoundsCheckedArrayGet(fctx: FunctionContext, arrTypeIdx: number, elementType: ValType): void {
+export function emitBoundsCheckedArrayGet(
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: ValType,
+  ctx?: CodegenContext,
+  useUndefinedSentinel = false,
+): void {
   // Save index and array ref to locals so we can use them in both branches
   const idxLocal = allocLocal(fctx, `__bounds_idx_${fctx.locals.length}`, { kind: "i32" });
   const arrLocal = allocLocal(fctx, `__bounds_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
 
   fctx.body.push({ op: "local.set", index: idxLocal }); // save index
   fctx.body.push({ op: "local.set", index: arrLocal }); // save array ref
+
+  // (#1396) When the destructuring caller asked for an undefined sentinel and
+  // the element type is externref-shaped, register the `__get_undefined`
+  // import BEFORE building the if-block so its funcIdx is stable and any
+  // index-shifts have already been flushed into the current function body.
+  let undefinedFuncIdx: number | undefined;
+  if (useUndefinedSentinel && ctx && (elementType.kind === "externref" || elementType.kind === "ref_extern")) {
+    undefinedFuncIdx = ensureGetUndefined(ctx);
+    if (undefinedFuncIdx !== undefined) flushLateImportShifts(ctx, fctx);
+  }
 
   // Condition: idx >= 0 && idx < array.len(arr)
   // We use: (unsigned)idx < array.len — this handles negative indices too
@@ -200,8 +225,12 @@ export function emitBoundsCheckedArrayGet(fctx: FunctionContext, arrTypeIdx: num
     { op: "array.get", typeIdx: arrTypeIdx } as Instr,
   ];
 
-  // Build the "else" branch: out-of-bounds -> default value
-  const elseInstrs: Instr[] = defaultValueInstrs(elementType);
+  // Build the "else" branch: out-of-bounds -> default value (or JS undefined
+  // when the destructuring caller opted in via `useUndefinedSentinel`).
+  const elseInstrs: Instr[] =
+    undefinedFuncIdx !== undefined
+      ? [{ op: "call", funcIdx: undefinedFuncIdx } as Instr]
+      : defaultValueInstrs(elementType);
 
   // When the element type is a non-null ref, the else branch produces ref.null
   // which is ref_null. Use ref_null as the block type so both branches validate,

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -135,7 +135,13 @@ export function compileArrowAsClosure(
 
 // ── emitBoundsCheckedArrayGet ─────────────────────────────────────────
 
-type EmitBoundsCheckedArrayGetFn = (fctx: FunctionContext, arrTypeIdx: number, elementType: ValType) => void;
+type EmitBoundsCheckedArrayGetFn = (
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: ValType,
+  ctx?: CodegenContext,
+  useUndefinedSentinel?: boolean,
+) => void;
 
 let _emitBoundsCheckedArrayGet: EmitBoundsCheckedArrayGetFn = () => {
   throw new Error("emitBoundsCheckedArrayGet not yet registered");
@@ -145,8 +151,14 @@ export function registerEmitBoundsCheckedArrayGet(fn: EmitBoundsCheckedArrayGetF
   _emitBoundsCheckedArrayGet = fn;
 }
 
-export function emitBoundsCheckedArrayGet(fctx: FunctionContext, arrTypeIdx: number, elementType: ValType): void {
-  _emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType);
+export function emitBoundsCheckedArrayGet(
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: ValType,
+  ctx?: CodegenContext,
+  useUndefinedSentinel?: boolean,
+): void {
+  _emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType, ctx, useUndefinedSentinel);
 }
 
 // ── resolveEnclosingClassName ─────────────────────────────────────────

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1087,7 +1087,15 @@ function compileForOfDestructuring(
         fctx.body.push({ op: "local.get", index: elemLocal });
         fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 1 });
         fctx.body.push({ op: "i32.const", value: i });
-        emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
+        // (#1396) Pass `useUndefinedSentinel: true` when this element has a
+        // default initializer AND the source-array element type is externref.
+        // The OOB else-branch must produce JS `undefined` (not `null`) so
+        // `emitDefaultValueCheck` → `__extern_is_undefined` returns 1 and
+        // the initializer fires for empty/short arrays.
+        const wantUndefinedSentinel =
+          element.initializer !== undefined &&
+          (innerElemType.kind === "externref" || innerElemType.kind === "ref_extern");
+        emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType, ctx, wantUndefinedSentinel);
 
         if (!valTypesMatch(innerElemType, bindingWasmType)) {
           coerceType(ctx, fctx, innerElemType, bindingWasmType);

--- a/tests/issue-1396.test.ts
+++ b/tests/issue-1396.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+describe("#1396 — for-of/dstr defaults fire on OOB extern-array reads (Task #50)", () => {
+  async function runTest(src: string): Promise<{ pass: boolean; ret?: unknown; error?: string }> {
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    if (!result.success) return { pass: false, error: result.error };
+    const importObj = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
+    if (typeof (importObj as any).setExports === "function") {
+      (importObj as any).setExports(instance.exports);
+    }
+    try {
+      const ret = (instance.exports as any).test();
+      return { pass: ret === 1, ret };
+    } catch (e: any) {
+      return { pass: false, error: String(e) };
+    }
+  }
+
+  it("for-of any[][]: const [x = 23] of [[]] uses default 23", async () => {
+    const src = `
+      export function test(): number {
+        const data: any[][] = [[]];
+        let xVal = -1;
+        for (const [x = 23] of data) {
+          xVal = x;
+        }
+        return xVal === 23 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("for-of any[][]: real value wins over default", async () => {
+    const src = `
+      export function test(): number {
+        const data: any[][] = [[100]];
+        let xVal = -1;
+        for (const [x = 23] of data) {
+          xVal = x;
+        }
+        return xVal === 100 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("for-of any[][]: multi-element with default for missing trailing element", async () => {
+    const src = `
+      export function test(): number {
+        const data: any[][] = [[5]];
+        let aVal = -1, bVal = -1;
+        for (const [a, b = 99] of data) {
+          aVal = a; bVal = b;
+        }
+        return aVal === 5 && bVal === 99 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("spec regression: [null] should NOT trigger default (defaults fire only for undefined)", async () => {
+    // Per ECMA-262 §13.7.5.5 — destructuring defaults fire only when the
+    // value is `undefined`, not `null`. Our fix uses JS `undefined` (via
+    // `__get_undefined`) for OOB sentinels but preserves `null` semantics
+    // for actual null values in the array.
+    const src = `
+      export function test(): number {
+        const data: any[][] = [[null]];
+        let xVal: any = -1;
+        for (const [x = 23] of data) {
+          xVal = x;
+        }
+        return xVal === null ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("regression: number[][] (vec with f64 elements) still works via sNaN sentinel", async () => {
+    const src = `
+      export function test(): number {
+        const data: number[][] = [[]];
+        let xVal = -1;
+        for (const [x = 23] of data) {
+          xVal = x;
+        }
+        return xVal === 23 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("regression: number[][] with multi-element default", async () => {
+    const src = `
+      export function test(): number {
+        const data: number[][] = [[5]];
+        let aVal = -1, bVal = -1;
+        for (const [a, b = 99] of data) {
+          aVal = a; bVal = b;
+        }
+        return aVal === 5 && bVal === 99 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+
+  it("for-of any[][]: counter increments correctly (loop body runs)", async () => {
+    // Mirrors test262 var-ary-ptrn-elem-id-init-exhausted.js pattern
+    const src = `
+      export function test(): number {
+        const data: any[][] = [[]];
+        let count = 0;
+        let xVal = -1;
+        for (const [x = 23] of data) {
+          xVal = x;
+          count++;
+        }
+        return count === 1 && xVal === 23 ? 1 : 0;
+      }
+    `;
+    const { pass, error } = await runTest(src);
+    expect(error).toBeUndefined();
+    expect(pass).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Triaged the 320-fail for-of/dstr cluster (task #50). Root cause: when destructuring an extern-typed array (`any[][]`) with a default initializer and the source has fewer elements than the binding pattern, the OOB sentinel was JS `null` instead of JS `undefined`. Per ECMA-262 §13.7.5.5 destructuring defaults fire only for `undefined` — `__extern_is_undefined(null) === 0` so the default never triggered.

```ts
const data: any[][] = [[]];
for (const [x = 23] of data) {  // x ended up null/0 instead of 23
  // ...
}
```

Fix: extend `emitBoundsCheckedArrayGet` with optional `ctx` + `useUndefinedSentinel` params. When opted in AND the element type is extern, emit `call $__get_undefined` for the OOB else-branch instead of `ref.null.extern`. Then `__extern_is_undefined` returns 1 and defaults fire.

Surgical scope: only `compileForOfDestructuring` opts in. Non-destructuring callers (Array methods etc.) keep current behavior.

Spec correctness preserved: `[null]` (real null in source array) does NOT trigger default — only the synthetic OOB position uses undefined. Verified by regression test.

## Test plan
- [x] New `tests/issue-1396.test.ts` — 7 cases, all pass:
  - for-of `any[][]`: `[x = 23] of [[]]` → 23
  - for-of `any[][]`: real value wins over default
  - for-of `any[][]`: multi-element default
  - spec regression: `[null]` does not trigger default
  - regression: `number[][]` (sNaN path) still works
  - regression: `number[][]` multi-element default
  - counter increments correctly
- [x] `tests/equivalence/for-of-basic.test.ts` and `for-of-array-destructuring.test.ts` pass — no regression
- [x] Pre-existing failures in `destructuring-initializer.test.ts` and `destructuring-extended.test.ts` are unchanged on origin/main (verified)
- [ ] CI: full test262 + sharded run (target ~320 in `for-of/dstr` + likely some in `assignment/dstr`)

Issue file: `plan/issues/sprints/51/1396-forof-dstr-externref-array-default.md`

Refs Task #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)