### PR TITLE
docs(landing): restore hero tagline to single research-preview sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1458,10 +1458,7 @@
             JS
             <sup>2</sup>
             is a research preview of an open source compiler focused on compiling JavaScript to WebAssembly ahead of
-            time, developed at Loopdive. It is an early-stage research prototype and technical demo — not a
-            production-ready compiler. Live conformance figures are on the
-            <a href="#goals">compatibility</a>
-            page.
+            time, developed at Loopdive.
           </p>
           <div class="hero-actions">
             <a class="btn-solid" href="./playground/">Playground</a>


### PR DESCRIPTION
Reverts the hero-sub to the single sentence; the prototype disclaimer remains in the Mission section, FAQ, README, and STATUS.md. Docs-only.