### PR TITLE
fix(#1130): array-index-exotic length growth on defineProperty (PR-0)

### DIFF
--- a/plan/issues/1130-array-methods-getter-observing-property.md
+++ b/plan/issues/1130-array-methods-getter-observing-property.md
@@ -3,7 +3,7 @@ id: 1130
 title: "Array methods — getter-observing property access on indices and length"
 status: ready
 created: 2026-04-20
-updated: 2026-04-28
+updated: 2026-05-25
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -912,3 +912,40 @@ codegen) and, if holes are not tracked, **scope PR-1/2 to the `[]`-or-dense
 than expanding #1130. This is the one place this issue could legitimately
 need more than a spec — flag it to the architect/PO if hole tracking turns
 out to be a prerequisite for a majority of the 96.
+
+---
+
+## PR-0 landed (2026-05-25, dev-c)
+
+Array-index-exotic `length` growth on `defineProperty` (item A of the
+2026-05-24 authoritative re-spec). `Object.defineProperty(arr, "n", desc)`
+with a canonical array index `n >= arr.length` now bumps the vec's logical
+length (struct field 0) to `n + 1`, per ES §10.4.2.1.
+
+- `src/codegen/object-ops.ts` — new helpers `parseCanonicalArrayIndex`,
+  `resolveVecTypeIdx`, `maybeEmitVecLengthGrowth` (emits a guarded
+  `if (n >= vec.length) vec.length = n+1` on the raw vec ref). Wired into
+  all three array-receiver defineProperty paths:
+  - struct-accessor branch (`get`/`set` on a typed vec → `<vec>_get_n`
+    accessor func; objLocal holds the raw ref),
+  - `emitExternDefinePropertyNoValue` (accessor + flag-only on externref),
+  - `emitExternDefinePropertyValue` (value descriptor; a raw vec ref is
+    captured via `local.tee` before `extern.convert_any`).
+- Only canonical array indices in `[0, 2^32-2]` grow length; `"length"`,
+  `"01"`, `"-1"`, `"1.5"`, `"4294967295"` do not. Gated on the receiver
+  statically resolving to a vec struct (length+data), so non-array
+  defineProperty and externref-typed locals are untouched (the type guard
+  prevents an invalid `struct.get`).
+- Test: `tests/issue-1130.test.ts` (7 tests) — accessor/value growth,
+  no-grow-within-length, non-index keys, string-element vec, and a
+  forEach-unaffected guard.
+
+**Note on the re-spec premise**: the 2026-05-24 claim that *every* array
+shape routes accessor `defineProperty` through `__defineProperty_accessor`
+is only true for `any`-typed arrays. A statically-typed `number[]` with an
+accessor descriptor routes to the struct-accessor branch (`<vec>_get_n`),
+NOT the host import — so PR-0 wires growth into that branch too. PR-1's
+accessor-observation probe will need to account for this (the getter on a
+typed vec is a compiled Wasm accessor func, not a `_wasmStructProps`
+sidecar entry). Element-read accessor observation is still PR-1 scope; PR-0
+only fixes the loop bound.

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -117,6 +117,94 @@ function isStaticallyNonObjectDescArg(descArg: ts.Expression): boolean {
   return false;
 }
 
+// ── #1130 PR-0: array-index-exotic length growth on defineProperty ───
+/**
+ * Parse a property key string as a canonical array index per the array
+ * exotic-object rules (`ToString(ToUint32(n)) === key`, ES §10.4.2.1).
+ * Returns the index when `key` is a canonical array index in `[0, 2^32-2]`,
+ * else undefined. "length", "01", "-1", "1.5", "4294967295" are NOT
+ * canonical array indices.
+ */
+function parseCanonicalArrayIndex(key: string): number | undefined {
+  if (!/^(0|[1-9][0-9]*)$/.test(key)) return undefined;
+  const n = Number(key);
+  // Array indices are < 2^32 - 1 (4294967295 is the max length, not an index).
+  if (!Number.isInteger(n) || n < 0 || n >= 0xffffffff) return undefined;
+  return n;
+}
+
+/**
+ * Resolve the vec struct typeIdx (length+data shape) for a defineProperty
+ * receiver expression, or undefined when the receiver is not a statically
+ * known WasmGC array (vec) struct.
+ */
+function resolveVecTypeIdx(ctx: CodegenContext, objArg: ts.Expression): number | undefined {
+  const objTsType = ctx.checker.getTypeAtLocation(objArg);
+  const wasmType = resolveWasmType(ctx, objTsType);
+  if (wasmType.kind !== "ref" && wasmType.kind !== "ref_null") return undefined;
+  const typeIdx = (wasmType as { typeIdx?: number }).typeIdx;
+  if (typeIdx === undefined) return undefined;
+  const typeDef = ctx.mod.types[typeIdx];
+  if (typeDef?.kind === "struct" && typeDef.fields[0]?.name === "length" && typeDef.fields[1]?.name === "data") {
+    return typeIdx;
+  }
+  return undefined;
+}
+
+/**
+ * #1130 PR-0: emit array-index-exotic `length` growth.
+ *
+ * `Object.defineProperty(arr, "n", desc)` on an array with `n >= arr.length`
+ * sets `arr.length = n + 1` (ES §10.4.2.1 ArraySetLength via array exotic
+ * `[[DefineOwnProperty]]`). Our WasmGC vec stores the logical length in
+ * struct field 0; this emits a guarded bump on the saved raw vec ref.
+ *
+ * `vecRefLocal` must hold the raw vec struct ref; `vecRefType` is that
+ * local's ValType. Emits nothing unless the local is a ref to the
+ * statically-resolved vec type — this guards against an externref-typed
+ * local (where `struct.get` would be a Wasm validation error) and against
+ * a static/runtime type mismatch. Emits nothing when `objArg` is not a vec
+ * or `propArg` is not a canonical array index. Leaves the stack unchanged.
+ */
+function maybeEmitVecLengthGrowth(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objArg: ts.Expression,
+  propArg: ts.Expression,
+  vecRefLocal: number,
+  vecRefType: ValType,
+): void {
+  if (!ts.isStringLiteral(propArg)) return;
+  const idx = parseCanonicalArrayIndex(propArg.text);
+  if (idx === undefined) return;
+  const vecTypeIdx = resolveVecTypeIdx(ctx, objArg);
+  if (vecTypeIdx === undefined) return;
+  // The saved local must be a ref to this exact vec type, or struct.get on
+  // it is invalid. An externref-typed local is skipped (the value path
+  // stores a separate raw-ref local for this purpose).
+  if (
+    (vecRefType.kind !== "ref" && vecRefType.kind !== "ref_null") ||
+    (vecRefType as { typeIdx?: number }).typeIdx !== vecTypeIdx
+  ) {
+    return;
+  }
+
+  // if (idx >= vec.length) vec.length = idx + 1
+  fctx.body.push({ op: "i32.const", value: idx });
+  fctx.body.push({ op: "local.get", index: vecRefLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "i32.ge_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: vecRefLocal },
+      { op: "i32.const", value: idx + 1 },
+      { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 },
+    ],
+  });
+}
+
 // ── Compile-time primitive type check for Object methods ─────────────
 
 /**
@@ -895,6 +983,12 @@ export function compileObjectDefineProperty(
       }
     }
 
+    // #1130 PR-0: array-index-exotic length growth. For a vec receiver the
+    // accessor compiles to a struct accessor func (not a host import); the
+    // backing vec's logical length still must grow so iteration reaches the
+    // index. objLocal holds the raw ref here.
+    maybeEmitVecLengthGrowth(ctx, fctx, objArg, propArg, objLocal, objType);
+
     // Return obj
     fctx.body.push({ op: "local.get", index: objLocal });
     return objType;
@@ -1374,7 +1468,15 @@ function emitExternDefinePropertyValue(
   // directly to get a stable externref identity for the WasmGC struct (#856).
   const objType = compileExpression(ctx, fctx, objArg);
   if (!objType) return null;
+  // #1130 PR-0: capture the raw vec ref (before extern.convert_any) so the
+  // array-index-exotic length bump below can struct.set field 0. Only when
+  // the receiver is statically a vec — otherwise no raw local is needed.
+  let rawVecLocal: number | undefined;
   if (objType.kind === "ref" || objType.kind === "ref_null") {
+    if (resolveVecTypeIdx(ctx, objArg) !== undefined) {
+      rawVecLocal = allocLocal(fctx, `__defprop_rawvec_${fctx.locals.length}`, objType);
+      fctx.body.push({ op: "local.tee", index: rawVecLocal });
+    }
     fctx.body.push({ op: "extern.convert_any" } as Instr);
   } else if (objType.kind !== "externref") {
     coerceType(ctx, fctx, objType, { kind: "externref" });
@@ -1455,6 +1557,11 @@ function emitExternDefinePropertyValue(
   flushLateImportShifts(ctx, fctx);
   if (funcIdx !== undefined) {
     fctx.body.push({ op: "call", funcIdx });
+  }
+
+  // #1130 PR-0: array-index-exotic length growth (raw vec ref captured above).
+  if (rawVecLocal !== undefined) {
+    maybeEmitVecLengthGrowth(ctx, fctx, objArg, propArg, rawVecLocal, objType);
   }
 
   // __defineProperty_value returns obj, so we're done
@@ -1695,6 +1802,8 @@ function emitExternDefinePropertyNoValue(
       if (accFuncIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx: accFuncIdx });
       }
+      // #1130 PR-0: array-index-exotic length growth (objLocal holds the raw ref).
+      maybeEmitVecLengthGrowth(ctx, fctx, objArg, propArg, objLocal, objType);
       return { kind: "externref" };
     }
 
@@ -1734,6 +1843,8 @@ function emitExternDefinePropertyNoValue(
     if (funcIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx });
     }
+    // #1130 PR-0: array-index-exotic length growth (objLocal holds the raw ref).
+    maybeEmitVecLengthGrowth(ctx, fctx, objArg, propArg, objLocal, objType);
     return { kind: "externref" };
   }
 

--- a/tests/issue-1130.test.ts
+++ b/tests/issue-1130.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1130 PR-0 — array-index-exotic `length` growth on Object.defineProperty.
+ *
+ * Per ES §10.4.2.1 (array exotic `[[DefineOwnProperty]]` / ArraySetLength):
+ * `Object.defineProperty(arr, "n", desc)` with a canonical array index `n`
+ * where `n >= arr.length` sets `arr.length = n + 1`. Our WasmGC vec stores
+ * the logical length in struct field 0; defineProperty must bump it.
+ *
+ * This is the prerequisite slice for the broader getter-observing work
+ * (PR-1/PR-2): without length growth the callback loop never reaches a
+ * newly accessor-defined index. PR-0 only grows `length`; element reads
+ * still take the raw fast path (accessor-observation lands in PR-1).
+ */
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+async function run(source: string): Promise<unknown> {
+  const exports = await compileAndInstantiate(source);
+  return (exports as Record<string, () => unknown>).test();
+}
+
+describe("#1130 PR-0: array-index-exotic length growth", () => {
+  it("accessor descriptor on index >= length grows length", async () => {
+    // empty array, define a getter on index 2 -> length becomes 3
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [];
+           Object.defineProperty(arr, "2", { get() { return 12; } });
+           return arr.length;
+         }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("value descriptor on index >= length grows length", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [0];
+           Object.defineProperty(arr, "4", { value: 9 });
+           return arr.length;
+         }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("index within current length does not change length", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [0, 1, 2, 3];
+           Object.defineProperty(arr, "1", { get() { return 9; } });
+           return arr.length;
+         }`,
+      ),
+    ).toBe(4);
+  });
+
+  it('the "length" key is not a canonical array index — no growth', async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [0, 1, 2];
+           Object.defineProperty(arr, "length", { value: 2 } as any);
+           return arr.length;
+         }`,
+      ),
+    ).toBe(2);
+  });
+
+  it('non-canonical numeric key "01" is not an array index — no growth', async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [0];
+           Object.defineProperty(arr, "01", { value: 9 });
+           return arr.length;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("string element array grows length too", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: string[] = ["a"];
+           Object.defineProperty(arr, "3", { value: "z" });
+           return arr.length;
+         }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("existing forEach over a non-accessor array is unaffected", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+           var arr: number[] = [1, 2, 3];
+           var sum = 0;
+           arr.forEach(function (v) { sum += v; });
+           return sum;
+         }`,
+      ),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
PR-0 of the #1130 getter-observing array-methods work (per the 2026-05-24 authoritative re-spec). `Object.defineProperty(arr, "n", desc)` with a canonical array index `n >= arr.length` now bumps the WasmGC vec's logical length (struct field 0) to `n + 1`, per ES §10.4.2.1 (array exotic `[[DefineOwnProperty]]` / ArraySetLength).

This is the prerequisite slice: without length growth, the array-method callback loop never reaches a newly accessor-defined index. PR-0 only fixes the loop bound; element-read accessor observation is PR-1 scope.

## Changes
- `src/codegen/object-ops.ts` — new helpers `parseCanonicalArrayIndex`, `resolveVecTypeIdx`, `maybeEmitVecLengthGrowth` (guarded `if (n >= vec.length) vec.length = n+1` on the raw vec ref). Wired into all three array-receiver defineProperty paths:
  - struct-accessor branch (`get`/`set` on a typed vec → `<vec>_get_n` accessor func),
  - `emitExternDefinePropertyNoValue` (accessor + flag-only),
  - `emitExternDefinePropertyValue` (value descriptor; raw vec ref captured via `local.tee` before `extern.convert_any`).
- `tests/issue-1130.test.ts` — 7 tests.
- Issue file: PR-0 results note appended; `status: ready` retained (PR-1/PR-2 follow).

## Notes
- Gated on the receiver statically resolving to a vec struct (length+data) — non-array defineProperty and externref-typed locals are untouched (a type guard prevents an invalid `struct.get`). Only canonical array indices in `[0, 2^32-2]` grow length (`"length"`, `"01"`, `"4294967295"` do not).
- The re-spec's claim that *every* array shape routes accessor defineProperty through `__defineProperty_accessor` holds only for `any`-typed arrays; a statically-typed `number[]` accessor routes to the struct-accessor branch (`<vec>_get_n`), so growth is wired there too. Flagged in the issue file for PR-1.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `tests/issue-1130.test.ts` — 7/7 pass (accessor/value growth, no-grow-within-length, non-index keys, string-element vec, forEach-unaffected guard)
- [x] Verified pre-existing `array-methods.test.ts` strict-type failures reproduce on clean main (unrelated to this change)
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)