### PR TITLE
fix(#1594A): closure-aware __typeof returns "function" for closure structs

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7035,7 +7035,24 @@ assert._isSameValue = isSameValue;
       if (name === "__call_2_f64") return (fn: Function, a: number, b: number) => fn(a, b);
       if (name === "__call_1_i32") return (fn: Function, a: number) => fn(a);
       if (name === "__call_2_i32") return (fn: Function, a: number, b: number) => fn(a, b);
-      if (name === "__typeof") return (v: any) => typeof v;
+      if (name === "__typeof")
+        return (v: any) => {
+          // (#1594A) Closure structs report `typeof === "object"` in JS, but the
+          // spec answer is "function". Probe via `__is_closure` (matches the
+          // discriminator used by `_maybeWrapCallableUnknownArity`).
+          if (v != null && typeof v === "object" && _isWasmStruct(v)) {
+            const exports = callbackState?.getExports();
+            const isClosureFn = exports?.__is_closure as ((x: any) => number) | undefined;
+            if (typeof isClosureFn === "function") {
+              try {
+                if (isClosureFn(v) === 1) return "function";
+              } catch {
+                /* fall through to typeof */
+              }
+            }
+          }
+          return typeof v;
+        };
       if (name === "__instanceof")
         return (v: any, ctorName: string) => {
           try {

--- a/tests/issue-1594a.test.ts
+++ b/tests/issue-1594a.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`CE: ${r.errors[0]?.message}`);
+  // Build host imports the same way test262 does: build → instantiate →
+  // setExports. The lazy `r.importObject` path used by #1667 doesn't wire
+  // setExports, so closure-aware host helpers (e.g. __typeof via #1594A)
+  // can't see __is_closure unless we use this manual flow.
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  if (typeof imports.setExports === "function") {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  const fn = (instance.exports as Record<string, unknown>).test as (() => unknown) | undefined;
+  if (typeof fn !== "function") throw new Error("no test export");
+  return fn();
+}
+
+describe("#1594A — typeof of block-hoisted function declaration", () => {
+  it('typeof of a function reference widened to any returns "function"', async () => {
+    // Function reference passed through an externref (any) — exercises the
+    // dynamic __typeof host path where the closure struct surfaces. Without
+    // the closure-aware probe in src/runtime.ts (#1594A), this returns "object".
+    const src = `
+      function f() { return 'decl'; }
+      export function test(): string {
+        const x: any = f;
+        return typeof x;
+      }
+    `;
+    expect(await run(src)).toBe("function");
+  });
+
+  it('typeof of a normal function expression returns "function" (regression guard)', async () => {
+    const src = `
+      export function test(): string {
+        const g = function () { return 1; };
+        return typeof g;
+      }
+    `;
+    expect(await run(src)).toBe("function");
+  });
+
+  it('typeof of a plain object stays "object" (regression guard)', async () => {
+    const src = `
+      export function test(): string {
+        const o: any = { a: 1 };
+        return typeof o;
+      }
+    `;
+    expect(await run(src)).toBe("object");
+  });
+});


### PR DESCRIPTION
## Summary

Closure values flowing through the host `__typeof` helper (via externref / any-typed identifier) returned `"object"` because WasmGC closure structs have no JS `[[Call]]` slot. Spec answer is `"function"`.

Probe `__is_closure` (the same discriminator used by `_maybeWrapCallableUnknownArity`) when the operand is a wasm struct; return `"function"` on match. Falls back to native `typeof` when callbackState or `__is_closure` is absent.

Per architect spec for #1594A in `plan/issues/1594-annexb-strict-function-code-tdz-referenceerror.md` (Implementation Plan → Changes → File: src/runtime.ts, line 7038).

## Scope discipline

- **In scope**: the runtime `__typeof` patch (Slice A, single-site, as specified).
- **Out of scope**: the §B.3.3.1 legacy var-binding write (Slice A Phase B in the spec) and the lazy `importObject` setExports wiring (#1667 adjacent gap). Neither is touched.

## Note on activation

Takes effect only when callers invoke `setExports` after instantiation (test262 runner, equivalence harness via `buildImports`). The lazy `r.importObject` getter introduced by #1667 currently does not wire `setExports`, so the fix is invisible through that path — adjacent gap, separately tracked.

## Test plan

- [x] `npm test -- tests/issue-1594a.test.ts` — 3 pass (closure-via-any returns "function"; regression guards for normal fn-expression and plain object)
- [x] Typecheck clean
- [x] Lint clean
- [ ] CI: annexB/language/function-code + global-code bucket movement visible in test262 shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)