### PR TITLE
chore: verify cla-check exempts internal authors (throwaway)

### DIFF
--- a/docs/.cla-gate-verify
+++ b/docs/.cla-gate-verify
@@ -1,0 +1,1 @@
+CLA gate verification throwaway file. Safe to delete.


### PR DESCRIPTION
Throwaway PR to verify the cla-check gate exempts internal/maintainer authors before promoting it to a required status check. Will be closed without merging.