### PR TITLE
fix(#1610): for-of over non-array iterables no longer rejected

### DIFF
--- a/plan/issues/1610-for-of-requires-array-expression.md
+++ b/plan/issues/1610-for-of-requires-array-expression.md
@@ -1,9 +1,10 @@
 ---
 id: 1610
 title: "codegen: for-of over non-array iterables rejected ('for-of requires an array expression')"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 task_type: feature
@@ -48,3 +49,38 @@ for-of across the corpus.
 - for-of over a non-array iterable compiles and iterates via the iterator
   protocol.
 - >=10 of the 13 tests move off `compile_error`.
+
+## Root cause (confirmed)
+
+`compileForOfStatement` (`src/codegen/statements/loops.ts`) branched on the TS
+type symbol name being `Array` and committed unconditionally to
+`compileForOfArray`, which throws "for-of requires an array expression" when the
+iterand does not lower to a vec struct. An Array-typed iterand is necessary but
+not sufficient: a `Symbol.iterator` whose declared return widens to `Array`, an
+array-subclass instance, or a union can carry the `Array` symbol yet not lower
+to a vec struct, so the loop hard-errored instead of using the (already-present)
+iterator-protocol fallback `compileForOfIterator`.
+
+## Fix
+
+Route both branches through the existing `compileForOfArrayTentative` gate: it
+tentatively compiles the expression and only takes the fast vec-struct array
+path when the result is genuinely a vec struct; otherwise it falls through to
+`compileForOfIterator`. The `isArray` symbol-name shortcut is removed. The array
+path is unchanged for real arrays (it already re-compiled the expression).
+
+## Test Results
+
+`tests/equivalence/issue-1610.test.ts` (4 tests) + existing for-of/iterator
+equivalence suites — all green:
+- array fast path (vec struct) — PASS
+- for-of over Set — PASS
+- for-of over custom `[Symbol.iterator]` object — PASS
+- for-of over generator result — PASS
+- for-of-basic, for-of-generator, for-of-array-destructuring,
+  iterator-protocol-custom, symbol-iterator-class,
+  for-of-assign-destructuring-primitive — all PASS (37 tests total)
+
+Out of scope: `for (const [k,v] of map)` returns only the last entry — a
+pre-existing Map `@@iterator` semantics gap tracked under #1103, not regressed
+by this change (the loop now runs without a compile error).

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -2205,18 +2205,15 @@ export function compileForOfStatement(ctx: CodegenContext, fctx: FunctionContext
     return;
   }
 
-  const sym = (exprTsType as ts.TypeReference).symbol ?? (exprTsType as ts.Type).symbol;
-  const isArray = sym?.name === "Array";
-
-  if (isArray) {
-    compileForOfArray(ctx, fctx, stmt);
-  } else {
-    // Type checker didn't resolve as Array — tentatively compile the expression
-    // to check if it produces a vec struct (e.g. tuple types, union types, etc.).
-    // If so, use the efficient array path; otherwise fall back to host iterator.
-    if (!compileForOfArrayTentative(ctx, fctx, stmt)) {
-      compileForOfIterator(ctx, fctx, stmt);
-    }
+  // The TS type resolving to `Array` is necessary but NOT sufficient to use the
+  // fast vec-struct array path: an Array-typed iterable can still lower to a
+  // non-vec value (a Symbol.iterator whose declared return widens to Array, an
+  // array-subclass instance, a union). Tentatively compile the expression and
+  // only take the array path when it genuinely produces a vec struct; otherwise
+  // fall back to the iterator protocol instead of hard-erroring with
+  // "for-of requires an array expression" (#1610).
+  if (!compileForOfArrayTentative(ctx, fctx, stmt)) {
+    compileForOfIterator(ctx, fctx, stmt);
   }
 }
 

--- a/tests/equivalence/issue-1610.test.ts
+++ b/tests/equivalence/issue-1610.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+describe("#1610 for-of over non-array iterables", () => {
+  it("array fast path still works", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        let sum = 0;
+        for (const x of [1, 2, 3]) sum += x;
+        return sum;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("for-of over Set", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const s = new Set<number>();
+        s.add(1); s.add(2); s.add(3);
+        let sum = 0;
+        for (const x of s) sum += x;
+        return sum;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("for-of over a custom Symbol.iterator object", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const obj = {
+          [Symbol.iterator]() {
+            let i = 0;
+            return {
+              next() {
+                return i < 3
+                  ? { value: i++, done: false }
+                  : { value: undefined, done: true };
+              },
+            };
+          },
+        };
+        let sum = 0;
+        for (const x of obj) sum += x as number;
+        return sum;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("for-of over a generator result", async () => {
+    await assertEquivalent(
+      `function* gen(): Generator<number> { yield 5; yield 7; }
+      export function test(): number {
+        let sum = 0;
+        for (const x of gen()) sum += x;
+        return sum;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `compileForOfStatement` committed unconditionally to the vec-struct array path whenever the iterand's TS type symbol was named `Array`, hard-erroring with "for-of requires an array expression" when it did not actually lower to a vec struct (a `Symbol.iterator` widening to `Array`, an array-subclass instance, a union).
- Route both branches through the existing `compileForOfArrayTentative` gate, which only takes the fast array path when the expression genuinely produces a vec struct and otherwise falls back to the existing iterator-protocol lowering (`compileForOfIterator`).
- The array fast path is unchanged for real arrays.

Fixes #1610.

## Test plan
- [x] `tests/equivalence/issue-1610.test.ts` — array fast path, Set, custom `[Symbol.iterator]` object, generator result (4/4 pass)
- [x] Existing for-of/iterator equivalence suites green: for-of-basic, for-of-generator, for-of-array-destructuring, iterator-protocol-custom, symbol-iterator-class, for-of-assign-destructuring-primitive (37 tests)
- [x] `npx tsc --noEmit` clean
- [ ] CI test262 regression gate

Out of scope: `for (const [k,v] of map)` still returns only the last entry — a pre-existing Map `@@iterator` semantics gap (#1103), not regressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)