### PR TITLE
fix(#1695): PropertyAssignment computed [Symbol.dispose] route to externref

### DIFF
--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -338,16 +338,42 @@ function compileObjectLiteralWithAccessors(
     } else if (ts.isPropertyAssignment(prop) || ts.isShorthandPropertyAssignment(prop)) {
       // __extern_set(obj, key, value)
       let propName: string | undefined;
+      let wellKnownSymId: number | undefined;
       if (ts.isIdentifier(prop.name)) propName = prop.name.text;
       else if (ts.isStringLiteral(prop.name)) propName = prop.name.text;
       else if (ts.isNumericLiteral(prop.name)) propName = prop.name.text;
-      // Computed property names not handled here — fall through silently.
-      if (propName === undefined) continue;
-      addStringConstantGlobal(ctx, propName);
-      const keyGlobal = ctx.stringGlobalMap.get(propName);
-      if (keyGlobal === undefined) continue;
-      fctx.body.push({ op: "local.get", index: objLocal });
-      fctx.body.push({ op: "global.get", index: keyGlobal });
+      else if (ts.isComputedPropertyName(prop.name)) {
+        // (#1695) Symmetric with the MethodDeclaration path below: well-known
+        // `[Symbol.X]: …` keys must be boxed into real JS Symbols via
+        // __box_symbol so host APIs (DisposableStack, `using`, iteration
+        // protocols) find the value under the real Symbol property.
+        const inner = prop.name.expression;
+        if (
+          ts.isPropertyAccessExpression(inner) &&
+          ts.isIdentifier(inner.expression) &&
+          inner.expression.text === "Symbol"
+        ) {
+          wellKnownSymId = getWellKnownSymbolId(inner.name.text);
+        }
+        if (wellKnownSymId === undefined) {
+          propName = resolveComputedKeyExpression(ctx, prop.name.expression);
+        }
+      }
+      if (wellKnownSymId !== undefined) {
+        const boxSymIdx = ensureLateImport(ctx, "__box_symbol", [{ kind: "i32" }], [{ kind: "externref" }]);
+        flushLateImportShifts(ctx, fctx);
+        if (boxSymIdx === undefined) continue;
+        fctx.body.push({ op: "local.get", index: objLocal });
+        fctx.body.push({ op: "i32.const", value: wellKnownSymId });
+        fctx.body.push({ op: "call", funcIdx: boxSymIdx });
+      } else {
+        if (propName === undefined) continue;
+        addStringConstantGlobal(ctx, propName);
+        const keyGlobal = ctx.stringGlobalMap.get(propName);
+        if (keyGlobal === undefined) continue;
+        fctx.body.push({ op: "local.get", index: objLocal });
+        fctx.body.push({ op: "global.get", index: keyGlobal });
+      }
       // Compile value and coerce to externref.
       let valType: ValType | null;
       if (ts.isShorthandPropertyAssignment(prop)) {
@@ -483,7 +509,11 @@ function compileObjectLiteralWithAccessors(
  */
 function _hasDisposalMethod(expr: ts.ObjectLiteralExpression): boolean {
   for (const p of expr.properties) {
-    if (!ts.isMethodDeclaration(p)) continue;
+    // (#1695) Catch both MethodDeclaration (`[Symbol.dispose]() {}`) and
+    // PropertyAssignment (`[Symbol.dispose]: () => {}`) shapes — both must
+    // route to the externref/accessor path so the host sees a real Symbol
+    // key on the resulting object.
+    if (!ts.isMethodDeclaration(p) && !ts.isPropertyAssignment(p)) continue;
     if (!ts.isComputedPropertyName(p.name)) continue;
     const inner = p.name.expression;
     if (!ts.isPropertyAccessExpression(inner)) continue;

--- a/tests/issue-1695-propkey.test.ts
+++ b/tests/issue-1695-propkey.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #1695 — PropertyAssignment form with computed [Symbol.dispose] /
+ * [Symbol.asyncDispose] keys was silently dropped at literals.ts:344, so
+ * `DisposableStack.use({ [Symbol.dispose]: () => … })` never invoked the
+ * disposer. The MethodDeclaration form (`{ [Symbol.dispose]() {} }`) was
+ * already routed correctly via #1433.
+ *
+ * Fix: extend the disposal-method detector + the PropertyAssignment branch
+ * in `compileObjectLiteralAsExternref`'s sibling (the
+ * `compileObjectLiteralWithAccessors` walker) so both shapes box the
+ * well-known symbol via `__box_symbol` and store the value under the real
+ * Symbol property.
+ */
+
+async function run(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  const exp = instance.exports as Record<string, unknown>;
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(exp);
+  }
+  const fn = exp.test as (() => unknown) | undefined;
+  if (typeof fn !== "function") throw new Error("no test() export");
+  return fn();
+}
+
+describe("#1695 PropertyAssignment computed-key (Symbol.dispose)", () => {
+  it("[Symbol.dispose] arrow property is invoked by DisposableStack.use()", async () => {
+    const src = `
+      export function test(): number {
+        let called = 0;
+        const resource: any = {
+          [Symbol.dispose]: () => {
+            called = called + 1;
+          },
+        };
+        const stack = new DisposableStack();
+        stack.use(resource);
+        stack.dispose();
+        return called;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("[Symbol.dispose] function-expression property is invoked by DisposableStack.use()", async () => {
+    const src = `
+      export function test(): number {
+        let called = 0;
+        const resource: any = {
+          [Symbol.dispose]: function () {
+            called = called + 2;
+          },
+        };
+        const stack = new DisposableStack();
+        stack.use(resource);
+        stack.dispose();
+        return called;
+      }
+    `;
+    expect(await run(src)).toBe(2);
+  });
+
+  it("[Symbol.asyncDispose] arrow property survives the routing change", async () => {
+    // Property is reachable under the real Symbol.asyncDispose key; we don't
+    // invoke the disposer (await semantics are out of scope for this fix).
+    const src = `
+      declare function check(o: any): number;
+      export function test(): number {
+        const r: any = {
+          [Symbol.asyncDispose]: () => 7,
+        };
+        return check(r);
+      }
+    `;
+    const result = compile(src, { fileName: "test.ts" });
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    const imports = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown> & {
+      env?: Record<string, unknown>;
+    };
+    imports.env = imports.env ?? {};
+    imports.env.check = (o: unknown) => {
+      const cb = (o as { [k: symbol]: unknown })[Symbol.asyncDispose];
+      return typeof cb === "function" ? 1 : 0;
+    };
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    const exp = instance.exports as Record<string, unknown>;
+    if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+      (imports as { setExports: (e: unknown) => void }).setExports(exp);
+    }
+    const fn = exp.test as () => number;
+    expect(fn()).toBe(1);
+  });
+
+  it("Non-symbol computed string key works via PropertyAssignment", async () => {
+    const src = `
+      export function test(): number {
+        const k = "foo";
+        const obj: any = { [k]: 42 };
+        return obj.foo;
+      }
+    `;
+    expect(await run(src)).toBe(42);
+  });
+
+  it("Mixed disposal + plain string keys preserved", async () => {
+    const src = `
+      export function test(): number {
+        let n = 0;
+        const r: any = {
+          tag: "x",
+          [Symbol.dispose]: () => { n = n + 5; },
+        };
+        const stack = new DisposableStack();
+        stack.use(r);
+        stack.dispose();
+        return n;
+      }
+    `;
+    expect(await run(src)).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Object literals written as `{ [Symbol.dispose]: () => {} }` were silently dropped at `literals.ts:344` ("Computed property names not handled here — fall through silently"), so `DisposableStack.use(resource)` could not find the disposer. The MethodDeclaration form (`{ [Symbol.dispose]() {} }`) already worked via the well-known-symbol path added in #1433.

This change makes the symmetric fix to the PropertyAssignment form:

- `_hasDisposalMethod` now also matches `PropertyAssignment` so the literal routes to the externref/accessor path (instead of the wasmGC struct path that stores under `@@dispose` and is invisible to the host).
- The `PropertyAssignment` branch in `compileObjectLiteralWithAccessors` now boxes well-known symbol keys via `__box_symbol(id)` (mirroring lines 392–404 for MethodDeclaration) and falls back to `resolveComputedKeyExpression` for plain computed string keys.

Scope is limited to `Symbol.dispose` / `Symbol.asyncDispose` — broader well-known symbols (`iterator`, `toPrimitive`, etc.) interact with struct-field codegen elsewhere and are tracked separately.

## Test plan

- [x] `npm test -- tests/issue-1695-propkey.test.ts` — 5/5 pass (arrow / function-expression disposers, asyncDispose visibility, plain computed string key, mixed disposal + tag)
- [x] `npm test -- tests/object-literals.test.ts tests/object-literal-getters-setters.test.ts tests/symbol-iterator-protocol.test.ts tests/issue-1347.test.ts` — no new failures (symbol-async-iterator + spec-gaps failures are pre-existing, verified via `git stash` baseline)
- [ ] CI test262 — gating on green