### PR TITLE
fix(ci): include push:main in gate `if:` — restores baseline promotion

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -78,7 +78,15 @@ jobs:
   gate:
     name: cheap gate (main-ancestor + lint)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    # Must include push:main — test262-shard `needs: [gate]`, so a skipped gate
+    # cascades to skipped shards, skipped merge-report, and skipped
+    # promote-baseline. That breaks landing-page pass-rate refresh after every
+    # PR merge (which fires push:main). Bot author filter prevents
+    # auto-baseline-refresh commits from re-triggering CI.
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'push' && github.actor != 'github-actions[bot]')
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The \`gate\` job's \`if:\` condition only fired on \`pull_request\` / \`merge_group\` events, but \`test262-shard\` has \`needs: [gate]\`. On \`push:main\` events (when the queue merges a PR), gate was skipped → shards skipped → merge-report skipped → \`promote-baseline\` never ran.

**Result**: landing-page pass rate (\`benchmarks/results/test262-current.json\`) stopped updating. Visible today: 12 PRs merged via queue, landing page still shows yesterday's number (28225/43160).

## Fix

Add \`push:main\` to the gate's \`if:\`, with \`github.actor != 'github-actions[bot]'\` filter so the bot's own baseline-refresh commits don't trigger re-runs.

\`\`\`yaml
if: |
  github.event_name == 'pull_request' ||
  github.event_name == 'merge_group' ||
  (github.event_name == 'push' && github.actor != 'github-actions[bot]')
\`\`\`

## Test plan

- [ ] After merge, monitor the next push:main run — \`gate\` should now run (not skip)
- [ ] Confirm \`promote-baseline\` job fires and commits new \`test262-current.{json,jsonl}\`
- [ ] Landing page pass-rate updates within ~10 min of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)