### PR TITLE
test(#1553b): confirm typed-struct decl-dstr covered by #1553c + regression test

### DIFF
--- a/plan/issues/1553b-decl-dstr-route-typed-struct-object-declaration-through-destructureparamobject-d.md
+++ b/plan/issues/1553b-decl-dstr-route-typed-struct-object-declaration-through-destructureparamobject-d.md
@@ -1,9 +1,10 @@
 ---
 id: 1553b
 title: "decl-dstr: route typed-struct object declaration through destructureParamObject (decl-mode)"
-status: ready
+status: done
 created: 2026-05-20
-updated: 2026-05-23
+updated: 2026-05-24
+resolution: "Covered by #1553c externref delegation work (commit d447400e9). The typed-struct path in compileObjectDestructuring already delegates to destructureParamObject({mode:'decl', bindingKind}) — see the `// #1553b` block at src/codegen/statements/destructuring.ts:500-570. Verified 2026-05-24 with cases: nested-default-fires, nested-no-default, simple-typed, top-level-default, nested-null-throws. Locked in with regression tests in tests/issue-1553b.test.ts (9 cases)."
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -231,3 +232,29 @@ TDZ-flag emission timing and the null-guard. Mitigate by:
 - Array decl path → #1553d.
 - Bug 5 (f64 explicit-undefined sentinel) → #1553e.
 - NamedEvaluation → #1450 (in-review).
+
+## Resolution (verified 2026-05-24)
+
+This slice was **skipped in sprint 55** (the team went straight to #1553c).
+On verification against current `main` (post-#1553c/#1553d), the typed-struct
+path is **already implemented** exactly as this spec describes: the
+`// #1553b`-tagged delegation block in
+`src/codegen/statements/destructuring.ts:500-570` stashes the RHS into a
+struct-typed temp local and calls
+`destructureParamObject(ctx, fctx, tmpLocal, pattern, paramType, {mode:'decl', bindingKind})`,
+keeping `syncDestructuredLocalsToGlobals` in the caller and routing
+`...rest` patterns to the externref fallback. This landed as part of the
+#1553c PR (commit `d447400e9`).
+
+Verified all repro/acceptance cases compile + run correctly on current main:
+
+| Case | Source | Result |
+| --- | --- | --- |
+| nested default fires | `let {w:{x,y,z}={x:1,y:2,z:3}}={w:undefined}` (typed) | PASS (`x=1,y=2,z=3`) |
+| nested, no default | `let {a, b:{c,d}} = {a:1,b:{c:2,d:3}}` (typed) | PASS |
+| simple typed | `let {x,y} = p` | PASS |
+| top-level default | `let {x=99,y} = {y:5}` | PASS (`x=99`) |
+| nested null guard | `let {w:{x}} = {w:null}` (typed) | PASS (throws TypeError) |
+
+No code change was required. Regression coverage added in
+`tests/issue-1553b.test.ts` (9 cases, all green) to lock the behaviour in.

--- a/tests/issue-1553b.test.ts
+++ b/tests/issue-1553b.test.ts
@@ -157,4 +157,30 @@ describe("#1553b: typed-struct object destructuring decl → shared helper", () 
     `;
     expect(await run(src)).toBe(1);
   });
+
+  it("typed nested null source throws TypeError (spec-correct null guard)", async () => {
+    // Bug 4 — destructuring a nested pattern off a null field must throw a
+    // TypeError, not silently bind undefined. The shared helper emits the
+    // per-element null guard on the typed-struct path. The host stub for
+    // __throw_type_error_destructure_null raises; in no-JS-host paths the
+    // in-module guard raises a Wasm trap. Either way the call must throw.
+    const src = `
+      const obj: { w: { x: number } | null } = { w: null };
+      const { w: { x } } = obj;
+      if (x !== x) return 2;
+    `;
+    await expect(run(src)).rejects.toThrow();
+  });
+
+  it("typed top-level default fires when field is undefined", async () => {
+    // emitDefaultValueCheck on the typed-struct path: a top-level binding's
+    // default must fire when the source field is undefined.
+    const src = `
+      const obj: { x?: number; y: number } = { y: 5 };
+      const { x = 99, y } = obj;
+      if (x !== 99) return 2;
+      if (y !== 5) return 3;
+    `;
+    expect(await run(src)).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Investigation of sprint-55 issue #1553b (route typed-struct object declaration
through `destructureParamObject`). Per the sprint-56 planning note, #1553b was
skipped in s55 and its typed-struct path may already be handled by the #1553c
delegation. **Verified: it is already covered.**

- The typed-struct path in `compileObjectDestructuring` already stashes the RHS
  into a struct-typed temp local and delegates to
  `destructureParamObject(ctx, fctx, tmpLocal, pattern, paramType, {mode:'decl', bindingKind})`
  — the `// #1553b`-tagged block at `src/codegen/statements/destructuring.ts:500-570`.
  It landed as part of #1553c (commit `d447400e9`). **No code change required.**
- Verified all repro/acceptance cases from the issue compile + run correctly on
  current main via the real runtime (`compileAndInstantiate`):

  | Case | Result |
  | --- | --- |
  | `let {w:{x,y,z}={x:1,y:2,z:3}}={w:undefined}` (typed) | PASS (`x=1,y=2,z=3`) |
  | `let {a, b:{c,d}} = {a:1,b:{c:2,d:3}}` (typed nested) | PASS |
  | `let {x,y} = p` (simple typed) | PASS |
  | `let {x=99,y} = {y:5}` (top-level default) | PASS |
  | `let {w:{x}} = {w:null}` (typed nested null) | PASS (throws TypeError) |

- Adds 2 regression cases to `tests/issue-1553b.test.ts` (now 9, all green):
  typed nested null source must throw TypeError, and a top-level default must
  fire on undefined field.
- Marks the issue `status: done` with a verification note.

## Test plan

- [x] `npx vitest run tests/issue-1553b.test.ts` — 9/9 pass
- [x] Verified repro cases on real runtime return correct values
- [x] `src/` is pristine `origin/main` — no compiler change in this PR

Note: a sweep of the destructuring equivalence lane surfaced 2 pre-existing
failures on pristine main, both outside #1553b scope and not in any
CI-required check: `destructuring-initializer > nested destructuring with
defaults` (a test-harness `__extern_get` stub fidelity gap — the real runtime
returns 42 correctly) and `destructuring-extended > destructured function
parameters with defaults` (a genuine scalar function-param default bug, real
runtime gives 30 not 40). Flagging for the tech lead; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)