### PR TITLE
fix(#1643): execute class static initializer blocks in source order

### DIFF
--- a/plan/issues/1643-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1643-spec-gap-class-static-init-and-private-fields.md
@@ -3,7 +3,7 @@ id: 1643
 title: "spec gap: class static initialization order + private field semantics (significant share of 1500+ class fails)"
 status: ready
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-27
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -82,3 +82,30 @@ Each sub-task is medium-sized; consider creating sub-issues if devs prefer.
 - `test262/test/language/expressions/class/elements/private-field-as-instance.js`
 - `test262/test/language/statements/class/subclass/builtin-objects/Array/super-must-be-called-1.js`
 - `test262/test/language/statements/class/static-block-private-name.js`
+
+## Progress
+
+### 2026-05-27 — static `{ ... }` initializer blocks (sub-problem 1, partial)
+
+`static { ... }` blocks were parsed (statements.ts:246) but never executed:
+they were not queued into `ctx.staticInitExprs`, so `__module_init` ran only
+static **field** initializers. Reproduced on main: `static { C.y = C.x + 10 }`
+left `C.y` at 0.
+
+Fix queues static blocks alongside static field initializers in source order
+(§15.7.10) so they run interleaved in `__module_init`:
+- `class-bodies.ts` — single source-order member scan pushes a
+  `{ staticBlock, className }` entry for each `ClassStaticBlockDeclaration`.
+- `context/types.ts` — `staticInitExprs` entries now carry an optional
+  `staticBlock` (and `globalIdx`/`initializer` become optional).
+- `declarations.ts` — `__module_init` builder compiles the block's statements
+  with `enclosingClassName`/`isStaticContext` set (so `this`/`C.x` resolve).
+- `registry/imports.ts` — index-shift guard skips entries without `globalIdx`.
+
+Verified (tests/issue-1643.test.ts): single block reads earlier field, source
+order (later field not visible to block), multiple blocks accumulate, private
+fields unaffected. Private instance fields already passed on main.
+
+**Still open** (not in this slice): super-class field shadow, private-field
+deletion/brand-check exotics, computed-name side-effect ordering. Issue stays
+`ready` for those.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -648,8 +648,15 @@ export function collectClassDeclaration(
     ctx.classStaticMethodNames.set(className, staticMethodNames);
   }
 
-  // Register static properties as module globals
+  // Register static properties as module globals, and queue static `{ ... }`
+  // blocks for execution. Both field initializers and static blocks must run
+  // in source order during class evaluation (§15.7.10), so we iterate members
+  // once and push to the shared `staticInitExprs` queue in declaration order.
   for (const member of decl.members) {
+    if (ts.isClassStaticBlockDeclaration(member)) {
+      ctx.staticInitExprs.push({ staticBlock: member, className });
+      continue;
+    }
     if (ts.isPropertyDeclaration(member) && member.name && hasStaticModifier(member)) {
       const propName = resolveClassMemberName(ctx, member.name);
       if (propName === undefined) continue; // dynamic computed name — skip

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -404,7 +404,12 @@ export interface CodegenContext {
    * inside the initializer (and any closures it spawns) resolves to the
    * class-object singleton via `emitLazyClassObjectGet`.
    */
-  staticInitExprs: { globalIdx: number; initializer: ts.Expression; className?: string }[];
+  staticInitExprs: {
+    globalIdx?: number;
+    initializer?: ts.Expression;
+    staticBlock?: ts.ClassStaticBlockDeclaration;
+    className?: string;
+  }[];
   /** Counter for generated closure types/functions */
   closureCounter: number;
   /** Map from local variable name → closure metadata (for call_ref dispatch) */

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -3324,7 +3324,7 @@ export function compileDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     // `compileExpression(ThisKeyword)`. We toggle these per-entry rather
     // than spawning a fresh fctx because the body must accumulate into
     // a single `__module_init` and globals/locals are shared.
-    for (const { globalIdx, initializer, className } of ctx.staticInitExprs) {
+    for (const { globalIdx, initializer, staticBlock, className } of ctx.staticInitExprs) {
       const savedEnclosing = initFctx.enclosingClassName;
       const savedIsStatic = initFctx.isStaticContext;
       if (className !== undefined) {
@@ -3332,9 +3332,16 @@ export function compileDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         initFctx.isStaticContext = true;
       }
       try {
-        const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
-        compileExpression(ctx, initFctx, initializer, globalDef?.type);
-        initFctx.body.push({ op: "global.set", index: globalIdx });
+        if (staticBlock) {
+          // `static { ... }` block — execute its statements in source order.
+          for (const s of staticBlock.body.statements) {
+            compileStatement(ctx, initFctx, s);
+          }
+        } else if (initializer && globalIdx !== undefined) {
+          const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+          compileExpression(ctx, initFctx, initializer, globalDef?.type);
+          initFctx.body.push({ op: "global.set", index: globalIdx });
+        }
       } finally {
         initFctx.enclosingClassName = savedEnclosing;
         initFctx.isStaticContext = savedIsStatic;

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -232,7 +232,7 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   shiftMap(ctx.tdzGlobals);
 
   for (const entry of ctx.staticInitExprs) {
-    if (entry.globalIdx >= threshold) {
+    if (entry.globalIdx !== undefined && entry.globalIdx >= threshold) {
       entry.globalIdx += delta;
     }
   }

--- a/tests/issue-1643.test.ts
+++ b/tests/issue-1643.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.ts";
+
+/**
+ * #1643 — class `static { ... }` initializer blocks must execute during class
+ * evaluation, in source order interleaved with static field initializers
+ * (§15.7.10). Before this fix the blocks were parsed but never run.
+ */
+describe("#1643 — class static initializer blocks", () => {
+  test("static block runs and can read earlier static fields", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        static x: number = 1;
+        static y: number = 0;
+        static { C.y = C.x + 10; }
+      }
+      export function test(): number { return C.y; }
+    `);
+    expect(ex.test()).toBe(11);
+  });
+
+  test("static block runs in source order; later field not yet visible", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        static a: number = 2;
+        static b: number = 0;
+        static { C.b = C.a; }
+        static c: number = 9;
+      }
+      export function test(): number { return C.b + C.c; }
+    `);
+    expect(ex.test()).toBe(11);
+  });
+
+  test("multiple static blocks accumulate in order", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        static n: number = 0;
+        static { C.n = 1; }
+        static { C.n = C.n + 5; }
+      }
+      export function test(): number { return C.n; }
+    `);
+    expect(ex.test()).toBe(6);
+  });
+
+  test("private instance fields unaffected", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        #v: number = 0;
+        constructor(n: number) { this.#v = n; }
+        get(): number { return this.#v; }
+      }
+      export function test(): number { return new C(7).get(); }
+    `);
+    expect(ex.test()).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- `static { ... }` blocks were parsed (statements.ts handled them) but never executed — they were never queued into `ctx.staticInitExprs`, so `__module_init` only ran static **field** initializers. `static { C.y = C.x + 10 }` left `C.y` at 0.
- Queue static blocks alongside static field initializers in a single source-order member scan, so they run interleaved in `__module_init` per §15.7.10.

## Changes
- `src/codegen/class-bodies.ts` — source-order scan pushes a `{ staticBlock, className }` entry for each `ClassStaticBlockDeclaration`.
- `src/codegen/context/types.ts` — `staticInitExprs` entries carry an optional `staticBlock`; `globalIdx`/`initializer` become optional.
- `src/codegen/declarations.ts` — `__module_init` builder compiles block statements with `enclosingClassName`/`isStaticContext` set so `this`/`C.x` resolve.
- `src/codegen/registry/imports.ts` — index-shift guard skips entries without `globalIdx`.

## Scope
This is sub-problem 1 of the #1643 umbrella (static-init order). Super-class field shadow, private-field deletion/brand-check exotics, and computed-name side-effect ordering remain open; issue stays `ready` for those.

## Test plan
- [x] `tests/issue-1643.test.ts` (4 cases): single block reads earlier field, source-order (later field not visible to block), multiple blocks accumulate, private fields unaffected
- [x] `npm run typecheck` clean
- [x] Helper-based class suites pass (class-static-private-this, issue-1435)
- Note: `classes.test.ts` / `class-elements-619.test.ts` failures are pre-existing (bare `{env:{}}` harness can't satisfy `string_constants` host import) — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)