### PR TITLE
fix(#1667): compile() returns ready-to-pass importObject for JS-host mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,17 @@ The imports a module needs depend on the compile target:
   supplied by the js2wasm JS runtime, so instantiating with an empty `{}`
   throws `Import #0 "string_constants": module is not an object or function`.
   Use this mode when you run the output alongside the JS runtime that provides
-  those imports.
+  those imports. The result carries a ready-to-pass `result.importObject` that
+  wires those host helpers for you — pass it straight to
+  `WebAssembly.instantiate` with no hand-wiring:
+
+  ```ts
+  const r = compile(`
+    export function add(a: number, b: number): number { return a + b; }
+  `);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  (instance.exports as any).add(2, 3); // → 5
+  ```
 - **Standalone mode** (`target: "standalone"`, also `target: "wasi"`) emits a
   pure WasmGC module with Wasm-native intrinsics and **no host imports**, so it
   instantiates with `WebAssembly.instantiate(binary, {})` and runs anywhere

--- a/plan/issues/1667-dx-generate-import-object.md
+++ b/plan/issues/1667-dx-generate-import-object.md
@@ -1,9 +1,10 @@
 ---
 id: 1667
 title: "DX: compile() should return a ready-to-pass import object for default/JS-host mode"
-status: ready
+status: done
 created: 2026-05-25
-updated: 2026-05-25
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 task_type: feature
@@ -80,3 +81,18 @@ Complementary, not duplicate:
 - **#1667** (this issue, feature) — adds the JS-host convenience: a generated
   import object the caller can pass directly, so default-mode output also
   instantiates without hand-wiring.
+
+## Resolution
+
+`CompileResult` now exposes `importObject` (`WebAssembly.Imports`), attached at
+the public `compile` / `compileMulti` / `compileFiles` / `compileProject` entry
+points in `src/index.ts` via `withImportObject`. It is a lazily-computed,
+cached getter that wires the existing `buildImports()` runtime into
+`{ env, "wasm:js-string", string_constants }` — the polyfill instantiation
+shape. Standalone / `wasi` (zero-import) and failed compiles return `{}`, so
+the field is always safe to pass to `WebAssembly.instantiate`.
+
+The standalone / zero-import path stays the recommended portable default — this
+is an opt-in convenience for the JS-host path only; default codegen is
+unchanged. README "Compile modes and imports" documents the new affordance
+alongside the standalone option. Tests in `tests/issue-1667.test.ts`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,27 @@ export interface CompileResult {
   hasMain: boolean;
   /** Whether the source has top-level executable statements (module init code) */
   hasTopLevelStatements: boolean;
+  /**
+   * Ready-to-pass JS-host import object for default/JS-host mode (#1667).
+   *
+   * In default mode the compiled binary needs host imports (`env.*`,
+   * `wasm:js-string`, `string_constants`), so `WebAssembly.instantiate(binary,
+   * {})` throws. This getter wires the runtime helpers from {@link buildImports}
+   * into a single object the caller passes directly:
+   *
+   * ```js
+   * const r = compile(src);
+   * const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+   * ```
+   *
+   * Standalone / `wasi` mode is the zero-import portable default and needs no
+   * import object; for those targets this is an empty object. Computed lazily —
+   * accessing it builds the runtime once and caches the result.
+   *
+   * Always present on results from the public `compile*` entry points; the
+   * low-level `compile*Source` helpers in compiler.ts do not attach it.
+   */
+  readonly importObject?: WebAssembly.Imports;
 }
 
 export interface CompileError {
@@ -204,6 +225,7 @@ import * as path from "path";
 import { IncrementalLanguageService } from "./checker/index.js";
 import { compileFilesSource, compileMultiSource, compileSource, compileToObjectSource } from "./compiler.js";
 import { ModuleResolver, resolveAllImports } from "./resolve.js";
+import { buildImports as buildImportsRuntime } from "./runtime.js";
 
 /**
  * Compile TypeScript source to Wasm GC binary.
@@ -222,7 +244,45 @@ import { ModuleResolver, resolveAllImports } from "./resolve.js";
  * ```
  */
 export function compile(source: string, options?: CompileOptions): CompileResult {
-  return compileSource(source, options);
+  return withImportObject(compileSource(source, options));
+}
+
+/**
+ * Attach a lazily-computed `importObject` getter (#1667) to a compile result.
+ *
+ * Building the host runtime via {@link buildImports} is deferred until the
+ * caller actually reads `result.importObject`, so standalone / `wasi` outputs
+ * (which need no host imports) pay nothing, and the result stays cheap to
+ * produce. The built object is cached on first access.
+ *
+ * The returned object is a valid `WebAssembly.Imports`: `{ env, "wasm:js-string",
+ * string_constants }`. It targets the polyfill instantiation path
+ * (`WebAssembly.instantiate(binary, importObject)` with no extra options),
+ * which is what the issue's example uses.
+ */
+function withImportObject(result: CompileResult): CompileResult {
+  let cached: WebAssembly.Imports | undefined;
+  Object.defineProperty(result, "importObject", {
+    enumerable: true,
+    configurable: true,
+    get() {
+      if (cached) return cached;
+      // Failed compile or zero-import (standalone / wasi) output needs no host
+      // runtime — return an empty, harmless import object.
+      if (!result.success || result.imports.length === 0) {
+        cached = {};
+        return cached;
+      }
+      const built = buildImportsRuntime(result.imports, undefined, result.stringPool);
+      cached = {
+        env: built.env,
+        "wasm:js-string": built["wasm:js-string"],
+        string_constants: built.string_constants,
+      } as unknown as WebAssembly.Imports;
+      return cached;
+    },
+  });
+  return result;
 }
 
 /**
@@ -234,7 +294,7 @@ export function compileMulti(
   entryFile: string,
   options?: CompileOptions,
 ): CompileResult {
-  return compileMultiSource(files, entryFile, options);
+  return withImportObject(compileMultiSource(files, entryFile, options));
 }
 
 /**
@@ -255,7 +315,7 @@ export function compileMulti(
  * ```
  */
 export function compileFiles(entryPath: string, options?: CompileOptions): CompileResult {
-  return compileFilesSource(entryPath, options);
+  return withImportObject(compileFilesSource(entryPath, options));
 }
 
 /** Only WAT text (debug) */
@@ -308,7 +368,7 @@ export function compileProject(entryFile: string, options?: CompileOptions): Com
   // Entry file key
   const entryKey = `./${path.relative(rootDir, resolvedEntry)}`;
 
-  return compileMultiSource(files, entryKey, effectiveOptions);
+  return withImportObject(compileMultiSource(files, entryKey, effectiveOptions));
 }
 
 /**

--- a/tests/issue-1667.test.ts
+++ b/tests/issue-1667.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#1667 compile() returns ready-to-pass importObject (JS-host mode)", () => {
+  it("default mode: instantiate(binary, result.importObject) runs with no hand-wiring", async () => {
+    const r = compile(`
+      export function add(a: number, b: number): number {
+        return a + b;
+      }
+    `);
+    expect(r.success).toBe(true);
+    expect(r.importObject).toBeDefined();
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject!);
+    expect((instance.exports.add as Function)(2, 3)).toBe(5);
+  });
+
+  it("default mode with string literals: importObject wires string_constants", async () => {
+    const r = compile(`
+      export function greet(): string {
+        return "hello" + " " + "world";
+      }
+    `);
+    expect(r.success).toBe(true);
+    expect(r.importObject).toBeDefined();
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject!);
+    const out = (instance.exports.greet as Function)();
+    expect(String(out)).toBe("hello world");
+  });
+
+  it("importObject exposes the env / wasm:js-string / string_constants namespaces", () => {
+    const r = compile(`export function id(x: number): number { return x; }`);
+    const io = r.importObject as Record<string, unknown>;
+    expect(io).toBeDefined();
+    expect(io.env).toBeTypeOf("object");
+    expect(io["wasm:js-string"]).toBeDefined();
+    expect(io.string_constants).toBeTypeOf("object");
+  });
+
+  it("importObject is cached — repeated reads return the same object", () => {
+    const r = compile(`export function id(x: number): number { return x; }`);
+    expect(r.importObject).toBe(r.importObject);
+  });
+
+  it("standalone mode: importObject is an empty object (zero-import path)", () => {
+    const r = compile(`export function add(a: number, b: number): number { return a + b; }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(true);
+    expect(r.importObject).toEqual({});
+  });
+
+  it("failed compile: importObject is an empty object", () => {
+    const r = compile(`export function bad(: { syntax error`);
+    expect(r.success).toBe(false);
+    expect(r.importObject).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1667 (feature requested by guest271314 in #601). In default (JS-host) mode the compiled binary needs host imports (`env.*`, `wasm:js-string`, `string_constants`), so `WebAssembly.instantiate(binary, {})` throws. The CLI already emits a `.imports.js` runtime, but the programmatic `compile()` API never exposed it.
- `CompileResult` now carries `importObject` (`WebAssembly.Imports`) — a lazily-computed, cached getter attached at the public `compile` / `compileMulti` / `compileFiles` / `compileProject` entry points (`withImportObject` in `src/index.ts`). It wires the existing `buildImports()` runtime into `{ env, "wasm:js-string", string_constants }`, the polyfill instantiation shape. Callers can now do:

  ```ts
  const r = compile(src);
  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
  ```

- Standalone / `wasi` (zero-import) outputs and failed compiles yield `{}`, so the field is always safe to pass. Default codegen is unchanged, and the standalone / zero-import path remains the recommended portable default (ties to #1661).
- README "Compile modes and imports" documents the new affordance alongside the standalone option.

## Test plan
- [x] `tests/issue-1667.test.ts` — 6 cases: default-mode `add(2,3)`, string-literal `string_constants` wiring, namespace presence, getter caching, standalone `{}`, failed-compile `{}` (all pass)
- [x] `npx tsc --noEmit` clean
- [x] `biome lint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)