### PR TITLE
feat(#1660): CLA gate — PR template checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+  Thanks for contributing! Please review the checklist below before opening your PR.
+  If your PR is an internal/org-member PR, the CLA check is skipped automatically.
+-->
+
+## Description
+
+<!-- What does this PR do? -->
+
+## CLA
+
+Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:
+
+- [ ] I have read and agree to the CLA
+
+<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->

--- a/.github/cla/cla-gate.mjs
+++ b/.github/cla/cla-gate.mjs
@@ -52,10 +52,42 @@ export function isBot(login) {
   return typeof login === "string" && /\[bot\]$/i.test(login);
 }
 
-/** Normalize a comment body for phrase matching. */
+/** Normalize a comment body for phrase matching.
+ *
+ * Accepts two formats (case-insensitive, trimmed):
+ *   1. Exact phrase: "I have read and agree to the CLA"
+ *   2. Checkbox:     "[x] I have read and agree to the CLA"
+ *                    "- [x] I have read and agree to the CLA"
+ *                    "* [x] I have read and agree to the CLA"
+ *
+ * The checkbox format lets contributors click a GitHub task-list checkbox
+ * (if the workflow triggers on issue_comment edited) or copy-paste the
+ * pre-filled checkbox from the instruction comment.
+ */
 export function commentMatchesPhrase(body) {
   if (typeof body !== "string") return false;
-  return body.trim().toLowerCase() === AGREEMENT_PHRASE.toLowerCase();
+  const trimmed = body.trim().toLowerCase();
+  const phrase = AGREEMENT_PHRASE.toLowerCase();
+  if (trimmed === phrase) return true;
+  // Checkbox format: optional "- " or "* " prefix, then "[x] " + phrase
+  const m = /^(?:[-*]\s+)?\[x\]\s+(.+)$/.exec(trimmed);
+  if (m && m[1].trim() === phrase) return true;
+  return false;
+}
+
+/** Check whether a PR body contains the CLA checkbox in checked state.
+ *
+ * Matches the PR template checkbox:  - [x] I have read and agree to the CLA
+ * Case-insensitive. The checkbox must be checked ([x] or [X]).
+ */
+export function prBodyMatchesCheckbox(body) {
+  if (typeof body !== "string") return false;
+  const phrase = AGREEMENT_PHRASE.toLowerCase();
+  for (const line of body.split("\n")) {
+    const m = /^(?:[-*]\s+)?\[x\]\s+(.+)$/i.exec(line.trim());
+    if (m && m[1].trim().toLowerCase() === phrase) return true;
+  }
+  return false;
 }
 
 /**
@@ -177,6 +209,7 @@ export default {
   currentClaVersion,
   isBot,
   commentMatchesPhrase,
+  prBodyMatchesCheckbox,
   staticExemptReason,
   hasSigned,
   makeSignature,

--- a/.github/cla/cla-gate.test.mjs
+++ b/.github/cla/cla-gate.test.mjs
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import {
   isBot,
   commentMatchesPhrase,
+  prBodyMatchesCheckbox,
   staticExemptReason,
   hasSigned,
   makeSignature,
@@ -33,7 +34,7 @@ test("isBot detects [bot] suffix", () => {
   assert.equal(isBot(undefined), false);
 });
 
-test("commentMatchesPhrase is exact (trim + case-insensitive)", () => {
+test("commentMatchesPhrase exact phrase (trim + case-insensitive)", () => {
   assert.equal(commentMatchesPhrase(AGREEMENT_PHRASE), true);
   assert.equal(commentMatchesPhrase("  I have read and agree to the CLA  "), true);
   assert.equal(commentMatchesPhrase("i have read and agree to the cla"), true);
@@ -41,6 +42,34 @@ test("commentMatchesPhrase is exact (trim + case-insensitive)", () => {
   assert.equal(commentMatchesPhrase("I have read and agree to the CLA, thanks!"), false);
   assert.equal(commentMatchesPhrase("LGTM"), false);
   assert.equal(commentMatchesPhrase(undefined), false);
+});
+
+test("commentMatchesPhrase checkbox format", () => {
+  assert.equal(commentMatchesPhrase("[x] I have read and agree to the CLA"), true);
+  assert.equal(commentMatchesPhrase("- [x] I have read and agree to the CLA"), true);
+  assert.equal(commentMatchesPhrase("* [x] I have read and agree to the CLA"), true);
+  assert.equal(commentMatchesPhrase("[X] I have read and agree to the CLA"), true);
+  assert.equal(commentMatchesPhrase("- [X] I HAVE READ AND AGREE TO THE CLA"), true);
+  assert.equal(commentMatchesPhrase("[ ] I have read and agree to the CLA"), false, "unchecked box");
+  assert.equal(commentMatchesPhrase("[x] I agree to the CLA"), false, "wrong phrase");
+  assert.equal(commentMatchesPhrase("[x] I have read and agree to the CLA extra"), false, "extra text");
+});
+
+test("prBodyMatchesCheckbox detects checked PR template box", () => {
+  const body = `## Description\n\nFixes stuff.\n\n## CLA\n\n- [x] I have read and agree to the CLA.\n`;
+  // Note: the template shows "...CLA." with a period, but our phrase is without period
+  // Test with the exact phrase (no period)
+  const body2 = `## CLA\n\n- [x] I have read and agree to the CLA\n`;
+  assert.equal(prBodyMatchesCheckbox(body2), true);
+  assert.equal(prBodyMatchesCheckbox("- [ ] I have read and agree to the CLA\n"), false, "unchecked");
+  assert.equal(prBodyMatchesCheckbox("No checkbox here"), false);
+  assert.equal(prBodyMatchesCheckbox(undefined), false);
+  assert.equal(
+    prBodyMatchesCheckbox("- [x] I have read and agree to the CLA\n- [x] other line"),
+    true,
+    "first match wins",
+  );
+  assert.equal(prBodyMatchesCheckbox("- [X] I HAVE READ AND AGREE TO THE CLA"), true, "case insensitive");
 });
 
 test("staticExemptReason: bots are exempt", () => {

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -33,9 +33,9 @@ name: CLA Check
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
   issue_comment:
-    types: [created]
+    types: [created, edited]
   # #1668 — must report on merge_group so the required `cla-check` context is
   # satisfied in the merge queue. There is no PR author to gate here (the
   # PR-level pull_request_target run already enforced acceptance); the job
@@ -149,33 +149,44 @@ jobs:
               return;
             }
 
-            // ---- 2) issue_comment: record a signature if the phrase matches ---
+            // Helper: record a new signature and commit it.
+            async function recordSignature() {
+              const store = gate.readStore();
+              const sig = gate.makeSignature({
+                login: author, name: authorName, pr: prNumber,
+                commitSha: headSha, claVersion,
+              });
+              const { store: next, added } = gate.appendSignature(store, sig);
+              if (added) {
+                gate.writeStore(next);
+                execFileSync("git", ["config", "user.name", "github-actions[bot]"]);
+                execFileSync("git", ["config", "user.email",
+                  "41898282+github-actions[bot]@users.noreply.github.com"]);
+                execFileSync("git", ["add", ".github/cla/signatures.json"]);
+                execFileSync("git", ["commit", "-m",
+                  `chore(cla): record CLA acceptance for @${author} (PR #${prNumber})`]);
+                execFileSync("git", ["push", "origin",
+                  `HEAD:${context.payload.repository.default_branch}`]);
+                core.info(`Recorded CLA signature for @${author}.`);
+              }
+              await setStatus("success", "CLA accepted and recorded.");
+            }
+
+            // ---- 2a) PR body checkbox (PR template) — checked on open or edit -
+            if (context.eventName === "pull_request_target" &&
+                gate.prBodyMatchesCheckbox(pr.body)) {
+              await recordSignature();
+              return;
+            }
+
+            // ---- 2b) issue_comment: record a signature if the phrase matches ---
             if (context.eventName === "issue_comment") {
               const commenter = context.payload.comment.user.login;
               const body = context.payload.comment.body;
               const commenterIsAuthor =
                 commenter.toLowerCase() === author.toLowerCase();
               if (commenterIsAuthor && gate.commentMatchesPhrase(body)) {
-                const store = gate.readStore();
-                const sig = gate.makeSignature({
-                  login: author, name: authorName, pr: prNumber,
-                  commitSha: headSha, claVersion,
-                });
-                const { store: next, added } = gate.appendSignature(store, sig);
-                if (added) {
-                  gate.writeStore(next);
-                  // Commit the appended signature to the base repo.
-                  execFileSync("git", ["config", "user.name", "github-actions[bot]"]);
-                  execFileSync("git", ["config", "user.email",
-                    "41898282+github-actions[bot]@users.noreply.github.com"]);
-                  execFileSync("git", ["add", ".github/cla/signatures.json"]);
-                  execFileSync("git", ["commit", "-m",
-                    `chore(cla): record CLA acceptance for @${author} (PR #${prNumber})`]);
-                  execFileSync("git", ["push", "origin",
-                    `HEAD:${context.payload.repository.default_branch}`]);
-                  core.info(`Recorded CLA signature for @${author}.`);
-                }
-                await setStatus("success", "CLA accepted and recorded.");
+                await recordSignature();
                 return;
               }
               // A non-matching comment on an unsigned PR: re-evaluate below.
@@ -204,14 +215,16 @@ jobs:
                   `Thanks for your contribution, @${author}! Before this PR can be ` +
                   `merged we need a recorded acceptance of our ` +
                   `[Contributor License Agreement](../blob/${context.payload.repository.default_branch}/CLA.md).\n\n` +
-                  `Please post a comment on this PR with **exactly** this phrase:\n\n` +
-                  `> ${gate.AGREEMENT_PHRASE}\n\n` +
+                  `If you have already opened the PR, edit the PR description and check the box:\n\n` +
+                  `- [x] ${gate.AGREEMENT_PHRASE}\n\n` +
+                  `If the box is not in your PR description (old PR), post a new comment:\n\n` +
+                  `\`\`\`\n- [x] ${gate.AGREEMENT_PHRASE}\n\`\`\`\n\n` +
                   `Your acceptance will be recorded in ` +
                   `\`.github/cla/signatures.json\` and the \`cla-check\` will turn green.`,
               });
             }
             await setStatus(
               "failure",
-              `Awaiting CLA acceptance — comment "${gate.AGREEMENT_PHRASE}".`,
+              `Awaiting CLA acceptance — check [x] box or post the phrase in a new comment.`,
             );
             core.setFailed(`@${author} has not accepted the CLA (version ${claVersion}).`);


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with an unchecked `- [ ] I have read and agree to the CLA` checkbox so contributors tick it before clicking "Create pull request" — no phrase-typing required
- Extends `cla-gate.mjs` with `prBodyMatchesCheckbox()` and updates `commentMatchesPhrase()` to also accept the `[x] phrase` checkbox format (case-insensitive, optional `- ` / `* ` prefix)
- Updates `cla-check.yml`: checks PR body first (section 2a), then comment phrase (2b); adds `edited` to both triggers so ticking the box on an already-open PR fires the gate automatically

## Test plan

- [x] `node --test .github/cla/cla-gate.test.mjs` — 11/11 pass (covers `prBodyMatchesCheckbox`, checkbox `commentMatchesPhrase`, exact-phrase, bots, hasSigned, appendSignature, makeSignature, computeClaVersion)
- [ ] Open a test PR and verify the checkbox auto-clears `cla-check` on submit
- [ ] Verify unchecked box leaves the check pending

Closes #1660

🤖 Generated with [Claude Code](https://claude.com/claude-code)