### PR TITLE
fix(#1658): apply optional-param default in inlined calls

### DIFF
--- a/plan/issues/1658-destructured-function-param-default-not-applied.md
+++ b/plan/issues/1658-destructured-function-param-default-not-applied.md
@@ -1,10 +1,11 @@
 ---
 id: 1658
 title: "Destructured/scalar function-parameter default not applied (returns wrong value)"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -63,3 +64,36 @@ runtime is correct. This issue is the opposite: the real runtime is **wrong**.)
   full `tests/equivalence/` suite (it OOMs in the runner). See **#1659** for the
   CI coverage gap; until that lands, this regression class is invisible to CI and
   must be validated locally.
+
+## Root cause & fix (2026-05-27)
+
+The actual failure was the **scalar** path, not destructuring: `process(5)`
+returned `5` (default `y = 10` dropped), so `process(5) + process(5, 20)` gave
+`5 + 25 = 30` instead of `15 + 25 = 40`.
+
+The call to `process` was **inlined** at the call site. The call-site inliner in
+`src/codegen/expressions/calls.ts` (the `ctx.inlinableFunctions` branch) padded a
+missing optional parameter with `pushDefaultValue` (which emits `f64.const 0` /
+`ref.null`), ignoring the parameter's registered default. The non-inlined direct
+call path correctly consults `ctx.funcOptionalParams` and uses `pushParamSentinel`
+(emits the inlined constant default, or the sNaN sentinel that the inlined
+prologue checks for expression defaults).
+
+**Fix:** in the inline path, look up `ctx.funcOptionalParams.get(funcName)` for the
+missing index and call `pushParamSentinel` (falling back to `pushDefaultValue` for
+non-optional padding). This mirrors the direct-call path so both constant and
+expression defaults fire under inlining.
+
+Regression test: `tests/issue-1658.test.ts` (scalar constant default fires/not-fired,
+expression default through inline path, multiple omitted defaults).
+
+## Test Results
+
+- `tests/issue-1658.test.ts` — 4/4 pass
+- `tests/equivalence/destructuring-extended.test.ts` — 4/4 pass (target case returns 40)
+- Inline/default regression set (`default-params`, `inline-small-functions`,
+  `array-inline-return`, `issue-1025-param-default-null`, `issue-43-assign-dstr-defaults`,
+  `fn-param-dstr-rest-in-rest`, `issue-1372-ir-destructuring-params`,
+  `issue-1374-ir-string-iter-inline`) — all pass.
+- `tests/math-inline.test.ts` has 6 pre-existing failures **on base** (unrelated
+  host-import harness issue) — unchanged by this fix.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7287,12 +7287,23 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     const inlineInfo = ctx.inlinableFunctions.get(funcName);
     if (inlineInfo && !expr.arguments.some((a: any) => ts.isSpreadElement(a))) {
       // Inline the function body: compile arguments into temp locals, then emit body
+      const inlineOptInfo = ctx.funcOptionalParams.get(funcName);
       const argLocals: number[] = [];
       for (let i = 0; i < inlineInfo.paramCount; i++) {
         if (i < expr.arguments.length) {
           compileExpression(ctx, fctx, expr.arguments[i]!, inlineInfo.paramTypes[i]);
         } else {
-          pushDefaultValue(fctx, inlineInfo.paramTypes[i]!, ctx);
+          // #1658: a missing optional param must receive its default — either the
+          // inlined constant (callee prologue is skipped for constant defaults) or
+          // the sNaN sentinel that the inlined prologue checks for expression
+          // defaults. pushDefaultValue alone emits 0/ref.null and silently drops
+          // the default.
+          const opt = inlineOptInfo?.find((o) => o.index === i);
+          if (opt) {
+            pushParamSentinel(fctx, inlineInfo.paramTypes[i]!, ctx, opt);
+          } else {
+            pushDefaultValue(fctx, inlineInfo.paramTypes[i]!, ctx);
+          }
         }
         const tmpLocal = allocLocal(
           fctx,

--- a/tests/issue-1658.test.ts
+++ b/tests/issue-1658.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+// #1658: a missing optional function-parameter default was dropped when the
+// call was inlined — the inliner padded the missing slot with 0/ref.null
+// instead of the parameter's constant/expression default.
+describe("issue-1658: inlined-call optional-parameter defaults", () => {
+  it("scalar constant default fires when arg omitted", async () => {
+    await assertEquivalent(
+      `
+      function process(x: number, y: number = 10): number {
+        return x + y;
+      }
+      export function test(): number {
+        return process(5) + process(5, 20);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("scalar constant default not applied when arg provided", async () => {
+    await assertEquivalent(
+      `
+      function f(x: number, y: number = 10): number {
+        return x + y;
+      }
+      export function test(): number {
+        return f(1, 99);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("expression default fires through inline path", async () => {
+    await assertEquivalent(
+      `
+      function g(x: number, y: number = x * 2): number {
+        return x + y;
+      }
+      export function test(): number {
+        return g(3) + g(3, 1);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("multiple omitted defaults", async () => {
+    await assertEquivalent(
+      `
+      function h(a: number, b: number = 2, c: number = 3): number {
+        return a * 100 + b * 10 + c;
+      }
+      export function test(): number {
+        return h(1) + h(1, 5) + h(1, 5, 7);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- The call-site inliner (`ctx.inlinableFunctions` branch in `src/codegen/expressions/calls.ts`) padded a missing optional parameter with `pushDefaultValue` (emits `f64.const 0` / `ref.null`), silently dropping the parameter's registered default.
- Result: `process(5)` returned `5` instead of `15`, so `process(5) + process(5, 20)` gave `30` instead of `40` (the `tests/equivalence/destructuring-extended.test.ts` "destructured function parameters with defaults" case).
- Fix: in the inline path, consult `ctx.funcOptionalParams` for the missing index and use `pushParamSentinel` — emits the inlined constant default, or the sNaN sentinel that the inlined prologue checks for expression defaults. This mirrors the non-inlined direct-call path so both constant and expression defaults fire under inlining.

## Test plan
- [x] `tests/issue-1658.test.ts` (new) — scalar constant default fires when omitted / not when provided, expression default through inline path, multiple omitted defaults — 4/4 pass
- [x] `tests/equivalence/destructuring-extended.test.ts` — 4/4 pass (target case now returns 40)
- [x] Inline/default regression set (default-params, inline-small-functions, array-inline-return, issue-1025-param-default-null, issue-43-assign-dstr-defaults, fn-param-dstr-rest-in-rest, issue-1372/1374) — all pass
- [x] `npx tsc --noEmit` clean
- Note: `tests/math-inline.test.ts` has 6 pre-existing failures **on base** (unrelated host-import harness issue), unchanged by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)