### PR TITLE
docs(plan): file issues for remaining fixable test262 CE causes

### DIFF
--- a/plan/issues/backlog/1601-array-iteration-callback-stack-underflow.md
+++ b/plan/issues/backlog/1601-array-iteration-callback-stack-underflow.md
@@ -1,0 +1,80 @@
+---
+id: 1601
+title: "codegen: Array.prototype reduce/reduceRight/map/filter callback paths emit invalid wasm (stack underflow at local.set/if/array.set)"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: array-iteration-methods
+es_edition: multi
+goal: compiler-correctness
+test262_count: 156
+related: [1522]
+---
+
+# #1601 — Array iteration methods emit stack-underflow wasm in callback path
+
+## Problem
+
+156 test262 tests fail with `invalid Wasm binary` where the Binaryen validator
+reports a **stack underflow** inside the compiled `test` (or `__closure_N`)
+function for an `Array.prototype` iteration method:
+
+```
+not enough arguments on the stack for local.set (need 1, got 0)
+not enough arguments on the stack for if (need 1, got 0)
+not enough arguments on the stack for array.set (need 3, got 2)
+```
+
+All 156 are `built-ins/Array` and concentrate on the callback-driven
+iteration methods:
+
+| method      | CE count |
+|-------------|----------|
+| reduce      | 62 |
+| reduceRight | 57 |
+| map         | 13 |
+| filter      | 11 |
+| findIndex   | 6 |
+| find        | 6 |
+| some        | 1 |
+
+This is distinct from the generic type-boundary umbrella #1522 (which lists
+only ~2 of each shape). The dominant cause here is the
+**reduce/reduceRight accumulator path** and the **map/filter store path**
+when the callback or species constructor is observed (e.g.
+`create-species-undef`, getter-observing length, predicate-call tests).
+
+## Failing test examples
+
+- `test/built-ins/Array/prototype/reduce/15.4.4.21-8-b-iii-1-33.js`
+- `test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-16.js`
+- `test/built-ins/Array/prototype/map/create-species-undef.js`
+- `test/built-ins/Array/prototype/filter/create-species-undef.js`
+- `test/built-ins/Array/prototype/findIndex/predicate-call-parameters.js`
+
+## Root-cause hypothesis
+
+The inlined/lowered iteration loop for these methods drops a value off the
+operand stack on one control-flow edge:
+- `local.set (need 1, got 0)` — the accumulator (reduce) or result temp is
+  consumed without being produced on the early-exit / empty-array edge.
+- `if (need 1, got 0)` — a predicate branch leaves the stack empty when the
+  callback path is taken vs. the species/length-observing path.
+- `array.set (need 3, got 2)` — the map/filter store emits index+array but
+  not the value when the callback result coercion is skipped.
+
+Likely site: the Array iteration intrinsic lowering in `src/codegen/`
+(builtin Array method codegen, the reduce/map/filter loop emitters). Audit
+the empty-array / species-undefined / abrupt-callback control-flow edges to
+ensure every path either pushes the loop-body result or branches before the
+consuming op.
+
+## Acceptance criteria
+
+- The five example tests above compile to a valid Wasm module (no
+  `invalid Wasm binary` / stack-underflow).
+- >=120 of the 156 tests in this cluster move off `compile_error`.

--- a/plan/issues/backlog/1602-call-arg-coercion-externref-invalid-wasm.md
+++ b/plan/issues/backlog/1602-call-arg-coercion-externref-invalid-wasm.md
@@ -1,0 +1,62 @@
+---
+id: 1602
+title: "codegen: call-site argument coercion emits invalid wasm (call expected externref, found f64/other)"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: type-coercion, call-expression
+es_edition: multi
+goal: compiler-correctness
+test262_count: 39
+related: [1522]
+---
+
+# #1602 — Call-site argument coercion produces invalid wasm
+
+## Problem
+
+39 test262 tests fail with `invalid Wasm binary` where the validator rejects a
+`call` op because the argument on the stack has the wrong type for the
+callee's signature:
+
+```
+call[N] expected type externref, found ... of type f64   (26 cases)
+call[N] expected type externref, found ... of type f64   (13 cases, mixed externref/f64)
+```
+
+Spread across `language/expressions` (spread-obj-null, dynamic-import LHS),
+`built-ins/Object`, `built-ins/Function` (toString of async methods),
+`built-ins/Atomics`, `built-ins/RegExp`, `built-ins/Number`,
+object method-definition, and `top-level-await` for-of.
+
+This is **distinct from** #1522's `extern.convert_any double-wrap` cluster:
+here the failure is at the **`call` op itself** — the argument was never
+coerced to the parameter type (an f64 or unboxed value is passed where the
+callee declares `externref`), rather than a global being double-wrapped.
+
+## Failing test examples
+
+- `test/language/expressions/new/spread-obj-null.js`
+- `test/built-ins/Function/prototype/toString/async-method-class-expression-static.js`
+- `test/language/expressions/object/method-definition/generator-length-dflt.js`
+- `test/language/module-code/top-level-await/syntax/for-of-await-expr-identifier.js`
+
+## Root-cause hypothesis
+
+The argument-lowering path in call codegen (`src/codegen/expressions.ts` call
+emission, `coerceType` in `src/codegen/type-coercion.ts`) skips the
+f64→externref / value→externref coercion for certain argument shapes:
+spread-into-call, generator/async trampoline params (`__obj_meth_tramp_*`),
+and dynamic-import call targets. The callee signature expects `externref` but
+the caller leaves the raw f64/value on the stack. Audit the per-argument
+coercion to apply `__box_number` / `extern.convert_any` against the resolved
+parameter type for these call paths.
+
+## Acceptance criteria
+
+- The four example tests compile to valid Wasm.
+- >=30 of the 39 tests move off `compile_error`.

--- a/plan/issues/backlog/1603-optional-chaining-ref-is-null-invalid-wasm.md
+++ b/plan/issues/backlog/1603-optional-chaining-ref-is-null-invalid-wasm.md
@@ -1,0 +1,55 @@
+---
+id: 1603
+title: "codegen: optional-chaining short-circuit emits invalid wasm (ref.is_null expected i32, found ref)"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: optional-chaining
+es_edition: es2020
+goal: compiler-correctness
+test262_count: 8
+related: [1522]
+---
+
+# #1603 — Optional-chaining short-circuit produces invalid wasm
+
+## Problem
+
+8 test262 tests fail with `invalid Wasm binary`:
+
+```
+ref.is_null[N] expected type i32, found ... (ref) ...
+```
+
+Concentrated in `language/expressions/optional-chaining` (call-expression,
+short-circuiting, iteration for-of type-error), plus one `built-ins/ArrayBuffer`.
+
+The optional-chaining short-circuit lowering emits a `ref.is_null` guard whose
+operand/result is wired into an i32 context incorrectly: the validator sees a
+ref where it expects i32 (or vice versa) at the null-check that decides whether
+to short-circuit the `?.` chain.
+
+## Failing test examples
+
+- `test/language/expressions/optional-chaining/call-expression.js`
+- `test/language/expressions/optional-chaining/short-circuiting.js`
+- `test/language/expressions/optional-chaining/iteration-statement-for-of-type-error.js`
+
+## Root-cause hypothesis
+
+The `?.` desugaring in `src/codegen/expressions.ts` emits `ref.is_null` to test
+the base value, but the surrounding select/branch consumes the result as the
+wrong type — likely the i32 boolean produced by `ref.is_null` is fed to a path
+expecting the ref itself, or the base was already unboxed to f64 and
+`ref.is_null` is applied to a non-ref. Audit the short-circuit branch
+construction to keep the null-test boolean (i32) and the chained value (ref)
+on separate, correctly-typed edges.
+
+## Acceptance criteria
+
+- The three example tests compile to valid Wasm.
+- All 8 tests move off `compile_error`.

--- a/plan/issues/backlog/1604-string-case-method-return-type-invalid-wasm.md
+++ b/plan/issues/backlog/1604-string-case-method-return-type-invalid-wasm.md
@@ -1,0 +1,55 @@
+---
+id: 1604
+title: "codegen: String case methods (toUpperCase/toLowerCase/toLocale*) return i32 into f64 comparison — invalid wasm"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: string-methods
+es_edition: multi
+goal: compiler-correctness
+test262_count: 8
+related: [1105, 1522]
+---
+
+# #1604 — String case-conversion method result type mismatch
+
+## Problem
+
+8 test262 tests fail with `invalid Wasm binary`:
+
+```
+f64.ne[0] expected type f64, found call of type i32
+```
+
+All 8 are `built-ins/String`, specifically the case-conversion methods:
+`toUpperCase`, `toLowerCase`, `toLocaleUpperCase`, `toLocaleLowerCase`.
+
+The compiled `test` function calls the string-case method (whose codegen emits
+an `i32`-typed result — likely a string-array ref index or a stale i32 temp)
+and then feeds it directly into an `f64.ne` comparison, which the validator
+rejects.
+
+## Failing test examples
+
+- `test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T9.js`
+- `test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T4.js`
+- `test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T4.js`
+
+## Root-cause hypothesis
+
+The String case-method intrinsic in `src/codegen/` (string method lowering,
+see #1105) declares or returns an `i32` result type where the surrounding
+expression expects an `externref`/f64 string value. When the test compares the
+result with `!=`, `coerceType` is not invoked (or invoked against the wrong
+source type) before `f64.ne`. Audit the return-type registration of the
+case-conversion methods so their result is a string ref that coerces correctly
+in numeric/equality contexts.
+
+## Acceptance criteria
+
+- The three example tests compile to valid Wasm.
+- All 8 tests move off `compile_error`.

--- a/plan/issues/backlog/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
+++ b/plan/issues/backlog/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
@@ -1,0 +1,58 @@
+---
+id: 1605
+title: "codegen: class computed-property-name / setter param-scope emits invalid wasm (local.tee externref mismatch)"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: classes
+es_edition: multi
+goal: compiler-correctness
+test262_count: 6
+related: [1522]
+---
+
+# #1605 — Class computed-name / setter scope local.tee type mismatch
+
+## Problem
+
+6 test262 tests fail with `invalid Wasm binary`:
+
+```
+local.tee[N] expected type externref, found ... (or vice versa)
+```
+
+All 6 are in `language/statements/class` and `language/expressions/class`,
+specifically:
+- computed-property-name accessors built from `null`
+  (`cpn-class-decl-accessors-computed-property-name-from-null`)
+- setter param-body var-close scope tests
+  (`scope-setter-paramsbody-var-close`, `scope-static-setter-paramsbody-var-close`)
+
+The failing function is `test`. A `local.tee` writes/reads a local declared
+with a type that doesn't match the value being tee'd — an externref value into
+a non-externref local, or the reverse — in the class member scope-setup code.
+
+## Failing test examples
+
+- `test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-null.js`
+- `test/language/statements/class/scope-setter-paramsbody-var-close.js`
+- `test/language/statements/class/scope-static-setter-paramsbody-var-close.js`
+
+## Root-cause hypothesis
+
+The class-member lowering (`src/codegen/` class/accessor codegen) allocates a
+local for a computed property key or a setter parameter with one declared type
+but tees a value of a different type into it. For the computed-name-from-null
+case the key is null/externref while the local is typed for the resolved key;
+for the setter param-scope cases the var-close scope copy mismatches. Audit the
+local-type declaration vs. the tee'd value type in computed-key evaluation and
+setter parameter scope copy-out.
+
+## Acceptance criteria
+
+- The three example tests compile to valid Wasm.
+- All 6 tests move off `compile_error`.

--- a/plan/issues/backlog/1606-internal-crash-object-literal-undefined-declarations.md
+++ b/plan/issues/backlog/1606-internal-crash-object-literal-undefined-declarations.md
@@ -1,0 +1,50 @@
+---
+id: 1606
+title: "codegen crash: 'Cannot read properties of undefined (reading declarations)' on object-literal expressions"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: object-literals
+es_edition: multi
+goal: compiler-correctness
+test262_count: 8
+---
+
+# #1606 — Internal compiler crash on object-literal expressions
+
+## Problem
+
+8 test262 tests crash the compiler:
+
+```
+Internal error compiling expression: Cannot read properties of undefined (reading 'declarations')
+```
+
+All 8 are `language/expressions/object` (the ES5 `11.1.5` object-initializer
+section). The compiler dereferences `.declarations` on an undefined node while
+compiling an object literal — an outright crash, not a graceful
+unsupported-feature error.
+
+## Failing test examples
+
+- `test/language/expressions/object/11.1.5_7-3-2.js`
+- `test/language/expressions/object/11.1.5-0-1.js`
+- `test/language/expressions/object/11.1.5_4-4-a-3.js`
+
+## Root-cause hypothesis
+
+Object-literal codegen in `src/codegen/expressions.ts` (or `literals.ts`)
+resolves a property's symbol/type and reads `symbol.declarations` (or
+`type.symbol.declarations`) without a null guard. Some object-literal property
+shapes in these ES5 tests (getter/setter pairs, duplicate keys, accessor
+descriptors) produce a symbol with no `declarations`. Add a guard / fallback
+type-resolution path.
+
+## Acceptance criteria
+
+- The three example tests compile without an internal crash.
+- All 8 tests move off `compile_error`.

--- a/plan/issues/backlog/1607-internal-crash-tdz-use-before-init-stack-overflow.md
+++ b/plan/issues/backlog/1607-internal-crash-tdz-use-before-init-stack-overflow.md
@@ -1,0 +1,53 @@
+---
+id: 1607
+title: "codegen crash: 'Maximum call stack size exceeded' on use-before-initialization (TDZ) in declaration statements"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: tdz-lexical-bindings
+es_edition: multi
+goal: compiler-correctness
+test262_count: 8
+---
+
+# #1607 — Compiler stack overflow on use-before-initialization declarations
+
+## Problem
+
+8 test262 tests crash the compiler:
+
+```
+Maximum call stack size exceeded
+```
+
+All 8 are use-before-initialization-in-declaration tests for `const`,
+`let`-style bindings, and `await using`:
+
+- `test/language/statements/const/block-local-use-before-initialization-in-declaration-statement.js`
+- `test/language/statements/await-using/block-local-use-before-initialization-in-declaration-statement.js`
+- `test/language/statements/await-using/global-use-before-initialization-in-declaration-statement.js`
+
+The declaration's initializer references the binding being declared (e.g.
+`const x = x;` / `await using x = x;`), and the compiler's type/value
+resolution recurses on the self-referential binding without a cycle guard,
+blowing the JS call stack.
+
+## Root-cause hypothesis
+
+Binding type-resolution or initializer codegen in `src/codegen/statements.ts`
+follows the declaration's symbol back to itself when the initializer names the
+declared identifier (a TDZ / self-reference case). There is no
+visited-set / recursion-depth guard. The spec behaviour is a `ReferenceError`
+at runtime (TDZ); the compiler should detect the self-reference and emit the
+TDZ throw rather than recursing. Add a cycle guard in the resolution path and
+emit the TDZ `ReferenceError` for self-referential lexical initializers.
+
+## Acceptance criteria
+
+- The three example tests compile without a stack-overflow crash.
+- All 8 tests move off `compile_error` (ideally to pass with a TDZ
+  `ReferenceError`).

--- a/plan/issues/backlog/1608-internal-crash-array-mutator-set-typeidx.md
+++ b/plan/issues/backlog/1608-internal-crash-array-mutator-set-typeidx.md
@@ -1,0 +1,52 @@
+---
+id: 1608
+title: "codegen crash: 'Cannot set properties of undefined (setting typeIdx)' on Array push/pop/shift/join/unshift"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: array-mutator-methods
+es_edition: multi
+goal: compiler-correctness
+test262_count: 5
+---
+
+# #1608 — Internal crash setting typeIdx in Array mutator codegen
+
+## Problem
+
+5 test262 tests crash the compiler:
+
+```
+Internal error compiling expression: Cannot set properties of undefined (setting 'typeIdx')
+```
+
+All 5 are `built-ins/Array/prototype` mutator/accessor methods invoked on a
+non-array `this` value (the `A2_T*` "apply to non-array / arguments-like"
+suites):
+
+- `test/built-ins/Array/prototype/push/S15.4.4.7_A2_T3.js`
+- `test/built-ins/Array/prototype/shift/S15.4.4.9_A2_T5.js`
+- `test/built-ins/Array/prototype/join/S15.4.4.5_A2_T4.js`
+- `test/built-ins/Array/prototype/pop/S15.4.4.6_A2_T4.js`
+
+The codegen attempts to assign `.typeIdx` on an undefined object while lowering
+the Array method — the receiver's element/array type was never resolved
+(generic / non-array `this`), so the type record is undefined.
+
+## Root-cause hypothesis
+
+The Array mutator intrinsic lowering in `src/codegen/` builds or looks up an
+array type descriptor and writes `descriptor.typeIdx = ...`, but the lookup
+returns undefined when the method is `.call`/`.apply`-ed on an array-like that
+is not a statically-typed array. Add a guard that resolves (or synthesizes) the
+array type record before assigning `typeIdx`, falling back to the generic
+array representation.
+
+## Acceptance criteria
+
+- The example tests compile without an internal crash.
+- All 5 tests move off `compile_error`.

--- a/plan/issues/backlog/1609-non-literal-spread-in-new-expression.md
+++ b/plan/issues/backlog/1609-non-literal-spread-in-new-expression.md
@@ -1,0 +1,49 @@
+---
+id: 1609
+title: "codegen: non-literal spread argument in new-expression not supported"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+task_type: feature
+area: codegen
+language_feature: spread, new-expression
+es_edition: es2015
+goal: compiler-correctness
+test262_count: 18
+---
+
+# #1609 — Non-literal spread in `new` expression unsupported
+
+## Problem
+
+18 test262 tests fail with:
+
+```
+new FunctionExpression with non-literal spread not supported
+```
+
+All are `language/expressions/new` spread tests where the constructor is
+invoked with `new F(...iterable)` and the spread operand is a non-array-literal
+(an iterator, a variable, an expression that throws mid-iteration).
+
+## Failing test examples
+
+- `test/language/expressions/new/spread-sngl-expr.js`
+- `test/language/expressions/new/spread-sngl-iter.js`
+- `test/language/expressions/new/spread-err-sngl-err-itr-step.js`
+
+## Root-cause hypothesis
+
+Spread-in-`new` codegen only handles the array-literal fast path
+(`new F(...[a, b])`) and bails on the general iterator-protocol spread. The
+call-expression path already supports general spread; the `new`-expression
+path in `src/codegen/expressions.ts` needs the same iterator-protocol
+expansion (build the argument array from the iterator, then apply to the
+constructor). Reuse the existing call-spread lowering for the construct path.
+
+## Acceptance criteria
+
+- `new F(...iter)` with a non-literal iterable compiles.
+- >=14 of the 18 tests move off `compile_error`.

--- a/plan/issues/backlog/1610-for-of-requires-array-expression.md
+++ b/plan/issues/backlog/1610-for-of-requires-array-expression.md
@@ -1,0 +1,50 @@
+---
+id: 1610
+title: "codegen: for-of over non-array iterables rejected ('for-of requires an array expression')"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+task_type: feature
+area: codegen
+language_feature: for-of, iterator-protocol
+es_edition: es2015
+goal: compiler-correctness
+test262_count: 13
+---
+
+# #1610 — for-of over a non-array iterable is rejected at compile time
+
+## Problem
+
+13 test262 tests fail with:
+
+```
+for-of requires an array expression
+```
+
+The compiler only lowers `for (x of <array>)` when the iterand is statically an
+array; a general iterable (object with `[Symbol.iterator]`, a generator result,
+a Set/Map, a promise-producing async iterator) is rejected at compile time.
+
+## Failing test examples
+
+- `test/built-ins/Temporal/Duration/prototype/round/relativeto-largestunit-smallestunit-combinations.js`
+- `test/built-ins/WeakRef/returns-new-object-from-constructor-with-object-target.js`
+- `test/language/expressions/class/async-gen-method-static/yield-promise-reject-next-for-await-of-sync-iterator.js`
+
+## Root-cause hypothesis
+
+The for-of statement codegen in `src/codegen/statements.ts` has a fast path
+that requires an array-typed iterand and throws otherwise instead of falling
+back to the iterator protocol (`[Symbol.iterator]()` → `.next()` loop). Add the
+general iterator-protocol lowering as the fallback when the iterand is not a
+statically-known array. This unblocks Set/Map/generator/custom-iterable
+for-of across the corpus.
+
+## Acceptance criteria
+
+- for-of over a non-array iterable compiles and iterates via the iterator
+  protocol.
+- >=10 of the 13 tests move off `compile_error`.

--- a/plan/issues/backlog/1611-lexical-declaration-single-statement-context.md
+++ b/plan/issues/backlog/1611-lexical-declaration-single-statement-context.md
@@ -1,0 +1,51 @@
+---
+id: 1611
+title: "parser: lexical declaration in single-statement context rejected for valid newline-separated cases"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+task_type: bug
+area: parser
+language_feature: lexical-declarations, asi
+es_edition: multi
+goal: compiler-correctness
+test262_count: 16
+---
+
+# #1611 — `let`/`const` in single-statement context: valid newline cases rejected
+
+## Problem
+
+16 test262 tests fail with:
+
+```
+Lexical declaration cannot appear in a single-statement context
+```
+
+The cluster is the `let-identifier-with-newline` / `let-block-with-newline`
+family under `for-in`, `for-of`, and `if`. In these tests `let` appears on its
+own line and, per ASI, is parsed as an *identifier reference* followed by a
+newline — NOT a lexical declaration — so the program is actually valid. The
+compiler eagerly classifies the token as a lexical declaration and rejects it.
+
+## Failing test examples
+
+- `test/language/statements/for-in/let-identifier-with-newline.js`
+- `test/language/statements/for-of/let-block-with-newline.js`
+- `test/language/statements/if/let-block-with-newline.js`
+
+## Root-cause hypothesis
+
+The parser/early-error check treats `let` as a lexical-declaration keyword in
+the body of `for`/`if` without applying the ASI / `let [` disambiguation rules
+(ECMA-262: `let` followed by a line terminator and then an identifier is an
+ExpressionStatement, not a LexicalDeclaration). Refine the single-statement
+lexical-declaration early error to respect the newline-based disambiguation.
+
+## Acceptance criteria
+
+- The newline-separated `let` identifier/block cases compile (or correctly
+  pass/fail per the test's `negative` expectation).
+- >=12 of the 16 tests move off `compile_error`.

--- a/plan/issues/backlog/1612-tla-array-literal-element-access-misparse.md
+++ b/plan/issues/backlog/1612-tla-array-literal-element-access-misparse.md
@@ -1,0 +1,52 @@
+---
+id: 1612
+title: "parser: top-level-await with array-literal operand misparsed as element access ('should take an argument')"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+task_type: bug
+area: parser
+language_feature: top-level-await, array-literals
+es_edition: es2022
+goal: compiler-correctness
+test262_count: 14
+---
+
+# #1612 — TLA + array-literal operand misparsed as element access
+
+## Problem
+
+14 test262 tests fail with:
+
+```
+An element access expression should take an argument.
+```
+
+All are `language/module-code/top-level-await/syntax/*-array-literal` tests:
+`await [x]`, `if (await [x])`, `void await [x]`, `export let y = await [x]`,
+etc. The parser treats the `[...]` array literal following `await` as a
+**member/element-access bracket** on the awaited value rather than a fresh
+ArrayLiteral expression, then errors because the bracket is "empty" or
+malformed for element access.
+
+## Failing test examples
+
+- `test/language/module-code/top-level-await/syntax/for-await-expr-array-literal.js`
+- `test/language/module-code/top-level-await/syntax/if-expr-await-expr-array-literal.js`
+- `test/language/module-code/top-level-await/syntax/void-await-expr-array-literal.js`
+
+## Root-cause hypothesis
+
+After parsing the `await` UnaryExpression operand, the parser's postfix loop
+greedily consumes a following `[` as an element-access on the await result.
+Per grammar, `await ArrayLiteral` should parse the `[...]` as the operand's
+primary expression. Fix the precedence so `await` binds its UnaryExpression
+operand (including a leading array literal) before postfix member access is
+considered.
+
+## Acceptance criteria
+
+- `await [ ... ]` in module top-level code parses correctly.
+- >=10 of the 14 tests move off `compile_error`.

--- a/plan/issues/backlog/1613-for-in-variable-must-be-identifier.md
+++ b/plan/issues/backlog/1613-for-in-variable-must-be-identifier.md
@@ -1,0 +1,50 @@
+---
+id: 1613
+title: "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: low
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: for-in, destructuring
+es_edition: multi
+goal: compiler-correctness
+test262_count: 10
+---
+
+# #1613 — for-in head non-identifier targets rejected
+
+## Problem
+
+10 test262 tests fail at compile time on the for-in head:
+
+```
+for-in variable must be an identifier            (7)
+for-in requires a variable declaration or identifier (3)
+```
+
+These are `language/statements/for-in` scope and bound-name tests where the
+for-in head is a `var`/`let` declaration with multiple bound names, a binding
+pattern, or a member-expression target rather than a bare identifier.
+
+## Failing test examples
+
+- `test/language/statements/for-in/head-var-bound-names-dup.js`
+- `test/language/statements/for-in/scope-body-lex-close.js`
+- `test/language/statements/for-in/scope-body-var-none.js`
+
+## Root-cause hypothesis
+
+The for-in statement codegen in `src/codegen/statements.ts` only accepts a
+single `Identifier` (or single-declaration) head and throws otherwise. It
+should accept the full ForBinding grammar: a binding declaration with its
+bound names, a destructuring binding pattern, or an assignment-target
+member expression — assigning the enumerated key to the target per iteration.
+Extend the head handling to cover these LHS forms.
+
+## Acceptance criteria
+
+- for-in over the declaration/pattern head forms compiles.
+- >=7 of the 10 tests move off `compile_error`.

--- a/plan/issues/backlog/1614-set-prototype-set-method-missing.md
+++ b/plan/issues/backlog/1614-set-prototype-set-method-missing.md
@@ -1,0 +1,53 @@
+---
+id: 1614
+title: "codegen: Set set-method intrinsics missing ('Cannot find method size/...' on parent class Set)"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: low
+feasibility: medium
+task_type: feature
+area: codegen
+language_feature: set-methods
+es_edition: es2024
+goal: compiler-correctness
+test262_count: 7
+related: [1103]
+---
+
+# #1614 — Set composition methods not resolved on subclass receivers
+
+## Problem
+
+7 test262 tests fail with:
+
+```
+Cannot find method 'size' on parent class 'Set'
+```
+
+All are the ES2024 Set-composition methods invoked on subclass receivers:
+`union`, `isDisjointFrom`, `isSupersetOf`, `symmetricDifference`,
+`intersection`, `difference`, `isSubsetOf` (the
+`*/subclass-receiver-methods.js` suite). The implementation of these methods
+calls the abstract `GetSetRecord` steps which read the `size` getter and the
+`has`/`keys` methods off the argument; the compiler cannot resolve `size`
+(and the other set-record members) on the `Set` parent class.
+
+## Failing test examples
+
+- `test/built-ins/Set/prototype/union/subclass-receiver-methods.js`
+- `test/built-ins/Set/prototype/isDisjointFrom/subclass-receiver-methods.js`
+- `test/built-ins/Set/prototype/symmetricDifference/subclass-receiver-methods.js`
+
+## Root-cause hypothesis
+
+The Set-method intrinsics (see #1103 wasm-native Map/Set) reference the `size`
+accessor and `has`/`keys` methods via a `parent class 'Set'` lookup that does
+not register the `size` getter (it is an accessor, not a data method) on the
+intrinsic Set shape. Register the Set `size` accessor and the
+`has`/`keys`/`values` methods so the GetSetRecord abstract operation resolves.
+
+## Acceptance criteria
+
+- The Set-composition methods resolve `size`/`has`/`keys` on receivers.
+- >=5 of the 7 tests move off `compile_error`.

--- a/plan/issues/backlog/1615-import-defer-source-phase-proposal-deferred.md
+++ b/plan/issues/backlog/1615-import-defer-source-phase-proposal-deferred.md
@@ -1,0 +1,55 @@
+---
+id: 1615
+title: "deferred: import.defer / import.source phase proposal not supported (Stage-N) — tracking"
+status: ready
+created: 2026-05-24
+updated: 2026-05-24
+priority: low
+feasibility: hard
+task_type: feature
+area: codegen
+language_feature: import-defer, import-source, module-phase-imports
+es_edition: proposal
+goal: compiler-correctness
+test262_count: 152
+related: [1315]
+---
+
+# #1615 — import.defer / import.source phase imports (deferred proposal)
+
+## Problem
+
+152 test262 tests fail with `compile_error` because the deferred-import /
+source-phase-import proposal syntax is not supported:
+
+```
+SyntaxError: import.defer(...) is not supported (Stage N proposal — import-defer / source-phase)   (62)
+SyntaxError: import.source(...) is not supported (Stage N proposal — import-defer / source-phase)   (90)
+```
+
+These are valid-syntax tests for the TC39 **import-defer** and
+**source-phase-imports** proposals (`import.defer(...)`, `import.source(...)`,
+`import defer` / `import source` declarations). The compiler emits a clean
+unsupported-feature SyntaxError rather than crashing.
+
+This is **deferred / proposal-tracking only** — these are not yet
+standardised ECMAScript. It is intentionally low priority.
+
+## Failing test examples
+
+- `test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js`
+- `test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-import-source-specifier-tostring-abrupt-rejects.js`
+
+## Relationship to #1315
+
+#1315 tracks the *negative* (early-error) side — proposal tests with
+`negative: { phase: parse, type: SyntaxError }` that should be rejected. This
+issue tracks the *positive* valid-syntax tests that can only pass once the
+phase-import proposal is actually implemented. Both stay deferred until the
+proposal advances.
+
+## Acceptance criteria (deferred)
+
+- Tracking only. No implementation expected until the proposal reaches a
+  later stage and is prioritised. Revisit if module-phase imports are added
+  to the goal graph.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,28 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## Harvest 2026-05-24b (fixable test262 compile-error causes — CE decomposition)
+
+Decomposed the 1,367 `compile_error` results in `test262-current.jsonl`. The
+528 `invalid Wasm binary` CEs were sub-clustered by validator error; sub-causes
+already enumerated in #1522 / #1543 / #1556 are not re-filed.
+
+- [#1601](1601-array-iteration-callback-stack-underflow.md) — Array reduce/reduceRight/map/filter callback paths emit stack-underflow wasm — **156 CE**, high
+- [#1602](1602-call-arg-coercion-externref-invalid-wasm.md) — call-site arg coercion: `call expected externref, found f64` — **39 CE**, high
+- [#1603](1603-optional-chaining-ref-is-null-invalid-wasm.md) — optional-chaining short-circuit `ref.is_null expected i32` — **8 CE**, high
+- [#1604](1604-string-case-method-return-type-invalid-wasm.md) — String toUpperCase/toLowerCase/toLocale* return i32 into f64.ne — **8 CE**, high
+- [#1605](1605-class-computed-setter-scope-local-tee-invalid-wasm.md) — class computed-name / setter scope `local.tee` type mismatch — **6 CE**, medium
+- [#1606](1606-internal-crash-object-literal-undefined-declarations.md) — internal crash `reading 'declarations'` on object literals — **8 CE**, high
+- [#1607](1607-internal-crash-tdz-use-before-init-stack-overflow.md) — stack overflow on TDZ self-referential lexical initializers — **8 CE**, high
+- [#1608](1608-internal-crash-array-mutator-set-typeidx.md) — internal crash `setting 'typeIdx'` on Array push/pop/shift/join — **5 CE**, high
+- [#1609](1609-non-literal-spread-in-new-expression.md) — non-literal spread in `new F(...iter)` unsupported — **18 CE**, medium
+- [#1610](1610-for-of-requires-array-expression.md) — for-of over non-array iterables rejected — **13 CE**, medium
+- [#1611](1611-lexical-declaration-single-statement-context.md) — valid newline `let` misclassified as lexical decl in single-stmt context — **16 CE**, medium
+- [#1612](1612-tla-array-literal-element-access-misparse.md) — top-level-await array-literal operand misparsed as element access — **14 CE**, medium
+- [#1613](1613-for-in-variable-must-be-identifier.md) — for-in head binding-pattern / non-identifier targets rejected — **10 CE**, low
+- [#1614](1614-set-prototype-set-method-missing.md) — Set union/isDisjointFrom etc. cannot resolve `size` on subclass receivers — **7 CE**, low
+- [#1615](1615-import-defer-source-phase-proposal-deferred.md) — import.defer / import.source phase proposal (deferred/proposal tracking) — **152 CE**, low
+
 ## Harvest 2026-05-24 (new issues from test262 error analysis)
 
 - [#1591](1591-class-elements-same-line-multi-definition.md) — class/elements same-line / stacked member definitions lost or reordered — **~294 fails**, high priority (formerly 779b)


### PR DESCRIPTION
## Summary

Decomposed all 1,367 `compile_error` (CE) results in
`benchmarks/results/test262-current.jsonl` by **root cause** and filed **15
new backlog issues** (#1601-#1615) for every fixable cause that did not already
have a tracking issue. The high-value work was sub-clustering the 528
`invalid Wasm binary` CEs by the specific Binaryen validator error rather than
filing a vague mega-issue.

### New issues filed

| # | Cause | CE |
|---|-------|----|
| 1601 | Array reduce/reduceRight/map/filter callback path → stack underflow | 156 |
| 1602 | call-site arg coercion `call expected externref, found f64` | 39 |
| 1603 | optional-chaining short-circuit `ref.is_null expected i32` | 8 |
| 1604 | String toUpperCase/toLowerCase/toLocale* return i32 into f64.ne | 8 |
| 1605 | class computed-name / setter scope `local.tee` type mismatch | 6 |
| 1606 | internal crash `reading 'declarations'` on object literals | 8 |
| 1607 | stack overflow on TDZ self-referential lexical initializers | 8 |
| 1608 | internal crash `setting 'typeIdx'` on Array push/pop/shift/join | 5 |
| 1609 | non-literal spread in `new F(...iter)` unsupported | 18 |
| 1610 | for-of over non-array iterables rejected | 13 |
| 1611 | valid newline `let` misclassified as lexical decl in single-stmt context | 16 |
| 1612 | top-level-await array-literal operand misparsed as element access | 14 |
| 1613 | for-in head binding-pattern / non-identifier targets rejected | 10 |
| 1614 | Set union/isDisjointFrom cannot resolve `size` on subclass receivers | 7 |
| 1615 | import.defer / import.source phase proposal (deferred tracking) | 152 |

### Deliberately skipped

- **WithStatement (294)** — sloppy-mode `with`, intentional non-support (wont-fix).
- **`smoosh` redeclare (60)** — test262 harness artifact, not a compiler bug.
- **no-test-export (27)** — harness artifact, not fixable.
- **SharedArrayBuffer (72)** — already tracked by #674 / #1354.
- **FinalizationRegistry (12)** — already tracked (#1600 / #1101).
- **invalid-wasm sub-causes already enumerated in #1522** (extern.convert_any double-wrap, struct.get-ref Temporal, f64.trunc compound-assign, any.convert_extern, f64.ne externref, fallthru/super-spread) and the **dstr-param struct-field cluster (#1543/#1544/#1556)** — not re-filed.
- Pure negative-syntax-test noise (assorted `',' expected` / `Invalid character`).

## Test plan

- [ ] Docs-only change (new `plan/issues/backlog/*.md` + backlog.md index). No code touched.