### PR TITLE
fix(#1613): support non-identifier for-in heads

### DIFF
--- a/plan/issues/1613-for-in-variable-must-be-identifier.md
+++ b/plan/issues/1613-for-in-variable-must-be-identifier.md
@@ -1,9 +1,10 @@
 ---
 id: 1613
 title: "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -48,3 +49,33 @@ Extend the head handling to cover these LHS forms.
 
 - for-in over the declaration/pattern head forms compiles.
 - >=7 of the 10 tests move off `compile_error`.
+
+## Implementation (2026-05-27)
+
+`compileForInStatement` (`src/codegen/statements/loops.ts`) previously accepted
+only a bare identifier or single-identifier var/let declaration and called
+`reportError` on every other head form. Extended to handle the full
+ForBinding/LeftHandSideExpression grammar:
+
+1. **Member-expression target** (`for (x.y in obj)` / `for (x[k] in obj)`):
+   the enumerated key is materialised in a temp externref local, then written
+   to the reference each iteration via a new `emitForInMemberTargetWrite`
+   helper (`__extern_set(receiver, key, value)`, mirroring the for-of
+   member-target path at loops.ts ~1985).
+2. **Binding-pattern head** (`for (var/let [a] in obj)` /
+   `for (var {a} in obj)`): the key (a string) is destructured each iteration
+   by reusing `compileExternrefArrayDestructuringDecl` /
+   `compileExternrefObjectDestructuringDecl`. Array patterns iterate the
+   string's code units (so `for (var [x, x] in {ab:null})` ends with `x === "b"`).
+
+Early-error parity (`src/compiler/validation.ts`): lexical for-in heads with
+duplicate bound names (`for (let [x, x] in {})` / `for (const [x, x] in {})`)
+now raise a parse-phase SyntaxError, mirroring the existing for-of check.
+
+## Test Results
+
+- `tests/issue-1613.test.ts` — 7/7 pass (member target value, string-key
+  array-destructure last-wins, lexical pattern iteration, both dup-bound-names
+  SyntaxError cases, plain-identifier no-regression).
+- The 2 failures in `tests/equivalence/new-non-constructor.test.ts` are
+  pre-existing on main (#432 stack-underflow), unrelated to this change.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1,14 +1,16 @@
+import { isStringType } from "../../checker/type-mapper.js";
+import type { Instr, ValType } from "../../ir/types.js";
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
  * Loop statement lowering: while, for, do-while, for-of, for-in.
  */
-import { ts, forEachChild } from "../../ts-api.js";
-import { isStringType } from "../../checker/type-mapper.js";
-import type { Instr, ValType } from "../../ir/types.js";
+import { forEachChild, ts } from "../../ts-api.js";
+import { collectReferencedIdentifiers } from "../closures.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError, reportErrorNoNode } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import {
   findUnresolvableInArrayPattern,
   findUnresolvableInObjectPattern,
@@ -16,7 +18,6 @@ import {
 } from "../expressions/assignment.js";
 import { emitCoercedLocalSet } from "../expressions/helpers.js";
 import { shiftLateImportIndices } from "../expressions/late-imports.js";
-import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import {
   addIteratorImports,
   ensureI32Condition,
@@ -25,7 +26,6 @@ import {
   resolveWasmType,
 } from "../index.js";
 import { resolveComputedKeyExpression } from "../literals.js";
-import { collectReferencedIdentifiers } from "../closures.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType } from "../registry/types.js";
 import {
@@ -589,7 +589,11 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   // earlier iterations keep their original cell. This implements the spec
   // semantics while letting non-capturing loops keep the fast single-local
   // path unchanged.
-  const perIterCells: { name: string; refCellTypeIdx: number; boxedLocal: number }[] = [];
+  const perIterCells: {
+    name: string;
+    refCellTypeIdx: number;
+    boxedLocal: number;
+  }[] = [];
   if (
     stmt.initializer &&
     ts.isVariableDeclarationList(stmt.initializer) &&
@@ -610,7 +614,9 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       const oldType =
         oldLocalIdx < fctx.params.length
           ? fctx.params[oldLocalIdx]!.type
-          : (fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? { kind: "f64" });
+          : (fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? {
+              kind: "f64",
+            });
       const refCellTypeIdx = getOrRegisterRefCellType(ctx, oldType);
       const boxedLocal = allocLocal(fctx, `__pi_box_${name}`, {
         kind: "ref_null",
@@ -677,7 +683,9 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       const oldLocalIdx = fctx.localMap.get(name);
       if (oldLocalIdx === undefined) continue; // not a local — globals/imports
       if (oldLocalIdx < fctx.params.length) continue; // params get boxed by closure construction itself
-      const oldType = fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? { kind: "f64" as const };
+      const oldType = fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? {
+        kind: "f64" as const,
+      };
       // Only box value-typed locals (i32, f64, externref, ref_null) — ref-cell
       // boxing of arbitrary struct/array refs is handled by the closure-side
       // path which knows the underlying type.
@@ -710,7 +718,13 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       fctx.localMap.set(name, boxedLocal);
       if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
       fctx.boxedCaptures.set(name, { refCellTypeIdx, valType: oldType });
-      preBoxedNames.push({ name, refCellTypeIdx, boxedLocal, valType: oldType, originalLocalIdx: oldLocalIdx });
+      preBoxedNames.push({
+        name,
+        refCellTypeIdx,
+        boxedLocal,
+        valType: oldType,
+        originalLocalIdx: oldLocalIdx,
+      });
     }
   }
 
@@ -851,7 +865,11 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   const freshCellInstrs: Instr[] = [];
   for (const cell of perIterCells) {
     freshCellInstrs.push({ op: "local.get", index: cell.boxedLocal });
-    freshCellInstrs.push({ op: "struct.get", typeIdx: cell.refCellTypeIdx, fieldIdx: 0 });
+    freshCellInstrs.push({
+      op: "struct.get",
+      typeIdx: cell.refCellTypeIdx,
+      fieldIdx: 0,
+    });
     freshCellInstrs.push({ op: "struct.new", typeIdx: cell.refCellTypeIdx });
     freshCellInstrs.push({ op: "local.set", index: cell.boxedLocal });
   }
@@ -898,7 +916,11 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
         else: [
           { op: "local.get", index: pb.boxedLocal } as Instr,
           { op: "ref.as_non_null" } as Instr,
-          { op: "struct.get", typeIdx: pb.refCellTypeIdx, fieldIdx: 0 } as Instr,
+          {
+            op: "struct.get",
+            typeIdx: pb.refCellTypeIdx,
+            fieldIdx: 0,
+          } as Instr,
           { op: "local.set", index: pb.originalLocalIdx } as Instr,
         ],
       } as Instr);
@@ -1112,7 +1134,10 @@ function compileForOfDestructuring(
                 [{ kind: "externref" }, { kind: "externref" }],
                 [{ kind: "externref" }],
               );
-              addImport(ctx, "env", "__extern_rest_object", { kind: "func", typeIdx: restObjType });
+              addImport(ctx, "env", "__extern_rest_object", {
+                kind: "func",
+                typeIdx: restObjType,
+              });
               shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
               restObjIdx = ctx.funcMap.get("__extern_rest_object");
             }
@@ -1273,7 +1298,10 @@ function compileForOfDestructuring(
             if (sliceIdx === undefined) {
               const importsBefore = ctx.numImportFuncs;
               const sliceType = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
-              addImport(ctx, "env", "__extern_slice", { kind: "func", typeIdx: sliceType });
+              addImport(ctx, "env", "__extern_slice", {
+                kind: "func",
+                typeIdx: sliceType,
+              });
               shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
               sliceIdx = ctx.funcMap.get("__extern_slice");
             }
@@ -1294,7 +1322,11 @@ function compileForOfDestructuring(
           ) {
             const nestedLocal = allocLocal(fctx, `__forof_nested_${fctx.locals.length}`, fieldType);
             fctx.body.push({ op: "local.get", index: elemLocal });
-            fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: i });
+            fctx.body.push({
+              op: "struct.get",
+              typeIdx: structTypeIdx,
+              fieldIdx: i,
+            });
             fctx.body.push({ op: "local.set", index: nestedLocal });
             compileForOfDestructuring(ctx, fctx, element.name, nestedLocal, fieldType, stmt);
             continue;
@@ -1307,7 +1339,11 @@ function compileForOfDestructuring(
           const localIdx = allocLocal(fctx, localName, bindingWasmType);
 
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: i });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: structTypeIdx,
+            fieldIdx: i,
+          });
 
           if (!valTypesMatch(fieldType, bindingWasmType)) {
             coerceType(ctx, fctx, fieldType, bindingWasmType);
@@ -1348,7 +1384,11 @@ function compileForOfDestructuring(
         ) {
           const nestedLocal = allocLocal(fctx, `__forof_nested_${fctx.locals.length}`, innerElemType);
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 1 });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: structTypeIdx,
+            fieldIdx: 1,
+          });
           fctx.body.push({ op: "i32.const", value: i });
           emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
           fctx.body.push({ op: "local.set", index: nestedLocal });
@@ -1363,7 +1403,11 @@ function compileForOfDestructuring(
           // Compute rest length: max(0, original.length - i)
           const restLenLocal = allocLocal(fctx, `__rest_len_${fctx.locals.length}`, { kind: "i32" });
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 0 }); // length
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: structTypeIdx,
+            fieldIdx: 0,
+          }); // length
           fctx.body.push({ op: "i32.const", value: i });
           fctx.body.push({ op: "i32.sub" } as Instr);
           fctx.body.push({ op: "local.set", index: restLenLocal });
@@ -1382,17 +1426,28 @@ function compileForOfDestructuring(
             typeIdx: innerArrTypeIdx,
           });
           fctx.body.push({ op: "local.get", index: restLenLocal });
-          fctx.body.push({ op: "array.new_default", typeIdx: innerArrTypeIdx } as Instr);
+          fctx.body.push({
+            op: "array.new_default",
+            typeIdx: innerArrTypeIdx,
+          } as Instr);
           fctx.body.push({ op: "local.set", index: restArrLocal });
 
           // array.copy(restArr, 0, srcData, i, restLen)
           fctx.body.push({ op: "local.get", index: restArrLocal });
           fctx.body.push({ op: "i32.const", value: 0 });
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 1 }); // src data
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: structTypeIdx,
+            fieldIdx: 1,
+          }); // src data
           fctx.body.push({ op: "i32.const", value: i });
           fctx.body.push({ op: "local.get", index: restLenLocal });
-          fctx.body.push({ op: "array.copy", dstTypeIdx: innerArrTypeIdx, srcTypeIdx: innerArrTypeIdx } as Instr);
+          fctx.body.push({
+            op: "array.copy",
+            dstTypeIdx: innerArrTypeIdx,
+            srcTypeIdx: innerArrTypeIdx,
+          } as Instr);
 
           // Create new vec struct: struct.new(restLen, restArr)
           const restVecType: ValType = { kind: "ref", typeIdx: structTypeIdx };
@@ -1421,7 +1476,11 @@ function compileForOfDestructuring(
         const localIdx = allocLocal(fctx, localName, bindingWasmType);
 
         fctx.body.push({ op: "local.get", index: elemLocal });
-        fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 1 });
+        fctx.body.push({
+          op: "struct.get",
+          typeIdx: structTypeIdx,
+          fieldIdx: 1,
+        });
         fctx.body.push({ op: "i32.const", value: i });
         // (#1396) Pass `useUndefinedSentinel: true` when this element has a
         // default initializer AND the source-array element type is externref.
@@ -1616,7 +1675,9 @@ function compileForOfAssignDestructuring(
             const globalIdx = ctx.moduleGlobals.get(oobTarget.text);
             if (globalIdx !== undefined) {
               const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
-              const globalType = globalDef?.type ?? { kind: "externref" as const };
+              const globalType = globalDef?.type ?? {
+                kind: "externref" as const,
+              };
               oobLocal = allocLocal(fctx, oobTarget.text, globalType);
               oobSyncGlobalIdx = globalIdx;
             }
@@ -1661,7 +1722,9 @@ function compileForOfAssignDestructuring(
               const globalIdx = ctx.moduleGlobals.get(oobTarget.text);
               if (globalIdx !== undefined) {
                 const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
-                const globalType = globalDef?.type ?? { kind: "externref" as const };
+                const globalType = globalDef?.type ?? {
+                  kind: "externref" as const,
+                };
                 oobLocal = allocLocal(fctx, oobTarget.text, globalType);
                 oobSyncGlobalIdx = globalIdx;
               }
@@ -1688,7 +1751,11 @@ function compileForOfAssignDestructuring(
         if (ts.isObjectLiteralExpression(el) || ts.isArrayLiteralExpression(el)) {
           const nestedLocal = allocLocal(fctx, `__forof_nested_${fctx.locals.length}`, fieldType);
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: i });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: innerVecTypeIdx,
+            fieldIdx: i,
+          });
           fctx.body.push({ op: "local.set", index: nestedLocal });
           compileForOfAssignDestructuring(ctx, fctx, el, nestedLocal, fieldType, vecTypeIdx, arrTypeIdx, stmt);
           continue;
@@ -1717,7 +1784,11 @@ function compileForOfAssignDestructuring(
 
         const targetType = getLocalType(fctx, targetLocal);
         fctx.body.push({ op: "local.get", index: elemLocal });
-        fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: i });
+        fctx.body.push({
+          op: "struct.get",
+          typeIdx: innerVecTypeIdx,
+          fieldIdx: i,
+        });
 
         if (defaultInit) {
           // Check for undefined and apply default — BEFORE type coercion
@@ -1749,7 +1820,11 @@ function compileForOfAssignDestructuring(
         if (ts.isObjectLiteralExpression(el) || ts.isArrayLiteralExpression(el)) {
           const nestedLocal = allocLocal(fctx, `__forof_nested_${fctx.locals.length}`, innerElemType);
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 1 });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: innerVecTypeIdx,
+            fieldIdx: 1,
+          });
           fctx.body.push({ op: "i32.const", value: i });
           emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
           fctx.body.push({ op: "local.set", index: nestedLocal });
@@ -1794,7 +1869,11 @@ function compileForOfAssignDestructuring(
           // returns NaN sentinel; for ref/externref it returns null.
           fctx.body.push({ op: "local.get", index: targetLocal });
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 1 });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: innerVecTypeIdx,
+            fieldIdx: 1,
+          });
           fctx.body.push({ op: "i32.const", value: i });
           emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
           // Now stack: [box-ref, value:innerElemType]. Apply default-on-undefined
@@ -1861,7 +1940,11 @@ function compileForOfAssignDestructuring(
             typeIdx: innerArrTypeIdx,
           });
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 1 });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: innerVecTypeIdx,
+            fieldIdx: 1,
+          });
           fctx.body.push({ op: "local.tee", index: arrDataLocal });
           fctx.body.push({ op: "array.len" });
           fctx.body.push({ op: "i32.const", value: i });
@@ -1872,7 +1955,10 @@ function compileForOfAssignDestructuring(
           const thenInstrs = collectInstrs(fctx, () => {
             fctx.body.push({ op: "local.get", index: arrDataLocal } as Instr);
             fctx.body.push({ op: "i32.const", value: i } as Instr);
-            fctx.body.push({ op: "array.get", typeIdx: innerArrTypeIdx } as Instr);
+            fctx.body.push({
+              op: "array.get",
+              typeIdx: innerArrTypeIdx,
+            } as Instr);
             emitDefaultValueCheck(ctx, fctx, innerElemType, targetLocal!, defaultInit!, targetType ?? undefined);
           });
           // Else branch: OOB — apply default directly
@@ -1888,7 +1974,11 @@ function compileForOfAssignDestructuring(
           } as Instr);
         } else {
           fctx.body.push({ op: "local.get", index: elemLocal });
-          fctx.body.push({ op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 1 });
+          fctx.body.push({
+            op: "struct.get",
+            typeIdx: innerVecTypeIdx,
+            fieldIdx: 1,
+          });
           fctx.body.push({ op: "i32.const", value: i });
           emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
 
@@ -1985,7 +2075,9 @@ function compileForOfAssignDestructuringExternref(
       const setFnIdx = ensureExternSet();
       if (setFnIdx === undefined) continue;
       // Push receiver (already-existing variable, evaluated each iteration)
-      const recvType = compileExpression(ctx, fctx, targetEl.expression, { kind: "externref" });
+      const recvType = compileExpression(ctx, fctx, targetEl.expression, {
+        kind: "externref",
+      });
       if (recvType && recvType.kind !== "externref") {
         coerceType(ctx, fctx, recvType, { kind: "externref" });
       }
@@ -2272,13 +2364,17 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   const strNullGuardStart = fctx.body.length;
 
   // Extract length from string (field 0 of AnyString struct)
-  const lenLocal = allocLocal(fctx, `__forof_len_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__forof_len_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "local.get", index: strLocal });
   fctx.body.push({ op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: lenLocal });
 
   // Allocate counter local (i32)
-  const iLocal = allocLocal(fctx, `__forof_i_${fctx.locals.length}`, { kind: "i32" });
+  const iLocal = allocLocal(fctx, `__forof_i_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: iLocal });
 
@@ -2742,7 +2838,10 @@ function compileForOfIteratorAssignDestructuring(
       if (setIdxIter === undefined) {
         const importsBefore = ctx.numImportFuncs;
         const setType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }], []);
-        addImport(ctx, "env", "__extern_set", { kind: "func", typeIdx: setType });
+        addImport(ctx, "env", "__extern_set", {
+          kind: "func",
+          typeIdx: setType,
+        });
         shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
         setIdxIter = ctx.funcMap.get("__extern_set");
         // Refresh boxIdx/getIdx since they may have shifted.
@@ -2769,7 +2868,9 @@ function compileForOfIteratorAssignDestructuring(
       if (ts.isPropertyAccessExpression(targetElIter) || ts.isElementAccessExpression(targetElIter)) {
         const setFnIdx = ensureExternSetIter();
         if (setFnIdx === undefined || boxIdx === undefined || getIdx === undefined) continue;
-        const recvType = compileExpression(ctx, fctx, targetElIter.expression, { kind: "externref" });
+        const recvType = compileExpression(ctx, fctx, targetElIter.expression, {
+          kind: "externref",
+        });
         if (recvType && recvType.kind !== "externref") {
           coerceType(ctx, fctx, recvType, { kind: "externref" });
         }
@@ -3106,7 +3207,11 @@ function compileForOfDirectIterator(
   if (nextResultType.kind === "ref_null") {
     fctx.body.push({ op: "ref.as_non_null" } as Instr);
   }
-  fctx.body.push({ op: "struct.get", typeIdx: resultStructTypeIdx, fieldIdx: doneFieldIdx });
+  fctx.body.push({
+    op: "struct.get",
+    typeIdx: resultStructTypeIdx,
+    fieldIdx: doneFieldIdx,
+  });
   // done field might be i32 (boolean) or f64; convert to i32 for br_if
   if (doneFieldType.kind === "f64") {
     fctx.body.push({ op: "i32.trunc_f64_s" } as Instr);
@@ -3128,7 +3233,11 @@ function compileForOfDirectIterator(
   if (nextResultType.kind === "ref_null") {
     fctx.body.push({ op: "ref.as_non_null" } as Instr);
   }
-  fctx.body.push({ op: "struct.get", typeIdx: resultStructTypeIdx, fieldIdx: valueFieldIdx });
+  fctx.body.push({
+    op: "struct.get",
+    typeIdx: resultStructTypeIdx,
+    fieldIdx: valueFieldIdx,
+  });
 
   // Coerce value to element type if needed
   const targetElemType = getLocalType(fctx, elemLocal) ?? elemType;
@@ -3281,7 +3390,9 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   {
     const backupLocal: number | undefined = (fctx as any).__lastGuardedCastBackup;
     const tagIdx = ensureExnTag(ctx);
-    const iterTmp = allocLocal(fctx, `__forit_null_${fctx.locals.length}`, { kind: "externref" });
+    const iterTmp = allocLocal(fctx, `__forit_null_${fctx.locals.length}`, {
+      kind: "externref",
+    });
     fctx.body.push({ op: "local.tee", index: iterTmp });
     fctx.body.push({ op: "ref.is_null" });
     if (backupLocal !== undefined) {
@@ -3335,11 +3446,15 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
     reportError(ctx, stmt, "for-of on non-array type requires iterator imports");
     return;
   }
-  const iterLocal = allocLocal(fctx, `__forof_iter_${fctx.locals.length}`, { kind: "externref" });
+  const iterLocal = allocLocal(fctx, `__forof_iter_${fctx.locals.length}`, {
+    kind: "externref",
+  });
   fctx.body.push({ op: "local.set", index: iterLocal });
 
   // Allocate locals for iterator result and loop element
-  const resultLocal = allocLocal(fctx, `__forof_result_${fctx.locals.length}`, { kind: "externref" });
+  const resultLocal = allocLocal(fctx, `__forof_result_${fctx.locals.length}`, {
+    kind: "externref",
+  });
 
   // Declare the loop variable (element type is externref for iterator protocol)
   const elemType: ValType = { kind: "externref" };
@@ -3390,7 +3505,9 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
 
   // Done flag: tracks whether iterator completed normally (done=true).
   // Used after the loop to decide whether to call iterator.return() (#851).
-  const doneFlag = allocLocal(fctx, `__forof_done_${fctx.locals.length}`, { kind: "i32" });
+  const doneFlag = allocLocal(fctx, `__forof_done_${fctx.locals.length}`, {
+    kind: "i32",
+  });
 
   // Iterator close finallyStack entry (#851): inline before return/outer-break/outer-continue.
   // Push BEFORE the for-of break/continue entries so that:
@@ -3570,22 +3687,89 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   }
 }
 
+/**
+ * Write the current for-in key (held in `keyLocal` as an externref) to a
+ * member-expression target (`for (x.y in obj)` / `for (x[k] in obj)`), per
+ * ECMA-262 §14.7.5.6 ForIn/OfBodyEvaluation (lhsKind = assignment). Emits
+ * `__extern_set(receiver, key, value)` (#1613).
+ */
+function emitForInMemberTargetWrite(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  keyLocal: number,
+): void {
+  let setIdx = ctx.funcMap.get("__extern_set");
+  if (setIdx === undefined) {
+    const importsBefore = ctx.numImportFuncs;
+    const setType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }], []);
+    addImport(ctx, "env", "__extern_set", { kind: "func", typeIdx: setType });
+    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
+    setIdx = ctx.funcMap.get("__extern_set");
+  }
+  if (setIdx === undefined) return;
+
+  // Receiver
+  const recvType = compileExpression(ctx, fctx, target.expression, {
+    kind: "externref",
+  });
+  if (recvType && recvType.kind !== "externref") {
+    coerceType(ctx, fctx, recvType, { kind: "externref" });
+  } else if (recvType === null) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  }
+
+  // Key
+  if (ts.isPropertyAccessExpression(target)) {
+    const propName = target.name.text;
+    addStringConstantGlobal(ctx, propName);
+    const keyGlobalIdx = ctx.stringGlobalMap.get(propName);
+    if (keyGlobalIdx === undefined) return;
+    fctx.body.push({ op: "global.get", index: keyGlobalIdx } as Instr);
+  } else {
+    const keyType = compileExpression(ctx, fctx, target.argumentExpression, {
+      kind: "externref",
+    });
+    if (keyType && keyType.kind !== "externref") {
+      coerceType(ctx, fctx, keyType, { kind: "externref" });
+    } else if (keyType === null) {
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+    }
+  }
+
+  // Value = the enumerated key string
+  fctx.body.push({ op: "local.get", index: keyLocal });
+  fctx.body.push({ op: "call", funcIdx: setIdx });
+}
+
 export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForInStatement): void {
   // Get the loop variable name
   const init = stmt.initializer;
   let varName: string;
   let keyLocal: number;
+  // For non-identifier heads (binding pattern / member-expression target) the
+  // enumerated key is materialised in a temp externref local, then written to
+  // the real target each iteration (#1613). These describe that write.
+  let bindingPattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern | null = null;
+  let memberTarget: ts.PropertyAccessExpression | ts.ElementAccessExpression | null = null;
   if (ts.isVariableDeclarationList(init)) {
     const decl = init.declarations[0]!;
     if (!ts.isIdentifier(decl.name)) {
-      // Destructuring patterns in for-in (e.g. `for (var [a] in obj)`)
-      // are exotic — the key is a string, destructuring it gives characters.
-      // For now, skip gracefully rather than crash.
-      reportError(ctx, decl, "for-in variable must be an identifier");
-      return;
+      // Destructuring binding head: `for (var/let [a] in obj)`. The key is a
+      // string; per spec the binding pattern destructures that string value.
+      bindingPattern = decl.name;
+      varName = `__forin_key_${fctx.locals.length}`;
+      keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+    } else {
+      varName = decl.name.text;
+      // Allocate a local for the loop variable (string / externref)
+      keyLocal = allocLocal(fctx, varName, { kind: "externref" });
     }
-    varName = decl.name.text;
-    // Allocate a local for the loop variable (string / externref)
+  } else if (ts.isPropertyAccessExpression(init) || ts.isElementAccessExpression(init)) {
+    // Member-expression target: `for (x.y in obj)` / `for (x[k] in obj)`.
+    // Per spec the enumerated key is assigned to the reference each iteration.
+    memberTarget = init;
+    varName = `__forin_key_${fctx.locals.length}`;
     keyLocal = allocLocal(fctx, varName, { kind: "externref" });
   } else if (ts.isIdentifier(init)) {
     // Bare identifier: `for (x in obj)` — look up existing local
@@ -3646,17 +3830,23 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   fctx.body.push({ op: "call", funcIdx: keysIdx }); // __for_in_keys(obj) -> keys array
 
   // Store keys array in a local
-  const keysLocal = allocLocal(fctx, `__forin_keys_${fctx.locals.length}`, { kind: "externref" });
+  const keysLocal = allocLocal(fctx, `__forin_keys_${fctx.locals.length}`, {
+    kind: "externref",
+  });
   fctx.body.push({ op: "local.set", index: keysLocal });
 
   // Get length
-  const lenLocal = allocLocal(fctx, `__forin_len_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__forin_len_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "local.get", index: keysLocal });
   fctx.body.push({ op: "call", funcIdx: lenIdx }); // __for_in_len(keys) -> i32
   fctx.body.push({ op: "local.set", index: lenLocal });
 
   // Counter
-  const iLocal = allocLocal(fctx, `__forin_i_${fctx.locals.length}`, { kind: "i32" });
+  const iLocal = allocLocal(fctx, `__forin_i_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: iLocal });
 
@@ -3674,6 +3864,27 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
 
   fctx.breakStack.push(2); // break = depth 2 (exit $break block)
   fctx.continueStack.push(0); // continue = depth 0 (exit $continue block -> falls to incr)
+
+  // Non-identifier head (#1613): write the per-iteration key into its real
+  // target before the user body runs. keyLocal holds keys[i] at this point.
+  if (memberTarget) {
+    emitForInMemberTargetWrite(ctx, fctx, memberTarget, keyLocal);
+  } else if (bindingPattern) {
+    // Spec: the binding pattern destructures the (string) key value. Reuse the
+    // externref destructuring helpers — array patterns iterate the string's
+    // code units, object patterns read named properties.
+    if (ts.isArrayBindingPattern(bindingPattern)) {
+      fctx.body.push({ op: "local.get", index: keyLocal });
+      compileExternrefArrayDestructuringDecl(ctx, fctx, bindingPattern, {
+        kind: "externref",
+      });
+    } else {
+      fctx.body.push({ op: "local.get", index: keyLocal });
+      compileExternrefObjectDestructuringDecl(ctx, fctx, bindingPattern, {
+        kind: "externref",
+      });
+    }
+  }
 
   // Compile the user's loop body — save/restore block-scoped shadows for let/const (#817).
   if (ts.isBlock(stmt.statement)) {

--- a/src/compiler/validation.ts
+++ b/src/compiler/validation.ts
@@ -1,6 +1,6 @@
-// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
-import { ts, forEachChild } from "../ts-api.js";
 import type { CompileError, CompileOptions } from "../index.js";
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { forEachChild, ts } from "../ts-api.js";
 
 // Default blocked members on extern classes in safe mode
 const DEFAULT_BLOCKED_MEMBERS = new Set([
@@ -14,7 +14,10 @@ const DEFAULT_BLOCKED_MEMBERS = new Set([
   "insertAdjacentHTML",
 ]);
 
-function getApproxSourceLocation(sourceFile: ts.SourceFile): { line: number; column: number } {
+function getApproxSourceLocation(sourceFile: ts.SourceFile): {
+  line: number;
+  column: number;
+} {
   const anchor = sourceFile.statements[0] ?? sourceFile;
   const { line, character } = sourceFile.getLineAndCharacterOfPosition(anchor.getStart(sourceFile));
   return { line: line + 1, column: character + 1 };
@@ -725,6 +728,19 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
           // for-in/for-of with multiple lexical bindings is always a SyntaxError
           if (isLexical && init.declarations.length > 1) {
             addError(node, "Only a single declaration is allowed in a for-in statement");
+          }
+          // ES spec: It is a Syntax Error if BoundNames of ForDeclaration
+          // contains any duplicate entries (lexical only) — e.g.
+          // `for (let [x, x] in {}) {}` / `for (const [x, x] in {}) {}`.
+          if (isLexical) {
+            const seen = new Set<string>();
+            const dupes = new Set<string>();
+            for (const decl of init.declarations) {
+              collectBindingNamesWithDuplicateCheck(decl.name, seen, dupes);
+            }
+            for (const name of dupes) {
+              addError(node, `Duplicate binding '${name}' in for-in declaration`);
+            }
           }
         }
       }
@@ -2460,7 +2476,10 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
 
         const existing = privateNames.get(name);
         if (!existing) {
-          privateNames.set(name, { kinds: new Set([kind]), isStatic: memberIsStatic });
+          privateNames.set(name, {
+            kinds: new Set([kind]),
+            isStatic: memberIsStatic,
+          });
         } else {
           // get+set pair is allowed ONLY if both have the same staticness
           const combined = new Set([...existing.kinds, kind]);
@@ -3344,7 +3363,12 @@ function hasExportModifier(node: ts.Node): boolean {
 function validateHardenedMode(
   sourceFile: ts.SourceFile,
 ): Array<{ message: string; line: number; column: number; severity: "error" }> {
-  const errors: Array<{ message: string; line: number; column: number; severity: "error" }> = [];
+  const errors: Array<{
+    message: string;
+    line: number;
+    column: number;
+    severity: "error";
+  }> = [];
 
   function visit(node: ts.Node): void {
     // Reject eval() calls

--- a/tests/issue-1613.test.ts
+++ b/tests/issue-1613.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #1613 — for-in head with a non-identifier target.
+//
+// Before this fix compileForInStatement only accepted a single bare
+// identifier (or single var/let declaration) and reported a compile error
+// for any other ForBinding form:
+//   - member-expression target:  for (x.y in obj)
+//   - destructuring binding head: for (var [a] in obj) / for (let {a} in obj)
+// It also did not reject lexical heads with duplicate bound names, which the
+// spec requires to be a parse-phase SyntaxError.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(source: string): Promise<number | string> {
+  const r = compile(source, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    allowJs: true,
+  });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number | string }).test();
+}
+
+function compileErrors(source: string): string[] {
+  const r = compile(source, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    allowJs: true,
+  });
+  return r.errors.map((e) => e.message);
+}
+
+describe("Issue #1613 — for-in non-identifier head", () => {
+  it("member-expression target receives the enumerated key", async () => {
+    const src = `
+      export function test(): number {
+        const x: any = {};
+        let n: number = 0;
+        for (x.y in { attr: null }) { n = n + 1; }
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("member-expression target ends holding the last key", async () => {
+    const src = `
+      export function test(): any {
+        const x: any = {};
+        for (x.y in { attr: null }) {}
+        return x.y;
+      }
+    `;
+    expect(await runTest(src)).toBe("attr");
+  });
+
+  it("array binding-pattern head destructures the string key", async () => {
+    // Key "ab" array-destructured into [a, b] — duplicate name, last char wins.
+    const src = `
+      export function test(): any {
+        let x: any;
+        for (var [x, x] in { ab: null }) {}
+        return x;
+      }
+    `;
+    expect(await runTest(src)).toBe("b");
+  });
+
+  it("lexical binding-pattern head iterates once", async () => {
+    const src = `
+      export function test(): number {
+        const obj: any = { key: 1 };
+        let n: number = 0;
+        for (let [a] in obj) { n = n + 1; }
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("rejects duplicate bound names in a lexical for-in head (SyntaxError)", () => {
+    const errs = compileErrors(`export function test(): number { for (let [x, x] in ({} as any)) {} return 0; }`);
+    expect(errs.some((m) => /Duplicate binding 'x' in for-in declaration/.test(m))).toBe(true);
+  });
+
+  it("rejects duplicate bound names for const for-in head", () => {
+    const errs = compileErrors(`export function test(): number { for (const [x, x] in ({} as any)) {} return 0; }`);
+    expect(errs.some((m) => /Duplicate binding 'x' in for-in declaration/.test(m))).toBe(true);
+  });
+
+  it("plain identifier for-in head still works (no regression)", async () => {
+    const src = `
+      export function test(): number {
+        const o: any = { x: 1, y: 2, z: 3 };
+        let n: number = 0;
+        for (const k in o) { n = n + 1; }
+        return n;
+      }
+    `;
+    expect(await runTest(src)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- `compileForInStatement` only accepted a bare identifier head and reported a compile error for member-expression targets and binding-pattern heads (#1613, ~10 test262 fails).
- **Member-expression target** (`for (x.y in o)` / `for (x[k] in o)`): the enumerated key is written to the reference each iteration via `__extern_set` (new `emitForInMemberTargetWrite`, mirrors the for-of member-target path).
- **Binding-pattern head** (`for (var/let [a] in o)` / `for (var {a} in o)`): the string key is destructured each iteration by reusing the existing externref array/object destructuring decl helpers. Array patterns iterate the string's code units per spec.
- **Early error**: lexical for-in heads with duplicate bound names (`for (let [x, x] in {})`) now raise a parse-phase SyntaxError, mirroring the existing for-of duplicate-bound-names check.

## Test plan
- [x] `tests/issue-1613.test.ts` — 7/7 pass (member target value, string-key array-destructure last-wins, lexical pattern iteration, both dup-bound-names SyntaxError cases, plain-identifier no-regression).
- [x] `npx tsc --noEmit` clean; biome clean on changed files.
- [x] The 2 failures in `tests/equivalence/new-non-constructor.test.ts` are pre-existing on main (#432), unrelated.
- [ ] CI: cheap gate + merge shard reports + quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)