### PR TITLE
fix(#1602): class-expression-as-value must coerce ctor funcref to externref

### DIFF
--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -4,7 +4,7 @@
  */
 import { ts, forEachChild } from "../../ts-api.js";
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
-import { collectReferencedIdentifiers, collectWrittenIdentifiers } from "../closures.js";
+import { collectReferencedIdentifiers, collectWrittenIdentifiers, emitFuncRefAsClosure } from "../closures.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
@@ -1219,6 +1219,28 @@ function compileNewFunctionExpression(
  * The class should already be collected during the collection phase.
  * We produce the constructor function reference so the class can be instantiated.
  */
+/**
+ * (#1602) Emit a class-expression-as-value: the constructor wrapped in a
+ * closure-struct converted to externref. A bare `ref.func` (funcref) is NOT a
+ * subtype of anyref/externref, so when the class value flowed into an externref
+ * context — `(class {...}).f` member read feeding `__extern_get`, or passed as
+ * a call argument — the raw funcref was left on the stack where externref was
+ * required, producing an invalid module (`call expected externref, found
+ * ref.func`). Mirror the proven `ClassName.constructor` / static-method
+ * extraction path: wrap the ctor funcref in a closure struct and
+ * `extern.convert_any`. Falls back to the legacy funcref only if closure
+ * construction fails (signature unresolvable), preserving prior behaviour.
+ */
+function emitClassCtorValue(ctx: CodegenContext, fctx: FunctionContext, ctorName: string, funcIdx: number): ValType {
+  const closureRef = emitFuncRefAsClosure(ctx, fctx, ctorName, funcIdx);
+  if (closureRef) {
+    fctx.body.push({ op: "extern.convert_any" });
+    return { kind: "externref" };
+  }
+  fctx.body.push({ op: "ref.func", funcIdx });
+  return { kind: "funcref" };
+}
+
 function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.ClassExpression): ValType | null {
   // Look up the synthetic name assigned during the collection phase
   const syntheticName = ctx.anonClassExprNames.get(expr);
@@ -1235,9 +1257,7 @@ function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr
     const ctorName = `${syntheticName}_new`;
     const funcIdx = ctx.funcMap.get(ctorName);
     if (funcIdx !== undefined) {
-      // Produce a ref.func to the constructor as the class value
-      fctx.body.push({ op: "ref.func", funcIdx });
-      return { kind: "funcref" };
+      return emitClassCtorValue(ctx, fctx, ctorName, funcIdx);
     }
   }
 
@@ -1248,8 +1268,7 @@ function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr
       const ctorName = `${className}_new`;
       const funcIdx = ctx.funcMap.get(ctorName);
       if (funcIdx !== undefined) {
-        fctx.body.push({ op: "ref.func", funcIdx });
-        return { kind: "funcref" };
+        return emitClassCtorValue(ctx, fctx, ctorName, funcIdx);
       }
     }
   }

--- a/tests/issue-1602.test.ts
+++ b/tests/issue-1602.test.ts
@@ -76,4 +76,30 @@ describe("#1602 call-site argument coercion emits valid wasm", () => {
       }
     `);
   });
+
+  it("multiple static-async class-method extractions are valid wasm", () => {
+    // Bug D: a class expression used as a value produced a bare `ref.func`
+    // (funcref) for the constructor. funcref is not a subtype of
+    // anyref/externref, so `(class {...}).f` member read fed the raw funcref
+    // into `__extern_get` (externref param) — invalid module
+    // ("call expected externref, found ref.func"). One extraction happened to
+    // dead-code-eliminate clean; two or more left the funcref on the stack.
+    compileValid(`
+      let x = "h";
+      let f = class { static async f() {} }.f;
+      let g = class { static async ["g"]() {} }.g;
+      let h = class { static async [x]() {} }.h;
+      export function test(): number { return 1; }
+    `);
+  });
+
+  it("class-expression value passed directly as a call argument is valid wasm", () => {
+    compileValid(`
+      function use(v: any): void {}
+      export function test(): number {
+        use(class { m() {} });
+        return 1;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #1602. A class expression used as a value (`(class {...}).f`, or passed as a call argument) emitted a bare `ref.func` (funcref) for the constructor. funcref is not a subtype of anyref/externref, so the raw funcref was left where externref was required (e.g. feeding `__extern_get`), producing an invalid module: `call expected externref, found ref.func`.
- Two or more static-async class-method extractions in one module reliably triggered it (a single one happened to dead-code-eliminate clean).
- Fix wraps the ctor funcref in a closure struct + `extern.convert_any`, mirroring the proven `ClassName.constructor` / static-method-extraction path. Falls back to the legacy funcref only if closure construction fails.

## Validation
- `tests/issue-1602.test.ts`: 6/6 pass (added 2 regression cases: multiple static-async class-method extractions; class-expression value passed as a call argument).
- `built-ins/Function/prototype/toString` bucket: invalid modules 8 → 5 (the named example `async-method-class-expression-static.js` now valid).
- The issue's four example tests all compile to valid wasm.
- No regressions in class test files (failure counts identical to clean main — pre-existing harness-instantiate limitations).
- `npx tsc --noEmit` clean.

## Test plan
- [ ] CI: cheap gate + merge shard reports + quality
- [ ] test262 regression gate (net per test > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)