### PR TITLE
docs(#1636): correct JSON.stringify status + escalate for architect spec

### DIFF
--- a/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
+++ b/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
@@ -1,9 +1,10 @@
 ---
 id: 1636
 title: "spec gap: JSON.stringify replacer/toJSON/property-list (49 of 66 test262 fails)"
-status: in-review
+status: blocked
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-27
+escalation: needs-architect-spec
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -18,11 +19,19 @@ related: 1324
 ---
 # #1341 — JSON.stringify: replacer function, toJSON method, property-list filter
 
+> **Status correction (2026-05-27).** A prior agent recorded this issue as
+> ~87.9% / effectively done. That was wrong. Re-measured on current `main`
+> via the real test262 runner: **`built-ins/JSON/stringify` = 18 / 66 (27.3%)**.
+> The issue is genuinely OPEN, the root cause is structural (not a localized
+> `src/runtime.ts` patch), and it is escalated for an architect spec.
+> See **§Confirmed root cause** and **§Escalation** below.
+
 ## Problem
 
-`built-ins/JSON/stringify`: **17 / 66 pass (25.8%)** — 42 assertion_fail, 2 type_error,
-2 runtime_error, 1 other, 1 null_deref.
-`built-ins/JSON/parse`: 55 / 77 (71.4%) — 19 assertion_fail.
+`built-ins/JSON/stringify`: **18 / 66 pass (27.3%)** (re-measured 2026-05-27 on
+current main) — dominated by assertion_fail, with type_error / runtime_error /
+null_deref tails.
+`built-ins/JSON/parse`: ~71% (separate, not addressed here).
 
 Spec §25.5.2 (JSON.stringify) requires:
 1. **`replacer`** can be a function (called for every key, with `(key, value)`) or an Array
@@ -42,44 +51,94 @@ The 42 assertion_fail errors strongly suggest:
 
 Pure-Wasm JSON is tracked by #1324; this issue is the host-mode fidelity problem.
 
-## Acceptance criteria
+## Confirmed root cause (2026-05-27)
+
+The previous "Implementation Plan" assumed a localized fix at the
+`__json_stringify` boundary (wrap the Wasm replacer in a JS closure). That
+is **necessary but not sufficient**, because of a deeper, structural problem
+in how Wasm values reach the host serializer.
+
+**`_wasmToPlain` flattens the value graph *before* host `JSON.stringify` sees
+it** (`src/runtime.ts:1564`, invoked from the stringify path at lines ~3075,
+~3098, ~3534). It walks named structs (`_structToPlainObject`) and vec
+wrappers recursively and returns a fresh plain JS object/array tree. By the
+time the host `JSON.stringify(plain, replacer, space)` runs, the original
+WasmGC values are gone. This loses, *irrecoverably*, everything
+`SerializeJSONProperty` (§25.5.2.2 / §25.5.2.3) needs to observe on the
+**live** value:
+
+1. **`toJSON`** — §25.5.2.2 step 2 does `Get(value, "toJSON")` and, if
+   callable, invokes it with the *original* value as `this` and the key as
+   the argument. The flattened plain object has no `toJSON` method (methods
+   are not struct fields), so it is never called. (Affects Date, BigInt
+   wrappers, custom `toJSON`.)
+2. **Replacer `this` = the live holder** — §25.5.2.2 step 3 calls the
+   replacer with `this` set to the holder object and `(key, value)`. After
+   flattening, the holder identity is a throwaway plain object, not the
+   user's live struct, so `replacer-function-arguments.js` (which asserts on
+   `this` identity and call order) fails.
+3. **Wrapper `[[PrimitiveValue]]`** — `new String()/new Number()/new
+   Boolean()` wrappers must be unwrapped per §25.5.2.2 steps 4–6 *after*
+   `toJSON`. Flattening drops the wrapper brand, so `value-tojson-*.js` and
+   wrapper tests fail.
+4. **Cycle detection** — §25.5.2.2 requires a TypeError when a value is
+   already on the serialization stack. Detection must run over the *live*
+   graph during the recursive walk; the eager flatten neither detects cycles
+   (it would infinite-loop or pre-resolve them) nor preserves identity for a
+   stack check.
+5. **String escaping / marshaling count** — `value-string-escape-ascii.js`
+   shows a string-marshaling count mismatch at the boundary independent of
+   the above.
+
+### Why this is NOT a localized `runtime.ts` patch
+
+A correct fix requires implementing **`SerializeJSONProperty` recursion over
+live values** (Wasm-side or a faithful host-side walk that can call back into
+Wasm for each node), so that `toJSON`, the replacer `this`/holder, wrapper
+unwrapping, and cycle detection all observe the original value at each step —
+instead of a pre-flattened copy. That, in turn, depends on a reliable
+**JS↔Wasm closure-marshaling boundary** for the per-node replacer/`toJSON`
+callbacks (no general JS-callable Wasm function-ref trampoline yet —
+**#1308 / #1382**). Net: this is a cross-cutting serialization-model change,
+not a patch to `_wasmToPlain` or the `__json_stringify` import.
+
+## Escalation — needs architect spec
+
+Routing this to an architect (`/architect-spec`) to design the
+`SerializeJSONProperty`-over-live-values lowering. The spec should cover:
+
+- Where recursion lives (Wasm-native `SerializeJSONProperty` vs host walk that
+  calls back into Wasm per node) and how it interacts with the existing
+  `_wasmToPlain` fast path for the common no-replacer/no-`toJSON` case.
+- The JS↔Wasm callback boundary for replacer + `toJSON` (depends on
+  **#1308 / #1382** closure marshaling — call out the dependency explicitly).
+- Wrapper-object `[[PrimitiveValue]]` unwrap order vs `toJSON`.
+- Cycle detection over live values (stack of seen holders).
+- Whether to keep the flatten path as the standalone/pure-Wasm route (#1324)
+  and only take the live-value path in JS-host mode, or unify both.
+
+**Recommendation:** do NOT attempt a speculative partial fix at the boundary
+— without the live-value walk it cannot move the four acceptance-criteria
+tests and risks regressing the currently-passing flatten path. Hold for the
+architect spec.
+
+## Dependencies
+
+- **#1308 / #1382** — JS↔Wasm closure marshaling (replacer + `toJSON`
+  callbacks must be JS-callable with correct `this`).
+- **#1324** — pure-Wasm JSON (the standalone-mode counterpart; the spec
+  should decide whether the two paths unify).
+
+## Acceptance criteria (unchanged)
 
 1. `built-ins/JSON/stringify/replacer-function-arguments.js` passes.
 2. `built-ins/JSON/stringify/value-tojson-{primitive,object}.js` passes.
 3. `built-ins/JSON/stringify/replacer-array-{normal,non-normal}.js` passes.
-4. Pass-rate for `built-ins/JSON/stringify` rises from 26% to ≥75%.
+4. Pass-rate for `built-ins/JSON/stringify` rises from 27% to ≥75%.
 
-## Files to modify
+### Test262 sample (verified failing on current main, 2026-05-27)
 
-- `src/runtime.ts` — `__json_stringify`, `__json_parse` callback bridge
-- `src/codegen/registry/json.ts` (or equivalent registration)
-
-## Implementation Plan
-
-### Root cause
-
-Replacer is a function, but when crossing into host JSON.stringify the host expects to call
-the replacer as a JavaScript function with `this` set to the holder. Our Wasm function refs
-are not directly JS-callable (issue #1308) — they need an externref-callable trampoline.
-
-### Approach
-
-1. Wrap Wasm-replacer functions in a JS closure at boundary: `function (k, v) { return wasmFn(this, k, v); }`.
-2. For Array replacers (property-list mode): pass the array directly to host; spec says only
-   strings and numbers are honored.
-3. For the `toJSON` lookup: JSON.stringify host code does `Get(value, "toJSON")` — works automatically
-   for externref objects with toJSON; for typed structs we may need to inline the lookup before
-   handing the value to the host (since host can't see Wasm struct fields).
-
-### Edge cases
-
-- Replacer returns undefined for an array element → element becomes null per spec.
-- toJSON is not a Function → ignored (no error).
-- Property-list replacer with duplicate names → use first occurrence per spec.
-- Object with cyclic reference → TypeError.
-
-### Test262 sample
-
-- `test262/test/built-ins/JSON/stringify/replacer-function-arguments.js`
-- `test262/test/built-ins/JSON/stringify/value-tojson-object.js`
+- `test262/test/built-ins/JSON/stringify/replacer-function-arguments.js` — null-deref / holder-`this` lost
+- `test262/test/built-ins/JSON/stringify/value-tojson-object.js` — `toJSON` never called
+- `test262/test/built-ins/JSON/stringify/value-string-escape-ascii.js` — string-marshaling count mismatch
 - `test262/test/built-ins/JSON/stringify/replacer-array-normal.js`

--- a/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
+++ b/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
@@ -125,7 +125,17 @@ architect spec.
 ## Dependencies
 
 - **#1308 / #1382** — JS↔Wasm closure marshaling (replacer + `toJSON`
-  callbacks must be JS-callable with correct `this`).
+  callbacks must be JS-callable with correct `this`). This is the
+  closure-value boundary the live-value walk depends on.
+- **#1644** — BigInt i64-bigint-brand representation. `JSON.stringify` must
+  throw `TypeError` on a BigInt value (§25.5.2.2 step 12) and must invoke a
+  BigInt `toJSON` if present; both need the BigInt brand to be observable at
+  the serialization boundary, which #1644 establishes.
+- **#1630 / #1631** — struct-target writeback + descriptor model. Wrapper
+  `[[PrimitiveValue]]` unwrap and `toJSON` result substitution both depend on
+  the descriptor/writeback model these issues define for struct-backed
+  objects; without it the live-value walk cannot faithfully observe wrapper
+  brands or replaced values.
 - **#1324** — pure-Wasm JSON (the standalone-mode counterpart; the spec
   should decide whether the two paths unify).
 


### PR DESCRIPTION
## Summary

- Corrects the recorded status of #1636. A prior agent recorded JSON.stringify as ~87.9% / effectively done. **Re-measured on current main: `built-ins/JSON/stringify` = 18/66 (27.3%)** — genuinely OPEN.
- Documents the **confirmed structural root cause**: `_wasmToPlain` (`src/runtime.ts:1564`) eager-flattens WasmGC structs to plain JS objects *before* the value reaches host `JSON.stringify`. This irrecoverably drops everything `SerializeJSONProperty` must observe on the live value:
  - `toJSON` is never called (methods aren't struct fields)
  - the replacer's `this`/holder identity is lost
  - wrapper `[[PrimitiveValue]]` brand is dropped
  - cycle detection has nothing live to detect over
- Concludes this is **not a localized `runtime.ts` patch** — it needs `SerializeJSONProperty` recursion over live values + a JS↔Wasm closure-marshaling boundary for the per-node replacer/`toJSON` callbacks (depends on #1308 / #1382).
- Sets `status: blocked`, `escalation: needs-architect-spec`. Recommends **no speculative partial fix** (would not move the acceptance tests and risks regressing the currently-passing flatten path).

## Scope

Docs-only — touches a single issue file (`plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md`). No compiler source changes. Supersedes the docs in PR #660 with corrected, more detailed findings.

## Test plan

- [ ] N/A — documentation/escalation only; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)