### PR TITLE
fix(#779c): String.prototype.split result .constructor === Array

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2323,7 +2323,17 @@ function emitVecAccessExports(ctx: CodegenContext): void {
   // Emit vec access exports when the runtime may need to introspect WasmGC arrays:
   // - for-of iteration on non-array types (__iterator)
   // - JSON.stringify on arrays of structs (JSON_stringify)
-  if (!ctx.funcMap.has("__iterator") && !ctx.funcMap.has("JSON_stringify") && !ctx.funcMap.has("__make_iterable"))
+  // - (#779c) `vec.constructor === Array` identity via the runtime's
+  //   `extern_get` constructor path, which calls `__vec_len` to positively
+  //   distinguish vec wrappers from other null-prototype WasmGC structs.
+  //   When `__extern_get` is imported, the property-access lowering may
+  //   need this discrimination for `vec.constructor` lookups.
+  if (
+    !ctx.funcMap.has("__iterator") &&
+    !ctx.funcMap.has("JSON_stringify") &&
+    !ctx.funcMap.has("__make_iterable") &&
+    !ctx.funcMap.has("__extern_get")
+  )
     return;
   try {
     _emitVecAccessExportsInner(ctx);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4673,7 +4673,22 @@ assert._isSameValue = isSameValue;
     case "extern_get":
       return (obj: any, key: any) => {
         const val = _safeGet(obj, key);
-        if (val !== undefined) return val;
+        if (val !== undefined) {
+          // (#779c) Sandbox-aware constructor identity. When a
+          // `globalSandbox` is supplied (test262 per-test realm isolation),
+          // the test's `Array` identifier resolves via `declared_global` to
+          // `sandbox.Array`, but `obj.constructor` for host JS arrays
+          // returns `globalThis.Array`. Substitute the sandbox version so
+          // `arr.constructor === Array` holds. No-op without a sandbox.
+          if (globalSandbox && key === "constructor" && typeof val === "function") {
+            const fname = (val as { name?: string }).name;
+            if (fname && val === (globalThis as any)[fname]) {
+              const sb = globalSandbox[fname];
+              if (sb !== undefined) return sb;
+            }
+          }
+          return val;
+        }
         if (typeof key === "string") {
           const exports = callbackState?.getExports();
           const getter = exports?.[`__sget_${key}`];
@@ -4693,7 +4708,11 @@ assert._isSameValue = isSameValue;
           if (typeof vecLen === "function") {
             try {
               const len = vecLen(obj);
-              if (typeof len === "number") return Array;
+              if (typeof len === "number") {
+                // (#779c) Return sandbox.Array when test262 sandbox is active,
+                // so `vec.constructor === Array` (sandbox.Array) holds.
+                return globalSandbox?.Array ?? Array;
+              }
             } catch {
               // Not a vec wrapper — fall through
             }

--- a/tests/issue-779c.test.ts
+++ b/tests/issue-779c.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+import { writeFileSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+/**
+ * #779c — String.prototype.split result `.constructor` must be `Array`.
+ *
+ * The test262 runner supplies a `globalSandbox` (vm.createContext) for
+ * per-test built-in isolation. The test's `Array` identifier resolves to
+ * `sandbox.Array` via `declared_global`, but the runtime's `extern_get`
+ * for `vec.constructor` previously returned `globalThis.Array` — identity
+ * mismatch failed ~78 split/array constructor assertions.
+ *
+ * The fix in src/runtime.ts substitutes `sandbox.Array` when a sandbox is
+ * active, restoring identity. src/codegen/index.ts is also updated to emit
+ * `__vec_len` whenever `__extern_get` is imported so the runtime can
+ * positively identify vec wrappers when this code path runs.
+ */
+
+function writeTest262Style(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "issue-779c-"));
+  const file = join(dir, "test.js");
+  writeFileSync(
+    file,
+    `// Copyright test262
+/*---
+description: synthetic regression test for #779c
+---*/
+
+${body}
+`,
+  );
+  return file;
+}
+
+describe("#779c — String.prototype.split / Array literal constructor identity under sandbox", () => {
+  it("'a,b,c'.split(',') result has constructor === Array", async () => {
+    const file = writeTest262Style(`
+      var __split = "a,b,c".split(",");
+      assert.sameValue(__split.constructor, Array);
+      assert.sameValue(__split.length, 3);
+    `);
+    const r = await runTest262File(file, "test", 30000);
+    expect(r.status).toBe("pass");
+  });
+
+  it("array literal has constructor === Array", async () => {
+    const file = writeTest262Style(`
+      var __arr = [1, 2, 3];
+      assert.sameValue(__arr.constructor, Array);
+    `);
+    const r = await runTest262File(file, "test", 30000);
+    expect(r.status).toBe("pass");
+  });
+
+  it("Array.prototype.constructor === Array", async () => {
+    const file = writeTest262Style(`
+      assert.sameValue(Array.prototype.constructor, Array);
+    `);
+    const r = await runTest262File(file, "test", 30000);
+    expect(r.status).toBe("pass");
+  });
+
+  it("new Array() has constructor === Array", async () => {
+    const file = writeTest262Style(`
+      var __arr = new Array(3);
+      assert.sameValue(__arr.constructor, Array);
+    `);
+    const r = await runTest262File(file, "test", 30000);
+    expect(r.status).toBe("pass");
+  });
+
+  it("real test262 split test passes", async () => {
+    const r = await runTest262File(
+      "/workspace/test262/test/built-ins/String/prototype/split/instance-is-string.js",
+      "built-ins/String",
+      30000,
+    );
+    expect(r.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

In the test262 runner each test runs against a per-test `globalSandbox` (vm.createContext) so that mutations to `Array.prototype` etc. cannot leak between tests. The test's bare `Array` identifier already routes through the `declared_global` import → `sandbox.Array`, but the runtime's `extern_get` returned `globalThis.Array` for `obj.constructor` on:

* wasm vec wrappers (split / array literals / map result) — via the existing `__vec_len`-discriminated branch that hard-coded `return Array`;
* real host JS arrays (e.g. results of `string_split` host import) — via the plain JS prototype chain.

The identity mismatch failed `assert.sameValue(result.constructor, Array)` across ~78 test262 split tests and the equivalent pattern on array literals, `new Array()`, and `Array.prototype.constructor`.

## Fix (two parts)

1. **`src/runtime.ts`** — in `extern_get`, when a `globalSandbox` is active and the key is `"constructor"`, substitute the looked-up value with `sandbox[val.name]` whenever it matches a host built-in (symmetric with the existing `declared_global` sandbox routing). Also use `globalSandbox?.Array ?? Array` in the vec-wrapper branch. Without a sandbox both paths are identity no-ops, preserving the historical fast path.

2. **`src/codegen/index.ts`** — also emit `__vec_len` / `__vec_get` when `__extern_get` is imported. The runtime's vec-wrapper constructor branch depends on `__vec_len` to positively distinguish vec wrappers from other null-prototype WasmGC structs (the fieldNames-based heuristic was previously judged too broad — see #1057 comment). Prior gating (iterator / JSON.stringify / make_iterable) excluded simple `arr.constructor` cases, so the branch was silently inert.

## Test plan

`tests/issue-779c.test.ts` exercises the regression via the real test262 runner:
- `"a,b,c".split(",").constructor === Array`
- `[1,2,3].constructor === Array`
- `Array.prototype.constructor === Array`
- `new Array(3).constructor === Array`
- A real test262 file: `built-ins/String/prototype/split/instance-is-string.js`

All 5 pass locally. CI will validate the broader test262 delta — the issue claims ~78 split fails should flip; the same pattern also exists in many `built-ins/Array/**` tests so the actual win may be larger. Non-constructor split failures (TypeError, primitive coercion) are pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)