### PR TITLE
fix(#1568): Object(BigInt) auto-boxes to wrapper object

### DIFF
--- a/plan/issues/1568-object-bigint-symbol-auto-box.md
+++ b/plan/issues/1568-object-bigint-symbol-auto-box.md
@@ -1,9 +1,10 @@
 ---
 id: 1568
 title: "Object(BigInt) and Object(Symbol) must auto-box to wrappers (typeof === \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"object\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\")"
-status: ready
+status: done
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
+completed: 2026-05-27
 feasibility: easy
 sprint: Backlog
 depends_on: [1129]
@@ -55,6 +56,32 @@ Assertion #5 (`typeof Object(BigInt(0))`) and #6 (`typeof Object(0n)`) likely fa
 
 - §20.1.1.1 `Object ( [ value ] )` — step 2.a: if `value` is `null` or `undefined`, return `! OrdinaryObjectCreate(%Object.prototype%)`. Step 3: return `! ToObject(value)`.
 - §7.1.18 ToObject — Table 13: BigInt → "Return a new BigInt object whose [[BigIntData]] internal slot is set to argument."
+
+## Resolution (2026-05-27)
+
+- **calls.ts** `Object(x)` switch — added a `BigInt` branch after boolean:
+  compiles the arg to `i64` and calls a new `__new_BigInt(i64) → externref`
+  late import.
+- **runtime.ts** construct dispatch (`intent.action === "new"`) — special-cases
+  `intent.className === "BigInt" || "Symbol"` to box via the spec's literal
+  `Object(v)`, since BigInt/Symbol are not constructors and `new BigInt(v)`
+  throws. Placed before the generic `new Ctor(...)` so `__new_BigInt` no longer
+  resolves to "No dependency provided for extern class BigInt".
+- Symbol shares the same runtime handler; the codegen Symbol branch is deferred
+  until Symbol primitives are plumbed end-to-end (no `isSymbolType` arg path
+  yet) — the runtime side is ready for when it lands.
+
+All 6 assertions of `test/language/expressions/typeof/bigint.js` now pass
+(verified directly), including #4/#5/#6 that previously returned "bigint".
+Note: `Object(0n).valueOf() === 0n` does not round-trip in the unit harness —
+this is a pre-existing wrapper-`.valueOf()` unboxing limitation shared by the
+number/string/boolean wrappers (the String equivalent behaves identically), out
+of scope here. The real test262 test only checks `typeof`.
+
+## Test Results
+
+- `tests/issue-1568.test.ts` — 6 new tests, all pass.
+- `tests/issue-1129.test.ts` — 9 existing tests, all pass (no regression).
 
 ## References
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1644,6 +1644,18 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         fctx.body.push({ op: "call", funcIdx: finalBoolIdx });
         return { kind: "externref" };
       }
+    } else if (isBigIntType(argTsType)) {
+      // (#1568) Object(bigint) → BigInt wrapper object (§7.1.18 Table 13).
+      // BigInt is i64-represented; `__new_BigInt` boxes via the spec's literal
+      // `Object(v)` — `BigInt` is not a constructor, so `new BigInt(v)` throws.
+      compileExpression(ctx, fctx, args[0]!, { kind: "i64" });
+      const newBigIntIdx = ensureLateImport(ctx, "__new_BigInt", [{ kind: "i64" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      const finalBigIntIdx = ctx.funcMap.get("__new_BigInt") ?? newBigIntIdx;
+      if (finalBigIntIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: finalBigIntIdx });
+        return { kind: "externref" };
+      }
     }
     // Unknown / object / externref / union — per spec, `Object(o)` returns `o`
     // unchanged for objects. We can't distinguish primitive-boxed-as-externref

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2776,6 +2776,14 @@ function resolveImport(
           options == null ? self.addEventListener(type, listener) : self.addEventListener(type, listener, options);
       }
       if (intent.action === "new") {
+        // (#1568) `__new_BigInt(v)` / `__new_Symbol(v)` — Object(bigint) /
+        // Object(symbol) auto-boxing (§7.1.18 ToObject). BigInt and Symbol are
+        // NOT constructors, so `new BigInt(v)` throws; box via the spec's
+        // literal `Object(v)`, yielding an object (typeof "object") whose
+        // valueOf() returns the underlying primitive.
+        if (intent.className === "BigInt" || intent.className === "Symbol") {
+          return (v: any): any => Object(v);
+        }
         // Test262Error is a simple Error subclass used by the test262 harness
         class Test262Error extends Error {
           constructor(msg?: string) {

--- a/tests/issue-1568.test.ts
+++ b/tests/issue-1568.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Tests for #1568 — Object(BigInt) auto-boxing (§7.1.18 ToObject, Table 13).
+ *
+ * PR #460 (#1129) added Object(primitive) boxing for number/string/boolean but
+ * not BigInt. Object(bigint) previously fell through the "Object(object) →
+ * return unchanged" branch, so `typeof Object(0n)` was "bigint" instead of
+ * "object". This adds a BigInt branch to the Object(x) switch + a __new_BigInt
+ * host handler that boxes via the spec's literal Object(v) (BigInt is not a
+ * constructor, so `new BigInt(v)` throws).
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1568 — Object(BigInt) auto-boxing", () => {
+  it("typeof Object(0n) === 'object'", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(0n) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("typeof Object(BigInt(42)) === 'object'", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(BigInt(42)) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("typeof Object(BigInt(0n)) === 'object' (test262 assertion #4)", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(BigInt(0n)) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("bare bigint literal stays typeof 'bigint' (no over-boxing)", async () => {
+    const r = await run(`export function test(): number {
+      const x = 0n;
+      return typeof x === "bigint" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("regression: Object(number) still boxes to object", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(42) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("regression: Object(boolean) still boxes to object", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(true) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `Object(bigint)` fell through the "Object(object) → return unchanged" branch, so `typeof Object(0n)` was `"bigint"` instead of `"object"` (§7.1.18 ToObject, Table 13). PR #460 (#1129) added number/string/boolean boxing but not BigInt.
- Added a `BigInt` branch to the `Object(x)` switch in `src/codegen/expressions/calls.ts` (compiles arg to `i64`, calls a new `__new_BigInt(i64) → externref` late import).
- Added a runtime handler in `src/runtime.ts` (construct dispatch) that special-cases `BigInt`/`Symbol` to box via the spec's literal `Object(v)` — both are non-constructors, so `new BigInt(v)` throws. Placed before the generic `new Ctor(...)` so `__new_BigInt` resolves correctly.
- Symbol shares the runtime handler; its codegen branch is deferred until Symbol primitives are plumbed end-to-end.

All 6 assertions of `test/language/expressions/typeof/bigint.js` now pass (including #4/#5/#6 that previously returned "bigint").

Note: `Object(0n).valueOf() === 0n` does not round-trip in the unit harness — this is a pre-existing wrapper-`.valueOf()` unboxing limitation shared by number/string/boolean wrappers, out of scope here. The real test262 test only checks `typeof`.

## Test plan
- [x] `tests/issue-1568.test.ts` — 6 new tests pass
- [x] `tests/issue-1129.test.ts` — 9 existing tests pass (no regression)
- [x] `npx tsc --noEmit` clean
- [ ] CI test262 conformance gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)