### PR TITLE
fix(#786): mixed numeric+object array literal boxes to externref

### DIFF
--- a/plan/issues/786-multi-assertion-failures-returned-n.md
+++ b/plan/issues/786-multi-assertion-failures-returned-n.md
@@ -199,3 +199,42 @@ and is a standalone spec-correctness improvement with no regression.
   cases + the pre-existing 11 block-scope / closure-capture cases).
 - Regression: `array-prototype-methods`, `array-externref-indexof`,
   `array-push-pop`, `issue-1360`, `in-operator-edge-cases` — 97/97 pass.
+
+## Implementation notes (mixed numeric+object array-literal typing, 2026-05-27, follow-up)
+
+This is the **array-element-typing change** the section above deferred — the
+piece that actually moves the dominant `[0, 1, targetObj].indexOf(targetObj)`
+cluster.
+
+### Root cause
+`compileArrayLiteral` (`src/codegen/literals.ts`, vec path ~L2299) inferred the
+vec element type from the **first element only**. For `[0, 1, o]` the first
+element is `0` → element type `f64`, so the trailing object `o` was compiled
+with an f64 hint and coerced to a number — the object reference was lost and
+`indexOf(o)` could never match. (`[o, 1, 2]` worked because the object came
+first.) The pre-existing escape only promoted to externref when a literal
+`null` was present.
+
+### Fix
+When the chosen first-element type is `f64`/`i32` but **any** non-string,
+non-undefined element resolves to a `ref`/`ref_null`/`externref` (a genuine
+object — e.g. an object literal `{}` resolves to externref), promote the whole
+vec to externref so object identity survives. String literals keep the
+native-string path; homogeneous numeric arrays are untouched. Combined with the
+externref strict-equality fix above, the search now matches by reference.
+
+### Test262 impact
+- 8 of 11 `indexOf`/`lastIndexOf` mixed-literal entries flip to PASS
+  (`15.4.4.14-5-10/-11/-18/-19/-20/-31/-32`, `15.4.4.15-5-22`).
+- Residual (out of scope): `[false].indexOf(0)` / `[false].lastIndexOf(0)`
+  cross-type on a **homogeneous boolean** vec (needs boolean arrays to box);
+  the `-0` SameValueZero case on a homogeneous number vec; and
+  `15.4.4.14-9-b-i-9` (index getters → **#1130**).
+
+### Test Results (this follow-up)
+- `tests/issue-786.test.ts` — 27/27 pass (6 new mixed-literal cases added).
+- No new failures in `array-methods` / `fast-arrays` /
+  `functional-array-methods` / `arrays-enums` — those carry a **pre-existing**
+  branch regression (22 / 9 / 23 / 9 fail), verified identical on
+  `c3f55339d~1` (before this issue's work) and unchanged by these edits.
+  Flagged for separate triage; NOT introduced here.

--- a/plan/issues/786-multi-assertion-failures-returned-n.md
+++ b/plan/issues/786-multi-assertion-failures-returned-n.md
@@ -1,9 +1,10 @@
 ---
 id: 786
 title: "- Multi-assertion failures: returned N > 2 (~1,183 tests)"
-status: in-review
+status: done
 created: 2026-03-25
-updated: 2026-04-28
+updated: 2026-05-27
+completed: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: high

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -2308,6 +2308,23 @@ export function compileArrayLiteral(
       const hasNullLiteral = expr.elements.some((e) => e.kind === ts.SyntaxKind.NullKeyword);
       if (hasNullLiteral) {
         elemWasm = { kind: "externref" };
+      } else if (elemWasm.kind === "f64" || elemWasm.kind === "i32") {
+        // A literal whose first element is numeric but which also contains a
+        // genuine object/reference element (e.g. `[0, 1, obj]`) must not store
+        // that object into an f64/i32 vec — the object reference would be
+        // coerced to a number and lost, so `[0,1,o].indexOf(o)` could never
+        // match (#786). Promote the whole vec to externref so object identity
+        // survives. Scoped to struct-ref / non-undefined externref elements:
+        // strings and numbers keep the numeric/native-string fast path.
+        const hasObjectElem = expr.elements.some((el) => {
+          if (ts.isOmittedExpression(el) || _isUndefinedLike(el) || ts.isSpreadElement(el)) return false;
+          if (el.kind === ts.SyntaxKind.StringLiteral) return false;
+          const t = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(el));
+          return t.kind === "ref" || t.kind === "ref_null" || t.kind === "externref";
+        });
+        if (hasObjectElem) {
+          elemWasm = { kind: "externref" };
+        }
       }
     }
   }

--- a/tests/issue-786.test.ts
+++ b/tests/issue-786.test.ts
@@ -264,3 +264,43 @@ describe("Issue #786: Array search methods use spec equality for externref eleme
     ).toBe(1);
   });
 });
+
+// #786 — A mixed array literal whose first element is numeric but which also
+// contains a genuine object element (e.g. `[0, 1, obj]`) was typed as an f64
+// vec from the first element, so the object reference was coerced to a number
+// and lost. `[0,1,o].indexOf(o)` could then never match. The fix promotes the
+// whole vec to externref when any element resolves to an object/ref type.
+describe("Issue #786: mixed numeric+object array literal preserves object refs", () => {
+  async function runExtern(src: string): Promise<number | boolean> {
+    const ex = await compileToWasm(src);
+    return ex.test() as number | boolean;
+  }
+
+  it("indexOf finds an object after leading numbers", async () => {
+    expect(await runExtern(`export function test(): number { const o={}; return [0,1,o].indexOf(o); }`)).toBe(2);
+  });
+
+  it("indexOf honours fromIndex for object after numbers", async () => {
+    expect(await runExtern(`export function test(): number { const o={}; return [0,1,o].indexOf(o,2); }`)).toBe(2);
+  });
+
+  it("indexOf object not found when fromIndex skips it", async () => {
+    expect(await runExtern(`export function test(): number { const o={}; return [0,o,2].indexOf(o,2); }`)).toBe(-1);
+  });
+
+  it("indexOf with string fromIndex coercion finds object", async () => {
+    expect(
+      await runExtern(`export function test(): number { const o={}; return [0,1,2,o,4].indexOf(o,"3E0" as any); }`),
+    ).toBe(3);
+  });
+
+  it("includes finds an object after leading numbers", async () => {
+    expect(await runExtern(`export function test(): boolean { const o={}; return [0,1,o].includes(o as any); }`)).toBe(
+      1,
+    );
+  });
+
+  it("homogeneous number array still uses numeric path", async () => {
+    expect(await runExtern(`export function test(): number { return [10,20,30].indexOf(20); }`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Array literals like `[0, 1, obj]` inferred their element type from the first element only, so a trailing object was stored into an f64/i32 vec and the object reference was coerced to a number and lost — `[0,1,o].indexOf(o)` could never match.
- Promote the whole vec to externref when any non-string, non-undefined element resolves to a ref/externref.
- Follow-up to PR #735 (externref strict-equality search fix, now merged to main). Combined, 8 of 11 indexOf/lastIndexOf mixed-literal test262 entries flip to PASS (15.4.4.14-5-10/-11/-18/-19/-20/-31/-32, 15.4.4.15-5-22).

## Test plan
- [x] `tests/issue-786.test.ts` — 27/27 pass on fresh origin/main
- [x] `tsc --noEmit` clean
- [ ] CI: all required checks green (test262 shards, quality, regression gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)