### PR TITLE
fix(pages): non-fatal wasm-opt so deploy-pages stops failing

### DIFF
--- a/scripts/generate-size-benchmarks.ts
+++ b/scripts/generate-size-benchmarks.ts
@@ -404,11 +404,18 @@ async function optimizeBenchmarkWasm(binary: Uint8Array, label: string): Promise
   for (let pass = 0; pass < 4; pass++) {
     const optResult = await optimizeBinaryAsync(optimizedBinary, { level: 4 });
     if (!optResult.optimized) {
-      throw new Error(
-        `[${label}] wasm-opt optimization is required for offline benchmark artifacts: ${
+      // wasm-opt cannot parse some js2wasm output — notably custom-descriptors
+      // ('exact' heap types), which the pinned Binaryen (v125) does not support
+      // (no Features.CustomDescriptors). Do NOT fail the entire Pages build over
+      // one un-optimizable benchmark artifact: warn and fall back to the best
+      // binary we have. The size figure for this artifact is then unoptimized.
+      // Tracked separately (Binaryen custom-descriptors support / emission gate).
+      console.warn(
+        `[${label}] wasm-opt could not optimize this artifact (${
           optResult.warning ?? "optimizer returned the original binary"
-        }`,
+        }); using unoptimized binary for size measurement.`,
       );
+      return optimizedBinary;
     }
     if (bytesEqual(optResult.binary, optimizedBinary)) return optimizedBinary;
     optimizedBinary = optResult.binary;


### PR DESCRIPTION
**deploy-pages has failed on every recent run**, freezing the landing page (incl. the ECMAScript conformance trend chart). 

Root cause: `generate-size-benchmarks.ts` throws when `wasm-opt` can't optimize an artifact. js2wasm now emits **custom-descriptors** (`exact` heap types); the pinned **Binaryen v125 has no `Features.CustomDescriptors`**, so `wasm-opt -O4` fails to parse the `calendar` example (`invalid type on stack`) → throw → entire Pages build dies → `deploy` skipped.

Fix: make `optimizeBenchmarkWasm` **non-fatal** — warn + fall back to the best binary instead of throwing. One un-optimizable benchmark no longer blocks the whole site. The affected artifact reports unoptimized size (acceptable degradation).

Follow-up (separate issue): upgrade Binaryen to a custom-descriptors-capable version, or gate custom-descriptors emission for benchmark artifacts. Also pending: remove a corrupt `pass=1337` point from runs/index.json.