### PR TITLE
fix(#1620): multi-value __iterator_next eliminates done/value host imports

### DIFF
--- a/plan/issues/1620-iterator-result-struct-runtime-wiring.md
+++ b/plan/issues/1620-iterator-result-struct-runtime-wiring.md
@@ -1,9 +1,10 @@
 ---
 id: 1620
 title: "$IteratorResult struct: eliminate __iterator_done/__iterator_value host imports (runtime wiring gap)"
-status: ready
+status: done
 created: 2026-05-24
 updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6746,23 +6746,14 @@ export function addIteratorImports(ctx: CodegenContext): void {
   const extToExt = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
   addImport(ctx, "env", "__iterator", { kind: "func", typeIdx: extToExt });
 
-  // __iterator_next: (externref) → externref — calls iter.next()
+  // __iterator_next: (externref) → (i32 done, externref value) — calls iter.next()
+  // Multi-value result avoids the $IteratorResult struct: a WasmGC struct cannot
+  // survive the JS import hop — it surfaces as undefined in V8 (see #1620). The
+  // two primitives (i32 done + externref value) cross the boundary cleanly.
+  const extToDoneValue = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }, { kind: "externref" }]);
   addImport(ctx, "env", "__iterator_next", {
     kind: "func",
-    typeIdx: extToExt,
-  });
-
-  // __iterator_done: (externref) → i32 — returns result.done ? 1 : 0
-  const extToI32 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
-  addImport(ctx, "env", "__iterator_done", {
-    kind: "func",
-    typeIdx: extToI32,
-  });
-
-  // __iterator_value: (externref) → externref — returns result.value
-  addImport(ctx, "env", "__iterator_value", {
-    kind: "func",
-    typeIdx: extToExt,
+    typeIdx: extToDoneValue,
   });
 
   // __iterator_return: (externref) → void — calls iter.return() if it exists

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -3231,9 +3231,9 @@ function findStructFieldsByTypeIdx(
  * Generated Wasm pseudo-code:
  *   iter = __iterator(obj)
  *   loop:
- *     result = __iterator_next(iter)
- *     if __iterator_done(result) → break
- *     elem = __iterator_value(result)
+ *     (done, value) = __iterator_next(iter)   // multi-value result (#1620)
+ *     if done → break
+ *     elem = value
  *     <body>
  *     br loop
  */
@@ -3328,18 +3328,19 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   fctx.body.push({ op: "call", funcIdx: iteratorIdx });
 
   const nextIdx = ctx.funcMap.get("__iterator_next");
-  const doneIdx = ctx.funcMap.get("__iterator_done");
-  const valueIdx = ctx.funcMap.get("__iterator_value");
   const returnIdx = ctx.funcMap.get("__iterator_return");
-  if (nextIdx === undefined || doneIdx === undefined || valueIdx === undefined) {
+  if (nextIdx === undefined) {
     reportError(ctx, stmt, "for-of on non-array type requires iterator imports");
     return;
   }
   const iterLocal = allocLocal(fctx, `__forof_iter_${fctx.locals.length}`, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: iterLocal });
 
-  // Allocate locals for iterator result and loop element
+  // Allocate locals for iterator result and loop element.
+  // __iterator_next now returns a multi-value (i32 done, externref value) — the
+  // value goes in resultLocal (externref), done in nextDoneLocal (i32). (#1620)
   const resultLocal = allocLocal(fctx, `__forof_result_${fctx.locals.length}`, { kind: "externref" });
+  const nextDoneLocal = allocLocal(fctx, `__forof_done_raw_${fctx.locals.length}`, { kind: "i32" });
 
   // Declare the loop variable (element type is externref for iterator protocol)
   const elemType: ValType = { kind: "externref" };
@@ -3439,14 +3440,16 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   fctx.body.push({ op: "i32.gt_s" });
   fctx.body.push({ op: "br_if", depth: 1 }); // break if >1M iterations
 
-  // Call __iterator_next(iter) → result
+  // Call __iterator_next(iter) → (i32 done, externref value).
+  // Multi-value result: value (externref) is on top of the stack, done (i32)
+  // below — so pop value first, then done. (#1620)
   fctx.body.push({ op: "local.get", index: iterLocal });
   fctx.body.push({ op: "call", funcIdx: nextIdx });
-  fctx.body.push({ op: "local.set", index: resultLocal });
+  fctx.body.push({ op: "local.set", index: resultLocal }); // externref value (top)
+  fctx.body.push({ op: "local.set", index: nextDoneLocal }); // i32 done (below)
 
-  // Check done: __iterator_done(result) → i32, break if truthy
-  fctx.body.push({ op: "local.get", index: resultLocal });
-  fctx.body.push({ op: "call", funcIdx: doneIdx });
+  // Check done: read the i32 local directly, break if truthy
+  fctx.body.push({ op: "local.get", index: nextDoneLocal });
   // If done, set the done flag to 1 before breaking
   fctx.body.push({
     op: "if",
@@ -3459,9 +3462,8 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
     else: [],
   });
 
-  // Get value: elem = __iterator_value(result)
+  // Get value: elem = value (already in resultLocal)
   fctx.body.push({ op: "local.get", index: resultLocal });
-  fctx.body.push({ op: "call", funcIdx: valueIdx });
   fctx.body.push({ op: "local.set", index: elemLocal });
 
   // If destructuring pattern, destructure from the element

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1389,24 +1389,18 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         out.push({ op: "call", funcIdx });
         return;
       }
-      case "iter.next": {
-        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_next" });
-        emitValue(instr.iter, out);
-        out.push({ op: "call", funcIdx });
-        return;
-      }
-      case "iter.done": {
-        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_done" });
-        emitValue(instr.resultObj, out);
-        out.push({ op: "call", funcIdx });
-        return;
-      }
-      case "iter.value": {
-        const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_value" });
-        emitValue(instr.resultObj, out);
-        out.push({ op: "call", funcIdx });
-        return;
-      }
+      case "iter.next":
+      case "iter.done":
+      case "iter.value":
+        // #1620: __iterator_next now returns a multi-value (i32 done, externref
+        // value), so the standalone single-result iter.next/iter.done/iter.value
+        // instruction model no longer maps to a host import. The front-end emits
+        // only forof.iter (handled below), which consumes the multi-value result
+        // inline; these standalone forms are unused. If a future producer needs
+        // them, lower the pair together (as forof.iter does), not separately.
+        throw new Error(
+          `ir/lower: '${instr.kind}' is not supported — __iterator_next returns a multi-value result; use forof.iter (#1620)`,
+        );
       case "iter.return": {
         const funcIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_return" });
         emitValue(instr.iter, out);
@@ -1419,8 +1413,6 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
         // `IrInstrForOfIter` in `nodes.ts`.
         const iteratorIdx = resolver.resolveFunc({ kind: "func", name: "__iterator" });
         const iteratorNextIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_next" });
-        const iteratorDoneIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_done" });
-        const iteratorValueIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_value" });
         const iteratorReturnIdx = resolver.resolveFunc({ kind: "func", name: "__iterator_return" });
 
         // iter = __iterator(iterable)
@@ -1430,17 +1422,14 @@ export function lowerIrFunctionToWasm(func: IrFunction, resolver: IrLowerResolve
 
         // Build loop body Wasm ops.
         const loopBody: Instr[] = [];
-        // result = iter.next(iter)
+        // (done, value) = __iterator_next(iter) — multi-value result (#1620).
+        // Stack after the call: done(i32) below, value(externref) on top. Pop
+        // value into the element slot, leaving done(i32) on top for br_if.
         loopBody.push({ op: "local.get", index: slotWasmIdx(instr.iterSlot) });
         loopBody.push({ op: "call", funcIdx: iteratorNextIdx });
-        loopBody.push({ op: "local.tee", index: slotWasmIdx(instr.resultSlot) });
-        // if (iter.done(result)) br 1 (exit)
-        loopBody.push({ op: "call", funcIdx: iteratorDoneIdx });
-        loopBody.push({ op: "br_if", depth: 1 });
-        // element = iter.value(result)
-        loopBody.push({ op: "local.get", index: slotWasmIdx(instr.resultSlot) });
-        loopBody.push({ op: "call", funcIdx: iteratorValueIdx });
         loopBody.push({ op: "local.set", index: slotWasmIdx(instr.elementSlot) });
+        // if (done) br 1 (exit)
+        loopBody.push({ op: "br_if", depth: 1 });
 
         // Body instrs (same materialisation pattern as forof.vec).
         for (const bodyInstr of instr.body) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5875,53 +5875,56 @@ assert._isSameValue = isSameValue;
           );
         };
       if (name === "__iterator_next")
-        return (iter: any) => {
+        // Returns a Wasm multi-value [i32 done, externref value]. The old split
+        // __iterator_done / __iterator_value imports are folded in here so the
+        // for-of loop makes one host call per step. A two-element JS array is the
+        // multi-value ABI shape V8 destructures onto the Wasm stack. (#1620)
+        return (iter: any): [number, any] => {
+          let raw: any;
           let next = iter.next ?? _sidecarGet(iter, "next");
           // Try struct getter for "next" method
           if (next === undefined) {
             const exports = callbackState?.getExports();
             next = exports?.__sget_next?.(iter);
           }
-          if (typeof next === "function") return next.call(iter);
-          // If next is a WasmGC closure, call via __call_fn_0
-          if (next != null && _isWasmStruct(next)) {
+          if (typeof next === "function") {
+            raw = next.call(iter);
+          } else if (next != null && _isWasmStruct(next)) {
+            // If next is a WasmGC closure, call via __call_fn_0
             const exports = callbackState?.getExports();
             const callFn0 = (exports as any)?.__call_fn_0;
             if (typeof callFn0 === "function") {
               const result = callFn0(next);
-              if (result != null) return result;
+              if (result != null) raw = result;
             }
           }
           // Try __call_next dispatch for WasmGC struct iterators
-          {
+          if (raw === undefined) {
             const exports = callbackState?.getExports();
             const callNext = (exports as any)?.["__call_next"];
             if (typeof callNext === "function") {
               const result = callNext(iter);
-              if (result != null) return result;
+              if (result != null) raw = result;
             }
           }
-          throw new TypeError("iterator.next is not a function");
-        };
-      if (name === "__iterator_done")
-        return (result: any) => {
-          let done = result.done ?? _sidecarGet(result, "done");
-          // Try struct getter for "done" field
+          if (raw == null) throw new TypeError("iterator.next is not a function");
+
+          // Extract done (own / sidecar / __sget_done)
+          let done = raw.done ?? _sidecarGet(raw, "done");
           if (done === undefined) {
             const exports = callbackState?.getExports();
-            done = exports?.__sget_done?.(result);
+            done = exports?.__sget_done?.(raw);
           }
-          return done ? 1 : 0;
-        };
-      if (name === "__iterator_value")
-        return (result: any) => {
-          let val = result.value;
-          if (val !== undefined) return val;
-          val = _sidecarGet(result, "value");
-          if (val !== undefined) return val;
-          // Try struct getter for "value" field
-          const exports = callbackState?.getExports();
-          return exports?.__sget_value?.(result);
+          // Extract value (own / sidecar / __sget_value)
+          let value = raw.value;
+          if (value === undefined) {
+            value = _sidecarGet(raw, "value");
+            if (value === undefined) {
+              const exports = callbackState?.getExports();
+              value = exports?.__sget_value?.(raw);
+            }
+          }
+          return [done ? 1 : 0, value];
         };
       if (name === "__iterator_rest")
         return (iter: any) => {

--- a/tests/equivalence/helpers.ts
+++ b/tests/equivalence/helpers.ts
@@ -118,9 +118,11 @@ export function buildImports(result: CompileResult): WebAssembly.Imports {
       if (asyncIter) return asyncIter.call(obj);
       return obj[Symbol.iterator]();
     },
-    __iterator_next: (iter: any) => iter.next(),
-    __iterator_done: (result: any) => (result.done ? 1 : 0),
-    __iterator_value: (result: any) => result.value,
+    // #1620: __iterator_next returns a multi-value [i32 done, externref value].
+    __iterator_next: (iter: any): [number, any] => {
+      const r = iter.next();
+      return [r.done ? 1 : 0, r.value];
+    },
     __iterator_return: (iter: any) => {
       if (iter && typeof iter.return === "function") iter.return();
     },

--- a/tests/iterators.test.ts
+++ b/tests/iterators.test.ts
@@ -87,8 +87,10 @@ describe("iterators", () => {
       expect(result.success).toBe(true);
       expect(result.wat).toContain("__iterator");
       expect(result.wat).toContain("__iterator_next");
-      expect(result.wat).toContain("__iterator_done");
-      expect(result.wat).toContain("__iterator_value");
+      // #1620: __iterator_done / __iterator_value were folded into the
+      // multi-value __iterator_next (i32 done, externref value) — gone.
+      expect(result.wat).not.toContain("__iterator_done");
+      expect(result.wat).not.toContain("__iterator_value");
     });
 
     it("does NOT generate iterator imports for array for...of", () => {


### PR DESCRIPTION
## Summary
- Changes `__iterator_next` from `(externref)→externref` to `(externref)→(i32 done, externref value)` — a Wasm multi-value result. The runtime reads `done`/`value` off the raw JS result and returns `[done?1:0, value]`; V8 destructures the two-element iterable onto the Wasm stack via the multi-value ABI.
- **Deletes the `__iterator_done` and `__iterator_value` host imports outright** (issue's primary acceptance criterion + `goal: host-independence`). Collapses 3 host calls per for-of step into 1.
- Both returned values are primitives, so there is **no `$IteratorResult` GC struct** to survive a JS import hop — sidesteps the v1 BLOCKED failure (a WasmGC struct externalized through the `__iterator_next` JS import surfaces as `undefined` in V8/Node 25). The BLOCKED failure mode is now structurally impossible.

## Implementation
Follows the `## Implementation Plan (v2)` in `plan/issues/1620-iterator-result-struct-runtime-wiring.md` (Direction 1: multi-value import).
- `src/codegen/index.ts` — `addIteratorImports`: `__iterator_next` registered with the 2-result func type; `__iterator_done`/`__iterator_value` + the `extToI32` type removed.
- `src/codegen/statements/loops.ts` — `compileForOfIterator`: single multi-value call; value (top of stack) → element, done (below) → break check. Doc-comment updated.
- `src/ir/lower.ts` — `forof.iter` lowering consumes the multi-value result inline (value into element slot, done left on stack for `br_if`); the now-incompatible standalone `iter.next`/`iter.done`/`iter.value` IR cases (unused — front-end only emits `forof.iter`) throw a clear error.
- `src/runtime.ts` — `__iterator_next` folds in done/value extraction and returns `[done?1:0, value]`; old split branches deleted.
- `tests/equivalence/helpers.ts` — host helper updated to the multi-value shape.
- `tests/iterators.test.ts` — stale WAT assertions flipped to assert `__iterator_done`/`__iterator_value` are **gone**.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `tests/iterators.test.ts` (5 string for-of) + `tests/symbol-iterator-protocol.test.ts` (custom iterable — the real `__iterator_next` exerciser, was the v1 proven regression) — **10/10 pass**
- [x] IR-path: `issue-1372-ir-destructuring-params`, `issue-1374-ir-string-iter-inline` — 17/17 pass
- [x] Equivalence sweep (for-of-basic, for-of-generator, iterator-protocol-custom, map-set, ir-slice10-map-set, generator-yield-delegation, spread-in-new) — pass
- [x] No new failures: `for await...of` (async-iteration), `tests/helpers.js`-missing files, and map-set type errors all **pre-exist on clean main** (verified via stash). Async-iterator parity is explicitly out of scope per the v2 spec (sync custom-iterable is the acceptance gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)