### PR TITLE
docs(#1352): mark done — already fixed on main by #1383 + #786

### DIFF
--- a/plan/issues/1352-regexp-exec-result-wasmgc-string-externref-equality.md
+++ b/plan/issues/1352-regexp-exec-result-wasmgc-string-externref-equality.md
@@ -1,9 +1,10 @@
 ---
 id: 1352
 title: "RegExp exec result: wasmGC string struct ≠ externref string in strict equality (S15.10.2 cluster)"
-status: backlog
+status: done
+completed: 2026-05-28
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -14,6 +15,68 @@ goal: spec-completeness
 sprint: ~
 parent: 1333
 ---
+
+## Resolution (2026-05-28, developer reconciliation)
+
+**ALREADY FIXED ON MAIN — close as `done`, no implementation work needed.**
+
+The S15.10.2 cluster cited as the primary failure surface is already
+fully passing in the current baseline:
+
+```
+$ grep '"S15.10.2' .test262-cache/test262-current.jsonl | jq -r .status | sort | uniq -c
+    290 pass
+      1 compile_error
+```
+
+No strict-equality failures remain. The fix landed earlier under a
+different issue:
+
+- **`4b7c1411` — fix(#1383): typeof-gated strict-equality fallback for
+  cross-type comparisons** — replaced the unsound
+  `host_eq(a,b) || unbox(a)===unbox(b)` shape in the strict-equality
+  codegen with a typeof-gated fallback, which routes the wasmGC-struct
+  / externref-string mixed-operand case through real JS `===` semantics
+  via the host bridge.
+- Followed by **`c3f55339` — fix(#786): Array indexOf/lastIndexOf/
+  includes use spec equality for externref elements** for the
+  SameValueZero side.
+
+Reproducer used to confirm (current main, `.mts`, default mode):
+
+```ts
+function test(): number {
+  const m = /(\d+)/.exec("abc42xyz");
+  if (m === null) return 99;
+  if (m[0] === "42") return 1;
+  return 0;
+}
+// test() = 1 → PASS
+```
+
+Multi-element `String.prototype.match` + element-by-element strict
+comparison also returns `1`.
+
+### Out of scope (carved to follow-up if surfaced)
+
+- `--nativeStrings` / `--target wasi` mode: the i16-array string struct
+  has no `Symbol.toPrimitive` and would need a dedicated
+  `__str_extern` reader at the host bridge. The architect spec below
+  flagged this; no S15.10.2 nativeStrings failures observed in the
+  baseline, so no follow-up filed.
+
+### Notes on prior attempt
+
+An orphaned branch `origin/issue-1352-host-eq` carries commit
+`383fb8fd2` ("fix(#1352): normalize wasmGC string structs in host
+equality bridges") that implemented the architect spec's Option 1
+(_normalizeForHostEq helper on host_eq / host_loose_eq /
+same_value_zero). It was never opened as a PR; the codegen-level fix in
+#1383 superseded it before it landed. The branch is now severely out of
+sync (5 ahead / 2583 behind) and can be deleted.
+
+---
+
 # #1352 — RegExp exec result: wasmGC string struct ≠ externref V8 string in strict equality
 
 ## Problem


### PR DESCRIPTION
## Summary

Reconciliation only — no code change. The S15.10.2 RegExp exec-result
strict-equality cluster cited by #1352 is **already passing on main**
(290/291 in the current baseline). The cross-type strict-equality fix
landed earlier under a different issue:

- `4b7c1411` **fix(#1383)** — typeof-gated strict-equality fallback
  for cross-type comparisons. Replaced the unsound
  `host_eq(a,b) || unbox(a)===unbox(b)` codegen shape so the
  wasmGC-struct vs externref-string case routes through real JS `===`.
- `c3f55339` **fix(#786)** — Array indexOf/lastIndexOf/includes use
  spec equality for externref elements (SameValueZero side).

Reproducer confirms on current main:

```ts
function test(): number {
  const m = /(\d+)/.exec("abc42xyz");
  if (m === null) return 99;
  if (m[0] === "42") return 1;
  return 0;
}
// test() = 1 → PASS
```

Baseline check:

```
$ grep '"S15.10.2' .test262-cache/test262-current.jsonl | jq -r .status | sort | uniq -c
    290 pass
      1 compile_error
```

The orphaned `origin/issue-1352-host-eq` branch (commit `383fb8fd2`,
"normalize wasmGC string structs in host equality bridges") implemented
the architect spec's Option 1 but was never opened as a PR; #1383
superseded it at the codegen layer. That branch is now 2583 commits
behind main and can be deleted.

## Test plan
- [x] Reproducer (`/(\d+)/.exec("abc42xyz")[0] === "42"`) returns PASS on current main
- [x] Multi-element match comparison returns PASS on current main
- [x] Baseline shows 0 strict-equality fails in S15.10.2 cluster