### PR TITLE
ci: bump remaining workflows from Node 22 → 25

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Setup pnpm via Corepack
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Setup pnpm via Corepack
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Setup pnpm via Corepack
         run: |

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Setup pnpm via Corepack
         run: |

--- a/.github/workflows/test262-nightly.yml
+++ b/.github/workflows/test262-nightly.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Setup pnpm via Corepack
         run: |


### PR DESCRIPTION
## Summary

Aligns the 5 stragglers with the test262 stack (already on Node 25):

- `ci.yml`
- `benchmark-refresh.yml`
- `diff-test.yml`
- `deploy-pages.yml`
- `test262-nightly.yml`

`publish-npm.yml` stays at Node 20 (LTS-aligned for stable npm publishing).

## Bonus

Node 25 has native support for wasm:js-string heap types — may make the `--experimental-wasm-stringref` flag from #513 unnecessary in the long run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)