### PR TITLE
fix(#779e): arguments.length reflects call-site count for closure/method calls

### DIFF
--- a/plan/issues/779e-arguments-object-residual.md
+++ b/plan/issues/779e-arguments-object-residual.md
@@ -1,9 +1,9 @@
 ---
 id: 779e
 title: "arguments-object mapped / trailing-comma / sloppy-strict residuals (~161 fails)"
-status: ready
+status: in-review
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -58,5 +58,57 @@ remain. They cluster around:
 ## Acceptance criteria
 
 - [ ] At least 110 of the ~161 tests flip to `pass`.
-- [ ] No regressions in already-passing arguments-object tests.
+- [x] No regressions in already-passing arguments-object tests.
 - [ ] Both strict and sloppy variants pass for each touched test family.
+
+## Root cause (2026-05-27)
+
+`arguments.length` / `arguments[i]` reported the **declared parameter count**,
+not the **actual call-site argument count**, for indirect/closure call paths.
+Named top-level functions already solved this via the `__argc` / `__extras_argv`
+globals (#1053/#1511): overflow args beyond declared arity are packed into a
+module global the callee's prologue reads. But three paths never wired it up:
+
+1. **Closure / function-expression calls** (`compileClosureCall`,
+   `src/codegen/expressions/calls-closures.ts`) — *dropped* excess args at the
+   call site and never set `__argc`/`__extras_argv`.
+2. **Getter-returned callable / class-private-method calls**
+   (`compileGetterCallable`, same file) — same drop-without-record bug.
+3. **Closure callee prologue** (`buildLiftedClosure`, `src/codegen/closures.ts`)
+   built the `arguments` vec sized to declared arity only, ignoring extras.
+
+## Fix
+
+- Exported `emitClosureCallArgcExtras` / `emitResetArgcExtras` from `calls.ts`.
+- `compileClosureCall` + `compileGetterCallable`: replace the drop-excess-args
+  loops with `emitClosureCallArgcExtras(...)` (packs overflow into the global,
+  evaluating each arg exactly once) and `emitResetArgcExtras(...)` after the
+  call (preserving the return value), matching the existing #1511 indirect-call
+  paths.
+- Closure callee prologue now calls the shared `emitArgumentsVecBody(...)` with
+  `paramOffset = 1` (lifted closures carry `__self` at local 0), so it reads the
+  true call-site length from `__argc`/`__extras_argv`.
+
+## Test Results (isolated test262 runs, `language/arguments-object/*`)
+
+| | baseline (main) | this branch |
+|---|---|---|
+| pass | 73 | **148** |
+| fail | 141 | 66 |
+| compile_error | 1 | 1 |
+
+- **+75 tests flip to pass, 0 regressions** within arguments-object.
+- Fixed: every `func-expr` / `gen-func-expr` / class `meth` / `private-meth` /
+  `gen-meth` / `async-private-gen-meth` trailing-comma family.
+- Still failing (out of scope, separate root causes):
+  - `*-args-trailing-comma-spread-operator` (32) — spread-arg call lowering, not
+    arguments-object.
+  - `async-gen-meth` object + `*-static` async-gen-meth (~12) — async-gen method
+    body goes through the generator trampoline, a different prologue.
+  - `10.6-*-s` / `S10.6_*` (~14) — strict/sloppy mapped-argument bidirectional
+    sync + `eval("arguments = …")` SyntaxError, distinct features.
+- Regression check: `test-call-ref`, `class-method-calls`, `getters-setters`,
+  `classes`, `class-methods` unit tests show identical pass/fail counts on this
+  branch vs clean main (their failures are a pre-existing host-import harness
+  issue, unrelated to this change). `issue-1053-arguments-global-staleness`,
+  `object-methods`, `generators`, `arguments-object` pass.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -55,6 +55,7 @@ import {
 } from "./statements.js";
 import { coercionInstrs, emitGuardedRefCast } from "./type-coercion.js";
 import { buildDestructureNullThrow, isNullOrUndefinedLiteral } from "./destructuring-params.js";
+import { emitArgumentsVecBody } from "./statements/nested-declarations.js";
 import { detectStringBuilders } from "./string-builder.js";
 
 // ── Arrow function callbacks ──────────────────────────────────────────
@@ -2007,7 +2008,6 @@ export function compileArrowAsClosure(
       flushLateImportShiftsShared(ctx, liftedFctx);
     }
 
-    const numArgs = arrowParams.length;
     const elemType: ValType = { kind: "externref" };
     const vti = getOrRegisterVecType(ctx, "externref", elemType);
     const ati = getArrTypeIdxFromVec(ctx, vti);
@@ -2015,38 +2015,16 @@ export function compileArrowAsClosure(
     const argsLocal = allocLocal(liftedFctx, "arguments", vecRef);
     const arrTmp = allocLocal(liftedFctx, "__args_arr_tmp", { kind: "ref", typeIdx: ati });
 
-    // Push each param coerced to externref (skip __self at index 0)
-    for (let i = 0; i < numArgs; i++) {
-      liftedFctx.body.push({ op: "local.get", index: i + 1 }); // +1 for __self
-      const pt = arrowParams[i]!;
-      if (pt.kind === "f64") {
-        const boxIdx = ctx.funcMap.get("__box_number");
-        if (boxIdx !== undefined) {
-          liftedFctx.body.push({ op: "call", funcIdx: boxIdx });
-        } else {
-          liftedFctx.body.push({ op: "drop" });
-          liftedFctx.body.push({ op: "ref.null.extern" });
-        }
-      } else if (pt.kind === "i32") {
-        liftedFctx.body.push({ op: "f64.convert_i32_s" });
-        const boxIdx = ctx.funcMap.get("__box_number");
-        if (boxIdx !== undefined) {
-          liftedFctx.body.push({ op: "call", funcIdx: boxIdx });
-        } else {
-          liftedFctx.body.push({ op: "drop" });
-          liftedFctx.body.push({ op: "ref.null.extern" });
-        }
-      } else if (pt.kind === "ref" || pt.kind === "ref_null") {
-        liftedFctx.body.push({ op: "extern.convert_any" });
-      }
-      // externref params are already externref — no conversion needed
-    }
-    liftedFctx.body.push({ op: "array.new_fixed", typeIdx: ati, length: numArgs });
-    liftedFctx.body.push({ op: "local.set", index: arrTmp });
-    liftedFctx.body.push({ op: "i32.const", value: numArgs });
-    liftedFctx.body.push({ op: "local.get", index: arrTmp });
-    liftedFctx.body.push({ op: "struct.new", typeIdx: vti });
-    liftedFctx.body.push({ op: "local.set", index: argsLocal });
+    // (#779e) Build the arguments vec via the shared extras-aware helper so the
+    // closure sees the TRUE call-site argument count (from __argc/__extras_argv
+    // set by the closure call site, #1511) — not just its declared arity.
+    // paramOffset is 1 because lifted closures carry __self at local index 0.
+    emitArgumentsVecBody(ctx, liftedFctx, arrowParams, 1, {
+      vecTypeIdx: vti,
+      arrTypeIdx: ati,
+      argsLocalIdx: argsLocal,
+      arrTmpIdx: arrTmp,
+    });
   }
 
   let conciseBodyHasValue = false;

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -20,6 +20,7 @@ import { coerceType, compileExpression, VOID_RESULT } from "../shared.js";
 import { emitGuardedFuncRefCast, emitGuardedRefCast, pushDefaultValue } from "../type-coercion.js";
 import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
+import { emitClosureCallArgcExtras, emitResetArgcExtras } from "./calls.js";
 
 /** Compile a call to a closure variable: closureVar(args...) */
 export function compileClosureCall(
@@ -106,18 +107,17 @@ export function compileClosureCall(
     compileExpression(ctx, fctx, expr.arguments[i]!, info.paramTypes[i]);
   }
 
-  // Drop excess arguments beyond the closure's parameter count (evaluate for side effects)
-  for (let i = paramCount; i < expr.arguments.length; i++) {
-    const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
-    if (extraType !== null) {
-      fctx.body.push({ op: "drop" });
-    }
-  }
-
   // Pad missing arguments with defaults (arity mismatch)
   for (let i = expr.arguments.length; i < info.paramTypes.length; i++) {
     pushDefaultValue(fctx, info.paramTypes[i]!, ctx);
   }
+
+  // (#779e/#1511) Overflow args beyond the closure's declared arity are NOT
+  // pushed to the wasm stack — instead pack them into `__extras_argv` and set
+  // `__argc` so a callee that reads `arguments` sees the true call-site length.
+  // emitClosureCallArgcExtras evaluates the overflow args itself (into the
+  // global), so we must NOT also evaluate them above. Cleanup after call_ref.
+  emitClosureCallArgcExtras(ctx, fctx, expr.arguments, paramCount);
 
   // Push the funcref from the closure struct (field 0) and cast to typed ref
   pushClosureRef();
@@ -132,6 +132,18 @@ export function compileClosureCall(
 
   // call_ref with the lifted function's type index
   fctx.body.push({ op: "call_ref", typeIdx: info.funcTypeIdx });
+
+  // (#779e/#1511) Reset __argc / __extras_argv. A callee that doesn't read
+  // `arguments` never consumed them and would otherwise leak stale values
+  // into the next call that does. Preserve the return value across the reset.
+  if (info.returnType === null || info.returnType === undefined) {
+    emitResetArgcExtras(ctx, fctx);
+  } else {
+    const retLocal = allocLocal(fctx, `__cc_ret_${fctx.locals.length}`, info.returnType);
+    fctx.body.push({ op: "local.set", index: retLocal });
+    emitResetArgcExtras(ctx, fctx);
+    fctx.body.push({ op: "local.get", index: retLocal });
+  }
 
   // Return VOID_RESULT for void closures so compileExpression doesn't treat
   // the null return as a compilation failure and roll back the emitted instructions
@@ -247,12 +259,6 @@ export function compileGetterCallable(
     for (let i = 0; i < Math.min(expr.arguments.length, methodParamCount); i++) {
       compileExpression(ctx, fctx, expr.arguments[i]!, paramTypes?.[i + selfOffset]);
     }
-    for (let i = methodParamCount; i < expr.arguments.length; i++) {
-      const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
-      if (extraType !== null) {
-        fctx.body.push({ op: "drop" });
-      }
-    }
     // Pad missing arguments
     if (paramTypes) {
       for (let i = Math.min(expr.arguments.length, methodParamCount) + selfOffset; i < paramTypes.length; i++) {
@@ -260,10 +266,29 @@ export function compileGetterCallable(
       }
     }
 
+    // (#779e/#1511) Overflow args beyond the method's declared arity go into
+    // `__extras_argv` (with `__argc`) so a callee reading `arguments` sees the
+    // true call-site length. emitClosureCallArgcExtras evaluates the overflow
+    // args itself, so we must NOT also drop-evaluate them above.
+    emitClosureCallArgcExtras(ctx, fctx, expr.arguments, methodParamCount);
+
     // Re-lookup: receiver/arg compilation may have triggered late imports
     // (e.g. emitUndefined for missing tuple elements) that shift function indices.
     const finalCandidateIdx = ctx.funcMap.get(candidateName) ?? candidateIdx;
     fctx.body.push({ op: "call", funcIdx: finalCandidateIdx });
+    // Reset globals so a callee that doesn't read `arguments` can't leak stale
+    // extras into the next call. Preserve the return value across the reset.
+    {
+      const retWasm = getWasmFuncReturnType(ctx, finalCandidateIdx);
+      if (retWasm && !wasmFuncReturnsVoid(ctx, finalCandidateIdx)) {
+        const retLocal = allocLocal(fctx, `__gc_ret_${fctx.locals.length}`, retWasm);
+        fctx.body.push({ op: "local.set", index: retLocal });
+        emitResetArgcExtras(ctx, fctx);
+        fctx.body.push({ op: "local.get", index: retLocal });
+      } else {
+        emitResetArgcExtras(ctx, fctx);
+      }
+    }
 
     // Determine return type
     const sig = ctx.checker.getResolvedSignature(expr);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -578,7 +578,7 @@ function emitSetArgc(ctx: CodegenContext, fctx: FunctionContext, actualArgCount:
  * inherit a stale extras_argv and produce a wrong arguments.length.
  * (#1511)
  */
-function emitResetArgcExtras(ctx: CodegenContext, fctx: FunctionContext): void {
+export function emitResetArgcExtras(ctx: CodegenContext, fctx: FunctionContext): void {
   const { globalIdx: extrasGlobalIdx, vecTypeIdx } = ensureExtrasArgvGlobal(ctx);
   const argcGlobalIdx = ensureArgcGlobal(ctx);
   fctx.body.push({ op: "ref.null", typeIdx: vecTypeIdx } as Instr);
@@ -600,7 +600,7 @@ function emitResetArgcExtras(ctx: CodegenContext, fctx: FunctionContext): void {
  * `emitResetArgcExtras` after the call to prevent stale-extras leaking
  * into a subsequent callee that DOES read `arguments`. (#1511)
  */
-function emitClosureCallArgcExtras(
+export function emitClosureCallArgcExtras(
   ctx: CodegenContext,
   fctx: FunctionContext,
   args: readonly ts.Expression[],


### PR DESCRIPTION
## Summary
- Closure, getter-callable, and class-private-method call paths dropped excess args beyond declared arity without recording them; the lifted-closure prologue also sized the `arguments` vec to declared params only. So `function(){ arguments.length }` called with extra args always saw the declared count (often 0), not the call-site count.
- Wire these three paths into the existing `__argc` / `__extras_argv` mechanism (#1053 / #1511) already used by named-function call sites: overflow args are packed into a module global the callee prologue reads, and reset after the call to avoid stale-extras leakage.
  - `compileClosureCall` + `compileGetterCallable` (`src/codegen/expressions/calls-closures.ts`): replace drop-excess-args loops with `emitClosureCallArgcExtras(...)` + `emitResetArgcExtras(...)` (return value preserved across the reset).
  - lifted-closure prologue (`src/codegen/closures.ts`): call shared `emitArgumentsVecBody(...)` with `paramOffset = 1` (lifted closures carry `__self` at local 0).
  - Exported the two helpers from `calls.ts`.

## Test plan
- [x] Isolated test262 `language/arguments-object/*`: **73 → 148 pass (+75), 0 regressions** within the directory.
- [x] Fixed clusters: `func-expr` / `gen-func-expr` / class `meth` / `private-meth` / `gen-meth` / `async-private-gen-meth` trailing-comma families.
- [x] Regression check: `test-call-ref`, `class-method-calls`, `getters-setters`, `classes`, `class-methods` unit tests show identical pass/fail counts on this branch vs clean main (pre-existing host-import harness failures, unrelated). `issue-1053-arguments-global-staleness`, `object-methods`, `generators`, `arguments-object` pass.
- [x] `tsc --noEmit` clean.
- Out of scope (separate root causes, still failing): `*-spread-operator` (spread-arg lowering), `async-gen-meth` (generator trampoline prologue), `10.6-*-s`/`S10.6_*` (strict/sloppy mapped-args sync + `eval("arguments=…")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)