### PR TITLE
fix(#1604): String case-method tests off compile_error — wrapTest read-rewrite guard

### DIFF
--- a/plan/issues/1604-string-case-method-return-type-invalid-wasm.md
+++ b/plan/issues/1604-string-case-method-return-type-invalid-wasm.md
@@ -1,9 +1,10 @@
 ---
 id: 1604
 title: "codegen: String case methods (toUpperCase/toLowerCase/toLocale*) return i32 into f64 comparison — invalid wasm"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -53,3 +54,34 @@ in numeric/equality contexts.
 
 - The three example tests compile to valid Wasm.
 - All 8 tests move off `compile_error`.
+
+## Resolution (2026-05-27)
+
+The `f64.ne expected f64, found i32` **compile_error was already fixed on
+main** (likely via the call-site argument coercion work in #1602): all 8 case
+tests already validate to valid Wasm and sit at `fail` (not `compile_error`) in
+the current baseline — acceptance criteria met.
+
+The remaining failure was a **`wrapTest` harness bug**, not a compiler bug.
+`tests/test262-runner.ts` unconditionally rewrote `__expected.index` /
+`__expected.input` *reads* into the extracted variables `__expected_index` /
+`__expected_input`. Those vars are only declared when the source *assigns*
+`__expected.index = N` (the RegExp-exec result pattern). The case-conversion
+tests only read `.index`/`.input` (both `undefined` on a plain string) and
+never assign them, so the rewrite left a reference to an undeclared variable
+→ `__expected_index is not defined`.
+
+Fix: guard the read-rewrite on whether the corresponding declaration was
+actually extracted; otherwise leave the property read intact (compiles to
+`undefined`).
+
+Result: **+4 tests** fail→pass (the `_T4` empty-string variants:
+`toLowerCase` `S15.5.4.16_A1_T4`, `toUpperCase` `S15.5.4.18_A1_T4`,
+`toLocaleLowerCase` `S15.5.4.17_A1_T4`, `toLocaleUpperCase`
+`S15.5.4.19_A1_T4`). The 4 `_T9` variants stay `fail` — a separate
+`new String(obj)` ToPrimitive issue (`{valueOf:fn, toString:void 0}` throwing
+"Cannot convert object to primitive value"), out of scope here. RegExp-exec
+result tests that *do* assign `__expected.index` (e.g. `S15.10.6.2_A*`) keep
+the extraction transform and remain `pass` — no regressions.
+
+Regression test: `tests/issue-1604.test.ts`.

--- a/tests/issue-1604.test.ts
+++ b/tests/issue-1604.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { wrapTest } from "./test262-runner.js";
+
+/**
+ * #1604 — String case-conversion tests (toUpperCase/toLowerCase/toLocale*)
+ * failed because the `wrapTest` harness unconditionally rewrote every
+ * `__expected.index` / `__expected.input` *read* into the extracted variables
+ * `__expected_index` / `__expected_input`. Those variables are only declared
+ * when the source *assigns* `__expected.index = N` (the RegExp-exec result
+ * pattern). The case tests only read `.index`/`.input` (both `undefined` on a
+ * plain string) and never assign them, so the rewrite left a reference to an
+ * undeclared variable, producing `__expected_index is not defined`.
+ *
+ * The transform must only rewrite the reads when the corresponding declaration
+ * was actually extracted; otherwise the property read stays intact (→ undefined).
+ */
+describe("#1604 wrapTest __expected.index/.input read rewrite", () => {
+  it("leaves __expected.index/.input as property reads when no assignment is present", () => {
+    const source = `
+var __upperCase = "".toUpperCase();
+var __expected = "";
+if (__upperCase.index !== __expected.index) {
+  throw new Test262Error('#2');
+}
+if (__upperCase.input !== __expected.input) {
+  throw new Test262Error('#3');
+}
+`;
+    const { source: wrapped } = wrapTest(source);
+    // No declaration extracted, so the reads must remain property accesses.
+    expect(wrapped).not.toContain("__expected_index");
+    expect(wrapped).not.toContain("__expected_input");
+    expect(wrapped).toContain("__expected.index");
+    expect(wrapped).toContain("__expected.input");
+  });
+
+  it("still extracts __expected.index/.input into vars when assigned (RegExp exec pattern)", () => {
+    const source = `
+var __executed = /str/.exec("astr");
+var __expected = ["str"];
+__expected.index = 1;
+__expected.input = "astr";
+if (__executed.index !== __expected.index) {
+  throw new Test262Error('#1');
+}
+if (__executed.input !== __expected.input) {
+  throw new Test262Error('#2');
+}
+`;
+    const { source: wrapped } = wrapTest(source);
+    // Declaration extracted → reads rewritten to the extracted vars.
+    expect(wrapped).toContain("var __expected_index");
+    expect(wrapped).toContain("var __expected_input");
+    // The original `__expected.index` *reads* (not the assignment) are gone.
+    expect(wrapped).toContain("__expected_index");
+    expect(wrapped).toContain("__expected_input");
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1849,18 +1849,37 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   // `ReferenceError: __expected_input is not defined`. Extended to handle both
   // quote styles. The `("(?:...)"|'(?:...)')` alternation captures the entire
   // quoted literal so the replacement preserves whichever style the source used.
-  body = body.replace(/__expected\.index\s*=\s*(\d+)\s*;/g, "var __expected_index: number = $1;");
+  let declaredExpectedIndex = false;
+  body = body.replace(/__expected\.index\s*=\s*(\d+)\s*;/g, (_m, n) => {
+    declaredExpectedIndex = true;
+    return `var __expected_index: number = ${n};`;
+  });
   // (#1352b) Match double-quoted, single-quoted, or identifier RHS — many tests
   // assign `__expected.input = __string` where `__string` is a previously-declared
   // local. The identifier branch lets the var-decl carry through any string-typed
   // value, not just literals.
+  let declaredExpectedInput = false;
   body = body.replace(
     /__expected\.input\s*=\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[A-Za-z_$][\w$]*)\s*;/g,
-    "var __expected_input: string = $1;",
+    (_m, rhs) => {
+      declaredExpectedInput = true;
+      return `var __expected_input: string = ${rhs};`;
+    },
   );
-  // Replace property accesses with the extracted variables
-  body = body.replace(/__expected\.index\b(?!\s*=)/g, "__expected_index");
-  body = body.replace(/__expected\.input\b(?!\s*=)/g, "__expected_input");
+  // Replace property accesses with the extracted variables — but only when the
+  // corresponding declaration was emitted. The String case-conversion tests
+  // (#1604: toUpperCase/toLowerCase/toLocale*) read `__expected.index` /
+  // `__expected.input` without ever assigning them (both sides are `undefined`
+  // on a plain string), so rewriting the reads to `__expected_index` /
+  // `__expected_input` left a reference to an undeclared variable
+  // (`__expected_index is not defined`). When no declaration was extracted,
+  // leave the property read intact so it compiles to `undefined`.
+  if (declaredExpectedIndex) {
+    body = body.replace(/__expected\.index\b(?!\s*=)/g, "__expected_index");
+  }
+  if (declaredExpectedInput) {
+    body = body.replace(/__expected\.input\b(?!\s*=)/g, "__expected_input");
+  }
 
   // Route comparisons involving _input variables to string assert
   body = body.replace(


### PR DESCRIPTION
## Summary
- #1604's `f64.ne expected f64, found i32` **compile_error was already fixed on main** (the 8 String case-method tests sit at `fail`, not `compile_error`, in the current baseline — acceptance criterion met).
- The remaining failure was a **`wrapTest` harness bug** in `tests/test262-runner.ts`: it unconditionally rewrote `__expected.index`/`.input` *reads* into the extracted vars `__expected_index`/`__expected_input`, which are only declared when the source *assigns* them (the RegExp-exec result pattern). The case-conversion tests only read `.index`/`.input` (both `undefined` on a plain string) and never assign, so the rewrite left a reference to an undeclared variable → `__expected_index is not defined`.
- Fix: guard the read-rewrite on whether the corresponding declaration was actually extracted; otherwise leave the property read intact (compiles to `undefined`).

## Result
- **+4 tests fail→pass**: the `_T4` empty-string variants of `toLowerCase`/`toUpperCase`/`toLocaleLowerCase`/`toLocaleUpperCase`.
- The 4 `_T9` variants stay `fail` — a separate `new String(obj)` ToPrimitive issue (`{valueOf:fn, toString:void 0}` throwing "Cannot convert object to primitive value"), out of scope here.
- RegExp-exec result tests that *do* assign `__expected.index` (e.g. `S15.10.6.2_A*`) keep the extraction transform and remain `pass` — **no regressions**.

## Test plan
- [x] `tests/issue-1604.test.ts` — covers both branches (read-only → property read preserved; assignment → vars extracted)
- [x] Spot-checked the real `runTest262File` runner on all 8 case-method tests (4 pass, 4 stay fail) and 6 RegExp-exec tests (no regressions)
- [x] `tsc --noEmit` clean
- [ ] CI: cheap gate + sharded test262 + quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)