### PR TITLE
fix(#820c): async-gen yield* object-method null deref (~39 fails)

### DIFF
--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -420,7 +420,18 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           wasmType.kind === "i64" ||
           wasmType.kind === "externref";
         const newIsRef = wasmType.kind === "ref" || wasmType.kind === "ref_null";
-        if (!(existingIsRef && newIsPrimitive) && !(existingIsExternref && newIsRef)) {
+        // (#820c) Accessor object literals always produce externref — the
+        // local's hoisted ref-struct type would force a ref.cast that fails
+        // on the JS host plain object, silently nulling the captured value
+        // and trapping later closures (#820c, async-gen-yield-star-*). The
+        // hoist pass emits no initialization for ref-typed locals, so
+        // narrowing ref → externref here is safe (no struct.new to
+        // invalidate, and externref locals default to ref.null.extern which
+        // is the same "undefined" sentinel a hoisted externref would carry
+        // before its first assignment).
+        if (initIsAccessorLiteral && existingIsRef && wasmType.kind === "externref") {
+          localSlot.type = wasmType;
+        } else if (!(existingIsRef && newIsPrimitive) && !(existingIsExternref && newIsRef)) {
           localSlot.type = wasmType;
         }
       }


### PR DESCRIPTION
## Summary
Fixes the null-pointer dereference in async-gen yield* with object-method iterables (~39 test262 fails in `language/expressions/object/method-definition/async-gen-yield-star-*`).

When a var/let is pre-hoisted with a struct ref type but its initializer is an object literal carrying get/set accessors, the local must be externref (JS host object). The previous guard in `compileVariableStatement` blocked the ref→primitive narrowing entirely, so the local kept its ref-struct type and the subsequent store of the accessor literal (externref) emitted a `ref.cast` that fails at runtime on the plain JS object — silently nulling captured references and trapping later closures.

The hoist pass emits no initialization for ref-typed locals, so narrowing ref → externref here is safe.

## Test plan
- [ ] CI: `language/expressions/object/method-definition/async-gen-yield-star-*` move from null-deref → pass
- [ ] No regressions in other accessor-literal codegen paths

Closes #820c.