### PR TITLE
fix: recover ~245 test262 regression from #1602 (spurious per-literal method fork)

### DIFF
--- a/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
+++ b/plan/issues/1602-call-arg-coercion-externref-invalid-wasm.md
@@ -103,3 +103,33 @@ Three independent codegen bugs all surfaced as the same validator error
 method, leaving a funcref uncoerced at the call. This is a missing
 class-expression static-member-access path in `property-access.ts`, not a
 call-site coercion bug; tracked for a follow-up.
+
+## Follow-up regression (fixed 2026-05-25) — ~245 test262 tests lost
+
+Fix #2 above (the per-literal-funcIdx fork on a same-arity param-*type*
+divergence) over-triggered. The pre-pass in `compileObjectLiteralForStruct`
+builds the method's **self** param as a non-null `ref structTypeIdx`, but the
+actually-compiled method uses `ref null structTypeIdx` for self (and
+`ref null U` for any default-initialised ref param). The strict `valTypesMatch`
+treats `ref T` and `ref null T` as different, so even the **single-literal
+common case** — `{ method([x,y,z] = [1,2,3]) {} }` — was flagged as a
+"mismatch" and forked a fresh per-literal func. That orphaned the original
+shared `funcMap` entry with an **empty body**. The per-literal map only
+redirects the **closure** path (`emitObjectMethodAsClosure`); a **direct**
+member call `obj.method()` dispatches via `funcMap`, so it landed on the empty
+func, which (combined with a `ref.null … ref.as_non_null` on the defaulted
+param) trapped at runtime — `dereferencing a null pointer`.
+
+This regressed **187** `language/expressions/object/dstr/*` + **22**
+`.../method-definition/*` tests (object methods with destructured / default
+params, invoked directly). Peak 29,603 (sha 65844, PR #593) → 29,355 (sha
+9265). Bisected: the probe passes at 65844 and traps at the post-#1602 HEAD.
+
+**Fix:** compare ref/ref_null of the **same struct typeIdx** as equal in the
+fork decision (`refTypesMatch` in `literals.ts`). Nullability of the same
+struct is not a real signature divergence — WasmGC `ref null T` is a supertype
+of `ref T` and the trampoline forwarding is unaffected. Genuine divergence
+(`[f64, externref]` vs `[externref, f64]`) differs in `kind`/`typeIdx` and is
+still detected, so #1602's Bug B sibling-generator case (covered by
+`tests/issue-1602.test.ts`) keeps passing. Regression guard:
+`tests/issue-1602-regress-direct-call.test.ts`.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1120,7 +1120,26 @@ export function compileObjectLiteralForStruct(
     const existingType = ctx.mod.types[existingFunc.typeIdx];
     if (!existingType || existingType.kind !== "func") continue;
     const sameArity = existingType.params.length === newParams.length;
-    const sameParamTypes = sameArity && existingType.params.every((p, i) => valTypesMatch(p, newParams[i]!));
+    // (#1602 regression fix) Compare param types nullability-insensitively for
+    // ref/ref_null of the SAME struct typeIdx. The pre-pass builds the self
+    // param as a non-null `ref structTypeIdx`, but the actual compiled method
+    // uses `ref null structTypeIdx` for self (and `ref null T` for any
+    // default-initialised ref param). A strict `valTypesMatch` flags this as a
+    // mismatch and forks a per-literal funcIdx — but that orphans the original
+    // shared funcMap entry (left with an empty body), so a *direct* call like
+    // `obj.method()` (which dispatches via funcMap, not the per-literal map)
+    // lands on the empty func and traps. Real divergence we still want to
+    // catch (e.g. sibling literals with [f64, externref] vs [externref, f64])
+    // differs in `kind` or `typeIdx`, which `refTypesMatch` still rejects.
+    const refTypesMatch = (p: ValType, q: ValType): boolean => {
+      const pRef = p.kind === "ref" || p.kind === "ref_null";
+      const qRef = q.kind === "ref" || q.kind === "ref_null";
+      if (pRef && qRef) {
+        return (p as { typeIdx: number }).typeIdx === (q as { typeIdx: number }).typeIdx;
+      }
+      return valTypesMatch(p, q);
+    };
+    const sameParamTypes = sameArity && existingType.params.every((p, i) => refTypesMatch(p, newParams[i]!));
     if (sameArity && sameParamTypes) continue;
 
     // Mismatch — allocate a fresh funcIdx for this literal's method without

--- a/tests/issue-1602-regress-direct-call.test.ts
+++ b/tests/issue-1602-regress-direct-call.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+/**
+ * Regression for the ~245-test test262 drop introduced by #1602 (PR #595).
+ *
+ * #1602 tightened the object-literal method dedup in
+ * `compileObjectLiteralForStruct` (literals.ts): in addition to a param-COUNT
+ * mismatch, a per-position param-TYPE mismatch now forks a fresh per-literal
+ * funcIdx. The comparison used the strict `valTypesMatch`, which treats a
+ * non-null `ref T` as different from `ref null T`. The pre-pass builds the
+ * method's self param as a non-null `ref structTypeIdx`, but the actually
+ * compiled method uses `ref null structTypeIdx` (and `ref null U` for any
+ * default-initialised ref param). That spurious nullability "mismatch" forked
+ * a fresh func for the SINGLE-literal common case — orphaning the original
+ * shared funcMap entry with an empty body. A *direct* call like `o.method()`
+ * dispatches via funcMap (not the per-literal map the closure path uses), so
+ * it landed on the empty func and trapped ("dereferencing a null pointer").
+ *
+ * This regressed 187 `language/expressions/object/dstr/*` and 22
+ * `.../method-definition/*` tests (object methods with destructured / default
+ * params, directly invoked). The fix compares ref/ref_null of the same struct
+ * typeIdx as equal, so the spurious fork no longer happens, while genuine
+ * type/order divergence (different `kind`/`typeIdx`, e.g. [f64, externref] vs
+ * [externref, f64]) is still detected (covered by tests/issue-1602.test.ts).
+ */
+describe("#1602 regression — object method default/destructured params, direct call", () => {
+  it("array-destructured default param", async () => {
+    const e = await compileToWasm(`
+      let c = 0;
+      const o = {
+        method([x, y, z] = [1, 2, 3]): void {
+          if (x !== 1 || y !== 2 || z !== 3) throw new Error("bad");
+          c = c + 1;
+        }
+      };
+      export function test(): number { o.method(); return c; }
+    `);
+    expect(e.test()).toBe(1);
+  });
+
+  it("object-destructured default param", async () => {
+    const e = await compileToWasm(`
+      let c = 0;
+      const o = {
+        method({ a, b } = { a: 7, b: 8 }): void {
+          if (a !== 7 || b !== 8) throw new Error("bad");
+          c = c + 1;
+        }
+      };
+      export function test(): number { o.method(); return c; }
+    `);
+    expect(e.test()).toBe(1);
+  });
+
+  it("explicit arg still overrides the default", async () => {
+    const e = await compileToWasm(`
+      let c = 0;
+      const o = { method([x] = [9]): void { c = c + x; } };
+      export function test(): number { o.method([42]); o.method(); return c; }
+    `);
+    expect(e.test()).toBe(51);
+  });
+});


### PR DESCRIPTION
## Summary
- **Culprit:** #1602 (PR #595). Its object-literal method dedup change in `compileObjectLiteralForStruct` (`src/codegen/literals.ts`) tightened the per-literal-funcIdx fork to also trigger on a same-arity param-**type** divergence, using strict `valTypesMatch`.
- **Root cause:** `valTypesMatch` treats non-null `ref T` as different from `ref null T`. The pre-pass builds the method **self** param as non-null `ref structTypeIdx`, but the compiled method uses `ref null structTypeIdx` for self (and `ref null U` for default-initialised ref params). So the **single-literal common case** `{ method([x,y,z] = [1,2,3]) {} }` was wrongly flagged as a mismatch and forked a fresh per-literal func — orphaning the original shared `funcMap` entry with an **empty body**. The per-literal map only redirects the **closure** path; a **direct** member call `obj.method()` dispatches via `funcMap`, so it landed on the empty func and trapped at runtime (`dereferencing a null pointer`).
- **Flipped cluster:** 187 `language/expressions/object/dstr/*` + 22 `.../method-definition/*` (object methods with destructured/default params, invoked directly). Peak **29,603** (sha 65844, PR #593) → **29,355** (sha 9265). Bisected: probe passes at 65844, traps at post-#1602 HEAD.
- **Fix:** compare ref/ref_null of the **same struct typeIdx** as equal in the fork decision (`refTypesMatch` local in `literals.ts`). Nullability of the same struct is not a real signature divergence (WasmGC `ref null T` ⊒ `ref T`; the trampoline forwarding is unaffected). Genuine divergence (`[f64, externref]` vs `[externref, f64]`, differing in `kind`/`typeIdx`) is still detected — #1602's Bug B sibling-generator case (`tests/issue-1602.test.ts`) stays green.

## Test plan
- [x] `tests/issue-1602-regress-direct-call.test.ts` — new regression guard (array/object-destructured default param + explicit-arg override, direct call). Fails on pre-fix HEAD ("dereferencing a null pointer"), passes with fix.
- [x] `tests/issue-1602.test.ts` — original #1602 fix preserved (4/4 pass).
- [x] Focused equivalence batch (generators/objects/classes/destructuring/closures): identical pass/fail with vs without the fix — **0 new failures** introduced; remaining failures pre-exist on `main` and are orthogonal.
- [x] `tsc --noEmit` clean.
- [ ] Full test262 (CI) — expected to recover toward ~29,600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)