### PR TITLE
fix(#1589A): preserve empty-object field values + spec HasProperty for array-like search

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6980,6 +6980,28 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
       wasmType = { kind: "externref" };
     }
     const callSigs = propType.getCallSignatures();
+    // (#1589A) When the property's TS type has zero own properties (an empty
+    // `{}` value) but resolveWasmType picked a `ref`/`ref_null` to a struct,
+    // widen the field to externref. An empty object literal is constructed at
+    // runtime as a host externref (`__new_plain_object`), not as a WasmGC
+    // struct instance — so coercing it into a `ref null <struct>` field fails
+    // the `ref.test` and stores `ref.null`. Reading the field back through
+    // `__sget_<i>` then yields null, which (a) loses the value and (b) makes
+    // `__extern_has_idx` report the property as absent, breaking spec
+    // HasProperty (§7.3.12) for `Array.prototype.indexOf.call`-style loops.
+    // Storing the value as externref preserves both the value and presence.
+    // (`__Date` is the i64-timestamp struct, never an empty object literal.)
+    if (
+      (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+      callSigs.length === 0 &&
+      propType.getProperties().length === 0
+    ) {
+      const refTypeIdx = (wasmType as { typeIdx: number }).typeIdx;
+      const refStructName = ctx.typeIdxToStructName.get(refTypeIdx);
+      if (refStructName !== "__Date") {
+        wasmType = { kind: "externref" };
+      }
+    }
     // For valueOf/toString callable properties, store as eqref instead of externref
     // so coercion can recover the closure and call it via call_ref
     if (wasmType.kind === "externref" && callSigs.length > 0 && (prop.name === "valueOf" || prop.name === "toString")) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3425,10 +3425,16 @@ assert._isSameValue = isSameValue;
           const exports = callbackState?.getExports();
           if (typeof exports?.[`__sget_${strKey}`] === "function") {
             try {
-              const v = exports[`__sget_${strKey}`](obj);
-              if (v != null) return 1;
+              // (#1589A) HasProperty (spec §7.3.12) is true for any own
+              // property regardless of value — including null/undefined. A
+              // struct getter that returns *at all* (even null) proves the
+              // field exists on this struct shape. Only a throw means "this
+              // field is not defined on this struct variant" (opaque-struct
+              // access error), so we fall through to `return 0` in that case.
+              exports[`__sget_${strKey}`](obj);
+              return 1;
             } catch {
-              /* not a field on this variant */
+              /* getter not defined for this struct variant — fall through */
             }
           }
           return 0;
@@ -3460,10 +3466,14 @@ assert._isSameValue = isSameValue;
             const exports = callbackState?.getExports();
             if (typeof exports?.[`__sget_${key}`] === "function") {
               try {
-                const v = exports[`__sget_${key}`](obj);
-                if (v !== undefined) return 1;
+                // (#1589A) Mirror __extern_has_idx: a getter that returns at
+                // all (even null/undefined) proves the field exists on this
+                // struct shape — HasProperty (§7.3.12) is value-independent.
+                // Only a throw signals "field not defined on this variant".
+                exports[`__sget_${key}`](obj);
+                return 1;
               } catch {
-                /* not a field on this variant */
+                /* getter not defined for this struct variant — fall through */
               }
             }
           }

--- a/tests/issue-1589a.test.ts
+++ b/tests/issue-1589a.test.ts
@@ -1,0 +1,113 @@
+// Regression test for #1589A (parent #1589 hot spot A):
+//
+// `Array.prototype.{indexOf,lastIndexOf}.call(obj, target)` on an object
+// literal whose values are empty `{}` objects and whose `length` is the
+// 2^32 boundary used to hang for ~30s and pin the test262 compile_timeout
+// budget. Two compounding bugs:
+//
+//   Bug 1 (codegen): an empty-object (`{}`) property value was registered as
+//   a ref-to-empty-struct field type. At construction the value is a host
+//   externref, so the externref→(ref null struct) coercion failed the
+//   ref.test and stored ref.null. Reading the field back yielded null,
+//   losing the value. Fixed in ensureStructForType (src/codegen/index.ts):
+//   a zero-own-property value type is now widened to externref.
+//
+//   Bug 2 (runtime): `__extern_has_idx` treated "struct getter returns null"
+//   as "property absent" (`if (v != null) return 1`). Spec HasProperty
+//   (§7.3.12) is true for any own property regardless of value. Fixed so a
+//   getter that returns at all (even null) reports presence; only a throw
+//   means "field not defined on this variant".
+//
+// Affected test262:
+//   built-ins/Array/prototype/indexOf/15.4.4.14-3-28.js
+//   built-ins/Array/prototype/indexOf/15.4.4.14-3-29.js
+//   built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-28.js
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function compileAndRun(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile failed: " + r.errors?.[0]?.message);
+  const imports = buildImports((r as any).imports ?? [], undefined, (r as any).stringPool ?? []);
+  const { instance } = await WebAssembly.instantiate(r.binary!, imports);
+  (imports as any).setExports?.(instance.exports);
+  return (instance.exports as any).test?.();
+}
+
+describe("#1589A — Array.prototype.{indexOf,lastIndexOf}.call on empty-object-valued array-likes", () => {
+  it("indexOf finds an empty-object value at index 0", async () => {
+    const out = await compileAndRun(`
+      export function test(): number {
+        var targetObj = {};
+        var obj = { 0: targetObj, 1: targetObj, length: 2 };
+        return Array.prototype.indexOf.call(obj, targetObj);
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("indexOf finds an empty-object value at a non-zero index", async () => {
+    const out = await compileAndRun(`
+      export function test(): number {
+        var t = {};
+        var obj = { 0: {}, 1: t, length: 2 };
+        return Array.prototype.indexOf.call(obj, t);
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("indexOf returns -1 when the empty-object value is not present", async () => {
+    const out = await compileAndRun(`
+      export function test(): number {
+        var t = {};
+        var obj = { 0: {}, 1: {}, length: 2 };
+        return Array.prototype.indexOf.call(obj, t);
+      }
+    `);
+    expect(out).toBe(-1);
+  });
+
+  it("lastIndexOf finds an empty-object value", async () => {
+    const out = await compileAndRun(`
+      export function test(): number {
+        var t = {};
+        var obj = { 0: t, 1: {}, length: 2 };
+        return Array.prototype.lastIndexOf.call(obj, t);
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("indexOf on a length=2^32 array-like short-circuits at index 0 (no hang)", async () => {
+    // The test262 shape: target lives at index 0 so HasProperty must report
+    // present on the first iteration and the loop returns 0 immediately
+    // instead of scanning 4.29B indices.
+    const out = await compileAndRun(`
+      export function test(): number {
+        var targetObj = {};
+        var obj = { 0: targetObj, 4294967294: targetObj, 4294967295: targetObj, length: 4294967296 };
+        return Array.prototype.indexOf.call(obj, targetObj);
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("regression guard: a thrown Error (named struct) still constructs and reads back", async () => {
+    // Bug 1's widening must only fire for zero-own-property values, never for
+    // named structs like Error. This exercises the dedup-collapse path the
+    // architect flagged as the high-risk collateral.
+    const out = await compileAndRun(`
+      export function test(): number {
+        try {
+          throw new Error("boom");
+        } catch (e: any) {
+          return e.message === "boom" ? 1 : 0;
+        }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1589A (parent #1589 hot spot A). Two compounding bugs made
`Array.prototype.{indexOf,lastIndexOf}.call(obj, target)` on an object literal
with empty-`{}` values and a 2^32 `length` hang ~30s, pinning the test262
`compile_timeout` budget for three tests.

- **Bug 1 (codegen, `ensureStructForType` in `src/codegen/index.ts`)**: an
  empty-object (`{}`) property value was registered as a ref-to-empty-struct
  field type. At construction the value is a host externref, so the
  externref→`(ref null struct)` coercion failed the `ref.test` and stored
  `ref.null`, losing the value on readback. A property whose TS type has zero
  own properties (and no call signatures) is now widened to externref. `__Date`
  is excluded.
- **Bug 2 (runtime, `__extern_has_idx` / `__extern_has` in `src/runtime.ts`)**:
  treated "struct getter returns null" as "property absent". Spec HasProperty
  (ECMA-262 §7.3.12) is true for any own property regardless of value. A getter
  that returns at all (even null) now reports presence; only a throw means the
  field is not defined on that struct variant.

## Affected test262 (expect compile_timeout → pass)
- `built-ins/Array/prototype/indexOf/15.4.4.14-3-28.js`
- `built-ins/Array/prototype/indexOf/15.4.4.14-3-29.js`
- `built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-28.js`

## Test plan
- [x] New `tests/issue-1589a.test.ts` (6 cases) — indexOf/lastIndexOf on
      empty-object-valued array-likes, the 2^32 boundary short-circuit, and an
      Error-construction regression guard. All pass.
- [x] `tests/issue-1360.test.ts` (array-like search) — 37/37 pass, no regressions.
- [x] `npx tsc --noEmit` clean; prettier clean on changed files.
- [x] Struct-heavy suites (anon-struct, class-method-struct-new, json-stringify-structs,
      empty-object-widening): 8 pre-existing failures are identical on origin/main —
      this change introduces zero new failures.
- [ ] Full test262 CI is the final acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)