### PR TITLE
docs(#1672): mark done — implementation already merged via PR #628

### DIFF
--- a/plan/issues/1672-async-gen-method-trampoline-result-wrapping.md
+++ b/plan/issues/1672-async-gen-method-trampoline-result-wrapping.md
@@ -2,7 +2,8 @@
 id: 1672
 title: "async / async-gen object+class method trampolines must return the real result, not null (completes #1671)"
 sprint: 55
-status: in-review
+status: done
+completed: 2026-05-27
 feasibility: hard
 reasoning_effort: max
 depends_on: [1671]


### PR DESCRIPTION
## Summary
- #1672 (async/async-gen method trampolines must return real result) was fully implemented and **merged to main via PR #628** (commit 8f333a178), but its issue file was left at `status: in-review`.
- Per the merged-PR lifecycle rule (a merged PR ⇒ `done`), flip `plan/issues/1672-*.md` to `status: done` + `completed: 2026-05-27`.

This reconciles a stale dispatch: the task queue still pointed at #1672 as if open. No code change — the fix is already on main.

## Test plan
- [ ] Docs-only (one frontmatter field); no source touched.
- [ ] CI green.