### PR TITLE
chore(#589): cleanup native-messaging example post-merge

### DIFF
--- a/examples/native-messaging/background.js
+++ b/examples/native-messaging/background.js
@@ -8,5 +8,3 @@ port.postMessage(new Array(209715));
 chrome.runtime.onInstalled.addListener((reason) => {
   console.log(reason);
 });
-
-

--- a/examples/native-messaging/manifest.json
+++ b/examples/native-messaging/manifest.json
@@ -9,6 +9,5 @@
     "type": "module"
   },
   "action": {},
-  "author": "guest271314",
   "homepage_url": "https://github.com/loopdive/js2"
 }


### PR DESCRIPTION
Follow-up to #589 — removes `"author": "guest271314"` from the Web extension manifest template (not a standard MV3 field, shouldn't carry contributor attribution in a shared template) and strips trailing blank lines from `background.js`.