### PR TITLE
fix(#1472): Phase A — refuse JS-host object/property ops in --target standalone

### DIFF
--- a/plan/issues/sprints/55/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/sprints/55/1472-no-js-host-object-property-ops.md
@@ -2,7 +2,7 @@
 id: 1472
 sprint: 55
 title: "host-independence: eliminate JS host object/property ops for standalone Wasm"
-status: ready
+status: in-progress
 created: 2026-05-20
 priority: high
 feasibility: medium
@@ -218,11 +218,47 @@ if (ctx.standalone) {
 ```
 
 Acceptance for Phase A:
-- [ ] `--target standalone` compiles a class-only / typed-only
+- [x] `--target standalone` compiles a class-only / typed-only
       program (math fixtures, fib, string-basics) with **zero**
       `env::__extern_*`/`env::__object_*` imports.
-- [ ] Any open-object usage in `--target standalone` fails with a
+- [x] Any open-object usage in `--target standalone` fails with a
       clear error message pointing to #1472 Phase B.
+
+### Phase A — DONE (PR pending)
+
+Implemented as a single central choke point rather than per-call-site
+gates (the plan's per-site retargeting is Phase B work):
+
+- `src/codegen/expressions/late-imports.ts` — `ensureLateImport` now
+  calls `refuseStandaloneObjectImport(ctx, name)`. Under `ctx.standalone`,
+  any object/property host-import family name (`__extern_*`, `__object_*`,
+  `__for_in_*`, `__defineProperty*`, `__getOwn*`, `__new_plain_object`,
+  `__delete_property`, `__hasOwnProperty`, `__propertyIsEnumerable`,
+  `__isPrototypeOf`, `__register_prototype`, `__register_class_object`,
+  `__proxy_*`, `__get_builtin`, `__proto_method_call`) queues a
+  `Codegen error:`-prefixed diagnostic (deduplicated per name) pointing
+  at Phase B. The prefix routes through compiler.ts's hard-fail path
+  (`success: false`, empty module) so no half-working module with a
+  leaked host import is emitted.
+- `src/codegen/index.ts` — the eager `__register_prototype` /
+  `__register_class_object` registration (only needed by the JS-host
+  Proxy wrapper) is now gated `&& !ctx.standalone`. `emitLazyProtoGet` /
+  `emitLazyClassObjectGet` already gate their `call` on the import being
+  in funcMap, so class prototype/class-object globals still work
+  natively (struct.new + global.set) with no host notification.
+- `src/codegen/context/types.ts` — added `standaloneRefusedImports?:
+  Set<string>` for per-name error dedup.
+- Test: `tests/issue-1472-standalone-object-imports.test.ts` (4 tests,
+  passing): typed object literal + class instance compile with zero host
+  object imports; open `any` object refuses with the Phase B error;
+  default `gc` target still uses the JS-host object machinery.
+
+Closed-shape struct access (the `getFieldEntry` fast path) never reaches
+the gate — it emits struct.get/struct.set and never calls
+`ensureLateImport` for these names, so it works standalone unchanged.
+
+**Phase B** (Wasm-native open-object runtime) and **Phase C** (Proxy
+refusal + Reflect dispatch) remain as follow-up work — see plan below.
 
 #### Phase B (follow-up issue): Wasm-native open-object runtime
 

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -612,6 +612,11 @@ export interface CodegenContext {
    *  `__unbox_string`, `__str_from_mem`, `__str_to_mem`,
    *  `__str_extern_len`). Implies `nativeStrings === true`. */
   standalone: boolean;
+  /** (#1472 Phase A) Set of dynamic-shape object/property host-import names
+   *  already refused under `--target standalone`, used to deduplicate the
+   *  compile-error so a single source construct emits at most one error per
+   *  import name. Lazily initialized in late-imports.ts. */
+  standaloneRefusedImports?: Set<string>;
   /**
    * (#1373b) When true, async functions flow through the IR's CPS lowering
    * (Phase C). When false (default), the IR selector buckets async functions

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -8,8 +8,69 @@
  */
 import type { Instr, ValType } from "../../ir/types.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { reportErrorNoNode } from "../context/errors.js";
 import { addImport } from "../registry/imports.js";
 import { addFuncType } from "../registry/types.js";
+
+/**
+ * #1472 Phase A — open-object / dynamic-shape property operations have no
+ * Wasm-native runtime yet (that's Phase B). Under `--target standalone` there
+ * is no JS host to satisfy these imports, so instead of leaking an
+ * `env::__extern_*` / `env::__object_*` import that fails at instantiation with
+ * an opaque "unknown import" linker error, we refuse at compile time with a
+ * message that points the user at the supported fast path (typed object
+ * literals / class instances compile to `struct.get`/`struct.set` with zero
+ * host calls) and at the follow-up issue.
+ *
+ * Closed-shape struct access never reaches this gate — it emits struct ops
+ * directly and never calls ensureLateImport for these names.
+ */
+const STANDALONE_REFUSED_IMPORT = (name: string): boolean =>
+  name.startsWith("__extern_") ||
+  name.startsWith("__object_") ||
+  name.startsWith("__for_in_") ||
+  name.startsWith("__defineProperty") ||
+  name.startsWith("__defineProperties") ||
+  name.startsWith("__getOwn") ||
+  name.startsWith("__getPrototypeOf") ||
+  name.startsWith("__proto_method_call") ||
+  name.startsWith("__get_builtin") ||
+  name.startsWith("__register_prototype") ||
+  name.startsWith("__register_class_object") ||
+  name.startsWith("__proxy_") ||
+  name === "__new_plain_object" ||
+  name === "__delete_property" ||
+  name === "__hasOwnProperty" ||
+  name === "__propertyIsEnumerable" ||
+  name === "__isPrototypeOf" ||
+  name === "__object_hasOwn";
+
+/**
+ * Emit the #1472 Phase A standalone refusal for a dynamic-shape object/property
+ * operation, deduplicated per import name so a single source construct doesn't
+ * spam the error list. Returns true if the import was refused (caller should
+ * still proceed so codegen doesn't crash; the queued error — prefixed with
+ * "Codegen error:" — forces `success: false` and an empty module in
+ * compiler.ts).
+ */
+function refuseStandaloneObjectImport(ctx: CodegenContext, name: string): boolean {
+  if (!ctx.standalone || !STANDALONE_REFUSED_IMPORT(name)) return false;
+  if (!ctx.standaloneRefusedImports) ctx.standaloneRefusedImports = new Set<string>();
+  if (ctx.standaloneRefusedImports.has(name)) return true;
+  ctx.standaloneRefusedImports.add(name);
+  // Prefix with "Codegen error:" so compiler.ts treats this as a hard failure
+  // (success: false, empty module) rather than a warning that leaves a
+  // half-working module with a leaked host import (#1472 acceptance criteria:
+  // "no silent fall-back to a half-working runtime").
+  reportErrorNoNode(
+    ctx,
+    `Codegen error: '${name}' (dynamic-shape object/property operation) is not ` +
+      `yet supported in --target standalone (#1472 Phase B). Use a typed object ` +
+      `literal or class instance for fast-path codegen, which compiles to ` +
+      `struct.get/struct.set with no JS host imports.`,
+  );
+  return true;
+}
 
 /**
  * Shift function indices after a late import addition. This must update all
@@ -141,6 +202,12 @@ export function ensureLateImport(
 ): number | undefined {
   const existing = ctx.funcMap.get(name);
   if (existing !== undefined) return existing;
+  // #1472 Phase A — refuse dynamic-shape object/property host imports under
+  // --target standalone with a clear compile error. We still register the
+  // import below so downstream codegen (which dereferences the returned
+  // funcIdx) doesn't crash; the queued error makes the compile fail and the
+  // module is never instantiated.
+  refuseStandaloneObjectImport(ctx, name);
   // Record importsBefore on the FIRST deferred addition in this batch
   if (ctx.pendingLateImportShift === null) {
     ctx.pendingLateImportShift = { importsBefore: ctx.numImportFuncs };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -791,7 +791,15 @@ export function generateModule(
     // #1047 — register __register_prototype host import before any local function
     // is created so `emitLazyProtoGet` can look it up from funcMap without
     // triggering late-import index shifts mid-expression compilation.
-    if (sourceContainsClass(ast.sourceFile)) {
+    //
+    // #1472 Phase A — these two imports exist solely so the JS-host Proxy
+    // wrapper can present a spec-correct own-key set for class prototypes /
+    // class objects. There is no Proxy (and no JS host) in --target standalone,
+    // so we skip registering them. `emitLazyProtoGet` / `emitLazyClassObjectGet`
+    // gate their `call` emission on the import being present in funcMap, so
+    // skipping registration cleanly drops the host notification while the
+    // struct-backed prototype/class globals still work natively.
+    if (sourceContainsClass(ast.sourceFile) && !ctx.standalone) {
       const regProtoTypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], []);
       addImport(ctx, "env", "__register_prototype", { kind: "func", typeIdx: regProtoTypeIdx });
       // (#1395) Same rationale for the class-object registry — must be

--- a/tests/issue-1472-standalone-object-imports.test.ts
+++ b/tests/issue-1472-standalone-object-imports.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1472 Phase A — `--target standalone` must not leak dynamic-shape
+ * object/property JS-host imports (`env::__extern_*`, `env::__object_*`,
+ * `env::__for_in_*`, `env::__defineProperty*`, `env::__hasOwnProperty`,
+ * `env::__getOwn*`, `env::__delete_property`, `env::__new_plain_object`,
+ * `env::__register_*`). Open-object usage instead fails at compile time with a
+ * message pointing at Phase B; closed-shape struct access (typed object
+ * literals / class instances) still compiles to struct.get/struct.set with
+ * zero host calls.
+ *
+ * Phase B (the Wasm-native open-object runtime) is a follow-up.
+ */
+
+const BANNED_IMPORTS: ReadonlyArray<RegExp> = [
+  /^env::__extern_/,
+  /^env::__object_/,
+  /^env::__for_in_/,
+  /^env::__defineProperty/,
+  /^env::__defineProperties/,
+  /^env::__getOwn/,
+  /^env::__getPrototypeOf$/,
+  /^env::__delete_property$/,
+  /^env::__new_plain_object$/,
+  /^env::__hasOwnProperty$/,
+  /^env::__propertyIsEnumerable$/,
+  /^env::__isPrototypeOf$/,
+  /^env::__register_prototype$/,
+  /^env::__register_class_object$/,
+];
+
+function assertNoHostObjectImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of BANNED_IMPORTS) {
+    const hits = labels.filter((l) => re.test(l));
+    expect(hits, `--target standalone leaked ${re} (got ${hits.join(", ")})`).toEqual([]);
+  }
+}
+
+describe("#1472 Phase A — --target standalone dynamic-object refusal", () => {
+  it("typed object literal (closed shape) compiles with zero host object imports", () => {
+    const r = compile(
+      `
+        interface Point { x: number; y: number; }
+        export function dist(): number {
+          const p: Point = { x: 3, y: 4 };
+          return p.x * p.x + p.y * p.y;
+        }
+      `,
+      { target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+  });
+
+  it("class instance with method dispatch compiles with zero host object imports", () => {
+    const r = compile(
+      `
+        class Counter {
+          n: number = 0;
+          inc(): number { this.n = this.n + 1; return this.n; }
+        }
+        export function run(): number {
+          const c = new Counter();
+          c.inc();
+          return c.inc();
+        }
+      `,
+      { target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+  });
+
+  it("dynamic property add on an any-typed object refuses with a #1472 Phase B error", () => {
+    const r = compile(
+      `
+        export function leak(): number {
+          const o: any = { x: 1 };
+          o.y = 2;
+          return o.y;
+        }
+      `,
+      { target: "standalone" },
+    );
+    expect(r.success).toBe(false);
+    const joined = r.errors.map((e) => e.message).join("\n");
+    expect(joined).toMatch(/standalone/);
+    expect(joined).toMatch(/#1472 Phase B/);
+    // The refusal must NOT leak the host import into the module.
+    assertNoHostObjectImports(r.imports);
+  });
+
+  it("default target (gc) still uses the JS-host object machinery", () => {
+    // Regression guard: standalone is opt-in. Default mode keeps the host
+    // object imports so browser-targeted modules work with the JS runtime.
+    const r = compile(
+      `
+        export function obj(): number {
+          const o: any = { x: 1 };
+          o.y = 2;
+          return o.y;
+        }
+      `,
+      {},
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **#1472 Phase A** (the issue's MVP): under `--target standalone` there is no JS host to satisfy the open-object / dynamic-shape property host-import family (`__extern_*`, `__object_*`, `__for_in_*`, `__defineProperty*`, `__getOwn*`, `__new_plain_object`, `__delete_property`, `__hasOwnProperty`, `__register_prototype`, `__register_class_object`, `__proxy_*`, …). Leaking one produces an opaque "unknown import" linker error at instantiation.
- Gated at a single choke point — `ensureLateImport` (`src/codegen/expressions/late-imports.ts`) — plus the eager `__register_prototype` / `__register_class_object` registration in `index.ts`. Under `ctx.standalone` these queue a `Codegen error:`-prefixed diagnostic pointing at Phase B, which routes through `compiler.ts`'s hard-fail path (`success: false`, empty module) — no half-working module with a leaked import.
- Closed-shape struct access (typed object literals, class instances) is **unchanged**: it emits `struct.get`/`struct.set` directly and never reaches the gate, so it compiles standalone with zero host object imports. Class prototype / class-object globals still materialize natively (`struct.new` + `global.set`); only the JS-host-Proxy registry notification is dropped.
- Default `gc` / `wasi` targets are untouched (`!ctx.standalone` guards).

Phase B (Wasm-native open-object runtime) and Phase C (Proxy refusal + Reflect dispatch) remain as follow-up work, per the issue's phased plan.

## Test plan
- [x] `tests/issue-1472-standalone-object-imports.test.ts` (4 tests): typed object literal + class instance compile standalone with zero host object imports; open `any` object refuses with the #1472 Phase B error; default `gc` target still uses the JS-host object machinery.
- [x] `tsc --noEmit` clean; biome lint clean on changed files.
- [x] Existing standalone tests (`issue-1470-standalone-string-imports`, `native-strings-standalone`) still pass.
- [ ] CI: full test262 (default mode unaffected by the standalone-only gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)