### PR TITLE
docs(#1329): investigation — Symbol.replace fails span 3 cross-cutting root causes

### DIFF
--- a/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
+++ b/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
@@ -59,7 +59,54 @@ Symbol.replace has the deepest semantic surface of the Symbol protocols:
 - 90+ of the 110 fails flip to pass
 - Remaining ones documented
 
+## Investigation 2026-05-27 (dev-1593)
+
+Smoke-tested the sample failures via `runTest262File`. The 110 fails do **not**
+share one root cause — they decompose into three independent buckets, each
+rooted **outside** the replace/@@replace code itself:
+
+1. **Host object-coercion closure dispatch (`__call_toString` runtime trap).**
+   Tests: `arg-1-coerce.js`, `result-coerce-matched.js`, `flags-tostring-error.js`,
+   and the `result-coerce-*` family. When a wasmGC object with `toString`/`valueOf`
+   closures is `ToString`-coerced by the host during the @@replace algorithm, the
+   `_wrapForHost` proxy dispatch traps with "illegal cast in `__call_toString()`".
+   Same machinery as #983/#1128/#1529 — NOT replace-specific.
+
+2. **Boolean → externref boxes as a number, losing identity.**
+   Tests: `cstm-replace-on-boolean-primitive.js`, `cstm-replaceall-on-boolean-primitive.js`.
+   Confirmed minimal repro: `"atruebtruec".replace(true, "X")` returns the
+   original string instead of `"aXbtruec"`, because the boolean `true` is boxed
+   via `__box_number` at `src/codegen/type-coercion.ts:1394` (i32→externref boxes
+   as number → host sees `1`, not `true`). Number/string primitive searches
+   already pass. This is the #1342/#1637-class representation gap (boolean has no
+   distinct externref boxing); the boxing site is shared by every i32 and carries
+   no source-type info to distinguish boolean from number. **Overlaps existing
+   task #1637 (Boolean + Symbol coercion TypeErrors).**
+
+3. **Custom replacer-callback arg/result coercion mismatches.**
+   Tests: `fn-invoke-args.js` (`assert.notSameValue(args, undefined)` fails), the
+   `fn-*` family. The Wasm-closure→JS-callable wrap and the GetSubstitution result
+   marshaling don't faithfully reconstruct the spec's `(matched, ...captures, pos,
+   string)` argument vector. Lives in runtime.ts `__regex_symbol_call` /
+   `_wrapWasmClosure` (~4717-4762).
+
+Each bucket is a cross-cutting compiler concern (type representation / host
+proxy / closure marshaling), not a localized replace fix. No single dev PR hits
+the "90+/110 flip" acceptance bar; fixing one bucket touches code shared by many
+other issues. **Recommend carving #1329 into bucket sub-issues (or folding the
+buckets into the existing #983/#1529/#1637 efforts) rather than one PR.** The
+replace/@@replace dispatch wiring itself (string-ops.ts `firstArgIsStringLike`
+guard + runtime.ts `__regex_symbol_call`) is already correct — passes confirmed
+for `fn-invoke-this-strict`, `fn-invoke-this-no-strict`, `y-fail-lastindex-no-write`,
+`subst-capture-idx-1`, `g-init-lastindex`.
+
+Reproduction note: the full directory sweep via `runTest262File` OOMs in a single
+process (~270 files, cumulative runner leak) even at 2 GB + `--expose-gc`; per-file
+runs are reliable. Use CI shards for full counts.
+
 ## Related
 
 - Parent #1002 (closed-as-scoped)
 - Sibling: #1328 (Symbol.match), #1330 (Symbol.search), #1331 (Symbol.split)
+- Overlaps: #983 / #1128 / #1529 (host object-coercion closure dispatch),
+  #1342 / #1637 (boolean externref representation)


### PR DESCRIPTION
## Summary

Investigation of #1329 (RegExp `Symbol.replace` / `String.prototype.replace` + `replaceAll`, ~110 test262 fails). The fails do **not** share one root cause — confirmed via per-file `runTest262File` smoke tests that they decompose into three independent buckets, none of which is a localized replace-protocol fix:

1. **Host object-coercion closure dispatch** — `__call_toString` runtime trap when a wasmGC object with `toString`/`valueOf` is `ToString`-coerced during @@replace. Same machinery as #983/#1128/#1529. (`arg-1-coerce`, `result-coerce-*`, `flags-tostring-error`)
2. **Boolean → externref boxes as a number** — `"atruebtruec".replace(true,"X")` returns the original string (host sees `1`, not `true`) because i32→externref boxes via `__box_number` at `src/codegen/type-coercion.ts:1394`. Overlaps #1342/#1637. (`cstm-replace-on-boolean-primitive`, `cstm-replaceall-on-boolean-primitive`)
3. **Custom replacer-callback arg/result marshaling** — the Wasm-closure→JS-callable wrap + GetSubstitution result coercion don't faithfully reconstruct the spec `(matched, ...captures, pos, string)` vector (runtime.ts `__regex_symbol_call` / `_wrapWasmClosure`). (`fn-invoke-args`, `fn-*`)

The replace/@@replace **dispatch wiring itself is correct** — `fn-invoke-this-strict`, `fn-invoke-this-no-strict`, `y-fail-lastindex-no-write`, `subst-capture-idx-1`, `g-init-lastindex` all pass.

**Recommendation:** carve #1329 into per-bucket sub-issues (or fold into the existing #983/#1529/#1637 efforts) rather than land one PR. No single dev change reaches the issue's "90+/110 flip" acceptance bar. Marked `status: blocked` pending triage.

This PR is **docs-only** (issue-file findings + status). No source changes.

## Test plan

- [ ] None — documentation/triage commit. CI quality/typecheck only.