### PR TITLE
fix(#1338): use defaultValueInstrs for externref element type in Array.from fast path

### DIFF
--- a/plan/issues/1338-spec-gap-array-from-of-construct.md
+++ b/plan/issues/1338-spec-gap-array-from-of-construct.md
@@ -3,7 +3,7 @@ id: 1338
 title: "spec gap: Array.from / Array.of constructor semantics (39 test262 fails, wasm_compile dominant)"
 status: ready
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -74,3 +74,21 @@ For Array.of — same dispatch.
 - `test262/test/built-ins/Array/from/iter-set-length.js`
 - `test262/test/built-ins/Array/from/calling-from-valid-1-noStrict.js`
 - `test262/test/built-ins/Array/of/proto-from-ctor-realm.js`
+
+## Partial fix (2026-05-28, developer)
+
+Carved a small, safe sub-fix from the broader scope: the Array.from fast path
+(`src/codegen/expressions/calls.ts`, the `Array.from(arr)` array-copy branch)
+was hand-rolling the `array.new` default value as `{ op: "ref.null",
+typeIdx: (elemType as any).typeIdx ?? -1 }`. When `elemType.kind` was
+`externref` (no `typeIdx` field), this emitted invalid Wasm with the validator
+error `Unknown heap type -1`.
+
+Replaced with `defaultValueInstrs(elemType)` — the canonical helper that
+handles `externref`/`ref`/`ref_null`/`i32`/`f64`/`i64` uniformly. Probe
+(`Array.from([0, 'foo', undefined, Infinity])`) now validates and returns
+length 4.
+
+Tests: `tests/issue-1338.test.ts` — 3 cases (mixed-typed, numeric, string)
+all passing. Broader subclass dispatch + iterator bridge work remains in the
+dependency chain (#1320/#820/#1318/#1523/#1684) and is unchanged by this PR.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3249,14 +3249,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             fieldIdx: 1,
           });
           fctx.body.push({ op: "local.set", index: srcData });
-          // Create new data array with default value
-          const defaultVal =
-            elemType.kind === "f64"
-              ? { op: "f64.const", value: 0 }
-              : elemType.kind === "i32"
-                ? { op: "i32.const", value: 0 }
-                : { op: "ref.null", typeIdx: (elemType as any).typeIdx ?? -1 };
-          fctx.body.push(defaultVal as Instr);
+          // Create new data array with default value — defaultValueInstrs
+          // handles externref/ref/ref_null/i32/f64/i64 uniformly. Hand-rolling
+          // `ref.null typeIdx: -1` for the externref element case produced
+          // "Unknown heap type -1" wasm_compile errors (#1338).
+          for (const ins of defaultValueInstrs(elemType)) fctx.body.push(ins);
           fctx.body.push({ op: "local.get", index: lenTmp });
           fctx.body.push({ op: "array.new", typeIdx: arrTypeIdx });
           fctx.body.push({ op: "local.set", index: dstData });

--- a/tests/issue-1338.test.ts
+++ b/tests/issue-1338.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+describe("#1338 — Array.from fast path: externref element type default value", () => {
+  async function run(src: string): Promise<any> {
+    const r = compile(src, { fileName: "test.ts" });
+    if (!r.success) throw new Error(`CE: ${r.errors[0]?.message}`);
+    const imports = buildImports(r.imports, undefined, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, imports);
+    return (instance.exports as any).test?.();
+  }
+
+  it("Array.from over mixed-typed (externref) array validates and copies length", async () => {
+    const ret = await run(`
+      export function test(): number {
+        const array: any[] = [0, 'foo', undefined, Infinity];
+        const result = Array.from(array);
+        return result.length;
+      }
+    `);
+    expect(ret).toBe(4);
+  });
+
+  it("Array.from over numeric array still works (f64 fast path)", async () => {
+    const ret = await run(`
+      export function test(): number {
+        const array: number[] = [1, 2, 3, 4, 5];
+        const result = Array.from(array);
+        return result.length;
+      }
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("Array.from over string array (externref) validates", async () => {
+    const ret = await run(`
+      export function test(): number {
+        const array: string[] = ['a', 'b', 'c'];
+        const result = Array.from(array);
+        return result.length;
+      }
+    `);
+    expect(ret).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

The `Array.from(arr)` fast path in `src/codegen/expressions/calls.ts` was hand-rolling the `array.new` default value as:

```ts
const defaultVal =
  elemType.kind === "f64"
    ? { op: "f64.const", value: 0 }
    : elemType.kind === "i32"
      ? { op: "i32.const", value: 0 }
      : { op: "ref.null", typeIdx: (elemType as any).typeIdx ?? -1 };
```

When `elemType.kind` was `externref` (no `typeIdx` field), the fallback emitted `ref.null typeIdx: -1`, which the validator rejects with `Unknown heap type -1`. This blocked `Array.from(mixedTypedArr)` over arrays whose element type lowers to externref (e.g. `[0, 'foo', undefined, Infinity]`).

Replaced with `defaultValueInstrs(elemType)` — the canonical helper that already handles `externref`/`ref`/`ref_null`/`i32`/`f64`/`i64` uniformly. The helper is already imported and used elsewhere in the same file.

## Scope

Focused PR: only the externref-element wasm_compile slice of #1338. The broader Array.from subclass-dispatch + iterator-bridge work (Sub.from, iterables, mapFn) remains carved into the dependency chain (#1320 / #820 / #1318 / #1523 / #1684) and is unchanged by this PR. AC for #1338 only partially advances.

## Test plan

- [x] `npx vitest run tests/issue-1338.test.ts` — 3/3 pass (mixed-typed externref, f64 fast path, string externref)
- [x] `npx vitest run tests/equivalence/array-*.test.ts tests/issue-1338.test.ts` — 17/17 pass
- [x] Probe: `compile()` of `Array.from([0, 'foo', undefined, Infinity])` now validates; previously hit `Unknown heap type -1`
- [ ] CI test262 — relies on the merge-group baseline to confirm no regressions on the default GC path

🤖 Generated with [Claude Code](https://claude.com/claude-code)