### PR TITLE
fix(#1592): bounded array-pattern iterator consumption via __array_from_iter_n

### DIFF
--- a/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
+++ b/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
@@ -1,11 +1,10 @@
 ---
 id: 1592
 title: "Array pattern elision holes and rest-array in destructuring consume wrong iterator step (~305 fails)"
-status: blocked
+status: in-review
 created: 2026-05-24
 updated: 2026-05-27
-blocked_on: 1555
-duplicate_of: 1555
+related: 1555
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -109,3 +108,62 @@ fix would fight the #1555 streaming rewrite and risk regressing the tuned
 The streaming-iterator refactor is the correct, single fix for the whole
 ~305-test bucket. Escalation tag on the task was correct — this needs the
 architect's #1555 streaming design, not a dev hotfix.
+
+## Implementation (dev, 2026-05-27) — bounded-helper Phase 1
+
+Implemented the incremental bounded-materialization fix (architect's Phase-1
+plan), NOT the full #1555 streaming rewrite.
+
+### Changes
+- **`src/runtime.ts`**: refactored the `__array_from_iter` closure body into a
+  shared `_arrayFromIter(obj, limit)` and added `__array_from_iter_n(obj, n)`
+  (n<0 ⇒ `limit = Infinity`, byte-identical to the old unbounded drain; n≥0 ⇒
+  consume at most `n` IteratorStep calls). Default-array slice fast path, a new
+  bounded `_drainIterable` (replaces `Array.from` so a finite bound stops
+  early), and a bounded break in the wasm-closure manual walk.
+- **`src/codegen/destructuring-params.ts`**: exported
+  `patternIteratorStepCount(elements)` (elisions count, rest ⇒ -1); the
+  externref param/decl fallback now imports `__array_from_iter_n` and pushes
+  `f64.const stepCount` before the call.
+- **`src/codegen/expressions/assignment.ts`**: array-assignment-pattern
+  materialization swapped to `__array_from_iter_n` with the same step count.
+
+### IteratorClose correction (vs the architect note)
+The architect plan said a bounded stop must NOT close. That is wrong for a
+**no-rest** pattern: §8.5.3 calls IteratorClose after the last element because
+`iteratorRecord.[[Done]]` is still false. Verified against native V8 and against
+test262 `*-ary-init-iter-close.js` (next×2 → return×1 for `[a,b]`; `[x]` over a
+never-done iterator → return×1). So the bounded break sets `cappedOut = true`
+→ closes. Natural `done:true` before the bound still does NOT close (matches
+`*-ary-init-iter-no-close.js`); rest patterns drain unbounded and never close.
+This made the existing #1219 unit test #2's `doneCallCount === 0` assertion
+(tuned to the old eager over-read) spec-incorrect — updated to `=== 1`.
+
+### Scope / residual
+The two patched sites (function/class-method params, decl-var, array
+assignment) are fixed: plain-object iterators consume exactly the
+pattern-length steps and close per spec (verified). One residual remains, OUT
+OF SCOPE for this fix: **compiled `function*` generators eagerly advance past a
+yield** — `_arrayFromIter`/`_drainIterable` correctly request only N steps
+(traced: one `.next()` call), but the generator host-bridge runs the body to
+the *next* yield, so a `[,]` over `function* g(){first++; yield; second++}`
+still observes `second === 1`. That is a generator-suspension codegen bug
+(separate from iterator-step accounting) and belongs with the deeper
+generator/lazy-default work (#1555 / generator codegen), as the architect noted
+for the lazy-default-interleaving sub-case. The for-of-loop-LHS destructuring
+(`for (let [x] of [iter])`) is a third codegen path not touched here and
+remains as-is (pre-existing).
+
+## Test Results
+- New `tests/issue-1592.test.ts` — 8 cases (single/gap/trailing elision, rest,
+  short source, assignment pattern, IteratorClose-on-non-done, rest no-close):
+  all pass.
+- `tests/issue-1219.test.ts` updated (test #2 → spec-correct `doneCallCount===1`)
+  — all pass.
+- Regression suite (1432, 1450, 1158, test262-dstr-patterns, basic/array-rest/
+  generator-method destructuring, iterators, symbol-iterator-protocol,
+  null-destructuring, 43-assign-dstr, 1372-ir): 82 tests pass, 0 failures.
+- test262 spot-check (sync): `*-iter-no-close` pass; `*-iter-step-err` /
+  `*-iter-val-err` pass; plain-object elision/close cases corrected. Async
+  (`for-await-of`) and generator-source variants still fail on the residual
+  above (pre-existing, not regressed). CI measures the net bucket delta.

--- a/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
+++ b/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
@@ -1,9 +1,11 @@
 ---
 id: 1592
 title: "Array pattern elision holes and rest-array in destructuring consume wrong iterator step (~305 fails)"
-status: backlog
+status: blocked
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+blocked_on: 1555
+duplicate_of: 1555
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -11,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: destructuring, array-pattern, for-of, for-await-of, classes
 goal: spec-completeness
-sprint: Backlog
+sprint: 56
 test262_fail: 305
 test262_category: language/statements/class/dstr, language/statements/for-await-of, language/statements/for-of, language/expressions/class/dstr
 ---
@@ -69,6 +71,41 @@ The `Cannot destructure 'null' or 'undefined'` error on the first binding of a c
 
 ## Notes
 
-- Not the same as #1555 (streaming IteratorStep-per-element) or #1158/#1159 (eager/empty patterns) — those fixed iterator consumption order; this is specifically about elision slots being silently skipped
-- The class/dstr failures at L8:5 ("Cannot destructure null/undefined in C_method") suggest the problem manifests at method param binding, not just local dstr
 - Spec reference: ECMA-262 §13.3.3.8 ArrayBindingPattern evaluation, steps for BindingElisionElement
+
+## Investigation 2026-05-27 (dev) — DUPLICATE OF #1555, root cause confirmed
+
+Reproduced both failure shapes against the real test262 harness (worktree
+`issue-1592-elision-rest`, branch from main 5932eef61):
+
+1. `class C { method([,]) {} }; new C().method(g())` → assertion fails
+   (`second` becomes 1, expected 0). The single-elision pattern `[,]` must call
+   `IteratorStep` exactly ONCE (spec §12.14.5.3 Elision step). We instead
+   **materialise the whole generator** via `__array_from_iter`, draining it to
+   completion (`first=1, second=1`).
+2. `class C { method([...[,]] = g()) {} }; new C().method()` → runtime
+   `Cannot destructure 'null' or 'undefined'`. Generator-default path only;
+   the same `[...[,]]` pattern with a **plain-array** arg or **plain-array**
+   default (`= [9,8,7]`) both PASS. So the null leak is in the
+   `__array_from_iter` materialisation of the generator default, not the rest
+   logic itself.
+
+Both failures share ONE root cause: `destructureParamArray`
+(`src/codegen/destructuring-params.ts`) materialises the entire iterator into a
+vec via `__array_from_iter` before binding. This over-consumes iterators with
+observable side effects (generators with statements between yields). The
+`isPatternEmptyOnly` guard only short-circuits length-0 `[]`, so elision-only
+patterns (`[,]`) still materialise fully.
+
+**This is exactly the repro and root cause already tracked by #1555**
+(`refactor: destructureParamArray — streaming IteratorStep-per-element instead
+of __array_from_iter materialisation`, `feasibility: hard`,
+`reasoning_effort: max`, Backlog). #1592 is the test262-failure-count view of
+the same defect. It is NOT fixable with a localised codegen patch — a partial
+fix would fight the #1555 streaming rewrite and risk regressing the tuned
+#1432/#1450/#1550 empty/elision/default handling.
+
+**Recommendation**: fold #1592 into #1555 (or mark #1592 blocked-on #1555).
+The streaming-iterator refactor is the correct, single fix for the whole
+~305-test bucket. Escalation tag on the task was correct — this needs the
+architect's #1555 streaming design, not a dev hotfix.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -64,6 +64,28 @@ function isPatternEmptyOnly(pattern: ts.ArrayBindingPattern): boolean {
 }
 
 /**
+ * Number of iterator steps an array binding/assignment pattern consumes
+ * (§8.5.3 IteratorBindingInitialization). Each element — INCLUDING elision
+ * holes (`OmittedExpression`) — costs exactly one IteratorStep. A rest element
+ * drains the remainder of the iterator → unbounded → -1.
+ *
+ * Binding patterns mark rest via `BindingElement.dotDotDotToken`; assignment
+ * patterns use `SpreadElement`. The returned count feeds `__array_from_iter_n`
+ * so a no-rest pattern materializes EXACTLY `elements.length` steps instead of
+ * draining a lazy generator to completion (#1592). `-1` routes through the
+ * unbounded (legacy `__array_from_iter`) path, preserving all IteratorClose
+ * tuning (#1219).
+ */
+export function patternIteratorStepCount(elements: readonly (ts.ArrayBindingElement | ts.Expression)[]): number {
+  for (const el of elements) {
+    if (el && (ts.isSpreadElement(el) || (ts.isBindingElement(el) && !!el.dotDotDotToken))) {
+      return -1;
+    }
+  }
+  return elements.length;
+}
+
+/**
  * Destructuring mode for the param-destructure helpers (#1553a).
  *
  * - `"param"` (default): function-parameter destructuring; emits no TDZ flags.
@@ -904,10 +926,20 @@ export function destructureParamArray(
         [{ kind: "externref" }],
       );
       flushLateImportShifts(ctx, fctx);
-      // __array_from_iter materializes iterables (generators, sets, custom @@iterator)
-      // via Array.from so __extern_length / __extern_get_idx operate on a real array.
-      // Throws from iterator .next() propagate (spec-compliant for throwing iterators, #1150).
-      const fbIterFn = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+      // __array_from_iter_n materializes iterables (generators, sets, custom
+      // @@iterator) so __extern_length / __extern_get_idx operate on a real
+      // array. Throws from iterator .next() propagate (spec-compliant for
+      // throwing iterators, #1150). The f64 step-count bounds consumption:
+      // no-rest patterns consume EXACTLY elements.length steps; rest patterns
+      // pass -1 → unbounded drain, byte-identical to legacy __array_from_iter
+      // and preserving its IteratorClose tuning (#1219, #1592).
+      const fbIterStepCount = patternIteratorStepCount(pattern.elements);
+      const fbIterFn = ensureLateImport(
+        ctx,
+        "__array_from_iter_n",
+        [{ kind: "externref" }, { kind: "f64" }],
+        [{ kind: "externref" }],
+      );
       flushLateImportShifts(ctx, fctx);
 
       // Else: try each other known vec type and convert element-by-element
@@ -1004,8 +1036,10 @@ export function destructureParamArray(
         const fbIdxTmp = allocLocal(fctx, `__dparam_fb_idx_${fctx.locals.length}`, { kind: "i32" });
 
         const fallbackInstrs: Instr[] = [
-          // materialized = __array_from_iter(param) — throws from iterator .next() propagate
+          // materialized = __array_from_iter_n(param, stepCount) — throws from
+          // iterator .next() propagate; stepCount bounds the drain (#1592).
           { op: "local.get", index: paramIdx } as Instr,
+          { op: "f64.const", value: fbIterStepCount } as Instr,
           { op: "call", funcIdx: fbIterFn } as Instr,
           { op: "local.set", index: fbMatTmp } as Instr,
           // len = i32(__extern_length(materialized))

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -24,7 +24,7 @@ import {
   localGlobalIdx,
   resolveWasmType,
 } from "../index.js";
-import { buildDestructureNullThrow } from "../destructuring-params.js";
+import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitNullGuardedStructGet, isProvablyNonNull, isSafeBoundsEliminated } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
@@ -1335,14 +1335,25 @@ function compileExternrefArrayDestructuringAssignment(
   // before reading binding elements. The previous `tmpLocal[i]` via
   // __extern_get path bypassed the @@iterator getter and .next() calls,
   // so a throwing @@iterator (iter-get-err) or throwing .next() (iter-step-err)
-  // was silently swallowed. Materialize the source via __array_from_iter
+  // was silently swallowed. Materialize the source via __array_from_iter_n
   // first — it invokes @@iterator + .next() and propagates throws.
-  // Plain arrays with the default @@iterator take the fast path.
+  // Plain arrays with the default @@iterator take the fast path. The f64
+  // step-count bounds consumption so a no-rest pattern (`[a,,b] = gen()`)
+  // consumes EXACTLY target.elements.length iterator steps rather than
+  // draining a lazy generator; a rest element passes -1 → unbounded, which is
+  // byte-identical to the legacy __array_from_iter drain (#1592).
   if (resultType.kind === "externref" && target.elements.length > 0) {
-    const matIterIdx = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+    const matStepCount = patternIteratorStepCount(target.elements);
+    const matIterIdx = ensureLateImport(
+      ctx,
+      "__array_from_iter_n",
+      [{ kind: "externref" }, { kind: "f64" }],
+      [{ kind: "externref" }],
+    );
     flushLateImportShifts(ctx, fctx);
     if (matIterIdx !== undefined) {
       fctx.body.push({ op: "local.get", index: tmpLocal });
+      fctx.body.push({ op: "f64.const", value: matStepCount });
       fctx.body.push({ op: "call", funcIdx: matIterIdx });
       fctx.body.push({ op: "local.set", index: tmpLocal });
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3817,19 +3817,26 @@ assert._isSameValue = isSameValue;
           }
           return Object.entries(obj);
         };
-      if (name === "__array_from_iter") {
+      if (name === "__array_from_iter" || name === "__array_from_iter_n") {
         // Cache the original Array.prototype[Symbol.iterator] so we can
         // detect when user code (e.g. test262 iter-get-err-array-prototype)
         // has overridden it. When overridden, we must invoke the protocol
         // rather than fast-pathing the array — otherwise a throwing custom
         // @@iterator on Array.prototype is silently swallowed (#1454).
         const _origArrayIter: any = (Array.prototype as any)[Symbol.iterator];
-        return (obj: any): any => {
-          // Materialize an iterable/array-like to a real JS array so downstream
-          // destructuring can walk it via .length + indexed access. For proper
-          // iterators (e.g. generators) this invokes the iterator protocol and
-          // propagates any throws from .next() — needed for spec-compliant
-          // destructuring of throwing iterators (#1150).
+        // Materialize an iterable/array-like to a real JS array, consuming AT
+        // MOST `limit` iterator steps. `limit === Infinity` (the unbounded
+        // case, used by rest patterns and spread) is byte-for-byte the legacy
+        // __array_from_iter behavior. A finite `limit` calls the iterator's
+        // .next() at most `limit` times — required for array binding patterns
+        // without a rest element, where the spec (§8.5.3) consumes exactly one
+        // IteratorStep per slot (INCLUDING elision holes), not a full drain
+        // (#1592). Stopping at the bound is a NormalCompletion: it must NOT
+        // trigger IteratorClose (only the defensive MAX_ITER cap does).
+        const _arrayFromIter = (obj: any, limit: number): any => {
+          // For proper iterators (e.g. generators) this invokes the iterator
+          // protocol and propagates any throws from .next() — needed for
+          // spec-compliant destructuring of throwing iterators (#1150).
           if (obj == null) return [];
           if (Array.isArray(obj)) {
             // #1454: Real arrays normally take a fast path, but if the user has
@@ -3841,10 +3848,13 @@ assert._isSameValue = isSameValue;
             const ownIter = (obj as any)[Symbol.iterator];
             if (ownIter !== _origArrayIter) {
               // Non-default iterator: fall through to the protocol path below
-              // by treating the array as a generic iterable.
-              return Array.from(obj);
+              // by treating the array as a generic iterable (bounded by limit).
+              return _drainIterable(obj, limit);
             }
-            return obj;
+            // Default array iterator: a finite bound just slices the prefix;
+            // the iterator protocol on a default array is side-effect-free so
+            // slicing is observationally identical to stepping `limit` times.
+            return limit < obj.length ? obj.slice(0, limit) : obj;
           }
           // Compiled sources that do `iter[Symbol.iterator] = fn` often land the
           // function under a stringified "Symbol(Symbol.iterator)" key rather
@@ -3922,6 +3932,24 @@ assert._isSameValue = isSameValue;
                       return undefined;
                     };
                     while (true) {
+                      // Bounded materialization (#1592): stop once we've
+                      // collected `limit` values. A no-rest array binding
+                      // pattern consumes EXACTLY `limit` IteratorStep calls;
+                      // §8.5.3 then requires IteratorClose because the iterator
+                      // record's [[Done]] is still false (we stopped while it
+                      // was still yielding). So this counts as an abrupt-from-
+                      // the-iterator's-view termination → set cappedOut to
+                      // trigger iterator.return() below. (This is the SAME
+                      // close path #1219 exercises for the single-element `[x]`
+                      // pattern over an infinite iterator.) Rest patterns pass
+                      // limit === Infinity and never take this branch, so they
+                      // drain to natural done and do NOT close — preserving the
+                      // dstr/*-ary-init-iter-no-close.js tuning. Checked before
+                      // MAX_ITER so a finite bound always wins.
+                      if (out.length >= limit) {
+                        cappedOut = true;
+                        break;
+                      }
                       if (iterCount++ >= MAX_ITER) {
                         cappedOut = true;
                         break;
@@ -3975,13 +4003,34 @@ assert._isSameValue = isSameValue;
                 }
               }
               const out: any[] = [];
-              const len = typeof (obj as any).length === "number" ? (obj as any).length >>> 0 : 0;
+              const lenRaw = typeof (obj as any).length === "number" ? (obj as any).length >>> 0 : 0;
+              const len = Math.min(lenRaw, limit);
               for (let i = 0; i < len; i++) out.push((obj as any)[i]);
               return out;
             }
           }
-          return Array.from(obj);
+          return _drainIterable(obj, limit);
         };
+        // Walk a plain iterable's @@iterator protocol, collecting at most
+        // `limit` values. Replaces `Array.from(obj)` so a finite bound can stop
+        // early (Array.from can't be bounded). Throws from @@iterator / .next()
+        // / the .value getter propagate unchanged (#1150/#1454). With
+        // limit === Infinity this matches Array.from's full drain.
+        function _drainIterable(obj: any, limit: number): any[] {
+          if (!(limit < Infinity)) return Array.from(obj);
+          const itFn = (obj as any)?.[Symbol.iterator];
+          if (typeof itFn !== "function") return Array.from(obj);
+          const it = itFn.call(obj);
+          const out: any[] = [];
+          while (out.length < limit) {
+            const r = it.next();
+            if (r == null || r.done) break;
+            out.push(r.value);
+          }
+          return out;
+        }
+        if (name === "__array_from_iter") return (obj: any): any => _arrayFromIter(obj, Infinity);
+        return (obj: any, n: number): any => _arrayFromIter(obj, n < 0 ? Infinity : n >>> 0);
       }
       if (name === "__extern_slice")
         return (arr: any, start: number) => {

--- a/tests/issue-1219.test.ts
+++ b/tests/issue-1219.test.ts
@@ -62,10 +62,14 @@ describe("#1219 — ArrayBindingPattern iter-close: hang fix + IteratorClose", (
     expect(elapsed).toBeLessThan(10_000);
   }, 15_000);
 
-  it("finite iterator destructure: stops at done:true and does NOT call return()", async () => {
-    // Per spec §7.4.6: when the iterator naturally terminates (`done:true`),
-    // IteratorClose is NOT invoked. This guards against over-eager return()
-    // calls from the fix.
+  it("no-rest pattern reads exactly N steps, then closes the non-done iterator (§8.5.3)", async () => {
+    // [a, b] consumes EXACTLY two IteratorStep calls (no third probe for
+    // done:true). After the last element, iteratorRecord.[[Done]] is still
+    // false, so §8.5.3 requires IteratorClose → return() IS called once.
+    // Verified against native V8 (next×2, return×1). This used to assert
+    // doneCallCount === 0 under the old eager-drain that over-read a third
+    // value to observe done; bounded materialization (#1592) makes it
+    // spec-correct, matching test262 `*-ary-init-iter-close.js`.
     const exports = await compileToWasm(`
       var doneCallCount: number = 0;
       var nextCallCount: number = 0;
@@ -91,8 +95,10 @@ describe("#1219 — ArrayBindingPattern iter-close: hang fix + IteratorClose", (
         var sum: number = takeTwo(iter);
         // 10 + 20 = 30
         if (sum !== 30) return -1;
-        // Iterator naturally terminated — return() must NOT have been called.
-        if (doneCallCount !== 0) return -2;
+        // Exactly two next() calls — no third probe for done.
+        if (nextCallCount !== 2) return -3;
+        // Iterator not done after the pattern → IteratorClose called once.
+        if (doneCallCount !== 1) return -2;
         return 1;
       }
     `);

--- a/tests/issue-1592.test.ts
+++ b/tests/issue-1592.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1592 — Array binding pattern elision holes and rest must consume
+ * exactly the spec-mandated number of iterator steps (§8.5.3
+ * IteratorBindingInitialization). Eager materialization via __array_from_iter
+ * over-drained lazy generators, so a later binding read a one-ahead value or
+ * the iterator came back null. Fixed by bounded __array_from_iter_n(obj, n).
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function runWasm(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  return (exports.test as () => unknown)();
+}
+
+describe("#1592 — array pattern iterator step count", () => {
+  it("single elision [,] consumes exactly one step", async () => {
+    expect(
+      await runWasm(`
+        function* g(){ yield 1; yield 2; }
+        export function test(): number {
+          const it = g();
+          const [,] = it;
+          return it.next().value as number; // 2 if only one step consumed
+        }`),
+    ).toBe(2);
+  });
+
+  it("gap [a,,b] reads positions 0 and 2", async () => {
+    expect(
+      await runWasm(`
+        function* g(){ yield 10; yield 20; yield 30; yield 40; }
+        export function test(): number {
+          const [a,,b] = g();
+          return (a as number) + (b as number); // 10 + 30 = 40
+        }`),
+    ).toBe(40);
+  });
+
+  it("rest [...r] collects the full remainder", async () => {
+    expect(
+      await runWasm(`
+        function* g(){ yield 1; yield 2; yield 3; }
+        export function test(): number {
+          const [...r] = g();
+          return r.length;
+        }`),
+    ).toBe(3);
+  });
+
+  it("[a, ...r] leaves remainder after first step", async () => {
+    expect(
+      await runWasm(`
+        function* g(){ yield 1; yield 2; yield 3; }
+        export function test(): number {
+          const [a, ...r] = g();
+          return (a as number) * 100 + r.length; // 1*100 + 2 = 102
+        }`),
+    ).toBe(102);
+  });
+
+  it("trailing elision [a,,] still steps the elided slot", async () => {
+    // §8.5.3: a trailing elision performs IteratorStep, so the iterator is
+    // advanced past element index 1 even though nothing is bound there.
+    expect(
+      await runWasm(`
+        function* g(){ yield 5; yield 6; yield 7; }
+        export function test(): number {
+          const it = g();
+          const [a,,] = it;
+          return (a as number) * 100 + (it.next().value as number); // 5*100 + 7 = 507
+        }`),
+    ).toBe(507);
+  });
+
+  it("array assignment pattern [a,,b] = gen() consumes exactly 3 steps", async () => {
+    expect(
+      await runWasm(`
+        function* g(){ yield 1; yield 2; yield 3; yield 4; }
+        export function test(): number {
+          let a = 0, b = 0;
+          const it = g();
+          [a,,b] = it;
+          return a * 1000 + b * 10 + (it.next().value as number); // 1000 + 30 + 4 = 1034
+        }`),
+    ).toBe(1034);
+  });
+
+  it("closes the iterator when a no-rest pattern ends before done (§8.5.3)", async () => {
+    // For a no-rest pattern [a,b] over a still-yielding iterator, the spec
+    // calls IteratorClose after the last element (iteratorRecord.[[Done]] is
+    // false), so the generator's finally runs. Bounded materialization stops
+    // at the pattern length, then the surrounding loop closes — matching
+    // native JS (verified: closed === 1).
+    expect(
+      await runWasm(`
+        let closed = 0;
+        function* g(){ try { yield 1; yield 2; yield 3; } finally { closed = 1; } }
+        export function test(): number {
+          const [a, b] = g(); // 2 steps consumed, iterator not done → closed
+          return (a as number) + (b as number) + closed * 100; // 1+2+100 = 103
+        }`),
+    ).toBe(103);
+  });
+
+  it("rest pattern drains to completion via the unbounded path", async () => {
+    // [a, ...r] passes n = -1 → unbounded, byte-identical to the legacy
+    // __array_from_iter drain. The generator runs to natural done (its finally
+    // fires on completion), r collects the remainder (verified vs native JS).
+    expect(
+      await runWasm(`
+        let closed = 0;
+        function* g(){ try { yield 1; yield 2; } finally { closed = 1; } }
+        export function test(): number {
+          const [a, ...r] = g();
+          return (a as number) + r.length + closed * 100; // 1 + 1 + 100 = 102
+        }`),
+    ).toBe(102);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a bounded `__array_from_iter_n(obj, n)` host import and wires it into the two externref array-destructuring materialization sites (param/decl-var fallback in `destructuring-params.ts`, array assignment pattern in `assignment.ts`) via a new exported `patternIteratorStepCount` helper (elisions count, rest → -1).
- A no-rest array binding/assignment pattern now consumes EXACTLY `elements.length` iterator steps instead of eagerly draining a lazy iterable through `__array_from_iter`. Rest patterns pass `n = -1` → unbounded, byte-identical to the legacy drain (preserves all #1219 IteratorClose tuning).
- Spec correction: per ECMA-262 §8.5.3 a no-rest pattern closes a still-yielding iterator after its last element. The bounded break sets `cappedOut` so IteratorClose fires — verified against native V8 and test262 `*-ary-init-iter-close.js`. Natural `done:true` before the bound and unbounded rest patterns do NOT close (matches `*-ary-init-iter-no-close.js`).

## Scope / residual
- Fixed: plain-object iterators in function/class-method params, decl-var, and array assignment patterns consume exactly the pattern-length steps and close per spec.
- Out of scope (pre-existing, not regressed): compiled `function*` generators eagerly advance past a `yield` in their host bridge, so generator-source elision cases still observe extra steps — that is a generator-suspension codegen bug, tracked alongside #1555 / generator codegen. The `for (let [x] of [iter])` for-of-loop-LHS path is a separate codegen site, untouched.

## Test plan
- [x] `tests/issue-1592.test.ts` (new, 8 cases): single/gap/trailing elision, rest, short source, assignment pattern, IteratorClose-on-non-done, rest no-close — all pass.
- [x] `tests/issue-1219.test.ts` updated: test #2 assertion corrected to spec (`doneCallCount === 1`) — was tuned to the old eager over-read.
- [x] Regression suite (1432, 1450, 1158, test262-dstr-patterns, basic/array-rest/generator-method destructuring, iterators, symbol-iterator-protocol, null-destructuring, 43-assign-dstr, 1372-ir): 82 tests pass, 0 failures.
- [x] `tsc --noEmit` clean; biome lint clean on changed files.
- [ ] CI test262 measures the net bucket delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)