### PR TITLE
feat(landing): add Javy + StarlingMonkey lanes to cold/warm isolate charts (#111)

### DIFF
--- a/benchmarks/results/wasm-host-wasmtime-hot-runtime.json
+++ b/benchmarks/results/wasm-host-wasmtime-hot-runtime.json
@@ -8,7 +8,10 @@
     "jsStdUs": 1916.3658326571722,
     "ratioStd": 0.15066153057109066,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 28800.0,
+    "starlingMonkeyUs": 37200.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib",
@@ -19,7 +22,10 @@
     "jsStdUs": 2451.8673361206543,
     "ratioStd": 0.42521984331324486,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 1193200.0,
+    "starlingMonkeyUs": 1024300.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib-recursive",
@@ -30,7 +36,10 @@
     "jsStdUs": 2988.8171321253485,
     "ratioStd": 0.18074199423778278,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 31200.0,
+    "starlingMonkeyUs": 26400.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib-recursive",
@@ -41,7 +50,10 @@
     "jsStdUs": 42.874978923301676,
     "ratioStd": 0.04413647198341376,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 87900.0,
+    "starlingMonkeyUs": 156700.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "array-sum",
@@ -52,7 +64,10 @@
     "jsStdUs": 2104.273302890544,
     "ratioStd": 0.35379093353823926,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 28000.0,
+    "starlingMonkeyUs": 31000.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "array-sum",
@@ -63,7 +78,10 @@
     "jsStdUs": 547.3251063111289,
     "ratioStd": 6.749706276568299,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 112900.0,
+    "starlingMonkeyUs": 125500.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "string-hash",
@@ -74,7 +92,10 @@
     "jsStdUs": 2851.9373522509827,
     "ratioStd": 0.047219569864664565,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 30700.0,
+    "starlingMonkeyUs": 30500.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "string-hash",
@@ -85,6 +106,9 @@
     "jsStdUs": 34.88853686077583,
     "ratioStd": 0.0004946225297867972,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 36000.0,
+    "starlingMonkeyUs": 14200.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   }
 ]

--- a/components/perf-benchmark-chart.js
+++ b/components/perf-benchmark-chart.js
@@ -903,6 +903,11 @@ class PerfBenchmarkChart extends HTMLElement {
       const baseOpacity = "0.1";
       const gradDir = ratio >= 1 ? "to right" : "to left";
       const textOpacity = (0.4 + dist * 0.6).toFixed(2);
+      // When the row carries an explicit lane colour (4-lane perf mode), use it
+      // instead of the default white gradient. baseColor/edgeColor are CSS
+      // colour strings with alpha already applied.
+      const customBaseColor = row.fillColor || `rgba(255,255,255,${baseOpacity})`;
+      const customEdgeColor = row.edgeColor || row.fillColor || null;
 
       const rowEl = document.createElement("div");
       rowEl.className = "bench-row";
@@ -926,6 +931,8 @@ class PerfBenchmarkChart extends HTMLElement {
         baseOpacity,
         edgeOpacity,
         textOpacity,
+        customBaseColor,
+        customEdgeColor,
         ratioStd: Number(row.ratioStd ?? 0),
         fillEl: rowEl.querySelector(".bench-fill"),
         errorEl: rowEl.querySelector(".bench-errorbar"),
@@ -960,7 +967,14 @@ class PerfBenchmarkChart extends HTMLElement {
 
         d.fillEl.style.left = curLeft + "%";
         d.fillEl.style.width = curWidth + "%";
-        d.fillEl.style.background = `linear-gradient(${d.gradDir}, rgba(255,255,255,${d.baseOpacity}), rgba(255,255,255,${curEdgeOp}))`;
+        if (d.customEdgeColor) {
+          // Lane-coloured bar: animate edge alpha by varying the gradient stop
+          // alpha. We keep the colour fixed and let the existing dist→alpha
+          // scaling stay visually consistent across lanes.
+          d.fillEl.style.background = `linear-gradient(${d.gradDir}, ${d.customBaseColor}, ${d.customEdgeColor})`;
+        } else {
+          d.fillEl.style.background = `linear-gradient(${d.gradDir}, rgba(255,255,255,${d.baseOpacity}), rgba(255,255,255,${curEdgeOp}))`;
+        }
 
         const stdRatio = Math.min(d.ratioStd || 0, Math.max(d.ratio - 0.01, 0), Math.max(scaleMax / 100 - d.ratio, 0));
         if (stdRatio > 0) {
@@ -1275,11 +1289,59 @@ class PerfBenchmarkChart extends HTMLElement {
           return;
         }
         ratios = [];
+        // Lane definitions: when any of these alternate fields are present we
+        // fan a row out into multiple lanes (one bar per lane). The js2wasm
+        // lane is always emitted from `wasmUs`; the others are conditional.
+        // Color is picked up by _renderRatioRows via row.fillColor.
+        const LANES = [
+          {
+            key: "wasmUs",
+            label: "js2wasm AOT",
+            // Brand blue (matches site primary), bright to identify "ours".
+            color: "rgba(96, 165, 250, 0.95)",
+            edgeColor: "rgba(96, 165, 250, 0.95)",
+          },
+          {
+            key: "javyUs",
+            label: "Javy (interpreter)",
+            color: "rgba(251, 146, 60, 0.85)",
+            edgeColor: "rgba(251, 146, 60, 0.95)",
+          },
+          {
+            key: "starlingMonkeyUs",
+            label: "StarlingMonkey (engine)",
+            color: "rgba(192, 132, 252, 0.85)",
+            edgeColor: "rgba(192, 132, 252, 0.95)",
+          },
+        ];
+        const anyHasExtraLanes = rows.some(
+          (row) => Number(row?.javyUs ?? 0) > 0 || Number(row?.starlingMonkeyUs ?? 0) > 0,
+        );
         for (const row of rows) {
-          const wasmUs = Number(row?.wasmUs ?? 0);
           const jsUs = Number(row?.jsUs ?? 0);
-          if (wasmUs <= 0 || jsUs <= 0) continue;
-          ratios.push({ ...row, ratio: jsUs / wasmUs, ratioStd: Number(row?.ratioStd ?? 0) });
+          if (jsUs <= 0) continue;
+          if (anyHasExtraLanes) {
+            // Multi-lane mode: emit one ratio entry per present lane. The lane
+            // name becomes the row label so the chart shows lane-per-bar.
+            const baseName = row?.name ?? "unknown";
+            for (const lane of LANES) {
+              const us = Number(row?.[lane.key] ?? 0);
+              if (us <= 0) continue;
+              ratios.push({
+                ...row,
+                name: `${baseName} — ${lane.label}`,
+                ratio: jsUs / us,
+                ratioStd: 0,
+                fillColor: lane.color,
+                edgeColor: lane.edgeColor,
+                lane: lane.key,
+              });
+            }
+          } else {
+            const wasmUs = Number(row?.wasmUs ?? 0);
+            if (wasmUs <= 0) continue;
+            ratios.push({ ...row, ratio: jsUs / wasmUs, ratioStd: Number(row?.ratioStd ?? 0) });
+          }
         }
       }
       const isAbsoluteMode = mode === "absolute-lower-better" || mode === "runtime" || mode === "module-size";

--- a/index.html
+++ b/index.html
@@ -3091,20 +3091,23 @@ match (value) {
         </div>
 
         <div class="host-bench-group" id="wasmtime-bench-group" style="display: none">
-          <h3 class="host-bench-title">WebAssembly host (Wasmtime) vs V8 isolate</h3>
+          <h3 class="host-bench-title">Four execution models on the same JS programs</h3>
           <p class="host-bench-subcopy">
             Per-request cost of running the same
             <a href="./benchmarks/competitive/programs/">JavaScript programs</a>
-            on two edge serverless execution models:
-            <strong>
-              Wasmtime with AOT-precompiled
-              <code>.cwasm</code>
-            </strong>
-            (Cranelift compiles offline, no runtime codegen) versus a
+            across four execution models on edge:
+            <strong>js2wasm AOT</strong>
+            (Cranelift-compiled
+            <code>.cwasm</code>
+            , no runtime codegen),
             <strong>V8 isolate</strong>
-            (Ignition → Liftoff → TurboFan, all at request time). Two scenarios per program: a fresh instance per
-            request (cold isolate) and a reused instance (warm isolate). Cranelift-AOT cost stays flat across both; V8
-            swings dramatically because most of its cost is parse + tier-up, paid once per fresh isolate.
+            (Ignition → Liftoff → TurboFan, all at request time),
+            <strong>Javy</strong>
+            (interpreter — Shopify-style dynamic-link, QuickJS plugin preloaded; ~3 kB per function), and
+            <strong>StarlingMonkey</strong>
+            (engine — SpiderMonkey-as-Wasm via ComponentizeJS + Wizer + Weval; ~14 MB per function). Two scenarios per
+            program: fresh instance per request (cold) and reused instance (warm). Javy and StarlingMonkey both run a JS
+            interpreter inside Wasm — the size and per-call cost tradeoff isn't free.
           </p>
           <div class="conformance-diagrams">
             <div
@@ -3119,7 +3122,7 @@ match (value) {
                 mode="perf"
                 title="Cold isolate — fresh instance per request"
                 baseline-label="JS in V8"
-                legend="Full process wall time. Wasmtime: startup + cwasm load + invocation. V8: startup + parse + Ignition → Liftoff → first run. 2× = Wasm twice as fast per cold request as V8. The cost a per-request platform (or the first request to any platform) pays."
+                legend="Full process wall time per program × execution model. js2wasm AOT (blue) loads precompiled .cwasm; V8 (the 1.0× baseline) parses + tiers up; Javy (orange) and StarlingMonkey (purple) load their preloaded interpreter then run. Higher = faster than V8. Per-function deployment cost: js2wasm ~3 kB, Javy ~3 kB + shared plugin, StarlingMonkey ~14 MB."
               ></perf-benchmark-chart>
             </div>
             <div
@@ -3134,7 +3137,7 @@ match (value) {
                 mode="perf"
                 title="Warm isolate — instance reused across requests"
                 baseline-label="JS in V8 (TurboFan-tiered)"
-                legend="Steady-state per-invocation cost on a reused instance. V8: in-process median after TurboFan has tiered up. Wasm: exec time with process startup amortized away. 2× = Wasm twice as fast per warm request as V8. The cost a long-lived isolate pays after warmup."
+                legend="Steady-state per-invocation cost on a reused instance. V8 (1.0× baseline) is in-process median after TurboFan tiered up; js2wasm AOT runs native Cranelift code; Javy + StarlingMonkey run their interpreters inside Wasm (no guest JIT possible in sandboxed Wasm). Where Wasm-native compilation beats interpreter-in-Wasm by 1-2 orders of magnitude on tight loops."
               ></perf-benchmark-chart>
             </div>
             <div

--- a/public/benchmarks/results/wasm-host-wasmtime-hot-runtime.json
+++ b/public/benchmarks/results/wasm-host-wasmtime-hot-runtime.json
@@ -8,7 +8,10 @@
     "jsStdUs": 1916.3658326571722,
     "ratioStd": 0.15066153057109066,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 28800.0,
+    "starlingMonkeyUs": 37200.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib",
@@ -19,7 +22,10 @@
     "jsStdUs": 2451.8673361206543,
     "ratioStd": 0.42521984331324486,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 1193200.0,
+    "starlingMonkeyUs": 1024300.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib-recursive",
@@ -30,7 +36,10 @@
     "jsStdUs": 2988.8171321253485,
     "ratioStd": 0.18074199423778278,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 31200.0,
+    "starlingMonkeyUs": 26400.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "fib-recursive",
@@ -41,7 +50,10 @@
     "jsStdUs": 42.874978923301676,
     "ratioStd": 0.04413647198341376,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 87900.0,
+    "starlingMonkeyUs": 156700.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "array-sum",
@@ -52,7 +64,10 @@
     "jsStdUs": 2104.273302890544,
     "ratioStd": 0.35379093353823926,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 28000.0,
+    "starlingMonkeyUs": 31000.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "array-sum",
@@ -63,7 +78,10 @@
     "jsStdUs": 547.3251063111289,
     "ratioStd": 6.749706276568299,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 112900.0,
+    "starlingMonkeyUs": 125500.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "string-hash",
@@ -74,7 +92,10 @@
     "jsStdUs": 2851.9373522509827,
     "ratioStd": 0.047219569864664565,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 30700.0,
+    "starlingMonkeyUs": 30500.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   },
   {
     "name": "string-hash",
@@ -85,6 +106,9 @@
     "jsStdUs": 34.88853686077583,
     "ratioStd": 0.0004946225297867972,
     "warmupRounds": 2,
-    "measuredRounds": 7
+    "measuredRounds": 7,
+    "javyUs": 36000.0,
+    "starlingMonkeyUs": 14200.0,
+    "lanesProvenance": "javyUs/starlingMonkeyUs derived from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in benchmarks/competitive/README.md (labs repo commit 0d25e197a). Javy = Shopify-style dynamic-link with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + Wizer + Weval AOT. wasmUs/jsUs from local wasmtime + node measurements."
   }
 ]

--- a/scripts/generate-wasmtime-hot-runtime.mjs
+++ b/scripts/generate-wasmtime-hot-runtime.mjs
@@ -38,6 +38,24 @@
  * use Cranelift-compiled native code). Including it confused the message;
  * the genuine comparison is Cranelift AOT vs V8 JIT.
  *
+ * ## Javy + StarlingMonkey lanes
+ *
+ * The hot-runtime JSON also carries `javyUs` and `starlingMonkeyUs` per row
+ * so the landing-page chart can render four lanes: js2wasm AOT, V8 with JIT,
+ * Javy (interpreter), StarlingMonkey (engine).
+ *
+ * Those two values are NOT measured by this script — they require:
+ *   - wasmtime ≥ 40 (for component `--invoke "fn(args)"` syntax)
+ *   - javy + javy-default-plugin-v3 (Shopify-style dynamic-link mode)
+ *   - @bytecodealliance/componentize-js ≥ 0.20.0 + Wizer + Weval AOT
+ *
+ * The full four-lane harness lives in the labs repo under
+ * `benchmarks/compare-runtimes.ts` + `benchmarks/competitive/`. This script
+ * (the public landing-page generator) carries the verified Javy /
+ * StarlingMonkey numbers forward from that harness; refresh them when the
+ * labs run produces new measurements by editing JAVY_NUMBERS_MS /
+ * STARLINGMONKEY_NUMBERS_MS below.
+ *
  * Requirements: `wasmtime` (v35+) on PATH; competitive programs under
  * `public/benchmarks/competitive/programs/*.js`.
  */
@@ -68,6 +86,29 @@ const PROGRAMS = [
 const WARMUP_RUNS = 2;
 const MEASURED_RUNS = 7;
 const WASMTIME_FEATURES = ["-W", "gc=y", "-W", "function-references=y"];
+
+// Javy + StarlingMonkey verified numbers (2026-04-27 wasmtime 44.0.0,
+// aarch64-linux) — see labs benchmarks/compare-runtimes.ts.
+// Map: `cold` → README "Cold ms" (process startup + first call);
+//      `warm` → README "Compute-only ms" (steady-state per call).
+// Programs not present in either table fall back to 0 (omitted from chart).
+const JAVY_NUMBERS_MS = {
+  fib: { cold: 28.8, warm: 1193.2 },
+  "fib-recursive": { cold: 31.2, warm: 87.9 },
+  "array-sum": { cold: 28.0, warm: 112.9 },
+  "string-hash": { cold: 30.7, warm: 36.0 },
+};
+const STARLINGMONKEY_NUMBERS_MS = {
+  fib: { cold: 37.2, warm: 1024.3 },
+  "fib-recursive": { cold: 26.4, warm: 156.7 },
+  "array-sum": { cold: 31.0, warm: 125.5 },
+  "string-hash": { cold: 30.5, warm: 14.2 },
+};
+const LANES_PROVENANCE =
+  "javyUs/starlingMonkeyUs from verified 2026-04-27 wasmtime 44.0.0 aarch64-linux " +
+  "labs measurements (compare-runtimes.ts). Javy = Shopify-style dynamic-link " +
+  "with javy-default-plugin-v3 preload. StarlingMonkey = ComponentizeJS 0.20.0 + " +
+  "Wizer + Weval AOT.";
 
 function median(values) {
   if (values.length === 0) return 0;
@@ -189,7 +230,7 @@ function buildRow({ programId, scenario, wasmSamplesUs, jsSamplesUs }) {
   const ratioSamples = wasmSamplesUs.map(
     (us, i) => (jsSamplesUs[i] ?? jsSamplesUs[jsSamplesUs.length - 1]) / Math.max(us, 0.000001),
   );
-  return {
+  const row = {
     name: programId,
     scenario,
     wasmUs: median(wasmSamplesUs),
@@ -200,6 +241,18 @@ function buildRow({ programId, scenario, wasmSamplesUs, jsSamplesUs }) {
     warmupRounds: WARMUP_RUNS,
     measuredRounds: MEASURED_RUNS,
   };
+  const javyMs = JAVY_NUMBERS_MS[programId]?.[scenario];
+  if (typeof javyMs === "number" && javyMs > 0) {
+    row.javyUs = javyMs * 1000;
+  }
+  const smMs = STARLINGMONKEY_NUMBERS_MS[programId]?.[scenario];
+  if (typeof smMs === "number" && smMs > 0) {
+    row.starlingMonkeyUs = smMs * 1000;
+  }
+  if (row.javyUs || row.starlingMonkeyUs) {
+    row.lanesProvenance = LANES_PROVENANCE;
+  }
+  return row;
 }
 
 function writeOutput(rows) {


### PR DESCRIPTION
## Summary

The Wasmtime cold/warm isolate charts on the landing page now compare four execution models per JS program instead of two:

| Lane | Color | What it is | Per-function deployment size |
|---|---|---|---|
| **js2wasm AOT** | blue | Cranelift-compiled `.cwasm`, no runtime codegen | ~3 kB |
| **V8 with JIT** (baseline) | red baseline marker | Ignition → Liftoff → TurboFan | n/a (host) |
| **Javy (interpreter)** | orange | Shopify-style dynamic-link, QuickJS plugin preloaded | ~3 kB + shared plugin |
| **StarlingMonkey (engine)** | purple | SpiderMonkey-as-Wasm via ComponentizeJS + Wizer + Weval AOT | ~14 MB |

Two scenarios per program (cold isolate / warm isolate) × 4 programs × 3 Wasm lanes = 12 colour-coded bars per chart (V8 stays the 1.0× baseline marker).

## What changed

- **`components/perf-benchmark-chart.js`** — when input rows carry `javyUs` or `starlingMonkeyUs` alongside `wasmUs`/`jsUs`, the default `mode="perf"` now fans each row out into one bar per lane with a custom colour. Two-lane data still renders the same as before (graceful fallback).
- **`benchmarks/results/wasm-host-wasmtime-hot-runtime.json`** (+ `public/` copy) — every row carries `javyUs`, `starlingMonkeyUs`, and a `lanesProvenance` field documenting the source. Values are the verified 2026-04-27 wasmtime 44.0.0 aarch64-linux measurements published in the labs benchmarks/competitive/README.md (commit 0d25e197a before that tree moved to the private repo).
- **`scripts/generate-wasmtime-hot-runtime.mjs`** — documents the four-lane data shape and carries the Javy + StarlingMonkey numbers forward via `JAVY_NUMBERS_MS` / `STARLINGMONKEY_NUMBERS_MS` constant tables. Refresh those when new labs measurements land.
- **`index.html`** — subcopy and per-chart legends now name the four execution models, note the size tradeoff, and explain that the interpreter and engine lanes both run a JS interpreter inside Wasm (no guest JIT possible in sandboxed Wasm — that's why Wasm-native compilation wins by 1-2 orders of magnitude on tight loops).

## Mapping cold/warm to the labs harness output

```
cold scenario javyUs           <- README "Cold ms" * 1000
warm scenario javyUs           <- README "Compute-only ms" * 1000
cold/warm starlingMonkeyUs     <- same mapping
```

## Notable findings the data reveals

- **fib (tight numeric loop)**: js2wasm 8.8× faster than V8 cold; Javy + StarlingMonkey both 4-6× faster than V8 cold but 1-2 orders of magnitude slower than js2wasm warm.
- **string-hash (warm)**: StarlingMonkey beats both Javy and js2wasm — Weval AOT specialization amortizes interpreter dispatch on workloads with diverse opcode mixes, and string-hash is a known js2wasm rough spot (#1175).
- **cold start across the board**: all three Wasm lanes (~28-37 ms) beat V8 cold (~58-164 ms), even Javy/StarlingMonkey — V8 process startup is the heavyweight cost, not the interpreter loop.

## Test plan

- [ ] Open the landing page locally, verify the cold/warm charts render 12 colour-coded bars each
- [ ] Verify two-lane data (other charts) still render normally (graceful fallback)
- [ ] Verify `node --check` passes on both modified `.js` / `.mjs` files
- [ ] Verify the JSON file parses and all rows carry the 4 lane fields
- [ ] CI: workflow/UI/data-only PR, no `src/**` changes, so test262 is skipped per paths filter

Refs: task #111, labs PR #51/#52/#56 history in `plan/agent-context/dev-1125-bench.md`.