### PR TITLE
fix(deploy-pages): add --experimental-wasm-stringref flag (unblocks 8 failing workflow runs)

### DIFF
--- a/scripts/run-pages-build.mjs
+++ b/scripts/run-pages-build.mjs
@@ -27,5 +27,13 @@ if (hasPlanningArtifacts) {
 run(process.execPath, ["--experimental-strip-types", "scripts/generate-editions.ts"]);
 run("pnpm", ["run", "build:playground"]);
 run("pnpm", ["run", "build:compiler-bundle"]);
-run(process.execPath, ["--experimental-strip-types", "scripts/generate-size-benchmarks.ts"]);
+// --experimental-wasm-stringref is required because generate-size-benchmarks
+// instantiates wasm modules that may use stringview_wtf16 (e.g. when the
+// compiler emits wasm:js-string ops). Without the flag, Node 22+ rejects
+// the module at compile-time with "invalid heap type 'stringview_wtf16'".
+run(process.execPath, [
+  "--experimental-strip-types",
+  "--experimental-wasm-stringref",
+  "scripts/generate-size-benchmarks.ts",
+]);
 run("node", ["scripts/build-pages.js"]);


### PR DESCRIPTION
## Issue

Deploy GitHub Pages + Refresh Benchmarks workflows failing 4× each in last 2h with:

```
CompileError: WebAssembly.Module(): Compiling function #20 failed:
invalid heap type 'stringview_wtf16', enable with --experimental-wasm-stringref
```

Recent compiler changes started emitting stringview_wtf16 ops; Node 22+ requires the experimental flag.

## Fix

Add `--experimental-wasm-stringref` to the `generate-size-benchmarks.ts` invocation in `scripts/run-pages-build.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)