### PR TITLE
fix(#1605): route prototype/class-object setter writes through dummy struct

### DIFF
--- a/plan/issues/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
+++ b/plan/issues/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
@@ -1,9 +1,9 @@
 ---
 id: 1605
 title: "codegen: class computed-property-name / setter param-scope emits invalid wasm (local.tee externref mismatch)"
-status: ready
+status: in-review
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -56,3 +56,44 @@ setter parameter scope copy-out.
 
 - The three example tests compile to valid Wasm.
 - All 6 tests move off `compile_error`.
+
+## Root cause
+
+`compilePropertyAssignment` / `compileElementAssignment` routed
+`C.prototype.<setter> = v` and `C.<static setter> = v` through the regular
+setter-call path, which compiles the receiver with the setter's struct `this`
+type hint. But the receiver of a prototype/class-object write is an **externref**
+(the lazy prototype/class-object singleton), not a struct instance. Coercing
+that externref to the struct `this` param produced an invalid `local.tee`
+(externref temp fed a struct `ref.null`).
+
+## Fix
+
+In `src/codegen/expressions/assignment.ts` (`compilePropertyAssignment` setter
+branch): when the assignment target's receiver is `<X>.prototype` or a bare
+class identifier, route through `emitSetterCallWithDummy` — the same dummy-struct
+path already used for `C.prototype[key] = v` element-access setters. The setter
+gets a throwaway struct receiver and the value flows through unchanged.
+
+## Test Results
+
+- `scope-setter-paramsbody-var-close` → **valid wasm** (fixed)
+- `scope-setter-paramsbody-var-open` → **valid wasm** (fixed)
+- `scope-static-setter-paramsbody-var-close` → **valid wasm** (fixed)
+- `scope-static-setter-paramsbody-var-open` → **valid wasm** (fixed)
+- `cpn-class-decl-accessors-...-from-null` → still INVALID (see below)
+- `cpn-class-expr-accessors-...-from-null` → still INVALID (see below)
+
+New unit test: `tests/issue-1605.test.ts` (3 cases, all pass).
+
+## Remaining (deferred — separate bug)
+
+The two `cpn-...-from-null` cases (`c[null] = null` element-write where the class
+has BOTH a computed `get [null]` and `set [null]`) hit a **distinct** defect: the
+top-level wrapper's `let c = new C()` is allocated TWICE — once by the let/const
+TDZ hoist pass and once by `compileVariableStatement` (the hoisted slot is not
+reused; `fctx.localMap` no longer resolves the name at statement time when
+computed-name accessors are present). The resulting dead duplicate local shifts
+binaryen's local typing so the (internally-correct) `ref.null.extern` tee is
+misvalidated against the struct local. This is a variable-hoisting / slot-reuse
+bug, not a setter-coercion bug, and warrants its own issue.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -2030,6 +2030,21 @@ function compilePropertyAssignment(
     const setterName = `${typeName}_set_${fieldName}`;
     const funcIdx = ctx.funcMap.get(setterName);
     if (funcIdx !== undefined) {
+      // `C.prototype.<setter> = v` and `C.<static setter> = v` both write
+      // through a receiver that is an externref (the prototype singleton or the
+      // class object), not a struct instance. Coercing that externref to the
+      // setter's struct `this` param produces an invalid `local.tee` (externref
+      // temp fed a struct ref.null). Use the dummy-struct call path (same as
+      // `C.prototype[key] = v`) so the setter receives a throwaway struct
+      // receiver and the value flows through unchanged.
+      const receiverIsProto =
+        ts.isPropertyAccessExpression(target.expression) &&
+        ts.isIdentifier(target.expression.name) &&
+        target.expression.name.text === "prototype";
+      const receiverIsClassObject = ts.isIdentifier(target.expression) && ctx.classSet.has(target.expression.text);
+      if (receiverIsProto || receiverIsClassObject) {
+        return emitSetterCallWithDummy(ctx, fctx, typeName, setterName, funcIdx, value);
+      }
       // Get setter's parameter types to provide type hints
       const setterParamTypes = getFuncParamTypes(ctx, funcIdx);
       const setterObjResult = compileExpression(ctx, fctx, target.expression, setterParamTypes?.[0]);

--- a/tests/issue-1605.test.ts
+++ b/tests/issue-1605.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compilesToValidWasm(src: string): Promise<boolean> {
+  const r = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!r.success || r.errors.some((e) => e.severity === "error")) return false;
+  return WebAssembly.validate(r.binary);
+}
+
+describe("#1605 — class setter assignment via prototype / class object", () => {
+  it("instance setter write through C.prototype emits valid wasm (var-close scope)", async () => {
+    const src = `
+      var probe;
+      class C {
+        set a(_ = null) {
+          var x = 'inside';
+          probe = function() { return x; };
+        }
+      }
+      C.prototype.a = null;
+    `;
+    expect(await compilesToValidWasm(src)).toBe(true);
+  });
+
+  it("static setter write through class object emits valid wasm", async () => {
+    const src = `
+      var probe;
+      class C {
+        static set a(_ = null) {
+          var x = 'inside';
+          probe = function() { return x; };
+        }
+      }
+      C.a = null;
+    `;
+    expect(await compilesToValidWasm(src)).toBe(true);
+  });
+
+  it("setter with null default and no body var emits valid wasm", async () => {
+    expect(await compilesToValidWasm(`class C { set a(_ = null) {} } C.prototype.a = null;`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `C.prototype.<setter> = v` and `C.<static setter> = v` wrote through a receiver that is an **externref** (the lazy prototype / class-object singleton), but the setter-assignment path coerced that externref to the setter's struct `this` param — producing an invalid externref→struct `ref.null` `local.tee` and `invalid Wasm binary`.
- Fix: when the assignment target's receiver is `<X>.prototype` or a bare class identifier, route through the existing `emitSetterCallWithDummy` path (already used for `C.prototype[key] = v`). The setter gets a throwaway struct receiver; the value flows through unchanged.

## Tests
- New `tests/issue-1605.test.ts` (3 cases) — all pass.
- Fixes 4 of the 6 test262 cases: `scope-setter-paramsbody-var-{close,open}`, `scope-static-setter-paramsbody-var-{close,open}` — all now compile to valid wasm.

## Out of scope (documented in issue file)
The 2 `cpn-...-from-null` cases (`c[null] = null` where the class has BOTH computed `get [null]` and `set [null]`) hit a **separate** variable-hoisting double-allocation bug — `let c = new C()` is allocated twice (hoist pass + var statement), shifting binaryen's local typing. That is a distinct hoisting/slot-reuse defect, not a setter-coercion bug, and warrants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)