### PR TITLE
chore(#1597): mark issue done after PR #583 merged

### DIFF
--- a/plan/issues/1597-throw-reference-error-standalone-gate.md
+++ b/plan/issues/1597-throw-reference-error-standalone-gate.md
@@ -1,7 +1,7 @@
 ---
 id: 1597
 title: "host-indep: gate __throw_reference_error in standalone mode"
-status: in-review
+status: done
 created: 2026-05-24
 updated: 2026-05-24
 priority: medium


### PR DESCRIPTION
Doc-only follow-up: flip #1597 frontmatter `status: in-review` → `done` now
that PR #583 (the regression-guard test) has merged. No source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)