### PR TITLE
fix(#1596): Function.prototype.apply/.call on compiled function expressions

### DIFF
--- a/plan/issues/1596-function-prototype-apply-call-not-accessible.md
+++ b/plan/issues/1596-function-prototype-apply-call-not-accessible.md
@@ -1,9 +1,10 @@
 ---
 id: 1596
 title: "Function.prototype.apply / .call not accessible on compiled Wasm functions (~46 fails)"
-status: backlog
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -84,3 +85,48 @@ Option 3 is compile-time (zero runtime overhead) but only covers the static-disp
 - Overlaps conceptually with WasmGC object leakage (#983) — compiled objects escape to JS and don't have expected prototype methods
 - If a static-rewrite approach is used for `fn.apply(...)`, must handle the case where `fn` is not a literal (dynamic dispatch)
 - The `spread-*.js` failures suggest the array spread `[...arr]` lowering itself calls `.apply` internally — inspect the spread codegen path before assuming the test calls `.apply` directly
+
+## Resolution (2026-05-27)
+
+**Root cause confirmed.** The `.call`/`.apply` handler in
+`compileCallExpression` (`src/codegen/expressions/calls.ts`) only handled two
+receiver shapes: a bare identifier (`fn.call(...)`) and a property access
+(`obj.method.call(...)`). A **(parenthesized) function/arrow expression**
+receiver — `(function(){}).apply(...)` / `(() => {}).call(...)`, the exact
+test262 shape — matched neither case and fell through to the generic
+member-call path, which routed `.apply`/`.call` to a host call on the WasmGC
+function struct. The struct is not a JS `Function`, so the host lookup threw
+`apply is not a function`.
+
+**Fix (option 3, compile-time static rewrite).** Added "Case 0" at the top of
+the handler: when the receiver unwraps to a non-generator function/arrow
+expression, rewrite `(fn).call(thisArg, a, b)` → `(fn)(a, b)` and
+`(fn).apply(thisArg, [a, b])` → `(fn)(a, b)`, dropping `thisArg` (standalone
+functions ignore `this`) after evaluating it for side effects. The synthetic
+direct call re-enters `compileCallExpression`, reusing the existing IIFE
+inlining path (which binds `arguments` correctly). For `.apply` the args-array
+literal is statically flattened via a new `flattenStaticArrayElements` helper
+that also expands spreads of nested array literals (`[...[3,4,5]]`, the common
+test262 shape). Non-literal args arrays and dynamic spread sources are left to
+the generic path (no regression).
+
+### Scope / known limitations
+- `fn.apply(null, dynamicVar)` and `fn.apply(null, [...iterableExpr])` where the
+  spread source is not a literal still defer (need a dynamic args-array path —
+  separate feature).
+- Dynamic-`this` tests (e.g. `S15.3.4.4_A3_T8.js`, which writes `this.feat` to
+  the global object) are out of scope — the compiler does not model
+  global-object `this`.
+
+## Test Results
+- New unit suite `tests/issue-1596.test.ts` — 6/6 pass (apply+literal,
+  apply+arguments.length, call+positional, arrow apply, empty-args apply,
+  nested call).
+- test262 `language/expressions/array/spread-*`: **12 → 24 pass** (+12) in that
+  directory alone (measured fixed-worktree vs main HEAD with the vitest runner).
+- The two issue example files `spread-sngl-literal.js` and
+  `spread-mult-literal.js` now pass.
+- No regressions: `function-expressions.test.ts` / `arrow-call-apply.test.ts` /
+  `fn-variable-call.test.ts` failures are pre-existing on main (stale harness:
+  missing `string_constants` import / missing `tests/helpers.js`), unrelated to
+  this change.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1230,6 +1230,31 @@ function matchProcessStdStreamWrite(
 }
 
 /**
+ * Statically flatten an array literal's elements into a positional argument
+ * list, expanding spreads of nested array literals (`[...[a, b]]` → `a, b`).
+ * Returns undefined when the literal contains an element we cannot expand at
+ * compile time (a spread of a non-literal, or an elided hole). Used by the
+ * `fn.apply(thisArg, [...])` rewrite (#1596).
+ */
+function flattenStaticArrayElements(arr: ts.ArrayLiteralExpression): ts.Expression[] | undefined {
+  const out: ts.Expression[] = [];
+  for (const el of arr.elements) {
+    if (ts.isOmittedExpression(el)) return undefined;
+    if (ts.isSpreadElement(el)) {
+      let inner: ts.Expression = el.expression;
+      while (ts.isParenthesizedExpression(inner)) inner = inner.expression;
+      if (!ts.isArrayLiteralExpression(inner)) return undefined;
+      const nested = flattenStaticArrayElements(inner);
+      if (nested === undefined) return undefined;
+      out.push(...nested);
+    } else {
+      out.push(el);
+    }
+  }
+  return out;
+}
+
+/**
  * #1653 — match `process.stdin.read(buf, offset?)` under --target wasi: the
  * binary, incremental stdin read (the Node-API replacement for readStdin()).
  * Returns true when matched. Mirrors `matchProcessStdStreamWrite`.
@@ -1994,6 +2019,60 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (propAccess.name.text === "call" || propAccess.name.text === "apply") {
       const isCall = propAccess.name.text === "call";
       const innerExpr = propAccess.expression;
+
+      // Case 0: (function(){}).call/apply(...) and (() => {}).call/apply(...).
+      // A compiled function is a WasmGC funcref/struct, not a JS Function, so a
+      // host-side `.apply`/`.call` lookup fails ("apply is not a function").
+      // Rewrite statically to a direct invocation of the function expression,
+      // dropping thisArg (standalone functions ignore `this`). This reuses the
+      // IIFE-inlining path, which also binds `arguments` correctly (#1596).
+      {
+        let fnExpr: ts.Expression = innerExpr;
+        while (ts.isParenthesizedExpression(fnExpr)) fnExpr = fnExpr.expression;
+        const isFnLiteral =
+          (ts.isFunctionExpression(fnExpr) && fnExpr.asteriskToken === undefined) || ts.isArrowFunction(fnExpr);
+        if (isFnLiteral) {
+          let directArgs: readonly ts.Expression[] | undefined;
+          if (isCall) {
+            // fn.call(thisArg, a, b, ...) → fn(a, b, ...)
+            directArgs = expr.arguments.slice(1);
+          } else if (expr.arguments.length < 2) {
+            // fn.apply(thisArg) / fn.apply() → fn()
+            directArgs = [];
+          } else {
+            // fn.apply(thisArg, [a, b, ...]) → fn(a, b, ...). Statically flatten
+            // the args-array literal into positional call arguments so the
+            // IIFE-inlining path sees a fixed argument count (it binds
+            // `arguments` from the literal arg list and does not expand spreads
+            // itself). A spread of a nested array literal (`[...[3,4,5]]`, the
+            // common test262 shape) is flattened recursively. Anything we
+            // cannot statically flatten (dynamic spread source, elided holes)
+            // is left to the generic path.
+            const argsExpr = expr.arguments[1]!;
+            if (ts.isArrayLiteralExpression(argsExpr)) {
+              const flattened = flattenStaticArrayElements(argsExpr);
+              if (flattened !== undefined) directArgs = flattened;
+            }
+          }
+          if (directArgs !== undefined) {
+            // Evaluate the receiver-position thisArg for side effects (spec:
+            // arguments are evaluated even though standalone functions ignore
+            // `this`). For .call/.apply the thisArg is expr.arguments[0].
+            if (expr.arguments.length > 0) {
+              const thisType = compileExpression(ctx, fctx, expr.arguments[0]!);
+              if (thisType !== null) fctx.body.push({ op: "drop" });
+            }
+            const directCall = ts.factory.createCallExpression(
+              fnExpr as ts.LeftHandSideExpression,
+              undefined,
+              directArgs,
+            );
+            ts.setTextRange(directCall, expr);
+            (directCall as any).parent = expr.parent;
+            return compileCallExpression(ctx, fctx, directCall as ts.CallExpression);
+          }
+        }
+      }
 
       // Case 1: identifier.call(thisArg, args...) — standalone function
       if (ts.isIdentifier(innerExpr)) {

--- a/tests/issue-1596.test.ts
+++ b/tests/issue-1596.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndRun(source: string) {
+  const result = compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+  ).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#1596 Function.prototype.apply/.call on function expressions", () => {
+  it("(function(){}).apply(null, [literal]) forwards arguments", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return (function(a: number, b: number, c: number): number {
+          return a + b + c;
+        }).apply(null, [3, 4, 5]);
+      }
+    `);
+    expect(e.test()).toBe(12);
+  });
+
+  it("(function(){}).apply binds arguments.length", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return (function(a: number, b: number, c: number): number {
+          return arguments.length;
+        }).apply(null, [3, 4, 5]);
+      }
+    `);
+    expect(e.test()).toBe(3);
+  });
+
+  it("(function(){}).call(null, a, b) forwards positional args", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return (function(a: number, b: number): number {
+          return a * b;
+        }).call(null, 6, 7);
+      }
+    `);
+    expect(e.test()).toBe(42);
+  });
+
+  it("(() => {}).apply(null, [literal]) works on arrow functions", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return ((a: number, b: number): number => a - b).apply(null, [10, 3]);
+      }
+    `);
+    expect(e.test()).toBe(7);
+  });
+
+  it(".apply with empty args array invokes with zero args", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return (function(): number { return 99; }).apply(null, []);
+      }
+    `);
+    expect(e.test()).toBe(99);
+  });
+
+  it("nested .call inside expression", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        const x = (function(a: number): number { return a + 1; }).call(null, 41);
+        return x;
+      }
+    `);
+    expect(e.test()).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- A compiled function is a WasmGC funcref/struct, not a JS `Function`, so `(function(){}).apply(...)` / `(() => {}).call(...)` routed `.apply`/`.call` through a host call that threw `apply is not a function`. The call/apply handler only recognized identifier and property-access receivers — not (parenthesized) function/arrow expressions.
- Adds a compile-time rewrite ("Case 0" in `compileCallExpression`): `(fn).call(thisArg, a, b)` → `(fn)(a, b)` and `(fn).apply(thisArg, [a, b])` → `(fn)(a, b)`, dropping `thisArg` (standalone functions ignore `this`) after evaluating it for side effects. The synthetic direct call reuses the existing IIFE-inlining path (which binds `arguments` correctly).
- `.apply` args-array literals are statically flattened via a new `flattenStaticArrayElements` helper that expands spreads of nested array literals (`[...[3,4,5]]`, the common test262 shape). Non-literal args arrays and dynamic spread sources defer to the generic path (no regression).

## Impact
- test262 `language/expressions/array/spread-*`: **12 → 24 pass (+12)** in that directory (measured fixed-worktree vs main HEAD).
- Issue example files `spread-sngl-literal.js` and `spread-mult-literal.js` now pass.

## Out of scope
- `fn.apply(null, dynamicVar)` / `[...iterableExpr]` (dynamic args-array — separate feature).
- Dynamic-`this` (`S15.3.4.4_A3_T8.js` writes `this.feat` to the global object) — compiler doesn't model global-object `this`.

## Test plan
- [x] New unit suite `tests/issue-1596.test.ts` — 6/6 pass.
- [x] Two issue example test262 files pass via the runner.
- [x] No regressions: `function-expressions` / `arrow-call-apply` / `fn-variable-call` failures are pre-existing on main (stale harness), unrelated.
- [ ] CI sharded test262 confirms net positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)