### PR TITLE
plan(s56): sprint 56 = codegen-bug CE issues only; feature gaps → backlog

### DIFF
--- a/plan/issues/backlog/1609-non-literal-spread-in-new-expression.md
+++ b/plan/issues/backlog/1609-non-literal-spread-in-new-expression.md
@@ -1,6 +1,5 @@
 ---
 id: 1609
-sprint: 56
 title: "codegen: non-literal spread argument in new-expression not supported"
 status: ready
 created: 2026-05-24

--- a/plan/issues/backlog/1610-for-of-requires-array-expression.md
+++ b/plan/issues/backlog/1610-for-of-requires-array-expression.md
@@ -1,6 +1,5 @@
 ---
 id: 1610
-sprint: 56
 title: "codegen: for-of over non-array iterables rejected ('for-of requires an array expression')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/backlog/1612-tla-array-literal-element-access-misparse.md
+++ b/plan/issues/backlog/1612-tla-array-literal-element-access-misparse.md
@@ -1,6 +1,5 @@
 ---
 id: 1612
-sprint: 56
 title: "parser: top-level-await with array-literal operand misparsed as element access ('should take an argument')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/backlog/1613-for-in-variable-must-be-identifier.md
+++ b/plan/issues/backlog/1613-for-in-variable-must-be-identifier.md
@@ -1,6 +1,5 @@
 ---
 id: 1613
-sprint: 56
 title: "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')"
 status: ready
 created: 2026-05-24

--- a/plan/issues/backlog/1614-set-prototype-set-method-missing.md
+++ b/plan/issues/backlog/1614-set-prototype-set-method-missing.md
@@ -1,6 +1,5 @@
 ---
 id: 1614
-sprint: 56
 title: "codegen: Set set-method intrinsics missing ('Cannot find method size/...' on parent class Set)"
 status: ready
 created: 2026-05-24

--- a/plan/issues/backlog/1615-import-defer-source-phase-proposal-deferred.md
+++ b/plan/issues/backlog/1615-import-defer-source-phase-proposal-deferred.md
@@ -1,6 +1,5 @@
 ---
 id: 1615
-sprint: 56
 title: "deferred: import.defer / import.source phase proposal not supported (Stage-N) — tracking"
 status: ready
 created: 2026-05-24


### PR DESCRIPTION
Refines the CE-issue scheduling per stakeholder direction: sprint 56 keeps only the **codegen bugs to fix immediately** — invalid-wasm (#1601-1605), compiler crashes (#1606-1608), and #1611 (valid `let` rejected). The **unsupported-feature/deferred** CE gaps (#1609/#1610/#1612/#1613/#1614/#1615) move back to backlog. Planning-only.