### PR TITLE
feat(#1653): process.stdin.read(buffer, offset?) binary sync stdin (Node API, replaces readStdin)

### DIFF
--- a/plan/issues/1481-wasi-stdin-fd-read.md
+++ b/plan/issues/1481-wasi-stdin-fd-read.md
@@ -133,3 +133,13 @@ program read `"hello\n"` as a string.
 1. Check `/workspace/.claude/ci-status/pr-400.json` — if `head_sha` matches `f2879c74f` and `net_per_test > 0`, ratio <10%, no bucket >50: `gh pr merge 400 --merge --admin`.
 2. If regressions, run `/dev-self-merge 400` to see analysis.
 3. After merge: set `status: done` in this file, `rm /workspace/.claude/agent-status/issue-1481-wasi-stdin.json`, `git worktree remove /workspace/.claude/worktrees/issue-1481-wasi-stdin`.
+
+## Deprecated by #1653 (2026-05-24)
+
+`readStdin()` is superseded by the standard Node API
+`process.stdin.read(buf, offset?)` (#1653) for binary input. `readStdin()`
+drains fd=0 to EOF, UTF-8-decodes to a string (losing binary fidelity), and
+cannot read incrementally — so it cannot frame a 4-byte-LE-header + N-body
+message nor sustain a continuous `while (true)` port loop. It remains
+available for back-compat and is annotated deprecated in
+`src/codegen/expressions/calls.ts`; new code should use `process.stdin.read`.

--- a/plan/issues/1653-wasi-process-stdin-read-binary.md
+++ b/plan/issues/1653-wasi-process-stdin-read-binary.md
@@ -1,9 +1,10 @@
 ---
 id: 1653
 title: "wasi: process.stdin.read(buffer, offset?) — binary incremental stdin read into a typed buffer"
-status: backlog
+status: done
 created: 2026-05-24
 updated: 2026-05-24
+completed: 2026-05-24
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -84,3 +85,40 @@ this issue. Without a valid standalone `ArrayBuffer`, there is nowhere for
 - The Native Messaging host (`examples/native-messaging/host.ts`) can adopt
   the binary read path (the string-based `readStdin()` workaround can be
   retired once this + #1654 + #1655 land — tracked in #1530).
+
+## Implementation notes (resolution)
+
+`process.stdin.read(buf, offset?)` is recognised under `--target wasi` as a
+standard-API builtin (no bespoke runtime function):
+
+- **Detection** — `matchProcessStdinRead` in `calls.ts` matches the
+  `process.stdin.read(...)` call shape (1-2 args, unshadowed `process`), mirror
+  of `matchProcessStdStreamWrite`. A parallel AST scan in `index.ts` sets
+  `needsFdRead` for the same shape so the `fd_read` import is registered even
+  when `readStdin()` is never used.
+- **Lowering** — `emitProcessStdinRead` (calls.ts):
+  1. recover the buffer's vec struct + backing array (field 1) + element kind;
+  2. `offset` → i32 (default 0); `capacity = buf.length - offset`;
+  3. set iovec at memory[0]={buf=WASI_STDIN_BUF_START, len=capacity};
+  4. `fd_read(0, 0, 1, 8)`; `nread = memory[8]`;
+  5. copy `nread` bytes from the stdin scratch page into `backing[offset+j]`,
+     converting per element kind (f64 vec for `Uint8Array`, i32_byte vec for
+     `ArrayBuffer` — both made valid standalone by #1654);
+  6. return `nread` as f64.
+
+  Reads are incremental: each call issues one `fd_read`, so the fd=0 cursor
+  advances and a `while (true)` port loop reads header then body then loops.
+  The EventEmitter `.on('data')` streaming form is explicitly out of scope.
+
+- **`readStdin()` deprecated** — kept working (back-compat) but annotated
+  deprecated in `calls.ts` in favour of `process.stdin.read`, since it drains
+  to EOF, UTF-8-decodes (binary loss), and can't sustain a continuous loop.
+
+**Verified under real wasmtime** (`-W gc=y,function-references=y,tail-call=y,
+exceptions=y`): a 4-byte-LE-header-then-body framed read round-trips ("HELLO"),
+and a `while (true)` two-message echo loop (ArrayBuffer-backed header read)
+emits both frames verbatim and terminates cleanly at EOF. Committed test
+`tests/issue-1653-wasi-process-stdin-read.test.ts` pins compile + module
+validity + binary-verbatim header/body + 2-message loop + non-zero-offset read
++ EOF=0 via the CI-portable raw-byte WASI shim. No regression: `readStdin()`
+(`wasi-stdin.test.ts`) and the stdout suites all pass.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -51,6 +51,7 @@ import {
   hoistVarDeclarations,
   nativeStringType,
   resolveWasmType,
+  WASI_STDIN_BUF_START,
 } from "../index.js";
 import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
 import {
@@ -1228,6 +1229,158 @@ function matchProcessStdStreamWrite(
   return { useStderr: streamName === "stderr" };
 }
 
+/**
+ * #1653 — match `process.stdin.read(buf, offset?)` under --target wasi: the
+ * binary, incremental stdin read (the Node-API replacement for readStdin()).
+ * Returns true when matched. Mirrors `matchProcessStdStreamWrite`.
+ */
+function matchProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
+  if (!ctx.wasi || ctx.wasiFdReadIdx === undefined || ctx.wasiFdReadIdx < 0) return false;
+  if (expr.questionDotToken || expr.arguments.length < 1 || expr.arguments.length > 2) return false;
+  const readAccess = expr.expression;
+  if (!ts.isPropertyAccessExpression(readAccess) || readAccess.name.text !== "read") return false;
+  const streamAccess = readAccess.expression;
+  if (!ts.isPropertyAccessExpression(streamAccess) || streamAccess.name.text !== "stdin") return false;
+  const procIdent = streamAccess.expression;
+  if (!ts.isIdentifier(procIdent) || procIdent.text !== "process") return false;
+  // Don't hijack a user-shadowed `process` local/capture.
+  if (fctx.localMap.has("process") || (fctx.boxedCaptures?.has("process") ?? false)) return false;
+  return true;
+}
+
+/**
+ * #1653 — emit `process.stdin.read(buf, offset?)` under --target wasi.
+ *
+ * Lowers to a single `fd_read(0, iov, 1, nread)` where the iov points at the
+ * WASI stdin scratch page; the bytes read are then copied into the
+ * caller-supplied buffer's WasmGC backing array starting at `offset`, and the
+ * byte count is returned (f64). The read length is `buf.length - offset` (the
+ * remaining writable capacity), so a caller can request exactly the bytes it
+ * needs (e.g. a 4-byte LE header, then N body bytes).
+ *
+ * The buffer is a Uint8Array (vec of f64 elements) or an ArrayBuffer (vec of
+ * i32 byte elements); we recover the backing array from the vec struct and pick
+ * the per-element store conversion accordingly (#1654 made both representations
+ * valid standalone). Returns null if the buffer doesn't resolve to a vec struct
+ * (caller falls through to generic handling).
+ */
+function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult | null {
+  const fdReadIdx = ctx.wasiFdReadIdx;
+  if (fdReadIdx === undefined || fdReadIdx < 0) return null;
+
+  // Compile the buffer expression and recover the vec struct.
+  const bufType = compileExpression(ctx, fctx, expr.arguments[0]!);
+  if (!bufType || (bufType.kind !== "ref" && bufType.kind !== "ref_null") || !("typeIdx" in bufType)) {
+    if (bufType) fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const vecTypeIdx = bufType.typeIdx;
+  const vecDef = ctx.mod.types[vecTypeIdx];
+  if (!vecDef || vecDef.kind !== "struct" || vecDef.fields.length < 2) {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  // Element kind of the backing array decides the per-byte store conversion.
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  const elemKind = arrDef && arrDef.kind === "array" && arrDef.element.kind === "f64" ? "f64" : "i32";
+
+  // Stash the vec (assert non-null) and its backing array.
+  if (bufType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  const vecLocal = allocLocal(fctx, `__stdin_vec_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.set", index: vecLocal });
+  const arrLocal = allocLocal(fctx, `__stdin_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // offset (arg 1) → i32, default 0.
+  const offLocal = allocLocal(fctx, `__stdin_off_${fctx.locals.length}`, { kind: "i32" });
+  if (expr.arguments.length >= 2) {
+    compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: offLocal });
+
+  // capacity = buf.length - offset (remaining writable bytes from offset).
+  const capLocal = allocLocal(fctx, `__stdin_cap_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+  fctx.body.push({ op: "i32.sub" } as Instr);
+  fctx.body.push({ op: "local.set", index: capLocal });
+
+  // iovec.buf = WASI_STDIN_BUF_START at memory[0]
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // iovec.buf_len = capacity at memory[4]
+  fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+  fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+
+  // fd_read(fd=0, iovs=0, iovs_len=1, nread=8) -> errno (ignored)
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "call", funcIdx: fdReadIdx } as Instr);
+  fctx.body.push({ op: "drop" } as Instr);
+
+  // nread = memory[8]
+  const nreadLocal = allocLocal(fctx, `__stdin_nread_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "i32.load", align: 2, offset: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: nreadLocal } as Instr);
+
+  // for (j = 0; j < nread; j++) arr[off + j] = mem[STDIN_BUF_START + j]
+  const jLocal = allocLocal(fctx, `__stdin_j_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: jLocal });
+  const storeByte: Instr[] = [
+    { op: "i32.const", value: WASI_STDIN_BUF_START } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.load8_u", align: 0, offset: 0 } as Instr,
+  ];
+  if (elemKind === "f64") storeByte.push({ op: "f64.convert_i32_u" } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "local.get", index: nreadLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // arr[off + j] = (conv) mem[STDIN_BUF_START + j]
+    { op: "local.get", index: arrLocal } as Instr,
+    { op: "local.get", index: offLocal } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    ...storeByte,
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    // j++
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: jLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // return nread as f64 (Node API returns the number of bytes read)
+  fctx.body.push({ op: "local.get", index: nreadLocal } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
 function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
   // Optional chaining on calls: obj?.method()
   if (expr.questionDotToken && ts.isPropertyAccessExpression(expr.expression)) {
@@ -1281,6 +1434,12 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
   }
 
   // #1481: readStdin() builtin under --target wasi → call __wasi_read_stdin_all
+  //
+  // DEPRECATED (#1653): readStdin() drains fd=0 to EOF and UTF-8-decodes the
+  // result to a STRING, so it cannot read a fixed byte count, cannot read
+  // incrementally (no continuous port loop), and loses binary fidelity. Prefer
+  // the standard Node API `process.stdin.read(buf, offset?)` (above) for binary,
+  // incremental reads. readStdin() is kept working for back-compat only.
   if (
     ctx.wasi &&
     ts.isIdentifier(expr.expression) &&
@@ -1293,6 +1452,17 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
       return { kind: "ref", typeIdx: ctx.nativeStrTypeIdx };
     }
+  }
+
+  // #1653: process.stdin.read(buf, offset?) under --target wasi → fd_read(0, …)
+  // into the caller-supplied typed buffer's backing array starting at `offset`,
+  // returning the number of bytes read. The binary, incremental Node-API
+  // replacement for readStdin() (which drains to EOF and UTF-8-decodes, losing
+  // binary fidelity). Lets a `while (true)` port loop read a fixed 4-byte LE
+  // header then exactly N body bytes — the Native Messaging frame shape.
+  if (matchProcessStdinRead(ctx, fctx, expr)) {
+    const r = emitProcessStdinRead(ctx, fctx, expr);
+    if (r) return r;
   }
 
   // #1651 (GitHub #572): process.stdout.write(x) / process.stderr.write(x)

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3532,6 +3532,21 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "readStdin") {
       needsFdRead = true;
     }
+    // #1653: process.stdin.read(buf, offset?) → triggers fd_read import (the
+    // binary, incremental Node-API replacement for readStdin()). Detect the
+    // `process.stdin.read(...)` call shape so fd_read is registered even when
+    // readStdin() is never used.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "read" &&
+      ts.isPropertyAccessExpression(node.expression.expression) &&
+      node.expression.expression.name.text === "stdin" &&
+      ts.isIdentifier(node.expression.expression.expression) &&
+      node.expression.expression.expression.text === "process"
+    ) {
+      needsFdRead = true;
+    }
     forEachChild(node, visit);
   }
   forEachChild(sourceFile, visit);
@@ -3903,7 +3918,7 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
  *   - WASI_WRITE_SCRATCH_START = 128KB (page 2) — fd_write staging buffer
  * `registerWasiImports` reserves 3 pages so both always exist.
  */
-const WASI_STDIN_BUF_START = 64 * 1024;
+export const WASI_STDIN_BUF_START = 64 * 1024;
 const WASI_WRITE_SCRATCH_START = 128 * 1024;
 
 /**

--- a/tests/issue-1653-wasi-process-stdin-read.test.ts
+++ b/tests/issue-1653-wasi-process-stdin-read.test.ts
@@ -1,0 +1,203 @@
+// #1653 — process.stdin.read(buf, offset?) under --target wasi: the binary,
+// incremental, synchronous Node-API stdin read. Lowers to fd_read(0, …) into
+// the caller's typed buffer at `offset`, returning the byte count, so a
+// `while (true)` port loop can read a fixed 4-byte LE header then exactly N
+// body bytes — the Chrome Native Messaging frame shape.
+//
+// This is the standard-API replacement for the bespoke `readStdin()` (#1481),
+// which drains to EOF and UTF-8-decodes (losing binary fidelity and the
+// continuous-loop design). readStdin() is kept working but deprecated.
+//
+// Validated against a raw-byte WASI shim that hands a fixed input to fd_read
+// in caller-controlled chunks (same shim shape verified under real wasmtime
+// during development).
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * Run a compiled WASI module with a fixed stdin payload, capturing fd=1 bytes.
+ * fd_read serves the payload incrementally (honouring each iov length and
+ * advancing a cursor), so successive `process.stdin.read` calls observe the
+ * stream advance — exactly like a real WASI host / wasmtime.
+ */
+function runWasiStdinToStdout(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const captured: number[] = [];
+  let pos = 0;
+  const wasi = {
+    fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const n = Math.min(len, stdin.length - pos);
+        new Uint8Array(ref.mem!.buffer, ptr, n).set(stdin.subarray(pos, pos + n));
+        pos += n;
+        total += n;
+        if (n < len) break;
+      }
+      view.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === 1) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+const DECL = `declare const process: {
+  stdin: { read(buf: Uint8Array | ArrayBuffer, offset?: number): number };
+  stdout: { write(c: Uint8Array): void };
+};`;
+
+// Read exactly `len` bytes into `buf` starting at 0 via a read-until loop, then
+// echo. Used by several tests; len comes from a 4-byte LE header.
+const FRAMED_ECHO = `${DECL}
+  export function main(): void {
+    const header = new Uint8Array(4);
+    let got = 0;
+    while (got < 4) {
+      const n = process.stdin.read(header, got);
+      if (n <= 0) return;
+      got = got + n;
+    }
+    const len = header[0] | (header[1] << 8) | (header[2] << 16) | (header[3] << 24);
+    const body = new Uint8Array(len);
+    let bgot = 0;
+    while (bgot < len) {
+      const n = process.stdin.read(body, bgot);
+      if (n <= 0) break;
+      bgot = bgot + n;
+    }
+    process.stdout.write(body);
+  }`;
+
+describe("#1653 process.stdin.read under --target wasi", () => {
+  it("compiles and produces an instantiable WASI module", () => {
+    const result = compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+    // fd_read import must be registered even without readStdin().
+    expect(result.wat).toContain("fd_read");
+  });
+
+  it("reads a 4-byte LE header then the exact body, binary-verbatim", () => {
+    const result = compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    // header len=5 (LE), body = bytes incl. non-printable / high bytes
+    const frame = Uint8Array.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+    const out = runWasiStdinToStdout(result.binary, frame);
+    expect(Array.from(out)).toEqual([0x00, 0xff, 0x0a, 0x7f, 0x80]);
+  });
+
+  it("read() returns the byte count (used to advance the offset)", () => {
+    // Echo only what the FIRST read() returns, by writing header[0..n).
+    const src = `${DECL}
+      export function main(): void {
+        const buf = new Uint8Array(8);
+        const n = process.stdin.read(buf, 0);
+        // store n in buf[7] (n fits a byte here) and emit just the n read bytes
+        const out = new Uint8Array(n);
+        let i = 0;
+        while (i < n) { out[i] = buf[i]; i = i + 1; }
+        process.stdout.write(out);
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiStdinToStdout(result.binary, Uint8Array.from([1, 2, 3]));
+    // The shim serves the whole 3-byte payload in one fd_read (iov len was 8).
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+  });
+
+  it("supports a while(true) port loop over two consecutive messages", () => {
+    const src = `${DECL}
+      export function main(): void {
+        while (true) {
+          const hbuf = new ArrayBuffer(4);
+          const h = new Uint8Array(hbuf);
+          let got = 0;
+          while (got < 4) {
+            const n = process.stdin.read(h, got);
+            if (n <= 0) return;
+            got = got + n;
+          }
+          const len = h[0] | (h[1] << 8) | (h[2] << 16) | (h[3] << 24);
+          const body = new Uint8Array(len);
+          let bgot = 0;
+          while (bgot < len) {
+            const n = process.stdin.read(body, bgot);
+            if (n <= 0) break;
+            bgot = bgot + n;
+          }
+          process.stdout.write(h);
+          process.stdout.write(body);
+        }
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    // frame1: len=2 "AB"; frame2: len=3 "XYZ"
+    const frames = Uint8Array.from([0x02, 0, 0, 0, 0x41, 0x42, 0x03, 0, 0, 0, 0x58, 0x59, 0x5a]);
+    const out = runWasiStdinToStdout(result.binary, frames);
+    expect(Array.from(out)).toEqual([0x02, 0, 0, 0, 0x41, 0x42, 0x03, 0, 0, 0, 0x58, 0x59, 0x5a]);
+  });
+
+  it("reads into an ArrayBuffer-backed Uint8Array at a non-zero offset", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const ab = new ArrayBuffer(6);
+        const view = new Uint8Array(ab);
+        // pre-fill, then read 3 bytes into offset 2
+        view[0] = 0xAA;
+        view[1] = 0xBB;
+        const n = process.stdin.read(view, 2);
+        process.stdout.write(view);
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiStdinToStdout(result.binary, Uint8Array.from([0x11, 0x22, 0x33]));
+    // [AA BB] preserved, then 3 read bytes at offset 2, byte 5 stays 0.
+    expect(Array.from(out)).toEqual([0xaa, 0xbb, 0x11, 0x22, 0x33, 0x00]);
+  });
+
+  it("returns 0 at EOF (empty stdin)", () => {
+    const src = `${DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        const n = process.stdin.read(buf, 0);
+        // emit a single byte: 1 if n==0 (EOF), else 0
+        const out = new Uint8Array(1);
+        out[0] = n === 0 ? 1 : 0;
+        process.stdout.write(out);
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiStdinToStdout(result.binary, new Uint8Array(0));
+    expect(Array.from(out)).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1653. Adds the standard Node API `process.stdin.read(buf: Uint8Array | ArrayBuffer, offset?: number): number` under `--target wasi` — the binary, incremental, **synchronous** stdin read that replaces the bespoke `readStdin()` builtin (#1481). Built on the #1654 foundation (ArrayBuffer/DataView/TypedArray valid standalone). No new runtime function: recognised as a builtin call shape and lowered inline.

- `matchProcessStdinRead` (calls.ts) detects `process.stdin.read(...)`; `index.ts` sets `needsFdRead` for the same shape so the `fd_read` import is registered even without `readStdin()`.
- `emitProcessStdinRead` recovers the buffer's vec backing array + element kind, sets the iovec at the WASI stdin scratch page with `len = buf.length - offset`, calls `fd_read(0, …)`, copies `nread` bytes into `backing[offset+j]` (f64 vec for `Uint8Array`, i32_byte vec for `ArrayBuffer`), and returns `nread`. Incremental: each call advances fd=0, so a `while (true)` port loop reads a 4-byte LE header then exactly N body bytes then loops (the Native Messaging frame shape). The EventEmitter `.on('data')` streaming form is explicitly out of scope.
- `readStdin()` kept working for back-compat but annotated **deprecated** (drains to EOF, UTF-8-decodes → binary loss, no incremental read) in favour of `process.stdin.read`. Noted in #1481.

Verified under **real wasmtime** (`-W gc=y,function-references=y,tail-call=y,exceptions=y`): a 4-byte-LE-header-then-body framed read round-trips ("HELLO"), and a `while (true)` two-message echo loop (ArrayBuffer-backed header) emits both frames verbatim and terminates cleanly at EOF.

## Test plan

- [x] `tests/issue-1653-wasi-process-stdin-read.test.ts` — compile + module validity + binary-verbatim header/body (incl. non-printable/high bytes) + 2-message `while(true)` loop + non-zero-offset ArrayBuffer-backed read + EOF returns 0, via the CI-portable raw-byte WASI shim
- [x] No regression: `readStdin()` (`wasi-stdin.test.ts`), the stdout suites (#1651), and the #1654 DataView suites all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)