### PR TITLE
fix(#1331): dispatch RegExp @@split protocol on any-typed receivers

### DIFF
--- a/plan/issues/1331-regexp-symbol-split-protocol-spec-compliance.md
+++ b/plan/issues/1331-regexp-symbol-split-protocol-spec-compliance.md
@@ -1,9 +1,10 @@
 ---
 id: 1331
 title: "RegExp host-mode: Symbol.split protocol spec compliance (123 fails)"
-status: ready
+status: done
 created: 2026-05-08
-updated: 2026-05-08
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -103,3 +104,46 @@ Note for the dev: there is no `RegExpExec` helper in this codebase — V8 *is* t
 ### Test files to verify
 - `tests/equivalence/regexp-methods.test.ts` — add cases: `"a,b,c".split(/,/)` returns `["a","b","c"]`; `"abcde".split(/x/iy)` species-ctor receiver; split with limit.
 - Re-run test262 buckets `built-ins/RegExp/prototype/Symbol.split/*` and `built-ins/String/prototype/split/*`.
+
+## Test Results (2026-05-27)
+
+Much of the originally-specced infrastructure had already landed via #1443
+(`collectStringMethodImports` union/non-string-like detection), #1433/#1467
+(`__box_symbol` plumbing) and #1439 (`__regex_symbol_call` host dispatch).
+A probe of the live compiler showed these already pass:
+
+- `"a,b,c".split(",")` → `"a|b|c"`
+- `"a1b2c".split(/\d/)` → `"a|b|c"` (literal regex separator)
+- `const re=/\d/; "a1b2c".split(re)` → `"a|b|c"` (var regex separator)
+- `"a1b2c3d".split(/\d/, 2)` → `"a|b"` (limit)
+- `RegExp.prototype[Symbol.split].call(re, str)` → works
+
+### Remaining gap fixed here
+`(re as any)[Symbol.split](str)` returned `undefined`. The element-access
+protocol dispatch in `compileCallExpression` (calls.ts) gated
+`__regex_symbol_call` on the receiver being a *statically-known* RegExp
+(`recvSym === "RegExp"`). When the receiver type is `any`/`unknown`
+(cast, parameter slot, or a base that loses its type) the dispatch fell
+through and produced `undefined`.
+
+**Fix**: broaden the gate to also fire for `any`/`unknown` receiver types,
+while still excluding user-defined wasm classes (which use
+`ClassName_method` dispatch) and the `@@iterator`/`@@asyncIterator` cases
+(handled earlier). The host helper `__regex_symbol_call` performs a fully
+dynamic `recv[Symbol.X](args)` lookup, so routing here is correct for any
+object implementing the well-known symbol method — not just RegExp.
+Also wrapped the `@@split` limit arg (arg1) in the runtime so a wasmGC
+struct limit reaches the host's ToUint32 ToPrimitive (matches the
+`@@replace` arg handling).
+
+### Files changed
+- `src/codegen/expressions/calls.ts` — broaden `isRegExpRecv` → also `any`/`unknown`, exclude user classes.
+- `src/runtime.ts` — wrap `@@split` arg1 (limit) via `wrapCallable` for struct ToPrimitive.
+- `tests/equivalence/regexp-methods.test.ts` — 6 new dispatch cases (all pass).
+
+### Verification
+- `regexp-methods.test.ts`: 22/22 pass.
+- `string-methods.test.ts` + `ir-slice10-extern-regexp.test.ts`: 47/47 pass.
+- iterator/spread/for-of suites: no regressions.
+- 3 `symbol-basic.test.ts` failures confirmed **pre-existing on main**
+  (reproduced with clean main sources; unrelated to this change).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8111,13 +8111,26 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         };
         const protocolId = REGEX_SYMBOL_METHODS[methodName];
         if (protocolId !== undefined) {
-          // Receiver must be RegExp (or `any` when types aren't resolved).
-          // Keep the dispatch narrow to RegExp to avoid catching unrelated
-          // `obj[Symbol.iterator]`-style calls (already handled above) or
-          // user classes that define their own @@match etc.
+          // Receiver is RegExp, or its static type is unresolvable (`any` /
+          // `unknown`) so we cannot prove it is *not* a RegExp. The latter
+          // covers `(re as any)[Symbol.split](str)`, a RegExp stored in an
+          // `any`/parameter slot, and `RegExp.prototype[Symbol.split]`
+          // accessed off a base that loses its type (#1331). In all these
+          // cases the host helper `__regex_symbol_call` does a fully dynamic
+          // `recv[Symbol.X](args)` lookup, so routing here is correct for any
+          // object that implements the well-known symbol method — not just
+          // RegExp. We must NOT catch receivers that resolve to a user-defined
+          // wasm class (handled by the ClassName_method dispatch below) or the
+          // `@@iterator`/`@@asyncIterator` cases (already handled above).
           const recvSym = receiverType.getSymbol()?.name;
           const isRegExpRecv = recvSym === "RegExp" || recvSym === "RegExpConstructor";
-          if (isRegExpRecv) {
+          let resolvedClassName = receiverType.getSymbol()?.name;
+          if (resolvedClassName && !ctx.classSet.has(resolvedClassName)) {
+            resolvedClassName = ctx.classExprNameMap.get(resolvedClassName) ?? resolvedClassName;
+          }
+          const recvIsUserClass = !!resolvedClassName && ctx.classSet.has(resolvedClassName);
+          const recvIsUnresolved = (receiverType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+          if ((isRegExpRecv || recvIsUnresolved) && !recvIsUserClass) {
             // Push receiver as externref (already a RegExp host object)
             const recvType = compileExpression(ctx, fctx, elemAccess.expression);
             if (recvType) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4759,7 +4759,10 @@ assert._isSameValue = isSameValue;
             // so the spec default 2^32-1 applies. JS `splitter.call(rx, S, null)`
             // would coerce null to 0 and return [] — wrong.
             if (arg1 == null) return fn.call(regex, wrappedArg0);
-            return fn.call(regex, wrappedArg0, arg1);
+            // The limit goes through ToUint32 → ToNumber → ToPrimitive; when
+            // it's a wasmGC struct (e.g. `{valueOf(){…}}`), wrap it so the
+            // host proxy exposes the struct's valueOf/toString closure (#1331).
+            return fn.call(regex, wrappedArg0, wrapCallable(arg1));
           }
           // Generic fallback
           if (arg1 == null) return fn.call(regex, wrappedArg0);

--- a/tests/equivalence/regexp-methods.test.ts
+++ b/tests/equivalence/regexp-methods.test.ts
@@ -203,4 +203,71 @@ describe("RegExp methods equivalence", () => {
   // Note: String.split() is tested in string-methods.test.ts.
   // The host import returns externref arrays which currently trigger
   // ref.cast issues when accessing .length, so we skip split here.
+
+  // --- RegExp.prototype[Symbol.split] protocol dispatch (#1331) ---
+
+  it("re[Symbol.split](str) dispatches through the @@split protocol", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        const re = /\\d/;
+        return (re as any)[Symbol.split]("a1b2c").join("|");
+      }
+    `),
+    ).toBe("a|b|c");
+  });
+
+  it("re[Symbol.split] on an any-typed receiver still dispatches", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        const re: any = /\\d/;
+        return re[Symbol.split]("x9y8z").join("|");
+      }
+    `),
+    ).toBe("x|y|z");
+  });
+
+  it("RegExp.prototype[Symbol.split].call(re, str) dispatches", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        const re = /\\d/;
+        return (RegExp.prototype as any)[Symbol.split].call(re, "a1b2c").join("|");
+      }
+    `),
+    ).toBe("a|b|c");
+  });
+
+  it("re[Symbol.match] on an any-typed receiver dispatches", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        const re: any = /\\d+/;
+        const m = re[Symbol.match]("a123b");
+        return m ? m[0] : "none";
+      }
+    `),
+    ).toBe("123");
+  });
+
+  it("String.prototype.split with a literal regex separator", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        return "a1b2c".split(/\\d/).join("|");
+      }
+    `),
+    ).toBe("a|b|c");
+  });
+
+  it("String.prototype.split with a regex separator and limit", async () => {
+    expect(
+      await run(`
+      export function main(): string {
+        return "a1b2c3d".split(/\\d/, 2).join("|");
+      }
+    `),
+    ).toBe("a|b");
+  });
 });


### PR DESCRIPTION
## Summary
- `(re as any)[Symbol.split](str)` returned `undefined` — the element-access protocol dispatch (`__regex_symbol_call`) was gated on a *statically-known* RegExp receiver. When the receiver type is `any`/`unknown` (cast, parameter slot, or a base that loses its type) it fell through to the null-pushing fallback.
- Broaden the gate to also fire for `any`/`unknown` receivers while still excluding user-defined wasm classes (which use `ClassName_method` dispatch) and `@@iterator`/`@@asyncIterator` (handled earlier). The host helper does a fully dynamic `recv[Symbol.X](args)` lookup, so this is correct for any object implementing the well-known symbol method.
- Wrap the `@@split` limit arg in the runtime so a wasmGC struct limit reaches the host's ToUint32 ToPrimitive (matches `@@replace`).

Most of the originally-specced infrastructure (#1443 string-method import gating, #1433/#1467 `__box_symbol`, #1439 `__regex_symbol_call`) had already landed; this closes the remaining `any`-typed-receiver dispatch gap.

## Test plan
- [x] `tests/equivalence/regexp-methods.test.ts` — 6 new dispatch cases, 22/22 pass
- [x] `string-methods.test.ts` + `ir-slice10-extern-regexp.test.ts` — 47/47 pass
- [x] iterator/spread/for-of suites — no regressions
- [x] `npx tsc --noEmit` clean
- [x] 3 `symbol-basic.test.ts` failures confirmed pre-existing on main (reproduced with clean sources, unrelated)
- [ ] CI test262 conformance (RegExp/Symbol.split + String/split buckets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)