### PR TITLE
docs(#1652): fix native-messaging README build command (npx js2wasm → from-source tsx)

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -53,10 +53,15 @@ is the part you'd replace for a real host.
 
 ## Build to `.wasm`
 
+From the repo root (works immediately after `pnpm install`, no build step):
+
 ```bash
 mkdir -p examples/native-messaging/out
-npx js2wasm examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out
 ```
+
+(Once the package is built — `pnpm run build` — or installed from npm, you can
+use the `js2wasm` bin directly: `npx js2wasm host.ts --target wasi -o out`.)
 
 This produces `out/host.wasm`. The module imports only from
 `wasi_snapshot_preview1` (`fd_read`, `fd_write`) — no `env.*` imports — so it

--- a/examples/native-messaging/run.sh
+++ b/examples/native-messaging/run.sh
@@ -14,8 +14,8 @@ DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 WASM="$DIR/out/host.wasm"
 
 if [ ! -f "$WASM" ]; then
-  echo "host.wasm not found at $WASM — build it first:" >&2
-  echo "  npx js2wasm $DIR/host.ts --target wasi -o $DIR/out" >&2
+  echo "host.wasm not found at $WASM — build it first (from the repo root):" >&2
+  echo "  npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out" >&2
   exit 1
 fi
 

--- a/plan/issues/1652-native-messaging-readme-build-command.md
+++ b/plan/issues/1652-native-messaging-readme-build-command.md
@@ -1,0 +1,63 @@
+---
+id: 1652
+title: Fix native-messaging README build command (npx js2wasm not found on fresh clone)
+status: in-review
+priority: low
+task_type: docs
+area: [docs, examples]
+related: [1530, 1590]
+sprint: 55
+---
+
+# Fix native-messaging README build command
+
+## The bug
+
+`examples/native-messaging/README.md` "Build to `.wasm`" section instructed
+the user to run:
+
+```
+npx js2wasm examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out
+```
+
+This FAILS on a fresh clone with `sh: 1: js2wasm: not found`. The package is
+`@loopdive/js2`; its `js2wasm` bin points at `./dist/cli.js`, which does NOT
+exist until `pnpm run build` is run (and even then resolves only via `npm
+link` or an npm publish). A user who just cloned and ran `pnpm install` has no
+`js2wasm` on PATH.
+
+## The fix
+
+The "Build to `.wasm`" block now LEADS with the from-source invocation, which
+works immediately after `pnpm install` with zero build step:
+
+```
+mkdir -p examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out
+```
+
+A short note documents the `js2wasm` bin as the alternative once the package is
+built (`pnpm run build`) or installed from npm. The `run.sh` "build it first"
+error hint carried the same stale `npx js2wasm` command and was fixed to match.
+
+Out of scope (left unchanged): `host.ts`, `manifest.json`, the smoke test, and
+`run.sh`'s `wasmtime` runtime invocation.
+
+## Context
+
+Part of the first-5-min UX thread (#1590) — a fresh-clone user following the
+example README should hit zero "command not found" walls. Related to the IR /
+example-surface work tracked under #1530.
+
+## Test Results
+
+Verified from a fresh worktree after the doc change:
+
+```
+$ mkdir -p examples/native-messaging/out
+$ npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out
+… examples/native-messaging/out/host.wasm  (7438 bytes)
+```
+
+The module compiles and emits `host.wasm` with no build step. The `out/` dir is
+gitignored and not committed.


### PR DESCRIPTION
## Summary
- The native-messaging example README's "Build to `.wasm`" section told users to run `npx js2wasm …`, which fails on a fresh clone with `sh: 1: js2wasm: not found` — the `js2wasm` bin (`@loopdive/js2`) points at `./dist/cli.js`, which only exists after `pnpm run build` + npm link/publish.
- Lead with the from-source invocation `npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out`, which works immediately after `pnpm install` (no build step). Note the built/published `js2wasm` bin as the alternative.
- Fixed the matching stale `npx js2wasm` hint in `run.sh`'s "build it first" error message.
- Out of scope (unchanged): `host.ts`, `manifest.json`, smoke test, `run.sh`'s `wasmtime` runtime line.
- Part of the first-5-min UX thread (#1590).

## Test plan
- [x] `mkdir -p examples/native-messaging/out && npx tsx src/cli.ts examples/native-messaging/host.ts --target wasi -o examples/native-messaging/out` emits `host.wasm` (7438 bytes) on a fresh worktree, no build step.
- [x] `out/` is gitignored — not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)