### PR TITLE
ci(#1668): cla-check passes on non-PR events (un-wedge merge queue)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -55,27 +55,30 @@ jobs:
     # issue_comment fires on ALL issues; only run for PR comments.
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
     steps:
-      # merge_group: CLA is gated at PR submission (pull_request_target); the
-      # queue's merge-group commit has no PR author to check. Pass immediately
-      # so the required `cla-check` context reports success. (#1668)
-      - name: merge_group — CLA already enforced at PR time
-        if: github.event_name == 'merge_group'
-        run: echo "merge_group event: CLA acceptance is enforced at PR submission; nothing to gate here."
+      # Non-PR events (merge_group, and the queue's gh-readonly-queue branch
+      # activity) have no PR author to gate — CLA is enforced at PR submission
+      # via pull_request_target. Pass immediately so the required `cla-check`
+      # context reports success and the merge queue can proceed. The real CLA
+      # evaluation below runs ONLY for pull_request_target / issue_comment, so
+      # it never executes in a non-PR context (which previously errored). (#1668)
+      - name: Non-PR event — CLA enforced at PR time, pass
+        if: github.event_name != 'pull_request_target' && github.event_name != 'issue_comment'
+        run: echo "Non-PR event (${{ github.event_name }}): CLA acceptance is enforced at PR submission; nothing to gate here."
 
       # BASE checkout only (default for pull_request_target). Never the PR head.
       - uses: actions/checkout@v5
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: true
 
       - uses: actions/setup-node@v6
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
         with:
           node-version: 25
 
       - name: Evaluate / record CLA acceptance
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         env:
           # Exposed so the gate module's own fetch()-based org-membership check


### PR DESCRIPTION
## Why
The earlier #1668 fix made cla-check trigger on `merge_group` but guarded its CLA-eval steps with `!= 'merge_group'`. The merge queue's `gh-readonly-queue` branch activity surfaces as **non-merge_group** events that still have **no PR context**, so the eval steps ran and failed (`cannot iterate over null`), leaving the required `cla-check` context failed/unposted on merge-group commits — the queue stayed wedged.

## Fix
Positive allow-list: the real CLA evaluation (checkout + github-script) runs **only** on `pull_request_target` / `issue_comment`. Every other event (merge_group, queue branch activity) passes via a no-op success step, so the required `cla-check` context always reports success outside of real PRs. PR-level CLA enforcement is unchanged.

## Test plan
- [x] no trailing whitespace/tabs
- [ ] `quality`/actionlint green (validates YAML) → then admin-merge to break the deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)