### PR TITLE
fix(#1670): Atomics/typed-array arg cast must follow validation throw (regressed by #1654)

### DIFF
--- a/plan/issues/1670-atomics-illegal-cast-regression.md
+++ b/plan/issues/1670-atomics-illegal-cast-regression.md
@@ -1,0 +1,87 @@
+---
+id: 1670
+slug: atomics-illegal-cast-regression
+title: "Atomics negative tests trap with `illegal cast` (regressed by #1654 / PR #599)"
+sprint: 55
+status: in-review
+feasibility: hard
+depends_on: []
+regressed_by: 1654
+---
+
+# #1670 — Atomics `illegal cast` regression from #1654
+
+## Problem
+
+PR #599 (`32071e49c`, `fix(#1654): ArrayBuffer/DataView/TypedArray valid under
+--target wasi`) flipped **28** `built-ins/Atomics/{wait,waitAsync,notify}/*`
+test262 tests from `pass` to `illegal cast`. The Atomics illegal-cast bucket
+jumps from 1 → 52 at exactly this commit and persists.
+
+Most of the affected tests are **negative** (`assert.throws`): they construct
+`new Int32Array(new SharedArrayBuffer(...))` and then expect a
+`RangeError`/`TypeError` from a bad index / non-integer / detached or
+non-shared buffer. They previously passed by throwing correctly.
+
+## Root cause
+
+#1654 added a native "byte-buffer view" path for `new TypedArray(buffer)` in
+`src/codegen/expressions/new-super.ts` (`emitTypedArrayFromByteBuffer`, plus
+two call sites at the single-arg TypedArray and Uint8-family constructors). The
+path emits an **unconditional** `ref.cast` (`any.convert_extern` + `ref.cast`)
+to the native `i32_byte` vec struct that backs a standalone/WASI ArrayBuffer.
+
+In **JS-host mode** that assumption is false:
+- `new ArrayBuffer(n)` is lowered to the `i32_byte` vec **only** in the
+  dedicated `className === "ArrayBuffer"` branch — and even then host code may
+  carry it as an externref.
+- `new SharedArrayBuffer(n)` has **no native struct lowering at all** — it
+  falls through to the generic extern/host path.
+
+So `new Int32Array(new SharedArrayBuffer(...))` reached `ref.cast i32_byte` on a
+value that is not an `i32_byte` vec → the cast **traps with `illegal cast` at
+construction time**, before any spec-required `ValidateAtomicAccess` /
+`ToIndex` throw could run. The negative tests then see a wasm trap instead of
+the JS `RangeError`/`TypeError` they assert.
+
+Reproduced on main HEAD (with #608 reverted) via `buildImports` +
+`WebAssembly.instantiate`:
+
+```
+new Int32Array(new SharedArrayBuffer(16)) → RUNTIME: illegal cast
+```
+
+## Fix
+
+Gate **both** `emitTypedArrayFromByteBuffer` call sites on `noJsHost(ctx)`
+(`ctx.wasi || ctx.standalone`). The byte-buffer view is only needed — and only
+sound — in standalone/WASI mode, where the buffer genuinely is the `i32_byte`
+vec. #1654's six tests are all `target: "wasi"`, so they keep the native path.
+In JS-host mode the buffer arg is handled by the runtime as before #1654, so
+construction no longer traps and the Atomics spec throws surface correctly.
+
+This is a TARGETED fix — #1654's WASI/standalone DataView/TypedArray validity
+work is untouched.
+
+### Files
+
+- `src/codegen/expressions/new-super.ts`
+  - import `noJsHost` from `./helpers.js`
+  - guard the single-arg TypedArray buffer-view branch (`~L1884`)
+  - guard the Uint8-family buffer-view branch (`~L2420`)
+- `tests/issue-1670-atomics-typedarray-cast.test.ts` — regression test
+  (positive `new Int32Array(new SharedArrayBuffer(n))` constructs + indexes
+  without `illegal cast`; negative shape proves a guarded bad-index throw is
+  reached rather than pre-empted by a trap).
+
+## Test Results
+
+- `tests/issue-1670-atomics-typedarray-cast.test.ts` — 2/2 pass
+- `tests/issue-1654-wasi-dataview-arraybuffer.test.ts` — 5/5 pass (no regression)
+- `tsc --noEmit` clean; `biome lint` clean on changed files
+- Pre-existing `tests/typed-array-basic.test.ts` /
+  `tests/arraybuffer-dataview.test.ts` failures (missing `string_constants`
+  import in the test harness) reproduce identically without this change — not
+  caused here.
+
+Expected test262 effect: net ~+28 (Atomics illegal-cast bucket 52 → ~1).

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -38,6 +38,7 @@ import {
   getFuncParamTypes,
   getWasmFuncReturnType,
   isEffectivelyVoidReturn,
+  noJsHost,
   wasmFuncReturnsVoid,
 } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
@@ -1880,8 +1881,19 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // ArrayBuffer/DataView is backed by an i32_byte vec; copy the bytes
         // into this TypedArray's f64 backing array. Must precede the
         // size-constructor path (an ArrayBuffer is NOT a numeric length).
+        //
+        // #1670 — only in no-JS-host mode. The byte-buffer view path emits an
+        // unconditional `ref.cast` to the native `i32_byte` vec. In JS-host
+        // mode an ArrayBuffer / SharedArrayBuffer is NOT lowered to that vec
+        // (e.g. `new SharedArrayBuffer(n)` has no native struct), so the cast
+        // traps with `illegal cast` before any spec validation runs — this
+        // regressed 28 Atomics negative tests built on
+        // `new Int32Array(new SharedArrayBuffer(...))`. Host mode already
+        // handles the buffer arg correctly via the runtime, so skip the
+        // native view path there.
         const argSymName = argSym?.name;
         if (
+          noJsHost(ctx) &&
           (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView") &&
           !ts.isNumericLiteral(args[0]!) &&
           emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)
@@ -2405,8 +2417,13 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // process.stdout.write, which expects a vec_f64, sees the real bytes).
         const argTsType = ctx.checker.getTypeAtLocation(args[0]!);
         const argSymName = argTsType.getSymbol?.()?.name;
+        // #1670 — gate on no-JS-host (see the matching guard above): the
+        // native byte-buffer view emits an unconditional `ref.cast` to the
+        // `i32_byte` vec that traps in JS-host mode, where the buffer is not
+        // that struct.
         const isBufferArg =
-          argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView";
+          noJsHost(ctx) &&
+          (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView");
         if (isBufferArg && emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)) {
           return { kind: "ref_null", typeIdx: vecTypeIdx };
         }

--- a/tests/issue-1670-atomics-typedarray-cast.test.ts
+++ b/tests/issue-1670-atomics-typedarray-cast.test.ts
@@ -1,0 +1,76 @@
+// #1670 — Atomics / typed-array arg cast must follow validation throw.
+//
+// PR #599 (fix(#1654)) added a native byte-buffer view path for
+// `new TypedArray(arrayBuffer)`. The path emits an unconditional `ref.cast`
+// to the native `i32_byte` vec. In JS-host mode an ArrayBuffer /
+// SharedArrayBuffer is NOT lowered to that vec — `new SharedArrayBuffer(n)`
+// has no native struct at all — so the cast trapped with `illegal cast`
+// before any spec-required validation could run. This regressed 28
+// `built-ins/Atomics/{wait,waitAsync,notify}/*` negative tests, all built on
+// `new Int32Array(new SharedArrayBuffer(...))` and expecting RangeError /
+// TypeError on bad index / non-integer / detached args.
+//
+// Fix: gate the native byte-buffer view path on no-JS-host mode (where the
+// buffer IS the native i32_byte vec). #1654's WASI/standalone DataView and
+// TypedArray validity work stays intact.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndRun(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  expect(r.success, `Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#1670 Int32Array over SharedArrayBuffer must not trap on construction (JS-host)", () => {
+  it("positive: new Int32Array(new SharedArrayBuffer(n)) constructs + indexes without illegal cast", async () => {
+    // Before the fix this trapped with `illegal cast` at construction time.
+    const ret = await compileAndRun(`
+      const i32a = new Int32Array(new SharedArrayBuffer(16));
+      i32a[0] = 42;
+      i32a[1] = 7;
+      export function test(): number { return i32a[0] + i32a[1]; }
+    `);
+    expect(ret).toBe(49);
+  });
+
+  it("negative shape: a guarded bad-index throw is reached (not pre-empted by an illegal-cast trap)", async () => {
+    // Mirrors the Atomics negative tests: a RangeError-style throw on a bad
+    // index must surface as a JS throw, not a wasm `illegal cast` trap. We
+    // model the spec throw with an explicit guard so the test stays
+    // host-runtime-agnostic; the regression was that construction trapped
+    // *before* any such guard could run.
+    const r = compile(
+      `
+      const i32a = new Int32Array(new SharedArrayBuffer(16));
+      i32a[0] = 5;
+      export function test(idx: number): number {
+        if (idx < 0) { throw new RangeError("bad index"); }
+        return i32a[idx];
+      }
+    `,
+      { fileName: "test.ts" },
+    );
+    expect(r.success).toBe(true);
+    const imports = buildImports(r.imports, undefined, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+    const test = (instance.exports as Record<string, (n: number) => number>).test;
+    // valid index: no trap, no throw (construction must have succeeded)
+    expect(test(0)).toBe(5);
+    // bad index: the guard throws (a JS exception), NOT an illegal-cast trap.
+    let threw = false;
+    let msg = "";
+    try {
+      test(-1);
+    } catch (e) {
+      threw = true;
+      msg = String((e as { message?: string }).message ?? e);
+    }
+    expect(threw).toBe(true);
+    // The decisive check: it must NOT be the regression's `illegal cast` trap.
+    expect(msg).not.toContain("illegal cast");
+  });
+});


### PR DESCRIPTION
## Summary
- Repairs a 28-test test262 regression introduced by PR #599 / `32071e49c` (`fix(#1654)`). The Atomics `illegal cast` bucket jumped 1 → 52 at that commit.
- Root cause: #1654's native byte-buffer view for `new TypedArray(buffer)` emits an unconditional `ref.cast` to the native `i32_byte` vec. In JS-host mode an ArrayBuffer / SharedArrayBuffer is not that struct (`new SharedArrayBuffer(n)` has no native lowering at all), so `new Int32Array(new SharedArrayBuffer(...))` trapped at construction — before any spec-required Atomics validation could throw. The 28 negative Atomics tests (`assert.throws` RangeError/TypeError) saw a wasm trap instead.
- Fix: gate both `emitTypedArrayFromByteBuffer` call sites on `noJsHost(ctx)`. The native view is only needed/sound in standalone/WASI mode; #1654's six WASI tests keep that path untouched. In JS-host mode the buffer arg is handled by the runtime as before #1654.

This is a TARGETED fix, not a revert — #1654's WASI/standalone DataView/TypedArray validity work stays.

## Test plan
- [x] `tests/issue-1670-atomics-typedarray-cast.test.ts` — 2/2 pass (positive `new Int32Array(new SharedArrayBuffer(n))` constructs + indexes without `illegal cast`; negative shape proves a guarded bad-index throw is reached, not a trap)
- [x] `tests/issue-1654-wasi-dataview-arraybuffer.test.ts` — 5/5 pass (no regression to #1654)
- [x] `tsc --noEmit` clean; `biome lint` clean on changed files
- [x] Pre-existing `typed-array-basic` / `arraybuffer-dataview` failures (missing `string_constants` import in the harness) reproduce identically without this change — not caused here
- [ ] CI required checks green (expected net ~+28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)