### PR TITLE
fix(#1318): bring sharded CI runner up to parity for assert diagnostics

### DIFF
--- a/plan/issues/1318-returned-n-bare-exit-code-context.md
+++ b/plan/issues/1318-returned-n-bare-exit-code-context.md
@@ -1,9 +1,10 @@
 ---
 id: 1318
 title: "test harness: 'returned N' bare exit code — capture last assertion detail (~8,900 vague failures)"
-status: ready
+status: done
 created: 2026-05-07
-updated: 2026-05-07
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -53,3 +54,36 @@ In `scripts/test262-worker.mjs`, when the test calls `$262.$262Fail(msg)` or thr
 - `returned 2` with no context never appears — replaced by the last `$262.$262Fail` message.
 - Message field in JSONL is not truncated below 500 chars.
 - The truncated-assertion count drops by >80% (most become diagnosable).
+
+## Resolution
+
+Landed in two parts.
+
+**Part 1 (commit 39fa6ef3f)** — improved the `runTest262File` smoke-test path
+in `tests/test262-runner.ts`: raised the assert-line truncation 160→600 chars,
+added the `assert #N at L<line>: <source>` format, added a `throw new
+Test262Error(...)` fallback, and bumped the worker JSONL `error` cap to 2000
+chars in `scripts/test262-worker-esm.mjs`.
+
+**Part 2 (this change)** — the **sharded CI runner** (`tests/test262-shared.ts`,
+driven by the `test262-chunk*.test.ts` files that generate the live conformance
+JSONL) and the legacy `tests/test262-vitest.test.ts` still used the OLD
+`findNthAssert`: a 120-char cap, a narrow `\b(assert|verify\w+)\b` regex, and a
+bare `returned N (found M asserts in source)` fallback. Extracted the locator
+into `tests/test262-assert-locator.ts` (side-effect-free, unit-tested) and used
+it from both runners. Improvements:
+
+- `extractFullAssert` balances parentheses across lines, capturing the full
+  `assert.sameValue(actual, expected, "message")` call — including the message
+  argument that `wrapTest` strips from the compiled body but is still in the
+  source — capped at 500 chars (was 120).
+- Broadened the assert-detection regex to also match `assert.*`, `compareArray`,
+  `$DONOTEVALUATE`, and `throw new Test262Error`.
+- When the executed-assert counter outruns the static source scan (loops,
+  helper-internal asserts), the diagnostic anchors on the **last** assertion in
+  the file instead of emitting a bare `returned N` — so the assertion_fail
+  bucket entries are diagnosable. The `returned N —` prefix is preserved so
+  `classifyError` bucketing is unchanged.
+
+Tests: `tests/issue-1318-locator.test.ts` (10 cases). Existing
+`tests/issue-1318.test.ts` (3 cases, Part 1 path) stays green.

--- a/tests/issue-1318-locator.test.ts
+++ b/tests/issue-1318-locator.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #1318 (follow-up) — assertion-locator parity for the SHARDED CI runner.
+ *
+ * The original #1318 fix (commit 39fa6ef3f) improved the `runTest262File`
+ * smoke-test path. The sharded CI runner (tests/test262-shared.ts via the
+ * test262-chunk*.test.ts files) and the legacy tests/test262-vitest.test.ts
+ * still used the old findNthAssert: a 120-char cap, a narrow assert regex, and
+ * a bare "returned N" fallback when the assertion counter outran the static
+ * source scan. Both now share tests/test262-assert-locator.ts. These tests pin
+ * the shared helper's behavior.
+ */
+import { describe, expect, it } from "vitest";
+import { findNthAssert, extractFullAssert, ASSERT_SNIPPET_MAX } from "./test262-assert-locator.js";
+
+describe("#1318 findNthAssert (shared locator)", () => {
+  // wrapTest sets __assert_count = 1 then pre-increments per assert, so the Kth
+  // assert (1-based) sets __fail = K + 1 → retVal = K + 1.
+  const source = [
+    "var x = foo();",
+    'assert.sameValue(x, 1, "first check");',
+    'assert.sameValue(x, 2, "second check");',
+    'assert.sameValue(x, 3, "third check");',
+  ].join("\n");
+
+  it("locates the first failing assertion (retVal=2 → assert #1)", () => {
+    const msg = findNthAssert(source, 2);
+    expect(msg).toContain("assert #1");
+    expect(msg).toContain("L2");
+    expect(msg).toContain("first check");
+  });
+
+  it("locates the second failing assertion (retVal=3 → assert #2)", () => {
+    const msg = findNthAssert(source, 3);
+    expect(msg).toContain("assert #2");
+    expect(msg).toContain("L3");
+    expect(msg).toContain("second check");
+  });
+
+  it("surfaces actual+expected operands AND the (stripped-from-body) message arg", () => {
+    const msg = findNthAssert(source, 4);
+    expect(msg).toContain("third check");
+    expect(msg).toMatch(/x\s*,\s*3/);
+  });
+
+  it("never returns a bare 'returned N'/'found M asserts' when the counter outruns the scan", () => {
+    const loopSource = ["for (var i = 0; i < 100; i++) {", '  assert.sameValue(arr[i], i, "loop check");', "}"].join(
+      "\n",
+    );
+    const msg = findNthAssert(loopSource, 50);
+    expect(msg).toContain("counter exceeded");
+    expect(msg).toContain("loop check");
+    expect(msg).not.toMatch(/\(found \d+ asserts in source\)$/);
+  });
+
+  it("gives a descriptive fallback when no assert call exists in source", () => {
+    const msg = findNthAssert("var y = 1;\nthrow y;", 5);
+    expect(msg).toContain("no assert/verify call found");
+  });
+
+  it("handles the exception sentinel and early-return cases", () => {
+    expect(findNthAssert(source, -1)).toBe("exception caught in test body");
+    expect(findNthAssert(source, 1)).toContain("early return");
+  });
+
+  it("detects verifyProperty / compareArray / Test262Error harness forms", () => {
+    const s = [
+      "var d = {};",
+      "verifyProperty(d, 'x', { value: 1 });",
+      "assert(compareArray([1], [1]), 'arrays');",
+      'throw new Test262Error("boom");',
+    ].join("\n");
+    expect(findNthAssert(s, 2)).toContain("verifyProperty");
+    expect(findNthAssert(s, 3)).toContain("compareArray");
+    expect(findNthAssert(s, 4)).toContain("Test262Error");
+  });
+});
+
+describe("#1318 extractFullAssert (shared locator)", () => {
+  it("captures a multi-line assertion call by balancing parens", () => {
+    const lines = [
+      "assert.sameValue(",
+      "  computeValue(input),",
+      "  expectedValue,",
+      '  "a long descriptive message"',
+      ");",
+    ];
+    const text = extractFullAssert(lines, 0);
+    expect(text).toContain("computeValue(input)");
+    expect(text).toContain("expectedValue");
+    expect(text).toContain("a long descriptive message");
+  });
+
+  it("does not truncate below the old 120-char cap", () => {
+    const longMsg = "x".repeat(400);
+    const lines = [`assert.sameValue(actual, expected, "${longMsg}");`];
+    const text = extractFullAssert(lines, 0);
+    expect(text.length).toBeGreaterThan(120);
+    expect(text).toContain(longMsg.slice(0, 300));
+  });
+
+  it("caps very long assertions at ASSERT_SNIPPET_MAX", () => {
+    const longMsg = "y".repeat(2000);
+    const lines = [`assert.sameValue(actual, expected, "${longMsg}");`];
+    const text = extractFullAssert(lines, 0);
+    expect(text.length).toBeLessThanOrEqual(ASSERT_SNIPPET_MAX);
+  });
+});

--- a/tests/test262-assert-locator.ts
+++ b/tests/test262-assert-locator.ts
@@ -1,0 +1,91 @@
+/**
+ * test262 failure-diagnostic helpers (#1318).
+ *
+ * A failing test262 test returns the *index* of the first failing assertion
+ * (the wrapTest harness sets `__fail = __assert_count`). The runner re-locates
+ * that assertion in the original source to build a human-readable `returned N —
+ * assert #K at L… : …` diagnostic.
+ *
+ * This module is side-effect-free so it can be unit-tested directly, unlike the
+ * runner modules that open result files at import time.
+ */
+
+// Max chars of assertion source surfaced in a `returned N` diagnostic.
+// The prior 120-char cap truncated `assert.sameValue(actual, expected, "long
+// message...")` mid-line, hiding the actual/expected operands and the message.
+// JSONL is one line per test, so a 500-char operand snippet is cheap and makes
+// the failure diagnosable.
+export const ASSERT_SNIPPET_MAX = 500;
+
+// Detect the start of a test262 assertion / verification call. Covers the
+// harness helpers that previously fell through and produced a bare "returned
+// N": assert / assert.* , the propertyHelper verify* family, compareArray,
+// $DONOTEVALUATE, and `throw new Test262Error`.
+export const ASSERT_LINE_RE =
+  /(?:^|[;{}\s])(assert\b|assert\.\w+|verify\w+|compareArray\b|\$DONOTEVALUATE\b|throw\s+new\s+Test262Error\b)/;
+
+// Capture the full assertion statement starting at `lines[startLine]`, balancing
+// parentheses across line breaks so the actual+expected operands and the
+// optional message argument (still present in the original source even though
+// wrapTest strips it from the compiled body) are all included. Falls back to a
+// single trimmed line when no balanced call is found. Result is capped at
+// ASSERT_SNIPPET_MAX chars.
+export function extractFullAssert(lines: string[], startLine: number): string {
+  const first = lines[startLine];
+  const parenIdx = first.indexOf("(");
+  if (parenIdx === -1) {
+    return first.trim().slice(0, ASSERT_SNIPPET_MAX);
+  }
+  let depth = 0;
+  let started = false;
+  const collected: string[] = [];
+  for (let i = startLine; i < lines.length && i < startLine + 12; i++) {
+    const line = lines[i];
+    collected.push(line);
+    for (let c = i === startLine ? parenIdx : 0; c < line.length; c++) {
+      const ch = line[c];
+      if (ch === "(") {
+        depth++;
+        started = true;
+      } else if (ch === ")") {
+        depth--;
+      }
+    }
+    if (started && depth <= 0) break;
+  }
+  const text = collected.join(" ").replace(/\s+/g, " ").trim();
+  return text.slice(0, ASSERT_SNIPPET_MAX);
+}
+
+// Given a test's source and the assertion-counter value the wrapped test
+// returned, build a diagnostic string identifying the failing assertion. Never
+// returns a bare "returned N" with zero context.
+export function findNthAssert(source: string, retVal: number): string {
+  if (retVal === -1) return "exception caught in test body";
+  const idx = retVal - 1;
+  if (idx < 1) return `early return (${retVal})`;
+
+  const lines = source.split("\n");
+  const assertStarts: { line: number; text: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (ASSERT_LINE_RE.test(lines[i])) {
+      assertStarts.push({ line: i + 1, text: extractFullAssert(lines, i) });
+    }
+  }
+
+  const target = idx - 1;
+  if (target >= 0 && target < assertStarts.length) {
+    const a = assertStarts[target];
+    return `assert #${idx} at L${a.line}: ${a.text}`;
+  }
+  // The assertion counter counts every *executed* assert (including those in
+  // loops and helper functions), so it can outrun the static source-line scan.
+  // When it does, anchor on the LAST assertion in the file — most test262
+  // failures land on the final check — so the diagnostic still points at a
+  // concrete assertion instead of a bare count.
+  if (assertStarts.length > 0) {
+    const a = assertStarts[assertStarts.length - 1];
+    return `assert #${idx} (counter exceeded ${assertStarts.length} source asserts; last at L${a.line}: ${a.text})`;
+  }
+  return `assert #${idx} (no assert/verify call found in source — likely a loop body or helper-internal check)`;
+}

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -15,6 +15,7 @@ import { dirname, join, relative } from "path";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { availableParallelism } from "os";
 import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
+import { findNthAssert } from "./test262-assert-locator.js";
 import {
   buildNegativeCompileSource,
   classifyError,
@@ -275,30 +276,9 @@ function adjustErrorLines(msg: string, offset: number): string {
   });
 }
 
-function findNthAssert(source: string, retVal: number): string {
-  if (retVal === -1) return "exception caught in test body";
-  const idx = retVal - 1;
-  if (idx < 1) return `early return (${retVal})`;
-
-  const lines = source.split("\n");
-  const assertStarts: { line: number; text: string }[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (/^\s*(assert\b|assert\.\w+|\$DONOTEVALUATE|verify\w+)/.test(lines[i])) {
-      const text = lines
-        .slice(i, Math.min(i + 3, lines.length))
-        .join(" ")
-        .trim();
-      assertStarts.push({ line: i + 1, text: text.substring(0, 120) });
-    }
-  }
-
-  const target = idx - 1;
-  if (target >= 0 && target < assertStarts.length) {
-    const a = assertStarts[target];
-    return `assert #${idx} at L${a.line}: ${a.text}`;
-  }
-  return `assert #${idx} (found ${assertStarts.length} asserts in source)`;
-}
+// findNthAssert / extractFullAssert moved to ./test262-assert-locator (#1318):
+// shared with the legacy vitest runner and unit-testable without the
+// result-file side effects this module performs at import time.
 
 // ── Test generation ─────────────────────────────────────────────────
 

--- a/tests/test262-vitest.test.ts
+++ b/tests/test262-vitest.test.ts
@@ -15,6 +15,7 @@ process.on("unhandledRejection", () => {});
 import { createHash } from "crypto";
 import { join, relative, dirname, basename } from "path";
 import { buildImports } from "../src/runtime.js";
+import { findNthAssert } from "./test262-assert-locator.js";
 // Lazy-load compileMulti only when needed (FIXTURE tests) to avoid
 // loading the full compiler into the fork alongside the pool worker.
 let _compileMulti: typeof import("../src/index.js").compileMulti | null = null;
@@ -474,30 +475,7 @@ function adjustErrorLines(msg: string, offset: number): string {
   });
 }
 
-function findNthAssert(source: string, retVal: number): string {
-  if (retVal === -1) return "exception caught in test body";
-  const idx = retVal - 1;
-  if (idx < 1) return `early return (${retVal})`;
-
-  const lines = source.split("\n");
-  const assertStarts: { line: number; text: string }[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (/\b(assert|verify\w+)\b/.test(lines[i])) {
-      const text = lines
-        .slice(i, Math.min(i + 3, lines.length))
-        .join(" ")
-        .trim();
-      assertStarts.push({ line: i + 1, text: text.substring(0, 120) });
-    }
-  }
-
-  const target = idx - 1;
-  if (target >= 0 && target < assertStarts.length) {
-    const a = assertStarts[target];
-    return `assert #${idx} at L${a.line}: ${a.text}`;
-  }
-  return `assert #${idx} (found ${assertStarts.length} asserts in source)`;
-}
+// findNthAssert moved to ./test262-assert-locator (#1318).
 
 // ── Test generation ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The first #1318 fix (commit 39fa6ef3f) only improved the `runTest262File` smoke-test path. The **sharded CI runner** (`tests/test262-shared.ts`, driven by the `test262-chunk*.test.ts` files that generate the live conformance JSONL) and the legacy `tests/test262-vitest.test.ts` still used the old `findNthAssert`: a 120-char cap, a narrow `assert|verify\w+` regex, and a bare `returned N (found M asserts in source)` fallback. That path is what produces the ~8,900 vague `assertion_fail` entries.

Extracted the locator into `tests/test262-assert-locator.ts` (side-effect-free, unit-testable) and consume it from both runners:

- `extractFullAssert` balances parens across lines, capturing the full `assert.sameValue(actual, expected, "message")` call — including the message argument `wrapTest` strips from the compiled body but is still in the source. Cap raised 120 → 500.
- Broadened the assert-detection regex to also match `assert.*`, `compareArray`, `$DONOTEVALUATE`, and `throw new Test262Error`.
- When the executed-assert counter outruns the static source scan (loops, helper-internal asserts), anchor on the **last** assertion instead of a bare `returned N`. The `returned N —` prefix is preserved so `classifyError` bucketing is unchanged (still `assertion_fail`).

This is a test-harness diagnostics change only — no compiler/runtime code touched, so test262 pass/fail counts are unaffected; only the `error` text of existing failures gets richer.

## Test plan

- [x] `tests/issue-1318-locator.test.ts` — 10 new cases (findNthAssert + extractFullAssert)
- [x] Existing `tests/issue-1318.test.ts` (Part 1 / runTest262File path) stays green
- [x] `tsc --noEmit` clean on touched files
- [ ] CI sharded test262 run shows no regression in pass/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)