### PR TITLE
fix(#1630): Object.assign writeback into typed wasmGC struct via __sset_ exports

### DIFF
--- a/plan/issues/1630-spec-gap-object-assign-getter-iteration.md
+++ b/plan/issues/1630-spec-gap-object-assign-getter-iteration.md
@@ -1,9 +1,9 @@
 ---
 id: 1630
 title: "spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fails)"
-status: ready
+status: done
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1105,6 +1105,7 @@ export function generateModule(
     // These allow JS host imports to read WasmGC struct fields that are
     // otherwise opaque to JS (V8 returns undefined for direct property access).
     emitStructFieldGetters(ctx);
+    emitStructFieldSetters(ctx);
 
     // Emit __vec_get / __vec_len exports for runtime iterator fallback on WasmGC arrays
     emitVecAccessExports(ctx);
@@ -1376,6 +1377,188 @@ function _emitStructFieldGettersInner(ctx: CodegenContext): void {
   // Returns a comma-separated string of field names for the struct type of the argument.
   // The runtime uses this for Object.keys(), JSON.stringify(), for-in, and spread on opaque structs.
   emitStructFieldNamesExport(ctx, fieldMap);
+}
+
+/**
+ * Emit exported `__sset_<name>(externref obj, externref val) -> ()` setters
+ * symmetric to the existing `__sget_<name>` getters (#1630). The runtime
+ * `_safeSet` calls these so a host `Object.assign(typedStruct, src)` (and
+ * other MOP writes routed through `_wrapForHost` set-trap) reflects back
+ * into the real WasmGC struct field rather than only updating the JS-side
+ * sidecar. Without these setters, struct.field reads via compiled Wasm see
+ * the initial value while sidecar reads via host see the updated value —
+ * the asymmetry that masks `Object.assign` and similar writeback cases.
+ *
+ * Only mutable fields get setters; immutable singleton structs (boxed
+ * number / boolean) are skipped to avoid `struct.set` validation errors.
+ * Field-name buckets that mix kinds (f64 / i32 / ref) across struct types
+ * are skipped so the sidecar still carries the write — homogeneous-kind
+ * buckets cover the object-literal cases in test262.
+ */
+function emitStructFieldSetters(ctx: CodegenContext): void {
+  try {
+    _emitStructFieldSettersInner(ctx);
+  } catch {
+    // Non-fatal: setter emission failure degrades to sidecar-only writeback
+    // (the current pre-fix behaviour), the module still runs.
+  }
+}
+
+function _emitStructFieldSettersInner(ctx: CodegenContext): void {
+  const mod = ctx.mod;
+
+  // Collect (fieldName → [{typeIdx, fieldIdx, fieldType}]) mappings, but
+  // ONLY for mutable fields. Mirror the skip rules used by the getter
+  // emitter so the two stay in lockstep.
+  const fieldMap = new Map<string, { typeIdx: number; fieldIdx: number; fieldType: ValType }[]>();
+
+  for (const [structName, fields] of ctx.structFields) {
+    const typeIdx = ctx.structMap.get(structName);
+    if (typeIdx === undefined) continue;
+
+    if (
+      structName.startsWith("Wrapper") ||
+      structName === "$AnyValue" ||
+      structName.startsWith("__vec_") ||
+      structName.startsWith("__arr_")
+    )
+      continue;
+
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      if (!field || !field.type) continue;
+      if (!field.name || field.name.startsWith("$")) continue;
+      // Only emit setters for mutable fields — `struct.set` on an immutable
+      // field is a Wasm validation error (e.g. boxed-number singletons).
+      if (!field.mutable) continue;
+
+      let entries = fieldMap.get(field.name);
+      if (!entries) {
+        entries = [];
+        fieldMap.set(field.name, entries);
+      }
+      entries.push({ typeIdx, fieldIdx: i, fieldType: field.type });
+    }
+  }
+
+  if (fieldMap.size === 0) return;
+
+  // Setter signatures: 3 variants by val type.
+  // Mixed-kind buckets are skipped — sidecar carries the write instead.
+  const setterExternTypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [], "$sset_extern_type");
+  const setterF64TypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], [], "$sset_f64_type");
+  const setterI32TypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [], "$sset_i32_type");
+
+  for (const [fieldName, entries] of fieldMap) {
+    const hasF64 = entries.some((e) => e.fieldType.kind === "f64");
+    const hasI32 = entries.some((e) => e.fieldType.kind === "i32");
+    const hasRef = entries.some((e) => e.fieldType.kind !== "f64" && e.fieldType.kind !== "i32");
+    const allF64 = hasF64 && !hasI32 && !hasRef;
+    const allI32 = hasI32 && !hasF64 && !hasRef;
+    const allRef = hasRef && !hasF64 && !hasI32;
+
+    // Skip mixed-kind buckets — sidecar handles those.
+    if (!allF64 && !allI32 && !allRef) continue;
+
+    let setterTypeIdx: number;
+    let valMode: "extern" | "f64" | "i32";
+    if (allF64) {
+      setterTypeIdx = setterF64TypeIdx;
+      valMode = "f64";
+    } else if (allI32) {
+      setterTypeIdx = setterI32TypeIdx;
+      valMode = "i32";
+    } else {
+      setterTypeIdx = setterExternTypeIdx;
+      valMode = "extern";
+    }
+
+    const funcName = `__sset_${fieldName}`;
+    const funcIdx = ctx.numImportFuncs + mod.functions.length;
+    const anyLocal = 2; // locals after the two params (local 0 = obj, local 1 = val)
+
+    const funcBody = buildSetterNestedIfElse(entries, anyLocal, valMode);
+
+    mod.functions.push({
+      name: funcName,
+      typeIdx: setterTypeIdx,
+      locals: [{ name: "__any", type: { kind: "anyref" } }],
+      body: funcBody,
+      exported: true,
+    } as WasmFunction);
+
+    mod.exports.push({
+      name: funcName,
+      desc: { kind: "func", index: funcIdx },
+    });
+  }
+}
+
+/** Build nested if/else for struct field setter dispatch. */
+function buildSetterNestedIfElse(
+  entries: { typeIdx: number; fieldIdx: number; fieldType: ValType }[],
+  anyLocal: number,
+  valMode: "extern" | "f64" | "i32",
+): Instr[] {
+  const body: Instr[] = [];
+
+  // Convert obj externref to anyref and store
+  body.push({ op: "local.get", index: 0 } as Instr);
+  body.push({ op: "any.convert_extern" } as Instr);
+  body.push({ op: "local.set", index: anyLocal } as Instr);
+
+  // Chain: if (ref.test T1) { cast + struct.set T1 } else if (ref.test T2) { ... }
+  let current: Instr[] = []; // final else: no-op
+
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i]!;
+    const thenBranch = buildSetterStore(entry, anyLocal, valMode);
+
+    const ifInstr: Instr = {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: thenBranch,
+      else: current,
+    };
+
+    current = [
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.test", typeIdx: entry.typeIdx } as Instr,
+      ifInstr,
+    ];
+  }
+
+  body.push(...current);
+  return body;
+}
+
+/** Build the "then" branch that stores `val` (local 1) into a struct field. */
+function buildSetterStore(
+  entry: { typeIdx: number; fieldIdx: number; fieldType: ValType },
+  anyLocal: number,
+  valMode: "extern" | "f64" | "i32",
+): Instr[] {
+  const then: Instr[] = [];
+  const ft = entry.fieldType;
+
+  // Push the cast struct ref onto the stack
+  then.push({ op: "local.get", index: anyLocal } as Instr);
+  then.push({ op: "ref.cast", typeIdx: entry.typeIdx } as Instr);
+
+  // Push the value (already typed per valMode) — since we only emit setters
+  // for homogeneous-kind buckets, valMode and ft.kind line up.
+  then.push({ op: "local.get", index: 1 } as Instr);
+
+  if (valMode === "extern") {
+    // Field is a ref type — convert externref → anyref so it matches.
+    if (ft.kind === "ref" || ft.kind === "ref_null" || ft.kind === "anyref" || ft.kind === "eqref") {
+      then.push({ op: "any.convert_extern" } as Instr);
+    }
+    // externref / ref_extern: no conversion needed.
+  }
+
+  then.push({ op: "struct.set", typeIdx: entry.typeIdx, fieldIdx: entry.fieldIdx } as Instr);
+  return then;
 }
 
 /**
@@ -3261,6 +3444,7 @@ export function generateMultiModule(
     // generateModule path — #1308 surfaced that multi-source projects
     // were missing these export emits).
     emitStructFieldGetters(ctx);
+    emitStructFieldSetters(ctx);
 
     // Emit __vec_get / __vec_len exports for runtime iterator fallback.
     emitVecAccessExports(ctx);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1449,15 +1449,22 @@ function _emitStructFieldSettersInner(ctx: CodegenContext): void {
   const setterF64TypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], [], "$sset_f64_type");
   const setterI32TypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [], "$sset_i32_type");
 
-  for (const [fieldName, entries] of fieldMap) {
-    const hasF64 = entries.some((e) => e.fieldType.kind === "f64");
-    const hasI32 = entries.some((e) => e.fieldType.kind === "i32");
-    const hasRef = entries.some((e) => e.fieldType.kind !== "f64" && e.fieldType.kind !== "i32");
-    const allF64 = hasF64 && !hasI32 && !hasRef;
-    const allI32 = hasI32 && !hasF64 && !hasRef;
-    const allRef = hasRef && !hasF64 && !hasI32;
+  // Only kinds we can emit a correct `struct.set` for after the externref →
+  // anyref convert. Abstract heap types other than `anyref` (eqref / structref /
+  // funcref) would need a `ref.cast` to an abstract heap type, which the
+  // current Instr encoding does not express — skip those buckets so the
+  // sidecar still carries the write.
+  const isRefKind = (k: ValType["kind"]) =>
+    k === "ref" || k === "ref_null" || k === "anyref" || k === "externref" || k === "ref_extern";
 
-    // Skip mixed-kind buckets — sidecar handles those.
+  for (const [fieldName, entries] of fieldMap) {
+    const allF64 = entries.every((e) => e.fieldType.kind === "f64");
+    const allI32 = entries.every((e) => e.fieldType.kind === "i32");
+    const allRef = entries.every((e) => isRefKind(e.fieldType.kind));
+
+    // Skip mixed-kind buckets or any bucket containing kinds we can't
+    // route through one of the three setter signatures (i64 / f32 / v128
+    // / packed i8/i16). The sidecar still carries those writes.
     if (!allF64 && !allI32 && !allRef) continue;
 
     let setterTypeIdx: number;
@@ -1550,11 +1557,21 @@ function buildSetterStore(
   then.push({ op: "local.get", index: 1 } as Instr);
 
   if (valMode === "extern") {
-    // Field is a ref type — convert externref → anyref so it matches.
-    if (ft.kind === "ref" || ft.kind === "ref_null" || ft.kind === "anyref" || ft.kind === "eqref") {
+    // Field kinds are restricted by isRefKind above to: ref / ref_null /
+    // anyref / externref / ref_extern. externref & ref_extern need no
+    // conversion; everything else converts externref → anyref first, then
+    // typed-ref fields cast down to the field's specific heap type. Cast
+    // failures trap; the runtime _safeSet wraps the setter call in
+    // try/catch so a wrong-type assign degrades to sidecar-only (the
+    // prior behaviour) rather than crashing.
+    if (ft.kind === "ref" || ft.kind === "ref_null" || ft.kind === "anyref") {
       then.push({ op: "any.convert_extern" } as Instr);
     }
-    // externref / ref_extern: no conversion needed.
+    if (ft.kind === "ref") {
+      then.push({ op: "ref.cast", typeIdx: ft.typeIdx } as Instr);
+    } else if (ft.kind === "ref_null") {
+      then.push({ op: "ref.cast_null", typeIdx: ft.typeIdx } as Instr);
+    }
   }
 
   then.push({ op: "struct.set", typeIdx: entry.typeIdx, fieldIdx: entry.fieldIdx } as Instr);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2042,8 +2042,17 @@ function _safeGet(obj: any, key: any): any {
   return undefined;
 }
 
-/** Safe property set: works on both JS objects and WasmGC structs. */
-function _safeSet(obj: any, key: any, val: any): void {
+/**
+ * Safe property set: works on both JS objects and WasmGC structs.
+ *
+ * When `exports` is provided AND `obj` is a WasmGC struct AND `key` is a
+ * string, the optional `__sset_<key>` export is invoked so the write lands
+ * in the real struct field (not only the sidecar). This is the writeback
+ * symmetric to `__sget_<key>` and unblocks struct-target `Object.assign`,
+ * `Reflect.set`, and `Object.defineProperty` data writes (#1630). Callers
+ * that don't pass `exports` get the prior sidecar-only behaviour.
+ */
+function _safeSet(obj: any, key: any, val: any, exports?: Record<string, Function>): void {
   if (obj == null) return;
   // Coerce WasmGC struct keys to primitives via ToPrimitive (#1090)
   if (key != null && typeof key === "object" && _isWasmStruct(key)) {
@@ -2100,6 +2109,21 @@ function _safeSet(obj: any, key: any, val: any): void {
       const hasInDescs = descs?.has(propKey);
       if (!hasInSidecar && !hasInDescs) {
         return; // silent fail: non-extensible, new property not added
+      }
+    }
+    // Symmetric writeback through the compiled `__sset_<key>` export so the
+    // real WasmGC struct field gets updated, not just the sidecar (#1630).
+    // Falls back silently when the export is missing or doesn't match the
+    // struct's runtime type — sidecar still carries the value so host-side
+    // reads (Object.keys, JSON.stringify, dynamic-key reads) keep working.
+    if (typeof key === "string" && exports) {
+      const setter = exports[`__sset_${key}`];
+      if (typeof setter === "function") {
+        try {
+          setter(obj, val);
+        } catch {
+          /* not a field of this struct's runtime type */
+        }
       }
     }
     try {
@@ -2458,7 +2482,7 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       return val;
     },
     set(_t, key, val) {
-      _safeSet(obj, key, val);
+      _safeSet(obj, key, val, exports);
       return true;
     },
     has(_t, key) {

--- a/tests/issue-1630.test.ts
+++ b/tests/issue-1630.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+describe("#1630 — Object.assign writeback into typed wasmGC struct", () => {
+  async function runReturn(src: string): Promise<{ ret?: unknown; error?: string }> {
+    const result = compile(src, { skipSemanticDiagnostics: true });
+    if (!result.success) return { error: result.errors?.[0]?.message ?? "compile failed" };
+    const importObj = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
+    if (typeof (importObj as any).setExports === "function") {
+      (importObj as any).setExports(instance.exports);
+    }
+    try {
+      const ret = (instance.exports as { test: () => unknown }).test();
+      return { ret };
+    } catch (e: unknown) {
+      return { error: String(e) };
+    }
+  }
+
+  it("plain data-property copy reflects into struct fields read via Wasm", async () => {
+    const src = `
+      const t: { a: number, b: number } = { a: 0, b: 0 };
+      const src: { a: number, b: number } = { a: 7, b: 9 };
+      export function test(): number {
+        Object.assign(t, src);
+        return t.a + t.b;
+      }
+    `;
+    const { ret, error } = await runReturn(src);
+    expect(error).toBeUndefined();
+    expect(ret).toBe(16);
+  });
+
+  it("struct-typed sources copy their data properties into struct target", async () => {
+    const src = `
+      const t: { x: number, y: number, z: number } = { x: 0, y: 0, z: 0 };
+      const s: { x: number, y: number, z: number } = { x: 1, y: 2, z: 3 };
+      export function test(): number {
+        Object.assign(t, s);
+        return t.x * 100 + t.y * 10 + t.z;
+      }
+    `;
+    const { ret, error } = await runReturn(src);
+    expect(error).toBeUndefined();
+    expect(ret).toBe(123);
+  });
+
+  it("multi-source assign: later sources overwrite earlier ones", async () => {
+    const src = `
+      const t: { a: number, b: number } = { a: 0, b: 0 };
+      const s1: { a: number, b: number } = { a: 1, b: 2 };
+      const s2: { a: number, b: number } = { a: 10, b: 20 };
+      export function test(): number {
+        Object.assign(t, s1, s2);
+        return t.a * 100 + t.b;
+      }
+    `;
+    const { ret, error } = await runReturn(src);
+    expect(error).toBeUndefined();
+    expect(ret).toBe(1020);
+  });
+
+  it("Object.assign returns the target object", async () => {
+    const src = `
+      const t: { a: number } = { a: 0 };
+      const s: { a: number } = { a: 5 };
+      export function test(): number {
+        const ret: any = Object.assign(t, s);
+        return ret === t ? 1 : 0;
+      }
+    `;
+    const { ret, error } = await runReturn(src);
+    expect(error).toBeUndefined();
+    expect(ret).toBe(1);
+  });
+
+  it("null/undefined sources are skipped without error", async () => {
+    const src = `
+      const t: { a: number } = { a: 3 };
+      export function test(): number {
+        Object.assign(t, null as any, undefined as any, { a: 7 });
+        return t.a;
+      }
+    `;
+    const { ret, error } = await runReturn(src);
+    expect(error).toBeUndefined();
+    expect(ret).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the struct-target writeback slice of #1630 per the 2026-05-27 architect spec.

`Object.assign(typedStruct, src)` (and any host-side MOP write through the `_wrapForHost` set-trap) previously left the target's real WasmGC struct fields unchanged — only the JS-side sidecar copy was written, which compiled Wasm code never reads (it does `struct.get` on the real field). This PR emits a symmetric `__sset_<name>` setter export for every mutable struct field name, mirroring the existing `__sget_<name>` getter, and threads `exports` through `_safeSet` so the runtime can call the right setter for the receiver's runtime type.

Without the fix the canonical probe `const t={a:0,b:0}; Object.assign(t,{a:7,b:9}); t.a+t.b` reads 0 from compiled code; with the fix it reads 16.

## What's in scope (this PR)

- `src/codegen/index.ts`: new `emitStructFieldSetters` (called next to `emitStructFieldGetters` at both `generateModule` and `generateMultiModule` sites). Only mutable fields get setters (skips boxed-number / boxed-boolean singletons to avoid `struct.set` validation errors). Homogeneous-kind buckets (all-f64, all-i32, all-ref) emit setters; mixed-kind buckets fall back to sidecar (preserves current behaviour).
- `src/runtime.ts`: `_safeSet` accepts an optional 4th `exports` param. When set and the target is a wasmGC struct, `__sset_<key>` is invoked; sidecar still gets the value for host-side reads, dynamic keys, and unknown struct types. `_wrapForHost`'s `set` trap passes its `exports` closure through.
- `tests/issue-1630.test.ts`: 5 cases — plain copy, multi-source overrides, return-value identity, null/undefined sources, all-data struct→struct.

## What's NOT in scope (deferred per architect spec)

The original 23-fail spread decomposes into four independent root causes; this fix targets only the writeback mirror:
- Descriptor `enumerable`/`writable` not honoured on the struct mirror
- `freeze`/`seal`/`preventExtensions` not throwing on Set
- Boxed wrapper `.valueOf()` round-trip
- Getter-invocation order logging + Proxy `ownKeys` ordering

Each is tracked separately in the issue file's "Out of scope" section.

## Test plan

- [x] `npm test -- tests/issue-1630.test.ts` — 5/5 pass
- [x] 41 object-related equivalence tests pass (`tests/equivalence/empty-object-widening`, `assignment-expression-value`, `tests/issue-1006`, `tests/object-file`)
- [x] Probe: `__sset_a(struct, val)` + `t.a` read via compiled code yields `val` (was 0)
- [ ] CI: full sharded test262 will measure cross-suite delta — expected lift on `Override*`/`Target-Object` in `built-ins/Object/assign` and small incidental gains in `Reflect/set`, `Object/defineProperty` data writes, object-spread

Closes #1630 (writeback slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)