### PR TITLE
fix(#1552): catch destructuring — empty-pattern coercibility + rest non-enum

### DIFF
--- a/plan/issues/1552-spec-gap-try-catch-parameter-destructuring.md
+++ b/plan/issues/1552-spec-gap-try-catch-parameter-destructuring.md
@@ -1,9 +1,10 @@
 ---
 id: 1552
 title: "spec gap: catch parameter destructuring (`try/dstr`) — share dstr-binding helper with function decls"
-status: ready
+status: done
 created: 2026-05-20
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: easy
 reasoning_effort: high
@@ -184,3 +185,38 @@ land them first to maximise ripple.
 
 - `catch` clause without binding (`catch { ... }`) — already supported.
 - `try { } catch(e) { } finally { }` completion semantics — separate issue.
+
+## Resolution (2026-05-27)
+
+Most of the 58 fails had already resolved as ripple from the sibling issues
+(#1450 fn-name, #1454 iterator protocol, #1550 init-skipped) landing — the
+catch path was already routing non-empty patterns through the shared
+`compileExternrefObjectDestructuringDecl` / `compileExternrefArrayDestructuring-
+Decl` helpers. Re-running `test/language/statements/try/dstr/` (93 files) found
+**92 pass, 1 CE** before this PR. The lone remaining CE
+(`ary-ptrn-elem-id-iter-val-array-prototype.js`) is a TypeScript type-check
+error from assigning a generator to `Array.prototype[Symbol.iterator]` — a
+shared iterator-override typing gap, not catch-specific.
+
+Two real behavioural gaps remained, fixed here:
+
+1. **Object-rest non-enumerable leak** (`src/runtime.ts` `__extern_rest_object`):
+   for WasmGC-struct sources the struct-field and sidecar copy loops did not
+   consult the sidecar property-descriptor map, so a `defineProperty`-marked
+   non-enumerable own property leaked into `catch ({ ...rest })`. Per
+   ECMA-262 §14.7.4 CopyDataProperties only enumerable own properties are
+   copied. Now filtered via `_wasmPropDescs` / `_SC_ENUMERABLE`. (Also fixes
+   the same leak for `let { ...r } = obj` declarations.)
+
+2. **Empty-pattern RequireObjectCoercible** (`src/codegen/statements/exceptions.ts`):
+   `catch ({})` / `catch ([])` over a thrown `null` / `undefined` must throw
+   TypeError (§8.5.2 / §8.5.3 begin with RequireObjectCoercible / GetIterator).
+   The decl helper deliberately short-circuits empty patterns (to keep
+   `let {} = null` behaviour per #1553c), so the catch path now emits the
+   `emitExternrefDestructureGuard` coercibility check itself for empty
+   patterns. A coercible value (object / array / number) still binds without
+   throwing.
+
+Acceptance criteria 1-6 verified; `tests/issue-1552.test.ts` extended with
+non-enumerable-rest, empty-pattern null/undefined-throw, empty-pattern
+coercible-no-throw, and fn-name cases (15 tests, all green).

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -15,6 +15,7 @@ import {
   compileExternrefObjectDestructuringDecl,
   ensureBindingLocals,
 } from "./destructuring.js";
+import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import { adjustRethrowDepth, restoreBlockScopedShadows, saveBlockScopedShadows } from "./shared.js";
 
 /**
@@ -88,15 +89,31 @@ function compileExternrefCatchDestructure(
   // exceptions.ts before invoking us. They internally store it in a fresh
   // temp local and run the full BindingInitialization algorithm.
   if (ts.isObjectBindingPattern(pattern)) {
+    // (#1552) Empty object pattern `catch ({})` still performs
+    // RequireObjectCoercible per ECMA-262 §8.5.2 BindingInitialization
+    // (`ObjectBindingPattern : { }` runs through CatchParameter binding,
+    // whose value is `thrownValue`). A thrown `null`/`undefined` must raise
+    // TypeError. The decl helper deliberately short-circuits the empty
+    // pattern (to keep `let {} = null` non-throwing, see #1553c), so the
+    // catch path must emit the coercibility guard itself.
+    if (pattern.elements.length === 0) {
+      const tmp = allocLocal(fctx, `__catch_empty_obj_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: tmp });
+      emitExternrefDestructureGuard(ctx, fctx, tmp);
+      return;
+    }
     compileExternrefObjectDestructuringDecl(ctx, fctx, pattern, { kind: "externref" });
     return;
   }
   if (ts.isArrayBindingPattern(pattern)) {
-    // Empty pattern `[]` short-circuits — drop the externref to keep stack
-    // clean. The shared helper also handles empty patterns but emits no-op
-    // bookkeeping; an explicit drop is simpler.
+    // (#1552) Empty array pattern `catch ([])` performs GetIterator on the
+    // thrown value (ECMA-262 §8.5.3), which begins with RequireObjectCoercible
+    // — a thrown `null`/`undefined` must raise TypeError. Emit the same guard
+    // before dropping the value.
     if (pattern.elements.length === 0) {
-      fctx.body.push({ op: "drop" });
+      const tmp = allocLocal(fctx, `__catch_empty_ary_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: tmp });
+      emitExternrefDestructureGuard(ctx, fctx, tmp);
       return;
     }
     compileExternrefArrayDestructuringDecl(ctx, fctx, pattern, { kind: "externref" });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4034,13 +4034,25 @@ assert._isSameValue = isSameValue;
           if (obj == null) return {};
           const excluded = new Set(excludedKeysStr ? String(excludedKeysStr).split(",") : []);
           const result: Record<string, any> = {};
+          // ES §14.7.4 CopyDataProperties copies only ENUMERABLE own properties.
+          // Sidecar descriptors (set via Object.defineProperty) may mark a key
+          // non-enumerable; consult the descriptor map to skip those. Plain
+          // struct fields and sidecar entries without an explicit descriptor
+          // default to enumerable. (#1552)
+          const descs = _isWasmStruct(obj) ? _wasmPropDescs.get(obj) : undefined;
+          const isEnumerable = (key: string): boolean => {
+            if (!descs) return true;
+            const flags = descs.get(_normalizeDescKey(key));
+            if (flags === undefined) return true;
+            return !!(flags & _SC_ENUMERABLE);
+          };
           // For WasmGC structs, use exported getters to read fields
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               for (const key of fieldNames) {
-                if (!excluded.has(key)) {
+                if (!excluded.has(key) && isEnumerable(key)) {
                   const getter = exports?.[`__sget_${key}`];
                   if (typeof getter === "function") result[key] = getter(obj);
                 }
@@ -4055,7 +4067,7 @@ assert._isSameValue = isSameValue;
           const sc = _wasmStructProps.get(obj);
           if (sc) {
             for (const key of Object.keys(sc)) {
-              if (!excluded.has(key) && !(key in result)) result[key] = sc[key];
+              if (!excluded.has(key) && !(key in result) && isEnumerable(key)) result[key] = sc[key];
             }
           }
           return result;

--- a/tests/issue-1552.test.ts
+++ b/tests/issue-1552.test.ts
@@ -54,13 +54,7 @@ describe("issue #1552 — catch parameter destructuring", () => {
     expect(r).toBe("5-0");
   });
 
-  // (#1552 follow-up) — `throw { y: undefined }` stores `y` as ref.null.extern in
-  // the WasmGC struct. The helper's `__extern_is_undefined` check reads the
-  // field via `__sget_y(struct)` which currently returns ref.null.extern, but
-  // `__extern_is_undefined` returns 0 for ref.null.extern (only `=== undefined`
-  // in JS triggers it). Documented gap — tracked for the broader
-  // null-vs-undefined struct-field representation work.
-  it.todo("default IS evaluated when value is undefined", async () => {
+  it("default IS evaluated when value is undefined", async () => {
     const r = await runReturning(`
       let n = 0;
       try { throw { y: undefined } } catch ({ y = ++n }) { return y + '-' + n }
@@ -76,13 +70,11 @@ describe("issue #1552 — catch parameter destructuring", () => {
     expect(r).toBe("1-1");
   });
 
-  // (#1552 follow-up) — `throw null` results in ref.null.extern as the caught
-  // value. The helper's null guard combines `ref.is_null` OR
-  // `__extern_is_undefined(value)` and SHOULD detect ref.null.extern via
-  // ref.is_null. However the empty-pattern object case `catch ({})` doesn't
-  // re-enter the destructuring loop, so we route through the shared helper
-  // which emits the null guard — pending follow-up.
-  it.todo("destructuring `null` throws TypeError", async () => {
+  // Empty patterns still RequireObjectCoercible per ECMA-262 §8.5.2 /
+  // §8.5.3 (the catch path emits the null/undefined guard for `catch ({})`
+  // and `catch ([])` even though the decl path short-circuits empty
+  // patterns to keep `let {} = null` non-throwing, see #1553c).
+  it("destructuring `null` with an empty object pattern throws TypeError", async () => {
     const r = await runReturning(`
       let kind = 'none';
       try {
@@ -93,6 +85,61 @@ describe("issue #1552 — catch parameter destructuring", () => {
       return kind;
     `);
     expect(r).toBe("TypeError");
+  });
+
+  it("destructuring `undefined` with an empty object pattern throws TypeError", async () => {
+    const r = await runReturning(`
+      let kind = 'none';
+      try {
+        try { throw undefined } catch ({}) { /* unreachable */ }
+      } catch (e) {
+        kind = (e && e.name) || String(e);
+      }
+      return kind;
+    `);
+    expect(r).toBe("TypeError");
+  });
+
+  it("destructuring `null` with an empty array pattern throws TypeError", async () => {
+    const r = await runReturning(`
+      let kind = 'none';
+      try {
+        try { throw null } catch ([]) { /* unreachable */ }
+      } catch (e) {
+        kind = (e && e.name) || String(e);
+      }
+      return kind;
+    `);
+    expect(r).toBe("TypeError");
+  });
+
+  it("empty patterns over a coercible value do NOT throw", async () => {
+    expect(
+      await runReturning(`
+      let t = 9; try { try { throw { a: 1 } } catch ({}) { t = 1 } } catch (e) { t = 2 } return t;
+    `),
+    ).toBe(1);
+    expect(
+      await runReturning(`
+      let t = 9; try { try { throw [1, 2] } catch ([]) { t = 1 } } catch (e) { t = 2 } return t;
+    `),
+    ).toBe(1);
+  });
+
+  it("object-rest skips non-enumerable own properties (CopyDataProperties)", async () => {
+    const r = await runReturning(`
+      let o = { a: 1 };
+      Object.defineProperty(o, 'x', { value: 9, enumerable: false });
+      try { throw o } catch ({ ...rest }) { return JSON.stringify(rest) }
+    `);
+    expect(r).toBe(JSON.stringify({ a: 1 }));
+  });
+
+  it("infers fn.name on an anonymous default initializer (#1450)", async () => {
+    const r = await runReturning(`
+      try { throw [] } catch ([fn = function () {}]) { return fn.name }
+    `);
+    expect(r).toBe("fn");
   });
 
   it("rest pattern collects remaining own properties", async () => {


### PR DESCRIPTION
## Summary

Closes #1552. Two spec gaps in `try { } catch (pattern) { }` destructuring
(ECMA-262 §14.15.2 CatchClauseEvaluation step 5 → BindingInitialization on the
thrown value):

1. **Object-rest leaks non-enumerable props** — `catch ({ ...rest })` over a
   WasmGC-struct value copied non-enumerable own properties. `__extern_rest_object`
   now consults the sidecar descriptor map (`_wasmPropDescs` / `_SC_ENUMERABLE`)
   so only enumerable own properties are copied per §14.7.4 CopyDataProperties.
   This also fixes the same leak for `let { ...r } = obj` declarations.

2. **Empty patterns skip RequireObjectCoercible** — `catch ({})` / `catch ([])`
   over a thrown `null` / `undefined` now throw TypeError (§8.5.2 / §8.5.3 begin
   with RequireObjectCoercible / GetIterator). The decl helper short-circuits
   empty patterns (to preserve #1553c `let {} = null` behaviour), so the catch
   path emits `emitExternrefDestructureGuard` itself. Coercible values still bind.

Non-empty catch patterns already routed through the shared `destructureParam*`
helpers (defaults/fn-name/iterator landed via #1450/#1454/#1550), so the bulk of
the 58 `try/dstr` fails were already resolved. Re-running the 93 files in
`test/language/statements/try/dstr/` shows **92 pass, 1 CE** (the lone CE is an
unrelated TypeScript iterator-override typing gap, not catch-specific).

## Test plan

- [x] `tests/issue-1552.test.ts` — 15 cases, all green (promotes two prior
      `it.todo` markers for undefined-default and null-throw; adds non-enum-rest,
      empty-array null-throw, empty-pattern coercible-no-throw, fn-name)
- [x] `tsc --noEmit` clean
- [x] try/catch + rest/destructuring equivalence suites pass (2 pre-existing
      failures in unrelated default-param / nested-default tests confirmed on
      clean main)
- [x] Acceptance criteria 1-6 verified against test262 `try/dstr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)