### PR TITLE
fix(#1612): emit top-level-await test bodies at module scope in wrapTest

### DIFF
--- a/plan/issues/1612-tla-array-literal-element-access-misparse.md
+++ b/plan/issues/1612-tla-array-literal-element-access-misparse.md
@@ -1,9 +1,10 @@
 ---
 id: 1612
 title: "parser: top-level-await with array-literal operand misparsed as element access ('should take an argument')"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -37,16 +38,41 @@ malformed for element access.
 - `test/language/module-code/top-level-await/syntax/if-expr-await-expr-array-literal.js`
 - `test/language/module-code/top-level-await/syntax/void-await-expr-array-literal.js`
 
-## Root-cause hypothesis
+## Root cause (actual — NOT the compiler parser)
 
-After parsing the `await` UnaryExpression operand, the parser's postfix loop
-greedily consumes a following `[` as an element-access on the await result.
-Per grammar, `await ArrayLiteral` should parse the `[...]` as the operand's
-primary expression. Fix the precedence so `await` binds its UnaryExpression
-operand (including a leading array literal) before postfix member access is
-considered.
+The original hypothesis (parser postfix precedence) is **wrong**. `await []`
+compiles cleanly at module scope: `compile("await [];", { module: true })`
+and `compile("void await [];\nexport function test(){return 1;}")` both succeed.
+
+The fault is in the **test262 harness**, `tests/test262-runner.ts:wrapTest()`.
+It wraps every test body in a *synchronous* `export function test(): number`.
+Inside a non-async function, `await` is an ordinary identifier, so
+`void await [];` parses as `void (await[])` — element access on the identifier
+`await` with empty brackets → "An element access expression should take an
+argument."
+
+## Fix
+
+In `wrapTest`, when `meta.features` includes `top-level-await`, emit the test
+body at **module top level** (where `await` is a keyword, since the
+`export function test` already marks the file as a module) instead of burying
+it inside the synchronous `test()`. `test()` becomes a trivial probe of the
+harness `__fail` counter. These are syntax-only tests (no assertions), so
+running the (inert) await expressions at module init is harmless.
+
+Non-TLA tests are untouched — verified the wrapped output is byte-identical to
+`main` for sampled non-TLA tests.
+
+## Result
+
+All 17 `top-level-await/syntax/*-array-literal` tests now compile.
+(The 6 `*-obj-literal` syntax tests remain `compile_error` — `void await
+{ function() {} }` is a separate obj-literal-after-await parse gap that
+predates this fix and is out of scope here.)
+
+Covered by `tests/issue-1612.test.ts`.
 
 ## Acceptance criteria
 
-- `await [ ... ]` in module top-level code parses correctly.
-- >=10 of the 14 tests move off `compile_error`.
+- [x] `await [ ... ]` in module top-level code parses correctly.
+- [x] >=10 of the array-literal tests move off `compile_error` (17/17 do).

--- a/tests/issue-1612.test.ts
+++ b/tests/issue-1612.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1612 — top-level-await syntax tests with an array-literal operand
+// (`void await []`, `if (await []) {}`, …) used to fail to compile with
+// "An element access expression should take an argument."
+//
+// Root cause was in the test262 harness, not the compiler parser: `wrapTest`
+// wraps the test body in a *synchronous* `export function test()`, where
+// `await` is an ordinary identifier — so `await []` misparses as element
+// access on an identifier. The fix emits top-level-await bodies at module top
+// level (where `await` is a keyword) and keeps `test()` as a trivial probe of
+// the harness `__fail` counter.
+//
+// These are syntax-only tests (no assertions): a pass is "compiles cleanly".
+
+import { describe, expect, it } from "vitest";
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { compile } from "../src/index.js";
+import { wrapTest } from "./test262-runner.js";
+
+const TLA_SYNTAX_DIR = "test262/test/language/module-code/top-level-await/syntax";
+
+function resolveTla(): string {
+  const candidates = [resolve(__dirname, "..", TLA_SYNTAX_DIR), `/workspace/${TLA_SYNTAX_DIR}`];
+  for (const c of candidates) {
+    try {
+      readdirSync(c);
+      return c;
+    } catch {
+      // try next
+    }
+  }
+  return candidates[0];
+}
+
+function parseMeta(src: string): { features: string[]; flags: string[] } {
+  const featM = src.match(/features:\s*\[([^\]]*)\]/);
+  const flagM = src.match(/flags:\s*\[([^\]]*)\]/);
+  const split = (s: string | undefined) =>
+    s
+      ? s
+          .split(",")
+          .map((x) => x.trim())
+          .filter(Boolean)
+      : [];
+  return { features: split(featM?.[1]), flags: split(flagM?.[1]) };
+}
+
+describe("issue #1612 — top-level-await + array-literal operand parses", () => {
+  const dir = resolveTla();
+  const files = readdirSync(dir).filter((f) => f.includes("array-literal") && f.endsWith(".js"));
+
+  it("discovers the array-literal TLA syntax tests", () => {
+    expect(files.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const f of files) {
+    it(`compiles ${f}`, () => {
+      const src = readFileSync(`${dir}/${f}`, "utf-8");
+      const meta = parseMeta(src);
+      const { source } = wrapTest(src, meta);
+      const r = compile(source, {
+        fileName: "test.ts",
+        skipSemanticDiagnostics: true,
+      });
+      expect(
+        r.success,
+        `compile failed: ${r.errors
+          .slice(0, 1)
+          .map((e) => e.message)
+          .join("")}`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe("issue #1612 — non-TLA wrapping is unaffected", () => {
+  it("only rewrites the wrapper when top-level-await is in features", () => {
+    // A plain body without the TLA feature flag must still be wrapped inside
+    // the synchronous `export function test()` with a try/catch.
+    const body = "var x: number = 1;\nassert_sameValue(x, 1);\n";
+    const fakeSource = `/*---\nfeatures: []\n---*/\n${body}`;
+    const { source } = wrapTest(fakeSource, { features: [], flags: [] });
+    expect(source).toContain("export function test(): number {");
+    expect(source).toContain("try {");
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2213,6 +2213,35 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   // checks apply (e.g. assignments to arguments/eval, duplicate params).
   const strictDirective = resolvedMeta.flags?.includes("onlyStrict") ? '"use strict";\n' : "";
 
+  // #1612 — top-level-await tests put `await` at module top level, where it is
+  // a keyword. Wrapping the body in a *synchronous* `test()` turns `await`
+  // back into an identifier, so `await [x]` misparses as element access
+  // ("An element access expression should take an argument."). These are
+  // syntax-only tests (no assertions), so emit the body at module top level —
+  // where `await` parses correctly — and leave `test()` as a trivial probe of
+  // `__fail`. The `export function test` already marks the file as a module,
+  // so module-goal top-level await is valid.
+  if (resolvedMeta.features?.includes("top-level-await")) {
+    const tlaPreBody = `${strictDirective}
+${preamble}
+${hoistedDecls}
+${implicitDecls.trim()}
+`;
+    const tlaPostBody = `
+export function test(): number {
+  if (__fail) { return __fail; }
+  return 1;
+}
+`;
+    const tlaBodyLineOffset = tlaPreBody.split("\n").length - 1;
+    const metaBlockTla = source.match(/\/\*---[\s\S]*?---\*\//);
+    const metaLinesTla = metaBlockTla ? metaBlockTla[0].split("\n").length - 1 : 0;
+    return {
+      source: tlaPreBody + bodyForFunc.trim() + "\n" + tlaPostBody,
+      bodyLineOffset: tlaBodyLineOffset - metaLinesTla,
+    };
+  }
+
   const preBody = `${strictDirective}
 ${preamble}
 ${hoistedDecls}


### PR DESCRIPTION
## Summary
- Fixes the 17 `language/module-code/top-level-await/syntax/*-array-literal` test262 tests that failed with "An element access expression should take an argument."
- Root cause was **not** the compiler parser (`await []` parses fine at module scope) — it was the test262 harness. `wrapTest()` wraps every body in a *synchronous* `export function test()`, where `await` is an ordinary identifier, so `void await []` misparses as element access on the identifier `await`.
- Fix: when `meta.features` includes `top-level-await`, emit the body at **module top level** (where `await` is a keyword) and keep `test()` as a trivial `__fail` probe. These are syntax-only tests (no assertions), so running the inert await expressions at module init is harmless.
- Non-TLA wrapping is **byte-identical** to before (the new branch is guarded by the feature check). Verified against sampled non-TLA tests.

## Scope notes
- The 6 `*-obj-literal` TLA syntax tests (`void await { function() {} }`) remain `compile_error` — that is a separate obj-literal-after-await parse gap that predates this change and is out of scope for #1612 (array-literal).

## Test plan
- [x] `tests/issue-1612.test.ts` — 19 tests, all 17 array-literal cases compile (+ discovery guard + non-TLA wrapping-unchanged check)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on changed files
- [x] CI test262 sharded gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)