### PR TITLE
docs(#1661): fix README programmatic-API example (standalone target instantiates with {})

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,17 +143,38 @@ Programmatic API:
 ```ts
 import { compile } from "js2wasm";
 
-const result = compile(`
+const result = compile(
+  `
   export function add(a: number, b: number): number {
     return a + b;
   }
-`);
+`,
+  { target: "standalone" },
+);
 
 if (result.success) {
+  // standalone modules have no host imports, so {} is sufficient
   const { instance } = await WebAssembly.instantiate(result.binary, {});
-  console.log((instance.exports as any).add(2, 3));
+  console.log((instance.exports as any).add(2, 3)); // → 5
 }
 ```
+
+### Compile modes and imports
+
+The imports a module needs depend on the compile target:
+
+- **Default (JS-host) mode** (no `target`, or `target: "gc"`) emits runtime
+  imports — a `string_constants` module plus `env.*` helpers such as
+  `__box_number`, `__extern_get`, and `__throw_reference_error`. These are
+  supplied by the js2wasm JS runtime, so instantiating with an empty `{}`
+  throws `Import #0 "string_constants": module is not an object or function`.
+  Use this mode when you run the output alongside the JS runtime that provides
+  those imports.
+- **Standalone mode** (`target: "standalone"`, also `target: "wasi"`) emits a
+  pure WasmGC module with Wasm-native intrinsics and **no host imports**, so it
+  instantiates with `WebAssembly.instantiate(binary, {})` and runs anywhere
+  WasmGC is available. Prefer this for portable, host-independent output — it is
+  what the snippet above uses.
 
 Useful local commands:
 

--- a/plan/issues/1661-readme-programmatic-api-host-imports.md
+++ b/plan/issues/1661-readme-programmatic-api-host-imports.md
@@ -1,9 +1,10 @@
 ---
 id: 1661
 title: "README programmatic-API example fails: instantiate(binary, {}) but default mode requires host imports"
-status: ready
+status: done
 created: 2026-05-25
 updated: 2026-05-25
+completed: 2026-05-25
 priority: high
 feasibility: easy
 reasoning_effort: low


### PR DESCRIPTION
## Summary
- The README programmatic-API snippet instantiated default-mode output with `{}`, which throws `Import #0 "string_constants"` because default (JS-host) mode emits `string_constants` + `env.*` runtime imports (reported in GitHub #601 by guest271314).
- Switched the example to `{ target: "standalone" }` — a pure WasmGC module with zero host imports that instantiates with `{}` and runs.
- Added a short "Compile modes and imports" note distinguishing default JS-host mode (runtime supplies imports) from standalone/`wasi` mode (intrinsics, instantiates with `{}`), recommending standalone for portability.

## Verification
Ran the exact README snippet verbatim via `npx tsx` against `src/index.ts`:
- `WebAssembly.Module.imports(...)` → 0 imports
- `WebAssembly.instantiate(binary, {})` succeeds
- `instance.exports.add(2, 3)` → `5`

Also confirmed default mode (no target) emits 3+ imports and fails `instantiate(binary, {})` with the reported error, matching the docs.

Docs-only change — no `src/` edits, so test262 does not run. Issue #1661 set to `status: done` in this PR (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)