### PR TITLE
feat(#1588): string encoding analysis (UTF-8/WTF-16 lattice) on IR alloc sites

### DIFF
--- a/docs/adr/0015-string-encoding-tracking.md
+++ b/docs/adr/0015-string-encoding-tracking.md
@@ -1,0 +1,122 @@
+# ADR-0015: String encoding tracking
+
+Status: Accepted
+
+## Context
+
+JavaScript strings are WTF-16: sequences of 16-bit code units with no
+requirement that surrogate pairs be well-formed (`String.fromCharCode(0xD800)`
+is a single unpaired high surrogate). The WebAssembly Component Model `string`
+type, by contrast, is a sequence of Unicode scalar values, canonically
+transferred as UTF-8 — there is no UTF-8 encoding for an unpaired surrogate.
+
+When a JS string crosses a Component boundary today it must be scanned for
+scalar correctness and re-encoded WTF-16 → UTF-8, which allocates and copies.
+For long strings, or high-frequency small-string transfers (logging, RPC,
+structured output), this dominates the boundary cost.
+
+In practice most strings at a boundary originate from sources that cannot
+introduce unpaired surrogates (source literals, `JSON.parse`,
+`TextDecoder.decode`, concatenations of such strings). If the compiler can
+prove a string is well-formed UTF-8, the boundary can use a cheap path.
+
+This builds on ADR-0013 (explicit allocation sites): encoding annotations are
+attached to string `AllocSite`s via the registry's namespaced metadata channel.
+
+## Decision
+
+Introduce a static, advisory **encoding lattice** and a forward analysis pass
+(`src/ir/analysis/encoding.ts`) that annotates string allocation sites in the
+`AllocSiteRegistry` under the `encoding` namespace
+(`ALLOC_NAMESPACES.encoding`). The analysis never mutates the IR and is inert
+at lowering, so emitted Wasm is byte-identical whether or not it runs.
+
+### Lattice
+
+```
+              wtf16            (top — most permissive, conservative default)
+                │
+          utf8-guaranteed
+                │
+              ascii            (bottom — strongest claim, code points ≤ 0x7F)
+```
+
+`ascii ⊑ utf8-guaranteed ⊑ wtf16`. The join (least upper bound) is the
+conservative combination: any operand `wtf16` forces `wtf16`; otherwise
+`utf8-guaranteed`, unless both operands are `ascii` (then `ascii`).
+
+| Left            | Right             | Result            |
+|-----------------|-------------------|-------------------|
+| `ascii`         | `ascii`           | `ascii`           |
+| `ascii`         | `utf8-guaranteed` | `utf8-guaranteed` |
+| `utf8-guaranteed` | `utf8-guaranteed` | `utf8-guaranteed` |
+| any             | `wtf16`           | `wtf16`           |
+
+### Origin rules (Phase 1)
+
+- **String literal**: classify by code units — `ascii` if all units ≤ 0x7F;
+  else `utf8-guaranteed` if no lone surrogate; else `wtf16` (a literal
+  containing a lone surrogate, e.g. via an escape, cannot be valid UTF-8).
+
+Phase 2 origins (deferred — see below): `JSON.parse` (UTF-8 per RFC 8259),
+`JSON.stringify` (escapes lone surrogates per ES2019+ §24.5.2.2),
+`TextDecoder.decode` (UTF-8 per WHATWG Encoding), `fetch().text()`.
+
+### Propagation rules (Phase 1)
+
+- **`s1 + s2` / template concat** (`string.concat`): join the operand
+  encodings per the lattice. Concatenating two well-formed UTF-8 strings
+  cannot introduce a lone surrogate; concatenating two ASCII strings stays
+  ASCII. (A WTF-16 operand forces `wtf16`, which conservatively covers the
+  surrogate-split-across-the-seam case.)
+
+Phase 2 propagation (deferred): `.toUpperCase`/`.toLowerCase`/`.trim`/
+`.normalize` (preserve), `.slice` on statically known code-point boundaries
+(preserve else drop), `.repeat`/`.padStart`/`.padEnd` (preserve),
+`.split`/`.replace` (conditional). Any operation without an explicit rule
+drops to `wtf16`.
+
+### Component Model boundary integration (deferred to Phase 2/3)
+
+The boundary lowering will read the annotation and select a path: zero-copy
+for `ascii`/`utf8-guaranteed` (when the runtime string representation
+permits), and the existing scan-and-encode path for `wtf16`. Two storage
+strategies are on the table — **dual storage** (`(array i8)` for proven-UTF-8
+allocation sites, `(array i16)` for WTF-16) and a **lazy re-encoding cache**.
+Dual storage is preferred for new allocations because it eliminates the copy;
+it requires the annotation to be available before storage layout is committed.
+Neither is implemented in Phase 1; the analysis lands first so the boundary
+work has data to consume.
+
+## Why this scope for Phase 1
+
+The issue (#1588) targets a useful initial version: lattice + analysis pass +
+the canonical origin/propagation set, banking the infrastructure that the
+boundary work depends on. The only string-producing IR instrs that currently
+carry an allocation-site id are `string.const` and `string.concat`, so those
+are the two rules the analysis can attach annotations to today. Call-result
+origins (`JSON.parse`, `TextDecoder`) and method propagation require the IR to
+mint string alloc ids on those results first — tracked as Phase 2 follow-up.
+
+## Consequences
+
+- **Soundness is the bar.** A wrongly-conservative annotation only costs a
+  slower path; a wrongly-optimistic one is a correctness bug (malformed UTF-8
+  at the boundary). Every rule errs conservative: default `wtf16`, only
+  audited rules promote. The literal classifier explicitly demotes lone
+  surrogates to `wtf16`.
+- **No semantic change.** WTF-16 indexing, `.length`, comparison, etc. are
+  untouched. The annotation is internal to the compiler/runtime.
+- **Advisory until a consumer lands.** Phase 1 produces annotations with no
+  reader; the boundary lowering (Phase 2/3) is the first consumer. The
+  annotations are exercised by unit tests in the interim.
+- **Reference-Typed Strings.** If that proposal stabilizes, type information
+  may replace inference, but the propagation rules and CM dispatch logic
+  remain useful.
+
+## References
+
+- ADR-0013 — explicit allocation sites (the attachment mechanism)
+- ECMA-262 §6.1.4 (String type / WTF-16), §24.5.2 (JSON.stringify)
+- WHATWG Encoding (TextDecoder UTF-8 guarantees), RFC 8259 (JSON UTF-8)
+- Component Model CanonicalABI (`string`)

--- a/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
+++ b/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
@@ -1,7 +1,7 @@
 ---
 id: 1588
 title: "String encoding tracking: prove UTF-8 guarantees for zero-copy Component Model interop"
-status: ready
+status: in-progress
 sprint: 55
 created: 2026-05-23
 updated: 2026-05-23
@@ -362,3 +362,47 @@ Strings.
 - Naming: "UTF-8 guaranteed" is the term used here for clarity; the
   ADR may settle on a different internal name (`wellformed`, `scalar`,
   etc.) once the analysis is implemented.
+
+## Phase 1 implementation status (2026-05-23)
+
+Landed:
+
+- **Lattice + analysis pass** — `src/ir/analysis/encoding.ts`. Exports
+  `Encoding` (`ascii | utf8-guaranteed | wtf16`), `joinEncoding`,
+  `classifyLiteral`, and `analyzeEncoding(fn, registry)`. The pass is a
+  single read-only forward pass over the IR; it writes annotations to the
+  `AllocSiteRegistry` `encoding` namespace (`ALLOC_NAMESPACES.encoding`,
+  reserved by #1586) and never mutates the IR. Re-exported from
+  `src/ir/index.ts`.
+- **Origin rule** — string literals (`string.const`): `ascii` if all code
+  units ≤ 0x7F; `utf8-guaranteed` if well-formed but non-ASCII; `wtf16` if a
+  lone surrogate is present (cannot be valid UTF-8).
+- **Propagation rule** — `s1 + s2` (`string.concat`): join the operands'
+  encodings per the lattice. Untracked operands (params, call results)
+  default to `wtf16`, which conservatively forces the result to `wtf16`.
+- **Pipeline wiring** — `compileIrPathFunctions` runs `analyzeEncoding` over
+  every hygiene-stable IR function (`src/ir/integration.ts`, after the 2a
+  hygiene loop). Annotations are inert at lowering, so emitted Wasm is
+  unchanged. Inline/mono passes preserve or alias the `alloc` ids, and the
+  registry's `alias` merges annotations onto the canonical site.
+- **ADR-0015** — `docs/adr/0015-string-encoding-tracking.md` (numbered 0015
+  to avoid colliding with #1587's reserved ADR-0014).
+- **Tests** — `tests/ir/encoding-analysis.test.ts` (11 cases): lattice join,
+  literal classifier incl. surrogate edge cases, pass annotation for
+  literals + concat, conservative-default for untracked operands, read-only
+  + idempotent invariants.
+
+Deferred to Phase 2 (require IR changes outside this issue's landed surface):
+
+- **Call-result origins** (`JSON.parse`, `JSON.stringify`,
+  `TextDecoder.decode`, `fetch().text()`) — their IR results
+  (`call`/`extern.call`) do not yet carry a string `alloc` id, so there is
+  no attachment point. Minting string alloc ids on those results is a
+  prerequisite.
+- **Method propagation** (`.toUpperCase`/`.toLowerCase`/`.trim`/`.slice`/
+  `.repeat`/`.padStart`/`.padEnd`/`.split`/`.replace`) — same prerequisite.
+- **Component Model boundary lowering** + **dual storage** (`(array i8)` for
+  proven-UTF-8 sites) + **benchmark** — these consume the annotation and
+  touch shared codegen / require a benchmark harness; the analysis lands
+  first so the boundary work has data to read. See ADR-0015 §"Component
+  Model boundary integration".

--- a/src/ir/analysis/encoding.ts
+++ b/src/ir/analysis/encoding.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// String encoding analysis (#1588).
+//
+// Propagates a per-string-value encoding guarantee through the IR,
+// distinguishing strings provably containing only well-formed UTF-8 scalar
+// values from strings that may contain unpaired surrogates (WTF-16). The
+// motivation is the WebAssembly Component Model `string` type, which is
+// UTF-8 by definition: a string proven to be valid UTF-8 can cross a
+// Component boundary without the scan-and-re-encode copy that a WTF-16
+// string requires.
+//
+// The analysis is purely advisory. A wrongly-conservative annotation yields
+// a slower boundary path; a wrongly-optimistic annotation is a correctness
+// bug, so every rule errs conservative: the default is `wtf16`, and only an
+// explicit, audited origin/propagation rule promotes a value to
+// `utf8-guaranteed` or `ascii`.
+//
+// It writes its result to the #1586 `AllocSiteRegistry` under the
+// `encoding` namespace (`ALLOC_NAMESPACES.encoding`); it never mutates the
+// IR, so it can run at any point after the build phase. See the issue file
+// `plan/issues/sprints/55/1588-...md` and ADR-0013 (allocation sites).
+//
+// Phase 1 (this pass) covers the string-producing IR instrs that exist on
+// the IR path today and carry an `alloc` id from the builder:
+//   - `string.const`  → origin rule (ascii if all chars ≤ 0x7F, else utf8)
+//   - `string.concat` → join the operands' encodings per the lattice
+// Calls that produce UTF-8-by-construction strings (JSON.parse,
+// TextDecoder.decode) and method-based propagation (slice/toUpperCase/…)
+// are Phase 2: their IR results do not yet carry string `alloc` ids, so
+// there is no attachment point for an annotation. Documented as follow-up
+// in the issue.
+
+import { ALLOC_NAMESPACES, type AllocSiteRegistry } from "../alloc-registry.js";
+import type { AllocSiteId, IrFunction, IrInstr, IrValueId } from "../nodes.js";
+
+/**
+ * Encoding lattice. Ordering (most → least restrictive):
+ *   ascii  ⊑  utf8-guaranteed  ⊑  wtf16
+ * `wtf16` is top (the conservative default); `ascii` is bottom (the
+ * strongest claim). The join of two encodings is their least upper bound:
+ * any operand being `wtf16` forces `wtf16`; otherwise `utf8-guaranteed`
+ * unless both are `ascii`.
+ */
+export type Encoding = "ascii" | "utf8-guaranteed" | "wtf16";
+
+/** Rank in the lattice — higher is more permissive (closer to top). */
+function rank(e: Encoding): number {
+  switch (e) {
+    case "ascii":
+      return 0;
+    case "utf8-guaranteed":
+      return 1;
+    case "wtf16":
+      return 2;
+  }
+}
+
+/** Least upper bound of two encodings (the conservative join). */
+export function joinEncoding(a: Encoding, b: Encoding): Encoding {
+  return rank(a) >= rank(b) ? a : b;
+}
+
+/**
+ * Classify a statically known string literal by its code units.
+ *   - all code units ≤ 0x7F           → `ascii`
+ *   - else, no lone surrogates        → `utf8-guaranteed`
+ *   - else (a lone surrogate present) → `wtf16`
+ *
+ * A surrogate is lone when a high surrogate (0xD800–0xDBFF) is not
+ * immediately followed by a low surrogate (0xDC00–0xDFFF), or a low
+ * surrogate appears without a preceding high surrogate. Such a string
+ * cannot be encoded as UTF-8, so it must stay `wtf16`.
+ */
+export function classifyLiteral(value: string): Encoding {
+  let ascii = true;
+  for (let i = 0; i < value.length; i++) {
+    const u = value.charCodeAt(i);
+    if (u > 0x7f) ascii = false;
+    if (u >= 0xd800 && u <= 0xdbff) {
+      // High surrogate — must be followed by a low surrogate.
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : -1;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        i++; // consume the well-formed pair
+      } else {
+        return "wtf16";
+      }
+    } else if (u >= 0xdc00 && u <= 0xdfff) {
+      // Low surrogate with no preceding high surrogate.
+      return "wtf16";
+    }
+  }
+  return ascii ? "ascii" : "utf8-guaranteed";
+}
+
+/**
+ * Run the encoding analysis over a single IR function, writing `encoding`
+ * annotations onto the string allocation sites in `registry`. Read-only on
+ * the IR. Idempotent: re-running overwrites the same annotations with the
+ * same values.
+ *
+ * The analysis is a single forward pass. SSA dominance guarantees each
+ * value is defined before use within a block, and string values in Phase 1
+ * are produced and consumed locally (literals + concat), so a per-function
+ * value→encoding map filled in instruction order is sufficient. Values with
+ * no tracked origin are absent from the map and treated as `wtf16`.
+ */
+export function analyzeEncoding(fn: IrFunction, registry: AllocSiteRegistry): void {
+  const ns = ALLOC_NAMESPACES.encoding;
+  const encodings = new Map<IrValueId, Encoding>();
+
+  const enc = (v: IrValueId): Encoding => encodings.get(v) ?? "wtf16";
+
+  const record = (result: IrValueId | null, alloc: AllocSiteId | undefined, e: Encoding): void => {
+    if (result !== null) encodings.set(result, e);
+    if (alloc !== undefined) registry.annotate(alloc, ns, e);
+  };
+
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) {
+      classifyInstr(instr, enc, record);
+    }
+  }
+}
+
+function classifyInstr(
+  instr: IrInstr,
+  enc: (v: IrValueId) => Encoding,
+  record: (result: IrValueId | null, alloc: AllocSiteId | undefined, e: Encoding) => void,
+): void {
+  switch (instr.kind) {
+    case "string.const":
+      record(instr.result, instr.alloc, classifyLiteral(instr.value));
+      return;
+    case "string.concat":
+      // Concatenation preserves well-formedness: joining two UTF-8 strings
+      // cannot create a lone surrogate, and joining two ASCII strings stays
+      // ASCII. (WTF-16 inputs can split surrogate pairs across the seam, but
+      // the lattice already forces `wtf16` whenever either operand is.)
+      record(instr.result, instr.alloc, joinEncoding(enc(instr.lhs), enc(instr.rhs)));
+      return;
+    default:
+      // Any other string-producing instr (and there are none in Phase 1 that
+      // carry a string `alloc` id beyond the two above) defaults to `wtf16`.
+      // We still record nothing here so the value stays absent from the map,
+      // which `enc` reads back as `wtf16`.
+      return;
+  }
+}

--- a/src/ir/index.ts
+++ b/src/ir/index.ts
@@ -9,3 +9,4 @@ export * from "./lower.js";
 export * from "./select.js";
 export * from "./from-ast.js";
 export * from "./integration.js";
+export * from "./analysis/encoding.js";

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -63,6 +63,7 @@ import { taggedUnions } from "./passes/tagged-unions.js";
 import { planIrCompilation, type IrSelection } from "./select.js";
 import { verifyIrFunction } from "./verify.js";
 import { AllocSiteRegistry } from "./alloc-registry.js";
+import { analyzeEncoding } from "./analysis/encoding.js";
 import { assertAllocProvenance } from "./verify-alloc.js";
 import type { FieldDef, FuncTypeDef, Instr, StructTypeDef, ValType } from "./types.js";
 
@@ -354,6 +355,16 @@ export function compileIrPathFunctions(
   }
 
   if (afterHygiene.length === 0) return { compiled, errors };
+
+  // #1588: string-encoding analysis. Read-only over the hygiene-stable IR;
+  // writes `encoding` annotations onto string allocation sites in the
+  // registry (`ALLOC_NAMESPACES.encoding`). Annotations are advisory and
+  // inert at lowering, so the emitted Wasm is unchanged. Later passes
+  // (inline/mono) preserve or alias the alloc ids, so an annotation written
+  // here travels to the canonical site via the registry's alias merge.
+  for (const entry of afterHygiene) {
+    analyzeEncoding(entry.fn, allocRegistry);
+  }
 
   // 2b. Module-scope inlining (#1167b).
   const modIn: IrModule = { functions: afterHygiene.map((e) => e.fn) };

--- a/tests/ir/encoding-analysis.test.ts
+++ b/tests/ir/encoding-analysis.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1588 — string encoding analysis unit tests.
+//
+// Covers:
+//   - the lattice join (conservative least-upper-bound)
+//   - the literal classifier (ascii / utf8 / wtf16, incl. surrogate cases)
+//   - the pass annotating string.const + string.concat alloc sites
+//   - conservative default (wtf16) for untracked operands
+//   - the analysis leaves the IR unchanged (advisory only)
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ALLOC_NAMESPACES,
+  AllocSiteRegistry,
+  IrFunctionBuilder,
+  analyzeEncoding,
+  classifyLiteral,
+  joinEncoding,
+  type Encoding,
+  type IrType,
+} from "../../src/ir/index.js";
+
+const STR: IrType = { kind: "string" };
+const NS = ALLOC_NAMESPACES.encoding;
+
+function readEnc(
+  reg: AllocSiteRegistry,
+  value: string,
+  kind: "string.const" | "string.concat",
+  fn: ReturnType<IrFunctionBuilder["finish"]>,
+): Encoding | undefined {
+  const instr = fn.blocks[0]!.instrs.find(
+    (i) => i.kind === kind && (kind !== "string.const" || (i as { value?: string }).value === value),
+  )!;
+  return reg.read<Encoding>(instr.alloc!, NS);
+}
+
+describe("#1588 — encoding lattice", () => {
+  it("join is the conservative least upper bound", () => {
+    expect(joinEncoding("ascii", "ascii")).toBe("ascii");
+    expect(joinEncoding("ascii", "utf8-guaranteed")).toBe("utf8-guaranteed");
+    expect(joinEncoding("utf8-guaranteed", "ascii")).toBe("utf8-guaranteed");
+    expect(joinEncoding("utf8-guaranteed", "utf8-guaranteed")).toBe("utf8-guaranteed");
+    expect(joinEncoding("ascii", "wtf16")).toBe("wtf16");
+    expect(joinEncoding("wtf16", "utf8-guaranteed")).toBe("wtf16");
+    expect(joinEncoding("wtf16", "wtf16")).toBe("wtf16");
+  });
+});
+
+describe("#1588 — classifyLiteral", () => {
+  it("all-ASCII literals are ascii", () => {
+    expect(classifyLiteral("")).toBe("ascii");
+    expect(classifyLiteral("hello")).toBe("ascii");
+    expect(classifyLiteral("a1!~")).toBe("ascii");
+    // 0x7F is the ASCII boundary (inclusive).
+    expect(classifyLiteral("\x7f")).toBe("ascii");
+  });
+
+  it("non-ASCII but well-formed literals are utf8-guaranteed", () => {
+    expect(classifyLiteral("café")).toBe("utf8-guaranteed");
+    expect(classifyLiteral("")).toBe("utf8-guaranteed");
+    expect(classifyLiteral("日本語")).toBe("utf8-guaranteed");
+    // A well-formed surrogate pair (U+1F600) is valid UTF-8.
+    expect(classifyLiteral("\u{1f600}")).toBe("utf8-guaranteed");
+    expect(classifyLiteral("a\u{1f600}b")).toBe("utf8-guaranteed");
+  });
+
+  it("lone surrogates are wtf16 (cannot be valid UTF-8)", () => {
+    expect(classifyLiteral("\uD800")).toBe("wtf16"); // lone high
+    expect(classifyLiteral("\uDC00")).toBe("wtf16"); // lone low
+    expect(classifyLiteral("a\uD800b")).toBe("wtf16"); // high not followed by low
+    expect(classifyLiteral("\uDC00\uD800")).toBe("wtf16"); // reversed (low then high)
+    expect(classifyLiteral("\uD800\uD800")).toBe("wtf16"); // high followed by high
+  });
+});
+
+describe("#1588 — analyzeEncoding pass", () => {
+  it("annotates a string literal's alloc site with its classification", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const s = b.emitStringConst("hi");
+    b.terminate({ kind: "return", values: [s] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+
+    expect(readEnc(reg, "hi", "string.const", fn)).toBe("ascii");
+  });
+
+  it("annotates a non-ASCII literal as utf8-guaranteed", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const s = b.emitStringConst("café");
+    b.terminate({ kind: "return", values: [s] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+
+    expect(readEnc(reg, "café", "string.const", fn)).toBe("utf8-guaranteed");
+  });
+
+  it("concat of two ASCII literals stays ascii", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const a = b.emitStringConst("foo");
+    const c = b.emitStringConst("bar");
+    const cat = b.emitStringConcat(a, c);
+    b.terminate({ kind: "return", values: [cat] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+
+    const catInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "string.concat")!;
+    expect(reg.read<Encoding>(catInstr.alloc!, NS)).toBe("ascii");
+  });
+
+  it("concat of ascii + utf8 joins to utf8-guaranteed", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const a = b.emitStringConst("foo"); // ascii
+    const c = b.emitStringConst("café"); // utf8
+    const cat = b.emitStringConcat(a, c);
+    b.terminate({ kind: "return", values: [cat] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+
+    const catInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "string.concat")!;
+    expect(reg.read<Encoding>(catInstr.alloc!, NS)).toBe("utf8-guaranteed");
+  });
+
+  it("concat with an untracked (param) operand is conservatively wtf16", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    const p = b.addParam("s", STR); // no origin rule → wtf16
+    b.openBlock();
+    const lit = b.emitStringConst("x"); // ascii
+    const cat = b.emitStringConcat(p, lit);
+    b.terminate({ kind: "return", values: [cat] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+
+    const catInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "string.concat")!;
+    expect(reg.read<Encoding>(catInstr.alloc!, NS)).toBe("wtf16");
+  });
+
+  it("is read-only — the IR function is structurally unchanged", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const s = b.emitStringConst("hi");
+    b.terminate({ kind: "return", values: [s] });
+    const fn = b.finish();
+    const before = JSON.stringify(fn);
+
+    analyzeEncoding(fn, reg);
+
+    expect(JSON.stringify(fn)).toBe(before);
+  });
+
+  it("is idempotent — re-running yields the same annotation", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const s = b.emitStringConst("hi");
+    b.terminate({ kind: "return", values: [s] });
+    const fn = b.finish();
+
+    analyzeEncoding(fn, reg);
+    const first = readEnc(reg, "hi", "string.const", fn);
+    analyzeEncoding(fn, reg);
+    const second = readEnc(reg, "hi", "string.const", fn);
+    expect(second).toBe(first);
+    expect(second).toBe("ascii");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of #1588 — a static, advisory string-encoding analysis that
annotates string allocation sites with a provable encoding guarantee,
building directly on the #1586 `AllocSiteRegistry`. The motivation is the
Component Model `string` type (UTF-8 by definition): strings proven
well-formed UTF-8 can later cross a Component boundary without the
scan-and-re-encode copy that WTF-16 strings require.

- **Lattice + pass** (`src/ir/analysis/encoding.ts`): `ascii ⊑ utf8-guaranteed ⊑ wtf16`. Read-only forward pass; writes annotations to the registry's `encoding` namespace (reserved by #1586). Never mutates the IR.
- **Origin rule** — string literals: `ascii` (all units ≤ 0x7F), `utf8-guaranteed` (well-formed non-ASCII), `wtf16` (lone surrogate — cannot be valid UTF-8).
- **Propagation rule** — `string.concat`: join operand encodings per the lattice; untracked operands default to `wtf16`.
- **Wiring** (`src/ir/integration.ts`): runs in `compileIrPathFunctions` after hygiene. Annotations are inert at lowering — **emitted Wasm is byte-identical**.
- **ADR-0015** documents the lattice, origin/propagation rules, and the (deferred) dual-storage + boundary strategy. Numbered 0015 to avoid colliding with #1587's reserved ADR-0014.

Deferred to Phase 2 (need string `alloc` ids on call results, which the IR
doesn't mint yet): call-result origins (`JSON.parse`, `TextDecoder.decode`),
method propagation, and the Component Model boundary lowering + dual storage
+ benchmark. Documented in the issue file.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/ir/encoding-analysis.test.ts` — 11 cases pass (lattice join, literal classifier incl. surrogate edge cases, pass annotation for literals + concat, conservative default for untracked operands, read-only + idempotent invariants)
- [x] Existing `tests/ir/alloc-*.test.ts` pass (the 2 pre-existing `ir-scaffold.test.ts` host-import failures reproduce on clean main — unrelated)
- [ ] CI: full conformance + gate (no codegen change expected — annotations are inert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)