### PR TITLE
chore(plan): mark #1671 done + queue-drain canary

### DIFF
--- a/plan/issues/1671-trampoline-null-receiver-runtime.md
+++ b/plan/issues/1671-trampoline-null-receiver-runtime.md
@@ -3,7 +3,7 @@ id: 1671
 slug: trampoline-null-receiver-runtime
 title: "object-method trampoline / direct dispatch lost the real receiver → ~200 runtime null-derefs (completes #1669/#621)"
 sprint: 55
-status: in-review
+status: done
 created: 2026-05-25
 updated: 2026-05-25
 priority: high


### PR DESCRIPTION
Flips #1671 in-review→done (PR #628 merged). Plan-only. Intentionally enqueued normally (not admin-merged) to verify the #629 cla-check merge_group fix unwedges the queue.