### PR TITLE
chore(#1659): ratchet equivalence baseline (101→99, gradual-typing boxed-any truthiness)

### DIFF
--- a/scripts/equivalence-baseline.json
+++ b/scripts/equivalence-baseline.json
@@ -36,8 +36,6 @@
     "tests/equivalence/generator-expressions.test.ts :: generator function expressions and methods generator function expression with yield in loop",
     "tests/equivalence/generator-type-mismatch.test.ts :: generator type mismatch fixes (#422) generator expression assigned to variable",
     "tests/equivalence/generator-type-mismatch.test.ts :: generator type mismatch fixes (#422) generator with return value expression",
-    "tests/equivalence/gradual-typing.test.ts :: Gradual typing: boxed any (fast mode) any null boxing — truthiness",
-    "tests/equivalence/gradual-typing.test.ts :: Gradual typing: boxed any (fast mode) any undefined boxing — truthiness",
     "tests/equivalence/iife-and-call-expressions.test.ts :: IIFE and call expression edge cases tagged template literals — different sites produce different objects",
     "tests/equivalence/iife-and-call-expressions.test.ts :: IIFE and call expression edge cases tagged template literals — same call site returns same object across calls",
     "tests/equivalence/iife-and-call-expressions.test.ts :: IIFE and call expression edge cases tagged template literals — same site caches even with different expression values",


### PR DESCRIPTION
## Summary
Bank 2 more known-failing equivalence tests that now pass on merged main:
- `gradual-typing.test.ts :: Gradual typing: boxed any (fast mode) any null boxing — truthiness`
- `gradual-typing.test.ts :: Gradual typing: boxed any (fast mode) any undefined boxing — truthiness`

Follow-up to PR #768 (106→101). Detected by running `node scripts/equivalence-gate.mjs` against current main: gate reported "2 baseline failure(s) now PASS — ratchet the baseline" with no new regressions. Ratchet written via `--update`.

## Verification
```
equivalence-gate: 99 failing, 1357 passing, 99 known-failures in baseline.
✓ No new equivalence regressions.
```

## Test plan
- [x] `node scripts/equivalence-gate.mjs` passes with 99 known failures (down from 101)
- [x] No new equivalence regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)