### PR TITLE
ci+hooks: parallelize gate and test262-shard; move typecheck+lint to pre-push

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -139,7 +139,13 @@ jobs:
       (github.event_name == 'pull_request' && github.actor != 'github-actions[bot]') ||
       github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
-    needs: [gate]
+    # Runs in PARALLEL with `gate` — both are independently required by the
+    # ruleset (`cheap gate (main-ancestor + lint)` and `merge shard reports`),
+    # so PRs still can't merge unless both pass, but they don't block each
+    # other in execution. Saves ~80s of sequential gate→shards wait per run.
+    # Typecheck + lint also run locally via `.husky/pre-push` so most gate
+    # failures are caught before CI; CI gate is the safety net for
+    # --no-verify pushes and contributors without the hook.
     name: test262 shard ${{ matrix.chunk }}
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -101,3 +101,39 @@ if [ "$remote" = "origin" ]; then
     esac
   done
 fi
+
+# ---------- (3) typecheck + lint -----------------------------------------
+#
+# Run locally before push so failures don't waste a CI cycle. CI's cheap
+# gate is the safety net for --no-verify pushes and contributors without
+# the hook installed. Skip with `git push --no-verify`.
+#
+# Run in parallel to minimize push latency (typecheck ~5-10s, lint ~1-2s).
+
+echo "Pre-push: typecheck + lint (parallel) ..."
+tmp_tc=$(mktemp); tmp_lint=$(mktemp)
+( pnpm run typecheck > "$tmp_tc" 2>&1 ) &
+pid_tc=$!
+( if grep -q '"lint"' package.json 2>/dev/null; then pnpm run lint > "$tmp_lint" 2>&1; fi ) &
+pid_lint=$!
+wait $pid_tc; tc_rc=$?
+wait $pid_lint; lint_rc=$?
+
+if [ "$tc_rc" -ne 0 ]; then
+  echo "Pre-push: typecheck FAILED (rc=$tc_rc). Output:"
+  tail -50 "$tmp_tc"
+  echo ""
+  echo "Fix typecheck errors before pushing, or use --no-verify (CI will catch)."
+  rm -f "$tmp_tc" "$tmp_lint"
+  exit 1
+fi
+if [ "$lint_rc" -ne 0 ]; then
+  echo "Pre-push: lint FAILED (rc=$lint_rc). Output:"
+  tail -50 "$tmp_lint"
+  echo ""
+  echo "Fix lint errors before pushing, or use --no-verify (CI will catch)."
+  rm -f "$tmp_tc" "$tmp_lint"
+  exit 1
+fi
+rm -f "$tmp_tc" "$tmp_lint"
+echo "Pre-push: typecheck + lint OK."


### PR DESCRIPTION
## Summary

Two coupled changes:

### CI: parallelize gate + test262-shard
- Drop `needs: [gate]` from `test262-shard`. Both jobs are independently required by the ruleset (`cheap gate (main-ancestor + lint)` + `merge shard reports`), so PRs still need both green to merge — they just don't block each other in execution.
- **Effect:** CI wall time 182s → max(79, 103) ≈ **103s**. Saves ~80s per run.

### Hooks: typecheck + lint in pre-push
- Add typecheck + lint to `.husky/pre-push` (parallelized, ~5-10s combined).
- Catches errors locally before they reach CI. Most gate failures get caught at push time.
- CI's gate becomes a safety net for `--no-verify` pushes and contributors without the hook.

## Trade-off

If gate fails in CI (now rare with the pre-push hook), the 115 shards still run in vain. Acceptable cost given the savings on every successful run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)