### PR TITLE
fix(#1669): restore externref coercion on object-method trampoline call sites (regressed by #1602)

### DIFF
--- a/plan/issues/1669-trampoline-externref-coercion-regression.md
+++ b/plan/issues/1669-trampoline-externref-coercion-regression.md
@@ -1,0 +1,138 @@
+---
+id: 1669
+title: "codegen: object-method trampoline forwards args without coercion → invalid wasm (regressed by #1602)"
+status: in-review
+created: 2026-05-25
+updated: 2026-05-25
+priority: high
+feasibility: hard
+task_type: bugfix
+area: codegen
+language_feature: type-coercion, object-method-closures, generators, async
+goal: compiler-correctness
+sprint: 55
+es_edition: multi
+test262_count: 217
+related: [1602, 595, 608]
+---
+# #1669 — Object-method trampoline externref coercion (regression from #1602)
+
+## Problem
+
+PR #595 / commit `47a9a32b1` ("fix(#1602): call-site argument coercion emits
+valid wasm") introduced a ~217-test test262 regression. Diffing the #593 (peak)
+report against #595 showed **235 regressions, 213 of them (91%) one root cause**,
+**209/235 under `language/expressions`**. The shared failure is invalid Wasm
+inside object-method-as-closure trampolines (`__obj_meth_tramp_*`):
+
+```
+__obj_meth_tramp___anon_1_m_5 failed:
+  call[0] expected type externref, found ref.cast null of type (ref null 26)
+__obj_meth_tramp___anon_0_method_1 failed:
+  type error in fallthru[0] (expected externref, got (ref null 18))
+```
+
+The first form is a **param-type drift**; the second is a **result-type drift**.
+The other ~84 regressions are the runtime knock-on (`null pointer` / "reading
+'next'") of the same mis-typed trampoline producing a malformed closure value.
+
+This is a targeted fix — #1602's own valid-wasm fix (its acceptance tests in
+`tests/issue-1602.test.ts`) must stay; this repairs the collateral damage.
+
+## Root cause
+
+#1602 added `finalizeMethodTrampolines` (`src/codegen/closures.ts`). An
+object-method read as a value (`var f = obj.m;`, `({m(){}}).m`) is lowered to a
+closure struct whose funcref points at a **trampoline**: it drops the
+closure-self arg, pushes `ref.null <objStruct>` for the method's `this`, forwards
+the user params, then `call methodFuncIdx`. The trampoline's OWN signature (its
+wrapper func type) is the closure-value ABI, fixed when the closure value is
+emitted; the forwarded `local.get`s have those wrapper param types.
+
+`emitObjectMethodAsClosure` builds the trampoline body eagerly, but the method's
+`func.typeIdx` can be **re-resolved later** during body compilation —
+default-param / generator / async methods finalize their param types and order
+then. #1602 correctly noticed this and added a post-pass that rebuilds the
+forwarding body against the method's FINAL signature. **But it forwarded each
+param verbatim** (`local.get i` straight into `call methodFuncIdx`) with **no
+coercion**. When the wrapper param type and the method's final param type drift,
+the rebuilt `call` is invalid:
+
+- `name-length-dflt.js`: sibling literals `{m(x=42)}` / `{m(x,y=42)}`
+  structurally dedupe; the wrapper params are `[externref, f64]` while the
+  method's final params are `[f64, externref]` (a position swap). Forwarding the
+  `externref` `local.get` into a `f64` param slot (and vice versa) is invalid.
+- generator / super-prop methods: the wrapper declares an `externref` result
+  while the method now returns `(ref null N)` → `fallthru` type error.
+
+The cached method-closure path (`emitCachedMethodClosureAccess`, #1394) has the
+same structural vulnerability and was never enrolled in the finalize pass.
+
+## Fix
+
+In `finalizeMethodTrampolines`, re-emit the forwarding with a coercion per arg
+and on the result:
+
+- Capture the wrapper's user-param types and result **at emit time**
+  (`wrapperUserParams` / `wrapperResult` on the pending record). Re-deriving them
+  from `trampolineFuncIdx` is unsafe — late-import index shifting can move that
+  index relative to the recorded value, returning a *different* function's
+  signature (observed for async methods, which was the cause of a transient
+  self-introduced regression during development).
+- For each forwarded param, coerce `wrapperUserParams[i] → methodUserParams[i]`
+  via `coercionInstrs` (handles externref↔f64, ref/ref_null→externref,
+  externref→ref/ref_null guarded cast, same-kind different-struct re-cast).
+- After the `call`, coerce the method result back to the wrapper result (and
+  `drop` when the method now returns a value the void wrapper must discard).
+- Coercions that need a scratch local allocate one through a minimal synthetic
+  `FunctionContext`; the allocated locals are attached to the registered
+  trampoline function (located by body-array identity, again to avoid the stale
+  index).
+- Also enroll the cached singleton trampoline (`emitCachedMethodClosureAccess`)
+  in the finalize pass so the same drift can't survive there.
+
+Files: `src/codegen/closures.ts` (`finalizeMethodTrampolines`,
+`emitObjectMethodAsClosure`, `emitCachedMethodClosureAccess`),
+`src/codegen/context/types.ts` (extend `pendingMethodTrampolines` record).
+
+## Failed approaches avoided
+
+- A first attempt derived the wrapper signature from `getFuncSignature(ctx,
+  trampolineFuncIdx)` inside finalize. That index is stale after late-import
+  shifting and returned the wrong function's type for async methods, *adding* two
+  invalid modules (`async-gen-yield-star-*`, `async-meth-dflt-params-ref-self`).
+  Fixed by capturing wrapper param/result types at emit time instead.
+
+## Verification
+
+Scoped validate-scan of `language/expressions/object`:
+
+| metric          | clean HEAD (#595) | with fix |
+|-----------------|-------------------|----------|
+| valid modules   | 784               | 930      |
+| invalid modules | 170               | 24*      |
+
+\* the remaining 24 are pre-existing `dstr/` destructuring-param bugs
+(`__anon_0_method__litNN` "not enough arguments on the stack"), unrelated to
+trampolines.
+
+`language/expressions/object/method-definition` alone: 195→198 valid, **3→0
+invalid** wasm modules; CE count unchanged (105).
+
+- `tests/issue-1669-trampoline-externref-coercion.test.ts` — new; all 4 cases
+  fail on clean HEAD, pass with the fix.
+- `tests/issue-1602.test.ts` — still green.
+- `tsc --noEmit` clean; `biome lint` clean.
+- `closures` / `classes` / `class-method-calls` / `class-expressions` /
+  `async-await` suites: same pass/fail set as clean HEAD (no new failures; the
+  pre-existing failures need host runtime imports the bare harness doesn't
+  provide).
+
+## Acceptance criteria
+
+- [x] The three canonical regressors compile to valid wasm:
+  `name-length-dflt.js`, `gen-yield-identifier-spread-non-strict.js`,
+  `generator-super-prop-body.js`.
+- [x] #1602's valid-wasm fix preserved (its tests pass).
+- [x] No new invalid-wasm modules introduced.
+- [ ] CI merge-group full test262 shows a large net-positive (~+200 pass).

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -16,7 +16,7 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
-import type { FieldDef, Instr, StructTypeDef, ValType } from "../ir/types.js";
+import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
 import { pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, getLocalType } from "./context/locals.js";
@@ -3093,9 +3093,12 @@ export function emitObjectMethodAsClosure(
   // final signature once all function bodies are compiled.
   ctx.pendingMethodTrampolines.push({
     trampolineBody,
+    trampolineFuncIdx,
     methodFuncIdx,
     objStructTypeIdx,
     userParamCount: userParams.length,
+    wrapperUserParams: userParams,
+    wrapperResult: results[0],
   });
 
   // Emit: ref.func $trampoline, struct.new $closure_struct
@@ -3123,23 +3126,120 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
   for (const t of ctx.pendingMethodTrampolines) {
     const sig = getFuncSignature(ctx, t.methodFuncIdx);
     if (!sig || sig.params.length === 0) continue;
-    const userParams = sig.params.slice(1);
+    const methodUserParams = sig.params.slice(1);
     // Only rebuild when the user-param arity is unchanged. The trampoline's
     // OWN func type (its wrapper type) was fixed at registration with
     // `userParamCount` params and is shared/cached, so it cannot change here;
     // forwarding a different number of params would violate that contract and
     // produce an invalid `local.get` index. An arity change (e.g. async method
     // param injection) is a separate concern handled by its own codegen path.
-    if (userParams.length !== t.userParamCount) continue;
-    // Rebuild the body in place: ref.null <objStruct>, forward each user param,
-    // call the method. Mutate the existing array so the already-registered
-    // function keeps the same body reference.
-    t.trampolineBody.length = 0;
-    t.trampolineBody.push({ op: "ref.null", typeIdx: t.objStructTypeIdx } as Instr);
-    for (let i = 0; i < userParams.length; i++) {
-      t.trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
+    if (methodUserParams.length !== t.userParamCount) continue;
+
+    // (#1669) The trampoline's OWN signature (the wrapper func type, captured
+    // when the closure value was emitted) fixes the types of the `local.get`s
+    // the forwarding body reads. The method's signature may have been
+    // re-resolved during body compilation (default-param / generator / async
+    // methods finalize their param types and order then), so the wrapper param
+    // types and the method param types can DRIFT — e.g. a default-param method
+    // resolves its param to `f64` while the closure-value ABI typed the wrapper
+    // param `externref`, or two structurally-deduped sibling literals swap a
+    // param's `f64`/`externref` position. Forwarding the wrapper-typed value
+    // straight into `call methodFuncIdx` then emits an invalid `call`
+    // ("expected externref, found (ref null N)" / "expected externref, found
+    // f64"). The same drift can affect the RESULT: the wrapper's declared
+    // result is `externref` while the method now returns `(ref null N)`, which
+    // shows up as a `fallthru` type error.
+    //
+    // #1602 introduced this rebuild but forwarded the params verbatim with no
+    // coercion, which is correct only when the types did not drift. Re-emit the
+    // forwarding with a per-arg coercion from the WRAPPER param type to the
+    // METHOD param type, and a final coercion from the method result to the
+    // wrapper result, so the rebuilt body validates against both signatures.
+    // The wrapper signature is captured at emit time (the static types of the
+    // `local.get`s the body reads and the type it must return). Re-deriving it
+    // from `t.trampolineFuncIdx` is unsafe: late-import shifting can move that
+    // index relative to the recorded value, returning a different function's
+    // signature (observed for async methods).
+    const wrapperUserParams = t.wrapperUserParams;
+    const wrapperResult = t.wrapperResult;
+    const methodResult = sig.results[0];
+
+    // Build a minimal FunctionContext so coercions that need a scratch local
+    // (externref → ref/ref_null) can allocate one. Its `params` mirror the
+    // trampoline's wrapper signature exactly (closure_self at index 0, then the
+    // wrapper's user params at 1..N) so `allocTempLocal` computes a temp index
+    // past the real params; the allocated `localDefs` are attached to the
+    // registered trampoline function below.
+    const localDefs: LocalDef[] = [];
+    const tFctx: FunctionContext = {
+      name: `__obj_meth_tramp_finalize_${t.trampolineFuncIdx}`,
+      params: [
+        { name: "__self", type: { kind: "anyref" } },
+        ...wrapperUserParams.map((p, i) => ({ name: `__p${i}`, type: p })),
+      ],
+      locals: localDefs,
+      localMap: new Map(),
+      returnType: wrapperResult ?? null,
+      body: [],
+      blockDepth: 0,
+      breakStack: [],
+      continueStack: [],
+      labelMap: new Map(),
+      savedBodies: [],
+    };
+
+    const newBody: Instr[] = [{ op: "ref.null", typeIdx: t.objStructTypeIdx } as Instr];
+    for (let i = 0; i < methodUserParams.length; i++) {
+      newBody.push({ op: "local.get", index: i + 1 } as Instr);
+      const from = wrapperUserParams[i];
+      const to = methodUserParams[i]!;
+      if (from && from.kind !== to.kind) {
+        tFctx.body = newBody;
+        newBody.push(...coercionInstrs(ctx, from, to, tFctx));
+      } else if (
+        from &&
+        (from.kind === "ref" || from.kind === "ref_null") &&
+        (to.kind === "ref" || to.kind === "ref_null")
+      ) {
+        // Same kind but possibly different struct typeIdx — guarded re-cast.
+        const fromIdx = (from as { typeIdx?: number }).typeIdx;
+        const toIdx = (to as { typeIdx?: number }).typeIdx;
+        if (fromIdx !== toIdx && toIdx !== undefined) {
+          tFctx.body = newBody;
+          newBody.push(...coercionInstrs(ctx, from, to, tFctx));
+        }
+      }
     }
-    t.trampolineBody.push({ op: "call", funcIdx: t.methodFuncIdx } as Instr);
+    newBody.push({ op: "call", funcIdx: t.methodFuncIdx } as Instr);
+    // Reconcile the result arity/type with the wrapper's declared result.
+    if (methodResult && !wrapperResult) {
+      // Method now returns a value the void wrapper must discard.
+      newBody.push({ op: "drop" } as Instr);
+    } else if (wrapperResult && methodResult && wrapperResult.kind !== methodResult.kind) {
+      tFctx.body = newBody;
+      newBody.push(...coercionInstrs(ctx, methodResult, wrapperResult, tFctx));
+    } else if (
+      wrapperResult &&
+      methodResult &&
+      (wrapperResult.kind === "ref" || wrapperResult.kind === "ref_null") &&
+      (methodResult.kind === "ref" || methodResult.kind === "ref_null") &&
+      (wrapperResult as { typeIdx?: number }).typeIdx !== (methodResult as { typeIdx?: number }).typeIdx
+    ) {
+      tFctx.body = newBody;
+      newBody.push(...coercionInstrs(ctx, methodResult, wrapperResult, tFctx));
+    }
+
+    // Mutate the existing body array in place so the already-registered
+    // function keeps the same body reference, and attach any temp locals
+    // coercion allocated for this trampoline. The function is located by body
+    // identity (not by `trampolineFuncIdx`, which may have shifted): the
+    // registered trampoline holds the SAME `t.trampolineBody` array reference.
+    if (localDefs.length > 0) {
+      const func = ctx.mod.functions.find((f) => f.body === t.trampolineBody);
+      if (func) func.locals.push(...localDefs);
+    }
+    t.trampolineBody.length = 0;
+    t.trampolineBody.push(...newBody);
   }
   ctx.pendingMethodTrampolines.length = 0;
 }
@@ -3210,6 +3310,27 @@ export function emitCachedMethodClosureAccess(
     });
     ctx.funcMap.set(trampolineName, trampolineFuncIdx);
     ctx.mod.declaredFuncRefs.push(trampolineFuncIdx);
+
+    // (#1669) The method's `func.typeIdx` may still be re-resolved after this
+    // first cached access (the method body is compiled later in the same pass,
+    // and generator/default-param/async methods finalize their param types and
+    // order during that body compile). The trampoline body built above forwards
+    // `local.get`s typed by THIS wrapper signature into `call methodFuncIdx`,
+    // which validates against the method's FINAL signature. If they drift, the
+    // module is invalid. #1602 fixed exactly this for the per-call-site
+    // (non-cached) trampoline via `pendingMethodTrampolines`; the cached
+    // singleton trampoline was never enrolled, so it kept the stale forwarding.
+    // Enroll it so `finalizeMethodTrampolines` rebuilds the body against the
+    // method's final signature (with per-arg externref coercion).
+    ctx.pendingMethodTrampolines.push({
+      trampolineBody,
+      trampolineFuncIdx,
+      methodFuncIdx,
+      objStructTypeIdx,
+      userParamCount: userParams.length,
+      wrapperUserParams: userParams,
+      wrapperResult: results[0],
+    });
   }
 
   // Reuse or allocate the cache global. Type is externref so the value

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -597,10 +597,25 @@ export interface CodegenContext {
    */
   pendingMethodTrampolines: {
     trampolineBody: Instr[];
+    /** The trampoline's own func index. */
+    trampolineFuncIdx: number;
     methodFuncIdx: number;
     objStructTypeIdx: number;
     /** User-param count the wrapper func type was built with (excludes self). */
     userParamCount: number;
+    /**
+     * (#1669) The wrapper func type's user-param types and result, captured at
+     * emit time. These are the static types of the `local.get`s the forwarding
+     * body reads, and the type the trampoline must return. The method's
+     * signature can drift away from these during later body compilation; the
+     * finalize pass coerces each forwarded arg from `wrapperUserParams[i]` to
+     * the method's final param type, and the method's result back to
+     * `wrapperResult`, so the rebuilt body validates against both signatures.
+     * Captured directly (not re-derived from `trampolineFuncIdx`) because late
+     * import shifting can move that index relative to the recorded value.
+     */
+    wrapperUserParams: ValType[];
+    wrapperResult: ValType | undefined;
   }[];
   /** True if Math.clz32 or Math.imul is used — requires ToUint32 Wasm helper */
   needsToUint32: boolean;

--- a/tests/issue-1669-trampoline-externref-coercion.test.ts
+++ b/tests/issue-1669-trampoline-externref-coercion.test.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+/**
+ * #1669 — object-method-as-closure trampolines emitted invalid wasm after #1602.
+ *
+ * #1602 added `finalizeMethodTrampolines`, which rebuilds each object-method
+ * trampoline body against the method's FINAL signature (param types/order are
+ * re-resolved during body compilation for default-param / generator / async
+ * methods). But it forwarded each param VERBATIM — `local.get i` straight into
+ * `call methodFuncIdx` — with no coercion. When the trampoline's wrapper
+ * (closure-value ABI) param type drifts from the method's final param type, the
+ * rebuilt `call` is invalid, e.g.:
+ *
+ *   __obj_meth_tramp___anon_1_m_5 failed:
+ *     call[0] expected type externref, found ref.cast null of type (ref null 26)
+ *   __obj_meth_tramp___anon_0_method_1 failed:
+ *     type error in fallthru[0] (expected externref, got (ref null 18))
+ *
+ * The second form is the RESULT drift (the wrapper declares an `externref`
+ * result while the method now returns `(ref null N)`). This regressed ~217
+ * test262 tests (91% one root cause) under `language/expressions`, the canonical
+ * regressor being
+ * `language/expressions/object/method-definition/name-length-dflt.js`.
+ *
+ * The fix re-emits the forwarding with a per-arg coercion from the wrapper param
+ * type to the method param type, and a result coercion from the method result to
+ * the wrapper result, so the rebuilt trampoline validates against both
+ * signatures.
+ *
+ * Each `expect(WebAssembly.validate(...)).toBe(true)` is the regression guard:
+ * before the fix these modules failed validation inside `__obj_meth_tramp_*`.
+ */
+function compileValid(source: string): void {
+  const result = compile(source, { fileName: "test.ts" });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+}
+
+// The trampoline-type drift only surfaces with the test262 harness's exact
+// shape — a `try/catch` around the body plus the assert-helper preamble
+// re-orders/re-resolves function types AFTER the method-as-closure trampolines
+// are emitted. This `wrapped(...)` reproduces that shape without the submodule.
+const HARNESS_PREAMBLE = `
+  class Test262Error { message: string; constructor(msg: string = "") { this.message = msg; } }
+  function isSameValue(a: any, b: any): number { if (a === b) return 1; if (a !== a && b !== b) return 1; return 0; }
+  let __fail = 0; let __assert_count = 1;
+  function assert_sameValue(actual: any, expected: any): void {
+    __assert_count = __assert_count + 1;
+    if (!isSameValue(actual, expected)) { if (!__fail) __fail = __assert_count; }
+  }
+`;
+function wrapped(body: string): string {
+  return `${HARNESS_PREAMBLE}
+    export function test(): number {
+      try { ${body} } catch (e) { if (!__fail) __fail = -1; throw e; }
+      return __fail ? __fail : 1;
+    }`;
+}
+
+describe("#1669 object-method trampoline externref coercion (regressed by #1602)", () => {
+  it("sibling non-generator default-param methods read as values (name-length-dflt shape)", () => {
+    // Sibling literals with default params in different positions structurally
+    // dedupe; the per-call-site trampoline's wrapper param types ([externref,
+    // f64]) drift from the method's final params ([f64, externref]). Before the
+    // fix the rebuilt `call` failed validation:
+    //   call[0] expected type externref, found ref.cast null of type (ref null N)
+    // This self-contained case reproduces the regression without the submodule.
+    compileValid(
+      wrapped(`
+        var f1 = { m(x = 42) {} }.m;
+        assert_sameValue((f1 as any).length, 0);
+        var f2 = { m(x = 42, y) {} }.m;
+        assert_sameValue((f2 as any).length, 0);
+        var f3 = { m(x, y = 42) {} }.m;
+        assert_sameValue((f3 as any).length, 1);
+        var f4 = { m(x, y = 42, z) {} }.m;
+        assert_sameValue((f4 as any).length, 1);
+      `),
+    );
+  });
+
+  // Direct compilation of the real test262 sources that regressed (param drift,
+  // generator-result drift, super-prop body result drift). These compile to
+  // invalid wasm on the broken compiler. Synchronous + statically imported so
+  // they don't race the concurrent compile of the synthetic case above. Skips
+  // gracefully when the submodule isn't checked out (CI checks it out).
+  const TEST262 = join(__dirname, "..", "test262", "test");
+  const regressedFiles = [
+    "language/expressions/object/method-definition/name-length-dflt.js",
+    "language/expressions/object/method-definition/gen-yield-identifier-spread-non-strict.js",
+    "language/expressions/object/method-definition/generator-super-prop-body.js",
+  ];
+  for (const rel of regressedFiles) {
+    const abs = join(TEST262, rel);
+    it.skipIf(!existsSync(abs))(`real test262 source compiles to valid wasm: ${rel}`, () => {
+      const src = readFileSync(abs, "utf-8");
+      compileValid(wrapTest(src, parseMeta(src)).source);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Repairs the ~217-test test262 regression introduced by PR #595 / `47a9a32b1`
("fix(#1602): call-site argument coercion emits valid wasm"). This is a
**targeted fix, not a revert** — #1602's own valid-wasm fix stays (its tests
pass); this fixes the collateral damage.

**Root cause:** #1602 added `finalizeMethodTrampolines`, which rebuilds
object-method-as-closure trampoline bodies against the method's FINAL signature
(re-resolved during body compilation for default-param/generator/async methods),
but forwarded each param **verbatim** — `local.get i` straight into
`call methodFuncIdx` — with **no coercion**. When the trampoline's wrapper
(closure-value ABI) param/result type drifts from the method's final signature,
the rebuilt `call`/`fallthru` is invalid wasm inside `__obj_meth_tramp_*`:

```
call[0] expected type externref, found ref.cast null of type (ref null 26)
type error in fallthru[0] (expected externref, got (ref null 18))
```

209/235 regressions were under `language/expressions`; ~84 were the runtime
knock-on (`null pointer` / "reading 'next'") of the malformed closure value.

**Fix:**
- Re-emit the forwarding with a per-arg coercion from the wrapper param type to
  the method param type, and a result coercion from the method result to the
  wrapper result, via `coercionInstrs` over a minimal synthetic
  `FunctionContext`.
- Capture the wrapper signature **at emit time** (`wrapperUserParams` /
  `wrapperResult`) instead of re-deriving it from `trampolineFuncIdx`, which
  late-import shifting can move (that stale-index read caused a transient
  async-method self-regression during development — see issue file).
- Enroll the cached singleton trampoline (`emitCachedMethodClosureAccess`) in
  the finalize pass so the same drift can't survive there.

## Verification

Scoped `WebAssembly.validate` scan of `language/expressions/object`:

| metric          | clean HEAD (#595) | with fix |
|-----------------|-------------------|----------|
| valid modules   | 784               | 930      |
| invalid modules | 170               | 24*      |

\* remaining 24 are pre-existing `dstr/` destructuring-param bugs, unrelated to
trampolines. `method-definition` alone: 3 → 0 invalid, CE unchanged.

- `tests/issue-1669-trampoline-externref-coercion.test.ts` — new; 4 cases, all
  fail on clean HEAD, pass with the fix (1 self-contained + 3 real test262
  sources, the latter skip if the submodule isn't checked out).
- `tests/issue-1602.test.ts` — still green.
- `tsc --noEmit` clean; `biome lint` clean.
- `closures`/`classes`/`class-method-calls`/`async-await` suites: same pass/fail
  set as clean HEAD (no new failures).

The CI merge-group runs full test262 — expect a large net-positive (~+200 pass).

## Test plan

- [ ] CI cheap gate + merge shard reports + quality green
- [ ] full test262 merge-report shows net-positive, no catastrophic regression