### PR TITLE
fix(#1600): FinalizationRegistry host-delegate + no-op standalone stub

### DIFF
--- a/plan/issues/1600-finalizationregistry-host-delegate-noop-stub.md
+++ b/plan/issues/1600-finalizationregistry-host-delegate-noop-stub.md
@@ -1,9 +1,10 @@
 ---
 id: 1600
 title: "FinalizationRegistry: host-delegate (JS mode) + no-op standalone stub (~12 CEs)"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -71,3 +72,42 @@ and acceptable.
 - The ~12 built-ins/FinalizationRegistry CEs that only exercise the API surface
   (construct/register/unregister, no forced-GC assertion) flip from CE to pass.
 - No regression to the existing WeakRef path.
+
+## Implementation
+
+Wired `FinalizationRegistry` as a host-constructible extern class, mirroring the
+`WeakMap`/`WeakSet` pattern:
+
+- `src/codegen/index.ts` — registered `FinalizationRegistry` in `ctx.externClasses`
+  (constructor takes the cleanup callback as externref; `register(target,
+  heldValue, token?)` → undefined, `unregister(token)` → boolean). This routes
+  `new FinalizationRegistry(...)` through the `externInfo` path in
+  `new-super.ts:2338` instead of falling through to "Unsupported new expression".
+- `src/runtime.ts` — added `FinalizationRegistry` to the `builtinCtors` resolver
+  map (guarded by `typeof`), and substituted a no-op `() => {}` for the cleanup
+  callback when the wasm-closure externref isn't a callable JS function (the
+  engine's constructor otherwise throws "cleanup must be callable"; spec permits
+  callbacks to never fire).
+
+**Root cause**: when the TS checker resolves the `FinalizationRegistry` lib type,
+`className` becomes `"FinalizationRegistry"`, bypassing the `!className`
+unknown-constructor host-import path and falling through to the "Unsupported new
+expression" error at `new-super.ts:2790`.
+
+## Test Results
+
+built-ins/FinalizationRegistry (JS-host runner):
+- Before: pass 18, fail 15, compile_error 14
+- After:  pass 31, fail 14, compile_error 2
+
+The 2 remaining CEs are an unrelated `for-of requires an array expression` codegen
+limitation (returns-new-object-from-constructor.js, unnaffected-by-poisoned-
+cleanupCallback.js), not FinalizationRegistry. Remaining fails are pre-existing
+limitations (Reflect.construct/isConstructor harness stub, Symbol coercion,
+prototype-chain, $262/forced-GC) shared with the WeakRef path.
+
+WeakRef regression check: pass 19, fail 9, compile_error 1 — unchanged.
+
+Standalone (`--target wasi`) `new FinalizationRegistry(cb)` compiles byte-valid.
+
+Unit test: `tests/issue-1600.test.ts` (3 cases, all pass).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7614,6 +7614,32 @@ export function registerBuiltinExternClasses(ctx: CodegenContext): void {
     });
   }
 
+  // FinalizationRegistry (#1600) — host-delegate in JS mode, no-op stub in
+  // standalone. The spec never guarantees cleanup callbacks run, so a registry
+  // that tracks register/unregister but never fires the callback is fully
+  // conformant. The host import builds a real engine FinalizationRegistry;
+  // register/unregister forward to it.
+  if (!ctx.externClasses.has("FinalizationRegistry")) {
+    const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
+    // register(target, heldValue, unregisterToken?) → undefined
+    methods.set("register", {
+      params: [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      results: [{ kind: "externref" }],
+      requiredParams: 2,
+    });
+    // unregister(token) → boolean (externref)
+    methods.set("unregister", externMethod(1));
+
+    ctx.externClasses.set("FinalizationRegistry", {
+      importPrefix: "FinalizationRegistry",
+      namespacePath: [],
+      className: "FinalizationRegistry",
+      constructorParams: [{ kind: "externref" }], // new FinalizationRegistry(cleanupCallback)
+      methods,
+      properties: new Map(),
+    });
+  }
+
   // DisposableStack / AsyncDisposableStack — TC39 Explicit Resource Management (#830)
   if (!ctx.externClasses.has("DisposableStack")) {
     const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2826,6 +2826,9 @@ function resolveImport(
           Test262Error,
           // (#1455) SharedArrayBuffer for `class Sub extends SharedArrayBuffer {}`
           ...(typeof SharedArrayBuffer !== "undefined" ? { SharedArrayBuffer } : {}),
+          // (#1600) FinalizationRegistry — host-delegate `new FinalizationRegistry(cb)`
+          // and register/unregister to the real engine registry.
+          ...(typeof FinalizationRegistry !== "undefined" ? { FinalizationRegistry } : {}),
           // TC39 Explicit Resource Management (stage 3 / Node.js 22+)
           ...(typeof DisposableStack !== "undefined" ? { DisposableStack } : {}),
           ...(typeof AsyncDisposableStack !== "undefined" ? { AsyncDisposableStack } : {}),
@@ -2895,6 +2898,14 @@ function resolveImport(
             // converted entries. For Map/WeakMap each entry must itself be
             // an iterable (tuple → [k, v] array).
             args[0] = _convertIterableForHost(args[0], exports);
+          } else if (intent.className === "FinalizationRegistry") {
+            // (#1600) The cleanup callback is a wasm closure externref, not a
+            // real callable JS function, so the engine's
+            // `new FinalizationRegistry(cb)` would throw "cleanup must be
+            // callable". The spec never guarantees cleanup callbacks run, so
+            // substitute a no-op function — register/unregister still work and
+            // the (never-fired) callback is spec-permissibly inert.
+            if (typeof args[0] !== "function") args[0] = () => {};
           } else if (isBufferConsumer && args.length > 0 && _isWasmStruct(args[0])) {
             const exports = callbackState?.getExports();
             const dvLen = exports?.__dv_byte_len as ((v: any) => number) | undefined;

--- a/tests/issue-1600.test.ts
+++ b/tests/issue-1600.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.js";
+
+describe("#1600 FinalizationRegistry host-delegate + no-op stub", () => {
+  const src = `
+    function cb() {}
+    var reg = new FinalizationRegistry(cb);
+    var target = {};
+    var token = {};
+    reg.register(target, 42, token);
+    var removed = reg.unregister(token);
+    export function test(): number { return 1; }
+  `;
+
+  it("compiles new FinalizationRegistry + register/unregister in JS-host mode", async () => {
+    const r = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    const imports = buildImports(r.imports, undefined, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, imports);
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("compiles to byte-valid Wasm in standalone (--target wasi) mode", async () => {
+    const r = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true, target: "wasi" });
+    expect(r.success).toBe(true);
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+  });
+
+  it("does not regress WeakRef", async () => {
+    const wr = `var o = {}; var w = new WeakRef(o); export function test(): number { return 1; }`;
+    const r = compile(wr, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Wire `FinalizationRegistry` as a host-constructible extern class (mirroring the WeakMap/WeakSet pattern) so `new FinalizationRegistry(cb)` + `register`/`unregister` compile instead of hitting "Unsupported new expression for class".

**Root cause**: when the TS checker resolves the `FinalizationRegistry` lib type, `className` becomes `"FinalizationRegistry"`, bypassing the `!className` unknown-constructor host-import path and falling through to the error at `new-super.ts:2790`.

- `src/codegen/index.ts` — register `FinalizationRegistry` in `ctx.externClasses` (cleanup callback ctor arg as externref; `register(target, heldValue, token?)` → undefined, `unregister(token)` → boolean)
- `src/runtime.ts` — add to `builtinCtors` resolver (typeof-guarded); substitute a no-op `() => {}` for the wasm-closure cleanup callback so the engine ctor doesn't throw "cleanup must be callable" (spec permits callbacks to never fire)

This is the cheap, spec-permissible path per the issue — NOT faithful standalone finalization (→ #1101).

## Test plan
- [x] `tests/issue-1600.test.ts` — 3 cases (JS-host instantiate, WASI byte-valid, WeakRef no-regression), all pass
- [x] test262 built-ins/FinalizationRegistry: CE 14→2 (2 remaining are unrelated `for-of`), pass 18→31
- [x] WeakRef path unchanged (pass 19, fail 9, CE 1)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)