### PR TITLE
fix(#1473): no-JS-host error construction + throw/catch/instanceof for standalone

### DIFF
--- a/plan/issues/sprints/55/1473-no-js-host-error-exceptions.md
+++ b/plan/issues/sprints/55/1473-no-js-host-error-exceptions.md
@@ -2,7 +2,7 @@
 id: 1473
 sprint: 55
 title: "host-independence: eliminate JS host error/exception ops for standalone Wasm"
-status: ready
+status: in-progress
 created: 2026-05-20
 priority: high
 feasibility: medium
@@ -496,3 +496,60 @@ Cross-issue ordering:
   WASI mode (uses the native-string bridge), so the gate is more
   about consistency than correctness.
 - #1473 is independent of #1472; can land in parallel.
+
+## Test Results (2026-05-23)
+
+Implemented the no-JS-host throw/catch/instanceof path for `--target standalone`
+(and extended the existing `--target wasi` Error infra to standalone). A
+`noJsHost(ctx) = ctx.wasi || ctx.standalone` predicate gates all changes; the
+JS-host (`gc`) code paths are untouched.
+
+Changes:
+- `expressions/helpers.ts`: added `noJsHost()` + `emitThrowReferenceError()`;
+  `emitThrowTypeError()` now registers the in-module `__new_TypeError`
+  constructor in noJsHost mode (so `ensureLateImport` resolves it without
+  adding a host import).
+- `expressions/identifiers.ts`: `emitLocalTdzCheck`, `emitStaticTdzThrow`, and
+  the undeclared-identifier site now build a ReferenceError instance via
+  `emitThrowReferenceError` in noJsHost mode. Added a Wasm-native
+  `e instanceof TypeError/Error/...` path that reads the `$Error_struct` `$tag`
+  field (no `__instanceof` host import) when the RHS is a builtin Error name.
+- `destructuring-params.ts` / `statements/destructuring.ts`: destructure-null
+  TypeError now uses the in-module constructor in noJsHost mode.
+- `expressions/calls.ts` / `string-ops.ts`: BigInt/Symbol→Number TypeError
+  throws use `emitThrowTypeError` in noJsHost mode.
+- `statements/exceptions.ts`: catch-with-binding omits the `catch_all` +
+  `__get_caught_exception` branch in noJsHost mode (dead code — all throws
+  come through the `$exc` tag; Wasm traps are uncatchable). The
+  finally-without-catch `catch_all` (finally + rethrow) is host-independent
+  and retained.
+- `declarations.ts`, `expressions/new-super.ts`, `property-access.ts`:
+  extended the `ctx.wasi` Error-constructor / `err.message` struct.get gating
+  to `ctx.wasi || ctx.standalone`.
+
+Validation (`tsc --noEmit` clean):
+- New `tests/issue-1473.test.ts` — 8/8 pass. Confirms a standalone build emits
+  none of the banned imports (`__throw_type_error`, `__throw_reference_error`,
+  `__get_caught_exception`, `__new_*`) and that, under Node WebAssembly with
+  only generic non-error stubs (`__box_number`, `__extern_get`), throw/catch
+  binds a real TypeError, `e instanceof TypeError`, subtype discrimination
+  (`RangeError` ∉ `TypeError`), `instanceof Error` for all subtypes, and
+  nested try/catch rethrow all behave per spec.
+- `tests/issue-1104-phase1.test.ts`, `issue-1104-phase2.test.ts`,
+  `issue-1128-dstr-tdz.test.ts` — 28/28 pass (no regression).
+- Exception/TDZ/instanceof suite (`try-catch`, `try-catch-throw`, `instanceof`,
+  `tdz-reference-error`, `issue-723-tdz`, `issue-728-null-typeerror`,
+  `null-property-access-throws`, `global-index-shift-trycatch`): 31 pass / 8
+  fail — IDENTICAL to the origin/main baseline (the 8 failures are
+  pre-existing default-mode equivalence-harness mismatches, not introduced by
+  this change).
+
+Known limitations (documented, out of scope / deferred):
+- `.stack` is left empty (spec note: no engine cooperation in standalone).
+- Stack-overflow surfaces as a wasmtime trap, not a catchable RangeError.
+- `e.message` still uses the `__extern_get` host import when the catch binding
+  is `any` (not banned by the acceptance criteria); when the catch variable is
+  typed as an Error subtype the existing struct.get fast path applies.
+- A `class extends TypeError {}` declaration triggers a pre-existing standalone
+  `__str_flatten` validation issue in the string backend — unrelated to
+  error/exception codegen.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1197,7 +1197,9 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
     // constructors still emit host imports (they may resolve via user-supplied
     // imports at instantiation time, or fail loudly if missing). JS-host mode
     // is unchanged.
-    if (ctx.wasi && isWasiErrorName(name)) {
+    // #1473 — standalone mode has no JS host either, so it needs the same
+    // in-module Error constructors as WASI mode.
+    if ((ctx.wasi || ctx.standalone) && isWasiErrorName(name)) {
       emitWasiErrorConstructor(ctx, name, argCount);
       continue;
     }

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -17,6 +17,7 @@ import {
   resolveWasmType,
 } from "./index.js";
 import { addImport, addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { emitLocalTdzInit } from "./statements/tdz.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
@@ -188,9 +189,29 @@ export function buildDestructureNullThrow(ctx: CodegenContext, fctx?: FunctionCo
   const msg = "Cannot destructure 'null' or 'undefined'";
   addStringConstantGlobal(ctx, msg);
   const strIdx = ctx.stringGlobalMap.get(msg)!;
-  // Prefer host import so caller sees a genuine JS TypeError (constructor-matching
-  // tests such as `({constructor}) => constructor === TypeError` pass). Fall back
-  // to wasm throw+tag when a FunctionContext isn't available for late-import flush.
+  // #1473 — no JS host (wasi / standalone): build a TypeError INSTANCE via the
+  // in-module `__new_TypeError` constructor so `e instanceof TypeError`
+  // works under wasmtime, with no `__throw_type_error` host import. The
+  // constructor is registered in funcMap as an internal function, so
+  // ensureLateImport resolves it without adding an import (no index shift).
+  if (ctx.wasi || ctx.standalone) {
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+    const newTypeErrorIdx = ctx.funcMap.get("__new_TypeError");
+    const tagIdx = ensureExnTag(ctx);
+    if (newTypeErrorIdx !== undefined) {
+      return [
+        { op: "global.get", index: strIdx } as Instr,
+        { op: "call", funcIdx: newTypeErrorIdx } as Instr,
+        { op: "throw", tagIdx } as Instr,
+      ];
+    }
+    // Degrade to throwing the raw string with the same tag.
+    return [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr];
+  }
+  // JS-host: prefer the host import so the caller sees a genuine JS TypeError
+  // (constructor-matching tests such as `({constructor}) => constructor ===
+  // TypeError` pass). Fall back to wasm throw+tag when a FunctionContext isn't
+  // available for late-import flush.
   const throwIdx = ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
   if (throwIdx !== undefined && fctx) {
     flushLateImportShifts(ctx, fctx);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -88,7 +88,14 @@ import {
 import { compileOptionalCallExpression } from "./calls-optional.js";
 import { tryStaticEvalInline } from "./eval-inline.js";
 import { compileExternMethodCall, compileSpreadCallArgs, emitLazyProtoGet } from "./extern.js";
-import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
+import {
+  emitThrowTypeError,
+  getFuncParamTypes,
+  getWasmFuncReturnType,
+  isEffectivelyVoidReturn,
+  noJsHost,
+  wasmFuncReturnsVoid,
+} from "./helpers.js";
 import { analyzeTdzAccessByPos, emitLocalTdzCheck, emitStaticTdzThrow } from "./identifiers.js";
 import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
@@ -5497,17 +5504,24 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
               : "TypeError: Cannot convert a Symbol value to a number";
             addStringConstantGlobal(ctx, msg);
             const strIdx = ctx.stringGlobalMap.get(msg)!;
-            const throwIdx = ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
-            if (throwIdx !== undefined) {
-              flushLateImportShifts(ctx, fctx);
-              const throwFuncIdx = ctx.funcMap.get("__throw_type_error")!;
-              fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-              fctx.body.push({ op: "call", funcIdx: throwFuncIdx } as Instr);
+            // #1473 — no JS host: throw a TypeError INSTANCE via the in-module
+            // constructor (no `__throw_type_error` host import).
+            if (noJsHost(ctx)) {
+              emitThrowTypeError(ctx, fctx, msg);
               fctx.body.push({ op: "unreachable" } as Instr);
             } else {
-              const tagIdx = ensureExnTag(ctx);
-              fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-              fctx.body.push({ op: "throw", tagIdx } as Instr);
+              const throwIdx = ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
+              if (throwIdx !== undefined) {
+                flushLateImportShifts(ctx, fctx);
+                const throwFuncIdx = ctx.funcMap.get("__throw_type_error")!;
+                fctx.body.push({ op: "global.get", index: strIdx } as Instr);
+                fctx.body.push({ op: "call", funcIdx: throwFuncIdx } as Instr);
+                fctx.body.push({ op: "unreachable" } as Instr);
+              } else {
+                const tagIdx = ensureExnTag(ctx);
+                fctx.body.push({ op: "global.get", index: strIdx } as Instr);
+                fctx.body.push({ op: "throw", tagIdx } as Instr);
+              }
             }
             // After unreachable / throw, the wasm stack is polymorphic.
             // Push a sentinel matching the method's return type so any

--- a/src/codegen/expressions/helpers.ts
+++ b/src/codegen/expressions/helpers.ts
@@ -16,7 +16,18 @@ import { getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { addStringConstantGlobal, ensureExnTag } from "../registry/imports.js";
+import { emitWasiErrorConstructor } from "../registry/error-types.js";
 import { coerceType, ensureLateImport, flushLateImportShifts, valTypesMatch } from "../shared.js";
+
+/**
+ * #1473 — No-JS-host predicate. Both `--target wasi` and `--target standalone`
+ * run without a JS runtime, so neither can rely on host imports such as
+ * `__throw_type_error` / `__new_TypeError` resolving to JS constructors. In
+ * these modes the compiler emits Wasm-native Error constructors instead.
+ */
+export function noJsHost(ctx: CodegenContext): boolean {
+  return ctx.wasi || ctx.standalone;
+}
 
 /**
  * Emit a Wasm throw instruction with a string error message.
@@ -91,6 +102,13 @@ export function resolveDeclaringClassForPrivateName(
  * mode, but the throw is observable and the caller still aborts.
  */
 export function emitThrowTypeError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  // #1473 — in no-JS-host mode, register the in-module `__new_TypeError`
+  // constructor (emitWasiErrorConstructor) BEFORE resolving the funcIdx, so
+  // `ensureLateImport` finds the in-module function in funcMap and does NOT
+  // add an unsatisfiable `env::__new_TypeError` host import.
+  if (noJsHost(ctx)) {
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+  }
   addStringConstantGlobal(ctx, message);
   fctx.body.push(...stringConstantExternrefInstrs(ctx, message));
   const newTypeErrorIdx = ensureLateImport(ctx, "__new_TypeError", [{ kind: "externref" }], [{ kind: "externref" }]);
@@ -101,6 +119,42 @@ export function emitThrowTypeError(ctx: CodegenContext, fctx: FunctionContext, m
   // If the import isn't available, the message externref is still on the
   // stack — degrade to throwing a string. Both paths produce the same
   // exception tag.
+  const tagIdx = ensureExnTag(ctx);
+  fctx.body.push({ op: "throw", tagIdx });
+}
+
+/**
+ * #1473 — Emit a throw of a ReferenceError INSTANCE for TDZ / unresolved
+ * identifier references. Mirrors `emitThrowTypeError`.
+ *
+ * In no-JS-host mode (`--target wasi` / `--target standalone`), the
+ * ReferenceError is built via the in-module `__new_ReferenceError` function
+ * (emitted by `emitWasiErrorConstructor`), so no `env::__new_ReferenceError`
+ * host import is required. In JS-host mode the same import name resolves to
+ * the JS `ReferenceError` constructor.
+ *
+ * Either way the throw is observable in the user's catch block via the
+ * shared `$exc` tag, and `e instanceof ReferenceError` works through the
+ * `$Error_struct` `$tag` field discrimination.
+ */
+export function emitThrowReferenceError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  if (noJsHost(ctx)) {
+    emitWasiErrorConstructor(ctx, "ReferenceError", 1);
+  }
+  addStringConstantGlobal(ctx, message);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, message));
+  const newRefErrorIdx = ensureLateImport(
+    ctx,
+    "__new_ReferenceError",
+    [{ kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (newRefErrorIdx !== undefined) {
+    fctx.body.push({ op: "call", funcIdx: newRefErrorIdx });
+  }
+  // If the constructor isn't available, the message externref is still on the
+  // stack — degrade to throwing a string. Both paths produce the same tag.
   const tagIdx = ensureExnTag(ctx);
   fctx.body.push({ op: "throw", tagIdx });
 }

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -22,9 +22,72 @@ import { coerceType, compileExpression } from "../shared.js";
 import { emitTdzCheck } from "../statements.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { emitStringBuilderRead, getBuilderInfo } from "../string-builder.js";
-import { isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
+import { BUILTIN_TYPE_TAGS, isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
+import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error-types.js";
+import { allocLocal } from "../context/locals.js";
+import { emitThrowReferenceError, noJsHost } from "./helpers.js";
+
+/**
+ * #1473 — Build the set of `$Error_struct` `$tag` values compatible with an
+ * `instanceof <ctorName>` test in no-JS-host mode. For `instanceof Error` this
+ * is every Error subtype tag; for `instanceof TypeError` it is TypeError's own
+ * tag plus any descendant (none today). Mirrors `isBuiltinSubtype` over the
+ * error portion of the BUILTIN_TYPE_TAGS registry.
+ */
+function collectErrorInstanceOfTags(ctorName: string): number[] {
+  const errorNames = [
+    "Error",
+    "TypeError",
+    "RangeError",
+    "SyntaxError",
+    "URIError",
+    "EvalError",
+    "ReferenceError",
+    "AggregateError",
+  ] as const;
+  const tags: number[] = [];
+  for (const n of errorNames) {
+    if (isBuiltinSubtype(n, ctorName)) {
+      tags.push(BUILTIN_TYPE_TAGS[n]);
+    }
+  }
+  return tags;
+}
 
 export function emitLocalTdzCheck(ctx: CodegenContext, fctx: FunctionContext, name: string, flagIdx: number): void {
+  const msg = `${name} is not defined`;
+  // #1473 — no JS host: build the TDZ flag check and emit a ReferenceError
+  // INSTANCE throw inside the `then` branch via the in-module constructor
+  // helper (no `__throw_reference_error` host import).
+  if (noJsHost(ctx)) {
+    const boxed = fctx.boxedTdzFlags?.get(name);
+    if (boxed) {
+      fctx.body.push({ op: "local.get", index: boxed.localIdx });
+      fctx.body.push({ op: "struct.get", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 } as Instr);
+    } else {
+      fctx.body.push({ op: "local.get", index: flagIdx });
+    }
+    fctx.body.push({ op: "i32.eqz" });
+    // emitThrowReferenceError appends to fctx.body; capture into the `then`
+    // branch by swapping in a temporary body (tracked in savedBodies so any
+    // late-import index shift reaches it).
+    const savedBody = fctx.body;
+    fctx.savedBodies.push(savedBody);
+    fctx.body = [];
+    emitThrowReferenceError(ctx, fctx, msg);
+    fctx.body.push({ op: "unreachable" });
+    const then = fctx.body;
+    const si = fctx.savedBodies.lastIndexOf(savedBody);
+    if (si >= 0) fctx.savedBodies.splice(si, 1);
+    fctx.body = savedBody;
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then,
+      else: [],
+    });
+    return;
+  }
   const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
   flushLateImportShifts(ctx, fctx);
   // If the flag has been boxed in an i32 ref cell (captured by a closure —
@@ -40,7 +103,6 @@ export function emitLocalTdzCheck(ctx: CodegenContext, fctx: FunctionContext, na
   fctx.body.push({ op: "i32.eqz" });
   let then: Instr[];
   if (throwRefErrIdx !== undefined) {
-    const msg = `${name} is not defined`;
     addStringConstantGlobal(ctx, msg);
     const strIdx = ctx.stringGlobalMap.get(msg)!;
     then = [
@@ -307,10 +369,16 @@ function analyzeTdzAccessByPos(ctx: CodegenContext, varName: string, callNode: t
 
 /** Emit a static TDZ throw (guaranteed violation — no flag check needed). */
 export function emitStaticTdzThrow(ctx: CodegenContext, fctx: FunctionContext, name: string): void {
+  const msg = `${name} is not defined`;
+  // #1473 — no JS host: throw a ReferenceError INSTANCE built in-module.
+  if (noJsHost(ctx)) {
+    emitThrowReferenceError(ctx, fctx, msg);
+    fctx.body.push({ op: "unreachable" });
+    return;
+  }
   const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
   flushLateImportShifts(ctx, fctx);
   if (throwRefErrIdx !== undefined) {
-    const msg = `${name} is not defined`;
     addStringConstantGlobal(ctx, msg);
     const strIdx = ctx.stringGlobalMap.get(msg)!;
     fctx.body.push({ op: "global.get", index: strIdx } as Instr);
@@ -579,22 +647,29 @@ function compileIdentifier(ctx: CodegenContext, fctx: FunctionContext, id: ts.Id
   // lib.d.ts and should use the fallback default instead.
   const sym = ctx.checker.getSymbolAtLocation(id);
   if (!sym) {
-    // Truly undeclared variable — throw a proper ReferenceError instance
-    // via the `__throw_reference_error` host import. The previous emission
-    // was a raw `throw ref.null.extern`, which surfaced to JS as `null` so
-    // `e instanceof ReferenceError` was false (#1380, S11.9.1_A2.1_T3).
+    // Truly undeclared variable — throw a proper ReferenceError instance.
+    // The previous emission was a raw `throw ref.null.extern`, which surfaced
+    // to JS as `null` so `e instanceof ReferenceError` was false (#1380,
+    // S11.9.1_A2.1_T3).
+    const msg = `${name} is not defined`;
+    // #1473 — no JS host: build the ReferenceError instance in-module so
+    // `e instanceof ReferenceError` works under wasmtime, with no
+    // `__throw_reference_error` host import.
+    if (noJsHost(ctx)) {
+      emitThrowReferenceError(ctx, fctx, msg);
+      fctx.body.push({ op: "unreachable" });
+      return { kind: "externref" };
+    }
     const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
     flushLateImportShifts(ctx, fctx);
     if (throwRefErrIdx !== undefined) {
-      const msg = `${name} is not defined`;
       addStringConstantGlobal(ctx, msg);
       const strIdx = ctx.stringGlobalMap.get(msg)!;
       fctx.body.push({ op: "global.get", index: strIdx } as Instr);
       fctx.body.push({ op: "call", funcIdx: throwRefErrIdx } as Instr);
       fctx.body.push({ op: "unreachable" });
     } else {
-      // Standalone/WASI mode without `__throw_reference_error`: fall back to
-      // the raw exception-tag throw (no JS host to construct a ReferenceError).
+      // Fallback: raw exception-tag throw (no JS host to construct a ReferenceError).
       const tagIdx = ensureExnTag(ctx);
       fctx.body.push({ op: "ref.null.extern" } as Instr);
       fctx.body.push({ op: "throw", tagIdx });
@@ -807,6 +882,62 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   const staticResult = tryStaticInstanceOf(ctx, expr, ctorName);
   if (staticResult !== undefined) {
     return emitConstantInstanceOf(ctx, fctx, expr, staticResult);
+  }
+
+  // #1473 — no JS host: `e instanceof TypeError` (and other Error subtypes)
+  // where the LHS is a dynamic value (any/externref). The caught value is the
+  // `$Error_struct` externref produced by emitWasiErrorConstructor; discriminate
+  // by reading its `$tag` field (fieldIdx 0) and comparing against the set of
+  // tags compatible with `ctorName`. No `__instanceof` host import.
+  if (noJsHost(ctx) && (ctorName === "Error" || isWasiErrorName(ctorName))) {
+    const compatTags = collectErrorInstanceOfTags(ctorName);
+    const structIdx = getOrRegisterErrorStructType(ctx);
+    const leftType = compileExpression(ctx, fctx, expr.left);
+    if (leftType && leftType.kind !== "externref") {
+      // Numeric / boolean primitives are never Error instances.
+      if (leftType.kind === "i32" || leftType.kind === "f64" || leftType.kind === "i64") {
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "i32.const", value: 0 });
+        return { kind: "i32" };
+      }
+      coerceType(ctx, fctx, leftType, { kind: "externref" });
+    } else if (!leftType) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    // externref -> anyref, store in temp, ref.test $Error_struct, then read tag.
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    const anyLocalIdx = allocLocal(fctx, `__err_instanceof_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+    fctx.body.push({ op: "local.set", index: anyLocalIdx });
+    const elseBody: Instr[] = [
+      { op: "local.get", index: anyLocalIdx },
+      { op: "ref.cast", typeIdx: structIdx } as Instr,
+      { op: "struct.get", typeIdx: structIdx, fieldIdx: 0 } as Instr,
+    ];
+    if (compatTags.length === 1) {
+      elseBody.push({ op: "i32.const", value: compatTags[0]! });
+      elseBody.push({ op: "i32.eq" });
+    } else {
+      const tagLocalIdx = allocLocal(fctx, `__err_tag_${fctx.locals.length}`, { kind: "i32" });
+      elseBody.push({ op: "local.set", index: tagLocalIdx });
+      elseBody.push({ op: "local.get", index: tagLocalIdx });
+      elseBody.push({ op: "i32.const", value: compatTags[0]! });
+      elseBody.push({ op: "i32.eq" });
+      for (let i = 1; i < compatTags.length; i++) {
+        elseBody.push({ op: "local.get", index: tagLocalIdx });
+        elseBody.push({ op: "i32.const", value: compatTags[i]! });
+        elseBody.push({ op: "i32.eq" });
+        elseBody.push({ op: "i32.or" });
+      }
+    }
+    fctx.body.push({ op: "local.get", index: anyLocalIdx });
+    fctx.body.push({ op: "ref.test", typeIdx: structIdx } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: elseBody,
+      else: [{ op: "i32.const", value: 0 }],
+    });
+    return { kind: "i32" };
   }
 
   // Ensure the __instanceof host import exists

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1489,7 +1489,8 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // instead of a `env.__new_<Name>` host import that would leave the
       // module unsatisfiable at instantiation time. JS-host mode is unchanged.
       const importName = `__new_${ctorName}`;
-      if (ctx.wasi && isWasiErrorName(ctorName)) {
+      // #1473 — standalone mode also has no JS host; build the Error in-module.
+      if ((ctx.wasi || ctx.standalone) && isWasiErrorName(ctorName)) {
         emitWasiErrorConstructor(ctx, ctorName, 1);
         const internalFuncIdx = ctx.funcMap.get(importName);
         if (internalFuncIdx !== undefined) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -953,7 +953,7 @@ export function compilePropertyAccess(
   // $Error_struct) + struct.get`. If the receiver is already null at
   // runtime, `ref.cast` traps — but native JS has the same behaviour
   // (`null.message` throws), so the trap is acceptable Phase 1/2 semantics.
-  if (ctx.wasi && (propName === "message" || propName === "name")) {
+  if ((ctx.wasi || ctx.standalone) && (propName === "message" || propName === "name")) {
     const lhsTsName = objType.getSymbol()?.name;
     const isErrorLhs =
       lhsTsName !== undefined &&

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -20,6 +20,7 @@ import {
 import { resolveComputedKeyExpression } from "../literals.js";
 import { type BindingKind, buildDestructureNullThrow, destructureParamObject } from "../destructuring-params.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
+import { emitWasiErrorConstructor } from "../registry/error-types.js";
 import {
   addFuncType,
   getArrTypeIdxFromVec,
@@ -522,13 +523,22 @@ export function compileObjectDestructuring(
     return;
   }
 
-  // Pre-trigger the late import shift for the null-throw host import that the
-  // helper's buildDestructureNullThrow will request. If we don't, the helper
-  // builds its else-branch (destructInstrs) BEFORE the import is added, and
-  // those instructions retain stale funcIdx values that the shift can't reach
-  // (destructInstrs is not yet attached to fctx.body when the shift fires).
-  ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
-  flushLateImportShifts(ctx, fctx);
+  // Pre-trigger the function-index resolution for the throw that the helper's
+  // buildDestructureNullThrow will emit. If we don't, the helper builds its
+  // else-branch (destructInstrs) BEFORE the function index is finalized, and
+  // those instructions retain stale funcIdx values that a later shift can't
+  // reach (destructInstrs is not yet attached to fctx.body when the shift fires).
+  //
+  // #1473 — in no-JS-host mode the helper uses the in-module `__new_TypeError`
+  // constructor instead of the `__throw_type_error` host import. Register that
+  // constructor now (it lands in funcMap as an internal function, after all
+  // current imports, so it introduces no late-import index shift).
+  if (ctx.wasi || ctx.standalone) {
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+  } else {
+    ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
+    flushLateImportShifts(ctx, fctx);
+  }
 
   // Stash RHS in a temp local matching the resolved struct type so the helper
   // can use struct.get directly. Use the resolved structTypeIdx (which may have

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -424,9 +424,16 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
     }
     catches = [{ tagIdx, body: fctx.body }];
 
+    // #1473 — in no-JS-host mode (wasi / standalone) there is no JS sidecar and
+    // no engine-raised exception that doesn't come through our `$exc` tag (Wasm
+    // traps are not catchable). The `catch_all` + `__get_caught_exception`
+    // branch is therefore dead code — omit it so the module needs no
+    // `env::__get_caught_exception` host import.
+    const skipCatchAll = ctx.wasi || ctx.standalone;
+
     // Build "catch_all" body: no value on stack from catch_all itself.
     // Call __get_caught_exception host import to retrieve the foreign JS exception.
-    {
+    if (!skipCatchAll) {
       // Track tryBody and catch bodies in savedBodies so late imports
       // (e.g. __get_caught_exception) shift their function indices too.
       fctx.savedBodies.push(tryBody);

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -12,7 +12,7 @@ import { pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
-import { getFuncParamTypes } from "./expressions/helpers.js";
+import { emitThrowTypeError, getFuncParamTypes, noJsHost } from "./expressions/helpers.js";
 import { addStringImports, addUnionImports, flatStringType, nativeStringType, resolveWasmType } from "./index.js";
 import { ensureNativeStringExternBridge } from "./native-strings.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
@@ -1305,6 +1305,13 @@ function emitTypeErrorThrow(ctx: CodegenContext, fctx: FunctionContext, msg: str
   // to externref. In JS-host mode pull it from the imported string-constants
   // global so JS sees the same intern as `String.raw`-style literals.
   addStringConstantGlobal(ctx, msg);
+  // #1473 — no JS host: throw a TypeError INSTANCE via the in-module
+  // constructor (no `__throw_type_error` host import).
+  if (noJsHost(ctx)) {
+    emitThrowTypeError(ctx, fctx, msg);
+    fctx.body.push({ op: "unreachable" } as Instr);
+    return;
+  }
   const throwIdx = ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
   if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
     compileNativeStringLiteral(ctx, fctx, msg);

--- a/tests/issue-1473.test.ts
+++ b/tests/issue-1473.test.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1473 — Eliminate JS host error/exception ops for standalone Wasm.
+//
+// Before this change, every implicit/explicit throw and every catch that
+// inspected the caught value routed through JS host imports:
+//   - __throw_type_error      (spec-mandated TypeError throws)
+//   - __throw_reference_error  (TDZ / unresolved-identifier ReferenceError)
+//   - __get_caught_exception   (catch_all binding via a JS sidecar)
+//   - __new_<Name> / __instanceof (JS-constructed Error + instanceof)
+// None of those resolve under wasmtime / pure standalone Wasm.
+//
+// This issue makes `--target standalone` (and, for parity, `--target wasi`)
+// build Error instances with the in-module `__new_<Name>` constructors
+// (emitWasiErrorConstructor → $Error_struct), throw them through the existing
+// `$exc` tag, bind the caught value directly from the tag payload (no
+// catch_all sidecar), and discriminate `instanceof TypeError` / `Error` via
+// the struct's `$tag` field — all without any JS host.
+//
+// Scope of the assertions below:
+//   1. Import-section: a standalone build emits none of the banned error/
+//      exception host imports.
+//   2. Runtime (Node WebAssembly, no JS host): throw/catch binds a real Error
+//      instance; instanceof + subtype discrimination behave per spec.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const BANNED_STANDALONE_IMPORTS = [
+  "__throw_type_error",
+  "__throw_reference_error",
+  "__get_caught_exception",
+  "__new_TypeError",
+  "__new_ReferenceError",
+  "__new_RangeError",
+  "__new_SyntaxError",
+  "__new_Error",
+];
+
+function envImportNames(r: { imports: { module: string; name: string }[] }): string[] {
+  return r.imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+describe("#1473 — no-JS-host error/exception ops (standalone mode)", () => {
+  describe("import section", () => {
+    it("emits no banned error/exception host imports for throw + catch + instanceof", () => {
+      const src = `
+        export function test(): number {
+          try {
+            throw new TypeError("x");
+          } catch (e: any) {
+            return e instanceof TypeError ? 1 : 0;
+          }
+        }
+      `;
+      const r = compile(src, { fileName: "t.ts", target: "standalone" });
+      expect(r.success).toBe(true);
+      const env = envImportNames(r);
+      for (const banned of BANNED_STANDALONE_IMPORTS) {
+        expect(env).not.toContain(banned);
+      }
+    });
+
+    it("emits no __throw_reference_error import for a TDZ access", () => {
+      const src = `
+        export function test(): number {
+          let n = 0;
+          try {
+            n = x;
+            let x = 1;
+          } catch (e: any) {
+            n = e instanceof ReferenceError ? 1 : 0;
+          }
+          return n;
+        }
+      `;
+      const r = compile(src, { fileName: "t.ts", target: "standalone" });
+      expect(r.success).toBe(true);
+      expect(envImportNames(r)).not.toContain("__throw_reference_error");
+    });
+
+    it("the __new_<Name> error constructors are in-module functions, not imports", () => {
+      const src = `
+        export function test(): number {
+          try { throw new RangeError("r"); } catch (e: any) { return 1; }
+        }
+      `;
+      const r = compile(src, { fileName: "t.ts", target: "standalone" });
+      expect(r.success).toBe(true);
+      const env = envImportNames(r);
+      expect(env).not.toContain("__new_RangeError");
+      // The in-module function should appear in the emitted module text.
+      expect(r.wat).toContain("__new_RangeError");
+    });
+  });
+
+  describe("runtime (no JS host)", () => {
+    // The standalone error path still relies on a couple of generic, non-error
+    // host functions (number boxing, generic property get) that are out of
+    // scope for #1473's banned list. Supply minimal stubs so the module can be
+    // exercised under Node; the *error/exception* behaviour is pure Wasm.
+    const stubs = {
+      env: {
+        __box_number: (n: number) => n,
+        __extern_get: (obj: any, key: string) => (obj == null ? undefined : obj[key]),
+      },
+    };
+
+    async function run(src: string): Promise<unknown> {
+      const r = compile(src, { fileName: "t.ts", target: "standalone" });
+      expect(r.success).toBe(true);
+      const { instance } = await WebAssembly.instantiate(r.binary, stubs);
+      return (instance.exports.test as () => unknown)();
+    }
+
+    it("catch binds a TypeError instance: `e instanceof TypeError`", async () => {
+      const got = await run(`
+        export function test(): number {
+          try { throw new TypeError("x"); } catch (e: any) { return e instanceof TypeError ? 1 : 0; }
+        }
+      `);
+      expect(got).toBe(1);
+    });
+
+    it("subtype discrimination: a RangeError is not a TypeError", async () => {
+      const got = await run(`
+        export function test(): number {
+          try { throw new RangeError("r"); } catch (e: any) { return e instanceof TypeError ? 0 : 1; }
+        }
+      `);
+      expect(got).toBe(1);
+    });
+
+    it("a RangeError IS a RangeError", async () => {
+      const got = await run(`
+        export function test(): number {
+          try { throw new RangeError("r"); } catch (e: any) { return e instanceof RangeError ? 1 : 0; }
+        }
+      `);
+      expect(got).toBe(1);
+    });
+
+    it("every error subtype is `instanceof Error`", async () => {
+      const got = await run(`
+        export function test(): number {
+          let ok = 0;
+          try { throw new TypeError("a"); } catch (e: any) { if (e instanceof Error) ok++; }
+          try { throw new RangeError("b"); } catch (e: any) { if (e instanceof Error) ok++; }
+          try { throw new SyntaxError("c"); } catch (e: any) { if (e instanceof Error) ok++; }
+          try { throw new Error("d"); } catch (e: any) { if (e instanceof Error) ok++; }
+          return ok;
+        }
+      `);
+      expect(got).toBe(4);
+    });
+
+    it("typed catch + nested try/catch preserve the Error payload across rethrow", async () => {
+      const got = await run(`
+        export function test(): number {
+          try {
+            try { throw new TypeError("inner"); } catch (e: any) { throw e; }
+          } catch (e: any) {
+            return e instanceof TypeError ? 1 : 0;
+          }
+        }
+      `);
+      expect(got).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Standalone (`--target standalone`) and WASI builds now construct Error instances, throw spec-mandated TypeError/ReferenceError, bind caught errors, and evaluate `instanceof TypeError/Error/...` entirely in Wasm — no JS host imports. All changes are gated behind `noJsHost(ctx) = ctx.wasi || ctx.standalone`; the JS-host (`gc`) codegen paths are untouched.
- A standalone build now emits **zero** `env::__throw_type_error`, `env::__throw_reference_error`, `env::__get_caught_exception`, or `env::__new_<Name>` imports. The `__new_<Name>` Error constructors are emitted as in-module functions (`emitWasiErrorConstructor` → `$Error_struct`); `instanceof` discriminates via the struct's `$tag` field.

## Changes
- `expressions/helpers.ts`: add `noJsHost()` + `emitThrowReferenceError()`; `emitThrowTypeError()` registers the in-module `__new_TypeError` constructor in noJsHost mode.
- `expressions/identifiers.ts`: TDZ (`emitLocalTdzCheck`/`emitStaticTdzThrow`) + undeclared-identifier sites build a ReferenceError instance in-module; add a Wasm-native `instanceof Error/TypeError/...` path.
- `destructuring-params.ts`, `statements/destructuring.ts`, `expressions/calls.ts`, `string-ops.ts`: implicit TypeError throws use the in-module constructor in noJsHost mode.
- `statements/exceptions.ts`: omit the dead `catch_all` + `__get_caught_exception` branch in noJsHost mode (all throws come through the `$exc` tag; Wasm traps are uncatchable). The finally-without-catch `catch_all` is host-independent and retained.
- `declarations.ts`, `expressions/new-super.ts`, `property-access.ts`: extend the existing `ctx.wasi` Error-construction / `err.message` struct.get gating to `ctx.standalone`.

## Known limitations (documented in the issue, out of scope)
- `.stack` left empty (no engine cooperation in standalone); stack overflow surfaces as a wasmtime trap, not a catchable RangeError.
- `e.message` still uses `__extern_get` when the catch binding is `any` (not in the banned list); typed Error catch vars use the struct.get fast path.

## Test plan
- [x] `tsc --noEmit` clean
- [x] New `tests/issue-1473.test.ts` — 8/8 (import-section assertions + runtime throw/catch/instanceof/subtype under Node WebAssembly with only generic non-error stubs)
- [x] `issue-1104-phase1/phase2`, `issue-1128-dstr-tdz` — 28/28, no regression
- [x] Exception/TDZ/instanceof suite: 31 pass / 8 fail — identical to origin/main baseline (the 8 are pre-existing default-mode equivalence-harness mismatches, not introduced here)
- [ ] CI test262: no regression in `language/statements/try/**`, `language/expressions/throw/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)