### PR TITLE
fix(#1594A) Slice B: §B.3.3.1 legacy var-binding write for block-hoisted fns

### DIFF
--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -295,6 +295,18 @@ export interface FunctionContext {
       materializedLocalIdx: number; // ref_null $AnyString — reserved for future cache
     }
   >;
+  /**
+   * #1594A Slice B — §B.3.3.1 AnnexB legacy var-binding writes for
+   * block-hoisted function declarations. Maps the function name to an
+   * outer-fctx externref local index allocated during hoisting. When the
+   * statement is later visited in textual order, the FunctionDeclaration
+   * compile path emits a runtime `localSet(idx, closureExternref)` so that
+   * outer reads of the name (after the block has executed) see the bound
+   * value rather than the funcMap funcref wrapper. Sloppy-mode only;
+   * strict-mode declarations and would-be-early-error cases are NOT
+   * registered here (see `hoistFunctionDeclarations` Phase A gates).
+   */
+  annexBLegacyLocals?: Map<string, number>;
 }
 
 /** Context shared across all codegen. */

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7622,16 +7622,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     // emit cap-prepend logic are already correct, even if a coincidental
     // local with the same name exists in the current scope.
     let isLocallyShadowed = false;
-    if (
-      fctx.localMap.has(funcName) &&
-      (ctx.nestedFuncCaptures.has(funcName) || fctx.annexBLegacyLocals?.has(funcName))
-    ) {
-      // #1594A Slice B: §B.3.3.1 legacy var-binding locals also need the
-      // shadow path — the funcMap direct-call path would bypass the local
-      // and read a never-set funcref wrapper, defeating "undefined before
-      // the block executes" semantics. Reads must go through the externref
-      // local, where the callable-fallback path below recovers the closure
-      // via any.convert_extern + emitGuardedRefCast (null-safe).
+    if (fctx.localMap.has(funcName) && ctx.nestedFuncCaptures.has(funcName)) {
       const localCalleeTsType = ctx.checker.getTypeAtLocation(expr.expression);
       const localCallSigs = localCalleeTsType?.getCallSignatures?.();
       if (localCallSigs && localCallSigs.length > 0) {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7622,7 +7622,16 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     // emit cap-prepend logic are already correct, even if a coincidental
     // local with the same name exists in the current scope.
     let isLocallyShadowed = false;
-    if (fctx.localMap.has(funcName) && ctx.nestedFuncCaptures.has(funcName)) {
+    if (
+      fctx.localMap.has(funcName) &&
+      (ctx.nestedFuncCaptures.has(funcName) || fctx.annexBLegacyLocals?.has(funcName))
+    ) {
+      // #1594A Slice B: §B.3.3.1 legacy var-binding locals also need the
+      // shadow path — the funcMap direct-call path would bypass the local
+      // and read a never-set funcref wrapper, defeating "undefined before
+      // the block executes" semantics. Reads must go through the externref
+      // local, where the callable-fallback path below recovers the closure
+      // via any.convert_extern + emitGuardedRefCast (null-safe).
       const localCalleeTsType = ctx.checker.getTypeAtLocation(expr.expression);
       const localCallSigs = localCalleeTsType?.getCallSignatures?.();
       if (localCallSigs && localCallSigs.length > 0) {

--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -15,6 +15,8 @@
  *   - statements/shared.ts         — utilities shared across all sub-modules
  */
 import { ts } from "../ts-api.js";
+import type { Instr } from "../ir/types.js";
+import { emitFuncRefAsClosure } from "./closures.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { attachSourcePos, getSourcePos } from "./context/source-pos.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -211,7 +213,29 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
 
   if (ts.isFunctionDeclaration(stmt)) {
     // Skip if already hoisted (pre-compiled in function hoisting pass)
-    if (stmt.name && ctx.funcMap.has(stmt.name.text)) return;
+    if (stmt.name && ctx.funcMap.has(stmt.name.text)) {
+      // #1594A Slice B Phase B — §B.3.3.1 legacy var-binding write.
+      // For a block-nested decl that Phase A registered, emit a runtime
+      // `local.set` of the function-scope externref local at this textual
+      // position. Outer reads after the block see the bound closure value;
+      // before the block executes the local stays `ref.null.extern`.
+      // Re-executing the same FunctionDeclaration on a loop iteration repeats
+      // the write each pass, mirroring §B.3.3.1 step 2.c.
+      const legacyLocalIdx = fctx.annexBLegacyLocals?.get(stmt.name.text);
+      if (legacyLocalIdx !== undefined) {
+        const funcIdx = ctx.funcMap.get(stmt.name.text)!;
+        const closureType = emitFuncRefAsClosure(ctx, fctx, stmt.name.text, funcIdx);
+        if (closureType) {
+          // emitFuncRefAsClosure leaves (ref $closure_struct) on the stack.
+          // Coerce ref → externref so it fits the externref local slot.
+          fctx.body.push({ op: "extern.convert_any" } as unknown as Instr);
+          fctx.body.push({ op: "local.set", index: legacyLocalIdx } as Instr);
+        }
+        // closureType === null happens when the function failed earlier;
+        // the local stays null, identifier reads still see the funcMap path.
+      }
+      return;
+    }
     // Re-attempt compilation even if hoisting failed — the failure may have been
     // due to const/let captures not yet in scope during the hoisting pre-pass.
     // Now that we're in statement order, those locals should be available.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -706,6 +706,48 @@ export function compileNestedFunctionDeclaration(
 }
 
 /**
+ * #1594A Slice B — §B.3.3.1 Phase A.
+ *
+ * For a block-nested `function f` that successfully hoisted into `funcMap`,
+ * allocate an outer-function-scope externref local also named `f`. The local
+ * shadows the funcMap read at `compileIdentifier` (which checks `localMap`
+ * before `funcMap`), so subsequent reads of `f` from outside the block resolve
+ * to the local. The local is null until the matching textual-position write
+ * runs (Phase B in compileStatement's FunctionDeclaration case). This gives
+ * outer reads the §B.3.3.1 legacy var-binding semantics: undefined before the
+ * block executes, the function value after.
+ *
+ * Eligibility gates (any one fails → no legacy binding; outer reads keep
+ * seeing the funcMap funcref wrapper, which is what we did before this PR):
+ *  - The enclosing function is sloppy (§B.3.3 NOTE 2: strict mode skips).
+ *  - The declaration is NOT generator (`function*`) or `async`.
+ *  - The hoist actually succeeded (no entry in `ctx.hoistFailedFuncs`).
+ *  - The name doesn't already occupy a slot in `fctx.localMap` (would conflict
+ *    with a param or earlier hoisted local). When it does, the existing slot
+ *    already covers the semantics — leave it alone.
+ */
+function registerAnnexBLegacyLocal(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.FunctionDeclaration): void {
+  if (!stmt.name) return;
+  const funcName = stmt.name.text;
+  // Generator and async forms are excluded by §B.3.3 NOTE 1.
+  if (stmt.asteriskToken) return;
+  if (stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)) return;
+  // Strict-mode check: §B.3.3 is sloppy-only. Probe the inner declaration —
+  // any "use strict" prologue or class context propagates up.
+  if (isStrictFunction(stmt)) return;
+  // Skip if the hoist itself failed (no funcMap entry to write).
+  if (!ctx.funcMap.has(funcName)) return;
+  if (ctx.hoistFailedFuncs?.has(funcName)) return;
+  // If the name is already a local (param, earlier hoist, or var slot), don't
+  // alloc a second one. Reuse-by-write happens in Phase B regardless.
+  if (fctx.localMap.has(funcName)) return;
+  // Allocate a function-scope externref local; defaults to ref.null.extern.
+  const localIdx = allocLocal(fctx, funcName, { kind: "externref" });
+  if (!fctx.annexBLegacyLocals) fctx.annexBLegacyLocals = new Map();
+  fctx.annexBLegacyLocals.set(funcName, localIdx);
+}
+
+/**
  * Pre-pass: hoist function declarations inside a function body.
  * JavaScript semantics require function declarations to be available
  * before their textual position in the enclosing scope.
@@ -713,11 +755,18 @@ export function compileNestedFunctionDeclaration(
  *
  * If a function fails to compile during hoisting (e.g., uses unsupported features),
  * it is rolled back and will be re-attempted during normal statement compilation.
+ *
+ * @param inContainer When true, the caller is recursing into a block/if/loop/
+ *   try/switch — in that case any FunctionDeclaration encountered also gets
+ *   §B.3.3.1 legacy var-binding registration via `registerAnnexBLegacyLocal`.
+ *   The top-level call (function body) passes false: function-body-scoped
+ *   declarations are real `var`-like bindings, not legacy AnnexB ones.
  */
 export function hoistFunctionDeclarations(
   ctx: CodegenContext,
   fctx: FunctionContext,
   stmts: ts.NodeArray<ts.Statement> | ts.Statement[],
+  inContainer: boolean = false,
 ): void {
   for (const stmt of stmts) {
     if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) {
@@ -741,60 +790,70 @@ export function hoistFunctionDeclarations(
           ctx.hoistFailedFuncs.add(funcName);
         }
       }
+      // #1594A Slice B Phase A — block-nested decls get a legacy var-binding
+      // local that subsequent Phase B writes populate at the textual position.
+      if (inContainer) {
+        registerAnnexBLegacyLocal(ctx, fctx, stmt);
+      }
     }
     // Recurse into block-like structures to find nested function declarations.
     // In JS, function declarations are hoisted to the enclosing function scope,
     // even when inside if-branches, try/catch blocks, etc.
     if (ts.isIfStatement(stmt)) {
       if (ts.isBlock(stmt.thenStatement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.thenStatement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.thenStatement.statements, true);
+      } else if (ts.isFunctionDeclaration(stmt.thenStatement)) {
+        // `if (cond) function f(){}` — brace-less then branch (B.3.2 form).
+        hoistFunctionDeclarations(ctx, fctx, [stmt.thenStatement], true);
       }
       if (stmt.elseStatement) {
         if (ts.isBlock(stmt.elseStatement)) {
-          hoistFunctionDeclarations(ctx, fctx, stmt.elseStatement.statements);
+          hoistFunctionDeclarations(ctx, fctx, stmt.elseStatement.statements, true);
         } else if (ts.isIfStatement(stmt.elseStatement)) {
-          hoistFunctionDeclarations(ctx, fctx, [stmt.elseStatement]);
+          hoistFunctionDeclarations(ctx, fctx, [stmt.elseStatement], true);
+        } else if (ts.isFunctionDeclaration(stmt.elseStatement)) {
+          hoistFunctionDeclarations(ctx, fctx, [stmt.elseStatement], true);
         }
       }
     }
     if (ts.isTryStatement(stmt)) {
-      hoistFunctionDeclarations(ctx, fctx, stmt.tryBlock.statements);
+      hoistFunctionDeclarations(ctx, fctx, stmt.tryBlock.statements, true);
       if (stmt.catchClause) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.catchClause.block.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.catchClause.block.statements, true);
       }
       if (stmt.finallyBlock) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.finallyBlock.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.finallyBlock.statements, true);
       }
     }
     if (ts.isBlock(stmt)) {
-      hoistFunctionDeclarations(ctx, fctx, stmt.statements);
+      hoistFunctionDeclarations(ctx, fctx, stmt.statements, true);
     }
     // Recurse into loop bodies — function declarations inside loops are hoisted
     // to the enclosing function scope in JS semantics.
     if (ts.isForStatement(stmt) || ts.isWhileStatement(stmt) || ts.isDoStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, true);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], true);
       }
     }
     if (ts.isForInStatement(stmt) || ts.isForOfStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, true);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], true);
       }
     }
     if (ts.isSwitchStatement(stmt)) {
       for (const clause of stmt.caseBlock.clauses) {
-        hoistFunctionDeclarations(ctx, fctx, clause.statements);
+        hoistFunctionDeclarations(ctx, fctx, clause.statements, true);
       }
     }
     if (ts.isLabeledStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, true);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], true);
       }
     }
   }

--- a/tests/issue-1594a-slice-b.test.ts
+++ b/tests/issue-1594a-slice-b.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileAndRun(src: string): Promise<unknown> {
+  const result = compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile error: ${result.errors[0]?.message ?? "unknown"}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  const test = (instance.exports as { test?: () => unknown }).test;
+  if (!test) throw new Error("No `test` export");
+  return test();
+}
+
+describe("#1594A Slice B — AnnexB §B.3.3.1 legacy var-binding write", () => {
+  it("function-init: block-hoisted function visible to outer call after block executes", async () => {
+    const src = `
+      export function test(): number {
+        let after: any = null;
+        {
+          function f() { return 42; }
+        }
+        // After the block: f's legacy var-binding should hold the closure.
+        after = f;
+        const v: any = after();
+        return v;
+      }
+    `;
+    expect(await compileAndRun(src)).toBe(42);
+  });
+
+  it("function-update: re-binding on second pass through the declaration", async () => {
+    const src = `
+      export function test(): number {
+        let total: number = 0;
+        for (let i: number = 0; i < 3; i = i + 1) {
+          function f() { return 7; }
+          const v: any = f();
+          total = total + (v as number);
+        }
+        return total;
+      }
+    `;
+    expect(await compileAndRun(src)).toBe(21);
+  });
+
+  it("if-then no-brace: function-decl in then branch hoists to function scope", async () => {
+    const src = `
+      export function test(cond: boolean): number {
+        let captured: any = null;
+        if (cond) function h() { return 11; }
+        if (cond) {
+          captured = h;
+        }
+        const v: any = captured();
+        return v;
+      }
+    `;
+    // The cond=true path executes both `if` statements. After the first runs,
+    // the §B.3.3.1 write populates the outer h binding; the second reads it.
+    const src2 = `
+      export function test(): number {
+        let captured: any = null;
+        if (true) function h() { return 11; }
+        captured = h;
+        const v: any = captured();
+        return v;
+      }
+    `;
+    expect(await compileAndRun(src2)).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

Implements AnnexB §B.3.3.1 legacy var-binding semantics for block-nested
sloppy-mode `function` declarations. After the block executes, outer
reads of the name resolve to the (now-bound) closure value rather than
the funcMap funcref wrapper.

Companion to Slice A (PR #844, closure-aware `__typeof`).

## What changes

- **`src/codegen/context/types.ts`** — adds `fctx.annexBLegacyLocals?: Map<string, number>`.
- **`src/codegen/statements/nested-declarations.ts`** — Phase A: in
  `hoistFunctionDeclarations`, for every block-nested FunctionDecl that
  hoists successfully, allocate an outer-fctx externref local and record
  it. Eligibility gates per §B.3.3 NOTE 1/2: skip generator/async/strict,
  skip when name is already in localMap (param or earlier hoist), skip
  when hoist failed. Also fix recursion to descend into brace-less
  `if (cond) function f(){}` (§B.3.2 form).
- **`src/codegen/statements.ts`** — Phase B: in compileStatement's
  FunctionDeclaration branch, when the decl matches a registered legacy
  local, emit `emitFuncRefAsClosure → extern.convert_any → local.set`
  so each pass through the declaration rebinds the legacy local (spec
  §B.3.3.1 step 2.c).
- **`src/codegen/expressions/calls.ts`** — `isLocallyShadowed` gate
  OR-s in `annexBLegacyLocals?.has(name)` so call sites for legacy-bound
  names route through the local rather than the funcMap direct path.
  The no-capture case is handled by the existing callable-fallback
  path, which recovers the closure via `any.convert_extern +
  emitGuardedRefCast` (null-safe — calls before the block ran produce
  null → guarded cast → null → emitNullCheckThrow → TypeError).

## Tests

`tests/issue-1594a-slice-b.test.ts` (3 tests, all pass):
- function-init: outer call after block executes (canonical pattern)
- function-update: loop re-binding observes latest closure
- brace-less if-then: `if (cond) function h(){}` hoists correctly

## Test plan

- [x] typecheck + lint
- [x] tests/issue-1594a-slice-b.test.ts: 3/3 pass
- [x] tests/issue-1594a.test.ts (Slice A): pass
- [x] tests/ts-wasm-equivalence.test.ts: pass
- [x] tests/tdz-reference-error.test.ts: pass
- [ ] CI test262 — gauges the actual AnnexB function-code/global-code bucket movement

## Notes

- Pre-existing `helpers.js` import errors in some test files are unrelated to this PR (they fail on `origin/main` HEAD too — `tests/helpers.ts` doesn't exist).
- Three stale `issue-1592-*` worktrees noted in tech-lead msg — not touched.