### PR TITLE
fix(#1618,#1651): WASI runtime-string stdout + process.stdout.write — completes Native Messaging host

### DIFF
--- a/.github/workflows/native-messaging-smoke.yml
+++ b/.github/workflows/native-messaging-smoke.yml
@@ -1,0 +1,61 @@
+name: native-messaging smoke (real wasmtime)
+
+# Real-wasmtime round-trip smoke test for the Native Messaging host example.
+#
+# The JS WASI polyfill zero-inits memory and masked an off-by-one in the
+# integer-print helper (#1618) — only real wasmtime, with reused bump memory,
+# exposed the stray trailing byte. This job runs the compiled example under an
+# actual wasmtime binary and asserts the stdout frame + clean stderr byte-for-
+# byte, so a codegen change that breaks the WASI stdout path can't slip through
+# the polyfill-based unit tests.
+#
+# Kept as a separate lightweight job (NOT a required check yet — it can be
+# promoted to required later). CI does not otherwise install wasmtime, so this
+# job installs a pinned release fresh.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "examples/native-messaging/**"
+      - "src/codegen/**"
+      - ".github/workflows/native-messaging-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install wasmtime (pinned)
+        run: |
+          # Pin a current release for reproducibility. v44 is what the example
+          # was verified against; it supports the GC / function-references /
+          # tail-call / exceptions proposals the module uses via the explicit
+          # -W flags the smoke script enables. (Do NOT bump to all-proposals:
+          # wasmtime 44 rejects stack-switching, which all-proposals turns on.)
+          WASMTIME_VERSION=v44.0.0
+          curl -L "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz" \
+            | tar xJ
+          echo "$PWD/wasmtime-${WASMTIME_VERSION}-x86_64-linux" >> "$GITHUB_PATH"
+
+      - name: Verify wasmtime is on PATH
+        run: wasmtime --version
+
+      - name: Native Messaging round-trip smoke test
+        run: ./examples/native-messaging/smoke-test.sh

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -18,13 +18,14 @@ examples/native-messaging/
   run.sh         ← wasmtime/wasmer wrapper Chrome invokes
 ```
 
-## Status: read this before wiring into Chrome
+## Status: a working drop-in Chrome host
 
-This example is **honest about what the WASI target can do today**. The
-message-processing core — reading the JSON body off stdin (fd=0), routing
-debug to stderr (fd=2), and emitting a JSON response on stdout (fd=1) — is the
-part js2wasm exercises. But two gaps mean it is **not yet a drop-in Chrome
-host**:
+This host now exercises the **full** Native Messaging loop under `--target
+wasi`: read the framed JSON message off stdin (fd=0), route debug to stderr
+(fd=2), and write a **correctly framed** JSON response — the binary 4-byte
+little-endian length prefix plus the JSON body — to stdout (fd=1) with no
+trailing newline. The two stdout gaps that previously blocked this are closed
+(#1618, #1651).
 
 | Capability | Status | Detail |
 |------------|--------|--------|
@@ -32,28 +33,15 @@ host**:
 | Decode the 4-byte LE length prefix | works | byte math on `charCodeAt` of the first 4 code units |
 | Route debug to stderr (fd=2) | works | `console.error` / `console.warn` (#1493) — keeps the stdout protocol stream clean |
 | Print a **string literal** to stdout | works | `console.log("…")` emits UTF-8 + `\n` (#1480) |
-| Print a **runtime/computed string** to stdout | **broken** | non-literal string values currently render as a corrupted `[object]` placeholder instead of their content — see "Known compiler gaps" below |
-| Emit the **binary 4-byte LE length prefix** on stdout | **not supported** | there is no raw-byte stdout API; `console.log` UTF-8-encodes its argument and appends a newline, so arbitrary bytes (including the NUL bytes a length prefix needs) can't be written |
+| Print a **runtime/computed string** to stdout | works | `console.log(x)` / `process.stdout.write(x)` of a variable, concatenation, or template literal emit the actual content (#1618) |
+| Write a **string** to stdout with no newline | works | `process.stdout.write(str)` → `fd_write(1, …)`, no `\n` (#1651) |
+| Emit the **binary 4-byte LE length prefix** on stdout | works | `process.stdout.write(new Uint8Array([…]))` writes raw bytes (incl. NUL) verbatim to fd=1 (#1651) |
 
-So today this host demonstrates the **read → decode → process** path
-end-to-end, but it cannot frame its response the way Chrome's protocol
-requires. Until the gaps below close, treat this as a **protocol-integration
-walkthrough + working stdin reader**, not a production Chrome host.
-
-### Known compiler gaps (follow-up issues)
-
-- **Raw-byte stdout for the length prefix.** Chrome's framing needs four
-  arbitrary bytes (a little-endian `uint32`) written verbatim to fd=1. The
-  WASI stdout path only writes UTF-8-encoded strings via `console.log`, which
-  also appends a trailing newline. A raw-byte stdout primitive (e.g. a
-  `writeStdout(bytes: Uint8Array)` builtin lowering directly to `fd_write`
-  with no newline) is required. *Filed as a follow-up to this issue.*
-- **Runtime string content on stdout.** `console.log` of a non-literal string
-  (a variable, template interpolation, or concatenation) currently emits a
-  corrupted mix of the real bytes and the `[object]` placeholder under
-  `--target wasi`, because the WASI value-to-stdout path treats `ref`
-  (NativeString) values as the "other" fallback case. Only string literals and
-  numeric values print cleanly. *Filed as a follow-up to this issue.*
+The response is framed with `process.stdout.write` — a `Uint8Array` for the
+binary length prefix, then the JSON body string — mirroring the Node.js host
+API used by the AssemblyScript reference (`nm_assemblyscript.ts`). It is a
+drop-in Chrome host; the only external dependency is a WASI preview1 runtime to
+launch it (see "Run it" below).
 
 ## The host source
 
@@ -94,9 +82,8 @@ printf '\x0d\x00\x00\x00{"ping":true}' | ./examples/native-messaging/run.sh
 ```
 
 You'll see the host's stderr diagnostic (received-length + decoded body
-length) and its stdout response. **Note** the response framing is subject to
-the stdout gaps documented above — verify against "Status" before relying on
-the exact bytes.
+length) and its stdout response, framed with the binary 4-byte LE length
+prefix followed by the JSON body — exactly the bytes Chrome expects.
 
 > If you don't have a WASI runtime installed, you can still confirm the module
 > is valid the same way the [`../wasi/README.md`](../wasi/README.md) Node
@@ -140,8 +127,8 @@ the exact bytes.
    ```
 
    Chrome handles the 4-byte length framing on its side; the host sees the
-   raw bytes on stdin and must produce correctly framed bytes on stdout — the
-   piece blocked on the stdout gaps above.
+   raw bytes on stdin and produces correctly framed bytes on stdout via
+   `process.stdout.write` (a `Uint8Array` prefix + the JSON body).
 
 ## Reference hosts in other runtimes
 

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -85,6 +85,14 @@ You'll see the host's stderr diagnostic (received-length + decoded body
 length) and its stdout response, framed with the binary 4-byte LE length
 prefix followed by the JSON body — exactly the bytes Chrome expects.
 
+For an automated byte-exact check (build + run under wasmtime, asserting the
+stdout frame and a clean stderr), run [`smoke-test.sh`](./smoke-test.sh) —
+the same script CI runs (`.github/workflows/native-messaging-smoke.yml`):
+
+```bash
+./examples/native-messaging/smoke-test.sh
+```
+
 > If you don't have a WASI runtime installed, you can still confirm the module
 > is valid the same way the [`../wasi/README.md`](../wasi/README.md) Node
 > snippet does — `WebAssembly.compile(readFileSync('out/host.wasm'))` — and

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -27,22 +27,23 @@ declare const process: {
   stderr: { write(chunk: Uint8Array | string): void };
 };
 
-// Strip Chrome's 4-byte little-endian length prefix from a framed message,
-// returning just the JSON body. readStdin() hands us the whole stdin buffer
-// (prefix + body) as a single string; we skip the first 4 code units.
-function stripLengthPrefix(framed: string): string {
-  // The 4 prefix bytes are read as 4 string code units by readStdin().
-  return framed.substring(4);
-}
-
 // Decode the little-endian uint32 length that Chrome wrote as the first 4
-// bytes, so a host can validate the frame size against the body it received.
+// bytes. readStdin() hands us the whole stdin buffer (prefix + body) as a
+// single string, one byte per code unit, so the prefix is the first 4 units.
 function decodeLength(framed: string): number {
   const b0 = framed.charCodeAt(0) & 0xff;
   const b1 = framed.charCodeAt(1) & 0xff;
   const b2 = framed.charCodeAt(2) & 0xff;
   const b3 = framed.charCodeAt(3) & 0xff;
   return b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
+}
+
+// Extract exactly the declared body bytes after the 4-byte prefix — mirroring
+// the AssemblyScript reference's "read the length, then read that many body
+// bytes" loop, rather than blindly taking everything after the prefix (which
+// would mishandle a stdin buffer carrying trailing bytes).
+function readBody(framed: string, length: number): string {
+  return framed.substring(4, 4 + length);
 }
 
 // Write a framed Native Messaging response: the 4-byte little-endian length
@@ -60,7 +61,7 @@ export function main(): void {
   // the simplest "stdio" wiring; a long-lived port would loop here).
   const framed = readStdin();
   const declaredLen = decodeLength(framed);
-  const body = stripLengthPrefix(framed);
+  const body = readBody(framed, declaredLen);
 
   // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
   // protocol stream. Chrome ignores the host's stderr.

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -7,22 +7,25 @@
 // the host process's stdin (fd=0) and stdout (fd=1). See:
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 //
-// js2wasm support today (see README.md → "What works / what doesn't"):
+// js2wasm support today:
 //   - stdin  : readStdin() drains fd=0 to EOF and returns it as a string (#1481)
-//   - stdout : console.log writes a UTF-8 string + newline to fd=1 (#1480/#1493)
+//   - stdout : process.stdout.write(bytes|str) writes raw bytes / a string to
+//              fd=1 with NO trailing newline (#1651) — used for the binary
+//              4-byte length prefix and the JSON body. console.log(str) also
+//              writes runtime strings correctly now (#1618).
 //   - stderr : console.error / console.warn write to fd=2 (#1493) — use these
 //              for debug output so they never corrupt the stdout protocol stream
 //
-// IMPORTANT — read the README before wiring this into Chrome. The compiler
-// cannot yet emit the *binary* 4-byte length prefix on stdout (there is no
-// raw-byte stdout API; console.log UTF-8-encodes and appends a newline). This
-// host therefore demonstrates the *message-processing core* — reading the JSON
-// body off stdin and producing a JSON response — but is NOT yet a drop-in
-// Chrome host until raw-byte framing lands (tracked as a follow-up issue,
-// see README). Run it with the wrapper in run.sh under wasmtime/wasmer to see
-// the read → process → respond loop end to end.
+// This is a drop-in Chrome host: it reads the framed JSON message off stdin,
+// builds a JSON response, and writes it back to stdout with the correct
+// 4-byte little-endian length prefix. Run it with the wrapper in run.sh under
+// wasmtime/wasmer to exercise the read -> process -> respond loop end to end.
 
 declare function readStdin(): string;
+declare const process: {
+  stdout: { write(chunk: Uint8Array | string): void };
+  stderr: { write(chunk: Uint8Array | string): void };
+};
 
 // Strip Chrome's 4-byte little-endian length prefix from a framed message,
 // returning just the JSON body. readStdin() hands us the whole stdin buffer
@@ -42,6 +45,16 @@ function decodeLength(framed: string): number {
   return b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
 }
 
+// Write a framed Native Messaging response: the 4-byte little-endian length
+// prefix followed by the JSON body, both on stdout (fd=1), no newline.
+function writeMessage(body: string): void {
+  const len = body.length;
+  // Binary 4-byte LE length prefix via raw-byte stdout (#1651).
+  process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
+  // JSON body — runtime string, written verbatim with no trailing newline.
+  process.stdout.write(body);
+}
+
 export function main(): void {
   // Read the whole framed message from stdin (Chrome sends one per launch in
   // the simplest "stdio" wiring; a long-lived port would loop here).
@@ -56,5 +69,6 @@ export function main(): void {
   // Application logic: echo the received JSON body back inside a wrapper
   // object. Real hosts would parse `body`, dispatch on a command field, and
   // build a structured response.
-  console.log(`{"received":${body},"runtime":"js2wasm+wasi"}`);
+  const response = `{"received":${body},"runtime":"js2wasm+wasi"}`;
+  writeMessage(response);
 }

--- a/examples/native-messaging/smoke-test.sh
+++ b/examples/native-messaging/smoke-test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Real-wasmtime smoke test for the Native Messaging host (#1530 / #1618 / #1651).
+#
+# The JS WASI polyfill (buildWasiPolyfill) zero-inits linear memory, so it
+# masked an off-by-one in the integer-print helper that appended an
+# uninitialized byte after each number — only REAL wasmtime, with reused bump
+# memory, exposed it (a stray 'i' in the stderr debug line). This script
+# compiles the shipped example and drives it under wasmtime, asserting:
+#   1. stdout is the EXACT Native Messaging response frame (4-byte LE length
+#      prefix + JSON body, no trailing newline);
+#   2. stderr is the clean debug line with NO stray bytes (the off-by-one guard).
+#
+# Run from anywhere; paths are resolved relative to this script.
+set -euo pipefail
+
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$DIR/../.." && pwd)
+OUT_DIR=$(mktemp -d)
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+echo "== Compiling examples/native-messaging/host.ts --target wasi =="
+( cd "$REPO_ROOT" && npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o "$OUT_DIR" )
+WASM="$OUT_DIR/host.wasm"
+[ -f "$WASM" ] || { echo "FAIL: $WASM was not produced" >&2; exit 1; }
+
+# Framed input: 4-byte LE length prefix (0x0d = 13) + the 13-byte body.
+# Total stdin = 17 bytes → the host's stderr should report
+# "received 17 chars, declared body length 13".
+FRAME='\x0d\x00\x00\x00{"ping":true}'
+
+# IMPORTANT: enable ONLY the proposals this module uses. Do NOT use
+# `-W all-proposals=y` — that turns on stack-switching, which wasmtime 44
+# rejects ("wasm_stack_switching feature is not supported").
+WASMTIME_FLAGS="-W gc=y,function-references=y,tail-call=y,exceptions=y"
+
+STDOUT_FILE="$OUT_DIR/stdout.bin"
+STDERR_FILE="$OUT_DIR/stderr.txt"
+
+echo "== Running under wasmtime ($(wasmtime --version)) =="
+# shellcheck disable=SC2086
+printf "$FRAME" | wasmtime $WASMTIME_FLAGS "$WASM" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+
+# ---- Expected stdout frame -------------------------------------------------
+# Body is the echo wrapper the host builds; its length is the LE prefix.
+EXPECTED_BODY='{"received":{"ping":true},"runtime":"js2wasm+wasi"}'
+BODY_LEN=${#EXPECTED_BODY}            # 51 → prefix 0x33 0x00 0x00 0x00 (computed, not hardcoded)
+EXPECTED_STDOUT_FILE="$OUT_DIR/expected_stdout.bin"
+{
+  # 4-byte little-endian uint32 length prefix.
+  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
+    $(( BODY_LEN & 0xff )) \
+    $(( (BODY_LEN >> 8) & 0xff )) \
+    $(( (BODY_LEN >> 16) & 0xff )) \
+    $(( (BODY_LEN >> 24) & 0xff )) )"
+  printf '%s' "$EXPECTED_BODY"
+} >"$EXPECTED_STDOUT_FILE"
+
+if ! cmp -s "$STDOUT_FILE" "$EXPECTED_STDOUT_FILE"; then
+  echo "FAIL: stdout frame mismatch" >&2
+  echo "--- expected (hex) ---" >&2
+  xxd "$EXPECTED_STDOUT_FILE" >&2 || od -An -tx1 "$EXPECTED_STDOUT_FILE" >&2
+  echo "--- actual (hex) ---" >&2
+  xxd "$STDOUT_FILE" >&2 || od -An -tx1 "$STDOUT_FILE" >&2
+  exit 1
+fi
+echo "OK: stdout is the exact $((4 + BODY_LEN))-byte frame (prefix=$BODY_LEN + body)."
+
+# ---- Expected stderr (off-by-one regression guard) -------------------------
+# Must be exactly the debug line + newline — NO stray byte after the integers.
+EXPECTED_STDERR='[host] received 17 chars, declared body length 13'
+ACTUAL_STDERR=$(cat "$STDERR_FILE")
+if [ "$ACTUAL_STDERR" != "$EXPECTED_STDERR" ]; then
+  echo "FAIL: stderr has unexpected content (stray byte? off-by-one regression)" >&2
+  echo "--- expected ---" >&2
+  printf '%s\n' "$EXPECTED_STDERR" | xxd >&2 || printf '%s\n' "$EXPECTED_STDERR" | od -An -tx1 >&2
+  echo "--- actual ---" >&2
+  printf '%s' "$ACTUAL_STDERR" | xxd >&2 || printf '%s' "$ACTUAL_STDERR" | od -An -tx1 >&2
+  exit 1
+fi
+echo "OK: stderr is the clean debug line, no stray bytes."
+
+echo "PASS: Native Messaging host round-trips byte-exactly under real wasmtime."

--- a/plan/issues/1618-wasi-runtime-string-stdout-corrupt.md
+++ b/plan/issues/1618-wasi-runtime-string-stdout-corrupt.md
@@ -1,7 +1,7 @@
 ---
 id: 1618
 title: "wasi: console.log of a runtime string emits corrupted [object] placeholder"
-status: backlog
+status: in-review
 created: 2026-05-24
 updated: 2026-05-24
 priority: high
@@ -62,3 +62,42 @@ path uses via `wasiAllocStringData`), instead of falling through to the
 Filed from #1530 (Native Messaging host example). This bug — combined with the
 missing raw-byte stdout primitive (#1617) — is why the #1530 host can read and
 process a message but cannot yet emit a correct response.
+
+## Implementation notes (resolution)
+
+The `[object]` placeholder was only *one* of two distinct bugs the runtime-string
+output triggered. Both are fixed:
+
+1. **`emitWasiValueToStdout` ref fallback (the documented symptom).**
+   `src/codegen/expressions/builtins.ts` now has a `ref`/`ref_null` + string-type
+   case that casts to `NativeString` and calls a new
+   `__wasi_write_any_string` helper (`ensureWasiWriteAnyStringHelper` in
+   `src/codegen/index.ts`). The helper flattens any AnyString (Cons/Utf8/template
+   result) via `__str_flatten`, copies the low byte of each i16 code unit into a
+   dedicated linear-memory scratch region, and issues one `fd_write`.
+
+2. **WASI memory-layout collision (the *real* cause of the "corrupted mix").**
+   The stdin read buffer and the string-literal data segments BOTH started at
+   offset 1024, so `fd_read` clobbered the initialized `[object]`/newline literal
+   bytes — that is why the output was a *mix* of real bytes and placeholder, not
+   a clean placeholder. `registerWasiImports` now reserves 3 pages and places the
+   stdin buffer at page 1 (`WASI_STDIN_BUF_START`) and the write scratch at page 2
+   (`WASI_WRITE_SCRATCH_START`), well above any page-0 data segment.
+
+3. **Template-literal extern-bridge leak under WASI (surfaced while fixing #1).**
+   `compileNativeTemplateExpression` (`src/codegen/string-ops.ts`)
+   unconditionally emitted the JS-host string-marshal bridge
+   (`__str_to_extern` / `__str_from_extern`), whose `__str_to_mem` /
+   `__str_from_mem` host imports do not exist under `--target wasi` and collapsed
+   to bogus function indices (a `call 0` → `fd_write`), producing an **invalid
+   module** for *any* template literal under WASI — independent of stdout. The
+   fix: a string-typed substitution is already a NativeString, so it concatenates
+   natively with zero marshaling; the bridge is now emitted only when a template
+   has a genuinely non-string (number/bigint/object) substitution. As a
+   robustness fix, `__str_flatten` is now also registered in `ctx.funcMap` (the
+   shift-maintained map) so internal `call __str_flatten` sites that follow a
+   late-import addition resolve correctly.
+
+Tests: `tests/issue-1618-1651-wasi-stdout.test.ts` (console.log + template
+runtime strings, no host-import leak) and the byte-exact round-trip in
+`tests/issue-1530.test.ts`.

--- a/plan/issues/1651-wasi-process-stdout-write.md
+++ b/plan/issues/1651-wasi-process-stdout-write.md
@@ -1,0 +1,78 @@
+---
+id: 1651
+title: "wasi: process.stdout.write(str|Uint8Array) → fd_write (no newline, raw bytes)"
+status: in-review
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: wasi, codegen
+language_feature: stdout, process
+goal: wasi-completeness
+sprint: Backlog
+related: [1530, 1617, 1618]
+supersedes: 1617
+---
+
+## Problem
+
+`console.log` in WASI mode always appends a newline and UTF-8-encodes its argument.
+There is no way to write a string without a trailing newline, or to write raw bytes
+verbatim to fd=1 (e.g. the binary 4-byte LE length prefix in Chrome Native Messaging).
+
+The natural Node.js API for both is `process.stdout.write`:
+```typescript
+process.stdout.write("hello")                        // no newline
+process.stdout.write(new Uint8Array([13, 0, 0, 0]))  // raw bytes
+```
+
+## Proposed implementation
+
+In `src/codegen/expressions/calls.ts`, detect `process.stdout.write(arg)` and
+`process.stderr.write(arg)` (for fd=2) in WASI mode:
+
+- **string arg**: encode to UTF-8 bytes (or extract from NativeString data array),
+  write via `fd_write(fd, iov, 1, nwritten)` — no trailing newline appended
+- **Uint8Array arg**: copy GC array elements to linear memory scratch, write via
+  `fd_write(fd, iov, 1, nwritten)` — raw bytes, no transformation
+
+## Acceptance criteria
+
+- `process.stdout.write("hello")` emits `hello` with no newline under wasmtime
+- `process.stdout.write(new Uint8Array([0x0d, 0x00, 0x00, 0x00]))` emits exactly 4 bytes
+- The Native Messaging host (`examples/native-messaging/host.ts`) frames a response
+  correctly: 4-byte LE prefix + JSON body on stdout
+- `buildWasiPolyfill()` round-trip test passes
+- `process.stderr.write` routes to fd=2 (same pattern as console.error)
+
+## Supersedes
+
+#1617 (`writeStdout` custom builtin) — `process.stdout.write` is the standard Node.js
+API and avoids adding a bespoke builtin. #1617 is closed in favour of this issue.
+
+## Implementation notes (resolution)
+
+- **Detection** (`src/codegen/expressions/calls.ts`): `matchProcessStdStreamWrite`
+  matches the exact shape `process.stdout|stderr.write(arg)` (one arg, no
+  optional-chaining, `process` not shadowed by a local/capture), gated on
+  `ctx.wasi` + an `fd_write` import. `registerWasiImports` was extended to set
+  `needsFdWrite` (and `needsConsoleStderr` for the stderr stream) when this
+  callee shape appears, so the imports/helpers are present.
+- **String arg**: routes through the same `__wasi_write_any_string` helper as
+  the #1618 `console.log` fix (`ensureWasiWriteAnyStringHelper`) — flatten +
+  per-code-unit byte copy + one `fd_write`, no trailing newline.
+- **Uint8Array arg**: `ensureWasiWriteUint8ArrayHelper` (new, in
+  `src/codegen/index.ts`) reads the Uint8Array's `vec` struct (field 0 = length,
+  field 1 = `array<f64>` data), truncates each element to a byte into the
+  page-2 write-scratch region, and issues one `fd_write` — raw bytes verbatim,
+  no transform, no newline. Works for the literal-array case the Native
+  Messaging length prefix needs.
+- **stderr**: `useStderr` swaps fd=1→fd=2 and selects the stderr helper variant.
+
+The host (`examples/native-messaging/host.ts`) now frames its response with
+`process.stdout.write(new Uint8Array([...4-byte LE...]))` + `process.stdout.write(body)`,
+mirroring the Node.js API of the AssemblyScript reference. Byte-exact round-trip
+covered by `tests/issue-1530.test.ts`; per-API behaviour by
+`tests/issue-1618-1651-wasi-stdout.test.ts`.

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -1763,10 +1763,21 @@ function ensureWasiWriteI32Helper(ctx: CodegenContext, useStderr: boolean = fals
       ],
     },
 
-    // Call __wasi_write_string(buf_pos, buf_start + 12 - buf_pos)
+    // Call __wasi_write_string(buf_pos, (buf_start + 11) - buf_pos)
+    //
+    // Off-by-one fix (pre-existing, surfaced by real-wasmtime testing of the
+    // #1530 Native Messaging host's stderr debug line): the digit buffer is
+    // bytes [buf_start .. buf_start+11]. buf_pos starts at buf_start+11 and each
+    // digit is written with a PRE-decrement, so the rightmost digit lands at
+    // buf_start+10 and the byte one-past-the-last-written is buf_start+11. The
+    // length must therefore be (buf_start + 11) - buf_pos, NOT +12 — using +12
+    // appended the uninitialized byte at buf_start+11 (observed as a stray 'i'
+    // after the number, e.g. "17i" instead of "17"). The 0 special-case writes
+    // its single byte at +11 via an early return and is unaffected; negatives
+    // are also correct (e.g. -17 → buf_pos at the '-', length = 3).
     { op: "local.get", index: bufPosLocal } as Instr,
     { op: "local.get", index: bufStartLocal } as Instr,
-    { op: "i32.const", value: 12 } as Instr,
+    { op: "i32.const", value: 11 } as Instr,
     { op: "i32.add" } as Instr,
     { op: "local.get", index: bufPosLocal } as Instr,
     { op: "i32.sub" } as Instr,

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -9,7 +9,7 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { flushLateImportShifts } from "../expressions/late-imports.js";
-import { addFuncType } from "../index.js";
+import { addFuncType, ensureWasiWriteAnyStringHelper } from "../index.js";
 import { ensureNativeStringExternBridge } from "../native-strings.js";
 import type { InnerResult } from "../shared.js";
 import { compileExpression, VOID_RESULT } from "../shared.js";
@@ -1545,7 +1545,7 @@ function emitWasiValueToStdout(
   ctx: CodegenContext,
   fctx: FunctionContext,
   exprType: InnerResult,
-  _node: ts.Node,
+  node: ts.Node,
   useStderr: boolean = false,
 ): void {
   // #1493: pick stdout (fd=1) or stderr (fd=2) helper based on call site.
@@ -1574,8 +1574,42 @@ function emitWasiValueToStdout(
     } else {
       fctx.body.push({ op: "drop" } as Instr);
     }
+  } else if (
+    (exprType.kind === "ref" || exprType.kind === "ref_null") &&
+    isStringType(ctx.checker.getTypeAtLocation(node)) &&
+    ctx.nativeStrTypeIdx >= 0
+  ) {
+    // #1618: runtime string value (variable / concatenation / template span).
+    // The compiled value is a NativeString ref (or its AnyString supertype).
+    // Flatten + write its bytes to fd=1/fd=2 instead of dropping it and
+    // emitting the "[object]" placeholder. The value on the stack may be typed
+    // as the AnyString supertype after a concat; cast to NativeString so it
+    // matches the helper's param type (__str_flatten accepts the supertype, so
+    // any non-flat tree is handled there — but the static cast is required for
+    // the call to typecheck against the helper signature).
+    const refKind = exprType.kind;
+    if (
+      refKind === "ref" &&
+      "typeIdx" in exprType &&
+      (exprType as { typeIdx: number }).typeIdx !== ctx.nativeStrTypeIdx
+    ) {
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+    } else if (refKind === "ref_null") {
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+    }
+    const writeAnyIdx = ensureWasiWriteAnyStringHelper(ctx, useStderr);
+    if (writeAnyIdx >= 0) {
+      fctx.body.push({ op: "call", funcIdx: writeAnyIdx } as Instr);
+    } else {
+      // Helper unavailable (no native strings) — fall back to placeholder.
+      fctx.body.push({ op: "drop" } as Instr);
+      const placeholder = wasiAllocStringData(ctx, "[object]");
+      fctx.body.push({ op: "i32.const", value: placeholder.offset } as Instr);
+      fctx.body.push({ op: "i32.const", value: placeholder.length } as Instr);
+      fctx.body.push({ op: "call", funcIdx: writeStringIdx });
+    }
   } else {
-    // For other types (externref, ref, etc.), just drop and write a placeholder
+    // For other types (externref, etc.), just drop and write a placeholder
     fctx.body.push({ op: "drop" } as Instr);
     const placeholder = wasiAllocStringData(ctx, "[object]");
     fctx.body.push({ op: "i32.const", value: placeholder.offset } as Instr);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -42,6 +42,8 @@ import {
   addUnionImports,
   ensureExnTag,
   ensureI32Condition,
+  ensureWasiWriteAnyStringHelper,
+  ensureWasiWriteUint8ArrayHelper,
   getArrTypeIdxFromVec,
   getOrRegisterRefCellType,
   getOrRegisterVecType,
@@ -1195,6 +1197,36 @@ function emitVirtualMethodDispatchByTag(
   return resultType;
 }
 
+/**
+ * #1651: recognise `process.stdout.write(x)` / `process.stderr.write(x)` under
+ * --target wasi. Returns `{ useStderr }` when the callee is exactly the
+ * `write` method of `process.stdout` / `process.stderr` (with exactly one
+ * argument and `process` not shadowed by a local), else null.
+ *
+ * Shape: CallExpression.expression is `PropertyAccess(name="write")` whose
+ * `.expression` is `PropertyAccess(name="stdout"|"stderr")` whose `.expression`
+ * is the identifier `process`.
+ */
+function matchProcessStdStreamWrite(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): { useStderr: boolean } | null {
+  if (!ctx.wasi || ctx.wasiFdWriteIdx === undefined || ctx.wasiFdWriteIdx < 0) return null;
+  if (expr.questionDotToken || expr.arguments.length !== 1) return null;
+  const writeAccess = expr.expression;
+  if (!ts.isPropertyAccessExpression(writeAccess) || writeAccess.name.text !== "write") return null;
+  const streamAccess = writeAccess.expression;
+  if (!ts.isPropertyAccessExpression(streamAccess)) return null;
+  const streamName = streamAccess.name.text;
+  if (streamName !== "stdout" && streamName !== "stderr") return null;
+  const procIdent = streamAccess.expression;
+  if (!ts.isIdentifier(procIdent) || procIdent.text !== "process") return null;
+  // Don't hijack a user-shadowed `process` local/capture.
+  if (fctx.localMap.has("process") || (fctx.boxedCaptures?.has("process") ?? false)) return null;
+  return { useStderr: streamName === "stderr" };
+}
+
 function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
   // Optional chaining on calls: obj?.method()
   if (expr.questionDotToken && ts.isPropertyAccessExpression(expr.expression)) {
@@ -1259,6 +1291,67 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (helperIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
       return { kind: "ref", typeIdx: ctx.nativeStrTypeIdx };
+    }
+  }
+
+  // #1651 (GitHub #572): process.stdout.write(x) / process.stderr.write(x)
+  // under --target wasi → write x to fd=1 / fd=2 with NO trailing newline
+  // (unlike console.log). Supersedes the bespoke `writeStdout` builtin from
+  // #1617 with the standard Node.js API. Accepts a string (UTF-8/Latin-1 bytes)
+  // or a Uint8Array (raw bytes — the 4-byte LE length prefix the Native
+  // Messaging host #1530 needs).
+  {
+    const stdoutWrite = matchProcessStdStreamWrite(ctx, fctx, expr);
+    if (stdoutWrite) {
+      const { useStderr } = stdoutWrite;
+      const argExpr = expr.arguments[0]!;
+      const argTsType = ctx.checker.getTypeAtLocation(argExpr);
+      if (isStringType(argTsType)) {
+        // String → reuse the runtime-string byte writer (#1618). It flattens
+        // and writes the string bytes verbatim, no newline.
+        const compiled = compileExpression(ctx, fctx, argExpr);
+        flushLateImportShifts(ctx, fctx);
+        if (compiled && ctx.nativeStrTypeIdx >= 0) {
+          if (compiled.kind === "ref_null") {
+            fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+          } else if (compiled.kind === "ref" && "typeIdx" in compiled && compiled.typeIdx !== ctx.nativeStrTypeIdx) {
+            fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+          }
+          const writeStrIdx = ensureWasiWriteAnyStringHelper(ctx, useStderr);
+          if (writeStrIdx >= 0) {
+            fctx.body.push({ op: "call", funcIdx: writeStrIdx } as Instr);
+            return VOID_RESULT;
+          }
+        }
+        // Fallback: drop to keep the stack balanced.
+        if (compiled) fctx.body.push({ op: "drop" } as Instr);
+        return VOID_RESULT;
+      }
+
+      // Uint8Array (or other typed array) → raw bytes. Uint8Array compiles to a
+      // "vec" struct wrapping an f64 GC array (new-super.ts `new Uint8Array`).
+      const vecTypeIdx = getOrRegisterVecType(ctx, "f64", { kind: "f64" });
+      const argType = compileExpression(ctx, fctx, argExpr);
+      flushLateImportShifts(ctx, fctx);
+      // The helper takes a non-null ref; cast a mismatched ref / assert non-null.
+      if (argType) {
+        if (argType.kind === "ref_null") {
+          if ("typeIdx" in argType && argType.typeIdx !== vecTypeIdx) {
+            fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+          } else {
+            fctx.body.push({ op: "ref.as_non_null" } as Instr);
+          }
+        } else if (argType.kind === "ref" && "typeIdx" in argType && argType.typeIdx !== vecTypeIdx) {
+          fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+        }
+      }
+      const helperIdx = ensureWasiWriteUint8ArrayHelper(ctx, vecTypeIdx, useStderr);
+      if (helperIdx >= 0) {
+        fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
+        return VOID_RESULT;
+      }
+      if (argType) fctx.body.push({ op: "drop" } as Instr);
+      return VOID_RESULT;
     }
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3388,8 +3388,18 @@ function collectConsoleImports(ctx: CodegenContext, sourceFile: ts.SourceFile): 
 
 /** Register WASI imports: fd_write, proc_exit, path_open, fd_close, linear memory, bump pointer global */
 function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
-  // Add linear memory (1 page = 64KB) for string data + iovec structs
-  ctx.mod.memories.push({ min: 1 });
+  // Add linear memory for string data + iovec structs.
+  //
+  // Layout (#1618 collision fix): page 0 (0..64KB) holds the iovec/nwritten
+  // scratch (0..15) and the bump-allocated data segments for string literals
+  // (`wasiAllocStringData`, from offset 1024 up). The stdin read buffer and the
+  // raw-byte write scratch MUST NOT alias those data segments — previously both
+  // the literal segments and the stdin buffer started at 1024, so reading stdin
+  // overwrote the initialized literal/newline bytes, corrupting console.log
+  // output. We now place the stdin buffer in page 1 (WASI_STDIN_BUF_START) and
+  // the write scratch in page 2 (WASI_WRITE_SCRATCH_START), well above any
+  // data segment, and reserve 3 pages so both regions always exist.
+  ctx.mod.memories.push({ min: 3 });
   // WASI requires the memory to be exported as "memory"
   ctx.mod.exports.push({ name: "memory", desc: { kind: "memory", index: 0 } });
 
@@ -3447,6 +3457,21 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
         propAccess.name.text === "exit"
       ) {
         needsProcExit = true;
+      }
+      // #1651: process.stdout.write(...) / process.stderr.write(...) need
+      // fd_write. The callee is `process.<stream>.write` — a PropertyAccess
+      // (name="write") whose receiver is itself `process.stdout|stderr`.
+      if (
+        propAccess.name.text === "write" &&
+        ts.isPropertyAccessExpression(propAccess.expression) &&
+        ts.isIdentifier(propAccess.expression.expression) &&
+        propAccess.expression.expression.text === "process" &&
+        (propAccess.expression.name.text === "stdout" || propAccess.expression.name.text === "stderr")
+      ) {
+        needsFdWrite = true;
+        if (propAccess.expression.name.text === "stderr") {
+          needsConsoleStderr = true;
+        }
       }
       // #1322: Math.random() in WASI mode uses random_get for entropy
       if (
@@ -3858,6 +3883,300 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
 }
 
 /**
+ * WASI linear-memory layout constants (#1618 collision fix).
+ *
+ * The iovec lives at memory[0..7] and nwritten at memory[8..11] (shared by all
+ * __wasi_write_* helpers). String-literal data segments are bump-allocated in
+ * page 0 from offset 1024 (`wasiAllocStringData`). To avoid aliasing those
+ * segments, the stdin read buffer and the raw-byte write scratch live in
+ * dedicated higher pages:
+ *   - WASI_STDIN_BUF_START  = 64KB  (page 1) — fd_read accumulation buffer
+ *   - WASI_WRITE_SCRATCH_START = 128KB (page 2) — fd_write staging buffer
+ * `registerWasiImports` reserves 3 pages so both always exist.
+ */
+const WASI_STDIN_BUF_START = 64 * 1024;
+const WASI_WRITE_SCRATCH_START = 128 * 1024;
+
+/**
+ * #1618: Ensure __wasi_write_any_string(s: ref NativeString) -> void exists and
+ * return its function index (lazy, emitted during expression compilation).
+ *
+ * Writes a *runtime* string (variable, concatenation, template span) to fd=1
+ * (stdout) or fd=2 (stderr). Previously these refs fell through to the
+ * `[object]` placeholder in emitWasiValueToStdout, corrupting the stream.
+ *
+ * Strategy: flatten any AnyString (FlatString / ConsString / Utf8String) to a
+ * NativeString via the existing __str_flatten helper, then copy the low byte
+ * of each i16 code unit into linear memory and issue a single fd_write. This
+ * mirrors readStdin's byte-per-i16 model (#1481), so a `readStdin()` →
+ * `console.log` round-trip is byte-exact for ASCII / Latin-1 content (the
+ * Native Messaging JSON case). Non-Latin-1 code points are truncated to their
+ * low byte — acceptable for the protocol use-case and consistent with how
+ * stdin bytes are stored.
+ *
+ * Param 0 is typed `ref NativeString` so callers can hand us a value compiled
+ * as `{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }` directly; __str_flatten
+ * accepts the NativeString supertype (AnyString) and returns the flat form.
+ */
+export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: boolean = false): number {
+  const helperName = useStderr ? "__wasi_write_any_string_stderr" : "__wasi_write_any_string";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  if (!ctx.wasi || ctx.wasiFdWriteIdx === undefined || ctx.nativeStrTypeIdx < 0) return -1;
+
+  // Make sure the native-string runtime (incl. __str_flatten) is emitted.
+  ensureNativeStringHelpers(ctx);
+  // __str_flatten via funcMap (shift-maintained), not nativeStrHelpers (which can
+  // be stale-low after late imports). See the registration in
+  // ensureNativeStringHelpers. (#1618)
+  const flattenIdx = ctx.funcMap.get("__str_flatten");
+  if (flattenIdx === undefined) return -1;
+
+  const fd = useStderr ? 2 : 1;
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+
+  // param: s(0); locals: flat(1), len(2), off(3), data(4), i(5)
+  const S = 0;
+  const FLAT = 1;
+  const LEN = 2;
+  const OFF = 3;
+  const DATA = 4;
+  const I = 5;
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: strTypeIdx }], []);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const body: Instr[] = [
+    // flat = __str_flatten(s)
+    { op: "local.get", index: S } as Instr,
+    { op: "call", funcIdx: flattenIdx } as Instr,
+    { op: "local.set", index: FLAT } as Instr,
+
+    // len = flat.len (field 0)
+    { op: "local.get", index: FLAT } as Instr,
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: LEN } as Instr,
+
+    // off = flat.off (field 1)
+    { op: "local.get", index: FLAT } as Instr,
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.set", index: OFF } as Instr,
+
+    // data = flat.data (field 2)
+    { op: "local.get", index: FLAT } as Instr,
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 } as Instr,
+    { op: "local.set", index: DATA } as Instr,
+
+    // i = 0
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.set", index: I } as Instr,
+
+    // while (i < len) mem[SCRATCH+i] = (u8) data[off+i]; i++
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: I } as Instr,
+            { op: "local.get", index: LEN } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+
+            // address = SCRATCH_START + i
+            { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.add" } as Instr,
+
+            // value = data[off + i] (i16, unsigned) — low byte kept by i32.store8
+            { op: "local.get", index: DATA } as Instr,
+            { op: "local.get", index: OFF } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+
+            { op: "i32.store8", align: 0, offset: 0 },
+
+            // i++
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: I } as Instr,
+
+            { op: "br", depth: 0 } as Instr,
+          ],
+        },
+      ],
+    },
+
+    // iovec.buf = SCRATCH_START at memory[0]
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // iovec.buf_len = len at memory[4]
+    { op: "i32.const", value: 4 } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+    { op: "i32.const", value: fd } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.const", value: 8 } as Instr,
+    { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
+    { op: "drop" } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: helperName,
+    typeIdx: funcTypeIdx,
+    locals: [
+      { name: "flat", type: { kind: "ref", typeIdx: strTypeIdx } },
+      { name: "len", type: { kind: "i32" } },
+      { name: "off", type: { kind: "i32" } },
+      { name: "data", type: { kind: "ref", typeIdx: strDataTypeIdx } },
+      { name: "i", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+
+  return funcIdx;
+}
+
+/**
+ * #1617/#1651: Ensure __wasi_write_uint8array(arr: ref __vec_f64) -> void
+ * exists and return its function index (lazy).
+ *
+ * Writes raw bytes from a typed-array (Uint8Array) GC object to fd=1 (stdout)
+ * or fd=2 (stderr) with NO trailing newline. Backs the
+ * `process.stdout.write(new Uint8Array([...]))` path (the standard Node API
+ * that supersedes the bespoke `writeStdout` builtin from #1617). A Uint8Array
+ * compiles to a "vec" struct:
+ *   field 0: length (i32)
+ *   field 1: data    (ref array<f64>) — each element is a byte value
+ *
+ * We truncate each f64 element to its byte and stage it in linear memory at
+ * WASI_WRITE_SCRATCH_START, then issue a single fd_write. This is what the
+ * Native Messaging host (#1530) needs to emit the 4-byte little-endian length
+ * prefix that console.log (UTF-8 + "\n") cannot.
+ */
+export function ensureWasiWriteUint8ArrayHelper(
+  ctx: CodegenContext,
+  vecTypeIdx: number,
+  useStderr: boolean = false,
+): number {
+  const helperName = useStderr ? "__wasi_write_uint8array_stderr" : "__wasi_write_uint8array";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  if (!ctx.wasi || ctx.wasiFdWriteIdx === undefined) return -1;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return -1;
+
+  const fd = useStderr ? 2 : 1;
+
+  // param: arr(0); locals: len(1), data(2), i(3)
+  const ARR = 0;
+  const LEN = 1;
+  const DATA = 2;
+  const I = 3;
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const body: Instr[] = [
+    // len = arr.length (field 0)
+    { op: "local.get", index: ARR } as Instr,
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: LEN } as Instr,
+
+    // data = arr.data (field 1)
+    { op: "local.get", index: ARR } as Instr,
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.set", index: DATA } as Instr,
+
+    // i = 0
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.set", index: I } as Instr,
+
+    // while (i < len) mem[SCRATCH+i] = (u8) trunc(data[i]); i++
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: I } as Instr,
+            { op: "local.get", index: LEN } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+
+            // address = SCRATCH_START + i
+            { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.add" } as Instr,
+
+            // value = (i32) data[i] — low byte kept by i32.store8
+            { op: "local.get", index: DATA } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+            { op: "i32.trunc_sat_f64_s" } as Instr,
+
+            { op: "i32.store8", align: 0, offset: 0 },
+
+            // i++
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: I } as Instr,
+
+            { op: "br", depth: 0 } as Instr,
+          ],
+        },
+      ],
+    },
+
+    // iovec.buf = SCRATCH_START at memory[0]
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // iovec.buf_len = len at memory[4]
+    { op: "i32.const", value: 4 } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+    { op: "i32.const", value: fd } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.const", value: 8 } as Instr,
+    { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
+    { op: "drop" } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: helperName,
+    typeIdx: funcTypeIdx,
+    locals: [
+      { name: "len", type: { kind: "i32" } },
+      { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
+      { name: "i", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+
+  return funcIdx;
+}
+
+/**
  * Emit __wasi_write_file_sync(pathPtr: i32, pathLen: i32, dataPtr: i32, dataLen: i32) helper.
  * Opens a file via path_open, writes data via fd_write, then closes via fd_close.
  *
@@ -4038,9 +4357,11 @@ function emitWasiSleepMsHelper(ctx: CodegenContext): void {
  * sized to fit comfortably inside the initial 1 page (64KB) of memory.
  */
 function emitWasiReadStdinAllHelper(ctx: CodegenContext): void {
-  const STDIN_BUF_START = 1024;
+  // #1618: stdin buffer lives in its own page (64KB), above the page-0 string
+  // literal data segments, so fd_read can't clobber initialized literal bytes.
+  const STDIN_BUF_START = WASI_STDIN_BUF_START;
   const CHUNK = 1024;
-  const MAX_BYTES = 60 * 1024; // ~60KB cap; first page is 64KB
+  const MAX_BYTES = 60 * 1024; // ~60KB cap; fits in the dedicated stdin page
 
   // () -> ref NativeString
   const funcTypeIdx = addFuncType(ctx, [], [{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }]);

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -810,6 +810,16 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     const typeIdx = addFuncType(ctx, [strRef], [flatStrRef]);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.nativeStrHelpers.set("__str_flatten", funcIdx);
+    // Also register in funcMap so the deferred late-import shift
+    // (flushLateImportShifts walks ctx.funcMap) keeps __str_flatten's index
+    // correct when imports are added after this registration. Internal callers
+    // that emit a `call __str_flatten` between flatten's registration and a
+    // late-import addition (notably ensureNativeStringExternBridge's
+    // __str_to_extern, which adds 3 fd-bridge imports first) would otherwise
+    // read a stale-low nativeStrHelpers index. funcMap is the authoritative,
+    // shift-maintained map; no code looks up __str_flatten via funcMap so adding
+    // it is side-effect-free. (#1618)
+    ctx.funcMap.set("__str_flatten", funcIdx);
 
     const copyTreeIdx = ctx.nativeStrHelpers.get("__str_copy_tree")!;
     // #1588 PR-B part 2: present iff --utf8-storage is on.
@@ -3345,14 +3355,36 @@ export function ensureNativeStringExternBridge(ctx: CodegenContext): void {
     ctx.nativeStrHelpers.set("__str_to_extern", funcIdx);
     ctx.funcMap.set("__str_to_extern", funcIdx);
 
+    // The param is typed as the AnyString supertype, but the body reads
+    // NativeString (FlatString) fields. We must flatten first: a ConsString /
+    // Utf8String / template-literal result is NOT a NativeString, so reading
+    // its fields via `struct.get NativeString` on the raw param produces an
+    // invalid module (struct.get expected NativeString, found AnyString). For
+    // an already-flat input __str_flatten is a cheap identity. (#1618 family —
+    // surfaced by `process.stdout.write`/`console.log` of a template literal
+    // under --target wasi, which emits this bridge.)
+    //
+    // __str_flatten via funcMap (NOT nativeStrHelpers): this body emits a `call
+    // __str_flatten` after the three fd-bridge late imports above have been
+    // queued, so the nativeStrHelpers index is stale-low (it's never rewritten by
+    // the deferred shift). funcMap IS shift-maintained — __str_flatten is now
+    // registered there too — so this resolves and shifts correctly. (#1618)
+    const flattenIdx = ctx.funcMap.get("__str_flatten")!;
+    const FLAT_LOCAL = 5;
+
     const body: Instr[] = [
+      // flat = __str_flatten(s)  (locals[5])
       { op: "local.get", index: 0 },
+      { op: "call", funcIdx: flattenIdx },
+      { op: "local.set", index: FLAT_LOCAL },
+
+      { op: "local.get", index: FLAT_LOCAL },
       { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
       { op: "local.set", index: 1 },
-      { op: "local.get", index: 0 },
+      { op: "local.get", index: FLAT_LOCAL },
       { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
       { op: "local.set", index: 4 },
-      { op: "local.get", index: 0 },
+      { op: "local.get", index: FLAT_LOCAL },
       { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
       { op: "local.set", index: 3 },
       { op: "i32.const", value: 0 },
@@ -3400,6 +3432,7 @@ export function ensureNativeStringExternBridge(ctx: CodegenContext): void {
         { name: "i", type: { kind: "i32" } },
         { name: "data", type: strDataRef },
         { name: "sOff", type: { kind: "i32" } },
+        { name: "flat", type: { kind: "ref", typeIdx: strTypeIdx } },
       ],
       body,
       exported: false,

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -169,8 +169,18 @@ export function compileNativeTemplateExpression(
 ): ValType | null {
   const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
   const toStrIdx = ctx.funcMap.get("number_toString");
-  ensureNativeStringExternBridge(ctx);
-  flushLateImportShifts(ctx, fctx);
+  // #1618: the extern bridge (__str_to_extern/__str_from_extern) is JS-host-only
+  // — it marshals via __str_to_mem/__str_from_mem host imports that don't exist
+  // under --target wasi/standalone, where they collapse to bogus indices and
+  // produce an invalid module. Only emit it when the template actually needs
+  // externref marshaling, i.e. it has a NON-string substitution (number/bigint/
+  // object → number_toString returns externref → __str_from_extern). A template
+  // whose spans are all strings concatenates natively with zero host calls.
+  const hasNonStringSpan = expr.templateSpans.some((s) => !isStringType(ctx.checker.getTypeAtLocation(s.expression)));
+  if (hasNonStringSpan) {
+    ensureNativeStringExternBridge(ctx);
+    flushLateImportShifts(ctx, fctx);
+  }
   const fromExternIdx = ctx.nativeStrHelpers.get("__str_from_extern");
   if (concatIdx === undefined) return null;
 
@@ -182,7 +192,20 @@ export function compileNativeTemplateExpression(
     const span = expr.templateSpans[i]!;
 
     const spanType = compileExpression(ctx, fctx, span.expression);
-    if (spanType && spanType.kind === "f64" && toStrIdx !== undefined) {
+    const spanIsString =
+      spanType &&
+      (spanType.kind === "ref" || spanType.kind === "ref_null") &&
+      isStringType(ctx.checker.getTypeAtLocation(span.expression));
+    if (spanIsString) {
+      // #1618: a string-typed substitution is ALREADY a native string ref
+      // (AnyString / NativeString). Concat it directly — do NOT round-trip
+      // through externref via __str_to_extern/__str_from_extern. That bridge is
+      // JS-host-only (__str_to_mem / __str_from_mem imports) and produces an
+      // invalid module under --target wasi/standalone, where those host imports
+      // don't exist and collapse to bogus function indices. __str_concat accepts
+      // the AnyString supertype, so a ref_null is fine to pass straight through.
+      // (No marshaling instructions emitted — value stays on the stack.)
+    } else if (spanType && spanType.kind === "f64" && toStrIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: toStrIdx });
       // number_toString returns externref, marshal to native string
       if (fromExternIdx !== undefined) {

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -48,3 +48,125 @@ describe("#1530 Native Messaging host example", () => {
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
   });
 });
+
+// #1618 + #1651 — byte-exact stdin→stdout round-trip for the Native Messaging
+// frame. This is the end-to-end behaviour the #1530 example demonstrates and
+// that the earlier compile-only test deliberately punted on (runtime-string
+// output + binary length prefix were documented gaps). We drive the compiled
+// module with a *raw-byte* WASI shim (NOT the line-buffering buildWasiPolyfill,
+// which decodes UTF-8 and splits on "\n") so the binary 4-byte length prefix —
+// which contains non-UTF8 bytes and no newline — is captured verbatim.
+describe("#1618/#1651 framed stdin→stdout round-trip", () => {
+  // Minimal raw-byte WASI shim: fd_read drains a preloaded stdin buffer, fd_write
+  // appends the exact bytes to an ordered capture list keyed by fd.
+  function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
+    // Boxed so the WASI closures can read it after the instance is created.
+    const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+    const memView = () => new DataView(ref.mem!.buffer);
+    const writes: Array<[number, Uint8Array]> = [];
+    let pos = 0;
+    const wasi = {
+      fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+        const view = memView();
+        let total = 0;
+        for (let i = 0; i < iovsLen; i++) {
+          const ptr = view.getUint32(iovs + i * 8, true);
+          const len = view.getUint32(iovs + i * 8 + 4, true);
+          const n = Math.min(len, stdin.length - pos);
+          new Uint8Array(ref.mem!.buffer, ptr, n).set(stdin.subarray(pos, pos + n));
+          pos += n;
+          total += n;
+          if (n < len) break; // short read → EOF for the remaining iovs
+        }
+        view.setUint32(nread, total, true);
+        return 0;
+      },
+      fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+        const view = memView();
+        let total = 0;
+        for (let i = 0; i < iovsLen; i++) {
+          const ptr = view.getUint32(iovs + i * 8, true);
+          const len = view.getUint32(iovs + i * 8 + 4, true);
+          writes.push([fd, Uint8Array.from(new Uint8Array(ref.mem!.buffer, ptr, len))]);
+          total += len;
+        }
+        view.setUint32(nwritten, total, true);
+        return 0;
+      },
+      proc_exit(code: number): void {
+        throw new Error(`proc_exit(${code})`);
+      },
+      random_get(): number {
+        return 0;
+      },
+      clock_time_get(): number {
+        return 0;
+      },
+    };
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+      wasi_snapshot_preview1: wasi,
+      env: {},
+    });
+    ref.mem = inst.exports.memory as WebAssembly.Memory;
+    (inst.exports.main as () => void)();
+    // Reassemble the fd=1 (stdout) byte stream in write order.
+    const fd1 = writes.filter(([fd]) => fd === 1).flatMap(([, b]) => Array.from(b));
+    return Uint8Array.from(fd1);
+  }
+
+  function frame(jsonBody: string): Uint8Array {
+    const body = new TextEncoder().encode(jsonBody);
+    const out = new Uint8Array(4 + body.length);
+    new DataView(out.buffer).setUint32(0, body.length, true);
+    out.set(body, 4);
+    return out;
+  }
+
+  it("decodes a framed input and re-frames the response with a 4-byte LE prefix", () => {
+    // A self-contained host that mirrors the example: strip the 4-byte prefix,
+    // rebuild the body char-by-char from the decoded length, then write a framed
+    // response (binary length prefix via Uint8Array + JSON body via string).
+    const src = `
+declare function readStdin(): string;
+declare const process: { stdout: { write(chunk: Uint8Array | string): void } };
+export function main(): void {
+  const framed = readStdin();
+  const b0 = framed.charCodeAt(0) & 0xff;
+  const b1 = framed.charCodeAt(1) & 0xff;
+  const b2 = framed.charCodeAt(2) & 0xff;
+  const b3 = framed.charCodeAt(3) & 0xff;
+  const len = b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
+  let body = "";
+  for (let i = 0; i < len; i++) {
+    body = body + framed.charAt(4 + i);
+  }
+  const response = \`{"received":\${body}}\`;
+  const rl = response.length;
+  process.stdout.write(
+    new Uint8Array([rl & 0xff, (rl >> 8) & 0xff, (rl >> 16) & 0xff, (rl >> 24) & 0xff]),
+  );
+  process.stdout.write(response);
+}`;
+    const result = compile(src, { fileName: "rt.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+
+    const out = runWasiRaw(result.binary, frame('{"a":1}'));
+    const expectedBody = '{"received":{"a":1}}';
+    // 4-byte LE length prefix matches the body length…
+    expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
+    // …and the body bytes after the prefix are the JSON response verbatim.
+    expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
+  });
+
+  it("compiles the shipped example and round-trips it byte-exactly", () => {
+    const src = readFileSync(hostPath, "utf-8");
+    const result = compile(src, { fileName: "host.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+
+    const out = runWasiRaw(result.binary, frame('{"cmd":"ping"}'));
+    const expectedBody = '{"received":{"cmd":"ping"},"runtime":"js2wasm+wasi"}';
+    expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
+    expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
+  });
+});

--- a/tests/issue-1618-1651-wasi-stdout.test.ts
+++ b/tests/issue-1618-1651-wasi-stdout.test.ts
@@ -127,3 +127,52 @@ describe("#1651 process.stdout.write under --target wasi", () => {
     }
   });
 });
+
+// Pre-existing off-by-one in the WASI integer-print helper
+// (ensureWasiWriteI32Helper), surfaced by real-wasmtime testing of the #1530
+// host's stderr debug line. The 12-byte digit buffer's last written byte is at
+// buf_start+10, so the write length must be (buf_start+11)-buf_pos; the helper
+// previously used +12, appending the uninitialized byte at buf_start+11 — a
+// stray char after every printed integer (e.g. "17i" instead of "17"). The f64
+// print helper delegates to the i32 helper, so template-literal number
+// interpolation inherited the same stray byte.
+describe("WASI integer print has no trailing stray byte", () => {
+  it("console.log(int) on stdout prints exactly the digits, no stray char", () => {
+    // 17 is the length the real-wasmtime repro produced ("17i").
+    const src = `export function main(): void { const n = 17; console.log(n); }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = new TextDecoder().decode(runWasiCaptureFd(result.binary, 1));
+    // console.log appends a newline; the integer itself must be exactly "17".
+    expect(out).toBe("17\n");
+    expect(out).not.toMatch(/17[^\n]/); // no character wedged between digits and newline
+  });
+
+  it("console.error(`x=${n}`) on stderr prints the number with no stray char", () => {
+    // Drives the f64 print path via template-literal interpolation (the #1530
+    // debug line shape: `declared body length ${n}`), routed to fd=2.
+    const src = `export function main(): void { const n = 13; console.error(\`len=\${n}\`); }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = new TextDecoder().decode(runWasiCaptureFd(result.binary, 2));
+    expect(out).toBe("len=13\n");
+    expect(out).not.toContain("13i");
+  });
+
+  it("prints a range of integer widths cleanly (boundary + multi-digit)", () => {
+    for (const [value, digits] of [
+      [0, "0"],
+      [7, "7"],
+      [42, "42"],
+      [100, "100"],
+      [99999, "99999"],
+      [-17, "-17"],
+    ] as Array<[number, string]>) {
+      const src = `export function main(): void { const n = ${value}; console.log(n); }`;
+      const result = compile(src, { fileName: "x.ts", target: "wasi" });
+      expect(result.success).toBe(true);
+      const out = new TextDecoder().decode(runWasiCaptureFd(result.binary, 1));
+      expect(out).toBe(`${digits}\n`);
+    }
+  });
+});

--- a/tests/issue-1618-1651-wasi-stdout.test.ts
+++ b/tests/issue-1618-1651-wasi-stdout.test.ts
@@ -1,0 +1,129 @@
+// #1618 — console.log of a *runtime* string under --target wasi must emit the
+// string content, not the "[object]" placeholder that emitWasiValueToStdout
+// previously wrote for every ref/ref_null value.
+//
+// #1651 — process.stdout.write(str) / process.stdout.write(new Uint8Array([...]))
+// lower to fd_write(1, ...) with NO trailing newline (the Node.js API the
+// Chrome Native Messaging host needs for its binary 4-byte length prefix).
+//
+// Both are validated by running the compiled module against a raw-byte WASI
+// shim so non-UTF8 bytes and the absence of a newline are observed verbatim.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Run a compiled WASI module, returning the raw bytes written to a given fd. */
+function runWasiCaptureFd(binary: Uint8Array, fd: number, stdin?: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const captured: number[] = [];
+  let pos = 0;
+  const wasi = {
+    fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+      const view = memView();
+      let total = 0;
+      const src = stdin ?? new Uint8Array(0);
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const n = Math.min(len, src.length - pos);
+        new Uint8Array(ref.mem!.buffer, ptr, n).set(src.subarray(pos, pos + n));
+        pos += n;
+        total += n;
+        if (n < len) break;
+      }
+      view.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === fd) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+describe("#1618 console.log of a runtime string under --target wasi", () => {
+  it("emits the string content, not the [object] placeholder", () => {
+    const src = `export function main(): void {
+      const a = "hello";
+      const b = a + " world";
+      console.log(b);
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = new TextDecoder().decode(runWasiCaptureFd(result.binary, 1));
+    expect(out).toContain("hello world");
+    expect(out).not.toContain("[object]");
+  });
+
+  it("emits a template-literal runtime string (no extern-bridge host imports)", () => {
+    const src = `export function main(): void {
+      const name = "ts2wasm";
+      console.log(\`built with \${name}\`);
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    // The JS-host string-marshal imports must NOT leak under WASI.
+    expect(result.wat).not.toContain("__str_from_mem");
+    expect(result.wat).not.toContain("__str_to_mem");
+    const out = new TextDecoder().decode(runWasiCaptureFd(result.binary, 1));
+    expect(out).toContain("built with ts2wasm");
+  });
+});
+
+describe("#1651 process.stdout.write under --target wasi", () => {
+  it("writes a string to fd=1 with no trailing newline", () => {
+    const src = `declare const process: { stdout: { write(c: Uint8Array | string): void } };
+      export function main(): void {
+        process.stdout.write("AB");
+        process.stdout.write("C");
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    // Exactly the three bytes, contiguous, no "\n".
+    expect(Array.from(out)).toEqual([0x41, 0x42, 0x43]);
+  });
+
+  it("writes a Uint8Array literal (raw bytes incl. non-printable) verbatim", () => {
+    const src = `declare const process: { stdout: { write(c: Uint8Array | string): void } };
+      export function main(): void {
+        process.stdout.write(new Uint8Array([0, 1, 255, 10, 13]));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([0, 1, 255, 10, 13]);
+  });
+
+  it("does not register fd_write for process.stdout.write outside --target wasi", () => {
+    const src = `declare const process: { stdout: { write(c: string): void } };
+      export function main(): void { process.stdout.write("x"); }`;
+    const result = compile(src); // default (gc) target
+    if (result.success) {
+      expect(result.wat).not.toContain("fd_write");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Completes the Chrome Native Messaging host example (#1530): a compiled `--target wasi` module now reads a framed message off stdin and emits a **correctly framed** response — binary 4-byte LE length prefix + JSON body — to stdout, byte-exact.

### #1618 — `console.log` of a runtime string emitted `[object]`
- `emitWasiValueToStdout` (`src/codegen/expressions/builtins.ts`) now has a `ref`/`ref_null` string case that flattens via a new `__wasi_write_any_string` helper and writes the bytes, instead of dropping the value and emitting the `[object]` placeholder.
- The *corrupted mix* (real bytes + placeholder) was a **memory-layout collision**: the stdin read buffer and the string-literal data segments both started at offset 1024, so `fd_read` clobbered initialized literal bytes. WASI memory now reserves 3 pages and isolates the stdin buffer (page 1) and write scratch (page 2) above the page-0 data segments.
- Template literals under WASI were emitting the JS-host string-marshal bridge (`__str_to_extern`/`__str_from_extern`), whose `__str_to_mem`/`__str_from_mem` host imports don't exist under wasi/standalone and collapsed to bogus indices (`call 0` → `fd_write`) — producing an **invalid module for any template literal**. Fixed: a string substitution is already a NativeString, so it concatenates natively with zero marshaling; the bridge is emitted only for non-string (number/bigint/object) spans. `__str_flatten` is also registered in `funcMap` (the shift-maintained map) so internal calls following a late-import addition resolve correctly.

### #1651 — `process.stdout.write` / `process.stderr.write`
- `matchProcessStdStreamWrite` (`src/codegen/expressions/calls.ts`) detects the Node.js API shape and lowers a **string** arg through `__wasi_write_any_string` and a **Uint8Array** literal through the new `__wasi_write_uint8array` helper (raw bytes, no transform, **no trailing newline**).
- `registerWasiImports` recognizes the `process.<stream>.write` callee shape and pulls in `fd_write` (and the stderr path for `process.stderr.write`).
- The example `host.ts` frames its response with `process.stdout.write` (a `Uint8Array` prefix + the JSON body), mirroring the Node.js API of the AssemblyScript reference. README updated — both stdout gaps are closed; it is a drop-in host.

## Test plan

- [x] `tests/issue-1530.test.ts` — byte-exact framed stdin→stdout round-trip (synthetic host + the shipped `host.ts`) via a raw-byte WASI shim
- [x] `tests/issue-1618-1651-wasi-stdout.test.ts` — console.log runtime string + template literal (no host-import leak); `process.stdout.write(str)` no-newline; `Uint8Array` raw bytes incl. non-printable; no `fd_write` outside wasi
- [x] `tests/wasi-stdin.test.ts`, `tests/wasi.test.ts`, `tests/wasi-target.test.ts`, `tests/wasi-clock.test.ts`, `tests/wasi-timers.test.ts` pass
- [x] `npx tsc --noEmit` clean, `npm run lint` clean, `npm run check:ir-fallbacks` OK (no unintended increases)
- [x] Pre-existing failures (`issue-958` `__concat_3`, `wasi-environ` `__extern_get`, `*helpers.js` loads) confirmed identical on base — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related

Delivers the working host requested in GitHub issue #389 ("Implement a Native Messaging host using WASM output by js2wasm"). Intentionally **not** using a `Closes`/`Fixes` keyword — that issue will be closed manually after downstream confirmation, not auto-closed on merge.