### PR TITLE
fix(#1671): object-method trampoline must forward the real receiver, not a null externref (completes #1669)

### DIFF
--- a/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
+++ b/plan/issues/1666-standalone-invalid-wasm-native-string-number-lowering.md
@@ -14,6 +14,11 @@ related: [1662, 1335, 1470, 1472]
 ---
 # #1666 — `--target wasi` produces invalid (non-instantiable) Wasm for several constructs
 
+> **REVERTED by #618** (the eager `fixupModuleFuncIndices` in `addImport`
+> corrupted the default-GC trampoline path → −3,600 test262). Re-land must
+> scope the func-index fixup so it never re-shifts already-emitted bodies in
+> the default (non-standalone) path. See #1668. Status stays `ready`.
+
 ## Problem
 
 Beyond host-import leaks, the standalone audit (#1662) found a distinct

--- a/plan/issues/1669-trampoline-externref-coercion-regression.md
+++ b/plan/issues/1669-trampoline-externref-coercion-regression.md
@@ -1,7 +1,7 @@
 ---
 id: 1669
 title: "codegen: object-method trampoline forwards args without coercion → invalid wasm (regressed by #1602)"
-status: in-review
+status: done
 created: 2026-05-25
 updated: 2026-05-25
 priority: high

--- a/plan/issues/1670-atomics-illegal-cast-regression.md
+++ b/plan/issues/1670-atomics-illegal-cast-regression.md
@@ -3,7 +3,7 @@ id: 1670
 slug: atomics-illegal-cast-regression
 title: "Atomics negative tests trap with `illegal cast` (regressed by #1654 / PR #599)"
 sprint: 55
-status: in-review
+status: done
 feasibility: hard
 depends_on: []
 regressed_by: 1654

--- a/plan/issues/1671-trampoline-null-receiver-runtime.md
+++ b/plan/issues/1671-trampoline-null-receiver-runtime.md
@@ -1,0 +1,98 @@
+---
+id: 1671
+slug: trampoline-null-receiver-runtime
+title: "object-method trampoline / direct dispatch lost the real receiver → ~200 runtime null-derefs (completes #1669/#621)"
+sprint: 55
+status: in-review
+created: 2026-05-25
+updated: 2026-05-25
+priority: high
+feasibility: hard
+task_type: bugfix
+area: codegen
+language_feature: object-method-closures, destructuring-params, generators, async-generators
+goal: compiler-correctness
+related: [1669, 1602, 1557]
+---
+# #1671 — object-method dispatch lost the real receiver (empty stub method func)
+
+## Problem
+
+#621/#1669 stopped the `__obj_meth_tramp_*` trampolines from emitting INVALID
+wasm, but ~200 tests then **compiled and validated yet null-deref'd at
+RUNTIME** (~160 `null_deref` + ~15 iterator-protocol "Cannot read properties of
+null (reading 'next')"). 201/220 of the still-regressed set were under
+`language/expressions` (163 `…/object/`, 38 `…/class/`). Representative:
+`language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js`.
+
+The initial hypothesis (the trampoline pushes a null externref for `this`) was
+only a symptom-level read. The trampoline's `ref.null <objStruct>` for a method
+read *as a value* (`var f = obj.m; f()`) is actually **spec-correct** — extracted
+methods call with `this = undefined`. The real failures were **direct** calls
+`obj.method()`, which never go through the trampoline.
+
+## Root cause
+
+An object-literal method's param signature is derived in THREE places that must
+agree:
+
+1. **Canonical `funcMap` pre-registration** — `ensureStructForType` (the method pre-registration loop)
+   in `src/codegen/index.ts` (the `methodParams` loop). This is the func a
+   *direct* call `obj.method()` dispatches through.
+2. **Per-literal fork decision** — `compileObjectLiteralForStruct` in
+   `src/codegen/literals.ts` (the `newParams` loop, #1557/#1602).
+3. **Actual body compile** — `compileObjectLiteralForStruct` in `literals.ts`
+   (the `methodParams` loop, ~line 1510).
+
+The body compile (#3) routes **binding-pattern params through the externref
+destructure path** (#1151 Gap B) and widens default-init `ref` params to
+`ref_null`. The pre-registration (#1) did **neither**. So for a method with an
+array/object binding-pattern param — e.g.
+`async *method([, , ...x] = [1, 2]) {…}` — the canonical func was registered as
+`(this, (ref null vec))` while the body compiled to `(this, externref)`.
+
+That signature MISMATCH made the body-compile **fork a per-literal funcIdx**
+(#1557 path) and leave the canonical `funcMap` entry an **empty stub body**
+(`ref.null extern` for an externref result). A direct `obj.method()` dispatches
+via `funcMap` (NOT the per-literal map), so it landed on the empty stub:
+returned `null` instead of the async generator, and the test's `.next()`
+trapped. The module still VALIDATED (the stub is well-typed) — that is exactly
+why #621's valid-wasm property held while runtime broke.
+
+#1602's earlier recovery (`db494631e`) only fixed the **nullability**-insensitive
+case (`ref` vs `ref null` of the same struct typeIdx). The binding-pattern case
+diverges in `kind` (`ref_null` vs `externref`), which `refTypesMatch` cannot
+reconcile, so the spurious fork survived.
+
+## Fix
+
+Apply the SAME widening — default-init `ref→ref_null` AND binding-pattern
+`→externref` (#1151 Gap B) — at BOTH the canonical pre-registration
+(`index.ts`) and the fork-decision sig (`literals.ts` `newParams`), so all
+three sig computations agree. No spurious fork happens; the real body lands in
+the canonical func; `obj.method()` reaches it. #621/#1602's valid-wasm
+properties are preserved (their tests still pass), and genuine sibling-arity /
+genuine-type-divergence forks (#1557 Bug A, #1602 Bug B) still trigger — those
+differ in arity or in a non-binding-pattern `kind`/`typeIdx`.
+
+## Files
+
+- `src/codegen/index.ts` — `ensureStructForType` (the method pre-registration loop) pre-registration
+  param-type derivation (the `methodParams` loop).
+- `src/codegen/literals.ts` — `compileObjectLiteralForStruct` fork-decision
+  (the `newParams` loop).
+- `tests/issue-1671-trampoline-null-receiver.test.ts` — RUNTIME regression
+  tests (array/object/rest binding-pattern method dispatched directly reads
+  `this` and returns the right value; would null-deref before the fix) + the
+  real test262 async-gen-meth source running without trap.
+
+## Verification
+
+- New runtime tests pass; `tests/issue-1669-*`, `tests/issue-1602.test.ts`,
+  `tests/issue-1557.test.ts` still pass.
+- `tsc --noEmit` clean; biome introduces no new diagnostics on the edited files.
+- Scoped runs of named `language/expressions/object/dstr` + `meth-` cases
+  (`gen-meth-ary-ptrn-rest-id-direct`, `meth-ary-ptrn-elem-id-init-undef`,
+  `async-gen-meth-dflt-ary-ptrn-rest-id-exhausted`) now PASS (return 1 / no
+  trap), versus null-deref on `main` HEAD (4784639cb).
+- Expected ~+190 test262 pass — restores the ~29,600 peak (sha 65844626e).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7437,11 +7437,32 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
     if (ctx.funcMap.has(fullName)) continue; // already registered
 
     const sig = callSigs[0]!;
-    // Build parameter types: self (ref $structTypeIdx) + declared params
+    // Build parameter types: self (ref $structTypeIdx) + declared params.
+    // (#1671) This pre-registration is the CANONICAL `funcMap` entry that
+    // direct calls `obj.method()` dispatch through. Its param types MUST match
+    // what the method body actually compiles to in
+    // `compileObjectLiteralForStruct` (search "methodParams" in literals.ts) —
+    // applying the same default-init `ref→ref_null` widening AND the
+    // binding-pattern `→externref` destructure widening (#1151 Gap B).
+    // Otherwise the body-compile detects a signature mismatch, forks a
+    // per-literal funcIdx, and leaves THIS canonical func an empty stub body —
+    // so a direct `obj.method()` lands on the stub and traps
+    // ("dereferencing a null pointer" / iterator "reading 'next' of null").
     const methodParams: ValType[] = [{ kind: "ref", typeIdx }];
     for (const param of sig.parameters) {
       const paramDecl = param.valueDeclaration;
-      if (paramDecl) {
+      if (paramDecl && ts.isParameter(paramDecl)) {
+        const pt = ctx.checker.getTypeAtLocation(paramDecl);
+        let wasmType = resolveWasmType(ctx, pt);
+        if (paramDecl.initializer && wasmType.kind === "ref") {
+          wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
+        }
+        const hasBindingPattern = ts.isArrayBindingPattern(paramDecl.name) || ts.isObjectBindingPattern(paramDecl.name);
+        if (hasBindingPattern && !paramDecl.type && !paramDecl.dotDotDotToken && wasmType.kind !== "externref") {
+          wasmType = { kind: "externref" };
+        }
+        methodParams.push(wasmType);
+      } else if (paramDecl) {
         const pt = ctx.checker.getTypeAtLocation(paramDecl);
         methodParams.push(resolveWasmType(ctx, pt));
       } else {

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1093,13 +1093,31 @@ export function compileObjectLiteralForStruct(
     const existingFuncIdx = ctx.funcMap.get(fullName);
     if (existingFuncIdx === undefined) continue;
 
-    // Compute the signature this method would compile to.
+    // Compute the signature this method would compile to. This MUST mirror the
+    // body-compile param-type derivation below (search "methodParams") exactly,
+    // otherwise the fork decision diverges from reality: it would think this
+    // single-literal method's params differ from the registered func type and
+    // fork a per-literal funcIdx, orphaning the shared `funcMap` entry with an
+    // empty stub body — a *direct* call `obj.method()` (dispatched via funcMap,
+    // not the per-literal map) then lands on the empty func and traps
+    // ("dereferencing a null pointer" / iterator-protocol "reading 'next' of
+    // null"). (#1671 — completes #1669/#1602.)
     const newParams: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }];
     for (const param of prop.parameters) {
       const paramType = ctx.checker.getTypeAtLocation(param);
       let wasmType = resolveWasmType(ctx, paramType);
       if (param.initializer && wasmType.kind === "ref") {
         wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
+      }
+      // (#1671) Binding-pattern params route through the externref destructure
+      // path during body compilation (#1151 Gap B — see line ~1524). The
+      // fork-decision sig must apply the SAME widening, or
+      // `async *method([, , ...x] = […]) {}` (array binding pattern) computes
+      // `(ref null vec)` here while the real body uses `externref`, a `kind`
+      // divergence `refTypesMatch` cannot reconcile, spuriously forking.
+      const hasBindingPattern = ts.isArrayBindingPattern(param.name) || ts.isObjectBindingPattern(param.name);
+      if (hasBindingPattern && !param.type && !param.dotDotDotToken && wasmType.kind !== "externref") {
+        wasmType = { kind: "externref" };
       }
       newParams.push(wasmType);
     }

--- a/tests/issue-1671-trampoline-null-receiver.test.ts
+++ b/tests/issue-1671-trampoline-null-receiver.test.ts
@@ -1,0 +1,153 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+/**
+ * #1671 — object-method trampoline / direct dispatch lost the real receiver,
+ * leaving the canonical method func an empty stub (completes #1669/#621/#1602).
+ *
+ * Root cause: an object-literal method's param signature is computed in THREE
+ * places that must agree:
+ *
+ *   1. The canonical `funcMap` pre-registration in `index.ts`
+ *      (`ensureStructForType`, the method pre-registration loop) — the func a
+ *      *direct* call `obj.method()` dispatches through.
+ *   2. The per-literal fork decision in `literals.ts`
+ *      (`compileObjectLiteralForStruct`, the `newParams` loop).
+ *   3. The actual body compile in `literals.ts` (the `methodParams` loop).
+ *
+ * Body compile (#3) routes binding-pattern params through the externref
+ * destructure path (#1151 Gap B) and widens default-init `ref` params to
+ * `ref_null`. The pre-registration (#1) did NEITHER, so for a method with an
+ * array/object binding-pattern param (e.g. `async *method([, , ...x] = […])`)
+ * the canonical func was registered as `(this, (ref null vec))` while the body
+ * compiled to `(this, externref)`. The signature MISMATCH made the body-compile
+ * fork a *per-literal* funcIdx and leave the canonical `funcMap` entry an empty
+ * stub body (`ref.null extern` for an externref result).
+ *
+ * A direct call `obj.method()` (dispatched via funcMap, not the per-literal
+ * map) then landed on the EMPTY stub: it returned `ref.null extern` instead of
+ * the async generator, and the test's `.next()` traps with
+ * "dereferencing a null pointer" / "Cannot read properties of null (reading
+ * 'next')". The module still VALIDATED (the stub is well-typed), so #621's
+ * valid-wasm property held — but ~200 tests under language/expressions/object
+ * + class null-deref'd at RUNTIME.
+ *
+ * Fix: apply the same default-init `ref→ref_null` and binding-pattern
+ * `→externref` widening at the pre-registration and the fork-decision sig, so
+ * all three computations agree, no spurious fork happens, the real body lands
+ * in the canonical func, and `obj.method()` reaches it.
+ *
+ * These tests RUN the wasm (not just validate) — they null-deref before the
+ * fix and return the correct value after.
+ */
+
+function compileAndRun(source: string): number | undefined {
+  const result = compile(source, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = buildImports(
+    (result as unknown as { imports: unknown[] }).imports as never,
+    undefined,
+    (result as unknown as { stringPool: unknown }).stringPool as never,
+  );
+  // Use the sync Module/Instance path so the assertion stays synchronous —
+  // these modules have no start-function side effects to await.
+  const mod = new WebAssembly.Module(result.binary);
+  const instance = new WebAssembly.Instance(mod, imports as WebAssembly.Imports);
+  return (instance.exports as { test?: () => number | undefined }).test?.();
+}
+
+describe("#1671 object-method trampoline must forward the real receiver", () => {
+  it("direct call to an object method with an array-binding-pattern param reads `this` (would null-deref before fix)", () => {
+    // The array-binding-pattern param forces the method's param to externref in
+    // the body compile. Before the fix the canonical funcMap entry was a stub,
+    // so `obj.run(...)` returned undefined/null and `this.base` was never read.
+    const source = `
+      const obj = {
+        base: 100,
+        run([a, b] = [1, 2]): number {
+          return (this as any).base + a + b;
+        },
+      };
+      export function test(): number {
+        const r = obj.run([10, 20]);
+        return r === 130 ? 1 : r;
+      }
+    `;
+    expect(compileAndRun(source)).toBe(1);
+  });
+
+  it("object method with object-binding-pattern param dispatched directly returns the right value", () => {
+    const source = `
+      const obj = {
+        factor: 3,
+        scale({ v } = { v: 7 }): number {
+          return (this as any).factor * v;
+        },
+      };
+      export function test(): number {
+        const r = obj.scale({ v: 5 });
+        return r === 15 ? 1 : r;
+      }
+    `;
+    expect(compileAndRun(source)).toBe(1);
+  });
+
+  it("generator method with a binding-pattern rest param iterates correctly via direct call", () => {
+    // Mirrors the test262 async-gen-meth-dflt-ary-ptrn-rest-id-exhausted shape
+    // (sync generator variant so the assertion is synchronous): the rest
+    // binding pattern forces an externref param; the canonical func must hold
+    // the real body so `obj.gen().next()` yields, not null-deref.
+    const source = `
+      const obj = {
+        seed: 11,
+        *gen([, , ...rest] = [1, 2, 3, 4]): any {
+          yield (this as any).seed + rest.length;
+        },
+      };
+      export function test(): number {
+        const it = obj.gen();
+        const first = it.next();
+        // seed(11) + rest.length(2) = 13
+        return first.value === 13 ? 1 : first.value;
+      }
+    `;
+    expect(compileAndRun(source)).toBe(1);
+  });
+
+  // The exact test262 source that drove the investigation. It's an async
+  // generator method, so success is observed via $DONE rather than a sync
+  // return; here we assert it COMPILES + instantiates + the synchronous prefix
+  // (building the async generator + first .next()) does NOT trap. Before the
+  // fix `obj.method()` returned a null async-generator and `.next()` trapped.
+  const TEST262 = join(__dirname, "..", "test262", "test");
+  const rel = "language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js";
+  const abs = join(TEST262, rel);
+  it.skipIf(!existsSync(abs))(`real test262 source runs without null-deref: ${rel}`, () => {
+    const raw = readFileSync(abs, "utf-8");
+    const { source } = wrapTest(raw, parseMeta(raw));
+    const result = compile(source, {
+      fileName: "test.ts",
+      skipSemanticDiagnostics: true,
+    });
+    expect(result.success).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = buildImports(
+      (result as unknown as { imports: unknown[] }).imports as never,
+      undefined,
+      (result as unknown as { stringPool: unknown }).stringPool as never,
+    );
+    const mod = new WebAssembly.Module(result.binary);
+    const instance = new WebAssembly.Instance(mod, imports as WebAssembly.Imports);
+    // Must not throw "dereferencing a null pointer" — the generator + first
+    // .next() are driven synchronously inside `test()`.
+    expect(() => (instance.exports as { test?: () => unknown }).test?.()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Completes #1669/#621. #621 stopped object-method `__obj_meth_tramp_*` trampolines from emitting **invalid** wasm, but ~200 tests then **compiled + validated yet null-deref'd at RUNTIME** (~160 `null_deref` + ~15 iterator-protocol "Cannot read properties of null (reading 'next')"); 201/220 under `language/expressions/{object,class}`. Canonical regressor: `language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js`.

### Root cause (not the trampoline null `this`)

The trampoline's `ref.null <objStruct>` for a method read **as a value** (`var f = obj.m; f()`) is spec-correct — an extracted method calls with `this = undefined`. The real failures were **direct** calls `obj.method()`, which never use the trampoline.

An object-literal method's param signature is derived in **three** places that must agree:

1. **Canonical `funcMap` pre-registration** — `ensureStructForType` in `src/codegen/index.ts` (the func a direct `obj.method()` dispatches through).
2. **Per-literal fork decision** — `compileObjectLiteralForStruct` in `src/codegen/literals.ts` (the `newParams` loop, #1557/#1602).
3. **Body compile** — `compileObjectLiteralForStruct` in `literals.ts` (the `methodParams` loop).

Body compile (#3) routes **binding-pattern params through the externref destructure path** (#1151 Gap B) and widens default-init `ref`→`ref_null`. The pre-registration (#1) did **neither**, so `async *method([, , ...x] = […])` registered the canonical func as `(this, (ref null vec))` while the body compiled to `(this, externref)`. That mismatch forked a **per-literal funcIdx** and left the canonical `funcMap` entry an **empty stub body** (`ref.null extern`). A direct `obj.method()` dispatches via `funcMap` (not the per-literal map), landing on the stub → returned null → `.next()` trapped. The module still **validated** (the stub is well-typed) — exactly why #621's valid-wasm property held while runtime broke. #1602's recovery only reconciled `ref`/`ref_null` nullability; the binding-pattern case diverges in `kind` (`ref_null` vs `externref`), which `refTypesMatch` can't reconcile.

### Fix

Apply the same default-init `ref→ref_null` **and** binding-pattern `→externref` widening at BOTH the pre-registration (`index.ts`) and the fork-decision sig (`literals.ts` `newParams`), so all three sig computations agree. No spurious fork; the real body lands in the canonical func; `obj.method()` reaches it. #621/#1602 valid-wasm properties preserved (their tests pass); genuine sibling-arity / type-divergence forks (#1557 Bug A, #1602 Bug B) still trigger.

Expected ~+190 test262 pass — should restore the ~29,600 peak (sha 65844626e).

## Test plan

- [x] New `tests/issue-1671-*.test.ts` RUNTIME tests (array/object/rest binding-pattern method dispatched directly reads `this` and returns the right value; null-deref before fix) + real test262 async-gen-meth source runs without trap
- [x] `tests/issue-1669-*`, `tests/issue-1602.test.ts`, `tests/issue-1557.test.ts` still green
- [x] `tsc --noEmit` clean; no new biome diagnostics on edited files
- [x] Scoped: `gen-meth-ary-ptrn-rest-id-direct`, `meth-ary-ptrn-elem-id-init-undef`, `async-gen-meth-dflt-ary-ptrn-rest-id-exhausted` now PASS (vs null-deref on main HEAD 4784639cb)
- [ ] CI full test262 shards green + net strongly positive

Also reconciles issue status (plan/ only): #1669 → done (PR #621), #1670 → done (PR #620), #1666 revert note (reverted by #618; status stays `ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)