### PR TITLE
arch(#1539,#1130): implementation specs to unblock hard sprint-55 issues

### DIFF
--- a/plan/issues/1130-array-methods-getter-observing-property.md
+++ b/plan/issues/1130-array-methods-getter-observing-property.md
@@ -688,3 +688,227 @@ decide the vec-accessor dispatch strategy above before further dev work.
 Branch with the (working-for-sidecar, harmless) machinery:
 `issue-1130-getter-observe`. NOT opened as a PR — it changes 4 files but
 flips 0 target tests, so it is net-neutral churn until the re-spec lands.
+
+---
+
+## Implementation Plan (authoritative — 2026-05-24, re-spec from corrected premise)
+
+Author: architect. **Supersedes all plans above.** Written after
+re-measuring current `main` (HEAD `92c7483a4`) end-to-end with the live
+compiler (`compileToWat` + `compileToWasm` probes), not from the stale
+2026-05-23 source snapshot. **Read this section and ignore the two earlier
+"authoritative" plans** — both rested on premises that current `main`
+falsifies.
+
+### TL;DR for the dev
+
+- **The dev-1130-6 blocker is STALE.** Its claim — "statically-typed vecs
+  compile `defineProperty(arr,"1",{get})` into a `<struct>_get_1` Wasm
+  accessor and never touch `_wasmStructProps`" — is **false on current
+  main**. Verified by WAT inspection across `var`/`const`/`number[]`/`any`
+  array shapes: *every* shape routes the accessor through
+  `__defineProperty_accessor`, which stores `sc["__get_1"]` in
+  `_wasmStructProps` keyed on the vec's `extern.convert_any` externref.
+  No `_get_1` struct accessor is emitted for arrays (arrays never resolve
+  to a named `structName`, so the struct branch at
+  `object-ops.ts:690` is not taken). The JS-sidecar mechanism the
+  2026-05-23 plan assumed **is** the real mechanism. It is unblocked.
+- **BUT the 2026-05-23 plan's scope is wrong in three material ways**
+  (below). Implementing it verbatim still flips far fewer tests than
+  promised. This re-spec corrects the scope and adds the two prerequisites
+  it missed.
+
+### Corrected scope (measured, not estimated)
+
+I classified every getter-observing test across the 7 methods
+(`forEach map every some filter reduce reduceRight`) by receiver shape
+(regex over `Object.defineProperty(.., "length"|<digits>, .. get:)`):
+
+| Receiver shape | Count | Owner |
+|----------------|------:|-------|
+| **Native vec** — `arr.method()`, getter on own index/length | **96** | **#1130 (this issue)** |
+| `Array.prototype.method.call(plainObj, cb)` | 233 | the **array-like `.call` path**, already largely handled — NOT #1130 |
+| getter installed on `Array.prototype[k]` (prototype chain) | 48 | separate prototype-visiting problem — NOT #1130 PR-1/2 |
+
+**The issue header's "~80" and its three "sample failing tests" are
+mis-scoped.** Two of the three samples are *not* native-vec receivers:
+- `every/15.4.4.16-7-b-3.js` → `Array.prototype.every.call({2:6.99,8:19}, cb)` (array-like `.call`).
+- `reduceRight/15.4.4.22-5-10.js` → `Array.prototype.reduceRight.call({0:11,1:12}, fn)` (array-like `.call`).
+- `filter/15.4.4.20-3-11.js` (listed in "Sample failing tests") → `Array.prototype.filter.call({1:11,2:9,length:"2"}, cb)` (array-like `.call`).
+
+**The array-like `.call` path is already correct** for these. Verified by
+probe: `Array.prototype.filter.call({1:11,2:9,length:"2"}, cb)` returns
+`newArr.length === 1` today — spec-correct. `compileArrayLikePrototypeCall`
+(`array-methods.ts:377`) routes plain-object/anonymous-struct receivers
+through `__extern_get_idx` / `__extern_length` (`runtime.ts:3371` / nearby),
+which **do** invoke accessor getters via `_safeGet`/sidecar. That path
+*deliberately bails on `__vec_*`/`__arr_*`* receivers (line 427) — which is
+exactly the gap #1130 must fill. **#1130's true domain is the 96 native-vec
+tests only.** (Note: every reference to "#1131 (the B fix / array-like
+receiver)" in the older notes is a wrong issue number — #1131 is the SSA-IR
+issue. The array-like path is `compileArrayLikePrototypeCall`, already in
+tree; there is no separate open issue to wait on.)
+
+### Three prerequisites the 2026-05-23 plan MISSED (load-bearing)
+
+These are not edge cases — the *clean native-vec targets require all three*:
+
+1. **Array-index-exotic `length` growth on `defineProperty`.** Per spec
+   (ArraySetLength / `[[DefineOwnProperty]]` on array exotic objects),
+   `Object.defineProperty(arr, "2", {get})` when `2 >= arr.length` sets
+   `arr.length = 3`. Targets like `forEach/15.4.4.18-7-c-i-10.js`
+   (`var arr = []; defineProperty(arr,"2",{get:()=>12})`) depend on this:
+   the loop bound must become 3 so index 2 is visited. **Measured today:
+   `arr.length` stays 0** after such a defineProperty (probe confirmed).
+   The accessor-probe element read is useless if the loop never reaches the
+   index. **This must be fixed first** (in the vec defineProperty path),
+   independent of the element-read change.
+2. **`HasProperty` / hole semantics are central, not deferred.** The clean
+   targets use holes (`[0, , ]`, `[9, , 12]`, `[]`) plus an accessor on a
+   specific index. `forEach`/`every`/`some`/`reduce`(no-init) MUST skip
+   absent indices and visit accessor-defined ones. So the loop needs a
+   per-index `HasProperty(arr, k)` that is true iff the index is a real
+   backing element OR has a sidecar accessor. The 2026-05-23 plan
+   explicitly deferred this ("out of strict scope for first PR") — but
+   without it the clean targets don't pass.
+3. **Prototype-chain getters appear even in native-receiver tests.**
+   `forEach/15.4.4.18-7-b-11.js` defines `Array.prototype[1]` and toggles
+   it inside an own-index getter. Spec `Get`/`HasProperty` walk the
+   prototype chain. This subset (and the 48 proto-getter tests) needs
+   prototype-chain consultation, which the sidecar probe does not do.
+   **Defer the prototype-chain subset to a follow-up** (see sequencing).
+
+### Mechanism (confirmed correct, reused from `_safeGet`)
+
+The element-read and length-read slow paths use the **exact pattern
+`_safeGet` already uses** (`runtime.ts:1729-1733`):
+```ts
+const getter = _wasmStructProps.get(obj)?.[`__get_${key}`];
+if (typeof getter === "function") return getter.call(obj);
+```
+`obj` is the vec's `extern.convert_any` externref. **Externref-wrapper
+identity is stable** for a WasmGC ref within an instance — this is already
+relied upon in production by the `#856` `defineProperty value` + sidecar
+read/write paths (`object-ops.ts:1374` comment), so the assumption is not
+new risk. The getter stored by `__defineProperty_accessor`
+(`runtime.ts:4121`, `_maybeWrapCallable`) is already JS-callable through the
+`__call_fn_<arity>` bridge — `getter.call(obj)` is correct, no new bridge.
+
+The host-import + sentinel design from the 2026-05-23 plan
+(`__array_idx_accessor_get`, `__array_length_accessor_get`,
+`__is_array_no_accessor`, `__to_length`, module-private `__array_no_accessor`
+sentinel) is **sound and is adopted verbatim** for the element/length reads
+— see that section above for the import signatures and the
+`emitElementLoad` codegen sketch. The compile-time whole-program gate
+(`ctx.arrayAccessorObserved` set from `state.getterCallbackFound` in
+`finalizeUnifiedCollector`, declarations.ts ~1091) is also adopted verbatim
+— re-verified the anchors (`getterCallbackFound` @declarations.ts:96/559,
+`finalizeUnifiedCollector` @814, the `if (state.getterCallbackFound)` block
+@1091; `CodegenContext` `nativeStrings` @types.ts:523;
+`setupArrayLoop` @array-methods.ts:4472, element loads @4538-4540 /
+@4592-4594). Add `__array_has_idx_accessor(obj, idx) -> i32` (returns 1 iff
+`_wasmStructProps.get(obj)?["__get_"+idx]` is a function) for the
+`HasProperty` slow path.
+
+### What this re-spec ADDS on top of the 2026-05-23 element/length design
+
+**A. Vec array-index-exotic length growth (new, prerequisite — PR-0).**
+- File: `src/codegen/object-ops.ts`, the vec/non-struct accessor branch
+  that reaches `emitExternDefinePropertyValue` / the `__defineProperty_accessor`
+  call path (the branch taken when `structName === undefined`, i.e. arrays).
+- When the prop key is a canonical array index `n` (`ToString(ToUint32(n)) === key`
+  and `n < 2^32-1`) and the receiver is a `__vec_*`, after the
+  `__defineProperty_accessor`/`__defineProperty_value` call, emit a guarded
+  length bump: `if (n >= vec.len) vec.len = n + 1` via `struct.get/struct.set`
+  on field 0. This mirrors array `[[DefineOwnProperty]]`. Gate on
+  `ctx.arrayAccessorObserved` is NOT required here (it is correct
+  unconditionally and cheap), but scope it to the vec-accessor branch so
+  non-array defineProperty is unaffected.
+- Add a runtime sentinel store so the accessor index is recoverable: the
+  getter is already in `_wasmStructProps[obj]["__get_n"]`; no extra runtime
+  store needed. The length bump is pure Wasm on the vec struct.
+- **Verify**: `compileToWasm` probe — `[]; defineProperty(arr,"2",{get}); arr.length` must return 3.
+
+**B. HasProperty in the callback loop (new, promoted from "deferred").**
+- In `setupArrayLoop` slow path and the per-method loop body: before the
+  element load, when `ctx.arrayAccessorObserved`, compute presence:
+  `present = (i < backingLen) ? array data has index (always true for dense vec, false for hole)` OR `__array_has_idx_accessor(vecExtern, i)`.
+  For a WasmGC vec the backing array is dense up to `vec.len`; holes from
+  `[0, , ]` literals are represented as the default element value, **not**
+  as true absences — so HasProperty for a hole index needs care. **Audit
+  how array-literal holes are currently encoded** (`array.new_default`
+  vs a hole bitmap): if holes are *not* tracked, `forEach` over `[0, , ]`
+  cannot distinguish hole index 1 from a real 0. This is the single biggest
+  open implementation question (see Risks). If holes are not represented,
+  PR-1 should target only the **non-hole** native targets first (e.g.
+  `7-c-i-10` uses `[]` + accessor, no interior hole) and the hole-dependent
+  targets (`map/15.4.4.19-8-9` uses `[9, , 12]`) move to a follow-up tied
+  to hole representation.
+- `forEach`/`every`/`some`/`find*`/`reduce`(no-init) skip when `!present`;
+  `map`/`filter` produce a hole in the result when `!present` (match
+  `map/15.4.4.19-8-9`: result keeps length 3 with `result[2]` undefined and
+  index 1 skipped after `arr.length=2` mutation).
+
+**C. Element + length read slow path** — exactly the 2026-05-23
+`emitElementLoad` + `__array_length_accessor_get` + `__to_length` design.
+No change.
+
+### Recommended PR sequencing (revised, honest)
+
+- **PR-0 (prerequisite, ~3-5 native tests)**: vec array-index-exotic
+  `length` growth on `defineProperty` (item A). Standalone, low-risk,
+  independently valuable (fixes `arr.length` after numeric-index
+  defineProperty). Land first; it unblocks any later loop-bound work.
+- **PR-1 (machinery + forEach, non-hole subset)**: ctx flag + 4 host
+  imports + sentinel + `__to_length` + `__array_has_idx_accessor`;
+  `setupArrayLoop` length-getter + element-accessor probe + HasProperty;
+  gate to `compileArrayForEach`. Land `tests/issue-1130.test.ts`:
+  getter-on-index fires (`[]`+accessor@2 → val 12); getter-on-length fires
+  + ToLength on string `"2"`; **externref-identity round-trip assertion**
+  (store getter, read back via helper in a later call — guards the
+  load-bearing assumption); **byte-equality microcheck** (getter-free
+  forEach emits identical bytes pre/post change, proving the gate).
+- **PR-2 (fan-out)**: map/every/some/filter/reduce/reduceRight via the
+  shared builders; `local`-elemSource audit; the `map` result-hole
+  semantics. Target the remaining clean native tests.
+- **Follow-up issues (NOT #1130)**: (i) interior-hole representation if
+  absent (blocks `[9, , 12]`-style targets); (ii) prototype-chain
+  `Get`/`HasProperty` for the 48 proto-getter tests + native tests that
+  toggle `Array.prototype[k]`.
+
+### Honest acceptance criteria (replaces the header's "≥60 of 80")
+
+The header's "≥60 of 80" is **not achievable in #1130's true scope** — only
+96 tests are native-receiver, and an unknown fraction depend on hole
+representation / prototype chain that are out of scope. Realistic targets:
+- **PR-0**: `arr.length` reflects numeric-index defineProperty (3-5 tests
+  + the length-read direct cases).
+- **PR-1+PR-2**: clear the **non-hole, own-accessor, native-receiver**
+  subset of the 96 — estimate **30-45 tests** (exact count to be measured
+  by the dev with a scoped test262 run on the 7 method dirs before/after).
+  Treat 30 as the floor for "worth merging"; if PR-1's scoped run shows
+  <15 in the non-hole subset, re-evaluate with the architect.
+
+### Why this is still worth doing (not wont-fix)
+
+The mechanism is proven (`_safeGet` already does it), the externref
+identity risk is already retired in production, and PR-0 alone fixes a
+visible correctness bug (`arr.length` after numeric defineProperty). The
+work is real and bounded; only the *headline test count* was inflated. Keep
+`status: ready`. Dispatch PR-0 first as a small, independent task; gate
+PR-1/2 on the dev's scoped before/after measurement so the team commits to
+real, measured numbers rather than the stale "~80".
+
+### Open question the dev MUST resolve early (could re-block)
+
+**Interior-hole representation.** If WasmGC array literals encode `[0, , 2]`
+as a dense `array.new` with a default value at index 1 (no hole bitmap),
+then `HasProperty(arr, 1)` cannot return false for the literal hole, and
+the hole-dependent targets are unreachable without a representation change
+(a follow-up issue, larger than #1130). The dev should answer this in the
+first hour (inspect `array.new`/`array.new_default`/literal-with-elision
+codegen) and, if holes are not tracked, **scope PR-1/2 to the `[]`-or-dense
++ own-accessor subset** and file the hole-representation follow-up rather
+than expanding #1130. This is the one place this issue could legitimately
+need more than a spec — flag it to the architect/PO if hole tracking turns
+out to be a prerequisite for a majority of the 96.

--- a/plan/issues/1539-wasm-native-regex-engine-regress.md
+++ b/plan/issues/1539-wasm-native-regex-engine-regress.md
@@ -163,3 +163,219 @@ Acceptance: ≥80% pass when compiled with `--target standalone`.
 - **Rust toolchain** — mitigated by committing prebuilt artifact; CI never runs `cargo`.
 - **Binary size** — ~250–400 KB added to every standalone module. Acceptable for `--target standalone`; irrelevant for JS-host builds.
 - **regress ABI stability** — pin version in `vendor/regress-version.txt`; review on upgrade.
+
+---
+
+## Architecture Plan (authoritative — 2026-05-24, supersedes the regress-first plan above)
+
+Author: architect. Written after reading the **current** standalone
+pipeline and the existing native-string helper layer end-to-end (HEAD
+`92c7483a4`). **The "Implementation Plan" above (regress side-module via
+`wasmMerge`) has a load-bearing flaw that blocks Phase 2a as written.** This
+section re-sequences the work so a dev can build the smallest slice today
+with **zero new toolchain**, and demotes the Rust `regress` side-module to a
+*later, optional* phase whose entry condition is explicit.
+
+### The flaw in the regress-first plan
+
+The standalone target is **pure WasmGC** (`src/cli.ts:35`:
+"`--standalone — pure WasmGC, no JS host`") and forces `nativeStrings`
+(`index.ts:4829-4830`). Standalone strings are therefore **WasmGC `i16`
+arrays** (`__str_data`), reachable directly by WasmGC code.
+
+A Rust `regress` build is `wasm32-unknown-unknown` — a **linear-memory**
+module. The plan proposes linking it with Binaryen `wasm-merge`. But:
+- **`wasm-merge` cannot coherently fuse a linear-memory module and a WasmGC
+  module into one instance.** They have separate memory models; there is no
+  shared address space. The strings the matcher must read live in WasmGC
+  `i16` arrays, which a linear-memory `regress` cannot address without an
+  explicit copy across a boundary that does not exist in a single merged
+  instance.
+- The plan's ABI ("strings pass as `(ptr, len)` into a shared linear memory
+  slab") presupposes that boundary and a marshalling layer (WasmGC `i16`
+  array → linear slab → back) that is itself a substantial, unspecified
+  piece of work — and it is pure overhead the standalone target should not
+  pay when the data is already WasmGC.
+- It also imports a Rust toolchain + a committed ~250-400 KB artifact + a
+  version-pin/rebuild story **before any regex byte has matched**. That is a
+  large irreversible commitment made on an unproven integration.
+
+**Conclusion**: side-module linking is the wrong *first* move. It may be a
+viable *later* move for full ES2023 coverage (`\p{}`, lookbehind,
+backreferences) **iff** we adopt a second-instance model (two `WebAssembly.
+Instance`s sharing an `externref`/copy ABI) rather than `wasm-merge` — that
+is a separate design (see Phase 2d entry condition). It is not Phase 2a.
+
+### The right Phase 2a: a pure-WasmGC matcher, self-hosted like the string layer
+
+`src/codegen/native-strings.ts` (4,211 lines) already contains **hand-
+authored WasmGC helper functions** that operate directly on `i16` string
+arrays — `__str_indexOf`, `__str_substring`, `__str_compare`,
+`__str_charAt`, `__str_slice`, `__str_includes`, … — each built as an
+explicit `WasmFunction` body and registered in `ctx.nativeStrHelpers`
+(emission sites listed at `native-strings.ts:285…2355+`). **This is the
+exact pattern a standalone regex matcher should follow**: emit a family of
+WasmGC helper functions that walk the `i16` array. No Rust, no
+`wasm-merge`, no linear memory, no marshalling — the matcher reads the same
+`i16` arrays everything else already uses.
+
+Regex compilation is split cleanly:
+- **Compile time (TS, in the compiler)**: parse the pattern string and flags
+  into a small bytecode/NFA program. The pattern is *always a literal or a
+  compile-time-known string* in the overwhelming majority of cases
+  (`/\d+/`, `new RegExp("ab+c")`); only `new RegExp(dynamicStr)` is runtime.
+  Phase 2a handles **literal/static patterns only** and refuses dynamic
+  patterns in standalone (keep the Phase-1 `reportError` for the dynamic
+  case, narrowed). The parser already exists in part: `parseRegExpLiteral`
+  (imported in `typeof-delete.ts:14`) extracts `{pattern, flags}`.
+- **Run time (emitted WasmGC)**: a generic `__regex_match` helper that
+  interprets the compiled program against an `i16` array + start index,
+  returning a match struct — OR, for the smallest slice, **specialised
+  per-pattern matcher functions** emitted directly from the parsed AST (no
+  interpreter), the way `native-strings.ts` emits one function per method.
+  Specialised emission is simpler to land first (no bytecode format to
+  design) and is the recommended Phase-2a form.
+
+### Data structures (WasmGC, no linear memory)
+
+Reuse the issue's `$RegExp` / `$MatchArray` struct shapes above **but drop
+`$handle` (no foreign engine) and `$indices` externref** (use a WasmGC
+`i32` pairs array instead). Concretely:
+
+```wat
+(type $RegExp (sub (struct
+  (field $tag        i32)                ;; REGEXP_TAG
+  (field $source     (ref $NativeString));; pattern (i16 array wrapper)
+  (field $flags      i32)                ;; g=1 i=2 m=4 s=8 u=16 y=32 d=64
+  (field $lastIndex  (mut f64))
+  (field $progIdx    i32)                ;; index of the emitted matcher fn (funcref table) — Phase 2b+
+)))
+
+(type $MatchResult (struct
+  (field $matched   i32)                 ;; 1 = matched, 0 = no match
+  (field $start     i32)                 ;; match start (i16 index)
+  (field $end       i32)                 ;; match end (exclusive)
+  (field $groups    (ref $arr_i32))      ;; flat [g0s,g0e,g1s,g1e,…]; -1 = unmatched
+)))
+```
+
+For Phase 2a (specialised per-pattern functions) the `$progIdx`/funcref
+table is unnecessary — the call site calls the specialised function
+directly, exactly as string methods do via `ctx.nativeStrHelpers`. Promote
+to a funcref/bytecode model only when the number of distinct patterns or
+the dynamic-pattern requirement forces it (Phase 2c).
+
+### Codegen routing (replaces the Phase-1 gates — same entry points as the regress plan)
+
+The entry points the regress plan lists are correct; only the target
+changes (emit WasmGC matcher calls, not regress imports):
+
+| File | Phase-1 gate (verified present) | Phase 2a change |
+|------|----------------------------------|-----------------|
+| `src/codegen/typeof-delete.ts` | `compileRegExpLiteral` @287, refuse @289-295 | when `ctx.standalone` and pattern is static-parseable: parse via `parseRegExpLiteral`, emit/return a `$RegExp` built by the WasmGC path; keep refuse only for unparseable/dynamic |
+| `src/codegen/expressions/new-super.ts` | refuse @1998-2008 | same for `new RegExp(p,f)` when `p` is a compile-time string |
+| `src/codegen/expressions/calls.ts` | refuse @1374 | same for `RegExp(p,f)` call form |
+| `src/codegen/string-ops.ts` | refuse @1956-1970 (match/matchAll/search; replace/replaceAll/split w/ RegExp arg) | route to the WasmGC matcher helpers when `ctx.standalone` |
+| `src/codegen/native-strings.ts` (or a new `src/codegen/native-regex.ts` sibling) | — | **new**: emit the matcher helper functions, registered in a `ctx.nativeRegexHelpers` map mirroring `ctx.nativeStrHelpers` |
+
+Put the matcher emission in a **new `src/codegen/native-regex.ts`** that
+mirrors `native-strings.ts`'s structure (one `WasmFunction` per primitive,
+shift-maintained funcMap registration). Do **not** bloat `native-strings.ts`.
+
+### Phased breakdown (smallest buildable slice first)
+
+- **Phase 2a — literal & character-class matching, no JS, no Rust.**
+  - Patterns: literal chars, `.`, char classes `[...]`/`[^...]`, anchors
+    `^`/`$`, quantifiers `*`/`+`/`?`/`{n,m}` (greedy), alternation `|`,
+    non-capturing groups `(?:…)`, the `i` and `g` flags.
+  - Methods: `RegExp.prototype.test`, `RegExp.prototype.exec`,
+    `String.prototype.match` (non-`g` returns first match struct; `g`
+    returns all-matches array), `String.prototype.search`,
+    `String.prototype.replace(re, string)` (no `$n` / function replacer
+    yet — refuse those in standalone), `String.prototype.split(re)`.
+  - Implementation: a backtracking matcher emitted as WasmGC helpers over
+    `i16` arrays. Capturing groups `( … )` recorded into `$groups`.
+  - **Refuse (keep Phase-1 error, narrowed)**: dynamic `new RegExp(var)`,
+    backreferences `\1`, lookahead/lookbehind, `\p{}`, the `u`/`v`/`y`/`s`
+    flags, and `replace` with a function/`$n` replacer. Each refusal cites
+    "#1539 Phase 2b/2c/2d".
+  - Smallest first PR within 2a: **`test` + literal/`.`/char-class/anchors
+    only**, proving the parse→emit→match pipeline + the string-ops routing,
+    with `tests/issue-1539-standalone-regex.test.ts` running under
+    `--target standalone` (compile + run via the existing standalone test
+    harness; see `tests/issue-1474-standalone-regex-refuse.test.ts` for the
+    inverse-direction harness to adapt).
+- **Phase 2b — capturing groups, `exec`/`match` group arrays, named groups
+  `(?<name>…)`, `lastIndex`/sticky `y`, empty-match advance.** Add the
+  funcref/bytecode model here if specialised emission becomes unwieldy.
+- **Phase 2c — `replace` with `$1`/`$<name>`/function replacer,
+  `matchAll`, `replaceAll`, multiline `m`, dotAll `s`, the `d`
+  indices flag.**
+- **Phase 2d (optional, entry-condition gated) — full ES2023 fancy
+  features** (`\p{}` Unicode property escapes, lookbehind, backreferences).
+  **Entry condition**: only if test262 RegExp pass-rate plateaus below
+  target on these specific features AND a **two-instance** linking design
+  (not `wasm-merge`) is specced and approved. This is where Rust `regress`
+  *could* return — as a separate WasmGC↔linear instance pair with a defined
+  copy ABI — but it is explicitly out of scope until 2a-2c land and the
+  data justifies the toolchain cost.
+
+### Test strategy
+
+- **Equivalence tests** (`tests/issue-1539-standalone-regex.test.ts`):
+  compile each pattern twice — once default (JS-host, `RegExp_new`) and once
+  `--target standalone` — assert identical results on a fixed input corpus.
+  This reuses the dual-run pattern already used for native strings
+  (`ctx.testRuntime && ctx.nativeStrings`, index.ts:774). Per Phase 2a
+  scope: literal, `.`, classes, anchors, quantifiers, alternation, `i`/`g`.
+- **test262 under standalone**: run `test/built-ins/RegExp/*`,
+  `test/built-ins/String/prototype/{match,replace,replaceAll,search,split}/*`,
+  `test/language/literals/regexp/*` with `--target standalone`. **Do not
+  promise ≥80% in 2a** — Phase 2a deliberately refuses fancy features;
+  expect the *feature-subset* pass rate to climb in 2b/2c. Track the
+  standalone-RegExp pass count as the metric, not a single threshold.
+- **Refusal tests**: extend `tests/issue-1474-standalone-regex-refuse.test.ts`
+  so the *narrowed* refusals (dynamic pattern, backrefs, lookaround, fancy
+  flags) still produce clean compile errors citing the right phase.
+
+### Edge cases (Phase 2a)
+
+- **Empty match + `g`** (`/x*/g` on `"abc"`): advance position by 1 after a
+  zero-width match (spec §22.2.7.2) to avoid an infinite loop.
+- **Anchored `^`/`$` with/without `m`**: in 2a, `^`/`$` match only
+  string start/end (multiline `m` is Phase 2c).
+- **Case-insensitive `i`**: simple ASCII case-fold in 2a; full Unicode
+  case-folding deferred (note in test file). Most test262 `i` tests are
+  ASCII.
+- **Greedy backtracking termination**: cap backtracking steps or use an
+  explicit stack to guarantee termination (no JS stack to rely on in
+  standalone). Document the cap.
+- **`split(re)` with capturing groups**: spec interleaves captured groups
+  into the result array — defer the capture-interleave to 2b; 2a `split`
+  handles non-capturing separators only (refuse capturing-group split with
+  a 2b citation).
+- **Surrogate pairs / `u` flag**: 2a operates on UTF-16 code units (the
+  `i16` array). The `u` flag (code-point semantics) is refused until 2c/2d.
+
+### Why this de-risks the issue
+
+- **Phase 2a ships with zero new toolchain or CI changes** — it is the same
+  hand-authored-WasmGC-helper pattern already proven by `native-strings.ts`,
+  reading the same `i16` arrays. No Rust, no `vendor/*.wasm`, no
+  `wasm-merge`, no `build-regress-wasm.sh`.
+- **The hard, irreversible bets** (Rust toolchain, prebuilt artifact, the
+  unsolved WasmGC↔linear linking) are deferred to Phase 2d behind an
+  explicit entry condition, instead of being prerequisites for the first
+  matched byte.
+- **Routing is proven first**: 2a's first PR validates the parse→emit→match
+  pipeline + string-ops/literal routing on the simplest patterns, so 2b/2c
+  are pure feature-addition on a known-good spine.
+
+### Recommendation
+
+Keep `status: ready`. Dispatch **Phase 2a, first PR** (test + literal/
+class/anchor matcher in a new `src/codegen/native-regex.ts`, with the
+narrowed refusals and a dual-run equivalence test) as the buildable slice.
+The `regress` side-module sections above are retained as **possible Phase 2d
+material only**, gated on the two-instance design + test262 data; they are
+**not** the Phase 2a plan.


### PR DESCRIPTION
## Summary

Implementation specs (plan files only — no compiler source changes) for two design-blocked sprint-55 hard issues, written after verifying premises against current `main` end-to-end.

- **#1539 (standalone RegExp)**: re-architected around a **pure-WasmGC matcher (Phase 2a)** that follows the proven `native-strings.ts` hand-authored-helper pattern over `i16` arrays — **zero new toolchain**. The original regress Rust side-module plan is demoted to optional **Phase 2d** behind an explicit two-instance-linking entry condition, because Binaryen `wasm-merge` cannot coherently fuse a linear-memory module with the pure-WasmGC standalone target (the original plan's load-bearing flaw). Phased breakdown, ABI, edge cases, dual-run test strategy included.
- **#1130 (array getter-observing)**: re-spec from corrected premise. The dev-1130-6 "struct accessor" blocker is **stale** — verified that every array declaration shape (`var`/`const`/`number[]`/`any`) routes `defineProperty(arr,"1",{get})` through the JS sidecar on current `main`, exactly as the abandoned 2026-05-23 plan assumed. Corrected scope by measuring all 377 getter-observing tests: only **96 are native-vec** (#1130's true domain); **233 are the already-working `.call` path** (probe-confirmed correct today). Added two prerequisites the prior plan missed (array-index-exotic `length` growth on `defineProperty`; `HasProperty`/hole semantics as core, not deferred) and replaced the inflated "~80" with honest, measurement-gated numbers.

Both issues keep `status: ready`. Neither appears in the dependency graph, so no graph update needed.

## Test plan
- [ ] N/A — plan/spec files only; no code changes. Verified against current `main` (HEAD `92c7483a4`) with throwaway `compileToWat`/`compileToWasm` probes (cleaned up, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)