### PR TITLE
fix(#1596): module-init collector skips paren-wrapped ExpressionStatements

### DIFF
--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2980,7 +2980,13 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     // Module-level expression statements with side effects:
     // new expressions, call expressions, ++/--, assignments to module globals
     if (ts.isExpressionStatement(stmt)) {
-      const expr = stmt.expression;
+      // #1596 — the test262 IIFE-with-trailing-call pattern
+      // `(function(){...}.apply(null, [...]))` parses with a
+      // ParenthesizedExpression at the top of the ExpressionStatement. Unwrap
+      // here so the inner CallExpression is recognised and the statement
+      // reaches `__module_init`.
+      let expr: ts.Expression = stmt.expression;
+      while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
       if (ts.isNewExpression(expr) || ts.isCallExpression(expr)) {
         ctx.moduleInitStatements.push(stmt);
         continue;

--- a/tests/issue-1596.test.ts
+++ b/tests/issue-1596.test.ts
@@ -74,4 +74,41 @@ describe("#1596 Function.prototype.apply/.call on function expressions", () => {
     `);
     expect(e.test()).toBe(42);
   });
+
+  // Module-level IIFE-with-trailing-call pattern: (function(){...}.apply(...)).
+  // The outer parens wrap the whole call expression (not the function literal).
+  // Before the fix this ExpressionStatement was silently dropped from
+  // `__module_init` because the collector only matched bare
+  // `isCallExpression`/`isNewExpression`, never a `ParenthesizedExpression`
+  // around them. This is the shape test262 generates for the
+  // `spread-sngl-literal.js` / `spread-mult-literal.js` family.
+  // Module-level IIFE-with-trailing-call shape `(function(){...}.apply(...))`
+  // — the test262 spread-sngl-literal.js / spread-mult-literal.js family's
+  // exact AST. The outer parens wrap the whole call expression, not the
+  // function literal. Before the fix this ExpressionStatement was silently
+  // dropped from `__module_init` because the collector only matched bare
+  // `isCallExpression`/`isNewExpression`, never a `ParenthesizedExpression`
+  // around them. We use a plain CallExpression-on-property-access shape with
+  // an outer paren around the whole statement, matching the test262 source.
+  it("module-level outer-paren CallExpression — was silently dropped from __module_init", async () => {
+    const e = await compileAndRun(`
+      var callCount = 0;
+      function bump(): void { callCount += 1; }
+      (bump());
+      export function test(): number { return callCount; }
+    `);
+    expect(e.test()).toBe(1);
+  });
+
+  it("module-level outer-paren MemberCall — was silently dropped from __module_init", async () => {
+    // (obj.method()) — parens around a property-access call. Same dropped-statement
+    // bug as above for the test262 (function(){}.apply(...)) shape.
+    const e = await compileAndRun(`
+      var callCount = 0;
+      const obj = { bump(): void { callCount += 1; } };
+      (obj.bump());
+      export function test(): number { return callCount; }
+    `);
+    expect(e.test()).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

The test262 `spread-sngl-literal.js` / `spread-mult-literal.js` family writes the assertion in the shape `(function(){...}.apply(null, [...]))` — outer parens wrap the **whole call expression** (not the function literal). The module-init collector in `src/codegen/declarations.ts:2982` only matched ExpressionStatements whose direct child was `isCallExpression` / `isNewExpression`, never a `ParenthesizedExpression` around them. The entire `.apply(...)` call was silently dropped from `__module_init` and never compiled — so even the existing static-rewrite path in `compileCallExpression` (Case 0) never ran on this shape.

The fix unwraps `ParenthesizedExpression` at the top of the ExpressionStatement before the call/new/unary/binary classification.

This is orthogonal to the architect spec's Sub-fix 1 (function-literal `.apply` with non-flattenable args via a spread-from-vec adapter) — without this paren fix, those static rewrites can't run on the test262 shape at all because the statement never compiles. Sub-fix 3 is being landed in PR #778; this PR addresses a third, independent cause behind the same test262 family.

## Test plan

- [x] `tests/issue-1596.test.ts` — 6 existing cases still green, 2 new cases for the dropped-statement shape:
  - module-level outer-paren CallExpression (`(bump());`)
  - module-level outer-paren MemberCall (`(obj.bump());`)
- [x] Confirmed no regressions in scoped equivalence/call-apply tests (`tests/arrow-call-apply.test.ts`, `tests/equivalence/arrow-call-apply.test.ts`, `tests/fn-variable-call.test.ts`, `tests/class-method-calls.test.ts`) — failure counts match stock main exactly (7+3 failures on both branches, pre-existing).
- [x] Validated end-to-end on the test262 source pattern `(function(){...}.apply(null, [...[3,4,5]]))` — runs callCount→1 as spec'd; without fix returns 0 (statement dropped).
- [ ] CI test262 will exercise `language/expressions/array/spread-sngl-literal.js`, `spread-mult-literal.js`, `spread-obj-getter-descriptor.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)