### PR TITLE
ci(test262): parallelize typecheck + lint in cheap-gate

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -117,11 +117,24 @@ jobs:
           corepack prepare pnpm@10.30.2 --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Typecheck + lint
+      - name: Typecheck + lint (parallel)
         run: |
-          pnpm run typecheck 2>&1 | tail -50 || (echo "::error::typecheck failed"; exit 1)
-          # If lint script exists, run it (otherwise skip silently)
-          if grep -q '"lint"' package.json; then pnpm run lint 2>&1 | tail -50; fi
+          # Run both in parallel; capture each to its own tail-buffer; wait;
+          # fail if either fails. typecheck is the heavier of the two (tsc
+          # incremental ~5-10s, biome lint <2s) so wall time is bounded by
+          # typecheck rather than typecheck+lint.
+          set -o pipefail
+          tmp_tc=$(mktemp); tmp_lint=$(mktemp)
+          ( pnpm run typecheck > "$tmp_tc" 2>&1 ) &
+          pid_tc=$!
+          ( if grep -q '"lint"' package.json; then pnpm run lint > "$tmp_lint" 2>&1; fi ) &
+          pid_lint=$!
+          wait $pid_tc; tc_rc=$?
+          wait $pid_lint; lint_rc=$?
+          echo "--- typecheck (last 50 lines) ---"; tail -50 "$tmp_tc"
+          echo "--- lint (last 50 lines) ---"; tail -50 "$tmp_lint"
+          if [ "$tc_rc" -ne 0 ]; then echo "::error::typecheck failed (rc=$tc_rc)"; exit "$tc_rc"; fi
+          if [ "$lint_rc" -ne 0 ]; then echo "::warning::lint failed (rc=$lint_rc) — not blocking"; fi
 
   test262-shard:
     # Heavy 16-shard test262 fires on all gate-relevant events:


### PR DESCRIPTION
## Summary

Runs typecheck and lint as background processes simultaneously in the cheap-gate step. Wall time bounded by typecheck (~5-10s) instead of typecheck + lint sequential. Saves ~1-2s per gate run.

## Notes from analysis

Looked at run 26319293974 (115-shard PR #503):
- Wall time end-to-end: 103s (excellent)
- Shard duration distribution tight: 49-101s, median 60s
- Only 3 outliers >90s (shards 11, 12, 64) — likely 1-2 long individual tests
- No queueing delays — runner pool handled all 115 fine

This parallelization is a modest cumulative improvement; the bigger gate-job time is still pnpm install. Worth doing for clarity (the step name 'typecheck + lint' was misleading when sequential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)