### PR TITLE
docs(#1674): GetSetRecord residuals decompose into #1364b + wasm-array prop retention

### DIFF
--- a/plan/issues/1674-getsetrecord-set-like-consumption.md
+++ b/plan/issues/1674-getsetrecord-set-like-consumption.md
@@ -1,7 +1,8 @@
 ---
 id: 1674
 title: "GetSetRecord set-like consumption: .size NaN, coercion count, has/keys callable checks"
-status: ready
+status: blocked
+escalation: needs-architect-spec
 created: 2026-05-27
 updated: 2026-05-27
 priority: low
@@ -52,3 +53,53 @@ re-reading off the live object.
 - `.size NaN`, coercion-count, and has/keys-callable clusters pass.
 - `built-ins/Set` pass-rate ≥ 90% (345/383).
 - No change to the `intent.className === "Set"` bridge.
+
+## Investigation 2026-05-27 (dev-1604) — real cause is the `_wrapForHost` proxy method/accessor dispatch (shared with #1364b)
+
+The original framing ("implement our own `GetSetRecord`") is slightly off. The
+set-method **receiver** (`s1`) is a host-native `Set` (the `Set` ctor + `.union`
+are extern imports), so V8's *own* GetSetRecord runs. The bug is that the
+set-like **argument** is consumed through `_wrapForHost`, and that proxy does
+NOT faithfully expose a wasm **class instance's** accessor / method properties:
+
+- `allows-set-like-class.js` / `set-like-class.js`: `s2 = new class { get size(){return 2} has(){…} *keys(){…} }` compiles to a wasm struct. At `src/runtime.ts:3139` the extern-method path wraps it: `_wrapForHost(s2, exports)`. V8's union then does `Get(proxy,"size")` / `Get(proxy,"has")` / `Get(proxy,"keys")`.
+  - `get size` → the proxy `get` trap has no path to invoke the wasm `__sget_size` **accessor** (it only knows data-field `__sget_*`), so `size` comes back `undefined` → `ToNumber` → **NaN** (the `.size NaN` bucket, ~17).
+  - `has` / `keys` → the proxy `get` trap returns `_getProtoMethodBridge(...)` (runtime.ts:2049), a placeholder that **throws** `"calling user-class method via JS-side prototype access is not yet supported (#1364b)"`. Hence `"has"/"keys" is not a function` / wrong-callable failures.
+- `set-like-array.js`: `s2 = [5,6]` with own `size/has/keys` data props is a plain JS array (not a wasm struct), passes through unwrapped, and V8 handles it — that sub-case is fine; the failures are the **wasm-class-instance** set-likes.
+
+**Conclusion:** the load-bearing fix is making `_wrapForHost`'s `get` trap (a)
+invoke wasm **accessor getters** (`get size`) and (b) return a real callable
+bridge for wasm **instance methods** (`has`, `keys`) that actually dispatches
+into the compiled method — i.e. the deferred **#1364b** "call user-class method
+via JS-side proxy" capability. That is a shared proxy-dispatch foundation, not a
+localized GetSetRecord shim, and is larger than the `feasibility: medium`
+estimate. The `keys()` generator must also return a real iterator the host can
+drive (overlaps the iterator-bridge work #1320/#1620).
+
+**Recommendation:** re-scope #1674 to depend on / fold into the #1364b proxy
+method+accessor dispatch (and the iterator bridge for `keys`), or route to an
+architect for a joint `_wrapForHost`-class-instance spec. The `intent.className
+=== "Set"` bridge stays untouched (correct per the issue).
+
+### The clusters split across THREE distinct deep gaps (not one shim)
+
+Verified per-test on main 2026-05-27:
+
+1. **wasm class-instance set-like** (`allows-set-like-class`, `set-like-class`):
+   needs `_wrapForHost` to dispatch wasm accessor getters + instance methods →
+   **#1364b** proxy method/accessor dispatch + iterator bridge for `keys`.
+2. **plain-array set-like** (`set-like-array.js`): `s2 = [5,6]; s2.size=3;
+   s2.has=fn; s2.keys=fn` — `.size` reads back **NaN**. The array compiles to a
+   wasm `number[]`/array struct that does NOT retain dynamically-added
+   non-index properties (`size`/`has`/`keys`), so they're lost. A separate
+   **wasm-array-arbitrary-property-retention** gap, not GetSetRecord.
+3. **plain-object set-like is already correct** (`allows-set-like-object`,
+   `called-with-object`, `has-is-callable`, `keys-is-callable` all PASS) — V8's
+   native GetSetRecord runs against the unwrapped plain object fine. So the
+   "implement our own GetSetRecord" framing would regress these.
+
+Because the residuals decompose into #1364b (proxy dispatch) + a wasm-array
+property-retention gap — two cross-cutting representation features — this is
+**not** a single localized runtime fix. Marked `status: blocked`,
+`escalation: needs-architect-spec`. No code changed; the `intent.className ===
+"Set"` bridge is untouched.


### PR DESCRIPTION
## Summary
Investigation of #1674 (GetSetRecord set-like consumption, ~53 built-ins/Set fails). Docs-only: marks the issue `status: blocked` / `escalation: needs-architect-spec` with the root-cause decomposition.

The "implement our own GetSetRecord" framing is wrong — the set-method receiver is a host-native `Set`, so V8's own GetSetRecord runs. The residuals split across **three distinct deep gaps**, verified per-test on main:

1. **wasm class-instance set-like** (`allows-set-like-class`, `set-like-class`): `_wrapForHost`'s proxy can't invoke wasm accessor getters (`get size` → NaN) or instance methods (`has`/`keys` return the throwing `_getProtoMethodBridge` placeholder, runtime.ts:2049). → needs **#1364b** proxy method/accessor dispatch + iterator bridge for `keys`.
2. **plain-array set-like** (`set-like-array.js`): `s2=[5,6]; s2.size=3; …` compiles to a wasm array that drops dynamically-added non-index props → `.size` NaN. Separate **wasm-array-property-retention** gap.
3. **plain-object set-like already passes** (`allows-set-like-object`, `called-with-object`, `has-is-callable`, `keys-is-callable`) — V8 native GetSetRecord handles the unwrapped object. The naive "own GetSetRecord" would regress these.

No code changed; the `intent.className === "Set"` bridge is untouched.

## Test plan
- [x] Per-test status verified on main (4/6 sampled clusters fail, 2 already pass)
- [x] Docs-only — no source changes, no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)