### PR TITLE
plan(#1553): architect specs for sub-issues 1553a-e (decl-destructuring residuals)

### DIFF
--- a/plan/issues/sprints/52/1553-spec-gap-declaration-destructuring-residuals.md
+++ b/plan/issues/sprints/52/1553-spec-gap-declaration-destructuring-residuals.md
@@ -2,7 +2,7 @@
 id: 1553
 sprint: 52
 title: "spec gap: let/const/var destructuring declarations — residuals after #1432/#1450/#1454/#1550"
-status: needs-spec
+status: decomposed
 created: 2026-05-20
 investigated: 2026-05-20
 priority: medium
@@ -354,3 +354,52 @@ without the matching fix to default-struct destructure semantics, and
 
 Worktree `/workspace/.claude/worktrees/issue-1553-dstr-residuals` is
 clean (no commits) and can be removed.
+
+## Architect spec 2026-05-20 (arch-1553b) — DECOMPOSED
+
+Confirmed the 5-sub-issue decomposition and wrote per-sub implementation
+plans. The slicing follows the dev's investigation but refines bug-to-slice
+mapping. Sub-issue files live in `plan/issues/sprints/53/`:
+
+| Sub | Title | Depends | LOC delta | Bugs closed |
+| --- | --- | --- | --- | --- |
+| **1553a** | Add `decl` mode + `bindingKind` opts to `destructureParamObject`/`Array` helpers (foundation, additive) | — | +150 | (none — plumbing only) |
+| **1553b** | Route typed-struct object decl path through helper (decl-mode) | 1553a | −260 | bug 3 (typed nested default), bug 2 partial |
+| **1553c** | Route externref-fallback object decl path through helper (decl-mode) | 1553a, 1553b | −130 | bug 1, bug 2, bug 4, bug 8 |
+| **1553d** | Route array decl path (typed-vec + externref) through `destructureParamArray` | 1553a, 1553c | −890 | bug 6 (vec rest), array-side bug 4, iter-close |
+| **1553e** | f64 array literal with explicit `undefined` must trigger destructuring default | — | +30 | bug 5 (independent of helper) |
+
+### Sequencing
+
+1. **1553a first** — additive, no behaviour change, unblocks everything.
+2. **1553b** — smallest behaviour-change PR, validates the decl-mode
+   plumbing on the typed-struct lane (lowest risk surface).
+3. **1553c** — externref decl object path; closes the "structural
+   blocker" (bug 2 — `__extern_get` on WasmGC struct) via the
+   helper's `ref.test`+`ref.cast` fast path.
+4. **1553d** — array decl paths; largest deletion (~890 LOC), highest
+   review burden but most unlock (≥35 test262 cases).
+5. **1553e** — orthogonal; can land any time, independent of 1553a-d.
+
+### Total expected unlock
+
+- 1553b: ≥18 cases
+- 1553c: ≥24 cases (after #1552 lands)
+- 1553d: ≥35 cases
+- 1553e: ~8-12 cases
+- **Total: ~85-100 case flips**, comfortably meeting the
+  acceptance criterion 6 (≥60 case reduction).
+
+Dependency on sibling issues:
+
+- **#1450** (NamedEvaluation): in-review. 1553b/c inherit the fix
+  automatically once #1450 lands in main.
+- **#1454** (iterator protocol): partially merged. 1553d depends on
+  `__array_from_iter` + `__extern_get_idx` host imports being stable.
+- **#1552** (catch-rest): in-review. 1553c's rest-binding fix
+  consumes the corrected `__extern_rest_object` host semantics
+  once #1552 lands.
+
+This issue (#1553) stays `needs-spec` → flip to `status: decomposed`
+on merge; close when 1553a-e are all `done` and the test262 delta
+on `language/statements/{let,const,variable}/dstr/` is ≥ 60.

--- a/plan/issues/sprints/53/1553a.md
+++ b/plan/issues/sprints/53/1553a.md
@@ -1,0 +1,250 @@
+---
+id: 1553a
+sprint: 53
+title: "destructure-helpers: thread decl-mode + bindingKind through destructureParamObject/Array (foundation)"
+status: ready
+created: 2026-05-20
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: refactor+bugfix
+area: codegen
+language_feature: declarations, destructuring
+goal: spec-completeness
+parent: 1553
+depends_on: []
+unblocks: [1553b, 1553c, 1553d]
+related: [1432, 1450, 1454, 1550, 1552]
+---
+
+# #1553a — Add `decl` mode to `destructureParamObject` / `destructureParamArray`
+
+Foundation slice for #1553. **Does not change runtime behaviour**: existing
+param and catch callers keep the same emission. Only adds optional `mode`
+and `bindingKind` plumbing so #1553b/c/d can route declaration-form
+destructuring through the same helper that already battle-tests
+function-parameter destructuring (#1432, #1454, #1550) and catch-parameter
+destructuring (#1552).
+
+## Goal
+
+Make `destructureParamObject` and `destructureParamArray` usable as the
+single source of truth for **all** binding pattern destructuring
+(parameter, catch, let/const/var declaration, for-of, for-in,
+assignment), parameterised by:
+
+```ts
+export type DestructureMode = "param" | "catch" | "decl";
+export type BindingKind = "let" | "const" | "var" | "param";
+
+export interface DestructureOpts {
+  mode?: DestructureMode;        // default: "param"
+  bindingKind?: BindingKind;     // default: "param"
+}
+```
+
+When `mode === "decl"`:
+
+- Emit per-binding TDZ init flag (`emitLocalTdzInit(fctx, name)`) after
+  each `local.set`. For `var` the TDZ pre-pass never allocates a flag,
+  so `emitLocalTdzInit` is a no-op there — behaviour is correct without
+  extra branching.
+- Honour `ensureLetConstBindingPatternTdzFlags` at entry when
+  `bindingKind === "let" || bindingKind === "const"` (already called by
+  `compileObjectDestructuring`/`compileArrayDestructuring`; centralising
+  here lets us delete the callers).
+- (For `const` only) the per-binding allocation already emits a local-set;
+  the writeable-vs-not distinction is enforced by `fctx.constBindings`
+  bookkeeping that the *caller* (`compileVariableStatement`) maintains —
+  the helper does not need to know `const` vs `let`.
+
+When `mode === "param"` (default): emit nothing TDZ-related, preserve
+the existing behaviour to a byte.
+
+## Files & exact changes
+
+### File: `src/codegen/destructuring-params.ts`
+
+1. **Add type exports** at the top of the file (after existing imports,
+   ~line 55, before `isPatternEmptyOnly`):
+
+   ```ts
+   export type DestructureMode = "param" | "catch" | "decl";
+   export type BindingKind = "let" | "const" | "var" | "param";
+   export interface DestructureOpts {
+     mode?: DestructureMode;
+     bindingKind?: BindingKind;
+   }
+   ```
+
+2. **Extend `destructureParamObject` signature** (line 412):
+
+   ```ts
+   export function destructureParamObject(
+     ctx: CodegenContext,
+     fctx: FunctionContext,
+     paramIdx: number,
+     pattern: ts.ObjectBindingPattern,
+     paramType: ValType,
+     opts: DestructureOpts = {},
+   ): void {
+     const mode = opts.mode ?? "param";
+     const bindingKind = opts.bindingKind ?? "param";
+     const isDecl = mode === "decl";
+     // ... existing body unchanged except for the additions below
+   }
+   ```
+
+   - **At entry** (immediately after the signature):
+
+     ```ts
+     if (isDecl && (bindingKind === "let" || bindingKind === "const")) {
+       ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
+     }
+     ```
+
+     (Requires importing `ensureLetConstBindingPatternTdzFlags` from
+     `./statements/tdz.js` — or, if there is a circular-import risk,
+     accept it as an injected helper through `opts` to avoid an
+     `import` cycle. **Inspect first**: if `destructuring-params.ts`
+     already imports from `./statements/tdz.js` it is safe, otherwise
+     pass the function in `opts` and call only when defined.)
+
+   - **After each successful `local.set` of a binding identifier**, emit:
+
+     ```ts
+     if (isDecl) emitLocalTdzInit(fctx, localName);
+     ```
+
+     The four spots in `destructureParamObject` that do `local.set` of a
+     bound identifier (the simple-field path at ~line 627, the nested
+     path's recursive call returns into named locals via
+     `ensureBindingLocals`, the rest path inside
+     `destructureParamObjectExternref`, the externref simple-field
+     path).
+
+   - **Forward `opts` on recursive calls** (lines ~594/596) so nested
+     patterns inherit decl mode:
+
+     ```ts
+     destructureParamObject(ctx, fctx, tmpLocal, element.name, fieldType, opts);
+     ```
+
+3. **Extend `destructureParamObjectExternref` signature**
+   (line 185) the same way (`opts: DestructureOpts = {}`) and apply the
+   `emitLocalTdzInit` after each `local.set` (~line 326). Forward
+   `opts` on recursive calls (~lines 378, 380).
+
+4. **Extend `destructureParamArray` signature** (line 655) the same
+   way. Apply at:
+
+   - Entry: `ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern)`
+     when `isDecl && (bindingKind === "let" || bindingKind === "const")`.
+   - After each `local.set` of a bound identifier (multiple sites — use
+     `grep -n "local.set" src/codegen/destructuring-params.ts` to enumerate;
+     each binding-element identifier path needs a sibling `emitLocalTdzInit`).
+   - Forward `opts` on recursive `destructureParamArray` /
+     `destructureParamObject` calls inside the helper.
+
+### File: `src/codegen/statements/tdz.ts`
+
+No changes required — `emitLocalTdzInit` already exists and tolerates a
+missing flag (no-op for `var`).
+
+### File: `src/codegen/statements/destructuring.ts`
+
+No call-site changes in this slice — that's what 1553b/c/d are for. This
+slice is **strictly additive** to the helper.
+
+## Wasm IR pattern (no change for `mode === "param"`)
+
+For `mode === "decl"` with `bindingKind === "let"`:
+
+```wasm
+;; --- ensureLetConstBindingPatternTdzFlags (once at entry) ---
+i32.const 0
+local.set $__tdz_x      ;; per binding identifier in the pattern
+;; ... (one per binding)
+
+;; --- per-binding store + TDZ init ---
+local.get $rhs
+struct.get $T 0           ;; field read
+local.set $x              ;; existing store
+i32.const 1
+local.set $__tdz_x        ;; NEW (emitLocalTdzInit)
+```
+
+## Edge cases
+
+1. **Catch-mode callers** — `#1552` already routes catch parameters
+   through `destructureParamObject({mode:'catch'})` (or an equivalent
+   passthrough). Verify by grepping `compileCatchClause` / catch-spec
+   logic; if the call site does not yet pass `opts`, leave it as-is —
+   default `opts = {}` keeps `mode === "param"` and preserves catch
+   semantics until #1552 lands a follow-up.
+
+2. **`var` binding inside an `if`/`for` block** — `var` hoists to the
+   function. `emitLocalTdzInit` is a no-op when no flag was allocated,
+   so the helper doesn't need to special-case `var`.
+
+3. **Nested let pattern inside a param pattern** — e.g.,
+   `function f([{a} = {}]) { let [{b}] = [...]; }`. The outer call is
+   `mode:'param'`, the inner call is `mode:'decl'`. Each call site
+   passes its own `opts`; recursion within a call inherits its own
+   `opts`. No cross-contamination.
+
+4. **`const`/`let` re-allocation in block scope (#1128)** — already
+   handled in current callers via `ensureLetConstBindingPatternTdzFlags`;
+   centralising that call inside the helper does not change semantics
+   because the helper is the leaf of the call chain.
+
+5. **`syncDestructuredLocalsToGlobals`** — must remain the *caller's*
+   responsibility (it walks the pattern in a separate pass after the
+   destructure loop completes, and not all callers want to sync —
+   catch-mode and param-mode don't).
+
+## Test files
+
+- `tests/issue-1553a.test.ts` — focused decl-mode plumbing test (build only,
+  no behaviour assertion): call the helper directly with
+  `{mode:'decl', bindingKind:'let'}` for a 2-prop object pattern and a
+  3-elem array pattern; verify generated body contains
+  `i32.const 1`/`local.set $__tdz_*` after each `local.set $name`.
+
+- **Regression guard**: all existing
+  `tests/equivalence.test.ts` cases that hit param destructuring must
+  remain green. No param/catch test should diff.
+
+## Acceptance criteria
+
+1. `destructureParamObject(... , {mode:'decl', bindingKind:'let'})`
+   produces the same IR as the current
+   `compileObjectDestructuring` typed-struct branch for a simple
+   `let {x,y} = obj` (modulo `emitNestedBindingDefault` ordering — the
+   helper version is more correct, see #1553b).
+
+2. `npm test -- tests/equivalence.test.ts` is green.
+
+3. No callers changed → no test262 delta. CI must show
+   `net_per_test ≈ 0`.
+
+## Estimated change size
+
+~150 lines added in `destructuring-params.ts`. No deletions in this
+slice. Self-contained PR.
+
+## Risk
+
+Low. Strictly additive; default `opts = {}` keeps current call-sites
+unchanged. The only risk is the import-cycle from pulling
+`ensureLetConstBindingPatternTdzFlags` / `emitLocalTdzInit` into
+`destructuring-params.ts`. Inspect import graph first — if a cycle
+appears, accept the two helpers via `opts` from the caller.
+
+## Out of scope
+
+- Behaviour fixes for declaration-form destructuring (those are
+  #1553b/c/d).
+- f64 sentinel for explicit `undefined` array literal (#1553e).
+- NamedEvaluation in declaration default (#1450 — separate issue,
+  in-review).

--- a/plan/issues/sprints/53/1553b.md
+++ b/plan/issues/sprints/53/1553b.md
@@ -1,0 +1,231 @@
+---
+id: 1553b
+sprint: 53
+title: "decl-dstr: route typed-struct object declaration through destructureParamObject (decl-mode)"
+status: blocked
+created: 2026-05-20
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: refactor+bugfix
+area: codegen
+language_feature: declarations, destructuring
+goal: spec-completeness
+parent: 1553
+depends_on: [1553a]
+unblocks: [1553c]
+related: [1450, 1454, 1550]
+---
+
+# #1553b — Delegate `compileObjectDestructuring` typed-struct path to shared helper
+
+After #1553a lands the `mode:'decl'` plumbing, this slice replaces the
+~270-line hand-rolled typed-struct branch in
+`src/codegen/statements/destructuring.ts:compileObjectDestructuring`
+(currently lines 419-683) with a thin wrapper that delegates to
+`destructureParamObject({mode:'decl', bindingKind})`.
+
+## Root cause closed by this slice
+
+- **Bug 3 (investigation §2026-05-20, root-cause 3)** — typed-struct
+  nested pattern at lines 538-598 has *no* `element.initializer`
+  (default) handling at all. The inner per-field loop (544-564) also
+  ignores `ne.initializer`. The shared helper handles both via
+  `emitNestedBindingDefault` (lines 207-281 of
+  `statements/destructuring.ts`) and `emitDefaultValueCheck`
+  (lines 297-374).
+
+- **Bug 2 partial mitigation** — the externref-with-known-struct
+  fast-path in the shared helper (`destructure-params.ts:489-517`)
+  uses `ref.test` + `ref.cast` + `struct.get` instead of round-tripping
+  the struct through `__extern_get`, so when the *default*
+  initialiser compiles to a known struct type, fields are reachable.
+
+## Failure patterns fixed
+
+From the issue's 8 smoke-tested patterns (investigation §Reproductions):
+
+| Probe | Source | Pre-fix result | Post-fix expected |
+| --- | --- | --- | --- |
+| `let {w:{x,y,z}={x:1,y:2,z:3}}={w:undefined}` (typed RHS) | typed path | throws TypeError | `x=1, y=2, z=3` |
+| `let {a, b: {c, d}} = {a:1, b:{c:2, d:3}}` (typed nested, no default) | typed path | works, but TDZ flag missed | works + TDZ flag |
+| `let {a={fn:function(){}}} = {}` (typed) | typed path | a.fn.name === "" | a.fn.name === "fn" after #1450 |
+
+test262 patterns that flip on this slice (subset of #1553's 93 fails):
+
+- `test/language/statements/let/dstr/obj-ptrn-prop-obj-value-undef.js`
+- `test/language/statements/let/dstr/obj-ptrn-prop-obj-init.js`
+- `test/language/statements/const/dstr/obj-ptrn-prop-obj-value-undef.js`
+- `test/language/statements/variable/dstr/obj-ptrn-prop-obj-value-undef.js`
+- nested object dstr cases that currently `assertion_fail`.
+
+Estimated direct unlock: **≥ 18** cases (the
+`obj-ptrn-prop-obj-*` cluster from the issue table). Indirect: more
+cases pass once 1553c lands.
+
+## Changes
+
+### File: `src/codegen/statements/destructuring.ts`
+
+**Function: `compileObjectDestructuring` (line 376-683)**
+
+Replace the body **after** the `resultType` computation
+(roughly line 419 onward — keep lines 376-417 which compute
+`resultType` and dispatch to externref/scalar paths) with:
+
+```ts
+// Save current body length so we can rollback if the helper bails
+const bodyLenBefore = fctx.body.length;
+
+// Stash the RHS in a temp local for the helper
+const tmpLocal = allocLocal(fctx, `__destruct_${fctx.locals.length}`, resultType);
+fctx.body.push({ op: "local.set", index: tmpLocal });
+
+// Determine binding kind for TDZ + const tracking
+const bindingKind: BindingKind =
+  decl.parent.flags & ts.NodeFlags.Const ? "const"
+  : decl.parent.flags & ts.NodeFlags.Let ? "let"
+  : "var";
+
+// Delegate
+destructureParamObject(ctx, fctx, tmpLocal, pattern, resultType, {
+  mode: "decl",
+  bindingKind,
+});
+
+// Module-global sync remains in the caller
+syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+return;
+```
+
+The dispatchers immediately above the replacement (the externref and
+scalar branches that already call
+`compileExternrefObjectDestructuringDecl`) are not affected by this
+slice — 1553c rewrites those.
+
+Imports to add:
+
+```ts
+import {
+  destructureParamObject,
+  type BindingKind,
+} from "../destructuring-params.js";
+```
+
+### File: `src/codegen/destructuring-params.ts`
+
+No changes — the helper already exposes the necessary surface after
+#1553a.
+
+### Deletion size
+
+~270 lines removed from `compileObjectDestructuring`
+(approximately lines 419-683). Net diff: roughly **-260 LOC**.
+
+## Wasm IR pattern (illustrative)
+
+For `let {w: {x, y, z} = {x:1, y:2, z:3}} = {w: undefined}` with the
+RHS compiling to struct ref `$Wrapper`:
+
+```wasm
+;; outer pattern: stash RHS
+local.get $rhs        ;; $Wrapper
+local.set $tmp_outer  ;; type: ref_null $Wrapper
+
+;; per-binding TDZ flags (from #1553a)
+i32.const 0
+local.set $__tdz_x
+i32.const 0
+local.set $__tdz_y
+i32.const 0
+local.set $__tdz_z
+
+;; null guard on outer
+local.get $tmp_outer
+ref.is_null
+if
+  call $__throw_type_error_destructure_null
+end
+
+;; extract w
+local.get $tmp_outer
+struct.get $Wrapper 0
+local.set $tmp_w      ;; type ref_null $Inner
+
+;; emit nested default (via emitNestedBindingDefault)
+local.get $tmp_w
+ref.is_null
+if
+  ;; default initialiser {x:1, y:2, z:3} → struct ref
+  i32.const 1  i32.const 2  i32.const 3
+  struct.new $Inner
+  local.set $tmp_w
+end
+
+;; recurse: destructure $tmp_w into {x, y, z} (with TDZ inits per binding)
+```
+
+## Edge cases
+
+1. **RHS type is unknown / not a known struct** — the existing
+   fall-through to externref (lines 458-466 / 472-480) is retained.
+   1553c covers that path.
+
+2. **RHS resolves to a struct ref but the pattern has a rest element
+   `{a, ...r} = obj`** — the shared helper does **not** rest-emit on
+   the struct fast path (it forces `structTypeIdx = undefined` when
+   `hasRestElement` at lines 442-443). The helper falls through to
+   `destructureParamObjectExternref` automatically. That is correct
+   for the typed RHS too — rest must enumerate all enumerable own
+   properties (struct.get cannot do that). Verify by inspecting the
+   helper output and writing one regression test.
+
+3. **`ensureLetConstBindingPatternTdzFlags`** — moved into the helper
+   by 1553a. The caller no longer needs to call it explicitly.
+
+4. **Test262 cases that currently silently pass** because the typed
+   path doesn't throw on null — after this slice, the helper's
+   `emitExternrefDestructureGuard` (struct path also calls
+   `buildDestructureNullThrow` via the nullable-guard at lines 631-643
+   of `destructuring-params.ts`) will throw. Verify that any tests
+   asserting no-throw on null actually expected the throw (per spec).
+
+## Test files to verify
+
+- `tests/issue-1553.test.ts` (new — shared with #1553c/d; add cases
+  incrementally):
+  - `let-obj-default-nested` (case in issue file step 6).
+- test262 `obj-ptrn-prop-obj-value-undef` for `let`, `const`,
+  `variable`.
+- test262 `obj-ptrn-prop-obj-init` cluster.
+
+## Regression gate
+
+Before merging, run scoped equivalence tests; then in CI:
+
+- Required: `net_per_test > 0`, no bucket >50, no
+  `obj-ptrn-*` regression.
+- Watch: `tests/equivalence.test.ts` `# destructuring` block.
+
+## Estimated change size
+
+~ -260 LOC diff (mostly deletions, small insertion of delegation +
+import). Single PR.
+
+## Risk
+
+Medium. The replaced code path is on a hot lane (every typed-struct
+`let/const/var {…}=expr`). The helper has been exercised heavily for
+function parameters, so the risk is in subtle differences in
+TDZ-flag emission timing and the null-guard. Mitigate by:
+
+- Comparing the IR of `let {x,y}=obj` before and after on a fixture.
+- Verifying that `syncDestructuredLocalsToGlobals` is still called
+  (it must remain in the caller, not the helper).
+
+## Out of scope
+
+- Externref-fallback decl path → #1553c.
+- Array decl path → #1553d.
+- Bug 5 (f64 explicit-undefined sentinel) → #1553e.
+- NamedEvaluation → #1450 (in-review).

--- a/plan/issues/sprints/53/1553c.md
+++ b/plan/issues/sprints/53/1553c.md
@@ -1,0 +1,273 @@
+---
+id: 1553c
+sprint: 53
+title: "decl-dstr: route externref-fallback object declaration through destructureParamObject (decl-mode)"
+status: blocked
+created: 2026-05-20
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: refactor+bugfix
+area: codegen
+language_feature: declarations, destructuring
+goal: spec-completeness
+parent: 1553
+depends_on: [1553a, 1553b]
+unblocks: [1553d]
+related: [1450, 1454, 1550, 1552]
+---
+
+# #1553c — Replace `compileExternrefObjectDestructuringDecl` with shared-helper delegate
+
+`compileExternrefObjectDestructuringDecl`
+(`src/codegen/statements/destructuring.ts:689-862`, ~170 LOC) is a
+twin of `destructureParamObjectExternref`
+(`src/codegen/destructuring-params.ts:185-384`, ~200 LOC), but the two
+have drifted apart: only the param twin received the fixes from
+#1432 (default-on-undefined-OR-null distinction), #1450
+(NamedEvaluation), and #1552 (catch-rest enumerable filtering). The
+decl twin has independent bugs (investigation root-causes 1, 2, 4, 8).
+
+## Root causes closed by this slice
+
+- **Bug 1 (root-cause 1)** — `compileExternrefObjectDestructuringDecl`
+  lines 842-854 drop `element.initializer` when the binding target is
+  itself a pattern. The param twin handles this at lines 335-367 of
+  `destructuring-params.ts`. ✅ Fixed by delegation.
+
+- **Bug 2 (root-cause 2 — the "blocker")** — when the default
+  initialiser `{x:1, y:2, z:3}` compiles to a known struct type and
+  the decl path is operating on externref, the *decl* twin
+  `extern.convert_any`-roundtrips the struct then calls
+  `__extern_get`, which returns `undefined` for every field because
+  WasmGC structs are opaque to JS property access. The param twin
+  detects this case via `ref.test typeIdx` on the converted any-ref
+  (lines 489-517 of `destructuring-params.ts`) and uses `struct.get`
+  directly. ✅ Fixed by delegation.
+
+- **Bug 4 (root-cause 4)** — per-element null guard. The decl twin's
+  top-level null guard (lines 716-722) doesn't catch nested null:
+  `let {w: {x}} = {w: null}` silently produces `x = undefined` instead
+  of throwing TypeError. The param twin gates each nested-pattern
+  recursion behind `emitExternrefDestructureGuard` (line 373-375 of
+  `destructuring-params.ts`). ✅ Fixed by delegation.
+
+- **Bug 8 (root-cause 8)** — `__extern_rest_object` enumerable
+  filtering. After #1552 lands the catch-rest fix, the helper
+  consumes the corrected host import; the decl twin currently re-implements
+  the rest call without re-checking the enumerable contract. Delegating
+  ensures decl rest matches catch rest matches param rest.
+
+## Failure patterns fixed
+
+| Probe | Source | Pre-fix result | Post-fix expected |
+| --- | --- | --- | --- |
+| `let {w:{x,y,z}={...}} = ({w:undefined} as any)` (externref RHS) | externref path | throws TypeError | `x=1, y=2, z=3` |
+| `let {w:{x,y,z}={...}} = ({w:null} as any)` | externref path | silent (`x = undefined`) | throws TypeError |
+| `let {fn = function(){}} = ({} as any)` | externref path | `fn.name === ""` | `fn.name === "fn"` after #1450 |
+| `let {...r} = obj-with-non-enum` | externref rest | wrong inclusion | excludes non-enumerable only |
+
+test262 patterns expected to flip:
+
+- `test/language/statements/{let,const,variable}/dstr/obj-ptrn-prop-obj-value-undef.js`
+- `test/language/statements/{let,const,variable}/dstr/obj-ptrn-prop-obj-value-null.js`
+- `test/language/statements/{let,const,variable}/dstr/obj-init-null.js`
+- `test/language/statements/{let,const,variable}/dstr/obj-init-undefined.js`
+- `test/language/statements/{let,const,variable}/dstr/obj-ptrn-rest-getter-*.js` (after #1552 lands)
+- `obj-ptrn-id-init-fn-name-*` cluster (after #1450 lands in main).
+
+Estimated direct unlock: **≥ 24** cases (the
+`obj-ptrn-prop-obj-*` + `obj-init-null/undefined` clusters from the
+issue table). When combined with #1553b, ~42 of the 93 fails should flip.
+
+## Changes
+
+### File: `src/codegen/statements/destructuring.ts`
+
+**Function: `compileExternrefObjectDestructuringDecl` (line 689-862)**
+
+Replace the whole function body with a delegation. Keep the export
+signature so all internal callers (lines 402, 413, 460, 475, 849, 1061)
+keep working until 1553d removes them:
+
+```ts
+export function compileExternrefObjectDestructuringDecl(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  pattern: ts.ObjectBindingPattern,
+  resultType: ValType,
+): void {
+  // Stash externref into a temp local for the helper
+  const tmpLocal = allocLocal(fctx, `__ext_obj_destruct_${fctx.locals.length}`, resultType);
+  fctx.body.push({ op: "local.set", index: tmpLocal });
+
+  // Decl-mode delegation. Bindingkind is recovered from the enclosing
+  // VariableDeclaration on the call stack; if unavailable, default to
+  // `var` (TDZ-init is a no-op for `var`).
+  const bindingKind = recoverBindingKind(ctx, fctx, pattern) ?? "var";
+
+  destructureParamObject(ctx, fctx, tmpLocal, pattern, resultType, {
+    mode: "decl",
+    bindingKind,
+  });
+
+  // Module-global sync remains in the caller
+  syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+}
+```
+
+`recoverBindingKind` is a small helper on the same file (or in
+`statements/variables.ts`) that walks `pattern.parent` looking for a
+`VariableDeclaration` ancestor and reads
+`parent.declarationList.flags`. If not found, returns `"var"` —
+correct because `let`/`const` always have the flag set, and `var`
+flag absent is the default.
+
+```ts
+function recoverBindingKind(
+  _ctx: CodegenContext,
+  _fctx: FunctionContext,
+  pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern,
+): BindingKind | undefined {
+  let n: ts.Node | undefined = pattern;
+  while (n) {
+    if (ts.isVariableDeclarationList(n)) {
+      if (n.flags & ts.NodeFlags.Const) return "const";
+      if (n.flags & ts.NodeFlags.Let) return "let";
+      return "var";
+    }
+    n = n.parent;
+  }
+  return undefined;
+}
+```
+
+Net deletion: ~165 LOC (689-862 minus the new 20-line shim).
+
+### File: `src/codegen/statements/destructuring.ts`, line 402 + 413
+
+The dispatch from `compileObjectDestructuring`
+(`if (resultType.kind === "externref") { compileExternrefObject...; }`)
+already routes through the shim; no caller-side changes needed once
+the shim delegates. After #1553b merges this leaves a single export
+that just delegates — keep it for compile compatibility, mark with a
+`@deprecated` JSDoc comment for removal in #1553d.
+
+### File: `src/codegen/destructuring-params.ts`
+
+No changes (already prepared by #1553a). Confirm that the helper's
+externref branch (lines 421-522) handles all 4 input shapes:
+
+1. externref wrapping a known WasmGC struct → ref.test + struct.get fast path.
+2. externref wrapping a JS object → `__extern_get` slow path.
+3. externref that is `ref.null.extern` → null guard throws.
+4. externref wrapping `undefined` (boxed) → null guard throws.
+
+If shape (1) is not covered for nested patterns whose defaults are
+struct-typed, file a follow-up — but per the dev's reproduction the
+fast path *does* fire for top-level cases, just not nested.
+
+## Wasm IR pattern (illustrative)
+
+For `let {w: {x, y, z} = {x:1, y:2, z:3}} = ({w: null} as any)`:
+
+```wasm
+;; outer externref guard
+local.get $rhs                  ;; type externref
+ref.is_null
+if call $__throw_type_error_destructure_null end
+local.get $rhs
+call $__extern_is_undefined
+if call $__throw_type_error_destructure_null end
+
+;; per-binding TDZ flags
+i32.const 0  local.set $__tdz_x
+i32.const 0  local.set $__tdz_y
+i32.const 0  local.set $__tdz_z
+
+;; read w
+local.get $rhs
+global.get $__str_w
+call $__extern_get        ;; returns externref(null) for {w:null}
+local.set $__nested_w
+
+;; nested default — fire ONLY if `w === undefined`, per spec.
+;; null does NOT trigger the default.
+local.get $__nested_w
+call $__extern_is_undefined
+if
+  ;; compile default {x:1,y:2,z:3} → struct ref → extern.convert_any
+  ...
+  local.set $__nested_w
+end
+
+;; nested null/undefined guard — throws when value is null (not undefined,
+;; because default-on-undefined already fired above).
+local.get $__nested_w
+ref.is_null
+if call $__throw_type_error_destructure_null end
+local.get $__nested_w
+call $__extern_is_undefined
+if call $__throw_type_error_destructure_null end
+
+;; recurse: destructure $__nested_w into {x, y, z}
+;; (helper takes the struct fast path if the default value happens to
+;; be a known struct typed; otherwise __extern_get slow path)
+```
+
+## Edge cases
+
+1. **`recoverBindingKind` returns `undefined`** for assignment patterns
+   (`({x} = obj)`) and for-of/for-in heads. Those callers don't go
+   through `compileExternrefObjectDestructuringDecl` — they have
+   their own emission pipeline. Default-to-`"var"` is a safe fallback
+   for any unforeseen caller.
+
+2. **`syncDestructuredLocalsToGlobals` ordering** — keep it as the last
+   call in the shim, matching current behaviour.
+
+3. **`__extern_rest_object` host import** — currently has a slight
+   semantic mismatch with spec re. enumerable filtering (bug 8). That
+   fix lives in `src/runtime.ts` and is part of #1552's domain; this
+   slice just routes through the corrected host import.
+
+## Test files to verify
+
+- `tests/issue-1553.test.ts` — add the 3 externref-RHS cases from the
+  issue's step 6.
+- `test/language/statements/{let,const,variable}/dstr/obj-init-null.js`.
+- `test/language/statements/{let,const,variable}/dstr/obj-init-undefined.js`.
+- `test/language/statements/{let,const,variable}/dstr/obj-ptrn-prop-obj-value-null.js`.
+- `test/language/statements/{let,const,variable}/dstr/obj-ptrn-rest-getter-*.js`.
+
+## Regression gate
+
+- Required: `net_per_test > 0`, no `obj-ptrn-*` bucket grows > 5.
+- Watch: `obj-ptrn-rest-*` (some currently-passing cases rely on the
+  pre-fix bug-8 host behaviour — if they flip, file as follow-ups).
+
+## Estimated change size
+
+- ~ -150 LOC in `destructuring.ts` (deletion of the twin).
+- + 20 LOC of shim + `recoverBindingKind`.
+- Net: **~ -130 LOC** in a single PR.
+
+## Risk
+
+Medium. The externref decl path is exercised by every `let/const/var`
+destructure of an `any`-typed RHS — including `arguments`,
+`JSON.parse(...)`, foreign-host returns. The helper has identical
+shape to the twin and is the active path for function-parameter
+destructuring of the same RHS, so the risk is dominated by drift in
+edge cases (rest excluded-keys list, null vs undefined gating).
+
+Mitigation: write three explicit equivalence tests that exercise
+shapes (1)-(4) above before opening the PR.
+
+## Out of scope
+
+- Removing the `compileExternrefObjectDestructuringDecl` export
+  entirely → #1553d.
+- Array decl path → #1553d.
+- f64 explicit-undefined sentinel → #1553e.
+- NamedEvaluation lookup-by-binding → #1450 (in-review).

--- a/plan/issues/sprints/53/1553d.md
+++ b/plan/issues/sprints/53/1553d.md
@@ -1,0 +1,324 @@
+---
+id: 1553d
+sprint: 53
+title: "decl-dstr: route array declaration (typed-vec + externref) through destructureParamArray (decl-mode)"
+status: blocked
+created: 2026-05-20
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: refactor+bugfix
+area: codegen
+language_feature: declarations, destructuring
+goal: spec-completeness
+parent: 1553
+depends_on: [1553a, 1553c]
+unblocks: []
+related: [1432, 1454, 1550, 1555]
+---
+
+# #1553d — Replace `compileArrayDestructuring` + `compileExternrefArrayDestructuringDecl` with shared-helper delegate
+
+Largest slice. `compileArrayDestructuring` (lines 1070-1980,
+~910 LOC) and `compileExternrefArrayDestructuringDecl`
+(lines 868-1068, ~200 LOC) together implement the declaration-form
+array destructuring lane. They are twins of `destructureParamArray`
+(`src/codegen/destructuring-params.ts:655` — ~770 LOC), with multiple
+drift points: rest binding, nested defaults, vec-vs-tuple
+fast-paths, iterator close on throwing init, OOB sentinel handling.
+
+This slice converts both decl-side functions into delegations to the
+shared helper.
+
+## Root causes closed by this slice
+
+- **Bug 6 (root-cause 6)** — `let [a, ...rest] = [1,2,3,4]` produces
+  `[1, 0]`. `ensureBindingLocals` pre-allocates `rest` as externref;
+  then the rest-handling path inside
+  `compileExternrefArrayDestructuringDecl` (lines 944-974) allocates a
+  *second* slot for the same name when reading back, so subsequent
+  reads collide. The helper's `destructureParamArray` rest-path uses a
+  single `localMap` lookup. ✅ Fixed by delegation.
+
+- **Bug 4 (root-cause 4, array-side)** — `let [{x}] = [null]` must
+  throw `TypeError` (null nested target). The decl twin's array path
+  silently falls through; the param helper gates with
+  `emitExternrefDestructureGuard` for nested patterns. ✅ Fixed by
+  delegation.
+
+- **Iterator close on throwing init** (related to #1454) — the decl
+  twin doesn't drive `IteratorClose` when an element's default
+  throws. The helper closes via `__array_from_iter` materialization
+  (which propagates throws cleanly per #1150). ✅ Inherited by delegation.
+
+- **Tuple-struct + nested pattern + default** — current decl path
+  (lines 1650-1750) does its own emission instead of recursing. After
+  delegation the helper handles it uniformly.
+
+## Failure patterns fixed
+
+| Probe | Source | Pre-fix result | Post-fix expected |
+| --- | --- | --- | --- |
+| `let [a, ...rest] = [1, 2, 3, 4]` (vec) | vec rest path | `[1, 0]` | `[1, [2, 3, 4]]` |
+| `let [x = (function(){throw 'bang'})()] = []` (tuple/vec) | tuple/vec path | `x=NaN, no throw` | throws `'bang'` |
+| `let [{x}] = [null]` | externref array | `x = undefined` | TypeError |
+| `let [{x, y}] = [{x:1, y:2}]` (nested) | externref array | works, no TDZ flag | works + TDZ flag |
+
+test262 patterns expected to flip:
+
+- `ary-ptrn-rest-*` cluster (6 fails in issue table).
+- `ary-init-iter-*` cluster (9 fails) — partly via #1454, partly here.
+- `ary-ptrn-elem-id-init-throws.js` (var + let + const variants).
+- `ary-ptrn-elision-*` (3 fails).
+- `ary-ptrn-empty-*` (3 fails — empty pattern observable iterator).
+- many `ary-ptrn-elem-*` (27 fails total — at least half from here).
+
+Estimated direct unlock: **≥ 35** cases. Combined with 1553b/c the
+total unlock for #1553 should reach the target of ≥ 60 (acceptance
+criterion 6).
+
+## Changes
+
+### File: `src/codegen/statements/destructuring.ts`
+
+**Function: `compileExternrefArrayDestructuringDecl` (line 868-1068)**
+
+Replace body with a delegating shim:
+
+```ts
+export function compileExternrefArrayDestructuringDecl(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  pattern: ts.ArrayBindingPattern,
+  resultType: ValType,
+): void {
+  const tmpLocal = allocLocal(fctx, `__ext_arr_destruct_${fctx.locals.length}`, resultType);
+  fctx.body.push({ op: "local.set", index: tmpLocal });
+
+  const bindingKind = recoverBindingKind(fctx, pattern) ?? "var";
+
+  destructureParamArray(ctx, fctx, tmpLocal, pattern, resultType, {
+    mode: "decl",
+    bindingKind,
+  });
+
+  syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+}
+```
+
+Net deletion: ~180 LOC.
+
+**Function: `compileArrayDestructuring` (line 1070-1980)**
+
+Keep the prologue (lines 1070-1170) that:
+
+1. Forces `_arrayLiteralForceVec = true` when pattern has rest.
+2. Compiles the initializer.
+3. Decides whether the resultType is externref, scalar, ref-to-struct,
+   or unknown.
+
+But replace **everything after** the typed-struct prologue
+(line ~1170 onward — the body that does tuple-struct / vec-array
+emission) with:
+
+```ts
+// At this point: resultType is a ref to a known struct (vec or tuple).
+// Stash and delegate.
+
+const tmpLocal = allocLocal(fctx, `__destruct_${fctx.locals.length}`, resultType);
+fctx.body.push({ op: "local.set", index: tmpLocal });
+
+const bindingKind: BindingKind =
+  decl.parent.flags & ts.NodeFlags.Const ? "const"
+  : decl.parent.flags & ts.NodeFlags.Let ? "let"
+  : "var";
+
+// The helper handles tuple-struct, vec, ref-to-struct, and externref
+// uniformly when given a struct ref param.
+destructureParamArray(ctx, fctx, tmpLocal, pattern, resultType, {
+  mode: "decl",
+  bindingKind,
+});
+
+syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+return;
+```
+
+Net deletion: ~750 LOC. **Caution**: scan the deleted block for
+any code that emits *into* `fctx.body` outside the destructure (e.g.,
+the `bodyLenBefore = fctx.body.length` rollback logic, or special
+treatment for string destructuring at line 1162). Preserve:
+
+- `compileStringDestructuring(ctx, fctx, pattern, resultType, bodyLenBefore)`
+  branch — strings are not arrays, the helper does not handle them.
+  Keep this branch intact.
+- The `_arrayLiteralForceVec` flag handling around `compileExpression`.
+- Rollback (`fctx.body.length = bodyLenBefore`) for the "Cannot
+  destructure" error case.
+
+### File: `src/codegen/destructuring-params.ts`
+
+Audit `destructureParamArray` for these capabilities before delegation:
+
+1. **Receives a struct-typed param (not externref)** — the function
+   currently handles externref by routing through any.convert_extern +
+   tuple/vec ref.test detection. Passing a `ref_null $vec_T` directly
+   should also work but verify: at line 662 the early-return for
+   non-ref types goes to the externref branch only when paramType is
+   externref. For a `ref` paramType it falls through to the
+   struct-handling code at line ~1000+. **If a typed-struct param is
+   not in `paramType.kind` of `"ref" | "ref_null"` plus a known
+   struct type at `paramType.typeIdx`, the function should still
+   dispatch correctly.** If gaps are found, add them in this slice
+   (small: extend the type-dispatch ladder).
+
+2. **`syncDestructuredLocalsToGlobals` not called inside helper** —
+   confirmed; remains caller's job.
+
+3. **String destructuring** — `compileStringDestructuring` is a
+   separate call in `compileArrayDestructuring`. Helper does NOT
+   handle string destructuring. Keep the branch in the caller.
+
+### Imports
+
+`destructuring.ts` already imports `destructureParamArray`? Check:
+
+```bash
+grep -n "destructureParamArray" src/codegen/statements/destructuring.ts
+```
+
+If not imported, add:
+
+```ts
+import {
+  destructureParamArray,
+  type BindingKind,
+} from "../destructuring-params.js";
+```
+
+(Note: `destructuring-params.ts` is in `src/codegen/`, so the relative
+path from `src/codegen/statements/` is `../destructuring-params.js`.)
+
+## Wasm IR pattern (illustrative)
+
+For `let [a, ...rest] = [1, 2, 3, 4]`:
+
+```wasm
+;; compile [1,2,3,4] with _arrayLiteralForceVec=true → ref_null $vec_f64
+local.set $tmp_vec
+
+;; per-binding TDZ flags (from #1553a)
+i32.const 0  local.set $__tdz_a
+i32.const 0  local.set $__tdz_rest
+
+;; element 0 → a
+local.get $tmp_vec
+struct.get $vec_f64 1   ;; data array
+i32.const 0
+array.get $arr_f64      ;; bounds-checked, OOB returns sNaN sentinel
+local.set $a            ;; f64
+
+;; rest [2,3,4] → vec slice via array.copy + struct.new (no externref)
+local.get $tmp_vec
+struct.get $vec_f64 0    ;; len
+i32.const 1
+i32.sub                  ;; rest_len = len - 1
+local.set $rest_len
+...
+struct.new $vec_f64
+local.set $rest          ;; SINGLE slot — no name collision (fixed)
+i32.const 1
+local.set $__tdz_rest
+```
+
+## Edge cases
+
+1. **Iterator close on throwing default** — the helper materializes
+   externref iterables via `__array_from_iter` before calling
+   `__extern_length` / `__extern_get_idx`. Exceptions from `.next()`
+   propagate as JS exceptions (#1150). Verify no regression on
+   `tests/equivalence.test.ts` iterator-close cases.
+
+2. **Empty pattern `let [] = nonIterable`** — per spec, GetIterator
+   must still fire on the RHS (observable). The helper's empty-pattern
+   short-circuit at line 685 (`isPatternEmptyOnly(pattern)`) **does
+   skip** materialization. If a test262 case requires the call,
+   investigate after the merge; the issue file's
+   `ary-ptrn-empty` cluster (3 fails) hits exactly this.
+
+3. **Elision `let [, x] = [1, 2]`** — `ts.OmittedExpression`. The
+   helper skips elision in the standard loop. The helper's externref
+   branch handles this correctly via `__extern_get_idx(i)`. Verify
+   `ary-ptrn-elision-*` flips.
+
+4. **Tuple-struct vec rest** — current `compileArrayDestructuring`
+   has a tuple+rest fallback at line 1176-1184 that converts to
+   externref. The helper does the same via its anyref + vec_externref
+   conversion (line 690-806). Behavior matches.
+
+5. **For-of head, for-in head** — these don't reach
+   `compileArrayDestructuring` (separate emission lane). No
+   cross-contamination.
+
+## Test files to verify
+
+- `tests/issue-1553.test.ts` — add cases for vec rest, throwing init,
+  null-nested.
+- `test/language/statements/{let,const,variable}/dstr/ary-ptrn-rest-*.js`
+- `test/language/statements/{let,const,variable}/dstr/ary-ptrn-elem-id-init-throws.js`
+- `test/language/statements/{let,const,variable}/dstr/ary-ptrn-elision-*.js`
+- `test/language/statements/{let,const,variable}/dstr/ary-init-iter-*.js`
+
+## Regression gate
+
+- Required: `net_per_test > 0`, no `ary-ptrn-*` bucket grows > 10.
+- Watch: any test asserting *exactly* a tuple-struct emission shape
+  (none expected) — none in test262.
+- Hard rule: if `assertion_fail` in `ary-ptrn-rest-array-elision.js`
+  appears (post-fix), block merge — that's the regression flag for
+  the `_arrayLiteralForceVec` flag interaction.
+
+## Estimated change size
+
+- ~ -750 LOC in `destructuring.ts` (the bulk of
+  `compileArrayDestructuring`).
+- ~ -180 LOC in `destructuring.ts` (the externref decl twin).
+- + 40 LOC of shim + `recoverBindingKind` (shared with #1553c).
+- Net: **~ -890 LOC** in a single PR.
+
+This is the largest slice; consider splitting into 1553d-1 (externref
+twin) and 1553d-2 (typed array body) if the PR exceeds ~600 LOC of
+*net* diff after deletions cancel insertions. The reviewer-burden line
+is "are the deletions safe?", which is the same question for both
+halves.
+
+## Risk
+
+High. `compileArrayDestructuring` is on the hottest destructuring
+lane (every `let [...] = expr`, every for-of head — well, for-of has
+its own path, but the bulk of tests). The helper has been exercised
+under param destructuring with the same RHS shapes for many sprints
+(through #1432, #1454, #1542, #1550), so the risk lives in two
+specific places:
+
+1. **String destructuring** branch — keep it in the caller.
+2. **Tuple-struct + rest** fallback — verify the helper's
+   conversion-to-externref path matches the current caller's
+   `convert + delegate` order.
+
+Mitigation:
+
+- Run `tests/equivalence.test.ts` locally after merge with a focus on
+  destructuring cases.
+- Inspect a diff of `wasm-dis` for `let [a,b,c]=arr` and
+  `let [...r]=arr` before and after.
+- Verify `tests/issue-1454.test.ts` and `tests/issue-1432.test.ts`
+  still pass.
+
+## Out of scope
+
+- f64 explicit-undefined sentinel → #1553e.
+- String destructuring rewrite (lives in
+  `compileStringDestructuring`, separate concern).
+- Removing the deprecated decl twin exports entirely (do in a
+  follow-up cleanup commit once nothing references them).

--- a/plan/issues/sprints/53/1553e.md
+++ b/plan/issues/sprints/53/1553e.md
@@ -1,0 +1,229 @@
+---
+id: 1553e
+sprint: 53
+title: "decl-dstr: f64-array literal with explicit `undefined` element must trigger destructuring default"
+status: ready
+created: 2026-05-20
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: array-literal, destructuring
+goal: spec-completeness
+parent: 1553
+depends_on: []
+unblocks: []
+related: [866, 1432, 1454]
+---
+
+# #1553e — Array literal `[undefined]` must let destructuring default fire for f64 elements
+
+Orthogonal to the helper-consolidation slices (#1553a-d). This is a
+codegen bug in array-literal compilation that affects all destructure
+modes (param, catch, decl) equally.
+
+## Root cause
+
+When the source array literal contains an explicit `undefined` and
+type inference resolves the element to `f64` (the common case in
+this compiler — anonymous numeric arrays), the `undefined` literal
+gets emitted as `f64.const NaN` (or `f64.const 0`), which is *not*
+the sNaN sentinel `0x7FF00000DEADC0DE` that `emitDefaultValueCheck`
+matches.
+
+Result: `let [x = 42] = [undefined]` produces `x = NaN` (or `x = 0`)
+instead of firing the default and producing `x = 42`.
+
+This is the same sentinel mechanism #866 introduced for missing
+function-parameter defaults. We need to extend it to:
+
+1. Out-of-bounds array reads (already done — `defaultValueInstrs`
+   emits the sentinel).
+2. **Explicit `undefined` literals in array initializers** (this issue).
+3. **Explicit `undefined` literals in object initializers** for f64
+   fields (related — verify behaviour, possibly a follow-up).
+
+## Failure patterns
+
+From the investigation §Reproductions:
+
+| Probe | Source | Pre-fix result | Post-fix expected |
+| --- | --- | --- | --- |
+| `let [x = bump()] = [undefined as any]` (vec f64) | array literal | `x = NaN`, default skipped | default fires, `x = 42` |
+| `let [, x = 9] = [1, undefined]` (vec f64) | array literal | `x = NaN` | `x = 9` |
+| `function f([x = 7]) { return x } f([undefined])` (param) | param destructure | likely same bug | `x = 7` |
+
+test262 patterns expected to flip:
+
+- `ary-ptrn-elem-id-init-skipped.js` (let/const/var variants).
+- `ary-ptrn-elem-id-init-fn-name-fn.js` (combined with #1450).
+- Selected `for-of/dstr/ary-ptrn-elem-id-init-*.js`.
+
+Estimated direct unlock: **~8-12** cases.
+
+## Changes
+
+### File: `src/codegen/expressions/array-literal.ts`
+
+(Confirm filename via `grep -nR "compileArrayLiteralExpression\|ArrayLiteral" src/codegen` — adjust accordingly. Likely lives in
+`src/codegen/expressions.ts` or `src/codegen/expressions/literal.ts`.)
+
+**Function:** the one that builds vec/tuple arrays from
+`ts.ArrayLiteralExpression`.
+
+For each element:
+
+```ts
+if (
+  ts.isIdentifier(element) &&
+  element.text === "undefined" &&
+  /* not shadowed in scope */
+) {
+  if (elemType.kind === "f64") {
+    // Emit sNaN sentinel so destructuring default fires (#1553e)
+    fctx.body.push({ op: "i64.const", value: 0x7ff00000deadc0den } as unknown as Instr);
+    fctx.body.push({ op: "f64.reinterpret_i64" } as unknown as Instr);
+    continue;
+  }
+  if (elemType.kind === "externref") {
+    // Emit JS undefined (already handled — verify)
+    const undefIdx = ensureGetUndefined(ctx);
+    if (undefIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: undefIdx });
+      continue;
+    }
+  }
+}
+```
+
+Use the same sentinel emit pattern as `defaultValueInstrs` in
+`type-coercion.ts:2266` so the values match exactly.
+
+**Important — undefined identifier resolution**: only emit the
+sentinel when the `undefined` identifier resolves to the global
+`undefined` (i.e. is not shadowed by a local). Use
+`ctx.checker.getSymbolAtLocation(element)` and verify the symbol is
+the global `undefined` (or has no local declaration). For
+`void 0` literal — also treat as undefined. **Implementation hint**:
+factor out an `isUndefinedExpression(ctx, node): boolean` helper if
+one doesn't already exist (grep first — there's likely one near the
+existing `isNullOrUndefinedLiteral` in `destructuring-params.ts:170`).
+
+### File: `src/codegen/destructuring-params.ts` (verify only)
+
+Confirm `isNullOrUndefinedLiteral(expr: ts.Expression): boolean`
+exists (line 170) and use it as a model.
+
+## Wasm IR pattern
+
+For `[1, undefined, 3]` when inferred as `vec_f64`:
+
+```wasm
+;; alloc array of 3 f64
+i32.const 3
+array.new_default $arr_f64
+local.tee $arr_tmp
+
+;; elem 0 = 1
+i32.const 0
+f64.const 1
+array.set $arr_f64
+
+;; elem 1 = sNaN sentinel (explicit undefined)
+local.get $arr_tmp
+i32.const 1
+i64.const 0x7ff00000deadc0de
+f64.reinterpret_i64
+array.set $arr_f64
+
+;; elem 2 = 3
+local.get $arr_tmp
+i32.const 2
+f64.const 3
+array.set $arr_f64
+
+;; len
+i32.const 3
+local.get $arr_tmp
+struct.new $vec_f64
+```
+
+## Edge cases
+
+1. **`void 0` and `(undefined)`** — both must produce the sentinel.
+   Use a shared `isUndefinedExpression` helper.
+
+2. **User-defined local `let undefined = 5; arr = [undefined]`** —
+   must NOT produce the sentinel; emit the user's local value. This
+   is why symbol resolution matters.
+
+3. **`{a: undefined}` object literal with f64 field type** — same
+   sentinel logic applies. Consider as **follow-up**: do not fix in
+   this slice unless trivial (different code path:
+   `compileObjectLiteralExpression`).
+
+4. **Vec_externref array** — `[undefined as externref]` already maps
+   to `__get_undefined()`. No change.
+
+5. **i32 element type** — i32 has no reliable sentinel (already
+   noted in `emitDefaultValueCheck`). Skip — `i32` defaults already
+   never fire. Document as known limitation; track separately if a
+   test surfaces.
+
+6. **`[, ]` (elision)** — elision is **not** explicit-undefined per
+   spec (`§13.2.4.1 ArrayAccumulation`). Out-of-bounds reads use the
+   sentinel already. Make sure your detection treats elision (empty
+   element slot) the same as OOB, not as explicit undefined. (In TS
+   AST, elision is `ts.OmittedExpression`, which is not an
+   `Identifier` — so the gate naturally skips it.)
+
+## Test files
+
+- `tests/issue-1553e.test.ts` — new focused regressions:
+  - `[undefined, undefined]` with array destructuring + defaults.
+  - `[1, undefined, 3][1]` direct index access must produce
+    sentinel-compatible value (or, if we keep direct-index reads
+    returning sentinel as well, document that NaN-the-sentinel and
+    NaN-the-value alias).
+
+## Regression gate
+
+- Required: `net_per_test > 0`, no bucket grows > 5.
+- Watch: any test that does `arr[i] === undefined` on a numeric
+  array — the sentinel would now compare as `NaN`, which is
+  `=== undefined`-false (already false today, but verify). The sNaN
+  bit pattern flushes to a quiet NaN in arithmetic — confirm
+  `arr[i] + 0 === NaN` (it is, both pre- and post-fix).
+
+## Estimated change size
+
+~30 LOC in `array-literal.ts`, plus optional ~15 LOC for the
+shared `isUndefinedExpression` helper if one doesn't exist. Plus
+~50 LOC of focused regression test.
+
+## Risk
+
+Low-medium. Sentinel values may **leak** into user-observable code if
+the user writes `arr[0]` and then compares to a specific NaN bit
+pattern — but no realistic JS code does that, and the sentinel is
+indistinguishable from a quiet NaN under all standard JS operations
+(`===`, `Number.isNaN`, arithmetic).
+
+The one observable place is `Number.isNaN(arr[0])` which returns true
+both pre- and post-fix. ✅ Safe.
+
+## Out of scope
+
+- Helper consolidation → #1553a-d.
+- Object-literal explicit-undefined → follow-up.
+- i32 sentinel mechanism → infeasible (no reliable sentinel).
+- NamedEvaluation → #1450.
+
+## Why this is independent of #1553a-d
+
+The bug is in *value production* (how `[undefined]` lowers to
+Wasm), not in *destructuring*. Fixing the helper does nothing for
+this case because the helper's default check is correct — it just
+never observes the sentinel because the array literal emits a
+non-sentinel value. Hence orthogonal; can land in parallel.


### PR DESCRIPTION
## Summary

Decomposes #1553 into 5 sliced sub-issues with focused implementation plans,
each keyed to exact file:line targets in `src/codegen/`. The dev's
investigation (issue body §Investigation 2026-05-20) identified 5 distinct
codegen bugs across `destructuring.ts` + `destructuring-params.ts` +
`type-coercion.ts` + `array-methods.ts`. A single-call-site fix doesn't pass
any test262 case end-to-end — needs slicing.

| Sub | LOC delta | Bugs closed | Depends |
| --- | --- | --- | --- |
| **1553a** | +150 (additive) | helper plumbing | — |
| **1553b** | −260 | bug 3 (typed nested default) + bug 2 partial | 1553a |
| **1553c** | −130 | bug 1, bug 2 (struct-via-extern_get), bug 4, bug 8 | 1553a, 1553b |
| **1553d** | −890 | bug 6 (vec rest), iter-close, array-side bug 4 | 1553a, 1553c |
| **1553e** | +30 | bug 5 (f64 explicit-undefined sentinel) | independent |

## Sequencing

1. **1553a first** — additive, no behaviour change, unblocks everything.
2. **1553b** — smallest behaviour-change PR, validates plumbing on typed-struct lane.
3. **1553c** — closes the "structural blocker" (bug 2) via the helper's `ref.test`+`ref.cast` fast path.
4. **1553d** — largest deletion (~890 LOC), most unlock (≥35 test262 cases).
5. **1553e** — orthogonal, can land any time.

## Expected unlock

- 1553b: ≥18 cases
- 1553c: ≥24 cases (after #1552 lands)
- 1553d: ≥35 cases
- 1553e: ~8-12 cases
- **Total: ~85-100 case flips**, comfortably hitting #1553 acceptance criterion 6 (≥60).

## Files

- `plan/issues/sprints/53/1553a.md` through `1553e.md` (new)
- `plan/issues/sprints/52/1553-…residuals.md` — appended architect-spec section, `status: needs-spec` → `decomposed`

## Test plan

- [ ] Plan-only PR; no source changes; no CI test impact expected
- [ ] Manual: confirm sub-issues appear in sprint 53 dir, parent issue links to them, dependency chain (1553a → b → c → d; e independent) renders correctly in the table
- [ ] After merge: tech lead populates TaskList with 1553a as `ready`, 1553b/c/d as `blocked`, 1553e as `ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)