### PR TITLE
fix(#786): Array indexOf/lastIndexOf/includes use spec equality for externref elements

### DIFF
--- a/plan/issues/786-multi-assertion-failures-returned-n.md
+++ b/plan/issues/786-multi-assertion-failures-returned-n.md
@@ -151,3 +151,51 @@ separate Wasm functions cannot read/write variables from the enclosing function 
 - Top categories fixed: `class/dstr` (524 tests), `object/dstr` (166), `function/dstr` (51),
   `generators/dstr` (55), `arrow-function/dstr` (30), `async-generator/dstr` (81)
 - Estimated total fix: ~900+ tests (those where callCount is the only failing assertion)
+
+## Implementation notes (Array search-method externref equality, 2026-05-27)
+
+### Sub-cluster picked
+`built-ins/Array/prototype/{indexOf,lastIndexOf,includes}` — the search
+methods were comparing **externref** array elements using the
+`wasm:js-string equals` builtin, which coerces both operands to strings.
+
+### Root cause
+`compileArrayIndexOf` / `compileArrayLastIndexOf` / `compileArrayIncludes`
+(`src/codegen/array-methods.ts`) chose `ctx.jsStringImports.get("equals")`
+for `elemType.kind === "externref"`. That builtin string-coerces its
+operands, so:
+- object elements stringify to `"[object Object]"` (identity lost),
+- `["0"].indexOf(0)` and `[false].indexOf(0)` mis-coerce cross-type
+  comparisons,
+- only string-vs-string comparisons worked.
+
+### Fix
+Route externref comparison through the spec-correct host helpers:
+- `indexOf` / `lastIndexOf` → `__host_eq` (Strict Equality, §7.2.16) —
+  real JS `===`: object identity, cross-type → false.
+- `includes` → `__same_value_zero` (§7.2.11) — like strict eq but NaN
+  matches NaN.
+
+Both are existing late imports (`ensureLateImport` + `flushLateImportShifts`,
+mirroring the array-like `compileArrayLikePrototypeSearch` path that already
+used `__host_eq`). The `wasm:js-string equals` call is removed from these
+three functions.
+
+### Scope limit (documented for the umbrella)
+The fix corrects comparison for **homogeneous-externref** arrays (objects-only,
+strings-only, or mixed-with-string). It does NOT move the dominant test262
+`indexOf` cluster (`[0, targetObj].indexOf(targetObj)`, `arr.indexOf(true)` over
+a boolean array, `[0, 1, targetObj].indexOf(targetObj, 2)`), because those
+arrays are stored with **numeric (f64) / boolean (i32) element types** — the
+search argument is coerced to that numeric type before the comparison path is
+even reached, so the externref branch never runs. Making a number+object array
+literal infer an externref element type is the **array-element-typing**
+representation change tracked under #1130 / #1592, out of scope for this
+localized search-method fix. This fix is a prerequisite for that broader change
+and is a standalone spec-correctness improvement with no regression.
+
+### Test Results
+- `tests/issue-786.test.ts` — 21/21 pass (10 new externref search-equality
+  cases + the pre-existing 11 block-scope / closure-capture cases).
+- Regression: `array-prototype-methods`, `array-externref-indexof`,
+  `array-push-pop`, `issue-1360`, `in-operator-edge-cases` — 97/97 pass.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3189,13 +3189,27 @@ function compileArrayIndexOf(
 
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
 
-  // For externref elements, use the `equals` string import (JS ===) for comparison
-  // For ref/ref_null elements, use ref.eq for reference identity comparison
+  // For externref elements, use __host_eq (JS Strict Equality, §7.2.16) so
+  // object identity, cross-type (e.g. `[false].indexOf(0)`), and string
+  // comparisons all follow spec. The wasm:js-string `equals` builtin coerces
+  // both operands to strings, which mis-matches object/boolean/number
+  // elements (#786 — `indexOf` on an externref vec).
+  // For ref/ref_null elements, use ref.eq for reference identity comparison.
   let eqInstrs: Instr[];
   if (elemType.kind === "externref") {
-    addStringImports(ctx);
-    const equalsIdx = ctx.jsStringImports.get("equals")!;
-    eqInstrs = [{ op: "call", funcIdx: equalsIdx } as Instr];
+    const hostEqIdx = ensureLateImport(
+      ctx,
+      "__host_eq",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalHostEqIdx = ctx.funcMap.get("__host_eq") ?? hostEqIdx;
+    if (finalHostEqIdx === undefined) {
+      reportError(ctx, callExpr, "indexOf: failed to bind __host_eq import");
+      return null;
+    }
+    eqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     eqInstrs = [{ op: "ref.eq" }];
   } else {
@@ -3389,14 +3403,28 @@ function compileArrayIncludes(
       { op: "i32.or" } as Instr,
     ];
   } else if (elemType.kind === "externref") {
-    addStringImports(ctx);
-    const equalsIdx = ctx.jsStringImports.get("equals")!;
+    // SameValueZero (§7.2.11) via __same_value_zero: NaN matches NaN, object
+    // identity, cross-type → false. The wasm:js-string `equals` builtin
+    // coerces both operands to strings, mis-matching object/boolean/number
+    // elements (#786 — `includes` on an externref vec).
+    const svzIdx = ensureLateImport(
+      ctx,
+      "__same_value_zero",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalSvzIdx = ctx.funcMap.get("__same_value_zero") ?? svzIdx;
+    if (finalSvzIdx === undefined) {
+      reportError(ctx, callExpr, "includes: failed to bind __same_value_zero import");
+      return null;
+    }
     comparisonInstrs = [
       { op: "local.get", index: dataTmp } as Instr,
       { op: "local.get", index: iTmp } as Instr,
       { op: getOp, typeIdx: arrTypeIdx } as Instr,
       { op: "local.get", index: valTmp } as Instr,
-      { op: "call", funcIdx: equalsIdx } as Instr,
+      { op: "call", funcIdx: finalSvzIdx } as Instr,
     ];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     comparisonInstrs = [
@@ -6042,13 +6070,26 @@ function compileArrayLastIndexOf(
 
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
 
-  // For externref elements, use the `equals` string import (JS ===) for comparison
-  // For ref/ref_null elements, use ref.eq for reference identity comparison
+  // For externref elements, use __host_eq (JS Strict Equality, §7.2.16) so
+  // object identity, cross-type, and string comparisons follow spec. The
+  // wasm:js-string `equals` builtin coerces both operands to strings, which
+  // mis-matches object/boolean/number elements (#786).
+  // For ref/ref_null elements, use ref.eq for reference identity comparison.
   let liofEqInstrs: Instr[];
   if (elemType.kind === "externref") {
-    addStringImports(ctx);
-    const equalsIdx = ctx.jsStringImports.get("equals")!;
-    liofEqInstrs = [{ op: "call", funcIdx: equalsIdx } as Instr];
+    const hostEqIdx = ensureLateImport(
+      ctx,
+      "__host_eq",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalHostEqIdx = ctx.funcMap.get("__host_eq") ?? hostEqIdx;
+    if (finalHostEqIdx === undefined) {
+      reportError(ctx, callExpr, "lastIndexOf: failed to bind __host_eq import");
+      return null;
+    }
+    liofEqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     liofEqInstrs = [{ op: "ref.eq" }];
   } else {

--- a/tests/issue-786.test.ts
+++ b/tests/issue-786.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.ts";
 import { buildImports } from "../src/runtime.ts";
+import { compileToWasm } from "./equivalence/helpers.js";
 
 async function run(src: string): Promise<number> {
   const r = compile(src, { fileName: "test.ts" });
@@ -182,5 +183,84 @@ describe("Issue #786: method closure captures", () => {
       }
     `);
     expect(result).toBe(1);
+  });
+});
+
+// #786 — Array.prototype.{indexOf,lastIndexOf,includes} on an externref-element
+// vec used the wasm:js-string `equals` builtin, which coerces both operands to
+// strings. That mis-matched object identity, cross-type (e.g. boolean vs
+// number), and other non-string elements. The fix routes externref comparison
+// through __host_eq (Strict Equality, §7.2.16) for indexOf/lastIndexOf and
+// __same_value_zero (§7.2.11) for includes.
+describe("Issue #786: Array search methods use spec equality for externref elements", () => {
+  async function runExtern(src: string): Promise<number | boolean> {
+    const ex = await compileToWasm(src);
+    return ex.test() as number | boolean;
+  }
+
+  it("indexOf finds an object element by reference", async () => {
+    expect(
+      await runExtern(`export function test(): number { const o={}; const a:any[]=[o]; return a.indexOf(o); }`),
+    ).toBe(0);
+  });
+
+  it("indexOf finds an object among other objects", async () => {
+    expect(
+      await runExtern(
+        `export function test(): number { const o={}; const p={}; const a:any[]=[p,o]; return a.indexOf(o); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("indexOf honours fromIndex for object elements", async () => {
+    expect(
+      await runExtern(
+        `export function test(): number { const o={}; const a:any[]=["x","y",o]; return a.indexOf(o,2); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("indexOf returns -1 when fromIndex skips the match", async () => {
+    expect(
+      await runExtern(
+        `export function test(): number { const o={}; const a:any[]=[o,"x","y"]; return a.indexOf(o,1); }`,
+      ),
+    ).toBe(-1);
+  });
+
+  it('indexOf does not coerce "0" to number 0 (strict equality)', async () => {
+    expect(await runExtern(`export function test(): number { const a:any[]=["0"]; return a.indexOf(0); }`)).toBe(-1);
+  });
+
+  it("indexOf matches a string element", async () => {
+    expect(
+      await runExtern(`export function test(): number { const a:string[]=["x","y","z"]; return a.indexOf("y"); }`),
+    ).toBe(1);
+  });
+
+  it("lastIndexOf finds the last matching object", async () => {
+    expect(
+      await runExtern(
+        `export function test(): number { const o={}; const a:any[]=[o,"x",o]; return a.lastIndexOf(o); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("includes finds an object by reference (SameValueZero)", async () => {
+    expect(
+      await runExtern(`export function test(): boolean { const o={}; const a:any[]=["x",o]; return a.includes(o); }`),
+    ).toBe(1);
+  });
+
+  it('includes does not coerce "0" to number 0', async () => {
+    expect(
+      await runExtern(`export function test(): boolean { const a:any[]=["0"]; return a.includes(0 as any); }`),
+    ).toBe(0);
+  });
+
+  it("includes finds a matching string", async () => {
+    expect(
+      await runExtern(`export function test(): boolean { const a:string[]=["a","b"]; return a.includes("b"); }`),
+    ).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Sub-cluster of the #786 multi-assertion umbrella: `Array.prototype.{indexOf,lastIndexOf,includes}` compared **externref** array elements using the `wasm:js-string equals` builtin, which coerces both operands to strings. That lost object identity and mis-handled cross-type comparisons.

- `indexOf` / `lastIndexOf` → now use `__host_eq` (Strict Equality, §7.2.16)
- `includes` → now uses `__same_value_zero` (§7.2.11)

These are the same spec helpers the array-like `Array.prototype.METHOD.call` path (`compileArrayLikePrototypeSearch`) already uses; the WasmGC-vec inline path was the only one still string-coercing.

Fixes homogeneous-externref arrays (objects, strings, mixed-with-string). E.g. `[obj].indexOf(obj)`, `["0"].indexOf(0)`, `[obj].includes(obj)` now follow spec.

## Scope limit
Does NOT move the dominant test262 `indexOf` cluster (`[0, targetObj].indexOf(targetObj)`, `arr.indexOf(true)` over boolean arrays): those arrays store numeric/boolean element types, so the search arg is coerced to that numeric type before the externref comparison path runs. That's the array-element-typing representation change tracked under #1130/#1592 — out of scope. This is a prerequisite for it and a standalone spec-correctness fix with no regression.

## Test plan
- [x] `tests/issue-786.test.ts` — 21/21 pass (10 new externref search-equality cases)
- [x] No regression: `array-prototype-methods`, `array-externref-indexof`, `array-push-pop`, `issue-1360`, `in-operator-edge-cases` — 97/97
- [x] tsc clean, biome clean on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)