### PR TITLE
fix(#1343): TimeClip on Date construction — RangeError for out-of-range

### DIFF
--- a/plan/issues/1343-spec-gap-date-prototype-formatters.md
+++ b/plan/issues/1343-spec-gap-date-prototype-formatters.md
@@ -1,9 +1,9 @@
 ---
 id: 1343
 title: "spec gap: Date.prototype string formatters and parsers (174 of 485 test262 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -181,3 +181,70 @@ Started investigation in worktree
 focused multi-hour effort and shouldn't be rushed during CI-wait. Worktree
 is clean — only this issue file is modified. Ready for re-claim by next dev
 or for me to resume after #264 self-merges.
+
+## Update (2026-05-28, developer)
+
+Baseline on current `main` (bbd14bf92): **403 / 485 pass (83.1 %)**, 82
+fails in `built-ins/Date/prototype` — Slices 1 (NaN), 2 (time-of-day
+setters), 3 (calendar setters) landed via PR #662 / PR #358
+(`fix(#1638)` + `fix(#1440)` / `fix(#1344)`). Remaining buckets:
+
+| Bucket | Fails | Source |
+|---|---:|---|
+| `toTemporalInstant` | 6 | Temporal proposal — already in skip filters |
+| `toISOString` | 8 | RangeError on out-of-range / Invalid Date |
+| `toJSON` | 7 | requires ToPrimitive on receiver — non-Date-receiver case |
+| `Symbol.toPrimitive` | 6 | method not exposed on Date.prototype |
+| `toUTCString` | 5 | format edge cases (invalid-date branch + day-name table) |
+| `toString` / `toDateString` / `toTimeString` | 9 | format edge cases |
+| setters | ~30 | residuals on Slice 2/3 |
+| misc | 5 | valueOf, no-date-value, S15.9.5_A01_T1 etc. |
+
+### Landing: TimeClip on Date construction (Slice 4 partial)
+
+`src/codegen/expressions/new-super.ts` previously sentineled only on the
+1-arg `new Date(NaN)` case. Out-of-range timestamps (`new Date(8.64e15 + 1)`,
+`new Date(Infinity)`) and multi-arg non-finite components
+(`new Date(Infinity, 1, 70, 0, 0, 0)`) silently saturated through
+`i64.trunc_sat_f64_s` and produced a bogus formatted string instead of the
+spec-mandated RangeError from `toISOString`.
+
+Fix folds TimeClip §21.4.1.31 into both construction paths:
+
+1. **1-arg `new Date(ms)`** — the NaN test is OR'd with
+   `abs(ms) > 8.64e15`. Both branches go to the existing `i64.MIN`
+   sentinel, so the runtime's `_formatDate(mode === ISO && invalid)` path
+   throws RangeError naturally.
+2. **Multi-arg `new Date(y,m,d,h,m,s,ms)`** — each f64 arg now also
+   updates a `nonFiniteLocal` i32 flag (`NaN || abs > 8.64e15`); the
+   final timestamp computation OR's that flag with the post-arithmetic
+   magnitude check; the result becomes the sentinel on overflow.
+
+The default JS-host path is untouched (the wasmGC Date struct lives only
+in standalone-capable codegen; #618 hazard does not apply — no
+addImport/funcIdx shift here).
+
+Tests: `tests/issue-1343-timeclip.test.ts` — 8/8 pass
+(out-of-range positive/negative ms, Infinity ms, multi-arg Infinity year,
+multi-arg NaN year, valid Date round-trip, 1-arg `new Date(0)`, boundary
+8.64e15 still valid).
+
+### Out of scope this PR — follow-up needed
+
+- **`toJSON` non-Date receiver** (7 fails). Per §21.4.4.45 `toJSON` calls
+  ToPrimitive(this, "number"); the receiver may be any object. Currently
+  toJSON is wired through the same dispatch as the formatters and
+  assumes a `__Date` struct receiver — fixing it needs a Symbol.toPrimitive
+  / ToPrimitive(this,"number") plumbing pass that overlaps `__Date` brand
+  handling.
+- **`Symbol.toPrimitive` on Date.prototype** (6 fails). The well-known
+  symbol is not yet registered as a method on the Date prototype; adding
+  it requires the classAccessorSet wiring documented in the senior-dev
+  plan (Slice 4 second item).
+- **Format polish on edge years** (~16 fails across `to{,UTC,Date,Time}String`).
+  The runtime's `_datePad` for negative years already does 6-digit padding;
+  the failing tests typically check exact-character matches that depend
+  on specific day-of-week / month-name table entries for years far outside
+  1970-9999. Worth a focused audit but not blocking.
+- **Setter residuals** (~30 fails across `set{,UTC}{Date,Hours,…,FullYear}`)
+  — out of scope; Slices 2/3 mostly landed but edge cases remain.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1950,12 +1950,22 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // calls (getDay, getHours, getTime, …) can return NaN per spec
       // (`new Date(NaN).getTime() → NaN`). Without this, `i64.trunc_sat_f64_s`
       // saturates NaN to 0 and the Date silently behaves like the epoch.
+      //
+      // (#1343) TimeClip per §21.4.1.31: if !isFinite(ms) or abs(ms) > 8.64e15,
+      // return NaN. Both NaN and out-of-range get the sentinel. ±Infinity is
+      // out-of-range (abs > 8.64e15), so the single magnitude check covers it.
       compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
       const msLocal = allocTempLocal(fctx, { kind: "f64" });
       fctx.body.push({ op: "local.tee", index: msLocal } as Instr);
-      // ms != ms is true iff ms is NaN
+      // isInvalid = (ms != ms) || (abs(ms) > 8.64e15)
+      // ms != ms is true iff ms is NaN (covers NaN)
       fctx.body.push({ op: "local.get", index: msLocal } as Instr);
       fctx.body.push({ op: "f64.ne" } as Instr);
+      fctx.body.push({ op: "local.get", index: msLocal } as Instr);
+      fctx.body.push({ op: "f64.abs" } as Instr);
+      fctx.body.push({ op: "f64.const", value: 8.64e15 } as Instr);
+      fctx.body.push({ op: "f64.gt" } as Instr);
+      fctx.body.push({ op: "i32.or" } as Instr);
       fctx.body.push({
         op: "if",
         blockType: { kind: "val", type: { kind: "i64" } },
@@ -1972,69 +1982,74 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     {
       const daysFromCivilIdx = ensureDateDaysFromCivilHelper(ctx);
 
+      // (#1343) Track whether any arg is NaN or non-finite. If so, the resulting
+      // Date is Invalid (§21.4.2.1 MakeDate / TimeClip step on non-finite).
+      // We OR-accumulate an i32 flag and stash the f64 value before trunc.
+      const nonFiniteLocal = allocTempLocal(fctx, { kind: "i32" });
+      fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+      fctx.body.push({ op: "local.set", index: nonFiniteLocal } as Instr);
+
+      const checkNonFinite = (f64Local: number) => {
+        // flag = flag | (v != v) | (abs(v) == +Inf)
+        // We treat ±Inf as "non-finite enough" too — abs(v) > 8.64e15 is sufficient.
+        fctx.body.push({ op: "local.get", index: nonFiniteLocal } as Instr);
+        fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+        fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+        fctx.body.push({ op: "f64.ne" } as Instr); // NaN check
+        fctx.body.push({ op: "i32.or" } as Instr);
+        fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+        fctx.body.push({ op: "f64.abs" } as Instr);
+        fctx.body.push({ op: "f64.const", value: 8.64e15 } as Instr);
+        fctx.body.push({ op: "f64.gt" } as Instr);
+        fctx.body.push({ op: "i32.or" } as Instr);
+        fctx.body.push({ op: "local.set", index: nonFiniteLocal } as Instr);
+      };
+
       // Compile year
       compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
+      const yearF64Local = allocTempLocal(fctx, { kind: "f64" });
+      fctx.body.push({ op: "local.tee", index: yearF64Local } as Instr);
+      checkNonFinite(yearF64Local);
       fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
       const yearLocal = allocTempLocal(fctx, { kind: "i64" });
       fctx.body.push({ op: "local.set", index: yearLocal } as Instr);
+      releaseTempLocal(fctx, yearF64Local);
 
       // Compile month (0-indexed) + 1 for civil algorithm
       compileExpression(ctx, fctx, args[1]!, { kind: "f64" });
+      const monthF64Local = allocTempLocal(fctx, { kind: "f64" });
+      fctx.body.push({ op: "local.tee", index: monthF64Local } as Instr);
+      checkNonFinite(monthF64Local);
+      releaseTempLocal(fctx, monthF64Local);
       fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
       fctx.body.push({ op: "i64.const", value: 1n } as Instr);
       fctx.body.push({ op: "i64.add" } as Instr);
       const monthLocal = allocTempLocal(fctx, { kind: "i64" });
       fctx.body.push({ op: "local.set", index: monthLocal } as Instr);
 
-      // Compile day (default 1)
-      if (args.length >= 3) {
-        compileExpression(ctx, fctx, args[2]!, { kind: "f64" });
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
-      } else {
-        fctx.body.push({ op: "i64.const", value: 1n } as Instr);
-      }
-      const dayLocal = allocTempLocal(fctx, { kind: "i64" });
-      fctx.body.push({ op: "local.set", index: dayLocal } as Instr);
+      // (#1343) For the remaining optional args, also accumulate the non-finite
+      // flag when the arg is present.
+      const compileTimePart = (argIdx: number, defaultI64: bigint, localKind: ValType) => {
+        if (args.length > argIdx) {
+          compileExpression(ctx, fctx, args[argIdx]!, { kind: "f64" });
+          const f64L = allocTempLocal(fctx, { kind: "f64" });
+          fctx.body.push({ op: "local.tee", index: f64L } as Instr);
+          checkNonFinite(f64L);
+          releaseTempLocal(fctx, f64L);
+          fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+        } else {
+          fctx.body.push({ op: "i64.const", value: defaultI64 } as Instr);
+        }
+        const local = allocTempLocal(fctx, localKind);
+        fctx.body.push({ op: "local.set", index: local } as Instr);
+        return local;
+      };
 
-      // Compile hours (default 0)
-      if (args.length >= 4) {
-        compileExpression(ctx, fctx, args[3]!, { kind: "f64" });
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
-      } else {
-        fctx.body.push({ op: "i64.const", value: 0n } as Instr);
-      }
-      const hoursLocal = allocTempLocal(fctx, { kind: "i64" });
-      fctx.body.push({ op: "local.set", index: hoursLocal } as Instr);
-
-      // Compile minutes (default 0)
-      if (args.length >= 5) {
-        compileExpression(ctx, fctx, args[4]!, { kind: "f64" });
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
-      } else {
-        fctx.body.push({ op: "i64.const", value: 0n } as Instr);
-      }
-      const minutesLocal = allocTempLocal(fctx, { kind: "i64" });
-      fctx.body.push({ op: "local.set", index: minutesLocal } as Instr);
-
-      // Compile seconds (default 0)
-      if (args.length >= 6) {
-        compileExpression(ctx, fctx, args[5]!, { kind: "f64" });
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
-      } else {
-        fctx.body.push({ op: "i64.const", value: 0n } as Instr);
-      }
-      const secondsLocal = allocTempLocal(fctx, { kind: "i64" });
-      fctx.body.push({ op: "local.set", index: secondsLocal } as Instr);
-
-      // Compile ms (default 0)
-      if (args.length >= 7) {
-        compileExpression(ctx, fctx, args[6]!, { kind: "f64" });
-        fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
-      } else {
-        fctx.body.push({ op: "i64.const", value: 0n } as Instr);
-      }
-      const msLocal = allocTempLocal(fctx, { kind: "i64" });
-      fctx.body.push({ op: "local.set", index: msLocal } as Instr);
+      const dayLocal = compileTimePart(2, 1n, { kind: "i64" });
+      const hoursLocal = compileTimePart(3, 0n, { kind: "i64" });
+      const minutesLocal = compileTimePart(4, 0n, { kind: "i64" });
+      const secondsLocal = compileTimePart(5, 0n, { kind: "i64" });
+      const msLocal = compileTimePart(6, 0n, { kind: "i64" });
 
       // Handle year 0-99 mapping to 1900-1999 (JS Date quirk)
       // if (0 <= year <= 99) year += 1900
@@ -2085,6 +2100,31 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         { op: "local.get", index: msLocal } as Instr,
         { op: "i64.add" } as Instr,
       );
+
+      // (#1343) TimeClip §21.4.1.31: if any arg was NaN/non-finite, or
+      // abs(ts) > 8.64e15, the time is invalid. The nonFiniteLocal flag covers
+      // the f64 NaN/Inf cases (i64.trunc_sat_f64_s would otherwise saturate them
+      // silently); the magnitude check covers in-range f64 values that still
+      // produce an out-of-range timestamp.
+      const tsResultLocal = allocTempLocal(fctx, { kind: "i64" });
+      fctx.body.push({ op: "local.set", index: tsResultLocal } as Instr);
+      fctx.body.push(
+        { op: "local.get", index: nonFiniteLocal } as Instr,
+        { op: "local.get", index: tsResultLocal } as Instr,
+        { op: "f64.convert_i64_s" } as Instr,
+        { op: "f64.abs" } as Instr,
+        { op: "f64.const", value: 8.64e15 } as Instr,
+        { op: "f64.gt" } as Instr,
+        { op: "i32.or" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i64" } },
+          then: [{ op: "i64.const", value: -9223372036854775808n } as Instr],
+          else: [{ op: "local.get", index: tsResultLocal } as Instr],
+        } as unknown as Instr,
+      );
+      releaseTempLocal(fctx, tsResultLocal);
+      releaseTempLocal(fctx, nonFiniteLocal);
 
       fctx.body.push({ op: "struct.new", typeIdx: dateTypeIdx } as Instr);
 

--- a/tests/issue-1343-timeclip.test.ts
+++ b/tests/issue-1343-timeclip.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #1343 Slice 4 (partial) — TimeClip on Date construction.
+ *
+ * Per ECMAScript §21.4.1.31 TimeClip: a millisecond timestamp whose magnitude
+ * exceeds 8.64e15 (or which is non-finite) yields the Invalid Date sentinel.
+ * Without TimeClip, `new Date(8.64e15 + 1).toISOString()` quietly produced a
+ * formatted string instead of the spec-mandated RangeError; multi-arg
+ * `new Date(Infinity, ...)` saturated through `i64.trunc_sat_f64_s` and built
+ * a bogus epoch-relative timestamp.
+ *
+ * Fix lives in `src/codegen/expressions/new-super.ts` — the two `new Date(...)`
+ * codegen paths (1-arg ms, multi-arg y/m/d/h/m/s/ms) now both fold to the
+ * `i64.MIN` Invalid sentinel when a non-finite f64 or out-of-range ms shows up.
+ * `toISOString` and the runtime `_formatDate` helper then take the RangeError
+ * branch (`mode === _DATE_FMT_ISO && invalid`).
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("issue #1343 Slice 4 — TimeClip on Date construction", () => {
+  it("toISOString throws RangeError when 1-arg ms exceeds +8.64e15", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(8.64e15 + 1);
+        try {
+          return d.toISOString();
+        } catch (e: any) {
+          return "threw: " + (e.name ?? "Error");
+        }
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("threw: RangeError");
+  });
+
+  it("toISOString throws RangeError when 1-arg ms is below -8.64e15", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(-8.64e15 - 1);
+        try {
+          return d.toISOString();
+        } catch (e: any) {
+          return "threw: " + (e.name ?? "Error");
+        }
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("threw: RangeError");
+  });
+
+  it("toISOString throws RangeError when 1-arg ms is +Infinity", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(Infinity);
+        try {
+          return d.toISOString();
+        } catch (e: any) {
+          return "threw: " + (e.name ?? "Error");
+        }
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("threw: RangeError");
+  });
+
+  it("toISOString throws RangeError when multi-arg year is Infinity", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(Infinity, 1, 70, 0, 0, 0);
+        try {
+          return d.toISOString();
+        } catch (e: any) {
+          return "threw: " + (e.name ?? "Error");
+        }
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("threw: RangeError");
+  });
+
+  it("toISOString throws RangeError when multi-arg year is NaN", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(NaN, 1, 1);
+        try {
+          return d.toISOString();
+        } catch (e: any) {
+          return "threw: " + (e.name ?? "Error");
+        }
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("threw: RangeError");
+  });
+
+  it("valid Date still formats correctly post-TimeClip", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(1999, 9, 10, 10, 10, 10, 10);
+        return d.toISOString();
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("1999-10-10T10:10:10.010Z");
+  });
+
+  it("valid 1-arg ms Date still formats correctly post-TimeClip", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(0);
+        return d.toISOString();
+      }
+    `;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe("1970-01-01T00:00:00.000Z");
+  });
+
+  it("boundary value 8.64e15 itself is valid", async () => {
+    const source = `
+      export function test(): string {
+        const d = new Date(8.64e15);
+        return d.toISOString();
+      }
+    `;
+    const exports = await compileToWasm(source);
+    // 8.64e15 ms = Sep 13, 275760 — the +0.. extended-year ISO format.
+    // We accept either V8's canonical "+275760-..." form or the runtime's chosen form.
+    const out = exports.test!() as string;
+    expect(out).toMatch(/^\+275760-09-13T00:00:00\.000Z$/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements §21.4.1.31 TimeClip on the two `new Date(...)` codegen paths in `src/codegen/expressions/new-super.ts`. Previously only the literal `new Date(NaN)` case sentineled — out-of-range timestamps (`new Date(8.64e15 + 1)`) and multi-arg non-finite components (`new Date(Infinity, 1, 70, …)`) silently saturated through `i64.trunc_sat_f64_s` and produced a bogus formatted string instead of the spec-mandated RangeError from `toISOString`.

## Approach

- **1-arg `new Date(ms)`**: OR the NaN test with `abs(ms) > 8.64e15`. Both branches reach the existing `i64.MIN` Invalid sentinel.
- **Multi-arg `new Date(y,m,d,h,m,s,ms)`**: accumulate a `nonFiniteLocal` i32 flag across the f64 args (`NaN || abs > 8.64e15`); OR it with a post-arithmetic magnitude check on the final timestamp; fold the result to the sentinel on overflow.

Out-of-range and ±Infinity inputs now route to the runtime's existing `_formatDate(mode === ISO && invalid)` RangeError branch.

The default JS-host path is untouched (no host imports added, no funcIdx shift, no #618 hazard).

## Context

Issue #1343 has the broad Date `built-ins/Date/prototype` umbrella (174 fails at the time it was filed). Baseline today on current `main` (bbd14bf92): **403 / 485 pass (83.1 %)**, **82 fails** — Slices 1-3 already landed via PR #662 / #358. This PR targets the Slice 4 TimeClip portion only; remaining residuals (`toJSON` non-Date receiver, `Symbol.toPrimitive` on Date.prototype, format polish on edge years, setter edge cases) are documented in the issue file as follow-up work.

## Test plan

- [x] `tests/issue-1343-timeclip.test.ts` — 8/8 pass
  - out-of-range positive ms (`8.64e15 + 1`) → RangeError
  - out-of-range negative ms (`-8.64e15 - 1`) → RangeError
  - `+Infinity` ms → RangeError
  - multi-arg `Infinity` year → RangeError
  - multi-arg `NaN` year → RangeError
  - valid Date round-trip (`new Date(1999,9,10,...).toISOString()`)
  - valid 1-arg ms (`new Date(0).toISOString()`)
  - boundary `8.64e15` itself still valid
- [x] Existing `tests/issue-1343-date-setters.test.ts` still green (28/28)
- [ ] CI test262 — expect ~5-8 flips in `built-ins/Date/prototype/toISOString/15.9.5.43-0-{9..15}.js` plus the `invalid-date` family in `toString` / `toUTCString` / `toDateString` / `toTimeString`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)