### PR TITLE
ci: gate test262 behind cheap checks + auto-refresh open PRs on main push

### DIFF
--- a/.github/workflows/auto-refresh-prs.yml
+++ b/.github/workflows/auto-refresh-prs.yml
@@ -1,0 +1,55 @@
+name: Auto-refresh open PR branches with main
+
+on:
+  push:
+    branches: [main]
+
+# Skip auto-refresh commits to avoid infinite loops
+concurrency:
+  group: auto-refresh-prs
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    if: ${{ !contains(github.event.head_commit.message, '[skip auto-refresh]') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 30
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.email "ci-auto-refresh@js2wasm.local"
+          git config user.name "ci-auto-refresh"
+
+      - name: Refresh each open PR branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # List open PRs targeting main
+          prs=$(gh pr list --state open --base main --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"')
+          echo "$prs" | while read pr branch; do
+            [ -z "$branch" ] && continue
+            echo "=== Refreshing PR #$pr (branch: $branch) ==="
+            git fetch origin "$branch" || { echo "  failed to fetch — skip"; continue; }
+            git checkout -B "$branch" "origin/$branch"
+            if git merge-base --is-ancestor origin/main HEAD; then
+              echo "  already up to date"
+              continue
+            fi
+            if git merge origin/main --no-edit -m "Merge main into $branch (auto-refresh after $(git rev-parse --short origin/main))"; then
+              git push origin "$branch"
+              echo "  merged and pushed"
+            else
+              echo "  conflict — leaving for dev"
+              git merge --abort
+              gh pr comment "$pr" --body "Auto-refresh failed: this branch conflicts with the latest \`main\`. Please merge \`origin/main\` locally, resolve the conflicts, and push." || true
+            fi
+          done

--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -1,8 +1,6 @@
 name: Refresh Benchmarks
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -19,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Verify origin/main is merged into branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: |
           git fetch origin main
           if ! git merge-base --is-ancestor origin/main HEAD; then

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/diff-test.yml"
   push:
     branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -68,8 +71,8 @@ jobs:
 
       # Delta-gate ON PRs ONLY — block merge if a previously-matching program
       # now mismatches. On `push: main` the baseline is refreshed below.
-      - name: Delta gate (PR only)
-        if: github.event_name == 'pull_request'
+      - name: Delta gate (PR + merge queue)
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: npx tsx scripts/diff-test-gate.ts
 
       # On merge to main, refresh the committed baseline so the next PR

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -41,6 +41,9 @@ on:
       - "tests/test262-runner.ts"
       - "tests/test262-scope-classification.test.ts"
       - "tests/test262-shared.ts"
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       include_proposals:
@@ -78,6 +81,7 @@ concurrency:
   group: >-
     ${{ github.event_name == 'push' && 'test262-sharded-main'
      || github.event_name == 'pull_request' && format('test262-sharded-pr-{0}', github.ref)
+     || github.event_name == 'merge_group' && format('test262-sharded-mq-{0}', github.ref)
      || format('test262-sharded-dispatch-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -85,7 +89,7 @@ jobs:
   gate:
     name: cheap gate (main-ancestor + lint)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -124,7 +128,7 @@ jobs:
           if grep -q '"lint"' package.json; then pnpm run lint 2>&1 | tail -50; fi
 
   test262-shard:
-    if: (github.event_name != 'push' || github.actor != 'github-actions[bot]') && (github.event_name != 'pull_request' || needs.gate.result == 'success')
+    if: (github.event_name != 'push' || github.actor != 'github-actions[bot]') && ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.gate.result == 'success')
     needs: [gate]
     name: test262 shard ${{ matrix.chunk }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -82,8 +82,50 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  gate:
+    name: cheap gate (main-ancestor + lint)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Verify origin/main is merged into branch
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "origin/main is an ancestor of this branch"
+          else
+            missing=$(git log HEAD..origin/main --oneline | grep -v '\[skip ci\]' | wc -l)
+            if [ "$missing" -eq 0 ]; then
+              echo "only [skip ci] commits not in branch"
+            else
+              echo "::error::Branch is missing $missing non-[skip ci] commits from origin/main. The auto-refresh workflow should have merged main into this branch automatically — if it didn't, push 'git merge origin/main' manually."
+              exit 1
+            fi
+          fi
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck + lint
+        run: |
+          pnpm run typecheck 2>&1 | tail -50 || (echo "::error::typecheck failed"; exit 1)
+          # If lint script exists, run it (otherwise skip silently)
+          if grep -q '"lint"' package.json; then pnpm run lint 2>&1 | tail -50; fi
+
   test262-shard:
-    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
+    if: (github.event_name != 'push' || github.actor != 'github-actions[bot]') && (github.event_name != 'pull_request' || needs.gate.result == 'success')
+    needs: [gate]
     name: test262 shard ${{ matrix.chunk }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -171,7 +213,7 @@ jobs:
   merge-report:
     if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     name: merge shard reports
-    needs: test262-shard
+    needs: [test262-shard]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Three coordinated workflow changes that fix the runner-hour waste observed during today's 17-PR merge wave:

1. **`test262-sharded.yml`** — add a `gate` job (main-ancestor check + lint + typecheck) before the 5h shard matrix. Stale or broken branches fail in ~5 min instead of 5 hours.

2. **`benchmark-refresh.yml`** — remove `pull_request` trigger; benchmarks are main-only.

3. **`auto-refresh-prs.yml`** (new) — on push to main, merge main into every open PR branch and push. Preserves reproducibility (branch state = what CI tested) and eliminates the manual "merge main, push, wait" loop.

## Replaces #472

#472 tried to fix this by merging main *inside the test262 runner*. That breaks reproducibility (re-running the same PR tomorrow gives a different result because main moved). This PR fixes the same problem from the other direction: keep CI deterministic, and push the actual merge to the branch via a separate workflow.

## Test plan

- [ ] All three YAMLs validate
- [ ] After merge: a stale PR opens and the gate job fails fast on it (no 5h shards)
- [ ] After this PR merges: every open PR should receive an auto-refresh commit