### PR TITLE
fix(#1644): BigInt(value) constructor — SyntaxError/RangeError per §21.2.1.1 (Slice B)

### DIFF
--- a/plan/issues/1644-spec-gap-bigint-typed-paths.md
+++ b/plan/issues/1644-spec-gap-bigint-typed-paths.md
@@ -151,6 +151,57 @@ No code landed — a type-guard-only patch cannot satisfy the ≥75% acceptance
 bar and risks regressing native `type i64` code without the brand decision.
 Baseline recorded: 28/77 pass on b290fe96d.
 
+## Slice B implementation (2026-05-27, senior-developer)
+
+Implemented the spec `BigInt(value)` constructor (§21.2.1.1) on top of Slice A's
+brand plumbing (branched off `issue-1644-slice-a`). Before: a string arg fell
+through and returned the raw string; an f64 arg silently truncated instead of
+throwing. After: full ToPrimitive(number) → NumberToBigInt (RangeError) /
+ToBigInt → StringToBigInt (SyntaxError) semantics.
+
+**New host helper `__bigint_ctor(externref) → i64`** — distinct from Slice A's
+`__to_bigint` (§7.1.13 ToBigInt, which throws **TypeError** on a Number). The
+constructor must throw **RangeError** on a non-safe-integer Number, so it needs
+its own helper:
+- Number → `Number.isInteger` gate then `BigInt(n)`; NaN/±Infinity/non-integer
+  all fail the gate → RangeError (NumberToBigInt).
+- Symbol → TypeError. bigint/boolean → identity/0n/1n. string → `BigInt(s)`
+  (StringToBigInt parses hex/octal/binary/decimal; SyntaxError on malformed).
+- WasmGC-struct / proxy args run through `_toPrimitive`/`_hostToPrimitive`
+  ("number" hint) first (ToPrimitive step).
+
+Files (5):
+- `src/codegen/index.ts` — declare `__bigint_ctor` import + add to the
+  index-shift skip set.
+- `src/compiler/import-manifest.ts` — map `__bigint_ctor` to a `builtin` intent.
+- `src/runtime.ts` — `__bigint_ctor` body in the `builtin` dispatch.
+- `src/codegen/expressions/calls.ts` — `BigInt(x)` routes f64/string/object
+  through `__bigint_ctor`; **compile-time numeric-literal fold** to `i64.const`
+  for safe integers (incl. negative `-NumericLiteral`) avoids a host call;
+  i32/native-i64 still extend/identity directly (no RangeError possible).
+- `tests/equivalence/helpers.ts` — `__bigint_ctor` for the unit-test host.
+
+**Result:** `built-ins/BigInt` constructor tests **3/22 → 15/22** through the
+real runner. Slice B tests `tests/issue-1644-sliceb.test.ts` (6) + Slice A
+`tests/issue-1644.test.ts` (5) all pass; tsc clean.
+
+### Residual (still failing, out of Slice-B scope)
+- `is-a-constructor`, `proto`, `wrapper-object-ordinary-toprimitive` — need the
+  `BigInt` **extern wrapper class** dependency (shared with #1568, host-class
+  gap), not constructor semantics.
+- `constructor-coercion` — `Symbol.toPrimitive` on a WasmGC struct returning a
+  string: the struct's `Symbol.toPrimitive` is a Wasm closure the host can't
+  invoke (#1090 ToPrimitive-with-closure gap).
+- `constructor-from-decimal-string` / `constructor-integer` /
+  `constructor-trailing-leading-spaces` — fail only at the **negative** assert
+  (`BigInt("-10")`, `BigInt(-MAX_SAFE_INTEGER)`) **under the test262 harness**.
+  Verified the same comparison passes in isolation and in the equivalence
+  helper (`BigInt("-10") === -10n` → true in-Wasm), so this is the harness
+  `wrapTest`/scope-wrapping artifact tracked in #1318/#786, not a constructor
+  bug.
+
+Slices C (`asIntN`/`asUintN`) and D (`toString(radix)`) remain open.
+
 ## Architect Decision — i64-bigint-brand ValType representation (RATIFIED 2026-05-27)
 
 This section answers the open representation question the developer flagged

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6871,25 +6871,58 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       return argType;
     }
 
-    // BigInt(x) — ToBigInt coercion. (#1644 Slice A) The result is brand-bigint
-    // so it boxes as a JS bigint at the externref frontier. Full string-parse /
-    // RangeError semantics are Slice B; here we keep the existing numeric
-    // truncation but tag the result type.
+    // BigInt(x) — §21.2.1.1 constructor. (#1644 Slice A+B) The result is
+    // brand-bigint so it boxes as a JS bigint at the externref frontier.
+    //
+    // - i32 / native-i64: already an integer Number representation, no
+    //   RangeError possible — extend/identity directly (avoids a host call).
+    // - f64: may be a non-safe-integer / NaN / ±Infinity → must throw
+    //   RangeError (NumberToBigInt). Box to externref, then __bigint_ctor.
+    // - string / object / boolean (externref): StringToBigInt (SyntaxError on
+    //   malformed syntax), ToPrimitive on objects, boolean → 0n/1n →
+    //   __bigint_ctor.
     if (funcName === "BigInt" && expr.arguments.length >= 1) {
-      const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
-      if (argType?.kind === "f64") {
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" });
+      // Compile-time numeric literal: fold to an i64.const when it is a safe
+      // integer (NumberToBigInt with no RangeError), avoiding a host call.
+      // A negative literal parses as a unary-minus on a NumericLiteral.
+      const litArg = expr.arguments[0]!;
+      let litNum: number | undefined;
+      if (ts.isNumericLiteral(litArg)) {
+        litNum = Number(litArg.text);
+      } else if (
+        ts.isPrefixUnaryExpression(litArg) &&
+        litArg.operator === ts.SyntaxKind.MinusToken &&
+        ts.isNumericLiteral(litArg.operand)
+      ) {
+        litNum = -Number(litArg.operand.text);
+      }
+      if (litNum !== undefined && Number.isSafeInteger(litNum)) {
+        fctx.body.push({ op: "i64.const", value: BigInt(litNum) } as Instr);
         return { kind: "i64", bigint: true };
       }
+
+      const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
       if (argType?.kind === "i32") {
         fctx.body.push({ op: "i64.extend_i32_s" });
         return { kind: "i64", bigint: true };
       }
-      // Already i64 — tag as bigint-branded.
+      // Already i64 — tag as bigint-branded (native integer, no RangeError).
       if (argType?.kind === "i64") {
         return { kind: "i64", bigint: true };
       }
-      return argType;
+      addUnionImports(ctx);
+      // Coerce the argument to externref so the §21.2.1.1 host helper can run
+      // ToPrimitive + NumberToBigInt / StringToBigInt with the correct
+      // RangeError / SyntaxError / TypeError semantics.
+      if (argType && argType.kind !== "externref") {
+        coerceType(ctx, fctx, argType, { kind: "externref" }, "default");
+      }
+      const ctorIdx = ctx.funcMap.get("__bigint_ctor");
+      if (ctorIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: ctorIdx });
+        return { kind: "i64", bigint: true };
+      }
+      return { kind: "i64", bigint: true };
     }
 
     // Number() with 0 args → 0

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6262,6 +6262,13 @@ export function addUnionImports(ctx: CodegenContext): void {
   const toBigType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i64" }]);
   addImport(ctx, "env", "__to_bigint", { kind: "func", typeIdx: toBigType });
 
+  // __bigint_ctor: (externref) → i64  (#1644 Slice B — §21.2.1.1 BigInt(value):
+  // ToPrimitive(number) then NumberToBigInt (RangeError) for Number, else
+  // ToBigInt (SyntaxError on bad string syntax). Distinct from __to_bigint,
+  // which throws TypeError on a Number per §7.1.13.)
+  const ctorBigType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i64" }]);
+  addImport(ctx, "env", "__bigint_ctor", { kind: "func", typeIdx: ctorBigType });
+
   // __typeof: (externref) → externref (returns type string)
   const typeofStrType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
   addImport(ctx, "env", "__typeof", {
@@ -6291,6 +6298,7 @@ export function addUnionImports(ctx: CodegenContext): void {
       "__box_boolean",
       "__box_bigint",
       "__to_bigint",
+      "__bigint_ctor",
       "__typeof",
     ]);
     // Update funcMap entries for defined functions (not imports)

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -105,6 +105,7 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   if (name === "__box_boolean") return { type: "box", targetType: "boolean" };
   if (name === "__box_bigint") return { type: "box", targetType: "bigint" };
   if (name === "__to_bigint") return { type: "unbox", targetType: "bigint" };
+  if (name === "__bigint_ctor") return { type: "builtin", name: "__bigint_ctor" };
   if (name === "__is_truthy") return { type: "truthy_check" };
   if (name === "__typeof") return { type: "builtin", name: "__typeof" };
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3367,6 +3367,40 @@ function resolveImport(
     }
     case "builtin": {
       const name = intent.name;
+      // (#1644 Slice B) __bigint_ctor: §21.2.1.1 BigInt(value).
+      //   1. ToPrimitive(value, number)
+      //   2. If prim is a Number → NumberToBigInt: RangeError unless it is a
+      //      safe integer (NaN / ±Infinity / non-integer all throw RangeError).
+      //   3. Otherwise → ToBigInt(prim): bigint identity; boolean → 0n/1n;
+      //      string → StringToBigInt (SyntaxError on malformed numeric string);
+      //      Symbol → TypeError.
+      // Returns the bigint as a wasm i64 (JS-BigInt-integration).
+      if (name === "__bigint_ctor") {
+        return (v: any): bigint => {
+          // ToPrimitive(value, number). WasmGC structs / proxies need our
+          // host ToPrimitive; plain host primitives/objects use the native one.
+          let prim = v;
+          if (v != null && typeof v === "object") {
+            const p = _toPrimitive(v, "number", callbackState);
+            prim = p !== undefined ? p : _hostToPrimitive(v, "number", callbackState);
+          }
+          if (typeof prim === "number") {
+            // NumberToBigInt: RangeError unless a safe integer.
+            if (!Number.isInteger(prim)) {
+              throw new RangeError(
+                "The number " + prim + " cannot be converted to a BigInt because it is not an integer",
+              );
+            }
+            return BigInt(prim);
+          }
+          if (typeof prim === "symbol") {
+            throw new TypeError("Cannot convert a Symbol value to a BigInt");
+          }
+          // bigint → identity; boolean → 0n/1n; string → StringToBigInt
+          // (BigInt() throws SyntaxError on a malformed numeric string).
+          return BigInt(prim);
+        };
+      }
       // Batched string concat: __concat_3, __concat_4, ... (#958)
       if (name.startsWith("__concat_")) {
         return (...args: any[]) => {

--- a/tests/equivalence/helpers.ts
+++ b/tests/equivalence/helpers.ts
@@ -72,6 +72,19 @@ export function buildImports(result: CompileResult): WebAssembly.Imports {
       if (typeof v === "symbol") throw new TypeError("Cannot convert a Symbol value to a BigInt");
       return BigInt(v);
     },
+    // (#1644 Slice B) __bigint_ctor: §21.2.1.1 BigInt(value). Number →
+    // NumberToBigInt (RangeError unless safe integer); string → StringToBigInt
+    // (SyntaxError on malformed); Symbol → TypeError; bigint/boolean identity.
+    __bigint_ctor: (v: any): bigint => {
+      if (typeof v === "number") {
+        if (!Number.isInteger(v)) {
+          throw new RangeError(`The number ${v} cannot be converted to a BigInt because it is not an integer`);
+        }
+        return BigInt(v);
+      }
+      if (typeof v === "symbol") throw new TypeError("Cannot convert a Symbol value to a BigInt");
+      return BigInt(v);
+    },
     __make_callback: () => null,
     __extern_get: (obj: any, key: any) => (obj == null ? undefined : obj[key]),
     __extern_set: (obj: any, key: any, val: any) => {

--- a/tests/issue-1644-sliceb.test.ts
+++ b/tests/issue-1644-sliceb.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #1644 Slice B — BigInt(value) constructor (§21.2.1.1).
+//
+// The constructor coerces via ToPrimitive(number); a resulting Number goes
+// through NumberToBigInt (RangeError unless a safe integer); anything else
+// goes through ToBigInt (StringToBigInt parses hex/octal/binary/decimal and
+// throws SyntaxError on malformed input; boolean → 0n/1n; Symbol → TypeError).
+describe("#1644 Slice B — BigInt(string|number) constructor", () => {
+  it("parses a decimal string", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        return BigInt("42");
+      }
+    `);
+    const v = exports.test();
+    expect(typeof v).toBe("bigint");
+    expect(v).toBe(42n);
+  });
+
+  it("parses hex / octal / binary strings", async () => {
+    const exports = await compileToWasm(`
+      export function test(s: any): any {
+        return BigInt(s);
+      }
+    `);
+    expect(exports.test("0xff")).toBe(255n);
+    expect(exports.test("0o17")).toBe(15n);
+    expect(exports.test("0b101")).toBe(5n);
+    expect(exports.test("")).toBe(0n);
+    expect(exports.test("  42  ")).toBe(42n);
+  });
+
+  it("throws SyntaxError on a malformed numeric string", async () => {
+    const exports = await compileToWasm(`
+      export function test(s: any): any {
+        return BigInt(s);
+      }
+    `);
+    expect(() => exports.test("10n")).toThrow(SyntaxError);
+    expect(() => exports.test("10.5")).toThrow(SyntaxError);
+    expect(() => exports.test("abc")).toThrow(SyntaxError);
+  });
+
+  it("throws RangeError on a non-integer number", async () => {
+    const exports = await compileToWasm(`
+      export function test(n: number): any {
+        return BigInt(n);
+      }
+    `);
+    expect(() => exports.test(1.5)).toThrow(RangeError);
+    expect(() => exports.test(0.00005)).toThrow(RangeError);
+    expect(() => exports.test(NaN)).toThrow(RangeError);
+    expect(() => exports.test(Infinity)).toThrow(RangeError);
+  });
+
+  it("accepts an integer number", async () => {
+    const exports = await compileToWasm(`
+      export function test(n: number): any {
+        return BigInt(n);
+      }
+    `);
+    expect(exports.test(255)).toBe(255n);
+    expect(exports.test(-7)).toBe(-7n);
+  });
+
+  it("native integer literal — no host roundtrip, no RangeError", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        return BigInt(100);
+      }
+    `);
+    expect(exports.test()).toBe(100n);
+  });
+});


### PR DESCRIPTION
## Summary

Implements §21.2.1.1 BigInt(value) on top of Slice A's i64-bigint brand (merged in #734).

- ToPrimitive(number) → NumberToBigInt (RangeError on non-safe-integer) for a Number
- Otherwise ToBigInt → StringToBigInt (SyntaxError on malformed numeric string; hex/octal/binary/decimal parse)
- Result is brand-bigint i64
- New host import \`__bigint_ctor\` (externref → i64), distinct from Slice A's \`__to_bigint\` (§7.1.13 ToBigInt, which throws TypeError on a Number — the constructor must throw RangeError)
- Compile-time numeric-literal fold to i64.const for safe integers (incl. negative \`-NumericLiteral\`) avoids a host call

Re-cut from current \`origin/main\` (which already carries Slice A from #734). Replaces the abandoned \`issue-1644-slice-b\` branch which was based on the pre-merge Slice A and had a stale main-integration merge commit.

## Test plan
- [x] \`tests/issue-1644-sliceb.test.ts\` (6 tests) pass
- [x] \`tests/issue-1644.test.ts\` Slice A regression (5 tests) pass
- [x] Equivalence gate: 0 new regressions (7 incidental baseline-now-pass, unrelated to this PR — main's recent merges)
- [x] Pre-push typecheck + lint OK
- [ ] CI cheap gate, sharded test262, equivalence-shard, quality
- [ ] Self-merge on green per dev-self-merge skill

## Files
- \`src/codegen/index.ts\` — declare \`__bigint_ctor\` import + index-shift skip set
- \`src/compiler/import-manifest.ts\` — map \`__bigint_ctor\` to a builtin intent
- \`src/runtime.ts\` — \`__bigint_ctor\` body in the builtin dispatch
- \`src/codegen/expressions/calls.ts\` — \`BigInt(x)\` routes f64/string/object through \`__bigint_ctor\`; compile-time literal fold
- \`tests/equivalence/helpers.ts\` — \`__bigint_ctor\` for the unit-test host
- \`tests/issue-1644-sliceb.test.ts\` — 6 new tests
- \`plan/issues/1644-spec-gap-bigint-typed-paths.md\` — Slice B notes

built-ins/BigInt constructor tests 3/22 → 15/22 through the real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)