### PR TITLE
ci: use MAIN_DEPLOY_KEY for promote-baseline push to main

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -462,7 +462,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Authenticate via SSH deploy key so the post-merge baseline-refresh
+          # commit can be pushed. The merge_queue ruleset blocks GITHUB_TOKEN
+          # pushes — MAIN_DEPLOY_KEY is in the ruleset's bypass_actors list.
+          ssh-key: ${{ secrets.MAIN_DEPLOY_KEY }}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

The `promote-baseline` job needs to push the new `test262-current.json` to main after every CI cycle, but the merge_queue ruleset blocks `GITHUB_TOKEN` pushes. This switches `actions/checkout` to use SSH authentication with the new `MAIN_DEPLOY_KEY` secret. The deploy key is registered on `loopdive/js2wasm` with write access and added to the ruleset's `bypass_actors`.

## Test plan

- [ ] After merge, monitor next push:main Test262 Sharded run — the `promote merged report to main baseline` job should now succeed (not fail with `GH013`)
- [ ] Confirm `benchmarks/results/test262-current.json` on main updates with the new pass numbers
- [ ] `chore(test262): refresh sharded baseline …` `[skip ci]` commit appears on main

## Notes

If deploy keys aren't actually supported as bypass actors on personal-account ruleset (the actor_id came back as null in the bypass list), this PR will still fail and we'll need the PAT-based approach instead. Empirical test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)