### PR TITLE
docs(#1593): reconcile status to done — fix already live on main

### DIFF
--- a/plan/issues/1593-default-init-triggers-on-null-should-be-undefined-only.md
+++ b/plan/issues/1593-default-init-triggers-on-null-should-be-undefined-only.md
@@ -1,9 +1,10 @@
 ---
 id: 1593
 title: "Destructuring default initializer triggers on null — spec requires undefined-only check (~165 fails)"
-status: ready
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-28
+completed: 2026-05-27
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -85,3 +86,55 @@ The guard likely uses `ref.is_null` or a host import that checks for `null || un
 - Spec: ECMA-262 §13.3.3.1 BindingElement Evaluation, step 5.c.ii: "If Initializer is present and v is **undefined**"
 - The `initCount` pattern in test files uses a side-effectful counter to verify the initializer body does not execute at all
 - Easy fix: a one-line guard change in `emitDefaultValueCheck`, but must also verify the `destructureParamObject` / `destructureParamArray` paths use the same guard
+
+## Resolution (2026-05-27, PR #637)
+
+Fixed by commit e89c72eaf (`fix(#1593): coerce dstr default initializer
+result to binding local type`), merged via PR #637 on 2026-05-27.
+
+The null-vs-undefined *guard* was already correct on main —
+`emitExternrefDefaultCheck` uses `__extern_is_undefined` exclusively
+(landed via #1550 / #1553e), so `[null]` and `{s: null}` correctly skip
+the default. The faithful test262 `init-skipped` templates
+(`[null, 0, false, '']` / `{s: null, u: 0, ...}` / for-of) already
+passed once reproduced exactly.
+
+The remaining failures were a **codegen type bug**, not a guard bug: in
+`emitDefaultValueCheck` (`src/codegen/statements/destructuring.ts`) the
+then-branch compiled the default initializer and `local.set` its result
+without coercing to the binding local's declared type. test262
+init-skipped tests use a `counter()` that returns **void**
+(`undefined`), which lowers to an `externref` on the stack. When the
+binding local is `f64` (e.g. field `u: 0`), the `local.set` failed Wasm
+validation (`local.set expected type f64, found call of type externref`)
+— failing the *whole* `if/else` (and thus the test) even though the
+default never fires at runtime.
+
+Fix: a shared `emitDefaultIntoLocal` closure compiles the initializer,
+maps a `VOID_RESULT` to `externref`, and coerces to
+`getLocalType(localIdx)` before `local.set`. Applied to all three
+branches (externref / f64 / ref).
+
+Tests: `tests/issue-1593.test.ts` (5 cases — array / object / for-of
+init-skipped + numeric-field-void-default compile +
+missing-prop-triggers-default). All passing on
+HEAD as of 2026-05-28.
+
+### Status-field reconciliation (2026-05-28)
+
+The post-merge bulk-update commit 4222350b6 (Team Lead sprint promotion,
+2026-05-27 14:07) was authored against a pre-#637 snapshot of this
+issue file. When merged it silently reverted PR #637's
+`status: done`/`completed:` and removed this Resolution section,
+reintroducing the issue as `ready` on the s56 queue. This commit
+restores both. No code change is needed — the fix has been live on
+main since 2026-05-27.
+
+Out of scope (separate pre-existing bugs, still failing on main, NOT
+touched by PR #637):
+- single-element `[null as any]` / `[undefined as any]` value
+  corruption (mixed-type array element narrowing) — distinct from
+  init-skipped cluster.
+- `function f(x: number = 42)` returning `0` when arg omitted
+  (`default-params.test.ts`) — pre-existing param-default failure on
+  main.


### PR DESCRIPTION
## Summary
- Docs-only PR: restores \`status: done\` + \`completed: 2026-05-27\` + the Resolution section in \`plan/issues/1593-...md\`.
- The code fix for #1593 already landed via **PR #637** (commit \`e89c72eaf\`, merged 2026-05-27). \`tests/issue-1593.test.ts\` (5/5) passes on current main HEAD as of 2026-05-28.
- A subsequent bulk-update commit (\`4222350b6\`, sprint promotion on 2026-05-27 14:07) was authored against a pre-#637 snapshot of this issue file and silently reverted the status fields back to \`ready\`. This PR restores them.

## Test plan
- [x] \`npx vitest run tests/issue-1593.test.ts\` → 5/5 pass on current main HEAD
- [x] No code changes — only \`plan/issues/1593-...md\` modified
- [x] CI typecheck + lint passing locally (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)