### PR TITLE
fix(#1594A): closure-aware __typeof for hoisted block fns (Slice A)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7035,7 +7035,25 @@ assert._isSameValue = isSameValue;
       if (name === "__call_2_f64") return (fn: Function, a: number, b: number) => fn(a, b);
       if (name === "__call_1_i32") return (fn: Function, a: number) => fn(a);
       if (name === "__call_2_i32") return (fn: Function, a: number, b: number) => fn(a, b);
-      if (name === "__typeof") return (v: any) => typeof v;
+      if (name === "__typeof")
+        return (v: any) => {
+          // (#1594A Slice A) Wasm closure structs are externref-typed in JS
+          // and have no `[[Call]]`, so the bare `typeof v` returns "object".
+          // Per spec they should report "function". `__is_closure` (emitted
+          // alongside any closure type) is the authoritative discriminator,
+          // identical to the one used by `_maybeWrapCallableUnknownArity`.
+          if (v != null && typeof v === "object") {
+            const isClosureFn = callbackState?.getExports()?.__is_closure as ((x: any) => number) | undefined;
+            if (typeof isClosureFn === "function") {
+              try {
+                if (isClosureFn(v) === 1) return "function";
+              } catch {
+                /* not a closure-struct shape — fall through */
+              }
+            }
+          }
+          return typeof v;
+        };
       if (name === "__instanceof")
         return (v: any, ctorName: string) => {
           try {

--- a/tests/issue-1594a.test.ts
+++ b/tests/issue-1594a.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1594A Slice A — closure-aware __typeof for block-hoisted function declarations.
+//
+// Per spec in plan/issues/1594-annexb-strict-function-code-tdz-referenceerror.md,
+// `hoistFunctionDeclarations` lifts a block-scoped `function f(){}` to function
+// scope and exposes it through `funcMap`. Identifier reads of `f` wrap the
+// funcref in a closure struct via `emitFuncRefAsClosure`. A closure struct is
+// a WasmGC struct with a null prototype — when handed to the runtime
+// `__typeof` shim, `typeof <opaque struct>` returns `"object"`. This is the
+// `typeof after === "object"` failure pattern across the annexB function-code
+// suite.
+//
+// Fix: `__typeof` (and `__any_typeof` in the gcref arm) consult the
+// `__is_closure` export — already the authoritative discriminator used by
+// `_maybeWrapCallableUnknownArity` (src/runtime.ts:1024) — and report
+// `"function"` for closure structs.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<Record<string, Function>> {
+  const r = compile(src, { fileName: "t.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, any>;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(instance.exports);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#1594A Slice A — closure-aware __typeof", () => {
+  it("typeof of block-hoisted fn read at outer scope is 'function'", { timeout: 15000 }, async () => {
+    const exports = await instantiate(`
+      export function getResult(): string {
+        let after: any;
+        { function f() { return 'decl'; } }
+        after = f;
+        return typeof after;
+      }
+    `);
+    expect(exports.getResult!()).toBe("function");
+  });
+
+  it("typeof of an externref-erased function decl is 'function'", { timeout: 15000 }, async () => {
+    const exports = await instantiate(`
+      function f() { return 1; }
+      export function getResult(): string {
+        const g: any = f;
+        return typeof g;
+      }
+    `);
+    expect(exports.getResult!()).toBe("function");
+  });
+
+  it("typeof of plain object stays 'object' (regression: non-closure struct)", { timeout: 15000 }, async () => {
+    const exports = await instantiate(`
+      export function getResult(): string {
+        const o: any = { x: 1 };
+        return typeof o;
+      }
+    `);
+    expect(exports.getResult!()).toBe("object");
+  });
+
+  it("typeof of null stays 'object' (regression)", { timeout: 15000 }, async () => {
+    const exports = await instantiate(`
+      export function getResult(): string {
+        const x: any = null;
+        return typeof x;
+      }
+    `);
+    expect(exports.getResult!()).toBe("object");
+  });
+
+  it("typeof of array stays 'object' (regression)", { timeout: 15000 }, async () => {
+    const exports = await instantiate(`
+      export function getResult(): string {
+        const a: any = [1, 2, 3];
+        return typeof a;
+      }
+    `);
+    expect(exports.getResult!()).toBe("object");
+  });
+});


### PR DESCRIPTION
## Summary

Slice A of #1594A (AnnexB legacy block-function hoisting). The runtime
`__typeof` host helper at `src/runtime.ts:7038` returned `"object"` for
Wasm closure structs because they are externref-typed in JS and lack a
`[[Call]]` internal method. Per the architect spec in
`plan/issues/1594-annexb-strict-function-code-tdz-referenceerror.md`
(*typeof defect* section), this is the dominant root cause of the ~202
annexB function-code failures — most use `assert.sameValue(typeof f,
\"function\")` as their oracle.

Fix: when the operand is a JS object, consult the `__is_closure` export
(emitted alongside every closure type, same authoritative discriminator
used by `_maybeWrapCallableUnknownArity` at `runtime.ts:1024`) and report
`\"function\"` when it answers 1. When `__is_closure` is absent (no
closures were emitted in this module) we fall through to the legacy
`typeof v` — strict superset of prior semantics.

## What this does NOT cover

- **Slice B** (the §B.3.3.1 legacy var-binding write at
  `nested-declarations.ts:150`) is a separate follow-up PR. Without
  Slice A landing first, Slice B is a no-op for the test oracle.
- **`__any_typeof`** (wasm-generated, in `any-helpers.ts`) is only
  reached under `ctx.fast` mode and operates on Any-tagged structs; its
  gcref arm (tag 6) returns `\"object\"` without closure detection.
  Adding `__is_closure` plumbing there needs new codegen wiring and is
  deferred — the default-mode test262 oracle goes through the host
  `__typeof` path patched here.

## Test plan

- [x] Reproduced the spec's minimal repro: `function outer() { { function f(){}; } return typeof f; }` returned `\"object\"` pre-fix.
- [x] `tests/issue-1594a.test.ts` — 5 cases (block-hoisted fn, externref-erased fn, plus regression guards for plain object / null / array). Pre-fix: 2 failures. Post-fix: 5/5 green.
- [x] Typeof-related equivalence suites pass: `typeof-comparison.test.ts`, `typeof-narrowing.test.ts`, `typeof-member-expression.test.ts`, `symbol-typeof.test.ts` — 14/14 green.
- [x] Typecheck clean (`tsc --noEmit`).
- [x] Pre-push hook (typecheck + lint) passed.
- [ ] CI will run full equivalence-gate, lint, and test262 — measure annexB/language/function-code lift from `pass=108, fail=202, ce=2` baseline (spec target: `pass≥290`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)