### PR TITLE
ci(test262): auto-retry compile_timeout tests in isolation (kills CI fork-pool flake)

### DIFF
--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -134,6 +134,30 @@ const POOL_SIZE = parseInt(process.env.COMPILER_POOL_SIZE || String(Math.max(1, 
 
 let pool: CompilerPool | null = null;
 
+// ── Compile-timeout retry (#1589) ──────────────────────────────────
+// CI fork-pool contention makes tests show `compile_timeout` (30 s, exec
+// 0 ms) when in isolation they pass in <300 ms. Per the #1589 investigation,
+// 95/100 baseline timeouts are this kind of flake. On a `compile_timeout`
+// result, we re-run the test serially with a tighter 10 s ceiling. If it
+// passes, we record `pass` with `retried: true`. If it still times out or
+// fails, we record the (new) failure. A per-shard counter caps retries at
+// MAX_RETRIES_PER_SHARD so a systemically broken pool doesn't add
+// MAX_RETRIES * RETRY_TIMEOUT_MS of wall time.
+const MAX_RETRIES_PER_SHARD = 10;
+const RETRY_TIMEOUT_MS = 10_000;
+let retriesUsed = 0;
+// Mutex (serial Promise chain) — only one retry runs at a time so retries
+// are truly isolated from each other on the fork pool.
+let retryMutex: Promise<void> = Promise.resolve();
+function runRetrySerial<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = retryMutex;
+  let release!: () => void;
+  retryMutex = new Promise<void>((r) => {
+    release = r;
+  });
+  return prev.then(fn).finally(() => release());
+}
+
 // ── Result tracking (JSONL output for report.html) ──────────────────
 
 const RESULTS_DIR = join(import.meta.dirname ?? ".", "..", "benchmarks", "results");
@@ -195,6 +219,7 @@ function recordResult(
   error?: string,
   timing?: { compileMs?: number; execMs?: number },
   scopeInfo?: { scope: Test262Scope; official: boolean; reason?: string; strict?: "only" | "no" | "both" },
+  retryInfo?: { retried?: boolean; retryCount?: number },
 ) {
   const errorCategory = status === "fail" || status === "compile_error" ? classifyError(error) : undefined;
 
@@ -211,6 +236,8 @@ function recordResult(
     scope_official: scopeInfo?.official ?? true,
     scope_reason: scopeInfo?.reason,
     strict: scopeInfo?.strict ?? "both",
+    retried: retryInfo?.retried || undefined,
+    retry_count: retryInfo?.retryCount || undefined,
   });
   fdWrite(jsonlFd, entry + "\n");
   summary.total++;
@@ -355,6 +382,9 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
     console.log(
       `\nTest262 chunk ${chunkIndex + 1}/${totalChunks}: ${summary.total} total — ${summary.pass} pass, ${summary.fail} fail, ${summary.compile_error} CE, ${summary.skip} skip`,
     );
+    if (retriesUsed > 0) {
+      console.log(`Compile-timeout retries (#1589): ${retriesUsed}/${MAX_RETRIES_PER_SHARD} used`);
+    }
   });
 
   for (const [category, files] of byCategory) {
@@ -499,6 +529,51 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
             }
 
             if (r.status === "compile_error" || r.status === "compile_timeout") {
+              // #1589 — auto-retry compile_timeout in isolation. Most CI
+              // timeouts are fork-pool contention flakes that pass in <300 ms
+              // when not competing with siblings. Retry once with a tighter
+              // 10 s ceiling, serialized via a per-shard mutex. Capped at
+              // MAX_RETRIES_PER_SHARD so a broken pool doesn't blow up the
+              // shard's wall time.
+              if (r.status === "compile_timeout" && retriesUsed < MAX_RETRIES_PER_SHARD) {
+                retriesUsed++;
+                const retry = await runRetrySerial(() =>
+                  pool!.runTest(
+                    compileSource,
+                    {
+                      isNegative: isNegative || false,
+                      isRuntimeNegative: isRuntimeNegative || false,
+                      expectedErrorType: meta.negative?.type,
+                      wasmPath,
+                      metaPath,
+                      label: relPath + " [retry]",
+                    },
+                    RETRY_TIMEOUT_MS,
+                  ),
+                );
+                const retryTiming = { compileMs: retry.compileMs, execMs: retry.execMs };
+                const retryInfo = { retried: true, retryCount: 1 };
+
+                if (retry.status === "pass") {
+                  recordResult(relPath, category, "pass", undefined, retryTiming, scopeInfo, retryInfo);
+                  return;
+                }
+                if (retry.status === "fail") {
+                  // Retry executed but assertions failed — record as a real
+                  // fail with the retry error message (preserves the new
+                  // signal rather than the timeout-shaped one).
+                  const error = retry.error ? adjustErrorLines(retry.error, lineAdjustOffset) : "fail after retry";
+                  recordResult(relPath, category, "fail", error, retryTiming, scopeInfo, retryInfo);
+                  return;
+                }
+                // compile_error or another compile_timeout on retry → record
+                // the retry status (with retried flag) so we can distinguish
+                // genuine-slow tests from flakes in baseline analysis.
+                const retryError = retry.error ? adjustErrorLines(retry.error, lineAdjustOffset) : retry.status;
+                recordResult(relPath, category, retry.status, retryError, retryTiming, scopeInfo, retryInfo);
+                return;
+              }
+
               const error = r.error ? adjustErrorLines(r.error, lineAdjustOffset) : r.status;
               recordResult(relPath, category, r.status, error, timing, scopeInfo);
               return;


### PR DESCRIPTION
## Summary

Auto-retry pass for test262 tests that hit `compile_timeout`, addressing the 100-test bucket flagged in #1589.

Per the investigation already documented on that issue, ~95/100 of the baseline `compile_timeout` entries are CI fork-pool contention flakes — those tests pass in <300 ms when re-run in isolation, but pin the 30 s ceiling under load because the unified-fork pool is saturated by sibling `describe.concurrent` work in the shard.

This implements the cheapest possible mitigation: when the pool returns `compile_timeout`, re-run the same test serially through a per-shard mutex with a tighter 10 s ceiling. If the retry passes, record `pass` with `retried: true`. If it still times out / fails, keep the failure but mark it retried so baseline analysis can distinguish "true compile pathology" from "flake we tried to rescue."

## Mechanics

- `tests/test262-shared.ts` only — no changes to source or to merge-report aggregation.
- New `retryInfo` argument on `recordResult` adds `retried` / `retry_count` to the JSONL row. Merge-report aggregation merges rows by path; the new fields are passive.
- `runRetrySerial` chains retries through a `Promise` mutex so only one retry runs at a time — they don't compete with each other on the fork pool, restoring the isolation the original 30 s budget assumed.
- `MAX_RETRIES_PER_SHARD = 10` — a systemically broken pool can't add minutes of extra wall time.
- Shards with zero timeouts hit the retry block zero times — true zero overhead in the happy path.
- `RETRY_TIMEOUT_MS = 10_000` — if the test doesn't compile in 10 s while alone on the pool, it's a genuine compile bug, not contention.

## Expected impact

- ~95 of the 100 `compile_timeout` entries in `benchmarks/results/test262-current.jsonl` should flip to `pass` on retry (per the #1589 investigation finding that 95/100 pass in <300 ms when isolated).
- Remaining ~5 are genuine pathologies — they'll still show as `compile_timeout`, now with `retried: true` so they're easy to triage.
- Per-shard p95 wall time should drop because timeouts no longer pin 30 s of fork wall time — they consume 30 s (first attempt) + up to 10 s (retry), and the retry is serialised behind the rest of the shard's work which is mostly done by then.
- Net pass count uplift in the next baseline refresh: +~95.

## Tradeoffs / risks

- **Masks intermittent compiler bugs**: if a real compiler bug only manifests under load (e.g. a race in a worker), retry would mask it. Mitigation: the `retried: true` flag is preserved in the JSONL, so it's filterable.
- **Worst-case wall-time**: 10 retries × 10 s = 100 s of extra serial work in the absolute worst case. In the typical 100-timeouts-spread-over-115-shards case, it's < 1 retry per shard ≈ < 10 s overhead.
- **Doesn't fix the underlying pool saturation** — that's a deeper rework. This is the cheap, additive mitigation.

Refs: [`plan/issues/backlog/1589-test262-compile-timeout-bucket-100-tests.md`](../blob/main/plan/issues/backlog/1589-test262-compile-timeout-bucket-100-tests.md)

## Test plan

- [x] `pnpm run typecheck` passes
- [ ] CI test262-sharded run completes — the retried flag should appear on some entries; expect a ~95-test pass uplift
- [ ] No new regressions (the change is purely additive in the timeout path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)