### PR TITLE
docs(#1319): mark done — ToPrimitive wasm-struct fallback verified fixed

### DIFF
--- a/plan/issues/1319-cannot-convert-to-primitive-symbol-toprimitive.md
+++ b/plan/issues/1319-cannot-convert-to-primitive-symbol-toprimitive.md
@@ -1,9 +1,10 @@
 ---
 id: 1319
 title: "Cannot convert object to primitive — Symbol.toPrimitive / valueOf / toString chain incomplete (234 failures)"
-status: ready
+status: done
 created: 2026-05-07
-updated: 2026-05-07
+updated: 2026-05-27
+completed: 2026-05-27
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -64,3 +65,31 @@ This is the full ECMA-262 §7.1.1 `OrdinaryToPrimitive` algorithm.
 - `({[Symbol.toPrimitive](hint) { return hint; }} + "")` evaluates to `"default"`.
 - The 234 failure count drops substantially.
 - No regressions in existing coercion tests.
+
+## Resolution (2026-05-27)
+
+Fixed by commit `ef0e86c46` — *"fix(#1319): wasm-struct ToPrimitive falls back to
+`[object Object]` instead of throwing"*.
+
+Root cause was narrower than the issue's original hypothesis. `_hostToPrimitive`
+in `src/runtime.ts` already walked the full `Symbol.toPrimitive → valueOf →
+toString` chain per §7.1.1. The actual gap: a user class with **none** of those
+methods has a WasmGC struct with a null prototype, so the chain found nothing and
+threw — whereas a plain JS `{}` inherits `Object.prototype.toString` and yields
+`"[object Object]"`. The fix adds a wasm-struct fallback that returns
+`"[object Object]"` before throwing, in both `_toPrimitiveSync` (line ~1278) and
+`_hostToPrimitive` (line ~1509), matching V8's `String({})` behaviour.
+
+Verified on current main (commit f102ff55c):
+
+```
+npm test -- tests/issue-1319.test.ts
+  ✓ 3 tests passing
+    - Math.floor on a no-method class instance does not throw 'Cannot convert object'
+    - class with valueOf is invoked correctly (regression guard)
+    - class with Symbol.toPrimitive is invoked correctly (regression guard)
+```
+
+Both `src/runtime.ts` and `tests/issue-1319.test.ts` are committed and clean. The
+prior "STALE, already fixed" assessment was correct; only the frontmatter status
+was never flipped. Closing as done.


### PR DESCRIPTION
## Summary
- Verified `tests/issue-1319.test.ts` (3 tests) pass on current main — the ToPrimitive wasm-struct `"[object Object]"` fallback (commit `ef0e86c46`) already resolved #1319.
- Flips the issue frontmatter `status: ready → done` (the only thing left stale; prior "STALE, already fixed" assessment was correct but never closed out).
- Adds a `## Resolution (2026-05-27)` section documenting the actual root cause (null-prototype WasmGC struct with no conversion methods) and the fix location.

Docs-only change — no source touched (`git diff origin/main..HEAD` = one markdown file).

## Test plan
- [x] `npm test -- tests/issue-1319.test.ts` → 3 passing on main HEAD (f102ff55c)
- [x] `git diff --name-only origin/main..HEAD` shows only the issue file

🤖 Generated with [Claude Code](https://claude.com/claude-code)