### PR TITLE
docs(landing): flag early-prototype status + one module-size example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC.
 
+> **Status: early-stage research prototype — a tech demo, not a production-ready compiler.** This is an experimental project under active development. Expect rough edges, incomplete language/standard-library coverage, and breaking changes. It is not yet suitable for production use.
+
 `js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That removes the runtime tax common in interpreter-in-Wasm and bundled-engine stacks, where interpreters often land in the high-hundreds-of-kilobytes range and full-fledged JavaScript engines in the megabytes, and keeps the output aligned with Wasm-native deployment models.
 
 `js2wasm` is the core compiler product of **Loopdive GmbH**, released under **Apache License 2.0 with LLVM Exceptions** — and developed fully in the open, including its agentic engineering workflow. The repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.

--- a/index.html
+++ b/index.html
@@ -1457,8 +1457,9 @@
           <p class="hero-sub">
             JS
             <sup>2</sup>
-            is a research preview of an open source compiler focused on compiling JavaScript to WebAssembly ahead of
-            time, developed at Loopdive.
+            is an <strong>early-stage research prototype</strong> &mdash; a technical demo exploring ahead-of-time
+            compilation of JavaScript to WebAssembly, developed at Loopdive. It is <strong>not a production-ready
+            compiler</strong>; expect rough edges, missing features, and breaking changes.
           </p>
           <div class="hero-actions">
             <a class="btn-solid" href="./playground/">Playground</a>
@@ -3536,51 +3537,6 @@ export function run(n) {
                   benchmark="fib"
                   mode="absolute-lower-better"
                   title="Fibonacci loop"
-                  baseline-label="JS"
-                  show-delta
-                  delta-kind="factor"
-                ></perf-benchmark-chart>
-              </div>
-              <div
-                class="diagram-panel"
-                data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                style="display: none"
-              >
-                <perf-benchmark-chart
-                  src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                  benchmark="fib-recursive"
-                  mode="absolute-lower-better"
-                  title="Fibonacci recursion"
-                  baseline-label="JS"
-                  show-delta
-                  delta-kind="factor"
-                ></perf-benchmark-chart>
-              </div>
-              <div
-                class="diagram-panel"
-                data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                style="display: none"
-              >
-                <perf-benchmark-chart
-                  src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                  benchmark="array-sum"
-                  mode="absolute-lower-better"
-                  title="Array fill + sum"
-                  baseline-label="JS"
-                  show-delta
-                  delta-kind="factor"
-                ></perf-benchmark-chart>
-              </div>
-              <div
-                class="diagram-panel"
-                data-benchmark-src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                style="display: none"
-              >
-                <perf-benchmark-chart
-                  src="./benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"
-                  benchmark="string-hash"
-                  mode="absolute-lower-better"
-                  title="String build + hash"
                   baseline-label="JS"
                   show-delta
                   delta-kind="factor"


### PR DESCRIPTION
## Changes
- **Early-prototype disclaimer** added up front on the landing page hero and the README: states clearly this is an early-stage research prototype / tech demo, **not a production-ready compiler** (rough edges, missing features, breaking changes expected).
- **Module-size benchmark** section trimmed from four near-identical example charts (fib, fib-recursive, array-sum, string-hash) to a single representative one (Fibonacci loop) — the others were redundant.

Docs/landing only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)