### PR TITLE
fix(#820m): widen class-constructor-typed object-literal fields to externref

### DIFF
--- a/plan/issues/820m-namedevaluation-fn-name-class-and-proto-setter.md
+++ b/plan/issues/820m-namedevaluation-fn-name-class-and-proto-setter.md
@@ -1,7 +1,7 @@
 ---
 id: 820m
 title: "NamedEvaluation: anonymous class/function value not named from binding key (~12 fails, fn-name-class + __proto__-fn-name)"
-status: blocked
+status: in-progress
 created: 2026-05-28
 updated: 2026-05-28
 priority: medium
@@ -216,3 +216,79 @@ all of them.
 No code change landed under this task; needs architect spec before
 implementation. The probe files (`.tmp/probe-820m-*.ts`,
 `.tmp/run-*.mts`) are gitignored and used only for the investigation.
+
+## Implementation 2026-05-28 (senior-developer)
+
+### Landed: Slice 1 only (Phase A value retention)
+
+Implemented a class-constructor-typed field-type widening in
+`ensureStructForType` (src/codegen/index.ts, right after the existing
+empty-`{}` / `valueOf` widenings). For an object-literal property whose
+TS-resolved type has `getConstructSignatures().length > 0` and
+`getCallSignatures().length === 0` (i.e. it's a `typeof <anonymous class>`
+constructor type), `resolveWasmType` originally returned `ref <instance
+struct>`. The struct cast on field assignment then dropped the value to
+`ref.null`. We now widen such field types to `externref`, preserving the
+closure-struct externref that `compileClassExpression` emits via
+`extern.convert_any`.
+
+Verified with `.tmp/probe-820m.ts`:
+```ts
+const obj: any = { id: class {} };
+return obj.id;
+// Before: RESULT=null
+// After:  RESULT=[Object: null prototype] {} (closure externref retained)
+```
+
+Non-regression spot checks:
+- typed class methods (`class Foo { hello(){return 42} }; new Foo().hello()`) → 42
+- typed class instance in object literal (`{ f: new Foo() }; o.f.x`) → 7
+
+### Phase B (NamedEvaluation `.name` propagation): DEFERRED
+
+While implementing Slice 1 the architect's Phase B turned out to require
+more plumbing than its spec described:
+
+1. `ctx.functionNameMap` is **write-only** in the current codebase — no
+   read path consumes it for runtime `.name` resolution. The architect's
+   spec assumed it was the runtime channel; it isn't.
+2. Class `.name` is statically resolved at the property-access call site
+   (`src/codegen/property-access.ts:1780-1879`) only when the receiver
+   expression is an identifier or a property access AND the receiver's
+   TS type has call/construct signatures.
+3. For `o.id.name` where `o: any`, the receiver `o.id` is a
+   PropertyAccessExpression with 0 call/construct sigs → the static
+   `.name` peephole doesn't fire.
+4. The runtime closure-struct externref does not expose a `name` property
+   to the host (no `__set_function_name`-style writeback exists), so
+   `__extern_get(.name)` returns `undefined`.
+
+A proper Phase B therefore requires either:
+- A new `__set_function_name` host writeback called at class-value
+  emission time with the binding-key hint (touches the host-import
+  surface, runtime, and `compileClassExpression`); OR
+- Extending the static `.name` peephole in property-access.ts to
+  recognise `propertyAccess.name` when the outer object is a struct-typed
+  widened externref field whose anon class was registered under a
+  binding-key hint (requires new ctx state mapping the externref field →
+  nameHint at the per-property level).
+
+Either path is a self-contained ~50–100 LOC change with its own test
+matrix and risks. The architect's spec budgeted Phase B as "low-risk,
+30–60 min" but that estimate assumed `functionNameMap` was already
+plumbed end-to-end. Carving as **#820m-b2** for follow-up.
+
+### Test262 impact (expected)
+
+Slice 1 alone changes the failure mode of the target tests from
+`type_error: Cannot access property on null or undefined` (today) to
+either pass (if subsequent assertions pass without the `.name` check) or
+`assertion failure` on the `.name === expected` check. Net impact will
+be visible after CI's test262 sharded run; Phase B is required to fully
+resolve the 7 named tests.
+
+### Files changed
+
+- `src/codegen/index.ts` — single ~10-line widening block at the per-prop
+  loop of `ensureStructForType`, right after the existing
+  `valueOf`/`toString` eqref widening.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7929,6 +7929,25 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
     if (wasmType.kind === "externref" && callSigs.length > 0 && (prop.name === "valueOf" || prop.name === "toString")) {
       wasmType = { kind: "eqref" };
     }
+    // (#820m) Anonymous/named class expression as property value: TS infers
+    // the property type as `typeof <anonClass>` whose construct signature's
+    // `.prototype` walks back to the instance struct, so resolveWasmType
+    // hands us `ref <instance struct>`. But compileClassExpression emits an
+    // externref (closure-struct via extern.convert_any), and the struct cast
+    // on field assignment drops the value to ref.null. Widen any
+    // construct-signature-only property type (no call signatures) to
+    // externref so the closure ref is retained verbatim. Mirrors the
+    // empty-`{}` widening just above.
+    {
+      const constructSigs = propType.getConstructSignatures();
+      if (
+        constructSigs.length > 0 &&
+        callSigs.length === 0 &&
+        (wasmType.kind === "ref" || wasmType.kind === "ref_null")
+      ) {
+        wasmType = { kind: "externref" };
+      }
+    }
     fields.push({ name: prop.name, type: wasmType, mutable: true });
     if (callSigs.length > 0) {
       const sig = callSigs[0]!;

--- a/tests/issue-820m.test.ts
+++ b/tests/issue-820m.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #820m Phase A (Slice 1) — class-as-value field-type widening.
+// `{ id: class {} }` inside a function body used to drop the class value to
+// null because resolveWasmType picked a ref-to-instance type for the field,
+// and the externref produced by compileClassExpression silently coerced to
+// ref.null. Slice 1 widens construct-signature-only property types to
+// externref in ensureStructForType so the closure-struct externref is
+// retained verbatim.
+//
+// The .name propagation half (Phase B) is a separate carve-out — the
+// closure-struct externref does not yet carry an ES `.name` property.
+
+async function runWithCheck<T>(src: string, check: (o: unknown) => T): Promise<T> {
+  const r = compile(src, { fileName: "test.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown> & {
+    env?: Record<string, unknown>;
+  };
+  imports.env = imports.env ?? {};
+  imports.env.check = check as (o: unknown) => unknown;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  const exp = instance.exports as Record<string, unknown>;
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(exp);
+  }
+  const fn = exp.test as () => unknown;
+  if (typeof fn !== "function") throw new Error("no test() export");
+  return fn() as T;
+}
+
+describe("#820m Phase A — class-as-value retained in object-literal property", () => {
+  it("`{ id: class {} }` inside function body — property is non-null", async () => {
+    const src = `
+      declare function check(o: any): number;
+      export function test(): number {
+        const obj: any = { id: class {} };
+        return check(obj.id);
+      }
+    `;
+    const result = await runWithCheck<number>(src, (o) => (o == null ? 0 : 1));
+    expect(result).toBe(1);
+  });
+
+  it("`{ id: class C {} }` inside function body — property is non-null (named class)", async () => {
+    const src = `
+      declare function check(o: any): number;
+      export function test(): number {
+        const obj: any = { id: class C {} };
+        return check(obj.id);
+      }
+    `;
+    const result = await runWithCheck<number>(src, (o) => (o == null ? 0 : 1));
+    expect(result).toBe(1);
+  });
+
+  it("multiple class-valued properties — both retained", async () => {
+    const src = `
+      declare function check(a: any, b: any): number;
+      export function test(): number {
+        const obj: any = { foo: class {}, bar: class {} };
+        return check(obj.foo, obj.bar);
+      }
+    `;
+    const result = await runWithCheck<number>(src, (a, b) => (a != null && b != null ? 1 : 0));
+    expect(result).toBe(1);
+  });
+
+  it("top-level `const C = class {}` unaffected — still retained", async () => {
+    const src = `
+      declare function check(o: any): number;
+      const C: any = class {};
+      export function test(): number {
+        return check(C);
+      }
+    `;
+    const result = await runWithCheck<number>(src, (o) => (o == null ? 0 : 1));
+    expect(result).toBe(1);
+  });
+
+  it("nested function returning anonymous class — retained", async () => {
+    const src = `
+      declare function check(o: any): number;
+      function make(): any { return class {}; }
+      export function test(): number {
+        return check(make());
+      }
+    `;
+    const result = await runWithCheck<number>(src, (o) => (o == null ? 0 : 1));
+    expect(result).toBe(1);
+  });
+
+  it("plain data property next to class property — both retained", async () => {
+    const src = `
+      declare function check(t: string, c: any): number;
+      export function test(): number {
+        const obj: any = { tag: "x", cls: class {} };
+        return check(obj.tag, obj.cls);
+      }
+    `;
+    const result = await runWithCheck<number>(src, (t, c) => (t === "x" && c != null ? 1 : 0));
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the `class-as-value in function body returns null` half of #820m (Slice 1 / Phase A from the architect spec).
- `{ id: class {} }` inside any function body used to drop the class value to `null` because the property's resolved Wasm type was `ref <instance struct>` while `compileClassExpression` emits an externref (closure-struct via `extern.convert_any`) — the struct cast on field assignment silently coerced the externref to `ref.null`.
- Widen any object-literal property whose TS type has construct signatures (and no call signatures) to `externref` in `ensureStructForType`, mirroring the existing empty-`{}` widening just above. The closure-struct externref is then retained verbatim.

## What this does NOT do

- **Phase B (NamedEvaluation `.name` propagation)** is carved as **#820m-b2**. `ctx.functionNameMap` is write-only today, and the runtime closure-struct externref doesn't expose `.name` to the host, so making `obj.id.name === "id"` is a larger, separate change documented in the issue file.
- Tests that only check the value is non-null will pass; tests that further check `.name` will progress from `TypeError: Cannot access property on null or undefined` to an assertion-failure mode until Phase B lands.

## Risk / blast radius

- Narrow trigger: only properties whose TS type has `>0` construct signatures AND `0` call signatures (a `typeof Class` constructor reference). Plain objects, classes-as-call-targets, and method shorthand are unaffected.
- Mirrors a precedent (`empty-{}` widening) immediately above in the same per-prop loop.
- Non-regression spot checks pass: typed class methods, typed class instances in objects.
- Full equivalence suite running locally; CI will validate.

## Test plan

- [x] Compile + run probes: `{ id: class {} }` returns non-null externref.
- [x] 6 new unit tests in `tests/issue-820m.test.ts` (anonymous/named class, multiple class props, top-level const-class still works, nested return, class adjacent to data property) — all pass.
- [x] Sanity: typed class method (`new Foo().hello()`) → 42; typed class instance in object (`{ f: new Foo() }; o.f.x`) → 7.
- [ ] Equivalence suite (running locally) + CI test262 sharded — gate.
- [ ] Verify expected test262 failure-mode flip (`type_error → assertion` for the 7 named tests pending Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)