### PR TITLE
fix(#1623): extern.convert_any double-wrap on already-externref operand

### DIFF
--- a/plan/issues/1623-codegen-invalid-wasm-type-coercion-boundaries.md
+++ b/plan/issues/1623-codegen-invalid-wasm-type-coercion-boundaries.md
@@ -1,7 +1,7 @@
 ---
 id: 1623
 title: "codegen: invalid Wasm binary at type-boundary coercion (extern/anyref + struct ref types)"
-status: in-progress
+status: in-review
 created: 2026-05-20
 updated: 2026-05-28
 priority: high

--- a/plan/issues/1623-codegen-invalid-wasm-type-coercion-boundaries.md
+++ b/plan/issues/1623-codegen-invalid-wasm-type-coercion-boundaries.md
@@ -1,9 +1,9 @@
 ---
 id: 1623
 title: "codegen: invalid Wasm binary at type-boundary coercion (extern/anyref + struct ref types)"
-status: backlog
+status: in-progress
 created: 2026-05-20
-updated: 2026-05-20
+updated: 2026-05-28
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -75,3 +75,78 @@ showing up across the test262 corpus.
 
 **~530 test262 compile errors** today; some unblock further runtime
 fails behind them, so realised gain may exceed the raw count.
+
+## Fix 2026-05-28 (issue-1623-extern-doublewrap / dev-1623) — sub-cluster #1
+
+Targets the dominant sub-cluster: 53 fails with shape
+`extern.convert_any[0] expected type anyref, found global.get of type externref`.
+
+**Root cause.** `compilePropertyAccess` in `src/codegen/property-access.ts`
+at the `(#799 WI4) Property not found on struct ... fall back to
+__extern_get` branch unconditionally emits `extern.convert_any` after
+compiling the receiver expression. The comment says "Coerce struct ref to
+externref" but the receiver can already be externref — most notably `this`
+inside a `static` method, where `compileExpression(expr.expression)`
+returns the static class-object global (externref). `extern.convert_any`
+expects an `anyref` operand, so the validator rejects the module.
+
+**Fix.** Capture the receiver's compiled type and call `coerceType` to
+emit the correct conversion (which is a no-op when source equals
+destination kind):
+
+```ts
+const recvType = compileExpression(ctx, fctx, expr.expression);
+if (recvType && recvType.kind !== "externref") {
+  coerceType(ctx, fctx, recvType, { kind: "externref" });
+}
+```
+
+(was: bare `extern.convert_any` after `compileExpression`).
+
+**Repro** (was: `compile_error`, now: compiles and runs):
+
+```ts
+class C {
+  static set #f(v) { throw new Error(); }
+  static getAccess() { return this.#f; }
+}
+```
+
+**Impact on the four canonical fails listed in this issue:**
+
+| Test | Before | After |
+|------|--------|-------|
+| `Iterator/from/result-proto.js` | compile_error (extern.convert_any) | fail (runtime — `Cannot convert null to object`) |
+| `class/elements/static-field-declaration.js` | compile_error | fail (assertion mismatch) |
+| `class/elements/get-access-of-missing-private-static-getter.js` | compile_error | fail (assertion mismatch) |
+| `Promise/prototype/then/capability-executor-called-twice.js` | compile_error (`found call of type externref`) | unchanged — different sub-cluster (#1623b) |
+
+The first three are now valid Wasm; the runtime failures are downstream
+issues outside the type-coercion scope. The Promise case is a different
+shape (call-of-externref-result rather than global.get-of-externref) and
+is not addressed by this fix.
+
+**Scope.** Single-site fix in `src/codegen/property-access.ts:2517-2519`.
+Adds `coerceType` to the imports from `./type-coercion.js`. Regression
+test in `tests/issue-1623.test.ts`. 38 nearby tests (`#1605`, `#1680`,
+`#1681`, `#1682`, `#1683`, `#1612`, `#1605-cpn`) still pass.
+
+### Companion fix in `src/codegen/fixups.ts`
+
+The peephole/late fixup passes (`fixupStructNewResultCoercion` and
+`fixupExternConvertAny`) resolved `global.get` operands via
+`ctx.mod.globals[gIdx]`. That array stores only the module-defined
+globals — imported globals occupy the lower part of the combined Wasm
+global index space. For any module that imports globals (the common
+case), `globals[gIdx]` returned `undefined` for every import-side
+index, so the safety net missed all redundant `extern.convert_any`
+ops over imported externref globals.
+
+Added a `getGlobalType(gIdx)` helper to both passes that resolves
+combined indices against `ctx.mod.imports` first, then falls back to
+`ctx.mod.globals`. Of the 53 baseline tests in the
+`global.get of type externref` sub-cluster, 46 now compile to valid
+Wasm (the remaining 7 are unrelated TS compile errors or different
+codegen shapes). Regression test in
+`tests/issue-1623-extern-doublewrap.test.ts`.
+

--- a/src/codegen/fixups.ts
+++ b/src/codegen/fixups.ts
@@ -622,6 +622,23 @@ export function fixupStructNewResultCoercion(ctx: CodegenContext): void {
     return null;
   }
 
+  // See fixupExternConvertAny for the rationale — imported globals occupy the
+  // lower part of the combined index space and aren't present in mod.globals.
+  const numImportedGlobals = ctx.mod.imports.filter((imp: any) => imp.desc?.kind === "global").length;
+  function getGlobalType(gIdx: number): ValType | null {
+    if (gIdx < numImportedGlobals) {
+      let seen = 0;
+      for (const imp of ctx.mod.imports) {
+        if ((imp as any).desc?.kind !== "global") continue;
+        if (seen === gIdx) return (imp as any).desc.type as ValType;
+        seen++;
+      }
+      return null;
+    }
+    const def = ctx.mod.globals[gIdx - numImportedGlobals];
+    return def ? def.type : null;
+  }
+
   function fixupInstrs(func: WasmFunction, instrs: Instr[]): void {
     for (let i = 0; i < instrs.length; i++) {
       const instr = instrs[i]!;
@@ -656,9 +673,8 @@ export function fixupStructNewResultCoercion(ctx: CodegenContext): void {
             const lt = getLocalType(func, (prev as { index: number }).index);
             if (lt && lt.kind === "externref") isExternref = true;
           } else if (prev.op === "global.get") {
-            const gIdx = (prev as { index: number }).index;
-            const gDef = ctx.mod.globals[gIdx];
-            if (gDef && gDef.type.kind === "externref") isExternref = true;
+            const gType = getGlobalType((prev as { index: number }).index);
+            if (gType && gType.kind === "externref") isExternref = true;
           }
           if (isExternref) {
             const unboxIdx = ctx.funcMap.get("__unbox_number");
@@ -694,10 +710,8 @@ export function fixupStructNewResultCoercion(ctx: CodegenContext): void {
           i++; // skip the inserted instruction
         }
       } else if (next.op === "global.set") {
-        // Check global type
-        const globalIdx = (next as { index: number }).index;
-        const globalDef = ctx.mod.globals[globalIdx];
-        if (globalDef && globalDef.type.kind === "externref") {
+        const gType = getGlobalType((next as { index: number }).index);
+        if (gType && gType.kind === "externref") {
           instrs.splice(i + 1, 0, { op: "extern.convert_any" } as Instr);
           i++;
         }
@@ -723,10 +737,9 @@ export function fixupStructNewResultCoercion(ctx: CodegenContext): void {
           if (lt && lt.kind === "externref") isAlreadyExternref = true;
           if (lt && lt.kind === "funcref") isFuncref = true;
         } else if (prev.op === "global.get") {
-          const gIdx = (prev as { index: number }).index;
-          const gDef = ctx.mod.globals[gIdx];
-          if (gDef && gDef.type.kind === "externref") isAlreadyExternref = true;
-          if (gDef && gDef.type.kind === "funcref") isFuncref = true;
+          const gType = getGlobalType((prev as { index: number }).index);
+          if (gType && (gType.kind === "externref" || gType.kind === "ref_extern")) isAlreadyExternref = true;
+          if (gType && gType.kind === "funcref") isFuncref = true;
         } else if (prev.op === "struct.get") {
           // struct.get can produce funcref fields — check the struct type
           const sTypeIdx = (prev as any).typeIdx;
@@ -777,6 +790,28 @@ export function fixupExternConvertAny(ctx: CodegenContext): void {
     return null;
   }
 
+  // Resolve a Wasm `global.get` operand to its ValType. The combined index
+  // space starts with imported globals (in import-section order), followed by
+  // module-defined globals (`ctx.mod.globals`). Looking up `mod.globals[gIdx]`
+  // directly is wrong for any module that imports globals, since the module
+  // globals array only stores the definition side — for the `static [computed]`
+  // class-field path this caused the fixup to miss redundant
+  // `extern.convert_any` ops over externref globals (#1623).
+  const numImportedGlobals = ctx.mod.imports.filter((imp: any) => imp.desc?.kind === "global").length;
+  function getGlobalType(gIdx: number): ValType | null {
+    if (gIdx < numImportedGlobals) {
+      let seen = 0;
+      for (const imp of ctx.mod.imports) {
+        if ((imp as any).desc?.kind !== "global") continue;
+        if (seen === gIdx) return (imp as any).desc.type as ValType;
+        seen++;
+      }
+      return null;
+    }
+    const def = ctx.mod.globals[gIdx - numImportedGlobals];
+    return def ? def.type : null;
+  }
+
   function fixupInstrs(func: WasmFunction, instrs: Instr[]): void {
     // Recurse into nested blocks first
     for (const instr of instrs) {
@@ -822,12 +857,9 @@ export function fixupExternConvertAny(ctx: CodegenContext): void {
           if (refDef && refDef.kind === "func") isFuncref = true;
         }
       } else if (prev.op === "global.get") {
-        const gIdx = (prev as { index: number }).index;
-        const gDef = ctx.mod.globals[gIdx];
-        if (gDef && gDef.type.kind === "externref") isAlreadyExternref = true;
-        if (gDef && gDef.type.kind === "funcref") isFuncref = true;
-        // Also check globals with externref type
-        if (gDef && (gDef.type.kind === "externref" || gDef.type.kind === "ref_extern")) isAlreadyExternref = true;
+        const gType = getGlobalType((prev as { index: number }).index);
+        if (gType && (gType.kind === "externref" || gType.kind === "ref_extern")) isAlreadyExternref = true;
+        if (gType && gType.kind === "funcref") isFuncref = true;
       } else if (prev.op === "struct.get") {
         const sTypeIdx = (prev as any).typeIdx;
         const sFieldIdx = (prev as any).fieldIdx;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2514,9 +2514,15 @@ export function compilePropertyAccess(
         );
         flushLateImportShifts(ctx, fctx);
         if (getIdx !== undefined) {
-          compileExpression(ctx, fctx, expr.expression);
-          // Coerce struct ref to externref
-          fctx.body.push({ op: "extern.convert_any" } as Instr);
+          // #1623: receiver may already be externref (e.g. `this` in a static
+          // method = the class object global, typed externref). Blindly emitting
+          // extern.convert_any on an externref source produces invalid Wasm
+          // (`expected anyref, found ... of type externref`). Coerce only when
+          // necessary.
+          const recvType = compileExpression(ctx, fctx, expr.expression);
+          if (recvType && recvType.kind !== "externref") {
+            coerceType(ctx, fctx, recvType, { kind: "externref" });
+          }
           addStringConstantGlobal(ctx, propName);
           const strIdx = ctx.stringGlobalMap.get(propName);
           if (strIdx !== undefined) {

--- a/tests/issue-1623-extern-doublewrap.test.ts
+++ b/tests/issue-1623-extern-doublewrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #1623: When a module-level `any`-typed binding lowers to an `externref`
+// global, downstream coercions (e.g. a computed class-member key reading
+// that global) must not wrap the value in `extern.convert_any` a second
+// time — that op expects an anyref operand and Wasm rejects the module
+// with `expected type anyref, found global.get of type externref`.
+
+async function instantiates(src: string): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) return { ok: false, reason: `CE: ${r.errors[0]?.message ?? "unknown"}` };
+  try {
+    const imports = new Proxy({}, { get: () => new Proxy({}, { get: () => () => undefined }) });
+    await WebAssembly.instantiate(r.binary, imports as never);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: `instantiate: ${(e as Error).message}` };
+  }
+}
+
+describe("#1623 extern.convert_any over already-externref operand", () => {
+  it("computed class-member key read from externref global yields valid Wasm", async () => {
+    const src = `
+let __fail: number = 0;
+let computed: any;
+
+export function test(): number {
+  computed = 'h';
+  try {
+    class C {
+      static f = 'test262';
+      static 'g';
+      static 0 = 'bar';
+      static [computed];
+    }
+    let c = new C();
+  } catch (e) {
+    if (!__fail) __fail = -1;
+    throw e;
+  }
+  return 1;
+}
+`;
+    const result = await instantiates(src);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("subclass of externref-backed parent — global.get + extern.convert_any chain", async () => {
+    // The S15.7.1/subclass binding shape, condensed: an externref global is
+    // assigned a host-constructed value and then read back inside the test
+    // function body. Pre-#1623 the fixup pass missed the import-side global
+    // index and left a redundant extern.convert_any in the body.
+    const src = `
+let g: any;
+
+export function test(): number {
+  g = {};
+  let x: any = g;
+  try { return 1; } catch (e) { return -1; }
+}
+`;
+    const result = await instantiates(src);
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/tests/issue-1623.test.ts
+++ b/tests/issue-1623.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+describe("#1623 extern.convert_any double-wrap on already-externref receiver", () => {
+  it("emits valid Wasm for `this.#priv` in static method when #priv is set-only", async () => {
+    const src = `
+      class C {
+        static set #f(v) { throw new Error(); }
+        static getAccess() { return this.#f; }
+      }
+      C.getAccess;
+      export function test(): number { return 1; }
+    `;
+    const r = compile(src, { fileName: "t.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    // Validate the module compiles — instantiation may need host imports
+    // but byte-level Wasm validation must succeed.
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+  });
+
+  it("emits valid Wasm for `this.unknownProp` in a static method (extern_get fallback)", async () => {
+    const src = `
+      class C {
+        static probe() { return (this as any).unknown; }
+      }
+      C.probe;
+      export function test(): number { return 1; }
+    `;
+    const r = compile(src, { fileName: "t.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two complementary fixes for the dominant 53-test sub-cluster of #1623, where the validator rejected modules with `extern.convert_any[0] expected type anyref, found global.get of type externref`:

- **`src/codegen/property-access.ts`** — the `__extern_get` fallback path
  unconditionally emitted `extern.convert_any` after the receiver expression. For
  `this` inside a `static` method the receiver is the class-object global
  (already externref), so the op was illegal. Use `coerceType`, which is a no-op
  when source equals destination.
- **`src/codegen/fixups.ts`** — `fixupExternConvertAny` and
  `fixupStructNewResultCoercion` resolved `global.get` operands via
  `ctx.mod.globals[gIdx]`, which only stores module-defined globals. Imported
  globals share the same index space but live in `ctx.mod.imports`, so every
  import-side index returned `undefined` and the safety net missed redundant
  `extern.convert_any` ops over imported externref globals (the common case for
  modules that import globals). Added a shared `getGlobalType` helper that
  consults the import side first.

## Impact

Of the 53 baseline tests in the `global.get of type externref` sub-cluster, 46
now produce valid Wasm. The remaining 7 are pre-existing TS compile errors or
different invalid-Wasm shapes (e.g. `not enough arguments on the stack for
call`) outside this scope. The 7-test `call of type externref` sub-cluster is a
different shape and is left for follow-up.

## Test plan

- [x] `tests/issue-1623.test.ts` — static `this.#priv` accessor reads
- [x] `tests/issue-1623-extern-doublewrap.test.ts` — computed class-member key
      read from externref global; subclass extern-backed parent chain
- [x] Targeted nearby equivalence suites (computed-property-class,
      computed-property-names, computed-setter-class, global-index-shift-trycatch,
      global-type-checks, element-access-externref, externref-array-destructuring,
      nested-class-declarations, array-externref-indexof, private-class-members) —
      pre-existing baseline failure carries over, no new regressions
- [x] 12/15 sampled failing test262 entries now compile valid; the rest are
      pre-existing TS CE / different shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)