### PR TITLE
chore(#1525,#1640,#820h,#820j): reconcile issue statuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
+**test262 conformance**: 30,341 / 43,135 (70.3 %) — baseline 119b766c, 2026-05-28T18:28:42Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ by CI on every merge) is below; everything else links to STATUS.md rather than
 duplicating numbers that go stale.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
+**test262 conformance**: 30,341 / 43,135 (70.3 %) — baseline 119b766c, 2026-05-28T18:28:42Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
+**test262 conformance**: 30,341 / 43,135 (70.3 %) — baseline 119b766c, 2026-05-28T18:28:42Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 28,842 / 43,159 (66.8 %) — baseline 1f5208c8, 2026-05-22T19:51:21Z
+**test262 conformance**: 30,341 / 43,135 (70.3 %) — baseline 119b766c, 2026-05-28T18:28:42Z
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/plan/issues/1525-spec-gap-toprimitive-eager-throw-on-object-args.md
+++ b/plan/issues/1525-spec-gap-toprimitive-eager-throw-on-object-args.md
@@ -1,9 +1,10 @@
 ---
 id: 1525
 title: "spec gap: built-in coercion paths throw 'Cannot convert object to primitive value' eagerly"
-status: ready
+status: done
 created: 2026-05-20
-updated: 2026-05-27
+updated: 2026-05-28
+completed: 2026-05-28
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -174,3 +175,28 @@ with a pointer to #1525b.
 
 #1525 stays open (`status: ready`) tracking the full 170-fail cluster; the
 residual is now #1525b.
+
+## Resolution (2026-05-28, dev-1525 — all three root causes landed, closing)
+
+Verified on current main (`c2295fd82`) that **all three root causes are now
+fixed** and the full `tests/issue-1525.test.ts` suite passes 10/10 with both
+previously-`it.skip`'d cases active:
+
+1. Root cause #1 (`new Object()` → null-proto) — landed earlier via the
+   `__new_plain_object` lowering.
+2. Root cause #2 (the dominant ~142: object-literal user `toString`/`valueOf`
+   via `String(obj)` → invalid Wasm in `finalizeMethodTrampolines`,
+   double `f64.convert_i32_s`) — fixed by **#1525b** (pendingMethodTrampolines
+   funcIdx-shift tracked through all three late-import shift sites, task #240).
+   Probe: `String({ valueOf(){return 100;}, toString(){return "stringified";} })`
+   now returns `"stringified"` (was invalid-Wasm / NaN).
+3. Root cause #3 (§7.1.1.1 step-6 TypeError when both `valueOf` and `toString`
+   return objects) — fixed by **#1525b** (ref→f64 step-6 routed through the
+   host `__to_primitive` helper). Probe: `obj + 1` with both methods returning
+   `{}` now throws a genuine `TypeError` observable by user `try/catch`
+   (`TYPEERR:true`), instead of silently bottoming out at `[object Object]`/NaN.
+
+No source change was required in this PR — the residuals were closed by the
+#1525b trampoline + step-6 work. The `tests/issue-1525.test.ts` cases were
+already un-skipped on main. This PR only flips `#1525` frontmatter to
+`status: done`. The umbrella cluster (#1525 + #1525b) is fully resolved.

--- a/plan/issues/1640-spec-gap-reflect-internal-method-mirror.md
+++ b/plan/issues/1640-spec-gap-reflect-internal-method-mirror.md
@@ -3,7 +3,7 @@ id: 1640
 title: "spec gap: Reflect.* invariant checks mirror internal-method bugs (47 test262 fails)"
 status: blocked
 created: 2026-05-08
-updated: 2026-05-28
+updated: 2026-05-28b
 blocked_on: [1629, 1596]
 investigation_done: 2026-05-27
 reverified: 2026-05-28
@@ -240,3 +240,25 @@ Symbol-key / proto-chain bucket worth its own carve.
 Task #178 (this re-verification) closed: *re-verified, still blocked, no
 action — pass rate unchanged at 106/153 / 69.3 %, all 47 fails attributable
 to #1629 and #1596*. No PR opened.
+
+## Re-verification (2026-05-28, dev-1525, task #242)
+
+Re-checked after the descriptor work that landed (#1629a / PR #835, #862).
+**Still blocked — the descriptor blocker is NOT resolved.** The full
+descriptor model issue **#1629** remains `status: ready` (only the narrow
+`#1629a` dynamic-descriptor slice landed), and **#1596** is still
+`status: in-progress`. The Cluster-A symptom still reproduces on current main
+(`c2295fd82`):
+
+```ts
+const o: any = {};
+Object.defineProperty(o, 'p', { get() { return 42; }, configurable: true });
+Reflect.get(o, 'p');   // → null/undefined (should be 42)
+```
+
+So the descriptor-attribute storage (`writable/enumerable/configurable/get/set`)
+on struct-backed objects is still missing, and Reflect inherits that gap.
+**Verdict unchanged: `status: blocked` on [1629, 1596].** No Reflect-layer
+patch exists; re-run the `built-ins/Reflect` suite and close once #1629 lands
+and the suite reaches ≥80%. Task #242 closed: *verified, still blocked, no
+action*.

--- a/plan/issues/820h-disposable-stack-brand-check.md
+++ b/plan/issues/820h-disposable-stack-brand-check.md
@@ -1,9 +1,10 @@
 ---
 id: 820h
 title: "DisposableStack / AsyncDisposableStack brand-check and protocol stubs (~74 fails)"
-status: in-review
+status: done
 created: 2026-05-21
-updated: 2026-05-27
+updated: 2026-05-28
+completed: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/820j-generator-prototype-brand.md
+++ b/plan/issues/820j-generator-prototype-brand.md
@@ -1,9 +1,10 @@
 ---
 id: 820j
 title: "(Async)GeneratorPrototype brand check + receiver TypeError (~36 fails)"
-status: in-review
+status: done
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-28
+completed: 2026-05-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium


### PR DESCRIPTION
Docs-only chore reconciling stale issue statuses against current main (\`c2295fd82\`). No source changes.

## #1525 — ToPrimitive eager-throw (status: ready → done)
All three root causes are now fixed on main; \`tests/issue-1525.test.ts\` passes **10/10** with both formerly \`it.skip\`'d cases active (verified in this worktree):
- RC#1 (\`new Object()\` → null-proto): \`__new_plain_object\` lowering (landed earlier).
- RC#2 (dominant ~142: \`String(obj)\` over user \`toString\`/\`valueOf\` → invalid Wasm double \`f64.convert_i32_s\` in \`finalizeMethodTrampolines\`): fixed by **#1525b** (task #240, funcIdx-shift through all three late-import sites). Probe now returns \`"stringified"\`.
- RC#3 (§7.1.1.1 step-6 TypeError when both \`valueOf\` and \`toString\` return objects): fixed by **#1525b** (ref→f64 step-6 routed through host \`__to_primitive\`). Probe now throws a genuine \`TypeError\` (\`TYPEERR:true\`) observable by user \`try/catch\`.

## #820h / #820j (status: in-review → done, completed: 2026-05-28)
Fixed by merged PRs **#652** (#820h DisposableStack) and **#647** (#820j (Async)GeneratorPrototype). Both confirmed \`MERGED\` via \`gh pr view\`.

## #1640 — Reflect invariant checks (stays blocked)
Re-verified after #1629a/#862 descriptor work: still blocked on **#1629** (\`status: ready\` — only the #1629a slice landed) and **#1596** (\`in-progress\`). The Cluster-A symptom still reproduces on main:
\`\`\`ts
Object.defineProperty(o, 'p', { get() { return 42; } }); Reflect.get(o, 'p'); // → undefined, not 42
\`\`\`
No Reflect-layer patch exists; added a re-verification note, kept \`status: blocked\`.

Closes #1525. Reconciles #820h, #820j. Re-verifies #1640 (no status change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)