### PR TITLE
fix(#1607): block-scoped lexical self-reference throws TDZ ReferenceError

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9145,7 +9145,7 @@ export function hoistLetConstWithTdz(
  * Returns false if every access to the symbol is provably after the declaration
  * in straight-line code (same function, no closures, loop-local safe).
  */
-function needsTdzFlag(ctx: CodegenContext, decl: ts.VariableDeclaration): boolean {
+export function needsTdzFlag(ctx: CodegenContext, decl: ts.VariableDeclaration): boolean {
   const symbol = ctx.checker.getSymbolAtLocation(decl.name);
   if (!symbol) return true;
   const declEnd = decl.getEnd();

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -10,7 +10,7 @@ import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { emitCoercedLocalSet } from "../expressions/helpers.js";
 import { emitUndefined } from "../expressions/late-imports.js";
-import { resolveWasmType } from "../index.js";
+import { needsTdzFlag, resolveWasmType } from "../index.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { getOrRegisterVecType } from "../registry/types.js";
@@ -425,10 +425,28 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       (ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing)
     );
     const isHoistedLetConst = !isVar && existingIdx !== undefined && existingIdx >= fctx.params.length;
+    const freshLocalForLetConst = !isVar && !isHoistedLetConst;
     const localIdx =
       (isVar || isHoistedLetConst) && existingIdx !== undefined && existingIdx >= fctx.params.length
         ? existingIdx
         : allocLocal(fctx, name, wasmType);
+
+    // #1607: A block-scoped let/const that did NOT reuse a pre-hoisted slot
+    // (because `saveBlockScopedShadows` removed its hoisted localMap/TDZ entry
+    // on block entry) gets a fresh local with no TDZ flag. A self-referential
+    // initializer like `{ const x = x + 1; }` would then read the
+    // zero/undefined-initialized fresh local instead of throwing a TDZ
+    // ReferenceError. Re-allocate the TDZ flag here, BEFORE the initializer is
+    // compiled, and zero-init it so the self-reference read fires the check.
+    if (freshLocalForLetConst && needsTdzFlag(ctx, decl)) {
+      if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+      if (!fctx.tdzFlagLocals.has(name)) {
+        const tdzFlagIdx = allocLocal(fctx, `__tdz_${name}`, { kind: "i32" });
+        fctx.tdzFlagLocals.set(name, tdzFlagIdx);
+        // Wasm i32 locals zero-init to 0 (uninitialized) automatically — no
+        // explicit store needed before the initializer runs.
+      }
+    }
 
     // If we reused a pre-hoisted slot but inference found a more precise type
     // (e.g. Array<any> hoisted as vec_externref, but inferred as vec_f64),

--- a/tests/issue-1607.test.ts
+++ b/tests/issue-1607.test.ts
@@ -43,3 +43,40 @@ describe("#1607 self-referential lexical initializer (TDZ) must not overflow the
     expect(hasInternalError(r.errors)).toBe(false);
   });
 });
+
+// A block-scoped lexical self-reference (`{ const x = x + 1; }`) does not hit
+// the static numeric folder's cycle guard (the initializer is a runtime read),
+// so it must instead emit the spec-required TDZ ReferenceError. Before this fix
+// `saveBlockScopedShadows` stripped the hoisted TDZ flag on block entry, so the
+// fresh block-local was allocated WITHOUT a flag and the self-reference silently
+// read the zero/undefined-initialized slot instead of throwing.
+describe("#1607 block-scoped lexical self-reference emits a TDZ throw", () => {
+  const throwingCases = [
+    "function f(): number { { const x = x + 1; } return 0; }",
+    "function f(): number { { let x = x + 1; } return 0; }",
+  ];
+
+  for (const src of throwingCases) {
+    it(`emits a static TDZ throw: ${JSON.stringify(src)}`, () => {
+      const r = compile(src, { fileName: "test.ts", emitWat: true, skipSemanticDiagnostics: true });
+      expect(r.success).toBe(true);
+      const wat = r.wat ?? "";
+      const fnStart = wat.indexOf("(func $f");
+      const fnBody = wat.slice(fnStart, fnStart + 200);
+      expect(fnBody).toContain("unreachable");
+    });
+  }
+
+  it("does NOT inject a TDZ throw for a valid block-scoped const", () => {
+    const r = compile("function f(): number { { const x = 5; return x; } }", {
+      fileName: "test.ts",
+      emitWat: true,
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success).toBe(true);
+    const wat = r.wat ?? "";
+    const fnStart = wat.indexOf("(func $f");
+    const fnBody = wat.slice(fnStart, fnStart + 120);
+    expect(fnBody).not.toContain("unreachable");
+  });
+});


### PR DESCRIPTION
## Summary
- The compiler stack-overflow crash on self-referential lexical initializers (`const x = x + 1`) was already fixed on main (commit b3bc41631, the `tryStaticToNumber` cycle guard). All 8 test262 use-before-initialization-in-declaration tests are off `compile_error`.
- This follow-up fixes the 2 **block-local** cases (`{ const x = x + 1; }` / `{ let x = x + 1; }`) that compiled cleanly but silently read the uninitialized slot instead of throwing the spec-required TDZ `ReferenceError` — leaving them `fail`.

## Root cause
`saveBlockScopedShadows` removes a block-scoped name's hoisted `localMap` and `tdzFlagLocals` entry on block entry so the inner declaration allocates a fresh local. The fresh local was allocated **without a TDZ flag**, so the self-referential read found no flag and skipped the TDZ check, reading the zero/undefined-initialized slot. The fix re-allocates the TDZ flag in `compileVariableStatement` (reusing the existing `needsTdzFlag` analysis) **before** the initializer is compiled, so the self-reference read fires the check and throws.

## Result
- All 8 test262 const/let/await-using `use-before-initialization-in-declaration` tests now **pass** (was 6 pass / 2 fail), verified via the real test262 runner.
- Valid block-scoped declarations emit **no** spurious TDZ throw (verified via WAT inspection — `needsTdzFlag` returns false for provably-safe accesses).
- The 18 failures in `tests/equivalence/tdz-reference-error.test.ts` and `tests/ir-let-const-equivalence.test.ts` are **pre-existing** — they fail identically on clean main (confirmed by stash + re-run).

## Test plan
- [x] `tests/issue-1607.test.ts` — 11 pass (crash cases + new block-local TDZ-throw cases + valid-case negative check)
- [x] All 8 test262 `use-before-initialization-in-declaration` files pass via `runTest262File`
- [x] Typecheck + lint clean
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)