### PR TITLE
fix(#1606): codegen crash on undefined read

### DIFF
--- a/plan/issues/1606-internal-crash-object-literal-undefined-declarations.md
+++ b/plan/issues/1606-internal-crash-object-literal-undefined-declarations.md
@@ -1,7 +1,7 @@
 ---
 id: 1606
 title: "codegen crash: 'Cannot read properties of undefined (reading declarations)' on object-literal expressions"
-status: ready
+status: in-review
 created: 2026-05-24
 updated: 2026-05-24
 priority: high
@@ -48,3 +48,51 @@ type-resolution path.
 
 - The three example tests compile without an internal crash.
 - All 8 tests move off `compile_error`.
+
+## Root cause (confirmed)
+
+The crash fires only through the test262 runner's `wrapTest` + the static
+eval-inline path (#1163). These tests do `eval("o = {get foo(){…}}")` /
+`eval("({foo:0,foo:1})")` with a **constant string** argument, so the compiler
+parses and splices the eval body inline (`src/codegen/expressions/eval-inline.ts`).
+The spliced statements come from a foreign `SourceFile` created via
+`ts.createSourceFile` — the TypeScript checker has **no symbol bindings** for
+those nodes. Two object-literal codegen paths then call into the checker on
+those foreign nodes, and TypeScript itself dereferences `.declarations` /
+`.flags` / `.escapedName` on an undefined symbol and throws:
+
+1. `compileArrowAsCallback` (`src/codegen/closures.ts`) →
+   `checker.getSignatureFromDeclaration(getter/setter)` →
+   `getDeclarationOfKind` reads `.declarations` of undefined.
+2. `compileObjectLiteral` (`src/codegen/literals.ts:558`) →
+   `checker.getTypeAtLocation({foo:0,foo:1})` → `checkObjectLiteral` reads
+   `.flags` of undefined for the duplicate-key symbol.
+
+The three distinct error spellings (`declarations` / `flags` / `escapedName`)
+are all the same class: a checker call on a foreign-SourceFile node.
+
+## Fix
+
+Guard both checker calls so a checker-internal crash degrades to the existing
+graceful path instead of crashing the whole compile:
+
+- `closures.ts`: wrap `getSignatureFromDeclaration` + `getReturnTypeOfSignature`
+  in try/catch; on failure the callback compiles with a void/any return type
+  (the body still coerces its actual return value normally).
+- `literals.ts`: wrap the no-contextual-type `getTypeAtLocation(expr)` in
+  try/catch; on failure fall through to the externref plain-object lowering.
+
+## Test Results
+
+`tests/issue-1606.test.ts` — 4 cases (get/set pair, set-only, get-only,
+duplicate data keys), all fail without the fix and pass with it.
+
+Full `language/expressions/object` directory (306 tests) via `runTest262File`:
+**0 internal crashes** (was 8). Post-fix the 8 tests are:
+- `11.1.5_4-4-a-3` → now compiles and runs (`fail`, no longer a crash).
+- the other 7 → clean `compile_error: Missing __make_getter_callback import`
+  (graceful unsupported-feature diagnostic — wiring accessor callbacks through
+  the eval-inline path is a separate feature, out of scope here).
+
+No regressions: the additive try/catch guards only fire on a checker crash;
+existing object-literal/accessor test files are unchanged with vs. without the fix.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2405,13 +2405,25 @@ export function compileArrowAsCallback(
     }
   }
 
-  const sig = ctx.checker.getSignatureFromDeclaration(arrow);
+  // #1606: For functions parsed from a foreign SourceFile (e.g. statically
+  // inlined `eval("...")` bodies), the checker has no symbol binding for the
+  // declaration. `getSignatureFromDeclaration` then dereferences `.declarations`
+  // on an undefined symbol deep inside TypeScript and throws
+  // "Cannot read properties of undefined (reading 'declarations')". Guard the
+  // signature/return-type resolution so the callback compiles with a void/any
+  // return type instead of crashing the whole compile — the body still coerces
+  // its actual return value via the normal path.
   let cbReturnType: ValType | null = null;
-  if (sig) {
-    const retType = ctx.checker.getReturnTypeOfSignature(sig);
-    if (!isVoidType(retType)) {
-      cbReturnType = resolveWasmType(ctx, retType);
+  try {
+    const sig = ctx.checker.getSignatureFromDeclaration(arrow);
+    if (sig) {
+      const retType = ctx.checker.getReturnTypeOfSignature(sig);
+      if (!isVoidType(retType)) {
+        cbReturnType = resolveWasmType(ctx, retType);
+      }
     }
+  } catch {
+    cbReturnType = null;
   }
 
   const cbResults: ValType[] = cbReturnType ? [cbReturnType] : [];

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -555,7 +555,20 @@ export function compileObjectLiteral(
 
   const contextType = ctx.checker.getContextualType(expr);
   if (!contextType) {
-    const type = ctx.checker.getTypeAtLocation(expr);
+    // #1606: `getTypeAtLocation` can crash inside TypeScript's `checkObjectLiteral`
+    // for object literals parsed from a foreign SourceFile (e.g. statically inlined
+    // `eval("({foo:0,foo:1})")` bodies) — the checker has no binding for the
+    // duplicate-property symbol and dereferences `.flags` on undefined. Fall back
+    // to the externref plain-object lowering instead of crashing the compile.
+    let type: ts.Type | undefined;
+    try {
+      type = ctx.checker.getTypeAtLocation(expr);
+    } catch {
+      const fallback = compileObjectLiteralAsExternref(ctx, fctx, expr);
+      if (fallback) return fallback;
+      reportError(ctx, expr, "Cannot determine struct type for object literal");
+      return null;
+    }
     let typeName = resolveStructName(ctx, type);
     if (!typeName) {
       // Auto-register the struct type for inline object literals

--- a/tests/issue-1606.test.ts
+++ b/tests/issue-1606.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+
+// #1606 — Internal compiler crash on object-literal expressions parsed from a
+// statically-inlined `eval("...")` body.
+//
+// When `eval(<constant string>)` is inlined at compile time (#1163), the
+// parsed statements come from a foreign SourceFile that the TypeScript checker
+// has no bindings for. Object-literal codegen then made checker calls
+// (`getSignatureFromDeclaration` for get/set accessors, `getTypeAtLocation`
+// for duplicate-key data literals) that crash *inside* TypeScript with
+// "Cannot read properties of undefined (reading 'declarations' | 'flags' |
+// 'escapedName')". The fix guards those checker calls so the literal degrades
+// to a graceful diagnostic / externref fallback instead of an internal crash.
+//
+// This test asserts the crash no longer surfaces. We do NOT assert successful
+// compilation — wiring full getter/setter accessor support through the
+// eval-inline path is out of scope; the contract is "no internal compiler
+// crash".
+
+function internalCrashErrors(src: string): string[] {
+  const result = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  const msgs = (result.errors ?? []).map((e) => e.message);
+  return msgs.filter(
+    (m) =>
+      /Internal error compiling/.test(m) ||
+      /Codegen error: Cannot read properties of undefined/.test(m) ||
+      /Cannot read properties of undefined \(reading '(declarations|flags|escapedName)'\)/.test(m),
+  );
+}
+
+describe("#1606 — no internal crash on eval-inlined object literals", () => {
+  it("get/set accessor pair in inlined eval does not crash the compiler", () => {
+    const src = `
+      var s1 = "g";
+      var o: any;
+      eval("o = {get foo(){ return s1;},set foo(arg){ s1 = arg; }};");
+    `;
+    expect(internalCrashErrors(src)).toEqual([]);
+  });
+
+  it("set-only accessor in inlined eval does not crash the compiler", () => {
+    const src = `
+      var o: any;
+      eval("o = {set foo(arg){}};");
+    `;
+    expect(internalCrashErrors(src)).toEqual([]);
+  });
+
+  it("get-only accessor in inlined eval does not crash the compiler", () => {
+    const src = `
+      var o: any;
+      eval("o = {get foo(){ return 1; }};");
+    `;
+    expect(internalCrashErrors(src)).toEqual([]);
+  });
+
+  it("duplicate data-property keys in inlined eval do not crash the compiler", () => {
+    const src = `
+      var o: any = eval("({foo:0,foo:1});");
+    `;
+    expect(internalCrashErrors(src)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the internal compiler crash `Cannot read properties of undefined (reading 'declarations' | 'flags' | 'escapedName')` (#1606).
- Root cause: object literals spliced from a statically-inlined `eval("...")` body (#1163) come from a foreign `SourceFile` with no checker bindings. `compileArrowAsCallback` (`getSignatureFromDeclaration` on get/set accessors) and `compileObjectLiteral` (`getTypeAtLocation` on duplicate-key data literals) called into the checker on those nodes, and TypeScript itself threw on an undefined symbol.
- Fix: guard both checker calls in `src/codegen/closures.ts` and `src/codegen/literals.ts` so a checker-internal crash degrades to the existing graceful path (void/any return type for accessors; externref plain-object lowering for data literals) instead of crashing the whole compile.

## Impact
- Eliminates all 8 internal crashes in `language/expressions/object`.
- Full directory (306 tests) now reports **0 internal crashes** (was 8). Post-fix: `11.1.5_4-4-a-3` compiles and runs; the other 7 give a clean `compile_error: Missing __make_getter_callback import` (graceful unsupported-feature diagnostic — accessor-callback wiring through the eval-inline path is out of scope).
- Purely additive try/catch guards that only fire on a checker crash — existing object-literal/accessor tests are unchanged with vs. without the fix.

## Test plan
- [x] `tests/issue-1606.test.ts` — 4 cases (get/set pair, set-only, get-only, duplicate data keys); all fail without the fix, pass with it.
- [x] `npx tsc --noEmit` clean.
- [x] Full `language/expressions/object` dir: 0 internal crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)