### PR TITLE
docs(#1680): mark issue done — fix landed via PR #721

### DIFF
--- a/plan/issues/1680-private-setter-dispatch-falls-through-to-field-write.md
+++ b/plan/issues/1680-private-setter-dispatch-falls-through-to-field-write.md
@@ -1,9 +1,12 @@
 ---
 id: 1680
 title: "Private setter write falls through to struct-field write — stacked private accessors cross-talk (~132 fails)"
-status: ready
+status: done
 created: 2026-05-27
-updated: 2026-05-27
+updated: 2026-05-28
+completed: 2026-05-28
+pr: 721
+fix_commit: 9ffbb1a52
 priority: medium
 feasibility: medium
 reasoning_effort: medium


### PR DESCRIPTION
## Summary

Reconcile `plan/issues/1680-private-setter-dispatch-falls-through-to-field-write.md` to `status: done`. The code fix shipped via PR #721 (commit `9ffbb1a52`), and the accessor-dispatch branch is live at `src/codegen/expressions/assignment.ts:1965-1996`. The issue file was still at `status: ready`.

## Changes

- `status: ready` → `status: done`
- Added `completed: 2026-05-28`, `pr: 721`, `fix_commit: 9ffbb1a52`
- `updated: 2026-05-27` → `2026-05-28`

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)