### PR TITLE
feat(landing): generic lane labels, monochrome bars, per-benchmark chart layout (#111 follow-up)

### DIFF
--- a/components/perf-benchmark-chart.js
+++ b/components/perf-benchmark-chart.js
@@ -1290,50 +1290,38 @@ class PerfBenchmarkChart extends HTMLElement {
         }
         ratios = [];
         // Lane definitions: when any of these alternate fields are present we
-        // fan a row out into multiple lanes (one bar per lane). The js2wasm
-        // lane is always emitted from `wasmUs`; the others are conditional.
-        // Color is picked up by _renderRatioRows via row.fillColor.
+        // fan a row out into multiple lanes (one bar per lane). Labels are
+        // generic execution-model categories (AOT / Interpreter / Engine) —
+        // bars are monochrome and distinguished by their label, not by color,
+        // so the comparison doesn't visually privilege any one lane.
         const LANES = [
-          {
-            key: "wasmUs",
-            label: "js2wasm AOT",
-            // Brand blue (matches site primary), bright to identify "ours".
-            color: "rgba(96, 165, 250, 0.95)",
-            edgeColor: "rgba(96, 165, 250, 0.95)",
-          },
-          {
-            key: "javyUs",
-            label: "Javy (interpreter)",
-            color: "rgba(251, 146, 60, 0.85)",
-            edgeColor: "rgba(251, 146, 60, 0.95)",
-          },
-          {
-            key: "starlingMonkeyUs",
-            label: "StarlingMonkey (engine)",
-            color: "rgba(192, 132, 252, 0.85)",
-            edgeColor: "rgba(192, 132, 252, 0.95)",
-          },
+          { key: "wasmUs", label: "AOT" },
+          { key: "javyUs", label: "Interpreter" },
+          { key: "starlingMonkeyUs", label: "Engine" },
         ];
         const anyHasExtraLanes = rows.some(
           (row) => Number(row?.javyUs ?? 0) > 0 || Number(row?.starlingMonkeyUs ?? 0) > 0,
         );
+        // When the caller has filtered down to a single benchmark name (the
+        // "one chart per benchmark" layout), prefix each bar with the scenario
+        // so cold/warm bars stay distinguishable inside the same chart.
+        const distinctBenchNames = new Set(rows.map((row) => String(row?.name ?? "")));
+        const showScenarioInLabel = distinctBenchNames.size === 1 && rows.some((row) => row?.scenario);
         for (const row of rows) {
           const jsUs = Number(row?.jsUs ?? 0);
           if (jsUs <= 0) continue;
           if (anyHasExtraLanes) {
-            // Multi-lane mode: emit one ratio entry per present lane. The lane
-            // name becomes the row label so the chart shows lane-per-bar.
-            const baseName = row?.name ?? "unknown";
+            // Multi-lane mode: emit one ratio entry per present lane. The
+            // label becomes the bar's row label so the chart shows lane-per-bar.
+            const baseName = showScenarioInLabel ? String(row?.scenario ?? "") : (row?.name ?? "unknown");
             for (const lane of LANES) {
               const us = Number(row?.[lane.key] ?? 0);
               if (us <= 0) continue;
               ratios.push({
                 ...row,
-                name: `${baseName} — ${lane.label}`,
+                name: baseName ? `${baseName} — ${lane.label}` : lane.label,
                 ratio: jsUs / us,
                 ratioStd: 0,
-                fillColor: lane.color,
-                edgeColor: lane.edgeColor,
                 lane: lane.key,
               });
             }

--- a/index.html
+++ b/index.html
@@ -3096,48 +3096,79 @@ match (value) {
             Per-request cost of running the same
             <a href="./benchmarks/competitive/programs/">JavaScript programs</a>
             across four execution models on edge:
-            <strong>js2wasm AOT</strong>
+            <strong>AOT</strong>
             (Cranelift-compiled
             <code>.cwasm</code>
             , no runtime codegen),
-            <strong>V8 isolate</strong>
-            (Ignition → Liftoff → TurboFan, all at request time),
-            <strong>Javy</strong>
-            (interpreter — Shopify-style dynamic-link, QuickJS plugin preloaded; ~3 kB per function), and
-            <strong>StarlingMonkey</strong>
-            (engine — SpiderMonkey-as-Wasm via ComponentizeJS + Wizer + Weval; ~14 MB per function). Two scenarios per
-            program: fresh instance per request (cold) and reused instance (warm). Javy and StarlingMonkey both run a JS
-            interpreter inside Wasm — the size and per-call cost tradeoff isn't free.
+            <strong>JS in V8</strong>
+            (Ignition → Liftoff → TurboFan, all at request time, the implicit 1.0× baseline),
+            <strong>Interpreter</strong>
+            (a per-function tiny module — ~3 kB — delegating to a preloaded QuickJS-style plugin), and
+            <strong>Engine</strong>
+            (a full JS engine bundled inside Wasm with AOT pre-init — ~14 MB per function). Two scenarios per program:
+            fresh instance per request (cold) and reused instance (warm). Interpreter and Engine both run a JS
+            interpreter inside Wasm — the size and per-call cost tradeoff isn't free. One chart per benchmark; each
+            chart shows AOT vs Interpreter vs Engine for both scenarios.
           </p>
           <div class="conformance-diagrams">
             <div
               class="diagram-panel"
               data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
-              data-row-filter="cold"
+              data-row-filter="fib"
               style="display: none"
             >
               <perf-benchmark-chart
                 src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
-                src-filter="cold"
+                benchmark="fib"
                 mode="perf"
-                title="Cold isolate — fresh instance per request"
+                title="fib — AOT vs Interpreter vs Engine (cold + warm)"
                 baseline-label="JS in V8"
-                legend="Full process wall time per program × execution model. js2wasm AOT (blue) loads precompiled .cwasm; V8 (the 1.0× baseline) parses + tiers up; Javy (orange) and StarlingMonkey (purple) load their preloaded interpreter then run. Higher = faster than V8. Per-function deployment cost: js2wasm ~3 kB, Javy ~3 kB + shared plugin, StarlingMonkey ~14 MB."
+                legend="Per-program wall time relative to V8 (1.0× baseline). Cold = fresh instance per request; warm = instance reused. Bars share one neutral colour — compare heights, not hues."
               ></perf-benchmark-chart>
             </div>
             <div
               class="diagram-panel"
               data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
-              data-row-filter="warm"
+              data-row-filter="fib-recursive"
               style="display: none"
             >
               <perf-benchmark-chart
                 src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
-                src-filter="warm"
+                benchmark="fib-recursive"
                 mode="perf"
-                title="Warm isolate — instance reused across requests"
-                baseline-label="JS in V8 (TurboFan-tiered)"
-                legend="Steady-state per-invocation cost on a reused instance. V8 (1.0× baseline) is in-process median after TurboFan tiered up; js2wasm AOT runs native Cranelift code; Javy + StarlingMonkey run their interpreters inside Wasm (no guest JIT possible in sandboxed Wasm). Where Wasm-native compilation beats interpreter-in-Wasm by 1-2 orders of magnitude on tight loops."
+                title="fib-recursive — AOT vs Interpreter vs Engine (cold + warm)"
+                baseline-label="JS in V8"
+                legend="Per-program wall time relative to V8 (1.0× baseline). Cold = fresh instance per request; warm = instance reused."
+              ></perf-benchmark-chart>
+            </div>
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
+              data-row-filter="array-sum"
+              style="display: none"
+            >
+              <perf-benchmark-chart
+                src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
+                benchmark="array-sum"
+                mode="perf"
+                title="array-sum — AOT vs Interpreter vs Engine (cold + warm)"
+                baseline-label="JS in V8"
+                legend="Per-program wall time relative to V8 (1.0× baseline). Cold = fresh instance per request; warm = instance reused."
+              ></perf-benchmark-chart>
+            </div>
+            <div
+              class="diagram-panel"
+              data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
+              data-row-filter="string-hash"
+              style="display: none"
+            >
+              <perf-benchmark-chart
+                src="./benchmarks/results/wasm-host-wasmtime-hot-runtime.json"
+                benchmark="string-hash"
+                mode="perf"
+                title="string-hash — AOT vs Interpreter vs Engine (cold + warm)"
+                baseline-label="JS in V8"
+                legend="Per-program wall time relative to V8 (1.0× baseline). Cold = fresh instance per request; warm = instance reused."
               ></perf-benchmark-chart>
             </div>
             <div


### PR DESCRIPTION
## Summary

Three user-feedback revisions on top of #480's Javy + StarlingMonkey lanes:

1. **Generic lane labels** — rendered UI no longer uses vendor names. `Javy` → `Interpreter`, `StarlingMonkey` → `Engine`, `js2wasm AOT` → `AOT`. JSON data field names (`javyUs` / `starlingMonkeyUs`) stay unchanged so the competitive benchmark scripts and result files don't need to move.
2. **Monochrome bars** — dropped the per-lane blue / orange / purple colors. All bars share the site's neutral white-gradient fill; lanes are distinguished by their label and position, not by hue. A reader compares bar heights neutrally without one execution model being visually privileged.
3. **One chart per benchmark** instead of one per scenario — replaced the two cold/warm panels with one panel per benchmark (`fib`, `fib-recursive`, `array-sum`, `string-hash`). Each chart shows AOT vs Interpreter vs Engine for both cold and warm scenarios, making per-benchmark pattern-spotting straightforward (e.g. AOT wins on fib but loses on string-hash).

## Implementation

- `components/perf-benchmark-chart.js`: lane definitions trimmed to `{key, label}` only — no `color` / `edgeColor` — so `_renderRatioRows` falls through to its existing monochrome white-gradient path. When the caller filters down to a single benchmark via the existing `benchmark=` attribute, the component now prefixes each bar with its scenario (`cold — AOT`, `warm — Interpreter`, …) so both scenarios coexist legibly inside one chart.
- `index.html`: the `#wasmtime-bench-group` div now lists one `<perf-benchmark-chart benchmark="…">` per benchmark name. Subcopy is rewritten to introduce the four generic execution models (AOT / JS in V8 / Interpreter / Engine) with brief size + cost notes — Interpreter ≈ ~3 kB per-function tiny module delegating to a preloaded plugin; Engine ≈ ~14 MB JS engine bundled in Wasm with AOT pre-init — but no vendor names.

UI / data only. No `src/**` changes; test262 unaffected.

## Test plan

- [ ] Open the landing page locally — four per-benchmark panels render under "Four execution models on the same JS programs"
- [ ] Bars are monochrome (white gradient), no blue/orange/purple
- [ ] Bar row labels read "cold — AOT", "cold — Interpreter", "cold — Engine", "warm — AOT", "warm — Interpreter", "warm — Engine"
- [ ] No occurrences of "Javy" or "StarlingMonkey" in any rendered text
- [ ] Cold scenario shows AOT winning over JS-in-V8 by ~9× on fib (1.0× baseline)
- [ ] Warm scenario shows AOT comfortably ahead of Interpreter / Engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)