### PR TITLE
plan(s53): architect review for #1559 + revised #1560 spec

### DIFF
--- a/plan/issues/sprints/53/1559-resolver-bare-package-import-prefer-impl-over-dts-for-codegen.md
+++ b/plan/issues/sprints/53/1559-resolver-bare-package-import-prefer-impl-over-dts-for-codegen.md
@@ -324,3 +324,138 @@ status: needs-spec  →  status: ready
 feasibility: hard   →  feasibility: medium
 reasoning_effort: max →  reasoning_effort: high
 ```
+
+---
+
+## Architect review — 2026-05-20 (confirmation pass)
+
+Re-read `src/resolve.ts` end-to-end against the spec above. Findings:
+
+### Confirmations
+
+1. **Decision point verified.** The redirect is at `src/resolve.ts:155`
+   inside `ModuleResolver.resolve()`. The current trigger
+   `/[/\\]@types[/\\]/.test(resolved)` is the ONLY mechanism for
+   switching from a `.d.ts` to an implementation body. Extending the
+   condition with `|| resolved.endsWith(".d.ts")` is the minimal
+   correct fix.
+
+2. **`findImplementationBody` is callsite-safe for bare specifiers.**
+   For `specifier === "eslint"` and `pkgName === "eslint"`,
+   `afterPkg === ""` and `probeImplementationPath` reads
+   `pkg.module ?? pkg.main` (line 255). ESLint's `package.json`
+   has `main: "./lib/api.js"` (no `module`), so we get
+   `.../node_modules/eslint/lib/api.js`, which is exactly the impl
+   entry the package author marked as canonical.
+
+3. **The walk-up algorithm correctly handles the entry-outside-pkg
+   case.** `containingFile` here is the user's `entry.ts` (e.g.
+   `/workspace/entry.ts`). The walk-up loop hits
+   `/workspace/node_modules/eslint`, `stat`s the dir, and probes
+   the impl path. No pnpm / hoisting wrinkle — ESLint is a regular
+   top-level dependency.
+
+4. **Resolve cache invariance.** `this.resolveCache` is keyed by
+   `${containingFile}::${specifier}`. The redirect happens before
+   caching (line 163), so subsequent resolutions return the impl
+   path consistently. No stale-`.d.ts` risk.
+
+### Clarifications (call out to the implementer)
+
+1. **The fix is a single conjunctive extension, not a new code path.**
+   Do NOT introduce a parallel `if (resolved.endsWith(".d.ts"))`
+   branch. Keep the `findImplementationBody` call shared so future
+   changes to the impl-finding logic apply to both triggers.
+
+2. **`pkgName` MUST be non-null.** `getBarePackageName` returns
+   `null` for relative/absolute paths. Relative imports like
+   `import "./types.d.ts"` (rare but legal) MUST NOT be redirected
+   — they are file-local references the user explicitly wrote, and
+   we have no `node_modules/<pkgName>` to probe. The existing
+   guard `if (pkgName && ...)` already covers this; the
+   `.d.ts`-suffix extension goes INSIDE that pkgName guard.
+
+3. **Subpath specifiers with declaration-only entries
+   (e.g. `eslint/rules`).** Looking at the ESLint `exports` map:
+   `"./rules": { "types": "./lib/types/rules.d.ts" }` — there is
+   NO `default` condition. If a consumer writes
+   `import x from "eslint/rules"`, TS resolves to
+   `lib/types/rules.d.ts`, we trigger the redirect, then
+   `probeImplementationPath` tries the direct path
+   `lib/types/rules` — which does not exist as `.js`/`.mjs`/`.cjs`.
+   It returns `null`, and we keep the `.d.ts`. The fallback chain
+   is correct — declaration-only subpaths gracefully degrade to
+   extern, no regression. Add a regression test case for this
+   (test plan case 7 below).
+
+4. **Tier 1a stress test currently passes without the fix.**
+   Re-read `tests/stress/eslint-tier1.test.ts:70-87`: Tier 1a
+   asserts `r.success === true`. ESLint compiles successfully today
+   because `__new_Linter` extern is added as a fallback. The
+   assertion that catches the bug is the absence of `__new_Linter`
+   in `r.imports`. Add this assertion to Tier 1a (and Tier 1b) as
+   part of the fix — this is the regression gate.
+
+### Updated test plan — extra cases
+
+Add to the existing six cases:
+
+7. **Declaration-only subpath (regression guard for ESLint
+   `./rules`-style exports).** Fixture:
+   ```
+   package.json: {
+     "exports": {
+       ".": { "types": "./types.d.ts", "default": "./impl.js" },
+       "./decls": { "types": "./decls.d.ts" }
+     }
+   }
+   decls.d.ts: export declare const x: number;
+   ```
+   Compile entry with `import { x } from "foo/decls"`. Assert:
+   resolves to `decls.d.ts` (extern fallback), `r.success` is true.
+   This pins the "subpath has no impl → keep `.d.ts`" behavior.
+
+8. **`module` field preferred over `main` (regression guard).**
+   Fixture with `package.json: { "main": "./cjs.js", "module":
+   "./esm.mjs" }`. Compile entry with `import x from "foo"`.
+   Assert resolved file is `esm.mjs`. (Already covered by
+   `probeImplementationPath` line 255; this test pins behavior.)
+
+### Regression gate (run before merge)
+
+The implementer MUST run these locally and verify all pass:
+
+```bash
+npm test -- tests/resolve.test.ts
+npm test -- tests/import-resolver.test.ts
+npm test -- tests/issue-1060.test.ts      # if present
+npm test -- tests/issue-1287.test.ts      # if present
+npm test -- tests/issue-1559.test.ts      # new
+npm test -- tests/issue-1560.test.ts      # positive regression guard
+npm test -- tests/stress/lodash-tier1.test.ts
+npm test -- tests/stress/lodash-tier2.test.ts
+npm test -- tests/stress/hono-tier1.test.ts
+npm test -- tests/stress/hono-tier5.test.ts   # class App with method re-exports
+npm test -- tests/stress/eslint-tier1.test.ts # Tier 1a/1b must still pass
+```
+
+The Hono Tier 5 and lodash Tier 1/2 tests are the strongest gates
+— they exercise real npm packages with self-typed declarations and
+will surface any over-eager redirect.
+
+### One last sanity check — `.d.ts` in user source
+
+If a user has a hand-written `.d.ts` inside their own project
+(e.g. `src/types/foo.d.ts`) and imports it relatively
+(`import { X } from "./types/foo"`), the resolved path will end in
+`.d.ts` BUT `pkgName` will be `null` (relative specifier). The
+`pkgName &&` guard already excludes this case. **No regression.**
+
+If the same user has `node_modules/foo/index.d.ts` (a
+declaration-only dependency), the redirect fires, `pkg.main` is
+absent (only `types` field), `probeImplementationPath` falls back
+to `index.{js,mjs,cjs,ts}` probes (line 270-274), finds nothing,
+returns `null`, and we keep the `.d.ts`. **No regression.**
+
+The spec is approved. Flip frontmatter to `status: ready`,
+`feasibility: medium`, `reasoning_effort: high`.

--- a/plan/issues/sprints/53/1560-cjs-class-reexport-link-to-compiled-class.md
+++ b/plan/issues/sprints/53/1560-cjs-class-reexport-link-to-compiled-class.md
@@ -192,3 +192,153 @@ Until #1559 lands, this issue cannot be confirmed live. The current
 regression test in `tests/issue-1560.test.ts` remains as a positive
 guard for local-file CJS class re-exports — that pattern must
 continue to work.
+
+---
+
+## Implementation Plan
+
+### Root cause (revised after 2026-05-20 finding)
+
+The local-file CJS class re-export chain ALREADY WORKS on current
+main (`leaf.js → middle.js → entry.ts` with `module.exports =
+{ Foo }` at every hop). `tests/issue-1560.test.ts` confirms this
+end-to-end: `r.imports` has no `__new_Foo` extern and `new
+Foo().hello()` returns 42.
+
+The originally observed symptom (`__new_Linter` in `r.imports`
+after `import { Linter } from "eslint"`) is **caused by the #1559
+resolver bug**: TypeScript's `ts.resolveModuleName` picks
+ESLint's `./lib/types/index.d.ts` (the `types` condition of the
+`exports` map) and codegen receives a `.d.ts` file as if it were
+the implementation. The `.d.ts` only contains `declare class
+Linter`, so codegen falls through to extern. The CJS re-export
+plumbing is never exercised in the ESLint path.
+
+### Action — DEFER, GATE ON #1559
+
+This issue is **gated entirely on #1559**. No code change is
+proposed under #1560 until we have empirical evidence that
+something is still broken after #1559 lands.
+
+### Procedure (executed after #1559 merges)
+
+1. **Confirm #1559 is merged on main** (commit landed,
+   `tests/issue-1559.test.ts` green in CI).
+
+2. **Smoke-test ESLint Tier 1a with the resolver fix in place:**
+   ```bash
+   cd /workspace
+   npm test -- tests/stress/eslint-tier1.test.ts
+   ```
+   If Tier 1a's new assertion (`r.imports` does NOT contain
+   `__new_Linter`) is green → the residual bug imagined by #1560
+   does not exist. Close #1560 as "covered by #1559" with a
+   reference to the merged PR.
+
+3. **If `__new_Linter` is still present after #1559:** the
+   residual bug IS in the bare-package CJS class re-export hop.
+   Reopen / proceed with the investigation below.
+
+### If reopened — investigation steps
+
+The reduced repro that already passes uses **relative-path**
+imports. The failing case (hypothetically) would use
+**bare-package + `node_modules`-resolved** paths. Differences to
+probe:
+
+1. **Module key normalization.** When resolveAllImports
+   (`src/resolve.ts:360`) populates the `Map<string, string>`,
+   relative-path repros end up with file paths under the entry's
+   directory; `node_modules` paths end up under the package's
+   own directory. The `module.exports` lowering keys exports by
+   absolute file path. If the consumer's TypeScript-resolved path
+   (`.../node_modules/eslint/lib/api.js`) differs from the path
+   recorded by `resolveAllImports` (e.g. via symlink resolution
+   in `host.realpath`), the binding lookup misses.
+   - **Check**: log `allFiles.keys()` and the resolver output for
+     `eslint` next to each other and assert path equality
+     (compare via `path.resolve` AND `fs.realpathSync`).
+
+2. **CJS rewrite scope.** `rewriteCjsRequire` (line 381 of
+   resolve.ts) is applied to ALL files including those under
+   `node_modules`. Confirm that `eslint/lib/api.js`'s
+   `module.exports = { Linter, ... }` pattern is rewritten the
+   same way the reduced repro's `pkg/leaf.js` is rewritten.
+   - **Check**: dump `rewriteCjsRequire(fs.readFileSync(
+     ".../node_modules/eslint/lib/api.js", "utf-8"))` and diff
+     against the test fixture's `module.exports = { Foo }` after
+     rewrite.
+
+3. **Multi-hop re-export depth.** ESLint's chain is three hops
+   (`api.js` → `linter/index.js` → `linter/linter.js`), the
+   reduced repro is two hops (`middle.js` → `leaf.js`). If the
+   class identity survives the first hop but not the second, the
+   issue is hop-count related.
+   - **Check**: extend `tests/issue-1560.test.ts` with a
+     three-hop variant (`leaf.js` → `mid1.js` → `mid2.js` →
+     `entry.ts`). If this still passes locally but the ESLint
+     case fails, the bug is bare-package specific (e.g. a
+     `node_modules` path-normalization quirk).
+
+4. **`.d.ts` ambient declaration interference.** Even after
+   #1559 redirects codegen to `lib/api.js`, the TypeScript
+   checker still sees `lib/types/index.d.ts`. If type info from
+   the `.d.ts` shadows the class type from `api.js` in the
+   binding table, the class identity is lost during binding
+   resolution.
+   - **Check**: grep `src/codegen/index.ts` for places where
+     binding lookup consults the type-checker's class shape
+     versus the runtime export shape. If they disagree, the
+     `.d.ts`-derived shape is winning.
+
+### If the bug is real — proposed fix locations
+
+(These are exploratory pointers. Do NOT implement until step 3
+above confirms the bug exists.)
+
+- `src/codegen/index.ts` — the module-export propagation logic
+  for CJS re-exports. Search for `module.exports`,
+  `exportBindings`, or `cjsExports` to find where the binding
+  table is populated from `module.exports = { Foo }` patterns.
+- `src/cjs-rewrite.ts` — the AST rewrite that turns
+  `module.exports = { Foo }` into ESM-equivalent
+  `export { Foo }`. Verify that bare-package paths produce
+  identical output to relative paths.
+
+### Acceptance criteria (only relevant if reopened)
+
+1. Three-hop class re-export from a `node_modules`-resolved
+   bare-package import produces no `__new_Linter` (or
+   `__new_Foo` in the synthetic case) in `r.imports`.
+2. ESLint Tier 1a `r.imports` has no `__new_Linter`.
+3. The existing local-file repro in `tests/issue-1560.test.ts`
+   continues to pass.
+
+### Regression gate
+
+Even though no code change is proposed pre-#1559, when this
+issue's status is finalized (closed or fixed) run:
+
+```bash
+npm test -- tests/issue-1560.test.ts
+npm test -- tests/stress/eslint-tier1.test.ts
+npm test -- tests/stress/lodash-tier1.test.ts
+npm test -- tests/stress/lodash-tier2.test.ts
+npm test -- tests/stress/hono-tier5.test.ts   # class App method re-exports
+```
+
+### Frontmatter changes
+
+Apply now (independent of #1559 outcome):
+
+```yaml
+status: ready → blocked
+depends_on: [1559]   # already present, keep
+```
+
+Apply after #1559 merges (depending on outcome):
+
+- If ESLint Tier 1a is clean → `status: blocked → done` with
+  resolution `covered-by: 1559`.
+- If `__new_Linter` still appears → `status: blocked → ready`
+  and dispatch a dev to execute the investigation above.


### PR DESCRIPTION
## Summary

Architect specs for ESLint Tier 1e unblockers (#1559 + #1560).

- **#1559** — confirmation pass on the existing implementation plan in `src/resolve.ts`. Verified decision point (line 155), `findImplementationBody` callsite-safety for bare specifiers, walk-up algorithm correctness, and resolve-cache invariance. Added clarifications for declaration-only subpaths (ESLint's `./rules` pattern → graceful fallback to extern), relative `.d.ts` imports (excluded by `pkgName` guard), and the declaration-only top-level case. Extended the test plan with two new cases. Documented the regression-gate command list and noted that Tier 1a needs a new `no __new_Linter in r.imports` assertion to actually catch the bug today.
- **#1560** — rewrote the Implementation Plan to reflect the 2026-05-20 finding that the local-file CJS class re-export pattern (`leaf.js` → `middle.js` → `entry.ts`) already works on `main`. The ESLint failure is downstream of the #1559 resolver bug. Recommended action: defer #1560, gate on #1559 merging, then close as `covered-by: 1559` if `__new_Linter` no longer appears in `r.imports`. Investigation steps and proposed fix locations included for the residual-bug case.

No source code changes — pure planning artifacts.

## Test plan
- [x] Both spec files staged with additions only (no deletions, 285 lines added across 2 files)
- [x] No source changes; CI should be a no-op for compile/test stages
- [x] Frontmatter changes are documented in the spec but NOT applied in this PR — PO/tech lead will flip `status:` after dispatch