### PR TITLE
docs(#1609): mark blocked on iterator bridge (#1620/#1633)

### DIFF
--- a/plan/issues/1609-non-literal-spread-in-new-expression.md
+++ b/plan/issues/1609-non-literal-spread-in-new-expression.md
@@ -1,9 +1,10 @@
 ---
 id: 1609
 title: "codegen: non-literal spread argument in new-expression not supported"
-status: ready
+status: blocked
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+blocked_on: [1620, 1633]
 priority: medium
 feasibility: medium
 task_type: feature
@@ -47,3 +48,39 @@ constructor). Reuse the existing call-spread lowering for the construct path.
 
 - `new F(...iter)` with a non-literal iterable compiles.
 - >=14 of the 18 tests move off `compile_error`.
+
+## Investigation 2026-05-27 (dev-1604) — root-cause hypothesis is wrong; BLOCKED on iterator bridge
+
+The "reuse call-expression spread lowering" hypothesis underestimates the work.
+Findings from inspecting the actual failing test262 files
+(`language/expressions/new/spread-*`):
+
+1. **Every** failing test invokes an anonymous `new function() { ... }` with
+   **no formal parameters** and reads `arguments.length` / `arguments[i]`.
+   So there is no formal-param subset to expand a spread into — the spread
+   result must populate a **dynamic-length `arguments` object**.
+   `compileNewFunctionExpression` (src/codegen/expressions/new-super.ts:854)
+   builds a *static* `arguments` vec from a **compile-time-fixed** formal/flat
+   arg count (lines 1064-1078). A runtime-variable spread length breaks that
+   assumption outright.
+
+2. The non-literal sources are custom `Symbol.iterator` objects
+   (`spread-sngl-iter`, `spread-mult-iter`) and assignment expressions / vars
+   holding plain arrays (`spread-sngl-expr` = `...(target = source)`), plus a
+   block of error tests (`spread-err-*-itr-step/value/get-*`) that require
+   driving an arbitrary iterator and propagating a **mid-iteration throw**.
+
+3. `compileSpreadCallArgs` (src/codegen/expressions/extern.ts:404) — the
+   lowering the issue suggested reusing — only expands a **vec-struct
+   (compiled-array) source into a fixed param count**. It does NOT drive a
+   general `Symbol.iterator`. Confirmed: even the *plain call* path emits
+   invalid Wasm for `f(...customIterObj)` ("not enough arguments on the stack").
+   Only a typed-array variable (`number[]`) spread compiles to valid Wasm today.
+
+**Conclusion**: #1609 needs (a) a runtime iterator-protocol driver producing a
+dynamic-length argv, and (b) a dynamic-argv lifted constructor to build
+`arguments`. That is the **same iterator-bridge infrastructure as #1620 /
+#1633** (the latter escalated NEEDS-SPEC for exactly this). This issue is
+**blocked on #1620 / #1633**, not a localized dev fix. Re-route after the
+iterator bridge lands; reassess then whether the array-literal/typed-array
+subset can be carved off as a partial win.


### PR DESCRIPTION
## Summary

Investigation of #1609 (non-literal spread in `new`-expression, ~18 test262 fails). The issue's root-cause hypothesis — "reuse the call-expression spread lowering for the construct path" — does **not** hold. This PR is **docs-only**: it records the findings and re-routes #1609 as blocked.

## Findings

- **Every** failing test262 case (`language/expressions/new/spread-*`) is an anonymous `new function(){...}` with **no formal parameters** that reads `arguments.length` / `arguments[i]`. The spread result must populate a **dynamic-length `arguments` object**; `compileNewFunctionExpression` (`src/codegen/expressions/new-super.ts:854`) builds a *static* `arguments` vec from a compile-time-fixed arg count.
- Non-literal sources are custom `Symbol.iterator` objects and assignment-expr/var arrays, plus error tests requiring a mid-iteration throw.
- `compileSpreadCallArgs` (`src/codegen/expressions/extern.ts:404`) only expands a vec-struct (compiled-array) source into a fixed param count — it does NOT drive a general iterator. Confirmed: even the plain call path emits **invalid Wasm** for `f(...customIterObj)`.

## Conclusion

#1609 needs the **iterator-bridge infrastructure (#1620 / #1633)** plus a dynamic-argv lifted constructor. Marked `status: blocked`, `blocked_on: [1620, 1633]`. Reassess after the bridge lands.

## Test plan

- [ ] Docs-only — no code change, no behavior change. CI green = mergeable.