### PR TITLE
fix(#1596): Sub-fix 3 — Function.prototype.{apply,call}.call(fn, ...) reshape

### DIFF
--- a/plan/issues/1596-function-prototype-apply-call-not-accessible.md
+++ b/plan/issues/1596-function-prototype-apply-call-not-accessible.md
@@ -1,9 +1,9 @@
 ---
 id: 1596
 title: "Function.prototype.apply / .call not accessible on compiled Wasm functions (~46 fails)"
-status: ready
+status: in-progress
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-28
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2093,6 +2093,36 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       const isCall = propAccess.name.text === "call";
       const innerExpr = propAccess.expression;
 
+      // Sub-fix 3 (#1596): Function.prototype.{apply,call}.call(fn, ...) reshape.
+      // Rewrite `Function.prototype.apply.call(fn, thisArg, argsArr)` to
+      // `fn.apply(thisArg, argsArr)` (and analogous for .call.call) so the
+      // existing Case 0 / Case 1 handlers fire. Only the outer `.call` form is
+      // matched — `Function.prototype.apply.apply(fn, [thisArg, argsArr])` is
+      // rare and would need a packed-args reshape.
+      if (
+        isCall &&
+        ts.isPropertyAccessExpression(innerExpr) &&
+        (innerExpr.name.text === "apply" || innerExpr.name.text === "call") &&
+        ts.isPropertyAccessExpression(innerExpr.expression) &&
+        innerExpr.expression.name.text === "prototype" &&
+        ts.isIdentifier(innerExpr.expression.expression) &&
+        innerExpr.expression.expression.text === "Function" &&
+        expr.arguments.length >= 1
+      ) {
+        const innerMethod = innerExpr.name.text; // "apply" or "call"
+        const fnExpr = expr.arguments[0]!;
+        const reshapedArgs = expr.arguments.slice(1);
+        const reshapedProp = ts.factory.createPropertyAccessExpression(
+          fnExpr as ts.LeftHandSideExpression,
+          innerMethod,
+        );
+        ts.setTextRange(reshapedProp, propAccess);
+        const reshapedCall = ts.factory.createCallExpression(reshapedProp, undefined, reshapedArgs);
+        ts.setTextRange(reshapedCall, expr);
+        (reshapedCall as any).parent = expr.parent;
+        return compileCallExpression(ctx, fctx, reshapedCall as ts.CallExpression);
+      }
+
       // Case 0: (function(){}).call/apply(...) and (() => {}).call/apply(...).
       // A compiled function is a WasmGC funcref/struct, not a JS Function, so a
       // host-side `.apply`/`.call` lookup fails ("apply is not a function").

--- a/tests/issue-1596.test.ts
+++ b/tests/issue-1596.test.ts
@@ -74,4 +74,37 @@ describe("#1596 Function.prototype.apply/.call on function expressions", () => {
     `);
     expect(e.test()).toBe(42);
   });
+
+  it("Function.prototype.apply.call(fn, thisArg, argsArr) forwards arguments", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        function g(a: number, b: number): number { return a + b; }
+        return Function.prototype.apply.call(g, null, [1, 2]);
+      }
+    `);
+    expect(e.test()).toBe(3);
+  });
+
+  it("Function.prototype.call.call(fn, thisArg, ...args) forwards positional args", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        function g(a: number, b: number, c: number): number { return a + b + c; }
+        return Function.prototype.call.call(g, null, 1, 2, 4);
+      }
+    `);
+    expect(e.test()).toBe(7);
+  });
+
+  it("Function.prototype.apply.call on a function literal", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        return Function.prototype.apply.call(
+          function(a: number, b: number): number { return a * b; },
+          null,
+          [3, 7],
+        );
+      }
+    `);
+    expect(e.test()).toBe(21);
+  });
 });


### PR DESCRIPTION
## Summary
- Rewrites `Function.prototype.apply.call(fn, thisArg, argsArr)` to `fn.apply(thisArg, argsArr)` and `Function.prototype.call.call(fn, thisArg, ...rest)` to `fn.call(thisArg, ...rest)` at the top of the existing `.call`/`.apply` block in `src/codegen/expressions/calls.ts`.
- Pure AST reshape — the receiver feeds back into the existing Case 0 (function-literal) and Case 1 (identifier) handlers. No new runtime helpers, no new host imports.
- Pulls the test262 `Function.prototype.apply` / `.call` explicit-form cases out of the dynamic host path (where compiled-function externrefs have no `Function.prototype`) into the existing static rewrites.
- Implements Sub-fix 3 from the architect spec at 060baea71. Sub-fixes 1 and 2 (dynamic args on function literals; dynamic receivers via TS call-signature lookup) remain follow-ups — they require a spread-from-vec adapter that builds `arguments` from a runtime vec.

## Test plan
- [x] `tests/issue-1596.test.ts` — original 6 cases still green, 3 new cases for Sub-fix 3 added:
  - `Function.prototype.apply.call(g, null, [1, 2])` → 3
  - `Function.prototype.call.call(g, null, 1, 2, 4)` → 7
  - `Function.prototype.apply.call(function(a, b) {...}, null, [3, 7])` → 21
- [x] Confirmed no regressions: a sampling of `tests/class-method-calls.test.ts`, `tests/fn-variable-call.test.ts`, `tests/call-arg-type-coercion.test.ts`, `tests/call-expression-patterns.test.ts`, `tests/functional-array-methods.test.ts` failures observed are identical between stock main and this branch (pre-existing; no Sub-fix 3 regression).
- [ ] CI test262 will exercise the test262 cases (`built-ins/Function/prototype/apply/S15.3.4.3_A3_T8.js` family and any `Function.prototype.{apply,call}.call(...)` patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)