### PR TITLE
fix(#820d): externref for destructuring-pattern method params at closure call sites

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6493,6 +6493,27 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         const sigRetWasm = isVoidType(sigRetType) ? null : resolveWasmType(ctx, sigRetType);
         const sigParamWasmTypes: ValType[] = [];
         for (let i = 0; i < sigParamCount; i++) {
+          // (#820d) Destructuring-pattern parameters (e.g. `method({ x = 5 } = {})`)
+          // are compiled by the callee as a single `externref` slot — the binding
+          // pattern is destructured inside the body from that externref, and the
+          // param-default check uses `__extern_is_undefined`. Resolving the TS
+          // type of such a param to a concrete struct ref (which `resolveWasmType`
+          // does once the anonymous object type gets a registered struct) produces
+          // a funcref wrapper type that mismatches the actual method/trampoline
+          // signature. The closure call then casts the trampoline funcref to the
+          // wrong (struct-param) type and traps with `illegal cast` — and for an
+          // unresolvable default the spec-correct ReferenceError never gets a
+          // chance to throw. Force `externref` for binding-pattern params so the
+          // call site agrees with the compiled callee.
+          const paramDecl = sig.parameters[i]!.valueDeclaration;
+          if (
+            paramDecl &&
+            ts.isParameter(paramDecl) &&
+            (ts.isObjectBindingPattern(paramDecl.name) || ts.isArrayBindingPattern(paramDecl.name))
+          ) {
+            sigParamWasmTypes.push({ kind: "externref" });
+            continue;
+          }
           const paramType = ctx.checker.getTypeOfSymbol(sig.parameters[i]!);
           sigParamWasmTypes.push(resolveWasmType(ctx, paramType));
         }

--- a/tests/issue-820d.test.ts
+++ b/tests/issue-820d.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #820d — class/dstr async-gen-meth default-init `unresolvable` illegal cast.
+//
+// A method with a destructuring parameter whose default initializer references
+// an unresolvable identifier (`{ x = unresolvableReference } = {}`) must throw a
+// spec-correct ReferenceError when the parameter is `undefined`. Previously the
+// closure-extracted method path (`var m = C.prototype.m; m();`) resolved the
+// destructuring param to a struct ref at the call site, mismatching the
+// externref slot the compiled method/trampoline actually uses. The trampoline
+// funcref cast then trapped with `illegal cast` before the default expression
+// could run, so the ReferenceError never surfaced.
+
+async function compileOk(src: string) {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("Compile: " + r.errors.map((e) => `L${e.line}: ${e.message}`).join("; "));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return instance.exports as any;
+}
+
+describe("#820d — destructuring method default-init unresolvable cast", () => {
+  it("obj-ptrn-id-init-unresolvable throws ReferenceError (extracted method, no receiver)", async () => {
+    const ex = await compileOk(`
+      var C = class {
+        async *method({ x = unresolvableReference } = {}) {}
+      };
+      var method = C.prototype.method;
+      export function test(): number {
+        try { method(); } catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+        return 3;
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("ary-ptrn-elem-init-unresolvable throws ReferenceError (extracted method, no receiver)", async () => {
+    const ex = await compileOk(`
+      var C = class {
+        async *method([ x = unresolvableReference ] = []) {}
+      };
+      var method = C.prototype.method;
+      export function test(): number {
+        try { method(); } catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+        return 3;
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("statement-class async-gen method, array pattern", async () => {
+    const ex = await compileOk(`
+      class C {
+        async *method([ x = unresolvableReference ] = []) {}
+      }
+      var method = C.prototype.method;
+      export function test(): number {
+        try { method(); } catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+        return 3;
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("object-literal async-gen method, object pattern", async () => {
+    const ex = await compileOk(`
+      var o = { async *method({ x = unresolvableReference } = {}) {} };
+      var method = o.method;
+      export function test(): number {
+        try { method(); } catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+        return 3;
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("plain method (non-async) with destructuring default still traps→RefError on unresolvable", async () => {
+    const ex = await compileOk(`
+      class C {
+        method({ x = unresolvableReference } = {}) { return x; }
+      }
+      var method = C.prototype.method;
+      export function test(): number {
+        try { method(); } catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+        return 3;
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  // Regression guards: resolvable defaults must still fire and explicit args pass through.
+  it("resolvable object-pattern default fires when arg omitted (no throw)", async () => {
+    const ex = await compileOk(`
+      class C { method({ x = 7 } = {}) { return x; } }
+      var method = C.prototype.method;
+      export function test(): number { return method(); }
+    `);
+    expect(ex.test()).toBe(7);
+  });
+
+  it("explicit argument is destructured normally (extracted method)", async () => {
+    const ex = await compileOk(`
+      class C { method({ x = 7 } = {}) { return x; } }
+      export function test(): number { return new C().method({ x: 42 }); }
+    `);
+    expect(ex.test()).toBe(42);
+  });
+
+  it("resolvable array-pattern default fires when arg omitted (extracted method)", async () => {
+    const ex = await compileOk(`
+      class C { method([ x = 11 ] = []) { return x; } }
+      var method = C.prototype.method;
+      export function test(): number { return method(); }
+    `);
+    expect(ex.test()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #820d (~104 test262 fails in `language/{expressions,statements}/class/dstr/async-gen-meth-dflt-*-init-unresolvable.js` plus the object-literal variants).
- **Root cause:** a method with a destructuring parameter (`method({ x = d } = {})`) is compiled with that param in a single `externref` slot — the binding pattern is destructured inside the body and the param default fires via `__extern_is_undefined`. The closure-extracted call path (`var m = C.prototype.m; m()`) instead resolved the param's TS type to a concrete struct ref via `resolveWasmType`, producing a funcref wrapper type that mismatched the actual method/trampoline signature. The dispatch then cast the trampoline funcref to the wrong (struct-param) type and trapped with `illegal cast` **before** the default expression could run — so for an unresolvable default the spec-correct `ReferenceError` never surfaced.
- **Fix:** in `src/codegen/expressions/calls.ts`, force `externref` for binding-pattern parameters when resolving the callee signature at the closure call site, so the call site agrees with the compiled callee.

This was not fully covered by #1543 — the `-init-unresolvable` subset goes through the extracted-method (no-receiver) closure path, which the earlier fix did not touch.

## Validation
- `tests/issue-820d.test.ts` — 8 cases (expr-class / stmt-class / object-literal async-gen, array & object patterns, plain method, plus regression guards that resolvable defaults still fire and explicit args pass through). All pass.
- `pnpm run typecheck` (via tsc --noEmit): clean, exit 0.
- Spot-checked against Node oracle: unresolvable default → `ReferenceError`; resolvable default (`{ x = 7 } = {}`) → applies; explicit arg → destructured normally.

## Notes
- A separate, pre-existing nested default-of-default bug (`{ a: { b = 9 } = {} } = {}` throws TypeError instead of returning 9) is **out of scope** for this issue (#820d targets single-level `dflt-{ary,obj}-ptrn-*-init-unresolvable`) and is unaffected by this change.

## Test plan
- [ ] CI required checks green (gate, shard reports, quality)
- [ ] test262 delta ≥ +80 (target ~104) in `class/dstr/async-gen-meth-dflt-*-init-unresolvable`
- [ ] No regression in #1543 acceptance set

🤖 Generated with [Claude Code](https://claude.com/claude-code)