### PR TITLE
fix(#1605-cpn): treat local.tee as transparent in call-arg null fixup

### DIFF
--- a/plan/issues/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
+++ b/plan/issues/1605-class-computed-setter-scope-local-tee-invalid-wasm.md
@@ -56,3 +56,36 @@ setter parameter scope copy-out.
 
 - The three example tests compile to valid Wasm.
 - All 6 tests move off `compile_error`.
+
+## Sub-cluster CPN — FIXED (2026-05-27)
+
+Root cause was **not** in class/accessor codegen — the setter call was lowered
+correctly (`local.get self`, `ref.null.extern` value, `local.tee` temp,
+`call C_set_null`). The bug was in the **call-arg fixup** in
+`src/codegen/fixups.ts` (the "ref.null extern where (ref null N) is expected"
+pass, ~line 878). It walks backwards from a `call` mapping params to preceding
+instructions, skipping multi-consuming producers (`struct.new`,
+`array.new_fixed`, nested `call`). It did **not** account for `local.tee`,
+which is stack-neutral (pops 1, pushes 1) and therefore transparent — not an
+arg producer. With a value `ref.null.extern` tee'd into a temp before the
+`call`, the walk treated the `local.tee` as the param-1 producer, then
+mis-mapped the underlying `ref.null.extern` to param 0 (the struct receiver
+`(ref null N)`), rewriting it to `ref.null <struct>`. That mismatched the
+externref temp the value was tee'd into → `local.tee[N] expected externref,
+found ref.null of <struct>`.
+
+Fix: in the backward arg-walk, treat `local.tee` as transparent — skip it
+without advancing the param index so the real producer beneath maps to the
+current param.
+
+**File**: `src/codegen/fixups.ts`. Test: `tests/issue-1605-cpn.test.ts`.
+
+**test262 results (verified via `runTest262File`)**:
+- `cpn-class-decl-accessors-computed-property-name-from-null.js` — **pass** (was compile_error)
+- `scope-setter-paramsbody-var-close.js` — compile_error → **fail** (now valid wasm; remaining `returned 2` is a separate setter param/body var-close scope-semantics bug, NOT invalid-wasm)
+- `scope-static-setter-paramsbody-var-close.js` — compile_error → **fail** (same; off compile_error)
+
+All three are off `compile_error`. The two `scope-*-var-close` runtime
+semantics failures are a distinct sub-cluster left to the broader #1605 work.
+A 100-file slice of `language/statements/class` shows identical status counts
+to clean main (82 pass / 13 fail / 5 ce) — no regression from the fixup change.

--- a/src/codegen/fixups.ts
+++ b/src/codegen/fixups.ts
@@ -916,6 +916,17 @@ export function fixupExternConvertAny(ctx: CodegenContext): void {
         if (pos < 0) break;
         const argInstr = instrs[pos]!;
 
+        // local.tee is stack-neutral (pops 1, pushes 1) — it is NOT an arg
+        // producer, it sits between the real value producer and the consumer.
+        // Skip it WITHOUT advancing the param index so the producer beneath it
+        // maps to the current param. (Without this, a `ref.null.extern` value
+        // tee'd into a temp gets mis-assigned to the wrong param and rewritten
+        // to a struct null — #1605-cpn.)
+        if (argInstr.op === "local.tee") {
+          pi++; // counteract the loop's pi-- so this param is retried
+          continue;
+        }
+
         // struct.new consumes N fields and produces 1 value.
         // The current pos IS a call arg (the struct.new result), but the N
         // instructions before it are struct field args, NOT call args.

--- a/tests/issue-1605-cpn.test.ts
+++ b/tests/issue-1605-cpn.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * Issue #1605-cpn — a `call`-arg fixup walked backwards from a `call`
+ * matching params to preceding instructions but did not treat `local.tee`
+ * (stack-neutral) as transparent. For `c[null] = null` lowered as a setter
+ * call `C_set_null(self, value)`, the externref `value` (`ref.null.extern`)
+ * was tee'd into a temp; the backward walk mis-mapped that `ref.null.extern`
+ * to param 0 (the struct receiver) and rewrote it to `ref.null <struct>`,
+ * producing `local.tee[N] expected externref, found ref.null of <struct>`
+ * invalid wasm.
+ */
+
+function buildImports(wasmModule: WebAssembly.Module): Record<string, Record<string, any>> {
+  const importObj: Record<string, Record<string, any>> = {};
+  for (const imp of WebAssembly.Module.imports(wasmModule)) {
+    if (!importObj[imp.module]) importObj[imp.module] = {};
+    if (imp.kind === "function") {
+      importObj[imp.module]![imp.name] = (...args: any[]) => args[0];
+    } else if (imp.kind === "global") {
+      importObj[imp.module]![imp.name] = imp.name;
+    } else if (imp.kind === "tag") {
+      importObj[imp.module]![imp.name] = new WebAssembly.Tag({ parameters: ["externref"] });
+    }
+  }
+  return importObj;
+}
+
+function compileAndRun(code: string): number {
+  const result = compile(code);
+  expect(result.success).toBe(true);
+  const wasmModule = new WebAssembly.Module(result.binary);
+  const instance = new WebAssembly.Instance(wasmModule, buildImports(wasmModule));
+  return (instance.exports as any).test();
+}
+
+describe("class computed-accessor setter call-arg fixup (#1605-cpn)", () => {
+  it("c[null] = null on an accessor-only class compiles to valid wasm and calls the setter", () => {
+    expect(
+      compileAndRun(`
+        let calls = 0;
+        class C {
+          get [null]() { return null; }
+          set [null](v: any) { calls = calls + 1; }
+        }
+        export function test(): number {
+          let c = new C();
+          c[null] = null;
+          return calls;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("does not regress a normal string-key setter on a class", () => {
+    expect(
+      compileAndRun(`
+        let calls = 0;
+        class C {
+          set ['x'](v: any) { calls = calls + 1; }
+        }
+        export function test(): number {
+          let c = new C();
+          c['x'] = 5 as any;
+          return calls;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- The call-arg fixup in `src/codegen/fixups.ts` (rewriting `ref.null.extern` args to `ref.null <typeIdx>` when a param expects `(ref null N)`) walks backwards from a `call` matching params to preceding instructions. It skips multi-consuming producers (`struct.new`, `array.new_fixed`, nested `call`) but did **not** account for `local.tee`, which is stack-neutral (pops 1, pushes 1) and therefore transparent.
- For `c[null] = null` lowered as `C_set_null(self, value)`, the externref value `ref.null.extern` is tee'd into a temp before the call. The walk treated `local.tee` as the param-1 producer, then mis-mapped the underlying `ref.null.extern` to param 0 (the struct receiver `(ref null N)`), rewriting it to `ref.null <struct>` → `local.tee[N] expected externref, found ref.null of <struct>` invalid wasm.
- Fix: skip `local.tee` in the backward arg-walk without advancing the param index.

Scoped sub-task of #1605. The two `scope-*-setter-paramsbody-var-close` tests move **off compile_error** (now valid wasm); their remaining `returned 2` runtime failures are a separate setter param/body var-close scope-semantics sub-cluster left to the broader #1605 work.

## test262 (verified via `runTest262File`)
- `cpn-class-decl-accessors-computed-property-name-from-null.js` — **pass** (was compile_error)
- `scope-setter-paramsbody-var-close.js` — compile_error → fail (off CE)
- `scope-static-setter-paramsbody-var-close.js` — compile_error → fail (off CE)

## Test plan
- [x] `tests/issue-1605-cpn.test.ts` — 2 unit tests (null-key setter calls + no-regression on string-key setter)
- [x] 100-file `language/statements/class` slice: identical status counts to clean main (82/13/5) — no fixup regression
- [x] `npx tsc --noEmit` clean
- [ ] CI conformance gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)