### PR TITLE
fix(#1637): Boolean.prototype.toString/valueOf receiver coercion on primitives

### DIFF
--- a/plan/issues/1637-spec-gap-boolean-symbol-coercion.md
+++ b/plan/issues/1637-spec-gap-boolean-symbol-coercion.md
@@ -1,9 +1,9 @@
 ---
 id: 1637
 title: "spec gap: Boolean wrapper + Symbol coercion TypeErrors (24 + 45 test262 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-27
 priority: medium
 feasibility: easy
 reasoning_effort: medium
@@ -98,3 +98,46 @@ For Symbol coercion:
 - `test262/test/built-ins/Boolean/prototype/toString/this-val-non-boolean.js`
 - `test262/test/built-ins/Symbol/prototype/toString/symbol-thisvalue.js`
 - `test262/test/built-ins/Symbol/for/registry.js`
+
+## Resolution 2026-05-27 (dev-1606) — Boolean half fixed, Symbol half deferred
+
+The architect's file paths (`src/codegen/registry/boolean.ts`,
+`src/codegen/registry/symbol.ts`) are **stale** — those files do not exist on
+main. The real code is `src/runtime.ts` (host imports) +
+`src/codegen/string-ops.ts` / `binary-ops.ts` (concat lowering).
+
+### Fixed: Boolean.prototype.toString/valueOf receiver coercion (~24 fails)
+
+`Boolean.prototype.toString.call(0)` and `.valueOf.call(true)` previously threw
+`TypeError: requires that 'this' be a Boolean`. `.call`/`.apply` on a
+Boolean.prototype method routes through `__extern_method_call` (runtime.ts:4521),
+which — unlike `__proto_method_call` (4785, #1342) — did not apply the
+§20.3.3.{2,3} thisBooleanValue coercion. Boolean primitives arrive as numbers
+(i32→externref via `__box_number`), so V8's native method rejected them.
+
+**Fix** (runtime.ts, `__extern_method_call`): when `method` is `call`/`apply`
+and the receiver function is `Boolean.prototype.{toString,valueOf}`, coerce a
+numeric/bigint receiver arg back to a boolean primitive before dispatch.
+
+Verified: `tests/issue-1637.test.ts` (5 cases) — toString.call(0)→"false",
+.call(1)→"true", valueOf.call(true)→true, valueOf.call(false)→false,
+toString.call(true)→"true". All pass.
+
+### Deferred: Symbol→string implicit coercion (~45 fails) — NEEDS ARCHITECT RESPEC
+
+`"v" + sym` returns `"v101"` and `String(sym)` returns `"101"` instead of
+throwing/returning `"Symbol(x)"`. **Root cause is representational, not a
+localized coercion bug**: Symbols are materialized as numeric (f64/i32) handles,
+so binary-`+` concat lowers through `number_toString(handle)` (string-ops.ts
+`compileAndCoerceConcatOperand`, the `valType.kind === "f64"` branch) and never
+reaches the `__concat_*` host helper — which *already* throws on
+`typeof === "symbol"` (#1342). A properly-typed Symbol operand currently even
+emits a CompileError (`expected f64, found externref`), confirming the value
+representation is inconsistent across the concat path.
+
+A correct fix must make Symbol values flow as boxed externref (via
+`__box_symbol`) through ToString sites so the runtime throw fires, OR add a
+static-Symbol-type guard in `compileAndCoerceConcatOperand` that boxes +
+routes through `__concat_*`. This spans concat codegen + Symbol representation
+and is beyond the "easy" label. Recommend a follow-up sub-issue with an
+architect spec on Symbol value representation at ToString boundaries.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4538,6 +4538,26 @@ assert._isSameValue = isSameValue;
               wrappedArgs[slot.argIdx] = _maybeWrapCallable(wrappedArgs[slot.argIdx], slot.arity, callbackState);
             }
           }
+          // #1637 — `Boolean.prototype.toString.call(prim)` / `.valueOf.call(prim)`
+          // route here as obj=Boolean.prototype.method, method="call"/"apply".
+          // Boolean primitives travel i32→externref via __box_number so the
+          // receiver arrives as a number; §20.3.3.{2,3} thisBooleanValue accepts
+          // a Boolean primitive or wrapper, so coerce a numeric/bigint receiver
+          // back to a boolean primitive before the native method runs (V8 would
+          // otherwise throw "requires that 'this' be a Boolean"). Mirrors the
+          // __proto_method_call coercion (#1342) for the .call/.apply path.
+          if (
+            (method === "call" || method === "apply") &&
+            (wrappedObj === Boolean.prototype.toString || wrappedObj === Boolean.prototype.valueOf)
+          ) {
+            const coerceRecv = (r: any) => (typeof r === "number" || typeof r === "bigint" ? Boolean(r) : r);
+            if (method === "call") {
+              if (wrappedArgs.length > 0) wrappedArgs[0] = coerceRecv(wrappedArgs[0]);
+            } else if (method === "apply") {
+              // apply(thisArg, argsArray): the receiver is arg 0.
+              if (wrappedArgs.length > 0) wrappedArgs[0] = coerceRecv(wrappedArgs[0]);
+            }
+          }
           const fn = wrappedObj[method];
           if (typeof fn !== "function") {
             // (#837) Map/WeakMap upsert proposal polyfill — Node 25 / V8

--- a/tests/issue-1637.test.ts
+++ b/tests/issue-1637.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Tests for #1637 — Boolean.prototype.toString/valueOf receiver coercion.
+ *
+ * §20.3.3.2/.3 thisBooleanValue accepts a Boolean primitive or a Boolean
+ * wrapper. Calling `Boolean.prototype.toString.call(prim)` routes through the
+ * __extern_method_call host import (method="call"); Boolean primitives travel
+ * i32→externref via __box_number, so the receiver arrives as a number. Before
+ * this fix the native method threw "requires that 'this' be a Boolean" instead
+ * of returning "true"/"false". The fix coerces a numeric/bigint receiver back
+ * to a boolean primitive for Boolean.prototype.{toString,valueOf} call/apply.
+ *
+ * The Symbol→string implicit-coercion half of #1637 is deferred — it requires
+ * reworking the Symbol value representation in concat codegen (Symbols are
+ * materialized as numeric handles, so binary-+ lowers through number_toString
+ * rather than the throwing __concat_* path). Tracked in the issue file.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, {}, r.stringPool) as Record<string, unknown> & {
+    setExports?: (e: Record<string, Function>) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1637 — Boolean.prototype receiver coercion", () => {
+  it('Boolean.prototype.toString.call(0) === "false"', async () => {
+    const r = await run(`export function test(): string { return (Boolean.prototype.toString as any).call(0); }`);
+    expect(r).toBe("false");
+  });
+
+  it('Boolean.prototype.toString.call(1) === "true"', async () => {
+    const r = await run(`export function test(): string { return (Boolean.prototype.toString as any).call(1); }`);
+    expect(r).toBe("true");
+  });
+
+  it("Boolean.prototype.valueOf.call(true) === true", async () => {
+    const r = await run(
+      `export function test(): number { return (Boolean.prototype.valueOf as any).call(true) === true ? 1 : 0; }`,
+    );
+    expect(r).toBe(1);
+  });
+
+  it("Boolean.prototype.valueOf.call(false) === false", async () => {
+    const r = await run(
+      `export function test(): number { return (Boolean.prototype.valueOf as any).call(false) === false ? 1 : 0; }`,
+    );
+    expect(r).toBe(1);
+  });
+
+  it('Boolean.prototype.toString.call(true) === "true"', async () => {
+    const r = await run(`export function test(): string { return (Boolean.prototype.toString as any).call(true); }`);
+    expect(r).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- `Boolean.prototype.toString.call(prim)` / `.valueOf.call(prim)` now return the correct primitive result instead of throwing `TypeError: requires that 'this' be a Boolean`.
- Root cause: `.call`/`.apply` on a Boolean.prototype method routes through `__extern_method_call`, which (unlike `__proto_method_call`, #1342) did not apply §20.3.3.{2,3} thisBooleanValue coercion. Boolean primitives arrive as numbers (i32→externref via `__box_number`), so V8's native method rejected them.
- Fix coerces a numeric/bigint receiver back to a boolean primitive for the Boolean.prototype `{toString,valueOf}` call/apply path (`src/runtime.ts`).

## Scope note
This PR fixes the **Boolean** half of #1637 (~24 fails). The **Symbol→string implicit coercion** half (~45 fails) is **deferred** — it is a representational issue (Symbols materialize as numeric handles, so binary-`+` concat lowers through `number_toString` rather than the throwing `__concat_*` path) and needs an architect respec. Documented in the issue file. The architect's original file paths (`src/codegen/registry/{boolean,symbol}.ts`) are stale and do not exist on main.

## Test plan
- [x] `tests/issue-1637.test.ts` — 5 Boolean cases pass locally (toString.call(0)→"false", .call(1)→"true", valueOf.call(true)→true, valueOf.call(false)→false, toString.call(true)→"true")
- [x] `npx tsc --noEmit` clean
- [ ] CI test262 — expect Boolean built-ins pass-rate improvement, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)