### PR TITLE
docs(#1673): mark done — super.method() on builtin parent already fixed by #1614

### DIFF
--- a/plan/issues/1673-super-method-builtin-parent.md
+++ b/plan/issues/1673-super-method-builtin-parent.md
@@ -1,9 +1,10 @@
 ---
 id: 1673
 title: "super.<method>() on a built-in parent class fails to compile"
-status: ready
+status: done
 created: 2026-05-27
 updated: 2026-05-27
+completed: 2026-05-27
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -64,3 +65,26 @@ erroring. Both `compileSuperMethodCall` (:118) and
 - The 7 `subclass-receiver-methods.js` tests compile (then pass or fail on
   their actual assertions, not CE).
 - No regression in user-class `super.method()` dispatch.
+
+## Resolution (2026-05-27, dev-1607) — ALREADY FIXED on main
+
+Verified against `origin/main` (HEAD aeb6cde16). The compile error described
+here no longer occurs: the `super.<method>()` builtin-parent fallback already
+exists as `emitSuperExternMethodCall` (`src/codegen/expressions/new-super.ts:64`),
+wired into both `compileSuperMethodCall` (:199-207) and
+`compileSuperElementMethodCall` (:294-300). When the resolved parent walks to a
+registered extern class and no user `funcMap` entry exists, it dispatches
+`super.method(args)` via `__extern_method_call(this, name, argsArray)` instead
+of erroring. This landed with the #1614 work.
+
+Verification:
+- Standalone compile probes (`super.has(...rest)`, `super.size`,
+  `super.keys(...rest)` on `class extends Set`) all compile — no CE.
+- The real test262 runner (`runTest262File`) on all 7 named files
+  (`built-ins/Set/prototype/{union,intersection,difference,symmetricDifference,
+  isSubsetOf,isSupersetOf,isDisjointFrom}/subclass-receiver-methods.js`)
+  reports **PASS** for all 7 — they not only compile but also pass their actual
+  assertions (`Set.prototype.union` & friends never call the receiver's
+  overridden `size`/`has`/`keys`).
+
+No source change needed. Closing as done (stale — fixed by #1614 dispatch path).


### PR DESCRIPTION
## Summary
- #1673 reported `super.<method>()` on a built-in parent class (Set/Map/Array) failing at compile time.
- Verified on origin/main: the fallback already exists as `emitSuperExternMethodCall` (`src/codegen/expressions/new-super.ts:64`), wired into both `compileSuperMethodCall` (:199-207) and `compileSuperElementMethodCall` (:294-300). It dispatches `super.method(args)` on a builtin-extern parent via `__extern_method_call(this, name, argsArray)` instead of erroring. This landed with the #1614 work.
- No source change needed — docs-only: marks the issue `done` with the verification record.

## Verification
- Standalone compile probes (`super.has(...rest)`, `super.size`, `super.keys(...rest)` on `class extends Set`) all compile — no CE.
- Real test262 runner (`runTest262File`) on all 7 named files `built-ins/Set/prototype/{union,intersection,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom}/subclass-receiver-methods.js` → **PASS** for all 7 (compile + actual assertions).

## Test plan
- [x] 7 affected test262 files PASS via real runner
- [x] standalone compile probes for rest-param/getter/keys super-dispatch compile cleanly