### PR TITLE
feat(#1588) Phase 2 PR-B part 2: activate i8 string storage end-to-end

### DIFF
--- a/docs/adr/0015-string-encoding-tracking.md
+++ b/docs/adr/0015-string-encoding-tracking.md
@@ -140,21 +140,36 @@ on the WasmGC backend):
 - The live `AllocSiteRegistry` is exposed on `ctx.allocRegistry` from the IR
   pipeline so the lowering sites can read the `encoding` annotation.
 
-This part is **not yet reached at runtime**: the IR lowering resolver still
-calls `nativeStringLiteralInstrs(ctx, value)` without an encoding, so even with
-`--utf8-storage` on, literals currently take the i16 path. Wiring the resolver
-to pass the annotation + the access-primitive `Utf8String` dispatch arm is
-**PR-B part 2** (required before the path is correct end-to-end, since an
-i8 string must be readable by `charCodeAt`/`length`).
+**PR-B part 2 (landed — storage path now active under `--utf8-storage`).**
 
-**PR-B part 2 (next).** Thread `instr.alloc` through the `emitStringConst`
-resolver hook (`lower.ts`), read the annotation at the literal/concat/flatten
-sites, and add the third subtype-dispatch arm to the access primitives in
-`ensureNativeStringHelpers` so `Utf8String` interoperates with
-`NativeString`/`ConsString` in the same module. Round-trip + fuzz correctness
-tests. **Alias-fusion soundness guard** (issue §4): before any CSE may fuse
-string sites, enforce that a `wtf16` site never aliases into a `utf8`
-canonical (no string-fusing pass exists today — forward guard).
+- The `emitStringConst` resolver hook now takes the `string.const`'s
+  `alloc` id (`lower.ts` passes `instr.alloc`); the integration.ts resolver
+  reads the `encoding` annotation off `ctx.allocRegistry` and delegates to
+  `nativeStringLiteralInstrs(ctx, value, enc)`, so an `ascii`/`utf8-guaranteed`
+  literal is now actually materialized as an i8 `Utf8String` when the flag
+  is on.
+- **Interop is handled at the flatten boundary, not per primitive.** Rather
+  than adding a `Utf8String` arm to every access primitive, `__str_flatten`
+  gains one branch: a `Utf8String` input is decoded back to an i16
+  `NativeString` via a new `__str_utf8_to_flat` helper (a hand-written Wasm
+  UTF-8→UTF-16 decode loop: 1/2/3/4-byte sequences, astral scalars re-split
+  into surrogate pairs; output pre-sized to the stored code-unit `len`).
+  Since all access primitives (`charCodeAt`, `length` on ropes, substring,
+  …) already route through `__str_flatten`/`ref.cast` to `NativeString`, they
+  work on `Utf8String` values unchanged. This is the "abstract string
+  interface" the issue Risks call for, localized to one decode point.
+- **Round-trip correctness** verified by `tests/ir/utf8-storage-roundtrip.test.ts`
+  (10 cases): each program compiled with the flag OFF (i16) and ON (i8) returns
+  observably identical results across `.length`, `charCodeAt` (incl. multi-byte
+  decode and astral surrogate halves), `concat`, and `===` — for ascii,
+  multi-byte, astral, and lone-surrogate (stays i16) literals.
+
+**Still open (PR-B follow-up / PR-C):** the **alias-fusion soundness guard**
+(issue §4) — before any future CSE may fuse string sites, enforce that a
+`wtf16` site never aliases into a `utf8` canonical (no string-fusing pass
+exists today, so this is a forward guard, not a present bug). Concat-result
+i8 storage (`string.concat` still produces i16; only literals take i8 in this
+PR — concat decodes its operands via flatten, so it stays correct).
 
 **PR-C (deferred).** Component Model boundary lowering (Edge A `c-abi.ts` scan
 elision; Edge B `declarations.ts` import selection + standalone Wasm-native

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -16,6 +16,41 @@ export function nativeStringType(ctx: CodegenContext): ValType {
 }
 
 /**
+ * #1588 PR-B part 2: the cons-string flatten body — `__str_flatten`'s `else`
+ * arm for a non-flat, non-Utf8String input (i.e. a ConsString rope). Extracted
+ * so the Utf8String dispatch arm can wrap it. Operates on locals: s(0), len(1),
+ * buf(2). Returns the rope flattened to a `NativeString`.
+ */
+function flattenConsBody(
+  strDataTypeIdx: number,
+  strTypeIdx: number,
+  anyStrTypeIdx: number,
+  copyTreeIdx: number,
+): Instr[] {
+  return [
+    // len = s.len (field 0 of AnyString)
+    { op: "local.get", index: 0 },
+    { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: 1 },
+    // buf = array.new_default(len)
+    { op: "local.get", index: 1 },
+    { op: "array.new_default", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: 2 },
+    // copy_tree(s, buf, 0)
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 2 },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: copyTreeIdx },
+    { op: "drop" },
+    // return struct.new $NativeString(len, 0, buf)
+    { op: "local.get", index: 1 },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: 2 },
+    { op: "struct.new", typeIdx: strTypeIdx },
+  ];
+}
+
+/**
  * Build the inline instruction sequence that materializes a string literal as
  * a NativeString (FlatString) struct ref. Mirrors `compileNativeStringLiteral`
  * but returns an `Instr[]` for callers that build instruction streams without
@@ -510,6 +545,265 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     });
   }
 
+  // #1588 PR-B part 2: $__str_utf8_to_flat(u: ref $Utf8String) -> ref $NativeString
+  // Decode the i8 UTF-8 bytes back to i16 WTF-16 code units. Only emitted when
+  // --utf8-storage is on (the Utf8String type exists). The output array is
+  // pre-sized to `u.len` (the code-unit count stored at allocation time), so no
+  // resize is needed. Well-formed UTF-8 is assumed (the encoder only produces it
+  // for ascii/utf8-guaranteed strings; lone surrogates never reach i8 storage).
+  if (ctx.utf8Storage && ctx.utf8StrTypeIdx >= 0) {
+    const u8StrRef: ValType = { kind: "ref", typeIdx: ctx.utf8StrTypeIdx };
+    const typeIdx = addFuncType(ctx, [u8StrRef], [flatStrRef]);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.nativeStrHelpers.set("__str_utf8_to_flat", funcIdx);
+    // params: u(0)
+    // locals: len(1) code-unit count, byteLen(2), data(3) i8 array, out(4) i16 array,
+    //         b(5) byte index, o(6) out index, c0(7) lead byte, cp(8) code point
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: ctx.utf8StrTypeIdx, fieldIdx: 0 }, // len
+      { op: "local.set", index: 1 },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: ctx.utf8StrTypeIdx, fieldIdx: 1 }, // byteLen
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: ctx.utf8StrTypeIdx, fieldIdx: 3 }, // data (ref $__str_data_u8)
+      { op: "local.set", index: 3 },
+      // out = array.new_default $__str_data(len)
+      { op: "local.get", index: 1 },
+      { op: "array.new_default", typeIdx: strDataTypeIdx },
+      { op: "local.set", index: 4 },
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 5 }, // b = 0
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 6 }, // o = 0
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if b >= byteLen break
+              { op: "local.get", index: 5 },
+              { op: "local.get", index: 2 },
+              { op: "i32.ge_s" },
+              { op: "br_if", depth: 1 },
+              // c0 = data[b] & 0xFF (array.get_u zero-extends an i8 lane)
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: 5 },
+              { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+              { op: "local.set", index: 7 },
+              // dispatch on c0
+              { op: "local.get", index: 7 },
+              { op: "i32.const", value: 0x80 },
+              { op: "i32.lt_u" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // 1-byte: cp = c0
+                  { op: "local.get", index: 7 },
+                  { op: "local.set", index: 8 },
+                  { op: "local.get", index: 5 },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "local.set", index: 5 },
+                ],
+                else: [
+                  { op: "local.get", index: 7 },
+                  { op: "i32.const", value: 0xe0 },
+                  { op: "i32.lt_u" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      // 2-byte: cp = ((c0 & 0x1F)<<6) | (data[b+1] & 0x3F)
+                      { op: "local.get", index: 7 },
+                      { op: "i32.const", value: 0x1f },
+                      { op: "i32.and" },
+                      { op: "i32.const", value: 6 },
+                      { op: "i32.shl" },
+                      { op: "local.get", index: 3 },
+                      { op: "local.get", index: 5 },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                      { op: "i32.const", value: 0x3f },
+                      { op: "i32.and" },
+                      { op: "i32.or" },
+                      { op: "local.set", index: 8 },
+                      { op: "local.get", index: 5 },
+                      { op: "i32.const", value: 2 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: 5 },
+                    ],
+                    else: [
+                      { op: "local.get", index: 7 },
+                      { op: "i32.const", value: 0xf0 },
+                      { op: "i32.lt_u" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: [
+                          // 3-byte: cp = ((c0&0x0F)<<12)|((b1&0x3F)<<6)|(b2&0x3F)
+                          { op: "local.get", index: 7 },
+                          { op: "i32.const", value: 0x0f },
+                          { op: "i32.and" },
+                          { op: "i32.const", value: 12 },
+                          { op: "i32.shl" },
+                          { op: "local.get", index: 3 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 1 },
+                          { op: "i32.add" },
+                          { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                          { op: "i32.const", value: 0x3f },
+                          { op: "i32.and" },
+                          { op: "i32.const", value: 6 },
+                          { op: "i32.shl" },
+                          { op: "i32.or" },
+                          { op: "local.get", index: 3 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 2 },
+                          { op: "i32.add" },
+                          { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                          { op: "i32.const", value: 0x3f },
+                          { op: "i32.and" },
+                          { op: "i32.or" },
+                          { op: "local.set", index: 8 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 3 },
+                          { op: "i32.add" },
+                          { op: "local.set", index: 5 },
+                        ],
+                        else: [
+                          // 4-byte: cp = ((c0&0x07)<<18)|((b1&0x3F)<<12)|((b2&0x3F)<<6)|(b3&0x3F)
+                          { op: "local.get", index: 7 },
+                          { op: "i32.const", value: 0x07 },
+                          { op: "i32.and" },
+                          { op: "i32.const", value: 18 },
+                          { op: "i32.shl" },
+                          { op: "local.get", index: 3 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 1 },
+                          { op: "i32.add" },
+                          { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                          { op: "i32.const", value: 0x3f },
+                          { op: "i32.and" },
+                          { op: "i32.const", value: 12 },
+                          { op: "i32.shl" },
+                          { op: "i32.or" },
+                          { op: "local.get", index: 3 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 2 },
+                          { op: "i32.add" },
+                          { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                          { op: "i32.const", value: 0x3f },
+                          { op: "i32.and" },
+                          { op: "i32.const", value: 6 },
+                          { op: "i32.shl" },
+                          { op: "i32.or" },
+                          { op: "local.get", index: 3 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 3 },
+                          { op: "i32.add" },
+                          { op: "array.get_u", typeIdx: ctx.utf8StrDataTypeIdx },
+                          { op: "i32.const", value: 0x3f },
+                          { op: "i32.and" },
+                          { op: "i32.or" },
+                          { op: "local.set", index: 8 },
+                          { op: "local.get", index: 5 },
+                          { op: "i32.const", value: 4 },
+                          { op: "i32.add" },
+                          { op: "local.set", index: 5 },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              // emit cp into out: BMP → one code unit; astral → surrogate pair
+              { op: "local.get", index: 8 },
+              { op: "i32.const", value: 0xffff },
+              { op: "i32.gt_u" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // cp -= 0x10000; high = 0xD800 | (cp>>10); low = 0xDC00 | (cp&0x3FF)
+                  { op: "local.get", index: 8 },
+                  { op: "i32.const", value: 0x10000 },
+                  { op: "i32.sub" },
+                  { op: "local.set", index: 8 },
+                  // out[o] = 0xD800 | (cp>>10)
+                  { op: "local.get", index: 4 },
+                  { op: "local.get", index: 6 },
+                  { op: "i32.const", value: 0xd800 },
+                  { op: "local.get", index: 8 },
+                  { op: "i32.const", value: 10 },
+                  { op: "i32.shr_u" },
+                  { op: "i32.or" },
+                  { op: "array.set", typeIdx: strDataTypeIdx },
+                  { op: "local.get", index: 6 },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "local.set", index: 6 },
+                  // out[o] = 0xDC00 | (cp & 0x3FF)
+                  { op: "local.get", index: 4 },
+                  { op: "local.get", index: 6 },
+                  { op: "i32.const", value: 0xdc00 },
+                  { op: "local.get", index: 8 },
+                  { op: "i32.const", value: 0x3ff },
+                  { op: "i32.and" },
+                  { op: "i32.or" },
+                  { op: "array.set", typeIdx: strDataTypeIdx },
+                  { op: "local.get", index: 6 },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "local.set", index: 6 },
+                ],
+                else: [
+                  // out[o] = cp
+                  { op: "local.get", index: 4 },
+                  { op: "local.get", index: 6 },
+                  { op: "local.get", index: 8 },
+                  { op: "array.set", typeIdx: strDataTypeIdx },
+                  { op: "local.get", index: 6 },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "local.set", index: 6 },
+                ],
+              },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // return struct.new $NativeString(len, 0, out)
+      { op: "local.get", index: 1 },
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: 4 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+    ctx.mod.functions.push({
+      name: "__str_utf8_to_flat",
+      typeIdx,
+      locals: [
+        { name: "len", type: { kind: "i32" } },
+        { name: "byteLen", type: { kind: "i32" } },
+        { name: "data", type: { kind: "ref", typeIdx: ctx.utf8StrDataTypeIdx } },
+        { name: "out", type: strDataRef },
+        { name: "b", type: { kind: "i32" } },
+        { name: "o", type: { kind: "i32" } },
+        { name: "c0", type: { kind: "i32" } },
+        { name: "cp", type: { kind: "i32" } },
+      ],
+      body,
+      exported: false,
+    });
+  }
+
   // --- $__str_flatten(s: ref $AnyString) -> ref $NativeString ---
   // If s is already a FlatString, returns it. Otherwise flattens the rope tree.
   {
@@ -518,6 +812,8 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     ctx.nativeStrHelpers.set("__str_flatten", funcIdx);
 
     const copyTreeIdx = ctx.nativeStrHelpers.get("__str_copy_tree")!;
+    // #1588 PR-B part 2: present iff --utf8-storage is on.
+    const utf8ToFlatIdx = ctx.nativeStrHelpers.get("__str_utf8_to_flat");
 
     // params: s(0)
     // locals: len(1), buf(2)
@@ -532,30 +828,24 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
           { op: "local.get", index: 0 },
           { op: "ref.cast", typeIdx: strTypeIdx },
         ],
-        else: [
-          // len = s.len (field 0 of AnyString)
-          { op: "local.get", index: 0 },
-          { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
-          { op: "local.set", index: 1 },
-
-          // buf = array.new_default(len)
-          { op: "local.get", index: 1 },
-          { op: "array.new_default", typeIdx: strDataTypeIdx },
-          { op: "local.set", index: 2 },
-
-          // copy_tree(s, buf, 0)
-          { op: "local.get", index: 0 },
-          { op: "local.get", index: 2 },
-          { op: "i32.const", value: 0 },
-          { op: "call", funcIdx: copyTreeIdx },
-          { op: "drop" }, // discard returned position
-
-          // return struct.new $NativeString(len, 0, buf)
-          { op: "local.get", index: 1 }, // len
-          { op: "i32.const", value: 0 }, // off = 0
-          { op: "local.get", index: 2 }, // data = buf
-          { op: "struct.new", typeIdx: strTypeIdx },
-        ],
+        else:
+          ctx.utf8Storage && ctx.utf8StrTypeIdx >= 0 && utf8ToFlatIdx !== undefined
+            ? [
+                // #1588 PR-B part 2: if s is a Utf8String, decode it to a NativeString.
+                { op: "local.get", index: 0 },
+                { op: "ref.test", typeIdx: ctx.utf8StrTypeIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: flatStrRef },
+                  then: [
+                    { op: "local.get", index: 0 },
+                    { op: "ref.cast", typeIdx: ctx.utf8StrTypeIdx },
+                    { op: "call", funcIdx: utf8ToFlatIdx },
+                  ],
+                  else: flattenConsBody(strDataTypeIdx, strTypeIdx, anyStrTypeIdx, copyTreeIdx),
+                },
+              ]
+            : flattenConsBody(strDataTypeIdx, strTypeIdx, anyStrTypeIdx, copyTreeIdx),
       },
     ];
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -26,7 +26,11 @@ import { ts } from "../ts-api.js";
 
 import { getOrRegisterPromiseType } from "../codegen/async-scheduler.js";
 import { addGeneratorImports, addIteratorImports, addStringImports } from "../codegen/index.js";
-import { ensureNativeStringHelpers } from "../codegen/native-strings.js";
+import {
+  ensureNativeStringHelpers,
+  nativeStringLiteralInstrs,
+  type StringEncoding,
+} from "../codegen/native-strings.js";
 import { addStringConstantGlobal, ensureExnTag } from "../codegen/registry/imports.js";
 import { addFuncType, getOrRegisterRefCellType } from "../codegen/registry/types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
@@ -64,7 +68,7 @@ import { UnionStructRegistry } from "./passes/tagged-union-types.js";
 import { taggedUnions } from "./passes/tagged-unions.js";
 import { planIrCompilation, type IrSelection } from "./select.js";
 import { verifyIrFunction } from "./verify.js";
-import { AllocSiteRegistry } from "./alloc-registry.js";
+import { AllocSiteRegistry, ALLOC_NAMESPACES } from "./alloc-registry.js";
 import { analyzeEncoding } from "./analysis/encoding.js";
 import { assertAllocProvenance } from "./verify-alloc.js";
 import type { FieldDef, FuncTypeDef, Instr, StructTypeDef, ValType } from "./types.js";
@@ -1014,8 +1018,17 @@ function makeResolver(
     nativeStrings(): boolean {
       return ctx.nativeStrings;
     },
-    emitStringConst(value: string): readonly Instr[] {
+    emitStringConst(value: string, alloc?: import("./nodes.js").AllocSiteId): readonly Instr[] {
       if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+        // #1588 PR-B part 2: when --utf8-storage is on, read the encoding
+        // annotation off the string.const's alloc site and let
+        // nativeStringLiteralInstrs pick i8 (Utf8String) vs i16 (NativeString).
+        // When off, or the annotation is absent/wtf16, this is the i16 path —
+        // byte-identical to before.
+        if (ctx.utf8Storage && alloc !== undefined && ctx.allocRegistry) {
+          const enc = ctx.allocRegistry.read<StringEncoding>(alloc, ALLOC_NAMESPACES.encoding);
+          return nativeStringLiteralInstrs(ctx, value, enc);
+        }
         // Native strings: inline `array.new_fixed` of WTF-16 code units +
         // `struct.new $NativeString(len, off, data)` — same shape as
         // `compileNativeStringLiteral` in the legacy path.

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -279,7 +279,10 @@ export interface IrLowerResolver {
    *   - native       → inline `i32.const len`, `i32.const 0`, code-unit
    *                    `i32.const`s, `array.new_fixed`, `struct.new`.
    */
-  emitStringConst?(value: string): readonly Instr[];
+  // #1588 PR-B part 2: `alloc` carries the string.const's allocation-site id
+  // so the resolver can read the encoding annotation (utf8-storage decision).
+  // Optional — resolvers/callers that omit it get the i16 path (byte-identical).
+  emitStringConst?(value: string, alloc?: import("./nodes.js").AllocSiteId): readonly Instr[];
   /** `[call concat]` (host) or `[call __str_concat]` (native). */
   emitStringConcat?(): readonly Instr[];
   /** `[call equals]` (host) or `[call __str_equals]` (native). */
@@ -951,7 +954,7 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         return;
       }
       case "string.const": {
-        const ops = resolver.emitStringConst?.(instr.value);
+        const ops = resolver.emitStringConst?.(instr.value, instr.alloc);
         if (!ops) throw new Error(`ir/lower: resolver cannot emit string.const (${func.name})`);
         for (const o of ops) out.push(o);
         return;

--- a/tests/ir/utf8-storage-roundtrip.test.ts
+++ b/tests/ir/utf8-storage-roundtrip.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1588 PR-B part 2 — UTF-8 dual-storage round-trip correctness.
+//
+// Compiles string programs twice on the WasmGC backend — once with
+// --utf8-storage OFF (i16 NativeString, the baseline) and once ON (i8
+// Utf8String for ascii/utf8-guaranteed literals) — and asserts identical
+// observable results. The encoding distinction must be invisible to JS
+// semantics (.length, charCodeAt, ===, concat all WTF-16-observable), so an
+// i8-backed literal that flows into a string op must decode back to the same
+// code units via __str_utf8_to_flat.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../../src/index.js";
+
+// Permissive host imports: a real env namespace with identity-ish stubs plus a
+// Proxy fallback so any module-declared `env` import we didn't enumerate
+// resolves to a harmless function. (nativeStrings keeps strings in-heap, so the
+// programs don't need wasm:js-string, but `__box_number` etc. are still
+// declared on the module.)
+const envBase: Record<string, Function> = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+  __box_number: (v: number) => v,
+  __unbox_number: (v: unknown) => Number(v),
+};
+const ENV = {
+  env: new Proxy(envBase, {
+    get(target, prop: string) {
+      return prop in target ? target[prop] : () => 0;
+    },
+    has() {
+      return true;
+    },
+  }),
+};
+
+async function run(source: string, exportName: string, utf8Storage: boolean): Promise<unknown> {
+  const result = compile(source, { experimentalIR: true, nativeStrings: true, utf8Storage });
+  if (!result.success) {
+    throw new Error(`compile failed (utf8Storage=${utf8Storage}): ${result.errors.map((e) => e.message).join("; ")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, ENV);
+  const fn = (instance.exports as Record<string, (...a: unknown[]) => unknown>)[exportName];
+  if (typeof fn !== "function") throw new Error(`export "${exportName}" not found`);
+  return fn();
+}
+
+interface Case {
+  readonly name: string;
+  readonly source: string;
+  readonly exportName: string;
+}
+
+// Each program returns a number so the i16 and i8 builds can be compared
+// directly. Literals span ascii / multi-byte / astral / wtf16 so both storage
+// widths and the UTF-8→UTF-16 decode path are exercised.
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: "ascii literal .length",
+    source: `export function f(): number { const s = "hello"; return s.length; }`,
+    exportName: "f",
+  },
+  {
+    name: "ascii charCodeAt",
+    source: `export function f(): number { const s = "ABC"; return s.charCodeAt(1); }`,
+    exportName: "f",
+  },
+  {
+    name: "multi-byte literal .length (code units, not bytes)",
+    source: `export function f(): number { const s = "café"; return s.length; }`,
+    exportName: "f",
+  },
+  {
+    name: "multi-byte charCodeAt decodes back to the right code unit",
+    // é = U+00E9 = 233; index 3.
+    source: `export function f(): number { const s = "café"; return s.charCodeAt(3); }`,
+    exportName: "f",
+  },
+  {
+    name: "astral literal .length is 2 (surrogate pair)",
+    source: `export function f(): number { const s = "a\u{1f600}b"; return s.length; }`,
+    exportName: "f",
+  },
+  {
+    name: "astral charCodeAt yields the high surrogate",
+    // index 1 of "a😀b" is the high surrogate 0xD83D = 55357.
+    source: `export function f(): number { const s = "a\u{1f600}b"; return s.charCodeAt(1); }`,
+    exportName: "f",
+  },
+  {
+    name: "concat of two ascii literals length",
+    source: `export function f(): number { const a = "foo"; const b = "bar"; return (a + b).length; }`,
+    exportName: "f",
+  },
+  {
+    name: "concat ascii + multi-byte charCodeAt",
+    source: `export function f(): number { const a = "x"; const b = "é"; return (a + b).charCodeAt(1); }`,
+    exportName: "f",
+  },
+  {
+    name: "equality of equal ascii literals",
+    source: `export function f(): number { const a = "same"; const b = "same"; return a === b ? 1 : 0; }`,
+    exportName: "f",
+  },
+  {
+    name: "wtf16 lone-surrogate literal stays i16 and round-trips length",
+    source: `export function f(): number { const s = "x\uD800y"; return s.length; }`,
+    exportName: "f",
+  },
+];
+
+describe("#1588 PR-B part 2 — utf8-storage round-trip equivalence", () => {
+  for (const c of CASES) {
+    it(`${c.name}: i8-on === i16-off`, async () => {
+      const off = await run(c.source, c.exportName, false);
+      const on = await run(c.source, c.exportName, true);
+      expect(on).toBe(off);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

PR-B **part 2** of #1588 — makes `--utf8-storage` actually materialize i8-backed `Utf8String` literals and read them back correctly. Still default-OFF → byte-identical when off.

- **Resolver wiring**: `emitStringConst` hook now takes the `string.const`'s `alloc` id (`lower.ts` passes `instr.alloc`); the integration.ts resolver reads the `encoding` annotation off `ctx.allocRegistry` and delegates to `nativeStringLiteralInstrs(ctx, value, enc)`. ascii/utf8-guaranteed literals allocate as `Utf8String` when the flag is on.
- **Interop at the flatten boundary** (not per primitive): `__str_flatten` gets one `Utf8String` branch that decodes back to an i16 `NativeString` via a new `__str_utf8_to_flat` Wasm helper (UTF-8→UTF-16: 1/2/3/4-byte sequences, astral scalars re-split into surrogate pairs, output pre-sized to the stored code-unit length). All access primitives already route through `__str_flatten`, so `charCodeAt`/`length`/etc. work on `Utf8String` unchanged. The cons-flatten body was extracted to a `flattenConsBody` helper so the `Utf8String` arm can wrap it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/ir/utf8-storage-roundtrip.test.ts` — **10 cases**: each program compiled flag-OFF (i16) and flag-ON (i8) returns identical results across `.length`, `charCodeAt` (incl. multi-byte é decode + astral 😀 surrogate halves), `concat`, `===`, for ascii/multi-byte/astral/lone-surrogate literals.
- [x] `tests/ir/utf8-storage.test.ts` (7) + `tests/ir/encoding-analysis.test.ts` (18) still pass
- [x] Pre-existing `native-strings.test.ts` (8/86) + `native-strings-roundtrip.test.ts` (5/7) failures are **identical on clean main** — not regressed by this PR
- [ ] CI: full conformance + gate (flag default-off → no codegen change expected)

Follow-ups (documented in ADR-0015): alias-fusion soundness guard (forward guard — no string-fusing CSE exists today); concat-result i8 storage (concat stays i16 and decodes operands via flatten, so correct); PR-C = Component Model boundary + benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)