### PR TITLE
fix(#1553c): route externref object decl destructuring through shared helper

### DIFF
--- a/plan/issues/sprints/55/1553c.md
+++ b/plan/issues/sprints/55/1553c.md
@@ -2,7 +2,7 @@
 id: 1553c
 sprint: 55
 title: "decl-dstr: route externref-fallback object declaration through destructureParamObject (decl-mode)"
-status: blocked
+status: in-progress
 created: 2026-05-20
 priority: high
 feasibility: medium

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -562,8 +562,44 @@ export function compileObjectDestructuring(
 }
 
 /**
- * Destructure an externref value using __extern_get(obj, key_string) for each property.
- * Fallback for when the source type is unknown/any/externref (no struct info available).
+ * Recover the binding kind (`let`/`const`/`var`) of a binding pattern by
+ * walking its `parent` chain for the enclosing `VariableDeclarationList`.
+ *
+ * Works for top-level decl patterns, nested binding patterns (parent pointers
+ * stay intact through ObjectBindingPattern/BindingElement up to the
+ * VariableDeclarationList), and for-of/for-in heads (whose initializer is a
+ * VariableDeclarationList). Returns `undefined` for assignment patterns
+ * (`({x} = obj)`) which have no VariableDeclarationList ancestor — callers
+ * default to `"var"`, a safe no-op for TDZ init.
+ */
+function recoverBindingKind(pattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern): BindingKind | undefined {
+  let n: ts.Node | undefined = pattern;
+  while (n) {
+    if (ts.isVariableDeclarationList(n)) {
+      if (n.flags & ts.NodeFlags.Const) return "const";
+      if (n.flags & ts.NodeFlags.Let) return "let";
+      return "var";
+    }
+    n = n.parent;
+  }
+  return undefined;
+}
+
+/**
+ * Destructure an externref value using the shared param-destructure helper
+ * (`destructureParamObject` in decl mode).
+ *
+ * Fallback for when the source type is unknown/any/externref (no struct info
+ * available). The externref on the WasmGC stack is stashed into a temp local
+ * and handed to `destructureParamObject`, which routes through its externref
+ * branch — including the `ref.test`/`struct.get` fast path for known struct
+ * types, per-element null/undefined guards, NamedEvaluation of function/class
+ * defaults, and enumerable-correct rest collection. This replaces the legacy
+ * twin that had drifted from the param path (#1553c — root causes 1, 2, 4, 8).
+ *
+ * @deprecated Internal callers (nested patterns, for-of/for-in heads) still
+ * reach this shim; the export is retained for compile compatibility until
+ * #1553d removes it. New code should call `destructureParamObject` directly.
  */
 export function compileExternrefObjectDestructuringDecl(
   ctx: CodegenContext,
@@ -571,172 +607,34 @@ export function compileExternrefObjectDestructuringDecl(
   pattern: ts.ObjectBindingPattern,
   resultType: ValType,
 ): void {
-  // Store externref in temp local
+  // Stash the externref off the WasmGC stack into a temp local for the helper.
   const tmpLocal = allocLocal(fctx, `__ext_obj_destruct_${fctx.locals.length}`, resultType);
   fctx.body.push({ op: "local.set", index: tmpLocal });
 
-  // Ensure __extern_get is available
-  let getIdx = ctx.funcMap.get("__extern_get");
-  if (getIdx === undefined) {
-    const importsBefore = ctx.numImportFuncs;
-    const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-    getIdx = ctx.funcMap.get("__extern_get");
-  }
-  if (getIdx === undefined) {
+  // Per ECMA-262 §13.15.5.5, an empty ObjectBindingPattern `{}` performs no
+  // property access and therefore no RequireObjectCoercible: `const {} = null`
+  // must NOT throw. `destructureParamObject` emits an unconditional
+  // null/undefined guard for externref sources, so we must short-circuit the
+  // empty pattern here before delegating (the binding-locals pre-pass is a
+  // no-op for an empty pattern). (#1553c — preserves twin behaviour.)
+  if (pattern.elements.length === 0) {
     ensureBindingLocals(ctx, fctx, pattern);
     return;
   }
 
-  // Pre-allocate all binding locals
-  ensureBindingLocals(ctx, fctx, pattern);
+  // Recover the binding kind from the enclosing VariableDeclarationList so the
+  // helper emits correct TDZ init for let/const. Assignment patterns and any
+  // unforeseen caller default to "var" (TDZ init is a no-op for var).
+  const bindingKind = recoverBindingKind(pattern) ?? "var";
 
-  // Null guard: skip destructuring if source is null
-  const isNullable = resultType.kind === "externref" || resultType.kind === "ref_null";
-  emitNullGuard(
-    ctx,
-    fctx,
-    tmpLocal,
-    isNullable,
-    () => {
-      // Collect non-rest property names for __extern_rest_object exclusion
-      const excludedKeys: string[] = [];
-      for (const element of pattern.elements) {
-        if (!ts.isBindingElement(element) || element.dotDotDotToken) continue;
-        const pn = element.propertyName ?? element.name;
-        if (ts.isIdentifier(pn)) excludedKeys.push(pn.text);
-        else if (ts.isStringLiteral(pn)) excludedKeys.push(pn.text);
-        else if (ts.isNumericLiteral(pn)) excludedKeys.push(pn.text);
-      }
+  // Decl-mode delegation. The helper's externref branch handles the struct
+  // fast path, per-element guards, defaults, and rest collection.
+  destructureParamObject(ctx, fctx, tmpLocal, pattern, resultType, {
+    mode: "decl",
+    bindingKind,
+  });
 
-      for (const element of pattern.elements) {
-        if (!ts.isBindingElement(element)) continue;
-
-        // Handle rest element: const { a, ...rest } = externObj
-        if (element.dotDotDotToken) {
-          if (ts.isIdentifier(element.name)) {
-            const restName = element.name.text;
-            let restIdx = fctx.localMap.get(restName);
-            if (restIdx === undefined) {
-              restIdx = allocLocal(fctx, restName, { kind: "externref" });
-            }
-            // Use __extern_rest_object(obj, excludedKeysStr)
-            let restObjIdx = ctx.funcMap.get("__extern_rest_object");
-            if (restObjIdx === undefined) {
-              const importsBefore = ctx.numImportFuncs;
-              const restObjType = addFuncType(
-                ctx,
-                [{ kind: "externref" }, { kind: "externref" }],
-                [{ kind: "externref" }],
-              );
-              addImport(ctx, "env", "__extern_rest_object", { kind: "func", typeIdx: restObjType });
-              shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-              restObjIdx = ctx.funcMap.get("__extern_rest_object");
-              getIdx = ctx.funcMap.get("__extern_get");
-            }
-            if (restObjIdx !== undefined) {
-              const excludedStr = excludedKeys.join(",");
-              addStringConstantGlobal(ctx, excludedStr);
-              const excludedStrIdx = ctx.stringGlobalMap.get(excludedStr);
-              if (excludedStrIdx !== undefined) {
-                fctx.body.push({ op: "local.get", index: tmpLocal });
-                fctx.body.push({ op: "global.get", index: excludedStrIdx });
-                fctx.body.push({ op: "call", funcIdx: restObjIdx });
-                fctx.body.push({ op: "local.set", index: restIdx });
-              }
-            }
-          }
-          continue;
-        }
-
-        // Determine the property name to look up
-        const propNameNode = element.propertyName ?? element.name;
-        let propNameText: string | undefined;
-        if (ts.isIdentifier(propNameNode)) {
-          propNameText = propNameNode.text;
-        } else if (ts.isStringLiteral(propNameNode)) {
-          propNameText = propNameNode.text;
-        } else if (ts.isNumericLiteral(propNameNode)) {
-          propNameText = propNameNode.text;
-        }
-
-        if (!propNameText) continue;
-
-        // Emit: __extern_get(tmpLocal, "propName") -> externref
-        // Register the property name as a string constant global
-        addStringConstantGlobal(ctx, propNameText);
-        const strGlobalIdx = ctx.stringGlobalMap.get(propNameText);
-        if (strGlobalIdx === undefined) continue;
-
-        // Refresh getIdx in case addStringConstantGlobal shifted indices
-        getIdx = ctx.funcMap.get("__extern_get");
-        if (getIdx === undefined) continue;
-
-        fctx.body.push({ op: "local.get", index: tmpLocal });
-        fctx.body.push({ op: "global.get", index: strGlobalIdx });
-        fctx.body.push({ op: "call", funcIdx: getIdx });
-
-        const elemType: ValType = { kind: "externref" };
-
-        if (ts.isIdentifier(element.name)) {
-          const localName = element.name.text;
-          let localIdx = fctx.localMap.get(localName);
-          if (localIdx === undefined) {
-            localIdx = allocLocal(fctx, localName, elemType);
-          }
-          const localType = getLocalType(fctx, localIdx);
-
-          // Handle default value: check ref.is_null || __extern_is_undefined
-          if (element.initializer) {
-            const tmpElem = allocLocal(fctx, `__ext_obj_dflt_${fctx.locals.length}`, elemType);
-            fctx.body.push({ op: "local.tee", index: tmpElem });
-            emitExternrefDefaultCheck(ctx, fctx, tmpElem);
-            const thenInstrs = collectInstrs(fctx, () => {
-              compileExpression(ctx, fctx, element.initializer!, localType ?? elemType);
-              fctx.body.push({ op: "local.set", index: localIdx! } as Instr);
-            });
-            const elseCoerce =
-              localType && !valTypesMatch(elemType, localType)
-                ? collectInstrs(fctx, () => {
-                    coerceType(ctx, fctx, elemType, localType!);
-                  })
-                : [];
-            fctx.body.push({
-              op: "if",
-              blockType: { kind: "empty" },
-              then: thenInstrs,
-              else: [
-                { op: "local.get", index: tmpElem } as Instr,
-                ...elseCoerce,
-                { op: "local.set", index: localIdx! } as Instr,
-              ],
-            });
-          } else {
-            if (localType && !valTypesMatch(elemType, localType)) {
-              coerceType(ctx, fctx, elemType, localType);
-            }
-            fctx.body.push({ op: "local.set", index: localIdx });
-          }
-        } else if (ts.isObjectBindingPattern(element.name) || ts.isArrayBindingPattern(element.name)) {
-          // Nested destructuring on externref — recursively destructure
-          const nestedLocal = allocLocal(fctx, `__ext_nested_${fctx.locals.length}`, elemType);
-          fctx.body.push({ op: "local.set", index: nestedLocal });
-          ensureBindingLocals(ctx, fctx, element.name);
-          if (ts.isObjectBindingPattern(element.name)) {
-            fctx.body.push({ op: "local.get", index: nestedLocal });
-            compileExternrefObjectDestructuringDecl(ctx, fctx, element.name, elemType);
-          } else {
-            fctx.body.push({ op: "local.get", index: nestedLocal });
-            compileExternrefArrayDestructuringDecl(ctx, fctx, element.name, elemType);
-          }
-        }
-      }
-    },
-    resultType.kind,
-  ); // end null guard
-
-  // Sync destructured locals to module globals
+  // Module-global sync stays in the caller — the helper only writes to locals.
   syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
 }
 

--- a/tests/issue-1553c.test.ts
+++ b/tests/issue-1553c.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1553c — route the externref object *declaration* destructuring path
+ * through the shared `destructureParamObject` helper (decl-mode).
+ *
+ * The legacy twin `compileExternrefObjectDestructuringDecl` had drifted from
+ * the function-parameter helper: it lacked the struct fast path for
+ * struct-typed nested defaults (root-cause 2), dropped initializers when the
+ * binding target was itself a pattern (root-cause 1), and did not gate each
+ * nested-pattern recursion behind a null/undefined guard (root-cause 4),
+ * silently producing `undefined` instead of throwing TypeError for nested
+ * null. Delegating to `destructureParamObject` fixes all three because that
+ * path is the one already exercised by function-parameter destructuring of
+ * the same externref RHS shapes.
+ *
+ * Spec basis: ECMA-262 §13.15.5.6 KeyedBindingInitialization /
+ * §14.3.3.3 BindingInitialization — defaults fire only on `undefined`
+ * (not `null`); destructuring a nullish value through a non-empty nested
+ * pattern throws TypeError (RequireObjectCoercible).
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("#1553c — externref decl destructuring via shared helper", () => {
+  it("nested default fires on undefined prop (struct-typed default)", async () => {
+    // root-cause 2: `{x:1,y:2,z:3}` default compiles to a known struct; the
+    // decl twin used to extern.convert_any-roundtrip + __extern_get, which
+    // returned undefined for every field. The helper takes the struct fast
+    // path (ref.test + struct.get).
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { w: { x, y, z } = { x: 1, y: 2, z: 3 } } = ({ w: undefined } as any);
+        return x + y + z;
+      }
+    `);
+    expect(exports.f()).toBe(6);
+  });
+
+  it("nested null throws TypeError (does NOT fire default, does NOT silently undefined)", async () => {
+    // root-cause 4: `{w:null}` — null does not trigger the default, and
+    // destructuring null through `{x}` must throw TypeError.
+    const exports = await compileToWasm(`
+      export function f(): number {
+        try {
+          let { w: { x } } = ({ w: null } as any);
+          return x;
+        } catch {
+          return 99;
+        }
+      }
+    `);
+    expect(exports.f()).toBe(99);
+  });
+
+  it("nested undefined fires the nested default", async () => {
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { w: { x } = { x: 42 } } = ({ w: undefined } as any);
+        return x;
+      }
+    `);
+    expect(exports.f()).toBe(42);
+  });
+
+  it("top-level identifier default fires for a missing prop (object-typed default)", async () => {
+    // Use an object-typed default so the binding local is externref — the
+    // f64 explicit-undefined sentinel for numeric defaults is deferred to
+    // #1553e and is out of scope here.
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { a = { v: 7 } } = ({} as any);
+        return (a as any).v;
+      }
+    `);
+    expect(exports.f()).toBe(7);
+  });
+
+  it("present prop overrides its default", async () => {
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { a = { v: 7 } } = ({ a: { v: 99 } } as any);
+        return (a as any).v;
+      }
+    `);
+    expect(exports.f()).toBe(99);
+  });
+
+  it("null property does not trigger a sibling default", async () => {
+    // default-on-undefined-OR-null distinction (#1432): a present `null`
+    // value must be kept, not replaced by the default.
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { a = 5 } = ({ a: null } as any);
+        return a === null ? 1 : 0;
+      }
+    `);
+    expect(exports.f()).toBe(1);
+  });
+
+  it("rest binding collects remaining own properties", async () => {
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { a, ...rest } = ({ a: 1, b: 2, c: 3 } as any);
+        return a + (rest as any).b + (rest as any).c;
+      }
+    `);
+    expect(exports.f()).toBe(6);
+  });
+
+  it("destructuring a null RHS through a non-empty pattern throws TypeError", async () => {
+    const exports = await compileToWasm(`
+      export function f(): number {
+        try {
+          let { a } = (null as any);
+          return a;
+        } catch {
+          return 7;
+        }
+      }
+    `);
+    expect(exports.f()).toBe(7);
+  });
+
+  it("renamed binding with default", async () => {
+    const exports = await compileToWasm(`
+      export function f(): number {
+        let { p: q = 11 } = ({} as any);
+        return q;
+      }
+    `);
+    expect(exports.f()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the ~170-LOC `compileExternrefObjectDestructuringDecl` twin in `src/codegen/statements/destructuring.ts` with a delegation to `destructureParamObject` (decl-mode), the same helper used for function-parameter destructuring (#1553a/b prepared it).
- Fixes root-causes 1 (dropped initializer on pattern targets), 2 (struct-typed nested defaults read via `__extern_get` returning undefined — now uses `ref.test` + `struct.get` fast path), 4 (nested null silently produced `undefined` instead of throwing TypeError), and 8 (rest now flows through the shared enumerable-correct `__extern_rest_object`).
- Adds `recoverBindingKind` (walks the pattern's parent chain to the enclosing `VariableDeclarationList`) so let/const TDZ init is emitted correctly.
- Short-circuits empty pattern `{} = null` before delegating — an empty ObjectBindingPattern performs no RequireObjectCoercible per ECMA-262 §13.15.5.5 (the param helper guards unconditionally).
- Export retained (`@deprecated`) for internal callers until #1553d.

Net: ~ -130 LOC (deletion of the twin, +20 LOC shim).

## Test plan
- [x] `tests/issue-1553c.test.ts` — 9 cases: struct-typed nested default on undefined prop (bug 2), nested null throws TypeError (bug 4), nested undefined fires default, object-typed top-level default, null prop does not trigger sibling default (#1432), rest collection, null RHS throws, renamed binding with default.
- [x] `pnpm run typecheck` clean.
- [x] Destructuring regression suite (basic-destructuring, issue-1021/1128/1225/1432/1450/1552/1553a/1553b/1553e, dstr-requireobj, null-destructuring, test262-dstr-patterns, etc.) — zero net regression vs baseline (the 4 remaining failures are pre-existing harness/baseline issues identical to the unmodified twin).
- [ ] CI test262 conformance gate (expected: ≥24 `obj-ptrn-prop-obj-*` / `obj-init-null/undefined` cases flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)