### PR TITLE
fix(#1347b): for-await-of obtains async iterator from closure-valued Symbol.asyncIterator

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5868,9 +5868,29 @@ assert._isSameValue = isSameValue;
         return (obj: any) => {
           const asyncIter =
             obj[Symbol.asyncIterator] ?? _sidecarGet(obj, Symbol.asyncIterator) ?? _sidecarGet(obj, "@@asyncIterator");
-          if (asyncIter) return asyncIter.call(obj);
+          if (asyncIter != null) {
+            if (typeof asyncIter === "function") return asyncIter.call(obj);
+            // (#1347b) `obj[Symbol.asyncIterator]` was assigned a WasmGC closure
+            // struct in compiled code — it has no JS `[[Call]]`. Dispatch via
+            // __call_fn_0 the same way the sync `__iterator` path does, instead
+            // of letting `.call` throw "is not a function".
+            if (_isWasmStruct(asyncIter)) {
+              const callFn0 = (callbackState?.getExports() as any)?.__call_fn_0;
+              if (typeof callFn0 === "function") {
+                const iter = callFn0(asyncIter);
+                if (iter != null) return iter;
+              }
+            }
+          }
           const syncIter = obj[Symbol.iterator] ?? _sidecarGet(obj, Symbol.iterator) ?? _sidecarGet(obj, "@@iterator");
           if (typeof syncIter === "function") return syncIter.call(obj);
+          if (syncIter != null && _isWasmStruct(syncIter)) {
+            const callFn0 = (callbackState?.getExports() as any)?.__call_fn_0;
+            if (typeof callFn0 === "function") {
+              const iter = callFn0(syncIter);
+              if (iter != null) return iter;
+            }
+          }
           // WasmGC struct fallback: check @@iterator struct field, then vec iteration
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();

--- a/tests/issue-1347b.test.ts
+++ b/tests/issue-1347b.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1347b — for-await-of must obtain the async iterator from a WasmGC-closure-valued
+// `[Symbol.asyncIterator]`, mirroring the sync for-of path.
+//
+// The `__async_iterator` host import (src/runtime.ts) previously did
+// `asyncIter.call(obj)` unconditionally. When compiled code assigns a closure to
+// `obj[Symbol.asyncIterator] = function(){...}`, the stored value is a WasmGC
+// closure struct, not a JS function — so `.call` threw
+// "asyncIter.call is not a function" before the loop body ever ran. The sync
+// `__iterator` path already dispatched WasmGC closures via __call_fn_0; this
+// mirrors that into the async path (and its sync-iterator fallback).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function exportsOf(source: string): Promise<Record<string, Function>> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const imports: any = buildImports(r.imports, undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(inst.instance.exports);
+  return inst.instance.exports as Record<string, Function>;
+}
+
+describe("#1347b — for-await-of obtains async iterator from closure-valued Symbol.asyncIterator", () => {
+  /**
+   * Headline test262 cluster shape (iterator-close-*-get-method-non-callable):
+   * a closure assigned to [Symbol.asyncIterator]. Before the fix, the host
+   * threw "asyncIter.call is not a function" and the loop body never ran.
+   * After the fix, the iterator IS obtained and the loop body runs at least
+   * once (the subsequent non-callable `return` close is a separate concern).
+   */
+  it("loop body executes — closure asyncIterator is invoked, not '.call is not a function'", async () => {
+    const exports = await exportsOf(`
+      async function test(): Promise<number> {
+        let count = 0;
+        const asyncIterable: any = {};
+        asyncIterable[Symbol.asyncIterator] = function() {
+          return {
+            next: function() { return { done: count >= 1, value: null }; },
+          };
+        };
+        for await (const x of asyncIterable) { count += 1; }
+        return count;
+      }
+      export { test };
+    `);
+    // The compiled async fn currently returns a plain number (sync async-model
+    // limitation), or a Promise. Either way the key invariant is: it does NOT
+    // throw "asyncIter.call is not a function", and the loop body ran (count>=1).
+    const res = (exports.test as any)();
+    const value = res && typeof res.then === "function" ? await res : res;
+    expect(value).toBe(1);
+  });
+
+  /**
+   * Regression guard: a real async generator (proper async iterator) still
+   * iterates correctly — the new closure branch must not shadow the
+   * already-working `typeof asyncIter === "function"` path.
+   */
+  it("async generator still iterates (regression guard)", async () => {
+    const exports = await exportsOf(`
+      async function* gen() { yield 1; yield 2; yield 3; }
+      async function test(): Promise<number> {
+        let count = 0;
+        for await (const x of gen()) { count += 1; }
+        return count;
+      }
+      export { test };
+    `);
+    const res = (exports.test as any)();
+    const value = res && typeof res.then === "function" ? await res : res;
+    expect(value).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- `__async_iterator` (the for-await-of host import) did `asyncIter.call(obj)` unconditionally. When compiled code assigns a closure to `obj[Symbol.asyncIterator] = function(){}`, the stored value is a **WasmGC closure struct** with no JS `[[Call]]` — so `.call` threw `"asyncIter.call is not a function"` before the loop body ever ran.
- The sync `__iterator` (for-of) path already dispatched WasmGC closures via `__call_fn_0`. This mirrors that into the async path (and its sync-iterator fallback) — the gap the task flagged: a for-of fix not mirrored to for-await-of.
- After the fix, for-await-of obtains the iterator and runs the loop body; the subsequent AsyncIteratorClose protocol (non-callable `return` → TypeError, #1347) then fires correctly.

This is the headline shape of the `language/statements/for-await-of/iterator-close-*` cluster (closure-valued `[Symbol.asyncIterator]`).

## Investigation notes
- The remaining `"[object Object] is not iterable"` for closure-returned plain-object iterators reproduces **identically on for-of baseline** — a separate pre-existing limitation, not touched here.
- `async-await.test.ts` has 6 pre-existing failures (`string_constants import` harness issue) that also reproduce on main — unrelated.

## Test plan
- [x] `tests/issue-1347b.test.ts` — closure asyncIterator runs loop body; async-gen regression guard (2 passing)
- [x] `tests/issue-1347.test.ts` (for-of close, 5), `tests/issue-851.test.ts`, `tests/for-of-generator.test.ts`, async-gen-trampoline — all pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)