### PR TITLE
fix(#1697): static method this.X = v writes to staticProps global (~11 test262 fails)

### DIFF
--- a/plan/issues/1697-static-method-this-write-not-routed.md
+++ b/plan/issues/1697-static-method-this-write-not-routed.md
@@ -1,0 +1,115 @@
+---
+id: 1697
+title: "static method `this.X = v` write not routed to staticProps global — public + private (asymmetric with read path)"
+status: in-progress
+created: 2026-05-28
+updated: 2026-05-28
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: classes, private-methods, static
+goal: spec-completeness
+sprint: Backlog
+test262_fail: 12
+related: [1680, 1681, 1683-brand, 1693]
+---
+# #1697 — `this.X = v` in static method body silently drops write
+
+## Problem
+
+Inside a `static` method body, an assignment of the form
+`this.publicField = v` or `this.#privateField = v` **does not write
+through to the static-prop backing global**. The read path
+(property-access.ts:1427-1453) already handles `ThisKeyword` in a static
+context by resolving the enclosing class and reading
+`ctx.staticProps.get(...)`. The symmetric write arm in
+`src/codegen/expressions/assignment.ts` is missing — only the
+`Identifier + ClassSet` arm at L2010 handles `C.X = v` writes, not the
+`ThisKeyword + isStaticContext` shape.
+
+## Confirmed root cause
+
+Probe results (`.tmp/probes-1697/probe-1697g.mjs`):
+
+| Shape | Result | Path taken |
+|---|---|---|
+| `C.publicField = v` from static method | ✅ 42 | identifier-classSet arm L2010 |
+| `C.#privField = v` from static method | ✅ 42 | identifier-classSet arm L2010 |
+| `this.publicField = v` from static method | ❌ 5 | falls through to generic struct write |
+| `this.#privField = v` from static method | ❌ 5 | same generic fallthrough |
+
+The reads work because property-access.ts:1427 has a
+`ThisKeyword && (localMap.get("this") === undefined || isStaticContext)`
+arm that resolves the enclosing class. The write side has no analogous
+arm — the LHS expression is `ThisKeyword` and the generic struct-write
+fallthrough either drops the value (when `this` is `null`/undefined) or
+emits a no-op cast.
+
+## Acceptance criteria
+
+1. `class C { static #x: number = 0; static doIt() { this.#x = 42; return this.#x; } }`
+   → `C.doIt()` returns `42`.
+2. Same with public static field (`static x = 0`).
+3. Same with `this.#x = v` inside a static method calling another static private method.
+4. Test262 cluster:
+   - `language/expressions/class/elements/after-same-line-method-static-private-methods-with-fields.js`
+   - `language/expressions/class/elements/regular-definitions-static-private-methods-with-fields.js`
+   - `language/expressions/class/elements/same-line-gen-static-private-methods-with-fields.js`
+   - plus ~10 sibling templates from the same generator
+5. `tests/issue-1697.test.ts` covering the probe shapes.
+
+## Investigation findings
+
+The team-lead's prompt sketched the candidate as ~12 private-method
+fails. Ran the cluster
+`language/expressions/class/elements/.*private-method.*` against
+`.test262-cache/test262-current.jsonl` (2026-05-28 baseline). Actual
+size: **50 fails**, decomposing into:
+
+| Sub-cluster | Count | Root cause |
+|---|---|---|
+| `this.#X = v` / `this.X = v` static-method write missing | ~12-15 | **THIS ISSUE (#1697)** |
+| `verifyProperty` descriptor-attribute mismatch | ~8 | #1629 (descriptor model) |
+| `Reflect.has called on non-object` in async-priv | ~5 | #1665 (generator/async-gen gap) |
+| yield-spread / yield-promise in gen-priv | ~10 | #1665 (generator gap) |
+| Brand check on subclass receiver `D.f()` | ~4 | #1683-brand (done investigation) |
+| `extern.convert_any[0]` wasm validation | ~3 | #1693 (funcref dispatch) |
+| Nested-class private-method `extends` scoping | ~3 | separate (low priority) |
+| `Symbol value to number` yield-star | ~2 | #1665 |
+| `call is not a function` codegen | ~1 | separate (look at #1693) |
+
+Only the first sub-cluster is a clean localized fix. The rest already
+have owners or need separate carving.
+
+## Implementation plan
+
+Mirror the read path's `ThisKeyword + isStaticContext` arm in
+`src/codegen/expressions/assignment.ts`, just before the existing
+identifier-classSet arm at L2010. Resolve the enclosing class via
+`fctx.enclosingClassName` first, then fall back to the underscore-prefix
+scan against `ctx.classSet` (the exact dance from
+property-access.ts:1435-1445). When matched, lookup
+`ctx.staticProps.get(\`\${enclosing}_\${propName}\`)` and emit
+`local.tee + global.set + local.get` exactly like the identifier-classSet
+arm.
+
+For private names, prefix the propName with `__priv_` (matching how
+identifier-classSet arm at L2012 already does it).
+
+Should be ~20 LOC and a single function-internal change. No
+cross-cutting impact: gated on `expr.expression.kind === ThisKeyword`
+**and** `(localMap.get("this") === undefined || isStaticContext)` — which
+is exactly the read-path gate, provably never fires on instance method
+bodies.
+
+## Files to modify
+
+- `src/codegen/expressions/assignment.ts` — add `this`-arm mirroring L2010
+- `tests/issue-1697.test.ts` — new
+
+## Probe (saved in `.tmp/probes-1697/`)
+
+`probe-1697g.mjs` reproduces the four shapes above (`C.publicField`,
+`C.#privField`, `this.publicField`, `this.#privField`).

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -2025,6 +2025,44 @@ function compilePropertyAssignment(
     }
   }
 
+  // #1697: `this.X = v` / `this.#X = v` inside a static method body —
+  // mirror the read path's ThisKeyword+staticContext arm in
+  // property-access.ts:1427. Without this, the LHS is `this` (not an
+  // Identifier in classSet) and the static-prop assignment falls through to
+  // the generic struct-write path, which silently drops the write because
+  // `this` is the class constructor (not a per-instance struct).
+  if (
+    target.expression.kind === ts.SyntaxKind.ThisKeyword &&
+    (fctx.localMap.get("this") === undefined || fctx.isStaticContext)
+  ) {
+    let enclosingClass: string | undefined = fctx.enclosingClassName;
+    if (!enclosingClass) {
+      const fname = fctx.name;
+      let pos = -1;
+      while (!enclosingClass) {
+        pos = fname.indexOf("_", pos + 1);
+        if (pos < 0) break;
+        const candidate = fname.substring(0, pos);
+        if (candidate && ctx.classSet.has(candidate)) enclosingClass = candidate;
+      }
+    }
+    if (enclosingClass) {
+      const propName = ts.isPrivateIdentifier(target.name) ? "__priv_" + target.name.text.slice(1) : target.name.text;
+      const fullName = `${enclosingClass}_${propName}`;
+      const globalIdx = ctx.staticProps.get(fullName);
+      if (globalIdx !== undefined) {
+        const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+        const valType = compileExpression(ctx, fctx, value, globalDef?.type);
+        if (!valType) return null;
+        const tmpVal = allocLocal(fctx, `__prop_assign_${fctx.locals.length}`, valType);
+        fctx.body.push({ op: "local.tee", index: tmpVal });
+        fctx.body.push({ op: "global.set", index: globalIdx });
+        fctx.body.push({ op: "local.get", index: tmpVal });
+        return valType;
+      }
+    }
+  }
+
   // Handle externref property set
   if (isExternalDeclaredClass(objType, ctx.checker)) {
     const externSetResult = compileExternPropertySet(ctx, fctx, target, value, objType);

--- a/tests/issue-1697.test.ts
+++ b/tests/issue-1697.test.ts
@@ -1,0 +1,92 @@
+// #1697: `this.X = v` in static method body must route to the staticProps
+// global. Without the fix the write silently dropped (read path already
+// resolved `this` to the class constructor; write path didn't).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+async function runTest(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "p.ts" });
+  if (!r.success) throw new Error("CE: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports.test as () => unknown)();
+}
+
+describe("#1697 static method this-write to staticProps", () => {
+  it("writes public static field via this.X", async () => {
+    const v = await runTest(`
+      class C {
+        static xVal: number = 5;
+        static doIt() { this.xVal = 42; return this.xVal; }
+      }
+      export function test(): number { return C.doIt(); }
+    `);
+    expect(v).toBe(42);
+  });
+
+  it("writes private static field via this.#X", async () => {
+    const v = await runTest(`
+      class C {
+        static #xVal: number = 5;
+        static doIt() { this.#xVal = 42; return this.#xVal; }
+      }
+      export function test(): number { return C.doIt(); }
+    `);
+    expect(v).toBe(42);
+  });
+
+  it("private static setter pattern (test262 shape)", async () => {
+    const v = await runTest(`
+      var C = class {
+        static #xVal: number = 0;
+        static #x(value: number) {
+          this.#xVal = value;
+          return this.#xVal;
+        }
+        static x() { return this.#x(42); }
+      }
+      export function test(): number { return C.x(); }
+    `);
+    expect(v).toBe(42);
+  });
+
+  it("ClassName.publicField still works (regression guard)", async () => {
+    const v = await runTest(`
+      class C {
+        static xVal: number = 5;
+        static doIt() { C.xVal = 42; return C.xVal; }
+      }
+      export function test(): number { return C.doIt(); }
+    `);
+    expect(v).toBe(42);
+  });
+
+  it("ClassName.#privField still works (regression guard)", async () => {
+    const v = await runTest(`
+      class C {
+        static #xVal: number = 5;
+        static doIt() { C.#xVal = 42; return C.#xVal; }
+      }
+      export function test(): number { return C.doIt(); }
+    `);
+    expect(v).toBe(42);
+  });
+
+  it("instance method this.X writes are NOT misrouted to static globals", async () => {
+    // Same-name public field on instance vs static — must remain disjoint.
+    const v = await runTest(`
+      class C {
+        x: number = 1;
+        static x: number = 100;
+        doIt() { this.x = 7; return this.x; }
+      }
+      export function test(): number {
+        const c = new C();
+        const r = c.doIt();
+        // Static C.x must be untouched (still 100); return r + (C.x===100 ? 0 : 1000)
+        return r + (C.x === 100 ? 0 : 1000);
+      }
+    `);
+    expect(v).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

Inside a `static` method body, `this.publicField = v` and `this.#privField = v`
were silently dropped. The read path (`property-access.ts:1427-1453`) already
handles `ThisKeyword` in a static context. The symmetric **write** arm in
`expressions/assignment.ts` was missing — only the `Identifier + ClassSet` arm
at L2010 handled `C.X = v`, not the `ThisKeyword + isStaticContext` shape.

Probe results (`.tmp/probes-1697g.mjs`):

| Shape | Before | After |
|---|---|---|
| `C.publicField = v` from static method | ✅ 42 | ✅ 42 |
| `C.#privField = v` from static method | ✅ 42 | ✅ 42 |
| `this.publicField = v` from static method | ❌ 5 (write dropped) | ✅ 42 |
| `this.#privField = v` from static method | ❌ 5 (write dropped) | ✅ 42 |

## Test262 impact

Targeted cluster `language/expressions/class/elements/.*static-private-methods-with-fields.*`:
**11/13 newly pass** (`after-same-line-method`, `regular-definitions`,
`same-line-gen`, `wrapped-in-sc`, `new-no-sc-line-method`,
`new-sc-line-method`, `after-same-line-static-gen`,
`after-same-line-static-method`, `after-same-line-gen`,
`same-line-method`, `new-sc-line-gen`).

The 2 remaining (`multiple-definitions-*`, `multiple-stacked-definitions-*`)
fail on `assert(!Object.prototype.hasOwnProperty.call(C.prototype, "foo"))`
— that's the class-field-on-prototype gap (#1629 family), unrelated.

## Investigation findings

Ran the full `language/expressions/class/elements/.*private-method.*`
cluster on the 2026-05-28 baseline: **50 fails total**, not the ~12
estimated. They decompose into:

- ~12-15 — `this.X` static-write (this issue, #1697)
- ~8 — `verifyProperty` descriptor-attribute mismatch (#1629 family)
- ~10 — yield-spread / yield-promise / yield-star in gen/async-gen private methods (#1665)
- ~5 — `Reflect.has called on non-object` in async-priv (#1665)
- ~4 — Brand check on subclass receiver (#1683-brand)
- ~3 — `extern.convert_any[0]` wasm validation (#1693)
- ~3 — Nested-class private-method `extends` scoping (separate)
- ~2 — `Symbol value to number` yield-star (#1665)
- ~1 — `call is not a function` (possibly #1693)

Only the first sub-cluster is a clean localized fix; the rest already
have owners. The team-lead's hypothesis ("closure capture of `this`") was
half-right: it's a `this`-resolution gap, but on the **write** side, not
closure capture.

## Implementation

`src/codegen/expressions/assignment.ts` — 38-line addition just below
the existing `Identifier+ClassSet` arm. Mirrors the read path's
enclosingClass resolution (`fctx.enclosingClassName` → name-prefix scan
against `ctx.classSet`) and gated on the same
`(localMap.get("this") === undefined || isStaticContext)` condition, so
it provably never fires from an instance method body.

For private names, prefixes propName with `__priv_` like the sibling arm.

## Test plan

- [x] `tests/issue-1697.test.ts` — 6 cases, all pass (public/private via
  `this`, via classname, test262 setter shape, instance-method regression
  guard)
- [x] `tests/class-static-private-this.test.ts`, `tests/issue-1680.test.ts`,
  `tests/issue-1681.test.ts`, `tests/issue-1605-cpn.test.ts` — all green
- [x] Test262 cluster 11/13 newly pass (the 2 remaining are #1629 family)
- [x] `tests/classes.test.ts` + `tests/class-elements-619.test.ts` have
  identical pre-existing failures on main (`string_constants` Import #0),
  NOT caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)