### PR TITLE
fix(#1603): optional chaining on nullable-union receiver emits valid wasm

### DIFF
--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -794,8 +794,12 @@ export function compileOptionalPropertyAccess(
   // else branch (non-null path): get the property from the temp
   fctx.body = [];
   fctx.body.push({ op: "local.get", index: tmp });
-  // Compile the property access part without the receiver
-  const tsObjType = ctx.checker.getTypeAtLocation(expr.expression);
+  // Compile the property access part without the receiver. After the
+  // `ref.is_null` short-circuit the receiver is known non-null, so resolve
+  // the property against the non-nullable part of the union — the bare
+  // `C | null` union symbol is anonymous and would fail struct resolution,
+  // leaving the receiver ref stranded on the stack (#1603).
+  const tsObjType = ctx.checker.getNonNullableType(ctx.checker.getTypeAtLocation(expr.expression));
   const propName = expr.name.text;
   let elseResultType: ValType | null = null;
   if (isExternalDeclaredClass(tsObjType, ctx.checker)) {
@@ -867,8 +871,15 @@ export function compileOptionalPropertyAccess(
     }
   }
 
+  if (elseResultType === null) {
+    // Property could not be resolved to a concrete struct field/getter. The
+    // receiver ref is still on the stack from `local.get tmp`; coerce it to
+    // the block result type so the `if` typechecks rather than leaving a
+    // mismatched ref as the else-branch fallthrough (#1603).
+    elseResultType = objType;
+  }
   // Coerce else branch result to match the block result type
-  if (elseResultType && !valTypesMatch(elseResultType, resultType)) {
+  if (!valTypesMatch(elseResultType, resultType)) {
     coerceType(ctx, fctx, elseResultType, resultType);
   }
   const elseInstrs = fctx.body;

--- a/tests/issue-1603.test.ts
+++ b/tests/issue-1603.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Tests for #1603 — optional-chaining short-circuit emitted invalid wasm.
+ *
+ * `obj?.prop` on a nullable-union receiver compiled the property access
+ * against the bare `T | null` union, whose anonymous symbol failed struct
+ * resolution. The receiver ref was then left on the else-branch stack while
+ * the `if` block result type was forced to externref, producing a wasm that
+ * failed validation (`ref.is_null` / fallthru type error) at instantiate time.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  } as WebAssembly.Imports);
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1603 — optional chaining on nullable-union receiver", () => {
+  it("instantiates valid wasm for `a?.b` when a is a null class union", async () => {
+    const src = `
+      class C { b: number = 5; }
+      export function test(): number {
+        const a: C | null = null;
+        const x = a?.b;
+        // Reaching this point at all means instantiation succeeded.
+        return x === undefined ? 1 : 0;
+      }
+    `;
+    // The point of #1603 is that this compiles AND instantiates without a
+    // wasm validation error — previously it threw at WebAssembly.instantiate.
+    await expect(run(src)).resolves.toBeDefined();
+  });
+
+  it("instantiates valid wasm for `a?.b` on an inline nullable object type", async () => {
+    const src = `
+      export function test(): number {
+        const a: { b: number } | null = null;
+        const x = a?.b;
+        return x === undefined ? 1 : 0;
+      }
+    `;
+    await expect(run(src)).resolves.toBeDefined();
+  });
+
+  it("reads the property when the receiver is non-null", async () => {
+    const src = `
+      class C { b: number = 7; }
+      export function test(): number {
+        const a: C | null = new C();
+        return a?.b ?? -1;
+      }
+    `;
+    expect(await run(src)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #596. That PR fixed the **non-reference receiver** case for `?.`, but a second invalid-wasm path remained: when the receiver is a **nullable union** (e.g. `C | null`), `compileOptionalPropertyAccess` resolved the property against the bare union type, whose anonymous symbol fails `resolveStructName`. The struct field access was skipped entirely, leaving the receiver ref on the else-branch stack while the `if` block result type was forced to `externref` — producing wasm that fails validation at instantiate time (`ref.is_null` / fallthru type error).

Fix (in `src/codegen/property-access.ts`):
- Resolve the property against `getNonNullableType(...)` of the receiver — after the `ref.is_null` short-circuit the receiver is known non-null, so the `C | null` union should resolve to `C`.
- Safety net: when the property still can't be resolved, coerce the leftover receiver ref to the block result type so the else branch always matches the block type.

## Test results (test262 `language/expressions/optional-chaining/`)

| file | before (main) | after |
|------|---------------|-------|
| `call-expression.js` | `compile_error` | `fail` (assertion only — off compile_error) |
| `short-circuiting.js` | fail (chained `.c`, separate bug) | unchanged |
| `iteration-statement-for-of-type-error.js` | pass | pass |

New unit test `tests/issue-1603.test.ts` (3 cases) passes — confirms nullable-union `a?.b` now instantiates valid wasm.

## Test plan
- [x] `npx vitest run tests/issue-1603.test.ts` — 3/3 pass
- [x] `npx tsc --noEmit` clean
- [x] before/after confirmed via test262 runner on the 3 named files
- [ ] CI: required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)