### PR TITLE
fix(#1603): optional-chaining short-circuit emits valid wasm

### DIFF
--- a/plan/issues/1603-optional-chaining-ref-is-null-invalid-wasm.md
+++ b/plan/issues/1603-optional-chaining-ref-is-null-invalid-wasm.md
@@ -1,7 +1,7 @@
 ---
 id: 1603
 title: "codegen: optional-chaining short-circuit emits invalid wasm (ref.is_null expected i32, found ref)"
-status: ready
+status: in-review
 created: 2026-05-24
 updated: 2026-05-24
 priority: high

--- a/src/codegen/expressions/calls-optional.ts
+++ b/src/codegen/expressions/calls-optional.ts
@@ -26,10 +26,6 @@ export function compileOptionalCallExpression(
   const objType = compileExpression(ctx, fctx, propAccess.expression);
   if (!objType) return null;
 
-  const tmp = allocLocal(fctx, `__optcall_${fctx.locals.length}`, objType);
-  fctx.body.push({ op: "local.tee", index: tmp });
-  fctx.body.push({ op: "ref.is_null" });
-
   let callReturnType: ValType | typeof VOID_RESULT = VOID_RESULT;
   const sig = ctx.checker.getResolvedSignature(expr);
   if (sig) {
@@ -37,6 +33,24 @@ export function compileOptionalCallExpression(
     if (!isVoidType(retType)) callReturnType = resolveWasmType(ctx, retType);
   }
   let resultType: ValType = callReturnType === VOID_RESULT ? { kind: "externref" } : callReturnType;
+
+  // `?.` short-circuits on null/undefined. `ref.is_null` only validates on a
+  // reference operand, but the receiver can lower to a non-reference value type
+  // (e.g. a `const x = undefined` stored as an i32 global — #1603). A
+  // non-reference receiver here is the compiler's representation of
+  // `undefined`/`null`, which short-circuits the call: drop it and emit the
+  // default result.
+  if (objType.kind !== "ref" && objType.kind !== "ref_null" && objType.kind !== "externref") {
+    fctx.body.push({ op: "drop" });
+    let shortType: ValType = resultType;
+    if (shortType.kind === "ref") shortType = { kind: "ref_null", typeIdx: shortType.typeIdx };
+    fctx.body.push(...defaultValueInstrs(shortType));
+    return shortType;
+  }
+
+  const tmp = allocLocal(fctx, `__optcall_${fctx.locals.length}`, objType);
+  fctx.body.push({ op: "local.tee", index: tmp });
+  fctx.body.push({ op: "ref.is_null" });
 
   const savedBody = pushBody(fctx);
   const tsReceiverType = ctx.checker.getTypeAtLocation(propAccess.expression);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -748,10 +748,6 @@ export function compileOptionalPropertyAccess(
   const objType = compileExpression(ctx, fctx, expr.expression);
   if (!objType) return null;
 
-  const tmp = allocLocal(fctx, `__opt_${fctx.locals.length}`, objType);
-  fctx.body.push({ op: "local.tee", index: tmp });
-  fctx.body.push({ op: "ref.is_null" });
-
   // Determine result type from the TS type of the property being accessed
   const tsPropType = ctx.checker.getTypeAtLocation(expr);
   let resultType: ValType = resolveWasmType(ctx, tsPropType);
@@ -759,6 +755,28 @@ export function compileOptionalPropertyAccess(
   if (resultType.kind === "ref" || resultType.kind === "ref_null") {
     resultType = { kind: "externref" };
   }
+
+  // `?.` short-circuits on null/undefined. `ref.is_null` only validates on a
+  // reference operand, but the receiver can lower to a non-reference value
+  // type — e.g. a module-level `const obj = undefined` is stored as an i32
+  // global, so reading it yields i32 (#1603). A non-reference receiver here is
+  // the compiler's representation of `undefined`/`null`, which always
+  // short-circuits the chain: drop the receiver and emit the default result.
+  if (objType.kind !== "ref" && objType.kind !== "ref_null" && objType.kind !== "externref") {
+    fctx.body.push({ op: "drop" });
+    if (resultType.kind === "f64") {
+      fctx.body.push({ op: "f64.const", value: 0 });
+    } else if (resultType.kind === "i32") {
+      fctx.body.push({ op: "i32.const", value: 0 });
+    } else {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    return resultType;
+  }
+
+  const tmp = allocLocal(fctx, `__opt_${fctx.locals.length}`, objType);
+  fctx.body.push({ op: "local.tee", index: tmp });
+  fctx.body.push({ op: "ref.is_null" });
 
   const savedBody = fctx.body;
   fctx.savedBodies.push(savedBody);

--- a/tests/equivalence/issue-1603.test.ts
+++ b/tests/equivalence/issue-1603.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm, assertEquivalent, compile } from "./helpers.js";
+
+// #1603 — optional-chaining short-circuit emitted invalid wasm:
+// `ref.is_null expected reference type, found local.tee of type i32`.
+//
+// Root cause: the `?.` lowering unconditionally emitted `ref.is_null` on the
+// receiver, but a module-level `const x = undefined` is stored as an i32
+// global, so reading it inside a closure yields an i32 — applying `ref.is_null`
+// to a non-reference value is invalid wasm. A non-reference receiver here is the
+// compiler's representation of `undefined`/`null`, so the chain short-circuits.
+describe("optional chaining on non-reference (undefined) receiver (#1603)", () => {
+  it("module-level `const x = undefined` accessed via ?. inside a closure compiles to valid wasm", async () => {
+    // Mirrors test262 language/expressions/optional-chaining/
+    // iteration-statement-for-of-type-error.js, which captures a
+    // module-level undefined const inside a callback and short-circuits `?.`.
+    const exports = await compileToWasm(`
+      const obj = undefined;
+      function run(cb: () => void): void { /* don't invoke — undefined would throw */ }
+      export function test(): number {
+        run(function () {
+          const v = (obj as any)?.a;
+        });
+        return 0;
+      }
+    `);
+    expect(exports.test!()).toBe(0);
+  });
+
+  it("optional property access on undefined const short-circuits (?? fallback runs)", async () => {
+    await assertEquivalent(
+      `
+      const obj = undefined;
+      export function test(): number {
+        return (obj as any)?.a ?? 7;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("optional property AND optional call on an undefined const both compile to valid wasm", () => {
+    // The optional-call lowering carried the same unguarded `ref.is_null`
+    // (calls-optional.ts). Both forms must validate when the receiver lowers to
+    // a non-reference value type.
+    const src = `
+      const obj = undefined;
+      export function test(): number {
+        const a = (obj as any)?.a ?? 1;
+        const b = (obj as any)?.foo() ?? 2;
+        return a + b;
+      }
+    `;
+    const result = compile(src);
+    expect(result.success).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- The `?.` lowering unconditionally emitted `ref.is_null` on the receiver. A module-level `const x = undefined` is stored as an i32 global, so reading it (e.g. captured in a closure) yields an i32 — applying `ref.is_null` to a non-reference value produced **invalid wasm**: `ref.is_null expected reference type, found local.tee of type i32`.
- A non-reference receiver in this position is the compiler's representation of `undefined`/`null`, which always short-circuits the chain. Both `compileOptionalPropertyAccess` (property-access.ts) and `compileOptionalCallExpression` (calls-optional.ts) now guard: when the receiver lowers to a non-reference value type, drop it and emit the default (short-circuit) result instead of `ref.is_null`.

Fixes #1603. Reproduced via `test262/.../optional-chaining/iteration-statement-for-of-type-error.js`, which now compiles to valid wasm.

## Test plan
- [x] New regression test `tests/equivalence/issue-1603.test.ts` (3 cases: closure-captured undefined compiles+runs valid; `?.a ?? fallback` equivalence; property + optional-call both validate).
- [x] Full local equivalence suite: 107 failed on this branch vs 110 failed on clean main (same concurrent-agent contention) — net -3, no new regressions.
- [x] CI test262 conformance gate (validates the 8 optional-chaining `compile_error` tests move off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)