### PR TITLE
feat(#1587): ownership + access-semantics analysis on IR values (Phase 1)

### DIFF
--- a/docs/adr/0014-ownership-access-analysis.md
+++ b/docs/adr/0014-ownership-access-analysis.md
@@ -1,0 +1,91 @@
+# ADR-0014: Ownership and access-semantics analysis on IR values
+
+Status: Accepted
+
+## Context
+
+The typed SSA IR (ADR-0012) with explicit allocation sites (ADR-0013) gives a
+stable place to attach per-value facts, but nothing yet *computes* them.
+Several compiler enhancements want to know, for each value: how many references
+exist, whether the value outlives the current function, and how it is used
+(read / written / compared by identity). Today each would re-derive this ad hoc
+or pessimize:
+
+- **Escape analysis** — stack-allocate / scalar-replace allocations that never
+  escape.
+- **Closure specialization** — read-only captures can be inlined as constants.
+- **Built-in dispatch** — skip defensive copies for read-only arguments.
+- **Tier-up (#1584)** and **lifetime analysis for a linear-memory backend
+  (#1585)** both want ownership facts as a foundation.
+
+JavaScript semantics forbid a Rust-style *rejection* of programs that fail
+ownership rules. What we can do is *infer* where ownership and access
+properties provably hold.
+
+## Decision
+
+Add a flow-sensitive, intra-procedural, may-escape analysis
+(`src/ir/analysis/ownership.ts`) that annotates each IR value with two
+independent lattice values (`src/ir/analysis/lattice.ts`):
+
+- **Ownership** — a total order, BOTTOM→TOP:
+  `owned ⊑ borrowed ⊑ shared ⊑ escaped`. Join = the more conservative state.
+- **Access** — the powerset of `{ read, write, mutate, identity, escape }`
+  ordered by ⊆; join = set union.
+
+The analysis is a monotone worklist over the control-flow graph. Allocations
+(instrs carrying an `alloc` id, ADR-0013) seed at `owned` / `{}`; imported
+references (params, captures, globals) seed at `shared` / `{ read }`. Each
+operation widens its operands (field read → `read`; field write → `write` and
+the stored value escapes; opaque call / return / capture → operands escape).
+States join at CFG merges and across branch-args; the result is the
+meet-over-all-paths join.
+
+Results are written to the `AllocSiteRegistry` `ownership` namespace (ADR-0013)
+for allocated values and exposed per-function via `OwnershipResult.of(value)` /
+`.ownershipOf` / `.accessOf`.
+
+### Conservative defaults (the safety property)
+
+Anything the analysis cannot reason about gets the **TOP** element of each
+lattice: `shared` ownership, full access set. **No consumer may assume a
+tighter annotation than the analysis returns** — consumers check whether the
+result is tight enough for their optimization and otherwise take the
+conservative path. This is what makes the pass purely an optimization aid:
+removing it cannot change observable behavior.
+
+### Not a borrow checker
+
+"Ownership" here is *inferred classification*, not a *declared type*. Programs
+that would fail Rust's borrow checker compile fine; they simply receive
+conservative annotations. The Rust framing is deliberately disclaimed.
+
+### Inert + gated
+
+The pass does **not** mutate the IR; registry annotations are inert at
+lowering. It runs only behind `JS2WASM_IR_OWNERSHIP=1` during rollout. The
+demonstration consumer (`analysis/stack-alloc.ts`) is likewise annotation-only
+in Phase 1: it marks proven-`owned`-non-`escaped` small allocations as
+stack-allocation candidates without changing the emitted representation. The
+actual stack/scalar lowering is a follow-up.
+
+### Phasing
+
+Phase 1 (this ADR): intra-procedural analysis, both lattices, registry
+integration, one annotation-only consumer. Phase 2: inter-procedural function
+summaries. Phase 3: precision (better loops, conditional refinement,
+escape-via-exception) and joint analysis with encoding tracking (#1588).
+
+## Consequences
+
+- Downstream consumers (escape analysis, closure specialization, tier-up,
+  lifetime analysis) get a shared, conservative, composable source of ownership
+  facts instead of each recovering them.
+- Soundness risk is bounded by the conservative-default rule: a precision bug
+  costs an optimization, never correctness, as long as no consumer assumes
+  tighter-than-returned.
+- Arrays/closures/strings are not Phase-1 stack-alloc candidates (kept small and
+  conservative); broadening is a follow-up once a dedicated `array.new` IR instr
+  lands (ADR-0013 notes arrays route through `object.new` today).
+- Prior art: V8 TurboFan escape analysis, SpiderMonkey alias-set analysis,
+  Rust MIR borrow analysis — cited for style, not ported.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ The format follows Michael Nygard's 2011 ADR template: **Context**,
 | 011 | Accepted | [Implementation language: TypeScript with the `typescript` package as the frontend](./0011-implementation-language.md) |
 | 012 | Accepted | [Intermediate representation: multi-stage typed IR](./0012-intermediate-representation.md) |
 | 013 | Accepted | [Explicit allocation sites in the IR](./0013-ir-allocation-sites.md)          |
+| 014 | Accepted | [Ownership and access-semantics analysis on IR values](./0014-ownership-access-analysis.md) |
 
 ## Reading order
 

--- a/plan/issues/sprints/55/1587-ownership-and-access-semantics-analysis.md
+++ b/plan/issues/sprints/55/1587-ownership-and-access-semantics-analysis.md
@@ -1,7 +1,7 @@
 ---
 id: 1587
 title: "Static analysis pass: ownership and access semantics on IR values"
-status: ready
+status: in-progress
 sprint: 55
 created: 2026-05-23
 updated: 2026-05-23
@@ -277,3 +277,44 @@ tracking, integration with #1588's encoding tracking.
   allocations, and inter-procedural adds significant implementation
   surface (summary computation, summary serialization, summary
   invalidation on recompilation).
+
+## Implementation (Phase 1 — landed)
+
+Files added:
+- `src/ir/analysis/lattice.ts` — `Ownership` total order
+  (`owned ⊑ borrowed ⊑ shared ⊑ escaped`) with `joinOwnership` / `ownershipLeq`;
+  `AccessSet` powerset over `{read,write,mutate,identity,escape}` with union/subset;
+  `OwnershipAnnotation` + component-wise `joinAnnotations` + `topAnnotation`.
+- `src/ir/analysis/ownership.ts` — `analyzeOwnership(fn, registry?)`: monotone
+  worklist over the CFG. Allocations seed `owned`/{}, params/captures/globals
+  seed `shared`/{read}; per-op transfer widens operands (field read→read,
+  field write→write+value escapes, opaque call/return/capture→escape);
+  join at merges + branch-args; meet-over-paths final result. Writes the
+  `ownership` namespace on the registry and returns an `OwnershipResult` with
+  `of` / `ownershipOf` / `accessOf` / `isStackAllocatable` query API.
+- `src/ir/analysis/stack-alloc.ts` — demonstration consumer
+  `findStackAllocCandidates`: proven-`owned`-non-`escaped` small allocations
+  (object/refcell/box) → candidate list + inert `stackCandidate` marker.
+- `docs/adr/0014-ownership-access-analysis.md` — ADR (lattices, joins,
+  conservative-defaults guarantee, Rust-framing disclaimer, gating, phasing).
+
+Pipeline wiring (`src/ir/integration.ts`, step 2g): runs after mono/TU on the
+final IR shape, **gated behind `JS2WASM_IR_OWNERSHIP=1`, default OFF**. The pass
+does not mutate the IR and registry annotations are inert at lowering.
+
+## Test Results
+
+`tests/ir/ownership-analysis.test.ts` — 14 tests, all pass. Covers the lattices
+and all 7 required IR fragments: simple allocation, escape via return, escape
+via store-to-heap, escape via opaque call, mutation via field store, conditional
+escape via branching, loop-carried allocation; plus registry write-back, param
+seeding, and both demonstration-consumer cases.
+
+Inertness verified: compiling `make(){ const o={x:1}; o.x=2; return o.x }` with
+the flag OFF vs ON yields **byte-identical Wasm** (642 bytes both). `tsc --noEmit`
+and `biome lint` clean on all new/changed files. The 4 pre-existing
+`tests/ir/passes.test.ts` failures (`__box_number requires a callable`) reproduce
+on clean origin/main and are unrelated to this change.
+
+Phases 2 (inter-procedural summaries) and 3 (precision: loops, conditional
+refinement, escape-via-exception, join with #1588) are follow-up issues.

--- a/src/ir/analysis/lattice.ts
+++ b/src/ir/analysis/lattice.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Ownership + access lattices (#1587).
+//
+// Two independent lattices the ownership analysis (`ownership.ts`) computes per
+// IR value. Both are *inference* results, not declarations — see ADR-0014. A
+// value the analysis cannot reason about gets the TOP (most permissive)
+// element of each lattice, which is correctness-preserving for every consumer.
+//
+// The Rust-borrow-checker framing is deliberately disclaimed: "ownership" here
+// is a discovered classification, never a rejected program property.
+
+/**
+ * Ownership state — a totally ordered lattice from most-precise (`owned`) to
+ * most-permissive (`escaped`). Higher = more conservative = safer default.
+ *
+ *   owned  ⊑ borrowed ⊑ shared ⊑ escaped
+ *
+ * - `owned`    — exactly one live reference (this one) for its liveness.
+ * - `borrowed` — referenced elsewhere; this ref must not deallocate/invalidate.
+ * - `shared`   — multiple references; mutation must be observable to all.
+ * - `escaped`  — lifetime extends beyond this function (return, capture,
+ *                store-to-heap, pass to opaque code).
+ */
+export type Ownership = "owned" | "borrowed" | "shared" | "escaped";
+
+/** Lattice rank — index into the total order. Lower = more precise. */
+const OWNERSHIP_RANK: Readonly<Record<Ownership, number>> = {
+  owned: 0,
+  borrowed: 1,
+  shared: 2,
+  escaped: 3,
+};
+
+const OWNERSHIP_BY_RANK: readonly Ownership[] = ["owned", "borrowed", "shared", "escaped"];
+
+/** Bottom of the ownership lattice — the most precise classification. */
+export const OWNERSHIP_BOTTOM: Ownership = "owned";
+
+/** Top of the ownership lattice — the conservative default. */
+export const OWNERSHIP_TOP: Ownership = "escaped";
+
+/**
+ * Join (least upper bound) of two ownership states. Used at control-flow merge
+ * points and whenever an operation widens a value's classification: the result
+ * is the *more conservative* of the two. Commutative, associative, idempotent.
+ */
+export function joinOwnership(a: Ownership, b: Ownership): Ownership {
+  return OWNERSHIP_BY_RANK[Math.max(OWNERSHIP_RANK[a], OWNERSHIP_RANK[b])]!;
+}
+
+/** True iff `a` is at least as precise as `b` (`a ⊑ b`). */
+export function ownershipLeq(a: Ownership, b: Ownership): boolean {
+  return OWNERSHIP_RANK[a] <= OWNERSHIP_RANK[b];
+}
+
+/**
+ * Access operation — how a reference is used. The access lattice is the
+ * powerset of these tags ordered by ⊆; join is set union, bottom is `{}`, top
+ * is the full set. A value that escapes to opaque code conservatively widens
+ * to the full set (the callee may do anything).
+ */
+export type AccessOp = "read" | "write" | "mutate" | "identity" | "escape";
+
+const ALL_ACCESS_OPS: readonly AccessOp[] = ["read", "write", "mutate", "identity", "escape"];
+
+/**
+ * An access set — a small immutable wrapper over `Set<AccessOp>` with union
+ * (join) and subset (⊑) operations. Kept as a class so the query API can hand
+ * consumers a value they cannot accidentally mutate.
+ */
+export class AccessSet {
+  private readonly ops: ReadonlySet<AccessOp>;
+
+  private constructor(ops: ReadonlySet<AccessOp>) {
+    this.ops = ops;
+  }
+
+  /** Bottom — no observed access. */
+  static empty(): AccessSet {
+    return new AccessSet(new Set());
+  }
+
+  /** Top — the conservative full access set. */
+  static full(): AccessSet {
+    return new AccessSet(new Set(ALL_ACCESS_OPS));
+  }
+
+  static of(...ops: readonly AccessOp[]): AccessSet {
+    return new AccessSet(new Set(ops));
+  }
+
+  has(op: AccessOp): boolean {
+    return this.ops.has(op);
+  }
+
+  /** Join — set union. Returns `this` unchanged when `op` is already present. */
+  with(op: AccessOp): AccessSet {
+    if (this.ops.has(op)) return this;
+    const next = new Set(this.ops);
+    next.add(op);
+    return new AccessSet(next);
+  }
+
+  /** Join — set union of two access sets. */
+  union(other: AccessSet): AccessSet {
+    let needsCopy = false;
+    for (const op of other.ops) {
+      if (!this.ops.has(op)) {
+        needsCopy = true;
+        break;
+      }
+    }
+    if (!needsCopy) return this;
+    const next = new Set(this.ops);
+    for (const op of other.ops) next.add(op);
+    return new AccessSet(next);
+  }
+
+  /** True iff `this ⊆ other`. */
+  subsetOf(other: AccessSet): boolean {
+    for (const op of this.ops) {
+      if (!other.ops.has(op)) return false;
+    }
+    return true;
+  }
+
+  equals(other: AccessSet): boolean {
+    return this.ops.size === other.ops.size && this.subsetOf(other);
+  }
+
+  /** Stable, sorted array view — for annotations, tests, and diagnostics. */
+  toArray(): AccessOp[] {
+    return ALL_ACCESS_OPS.filter((op) => this.ops.has(op));
+  }
+}
+
+/**
+ * The full classification the analysis attaches to a value. This is the shape
+ * stored in the registry `ownership` namespace and the parallel `ValueAnnot`
+ * map. Consumers must treat it as the analysis's *tightest provable* result
+ * and fall back to their conservative path when it is not tight enough — they
+ * may never assume a tighter classification than this carries (ADR-0014).
+ */
+export interface OwnershipAnnotation {
+  readonly ownership: Ownership;
+  readonly access: AccessSet;
+}
+
+/** The conservative TOP annotation — used for anything not provably tighter. */
+export function topAnnotation(): OwnershipAnnotation {
+  return { ownership: OWNERSHIP_TOP, access: AccessSet.full() };
+}
+
+/** Join two annotations component-wise (used at CFG merges). */
+export function joinAnnotations(a: OwnershipAnnotation, b: OwnershipAnnotation): OwnershipAnnotation {
+  return {
+    ownership: joinOwnership(a.ownership, b.ownership),
+    access: a.access.union(b.access),
+  };
+}
+
+export function annotationsEqual(a: OwnershipAnnotation, b: OwnershipAnnotation): boolean {
+  return a.ownership === b.ownership && a.access.equals(b.access);
+}

--- a/src/ir/analysis/ownership.ts
+++ b/src/ir/analysis/ownership.ts
@@ -33,14 +33,7 @@
 
 import type { AllocSiteRegistry } from "../alloc-registry.js";
 import { ALLOC_NAMESPACES } from "../alloc-registry.js";
-import type {
-  IrBlock,
-  IrBlockId,
-  IrFunction,
-  IrInstr,
-  IrTerminator,
-  IrValueId,
-} from "../nodes.js";
+import type { IrBlock, IrBlockId, IrFunction, IrInstr, IrTerminator, IrValueId } from "../nodes.js";
 import {
   AccessSet,
   joinAnnotations,
@@ -213,7 +206,13 @@ function runBlock(block: IrBlock, state: State, allocOf: Map<IrValueId, number>)
 type State = Map<IrValueId, OwnershipAnnotation>;
 
 /** Widen `value`'s ownership to at least `o` and add access op `op` (if any). */
-function touch(state: State, value: IrValueId, allocOf: Map<IrValueId, number>, o: Ownership | null, op: AccessOp | null): void {
+function touch(
+  state: State,
+  value: IrValueId,
+  allocOf: Map<IrValueId, number>,
+  o: Ownership | null,
+  op: AccessOp | null,
+): void {
   const cur = state.get(value) ?? bottomFor(value, allocOf);
   let { ownership, access } = cur;
   if (o !== null) ownership = joinAnnotations({ ownership, access }, { ownership: o, access }).ownership;

--- a/src/ir/analysis/ownership.ts
+++ b/src/ir/analysis/ownership.ts
@@ -1,0 +1,491 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Intra-procedural ownership + access-semantics analysis (#1587, Phase 1).
+//
+// A flow-sensitive, intra-procedural, may-escape analysis. For each IR
+// function it infers, per value:
+//   - an ownership state (owned / borrowed / shared / escaped), and
+//   - an access set (read / write / mutate / identity / escape).
+//
+// The result is *inference*, not rejection (ADR-0014). A value the analysis
+// cannot reason about gets the conservative TOP element of each lattice. The
+// pass is purely an optimization aid: it writes annotations to the
+// `AllocSiteRegistry` ownership namespace (for allocated values) and to a
+// parallel `ValueAnnot` map (for parameters / captures / non-allocated values),
+// and NEVER mutates the IR. Removing the pass cannot change observable Wasm.
+//
+// Phase 1 is intra-procedural: unknown callees are treated as fully escaping.
+// Inter-procedural summaries are Phase 2 (a follow-up issue).
+//
+// Algorithm — monotone worklist over the control-flow graph:
+//   1. Seed: every allocation (`alloc`-carrying instr result) starts at
+//      `owned` / `{}`. Every imported reference (param, block-arg, global read,
+//      closure capture) starts at `shared` / `{ read }`.
+//   2. Transfer: per block, walk instrs in order applying each op's effect to
+//      its operands' state (widening only — joins are monotone increases).
+//   3. Join: block entry states join the exit states of all predecessors;
+//      block-args join the corresponding branch args.
+//   4. Fixpoint: iterate the worklist until no block's entry state changes.
+//
+// Because every transfer either leaves a value's state unchanged or moves it
+// strictly UP the (finite-height) lattice, the analysis is monotone and
+// terminates.
+
+import type { AllocSiteRegistry } from "../alloc-registry.js";
+import { ALLOC_NAMESPACES } from "../alloc-registry.js";
+import type {
+  IrBlock,
+  IrBlockId,
+  IrFunction,
+  IrInstr,
+  IrTerminator,
+  IrValueId,
+} from "../nodes.js";
+import {
+  AccessSet,
+  joinAnnotations,
+  type AccessOp,
+  type OwnershipAnnotation,
+  type Ownership,
+  annotationsEqual,
+  topAnnotation,
+} from "./lattice.js";
+
+/**
+ * The analysis result for one function. `of` returns the inferred annotation
+ * for any value; values the analysis never saw resolve to the conservative
+ * TOP, so consumers always get a correctness-preserving answer.
+ */
+export class OwnershipResult {
+  constructor(
+    private readonly annots: ReadonlyMap<IrValueId, OwnershipAnnotation>,
+    /** Value -> the alloc id of the instr that defined it, when allocated. */
+    private readonly allocOf: ReadonlyMap<IrValueId, number>,
+  ) {}
+
+  /** Inferred annotation for `value` — TOP if the value was never classified. */
+  of(value: IrValueId): OwnershipAnnotation {
+    return this.annots.get(value) ?? topAnnotation();
+  }
+
+  ownershipOf(value: IrValueId): Ownership {
+    return this.of(value).ownership;
+  }
+
+  accessOf(value: IrValueId): AccessSet {
+    return this.of(value).access;
+  }
+
+  /** True iff `value` is a heap allocation proven `owned` and never `escaped`. */
+  isStackAllocatable(value: IrValueId): boolean {
+    if (!this.allocOf.has(value)) return false;
+    const { ownership, access } = this.of(value);
+    return ownership === "owned" && !access.has("escape");
+  }
+
+  /** All classified values — for diagnostics / tests. */
+  entries(): Iterable<[IrValueId, OwnershipAnnotation]> {
+    return this.annots.entries();
+  }
+}
+
+/**
+ * Run the analysis on `fn`. When `registry` is supplied, the result for each
+ * allocated value is also written under the `ownership` namespace keyed by the
+ * defining instr's alloc id (the durable cross-pass channel). The returned
+ * `OwnershipResult` is the in-function view keyed by `IrValueId`.
+ */
+export function analyzeOwnership(fn: IrFunction, registry?: AllocSiteRegistry): OwnershipResult {
+  const blocks = fn.blocks;
+  if (blocks.length === 0) {
+    return new OwnershipResult(new Map(), new Map());
+  }
+
+  // value -> defining instr's alloc id, for the registry write-back + the
+  // stack-allocatable query. Only allocation results appear here.
+  const allocOf = new Map<IrValueId, number>();
+  collectAllocs(fn, allocOf);
+
+  const blockIndex = new Map<IrBlockId, number>();
+  blocks.forEach((b, i) => blockIndex.set(b.id, i));
+
+  // Seed the entry block's params/globals/captures as `shared`/{read}.
+  // Allocations are seeded lazily in the transfer (they start at BOTTOM).
+  const entryState: State = new Map();
+  for (const p of fn.params) {
+    entryState.set(p.value, { ownership: "shared", access: AccessSet.of("read") });
+  }
+
+  const blockEntry: State[] = blocks.map(() => new Map());
+  blockEntry[0] = cloneState(entryState);
+
+  // Worklist of block indices to (re)process.
+  const worklist: number[] = [];
+  const inWorklist = new Set<number>();
+  const enqueue = (i: number): void => {
+    if (!inWorklist.has(i)) {
+      inWorklist.add(i);
+      worklist.push(i);
+    }
+  };
+  enqueue(0);
+
+  // Per-block exit states, recomputed each visit.
+  const blockExit: State[] = blocks.map(() => new Map());
+
+  const MAX_VISITS = blocks.length * 8 + 64; // generous monotone-convergence guard
+  let visits = 0;
+
+  while (worklist.length > 0) {
+    if (++visits > MAX_VISITS) break; // monotone lattice guarantees fixpoint; guard is defensive
+    const bi = worklist.shift()!;
+    inWorklist.delete(bi);
+    const block = blocks[bi]!;
+
+    const state = cloneState(blockEntry[bi]!);
+    runBlock(block, state, allocOf);
+    blockExit[bi] = state;
+
+    // Propagate to successors: join exit state into their entry, and join the
+    // branch args into the successor's block-args.
+    for (const succ of successors(block.terminator)) {
+      const sIdx = blockIndex.get(succ.target);
+      if (sIdx === undefined) continue;
+      let changed = joinInto(blockEntry[sIdx]!, state);
+
+      // Block-args: the j-th arg flows into the successor's j-th block-arg.
+      const succBlock = blocks[sIdx]!;
+      for (let j = 0; j < succ.args.length && j < succBlock.blockArgs.length; j++) {
+        const argVal = succ.args[j]!;
+        const paramVal = succBlock.blockArgs[j]!;
+        const argAnnot = state.get(argVal) ?? bottomFor(argVal, allocOf);
+        if (mergeValue(blockEntry[sIdx]!, paramVal, argAnnot)) changed = true;
+      }
+      if (changed) enqueue(sIdx);
+    }
+  }
+
+  // Final per-value annotations: the join of every block's exit state (a value
+  // may be classified differently along different paths; the meet-over-paths
+  // result is the join of all of them).
+  const finalAnnots = new Map<IrValueId, OwnershipAnnotation>();
+  for (const exit of blockExit) {
+    for (const [v, a] of exit) {
+      const prev = finalAnnots.get(v);
+      finalAnnots.set(v, prev ? joinAnnotations(prev, a) : a);
+    }
+  }
+  // Params/captures that never appeared in any exit state still carry their seed.
+  for (const [v, a] of entryState) {
+    if (!finalAnnots.has(v)) finalAnnots.set(v, a);
+  }
+
+  // Write-back to the registry ownership namespace for allocated values.
+  if (registry) {
+    for (const [value, allocId] of allocOf) {
+      const annot = finalAnnots.get(value) ?? { ownership: "owned", access: AccessSet.empty() };
+      registry.annotate(allocId as never, ALLOC_NAMESPACES.ownership, {
+        state: annot.ownership,
+        ops: annot.access.toArray(),
+      });
+    }
+  }
+
+  return new OwnershipResult(finalAnnots, allocOf);
+}
+
+// ---------------------------------------------------------------------------
+// Transfer function
+// ---------------------------------------------------------------------------
+
+/** Run one block's instrs over `state`, mutating it in place (widening only). */
+function runBlock(block: IrBlock, state: State, allocOf: Map<IrValueId, number>): void {
+  for (const instr of block.instrs) {
+    // An allocation result is seeded at BOTTOM (owned / {}) when first seen.
+    if (instr.result !== null && instr.alloc !== undefined && !state.has(instr.result)) {
+      state.set(instr.result, { ownership: "owned", access: AccessSet.empty() });
+    }
+    applyInstrEffect(instr, state, allocOf);
+  }
+  applyTerminatorEffect(block.terminator, state, allocOf);
+}
+
+type State = Map<IrValueId, OwnershipAnnotation>;
+
+/** Widen `value`'s ownership to at least `o` and add access op `op` (if any). */
+function touch(state: State, value: IrValueId, allocOf: Map<IrValueId, number>, o: Ownership | null, op: AccessOp | null): void {
+  const cur = state.get(value) ?? bottomFor(value, allocOf);
+  let { ownership, access } = cur;
+  if (o !== null) ownership = joinAnnotations({ ownership, access }, { ownership: o, access }).ownership;
+  if (op !== null) access = access.with(op);
+  state.set(value, { ownership, access });
+}
+
+/** Mark `value` escaped — widens ownership to `escaped` and adds `escape`. */
+function markEscaped(state: State, value: IrValueId, allocOf: Map<IrValueId, number>): void {
+  touch(state, value, allocOf, "escaped", "escape");
+}
+
+function applyInstrEffect(instr: IrInstr, state: State, allocOf: Map<IrValueId, number>): void {
+  switch (instr.kind) {
+    // --- field reads -> `read` on the receiver -------------------------------
+    case "object.get":
+    case "class.get":
+      touch(state, instr.value, allocOf, null, "read");
+      break;
+    case "refcell.get":
+      touch(state, instr.cell, allocOf, null, "read");
+      break;
+    case "vec.get":
+      touch(state, instr.vec, allocOf, null, "read");
+      break;
+    case "vec.len":
+      touch(state, instr.vec, allocOf, null, "read");
+      break;
+    case "string.len":
+      touch(state, instr.value, allocOf, null, "read");
+      break;
+
+    // --- field writes -> `write` on the receiver; value may escape into it ---
+    case "object.set":
+      touch(state, instr.value, allocOf, null, "write");
+      markEscaped(state, instr.newValue, allocOf); // stored into a heap-reachable field
+      break;
+    case "class.set":
+      touch(state, instr.value, allocOf, null, "write");
+      markEscaped(state, instr.newValue, allocOf);
+      break;
+    case "refcell.set":
+      // A ref cell is the canonical escape channel for a mutable capture.
+      touch(state, instr.cell, allocOf, null, "write");
+      markEscaped(state, instr.value, allocOf);
+      break;
+
+    // --- read-modify-write -> `mutate` ---------------------------------------
+    // (no dedicated RMW instr in Phase-1 IR; reserved for when one lands.)
+
+    // --- identity (===) on references ----------------------------------------
+    case "binary":
+      if (instr.op === "i32.eq" || instr.op === "i32.ne") {
+        touch(state, instr.lhs, allocOf, null, "identity");
+        touch(state, instr.rhs, allocOf, null, "identity");
+      }
+      break;
+    case "string.eq":
+      touch(state, instr.lhs, allocOf, null, "read");
+      touch(state, instr.rhs, allocOf, null, "read");
+      break;
+
+    // --- opaque calls -> every ref arg escapes with full access --------------
+    case "call":
+      for (const a of instr.args) markEscaped(state, a, allocOf);
+      break;
+    case "class.call":
+      markEscaped(state, instr.receiver, allocOf);
+      for (const a of instr.args) markEscaped(state, a, allocOf);
+      break;
+    case "closure.call":
+      markEscaped(state, instr.callee, allocOf);
+      for (const a of instr.args) markEscaped(state, a, allocOf);
+      break;
+    case "extern.call":
+    case "extern.new":
+    case "extern.prop":
+    case "extern.propSet":
+      // Extern ops cross into host code — everything they touch escapes.
+      for (const v of operandsOf(instr)) markEscaped(state, v, allocOf);
+      break;
+
+    // --- captures: a closure stores its captured values (they escape) --------
+    case "closure.new":
+      for (const cap of instr.captures) markEscaped(state, cap, allocOf);
+      break;
+
+    // --- iterators / coercions reach into opaque host iterator protocol ------
+    case "iter.new":
+      markEscaped(state, instr.iterable, allocOf);
+      break;
+    case "coerce.to_externref":
+      markEscaped(state, instr.value, allocOf);
+      break;
+
+    // --- async: awaited / returned / thrown values escape the frame ----------
+    case "await":
+      markEscaped(state, instr.operand, allocOf);
+      break;
+    case "async.return":
+      markEscaped(state, instr.value, allocOf);
+      break;
+    case "async.throw":
+      markEscaped(state, instr.reason, allocOf);
+      break;
+    case "throw":
+      markEscaped(state, (instr as { value: IrValueId }).value, allocOf);
+      break;
+
+    // Control-flow-bearing instrs carry nested bodies; recurse into them so
+    // effects inside arms / loop bodies are observed. The nested instrs
+    // reference the same function-level SSA values, so a shared `state` is
+    // correct for an intra-procedural may-escape result.
+    case "if":
+      for (const sub of instr.then) applyInstrEffect(sub, state, allocOf);
+      for (const sub of instr.else) applyInstrEffect(sub, state, allocOf);
+      break;
+    case "forof.vec":
+    case "forof.iter":
+    case "forof.string":
+      for (const sub of (instr as { body: readonly IrInstr[] }).body) applyInstrEffect(sub, state, allocOf);
+      break;
+    case "while.loop":
+    case "for.loop":
+    case "try":
+      for (const sub of nestedInstrArrays(instr)) applyInstrEffect(sub, state, allocOf);
+      break;
+
+    default:
+      // Pure / structural instrs (const, select, box, unbox, tag.test,
+      // string.const, string.concat, slot.read/write, global.get/set, unary,
+      // closure.cap, gen.*, raw.wasm, …) impose no ownership effect on their
+      // operands in Phase 1.
+      break;
+  }
+}
+
+function applyTerminatorEffect(term: IrTerminator, state: State, allocOf: Map<IrValueId, number>): void {
+  if (term.kind === "return") {
+    for (const v of term.values) markEscaped(state, v, allocOf);
+  }
+  // br / br_if / unreachable carry no escaping effect; branch args flow into
+  // successor block-args via the caller's join (they do not escape).
+}
+
+// ---------------------------------------------------------------------------
+// CFG + helpers
+// ---------------------------------------------------------------------------
+
+function successors(term: IrTerminator): { target: IrBlockId; args: readonly IrValueId[] }[] {
+  switch (term.kind) {
+    case "br":
+      return [term.branch];
+    case "br_if":
+      return [term.ifTrue, term.ifFalse];
+    case "return":
+    case "unreachable":
+      return [];
+  }
+}
+
+/** Lazy BOTTOM for a value: owned/{} for allocations, shared/{read} otherwise. */
+function bottomFor(value: IrValueId, allocOf: Map<IrValueId, number>): OwnershipAnnotation {
+  if (allocOf.has(value)) return { ownership: "owned", access: AccessSet.empty() };
+  // Non-allocated, never-seeded value (e.g. a global read result, a capture
+  // read, a value defined by a pure instr). Treat conservatively as shared.
+  return { ownership: "shared", access: AccessSet.of("read") };
+}
+
+function cloneState(s: State): State {
+  return new Map(s);
+}
+
+/** Join `src` into `dst` (component-wise). Returns true if `dst` changed. */
+function joinInto(dst: State, src: State): boolean {
+  let changed = false;
+  for (const [v, a] of src) {
+    if (mergeValue(dst, v, a)) changed = true;
+  }
+  return changed;
+}
+
+/** Join annotation `a` into `dst[value]`. Returns true if `dst` changed. */
+function mergeValue(dst: State, value: IrValueId, a: OwnershipAnnotation): boolean {
+  const prev = dst.get(value);
+  if (prev === undefined) {
+    dst.set(value, a);
+    return true;
+  }
+  const merged = joinAnnotations(prev, a);
+  if (annotationsEqual(prev, merged)) return false;
+  dst.set(value, merged);
+  return true;
+}
+
+/** Record every allocation result (instr carrying `alloc`) into `allocOf`. */
+function collectAllocs(fn: IrFunction, allocOf: Map<IrValueId, number>): void {
+  const walk = (instr: IrInstr): void => {
+    if (instr.result !== null && instr.alloc !== undefined) {
+      allocOf.set(instr.result, instr.alloc as unknown as number);
+    }
+    for (const sub of nestedInstrArrays(instr)) walk(sub);
+  };
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) walk(instr);
+  }
+}
+
+/** Yield every nested instr carried by control-flow-bearing instrs. */
+function* nestedInstrArrays(instr: IrInstr): Iterable<IrInstr> {
+  for (const value of Object.values(instr as unknown as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const el of value) if (isInstrLike(el)) yield el as IrInstr;
+    } else if (value !== null && typeof value === "object") {
+      for (const inner of Object.values(value as Record<string, unknown>)) {
+        if (Array.isArray(inner)) {
+          for (const el of inner) if (isInstrLike(el)) yield el as IrInstr;
+        }
+      }
+    }
+  }
+}
+
+function isInstrLike(v: unknown): boolean {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    typeof (v as { kind?: unknown }).kind === "string" &&
+    "result" in (v as object)
+  );
+}
+
+/** Best-effort: yield every IrValueId-typed operand of an instr (for extern ops). */
+function* operandsOf(instr: IrInstr): Iterable<IrValueId> {
+  for (const [key, value] of Object.entries(instr as unknown as Record<string, unknown>)) {
+    if (key === "result") continue;
+    if (typeof value === "number" && looksLikeValueId(instr, key)) {
+      yield value as unknown as IrValueId;
+    } else if (Array.isArray(value)) {
+      for (const el of value) {
+        if (typeof el === "number") yield el as unknown as IrValueId;
+      }
+    }
+  }
+}
+
+// Operand fields that hold IrValueIds across the instr union. Used to keep the
+// generic `operandsOf` from mistaking structural numbers (slot indices, capture
+// counts) for value ids.
+const VALUE_OPERAND_FIELDS = new Set([
+  "value",
+  "newValue",
+  "lhs",
+  "rhs",
+  "rand",
+  "cond",
+  "condition",
+  "callee",
+  "receiver",
+  "cell",
+  "vec",
+  "index",
+  "operand",
+  "reason",
+  "iterable",
+  "iter",
+  "resultObj",
+  "self",
+  "whenTrue",
+  "whenFalse",
+]);
+
+function looksLikeValueId(_instr: IrInstr, key: string): boolean {
+  return VALUE_OPERAND_FIELDS.has(key);
+}

--- a/src/ir/analysis/stack-alloc.ts
+++ b/src/ir/analysis/stack-alloc.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Demonstration consumer of the ownership analysis (#1587).
+//
+// The ownership pass is only worth keeping if a real consumer uses its output
+// (ADR-0014, "one demonstration consumer" requirement). This is that consumer:
+// it identifies allocations the analysis proved `owned` and never `escaped` —
+// the precondition for stack-allocation / scalar-replacement of a small,
+// short-lived object.
+//
+// IMPORTANT — Phase 1 is *annotation-only*. It does NOT rewrite the IR to
+// actually stack-allocate; it records a candidacy marker on the registry under
+// the ownership namespace (`stackCandidate: true`). The real lowering change is
+// a follow-up that flips proven candidates to a stack/scalar representation.
+// Keeping Phase 1 inert preserves the "removing the pass cannot change emitted
+// Wasm" guarantee while giving a measurable signal (candidate count) that the
+// analysis output is precise enough to build on.
+
+import type { AllocSiteRegistry } from "../alloc-registry.js";
+import { ALLOC_NAMESPACES } from "../alloc-registry.js";
+import type { AllocKind, IrFunction } from "../nodes.js";
+import { analyzeOwnership, type OwnershipResult } from "./ownership.js";
+
+/** A value-creating instr the analysis proved safe to stack-allocate. */
+export interface StackAllocCandidate {
+  readonly allocId: number;
+  readonly kind: AllocKind;
+}
+
+/** Allocation kinds small enough to be worth stack-allocating in Phase 1. */
+const SMALL_ALLOC_KINDS: ReadonlySet<AllocKind> = new Set<AllocKind>(["object", "refcell", "box"]);
+
+/**
+ * Find stack-allocation candidates in `fn` using an ownership result (computed
+ * fresh when not supplied). A candidate is an allocation that is:
+ *   - of a "small" kind (object / refcell / box — not array/closure/string),
+ *   - proven `owned`, and
+ *   - never `escaped`.
+ *
+ * When `registry` is supplied, each candidate's site is marked with a
+ * `stackCandidate: true` flag merged into its existing ownership annotation.
+ * The marker is inert at lowering — it changes no emitted Wasm.
+ */
+export function findStackAllocCandidates(
+  fn: IrFunction,
+  registry?: AllocSiteRegistry,
+  precomputed?: OwnershipResult,
+): StackAllocCandidate[] {
+  const result = precomputed ?? analyzeOwnership(fn, registry);
+  const candidates: StackAllocCandidate[] = [];
+
+  const visit = (instr: IrFunction["blocks"][number]["instrs"][number]): void => {
+    if (instr.result !== null && instr.alloc !== undefined) {
+      const kind = (instr as { kind: string }).kind;
+      const allocKind = allocKindOfInstr(kind);
+      if (allocKind !== null && SMALL_ALLOC_KINDS.has(allocKind) && result.isStackAllocatable(instr.result)) {
+        const allocId = instr.alloc as unknown as number;
+        candidates.push({ allocId, kind: allocKind });
+        if (registry) {
+          const prev = registry.read<Record<string, unknown>>(instr.alloc, ALLOC_NAMESPACES.ownership) ?? {};
+          registry.annotate(instr.alloc, ALLOC_NAMESPACES.ownership, { ...prev, stackCandidate: true });
+        }
+      }
+    }
+    for (const sub of nestedInstrs(instr)) visit(sub);
+  };
+
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) visit(instr);
+  }
+  return candidates;
+}
+
+/** Map a value-creating instr kind to its AllocKind, or null if not one. */
+function allocKindOfInstr(kind: string): AllocKind | null {
+  switch (kind) {
+    case "object.new":
+      return "object";
+    case "refcell.new":
+      return "refcell";
+    case "box":
+      return "box";
+    case "closure.new":
+      return "closure";
+    case "string.const":
+      return "string";
+    case "class.new":
+      return "object";
+    default:
+      return null;
+  }
+}
+
+function* nestedInstrs(
+  instr: IrFunction["blocks"][number]["instrs"][number],
+): Iterable<IrFunction["blocks"][number]["instrs"][number]> {
+  for (const value of Object.values(instr as unknown as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const el of value) if (isInstrLike(el)) yield el as never;
+    } else if (value !== null && typeof value === "object") {
+      for (const inner of Object.values(value as Record<string, unknown>)) {
+        if (Array.isArray(inner)) {
+          for (const el of inner) if (isInstrLike(el)) yield el as never;
+        }
+      }
+    }
+  }
+}
+
+function isInstrLike(v: unknown): boolean {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    typeof (v as { kind?: unknown }).kind === "string" &&
+    "result" in (v as object)
+  );
+}

--- a/src/ir/index.ts
+++ b/src/ir/index.ts
@@ -9,3 +9,6 @@ export * from "./lower.js";
 export * from "./select.js";
 export * from "./from-ast.js";
 export * from "./integration.js";
+export * from "./analysis/lattice.js";
+export * from "./analysis/ownership.js";
+export * from "./analysis/stack-alloc.js";

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -53,6 +53,7 @@ import type {
   IrType,
   IrTypeRef,
 } from "./nodes.js";
+import { analyzeOwnership } from "./analysis/ownership.js";
 import { constantFold } from "./passes/constant-fold.js";
 import { deadCode } from "./passes/dead-code.js";
 import { inlineSmall } from "./passes/inline-small.js";
@@ -442,6 +443,24 @@ export function compileIrPathFunctions(
   if (readyForLower.length === 0) return { compiled, errors };
 
   // -------------------------------------------------------------------------
+  // 2g. Ownership + access-semantics analysis (#1587) — gated, default OFF.
+  //
+  // Runs on the final (post-mono/TU) IR shape, writing inferred ownership /
+  // access annotations to the registry `ownership` namespace. The analysis is
+  // purely an optimization aid: it does NOT mutate the IR and registry
+  // annotations are inert at lowering, so emitted Wasm is byte-identical
+  // whether or not this runs (ADR-0014). Consumers query the per-function
+  // `OwnershipResult` (the demonstration consumer in `analysis/stack-alloc.ts`
+  // is likewise gated and annotation-only). Behind `JS2WASM_IR_OWNERSHIP=1`
+  // for the rollout period.
+  // -------------------------------------------------------------------------
+  if (ownershipAnalysisEnabled()) {
+    for (const entry of readyForLower) {
+      analyzeOwnership(entry.fn, allocRegistry);
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Register monomorphized clones in `ctx` — append a placeholder
   // WasmFunction slot and record the assigned funcIdx in `ctx.funcMap`.
   // The placeholder body is overwritten with the real lowered body in the
@@ -655,6 +674,15 @@ export function compileIrPathFunctions(
 
 function hasExportModifier(fn: ts.FunctionDeclaration): boolean {
   return !!fn.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+/**
+ * #1587 rollout gate. The ownership analysis is default-OFF: it only runs the
+ * extra (inert) analysis pass when explicitly enabled, so production builds pay
+ * nothing and emitted Wasm is unchanged until a consumer opts in.
+ */
+function ownershipAnalysisEnabled(): boolean {
+  return process.env.JS2WASM_IR_OWNERSHIP === "1" || process.env.JS2WASM_IR_OWNERSHIP === "true";
 }
 
 /**

--- a/tests/ir/ownership-analysis.test.ts
+++ b/tests/ir/ownership-analysis.test.ts
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1587 — intra-procedural ownership + access analysis.
+//
+// Covers the lattices (join / order / access union) and the seven IR fragments
+// the acceptance criteria call out:
+//   simple allocation, escape via return, escape via store-to-heap, escape via
+//   opaque call, mutation via field store, conditional escape via branching,
+//   loop-carried allocation.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AccessSet,
+  AllocSiteRegistry,
+  IrFunctionBuilder,
+  analyzeOwnership,
+  findStackAllocCandidates,
+  irVal,
+  joinOwnership,
+  ownershipLeq,
+  type IrObjectShape,
+  type IrType,
+  type IrValueId,
+} from "../../src/ir/index.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+
+const OBJ_SHAPE: IrObjectShape = { fields: [{ name: "x", type: F64 }] };
+const OBJ_TYPE: IrType = { kind: "object", shape: OBJ_SHAPE };
+
+/** Build a one-block function returning `values`, given a body emitter. */
+function buildFn(
+  emit: (b: IrFunctionBuilder) => IrValueId[],
+  opts: { params?: number; resultTypes?: readonly IrType[] } = {},
+) {
+  const reg = new AllocSiteRegistry();
+  const b = new IrFunctionBuilder("f", opts.resultTypes ?? [], false, reg);
+  for (let i = 0; i < (opts.params ?? 0); i++) b.addParam(`p${i}`, OBJ_TYPE);
+  b.openBlock();
+  const ret = emit(b);
+  b.terminate({ kind: "return", values: ret });
+  return { fn: b.finish(), reg };
+}
+
+describe("#1587 — ownership / access lattices", () => {
+  it("ownership join is the more-conservative of two states", () => {
+    expect(joinOwnership("owned", "borrowed")).toBe("borrowed");
+    expect(joinOwnership("borrowed", "shared")).toBe("shared");
+    expect(joinOwnership("shared", "escaped")).toBe("escaped");
+    expect(joinOwnership("owned", "owned")).toBe("owned");
+    // commutative
+    expect(joinOwnership("escaped", "owned")).toBe("escaped");
+  });
+
+  it("ownership order is owned ⊑ borrowed ⊑ shared ⊑ escaped", () => {
+    expect(ownershipLeq("owned", "escaped")).toBe(true);
+    expect(ownershipLeq("shared", "borrowed")).toBe(false);
+    expect(ownershipLeq("borrowed", "borrowed")).toBe(true);
+  });
+
+  it("access set union is join; subset is the order", () => {
+    const rw = AccessSet.of("read", "write");
+    const r = AccessSet.of("read");
+    expect(r.subsetOf(rw)).toBe(true);
+    expect(rw.subsetOf(r)).toBe(false);
+    expect(r.union(AccessSet.of("write")).equals(rw)).toBe(true);
+    expect(AccessSet.empty().toArray()).toEqual([]);
+    expect(AccessSet.full().has("escape")).toBe(true);
+  });
+});
+
+describe("#1587 — analysis on IR fragments", () => {
+  it("simple allocation that does not escape stays owned with no escape access", () => {
+    // const o = {x: 1}; return 1  (o never used after construction)
+    const { fn } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [one];
+      },
+      { resultTypes: [F64] },
+    );
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    expect(r.ownershipOf(objInstr.result!)).toBe("owned");
+    expect(r.accessOf(objInstr.result!).has("escape")).toBe(false);
+    expect(r.isStackAllocatable(objInstr.result!)).toBe(true);
+  });
+
+  it("escape via return marks the allocation escaped", () => {
+    // const o = {x: 1}; return o
+    const { fn } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [o];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    expect(r.ownershipOf(objInstr.result!)).toBe("escaped");
+    expect(r.accessOf(objInstr.result!).has("escape")).toBe(true);
+    expect(r.isStackAllocatable(objInstr.result!)).toBe(false);
+  });
+
+  it("escape via store-to-heap: a value stored into an object's field escapes", () => {
+    // const outer = {x:0}; const inner = {x:1}; outer.x = inner; return outer
+    const { fn } = buildFn(
+      (b) => {
+        const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+        const outer = b.emitObjectNew(OBJ_SHAPE, [zero]);
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const inner = b.emitObjectNew(OBJ_SHAPE, [one]);
+        b.emitObjectSet(outer, "x", inner);
+        return [outer];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const objInstrs = fn.blocks[0]!.instrs.filter((i) => i.kind === "object.new");
+    const outerV = objInstrs[0]!.result!;
+    const innerV = objInstrs[1]!.result!;
+    const r = analyzeOwnership(fn);
+    // outer is written (write access) and returned (escaped).
+    expect(r.accessOf(outerV).has("write")).toBe(true);
+    expect(r.ownershipOf(outerV)).toBe("escaped");
+    // inner escaped because it was stored into outer's field.
+    expect(r.ownershipOf(innerV)).toBe("escaped");
+    expect(r.accessOf(innerV).has("escape")).toBe(true);
+  });
+
+  it("escape via opaque call: an allocation passed to a call escapes with full intent", () => {
+    // const o = {x:1}; sink(o)
+    const { fn } = buildFn((b) => {
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+      b.emitCall({ kind: "func", name: "sink" }, [o], null);
+      return [];
+    });
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    expect(r.ownershipOf(objInstr.result!)).toBe("escaped");
+    expect(r.accessOf(objInstr.result!).has("escape")).toBe(true);
+  });
+
+  it("mutation via field store: receiver gains write access", () => {
+    // const o = {x:0}; o.x = 1  (o not returned — owned but written)
+    const { fn } = buildFn((b) => {
+      const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [zero]);
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      b.emitObjectSet(o, "x", one);
+      return [];
+    });
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    expect(r.accessOf(objInstr.result!).has("write")).toBe(true);
+    // Written but never escaped → still owned, still stack-allocatable.
+    expect(r.ownershipOf(objInstr.result!)).toBe("owned");
+    expect(r.isStackAllocatable(objInstr.result!)).toBe(true);
+  });
+
+  it("conditional escape: an allocation escaping on one branch is escaped at the merge", () => {
+    // entry: o = {x:1}; br_if c -> esc(o) / noesc
+    // esc: sink(o); br exit
+    // noesc: br exit
+    // exit: return
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [], false, reg);
+    const c = b.addParam("c", irVal({ kind: "i32" }));
+    const esc = b.reserveBlockId();
+    const noesc = b.reserveBlockId();
+    const exit = b.reserveBlockId();
+
+    b.openBlock();
+    const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+    const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+    b.terminate({
+      kind: "br_if",
+      condition: c,
+      ifTrue: { target: esc, args: [] },
+      ifFalse: { target: noesc, args: [] },
+    });
+
+    b.openReservedBlock(esc);
+    b.emitCall({ kind: "func", name: "sink" }, [o], null);
+    b.terminate({ kind: "br", branch: { target: exit, args: [] } });
+
+    b.openReservedBlock(noesc);
+    b.terminate({ kind: "br", branch: { target: exit, args: [] } });
+
+    b.openReservedBlock(exit);
+    b.terminate({ kind: "return", values: [] });
+
+    const fn = b.finish();
+    const objInstr = fn.blocks.flatMap((bl) => bl.instrs).find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    // Meet-over-paths: escapes on the `esc` branch ⇒ escaped overall.
+    expect(r.ownershipOf(objInstr.result!)).toBe("escaped");
+    expect(r.isStackAllocatable(objInstr.result!)).toBe(false);
+  });
+
+  it("loop-carried allocation that escapes via call inside the loop is escaped", () => {
+    // entry: br loop
+    // loop: o = {x:1}; sink(o); br_if c -> loop / exit
+    // exit: return
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [], false, reg);
+    const c = b.addParam("c", irVal({ kind: "i32" }));
+    const loop = b.reserveBlockId();
+    const exit = b.reserveBlockId();
+
+    b.openBlock();
+    b.terminate({ kind: "br", branch: { target: loop, args: [] } });
+
+    b.openReservedBlock(loop);
+    const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+    const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+    b.emitCall({ kind: "func", name: "sink" }, [o], null);
+    b.terminate({
+      kind: "br_if",
+      condition: c,
+      ifTrue: { target: loop, args: [] },
+      ifFalse: { target: exit, args: [] },
+    });
+
+    b.openReservedBlock(exit);
+    b.terminate({ kind: "return", values: [] });
+
+    const fn = b.finish();
+    const objInstr = fn.blocks.flatMap((bl) => bl.instrs).find((i) => i.kind === "object.new")!;
+    const r = analyzeOwnership(fn);
+    expect(r.ownershipOf(objInstr.result!)).toBe("escaped");
+  });
+
+  it("writes the ownership annotation to the registry namespace", () => {
+    const { fn, reg } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [o];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    analyzeOwnership(fn, reg);
+    const annot = reg.read<{ state: string; ops: string[] }>(objInstr.alloc!, "ownership");
+    expect(annot).toBeDefined();
+    expect(annot!.state).toBe("escaped");
+    expect(annot!.ops).toContain("escape");
+  });
+
+  it("demonstration consumer: an owned non-escaped object is a stack-alloc candidate", () => {
+    const { fn, reg } = buildFn((b) => {
+      const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [zero]);
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      b.emitObjectSet(o, "x", one); // mutated but never escapes
+      return [];
+    });
+    const objInstr = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const candidates = findStackAllocCandidates(fn, reg);
+    expect(candidates.map((c) => c.allocId)).toContain(objInstr.alloc! as unknown as number);
+    expect(candidates[0]!.kind).toBe("object");
+    // The marker is merged into the ownership annotation.
+    const annot = reg.read<{ stackCandidate?: boolean }>(objInstr.alloc!, "ownership");
+    expect(annot!.stackCandidate).toBe(true);
+  });
+
+  it("demonstration consumer: an escaped object is NOT a stack-alloc candidate", () => {
+    const { fn, reg } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [o]; // escapes via return
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const candidates = findStackAllocCandidates(fn, reg);
+    expect(candidates).toEqual([]);
+  });
+
+  it("a function parameter is seeded shared/read, never owned", () => {
+    const { fn } = buildFn(
+      (b) => {
+        return [];
+      },
+      { params: 1 },
+    );
+    const p0 = fn.params[0]!.value;
+    const r = analyzeOwnership(fn);
+    expect(r.ownershipOf(p0)).toBe("shared");
+    expect(r.accessOf(p0).has("read")).toBe(true);
+    expect(r.isStackAllocatable(p0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a flow-sensitive, intra-procedural may-escape analysis (#1587 Phase 1) over the typed IR, built on the #1586 `AllocSiteRegistry`.
- Infers two per-value lattices: **ownership** (`owned ⊑ borrowed ⊑ shared ⊑ escaped`) and **access** (powerset of `read/write/mutate/identity/escape`).
- Ships one **demonstration consumer** (stack-alloc candidate detection) per the issue's "no dead analysis" requirement.

## What landed
- `src/ir/analysis/lattice.ts` — lattices + joins (`joinOwnership`, `AccessSet.union`, `joinAnnotations`, `topAnnotation`).
- `src/ir/analysis/ownership.ts` — `analyzeOwnership(fn, registry?)`: monotone worklist over the CFG, seeds allocs `owned`/{} and imports `shared`/{read}, widens per-op, joins at merges + branch-args, writes the registry `ownership` namespace, returns an `OwnershipResult` query API (`of`/`ownershipOf`/`accessOf`/`isStackAllocatable`).
- `src/ir/analysis/stack-alloc.ts` — `findStackAllocCandidates`: proven-`owned`-non-`escaped` small allocs (object/refcell/box) → candidate list + inert `stackCandidate` marker.
- `docs/adr/0014-ownership-access-analysis.md` — lattices, joins, **conservative-defaults guarantee**, Rust-framing disclaimer, gating, phasing.
- `src/ir/integration.ts` step 2g — runs after mono/TU on the final IR shape, **gated behind `JS2WASM_IR_OWNERSHIP=1`, default OFF**.

## Inertness guarantee
The pass does not mutate the IR; registry annotations are inert at lowering. Verified: compiling a mutate-and-return function with the flag OFF vs ON produces **byte-identical Wasm** (642 bytes both). Removing the pass cannot change observable behavior.

## Test plan
- [x] `tests/ir/ownership-analysis.test.ts` — 14 tests covering the lattices + all 7 required IR fragments (simple alloc, escape via return / store-to-heap / opaque call, mutation via field store, conditional escape via branching, loop-carried alloc) + registry write-back + both demonstration-consumer cases.
- [x] `tsc --noEmit` + `biome lint` clean on all new/changed files.
- [x] Byte-identical Wasm flag on vs off.
- [x] Existing `tests/ir/alloc-*.test.ts` still green. Pre-existing `tests/ir/passes.test.ts` `__box_number` failures reproduce on clean main — unrelated.

Phases 2 (inter-procedural summaries) and 3 (precision) are follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)