### PR TITLE
fix(#1617): don't pre-box body-local let/const captured by closure in for-loop

### DIFF
--- a/plan/issues/sprints/56/1617-rendercal-prebox-body-local-const-ref-isnull-f64.md
+++ b/plan/issues/sprints/56/1617-rendercal-prebox-body-local-const-ref-isnull-f64.md
@@ -1,0 +1,105 @@
+---
+id: 1617
+sprint: 56
+title: "codegen: loop pre-box wrongly boxes body-local let/const captured by closure → ref.is_null over f64 (invalid wasm)"
+status: done
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: closures-per-iteration-binding
+es_edition: es2015
+goal: compiler-correctness
+related: [1602, 1603, 1589, 1453]
+---
+
+# #1617 — Loop pre-box boxes body-local let/const captured by a closure → `ref.is_null` over f64
+
+## Problem
+
+The deployed playground calendar example fails to instantiate:
+
+```
+Compiling function #25:"renderCal" failed:
+  ref.is_null[0] expected reference type, found local.get of type f64 @+8105
+```
+
+User-facing flagship DOM example (`playground/examples/dom/calendar.ts`).
+Sibling of the #1602 / #1603 f64↔ref coercion family — same "invalid wasm
+because a ref op is applied to an f64 value" shape, but a distinct root cause
+in the **closure per-iteration binding** machinery.
+
+## Repro (minimal)
+
+```ts
+function renderCal(): void {
+  for (let d = 1; d <= 31; d++) {
+    const day = d;                  // body-local block-scoped const, type number → f64
+    const f = () => { return day; }; // captured by a closure
+  }
+}
+```
+
+Compiling `renderCal` yields invalid wasm. No null-check, no `gridEl`, no DOM
+needed — the trigger is a **body-local `let`/`const` number variable captured
+by a closure inside a `for` loop**. The misleading `if (gridEl === null)` in
+the original source is NOT involved.
+
+## Root cause
+
+The #1589 pre-box pass in `src/codegen/statements/loops.ts`
+(`findAllNamesCapturedByClosuresInForLoop` → `preBoxedNames` loop) exists to
+promote **`var`-declared / enclosing-function** variables captured by a closure
+to a ref-cell *before* the loop condition is compiled (otherwise the condition
+reads the unboxed slot and the loop spins forever).
+
+But `findAllNamesCapturedByClosuresInForLoop` returns **every** identifier
+referenced inside any closure in the loop — including body-local `let`/`const`
+names like `day`. The pre-box pass had no guard to exclude them, so for `day`:
+
+1. `hoistLetConstWithTdz` had already pre-allocated an **f64** value slot for
+   the body's `const day`.
+2. The pre-box pass read `oldLocalIdx = localMap.get("day")` (the hoisted f64
+   slot), boxed it at loop head into a `__pre_box_day` ref-cell, and redirected
+   `localMap["day"]` → the cell, plus registered `boxedCaptures["day"]`.
+3. When the body declaration `const day = d` compiled
+   (`src/codegen/statements/variables.ts`), the boxed-init branch
+   (`boxedForInit`, lines ~565-588) fired. It emits `local.get localIdx;
+   ref.is_null; (if … struct.set …)` — but `localIdx` resolved to the **f64**
+   hoisted slot (the `(local $day f64)`), not the ref-cell. Result:
+   `ref.is_null` over an f64 → invalid wasm.
+
+The deeper invariant violated: a body-local `let`/`const` is **block-scoped to
+each iteration**. It is handled correctly by the body declaration + the
+closure-construction path (which boxes it per-iteration with the right local
+index). It must NOT be pre-boxed at the loop head, where the binding does not
+even exist yet.
+
+## Fix
+
+`src/codegen/statements/loops.ts`:
+
+- Added `findBodyLocalLexicalNames(stmt)` — collects names lexically declared
+  (`let`/`const`/`using`, class, function) at the top level of the loop body.
+- In the #1589 pre-box pass, skip any captured name that is in that set.
+
+This is a ~30-line, surgical narrowing of the pre-box candidate set. It does
+not touch the `var`/enclosing-variable infinite-loop fix (#1589) nor the
+per-iteration head-binding cells (#1453) — those names are not body-local
+lexical declarations, so they are unaffected.
+
+## Verification
+
+- `playground/examples/dom/calendar.ts` → `new WebAssembly.Module()` validates.
+- Minimal repro + variants (closure capturing body-local number, two closures,
+  loop with DOM appendChild) all validate.
+- #1589 `var`-capture loop still compiles (no regression in the pre-box path).
+- Regression test: `tests/issue-1617.test.ts` (per-iteration capture semantics
+  + module validity).
+
+## Files
+
+- `src/codegen/statements/loops.ts` — `findBodyLocalLexicalNames` + pre-box guard
+- `tests/issue-1617.test.ts` — regression test

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -385,6 +385,44 @@ function findAllNamesCapturedByClosuresInForLoop(stmt: ts.ForStatement): Set<str
   return captured;
 }
 
+/**
+ * Collect names that are lexically declared (`let`/`const`/`using`, class,
+ * or function) at the top level of the loop body — i.e. block-scoped bindings
+ * that belong to each iteration's environment rather than to an outer scope.
+ *
+ * The #1589 pre-box pass is only meant for `var`-declared or enclosing-function
+ * variables. A body-local `let`/`const` captured by a closure already gets a
+ * fresh per-iteration cell via the body declaration + closure-construction
+ * path; pre-boxing it at the loop head is semantically wrong (the binding does
+ * not exist yet) and conflates the hoisted value slot with the ref cell,
+ * emitting `ref.is_null` over an f64 local (invalid wasm). We exclude these.
+ *
+ * We do NOT descend into nested closures or nested blocks/loops: only bindings
+ * whose scope is the loop body's own lexical environment matter here.
+ */
+function findBodyLocalLexicalNames(stmt: ts.ForStatement): Set<string> {
+  const names = new Set<string>();
+  const body = stmt.statement;
+  const statements = ts.isBlock(body) ? body.statements : [body];
+  for (const s of statements) {
+    if (ts.isVariableStatement(s)) {
+      const isLexical =
+        (s.declarationList.flags &
+          (ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing)) !==
+        0;
+      if (!isLexical) continue;
+      for (const decl of s.declarationList.declarations) {
+        for (const n of collectPatternBindingNames(decl.name)) names.add(n);
+      }
+    } else if (ts.isFunctionDeclaration(s) && s.name) {
+      names.add(s.name.text);
+    } else if (ts.isClassDeclaration(s) && s.name) {
+      names.add(s.name.text);
+    }
+  }
+  return names;
+}
+
 export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForStatement): void {
   // Save localMap entries for let/const initializers that shadow outer variables.
   // `for (let x = ...; ...)` creates a block scope that ends after the loop.
@@ -628,7 +666,13 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   }[] = [];
   {
     const capturedNames = findAllNamesCapturedByClosuresInForLoop(stmt);
+    // Body-local `let`/`const`/class/function bindings are block-scoped to each
+    // iteration and handled by the body declaration + closure-construction path.
+    // Pre-boxing them at the loop head conflates the hoisted value slot with the
+    // ref cell (→ `ref.is_null` over an f64 local). Exclude them.
+    const bodyLocalLexical = findBodyLocalLexicalNames(stmt);
     for (const name of capturedNames) {
+      if (bodyLocalLexical.has(name)) continue;
       if (fctx.boxedCaptures?.has(name)) continue; // already boxed (let/const per-iter)
       const oldLocalIdx = fctx.localMap.get(name);
       if (oldLocalIdx === undefined) continue; // not a local — globals/imports

--- a/tests/issue-1617.test.ts
+++ b/tests/issue-1617.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #1617: the #1589 loop pre-box pass wrongly boxed body-local `let`/`const`
+// names captured by a closure, conflating the hoisted f64 value slot with the
+// ref cell and emitting `ref.is_null` over an f64 local — invalid wasm. The
+// flagship playground calendar example (a closure capturing a per-cell `day`
+// number inside the day-render loop) failed to instantiate as a result.
+//
+// These tests assert the binary VALIDATES (the bug was a validation failure)
+// and, where the runtime path is supported, that the value is correct. We keep
+// to inline closure invocation; arrays-of-closures have a separate, pre-existing
+// runtime null-deref limitation unrelated to this fix.
+
+function compileValid(source: string) {
+  const result = compile(source);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  // The original bug produced a module that failed WebAssembly validation.
+  expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  return result;
+}
+
+async function run(source: string, fn: string) {
+  const result = compileValid(source);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as Record<string, Function>)[fn]!();
+}
+
+describe("#1617 — loop pre-box must not box body-local let/const captured by a closure", () => {
+  it("compiles a body-local number const captured by a closure inside a for-loop", async () => {
+    // Minimal repro: previously emitted `ref.is_null` over an f64 local.
+    expect(
+      await run(
+        `
+      export function test(): number {
+        let count = 0;
+        for (let d = 1; d <= 3; d++) {
+          const day = d;
+          const f = (): number => day;
+          count = count + f();
+        }
+        return count;
+      }
+    `,
+        "test",
+      ),
+    ).toBe(6); // 1 + 2 + 3
+  });
+
+  it("validates a body-local number const captured by two closures in the same iteration", () => {
+    // Two captures of differently-typed body locals (number → f64, string → ref)
+    // — the calendar's click/mouseenter handler shape. Validation-only: the
+    // closures escape into DOM-like sinks, exercising the boxing path.
+    compileValid(`
+      let sink: HTMLElement | null = null;
+      function el(t: string): HTMLElement { return document.createElement(t); }
+      export function render(): void {
+        if (sink === null) return;
+        for (let d = 1; d <= 31; d++) {
+          const day = d;
+          const bg = "x";
+          const cell = el("div");
+          cell.addEventListener("click", () => { onDay(day); });
+          cell.addEventListener("mouseenter", () => { if (bg === "x") cell.style.background = "#222"; });
+          sink.appendChild(cell);
+        }
+      }
+      function onDay(d: number): void {}
+    `);
+  });
+
+  it("validates the playground calendar example (renderCal regression)", () => {
+    // Direct guard for the reported failure: function #25 "renderCal" must
+    // produce a module that validates.
+    const src = readFileSync(resolve(__dirname, "../playground/examples/dom/calendar.ts"), "utf-8");
+    compileValid(src);
+  });
+
+  it("does not regress #1589 var/enclosing capture in a for-loop", () => {
+    // `var i` shares a single binding across iterations; the pre-box pass must
+    // still box it so the loop condition sees mutations. Validation-only.
+    compileValid(`
+      export function test(): number {
+        var sum = 0;
+        var fns: (() => void)[] = [];
+        for (var i = 0; i < 3; i++) {
+          fns.push(() => { sum = sum + i; });
+        }
+        return sum;
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

The deployed playground **calendar** example failed to instantiate:

```
Compiling function #25:"renderCal" failed:
  ref.is_null[0] expected reference type, found local.get of type f64 @+8105
```

Root cause is **not** the source `if (gridEl === null)` check. The trigger is a
body-local block-scoped `let`/`const` number variable captured by a closure
inside a `for` loop:

```ts
for (let d = 1; d <= 31; d++) {
  const day = d;                   // body-local const, number → f64
  const f = () => { return day; }; // captured by a closure
}
```

The #1589 loop pre-box pass (`src/codegen/statements/loops.ts`) promotes **every**
closure-captured name — including body-local `let`/`const` — to a ref-cell at the
loop head. Those names already have a hoisted f64 value slot, so the subsequent
body declaration hits the boxed-init path in `statements/variables.ts` and emits
`ref.is_null` over the **f64** slot → invalid wasm.

Body-local `let`/`const` are block-scoped per iteration and are already boxed
correctly by the body-declaration + closure-construction path. The loop-head
pre-box is only meant for `var`/enclosing variables (#1589).

## Fix

- `src/codegen/statements/loops.ts`: add `findBodyLocalLexicalNames(stmt)` and
  exclude those names from the pre-box candidate set. ~30 LOC, surgical. Does not
  touch the #1589 `var`/enclosing infinite-loop fix nor #1453 head-binding cells.

## Test plan

- [x] `playground/examples/dom/calendar.ts` → `new WebAssembly.Module()` validates
- [x] Minimal repro + variants (single/double closure, DOM appendChild) validate
- [x] `#1589` `var`-capture loop still compiles (no regression)
- [x] `tests/issue-1617.test.ts` (4 tests) pass
- [x] `tsc --noEmit`, `biome lint`, `check:ir-fallbacks` all green
- [x] Adjacent loop/closure suites (`issue-1453`, `issue-1589a`, `flatmap-closure`, …) unchanged vs main

Note: a pre-existing **array-of-closures runtime null-deref** (reproduces on
clean main even without body-local capture) is out of scope — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)