### PR TITLE
fix(#1597): throw ReferenceError standalone gate

### DIFF
--- a/plan/issues/1597-throw-reference-error-standalone-gate.md
+++ b/plan/issues/1597-throw-reference-error-standalone-gate.md
@@ -1,7 +1,7 @@
 ---
 id: 1597
 title: "host-indep: gate __throw_reference_error in standalone mode"
-status: ready
+status: in-review
 created: 2026-05-24
 updated: 2026-05-24
 priority: medium
@@ -63,3 +63,29 @@ No host import is registered; no import appears in the output module.
 ## Effort
 
 ~20 LOC across 3 sites. No new types or helpers needed.
+
+## Resolution (2026-05-24)
+
+All three call sites in `src/codegen/expressions/identifiers.ts`
+(`emitLocalTdzCheck`, `emitStaticTdzThrow`, and the unresolved-identifier
+path in `compileIdentifier`) are **already gated** by `noJsHost(ctx)`
+(`ctx.wasi || ctx.standalone`) as a consequence of the #1473 errors/exceptions
+host-independence work. In no-JS-host mode they build a ReferenceError
+*instance* in-module and trap (`unreachable`) — strictly better than the bare
+`unreachable` the spec sketched, since `e instanceof ReferenceError` works
+under wasmtime. No host import is registered.
+
+Empirically verified against current main:
+
+- `--target standalone` TDZ violation and unresolved-identifier modules
+  compile with **zero** env imports (no `__throw_reference_error`).
+- Standalone module instantiates with `{}` imports — no panic at
+  instantiation. A try/catch-wrapped TDZ access catches the in-module
+  ReferenceError.
+- `--target wasi` likewise omits the import.
+- Default (gc / JS-host) mode is unchanged — import still present.
+
+The remaining deliverable for this issue is the regression-guard test
+`tests/issue-1597-standalone-reference-error.test.ts`, which pins all four
+of the above behaviours so the dual-mode gating cannot silently regress.
+No source change was required.

--- a/tests/issue-1597-standalone-reference-error.test.ts
+++ b/tests/issue-1597-standalone-reference-error.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1597 — `__throw_reference_error` must not leak as a JS-host import under
+ * `--target standalone` (or `--target wasi`). The three reference-error sites
+ * in `src/codegen/expressions/identifiers.ts` (TDZ flag check, static TDZ
+ * throw, unresolved-identifier throw) are all gated by `noJsHost(ctx)`, which
+ * is true for standalone/wasi. In those modes the compiler builds a
+ * ReferenceError INSTANCE in-module (so `e instanceof ReferenceError` works
+ * under wasmtime) instead of calling the absent host import — closing the
+ * `unknown import env::__throw_reference_error` instantiation failure.
+ *
+ * Sibling host-independence work: #1471–#1474, #1473 (errors/exceptions).
+ */
+
+function hasRefErrorImport(imports: ReadonlyArray<{ module: string; name: string }>): boolean {
+  return imports.some((i) => i.name === "__throw_reference_error");
+}
+
+const TDZ_SRC = `
+  export function test(): number {
+    try {
+      return x;
+    } catch (e) {
+      return 1;
+    }
+    let x = 5;
+  }
+`;
+
+const UNDEF_SRC = `
+  export function test(): number {
+    return notDefinedAnywhere;
+  }
+`;
+
+describe("#1597 — standalone gate for __throw_reference_error", () => {
+  it("TDZ violation compiles standalone with no __throw_reference_error import", () => {
+    const r = compile(TDZ_SRC, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(
+      hasRefErrorImport(r.imports),
+      `standalone leaked __throw_reference_error: ${r.imports.map((i) => `${i.module}::${i.name}`).join(", ")}`,
+    ).toBe(false);
+  });
+
+  it("unresolved identifier compiles standalone with no __throw_reference_error import", () => {
+    const r = compile(UNDEF_SRC, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(hasRefErrorImport(r.imports)).toBe(false);
+  });
+
+  it("standalone TDZ module instantiates with zero env imports (no panic at instantiation)", async () => {
+    const r = compile(TDZ_SRC, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // {} imports — instantiation must not fail on a missing host import.
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    // The TDZ access is wrapped in try/catch; the in-module ReferenceError
+    // is caught and the function returns 1.
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("wasi target also gates the reference-error import", () => {
+    const r = compile(UNDEF_SRC, { target: "wasi" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(hasRefErrorImport(r.imports)).toBe(false);
+  });
+
+  it("default (gc / JS-host) mode preserves the __throw_reference_error import", () => {
+    // Regression guard: standalone gating is opt-in. The default browser
+    // target keeps the host import so JS-hosted modules behave as before.
+    const r = compile(TDZ_SRC, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(hasRefErrorImport(r.imports)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1597. The three `__throw_reference_error` call sites in
`src/codegen/expressions/identifiers.ts` (TDZ flag check in `emitLocalTdzCheck`,
static TDZ throw in `emitStaticTdzThrow`, and the unresolved-identifier path in
`compileIdentifier`) are **already gated** by `noJsHost(ctx)` (`ctx.wasi ||
ctx.standalone`) as a result of the #1473 host-independence work. In no-JS-host
mode they build a ReferenceError *instance* in-module and trap — strictly
better than the bare `unreachable` the issue sketched, since `e instanceof
ReferenceError` works under wasmtime — and register **no** host import.

This PR adds the regression-guard test the issue calls for. No source change
was required.

## What the test pins (`tests/issue-1597-standalone-reference-error.test.ts`)

- `--target standalone` TDZ violation compiles with no `__throw_reference_error` import
- `--target standalone` unresolved identifier compiles with no such import
- standalone TDZ module instantiates with `{}` imports (no panic at instantiation); a try/catch-wrapped TDZ access catches the in-module ReferenceError (returns 1)
- `--target wasi` likewise omits the import
- default (gc / JS-host) mode still registers `__throw_reference_error` (no regression)

## Test plan

- [x] `tests/issue-1597-standalone-reference-error.test.ts` — 5/5 pass
- [x] TDZ/scope sibling tests + standalone siblings (#1471–#1474, #1473) pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)