### PR TITLE
docs(#1693): mark issue done — fix landed on main

### DIFF
--- a/plan/issues/1693-multi-funcref-dispatch-return-type-coercion-gap.md
+++ b/plan/issues/1693-multi-funcref-dispatch-return-type-coercion-gap.md
@@ -1,9 +1,10 @@
 ---
 id: 1693
 title: "multi-funcref-dispatch (#1131) missing return-type coercion — emits invalid Wasm on full-module axios/utils.js (mis-presented as `&&` fallthru bug)"
-status: ready
+status: done
 created: 2026-05-28
 updated: 2026-05-28
+completed: 2026-05-28
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -14,7 +15,7 @@ goal: npm-library-support
 sprint: Backlog
 parent: 1571
 related: [191, 1131, 1571, 1690, 1558]
-note: "Carved out of task #191 (the `&&` fallthru widening proposal) after dev-1655 investigation showed the minimal `&&` snippet validates and only the full-module compile fails. The `&&` lowering at logical-ops.ts:55-92 is correct; the bug is in the closure-dispatch trampoline."
+note: "Carved out of task #191 (the `&&` fallthru widening proposal) after dev-1655 investigation showed the minimal `&&` snippet validates and only the full-module compile fails. The `&&` lowering at logical-ops.ts:55-92 is correct; the bug is in the closure-dispatch trampoline. RESOLVED on main: a72cb9002 added the missing 4th-case coercion at calls.ts:7945-7969 (multi-funcref dispatch ladder); 75bc8bbfd narrowed it to numeric-primitive pairs only ({i32,f64,i64}) after the catch-all broke 8 equivalence tests on ref/ref_null/externref combinations. tests/issue-1693.test.ts covers 3 scenarios (single-candidate, multi-candidate diverging kinds, full axios/lib/utils.js) and passes."
 ---
 # #1693 — multi-funcref-dispatch trampoline misses return-type coercion (full-module axios/utils.js)
 


### PR DESCRIPTION
## Summary

Bookkeeping: flip `plan/issues/1693-multi-funcref-dispatch-return-type-coercion-gap.md` frontmatter from `status: ready` to `status: done` with `completed: 2026-05-28`. The fix actually shipped via two commits and is already on main:

- a72cb9002 fix(#1693): add missing return-type coercion for multi-funcref dispatch
- 75bc8bbfd fix(#191): narrow multi-funcref dispatch return-coerce to numeric pairs only

The issue file was never flipped post-merge — this PR closes that loop. No code changes; doc-only.

## Test plan

- [x] tests/issue-1693.test.ts — 3/3 pass (single-candidate, multi-candidate diverging i32/f64/externref, full axios/lib/utils.js compileProject)
- [x] No source files modified — codegen unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)