### PR TITLE
ci: skip PR-level test262 on github-actions[bot] synchronize events

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -78,13 +78,13 @@ jobs:
   gate:
     name: cheap gate (main-ancestor + lint)
     runs-on: ubuntu-latest
-    # Must include push:main — test262-shard `needs: [gate]`, so a skipped gate
-    # cascades to skipped shards, skipped merge-report, and skipped
-    # promote-baseline. That breaks landing-page pass-rate refresh after every
-    # PR merge (which fires push:main). Bot author filter prevents
-    # auto-baseline-refresh commits from re-triggering CI.
+    # Skip when the synchronize event was triggered by auto-refresh-prs
+    # (github-actions[bot] doing 'Merge branch main into <branch>'). Otherwise
+    # every push to main triggers N PR-level test262 runs (one per auto-refreshed
+    # PR), which with global concurrency serialize and gridlock the queue.
+    # The merge_group cycle will still validate the PR when the queue picks it.
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' && github.actor != 'github-actions[bot]') ||
       github.event_name == 'merge_group' ||
       (github.event_name == 'push' && github.actor != 'github-actions[bot]')
     timeout-minutes: 10
@@ -130,7 +130,7 @@ jobs:
     # batch.
     if: |
       (github.event_name == 'push' && github.actor != 'github-actions[bot]') ||
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' && github.actor != 'github-actions[bot]') ||
       github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
     needs: [gate]


### PR DESCRIPTION
## Summary

Filter PR-level `test262-sharded` to skip when the triggering actor is `github-actions[bot]` (e.g., auto-refresh-prs synchronize events).

## Why

#495 re-enabled `auto-refresh-prs.yml` on push:main. Every push now fires N `update-branch` calls (one per open PR with auto-merge), each creating a synchronize event. Without this filter, the synchronize event triggers `test262-sharded.yml` at PR-level — with global concurrency, those serialize to ~7.5h of backlog per main push, gridlocking the queue.

This filter preserves test262 on real dev pushes (synchronize from human/agent) but skips bot's auto-refresh synchronizes. The merge_group cycle still validates each PR when the queue picks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)