### PR TITLE
fix(any): guard struct-ref null fast-path against $AnyValue refs

### DIFF
--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -423,8 +423,12 @@ function compileExpressionBody(
     }
   }
 
-  // Fast-path: null/undefined in struct ref context
-  if (expectedType && (expectedType.kind === "ref_null" || expectedType.kind === "ref")) {
+  // Fast-path: null/undefined in struct ref context (skip for $AnyValue — handled below)
+  if (
+    expectedType &&
+    (expectedType.kind === "ref_null" || expectedType.kind === "ref") &&
+    !isAnyValue(expectedType, ctx)
+  ) {
     let inner: ts.Expression = expr;
     while (
       ts.isAsExpression(inner) ||


### PR DESCRIPTION
## Summary

- The null/undefined struct-ref fast-path in `expressions.ts` matched all `ref_null` types including `$AnyValue`, emitting a raw `ref.null` instruction instead of calling `__any_box_null` / `__any_box_undefined`
- `__any_unbox_bool` (and other unboxers) then trapped with "dereferencing a null pointer" when receiving the raw null pointer on `struct.get`
- Fix: add `!isAnyValue(expectedType, ctx)` guard so `null`/`undefined` assigned to `any`-typed locals go through the boxing helpers

Fixes 2 equivalence regressions:
- `Gradual typing: boxed any (fast mode) > any null boxing — truthiness`
- `Gradual typing: boxed any (fast mode) > any undefined boxing — truthiness`

## Test plan

- [x] `npm test -- tests/equivalence/gradual-typing.test.ts` — 34/34 pass (was 32/34)
- [x] Equivalence gate: run via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)