### PR TITLE
fix(#1525b): ToPrimitive residuals — trampoline shift + ref→f64 step-6

### DIFF
--- a/plan/issues/1525b-toprimitive-method-trampoline-and-step6.md
+++ b/plan/issues/1525b-toprimitive-method-trampoline-and-step6.md
@@ -1,7 +1,7 @@
 ---
 id: 1525b
 title: "ToPrimitive residuals: object-method trampoline invalid Wasm + §7.1.1.1 step-6 TypeError"
-status: in-progress
+status: in-review
 created: 2026-05-27
 updated: 2026-05-27
 priority: medium

--- a/plan/issues/1525b-toprimitive-method-trampoline-and-step6.md
+++ b/plan/issues/1525b-toprimitive-method-trampoline-and-step6.md
@@ -1,7 +1,7 @@
 ---
 id: 1525b
 title: "ToPrimitive residuals: object-method trampoline invalid Wasm + §7.1.1.1 step-6 TypeError"
-status: ready
+status: in-progress
 created: 2026-05-27
 updated: 2026-05-27
 priority: medium

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -3102,6 +3102,16 @@ export function emitObjectMethodAsClosure(
  */
 export function finalizeMethodTrampolines(ctx: CodegenContext): void {
   for (const t of ctx.pendingMethodTrampolines) {
+    // (#1525b) If the captured methodFuncIdx now resolves to an IMPORT (i.e.,
+    // < ctx.numImportFuncs at the time of finalize), the late-import shift
+    // machinery missed this entry. Fail loudly rather than emit invalid Wasm.
+    if (t.methodFuncIdx < ctx.numImportFuncs) {
+      throw new Error(
+        `pendingMethodTrampolines: methodFuncIdx ${t.methodFuncIdx} ` +
+          `points at import "${ctx.mod.imports[t.methodFuncIdx]?.name}" — ` +
+          `shift walker missed this entry (#1525b regression)`,
+      );
+    }
     const sig = getFuncSignature(ctx, t.methodFuncIdx);
     if (!sig || sig.params.length === 0) continue;
     const methodUserParams = sig.params.slice(1);

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -200,6 +200,17 @@ export function shiftLateImportIndices(
       ctx.nativeStrHelpers.set(name, idx + added);
     }
   }
+  // (#1525b) Trampolines registered via emitObjectMethodAsClosure /
+  // emitCachedMethodClosureAccess capture the method's funcIdx and the
+  // trampoline's own funcIdx as plain numbers in pendingMethodTrampolines.
+  // This walker only walks Instr arrays — these side-channel numbers must be
+  // shifted too, otherwise finalizeMethodTrampolines later calls
+  // getFuncSignature on a stale index that now points at a late-added import
+  // (e.g. __typeof_string), corrupting the rebuilt body.
+  for (const t of ctx.pendingMethodTrampolines) {
+    if (t.methodFuncIdx >= importsBefore) t.methodFuncIdx += added;
+    if (t.trampolineFuncIdx >= importsBefore) t.trampolineFuncIdx += added;
+  }
   // Shift export descriptors
   for (const exp of ctx.mod.exports) {
     if (exp.desc.kind === "func" && exp.desc.index >= importsBefore) {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5543,6 +5543,12 @@ export function addStringImports(ctx: CodegenContext): void {
     if (ctx.mod.declaredFuncRefs.length > 0) {
       ctx.mod.declaredFuncRefs = ctx.mod.declaredFuncRefs.map((idx) => (idx >= importsBefore ? idx + delta : idx));
     }
+    // (#1525b) Shift pendingMethodTrampolines side-channel indices in lockstep
+    // — see the matching block in addUnionImports / shiftLateImportIndices.
+    for (const t of ctx.pendingMethodTrampolines) {
+      if (t.methodFuncIdx >= importsBefore) t.methodFuncIdx += delta;
+      if (t.trampolineFuncIdx >= importsBefore) t.trampolineFuncIdx += delta;
+    }
   }
 }
 
@@ -6925,6 +6931,14 @@ export function addUnionImports(ctx: CodegenContext): void {
         if (idx >= importsBefore) ctx.nativeStrHelpers.set(name, idx + delta);
       }
       ctx.nativeStrHelperImportBase = ctx.numImportFuncs;
+    }
+    // (#1525b) Shift pendingMethodTrampolines side-channel indices in lockstep.
+    // The captured methodFuncIdx / trampolineFuncIdx are plain numbers not
+    // reachable from any Instr — without this, finalizeMethodTrampolines later
+    // resolves the wrong (import) signature, producing invalid Wasm.
+    for (const t of ctx.pendingMethodTrampolines) {
+      if (t.methodFuncIdx >= importsBefore) t.methodFuncIdx += delta;
+      if (t.trampolineFuncIdx >= importsBefore) t.trampolineFuncIdx += delta;
     }
   }
 }

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -1781,9 +1781,16 @@ export function coerceType(
                 fctx.body.push({ op: "f64.const", value: NaN });
               }
             } else if (closureInfo.returnType.kind === "ref" || closureInfo.returnType.kind === "ref_null") {
-              // valueOf returned an object ref — drop and push NaN
+              // (#1525b §7.1.1.1 step 6) valueOf returned an object — must try
+              // toString and throw TypeError if both return non-primitives.
+              // Route through the host __to_primitive helper (same path the
+              // eqref subpath uses at line ~1882, fixed by #1253). Re-push the
+              // ORIGINAL struct so the host sees it; the valueOf result is
+              // already dropped. Pre-#1525b this silently emitted NaN.
               fctx.body.push({ op: "drop" });
-              fctx.body.push({ op: "f64.const", value: NaN });
+              fctx.body.push({ op: "local.get", index: structLocal });
+              const hintRefRet = toPrimitiveHint ?? "number";
+              emitToPrimitiveHostCall(ctx, fctx, "f64", hintRefRet);
             }
             // f64 return → value is already on stack
             cleanup();
@@ -1907,9 +1914,21 @@ export function coerceType(
           // function rather than a closure stored in the struct field.
           const standaloneValueOf = ctx.funcMap.get(`${name}_valueOf`);
           if (standaloneValueOf !== undefined) {
-            fctx.body.push({ op: "call", funcIdx: standaloneValueOf });
             const funcType = ctx.mod.types[ctx.mod.functions[standaloneValueOf - ctx.numImportFuncs]?.typeIdx ?? -1];
             const retKind = funcType?.kind === "func" ? funcType.results?.[0]?.kind : undefined;
+            // (#1525b §7.1.1.1 step 6) For object-ref return, we must re-route
+            // through the host helper using the ORIGINAL struct. Save it before
+            // the call consumes it. For other return kinds the original code
+            // path is unchanged.
+            const needsHostFallback = retKind === "ref" || retKind === "ref_null";
+            let savedStructLocal = -1;
+            if (needsHostFallback) {
+              savedStructLocal = allocLocal(fctx, `__svo_struct_${fctx.locals.length}`, from);
+              // Stack currently has `from` (struct) — duplicate via tee then
+              // restore via local.get so the call sees the same value.
+              fctx.body.push({ op: "local.tee", index: savedStructLocal });
+            }
+            fctx.body.push({ op: "call", funcIdx: standaloneValueOf });
             if (retKind === "i32") {
               fctx.body.push({ op: "f64.convert_i32_s" });
             } else if (retKind === "externref" || retKind === "ref_extern") {
@@ -1922,10 +1941,13 @@ export function coerceType(
                 fctx.body.push({ op: "drop" });
                 fctx.body.push({ op: "f64.const", value: NaN });
               }
-            } else if (retKind === "ref" || retKind === "ref_null") {
-              // valueOf returned an object ref — drop and push NaN
+            } else if (needsHostFallback) {
+              // (#1525b) valueOf returned an object — try toString and throw
+              // TypeError per §7.1.1.1. Mirror the eqref subpath at ~line 1882.
               fctx.body.push({ op: "drop" });
-              fctx.body.push({ op: "f64.const", value: NaN });
+              fctx.body.push({ op: "local.get", index: savedStructLocal });
+              const hintSvoRet = toPrimitiveHint ?? "number";
+              emitToPrimitiveHostCall(ctx, fctx, "f64", hintSvoRet);
             }
             return;
           }

--- a/tests/issue-1525.test.ts
+++ b/tests/issue-1525.test.ts
@@ -171,9 +171,8 @@ describe("#1525 — ToPrimitive walks valueOf/toString before throwing", () => {
     ).toBe(99);
   });
 
-  // Carved to #1525b (root cause #3): §7.1.1.1 step-6 TypeError still bottoms
-  // out instead of surfacing to the Wasm catch_all. Needs architect spec.
-  it.skip("TypeError when both valueOf and toString return objects", async () => {
+  // Fixed by #1525b: route ref→f64 step-6 through the host __to_primitive helper.
+  it("TypeError when both valueOf and toString return objects", async () => {
     // §7.1.1.1 step 6 — TypeError propagates to Wasm catch_all.
     // Pre-#1525 the eager `extern.convert_any` + later `__unbox_number`
     // silently bottomed out at "[object Object]" → NaN; per spec the
@@ -191,9 +190,8 @@ describe("#1525 — ToPrimitive walks valueOf/toString before throwing", () => {
     ).toBe("TYPEERR");
   });
 
-  // Carved to #1525b (root cause #2, dominant ~142): invalid Wasm in
-  // finalizeMethodTrampolines (double f64.convert_i32_s). Needs architect spec.
-  it.skip("explicit String(obj) calls toString even with valueOf present", async () => {
+  // Fixed by #1525b: pendingMethodTrampolines indices now tracked through all three late-import shift sites.
+  it("explicit String(obj) calls toString even with valueOf present", async () => {
     // String(obj) is an explicit ToPrimitive("string") site — toString wins
     // over valueOf for hint "string" per §7.1.1.1.
     expect(

--- a/tests/issue-1525b.test.ts
+++ b/tests/issue-1525b.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1525b — ToPrimitive residuals carved from #1525.
+ *
+ * Two independent root causes:
+ *
+ *   #2 (dominant ~142 fails): Object-method trampolines emitted invalid Wasm
+ *      whenever a `String(obj)` / `obj + 1` site introduced a late import
+ *      (e.g. `__typeof_string`, `__box_number`) AFTER the trampoline was
+ *      registered. `pendingMethodTrampolines[i].methodFuncIdx` is a plain
+ *      number not reachable from any Instr, so the three late-import shift
+ *      sites (`shiftLateImportIndices`, `addUnionImports` inline shifter,
+ *      `addStringImports` inline shifter) missed it. `finalizeMethodTrampolines`
+ *      then resolved the stale index to the wrong (import) signature and
+ *      emitted a double `f64.convert_i32_s` cascade.
+ *
+ *   #3 (~8-10 fails): Two `ref → f64` subpaths in
+ *      `src/codegen/type-coercion.ts` (closure-typed valueOf call_ref, and
+ *      standalone `${name}_valueOf` shorthand-method) silently emitted
+ *      `drop + f64.const NaN` when valueOf returned an object ref, instead
+ *      of routing through the host `__to_primitive` helper. Per ECMA-262
+ *      §7.1.1.1 step 6 this must continue to toString and throw TypeError
+ *      if both methods return non-primitives.
+ *
+ * Fix: register `pendingMethodTrampolines` with all three shift sites,
+ * add a defensive guard at `finalizeMethodTrampolines`, and re-route both
+ * ref-return subpaths through `emitToPrimitiveHostCall`.
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function runWasm(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  const fn = exports.test as () => unknown;
+  return fn();
+}
+
+describe("#1525b — ToPrimitive trampoline shift + step-6 TypeError", () => {
+  // Fix #2: late imports shifted around a registered trampoline.
+  it("String(obj) with user toString does not produce invalid Wasm", async () => {
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const obj: any = {
+            valueOf() { return 100; },
+            toString() { return "stringified"; },
+          };
+          return String(obj);
+        }
+      `),
+    ).toBe("stringified");
+  });
+
+  // Fix #2: a value-receiving (`obj + 1`) site that triggers `__box_number` /
+  // `__unbox_number` import additions after the trampoline registration.
+  it("obj+1 with user valueOf returning a primitive does not invalidate the trampoline", async () => {
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const obj: any = {
+            valueOf() { return 41; },
+            toString() { return "noop"; },
+          };
+          return obj + 1;
+        }
+      `),
+    ).toBe(42);
+  });
+
+  // Fix #3 subpath 1 (closure-typed valueOf): both valueOf AND toString return
+  // objects → §7.1.1.1 step 6 TypeError must surface to the Wasm catch_all.
+  it("TypeError when both valueOf and toString return objects (closure dispatch)", async () => {
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const obj: any = {
+            valueOf() { return ({} as any); },
+            toString() { return ({} as any); },
+          };
+          try { return obj + 1; } catch (e) { return "TYPEERR"; }
+        }
+      `),
+    ).toBe("TYPEERR");
+  });
+
+  // Fix #3 subpath 2 (standalone shorthand-method): valueOf returning a non-
+  // primitive must still let toString primary handle it.
+  it("valueOf returns object, toString returns string → string used", async () => {
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const obj: any = {
+            valueOf() { return ({} as any); },
+            toString() { return "fallback"; },
+          };
+          // Hint "default" — toString runs after valueOf bottoms out.
+          return obj + "";
+        }
+      `),
+    ).toBe("fallback");
+  });
+
+  // Fix #2 cross-check: distinct user-method objects with different shapes
+  // (so they don't structurally dedupe) and mixed value/string sites — none
+  // of the trampolines should desync as late imports get added.
+  it("distinct-shape user-method objects survive concurrent late imports", async () => {
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const a: any = { valueOf() { return 10; }, tag: "a" };
+          const c: any = { toString() { return "tail"; } };
+          return a + 32 + " " + String(c);
+        }
+      `),
+    ).toBe("42 tail");
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix #2 (dominant, ~130 test262 fails)**: `pendingMethodTrampolines[i].methodFuncIdx` and `.trampolineFuncIdx` are plain numbers in a side-channel array, not reachable from any `Instr`. The three late-import shift sites (`shiftLateImportIndices`, `addUnionImports` inline shifter, `addStringImports` inline shifter) walked Instr arrays only — they missed these entries. After a late-added import (e.g. `__typeof_string`, `__box_number`) bumped the import count, `finalizeMethodTrampolines` resolved the stale `methodFuncIdx` to that import's signature and emitted a double `f64.convert_i32_s`, producing invalid Wasm. **Add a 2-line shift loop at all three sites + a defensive guard at the top of `finalizeMethodTrampolines`** that fails loudly if `methodFuncIdx` ever resolves to an import index (turns future regressions into clear compile errors instead of validator-deep failures).
- **Fix #3 (~8-10 fails)**: Two `ref → f64` subpaths in `src/codegen/type-coercion.ts` (closure-typed `valueOf` via `call_ref` at ~1783, standalone shorthand-method `${name}_valueOf` at ~1925) silently emitted `drop + f64.const NaN` when `valueOf` returned an object ref. Per ECMA-262 §7.1.1.1 step 6 they must continue to `toString` and throw `TypeError` if both return non-primitives. **Mirror the existing eqref subpath at ~1882**: drop the result, re-push the ORIGINAL struct, route through `emitToPrimitiveHostCall`. For the standalone case the struct is saved via `local.tee` before the call consumes it.

## Test plan
- [x] `tests/issue-1525b.test.ts` (5 new cases — all 5 green)
- [x] Un-skipped 2 `tests/issue-1525.test.ts` cases (one per fix path) — both green
- [x] Adjacent suites stay green: #1525, #1602, #1672 (async-gen trampoline), #1319 (no-method ToPrimitive), #866 (NaN sentinel), #1636 (JSON.stringify, just merged)
- [ ] CI test262 sharded — expect ~+130 net pass-rate delta (88 misclassified `wasm_compile` + step-6 ref-return residuals)

## Architect spec
`plan/issues/1525b-toprimitive-method-trampoline-and-step6.md` — followed exactly. Three shift sites + finalize guard + two type-coercion subpaths. No structural changes beyond what the spec called for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)