### PR TITLE
plan: add #1586, #1587, #1588 to sprint 55

### DIFF
--- a/plan/issues/sprints/55/1586-explicit-allocation-sites-in-ir.md
+++ b/plan/issues/sprints/55/1586-explicit-allocation-sites-in-ir.md
@@ -1,0 +1,228 @@
+---
+id: 1586
+title: "IR preparation: explicit allocation sites with stable identity and metadata hooks"
+status: ready
+sprint: 55
+created: 2026-05-23
+updated: 2026-05-23
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: infrastructure
+area: compiler
+language_feature: compiler-internals
+goal: platform
+depends_on: []
+es_edition: n/a
+---
+# #1586 — IR preparation: explicit allocation sites with stable identity and metadata hooks
+
+Foundational IR refactor that makes every value-creation site in the
+intermediate representation a first-class, identifiable, annotatable node.
+This is the prerequisite for any future static analysis that needs to reason
+about allocations — escape analysis, lifetime analysis, ownership tracking
+(#1587), and the dual-target IR architecture (#1585).
+
+The issue is intentionally narrow: it does not perform any new analysis. It
+prepares the IR so that subsequent analyses *can* be added without
+re-plumbing every pass.
+
+## Goal
+
+After this issue:
+
+1. Every operation that brings a new value into existence is an explicit
+   `AllocSite` node (or carries an `AllocSite` annotation), addressable by
+   subsequent passes.
+2. Each `AllocSite` has a stable identifier that survives IR transformations
+   — inlining, constant folding, dead-code elimination must either preserve
+   the ID, transfer it to a fused node, or explicitly mark it as deleted.
+3. A documented metadata API allows passes to attach typed annotations to
+   `AllocSite` nodes (e.g. `escapes: true`, `lifetime: function-local`,
+   `encoding: utf8-guaranteed`) without modifying the IR core.
+4. No behavioral changes. The existing test suite (unit, equivalence,
+   test262, differential) passes unchanged before and after.
+
+## Why this is a prerequisite
+
+Several pending compiler enhancements depend on the IR being able to answer
+"where was this value allocated, and what do we know about it?" reliably
+across passes:
+
+- **Ownership and access semantics analysis (#1587)** — needs allocation
+  sites as analysis anchor points.
+- **Dual-target IR architecture (#1585)** — the long-term ability to target
+  linear memory requires lifetime annotations on allocation sites.
+- **String encoding tracking (#1588)** — tags strings at their origin
+  (allocation site) and propagates through.
+- **Escape analysis for closure-capture optimization** — currently implicit;
+  becomes explicit and reusable.
+
+Each of these can be implemented independently *if* the IR provides stable,
+annotatable allocation sites. Without it, each analysis has to recover the
+information itself, and the results do not compose.
+
+## Current state (to be confirmed during implementation plan)
+
+The current IR mixes explicit and implicit allocation:
+
+- **Explicit**: object literals, array literals, function declarations,
+  class instantiations, explicit `new`-expressions. These already have
+  dedicated IR nodes.
+- **Implicit**: string concatenation result objects, intermediate values
+  from spread/rest, arguments objects, template-literal cooked/raw arrays,
+  return values from built-ins that allocate.
+- **Black-box**: allocations performed inside built-in implementations are
+  not visible to the IR and remain so under this issue.
+
+The "implicit" category is where the cleanup happens. The audit step of the
+implementation plan must enumerate every such case.
+
+## Design
+
+### `AllocSite` node shape
+
+```ts
+interface AllocSite {
+  id: AllocSiteId;          // stable across passes
+  kind: AllocKind;           // 'object' | 'array' | 'string' | 'closure' | …
+  type: IRType;              // what is being allocated
+  origin: SourceLocation;    // for diagnostics and source maps
+  metadata: AllocMetadata;   // open map for analysis annotations
+}
+```
+
+`AllocSiteId` is a numeric ID assigned at IR construction. Passes that
+fuse or replace nodes must update the IR's allocation-site registry to
+reflect provenance:
+
+```ts
+interface AllocSiteRegistry {
+  resolve(id: AllocSiteId): AllocSite | null;
+  alias(from: AllocSiteId, to: AllocSiteId): void;  // for fusion
+  retire(id: AllocSiteId): void;                     // for deletion
+}
+```
+
+### Metadata API
+
+Annotations are typed by namespace + key, written and read through the
+registry:
+
+```ts
+registry.annotate(id, 'ownership', { kind: 'owned' });
+registry.read(id, 'ownership'); // → { kind: 'owned' } | undefined
+```
+
+Namespace prevents collision between analyses; each analysis owns its own
+namespace and may not write to others.
+
+### Pass discipline
+
+Three rules every pass must follow after this issue lands:
+
+1. **Preserve IDs through value-preserving transformations.** If a pass
+   rewrites `x = new Foo()` to `x = inlined-foo-body`, the resulting value
+   must carry the original `AllocSite` ID.
+2. **Alias IDs through fusion.** If two allocations are fused (e.g. by
+   common subexpression elimination), the registry records the alias.
+3. **Retire IDs on deletion.** If a pass proves an allocation dead and
+   removes it, the registry is informed so downstream passes do not see
+   stale references.
+
+Verification: a debug-mode invariant checker walks the IR after each pass
+and asserts that every value with an allocation provenance resolves
+through the registry to a live or retired entry.
+
+## Scope
+
+1. Audit the existing IR for implicit allocations. Produce a list in the
+   implementation plan; convert each to an explicit `AllocSite` node or
+   annotation.
+2. Implement the `AllocSiteRegistry` with the API above.
+3. Update every existing IR pass to follow the three pass-discipline rules.
+   This is the bulk of the work — each pass must be reviewed and patched
+   if it currently loses provenance.
+4. Add the debug-mode invariant checker. Make it a CI gate at least in
+   `pnpm typecheck` or a dedicated check.
+5. Document the API and discipline in a new ADR. The ADR should
+   cross-reference #1587, #1588, and #1585 as known consumers.
+6. No new analyses in this issue. The hooks are added; the analyses come
+   in follow-up issues.
+
+## Non-goals
+
+- Performing any new analysis (ownership, lifetime, escape, encoding) —
+  those are #1587, #1588, and future issues.
+- Changing the IR's external semantics. All test suites must pass
+  unchanged.
+- Reaching into built-in implementations to expose their internal
+  allocations. Built-ins remain black boxes at the IR level; if a future
+  analysis needs visibility inside a built-in, that built-in is rewritten
+  to expose its allocations or a separate mechanism is added.
+- Tracking allocation sites in the bytecode interpreter (#1584). The
+  interpreter is a separate concern; the registry is for the AOT IR.
+  Future work can extend it.
+
+## Relationship to other issues
+
+- **#1587** (ownership and access semantics analysis) — hard dependency on
+  this issue. The analysis pass reads from and writes to `AllocSite`
+  metadata.
+- **#1588** (string encoding tracking) — hard dependency on this issue.
+  Encoding annotations live on string `AllocSite` nodes.
+- **#1585** (dual-target IR architecture) — long-term consumer. The
+  defensive-design checklist in #1585 point 3 ("Allocation sites
+  identified explicitly") is satisfied by this issue.
+- **#1584** (Wasm-GC-native bytecode interpreter) — orthogonal. Does not
+  block this issue, does not depend on it.
+
+## Acceptance criteria
+
+- [ ] Implementation plan enumerates every implicit allocation in the
+      current IR with an audit table (source location, kind, planned
+      conversion to explicit `AllocSite`).
+- [ ] `AllocSiteRegistry` implemented under `src/ir/alloc-registry.ts`
+      (or equivalent).
+- [ ] All existing IR passes patched to preserve, alias, or retire IDs
+      per the three pass-discipline rules.
+- [ ] Debug-mode invariant checker added and runs in CI.
+- [ ] ADR-XXX (`docs/adr/`) documents the API, discipline, and known
+      consumers.
+- [ ] All existing test suites (`npm test`, `pnpm run test:262`,
+      `pnpm run test:diff`) pass with no new failures and no behavioral
+      changes vs. baseline.
+- [ ] No new failing test262 cases. No new differential-testing
+      mismatches.
+
+## Risks
+
+- **Audit incompleteness.** An implicit allocation missed in the audit
+  remains invisible to downstream analyses. Mitigation: invariant checker
+  is conservative — if a value appears without provenance, it is flagged.
+  Forces audit gaps to surface during CI rather than later.
+- **Performance regression from registry overhead.** The registry is
+  consulted on every IR transformation. Mitigation: implement as a flat
+  array indexed by ID, not a hash map; benchmark on a representative
+  test262 subset before merging.
+- **Pass-discipline drift over time.** Future passes may forget to update
+  the registry. Mitigation: the invariant checker catches violations in
+  CI; ADR documents the rules clearly.
+- **Scope creep into analysis work.** Tempting to add "just one simple
+  analysis" while doing the plumbing. Mitigation: explicit non-goal; any
+  analysis is a separate issue.
+
+## Notes
+
+- This issue is **infrastructure**, not feature work. It produces no
+  user-visible behavior change. Its value is enabling subsequent issues to
+  be smaller and more focused.
+- The pattern (registry + per-pass discipline) is the same one LLVM uses
+  for its `Value` provenance and MLIR uses for its op-attribute system.
+  Worth referencing in the ADR.
+- The work can plausibly run in parallel with built-in expansion work,
+  since the audit and registry implementation touch the IR core and IR
+  passes, not the built-in library.
+- A natural sprint shape: week 1 audit + ADR draft, weeks 2–3 registry
+  implementation + pass patching, week 4 invariant checker + CI
+  integration + ADR finalization.

--- a/plan/issues/sprints/55/1587-ownership-and-access-semantics-analysis.md
+++ b/plan/issues/sprints/55/1587-ownership-and-access-semantics-analysis.md
@@ -1,0 +1,279 @@
+---
+id: 1587
+title: "Static analysis pass: ownership and access semantics on IR values"
+status: ready
+sprint: 55
+created: 2026-05-23
+updated: 2026-05-23
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: compiler
+language_feature: compiler-internals
+goal: platform
+depends_on: [1586]
+es_edition: n/a
+---
+# #1587 — Static analysis pass: ownership and access semantics on IR values
+
+Flow-sensitive static analysis pass that annotates every IR value with
+inferred **ownership state** (owned / borrowed / shared) and **access
+pattern** (read-only / write-only / read-write / escaped). The output is
+consumable metadata that downstream passes use to make better optimization,
+specialization, and lowering decisions.
+
+This is not a borrow checker in the Rust sense — JavaScript semantics do
+not permit a strict-mode rejection of programs that fail ownership rules.
+It is an **inference pass**: it discovers ownership and access properties
+where they hold, conservatively falls back to the most permissive
+classification where it cannot prove anything, and exposes the result.
+
+Depends on #1586 (explicit allocation sites) for analysis anchor points.
+
+## Goal
+
+Given an IR function, produce two pieces of metadata per value reference:
+
+1. **Ownership state.** One of:
+   - `owned` — the value has exactly one reference, which is this one,
+     for the duration of this reference's liveness
+   - `borrowed` — the value is referenced elsewhere; this reference cannot
+     deallocate or invalidate it
+   - `shared` — multiple references exist; mutation must be observable to
+     all of them
+   - `escaped` — the value's lifetime extends beyond this function via
+     return, capture, parameter passing to opaque code, or storage in a
+     heap-reachable location
+
+2. **Access pattern.** A set of:
+   - `read` — this reference is used for property reads
+   - `write` — this reference is used for property writes
+   - `mutate` — this reference is used for read-modify-write operations
+   - `identity` — this reference participates in `===` comparisons
+   - `escape` — this reference is passed to opaque code (built-in,
+     unknown function, host import)
+
+Both annotations are *inferred*, not declared. A value that an analysis
+cannot reason about gets the most conservative classification: `shared`
+ownership with full access set.
+
+## Why this matters
+
+The pass enables several concrete improvements across the compiler, each
+of which currently either ad-hocs the analysis or pessimizes:
+
+- **Escape analysis.** Allocations that the pass proves `owned` and
+  never `escaped` can be stack-allocated (or scalar-replaced) instead of
+  heap-allocated. Significant size and GC-pressure wins for small,
+  short-lived objects.
+- **Closure specialization.** A closure that only reads its captures can
+  be lowered differently from one that mutates them — read-only captures
+  can be inlined as constants when the call site is monomorphic.
+- **Built-in dispatch.** Calls into shared built-ins that we know take
+  read-only arguments can skip defensive copies that the built-in
+  currently makes.
+- **Tier-up decisions (Phase 2 of #1584).** Hot interpreted functions
+  with `owned` allocations are good tier-up candidates because their
+  state is locally analyzable.
+- **Dual-target preparation (#1585).** Lifetime analysis for a future
+  linear-memory backend depends on ownership inference being available.
+- **Differential testing diagnostics.** When AOT and bytecode paths
+  diverge, ownership annotations on the divergent values help bisect
+  whether the bug is in escape-analysis assumptions or elsewhere.
+
+The pass is a force multiplier: one analysis, many downstream consumers.
+
+## Design
+
+### Analysis structure
+
+A flow-sensitive, intra-procedural, may-escape analysis. For each
+function in the IR:
+
+1. **Initialization.** Every `AllocSite` from #1586 starts as `owned` with
+   access set `{}`. Every imported reference (parameter, closure capture,
+   global access) starts as `shared` with access set `{ read }`.
+2. **Flow.** Walk the IR in topological order over the control-flow
+   graph. For each operation, update the ownership and access state of
+   each operand reference according to the operation's effect:
+   - `LoadField(ref, name)` → adds `read` to `ref`'s access set
+   - `StoreField(ref, name, value)` → adds `write` to `ref`, escape may
+     apply to `value` depending on the field
+   - `Call(fn, args)` → if `fn` is opaque, all `args` are `escaped` with
+     full access; if `fn` is known and analyzed, propagate from `fn`'s
+     parameter annotations
+   - `Return(value)` → `value` becomes `escaped`
+   - `StoreCapture(slot, value)` → `value` becomes `escaped`
+3. **Join.** At control-flow merge points, ownership states are joined
+   conservatively: `owned ∨ borrowed = borrowed`, `borrowed ∨ shared =
+   shared`, `shared ∨ escaped = escaped`.
+4. **Fixed point.** Iterate until annotations stabilize. For loops, this
+   requires careful initial seeding; values in loops generally widen to
+   `shared` quickly unless the loop is a simple counted form.
+
+### Inter-procedural extension
+
+The initial implementation is **intra-procedural**: each function is
+analyzed in isolation, and unknown callees are treated as fully escaping.
+This already provides useful information for the majority of allocations,
+which are function-local.
+
+A follow-up issue can add inter-procedural propagation: analyze known
+callees first, summarize their parameter and return effects, use the
+summaries when analyzing callers. This is a substantial extension and
+explicitly out of scope here.
+
+### Output API
+
+Annotations are written to the `AllocSiteRegistry` from #1586 under the
+`ownership` and `access` namespaces:
+
+```ts
+registry.annotate(allocId, 'ownership', { state: 'owned' });
+registry.annotate(allocId, 'access', { ops: ['read', 'write'] });
+```
+
+For non-allocated values (parameters, captures), a parallel `ValueAnnot`
+map keyed by IR value ID stores the same shape of annotation.
+
+Downstream passes consume the annotations via a typed query API:
+
+```ts
+const ownership = analyses.ownership.of(value); // 'owned' | 'borrowed' | …
+const access    = analyses.access.of(value);     // Set<'read'|'write'|…>
+```
+
+### Conservative defaults
+
+When in doubt, the analysis returns the *most permissive* result that
+preserves correctness:
+
+- Ownership: `shared`
+- Access: `{ read, write, mutate, identity, escape }`
+
+Consumers must check whether the annotation is tight enough to enable
+their optimization. If not, they fall back to the conservative path. No
+optimization is allowed to assume tighter annotations than the analysis
+returns.
+
+## Scope
+
+1. Define the lattice for ownership and access in code, with documented
+   join and meet operations.
+2. Implement the intra-procedural analysis pass as a worklist algorithm
+   over the IR control-flow graph.
+3. Wire the analysis into the pass pipeline, running after #1586's
+   allocation-site infrastructure is in place but before any consumer
+   pass.
+4. Document the analysis output and the consumer query API in an ADR.
+   The ADR must include the conservative-defaults guarantee.
+5. Implement one canonical consumer as a demonstration and regression
+   anchor: **stack-allocation for proven-`owned`-non-`escaped`
+   allocations of small objects**. This produces measurable size and
+   performance signal and ensures the pass output is correct enough to
+   build on.
+6. Add tests for the analysis itself (unit tests with known IR fragments
+   and expected annotations) and for the demonstration consumer
+   (equivalence + benchmark deltas).
+
+## Phasing
+
+**Phase 1 (this issue, ~4-6 weeks)**: intra-procedural analysis,
+ownership and access lattices, registry integration, ADR, one
+demonstration consumer.
+
+**Phase 2 (follow-up issue)**: inter-procedural extension with function
+summaries.
+
+**Phase 3 (follow-up issue)**: precision improvements — better loop
+handling, conditional ownership refinement, escape-via-exception
+tracking, integration with #1588's encoding tracking.
+
+## Non-goals
+
+- Rust-style borrow checking. The analysis is inference, not rejection.
+  Programs that would fail Rust's borrow checker compile fine; they
+  simply get conservative annotations.
+- Inter-procedural analysis. Phase 2.
+- Annotations on values inside built-ins. Built-ins are opaque to this
+  pass; they declare their parameter and return effects via manual
+  annotations (a separate small issue if needed).
+- Annotations as program semantics. The analysis is purely an
+  optimization aid. Removing the pass must not change observable program
+  behavior.
+
+## Relationship to other issues
+
+- **#1586** (explicit allocation sites) — hard dependency. The
+  registry is where annotations live.
+- **#1588** (string encoding tracking) — parallel analysis. Both run
+  after #1586; both write to the registry; they do not interact in Phase
+  1 but Phase 3 may benefit from joint analysis.
+- **#1585** (dual-target IR architecture) — long-term consumer.
+  Ownership annotations are the foundation for lifetime analysis on
+  allocation sites, which is in turn a defensive-design point for a
+  linear-memory backend.
+- **#1584** (Wasm-GC-native bytecode interpreter) — orthogonal but
+  potentially synergistic: ownership-known bytecode functions are
+  better candidates for tier-up to AOT.
+
+## Acceptance criteria
+
+- [ ] ADR-XXX documents the ownership and access lattices, the join
+      operations, and the conservative defaults.
+- [ ] Analysis pass implemented under `src/ir/analysis/ownership.ts`
+      (or equivalent), reading from and writing to the registry from
+      #1586.
+- [ ] Pass runs as part of the standard optimization pipeline and is
+      gated behind a feature flag for the rollout period.
+- [ ] Unit tests cover ownership and access propagation for at least
+      these IR fragments: simple allocation, escape via return, escape
+      via store-to-heap, escape via opaque call, mutation via field
+      store, conditional escape via branching, loop-carried allocation.
+- [ ] Demonstration consumer (stack-allocation for owned+non-escaped
+      small objects) implemented and gated separately. Measured size
+      reduction on a representative test262 subset.
+- [ ] No new failures in `npm test`, `pnpm run test:262`, or
+      `pnpm run test:diff`.
+
+## Risks
+
+- **Precision insufficient for downstream consumers.** If the analysis
+  classifies too many values as `shared` or `escaped`, consumers find
+  the output unusable. Mitigation: implement the demonstration consumer
+  as part of this issue; if it does not produce measurable wins, the
+  precision is too low and the pass needs more work before being marked
+  done.
+- **Performance overhead on compile time.** Flow-sensitive analyses can
+  be slow on large functions. Mitigation: budget for the analysis
+  separately; benchmark on the largest test262 file as a stress test;
+  add an early-exit for functions trivially classifiable.
+- **Soundness bugs.** A bug in the analysis that returns a tighter
+  annotation than reality permits causes downstream miscompilation.
+  Mitigation: differential testing must include all consumer
+  optimizations; conservative defaults are the safety net; ADR
+  documents the "no consumer assumes tighter than returned" rule.
+- **Drift between AOT and interpreter paths.** If only AOT consumes the
+  analysis, interpreted code becomes the more pessimistic path. That
+  may be fine in Phase 1, but should be acknowledged. Mitigation:
+  document explicitly in the ADR.
+
+## Notes
+
+- The analysis is broadly similar in style to Rust's MIR-level borrow
+  analysis, V8's escape analysis in TurboFan, and SpiderMonkey's alias
+  set analysis. Worth citing in the ADR; not worth porting from.
+- The "one demonstration consumer" requirement is deliberate. Static
+  analyses that no pass consumes are dead code with maintenance cost. By
+  requiring a real consumer, this issue forces the analysis to be
+  immediately useful, not speculative.
+- Naming-wise: "ownership" is the closest English word to what the
+  analysis tracks, but it carries Rust-language baggage. The ADR should
+  explicitly disclaim the Rust framing: ownership here is *inferred*
+  classification, not *declared* type.
+- Phase 1 deliberately avoids inter-procedural analysis because the
+  intra-procedural results are already useful for most short-lived
+  allocations, and inter-procedural adds significant implementation
+  surface (summary computation, summary serialization, summary
+  invalidation on recompilation).

--- a/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
+++ b/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
@@ -1,0 +1,364 @@
+---
+id: 1588
+title: "String encoding tracking: prove UTF-8 guarantees for zero-copy Component Model interop"
+status: ready
+sprint: 55
+created: 2026-05-23
+updated: 2026-05-23
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: compiler
+language_feature: strings
+goal: platform
+depends_on: [1586]
+es_edition: multi
+---
+# #1588 — String encoding tracking: prove UTF-8 guarantees for zero-copy Component Model interop
+
+Static analysis that propagates a per-string-value encoding guarantee
+through the IR, distinguishing **provably-UTF-8** strings from
+**possibly-WTF-16** ones. The motivation is the WebAssembly Component
+Model: its `string` type is defined as a list of Unicode scalar values
+encoded as UTF-8, while JavaScript strings are WTF-16 (UTF-16 with
+unpaired surrogates permitted). Without tracking, every JS string crossing
+a Component boundary requires re-encoding and a copy. With tracking, strings
+proven to contain only valid UTF-8 scalars can cross the boundary directly.
+
+The performance opportunity is substantial. The correctness consequence is
+zero: tracking is purely advisory; strings without a UTF-8 guarantee fall
+back to the existing re-encode-and-copy path.
+
+Depends on #1586 (explicit allocation sites) for attachment point on
+string allocations.
+
+## Background
+
+### Encoding mismatch
+
+JavaScript strings, per ECMAScript spec, are sequences of 16-bit code
+units, with no requirement that surrogate pairs are well-formed. A string
+like `String.fromCharCode(0xD800)` is a single unpaired high surrogate.
+This is WTF-16, not UTF-16.
+
+The Component Model's `string` type is defined as a sequence of Unicode
+scalar values (excluding surrogates by definition), canonically transferred
+as UTF-8. There is no encoding for unpaired surrogates in UTF-8 because
+the Unicode scalar set excludes them.
+
+When a JS string crosses a Component boundary today:
+
+1. The full string is scanned to validate Unicode scalar correctness.
+2. Either it is re-encoded WTF-16 → UTF-8 (allocation + copy), or it
+   contains unpaired surrogates and the conversion traps or substitutes.
+
+For long strings, this scan + copy is measurable. For high-frequency
+small-string transfers (logging, structured output, RPC) it dominates
+the boundary cost.
+
+### Many JS strings are provably UTF-8
+
+In practice, most JavaScript strings encountered at Component
+boundaries originate from sources that cannot introduce unpaired
+surrogates:
+
+- **String literals** in source code are validated at parse time.
+- **`TextDecoder` decode results** are UTF-8 by construction (the spec
+  forbids the decoder from producing unpaired surrogates).
+- **`JSON.parse` outputs** are UTF-8 by spec (RFC 8259 restricts JSON
+  text to UTF-8).
+- **`fetch().text()` results** are UTF-8 unless explicitly told otherwise
+  by the response headers.
+- **Concatenations of UTF-8-guaranteed strings** preserve the guarantee.
+
+Tracking these origins through the IR and propagating the guarantee
+through preserving operations lets the boundary code use the cheap path
+for the strings that allow it.
+
+## Goal
+
+After this issue:
+
+1. Every string `AllocSite` from #1586 carries an `encoding` annotation
+   with one of three values:
+   - `utf8-guaranteed` — the analysis can prove the string contains
+     only well-formed UTF-8 scalar values.
+   - `wtf16` — the string may contain unpaired surrogates (the
+     conservative default).
+   - `ascii` — a stricter subset of `utf8-guaranteed` for strings provably
+     containing only code points ≤ 0x7F. Enables further optimization
+     (single-byte-per-char paths in Component Model implementations that
+     support it).
+
+2. A documented set of propagation rules for string operations:
+   - origin operations (literal, decoder, JSON, etc.) seed the
+     annotation.
+   - preserving operations (concat, slice on code-point boundaries,
+     intern) preserve the annotation.
+   - encoding-destroying operations (fromCharCode with arbitrary
+     argument, substring on raw code-unit indices, regex with capture
+     groups that may split surrogates) drop the annotation to `wtf16`.
+
+3. The Component Model boundary lowering reads the annotation and
+   selects the appropriate path: zero-copy externref-passing for
+   `utf8-guaranteed`, the existing scan-and-encode path for `wtf16`.
+
+4. No semantic change to the program. A wrongly-conservative annotation
+   yields a slower path but identical results. A wrongly-optimistic
+   annotation is a correctness bug, and the analysis is required to err
+   conservative.
+
+## Why this is achievable in a short timeframe
+
+Encoding analysis is structurally simpler than ownership analysis (#1587):
+
+- It is **flow-insensitive in most cases** — the encoding of a string
+  is determined at its origin and propagates statically through
+  operations regardless of execution order.
+- It is **monotonic**: starting `utf8-guaranteed`, an operation either
+  preserves the guarantee or drops it. No fixed-point iteration needed
+  for the common case.
+- The propagation rules are a **small, finite table** — one entry per
+  string-producing operation in the language.
+- Wrong answers are degrading (slower path) rather than incorrect, so
+  the safety bar is "never claim guarantee when none exists" rather
+  than "always find every guarantee".
+
+This means the implementation can be staged aggressively: a useful
+initial version covers literal-origin + concat + JSON-decode and already
+captures the majority of string traffic in real applications. Refinement
+proceeds incrementally.
+
+## Design
+
+### Annotation lattice
+
+A simple three-level lattice with `ascii` as a sublattice of
+`utf8-guaranteed`:
+
+```
+              wtf16   (top, most permissive)
+                │
+          utf8-guaranteed
+                │
+              ascii  (bottom, most restrictive)
+```
+
+Operations join annotations conservatively. Two strings concatenated:
+
+| Left          | Right         | Result        |
+|---------------|---------------|---------------|
+| `ascii`       | `ascii`       | `ascii`       |
+| `ascii`       | `utf8-guaranteed` | `utf8-guaranteed` |
+| `utf8-guaranteed` | `utf8-guaranteed` | `utf8-guaranteed` |
+| any           | `wtf16`       | `wtf16`       |
+
+### Origin rules
+
+- String literal in source: `ascii` if all chars ≤ 0x7F, else
+  `utf8-guaranteed`. Decided at parse time.
+- `JSON.parse` result strings: `utf8-guaranteed` (JSON forbids
+  unpaired surrogates per RFC 8259 §7).
+- `TextDecoder.decode(buf)` result: `utf8-guaranteed` (per WHATWG
+  Encoding spec).
+- `fetch().text()` result: `utf8-guaranteed` if the response had a
+  text/* media type with UTF-8 charset (the common case); `wtf16`
+  otherwise. Conservative default if unknown: `wtf16`.
+- `String.fromCharCode(n)` with statically known `n` ≤ 0xD7FF or
+  in `[0xE000, 0xFFFF]`: `utf8-guaranteed`. Otherwise `wtf16`.
+- `String.fromCodePoint(n)` with statically known scalar `n`:
+  `utf8-guaranteed`. Dynamic `n`: `wtf16`.
+- Property accesses, method results from non-tracked sources: `wtf16`.
+
+### Propagation rules
+
+- `s1 + s2`, template literal interpolation: join the annotations per
+  the lattice table.
+- `s.toUpperCase()`, `s.toLowerCase()`, `s.trim()`, `s.normalize()`:
+  preserve the annotation. (These cannot introduce surrogates from
+  non-surrogate input.)
+- `s.slice(a, b)` with statically known indices that fall on code-point
+  boundaries: preserve. Otherwise drop to `wtf16` (slicing in the
+  middle of a surrogate pair would split the pair).
+- `s.split(sep)` results: preserve if `sep` is statically known to be
+  a non-surrogate string; otherwise `wtf16`.
+- `s.replace(pattern, replacement)`: preserve if `pattern` is a string
+  literal and `replacement` is a tracked string; drop for regex
+  patterns unless the regex is statically analyzable.
+- `s.repeat(n)`, `s.padStart(n, pad)`, `s.padEnd(n, pad)`: preserve.
+- `JSON.stringify(value)` result: `utf8-guaranteed` (JSON stringify
+  escapes lone surrogates per ES2019+ §24.5.2.2 Step 11).
+- Any operation not in the above table: drop to `wtf16`.
+
+### Component Model boundary integration
+
+When the IR emits a call across a Component Model boundary that takes a
+`string` argument, the lowering pass checks the annotation on the value:
+
+- `ascii` or `utf8-guaranteed`: pass directly as a `(list u8)` view of
+  the string's underlying storage, if the runtime representation
+  permits zero-copy. Otherwise, fall through to the next case.
+- `wtf16`: emit the existing scan-and-encode path.
+
+The "if the runtime representation permits zero-copy" caveat depends on
+how strings are stored in the Wasm-GC heap. If we store strings as
+`(array i16)` (typical WTF-16 storage), zero-copy is not possible even
+for `utf8-guaranteed` strings — they still need to be re-encoded from
+16-bit units to 8-bit units. Two follow-up paths:
+
+1. **Dual storage**: store `ascii` and `utf8-guaranteed` strings as
+   `(array i8)` from the start; store `wtf16` strings as `(array i16)`.
+   The encoding annotation drives the storage decision at the
+   allocation site. This requires the annotation to be available before
+   storage layout is committed.
+2. **Lazy re-encoding cache**: keep WTF-16 storage everywhere but cache
+   a UTF-8 view next to the string for tracked-UTF-8 strings.
+
+Path 1 is preferable for new allocations because it eliminates the copy
+entirely; Path 2 may be useful as an intermediate step. This is a
+deliberate design decision in the implementation plan.
+
+## Scope
+
+1. ADR documenting the encoding lattice, origin rules, propagation
+   table, and Component Model boundary integration.
+2. Analysis pass implemented as a small dataflow over the IR, writing
+   `encoding` annotations to the `AllocSiteRegistry` from #1586 (under
+   the `encoding` namespace).
+3. Update the Component Model boundary lowering to read the annotation
+   and emit the appropriate path. Initial implementation may emit both
+   paths and dispatch at runtime if static encoding is `wtf16`; the
+   zero-copy path is only taken for tracked annotations.
+4. Choose between dual-storage and lazy-re-encoding strategies. Initial
+   implementation: dual storage for newly allocated `utf8-guaranteed`
+   strings; keep WTF-16 storage for `wtf16` strings.
+5. Implement the canonical origin rules (literal, JSON, TextDecoder)
+   and propagation rules (concat, slice with known boundaries,
+   case-conversion). Document gaps as follow-up items.
+6. Test coverage: encoding annotations correctly inferred for a corpus
+   of representative string patterns; Component Model boundary tests
+   pass with both `utf8-guaranteed` and `wtf16` paths exercised.
+
+## Phasing
+
+**Phase 1 (this issue, ~3-4 weeks)**: lattice + analysis pass +
+boundary integration + dual storage for the canonical origin set
+(literal, JSON, TextDecoder, concat).
+
+**Phase 2 (follow-up)**: extended origin coverage (fetch, regex
+matches, Intl operations), propagation through more methods, refinement
+of slice/substring rules.
+
+**Phase 3 (follow-up)**: integration with the Reference-Typed Strings
+proposal once it stabilizes — if that proposal lands, much of the
+encoding tracking can be expressed in the type system rather than
+inferred. Coordinate with #1165 (JIT-interface tracking) and other
+proposal-tracking issues if a similar issue exists for Reference-Typed
+Strings.
+
+## Non-goals
+
+- Changing the observable JavaScript semantics. WTF-16 indexing, length,
+  comparison, etc. continue to work unchanged.
+- Building a fully-precise encoding analysis. Conservative annotations
+  on operations we cannot easily analyze (regex, dynamic indices) are
+  acceptable; precision improvements are follow-up issues.
+- Re-encoding all storage to UTF-8. WTF-16 storage remains the default
+  for strings that the analysis cannot prove. Dual storage is only for
+  proven-UTF-8 allocation sites.
+- Adding new JavaScript-level APIs. The annotation is internal to the
+  compiler and runtime.
+
+## Relationship to other issues
+
+- **#1586** (explicit allocation sites) — hard dependency. Encoding
+  annotations live on string `AllocSite` nodes.
+- **#1587** (ownership and access semantics analysis) — parallel
+  analysis. Both run after #1586; both write to the registry; the two
+  analyses do not interact in Phase 1, but Phase 2 of either may
+  benefit from the other.
+- **Component Model boundary issues** (existing or to-be-filed) — direct
+  consumer of this analysis. Coordinate naming and ABI.
+- **Reference-Typed Strings proposal** (WebAssembly/stringref) — long-
+  term, may subsume parts of this analysis. Track separately.
+- **#1105** (Wasm-native string method implementations) — relevant.
+  Built-in string method implementations are the propagation rules in
+  action; #1105 work should be designed to preserve encoding
+  annotations.
+
+## ECMAScript and WHATWG spec references
+
+- [ECMA-262 §6.1.4 String type](https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type) — WTF-16 semantics
+- [ECMA-262 §24.5.2 JSON.stringify](https://tc39.es/ecma262/#sec-json.stringify) — UTF-8 escape behavior
+- [ECMA-262 §22.1.3.x String.prototype methods](https://tc39.es/ecma262/#sec-properties-of-the-string-prototype-object) — method-by-method propagation rules
+- [WHATWG Encoding spec](https://encoding.spec.whatwg.org/) — TextDecoder UTF-8 guarantees
+- [RFC 8259 JSON](https://datatracker.ietf.org/doc/html/rfc8259) — UTF-8 requirement for JSON text
+- [Component Model: string](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md) — canonical ABI for strings
+
+## Acceptance criteria
+
+- [ ] ADR-XXX documents the encoding lattice, origin rules, propagation
+      table, and storage strategy.
+- [ ] Analysis pass implemented under `src/ir/analysis/encoding.ts`,
+      writing to the `AllocSiteRegistry` `encoding` namespace.
+- [ ] Origin rules implemented for: string literals, `JSON.parse`,
+      `JSON.stringify`, `TextDecoder.prototype.decode`.
+- [ ] Propagation rules implemented for: `+` and template literals
+      (concat), `.toUpperCase`, `.toLowerCase`, `.trim`,
+      `.slice` with statically known boundaries, `.repeat`, `.padStart`,
+      `.padEnd`.
+- [ ] Component Model boundary lowering reads the annotation and
+      selects path. Both paths exercised by tests.
+- [ ] Dual storage implemented for `utf8-guaranteed` allocation sites:
+      strings allocated under `utf8-guaranteed` use `(array i8)`
+      storage; `wtf16` strings retain `(array i16)`.
+- [ ] Benchmark: end-to-end measurement of string-heavy Component Model
+      interop showing the zero-copy path's improvement over the
+      scan-and-encode baseline. Numbers go into the ADR.
+- [ ] No semantic regressions in any test suite. WTF-16 strings continue
+      to work; equality, indexing, length, comparison all unchanged.
+
+## Risks
+
+- **Soundness bug claims UTF-8 when string contains a surrogate.**
+  Catastrophic — produces malformed UTF-8 at the Component boundary,
+  which may corrupt the receiving Component or trap. Mitigation: the
+  conservative default is `wtf16`; only explicit, audited origin rules
+  promote to `utf8-guaranteed`; differential testing must include
+  fuzzed string inputs that exercise the boundary.
+- **Dual storage doubles complexity in the string runtime.** Every
+  string operation now needs to handle both representations.
+  Mitigation: built-ins are coded against an abstract string interface;
+  the i8/i16 difference is hidden behind a small set of access
+  primitives. This pattern is already established in #1105.
+- **Coverage of origin rules insufficient to move the benchmark.** If
+  the analysis only promotes a small fraction of strings, the boundary
+  improvement is invisible. Mitigation: the canonical origin set
+  (literal, JSON, decoder) covers the majority of real-world strings;
+  benchmark numbers in the ADR validate this.
+- **Reference-Typed Strings proposal lands and obsoletes this work.**
+  Possible long-term outcome. Mitigation: the analysis investment is
+  still useful even if the proposal lands — type information from the
+  proposal would replace inference, but the propagation rules and
+  Component Model dispatch logic remain. Worst case: the analysis
+  becomes vestigial and is removed; the dual-storage work transfers.
+
+## Notes
+
+- This issue produces directly user-visible performance improvements at
+  the Component Model boundary, which is the integration surface that
+  matters most for adoption in Wasm-component ecosystems. The ADR
+  should make the performance story explicit, with measured numbers,
+  so that downstream users can evaluate whether their workload is
+  positioned to benefit.
+- The conservative-by-default rule is more important here than in
+  #1587, because the failure mode is correctness rather than missed
+  optimization. The pattern of "small audited origin set, monotonic
+  drop to conservative on uncertainty" is the right shape.
+- A real benchmark is required as an acceptance criterion (rather than
+  being a Phase 2 nice-to-have) because the entire motivation is
+  performance. Without numbers, the analysis is theoretical.
+- Naming: "UTF-8 guaranteed" is the term used here for clarity; the
+  ADR may settle on a different internal name (`wellformed`, `scalar`,
+  etc.) once the analysis is implemented.

--- a/plan/issues/sprints/55/sprint.md
+++ b/plan/issues/sprints/55/sprint.md
@@ -1,0 +1,20 @@
+---
+sprint: 55
+status: planning
+created: 2026-05-23
+---
+
+# Sprint 55 Plan
+
+## Issues
+
+| ID | Title | Feasibility | Depends on |
+|----|-------|-------------|------------|
+| [#1586](1586-explicit-allocation-sites-in-ir.md) | IR preparation: explicit allocation sites with stable identity and metadata hooks | medium | — |
+| [#1587](1587-ownership-and-access-semantics-analysis.md) | Static analysis pass: ownership and access semantics on IR values | hard | #1586 |
+| [#1588](1588-string-encoding-tracking-utf8-wtf16.md) | String encoding tracking: prove UTF-8 guarantees for zero-copy Component Model interop | medium | #1586 |
+
+## Notes
+
+- #1586 must land first; #1587 and #1588 both depend on it.
+- #1587 is `feasibility: hard` — needs architect spec before dispatch.


### PR DESCRIPTION
## Summary

- Creates `plan/issues/sprints/55/` with sprint.md and three issue files
- #1586 explicit allocation sites in IR (prerequisite, no deps)
- #1587 ownership and access semantics analysis (depends on #1586, `feasibility: hard`)
- #1588 string encoding tracking for zero-copy Component Model interop (depends on #1586)

Planning-only change, no code.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)