### PR TITLE
docs(#1595): mark ArrayBuffer.transfer blocked on #1645

### DIFF
--- a/plan/issues/1595-arraybuffer-transfer-methods-not-implemented.md
+++ b/plan/issues/1595-arraybuffer-transfer-methods-not-implemented.md
@@ -1,7 +1,7 @@
 ---
 id: 1595
 title: "ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable not implemented (~40 fails)"
-status: backlog
+status: blocked
 created: 2026-05-24
 updated: 2026-05-24
 priority: medium
@@ -60,3 +60,48 @@ test/built-ins/DataView/prototype/setInt16/immutable-buffer.js
 - Check whether #1351 (resizable ArrayBuffer) overlaps — `transfer` interacts with resizable buffers
 - Our runtime has `ArrayBuffer` host interop via `src/runtime.ts`; the new methods likely need to be added there and exported
 - `transferToImmutable` is the only one that creates a new semantics concept (immutable buffers). May need a flag in the host wrapper.
+
+## Investigation (2026-05-27, dev-1603) — BLOCKED on #1645
+
+The dispatch note in the issue ("delegate to host transfer like resize()") does
+not hold against current main. There is **no host-backed ArrayBuffer and no
+landed `resize` / detach implementation** to mimic:
+
+- `new ArrayBuffer(n)` compiles to a bare WasmGC vec struct `{ length: i32,
+  data: array(i32) }` (`src/codegen/expressions/new-super.ts:2445-2495`). No
+  detach flag, no resizable flag, no `maxByteLength` field.
+- A repo-wide grep for `maxByteLength`, `resizable`, `detached`, `isDetached`,
+  `.resize` in `src/` returns no landed implementation — only construction-site
+  references. So `resize`, `resizable`, `maxByteLength`, and detach state are
+  not yet available on main.
+
+The transfer test262 cases require detach semantics the current representation
+cannot express. e.g. `transfer/from-fixed-to-same.js` asserts after
+`source.transfer()`: `source.byteLength === 0`, `source.slice()` **throws
+TypeError**, `dest.resizable === false`, `dest.maxByteLength === 4`. Detaching
+must make **every** subsequent op on the source (byteLength, slice, TypedArray
+view reads, DataView reads) observe the detached state and throw.
+
+### This is blocked on #1645 (not an independent fix)
+
+**#1645** ("ArrayBuffer resizable + TypedArray detached-buffer guards") is
+`status: in-review` and owns exactly the prerequisite representation work:
+the detach-state field on the ArrayBuffer vec struct plus the detached-buffer
+guards threaded across TypedArray/DataView reads. `transfer` is the operation
+that *produces* a detached buffer, so it must build on #1645's detach
+representation rather than inventing a parallel one.
+
+`transfer` / `transferToFixedLength` reduce to: construct a new buffer, copy
+`min(newLen, oldLen)` bytes, then detach the source via #1645's detach
+primitive. `transferToImmutable` additionally sets an immutable flag that write
+ops must honor.
+
+### Recommended sequencing
+
+1. Land #1645 (resizable + detach-state representation + detached guards).
+2. Dev: implement `transfer` / `transferToFixedLength` (copy + detach source via
+   the #1645 detach primitive; result carries `resizable=false`).
+3. Dev: `transferToImmutable` (immutable flag; write ops throw TypeError).
+
+Marking `status: blocked` (depends on #1645). No source changed; worktree
+`issue-1595-arraybuffer-transfer` left in place (only this doc edit committed).


### PR DESCRIPTION
## Summary
- Investigated #1595 (ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable, ~40 test262 fails).
- The issue's premise ("delegate to host transfer like resize()") does not hold: there is no host-backed ArrayBuffer and no landed resize/detach/resizable/maxByteLength implementation. `new ArrayBuffer(n)` is a bare WasmGC vec struct `{length, data}` with no detach state.
- `transfer` *produces a detached buffer* (source.byteLength→0, source.slice() throws), so it depends on the detach-state representation owned by **#1645** (ArrayBuffer resizable + TypedArray detached-buffer guards, currently `in-review`).
- Marked #1595 `status: blocked` on #1645 and documented recommended sequencing in the issue file. Docs-only change; no source touched.

## Test plan
- [ ] N/A — documentation-only change (issue-file frontmatter + investigation section). CI typecheck/lint suffices.