### PR TITLE
fix(ci): restore required checks on bot-refresh PRs (fixes #496 BLOCKED state)

### DIFF
--- a/.github/workflows/test262-pr-stub.yml
+++ b/.github/workflows/test262-pr-stub.yml
@@ -1,0 +1,80 @@
+name: Test262 PR stub
+
+# PR-level companion to test262-sharded.yml. Produces the two required check
+# names — "cheap gate (main-ancestor + lint)" and "merge shard reports" — on
+# EVERY pull_request event, cheaply.
+#
+# Why this exists (the over-filter bug, see PR #496):
+#   test262-sharded.yml skips its heavy `test262-shard` matrix when the
+#   pull_request synchronize was triggered by github-actions[bot] (i.e.
+#   auto-refresh-prs doing 'Merge branch main into <branch>'). That's correct
+#   — we don't want N PR-level test262 storms every time main moves.
+#
+#   However, `merge-report` has `needs: [test262-shard]`. When the shard job
+#   is skipped, `merge-report` also skips (GitHub's `needs:` semantics treat
+#   skipped as not-success). The required check "merge shard reports" is then
+#   never produced, and under strict-required-checks the PR is permanently
+#   BLOCKED with `mergeStateStatus: BLOCKED, checks_summary: []`.
+#
+#   This stub workflow fires on ALL pull_request events (no paths filter, no
+#   actor filter). It produces "merge shard reports" trivially so the required
+#   check exists. For dev synchronizes, the real test262-sharded.yml ALSO
+#   produces "merge shard reports" with a real result — GitHub picks the most
+#   recent run of a given check name, so the real result wins (it lands later
+#   in the run). For bot synchronizes, only this stub produces it → PR stays
+#   mergeable.
+#
+#   The merge_group event still runs the full 32-shard test262 on the temp
+#   merge-with-main branch, so regressions are gated at queue time.
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: test262-pr-stub-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: cheap gate (main-ancestor + lint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck + lint
+        run: |
+          pnpm run typecheck 2>&1 | tail -50 || (echo "::error::typecheck failed"; exit 1)
+          if grep -q '"lint"' package.json; then pnpm run lint 2>&1 | tail -50; fi
+
+  merge-report:
+    name: merge shard reports
+    runs-on: ubuntu-latest
+    needs: [gate]
+    steps:
+      - name: Stub-pass (real 32-shard test262 runs in merge_group)
+        run: |
+          echo "→ PR-level stub — does not run test262."
+          echo "→ For dev synchronizes, test262-sharded.yml's merge-report job"
+          echo "  produces the real 'merge shard reports' check result (latest"
+          echo "  run wins under required-check evaluation)."
+          echo "→ For bot synchronizes (auto-refresh-prs), only this stub fires,"
+          echo "  keeping the PR mergeable without paying for a 50-shard storm."
+          echo "→ The merge queue (merge_group event) runs full 50-shard test262"
+          echo "  on the temp merge-with-main branch — that gate validates the"
+          echo "  actual merge."

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -78,13 +78,19 @@ jobs:
   gate:
     name: cheap gate (main-ancestor + lint)
     runs-on: ubuntu-latest
-    # Skip when the synchronize event was triggered by auto-refresh-prs
-    # (github-actions[bot] doing 'Merge branch main into <branch>'). Otherwise
-    # every push to main triggers N PR-level test262 runs (one per auto-refreshed
-    # PR), which with global concurrency serialize and gridlock the queue.
-    # The merge_group cycle will still validate the PR when the queue picks it.
+    # Gate always runs on pull_request / merge_group / non-bot push. The
+    # PR-level test262 storm caused by auto-refresh-prs (github-actions[bot]
+    # doing 'Merge branch main into <branch>') is avoided by skipping JUST
+    # the heavy `test262-shard` matrix on bot synchronizes — NOT the gate.
+    # If the gate were also skipped, `test262-shard` and `merge-report` would
+    # cascade-skip (via `needs:`), and the required check "merge shard reports"
+    # would never be produced, permanently BLOCKING the PR under the strict
+    # required-checks policy. The companion workflow .github/workflows/
+    # test262-pr-stub.yml produces a cheap "merge shard reports" check name
+    # on bot synchronizes so PRs stay mergeable; the real workflow's gate
+    # still firing here keeps "cheap gate (main-ancestor + lint)" honest.
     if: |
-      (github.event_name == 'pull_request' && github.actor != 'github-actions[bot]') ||
+      github.event_name == 'pull_request' ||
       github.event_name == 'merge_group' ||
       (github.event_name == 'push' && github.actor != 'github-actions[bot]')
     timeout-minutes: 10


### PR DESCRIPTION
## Bug

PR #496 added a filter to skip the `gate` and `test262-shard` jobs in `.github/workflows/test262-sharded.yml` when `github.actor == 'github-actions[bot]'`. The intent — avoiding PR-level test262 storms when `auto-refresh-prs` fires `update-branch` on N PRs after every main push — was correct, but the implementation over-filtered.

**Cascade failure:**
- `test262-shard` has `needs: [gate]` → gate skipped → shard skipped (skipped `needs` does NOT count as success)
- `merge-report` has `needs: [test262-shard]` → also skipped

The required check **"merge shard reports"** is therefore NEVER produced for bot-synchronized PRs. With strict-policy-with-required-checks, the PR is permanently BLOCKED.

**Current impact:** ~30 PRs are stuck with `mergeStateStatus: BLOCKED, checks_summary: []`.

## Fix

Two parts:

### 1. Revert the gate's `if:` filter
`.github/workflows/test262-sharded.yml` — restore the gate to firing on all pull_request events. Skipping the heavy `test262-shard` matrix is what avoids the storm; the cheap typecheck+lint gate doesn't need to be skipped (and skipping it breaks the cascade).

### 2. Re-add `test262-pr-stub.yml`
A tiny companion workflow that fires on ALL pull_request events (no paths filter, no actor filter) and produces the required check name **"merge shard reports"** trivially.

GitHub's required-check evaluation picks the most-recent run by name:
- **Dev synchronize**: both stub and real workflow produce "merge shard reports" — real wins (lands later, real test262 result).
- **Bot synchronize**: only the stub produces it → PR stays mergeable, no test262 storm.

The merge queue (`merge_group` event) still runs full 50-shard test262 on the temp merge-with-main branch — that's where regressions are gated for actual merges.

## Behavior matrix

| Event | sharded.gate | sharded.shard | sharded.merge-report | stub.gate | stub.merge-report |
|---|---|---|---|---|---|
| Dev synchronize | runs | runs | runs (real) | runs | runs |
| Bot synchronize | runs | SKIP | SKIP (needs shard) | runs | runs (stub-pass) |
| merge_group | runs | runs | runs (real) | n/a | n/a |
| push main non-bot | runs | runs | runs | n/a | n/a |

## Unblocks

The ~30 PRs currently stuck in `BLOCKED` state with empty `checks_summary` should become mergeable once this lands and the stub workflow has run on their HEADs (auto-refresh-prs will push them again on the next main move, or they can be manually re-synced).

## Notes

- The stub workflow was created and deleted multiple times during recent CI iterations (see `6fb11fdb1`, `3026f833c`). This commit revives the canonical version with updated comments documenting the over-filter bug.
- Do NOT auto-merge — leaving for tech lead to admin-merge given the production-blocking nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)