### PR TITLE
docs+scripts: update loopdive/js2wasm refs to loopdive/js2

### DIFF
--- a/docs/self-hosted-runner-mac-mini.md
+++ b/docs/self-hosted-runner-mac-mini.md
@@ -2,7 +2,7 @@
 
 This runbook sets up a Mac mini at home as a self-hosted GitHub Actions runner
 host for the `test262-shard` matrix in `.github/workflows/test262-sharded.yml`.
-Trusted PRs (from collaborators on `loopdive/js2wasm`) route to the Mac mini;
+Trusted PRs (from collaborators on `loopdive/js2`) route to the Mac mini;
 fork PRs continue to use `ubuntu-latest`.
 
 > No workflow changes have been made yet. This runbook is the host-side plan —
@@ -25,7 +25,7 @@ If you upgrade RAM later: 32 GB → 6 runners; 48 GB → 9; 64 GB → 12+.
 
 ## What the runner host trusts
 
-- **Trusted code**: any commit reachable from a PR opened by a `loopdive/js2wasm`
+- **Trusted code**: any commit reachable from a PR opened by a `loopdive/js2`
   collaborator, plus pushes to `main`.
 - **Untrusted code**: fork PRs. These keep using `ubuntu-latest` via the
   workflow's `runs-on` gate. They never run on your Mac mini.
@@ -61,7 +61,7 @@ Go to https://github.com/organizations/loopdive/settings/actions and ensure
 self-hosted runners are not blocked. Recommended policy:
 
 - **Runner groups** → create a group `mac-mini` that is restricted to
-  `loopdive/js2wasm` only. (Prevents other repos in the org from accidentally
+  `loopdive/js2` only. (Prevents other repos in the org from accidentally
   scheduling onto your hardware.)
 - **Workflow permissions** for the repo stay as-is.
 
@@ -75,7 +75,7 @@ The runner image needs a token to register itself. Two options:
 - **Fine-grained PAT** (recommended). Generate at
   https://github.com/settings/personal-access-tokens with:
   - **Resource owner**: `loopdive`
-  - **Repository access**: only `loopdive/js2wasm`
+  - **Repository access**: only `loopdive/js2`
   - **Organization permissions**: `Self-hosted runners: Read and write`
   - **Expiration**: 90 days (rotate via calendar reminder)
 

--- a/scripts/build-adr-html.mjs
+++ b/scripts/build-adr-html.mjs
@@ -147,7 +147,7 @@ function htmlShell({ title, body }) {
     ${body}
   </main>
   <div class="footer">
-    Source: <a href="https://github.com/loopdive/js2wasm/tree/main/docs/adr">docs/adr/</a> on GitHub.
+    Source: <a href="https://github.com/loopdive/js2/tree/main/docs/adr">docs/adr/</a> on GitHub.
   </div>
   <script src="../../components/site-nav.js"></script>
 </body>

--- a/scripts/poll-pr-mentions.sh
+++ b/scripts/poll-pr-mentions.sh
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-REPO="${REPO:-loopdive/js2wasm}"
+REPO="${REPO:-loopdive/js2}"
 INTERVAL_SECS="${INTERVAL_SECS:-60}"
 STATE_FILE="${STATE_FILE:-${HOME}/.cache/poll-pr-drift-state.json}"
 LOCK_FILE="${LOCK_FILE:-/tmp/poll-pr-mentions.lock}"

--- a/scripts/validate-test262-baseline.ts
+++ b/scripts/validate-test262-baseline.ts
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
   if (failures.length > 5) console.error(`  ... ${failures.length - 5} more`);
   console.error("");
   console.error(`Refresh the committed baseline by manually triggering refresh-committed-baseline.yml on main:`);
-  console.error(`  https://github.com/loopdive/js2wasm/actions/workflows/refresh-committed-baseline.yml`);
+  console.error(`  https://github.com/loopdive/js2/actions/workflows/refresh-committed-baseline.yml`);
   console.error("");
   console.error(
     `Reproduce locally with:  PR_NUMBER=${process.env.PR_NUMBER ?? "<n>"} SAMPLE_SIZE=${SAMPLE_SIZE} npx tsx scripts/validate-test262-baseline.ts`,


### PR DESCRIPTION
## Summary

Updates 4 files containing bare `loopdive/js2wasm` references to the canonical name `loopdive/js2`. The repo was renamed; old URLs still work via GitHub's redirect, but canonical name should be used.

## Files changed

- `docs/self-hosted-runner-mac-mini.md` — 4 refs in trusted-PR / repo-access docs
- `scripts/poll-pr-mentions.sh` — `REPO` default value
- `scripts/validate-test262-baseline.ts` — URL in error message
- `scripts/build-adr-html.mjs` — URL in ADR footer

## Preserved (separate repos, not renamed)

- `loopdive/js2wasm-baselines` (baselines repo)
- `loopdive/js2wasm-labs` (labs repo)

## Note

`index.html`, `ROADMAP.md`, `CONTRIBUTING.md` were already updated in an earlier commit — they had no remaining bare refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)