### PR TITLE
fix(#1655): wasi process.stdout.write(ArrayBuffer) — accept ArrayBuffer arg

### DIFF
--- a/plan/issues/1655-wasi-process-stdout-write-arraybuffer.md
+++ b/plan/issues/1655-wasi-process-stdout-write-arraybuffer.md
@@ -1,9 +1,10 @@
 ---
 id: 1655
 title: "wasi: process.stdout.write(ArrayBuffer) — accept ArrayBuffer arg, not only Uint8Array literal"
-status: backlog
+status: done
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-28
+completed: 2026-05-28
 priority: medium
 feasibility: easy
 reasoning_effort: low

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -43,6 +43,7 @@ import {
   ensureExnTag,
   ensureI32Condition,
   ensureWasiWriteAnyStringHelper,
+  ensureWasiWriteArrayBufferHelper,
   ensureWasiWriteUint8ArrayHelper,
   getArrTypeIdxFromVec,
   getOrRegisterRefCellType,
@@ -1619,9 +1620,19 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         return VOID_RESULT;
       }
 
-      // Uint8Array (or other typed array) → raw bytes. Uint8Array compiles to a
-      // "vec" struct wrapping an f64 GC array (new-super.ts `new Uint8Array`).
-      const vecTypeIdx = getOrRegisterVecType(ctx, "f64", { kind: "f64" });
+      // #1655: distinguish ArrayBuffer (vec of i32_byte) from Uint8Array /
+      // typed-array views (vec of f64) at compile time. Under
+      // --target wasi/standalone, `new ArrayBuffer(n)` lowers to a vec struct
+      // with i32 byte elements (one byte per element, see dataview-native.ts);
+      // `new Uint8Array(...)` / `.subarray(...)` lowers to a vec with f64
+      // elements. The two helpers differ only in the per-element read
+      // conversion, so we pick the helper at compile time from the static
+      // type of the argument.
+      const argSymName = argTsType.getSymbol?.()?.name;
+      const isArrayBufferArg = argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
+      const elemKey: "i32_byte" | "f64" = isArrayBufferArg ? "i32_byte" : "f64";
+      const elemType: ValType = isArrayBufferArg ? { kind: "i32" } : { kind: "f64" };
+      const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
       const argType = compileExpression(ctx, fctx, argExpr);
       flushLateImportShifts(ctx, fctx);
       // The helper takes a non-null ref; cast a mismatched ref / assert non-null.
@@ -1636,7 +1647,9 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
         }
       }
-      const helperIdx = ensureWasiWriteUint8ArrayHelper(ctx, vecTypeIdx, useStderr);
+      const helperIdx = isArrayBufferArg
+        ? ensureWasiWriteArrayBufferHelper(ctx, vecTypeIdx, useStderr)
+        : ensureWasiWriteUint8ArrayHelper(ctx, vecTypeIdx, useStderr);
       if (helperIdx >= 0) {
         fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
         return VOID_RESULT;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4224,6 +4224,127 @@ export function ensureWasiWriteUint8ArrayHelper(
 }
 
 /**
+ * #1655: Ensure __wasi_write_arraybuffer(buf: ref __vec_i32_byte) -> void
+ * exists and return its function index (lazy).
+ *
+ * Companion to `ensureWasiWriteUint8ArrayHelper` for the ArrayBuffer-backing
+ * representation. Under `--target wasi` / `--target standalone`, an
+ * `ArrayBuffer` is lowered to a vec struct of i32 bytes (one byte per
+ * element, values 0..255 — see dataview-native.ts comment block) rather than
+ * the Uint8Array f64-element shape. The element conversion is therefore a
+ * direct i32 read (no `i32.trunc_sat_f64_s`).
+ */
+export function ensureWasiWriteArrayBufferHelper(
+  ctx: CodegenContext,
+  vecTypeIdx: number,
+  useStderr: boolean = false,
+): number {
+  const helperName = useStderr ? "__wasi_write_arraybuffer_stderr" : "__wasi_write_arraybuffer";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  if (!ctx.wasi || ctx.wasiFdWriteIdx === undefined) return -1;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return -1;
+
+  const fd = useStderr ? 2 : 1;
+
+  // param: buf(0); locals: len(1), data(2), i(3)
+  const BUF = 0;
+  const LEN = 1;
+  const DATA = 2;
+  const I = 3;
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const body: Instr[] = [
+    // len = buf.length (field 0)
+    { op: "local.get", index: BUF } as Instr,
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: LEN } as Instr,
+
+    // data = buf.data (field 1)
+    { op: "local.get", index: BUF } as Instr,
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.set", index: DATA } as Instr,
+
+    // i = 0
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.set", index: I } as Instr,
+
+    // while (i < len) mem[SCRATCH+i] = (u8) data[i]; i++
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: I } as Instr,
+            { op: "local.get", index: LEN } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+
+            // address = SCRATCH_START + i
+            { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.add" } as Instr,
+
+            // value = data[i] (i32; low byte kept by i32.store8)
+            { op: "local.get", index: DATA } as Instr,
+            { op: "local.get", index: I } as Instr,
+            { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+
+            { op: "i32.store8", align: 0, offset: 0 },
+
+            // i++
+            { op: "local.get", index: I } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: I } as Instr,
+
+            { op: "br", depth: 0 } as Instr,
+          ],
+        },
+      ],
+    },
+
+    // iovec.buf = SCRATCH_START at memory[0]
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // iovec.buf_len = len at memory[4]
+    { op: "i32.const", value: 4 } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+    { op: "i32.const", value: fd } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.const", value: 8 } as Instr,
+    { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
+    { op: "drop" } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: helperName,
+    typeIdx: funcTypeIdx,
+    locals: [
+      { name: "len", type: { kind: "i32" } },
+      { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
+      { name: "i", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+
+  return funcIdx;
+}
+
+/**
  * Emit __wasi_write_file_sync(pathPtr: i32, pathLen: i32, dataPtr: i32, dataLen: i32) helper.
  * Opens a file via path_open, writes data via fd_write, then closes via fd_close.
  *

--- a/tests/issue-1655-wasi-arraybuffer-write.test.ts
+++ b/tests/issue-1655-wasi-arraybuffer-write.test.ts
@@ -1,0 +1,144 @@
+// #1655 — process.stdout.write must also accept a bare ArrayBuffer (and a
+// non-literal Uint8Array / .subarray view) under --target wasi, not just the
+// new Uint8Array([...literal]) form from #1651. The AssemblyScript Native
+// Messaging reference host writes its framed response via
+// `process.stdout.write(arrayBuffer)`; without this the matcher fell through
+// to the generic path and emitted invalid Wasm (illegal cast of i32_byte vec
+// to f64 vec) or nothing at all.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Run a compiled WASI module, returning the raw bytes written to a given fd. */
+function runWasiCaptureFd(binary: Uint8Array, fd: number): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const captured: number[] = [];
+  const wasi = {
+    fd_read(): number {
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === fd) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+describe("#1655 process.stdout.write(ArrayBuffer) under --target wasi", () => {
+  it("writes a bare ArrayBuffer's bytes verbatim (no transform, no newline)", () => {
+    // Build a 4-byte LE length prefix in an ArrayBuffer via DataView, then
+    // hand the buffer itself to stdout.write. This is the AssemblyScript
+    // Native Messaging frame shape.
+    const src = `declare const process: {
+      stdout: { write(c: ArrayBuffer | Uint8Array | string): void };
+    };
+    export function main(): void {
+      const buf = new ArrayBuffer(5);
+      const dv = new DataView(buf);
+      dv.setUint8(0, 0xde);
+      dv.setUint8(1, 0xad);
+      dv.setUint8(2, 0xbe);
+      dv.setUint8(3, 0xef);
+      dv.setUint8(4, 0x00);
+      process.stdout.write(buf);
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([0xde, 0xad, 0xbe, 0xef, 0x00]);
+  });
+
+  it("writes a non-literal Uint8Array verbatim", () => {
+    const src = `declare const process: {
+      stdout: { write(c: Uint8Array | string): void };
+    };
+    export function main(): void {
+      const u = new Uint8Array(3);
+      u[0] = 7;
+      u[1] = 8;
+      u[2] = 9;
+      process.stdout.write(u);
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([7, 8, 9]);
+  });
+
+  it("writes a Uint8Array.subarray view honouring [begin, end)", () => {
+    const src = `declare const process: {
+      stdout: { write(c: Uint8Array | string): void };
+    };
+    export function main(): void {
+      const u = new Uint8Array([10, 20, 30, 40, 50]);
+      process.stdout.write(u.subarray(1, 4));
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([20, 30, 40]);
+  });
+
+  it("does not regress the existing string path", () => {
+    const src = `declare const process: { stdout: { write(c: string): void } };
+      export function main(): void {
+        process.stdout.write("ok");
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([0x6f, 0x6b]);
+  });
+
+  it("does not regress the existing Uint8Array-literal path (#1651)", () => {
+    const src = `declare const process: { stdout: { write(c: Uint8Array | string): void } };
+      export function main(): void {
+        process.stdout.write(new Uint8Array([0, 1, 255, 10, 13]));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 1);
+    expect(Array.from(out)).toEqual([0, 1, 255, 10, 13]);
+  });
+
+  it("routes ArrayBuffer through stderr when called on process.stderr", () => {
+    const src = `declare const process: {
+      stderr: { write(c: ArrayBuffer | string): void };
+    };
+    export function main(): void {
+      const buf = new ArrayBuffer(3);
+      const dv = new DataView(buf);
+      dv.setUint8(0, 0x01);
+      dv.setUint8(1, 0x02);
+      dv.setUint8(2, 0x03);
+      process.stderr.write(buf);
+    }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const out = runWasiCaptureFd(result.binary, 2);
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the WASI `process.stdout.write` / `process.stderr.write` lowering in
`src/codegen/expressions/calls.ts` to accept a bare `ArrayBuffer` argument in
addition to the existing string and `Uint8Array`-literal paths from #1651.

Under `--target wasi` / `--target standalone`, `ArrayBuffer` lowers to a vec
struct of i32 bytes (one i32 per byte, 0..255 — see `dataview-native.ts`),
distinct from the f64-element `Uint8Array` shape. The two helpers differ
only in the per-element read conversion (i32 `array.get` vs f64 `array.get`
+ `i32.trunc_sat_f64_s`); we add `ensureWasiWriteArrayBufferHelper`
alongside `ensureWasiWriteUint8ArrayHelper` and pick at compile time from the
static type of the argument (`ArrayBuffer` / `SharedArrayBuffer` → arraybuffer
helper, otherwise the Uint8Array helper).

Non-literal `Uint8Array` and `.subarray(...)` views already work via the
existing `Uint8Array` helper because `subarray` returns a new vec with the
same f64-element shape as the parent.

This unblocks the AssemblyScript Native Messaging reference host, which
frames its response via `process.stdout.write(arrayBuffer)` and via
`Uint8Array.buffer`.

Closes #1655. Depends on #1654 (already merged).

## Test plan

- [x] `tests/issue-1655-wasi-arraybuffer-write.test.ts` — 6 cases:
  - bare `ArrayBuffer` written verbatim via DataView
  - non-literal `Uint8Array` written verbatim
  - `Uint8Array.subarray(a, b)` view honours `[begin, end)`
  - regression check for the existing string path
  - regression check for the existing `Uint8Array`-literal path (#1651)
  - `process.stderr.write(ArrayBuffer)` routes through fd=2
- [x] Existing WASI suites pass post-merge: `issue-1618-1651-wasi-stdout`,
      `issue-1653-wasi-process-stdin-read`, `issue-1654-wasi-dataview-arraybuffer`,
      `wasi`, `wasi-target` — 50 tests green.

Checklist completed.