### PR TITLE
docs(#1665): senior-dev analysis — escalate as spec/design gap

### DIFF
--- a/plan/issues/1665-standalone-native-generators.md
+++ b/plan/issues/1665-standalone-native-generators.md
@@ -79,3 +79,79 @@ the generator `throw()` path.
 - New `src/codegen/wasm-helpers/generator-state.ts` — `$GeneratorState`
   struct + native iterator interface.
 - `src/codegen/host-import-allowlist.ts`.
+
+## Senior-dev analysis (2026-05-25) — STOP: spec/design gap, not an impl pass
+
+A senior-dev pass mapped the existing model end-to-end before coding. The
+conclusion is that the *smallest coherent slice* cannot land as an isolated
+implementation pass without either colliding with in-flight #1664 or baking
+wrong semantics into standalone mode. Escalated to tech-lead for a shared
+`$Iterator` design decision. Findings:
+
+### How generators are lowered today (the model is already EAGER)
+
+- `closures.ts:2067` — a `function*` body is **run to completion at
+  creation time**, inside a try/catch. It is NOT a coroutine/state machine.
+- Each `yield v` (`expressions/misc.ts:162`) pushes `v` into a host JS array
+  via `__gen_push_f64` / `__gen_push_i32` / `__gen_push_ref` (`runtime.ts:5652`).
+  `__gen_create_buffer` returns `[]`. A 1M-yield `__EAGER_GEN_LIMIT` guard
+  caps it.
+- `__create_generator(buf, pendingThrow)` (`runtime.ts:5685`) wraps
+  `{buf, index, pendingThrow}` into an object on `%GeneratorPrototype%`.
+- `for-of` (`statements/loops.ts:3314-3465`) and `.next()` walk it via the
+  polymorphic host helpers `__iterator` / `__iterator_next` /
+  `__iterator_done` / `__iterator_value` / `__iterator_return`
+  (`runtime.ts:5762-5906`).
+
+### Why a native slice IS structurally buildable (the good news)
+
+The precedent exists: `addUnionImportsAsNativeFuncs` (`index.ts:6404`, gated
+on `ctx.wasi || ctx.standalone`) already emits **native** `__box_number` /
+`__unbox_number` as a `$box_number` WasmGC struct + `extern.convert_any`, no
+host. So a native eager buffer is feasible: a `$Generator` struct
+`{ items: (array (mut anyref)), len: i32, index: i32 }`, native
+`__gen_push_*` that box-and-append, native `__create_generator` as identity,
+and native `__iterator*` that read the struct when the operand is a
+`$Generator`.
+
+### Why it must NOT land as #1665-only (the stop reasons)
+
+1. **`__iterator*` is a shared polymorphic dispatcher, co-owned by #1664 /
+   #1103.** A native `__iterator_next` cannot assume `$Generator` — in
+   standalone it must also serve arrays, Map/Set, native-string iterators,
+   and user `[Symbol.iterator]` structs. The issue text itself (lines 56-62)
+   calls for a **shared native `$Iterator` interface** for exactly this.
+   #1664 line 56-59 *depends on #1665* for that native iterator
+   ("a WasmGC loop calling the iterator protocol helpers (which themselves
+   must be native — see #1665)"). #1664 is **in-flight** (`origin/issue-1664`,
+   task #91). Building a generator-only `__iterator*` here would either be
+   non-reusable (forcing a #1664 rewrite) or require designing the full
+   polymorphic discriminator now — the "more design than one pass" line.
+
+2. **The eager model is semantically wrong and would be enshrined.** Running
+   the body at creation time mis-handles any generator with an unbounded loop
+   or observable interleaved side effects (it runs to completion / hits the
+   1M guard up front). The issue's own preferred lowering is the
+   state-machine transform precisely to fix this. Shipping a *native eager*
+   buffer would make standalone generators silently wrong — worse than the
+   current honest host-import leak.
+
+3. **#1666 (invalid-wasm) is an unfixed hard prerequisite.** The audit (#1662)
+   shows the generator probe emits **invalid Wasm today**, before the import
+   question. Both #1664 and #1665 list "resolve #1666 first." Native lowering
+   must land on a module that validates.
+
+### Recommended decomposition (needs architect + tech-lead decision)
+
+- **#1665a (shared, architect-owned):** design + build a single native
+  `$Iterator` interface (struct with a `next` funcref returning a
+  `{value:anyref, done:i32}` struct) reused by generators, for-of, Map/Set
+  (#1103), and `__array_from_iter` (#1664). This is the missing shared
+  artifact none of #1664/#1665/#1103 currently owns.
+- **#1665b:** native eager `$Generator` buffer on top of #1665a (acceptable
+  *only* if the eager-semantics limitation is explicitly documented and
+  scoped to the basic slice), OR
+- **#1665c (preferred long-term):** state-machine / CPS lowering so
+  generators are true coroutines — large, depends on the IR async/CPS work
+  (#1373b / #1042).
+- All of the above gated on **#1666** landing first.


### PR DESCRIPTION
## Summary

Analysis of standalone native generators. The existing generator model is eager (body runs at creation, yields pushed to a host buffer). Three blockers identified: (1) shared polymorphic `__iterator*` dispatcher co-owned by in-flight #1664 and #1103; (2) eager model is semantically wrong for unbounded/side-effecting generators; (3) #1666 (invalid-wasm) is an unfixed hard prerequisite.

Documented findings. Issue remains escalated/blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)