### PR TITLE
docs: restore #1588 ABI spec + record dispatch-model/worktree memory

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -41,7 +41,8 @@
 - [feedback_team_comm_channels.md](feedback_team_comm_channels.md) — Dev status via TaskUpdate not verbose SendMessage; shutdown handoffs via agent-context files
 - [feedback_token_budget_guardrails.md](feedback_token_budget_guardrails.md) — Warn at 25% weekly budget, force break at 40%, hard stop at 50%
 - [feedback_diary_and_sprints_before_compact.md](feedback_diary_and_sprints_before_compact.md) — Update plan/diary.md and plan/issues/sprints/N/sprint.md (+ retrospective) BEFORE /compact — never discard learnings with the conversation
-- [feedback_tasklist_sync_unreliable.md](feedback_tasklist_sync_unreliable.md) — TaskList sync per-agent is unreliable; when devs report mismatched task IDs, fall back to SendMessage as authoritative dispatch
+- [feedback_tasklist_sync_unreliable.md](feedback_tasklist_sync_unreliable.md) — DISPATCH MODEL (2026-05-23): native TaskList auto-dispatch is canonical; tech lead reconciles (mark merged done immediately), doesn't route manually; SendMessage dispatch is break-glass only
+- [feedback_ignore_unreliable_autodispatch.md](feedback_ignore_unreliable_autodispatch.md) — SUPERSEDED 2026-05-23 by native auto-dispatch switch. Devs now trust auto-dispatch; only verify live state (is it merged/owned?) before claiming. Ignoring auto-dispatch wholesale is break-glass only.
 - [feedback_sendmessage_discipline.md](feedback_sendmessage_discipline.md) — SendMessage = blockers/decisions/completions only; status/idle/ack → TaskUpdate or silence
 - [feedback_dev_silence_protocol.md](feedback_dev_silence_protocol.md) — No idle_notification messages ever; devs silent during CI-wait; TL keeps queue full, devs escalate only
 - [feedback_idle_notification_silence.md](feedback_idle_notification_silence.md) — Don't respond to idle notifications unless CI landed or work to assign; silence breaks the ping loop

--- a/.claude/memory/feedback_agent_fetch_before_worktree.md
+++ b/.claude/memory/feedback_agent_fetch_before_worktree.md
@@ -1,0 +1,28 @@
+---
+name: feedback-agent-fetch-before-worktree
+description: "Agents must `git fetch origin main` before creating their worktree branch — never branch from stale local main"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 0ffbd21c-b73d-429a-a76d-4fb742ea9794
+---
+
+When a dev agent starts a task and creates its worktree, it MUST first
+`git fetch origin main` so the worktree branches off the FRESHEST origin/main —
+not a potentially stale local main pointer.
+
+**Why:** Local `/workspace` often lags origin/main by hundreds of commits
+(daemon noise, sync skips, the parent shell rarely pulls). If an agent
+worktree branches from local main, it inherits all the stale state and
+will hit immediate conflicts when pushing or rebasing.
+
+**How to apply:** Every agent spawn prompt should explicitly say:
+```
+git fetch origin main
+git worktree add /workspace/.claude/worktrees/<branch> -b <branch> origin/main
+```
+
+The CLAUDE.md "Worktree creation" rule already says this ("Always branch
+from `origin/main` (post-fetch), never from local `main`") but agents
+miss it without the explicit `git fetch` step in their prompt. Make
+both steps explicit in every dispatch.

--- a/.claude/memory/feedback_ignore_unreliable_autodispatch.md
+++ b/.claude/memory/feedback_ignore_unreliable_autodispatch.md
@@ -1,0 +1,37 @@
+---
+name: feedback-ignore-unreliable-autodispatch
+description: "SUPERSEDED 2026-05-23: team switched TO native auto-dispatch. Devs now trust auto-dispatch but sanity-check live state (already-merged? already-owned? right role?) before claiming. Wholesale ignoring of auto-dispatch is break-glass only."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 0ffbd21c-b73d-429a-a76d-4fb742ea9794
+---
+
+**SUPERSEDED 2026-05-23.** The user directed a switch TO Claude Code's native
+agent-teams auto-dispatch as the canonical dispatch model (see
+[[feedback_tasklist_sync_unreliable]] for the full decision). The earlier "ignore
+the auto-dispatcher" rule below was the manual-model stance and is now
+**break-glass only**.
+
+## Current rule (native model)
+
+Devs **trust auto-dispatch** and claim what it hands them — BUT do a cheap
+live-state sanity check first, because the dispatcher can lag the canonical list:
+- Is there already a merged/open PR for this issue? → skip, tell tech lead.
+- Does another agent already own it (agent-status file / worktree)? → skip.
+- Is it actually a dev-implementation task (not architect/PO/spec)? → if not, skip.
+
+If the check passes, claim it (set owner) and work it. The tech lead's job is to
+keep the canonical TaskList reconciled (mark merged tasks `completed` immediately)
+so these checks rarely trip. Only if sync visibly breaks for a dev (sees task IDs
+outside the known range, "TaskList doesn't show X") does the team fall back to
+SendMessage direct dispatch for that dev — the documented break-glass path.
+
+## Original observation (the why, retained)
+
+The mis-routes that motivated the manual stance: in one session the dispatcher
+handed dev-1116 a duplicate in-flight issue (#1588), an architect-role task
+(#126/#1130), and an already-merged issue (#64/#1553c). Root cause was a STALE
+CANONICAL LIST (merged tasks left `in_progress`/`pending`), not the dispatcher
+being inherently untrustworthy. The fix is prompt reconciliation, which is now
+the tech-lead discipline under the native model — not suppressing auto-dispatch.

--- a/.claude/memory/feedback_tasklist_sync_unreliable.md
+++ b/.claude/memory/feedback_tasklist_sync_unreliable.md
@@ -1,42 +1,36 @@
 ---
-name: TaskList sync across team members is unreliable — use SendMessage as fallback dispatch
-description: When dev agents report mismatched task IDs or treat incoming TaskList entries as "self-echoes," their local TaskList view is desynced from the shared team list. Switch to SendMessage as the authoritative dispatch channel for the remainder of the session.
-type: feedback
-originSessionId: 0ffbd21c-b73d-429a-a76d-4fb742ea9794
+name: Dispatch model — native TaskList auto-dispatch is canonical (manual SendMessage is break-glass)
+description: As of 2026-05-23 the team uses Claude Code's NATIVE agent-teams auto-dispatch as the dispatch model. The TaskList is the single source of truth; the tech lead's job is to keep it reconciled, not to route work manually. Manual SendMessage dispatch + owner-pinning is now a break-glass fallback only, used if per-agent TaskList sync visibly breaks.
+metadata:
+  type: feedback
+  originSessionId: 0ffbd21c-b73d-429a-a76d-4fb742ea9794
 ---
-## Observed problem
+## Decision (2026-05-23, user-directed)
 
-Mid-session on 2026-04-11, three separate dev agents (dev-1036, dev-1038, dev-990) reported that the shared team TaskList returned stale or wrong data from their side:
+Switched from the hand-rolled manual-dispatch model to **Claude Code's native agent-teams auto-dispatch**. Reason: running both layers at once (tech-lead manually pinning owners + the native auto-dispatcher routing) was causing collisions — the dispatcher kept offering already-merged, wrong-role, or already-owned tasks because the two layers had divergent state. The user's call: stop fighting the native system; lean into it.
 
-- **dev-1036**: "TaskList doesn't show #43/#44/#45" when those three tasks DID exist pending on the tech lead's shared view
-- **dev-1038**: "test task #21 shows completed" referring to an ID that didn't exist in the actual 15-entry TaskList
-- **dev-990**: seeing task IDs #21, #23 that didn't match the real #32–#45 range, and treating incoming TaskList assignments as "self-echoes from task system" to ignore
+## The model now
 
-The tech lead's `TaskList` call returned the correct 15-entry state every time. The problem was per-agent: their `TaskList`/`TaskUpdate` calls were landing in a disconnected namespace (possibly a stale cache, possibly a different task store pointer, possibly a team_name mismatch).
+- **The TaskList is the single source of truth.** Not issue files, not SendMessage. Issue files hold the spec/acceptance; the TaskList holds dispatch state.
+- **Tech lead's job is RECONCILIATION, not routing.** Keep the canonical TaskList accurate so the native dispatcher routes correctly:
+  - Mark a task `completed` the moment its PR merges (stale `in_progress`/`pending` entries are what cause mis-routes).
+  - Create tasks with enough description that a dev can work them cold.
+  - Let the native auto-dispatcher hand tasks to idle devs; don't pre-route via SendMessage.
+- **Devs self-claim** the lowest-ID unowned/unblocked task (their developer.md already says this) and accept auto-dispatched work.
+- **Owner is set on claim** (by the dev or the dispatcher), which stops re-offering.
 
-## Fix applied
+## Why the dispatcher mis-routed before (root cause)
 
-For the rest of the session, tech lead switched to **SendMessage as the authoritative dispatch channel**. Direct messages carry the full task assignment (issue number, file path, workflow, expected impact) so the dev doesn't need TaskList to understand what to work on. Tech lead also runs TaskUpdate to set `owner` + `status=in_progress` from the tech-lead side so the shared record is consistent, but does NOT rely on the dev's TaskList view reflecting it.
+The mis-routes were a STALE CANONICAL LIST, not (only) per-agent view desync: tasks for merged work (#1553c, #1116b, #1587) were left `in_progress`/`pending`, so the dispatcher still saw them as available. Fix = reconcile promptly. The tech-lead-side `TaskList` is authoritative and accurate; keep it that way and native dispatch works.
 
-When the dev completes a task, they report it via SendMessage ("PR #N shipped for #issue-number, completed") and tech lead updates TaskList from the tech-lead side.
+## Break-glass fallback (the OLD default, now exceptional)
 
-## How to apply next session
+If per-agent TaskList sync visibly breaks again — a dev reports task IDs outside the known range, "TaskList doesn't show X," or treats real assignments as "self-echoes" — THEN fall back to SendMessage as authoritative dispatch for that dev: send the full assignment (issue #, file path, workflow) and set owner+status from the tech-lead side. This is the documented 2026-04-11 failure mode (dev-1036/dev-1038/dev-990 saw disconnected task namespaces). Treat it as an exception, not the default. Don't debug the harness sync mid-session — fall back, continue, investigate after.
 
-1. **Signal to watch for**: any dev message that refers to task IDs outside the known range, says "TaskList doesn't show X," or labels legitimate assignments as "self-echoes to ignore"
-2. **Response**: immediately switch that dev to SendMessage dispatch. Tell them explicitly: *"Ignore TaskList output for the rest of the session. Treat SendMessage from team-lead as the authoritative task assignment. Ping me with PR-shipped status and I'll update TaskList from my side."*
-3. **Keep updating TaskList yourself** so the record stays accurate — just don't trust that the dev can read it
-4. **Do not debug the sync issue mid-session** — it's a harness/runtime-level problem, not a protocol issue. Fallback first, investigate afterward.
+## Tech-lead discipline checklist under native model
+1. PR merges → immediately `TaskUpdate status=completed`.
+2. New work discovered → `TaskCreate` with a self-contained description.
+3. Don't manually pin owners as routine (let dispatch/dev-claim do it); only intervene if a collision is observed.
+4. Watch for the break-glass signal; if seen, switch that dev to SendMessage.
 
-## Root cause (unresolved)
-
-Unclear. Candidates:
-- Per-agent process restart without team_name env var preserved
-- TaskList tool has per-session cache that doesn't invalidate on external updates
-- Team config file on disk has diverging state between agents
-- Some agents joined a default/different team context and aren't actually seeing the sprint-40 team's task list
-
-Investigate when capacity allows. Possibly file as an issue against the Claude Code harness team if reproducible.
-
-## Corollary: SendMessage is always authoritative for dispatches anyway
-
-Even when TaskList works, the one-sentence dispatch content lives in SendMessage (issue number, file path, workflow step, expected impact). TaskList is just an index. So falling back to SendMessage doesn't lose information — it just makes the dispatch explicit instead of implicit-via-poll.
+See also [[feedback_dev_self_serve_tasklist]] (aligned), [[feedback_sendmessage_discipline]].

--- a/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
+++ b/plan/issues/sprints/55/1588-string-encoding-tracking-utf8-wtf16.md
@@ -406,3 +406,315 @@ Deferred to Phase 2 (require IR changes outside this issue's landed surface):
   touch shared codegen / require a benchmark harness; the analysis lands
   first so the boundary work has data to read. See ADR-0015 §"Component
   Model boundary integration".
+
+## Phase 2 ABI Plan
+
+Author: Architect (one-shot spec). Date: 2026-05-23. Status: design only — no
+code in this section.
+
+> **Provenance of cited line numbers.** Phase 1 (lattice + analysis) and PR-A
+> (call-result origins + method propagation) are landed on the branches
+> `issue-1588-strenc` and `issue-1588-phase2a` respectively but **not yet
+> merged to `main`** as of this writing. File:line citations below reference
+> those branches where the symbol does not yet exist on `main`. The dev
+> implementing Phase 2 must rebase on the merged state and re-grep — treat the
+> line numbers as "nearest landmark", the symbol names as authoritative.
+
+### 0. What exists today (the inputs this ABI consumes)
+
+- **Encoding lattice + analysis** — `src/ir/analysis/encoding.ts`
+  (`@issue-1588-strenc`): `Encoding = "ascii" | "utf8-guaranteed" | "wtf16"`,
+  `joinEncoding`, `classifyLiteral`, `analyzeEncoding(fn, registry)`. PR-A
+  adds `classifyCall` / `classifyExternCall` (`@issue-1588-phase2a` encoding.ts
+  ~line 142–220) covering `JSON.parse`/`JSON.stringify` →
+  `utf8-guaranteed`, `TextDecoder.decode` → `utf8-guaranteed`, and the
+  preserving-method set (`toUpperCase`/`toLowerCase`/`trim*`/`normalize`/
+  `padStart`/`padEnd`/`repeat`).
+- **Annotation channel** — `AllocSiteRegistry` (`src/ir/alloc-registry.ts`),
+  `annotate(id, ns, value)` / `read(id, ns)`, namespace
+  `ALLOC_NAMESPACES.encoding = "encoding"`. `alias()` merges metadata onto the
+  canonical site on fusion (existing keys win), so annotations survive
+  inline/mono/CSE. `retire()` drops them. Read: `registry.read<Encoding>(id,
+  ALLOC_NAMESPACES.encoding)`.
+- **String alloc-site minting** — the IR builder mints a `"string"`
+  `AllocKind` on `string.const`, `string.concat` (Phase 1) and string-typed
+  `call` / `extern.call` results (PR-A, `src/ir/builder.ts` ~181, ~633). This
+  is the **only** set of sites with an annotation today; everything else reads
+  back `wtf16` by default (`encoding.ts` `enc()` fallback).
+- **Pass wiring** — `analyzeEncoding` runs in the IR pipeline after the 2a
+  hygiene loop (`src/ir/integration.ts` ~360, just past `assertAllocProvenance`).
+  The `allocRegistry` instance (integration.ts ~124) is the live object the
+  lowering pass must be handed; it is currently **not** threaded into the
+  lowering resolver.
+- **WasmGC string runtime** — `src/codegen/registry/types.ts:200`
+  `registerNativeStringTypes`: the backing array `__str_data` is
+  `(array (mut i16))` (line 205); `NativeString = { len:i32, off:i32,
+  data:ref __str_data }` (subtype of `AnyString`); `ConsString = { len, left,
+  right }` ropes. Literal materialization: `nativeStringLiteralInstrs`
+  (`src/codegen/native-strings.ts:25`). Host-string mode (default, no
+  `nativeStrings`) stores strings as opaque `externref` (wasm:js-string), where
+  the host owns the WTF-16 representation and we have **no byte access** at all.
+- **Linear backend CM/C-ABI edge** — `src/codegen-linear/c-abi.ts:9`:
+  `string → (i32 ptr, i32 byteLen)` pair, documented as **UTF-8 data**. This
+  is the existing WASI/Component-Model boundary; the wrapper marshalling is in
+  `emitCabiWrappers` (c-abi.ts ~164–260). The WIT generator
+  (`src/wit-generator.ts:138`) emits the abstract `string` WIT type and does
+  **not** itself perform canonical-ABI lowering.
+
+### 1. Dual i8 / i16 storage decision
+
+**Decision: storage width is keyed off the `encoding` annotation on the
+string's `AllocSite`, read from the registry at lowering time. The decision is
+made per allocation site, not per value, and only for the WasmGC
+(`nativeStrings`) backend.**
+
+#### Where the decision is made
+
+- The string-creating lowering sites are the consumers:
+  - Literals: `nativeStringLiteralInstrs` (`src/codegen/native-strings.ts:25`)
+    and `compileNativeStringLiteral` (its callers).
+  - Concat results: the `__str_concat` / cons-string builders in
+    `native-strings.ts` (the `ensureNativeStringHelpers` body, ~500–540).
+  - The IR lowering resolver `emitStringConst` /`string.concat` handlers
+    (`src/ir/lower.ts:953`, `:959`) which call the resolver hooks
+    (`emitStringConst?`, lower.ts:282).
+- At each, read the annotation:
+  `const enc = registry.read<Encoding>(instr.alloc, ALLOC_NAMESPACES.encoding) ?? "wtf16";`
+  Choose backing array: `enc === "ascii" || enc === "utf8-guaranteed"` →
+  **i8 array** (`__str_data_u8`, a new `(array (mut i8))` type), else the
+  existing i16 `__str_data`.
+
+#### New types (additive, behind the flag — see §3)
+
+Register alongside `registerNativeStringTypes`
+(`src/codegen/registry/types.ts:200`):
+
+- `__str_data_u8 = (array (mut i8))` — UTF-8 bytes.
+- `Utf8String = { len:i32 /* code-unit length, JS-visible */,
+  byteLen:i32, off:i32, data:ref __str_data_u8 }`, a **third subtype of
+  `AnyString`** (alongside `NativeString` and `ConsString`).
+
+  Rationale for keeping JS-visible `len` as code-unit (UTF-16) length: `.length`,
+  indexing, and comparison are observable WTF-16 semantics (Non-goals, this
+  issue). `len` preserves them; `byteLen` is the canonical-ABI size that lets
+  the boundary skip the scan. For an `ascii` string `len == byteLen`; for
+  `utf8-guaranteed` `byteLen >= len` is possible (multi-byte scalars).
+
+#### Keying off AllocSiteRegistry
+
+The annotation is attached to `instr.alloc` (an `AllocSiteId`). The lowering
+resolver does **not** currently receive the registry. **Required plumbing**:
+thread `allocRegistry` from `src/ir/integration.ts:124` into the
+`IrLowerResolver` (built in Phase 3 of integration; see integration.ts where
+the resolver is constructed) and store it on `CodegenContext` (add a field in
+`src/codegen/context/types.ts` next to `nativeStrDataTypeIdx:505`). The IR
+`alloc` id must reach the lowering callsite — the `string.const` /
+`string.concat` instrs already carry `instr.alloc`, so pass it through the
+resolver hook signatures (`emitStringConst`, lower.ts:282 — extend to
+`emitStringConst(value, alloc?)`).
+
+#### Fallback when encoding is unknown
+
+- `registry.read(...) === undefined` (no annotation: untracked origin,
+  legacy non-IR path, or AST→Wasm front-end) → treat as `wtf16` → i16
+  storage. **This is the existing behavior**, so any value the analysis does
+  not reach is byte-identical to today.
+- `ConsString` ropes: a concat result is annotated, but its operands may be
+  mixed-width (see §4). A `ConsString` whose flattened result is
+  `utf8-guaranteed` may still have an i16 leaf. **Decision: ropes always
+  flatten to the width of their own annotation**; the `flatten` helper
+  (`native-strings.ts` ~440) reads the annotation off the cons node's
+  `alloc` and emits into i8 or i16 accordingly, transcoding leaves as it
+  copies (it already does a code-unit copy loop). A cons node with no
+  annotation flattens to i16.
+- Host-string mode (`!ctx.nativeStrings`): **no dual storage.** Strings are
+  opaque host `externref`; we cannot pick their byte width. The annotation is
+  consumed only at the boundary (§2) to choose the host marshalling import.
+
+### 2. Component Model boundary lowering ABI
+
+The boundary is where the annotation pays off. Two distinct edges exist; the
+plan covers both.
+
+#### Edge A — linear-memory / WASI / canonical ABI (`c-abi.ts`)
+
+This is the real Component-Model edge. Canonical ABI `string` is
+`(ptr:i32, byteLen:i32)` of UTF-8 (`c-abi.ts:9`). Today the wrapper
+(`emitCabiWrappers`, c-abi.ts ~164) assumes the internal string is already
+UTF-8-laid-out in linear memory. With dual storage on the WasmGC side this
+edge only applies to the linear backend, whose internal strings are already
+byte-oriented — so the win here is **eliding the scalar-validity scan**, not a
+copy:
+
+- `utf8-guaranteed` / `ascii` arg: lower directly to `(ptr, byteLen)` from the
+  string header, **skipping** the WTF-16→UTF-8 re-encode and the
+  surrogate-validity scan. For `ascii`, the receiver may additionally advertise
+  a `latin1`/1-byte fast path to CM implementations that accept it.
+- `wtf16` arg: keep the existing scan-and-encode path (allocate a UTF-8
+  buffer, transcode, validate). On a lone surrogate this path traps/substitutes
+  per current behavior — **unchanged**.
+
+Lowering site: the per-arg marshalling switch in `emitCabiWrappers`
+(c-abi.ts, the `case "string"` arms ~72, ~133, ~252). Add a branch keyed on
+the arg's `Encoding` (resolved from the IR value's `alloc` annotation, plumbed
+the same way as §1). When the encoding is statically `wtf16` **or unknown**,
+emit the scan path; only the proven set takes the fast path.
+
+#### Edge B — WasmGC / wasm:js-string host edge
+
+For the default (host) backend strings are `externref` owned by the JS host;
+crossing to a Component requires the host glue to encode. Here the annotation
+selects **which host import** the call lowers to:
+
+- `utf8-guaranteed`/`ascii`: a `string_to_utf8_unchecked` import (host encodes
+  with `TextEncoder`, no JS-side surrogate check needed because we proved
+  well-formedness) — or, when the runtime supports the
+  `wasm:js-string`/stringref `encode` builtins, the unchecked encode variant.
+- `wtf16`: the checked `string_to_utf8` import that validates/substitutes.
+
+These imports are declared next to the existing console/string imports in
+`src/codegen/declarations.ts` (~831–867). The standalone-mode requirement
+(CLAUDE.md "JS host optional"): the WasmGC backend with `nativeStrings` + dual
+storage has the i8 bytes in-heap, so a Wasm-native `string_to_utf8` that just
+returns the `Utf8String.data` view satisfies standalone mode without a host
+import. Host imports remain the fast path when a JS runtime is present.
+
+#### WIT / canonical-ABI implications
+
+- The WIT type is unchanged: still `string` (`wit-generator.ts:138`). The
+  encoding distinction is an **internal lowering optimization**, invisible in
+  the interface. A Component consuming our exports sees standard
+  canonical-ABI UTF-8 either way.
+- `realloc`/`post-return`: the fast path for `utf8-guaranteed` linear strings
+  can hand the canonical ABI a pointer into the existing `Utf8String.data`
+  only if the data outlives the call (lift/lower lifetime rules). For an
+  **export return** the canonical ABI calls our `realloc` to own the buffer —
+  so the "zero-copy" claim is precise: zero *transcode* + zero *scan*, but the
+  canonical-ABI ownership copy may still occur per the CM lifting rules. The
+  benchmark (§3, PR-C) must measure against the scan+transcode baseline, not
+  claim a literal zero-byte-copy where the ABI mandates one.
+- Lone-surrogate strings can never be `utf8-guaranteed` (the classifier
+  demotes them, `encoding.ts` `classifyLiteral`), so the fast path can never
+  emit malformed UTF-8 across the WIT edge. This is the soundness anchor.
+
+### 3. Migration / safety — gating and PR sequencing
+
+**Hard requirement: default-OFF, byte-identical when off.** The Phase 1
+analysis is already inert (no consumer). Phase 2 introduces the first
+consumer, so it must be gated.
+
+#### The flag
+
+Add a compiler option `--utf8-storage` (CLI: `src/cli.ts`; option struct:
+`src/compiler.ts` / `src/index.ts` alongside `nativeStrings`). Default
+`false`. Gate everything in §1 and §2 behind it:
+
+- When `false`: the lowering sites never read the encoding annotation; storage
+  is i16 (WasmGC) and the boundary uses the existing scan path. The new
+  `Utf8String`/`__str_data_u8` types are **not registered** (no type-table
+  churn → emitted Wasm byte-identical to today). Verifiable by a golden-wasm
+  diff test on a literal-heavy fixture with the flag off.
+- When `true`: dual storage + fast boundary path active.
+- `--utf8-storage` implies `nativeStrings` for the WasmGC backend (the host
+  backend can't do dual storage; Edge B import selection still works there and
+  may be gated separately if desired). For `--target wasi` (linear), only
+  Edge A applies and `nativeStrings` is already auto-on.
+
+#### PR sequencing
+
+- **PR-B (storage)** — register `__str_data_u8` + `Utf8String`
+  (`registry/types.ts`), thread `allocRegistry` into the lowering resolver and
+  `CodegenContext`, implement the storage-width decision at the literal /
+  concat / flatten sites (`native-strings.ts`), behind `--utf8-storage`. No
+  boundary change yet: a `Utf8String` is consumed by the existing string
+  helpers via a small access-primitive abstraction (charCodeAt / length /
+  copy that branches on the `AnyString` subtype — the pattern already exists
+  for `NativeString` vs `ConsString` in `ensureNativeStringHelpers`). Tests:
+  golden-wasm byte-identity with flag off; round-trip correctness (length,
+  indexing, comparison, concat) for i8-backed strings with flag on; a
+  fuzz/property test that an i8 string and its i16 equivalent are
+  `===`-observably identical.
+- **PR-C (boundary + benchmark)** — implement Edge A
+  (`c-abi.ts`) and Edge B (`declarations.ts` import selection) keyed on the
+  annotation; add the standalone Wasm-native `string_to_utf8` fallback. Add
+  the benchmark harness (string-heavy CM interop: literal/JSON/decoder origins
+  through an exported function) measuring scan+transcode baseline vs fast path,
+  numbers into ADR-0015. Tests: both paths exercised (a `wtf16` value forced
+  through the scan path, a `utf8-guaranteed` value through the fast path);
+  differential test with fuzzed inputs incl. lone surrogates confirming the
+  fast path is never selected for a surrogate-bearing value.
+
+Each PR is independently revertible and inert-when-off. PR-B can merge and
+bake before PR-C flips any boundary behavior.
+
+### 4. Edge cases
+
+- **Lone surrogates (wtf16-only).** `classifyLiteral` already returns `wtf16`
+  for any lone surrogate (`encoding.ts`); such a string therefore always gets
+  i16 storage and the scan boundary path. **Invariant to preserve in PR-B:**
+  the storage-width decision uses the *same* annotation, so a value can never
+  be both surrogate-bearing and i8-backed. Add an assertion in the i8
+  literal/flatten emitter: if the source code units include a lone surrogate,
+  the annotation must not be `ascii`/`utf8-guaranteed` (defensive; the
+  classifier guarantees it, the assert catches a future classifier bug before
+  it produces malformed bytes).
+- **Concatenation of mixed-encoding operands.** `string.concat`'s annotation
+  is `joinEncoding(lhs, rhs)` (already landed). Storage cases:
+  - both i8-eligible (`ascii`/`utf8`) → result i8, leaves copied as bytes.
+  - one i16 (`wtf16`) → join is `wtf16` → result i16; an i8 leaf is
+    width-extended (zero-extend bytes to i16 code units — safe, ASCII/UTF-8
+    bytes are not surrogates) during the copy in `__str_concat`/flatten.
+  - **Cons-string deferral:** the rope node carries its own annotation; its
+    leaves may differ in width. Flattening reads the *node's* annotation to
+    pick output width and transcodes leaves on the fly (§1 fallback). A `wtf16`
+    cons over an i8 leaf zero-extends; a `utf8-guaranteed` cons over an i8 leaf
+    copies bytes directly. A `utf8-guaranteed` cons can never have a `wtf16`
+    (surrogate) leaf because the join would have forced `wtf16`.
+- **Interop with the existing dual string backend (nativeStrings vs
+  wasm:js-string).** Three sub-backends now coexist, selected at compile time:
+  1. host `externref` (default) — no in-heap bytes; annotation used only for
+     Edge B import selection. `Utf8String` is irrelevant; do **not** register
+     it in this mode.
+  2. `nativeStrings` i16 (today's WasmGC) — `--utf8-storage` off, or values
+     annotated `wtf16`.
+  3. `nativeStrings` + `--utf8-storage` i8 (`Utf8String`) — new path.
+  The access primitives (`charCodeAt`, `length`, substring/copy) must dispatch
+  on the `AnyString` subtype tag so mode-2 and mode-3 strings interoperate in
+  the same module (a function may receive an i16 param and concat an i8
+  literal). This is the "abstract string interface" called out in the issue
+  Risks; the existing `NativeString`/`ConsString` `ref.test` dispatch in
+  `ensureNativeStringHelpers` is the template — add a third arm for
+  `Utf8String`.
+- **Annotation absent on a code path the analysis didn't reach** (legacy
+  AST→Wasm front-end, IR fallback): `registry.read` → `undefined` → `wtf16` →
+  i16 + scan path. Strictly the slow, correct path. No new failure mode.
+- **`alias`/`retire` interaction.** If a future CSE fuses two string sites of
+  *different* encodings, `alias()` keeps the existing key (the canonical
+  site's annotation wins). This could let a `utf8` site alias into a `wtf16`
+  canonical (safe — slower) or vice-versa (**unsafe** — a `wtf16` value
+  reading a `utf8` annotation). **Required guard:** before PR-C flips the
+  boundary, add a check in the encoding analysis or a CSE precondition that
+  string sites may only be aliased when `joinEncoding(a,b)` equals the
+  surviving annotation (i.e. never alias a `wtf16` site into a `utf8`
+  canonical). Document in ADR-0015. No CSE pass fuses strings today, so this is
+  a forward-guard, not a present bug.
+
+### File:line target summary (rebase + re-grep before editing)
+
+| Concern | File:line | Symbol |
+|---|---|---|
+| Encoding type + join + classifier | `src/ir/analysis/encoding.ts` (@strenc) | `Encoding`, `joinEncoding`, `classifyLiteral` |
+| Call/extern origin rules | `src/ir/analysis/encoding.ts` ~142–220 (@phase2a) | `classifyCall`, `classifyExternCall` |
+| Annotation read/write | `src/ir/alloc-registry.ts` | `annotate`, `read`, `ALLOC_NAMESPACES.encoding` |
+| String alloc minting | `src/ir/builder.ts` ~181, ~633 (@phase2a) | `call`/`extern.call` `alloc` |
+| Pass invocation | `src/ir/integration.ts` ~360 | `analyzeEncoding`; registry @124 |
+| WasmGC string types | `src/codegen/registry/types.ts:200` | `registerNativeStringTypes`, `__str_data` (i16, :205) |
+| Literal materialization | `src/codegen/native-strings.ts:25` | `nativeStringLiteralInstrs` |
+| Concat / flatten helpers | `src/codegen/native-strings.ts` ~440, ~500 | `ensureNativeStringHelpers` |
+| IR lowering string hooks | `src/ir/lower.ts:953`, `:282` | `string.const`/`string.concat`, `emitStringConst?` |
+| Context field for registry | `src/codegen/context/types.ts:505` | add next to `nativeStrDataTypeIdx` |
+| Linear CM/C-ABI string edge | `src/codegen-linear/c-abi.ts:9`, ~72/133/252 | `emitCabiWrappers`, `case "string"` |
+| Host string-encode imports | `src/codegen/declarations.ts` ~831–867 | import declarations |
+| WIT string type (unchanged) | `src/wit-generator.ts:138` | `mapTypeNode` |
+| CLI / option flag | `src/cli.ts`, `src/compiler.ts`, `src/index.ts` | `--utf8-storage` |
+| ADR | `docs/adr/0015-string-encoding-tracking.md` (@strenc) | extend §"Component Model boundary" + add storage + alias-guard |


### PR DESCRIPTION
Two batches from the 'commit reasonable work' pass (docs/memory only, no source, daemon/benchmark churn excluded):
- **Batch B** — restore #1588 Phase 2 ABI Plan (dual i8/i16 storage + CM boundary design) held out of the doc-hygiene PR to avoid colliding with dev-1588's #548 (now merged).
- **Batch C** — team-memory: native auto-dispatch model, fetch-before-worktree rule, autodispatch-supersede note.