### PR TITLE
docs: harden public-facing positioning for announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ Projects in this category usually take years to reach meaningful semantic covera
 Current Test262 conformance and benchmark numbers are tracked in one place and
 change frequently — see **[STATUS.md](./STATUS.md)** for the live figures, the
 [Playground](https://loopdive.github.io/js2wasm/playground/), and the
-[Roadmap](./ROADMAP.md).
+[Roadmap](./ROADMAP.md). The single auto-updated conformance figure (refreshed
+by CI on every merge) is below; everything else links to STATUS.md rather than
+duplicating numbers that go stale.
+
+<!-- AUTO:conformance-start -->
+**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
+<!-- AUTO:conformance-end -->
 
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,62 @@ or open an issue. This is an actively developed compiler with a growing
 compatibility baseline and a clear infrastructure target — but it is a research
 prototype, not yet a "drop in any npm package" story.
 
+## FAQ
+
+**Why not embed an existing interpreter or engine?**
+That is the interpreter-based / engine-embedding approach, and it is a perfectly
+reasonable way to get compatibility — but every deployed module then ships and
+initializes a runtime, which is exactly the size and startup cost `js2wasm` is
+trying to avoid. The bet here is that *compiling* the code, rather than shipping
+something to run it, is worth pursuing for size- and cold-start-sensitive
+deployments. Whether that bet holds across enough real code is the open
+question.
+
+**Isn't the Test262 conformance still incomplete?**
+Yes, and the live figure is in [STATUS.md](./STATUS.md) and the
+[Test262 report](./benchmarks/results/report.html) rather than rounded up here.
+Two caveats matter more than the number: Test262 measures the ECMAScript
+*language* spec, **not** Web APIs, host/Node.js behavior, or whether an arbitrary
+npm package runs unchanged; and the standalone (no-JS-host) path is less complete
+than the JS-host path. A high pass rate is necessary but not sufficient for "runs
+real JavaScript."
+
+**Won't you eventually re-implement a JavaScript engine?**
+That is the real risk, treated as an empirical question, not a solved one. The
+design is compiled-code-first: resolve what can be resolved statically and lower
+it directly, with no interpreter on the common paths. The genuinely unstatic
+corners (`eval`, dynamic `Function`) would need a small interpreter fallback that
+runs only on those paths — not a full engine in every module. Whether that
+fallback stays small, and how much real code avoids it, is what the prototype is
+testing. If compatibility turns out to require shipping an engine, that is a
+negative result worth knowing.
+
+**Why not extend an existing typed JS/TS subset language?**
+Typed JS/TS subset languages produce small, fast Wasm *because* they deliberately
+exclude full ECMAScript — dynamic semantics are dropped by design and the static
+type system is the contract. Extending one toward full backwards compatibility
+means re-adding the dynamics it was built to avoid. `js2wasm` instead targets
+existing JavaScript semantics directly, so existing code is the input rather than
+a rewrite into a new dialect.
+
+**Why WasmGC rather than linear memory?**
+WasmGC gives the compiler host-managed structs, arrays, references, and function
+references, which map onto JavaScript objects, closures, and arrays fairly
+directly and let the host GC manage memory instead of shipping a collector inside
+the module. Linear-memory AOT compilation is a legitimate alternative with its
+own trade-offs (more control, broader runtime support today, but a self-managed
+heap); `js2wasm` keeps a linear-memory backend for WASI-oriented targets, so this
+is a per-target choice rather than a one-way bet. See the
+[ADRs](./docs/adr/README.md) for the reasoning.
+
+**What is the realistic timeline to production-ready?**
+Unknown. This is research-stage work, and a firm date would be a guess dressed up
+as a commitment. The viability of the core bet — full ECMAScript backwards
+compatibility, AOT-compiled to WasmGC, no bundled runtime — is still being
+established. The conformance and benchmark trends are public so progress can be
+judged from data. Until they say otherwise, treat it as something to evaluate,
+not to deploy.
+
 ## The Methodology
 
 Loopdive develops `js2wasm` with an **Automated Agile Team** model. The goal is not novelty for its own sake. The goal is to compress the feedback loop between product intent, compiler implementation, and conformance verification.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC.
 
-> **Status: early-stage research prototype — a tech demo, not a production-ready compiler.** This is an experimental project under active development. Expect rough edges, incomplete language/standard-library coverage, and breaking changes. It is not yet suitable for production use.
+> **Status: early-stage research prototype — a tech demo, not a production-ready compiler.**
+> `js2wasm` is an experimental ahead-of-time JavaScript/TypeScript-to-WasmGC compiler under active development. It explores one specific point in the design space: full ECMAScript backwards compatibility via direct AOT compilation, with no JavaScript engine or interpreter bundled into the output. It does **not** claim production readiness, full language coverage, or stable APIs — expect rough edges, gaps, and breaking changes. Live conformance and benchmark figures are in **[STATUS.md](./STATUS.md)** (numbers change frequently and are not duplicated in this README).
 
 `js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That avoids the runtime tax common in the interpreter-based and engine-embedding approaches — where a JavaScript interpreter or full engine is compiled to Wasm and shipped inside every module — and keeps the output aligned with Wasm-native deployment models.
 

--- a/README.md
+++ b/README.md
@@ -68,66 +68,58 @@ standalone path are all still hardening. What exists today:
 
 Treat it as a tech demo to evaluate the approach, not as something to deploy.
 
-## How It Compares
+## The AOT JavaScript compilation landscape
 
-Most JavaScript-on-Wasm approaches fit into one of four broad categories:
+There are several established ways to get JavaScript running on WebAssembly.
+Each makes a different, reasonable trade-off, and most have years of engineering
+behind them. The point of this map is not to rank them — it is to locate the
+specific gap `js2wasm` is exploring. Described by architecture rather than by
+product:
 
-1. bundled JavaScript interpreters,
-2. bundled JavaScript engines,
-3. incompatible JavaScript or TypeScript subsets, supersets, and new languages,
-4. direct AOT compilation of JavaScript semantics to WasmGC.
+- **Interpreter-based approach** — compile a JavaScript *interpreter* to Wasm
+  and run the user's program on top of it. Gets broad ECMAScript compatibility
+  more or less for free, because a real interpreter is doing the work. The cost:
+  every deployed module ships and initializes the interpreter, which adds size
+  and startup overhead and means application code runs interpreted rather than
+  compiled.
 
-`js2wasm` is in the fourth category.
+- **Engine-embedding approach** — compile a full production JavaScript *engine*
+  to Wasm (optionally specialized per-script, e.g. via partial evaluation).
+  Inherits mature, battle-tested engine semantics and very high compatibility.
+  The cost: the engine is large, and even when specialized the engine itself is
+  still part of what ships.
 
-Bundled-runtime approaches inherit compatibility from an interpreter or engine,
-but every deployed module pays for that runtime. Subset, superset, and
-new-language approaches can generate compact Wasm by changing the language
-contract.
+- **Typed JS/TS subset languages** — a statically typed language with
+  JavaScript-like or TypeScript-like syntax that compiles ahead of time to
+  compact Wasm. Output is small and fast precisely *because* it deliberately
+  does **not** accept full ECMAScript: dynamic semantics are excluded by design
+  and the type system is the contract. Excellent when you can write to that
+  language; not a path to running existing JavaScript unchanged.
 
-`js2wasm` is aimed at a different target: **JavaScript semantics without
-shipping a JavaScript engine or interpreter inside the deployed artifact**.
-Where the compiler can prove stable types and shapes, it lowers them directly to
-WasmGC structs, arrays, primitives, and functions. Where JavaScript remains
-dynamic, it inserts guards, uses dynamic representations, or delegates at host
-boundaries.
+- **Linear-memory AOT compilers** — compile JavaScript ahead of time to Wasm
+  using linear memory, implementing object model, allocation, and (typically) a
+  garbage collector inside the module. This shares the "compile, don't embed a
+  runtime" goal; the distinguishing axis from `js2wasm` is the lowering target
+  (linear memory and a self-managed heap vs. host-managed WasmGC) and, in
+  current projects, how much of full ECMAScript compatibility is an explicit
+  goal.
 
-### How does this compare to specific projects?
+**Where `js2wasm` sits.** Direct AOT compilation to **WasmGC** (objects,
+closures, and arrays lower to host-managed GC structs/arrays/references), with
+**full ECMAScript backwards compatibility as the explicit goal**, and **no
+JavaScript engine or interpreter bundled into the output**. Where the compiler
+can prove stable types and shapes it lowers them directly; where JavaScript
+stays dynamic it inserts guards, boxed representations, or host fallbacks.
 
-These projects share parts of the design space with `js2wasm` and each makes a
-different, reasonable trade-off:
-
-- **[AssemblyScript](https://www.assemblyscript.org/)** — a well-engineered
-  compiler for a TypeScript-*like* language with its own stricter type system,
-  lowering to compact Wasm via Binaryen. It achieves small output by defining a
-  new language contract rather than accepting mainstream JavaScript semantics.
-  `js2wasm` targets existing TypeScript/JavaScript semantics directly, which is
-  a harder compatibility goal; AssemblyScript is the better fit when you can
-  write to its language and want maximally lean output.
-
-- **[Javy](https://github.com/bytecodealliance/javy)** — embeds the QuickJS
-  interpreter inside the Wasm module and runs your JS on top of it. That
-  inherits broad JavaScript compatibility immediately, at the cost of shipping
-  and initializing an interpreter in every module. `js2wasm` instead compiles
-  the code ahead-of-time with no embedded interpreter, trading some
-  compatibility for a smaller, engine-free artifact.
-
-- **[Porffor](https://porffor.dev/)** — like `js2wasm`, an ahead-of-time
-  JavaScript-to-Wasm compiler aiming at real JS semantics rather than a subset,
-  which puts it in the same fourth category. It is an early-stage project that
-  lowers to linear memory; `js2wasm` lowers to WasmGC, leaning on the host
-  garbage collector for objects, closures, and arrays. The two are close
-  neighbors exploring different lowering strategies for the same hard target.
-
-- **StarlingMonkey + [weval](https://github.com/bytecodealliance/weval)** —
-  StarlingMonkey is a WASI-oriented build of the SpiderMonkey engine; weval
-  applies Wasm partial evaluation (a Futamura projection) to specialize the
-  engine for a given script, reducing interpreter overhead. This is a
-  bundled-engine approach made faster through specialization, so it keeps full
-  engine compatibility while still shipping the engine. `js2wasm` avoids
-  bundling an engine at all, accepting a narrower compatibility surface in
-  exchange.
-
-For a more detailed category-level comparison, see the [FAQ](./docs/faq.md).
+The structural observation behind the project is that this *combination* of
+trade-offs is largely unoccupied: the typed-subset languages excluded full
+ECMAScript compatibility on purpose; the linear-memory AOT compilers do not
+currently center it; and the interpreter-based and engine-embedding approaches
+reach compatibility only by shipping a runtime (paying in size and startup).
+Targeting WasmGC + full backwards compatibility + no bundled runtime is a point
+that has not been seriously attempted. `js2wasm` is testing whether it is
+viable — that is an open question, not a settled result, and the honest answer
+today is "we don't know yet."
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC.
 
 > **Status: early-stage research prototype — a tech demo, not a production-ready compiler.** This is an experimental project under active development. Expect rough edges, incomplete language/standard-library coverage, and breaking changes. It is not yet suitable for production use.
 
-`js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That removes the runtime tax common in interpreter-in-Wasm and bundled-engine stacks, where interpreters often land in the high-hundreds-of-kilobytes range and full-fledged JavaScript engines in the megabytes, and keeps the output aligned with Wasm-native deployment models.
+`js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That avoids the runtime tax common in the interpreter-based and engine-embedding approaches — where a JavaScript interpreter or full engine is compiled to Wasm and shipped inside every module — and keeps the output aligned with Wasm-native deployment models.
 
 `js2wasm` is the core compiler product of **Loopdive GmbH**, released under **Apache License 2.0 with LLVM Exceptions** — and developed fully in the open, including its agentic engineering workflow. The repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.
 
@@ -35,7 +35,7 @@ It also matters for security boundaries. In browsers, Node.js, and other JavaScr
 
 That includes practical combinations with hosts like Tauri, where compiler output can be shipped as executable Wasm artifacts instead of bundling a full browser-plus-JS-engine runtime into the application.
 
-The current public benchmark and conformance work is aimed at proving that direct compilation can become a viable alternative to interpreter bundling for production infrastructure.
+The current public benchmark and conformance work exists to test an open question: whether direct AOT compilation can become a viable alternative to bundling a runtime for these workloads. That has not been settled yet — it is what the project is investigating.
 
 Many alternatives in adjacent spaces solve the problem by narrowing the language instead:
 
@@ -46,24 +46,26 @@ Many alternatives in adjacent spaces solve the problem by narrowing the language
 
 Projects in this category usually take years to reach meaningful semantic coverage. A large part of the Loopdive thesis is that an AI-native compiler workflow can compress that timeline substantially without giving up on the harder target.
 
-Current public milestone:
-
-<!-- AUTO:conformance-start -->
-**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
-<!-- AUTO:conformance-end -->
-
-See the [Playground](https://loopdive.github.io/js2wasm/playground/) and [Roadmap](./ROADMAP.md) for the current public surface.
+Current Test262 conformance and benchmark numbers are tracked in one place and
+change frequently — see **[STATUS.md](./STATUS.md)** for the live figures, the
+[Playground](https://loopdive.github.io/js2wasm/playground/), and the
+[Roadmap](./ROADMAP.md).
 
 ## Current Status
 
-`js2wasm` is still an active compiler effort, but it is no longer just a research prototype. The project now has:
+`js2wasm` is an early-stage research prototype: an experimental compiler under
+active development, not a production-ready tool. It is being explored as a
+public, in-the-open project, and the conformance story, runtime boundary, and
+standalone path are all still hardening. What exists today:
 
-- **~60% Test262 compliance**
+- a JS-hosted compilation path passing a substantial subset of Test262 (see
+  [STATUS.md](./STATUS.md) for the current figure)
 - a public browser playground
-- ongoing benchmark and compatibility reporting
-- both JS-hosted and standalone-oriented compiler work, with standalone support still in progress and not yet the primary conformance path
+- continuous conformance and benchmark reporting on every change
+- a standalone (no-JS-host) path that is in progress and not yet the primary
+  conformance target
 
-The project is being positioned for a community-first release while the compiler, runtime boundary, and conformance story continue to harden.
+Treat it as a tech demo to evaluate the approach, not as something to deploy.
 
 ## How It Compares
 
@@ -239,11 +241,14 @@ output, see [docs/standalone-io.md](./docs/standalone-io.md).
 
 ## Current coverage and limitations
 
-`js2wasm` passes roughly two-thirds of Test262 in a JS host (see the conformance
-figure above and the full [Test262 report](./benchmarks/results/report.html)).
-That means a large, useful subset of the language works — but there are real
-gaps, and you will hit them. This section is the honest high-level shape; the
-report is the authoritative per-feature detail.
+In a JS host, `js2wasm` passes a substantial subset of Test262 — enough that a
+large, useful slice of the language works — but there are real gaps, and you
+will hit them. The current pass rate lives in [STATUS.md](./STATUS.md) and the
+full [Test262 report](./benchmarks/results/report.html); this section is the
+qualitative high-level shape, and the report is the authoritative per-feature
+detail. Note that Test262 measures conformance to the ECMAScript *language*
+specification — it does not cover Web APIs, Node.js host behavior, or whether an
+arbitrary real-world npm package runs unchanged.
 
 **Solid** (broadly works):
 
@@ -272,9 +277,9 @@ report is the authoritative per-feature detail.
 - dropping in an arbitrary npm package unchanged
 
 If a pattern you rely on does not work, check the [Test262 report](./benchmarks/results/report.html)
-or open an issue. This is a serious compiler with a growing compatibility
-baseline and a clear infrastructure target — not yet a "drop in any npm package"
-story.
+or open an issue. This is an actively developed compiler with a growing
+compatibility baseline and a clear infrastructure target — but it is a research
+prototype, not yet a "drop in any npm package" story.
 
 ## The Methodology
 
@@ -290,11 +295,11 @@ Loopdive develops `js2wasm` with an **Automated Agile Team** model. The goal is 
 
 ### Why It Matters
 
-This model is designed around one claim:
+This model is a bet that a tight, automated feedback loop lets a small team
+iterate on a hard compatibility target faster than a conventional one would.
+Whether that bet pays off is part of what this prototype is testing.
 
-**Velocity is our moat.**
-
-The project is optimized for:
+The workflow is optimized for:
 
 - short implementation-to-validation cycles
 - continuous spec-aligned compiler iteration

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,94 @@
+# Project status
+
+**Stage: early-stage research prototype / technical demo.** `js2wasm` is an
+experimental ahead-of-time compiler from JavaScript and TypeScript to
+WebAssembly GC. It is under active development, has incomplete language and
+standard-library coverage, known bugs, and breaking changes between versions.
+It is not production-ready and should be treated as something to evaluate and
+experiment with, not to deploy.
+
+This file is the single place that points at the **live** conformance and
+benchmark numbers. The numbers themselves change on every push to `main`, so
+they are not frozen into prose anywhere in the repo — follow the links below
+for current figures.
+
+## Where the live numbers live
+
+| What | Live source |
+|------|-------------|
+| Test262 pass rate (overall + per category/edition) | The conformance dashboard on the [landing page](https://loopdive.github.io/js2wasm/) and the [Test262 report](https://loopdive.github.io/js2wasm/benchmarks/report.html). The underlying data is published to the [`loopdive/js2wasm-baselines`](https://github.com/loopdive/js2wasm-baselines) repo (`test262-current.json`) and refreshed by CI on every merge. |
+| Module size & cold-start characteristics | The benchmark charts on the [landing page](https://loopdive.github.io/js2wasm/) (size and cold-start panels), regenerated from `benchmarks/results/` on every merge. |
+| Per-feature support detail | The feature tables and [Test262 report](https://loopdive.github.io/js2wasm/benchmarks/report.html), which break results down by language feature and edition. |
+
+If a number you see quoted elsewhere disagrees with these sources, the live
+sources win.
+
+## What Test262 does and does not measure
+
+Test262 is the official conformance suite for the **ECMAScript language
+specification**. A pass rate against it measures how much of the standardized
+*language* — syntax, semantics, built-in objects defined by ECMA-262 — the
+compiler implements correctly.
+
+It does **not** measure:
+
+- **Web APIs** (DOM, `fetch`, timers, etc.) — those are host platform APIs, not
+  part of ECMAScript.
+- **Node.js / host runtime behavior** — filesystem, process, networking, and
+  other host surfaces.
+- **Whether an arbitrary real-world npm package runs unchanged** — that depends
+  on the union of language features, host APIs, and package-specific
+  assumptions a given package happens to use.
+
+So a high Test262 pass rate is necessary but not sufficient for "runs real-world
+JavaScript." Treat the Test262 figure as a language-conformance signal, not a
+drop-in-compatibility guarantee.
+
+## What works today (high-level shape)
+
+This is the qualitative shape only; the per-feature detail and current pass
+rates live in the sources linked above.
+
+**Broadly works:**
+
+- arithmetic, comparison, and scalar operations
+- functions, closures, recursion, and most control-flow forms
+- classes, inheritance, methods, and object operations
+- arrays and array methods, destructuring, spread, template literals
+- strings and common string methods
+- `try` / `catch` / `finally` and `throw`
+- `async` / `await`, generators, and iterators
+
+**Partial (common cases work, with gaps):**
+
+- standard-library built-ins — many implemented, but not the full surface
+- `Map`, `Set`, `RegExp`, `JSON` — present but not fully spec-complete
+- standalone (no-JS-host) mode — actively in progress; conformance there is
+  lower than the JS-host path and it is not yet the primary target
+- getters/setters and other highly dynamic patterns — limited
+
+**Not supported today (intentionally out of scope or not yet implemented):**
+
+- `eval`, `with`, and dynamic `Function` construction (a small interpreter
+  fallback for these is an open research direction, not a shipped feature)
+- `Proxy` / `Reflect`-driven metaprogramming
+- `SharedArrayBuffer` / threads, `WeakRef` / `FinalizationRegistry`, `Temporal`
+- dropping in an arbitrary npm package unchanged
+
+## Output characteristics
+
+`js2wasm` emits WasmGC modules with no embedded JavaScript interpreter or engine
+in the output. Because there is no bundled runtime, modules are small relative
+to interpreter-based and engine-embedding approaches, and there is no
+runtime-initialization step before application code can run. The compiled
+output uses several post-MVP WebAssembly proposals (GC, typed function
+references, exception handling, tail calls); see the README for the exact host
+flags and minimum runtime versions. Current measured sizes and cold-start times
+for representative examples are on the landing-page benchmark panels linked
+above.
+
+---
+
+_This document is intentionally qualitative. For any specific number, follow the
+links to the live sources — they are authoritative and current; this page is
+not._

--- a/index.html
+++ b/index.html
@@ -3863,6 +3863,77 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
             <details>
               <summary>
+                <span class="approach-faq-question">Isn't the Test262 conformance still incomplete?</span>
+              </summary>
+              <div class="approach-faq-answer">
+                <p>
+                  Yes &mdash; and the live figures are published openly on the
+                  <a href="#goals">compatibility</a>
+                  page rather than rounded up in prose. Two honest caveats matter more than the headline number. First,
+                  Test262 measures conformance to the ECMAScript
+                  <em>language</em>
+                  specification; it does
+                  <strong>not</strong>
+                  cover Web APIs, Node.js or other host behavior, or whether an arbitrary real-world npm package runs
+                  unchanged. A high pass rate is necessary but not sufficient for &ldquo;runs real JavaScript.&rdquo;
+                  Second, the standalone (no-JS-host) path is less complete than the JS-host path. Check the per-feature
+                  report before relying on anything specific.
+                </p>
+              </div>
+            </details>
+            <details>
+              <summary>
+                <span class="approach-faq-question">Won't you eventually end up re-implementing a JavaScript engine?</span>
+              </summary>
+              <div class="approach-faq-answer">
+                <p>
+                  That is the real risk, and we treat it as an open empirical question rather than a solved one. The
+                  approach is compiled-code-first: resolve as much as possible statically and lower it directly, so the
+                  common paths carry no interpreter. The genuinely unstatic corners of the language &mdash;
+                  <code>eval</code>
+                  and dynamic
+                  <code>Function</code>
+                  construction &mdash; would need a small interpreter fallback that runs only on those paths, not a full
+                  engine in every module. Whether that fallback can stay small while the rest is compiled, and how much
+                  real code can avoid it, is precisely what the prototype is testing. If it turns out the only way to be
+                  compatible is to ship an engine, that would be a negative result worth knowing.
+                </p>
+              </div>
+            </details>
+            <details>
+              <summary>
+                <span class="approach-faq-question">Why not just extend an existing typed JavaScript/TypeScript subset language?</span>
+              </summary>
+              <div class="approach-faq-answer">
+                <p>
+                  Typed JS/TS subset languages compile to small, fast Wasm precisely
+                  <em>because</em>
+                  they deliberately exclude full ECMAScript: dynamic semantics are dropped by design and the static type
+                  system becomes the contract. That is a sound engineering choice, but it is a different goal. Extending
+                  one toward full backwards compatibility would mean re-adding the dynamic semantics it was built to
+                  avoid &mdash; you would be fighting the language's own design. We are targeting existing JavaScript
+                  semantics as the north star instead, so that existing code and npm packages are the input, not a
+                  rewrite into a new dialect.
+                </p>
+              </div>
+            </details>
+            <details>
+              <summary>
+                <span class="approach-faq-question">What is the realistic timeline to production-ready?</span>
+              </summary>
+              <div class="approach-faq-answer">
+                <p>
+                  Honestly: unknown. This is research-stage work, and a credible production date would be a guess
+                  dressed up as a commitment. The viability of the core bet &mdash; full ECMAScript backwards
+                  compatibility, AOT-compiled to WasmGC, with no bundled runtime &mdash; is still being established. The
+                  conformance and benchmark trends are public so progress can be judged from data rather than promises.
+                  Until those tell a clearly different story, treat the project as something to evaluate and experiment
+                  with, not to deploy.
+                </p>
+              </div>
+            </details>
+            <details>
+              <summary>
                 <span class="approach-faq-question">Do you plan to support all dynamic parts of the language?</span>
               </summary>
               <div class="approach-faq-answer">

--- a/index.html
+++ b/index.html
@@ -3250,9 +3250,9 @@ match (value) {
             <strong>JS in V8</strong>
             (Ignition → Liftoff → TurboFan, all at request time, the implicit 1.0× baseline),
             <strong>Interpreter</strong>
-            (a per-function tiny module — ~3 kB — delegating to a preloaded QuickJS-style plugin), and
+            (a per-function tiny module delegating to a preloaded embedded-interpreter plugin), and
             <strong>Engine</strong>
-            (a full JS engine bundled inside Wasm with AOT pre-init — ~14 MB per function). Two scenarios per program:
+            (a full JS engine bundled inside Wasm with AOT pre-init — multiple megabytes per function). Two scenarios per program:
             fresh instance per request (cold) and reused instance (warm). Interpreter and Engine both run a JS
             interpreter inside Wasm — the size and per-call cost tradeoff isn't free. One chart per benchmark; each
             chart shows AOT vs Interpreter vs Engine for both scenarios.

--- a/index.html
+++ b/index.html
@@ -1458,7 +1458,10 @@
             JS
             <sup>2</sup>
             is a research preview of an open source compiler focused on compiling JavaScript to WebAssembly ahead of
-            time, developed at Loopdive.
+            time, developed at Loopdive. It is an early-stage research prototype and technical demo — not a
+            production-ready compiler. Live conformance figures are on the
+            <a href="#goals">compatibility</a>
+            page.
           </p>
           <div class="hero-actions">
             <a class="btn-solid" href="./playground/">Playground</a>

--- a/index.html
+++ b/index.html
@@ -1446,7 +1446,7 @@
           <img class="hero-logo" src="./js2logo-squaring-the-circle-white.svg" alt="JS2 logo" />
           <h1
             id="hero-title"
-            data-texts='["A next generation JavaScript compiler.", "Compile JavaScript without embedding a JS engine.",
+            data-texts='["An ahead-of-time JavaScript compiler.", "Compile JavaScript without embedding a JS engine.",
             "JavaScript compiled ahead of time, for fast cold starts and speed.", "Reduce supply chain attack surface with module sandboxing.", "Target existing Javascript code, not a new language."]'
           >
             <span class="hero-title-shell">
@@ -1471,7 +1471,7 @@
 
       <section class="section-pad" id="mission">
         <div class="intro">
-          <h2>Mission: Next generation JavaScript.</h2>
+          <h2>Mission: JavaScript, compiled.</h2>
           <p>
             <strong>This is an early-stage research prototype and technical demo, not a production-ready compiler.</strong>
             Expect rough edges, incomplete language and standard-library coverage, and breaking changes between versions.
@@ -1483,8 +1483,8 @@
           </p>
           <p>
             The project is motivated by the idea that JavaScript, despite being a dynamic language, can be compiled
-            efficiently ahead of time without limiting it to an incompatible subset or shipping a full JS runtime like
-            V8, SpiderMonkey or JavaScriptCore.
+            efficiently ahead of time without limiting it to an incompatible subset or shipping a full JS engine
+            inside every module. Whether that idea holds up at scale is an open question the project is testing.
           </p>
           <p>The project is guided by the following goals:</p>
         </div>
@@ -3752,11 +3752,11 @@ console.log(instance.exports.run()); // &rarr; 55</pre
               </summary>
               <div class="approach-faq-answer">
                 <p>
-                  Good question! JavaScript engines like V8 are highly optimized multi-tier streaming JIT compilers that
-                  often run code two magnitudes faster than interpreters - within reach of native performance - and have
-                  a mature battle tested sandbox. WebAssembly has an edge in some scenarios, but overall it is not
-                  always faster or even on par. Interpreters like QuickJS on the other hand trade simplicity for
-                  performance.
+                  Good question! Large production JavaScript engines are highly optimized multi-tier streaming JIT
+                  compilers that often run code orders of magnitude faster than an interpreter - within reach of native
+                  performance - and have mature, battle-tested sandboxes. WebAssembly has an edge in some scenarios, but
+                  overall it is not always faster or even on par. Embedded JavaScript interpreters, on the other hand,
+                  trade peak performance for a small, portable footprint.
                 </p>
                 <h3>Runtime overhead</h3>
                 <p>


### PR DESCRIPTION
## Summary

Make the homepage (`index.html`) and `README.md` defensible before a broader
announcement (HN/Reddit/X). Docs-only — no compiler code. Six commits:

1. **Remove vulnerable claims** — drop named-project references (V8, QuickJS)
   for architectural classes; soften superlatives ("next generation" →
   "ahead-of-time"); remove the "no longer just a research prototype"
   contradiction and "Velocity is our moat"; pull aging inline metrics
   ("~60%", "two-thirds") out of prose.
2. **Above-the-fold stage marker** — README blockquote and homepage hero now
   state research-prototype status and link to the live status source.
3. **STATUS.md** — single live-status source; qualitative prose that points at
   the landing-page dashboard / Test262 report / baselines repo for numbers,
   and explains what Test262 does and does not measure (no Web/host APIs, no
   arbitrary npm packages).
4. **Design-space map** — README "How It Compares" rewritten as an
   architecture-class trade-off map (interpreter-based / engine-embedding /
   typed JS-TS subset / linear-memory AOT / js2wasm's WasmGC + full-ECMAScript
   + no-runtime point), framed as a structurally unoccupied combination the
   project is testing — not a superiority claim.
5. **FAQ** — new honest entries (test262 incompleteness, "won't you re-implement
   an engine", "why not extend a typed subset language", "why WasmGC", "timeline
   to production: unknown") on both surfaces, built around the existing
   production-ready entry; no named projects, no inline metrics.
6. **CI fix** — restore the `AUTO:conformance` anchor in README that the
   `sync:conformance:check` quality gate requires (the machine-maintained live
   figure is the one allowed inline number).

### Constraints honored
- No specific competing/adjacent projects named (architectural classes only).
  Remaining `V8`/`Node.js` references are benchmark *methodology* (the reference
  runtime measured against), not competitive positioning.
- No quickly-aging numbers in prose; numbers live in the AUTO block + STATUS.md
  and the live conformance/benchmark sections, linked everywhere else.

## Test plan
- [x] `pnpm run sync:conformance:check` passes (README anchor restored)
- [x] `pnpm run check:issues` passes (exit 0)
- [x] pre-push typecheck + lint OK
- [x] FAQ `<details>` tags balanced; no named projects / aging numbers remain
- [ ] `quality` + `cheap gate` green in CI

> Do not self-merge — merge queue is wedged on a separate cla-check issue.
> Pinging tech-lead for an admin-merge once `quality` + `cheap gate` are green.

Generated with [Claude Code](https://claude.com/claude-code)