### PR TITLE
docs(#1694,#820m): rescue issue files from dirty PR #817

### DIFF
--- a/plan/issues/1694-promise-subclass-capability.md
+++ b/plan/issues/1694-promise-subclass-capability.md
@@ -1,0 +1,115 @@
+---
+id: 1694
+title: "Promise.any/all/allSettled/race: non-Promise capability `this` + extends-Promise codegen (~50 fails)"
+status: backlog
+created: 2026-05-28
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen, runtime
+language_feature: promises, subclassing
+goal: spec-completeness
+sprint: Backlog
+related: [1368, 1465, 1528, 1116, 1644, 1682]
+---
+# #1694 — Promise combinators: non-Promise capability `this` + extends-Promise codegen
+
+## Problem
+
+Across `Promise.any`, `Promise.all`, `Promise.allSettled`, `Promise.race`, ~50
+test262 cases fail with two distinct error fingerprints that share the same
+underlying gap: the **NewPromiseCapability(C)** step of each combinator
+(§27.2.4.1 step 3 / §27.2.4.3 step 3 / §27.2.4.2 step 3 / §27.2.4.5 step 3) is
+not honoured when `C` is anything other than the host `Promise` constructor.
+
+### Sub-cluster A — non-Promise capability `this` (~40 fails, ~10 per method)
+
+```js
+Promise.any.call(NotPromise, [1])
+//  → "[object Object] is not a constructor"
+//  expected: NotPromise(executor) is called, resolving capability
+```
+
+Test262 `built-ins/Promise/{any,all,allSettled,race}/capability-executor-not-callable`,
+`ctor-poisoned-then`, `capability-resolve-throws-no-close`, `species-constructor`
+families. The combinator implementations in `src/runtime.ts` hard-wire
+`new Promise(...)` instead of constructing through the actual `C` receiver, so
+any non-`Promise` `this` value (including user functions and subclasses with a
+custom `Symbol.species`) is rejected by V8 at the `new C(executor)` step inside
+our host glue.
+
+### Sub-cluster B — `class X extends Promise` codegen invalid (~7 per method, ~28 fails)
+
+```
+class X extends Promise {}
+X.any([])
+//  Compiling function #N failed: extern.convert_any[0] invalid Wasm
+```
+
+Test262 `built-ins/Promise/{any,all,allSettled,race}/resolve-from-same-constructor`,
+`promise-resolve-function-from-same-constructor` families. The user-defined
+`extends Promise` produces invalid Wasm at compile time: the `extern.convert_any`
+operand stack does not match — the synthetic derived constructor returns an
+externref-shaped value where the parent path expects the host Promise externref,
+and the cast is emitted against an empty / wrong-type top-of-stack.
+
+Cross-references:
+- Builtin-parent derived-ctor super wiring (#1682, fixed for WeakMap/Promise/Object)
+  was the localized fix for the **constructor** half; **the static combinator
+  half is not covered**.
+- `__bind_function` / bound-function representation (#1632a, #1632b) is adjacent
+  — the codegen path that produces the wrong-type operand for `extern.convert_any`
+  here may share code with the bound-function representation issue.
+
+## Decomposition
+
+| Sub-cluster | Tests | Per method | Root cause | Feasibility |
+|---|---|---|---|---|
+| A — non-Promise capability `this` | ~40 | ~10 | combinators hard-wire `new Promise(...)`; ignore `C` | medium |
+| B — `class X extends Promise` static-method | ~28 | ~7 | derived-class static codegen emits `extern.convert_any[0]` with invalid stack | hard |
+
+## Acceptance criteria
+
+1. `Promise.any.call(F, [1])` invokes `F` as the capability constructor (no
+   `[object Object] is not a constructor`) — same for `all`, `allSettled`,
+   `race`. ~40 tests pass.
+2. `class X extends Promise {}; X.any([])` compiles to valid Wasm (no
+   `extern.convert_any[0] invalid Wasm` at compile time) and resolves through
+   `X.[[Construct]]`. ~28 tests pass.
+3. Combined pass-rate for `built-ins/Promise/{any,all,allSettled,race}` rises
+   by ~50.
+
+## Files to investigate
+
+- `src/runtime.ts` — `__promise_any`, `__promise_all`, `__promise_allSettled`,
+  `__promise_race` host bridges (NewPromiseCapability call site).
+- `src/codegen/class-bodies.ts` — derived-class static-method codegen
+  (where the bad `extern.convert_any` originates for Sub-cluster B).
+- `src/codegen/expressions/calls.ts` — `.call(ThisArg, ...)` dispatch on
+  static Promise methods (Sub-cluster A's user-call site).
+
+## Why this is hard
+
+Sub-cluster B intersects three known-hard areas already documented:
+- Derived-class constructor representation across builtin parents (#1682
+  delivered Half A; Half B was architect-blocked).
+- Bound-function / function-as-host-callable representation (#1632a/b, #1596).
+- The `extern.convert_any` operand-stack mismatch surfaces in roughly the same
+  shape as #1623-extern.
+
+Sub-cluster A is the simpler half — rewrite each `__promise_*` to call
+`new C(executor)` via the supplied `this` instead of hard-coded `Promise` —
+but verifying spec invariants (capability resolve/reject identity, abrupt
+completion ordering) is non-trivial and overlaps with #1368 (resolver-element
+spec gap) and #1465 (combinator iterable subclass).
+
+## Related
+
+- #1368 — `resolveElementFunction` / `resolveAndRejectElementFunctions` spec gap
+- #1465 — combinator iterable-subclass behaviour
+- #1528 — non-constructor TypeError + `Symbol.species` on Promise
+- #1116 — Promise resolution + async error handling (parent umbrella)
+- #1644 — BigInt rep spec (precedent for "needs architect rep decision")
+- #1682 — derived-ctor super-must-be-called for builtin subclasses (Half A
+  shipped, Half B architect-blocked)

--- a/plan/issues/820m-namedevaluation-fn-name-class-and-proto-setter.md
+++ b/plan/issues/820m-namedevaluation-fn-name-class-and-proto-setter.md
@@ -1,12 +1,12 @@
 ---
 id: 820m
 title: "NamedEvaluation: anonymous class/function value not named from binding key (~12 fails, fn-name-class + __proto__-fn-name)"
-status: ready
+status: blocked
 created: 2026-05-28
 updated: 2026-05-28
 priority: medium
-feasibility: easy-medium
-reasoning_effort: medium
+feasibility: hard
+reasoning_effort: high
 task_type: bugfix
 area: codegen
 language_feature: classes, function-name-inference, object-literal
@@ -120,3 +120,99 @@ test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
   issue or re-routing to #1542/#1543/#1544 dstr-default residuals after
   this lands.
 - #820b (computed-property accessor names) — already done.
+
+## Investigation 2026-05-28 (developer) — ESCALATED, needs architect spec
+
+### What the issue calls "NamedEvaluation gap" is actually a class-as-value codegen gap
+
+The two named tests in the issue (`object/__proto__-fn-name.js`,
+`object/fn-name-class.js`) both fail with **`TypeError: Cannot access property
+on null or undefined`** in the test262 baseline — NOT a `.name !== "expected"`
+mismatch. Reproduced via minimal probe in `.tmp/`:
+
+```ts
+// .tmp/probe-820m-gap-b.ts
+export function test(): any {
+  const obj: any = { id: class {} };
+  return obj.id;
+}
+// → RESULT=null (compiles, runs, returns null)
+```
+
+The anonymous class value inside the object literal compiles to `ref.null.extern`.
+Spec-wise the `name` is wrong, but observationally the *class is missing entirely*.
+
+Reduces further: even
+
+```ts
+export function test(): any {
+  const c: any = class {};
+  return c;
+}
+// → RESULT=null
+```
+
+returns null when nested inside a function body — only top-level
+`const C = class {...}` survives because the var-decl branch at
+`declarations.ts:2185` calls `collectClassDeclaration(ctx, decl.initializer,
+decl.name.text)` BUT a) does this only for top-level statements, b) the
+function-body recursion at `collectClassesFromStatements` line 2197 only
+handles `FunctionDeclaration` (not arrow/expression bodies, not non-decl
+contexts inside FunctionDeclaration).
+
+Even when collection runs (verified via instrumented `compileClassExpression`
+fallback path: never hit on the `{ id: class {} }` probe), the failure is
+elsewhere — the `compileObjectLiteralForStruct` path doesn't call
+`compileClassExpression` for property values, so an anonymous class in
+property position is silently dropped and the field is left default-initialised.
+
+### Why this is NOT a "SetFunctionName runtime hook" patch
+
+The original issue framing ("add NamedEvaluation to fn-name-class sites")
+assumes the class value exists and just needs its `.name` set. It doesn't —
+the value is null. Adding a `__setFunctionName(value, key)` host call would
+get called on `null` and either no-op or throw. Fixing this requires:
+
+1. **Anonymous class collection in nested expression contexts** —
+   `collectAnonymousClassesInNewExpr` only walks `NewExpression` and direct
+   `ClassExpression` nodes, missing:
+   - `{ prop: class {} }` (PropertyAssignment.initializer)
+   - `({ x = class {} } = ...)` (BindingElement.initializer)
+   - `var x = function(name) { return class {} }(...)` (any nested context)
+   Need a full recursive `forEachChild` walk of every expression position,
+   gated on whether the class would actually escape (e.g. assigned/returned).
+2. **Class-as-value emission in struct-typed object literal path** —
+   `compileObjectLiteralForStruct` (literals.ts:1032) currently emits field
+   values via the generic struct-field type, which for a class-typed field
+   resolves to `ref null Struct$X` not `externref`. The class expression
+   resolves through `compileExpression` → `compileClassExpression` returning
+   an externref, which then needs coercion + writeback into the struct field.
+   The actual current behavior is "silently drop" because the type inference
+   doesn't pick up that the field holds a class value.
+3. **Then, after the value is preserved**, layer the NamedEvaluation
+   bookkeeping: a compile-time pass that propagates the binding-key string
+   to a `class.name` field initialiser, OR a runtime `__set_class_name`
+   host hook called before the class struct escapes.
+
+### Why this is hard (feasibility: hard)
+
+Each of the three pieces above is a non-trivial codegen change touching
+shared paths (class collection, object-literal compilation, function-name
+inference). The blast radius hits every test that uses anonymous
+classes/functions inside complex contexts — which is a lot. The "easy-medium"
+rating in the original issue was based on the assumption that the .name was
+just being overwritten; the actual failure (null class value) is deeper.
+
+### Recommendation
+
+**Status: blocked / needs-architect-spec.** The three-piece scope above
+should be specced by an architect against a clean baseline. Two of the
+three pieces (anonymous class collection in nested contexts, class-value
+escape from object-literal struct path) overlap meaningfully with the
+class-expression issues tracked under #1605, #1681, and the dstr-default
+work in #1542/#1543/#1544 — there may be a unified design that handles
+all of them.
+
+No code change landed under this task; needs architect spec before
+implementation. The probe files (`.tmp/probe-820m-*.ts`,
+`.tmp/run-*.mts`) are gitignored and used only for the investigation.


### PR DESCRIPTION
## Summary

PR #817 (branch issue-820m-named-eval-v2) is DIRTY due to merge conflicts. Rescue the two issue files cleanly onto main so they don't get lost.

- **plan/issues/1694-promise-subclass-capability.md** (new) — Promise.any/all/allSettled/race subclass + capability gap (~50 fails). Two fingerprints: non-Promise capability `this` (combinators hard-wire `new Promise(...)` instead of `new C(executor)`) and `class X extends Promise` (derived-class static-method codegen emits invalid Wasm stack). feasibility:hard.
- **plan/issues/820m-namedevaluation-fn-name-class-and-proto-setter.md** (update) — append 2026-05-28 investigation: what was filed as a NamedEvaluation gap is actually a class-as-value codegen gap. Escalated to needs-architect-spec; status: blocked.

Will close PR #817 as superseded once this lands.

## Test plan

- [x] docs-only, no source changes
- [x] verified diff is exactly the two issue files
- [x] no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)