### PR TITLE
fix(#1611): allow ASI let-as-identifier in single-statement context

### DIFF
--- a/plan/issues/1611-lexical-declaration-single-statement-context.md
+++ b/plan/issues/1611-lexical-declaration-single-statement-context.md
@@ -1,9 +1,10 @@
 ---
 id: 1611
 title: "parser: lexical declaration in single-statement context rejected for valid newline-separated cases"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -49,3 +50,24 @@ lexical-declaration early error to respect the newline-based disambiguation.
 - The newline-separated `let` identifier/block cases compile (or correctly
   pass/fail per the test's `negative` expectation).
 - >=12 of the 16 tests move off `compile_error`.
+
+## Fix
+
+`src/compiler/validation.ts` — new `isAsiLetExpressionStatement` helper, wired
+into both the single-statement-position check and the labeled-statement check.
+Per ECMA-262 the ExpressionStatement lookahead restriction is only `let [`
+(with **no** `[no LineTerminator here]`), so `let` + LineTerminator +
+(identifier | `{`) is an ExpressionStatement (`let` identifier reference)
+closed by ASI — valid in single-statement / labeled position. `let [` stays a
+lexical declaration even across a newline; `const` is always a reserved word so
+it is never relaxed.
+
+## Test Results
+
+Checked all 25 `*with-newline*` test262 files under `language/statements`
+(for/for-in/for-of/for-await-of/if/while/do-while/labeled/with): 25/25 now
+classify correctly — 17 positive (`let-identifier` / `let-block`) no longer
+emit the single-statement/labeled early error, 8 negative (`let-array`) still
+correctly error. Regression test: `tests/issue-1611.test.ts` (14 cases, all
+pass). `labeled-loops.test.ts` (7 fail) and `issue-202` "var used before
+declaration" failures pre-exist on `origin/main` — unrelated to this change.

--- a/src/compiler/validation.ts
+++ b/src/compiler/validation.ts
@@ -1005,7 +1005,10 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
       // label: let x; or label: const x;
       if (ts.isVariableStatement(stmt)) {
         const flags = stmt.declarationList.flags;
-        if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
+        if (
+          ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) &&
+          !isAsiLetExpressionStatement(stmt, flags)
+        ) {
           addError(node, "Lexical declaration (let/const) cannot appear in a labeled statement");
         }
       }
@@ -1022,7 +1025,7 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
       const flags = node.declarationList.flags;
       if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
         const parent = node.parent;
-        if (parent && isStatementPosition(parent, node)) {
+        if (parent && isStatementPosition(parent, node) && !isAsiLetExpressionStatement(node, flags)) {
           addError(node, "Lexical declaration cannot appear in a single-statement context");
         }
       }
@@ -2578,6 +2581,36 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
         return false; // Found a non-generator function boundary
       }
       current = current.parent;
+    }
+    return false;
+  }
+
+  /**
+   * TypeScript parses `let` followed by a LineTerminator and then an identifier
+   * or `{` (e.g. `if (false) let\nx = 1;`) as a LexicalDeclaration, but per
+   * ECMA-262 the ExpressionStatement lookahead restriction is only `let [`
+   * (with NO `[no LineTerminator here]`). So `let` + newline + (anything but
+   * `[`) is actually an ExpressionStatement (`let` identifier reference) closed
+   * by ASI, which is valid in single-statement position. `let [` stays a
+   * lexical declaration even across a newline, and `const` is always a reserved
+   * word so it is never an expression statement.
+   */
+  function isAsiLetExpressionStatement(node: ts.VariableStatement, flags: ts.NodeFlags): boolean {
+    if ((flags & ts.NodeFlags.Let) === 0) return false;
+    const decls = node.declarationList.declarations;
+    if (decls.length !== 1) return false;
+    const binding = decls[0].name;
+    // `let [` is a lexical declaration / array destructuring even after a newline.
+    if (ts.isArrayBindingPattern(binding)) return false;
+    // Source text between the `let` keyword and the first binding: a line
+    // terminator there means ASI applies and `let` is an identifier reference.
+    const declList = node.declarationList;
+    const keywordEnd = declList.getStart(sourceFile) + "let".length;
+    const between = sourceFile.text.slice(keywordEnd, binding.getStart(sourceFile));
+    for (const ch of between) {
+      const c = ch.charCodeAt(0);
+      // LF, CR, LINE SEPARATOR (U+2028), PARAGRAPH SEPARATOR (U+2029)
+      if (c === 0x0a || c === 0x0d || c === 0x2028 || c === 0x2029) return true;
     }
     return false;
   }

--- a/tests/issue-1611.test.ts
+++ b/tests/issue-1611.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+function hasLexError(src: string): boolean {
+  const r = compile(src, { fileName: "test.ts" });
+  return (r.errors ?? []).some((e) => /single-statement context|labeled statement/.test(e.message));
+}
+
+describe("#1611 lexical declaration ASI in single-statement context", () => {
+  // `let` + LineTerminator + (identifier | `{`) is an ExpressionStatement
+  // (identifier reference) closed by ASI — valid in single-statement position.
+  it.each([
+    "if (false) let\nx = 1;",
+    "if (false) let\n{}",
+    "while (false) let\nx = 1;",
+    "do let\nx = 1; while (false);",
+    "for (;false;) let\nx = 1;",
+    "for (var x in null) let\nx = 1;",
+    "for (var x of []) let\nx = 1;",
+    "L: let\nx = 1;",
+  ])("accepts ASI let-as-identifier: %j", (src) => {
+    expect(hasLexError(src)).toBe(false);
+  });
+
+  // `let [` is a lexical declaration even across a newline (no `[no LineTerminator
+  // here]` in the spec lookahead) — still a SyntaxError in single-statement position.
+  it.each(["if (false) let\n[a] = 0;", "for (var x of []) let\n[a] = 0;", "while (false) let\n[a] = 0;"])(
+    "still rejects let-array after newline: %j",
+    (src) => {
+      expect(hasLexError(src)).toBe(true);
+    },
+  );
+
+  // No newline, or `const`, stays a genuine lexical declaration -> still rejected.
+  it.each(["if (x) let y = 1;", "if (false) const\nx = 1;", "while (x) const y = 1;"])(
+    "still rejects same-line let / any const: %j",
+    (src) => {
+      expect(hasLexError(src)).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Per ECMA-262, the ExpressionStatement lookahead restriction is only `let [` (with **no** `[no LineTerminator here]`). So `let` + LineTerminator + (identifier | `{`) is an ExpressionStatement (`let` identifier reference) closed by ASI — valid in single-statement / labeled position. TypeScript parses these as a `LexicalDeclaration`, so our early-error gate over-rejected them.
- Adds `isAsiLetExpressionStatement` in `src/compiler/validation.ts`, wired into both the single-statement-position check and the labeled-statement check. `let [` stays a lexical declaration even across a newline; `const` (always reserved) is never relaxed.

## Test plan
- [x] All 25 `*with-newline*` test262 files under `language/statements` classify correctly: 17 positive (`let-identifier`/`let-block`) no longer emit the early error; 8 negative (`let-array`) still correctly error.
- [x] `tests/issue-1611.test.ts` — 14 cases, all pass.
- [x] `tsc --noEmit` clean; `biome lint` clean.
- [x] `labeled-loops.test.ts` (7 fail) and `issue-202` "var used before declaration" failures pre-exist on `origin/main` — unrelated.

Closes #1611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)