### PR TITLE
fix(#1474): refuse RegExp in --target standalone (Phase 1)

### DIFF
--- a/plan/issues/sprints/55/1474-no-js-host-regex-standalone.md
+++ b/plan/issues/sprints/55/1474-no-js-host-regex-standalone.md
@@ -2,7 +2,7 @@
 id: 1474
 sprint: 55
 title: "host-independence: eliminate JS host RegExp for standalone Wasm"
-status: ready
+status: in-progress
 created: 2026-05-20
 priority: high
 feasibility: medium
@@ -128,13 +128,36 @@ uses.
 ## Acceptance criteria
 
 ### Phase 1 (this issue, Option A)
-- [ ] `--standalone` build with a regex literal or `new RegExp(…)`
+- [x] `--standalone` build with a regex literal or `new RegExp(…)`
       fails at compile time with: "RegExp is not supported in
       standalone mode (#1474). Recompile without --standalone, or
       avoid regex."
-- [ ] Source line / column reported in the error.
-- [ ] `--js-host` default mode unchanged — all existing regex tests
+- [x] Source line / column reported in the error.
+- [x] `--js-host` default mode unchanged — all existing regex tests
       still pass.
+
+## Phase 1 implementation notes (landed)
+
+Refuse-and-document gates added on `ctx.standalone` at every codegen
+site that produces or host-routes a RegExp value. All use the
+`Codegen error:` prefix so `compiler.ts` fails the build (matching the
+WASI DOM/timer refusal pattern at `index.ts:8362/8439`):
+
+- `src/codegen/typeof-delete.ts` `compileRegExpLiteral` — regex literals.
+- `src/codegen/expressions/new-super.ts` — `new RegExp(...)`.
+- `src/codegen/expressions/calls.ts` — `RegExp(...)` (no `new`), plus the
+  `eval("/"+X+"/")` peephole (returns `undefined` so the host import is
+  never registered).
+- `src/codegen/string-ops.ts` — host fall-through for
+  `match`/`matchAll`/`search` (always regex) and
+  `replace`/`replaceAll`/`split` when the first arg is statically a RegExp.
+
+Tests: `tests/issue-1474-standalone-regex-refuse.test.ts` (14 cases —
+9 refusal + location asserts, 4 default-mode-unchanged, 1 no-import
+assert). Default-mode `tests/regexp.test.ts` and standalone
+`tests/issue-1470-standalone-string-imports.test.ts` both still green.
+
+Phase 2 (NFA engine) remains a separate follow-up issue.
 
 ### Phase 2 (follow-up, Option B — separate issue)
 - [ ] `--standalone` builds with regex emit a pure-Wasm NFA engine.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -760,6 +760,10 @@ function tryEvalAsRegExpPeephole(
   fctx: FunctionContext,
   expr: ts.CallExpression,
 ): InnerResult | undefined {
+  // #1474 — this peephole desugars `eval("/" + X + "/")` to a RegExp_new
+  // host call. RegExp has no Wasm-native engine yet, so refuse to register
+  // the host import in --target standalone (eval itself is also host-only).
+  if (ctx.standalone) return undefined;
   if (expr.arguments.length !== 1) return undefined;
 
   // Strip parens around the argument.
@@ -1199,6 +1203,23 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
   // flags undefined, an edge case we accept). Emit the RegExp_new host call
   // directly so the host constructor runs and validates modifier syntax,
   // throwing SyntaxError on invalid patterns. (#1055)
+  // #1474 — RegExp delegates to the JS host engine; refuse `RegExp(...)`
+  // (no `new`) in --target standalone (Phase 1: refuse-and-document).
+  if (
+    ctx.standalone &&
+    !expr.questionDotToken &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "RegExp"
+  ) {
+    reportError(
+      ctx,
+      expr,
+      "Codegen error: RegExp(...) is not supported in --target standalone (#1474). " +
+        "Recompile without --target standalone.",
+    );
+    return null;
+  }
+
   if (
     !expr.questionDotToken &&
     ts.isIdentifier(expr.expression) &&

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1993,6 +1993,23 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
   }
 
+  // #1474 — RegExp delegates to the JS host engine; there is no Wasm-native
+  // regex engine yet. Refuse `new RegExp(...)` in --target standalone
+  // (Phase 1: refuse-and-document). Match either the resolved builtin name
+  // or the literal identifier (which is how `new RegExp(...)` appears).
+  if (
+    ctx.standalone &&
+    (className === "RegExp" || (ts.isIdentifier(expr.expression) && expr.expression.text === "RegExp"))
+  ) {
+    reportError(
+      ctx,
+      expr,
+      "Codegen error: new RegExp(...) is not supported in --target standalone (#1474). " +
+        "Recompile without --target standalone.",
+    );
+    return null;
+  }
+
   // Check if the identifier resolves to a function declaration used as constructor
   // (e.g. `function Foo() { this.x = 1; }; new Foo()`)
   if ((!className || !ctx.classSet.has(className)) && ts.isIdentifier(expr.expression)) {

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -1915,6 +1915,34 @@ export function compileNativeStringMethodCall(
     return compileExpression(ctx, fctx, propAccess.expression);
   }
 
+  // #1474 — These host-routed string methods build/consume a JS RegExp under
+  // the hood. There is no Wasm-native regex engine yet, so refuse in
+  // --target standalone (Phase 1: refuse-and-document).
+  //   - match / matchAll / search: the spec coerces the (string) argument to a
+  //     RegExp, so they always route through the host regex engine.
+  //   - replace / replaceAll / split: only when the first argument is
+  //     statically a RegExp (string-arg forms use the native helpers above and
+  //     never reach this fall-through).
+  if (ctx.standalone) {
+    const argIsRegExp = (): boolean => {
+      if (expr.arguments.length === 0) return false;
+      const argType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+      return argType.getSymbol()?.getName() === "RegExp";
+    };
+    const alwaysRegExp = method === "match" || method === "matchAll" || method === "search";
+    const regexArgForm = (method === "replace" || method === "replaceAll" || method === "split") && argIsRegExp();
+    if (alwaysRegExp || regexArgForm) {
+      reportError(
+        ctx,
+        expr,
+        `Codegen error: String.prototype.${method}(...) with a RegExp is not supported in ` +
+          "--target standalone (#1474). Pass a string pattern instead, or " +
+          "recompile without --target standalone.",
+      );
+      return null;
+    }
+  }
+
   // Other methods: marshal native->extern, call host, marshal extern->native
   const importName = `string_${method}`;
   const funcIdx = ctx.funcMap.get(importName);

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -285,6 +285,18 @@ export function compileDeleteExpression(
  * The pattern and flags strings are loaded from the string pool, then RegExp_new is called.
  */
 export function compileRegExpLiteral(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): ValType | null {
+  // #1474 — RegExp delegates to the JS host engine; there is no Wasm-native
+  // regex engine yet. Refuse in --target standalone (Phase 1: refuse-and-document).
+  if (ctx.standalone) {
+    reportError(
+      ctx,
+      expr,
+      "Codegen error: RegExp literals are not supported in --target standalone (#1474). " +
+        "Recompile without --target standalone, or replace the regex with " +
+        "String.prototype.{indexOf, startsWith, slice}.",
+    );
+    return null;
+  }
   const { pattern, flags } = parseRegExpLiteral(expr.getText());
 
   // Load pattern string

--- a/tests/issue-1474-standalone-regex-refuse.test.ts
+++ b/tests/issue-1474-standalone-regex-refuse.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1474 Phase 1 — refuse-and-document.
+ *
+ * RegExp delegates entirely to the JS host engine; there is no Wasm-native
+ * regex engine yet. In `--target standalone` (pure WasmGC, no JS host), any
+ * regex literal, `new RegExp(...)` / `RegExp(...)` call, or host-routed string
+ * method that builds/consumes a RegExp must fail at compile time with a clear
+ * `#1474` message and a source location — rather than emitting an
+ * `env::RegExp_new` import that fails at `wasmtime instantiate`.
+ *
+ * Phase 2 (a pure-Wasm NFA engine) is a separate follow-up issue.
+ */
+
+function expectRefused(src: string): ReturnType<typeof compile> {
+  const r = compile(src, { target: "standalone" });
+  expect(r.success, `expected compile failure, got success for:\n${src}`).toBe(false);
+  expect(r.errors.length).toBeGreaterThan(0);
+  expect(r.errors.some((e) => /#1474/.test(e.message))).toBe(true);
+  // Source location must be reported (line > 0).
+  const refusal = r.errors.find((e) => /#1474/.test(e.message))!;
+  expect(refusal.line).toBeGreaterThan(0);
+  return r;
+}
+
+describe("#1474 --target standalone refuses RegExp", () => {
+  it("rejects a regex literal", () => {
+    expectRefused(`export function f(s: string): boolean { return /\\d+/.test(s); }`);
+  });
+
+  it("rejects a flagged regex literal", () => {
+    expectRefused(`export function f(s: string): string { return s.replace(/a/g, "b"); }`);
+  });
+
+  it("rejects new RegExp(...)", () => {
+    expectRefused(`export function f(p: string): boolean { return new RegExp(p, "g").test("x"); }`);
+  });
+
+  it("rejects RegExp(...) called without new", () => {
+    expectRefused(`export function f(p: string): boolean { const r = RegExp(p); return r.test("x"); }`);
+  });
+
+  it("rejects s.match(regexLiteral)", () => {
+    expectRefused(`export function f(s: string): boolean { return s.match(/\\d+/) !== null; }`);
+  });
+
+  it("rejects s.matchAll(regexLiteral)", () => {
+    expectRefused(`export function f(s: string): number { return [...s.matchAll(/\\d/g)].length; }`);
+  });
+
+  it("rejects s.search(regexLiteral)", () => {
+    expectRefused(`export function f(s: string): number { return s.search(/\\d/); }`);
+  });
+
+  it("rejects s.split(regexArg)", () => {
+    expectRefused(`export function f(s: string): number { const r = /,/; return s.split(r).length; }`);
+  });
+
+  it("rejects s.replace(regexArg, ...)", () => {
+    expectRefused(`export function f(s: string): string { const r = /a/g; return s.replace(r, "b"); }`);
+  });
+
+  it("emits no env::RegExp_new import when refused", () => {
+    const r = compile(`export function f(s: string): boolean { return /\\d+/.test(s); }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+    const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+    expect(labels.some((l) => /RegExp_new/.test(l))).toBe(false);
+  });
+});
+
+describe("#1474 default (JS-host) mode unchanged", () => {
+  it("compiles a regex literal in default mode", () => {
+    const r = compile(`export function f(s: string): boolean { return /\\d+/.test(s); }`, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+
+  it("compiles s.replace(regex, ...) in default mode", () => {
+    const r = compile(`export function f(s: string): string { return s.replace(/a/g, "b"); }`, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+
+  it("compiles new RegExp(...) in default mode", () => {
+    const r = compile(`export function f(p: string): boolean { return new RegExp(p, "g").test("x"); }`, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+
+  it("standalone string methods without regex still compile", () => {
+    const r = compile(`export function f(s: string): string { return s.replace("a", "b").split(",")[0]!; }`, {
+      target: "standalone",
+    });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- #1474 Phase 1 (refuse-and-document): RegExp delegates entirely to the JS host engine (`env::RegExp_new`) with no Wasm-native fallback, so `--target standalone` modules fail at `wasmtime instantiate` with `unknown import env::RegExp_new`.
- Every codegen site that produces or host-routes a RegExp now gates on `ctx.standalone` and emits a `Codegen error:` with source line/column — matching the existing WASI DOM/timer refusal pattern (`index.ts:8362/8439`).

## Gated sites
- `src/codegen/typeof-delete.ts` `compileRegExpLiteral` — regex literals (`/\d+/g`)
- `src/codegen/expressions/new-super.ts` — `new RegExp(...)`
- `src/codegen/expressions/calls.ts` — `RegExp(...)` without `new`, and the `eval("/"+X+"/")` peephole (returns `undefined` so the host import is never registered)
- `src/codegen/string-ops.ts` — host fall-through for `match`/`matchAll`/`search` (always regex) and `replace`/`replaceAll`/`split` when the first arg is statically a RegExp

Default JS-host mode is unchanged. Phase 2 (pure-Wasm NFA engine) is tracked as a separate follow-up.

## Test plan
- [x] `tests/issue-1474-standalone-regex-refuse.test.ts` — 14 cases (literal, flagged literal, `new RegExp`, `RegExp(...)`, `match`/`matchAll`/`search`/`split`/`replace`, no-`RegExp_new`-import assert, plus 4 default-mode-unchanged cases). All green.
- [x] `tests/regexp.test.ts` (default JS-host mode) still green.
- [x] `tests/issue-1470-standalone-string-imports.test.ts` still green.
- [x] `npx tsc --noEmit` clean.