### PR TITLE
fix(#1151): broaden isAsyncCallExpression to Promise-returning callees (Gap A1)

### DIFF
--- a/plan/issues/backlog/1151-async-function-synchronous-throws-bypass.md
+++ b/plan/issues/backlog/1151-async-function-synchronous-throws-bypass.md
@@ -469,7 +469,39 @@ spec §5: ≤ 10 regressions, no single bucket > 50. Net target: **−5 ≤ Δ �
 
 | Gap | Owner | Status |
 |-----|-------|--------|
-| B — `closures.ts:1170` binding-pattern coercion | dev (1-line + mirror) | ready, ship first |
-| A1 — `expressions.ts:154` detector broadening | dev (~15 LOC) | ready, ship second |
+| B — `closures.ts:1170` binding-pattern coercion | dev (1-line + mirror) | DONE (landed on main; guard at closures.ts:1229) |
+| A1 — `expressions.ts:154` detector broadening | dev (~15 LOC) | DONE (dev-1587, this PR) |
 | A2 — body-wrap safety net | defer | open sub-issue only if residual traps remain |
 | C — `src/ir/lower.ts` comment + assertion | senior-dev | bundled with #1373b gate flip |
+
+## Gap A1 implementation (dev-1587, 2026-05-23)
+
+Shipped the detector broadening in `src/codegen/expressions.ts`
+`isAsyncCallExpression`. After the existing identifier + decl-modifier checks,
+added a fallback: inspect the callee type's CALL signatures
+(`ctx.checker.getTypeAtLocation(expr.expression).getCallSignatures()`) and
+return true if any return type satisfies `isPromiseType(...)`. Construct
+signatures are excluded by `getCallSignatures()` (so `new Foo()` callees never
+match); async generators return AsyncGenerator (not Promise) so they remain
+excluded.
+
+**Reproduction (verified on current main before the fix):** a callback param
+typed `() => Promise<T>` whose body throws synchronously **trapped** at the
+wasm boundary — `isAsyncCallExpression` returned false (anonymous signature, no
+`async` decl modifier) so `wrapAsyncCallInTryCatch` never fired. After the fix,
+the call is recognised as async and the throw surfaces as a rejected Promise.
+
+**Tests:** `tests/issue-1151-gap-a1.test.ts` (4 cases): Promise-returning
+callback param, variable-aliased async fn, sync-fn-returns-Promise (still
+wrapped — correct per spec), and a negative guard (non-Promise callback NOT
+wrapped).
+
+**Regression check:** local async/promise equivalence suites have pre-existing
+failures (the `assertEquivalent` harness cannot await Wasm Promise returns) —
+verified identical fail set on clean main; my change reduced failed files 5→4
+(net-neutral-to-positive). `effectiveRetType`, `wrapAsyncCallInTryCatch`, and
+the `await asyncCall()` fast-path were NOT touched, per the critical rules.
+
+**Not in scope / deferred:** Gap A2 (body-wrap safety net) — open only if a
+residual sync-throw cluster remains after CI measures A1. Gap C (`src/ir/lower.ts`
+`IrInstrAsyncThrow`) — bundled with the #1373b gate flip (senior-dev).

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -12,7 +12,7 @@
  *   4. Registers delegates in shared.ts (registerCompileExpression, etc.)
  */
 import { ts } from "../ts-api.js";
-import { mapTsTypeToWasm } from "../checker/type-mapper.js";
+import { isPromiseType, mapTsTypeToWasm } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import {
   emitStandalonePromiseReject,
@@ -166,6 +166,24 @@ function isAsyncCallExpression(ctx: CodegenContext, expr: ts.CallExpression): bo
         if (mod.kind === ts.SyntaxKind.AsyncKeyword) return true;
       }
     }
+  }
+
+  // (#1151 Gap A1) Detector fallback for async calls the decl-modifier check
+  // above misses: a callee with no reachable declaration / no `async` modifier
+  // but whose call signature returns `Promise<T>`. Covers callbacks typed
+  // `() => Promise<T>`, variables holding async refs whose declared type is the
+  // function type (not the `async function` decl), and anonymous IIFEs. A
+  // function that *returns a Promise* must still convert a synchronous throw
+  // into a rejection (same contract), so wrapping these is correct.
+  //
+  // Excluded by construction:
+  //   - constructors — `getCallSignatures()` returns CALL signatures only, not
+  //     construct signatures, so `new Foo()` callees contribute nothing here.
+  //   - async generators — their call signatures return AsyncGenerator, not
+  //     Promise, so `isPromiseType` is already false for them.
+  const calleeType = ctx.checker.getTypeAtLocation(expr.expression);
+  for (const callSig of calleeType.getCallSignatures()) {
+    if (isPromiseType(callSig.getReturnType())) return true;
   }
 
   return false;

--- a/tests/issue-1151-gap-a1.test.ts
+++ b/tests/issue-1151-gap-a1.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// Issue #1151 Gap A1: `isAsyncCallExpression` missed call shapes whose callee
+// has no reachable `async` declaration but whose call signature returns
+// `Promise<T>` — most importantly a callback parameter typed
+// `() => Promise<T>`. Such calls were not wrapped by `wrapAsyncCallInTryCatch`
+// (#1150), so a synchronous throw in the callee trapped at the wasm boundary
+// instead of surfacing as a rejected Promise.
+//
+// The fix adds a fallback in `isAsyncCallExpression` (expressions.ts): after
+// the decl-modifier check, inspect the callee type's CALL signatures and treat
+// the call as async if any returns a Promise. Construct signatures (`new`) are
+// excluded by `getCallSignatures()`; async generators return AsyncGenerator
+// (not Promise) so `isPromiseType` is already false for them.
+//
+// Spec: ECMA-262 §27.7.5.2 AsyncFunctionStart — an async function always
+// returns a Promise; a synchronous throw must become a rejected Promise.
+
+describe("issue #1151 Gap A1 — broaden async-call detection", () => {
+  it("a Promise-returning callback param: call result is a thenable, not a trap", async () => {
+    const src = `
+      function invoke(cb: () => Promise<number>): number {
+        const p: any = cb();
+        return p && typeof p.then === "function" ? 1 : 0;
+      }
+      async function thrower(): Promise<number> { throw 7; }
+      export function run(): number {
+        return invoke(thrower);
+      }
+    `;
+    const exports = await compileToWasm(src);
+    let trapped = false;
+    let val: unknown;
+    try {
+      val = (exports as Record<string, () => unknown>).run();
+    } catch {
+      trapped = true;
+    }
+    expect(trapped).toBe(false);
+    expect(val).toBe(1);
+    // Swallow the unhandled rejection from the thrower() Promise (no handler attached).
+    await Promise.resolve();
+  });
+
+  it("variable holding an async function ref: call wraps the sync throw", async () => {
+    const src = `
+      async function ax(): Promise<number> { throw 42; }
+      export function run(): number {
+        const f = ax;
+        const p: any = f();
+        return p && typeof p.then === "function" ? 1 : 0;
+      }
+    `;
+    const exports = await compileToWasm(src);
+    const val = (exports as Record<string, () => unknown>).run();
+    expect(val).toBe(1);
+    await Promise.resolve();
+  });
+
+  it("sync function declared to return Promise<T>: result is still a thenable", async () => {
+    // The fix intentionally also wraps sync functions whose declared return is
+    // Promise<T> — a sync throw from such a function still violates the
+    // Promise contract and must reject. Here the function does not throw, so
+    // the only observable effect is that the result is a real Promise.
+    const src = `
+      function makeP(): Promise<number> { return Promise.resolve(5); }
+      export function run(): number {
+        const p: any = makeP();
+        return p && typeof p.then === "function" ? 1 : 0;
+      }
+    `;
+    const exports = await compileToWasm(src);
+    const val = (exports as Record<string, () => unknown>).run();
+    expect(val).toBe(1);
+    await Promise.resolve();
+  });
+
+  it("a non-Promise-returning callback is NOT treated as async", async () => {
+    // Guard against over-broadening: a plain `() => number` callback must not
+    // get Promise-wrapped — its result stays a raw number.
+    const src = `
+      function invoke(cb: () => number): number {
+        return cb();
+      }
+      function plain(): number { return 11; }
+      export function run(): number {
+        return invoke(plain);
+      }
+    `;
+    const exports = await compileToWasm(src);
+    const val = (exports as Record<string, () => unknown>).run();
+    expect(val).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1151 **Gap A1**: `isAsyncCallExpression` (src/codegen/expressions.ts) missed call shapes whose callee has no reachable `async` declaration but whose call signature returns `Promise<T>` — most importantly a callback param typed `() => Promise<T>`.
- Such calls were not wrapped by `wrapAsyncCallInTryCatch` (#1150), so a **synchronous throw** in the callee trapped at the wasm boundary instead of surfacing as a rejected Promise.

## Fix
After the existing identifier + decl-modifier checks, inspect the callee type's CALL signatures (`getTypeAtLocation(expr.expression).getCallSignatures()`) and treat the call as async if any return type satisfies `isPromiseType(...)`.
- Construct signatures excluded by `getCallSignatures()` → `new Foo()` never matches.
- Async generators return AsyncGenerator (not Promise) → already excluded.

## Reproduction (verified on current main before fix)
A `() => Promise<T>` callback whose body throws synchronously **traps**; the broadened detector now routes it through the existing call-site try/catch so it **rejects**.

## Scope
- Gap B (binding-pattern param coercion) already landed on main (guard at closures.ts:1229) — not re-touched.
- Gap A2 (body-wrap safety net) and Gap C (`src/ir/lower.ts` IrInstrAsyncThrow) remain deferred per the architect spec.
- Did **not** touch `effectiveRetType`, `wrapAsyncCallInTryCatch`, or the `await asyncCall()` fast-path (critical rules).

## Test plan
- [x] `tests/issue-1151-gap-a1.test.ts` — 4 cases: Promise-returning callback param, variable-aliased async fn, sync-fn-returns-Promise (still wrapped — correct per spec), and a negative guard (non-Promise callback NOT wrapped).
- [x] tsc + biome + prettier clean.
- [x] Local async/promise equivalence failures are pre-existing (assertEquivalent can't await Wasm Promise returns) — verified identical fail set on clean main; this change reduced failed files 5→4.
- [ ] CI test262 measures the conformance delta (regression budget −5 ≤ Δ ≤ +30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)