### PR TITLE
fix(#1644): BigInt.prototype.toString(radix) — Slice D (i64 host dispatch)

### DIFF
--- a/plan/issues/1644-spec-gap-bigint-typed-paths.md
+++ b/plan/issues/1644-spec-gap-bigint-typed-paths.md
@@ -144,8 +144,18 @@ JS/host boundary and the `BigInt()` constructor:
   fails.
 - **Slice B:** `BigInt(string|number)` via `__to_bigint` (SyntaxError /
   RangeError per spec). Depends on A for comparable results.
-- **Slice C:** `BigInt.asIntN` / `asUintN` codegen + runtime.
-- **Slice D:** `BigInt.prototype.toString(radix)`.
+- **Slice C:** `BigInt.asIntN` / `asUintN` codegen + runtime. **STATUS:** already
+  works on current main via the generic `__extern_method_call` host-bridge
+  path (verified 2026-05-28 — `BigInt.asIntN(8, 256n) === 0n` etc.). No
+  codegen change required; can be folded into Slice D's PR as a coverage
+  note in the unit test if desired.
+- **Slice D:** `BigInt.prototype.toString(radix)`. **STATUS:** landed in PR for
+  this commit. `bigint_toString` (1-arg i64 → externref) and
+  `bigint_toString_radix` (2-arg i64 + i32 → externref) host imports added
+  to the runtime/allowlist; codegen routes typed-bigint `.toString(...)` via
+  these mirroring the `number_toString` pattern, including the §21.2.3.4
+  radix 2-36 RangeError guard. Test: `tests/issue-1644-slice-d.test.ts`
+  (7 cases, all pass).
 
 No code landed — a type-guard-only patch cannot satisfy the ≥75% acceptance
 bar and risks regressing native `type i64` code without the brand decision.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -263,6 +263,15 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
         state.primitiveNeeded.add("number_toString_radix");
       }
     }
+    // (#1644 Slice D) BigInt.prototype.toString — bigint-typed receiver routes
+    // to bigint_toString / bigint_toString_radix (i64 → externref). Without
+    // this registration the property-access path falls through and returns null.
+    if (isBigIntType(receiverType) && methodName === "toString") {
+      state.primitiveNeeded.add("bigint_toString");
+      if (node.arguments.length > 0) {
+        state.primitiveNeeded.add("bigint_toString_radix");
+      }
+    }
     if (isNumberType(receiverType) && methodName === "toFixed") {
       state.primitiveNeeded.add("number_toFixed");
     }
@@ -856,6 +865,15 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   if (state.primitiveNeeded.has("number_toString_radix")) {
     const t = addFuncType(ctx, [{ kind: "f64" }, { kind: "f64" }], [{ kind: "externref" }]);
     addImport(ctx, "env", "number_toString_radix", { kind: "func", typeIdx: t });
+  }
+  // (#1644 Slice D) BigInt#toString — i64 receiver, optional i32 radix.
+  if (state.primitiveNeeded.has("bigint_toString")) {
+    const t = addFuncType(ctx, [{ kind: "i64" }], [{ kind: "externref" }]);
+    addImport(ctx, "env", "bigint_toString", { kind: "func", typeIdx: t });
+  }
+  if (state.primitiveNeeded.has("bigint_toString_radix")) {
+    const t = addFuncType(ctx, [{ kind: "i64" }, { kind: "i32" }], [{ kind: "externref" }]);
+    addImport(ctx, "env", "bigint_toString_radix", { kind: "func", typeIdx: t });
   }
   // #1321 / #1335 Phase 2: in standalone / WASI mode there is no JS host to
   // satisfy the `number_toFixed` / `number_toPrecision` / `number_toExponential`

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5871,6 +5871,58 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         return { kind: "externref" };
       }
     }
+    // (#1644 Slice D) BigInt.prototype.toString — bigint receivers cross the
+    // boundary as i64. Mirror the number branch: validate radix range (2-36),
+    // throw RangeError otherwise, then call bigint_toString_radix (or the
+    // 1-arg bigint_toString for the default radix-10 case).
+    if (isBigIntType(receiverType) && propAccess.name.text === "toString") {
+      let radixLocalIdx: number | undefined;
+      if (expr.arguments.length > 0) {
+        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
+        fctx.body.push({ op: "f64.floor" });
+        radixLocalIdx = allocLocal(fctx, `__bi_radix_${fctx.locals.length}`, { kind: "f64" });
+        fctx.body.push({ op: "local.tee", index: radixLocalIdx });
+        fctx.body.push({ op: "f64.const", value: 2 });
+        fctx.body.push({ op: "f64.lt" });
+        fctx.body.push({ op: "local.get", index: radixLocalIdx });
+        fctx.body.push({ op: "f64.const", value: 36 });
+        fctx.body.push({ op: "f64.gt" });
+        fctx.body.push({ op: "i32.or" });
+        fctx.body.push({ op: "local.get", index: radixLocalIdx });
+        fctx.body.push({ op: "local.get", index: radixLocalIdx });
+        fctx.body.push({ op: "f64.ne" });
+        fctx.body.push({ op: "i32.or" });
+        {
+          const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
+          addStringConstantGlobal(ctx, rangeErrMsg);
+          const tagIdx = ensureExnTag(ctx);
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
+            else: [],
+          });
+        }
+      }
+      const exprType = compileExpression(ctx, fctx, propAccess.expression);
+      if (exprType && exprType.kind === "i32") {
+        fctx.body.push({ op: "i64.extend_i32_s" });
+      }
+      if (radixLocalIdx !== undefined) {
+        const radixFuncIdx = ctx.funcMap.get("bigint_toString_radix");
+        if (radixFuncIdx !== undefined) {
+          fctx.body.push({ op: "local.get", index: radixLocalIdx });
+          fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+          fctx.body.push({ op: "call", funcIdx: radixFuncIdx });
+          return { kind: "externref" };
+        }
+      }
+      const funcIdx = ctx.funcMap.get("bigint_toString");
+      if (funcIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx });
+        return { kind: "externref" };
+      }
+    }
     if (isNumberType(receiverType) && propAccess.name.text === "toFixed") {
       const exprType = compileExpression(ctx, fctx, propAccess.expression);
       if (exprType && exprType.kind === "i32") {

--- a/src/codegen/host-import-allowlist.ts
+++ b/src/codegen/host-import-allowlist.ts
@@ -105,6 +105,20 @@ export const HOST_IMPORT_ALLOWLIST: readonly HostImportAllowlistEntry[] = [
   },
   {
     kind: "exact",
+    name: "bigint_toString",
+    signature: "(i64) -> externref",
+    trackingIssue: 1644,
+    reason: "BigInt#toString default radix 10 (Slice D).",
+  },
+  {
+    kind: "exact",
+    name: "bigint_toString_radix",
+    signature: "(i64, i32) -> externref",
+    trackingIssue: 1644,
+    reason: "BigInt#toString(radix) base 2-36 (Slice D).",
+  },
+  {
+    kind: "exact",
     name: "number_toFixed",
     signature: "(f64, i32) -> externref",
     trackingIssue: 1335,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3411,6 +3411,12 @@ function resolveImport(
       // `number_toString` only handled base 10; the codegen previously dropped
       // the radix on the floor, silently producing decimal output for any radix.
       if (name === "number_toString_radix") return (v: number, r: number) => v.toString(r);
+      // (#1644 Slice D) BigInt.prototype.toString — bigint flows as i64 across
+      // the boundary thanks to JS-BigInt-integration. Default radix is 10; the
+      // 2-arg variant accepts a radix (2-36) and propagates RangeError per
+      // §21.2.3.4. Codegen validates radix range before calling.
+      if (name === "bigint_toString") return (v: bigint) => v.toString();
+      if (name === "bigint_toString_radix") return (v: bigint, r: number) => v.toString(r);
       if (name === "number_toFixed") return (v: number, d: number) => v.toFixed(d);
       // #1321: NaN-as-no-arg sentinel (matches `number_toExponential` pattern).
       // Compiled `(123.456).toPrecision()` (no args) pushes f64.const NaN on the

--- a/tests/issue-1644-slice-d.test.ts
+++ b/tests/issue-1644-slice-d.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #1644 Slice D — BigInt.prototype.toString(radix).
+//
+// Per §21.2.3.4: BigInt.prototype.toString returns a string in base `radix`
+// (2-36, default 10). Bigint-typed receivers cross the Wasm boundary as i64;
+// the codegen routes to `bigint_toString` / `bigint_toString_radix` host
+// imports that delegate to the spec-compliant V8 `BigInt.prototype.toString`.
+// Out-of-range radix throws RangeError, mirroring the number_toString_radix
+// validation gate.
+describe("#1644 Slice D — bigint.prototype.toString(radix)", () => {
+  it("bigint-typed receiver, no radix → base 10", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 255n;
+        return x.toString();
+      }
+    `);
+    expect(exports.test()).toBe("255");
+  });
+
+  it("bigint-typed receiver, radix 16", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 255n;
+        return x.toString(16);
+      }
+    `);
+    expect(exports.test()).toBe("ff");
+  });
+
+  it("bigint-typed receiver, radix 2", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 10n;
+        return x.toString(2);
+      }
+    `);
+    expect(exports.test()).toBe("1010");
+  });
+
+  it("bigint-typed receiver, radix 36", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 1295n;
+        return x.toString(36);
+      }
+    `);
+    expect(exports.test()).toBe("zz");
+  });
+
+  it("radix < 2 throws RangeError", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 10n;
+        try { return x.toString(1); } catch (e: any) { return "THREW"; }
+      }
+    `);
+    expect(exports.test()).toBe("THREW");
+  });
+
+  it("radix > 36 throws RangeError", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        const x: bigint = 10n;
+        try { return x.toString(37); } catch (e: any) { return "THREW"; }
+      }
+    `);
+    expect(exports.test()).toBe("THREW");
+  });
+
+  it("regression: number.toString still works (no cross-talk)", async () => {
+    const exports = await compileToWasm(`
+      export function test(): any {
+        return (255).toString(16);
+      }
+    `);
+    expect(exports.test()).toBe("ff");
+  });
+});


### PR DESCRIPTION
## Summary
Adds Slice D from #1644: BigInt.prototype.toString(radix) for bigint-typed receivers.

Per §21.2.3.4, BigInt.prototype.toString returns a base-`radix` string (2-36, default 10). Bigint-typed receivers cross the Wasm boundary as i64 (JS-BigInt-integration), so they need their own host-import dispatch — the existing `number_toString_radix` is f64-typed and silently dropped the receiver for `(255n as bigint).toString(...)`, returning null / "[object Object]".

Added two i64-typed host imports mirroring the number_toString pattern:
- `bigint_toString` (i64) → externref
- `bigint_toString_radix` (i64, i32) → externref

Wired through runtime registration (src/runtime.ts), allowlist (host-import-allowlist.ts), late-import collection (declarations.ts), and the codegen branch in calls.ts mirroring the number-toString flow including the §21.2.3.4 radix 2-36 RangeError guard.

## Slice C (BigInt.asIntN / asUintN) — already works on main
Verified during baseline probing on this branch: `BigInt.asIntN(8, 256n)` and `BigInt.asUintN(8, 256n)` already return correct values via the generic `__extern_method_call` host-bridge path. No codegen change needed; #1644 issue file updated to record this finding.

## Test plan
- [x] `tests/issue-1644-slice-d.test.ts` — 7 cases (default radix, radix 2/16/36, < 2 + > 36 → RangeError, number-toString regression guard) all pass
- [x] `tests/issue-1644.test.ts` (Slice A regression) — 5/5 pass
- [x] `tsc --noEmit` clean
- [ ] CI sharded test262 — confirm no regression; bigint/prototype/toString cluster should flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)