### PR TITLE
fix(#1602): call-site argument coercion emits valid wasm

### DIFF
--- a/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
+++ b/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
@@ -1,7 +1,7 @@
 ---
 id: 1602
 title: "codegen: call-site argument coercion emits invalid wasm (call expected externref, found f64/other)"
-status: ready
+status: in-progress
 created: 2026-05-24
 updated: 2026-05-24
 priority: high
@@ -60,3 +60,45 @@ parameter type for these call paths.
 
 - The four example tests compile to valid Wasm.
 - >=30 of the 39 tests move off `compile_error`.
+
+## Root cause & fix (resolved)
+
+Three independent codegen bugs all surfaced as the same validator error
+(`call[N] expected externref, found ...`). Fixed:
+
+1. **Stale lifted func index in `new <FunctionExpression>(args)`**
+   (`src/codegen/expressions/new-super.ts`, `compileNewFunctionExpression`).
+   The constructor `call` used a `liftedFuncIdx` captured at registration
+   time, but compiling a spread-object argument (`{...null}` →
+   `__new_plain_object`/`__object_assign` late imports) shifts every defined
+   function index. The shift machinery patched the already-emitted `ref.func`
+   and `funcMap`, but the stale local was used for the `call`, so `call` and
+   `ref.func` disagreed. Fix: re-resolve the index from `ctx.funcMap` after
+   the arguments are compiled.
+
+2. **Sibling object-literal method collision** (`src/codegen/literals.ts`,
+   `compileObjectLiteralForStruct`). `{ *m(x = 42, y) {} }` (params
+   `[f64, externref]`) and `{ *m(x, y = 42) {} }` (params `[externref, f64]`)
+   structurally dedupe to the same method name and shared one `funcMap`
+   entry; the second body-compile overwrote the func type, so the first
+   literal's value-closure trampoline forwarded args in the wrong order. The
+   per-literal-funcIdx guard (#1557) only fired on a param-*count* mismatch.
+   Fix: also treat a same-arity param-*type/order* divergence as a mismatch,
+   and seed the fresh per-literal func with a type built from THIS literal's
+   params (so a trampoline reading the signature up front sees the right one).
+
+3. **Method-as-closure trampoline body snapshot**
+   (`src/codegen/closures.ts`, `emitObjectMethodAsClosure` +
+   `finalizeMethodTrampolines`). The trampoline forwarding body is built when
+   the method value is accessed, but the method's `func.typeIdx` can be
+   refined during its own body compilation. Fix: record each trampoline and
+   rebuild its forwarding body against the method's final signature in a
+   post-pass after all function bodies are compiled (guarded to same arity so
+   the shared wrapper func type's contract is preserved).
+
+**Out of scope (separate feature gap):** `(class { static async f() {} }).f`
+— accessing a static method on a class *expression* value yields a bare
+`ref.func` (the class constructor) and `.f` is never resolved to the static
+method, leaving a funcref uncoerced at the call. This is a missing
+class-expression static-member-access path in `property-access.ts`, not a
+call-site coercion bug; tracked for a follow-up.

--- a/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
+++ b/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
@@ -1,7 +1,7 @@
 ---
 id: 1602
 title: "codegen: call-site argument coercion emits invalid wasm (call expected externref, found f64/other)"
-status: in-progress
+status: in-review
 created: 2026-05-24
 updated: 2026-05-24
 priority: high

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -3074,11 +3074,62 @@ export function emitObjectMethodAsClosure(
   });
   ctx.funcMap.set(trampolineName, trampolineFuncIdx);
 
+  // (#1602) The method's `func.typeIdx` may be re-resolved after this point
+  // (generator/default-param methods finalize their param types/order during
+  // body compilation). The forwarding body built above snapshots the CURRENT
+  // signature; record it so a post-pass can rebuild it against the method's
+  // final signature once all function bodies are compiled.
+  ctx.pendingMethodTrampolines.push({
+    trampolineBody,
+    methodFuncIdx,
+    objStructTypeIdx,
+    userParamCount: userParams.length,
+  });
+
   // Emit: ref.func $trampoline, struct.new $closure_struct
   fctx.body.push({ op: "ref.func", funcIdx: trampolineFuncIdx });
   fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
 
   return { kind: "ref", typeIdx: structTypeIdx };
+}
+
+/**
+ * (#1602) Rebuild every object-method-as-closure trampoline body against the
+ * method's FINAL signature. Must run after all function bodies are compiled
+ * (so `func.typeIdx` re-resolution has settled) and BEFORE late-import index
+ * shifting, since the rebuilt body re-emits `call methodFuncIdx` at the current
+ * (pre-shift) index — the shift machinery then walks it like any other body.
+ *
+ * The trampoline's own signature (its wrapper func type) is left untouched; we
+ * only fix the forwarding body so its `local.get` count and the `call`'s
+ * operand types match the method's resolved params. The wrapper's user-param
+ * count is invariant (derived from the same method), so the trampoline param
+ * indices stay valid; only the per-arg coercion is what could drift, and any
+ * coercion the call needs is applied by mirroring the method's param types.
+ */
+export function finalizeMethodTrampolines(ctx: CodegenContext): void {
+  for (const t of ctx.pendingMethodTrampolines) {
+    const sig = getFuncSignature(ctx, t.methodFuncIdx);
+    if (!sig || sig.params.length === 0) continue;
+    const userParams = sig.params.slice(1);
+    // Only rebuild when the user-param arity is unchanged. The trampoline's
+    // OWN func type (its wrapper type) was fixed at registration with
+    // `userParamCount` params and is shared/cached, so it cannot change here;
+    // forwarding a different number of params would violate that contract and
+    // produce an invalid `local.get` index. An arity change (e.g. async method
+    // param injection) is a separate concern handled by its own codegen path.
+    if (userParams.length !== t.userParamCount) continue;
+    // Rebuild the body in place: ref.null <objStruct>, forward each user param,
+    // call the method. Mutate the existing array so the already-registered
+    // function keeps the same body reference.
+    t.trampolineBody.length = 0;
+    t.trampolineBody.push({ op: "ref.null", typeIdx: t.objStructTypeIdx } as Instr);
+    for (let i = 0; i < userParams.length; i++) {
+      t.trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
+    }
+    t.trampolineBody.push({ op: "call", funcIdx: t.methodFuncIdx } as Instr);
+  }
+  ctx.pendingMethodTrampolines.length = 0;
 }
 
 /**

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -128,6 +128,7 @@ export function createCodegenContext(
     widenedVarStructMap: new Map(),
     externrefAccessorVars: new Set(),
     pendingMathMethods: new Set(),
+    pendingMethodTrampolines: [],
     needsToUint32: false,
     classDeclarationMap: new Map(),
     wrapperNumberTypeIdx: -1,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -586,6 +586,22 @@ export interface CodegenContext {
   externrefAccessorVars: Set<string>;
   /** Math methods that need inline Wasm implementations */
   pendingMathMethods: Set<string>;
+  /**
+   * (#1602) Object-method-as-closure trampolines whose body forwards the
+   * method's params positionally. The method's `func.typeIdx` can be
+   * re-resolved (param types / order finalized) AFTER the trampoline was
+   * emitted, which would leave the eagerly-built forwarding body referencing a
+   * stale signature and produce an invalid module. We rebuild each trampoline
+   * body against the method's FINAL signature in a post-pass after all function
+   * bodies are compiled.
+   */
+  pendingMethodTrampolines: {
+    trampolineBody: Instr[];
+    methodFuncIdx: number;
+    objStructTypeIdx: number;
+    /** User-param count the wrapper func type was built with (excludes self). */
+    userParamCount: number;
+  }[];
   /** True if Math.clz32 or Math.imul is used — requires ToUint32 Wasm helper */
   needsToUint32: boolean;
   /** Map from class name → class AST declaration node */

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1196,8 +1196,15 @@ function compileNewFunctionExpression(
     compileExpression(ctx, fctx, flatArgs[i]!, formalParams[i]);
   }
 
-  // Call the lifted function
-  fctx.body.push({ op: "call", funcIdx: liftedFuncIdx });
+  // Call the lifted function. Re-resolve its index from funcMap: compiling the
+  // arguments above may have added late imports (e.g. an object-spread arg like
+  // `{...null}` pulls in `__new_plain_object`/`__object_assign`), which shifts
+  // every defined-function index up. The shift machinery patches funcMap and the
+  // already-emitted `ref.func` instruction, but the `liftedFuncIdx` captured at
+  // registration time is stale — using it here would make `call` and `ref.func`
+  // disagree, emitting an invalid module (#1602).
+  const resolvedLiftedIdx = ctx.funcMap.get(closureName) ?? liftedFuncIdx;
+  fctx.body.push({ op: "call", funcIdx: resolvedLiftedIdx });
 
   // new expression returns the constructed object — produce externref null
   // since we don't construct actual objects, and callers typically discard the result

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -39,6 +39,7 @@ import {
   repairStructTypeMismatches,
 } from "./fixups.js";
 import { emitInlineMathFunctions } from "./math-helpers.js";
+import { finalizeMethodTrampolines } from "./closures.js";
 import { peepholeOptimize } from "./peephole.js";
 import { addImport, addStringConstantGlobal } from "./registry/imports.js";
 import {
@@ -840,6 +841,11 @@ export function generateModule(
 
     // Third pass: compile function bodies
     compileDeclarations(ctx, ast.sourceFile);
+
+    // (#1602) Rebuild object-method-as-closure trampoline bodies against the
+    // method's now-final signature (param types/order may have been re-resolved
+    // during body compilation above).
+    finalizeMethodTrampolines(ctx);
 
     // Experimental IR path: for functions selected by `planIrCompilation`,
     // rebuild their bodies via the middle-end IR (AST → IR → Wasm). Runs
@@ -3172,6 +3178,9 @@ export function generateMultiModule(
     for (const sf of multiAst.sourceFiles) {
       compileDeclarations(ctx, sf);
     }
+
+    // (#1602) Rebuild method-closure trampolines against final method sigs.
+    finalizeMethodTrampolines(ctx);
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
     fixupStructNewArgCounts(ctx);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -50,6 +50,7 @@ import {
   ensureLateImport,
   flushLateImportShifts,
   registerResolveComputedKeyExpression,
+  valTypesMatch,
 } from "./shared.js";
 import { buildVecFromExternref, getVecInfo, pushDefaultValue } from "./type-coercion.js";
 
@@ -1090,22 +1091,50 @@ export function compileObjectLiteralForStruct(
       newParams.push(wasmType);
     }
 
-    // Compare against existing function's param count. (Result-type comparison
-    // is harder; param count is the canonical mismatch that causes
-    // "not enough arguments on the stack" trampoline failures.)
+    // Compare against the existing function's signature. A mismatched param
+    // count causes "not enough arguments on the stack" trampoline failures.
+    // (#1602) A param-type/order mismatch with the SAME count is just as
+    // breaking: two structurally-deduped sibling literals (e.g.
+    // `{ *m(x = 42, y) {} }` → params [f64, externref] and
+    // `{ *m(x, y = 42) {} }` → params [externref, f64]) share one funcMap
+    // entry, so the second body-compile overwrites the func's typeIdx and any
+    // method-as-closure trampoline built for the first literal forwards args in
+    // the wrong order, emitting an invalid `call`. Treat any per-position type
+    // divergence as a mismatch too, so each literal gets its own funcIdx.
     const localIdx = existingFuncIdx - ctx.numImportFuncs;
     const existingFunc = ctx.mod.functions[localIdx];
     if (!existingFunc) continue;
     const existingType = ctx.mod.types[existingFunc.typeIdx];
     if (!existingType || existingType.kind !== "func") continue;
-    if (existingType.params.length === newParams.length) continue;
+    const sameArity = existingType.params.length === newParams.length;
+    const sameParamTypes = sameArity && existingType.params.every((p, i) => valTypesMatch(p, newParams[i]!));
+    if (sameArity && sameParamTypes) continue;
 
     // Mismatch — allocate a fresh funcIdx for this literal's method without
     // touching the shared funcMap entry.
+    //
+    // (#1602) Seed the fresh func with a type built from THIS literal's actual
+    // params (`newParams`) and result, not the colliding sibling's type. A
+    // method-as-closure trampoline emitted for this literal reads the func's
+    // signature up front (before the body-compile pass refines it); a stale
+    // placeholder type would make the trampoline forward args in the wrong
+    // order/type and emit an invalid `call`.
+    const isGen = prop.asteriskToken !== undefined;
+    const methodSig = ctx.checker.getSignatureFromDeclaration(prop);
+    let methodResult: ValType[] = [];
+    if (isGen) {
+      methodResult = [{ kind: "externref" }];
+    } else if (methodSig) {
+      let rt = ctx.checker.getReturnTypeOfSignature(methodSig);
+      const isAsync = prop.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+      if (isAsync) rt = unwrapPromiseType(rt, ctx.checker);
+      if (rt && !isVoidType(rt)) methodResult = [resolveWasmType(ctx, rt)];
+    }
+    const freshTypeIdx = addFuncType(ctx, newParams, methodResult, `${fullName}__lit_type`);
     const freshFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.mod.functions.push({
       name: `${fullName}__lit${freshFuncIdx}`,
-      typeIdx: existingFunc.typeIdx, // placeholder; the body-compile step rewrites this
+      typeIdx: freshTypeIdx, // seeded from this literal's params; body-compile may refine
       locals: [],
       body: [],
       exported: false,

--- a/tests/issue-1602.test.ts
+++ b/tests/issue-1602.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1602 — call-site argument coercion / method-closure trampolines emitted
+ * invalid wasm. Three independent codegen bugs surfaced as
+ * `WebAssembly.validate` failures ("call[N] expected externref, found ...").
+ * Each `expect(WebAssembly.validate(...)).toBe(true)` is the regression guard:
+ * before the fix these modules failed validation at the offending `call`.
+ */
+function compileValid(source: string): Uint8Array {
+  const result = compile(source, { fileName: "test.ts" });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  return result.binary;
+}
+
+describe("#1602 call-site argument coercion emits valid wasm", () => {
+  it("new function(obj){...}({...null}) with an extern call in the body", () => {
+    // Bug A: the `new <FunctionExpression>(args)` call captured a stale lifted
+    // func index — compiling the `{...null}` spread arg added late imports that
+    // shifted every function index, but the `call` used the pre-shift value,
+    // disagreeing with the already-shifted `ref.func`.
+    compileValid(`
+      function asv(a: any, b: any): void {}
+      export function test(): number {
+        var callCount = 0;
+        new function (obj) {
+          asv(Object.keys(obj).length, 0);
+          callCount += 1;
+        }({ ...null });
+        return callCount;
+      }
+    `);
+  });
+
+  it("sibling generator methods with default params in different positions", () => {
+    // Bug B: `{ *m(x = 42, y) {} }` (params [f64, externref]) and
+    // `{ *m(x, y = 42) {} }` (params [externref, f64]) structurally dedupe to
+    // the same method name and shared one funcMap entry. The second body
+    // overwrote the func type, so the first method's value-closure trampoline
+    // forwarded args in the wrong order. Each literal must get its own funcIdx.
+    compileValid(`
+      export function test(): number {
+        var f1 = ({ *m(x = 42) {} }).m;
+        var f2 = ({ *m(x = 42, y) {} }).m;
+        var f3 = ({ *m(x, y = 42) {} }).m;
+        var f4 = ({ *m(x, y = 42, z) {} }).m;
+        return (f1 ? 1 : 0) + (f2 ? 1 : 0) + (f3 ? 1 : 0) + (f4 ? 1 : 0);
+      }
+    `);
+  });
+
+  it("async object method accessed as a value", () => {
+    // Bug C: the method-as-closure trampoline body snapshotted the method
+    // signature before it was finalized; rebuilding it against the final
+    // signature after all bodies compiled keeps the forwarding consistent.
+    compileValid(`
+      export function test(): number {
+        var f = ({ async m() {} }).m;
+        return f ? 1 : 0;
+      }
+    `);
+  });
+
+  it("the four object-method literals together compile to one valid module", () => {
+    compileValid(`
+      function asv(a: any, b: any): void {}
+      export function test(): number {
+        var a = ({ *m(x = 42) {} }).m;
+        var b = ({ *m(x = 42, y) {} }).m;
+        var c = ({ *m(x, y = 42) {} }).m;
+        asv(a, b);
+        asv(c, 0);
+        return 1;
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1602 — three independent codegen bugs that all surfaced as the same
validator error `call[N] expected externref, found ...` on ~39 test262 tests.

1. **Stale lifted func index in `new <FunctionExpression>(args)`**
   (`new-super.ts`). Compiling a spread-object arg (`{...null}`) pulls in late
   imports that shift every defined-function index; the shift machinery patched
   the already-emitted `ref.func` and `funcMap`, but the `call` used a stale
   `liftedFuncIdx` captured before the args were compiled, so `call` and
   `ref.func` disagreed. Now re-resolved from `funcMap` after the args compile.

2. **Sibling object-literal method collision** (`literals.ts`).
   `{ *m(x = 42, y) {} }` (params `[f64, externref]`) and
   `{ *m(x, y = 42) {} }` (params `[externref, f64]`) structurally dedupe to one
   method name and shared a single `funcMap` entry; the second body-compile
   overwrote the func type and broke the first literal's value-closure
   trampoline. The per-literal-funcIdx guard (#1557) only fired on a param
   **count** mismatch — it now also fires on a same-arity param **type/order**
   divergence, and seeds the fresh func with this literal's own signature so a
   trampoline reading the signature up front sees the right one.

3. **Method-as-closure trampoline body snapshot** (`closures.ts`). The
   forwarding body is built when the method value is accessed, but the method's
   `func.typeIdx` may be refined during its own body compilation. A new
   `finalizeMethodTrampolines` post-pass (run after all bodies compile, before
   late-import shifting) rebuilds each trampoline body against the method's
   final signature, guarded to same arity so the shared wrapper func type's
   contract is preserved.

## Out of scope

`(class { static async f() {} }).f` — accessing a static method on a class
*expression* value yields a bare `ref.func` (the constructor) and `.f` is never
resolved to the static method. That's a missing class-expression
static-member-access path in `property-access.ts`, a distinct feature gap, not
a call-site coercion bug. Documented in the issue for follow-up.

## Test plan

- [x] `tests/issue-1602.test.ts` (4 cases) — all green
- [x] The three issue example tests (`spread-obj-null`,
      `generator-length-dflt`, `async-method-object`) compile to valid Wasm
      via the test262 wrap pipeline
- [x] `tsc --noEmit` clean
- [x] Equivalence failures observed locally are a pre-existing baseline
      (`tests/classes.test.ts` fails identically with this change reverted —
      a `string_constants` harness import gap, cf. #1659), not a regression
- [ ] CI full test262 + quality gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)