### PR TITLE
feat(#1660): self-hosted CLA-acceptance gate (records affirmative agreement in-repo)

### DIFF
--- a/.github/cla/allowlist.json
+++ b/.github/cla/allowlist.json
@@ -1,0 +1,5 @@
+{
+  "comment": "Explicit CLA exemption allowlist — a deterministic fallback so internal/automation committers never get blocked even if the live org-membership API call fails (rate limit, token scope, outage). The workflow ALSO checks live org membership via the GitHub API; this file is the belt-and-suspenders fallback. Bots ('*[bot]') are exempt unconditionally in code and need not be listed. Keep maintainers + known internal contributors here.",
+  "exempt_logins": ["ttraenkler", "github-actions[bot]", "dependabot[bot]"],
+  "exempt_orgs": ["loopdive"]
+}

--- a/.github/cla/cla-gate.mjs
+++ b/.github/cla/cla-gate.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// cla-gate.mjs — self-hosted CLA-acceptance gate (issue #1660).
+//
+// SECURITY (pull_request_target): the workflow that calls this runs on the
+// `pull_request_target` trigger, which executes with a WRITE token in the
+// context of the BASE repo even for fork PRs. We therefore NEVER check out or
+// execute PR head code. This script only:
+//   - reads PR / comment metadata that the workflow passes in via env vars,
+//   - reads/writes the in-repo signature store (.github/cla/signatures.json),
+//   - makes read-only GitHub API calls for org-membership / PR author.
+// No PR-supplied code is ever run.
+//
+// The script is intentionally dependency-free (Node stdlib + the GitHub REST
+// API via fetch) and split into pure, unit-testable functions plus a thin
+// `main()` that the workflow drives. See .github/cla/cla-gate.test.mjs.
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+export const SIGNATURES_PATH = path.join(REPO_ROOT, ".github", "cla", "signatures.json");
+export const ALLOWLIST_PATH = path.join(REPO_ROOT, ".github", "cla", "allowlist.json");
+export const CLA_PATH = path.join(REPO_ROOT, "CLA.md");
+
+// The exact phrase a contributor must comment (case-insensitive, trimmed).
+export const AGREEMENT_PHRASE = "I have read and agree to the CLA";
+
+// ---------------------------------------------------------------------------
+// CLA version — tied to the content hash of CLA.md so that ANY change to the
+// CLA terms bumps the version and forces all contributors to re-accept. A
+// signature is only valid for the cla_version it was recorded against.
+// ---------------------------------------------------------------------------
+export function computeClaVersion(claText) {
+  const hash = crypto.createHash("sha256").update(claText, "utf8").digest("hex");
+  return `sha256:${hash.slice(0, 12)}`;
+}
+
+export function currentClaVersion() {
+  return computeClaVersion(fs.readFileSync(CLA_PATH, "utf8"));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/** A bot login like "github-actions[bot]" / "dependabot[bot]" / any "*[bot]". */
+export function isBot(login) {
+  return typeof login === "string" && /\[bot\]$/i.test(login);
+}
+
+/** Normalize a comment body for phrase matching. */
+export function commentMatchesPhrase(body) {
+  if (typeof body !== "string") return false;
+  return body.trim().toLowerCase() === AGREEMENT_PHRASE.toLowerCase();
+}
+
+/**
+ * Decide exemption from the static allowlist + bot rule. Org membership is
+ * resolved separately (async, via API) by `isOrgMember`. Returns a reason
+ * string when exempt, otherwise null.
+ */
+export function staticExemptReason(login, allowlist) {
+  if (isBot(login)) return "bot";
+  const exempt = (allowlist && allowlist.exempt_logins) || [];
+  if (exempt.map((l) => l.toLowerCase()).includes(String(login).toLowerCase())) {
+    return "allowlist";
+  }
+  return null;
+}
+
+/** Has this login signed at the given cla_version? */
+export function hasSigned(signatures, login, claVersion) {
+  if (!Array.isArray(signatures)) return false;
+  const l = String(login).toLowerCase();
+  return signatures.some((s) => String(s.login).toLowerCase() === l && s.cla_version === claVersion);
+}
+
+/** Build a signature record. */
+export function makeSignature({ login, name, pr, commitSha, claVersion, signedAt }) {
+  return {
+    login,
+    name: name || login,
+    pr,
+    commit_sha: commitSha,
+    cla_version: claVersion,
+    signed_at: signedAt || new Date().toISOString(),
+  };
+}
+
+/** Append a signature into the parsed store object (idempotent per version). */
+export function appendSignature(store, sig) {
+  if (!store || typeof store !== "object") store = { signatures: [] };
+  if (!Array.isArray(store.signatures)) store.signatures = [];
+  if (hasSigned(store.signatures, sig.login, sig.cla_version)) {
+    return { store, added: false };
+  }
+  store.signatures.push(sig);
+  return { store, added: true };
+}
+
+// ---------------------------------------------------------------------------
+// Store IO
+// ---------------------------------------------------------------------------
+export function readStore() {
+  const raw = fs.readFileSync(SIGNATURES_PATH, "utf8");
+  return JSON.parse(raw);
+}
+
+export function readAllowlist() {
+  const raw = fs.readFileSync(ALLOWLIST_PATH, "utf8");
+  return JSON.parse(raw);
+}
+
+export function writeStore(store) {
+  // keep the cla_version field in sync with the current CLA on every write
+  store.cla_version = currentClaVersion();
+  fs.writeFileSync(SIGNATURES_PATH, JSON.stringify(store, null, 2) + "\n", "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API (read-only except the signature commit, which the workflow does)
+// ---------------------------------------------------------------------------
+async function gh(token, apiPath, { method = "GET" } = {}) {
+  const res = await fetch(`https://api.github.com${apiPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "js2wasm-cla-gate",
+    },
+  });
+  return res;
+}
+
+/**
+ * Live org-membership check. Uses GET /orgs/{org}/members/{login}, which an
+ * org-scoped GITHUB_TOKEN can read (204 => member, 404 => not a member). Any
+ * non-204/404 (rate limit, 403) is treated as "unknown" so the caller can
+ * fall back to the static allowlist rather than wrongly blocking.
+ */
+export async function isOrgMember(token, org, login) {
+  if (!token) return { member: false, known: false };
+  try {
+    const res = await gh(token, `/orgs/${org}/members/${encodeURIComponent(login)}`);
+    if (res.status === 204) return { member: true, known: true };
+    if (res.status === 404 || res.status === 302) return { member: false, known: true };
+    return { member: false, known: false };
+  } catch {
+    return { member: false, known: false };
+  }
+}
+
+/**
+ * Resolve the full exemption decision (static + live org membership).
+ * Returns { exempt, reason }.
+ */
+export async function resolveExemption({ token, org, login, allowlist }) {
+  const staticReason = staticExemptReason(login, allowlist);
+  if (staticReason) return { exempt: true, reason: staticReason };
+
+  const orgs = (allowlist && allowlist.exempt_orgs) || [org].filter(Boolean);
+  for (const o of orgs) {
+    const { member, known } = await isOrgMember(token, o, login);
+    if (known && member) return { exempt: true, reason: `org:${o}` };
+  }
+  return { exempt: false, reason: null };
+}
+
+export default {
+  AGREEMENT_PHRASE,
+  computeClaVersion,
+  currentClaVersion,
+  isBot,
+  commentMatchesPhrase,
+  staticExemptReason,
+  hasSigned,
+  makeSignature,
+  appendSignature,
+  readStore,
+  readAllowlist,
+  writeStore,
+  isOrgMember,
+  resolveExemption,
+};

--- a/.github/cla/cla-gate.test.mjs
+++ b/.github/cla/cla-gate.test.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Standalone unit tests for the CLA gate's pure logic (#1660).
+// Dependency-free (node:test) so it runs anywhere without the project toolchain:
+//   node --test .github/cla/cla-gate.test.mjs
+//
+// These tests cover the exemption + signature logic IN ISOLATION. They do NOT
+// hit the GitHub API and do NOT fire the workflow against any live PR.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isBot,
+  commentMatchesPhrase,
+  staticExemptReason,
+  hasSigned,
+  makeSignature,
+  appendSignature,
+  computeClaVersion,
+  AGREEMENT_PHRASE,
+} from "./cla-gate.mjs";
+
+const allowlist = {
+  exempt_logins: ["ttraenkler", "github-actions[bot]", "dependabot[bot]"],
+  exempt_orgs: ["loopdive"],
+};
+
+test("isBot detects [bot] suffix", () => {
+  assert.equal(isBot("github-actions[bot]"), true);
+  assert.equal(isBot("dependabot[bot]"), true);
+  assert.equal(isBot("renovate[bot]"), true);
+  assert.equal(isBot("guest271314"), false);
+  assert.equal(isBot("ttraenkler"), false);
+  assert.equal(isBot(undefined), false);
+});
+
+test("commentMatchesPhrase is exact (trim + case-insensitive)", () => {
+  assert.equal(commentMatchesPhrase(AGREEMENT_PHRASE), true);
+  assert.equal(commentMatchesPhrase("  I have read and agree to the CLA  "), true);
+  assert.equal(commentMatchesPhrase("i have read and agree to the cla"), true);
+  assert.equal(commentMatchesPhrase("I agree to the CLA"), false);
+  assert.equal(commentMatchesPhrase("I have read and agree to the CLA, thanks!"), false);
+  assert.equal(commentMatchesPhrase("LGTM"), false);
+  assert.equal(commentMatchesPhrase(undefined), false);
+});
+
+test("staticExemptReason: bots are exempt", () => {
+  assert.equal(staticExemptReason("github-actions[bot]", allowlist), "bot");
+  assert.equal(staticExemptReason("some-random[bot]", allowlist), "bot");
+});
+
+test("staticExemptReason: allowlisted maintainer exempt (case-insensitive)", () => {
+  assert.equal(staticExemptReason("ttraenkler", allowlist), "allowlist");
+  assert.equal(staticExemptReason("TTraenkler", allowlist), "allowlist");
+});
+
+test("staticExemptReason: external human NOT statically exempt", () => {
+  // External humans are only exempt via live org membership, not statically.
+  assert.equal(staticExemptReason("guest271314", allowlist), null);
+});
+
+test("hasSigned matches login + version", () => {
+  const sigs = [{ login: "guest271314", cla_version: "sha256:aaaa" }];
+  assert.equal(hasSigned(sigs, "guest271314", "sha256:aaaa"), true);
+  assert.equal(hasSigned(sigs, "GUEST271314", "sha256:aaaa"), true); // case-insens
+  assert.equal(hasSigned(sigs, "guest271314", "sha256:bbbb"), false); // version bump
+  assert.equal(hasSigned(sigs, "other", "sha256:aaaa"), false);
+  assert.equal(hasSigned([], "x", "v"), false);
+});
+
+test("appendSignature is idempotent per version", () => {
+  const store = { signatures: [] };
+  const sig = makeSignature({
+    login: "guest271314",
+    name: "Guest",
+    pr: 589,
+    commitSha: "deadbeef",
+    claVersion: "sha256:aaaa",
+    signedAt: "2026-05-24T00:00:00Z",
+  });
+  const r1 = appendSignature(store, sig);
+  assert.equal(r1.added, true);
+  assert.equal(r1.store.signatures.length, 1);
+
+  const r2 = appendSignature(r1.store, sig);
+  assert.equal(r2.added, false, "same login+version should not double-record");
+  assert.equal(r2.store.signatures.length, 1);
+
+  // A version bump (CLA changed) requires a fresh signature.
+  const sig2 = makeSignature({
+    login: "guest271314",
+    name: "Guest",
+    pr: 700,
+    commitSha: "cafe",
+    claVersion: "sha256:bbbb",
+  });
+  const r3 = appendSignature(r2.store, sig2);
+  assert.equal(r3.added, true);
+  assert.equal(r3.store.signatures.length, 2);
+});
+
+test("makeSignature shape", () => {
+  const sig = makeSignature({
+    login: "x",
+    pr: 1,
+    commitSha: "abc",
+    claVersion: "v",
+  });
+  assert.deepEqual(Object.keys(sig).sort(), ["cla_version", "commit_sha", "login", "name", "pr", "signed_at"]);
+  assert.equal(sig.name, "x"); // defaults to login
+  assert.match(sig.signed_at, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("computeClaVersion is deterministic + sensitive to content", () => {
+  const a = computeClaVersion("hello");
+  const b = computeClaVersion("hello");
+  const c = computeClaVersion("hello!");
+  assert.equal(a, b);
+  assert.notEqual(a, c);
+  assert.match(a, /^sha256:[0-9a-f]{12}$/);
+});

--- a/.github/cla/signatures.json
+++ b/.github/cla/signatures.json
@@ -1,0 +1,5 @@
+{
+  "comment": "Recorded CLA acceptances. Appended by .github/workflows/cla-check.yml when an external contributor comments the exact agreement phrase on their PR. Each entry: {login, name, pr, commit_sha, cla_version, signed_at}. Do not hand-edit signatures; the workflow is the source of truth. See CONTRIBUTING.md.",
+  "cla_version": "sha256:56fa61fcd8de",
+  "signatures": []
+}

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,19 +1,178 @@
 name: CLA Check
 
+# Self-hosted CLA-acceptance gate (#1660). No third-party service.
+#
+# Records affirmative CLA acceptance IN-REPO at .github/cla/signatures.json.
+# External (non-org-member, non-bot) human contributors must comment the exact
+# phrase  "I have read and agree to the CLA"  on their PR; the workflow then
+# appends their signature and the check passes. Internal authors (org members,
+# the maintainer, and any *[bot]) are EXEMPT and pass with no signature — this
+# is critical so the team's self-merge / automation PRs are never blocked.
+#
+# SECURITY — pull_request_target:
+#   This trigger runs with a WRITE token in the BASE-repo context even for fork
+#   PRs. We therefore NEVER `actions/checkout` the PR head, and never run any
+#   PR-supplied code. We only read PR/comment METADATA via the API and the
+#   tracked signature store, and (on a valid signing comment) commit an append
+#   to .github/cla/signatures.json. The checkout we DO perform is always the
+#   BASE ref (default checkout of pull_request_target = base), so the gate
+#   logic + signature store we read are the trusted repo's versions, not the
+#   fork's.
+#
+# The job is named `cla-check` so it maps to that branch-protection context.
+# It is currently informational (not yet a required check) — see the follow-up
+# note in plan/issues/1660-real-cla-gate.md before promoting it to required.
+#
+# ADMIN NOTE for the eventual branch-protection promotion: this workflow pushes
+# the signature commit directly to the default branch as github-actions[bot].
+# If `main` is later protected with required PR reviews / linear history, that
+# direct push can be rejected. When promoting, either (a) allow the
+# github-actions bot to bypass protection for `.github/cla/signatures.json`, or
+# (b) switch the signing path to open a tiny auto-merge PR instead of a direct
+# push. Until protection is enabled this direct push works as-is.
+
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write # to commit appended signatures to the base repo
+  pull-requests: write # to post the one-time instruction comment
+  issues: write
+  statuses: write # to set the cla-check commit status
 
 jobs:
   cla-check:
     runs-on: ubuntu-latest
+    # issue_comment fires on ALL issues; only run for PR comments.
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
     steps:
-      - name: Placeholder
-        run: |
-          echo "CLA enforcement placeholder."
-          echo "Replace this workflow with a real contributor signature or approval system."
-          echo "Required contributor terms are documented in CONTRIBUTING.md and CLA.md."
+      # BASE checkout only (default for pull_request_target). Never the PR head.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
+      - name: Evaluate / record CLA acceptance
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const gate = await import(`${process.env.GITHUB_WORKSPACE}/.github/cla/cla-gate.mjs`);
+            const fs = require("node:fs");
+            const { execFileSync } = require("node:child_process");
+
+            const org = context.repo.owner;
+            const repo = context.repo.repo;
+            const token = process.env.GITHUB_TOKEN || core.getInput("github-token");
+            const claVersion = gate.currentClaVersion();
+            const allowlist = gate.readAllowlist();
+
+            // ---- Resolve PR number + author + head SHA ------------------------
+            let prNumber, author;
+            if (context.eventName === "issue_comment") {
+              prNumber = context.payload.issue.number;
+            } else {
+              prNumber = context.payload.pull_request.number;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: org, repo, pull_number: prNumber,
+            });
+            author = pr.user.login;
+            const headSha = pr.head.sha;
+            const authorName = pr.user.name || author;
+
+            core.info(`PR #${prNumber} author=${author} cla_version=${claVersion} event=${context.eventName}`);
+
+            // ---- Helper: set the cla-check commit status ----------------------
+            async function setStatus(state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner: org, repo, sha: headSha,
+                state, // success | failure | pending
+                context: "cla-check",
+                description: description.slice(0, 140),
+              });
+            }
+
+            // ---- 1) EXEMPTION (static allowlist + bots + live org membership) -
+            const { exempt, reason } = await gate.resolveExemption({
+              token, org, login: author, allowlist,
+            });
+            if (exempt) {
+              core.info(`Author ${author} is exempt (${reason}); CLA not required.`);
+              await setStatus("success", `CLA not required (${reason}).`);
+              return;
+            }
+
+            // ---- 2) issue_comment: record a signature if the phrase matches ---
+            if (context.eventName === "issue_comment") {
+              const commenter = context.payload.comment.user.login;
+              const body = context.payload.comment.body;
+              const commenterIsAuthor =
+                commenter.toLowerCase() === author.toLowerCase();
+              if (commenterIsAuthor && gate.commentMatchesPhrase(body)) {
+                const store = gate.readStore();
+                const sig = gate.makeSignature({
+                  login: author, name: authorName, pr: prNumber,
+                  commitSha: headSha, claVersion,
+                });
+                const { store: next, added } = gate.appendSignature(store, sig);
+                if (added) {
+                  gate.writeStore(next);
+                  // Commit the appended signature to the base repo.
+                  execFileSync("git", ["config", "user.name", "github-actions[bot]"]);
+                  execFileSync("git", ["config", "user.email",
+                    "41898282+github-actions[bot]@users.noreply.github.com"]);
+                  execFileSync("git", ["add", ".github/cla/signatures.json"]);
+                  execFileSync("git", ["commit", "-m",
+                    `chore(cla): record CLA acceptance for @${author} (PR #${prNumber})`]);
+                  execFileSync("git", ["push", "origin",
+                    `HEAD:${context.payload.repository.default_branch}`]);
+                  core.info(`Recorded CLA signature for @${author}.`);
+                }
+                await setStatus("success", "CLA accepted and recorded.");
+                return;
+              }
+              // A non-matching comment on an unsigned PR: re-evaluate below.
+            }
+
+            // ---- 3) Already signed at the current version? --------------------
+            const store = gate.readStore();
+            if (gate.hasSigned(store.signatures, author, claVersion)) {
+              await setStatus("success", "CLA already accepted.");
+              return;
+            }
+
+            // ---- 4) Not signed → fail + one-time instruction comment ----------
+            const marker = "<!-- cla-gate:request -->";
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: org, repo, issue_number: prNumber, per_page: 100,
+            });
+            const alreadyAsked = comments.some(
+              (c) => c.body && c.body.includes(marker),
+            );
+            if (!alreadyAsked) {
+              await github.rest.issues.createComment({
+                owner: org, repo, issue_number: prNumber,
+                body:
+                  `${marker}\n` +
+                  `Thanks for your contribution, @${author}! Before this PR can be ` +
+                  `merged we need a recorded acceptance of our ` +
+                  `[Contributor License Agreement](../blob/${context.payload.repository.default_branch}/CLA.md).\n\n` +
+                  `Please post a comment on this PR with **exactly** this phrase:\n\n` +
+                  `> ${gate.AGREEMENT_PHRASE}\n\n` +
+                  `Your acceptance will be recorded in ` +
+                  `\`.github/cla/signatures.json\` and the \`cla-check\` will turn green.`,
+              });
+            }
+            await setStatus(
+              "failure",
+              `Awaiting CLA acceptance — comment "${gate.AGREEMENT_PHRASE}".`,
+            );
+            core.setFailed(`@${author} has not accepted the CLA (version ${claVersion}).`);

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -61,6 +61,11 @@ jobs:
 
       - name: Evaluate / record CLA acceptance
         uses: actions/github-script@v7
+        env:
+          # Exposed so the gate module's own fetch()-based org-membership check
+          # has a token. github-script also injects an authenticated `github`
+          # Octokit, but the gate module calls the REST API directly.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,38 @@ If you do not agree to these terms, do not submit a contribution.
 
 This CLA requirement exists so the project can maintain an Apache 2.0 with LLVM Exceptions community distribution while also supporting commercial and proprietary licensing arrangements for infrastructure partners.
 
+### How acceptance is recorded (the `cla-check` gate)
+
+Acceptance is recorded affirmatively and audibly — there is no third-party
+service. The `cla-check` GitHub Action (`.github/workflows/cla-check.yml`)
+gates every pull request:
+
+1. When you open a PR, the gate checks whether your GitHub account has a
+   recorded acceptance in `.github/cla/signatures.json` at the **current CLA
+   version**.
+2. If not, the gate fails and a bot posts a one-time comment asking you to
+   accept. **Comment this exact phrase on your PR:**
+
+   > I have read and agree to the CLA
+
+3. The Action then appends a signature record
+   (`{login, name, pr, commit_sha, cla_version, signed_at}`) to
+   `.github/cla/signatures.json`, commits it as `github-actions[bot]`, and the
+   `cla-check` turns green. Your acceptance is now part of the repo's history.
+
+**Exempt contributors** — members of the `loopdive` organization, the
+maintainer, and automation bots (`github-actions[bot]`, `dependabot[bot]`, any
+`*[bot]`) are exempt and pass the gate automatically with no signature. Only
+external (non-member) human contributors need to comment the phrase. The
+exemption is resolved live via the GitHub org-membership API, with an explicit
+fallback allowlist at `.github/cla/allowlist.json`.
+
+**CLA version / re-acceptance** — the CLA version is derived from the content
+hash of [`CLA.md`](./CLA.md) (`CLA_VERSION` in `.github/cla/cla-gate.mjs`). A
+signature is only valid for the version it was recorded against, so if the CLA
+terms ever change, the version bumps and contributors are asked to re-accept
+the updated terms. Past acceptances of the old terms remain in the audit trail.
+
 ## Pull Requests
 
 When opening a PR:
@@ -95,7 +127,9 @@ When opening a PR:
 - describe any conformance or behavior impact
 - include the relevant tests or rationale if tests are not added
 
-PRs may be subject to an automated CLA check workflow placeholder until a dedicated signature flow is wired in.
+PRs are gated by the `cla-check` workflow described above. For external
+contributors this means: open the PR, then comment the agreement phrase so the
+gate can record your acceptance.
 
 ## License
 

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -46,7 +46,7 @@ A failure here surfaces in the PR Checks tab but does not block merge.
 | `differential gate (branch vs main)` | `.github/workflows/test262-differential.yml` | Branch-vs-main HEAD comparison with src-tree-hash caching (#1246). Useful diagnostic signal, but the sharded `merge shard reports` is the authoritative gate. Kept running for visibility into per-PR deltas. |
 | `check for test262 regressions` | `.github/workflows/test262-sharded.yml` | Legacy rolling-baseline regression gate. Produced drift-induced false-positives — see PR #142/#143/#151 retros. Superseded by `merge shard reports`. |
 | `refresh-benchmarks` | `.github/workflows/benchmark-refresh.yml` | Playground benchmark regression gate. Currently informational at the branch-protection level, but the workflow itself fails on regression for PRs (#1525, §6 below). Promote to required once a longer signal window confirms stability. |
-| `CLA check` | `.github/workflows/cla-check.yml` | Currently informational; promote to required once the CLA flow is stable. |
+| `cla-check` | `.github/workflows/cla-check.yml` | Self-hosted CLA-acceptance gate (#1660): records affirmative acceptance in `.github/cla/signatures.json`. Internal authors (org members, maintainer, `*[bot]`) are exempt and pass with no signature; external humans must comment the agreement phrase. **Currently informational** — promote to required only after exemption is confirmed in practice (add `"cla-check"` to `REQUIRED_CHECKS` in `scripts/enable-branch-protection.sh` and re-run it). Do NOT promote before confirming internal/bot authors pass, or it would block the merge queue. |
 | `Test262 Canary` | `.github/workflows/test262-canary.yml` | Smoke check on a small slice of test262 — fast feedback, not authoritative. |
 
 ---

--- a/plan/issues/1660-real-cla-gate.md
+++ b/plan/issues/1660-real-cla-gate.md
@@ -1,10 +1,11 @@
 ---
 id: 1660
 title: "Replace placeholder cla-check with a real CLA signature/approval gate"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-05-24
 updated: 2026-05-24
+completed: 2026-05-24
 priority: high
 feasibility: medium
 task_type: infrastructure
@@ -72,3 +73,70 @@ The relicensing question itself warrants legal review; this issue covers the
 - #1530 (WASI native-messaging host example) — guest271314's PR #589 is gated
   on this issue. See the **HOLD** note in #1530: do not merge PR #589 until
   guest has an affirmative CLA acceptance recorded.
+
+## Implementation (done)
+
+Chose option (a) — a **self-hosted CLA-assistant-style gate** with signatures
+stored in-repo. No third-party service.
+
+### Files
+- `.github/cla/cla-gate.mjs` — dependency-free, unit-testable logic module
+  (exemption resolution, phrase matching, signature append, CLA-version hash).
+- `.github/cla/cla-gate.test.mjs` — `node --test` unit tests for the pure
+  logic (9 tests; run `node --test .github/cla/cla-gate.test.mjs`).
+- `.github/cla/signatures.json` — the audit trail. Array of
+  `{login, name, pr, commit_sha, cla_version, signed_at}`. Starts empty.
+- `.github/cla/allowlist.json` — explicit exemption fallback (logins + orgs).
+- `.github/workflows/cla-check.yml` — the gate (job name kept as `cla-check`).
+- `CONTRIBUTING.md`, `docs/ci-policy.md` — contributor flow + policy note.
+
+### How it works
+- Triggers: `pull_request_target` (opened/synchronize/reopened) and
+  `issue_comment` (created, PR comments only).
+- **Exemption (critical):** an author is exempt — and passes with NO signature
+  — if they are a `*[bot]`, on the allowlist, or a live member of the
+  `loopdive` org. Live membership is checked via
+  `GET /orgs/{org}/members/{login}` (204 ⇒ member). If that API call is
+  inconclusive (rate-limit/403) we fall back to the static allowlist rather
+  than blocking. **Only external (non-member) humans must sign.**
+- **Signing:** an `issue_comment` from the PR author whose body is exactly
+  `I have read and agree to the CLA` (trim + case-insensitive) appends a
+  signature, committed by `github-actions[bot]`, and flips the check green.
+- **CLA_VERSION** = `sha256:<first-12-of-CLA.md-hash>` (`currentClaVersion()`).
+  A signature is valid only for the version it was recorded against, so any
+  edit to `CLA.md` bumps the version and forces re-acceptance.
+
+### WHY these choices
+- **`pull_request_target`, not `pull_request`:** fork PRs need a write token to
+  record the signature and set the commit status. We mitigate the well-known
+  RCE risk of this trigger by **never checking out or running PR head code** —
+  we check out the BASE default branch, read only PR/comment *metadata* via the
+  API, and the only write is the signature-store commit. Documented in the
+  workflow header.
+- **Version tied to CLA.md hash, not a manual constant:** removes the failure
+  mode where someone edits the terms but forgets to bump the version, silently
+  keeping stale acceptances valid.
+- **Live org check + static allowlist (belt and suspenders):** the allowlist
+  alone would require hand-maintaining every teammate; the live check alone
+  could wrongly block on an API hiccup. Together, internal authors never get
+  blocked.
+
+### Verification (done in isolation — NOT fired at #589/#389)
+- `node --test .github/cla/cla-gate.test.mjs` → 9/9 pass.
+- Live exemption probe against the real GitHub API:
+  - `ttraenkler` → exempt (`allowlist`; and `org:loopdive` when allowlist
+    emptied — proves the live org path).
+  - `github-actions[bot]` → exempt (`bot`).
+  - `guest271314` (external) → NOT exempt → must sign. Correct.
+
+### Follow-up for an admin (NOT done in this PR — by design)
+`cla-check` is currently **informational** (it is not in `REQUIRED_CHECKS`, and
+branch protection on `main` is presently not even enabled). To make external
+PRs hard-blocked:
+1. Confirm a few internal/bot PRs pass the new gate in practice.
+2. Add `"cla-check"` to `REQUIRED_CHECKS` in
+   `scripts/enable-branch-protection.sh` and to `docs/ci-policy.md` §1.
+3. Run `./scripts/enable-branch-protection.sh`.
+
+This was deliberately deferred so an over-strict gate can't deadlock the
+internal merge queue before the exemption is proven in the wild.

--- a/plan/issues/1660-real-cla-gate.md
+++ b/plan/issues/1660-real-cla-gate.md
@@ -140,3 +140,14 @@ PRs hard-blocked:
 
 This was deliberately deferred so an over-strict gate can't deadlock the
 internal merge queue before the exemption is proven in the wild.
+
+### Note: why THIS PR has no `cla-check` status (expected)
+A `pull_request_target` workflow always runs the workflow definition from the
+**base branch**, and the old `pull_request` placeholder runs from the **head**.
+This PR removes the `pull_request` trigger (head) and adds `pull_request_target`
+(only active once on `main`), so the new gate does **not** run against its own
+introducing PR — standard GitHub behavior, and the usual way CLA gates are
+landed. The gate goes live for the *next* PR. Because `cla-check` is not a
+required check (and branch protection is off), the absent status does not block
+this merge; the required checks (`cheap gate`, `merge shard reports`,
+`quality`) all passed.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -42,7 +42,7 @@ both others); #1653 is the keystone for the read side + continuous loop.
 
 ## Governance / legal — CLA gate (2026-05-24)
 
-- [#1660](../1660-real-cla-gate.md) — Replace the placeholder `cla-check` workflow with a real CLA signature/approval gate (CLA-assistant bot or DCO `Signed-off-by`), made a required check on `main` — **high**, medium, **ready**. The current `cla-check` is a no-op that records nothing, so external contributions land with no auditable CLA acceptance. **Gates external-PR merges, including guest271314's PR #589 (see #1530 HOLD).** Related: #1530.
+- [#1660](../1660-real-cla-gate.md) — Replace the placeholder `cla-check` workflow with a real CLA signature/approval gate — **DONE**. Self-hosted in-repo gate: signatures recorded in `.github/cla/signatures.json` via an affirmative PR comment; internal authors (org members / maintainer / `*[bot]`) exempt, external humans sign by comment. CLA version tied to `CLA.md` hash for re-acceptance. Promotion to a *required* branch-protection check is deferred to an admin (documented follow-up in the issue) so the gate can't deadlock the internal merge queue before exemption is proven. Related: #1530.
 
 ## Spec-compliance easy wins (from #1563 gap analysis, 2026-05-21)
 

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -76,10 +76,10 @@ sign-off.
 
 | #    | Title | Priority | Feasibility | Status |
 |------|-------|----------|-------------|--------|
-| 1660 | Replace placeholder cla-check with a real CLA signature/approval gate | high | medium | **Ready** — gates external-PR merges incl. guest271314's PR #589 (#1530 HOLD) |
+| 1660 | Replace placeholder cla-check with a real CLA signature/approval gate | high | medium | **Done** — self-hosted in-repo signature gate (`.github/cla/`); internal/bot authors exempt, external humans sign by comment. Promotion to a *required* check deferred to an admin (see issue follow-up). |
 
 ```
-#1660 (real CLA gate) -- gates all external-PR merges
+#1660 (real CLA gate) -- DONE: gates external-PR merges once promoted to required
   └── PR #589 (guest271314, attached to #1530) -- HOLD until guest's CLA acceptance is recorded
 ```
 


### PR DESCRIPTION
## Summary

Replaces the no-op `cla-check` placeholder with a real, **self-hosted** CLA-acceptance gate (no third-party service). Affirmative acceptance is recorded **in-repo** at `.github/cla/signatures.json`, giving an auditable trail that the constructive "by contributing you agree" theory lacks (see #1660 / #1530 HOLD on guest271314's PR #589).

- **Gate** (`.github/workflows/cla-check.yml`): runs on `pull_request_target` (opened/synchronize/reopened) + `issue_comment` (created). Job name kept as `cla-check` so it maps to the branch-protection context.
- **Exemption (critical):** `loopdive` org members, the maintainer, and any `*[bot]` are EXEMPT and pass with **no signature** — so the team's self-merge / automation PRs are never blocked. Live org membership via `GET /orgs/{org}/members/{login}`, with a static `.github/cla/allowlist.json` fallback. Only **external humans** must sign by commenting the exact phrase `I have read and agree to the CLA`.
- **Signing:** a matching comment from the PR author appends a signature record (`{login,name,pr,commit_sha,cla_version,signed_at}`), committed by `github-actions[bot]`, and the check turns green.
- **CLA_VERSION** = `sha256:<first-12 of CLA.md hash>` → any change to the terms forces re-acceptance; old signatures stay in the audit trail.
- **Security (`pull_request_target`):** never checks out or runs PR head code; checks out the BASE default branch, reads only PR/comment metadata via the API, and the only write is the signature commit. Documented in the workflow header.
- **Logic** lives in dependency-free `.github/cla/cla-gate.mjs` with `node:test` unit tests in `.github/cla/cla-gate.test.mjs`.

## Deliberately deferred (admin follow-up)

`cla-check` is **informational**, NOT a required check (branch protection on `main` is currently disabled entirely). Promotion to required — add `"cla-check"` to `REQUIRED_CHECKS` in `scripts/enable-branch-protection.sh` and re-run it — is left to an admin **after** exemption is confirmed in practice, so an over-strict gate cannot deadlock the internal merge queue. See the issue file follow-up.

## Test plan

- [x] `node --test .github/cla/cla-gate.test.mjs` → 9/9 pass (exemption, phrase match, idempotent append, version hash).
- [x] Live exemption probe against the real GitHub API: `ttraenkler` → exempt (allowlist + `org:loopdive`), `github-actions[bot]` → exempt (bot), `guest271314` (external) → must sign. NOT fired at any live external PR/issue.
- [x] `pnpm run check:issues` passes; biome/prettier/tsc scopes don't cover `.github/` so the `quality` job is unaffected.
- [ ] Confirm this PR's own `cla-check` passes (internal/bot author path) before self-merge.

Closes #1660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)