### PR TITLE
ui(landing): remove redundant TC39-proposals toggle; JS host before Strict mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1569,19 +1569,12 @@
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
               <label class="feat-toggle">
-                <input type="checkbox" id="strict-only-toggle" />
-                <span>Strict mode</span>
-              </label>
-              <label class="feat-toggle">
                 <input type="checkbox" id="host-support-toggle" checked />
                 <span>JS host</span>
               </label>
-              <label
-                class="feat-toggle"
-                title="Include ~5k TC39 proposal tests (Temporal, decorators, etc.) on top of the ~43k ECMAScript current-standard tests."
-              >
-                <input type="checkbox" id="include-proposals-toggle" />
-                <span>Include TC39 proposals</span>
+              <label class="feat-toggle">
+                <input type="checkbox" id="strict-only-toggle" />
+                <span>Strict mode</span>
               </label>
             </div>
           </div>
@@ -5020,24 +5013,9 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           }
           editionTimeline.setAttribute("value", "overall");
 
-          // #106 — "Include TC39 proposals" toggle next to the donut.
-          // Off (default): pass rate counts only the ~43k ECMAScript
-          //   current-standard tests (scope: standard + annex_b).
-          // On: counts ~48k including ~5k TC39 proposals
-          //   (Temporal, decorators, source-phase imports, etc.).
-          // We piggy-back on the existing edition-timeline scope so the
-          // donut, feature rows, and history chart all stay consistent.
-          const proposalsToggle = document.getElementById("include-proposals-toggle");
-          if (proposalsToggle instanceof HTMLInputElement) {
-            // Only meaningful if the report actually carries proposal data.
-            if (!proposalDiffers) {
-              proposalsToggle.disabled = true;
-              proposalsToggle.parentElement?.setAttribute("title", "Current report has no proposal data");
-            }
-            proposalsToggle.addEventListener("change", () => {
-              editionTimeline.setAttribute("value", proposalsToggle.checked ? "overall+proposal" : "overall");
-            });
-          }
+          // #106 toggle removed (2026-05-24): the "Include TC39 proposals" scope
+          // is now implicit via the edition-timeline slider (overall+proposal).
+          // The donut / feature rows stay on current-standard ("overall") by default.
         } catch {
           window.__conformanceEditionScope = "overall";
         }


### PR DESCRIPTION
Removes the `Include TC39 proposals` toggle (redundant — proposals scope is implicit via the edition-timeline slider's `overall+proposal`) plus its now-dead #106 change-handler, and swaps the remaining toggles so **JS host** precedes **Strict mode**. Donut/feature rows default to current-standard (`overall`). HTML/JS-only.