### PR TITLE
chore(#1399): fix 8 biome lint errors in src/runtime.ts (+3 in calls.ts)

### DIFF
--- a/plan/issues/1399-biome-lint-runtime-errors.md
+++ b/plan/issues/1399-biome-lint-runtime-errors.md
@@ -1,9 +1,9 @@
 ---
 id: 1399
 title: "chore: fix 9 biome lint errors in src/runtime.ts"
-status: ready
+status: in-progress
 created: 2026-05-09
-updated: 2026-05-09
+updated: 2026-05-28
 priority: low
 feasibility: easy
 reasoning_effort: low

--- a/plan/issues/1399-biome-lint-runtime-errors.md
+++ b/plan/issues/1399-biome-lint-runtime-errors.md
@@ -1,7 +1,8 @@
 ---
 id: 1399
 title: "chore: fix 9 biome lint errors in src/runtime.ts"
-status: in-progress
+status: done
+completed: 2026-05-28
 created: 2026-05-09
 updated: 2026-05-28
 priority: low

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7562,6 +7562,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           // wins). The lifted callee may read `arguments` and needs the full
           // call-site arg list.
           const cpExtrasLocals: number[] = [];
+          // biome-ignore lint/complexity/noUselessLoneBlockStatements: groups arg-emit + extras-pack as one logical unit
           {
             for (let i = 0; i < Math.min(expr.arguments.length, cpParamCnt); i++) {
               compileExpression(ctx, fctx, expr.arguments[i]!, matchedClosureInfo.paramTypes[i]);
@@ -9318,6 +9319,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
         // Push call arguments (only up to declared param count)
         const crParamCnt = matchedClosureInfo.paramTypes.length;
+        // biome-ignore lint/complexity/noUselessLoneBlockStatements: groups arg-emit + extras-pack as one logical unit
         {
           for (let i = 0; i < Math.min(expr.arguments.length, crParamCnt); i++) {
             compileExpression(ctx, fctx, expr.arguments[i]!, matchedClosureInfo.paramTypes[i]);
@@ -9999,6 +10001,7 @@ function compileExpressionCallee(
 
       // Push call arguments (only up to declared param count)
       const ecParamCnt = matchedClosureInfo.paramTypes.length;
+      // biome-ignore lint/complexity/noUselessLoneBlockStatements: groups arg-emit + extras-pack as one logical unit
       {
         for (let i = 0; i < Math.min(expr.arguments.length, ecParamCnt); i++) {
           compileExpression(ctx, fctx, expr.arguments[i]!, matchedClosureInfo.paramTypes[i]);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3580,11 +3580,7 @@ function resolveImport(
             if (isSyntaxError) {
               // If the host-eval fallback can compile it, prefer that result;
               // js2wasm is more strict than V8/SpiderMonkey on some forms.
-              try {
-                return _legacyHostEval(src);
-              } catch (e2) {
-                throw e2;
-              }
+              return _legacyHostEval(src);
             }
             return _legacyHostEval(src);
           }
@@ -3633,6 +3629,8 @@ function resolveImport(
           // `as any`) — the eval'd code runs as plain JS and rejects TS syntax.
           const jsSrc = src.replace(/\bas\s+number\b/g, "").replace(/\bas\s+any\b/g, "");
           const needsShim = harnessIds.some((id) => jsSrc.includes(id));
+          // biome-ignore lint/style/noCommaOperator: (0, eval) forces indirect eval (global scope) per §19.2.1.1
+          // biome-ignore lint/security/noGlobalEval: intentional test262 runtime eval for harness compatibility
           if (!needsShim) return (0, eval)(jsSrc);
 
           // Build a JS-side harness that mirrors the wasm-compiled preamble.
@@ -3738,6 +3736,8 @@ assert._isSameValue = isSameValue;
 `;
           const wrapped =
             shim + jsSrc + `;\nif (__fail) throw new Test262Error('eval harness assertion ' + __fail + ' failed');`;
+          // biome-ignore lint/style/noCommaOperator: (0, eval) forces indirect eval (global scope) per §19.2.1.1
+          // biome-ignore lint/security/noGlobalEval: intentional test262 runtime eval for harness compatibility
           return (0, eval)(wrapped);
         }
       }
@@ -7332,7 +7332,7 @@ assert._isSameValue = isSameValue;
     case "host_loose_eq":
       // #1134 — loose equality for two externref operands (§7.2.15).
       // Handles null == undefined → true and other JS coercion rules.
-      // eslint-disable-next-line eqeqeq
+      // biome-ignore lint/suspicious/noDoubleEquals: §7.2.15 IsLooselyEqual requires == semantics (null == undefined, type coercion)
       return (a: any, b: any) => (a == b ? 1 : 0);
     case "same_value_zero":
       // #1360 — SameValueZero comparison (§7.2.11).
@@ -7341,7 +7341,7 @@ assert._isSameValue = isSameValue;
       // Used by Array.prototype.includes for array-like receivers.
       return (a: any, b: any) => {
         if (a === b) return 1;
-        // eslint-disable-next-line no-self-compare
+        // biome-ignore lint/suspicious/noSelfCompare: NaN detection — x !== x is the canonical NaN test (NaN is the only value not equal to itself per IEEE 754)
         if (typeof a === "number" && typeof b === "number" && a !== a && b !== b) return 1;
         return 0;
       };


### PR DESCRIPTION
## Summary

Closes #1399. Restores the `quality` CI check to green by clearing all biome lint errors flagged at `--diagnostic-level=error`.

**src/runtime.ts (8 errors)** — exactly the set documented in #1399:
- `noUselessCatch` (L3586): removed `try { ... } catch (e2) { throw e2; }` rethrow
- `noCommaOperator` + `noGlobalEval` (L3636, L3741): biome-ignore on the two `(0, eval)(...)` indirect-eval calls — intentional §19.2.1.1 pattern for global-scope eval in the test262 harness fallback
- `noDoubleEquals` (L7336): biome-ignore on `host_loose_eq`'s `a == b` — IsLooselyEqual (§7.2.15) explicitly requires `==` semantics (null == undefined, type coercion)
- `noSelfCompare` (L7345, two instances): biome-ignore on `a !== a && b !== b` — canonical NaN-detection idiom used by SameValueZero (§7.2.11)

**src/codegen/expressions/calls.ts (3 errors)** — `noUselessLoneBlockStatements` (L7565, L9321, L10002): three pre-existing lone-block groupings in `compileCallExpression` arms that pair "emit declared args + pack extras" as one logical unit. Suppressed with biome-ignore + intent comment; no behavior change. These were surfaced by the same `pnpm run lint` invocation and would have blocked the CI gate the issue is asking to restore, so they are included here rather than carved into a follow-up.

## Test plan

- [x] `pnpm run lint` exit 0 (was 11 errors before this PR)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `tests/wasi.test.ts` 24/24 green (exercises the runtime-side eval/host paths that the suppressed lines live in)
- [ ] CI `quality` check green
- [ ] CI test262 shards: no regression (lint-only PR, runtime semantics unchanged — only `try{}catch(e2){throw e2}` rethrow removed, behavior is identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)