### PR TITLE
docs: reconcile stale issue status for #1526, #1607

### DIFF
--- a/plan/issues/1526-spec-gap-bigint-number-mixed-arithmetic-typeerror.md
+++ b/plan/issues/1526-spec-gap-bigint-number-mixed-arithmetic-typeerror.md
@@ -1,9 +1,10 @@
 ---
 id: 1526
 title: "spec gap: BigInt + Number mixed arithmetic should throw spec TypeError, not host error"
-status: ready
+status: done
 created: 2026-05-20
-updated: 2026-05-20
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: easy
 reasoning_effort: low

--- a/plan/issues/1607-internal-crash-tdz-use-before-init-stack-overflow.md
+++ b/plan/issues/1607-internal-crash-tdz-use-before-init-stack-overflow.md
@@ -4,6 +4,7 @@ title: "codegen crash: 'Maximum call stack size exceeded' on use-before-initiali
 status: done
 created: 2026-05-24
 updated: 2026-05-24
+completed: 2026-05-24
 priority: high
 feasibility: medium
 task_type: bugfix


### PR DESCRIPTION
## Summary
Status-cleanup pass: two issues had merged fixes on main but stale frontmatter.

- **#1526** (BigInt+Number mixed arithmetic → spec TypeError): fix landed in PR #416 (commit `f588e0616`); `tests/issue-1526.test.ts` passes 4/4 against current main. `status: ready` → `done`, added `completed: 2026-05-27`.
- **#1607** (TDZ self-reference codegen stack overflow): fix landed in PR #633 (commit `7a02236e4`); was already `status: done` but missing the `completed:` field. Added `completed: 2026-05-24`.

## Verification
Checked every candidate the cleanup task listed. The following have **no merged fix PR** and were deliberately left untouched (genuinely in-flight or blocked, mostly `in_progress` in the task queue): #1593, #1596, #1638, #1639, #1640, #1641, #1644, #1645, #1646, #1634, #1637, and parent #1605 (only the `-cpn` sub-fix merged).

Docs-only change (2 plan/issues frontmatter files, +4/-2). No source touched.

## Test plan
- [x] `tests/issue-1526.test.ts` passes 4/4 on main HEAD
- [x] Merge evidence confirmed via `git log` fix commits + merged PRs
- [x] No source/TS files modified (typecheck/lint N/A; lint hook errors only because biome finds 0 lintable files in a docs-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)