### PR TITLE
fix(refresh-benchmarks): set wasm experimental flags via NODE_OPTIONS

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -17,6 +17,13 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Wasm experimental flags propagated to all child Node processes:
+  # - stringref: stringview_wtf16 heap type (wasm:js-string ops)
+  # - custom-descriptors: 'exact' heap type
+  # Needed by generate-size-benchmarks + generate-playground-benchmark-sidebar
+  # which instantiate emitted Wasm modules. Without these, Node 25 rejects
+  # the modules at compile-time.
+  NODE_OPTIONS: "--experimental-wasm-stringref --experimental-wasm-custom-descriptors"
 
 concurrency:
   group: benchmark-refresh-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Follow-up to #513 / #514 / #518. NODE_OPTIONS propagates the experimental Wasm flags to all child Node processes spawned by refresh:benchmarks (multiple scripts, not just generate-size-benchmarks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)