### PR TITLE
plan(s56): move CE-cause issues #1601-#1615 into sprint 56

### DIFF
--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -8,21 +8,6 @@ Decomposed the 1,367 `compile_error` results in `test262-current.jsonl`. The
 528 `invalid Wasm binary` CEs were sub-clustered by validator error; sub-causes
 already enumerated in #1522 / #1543 / #1556 are not re-filed.
 
-- [#1601](1601-array-iteration-callback-stack-underflow.md) — Array reduce/reduceRight/map/filter callback paths emit stack-underflow wasm — **156 CE**, high
-- [#1602](1602-call-arg-coercion-externref-invalid-wasm.md) — call-site arg coercion: `call expected externref, found f64` — **39 CE**, high
-- [#1603](1603-optional-chaining-ref-is-null-invalid-wasm.md) — optional-chaining short-circuit `ref.is_null expected i32` — **8 CE**, high
-- [#1604](1604-string-case-method-return-type-invalid-wasm.md) — String toUpperCase/toLowerCase/toLocale* return i32 into f64.ne — **8 CE**, high
-- [#1605](1605-class-computed-setter-scope-local-tee-invalid-wasm.md) — class computed-name / setter scope `local.tee` type mismatch — **6 CE**, medium
-- [#1606](1606-internal-crash-object-literal-undefined-declarations.md) — internal crash `reading 'declarations'` on object literals — **8 CE**, high
-- [#1607](1607-internal-crash-tdz-use-before-init-stack-overflow.md) — stack overflow on TDZ self-referential lexical initializers — **8 CE**, high
-- [#1608](1608-internal-crash-array-mutator-set-typeidx.md) — internal crash `setting 'typeIdx'` on Array push/pop/shift/join — **5 CE**, high
-- [#1609](1609-non-literal-spread-in-new-expression.md) — non-literal spread in `new F(...iter)` unsupported — **18 CE**, medium
-- [#1610](1610-for-of-requires-array-expression.md) — for-of over non-array iterables rejected — **13 CE**, medium
-- [#1611](1611-lexical-declaration-single-statement-context.md) — valid newline `let` misclassified as lexical decl in single-stmt context — **16 CE**, medium
-- [#1612](1612-tla-array-literal-element-access-misparse.md) — top-level-await array-literal operand misparsed as element access — **14 CE**, medium
-- [#1613](1613-for-in-variable-must-be-identifier.md) — for-in head binding-pattern / non-identifier targets rejected — **10 CE**, low
-- [#1614](1614-set-prototype-set-method-missing.md) — Set union/isDisjointFrom etc. cannot resolve `size` on subclass receivers — **7 CE**, low
-- [#1615](1615-import-defer-source-phase-proposal-deferred.md) — import.defer / import.source phase proposal (deferred/proposal tracking) — **152 CE**, low
 
 ## Harvest 2026-05-24 (new issues from test262 error analysis)
 

--- a/plan/issues/sprints/56/1601-array-iteration-callback-stack-underflow.md
+++ b/plan/issues/sprints/56/1601-array-iteration-callback-stack-underflow.md
@@ -1,5 +1,6 @@
 ---
 id: 1601
+sprint: 56
 title: "codegen: Array.prototype reduce/reduceRight/map/filter callback paths emit invalid wasm (stack underflow at local.set/if/array.set)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1602-call-arg-coercion-externref-invalid-wasm.md
+++ b/plan/issues/sprints/56/1602-call-arg-coercion-externref-invalid-wasm.md
@@ -1,5 +1,6 @@
 ---
 id: 1602
+sprint: 56
 title: "codegen: call-site argument coercion emits invalid wasm (call expected externref, found f64/other)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1603-optional-chaining-ref-is-null-invalid-wasm.md
+++ b/plan/issues/sprints/56/1603-optional-chaining-ref-is-null-invalid-wasm.md
@@ -1,5 +1,6 @@
 ---
 id: 1603
+sprint: 56
 title: "codegen: optional-chaining short-circuit emits invalid wasm (ref.is_null expected i32, found ref)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1604-string-case-method-return-type-invalid-wasm.md
+++ b/plan/issues/sprints/56/1604-string-case-method-return-type-invalid-wasm.md
@@ -1,5 +1,6 @@
 ---
 id: 1604
+sprint: 56
 title: "codegen: String case methods (toUpperCase/toLowerCase/toLocale*) return i32 into f64 comparison — invalid wasm"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
+++ b/plan/issues/sprints/56/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
@@ -1,5 +1,6 @@
 ---
 id: 1605
+sprint: 56
 title: "codegen: class computed-property-name / setter param-scope emits invalid wasm (local.tee externref mismatch)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1606-internal-crash-object-literal-undefined-declarations.md
+++ b/plan/issues/sprints/56/1606-internal-crash-object-literal-undefined-declarations.md
@@ -1,5 +1,6 @@
 ---
 id: 1606
+sprint: 56
 title: "codegen crash: 'Cannot read properties of undefined (reading declarations)' on object-literal expressions"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1607-internal-crash-tdz-use-before-init-stack-overflow.md
+++ b/plan/issues/sprints/56/1607-internal-crash-tdz-use-before-init-stack-overflow.md
@@ -1,5 +1,6 @@
 ---
 id: 1607
+sprint: 56
 title: "codegen crash: 'Maximum call stack size exceeded' on use-before-initialization (TDZ) in declaration statements"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1608-internal-crash-array-mutator-set-typeidx.md
+++ b/plan/issues/sprints/56/1608-internal-crash-array-mutator-set-typeidx.md
@@ -1,5 +1,6 @@
 ---
 id: 1608
+sprint: 56
 title: "codegen crash: 'Cannot set properties of undefined (setting typeIdx)' on Array push/pop/shift/join/unshift"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1609-non-literal-spread-in-new-expression.md
+++ b/plan/issues/sprints/56/1609-non-literal-spread-in-new-expression.md
@@ -1,5 +1,6 @@
 ---
 id: 1609
+sprint: 56
 title: "codegen: non-literal spread argument in new-expression not supported"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1610-for-of-requires-array-expression.md
+++ b/plan/issues/sprints/56/1610-for-of-requires-array-expression.md
@@ -1,5 +1,6 @@
 ---
 id: 1610
+sprint: 56
 title: "codegen: for-of over non-array iterables rejected ('for-of requires an array expression')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1611-lexical-declaration-single-statement-context.md
+++ b/plan/issues/sprints/56/1611-lexical-declaration-single-statement-context.md
@@ -1,5 +1,6 @@
 ---
 id: 1611
+sprint: 56
 title: "parser: lexical declaration in single-statement context rejected for valid newline-separated cases"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1612-tla-array-literal-element-access-misparse.md
+++ b/plan/issues/sprints/56/1612-tla-array-literal-element-access-misparse.md
@@ -1,5 +1,6 @@
 ---
 id: 1612
+sprint: 56
 title: "parser: top-level-await with array-literal operand misparsed as element access ('should take an argument')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1613-for-in-variable-must-be-identifier.md
+++ b/plan/issues/sprints/56/1613-for-in-variable-must-be-identifier.md
@@ -1,5 +1,6 @@
 ---
 id: 1613
+sprint: 56
 title: "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1614-set-prototype-set-method-missing.md
+++ b/plan/issues/sprints/56/1614-set-prototype-set-method-missing.md
@@ -1,5 +1,6 @@
 ---
 id: 1614
+sprint: 56
 title: "codegen: Set set-method intrinsics missing ('Cannot find method size/...' on parent class Set)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/sprints/56/1615-import-defer-source-phase-proposal-deferred.md
+++ b/plan/issues/sprints/56/1615-import-defer-source-phase-proposal-deferred.md
@@ -1,5 +1,6 @@
 ---
 id: 1615
+sprint: 56
 title: "deferred: import.defer / import.source phase proposal not supported (Stage-N) — tracking"
 status: ready
 created: 2026-05-24


### PR DESCRIPTION
Schedules the 15 test262 CE root-cause issues (filed in #557) into sprint 56 — sprint:56 frontmatter + moved to sprints/56/, stale backlog index lines removed. Planning-only.