### PR TITLE
fix(#779d): track dstr-param branch buffers in liveBodies (funcIdx shift)

### DIFF
--- a/plan/issues/779d-object-literal-dstr-residual.md
+++ b/plan/issues/779d-object-literal-dstr-residual.md
@@ -1,9 +1,9 @@
 ---
 id: 779d
 title: "Object-literal destructuring (non-class, non-for-of) residuals (~132 fails)"
-status: ready
+status: in-review
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -48,6 +48,32 @@ class-only paths fixed by #1543/#1544 and the for-of paths fixed by
 - ECMAScript §13.2.5 Object Initializer (PropertyDefinitionEvaluation for
   MethodDefinition)
 - §14.1.18 IteratorBindingInitialization
+
+## Fix (2026-05-27) — narrow funcIdx-shift sub-cluster
+
+Root cause confirmed in `src/codegen/destructuring-params.ts`
+`destructureParamObject` externref path (lines ~581-609): the struct-fast-path
+`then` branch and the `__extern_get` `else` branch each compile the binding
+default into a detached buffer via a manual `fctx.body` swap. When the *second*
+branch's compilation added a late/union import, the function indices shifted,
+but the *first* branch's buffer was detached from `fctx.body` at that moment, so
+the index-shift walk missed its forward `call`, leaving an off-by-one funcIdx
+("not enough arguments on the stack for call"). E.g. `method({ x = thrower() })`
+emitted `call <method>` instead of `call <thrower>`.
+
+Fix: register both branch buffers in `ctx.liveBodies` (walked by every shift
+path) for the whole construction window. Same mechanism as the #801/#1384
+liveBodies safety net.
+
+### Test Results
+- 6 `*-meth-obj-ptrn-*-init-throws` tests (meth/gen-meth/async-gen-meth ×
+  id/prop-id) flip from `compile_error` → `pass` (verified in process isolation).
+- `tests/issue-779d.test.ts` added (3 cases) — passes.
+- Regression check: `default-params.test.ts` 3 failures are PRE-EXISTING on the
+  branch base (verified by stashing the fix), NOT introduced here.
+- Out of scope (separate bugs, still failing): `*-init-skipped` family (default
+  fires on `null` — #821/#1550 semantics); `async-gen-*-prop-id-init-skipped`
+  has a distinct funcIdx orphan in the async-gen path; elision/rest = #1592.
 
 ## Acceptance criteria
 

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -580,6 +580,18 @@ export function destructureParamObject(
         const convertedType: ValType = { kind: "ref_null", typeIdx: structTypeIdx };
         const tmpLocal = allocLocal(fctx, `__dparam_cvt_${fctx.locals.length}`, convertedType);
         const thenInstrs: Instr[] = [];
+        const elseInstrs: Instr[] = [];
+        // (#779d) Register both branch buffers in liveBodies for the whole
+        // construction window. Each branch compiles a binding default that may
+        // emit a forward `call` to a function declared later (e.g.
+        // `method({ x = thrower() })`). When the *second* branch's compilation
+        // adds a late/union import, the function indices shift — but the *first*
+        // branch's buffer is detached from fctx.body at that moment (swapped back
+        // to savedBody), so the shift walk would miss its stale `call` funcIdx,
+        // leaving an off-by-one call. liveBodies is walked by every shift path, so
+        // keeping them tracked until the `if` is emitted closes the orphan window.
+        ctx.liveBodies.add(thenInstrs);
+        ctx.liveBodies.add(elseInstrs);
         const savedBody = fctx.body;
         fctx.body = thenInstrs;
         fctx.body.push({ op: "local.get", index: anyTmp });
@@ -589,12 +601,13 @@ export function destructureParamObject(
         fctx.body = savedBody;
 
         // Else branch: cast would fail (primitive/different struct) — use __extern_get (#852)
-        const elseInstrs: Instr[] = [];
         fctx.body = elseInstrs;
         destructureParamObjectExternref(ctx, fctx, paramIdx, pattern, opts);
         fctx.body = savedBody;
 
         fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenInstrs, else: elseInstrs });
+        ctx.liveBodies.delete(thenInstrs);
+        ctx.liveBodies.delete(elseInstrs);
       } else {
         // No struct type found — use __extern_get for all properties (#852)
         destructureParamObjectExternref(ctx, fctx, paramIdx, pattern, opts);

--- a/tests/issue-779d.test.ts
+++ b/tests/issue-779d.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #779d (narrow) — funcIdx off-by-one in object-literal method binding-default.
+//
+// `method({ x = thrower() })` where `thrower` is declared after the object
+// literal previously compiled to an invalid module: the externref param
+// destructuring path (destructureParamObject) emits a struct-fast-path `then`
+// branch and an `__extern_get` `else` branch, each compiling the default
+// initializer (`thrower()`) into a detached buffer via a manual fctx.body swap.
+// When the *second* branch's compilation triggered a late/union import, the
+// function indices shifted — but the *first* branch's buffer was detached from
+// fctx.body at that moment, so the index-shift walk missed its forward `call`,
+// leaving an off-by-one funcIdx ("not enough arguments on the stack for call").
+//
+// Fix: register both branch buffers in ctx.liveBodies (walked by every shift
+// path) for the whole construction window.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<Record<string, Function>> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  // Instantiation validates the module — the funcIdx bug surfaced here as
+  // "Compiling function ...: not enough arguments on the stack for call".
+  const imports: any = buildImports(r.imports, undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(inst.instance.exports);
+  return inst.instance.exports as Record<string, Function>;
+}
+
+describe("#779d — object-literal method binding-default funcIdx shift", () => {
+  // The headline shape: a method with a destructured-param default that calls a
+  // function declared AFTER the object literal. Enough surrounding functions /
+  // late imports must exist for the index shift to fire mid-method-body. The
+  // bug only reproduced once the module had grown large enough; we approximate
+  // that here with several helper functions plus the forward `thrower`.
+  it("method({ x = thrower() }) with thrower declared later instantiates", async () => {
+    await expect(
+      run(`
+        function pad1(): number { return 1; }
+        function pad2(): number { return 2; }
+        const obj: any = {
+          method({ x = thrower() }: any): any { return x; }
+        };
+        function thrower(): any { throw new Error("boom"); }
+        export function test(): number { pad1(); pad2(); return 0; }
+      `),
+    ).resolves.toBeDefined();
+  });
+
+  it("generator method with forward-called binding default instantiates", async () => {
+    await expect(
+      run(`
+        const obj: any = {
+          *gen({ x = later() }: any): any { yield x; }
+        };
+        function later(): any { return "lateval"; }
+        export function test(): number { return 0; }
+      `),
+    ).resolves.toBeDefined();
+  });
+
+  it("binding default that IS taken still evaluates the initializer (semantics intact)", async () => {
+    const exports = await run(`
+      function makeDefault(): number { return 99; }
+      const obj: any = {
+        method({ x = makeDefault() }: any): number { return x; }
+      };
+      export function test(): number {
+        // Call with an object missing 'x' so the default fires.
+        return obj.method({});
+      }
+    `);
+    expect(exports.test!()).toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the funcIdx off-by-one sub-cluster of #779d: object-literal method binding-defaults that call a function declared later (e.g. `method({ x = thrower() })`) compiled to an invalid module ("not enough arguments on the stack for call").
- Root cause: in `destructureParamObject`'s externref path (`src/codegen/destructuring-params.ts`), the struct-fast-path `then` branch and `__extern_get` `else` branch each compile the binding default into a buffer detached from `fctx.body` via a manual swap. When the second branch's compilation added a late/union import, function indices shifted, but the first branch's detached buffer was missed by the index-shift walk — leaving a stale forward `call`.
- Fix: register both branch buffers in `ctx.liveBodies` (walked by every index-shift path) for the whole construction window, matching the existing #801/#1384 safety net. ~12 lines.

## Test plan
- [x] 6 `*-meth-obj-ptrn-*-init-throws` test262 tests (meth/gen-meth/async-gen-meth × id/prop-id) flip `compile_error` → `pass` (verified in process isolation).
- [x] New `tests/issue-779d.test.ts` (3 cases) passes.
- [x] No regression: `default-params.test.ts` 3 failures are PRE-EXISTING on the branch base (verified by stashing the fix), not introduced here.
- [ ] CI full test262 conformance gate.

Scope note: `*-init-skipped` family (default fires on `null`), the async-gen-prop-id-init-skipped distinct orphan, and elision/rest (#1592) are out of scope and tracked separately. #779d umbrella left `in-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)