### PR TITLE
fix(#1565,#1566): ToBoolean(BigInt) i64.eqz + ToNumber(Symbol) TypeError

### DIFF
--- a/plan/issues/backlog/1565-toBoolean-bigint-i64-eqz.md
+++ b/plan/issues/backlog/1565-toBoolean-bigint-i64-eqz.md
@@ -1,7 +1,8 @@
 ---
 id: 1565
 title: "ToBoolean BigInt: must use i64.eqz, not f64.convert_i64_s (§7.1.2)"
-status: ready
+status: done
+sprint: 55
 priority: medium
 feasibility: easy
 reasoning_effort: low

--- a/plan/issues/backlog/1566-toNumber-symbol-throws-typeError.md
+++ b/plan/issues/backlog/1566-toNumber-symbol-throws-typeError.md
@@ -1,7 +1,8 @@
 ---
 id: 1566
 title: "ToNumber: Symbol argument must throw TypeError (§7.1.4)"
-status: ready
+status: done
+sprint: 55
 priority: medium
 feasibility: easy
 reasoning_effort: low

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6175,6 +6175,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
     // Number(x) — ToNumber coercion
     if (funcName === "Number" && expr.arguments.length >= 1) {
+      // ToNumber(Symbol) must throw TypeError (§7.1.4). Symbols are lowered to
+      // i32 ids, so a numeric pass-through would silently leak the id; detect
+      // the symbol TS type and throw instead.
+      if (isSymbolType(ctx.checker.getTypeAtLocation(expr.arguments[0]!))) {
+        const t = compileExpression(ctx, fctx, expr.arguments[0]!);
+        if (t !== null) fctx.body.push({ op: "drop" });
+        emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a number");
+        return { kind: "f64" };
+      }
       const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
       if (argType?.kind === "i64") {
         // BigInt → number: f64.convert_i64_s
@@ -6383,6 +6392,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         // i32: truthy if != 0
         fctx.body.push({ op: "i32.const", value: 0 });
         fctx.body.push({ op: "i32.ne" } as Instr);
+        return { kind: "i32" };
+      }
+      if (argType?.kind === "i64") {
+        // BigInt (§7.1.2 ToBoolean): 0n → false, any other BigInt → true.
+        // i64.eqz yields 1 for 0n; invert with i32.eqz so nonzero → 1.
+        // Must NOT route through f64.convert_i64_s — that loses precision
+        // for |x| > 2^53 and would misreport large BigInts.
+        fctx.body.push({ op: "i64.eqz" } as Instr);
+        fctx.body.push({ op: "i32.eqz" } as Instr);
         return { kind: "i32" };
       }
       // String: truthy if length > 0

--- a/src/codegen/expressions/unary.ts
+++ b/src/codegen/expressions/unary.ts
@@ -9,6 +9,7 @@
  * `PlusPlusToken` / `MinusMinusToken` cases.
  */
 import { ts } from "../../ts-api.js";
+import { isSymbolType } from "../../checker/type-mapper.js";
 import type { ValType } from "../../ir/types.js";
 import { emitToInt32 } from "../binary-ops.js";
 import { reportError } from "../context/errors.js";
@@ -16,6 +17,7 @@ import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { ensureAnyHelpers, ensureI32Condition, isAnyValue } from "../index.js";
 import { coerceType, compileExpression } from "../shared.js";
+import { emitThrowTypeError } from "./helpers.js";
 import { tryStaticToNumber } from "./misc.js";
 import { compileMemberIncDec, compilePostfixUnary, compilePrefixUpdate } from "./unary-updates.js";
 
@@ -27,6 +29,15 @@ function compilePrefixUnary(
   switch (expr.operator) {
     case ts.SyntaxKind.PlusToken: {
       // Unary + is ToNumber coercion
+      // ToNumber(Symbol) must throw TypeError (§7.1.4). Symbols are lowered
+      // to i32 ids, so a numeric coercion would silently turn the id into a
+      // number; detect the symbol TS type and throw instead.
+      if (isSymbolType(ctx.checker.getTypeAtLocation(expr.operand))) {
+        const t = compileExpression(ctx, fctx, expr.operand);
+        if (t !== null) fctx.body.push({ op: "drop" });
+        emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a number");
+        return { kind: "f64" };
+      }
       // Try static resolution first (handles objects with valueOf, {}, NaN, etc.)
       const staticVal = tryStaticToNumber(ctx, expr.operand);
       if (staticVal !== undefined) {

--- a/tests/issue-1565.test.ts
+++ b/tests/issue-1565.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #1565 — ToBoolean(BigInt) must use i64.eqz, not f64.convert_i64_s (§7.1.2).
+ *
+ * Per ECMA-262 §7.1.2 ToBoolean, the BigInt path is binary: `0n` is `false`,
+ * every other BigInt is `true`. Routing through `f64.convert_i64_s` first
+ * (the old behaviour) both produced a Wasm type error (i64 left on the stack
+ * for `Boolean(...)`) and would lose precision for |x| > 2^53.
+ *
+ * Fix in `src/codegen/expressions/calls.ts`: add an i64 case to the
+ * `Boolean(x)` handler — `i64.eqz` then `i32.eqz` (zero → false, nonzero →
+ * true). The `if (bigint)` condition path already had an i64.eqz branch in
+ * `ensureI32Condition`, so this completes the coverage.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("issue #1565 — ToBoolean(BigInt) via i64.eqz", () => {
+  it("Boolean(0n) === false", async () => {
+    const ex = await compileToWasm("export function test(): boolean { return Boolean(0n); }");
+    expect(ex.test!()).toBe(0);
+  });
+
+  it("Boolean(1n) === true", async () => {
+    const ex = await compileToWasm("export function test(): boolean { return Boolean(1n); }");
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("Boolean of a BigInt > 2^53 === true (no f64 precision loss)", async () => {
+    // 9007199254780000n > Number.MAX_SAFE_INTEGER. Going through
+    // f64.convert_i64_s would be lossy but still truthy here; the point is
+    // the i64.eqz path never rounds toward zero. (BigInts wider than i64 —
+    // e.g. 2n ** 100n — are a separate representation limit, not in scope.)
+    const ex = await compileToWasm("export function test(): boolean { return Boolean(9007199254780000n); }");
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("if (0n) does not enter the branch", async () => {
+    const ex = await compileToWasm("export function test(): number { if (0n) { return 1; } return 0; }");
+    expect(ex.test!()).toBe(0);
+  });
+
+  it("if (5n) enters the branch", async () => {
+    const ex = await compileToWasm("export function test(): number { if (5n) { return 1; } return 0; }");
+    expect(ex.test!()).toBe(1);
+  });
+});

--- a/tests/issue-1566.test.ts
+++ b/tests/issue-1566.test.ts
@@ -1,0 +1,54 @@
+/**
+ * #1566 — ToNumber(Symbol) must throw TypeError (§7.1.4).
+ *
+ * Per ECMA-262 §7.1.4 ToNumber: "If argument is a Symbol, throw a TypeError
+ * exception." Symbols are lowered to i32 ids in this compiler, so a numeric
+ * coercion (`+sym`, `Number(sym)`) previously emitted `f64.convert_i32_s`
+ * (or a pass-through), silently turning the id into a number.
+ *
+ * Fix: detect the symbol TS type at the unary-`+` (`src/codegen/expressions/
+ * unary.ts`) and `Number(x)` (`src/codegen/expressions/calls.ts`) ToNumber
+ * sites and throw a TypeError instance instead of coercing.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("issue #1566 — ToNumber(Symbol) throws TypeError", () => {
+  it("+Symbol() throws a TypeError instance", async () => {
+    const ex = await compileToWasm(`
+export function test(): string {
+  try { const x = +Symbol('x'); return 'no-throw'; }
+  catch (e: any) { return e instanceof TypeError ? 'TypeError' : 'other'; }
+}`);
+    expect(ex.test!()).toBe("TypeError");
+  });
+
+  it("+s (s: symbol) throws a TypeError instance", async () => {
+    const ex = await compileToWasm(`
+export function test(): string {
+  const s: symbol = Symbol();
+  try { const x = +s; return 'no-throw'; }
+  catch (e: any) { return e instanceof TypeError ? 'TypeError' : 'other'; }
+}`);
+    expect(ex.test!()).toBe("TypeError");
+  });
+
+  it("Number(Symbol()) throws a TypeError instance", async () => {
+    const ex = await compileToWasm(`
+export function test(): string {
+  try { const x = Number(Symbol('x')); return 'no-throw'; }
+  catch (e: any) { return e instanceof TypeError ? 'TypeError' : 'other'; }
+}`);
+    expect(ex.test!()).toBe("TypeError");
+  });
+
+  it("does not regress numeric ToNumber: +'42' === 42", async () => {
+    const ex = await compileToWasm("export function test(): number { return +'42'; }");
+    expect(ex.test!()).toBe(42);
+  });
+
+  it("does not regress Number('3.5') === 3.5", async () => {
+    const ex = await compileToWasm("export function test(): number { return Number('3.5'); }");
+    expect(ex.test!()).toBe(3.5);
+  });
+});


### PR DESCRIPTION
## Summary
Two spec-strictness fixes from the backlog, batched (sprint 55).

- **#1565** — `Boolean(bigint)` fell through every case in the `Boolean()` handler in `calls.ts`, leaving an i64 on the Wasm stack (type error) and, via the f64 path used elsewhere, losing precision for |x| > 2^53. Added an i64 case: `i64.eqz` then `i32.eqz` so `0n → false`, any other (i64-representable) BigInt → true, per ECMAScript §7.1.2 ToBoolean.
- **#1566** — Symbols lower to i32 ids, so unary `+sym` and `Number(sym)` silently coerced the id to a number. Per §7.1.4 ToNumber, a Symbol argument must throw a TypeError. Detect the symbol TS type at both ToNumber sites (`unary.ts` unary-plus, `calls.ts` `Number()`) and throw a real `TypeError` instance.

Note: BigInts wider than i64 (e.g. `2n ** 100n`) are a separate representation limit, not in scope here.

## Test plan
- [x] `tests/issue-1565.test.ts` — Boolean(0n)=false, Boolean(1n)=true, Boolean(>2^53)=true, if(0n)/if(5n) branch
- [x] `tests/issue-1566.test.ts` — `+Symbol()`, `+s`, `Number(Symbol())` throw TypeError; `+'42'`/`Number('3.5')` unchanged
- [x] `npx tsc --noEmit` clean
- [x] No regressions in `tests/issue-1526.test.ts` (BigInt arithmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)