### PR TITLE
Revert workflow repo-check back to 'loopdive/js2' (canonical name)

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   refresh-benchmarks:
-    if: github.repository == 'loopdive/js2wasm' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    if: github.repository == 'loopdive/js2' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'loopdive/js2wasm'
+    if: github.repository == 'loopdive/js2'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
           path: dist/pages
 
   deploy:
-    if: github.repository == 'loopdive/js2wasm'
+    if: github.repository == 'loopdive/js2'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary

Reverts PR #487's incorrect change to the if conditions in `deploy-pages.yml` and `benchmark-refresh.yml`.

## Root cause

The repo's canonical name is **`loopdive/js2`** (renamed at some point, probably during the public/private split). `loopdive/js2wasm` still works as a git URL via GitHub's redirect, but `${{ github.repository }}` in workflows returns the canonical name.

PR #487 (mine, earlier today) wrongly assumed the canonical name was `loopdive/js2wasm` and changed the conditions accordingly. Effect: Deploy GitHub Pages and Refresh Benchmarks have been skipping every run since #487 landed because the condition evaluates false.

## Verification

```
gh api repos/loopdive/js2wasm --jq .full_name
loopdive/js2   ← canonical name
```

## Effect after merge

- `Deploy GitHub Pages` will fire properly on the next push:main → landing page actually updates
- `Refresh Benchmarks` will fire properly on push:main

🤖 Generated with [Claude Code](https://claude.com/claude-code)