### PR TITLE
fix(#1528b): unwrap as/!/type-assertion in new-expression non-constructor guards

### DIFF
--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -1,9 +1,9 @@
 ---
 id: 1528
 title: "spec gap: non-constructor TypeError — Promise.all / allSettled species and executor paths"
-status: ready
+status: in-progress
 created: 2026-05-20
-updated: 2026-05-20
+updated: 2026-05-27
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -69,3 +69,44 @@ thrown object isn't recognised as `TypeError`. Two cases are related:
 
 **~79 test262 tests** plus indirect downstream unblocks once Promise
 combinators round-trip species correctly.
+
+## Investigation + decomposition (2026-05-27)
+
+Ran the five named test262 files and ground-truth compile/instantiate/run
+probes on current main. The cluster is NOT a single Promise/species bug; it is
+dominated by a **missing dynamic `[[Construct]]` path**, and the species half
+is already spec-correct.
+
+### Confirmed by probe
+1. **Dynamic `new <runtime-value>()` does not perform IsConstructor + throw.**
+   `new executorFunction()` where the callee is a runtime function value (the
+   `isConstructor.js`-harness tests) is the dominant failing shape. Today such
+   identifiers fall into the unknown-constructor `__new_<name>` extern-import
+   path (throws a generic `No dependency provided` Error, not a TypeError) or
+   silently no-throw. A type-checker heuristic cannot fix this safely: TS models
+   plain function *declarations* as call-only (`construct=0, call=1`), identical
+   to non-constructable function *expression values* — but `new f()` on a
+   function value IS valid JS, so rejecting on the signature shape would regress
+   valid constructions. This needs the architect-spec'd dynamic-construct path
+   (route to `__reflect_construct` / Wasm-native IsConstructor), which touches
+   the most-trafficked `new` dispatch. **Tracked as #1528a — needs architect
+   sign-off; NOT landed here.**
+2. **Species half already correct.** `Promise.allSettled.call(C, [])` does not
+   spuriously read `@@species` (probe passed); the JS-host delegation in
+   `runtime.ts` `Promise_allSettled` → native `Promise.allSettled.call` is
+   spec-correct.
+3. **`10.4.3-1-26gs.js` is mis-bucketed** — a strict-mode `new (anon fn)`
+   returning `this` case, unrelated to non-constructor TypeError.
+
+### Landed here (#1528b — safe static subset)
+Broadened the static non-constructor guards in `new-super.ts` to unwrap
+`as`/`!`/type-assertion wrappers (not just parens) via a shared
+`unwrapNewTarget` helper, so `new ((() => {}) as any)()` and
+`new (Math.abs as any)()` hit the real-TypeError throw path instead of slipping
+into the dynamic path and silently no-throwing. The call-sig-only / prototype-
+method guards now resolve the type on the *pre-cast* target. ~30 LOC, additive,
+zero regressions in the constructor/new unit suites. Spec §7.3.15 Construct /
+§7.2.4 IsConstructor.
+
+**Status:** #1528b landed; #1528a (the dominant 79-test cluster) remains open,
+escalated for an architect dynamic-construct spec.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1438,12 +1438,32 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     return compileNewFunctionExpression(ctx, fctx, expr, expr.expression);
   }
 
+  // (#1528b) Unwrap parens AND `as`/`!`/type-assertion wrappers so the static
+  // non-constructor guards below still fire on `new ((() => {}) as any)()` etc.
+  // — the bare paren-only unwrap let cast arrows slip through to the dynamic
+  // path and silently no-throw. Mirrors the builtin-namespace unwrap below.
+  const unwrapNewTarget = (e: ts.Expression): ts.Expression => {
+    let cur = e;
+    while (
+      ts.isParenthesizedExpression(cur) ||
+      ts.isAsExpression(cur) ||
+      ts.isNonNullExpression(cur) ||
+      ts.isTypeAssertionExpression(cur)
+    ) {
+      cur = ts.isParenthesizedExpression(cur)
+        ? cur.expression
+        : ts.isAsExpression(cur)
+          ? cur.expression
+          : ts.isNonNullExpression(cur)
+            ? cur.expression
+            : (cur as ts.TypeAssertion).expression;
+    }
+    return cur;
+  };
+
   // Arrow functions are NOT constructors — `new (() => {})` throws TypeError (#730)
   {
-    let unwrappedNew: ts.Expression = expr.expression;
-    while (ts.isParenthesizedExpression(unwrappedNew)) {
-      unwrappedNew = unwrappedNew.expression;
-    }
+    const unwrappedNew = unwrapNewTarget(expr.expression);
     if (ts.isArrowFunction(unwrappedNew)) {
       // #1528: throw a real TypeError instance so `assert.throws(TypeError, …)`
       // catches it (the bare-string throw is only `instanceof Error`/string).
@@ -1490,12 +1510,15 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   }
 
   // Non-identifier constructor: detect non-constructable functions.
-  if (!ts.isIdentifier(expr.expression) && !ts.isFunctionExpression(expr.expression)) {
+  // (#1528b) Unwrap `as`/`!`/type-assertion/paren wrappers so the guards fire
+  // on `new (Array.prototype.map as any)()` etc., not just the bare form.
+  const unwrappedNonId = unwrapNewTarget(expr.expression);
+  if (!ts.isIdentifier(unwrappedNonId) && !ts.isFunctionExpression(unwrappedNonId)) {
     // Pattern 1: `new X.prototype.Y()` — prototype methods are NEVER constructors.
     // This covers both ES2022 (forEach) and ES2023 (with, toSorted) methods,
     // even when TypeScript lib doesn't know about the method (type resolves to `any`).
-    if (ts.isPropertyAccessExpression(expr.expression)) {
-      const obj = expr.expression.expression; // e.g. Array.prototype
+    if (ts.isPropertyAccessExpression(unwrappedNonId)) {
+      const obj = unwrappedNonId.expression; // e.g. Array.prototype
       if (ts.isPropertyAccessExpression(obj) && obj.name.text === "prototype") {
         // #1528: real TypeError instance so test262 `assert.throws(TypeError, …)`
         // catches it (prototype methods are not constructors per spec §9.2.2).
@@ -1507,7 +1530,8 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
     // Pattern 2: TypeScript knows the expression has call sigs but no construct sigs.
     // e.g. `new decodeURIComponent()`, `new Math.abs()`, `new Array.from()`.
-    const exprType = ctx.checker.getTypeAtLocation(expr.expression);
+    // Resolve on the unwrapped target so a cast doesn't widen it to `any`.
+    const exprType = ctx.checker.getTypeAtLocation(unwrappedNonId);
     const constructSigs = ctx.checker.getSignaturesOfType(exprType, ts.SignatureKind.Construct);
     const callSigs = ctx.checker.getSignaturesOfType(exprType, ts.SignatureKind.Call);
     if (callSigs.length > 0 && constructSigs.length === 0) {

--- a/tests/issue-1528.test.ts
+++ b/tests/issue-1528.test.ts
@@ -95,4 +95,41 @@ export function test(): string {
     const msg = exports.test!() as string;
     expect(msg).toContain("is not a constructor");
   });
+
+  // (#1528b) The static non-constructor guards must also fire when the target
+  // is hidden behind an `as`/`!`/type-assertion wrapper, not just bare parens.
+  // Before the unwrap fix, `new ((() => {}) as any)()` slipped past the
+  // paren-only unwrap into the dynamic path and silently did NOT throw.
+  it("`new ((() => {}) as any)()` throws an instance of TypeError", async () => {
+    const source = `
+export function test(): number {
+  try {
+    new ((() => {}) as any)();
+    return -1;
+  } catch (e: any) {
+    return e instanceof TypeError ? 1 : -2;
+  }
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
+
+  // (#1528b) Cast-wrapped prototype-method / call-only-callable targets must
+  // resolve through the unwrap so the call-sig-only guard still sees the real
+  // (pre-cast) type rather than the widened `any`.
+  it("`new (Math.abs as any)()` throws an instance of TypeError", async () => {
+    const source = `
+export function test(): number {
+  try {
+    new (Math.abs as any)(1);
+    return -1;
+  } catch (e: any) {
+    return e instanceof TypeError ? 1 : -2;
+  }
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a shared `unwrapNewTarget` helper (parens + `as`/`!`/type-assertion) in `new-super.ts` so the static non-constructor guards fire on cast-wrapped targets like `new ((() => {}) as any)()` and `new (Math.abs as any)()`, which previously slipped past the paren-only unwrap into the dynamic construct path and silently did **not** throw.
- The prototype-method / call-sig-only guards now resolve the type on the *pre-cast* target so a cast can't widen it to `any`.
- Per ECMA-262 §7.3.15 Construct / §7.2.4 IsConstructor: constructing a value without `[[Construct]]` must throw `TypeError`.

## Scope (#1528 decomposition)
This lands the **safe static-cast subset (#1528b)** only. Investigation (in the issue file) found the dominant 79-test test262 cluster is a **missing dynamic `[[Construct]]` path (#1528a)** — `new <runtime-value>()`. That cannot be a dev-level type-checker heuristic (TS models plain function declarations identically to non-constructable function-expression values, so a signature-shape guard would regress valid `new f()`); it needs the architect dynamic-construct spec and touches the hottest `new` dispatch. **#1528a remains escalated.** The species half of #1528 is already spec-correct (probed).

## Test plan
- [x] `tests/issue-1528.test.ts` — 6/6 pass (incl. 2 new cast-wrapped cases)
- [x] `tests/issue-1519.test.ts`, `tests/issue-1679.test.ts`, `new-non-constructor`, `fn-constructor`, `new-function-noop` — green
- [x] `tsc --noEmit` clean
- [x] No regressions in the constructor/new suites (one pre-existing `constructor-arity` harness fail on clean main HEAD, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)