### PR TITLE
fix(#1589 hot spot B): pre-box for-loop captured vars to fix infinite loop

### DIFF
--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -345,6 +345,45 @@ function findHeadBindingsCapturedByClosures(stmt: ts.ForStatement, headNames: Re
   return captured;
 }
 
+/**
+ * #1589: Find every identifier name that appears inside a nested closure
+ * anywhere in the for-loop's condition/incrementor/body. Used to pre-emptively
+ * box outer-scope (`var`-declared or enclosing-function) variables before
+ * compiling the loop condition.
+ *
+ * Without this pre-pass, the closure-construction codegen promotes the
+ * variable to a ref-cell mid-loop. The loop condition (compiled first) reads
+ * the original unboxed slot, while the incrementor (compiled after the body)
+ * writes through the ref cell — so the condition's view never updates and the
+ * loop spins forever.
+ */
+function findAllNamesCapturedByClosuresInForLoop(stmt: ts.ForStatement): Set<string> {
+  const captured = new Set<string>();
+  function visit(node: ts.Node | undefined): void {
+    if (!node) return;
+    if (
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node)
+    ) {
+      const refs = new Set<string>();
+      collectReferencedIdentifiers(node, refs);
+      for (const n of refs) captured.add(n);
+      return;
+    }
+    forEachChild(node, visit);
+  }
+  visit(stmt.condition);
+  visit(stmt.incrementor);
+  visit(stmt.statement);
+  return captured;
+}
+
 export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForStatement): void {
   // Save localMap entries for let/const initializers that shadow outer variables.
   // `for (let x = ...; ...)` creates a block scope that ends after the loop.
@@ -552,6 +591,76 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
     }
   }
 
+  // #1589: Pre-emptive boxing for non-let/const names captured by closures.
+  //
+  // The closure-construction codegen promotes a captured variable to a ref
+  // cell at the point the closure literal is compiled. For `var`-declared or
+  // enclosing-function variables referenced from a closure INSIDE a for-loop,
+  // that promotion happens AFTER the loop condition was already compiled —
+  // the condition reads the original unboxed slot, while the body's
+  // incrementor writes through the ref cell. Result: condition's view never
+  // updates and the loop spins forever.
+  //
+  // Fix: before compiling the condition, find every name captured by any
+  // closure in the loop and, if it currently lives in a plain local that is
+  // NOT yet boxed, promote it to a ref cell now. Subsequent identifier reads
+  // (condition, body, incrementor) all route through the same ref cell.
+  //
+  // We deliberately skip names already covered by the let/const per-iteration
+  // pass above (those are in `boxedCaptures` now). Names not in `localMap`
+  // (e.g. globals, module imports) are left alone — the closure-construction
+  // path handles them by reading the underlying global.
+  const preBoxedNames: {
+    name: string;
+    refCellTypeIdx: number;
+    boxedLocal: number;
+    valType: ValType;
+    originalLocalIdx: number;
+  }[] = [];
+  {
+    const capturedNames = findAllNamesCapturedByClosuresInForLoop(stmt);
+    for (const name of capturedNames) {
+      if (fctx.boxedCaptures?.has(name)) continue; // already boxed (let/const per-iter)
+      const oldLocalIdx = fctx.localMap.get(name);
+      if (oldLocalIdx === undefined) continue; // not a local — globals/imports
+      if (oldLocalIdx < fctx.params.length) continue; // params get boxed by closure construction itself
+      const oldType = fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? { kind: "f64" as const };
+      // Only box value-typed locals (i32, f64, externref, ref_null) — ref-cell
+      // boxing of arbitrary struct/array refs is handled by the closure-side
+      // path which knows the underlying type.
+      if (
+        oldType.kind !== "i32" &&
+        oldType.kind !== "f64" &&
+        oldType.kind !== "i64" &&
+        oldType.kind !== "f32" &&
+        oldType.kind !== "externref" &&
+        oldType.kind !== "ref_null"
+      ) {
+        continue;
+      }
+      const refCellTypeIdx = getOrRegisterRefCellType(ctx, oldType);
+      const boxedLocal = allocLocal(fctx, `__pre_box_${name}`, {
+        kind: "ref_null",
+        typeIdx: refCellTypeIdx,
+      });
+      // Box the current value into a fresh ref cell.
+      fctx.body.push({ op: "local.get", index: oldLocalIdx });
+      fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+      fctx.body.push({ op: "local.set", index: boxedLocal });
+
+      // Save prior boxedCaptures entry so we can restore it on loop exit.
+      if (!savedForBoxedCaptures) savedForBoxedCaptures = new Map();
+      if (!savedForBoxedCaptures.has(name)) {
+        savedForBoxedCaptures.set(name, fctx.boxedCaptures?.get(name));
+      }
+
+      fctx.localMap.set(name, boxedLocal);
+      if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+      fctx.boxedCaptures.set(name, { refCellTypeIdx, valType: oldType });
+      preBoxedNames.push({ name, refCellTypeIdx, boxedLocal, valType: oldType, originalLocalIdx: oldLocalIdx });
+    }
+  }
+
   // Loop structure:
   // block $break {                    ; break target (depth 2 from body)
   //   loop $loop {                    ; loop restart (continue outer target)
@@ -718,6 +827,31 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       },
     ],
   });
+
+  // #1589: For pre-emptively boxed `var`/outer-scope names, write the final
+  // ref-cell value back to the original unboxed local so post-loop reads of
+  // the variable observe the loop's final state, then restore localMap.
+  if (preBoxedNames.length > 0) {
+    for (const pb of preBoxedNames) {
+      fctx.body.push({ op: "local.get", index: pb.boxedLocal });
+      // Null guard: if the ref cell somehow ended up null (shouldn't happen
+      // since we struct.new'd it at loop entry), skip the writeback rather
+      // than trapping.
+      fctx.body.push({ op: "ref.is_null" });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [],
+        else: [
+          { op: "local.get", index: pb.boxedLocal } as Instr,
+          { op: "ref.as_non_null" } as Instr,
+          { op: "struct.get", typeIdx: pb.refCellTypeIdx, fieldIdx: 0 } as Instr,
+          { op: "local.set", index: pb.originalLocalIdx } as Instr,
+        ],
+      } as Instr);
+      fctx.localMap.set(pb.name, pb.originalLocalIdx);
+    }
+  }
 
   // Restore localMap entries for for-loop let/const initializers
   if (savedForScope) {

--- a/tests/issue-1589-tosorted-hang.test.ts
+++ b/tests/issue-1589-tosorted-hang.test.ts
@@ -1,0 +1,75 @@
+// Regression test for #1589 hot spot B: for-loop with `var i` captured by
+// closures inside the body would compile to a loop that reads the unboxed `i`
+// slot for the condition while writing through the boxed cell for the
+// increment, causing an infinite loop at runtime. Manifested as a compile
+// timeout in test262 because the test wrapper times out the whole pipeline.
+//
+// Repro mirrors test262's
+// `built-ins/Array/prototype/toSorted/comparefn-not-a-function.js`:
+// a `for (var i = 0; i < ...; i++)` loop containing closures (here, the
+// `function() { ... }` expressions passed to a helper) that capture `i`.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function compileAndRun(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile failed: " + r.errors?.[0]?.message);
+  const imports = buildImports((r as any).imports ?? [], undefined, (r as any).stringPool ?? []);
+  const { instance } = await WebAssembly.instantiate(r.binary!, imports);
+  return (instance.exports as any).test?.();
+}
+
+describe("#1589 — for-loop with closure-captured var increments correctly", () => {
+  it("var i incremented inside body terminates loop (basic)", async () => {
+    const out = await compileAndRun(`
+      export function test(): number {
+        var arr = [10, 20, 30];
+        var f: any = null;
+        for (var i = 0; i < arr.length; i++) {
+          f = function () { return i; };
+        }
+        return i;
+      }
+    `);
+    expect(out).toBe(3);
+  });
+
+  it("var i captured by closures inside body terminates", async () => {
+    // Closures inside the body capture `i`. Without the fix, the loop spins
+    // forever because the condition reads an unboxed slot that never updates.
+    const out = await compileAndRun(`
+      export function test(): number {
+        var arr = [1, 2, 3, 4, 5];
+        var calls = 0;
+        for (var i = 0; i < arr.length; i++) {
+          var fn = function () { return arr[i]; };
+          calls += 1;
+          fn();
+        }
+        return calls;
+      }
+    `);
+    expect(out).toBe(5);
+  });
+
+  it("nested closures inside for-var loop body — both read i correctly", async () => {
+    // Mirrors the test262 pattern: two assert.throws-style closures per
+    // iteration, both capturing i.
+    const out = await compileAndRun(`
+      export function test(): number {
+        var items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var hits = 0;
+        for (var i = 0; i < items.length; i++) {
+          var a = function () { return items[i]; };
+          var b = function () { return items[i] + 1; };
+          if (a() === items[i]) hits += 1;
+          if (b() === items[i] + 1) hits += 1;
+        }
+        return hits;
+      }
+    `);
+    expect(out).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1589 hot spot B — test262 test `built-ins/Array/prototype/toSorted/comparefn-not-a-function.js` was hanging the compile pool (>15s) on a `for (var i = 0; …; i++)` loop whose body contained closures capturing `i`.

## Root cause

The closure-construction codegen (`src/codegen/closures.ts:2199-2222`) promotes a captured local to a ref-cell **mid-compilation** by mutating `fctx.localMap` and `fctx.boxedCaptures`. In `compileForStatement`:

1. Loop **condition** is compiled first → reads the original unboxed `i` slot.
2. Loop **body** contains a closure literal → triggers the promotion (`i` is now in a ref-cell at a new local idx).
3. Loop **incrementor** is compiled after the body → correctly writes through the new ref cell.

Result: the unboxed `i` slot referenced by the condition is never updated → infinite loop. The pool's compile timer kills it as `compile_timeout`.

## Fix

In `compileForStatement`, after the existing let/const per-iteration cell pass, run a second pass over every identifier captured by any closure in the loop (condition + incrementor + body). For any name that lives in a function-scoped local (not yet boxed, not a param), box it now into a fresh ref cell, re-aim `localMap` + `boxedCaptures`, and at loop exit write the final value back to the original slot so post-loop reads observe it.

The narrow gate (only locals, not already boxed, only value-typed) avoids disturbing:
- let/const per-iteration semantics (handled by the existing `perIterCells` pass)
- the param-capture path in `compileLiftedFunction`
- complex struct/array typed locals (which the closure-side path already handles)

## Spec reference

ECMA-262 §14.7.4 (ForStatement) — the loop condition's view of head bindings must observe assignments made in the body/incrementor. The prior codegen violated this for `var`s captured by body closures.

## Test plan

- [x] `tests/issue-1589-tosorted-hang.test.ts` — 3 regression cases covering basic `var i++`, single body-closure, nested body closures. All pass.
- [x] Scoped equivalence suites (loops, scope, destructuring, iife, for-of, array-prototype-methods, try-catch) — 4 failures observed are all pre-existing on `origin/main` (verified via `git stash`), not introduced by this change.
- [x] Original test262 file: drops from `compile_timeout` (15s) to `fail` (~340ms). Making it pass would require an IsCallable check in toSorted codegen — separate follow-up.
- [x] `tsc --noEmit` clean.

## Out of scope

The toSorted codegen still silently ignores the `compareFn` argument when it isn't a function. Adding the IsCallable check + throwing TypeError is a separate correctness gap tracked under #1589's broader umbrella (the spec quote in the test file lines 8-13 is the right specification reference for that follow-up).