### PR TITLE
fix(#1608): guard stale funcMap slot in object-literal method codegen

### DIFF
--- a/plan/issues/1608-internal-crash-array-mutator-set-typeidx.md
+++ b/plan/issues/1608-internal-crash-array-mutator-set-typeidx.md
@@ -1,9 +1,10 @@
 ---
 id: 1608
 title: "codegen crash: 'Cannot set properties of undefined (setting typeIdx)' on Array push/pop/shift/join/unshift"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -50,3 +51,42 @@ array representation.
 
 - The example tests compile without an internal crash.
 - All 5 tests move off `compile_error`.
+
+## Root cause (actual)
+
+Not in the Array mutator intrinsic. The crash is in
+`compileObjectLiteralForStruct` (`src/codegen/literals.ts`). These tests assign
+many sibling object literals with the same method names to a property
+(`obj.length = { valueOf() {...} }`, repeated). Sibling literals that share a
+struct dedup-key share the same method `fullName` (e.g. `__anon_0_valueOf`), so
+they share one `ctx.funcMap` entry. The first literal recorded a funcIdx that —
+after late-import index shifting (`addUnionImports`) — fell into the import
+range. A later sibling looked the entry up and computed
+`localIdx = existingFuncIdx - ctx.numImportFuncs`, which went **negative** (e.g.
+54 − 79 = −25). `ctx.mod.functions[-25]` was `undefined`, and writing
+`.typeIdx` on it threw `Cannot set properties of undefined`.
+
+## Fix
+
+`src/codegen/literals.ts` — guard the funcMap-slot resolution: when the
+recorded funcIdx resolves to an out-of-range / undefined function slot, treat it
+as "no existing function" and synthesize a fresh one (overwriting the stale
+funcMap entry with the new valid index). Mirrors the existing
+`if (!existingFunc) continue;` guard in the same file's fork-decision pre-pass.
+
+## Test Results (2026-05-27, branch issue-1608-array-typeidx)
+
+All five A2_T* tests now compile (off `compile_error`); they land on `fail`
+(runtime assertion — out of scope here, generic-array-like semantics):
+
+- push/S15.4.4.7_A2_T3 — compile_error → fail
+- shift/S15.4.4.9_A2_T5 — compile_error → fail
+- join/S15.4.4.5_A2_T4 — compile_error → fail
+- pop/S15.4.4.6_A2_T4 — compile_error → fail
+- unshift/S15.4.4.13_A2_T1 — compiles (fail)
+
+Unit test `tests/issue-1608.test.ts` reproduces via `wrapTest` + the full
+test262 preamble (fails without the fix, passes with it). No regressions in
+anon-struct / arguments-object / array-prototype-methods / class-methods /
+array-methods suites (identical pre-existing failure counts with and without
+the fix).

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1596,10 +1596,18 @@ export function compileObjectLiteralForStruct(
       // dedicated funcIdx instead of overwriting the shared one.
       const perLiteralIdx = literalMethodFuncIdx.get(methodName);
       const existingFuncIdx = perLiteralIdx ?? ctx.funcMap.get(fullName);
+      // The shared `funcMap` entry can become stale when sibling object
+      // literals share a struct dedup-key (so they share `fullName`) but the
+      // earlier-recorded funcIdx points into the import range or past the
+      // current functions array — e.g. after late imports shifted indices or
+      // a prior literal's function was dropped. Resolving the slot blindly
+      // then crashed on `undefined.typeIdx` (#1608). Treat an unresolvable
+      // slot as "no existing function" and synthesize a fresh one.
+      const localIdx = existingFuncIdx !== undefined ? existingFuncIdx - ctx.numImportFuncs : -1;
+      const existingFunc = existingFuncIdx !== undefined && localIdx >= 0 ? ctx.mod.functions[localIdx] : undefined;
       let methodFunc: WasmFunction;
-      if (existingFuncIdx !== undefined) {
-        const localIdx = existingFuncIdx - ctx.numImportFuncs;
-        methodFunc = ctx.mod.functions[localIdx]!;
+      if (existingFunc !== undefined) {
+        methodFunc = existingFunc;
         // Update type in case it was refined
         methodFunc.typeIdx = methodTypeIdx;
       } else {

--- a/tests/issue-1608.test.ts
+++ b/tests/issue-1608.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1608 — codegen crash "Cannot set properties of undefined (setting 'typeIdx')"
+// in compileObjectLiteralForStruct.
+//
+// Sibling object literals that share a struct dedup-key share the same method
+// `fullName` (e.g. `__anon_0_valueOf`). The first literal records a funcIdx in
+// `ctx.funcMap`; a later sibling looked that index up and indexed into
+// `ctx.mod.functions` blindly. When the recorded index pointed into the import
+// range (after late-import index shifting), the local index went negative,
+// `ctx.mod.functions[localIdx]` was `undefined`, and writing `.typeIdx` on it
+// threw. The five test262 Array `A2_T*` "apply mutator to non-array this" tests
+// all hit this through repeated `obj.length = { valueOf() {...} }`. The fix
+// treats an unresolvable funcMap slot as "no existing function" and synthesizes
+// a fresh one.
+//
+// The crash only manifests through the full test262 preamble (which adds the
+// late imports that shift indices), so this test wraps the real test262 bodies
+// via `wrapTest` + `skipSemanticDiagnostics` exactly as the runner does.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+function compilesWithoutInternalError(body: string): boolean {
+  const meta = parseMeta(body);
+  const { source } = wrapTest(body, meta);
+  const r = compile(source, { fileName: "test.ts", sourceMap: true, skipSemanticDiagnostics: true });
+  return !r.errors?.some((e) => /Internal error compiling|typeIdx/.test(e.message));
+}
+
+describe("#1608 sibling object literals sharing a method name must not crash codegen", () => {
+  // Reduced from built-ins/Array/prototype/push/S15.4.4.7_A2_T3.js: repeated
+  // assignment of object literals carrying same-named methods to a property.
+  it("repeated `obj.length = { valueOf() {...} }` compiles without internal crash", () => {
+    const body = `
+      var obj = {};
+      obj.push = Array.prototype.push;
+      obj.length = { valueOf() { return 3; } };
+      var p1 = obj.push();
+      obj.length = { valueOf() { return 3; }, toString() { return 1; } };
+      var p2 = obj.push();
+      obj.length = { toString() { return 1; } };
+      var p3 = obj.push();
+      obj.length = { valueOf() { return {}; }, toString() { return 1; } };
+      var p4 = obj.push();
+    `;
+    expect(compilesWithoutInternalError(body)).toBe(true);
+  });
+
+  it("many distinct same-shaped literals with shared method name compile", () => {
+    const body = `
+      var o = {};
+      o.a = { valueOf() { return 1; } };
+      o.b = { valueOf() { return 2; } };
+      o.c = { valueOf() { return 3; } };
+      o.d = { valueOf() { return 4; } };
+      assert.sameValue(typeof o.a, 'object');
+    `;
+    expect(compilesWithoutInternalError(body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the codegen crash `Cannot set properties of undefined (setting 'typeIdx')` in `compileObjectLiteralForStruct` (`src/codegen/literals.ts`).
- Root cause is **not** the Array mutator intrinsic (as the issue hypothesized). Sibling object literals that share a struct dedup-key share a method `fullName` (e.g. `__anon_0_valueOf`) and thus one `ctx.funcMap` entry. After late-import index shifting (`addUnionImports`), the recorded funcIdx could fall into the import range, making `existingFuncIdx - ctx.numImportFuncs` negative; `ctx.mod.functions[localIdx]` was then `undefined` and writing `.typeIdx` threw.
- Fix: when the recorded funcIdx resolves to an out-of-range/undefined function slot, treat it as "no existing function" and synthesize a fresh one (overwriting the stale funcMap entry with the new valid index). Mirrors the existing `if (!existingFunc) continue;` guard in the same file's fork-decision pre-pass.

Closes #1608.

## Test plan
- [x] All 5 test262 Array `A2_T*` tests move off `compile_error` (push/shift/join/pop/unshift) — verified via the full `runTest262File` path; they now `fail` on runtime assertions (out of scope, generic-array-like semantics).
- [x] New `tests/issue-1608.test.ts` reproduces via `wrapTest` + the full test262 preamble — fails without the fix, passes with it.
- [x] No regressions in anon-struct / arguments-object / array-prototype-methods / class-methods / array-methods suites (identical pre-existing failure counts with and without the fix).
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)