### PR TITLE
docs(#1347): reconcile status to done — IteratorClose fix already landed

### DIFF
--- a/plan/issues/1347-spec-gap-for-of-iterator-close-on-throw.md
+++ b/plan/issues/1347-spec-gap-for-of-iterator-close-on-throw.md
@@ -1,9 +1,10 @@
 ---
 id: 1347
 title: "spec gap: for-of doesn't IteratorClose on body throw (portion of 389 fails)"
-status: ready
+status: done
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: medium


### PR DESCRIPTION
## Summary
- #1347 (for-of IteratorClose on abrupt completion / non-callable `.return()` → TypeError) was fully implemented and merged to main in commit `d598dd3ce`.
- That commit contains the runtime change (`src/runtime.ts` `__iterator_return` throws `TypeError` on non-callable return), the throw-path suppression (`src/codegen/statements/loops.ts`), and the test suite (`tests/issue-1347.test.ts`, 5 tests).
- The only outstanding gap was stale frontmatter: the issue file still read `status: ready`. This PR flips it to `status: done` (+ `completed: 2026-05-27`).

## Verification
- `npm test -- tests/issue-1347.test.ts` → 5/5 pass against current main HEAD.

## Test plan
- [x] Docs-only change (issue frontmatter); no source modified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)