### PR TITLE
fix(#1567): bind %TypedArray% intrinsic in test262 harness, not Int8Array

### DIFF
--- a/plan/issues/1567-builtin-subclass-proto-splice-side-effects.md
+++ b/plan/issues/1567-builtin-subclass-proto-splice-side-effects.md
@@ -1,9 +1,10 @@
 ---
 id: 1567
 title: "Builtin subclass prototype splice leaks side effects (TypedArray length descriptor + RegExp brand)"
-status: ready
+status: done
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
+completed: 2026-05-27
 feasibility: hard
 sprint: 56
 owner: senior-developer
@@ -66,3 +67,52 @@ In `src/runtime.ts`, the host import that backs `RegExp.prototype.test` (likely 
 - PR #459 / commit `ca3e37094` "fix(#1455): make `instance instanceof Sub` work for builtin subclasses"
 - Investigation: `plan/issues/sprints/53/post-wave-regression-investigation.md`
 - Failing tests sampled locally on `main` (Wasm-side, not JS host) and still fail.
+
+## Resolution (2026-05-27, senior-dev)
+
+**The root-cause hypothesis above was wrong.** `__set_subclass_proto` was never
+involved — none of the three failing tests contain a `class extends`, so the
+helper is never invoked for them, and PR #459's runtime changes are unrelated.
+The real cause was **test-harness fidelity**, not the runtime.
+
+What actually happened, per failure:
+
+1. **`TypedArray/prototype/length/length.js`** and the `findLastIndex/BigInt/
+   get-length-ignores-length-prop.js` family: `wrapTest` injected
+   `const TypedArray = Int8Array` as the stand-in for the abstract `%TypedArray%`
+   intrinsic. The `length`/`byteLength`/`buffer`/`@@toStringTag` getters live on
+   `%TypedArray%.prototype` and are **inherited** by `Int8Array.prototype`, not
+   own — so `Object.getOwnPropertyDescriptor(Int8Array.prototype, "length")`
+   returned `undefined`, and `desc.get` threw. Every
+   `built-ins/TypedArray/prototype/*` descriptor test was silently failing on
+   this, far beyond the two named here.
+2. **`RegExp/prototype/test/S15.10.6.3_A2_T8.js`** already **passes** on current
+   `main` — the brand check was fixed by later work. Locked with a regression
+   test, no code change needed.
+
+**Fix** (`tests/test262-runner.ts`, the only source change): bind `TypedArray`
+to the real `%TypedArray%` intrinsic, which on the host is
+`Object.getPrototypeOf(Int8Array.prototype).constructor`. We route through
+`Int8Array.prototype` (member access on a builtin, which the compiler resolves
+to the host prototype) rather than the bare `Int8Array` identifier — the
+compiler does not evaluate bare builtin-constructor identifiers as first-class
+values (`Object.getPrototypeOf(Int8Array)` compiles `Int8Array` → `undefined`
+and throws `Cannot convert undefined to object`).
+
+**Validated impact** (per-process, isolated like CI forks — *not* the shared
+single-process probe, which produces spurious cascading CEs):
+
+| dir set | before | after |
+|---------|--------|-------|
+| `prototype/{length,byteLength,byteOffset,buffer,name,toStringTag}` | 37 pass / 27 fail | **53 pass / 11 fail** |
+| `prototype/{every,find}` sample (24) | 15 pass / 9 fail | **20 pass / 4 fail** |
+
+Net positive on both descriptor and method tests; zero new compile errors.
+The blanket abstract-intrinsic binding is safe because `%TypedArray%.prototype.X`
+=== `Int8Array.prototype.X` for every proto method, and the harness's
+`testWith*TypedArrayConstructors` helpers iterate the concrete constructors
+directly (they never call `new TypedArray()`).
+
+Tests: `tests/issue-1567.test.ts` (4 tests — descriptor getter `.length`,
+the wrapped `length.js` end-to-end through `wrapTest`, the shim-binding
+assertion, and the RegExp brand-check regression lock).

--- a/tests/issue-1567.test.ts
+++ b/tests/issue-1567.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1567 — "Builtin subclass proto splice leaks side effects" was filed as a
+ * trio of test262 regressions blamed on PR #459 (`__set_subclass_proto`).
+ *
+ * Investigation finding: none of the three failing tests use `class extends`,
+ * so `__set_subclass_proto` is never invoked for them. The two TypedArray
+ * descriptor failures were caused by the test *harness*, not the runtime:
+ * `wrapTest` injected `const TypedArray = Int8Array` as the stand-in for the
+ * abstract `%TypedArray%` intrinsic. The `length`/`byteLength`/`buffer`/… getters
+ * live on `%TypedArray%.prototype` and are *inherited* by `Int8Array.prototype`,
+ * not own — so `Object.getOwnPropertyDescriptor(Int8Array.prototype, "length")`
+ * returned `undefined`, failing every `built-ins/TypedArray/prototype/*`
+ * descriptor test. The third (RegExp brand check) already passes on current main.
+ *
+ * Fix: bind `TypedArray` to the real `%TypedArray%` intrinsic, which on the host
+ * is `Object.getPrototypeOf(Int8Array.prototype).constructor`. We route through
+ * `Int8Array.prototype` (member access on a builtin, which the compiler resolves
+ * to the host prototype) rather than the bare `Int8Array` identifier (which the
+ * compiler does not evaluate as a first-class value).
+ *
+ * These tests lock both the harness shim and the underlying spec behaviours.
+ */
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+import { wrapTest } from "./test262-runner.js";
+
+async function run(src: string): Promise<number> {
+  const exports = await compileAndInstantiate(src);
+  return ((exports as any).test as () => number)();
+}
+
+describe("#1567 — %TypedArray% intrinsic descriptor fidelity", () => {
+  it("Object.getPrototypeOf(Int8Array.prototype) exposes the %TypedArray%.prototype length getter", async () => {
+    // get %TypedArray%.prototype.length is an accessor whose getter Function
+    // has .length === 0 (ES §17 built-in function length default).
+    const src = `
+export function test(): number {
+  const taProto: any = Object.getPrototypeOf(Int8Array.prototype);
+  const desc: any = Object.getOwnPropertyDescriptor(taProto, "length");
+  if (desc == null) { return 10; }
+  if (typeof desc.get !== "function") { return 11; }
+  if (desc.get.length !== 0) { return 12; }
+  return 1;
+}`;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("end-to-end: the wrapped length.js descriptor query compiles and passes", async () => {
+    // Render the test262 `TypedArray/prototype/length/length.js` body through
+    // the real `wrapTest` pipeline, then compile + run it. With the abstract
+    // `%TypedArray%` binding the `length` getter resolves; with the old
+    // `Int8Array` binding `desc` was `undefined` and `desc.get` threw.
+    const { source } = wrapTest(
+      `/*---
+includes: [propertyHelper.js, testTypedArray.js]
+features: [TypedArray]
+---*/
+var desc = Object.getOwnPropertyDescriptor(TypedArray.prototype, "length");
+
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+`,
+      {} as never,
+    );
+    expect(await run(source)).toBe(1);
+  });
+
+  it("wrapTest binds TypedArray to the abstract %TypedArray% intrinsic, not Int8Array", () => {
+    const { source } = wrapTest(
+      `/*---
+includes: [propertyHelper.js, testTypedArray.js]
+features: [TypedArray]
+---*/
+var desc = Object.getOwnPropertyDescriptor(TypedArray.prototype, "length");
+`,
+      {} as never,
+    );
+    // The injected binding must derive %TypedArray% from the prototype chain,
+    // never bind the concrete Int8Array constructor directly.
+    expect(source).toContain("Object.getPrototypeOf(Int8Array.prototype).constructor");
+    expect(source).not.toContain("const TypedArray: any = Int8Array;");
+  });
+});
+
+describe("#1567 — RegExp.prototype.test brand check (already-fixed, regression lock)", () => {
+  it("RegExp.prototype.test called on a non-RegExp receiver throws TypeError", async () => {
+    // S15.10.6.3_A2_T8: stamping RegExp.prototype.test onto a string receiver
+    // must throw TypeError (the brand check rejects non-RegExp `this`).
+    const src = `
+export function test(): number {
+  let threw: number = 0;
+  let wasTypeError: number = 0;
+  try {
+    const t: any = (RegExp.prototype as any).test;
+    t.call(".", "abc");
+  } catch (e) {
+    threw = 1;
+    if (e instanceof TypeError) { wasTypeError = 1; }
+  }
+  if (!threw) { return 20; }
+  if (!wasTypeError) { return 21; }
+  return 1;
+}`;
+    expect(await run(src)).toBe(1);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1659,12 +1659,21 @@ function testWithTypedArrayConstructors(fn: any): void {
   }
 
   if (needsTypedArrayBinding) {
-    // Substitute for the abstract %TypedArray% intrinsic — see note at detection
-    // site. Int8Array.prototype.X === %TypedArray%.prototype.X in practice for
-    // the proto methods these tests exercise.
+    // Substitute for the abstract %TypedArray% intrinsic. `%TypedArray%` is the constructor
+    // that `Int8Array` (and every concrete TypedArray) inherits from; on the host it is
+    // exactly `Object.getPrototypeOf(Int8Array.prototype).constructor`. Binding to it (rather
+    // than `Int8Array` directly) exposes the descriptor accessors that live on
+    // `%TypedArray%.prototype` — e.g. the `length`/`byteLength`/`buffer`/`@@toStringTag`
+    // getters — which are *inherited* by `Int8Array.prototype`, not own. The old
+    // `const TypedArray = Int8Array` shim made `Object.getOwnPropertyDescriptor(
+    // TypedArray.prototype, "length")` return `undefined`, silently failing the
+    // `built-ins/TypedArray/prototype/*` descriptor tests (#1567). We route through
+    // `Int8Array.prototype` (member access on a builtin, which the compiler resolves to the
+    // host prototype) rather than the bare `Int8Array` identifier (which the compiler does
+    // not evaluate as a first-class value).
     p += `
 
-const TypedArray: any = Int8Array;`;
+const TypedArray: any = Object.getPrototypeOf(Int8Array.prototype).constructor;`;
   }
 
   if (needsIteratorBinding) {


### PR DESCRIPTION
## Summary

Fixes the three test262 failures filed against #1567. **The root-cause hypothesis in the issue was wrong** — `__set_subclass_proto` (PR #459) was never involved; none of the failing tests use `class extends`, so the splice never runs.

The real cause is **test-harness fidelity** in `tests/test262-runner.ts`: `wrapTest` injected `const TypedArray = Int8Array` as the stand-in for the abstract `%TypedArray%` intrinsic. But the `length`/`byteLength`/`buffer`/`@@toStringTag` getters live on `%TypedArray%.prototype` and are *inherited* by `Int8Array.prototype`, not own — so `Object.getOwnPropertyDescriptor(Int8Array.prototype, "length")` returned `undefined` and `desc.get` threw. This silently broke every `built-ins/TypedArray/prototype/*` descriptor test.

**Fix:** bind `TypedArray` to the real `%TypedArray%` intrinsic, which on the host is `Object.getPrototypeOf(Int8Array.prototype).constructor`. Routed through `.prototype` member access (which the compiler resolves on builtins) rather than the bare `Int8Array` identifier (which the compiler does not evaluate as a first-class value).

- The RegExp brand-check test (`S15.10.6.3_A2_T8.js`) already passes on `main`; locked with a regression test, no code change needed.

## Validated impact (per-process, CI-isolated)

| dir set | before | after |
|---------|--------|-------|
| `prototype/{length,byteLength,byteOffset,buffer,name,toStringTag}` | 37 / 27 fail | **53 / 11 fail** |
| `prototype/{every,find}` sample (24) | 15 / 9 fail | **20 / 4 fail** |

Net positive on descriptor AND method tests; zero new compile errors. Safe because `%TypedArray%.prototype.X === Int8Array.prototype.X` for every proto method, and the harness's `testWith*TypedArrayConstructors` helpers iterate concrete constructors (never `new TypedArray()`).

## Test plan
- [x] `tests/issue-1567.test.ts` — 4 tests (descriptor getter `.length`, wrapped `length.js` end-to-end via `wrapTest`, shim-binding assertion, RegExp brand-check regression lock)
- [x] `tests/issue-1455.test.ts` still green (no #1455 regression)
- [ ] CI sharded test262 confirms net-positive delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)