### PR TITLE
fix(ci): restore 'loopdive/js2wasm' in repo-check conditions (typo from #1529)

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   refresh-benchmarks:
-    if: github.repository == 'loopdive/js2' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    if: github.repository == 'loopdive/js2wasm' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'loopdive/js2'
+    if: github.repository == 'loopdive/js2wasm'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
           path: dist/pages
 
   deploy:
-    if: github.repository == 'loopdive/js2'
+    if: github.repository == 'loopdive/js2wasm'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/scripts/build-adr-html.mjs
+++ b/scripts/build-adr-html.mjs
@@ -147,7 +147,7 @@ function htmlShell({ title, body }) {
     ${body}
   </main>
   <div class="footer">
-    Source: <a href="https://github.com/loopdive/js2/tree/main/docs/adr">docs/adr/</a> on GitHub.
+    Source: <a href="https://github.com/loopdive/js2wasm/tree/main/docs/adr">docs/adr/</a> on GitHub.
   </div>
   <script src="../../components/site-nav.js"></script>
 </body>

--- a/scripts/validate-test262-baseline.ts
+++ b/scripts/validate-test262-baseline.ts
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
   if (failures.length > 5) console.error(`  ... ${failures.length - 5} more`);
   console.error("");
   console.error(`Refresh the committed baseline by manually triggering refresh-committed-baseline.yml on main:`);
-  console.error(`  https://github.com/loopdive/js2/actions/workflows/refresh-committed-baseline.yml`);
+  console.error(`  https://github.com/loopdive/js2wasm/actions/workflows/refresh-committed-baseline.yml`);
   console.error("");
   console.error(
     `Reproduce locally with:  PR_NUMBER=${process.env.PR_NUMBER ?? "<n>"} SAMPLE_SIZE=${SAMPLE_SIZE} npx tsx scripts/validate-test262-baseline.ts`,


### PR DESCRIPTION
## Root cause

Commit 17dda824b ('docs: align in-repo references to loopdive/js2 (#1529)') accidentally dropped the 'wasm' suffix in several repo-check conditions, causing the affected workflows to skip every run since 2026-05-20:

- `.github/workflows/deploy-pages.yml` (build + deploy jobs)
- `.github/workflows/benchmark-refresh.yml` (main job)

## Symptom observed

The landing page on https://js2.loopdive.com/ hasn't updated despite multiple PR merges and successful `Test262 Sharded` runs. Deploy GitHub Pages was firing on every main push, but the job-level `if` condition evaluated `github.repository == 'loopdive/js2'` to **false** (actual: `loopdive/js2wasm`), so both build and deploy jobs were skipped.

Zero successful Deploy GitHub Pages runs since the typo landed:

```
18:41:06Z conclusion=skipped head=c28bcbe69 event=workflow_dispatch
18:40:58Z conclusion=skipped head=c28bcbe69 event=workflow_dispatch
18:39:51Z conclusion=skipped head=c28bcbe69 event=push
...all skipped...
```

## Fix

- `deploy-pages.yml` lines 23, 83 → `loopdive/js2wasm`
- `benchmark-refresh.yml` line 27 → `loopdive/js2wasm`
- `scripts/build-adr-html.mjs` line 150 (URL ref) → `loopdive/js2wasm`
- `scripts/validate-test262-baseline.ts` line 252 (URL ref) → `loopdive/js2wasm`

`publish-npm.yml` is **unaffected** — `@loopdive/js2` is the intentional npm package name, not the repo name.

## Test plan

- [ ] After merge, the next push:main fires `Deploy GitHub Pages` — it should now run (not skip)
- [ ] After deploy completes, https://js2.loopdive.com/ updates with my prior #486 changes (baselines-repo URL fetches)
- [ ] Landing page pass-rate badge shows current data

🤖 Generated with [Claude Code](https://claude.com/claude-code)