### PR TITLE
fix(#1698): native ArrayBuffer.prototype.slice in --target wasi

### DIFF
--- a/plan/issues/1698-arraybuffer-slice-standalone.md
+++ b/plan/issues/1698-arraybuffer-slice-standalone.md
@@ -1,0 +1,110 @@
+---
+id: 1698
+title: "ArrayBuffer.prototype.slice() not implemented in --target wasi (dual-mode gap, same shape as #1654)"
+status: in-progress
+created: 2026-05-28
+updated: 2026-05-28
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: wasi, codegen
+language_feature: arraybuffer
+goal: wasi-completeness
+sprint: Backlog
+related: [1654, 1530, 1595]
+---
+
+## Problem
+
+Under `--target wasi`, `ArrayBuffer.prototype.slice(begin, end)` **compiles**
+but **traps at runtime with `illegal cast`**. The slice() call is silently
+dropped: the arguments are evaluated and discarded, and the receiver is
+replaced with `ref.null extern` — so the next operation that recovers the
+backing `i32_byte` vec struct (e.g. `new Uint8Array(sliced)`) traps.
+
+Same dual-mode gap as #1654 (DataView accessors / ArrayBuffer-backed
+TypedArrays): the JS host implements `slice` natively, but standalone /
+WASI mode has no JS runtime and no Wasm-native path either, so the call
+falls through and emits a no-op.
+
+## Minimal repro (verified)
+
+```ts
+declare const process: { stdout: { write(c: Uint8Array): void } };
+export function main(): void {
+  const ab = new ArrayBuffer(4);
+  const dv = new DataView(ab);
+  dv.setUint8(0, 0x41);
+  dv.setUint8(1, 0x42);
+  dv.setUint8(2, 0x43);
+  dv.setUint8(3, 0x44);
+  const sliced = ab.slice(1, 3);
+  process.stdout.write(new Uint8Array(sliced));
+}
+```
+
+Compile with `npx tsx src/cli.ts repro.ts --target wasi -o out`, then
+instantiate the resulting module. The `new WebAssembly.Module(binary)` step
+succeeds (valid module) but `inst.exports.main()` throws `RuntimeError:
+illegal cast`. The WAT shows the slice() call lowering to:
+
+```
+f64.const 1
+drop
+f64.const 3
+drop
+ref.null extern
+local.set $sliced
+```
+
+— args evaluated for side effects and discarded; result is `null`.
+
+## Root cause
+
+In `src/codegen/expressions/calls.ts`, ArrayBuffer is declared in lib.d.ts so
+`isExternalDeclaredClass(receiverType, ...)` returns true. The extern-class
+dispatch tries to resolve `ArrayBuffer_slice` as a host import; under
+`--target wasi` (`noJsHost(ctx) === true`) no such host import exists, so the
+call falls through to a degraded path that drops args and returns `null`.
+
+There is no Wasm-native `slice` implementation analogous to the
+`emitDataViewAccessor` in `src/codegen/dataview-native.ts` from #1654.
+
+## Acceptance criteria
+
+- `ab.slice(begin, end)` returns a new ArrayBuffer of length
+  `min(end, ab.byteLength) - max(begin, 0)`, containing the bytes from
+  `[begin, end)`, under `--target wasi` and `--target standalone`.
+- Negative `begin`/`end` arguments resolve via spec §25.1.5.3
+  (negative = length + arg, clamped to [0, length]).
+- Omitted `end` defaults to `ab.byteLength` (full tail).
+- The resulting buffer is independent — mutating the source after slice
+  does not affect the slice.
+- `new Uint8Array(sliced)` views the slice's bytes.
+- A unit test (`tests/issue-1698.test.ts`) pins basic slice, OOB slice,
+  negative-offset slice, and the "independent buffer" property.
+- No regression in the existing #1654 ArrayBuffer/DataView WASI tests
+  (`tests/issue-1654-wasi-dataview-arraybuffer.test.ts`).
+
+## Implementation plan
+
+Mirror the #1654 dual-mode pattern in `src/codegen/dataview-native.ts`:
+
+1. Add `emitArrayBufferSlice(ctx, fctx, receiver, args, compileExpr)` that:
+   - Recovers the source `i32_byte` vec struct from the receiver (externref
+     → `any.convert_extern` → `ref.cast`).
+   - Computes `srcLen`, normalizes `begin` and `end` per spec
+     (negative = len + arg; clamp to `[0, len]`; missing end = len).
+   - Computes `sliceLen = max(end - begin, 0)`.
+   - Allocates a new `i32_byte` array of `sliceLen`, copies bytes
+     `src[begin .. begin+sliceLen)` byte-by-byte (`array.get` →
+     `array.set`).
+   - Constructs and returns the new `i32_byte` vec struct, returning it as
+     `externref` via `extern.convert_any` so it slots into the
+     externref-typed `sliced` local that user code declares.
+2. Hook it into `calls.ts` just below the DataView accessor block — gated
+   on `noJsHost(ctx) && receiverSym === "ArrayBuffer" && propAccess.name.text === "slice"`.
+3. Out of scope: `SharedArrayBuffer.slice` (not yet supported in standalone),
+   `TypedArray.prototype.slice` (separate buffer model, tracked elsewhere),
+   `transferable` semantics (#1595 covers transfer).

--- a/plan/issues/1698-arraybuffer-slice-standalone.md
+++ b/plan/issues/1698-arraybuffer-slice-standalone.md
@@ -1,7 +1,8 @@
 ---
 id: 1698
 title: "ArrayBuffer.prototype.slice() not implemented in --target wasi (dual-mode gap, same shape as #1654)"
-status: in-progress
+status: done
+completed: 2026-05-28
 created: 2026-05-28
 updated: 2026-05-28
 priority: high

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -64,6 +64,189 @@ export function isDataViewAccessor(name: string): boolean {
   return Object.prototype.hasOwnProperty.call(DV_ACCESSORS, name);
 }
 
+/**
+ * #1698 — `ab.slice(begin?, end?)` in no-JS-host mode. Returns a new
+ * ArrayBuffer (i32_byte vec struct) holding bytes `[begin, end)` of the
+ * source, with the spec §25.1.5.3 negative-offset / clamp / default-end
+ * normalisation applied at runtime. Receiver and result are externref
+ * (the user's `const sliced = ab.slice(...)` local is typed externref;
+ * matching that here keeps `new Uint8Array(sliced)` working without
+ * additional coercion).
+ */
+export function emitArrayBufferSlice(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: import("../ts-api.js").ts.Expression,
+  args: readonly import("../ts-api.js").ts.Expression[],
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return null;
+
+  // Recover the source vec struct from the receiver (externref → struct).
+  const srcVecLocal = allocLocal(fctx, `__abs_src_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: vecTypeIdx,
+  });
+  const recvType = compileExpr(receiver);
+  if (recvType && recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  } else if (recvType && (recvType.kind === "ref" || recvType.kind === "ref_null")) {
+    if ("typeIdx" in recvType && recvType.typeIdx !== vecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+    }
+  } else {
+    return null;
+  }
+  fctx.body.push({ op: "local.set", index: srcVecLocal } as Instr);
+
+  // srcLen = src.length (field 0); srcArr = src.data (field 1).
+  const srcLenLocal = allocLocal(fctx, `__abs_srclen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: srcVecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: srcLenLocal } as Instr);
+  const srcArrLocal = allocLocal(fctx, `__abs_srcarr_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: arrTypeIdx,
+  });
+  fctx.body.push({ op: "local.get", index: srcVecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: srcArrLocal } as Instr);
+
+  // begin (default 0). Spec §25.1.5.3 steps 5-7: ToIntegerOrInfinity, then
+  // negative = max(srcLen + begin, 0), positive = min(begin, srcLen).
+  const beginLocal = allocLocal(fctx, `__abs_begin_${fctx.locals.length}`, { kind: "i32" });
+  if (args.length >= 1) {
+    compileExpr(args[0]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: beginLocal } as Instr);
+  emitNormalizeIndex(fctx, beginLocal, srcLenLocal);
+
+  // end (default srcLen). Same clamp/negate.
+  const endLocal = allocLocal(fctx, `__abs_end_${fctx.locals.length}`, { kind: "i32" });
+  if (args.length >= 2) {
+    compileExpr(args[1]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+    fctx.body.push({ op: "local.set", index: endLocal } as Instr);
+    emitNormalizeIndex(fctx, endLocal, srcLenLocal);
+  } else {
+    fctx.body.push({ op: "local.get", index: srcLenLocal } as Instr);
+    fctx.body.push({ op: "local.set", index: endLocal } as Instr);
+  }
+
+  // sliceLen = max(end - begin, 0)
+  const sliceLenLocal = allocLocal(fctx, `__abs_slen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: endLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: beginLocal } as Instr);
+  fctx.body.push({ op: "i32.sub" } as Instr);
+  fctx.body.push({ op: "local.set", index: sliceLenLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: sliceLenLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "i32.const", value: 0 } as Instr, { op: "local.set", index: sliceLenLocal } as Instr],
+    else: [],
+  } as unknown as Instr);
+
+  // dstArr = new i32[sliceLen]
+  const dstArrLocal = allocLocal(fctx, `__abs_dstarr_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: arrTypeIdx,
+  });
+  fctx.body.push({ op: "local.get", index: sliceLenLocal } as Instr);
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: dstArrLocal } as Instr);
+
+  // for (i = 0; i < sliceLen; i++) dstArr[i] = srcArr[begin + i]
+  const iLocal = allocLocal(fctx, `__abs_i_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: iLocal } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: sliceLenLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    { op: "local.get", index: dstArrLocal } as Instr,
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: srcArrLocal } as Instr,
+    { op: "local.get", index: beginLocal } as Instr,
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: iLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // struct.new vec(sliceLen, dstArr); return as externref (matches the
+  // externref local that user code declares for the slice() result).
+  fctx.body.push({ op: "local.get", index: sliceLenLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: dstArrLocal } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx } as Instr);
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  return { kind: "externref" };
+}
+
+/**
+ * Normalize an index in-place per spec §25.1.5.3:
+ *   if (idx < 0) idx = max(srcLen + idx, 0);
+ *   else         idx = min(idx, srcLen);
+ */
+function emitNormalizeIndex(fctx: FunctionContext, idxLocal: number, lenLocal: number): void {
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr);
+  const negBranch: Instr[] = [
+    // idx = srcLen + idx; if (idx < 0) idx = 0
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: idxLocal } as Instr,
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.lt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 } as Instr, { op: "local.set", index: idxLocal } as Instr],
+      else: [],
+    } as unknown as Instr,
+  ];
+  const posBranch: Instr[] = [
+    // if (idx > srcLen) idx = srcLen
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "i32.gt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: lenLocal } as Instr, { op: "local.set", index: idxLocal } as Instr],
+      else: [],
+    } as unknown as Instr,
+  ];
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: negBranch,
+    else: posBranch,
+  } as unknown as Instr);
+}
+
 /** Lazily ensure the i32_byte vec type exists and return its struct/array indices. */
 function i32ByteVec(ctx: CodegenContext): { vecTypeIdx: number; arrTypeIdx: number } {
   const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -105,7 +105,7 @@ import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImport
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
 import { ensureNativeStringExternBridge, stringConstantExternrefInstrs } from "../native-strings.js";
-import { emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
+import { emitArrayBufferSlice, emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
 
 /**
  * Known built-in global class/object names that compile to ref.null.extern
@@ -5414,6 +5414,20 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         if (dvResult) {
           return dvResult.kind === "get" ? dvResult.result : VOID_RESULT;
         }
+      }
+    }
+
+    // #1698 — native ArrayBuffer.prototype.slice in no-JS-host mode. Same
+    // dual-mode gap as #1654: JS host has slice natively, standalone has no
+    // runtime and the extern-class dispatch would drop the call. Emit a
+    // byte-by-byte copy into a fresh i32_byte vec.
+    if (noJsHost(ctx) && propAccess.name.text === "slice") {
+      const recvSym = receiverType.getSymbol()?.name;
+      if (recvSym === "ArrayBuffer") {
+        const sliceResult = emitArrayBufferSlice(ctx, fctx, propAccess.expression, expr.arguments, (e, hint) =>
+          compileExpression(ctx, fctx, e, hint),
+        );
+        if (sliceResult) return sliceResult;
       }
     }
 

--- a/tests/issue-1698.test.ts
+++ b/tests/issue-1698.test.ts
@@ -1,0 +1,167 @@
+// #1698 — `ArrayBuffer.prototype.slice(begin, end)` under --target wasi.
+//
+// In standalone / WASI mode there is no JS host runtime. Previously the
+// extern-class dispatch for `slice` returned a degraded `ref.null extern`
+// (args dropped) so a subsequent `new Uint8Array(sliced)` trapped with
+// `illegal cast`. This test pins the native Wasm-only slice path against a
+// CI-portable raw-byte WASI shim (the same shim used for the sibling
+// #1654 DataView/ArrayBuffer test).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function runWasiCaptureStdout(binary: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const captured: number[] = [];
+  const wasi = {
+    fd_read(): number {
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === 1) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+const DECL = `declare const process: { stdout: { write(c: Uint8Array): void } };`;
+const PRELUDE = `${DECL}
+function fill(ab: ArrayBuffer): void {
+  const dv = new DataView(ab);
+  dv.setUint8(0, 0x41);
+  dv.setUint8(1, 0x42);
+  dv.setUint8(2, 0x43);
+  dv.setUint8(3, 0x44);
+}`;
+
+describe("#1698 ArrayBuffer.prototype.slice under --target wasi", () => {
+  it("compiles to a valid module (no `illegal cast` trap)", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(1, 3);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  it("basic slice(1, 3) returns bytes 0x42 0x43", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(1, 3);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x42, 0x43]);
+  });
+
+  it("omitted end defaults to byteLength (slice(1) → tail)", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(1);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x42, 0x43, 0x44]);
+  });
+
+  it("negative begin resolves from end (slice(-2) → last 2 bytes)", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(-2);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x43, 0x44]);
+  });
+
+  it("negative end resolves from end (slice(1, -1))", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(1, -1);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x42, 0x43]);
+  });
+
+  it("out-of-bounds end is clamped to byteLength (slice(2, 100))", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(2, 100);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x43, 0x44]);
+  });
+
+  it("begin >= end produces an empty buffer (slice(3, 1))", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(3, 1);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([]);
+  });
+
+  it("the slice is independent — mutating the source after slice does not affect it", () => {
+    const src = `${PRELUDE}
+      export function main(): void {
+        const ab = new ArrayBuffer(4);
+        fill(ab);
+        const sliced = ab.slice(0, 2);   // [0x41, 0x42]
+        const dv = new DataView(ab);
+        dv.setUint8(0, 0xFF);              // mutate source
+        dv.setUint8(1, 0xFF);
+        process.stdout.write(new Uint8Array(sliced));
+      }`;
+    const result = compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(Array.from(runWasiCaptureStdout(result.binary))).toEqual([0x41, 0x42]);
+  });
+});


### PR DESCRIPTION
## Summary

- `ArrayBuffer.prototype.slice(begin, end)` compiled but **trapped at runtime** with `illegal cast` under `--target wasi`: the extern-class dispatch routed the call to a missing host import, leaving a degraded path that dropped the args and emitted `ref.null extern` for the result. Any subsequent struct-field read (e.g. `new Uint8Array(sliced)`) then trapped on the `ref.cast`.
- Same dual-mode gap shape as #1654 (DataView / ArrayBuffer-backed TypedArrays). Fix mirrors that pattern: add a Wasm-native `emitArrayBufferSlice` in `src/codegen/dataview-native.ts` that copies bytes between `i32_byte` vec structs, applying spec §25.1.5.3 (negative-offset / clamp / default-end) normalisation at runtime.
- Hook into `calls.ts` under the existing `noJsHost(ctx)` DataView block, gated on receiver-symbol === `ArrayBuffer` and method === `slice`. **JS-host mode is untouched** (the gate is `noJsHost`, so the regular host-backed `ArrayBuffer.prototype.slice` continues to apply for the default GC path).

## Test plan

- [x] `tests/issue-1698.test.ts` — 8 cases pinned via the CI-portable raw-byte WASI shim (same shim used by #1654): basic slice, omitted end, negative begin, negative end, OOB end clamp, `begin >= end` empty, and the "independent buffer" property after mutating the source.
- [x] `tests/issue-1654-wasi-dataview-arraybuffer.test.ts` — sibling suite still passes (5/5).
- [x] `tests/wasi.test.ts`, `tests/issue-1618-1651-wasi-stdout.test.ts`, `tests/issue-1653-wasi-process-stdin-read.test.ts` — no regression (combined 51/51).
- [x] Pre-existing `tests/arraybuffer-dataview.test.ts` `string_constants` failures (6) are baseline on main, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)