### PR TITLE
fix(#1629a): dynamic-descriptor materialization for Object.defineProperty

### DIFF
--- a/plan/issues/1629a-dynamic-descriptor.md
+++ b/plan/issues/1629a-dynamic-descriptor.md
@@ -1,0 +1,133 @@
+---
+id: 1629a
+title: "Object.defineProperty dynamic (non-literal) descriptor materialization"
+status: done
+completed: 2026-05-28
+created: 2026-05-28
+updated: 2026-05-28
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen, runtime
+language_feature: object
+goal: spec-completeness
+sprint: Backlog
+owner: senior-developer
+parent: 1629
+related: [1629, 1630, 1631, 1335]
+---
+# #1629a — Object.defineProperty dynamic descriptor materialization
+
+> Sub-issue of #1629 (spec-gap descriptor attribute fidelity). Covers the
+> dynamic (non-literal) descriptor argument case: when `desc` is a variable
+> instead of an inline `{...}` literal at the `Object.defineProperty` call
+> site. ~150 test262 fails in the plain-object subset.
+
+## Problem
+
+`Object.defineProperty(o, "foo", desc)` where `desc` is a variable (not an
+`ObjectLiteralExpression`) silently dropped the entire descriptor on the floor.
+The compile-time path in `compileObjectDefineProperty`
+(`src/codegen/object-ops.ts`) extracted `value` / `get` / `set` / flags only
+when the descriptor argument was an `ObjectLiteralExpression`. When it was a
+variable, every extracted field was `undefined`, and the fall-through to
+`emitExternDefinePropertyNoValue` then emitted `__defineProperty_value(obj,
+"foo", null, flags=0)` — meaning:
+
+- the data+accessor mix TypeError check fired with `hasData=false,
+  hasAccessor=false` and silently passed;
+- non-object descriptor coercion never ran;
+- `value`, `get`, `set` never reached the runtime;
+- the runtime call was outright skipped for typed-struct receivers because
+  `isKnownStructField=true` shortcut elided it.
+
+This made the entire `15.2.3.6-3-*` test262 cluster (~173 ToPropertyDescriptor
+fails) and a slice of the `15.2.3.6-4-*` family unable to observe spec
+invariants for the common pattern `var desc = {get, value}; defineProperty(o,
+k, desc)`.
+
+## Root cause
+
+`compileObjectDefineProperty` in `src/codegen/object-ops.ts:576` parses the
+descriptor argument as an AST literal. Every guard, attribute extraction,
+type-mix check, and accessor compilation is gated on
+`if (ts.isObjectLiteralExpression(descArg))`. The dynamic case has no inline
+AST to extract from, and the fall-through path was implemented as
+`__defineProperty_value(obj, k, null, 0)` — a value-less, flag-less, semantic
+no-op.
+
+The runtime already has the right helper: `__defineProperty_desc(obj, prop,
+desc)` at `src/runtime.ts:4571` accepts an externref descriptor and
+materializes its fields via a struct-aware `getField` that reads sidecar
+properties AND falls back to the compiled module's `__sget_<f>` exports for
+typed struct fields. This is the same path #1631 added for
+`Object.create(proto, {k: descObj})` (a sibling dynamic-descriptor map case).
+It just wasn't being invoked from `Object.defineProperty`.
+
+## Fix
+
+`src/codegen/object-ops.ts` — `compileObjectDefineProperty`: when `descArg`
+is NOT an `ObjectLiteralExpression`, route to the runtime
+`__defineProperty_desc(obj, prop, desc)` helper after coercing all three
+arguments to externref. This applies uniformly whether the receiver is a
+typed struct or a plain externref object; the runtime handles both via its
+`getField` closure. Mirrors the structurally-identical `Object.create`
+dispatch at `calls.ts:3996-4042` (#1631).
+
+`src/runtime.ts` — extended `_toPropertyDescriptorValidate` with an optional
+`wrapCallable` parameter and used it inside `__defineProperty_desc` to wrap
+WasmGC-closure get/set into JS callables via `_maybeWrapCallable(..., 0/1,
+callbackState)`. Without wrapping, the `typeof === "function"` invariant in
+the validator threw "Getter must be a function" for WasmGC-struct
+descriptors whose `get`/`set` fields were closures, not host functions.
+
+## Acceptance criteria
+
+1. `var desc = {get: <fn>, value: 99}; Object.defineProperty(o, "foo", desc)` —
+   throws TypeError per §6.2.5.6 step 4. *(was: silently succeeded)*
+2. `var desc = 42; Object.defineProperty(o, "foo", desc)` — throws TypeError
+   per §10.1.6 step 1. *(was: silently succeeded)*
+3. `Object.defineProperty(null, "foo", desc)` — throws TypeError per
+   §19.1.2.4 step 1.
+4. `Object.defineProperty(o, "foo", {value: 42, ...})` — inline-literal data
+   path unaffected; returns 42 from `o.foo`. *(no regression)*
+5. `#1630` (struct writeback) and `#1631` (Object.create descriptor map)
+   tests continue to pass: 13/13 green across `tests/issue-1630.test.ts +
+   tests/issue-1631.test.ts + tests/issue-1629a.test.ts`.
+6. Equivalence tests `tests/equivalence/object-define-property.test.ts +
+   tests/equivalence/object-to-primitive.test.ts` continue green: 11/11.
+
+## Out of scope
+
+- **Accessor read-back via `o.foo` after a dynamic accessor descriptor.** The
+  receiver is typed as a WasmGC struct (e.g. `__anon_0`), so `o.foo = v` and
+  `return o.foo` lower to `struct.get`/`struct.set` against the struct field.
+  Writing through the descriptor's setter into a sidecar is invisible to
+  subsequent struct.get reads. Tracked by **#1630** (descriptor-model
+  writeback into struct fields) and **#1629b** (getOwnPropertyDescriptor
+  attribute read-back for non-struct-field defined props).
+- **Typed-struct field overwrite with a dynamic-descriptor data value.** The
+  runtime helper stores via native Object.defineProperty (which falls back to
+  the sidecar for WasmGC structs); subsequent compiled `struct.get` reads
+  the original (default) field value. Resolves when #1630 lands the
+  descriptor-model writeback.
+- **15.2.3.6-4-* Array/Function exotic objects.** Distinct workstream
+  (see #1629 investigation; covered separately under #1130 array semantics
+  and the bound-function representation work).
+
+## Files modified
+
+- `src/codegen/object-ops.ts` — new dynamic-descriptor branch in
+  `compileObjectDefineProperty` (~56 LOC), routes externref-coerced obj +
+  prop + desc to `__defineProperty_desc`.
+- `src/runtime.ts` — `_toPropertyDescriptorValidate` accepts an optional
+  `wrapCallable`; `__defineProperty_desc` passes
+  `(v, arity) => _maybeWrapCallable(v, arity, callbackState)` so WasmGC
+  closure get/set fields satisfy the spec callable check.
+
+## Tests added
+
+- `tests/issue-1629a.test.ts` — 4 tests covering the four acceptance criteria
+  (data+accessor mix throws, non-object desc throws, null receiver throws,
+  inline-literal data path unaffected).

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -759,6 +759,62 @@ export function compileObjectDefineProperty(
     propName = propArg.text;
   }
 
+  // (#1629a) Dynamic-descriptor path: when the descriptor argument is not an
+  // ObjectLiteralExpression (e.g. `var d = {value: 1}; defineProperty(o, k, d)`),
+  // the inline-literal code below has nothing to extract — valueExpr / getNode /
+  // descWritable are all undefined. The legacy fall-through to
+  // emitExternDefinePropertyNoValue silently emits empty flags AND for typed
+  // struct receivers skips the runtime call entirely, so the descriptor's
+  // value / accessor / flag bits are dropped on the floor.
+  //
+  // Route to the runtime's __defineProperty_desc helper, which materializes
+  // the descriptor via struct-aware getField (sidecar + __sget_<f> exports)
+  // and applies it via native Object.defineProperty. The obj is coerced to
+  // externref so the runtime sees a uniform entry point — this matches the
+  // sibling Object.create path at calls.ts:3996+ (#1631).
+  if (!ts.isObjectLiteralExpression(descArg)) {
+    // Compile obj → externref
+    const objType = compileExpression(ctx, fctx, objArg);
+    if (!objType) return null;
+    if (objType.kind === "ref" || objType.kind === "ref_null") {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+    } else if (objType.kind !== "externref") {
+      coerceType(ctx, fctx, objType, { kind: "externref" });
+    }
+    // Compile prop → externref
+    const propType = compileExpression(ctx, fctx, propArg, { kind: "externref" });
+    if (propType && propType.kind !== "externref") {
+      coerceType(ctx, fctx, propType, { kind: "externref" });
+    } else if (!propType) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    // Compile descArg → externref (WasmGC struct or plain object both work;
+    // runtime helper handles both via struct-aware getField).
+    const descType = compileExpression(ctx, fctx, descArg);
+    if (descType) {
+      if (descType.kind === "ref" || descType.kind === "ref_null") {
+        fctx.body.push({ op: "extern.convert_any" } as Instr);
+      } else if (descType.kind !== "externref") {
+        coerceType(ctx, fctx, descType, { kind: "externref" });
+      }
+    } else {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    const dpDescIdx = ensureLateImport(
+      ctx,
+      "__defineProperty_desc",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (dpDescIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: dpDescIdx });
+    } else {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    return { kind: "externref" };
+  }
+
   // Check if obj is a struct type with the given field
   const objTsType = ctx.checker.getTypeAtLocation(objArg);
   let structName =

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -848,7 +848,11 @@ function _validatePropertyDescriptor(
   return resultFlags;
 }
 
-function _toPropertyDescriptorValidate(rawDesc: any, getField: (o: any, f: string) => any): PropertyDescriptor {
+function _toPropertyDescriptorValidate(
+  rawDesc: any,
+  getField: (o: any, f: string) => any,
+  wrapCallable?: (v: any, arity: number) => any,
+): PropertyDescriptor {
   // Primitive rawDesc (number/string/boolean/symbol/bigint) violates
   // ECMA-262 10.1 step 1 — throw TypeError. We intentionally allow null/undefined
   // through as an empty descriptor because reads from WasmGC struct fields whose
@@ -865,8 +869,16 @@ function _toPropertyDescriptorValidate(rawDesc: any, getField: (o: any, f: strin
   const wr = getField(rawDesc, "writable");
   const en = getField(rawDesc, "enumerable");
   const conf = getField(rawDesc, "configurable");
-  const getFn = getField(rawDesc, "get");
-  const setFn = getField(rawDesc, "set");
+  let getFn = getField(rawDesc, "get");
+  let setFn = getField(rawDesc, "set");
+  // (#1629a) When the source descriptor is a WasmGC struct, `get`/`set` arrive
+  // as Wasm-closure structs (not JS callables). Wrap them into JS Functions so
+  // the spec-mandated `typeof === "function"` checks below pass and so that the
+  // resulting property descriptor invokes the closure correctly when called.
+  if (wrapCallable) {
+    if (getFn != null && typeof getFn !== "function") getFn = wrapCallable(getFn, 0);
+    if (setFn != null && typeof setFn !== "function") setFn = wrapCallable(setFn, 1);
+  }
   // Treat null getter/setter as "field absent" — reading a WasmGC struct field
   // whose accessor source read out to null (no value stored) is functionally
   // identical to the field being missing. The spec only throws for present
@@ -4591,6 +4603,10 @@ assert._isSameValue = isSameValue;
             }
             return v;
           };
+          // (#1629a) When the descriptor is a WasmGC struct, its get/set fields
+          // are Wasm-closure structs, not JS callables. Wrap them so the spec
+          // typeof check passes and the resulting accessor is invocable.
+          const wrap = (v: any, arity: number) => _maybeWrapCallable(v, arity, callbackState);
           // For a plain JS object whose descriptor is also a plain JS object,
           // native Object.defineProperty follows the descriptor's prototype
           // chain and accessor getters correctly — use it directly.
@@ -4603,12 +4619,12 @@ assert._isSameValue = isSameValue;
           // Object.defineProperty sees it as null-proto/no-keys and drops every
           // attribute. Materialize a plain descriptor via getField first.
           if (!_isWasmStruct(obj)) {
-            const d2 = _toPropertyDescriptorValidate(desc, getField);
+            const d2 = _toPropertyDescriptorValidate(desc, getField, wrap);
             Object.defineProperty(obj, key, d2);
             return obj;
           }
           // WasmGC struct obj: apply via sidecar
-          const d = _toPropertyDescriptorValidate(desc, getField);
+          const d = _toPropertyDescriptorValidate(desc, getField, wrap);
           const sDescs = _getSidecarDescs(obj);
           const nKey = _normalizeDescKey(key);
           const existingVal = _sidecarGet(obj, key);

--- a/tests/issue-1629a.test.ts
+++ b/tests/issue-1629a.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.ts";
+
+async function run(body: string): Promise<unknown> {
+  const src = `export function test(): any {\n${body}\n}`;
+  const ex = (await compileAndInstantiate(src)) as { test?: () => unknown };
+  return ex.test!();
+}
+
+// (#1629a) When Object.defineProperty's descriptor argument is a *variable*
+// (not an ObjectLiteralExpression at the call site), the compiler used to
+// drop the descriptor on the floor — it had no inline AST to extract `value`,
+// `get`, `set`, or `writable`/`enumerable`/`configurable` from. The fall-through
+// to `emitExternDefinePropertyNoValue` then emitted empty flags, so spec
+// invariants (data+accessor mix → TypeError, non-object desc → TypeError,
+// value persistence) were silently ignored.
+//
+// The fix routes the dynamic-descriptor case to the runtime's
+// `__defineProperty_desc` helper, which materializes the WasmGC-struct
+// descriptor via struct-aware getField (sidecar + `__sget_<f>` exports) and
+// applies it via native Object.defineProperty. Mirrors the sibling
+// Object.create dynamic-descriptor path (#1631).
+//
+// Accessor read-back through `o.foo` after a dynamic accessor descriptor is
+// OUT OF SCOPE here (struct-field vs sidecar reconciliation — see #1629b,
+// #1630, #1631). This issue covers the TypeError + value-dispatch surface.
+describe("#1629a dynamic-descriptor — Object.defineProperty", () => {
+  it("data+accessor mix throws TypeError per §6.2.5.6 step 4", async () => {
+    const r = await run(`
+      const o: any = {};
+      const desc: any = { get: function(): any { return 42; }, value: 99 };
+      try {
+        Object.defineProperty(o, "foo", desc);
+        return "no-throw";
+      } catch (e: any) {
+        if (e instanceof TypeError) return "TypeError";
+        return "other-throw:" + String(e);
+      }`);
+    expect(r).toBe("TypeError");
+  });
+
+  it("non-object descriptor (number) throws TypeError per §10.1.6 step 1", async () => {
+    const r = await run(`
+      const o: any = {};
+      const desc: any = 42;
+      try {
+        Object.defineProperty(o, "foo", desc);
+        return "no-throw";
+      } catch (e: any) {
+        if (e instanceof TypeError) return "TypeError";
+        return "other-throw:" + String(e);
+      }`);
+    expect(r).toBe("TypeError");
+  });
+
+  it("first-arg null throws TypeError per §19.1.2.4 step 1", async () => {
+    const r = await run(`
+      const desc: any = { value: 1 };
+      try {
+        Object.defineProperty(null as any, "foo", desc);
+        return "no-throw";
+      } catch (e: any) {
+        if (e instanceof TypeError) return "TypeError";
+        return "other-throw:" + String(e);
+      }`);
+    expect(r).toBe("TypeError");
+  });
+
+  it("does not regress inline object-literal descriptors (data path)", async () => {
+    const r = await run(`
+      const o: any = {};
+      Object.defineProperty(o, "foo", { value: 42, writable: true, configurable: true, enumerable: true });
+      return o.foo;`);
+    expect(r).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

`Object.defineProperty(o, k, desc)` with a **variable** descriptor argument
silently dropped the entire descriptor. Every attribute extraction in
`compileObjectDefineProperty` (`src/codegen/object-ops.ts`) was gated on
`ts.isObjectLiteralExpression(descArg)`, so for the dominant test262 c3
shape (`var desc = {...}; defineProperty(o, k, desc)`) the fall-through emitted
an empty-flag `__defineProperty_value(obj, k, null, 0)` call — and for
typed-struct receivers, skipped the runtime call entirely. No value, no
accessor, no flag bits, no validation.

Added a dynamic-descriptor branch that coerces obj+prop+desc to externref and
routes to the existing `__defineProperty_desc` runtime helper. That helper
already materializes WasmGC-struct descriptors via struct-aware `getField`
(sidecar + `__sget_<f>` exports) — the same path #1631 added for the sibling
`Object.create(proto, {k: descObj})` dispatch.

Also threaded `wrapCallable` through `_toPropertyDescriptorValidate` and used
`_maybeWrapCallable` inside `__defineProperty_desc` so WasmGC-closure get/set
fields satisfy the spec callable check instead of throwing
\"Getter must be a function\".

Restores spec invariants for the test262 15.2.3.6-3-* cluster:
- data+accessor mix → TypeError (§6.2.5.6 step 4)
- non-object descriptor → TypeError (§10.1.6 step 1)
- null receiver → TypeError (§19.1.2.4 step 1)

Carved from #1629. Out of scope for this PR (tracked elsewhere):
- Accessor read-back via `o.foo` after a dynamic accessor descriptor →
  struct-vs-sidecar reconciliation (#1630 / #1629b).

## Test plan
- [x] `tests/issue-1629a.test.ts` — 4/4 pass
- [x] `tests/equivalence/object-define-property{,-extended,-return}.test.ts` — no regressions
- [x] `tests/equivalence/define-property-typeerror.test.ts` — 5/6 pass; the 1 failure (\"preventExtensions then defineProperty\") is pre-existing on main, confirmed by reverting `object-ops.ts` to main HEAD and reproducing the identical failure
- [x] `tests/equivalence/object-create.test.ts` — green
- [ ] CI test262 conformance — expect ~150 fail-bucket reduction in `built-ins/Object/defineProperty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)