### PR TITLE
feat(#1588) Phase 2 PR-A: call-result string-encoding origins + method propagation

### DIFF
--- a/docs/adr/0015-string-encoding-tracking.md
+++ b/docs/adr/0015-string-encoding-tracking.md
@@ -98,6 +98,32 @@ are the two rules the analysis can attach annotations to today. Call-result
 origins (`JSON.parse`, `TextDecoder`) and method propagation require the IR to
 mint string alloc ids on those results first — tracked as Phase 2 follow-up.
 
+## Phase 2 status
+
+**PR-A (landed, still inert).** The builder now mints a `"string"`
+allocation-site id on `call` and `extern.call` instrs whose result type is
+`string` (`emitCall` / `emitExternCall`). This is inert at lowering — the
+emitted Wasm is byte-identical — and gives the analysis an attachment point
+for call-result rules:
+
+- **Call-result origins**: `JSON.parse` / `JSON.stringify` (host import names
+  `JSON_parse` / `JSON_stringify`) → `utf8-guaranteed`. `TextDecoder.decode`
+  (an `extern.call`) → `utf8-guaranteed`.
+- **Method propagation**: string methods lower to a `call` named
+  `string_<m>` (host) or `__str_<m>` (native) with the receiver as the first
+  argument. Methods that cannot introduce a surrogate from non-surrogate
+  input — `toUpperCase`, `toLowerCase`, `trim`, `trimStart`, `trimEnd`,
+  `normalize`, `padStart`, `padEnd`, `repeat` — propagate the receiver's
+  encoding. `slice` / `substring` / `charAt` are **not** preserving:
+  code-unit indexing can split a surrogate pair, so they conservatively drop
+  to `wtf16` (refining `slice` with statically-known code-point boundaries is
+  a later refinement). Any other string-returning call is `wtf16`.
+
+**PR-B / PR-C (still deferred).** Dual i8/i16 storage at allocation sites and
+the Component Model boundary lowering + benchmark. These change storage
+layout / emitted Wasm and warrant an architect design pass on the storage +
+boundary ABI before implementation.
+
 ## Consequences
 
 - **Soundness is the bar.** A wrongly-conservative annotation only costs a

--- a/src/ir/analysis/encoding.ts
+++ b/src/ir/analysis/encoding.ts
@@ -139,11 +139,83 @@ function classifyInstr(
       // the lattice already forces `wtf16` whenever either operand is.)
       record(instr.result, instr.alloc, joinEncoding(enc(instr.lhs), enc(instr.rhs)));
       return;
+    case "call":
+      // String-returning calls (Phase 2): origin rules for built-ins that
+      // produce UTF-8 by construction, propagation rules for string methods
+      // whose result preserves the receiver's encoding. Only fires when the
+      // builder minted a string `alloc` id (i.e. resultType is string).
+      if (instr.alloc !== undefined) {
+        record(instr.result, instr.alloc, classifyCall(instr.target.name, instr.args, enc));
+      }
+      return;
+    case "extern.call":
+      // Extern-class string-returning calls (Phase 2), e.g.
+      // `TextDecoder.decode` → utf8-guaranteed (WHATWG Encoding spec).
+      if (instr.alloc !== undefined) {
+        record(instr.result, instr.alloc, classifyExternCall(instr.className, instr.method, enc(instr.receiver)));
+      }
+      return;
     default:
-      // Any other string-producing instr (and there are none in Phase 1 that
-      // carry a string `alloc` id beyond the two above) defaults to `wtf16`.
-      // We still record nothing here so the value stays absent from the map,
-      // which `enc` reads back as `wtf16`.
+      // Any other string-producing instr defaults to `wtf16`. We record
+      // nothing so the value stays absent from the map, which `enc` reads
+      // back as `wtf16`.
       return;
   }
+}
+
+/**
+ * Method names (after the `string_` / `__str_` backend prefix) whose result
+ * preserves the receiver's encoding: case folding and trimming cannot turn a
+ * non-surrogate scalar into a surrogate, so a UTF-8/ASCII receiver yields a
+ * UTF-8/ASCII result. `slice`/`substring`/`charAt` are deliberately NOT here
+ * — code-unit-indexed slicing can split a surrogate pair, so they
+ * conservatively drop to `wtf16` (refining slice with statically-known
+ * code-point boundaries is a later refinement).
+ */
+const ENCODING_PRESERVING_METHODS: ReadonlySet<string> = new Set([
+  "toUpperCase",
+  "toLowerCase",
+  "trim",
+  "trimStart",
+  "trimEnd",
+  "normalize",
+  "padStart",
+  "padEnd",
+  "repeat",
+]);
+
+/**
+ * Built-in functions whose string result is UTF-8 by construction:
+ *   - `JSON.stringify` escapes lone surrogates per ES2019+ (§24.5.2.2).
+ *   - `JSON.parse` result strings are UTF-8 (RFC 8259 restricts JSON text).
+ * These lower to host-import calls named `JSON_stringify` / `JSON_parse`.
+ */
+const UTF8_ORIGIN_FUNCS: ReadonlySet<string> = new Set(["JSON_stringify", "JSON_parse"]);
+
+/** Strip the string-backend prefix (`string_` host, `__str_` native) if present. */
+function stripStringMethodPrefix(name: string): string | null {
+  if (name.startsWith("string_")) return name.slice("string_".length);
+  if (name.startsWith("__str_")) return name.slice("__str_".length);
+  return null;
+}
+
+/** Origin/propagation rule for a `call` instr that produces a string. */
+function classifyCall(name: string, args: readonly IrValueId[], enc: (v: IrValueId) => Encoding): Encoding {
+  if (UTF8_ORIGIN_FUNCS.has(name)) return "utf8-guaranteed";
+  const method = stripStringMethodPrefix(name);
+  if (method !== null && ENCODING_PRESERVING_METHODS.has(method)) {
+    // String methods lower with the receiver as the first argument.
+    return args.length > 0 ? enc(args[0]!) : "wtf16";
+  }
+  // `__str_concat` carries no alloc on its own (string.concat does); any other
+  // string-returning call is conservatively WTF-16.
+  return "wtf16";
+}
+
+/** Origin rule for an `extern.call` instr that produces a string. */
+function classifyExternCall(className: string, method: string, _receiver: Encoding): Encoding {
+  // TextDecoder.decode yields UTF-8 by construction (WHATWG Encoding spec
+  // forbids the decoder from producing unpaired surrogates).
+  if (className === "TextDecoder" && method === "decode") return "utf8-guaranteed";
+  return "wtf16";
 }

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -181,7 +181,12 @@ export class IrFunctionBuilder {
       result = this.allocator.fresh();
       this.valueTypes.set(result, resultType);
     }
-    this.pushInstr({ kind: "call", target, args: [...args], result, resultType });
+    // #1588 Phase 2: a call that produces a string is a string allocation site.
+    // Minting the id is inert at lowering (the encoding analysis reads it; the
+    // emitted Wasm is unchanged), and gives the analysis an attachment point
+    // for call-result origin rules (JSON.parse, string methods, …).
+    const alloc = resultType?.kind === "string" ? this.allocId("string", resultType) : undefined;
+    this.pushInstr({ kind: "call", target, args: [...args], result, resultType, alloc });
     return result;
   }
 
@@ -628,6 +633,9 @@ export class IrFunctionBuilder {
       result = this.allocator.fresh();
       this.valueTypes.set(result, resultType);
     }
+    // #1588 Phase 2: string-returning extern call (e.g. TextDecoder.decode) is
+    // a string allocation site — inert id for the encoding analysis.
+    const alloc = resultType?.kind === "string" ? this.allocId("string", resultType) : undefined;
     this.pushInstr({
       kind: "extern.call",
       className,
@@ -636,6 +644,7 @@ export class IrFunctionBuilder {
       args: [...args],
       result,
       resultType,
+      alloc,
     });
     return result;
   }

--- a/tests/ir/encoding-analysis.test.ts
+++ b/tests/ir/encoding-analysis.test.ts
@@ -18,6 +18,7 @@ import {
   analyzeEncoding,
   classifyLiteral,
   joinEncoding,
+  irVal,
   type Encoding,
   type IrType,
 } from "../../src/ir/index.js";
@@ -179,5 +180,99 @@ describe("#1588 — analyzeEncoding pass", () => {
     const second = readEnc(reg, "hi", "string.const", fn);
     expect(second).toBe(first);
     expect(second).toBe("ascii");
+  });
+});
+
+describe("#1588 Phase 2 — call-result origins + method propagation", () => {
+  const callEnc = (reg: AllocSiteRegistry, fn: ReturnType<IrFunctionBuilder["finish"]>): Encoding | undefined => {
+    const instr = fn.blocks[0]!.instrs.find((i) => i.kind === "call" && i.alloc !== undefined)!;
+    return reg.read<Encoding>(instr.alloc!, NS);
+  };
+
+  it("JSON.parse / JSON.stringify results are utf8-guaranteed", () => {
+    for (const fnName of ["JSON_parse", "JSON_stringify"]) {
+      const reg = new AllocSiteRegistry();
+      const b = new IrFunctionBuilder("f", [STR], false, reg);
+      const arg = b.addParam("x", STR);
+      b.openBlock();
+      const r = b.emitCall({ kind: "func", name: fnName }, [arg], STR)!;
+      b.terminate({ kind: "return", values: [r] });
+      const fn = b.finish();
+      analyzeEncoding(fn, reg);
+      expect(callEnc(reg, fn)).toBe("utf8-guaranteed");
+    }
+  });
+
+  it("encoding-preserving string methods propagate the receiver encoding", () => {
+    // ASCII receiver → toUpperCase stays ascii.
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const recv = b.emitStringConst("hello"); // ascii
+    const r = b.emitCall({ kind: "func", name: "string_toUpperCase" }, [recv], STR)!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    expect(callEnc(reg, fn)).toBe("ascii");
+  });
+
+  it("native-mode method prefix (__str_) also propagates", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const recv = b.emitStringConst("café"); // utf8-guaranteed
+    const r = b.emitCall({ kind: "func", name: "__str_trim" }, [recv], STR)!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    expect(callEnc(reg, fn)).toBe("utf8-guaranteed");
+  });
+
+  it("slice is conservatively wtf16 (code-unit indices can split a pair)", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const recv = b.emitStringConst("hello"); // ascii receiver
+    const r = b.emitCall({ kind: "func", name: "string_slice" }, [recv], STR)!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    expect(callEnc(reg, fn)).toBe("wtf16");
+  });
+
+  it("an unknown string-returning call is conservatively wtf16", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    b.openBlock();
+    const r = b.emitCall({ kind: "func", name: "someUserFunc" }, [], STR)!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    expect(callEnc(reg, fn)).toBe("wtf16");
+  });
+
+  it("a non-string-returning call gets no string alloc id / no annotation", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [irVal({ kind: "f64" })], false, reg);
+    b.openBlock();
+    const r = b.emitCall({ kind: "func", name: "numFunc" }, [], irVal({ kind: "f64" }))!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    const call = fn.blocks[0]!.instrs.find((i) => i.kind === "call")!;
+    expect(call.alloc).toBeUndefined();
+  });
+
+  it("TextDecoder.decode (extern.call) is utf8-guaranteed", () => {
+    const reg = new AllocSiteRegistry();
+    const b = new IrFunctionBuilder("f", [STR], false, reg);
+    const buf = b.addParam("buf", irVal({ kind: "externref" }));
+    b.openBlock();
+    const r = b.emitExternCall("TextDecoder", "decode", buf, [], STR)!;
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    analyzeEncoding(fn, reg);
+    const ec = fn.blocks[0]!.instrs.find((i) => i.kind === "extern.call" && i.alloc !== undefined)!;
+    expect(reg.read<Encoding>(ec.alloc!, NS)).toBe("utf8-guaranteed");
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 PR-A of #1588 (string encoding tracking). Still **inert at lowering** — emitted Wasm is byte-identical; only the advisory `encoding` annotations on the registry change.

- **Builder**: `emitCall` / `emitExternCall` now mint a `"string"` allocation-site id when the result type is `string`, giving the analysis an attachment point for call results (mirrors the existing `string.const` / `string.concat` minting).
- **Analysis** (`src/ir/analysis/encoding.ts`):
  - **Call-result origins**: `JSON.parse` / `JSON.stringify` → `utf8-guaranteed`; `TextDecoder.decode` (extern.call) → `utf8-guaranteed`.
  - **Method propagation**: encoding-preserving string methods (`toUpperCase`, `toLowerCase`, `trim`, `trimStart`, `trimEnd`, `normalize`, `padStart`, `padEnd`, `repeat`) carry the receiver's encoding. `slice` / `substring` / `charAt` and unknown string-returning calls stay `wtf16` — conservative, since code-unit indexing can split a surrogate pair.
- **ADR-0015** updated with a Phase 2 status section.

Deferred to PR-B (dual i8/i16 storage) and PR-C (CM boundary + benchmark) — these change storage layout / emitted Wasm and warrant an architect design pass on the storage + boundary ABI first (flagged to tech lead).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/ir/encoding-analysis.test.ts` — 18 cases (11 Phase 1 + 7 new Phase 2: JSON origins, method propagation host+native prefix, slice conservatism, unknown-call conservatism, non-string-call no-alloc, TextDecoder.decode)
- [x] `tests/ir/alloc-*.test.ts` pass (calls are side-effecting → DCE keeps them live → no provenance regression)
- [x] Pre-existing `ir-backend-decoupling.test.ts` `__box_number` harness failures reproduce on clean main (unrelated)
- [ ] CI: full conformance + gate (no codegen change expected — alloc ids inert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)