### PR TITLE
investigate(#1338): [NOT-A-LOCALIZED-FIX] decomposes into #1318/#820/#1320/#1523

### DIFF
--- a/plan/issues/1338-spec-gap-array-from-of-construct.md
+++ b/plan/issues/1338-spec-gap-array-from-of-construct.md
@@ -1,7 +1,7 @@
 ---
 id: 1338
 title: "spec gap: Array.from / Array.of constructor semantics (39 test262 fails, wasm_compile dominant)"
-status: in-progress
+status: in-review
 created: 2026-05-08
 updated: 2026-05-28
 priority: medium

--- a/plan/issues/1338-spec-gap-array-from-of-construct.md
+++ b/plan/issues/1338-spec-gap-array-from-of-construct.md
@@ -1,9 +1,9 @@
 ---
 id: 1338
 title: "spec gap: Array.from / Array.of constructor semantics (39 test262 fails, wasm_compile dominant)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -74,3 +74,73 @@ For Array.of — same dispatch.
 - `test262/test/built-ins/Array/from/iter-set-length.js`
 - `test262/test/built-ins/Array/from/calling-from-valid-1-noStrict.js`
 - `test262/test/built-ins/Array/of/proto-from-ctor-realm.js`
+
+## Investigation 2026-05-28 (dev-1338, branch issue-1338-array-from-of)
+
+Re-baselined `built-ins/Array/from` (47 files) against current main
+(`9a819e46c`). **Reality differs from the 2026-05-08 framing:**
+
+- `from/iter-set-length.js` (acceptance #2) — **already passes** on main.
+- `from/calling-from-valid-1-noStrict.js` (acceptance #1) — fails with
+  "Cannot access property on null or undefined" at runtime, not
+  `wasm_compile`. Not a subclassing bug — the receiver is `Array`. The
+  source uses `assert.sameValue(calls[0].thisArg, this, …)` and our
+  `args.push(arguments)` path drops/dereferences something to null.
+- `of/proto-from-ctor-realm.js` (acceptance #3) — fails with
+  `$262 is not defined`. Blocked on **#1523** (wire up $262 host-object
+  in test262 runner). Not a #1338-localized fix.
+
+Categorised failures in `built-ins/Array/from`:
+
+| Bucket | Count | Belongs to |
+|--------|-------|------------|
+| `wasm_compile` (real codegen) | 4 | #1338 candidate |
+| `returned N` (test262 multi-assert wrapping) | ~12 | **#1318** |
+| null/undefined deref (mapfn / iterator host-bridge) | ~3 | **#820** family |
+| `$262` not defined | 1 | **#1523** |
+| pre-existing assertion fails (spec gap) | rest | mixed |
+
+The 4 real wasm_compile errors are **NOT subclassing**:
+- `from/iter-map-fn-args.js` — `call[0] expected externref, found (ref null 20)`
+- `from/iter-set-elem-prop.js` — same shape
+- `from/source-object-iterator-1.js` — `__cb_1 struct.get expected (ref null 26), found (ref null 25)`
+- `from/source-object-iterator-2.js` — same shape
+
+Pattern: **closure struct-type mismatch when an iterator/mapFn closure
+captures into a vec / iterator-result struct.** This overlaps with
+#1684 (iterator-result object literal nested-closure types) and #1620
+(`__iterator_next` multi-value), both already in flight.
+
+`built-ins/Array/of` scan crashed the host with `WebAssembly.Exception`
+on `of/does-not-use-set-for-indices.js` and `of/length.js` — wasm trap
+bubbling past the runner's catch. Not investigated further.
+
+### Subclassing path (the original #1338 framing)
+
+The `Sub extends Array; Sub.from(...)` case requires:
+1. **`__construct_with_this(thisCtor, length)` host import + runtime
+   support** — not present in `src/runtime.ts`.
+2. Runtime per-element write via `__set_element(target, i, v)` instead
+   of `array.set $Array.elements` — requires struct/vec untyping.
+3. Receiver-dispatch at `propAccess.expression !== "Array"` in
+   `compileArrayFrom`/`compileArrayOf`.
+
+This is the same iterator-bridge gap **#1320** has already been
+**ESCALATED-NEEDS-ARCHITECT** for (task #158). Without that bridge
+landing, the #1338 subclass path has no scaffolding to attach to.
+
+### Recommendation
+
+#1338 as written is **NOT a single localized bugfix**. The failures
+decompose into:
+
+- 4 closure-struct wasm_compile errors → overlap with **#1684/#1620**
+  (already escalated/in-flight).
+- ~12 `returned N` wraps → **#1318**.
+- ~3 null deref → **#820** family.
+- $262 → **#1523**.
+- Subclass-via-`this`-construct → **blocked on #1320 architect spec**.
+
+Suggest: close as `[NOT-A-LOCALIZED-FIX]` and route the residuals into
+existing issues, OR keep open and gate on #1320 + #1684 + #1318 landing.
+No standalone PR should land for #1338 in its current scope.


### PR DESCRIPTION
## Summary

Docs-only investigation PR for #1338 (Array.from / Array.of spec gap).

Re-baselined `built-ins/Array/from` (47 files) against current main and
documented findings in the issue file. The 2026-05-08 framing
("subclassing causes 15 wasm_compile errors") **does not match current reality**:

- Acceptance #2 (`iter-set-length.js`) — already passes on main.
- Acceptance #1 (`calling-from-valid-1-noStrict.js`) — fails with a
  runtime null-deref, not `wasm_compile`. Receiver is `Array`, not a
  subclass.
- Acceptance #3 (`proto-from-ctor-realm.js`) — needs `$262`, blocked on
  **#1523**.

Only 4 of 47 from-tests fail with real `wasm_compile` errors, and they
are closure struct-type mismatches that overlap with **#1684/#1620**,
not subclassing. The genuine subclass path requires the
`__construct_with_this` host import / iterator-bridge already escalated
to architect in **#1320**.

## Recommendation

Close as `[NOT-A-LOCALIZED-FIX]` and route residuals into existing
issues, OR keep open and gate on #1320 + #1684 + #1318 landing.
No standalone PR should attempt to "fix #1338" in current scope.

## Test plan

- [x] Docs-only — no source code modified
- [x] Re-baseline scan logged at `.tmp/scan-results.log` during investigation
- [x] Status flipped to `in-review`

Same pattern as #1674 (PR #750) and #1632 (PR #736).