### PR TITLE
fix(#1658): apply parameter default in call-site inlining path

### DIFF
--- a/plan/issues/1658-destructured-function-param-default-not-applied.md
+++ b/plan/issues/1658-destructured-function-param-default-not-applied.md
@@ -1,10 +1,11 @@
 ---
 id: 1658
 title: "Destructured/scalar function-parameter default not applied (returns wrong value)"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -63,3 +64,25 @@ runtime is correct. This issue is the opposite: the real runtime is **wrong**.)
   full `tests/equivalence/` suite (it OOMs in the runner). See **#1659** for the
   CI coverage gap; until that lands, this regression class is invisible to CI and
   must be validated locally.
+
+## Root cause & fix
+
+The failure was in the **call-site inlining** path, not the destructuring step.
+`process` is a small expression-shaped function, so `registerInlinableFunction`
+marks it inlinable. For a **constant** parameter default (e.g. `y = 10`), the
+callee-side default guard is elided entirely (#869) — the caller is responsible
+for materializing the default. But the inline path
+(`src/codegen/expressions/calls.ts`) padded any missing argument with
+`pushDefaultValue` (a plain `f64.const 0`), ignoring the declared default. So
+`process(5)` inlined to `y = 0` instead of `y = 10`, and the suite returned 30
+instead of 40.
+
+Fix: in the inline path, consult `ctx.funcOptionalParams` for the callee and,
+when an argument is missing OR an explicit `undefined`-like literal, emit the
+recorded default via `pushParamSentinel(..., optEntry)` (which yields the
+constant value for constant defaults). Expression defaults can't reach this path
+— their callee guard emits an `if`/`local.set`, which `INLINE_DISALLOWED_OPS`
+already excludes from inlining.
+
+Regression test: `tests/issue-1658.test.ts` (scalar omitted, explicit
+`undefined`, default-of-0, and multiple trailing defaults).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7286,11 +7286,29 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     // Check if this function is eligible for call-site inlining
     const inlineInfo = ctx.inlinableFunctions.get(funcName);
     if (inlineInfo && !expr.arguments.some((a: any) => ts.isSpreadElement(a))) {
-      // Inline the function body: compile arguments into temp locals, then emit body
+      // Inline the function body: compile arguments into temp locals, then emit body.
+      // #1658: an inlinable callee has had its callee-side default guard elided —
+      // for constant defaults the guard is skipped entirely (#869), and the body
+      // is too small to carry one — so the caller MUST materialize the parameter
+      // default here. Look up the callee's optional-param table and, when an
+      // argument is missing OR an explicit `undefined`-like literal, emit the
+      // recorded default (constant value, or sNaN/undefined sentinel) instead of a
+      // plain zero. `pushParamSentinel` already encodes that choice via optInfo.
+      const inlineOptInfo = ctx.funcOptionalParams.get(funcName);
       const argLocals: number[] = [];
       for (let i = 0; i < inlineInfo.paramCount; i++) {
-        if (i < expr.arguments.length) {
-          compileExpression(ctx, fctx, expr.arguments[i]!, inlineInfo.paramTypes[i]);
+        const optEntry = inlineOptInfo?.find((o) => o.index === i);
+        const providedArg = i < expr.arguments.length ? expr.arguments[i]! : undefined;
+        const argIsUndefinedLike =
+          providedArg !== undefined &&
+          (providedArg.kind === ts.SyntaxKind.UndefinedKeyword ||
+            (ts.isIdentifier(providedArg) && providedArg.text === "undefined") ||
+            providedArg.kind === ts.SyntaxKind.VoidExpression);
+        if (providedArg !== undefined && !(optEntry && argIsUndefinedLike)) {
+          compileExpression(ctx, fctx, providedArg, inlineInfo.paramTypes[i]);
+        } else if (optEntry) {
+          // Missing arg, or explicit `undefined` with a default → apply the default.
+          pushParamSentinel(fctx, inlineInfo.paramTypes[i]!, ctx, optEntry);
         } else {
           pushDefaultValue(fctx, inlineInfo.paramTypes[i]!, ctx);
         }

--- a/tests/issue-1658.test.ts
+++ b/tests/issue-1658.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+// #1658 — function-parameter default not applied (returns wrong value).
+// An inlinable callee has its callee-side default guard elided (#869), so the
+// caller must materialize the parameter default at the (inlined) call site.
+// Before the fix, a missing arg got a plain f64 0 instead of the declared
+// default, so `process(5)` returned 5 (not 15) and the suite returned 30 not 40.
+describe("#1658 function-parameter defaults", () => {
+  it("scalar default fires when the trailing arg is omitted", async () => {
+    await assertEquivalent(
+      `
+      function process(x: number, y: number = 10): number {
+        return x + y;
+      }
+      export function test(): number {
+        return process(5) + process(5, 20);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("scalar default fires for explicit undefined", async () => {
+    await assertEquivalent(
+      `
+      function f(x: number, y: number = 42): number {
+        return x + y;
+      }
+      export function omitted(): number { return f(1); }
+      export function explicitUndef(): number { return f(1, undefined); }
+      export function provided(): number { return f(1, 0); }
+      `,
+      [
+        { fn: "omitted", args: [] },
+        { fn: "explicitUndef", args: [] },
+        { fn: "provided", args: [] },
+      ],
+    );
+  });
+
+  it("default of 0 is still applied (not skipped) when arg omitted", async () => {
+    await assertEquivalent(
+      `
+      function g(x: number, y: number = 0): number {
+        return x * 10 + y;
+      }
+      export function test(): number {
+        return g(3) + g(3, 7);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("multiple trailing defaults", async () => {
+    await assertEquivalent(
+      `
+      function h(a: number, b: number = 2, c: number = 3): number {
+        return a + b + c;
+      }
+      export function test(): number {
+        return h(1) + h(1, 20) + h(1, 20, 30);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #1658 — a function-parameter default was not applied when the callee was inlined, so `process(5)` returned 5 (not 15) and the `tests/equivalence/destructuring-extended.test.ts` "destructured function parameters with defaults" case returned **30** instead of **40**.

## Root cause
A small expression-shaped function with a **constant** parameter default (`function f(x, y = 10)`) is marked inlinable by `registerInlinableFunction`. For constant defaults the callee-side default guard is elided (#869), so the caller must materialize the default. The inline path in `src/codegen/expressions/calls.ts` padded missing args with a plain `pushDefaultValue` (`f64.const 0`), ignoring the declared default → `f(5)` inlined to `y = 0`.

## Fix
In the inline path, consult `ctx.funcOptionalParams` for the callee. When an argument is **missing** OR an explicit **`undefined`-like literal**, emit the recorded default via `pushParamSentinel(..., optEntry)` (which yields the constant value for constant defaults). Expression defaults can't reach this path — their callee guard emits an `if`/`local.set`, which `INLINE_DISALLOWED_OPS` already excludes from inlining.

## Test plan
- [x] `tests/issue-1658.test.ts` — scalar omitted, explicit `undefined`, default-of-0, multiple trailing defaults (4 pass)
- [x] `tests/equivalence/destructuring-extended.test.ts` now returns 40 (4 pass)
- [x] No new regressions: pre-existing failures in `arrow-call-apply`, `null-destructure-param-object`, tagged-template, `destructuring-initializer` are identical with and without this change (verified via stash A/B)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)