### PR TITLE
fix(#820k): Object.* throws TypeError on null/undefined receiver (ToObject)

### DIFF
--- a/plan/issues/820k-object-receiver-toobject.md
+++ b/plan/issues/820k-object-receiver-toobject.md
@@ -1,9 +1,10 @@
 ---
 id: 820k
 title: "Object.* receiver TypeError on null/undefined (ToObject step) (~39 fails)"
-status: ready
+status: done
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -57,3 +58,28 @@ residual.
 
 - Likely a small, mechanical fix once #1129 lands. Consider sequencing
   after #1129.
+
+## Resolution 2026-05-27 (dev-1606)
+
+#1129 (auto-boxing) already landed. The residual was in `src/runtime.ts`: the
+host-import handlers `__object_keys`, `__object_values`, `__object_entries`, and
+`__getOwnPropertyNames` started with `if (obj == null) return [];` — silently
+returning an empty array instead of throwing TypeError. Per ES §20.1.2.{5,10,18,22}
+these perform ToObject (§7.1.18) which throws on null/undefined.
+
+**Fix:** replaced the four `return [];` early-returns with
+`throw new TypeError("Cannot convert null/undefined to object")`.
+
+Verified safe (no regressions):
+- `Object.assign(null)` already threw (delegates to native Object.assign).
+- `Object.getOwnPropertySymbols(null)` already threw (delegates to native fn).
+- `Object.freeze/seal/preventExtensions(undefined)` correctly pass through the
+  arg unchanged (ES2015+ non-object passthrough) — left untouched.
+- Object spread `{...null}` routes through `__object_assign` (null-tolerant),
+  NOT the keys/getOwnPropertyNames handlers — unaffected.
+- `__getOwnPropertyNames` has a single codegen caller (`Object.getOwnPropertyNames`),
+  so the throw can't break internal enumeration.
+
+Tests: `tests/issue-820k.test.ts` (12 cases, all pass) — keys/values/entries/
+getOwnPropertyNames × null/undefined throw TypeError, plus positive cases
+(real object enumeration, string auto-box, freeze passthrough).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3757,7 +3757,8 @@ assert._isSameValue = isSameValue;
       // exported getters so opaque struct fields are visible at runtime.
       if (name === "__object_keys")
         return (obj: any) => {
-          if (obj == null) return [];
+          // ES §20.1.2.18 Object.keys → ToObject (§7.1.18) throws on null/undefined.
+          if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();
             const fieldNames = _getStructFieldNames(obj, exports);
@@ -3774,7 +3775,8 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__object_values")
         return (obj: any) => {
-          if (obj == null) return [];
+          // ES §20.1.2.22 Object.values → ToObject (§7.1.18) throws on null/undefined.
+          if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();
             const fieldNames = _getStructFieldNames(obj, exports);
@@ -3796,7 +3798,8 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__object_entries")
         return (obj: any) => {
-          if (obj == null) return [];
+          // ES §20.1.2.5 Object.entries → ToObject (§7.1.18) throws on null/undefined.
+          if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();
             const fieldNames = _getStructFieldNames(obj, exports);
@@ -4361,7 +4364,8 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__getOwnPropertyNames")
         return (obj: any) => {
-          if (obj == null) return [];
+          // ES §20.1.2.10 Object.getOwnPropertyNames → ToObject (§7.1.18) throws on null/undefined.
+          if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (!_isWasmStruct(obj)) return Object.getOwnPropertyNames(obj);
           const exports = callbackState?.getExports();
           // #1047 — registered class prototype: return only the allowlist

--- a/tests/issue-820k.test.ts
+++ b/tests/issue-820k.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #820k — Object.* receiver TypeError on null/undefined (ToObject step).
+ *
+ * ES §20.1.2 Object methods perform ToObject(O) (§7.1.18) on their argument
+ * before enumerating. ToObject throws a TypeError on null/undefined. The host
+ * import handlers for Object.keys/values/entries/getOwnPropertyNames previously
+ * returned an empty array instead of throwing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("#820k Object.* receiver ToObject TypeError", () => {
+  const throwsTypeError = (method: string, arg: "null" | "undefined") => `
+    export function test(): number {
+      try {
+        Object.${method}(${arg} as any);
+        return 0;
+      } catch (e) {
+        return e instanceof TypeError ? 1 : 2;
+      }
+    }
+  `;
+
+  for (const method of ["keys", "values", "entries", "getOwnPropertyNames"]) {
+    for (const arg of ["null", "undefined"] as const) {
+      it(`Object.${method}(${arg}) throws TypeError`, async () => {
+        const exports = await compileToWasm(throwsTypeError(method, arg));
+        expect((exports as any).test()).toBe(1);
+      });
+    }
+  }
+
+  it("Object.keys on a real object still enumerates", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        return Object.keys({ a: 1, b: 2 }).length;
+      }
+    `);
+    expect((exports as any).test()).toBe(2);
+  });
+
+  it("Object.values on a real object still enumerates", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const v = Object.values({ a: 10, b: 20 });
+        return (v[0] as number) + (v[1] as number);
+      }
+    `);
+    expect((exports as any).test()).toBe(30);
+  });
+
+  it("Object.keys autoboxes a primitive string (#1129)", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        return Object.keys("ab").length;
+      }
+    `);
+    expect((exports as any).test()).toBe(2);
+  });
+
+  it("Object.freeze(undefined) does not throw (non-object passthrough)", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        return Object.freeze(undefined as any) === undefined ? 1 : 0;
+      }
+    `);
+    expect((exports as any).test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `Object.keys` / `Object.values` / `Object.entries` / `Object.getOwnPropertyNames` now throw `TypeError` on a `null`/`undefined` argument, per ES §20.1.2.{5,10,18,22} → ToObject (§7.1.18).
- Previously the host-import handlers in `src/runtime.ts` started with `if (obj == null) return [];`, silently returning an empty array. ~39 test262 `built-ins/Object/*` failures.

## Why this is safe (no regressions)
- `Object.assign(null)` and `Object.getOwnPropertySymbols(null)` already threw (native delegation) — untouched.
- `Object.freeze`/`seal`/`preventExtensions(undefined)` correctly pass non-objects through unchanged (ES2015+) — untouched.
- Object spread `{...null}` routes through `__object_assign` (null-tolerant), NOT these handlers.
- `__getOwnPropertyNames` has a single codegen caller (`Object.getOwnPropertyNames`), so the throw can't break internal enumeration.
- Positive paths verified: real-object enumeration, primitive string auto-box (#1129), freeze passthrough.

## Test plan
- [x] `tests/issue-820k.test.ts` — 12 cases, all pass (keys/values/entries/getOwnPropertyNames × null/undefined throw TypeError + positive cases)
- [x] Local typecheck clean on changed files
- [ ] CI test262: expect >=30 of ~39 `built-ins/Object/*` to flip to pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)