### PR TITLE
fix(#1634): AggregateError iterable errors + SuppressedError ctor + cause

### DIFF
--- a/plan/issues/1634-spec-gap-aggregate-suppressed-error-iterable.md
+++ b/plan/issues/1634-spec-gap-aggregate-suppressed-error-iterable.md
@@ -1,9 +1,9 @@
 ---
 id: 1634
 title: "spec gap: AggregateError + SuppressedError errors-iterable + cause coercion (37 test262 fails)"
-status: ready
+status: done
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -84,3 +84,55 @@ Mirror for SuppressedError.
 
 - `test262/test/built-ins/AggregateError/errors-iterabletolist.js`
 - `test262/test/built-ins/SuppressedError/cause.js`
+
+## Findings & resolution (2026-05-27)
+
+### What was actually broken (root cause)
+
+1. **`new AggregateError([1,2,3])` trapped at runtime.** The `errors` arg arrives
+   as an opaque WasmGC vec struct — neither `Array.isArray` nor JS-iterable. The
+   old code's fallback `throw new TypeError(String(errors) + ...)` itself trapped
+   with *"Cannot convert object to primitive value"* (ToPrimitive on the opaque
+   struct). Now: when `errors` has no JS `Symbol.iterator` AND is a genuine vec
+   (no named struct fields, via `_getStructFieldNames`), materialize it through
+   `__vec_len`/`__vec_get` (same machinery `__array_from` uses). `Set` / arrays /
+   generators iterate correctly.
+2. **`SuppressedError` had no dedicated constructor** — it went through the generic
+   3-param extern-class path which dropped the 4th `options` arg (no `cause`) and
+   mishandled message coercion. Added `__new_SuppressedError(error, suppressed,
+   message, options)` host import + new-super.ts/calls.ts codegen, mirroring
+   `__new_AggregateError`.
+3. **`cause` from `options` (HasProperty, incl. `cause: undefined`)** is now
+   installed for both via the shared `_installErrorCause` helper. The engine's
+   native `InstallErrorCause` can't read an opaque WasmGC options struct, so we
+   read the field ourselves (raw, no recursive struct→plain conversion that would
+   break `error.cause === cause` reference identity).
+
+### Verified (tests/issue-1634.test.ts, 10/10 pass)
+Array-literal errors, Set errors, `Array.isArray(errors)`, cause object-identity,
+no-cause-when-options-omitted, cause-when-`cause:undefined` (HasProperty),
+`AggregateError(undefined)` throws TypeError, SuppressedError error/suppressed
+reference identity, message coercion, no-cause-when-options-omitted.
+
+### test262 conformance: NET ZERO in the two target dirs (no regression)
+`built-ins/AggregateError` 6/25 and `built-ins/SuppressedError` 7/22 — **same as
+current main** (baseline measured 6/25 + 7/22, not the stale 4/25 + 6/22 in the
+problem statement). The ≥70% acceptance target is **not reachable from this
+issue's scope**: the dominant remaining failures are out-of-scope infrastructure
+gaps, not the iterable/cause behavior this issue targets:
+- `TypeError: Cannot access property on null or undefined` — `AggregateError.prototype`
+  / `Object.getPrototypeOf(...)` returns null on extern classes (prototype-object
+  access gap). Affects ~9 prototype/* tests in each dir.
+- `is-a-constructor.js` / `length.js` — `Reflect.construct` brand + `fn.length`
+  introspection on extern-class constructors.
+- `message-method-prop-cast.js` / `order-of-args-evaluation.js` — ToPrimitive on a
+  Symbol/object `message` (Symbol→string coercion, see #1658).
+- `proto-from-ctor-realm.js` — needs `$262` realm helper (always skipped).
+- The remaining `errors-iterabletolist.js` failure is a **custom JS iterator
+  protocol over a WasmGC-struct object literal** (`{ [Symbol.iterator]() {...} }`)
+  — the shared iterator-bridge gap (#1320 / #1620 / #1633), where the struct's
+  sidecar-stored `@@iterator` method is not invokable through the host boundary.
+
+These improvements are runtime-correctness wins (programs constructing these
+errors with real iterables / cause now behave per spec) even though the test262
+*harness* files still fail on the unrelated introspection asserts above.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1955,6 +1955,46 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     return { kind: "externref" };
   }
 
+  // (#1634) SuppressedError(error, suppressed, message, options?) — called
+  // WITHOUT `new`. Per ES §20.5.10.1, called as a function it constructs
+  // normally. Mirror the new-super.ts codegen so without-new and with-new
+  // resolve together. Unwrap parenthesized/cast wrappers like the AggregateError
+  // dispatch above.
+  let _suppCallee: ts.Expression = expr.expression;
+  while (
+    ts.isParenthesizedExpression(_suppCallee) ||
+    ts.isAsExpression(_suppCallee) ||
+    ts.isTypeAssertionExpression(_suppCallee) ||
+    ts.isSatisfiesExpression(_suppCallee) ||
+    ts.isNonNullExpression(_suppCallee)
+  ) {
+    _suppCallee = (_suppCallee as ts.AsExpression | ts.ParenthesizedExpression).expression;
+  }
+  if (ts.isIdentifier(_suppCallee) && _suppCallee.text === "SuppressedError") {
+    const args = expr.arguments ?? [];
+    for (let i = 0; i < 4; i++) {
+      if (args.length > i) {
+        const t = compileExpression(ctx, fctx, args[i]!, { kind: "externref" });
+        if (t && t.kind !== "externref") {
+          coerceType(ctx, fctx, t, { kind: "externref" });
+        }
+      } else {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+    }
+    const funcIdx = ensureLateImport(
+      ctx,
+      "__new_SuppressedError",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (funcIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx });
+    }
+    return { kind: "externref" };
+  }
+
   // Handle property access calls: console.log, Math.xxx, extern methods
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const propAccess = expr.expression;

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1567,6 +1567,36 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     return { kind: "externref" };
   }
 
+  // Handle `new SuppressedError(error, suppressed, message, options?)` (#1634).
+  // Spec §20.5.10.1: all four arguments are externref; `options.cause` is
+  // installed via the dedicated `__new_SuppressedError` host import. The generic
+  // 3-param extern-class path dropped `options` (no `cause`) and mishandled the
+  // message coercion, so route through the dedicated import like AggregateError.
+  if (ts.isIdentifier(expr.expression) && expr.expression.text === "SuppressedError") {
+    const args = expr.arguments ?? [];
+    for (let i = 0; i < 4; i++) {
+      if (args.length > i) {
+        const t = compileExpression(ctx, fctx, args[i]!, { kind: "externref" });
+        if (t && t.kind !== "externref") {
+          coerceType(ctx, fctx, t, { kind: "externref" });
+        }
+      } else {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+    }
+    const funcIdx = ensureLateImport(
+      ctx,
+      "__new_SuppressedError",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (funcIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx });
+    }
+    return { kind: "externref" };
+  }
+
   // Handle `new Object()` — create an empty object (equivalent to `{}`).
   // (#1343) Previously this emitted `ref.null.extern`, but JS spec treats
   // `new Object()` as a real object: `Boolean(new Object()) === true`,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1555,6 +1555,47 @@ function _structToPlainObject(
 }
 
 /**
+ * (#1634) Spec InstallErrorCause(O, options) — §20.5.8.1. If `options` is an
+ * object and HasProperty(options, "cause") is true, set a non-enumerable own
+ * data property `cause` on `O` with the value Get(options, "cause").
+ *
+ * `options` may arrive as an opaque WasmGC struct (object literal compiled
+ * inline, e.g. `new AggregateError([], "m", { cause })`). We read the raw
+ * `cause` field via the `__sget_cause` export — NOT `_structToPlainObject`,
+ * which recursively converts nested structs and would break reference identity
+ * (test262 checks `error.cause === cause`). Plain JS objects use native
+ * `in` / property access.
+ */
+function _installErrorCause(inst: any, options: any, exports: Record<string, Function> | undefined): void {
+  if (options == null || typeof options !== "object") return;
+  let hasCause = false;
+  let causeVal: any;
+  if (_isWasmStruct(options)) {
+    const fieldNames = _getStructFieldNames(options, exports);
+    const sidecar = _wasmStructProps.get(options);
+    if (fieldNames && fieldNames.includes("cause")) {
+      hasCause = true;
+      const getter = exports?.__sget_cause;
+      if (typeof getter === "function") causeVal = getter(options);
+    } else if (sidecar && "cause" in sidecar) {
+      hasCause = true;
+      causeVal = sidecar.cause;
+    }
+  } else if ("cause" in options) {
+    hasCause = true;
+    causeVal = options.cause;
+  }
+  if (hasCause) {
+    Object.defineProperty(inst, "cause", {
+      value: causeVal,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}
+
+/**
  * Recursively convert a WasmGC value (struct, vec/array, or primitive) to a
  * plain JS value suitable for JSON.stringify.  Handles:
  *   - WasmGC structs  -> plain objects (via _structToPlainObject)
@@ -5034,34 +5075,63 @@ assert._isSameValue = isSameValue;
             throw new TypeError("Cannot convert undefined or null to object");
           }
           // (#1467) The compiler wraps Wasm vec arguments via `__make_iterable`
-          // before they reach this import, so `errors` is already a plain JS
-          // array when called from compiled code. We DELIBERATELY do NOT call
-          // `__make_iterable` recursively on each element — its vec-shape
-          // detection misfires on host Error instances and converts them into
-          // empty arrays. For values that arrive from user JS (rare in
-          // compiled code, but possible via interop) `Array.isArray` is false
-          // and we walk the iterator protocol directly.
+          // before they reach this import, so `errors` is usually already a plain
+          // JS array (or wrapped iterable) when called from compiled code. We
+          // DELIBERATELY do NOT call `__make_iterable` recursively on each element
+          // — its vec-shape detection misfires on host Error instances and
+          // converts them into empty arrays. For values that arrive from user JS
+          // `Array.isArray` is false and we walk the iterator protocol directly;
+          // abrupt completions there must propagate (test262
+          // errors-iterabletolist-failures).
           let errorsList: any[];
           if (Array.isArray(errors)) {
             errorsList = errors.slice();
           } else {
-            const iter = (errors as any)[Symbol.iterator];
-            if (typeof iter !== "function") {
-              throw new TypeError(String(errors) + " is not iterable");
+            let iter: any;
+            try {
+              iter = (errors as any)[Symbol.iterator];
+            } catch {
+              // Opaque WasmGC struct — `Symbol.iterator` access traps.
+              iter = undefined;
             }
-            errorsList = [];
-            const it = iter.call(errors);
-            while (true) {
-              const r = it.next();
-              if (r == null || r.done) break;
-              errorsList.push(r.value);
+            if (typeof iter !== "function") {
+              // (#1634) A bare opaque WasmGC *vec* struct (array literal `[1,2,3]`
+              // that wasn't pre-wrapped) has no JS `Symbol.iterator`. Materialize
+              // it via `__vec_len`/`__vec_get` (same machinery `__array_from`
+              // uses) — but ONLY when it is genuinely vec-shaped (no named struct
+              // fields). A non-vec object-literal struct (e.g. a user iterable
+              // whose `@@iterator` lives in the sidecar) must NOT be silently
+              // turned into an empty array; fall through to the TypeError so
+              // abrupt/protocol-violation cases still throw (test262
+              // errors-iterabletolist-failures).
+              const exports = callbackState?.getExports();
+              const looksLikeVec = _isWasmStruct(errors) && _getStructFieldNames(errors, exports) === null;
+              if (looksLikeVec) {
+                const materialized = _materializeIterable(errors, callbackState);
+                if (Array.isArray(materialized)) {
+                  errorsList = materialized.slice();
+                } else {
+                  throw new TypeError("AggregateError: errors argument is not iterable");
+                }
+              } else {
+                throw new TypeError("AggregateError: errors argument is not iterable");
+              }
+            } else {
+              errorsList = [];
+              const it = iter.call(errors);
+              while (true) {
+                const r = it.next();
+                if (r == null || r.done) break;
+                errorsList.push(r.value);
+              }
             }
           }
           // Spec step 3: if message !== undefined, ToString(message); then
           // CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
-          // Construct without message first to leave the slot empty (per spec
-          // when message is undefined, no own message property is set).
-          const inst = options === undefined ? new AggregateError([]) : new AggregateError([], undefined, options);
+          // Construct without message/options first; the engine's native
+          // InstallErrorCause cannot read an opaque WasmGC `options` struct, so
+          // we install `cause` ourselves below (#1634).
+          const inst = new AggregateError([]);
           if (message !== undefined) {
             const msgStr = typeof message === "string" ? message : String(message);
             Object.defineProperty(inst, "message", {
@@ -5081,6 +5151,58 @@ assert._isSameValue = isSameValue;
             enumerable: false,
             configurable: true,
           });
+          // Spec step (InstallErrorCause): set own non-enumerable `cause` if
+          // options has the property (HasProperty, not truthiness) (#1634).
+          _installErrorCause(inst, options, callbackState?.getExports());
+          return inst;
+        };
+      // new SuppressedError(error, suppressed, message, options?) — spec §20.5.10.1
+      // (#1634). Mirrors __new_AggregateError: the generic 3-param extern-class
+      // path dropped the `options` argument (no `cause` support) and could not
+      // coerce `message` correctly. This dedicated import implements the spec
+      // construction sequence:
+      //   • error / suppressed stored as non-enumerable own data properties,
+      //   • message coerced via ToString only if defined (no own prop otherwise),
+      //   • InstallErrorCause(O, options): if options is an object and
+      //     HasProperty(options, "cause"), set a non-enumerable `cause`.
+      if (name === "__new_SuppressedError")
+        return (error: any, suppressed: any, message: any, options: any): any => {
+          if (typeof SuppressedError === "undefined") {
+            throw new TypeError("SuppressedError is not supported by the host");
+          }
+          // Construct via the native engine so the prototype chain and brand
+          // (`SuppressedError.prototype`, name "SuppressedError") are correct.
+          // The engine cannot read an opaque WasmGC `options` struct, so we
+          // install `cause` ourselves below (#1634).
+          const inst = new (SuppressedError as unknown as new () => Error)();
+          // Spec steps 4: CreateNonEnumerableDataPropertyOrThrow(O, "error", error).
+          Object.defineProperty(inst, "error", {
+            value: error,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+          });
+          // Spec step 3: CreateNonEnumerableDataPropertyOrThrow(O, "suppressed", suppressed).
+          Object.defineProperty(inst, "suppressed", {
+            value: suppressed,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+          });
+          // Spec step 5: if message is not undefined, msg = ToString(message);
+          // CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+          if (message !== undefined) {
+            const msgStr = typeof message === "string" ? message : String(message);
+            Object.defineProperty(inst, "message", {
+              value: msgStr,
+              writable: true,
+              enumerable: false,
+              configurable: true,
+            });
+          }
+          // Spec step 6 (InstallErrorCause): set own non-enumerable `cause` if
+          // options has the property (HasProperty, not truthiness) (#1634).
+          _installErrorCause(inst, options, callbackState?.getExports());
           return inst;
         };
       // ArrayBuffer.isView(arg) — checks if arg is a TypedArray or DataView (#965)

--- a/tests/issue-1634.test.ts
+++ b/tests/issue-1634.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #1634 — AggregateError accepts any iterable errors (array literal, Set);
+// SuppressedError gets a spec-faithful dedicated constructor; both install
+// `cause` from options via HasProperty semantics.
+//
+// Construction happens INSIDE the exported `test` function (after setExports),
+// matching how test262 / the real driver run — the host needs the module's
+// `__vec_len`/`__sget_*` exports to materialize WasmGC vec/struct arguments.
+async function run(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "t.ts" });
+  if (!r.success) throw new Error("CE: " + (r.errors[0]?.message ?? "unknown"));
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  if (typeof imports.setExports === "function") {
+    (imports.setExports as (e: unknown) => void)(instance.exports);
+  }
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#1634 AggregateError / SuppressedError iterable + cause", () => {
+  it("AggregateError errors from an array literal", async () => {
+    const out = await run(
+      `export function test(): number { const e = new AggregateError([1, 2, 3]); return e.errors.length; }`,
+    );
+    expect(out).toBe(3);
+  });
+
+  it("AggregateError errors from a Set (any iterable)", async () => {
+    const out = await run(
+      `export function test(): number { const s = new Set([1, 2]); const e = new AggregateError(s); return e.errors.length; }`,
+    );
+    expect(out).toBe(2);
+  });
+
+  it("AggregateError errors property is a real Array", async () => {
+    const out = await run(
+      `export function test(): number { const e = new AggregateError([1, 2, 3]); return Array.isArray(e.errors) ? 1 : 0; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("AggregateError installs cause from options (object identity preserved)", async () => {
+    const out = await run(
+      `export function test(): number { const cause = { m: 1 }; const e = new AggregateError([], "msg", { cause }); return ((e as any).cause === cause) ? 1 : 0; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("AggregateError: no cause property when options omitted", async () => {
+    const out = await run(
+      `export function test(): number { const e = new AggregateError([], "msg"); return ("cause" in (e as any)) ? 1 : 0; }`,
+    );
+    expect(out).toBe(0);
+  });
+
+  it("AggregateError: cause installed even when options.cause is undefined (HasProperty)", async () => {
+    const out = await run(
+      `export function test(): number { const o = { cause: undefined }; const e = new AggregateError([], "msg", o); return ("cause" in (e as any)) ? 1 : 0; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("AggregateError(undefined) throws TypeError (not iterable)", async () => {
+    const out = await run(
+      `export function test(): number { let t = 0; try { new AggregateError(undefined as any); } catch (e) { if (e instanceof TypeError) t = 1; } return t; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("SuppressedError stores error and suppressed (reference identity)", async () => {
+    const out = await run(
+      `export function test(): number { const err = { a: 1 }; const sup = { b: 2 }; const e = new SuppressedError(err, sup, "m"); return ((e as any).error === err && (e as any).suppressed === sup) ? 1 : 0; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("SuppressedError coerces message to string", async () => {
+    const out = await run(
+      `export function test(): number { const e = new SuppressedError(1, 2, "hello"); return e.message === "hello" ? 1 : 0; }`,
+    );
+    expect(out).toBe(1);
+  });
+
+  it("SuppressedError: no cause property when options omitted", async () => {
+    const out = await run(
+      `export function test(): number { const e = new SuppressedError(1, 2, "m"); return ("cause" in (e as any)) ? 1 : 0; }`,
+    );
+    expect(out).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `new AggregateError(iterable)` now accepts any iterable for `errors`: a compiler-emitted WasmGC vec (array literal `[1,2,3]`) is materialized via `__vec_len`/`__vec_get` instead of trapping on `String(opaque-struct)` ("Cannot convert object to primitive value"). `Set` / arrays / generators iterate per spec; non-vec object-literal structs still throw so the iterator abrupt-completion cases (`errors-iterabletolist-failures`) stay green.
- `SuppressedError` gets a dedicated `__new_SuppressedError(error, suppressed, message, options)` host import + codegen (new-super.ts / calls.ts). Previously it went through the generic 3-param extern-class path that dropped `options` (no `cause`) and mishandled message coercion.
- Both install `cause` from `options` via HasProperty semantics (including `cause: undefined`) through a shared `_installErrorCause` helper that reads the field without breaking the cause's reference identity (`error.cause === cause`).

## Conformance
Net-zero in `built-ins/AggregateError` (6/25) and `built-ins/SuppressedError` (7/22) — **same as current main**, no regression. The issue's ≥70% target is not reachable from this scope: remaining failures are out-of-scope infrastructure — extern-class `.prototype` access returns null (~9 prototype/* tests each dir), `Reflect.construct`/`fn.length` introspection, Symbol→string message coercion (#1658), and the custom-iterator-over-wasm-struct bridge gap (#1320/#1620/#1633). These are runtime-correctness fixes (programs constructing these errors with real iterables/cause now behave per spec).

## Test plan
- [x] `tests/issue-1634.test.ts` — 10/10 pass (array/Set errors, Array.isArray, cause object-identity, no-cause-when-omitted, cause-when-`cause:undefined`, `AggregateError(undefined)` throws, SuppressedError error/suppressed identity + message coercion)
- [x] `tests/issue-1467.test.ts`, `issue-844.test.ts`, `issue-830.test.ts` — 19/19 pass (no regression)
- [x] `built-ins/AggregateError` + `built-ins/SuppressedError` test262: no regression vs main; `errors-iterabletolist-failures` stays green
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)