### PR TITLE
fix(#1629b): Object.getOwnPropertyDescriptor reads definedPropertyFlags

### DIFF
--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -158,3 +158,23 @@ Recommend splitting into sub-issues:
   fails) — likely overlaps #1130.
 
 No code change landed under this task; needs architect spec before implementation.
+
+## Partial fix #1629b (2026-05-28)
+
+Sub-cluster fixed: `Object.getOwnPropertyDescriptor` attribute readback
+for plain-object struct fields that were redefined via
+`Object.defineProperty`. Root cause: the GOPD fast path in
+`src/codegen/expressions/calls.ts` reads `ctx.shapePropFlags`, but that
+table is built via `buildShapePropFlagsTable` *after* body compilation
+finishes — so per-variable updates recorded during codegen
+(`definedPropertyFlags`, keyed `varName:propName`) are overwritten with
+defaults. The defineProperty path's attempt to update `shapePropFlags`
+inline (object-ops.ts:1133-1137) is a no-op when the table has not yet
+been created.
+
+Fix: GOPD fast path now consults `ctx.definedPropertyFlags` first when
+arg0 is an identifier, falling back to the shape table. Tests:
+`tests/issue-1629b.test.ts` (4 cases: writable/enumerable/configurable
+overrides + default preservation, all green). Does not address
+sub-clusters #1629a (dynamic descriptor) or #1629c (Array/Function
+exotic) — those remain open.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4135,10 +4135,19 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           const entry = userFields.find((e) => e.field.name === propLiteral);
 
           if (entry) {
-            // Look up flags from shapePropFlags
+            // #1629b: Object.defineProperty updates `definedPropertyFlags`
+            // (keyed `varName:propName`) but `shapePropFlags` is built AFTER
+            // body compilation finishes, so per-variable updates made during
+            // codegen are lost when the table is initialized with defaults.
+            // Read the per-variable map first, then fall back to the shape table.
             const flagsArr = ctx.shapePropFlags.get(structTypeIdx);
             const userFieldIdx = userFields.indexOf(entry);
-            const flags = flagsArr && userFieldIdx >= 0 ? flagsArr[userFieldIdx]! : 0x07; // default WEC
+            let flags = flagsArr && userFieldIdx >= 0 ? flagsArr[userFieldIdx]! : 0x07; // default WEC
+            if (ts.isIdentifier(arg0)) {
+              const dpfKey = `${arg0.text}:${propLiteral}`;
+              const dpfFlags = ctx.definedPropertyFlags.get(dpfKey);
+              if (dpfFlags !== undefined) flags = dpfFlags & 0x0f;
+            }
 
             // Compile the object expression
             const objType = compileExpression(ctx, fctx, arg0);

--- a/tests/issue-1629b.test.ts
+++ b/tests/issue-1629b.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile error: ${r.errors[0]?.message}`);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#1629b — Object.getOwnPropertyDescriptor attribute readback", () => {
+  it("reads writable:false after defineProperty on existing field", async () => {
+    const src = `
+      export function test(): number {
+        const o = { foo: 1 };
+        Object.defineProperty(o, "foo", { value: 101, writable: false });
+        const desc = Object.getOwnPropertyDescriptor(o, "foo");
+        if (desc === undefined) return 100;
+        if ((desc as any).writable === false) return 0;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(0);
+  });
+
+  it("reads enumerable:false after defineProperty", async () => {
+    const src = `
+      export function test(): number {
+        const o = { bar: 2 };
+        Object.defineProperty(o, "bar", { value: 5, enumerable: false });
+        const desc = Object.getOwnPropertyDescriptor(o, "bar");
+        if (desc === undefined) return 100;
+        if ((desc as any).enumerable === false) return 0;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(0);
+  });
+
+  it("reads configurable:false after defineProperty", async () => {
+    const src = `
+      export function test(): number {
+        const o = { baz: 3 };
+        Object.defineProperty(o, "baz", { value: 7, configurable: false });
+        const desc = Object.getOwnPropertyDescriptor(o, "baz");
+        if (desc === undefined) return 100;
+        if ((desc as any).configurable === false) return 0;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(0);
+  });
+
+  it("preserves default writable:true when no defineProperty call", async () => {
+    const src = `
+      export function test(): number {
+        const o = { x: 9 };
+        const desc = Object.getOwnPropertyDescriptor(o, "x");
+        if (desc === undefined) return 100;
+        if ((desc as any).writable === true) return 0;
+        return 1;
+      }
+    `;
+    expect(await run(src)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`Object.getOwnPropertyDescriptor(o, "foo").writable` returned the default
`true` even after `Object.defineProperty(o, "foo", { value: 101, writable: false })`
— the override bits were dropped on read-back (the 15.2.3.6-4-17 family).

`Object.defineProperty` updates per-variable `ctx.definedPropertyFlags`
during codegen (keyed `varName:propName`). The GOPD fast path was reading
`ctx.shapePropFlags`, a table that is built **after** body compilation by
`buildShapePropFlagsTable` with default flags — so the inline
`shapePropFlags` update inside `defineProperty` was a no-op at GOPD time
and the override was lost.

GOPD fast path now consults `definedPropertyFlags` first when arg0 is an
identifier, then falls back to the shape table for non-overridden fields.

## Files changed

- `src/codegen/expressions/calls.ts` — GOPD fast path consults `definedPropertyFlags`
- `tests/issue-1629b.test.ts` — 4 unit tests (writable/enumerable/configurable/default)
- `plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md` — annotated b sub-issue

## Test plan

- [x] `npx vitest run tests/issue-1629b.test.ts` — 4/4 pass
- [x] pre-push typecheck + lint OK
- [ ] CI required checks (cheap gate, shard reports, quality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)