### PR TITLE
plan(#1661): README programmatic-API host-imports gap (from guest #601), sprint 55

### DIFF
--- a/plan/issues/1661-readme-programmatic-api-host-imports.md
+++ b/plan/issues/1661-readme-programmatic-api-host-imports.md
@@ -1,0 +1,73 @@
+---
+id: 1661
+title: "README programmatic-API example fails: instantiate(binary, {}) but default mode requires host imports"
+status: ready
+created: 2026-05-25
+updated: 2026-05-25
+priority: high
+feasibility: easy
+reasoning_effort: low
+task_type: docs
+area: docs
+language_feature: n/a
+sprint: 55
+github_issue: 601
+filed_by: guest271314
+related: [1471, 1472, 1473, 1474, 1530]
+---
+
+## Problem
+
+Reported by **guest271314** in GitHub issue **#601**. The README's programmatic
+API section shows:
+
+```js
+import { compile } from "js2wasm";
+const result = compile(`export function add(a: number, b: number): number { return a + b; }`);
+if (result.success) {
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  console.log(instance.exports.add(2, 3));
+}
+```
+
+**Actual failure**:
+
+```
+TypeError: WebAssembly.instantiate(): Import #0 "string_constants": module is not an object or function
+```
+
+…and likewise the `env` module expects `__throw_reference_error`,
+`__extern_length`, `__extern_get`, `__unbox_number`, `__box_number`,
+`__array_from_iter`. So `instantiate(binary, {})` cannot work for default-mode
+output.
+
+**Likely cause**: the example uses **default JS-host compile mode**, which emits
+the `string_constants` module + `env.*` runtime imports. Instantiating with an
+empty imports object `{}` therefore fails. The README neither discloses the
+required imports nor shows the standalone / no-host option.
+
+## Fix direction
+
+(Let the implementing dev pick, but recommend (a).)
+
+- **(a) preferred** — change the example to compile in **standalone / no-JS-host
+  mode** (the `--target wasi` / `standalone` path from #1471–#1474, where the
+  module instantiates with `{}` because it has no `env` / `string_constants`
+  imports) and verify the snippet runs end-to-end.
+- **(b)** — document how to supply the runtime host imports the compiler emits
+  (and where they come from).
+
+Given the project's standalone-first direction, **(a)** is preferred — the
+README should show a snippet that genuinely runs under `instantiate(binary, {})`.
+
+## Acceptance criteria
+
+- The README programmatic-API snippet, copy-pasted, runs successfully (exports
+  callable) under Node with no missing-import error.
+- The default-vs-standalone import requirement is documented.
+- Verified by **actually running** the snippet.
+
+## Theme link
+
+Same root as guest's **#389** / `readStdin` finding — docs imply standalone
+behavior the default mode doesn't deliver.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -29,6 +29,7 @@ From the dev-1553b destructuring-lane verification sweep.
 
 - [#1656](../1656-group-website-files-into-website-dir.md) — Consolidate all website/frontend files under `website/` (components, dashboard, playground, index.html, public, frame-nav-sync.js, images, vite.config.ts, CNAME) — medium, medium, **ready (sprint 55)**. Needs architect spec (`arch(#1656)`) before dev; lands as one PR. Related: #1583, #1590.
 - [#1657](../1657-mq-test262-paths-filter.md) — Skip `merge_group` test262 shards for non-src changes while keeping the "merge shard reports" required check green — medium, medium, **in-review (sprint 55)**. Conservative path detector (`scripts/test262-paths-match.sh`) + `changes` job gate the queue's shard matrix; fail-safe runs shards on any doubt. Related: #1656.
+- [#1661](../1661-readme-programmatic-api-host-imports.md) — README programmatic-API example fails: `instantiate(binary, {})` but default JS-host mode emits `string_constants` + `env.*` imports, so the empty-imports snippet throws `Import #0 "string_constants"`. Recommend switching the example to standalone / no-host mode (#1471–#1474) so it genuinely runs under `{}`, and document the default-vs-standalone import requirement — **high**, easy, **ready (sprint 55)**. Plan-only; from guest271314 GitHub #601. Same theme as #389 (docs imply standalone behavior default mode doesn't deliver). Related: #1471, #1472, #1473, #1474, #1530.
 
 ## WASI Native Messaging — AssemblyScript-reference alignment (2026-05-24)
 

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -38,6 +38,12 @@ coverage) gates #1658 in the sense that #1658 is only CI-visible once #1659 land
 | 1659 | CI does not run tests/equivalence/ (OOM) — equivalence regressions land silently | high | medium | **Ready** (gates CI-visibility of #1658) |
 | 1658 | Destructured/scalar function-parameter default not applied (returns 30, expects 40) | high | medium | **Ready** (depends on #1659 for CI gating) |
 
+## Sprint 55 — docs (added 2026-05-25)
+
+| #    | Title | Priority | Feasibility | Status |
+|------|-------|----------|-------------|--------|
+| 1661 | README programmatic-API example fails — `instantiate(binary, {})` vs default-mode host imports (guest #601) | high | easy | **Ready** (sprint 55, docs, plan-only) |
+
 ## WASI Native Messaging — AssemblyScript-reference alignment (added 2026-05-24)
 
 Compiler gaps blocking full convergence of `examples/native-messaging/host.ts`


### PR DESCRIPTION
## Summary
- Capture guest271314's GitHub issue #601 as plan issue #1661 in active sprint 55.
- README programmatic-API snippet uses `instantiate(binary, {})` but default JS-host mode emits `string_constants` + `env.*` imports, so the empty-imports call throws `Import #0 "string_constants"`.
- Recommends switching the example to standalone / no-host mode (#1471-#1474) and documenting the default-vs-standalone import requirement.

Plan-only PR (issue file + backlog + dependency graph). No code or GitHub-issue changes.

## Files
- `plan/issues/1661-readme-programmatic-api-host-imports.md` (new)
- `plan/issues/backlog/backlog.md` (sprint-55 section)
- `plan/log/dependency-graph.md` (sprint-55 docs entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)