### PR TITLE
plan: standalone (--target wasi) host-import audit + remaining-gap issues

### DIFF
--- a/plan/issues/1662-standalone-host-import-audit.md
+++ b/plan/issues/1662-standalone-host-import-audit.md
@@ -1,0 +1,127 @@
+---
+id: 1662
+title: "audit: standalone (--target wasi) host-import leaks per construct + remaining-gap map"
+status: done
+created: 2026-05-25
+completed: 2026-05-25
+priority: high
+feasibility: easy
+task_type: research
+area: codegen, standalone
+language_feature: host-imports
+goal: standalone-mode
+sprint: Backlog
+related: [1535, 1471, 1472, 1473, 1474, 1103, 1335, 1470, 1599, 682, 1598]
+---
+# #1662 — Standalone (`--target wasi`) host-import audit
+
+## Problem
+
+The dual-mode principle (CLAUDE.md) says every feature should have a
+Wasm-native path that needs no JS runtime. #1535 produced a *source-level*
+inventory of host imports; this issue is the *empirical* counterpart — for a
+representative feature matrix, compile each construct with `--target wasi`
+and record which **non-`wasi_snapshot_preview1`** imports actually leak into
+the emitted `.wasm`.
+
+`wasi_snapshot_preview1.*` (fd_write, proc_exit, random_get, …) is the WASI
+ABI and is **expected** — not a leak. Only `env.*` (and any
+`wasm:js-string` / `string_constants`) count as JS-host leaks.
+
+## Method
+
+36 minimal probes in `.tmp/probes/*.ts`, each
+`npx tsx src/cli.ts <probe>.ts --target wasi -o <out> --no-dts`, then the
+module's import section parsed (tolerant raw parser used so leaks are
+visible even for modules that fail full WASM validation — see the
+"invalid-wasm" cluster below). Cross-checked against `--target standalone`
+and the strict-mode allowlist (`src/codegen/host-import-allowlist.ts`).
+
+## Findings table (construct → leak under `--target wasi`)
+
+| Construct | Result under `--target wasi` | Leaking `env.*` imports | Owner |
+|---|---|---|---|
+| number arithmetic (`*`,`/`,`%`) | CLEAN | — | — |
+| string literals + concat + `+` | CLEAN | — | — |
+| `String.prototype` `.length`/`.slice`/`.indexOf`/`.toUpperCase` | CLEAN | — | — |
+| `String.prototype.split(",")` | CLEAN | — | — |
+| `String.fromCharCode` | CLEAN | — | #1598 (landed) |
+| `Uint8Array` `.set`/`.subarray` | **INVALID WASM** + leaks | `__extern_get`, `__extern_length`, `__array_from_iter` | #1664 / #1666 |
+| `Float64Array`/`Int32Array` | CLEAN | — | — |
+| `ArrayBuffer` + `DataView` get/set | CLEAN | — | — |
+| plain array `.push` + `.length` | CLEAN | — | — |
+| array `.map`/`.filter`/`.reduce` | **INVALID WASM** + leaks | `__make_callback`, `__call_1_f64`, `__call_2_f64` | #1470 / #1666 |
+| array `for-of` iteration | CLEAN | — | — |
+| object literal + property get/set | CLEAN | — | — |
+| object spread `{...o, b:2}` | CLEAN | — | — |
+| class + method + `extends`/`super` | **INVALID WASM** + leaks | `__register_prototype`, `__register_class_object` | #1664 / #1666 |
+| closure capturing local | **INVALID WASM** + leaks | `__make_callback` | #1470 / #1666 |
+| `JSON.stringify` (object) | **CE (gated)** | (gate rejects `env.eval`/`isNaN`/`isFinite`/`global_JSON`) | #1599 Phase 2 |
+| `JSON.parse` | **CE (gated)** | (same) | #1599 Phase 2 |
+| `Math.*` (sqrt/floor/max/sin) | CLEAN | — | — |
+| `parseInt`/`parseFloat`/`Number()` | leaks | `parseInt`, `parseFloat` | **#1663 (new)** |
+| `(x).toFixed`/`(n).toString(16)` | **INVALID WASM** + leaks | `number_toString`, `number_toString_radix`, `number_toFixed` | #1335 / #1666 |
+| `String(42)`/`String(true)` | **INVALID WASM** + leaks | `number_toString` | #1335 / #1666 |
+| template literal `` `${x}` `` (number interp) | **INVALID WASM** + leaks | `number_toString` | #1335 / #1666 |
+| `/re/.test(s)` | **INVALID WASM** + leaks | `RegExp_new`, `RegExp_test` | #682 / #1474 |
+| `/re/.exec(s)` | **INVALID WASM** + leaks | `RegExp_new`, `RegExp_exec`, `__extern_get` | #682 / #1474 |
+| `s.replace(/x/g,…)` | **INVALID WASM** + leaks | `RegExp_new`, `string_replace` | #682 / #1474 |
+| `Map` (`new`/`set`/`get`/`size`) | leaks | `Map_new`, `Map_set`, `Map_get`, `Map_get_size` | #1103 |
+| `Set` (`new`/`add`/`size`) | leaks | `Set_new`, `Set_add`, `Set_get_size` | #1103 |
+| `try { throw new Error } catch` | CLEAN | — | #1473 (landed) |
+| null-deref TypeError try/catch | CLEAN | — | #1473 (landed) |
+| `function*` generator + for-of | **INVALID WASM** + leaks | `__gen_create_buffer`, `__gen_push_f64`, `__gen_push_i32`, `__create_generator`, `__create_async_generator`, `__gen_throw`, `__get_caught_exception`, `__iterator*` | **#1665 (new)** |
+| `a[Symbol.iterator]()` | CE (TS type) | — | (probe artefact) |
+| `async function` (declared) | CLEAN | — | — |
+| `Promise.resolve` | CLEAN | — | — |
+| `new Date(0).getFullYear()` | CLEAN | — | — |
+| `BigInt` (`10n+20n`) | CLEAN | — | — |
+| `Symbol("x")` identity | CLEAN | — | — |
+
+(CLEAN = zero non-wasi imports. "INVALID WASM" = the module also fails
+`WebAssembly.compile` validation — a correctness bug, see #1666 — but the
+import section still parses and shows the leak.)
+
+## Interpretation
+
+The host-import gate (`--no-host-imports`, implied by `--target wasi`) has
+two failure modes:
+
+1. **Allowlisted leak** — the import name matches a transitional entry in
+   `host-import-allowlist.ts`, so the gate lets it through and the `.wasm`
+   carries an unsatisfiable `env.*` import. Every leak above is allowlisted,
+   each citing a tracking issue. These are the genuine remaining gaps.
+2. **Hard CE** — JSON pulls `env.eval`/`env.global_JSON`, which are NOT on
+   the allowlist, so the strict gate rejects them at compile time (the gate
+   working as designed; #1599 Phase 2 owns the pure-Wasm codec).
+
+A third, independent failure surfaced: many constructs that *should* lower
+to pure WasmGC (classes, closures, callback-based array methods, number→
+string, regex, generators, typed-array `.set`) emit **invalid Wasm** under
+`--target wasi` — the native string/number helpers (`__str_flatten`,
+`__str_to_extern`) get a type-mismatched call, or a global index resolves to
+`0xffffffff` (-1, an unbound late global). This is tracked separately as a
+correctness bug in **#1666**.
+
+## Genuine remaining gaps and their owners
+
+| Bucket | Leaking imports | Tracking issue | Status |
+|---|---|---|---|
+| Map/Set/WeakMap/WeakSet | `Map_*`,`Set_*`,`WeakMap_*`,`WeakSet_*` | **#1103** (exists) | ready — link |
+| Number→string formatting | `number_toString*`,`number_toFixed`,`number_toPrecision`,`number_toExponential` | **#1335** (exists) | ready — link |
+| RegExp engine | `RegExp_*`, regex-arg `string_*` | **#682 / #1474** | ready/done — link |
+| Closures / host callbacks | `__make_*`,`__call_*` | **#1470** | review — link |
+| JSON codec (Phase 2) | (gated `eval`/`global_JSON`) | **#1599** | done Phase 1 — link |
+| `parseInt`/`parseFloat`/`Number()` | `parseInt`,`parseFloat` | **#1663 (new)** — #1471 was closed without covering these | new |
+| Object/extern/iterator residual | `__extern_*`,`__register_*`,`__iterator*`,`__array_*`,`__get_undefined` | **#1664 (new)** — residual after #1472 closed | new |
+| Native generators | `__gen_*`,`__create_generator`,`__create_async_generator` | **#1665 (new)** — only owned by the #1376 IR telemetry gate, no native-engine issue | new |
+| Invalid-wasm correctness bug | (n/a — module fails validation) | **#1666 (new)** | new |
+
+## Expected / wont-fix (not filed)
+
+- `eval`, `Function(string)`, Proxy, `with`, dynamic `import()` — wont-fix in
+  standalone per CLAUDE.md skip filters. JSON's `env.eval` leak is an
+  implementation detail of the host JSON shim, retired by #1599 Phase 2, not
+  a reason to support eval.
+- Full `Intl.*` / `localeCompare` collation — keep host-only (≥0.5 MB data),
+  per #1535 recommendation.

--- a/plan/issues/1663-standalone-parseint-parsefloat-native.md
+++ b/plan/issues/1663-standalone-parseint-parsefloat-native.md
@@ -1,0 +1,80 @@
+---
+id: 1663
+title: "host-indep: pure-Wasm parseInt / parseFloat / Number(string) in standalone mode"
+status: ready
+created: 2026-05-25
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen, standalone
+language_feature: numbers, string-to-number
+goal: standalone-mode
+sprint: Backlog
+related: [1662, 1471, 1335]
+---
+# #1663 — Pure-Wasm `parseInt` / `parseFloat` / `Number(string)` standalone
+
+## Problem
+
+Under `--target wasi` (and `--target standalone`), `parseInt`, `parseFloat`,
+and `Number(<string>)` still emit JS-host imports:
+
+```
+env.parseInt    (externref, f64) -> f64
+env.parseFloat  (externref)      -> f64
+```
+
+The emitted module cannot instantiate without a JS runtime. These were
+*supposed* to be covered by #1471 ("native path in #1471", per the allowlist
+reason on lines 131–142 of `src/codegen/host-import-allowlist.ts`), but
+#1471 landed (status done) covering only box/unbox/typeof/is_truthy — the
+string→number parsers were never implemented. The allowlist entries are now
+orphaned: they cite a closed issue.
+
+Probe (`.tmp/probes/parseint.ts`):
+```ts
+export function test(): number { return parseInt("42") + parseFloat("3.14") + Number("7"); }
+```
+→ leaks `env.parseInt`, `env.parseFloat`.
+
+## Standalone alternative
+
+Both are pure functions over a string and produce an `f64`/NaN. With
+`nativeStrings` (auto-on under WASI) the argument is already a WasmGC i16
+array, so a Wasm-native scanner is straightforward:
+
+- **`parseInt(s, radix)`** — ECMA-262 §19.2.5: trim leading whitespace,
+  optional sign, optional `0x` prefix (radix 16 / auto), then a digit loop
+  accumulating `value = value * radix + digit` until the first invalid
+  digit; return NaN if no digits consumed. Radix range 2..36 with a digit
+  table.
+- **`parseFloat(s)`** — ECMA-262 §19.2.4: scan the longest prefix matching
+  `StrDecimalLiteral` (sign, integer, fraction, exponent, `Infinity`), then
+  reuse the existing `__str_to_number` helper (already emitted by the native
+  string path for `__unbox_num_wasm`) on the matched slice.
+- **`Number(s)`** — ECMA-262 §7.1.4 StringToNumber: full string must match
+  (after trim) else NaN; reuse `__str_to_number`.
+
+A single `$__parse_int_wasm` / `$__parse_float_wasm` helper module mirrors
+the `box-unbox` helper pattern (cached on `ctx`, never imported).
+
+## Acceptance criteria
+
+- [ ] `--target wasi` and `--target standalone` emit **zero** `env.parseInt`
+      / `env.parseFloat` imports for the probe above.
+- [ ] `parseInt("42")===42`, `parseInt("0xFF")===255`, `parseInt("10",2)===2`,
+      `parseInt("  -7px")===-7`, `parseInt("abc")` is NaN.
+- [ ] `parseFloat("3.14")===3.14`, `parseFloat("1e3")===1000`,
+      `parseFloat("Infinity")===Infinity`, `parseFloat("xyz")` is NaN.
+- [ ] `Number("7")===7`, `Number(" 3.5 ")===3.5`, `Number("7px")` is NaN.
+- [ ] Remove the now-orphaned `parseInt`/`parseFloat` allowlist entries
+      (lines 129–142) once the native path lands; budget gate ratchets down.
+- [ ] equivalence tests green in default (JS-host) and standalone modes.
+
+## Files
+
+- `src/codegen/host-import-allowlist.ts` — remove parseInt/parseFloat entries.
+- The `parseInt`/`parseFloat`/`Number` codegen call sites (search
+  `ensureLateImport(ctx, "parseInt"` / `"parseFloat"`).
+- New `src/codegen/wasm-helpers/parse-number.ts` (or fold into the existing
+  native-strings number helpers).

--- a/plan/issues/1664-standalone-extern-object-iterator-residual.md
+++ b/plan/issues/1664-standalone-extern-object-iterator-residual.md
@@ -1,0 +1,87 @@
+---
+id: 1664
+title: "host-indep: residual __extern_* / __register_* / __iterator* / __array_* leaks after #1472"
+status: ready
+created: 2026-05-25
+priority: medium
+feasibility: hard
+task_type: bugfix
+area: codegen, standalone
+language_feature: objects, classes, typed-arrays, iterators
+goal: standalone-mode
+sprint: Backlog
+related: [1662, 1472, 1473]
+---
+# #1664 — Residual generic-object / iterator host imports under `--target wasi`
+
+## Problem
+
+#1472 ("eliminate JS host object/property ops for standalone") is marked
+**done**, but several common constructs still leak the generic
+externref-dispatch helpers it was supposed to retire. The allowlist entries
+for `__extern_`, `__register_`, `__iterator`, `__array_` (lines 207–249 of
+`src/codegen/host-import-allowlist.ts`) all cite #1472 — they are now
+residual gaps after a partial landing.
+
+Observed leaks (`--target wasi`, raw import section):
+
+| Probe | Leaking imports |
+|---|---|
+| `class B extends A { … super.get() }` | `__register_prototype`, `__register_class_object` |
+| `new Uint8Array(4).set([1,2,3]).subarray(1)` | `__extern_get`, `__extern_length`, `__array_from_iter` |
+| `re.exec(s)` result indexing | `__extern_get` |
+| `Map`/`Set` (standalone) | also pulls `__get_undefined` |
+
+Note: most of these probes ALSO emit invalid Wasm (see #1666) — the leak and
+the validation failure share a root cause in the native-string/late-global
+lowering path. Fix #1666 first; the residual imports here may partly resolve
+once the native lowering path is exercised correctly, but the
+`__register_*` prototype side-table and `__array_from_iter` typed-array
+bridge are genuine missing Wasm-native pieces.
+
+## Standalone alternative
+
+- **`__register_prototype` / `__register_class_object`** — these maintain a
+  host-side side-table linking WasmGC structs to JS prototypes for
+  `instanceof` and method dispatch. In standalone mode `instanceof` over
+  user classes can be resolved with a compile-time class-id field on the
+  struct + a `ref.test`/id-compare chain; no host registry needed (#1472
+  spec describes the vtable approach).
+- **`__extern_get` / `__extern_length`** — generic property/index/length on
+  an externref. For typed arrays the element/length access is a pure WasmGC
+  `array.get`/`array.len` once the value is known to be a `$TypedArray`
+  struct rather than an opaque externref; the leak means the value escaped
+  to externref. Audit why the typed-array `.set`/`.subarray` path boxes to
+  externref under WASI.
+- **`__array_from_iter`** — `Array.from(iterable)` / spread-of-iterable.
+  Standalone path: a WasmGC loop calling the iterator protocol helpers
+  (which themselves must be native — see #1665) and pushing into a WasmGC
+  array.
+- **`__get_undefined`** — the `undefined` sentinel; in standalone this is a
+  module-level global `(global $__undefined (ref null any))` initialised
+  once, not a host call.
+
+## Acceptance criteria
+
+- [ ] `class B extends A`, `Uint8Array.set/.subarray`, and `Map`/`Set`
+      probes emit zero `__register_*` / `__extern_*` / `__array_from_iter`
+      / `__get_undefined` imports under `--target wasi` and
+      `--target standalone`.
+- [ ] `new B(5).get()` (super call) returns the correct value standalone.
+- [ ] Remove the now-clean allowlist prefixes (or narrow them) and ratchet
+      the budget down.
+- [ ] equivalence tests green in both modes.
+
+## Files
+
+- `src/codegen/object-ops.ts`, `src/codegen/property-access.ts` —
+  externref-dispatch sites.
+- `src/codegen/registry/*` — prototype/class registry.
+- `src/codegen/typed-arrays*` — typed-array `.set`/`.subarray` lowering.
+- `src/codegen/host-import-allowlist.ts` — remove/narrow entries.
+
+## Dependency
+
+Resolve **#1666** (invalid-wasm cluster) first — several of these probes
+fail WASM validation, masking whether the leak is intrinsic or a fallout of
+the broken lowering path.

--- a/plan/issues/1665-standalone-native-generators.md
+++ b/plan/issues/1665-standalone-native-generators.md
@@ -1,0 +1,81 @@
+---
+id: 1665
+title: "host-indep: Wasm-native generators (retire __gen_* / __create_generator host scheduler)"
+status: ready
+created: 2026-05-25
+priority: medium
+feasibility: hard
+task_type: feature
+area: codegen, standalone
+language_feature: generators, iterators
+goal: standalone-mode
+sprint: Backlog
+related: [1662, 1376, 1103]
+---
+# #1665 — Wasm-native generators for standalone mode
+
+## Problem
+
+`function*` generators (and `for-of` over them) emit a large family of
+JS-host scheduler imports under `--target wasi`:
+
+```
+env.__gen_create_buffer, env.__gen_push_f64, env.__gen_push_i32,
+env.__create_generator, env.__create_async_generator, env.__gen_throw,
+env.__get_caught_exception,
+env.__iterator, env.__iterator_next, env.__iterator_done,
+env.__iterator_value, env.__iterator_return
+```
+
+Probe (`.tmp/probes/generator.ts`):
+```ts
+function* gen() { yield 1; yield 2; }
+export function test(): number { let s = 0; for (const x of gen()) s += x; return s; }
+```
+→ all twelve imports above; the module also fails WASM validation (#1666).
+
+The allowlist entries for `__gen_` / `__create_generator` /
+`__create_async_generator` (lines 273–291) cite **#1376**, but #1376 is the
+*IR fallback telemetry gate* (done) — it tracks generators as an IR
+*fallback*, not a native-implementation issue. There is no issue that owns a
+**Wasm-native generator engine**. This issue fills that ownership gap.
+
+## Standalone alternative
+
+Generators are coroutines. Two viable lowerings without a JS host:
+
+1. **State-machine transform (preferred, no proposal dependency)** — lower a
+   generator body to a switch over a `state: i32` field stored in a WasmGC
+   `$GeneratorState` struct: each `yield` is a state checkpoint that saves
+   live locals into struct fields and returns; `next()` re-enters the switch
+   at the saved state. This is the classic Babel/regenerator approach,
+   expressed in WasmGC. No host scheduler, no stack-switching proposal.
+2. **Wasm stack-switching proposal** (`cont`/`resume`) — cleaner but the
+   proposal is not yet broadly shipping; defer.
+
+The iterator-protocol helpers (`__iterator*`) are shared with #1664 and
+#1103 (for-of over Map/Set) — a native `$Iterator` interface (a WasmGC
+struct with a `next` funcref returning a `{value, done}` struct) lets
+for-of, generators, and collection iteration all share one native path.
+`__get_caught_exception` is owned by #1473 (landed) but reappears here via
+the generator `throw()` path.
+
+## Acceptance criteria
+
+- [ ] The generator probe emits **zero** `__gen_*` / `__create_generator*`
+      / `__iterator*` imports under `--target wasi` / `--target standalone`,
+      and the module validates (coordinate with #1666).
+- [ ] `for (const x of gen()) s += x` yields `s === 3` standalone.
+- [ ] `gen().next()` returns `{value:1, done:false}` then `{value:2,…}` then
+      `{value:undefined, done:true}`.
+- [ ] `yield*` delegation works standalone (separate phase acceptable).
+- [ ] async generators may remain deferred (document; out of standalone
+      scope short-term per the IR fallback "deferred" bucket).
+- [ ] Remove `__gen_*` / `__create_generator*` allowlist entries on landing.
+
+## Files
+
+- `src/codegen/closures.ts` / generator lowering (search `__create_generator`).
+- New `src/codegen/wasm-helpers/generator-state.ts` — `$GeneratorState`
+  struct + native iterator interface.
+- `src/codegen/host-import-allowlist.ts`.

--- a/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
+++ b/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
@@ -1,0 +1,109 @@
+---
+id: 1666
+title: "bug: --target wasi emits INVALID wasm for class/closure/callback/number→string/regex/generator/typed-array (native helper type mismatch + unbound late global)"
+status: ready
+created: 2026-05-25
+priority: high
+feasibility: hard
+task_type: bugfix
+area: codegen, standalone
+language_feature: classes, closures, number-formatting, typed-arrays
+goal: standalone-mode
+sprint: Backlog
+related: [1662, 1335, 1470, 1472]
+---
+# #1666 — `--target wasi` produces invalid (non-instantiable) Wasm for several constructs
+
+## Problem
+
+Beyond host-import leaks, the standalone audit (#1662) found a distinct
+**correctness** bug: several constructs that should lower to pure WasmGC
+emit a `.wasm` that **fails `WebAssembly.compile` validation** under
+`--target wasi`. The byte stream is malformed, not merely missing an import.
+
+Two failure signatures recur:
+
+### Signature A — native string helper type mismatch
+
+```
+Compiling function #N:"__str_flatten"  failed: call[k] expected type <T>, found <U>
+Compiling function #N:"__str_to_extern" failed: call[0] expected type f64, found local.get
+```
+
+Reproducers (`.tmp/probes/`):
+| Probe | Error |
+|---|---|
+| `array-map` (`.map().filter().reduce()`) | `__str_flatten` call[0] expected i32, found local.get |
+| `class` (`extends`/`super`) | `__str_flatten` call[1] expected externref, found i31 |
+| `closure` (captured local) | `__str_flatten` call[0] expected i32, found local.get |
+| `str-replace-re` | `__str_flatten` call[1] mismatch |
+| `str-template` (`` `${x}` ``) | `__str_to_extern` call[0] expected f64, found local |
+| `generator` | `__str_flatten` type error |
+
+The `__str_flatten` / `__str_to_extern` native-string helpers are being
+called with arguments of the wrong Wasm type — the call site builds a
+stack shape that doesn't match the helper signature. Likely the native
+string path and the (still-present) host-boxing path are being mixed: a
+value is boxed for the JS-host helper signature but then fed into the
+native helper, or vice versa.
+
+### Signature B — unbound late global (index 0xffffffff)
+
+```
+Compiling function #N:"test" failed: Invalid global index: 4294967295 @+offset
+```
+
+Reproducers:
+| Probe | Error |
+|---|---|
+| `numstr` (`.toFixed`/`.toString(16)`) | Invalid global index 4294967295 |
+| `string-ctor` (`String(42)`) | Invalid global index 4294967295 |
+| `uint8` (`Uint8Array.set/.subarray`) | Invalid global index 4294967295 |
+
+`4294967295` = `-1` = an unresolved/placeholder late global index that was
+never patched. A global is referenced before (or without) being registered
+— the late-global fixup that runs for the JS-host path doesn't run (or
+runs with a stale base) on the WASI native path.
+
+## Impact
+
+These constructs are *unusable* in standalone/WASI today — they don't even
+instantiate, regardless of whether a JS host is present. This is more severe
+than a host-import leak (which at least instantiates given the host). The
+audit had to use a tolerant raw import-section parser to see the leaks
+because the modules fail full validation.
+
+## Investigation starting points
+
+- **Signature A**: `src/codegen/native-strings.ts` (`__str_flatten`,
+  `__str_to_extern` emitters) and the number→string / concat call sites that
+  invoke them. Check whether `noJsHost = ctx.wasi || ctx.standalone`
+  consistently selects the native helper signature at *both* the helper
+  definition and every call site. The number→string path (#1335) and the
+  template-literal/`String()` concat path are prime suspects.
+- **Signature B**: the late-global registration + fixup (search for global
+  index assignment and the `0xffffffff` / `-1` placeholder). Compare the
+  JS-host code path (which works) against the WASI path for `.toFixed`,
+  `String(number)`, and typed-array `.set`. The global is likely the
+  number-formatting helper's lookup table or a typed-array template global.
+
+## Acceptance criteria
+
+- [ ] All probes in #1662 marked "INVALID WASM" compile to **valid**,
+      instantiable modules under `--target wasi` and `--target standalone`
+      (given the host imports they still legitimately need per #1335/#1470/
+      #1664/#1665 — validity is independent of leak-elimination).
+- [ ] `String(42)`, `(3.14159).toFixed(2)`, `(255).toString(16)`,
+      `` `val=${x}` ``, `new B(5).get()`, `[1,2,3].map(x=>x*2)`,
+      `new Uint8Array(4).set([1,2,3])` each instantiate and return correct
+      values standalone.
+- [ ] Add an import-section + `WebAssembly.compile` validity assertion to
+      the standalone test harness so a future regression is caught (extend
+      `assert-no-js-host-imports` to also assert the module validates).
+- [ ] equivalence tests green in both modes.
+
+## Note
+
+This bug likely **masks** part of the residual-leak analysis in #1664 — fix
+this first; some leaks may resolve once the native lowering path is
+exercised correctly.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,16 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## Standalone (--target wasi) host-import audit (2026-05-25) — goal `standalone-mode`
+
+Empirical per-construct audit of remaining JS-host (`env.*`) leaks under `--target wasi`. Audit record: [#1662](../1662-standalone-host-import-audit.md) (done). Each genuine remaining leak is owned by a tracking issue; new gaps filed where the cited issue was closed without coverage or no native-engine issue existed. Already-tracked: Map/Set → #1103, number→string → #1335, RegExp → #682/#1474, closures/callbacks → #1470, JSON Phase 2 → #1599. Expected/wont-fix (not filed): eval, Proxy, with, dynamic import, full Intl collation.
+
+- [#1662](../1662-standalone-host-import-audit.md) — Audit record + findings table (done) — high, easy.
+- [#1666](../1666-standalone-invalid-wasm-native-string-number-lowering.md) — **Bug**: `--target wasi` emits *invalid* (non-instantiable) wasm for class/closure/callback-array-methods/number→string/regex/generator/typed-array — `__str_flatten`/`__str_to_extern` type mismatch + unbound late global (`0xffffffff`). More severe than a leak (won't instantiate even with a host). Fix first — masks #1664. — high, hard, ready.
+- [#1663](../1663-standalone-parseint-parsefloat-native.md) — Pure-Wasm `parseInt`/`parseFloat`/`Number(string)`. `env.parseInt`/`env.parseFloat` still leak; #1471 (the cited owner) closed without implementing them. — medium, medium, ready.
+- [#1664](../1664-standalone-extern-object-iterator-residual.md) — Residual `__extern_*`/`__register_*`/`__iterator*`/`__array_*`/`__get_undefined` leaks after #1472 landed partial. class/super, typed-array `.set`/`.subarray`, Map/Set. — medium, hard, ready (after #1666).
+- [#1665](../1665-standalone-native-generators.md) — Wasm-native generators (state-machine lowering) to retire `__gen_*`/`__create_generator*`/`__iterator*` host scheduler. Currently only owned by the #1376 IR telemetry gate, not a native-engine issue. — medium, hard, ready (after #1666).
+
 ## Harvest 2026-05-24b (fixable test262 compile-error causes — CE decomposition)
 
 Decomposed the 1,367 `compile_error` results in `test262-current.jsonl`. The

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -362,10 +362,17 @@ All independent — can run in parallel.
 #681 (pure Wasm iterators) -- enables broader standalone coverage
 #682 (RegExp standalone) ──→ #1105 Tier 2 string methods (match, replace, search)
 #1101 (WeakRef) ──→ #1103 WeakMap/WeakSet (strong-ref fallback available without #1101)
+#1666 (invalid-wasm cluster) ──→ #1664 (residual object/extern leaks), #1665 (native generators)
+#1662 (audit) -- empirical --target wasi host-import map; spawned #1663–#1666
 ```
 
 | #   | Title | Impact | Ready? |
 |-----|-------|--------|--------|
+| 1662 | Audit: standalone (--target wasi) host-import leaks per construct | Standalone gap map | **Done** (audit record) |
+| 1666 | Bug: --target wasi emits invalid wasm (class/closure/number→string/typed-array) | Standalone correctness | **Ready** (H) |
+| 1663 | Pure-Wasm parseInt / parseFloat / Number(string) | Standalone numerics | **Ready** (M, #1471 closed without it) |
+| 1664 | Residual __extern_/__register_/__iterator/__array_ leaks after #1472 | Standalone objects/iterators | **Ready** (H, after #1666) |
+| 1665 | Wasm-native generators (retire __gen_/__create_generator) | Standalone generators | **Ready** (H, after #1666) |
 | 1099 | Standalone execution demo — FizzBuzz on Wasmtime, zero JS | Production credibility | **Ready** (H, depends on #1094) |
 | 1103 | Wasm-native Map, Set, WeakMap, WeakSet | Standalone collections | **Ready** (H) |
 | 1105 | Wasm-native String methods on i16 arrays | Standalone string ops | **Ready** (H) |


### PR DESCRIPTION
## Summary

Empirical per-construct audit (#1662) of which language/library constructs still emit `env.*` JS-host imports when compiled with `--target wasi` (standalone). Turns "eliminate host deps — on the roadmap" into a concrete, scoped gap map. **Plan/issue files only — no compiler source changes.**

Method: 36 minimal probes compiled `--target wasi`, import sections parsed (tolerant raw parser so leaks show even for modules that fail full WASM validation), cross-checked against `--target standalone` and `src/codegen/host-import-allowlist.ts`.

### Clean today (zero non-wasi imports)
number arithmetic, string literals/concat, runtime string ops (`.length/.slice/.indexOf/.toUpperCase/.split`), `String.fromCharCode`, `Float64Array`/`Int32Array`, `ArrayBuffer`+`DataView`, array `.push`/for-of, object literals + get/set + spread, `Math.*`, try/catch + Error, async/Promise, `Date`, `BigInt`, `Symbol`.

### Genuine remaining leaks → owners
| Bucket | Leak | Owner |
|---|---|---|
| Map/Set | `Map_*`,`Set_*` | #1103 (exists) |
| Number→string | `number_toString*`,`number_toFixed` | #1335 (exists) |
| RegExp | `RegExp_*`,`string_replace` | #682 / #1474 |
| Closures/callbacks | `__make_*`,`__call_*` | #1470 |
| JSON (gated CE) | `eval`/`global_JSON` | #1599 Phase 2 |
| parseInt/parseFloat/Number(str) | `parseInt`,`parseFloat` | **#1663 new** (#1471 closed without it) |
| Object/extern/iterator residual | `__extern_*`,`__register_*`,`__iterator*`,`__array_*` | **#1664 new** (after #1472 partial) |
| Native generators | `__gen_*`,`__create_generator*` | **#1665 new** (only owned by #1376 telemetry gate) |
| **Invalid-wasm bug** | module fails validation | **#1666 new** |

### Key finding beyond leaks
Several constructs that should lower to pure WasmGC (class/super, closures, callback array methods, number→string, `String()`, template literals, regex, generators, typed-array `.set`/`.subarray`) emit **invalid, non-instantiable Wasm** under `--target wasi` — native-string helper (`__str_flatten`/`__str_to_extern`) type mismatch + unbound late global (`0xffffffff`). More severe than a leak. Filed as **#1666** (high), to fix first as it masks #1664.

Expected/wont-fix (not filed): eval, Proxy, with, dynamic import, full Intl collation.

## Files
- New: `plan/issues/1662–1666-*.md`
- Updated: `plan/log/dependency-graph.md`, `plan/issues/backlog/backlog.md`

## Test plan
- [ ] Plan-only PR; no source changed. CI `quality` + gate should pass on docs.