### PR TITLE
docs(agents): switch dev protocol to synchronous CI-wait now that wall is ~2min

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -12,7 +12,12 @@ You are a Developer teammate on the js2wasm project — a TypeScript-to-WebAssem
 
 **Never send `idle_notification` messages** — ever, for any reason. They are discarded.
 
-You do not wait for CI — you open a PR and terminate (or claim the next task). CI monitoring is the tech lead's job.
+You **wait for CI synchronously, in-context**. CI wall time is now ~2 min
+(115-shard parallel, sort-by-duration scheduling, parallel gate+shards — see
+PRs #503, #505, #506). Idle Sonnet polling is nearly free, and on-the-spot
+recovery from drift or CI failure with full PR context beats handing off to
+the tech lead. After `gh pr create`, block on `gh run watch` (or a 30s poll
+loop) until CI completes, then self-merge / self-recover per `/dev-self-merge`.
 
 ## Communication
 
@@ -70,21 +75,25 @@ These help the tech lead know you're alive and progressing, not stuck. Keep them
    ```
    Then open the PR:
    `gh pr create --base main --title "fix(#N): <description>" --body "..."`
-5. **After `gh pr create` returns — do NOT wait for CI:**
-   CI monitoring and merging is the tech lead's job. Your job ends when the PR is open.
+5. **After `gh pr create` returns — block on CI synchronously:**
    - Update your status file to show the open PR:
      ```bash
      printf '{"name":"issue-{N}-{slug}","state":"pr-open","issue":"#{N}","pr":<PR>,"since":%s}\n' "$(date +%s)" \
        > "/workspace/.claude/agent-status/issue-{N}-{slug}.json"
      ```
-   - Then immediately proceed to step 6 (next task or terminate).
-6. After opening the PR:
+   - Block on CI with `gh run watch <run-id> --exit-status` (preferred) or a 30s poll loop on `gh pr checks <N>` until all required checks settle (~2 min wall). Max wait: 10 min before noting unusual delay via `TaskUpdate`; 20 min before escalating to tech lead.
+   - **On CI completion:**
+     - **All required checks green** → run `/dev-self-merge <N>`. If MERGE: `gh pr merge <N> --merge --auto`, proceed to step 6.
+     - **Drift detected** (`mergeable_state` becomes `BEHIND`) → `git fetch origin && git merge origin/main`, resolve conflicts with full PR context, `git push`, loop back to wait-for-CI. Do NOT escalate.
+     - **CI failure** (any required check `FAILURE`) → diagnose with full PR context — you KNOW what you changed. Fix locally, `git push`, loop back to wait-for-CI. Do NOT escalate ordinary failures.
+     - **ESCALATE per `/dev-self-merge`** (regressions >10, single bucket >50, judgment call): message tech lead immediately with criterion + values.
+6. After merge lands:
    - `rm -f "/workspace/.claude/agent-status/issue-{N}-{slug}.json"` — clear your status
    - `git worktree remove /workspace/.claude/worktrees/<branch>` — clean up your own worktree
    - `TaskUpdate(status: completed)`
    - `TaskList` → look for the lowest-ID task with no owner and status pending/ready
      - If found: claim it (`TaskUpdate owner: "your-name"`, status: in_progress) → start implementing
-     - If **no unowned task exists** (queue empty OR all tasks already owned): send tech-lead `"PR #N open. TaskList empty — shutting down."` then wait for `shutdown_request` and approve it. Do not idle silently.
+     - If **no unowned task exists** (queue empty OR all tasks already owned): send tech-lead `"PR #N merged. TaskList empty — shutting down."` then wait for `shutdown_request` and approve it. Do not idle silently.
 
 ### Pause / Suspend / Shutdown
 - **PAUSE message from tech lead**: stop immediately, kill running tests. Reply: `"Paused on #N."` Wait for RESUME.

--- a/.claude/skills/dev-self-merge.md
+++ b/.claude/skills/dev-self-merge.md
@@ -5,18 +5,49 @@ description: Algorithmic gate for self-merging a PR. Reads CI JSON, applies 4 ha
 
 # /dev-self-merge \<N\>
 
-## Waiting for CI — how to poll
+## Waiting for CI — synchronous, in-context
 
-The CI feed commits `pr-<N>.json` to **origin/main** (not your branch). Your
-worktree never sees it until you fetch. While waiting for CI, poll with:
+CI wall time is now ~2 min (115-shard parallel, sort-by-duration scheduling,
+parallel gate+shards — see PRs #503, #505, #506). The dev agent **blocks
+in-context** waiting for CI rather than terminating and handing off. Idle
+Sonnet polling is nearly free, and on-the-spot recovery from drift or CI
+failure with full PR context beats the complexity of fire-and-forget.
+
+```bash
+# Watch the run live (preferred — exits when the run finishes):
+run_id=$(gh pr view <N> --json statusCheckRollup \
+  --jq '[.statusCheckRollup[] | select(.detailsUrl) | .detailsUrl][0]' \
+  | grep -oE 'runs/[0-9]+' | cut -d/ -f2)
+gh run watch "$run_id" --exit-status
+
+# Or poll every 30s with a timeout:
+deadline=$(( $(date +%s) + 1200 ))   # 20 min hard cap
+while :; do
+  pending=$(gh pr checks <N> --json state \
+    --jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS")] | length')
+  [ "$pending" = "0" ] && break
+  [ "$(date +%s)" -gt "$deadline" ] && { echo "CI > 20 min — escalate"; exit 2; }
+  sleep 30
+done
+```
+
+After the run exits:
+
+| Outcome | Action |
+|---|---|
+| **All required checks green** | Proceed to Step 0 (or directly to Step 1 if the CI feed JSON is present) |
+| **Drift** (mergeable_state becomes `BEHIND` while waiting) | `git fetch origin && git merge origin/main` in the worktree, resolve conflicts with full PR context, `git push`, loop back to wait-for-CI |
+| **CI failure** (any required check `FAILURE`) | Diagnose with full PR context — the agent KNOWS what it changed. Fix locally, `git push`, loop back to wait-for-CI |
+| **Long wait** (>10 min) | Emit a `TaskUpdate` noting the unusual wait but keep waiting |
+| **Very long wait** (>20 min) | Escalate to tech lead |
+
+The CI feed `pr-<N>.json` still drives the merge gate below — fetch it once
+CI completes:
 
 ```bash
 git fetch origin
 git show origin/main:.claude/ci-status/pr-<N>.json 2>/dev/null
 ```
-
-Run this every few minutes. When output appears and the `head_sha` matches
-`git rev-parse HEAD`, CI is done — proceed to Step 0 below.
 
 Do NOT `git merge origin/main` just to check — `git show` reads the remote ref
 without touching your working tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,10 +286,13 @@ GitHub branch protection is the hard block.
    - Compiler source conflicts (`src/**/*.ts`) → create a priority `[CONFLICT]` TaskList item; assign to `senior-developer` (Opus); do NOT resolve inline
 2. **Dev runs scoped local checks** — issue-targeted compile/run checks for confidence
 3. **Dev pushes the branch to origin and opens a PR against `main`**
-4. **Dev waits for CI** — monitors `.claude/ci-status/pr-<N>.json` until it appears with a SHA matching HEAD (idle wait, no token burn)
-5. **Dev self-merges** — if `net_per_test > 0`, SHA matches, ratio <10%, no bucket >50: `gh pr merge <N> --merge --auto` (enqueues; queue does the final verification)
-6. **If regressions**: dev fixes on branch, pushes again, loops back to step 4
-7. **Escalate to tech lead** only when: regressions >10, single bucket >50, or judgment call needed
+4. **Dev blocks on CI** — polls `gh pr checks <N>` every 30s for ~2 min wall time, in-context (Sonnet idle is nearly free). Use `gh run watch <run-id>` or a `while ! done; do sleep 30; done` loop with a max timeout (~10 min before noting unusual wait, ~20 min before escalating).
+5. **On CI completion**:
+   - **All required checks green** → run `/dev-self-merge`; if MERGE, `gh pr merge <N> --merge --auto`, then proceed to step 8
+   - **Drift detected** (mergeable_state becomes "behind") → `git merge origin/main` in the worktree, resolve conflicts with full PR context, push again, loop back to step 4
+   - **CI failure** (any required check failed) → diagnose with full PR context (the agent KNOWS what it changed), fix locally, push again, loop back to step 4
+6. **If regressions per `/dev-self-merge`**: dev fixes on branch, pushes again, loops back to step 4
+7. **Escalate to tech lead** only when: regressions >10, single bucket >50, or judgment call needed. **Drift and ordinary CI failures are NOT escalations — dev handles them with full context.**
 8. **After merge**: dev marks task `completed`, claims next task
 9. **Never use `git merge` on main directly.** All merges go through PRs + CI.
 10. **Never rebase.** Merge preserves history and is safely reversible.


### PR DESCRIPTION
## Summary

Revert dev agent protocol from fire-and-forget (open PR -> exit, tech lead monitors) to synchronous in-context CI-wait. CI wall time is now ~2 min, making blocking polls cheaper than the orchestration cost of handoff.

CI improvements that made this viable:
- PR #503 - 115 shards
- PR #505 - sort-by-duration scheduling
- PR #506 - parallel gate + shards

## Changes

- **`.claude/skills/dev-self-merge.md`** - Replaced the async `git show origin/main:.claude/ci-status/pr-<N>.json` polling intro with synchronous `gh run watch --exit-status` (preferred) or a 30s `gh pr checks` poll loop with 20-min hard cap. Added an outcome table covering all-green, drift (BEHIND), CI failure, long wait, and very long wait. Kept the CI-feed JSON read for the merge-gate criteria below.
- **`/workspace/CLAUDE.md`** (Merge protocol section) - Steps 4-7 rewritten. Step 4 is now a blocking poll. Step 5 splits into three on-completion branches (green / drift / failure) with self-recovery loops back to step 4. Step 7 explicitly clarifies that drift and ordinary CI failures are NOT escalations - dev handles them with full PR context. Escalation criteria unchanged (regressions >10, single bucket >50, judgment call).
- **`.claude/agents/developer.md`** - Replaced the "you do not wait for CI" header with synchronous-wait guidance referencing PRs #503/#505/#506. Step 5 of the Merge section now blocks on `gh run watch`, handles drift via `git merge origin/main` + push + re-wait, handles CI failure via local fix + push + re-wait, and only escalates per `/dev-self-merge` criteria. Step 6 (post-merge cleanup) preserved.

## Justification

The previous fire-and-forget protocol made sense when CI took 5+ minutes (token cost of idle poll > orchestration cost). At ~2 min wall, the equation flips:

- Idle Sonnet polling: ~free
- Fire-and-forget handoff cost: JSON feed, status files, tech-lead context-switch, lost PR context for drift/failure recovery

The dev that opened the PR knows what changed. On drift, it can resolve conflicts intelligently. On CI failure, it can diagnose with full context. Both of those become much harder when handed off to a tech lead who has to reload state.

## Test plan

- [x] Pure docs PR - no source changes, no equiv tests needed
- [x] `git diff --stat` shows only the 3 intended files
- [ ] Basic CI (lint + cheap gate) passes on the PR