### PR TITLE
ci(#1657): skip merge_group test262 shards for non-src changes (keep required check green)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -138,6 +138,112 @@ jobs:
           if [ "$tc_rc" -ne 0 ]; then echo "::error::typecheck failed (rc=$tc_rc)"; exit "$tc_rc"; fi
           if [ "$lint_rc" -ne 0 ]; then echo "::warning::lint failed (rc=$lint_rc) — not blocking"; fi
 
+  changes:
+    # merge_group has no native `paths:` filter (unlike pull_request/push
+    # above), so a website/plan/doc-only PR entering the queue would otherwise
+    # run the full ~1.5h 32-shard matrix for nothing. This job diffs the
+    # queued group's base..head and decides whether any test262-relevant path
+    # changed, exposing `run_shards=true|false`.
+    #
+    # CONSERVATIVE FAIL-SAFE: if base_sha is missing/empty, the diff fails, or
+    # detection is in any way uncertain → `run_shards=true` (run test262). We
+    # only emit `false` when we POSITIVELY confirm zero test262-relevant paths
+    # changed. A false positive (running shards we didn't need) costs CI time;
+    # a false negative (skipping shards we needed) lets a real regression
+    # through — so we bias hard toward running.
+    #
+    # Only meaningful on merge_group. On pull_request/push the native `paths:`
+    # filter already gates the whole workflow, and on workflow_dispatch we
+    # always want shards — so this job emits `true` for every non-merge_group
+    # event and the shard `if:` keeps its existing arms for those.
+    name: detect test262-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.actor != 'github-actions[bot]')
+    outputs:
+      run_shards: ${{ steps.detect.outputs.run_shards }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Detect test262-relevant changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -uo pipefail
+          # Non-merge_group events keep the old behaviour: the workflow-level
+          # `paths:` filter (PR/push) or unconditional intent (dispatch) already
+          # decided we should run, so emit true and let the shard `if:` arms
+          # handle gating per event_name.
+          if [ "$EVENT_NAME" != "merge_group" ]; then
+            echo "Non-merge_group event ($EVENT_NAME): run_shards=true (native paths filter / dispatch governs)."
+            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # --- merge_group: diff base..head ourselves ---
+          if [ -z "${MG_BASE_SHA:-}" ] || [ -z "${MG_HEAD_SHA:-}" ]; then
+            echo "::warning::merge_group base/head sha missing (base='${MG_BASE_SHA:-}' head='${MG_HEAD_SHA:-}') — FAIL-SAFE run_shards=true."
+            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Make sure both commits are present (fetch-depth:0 should cover it,
+          # but the merge_group head may be a freshly-built ref).
+          git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || git fetch --no-tags origin "$MG_BASE_SHA" 2>/dev/null || true
+          git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || git fetch --no-tags origin "$MG_HEAD_SHA" 2>/dev/null || true
+
+          set +e
+          DIFF=$(git diff --name-only "$MG_BASE_SHA" "$MG_HEAD_SHA" 2>/tmp/diff_err)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::git diff $MG_BASE_SHA..$MG_HEAD_SHA failed (rc=$rc): $(cat /tmp/diff_err) — FAIL-SAFE run_shards=true."
+            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed paths in queued group:"
+          echo "$DIFF" | sed 's/^/  /'
+
+          # Empty diff is suspicious (a no-op merge shouldn't be queued); be
+          # conservative and run.
+          if [ -z "$DIFF" ]; then
+            echo "::warning::Empty diff for merge_group $MG_BASE_SHA..$MG_HEAD_SHA — FAIL-SAFE run_shards=true."
+            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RESULT=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh)
+          echo "test262-paths-match → run_shards=$RESULT"
+          echo "run_shards=$RESULT" >> "$GITHUB_OUTPUT"
+
+  # =====================================================================
+  # merge_group gating truth table (the other event_names are governed by
+  # the workflow-level `paths:` filter + the per-job `if:` arms below):
+  #
+  #   queued change          changes.run_shards   test262-shard   merge-report
+  #   ---------------------  ------------------   -------------   -------------------
+  #   src/** (or any         true                 RUNS (matrix)   runs, real result
+  #     &test262-paths)
+  #   website/plan/doc-only  false                SKIPPED         runs, trivial PASS
+  #   base_sha empty /       true (fail-safe)     RUNS (matrix)   runs, real result
+  #     diff fails / empty
+  #
+  # In ALL three rows the required check "merge shard reports" is produced
+  # green — that is the invariant that keeps the PR mergeable (see the trap
+  # documented in test262-pr-stub.yml). The only thing that varies is whether
+  # the heavy matrix actually executed.
+  # =====================================================================
+
   test262-shard:
     # Heavy 16-shard test262 fires on all gate-relevant events:
     #   pull_request → per-PR validation (serial queue model — each PR is
@@ -149,10 +255,18 @@ jobs:
     # regression-gate reports per-test transitions; bad PRs bounce back to
     # their authors with actionable feedback rather than slipping into a
     # batch.
+    #
+    # merge_group arm now also requires `needs.changes.outputs.run_shards`
+    # to be 'true' — the `changes` job skips the heavy matrix for queued
+    # website/plan/doc-only changes (and fails safe to 'true' on any doubt,
+    # see that job). The other arms are unchanged: pull_request/push are
+    # already gated by the workflow-level `paths:` filter, and
+    # workflow_dispatch always runs.
+    needs: [changes]
     if: |
       (github.event_name == 'push' && github.actor != 'github-actions[bot]') ||
       (github.event_name == 'pull_request' && github.actor != 'github-actions[bot]') ||
-      github.event_name == 'merge_group' ||
+      (github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'true') ||
       github.event_name == 'workflow_dispatch'
     # Runs in PARALLEL with `gate` — both are independently required by the
     # ruleset (`cheap gate (main-ancestor + lint)` and `merge shard reports`),
@@ -268,32 +382,64 @@ jobs:
     # for all gate-relevant contexts. Serial-queue model: this is the same
     # job whether the trigger is pull_request (PR-level validation) or
     # merge_group (final pre-merge validation).
+    # CRITICAL — this job produces the required check "merge shard reports".
+    # It MUST run and report green in BOTH of these cases, or the PR is
+    # permanently BLOCKED (the cascade-skip trap documented in
+    # test262-pr-stub.yml):
+    #   (a) shards ran and succeeded                        → real merged report
+    #   (b) shards were intentionally skipped on merge_group
+    #       because run_shards=='false' (no test262-relevant
+    #       change in the queue)                            → trivial PASS
+    # `needs.test262-shard.result` is 'skipped' in case (b), so we cannot
+    # gate solely on it; we OR-in the run_shards=='false' branch. Steps that
+    # touch shard artifacts are themselves guarded by `SHARDS_RAN` so the
+    # skip path short-circuits to a clean exit 0 (see the per-step `if:`).
     if: |
       always() &&
       (github.event_name != 'push' || github.actor != 'github-actions[bot]') &&
-      needs.test262-shard.result == 'success'
+      (needs.test262-shard.result == 'success' ||
+       (github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'false'))
     name: merge shard reports
-    needs: [test262-shard]
+    needs: [changes, test262-shard]
     runs-on: ubuntu-latest
+    env:
+      # 'true' when the heavy matrix actually executed and produced artifacts;
+      # 'false' on the merge_group skip path (no test262-relevant change).
+      SHARDS_RAN: ${{ needs.test262-shard.result == 'success' && 'true' || 'false' }}
 
     steps:
+      - name: No-op pass (shards skipped — no test262-relevant changes)
+        if: env.SHARDS_RAN != 'true'
+        run: |
+          echo "→ merge_group queued only non-test262-relevant changes"
+          echo "  (changes.run_shards=='false'); the heavy 32-shard matrix was"
+          echo "  skipped. Reporting 'merge shard reports' green so the required"
+          echo "  check exists and the PR stays mergeable."
+          echo "→ A src/** (or any &test262-paths) change in the queue would"
+          echo "  have run the full matrix and produced a real merged report."
+
       - name: Checkout
+        if: env.SHARDS_RAN == 'true'
         uses: actions/checkout@v5
 
       - name: Setup Node
+        if: env.SHARDS_RAN == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 25
 
       - name: Setup pnpm via Corepack
+        if: env.SHARDS_RAN == 'true'
         run: |
           corepack enable
           corepack prepare pnpm@10.30.2 --activate
 
       - name: Install dependencies
+        if: env.SHARDS_RAN == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download shard artifacts
+        if: env.SHARDS_RAN == 'true'
         uses: actions/download-artifact@v7
         with:
           path: shard-artifacts
@@ -301,12 +447,14 @@ jobs:
           merge-multiple: false
 
       - name: Merge test262 JSONL results
+        if: env.SHARDS_RAN == 'true'
         run: |
           mkdir -p merged-reports
           find shard-artifacts -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-results-merged.jsonl
           test -s merged-reports/test262-results-merged.jsonl
 
       - name: Build merged test262 report
+        if: env.SHARDS_RAN == 'true'
         run: |
           node scripts/build-test262-report.mjs \
             --input merged-reports/test262-results-merged.jsonl \
@@ -316,7 +464,7 @@ jobs:
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}
 
       - name: Upload merged reports
-        if: always()
+        if: always() && env.SHARDS_RAN == 'true'
         uses: actions/upload-artifact@v6
         with:
           retention-days: 1
@@ -328,9 +476,18 @@ jobs:
   regression-gate:
     # Runs after merge-report in all non-bot push contexts (merge_group / manual
     # push / workflow_dispatch). Compares branch report against baseline.
-    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
+    #
+    # Skips cleanly on the merge_group no-shards path (run_shards=='false'):
+    # there is no merged report to diff, and a non-test262-relevant change
+    # cannot cause a conformance regression by definition. regression-gate is
+    # NOT a required check, so a `skipped` result here is harmless. We also
+    # add `changes` to `needs` and require shards to have actually run so the
+    # download/diff steps never look for an artifact that wasn't produced.
+    if: |
+      (github.event_name != 'push' || github.actor != 'github-actions[bot]') &&
+      needs.test262-shard.result == 'success'
     name: check for test262 regressions
-    needs: [merge-report]
+    needs: [changes, test262-shard, merge-report]
     runs-on: ubuntu-latest
 
     steps:

--- a/plan/issues/1657-mq-test262-paths-filter.md
+++ b/plan/issues/1657-mq-test262-paths-filter.md
@@ -1,0 +1,112 @@
+---
+id: 1657
+title: "Skip merge_group test262 shards for non-src changes (keep required check green)"
+status: in-review
+sprint: 55
+created: 2026-05-24
+updated: 2026-05-24
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: ci
+area: ci, test262
+related: [1656]
+---
+
+# Skip merge_group test262 shards for non-src changes
+
+## Problem / goal
+
+The merge queue runs the full ~1.5h, 32-shard `test262-sharded.yml` matrix on
+**every** queued PR — including website-only, plan-only, and docs-only PRs that
+cannot possibly affect test262 conformance. The `pull_request` and `push`
+triggers already have a `paths:` allowlist (the `&test262-paths` anchor:
+`src/**`, `package.json`, lockfile, tsconfigs, `vitest.config.ts`, the test262
+scripts/tests, and the workflow file itself), so PR-time is already filtered.
+But the `merge_group` trigger has **no native `paths:` filter**, so every
+queued change pays for the whole matrix.
+
+Goal: make the `merge_group` run skip the heavy shards when no test262-relevant
+path changed, while never breaking the branch-protection required checks.
+
+## The trap (why this is not a one-line `paths:` add)
+
+`merge_group` events do not support `paths:`. The naive fix — cascade-skipping
+`test262-shard` — triggers the **cascade-skip trap** already documented in
+`.github/workflows/test262-pr-stub.yml`:
+
+- `merge-report` (the required check **"merge shard reports"**) has
+  `needs: [test262-shard]`.
+- If `test262-shard` is **skipped**, GitHub's `needs:` semantics treat skipped
+  as not-success, so `merge-report` cascade-skips too.
+- The required check **"merge shard reports"** is then **never produced**, and
+  under the strict required-checks ruleset the PR becomes permanently
+  **BLOCKED** (`mergeStateStatus: BLOCKED, checks_summary: []`).
+
+So the skip must be **selective on the shards** while the required check name
+is **always produced green**.
+
+## Design — conservative path detector + always-green required check
+
+1. **`scripts/test262-paths-match.sh`** — single source of truth that mirrors
+   the `&test262-paths` allowlist. Reads changed paths on stdin, prints
+   `true` if any path is test262-relevant, else `false`. (Must be kept in sync
+   with the workflow's `paths:` anchor — a comment in both points at the other.)
+
+2. **`changes` job** (merge_group, ~10s) — diffs
+   `github.event.merge_group.base_sha .. github.event.merge_group.head_sha`
+   and pipes the file list through the matcher, exposing
+   `run_shards=true|false`. **Conservative fail-safe**: missing/empty base_sha,
+   a failed diff, or an empty diff all emit `run_shards=true` (run test262).
+   `false` is only emitted when zero test262-relevant paths are positively
+   confirmed. Non-merge_group events always emit `true` (their native `paths:`
+   filter / dispatch intent already governs).
+
+3. **`test262-shard`** — `needs: [changes]`; the merge_group arm of its `if:`
+   now also requires `needs.changes.outputs.run_shards == 'true'`. Other arms
+   (pull_request / push / workflow_dispatch) unchanged.
+
+4. **`merge-report`** — `needs: [changes, test262-shard]`, `if:` extended to run
+   when shards succeeded **or** when `merge_group && run_shards=='false'`. A
+   job-level `SHARDS_RAN` env (`'true'` iff shards succeeded) guards every
+   artifact-touching step; on the skip path a single no-op step echoes the
+   reason and exits 0, so the required check **"merge shard reports"** is still
+   reported **green**.
+
+5. **`regression-gate`** — `needs: [changes, test262-shard, merge-report]`, only
+   runs when `test262-shard.result == 'success'`. On the skip path it cleanly
+   `skipped`s (it is not a required check and a non-test262 change cannot cause
+   a conformance regression by definition), so it never blocks.
+
+Required-check **names are unchanged** (`cheap gate (main-ancestor + lint)`,
+`merge shard reports`). The PR-time stub (`test262-pr-stub.yml`) is untouched.
+
+## merge_group gating truth table
+
+| queued change | `run_shards` | `test262-shard` | `merge-report` ("merge shard reports") |
+|---|---|---|---|
+| `src/**` / any `&test262-paths` | `true` | RUNS (matrix) | runs, real merged report → green |
+| website / plan / docs only | `false` | SKIPPED | runs no-op step → green |
+| base_sha empty / diff fails / empty diff | `true` (fail-safe) | RUNS (matrix) | runs, real merged report → green |
+
+The invariant across all rows: **"merge shard reports" is produced green**, so
+the PR is never wedged BLOCKED.
+
+## Acceptance criteria
+
+- A `src/**` (or any `&test262-paths`) change in the merge queue still runs the
+  full shards + regression gate.
+- A website/plan/docs-only change in the merge queue skips the shards yet still
+  produces a green **"merge shard reports"** required check (PR stays mergeable).
+- Missing/empty `base_sha`, a failed diff, or an empty diff all fall back to
+  running the full shards (fail safe = run).
+- Required-check names unchanged; PR-time stub behaviour unchanged.
+- This PR itself touches `.github/workflows/test262-sharded.yml` (in the
+  `&test262-paths` list), so it correctly runs full test262 at PR-time and in
+  the queue — proving the src/workflow path still triggers shards.
+
+## Files
+
+- `scripts/test262-paths-match.sh` (new) — path matcher, single source of truth.
+- `.github/workflows/test262-sharded.yml` — `changes` job; gated `test262-shard`,
+  `merge-report`, `regression-gate`; embedded truth-table comment.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -21,6 +21,7 @@ already enumerated in #1522 / #1543 / #1556 are not re-filed.
 ## Sprint 55 — repo structure / website (2026-05-24)
 
 - [#1656](../1656-group-website-files-into-website-dir.md) — Consolidate all website/frontend files under `website/` (components, dashboard, playground, index.html, public, frame-nav-sync.js, images, vite.config.ts, CNAME) — medium, medium, **ready (sprint 55)**. Needs architect spec (`arch(#1656)`) before dev; lands as one PR. Related: #1583, #1590.
+- [#1657](../1657-mq-test262-paths-filter.md) — Skip `merge_group` test262 shards for non-src changes while keeping the "merge shard reports" required check green — medium, medium, **in-review (sprint 55)**. Conservative path detector (`scripts/test262-paths-match.sh`) + `changes` job gate the queue's shard matrix; fail-safe runs shards on any doubt. Related: #1656.
 
 ## WASI Native Messaging — AssemblyScript-reference alignment (2026-05-24)
 

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -50,6 +50,7 @@ Compiler gaps blocking full convergence of `examples/native-messaging/host.ts`
 | #    | Title | Priority | Feasibility | Status |
 |------|-------|----------|-------------|--------|
 | 1656 | Consolidate all website/frontend files under website/ | medium | medium | **Ready** — needs architect spec (`arch(#1656)`) before dev; one PR. Related: #1583, #1590 |
+| 1657 | Skip merge_group test262 shards for non-src changes (keep required check green) | medium | medium | **In review** — `changes` job + conservative path detector gates the merge_group shard matrix; "merge shard reports" always green. Related: #1656 |
 
 ---
 

--- a/scripts/test262-paths-match.sh
+++ b/scripts/test262-paths-match.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# test262-paths-match.sh — decide whether a set of changed paths touches any
+# test262-relevant path.
+#
+# Reads NUL- or newline-separated changed paths on stdin (one per line).
+# Prints "true" to stdout if ANY changed path matches the test262-relevant
+# path set, "false" otherwise. Always exits 0 (the caller reads stdout).
+#
+# This is the single source of truth for "does this change affect test262
+# conformance?". It MUST stay in sync with the `&test262-paths` allowlist in
+# .github/workflows/test262-sharded.yml (the pull_request/push paths filter).
+# If you add a path there, add the matching pattern here.
+#
+# Used by the `changes` job in test262-sharded.yml to gate the merge_group
+# shard matrix: GitHub's merge_group event has no native `paths:` filter, so
+# we diff base_sha..head_sha ourselves and pipe the file list through here.
+#
+# Fail-safe: this script only decides false vs true on the path patterns. The
+# CALLER is responsible for the conservative default (emit "true" when the
+# diff itself failed or base_sha is empty). This script, given an EMPTY input
+# (no changed paths detected), prints "false" — so the caller must guarantee
+# it only reaches here with a real, non-empty, trustworthy diff.
+
+set -euo pipefail
+
+# Glob patterns (bash extglob / `case`) mirroring &test262-paths. `**` is
+# emulated by matching the prefix; `case` globbing is non-recursive so we
+# match `src/*` as "anything under src/" via the `src/*` pattern (a path like
+# `src/a/b.ts` matches `src/*` in bash `case` because `*` spans slashes).
+matches_test262_path() {
+  local p="$1"
+  case "$p" in
+    .github/workflows/test262-sharded.yml) return 0 ;;
+    package.json) return 0 ;;
+    pnpm-lock.yaml) return 0 ;;
+    tsconfig.json) return 0 ;;
+    scripts/tsconfig.json) return 0 ;;
+    vitest.config.ts) return 0 ;;
+    src/*) return 0 ;;
+    scripts/build-test262-report.mjs) return 0 ;;
+    scripts/compiler-fork-worker.mjs) return 0 ;;
+    scripts/compiler-pool.ts) return 0 ;;
+    scripts/diff-test262.ts) return 0 ;;
+    scripts/generate-editions.ts) return 0 ;;
+    scripts/test262-worker.mjs) return 0 ;;
+    tests/test262-chunk*.test.ts) return 0 ;;
+    tests/test262-runner.ts) return 0 ;;
+    tests/test262-scope-classification.test.ts) return 0 ;;
+    tests/test262-shared.ts) return 0 ;;
+    # The path matcher itself affects gating logic — treat as relevant so a
+    # change to the matcher always re-runs the full suite (fail-safe).
+    scripts/test262-paths-match.sh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+result="false"
+while IFS= read -r line || [ -n "$line" ]; do
+  # Tolerate trailing CR and skip blank lines.
+  line="${line%$'\r'}"
+  [ -z "$line" ] && continue
+  if matches_test262_path "$line"; then
+    result="true"
+    break
+  fi
+done
+
+printf '%s\n' "$result"


### PR DESCRIPTION
## Summary

The merge queue runs the full ~1.5h, 32-shard `test262-sharded.yml` matrix on **every** queued PR. `pull_request`/`push` already have the `&test262-paths` allowlist, but `merge_group` has **no native `paths:` filter**, so website/plan/docs-only PRs pay for the whole matrix for nothing.

This adds a cheap `changes` job that diffs the queued group's `base_sha..head_sha` and gates the shard matrix on a test262-relevant path detector — **without** tripping the cascade-skip BLOCKED trap (the required check is always produced green).

## Changes

- **`scripts/test262-paths-match.sh`** (new) — single source of truth mirroring the `&test262-paths` allowlist. Reads changed paths on stdin, prints `true`/`false`.
- **`changes` job** (merge_group, ~10s) — diffs `github.event.merge_group.base_sha .. head_sha`, pipes through the matcher, exposes `run_shards`.
- **`test262-shard`** — `needs: [changes]`; merge_group arm now requires `run_shards == 'true'`. Other arms unchanged.
- **`merge-report`** — runs on shard-success **or** the merge_group skip path; `SHARDS_RAN` env guards every artifact step; no-op step keeps **"merge shard reports"** green.
- **`regression-gate`** — skips cleanly on the no-shards path (not a required check).
- Embedded truth-table comment in the workflow; tracking issue + dep-graph + backlog updated.

## merge_group gating truth table (walked)

| queued change | `run_shards` | `test262-shard` | "merge shard reports" |
|---|---|---|---|
| **src change** (`src/**` / any `&test262-paths`) | `true` | **RUNS** (full matrix) → regression gate runs | real merged report → **green** |
| **website/plan/docs-only** | `false` | **SKIPPED** | no-op step → **green** |
| **base_sha empty / diff fails / empty diff** | `true` (fail-safe) | **RUNS** (full matrix) | real merged report → **green** |

Invariant: the required check **"merge shard reports"** is produced **green** in all three rows, so the PR is never wedged `BLOCKED`. A real shard failure (`run_shards=='true'` + shard fails) correctly leaves the check **not green** → PR blocks, as today.

## Conservative fail-safe

`false` is emitted only when zero test262-relevant paths are positively confirmed. Missing/empty `base_sha`, a failed `git diff`, or an empty diff all emit `run_shards=true` (run test262). Non-merge_group events always emit `true` (their native `paths:` filter / dispatch intent governs).

## This PR proves the src/workflow path still triggers shards

This PR touches `.github/workflows/test262-sharded.yml`, which **is** in the `&test262-paths` list — so it correctly runs the full test262 at PR-time and in the merge queue. That is expected and validates the "src change → shards run" row above.

## Test plan
- [ ] YAML parses (validated locally: all 17 workflows load via js-yaml).
- [ ] `scripts/test262-paths-match.sh` truth table validated locally (src/nested-src/exact-filenames → true; docs/plan/website/unrelated-scripts → false; CRLF tolerated; empty input → false; self-reference → true).
- [ ] CI: this PR runs full test262 at PR-time + in queue (src/workflow path).
- [ ] Required-check names unchanged (`cheap gate (main-ancestor + lint)`, `merge shard reports`); PR-time stub untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)