### PR TITLE
fix(#1471): Wasm-native numeric box/unbox in standalone mode (no JS host)

### DIFF
--- a/plan/issues/sprints/55/1471-no-js-host-boxing-unboxing.md
+++ b/plan/issues/sprints/55/1471-no-js-host-boxing-unboxing.md
@@ -2,7 +2,7 @@
 id: 1471
 sprint: 55
 title: "host-independence: eliminate JS host boxing/unboxing for standalone Wasm"
-status: ready
+status: in-progress
 created: 2026-05-20
 priority: high
 feasibility: medium
@@ -565,3 +565,57 @@ Cross-issue ordering:
   (anyref slots, vtable-driven dispatch). #1472 also needs
   `$__to_primitive_wasm` to land fully.
 - #1474 is independent (Phase 1 is just a compile-time error).
+
+## Implementation Notes (Phase 1 — landed)
+
+The `--target wasi` path already had a complete Wasm-native implementation
+of the box / unbox / typeof / is_truthy helpers
+(`addUnionImportsAsNativeFuncs` in `src/codegen/index.ts`, built on a
+`__box_number_struct` WasmGC struct — the `$BoxedNumber` shape from the
+spec). It registers `__box_number`, `__unbox_number`, `__box_boolean`,
+`__unbox_boolean`, `__is_truthy`, and the `__typeof_*` family in
+`ctx.funcMap` so the ~45 existing call sites
+(`ctx.funcMap.get("__unbox_number")` etc.) resolve to in-module funcs with
+no `env::*` host import.
+
+Phase 1 reuses that infrastructure rather than duplicating it:
+
+1. **`addUnionImports` gate** widened from `ctx.wasi` to
+   `ctx.wasi || ctx.standalone` — standalone now routes to the native funcs.
+2. **`ensureLateImport`** (`src/codegen/expressions/late-imports.ts`) now
+   detects the union-helper names (`UNION_NATIVE_HELPER_NAMES`) and, under
+   no-JS-host mode, routes them through `addUnionImports` instead of adding
+   an unsatisfiable `env::*` import. This closes the ~45 direct
+   `ensureLateImport(ctx, "__box_number", …)` call sites (array-methods,
+   expressions/calls, property-access, etc.) that previously bypassed the
+   native path even under WASI. The cross-module cycle
+   (late-imports → index) is broken with a lazy `registerAddUnionImports`
+   binding in `shared.ts`, mirroring the existing `ensureAnyHelpers`
+   pattern.
+
+Net effect: `--target standalone` (and, as a bonus, `--target wasi`) emit
+**zero** `env::__box_*` / `__unbox_*` / `__typeof*` / `__is_truthy` host
+imports for `any`/number/boolean/typeof/if-truthy programs.
+
+### Deferred to follow-ups (documented in the plan above)
+
+- **i31ref SMI fast path** — the IR `Instr` union and binary emitter do not
+  yet carry `ref.i31` / `i31.get_s`; Phase 1 uses the `$BoxedNumber` struct
+  for every number (correctness-complete, perf optimisation deferred).
+- **`__to_primitive`, `__box_symbol`, full `__typeof`-string result** —
+  these are separate import names not covered by `addUnionImports` and are
+  scoped to later phases per the issue's dependency ordering.
+
+## Test Results
+
+`tests/issue-1471.test.ts` — 8/8 pass:
+- integer / negative / float box+unbox round-trip through `any` (standalone)
+- truthy / falsy `any` in if-condition (native `__is_truthy`)
+- mixed `any` program emits **zero** box/unbox/typeof host imports
+- control: default JS-host mode still emits `__box_number`/`__unbox_number`
+
+Regression spot-check (vitest): `issue-865-wasi-polyfill`,
+`issue-1470-standalone-string-imports`, `native-strings-standalone`,
+`typeof-expression`, `union-narrowing`, `call-arg-type-coercion` — all
+green (34 tests). All standalone modules instantiate with an empty import
+object `{}`.

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -10,6 +10,29 @@ import type { Instr, ValType } from "../../ir/types.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { addImport } from "../registry/imports.js";
 import { addFuncType } from "../registry/types.js";
+import { addUnionImportsViaRegistry } from "../shared.js";
+
+/**
+ * #1471: helper names that `addUnionImports` provides Wasm-native
+ * implementations for under no-JS-host mode (WASI / standalone). When any of
+ * these is requested via `ensureLateImport` while there is no JS host, route
+ * through `addUnionImports` (which emits in-module funcs registered in
+ * `ctx.funcMap`) instead of adding an unsatisfiable `env::*` host import.
+ */
+const UNION_NATIVE_HELPER_NAMES = new Set([
+  "__box_number",
+  "__unbox_number",
+  "__box_boolean",
+  "__unbox_boolean",
+  "__is_truthy",
+  "__typeof_number",
+  "__typeof_boolean",
+  "__typeof_string",
+  "__typeof_undefined",
+  "__typeof_object",
+  "__typeof_function",
+  "__typeof",
+]);
 
 /**
  * Shift function indices after a late import addition. This must update all
@@ -141,6 +164,15 @@ export function ensureLateImport(
 ): number | undefined {
   const existing = ctx.funcMap.get(name);
   if (existing !== undefined) return existing;
+  // #1471: under no-JS-host mode, the box/unbox/typeof/is_truthy helpers have
+  // Wasm-native implementations emitted by addUnionImports. Route there so the
+  // module needs no unsatisfiable `env::*` host import. addUnionImports is
+  // idempotent and registers every name in UNION_NATIVE_HELPER_NAMES, so a
+  // single call resolves this lookup.
+  if ((ctx.wasi || ctx.standalone) && UNION_NATIVE_HELPER_NAMES.has(name)) {
+    addUnionImportsViaRegistry(ctx);
+    return ctx.funcMap.get(name);
+  }
   // Record importsBefore on the FIRST deferred addition in this batch
   if (ctx.pendingLateImportShift === null) {
     ctx.pendingLateImportShift = { importsBefore: ctx.numImportFuncs };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -48,7 +48,7 @@ import {
   getOrRegisterVecType,
 } from "./registry/types.js";
 import { exportDrainMicrotasksIfRegistered, getDrainFuncIdxForWasiStart } from "./async-scheduler.js";
-import { registerAddStringImports } from "./shared.js";
+import { registerAddStringImports, registerAddUnionImports } from "./shared.js";
 import { stackBalance } from "./stack-balance.js";
 
 // ── Extracted sub-modules ──────────────────────────────────────────────────
@@ -4641,6 +4641,9 @@ export function addStringImports(ctx: CodegenContext): void {
 // Register addStringImports so any-helpers.ts can call it via the delegate
 // (breaks circular dep: index.ts → any-helpers.ts → shared.ts ← index.ts)
 registerAddStringImports(addStringImports);
+// #1471: lets late-imports.ts route box/unbox/typeof/is_truthy names to the
+// in-module native funcs under no-JS-host mode without an import cycle.
+registerAddUnionImports(addUnionImports);
 
 /** Parse a RegExp literal text (e.g. "/\\d+/gi") into pattern and flags */
 export function parseRegExpLiteral(text: string): { pattern: string; flags: string } {
@@ -5803,13 +5806,14 @@ export function addUnionImports(ctx: CodegenContext): void {
   if (ctx.hasUnionImports) return;
   ctx.hasUnionImports = true;
 
-  // Under `--target wasi` (#1180): emit Wasm-native implementations of the
-  // box / unbox / typeof / is_truthy helpers instead of `env::*` host
-  // imports, since wasmtime cannot satisfy the env::* imports without a JS
-  // host. The native impls preserve the same name + signature so existing
-  // call sites (`ctx.funcMap.get("__unbox_number")` etc.) work unchanged.
+  // Under `--target wasi` (#1180) and `--standalone` (#1471): emit Wasm-native
+  // implementations of the box / unbox / typeof / is_truthy helpers instead of
+  // `env::*` host imports, since a pure-Wasm engine (wasmtime, wasmer) cannot
+  // satisfy the env::* imports without a JS host. The native impls preserve the
+  // same name + signature so existing call sites
+  // (`ctx.funcMap.get("__unbox_number")` etc.) work unchanged.
   // Same dual-mode pattern as #679 (strings) and #682 (RegExp).
-  if (ctx.wasi) {
+  if (ctx.wasi || ctx.standalone) {
     addUnionImportsAsNativeFuncs(ctx);
     return;
   }

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -270,6 +270,26 @@ export function registerEnsureAnyHelpers(fn: EnsureAnyHelpersFn): void {
   _ensureAnyHelpers = fn;
 }
 
+// ── addUnionImports (lazy binding to avoid index.ts ↔ late-imports.ts cycle) ──
+// #1471: late-imports.ts needs to route box/unbox/typeof/is_truthy helper
+// names to the in-module native funcs under no-JS-host mode, but
+// addUnionImports lives in index.ts which already imports ensureLateImport.
+// Break the cycle the same way ensureAnyHelpers does.
+
+type AddUnionImportsFn = (ctx: CodegenContext) => void;
+
+let _addUnionImports: AddUnionImportsFn = () => {
+  throw new Error("addUnionImports not yet registered");
+};
+
+export function registerAddUnionImports(fn: AddUnionImportsFn): void {
+  _addUnionImports = fn;
+}
+
+export function addUnionImportsViaRegistry(ctx: CodegenContext): void {
+  _addUnionImports(ctx);
+}
+
 export function ensureAnyHelpers(ctx: CodegenContext): void {
   _ensureAnyHelpers(ctx);
 }

--- a/tests/issue-1471.test.ts
+++ b/tests/issue-1471.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1471 — eliminate JS-host numeric boxing/unboxing for standalone Wasm.
+ *
+ * In standalone (and WASI) mode the compiler must not emit `env::__box_number`
+ * / `env::__unbox_number` (and the related typeof / is_truthy) host imports,
+ * because a pure-Wasm engine cannot satisfy them. The dual-mode path
+ * (`addUnionImportsAsNativeFuncs`, gated on `ctx.wasi || ctx.standalone`)
+ * provides in-module WasmGC `$BoxedNumber`-struct helpers instead. This
+ * mirrors the #679 (strings) / #682 (RegExp) dual-backend pattern.
+ *
+ * These tests assert two things per case:
+ *   1. The compiled standalone module instantiates with an EMPTY import object
+ *      (proving no host import is required).
+ *   2. The boxed-then-unboxed value round-trips to the correct number.
+ *
+ * A control case proves the default (JS-host) path is unchanged — it still
+ * emits the host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const BOX_UNBOX_IMPORT_RE = /__box_|__unbox_|__to_primitive|__to_boolean|__typeof|__is_truthy/;
+
+async function compileStandalone(src: string): Promise<{ binary: Uint8Array; hostImports: string[] }> {
+  const r = compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostImports = WebAssembly.Module.imports(mod)
+    .filter((i) => BOX_UNBOX_IMPORT_RE.test(i.name))
+    .map((i) => `${i.module}::${i.name}`);
+  return { binary: r.binary, hostImports };
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const { binary, hostImports } = await compileStandalone(src);
+  // No host imports → instantiate with an empty import object.
+  expect(hostImports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#1471 standalone numeric box/unbox — no JS host imports", () => {
+  it("boxes and unboxes an integer through `any`", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let x: any = 1 + 2; let y: number = x; return y; }`),
+    ).toBe(3);
+  });
+
+  it("round-trips a positive integer with arithmetic", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let x: any = 42; let y: number = x; return y * 2; }`),
+    ).toBe(84);
+  });
+
+  it("round-trips a negative integer", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let a: any = -5; let b: number = a; return b; }`),
+    ).toBe(-5);
+  });
+
+  it("round-trips a float", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let a: any = 3.5; let b: number = a; return b + 0.5; }`),
+    ).toBe(4);
+  });
+
+  it("evaluates a truthy `any` in an if-condition (is_truthy native helper)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let x: any = 1; if (x) { return 11; } return 0; }`),
+    ).toBe(11);
+  });
+
+  it("evaluates a falsy `any` in an if-condition", async () => {
+    expect(
+      await runStandalone(`export function test(): number { let x: any = 0; if (x) { return 11; } return 22; }`),
+    ).toBe(22);
+  });
+
+  it("emits zero box/unbox/typeof host imports for a mixed `any` program", async () => {
+    const { hostImports } = await compileStandalone(`
+      export function test(): number {
+        let x: any = 10;
+        let y: any = 20;
+        let z: number = x;
+        let w: number = y;
+        if (x) { return z + w; }
+        return 0;
+      }
+    `);
+    expect(hostImports).toEqual([]);
+  });
+});
+
+describe("#1471 default (JS-host) path is unchanged", () => {
+  it("still emits the __box_number / __unbox_number host imports in default mode", async () => {
+    const r = compile(`export function test(): number { let x: any = 1 + 2; let y: number = x; return y; }`, {
+      fileName: "test.ts",
+    });
+    expect(r.success).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    const names = WebAssembly.Module.imports(mod).map((i) => i.name);
+    expect(names).toContain("__box_number");
+    expect(names).toContain("__unbox_number");
+  });
+});


### PR DESCRIPTION
## Summary
- Standalone (`--target standalone`) modules no longer emit unsatisfiable `env::__box_number` / `__unbox_number` / `__typeof*` / `__is_truthy` host imports, so they instantiate under pure-Wasm engines (wasmtime, wasmer) with an empty import object.
- Reuses the existing WASI WasmGC-native implementation (`addUnionImportsAsNativeFuncs`, built on a `$BoxedNumber`-shaped struct) rather than duplicating it: the native-funcs gate is widened from `ctx.wasi` to `ctx.wasi || ctx.standalone`.
- Routes the ~45 direct `ensureLateImport("__box_number", …)` call sites (array-methods, expressions/calls, property-access, …) through the native path under no-JS-host mode — they previously bypassed it even under WASI. The late-imports → index module cycle is broken with a lazy `registerAddUnionImports` binding in `shared.ts`, mirroring the existing `ensureAnyHelpers` pattern.

Default JS-host path is unchanged (control test asserts the host imports are still emitted in default mode). i31ref SMI fast path and `__to_primitive` / `__box_symbol` are deferred follow-ups documented in the issue plan.

## Test plan
- [x] `tests/issue-1471.test.ts` — 8/8 pass: integer/negative/float box+unbox round-trip through `any` (standalone), truthy/falsy `any` if-condition (native `__is_truthy`), mixed-`any` program emits zero box/unbox/typeof host imports, control case for unchanged default mode
- [x] Regression spot-check: `issue-865-wasi-polyfill`, `issue-1470-standalone-string-imports`, `native-strings-standalone`, `typeof-expression`, `union-narrowing`, `call-arg-type-coercion` all green (34 tests)
- [x] All standalone modules instantiate with `{}` (no imports required)
- [ ] CI: full test262 + quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)