### PR TITLE
fix(#1654): ArrayBuffer/DataView/TypedArray valid under --target wasi

### DIFF
--- a/plan/issues/1654-wasi-dataview-arraybuffer-invalid-module.md
+++ b/plan/issues/1654-wasi-dataview-arraybuffer-invalid-module.md
@@ -1,9 +1,10 @@
 ---
 id: 1654
 title: "wasi: DataView/ArrayBuffer-backed TypedArrays emit an invalid wasm module under --target wasi"
-status: backlog
+status: done
 created: 2026-05-24
 updated: 2026-05-24
+completed: 2026-05-24
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -76,3 +77,56 @@ specifically the ArrayBuffer-backing global, not TypedArrays in general.
 - A test (e.g. `tests/issue-1654-*.test.ts`) pins compile + WASI-module
   validity + a byte round-trip for the ArrayBuffer/DataView path.
 - No regression to the literal-array `new Uint8Array([...])` path (#1651).
+
+## Implementation notes (resolution)
+
+The `unknown global` was only the surface symptom. Root-causing it exposed
+**three** distinct dual-mode gaps; all three were the same underlying problem
+(ArrayBuffer/DataView/TypedArray codegen assumed the JS host, with no
+standalone Wasm-native path):
+
+1. **Invalid module (`global.get -1`)** — the ArrayBuffer/DataView/Array
+   RangeError validation paths in `src/codegen/expressions/new-super.ts`
+   emitted `global.get strIdx` where `strIdx` came from
+   `ctx.stringGlobalMap.get(msg)`. In `nativeStrings` mode (auto-enabled for
+   `--target wasi`), `addStringConstantGlobal` stores the sentinel `-1` because
+   strings are materialised *inline*, not via an imported global — so the
+   throw branch emitted `global.get -1`, an out-of-range global. Fixed by
+   routing all eight RangeError throw sites through
+   `stringConstantExternrefInstrs(ctx, msg)` (native-strings.ts), which already
+   handles both modes (inline NativeString → `extern.convert_any` in WASI,
+   `global.get` in JS-host).
+
+2. **`dv.setUint32(...)` was a silent no-op** — DataView accessors had no
+   standalone implementation; only the JS runtime (`runtime.ts`) implemented
+   them via the `__dv_byte_{get,set}` exports + a real native `DataView`. In
+   no-JS-host mode the method call fell through and its args were compiled and
+   dropped, writing nothing. Fixed with a new module
+   `src/codegen/dataview-native.ts` (`emitDataViewAccessor`) that emits
+   Wasm-native byte read/write directly into the `i32_byte` vec backing array
+   (field 0 = len, field 1 = byte array). Honours the `littleEndian` flag at
+   runtime; covers get/set {Uint,Int}{8,16,32}, getFloat/setFloat{32,64}.
+   Hooked into `calls.ts` *before* the extern-class dispatch, gated on
+   `noJsHost(ctx) && receiver is DataView`.
+
+3. **`new Uint8Array(arrayBuffer)` created an empty array** — the TypedArray
+   constructor treated *any* single arg as a numeric length, so an ArrayBuffer
+   arg was coerced f64 (→ 0) and the bytes were never copied. Fixed by
+   detecting an ArrayBuffer/DataView/SharedArrayBuffer arg
+   (`emitTypedArrayFromByteBuffer` in new-super.ts) and copying the `i32_byte`
+   backing bytes into the TypedArray's f64-element vec (the representation
+   `process.stdout.write` consumes).
+
+**New Wasm opcodes**: `i32.reinterpret_f32` (0xBC) and `f32.reinterpret_i32`
+(0xBE) were added to the `Instr` union, both encoders (binary.ts/object.ts),
+and the stack-balance unary group — needed for Float32 DataView accessors.
+
+**Verified under real wasmtime** (`-W gc=y,function-references=y,tail-call=y,
+exceptions=y`): the repro emits exactly `0b 00 00 00`; a mixed LE/BE/8/16/32
+get+set round-trip produced the expected byte pattern. Committed test
+`tests/issue-1654-wasi-dataview-arraybuffer.test.ts` pins the same via the
+CI-portable raw-byte WASI shim. No regression: the pre-existing JS-host
+DataView suites (#1056, #1064, #1515) and the literal-array path (#1651) all
+still pass; the `string_constants`-import failures in `typed-array-basic` /
+`arraybuffer-dataview` are a pre-existing test-harness gap (identical
+pass/fail counts before and after this change).

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -1,0 +1,488 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Native (standalone / WASI) DataView and ArrayBuffer-backed TypedArray
+ * support (#1654).
+ *
+ * In JS-host mode, DataView.prototype.{get,set}{Uint,Int,Float}* are
+ * implemented by the JS runtime, which materializes a real `DataView` over the
+ * WasmGC byte array (`__dv_byte_{get,set}` exports, see codegen/index.ts).
+ *
+ * In no-JS-host mode (`--target wasi` / `--target standalone`) there is no JS
+ * runtime, so those accessors had no implementation and the compiler silently
+ * dropped the call (writing nothing, reading garbage) — and the
+ * ArrayBuffer-length RangeError path referenced a `global.get -1` sentinel,
+ * producing an *invalid* module (`unknown global`).
+ *
+ * This module emits Wasm-native byte read/write directly into the `i32_byte`
+ * vec struct that backs ArrayBuffer / DataView (field 0 = length i32, field 1 =
+ * array of i32, one byte per element, values 0..255). Multi-byte accessors
+ * honour the `littleEndian` flag at runtime.
+ *
+ * Backing-store representation:
+ *   ArrayBuffer / DataView  → vec "i32_byte"  (one i32 per byte, 0..255)
+ *   Uint8Array (write path) → vec "f64"       (process.stdout.write helper)
+ *
+ * The receiver (`this`) of a DataView accessor is an externref holding the
+ * i32_byte vec; we `any.convert_extern` + `ref.cast` to recover the struct.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
+
+/** DataView accessor descriptor parsed from a method name like "getUint32". */
+interface DvAccessor {
+  kind: "get" | "set";
+  /** Number of bytes the element occupies (1, 2, 4, 8). */
+  bytes: number;
+  /** Signed integer read (Int8/Int16/Int32) — sign-extend on read. */
+  signed: boolean;
+  /** Float element (Float32/Float64) — reinterpret bits. */
+  float: boolean;
+}
+
+const DV_ACCESSORS: Record<string, DvAccessor> = {
+  getInt8: { kind: "get", bytes: 1, signed: true, float: false },
+  getUint8: { kind: "get", bytes: 1, signed: false, float: false },
+  getInt16: { kind: "get", bytes: 2, signed: true, float: false },
+  getUint16: { kind: "get", bytes: 2, signed: false, float: false },
+  getInt32: { kind: "get", bytes: 4, signed: true, float: false },
+  getUint32: { kind: "get", bytes: 4, signed: false, float: false },
+  getFloat32: { kind: "get", bytes: 4, signed: false, float: true },
+  getFloat64: { kind: "get", bytes: 8, signed: false, float: true },
+  setInt8: { kind: "set", bytes: 1, signed: true, float: false },
+  setUint8: { kind: "set", bytes: 1, signed: false, float: false },
+  setInt16: { kind: "set", bytes: 2, signed: true, float: false },
+  setUint16: { kind: "set", bytes: 2, signed: false, float: false },
+  setInt32: { kind: "set", bytes: 4, signed: true, float: false },
+  setUint32: { kind: "set", bytes: 4, signed: false, float: false },
+  setFloat32: { kind: "set", bytes: 4, signed: false, float: true },
+  setFloat64: { kind: "set", bytes: 8, signed: false, float: true },
+};
+
+export function isDataViewAccessor(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(DV_ACCESSORS, name);
+}
+
+/** Lazily ensure the i32_byte vec type exists and return its struct/array indices. */
+function i32ByteVec(ctx: CodegenContext): { vecTypeIdx: number; arrTypeIdx: number } {
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  return { vecTypeIdx, arrTypeIdx };
+}
+
+/**
+ * Emit native code for `dv.{get,set}{Uint,Int,Float}N(byteOffset[, value][, littleEndian])`
+ * operating directly on the i32_byte backing array.
+ *
+ * Preconditions on the Wasm stack: nothing (this function compiles all operands).
+ * Postcondition: for getters, the numeric result (f64) is on the stack; for
+ * setters, nothing is pushed (void).
+ *
+ * Returns the result ValType for getters, or null for setters (void).
+ *
+ * `compileExpr`/`offsetArg`/`valueArg`/`leArg` are passed in so this module
+ * stays decoupled from the big calls.ts dispatcher.
+ */
+export function emitDataViewAccessor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  methodName: string,
+  receiver: import("../ts-api.js").ts.Expression,
+  args: readonly import("../ts-api.js").ts.Expression[],
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): { kind: "get"; result: ValType } | { kind: "set" } | null {
+  const acc = DV_ACCESSORS[methodName];
+  if (!acc) return null;
+
+  const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
+  if (arrTypeIdx < 0) return null;
+
+  // Recover the i32_byte vec struct from the (externref) receiver and stash
+  // its backing array in a local. `dv` may be typed as a struct ref already
+  // (when DataView codegen returns the buffer struct) or externref.
+  const arrLocal = allocLocal(fctx, `__dvn_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const recvType = compileExpr(receiver);
+  if (recvType && recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  } else if (recvType && (recvType.kind === "ref" || recvType.kind === "ref_null")) {
+    if ("typeIdx" in recvType && recvType.typeIdx !== vecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+    }
+  } else {
+    return null;
+  }
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // byteOffset (arg 0) → i32 index.
+  const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
+  if (args.length >= 1) {
+    compileExpr(args[0]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: offLocal });
+
+  if (acc.kind === "get") {
+    // littleEndian flag is the 2nd arg for getters (getUintN(off, le)).
+    const leLocal = emitLittleEndianFlag(ctx, fctx, args[1], compileExpr);
+    emitReadBytes(ctx, fctx, acc, arrLocal, offLocal, leLocal, arrTypeIdx);
+    return { kind: "get", result: { kind: "f64" } };
+  }
+
+  // Setter: value is arg 1, littleEndian is arg 2.
+  const valLocal = allocLocal(fctx, `__dvn_val_${fctx.locals.length}`, { kind: "f64" });
+  if (args.length >= 2) {
+    compileExpr(args[1]!, { kind: "f64" });
+  } else {
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: valLocal });
+  const leLocal = emitLittleEndianFlag(ctx, fctx, args[2], compileExpr);
+  emitWriteBytes(ctx, fctx, acc, arrLocal, offLocal, valLocal, leLocal, arrTypeIdx);
+  return { kind: "set" };
+}
+
+/**
+ * Compile the optional `littleEndian` argument into an i32 local (0 = big
+ * endian, 1 = little endian). When absent, defaults to 0 (big endian) per the
+ * DataView spec. The argument is `boolean`; truthiness is captured via the
+ * standard i32 boolean lowering.
+ */
+function emitLittleEndianFlag(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  leArg: import("../ts-api.js").ts.Expression | undefined,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): number {
+  const leLocal = allocLocal(fctx, `__dvn_le_${fctx.locals.length}`, { kind: "i32" });
+  if (leArg) {
+    const t = compileExpr(leArg, { kind: "i32" });
+    // If the boolean compiled to f64 (boxed), normalize to i32 truthiness.
+    if (t && t.kind === "f64") {
+      fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+      fctx.body.push({ op: "f64.ne" } as Instr);
+    } else if (t && t.kind !== "i32") {
+      // Non-i32, non-f64 (e.g. externref) — drop and default to big endian.
+      fctx.body.push({ op: "drop" } as Instr);
+      fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    }
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: leLocal });
+  return leLocal;
+}
+
+/** Push `arr[off + k]` (unsigned byte 0..255) as i32. */
+function pushByte(fctx: FunctionContext, arrLocal: number, offLocal: number, k: number, arrTypeIdx: number): void {
+  fctx.body.push({ op: "local.get", index: arrLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+  if (k !== 0) {
+    fctx.body.push({ op: "i32.const", value: k } as Instr);
+    fctx.body.push({ op: "i32.add" } as Instr);
+  }
+  fctx.body.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
+  // Mask to a byte — the backing array holds 0..255 already, but defensively
+  // keep only the low 8 bits so sign/overflow can't leak in.
+  fctx.body.push({ op: "i32.const", value: 0xff } as Instr);
+  fctx.body.push({ op: "i32.and" } as Instr);
+}
+
+/**
+ * Assemble the N bytes into an i32 (for <=4 byte ints / Float32) or an i64
+ * (for Float64), honouring endianness, then convert to the f64 result.
+ */
+function emitReadBytes(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  acc: DvAccessor,
+  arrLocal: number,
+  offLocal: number,
+  leLocal: number,
+  arrTypeIdx: number,
+): void {
+  if (acc.bytes === 1) {
+    pushByte(fctx, arrLocal, offLocal, 0, arrTypeIdx);
+    if (acc.signed) {
+      // sign-extend an 8-bit value: (x << 24) >> 24
+      fctx.body.push({ op: "i32.const", value: 24 } as Instr);
+      fctx.body.push({ op: "i32.shl" } as Instr);
+      fctx.body.push({ op: "i32.const", value: 24 } as Instr);
+      fctx.body.push({ op: "i32.shr_s" } as Instr);
+      fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    } else {
+      fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+    }
+    return;
+  }
+
+  if (acc.bytes === 8) {
+    // Float64 only — assemble an i64 then f64.reinterpret_i64.
+    emitReadI64(fctx, acc, arrLocal, offLocal, leLocal, arrTypeIdx);
+    fctx.body.push({ op: "f64.reinterpret_i64" } as Instr);
+    return;
+  }
+
+  // 2 or 4 byte values — assemble an i32 with a runtime endianness branch.
+  // Result i32 is left on the stack, then converted to f64.
+  emitReadI32(fctx, acc.bytes, arrLocal, offLocal, leLocal, arrTypeIdx);
+
+  if (acc.float) {
+    // Float32: reinterpret the 32-bit pattern, then promote to f64.
+    fctx.body.push({ op: "f32.reinterpret_i32" } as Instr);
+    fctx.body.push({ op: "f64.promote_f32" } as Instr);
+    return;
+  }
+
+  if (acc.signed) {
+    if (acc.bytes === 2) {
+      // sign-extend 16-bit: (x << 16) >> 16
+      fctx.body.push({ op: "i32.const", value: 16 } as Instr);
+      fctx.body.push({ op: "i32.shl" } as Instr);
+      fctx.body.push({ op: "i32.const", value: 16 } as Instr);
+      fctx.body.push({ op: "i32.shr_s" } as Instr);
+    }
+    fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+  }
+}
+
+/**
+ * Assemble a 2- or 4-byte little/big-endian integer into an i32 on the stack.
+ * Emits a runtime branch on `leLocal`.
+ */
+function emitReadI32(
+  fctx: FunctionContext,
+  bytes: number,
+  arrLocal: number,
+  offLocal: number,
+  leLocal: number,
+  arrTypeIdx: number,
+): void {
+  // little-endian assembly: b0 | b1<<8 | b2<<16 | b3<<24
+  const leInstrs: Instr[] = [];
+  buildIntoBranch(leInstrs, fctx, bytes, arrLocal, offLocal, arrTypeIdx, /*little*/ true);
+  const beInstrs: Instr[] = [];
+  buildIntoBranch(beInstrs, fctx, bytes, arrLocal, offLocal, arrTypeIdx, /*little*/ false);
+
+  fctx.body.push({ op: "local.get", index: leLocal } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: leInstrs,
+    else: beInstrs,
+  } as unknown as Instr);
+}
+
+/**
+ * Build the byte-assembly instructions for one endianness into `out`.
+ * The assembly does not reference `fctx.body`; it composes a self-contained
+ * Instr[] that pushes a single i32.
+ */
+function buildIntoBranch(
+  out: Instr[],
+  _fctx: FunctionContext,
+  bytes: number,
+  arrLocal: number,
+  offLocal: number,
+  arrTypeIdx: number,
+  little: boolean,
+): void {
+  const byteAt = (k: number): Instr[] => {
+    const seq: Instr[] = [{ op: "local.get", index: arrLocal } as Instr, { op: "local.get", index: offLocal } as Instr];
+    if (k !== 0) {
+      seq.push({ op: "i32.const", value: k } as Instr);
+      seq.push({ op: "i32.add" } as Instr);
+    }
+    seq.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
+    seq.push({ op: "i32.const", value: 0xff } as Instr);
+    seq.push({ op: "i32.and" } as Instr);
+    return seq;
+  };
+
+  // Accumulate: for each byte k (0..bytes-1), shift = little ? k*8 : (bytes-1-k)*8
+  for (let k = 0; k < bytes; k++) {
+    const shift = little ? k * 8 : (bytes - 1 - k) * 8;
+    out.push(...byteAt(k));
+    if (shift !== 0) {
+      out.push({ op: "i32.const", value: shift } as Instr);
+      out.push({ op: "i32.shl" } as Instr);
+    }
+    if (k > 0) out.push({ op: "i32.or" } as Instr);
+  }
+}
+
+/** Assemble an 8-byte little/big-endian value into an i64 on the stack. */
+function emitReadI64(
+  fctx: FunctionContext,
+  _acc: DvAccessor,
+  arrLocal: number,
+  offLocal: number,
+  leLocal: number,
+  arrTypeIdx: number,
+): void {
+  const build = (little: boolean): Instr[] => {
+    const out: Instr[] = [];
+    const byteAt = (k: number): Instr[] => {
+      const seq: Instr[] = [
+        { op: "local.get", index: arrLocal } as Instr,
+        { op: "local.get", index: offLocal } as Instr,
+      ];
+      if (k !== 0) {
+        seq.push({ op: "i32.const", value: k } as Instr);
+        seq.push({ op: "i32.add" } as Instr);
+      }
+      seq.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
+      seq.push({ op: "i32.const", value: 0xff } as Instr);
+      seq.push({ op: "i32.and" } as Instr);
+      seq.push({ op: "i64.extend_i32_u" } as Instr);
+      return seq;
+    };
+    for (let k = 0; k < 8; k++) {
+      const shift = little ? k * 8 : (7 - k) * 8;
+      out.push(...byteAt(k));
+      if (shift !== 0) {
+        out.push({ op: "i64.const", value: BigInt(shift) } as Instr);
+        out.push({ op: "i64.shl" } as Instr);
+      }
+      if (k > 0) out.push({ op: "i64.or" } as Instr);
+    }
+    return out;
+  };
+  fctx.body.push({ op: "local.get", index: leLocal } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i64" } },
+    then: build(true),
+    else: build(false),
+  } as unknown as Instr);
+}
+
+/** Store `arr[off + k] = byte` (byte already an i32 0..255 on caller's responsibility). */
+function emitStoreByte(
+  out: Instr[],
+  arrLocal: number,
+  offLocal: number,
+  k: number,
+  byte: Instr[],
+  arrTypeIdx: number,
+): void {
+  out.push({ op: "local.get", index: arrLocal } as Instr);
+  out.push({ op: "local.get", index: offLocal } as Instr);
+  if (k !== 0) {
+    out.push({ op: "i32.const", value: k } as Instr);
+    out.push({ op: "i32.add" } as Instr);
+  }
+  out.push(...byte);
+  out.push({ op: "array.set", typeIdx: arrTypeIdx } as Instr);
+}
+
+/**
+ * Write the value into the backing byte array. The value local is f64; we
+ * convert to the integer/bit representation then store each byte with an
+ * endianness branch.
+ */
+function emitWriteBytes(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  acc: DvAccessor,
+  arrLocal: number,
+  offLocal: number,
+  valLocal: number,
+  leLocal: number,
+  arrTypeIdx: number,
+): void {
+  if (acc.bytes === 1) {
+    // arr[off] = trunc(val) & 0xff
+    const out: Instr[] = [];
+    emitStoreByte(
+      out,
+      arrLocal,
+      offLocal,
+      0,
+      [
+        { op: "local.get", index: valLocal } as Instr,
+        { op: "i32.trunc_sat_f64_s" } as Instr,
+        { op: "i32.const", value: 0xff } as Instr,
+        { op: "i32.and" } as Instr,
+      ],
+      arrTypeIdx,
+    );
+    fctx.body.push(...out);
+    return;
+  }
+
+  if (acc.bytes === 8) {
+    // Float64: bits = i64.reinterpret_f64(val); store 8 bytes.
+    const bitsLocal = allocLocal(fctx, `__dvn_bits64_${fctx.locals.length}`, { kind: "i64" });
+    fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+    fctx.body.push({ op: "i64.reinterpret_f64" } as Instr);
+    fctx.body.push({ op: "local.set", index: bitsLocal } as Instr);
+    const storeAll = (little: boolean): Instr[] => {
+      const out: Instr[] = [];
+      for (let k = 0; k < 8; k++) {
+        const shift = little ? k * 8 : (7 - k) * 8;
+        const byte: Instr[] = [{ op: "local.get", index: bitsLocal } as Instr];
+        if (shift !== 0) {
+          byte.push({ op: "i64.const", value: BigInt(shift) } as Instr);
+          byte.push({ op: "i64.shr_u" } as Instr);
+        }
+        byte.push({ op: "i32.wrap_i64" } as Instr);
+        byte.push({ op: "i32.const", value: 0xff } as Instr);
+        byte.push({ op: "i32.and" } as Instr);
+        emitStoreByte(out, arrLocal, offLocal, k, byte, arrTypeIdx);
+      }
+      return out;
+    };
+    fctx.body.push({ op: "local.get", index: leLocal } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: storeAll(true),
+      else: storeAll(false),
+    } as unknown as Instr);
+    return;
+  }
+
+  // 2 or 4 byte integers (or Float32) — derive an i32 bit pattern.
+  const bitsLocal = allocLocal(fctx, `__dvn_bits32_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  if (acc.float) {
+    // Float32: demote f64→f32, reinterpret to i32 bits.
+    fctx.body.push({ op: "f32.demote_f64" } as Instr);
+    fctx.body.push({ op: "i32.reinterpret_f32" } as Instr);
+  } else {
+    // Integer: truncate toward zero. trunc_sat_f64_s gives a 32-bit pattern;
+    // for unsigned/odd widths the low N bytes are what matters.
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: bitsLocal } as Instr);
+
+  const storeAll = (little: boolean): Instr[] => {
+    const out: Instr[] = [];
+    for (let k = 0; k < acc.bytes; k++) {
+      const shift = little ? k * 8 : (acc.bytes - 1 - k) * 8;
+      const byte: Instr[] = [{ op: "local.get", index: bitsLocal } as Instr];
+      if (shift !== 0) {
+        byte.push({ op: "i32.const", value: shift } as Instr);
+        byte.push({ op: "i32.shr_u" } as Instr);
+      }
+      byte.push({ op: "i32.const", value: 0xff } as Instr);
+      byte.push({ op: "i32.and" } as Instr);
+      emitStoreByte(out, arrLocal, offLocal, k, byte, arrTypeIdx);
+    }
+    return out;
+  };
+  fctx.body.push({ op: "local.get", index: leLocal } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: storeAll(true),
+    else: storeAll(false),
+  } as unknown as Instr);
+}

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -103,6 +103,7 @@ import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImport
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
 import { ensureNativeStringExternBridge } from "../native-strings.js";
+import { emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
 
 /**
  * Known built-in global class/object names that compile to ref.null.extern
@@ -4649,6 +4650,29 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     // looking for a non-existent RegExp_hasOwnProperty import.
     if (propAccess.name.text === "hasOwnProperty" || propAccess.name.text === "propertyIsEnumerable") {
       return compilePropertyIntrospection(ctx, fctx, propAccess, expr);
+    }
+
+    // #1654 — native DataView accessors in no-JS-host mode. In JS-host mode the
+    // runtime materializes a real DataView over the byte array; standalone/WASI
+    // has no JS runtime, so emit Wasm-native byte read/write into the i32_byte
+    // backing array directly. Must run BEFORE the extern-class dispatch, which
+    // would otherwise route DataView_setUint32 to an unsatisfiable host import
+    // (or silently drop the call).
+    if (noJsHost(ctx) && isDataViewAccessor(propAccess.name.text)) {
+      const recvSym = receiverType.getSymbol()?.name;
+      if (recvSym === "DataView") {
+        const dvResult = emitDataViewAccessor(
+          ctx,
+          fctx,
+          propAccess.name.text,
+          propAccess.expression,
+          expr.arguments,
+          (e, hint) => compileExpression(ctx, fctx, e, hint),
+        );
+        if (dvResult) {
+          return dvResult.kind === "get" ? dvResult.result : VOID_RESULT;
+        }
+      }
     }
 
     if (isExternalDeclaredClass(receiverType, ctx.checker)) {

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -28,6 +28,7 @@ import {
   registerResolveEnclosingClassName,
 } from "../shared.js";
 import { compileStringLiteral } from "../string-ops.js";
+import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { coerceType as coerceTypeImpl, pushDefaultValue } from "../type-coercion.js";
 import { ensureDateDaysFromCivilHelper, ensureDateStruct } from "./builtins.js";
 import { compileSpreadCallArgs } from "./extern.js";
@@ -1875,6 +1876,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // vs an array/iterable (copy constructor)
         const argType = ctx.checker.getTypeAtLocation(args[0]!);
         const argSym = argType.getSymbol?.();
+        // #1654 — `new Uint8Array(arrayBuffer)` views the buffer's bytes. The
+        // ArrayBuffer/DataView is backed by an i32_byte vec; copy the bytes
+        // into this TypedArray's f64 backing array. Must precede the
+        // size-constructor path (an ArrayBuffer is NOT a numeric length).
+        const argSymName = argSym?.name;
+        if (
+          (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView") &&
+          !ts.isNumericLiteral(args[0]!) &&
+          emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)
+        ) {
+          return { kind: "ref_null", typeIdx: vecTypeIdx };
+        }
         const isArrayLike =
           argSym?.name === "Array" ||
           ((argType.flags & ts.TypeFlags.Object) !== 0 &&
@@ -2104,12 +2117,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       {
         const rangeErrMsg = "RangeError: Invalid array buffer length";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
       }
@@ -2147,12 +2159,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         {
           const rangeErrMsg = "RangeError: Start offset is outside the bounds of the buffer";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -2186,12 +2197,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         {
           const rangeErrMsg = "RangeError: Invalid DataView length";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -2221,12 +2231,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       {
         const rangeErrMsg = "RangeError: Invalid array length";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
       }
@@ -2389,6 +2398,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
         fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
       } else {
+        // #1654 — `new Uint8Array(arrayBuffer)` must VIEW the buffer's bytes,
+        // not treat the buffer as a numeric length. The ArrayBuffer is backed
+        // by an `i32_byte` vec (one i32 per byte). Detect that case and copy the
+        // bytes into the f64-element vec this TypedArray uses (so e.g.
+        // process.stdout.write, which expects a vec_f64, sees the real bytes).
+        const argTsType = ctx.checker.getTypeAtLocation(args[0]!);
+        const argSymName = argTsType.getSymbol?.()?.name;
+        const isBufferArg =
+          argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView";
+        if (isBufferArg && emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)) {
+          return { kind: "ref_null", typeIdx: vecTypeIdx };
+        }
         // new Uint8Array(n) → array of size n, all zeros
         compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
         fctx.body.push({ op: "i32.trunc_sat_f64_s" });
@@ -2431,12 +2452,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       {
         const rangeErrMsg = "RangeError: Invalid array buffer length";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
       }
@@ -2526,12 +2546,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         {
           const rangeErrMsg = "RangeError: Start offset is outside the bounds of the buffer";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -2584,12 +2603,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         {
           const rangeErrMsg = "RangeError: Invalid DataView length";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -2752,12 +2770,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       {
         const rangeErrMsg = "RangeError: Invalid array length";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
       }
@@ -2796,6 +2813,103 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
   reportError(ctx, expr, `Unsupported new expression for class: ${className}`);
   return null;
+}
+
+/**
+ * #1654 — `new Uint8Array(arrayBuffer)`: copy the ArrayBuffer's bytes into the
+ * TypedArray's f64-element backing array.
+ *
+ * The ArrayBuffer / DataView is backed by an `i32_byte` vec (field 0 = length,
+ * field 1 = array of i32, one byte per element). User code lowers ArrayBuffer
+ * variables to externref, so recover the struct via any.convert_extern +
+ * ref.cast, read its length, allocate an f64 array of that length, and copy
+ * byte-by-byte (i32 → f64). Returns true on success; false to let the caller
+ * fall back to the numeric-length path.
+ */
+function emitTypedArrayFromByteBuffer(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  bufExpr: ts.Expression,
+  dstVecTypeIdx: number,
+  dstArrTypeIdx: number,
+): boolean {
+  const srcVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const srcArrTypeIdx = getArrTypeIdxFromVec(ctx, srcVecTypeIdx);
+  if (srcArrTypeIdx < 0 || dstArrTypeIdx < 0) return false;
+
+  // Compile the buffer expression and recover the i32_byte vec struct.
+  const bufType = compileExpression(ctx, fctx, bufExpr);
+  if (!bufType) return false;
+  if (bufType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: srcVecTypeIdx } as Instr);
+  } else if (bufType.kind === "ref" || bufType.kind === "ref_null") {
+    if ("typeIdx" in bufType && bufType.typeIdx !== srcVecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: srcVecTypeIdx } as Instr);
+    }
+  } else {
+    fctx.body.push({ op: "drop" } as Instr);
+    return false;
+  }
+  const srcVecLocal = allocLocal(fctx, `__tab_src_${fctx.locals.length}`, { kind: "ref", typeIdx: srcVecTypeIdx });
+  fctx.body.push({ op: "local.set", index: srcVecLocal });
+
+  // len = src.length (field 0)
+  const lenLocal = allocLocal(fctx, `__tab_len_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: srcVecLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: srcVecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal });
+
+  // srcArr = src.data (field 1)
+  const srcArrLocal = allocLocal(fctx, `__tab_srcarr_${fctx.locals.length}`, { kind: "ref", typeIdx: srcArrTypeIdx });
+  fctx.body.push({ op: "local.get", index: srcVecLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: srcVecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: srcArrLocal });
+
+  // dstArr = new f64[len]
+  const dstArrLocal = allocLocal(fctx, `__tab_dstarr_${fctx.locals.length}`, { kind: "ref", typeIdx: dstArrTypeIdx });
+  fctx.body.push({ op: "local.get", index: lenLocal });
+  fctx.body.push({ op: "array.new_default", typeIdx: dstArrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: dstArrLocal });
+
+  // for (i = 0; i < len; i++) dstArr[i] = f64(srcArr[i] & 0xff)
+  const iLocal = allocLocal(fctx, `__tab_i_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: iLocal });
+  const loopBody: Instr[] = [
+    // if (i >= len) break (br 1 out of loop)
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // dstArr[i] = f64(srcArr[i] & 0xff)
+    { op: "local.get", index: dstArrLocal } as Instr,
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: srcArrLocal } as Instr,
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "array.get", typeIdx: srcArrTypeIdx } as Instr,
+    { op: "i32.const", value: 0xff } as Instr,
+    { op: "i32.and" } as Instr,
+    { op: "f64.convert_i32_u" } as Instr,
+    { op: "array.set", typeIdx: dstArrTypeIdx } as Instr,
+    // i++
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: iLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // struct.new dstVec(len, dstArr)
+  fctx.body.push({ op: "local.get", index: lenLocal });
+  fctx.body.push({ op: "local.get", index: dstArrLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: dstVecTypeIdx } as Instr);
+  return true;
 }
 
 export {

--- a/src/codegen/stack-balance.ts
+++ b/src/codegen/stack-balance.ts
@@ -181,6 +181,8 @@ function instrDelta(instr: Instr, types: TypeDef[], funcSigs: FuncSigInfo): numb
     op === "f32.demote_f64" ||
     op === "f64.reinterpret_i64" ||
     op === "i64.reinterpret_f64" ||
+    op === "f32.reinterpret_i32" ||
+    op === "i32.reinterpret_f32" ||
     op === "i32.trunc_sat_f64_s" ||
     op === "i32.trunc_sat_f64_u" ||
     op === "i32.trunc_f64_s" ||

--- a/src/emit/binary.ts
+++ b/src/emit/binary.ts
@@ -804,6 +804,12 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
     case "f64.reinterpret_i64":
       enc.byte(OP.f64_reinterpret_i64);
       break;
+    case "i32.reinterpret_f32":
+      enc.byte(OP.i32_reinterpret_f32);
+      break;
+    case "f32.reinterpret_i32":
+      enc.byte(OP.f32_reinterpret_i32);
+      break;
     case "f64.const":
       enc.byte(OP.f64_const);
       enc.f64(instr.value);

--- a/src/emit/object.ts
+++ b/src/emit/object.ts
@@ -679,6 +679,12 @@ function encodeInstrWithReloc(
     case "f64.reinterpret_i64":
       enc.byte(OP.f64_reinterpret_i64);
       break;
+    case "i32.reinterpret_f32":
+      enc.byte(OP.i32_reinterpret_f32);
+      break;
+    case "f32.reinterpret_i32":
+      enc.byte(OP.f32_reinterpret_i32);
+      break;
     case "ref.null":
       enc.byte(OP.ref_null);
       enc.i32(instr.typeIdx);

--- a/src/emit/opcodes.ts
+++ b/src/emit/opcodes.ts
@@ -127,7 +127,9 @@ export const OP = {
   f64_convert_i32_s: 0xb7,
   f64_convert_i32_u: 0xb8,
   // reinterpret (bit-cast) conversions
+  i32_reinterpret_f32: 0xbc,
   i64_reinterpret_f64: 0xbd,
+  f32_reinterpret_i32: 0xbe,
   f64_reinterpret_i64: 0xbf,
   ref_null: 0xd0,
   ref_is_null: 0xd1,

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -151,6 +151,8 @@ type InstrBase =
   | { op: "i64.extend_i32_u" }
   | { op: "i64.trunc_f64_s" }
   | { op: "i64.reinterpret_f64" }
+  | { op: "i32.reinterpret_f32" }
+  | { op: "f32.reinterpret_i32" }
   | { op: "f64.convert_i64_s" }
   | { op: "f64.reinterpret_i64" }
   | { op: "f64.const"; value: number }

--- a/tests/issue-1654-wasi-dataview-arraybuffer.test.ts
+++ b/tests/issue-1654-wasi-dataview-arraybuffer.test.ts
@@ -1,0 +1,160 @@
+// #1654 — ArrayBuffer / DataView-backed TypedArrays under --target wasi.
+//
+// Previously, `new ArrayBuffer(n)` + `DataView.setUint32(…, true)` +
+// `new Uint8Array(arrayBuffer)` COMPILED but produced an INVALID module:
+// wasmtime rejected it with `unknown global: global index out of bounds`.
+// Root cause: the ArrayBuffer-length RangeError path emitted `global.get -1`
+// (the nativeStrings sentinel) instead of materialising the message string
+// inline, AND the DataView accessors + `new Uint8Array(arrayBuffer)` had no
+// standalone (no-JS-host) implementation — the writes were silently dropped
+// and the Uint8Array was created empty.
+//
+// This pins: (a) the module is VALID and instantiable, (b) DataView
+// get/set{Uint,Int}{8,16,32} round-trip little- AND big-endian, and
+// (c) `new Uint8Array(arrayBuffer)` views the buffer's bytes. Validated
+// against a raw-byte WASI shim (the same shim shape verified under real
+// wasmtime during development).
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Run a compiled WASI module, returning the raw bytes written to fd=1. */
+function runWasiCaptureStdout(binary: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const captured: number[] = [];
+  const wasi = {
+    fd_read(): number {
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === 1) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+const DECL = `declare const process: { stdout: { write(c: Uint8Array): void } };`;
+
+describe("#1654 ArrayBuffer/DataView under --target wasi", () => {
+  it("compiles to a VALID, instantiable module (no `unknown global`)", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const header = new ArrayBuffer(4);
+        const dv = new DataView(header);
+        dv.setUint32(0, 11, true);
+        process.stdout.write(new Uint8Array(header));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    // The invalid-module bug surfaced as a -1 global index in the WAT.
+    expect(result.wat).not.toContain("global.get -1");
+    // Instantiation itself is the WebAssembly.validate gate (throws if invalid).
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  it("the exact repro emits the LE uint32 header bytes 0b 00 00 00", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const header = new ArrayBuffer(4);
+        const dv = new DataView(header);
+        dv.setUint32(0, 11, true);
+        process.stdout.write(new Uint8Array(header));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureStdout(result.binary);
+    expect(Array.from(out)).toEqual([0x0b, 0x00, 0x00, 0x00]);
+  });
+
+  it("DataView get/set round-trips little- and big-endian across widths", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const ab = new ArrayBuffer(16);
+        const dv = new DataView(ab);
+        dv.setUint32(0, 0x01020304, true);   // LE: 04 03 02 01
+        dv.setUint32(4, 0x01020304, false);  // BE: 01 02 03 04
+        dv.setUint8(8, 0xAB);
+        dv.setUint16(9, 0xBEEF, true);       // LE: EF BE
+        // read back and re-store to prove the getters work
+        const g32 = dv.getUint32(0, true);   // 0x01020304
+        dv.setUint8(11, g32 & 0xff);         // 04
+        const g16 = dv.getUint16(9, true);   // 0xBEEF
+        dv.setUint8(12, (g16 >> 8) & 0xff);  // BE
+        const s8 = dv.getInt8(8);            // 0xAB as signed
+        dv.setUint8(13, s8 & 0xff);          // AB
+        process.stdout.write(new Uint8Array(ab));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureStdout(result.binary);
+    expect(Array.from(out)).toEqual([
+      0x04,
+      0x03,
+      0x02,
+      0x01, // setUint32 LE
+      0x01,
+      0x02,
+      0x03,
+      0x04, // setUint32 BE
+      0xab, // setUint8
+      0xef,
+      0xbe, // setUint16 LE
+      0x04, // getUint32(LE) & 0xff
+      0xbe, // getUint16(LE) >> 8
+      0xab, // getInt8 & 0xff
+      0x00,
+      0x00, // untouched
+    ]);
+  });
+
+  it("new Uint8Array(arrayBuffer) views the buffer bytes (not a zeroed length)", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const ab = new ArrayBuffer(3);
+        const dv = new DataView(ab);
+        dv.setUint8(0, 0x10);
+        dv.setUint8(1, 0x20);
+        dv.setUint8(2, 0x30);
+        const view = new Uint8Array(ab);
+        process.stdout.write(view);
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureStdout(result.binary);
+    expect(Array.from(out)).toEqual([0x10, 0x20, 0x30]);
+  });
+
+  it("the literal-array Uint8Array path (#1651) still works (no regression)", () => {
+    const src = `${DECL}
+      export function main(): void {
+        process.stdout.write(new Uint8Array([0, 1, 255, 10, 13]));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureStdout(result.binary);
+    expect(Array.from(out)).toEqual([0, 1, 255, 10, 13]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1654. ArrayBuffer/DataView/TypedArray code COMPILED but produced an INVALID module under `--target wasi` (wasmtime: `unknown global: global index out of bounds`), and even once valid, silently dropped DataView writes and created empty Uint8Arrays. Root-causing the symptom exposed three dual-mode gaps (codegen assumed a JS host, no standalone Wasm-native path):

1. **Invalid module** — the ArrayBuffer/DataView/Array RangeError throw sites emitted `global.get -1` in `nativeStrings` mode (auto-enabled for WASI), where `-1` is the sentinel for inline-materialised strings. Routed all eight through `stringConstantExternrefInstrs` (handles both host and native-string modes).
2. **`dv.setUint32(...)` was a no-op** — DataView accessors were JS-runtime-only. New `src/codegen/dataview-native.ts` emits Wasm-native byte read/write into the `i32_byte` vec backing array, honouring `littleEndian` at runtime (get/set {Uint,Int}{8,16,32}, {Float}{32,64}). Hooked into `calls.ts` before extern-class dispatch when `noJsHost && receiver is DataView`.
3. **`new Uint8Array(arrayBuffer)` was empty** — the ctor treated the buffer as a numeric length. Now detects ArrayBuffer/DataView args and copies the bytes into the TypedArray's f64 backing (`emitTypedArrayFromByteBuffer`).

Also adds `i32.reinterpret_f32` / `f32.reinterpret_i32` opcodes (Instr union, both encoders, stack-balance) — needed for Float32 accessors.

Verified under **real wasmtime** (`-W gc=y,function-references=y,tail-call=y,exceptions=y`): the issue's repro emits exactly `0b 00 00 00`; a mixed LE/BE/8/16/32 get+set round-trip produces the expected bytes.

## Test plan

- [x] `tests/issue-1654-wasi-dataview-arraybuffer.test.ts` — compile + WASI-module validity + byte round-trip (LE/BE/8/16/32) + `new Uint8Array(ab)` view + literal-array no-regression, via the CI-portable raw-byte WASI shim
- [x] No regression: JS-host DataView suites (#1056, #1064, #1515) all pass; literal-array path (#1651) passes
- [x] Pre-existing `string_constants`-import harness failures in `typed-array-basic`/`arraybuffer-dataview` have identical pass/fail counts before and after (not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)