### PR TITLE
fix(#1666): --target wasi emits valid wasm (or clean CE) for classes/closures/array-methods/number→string/typed-arrays

### DIFF
--- a/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
+++ b/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
@@ -1,8 +1,9 @@
 ---
 id: 1666
 title: "bug: --target wasi emits INVALID wasm for class/closure/callback/number→string/regex/generator/typed-array (native helper type mismatch + unbound late global)"
-status: ready
+status: done
 created: 2026-05-25
+completed: 2026-05-25
 priority: high
 feasibility: hard
 task_type: bugfix
@@ -107,3 +108,109 @@ because the modules fail full validation.
 This bug likely **masks** part of the residual-leak analysis in #1664 — fix
 this first; some leaks may resolve once the native lowering path is
 exercised correctly.
+
+## Resolution (2026-05-25)
+
+Both signatures were distinct **index-shift** bugs, plus one knock-on
+**string-materialization** bug. Root-caused and fixed:
+
+### Root cause A — func-index drift in already-emitted helper bodies
+
+`finalizeUnifiedCollector` (declarations.ts) emits the native-string helpers
+(`__str_copy_tree`, `__str_flatten`, …) into `ctx.mod.functions`, then later in
+the *same* pass adds late func imports (`__make_callback`, `number_toString*`,
+`__call_*`, …) via `addImport`. `addImport` bumped `ctx.numImportFuncs` and the
+`funcMap`, but — unlike `addStringConstantGlobal`, which has called
+`fixupModuleGlobalIndices` for *globals* since #1174 — it never patched the
+`call` indices already baked into the emitted helper bodies. So `__str_flatten`'s
+`call $__str_copy_tree` (originally `call 0`) kept pointing at index 0, which the
+later import insertion had reassigned to `__make_callback`. wasmtime/V8 then
+rejected the module with `call[k] expected type <T>, found <U>` *inside the
+helper*, not at the user call site.
+
+**Fix**: an eager func-index fixup in `addImport` (`registry/imports.ts`,
+`fixupModuleFuncIndices`) — symmetric with the global fixup. It shifts every
+`call`/`return_call`/`ref.func` ≥ threshold across all live bodies
+(mod.functions, currentFunc, funcStack, parentBodiesStack, liveBodies,
+pendingInitBody, global inits), plus `funcMap`, exports, table elements,
+declaredFuncRefs, and `startFuncIdx`. The four self-shifting batch adders
+(`addUnionImports`, `addStringImports` in index.ts) bump a re-entrancy guard
+(`ctx.suppressFuncIndexFixup`) so they keep doing their single batched shift
+without double-shifting; `addArrayIteratorImports` / `addGeneratorImports`
+previously did **no** shift at all (a latent sibling of this bug) and are now
+fixed for free by the eager path.
+
+### Root cause B — unbound late global (`global.get -1`)
+
+Under nativeStrings (auto-on for wasi/standalone) a string constant carries the
+`-1` sentinel in `stringGlobalMap` (no `string_constants` global exists). Many
+dynamic-dispatch sites used the shape
+`addStringConstantGlobal(v); const i = stringGlobalMap.get(v); if (i !==
+undefined) global.get i`. Because `-1 !== undefined`, the guard emitted
+`global.get -1` → `Invalid global index: 4294967295`. Sites: the `toString`/
+`toFixed`/`toPrecision`/`toExponential` RangeError throw payloads
+(`expressions/calls.ts`), the extern method-name / builtin-name / `__extern_get`
+property-key pushes (`calls.ts` + `property-access.ts`).
+
+**Fix**: materialize the constant inline via `stringConstantExternrefInstrs`
+(which already handles both string backends) at every such site; added a local
+`pushStringConstantExternref` helper in calls.ts.
+
+### Knock-on — template literal number substitution
+
+`compileNativeTemplateExpression` round-tripped a non-string span through the
+JS-host extern bridge (`__str_to_extern`/`__str_from_extern`, backed by
+`__str_to_mem`/`__str_from_mem` host imports the strict wasi gate drops). Under
+nativeStrings, `number_toString` already returns a boxed NativeString-as-
+externref, so the span is now brought back to a string ref with a pure
+`any.convert_extern` + guarded `ref.cast` (the same pattern `String(n)` uses) —
+no host bridge.
+
+### Outcome (which became valid vs which refuse vs which still leak)
+
+| Construct | Before | After |
+|---|---|---|
+| closure (captured local) | INVALID | **valid + fully standalone** (0 env imports, runs under wasmtime → 10) |
+| class extends/super | INVALID | **valid + fully standalone** (0 env imports, → 5) |
+| array .map/.filter/.reduce | INVALID | **valid + fully standalone** (0 env imports, → 12) |
+| template `` `val=${x}` `` | INVALID | **valid** (leaks `number_toString` — #1335) |
+| `(255).toString(16)` / `.toFixed` | INVALID | **valid** (leaks `number_toString*` — #1335) |
+| `String(42)` | (already valid) | valid (leaks `number_toString` — #1335) |
+| `Uint8Array.set` | INVALID | **valid** (leaks `__extern_get` — #1664) |
+
+The audit's "INVALID WASM + leaks" entries were misleading: the leak counts came
+from a *tolerant* import-section parser reading a malformed module. Once valid,
+classes/closures/array-methods carry **zero** env imports. The remaining leaks
+(`number_toString*`, `__extern_get`) are genuine feature gaps owned by #1335 /
+#1664; this issue delivers **validity**, which is independent of
+leak-elimination per the original acceptance note.
+
+### Verification
+
+- New regression suite `tests/issue-1666-standalone-valid-wasm.test.ts`:
+  asserts `WebAssembly.compile` validity for every construct under both
+  `--target wasi` and `--target standalone`; instantiates the three
+  zero-host-import constructs with an empty import object and checks return
+  values (10 / 5 / 12); plus a gc-mode regression guard.
+- Confirmed end-to-end under real `wasmtime -W gc=y,function-references=y,
+  tail-call=y,exceptions=y --invoke test`: closure→10, arrmap→12, cls→5.
+- Targeted equivalence sweep (~250 tests across strings/classes/closures/
+  arrays/templates/typed-arrays/map-set/standalone/wasi-stdout): no new
+  failures; the handful of red tests (json-stringify boolean-coercion quirk,
+  iife-tagged-templates, optional-direct-closure-call, object-literal
+  getters/setters) fail identically on `origin/main` — pre-existing, unrelated.
+- `tsc --noEmit` clean; biome lint introduces no new diagnostics.
+
+### Files
+
+- `src/codegen/registry/imports.ts` — eager func-index fixup in `addImport` +
+  `fixupModuleFuncIndices`.
+- `src/codegen/context/types.ts` — `suppressFuncIndexFixup` re-entrancy guard.
+- `src/codegen/index.ts` — guard the two self-shifting batch import adders.
+- `src/codegen/expressions/calls.ts` — RangeError throw payloads +
+  dynamic-name pushes via `stringConstantExternrefInstrs` /
+  `pushStringConstantExternref`.
+- `src/codegen/property-access.ts` — `__extern_get` property-key pushes via
+  `stringConstantExternrefInstrs`.
+- `src/codegen/string-ops.ts` — template number substitution avoids the host
+  extern bridge under nativeStrings.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -633,6 +633,15 @@ export interface CodegenContext {
   anonStructHash: Map<string, string>;
   /** Pending late import shift state */
   pendingLateImportShift: { importsBefore: number } | null;
+  /**
+   * #1666: re-entrancy guard for the eager func-index fixup in `addImport`.
+   * Batch import adders (`addUnionImports`, `addStringImports`,
+   * `addArrayIteratorImports`, `addUnionImportsAsNativeFuncs`) capture
+   * `importsBefore`, add several imports, then shift function indices ONCE
+   * themselves. While such a batch is active they bump this counter so the
+   * per-`addImport` eager fixup does not double-shift. `undefined`/`0` means
+   * "no batch active — eager fixup is allowed". */
+  suppressFuncIndexFixup?: number;
   /** Map from class name → global index of the prototype externref singleton */
   protoGlobals: Map<string, number>;
   /** Map from class name → own method names (instance methods, for prototype allowlist; see #1047) */

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -103,7 +103,7 @@ import { analyzeTdzAccessByPos, emitLocalTdzCheck, emitStaticTdzThrow } from "./
 import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
-import { ensureNativeStringExternBridge } from "../native-strings.js";
+import { ensureNativeStringExternBridge, stringConstantExternrefInstrs } from "../native-strings.js";
 import { emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
 
 /**
@@ -178,6 +178,26 @@ function resolveClosureInfoFromLocal(
     return ctx.closureInfoByTypeIdx.get(localType.typeIdx);
   }
   return undefined;
+}
+
+/**
+ * #1666: push a string constant onto the stack as an externref, correct in
+ * BOTH string backends. Many dynamic-dispatch sites (extern method name,
+ * builtin name, property key for `__extern_get`) used to do
+ * `addStringConstantGlobal(v); const idx = stringGlobalMap.get(v); if (idx !==
+ * undefined) global.get idx`. Under nativeStrings (auto-on for --target wasi/
+ * standalone) `addStringConstantGlobal` records the `-1` sentinel — which is
+ * `!== undefined`, so the old guard emitted `global.get -1`, an unbound global
+ * index that fails validation (`Invalid global index: 4294967295`). This helper
+ * materializes the constant inline as a NativeString → externref in
+ * nativeStrings mode and falls back to `global.get` of the string_constants
+ * import in legacy mode.
+ */
+function pushStringConstantExternref(ctx: CodegenContext, fctx: FunctionContext, value: string): void {
+  addStringConstantGlobal(ctx, value);
+  for (const instr of stringConstantExternrefInstrs(ctx, value)) {
+    fctx.body.push(instr);
+  }
 }
 
 /**
@@ -422,13 +442,7 @@ function resolvePromiseSubclassThisArg(ctx: CodegenContext, fctx: FunctionContex
   // Push the class name (the synthesized subclass is cached per name). Use the
   // same host-string mechanism as extern method dispatch so it works in both
   // string backends.
-  addStringConstantGlobal(ctx, resolved);
-  const nameIdx = ctx.stringGlobalMap.get(resolved);
-  if (nameIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: nameIdx } as Instr);
-  } else {
-    compileStringLiteral(ctx, fctx, resolved);
-  }
+  pushStringConstantExternref(ctx, fctx, resolved);
   fctx.body.push({ op: "call", funcIdx });
   return true;
 }
@@ -535,13 +549,7 @@ function emitWrapperDynamicMethodCall(
   }
 
   // Push method name as a string constant.
-  addStringConstantGlobal(ctx, methodName);
-  const methodNameIdx = ctx.stringGlobalMap.get(methodName);
-  if (methodNameIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: methodNameIdx } as Instr);
-  } else {
-    compileStringLiteral(ctx, fctx, methodName);
-  }
+  pushStringConstantExternref(ctx, fctx, methodName);
 
   // Empty args array: __js_array_new() → externref.
   fctx.body.push({ op: "call", funcIdx: arrNewIdx });
@@ -2261,22 +2269,10 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
             if (protoCallIdx !== undefined && arrNewIdx !== undefined && arrPushIdx !== undefined) {
               // Push typeName string
-              addStringConstantGlobal(ctx, typeName);
-              const typeNameIdx = ctx.stringGlobalMap.get(typeName);
-              if (typeNameIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: typeNameIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, typeName);
-              }
+              pushStringConstantExternref(ctx, fctx, typeName);
 
               // Push methodName string
-              addStringConstantGlobal(ctx, methodName);
-              const methodNameIdx = ctx.stringGlobalMap.get(methodName);
-              if (methodNameIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: methodNameIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, methodName);
-              }
+              pushStringConstantExternref(ctx, fctx, methodName);
 
               // Compile receiver (first argument to .call).
               // (#1442) When the receiver's static TS type is `boolean`, the
@@ -3392,13 +3388,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
               // obj
               fctx.body.push({ op: "local.get", index: objLocal });
               // prop name as string constant
-              addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              pushStringConstantExternref(ctx, fctx, propName);
               // value (or null for accessor descriptors)
               if (valueExpr) {
                 const vt = compileExpression(ctx, fctx, valueExpr);
@@ -3458,13 +3448,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
             if (dpDescIdx !== undefined) {
               fctx.body.push({ op: "local.get", index: objLocal });
-              addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              pushStringConstantExternref(ctx, fctx, propName);
               const descValType = compileExpression(ctx, fctx, prop.initializer);
               if (!descValType) {
                 fctx.body.push({ op: "ref.null.extern" });
@@ -3745,13 +3729,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       let objType: ReturnType<typeof compileExpression>;
       if (arg0IsBuiltin && getBuiltinFuncIdx !== undefined) {
         const builtinName = (arg0 as ts.Identifier).text;
-        addStringConstantGlobal(ctx, builtinName);
-        const strIdx = ctx.stringGlobalMap.get(builtinName);
-        if (strIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-        } else {
-          compileStringLiteral(ctx, fctx, builtinName);
-        }
+        pushStringConstantExternref(ctx, fctx, builtinName);
         fctx.body.push({ op: "call", funcIdx: getBuiltinFuncIdx });
         objType = { kind: "externref" };
       } else {
@@ -5619,12 +5597,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         {
           const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -5675,12 +5652,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         {
           const rangeErrMsg = "RangeError: toFixed() digits argument must be between 0 and 100";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -5737,7 +5713,6 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         fctx.body.push({ op: "local.get", index: isFiniteLocal });
         const rangeErrMsg = "RangeError: toPrecision() argument must be between 1 and 100";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         const rangeCheckBody: Instr[] = [];
         // Build: if (p < 1 || p > 100 || p != p) throw RangeError
@@ -5755,7 +5730,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         rangeCheckBody.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
         fctx.body.push({
@@ -5811,7 +5786,6 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         // Range check gate: only when v is finite.
         const rangeErrMsg = "RangeError: toExponential() argument must be between 0 and 100";
         addStringConstantGlobal(ctx, rangeErrMsg);
-        const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
         const tagIdx = ensureExnTag(ctx);
         const rangeCheckBody: Instr[] = [];
         rangeCheckBody.push({ op: "local.get", index: digitsLocal });
@@ -5824,7 +5798,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         rangeCheckBody.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
           else: [],
         });
         fctx.body.push({ op: "local.get", index: isFiniteLocal });
@@ -6317,13 +6291,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             let recvType: ValType | null;
             if (receiverIsBuiltin && getBuiltinIdx !== undefined) {
               const builtinName = (propAccess.expression as ts.Identifier).text;
-              addStringConstantGlobal(ctx, builtinName);
-              const strIdx = ctx.stringGlobalMap.get(builtinName);
-              if (strIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, builtinName);
-              }
+              pushStringConstantExternref(ctx, fctx, builtinName);
               fctx.body.push({ op: "call", funcIdx: getBuiltinIdx });
               recvType = { kind: "externref" };
             } else {
@@ -6354,13 +6322,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
             // Push receiver, method name, args array → call __extern_method_call
             fctx.body.push({ op: "local.get", index: recvLocal });
-            addStringConstantGlobal(ctx, methodName);
-            const strIdx = ctx.stringGlobalMap.get(methodName);
-            if (strIdx !== undefined) {
-              fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-            } else {
-              compileStringLiteral(ctx, fctx, methodName);
-            }
+            pushStringConstantExternref(ctx, fctx, methodName);
             fctx.body.push({ op: "local.get", index: argsLocal });
             fctx.body.push({ op: "call", funcIdx: methodCallIdx });
             return { kind: "externref" };
@@ -8442,12 +8404,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           {
             const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
             addStringConstantGlobal(ctx, rangeErrMsg);
-            const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
             const tagIdx = ensureExnTag(ctx);
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
               else: [],
             });
           }
@@ -8472,12 +8433,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           {
             const rangeErrMsg = "RangeError: toFixed() digits argument must be between 0 and 100";
             addStringConstantGlobal(ctx, rangeErrMsg);
-            const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
             const tagIdx = ensureExnTag(ctx);
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
               else: [],
             });
           }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4865,6 +4865,9 @@ export function addStringImports(ctx: CodegenContext): void {
   // Record import count before adding so we can shift function indices
   // if this is called after collectDeclarations has run.
   const importsBefore = ctx.numImportFuncs;
+  // #1666: suppress addImport's per-call eager func-index fixup — this function
+  // adds a batch of imports and does its own single shift below.
+  ctx.suppressFuncIndexFixup = (ctx.suppressFuncIndexFixup ?? 0) + 1;
 
   // concat: (externref, externref) -> (ref extern)
   const concatType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "ref_extern" }]);
@@ -4911,6 +4914,9 @@ export function addStringImports(ctx: CodegenContext): void {
     const idx = ctx.funcMap.get(name);
     if (idx !== undefined) ctx.jsStringImports.set(name, idx);
   }
+
+  // #1666: end of import batch — re-enable addImport's eager fixup.
+  ctx.suppressFuncIndexFixup = (ctx.suppressFuncIndexFixup ?? 1) - 1;
 
   // If imports were added after defined functions were registered (late addition),
   // shift all defined-function indices.
@@ -6174,6 +6180,9 @@ export function addUnionImports(ctx: CodegenContext): void {
   // Record the import count before adding, so we can adjust defined-function
   // indices if imports are added after collectDeclarations has run.
   const importsBefore = ctx.numImportFuncs;
+  // #1666: suppress addImport's per-call eager func-index fixup — this function
+  // adds a batch of imports and does its own single shift below.
+  ctx.suppressFuncIndexFixup = (ctx.suppressFuncIndexFixup ?? 0) + 1;
 
   // __typeof_number: (externref) → i32
   const typeofType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
@@ -6235,6 +6244,9 @@ export function addUnionImports(ctx: CodegenContext): void {
     kind: "func",
     typeIdx: typeofStrType,
   });
+
+  // #1666: end of import batch — re-enable addImport's eager fixup.
+  ctx.suppressFuncIndexFixup = (ctx.suppressFuncIndexFixup ?? 1) - 1;
 
   // If imports were added after defined functions were registered (late addition),
   // shift all defined-function indices and fix exports/funcMap/call instructions.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -636,14 +636,10 @@ export function emitExternrefToStructGet(
       // Convert anyref back to externref for __extern_get
       externGetFallback.push({ op: "local.get", index: tmpAny } as Instr);
       externGetFallback.push({ op: "extern.convert_any" } as Instr);
-      // Push property name string
+      // Push property name string (#1666: native-string-safe — handles the
+      // nativeStrings -1 sentinel by materializing the constant inline).
       addStringConstantGlobal(ctx, propName);
-      const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-      if (strGlobalIdx !== undefined) {
-        externGetFallback.push({ op: "global.get", index: strGlobalIdx } as Instr);
-      } else {
-        externGetFallback.push({ op: "ref.null.extern" } as Instr);
-      }
+      externGetFallback.push(...stringConstantExternrefInstrs(ctx, propName));
       externGetFallback.push({ op: "call", funcIdx: getIdx } as Instr);
       // Coerce externref result to the expected result type
       if (resultType.kind === "f64") {
@@ -1127,12 +1123,7 @@ export function compilePropertyAccess(
     // Emit: __extern_get(__get_globalThis(), key) -> externref
     fctx.body.push({ op: "call", funcIdx: gtFuncIdx });
     addStringConstantGlobal(ctx, propName);
-    const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-    if (strGlobalIdx !== undefined) {
-      fctx.body.push({ op: "global.get", index: strGlobalIdx });
-    } else {
-      fctx.body.push({ op: "ref.null.extern" });
-    }
+    for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
     if (getIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: getIdx });
     }
@@ -1253,21 +1244,11 @@ export function compilePropertyAccess(
       if (getBuiltinIdx !== undefined && getIdx !== undefined) {
         // Push builtin name string, call __get_builtin to get the real JS object
         addStringConstantGlobal(ctx, builtinName);
-        const builtinStrIdx = ctx.stringGlobalMap.get(builtinName);
-        if (builtinStrIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: builtinStrIdx });
-        } else {
-          compileStringLiteral(ctx, fctx, builtinName);
-        }
+        for (const instr of stringConstantExternrefInstrs(ctx, builtinName)) fctx.body.push(instr);
         fctx.body.push({ op: "call", funcIdx: getBuiltinIdx });
         // Push property name string, call __extern_get to read the property
         addStringConstantGlobal(ctx, propName);
-        const propStrIdx = ctx.stringGlobalMap.get(propName);
-        if (propStrIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: propStrIdx });
-        } else {
-          compileStringLiteral(ctx, fctx, propName);
-        }
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
         fctx.body.push({ op: "call", funcIdx: getIdx });
         return { kind: "externref" };
       }
@@ -2315,7 +2296,7 @@ export function compilePropertyAccess(
 
           // If proto is non-null, call __extern_get(proto, propName)
           addStringConstantGlobal(ctx, propName);
-          const strGlobalIdx = ctx.stringGlobalMap.get(propName);
+          const propKeyInstrs = stringConstantExternrefInstrs(ctx, propName);
 
           fctx.body.push({ op: "local.get", index: protoLocal });
           fctx.body.push({ op: "ref.is_null" });
@@ -2326,9 +2307,7 @@ export function compilePropertyAccess(
             then: protoDefaultInstrs,
             else: [
               { op: "local.get", index: protoLocal } as Instr,
-              ...(strGlobalIdx !== undefined
-                ? [{ op: "global.get", index: strGlobalIdx } as Instr]
-                : [{ op: "ref.null.extern" } as Instr]),
+              ...propKeyInstrs,
               { op: "call", funcIdx: getIdx } as Instr,
               ...(effectiveResult.kind === "f64" && unboxIdx !== undefined
                 ? [{ op: "call", funcIdx: unboxIdx } as Instr]
@@ -2358,12 +2337,7 @@ export function compilePropertyAccess(
           // Coerce struct ref to externref
           fctx.body.push({ op: "extern.convert_any" } as Instr);
           addStringConstantGlobal(ctx, propName);
-          const strIdx = ctx.stringGlobalMap.get(propName);
-          if (strIdx !== undefined) {
-            fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-          } else {
-            fctx.body.push({ op: "ref.null.extern" });
-          }
+          for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
           fctx.body.push({ op: "call", funcIdx: getIdx });
 
           // Unbox if the expected type is numeric
@@ -2571,12 +2545,7 @@ export function compilePropertyAccess(
           // Build the __extern_get fallback instructions
           const externGetFallback: Instr[] = [{ op: "local.get", index: objTmp } as Instr];
           addStringConstantGlobal(ctx, propName);
-          const strGlobalIdxExt = ctx.stringGlobalMap.get(propName);
-          if (strGlobalIdxExt !== undefined) {
-            externGetFallback.push({ op: "global.get", index: strGlobalIdxExt } as Instr);
-          } else {
-            externGetFallback.push({ op: "ref.null.extern" } as Instr);
-          }
+          externGetFallback.push(...stringConstantExternrefInstrs(ctx, propName));
           externGetFallback.push({ op: "call", funcIdx: getIdx } as Instr);
           if (resultWasm.kind === "f64" && unboxIdx !== undefined) {
             externGetFallback.push({ op: "call", funcIdx: unboxIdx } as Instr);
@@ -2680,12 +2649,7 @@ export function compilePropertyAccess(
           fctx.body.push({ op: "extern.convert_any" });
         }
         addStringConstantGlobal(ctx, propName);
-        const strGIdx856 = ctx.stringGlobalMap.get(propName);
-        if (strGIdx856 !== undefined) {
-          fctx.body.push({ op: "global.get", index: strGIdx856 });
-        } else {
-          fctx.body.push({ op: "ref.null.extern" });
-        }
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
         fctx.body.push({ op: "call", funcIdx: getIdx856 });
         if (accessWasm.kind === "f64") {
           if (unboxIdx856 !== undefined) fctx.body.push({ op: "call", funcIdx: unboxIdx856 });

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -46,11 +46,130 @@ export function addImport(ctx: CodegenContext, module: string, name: string, des
   }
   ctx.mod.imports.push({ module, name, desc });
   if (desc.kind === "func") {
+    // #1666: Adding a func import shifts the function index space — every
+    // already-emitted `call`/`return_call`/`ref.func` that targets a *module*
+    // function (index >= numImportFuncs at the time it was emitted) is now off
+    // by one. `addStringConstantGlobal` has done this fixup for *globals* since
+    // #1174; func imports added after module functions already exist (e.g.
+    // `finalizeUnifiedCollector` emits the native-string helpers, then adds
+    // `__make_callback` / `number_toString*` / `__call_*`) left helper bodies
+    // pointing at the wrong callee, producing modules that fail validation
+    // ("call[k] expected type <T>, found <U>" inside `__str_flatten`/
+    // `__str_to_extern`).
+    //
+    // Only fix up here when NOT inside a deferred late-import batch: the
+    // `ensureLateImport`/`flushLateImportShifts` path (body compilation) sets
+    // `ctx.pendingLateImportShift` BEFORE calling addImport and does its own
+    // single batched shift, so an eager shift here would double-shift.
+    const threshold = ctx.numImportFuncs;
     ctx.funcMap.set(name, ctx.numImportFuncs);
     ctx.numImportFuncs++;
+    if (ctx.pendingLateImportShift === null && !ctx.suppressFuncIndexFixup && ctx.mod.functions.length > 0) {
+      fixupModuleFuncIndices(ctx, threshold, 1);
+    }
   }
   if (desc.kind === "global") {
     ctx.numImportGlobals++;
+  }
+}
+
+/**
+ * #1666: Shift every `call`/`return_call`/`ref.func` index that targets a
+ * module function (index >= `threshold`) up by `delta`, after a func import is
+ * inserted at `threshold`. Mirrors `fixupModuleGlobalIndices` but for the
+ * function index space. Also shifts `funcMap` (skipping import names), export
+ * descriptors, table element segments, and declared func refs.
+ *
+ * The import that was just registered has its funcMap entry at `threshold`;
+ * it is an import name, so the import-name filter below skips it (it must not
+ * be re-shifted).
+ */
+function fixupModuleFuncIndices(ctx: CodegenContext, threshold: number, delta: number): void {
+  const visitedArrays = new WeakSet<Instr[]>();
+  function shiftFuncIndices(instrs: Instr[]): void {
+    if (visitedArrays.has(instrs)) return;
+    visitedArrays.add(instrs);
+    for (const instr of instrs) {
+      if ("funcIdx" in instr && typeof (instr as any).funcIdx === "number") {
+        if ((instr as any).funcIdx >= threshold) {
+          (instr as any).funcIdx += delta;
+        }
+      }
+      const a = instr as any;
+      if (a.body && Array.isArray(a.body)) shiftFuncIndices(a.body);
+      if (a.then && Array.isArray(a.then)) shiftFuncIndices(a.then);
+      if (a.else && Array.isArray(a.else)) shiftFuncIndices(a.else);
+      if (a.catches && Array.isArray(a.catches)) {
+        for (const c of a.catches) {
+          if (Array.isArray(c.body)) shiftFuncIndices(c.body);
+        }
+      }
+      if (a.catchAll && Array.isArray(a.catchAll)) shiftFuncIndices(a.catchAll);
+    }
+  }
+
+  for (const func of ctx.mod.functions) {
+    shiftFuncIndices(func.body);
+  }
+  if (ctx.currentFunc) {
+    shiftFuncIndices(ctx.currentFunc.body);
+    for (const sb of ctx.currentFunc.savedBodies) shiftFuncIndices(sb);
+  }
+  for (const parentFctx of ctx.funcStack) {
+    shiftFuncIndices(parentFctx.body);
+    for (const sb of parentFctx.savedBodies) shiftFuncIndices(sb);
+  }
+  for (const pb of ctx.parentBodiesStack) {
+    shiftFuncIndices(pb);
+  }
+  for (const lb of ctx.liveBodies) {
+    shiftFuncIndices(lb);
+  }
+  if (ctx.pendingInitBody) {
+    shiftFuncIndices(ctx.pendingInitBody);
+  }
+  // Global initializer expressions can carry ref.func (e.g. method-closure
+  // globals); shift those too.
+  for (const g of ctx.mod.globals) {
+    if (g.init) shiftFuncIndices(g.init);
+  }
+
+  // Shift funcMap entries for defined functions. Import entries keep their
+  // (already-correct) indices. The just-added import name is an import entry
+  // and is skipped by the import-name filter.
+  const importNames = new Set<string>();
+  for (const imp of ctx.mod.imports) {
+    if (imp.desc.kind === "func") importNames.add(imp.name);
+  }
+  for (const [n, idx] of ctx.funcMap) {
+    if (importNames.has(n)) continue;
+    if (idx >= threshold) ctx.funcMap.set(n, idx + delta);
+  }
+
+  // Shift export descriptors.
+  for (const exp of ctx.mod.exports) {
+    if (exp.desc.kind === "func" && exp.desc.index >= threshold) {
+      exp.desc.index += delta;
+    }
+  }
+  // Shift table element segments.
+  for (const elem of ctx.mod.elements) {
+    if (elem.funcIndices) {
+      for (let i = 0; i < elem.funcIndices.length; i++) {
+        if (elem.funcIndices[i]! >= threshold) {
+          elem.funcIndices[i]! += delta;
+        }
+      }
+    }
+  }
+  // Shift declared func refs.
+  if (ctx.mod.declaredFuncRefs.length > 0) {
+    ctx.mod.declaredFuncRefs = ctx.mod.declaredFuncRefs.map((idx) => (idx >= threshold ? idx + delta : idx));
+  }
+  // Shift the Wasm start function index (#907) if the defined function it
+  // points at moved.
+  if (ctx.mod.startFuncIdx !== undefined && ctx.mod.startFuncIdx >= threshold) {
+    ctx.mod.startFuncIdx += delta;
   }
 }
 

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -176,13 +176,31 @@ export function compileNativeTemplateExpression(
   // externref marshaling, i.e. it has a NON-string substitution (number/bigint/
   // object → number_toString returns externref → __str_from_extern). A template
   // whose spans are all strings concatenates natively with zero host calls.
+  //
+  // #1666: under nativeStrings (auto-on for --target wasi/standalone) the host
+  // bridge is unavailable. `number_toString` already returns a boxed
+  // NativeString-as-externref there, so a non-string span is brought back to a
+  // string ref with a pure `any.convert_extern` + guarded ref.cast (the same
+  // pattern `String(n)` uses) instead of the `__str_from_extern` host bridge.
   const hasNonStringSpan = expr.templateSpans.some((s) => !isStringType(ctx.checker.getTypeAtLocation(s.expression)));
-  if (hasNonStringSpan) {
+  const useNativeExternToStr = noJsHost(ctx) || ctx.nativeStrings;
+  if (hasNonStringSpan && !useNativeExternToStr) {
     ensureNativeStringExternBridge(ctx);
     flushLateImportShifts(ctx, fctx);
   }
   const fromExternIdx = ctx.nativeStrHelpers.get("__str_from_extern");
   if (concatIdx === undefined) return null;
+  // Marshal the externref result of `number_toString` (etc.) back to a native
+  // string ref. Prefers the host bridge when present (JS-host mode); otherwise
+  // converts the externref directly via the WasmGC anyref cast.
+  const marshalExternToNativeStr = (): void => {
+    if (fromExternIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: fromExternIdx });
+    } else {
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      emitGuardedRefCast(fctx, ctx.anyStrTypeIdx);
+    }
+  };
 
   if (expr.head.text) {
     compileStringLiteral(ctx, fctx, expr.head.text, expr.head);
@@ -208,27 +226,19 @@ export function compileNativeTemplateExpression(
     } else if (spanType && spanType.kind === "f64" && toStrIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: toStrIdx });
       // number_toString returns externref, marshal to native string
-      if (fromExternIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: fromExternIdx });
-      }
+      marshalExternToNativeStr();
     } else if (spanType && spanType.kind === "i32" && toStrIdx !== undefined) {
       fctx.body.push({ op: "f64.convert_i32_s" });
       fctx.body.push({ op: "call", funcIdx: toStrIdx });
-      if (fromExternIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: fromExternIdx });
-      }
+      marshalExternToNativeStr();
     } else if (spanType && spanType.kind === "i64" && toStrIdx !== undefined) {
       fctx.body.push({ op: "f64.convert_i64_s" });
       fctx.body.push({ op: "call", funcIdx: toStrIdx });
-      if (fromExternIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: fromExternIdx });
-      }
+      marshalExternToNativeStr();
     } else if (spanType && (spanType.kind === "ref" || spanType.kind === "ref_null") && toStrIdx !== undefined) {
       // Struct ref → externref: use coerceType which checks @@toPrimitive("string") first
       coerceType(ctx, fctx, spanType, { kind: "externref" }, "string");
-      if (fromExternIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: fromExternIdx });
-      }
+      marshalExternToNativeStr();
     }
     // ref $NativeString is already the right type
 

--- a/tests/issue-1666-standalone-valid-wasm.test.ts
+++ b/tests/issue-1666-standalone-valid-wasm.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1666 — `--target wasi` (and `--target standalone`) must emit a module that
+ * **passes `WebAssembly.compile` validation** for the constructs the audit
+ * (#1662) flagged as "INVALID WASM": classes/super, closures, array
+ * .map/.filter/.reduce, number→string (toString/String()/template), and
+ * typed-array .set.
+ *
+ * Two root causes were fixed:
+ *
+ *  A. **Func-index drift in helper bodies.** `finalizeUnifiedCollector` emits
+ *     the native-string helpers into `ctx.mod.functions`, then adds late func
+ *     imports (`__make_callback`, `number_toString*`, `__call_*`). `addImport`
+ *     bumped the function index space but did NOT patch the already-emitted
+ *     helper bodies' `call` indices, so `__str_flatten` / `__str_to_extern`
+ *     ended up calling the wrong callee ("call[k] expected type <T>, found
+ *     <U>"). Fixed by an eager func-index fixup in `addImport` (mirroring the
+ *     long-standing global-index fixup in `addStringConstantGlobal`).
+ *
+ *  B. **Unbound late global (`global.get -1`).** Under nativeStrings (auto-on
+ *     for wasi/standalone) string constants carry the `-1` sentinel instead of
+ *     a `string_constants` global. Many dynamic-dispatch sites pushed
+ *     `global.get <idx>` directly; with `idx === -1` that is an unbound global
+ *     (`Invalid global index: 4294967295`). Fixed by materializing the constant
+ *     inline (`stringConstantExternrefInstrs`) at every such site.
+ *
+ * Validity is independent of leak-elimination: number→string still legitimately
+ * needs the `number_toString*` host import (#1335) and typed-array `.set` still
+ * needs `__extern_get` (#1664) — those are tracked separately. This test
+ * asserts the modules VALIDATE; the genuinely-standalone constructs (classes /
+ * closures / array methods) additionally instantiate and return correct values
+ * with an EMPTY import object.
+ */
+
+const TARGETS = ["wasi", "standalone"] as const;
+
+async function compileAndValidate(src: string, target: (typeof TARGETS)[number]): Promise<Uint8Array> {
+  const r = compile(src, { target });
+  expect(r.success, `compile failed (${target}):\n${r.errors.map((e) => e.message).join("\n")}`).toBe(true);
+  // The core #1666 assertion: the emitted bytes must pass WASM validation.
+  await expect(
+    WebAssembly.compile(r.binary),
+    `module failed WebAssembly.compile validation under --target ${target}`,
+  ).resolves.toBeInstanceOf(WebAssembly.Module);
+  return r.binary;
+}
+
+/** Names of the `env` (JS-host) imports the module still requires. */
+async function envImports(binary: Uint8Array): Promise<string[]> {
+  const m = await WebAssembly.compile(binary);
+  return WebAssembly.Module.imports(m)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+describe("#1666 --target wasi/standalone emits valid (compilable) Wasm", () => {
+  describe("Signature A — native helper call-index drift", () => {
+    it("closure capturing a local validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(`export function test(): number { let n = 5; const f = () => n * 2; return f(); }`, t);
+      }
+    });
+
+    it("class with extends/super validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(
+          `class A { x: number; constructor(x: number){ this.x = x; } get(){ return this.x; } }
+           class B extends A { constructor(x: number){ super(x); } }
+           export function test(): number { return new B(5).get(); }`,
+          t,
+        );
+      }
+    });
+
+    it("array .map/.filter/.reduce validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(
+          `export function test(): number { return [1,2,3].map(x => x*2).reduce((a,b)=>a+b, 0); }`,
+          t,
+        );
+      }
+    });
+
+    it("template literal with number substitution validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(`export function test(x: number): string { return \`val=\${x}\`; }`, t);
+      }
+    });
+  });
+
+  describe("Signature B — unbound late global (global.get -1)", () => {
+    it("(255).toString(16) validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(`export function test(): string { return (255).toString(16); }`, t);
+      }
+    });
+
+    it("String(42) validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(`export function test(): string { return String(42); }`, t);
+      }
+    });
+
+    it("(3.14159).toFixed(2) validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(`export function test(): string { return (3.14159).toFixed(2); }`, t);
+      }
+    });
+
+    it("Uint8Array .set validates", async () => {
+      for (const t of TARGETS) {
+        await compileAndValidate(
+          `export function test(): number { const a = new Uint8Array(4); a.set([1,2,3]); return a[0]+a[1]+a[2]; }`,
+          t,
+        );
+      }
+    });
+  });
+
+  describe("fully-standalone constructs instantiate with no JS host and run correctly", () => {
+    it("closure: f()=n*2 returns 10 with zero env imports", async () => {
+      const bin = await compileAndValidate(
+        `export function test(): number { let n = 5; const f = () => n * 2; return f(); }`,
+        "wasi",
+      );
+      expect(await envImports(bin)).toEqual([]);
+      const { instance } = await WebAssembly.instantiate(bin, {});
+      expect((instance.exports.test as () => number)()).toBe(10);
+    });
+
+    it("class new B(5).get() returns 5 with zero env imports", async () => {
+      const bin = await compileAndValidate(
+        `class A { x: number; constructor(x: number){ this.x = x; } get(){ return this.x; } }
+         class B extends A { constructor(x: number){ super(x); } }
+         export function test(): number { return new B(5).get(); }`,
+        "wasi",
+      );
+      expect(await envImports(bin)).toEqual([]);
+      const { instance } = await WebAssembly.instantiate(bin, {});
+      expect((instance.exports.test as () => number)()).toBe(5);
+    });
+
+    it("array [1,2,3].map(x=>x*2).reduce(...) returns 12 with zero env imports", async () => {
+      const bin = await compileAndValidate(
+        `export function test(): number { return [1,2,3].map(x => x*2).reduce((a,b)=>a+b, 0); }`,
+        "wasi",
+      );
+      expect(await envImports(bin)).toEqual([]);
+      const { instance } = await WebAssembly.instantiate(bin, {});
+      expect((instance.exports.test as () => number)()).toBe(12);
+    });
+  });
+
+  describe("regression guard: default (gc) mode unchanged", () => {
+    it("the same constructs still validate in gc mode", async () => {
+      const srcs = [
+        `export function test(): number { let n = 5; const f = () => n * 2; return f(); }`,
+        `export function test(): number { return [1,2,3].map(x => x*2).reduce((a,b)=>a+b, 0); }`,
+        `export function test(): string { return (255).toString(16); }`,
+        `export function test(x: number): string { return \`val=\${x}\`; }`,
+      ];
+      for (const src of srcs) {
+        const r = compile(src, {});
+        expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+        await expect(WebAssembly.compile(r.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1666 — `--target wasi`/`--target standalone` emitted **non-instantiable** wasm (failed `WebAssembly.compile`, not just leaked imports) for a whole class of constructs. Two distinct index-shift root causes + one knock-on:

- **A. Func-index drift in helper bodies.** `finalizeUnifiedCollector` emits the native-string helpers into `ctx.mod.functions`, then adds late func imports (`__make_callback`, `number_toString*`, `__call_*`). `addImport` bumped the function index space but never patched the already-emitted helper bodies' `call` indices, so `__str_flatten`/`__str_to_extern` called the wrong callee (`call[k] expected type <T>, found <U>`). Fixed with an eager func-index fixup in `addImport` (`fixupModuleFuncIndices`), symmetric with the long-standing global-index fixup (`addStringConstantGlobal`/#1174). Self-shifting batch adders (`addUnionImports`, `addStringImports`) use a `suppressFuncIndexFixup` re-entrancy guard so they keep doing their single batched shift. (`addArrayIteratorImports`/`addGeneratorImports` did *no* shift before — a latent sibling bug — now fixed for free.)
- **B. Unbound late global (`global.get -1`).** Under nativeStrings, string constants carry the `-1` sentinel; dynamic-dispatch sites pushed `global.get -1` → `Invalid global index: 4294967295`. Fixed by materializing the constant inline (`stringConstantExternrefInstrs`) at the toString/toFixed/toPrecision/toExponential RangeError throws and the extern method-name / `__extern_get` property-key pushes.
- **Knock-on.** Template number substitution no longer round-trips through the JS-host extern bridge under nativeStrings (`number_toString` already returns a boxed NativeString-as-externref → `any.convert_extern` + guarded cast).

### Made VALID + fully standalone (zero env imports, run under real wasmtime)
- classes/`super` → `new B(5).get()` = 5
- closures → `() => n*2` = 10
- array `.map`/`.filter`/`.reduce` → 12

The audit's "leak" counts for these were artifacts of a tolerant parser reading a malformed module; once valid they carry **zero** env imports.

### Made VALID, leak is a separately-tracked feature gap (validity ≠ leak-elimination)
- number→string (`toString(16)`/`String(42)`/`toFixed`/template `${n}`) — still needs `number_toString*` (**#1335**)
- typed-array `.set`/`.subarray` — still needs `__extern_get` (**#1664**)

Nothing newly *refuses*; RegExp/JSON/generators remain out of scope (#682/#1599/#1665) and were already gated.

## Test plan
- [x] New `tests/issue-1666-standalone-valid-wasm.test.ts` — `WebAssembly.compile` validity for every construct under `--target wasi` **and** `--target standalone`; instantiate+run the 3 zero-import constructs with an empty import object (5/10/12); gc-mode regression guard. 12/12 pass.
- [x] Real `wasmtime -W gc=y,function-references=y,tail-call=y,exceptions=y --invoke test`: closure→10, arrmap→12, cls→5.
- [x] Targeted equivalence sweep (~250 tests: strings/classes/closures/arrays/templates/typed-arrays/map-set/standalone/wasi-stdout) — no new failures. The few red tests (json-stringify bool-coercion quirk, iife-tagged-templates, optional-direct-closure-call, object-literal getters/setters) fail identically on `origin/main` (pre-existing, unrelated).
- [x] `tsc --noEmit` clean; biome lint adds no new diagnostics.
- [ ] Full test262 via CI (touches `src/codegen/**` — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)