### PR TITLE
fix(#1116b): bridge Wasm Promise subclasses as JS combinator thisArg

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -372,6 +372,63 @@ function emitIterableArg(ctx: CodegenContext, fctx: FunctionContext, argExpr: ts
   compileExpression(ctx, fctx, argExpr, { kind: "externref" });
 }
 
+/**
+ * (#1116b) Resolve a Promise-combinator `thisArg`/receiver that names a
+ * Wasm-compiled `class X extends Promise`.
+ *
+ * Such a class is externref-backed (#1366a/b): its instances are real host
+ * Promises (built via `__new_Promise`), but the class *identifier itself* has
+ * no class-object singleton global, so `compileExpression(MyPromise)` yields
+ * `null`/opaque — and `Promise.all.call(MyPromise, iter)` then throws
+ * `[object Object] is not a constructor` in V8. The fix: resolve the
+ * identifier to a real JS-callable Promise subclass synthesized (and cached)
+ * by the `__promise_subclass_ctor` host import, keyed on the class name.
+ *
+ * Returns true if it emitted a JS-constructor externref for `argExpr`; false
+ * if the caller should fall back to plain `compileExpression`.
+ */
+function resolvePromiseSubclassThisArg(ctx: CodegenContext, fctx: FunctionContext, argExpr: ts.Expression): boolean {
+  // (E7) Standalone (WASI) mode has no JS host, so `__promise_subclass_ctor`
+  // is unsatisfiable. Never emit the import there.
+  if (isStandalonePromiseActive(ctx)) return false;
+  // Only fires for a bare identifier (or class-expr alias) naming a class.
+  if (!ts.isIdentifier(argExpr)) return false;
+  const resolved = ctx.classExprNameMap.get(argExpr.text) ?? argExpr.text;
+  // Walk the parent chain so a chained subclass (E3 — `class B extends A`,
+  // `class A extends Promise`) still resolves: `classBuiltinParentMap` only
+  // records the *immediate* builtin parent, so B maps to "A", not "Promise".
+  let cursor: string | undefined = resolved;
+  let extendsPromise = false;
+  const seen = new Set<string>();
+  while (cursor !== undefined && !seen.has(cursor)) {
+    seen.add(cursor);
+    if (ctx.classBuiltinParentMap.get(cursor) === "Promise") {
+      extendsPromise = true;
+      break;
+    }
+    cursor = ctx.classParentMap.get(cursor);
+  }
+  if (!extendsPromise) return false;
+  const importName = "__promise_subclass_ctor";
+  let funcIdx =
+    ctx.funcMap.get(importName) ?? ensureLateImport(ctx, importName, [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  funcIdx = ctx.funcMap.get(importName) ?? funcIdx;
+  if (funcIdx === undefined) return false;
+  // Push the class name (the synthesized subclass is cached per name). Use the
+  // same host-string mechanism as extern method dispatch so it works in both
+  // string backends.
+  addStringConstantGlobal(ctx, resolved);
+  const nameIdx = ctx.stringGlobalMap.get(resolved);
+  if (nameIdx !== undefined) {
+    fctx.body.push({ op: "global.get", index: nameIdx } as Instr);
+  } else {
+    compileStringLiteral(ctx, fctx, resolved);
+  }
+  fctx.body.push({ op: "call", funcIdx });
+  return true;
+}
+
 function usesArguments(node: ts.Node): boolean {
   if (ts.isIdentifier(node) && node.text === "arguments") return true;
   if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
@@ -3985,13 +4042,32 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     // helper can construct via `thisArg.call(...)` for subclass support.
     // Resolve/reject keep their original 1-arg signature (no thisArg needed).
     {
+      const isAggregatorMethod =
+        propAccess.name.text === "all" ||
+        propAccess.name.text === "race" ||
+        propAccess.name.text === "allSettled" ||
+        propAccess.name.text === "any";
+      // (#1116b, E1) `Sub.all(iter)` where `Sub` is a `class extends Promise`
+      // is a subclass static inherited from Promise. Recognise the subclass
+      // receiver here too so it reaches the aggregator lowering (the thisArg
+      // resolution below switches it to directCall=0).
+      const isPromiseSubclassReceiver =
+        ts.isIdentifier(propAccess.expression) &&
+        (() => {
+          const name = ctx.classExprNameMap.get(propAccess.expression.text) ?? propAccess.expression.text;
+          let cursor: string | undefined = name;
+          const seen = new Set<string>();
+          while (cursor !== undefined && !seen.has(cursor)) {
+            seen.add(cursor);
+            if (ctx.classBuiltinParentMap.get(cursor) === "Promise") return true;
+            cursor = ctx.classParentMap.get(cursor);
+          }
+          return false;
+        })();
       const isAggregator =
         ts.isIdentifier(propAccess.expression) &&
-        propAccess.expression.text === "Promise" &&
-        (propAccess.name.text === "all" ||
-          propAccess.name.text === "race" ||
-          propAccess.name.text === "allSettled" ||
-          propAccess.name.text === "any");
+        (propAccess.expression.text === "Promise" || isPromiseSubclassReceiver) &&
+        isAggregatorMethod;
       const isResolveReject =
         ts.isIdentifier(propAccess.expression) &&
         propAccess.expression.text === "Promise" &&
@@ -4015,9 +4091,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         flushLateImportShifts(ctx, fctx);
         funcIdx = ctx.funcMap.get(importName) ?? funcIdx;
         if (funcIdx !== undefined) {
-          // Direct `Promise.METHOD(iter)` — no explicit thisArg.
-          // (Subclass `Sub.all(iter)` is handled below via the receiver-detection branch.)
-          fctx.body.push({ op: "ref.null.extern" });
+          // (#1116b, E1) Subclass static `Sub.all(iter)` — the receiver
+          // `Sub` is a `class extends Promise`. Resolve it to the synthesized
+          // JS subclass as thisArg and switch to directCall=0 so the runtime
+          // uses it instead of substituting globalThis.Promise.
+          const subclassThisArg = resolvePromiseSubclassThisArg(ctx, fctx, propAccess.expression);
+          if (!subclassThisArg) {
+            // Direct `Promise.METHOD(iter)` — no explicit thisArg.
+            fctx.body.push({ op: "ref.null.extern" });
+          }
           if (expr.arguments.length >= 1) {
             // (#1465) The runtime helper delegates to native
             // `Promise.METHOD.call(C, iter)` which drives `GetIterator(iter)`
@@ -4032,8 +4114,10 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           } else {
             fctx.body.push({ op: "ref.null.extern" });
           }
-          // directCall=1 — runtime substitutes globalThis.Promise.
-          fctx.body.push({ op: "i32.const", value: 1 });
+          // directCall=1 — runtime substitutes globalThis.Promise. When a
+          // subclass receiver was resolved (E1), directCall=0 so the runtime
+          // uses the synthesized thisArg ctor instead.
+          fctx.body.push({ op: "i32.const", value: subclassThisArg ? 0 : 1 });
           fctx.body.push({ op: "call", funcIdx });
           return { kind: "externref" };
         }
@@ -4125,7 +4209,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       if (funcIdx !== undefined) {
         // arg0 = thisArg (user-provided — may be undefined/null/primitive,
         // in which case the runtime / V8 throws TypeError per spec §27.2.4.X step 2).
-        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+        // (#1116b) When thisArg names a `class X extends Promise`, resolve it to
+        // a synthesized JS-callable Promise subclass; otherwise compile normally.
+        if (!resolvePromiseSubclassThisArg(ctx, fctx, expr.arguments[0]!)) {
+          compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+        }
         // arg1 = iterable (or ref.null if missing). #1465: materialise array
         // literals to JS arrays so native GetIterator can drive them.
         if (expr.arguments.length >= 2) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5578,6 +5578,33 @@ assert._isSameValue = isSameValue;
         if (directCall) return Promise;
         return thisArg;
       };
+      // (#1116b) Synthesize (and cache) a JS subclass of Promise for a
+      // Wasm-compiled `class MyPromise extends Promise`. The instance is
+      // already a real host Promise (built via __new_Promise); this JS
+      // constructor only needs to be [[Construct]]-able and carry a distinct
+      // .prototype so the combinators' NewPromiseCapability + @@species
+      // resolution work. Keyed on class name. Synthesized from the lexical
+      // (intrinsic) `Promise`, never a user-shadowed global.
+      if (name === "__promise_subclass_ctor") {
+        const _promiseSubclassCtors = new Map<string, any>();
+        return (classNameRef: any): any => {
+          const className = String(classNameRef);
+          let C = _promiseSubclassCtors.get(className);
+          if (C === undefined) {
+            // Cast the base to a plain constructor: `class extends Promise {}`
+            // trips TS2508 (Promise's lib.d.ts type is generic) but is valid
+            // JS — the emitted runtime subclasses the intrinsic Promise.
+            C = class extends (Promise as unknown as { new (...args: any[]): any }) {};
+            try {
+              Object.defineProperty(C, "name", { value: className, configurable: true });
+            } catch {
+              /* Function.name redefinition is best-effort; non-fatal. */
+            }
+            _promiseSubclassCtors.set(className, C);
+          }
+          return C;
+        };
+      }
       if (name === "Promise_all")
         return (thisArg: any, arr: any, directCall: number) => {
           const C = _resolveCtor(thisArg, directCall);

--- a/tests/issue-1116b.test.ts
+++ b/tests/issue-1116b.test.ts
@@ -1,0 +1,114 @@
+// #1116b — Wasm-class-as-JS-ctor bridge for Promise subclasses.
+//
+// A `class MyPromise extends Promise` is externref-backed (#1366a/b): its
+// instances are real host Promises, but the class *identifier* has no
+// class-object singleton, so `Promise.all.call(MyPromise, iter)` used to push
+// null/opaque as thisArg and V8 threw "[object Object] is not a constructor".
+//
+// The fix (src/codegen/expressions/calls.ts `resolvePromiseSubclassThisArg` +
+// src/runtime.ts `__promise_subclass_ctor`) resolves the identifier to a
+// runtime-synthesized JS subclass of Promise, keyed on class name, so the
+// combinator's NewPromiseCapability + @@species resolution succeed.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<WebAssembly.Exports> {
+  const r = compile(src);
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const m = await WebAssembly.instantiate(r.binary, imports);
+  const setExports = (imports as unknown as { setExports?: (e: WebAssembly.Exports) => void }).setExports;
+  if (typeof setExports === "function") setExports(m.instance.exports);
+  return m.instance.exports;
+}
+
+describe("#1116b — Promise subclass as combinator thisArg", () => {
+  it("Promise.all.call(Subclass, iter) does not throw 'is not a constructor'", async () => {
+    const ex = await instantiate(`
+      class MyPromise extends Promise<number> {}
+      export async function main(): Promise<number> {
+        await Promise.all.call(MyPromise, [Promise.resolve(1), Promise.resolve(2)]);
+        return 1;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(1);
+  });
+
+  it("Promise.race.call(Subclass, iter) resolves", async () => {
+    const ex = await instantiate(`
+      class P extends Promise<number> {}
+      export async function main(): Promise<number> {
+        await Promise.race.call(P, [Promise.resolve(5), Promise.resolve(9)]);
+        return 1;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(1);
+  });
+
+  it("Promise.allSettled.call(Subclass, mixed) resolves", async () => {
+    const ex = await instantiate(`
+      class P extends Promise<number> {}
+      export async function main(): Promise<number> {
+        await Promise.allSettled.call(P, [Promise.resolve(1), Promise.reject(2)]);
+        return 1;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(1);
+  });
+
+  it("Promise.any.call(Subclass, iter) resolves to first-fulfilled", async () => {
+    const ex = await instantiate(`
+      class P extends Promise<number> {}
+      export async function main(): Promise<number> {
+        await Promise.any.call(P, [Promise.reject(1), Promise.resolve(2)]);
+        return 1;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(1);
+  });
+
+  it("E1: subclass static Sub.all(iter) resolves without throwing", async () => {
+    const ex = await instantiate(`
+      class P extends Promise<number> {}
+      export async function main(): Promise<number> {
+        await P.all([Promise.resolve(1), Promise.resolve(2)]);
+        return 1;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(1);
+  });
+
+  it("regression: plain Promise.all (no subclass) still works", async () => {
+    const ex = await instantiate(`
+      export async function main(): Promise<number> {
+        await Promise.all([Promise.resolve(1)]);
+        return 7;
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(7);
+  });
+
+  it("regression: Promise.all.call(undefined, []) still rejects with TypeError", async () => {
+    // PR #436 behavior must be preserved — the guard returns false for a
+    // non-Promise-subclass thisArg, so the existing TypeError path fires.
+    const ex = await instantiate(`
+      export async function main(): Promise<number> {
+        try {
+          await Promise.all.call(undefined as any, [] as Promise<number>[]);
+          return 0;
+        } catch (e) {
+          return 99;
+        }
+      }
+    `);
+    const result = await (ex.main as () => Promise<number>)();
+    expect(result).toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary
- `class X extends Promise` is externref-backed (#1366a/b): instances are real host Promises, but the class identifier has no class-object singleton, so `Promise.all.call(X, iter)` pushed null/opaque as thisArg and V8 threw `[object Object] is not a constructor` (~61 test262 fails in `built-ins/Promise/*/{ctx-ctor,species-*}`).
- Adds `resolvePromiseSubclassThisArg` in `calls.ts`: when a combinator thisArg (`.call` form) or receiver (`Sub.all(...)` direct form) names a class whose parent chain reaches `extends Promise`, resolves it to a runtime-synthesized JS Promise subclass via the new `__promise_subclass_ctor` host import (lazily created + cached by class name from the intrinsic `Promise`). Flips the 3-arg import's `directCall` flag to 0 so the runtime uses the synthesized ctor.
- Implements v2 spec (PR #528). Does **not** depend on the v1 `_buildJsConstructorBridge`/`__register_constructor` infra (which never existed).

## Scope / edge cases
- E1 (`Sub.all(iter)` direct static) — handled by broadening `isAggregator` + thisArg resolution.
- E3 (chained `class B extends A extends Promise`) — handled via parent-chain walk.
- E7 (standalone/WASI) — guarded out (`isStandalonePromiseActive`); no JS host.
- E4 (user-constructor side effects) — documented deferred limitation (matches v2 spec).

## Test plan
- [x] 7 new equivalence tests in `tests/issue-1116b.test.ts` (all/race/allSettled/any via `.call`, E1 direct static, plain-Promise regression, undefined-thisArg TypeError regression) — all pass.
- [x] `#1366a` / `#1366b` (`class extends Promise`) / `#1455` suites green (24 pass).
- [x] No regression in class suites — verified clean-vs-branch (identical pre-existing failures in `classes.test.ts` and `promise-combinators.test.ts` host-class-boundary cases, unrelated to this change).
- [ ] CI test262 conformance — expect ≥50 of ~61 species/ctx-ctor Promise tests to flip to pass, zero regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)