### PR TITLE
ci(test262): bump shards from 50 to 115

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -146,17 +146,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 50 shards — maximizes parallelism within the 60-runner budget while
-        # leaving headroom (~5) for cheap-gate, quality, cla-check, differential-test.
-        # With Test262 Differential dropped from merge_group + PR contexts, this
-        # is the sweet spot for one PR in flight. Per-shard work shrinks to ~860
-        # tests / ~8 min wall, vs ~13 min at 32 shards. Concurrent PRs will see
-        # ~50 of their shards queue (no priority queue in GH Actions).
+        # 115 shards — bumped from 50 per user request. Per-shard work shrinks
+        # to ~375 tests / ~3-4 min wall. On GH-hosted runners (60 concurrent
+        # max for public repos), the first ~60 shards run in parallel and the
+        # remaining ~55 queue as the first wave finishes. Net wall time should
+        # be similar to or slightly better than 50 shards once the queueing
+        # absorbs into the runner pool.
         chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
                 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
                 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-                41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
+                41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                111, 112, 113, 114, 115]
 
     env:
       COMPILER_POOL_SIZE: ${{ inputs.compiler_pool_size || '2' }}

--- a/tests/test262-chunk1.test.ts
+++ b/tests/test262-chunk1.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 1/50 — round-robin by test for even distribution. */
+/** Test262 chunk 1/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(0, 50);
+runTest262Chunk(0, 115);

--- a/tests/test262-chunk10.test.ts
+++ b/tests/test262-chunk10.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 10/50 — round-robin by test for even distribution. */
+/** Test262 chunk 10/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(9, 50);
+runTest262Chunk(9, 115);

--- a/tests/test262-chunk100.test.ts
+++ b/tests/test262-chunk100.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 100/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(99, 115);

--- a/tests/test262-chunk101.test.ts
+++ b/tests/test262-chunk101.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 101/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(100, 115);

--- a/tests/test262-chunk102.test.ts
+++ b/tests/test262-chunk102.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 102/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(101, 115);

--- a/tests/test262-chunk103.test.ts
+++ b/tests/test262-chunk103.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 103/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(102, 115);

--- a/tests/test262-chunk104.test.ts
+++ b/tests/test262-chunk104.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 104/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(103, 115);

--- a/tests/test262-chunk105.test.ts
+++ b/tests/test262-chunk105.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 105/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(104, 115);

--- a/tests/test262-chunk106.test.ts
+++ b/tests/test262-chunk106.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 106/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(105, 115);

--- a/tests/test262-chunk107.test.ts
+++ b/tests/test262-chunk107.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 107/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(106, 115);

--- a/tests/test262-chunk108.test.ts
+++ b/tests/test262-chunk108.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 108/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(107, 115);

--- a/tests/test262-chunk109.test.ts
+++ b/tests/test262-chunk109.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 109/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(108, 115);

--- a/tests/test262-chunk11.test.ts
+++ b/tests/test262-chunk11.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 11/50 — round-robin by test for even distribution. */
+/** Test262 chunk 11/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(10, 50);
+runTest262Chunk(10, 115);

--- a/tests/test262-chunk110.test.ts
+++ b/tests/test262-chunk110.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 110/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(109, 115);

--- a/tests/test262-chunk111.test.ts
+++ b/tests/test262-chunk111.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 111/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(110, 115);

--- a/tests/test262-chunk112.test.ts
+++ b/tests/test262-chunk112.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 112/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(111, 115);

--- a/tests/test262-chunk113.test.ts
+++ b/tests/test262-chunk113.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 113/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(112, 115);

--- a/tests/test262-chunk114.test.ts
+++ b/tests/test262-chunk114.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 114/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(113, 115);

--- a/tests/test262-chunk115.test.ts
+++ b/tests/test262-chunk115.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 115/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(114, 115);

--- a/tests/test262-chunk12.test.ts
+++ b/tests/test262-chunk12.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 12/50 — round-robin by test for even distribution. */
+/** Test262 chunk 12/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(11, 50);
+runTest262Chunk(11, 115);

--- a/tests/test262-chunk13.test.ts
+++ b/tests/test262-chunk13.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 13/50 — round-robin by test for even distribution. */
+/** Test262 chunk 13/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(12, 50);
+runTest262Chunk(12, 115);

--- a/tests/test262-chunk14.test.ts
+++ b/tests/test262-chunk14.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 14/50 — round-robin by test for even distribution. */
+/** Test262 chunk 14/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(13, 50);
+runTest262Chunk(13, 115);

--- a/tests/test262-chunk15.test.ts
+++ b/tests/test262-chunk15.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 15/50 — round-robin by test for even distribution. */
+/** Test262 chunk 15/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(14, 50);
+runTest262Chunk(14, 115);

--- a/tests/test262-chunk16.test.ts
+++ b/tests/test262-chunk16.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 16/50 — round-robin by test for even distribution. */
+/** Test262 chunk 16/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(15, 50);
+runTest262Chunk(15, 115);

--- a/tests/test262-chunk17.test.ts
+++ b/tests/test262-chunk17.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 17/50 — round-robin by test for even distribution. */
+/** Test262 chunk 17/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(16, 50);
+runTest262Chunk(16, 115);

--- a/tests/test262-chunk18.test.ts
+++ b/tests/test262-chunk18.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 18/50 — round-robin by test for even distribution. */
+/** Test262 chunk 18/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(17, 50);
+runTest262Chunk(17, 115);

--- a/tests/test262-chunk19.test.ts
+++ b/tests/test262-chunk19.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 19/50 — round-robin by test for even distribution. */
+/** Test262 chunk 19/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(18, 50);
+runTest262Chunk(18, 115);

--- a/tests/test262-chunk2.test.ts
+++ b/tests/test262-chunk2.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 2/50 — round-robin by test for even distribution. */
+/** Test262 chunk 2/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(1, 50);
+runTest262Chunk(1, 115);

--- a/tests/test262-chunk20.test.ts
+++ b/tests/test262-chunk20.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 20/50 — round-robin by test for even distribution. */
+/** Test262 chunk 20/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(19, 50);
+runTest262Chunk(19, 115);

--- a/tests/test262-chunk21.test.ts
+++ b/tests/test262-chunk21.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 21/50 — round-robin by test for even distribution. */
+/** Test262 chunk 21/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(20, 50);
+runTest262Chunk(20, 115);

--- a/tests/test262-chunk22.test.ts
+++ b/tests/test262-chunk22.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 22/50 — round-robin by test for even distribution. */
+/** Test262 chunk 22/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(21, 50);
+runTest262Chunk(21, 115);

--- a/tests/test262-chunk23.test.ts
+++ b/tests/test262-chunk23.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 23/50 — round-robin by test for even distribution. */
+/** Test262 chunk 23/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(22, 50);
+runTest262Chunk(22, 115);

--- a/tests/test262-chunk24.test.ts
+++ b/tests/test262-chunk24.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 24/50 — round-robin by test for even distribution. */
+/** Test262 chunk 24/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(23, 50);
+runTest262Chunk(23, 115);

--- a/tests/test262-chunk25.test.ts
+++ b/tests/test262-chunk25.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 25/50 — round-robin by test for even distribution. */
+/** Test262 chunk 25/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(24, 50);
+runTest262Chunk(24, 115);

--- a/tests/test262-chunk26.test.ts
+++ b/tests/test262-chunk26.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 26/50 — round-robin by test for even distribution. */
+/** Test262 chunk 26/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(25, 50);
+runTest262Chunk(25, 115);

--- a/tests/test262-chunk27.test.ts
+++ b/tests/test262-chunk27.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 27/50 — round-robin by test for even distribution. */
+/** Test262 chunk 27/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(26, 50);
+runTest262Chunk(26, 115);

--- a/tests/test262-chunk28.test.ts
+++ b/tests/test262-chunk28.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 28/50 — round-robin by test for even distribution. */
+/** Test262 chunk 28/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(27, 50);
+runTest262Chunk(27, 115);

--- a/tests/test262-chunk29.test.ts
+++ b/tests/test262-chunk29.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 29/50 — round-robin by test for even distribution. */
+/** Test262 chunk 29/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(28, 50);
+runTest262Chunk(28, 115);

--- a/tests/test262-chunk3.test.ts
+++ b/tests/test262-chunk3.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 3/50 — round-robin by test for even distribution. */
+/** Test262 chunk 3/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(2, 50);
+runTest262Chunk(2, 115);

--- a/tests/test262-chunk30.test.ts
+++ b/tests/test262-chunk30.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 30/50 — round-robin by test for even distribution. */
+/** Test262 chunk 30/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(29, 50);
+runTest262Chunk(29, 115);

--- a/tests/test262-chunk31.test.ts
+++ b/tests/test262-chunk31.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 31/50 — round-robin by test for even distribution. */
+/** Test262 chunk 31/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(30, 50);
+runTest262Chunk(30, 115);

--- a/tests/test262-chunk32.test.ts
+++ b/tests/test262-chunk32.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 32/50 — round-robin by test for even distribution. */
+/** Test262 chunk 32/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(31, 50);
+runTest262Chunk(31, 115);

--- a/tests/test262-chunk33.test.ts
+++ b/tests/test262-chunk33.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 33/50 — round-robin by test for even distribution. */
+/** Test262 chunk 33/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(32, 50);
+runTest262Chunk(32, 115);

--- a/tests/test262-chunk34.test.ts
+++ b/tests/test262-chunk34.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 34/50 — round-robin by test for even distribution. */
+/** Test262 chunk 34/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(33, 50);
+runTest262Chunk(33, 115);

--- a/tests/test262-chunk35.test.ts
+++ b/tests/test262-chunk35.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 35/50 — round-robin by test for even distribution. */
+/** Test262 chunk 35/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(34, 50);
+runTest262Chunk(34, 115);

--- a/tests/test262-chunk36.test.ts
+++ b/tests/test262-chunk36.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 36/50 — round-robin by test for even distribution. */
+/** Test262 chunk 36/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(35, 50);
+runTest262Chunk(35, 115);

--- a/tests/test262-chunk37.test.ts
+++ b/tests/test262-chunk37.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 37/50 — round-robin by test for even distribution. */
+/** Test262 chunk 37/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(36, 50);
+runTest262Chunk(36, 115);

--- a/tests/test262-chunk38.test.ts
+++ b/tests/test262-chunk38.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 38/50 — round-robin by test for even distribution. */
+/** Test262 chunk 38/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(37, 50);
+runTest262Chunk(37, 115);

--- a/tests/test262-chunk39.test.ts
+++ b/tests/test262-chunk39.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 39/50 — round-robin by test for even distribution. */
+/** Test262 chunk 39/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(38, 50);
+runTest262Chunk(38, 115);

--- a/tests/test262-chunk4.test.ts
+++ b/tests/test262-chunk4.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 4/50 — round-robin by test for even distribution. */
+/** Test262 chunk 4/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(3, 50);
+runTest262Chunk(3, 115);

--- a/tests/test262-chunk40.test.ts
+++ b/tests/test262-chunk40.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 40/50 — round-robin by test for even distribution. */
+/** Test262 chunk 40/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(39, 50);
+runTest262Chunk(39, 115);

--- a/tests/test262-chunk41.test.ts
+++ b/tests/test262-chunk41.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 41/50 — round-robin by test for even distribution. */
+/** Test262 chunk 41/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(40, 50);
+runTest262Chunk(40, 115);

--- a/tests/test262-chunk42.test.ts
+++ b/tests/test262-chunk42.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 42/50 — round-robin by test for even distribution. */
+/** Test262 chunk 42/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(41, 50);
+runTest262Chunk(41, 115);

--- a/tests/test262-chunk43.test.ts
+++ b/tests/test262-chunk43.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 43/50 — round-robin by test for even distribution. */
+/** Test262 chunk 43/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(42, 50);
+runTest262Chunk(42, 115);

--- a/tests/test262-chunk44.test.ts
+++ b/tests/test262-chunk44.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 44/50 — round-robin by test for even distribution. */
+/** Test262 chunk 44/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(43, 50);
+runTest262Chunk(43, 115);

--- a/tests/test262-chunk45.test.ts
+++ b/tests/test262-chunk45.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 45/50 — round-robin by test for even distribution. */
+/** Test262 chunk 45/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(44, 50);
+runTest262Chunk(44, 115);

--- a/tests/test262-chunk46.test.ts
+++ b/tests/test262-chunk46.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 46/50 — round-robin by test for even distribution. */
+/** Test262 chunk 46/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(45, 50);
+runTest262Chunk(45, 115);

--- a/tests/test262-chunk47.test.ts
+++ b/tests/test262-chunk47.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 47/50 — round-robin by test for even distribution. */
+/** Test262 chunk 47/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(46, 50);
+runTest262Chunk(46, 115);

--- a/tests/test262-chunk48.test.ts
+++ b/tests/test262-chunk48.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 48/50 — round-robin by test for even distribution. */
+/** Test262 chunk 48/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(47, 50);
+runTest262Chunk(47, 115);

--- a/tests/test262-chunk49.test.ts
+++ b/tests/test262-chunk49.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 49/50 — round-robin by test for even distribution. */
+/** Test262 chunk 49/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(48, 50);
+runTest262Chunk(48, 115);

--- a/tests/test262-chunk5.test.ts
+++ b/tests/test262-chunk5.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 5/50 — round-robin by test for even distribution. */
+/** Test262 chunk 5/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(4, 50);
+runTest262Chunk(4, 115);

--- a/tests/test262-chunk50.test.ts
+++ b/tests/test262-chunk50.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 50/50 — round-robin by test for even distribution. */
+/** Test262 chunk 50/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(49, 50);
+runTest262Chunk(49, 115);

--- a/tests/test262-chunk51.test.ts
+++ b/tests/test262-chunk51.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 51/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(50, 115);

--- a/tests/test262-chunk52.test.ts
+++ b/tests/test262-chunk52.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 52/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(51, 115);

--- a/tests/test262-chunk53.test.ts
+++ b/tests/test262-chunk53.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 53/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(52, 115);

--- a/tests/test262-chunk54.test.ts
+++ b/tests/test262-chunk54.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 54/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(53, 115);

--- a/tests/test262-chunk55.test.ts
+++ b/tests/test262-chunk55.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 55/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(54, 115);

--- a/tests/test262-chunk56.test.ts
+++ b/tests/test262-chunk56.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 56/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(55, 115);

--- a/tests/test262-chunk57.test.ts
+++ b/tests/test262-chunk57.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 57/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(56, 115);

--- a/tests/test262-chunk58.test.ts
+++ b/tests/test262-chunk58.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 58/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(57, 115);

--- a/tests/test262-chunk59.test.ts
+++ b/tests/test262-chunk59.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 59/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(58, 115);

--- a/tests/test262-chunk6.test.ts
+++ b/tests/test262-chunk6.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 6/50 — round-robin by test for even distribution. */
+/** Test262 chunk 6/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(5, 50);
+runTest262Chunk(5, 115);

--- a/tests/test262-chunk60.test.ts
+++ b/tests/test262-chunk60.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 60/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(59, 115);

--- a/tests/test262-chunk61.test.ts
+++ b/tests/test262-chunk61.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 61/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(60, 115);

--- a/tests/test262-chunk62.test.ts
+++ b/tests/test262-chunk62.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 62/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(61, 115);

--- a/tests/test262-chunk63.test.ts
+++ b/tests/test262-chunk63.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 63/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(62, 115);

--- a/tests/test262-chunk64.test.ts
+++ b/tests/test262-chunk64.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 64/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(63, 115);

--- a/tests/test262-chunk65.test.ts
+++ b/tests/test262-chunk65.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 65/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(64, 115);

--- a/tests/test262-chunk66.test.ts
+++ b/tests/test262-chunk66.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 66/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(65, 115);

--- a/tests/test262-chunk67.test.ts
+++ b/tests/test262-chunk67.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 67/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(66, 115);

--- a/tests/test262-chunk68.test.ts
+++ b/tests/test262-chunk68.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 68/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(67, 115);

--- a/tests/test262-chunk69.test.ts
+++ b/tests/test262-chunk69.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 69/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(68, 115);

--- a/tests/test262-chunk7.test.ts
+++ b/tests/test262-chunk7.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 7/50 — round-robin by test for even distribution. */
+/** Test262 chunk 7/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(6, 50);
+runTest262Chunk(6, 115);

--- a/tests/test262-chunk70.test.ts
+++ b/tests/test262-chunk70.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 70/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(69, 115);

--- a/tests/test262-chunk71.test.ts
+++ b/tests/test262-chunk71.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 71/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(70, 115);

--- a/tests/test262-chunk72.test.ts
+++ b/tests/test262-chunk72.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 72/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(71, 115);

--- a/tests/test262-chunk73.test.ts
+++ b/tests/test262-chunk73.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 73/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(72, 115);

--- a/tests/test262-chunk74.test.ts
+++ b/tests/test262-chunk74.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 74/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(73, 115);

--- a/tests/test262-chunk75.test.ts
+++ b/tests/test262-chunk75.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 75/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(74, 115);

--- a/tests/test262-chunk76.test.ts
+++ b/tests/test262-chunk76.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 76/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(75, 115);

--- a/tests/test262-chunk77.test.ts
+++ b/tests/test262-chunk77.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 77/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(76, 115);

--- a/tests/test262-chunk78.test.ts
+++ b/tests/test262-chunk78.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 78/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(77, 115);

--- a/tests/test262-chunk79.test.ts
+++ b/tests/test262-chunk79.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 79/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(78, 115);

--- a/tests/test262-chunk8.test.ts
+++ b/tests/test262-chunk8.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 8/50 — round-robin by test for even distribution. */
+/** Test262 chunk 8/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(7, 50);
+runTest262Chunk(7, 115);

--- a/tests/test262-chunk80.test.ts
+++ b/tests/test262-chunk80.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 80/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(79, 115);

--- a/tests/test262-chunk81.test.ts
+++ b/tests/test262-chunk81.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 81/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(80, 115);

--- a/tests/test262-chunk82.test.ts
+++ b/tests/test262-chunk82.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 82/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(81, 115);

--- a/tests/test262-chunk83.test.ts
+++ b/tests/test262-chunk83.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 83/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(82, 115);

--- a/tests/test262-chunk84.test.ts
+++ b/tests/test262-chunk84.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 84/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(83, 115);

--- a/tests/test262-chunk85.test.ts
+++ b/tests/test262-chunk85.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 85/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(84, 115);

--- a/tests/test262-chunk86.test.ts
+++ b/tests/test262-chunk86.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 86/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(85, 115);

--- a/tests/test262-chunk87.test.ts
+++ b/tests/test262-chunk87.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 87/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(86, 115);

--- a/tests/test262-chunk88.test.ts
+++ b/tests/test262-chunk88.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 88/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(87, 115);

--- a/tests/test262-chunk89.test.ts
+++ b/tests/test262-chunk89.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 89/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(88, 115);

--- a/tests/test262-chunk9.test.ts
+++ b/tests/test262-chunk9.test.ts
@@ -1,3 +1,3 @@
-/** Test262 chunk 9/50 — round-robin by test for even distribution. */
+/** Test262 chunk 9/115 — round-robin by test for even distribution. */
 import { runTest262Chunk } from "./test262-shared.js";
-runTest262Chunk(8, 50);
+runTest262Chunk(8, 115);

--- a/tests/test262-chunk90.test.ts
+++ b/tests/test262-chunk90.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 90/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(89, 115);

--- a/tests/test262-chunk91.test.ts
+++ b/tests/test262-chunk91.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 91/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(90, 115);

--- a/tests/test262-chunk92.test.ts
+++ b/tests/test262-chunk92.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 92/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(91, 115);

--- a/tests/test262-chunk93.test.ts
+++ b/tests/test262-chunk93.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 93/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(92, 115);

--- a/tests/test262-chunk94.test.ts
+++ b/tests/test262-chunk94.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 94/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(93, 115);

--- a/tests/test262-chunk95.test.ts
+++ b/tests/test262-chunk95.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 95/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(94, 115);

--- a/tests/test262-chunk96.test.ts
+++ b/tests/test262-chunk96.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 96/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(95, 115);

--- a/tests/test262-chunk97.test.ts
+++ b/tests/test262-chunk97.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 97/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(96, 115);

--- a/tests/test262-chunk98.test.ts
+++ b/tests/test262-chunk98.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 98/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(97, 115);

--- a/tests/test262-chunk99.test.ts
+++ b/tests/test262-chunk99.test.ts
@@ -1,0 +1,3 @@
+/** Test262 chunk 99/115 — round-robin by test for even distribution. */
+import { runTest262Chunk } from "./test262-shared.js";
+runTest262Chunk(98, 115);


### PR DESCRIPTION
## Summary

Bumps test262-sharded matrix from 50 → 115 chunks. Per-shard work shrinks ~3x (from ~860 to ~375 tests).

## Effect

GH-hosted runner concurrency is 60 max for public repos. So first ~60 shards run in parallel, remaining ~55 queue as first wave finishes. Wall time should be similar or slightly better than 50 once queueing absorbs.

## Changes (116 files)

- Workflow matrix: chunks [1..50] → [1..115]
- 50 existing chunk files updated: divisor 50 → 115
- 65 new chunk files created (test262-chunk51..115.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)