### PR TITLE
fix(#1601): box map bridge result + register reduceRight 2-arg bridge

### DIFF
--- a/plan/issues/1601-array-iteration-callback-stack-underflow.md
+++ b/plan/issues/1601-array-iteration-callback-stack-underflow.md
@@ -1,9 +1,9 @@
 ---
 id: 1601
 title: "codegen: Array.prototype reduce/reduceRight/map/filter callback paths emit invalid wasm (stack underflow at local.set/if/array.set)"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -78,3 +78,44 @@ consuming op.
 - The five example tests above compile to a valid Wasm module (no
   `invalid Wasm binary` / stack-underflow).
 - >=120 of the 156 tests in this cluster move off `compile_error`.
+
+## Resolution (2026-05-27)
+
+The original 156-test stack-underflow cluster (`local.set`/`if`/`array.set
+need N got N-1`) was **already resolved** by intervening merges between
+2026-05-24 and 2026-05-27 — the committed test262 baseline showed only **10**
+remaining `compile_error` entries in the Array iteration cluster, and none
+were the cited stack-underflow examples (those now `fail` on species
+semantics, having compiled cleanly).
+
+The 10 residual `compile_error`s were two distinct, narrower codegen bugs,
+both fixed here:
+
+1. **map bridge result not boxed** (8 tests: `map/create-ctor-*`,
+   `map/create-species-*`, `map/create-revoked-proxy`, `map/15.4.4.19-4-7`).
+   `compileArrayMap`'s host-bridge branch (`src/codegen/array-methods.ts`)
+   only coerced the f64 bridge result to i32 — never f64→externref. When the
+   source array is untyped (`new Array(n)`, element type externref) the
+   `array.set` expected externref but found f64 →
+   `array.set[2] expected type externref, found call of type f64`. Fix:
+   replace the i32-only coercion with the general
+   `coercionInstrs(ctx, {kind:"f64"}, mapResultElemType, fctx)`, which boxes
+   via `__box_number` for the externref target.
+
+2. **reduceRight 2-arg bridge never registered** (2 tests:
+   `reduceRight/15.4.4.22-4-2`, `15.4.4.22-4-7`). The `__call_2_f64` import
+   pre-scan (`collectFunctionalArrayImports` in `src/codegen/index.ts` and the
+   parallel scan in `src/codegen/declarations.ts`) only set `need2` for
+   `"reduce"`, and `reduceRight` was absent from `FUNCTIONAL_ARRAY_METHODS`.
+   A non-closure `reduceRight` callback hit the bridge path with no registered
+   import → "Missing __call_2_f64 import for reduceRight". Fix: add
+   `reduceRight` to the set and treat it like `reduce` (needs the 2-arg
+   bridge) in both pre-scans.
+
+## Test Results
+
+All 10 baseline `compile_error`s now compile to valid Wasm (verified per-file
+via `runTest262File`): 2 `pass`, 8 `fail` (species/abrupt-ctor runtime
+semantics, out of scope). Guarded by `tests/issue-1601.test.ts` — 10 cases
+that fail on clean main and pass with the fix. No regressions in the
+previously-passing/`fail` cluster members (isolated per-process runs).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4884,8 +4884,11 @@ function compileArrayMap(
   } else {
     callInstrs = [
       ...buildBridgeCallInstrs(ctx, setup, elemType, arrTypeIdx, loop, { kind: "inline" }),
-      // Convert result to target element type if needed
-      ...(!ctx.fast && mapResultElemType.kind === "i32" ? [{ op: "i32.trunc_sat_f64_s" } as Instr] : []),
+      // The host bridge returns f64. Coerce it to the result element type so the
+      // downstream `array.set` validates — notably f64 → externref must box via
+      // __box_number when the source array is untyped (`new Array(n)`). Without
+      // this, `array.set` sees f64 where it expects externref. (#1601)
+      ...(!ctx.fast ? coercionInstrs(ctx, { kind: "f64" }, mapResultElemType, fctx) : []),
     ];
   }
 

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -587,7 +587,7 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
   if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
     const method = node.expression.name.text;
     if (FUNCTIONAL_ARRAY_METHODS.has(method)) {
-      if (method === "reduce") {
+      if (method === "reduce" || method === "reduceRight") {
         state.funcArrayNeed2 = true;
       } else {
         state.funcArrayNeed1 = true;
@@ -596,7 +596,7 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
     if (method === "call" && ts.isPropertyAccessExpression(node.expression.expression)) {
       const innerMethod = node.expression.expression.name.text;
       if (FUNCTIONAL_ARRAY_METHODS.has(innerMethod)) {
-        if (innerMethod === "reduce") {
+        if (innerMethod === "reduce" || innerMethod === "reduceRight") {
           state.funcArrayNeed2 = true;
         } else {
           state.funcArrayNeed1 = true;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6002,6 +6002,7 @@ export const FUNCTIONAL_ARRAY_METHODS = new Set([
   "filter",
   "map",
   "reduce",
+  "reduceRight",
   "forEach",
   "find",
   "findIndex",
@@ -6018,7 +6019,7 @@ function collectFunctionalArrayImports(ctx: CodegenContext, sourceFile: ts.Sourc
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
       const method = node.expression.name.text;
       if (FUNCTIONAL_ARRAY_METHODS.has(method)) {
-        if (method === "reduce") {
+        if (method === "reduce" || method === "reduceRight") {
           need2 = true;
         } else {
           need1 = true;
@@ -6028,7 +6029,7 @@ function collectFunctionalArrayImports(ctx: CodegenContext, sourceFile: ts.Sourc
       if (method === "call" && ts.isPropertyAccessExpression(node.expression.expression)) {
         const innerMethod = node.expression.expression.name.text;
         if (FUNCTIONAL_ARRAY_METHODS.has(innerMethod)) {
-          if (innerMethod === "reduce") {
+          if (innerMethod === "reduce" || innerMethod === "reduceRight") {
             need2 = true;
           } else {
             need1 = true;

--- a/tests/issue-1601.test.ts
+++ b/tests/issue-1601.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { runTest262File } from "./test262-runner.js";
+
+/**
+ * #1601 — Array iteration methods (map / reduceRight) on untyped arrays
+ * emitted invalid Wasm and showed up as test262 `compile_error`:
+ *  - the map bridge path stored the f64 callback result into an externref
+ *    result array without boxing → `array.set[2] expected externref, found f64`.
+ *  - reduceRight never registered the `__call_2_f64` host bridge (the import
+ *    pre-scan only handled `reduce`) → "Missing __call_2_f64 import".
+ *
+ * These were the last 10 `compile_error` entries in the Array iteration
+ * cluster. We assert they no longer classify as `compile_error` (they now
+ * compile to valid Wasm; species/abrupt-ctor semantics are out of scope and
+ * may still `fail` at runtime).
+ */
+
+const TEST262 = "/workspace/test262";
+const ROOT = `${TEST262}/test/built-ins/Array/prototype`;
+
+const cases = [
+  "map/15.4.4.19-4-7.js",
+  "map/create-ctor-non-object.js",
+  "map/create-ctor-poisoned.js",
+  "map/create-revoked-proxy.js",
+  "map/create-species-abrupt.js",
+  "map/create-species-non-ctor.js",
+  "map/create-species-poisoned.js",
+  "map/create-species-undef-invalid-len.js",
+  "reduceRight/15.4.4.22-4-2.js",
+  "reduceRight/15.4.4.22-4-7.js",
+];
+
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+maybe("#1601 array iteration callback codegen", () => {
+  for (const rel of cases) {
+    it(`${rel} compiles to valid Wasm (not compile_error)`, async () => {
+      const r = await runTest262File(`${ROOT}/${rel}`, "built-ins/Array");
+      expect(r.status, `reason: ${r.reason ?? ""}`).not.toBe("compile_error");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

The Array iteration callback cluster (#1601) was originally a 156-test
stack-underflow cluster; that was already resolved by intervening merges. The
committed test262 baseline showed only **10** residual `compile_error`s in the
cluster, which were two distinct, narrower codegen bugs — both fixed here:

- **map bridge result not boxed** (8 tests): `compileArrayMap`'s host-bridge
  branch only coerced the f64 callback result to i32, never f64→externref. On
  an untyped source array (`new Array(n)`, externref elements) `array.set`
  expected externref but found f64. Now uses the general `coercionInstrs`
  (`f64 → mapResultElemType`), which boxes via `__box_number` for externref.
- **reduceRight 2-arg bridge never registered** (2 tests): the `__call_2_f64`
  import pre-scans (`index.ts`, `declarations.ts`) only set `need2` for
  `"reduce"`, and `reduceRight` was missing from `FUNCTIONAL_ARRAY_METHODS`.
  A non-closure `reduceRight` callback hit the bridge path with no registered
  import → "Missing __call_2_f64 import". Added `reduceRight` to the set and
  treated like `reduce` in both pre-scans.

All 10 baseline `compile_error`s now compile to valid Wasm (2 pass, 8 fail on
species/abrupt-ctor runtime semantics that are out of scope).

## Test plan

- [x] `tests/issue-1601.test.ts` — 10 test262-backed cases; fail on clean main, pass with fix
- [x] `npx tsc --noEmit` clean
- [x] Isolated per-process `runTest262File` runs confirm no regressions in cluster
- [ ] CI test262 sharded run

🤖 Generated with [Claude Code](https://claude.com/claude-code)