### PR TITLE
feat(#747): IR escape analysis on #1587 ownership (Phase 1)

### DIFF
--- a/plan/issues/sprints/55/747-escape-analysis-for-stack-allocation.md
+++ b/plan/issues/sprints/55/747-escape-analysis-for-stack-allocation.md
@@ -1,7 +1,7 @@
 ---
 id: 747
 title: "Escape analysis for stack allocation"
-status: ready
+status: in-progress
 created: 2026-03-22
 updated: 2026-05-23
 sprint: 55
@@ -160,3 +160,54 @@ Equivalence tests in `tests/issue-747-escape.test.ts`:
   `ctx.escapeAnalysis` flag; default off until soak-tested.
 - **Performance**: should be a clear win for hot allocation sites
   (e.g. Point-like classes in inner loops).
+
+## Implementation (Phase 1 — landed)
+
+The architect spec above predates #1586/#1587 and assumed an AST-level pass in
+`src/checker/`. Both dependencies (#1586 AllocSiteRegistry, #1587 ownership /
+access analysis) landed first, so Phase 1 implements escape analysis at the
+**IR level**, directly consuming #1587's ownership result rather than
+re-deriving escape from the AST.
+
+Files added:
+- `src/ir/analysis/escape.ts` — `analyzeEscape(fn, registry?, ownership?)`.
+  Uses the #1587 `OwnershipResult` as the escape oracle, then walks the IR to
+  attribute the strongest escape edge per allocation:
+  `local` ⊏ `returned` ⊏ `stored` ⊏ `captured` ⊏ `opaque`. Edges:
+  return terminator / async.return → returned; object.set/class.set/refcell.set
+  payload → stored; closure.new capture → captured; opaque call / extern /
+  iter.new / coerce / await / throw → opaque. A soundness backstop downgrades
+  any value #1587 proved escaped but the edge walk missed from `local` →
+  `opaque`. Returns an `EscapeResult` (`of`/`classOf`/`localAllocations`) and
+  writes the classification to the registry `escape` namespace (reserved by
+  ADR-0013 for this issue).
+
+Pipeline wiring (`src/ir/integration.ts` step 2h): runs after the #1587
+ownership pass on the final IR shape, **gated behind `JS2WASM_IR_ESCAPE=1`,
+default OFF** (enabling it implies running ownership, its oracle). The pass does
+not mutate the IR; registry annotations are inert at lowering.
+
+### Phase 1 scope vs. the spec
+
+Phase 1 produces the **classification only** — it does NOT yet perform scalar
+replacement / stack allocation (the `expressions.ts` / `property-access.ts`
+rewrites in the spec). That codegen change is the follow-up consumer; keeping
+Phase 1 annotation-only preserves the "removing the pass cannot change emitted
+Wasm" guarantee (matching #1587's discipline and the issue's "default off until
+soak-tested" risk mitigation). The `local` classification (= `localAllocations()`)
+is exactly the set the follow-up will scalar-replace.
+
+## Test Results
+
+`tests/ir/escape-analysis.test.ts` — 7 tests, all pass. Covers each
+classification (local, returned, stored, captured, opaque), the strongest-edge
+rule, and the registry write-back.
+
+Inertness verified: compiling `make(){ const o={x:1}; o.x=2; return o.x }` with
+`JS2WASM_IR_ESCAPE` OFF vs ON yields **byte-identical Wasm** (642 bytes both).
+`tsc --noEmit`, `biome lint`, and `prettier --check` clean on all new/changed
+files.
+
+Follow-ups: scalar-replacement codegen consumer (the actual perf win), and
+inter-procedural escape propagation (depends on a call-graph; #1587 Phase 2
+adds the function summaries this would build on).

--- a/src/ir/analysis/escape.ts
+++ b/src/ir/analysis/escape.ts
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Escape analysis for stack allocation (#747, Phase 1).
+//
+// Built directly on the #1587 ownership/access analysis: that pass already
+// decides *whether* an allocation escapes (ownership `escaped` / access
+// `escape`); this consumer decides *how* it escapes so downstream
+// optimizations (scalar replacement, stack allocation, #652 compile-time ARC)
+// can act on the classification.
+//
+// Classification (ECMA-agnostic; see the issue #747 "What escape means"):
+//   - `local`    — never escapes; lifetime bounded by the function. Candidate
+//                  for scalar replacement / stack allocation.
+//   - `returned` — flows to a `return` terminator (or `async.return`).
+//   - `stored`   — written into a heap-reachable field of another object/array
+//                  (object.set / class.set / refcell.set newValue).
+//   - `captured` — closed over by a `closure.new` capture list.
+//   - `opaque`   — passed to an opaque call / extern / coercion / await / throw;
+//                  the callee may retain it. The most conservative escape.
+//
+// Like #1587 this pass is *inference*, default-OFF, and inert: it writes to the
+// `AllocSiteRegistry` `escape` namespace (reserved by ADR-0013 for this issue)
+// and NEVER mutates the IR. Removing it cannot change emitted Wasm. Scalar
+// replacement / stack allocation itself is a follow-up that consumes this
+// classification; Phase 1 only produces it (matching #1587's "annotation-only
+// demonstration consumer" discipline).
+
+import type { AllocSiteRegistry } from "../alloc-registry.js";
+import { ALLOC_NAMESPACES } from "../alloc-registry.js";
+import type { IrFunction, IrInstr, IrTerminator, IrValueId } from "../nodes.js";
+import { analyzeOwnership, type OwnershipResult } from "./ownership.js";
+
+/**
+ * How an allocation escapes its defining function. Ordered most-precise →
+ * most-conservative; `local` is the only stack-allocatable classification.
+ */
+export type EscapeClass = "local" | "returned" | "stored" | "captured" | "opaque";
+
+export interface EscapeInfo {
+  readonly classification: EscapeClass;
+  /** True iff `classification === "local"` — safe for scalar replacement. */
+  readonly stackAllocatable: boolean;
+}
+
+/** Severity order — a value flowing through several escape edges takes the max. */
+const ESCAPE_RANK: Readonly<Record<EscapeClass, number>> = {
+  local: 0,
+  returned: 1,
+  stored: 2,
+  captured: 3,
+  opaque: 4,
+};
+
+function worse(a: EscapeClass, b: EscapeClass): EscapeClass {
+  return ESCAPE_RANK[a] >= ESCAPE_RANK[b] ? a : b;
+}
+
+/** Per-function escape-analysis result, keyed by allocation result value. */
+export class EscapeResult {
+  constructor(private readonly infos: ReadonlyMap<IrValueId, EscapeInfo>) {}
+
+  /** Escape info for an allocation value, or `undefined` if it is not an alloc. */
+  of(value: IrValueId): EscapeInfo | undefined {
+    return this.infos.get(value);
+  }
+
+  classOf(value: IrValueId): EscapeClass | undefined {
+    return this.infos.get(value)?.classification;
+  }
+
+  /** Allocation values proven `local` — the stack-allocation candidates. */
+  localAllocations(): IrValueId[] {
+    const out: IrValueId[] = [];
+    for (const [v, info] of this.infos) {
+      if (info.classification === "local") out.push(v);
+    }
+    return out;
+  }
+
+  entries(): Iterable<[IrValueId, EscapeInfo]> {
+    return this.infos.entries();
+  }
+}
+
+/**
+ * Run escape analysis on `fn`. Uses the #1587 ownership result (computed fresh
+ * when not supplied) as the escape oracle, then walks the IR to attribute the
+ * strongest escape edge per allocation. When `registry` is supplied, each
+ * allocation's classification is written under the `escape` namespace keyed by
+ * the defining instr's alloc id.
+ */
+export function analyzeEscape(
+  fn: IrFunction,
+  registry?: AllocSiteRegistry,
+  precomputedOwnership?: OwnershipResult,
+): EscapeResult {
+  const ownership = precomputedOwnership ?? analyzeOwnership(fn, registry);
+
+  // value -> (allocId, defining instr kind) for every allocation site.
+  const allocs = new Map<IrValueId, number>();
+  collectAllocs(fn, allocs);
+
+  // Seed every allocation as `local`; escape edges only ever raise the class.
+  const cls = new Map<IrValueId, EscapeClass>();
+  for (const v of allocs.keys()) cls.set(v, "local");
+
+  const raise = (v: IrValueId, c: EscapeClass): void => {
+    if (!cls.has(v)) return; // only classify known allocations
+    cls.set(v, worse(cls.get(v)!, c));
+  };
+
+  // Attribute escape edges by walking every instr + terminator.
+  const visitInstr = (instr: IrInstr): void => {
+    switch (instr.kind) {
+      case "object.set":
+      case "class.set":
+        raise(instr.newValue, "stored");
+        break;
+      case "refcell.set":
+        raise(instr.value, "stored");
+        break;
+      case "closure.new":
+        for (const cap of instr.captures) raise(cap, "captured");
+        break;
+      case "call":
+        for (const a of instr.args) raise(a, "opaque");
+        break;
+      case "class.call":
+        raise(instr.receiver, "opaque");
+        for (const a of instr.args) raise(a, "opaque");
+        break;
+      case "closure.call":
+        raise(instr.callee, "opaque");
+        for (const a of instr.args) raise(a, "opaque");
+        break;
+      case "extern.call":
+      case "extern.new":
+      case "extern.prop":
+      case "extern.propSet":
+        for (const v of refOperands(instr)) raise(v, "opaque");
+        break;
+      case "iter.new":
+        raise(instr.iterable, "opaque");
+        break;
+      case "coerce.to_externref":
+        raise(instr.value, "opaque");
+        break;
+      case "await":
+        raise(instr.operand, "opaque");
+        break;
+      case "async.return":
+        raise(instr.value, "returned");
+        break;
+      case "async.throw":
+        raise(instr.reason, "opaque");
+        break;
+      case "throw":
+        raise((instr as { value: IrValueId }).value, "opaque");
+        break;
+      case "if":
+        for (const sub of instr.then) visitInstr(sub);
+        for (const sub of instr.else) visitInstr(sub);
+        break;
+      case "forof.vec":
+      case "forof.iter":
+      case "forof.string":
+        for (const sub of (instr as { body: readonly IrInstr[] }).body) visitInstr(sub);
+        break;
+      case "while.loop":
+      case "for.loop":
+      case "try":
+        for (const sub of nestedInstrs(instr)) visitInstr(sub);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const visitTerminator = (term: IrTerminator): void => {
+    if (term.kind === "return") {
+      for (const v of term.values) raise(v, "returned");
+    }
+  };
+
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) visitInstr(instr);
+    visitTerminator(block.terminator);
+  }
+
+  // Soundness backstop: if #1587 proved a value escaped but our edge walk found
+  // no specific edge (e.g. an escape path the edge attribution doesn't model),
+  // never report it as `local`. Fall back to `opaque` — the safe default.
+  for (const v of allocs.keys()) {
+    const c = cls.get(v)!;
+    if (c === "local" && !ownership.isStackAllocatable(v)) {
+      cls.set(v, "opaque");
+    }
+  }
+
+  const infos = new Map<IrValueId, EscapeInfo>();
+  for (const [v, allocId] of allocs) {
+    const classification = cls.get(v)!;
+    const info: EscapeInfo = { classification, stackAllocatable: classification === "local" };
+    infos.set(v, info);
+    if (registry) {
+      registry.annotate(allocId as never, ALLOC_NAMESPACES.escape, {
+        classification,
+        stackAllocatable: info.stackAllocatable,
+      });
+    }
+  }
+
+  return new EscapeResult(infos);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function collectAllocs(fn: IrFunction, out: Map<IrValueId, number>): void {
+  const walk = (instr: IrInstr): void => {
+    if (instr.result !== null && instr.alloc !== undefined) {
+      out.set(instr.result, instr.alloc as unknown as number);
+    }
+    for (const sub of nestedInstrs(instr)) walk(sub);
+  };
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) walk(instr);
+  }
+}
+
+const REF_OPERAND_FIELDS = new Set([
+  "value",
+  "newValue",
+  "receiver",
+  "callee",
+  "cell",
+  "operand",
+  "reason",
+  "iterable",
+  "self",
+]);
+
+function* refOperands(instr: IrInstr): Iterable<IrValueId> {
+  for (const [key, value] of Object.entries(instr as unknown as Record<string, unknown>)) {
+    if (key === "result") continue;
+    if (typeof value === "number" && REF_OPERAND_FIELDS.has(key)) {
+      yield value as unknown as IrValueId;
+    } else if (Array.isArray(value)) {
+      for (const el of value) if (typeof el === "number") yield el as unknown as IrValueId;
+    }
+  }
+}
+
+function* nestedInstrs(instr: IrInstr): Iterable<IrInstr> {
+  for (const value of Object.values(instr as unknown as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const el of value) if (isInstrLike(el)) yield el as IrInstr;
+    } else if (value !== null && typeof value === "object") {
+      for (const inner of Object.values(value as Record<string, unknown>)) {
+        if (Array.isArray(inner)) {
+          for (const el of inner) if (isInstrLike(el)) yield el as IrInstr;
+        }
+      }
+    }
+  }
+}
+
+function isInstrLike(v: unknown): boolean {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    typeof (v as { kind?: unknown }).kind === "string" &&
+    "result" in (v as object)
+  );
+}

--- a/src/ir/index.ts
+++ b/src/ir/index.ts
@@ -12,3 +12,4 @@ export * from "./integration.js";
 export * from "./analysis/lattice.js";
 export * from "./analysis/ownership.js";
 export * from "./analysis/stack-alloc.js";
+export * from "./analysis/escape.js";

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -53,6 +53,7 @@ import type {
   IrType,
   IrTypeRef,
 } from "./nodes.js";
+import { analyzeEscape } from "./analysis/escape.js";
 import { analyzeOwnership } from "./analysis/ownership.js";
 import { constantFold } from "./passes/constant-fold.js";
 import { deadCode } from "./passes/dead-code.js";
@@ -454,9 +455,22 @@ export function compileIrPathFunctions(
   // is likewise gated and annotation-only). Behind `JS2WASM_IR_OWNERSHIP=1`
   // for the rollout period.
   // -------------------------------------------------------------------------
-  if (ownershipAnalysisEnabled()) {
+  //
+  // 2h. Escape analysis (#747) — gated, default OFF. When
+  // `JS2WASM_IR_ESCAPE=1`, classifies each allocation
+  // (local/returned/stored/captured/opaque) on top of the ownership result and
+  // writes it to the registry `escape` namespace. Enabling escape implies
+  // running ownership (its oracle). Both are inert — no IR mutation, byte-
+  // identical Wasm — so scalar replacement / stack allocation stays a
+  // follow-up consumer.
+  const wantOwnership = ownershipAnalysisEnabled();
+  const wantEscape = escapeAnalysisEnabled();
+  if (wantOwnership || wantEscape) {
     for (const entry of readyForLower) {
-      analyzeOwnership(entry.fn, allocRegistry);
+      const ownershipResult = analyzeOwnership(entry.fn, allocRegistry);
+      if (wantEscape) {
+        analyzeEscape(entry.fn, allocRegistry, ownershipResult);
+      }
     }
   }
 
@@ -683,6 +697,15 @@ function hasExportModifier(fn: ts.FunctionDeclaration): boolean {
  */
 function ownershipAnalysisEnabled(): boolean {
   return process.env.JS2WASM_IR_OWNERSHIP === "1" || process.env.JS2WASM_IR_OWNERSHIP === "true";
+}
+
+/**
+ * #747 rollout gate. Escape analysis is default-OFF and inert; enabling it runs
+ * the ownership pass (its oracle) too. Stack allocation / scalar replacement
+ * consuming the classification is a follow-up — Phase 1 only annotates.
+ */
+function escapeAnalysisEnabled(): boolean {
+  return process.env.JS2WASM_IR_ESCAPE === "1" || process.env.JS2WASM_IR_ESCAPE === "true";
 }
 
 /**

--- a/tests/ir/escape-analysis.test.ts
+++ b/tests/ir/escape-analysis.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #747 — escape analysis (built on #1587 ownership). Classifies each allocation
+// as local / returned / stored / captured / opaque and marks the `local` ones
+// as stack-allocatable. Covers each classification path + the registry
+// write-back.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AllocSiteRegistry,
+  IrFunctionBuilder,
+  analyzeEscape,
+  irVal,
+  type IrObjectShape,
+  type IrType,
+  type IrValueId,
+} from "../../src/ir/index.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+const OBJ_SHAPE: IrObjectShape = { fields: [{ name: "x", type: F64 }] };
+const OBJ_TYPE: IrType = { kind: "object", shape: OBJ_SHAPE };
+
+function buildFn(emit: (b: IrFunctionBuilder) => IrValueId[], opts: { resultTypes?: readonly IrType[] } = {}) {
+  const reg = new AllocSiteRegistry();
+  const b = new IrFunctionBuilder("f", opts.resultTypes ?? [], false, reg);
+  b.openBlock();
+  const ret = emit(b);
+  b.terminate({ kind: "return", values: ret });
+  return { fn: b.finish(), reg };
+}
+
+describe("#747 — escape analysis", () => {
+  it("an object that never escapes is classified local + stack-allocatable", () => {
+    const { fn } = buildFn((b) => {
+      const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [zero]);
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      b.emitObjectSet(o, "x", one); // mutated, but never escapes
+      return [];
+    });
+    const obj = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeEscape(fn);
+    const info = r.of(obj.result!)!;
+    expect(info.classification).toBe("local");
+    expect(info.stackAllocatable).toBe(true);
+    expect(r.localAllocations()).toContain(obj.result!);
+  });
+
+  it("returned via the block terminator → returned", () => {
+    const { fn } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [o];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const obj = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeEscape(fn);
+    expect(r.classOf(obj.result!)).toBe("returned");
+    expect(r.of(obj.result!)!.stackAllocatable).toBe(false);
+  });
+
+  it("stored into another object's field → stored", () => {
+    const { fn } = buildFn(
+      (b) => {
+        const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+        const outer = b.emitObjectNew(OBJ_SHAPE, [zero]);
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const inner = b.emitObjectNew(OBJ_SHAPE, [one]);
+        b.emitObjectSet(outer, "x", inner);
+        return [outer];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const objs = fn.blocks[0]!.instrs.filter((i) => i.kind === "object.new");
+    const inner = objs[1]!.result!;
+    const r = analyzeEscape(fn);
+    expect(r.classOf(inner)).toBe("stored");
+  });
+
+  it("passed to an opaque call → opaque", () => {
+    const { fn } = buildFn((b) => {
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+      b.emitCall({ kind: "func", name: "sink" }, [o], null);
+      return [];
+    });
+    const obj = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeEscape(fn);
+    expect(r.classOf(obj.result!)).toBe("opaque");
+  });
+
+  it("captured by a closure → captured", () => {
+    const { fn } = buildFn((b) => {
+      const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+      const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+      const sig = { params: [] as readonly IrType[], returnType: F64 };
+      b.emitClosureNew({ kind: "func", name: "lifted" }, sig, [OBJ_TYPE], [o]);
+      return [];
+    });
+    const obj = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    const r = analyzeEscape(fn);
+    expect(r.classOf(obj.result!)).toBe("captured");
+  });
+
+  it("the strongest edge wins when an allocation both stores and returns", () => {
+    // inner is stored into outer (stored) — outer itself is returned. inner's
+    // own classification is `stored` (the field-store edge), not `returned`.
+    const { fn } = buildFn(
+      (b) => {
+        const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+        const outer = b.emitObjectNew(OBJ_SHAPE, [zero]);
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const inner = b.emitObjectNew(OBJ_SHAPE, [one]);
+        b.emitObjectSet(outer, "x", inner);
+        // also pass inner to an opaque call → opaque outranks stored
+        b.emitCall({ kind: "func", name: "sink" }, [inner], null);
+        return [outer];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const objs = fn.blocks[0]!.instrs.filter((i) => i.kind === "object.new");
+    const inner = objs[1]!.result!;
+    const r = analyzeEscape(fn);
+    expect(r.classOf(inner)).toBe("opaque");
+  });
+
+  it("writes the classification to the registry escape namespace", () => {
+    const { fn, reg } = buildFn(
+      (b) => {
+        const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+        const o = b.emitObjectNew(OBJ_SHAPE, [one]);
+        return [o];
+      },
+      { resultTypes: [OBJ_TYPE] },
+    );
+    const obj = fn.blocks[0]!.instrs.find((i) => i.kind === "object.new")!;
+    analyzeEscape(fn, reg);
+    const annot = reg.read<{ classification: string; stackAllocatable: boolean }>(obj.alloc!, "escape");
+    expect(annot).toBeDefined();
+    expect(annot!.classification).toBe("returned");
+    expect(annot!.stackAllocatable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements #747 escape analysis at the **IR level**, consuming the #1587 ownership/access result as the escape oracle (deps #1586 + #1587 both landed). Closes the Phase 1 classification half of #747.
- Classifies each allocation `local` ⊏ `returned` ⊏ `stored` ⊏ `captured` ⊏ `opaque`; the `local` set is the stack-allocation candidate set the follow-up scalar-replacement consumer acts on.

## What landed
- `src/ir/analysis/escape.ts` — `analyzeEscape(fn, registry?, ownership?)`: strongest-edge attribution over the IR (return/async.return → returned; object.set/class.set/refcell.set payload → stored; closure.new capture → captured; opaque call/extern/iter.new/coerce/await/throw → opaque). A **soundness backstop** downgrades any value #1587 proved escaped but the edge-walk missed from `local` → `opaque`. Returns `EscapeResult` (`of`/`classOf`/`localAllocations`) and writes the registry `escape` namespace (reserved by ADR-0013 for this issue).
- `src/ir/integration.ts` step 2h — gated behind `JS2WASM_IR_ESCAPE=1` (default OFF); enabling it runs the ownership oracle too. Coexists with #1588's encoding pass (separate block).

## Phase 1 scope
Annotation-only — scalar replacement / stack-allocation codegen is the follow-up consumer. Keeping Phase 1 inert preserves the "removing the pass can't change emitted Wasm" guarantee and the issue's "default off until soak-tested" risk mitigation.

## Inertness guarantee
Compiling a mutate-and-return function with `JS2WASM_IR_ESCAPE` OFF vs ON yields **byte-identical Wasm** (642 bytes both).

## Test plan
- [x] `tests/ir/escape-analysis.test.ts` — 7 tests: each classification (local/returned/stored/captured/opaque), strongest-edge rule, registry write-back.
- [x] tsc + biome + prettier clean; ownership (14) + encoding (11) + escape (7) suites all green post-merge.
- [x] Byte-identical Wasm flag on vs off.

Follow-ups: scalar-replacement codegen (the perf win) and inter-procedural propagation (builds on #1587 Phase 2 summaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)