### PR TITLE
docs(#1340): [ESCALATED-NEEDS-SPEC] real cause not wasm_compile — function.prototype host-bridge bug

### DIFF
--- a/plan/issues/1340-spec-gap-iterator-helpers-wasm-compile.md
+++ b/plan/issues/1340-spec-gap-iterator-helpers-wasm-compile.md
@@ -1,9 +1,9 @@
 ---
 id: 1340
 title: "spec gap: Iterator.prototype helpers wasm_compile errors (89 of 245 fails)"
-status: ready
+status: blocked
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-28
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -14,6 +14,7 @@ goal: spec-completeness
 sprint: 50
 parent: 1328
 related: 1320, 1323
+blocked_on: architect-spec
 ---
 # #1340 — Iterator.prototype helper methods: wasm_compile failures
 
@@ -78,3 +79,100 @@ benchmarks.
 - `test262/test/built-ins/Iterator/prototype/drop/argumenttype-undefined.js`
 - `test262/test/built-ins/Iterator/prototype/map/callable-fn.js`
 - `test262/test/built-ins/Iterator/prototype/flatMap/inner-generator-throw.js`
+
+## 2026-05-28 (developer) — recon + escalation
+
+**Baseline** (test262-current.jsonl, main HEAD 38682fdbd):
+- 134 pass / 239 fail (36% pass-rate, basically unchanged from sprint-50 numbers)
+- Error-category split: 121 assertion_fail, **88 wasm_compile**, 12 runtime_error,
+  8 other, 5 type_error, 3 null_deref, 2 range_error.
+
+**The "88 wasm_compile" classification is misleading** — every one of the
+sampled entries is a runtime `"<X> is not a function"` TypeError (drop/take/
+map/filter/flatMap/some/every/find/forEach/reduce/toArray), not a Wasm
+validator failure. The runner's `error_category` bucketing groups these under
+`wasm_compile` because the test fails before any assertion runs. A direct
+probe (compile + instantiate, no runner) of 110 sampled files in
+`Iterator/prototype/{drop,take,map,filter,flatMap,some,every,find,forEach,reduce,toArray}`
+showed **0 compile failures** — all 110 compile cleanly under `--target js-host`.
+
+So this is not the IR-lowering / `(ref $Iterator)` type-mismatch hypothesis
+in the sprint-50 spec. The compiler doesn't have an "Iterator helper" code
+path at all — the runtime currently leans on `globalThis.Iterator.prototype`
+(Node 25 provides drop/take/map/etc natively).
+
+**Real root cause — host-bridged Iterator.prototype isn't reachable from
+compiled code.** Reduced repro (no test262 harness):
+```ts
+function Iterator(this: any): void {}
+(Iterator as any).prototype =
+  Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+
+export function test(): number {
+  const p = (Iterator as any).prototype;
+  if (p == null) return 81;          // <-- this returns 81
+  const t = (p as any).take;
+  if (typeof t !== "function") return 83;
+  return 1;
+}
+```
+Returns `81` — the assignment to `(Iterator as any).prototype` does not
+round-trip: reading `Iterator.prototype` back returns null. So even before
+we get to "does our property-read traverse Node's `%IteratorPrototype%`?"
+the *write* of `.prototype` on a function-typed compiler-declared local is
+not preserved. This is the shape the test262 runner shim relies on
+(`tests/test262-runner.ts:1705-1708`), so every test that uses `Iterator.X`
+on a sample value crashes with `"X is not a function"`.
+
+**A second, separate defect surfaced**: simplifying the assignment to a
+host-iterable target (`(Iterator as any).prototype = [][Symbol.iterator]();`)
+crashes the module *at init* with `[object Object] is not iterable` from
+`src/runtime.ts:7016` — `__iterator` is being called on the RHS, suggesting
+the assignment is being misrouted to a destructuring/iteration path. Same
+class of bug — assignment-target evaluation on a host externref captured
+into a function's `.prototype` slot is going through the wrong codegen
+arm.
+
+**Why this needs architect spec**, not a localised dev fix:
+1. The issue's "Approach" (polymorphic dispatch at call site with
+   `ref.test $Iterator`) doesn't address the actual defect. The compiler
+   has no Iterator helper code path. Writing one is the architect's
+   call (mirrors Wasm-native Map/Set in #1103/#1105).
+2. The reproducer is a *property-write semantics bug* on the
+   compiler-declared `function Iterator()`'s `.prototype` slot — it
+   touches function-object boxing, assignment-target resolution, and
+   the staticProps global path. Fixing it locally risks the same
+   `__sset_` regression class that bit #1630/PR #781.
+3. Alternative narrow fix — extend the runtime polyfill
+   (`_installIteratorHelperPolyfills` in `src/runtime.ts:480`) to install
+   the 11 missing helpers on `%IteratorPrototype%` directly — works
+   without touching codegen, but does **not** help the failing tests
+   because those tests read `Iterator.prototype.X` through the runner's
+   shimmed `Iterator` function, and that path is the one that's broken.
+   Installing on `globalThis.Iterator.prototype` is irrelevant when the
+   compiler-side `Iterator` binding can't see it.
+4. Acceptance criterion 3 ("wasm_compile <10") is **already roughly true
+   in spirit** — the 88 entries are not Wasm-validator failures. Better
+   target: pass-rate ≥65% on the cluster. That requires either (a) fixing
+   the function `.prototype = ...` host-bridge round-trip, or (b) carving
+   out a special compiler path that recognises the runner shim pattern
+   and emits a direct global-iterator-prototype lookup.
+
+**Recommendation**: architect spec covering option (a) — function
+`.prototype` writebacks when RHS is a host externref. Once that's stable,
+re-run the cluster; remaining residuals (true assertion mismatches) become
+the dev-sized follow-ups (~120 fails, much narrower scope per-test).
+
+**Worktree**: `/workspace/.claude/worktrees/issue-1340-iterator-helpers`
+(branch `issue-1340-iterator-helpers`, only this doc commit so far).
+No code changes.
+
+**Related upstream defects**:
+- `#1320` — Array.from iterator bridge (also blocked on architect)
+- `#1665` — native generators (architect-blocked on shared $Iterator design)
+- `#1644` — i64-bigint-brand (architect representation spec)
+
+These three plus #1340 share a common need: a typed bridge between
+compiler-declared "iterator-shaped" values and host iterator
+prototypes. A combined spec is more efficient than four sequential
+ones.


### PR DESCRIPTION
## Summary

- Recon of #1340 against current main (38682fdbd) shows the 88 "wasm_compile" errors are **runtime "X is not a function" TypeErrors**, NOT Wasm validator failures.
- All 110 sampled `Iterator/prototype/{drop,take,map,filter,flatMap,some,every,find,forEach,reduce,toArray}` files compile cleanly via direct `compile()` calls.
- Real defect: function `.prototype = host-externref` assignment does not round-trip. Reading `Iterator.prototype` back returns null. The test262 runner's Iterator shim depends on exactly this pattern, so every test fails before any assertion runs.
- Original issue's "Approach" (polymorphic dispatch with `ref.test \$Iterator`) addresses a hypothetical that isn't real — compiler has no Iterator helper code path.
- Escalating to architect: this needs a typed-bridge spec for compiler-declared "iterator-shaped" values vs host iterator prototypes. Joint with #1320, #1665, #1644.

## Test plan

- [x] Recon repro reduced to 9 lines (function `Iterator()` + `.prototype` = `[][Symbol.iterator]()`'s proto chain)
- [x] Confirmed 0/110 sample files have actual `wasm_compile` failures
- [x] Confirmed runner-side path is what's failing (`runTest262File` returns "take is not a function in test() at source L4")
- [x] No code changes — docs-only PR documents findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)