### PR TITLE
fix(#1700): TypedArray export-parameter marshalling (copy-in/copy-out)

### DIFF
--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -59,6 +59,7 @@ export function createCodegenContext(
     enumStringValues: new Map(),
     arrayTypeMap: new Map(),
     vecTypeMap: new Map(),
+    exportSignatures: new Map(),
     externClassParent: new Map(),
     declaredGlobals: new Map(),
     callbackCounter: 0,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -371,6 +371,12 @@ export interface CodegenContext {
   arrayTypeMap: Map<string, number>;
   /** Map from element kind (e.g. "f64") → registered vec struct type index */
   vecTypeMap: Map<string, number>;
+  /**
+   * Per-export TypedArray classification populated during user-function
+   * declaration emission (#1700). Read by the runtime `wrapExports` to
+   * marshal `Uint8Array` params/results across the JS↔Wasm boundary.
+   */
+  exportSignatures: Map<string, import("../../ir/types.js").ExportSignature>;
   /** Map from className → parent className (for inheritance chain walk) */
   externClassParent: Map<string, string>;
   /** Map from global name (e.g. "document") → import info */

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -32,6 +32,7 @@ import {
   addStringImports,
   addUnionImports,
   collectEnumDeclarations,
+  classifyTypedArrayType,
   ensureStructForType,
   extractConstantDefault,
   FUNCTIONAL_ARRAY_METHODS,
@@ -124,6 +125,40 @@ interface UnifiedCollectorState {
 }
 
 const CONSOLE_METHODS_SET = new Set(["log", "warn", "error", "info", "debug"]);
+
+/**
+ * (#1700) Record TypedArray classifications for a user-exported function so
+ * the JS-host `wrapExports` can marshal `Uint8Array` params/returns across
+ * the JS↔Wasm boundary. The Wasm signature alone is ambiguous —
+ * `(input: Uint8Array)` and `(input: number[])` lower to the same
+ * `(ref null $Vec[f64])` — so we surface the TS-level distinction here.
+ *
+ * No-op when every slot classifies as `"other"` so non-TypedArray modules
+ * accumulate no metadata.
+ */
+function recordExportSignature(
+  ctx: CodegenContext,
+  exportName: string,
+  stmt: ts.FunctionDeclaration,
+  isAsync: boolean,
+): void {
+  const sig = ctx.checker.getSignatureFromDeclaration(stmt);
+  if (!sig) return;
+  const params: import("../ir/types.js").TypedArrayKind[] = [];
+  let anyHit = false;
+  for (const p of stmt.parameters) {
+    const pt = ctx.checker.getTypeAtLocation(p);
+    const kind = classifyTypedArrayType(pt, ctx.checker);
+    if (kind !== "other") anyHit = true;
+    params.push(kind);
+  }
+  const retType = ctx.checker.getReturnTypeOfSignature(sig);
+  const unwrappedRet = isAsync ? unwrapPromiseType(retType, ctx.checker) : retType;
+  const result = classifyTypedArrayType(unwrappedRet, ctx.checker);
+  if (result !== "other") anyHit = true;
+  if (!anyHit) return;
+  ctx.exportSignatures.set(exportName, { params, result });
+}
 
 export function createUnifiedCollectorState(sourceFile: ts.SourceFile): UnifiedCollectorState {
   return {
@@ -2544,6 +2579,7 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
           name,
           desc: { kind: "func", index: funcIdx },
         });
+        recordExportSignature(ctx, name, stmt, isAsync);
         // `export default function foo() {}` — also export as "default" (#1074)
         // Skip if name is already "default" (anonymous export default function)
         const mods = ts.canHaveModifiers(stmt) ? ts.getModifiers(stmt) : undefined;
@@ -2553,6 +2589,7 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
             name: "default",
             desc: { kind: "func", index: funcIdx },
           });
+          recordExportSignature(ctx, "default", stmt, isAsync);
         }
       }
     }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -117,6 +117,59 @@ export {
  * Returns the constant default info if the initializer is a numeric/boolean literal,
  * undefined/null, or a unary minus on a numeric literal. Returns undefined otherwise.
  */
+/**
+ * TypedArray constructor names that lower to a `(ref null $Vec[f64])` Wasm
+ * type (#1700). Shared between `resolveWasmType` and `classifyTypedArrayType`
+ * so the export-signature side table and the codegen lowering stay in sync.
+ */
+export const TYPED_ARRAY_NAMES: ReadonlySet<string> = new Set([
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+]);
+
+/**
+ * (#1700) Classify a TS type at an export boundary for the runtime
+ * `wrapExports` marshalling step. The Wasm signature for `Uint8Array` and
+ * `number[]` is identical (`(ref null $Vec[f64])`), so we surface the
+ * TS-level distinction as metadata.
+ *
+ * - "uint8array"  → caller may pass JS Uint8Array; result-side wraps as Uint8Array
+ * - "typed-array" → any other TypedArray (Int8Array / Float32Array / ...) — v1
+ *                   treats these like number[] on the return path; tracked for
+ *                   element-fidelity follow-up
+ * - "other"       → not a typed array; wrapper is a no-op for this slot
+ */
+export function classifyTypedArrayType(
+  tsType: ts.Type,
+  checker: ts.TypeChecker,
+): import("../ir/types.js").TypedArrayKind {
+  // Strip null/undefined/void/Promise wrappers so `Uint8Array | undefined`,
+  // `Promise<Uint8Array>` etc. still classify. Match `resolveWasmType`'s
+  // own unwrapping rules.
+  let t = tsType;
+  if (t.isUnion()) {
+    const non = t.types.filter(
+      (x) => !(x.flags & ts.TypeFlags.Null) && !(x.flags & ts.TypeFlags.Undefined) && !(x.flags & ts.TypeFlags.Void),
+    );
+    if (non.length === 1) t = non[0]!;
+  }
+  const sym = t.aliasSymbol ?? t.getSymbol();
+  if (sym?.name === "Promise") {
+    const args = checker.getTypeArguments(t as ts.TypeReference);
+    if (args.length > 0) return classifyTypedArrayType(args[0]!, checker);
+  }
+  const name = sym?.name;
+  if (!name || !TYPED_ARRAY_NAMES.has(name)) return "other";
+  return name === "Uint8Array" ? "uint8array" : "typed-array";
+}
+
 function sourceContainsClass(sourceFile: ts.SourceFile): boolean {
   let found = false;
   function walk(node: ts.Node): void {
@@ -1101,6 +1154,13 @@ export function generateModule(
     }
     mod.stringLiteralValues = ctx.stringLiteralValues;
     mod.asyncFunctions = ctx.asyncFunctions;
+    // (#1700) Surface per-export TypedArray classifications so the JS-host
+    // wrapExports can marshal Uint8Array params/results across the boundary.
+    if (ctx.exportSignatures.size > 0) {
+      const obj: Record<string, import("../ir/types.js").ExportSignature> = {};
+      for (const [k, v] of ctx.exportSignatures) obj[k] = v;
+      mod.exportSignatures = obj;
+    }
 
     // Emit exported struct field getter helpers for the runtime.
     // These allow JS host imports to read WasmGC struct fields that are
@@ -1117,6 +1177,11 @@ export function generateModule(
 
     // (#1503) __vec_set_byte for crypto.getRandomValues to write into Uint8Array vecs.
     emitVecSetByteExport(ctx);
+
+    // (#1700) __new_vec_f64 — JS-callable allocator for f64-element vecs so
+    // wrapExports can copy Uint8Array (and other TypedArray) inputs across
+    // the JS↔Wasm boundary. Gated on an exported user fn accepting a vec.
+    emitNewVecF64Export(ctx);
 
     // Emit __test_str_from_externref / __test_str_to_externref exports for
     // dual-run testing in nativeStrings mode (#1187). No-op unless
@@ -2986,7 +3051,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
  * a dead export and bloat every module.
  */
 function emitVecSetByteExport(ctx: CodegenContext): void {
-  if (!ctx.funcMap.has("__crypto_get_random_values")) return;
+  // (#1503) Originally gated on `__crypto_get_random_values` so the export
+  // only appeared when crypto.getRandomValues was reachable.
+  // (#1700) Now also needed by the JS-host `wrapExports` to populate freshly
+  // allocated f64 vecs with Uint8Array bytes. Emit when either consumer is
+  // present.
+  if (!ctx.funcMap.has("__crypto_get_random_values") && !hasExportedVecParam(ctx)) return;
   try {
     _emitVecSetByteExportInner(ctx);
   } catch {
@@ -3066,6 +3136,103 @@ function _emitVecSetByteExportInner(ctx: CodegenContext): void {
     exported: true,
   } as any);
   mod.exports.push({ name: "__vec_set_byte", desc: { kind: "func", index: funcIdx } });
+}
+
+/**
+ * (#1700) Emit `__new_vec_f64(i32 len) -> externref` so the JS-host
+ * `wrapExports` can allocate a fresh f64-element vec struct and populate it
+ * with bytes from a JS `Uint8Array` argument. Without this export, callers
+ * have no JS entry point to construct a `(ref null $Vec[f64])` and hit
+ * "type incompatibility when transforming from/to JS" at the call boundary.
+ *
+ * The signature returns `externref` (not the typed vec ref) so the result
+ * is opaque on the JS side — callers pass it straight back to a compiled
+ * function param, which casts it to the right vec type internally.
+ *
+ * Gated: only emitted when (a) an `f64`-element vec is registered, AND
+ * (b) at least one exported user function accepts a vec-shaped ref param.
+ * Modules without TypedArray exports pay zero bytes.
+ */
+function emitNewVecF64Export(ctx: CodegenContext): void {
+  if (!ctx.vecTypeMap.has("f64")) return;
+  if (!hasExportedVecParam(ctx)) return;
+  try {
+    _emitNewVecF64ExportInner(ctx);
+  } catch {
+    // Non-fatal — if dispatch emission fails the JS-side wrapper falls
+    // back to passing the raw arg (which raises the original TypeError),
+    // which is no worse than the pre-#1700 baseline.
+  }
+}
+
+function hasExportedVecParam(ctx: CodegenContext): boolean {
+  const mod = ctx.mod;
+  const vecTypeIdxs = new Set<number>(ctx.vecTypeMap.values());
+  for (const exp of mod.exports) {
+    if (exp.desc.kind !== "func") continue;
+    const idx = exp.desc.index - ctx.numImportFuncs;
+    if (idx < 0 || idx >= mod.functions.length) continue;
+    const fn = mod.functions[idx]!;
+    const typeDef = mod.types[fn.typeIdx];
+    if (!typeDef) continue;
+    // Resolve sub-type wrappers (some FuncTypeDefs are nested under SubTypeDef).
+    const ft = typeDef.kind === "sub" ? typeDef.type : typeDef;
+    if (ft.kind !== "func") continue;
+    for (const p of ft.params) {
+      if ((p.kind === "ref" || p.kind === "ref_null") && vecTypeIdxs.has(p.typeIdx)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function _emitNewVecF64ExportInner(ctx: CodegenContext): void {
+  const mod = ctx.mod;
+  const vecTypeIdx = ctx.vecTypeMap.get("f64")!;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return;
+  // Skip if the export is already emitted (defensive — multi-source paths
+  // may invoke the emit pass more than once; emitVecSetByteExport doesn't
+  // guard either but is gated by funcMap which prevents a second emit).
+  if (mod.exports.some((e) => e.name === "__new_vec_f64")) return;
+
+  // Return the typed vec ref directly (NOT externref). V8 and SpiderMonkey
+  // both reject the JS↔Wasm round-trip if we return externref and try to
+  // pass it back to a `(ref null $Vec)` param — the boundary will not
+  // narrow externref → concrete WasmGC ref. By returning the real type,
+  // JS sees an opaque WasmGC handle and the engine accepts it on the way
+  // back in (same type identity).
+  const typeIdx = addFuncType(
+    ctx,
+    [{ kind: "i32" }],
+    [{ kind: "ref_null", typeIdx: vecTypeIdx }],
+    "$__new_vec_f64_type",
+  );
+  const funcIdx = ctx.numImportFuncs + mod.functions.length;
+
+  // local 0 = len (i32 param)
+  // local 1 = $arr (ref null $arr_f64) — the zero-initialised data array
+  const arrRefType: ValType = { kind: "ref_null", typeIdx: arrTypeIdx };
+  const body: Instr[] = [
+    // arr = array.new_default $arr_f64 (len)
+    { op: "local.get", index: 0 } as Instr,
+    { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+    { op: "local.set", index: 1 } as Instr,
+    // struct.new $Vec[f64] { length: len, data: arr }
+    { op: "local.get", index: 0 } as Instr,
+    { op: "local.get", index: 1 } as Instr,
+    { op: "struct.new", typeIdx: vecTypeIdx } as Instr,
+  ];
+
+  mod.functions.push({
+    name: "__new_vec_f64",
+    typeIdx,
+    locals: [{ name: "__arr", type: arrRefType }],
+    body,
+    exported: true,
+  } as any);
+  mod.exports.push({ name: "__new_vec_f64", desc: { kind: "func", index: funcIdx } });
 }
 
 /**
@@ -3492,6 +3659,13 @@ export function generateMultiModule(
     }
     mod.stringLiteralValues = ctx.stringLiteralValues;
     mod.asyncFunctions = ctx.asyncFunctions;
+    // (#1700) Surface per-export TypedArray classifications so the JS-host
+    // wrapExports can marshal Uint8Array params/results across the boundary.
+    if (ctx.exportSignatures.size > 0) {
+      const obj: Record<string, import("../ir/types.js").ExportSignature> = {};
+      for (const [k, v] of ctx.exportSignatures) obj[k] = v;
+      mod.exportSignatures = obj;
+    }
 
     // Emit exported struct field getter helpers for the runtime (mirrors
     // generateModule path — #1308 surfaced that multi-source projects
@@ -7498,17 +7672,6 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
     // TypedArray types → vec struct with f64 elements (same representation as number[])
     // Covers: Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
     //         Int32Array, Uint32Array, Float32Array, Float64Array
-    const TYPED_ARRAY_NAMES = new Set([
-      "Int8Array",
-      "Uint8Array",
-      "Uint8ClampedArray",
-      "Int16Array",
-      "Uint16Array",
-      "Int32Array",
-      "Uint32Array",
-      "Float32Array",
-      "Float64Array",
-    ]);
     if (sym?.name && TYPED_ARRAY_NAMES.has(sym.name)) {
       const elemWasm: ValType = { kind: "f64" };
       const vecIdx = getOrRegisterVecType(ctx, "f64", elemWasm);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -540,6 +540,7 @@ export function compileSource(
     wit: witOutput,
     hasMain: mod.exports.some((e) => e.name === "main" && e.desc.kind === "func"),
     hasTopLevelStatements: mod.hasTopLevelStatements === true,
+    exportSignatures: mod.exportSignatures,
   };
 }
 
@@ -813,6 +814,7 @@ export function compileMultiSource(
     imports: buildImportManifest(mod),
     hasMain: mod.exports.some((e) => e.name === "main" && e.desc.kind === "func"),
     hasTopLevelStatements: mod.hasTopLevelStatements === true,
+    exportSignatures: mod.exportSignatures,
   };
 }
 
@@ -1052,5 +1054,6 @@ export function compileFilesSource(entryPath: string, options: CompileOptions = 
     imports: buildImportManifest(mod),
     hasMain: mod.exports.some((e) => e.name === "main" && e.desc.kind === "func"),
     hasTopLevelStatements: mod.hasTopLevelStatements === true,
+    exportSignatures: mod.exportSignatures,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,9 @@ export interface ImportDescriptor {
   intent: ImportIntent;
 }
 
+export type { ExportSignature, TypedArrayKind } from "./ir/types.js";
+import type { ExportSignature } from "./ir/types.js";
+
 export interface CompileResult {
   /** Wasm binary with GC proposal */
   binary: Uint8Array;
@@ -83,6 +86,18 @@ export interface CompileResult {
   hasMain: boolean;
   /** Whether the source has top-level executable statements (module init code) */
   hasTopLevelStatements: boolean;
+  /**
+   * Per-export TypedArray classifications (#1700). Surfaced so
+   * {@link wrapExports} can marshal `Uint8Array` (and other TypedArray)
+   * params/results across the JS↔Wasm boundary — the Wasm signature is
+   * ambiguous (`Uint8Array` and `number[]` share the same `(ref null $Vec[f64])`
+   * lowering), so we expose the TS-level distinction as metadata.
+   *
+   * Only present (and even then, possibly an empty object) when at least
+   * one exported function has a TypedArray param or return. Forward the
+   * value to `wrapExports(exports, { signatures: result.exportSignatures })`.
+   */
+  exportSignatures?: Record<string, ExportSignature>;
   /**
    * Ready-to-pass JS-host import object for default/JS-host mode (#1667).
    *

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -43,6 +43,22 @@ export interface WasmModule {
   hasTopLevelStatements?: boolean;
   /** Wasm start function index — runs automatically on instantiation (#907) */
   startFuncIdx?: number;
+  /**
+   * Per-export TS-level type annotations (#1700). Surfaced so the JS-host
+   * `wrapExports` can faithfully marshal `Uint8Array` (and other TypedArray)
+   * params/results that share the same Wasm signature as `number[]`. Keyed
+   * by export name. Only populated for exports whose params/result reference
+   * TypedArray types.
+   */
+  exportSignatures?: Record<string, ExportSignature>;
+}
+
+/** TS-level kind hint for a single export parameter or result (#1700). */
+export type TypedArrayKind = "uint8array" | "typed-array" | "other";
+
+export interface ExportSignature {
+  params: TypedArrayKind[];
+  result: TypedArrayKind;
 }
 
 export type TypeDef = FuncTypeDef | StructTypeDef | ArrayTypeDef | RecGroupDef | SubTypeDef;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8318,9 +8318,73 @@ export function buildImports(
  * negated();                              // dispatches via __call_fn_0
  * ```
  */
+/**
+ * (#1700) TS-level classification of a single export param or result slot
+ * surfaced via `CompileResult.exportSignatures`. The Wasm signature alone
+ * is ambiguous for TypedArray vs `number[]` — both lower to
+ * `(ref null $Vec[f64])` — so the JS-host wrapper consults this metadata
+ * to (a) copy a JS `Uint8Array` into a fresh Wasm vec before the call and
+ * (b) wrap the returned plain `Array<number>` back into a `Uint8Array`.
+ */
+export interface WrapExportsSignature {
+  params: ("uint8array" | "typed-array" | "other")[];
+  result: "uint8array" | "typed-array" | "other";
+}
+
+/**
+ * (#1700) Copy each `Uint8Array` / TypedArray / plain-array argument into a
+ * fresh Wasm vec via `__new_vec_f64` + `__vec_set_byte`. Non-TypedArray
+ * slots (`kind === "other"`) and `null` / `undefined` pass through. Other
+ * values for a TypedArray slot throw `TypeError`, matching the shape of
+ * `new Uint8Array(nonIterable)`.
+ */
+function marshalTypedArrayArgs(
+  args: any[],
+  sig: WrapExportsSignature,
+  exportName: string,
+  newVecF64: (len: number) => any,
+  vecSetByte: (vec: any, idx: number, byte: number) => void,
+): any[] {
+  const out = new Array(args.length);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const kind = sig.params[i];
+    if (kind !== "uint8array" && kind !== "typed-array") {
+      out[i] = arg;
+      continue;
+    }
+    if (arg == null) {
+      // Pass null/undefined straight through — compiled function takes
+      // a ref_null vec param and is responsible for its own null handling.
+      out[i] = arg;
+      continue;
+    }
+    if (!ArrayBuffer.isView(arg) && !Array.isArray(arg)) {
+      throw new TypeError(`wrapExports: export "${exportName}" expects ${kind} for arg #${i}, got ${typeof arg}`);
+    }
+    const src = arg as ArrayLike<number>;
+    const len = src.length | 0;
+    const vec = newVecF64(len);
+    for (let j = 0; j < len; j++) {
+      // Mask to byte range — matches `new Uint8Array(arr)` indexed-write
+      // semantics (and __vec_set_byte's i32-byte contract).
+      vecSetByte(vec, j, src[j]! & 0xff);
+    }
+    out[i] = vec;
+  }
+  return out;
+}
+
 export function wrapExports(
   rawExports: WebAssembly.Exports,
-  options?: { marshal?: "copy" | false },
+  options?: {
+    marshal?: "copy" | false;
+    /** Per-export TS-level type metadata from `CompileResult.exportSignatures`
+     *  (#1700). When provided, Uint8Array arguments are copied into a Wasm
+     *  vec before the call and Uint8Array-typed returns are wrapped on the
+     *  way out. Omitted ⇒ legacy behaviour (no per-call marshalling). */
+    signatures?: Record<string, WrapExportsSignature>;
+  },
 ): Record<string, any> {
   const callFn0 = rawExports.__call_fn_0 as ((closure: any) => any) | undefined;
   const callFn1 = rawExports.__call_fn_1 as ((closure: any, arg: any) => any) | undefined;
@@ -8329,6 +8393,15 @@ export function wrapExports(
   // (used by test262 runners and advanced callers that want zero-copy access).
   const marshal: "copy" | false = options?.marshal === false ? false : "copy";
   const exportsForMarshal = rawExports as unknown as Record<string, Function>;
+  // (#1700) Vec allocator + byte-writer for marshalling Uint8Array args into
+  // Wasm vec structs. Either may be undefined (legacy modules / no TypedArray
+  // exports gated their emission off), in which case the wrapper falls back
+  // to passing the arg through unchanged.
+  const newVecF64 = (rawExports as Record<string, any>).__new_vec_f64 as ((len: number) => any) | undefined;
+  const vecSetByte = (rawExports as Record<string, any>).__vec_set_byte as
+    | ((vec: any, idx: number, byte: number) => void)
+    | undefined;
+  const signatures = options?.signatures;
 
   // Build a JS-callable wrapper around a Wasm closure struct.
   const makeCallableClosureWrapper = (closure: any): ((...args: any[]) => any) => {
@@ -8395,12 +8468,25 @@ export function wrapExports(
     //   - named struct / vec → plain JS object/array via `_wasmToPlain`
     //     (#1504), unless `marshal: false` is passed
     //   - everything else (primitives, strings, raw externrefs) → pass through
+    const sig = signatures ? signatures[key] : undefined;
     wrapped[key] = function (this: any, ...args: any[]): any {
-      const result = (val as Function).apply(this, args);
+      // (#1700) Argument marshalling: copy JS Uint8Array → Wasm vec via
+      // `__new_vec_f64` + `__vec_set_byte`. Runs even under `marshal: false`
+      // because the user must be able to call the export at all.
+      const marshalled =
+        sig && newVecF64 && vecSetByte ? marshalTypedArrayArgs(args, sig, key, newVecF64, vecSetByte) : args;
+      const result = (val as Function).apply(this, marshalled);
       if (result == null || !_isWasmStruct(result)) return result;
       const marshalable = looksMarshalable(result);
       if (marshal === "copy" && marshalable) {
-        return _wasmToPlain(result, exportsForMarshal);
+        const plain = _wasmToPlain(result, exportsForMarshal);
+        // (#1700) Uint8Array fidelity on the return side. The Wasm signature
+        // is ambiguous (Uint8Array and number[] share `(ref null $Vec[f64])`)
+        // so we wrap based on the TS-level metadata, not a runtime probe.
+        if (sig && sig.result === "uint8array" && Array.isArray(plain)) {
+          return new Uint8Array(plain as number[]);
+        }
+        return plain;
       }
       if (marshalable) {
         // Struct/vec but `marshal: false` → return the raw WasmGC handle

--- a/tests/issue-1700.test.ts
+++ b/tests/issue-1700.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+
+/**
+ * #1700 — TypedArray (Uint8Array) export-parameter ABI gap.
+ *
+ * Before this change, an exported function `(input: Uint8Array)` lowered to
+ * `(ref null $Vec[f64])` and JS callers passing a real `Uint8Array` hit
+ * `TypeError: type incompatibility when transforming from/to JS` at the
+ * boundary. The fix adds:
+ *
+ *   - `__new_vec_f64(i32 len) -> externref`, a JS-callable vec allocator.
+ *   - `CompileResult.exportSignatures`, a per-export TS-level classification.
+ *   - `wrapExports(exports, { signatures })`, which copies `Uint8Array`
+ *     args into a Wasm vec via the allocator + `__vec_set_byte`, and wraps
+ *     `Uint8Array`-typed returns back into a real `Uint8Array`.
+ */
+
+async function instantiate(r: CompileResult): Promise<WebAssembly.Instance> {
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return instance;
+}
+
+describe("#1700 TypedArray export-parameter marshalling", () => {
+  it("compiles: round-trips Uint8Array through a Uint8Array-typed export", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    expect(r.exportSignatures).toBeDefined();
+    const sig = r.exportSignatures!.echoBytes;
+    expect(sig).toBeDefined();
+    expect(sig!.params).toEqual(["uint8array"]);
+    expect(sig!.result).toBe("uint8array");
+
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const input = new Uint8Array([97, 98, 99]);
+    const out = exports.echoBytes(input);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out as Uint8Array)).toEqual([97, 98, 99]);
+  });
+
+  it("empty Uint8Array round-trips as length-zero Uint8Array", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const out = exports.echoBytes(new Uint8Array(0));
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect((out as Uint8Array).length).toBe(0);
+  });
+
+  it("accepts plain Array<number> for a Uint8Array param (Uint8Array.from-style)", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const out = exports.echoBytes([1, 2, 3]);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out as Uint8Array)).toEqual([1, 2, 3]);
+  });
+
+  it("masks out-of-range values into byte range (matches Uint8Array semantics)", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const out = exports.echoBytes([256, -1, 257]);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out as Uint8Array)).toEqual([0, 255, 1]);
+  });
+
+  it("throws TypeError when caller passes a non-array to a Uint8Array param", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    expect(() => exports.echoBytes("foo" as any)).toThrow(TypeError);
+    expect(() => exports.echoBytes(42 as any)).toThrow(TypeError);
+  });
+
+  it("multi-arg: only Uint8Array slot is marshalled; number and string pass through", async () => {
+    const r = compile(`
+      export function blendBytes(n: number, buf: Uint8Array): Uint8Array {
+        return buf;
+      }
+    `);
+    expect(r.exportSignatures!.blendBytes.params).toEqual(["other", "uint8array"]);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const out = exports.blendBytes(7, new Uint8Array([10, 20, 30]));
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out as Uint8Array)).toEqual([10, 20, 30]);
+  });
+
+  it("regression guard: externref/any param keeps the externref pass-through path", async () => {
+    // No Uint8Array in the signature → no exportSignatures entry, wrapper
+    // is the legacy pass-through (this is the path that already worked).
+    const r = compile(`
+      export function echoAny(input: any): any { return input; }
+    `);
+    expect(r.exportSignatures?.echoAny).toBeUndefined();
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const input = new Uint8Array([1, 2, 3]);
+    const out = exports.echoAny(input);
+    // externref result; identity preserved across the call (no copying)
+    expect(out).toBe(input);
+  });
+
+  it("module size: a TypedArray-free module does not emit __new_vec_f64", async () => {
+    const r = compile(`
+      export function add(a: number, b: number): number { return a + b; }
+    `);
+    const instance = await instantiate(r);
+    expect((instance.exports as Record<string, unknown>).__new_vec_f64).toBeUndefined();
+    expect(r.exportSignatures).toBeUndefined();
+  });
+
+  it("marshal: false — argument marshalling still runs (export must be callable)", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, {
+      marshal: false,
+      signatures: r.exportSignatures,
+    });
+    const out = exports.echoBytes(new Uint8Array([5, 6, 7]));
+    // marshal:false → raw WasmGC handle. Not a Uint8Array. We can still
+    // inspect length via the exported __vec_len helper.
+    expect(out).not.toBeInstanceOf(Uint8Array);
+    const vecLen = (instance.exports as Record<string, any>).__vec_len as (v: any) => number;
+    expect(vecLen(out)).toBe(3);
+  });
+
+  it("--target wasi: Uint8Array argument marshalling reaches the compiled function", async () => {
+    // Under WASI, `__box_number` is intentionally absent, so `__vec_get`
+    // returns null for numeric elements and the return-side
+    // `_wasmToPlain` ⇒ `Uint8Array` wrap is lossy (separate follow-up;
+    // tracked alongside #1664). What #1700 fixes — the JS→Wasm arg
+    // path — must still work. Verify by passing marshal:false and using
+    // `__vec_len` directly to confirm the vec made it across.
+    const r = compile(`export function echoBytes(input: Uint8Array): Uint8Array { return input; }`, { target: "wasi" });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect(r.exportSignatures?.echoBytes?.result).toBe("uint8array");
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const exports = wrapExports(instance.exports, {
+      marshal: false,
+      signatures: r.exportSignatures,
+    });
+    const out = exports.echoBytes(new Uint8Array([42, 43, 44]));
+    const vecLen = (instance.exports as Record<string, any>).__vec_len as (v: any) => number;
+    expect(vecLen(out)).toBe(3);
+  });
+
+  it("null pass-through: Uint8Array param accepting null forwards null without alloc", async () => {
+    const r = compile(`export function echoBytes(input: Uint8Array | null): Uint8Array | null { return input; }`);
+    expect(r.exportSignatures?.echoBytes?.params).toEqual(["uint8array"]);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { signatures: r.exportSignatures });
+    const out = exports.echoBytes(null);
+    // Wasm ref.null → JS null is the expected pass-through.
+    expect(out).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1700 — JS callers passing `Uint8Array` to a compiled `(input: Uint8Array)` export previously hit `TypeError: type incompatibility when transforming from/to JS` at the boundary.

Three pieces wired together (per arch spec in `plan/issues/1700-typedarray-export-param-abi-gap.md`):

- **`__new_vec_f64(i32 len) -> (ref null \$Vec[f64])`** — JS-callable allocator gated on `vecTypeMap.has("f64")` plus an exported user fn that accepts a vec param. Returns the typed vec ref so JS holds an opaque WasmGC handle the engine accepts back. Also lifts the crypto-only gate on `__vec_set_byte` so it ships alongside.
- **`CompileResult.exportSignatures`** — per-export TS-level classification (`"uint8array" | "typed-array" | "other"`). Disambiguates the otherwise-ambiguous Wasm sig (`Uint8Array` and `number[]` share `(ref null \$Vec[f64])`).
- **`wrapExports(exports, { signatures })`** — copies each Uint8Array/plain-array arg into a fresh vec via `__new_vec_f64` + `__vec_set_byte`, masks to byte range. Uint8Array-typed returns wrap back into a real `Uint8Array`. Non-array values throw `TypeError`. The existing `marshal: false` callers stay byte-identical.

Module-size impact: zero for modules without a Uint8Array (or other vec) param — both the allocator export and the metadata are gated.

WASI return-side `Uint8Array` fidelity is documented as a follow-up — `__box_number` is absent under WASI, so `_wasmToPlain` reads null for f64 vec elements. The JS→Wasm arg path (what #1700 is) works under WASI; the test asserts that explicitly via `__vec_len`.

## Test plan

- [x] `npm test -- tests/issue-1700.test.ts` — 11/11 pass (round-trip, empty, plain-array coerce, masking, TypeError on non-array, multi-arg, `any` regression guard, module-size gate, `marshal: false`, WASI variant, null pass-through)
- [x] Related: `tests/issue-1308.test.ts` (wrapExports closure path), `tests/issue-1504.test.ts` (vec/struct return marshalling), `tests/issue-1667.test.ts` (importObject), `tests/equivalence/ir-slice10-typed-array.test.ts`, `tests/equivalence/ir-slice10-arraybuffer-dataview.test.ts`, `tests/issue-1654-wasi-dataview-arraybuffer.test.ts`, `tests/wasi.test.ts` — all pass
- [x] tsc --noEmit clean
- [ ] CI green on this branch (test262 conformance unchanged — test262 uses `marshal: false` and doesn't exercise `Uint8Array` params through wrapExports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)