### PR TITLE
fix(#820h): resolve (Async)DisposableStack as host-global values

### DIFF
--- a/plan/issues/820h-disposable-stack-brand-check.md
+++ b/plan/issues/820h-disposable-stack-brand-check.md
@@ -1,9 +1,9 @@
 ---
 id: 820h
 title: "DisposableStack / AsyncDisposableStack brand-check and protocol stubs (~74 fails)"
-status: ready
+status: in-review
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,7 +11,7 @@ task_type: bugfix
 area: builtins
 language_feature: explicit-resource-management
 goal: async-model
-sprint: Backlog
+sprint: 56
 parent: 820
 es_edition: ES2025
 test262_fail: 74
@@ -67,3 +67,44 @@ delegation are not.
 - ES2025 feature; consider whether this is in scope before the rest of the
   ES2025 surface is built out. May be a candidate for `goal: deferred`
   re-classification if the team isn't pursuing ES2025 coverage yet.
+
+## Root cause
+
+The suspected source (`prototype-from-newtarget` chain wiring / missing
+brand checks) was a red herring. The constructors *are* host-delegated and
+`new DisposableStack().dispose()` already works. The real defect: bare
+identifiers `DisposableStack` / `AsyncDisposableStack` / `SuppressedError`
+used as **values** (not in `new X()` / `x.method()` position) fell through
+`compileIdentifier`'s "graceful fallback for known-but-unimplemented globals"
+and emitted `ref.null.extern`. So every reflective test —
+`DisposableStack.prototype`, `Object.getOwnPropertyDescriptor(DisposableStack.prototype, …)`,
+`Reflect.construct(DisposableStack, …)` — saw `null` and threw a
+WebAssembly.Exception or "null is not a constructor".
+
+## Fix
+
+`src/codegen/expressions/identifiers.ts` — added a handler (mirroring the
+existing `globalThis` handler) that resolves these three ERM globals to the
+real host constructor via `__extern_get(__get_globalThis(), name)` when the
+name is not shadowed by a local/captured binding or a user class. With the
+host constructor object visible, its `.prototype`, accessor descriptors, and
+`[[Construct]]` all work through the existing extern machinery.
+
+## Test Results (against /workspace/test262, via real harness)
+
+DisposableStack + AsyncDisposableStack suite (143 tests, runnable subset):
+- **before**: 72 pass / 71 fail
+- **after**:  121 pass / 22 fail  (**+49 flips**)
+
+The `[object WebAssembly.Exception]` brand/descriptor failure class is fully
+eliminated. Unit coverage: `tests/issue-820h.test.ts` (7 tests, incl.
+shadowing + normal-use regression guards).
+
+### Remaining 22 (out of scope for this fix)
+- `$262 is not defined` (2) — cross-realm harness, not implementable here.
+- `[Symbol.dispose] is not a function` / `[object Object] is not a function`
+  (~7) — disposer callbacks/objects are WasmGC values the host can't invoke
+  as JS functions; needs a broader compiled-object→host-protocol bridge.
+- `is-a-constructor` / `undefined-newtarget` / `newtarget-prototype-is-not-object`
+  / `prototype-from-newtarget-*` (~13) — `Reflect.construct` with bound-fn
+  newTarget and `new stack.method()` edge cases; deeper host bridging.

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -603,6 +603,44 @@ function compileIdentifier(ctx: CodegenContext, fctx: FunctionContext, id: ts.Id
     return { kind: "externref" };
   }
 
+  // (#820h) Explicit Resource Management constructors referenced as *values*
+  // (not in `new`/method position) — e.g. `DisposableStack.prototype`,
+  // `Reflect.construct(DisposableStack, …)`, `Object.getOwnPropertyDescriptor`.
+  // The extern-class machinery only models `new X()` / `x.method()`; a bare
+  // identifier falls through to the null-externref fallback below, so reflective
+  // test262 cases see `null` instead of the host constructor. Resolve them to
+  // the real host global via `__extern_get(__get_globalThis(), name)` so the
+  // native constructor object (with its prototype + accessor descriptors) is
+  // visible. Scope strictly to these host-delegated ERM globals and only when
+  // the name is not shadowed by a local/captured binding.
+  if (
+    (name === "DisposableStack" || name === "AsyncDisposableStack" || name === "SuppressedError") &&
+    !fctx.localMap.has(name) &&
+    !(fctx.boxedCaptures?.has(name) ?? false) &&
+    !ctx.classSet.has(name)
+  ) {
+    const gtFuncIdx = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
+    const getIdx = ensureLateImport(
+      ctx,
+      "__extern_get",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (gtFuncIdx !== undefined && getIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: gtFuncIdx });
+      addStringConstantGlobal(ctx, name);
+      const strGlobalIdx = ctx.stringGlobalMap.get(name);
+      if (strGlobalIdx !== undefined) {
+        fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
+      } else {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+      fctx.body.push({ op: "call", funcIdx: getIdx });
+      return { kind: "externref" };
+    }
+  }
+
   // Built-in numeric constants: NaN, Infinity
   if (name === "NaN") {
     fctx.body.push({ op: "f64.const", value: NaN });

--- a/tests/issue-820h.test.ts
+++ b/tests/issue-820h.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const r = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!r.success) throw new Error("CE: " + r.errors.map((e) => e.message).join("; "));
+  const importObj = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(r.binary, importObj as never);
+  if (typeof importObj.setExports === "function") {
+    (importObj.setExports as (e: unknown) => void)(instance.exports);
+  }
+  return (instance.exports as { test: () => number }).test();
+}
+
+// #820h — (Async)DisposableStack referenced as a *value* (not in new/method
+// position) must resolve to the host global constructor so reflective
+// operations (prototype access, property descriptors, Reflect.construct)
+// see the real native object instead of a null externref.
+describe("#820h (Async)DisposableStack as a host-global value", () => {
+  it("DisposableStack.prototype is a non-null object", async () => {
+    expect(await run(`export function test(): number { return DisposableStack.prototype != null ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("Object.getOwnPropertyDescriptor sees the disposed accessor", async () => {
+    expect(
+      await run(`export function test(): number {
+        let d = Object.getOwnPropertyDescriptor(DisposableStack.prototype, 'disposed');
+        return (typeof d.get === 'function' && typeof d.set === 'undefined') ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.construct(DisposableStack, []) builds an instance", async () => {
+    expect(
+      await run(`export function test(): number {
+        let s = Reflect.construct(DisposableStack, []);
+        return s != null ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("AsyncDisposableStack.prototype resolves too", async () => {
+    expect(await run(`export function test(): number { return AsyncDisposableStack.prototype != null ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("a user-defined class named DisposableStack still shadows the global", async () => {
+    expect(
+      await run(`class DisposableStack { x: number = 5; getX(): number { return this.x; } }
+        export function test(): number { let d = new DisposableStack(); return d.getX(); }`),
+    ).toBe(5);
+  });
+
+  it("a local binding named SuppressedError still shadows the global", async () => {
+    expect(await run(`export function test(): number { let SuppressedError = 7; return SuppressedError; }`)).toBe(7);
+  });
+
+  it("normal new DisposableStack().dispose() still works", async () => {
+    expect(
+      await run(`export function test(): number {
+        let s = new DisposableStack(); s.dispose(); return s.disposed ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Bare ERM constructor identifiers (`DisposableStack`, `AsyncDisposableStack`, `SuppressedError`) used as **values** — not in `new X()` / `x.method()` position — fell through `compileIdentifier`'s known-but-unimplemented-global fallback and emitted `ref.null.extern`. Reflective test262 cases (`DisposableStack.prototype`, `Object.getOwnPropertyDescriptor(...)`, `Reflect.construct(DisposableStack, …)`) therefore saw `null` and threw `WebAssembly.Exception` / "null is not a constructor".
- Fix in `src/codegen/expressions/identifiers.ts`: resolve these globals via `__extern_get(__get_globalThis(), name)` when not shadowed by a local/captured binding or a user class, mirroring the existing `globalThis` handler. The host constructor object then exposes its prototype, accessor descriptors, and `[[Construct]]` through the existing extern machinery.

## Results
DisposableStack + AsyncDisposableStack suite (143-test runnable subset, real harness): **72 → 121 pass (+49 flips)**. The `[object WebAssembly.Exception]` brand/descriptor failure class is eliminated. Remaining 22 are out of scope (cross-realm `$262` harness, wasm-closure-as-disposer bridging, `Reflect.construct` bound-newTarget edge cases).

## Test plan
- [x] `tests/issue-820h.test.ts` — 7 tests incl. shadowing + normal-use regression guards
- [x] `npx tsc --noEmit` clean
- [ ] CI test262 conformance gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)