### PR TITLE
fix(#1592): bounded array-pattern iterator consumption (__array_from_iter_n)

### DIFF
--- a/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
+++ b/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
@@ -1,9 +1,11 @@
 ---
 id: 1592
 title: "Array pattern elision holes and rest-array in destructuring consume wrong iterator step (~305 fails)"
-status: backlog
+status: blocked
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+blocked_on: 1555
+duplicate_of: 1555
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -11,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: destructuring, array-pattern, for-of, for-await-of, classes
 goal: spec-completeness
-sprint: Backlog
+sprint: 56
 test262_fail: 305
 test262_category: language/statements/class/dstr, language/statements/for-await-of, language/statements/for-of, language/expressions/class/dstr
 ---
@@ -69,6 +71,264 @@ The `Cannot destructure 'null' or 'undefined'` error on the first binding of a c
 
 ## Notes
 
-- Not the same as #1555 (streaming IteratorStep-per-element) or #1158/#1159 (eager/empty patterns) — those fixed iterator consumption order; this is specifically about elision slots being silently skipped
-- The class/dstr failures at L8:5 ("Cannot destructure null/undefined in C_method") suggest the problem manifests at method param binding, not just local dstr
 - Spec reference: ECMA-262 §13.3.3.8 ArrayBindingPattern evaluation, steps for BindingElisionElement
+
+## Investigation 2026-05-27 (dev) — DUPLICATE OF #1555, root cause confirmed
+
+Reproduced both failure shapes against the real test262 harness (worktree
+`issue-1592-elision-rest`, branch from main 5932eef61):
+
+1. `class C { method([,]) {} }; new C().method(g())` → assertion fails
+   (`second` becomes 1, expected 0). The single-elision pattern `[,]` must call
+   `IteratorStep` exactly ONCE (spec §12.14.5.3 Elision step). We instead
+   **materialise the whole generator** via `__array_from_iter`, draining it to
+   completion (`first=1, second=1`).
+2. `class C { method([...[,]] = g()) {} }; new C().method()` → runtime
+   `Cannot destructure 'null' or 'undefined'`. Generator-default path only;
+   the same `[...[,]]` pattern with a **plain-array** arg or **plain-array**
+   default (`= [9,8,7]`) both PASS. So the null leak is in the
+   `__array_from_iter` materialisation of the generator default, not the rest
+   logic itself.
+
+Both failures share ONE root cause: `destructureParamArray`
+(`src/codegen/destructuring-params.ts`) materialises the entire iterator into a
+vec via `__array_from_iter` before binding. This over-consumes iterators with
+observable side effects (generators with statements between yields). The
+`isPatternEmptyOnly` guard only short-circuits length-0 `[]`, so elision-only
+patterns (`[,]`) still materialise fully.
+
+**This is exactly the repro and root cause already tracked by #1555**
+(`refactor: destructureParamArray — streaming IteratorStep-per-element instead
+of __array_from_iter materialisation`, `feasibility: hard`,
+`reasoning_effort: max`, Backlog). #1592 is the test262-failure-count view of
+the same defect. It is NOT fixable with a localised codegen patch — a partial
+fix would fight the #1555 streaming rewrite and risk regressing the tuned
+#1432/#1450/#1550 empty/elision/default handling.
+
+**Recommendation**: fold #1592 into #1555 (or mark #1592 blocked-on #1555).
+The streaming-iterator refactor is the correct, single fix for the whole
+~305-test bucket. Escalation tag on the task was correct — this needs the
+architect's #1555 streaming design, not a dev hotfix.
+
+## Implementation Plan (architect, 2026-05-27)
+
+### Relationship to #1555 — why a bounded helper, not the full streaming rewrite
+
+The dev rec above proposes folding into #1555 (a full
+`destructureParamArray` → streaming-IteratorStep-per-element rewrite,
+`feasibility: hard`). That rewrite is the *eventual* correct shape, but it is a
+large, regression-prone refactor that fights the carefully-tuned
+#1432/#1450/#1550 empty/elision/default paths.
+
+This plan is the **incremental, low-blast-radius fix**: it does **not** rewrite
+the per-element binding loop and does **not** make iteration truly streaming.
+It changes only **how many iterator steps the materialization consumes**, by
+adding a bounded variant of `__array_from_iter`. The per-element loop, elision
+`continue`, rest slice, defaults, and IteratorClose tuning all stay exactly as
+they are. This recovers spec-correct step counts for the fixed-prefix (no-rest)
+patterns that dominate the ~305 bucket, at a fraction of #1555's risk.
+
+The one semantic gap vs. full streaming: an iterator whose side effects occur
+*between* a binding element and its default-evaluation (`[a = sideEffect()]`)
+is still materialized in one shot, so default-evaluation interleaving is not
+made lazy. That sub-case stays with #1555. **Recommend: keep #1592 as the
+bounded-helper fix targeting the step-count bucket; leave #1555 open for the
+residual lazy-default interleaving.** If the team prefers a single fix, this
+plan can be the Phase 1 of #1555.
+
+### Root cause (refined)
+
+The per-element loop already skips elisions correctly
+(`if (ts.isOmittedExpression(element)) continue;` —
+`destructuring-params.ts:1196/1339`, `assignment.ts:1377`). The bug is one
+level up: **materialization is eager**. Every array-destructuring path that
+sees an `externref` source calls `__array_from_iter(obj)`
+(`src/runtime.ts:3820`), which drains the **entire** iterator —
+`Array.from(obj)` for plain iterables, or the manual `while (true)` walk
+(runtime.ts:3924–3956, capped at `MAX_ITER = 1<<16`) for wasm-closure
+iterators. For a lazy generator, the spec requires exactly **N IteratorStep
+calls** for an N-slot pattern (elisions and a trailing rest each count toward
+N — §8.5.3 IteratorBindingInitialization), **not** a full drain.
+
+The `Cannot destructure 'null' or 'undefined'` L8:5 class-method fails are a
+**secondary symptom**: when the eager drain over-runs a generator default and
+it returns/throws early, the materialized array comes back short (or stale
+null) and a later binding element reads `undefined`, tripping the destructure
+guard.
+
+### Fix: bounded materialization helper `__array_from_iter_n`
+
+Add a host import that materializes **at most `n`** iterator steps.
+
+**Signature (JS host):** `(obj: externref, n: f64) -> externref`
+- `n >= 0`: consume **exactly** `n` iterator steps (call `.next()` up to `n`
+  times); stop early if the iterator reports `done` first. Returned array has
+  `length <= n`.
+- `n < 0` (sentinel `-1`): unbounded — behaves **identically** to today's
+  `__array_from_iter` (full drain). Used when the pattern ends in a rest
+  element, so it shares the exact existing drain + IteratorClose code.
+
+Wasm import type:
+`[{kind:"externref"},{kind:"f64"}] -> [{kind:"externref"}]`. f64 (not i32) for
+the count matches the project's host-import numeric convention
+(`__extern_get_idx`, `__extern_length`).
+
+**Why exactly-N suffices:** a pattern with a rest element always wants the full
+remainder → `n = -1`. A pattern WITHOUT a rest performs `IteratorStep` for
+every slot including trailing elisions → `n = elements.length` is exact, and
+the returned (possibly short) array drives the unchanged per-element loop,
+whose elision `continue` and out-of-range reads already yield correct
+`undefined` bindings.
+
+#### Runtime change — `src/runtime.ts`
+
+Refactor to reuse the existing body:
+
+1. Extract the current `__array_from_iter` closure body (runtime.ts:3827–3984)
+   into a private helper `const _arrayFromIter = (obj: any, limit: number) => …`
+   (`limit` defaults to `Infinity`):
+   - `Array.isArray(obj)` fast path: when `limit` is finite and `< obj.length`,
+     return `obj.slice(0, limit)` — but only AFTER the existing
+     overridden-`@@iterator` check; if the array has a non-default
+     `@@iterator`, go through the protocol so a custom iterator is stepped at
+     most `limit` times (do not whole-materialize-then-slice a custom iterator).
+   - Plain-iterable `Array.from(obj)` branches: replace with a manual loop —
+     `const it = obj[Symbol.iterator](); ` then call `it.next()` up to `limit`
+     times, pushing `value` while `!done`. `Array.from` can't be bounded.
+     Preserve throw propagation from a throwing `@@iterator`/`.next()`/`.value`.
+   - Wasm-closure manual walk (runtime.ts:3924): add
+     `if (out.length >= limit) break;` at the **top** of the `while (true)`
+     loop, **before** the `iterCount++ >= MAX_ITER` check, and ensure this
+     bounded break does **NOT** set `cappedOut`.
+
+2. Keep `__array_from_iter` as a thin wrapper and register the new name:
+   ```ts
+   if (name === "__array_from_iter")
+     return (obj: any) => _arrayFromIter(obj, Infinity);
+   if (name === "__array_from_iter_n")
+     return (obj: any, n: number) =>
+       _arrayFromIter(obj, n < 0 ? Infinity : (n >>> 0));
+   ```
+   `n = -1` is byte-for-byte the old behavior → rest path + IteratorClose tuning
+   unchanged.
+
+3. If host imports are gated, add `"__array_from_iter_n"` next to
+   `__array_from_iter` in `src/codegen/host-import-allowlist.ts`.
+
+#### Codegen wiring
+
+Add a step-count helper near `isPatternEmptyOnly`
+(`destructuring-params.ts:63`):
+```ts
+/**
+ * Iterator steps an array binding/assignment pattern consumes (§8.5.3).
+ * Each element — INCLUDING elision holes (OmittedExpression) — costs one
+ * IteratorStep. A rest element drains the remainder → unbounded → -1.
+ * Binding patterns use BindingElement.dotDotDotToken; assignment patterns
+ * use SpreadElement.
+ */
+function patternIteratorStepCount(
+  elements: readonly (ts.ArrayBindingElement | ts.Expression)[],
+): number {
+  for (const el of elements) {
+    if (el && (ts.isSpreadElement(el) ||
+        (ts.isBindingElement(el) && !!el.dotDotDotToken))) return -1;
+  }
+  return elements.length;
+}
+```
+
+**Site 1 — `src/codegen/destructuring-params.ts:944`** (param/decl externref
+fallback materialization):
+- Swap `ensureLateImport(ctx, "__array_from_iter", [externref], [externref])`
+  → `ensureLateImport(ctx, "__array_from_iter_n", [externref, f64], [externref])`.
+  Keep the surrounding `flushLateImportShifts` ordering.
+- At the IR call site (lines 1041–1044), compute
+  `const n = patternIteratorStepCount(pattern.elements)` at codegen time and
+  emit, after `local.get paramIdx`:
+  `{ op: "f64.const", value: n }` then `call __array_from_iter_n`.
+- Leave the `isPatternEmptyOnly` short-circuit (line 806) untouched.
+
+**Site 2 — `src/codegen/expressions/assignment.ts:1342`** (`[a,,b] = expr`):
+- Same import swap; push `f64.const patternIteratorStepCount(target.elements)`
+  before the call (lines 1345–1346).
+
+**Do NOT touch** the `type-coercion.ts` uses (lines 206/356/362) — spread /
+tuple-coercion paths (`[...iter]`) that genuinely want the full drain.
+`class-bodies.ts:1331` and `statements/exceptions.ts:80` are comments only.
+
+The WasmGC-native vec loop (destructuring-params.ts:949) and tuple-struct fast
+path (line 834) read a concrete struct/array of known static length and never
+step an iterator — elision/rest already correct there; no change.
+
+### Standalone / WASI equivalent
+
+`__array_from_iter` is **JS-host-only**; there is no WasmGC-native iterator
+drain in `src/codegen-linear/` (confirmed: no `array_from_iter` reference under
+that dir). Destructuring an arbitrary externref *iterable* in pure-standalone
+mode is already unsupported and this fix does not regress it. The WasmGC vec /
+tuple paths use static-length indexed reads (elisions honored, no iterator) so
+standalone mode is already correct for those. **No new standalone host import
+is required by this issue.** If a future issue adds a Wasm-native
+generator-drain for standalone mode, it should accept the same `n` bound — note
+here, do not build it now.
+
+### IteratorClose handling (MUST preserve verbatim)
+
+`__array_from_iter` calls `iterator.return()` ONLY on the `cappedOut`
+(`MAX_ITER` defensive cap) path (runtime.ts:3963–3972), and deliberately does
+**not** close on natural `done`, `result == null`, or missing `.next`
+(tuned against `dstr/*-ary-init-iter-no-close.js`, #1219).
+`__array_from_iter_n` inherits this because it shares `_arrayFromIter`:
+- `n = -1` → `limit = Infinity` → identical control flow → identical close.
+- `n >= 0` reaching the bound → **NormalCompletion**, do **NOT** call
+  `return()`; the bounded break must not set `cappedOut`. Closing here would
+  regress `dstr/*-ary-init-iter-no-close.js`.
+- Keep `MAX_ITER` + its `cappedOut → return()` exactly as-is for the unbounded
+  (rest) case.
+
+### Edge cases
+
+- **Rest** `[a, ...rest]` → `patternIteratorStepCount` = -1 → unbounded →
+  byte-identical to today; downstream `__extern_slice` (assignment.ts:1379) /
+  vec slice unchanged.
+- **Elision counts**: `[, x]`→n=2, `[a,,b]`→n=3, `[a,,]`→n=2 (trailing elision
+  still steps). TS keeps `OmittedExpression` nodes in `elements`, so
+  `elements.length` is automatically right.
+- **`[...rest,]`** (rest + trailing comma) → has rest → n=-1.
+- **Nested** `[[a],,b]` → each top-level slot = one step; n = top-level
+  `elements.length`; nested destructure runs on the materialized element.
+- **Empty `[]`** → handled earlier by `isPatternEmptyOnly`; never reaches the
+  helper.
+- **Short source** `[a,b,c] = [1]` (n=3, yields 1) → helper returns `[1]`;
+  out-of-range reads → `undefined` bindings (matches eager behavior, fewer
+  `.next()` calls).
+- **n=0 reaching helper** → `limit=0` → no `.next()`, returns `[]`. Safe.
+
+### Test files to verify
+
+```
+test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-ary-elision.js
+test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elision.js
+test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-elision.js
+test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-empty.js
+test/language/statements/for-of/*-ary-ptrn-elision*.js
+test/language/expressions/assignment/dstr/array-elision-*.js
+```
+
+### Regression risks & categories to run
+
+- **Highest risk: IteratorClose.** Route the rest case through unchanged
+  `limit=Infinity`; never `return()` on the new bounded break.
+- **`Array.from` → manual loop swap** must preserve throw propagation
+  (#1150, #1454): run `dstr/*-iter-get-err*`, `*-iter-step-err*`,
+  `*-iter-val-err*`.
+- **Late-import shifts**: `__array_from_iter_n` has 2 args; preserve the
+  `ensureLateImport` + `flushLateImportShifts` ordering at the two sites so
+  funcIdx shifts propagate (`body: []` / savedBodies pattern — see CLAUDE.md
+  addUnionImports note).
+- **Run:** `language/statements/class` + `language/expressions/class` (dstr);
+  `for-of`, `for-await-of`; `language/expressions/assignment/dstr`;
+  `language/statements/function`; `language/expressions/async-generator`;
+  full `tests/equivalence.test.ts`; any `issue-1158`/`issue-1159`/`iter-close`
+  equivalence tests to confirm no IteratorClose regression.

--- a/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
+++ b/plan/issues/1592-ary-ptrn-elision-rest-holes-dstr.md
@@ -1,11 +1,11 @@
 ---
 id: 1592
 title: "Array pattern elision holes and rest-array in destructuring consume wrong iterator step (~305 fails)"
-status: blocked
+status: done
 created: 2026-05-24
 updated: 2026-05-27
-blocked_on: 1555
-duplicate_of: 1555
+completed: 2026-05-27
+related: 1555
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -332,3 +332,45 @@ test/language/expressions/assignment/dstr/array-elision-*.js
   `language/statements/function`; `language/expressions/async-generator`;
   full `tests/equivalence.test.ts`; any `issue-1158`/`issue-1159`/`iter-close`
   equivalence tests to confirm no IteratorClose regression.
+
+## Implementation + Test Results (2026-05-27, dev)
+
+Implemented the bounded-helper plan above.
+
+**Runtime (`src/runtime.ts`)**: refactored `__array_from_iter` into a shared
+`_arrayFromIter(obj, limit)` + a generic `_drainIterable(obj, limit)`; added
+the `__array_from_iter_n` import. `n < 0` (-1 sentinel) → `limit = Infinity`,
+byte-identical to the legacy drain (rest patterns). `n >= 0` → consume at most
+`n` steps. Refinement vs. the original spec: per ECMA-262 §13.3.3.6 a rest-less
+ArrayBindingPattern performs IteratorClose when `[[Done]]` is false after the
+last element — so stopping at a finite bound while the iterator is still
+yielding now sets `cappedOut` and calls `iterator.return()` (matches V8). The
+`Infinity`/rest path is unchanged (close still governed by natural `done` /
+`MAX_ITER`).
+
+**Codegen**: added `patternIteratorStepCount(elements)` in
+`destructuring-params.ts` (elisions count as one step; a rest/spread → -1).
+Wired the two materialization sites — `destructureParamArray` param/decl
+fallback and `assignment.ts` array-assignment — to call `__array_from_iter_n`
+with the per-pattern step count. `__array_from_iter_n` matches the existing
+`__array_` allowlist prefix, so no allowlist-budget change.
+
+**Validated**:
+- `tests/issue-1592.test.ts` — 7/7 (param `[a,,b]` from generator; param
+  `[...[,]]=g()` full drain; decl/for-of elision value-correctness; rest full
+  remainder; assignment `[a,,b]=g()`; plain-array fast path).
+- `tests/issue-1219.test.ts` — IteratorClose suite green; updated the stale
+  "finite iterator does NOT close" assertion to the spec/V8 behavior
+  (rest-less `[a,b]` over a still-yielding iterator closes once, 2 `next()`
+  calls — the old expectation depended on the over-consumption bug #1592 fixes).
+- No regressions across issue-1158/1432/1450, array-rest/basic/for-of/class/
+  fn-param destructuring, generator-method-destructuring, iterators, 862, 1372,
+  1128, allowlist-budget. (Three sibling files fail to *load* on an unrelated
+  pre-existing `./helpers.js` import path — identical on origin/main.)
+- `tsc --noEmit` clean.
+
+**Residual (→ #1555)**: `const`-declaration over a lazy generator still
+materializes eagerly for the side-effect-step-count sub-case (value binding is
+correct; observable step count over-consumes). That is the lazy-default
+interleaving the plan explicitly left to the #1555 streaming rewrite. Kept
+`related: 1555`.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -64,6 +64,24 @@ function isPatternEmptyOnly(pattern: ts.ArrayBindingPattern): boolean {
 }
 
 /**
+ * Iterator steps an array binding/assignment pattern consumes (§8.5.3).
+ * Each element — INCLUDING elision holes (OmittedExpression) — costs one
+ * IteratorStep. A rest element drains the remainder → unbounded → -1.
+ * Binding patterns mark rest via `BindingElement.dotDotDotToken`; assignment
+ * patterns use `SpreadElement`. Used to bound `__array_from_iter_n` so a
+ * rest-less pattern steps a lazy generator exactly `elements.length` times
+ * instead of draining it (#1592).
+ */
+export function patternIteratorStepCount(elements: ReadonlyArray<ts.ArrayBindingElement | ts.Expression>): number {
+  for (const el of elements) {
+    if (el && (ts.isSpreadElement(el) || (ts.isBindingElement(el) && !!el.dotDotDotToken))) {
+      return -1;
+    }
+  }
+  return elements.length;
+}
+
+/**
  * Destructuring mode for the param-destructure helpers (#1553a).
  *
  * - `"param"` (default): function-parameter destructuring; emits no TDZ flags.
@@ -904,11 +922,19 @@ export function destructureParamArray(
         [{ kind: "externref" }],
       );
       flushLateImportShifts(ctx, fctx);
-      // __array_from_iter materializes iterables (generators, sets, custom @@iterator)
-      // via Array.from so __extern_length / __extern_get_idx operate on a real array.
+      // __array_from_iter_n materializes iterables (generators, sets, custom @@iterator)
+      // so __extern_length / __extern_get_idx operate on a real array. Bounded to the
+      // pattern's iterator-step count (#1592): a rest-less pattern steps a lazy generator
+      // exactly N times instead of draining it; a rest pattern passes -1 (unbounded).
       // Throws from iterator .next() propagate (spec-compliant for throwing iterators, #1150).
-      const fbIterFn = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+      const fbIterFn = ensureLateImport(
+        ctx,
+        "__array_from_iter_n",
+        [{ kind: "externref" }, { kind: "f64" }],
+        [{ kind: "externref" }],
+      );
       flushLateImportShifts(ctx, fctx);
+      const fbIterStepCount = patternIteratorStepCount(pattern.elements);
 
       // Else: try each other known vec type and convert element-by-element
       const convertInstrs: Instr[] = [];
@@ -1004,8 +1030,9 @@ export function destructureParamArray(
         const fbIdxTmp = allocLocal(fctx, `__dparam_fb_idx_${fctx.locals.length}`, { kind: "i32" });
 
         const fallbackInstrs: Instr[] = [
-          // materialized = __array_from_iter(param) — throws from iterator .next() propagate
+          // materialized = __array_from_iter_n(param, stepCount) — throws from .next() propagate
           { op: "local.get", index: paramIdx } as Instr,
+          { op: "f64.const", value: fbIterStepCount } as Instr,
           { op: "call", funcIdx: fbIterFn } as Instr,
           { op: "local.set", index: fbMatTmp } as Instr,
           // len = i32(__extern_length(materialized))

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -24,7 +24,7 @@ import {
   localGlobalIdx,
   resolveWasmType,
 } from "../index.js";
-import { buildDestructureNullThrow } from "../destructuring-params.js";
+import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitNullGuardedStructGet, isProvablyNonNull, isSafeBoundsEliminated } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
@@ -1339,10 +1339,19 @@ function compileExternrefArrayDestructuringAssignment(
   // first — it invokes @@iterator + .next() and propagates throws.
   // Plain arrays with the default @@iterator take the fast path.
   if (resultType.kind === "externref" && target.elements.length > 0) {
-    const matIterIdx = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+    // #1592: bound materialization to the pattern's iterator-step count so a
+    // rest-less assignment pattern (`[a,,b] = gen()`) steps a lazy generator
+    // exactly N times instead of draining it; a rest pattern passes -1 (unbounded).
+    const matIterIdx = ensureLateImport(
+      ctx,
+      "__array_from_iter_n",
+      [{ kind: "externref" }, { kind: "f64" }],
+      [{ kind: "externref" }],
+    );
     flushLateImportShifts(ctx, fctx);
     if (matIterIdx !== undefined) {
       fctx.body.push({ op: "local.get", index: tmpLocal });
+      fctx.body.push({ op: "f64.const", value: patternIteratorStepCount(target.elements) });
       fctx.body.push({ op: "call", funcIdx: matIterIdx });
       fctx.body.push({ op: "local.set", index: tmpLocal });
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3825,19 +3825,23 @@ assert._isSameValue = isSameValue;
           }
           return Object.entries(obj);
         };
-      if (name === "__array_from_iter") {
+      if (name === "__array_from_iter" || name === "__array_from_iter_n") {
         // Cache the original Array.prototype[Symbol.iterator] so we can
         // detect when user code (e.g. test262 iter-get-err-array-prototype)
         // has overridden it. When overridden, we must invoke the protocol
         // rather than fast-pathing the array — otherwise a throwing custom
         // @@iterator on Array.prototype is silently swallowed (#1454).
         const _origArrayIter: any = (Array.prototype as any)[Symbol.iterator];
-        return (obj: any): any => {
-          // Materialize an iterable/array-like to a real JS array so downstream
-          // destructuring can walk it via .length + indexed access. For proper
-          // iterators (e.g. generators) this invokes the iterator protocol and
-          // propagates any throws from .next() — needed for spec-compliant
-          // destructuring of throwing iterators (#1150).
+        // Materialize an iterable/array-like to a real JS array, consuming at
+        // most `limit` iterator steps (`Infinity` = full drain — the legacy
+        // `__array_from_iter` behavior). The bounded form (`__array_from_iter_n`,
+        // #1592) lets a rest-less array pattern step the iterator exactly
+        // `pattern.length` times per §8.5.3, instead of draining a lazy
+        // generator to completion.
+        const _arrayFromIter = (obj: any, limit: number): any => {
+          // For proper iterators (e.g. generators) this invokes the iterator
+          // protocol and propagates any throws from .next() — needed for
+          // spec-compliant destructuring of throwing iterators (#1150).
           if (obj == null) return [];
           if (Array.isArray(obj)) {
             // #1454: Real arrays normally take a fast path, but if the user has
@@ -3850,9 +3854,11 @@ assert._isSameValue = isSameValue;
             if (ownIter !== _origArrayIter) {
               // Non-default iterator: fall through to the protocol path below
               // by treating the array as a generic iterable.
-              return Array.from(obj);
+              return _drainIterable(obj, limit);
             }
-            return obj;
+            // Default array iterator with no observable side effects: a slice
+            // to `limit` is equivalent to stepping the iterator `limit` times.
+            return limit < obj.length ? obj.slice(0, limit) : obj;
           }
           // Compiled sources that do `iter[Symbol.iterator] = fn` often land the
           // function under a stringified "Symbol(Symbol.iterator)" key rather
@@ -3930,6 +3936,21 @@ assert._isSameValue = isSameValue;
                       return undefined;
                     };
                     while (true) {
+                      // #1592: bounded materialization — a rest-less array
+                      // pattern consumes exactly `limit` iterator steps
+                      // (§8.5.3). If the iterator is still NOT done after the
+                      // last element is bound, §13.3.3.6 BindingRestElement-less
+                      // ArrayBindingPattern performs IteratorClose. So a finite
+                      // bound that stops a still-yielding iterator is an ABRUPT
+                      // (consumer-abandons) completion → set `cappedOut` so the
+                      // close fires below. `limit === Infinity` (rest pattern)
+                      // never hits this break; its close stays governed by the
+                      // natural `done` / MAX_ITER paths, byte-identical to the
+                      // legacy unbounded behavior.
+                      if (out.length >= limit) {
+                        cappedOut = true;
+                        break;
+                      }
                       if (iterCount++ >= MAX_ITER) {
                         cappedOut = true;
                         break;
@@ -3984,12 +4005,48 @@ assert._isSameValue = isSameValue;
               }
               const out: any[] = [];
               const len = typeof (obj as any).length === "number" ? (obj as any).length >>> 0 : 0;
-              for (let i = 0; i < len; i++) out.push((obj as any)[i]);
+              const bound = len < limit ? len : limit;
+              for (let i = 0; i < bound; i++) out.push((obj as any)[i]);
               return out;
             }
           }
-          return Array.from(obj);
+          return _drainIterable(obj, limit);
         };
+        // Generic iterable drain bounded to `limit` steps. Replaces the
+        // unbounded `Array.from(obj)` so a lazy generator is stepped only as
+        // many times as the pattern requires (#1592). Preserves throw
+        // propagation from a throwing `@@iterator`/`.next()`/`.value` getter
+        // (#1150/#1454) by walking the protocol manually.
+        const _drainIterable = (obj: any, limit: number): any[] => {
+          if (!(limit < Infinity)) return Array.from(obj);
+          const it = (obj as any)[Symbol.iterator]();
+          const out: any[] = [];
+          let done = false;
+          while (out.length < limit) {
+            const result = it.next();
+            if (result == null || result.done) {
+              done = true;
+              break;
+            }
+            out.push(result.value);
+          }
+          // §13.3.3.6: a rest-less pattern that stopped at the bound while the
+          // iterator is still yielding performs IteratorClose.
+          if (!done && typeof it.return === "function") {
+            try {
+              it.return();
+            } catch {
+              /* IteratorClose swallows the inner completion's return() throw here. */
+            }
+          }
+          return out;
+        };
+        if (name === "__array_from_iter_n")
+          // #1592: n < 0 (sentinel -1) → unbounded, byte-identical to
+          // __array_from_iter (rest patterns want the full remainder). n >= 0 →
+          // step the iterator at most n times (rest-less pattern, §8.5.3).
+          return (obj: any, n: number) => _arrayFromIter(obj, n < 0 ? Infinity : n >>> 0);
+        return (obj: any) => _arrayFromIter(obj, Infinity);
       }
       if (name === "__extern_slice")
         return (arr: any, start: number) => {

--- a/tests/issue-1219.test.ts
+++ b/tests/issue-1219.test.ts
@@ -62,10 +62,15 @@ describe("#1219 — ArrayBindingPattern iter-close: hang fix + IteratorClose", (
     expect(elapsed).toBeLessThan(10_000);
   }, 15_000);
 
-  it("finite iterator destructure: stops at done:true and does NOT call return()", async () => {
-    // Per spec §7.4.6: when the iterator naturally terminates (`done:true`),
-    // IteratorClose is NOT invoked. This guards against over-eager return()
-    // calls from the fix.
+  it("rest-less [a,b] over a still-yielding iterator: binds 2, calls IteratorClose once (#1592)", async () => {
+    // §13.3.3.6: a rest-less ArrayBindingPattern that consumes exactly N
+    // elements performs IteratorClose when iteratorRecord.[[Done]] is false
+    // after the last binding. Here `[a, b]` steps the iterator twice (both
+    // `done:false`) so [[Done]] is false → return() is called exactly once,
+    // with only 2 next() calls (no over-consumption). Verified against V8:
+    // `doneCallCount === 1`, `nextCallCount === 2`. The pre-#1592 runtime
+    // drained until done:true (a 3rd next() call) — itself the over-consumption
+    // bug #1592 fixes — so the old assertion `doneCallCount === 0` was stale.
     const exports = await compileToWasm(`
       var doneCallCount: number = 0;
       var nextCallCount: number = 0;
@@ -91,8 +96,10 @@ describe("#1219 — ArrayBindingPattern iter-close: hang fix + IteratorClose", (
         var sum: number = takeTwo(iter);
         // 10 + 20 = 30
         if (sum !== 30) return -1;
-        // Iterator naturally terminated — return() must NOT have been called.
-        if (doneCallCount !== 0) return -2;
+        // Bound reached with [[Done]] false → IteratorClose called once.
+        if (doneCallCount !== 1) return -2;
+        // Bounded: exactly 2 next() calls, no probe for done:true.
+        if (nextCallCount !== 2) return -3;
         return 1;
       }
     `);

--- a/tests/issue-1592.test.ts
+++ b/tests/issue-1592.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const r = compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports.test as () => number)();
+}
+
+describe("#1592 array pattern elision/rest bounded iterator consumption", () => {
+  // Param-context elision: `[a,,b]` parameter pattern over a lazy generator.
+  // The bounded helper steps it exactly 3 times (no rest) and binds the 1st/3rd
+  // yields to a/b. This is the dominant shape of the ~305 test262 bucket.
+  it("param [a,,b] from a generator binds 0 and 2", async () => {
+    const src = `
+      function m([a, , b]: number[] = g()): number {
+        return a === 10 && b === 30 ? 1 : a * 100 + b;
+      }
+      function* g() { yield 10; yield 20; yield 30; yield 40; }
+      export function test(): number { return m(); }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Param-context rest-with-nested-elision `[...[,]] = g()` must drain the
+  // generator fully (rest → unbounded, -1 sentinel — byte-identical to the
+  // legacy path). Mirrors test262 meth-dflt-ary-ptrn-rest-ary-elision.
+  it("param [...[,]] = g() drains the generator fully (rest is unbounded)", async () => {
+    const src = `
+      let first = 0;
+      let second = 0;
+      function* g() { first += 1; yield 1; second += 1; yield 2; }
+      function m([...[,]]: number[] = g()): number {
+        return first === 1 && second === 1 ? 1 : first * 10 + second;
+      }
+      export function test(): number { return m(); }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Declaration elision binds the right values (1st/3rd yields).
+  it("decl [a,,b] from a generator binds 0 and 2", async () => {
+    const src = `
+      export function test(): number {
+        function* g() { yield 10; yield 20; yield 30; yield 40; }
+        const [a, , b] = g();
+        if (a !== 10) return 100 + a;
+        if (b !== 30) return 200 + b;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Rest pattern collects ALL remaining values (unbounded, -1 sentinel path).
+  it("[first, ...rest] collects the full remainder", async () => {
+    const src = `
+      export function test(): number {
+        function* g() { yield 1; yield 2; yield 3; yield 4; }
+        const [first, ...rest] = g();
+        if (first !== 1) return 100 + first;
+        if (rest.length !== 3) return 200 + rest.length;
+        if (rest[0] !== 2 || rest[2] !== 4) return 300;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Plain-array fast path still works (no iterator side effects).
+  it("plain array [a,,b] reads indices 0 and 2", async () => {
+    const src = `
+      export function test(): number {
+        const [a, , b] = [5, 6, 7];
+        if (a !== 5) return 100 + a;
+        if (b !== 7) return 200 + b;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Assignment-target form (site 2): [a,,b] = gen().
+  it("assignment [a,,b] = gen() binds 0 and 2", async () => {
+    const src = `
+      export function test(): number {
+        function* g() { yield 1; yield 2; yield 3; }
+        let a = 0;
+        let b = 0;
+        [a, , b] = g();
+        if (a !== 1) return 100 + a;
+        if (b !== 3) return 200 + b;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  // for-of with an elision pattern over plain arrays.
+  it("for-of [a,,b] binds 0 and 2 each iteration", async () => {
+    const src = `
+      export function test(): number {
+        let sum = 0;
+        for (const [a, , b] of [[1, 2, 3], [10, 20, 30]]) { sum += a + b; }
+        return sum === 1 + 3 + 10 + 30 ? 1 : sum;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Array binding/assignment patterns materialized the **entire** iterator via `__array_from_iter` before binding, over-consuming lazy generators with observable side effects — the ~305-test elision/rest bucket (class/expr dstr, for-of, for-await-of, function params).

- **`src/runtime.ts`**: refactored `__array_from_iter` into shared `_arrayFromIter(obj, limit)` + generic `_drainIterable(obj, limit)`; added `__array_from_iter_n(obj, n)`. `n < 0` (-1 sentinel) → unbounded, byte-identical to the legacy drain (rest patterns); `n >= 0` → consume at most `n` iterator steps.
- **IteratorClose (refinement vs. the original architect note)**: per ECMA-262 §13.3.3.6, a rest-less `ArrayBindingPattern` performs IteratorClose when `[[Done]]` is false after the last bound element. So stopping at a finite bound while the iterator is still yielding now calls `iterator.return()` — matching V8. The `Infinity`/rest path is unchanged (close still governed by natural `done` / `MAX_ITER`).
- **Codegen**: `patternIteratorStepCount(elements)` (elisions count as one step; rest/spread → -1) wires the two materialization sites — `destructureParamArray` param/decl fallback and `assignment.ts` array-assignment — to call `__array_from_iter_n` with the per-pattern step count. The name matches the existing `__array_` strict-mode allowlist prefix, so no allowlist-budget change.

## Scope
- `src/runtime.ts`, `src/codegen/destructuring-params.ts`, `src/codegen/expressions/assignment.ts`
- `tests/issue-1592.test.ts` (new), `tests/issue-1219.test.ts` (updated stale assertion)
- `plan/issues/1592-…md` (carries the architect spec + results; status: done)

## Test plan
- [x] `tests/issue-1592.test.ts` — 7/7 (param `[a,,b]` from generator; param `[...[,]]=g()` full drain; decl/for-of elision value-correctness; rest full remainder; assignment `[a,,b]=g()`; plain-array fast path)
- [x] `tests/issue-1219.test.ts` — IteratorClose suite green; updated the "finite iterator does NOT close" case to spec/V8 behavior (rest-less `[a,b]` over a still-yielding iterator closes once, 2 `next()` calls). The old expectation depended on the over-consumption bug this PR fixes; verified against Node/V8.
- [x] No regressions: issue-1158/1432/1450, array-rest/basic/for-of/class/fn-param destructuring, generator-method-destructuring, iterators, 862, 1372, 1128, host-import-allowlist-budget. (Three sibling files fail to *load* on an unrelated pre-existing `./helpers.js` import — identical on origin/main.)
- [x] `tsc --noEmit` clean
- [ ] CI: sharded test262 + quality

Residual (→ #1555): `const`-declaration over a lazy generator still materializes eagerly for the side-effect-step-count sub-case (value binding is correct; observable step count over-consumes). That is the lazy-default interleaving the architect plan explicitly left to the #1555 streaming rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)