### PR TITLE
fix(landing): fetch test262 data from baselines repo (decouples from main)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1111,7 +1111,9 @@
         // Use test262-report.json as the authoritative pass rate (same source as landing page).
         // runs/index.json may contain PR runs that differ from the merged baseline.
         try {
-          const reportData = await loadJSON("../benchmarks/results/test262-report.json");
+          const reportData = await loadJSON(
+            "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
+          );
           if (reportData?.summary?.pass && reportData?.summary?.total) {
             const passRate = ((reportData.summary.pass / reportData.summary.total) * 100).toFixed(1);
             document.getElementById("m-passrate").textContent = passRate + "%";
@@ -1130,7 +1132,9 @@
 
         // ── Baseline age badge ──
         try {
-          const reportData = await loadJSON("../benchmarks/results/test262-current.json");
+          const reportData = await loadJSON(
+            "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
+          );
           if (reportData && reportData.baseline_generated_at) {
             const genTime = new Date(reportData.baseline_generated_at).getTime();
             const ageMs = Date.now() - genTime;

--- a/index.html
+++ b/index.html
@@ -1505,7 +1505,7 @@
           <div class="diagram-panel">
             <div id="conformance-donut-slot">
               <t262-donut
-                src="./benchmarks/results/test262-report.json"
+                src="https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json"
                 style="--t262-bg: var(--bg, #060a14)"
               ></t262-donut>
             </div>
@@ -4536,7 +4536,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const labelEl = document.getElementById("compat-pass-rate-label");
         if (!rateEl || !labelEl) return;
         try {
-          const resp = await fetch("./benchmarks/results/test262-report.json");
+          const resp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!resp.ok) return;
           const report = await resp.json();
           // Use strict-mode summary (tests compatible with ES modules) when available
@@ -4850,7 +4850,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         };
 
         try {
-          const reportResp = await fetch("./benchmarks/results/test262-report.json");
+          const reportResp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!reportResp.ok) throw new Error("conformance data unavailable");
 
           const report = await reportResp.json();
@@ -5200,7 +5200,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const labelEl = document.getElementById("feature-coverage-label");
         if (!coverageEl || !labelEl) return;
         try {
-          const resp = await fetch("./benchmarks/results/test262-report.json");
+          const resp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!resp.ok) return;
           const report = await resp.json();
           const categories = report?.categories;


### PR DESCRIPTION
## Summary

The landing-page pass rate badge stops updating because the merge_queue rule blocks the bot from pushing baseline refreshes to main. Test262 IS running fresh after every PR merge — the data just can't land on main.

The baselines repo (`loopdive/js2wasm-baselines`) is a separate repo, not subject to the merge_queue rule. `promote-baseline` already pushes a fresh `test262-current.json` there after every successful CI run.

## Fix

Switch 6 landing-page fetches to read directly from the baselines repo via GitHub Raw:

```
before: ./benchmarks/results/test262-report.json
after:  https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json
```

Both files have identical content (`promote-baseline` copies the same `test262-report-merged.json` artifact to both names). GitHub Raw serves public content with `Access-Control-Allow-Origin: *`, so cross-origin fetch from `loopdive.github.io` works.

After this lands, the landing page pass rate updates within seconds of any successful CI run on main — no more main-push step needed for the headline number.

## Files

- `index.html` (4 fetches — conformance donut, 3 inline summary loads)
- `dashboard/index.html` (2 fetches — pass-rate metric + baseline-age badge)

## Test plan

- [ ] After merge, load the landing page and confirm pass rate shows the current baselines-repo number (28548 or whatever's latest there) rather than yesterday's 28225
- [ ] Network tab in DevTools shows `200 OK` from `raw.githubusercontent.com`
- [ ] No CORS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)