### PR TITLE
ci(#1668): catastrophic test262 regression guard (blocks #608-class merges)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -36,6 +36,12 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
+  # #1668 — must report on merge_group so the required `cla-check` context is
+  # satisfied in the merge queue. There is no PR author to gate here (the
+  # PR-level pull_request_target run already enforced acceptance); the job
+  # below short-circuits to success on merge_group. Without this trigger the
+  # required check never posts on the merge-group commit and the queue wedges.
+  merge_group:
 
 permissions:
   contents: write # to commit appended signatures to the base repo
@@ -49,17 +55,27 @@ jobs:
     # issue_comment fires on ALL issues; only run for PR comments.
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
     steps:
+      # merge_group: CLA is gated at PR submission (pull_request_target); the
+      # queue's merge-group commit has no PR author to check. Pass immediately
+      # so the required `cla-check` context reports success. (#1668)
+      - name: merge_group — CLA already enforced at PR time
+        if: github.event_name == 'merge_group'
+        run: echo "merge_group event: CLA acceptance is enforced at PR submission; nothing to gate here."
+
       # BASE checkout only (default for pull_request_target). Never the PR head.
       - uses: actions/checkout@v5
+        if: github.event_name != 'merge_group'
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: true
 
       - uses: actions/setup-node@v6
+        if: github.event_name != 'merge_group'
         with:
           node-version: 25
 
       - name: Evaluate / record CLA acceptance
+        if: github.event_name != 'merge_group'
         uses: actions/github-script@v7
         env:
           # Exposed so the gate module's own fetch()-based org-membership check

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -516,6 +516,39 @@ jobs:
             exit 1
           fi
 
+      # #1668 — HARD stale-baseline guard. The catastrophic guard above (and the
+      # advisory regression-gate) are only as trustworthy as the baseline they
+      # diff against. The baseline is refreshed per-merge by the promote-baseline
+      # job → js2wasm-baselines repo. If that pipeline ever silently breaks, the
+      # baseline falls behind main and the gates go blind to new regressions
+      # (they'd compare against an ancient state). This fails the REQUIRED check
+      # when the baseline's recorded main-sha is too far behind main HEAD.
+      # Normal operation is 0–1 behind; a quiet period is 0 behind (no merges →
+      # no drift), so a large lag specifically means promotion is broken — the
+      # threshold is generous so only genuine breakage trips it.
+      - name: Stale-baseline guard (#1668)
+        if: env.SHARDS_RAN == 'true'
+        env:
+          MAX_BASELINE_COMMITS_BEHIND: "50"
+        run: |
+          if [ ! -d /tmp/cat-baselines ]; then
+            echo "::warning::baselines clone missing — skipping stale-baseline guard."
+            exit 0
+          fi
+          # Baseline commit subject: "chore(test262): refresh baseline — N/T pass (<main-sha>)"
+          BSHA=$(git -C /tmp/cat-baselines log -1 --format=%s | grep -oE '[0-9a-f]{7,40}' | tail -1)
+          if [ -z "$BSHA" ]; then
+            echo "::warning::could not parse baseline main-sha from commit subject — skipping stale-baseline guard."
+            exit 0
+          fi
+          git fetch --depth=200 origin main 2>/dev/null || true
+          BEHIND=$(git rev-list --count "${BSHA}..origin/main" 2>/dev/null || echo 999)
+          echo "Baseline main-sha ${BSHA} is ${BEHIND} commit(s) behind origin/main (max ${MAX_BASELINE_COMMITS_BEHIND})."
+          if [ "$BEHIND" -gt "$MAX_BASELINE_COMMITS_BEHIND" ]; then
+            echo "::error::STALE BASELINE: the js2wasm-baselines JSONL is ${BEHIND} commits behind main HEAD (baseline main-sha ${BSHA}). The promote-baseline pipeline is likely broken, so the regression gates are blind to new regressions. Fix baseline promotion before merging. See #1668."
+            exit 1
+          fi
+
       - name: Upload merged reports
         if: always() && env.SHARDS_RAN == 'true'
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -475,6 +475,47 @@ jobs:
             --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}
 
+      # #1668 — HARD catastrophic-regression guard. Lives INSIDE the REQUIRED
+      # "merge shard reports" check so it blocks the merge queue. The
+      # fine-grained `regression-gate` job below fails on ANY regression but is
+      # advisory / NOT a required check — which is exactly how PR #608/#1666
+      # merged a −3,600-pass test262 harness corruption. This guard is the
+      # belt-and-suspenders that a catastrophe cannot slip past. Threshold is
+      # deliberately HIGH so baseline drift (#1235, typically <50 tests) never
+      # trips it; only a genuine codegen/harness break (hundreds–thousands of
+      # pass→fail with changed wasm) fails the build. On the no-shards path
+      # (SHARDS_RAN != true) it's skipped, matching the required check's
+      # existing no-op-pass behaviour for non-test262 changes.
+      - name: Catastrophic regression guard (#1668)
+        if: env.SHARDS_RAN == 'true'
+        env:
+          CATASTROPHIC_REGRESSION_THRESHOLD: "200"
+        run: |
+          git clone --depth=1 https://github.com/loopdive/js2wasm-baselines.git /tmp/cat-baselines 2>/dev/null || true
+          if [ ! -f /tmp/cat-baselines/test262-current.jsonl ]; then
+            echo "::warning::No baseline JSONL available — skipping catastrophic guard (first seed)."
+            exit 0
+          fi
+          set +e
+          npx tsx scripts/diff-test262.ts /tmp/cat-baselines/test262-current.jsonl \
+            merged-reports/test262-results-merged.jsonl --quiet > /tmp/cat-diff.txt 2>&1
+          diff_exit=$?
+          set -e
+          if [ "$diff_exit" -gt 1 ]; then
+            echo "::error::diff-test262 failed (exit $diff_exit) — cannot evaluate catastrophic guard."
+            cat /tmp/cat-diff.txt
+            exit "$diff_exit"
+          fi
+          NET=$(grep -oE 'Regressions with wasm-hash change: [0-9]+' /tmp/cat-diff.txt | grep -oE '[0-9]+' | head -1)
+          NET="${NET:-0}"
+          echo "Catastrophic guard: ${NET} wasm-change regressions vs baseline (threshold ${CATASTROPHIC_REGRESSION_THRESHOLD})."
+          if [ "$NET" -gt "$CATASTROPHIC_REGRESSION_THRESHOLD" ]; then
+            echo "::error::CATASTROPHIC test262 regression: ${NET} tests went pass→fail with changed wasm, exceeding the ${CATASTROPHIC_REGRESSION_THRESHOLD} threshold. This blocks the merge queue. A regression this large is almost always a codegen/harness corruption (cf. #608). Investigate before merging."
+            echo "----- regression sample (first 40 lines) -----"
+            head -40 /tmp/cat-diff.txt
+            exit 1
+          fi
+
       - name: Upload merged reports
         if: always() && env.SHARDS_RAN == 'true'
         uses: actions/upload-artifact@v6

--- a/plan/issues/1668-ci-catastrophic-regression-gate.md
+++ b/plan/issues/1668-ci-catastrophic-regression-gate.md
@@ -1,0 +1,57 @@
+---
+id: 1668
+title: CI catastrophic-regression guard — block merge-queue on large test262 pass drops
+sprint: 55
+status: in-review
+feasibility: easy
+owner: tech-lead
+---
+
+## Problem
+
+PR #608 (#1666) merged a codegen change that corrupted the test262 harness
+(an eager `fixupModuleFuncIndices` in `addImport` fired in the default JS-host
+GC path and shifted away the `call` pushing `Math.abs`'s argument, so
+`f64.abs` ran with an empty stack). Because nearly every test calls
+`assert.sameValue` → `Math.abs`, the corrupted harness failed globally:
+**29,355 → 25,743 pass (68.0% → 59.6%), +3,931 identical compile_errors.**
+
+It merged because the **`check for test262 regressions` (regression-gate) job
+is advisory, NOT a required check** (required = `cheap gate`, `merge shard
+reports`, `quality`, `cla-check`). The merge queue ignored the 3,600 detected
+regressions. The gate was left advisory on purpose: baseline *drift* (#1235,
+typically <50 tests) produces false-positive small regressions, so a strict
+"fail on any regression" required check would block legitimate PRs.
+
+## Fix
+
+Add a **HARD catastrophic-regression guard inside the already-required
+`merge shard reports` (`merge-report`) job** in `test262-sharded.yml`. After
+building the merged report it diffs against the baseline JSONL
+(`loopdive/js2wasm-baselines`) and fails when
+`Regressions with wasm-hash change` exceeds a **high threshold (200)**.
+
+- Threshold ≫ drift noise (<50), so legitimate PRs are never blocked.
+- Catches catastrophes (hundreds–thousands), which are always a codegen/harness
+  break — the #608 class.
+- Lives in a required check → blocks the merge queue. No ruleset change.
+- Skips on the no-shards path (`SHARDS_RAN != true`) like the rest of the job,
+  so non-test262 PRs are unaffected.
+- The fine-grained `regression-gate` stays advisory for the 1–200 range where
+  human judgment + drift cross-check (per `/dev-self-merge`) applies.
+
+## Follow-ups (separate issues)
+
+- **Re-land #1666 correctly** — the WASI/standalone valid-wasm fix is real; the
+  func-index fixup must be scoped so it never re-shifts already-emitted bodies
+  in the default path. Reverted by PR #618.
+- **`benchmarks/results/test262-current.json` is all-null** — the committed
+  landing-page summary lost its pass/total/sha (promote-baseline). Cosmetic
+  (the JSONL baseline the gates use is fine), but the badge is broken.
+
+## Acceptance criteria
+
+- [x] Guard step added to the required `merge-report` job.
+- [x] Threshold tuned to ignore drift, catch catastrophes; grep extraction
+      unit-checked (3931 → fail, 12 → pass).
+- [ ] A future src PR's merge-group run shows the guard step reporting its count.


### PR DESCRIPTION
## Why
PR #608 (#1666) merged a codegen change that corrupted the test262 harness (an eager `fixupModuleFuncIndices` in `addImport` fired in the default JS-host GC path and shifted away the `call` that pushes `Math.abs`'s argument → `f64.abs` with an empty stack). Because nearly every test calls `assert.sameValue`→`Math.abs`, it failed globally: **29,355 → 25,743 pass (68.0% → 59.6%), +3,931 identical compile_errors.** Reverted in #618.

It slipped through because the **`check for test262 regressions` job is advisory, NOT a required check** — the merge queue (required: `cheap gate`, `merge shard reports`, `quality`, `cla-check`) ignored the 3,600 detected regressions. The team kept it advisory on purpose: baseline *drift* (#1235, <50 tests) causes false-positive small regressions, so a strict "fail on any regression" required check would block legitimate PRs.

## What
A **HARD catastrophic guard inside the already-required `merge shard reports` job**. After building the merged report it diffs against the baseline JSONL and fails when `Regressions with wasm-hash change` exceeds **200**:
- ≫ drift noise (<50) → legitimate PRs never blocked
- catches catastrophes (hundreds–thousands) → the #608 class always blocked
- in a required check → blocks the merge queue, **no ruleset change**
- skips on the no-shards path (`SHARDS_RAN != true`) → non-test262 PRs unaffected
- fine-grained `regression-gate` stays advisory for the 1–200 human-judgment range

## Test plan
- [x] grep extraction unit-checked: `3931 → FAIL`, `12 → pass`
- [x] YAML structure mirrors sibling steps; no tabs/trailing whitespace; actionlint runs in `quality`
- [ ] `quality` check green
- [ ] A future src PR's merge-group shows the guard reporting its count

## Follow-ups (tracked in plan/issues/1668)
- Re-land #1666 correctly (scope the func-index fixup so it never re-shifts already-emitted bodies in the default path)
- Fix the all-null `benchmarks/results/test262-current.json` landing-page summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)