### PR TITLE
plan(#1658,#1659): scalar-param default bug + CI equivalence-coverage gap

### DIFF
--- a/plan/issues/1658-destructured-function-param-default-not-applied.md
+++ b/plan/issues/1658-destructured-function-param-default-not-applied.md
@@ -1,0 +1,65 @@
+---
+id: 1658
+title: "Destructured/scalar function-parameter default not applied (returns wrong value)"
+status: ready
+sprint: Backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring
+goal: spec-completeness
+related: [1553b, 1553d]
+depends_on: [1659]
+---
+# #1658 — Destructured/scalar function-parameter default not applied (returns wrong value)
+
+## Summary
+
+In `tests/equivalence/destructuring-extended.test.ts` under the test case
+**"destructured function parameters with defaults"**, a function-parameter
+default evaluates to the **wrong value on the real runtime** — the compiled
+function returns **30 where 40 is expected**.
+
+This is a genuine codegen bug in the **function-parameter default path**, and is
+**distinct from object destructuring**: the related #1553b / #1553d work covered
+object/array **declaration-mode** destructuring defaults and is done. This one is
+the **function-parameter** path (the scalar/destructured param default applied at
+call-time binding), which #1553b/#1553d did not touch.
+
+Found during the **#1553b verification sweep** (dev-1553b destructuring-lane
+sweep, 2026-05-24).
+
+## Reproduction
+
+- **Test file:** `tests/equivalence/destructuring-extended.test.ts`
+- **Test name:** "destructured function parameters with defaults"
+- **Observed:** the function returns **30**
+- **Expected:** **40** (the parameter default should fire and contribute the
+  larger value)
+
+The discrepancy reproduces **on the real runtime** — it is **not** a harness /
+test-stub artifact. (Contrast with the separate harness-fidelity gap noted in
+#1659, where `__extern_get` in `tests/equivalence/helpers.ts` returns `undefined`
+for opaque WasmGC structs and makes a default *wrongly* fire while the real
+runtime is correct. This issue is the opposite: the real runtime is **wrong**.)
+
+## Acceptance criteria
+
+- The function-parameter default fires correctly so the
+  "destructured function parameters with defaults" case in
+  `tests/equivalence/destructuring-extended.test.ts` returns **40**.
+- A focused regression test is added covering the function-parameter default
+  path (both the scalar-param default and the destructured-param default
+  variants where applicable).
+- No regressions in the existing destructuring equivalence suites.
+
+## Notes
+
+- This bug is **NOT currently caught by CI** — the `quality` job does not run the
+  full `tests/equivalence/` suite (it OOMs in the runner). See **#1659** for the
+  CI coverage gap; until that lands, this regression class is invisible to CI and
+  must be validated locally.

--- a/plan/issues/1659-ci-equivalence-tests-not-run.md
+++ b/plan/issues/1659-ci-equivalence-tests-not-run.md
@@ -1,0 +1,66 @@
+---
+id: 1659
+title: "CI does not run tests/equivalence/ (OOM) — genuine equivalence regressions land silently"
+status: ready
+sprint: Backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: spec-completeness
+related: [1658]
+---
+# #1659 — CI does not run tests/equivalence/ (OOM); equivalence regressions land silently
+
+## Summary
+
+The `quality` CI job currently runs only the **host-import budget** + **IR-alloc**
+tests. The full **`tests/equivalence/`** suite is **NOT run in CI** because it
+**OOMs in the runner**.
+
+**Consequence:** real equivalence regressions are invisible to CI and can land on
+`main` undetected. Two concrete examples surfaced during the dev-1553b
+destructuring-lane sweep (2026-05-24):
+
+1. **#1658** — a genuine codegen bug in the function-parameter default path
+   (returns 30 where 40 is expected, on the real runtime). CI would not have
+   caught it.
+2. **Harness-fidelity gap** in `tests/equivalence/destructuring-initializer.test.ts`:
+   the `__extern_get` stub in **`tests/equivalence/helpers.ts`** returns
+   `undefined` for opaque WasmGC structs, so a destructuring **default wrongly
+   fires** in the *test harness* even though the **real runtime is correct**.
+   This is a harness bug, not a compiler bug — but it means the suite cannot run
+   green as-is even once CI runs it.
+
+## Acceptance criteria
+
+Equivalence regressions get **gated (or at least reported)** in CI. Options to
+explore (do **not** prescribe a single one up front — pick what fits the runner's
+memory budget):
+
+- **Shard** the equivalence suite like test262 (split across runners).
+- Run it with **constrained workers** / `--no-threads` (single-fork, lower peak
+  RAM) so it fits the runner.
+- **Split** it into a separate **scheduled** CI job (e.g. nightly / on-merge)
+  rather than the per-PR `quality` gate.
+
+Whatever the chosen mechanism, the goal is: **a genuine equivalence regression
+fails (or is reported on) a CI run**, rather than landing silently.
+
+## Sub-item — harness fidelity fix
+
+So the suite can run **cleanly** once enabled, fix the harness-fidelity gap in
+`tests/equivalence/helpers.ts`: `__extern_get` returns `undefined` for opaque
+WasmGC structs, which makes destructuring defaults wrongly fire in
+`tests/equivalence/destructuring-initializer.test.ts`. The stub must faithfully
+return the struct-backed value so the harness matches real-runtime behavior.
+
+## Notes
+
+- This is the gating dependency for **#1658**: #1658 is a real bug that is only
+  currently catchable by running `tests/equivalence/` locally. Landing #1659
+  makes that whole regression class CI-visible.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -18,6 +18,13 @@ already enumerated in #1522 / #1543 / #1556 are not re-filed.
 - [#1595](1595-arraybuffer-transfer-methods-not-implemented.md) — ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable not implemented — **~40 fails**, medium
 - [#1596](1596-function-prototype-apply-call-not-accessible.md) — Function.prototype.apply / .call not accessible on compiled Wasm functions — **~46 fails**, high
 
+## Destructuring-lane sweep follow-ups (2026-05-24)
+
+From the dev-1553b destructuring-lane verification sweep.
+
+- [#1658](../1658-destructured-function-param-default-not-applied.md) — Destructured/scalar **function-parameter** default not applied: returns 30 where 40 is expected on the real runtime (distinct from the object/array decl-mode #1553b/#1553d which are done) — high, medium, **ready**. NOT currently caught by CI (see #1659); depends on #1659 for gating.
+- [#1659](../1659-ci-equivalence-tests-not-run.md) — CI does not run `tests/equivalence/` (OOMs in runner) so genuine equivalence regressions (e.g. #1658) land silently. Options: shard like test262 / constrained workers / `--no-threads` / separate scheduled job. Sub-item: fix `__extern_get` harness-fidelity gap in `tests/equivalence/helpers.ts` so the suite runs clean — high, medium, **ready**. Gates CI-visibility of #1658.
+
 ## Sprint 55 — repo structure / website (2026-05-24)
 
 - [#1656](../1656-group-website-files-into-website-dir.md) — Consolidate all website/frontend files under `website/` (components, dashboard, playground, index.html, public, frame-nav-sync.js, images, vite.config.ts, CNAME) — medium, medium, **ready (sprint 55)**. Needs architect spec (`arch(#1656)`) before dev; lands as one PR. Related: #1583, #1590.

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -28,6 +28,16 @@ Pulled into S50 alongside the original closure/dispatch cohort. Direct-dispatch 
 - File icons show which codegen file is primarily touched:
   `[E]` = expressions.ts, `[S]` = statements.ts, `[I]` = index.ts, `[T]` = test262-runner.ts
 
+## Destructuring-lane sweep follow-ups (added 2026-05-24)
+
+From the dev-1553b destructuring-lane verification sweep. #1659 (CI equivalence
+coverage) gates #1658 in the sense that #1658 is only CI-visible once #1659 lands.
+
+| #    | Title | Priority | Feasibility | Status |
+|------|-------|----------|-------------|--------|
+| 1659 | CI does not run tests/equivalence/ (OOM) — equivalence regressions land silently | high | medium | **Ready** (gates CI-visibility of #1658) |
+| 1658 | Destructured/scalar function-parameter default not applied (returns 30, expects 40) | high | medium | **Ready** (depends on #1659 for CI gating) |
+
 ## WASI Native Messaging — AssemblyScript-reference alignment (added 2026-05-24)
 
 Compiler gaps blocking full convergence of `examples/native-messaging/host.ts`


### PR DESCRIPTION
## Summary

Plan-only PR. Two issues from the dev-1553b destructuring-lane verification sweep:

- **#1658** — Destructured/scalar **function-parameter** default not applied: returns 30 where 40 is expected on the **real runtime** in `tests/equivalence/destructuring-extended.test.ts` > "destructured function parameters with defaults". Distinct from object/array decl-mode (#1553b/#1553d, done). NOT currently caught by CI (see #1659).
- **#1659** — CI does not run `tests/equivalence/` (OOMs in the runner), so genuine equivalence regressions (e.g. #1658) land silently. Options to explore: shard like test262 / constrained workers / `--no-threads` / separate scheduled job. Sub-item: fix the `__extern_get` harness-fidelity gap in `tests/equivalence/helpers.ts` (returns undefined for opaque WasmGC structs, making a default wrongly fire while the real runtime is correct) so the suite runs clean once enabled. Gates CI-visibility of #1658.

Also updated `plan/log/dependency-graph.md` and `plan/issues/backlog/backlog.md` to list both.

## Changes

- `plan/issues/1658-destructured-function-param-default-not-applied.md` (new)
- `plan/issues/1659-ci-equivalence-tests-not-run.md` (new)
- `plan/log/dependency-graph.md`
- `plan/issues/backlog/backlog.md`

No source/test changes.