### PR TITLE
ui(landing): move Strict mode + JS host toggles left of Include TC39 proposals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1568,6 +1568,14 @@
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
+              <label class="feat-toggle">
+                <input type="checkbox" id="strict-only-toggle" />
+                <span>Strict mode</span>
+              </label>
+              <label class="feat-toggle">
+                <input type="checkbox" id="host-support-toggle" checked />
+                <span>JS host</span>
+              </label>
               <label
                 class="feat-toggle"
                 title="Include ~5k TC39 proposal tests (Temporal, decorators, etc.) on top of the ~43k ECMAScript current-standard tests."
@@ -1603,16 +1611,6 @@
           ></t262-edition-timeline>
         </div>
 
-        <div class="feat-filter">
-          <label class="feat-toggle">
-            <input type="checkbox" id="strict-only-toggle" />
-            <span>Strict mode</span>
-          </label>
-          <label class="feat-toggle">
-            <input type="checkbox" id="host-support-toggle" checked />
-            <span>JS host</span>
-          </label>
-        </div>
 
         <div class="feat-tables">
           <div class="feat-panel">


### PR DESCRIPTION
Moves the `strict-only-toggle` and `host-support-toggle` into the `conformance-scope-toggle` row, positioned left of `include-proposals-toggle` (order: Strict mode, JS host, Include TC39 proposals). Removes the old standalone strict/host `.feat-filter` block. Element IDs unchanged so all existing JS handlers keep working. HTML-only.

NOTE: won't be visible on the live site until the deploy-pages build failure is fixed (separate issue).