### PR TITLE
fix(#1690): walk liveBodies during module-global index shift

### DIFF
--- a/plan/issues/1690-acorn-isinastralset-global-array-f64-mismatch.md
+++ b/plan/issues/1690-acorn-isinastralset-global-array-f64-mismatch.md
@@ -1,9 +1,10 @@
 ---
 id: 1690
 title: "Stress test: compile acorn.mjs — invalid Wasm in isInAstralSet (f64 op reads global array ref)"
-status: ready
+status: done
 created: 2026-05-27
-updated: 2026-05-27
+updated: 2026-05-28
+completed: 2026-05-28
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -14,6 +15,149 @@ goal: real-world-compat
 sprint: Backlog
 related: [1679, 1677, 1666, 1618, 1314]
 note: "Surfaced behind #1679. With #1679's `new this(...)` blocker gone on current main (e622751f7), acorn.mjs now compiles to success=true with 0 errors but emits INVALID Wasm — the next blocker. Distinct from #1679 (which is codegen-acceptance only)."
+---
+
+## Root cause + fix (2026-05-28)
+
+The hypothesis in the issue body was almost right (an index-shift
+bookkeeping miscount) but the location was different from #1618/#1677/#1314.
+The `global.get` index passed to `f64.lt` was NOT computed from a stale
+function index or a stale late-import shift — it was a stale
+**module-global** index read out of `ctx.moduleGlobals` AFTER
+`fixupModuleGlobalIndices` had already moved it. The walker simply could
+not reach the instruction.
+
+**Minimal repro** (see `tests/issue-1690.test.ts` — `compile()` returns
+`success=true` but `WebAssembly.compile()` rejects the binary):
+
+```js
+for (var i = 0, list = [1, 2, 3]; i < list.length; i += 1) {
+  var x = list[i];
+}
+
+function f(set) {
+  var pos = 0;
+  for (var i = 0; i < set.length; i += 2) {
+    pos += set[i];
+    if (pos > 10) return false;
+    pos += set[i + 1];
+    if (pos >= 20) return true;
+  }
+  return false;
+}
+```
+
+The top-level `for (var i = 0, list = [...])` registers `i` and `list` as
+**module globals** (`__mod_i`, `__mod_list`) via the top-level `var`
+for-init path that converts to `global.set`. The function-local `var i`
+inside `f` then ALSO resolves to `__mod_i` (a separate but pre-existing
+scope leak — `compileForStatement` doesn't check `fctx.localMap`/scope
+before reaching for `moduleGlobals`). That scope leak alone would have been
+a correctness bug at runtime, but a WORSE bug fires first: invalid Wasm at
+validation time.
+
+### What was actually broken
+
+`compileForStatement` (`src/codegen/statements/loops.ts`) used a **manual
+body swap** to compile the loop condition into a fresh array, then copied
+the result into a local `condInstrs` variable:
+
+```ts
+const condInstrs: Instr[] = [];
+if (stmt.condition) {
+  const condBody = fctx.body;
+  fctx.body = [];                    // unregistered fresh array
+  compileExpression(ctx, fctx, stmt.condition);
+  ensureI32Condition(fctx, condType, ctx);
+  fctx.body.push({ op: "i32.eqz" });
+  fctx.body.push({ op: "br_if", depth: 1 });
+  condInstrs.push(...fctx.body);     // copies refs into a detached array
+  fctx.body = condBody;              // detach: condInstrs is now orphaned
+}
+```
+
+The same pattern was used for `incrInstrs` a few lines below.
+
+After this block `condInstrs` holds references to Instr objects that are
+**not** reachable from `fctx.body`, `fctx.savedBodies`, `ctx.funcStack`,
+`ctx.parentBodiesStack`, or `ctx.liveBodies`. They sit in a JS local
+variable until the loop is assembled and pushed back into `fctx.body` at
+the end of `compileForStatement`.
+
+During the loop body compilation (which happens in the middle of that
+window), nested codegen routinely fires `addStringConstantGlobal` — e.g.
+for `"TypeError: Cannot access property on null or undefined at L:C"`
+strings emitted on every null-check arm. Each such call inserts an import
+global, calls `fixupModuleGlobalIndices(ctx, threshold, +1)` to shift every
+`global.get`/`global.set` index >= threshold by +1, and `shiftMap` to bump
+every entry in `ctx.moduleGlobals` similarly.
+
+`fixupModuleGlobalIndices` walks `mod.functions[*].body`,
+`currentFunc.body+savedBodies`, `funcStack[*].body+savedBodies`,
+`parentBodiesStack`, `pendingInitBody`, and `mod.globals[*].init`. It did
+**not** walk `ctx.liveBodies`, and `condInstrs`/`incrInstrs` are not in any
+of the other roots. So the map entry for `__mod_i` shifts from N → N+1,
+but the already-emitted `global.get N`/`global.set N` instr objects sitting
+in `condInstrs` are left untouched.
+
+Net result for `isInAstralSet`: the condition `i < set.length` was emitted
+when `moduleGlobals.get("i") === 2472`. Body compilation added two
+string-constant globals (the TypeError messages on the null-check arms),
+shifting `moduleGlobals.get("i")` to 2474. The init `i = 0` and the
+incrementor `i += 2` (emitted later in compile order) used 2474 (correct),
+but the cond's stale `global.get 2472` now pointed at
+`__mod_unicodeScriptValues` — a `(ref null 57)` array global. The
+validator saw `f64.lt` consuming a ref operand and rejected the module.
+
+The bug is the SAME class as the function-index-shift gap that #1384
+closed (unreached `cbFctx.body` / `liftedFctx.body`) — the fix used
+`liveBodies` as the catch-all root for orphaned-but-live instruction
+buffers. This fix extends the same mechanism to the module-global walker.
+
+### Fix (two changes)
+
+1. **`src/codegen/statements/loops.ts`** — register the temporary
+   `condInstrs` and `incrInstrs` arrays in `ctx.liveBodies` for the window
+   they sit detached from `fctx.body`, and assign `fctx.body = condInstrs`
+   directly instead of copying via spread (so emitted instrs land in the
+   tracked array, not a throwaway intermediate). Same fix applied to
+   `compileDoWhileStatement` for its detached cond buffer.
+
+2. **`src/codegen/registry/imports.ts`** — `fixupModuleGlobalIndices` now
+   walks `ctx.liveBodies` alongside the other roots. This brings the
+   module-global walker in line with `shiftLateImportIndices` (function
+   index shifts), which has walked `liveBodies` since #1384.
+
+### Verification
+
+- `tests/issue-1690.test.ts` — three focused tests covering the for-loop,
+  incrementor, and do-while paths. All pre-fix repros now produce a binary
+  that passes `WebAssembly.compile()`.
+- The original f64.lt validation failure in `isInAstralSet` is gone:
+  `WebAssembly.compile()` now gets past `isInAstralSet` and reports a
+  DIFFERENT failure further along (`any.convert_extern[0] expected type
+  externref, found ref.cast null of type (ref null N)` inside
+  `__fnctor_Parser_new`). That's a separate, unrelated codegen bug in
+  class ctor wrappers — not in scope for #1690 and worth its own issue.
+- Scoped existing tests (loops, module-globals, for-of, arguments-loops):
+  failure pattern identical before and after the fix (the seven
+  `string_constants` instantiate failures are pre-existing harness issues,
+  not regressions).
+
+### Out of scope (worth their own issues)
+
+- **`__fnctor_Parser_new` `any.convert_extern` type mismatch** — newly
+  visible after this fix unblocks `isInAstralSet`. Validator sees
+  `any.convert_extern` consuming a `ref.cast null` of class-struct type
+  instead of an externref. Class constructor wrapper lowering issue,
+  unrelated to global-index shifts.
+- **The `compileForStatement` scope leak** —
+  `ctx.moduleGlobals.get(name)` is consulted in the for-init path
+  *without* first checking `fctx.localMap.has(name)`. Function-local
+  `var i` is currently treated as the top-level `__mod_i` if a same-named
+  top-level for-init exists. The runtime semantics are wrong (the function
+  clobbers a module global instead of using its own slot) but they no
+  longer produce invalid Wasm. Track separately.
 ---
 # #1690 — acorn.mjs compiles but emits invalid Wasm: `f64.lt` reads a global array ref in `isInAstralSet`
 

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -212,6 +212,20 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
     shifted.add(ctx.pendingInitBody);
   }
 
+  // (#1690) Walk detached instruction buffers that codegen has parked in
+  // `liveBodies` while they sit outside `fctx.body`/savedBodies. The for-loop
+  // condition/incrementor buffers (see `compileForStatement`) live here for the
+  // window between when they're compiled and when they're spliced into the
+  // assembled loop body — without this walk, an `addStringConstantGlobal` fired
+  // from body compilation in the middle of that window leaves their stale
+  // `global.get`/`global.set` indices pointing one or more globals too low.
+  for (const lb of ctx.liveBodies) {
+    if (!shifted.has(lb)) {
+      shiftGlobalIndices(lb);
+      shifted.add(lb);
+    }
+  }
+
   for (const g of ctx.mod.globals) {
     if (g.init) shiftGlobalIndices(g.init);
   }

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -754,15 +754,21 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   fctx.continueStack.push(0);
 
   // Condition (inside $loop, before $continue block)
+  // (#1690) Register condInstrs in liveBodies before any nested compilation
+  // can fire an `addStringConstantGlobal` whose fixup walker would otherwise
+  // miss this detached buffer. The cond instrs live outside `fctx.body`
+  // (which is the loop body buffer registered via savedBodies) for the entire
+  // window from cond compilation through body+incrementor compilation until
+  // the assembled loop is pushed back into fctx.body below.
   const condInstrs: Instr[] = [];
+  ctx.liveBodies.add(condInstrs);
   if (stmt.condition) {
     const condBody = fctx.body;
-    fctx.body = [];
+    fctx.body = condInstrs;
     const condType = compileExpression(ctx, fctx, stmt.condition);
     ensureI32Condition(fctx, condType, ctx);
     fctx.body.push({ op: "i32.eqz" });
     fctx.body.push({ op: "br_if", depth: 1 }); // break: exits $break (depth 1 from $loop body)
-    condInstrs.push(...fctx.body);
     fctx.body = condBody;
   }
 
@@ -834,12 +840,15 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   fctx.safeIndexedArrays = savedSafeIndexed;
 
   // Incrementor (inside $loop, after $continue block)
-  fctx.body = [];
+  // (#1690) Same liveBodies registration as condInstrs above: the incrementor
+  // buffer is detached until the assembled loop is pushed below.
+  const incrInstrs: Instr[] = [];
+  ctx.liveBodies.add(incrInstrs);
+  fctx.body = incrInstrs;
   if (stmt.incrementor) {
     const resultType = compileExpression(ctx, fctx, stmt.incrementor);
     if (resultType !== null) fctx.body.push({ op: "drop" });
   }
-  const incrInstrs = fctx.body;
 
   fctx.breakStack.pop();
   fctx.continueStack.pop();
@@ -898,6 +907,12 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       },
     ],
   });
+
+  // (#1690) The cond/incr Instr objects are now reachable via fctx.body →
+  // assembled loop. The condInstrs/incrInstrs arrays themselves are no longer
+  // needed by the walker (their contents were spread into `loopBody`).
+  ctx.liveBodies.delete(condInstrs);
+  ctx.liveBodies.delete(incrInstrs);
 
   // #1589: For pre-emptively boxed `var`/outer-scope names, write the final
   // ref-cell value back to the original unboxed local so post-loop reads of
@@ -996,11 +1011,14 @@ export function compileDoWhileStatement(ctx: CodegenContext, fctx: FunctionConte
   const bodyInstrs = fctx.body;
 
   // Compile condition — true means continue looping
-  fctx.body = [];
+  // (#1690) Same liveBodies registration as compileForStatement: the cond
+  // buffer is detached from fctx.body until the assembled loop is pushed.
+  const condInstrs: Instr[] = [];
+  ctx.liveBodies.add(condInstrs);
+  fctx.body = condInstrs;
   const condType = compileExpression(ctx, fctx, stmt.expression);
   ensureI32Condition(fctx, condType, ctx);
   fctx.body.push({ op: "br_if", depth: 0 }); // restart $loop if true
-  const condInstrs = fctx.body;
 
   fctx.breakStack.pop();
   fctx.continueStack.pop();
@@ -1034,6 +1052,9 @@ export function compileDoWhileStatement(ctx: CodegenContext, fctx: FunctionConte
       },
     ],
   });
+
+  // (#1690) The cond Instr objects are now reachable via fctx.body → loop.
+  ctx.liveBodies.delete(condInstrs);
 }
 
 function compileForOfDestructuring(

--- a/tests/issue-1690.test.ts
+++ b/tests/issue-1690.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1690 — for-loop condition/incrementor buffers were detached from any
+ * walker-reachable location for the window between when they're compiled and
+ * when they're spliced into the assembled loop body. Body compilation often
+ * triggers `addStringConstantGlobal` (e.g., a null-check error message),
+ * which shifts module-global indices and updates the moduleGlobals map.
+ * Because the cond/incr buffers were unreachable, their `global.get`/`global.set`
+ * indices were left stale-low, so a later read of a module-global variable
+ * (`__mod_i`, `__mod_list`, etc.) silently pointed at the global that
+ * USED to occupy that slot — frequently a `(ref null N)` array global where an
+ * f64 was expected, producing invalid Wasm at `f64.lt`/`f64.add` consumers.
+ *
+ * This surfaced compiling acorn.mjs (#1690 issue file) with the error
+ *   "f64.lt[0] expected type f64, found global.get of type (ref null N)"
+ * inside `isInAstralSet`. Reduced to a minimal repro: a top-level
+ * `for (var i = 0, list = [...]; ...)` registers `i` and `list` as module
+ * globals, then a function-local `for (var i = 0; i < set.length; ...)` whose
+ * body emits null-check errors triggers the shift mid-loop.
+ *
+ * Fix: register the temporary cond/incr buffers in `ctx.liveBodies` for the
+ * window they sit outside `fctx.body`, and have `fixupModuleGlobalIndices`
+ * walk `liveBodies` (parallel to the existing function-index shift walker).
+ */
+describe("#1690 — for-loop global-index shift during body compilation", () => {
+  it("minimal repro: function-local for-loop after top-level for-loop", () => {
+    const src = [
+      "for (var i = 0, list = [1, 2, 3]; i < list.length; i += 1) {",
+      "  var x = list[i];",
+      "}",
+      "",
+      "function f(set) {",
+      "  var pos = 0;",
+      "  for (var i = 0; i < set.length; i += 2) {",
+      "    pos += set[i];",
+      "    if (pos > 10) return false;",
+      "    pos += set[i + 1];",
+      "    if (pos >= 20) return true;",
+      "  }",
+      "  return false;",
+      "}",
+    ].join("\n");
+
+    const r = compile(src, { fileName: "issue-1690.mjs" });
+    expect(r.success).toBe(true);
+    expect(r.binary).toBeDefined();
+    // The smoking-gun assertion — the bug manifested as an invalid Wasm
+    // module that compile() accepted (success=true) but WebAssembly.compile
+    // rejected. The fix must keep WebAssembly.compile happy.
+    return WebAssembly.compile(r.binary as BufferSource).then((mod) => {
+      expect(mod).toBeDefined();
+    });
+  });
+
+  it("incrementor expression with module-global aliasing", () => {
+    // Variant covering the `incrInstrs` half of the fix: the incrementor
+    // buffer is also detached during cond+body compilation.
+    const src = [
+      "var counter = 0;",
+      "for (var i = 0; i < 3; i = i + 1) { counter = counter + 1; }",
+      "",
+      "function g(arr) {",
+      "  var sum = 0;",
+      "  for (var i = 0; i < arr.length; i += 1) {",
+      "    sum += arr[i];",
+      "    if (sum > 100) return -1;",
+      "  }",
+      "  return sum;",
+      "}",
+    ].join("\n");
+
+    const r = compile(src, { fileName: "issue-1690b.mjs" });
+    expect(r.success).toBe(true);
+    return WebAssembly.compile(r.binary as BufferSource).then((mod) => {
+      expect(mod).toBeDefined();
+    });
+  });
+
+  it("do-while condition buffer follows the same fix", () => {
+    // The same detached-buffer pattern exists in compileDoWhileStatement
+    // (the cond is compiled into a fresh array, then spliced after the
+    // body). This variant exercises that path.
+    const src = [
+      "var moduleI = 0;",
+      "var moduleList = [1, 2, 3];",
+      "",
+      "function h(set) {",
+      "  var i = 0;",
+      "  var sum = 0;",
+      "  do {",
+      "    sum += set[i];",
+      "    i += 1;",
+      "  } while (i < set.length);",
+      "  return sum;",
+      "}",
+    ].join("\n");
+
+    const r = compile(src, { fileName: "issue-1690c.mjs" });
+    expect(r.success).toBe(true);
+    return WebAssembly.compile(r.binary as BufferSource).then((mod) => {
+      expect(mod).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes invalid Wasm in `isInAstralSet` when compiling acorn.mjs: validator rejected `f64.lt` consuming a `(ref null 57)` global where an `f64` was expected.
- Root cause: for-loop `condInstrs` / `incrInstrs` buffers sit detached from `fctx.body` / `savedBodies` / `liveBodies` while the body is compiled. Body codegen routinely calls `addStringConstantGlobal`, which shifts `ctx.moduleGlobals` but couldn't reach those detached buffers' already-emitted `global.get N` instructions — leaving them stale-low.
- Two surgical changes: register the detached cond/incr arrays in `ctx.liveBodies` (loops.ts + do-while), and have `fixupModuleGlobalIndices` walk `ctx.liveBodies` (parallel to the function-index shift walker, which has walked it since #1384).

## Test plan

- [x] `tests/issue-1690.test.ts` — 3 focused repros (for-loop with module-global aliasing, incrementor expression, do-while) all assert `WebAssembly.compile()` accepts the binary.
- [x] Scoped regression sweep (loop tests, module-globals, for-of, arguments-loops): identical failure pattern before/after — no new regressions.
- [x] acorn.mjs compile: original `isInAstralSet` `f64.lt` error gone; validator now gets past it. (A different downstream failure surfaces in `__fnctor_Parser_new` — class-ctor wrapper bug, unrelated to global-index shifts, worth its own issue. Documented in the issue file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)