### PR TITLE
plan(#1660): real CLA gate + hold #589 until CLA acceptance

### DIFF
--- a/plan/issues/1530-wasi-native-messaging-host-example.md
+++ b/plan/issues/1530-wasi-native-messaging-host-example.md
@@ -298,6 +298,11 @@ two flaws**:
 - The rewrite is **dispatched after #1653 + #1654 land** (depends_on). Do not
   start the `host.ts` rewrite before the binary stdin read + ArrayBuffer/DataView
   validity are in.
+- **HOLD — do not merge guest271314's PR #589 until guest has an affirmative
+  CLA acceptance recorded (gated on #1660).** Our current `cla-check` workflow
+  is a no-op placeholder that records nothing, so we have no evidence guest271314
+  ever accepted the CLA. PR #589 must wait behind a real CLA gate (#1660) before
+  it can land.
 - **How to integrate vs guest271314's PR #589 is a maintainer decision.** Do
   **not** clobber the external PR — coordinate so guest's contribution lands
   with attribution rather than being silently re-implemented. This plan

--- a/plan/issues/1660-real-cla-gate.md
+++ b/plan/issues/1660-real-cla-gate.md
@@ -1,0 +1,74 @@
+---
+id: 1660
+title: "Replace placeholder cla-check with a real CLA signature/approval gate"
+status: ready
+sprint: Backlog
+created: 2026-05-24
+updated: 2026-05-24
+priority: high
+feasibility: medium
+task_type: infrastructure
+area: ci/legal/governance
+related: [1530]
+---
+
+# Replace placeholder cla-check with a real CLA signature/approval gate
+
+## Problem
+
+`.github/workflows/cla-check.yml` is a no-op placeholder. It only echoes:
+
+> "CLA enforcement placeholder. Replace this workflow with a real contributor
+> signature or approval system."
+
+and passes for everyone, recording nothing. So the green `cla-check` status is
+meaningless: no contributor has *affirmatively* accepted the CLA, and there is
+no audit trail of acceptance.
+
+## Why it matters
+
+`CLA.md` (Loopdive GmbH terms) grants an irrevocable, worldwide, perpetual,
+sublicensable, **relicensing** license — the contribution can be used under the
+Apache-2.0-with-LLVM-Exceptions community distribution *and* commercial /
+proprietary partner licenses. But today that grant rests only on a constructive
+"by contributing you agree" theory: there is no signature, no recorded
+acceptance, and no evidence the contributor ever saw the terms. That is weak
+ground for any future relicensing.
+
+This was surfaced by guest271314's first external PR (#589): we cannot rely on
+any recorded CLA acceptance from them, because the gate records nothing.
+
+## Proposed
+
+Implement a real gate. Either:
+
+- **(a) CLA-assistant bot** — requires an explicit "I have read and agree to the
+  CLA" comment from the PR author and records signatures in a tracked file
+  (auditable signatures list), or
+- **(b) DCO `Signed-off-by` enforcement** — a required check that every commit
+  in a PR carries a `Signed-off-by:` trailer matching the author.
+
+Make the chosen gate a **required** status check on `main` (branch protection;
+see `scripts/enable-branch-protection.sh` / `docs/ci-policy.md`). Document the
+contributor flow in `CONTRIBUTING.md`. Remove the placeholder workflow.
+
+## Acceptance
+
+- External PRs **cannot merge** without a recorded affirmative CLA acceptance
+  (bot signature or DCO sign-off).
+- Signatures / acceptances are **auditable** (tracked file or per-commit
+  trailer, inspectable after the fact).
+- `CONTRIBUTING.md` explains the contributor flow.
+- The placeholder `cla-check.yml` workflow is removed (replaced by the real
+  gate as a required check).
+
+## Note (legal)
+
+The relicensing question itself warrants legal review; this issue covers the
+**technical / process gate** only.
+
+## Related
+
+- #1530 (WASI native-messaging host example) — guest271314's PR #589 is gated
+  on this issue. See the **HOLD** note in #1530: do not merge PR #589 until
+  guest has an affirmative CLA acceptance recorded.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -40,6 +40,10 @@ both others); #1653 is the keystone for the read side + continuous loop.
 - [#1653](../1653-wasi-process-stdin-read-binary.md) — `process.stdin.read(buffer, offset?)` binary incremental stdin read (keystone) — high, hard, **depends on #1654**
 - [#1655](../1655-wasi-process-stdout-write-arraybuffer.md) — `process.stdout.write(ArrayBuffer)` accept ArrayBuffer arg, not only Uint8Array literal — medium, easy, **depends on #1654**
 
+## Governance / legal — CLA gate (2026-05-24)
+
+- [#1660](../1660-real-cla-gate.md) — Replace the placeholder `cla-check` workflow with a real CLA signature/approval gate (CLA-assistant bot or DCO `Signed-off-by`), made a required check on `main` — **high**, medium, **ready**. The current `cla-check` is a no-op that records nothing, so external contributions land with no auditable CLA acceptance. **Gates external-PR merges, including guest271314's PR #589 (see #1530 HOLD).** Related: #1530.
+
 ## Spec-compliance easy wins (from #1563 gap analysis, 2026-05-21)
 
 - [#1564](1564-toNumeric-symbol-throws-typeError.md) — ToNumeric: Symbol argument must throw TypeError (§7.1.3 step 3) — ~12 fails, easy

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -67,6 +67,22 @@ example is being rewritten onto `process.stdin.read()` (#1653) + already-shipped
 #1628 (a.k.a. "#1617" in the #1530 history) -> wont-fix (superseded by #1651).
 ```
 
+## Governance / legal — CLA gate (added 2026-05-24)
+
+Gates merges of **external** PRs (including guest271314's PR #589, which is
+attached to #1530). The current `cla-check` workflow is a no-op placeholder that
+records no acceptance, so external contributions land with no auditable CLA
+sign-off.
+
+| #    | Title | Priority | Feasibility | Status |
+|------|-------|----------|-------------|--------|
+| 1660 | Replace placeholder cla-check with a real CLA signature/approval gate | high | medium | **Ready** — gates external-PR merges incl. guest271314's PR #589 (#1530 HOLD) |
+
+```
+#1660 (real CLA gate) -- gates all external-PR merges
+  └── PR #589 (guest271314, attached to #1530) -- HOLD until guest's CLA acceptance is recorded
+```
+
 ## Sprint 55 — repo structure / website (added 2026-05-24)
 
 | #    | Title | Priority | Feasibility | Status |


### PR DESCRIPTION
## Summary

- File **#1660** — replace the no-op `cla-check` workflow with a real CLA signature/approval gate (CLA-assistant bot or DCO `Signed-off-by`), made a **required** check on `main`. The current placeholder records nothing, so external PRs land with no auditable CLA acceptance and the green status is meaningless. `feasibility: medium`, `task_type: infrastructure`, priority high.
- Record a **HOLD** in #1530 on guest271314's PR #589: do not merge until guest has an affirmative CLA acceptance recorded (gated on #1660). Existing "don't clobber the external PR / maintainer decision" note is preserved.
- List #1660 in `plan/log/dependency-graph.md` and `plan/issues/backlog/backlog.md` (high priority; gates external-PR merges incl. #589).

Plan-only PR — no source, workflow, or guest-PR files touched. Legal review of the relicensing question itself is flagged in the issue as out of scope for the technical gate.

## Test plan

- [ ] Plan files only (4 files, +99 lines): `plan/issues/1660-real-cla-gate.md`, `plan/issues/1530-...md`, `plan/issues/backlog/backlog.md`, `plan/log/dependency-graph.md`
- [ ] CI green (docs/plan path — test262 shards skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)