### PR TITLE
fix(#1594B): class name in own extends is TDZ ReferenceError

### DIFF
--- a/plan/issues/1594-annexb-strict-function-code-tdz-referenceerror.md
+++ b/plan/issues/1594-annexb-strict-function-code-tdz-referenceerror.md
@@ -65,3 +65,26 @@ Spec §15.7.1 ClassDeclaration: the class name binding is added to the class's i
 - Sub-cluster B is a 2-line fix (install class-name binding after extends evaluation, not before). High confidence / easy to isolate.
 - Sub-cluster A requires understanding the AnnexB §B.3.3 legacy binding rules and how we implement strict-mode block function declarations. May require a separate approach.
 - Consider splitting into #1594A (class-name TDZ, 2 tests, trivial) and #1594B (AnnexB block-fn, ~98 tests, medium) if implementation complexity diverges significantly.
+
+## Sub-cluster B — FIXED (2026-05-27)
+
+Class name in its own `extends` expression is now a TDZ ReferenceError. Both
+the declaration path (`compileNestedClassDeclaration`) and the class-expression
+path (`compileClassExpression`) statically detect a reference to the class's own
+name inside the heritage `extends` clause and emit a real `ReferenceError`
+instance via `emitThrowReferenceError` (works in both JS-host and standalone
+modes). Previously the declaration path silently swallowed the self-reference
+(`class-bodies.ts:147` set `parentClassName = undefined`) and the
+class-expression path either succeeded (returning 2) or null-deref'd.
+
+**Files**: `src/codegen/statements/nested-declarations.ts`,
+`src/codegen/expressions/new-super.ts`. Tests: `tests/issue-1594b.test.ts`.
+
+**test262 results (verified via `runTest262File`)**:
+- `language/statements/class/name-binding/in-extends-expression.js` — pass
+- `language/statements/class/name-binding/in-extends-expression-grouped.js` — pass (class-expression path)
+- `language/statements/class/name-binding/in-extends-expression-assigned.js` — pass (was a crash; now correct)
+
+Sub-cluster A (AnnexB block-fn legacy hoisting, ~98 fails) remains open and is
+escalated to the architect — it is a deep cross-cutting change unrelated to
+this fix.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -33,6 +33,7 @@ import { coerceType as coerceTypeImpl, pushDefaultValue } from "../type-coercion
 import { ensureDateDaysFromCivilHelper, ensureDateStruct } from "./builtins.js";
 import { compileSpreadCallArgs } from "./extern.js";
 import {
+  emitThrowReferenceError,
   emitThrowString,
   emitThrowTypeError,
   getFuncParamTypes,
@@ -1219,7 +1220,45 @@ function compileNewFunctionExpression(
  * The class should already be collected during the collection phase.
  * We produce the constructor function reference so the class can be instantiated.
  */
+/**
+ * §15.7.1 ClassDefinitionEvaluation: a named class binds its own name in an
+ * inner scope that is populated only AFTER the `extends` clause is evaluated.
+ * Referencing that name inside `extends` hits the TDZ — `(class x extends x {})`
+ * must throw ReferenceError (#1594B). The inner binding shadows any outer `x`,
+ * so any reference to the class's own name in `extends` is the TDZ binding.
+ */
+function classExtendsReferencesOwnName(expr: ts.ClassExpression): boolean {
+  if (!expr.name) return false;
+  const ownName = expr.name.text;
+  if (!expr.heritageClauses) return false;
+  for (const clause of expr.heritageClauses) {
+    if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+    for (const typeNode of clause.types) {
+      let found = false;
+      const visit = (node: ts.Node): void => {
+        if (found) return;
+        if (ts.isIdentifier(node) && node.text === ownName) {
+          found = true;
+          return;
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(typeNode.expression);
+      if (found) return true;
+    }
+  }
+  return false;
+}
+
 function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.ClassExpression): ValType | null {
+  // §15.7.1: the class-expression name is in TDZ during its own `extends`
+  // evaluation. `(class x extends x {})` must throw ReferenceError (#1594B).
+  if (classExtendsReferencesOwnName(expr)) {
+    emitThrowReferenceError(ctx, fctx, `Cannot access '${expr.name!.text}' before initialization`);
+    fctx.body.push({ op: "ref.null.extern" });
+    return { kind: "externref" };
+  }
+
   // Look up the synthetic name assigned during the collection phase
   const syntheticName = ctx.anonClassExprNames.get(expr);
   const classNameForCheck = syntheticName ?? expr.name?.text;

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -18,7 +18,7 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext, OptionalParamInfo } from "../context/types.js";
-import { emitThrowString, emitThrowTypeError } from "../expressions/helpers.js";
+import { emitThrowReferenceError, emitThrowString, emitThrowTypeError } from "../expressions/helpers.js";
 import {
   collectClassDeclaration,
   compileClassBodies,
@@ -43,6 +43,34 @@ import {
   registerHoistFunctionDeclarations,
 } from "../shared.js";
 
+/**
+ * §15.7.1 ClassDefinitionEvaluation: the class name binding is added to the
+ * class's inner scope AFTER the `extends` clause is evaluated. Referencing the
+ * class name inside its own `extends` expression therefore hits the TDZ and
+ * must throw ReferenceError (e.g. `class x extends x {}`). Returns true if the
+ * extends heritage clause contains an identifier equal to the class name.
+ */
+function extendsReferencesClassName(decl: ts.ClassDeclaration, className: string): boolean {
+  if (!decl.heritageClauses) return false;
+  for (const clause of decl.heritageClauses) {
+    if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+    for (const typeNode of clause.types) {
+      let found = false;
+      const visit = (node: ts.Node): void => {
+        if (found) return;
+        if (ts.isIdentifier(node) && node.text === className) {
+          found = true;
+          return;
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(typeNode.expression);
+      if (found) return true;
+    }
+  }
+  return false;
+}
+
 export function compileNestedClassDeclaration(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -50,6 +78,13 @@ export function compileNestedClassDeclaration(
 ): void {
   if (!decl.name) return;
   const className = decl.name.text;
+
+  // §15.7.1: the class name is in TDZ while its own `extends` clause is
+  // evaluated. `class x extends x {}` must throw ReferenceError (#1594B).
+  if (extendsReferencesClassName(decl, className)) {
+    emitThrowReferenceError(ctx, fctx, `Cannot access '${className}' before initialization`);
+    return;
+  }
 
   const isDeferred = ctx.deferredClassBodies.has(className);
   // Skip if already collected AND not deferred (already fully compiled)

--- a/tests/issue-1594b.test.ts
+++ b/tests/issue-1594b.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * Issue #1594B — class name in its own `extends` expression is in the TDZ.
+ * Per ECMA-262 §15.7.1 ClassDefinitionEvaluation, the class-name binding is
+ * installed in the class's inner scope only AFTER the `extends` clause is
+ * evaluated. Referencing the class name inside `extends` must throw
+ * ReferenceError: `class x extends x {}`.
+ */
+
+function buildImports(wasmModule: WebAssembly.Module): Record<string, Record<string, any>> {
+  const importObj: Record<string, Record<string, any>> = {};
+  for (const imp of WebAssembly.Module.imports(wasmModule)) {
+    if (!importObj[imp.module]) importObj[imp.module] = {};
+    if (imp.kind === "function") {
+      importObj[imp.module]![imp.name] = (...args: any[]) => args[0];
+    } else if (imp.kind === "global") {
+      importObj[imp.module]![imp.name] = imp.name;
+    } else if (imp.kind === "tag") {
+      importObj[imp.module]![imp.name] = new WebAssembly.Tag({ parameters: ["externref"] });
+    }
+  }
+  return importObj;
+}
+
+function compileAndRun(code: string): number {
+  const result = compile(code);
+  expect(result.success).toBe(true);
+  const wasmModule = new WebAssembly.Module(result.binary);
+  const instance = new WebAssembly.Instance(wasmModule, buildImports(wasmModule));
+  const exports = instance.exports as any;
+  return exports.getResult();
+}
+
+describe("class name in own extends expression is TDZ (#1594B)", () => {
+  test("class x extends x {} throws ReferenceError", { timeout: 15000 }, () => {
+    const val = compileAndRun(`
+      export function getResult(): number {
+        let caught = 0;
+        try {
+          class x extends x {}
+        } catch (e) {
+          caught = 1;
+        }
+        return caught;
+      }
+    `);
+    expect(val).toBe(1);
+  });
+
+  test("grouped: class x extends (x) {} throws ReferenceError", { timeout: 15000 }, () => {
+    const val = compileAndRun(`
+      export function getResult(): number {
+        let caught = 0;
+        try {
+          class x extends (x) {}
+        } catch (e) {
+          caught = 1;
+        }
+        return caught;
+      }
+    `);
+    expect(val).toBe(1);
+  });
+
+  test("class referencing its own name in a member-access extends throws", { timeout: 15000 }, () => {
+    const val = compileAndRun(`
+      export function getResult(): number {
+        let caught = 0;
+        try {
+          class x extends x.foo {}
+        } catch (e) {
+          caught = 1;
+        }
+        return caught;
+      }
+    `);
+    expect(val).toBe(1);
+  });
+
+  test("class expression: (class x extends x {}) throws ReferenceError", { timeout: 15000 }, () => {
+    const val = compileAndRun(`
+      export function getResult(): number {
+        let caught = 0;
+        try {
+          const C = (class x extends x {});
+        } catch (e) {
+          caught = 1;
+        }
+        return caught;
+      }
+    `);
+    expect(val).toBe(1);
+  });
+
+  test("extends an unrelated identifier still compiles (no false positive)", { timeout: 15000 }, () => {
+    const val = compileAndRun(`
+      class Base { getV(): number { return 7; } }
+      export function getResult(): number {
+        class Derived extends Base {}
+        const d = new Derived();
+        return d.getV();
+      }
+    `);
+    expect(val).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- Per ECMA-262 §15.7.1, a class's name binding is installed in its inner scope only **after** the `extends` clause is evaluated. Referencing the class name inside its own `extends` therefore hits the TDZ and must throw `ReferenceError` (`class x extends x {}`).
- Both the declaration path (`compileNestedClassDeclaration`) and the class-expression path (`compileClassExpression`) now statically detect a self-reference in the heritage `extends` clause and emit a real `ReferenceError` instance via `emitThrowReferenceError` (works in JS-host and standalone modes).
- Previously the declaration path silently swallowed the self-reference (`class-bodies.ts` set `parentClassName = undefined`) and the class-expression path either succeeded (returning 2) or null-deref'd.

This is sub-cluster **B** of #1594. Sub-cluster A (AnnexB block-fn legacy hoisting, ~98 fails) remains open and is escalated to the architect — it is a deep cross-cutting change unrelated to this fix.

## test262 (verified via `runTest262File`)
- `language/statements/class/name-binding/in-extends-expression.js` — pass
- `language/statements/class/name-binding/in-extends-expression-grouped.js` — pass (class-expression path)
- `language/statements/class/name-binding/in-extends-expression-assigned.js` — pass (was a crash)

## Test plan
- [x] `tests/issue-1594b.test.ts` — 5 unit tests (decl, grouped-expr, member-access extends, class-expression, no-false-positive `Derived extends Base`)
- [x] 3 target test262 files flip to pass
- [x] `npx tsc --noEmit` clean
- [ ] CI conformance gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)