### PR TITLE
fix(#779e): unmapped arguments object in strict-mode functions

### DIFF
--- a/plan/issues/779e-arguments-object-residual.md
+++ b/plan/issues/779e-arguments-object-residual.md
@@ -1,9 +1,10 @@
 ---
 id: 779e
 title: "arguments-object mapped / trailing-comma / sloppy-strict residuals (~161 fails)"
-status: ready
+status: done
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -60,3 +61,48 @@ remain. They cluster around:
 - [ ] At least 110 of the ~161 tests flip to `pass`.
 - [ ] No regressions in already-passing arguments-object tests.
 - [ ] Both strict and sloppy variants pass for each touched test family.
+
+## Resolution (2026-05-27)
+
+Triage against current main found only ONE of the three listed sub-clusters
+actually reproduces:
+
+- **Trailing comma** (cluster 2): already passing — the TS parser drops a
+  trailing comma, so `f(42, undefined,)` already gives `arguments.length === 2`.
+- **Sloppy mapped** (cluster 1a): already passing — sloppy `arguments[i] = v`
+  reflects into the named param (and vice-versa) via `fctx.mappedArgsInfo`.
+- **`eval("arguments = 10")` SyntaxError** (cluster 3): eval-family, test262-
+  skipped — out of scope.
+- **Strict unmapped** (cluster 1b): THE BUG. The arguments object was built as
+  *mapped* even in strict-mode functions, so writes to `arguments[i]` wrongly
+  reflected into the named parameter (and back). §10.4.4 requires strict
+  functions to get an *unmapped* arguments object.
+
+### Fix
+
+New helper `src/codegen/helpers/is-strict-function.ts` — detects strict-mode
+functions via (a) a `"use strict"` directive prologue on the function or any
+enclosing function / the SourceFile, or (b) class context (class bodies are
+always strict). ES-module strictness is deliberately NOT inferred from
+top-level import/export, because the compiler wraps every program in a
+synthetic `export function test(...)` entry point — inferring module strictness
+there would wrongly unmap *all* sloppy functions.
+
+The mapped-arguments wiring now skips `fctx.mappedArgsInfo` for strict
+functions, so the built `arguments` vec stays an independent copy:
+
+- `src/codegen/function-body.ts` — top-level function declarations.
+- `src/codegen/statements/nested-declarations.ts` — `emitArgumentsObject` gains
+  an `unmapped` param; lifted function declarations pass `isStrictFunction`.
+- `src/codegen/class-bodies.ts` — class methods always pass `unmapped = true`.
+- `src/codegen/literals.ts` — object-literal methods pass `isStrictFunction`.
+- `src/codegen/shared.ts` — delegate signature threads the `unmapped` flag.
+
+### Tests
+
+`tests/issue-779e.test.ts` — 6 cases (sloppy/strict × both sync directions,
+trailing comma, class method). All pass. No new failures in the arguments
+suites that use the standard import harness (issue-849, issue-1053). Pre-
+existing failures in arguments-object.test.ts / issue-820b.test.ts are
+unrelated harness issues (`{env:{}}` import object / missing `./helpers.js`),
+not regressions from this change.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -1415,7 +1415,8 @@ export function compileClassBodies(
       if (member.body && bodyUsesArguments(member.body)) {
         const methodParamTypes = params.slice(isStatic ? 0 : 1).map((p) => p.type);
         const paramOffset = isStatic ? 0 : 1; // skip 'this' param for instance methods
-        emitArgumentsObject(ctx, fctx, methodParamTypes, paramOffset);
+        // Class bodies are always strict code → unmapped arguments (#779e).
+        emitArgumentsObject(ctx, fctx, methodParamTypes, paramOffset, true);
       }
 
       if (isGeneratorMethod && member.body) {

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -38,6 +38,7 @@ import {
 } from "./shared.js";
 import { emitArgumentsVecBody } from "./statements/nested-declarations.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
+import { isStrictFunction } from "./helpers/is-strict-function.js";
 import { detectStringBuilders } from "./string-builder.js";
 import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
@@ -814,10 +815,15 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
 
     // Check if all params are simple identifiers (not destructuring patterns).
     // Mapped arguments only applies to simple parameter lists in non-strict mode.
+    // In strict mode the arguments object is *unmapped* (§10.4.4): writes to
+    // `arguments[i]` must not flow back into the named parameter, so skip
+    // mappedArgsInfo entirely and leave the built vec as an independent copy
+    // (#779e).
     const allSimpleParams = decl.parameters.every((p) => ts.isIdentifier(p.name) && !p.dotDotDotToken);
+    const mappedAllowed = allSimpleParams && !isStrictFunction(decl);
 
     // Set up mapped arguments info for param ↔ arguments sync (#849)
-    if (allSimpleParams && params.length > 0) {
+    if (mappedAllowed && params.length > 0) {
       fctx.mappedArgsInfo = {
         argsLocalIdx: argsLocal,
         arrTypeIdx,

--- a/src/codegen/helpers/is-strict-function.ts
+++ b/src/codegen/helpers/is-strict-function.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../../ts-api.js";
+
+const cache = new WeakMap<ts.Node, boolean>();
+
+/** True when the prologue of `body` opens with a `"use strict"` directive. */
+function hasUseStrictPrologue(statements: readonly ts.Statement[]): boolean {
+  for (const s of statements) {
+    // A Directive Prologue is a leading run of ExpressionStatements whose
+    // expression is a string literal. The first non-directive statement ends it.
+    if (ts.isExpressionStatement(s) && ts.isStringLiteralLike(s.expression)) {
+      if (s.expression.text === "use strict") return true;
+      continue;
+    }
+    break;
+  }
+  return false;
+}
+
+/**
+ * Decide whether `fn`'s body is strict-mode code (ECMA-262 §11.2.2).
+ *
+ * Strict applies when any of these hold:
+ *  - the function body itself opens with a `"use strict"` directive,
+ *  - an enclosing function body or the SourceFile opens with `"use strict"`,
+ *  - the function is a class element or lives anywhere inside a class
+ *    (ClassDeclaration / ClassExpression bodies are always strict).
+ *
+ * NOTE: ES-module strictness is deliberately NOT inferred from top-level
+ * import/export here. The compiler wraps every program in a synthetic
+ * `export function test(...)` entry point, which would make *every* source a
+ * module and wrongly unmap sloppy-mode `arguments`. The only reliable signals
+ * left after wrapping are explicit `"use strict"` prologues and class context.
+ *
+ * This drives the mapped-vs-unmapped `arguments` split: strict functions get
+ * an *unmapped* arguments object, so writes to `arguments[i]` must not flow
+ * back into the named parameter (#779e).
+ */
+export function isStrictFunction(fn: ts.FunctionLikeDeclaration): boolean {
+  const cached = cache.get(fn);
+  if (cached !== undefined) return cached;
+
+  let result = false;
+
+  // 1. The function's own directive prologue.
+  if (fn.body && ts.isBlock(fn.body) && hasUseStrictPrologue(fn.body.statements)) {
+    result = true;
+  }
+
+  // 2. Walk enclosing scopes for a class context or an outer "use strict".
+  if (!result) {
+    for (let node: ts.Node | undefined = fn.parent; node; node = node.parent) {
+      if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+        result = true;
+        break;
+      }
+      if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isMethodDeclaration(node)) {
+        if (node.body && ts.isBlock(node.body) && hasUseStrictPrologue(node.body.statements)) {
+          result = true;
+          break;
+        }
+      }
+      if (ts.isSourceFile(node)) {
+        if (hasUseStrictPrologue(node.statements)) {
+          result = true;
+        }
+        break;
+      }
+    }
+  }
+
+  cache.set(fn, result);
+  return result;
+}

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -30,6 +30,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
+import { isStrictFunction } from "./helpers/is-strict-function.js";
 import {
   cacheStringLiterals,
   destructureParamArray,
@@ -1684,7 +1685,8 @@ export function compileObjectLiteralForStruct(
       // `arguments.length` and `arguments[n]` work at runtime.
       if (prop.body && bodyUsesArguments(prop.body)) {
         const methodParamTypes = methodFctxParams.slice(1).map((p) => p.type); // skip 'this'
-        emitArgumentsObject(ctx, methodFctx, methodParamTypes, 1); // paramOffset 1 to skip 'this'
+        // Object-literal methods inherit the surrounding code's strictness (#779e).
+        emitArgumentsObject(ctx, methodFctx, methodParamTypes, 1, isStrictFunction(prop)); // paramOffset 1 to skip 'this'
       }
 
       if (isGeneratorMethod && prop.body) {

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -431,6 +431,7 @@ type EmitArgumentsObjectFn = (
   fctx: FunctionContext,
   paramTypes: ValType[],
   paramOffset: number,
+  unmapped?: boolean,
 ) => void;
 
 let _emitArgumentsObject: EmitArgumentsObjectFn = () => {
@@ -441,13 +442,19 @@ export function registerEmitArgumentsObject(fn: EmitArgumentsObjectFn): void {
   _emitArgumentsObject = fn;
 }
 
+/**
+ * `unmapped`: when true (strict-mode functions, §10.4.4) the param↔arguments
+ * sync is suppressed so writes to `arguments[i]` do not flow back into the
+ * named parameter (#779e). Defaults to false (sloppy, mapped).
+ */
 export function emitArgumentsObject(
   ctx: CodegenContext,
   fctx: FunctionContext,
   paramTypes: ValType[],
   paramOffset: number,
+  unmapped = false,
 ): void {
-  _emitArgumentsObject(ctx, fctx, paramTypes, paramOffset);
+  _emitArgumentsObject(ctx, fctx, paramTypes, paramOffset, unmapped);
 }
 
 // ── compileStringLiteral ──────────────────────────────────────────────

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -7,6 +7,7 @@
 import { ts } from "../../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../../checker/type-mapper.js";
 import { bodyUsesArguments } from "../helpers/body-uses-arguments.js";
+import { isStrictFunction } from "../helpers/is-strict-function.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import {
   collectFunctionOwnLocals,
@@ -352,7 +353,7 @@ export function compileNestedFunctionDeclaration(
 
     // Set up `arguments` object if the function body references it
     if (stmt.body && bodyUsesArguments(stmt.body)) {
-      emitArgumentsObject(ctx, liftedFctx, paramTypes, 0);
+      emitArgumentsObject(ctx, liftedFctx, paramTypes, 0, isStrictFunction(stmt));
     }
 
     if (isGenerator) {
@@ -590,7 +591,7 @@ export function compileNestedFunctionDeclaration(
 
     // Set up `arguments` object if the function body references it
     if (stmt.body && bodyUsesArguments(stmt.body)) {
-      emitArgumentsObject(ctx, liftedFctx, paramTypes, captures.length);
+      emitArgumentsObject(ctx, liftedFctx, paramTypes, captures.length, isStrictFunction(stmt));
     }
 
     if (isGenerator) {
@@ -1153,6 +1154,7 @@ export function emitArgumentsObject(
   fctx: FunctionContext,
   paramTypes: ValType[],
   paramOffset: number,
+  unmapped = false,
 ): void {
   const numArgs = paramTypes.length;
   const elemType: ValType = { kind: "externref" };
@@ -1170,15 +1172,19 @@ export function emitArgumentsObject(
     flushLateImportShifts(ctx, fctx);
   }
 
-  // Set up mapped arguments info for param ↔ arguments bidirectional sync (#849)
-  fctx.mappedArgsInfo = {
-    argsLocalIdx: argsLocal,
-    arrTypeIdx: ati,
-    vecTypeIdx: vti,
-    paramCount: numArgs,
-    paramOffset,
-    paramTypes: paramTypes.slice(),
-  };
+  // Set up mapped arguments info for param ↔ arguments bidirectional sync (#849).
+  // Strict-mode functions get an *unmapped* arguments object (§10.4.4): skip the
+  // sync so writes to `arguments[i]` don't reflect into the named param (#779e).
+  if (!unmapped) {
+    fctx.mappedArgsInfo = {
+      argsLocalIdx: argsLocal,
+      arrTypeIdx: ati,
+      vecTypeIdx: vti,
+      paramCount: numArgs,
+      paramOffset,
+      paramTypes: paramTypes.slice(),
+    };
+  }
 
   // Build the arguments vec by concatenating formal params with
   // extras delivered via the __extras_argv global (#1053).

--- a/tests/issue-779e.test.ts
+++ b/tests/issue-779e.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "t.ts" });
+  if (!r.success) throw new Error("compile failed: " + r.errors?.[0]?.message);
+  const imp = buildImports(r.imports, undefined, r.stringPool) as any;
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  if (imp.setExports) imp.setExports(instance.exports);
+  return (instance.exports as any).test();
+}
+
+describe("#779e arguments-object mapped/unmapped strict split", () => {
+  it("sloppy: writing arguments[i] reflects into the named param (mapped)", async () => {
+    expect(
+      await runTest(`export function test(): number {
+        function f(a) { arguments[0] = 99; return a; }
+        return f(1);
+      }`),
+    ).toBe(99);
+  });
+
+  it("strict: writing arguments[i] does NOT reflect into the named param (unmapped)", async () => {
+    expect(
+      await runTest(`"use strict";
+      export function test(): number {
+        function f(a) { arguments[0] = 99; return a; }
+        return f(1);
+      }`),
+    ).toBe(1);
+  });
+
+  it("sloppy: writing the param reflects into arguments[i] (mapped, read direction)", async () => {
+    expect(
+      await runTest(`export function test(): number {
+        function f(a) { a = 7; return arguments[0]; }
+        return f(1);
+      }`),
+    ).toBe(7);
+  });
+
+  it("strict: writing the param does NOT reflect into arguments[i]", async () => {
+    expect(
+      await runTest(`"use strict";
+      export function test(): number {
+        function f(a) { a = 7; return arguments[0]; }
+        return f(1);
+      }`),
+    ).toBe(1);
+  });
+
+  it("trailing comma in the argument list does not inflate arguments.length", async () => {
+    expect(
+      await runTest(`export function test(): number {
+        function f() { return arguments.length; }
+        return f(42, undefined,);
+      }`),
+    ).toBe(2);
+  });
+
+  it("class methods are always strict → unmapped arguments", async () => {
+    expect(
+      await runTest(`export function test(): number {
+        class C { m(a) { arguments[0] = 99; return a; } }
+        return new C().m(1);
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Strict-mode functions now get an **unmapped** arguments object (§10.4.4): writes to `arguments[i]` no longer reflect into the named parameter (nor the reverse). The mapped/unmapped split was documented in `function-body.ts` but never implemented — the arguments object was always built as mapped.
- New helper `src/codegen/helpers/is-strict-function.ts` detects strict mode via a `"use strict"` directive prologue (on the function or any enclosing function / the SourceFile) or class context. Module strictness is deliberately **not** inferred from top-level import/export, because the compiler wraps every program in a synthetic `export function test(...)` entry point — that would wrongly unmap *all* sloppy functions.
- Wiring: `function-body.ts` (top-level fns), `statements/nested-declarations.ts` (lifted fns + `emitArgumentsObject` gains an `unmapped` param), `class-bodies.ts` (class methods always unmapped), `literals.ts` (object methods), `shared.ts` (delegate threads the flag).

## Triage note
Of the three sub-clusters in #779e, only strict-unmapped actually reproduced on main. Trailing-comma (`f(42, undefined,)` → length 2) and sloppy mapped were already correct; `eval("arguments = 10")` SyntaxError is eval-family (test262-skipped).

## Test plan
- [x] `tests/issue-779e.test.ts` — 6 cases (sloppy/strict × both sync directions, trailing comma, class method) all pass
- [x] `npx tsc --noEmit` clean; `biome lint` clean; `prettier --check` clean
- [x] No new failures in arguments suites using the standard import harness (issue-849, issue-1053). Pre-existing failures in arguments-object.test.ts / issue-820b.test.ts are unrelated harness issues (`{env:{}}` import object / missing `./helpers.js`), present without this change.
- [ ] CI test262 conformance (regression gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)