### PR TITLE
docs(process): auto-dispatcher respects owner pins + task scope; PR->status lifecycle

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -46,9 +46,13 @@ These help the tech lead know you're alive and progressing, not stuck. Keep them
 ## Workflow
 
 ### Start
-1. `TaskList` — claim the lowest-ID unowned/unblocked task via `TaskUpdate(owner: "your-name")`
+1. `TaskList` — pick the lowest-ID candidate task. **Before claiming, run the pre-claim gate. Skip the task (do NOT claim) and move to the next candidate if ANY of these is true:**
+   - **Owner pin**: the task already has an `owner` set to a name other than yours. An owned task belongs to that agent — never take it, even if it looks idle. (The auto-dispatcher only offers ownerless tasks; if you were handed an owned one, that is stale routing — skip it.)
+   - **Scope mismatch**: the subject carries a role tag outside your lane — `[SENIOR-DEV ONLY]`, `[ARCH]`/`arch(...)`, `[PO]`/`po:`, `[CONFLICT]` (senior-dev), or `[PARKED ...]`/`[PAUSE]`. You are a `developer`; only claim plain `fix(...)`/`refactor(...)`/`dev:` tasks with no foreign role tag.
+   - **Already done**: a PR for this issue is already merged (`gh pr list --state merged --search "<issue#>"`) or open and owned by someone else. If so, the task is stale — flag the tech lead so they reconcile it, and skip.
+   Only when the gate passes: claim it via `TaskUpdate(owner: "your-name", status: in_progress)`.
 2. If the issue has `status: suspended` + `## Suspended Work`, use the listed worktree and resume instructions
-3. If no tasks: message tech lead `"TaskList is empty, need next task."`
+3. If no claimable task survives the gate: message tech lead `"TaskList is empty (or all remaining tasks are owned/out-of-scope), need next task."`
 
 ### Implement
 1. Read `plan/issues/sprints/{sprint}/{N}.md` + smoke-test 1-2 failing cases to confirm the bug reproduces
@@ -75,6 +79,7 @@ These help the tech lead know you're alive and progressing, not stuck. Keep them
    ```
    Then open the PR:
    `gh pr create --base main --title "fix(#N): <description>" --body "..."`
+   **Immediately after the PR is created, set the issue frontmatter `status: in-review`** in `plan/issues/sprints/{sprint}/{N}.md` (commit it on your branch). This signals the issue has left active dev and is awaiting merge — never leave it at `in-progress` once a PR is open.
 5. **After `gh pr create` returns — block on CI synchronously:**
    - Update your status file to show the open PR:
      ```bash
@@ -87,7 +92,8 @@ These help the tech lead know you're alive and progressing, not stuck. Keep them
      - **Drift detected** (`mergeable_state` becomes `BEHIND`) → `git fetch origin && git merge origin/main`, resolve conflicts with full PR context, `git push`, loop back to wait-for-CI. Do NOT escalate.
      - **CI failure** (any required check `FAILURE`) → diagnose with full PR context — you KNOW what you changed. Fix locally, `git push`, loop back to wait-for-CI. Do NOT escalate ordinary failures.
      - **ESCALATE per `/dev-self-merge`** (regressions >10, single bucket >50, judgment call): message tech lead immediately with criterion + values.
-6. After merge lands:
+6. After merge lands (by you OR by the merge queue):
+   - Set the issue frontmatter `status: done` in `plan/issues/sprints/{sprint}/{N}.md`. A merged PR ALWAYS implies `status: done` — whoever observes the merge sets it; do not leave a merged issue at `in-review`.
    - `rm -f "/workspace/.claude/agent-status/issue-{N}-{slug}.json"` — clear your status
    - `git worktree remove /workspace/.claude/worktrees/<branch>` — clean up your own worktree
    - `TaskUpdate(status: completed)`

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -23,3 +23,14 @@ Read `.claude/agents/developer.md` for the full workflow, communication protocol
 **When to use senior-developer vs developer:**
 - `feasibility: hard` or `reasoning_effort: max` → senior-developer (you)
 - `feasibility: easy/medium` → developer (sonnet, faster, cheaper)
+
+**Pre-claim gate — your lane (overrides developer.md's lane for you):**
+Apply the same owner-pin and already-done checks from developer.md's Start step. The
+*scope* check is widened for you: you MAY claim `[SENIOR-DEV ONLY]`, `[CONFLICT]`, and
+hard `fix(...)`/`refactor(...)` tasks. You must still skip:
+- tasks `owner`ed by another agent (including another senior-dev) — owner pins are absolute;
+- `[ARCH]`/`arch(...)`, `[PO]`/`po:` tasks — those are spec/planning roles, not implementation;
+- `[PARKED ...]`/`[PAUSE]` tasks — design-blocked, not ready to code;
+- tasks whose issue already has a merged/another-agent-owned-open PR — flag the tech lead, skip.
+A task pinned to a *named* senior-dev (e.g. `owner sendev-flatten` in the subject or `owner`
+field) belongs to that agent only — do not take it even though it is in your role lane.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,9 @@ Sprint planning is a collaborative process, not a solo tech lead activity:
 
 ### Agent work dispatch
 - **Tech lead populates TaskList** — devs self-serve from it. No per-task dispatch messages needed.
+- **Owner pins + scope are how the auto-dispatcher is steered.** The native agent-teams auto-dispatcher only auto-offers tasks with **no `owner`**, and it does **not** read role. So the tech lead encodes routing in two places the dispatcher/agents actually honor:
+  - **Set `owner` immediately** on any task pinned to a specific agent (e.g. an in-flight `[CONFLICT]` for a named senior-dev, or a one-PR migration). An ownerless `in_progress` task is the #1 mis-route cause — the dispatcher re-offers it. Reconcile (`TaskUpdate status=completed` the moment a PR merges) so stale entries never get re-offered.
+  - **Tag role/scope in the subject** so agents can self-gate: `[SENIOR-DEV ONLY]`, `[CONFLICT]` (senior-dev), `arch(...)`/`[ARCH]` (architect), `po:`/`[PO]` (product owner), `[PARKED …]`/`[PAUSE]` (not ready). Plain `fix(...)`/`refactor(...)`/`dev:` = developer-claimable. Agents skip tasks owned by others or tagged outside their lane (see the pre-claim gate in `developer.md`/`senior-developer.md`).
 - **Dev loop**: claim task from TaskList → implement → push PR → wait for CI → self-merge if green → mark completed → claim next task.
 - **Dev self-merge**: when `.claude/ci-status/pr-<N>.json` has matching SHA, `net_per_test > 0`, ratio <10%, no bucket >50 — run `gh pr merge <N> --merge --auto` (queues for the merge queue; queue re-runs required checks on the merged state and lands the PR). Escalate to tech lead only when criteria fail. `--admin --merge` is reserved for workflow-only / hotfix bypass. See `.claude/skills/dev-self-merge.md`.
 - **Tech lead reading ci-status files**: always verify `head_sha` matches current PR HEAD (`gh pr view N --json headRefOid`) before interpreting `net_per_test` or regression counts. A SHA mismatch means CI ran on a stale commit — the numbers are misleading. Also check `baseline_staleness_commits` > 0 as a secondary signal.
@@ -310,6 +313,12 @@ GitHub branch protection is the hard block.
 8. **After merge**: dev marks task `completed`, claims next task
 9. **Never use `git merge` on main directly.** All merges go through PRs + CI.
 10. **Never rebase.** Merge preserves history and is safely reversible.
+
+### Issue status lifecycle
+The issue frontmatter `status:` field tracks where an issue is, set by whichever agent drives the transition:
+- `ready`/`in-progress` → dev starts work (sets `in-progress` when claiming).
+- **`in-review`** — set by the agent the moment it **opens a PR** for the issue. An open PR ⇒ the issue is no longer `in-progress`.
+- **`done`** — set when the **PR merges** (by the dev who observes the merge, or by the merge queue's observer). A merged PR ⇒ `done`. Never leave a merged issue at `in-review`.
 
 ### Issue completion (post-merge)
 1. Set `status: done` in the issue file at `plan/issues/sprints/{N}/{ID}.md`


### PR DESCRIPTION
## Summary
Two protocol hardenings, both driven by the session-long auto-dispatch mis-routing (the native agent-teams dispatcher repeatedly offered owned / wrong-role / already-merged tasks to idle agents).

**1. Pre-claim gate** (`developer.md` Start, `senior-developer.md` lane note). Before claiming, an agent skips a task if:
- it has an `owner` set to another agent (owner pins are absolute — the dispatcher only auto-offers ownerless tasks, so a handed-over owned task is stale routing);
- its subject carries a role tag outside the agent's lane (`[SENIOR-DEV ONLY]`, `[CONFLICT]`, `arch(...)`/`[ARCH]`, `po:`/`[PO]`, `[PARKED …]`/`[PAUSE]`);
- a PR for the issue is already merged or open under another owner → flag the tech lead, skip.

Senior-dev's lane is widened (it may claim `[SENIOR-DEV ONLY]`/`[CONFLICT]`/hard fixes) but still honors owner pins and skips arch/PO/parked work.

`CLAUDE.md` "Agent work dispatch" documents the tech-lead side: the dispatcher honors only `owner` (set it immediately on pinned tasks; reconcile to `completed` on merge) and subject scope tags — the two levers, since the dispatcher does not read role.

**2. Issue status lifecycle.** Opening a PR ⇒ `status: in-review`; a merged PR (agent or merge queue) ⇒ `status: done`. Documented in `developer.md` Merge steps and a new `CLAUDE.md` "Issue status lifecycle" section.

Docs/process only — no compiler or CI changes.

## Test plan
- [ ] CI `quality` check green (no src touched; test262 path-filtered out)