### PR TITLE
ci: disable auto-refresh-prs push trigger (GITHUB_TOKEN can't trigger downstream CI)

### DIFF
--- a/.github/workflows/auto-refresh-prs.yml
+++ b/.github/workflows/auto-refresh-prs.yml
@@ -1,18 +1,20 @@
 name: Auto-refresh open PR branches with main
 
-# Fires on every push to main to keep open PRs current. Necessary under the
-# serial merge queue + strict_required_status_checks_policy model: after each
-# merge, all other auto-merge-enabled PRs become 1 commit behind main, and
-# strict policy bounces them from the queue. Without auto-refresh, drain
-# stalls after every merge until someone manually runs update-branch.
+# DISABLED: GITHUB_TOKEN-authored commits do NOT trigger downstream
+# workflows (documented GitHub Actions limitation). So auto-refresh-prs's
+# update-branch calls create bot commits on PR branches but the resulting
+# synchronize events don't fire any CI workflows — PRs stay BLOCKED with
+# empty check sets after refresh. Net effect was harmful churn.
 #
-# Churn cost: every main push fires N `update-branch` calls (one per open
-# PR with auto-merge enabled), each triggering CI re-runs. Acceptable cost
-# for self-sustaining drain.
+# Replaced by: drift watcher polling script (scripts/poll-pr-mentions.sh)
+# running in the tech lead's session. On detected drift, tech lead
+# manually dispatches an agent that pulls main, reviews the merge
+# semantically, and pushes. Authored by user, so synchronize events
+# trigger CI normally.
+#
+# Kept as workflow_dispatch for occasional manual emergency refreshes.
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
## Why

GitHub Actions limitation: events triggered by GITHUB_TOKEN don't fire downstream workflows. So #495's enable created bot commits on PR branches but no CI fired for the synchronize events. Net effect: PRs were 'refreshed' but stayed BLOCKED with empty check sets.

## Replacement

The drift watcher polling script (`scripts/poll-pr-mentions.sh`) running in tech lead's session detects drifted PRs. Tech lead manually dispatches a Claude agent that:
1. Merges main into the branch
2. Reviews the diff semantically (catches semantic conflicts git can't see)
3. Pushes — as user, triggers CI normally

This was the original design from earlier today. Going back to it.

## Effect

- auto-refresh-prs.yml: workflow_dispatch only (was: push:main)
- No more wasted bot commits on PR branches
- Drain runs at agent-dispatch pace (manual but correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)