### PR TITLE
fix(#1613): accept binding-pattern for-in head

### DIFF
--- a/plan/issues/1613-for-in-variable-must-be-identifier.md
+++ b/plan/issues/1613-for-in-variable-must-be-identifier.md
@@ -1,9 +1,10 @@
 ---
 id: 1613
 title: "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -48,3 +49,31 @@ Extend the head handling to cover these LHS forms.
 
 - for-in over the declaration/pattern head forms compiles.
 - >=7 of the 10 tests move off `compile_error`.
+
+## Resolution (2026-05-27)
+
+`compileForInStatement` in `src/codegen/statements/loops.ts` now accepts an
+`ObjectBindingPattern`/`ArrayBindingPattern` head. The enumerated key (a string
+externref) is destructured into the pattern's bound names at the top of each
+loop iteration by delegating to `compileForOfDestructuring` — array-pattern
+destructuring of a string iterates its characters, which is the correct JS
+semantics (`for (var [x, x] in { ab: 1 })` binds `x = 'b'`).
+
+### Test Results
+
+Measured against `test262/test/language/statements/for-in/` (binding-pattern /
+bound-names / scope-body / head candidates, 20 files) via the vitest test262
+runner:
+
+- Baseline (main): 10 pass / 10 fail
+- This branch: 12 pass / 8 fail — **net +2**, no regressions (all 10 baseline
+  passes preserved).
+- Newly passing: `head-var-bound-names-dup.js`, `head-let-destructuring.js`.
+
+The remaining 8 fails are unrelated deeper issues (fresh-binding-per-iteration
+lexical scoping, TDZ closure capture, default-on-exhausted-iterator) — out of
+scope for the "head rejected at compile time" fix. Member-expression
+assignment-target heads (`for (x.y in obj)`) are not in the test262 set and
+remain a follow-up.
+
+Unit coverage: `tests/issue-1613.test.ts`.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -3575,18 +3575,26 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   const init = stmt.initializer;
   let varName: string;
   let keyLocal: number;
+  // When the head is a binding pattern (`for (var [a,b] in obj)`), the key
+  // string is destructured into the pattern each iteration. keyLocal holds the
+  // raw key string; bindingPattern (if set) is applied per-iteration below.
+  let bindingPattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern | undefined;
   if (ts.isVariableDeclarationList(init)) {
     const decl = init.declarations[0]!;
     if (!ts.isIdentifier(decl.name)) {
-      // Destructuring patterns in for-in (e.g. `for (var [a] in obj)`)
-      // are exotic — the key is a string, destructuring it gives characters.
-      // For now, skip gracefully rather than crash.
-      reportError(ctx, decl, "for-in variable must be an identifier");
-      return;
+      if (ts.isObjectBindingPattern(decl.name) || ts.isArrayBindingPattern(decl.name)) {
+        bindingPattern = decl.name;
+        varName = `__forin_key_${fctx.locals.length}`;
+        keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+      } else {
+        reportError(ctx, decl, "for-in variable must be an identifier");
+        return;
+      }
+    } else {
+      varName = decl.name.text;
+      // Allocate a local for the loop variable (string / externref)
+      keyLocal = allocLocal(fctx, varName, { kind: "externref" });
     }
-    varName = decl.name.text;
-    // Allocate a local for the loop variable (string / externref)
-    keyLocal = allocLocal(fctx, varName, { kind: "externref" });
   } else if (ts.isIdentifier(init)) {
     // Bare identifier: `for (x in obj)` — look up existing local
     varName = init.text;
@@ -3674,6 +3682,20 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
 
   fctx.breakStack.push(2); // break = depth 2 (exit $break block)
   fctx.continueStack.push(0); // continue = depth 0 (exit $continue block -> falls to incr)
+
+  // Binding-pattern head (`for (var [a,b] in obj)`): destructure the key string
+  // into the pattern's bound names at the top of each iteration. The key is a
+  // string (externref); array-pattern destructuring iterates its characters.
+  if (bindingPattern) {
+    compileForOfDestructuring(
+      ctx,
+      fctx,
+      bindingPattern,
+      keyLocal,
+      { kind: "externref" },
+      stmt as unknown as ts.ForOfStatement,
+    );
+  }
 
   // Compile the user's loop body — save/restore block-scoped shadows for let/const (#817).
   if (ts.isBlock(stmt.statement)) {

--- a/tests/issue-1613.test.ts
+++ b/tests/issue-1613.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports, instantiateWasm } from "../src/runtime.ts";
+
+async function run(src: string): Promise<any> {
+  const result = compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error("Compile error: " + result.errors.map((e) => e.message).join("; "));
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports["wasm:js-string"],
+    imports.string_constants,
+  );
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+describe("#1613 for-in head with binding pattern", () => {
+  it("destructures the key string via an array binding pattern", async () => {
+    // key 'hi' -> [first] binds first = 'h'
+    const r = await run(`
+      export function test(): string {
+        let c = '';
+        for (let [first] in { hi: 1 }) { c = first; }
+        return c;
+      }
+    `);
+    expect(r).toBe("h");
+  });
+
+  it("duplicate binding names take the last enumerated character", async () => {
+    // key 'ab' -> [x, x] binds x = 'a' then x = 'b'
+    const r = await run(`
+      export function test(): string {
+        let last = '';
+        for (var [x, x] in { ab: 1 }) { last = x; }
+        return last;
+      }
+    `);
+    expect(r).toBe("b");
+  });
+});


### PR DESCRIPTION
## Summary
- `compileForInStatement` rejected for-in heads with an array/object binding pattern (`for (var [x, x] in obj)`) at compile time ("for-in variable must be an identifier").
- Now destructures the enumerated key string into the pattern each iteration via `compileForOfDestructuring` — array-pattern destructuring of a string iterates its characters per spec (`for (var [x, x] in { ab: 1 })` binds `x = 'b'`).

## Test results (test262 for-in dir, 20 binding-pattern/scope candidates)
- Baseline (main): 10 pass / 10 fail
- This branch: 12 pass / 8 fail — net +2, no regressions
- Newly passing: `head-var-bound-names-dup.js`, `head-let-destructuring.js`
- Remaining fails are unrelated (fresh-binding-per-iteration, TDZ closure capture, default-on-exhausted-iterator).

## Test plan
- [x] `tests/issue-1613.test.ts` (new) passes
- [x] `tests/issue-forin.test.ts` (existing) still passes
- [x] `npx tsc --noEmit` clean
- [ ] CI sharded test262 + quality green

🤖 Generated with [Claude Code](https://claude.com/claude-code)