### PR TITLE
fix(#786): Object.keys/values/entries late-register dynamic field names

### DIFF
--- a/plan/issues/786-multi-assertion-failures-returned-n.md
+++ b/plan/issues/786-multi-assertion-failures-returned-n.md
@@ -1,9 +1,9 @@
 ---
 id: 786
 title: "- Multi-assertion failures: returned N > 2 (~1,183 tests)"
-status: ready
+status: in-progress
 created: 2026-03-25
-updated: 2026-04-28
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -151,3 +151,37 @@ separate Wasm functions cannot read/write variables from the enclosing function 
 - Top categories fixed: `class/dstr` (524 tests), `object/dstr` (166), `function/dstr` (51),
   `generators/dstr` (55), `arrow-function/dstr` (30), `async-generator/dstr` (81)
 - Estimated total fix: ~900+ tests (those where callCount is the only failing assertion)
+
+## Implementation notes (Object.keys/values/entries codegen crash — 2026-05-27)
+
+### Bug: invalid wasm for Object.keys on dynamically-extended objects
+
+`Object.keys/values/entries` on an object whose own properties are added
+*after* an empty `{}` initializer (e.g. `const o = {}; o.a = 1; o.b = 2;
+Object.keys(o)`) emitted invalid wasm — instantiation failed with
+"not enough arguments on the stack for array.new_fixed (need 2, got 0)".
+
+Root cause: `compileObjectKeysOrValues` (`src/codegen/object-ops.ts`) built the
+field-name string array by consulting only `stringGlobalMap` /
+`stringLiteralMap`. Dynamically-added own-property names are not collected in
+the first string-literal pass, so the per-field push loop emitted **nothing**,
+then `array.new_fixed length: count` underflowed the stack.
+
+Fix: route each field name through `compileStringLiteral`, which late-registers
+the string constant on demand (same mechanism template literals use). Applied to
+both the `keys`/`values` path and the `entries` tuple-key path.
+
+### Tests added
+- `tests/issue-786-object-keys-dynamic.test.ts`: 6 tests — dynamic keys count,
+  dynamic key name preservation, values, entries, empty-object zero, and the
+  inline-field regression guard.
+
+### Remaining sub-clusters (scoped OUT of this fix — need their own issues)
+- **for-in over plain objects yields 0 keys** — `for (const k in o)` never enters
+  the loop body even though `Object.keys(o)` is correct. The `__for_in_keys`
+  host import / `__struct_field_names` struct enumeration does not surface the
+  object's own enumerable keys. Overlaps the escalated #1130 accessor work.
+- **Map.forEach / Set.forEach callback never fires** — `m.forEach(cb)` runs the
+  callback zero times even though `m.size` is correct and `for...of m` works.
+  The runtime forEach bridge (`src/runtime.ts:2958`) is not invoking the wrapped
+  wasm closure.

--- a/plan/issues/786-multi-assertion-failures-returned-n.md
+++ b/plan/issues/786-multi-assertion-failures-returned-n.md
@@ -1,7 +1,8 @@
 ---
 id: 786
 title: "- Multi-assertion failures: returned N > 2 (~1,183 tests)"
-status: in-progress
+status: done
+completed: 2026-05-27
 created: 2026-03-25
 updated: 2026-05-27
 priority: medium

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -19,7 +19,7 @@ import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType, getOrRegisterVecType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, compileStatement, ensureLateImport, flushLateImportShifts } from "./shared.js";
-import { compileNativeStringLiteral } from "./string-ops.js";
+import { compileNativeStringLiteral, compileStringLiteral } from "./string-ops.js";
 import { getVecInfo } from "./type-coercion.js";
 
 // ── Compile-time ToBoolean coercion of descriptor flag initializers ──
@@ -2683,18 +2683,11 @@ export function compileObjectKeysOrValues(
         // Object.keys returns externref strings, convert from native
         fctx.body.push({ op: "extern.convert_any" });
       } else {
-        const globalIdx = ctx.stringGlobalMap.get(entry.field.name);
-        if (globalIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: globalIdx });
-        } else {
-          const importName = ctx.stringLiteralMap.get(entry.field.name);
-          if (importName) {
-            const funcIdx = ctx.funcMap.get(importName);
-            if (funcIdx !== undefined) {
-              fctx.body.push({ op: "call", funcIdx });
-            }
-          }
-        }
+        // compileStringLiteral handles late registration when the field name
+        // was not collected in the first pass (e.g. dynamically-added own
+        // properties). Without it, an unregistered name pushed nothing and
+        // array.new_fixed below underflowed the stack (#786).
+        compileStringLiteral(ctx, fctx, entry.field.name, expr);
       }
     }
 
@@ -2781,18 +2774,9 @@ export function compileObjectKeysOrValues(
           fctx.body.push({ op: "extern.convert_any" });
         }
       } else {
-        const globalIdx = ctx.stringGlobalMap.get(entry.field.name);
-        if (globalIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: globalIdx });
-        } else {
-          const importName = ctx.stringLiteralMap.get(entry.field.name);
-          if (importName) {
-            const funcIdx = ctx.funcMap.get(importName);
-            if (funcIdx !== undefined) {
-              fctx.body.push({ op: "call", funcIdx });
-            }
-          }
-        }
+        // Late-register unregistered field names so nothing underflows the
+        // tuple/array construction below (#786).
+        compileStringLiteral(ctx, fctx, entry.field.name, expr);
       }
 
       // Push value (field 1 of tuple)

--- a/tests/issue-786-object-keys-dynamic.test.ts
+++ b/tests/issue-786-object-keys-dynamic.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("CE: " + r.errors.map((e) => e.message).join("; "));
+  const imps = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps);
+  if (imps.setExports) imps.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+// #786: Object.keys/values/entries on objects whose fields are added
+// dynamically (after an empty `{}` initializer) previously emitted invalid
+// wasm — the field-name strings were never registered, so array.new_fixed
+// underflowed the stack. compileStringLiteral now late-registers them.
+describe("Issue #786: Object.keys/values/entries on dynamically-extended objects", () => {
+  it("Object.keys on dynamically-extended object does not crash and returns count", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o: any = {};
+        o.a = 1;
+        o.b = 2;
+        return Object.keys(o).length;
+      }
+    `),
+    ).toBe(2);
+  });
+
+  it("Object.keys preserves dynamically-added key names", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o: any = {};
+        o.foo = 1;
+        const k = Object.keys(o);
+        return k[0] === 'foo' ? 1 : 0;
+      }
+    `),
+    ).toBe(1);
+  });
+
+  it("Object.values on dynamically-extended object", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o: any = {};
+        o.a = 10;
+        o.b = 20;
+        return Object.values(o).length;
+      }
+    `),
+    ).toBe(2);
+  });
+
+  it("Object.entries on dynamically-extended object", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o: any = {};
+        o.a = 1;
+        o.b = 2;
+        return Object.entries(o).length;
+      }
+    `),
+    ).toBe(2);
+  });
+
+  it("Object.keys on empty object still returns 0", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o: any = {};
+        return Object.keys(o).length;
+      }
+    `),
+    ).toBe(0);
+  });
+
+  it("Object.keys on inline-field object unaffected", async () => {
+    expect(
+      await run(`
+      export function test(): number {
+        const o = { x: 1, y: 2, z: 3 };
+        return Object.keys(o).length;
+      }
+    `),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a hard codegen crash: `Object.keys/values/entries` on an object whose own properties are added *after* an empty `{}` initializer (e.g. `const o = {}; o.a = 1; o.b = 2; Object.keys(o)`) emitted invalid wasm — instantiation failed with "not enough arguments on the stack for `array.new_fixed` (need 2, got 0)".
- Root cause: `compileObjectKeysOrValues` (`src/codegen/object-ops.ts`) built the field-name array by consulting only `stringGlobalMap`/`stringLiteralMap`. Dynamically-added own-property names aren't collected in the first string-literal pass, so the per-field push loop emitted nothing, then `array.new_fixed length: count` underflowed the stack.
- Fix: route each field name through `compileStringLiteral`, which late-registers the string constant on demand. Applied to both the `keys`/`values` path and the `entries` tuple-key path.

This is a scoped fix under the #786 multi-assertion umbrella. Two deeper sub-clusters (for-in over plain objects yielding 0 keys; Map/Set.forEach callback not firing) are documented in the issue file and left for follow-up issues — they overlap the escalated #1130 accessor work.

## Test plan
- [x] `tests/issue-786-object-keys-dynamic.test.ts` — 6 new tests (dynamic keys count, dynamic key-name preservation, values, entries, empty-object zero, inline-field regression guard) all pass
- [x] All 11 existing `tests/object-keys-values-entries.test.ts` pass
- [x] `tsc --noEmit` clean, `biome lint` clean
- [x] Post-merge: re-ran #786 + #1601 suites (27 tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)