### PR TITLE
plan(#1653,#1654,#1655): compiler gaps blocking AssemblyScript-reference alignment of the WASI Native Messaging host

### DIFF
--- a/plan/issues/1530-wasi-native-messaging-host-example.md
+++ b/plan/issues/1530-wasi-native-messaging-host-example.md
@@ -185,3 +185,24 @@ once #1617 and #1618 land.
 
 - **#1617** — `plan/issues/1628-wasi-raw-byte-stdout.md` (raw-byte stdout)
 - **#1618** — `plan/issues/1618-wasi-runtime-string-stdout-corrupt.md` (runtime-string corruption bug)
+
+## Aligning with the AssemblyScript reference (follow-ups)
+
+Full convergence on
+[`nm_assemblyscript.ts`](https://github.com/guest271314/native-messaging-webassembly/blob/main/nm_assemblyscript.ts)
+— the binary incremental stdin read, the ArrayBuffer/DataView framing, and
+the continuous `while (true)` port loop — is blocked on three compiler gaps:
+
+- **#1653** — `process.stdin.read(buffer, offset?)`: binary incremental stdin
+  read into a typed buffer (keystone; unlocks both the read side and the
+  continuous-loop design). Depends on #1654.
+- **#1654** — DataView/ArrayBuffer-backed TypedArrays emit an **invalid wasm
+  module** under `--target wasi` (the dual-mode heap/memory-global gap).
+- **#1655** — `process.stdout.write(ArrayBuffer)`: accept an `ArrayBuffer`
+  (and non-literal `Uint8Array`/`.subarray`) argument, not only a
+  `Uint8Array` literal. Depends on #1654.
+
+Until those land, `examples/native-messaging/host.ts` **deliberately** uses
+the string-based `readStdin()` (#1481) for input and the `Uint8Array`-literal
+`process.stdout.write` (#1651) for the length prefix — the working subset the
+current compiler supports. `host.ts` is intentionally left unchanged.

--- a/plan/issues/1653-wasi-process-stdin-read-binary.md
+++ b/plan/issues/1653-wasi-process-stdin-read-binary.md
@@ -1,0 +1,86 @@
+---
+id: 1653
+title: "wasi: process.stdin.read(buffer, offset?) — binary incremental stdin read into a typed buffer"
+status: backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: wasi, codegen, runtime
+language_feature: stdin, process, arraybuffer
+goal: wasi-completeness
+sprint: Backlog
+depends_on: [1654]
+related: [1530, 1481, 1651, 1654]
+---
+
+## Problem
+
+The AssemblyScript reference host
+([`nm_assemblyscript.ts`](https://github.com/guest271314/native-messaging-webassembly/blob/main/nm_assemblyscript.ts))
+reads the Native Messaging stream in two precise steps inside a long-lived
+`while (true)` port loop:
+
+1. Read the **4-byte LE length header** — exactly 4 bytes.
+2. Read **exactly N body bytes** — where N is decoded from the header.
+
+It does this via `process.stdin.read(arrayBuffer)` /
+`process.stdin.read(buffer, offset)`, which **returns the number of bytes
+read** and fills a caller-supplied typed buffer.
+
+js2wasm only has `readStdin()` (#1481). That builtin:
+
+- **drains fd=0 to EOF** — it cannot read a fixed byte count;
+- **cannot read incrementally** — once it hits EOF the loop is over, so a
+  continuous request/response port loop is impossible;
+- **returns a STRING** — UTF-8 decoded, so binary fidelity is lost (the
+  4-byte LE header and any binary body get mangled).
+
+This means js2wasm can neither read a framed message the way the reference
+does, nor sustain the reference's continuous-loop design.
+
+## Proposed implementation
+
+Add a `process.stdin.read` builtin, recognised under `--target wasi`:
+
+```typescript
+process.stdin.read(buf: ArrayBuffer | Uint8Array, offset?: number): number
+```
+
+- Lowers to `fd_read(0, iov, 1, nread)` where the single `iov` points at the
+  backing bytes of `buf` starting at `offset` (default 0), with `iov.len`
+  equal to the remaining writable capacity of `buf` from `offset`.
+- Returns `nread` (bytes actually read), so the caller can loop until it has
+  the exact count it needs — matching the AssemblyScript reference's
+  read-header-then-read-body pattern.
+- Reads are incremental: each call advances fd=0's cursor, so a
+  `while (true)` port loop can read header + body, respond, and read again.
+
+This is the **keystone** issue: it unlocks BOTH the reference's read side
+*and* its continuous-loop design. With only `readStdin()` neither is
+expressible.
+
+## Dependencies
+
+Depends on **#1654** — the buffer this builtin reads into is an
+`ArrayBuffer`/typed buffer, which currently produces an **invalid wasm
+module under `--target wasi`** (the dual-mode heap/memory-global gap). The
+backing-buffer story must work standalone first, or be co-designed with
+this issue. Without a valid standalone `ArrayBuffer`, there is nowhere for
+`fd_read` to write the bytes.
+
+## Acceptance criteria
+
+- `process.stdin.read(buf, offset?)` compiles under `--target wasi` and
+  produces a module wasmtime accepts.
+- Reading the 4-byte LE header: a call with a 4-byte buffer returns `4` and
+  the buffer holds the exact header bytes (no UTF-8 mangling).
+- Reading the body: a subsequent call with an N-byte buffer returns the body
+  bytes verbatim.
+- A `while (true)` loop reading header then body, framing a response, and
+  reading again works for at least two consecutive messages under wasmtime.
+- The Native Messaging host (`examples/native-messaging/host.ts`) can adopt
+  the binary read path (the string-based `readStdin()` workaround can be
+  retired once this + #1654 + #1655 land — tracked in #1530).

--- a/plan/issues/1654-wasi-dataview-arraybuffer-invalid-module.md
+++ b/plan/issues/1654-wasi-dataview-arraybuffer-invalid-module.md
@@ -1,0 +1,78 @@
+---
+id: 1654
+title: "wasi: DataView/ArrayBuffer-backed TypedArrays emit an invalid wasm module under --target wasi"
+status: backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: wasi, codegen
+language_feature: arraybuffer, dataview, typedarray
+goal: wasi-completeness
+sprint: Backlog
+related: [1530, 1651, 1653]
+---
+
+## Problem
+
+Under `--target wasi`, code using `new ArrayBuffer(n)` +
+`DataView.setUint32/getUint32(…, true)` + `new Uint8Array(arrayBuffer)`
+**COMPILES** but produces an **INVALID module**. wasmtime rejects it at
+instantiation/compile time:
+
+```
+Error: failed to compile: wasm[0]::function[N]::main
+  Invalid input WebAssembly code: unknown global: global index out of bounds
+```
+
+## Minimal repro (verified)
+
+Compile with `npx tsx src/cli.ts repro.ts --target wasi -o out`, then run the
+emitted module under wasmtime:
+
+```ts
+declare const process: { stdout: { write(c: Uint8Array): void } };
+export function main(): void {
+  const header = new ArrayBuffer(4);
+  const dv = new DataView(header);
+  dv.setUint32(0, 11, true);
+  process.stdout.write(new Uint8Array(header));
+}
+```
+
+The compile step succeeds; wasmtime rejects the resulting binary with the
+`unknown global: global index out of bounds` error above.
+
+## Likely cause
+
+The ArrayBuffer/DataView/TypedArray codegen references a heap or memory
+global that is only emitted in **JS-host mode**, not in **standalone/WASI
+mode**. This is the dual-mode gap described under "Architecture Principles"
+in `CLAUDE.md`: features need a Wasm-native implementation for standalone
+mode, but the ArrayBuffer/DataView path appears to assume the JS-host heap
+global is always present.
+
+This is **broader than the Native Messaging example**: any binary-buffer
+code (ArrayBuffer / DataView / ArrayBuffer-backed TypedArray) is affected
+under `--target wasi`.
+
+## Contrast — what does work
+
+`new Uint8Array([b0, b1, b2, b3])` (the literal-array constructor form,
+delivered in #1651) **DOES work** under `--target wasi`. Only the
+**ArrayBuffer/DataView-backed** path is broken. So the regression surface is
+specifically the ArrayBuffer-backing global, not TypedArrays in general.
+
+## Acceptance criteria
+
+- The minimal repro above compiles AND the emitted module is accepted by
+  wasmtime (no `unknown global` error).
+- `DataView.setUint32(0, v, true)` / `getUint32(0, true)` round-trip correctly
+  under wasmtime in standalone/WASI mode.
+- `new Uint8Array(arrayBuffer)` produces a view whose bytes match what was
+  written through the `DataView`.
+- A test (e.g. `tests/issue-1654-*.test.ts`) pins compile + WASI-module
+  validity + a byte round-trip for the ArrayBuffer/DataView path.
+- No regression to the literal-array `new Uint8Array([...])` path (#1651).

--- a/plan/issues/1655-wasi-process-stdout-write-arraybuffer.md
+++ b/plan/issues/1655-wasi-process-stdout-write-arraybuffer.md
@@ -1,0 +1,61 @@
+---
+id: 1655
+title: "wasi: process.stdout.write(ArrayBuffer) — accept ArrayBuffer arg, not only Uint8Array literal"
+status: backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: feature
+area: wasi, codegen
+language_feature: stdout, process, arraybuffer
+goal: wasi-completeness
+sprint: Backlog
+depends_on: [1654]
+related: [1651, 1653, 1654]
+---
+
+## Problem
+
+#1651 added `process.stdout.write(str)` and
+`process.stdout.write(new Uint8Array([…literal…]))` under `--target wasi`.
+
+The AssemblyScript reference host
+([`nm_assemblyscript.ts`](https://github.com/guest271314/native-messaging-webassembly/blob/main/nm_assemblyscript.ts))
+writes its framed response with `process.stdout.write(arrayBuffer)` (and via
+`Uint8Array.buffer`). js2wasm's WASI `process.stdout.write` lowering does not
+accept a bare `ArrayBuffer`, nor a non-literal `Uint8Array` / `.subarray`
+view — only the literal-array `Uint8Array` form.
+
+## Proposed implementation
+
+Extend the WASI `process.stdout.write` lowering (in
+`src/codegen/expressions/calls.ts`, alongside the #1651 matching) to accept:
+
+- an `ArrayBuffer` argument — copy its backing bytes to the page-2 write
+  scratch region and issue one `fd_write`;
+- a non-literal `Uint8Array` and `.subarray(...)` view — same copy-to-scratch
+  + single `fd_write`, honouring the view's `byteOffset`/`length`.
+
+Raw bytes verbatim, no transform, no trailing newline — same contract as the
+#1651 `Uint8Array`-literal path.
+
+## Dependencies
+
+Depends on **#1654** — `ArrayBuffer` must produce a valid standalone/WASI
+module before its bytes can be written. Until #1654 lands, an `ArrayBuffer`
+argument can't even be constructed validly under `--target wasi`.
+
+## Acceptance criteria
+
+- `process.stdout.write(arrayBuffer)` compiles under `--target wasi` and emits
+  exactly the buffer's bytes (no newline, no transform) under wasmtime.
+- `process.stdout.write(uint8.subarray(a, b))` emits exactly `b - a` bytes from
+  the correct offset.
+- A non-literal `Uint8Array` (e.g. `new Uint8Array(arrayBuffer)`) writes its
+  bytes verbatim.
+- No regression to the #1651 string / `Uint8Array`-literal paths.
+- The Native Messaging host can frame its response via
+  `process.stdout.write(arrayBuffer)`, matching the reference (retirement of
+  the literal workaround tracked in #1530).

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -18,6 +18,16 @@ already enumerated in #1522 / #1543 / #1556 are not re-filed.
 - [#1595](1595-arraybuffer-transfer-methods-not-implemented.md) — ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable not implemented — **~40 fails**, medium
 - [#1596](1596-function-prototype-apply-call-not-accessible.md) — Function.prototype.apply / .call not accessible on compiled Wasm functions — **~46 fails**, high
 
+## WASI Native Messaging — AssemblyScript-reference alignment (2026-05-24)
+
+Compiler gaps blocking full convergence of `examples/native-messaging/host.ts`
+(#1530) on the reference `nm_assemblyscript.ts`. #1654 is the root (unblocks
+both others); #1653 is the keystone for the read side + continuous loop.
+
+- [#1654](../1654-wasi-dataview-arraybuffer-invalid-module.md) — DataView/ArrayBuffer-backed TypedArrays emit an invalid wasm module under `--target wasi` — high, medium, **root (ready)**
+- [#1653](../1653-wasi-process-stdin-read-binary.md) — `process.stdin.read(buffer, offset?)` binary incremental stdin read (keystone) — high, hard, **depends on #1654**
+- [#1655](../1655-wasi-process-stdout-write-arraybuffer.md) — `process.stdout.write(ArrayBuffer)` accept ArrayBuffer arg, not only Uint8Array literal — medium, easy, **depends on #1654**
+
 ## Spec-compliance easy wins (from #1563 gap analysis, 2026-05-21)
 
 - [#1564](1564-toNumeric-symbol-throws-typeError.md) — ToNumeric: Symbol argument must throw TypeError (§7.1.3 step 3) — ~12 fails, easy

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -28,6 +28,23 @@ Pulled into S50 alongside the original closure/dispatch cohort. Direct-dispatch 
 - File icons show which codegen file is primarily touched:
   `[E]` = expressions.ts, `[S]` = statements.ts, `[I]` = index.ts, `[T]` = test262-runner.ts
 
+## WASI Native Messaging — AssemblyScript-reference alignment (added 2026-05-24)
+
+Compiler gaps blocking full convergence of `examples/native-messaging/host.ts`
+(#1530) on the AssemblyScript reference `nm_assemblyscript.ts`.
+
+| #    | Title | Priority | Feasibility | Status |
+|------|-------|----------|-------------|--------|
+| 1654 | DataView/ArrayBuffer-backed TypedArrays emit an invalid wasm module under --target wasi | high | medium | **Ready** (root) |
+| 1653 | process.stdin.read(buffer, offset?) — binary incremental stdin read (keystone) | high | hard | Blocked by #1654 |
+| 1655 | process.stdout.write(ArrayBuffer) — accept ArrayBuffer arg, not only Uint8Array literal | medium | easy | Blocked by #1654 |
+
+```
+#1654 (ArrayBuffer/DataView valid standalone) -- root, unblocks both
+  ├── #1653 (binary stdin read) -- keystone
+  └── #1655 (stdout write ArrayBuffer)
+```
+
 ---
 
 ## TOP PRIORITY: Highest-impact runtime failures `[E][S][I]`


### PR DESCRIPTION
## Summary

Files three backlog issues capturing the compiler gaps that block aligning the WASI Native Messaging example (`examples/native-messaging/host.ts`, #1530) with the AssemblyScript reference host (`nm_assemblyscript.ts`):

- **#1654** (root, bug, high/medium) — DataView/ArrayBuffer-backed TypedArrays emit an **invalid wasm module** under `--target wasi` (dual-mode heap/memory-global gap). Embedded verified repro. Unblocks the other two.
- **#1653** (keystone, feature, high/hard) — `process.stdin.read(buffer, offset?)`: binary incremental stdin read into a typed buffer. Unlocks both the reference's read side and its continuous `while(true)` port loop. Depends on #1654.
- **#1655** (feature, medium/easy) — `process.stdout.write(ArrayBuffer)`: accept an `ArrayBuffer` (and non-literal `Uint8Array`/`.subarray`) arg, not only the `Uint8Array`-literal form. Depends on #1654.

Also adds an "Aligning with the AssemblyScript reference (follow-ups)" note to #1530, and lists the three issues in the dependency graph + backlog (1653/1655 depend-on 1654).

`host.ts` is intentionally left unchanged — it deliberately uses string-based `readStdin()` + Uint8Array-literal stdout until these land.

## Scope

Plan files only (`plan/issues/`, `plan/log/dependency-graph.md`, `plan/issues/backlog/backlog.md`). No source changes. No GitHub issues created.

## Test plan

- [ ] CI green (plan-only change; no code paths touched)