### PR TITLE
fix(#821): preserve real value for void-default dstr bindings

### DIFF
--- a/plan/issues/821-bindingelement-null-guard-over-triggering.md
+++ b/plan/issues/821-bindingelement-null-guard-over-triggering.md
@@ -1,9 +1,10 @@
 ---
 id: 821
 title: "BindingElement null guard over-triggering"
-status: ready
+status: done
 created: 2026-03-27
-updated: 2026-04-28
+updated: 2026-05-27
+completed: 2026-05-27
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -50,3 +51,37 @@ This issue should be re-scoped or broken into specific sub-issues:
 - Iterator protocol for array destructuring (Symbol.iterator support)
 - Async generator destructured parameters
 - Rest element with nested destructuring
+
+## Resolution (2026-05-27)
+
+The 2026-03-27 note was correct that the null *guard* mechanism is sound. The
+real bug in the `init-skipped` family is a **binding-local type-inference**
+problem, not a guard problem:
+
+For `{ s: t = counter() }` (or `[w = counter()]`) where `counter()` returns
+`void`, TypeScript infers the binding's type as pure `void` — the default
+initializer is its only type evidence. `mapTsTypeToWasm` maps `void` → `i32`
+(type-mapper.ts:51), so when the property is present and non-`undefined`
+(`null`/`0`/`false`/`''`, an externref), the value is coerced into an `i32`
+local and destroyed. The default never actually fires (the guard is correct),
+but the preserved value is mangled → `assert.sameValue(t, null)` fails.
+
+**Fix**: `resolveBindingElementType` (new, in type-mapper.ts) — when a binding
+element has a default initializer AND its resolved type is the void/undefined
+sentinel, type the local as `externref` so the real value survives unchanged.
+Wired into `ensureBindingLocals` (the central pre-allocation for every
+destructuring path: decl, function-param, class-method, catch).
+
+**Measured impact** (init-skipped + init-undef dstr family, 376 tests, via
+the test262 runner): main 209 pass → fix 262 pass (**+53**), compile_errors
+unchanged (14 → 14). No regressions in the destructuring equivalence suite
+(78 pass; the 2 failures in destructuring-extended / destructuring-initializer
+pre-date this change).
+
+**Residual sub-issues (NOT fixed here — separate root causes):**
+- Eager default-evaluation for `[x = counter()] = [literal]` array params
+  nested inside object-literal methods (the param-level default `= [...]`
+  interacts with element defaults — ~49 `initCount != 0` fails).
+- `init-undef` in `for-await-of` async-generator destructuring (default
+  should fire for `undefined` but doesn't — ~27 fails).
+- `illegal cast in __closure_*` for some closure-captured dstr defaults (~4).

--- a/src/checker/type-mapper.ts
+++ b/src/checker/type-mapper.ts
@@ -187,6 +187,33 @@ export function isVoidType(type: ts.Type): boolean {
   return (type.flags & ts.TypeFlags.Void) !== 0 || (type.flags & ts.TypeFlags.Undefined) !== 0;
 }
 
+/**
+ * Resolve the Wasm type of a destructuring binding element's local (#821).
+ *
+ * For `{ s: t = counter() }` where `counter()` returns `void`, TS infers `t`'s
+ * type as `void` (or `void | undefined`) — its only evidence is the default
+ * initializer. `resolveWasmType` then maps that to `i32`, so the *actual*
+ * property value (`null`/`0`/`false`/`''`, an externref) gets coerced into an
+ * i32 local and is destroyed — the spec requires the present, non-`undefined`
+ * value to be preserved and the default skipped (§13.3.3.6/§13.3.3.7).
+ *
+ * When an element has a default initializer AND the resolved type is the
+ * void/undefined sentinel, the local must be `externref` so it can faithfully
+ * hold whatever real value flows in. `resolve` is the caller's
+ * `resolveWasmType(ctx, tsType)` (passed in to avoid a circular import).
+ */
+export function resolveBindingElementType(
+  element: ts.BindingElement,
+  tsType: ts.Type,
+  resolve: (t: ts.Type) => ValType,
+): ValType {
+  const resolved = resolve(tsType);
+  if (element.initializer && isVoidType(tsType)) {
+    return { kind: "externref" };
+  }
+  return resolved;
+}
+
 /** Check if a ts.Type represents bigint */
 export function isBigIntType(type: ts.Type): boolean {
   return (type.flags & ts.TypeFlags.BigInt) !== 0 || (type.flags & ts.TypeFlags.BigIntLiteral) !== 0;

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -17,6 +17,7 @@ import {
   nativeStringType,
   resolveWasmType,
 } from "../index.js";
+import { resolveBindingElementType } from "../../checker/type-mapper.js";
 import {
   type BindingKind,
   buildDestructureNullThrow,
@@ -50,7 +51,7 @@ export function ensureBindingLocals(ctx: CodegenContext, fctx: FunctionContext, 
       // Without a local, nested binding pattern destructuring silently skips the
       // assignment because fctx.localMap.get(name) returns undefined (#794).
       const elemType = ctx.checker.getTypeAtLocation(element);
-      const wasmType = resolveWasmType(ctx, elemType);
+      const wasmType = resolveBindingElementType(element, elemType, (t) => resolveWasmType(ctx, t));
       allocLocal(fctx, name, wasmType);
     } else if (ts.isObjectBindingPattern(element.name) || ts.isArrayBindingPattern(element.name)) {
       ensureBindingLocals(ctx, fctx, element.name);

--- a/tests/issue-821.test.ts
+++ b/tests/issue-821.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #821 — A destructuring binding element whose default initializer returns
+ * `void` (e.g. `{ s: t = counter() }` where `counter(): void`) made TypeScript
+ * infer the binding's type as `void`. `mapTsTypeToWasm` mapped that to `i32`,
+ * so the *actual* present property value (`null`/`0`/`false`/`''`, an
+ * externref) was coerced into an `i32` local and destroyed.
+ *
+ * Per ECMA-262 §13.3.3.6/§13.3.3.7 the default is only used when the value is
+ * `undefined`; a present, non-`undefined` value must be preserved unchanged.
+ * The fix types such bindings as `externref` so the real value survives.
+ */
+async function run(src: string): Promise<Record<string, any>> {
+  const r = compile(src, { fileName: "test.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as any;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(instance.exports);
+  return instance.exports as Record<string, any>;
+}
+
+describe("#821 — void-default dstr binding preserves the real value", () => {
+  it("object param with renamed binding + void default: falsy values preserved", async () => {
+    const ex = await run(`
+      var initCount = 0;
+      function counter() { initCount += 1; }
+      let rt: any, rv: any, rx: any, rz: any;
+      function f({ s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() }: any) {
+        rt = t; rv = v; rx = x; rz = z;
+      }
+      export function test(): number {
+        initCount = 0;
+        f({ s: null, u: 0, w: false, y: '' });
+        if (rt !== null) return -10;
+        if (rv !== 0) return -11;
+        if (rx !== false) return -12;
+        if (rz !== '') return -13;
+        if (initCount !== 0) return -14;
+        return 1;
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+
+  it("class method object param with void default: falsy values preserved", async () => {
+    const ex = await run(`
+      var initCount = 0;
+      function counter() { initCount += 1; }
+      let oa: any, ob: any;
+      class C {
+        m({ a = counter(), b = counter() }: any): number {
+          oa = a; ob = b;
+          if (oa !== null) return -40;
+          if (ob !== 0) return -41;
+          if (initCount !== 0) return -42;
+          return 1;
+        }
+      }
+      export function test(): number {
+        initCount = 0;
+        return new C().m({ a: null, b: 0 });
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+
+  it("void default still fires when the property is undefined", async () => {
+    const ex = await run(`
+      var initCount = 0;
+      function counter() { initCount += 1; }
+      let oa: any;
+      function f({ a = counter() }: any) { oa = a; }
+      export function test(): number {
+        initCount = 0;
+        f({});
+        // a was undefined -> default ran exactly once; counter() returns undefined
+        if (initCount !== 1) return -50 - initCount;
+        if (oa !== undefined) return -60;
+        return 1;
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- A destructuring binding element whose default initializer returns `void` (e.g. `{ s: t = counter() }` with `counter(): void`) made TypeScript infer the binding type as pure `void`. `mapTsTypeToWasm` maps `void` → `i32`, so the present, non-`undefined` property value (`null`/`0`/`false`/`''`, an externref) was coerced into an `i32` local and **destroyed** — failing the `init-skipped` test262 family. Per §13.3.3.6/§13.3.3.7 a present value must be preserved and the default skipped.
- Fix: new `resolveBindingElementType` in `src/checker/type-mapper.ts` — when an element has a default initializer **and** its resolved type is the void/undefined sentinel, type the local as `externref` so the real value survives unchanged. Wired into `ensureBindingLocals` (the central pre-allocation used by every destructuring path: decl, function-param, class-method, catch).

## Impact (measured via the test262 runner)
- `init-skipped` + `init-undef` dstr family (376 tests): **main 209 pass → 262 pass (+53)**, compile_errors unchanged (14 → 14).
- No regressions in the destructuring equivalence suite (78 pass; the 2 failures in `destructuring-extended` / `destructuring-initializer` pre-date this change and fail identically on `main`).

## Out of scope (separate root causes, noted in the issue file)
- Eager default-eval for `[x = counter()] = [literal]` array params nested in object-literal methods.
- `init-undef` in `for-await-of` async-generator destructuring.
- `illegal cast` for some closure-captured dstr defaults.

## Test plan
- [x] `tests/issue-821.test.ts` — object param + class method preserve falsy values; void default still fires for `undefined`
- [x] `npx tsc --noEmit` clean (0 errors)
- [x] dstr equivalence suite: no new failures vs main
- [ ] CI test262 regression gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)