### PR TITLE
fix(#1677): unify native-string helper func-index shift (Signature A, partial)

### DIFF
--- a/plan/issues/1677-native-string-helper-funcidx-shift-unification.md
+++ b/plan/issues/1677-native-string-helper-funcidx-shift-unification.md
@@ -1,8 +1,9 @@
 ---
 id: 1677
 title: "Signature A: native string helper func-index shift unification (__str_flatten/__str_to_extern call[k] type mismatch under --target wasi)"
-status: ready
+status: in-progress
 created: 2026-05-27
+updated: 2026-05-27
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -149,3 +150,61 @@ and `addImport` and choose the one that does not introduce a re-shift hazard.
 - Residual host-import leak elimination — #1664.
 - Native generators shared `$Iterator` design — #1665.
 - Pure-Wasm number→string lowering — #1335.
+
+## Resolution (2026-05-27, senior-developer) — partial, PR open
+
+**Fixed 3 of 6 Signature A probes: `class` (extends/super), `closure`
+(captured local), `generator` (for-of).** The func-index shift unification is
+implemented as `reconcileNativeStrFinalizeShift`
+(`src/codegen/expressions/late-imports.ts`), called at two points in
+`generateModule` / `generateMultiModule` finalize.
+
+Root cause confirmed by instrumentation: the native-string helpers AND their
+dependency helpers (`__box_number`, `__unbox_number`, … emitted via
+`addUnionImportsAsNativeFuncs`) are eagerly emitted during finalize while
+`numImportFuncs == base`. Finalize then adds more imports (string methods,
+parseInt, Promise statics) which bump every defined function's absolute Wasm
+index by `added`, but the baked sibling-call targets, the `funcMap` entries, and
+the export descriptors were left stale-low. `__vec_get` (emitted later) read a
+stale-low `funcMap.get("__box_number")` and called the wrong function
+(`call[k] not enough arguments on the stack`).
+
+The fix applies ONE **uniform** `+added` shift to all eagerly-emitted defined
+functions' bodies, their `funcMap` entries (gated on the name being a defined
+function so the freshly-added imports in `[base, base+added)` are not
+double-shifted), `nativeStrHelpers`, and func exports — for `funcIdx >= base`
+only. An earlier version restricted the shift to `nativeStrHelpers`-named
+functions, which left `__box_number` stale and produced the `__vec_get`
+over-/under-shift; the uniform shift is the correct generalization (it mirrors
+the JS-host path's late-import fixup at `addUnionImports`).
+
+**#618 safety verified:** `base` is set only inside `ensureNativeStringHelpers`
+(native-strings path). On the default JS-host GC path it stays -1 and the
+reconcile is a hard no-op. Confirmed: a default-mode `Math.abs` + string-concat
+snippet still validates (covered by `tests/issue-1677.test.ts`).
+
+**Tests:** `tests/issue-1677.test.ts` — 4/4 (class/closure/generator valid under
+wasi + the #618 default-GC guard). `tests/wasi.test.ts` green.
+
+### Out of scope — carve to follow-up (still failing, distinct root causes)
+
+Not func-index shift bugs; left for a follow-up:
+
+- **`str-template`** (`` `${x}` ``) — `__str_to_extern call[0] expected f64,
+  found i32`. Instrumented: at emit time `numImportFuncs==1`, `__str_flatten` is
+  at index 2 and the baked `flattenIdx==2` is *correct*; no shift occurs
+  (`added==0` at every reconcile). The mismatch is a **type/codegen** problem in
+  the `ensureNativeStringExternBridge` body, not an index shift.
+- **`array-map`** (`.map().filter().reduce()`) — `__module_init call[1]
+  expected (ref null 5), found global.get f64`. The same signature reproduces
+  with a minimal `Math.abs(-5)` + `"x"+a` snippet under `--target wasi`, so it is
+  a **string-constant-global materialized as f64** problem
+  (Signature-B-adjacent), independent of the helper func-index regime.
+
+Recommend a follow-up issue for these two.
+
+### Pre-existing (NOT this change)
+
+`tests/imported-string-constants.test.ts` has 10 failing e2e cases on main
+(`LinkError: env __box_number requires a callable`). Verified identical failure
+count with the reconcile gated off — pre-existing, unrelated to this fix.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -116,6 +116,7 @@ export function createCodegenContext(
     nativeStrExternBridgeEmitted: false,
     testRuntimeStringHelpersEmitted: false,
     nativeStrHelpers: new Map(),
+    nativeStrHelperImportBase: -1,
     refCellTypeMap: new Map(),
     anyValueTypeIdx: -1,
     anyHelpers: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -555,6 +555,12 @@ export interface CodegenContext {
   testRuntime: boolean;
   /** Map from native string helper name → function index */
   nativeStrHelpers: Map<string, number>;
+  /** #1677: import-function count captured the instant the native-string
+   *  helpers were first emitted (mid-finalize). Used by
+   *  `reconcileNativeStrFinalizeShift` to shift the helper bodies + map by the
+   *  number of imports added afterwards during the rest of finalize. -1 until
+   *  helpers are emitted; reset to -1 once reconciled. */
+  nativeStrHelperImportBase: number;
   /** Map from value type kind → ref cell struct type index */
   refCellTypeMap: Map<string, number>;
   /** Type index of the $AnyValue boxed-any struct */

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -188,6 +188,18 @@ export function shiftLateImportIndices(
       ctx.funcMap.set(name, idx + added);
     }
   }
+  // (#1677) Keep `nativeStrHelpers` in lockstep with the defined-function shift.
+  // Unlike funcMap, this map is read directly by string-lowering call sites
+  // (e.g. `__str_concat` in user code, the deferred WASI write helpers) AND by
+  // helper emitters that look up sibling helpers. It is NOT a separate copy of
+  // funcMap (most helper names are not in funcMap), so it must be shifted on
+  // its own. All entries are DEFINED functions (indices >= numImportFuncs), so
+  // every entry >= importsBefore moves up by `added`.
+  for (const [name, idx] of ctx.nativeStrHelpers) {
+    if (idx >= importsBefore) {
+      ctx.nativeStrHelpers.set(name, idx + added);
+    }
+  }
   // Shift export descriptors
   for (const exp of ctx.mod.exports) {
     if (exp.desc.kind === "func" && exp.desc.index >= importsBefore) {
@@ -248,6 +260,123 @@ export function ensureLateImport(
   const typeIdx = addFuncType(ctx, paramTypes, resultTypes);
   addImport(ctx, "env", name, { kind: "func", typeIdx });
   return ctx.funcMap.get(name);
+}
+
+/**
+ * #1677: reconcile native-string helper function indices at the end of the
+ * import-collection finalize phase.
+ *
+ * The native-string runtime helpers (`__str_flatten` & co.) are emitted as
+ * DEFINED functions *mid-finalize* (the first `ensureNativeStringHelpers`
+ * call), recording `ctx.nativeStrHelperImportBase` = the import count at that
+ * instant. Finalize then continues and adds more imports via raw `addImport`
+ * (string methods, parseInt, Promise statics, iterator/generator bridges, …).
+ * Raw `addImport` does NOT shift defined-function indices (the #618 revert
+ * deliberately removed that), so every helper body's internal `call` to a
+ * sibling helper — and every `nativeStrHelpers` map entry — is now stale-low by
+ * exactly `(numImportFuncs - base)`.
+ *
+ * This reconciliation runs once, after finalize is otherwise complete, and
+ * applies that single uniform delta via the same `shiftLateImportIndices`
+ * walker the compilation-phase late-import path uses — unifying the two shift
+ * regimes (#1666 root cause). It is a no-op unless native-string helpers were
+ * emitted, so the default GC path is never touched; and because it shifts
+ * `funcIdx >= base` (sibling-helper calls) but not `funcIdx < base` (calls to
+ * imports added before the helpers), it cannot corrupt the Math.* host
+ * trampoline path that the #618 naive `addImport` shift broke.
+ */
+export function reconcileNativeStrFinalizeShift(ctx: CodegenContext): void {
+  const base = ctx.nativeStrHelperImportBase;
+  if (base < 0) return; // helpers never emitted (default GC path or no strings)
+  const added = ctx.numImportFuncs - base;
+  // Re-base for the next incremental call so repeated invocations only apply
+  // the NEW imports added since the previous reconcile. (Imports are inserted
+  // between finalize and body compilation at several points — the
+  // register-prototype block, the deferred WASI helper emitters, etc. — and
+  // each batch drifts the indices further.)
+  ctx.nativeStrHelperImportBase = ctx.numImportFuncs;
+  if (added <= 0) return;
+
+  // Uniform defined-function index shift, restricted to the native-string
+  // finalize regime.
+  //
+  // At the point this runs (mid/end of finalize, before `collectDeclarations`),
+  // EVERY function already in `ctx.mod.functions` is an eagerly-emitted runtime
+  // helper (the native-string helpers AND their dependencies: `__box_number`,
+  // `__unbox_number`, `__toUint32`, …). They were all emitted while
+  // `numImportFuncs == base`, so their absolute index is `base + arrayPos` and
+  // any `call`/`ref.func funcIdx >= base` they baked points at a *sibling*
+  // defined function under that same regime. Adding `added` finalize imports
+  // (string methods, parseInt, Promise statics, …) bumps every defined
+  // function's true absolute index by `added` but leaves the baked call targets
+  // and the `funcMap` entries stale-low. We repair ALL of them uniformly by
+  // `added` for `funcIdx >= base`.
+  //
+  // Earlier versions shifted only `nativeStrHelpers`-named functions; that
+  // missed dependency helpers like `__box_number` (registered via
+  // `addUnionImportsAsNativeFuncs`, not tracked in `nativeStrHelpers`), whose
+  // stale-low `funcMap` entry made later callers (e.g. `__vec_get`) target the
+  // wrong function — `call[k] not enough arguments on the stack`.
+  //
+  // #618 safety: gated on `base >= 0`, which is set only inside
+  // `ensureNativeStringHelpers` (native-strings path: wasi/standalone or
+  // explicit `--nativeStrings`). On the default JS-host GC path the helpers are
+  // never emitted, `base` stays -1, and this is a hard no-op — so the
+  // Math.*-trampoline corruption the #608 `addImport` shift caused cannot recur.
+  // The `funcIdx < base` guard further protects calls into pre-helper imports
+  // (the host trampolines) from ever being shifted.
+  const seen = new Set<Instr[]>();
+  function shiftBody(instrs: Instr[]): void {
+    if (seen.has(instrs)) return;
+    seen.add(instrs);
+    for (const instr of instrs) {
+      const a = instr as any;
+      if (
+        (instr.op === "call" || instr.op === "return_call" || instr.op === "ref.func") &&
+        typeof a.funcIdx === "number" &&
+        a.funcIdx >= base
+      ) {
+        a.funcIdx += added;
+      }
+      if (Array.isArray(a.body)) shiftBody(a.body);
+      if (Array.isArray(a.then)) shiftBody(a.then);
+      if (Array.isArray(a.else)) shiftBody(a.else);
+      if (Array.isArray(a.catches)) {
+        for (const c of a.catches) if (Array.isArray(c.body)) shiftBody(c.body);
+      }
+      if (Array.isArray(a.catchAll)) shiftBody(a.catchAll);
+    }
+  }
+  for (const fn of ctx.mod.functions) {
+    shiftBody(fn.body);
+  }
+  // Shift `funcMap` entries for DEFINED functions only. The `added` imports we
+  // just inserted now occupy indices `[base, base+added)`, which collides by
+  // value with stale defined-function entries (also `>= base`). We cannot
+  // disambiguate by index value, so we gate on the function NAME being a
+  // defined function (present in `ctx.mod.functions`). Import names are never
+  // in that set, so their (correct) entries are left untouched.
+  const definedNames = new Set<string>();
+  for (const fn of ctx.mod.functions) {
+    const n = (fn as { name?: string }).name;
+    if (n) definedNames.add(n);
+  }
+  for (const [name, idx] of ctx.funcMap) {
+    if (idx >= base && definedNames.has(name)) ctx.funcMap.set(name, idx + added);
+  }
+  // Keep the helper-name map (read directly by string lowering) in lockstep —
+  // every entry is a defined function by construction.
+  for (const [name, idx] of ctx.nativeStrHelpers) {
+    if (idx >= base) ctx.nativeStrHelpers.set(name, idx + added);
+  }
+  // Shift export descriptors. Exports only ever reference defined functions in
+  // this regime (helpers/runtime exports like `__vec_get`); a func export with
+  // `index >= base` is a defined function whose true slot moved by `added`.
+  for (const exp of ctx.mod.exports) {
+    if (exp.desc.kind === "func" && exp.desc.index >= base) {
+      exp.desc.index += added;
+    }
+  }
 }
 
 /**

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -30,7 +30,7 @@ import type {
 } from "./context/types.js";
 import type { NodeBuiltinImport } from "../import-resolver.js";
 import { eliminateDeadImports } from "./dead-elimination.js";
-import { emitUndefined } from "./expressions/late-imports.js";
+import { emitUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import {
   fixupExternConvertAny,
   fixupStructNewArgCounts,
@@ -809,6 +809,14 @@ export function generateModule(
       addImport(ctx, "env", "__register_class_object", { kind: "func", typeIdx: regClassTypeIdx });
     }
 
+    // #1677 — reconcile native-string helper func indices before emitting more
+    // defined helpers that look them up. Imports registered after the helpers
+    // (e.g. the __register_prototype / __register_class_object pair above)
+    // shift the helpers' true indices but not their baked-in sibling-call
+    // targets nor the `nativeStrHelpers` / funcMap entries the deferred WASI
+    // write helpers read. Incremental + no-op on the default GC path.
+    reconcileNativeStrFinalizeShift(ctx);
+
     // Emit inline Wasm implementations for Math methods (after all imports are registered)
     if (ctx.pendingMathMethods.size > 0) {
       emitInlineMathFunctions(ctx, ctx.pendingMathMethods);
@@ -832,6 +840,14 @@ export function generateModule(
     // collectDeclarations so the inferred f64 return shows up directly in
     // the function's signature instead of being patched after the fact.
     ctx.numericReturnTypes = inferNumericReturnTypes(ctx, ast.sourceFile);
+
+    // #1677 — final reconcile of native-string helper indices before any USER
+    // function is registered. Any imports added by the deferred-helper
+    // emitters above are folded in here; afterward the compilation-phase
+    // late-import path (ensureLateImport → flushLateImportShifts, which now
+    // also shifts `nativeStrHelpers`) keeps them correct. Incremental no-op
+    // when nothing drifted.
+    reconcileNativeStrFinalizeShift(ctx);
 
     // Second pass: collect all function declarations and interfaces
     collectDeclarations(ctx, ast.sourceFile);
@@ -3138,6 +3154,10 @@ export function generateMultiModule(
       collectAllSourceImports(ctx, sf);
     }
 
+    // #1677 — reconcile native-string helper indices before emitting deferred
+    // helpers that look them up (see single-module path).
+    reconcileNativeStrFinalizeShift(ctx);
+
     // Emit inline Wasm implementations for Math methods (after all imports are registered)
     if (ctx.pendingMathMethods.size > 0) {
       emitInlineMathFunctions(ctx, ctx.pendingMathMethods);
@@ -3162,6 +3182,9 @@ export function generateMultiModule(
       }
       ctx.numericReturnTypes = merged;
     }
+
+    // #1677 — final reconcile before any user function is registered.
+    reconcileNativeStrFinalizeShift(ctx);
 
     // Phase 2: Collect all declarations — only entry file gets Wasm exports
     for (const sf of multiAst.sourceFiles) {

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -194,6 +194,13 @@ export function flatStringType(ctx: CodegenContext): ValType {
 export function ensureNativeStringHelpers(ctx: CodegenContext): void {
   if (ctx.nativeStrHelpersEmitted) return;
   ctx.nativeStrHelpersEmitted = true;
+  // #1677: snapshot the import-function count at the instant the helpers are
+  // emitted. Imports added later during the same finalize phase shift these
+  // helpers' true indices but NOT their baked-in sibling-call targets;
+  // `reconcileNativeStrFinalizeShift` applies that delta at finalize end.
+  if (ctx.nativeStrHelperImportBase < 0) {
+    ctx.nativeStrHelperImportBase = ctx.numImportFuncs;
+  }
 
   const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
   const strTypeIdx = ctx.nativeStrTypeIdx; // NativeString (FlatString) struct type index

--- a/tests/issue-1677.test.ts
+++ b/tests/issue-1677.test.ts
@@ -1,0 +1,80 @@
+// #1677 — Native string helper func-index shift unification (Signature A of #1666).
+//
+// Under `--target wasi` (auto `nativeStrings`), the native-string runtime
+// helpers (`__str_flatten` & co.) and their dependency helpers (`__box_number`,
+// …) are emitted as DEFINED functions during the import-collection finalize
+// phase. Imports added afterward shift every defined function's absolute Wasm
+// index, but the helper bodies' baked sibling-call targets, the funcMap entries,
+// and the export descriptors were left stale-low — producing modules that fail
+// `WebAssembly.compile` validation (`call[k] expected <T>, found <U>`).
+//
+// `reconcileNativeStrFinalizeShift` repairs them with one uniform shift over all
+// eagerly-emitted defined functions, hard-gated on a pinned helper base so it is
+// provably inert on the default JS-host GC path (the #618 hazard).
+//
+// These shapes (inner-arrow closure capture across class boundaries, super
+// calls, generator for-of) each exercised the stale-index path and previously
+// emitted invalid Wasm. The default-GC `Math.abs` + string-concat case is the
+// #618 regression guard: it must keep validating with the reconcile in place.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compilesValidWasm(source: string, target?: "wasi"): Promise<true> {
+  const result = compile(source, { fileName: "test.ts", target });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  // Throws if the module fails Wasm validation — this is the assertion.
+  await WebAssembly.compile(result.binary);
+  return true;
+}
+
+describe("#1677 native string helper func-index shift (--target wasi)", () => {
+  it("class with extends/super + string methods compiles to valid Wasm", async () => {
+    const src = `
+      class Animal {
+        name: string;
+        constructor(n: string) { this.name = n; }
+        speak(): string { return this.name + " makes a sound"; }
+      }
+      class Dog extends Animal {
+        constructor(n: string) { super(n); }
+        speak(): string { return super.speak() + " (woof)"; }
+      }
+      const d = new Dog("Rex");
+      const out = d.speak();
+    `;
+    expect(await compilesValidWasm(src, "wasi")).toBe(true);
+  });
+
+  it("captured-closure string concat compiles to valid Wasm", async () => {
+    const src = `
+      function make(prefix: string) { return (x: string) => prefix + x; }
+      const f = make("hi-");
+      const r = f("world");
+    `;
+    expect(await compilesValidWasm(src, "wasi")).toBe(true);
+  });
+
+  it("generator for-of accumulating strings compiles to valid Wasm", async () => {
+    const src = `
+      function* gen() { yield "a"; yield "b"; yield "c"; }
+      let acc = "";
+      for (const v of gen()) { acc = acc + v; }
+    `;
+    expect(await compilesValidWasm(src, "wasi")).toBe(true);
+  });
+
+  it("#618 guard: default GC-path Math.abs + string concat stays valid", async () => {
+    // The pre-#618 naive `addImport` shift corrupted the Math.* host trampoline
+    // on the default path. The reconcile is a hard no-op here (no native-string
+    // helpers are emitted) and must not regress this.
+    const src = `
+      const a = Math.abs(-5);
+      const b = "val=" + a;
+      const c = Math.max(1, 2) + Math.min(3, 4);
+    `;
+    expect(await compilesValidWasm(src)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Carves the func-index half of #1677 (Signature A of #1666). Under `--target wasi`
(auto `nativeStrings`), eagerly-emitted native-string helpers **and their
dependency helpers** (`__box_number`, `__unbox_number`, … emitted via
`addUnionImportsAsNativeFuncs`) had stale-low `call`/`ref.func` targets, `funcMap`
entries, and export descriptors after finalize added more imports — producing
modules that fail `WebAssembly.compile` (`call[k] expected <T>, found <U>`).

`reconcileNativeStrFinalizeShift` applies **one uniform `+added` shift** over all
eagerly-emitted defined functions for `funcIdx >= base`, gated on a pinned helper
base (`ctx.nativeStrHelperImportBase`, set only in `ensureNativeStringHelpers`).
On the default JS-host GC path the base stays `-1` and the reconcile is a hard
no-op — it provably cannot recur the #618 `Math.abs` trampoline corruption.

Fixes 3 of 6 Signature A probes:
- `class` (extends/super) — VALID
- `closure` (captured local) — VALID
- `generator` (for-of) — VALID (this was the #618-class over-shift the earlier
  helper-name-only shift introduced; the uniform shift is the correct fix)

## Out of scope — carved to follow-up (distinct, non-func-index root causes)

- **`str-template`** — `__str_to_extern call[0] expected f64, found i32`.
  Instrumented: the baked `__str_flatten` index is correct and no shift occurs
  (`added==0`); this is a type/codegen problem in `ensureNativeStringExternBridge`,
  not an index shift.
- **`array-map`** — `__module_init call[1] expected (ref null 5), found
  global.get f64`. Reproduces with a minimal `Math.abs(-5)` + `"x"+a` snippet
  under `--target wasi` — a string-constant-global-as-f64 problem
  (Signature-B-adjacent), independent of the helper func-index regime.

Both are documented in `plan/issues/1677-...md`; recommend a follow-up issue.

## Test plan

- [x] `tests/issue-1677.test.ts` — 4/4 (class/closure/generator valid under wasi
      + #618 default-GC `Math.abs`+concat guard)
- [x] `tests/wasi.test.ts` green
- [x] `npx tsc --noEmit` clean
- [ ] CI sharded test262 (default-path pass count must hold — the authoritative
      #618 gate)

Note: `tests/imported-string-constants.test.ts` has 10 pre-existing e2e failures
on main (verified identical with the reconcile gated off) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)