### PR TITLE
fix(#1329-b3): RegExp @@replace replacer return-value host-proxy wrap

### DIFF
--- a/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
+++ b/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
@@ -1,9 +1,9 @@
 ---
 id: 1329
 title: "RegExp host-mode: Symbol.replace / replaceAll protocol spec compliance (110 fails)"
-status: ready
+status: in-review
 created: 2026-05-08
-updated: 2026-05-08
+updated: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: high

--- a/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
+++ b/plan/issues/1329-regexp-symbol-replace-protocol-spec-compliance.md
@@ -110,3 +110,44 @@ runs are reliable. Use CI shards for full counts.
 - Sibling: #1328 (Symbol.match), #1330 (Symbol.search), #1331 (Symbol.split)
 - Overlaps: #983 / #1128 / #1529 (host object-coercion closure dispatch),
   #1342 / #1637 (boolean externref representation)
+
+## #1329-b3 — partial fix (2026-05-28, developer)
+
+Surgical fix for Bucket 3's *result-coercion* half. `__regex_symbol_call`'s
+`wrapCallable` returned a JS function whose return value flowed straight back
+to V8's @@replace. When the user replacer returned a wasmGC struct (typical
+shape: `{ toString(){ … } }`), V8 ran step 14.k.vi `replacement =
+ToString(replValue)` on an opaque WebAssembly object and threw "Cannot convert
+object to primitive value".
+
+The wrapper now post-processes the closure's return value: when it comes back
+as a WasmGC struct, it's routed through `_wrapForHost(ret, exports)` so V8's
+downstream `ToString` reaches the struct's `toString`/`valueOf` closure fields
+via the host proxy — mirroring the treatment we already apply to wasm-struct
+*args* (`wrappedArg0`).
+
+Touches: `src/runtime.ts` (~14 LOC inside the closure-arg wrapper) +
+`tests/issue-1329-b3.test.ts` (3 cases: object-with-toString, number→string,
+plain-string passthrough).
+
+Verification:
+
+| probe / test | before | after |
+|---|---|---|
+| `fn-coerce-replacement.js` (object-with-toString) | throws "Cannot convert object to primitive value" | "[toString value]" (PASS) |
+| `tests/issue-1329-b3.test.ts` | n/a | 3/3 PASS |
+| `tests/issue-1439.test.ts` (10 cases) | 10/10 | 10/10 (no regression) |
+| `tests/issue-1443.test.ts` (5 cases) | 5/5 | 5/5 (no regression) |
+
+### Still failing (out of scope for this PR)
+
+- **`fn-invoke-args.js`** — replacer is called with fewer args than the spec
+  requires. V8 hands @@replace a variadic `(matched, ...captures, position,
+  string)` arg vector; our `wrapCallable` truncates to whatever
+  `__call_fn_N` is the highest emitted dispatcher (capped at N=4 by the
+  codegen), losing the trailing `string`. Genuine codegen change — requires
+  emitting `__call_fn_5+` *and* full `arguments`-object reification inside
+  compiled closures. Not localizable to runtime.ts. Defer to a sibling
+  carve.
+- **String-replacement substitution patterns** (`$&`, `$\``, `$'`, `$n`,
+  `$<name>`) and the wider GetSubstitution edge cases — pre-existing.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5277,6 +5277,17 @@ assert._isSameValue = isSameValue;
           // struct. Tries multiple arities for closures since the user
           // function may declare 1–4 params (replace callback spec passes
           // (match, ...captures, offset, string)).
+          //
+          // (#1329-b3) The wrapping callable also routes the closure's
+          // RETURN value through `_wrapForHost` when it comes back as a
+          // wasmGC struct. V8's @@replace then performs `ToString` on the
+          // returned value (spec §22.2.5.8 step 14.k.vi — `replacement =
+          // ToString(replValue)`); without the host proxy the engine sees
+          // an opaque WebAssembly object and throws "Cannot convert object
+          // to primitive value". The proxy exposes the struct's
+          // `toString`/`valueOf` closure fields as callable, matching the
+          // same `_wrapForHost` treatment we already apply to wasm-struct
+          // args via `wrappedArg0`.
           const wrapCallable = (a: any): any => {
             if (a == null) return a;
             if (!_isWasmStruct(a)) return a;
@@ -5289,7 +5300,19 @@ assert._isSameValue = isSameValue;
                   // wrap — _wrapWasmClosure returns null only when callbacks
                   // are absent, so a non-null return means we can dispatch.
                   const wrapped = _wrapWasmClosure(a, ar, callbackState);
-                  if (wrapped) return wrapped;
+                  if (wrapped) {
+                    return function replacerBridge(...callArgs: any[]): any {
+                      const ret = wrapped(...callArgs);
+                      // Wrap an opaque WasmGC struct return value so the
+                      // host's downstream `ToString` reaches the struct's
+                      // `toString`/`valueOf` closure fields.
+                      if (ret != null && _isWasmStruct(ret)) {
+                        const exps2 = callbackState?.getExports();
+                        return _wrapForHost(ret, exps2);
+                      }
+                      return ret;
+                    };
+                  }
                 }
               }
             }

--- a/tests/issue-1329-b3.test.ts
+++ b/tests/issue-1329-b3.test.ts
@@ -1,0 +1,63 @@
+/**
+ * #1329-b3 — RegExp @@replace replacer return-value coercion.
+ *
+ * Mirrors `built-ins/RegExp/prototype/Symbol.replace/fn-coerce-replacement.js`
+ * from test262. When the replacer function returns a WasmGC struct with a
+ * `toString` field (compiled object literal), V8's @@replace performs
+ * `ToString(replValue)` per §22.2.5.8 step 14.k.vi. Without the host-proxy
+ * wrap inside `__regex_symbol_call`'s `wrapCallable` bridge, the engine sees
+ * an opaque WebAssembly object and throws "Cannot convert object to
+ * primitive value".
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = compile(source);
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    );
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  if (typeof imports.setExports === "function") {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  return (instance.exports as any)[fn]();
+}
+
+describe("#1329-b3 — @@replace replacer return-value coercion", { timeout: 30000 }, () => {
+  it("replacer returns an object with toString (host ToString reaches the closure)", async () => {
+    const out = await run(`
+      export function test(): string {
+        const replacer = function(): any {
+          return { toString: function(): string { return "toString value"; } };
+        };
+        return /x/[Symbol.replace]('[x]', replacer) as string;
+      }
+    `);
+    expect(out).toBe("[toString value]");
+  });
+
+  it("replacer that returns a number coerces via ToString", async () => {
+    const out = await run(`
+      export function test(): string {
+        const replacer = function(): any { return 42; };
+        return /x/[Symbol.replace]('[x]', replacer) as string;
+      }
+    `);
+    expect(out).toBe("[42]");
+  });
+
+  it("replacer that returns a string passes through", async () => {
+    const out = await run(`
+      export function test(): string {
+        const replacer = function(): string { return "Y"; };
+        return /x/g[Symbol.replace]('axbxc', replacer) as string;
+      }
+    `);
+    expect(out).toBe("aYbYc");
+  });
+});


### PR DESCRIPTION
## Summary
- `__regex_symbol_call`'s `wrapCallable` now post-processes the closure's return value: when it comes back as a WasmGC struct, it's routed through `_wrapForHost(ret, exports)` so V8's downstream `ToString` (spec §22.2.5.8 step 14.k.vi `replacement = ToString(replValue)`) reaches the struct's `toString`/`valueOf` closure fields via the host proxy.
- Mirrors the wasm-struct *arg* treatment we already apply via `wrappedArg0`; only the return-value side was previously unprotected.
- Bucket 3 of #1329 (per the issue's prior investigation). Argument-side variadic `arguments` reification (the `fn-invoke-args.js` shape) is genuinely cross-cutting (codegen `__call_fn_5+`) and intentionally left out — documented in the issue's resolution note.

## Test plan
- [x] `tests/issue-1329-b3.test.ts` — 3 new cases (object-with-toString, number coerce, plain-string passthrough) all pass
- [x] `tests/issue-1439.test.ts` (10/10) — no regression
- [x] `tests/issue-1443.test.ts` (5/5) — no regression
- [x] `fn-coerce-replacement.js` shape — flips from "Cannot convert object to primitive value" runtime throw to spec-correct `"[toString value]"`
- [ ] CI test262 + equivalence shards (will self-merge per `/dev-self-merge` once green)