### PR TITLE
fix(pages): skip un-optimizable benchmarks + reset Binaryen-poisoned exit code

### DIFF
--- a/scripts/generate-size-benchmarks.ts
+++ b/scripts/generate-size-benchmarks.ts
@@ -612,7 +612,12 @@ console.log("Generating size benchmarks...\n");
 console.log("How-it-works snippets:");
 
 process.stdout.write("  fib ...");
-const fibEntry = await measureSizes("fib", "fibonacci", HOW_FIB_JS, HOW_FIB_TS);
+let fibEntry: SizeEntry | null = null;
+try {
+  fibEntry = await measureSizes("fib", "fibonacci", HOW_FIB_JS, HOW_FIB_TS);
+} catch (e) {
+  console.warn(`\n  [fib] skipped — ${String((e as Error)?.message ?? e).split("\n")[0]}`);
+}
 if (fibEntry) {
   console.log(
     ` JS: ${fibEntry.jsSizeGzip}B gzip / ${fibEntry.jsParseMs.toFixed(4)}ms | Wasm: ${fibEntry.wasmSizeGzip}B gzip / ${fibEntry.wasmCompileMs.toFixed(4)}ms`,
@@ -620,7 +625,12 @@ if (fibEntry) {
 }
 
 process.stdout.write("  dom ...");
-const domEntry = await measureSizes("dom", "DOM append", HOW_DOM_JS, HOW_DOM_TS);
+let domEntry: SizeEntry | null = null;
+try {
+  domEntry = await measureSizes("dom", "DOM append", HOW_DOM_JS, HOW_DOM_TS);
+} catch (e) {
+  console.warn(`\n  [dom] skipped — ${String((e as Error)?.message ?? e).split("\n")[0]}`);
+}
 if (domEntry) {
   console.log(
     ` JS: ${domEntry.jsSizeGzip}B gzip / ${domEntry.jsParseMs.toFixed(4)}ms | Wasm: ${domEntry.wasmSizeGzip}B gzip / ${domEntry.wasmCompileMs.toFixed(4)}ms`,
@@ -633,7 +643,13 @@ console.log("\nPlayground benchmarks:");
 const benchmarkResults: SizeEntry[] = [];
 for (const bench of BENCHMARKS) {
   process.stdout.write(`  ${bench.name} ...`);
-  const entry = await measureMultiSizes(bench.name, bench.label, bench.path);
+  let entry: SizeEntry | null = null;
+  try {
+    entry = await measureMultiSizes(bench.name, bench.label, bench.path);
+  } catch (e) {
+    console.warn(`\n  [${bench.name}] skipped — ${String((e as Error)?.message ?? e).split("\n")[0]}`);
+    continue;
+  }
   if (entry) {
     benchmarkResults.push(entry);
     console.log(
@@ -674,3 +690,9 @@ console.log(`Copied to ${PUBLIC_PATH}`);
 console.log(`Wrote ${LOADTIME_RESULTS_PATH}`);
 console.log(`Copied to ${LOADTIME_PUBLIC_PATH}`);
 console.log(`Copied Binaryen wasm-opt bundle to loadtime benchmark assets`);
+
+// Binaryen's Emscripten runtime poisons process.exitCode to 1 when wasm-opt
+// aborts on an unparseable (custom-descriptors) binary — even though we catch
+// the thrown error and skip that benchmark above. All artifacts are written by
+// this point, so force a clean exit to keep the Pages build green.
+process.exitCode = 0;


### PR DESCRIPTION
Follow-up to #550, which was insufficient. deploy-pages still failed because:
1. A **second throw** (parseModule of calendar's host JS) after the optimize step, and
2. **Binaryen's Emscripten runtime poisons `process.exitCode=1`** when wasm-opt aborts on the calendar custom-descriptors binary — so even with the thrown error caught, the process exited non-zero and killed the build.

Two-part fix (verified locally — script now exits 0, calendar skipped, all artifacts written):
- try/catch around each per-example measurement (fib/dom/loop) → skip-on-throw, never fatal.
- `process.exitCode = 0` after all writes complete, overriding Binaryen's poisoned code.

calendar's size benchmark is omitted (Binaryen can't wasm-opt custom-descriptors output), but the Pages build completes → conformance chart + landing page unfreeze.