### PR TITLE
refactor: remove bespoke readStdin() builtin, use process.stdin.read (#1653)

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -47,11 +47,13 @@ launch it (see "Run it" below).
 
 ## The host source
 
-[`host.ts`](./host.ts) reads the whole framed message from stdin, strips and
-decodes the 4-byte length prefix, logs diagnostics to **stderr** (so they never
-corrupt the stdout protocol stream), and writes a JSON response. The
-application logic — here, echoing the received body inside a wrapper object —
-is the part you'd replace for a real host.
+[`host.ts`](./host.ts) runs a continuous `while (true)` port loop: it reads the
+4-byte length prefix then exactly the declared body bytes via
+`process.stdin.read` read-until loops (a `readExact` helper handles short
+reads), logs diagnostics to **stderr** (so they never corrupt the stdout
+protocol stream), and writes a framed JSON response, looping until stdin
+reaches EOF. The application logic — here, echoing the received body inside a
+wrapper object — is the part you'd replace for a real host.
 
 ## Build to `.wasm`
 
@@ -85,7 +87,7 @@ message. The 4-byte prefix below (`\x0d\x00\x00\x00`) declares a 13-byte body
 `{"ping":true}`:
 
 ```bash
-printf '\x0d\x00\x00\x00{"ping":true}' | ./examples/native-messaging/run.sh
+printf '\x0d\x00\x00\x00{"ping":true}' | ./examples/native-messaging/nm_js2wasm.sh
 ```
 
 You'll see the host's stderr diagnostic (received-length + decoded body
@@ -108,8 +110,8 @@ the same script CI runs (`.github/workflows/native-messaging-smoke.yml`):
 
 ## Wire it into Chrome
 
-1. **Build** `out/host.wasm` (above) and make sure `run.sh` is executable
-   (`chmod +x run.sh`).
+1. **Build** `out/host.wasm` (above) and make sure `nm_js2wasm.sh` is executable
+   (`chmod +x nm_js2wasm.sh`).
 
 2. **Edit `nm_js2wasm.json`**:
    - `path` → the **absolute** path to `nm_js2wasm.sh` (Chrome requires an absolute

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -29,8 +29,8 @@ trailing newline. The two stdout gaps that previously blocked this are closed
 
 | Capability | Status | Detail |
 |------------|--------|--------|
-| Read framed message from stdin | works | `readStdin()` drains fd=0 to EOF as a string (#1481) |
-| Decode the 4-byte LE length prefix | works | byte math on `charCodeAt` of the first 4 code units |
+| Read framed message from stdin | works | `process.stdin.read(buf, offset?)` does a binary, incremental fd=0 read into the caller's buffer, returning the byte count (#1653); a read-until loop assembles exactly N bytes |
+| Decode the 4-byte LE length prefix | works | byte math on the first 4 bytes of the read header buffer |
 | Route debug to stderr (fd=2) | works | `console.error` / `console.warn` (#1493) — keeps the stdout protocol stream clean |
 | Print a **string literal** to stdout | works | `console.log("…")` emits UTF-8 + `\n` (#1480) |
 | Print a **runtime/computed string** to stdout | works | `console.log(x)` / `process.stdout.write(x)` of a variable, concatenation, or template literal emit the actual content (#1618) |

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -92,8 +92,10 @@ export function main(): void {
     const bodyStr = bodyToString(body, declaredLen);
 
     // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
-    // protocol stream. Chrome ignores the host's stderr.
-    console.error(`[host] received frame, declared body length ${declaredLen}`);
+    // protocol stream. Chrome ignores the host's stderr. The frame is the
+    // 4-byte LE prefix plus the declared body, so the total bytes consumed is
+    // 4 + declaredLen.
+    console.error(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}`);
 
     // Application logic: echo the received JSON body back inside a wrapper
     // object. Real hosts would parse `bodyStr`, dispatch on a command field,

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -8,7 +8,12 @@
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 //
 // js2wasm support today:
-//   - stdin  : readStdin() drains fd=0 to EOF and returns it as a string (#1481)
+//   - stdin  : process.stdin.read(buf, offset?) does one binary, incremental
+//              fd=0 read into the caller's typed buffer at `offset`, returning
+//              the byte count (#1653) — the standard Node API. A read-until
+//              loop assembles exactly N bytes from possibly-short reads, so a
+//              continuous `while (true)` port loop can read the 4-byte LE
+//              header then exactly the declared body length.
 //   - stdout : process.stdout.write(bytes|str) writes raw bytes / a string to
 //              fd=1 with NO trailing newline (#1651) — used for the binary
 //              4-byte length prefix and the JSON body. console.log(str) also
@@ -16,34 +21,48 @@
 //   - stderr : console.error / console.warn write to fd=2 (#1493) — use these
 //              for debug output so they never corrupt the stdout protocol stream
 //
-// This is a drop-in Chrome host: it reads the framed JSON message off stdin,
+// This is a drop-in Chrome host: it reads each framed JSON message off stdin,
 // builds a JSON response, and writes it back to stdout with the correct
-// 4-byte little-endian length prefix. Run it with the wrapper in run.sh under
-// wasmtime/wasmer to exercise the read -> process -> respond loop end to end.
+// 4-byte little-endian length prefix, looping until stdin reaches EOF. Run it
+// with the wrapper in run.sh under wasmtime/wasmer to exercise the
+// read -> process -> respond loop end to end.
 
-declare function readStdin(): string;
 declare const process: {
+  stdin: { read(buf: Uint8Array, offset?: number): number };
   stdout: { write(chunk: Uint8Array | string): void };
   stderr: { write(chunk: Uint8Array | string): void };
 };
 
-// Decode the little-endian uint32 length that Chrome wrote as the first 4
-// bytes. readStdin() hands us the whole stdin buffer (prefix + body) as a
-// single string, one byte per code unit, so the prefix is the first 4 units.
-function decodeLength(framed: string): number {
-  const b0 = framed.charCodeAt(0) & 0xff;
-  const b1 = framed.charCodeAt(1) & 0xff;
-  const b2 = framed.charCodeAt(2) & 0xff;
-  const b3 = framed.charCodeAt(3) & 0xff;
-  return b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
+// Read exactly `n` bytes into the first `n` slots of `buf` via a read-until
+// loop, handling short reads (fd_read may return fewer bytes than requested).
+// Returns false on EOF (a read of <= 0 bytes before `n` were assembled) so the
+// caller can cleanly terminate the port loop.
+function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = process.stdin.read(buf, got);
+    if (r <= 0) return false; // EOF or error
+    got = got + r;
+  }
+  return true;
 }
 
-// Extract exactly the declared body bytes after the 4-byte prefix — mirroring
-// the AssemblyScript reference's "read the length, then read that many body
-// bytes" loop, rather than blindly taking everything after the prefix (which
-// would mishandle a stdin buffer carrying trailing bytes).
-function readBody(framed: string, length: number): string {
-  return framed.substring(4, 4 + length);
+// Decode the little-endian uint32 length that Chrome wrote as the first 4
+// bytes of the frame.
+function decodeLength(header: Uint8Array): number {
+  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+}
+
+// Build a string from the declared body bytes, one byte per code unit (the
+// Native Messaging JSON body is ASCII/UTF-8 framed by byte length).
+function bodyToString(body: Uint8Array, length: number): string {
+  let s = "";
+  let i = 0;
+  while (i < length) {
+    s = s + String.fromCharCode(body[i]);
+    i = i + 1;
+  }
+  return s;
 }
 
 // Write a framed Native Messaging response: the 4-byte little-endian length
@@ -57,19 +76,29 @@ function writeMessage(body: string): void {
 }
 
 export function main(): void {
-  // Read the whole framed message from stdin (Chrome sends one per launch in
-  // the simplest "stdio" wiring; a long-lived port would loop here).
-  const framed = readStdin();
-  const declaredLen = decodeLength(framed);
-  const body = readBody(framed, declaredLen);
+  // Long-lived port loop: read framed messages off stdin until EOF. A short
+  // read inside readExact is retried; a zero-byte read means the peer closed
+  // stdin, so we break and exit.
+  const header = new Uint8Array(4);
+  while (true) {
+    // 4-byte LE length prefix. EOF here = clean shutdown.
+    if (!readExact(header, 4)) break;
+    const declaredLen = decodeLength(header);
 
-  // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
-  // protocol stream. Chrome ignores the host's stderr.
-  console.error(`[host] received ${framed.length} chars, declared body length ${declaredLen}`);
+    // Read exactly the declared body bytes. A truncated body (EOF mid-frame)
+    // also terminates the loop.
+    const body = new Uint8Array(declaredLen);
+    if (!readExact(body, declaredLen)) break;
+    const bodyStr = bodyToString(body, declaredLen);
 
-  // Application logic: echo the received JSON body back inside a wrapper
-  // object. Real hosts would parse `body`, dispatch on a command field, and
-  // build a structured response.
-  const response = `{"received":${body},"runtime":"js2wasm+wasi"}`;
-  writeMessage(response);
+    // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
+    // protocol stream. Chrome ignores the host's stderr.
+    console.error(`[host] received frame, declared body length ${declaredLen}`);
+
+    // Application logic: echo the received JSON body back inside a wrapper
+    // object. Real hosts would parse `bodyStr`, dispatch on a command field,
+    // and build a structured response.
+    const response = `{"received":${bodyStr},"runtime":"js2wasm+wasi"}`;
+    writeMessage(response);
+  }
 }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -751,8 +751,6 @@ export interface CodegenContext {
   wasiPendingPathOpenHelper?: boolean;
   /** (#1483) Pending flag — emit `__wasi_date_now` / `__wasi_performance_now` after lib-globals scan. */
   wasiClockHelpersPending?: boolean;
-  /** (#1483 + #1481) Pending flag — emit `__wasi_read_stdin_all` after lib-globals scan. */
-  wasiPendingFdReadHelper?: boolean;
   /** (#1484) Pending flag — emit `__wasi_sleep_ms` after lib-globals scan. */
   wasiPendingSleepMsHelper?: boolean;
   /** Set of node:fs functions used in this compilation unit (both WASI and JS-host fs paths). */

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1579,7 +1579,7 @@ function flattenStaticArrayElements(arr: ts.ArrayLiteralExpression): ts.Expressi
 
 /**
  * #1653 — match `process.stdin.read(buf, offset?)` under --target wasi: the
- * binary, incremental stdin read (the Node-API replacement for readStdin()).
+ * binary, incremental Node-API stdin read.
  * Returns true when matched. Mirrors `matchProcessStdStreamWrite`.
  */
 function matchProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
@@ -1781,33 +1781,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     }
   }
 
-  // #1481: readStdin() builtin under --target wasi → call __wasi_read_stdin_all
-  //
-  // DEPRECATED (#1653): readStdin() drains fd=0 to EOF and UTF-8-decodes the
-  // result to a STRING, so it cannot read a fixed byte count, cannot read
-  // incrementally (no continuous port loop), and loses binary fidelity. Prefer
-  // the standard Node API `process.stdin.read(buf, offset?)` (above) for binary,
-  // incremental reads. readStdin() is kept working for back-compat only.
-  if (
-    ctx.wasi &&
-    ts.isIdentifier(expr.expression) &&
-    expr.expression.text === "readStdin" &&
-    ctx.wasiFdReadIdx !== undefined &&
-    ctx.wasiFdReadIdx >= 0
-  ) {
-    const helperIdx = ctx.funcMap.get("__wasi_read_stdin_all");
-    if (helperIdx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
-      return { kind: "ref", typeIdx: ctx.nativeStrTypeIdx };
-    }
-  }
-
   // #1653: process.stdin.read(buf, offset?) under --target wasi → fd_read(0, …)
   // into the caller-supplied typed buffer's backing array starting at `offset`,
-  // returning the number of bytes read. The binary, incremental Node-API
-  // replacement for readStdin() (which drains to EOF and UTF-8-decodes, losing
-  // binary fidelity). Lets a `while (true)` port loop read a fixed 4-byte LE
-  // header then exactly N body bytes — the Native Messaging frame shape.
+  // returning the number of bytes read. The binary, incremental Node-API stdin
+  // read. Lets a `while (true)` port loop read a fixed 4-byte LE header then
+  // exactly N body bytes — the Native Messaging frame shape.
   if (matchProcessStdinRead(ctx, fctx, expr)) {
     const r = emitProcessStdinRead(ctx, fctx, expr);
     if (r) return r;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3962,14 +3962,9 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
         needsEnviron = true;
       }
     }
-    // #1481: readStdin() builtin → triggers fd_read import + helper
-    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "readStdin") {
-      needsFdRead = true;
-    }
     // #1653: process.stdin.read(buf, offset?) → triggers fd_read import (the
-    // binary, incremental Node-API replacement for readStdin()). Detect the
-    // `process.stdin.read(...)` call shape so fd_read is registered even when
-    // readStdin() is never used.
+    // binary, incremental Node-API stdin read). Detect the
+    // `process.stdin.read(...)` call shape so fd_read is registered.
     if (
       ts.isCallExpression(node) &&
       ts.isPropertyAccessExpression(node.expression) &&
@@ -4135,9 +4130,6 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   if (needsClockTimeGet) {
     ctx.wasiClockHelpersPending = true;
   }
-  if (needsFdRead) {
-    ctx.wasiPendingFdReadHelper = true;
-  }
   if (needsPollOneoff) {
     ctx.wasiPendingSleepMsHelper = true;
   }
@@ -4171,10 +4163,6 @@ export function emitDeferredWasiHelpers(ctx: CodegenContext): void {
   // async scheduler to call this for setTimeout/await sleep().
   if (ctx.wasiPendingSleepMsHelper && !ctx.funcMap.has("__wasi_sleep_ms")) {
     emitWasiSleepMsHelper(ctx);
-  }
-  // #1481: register __wasi_read_stdin_all() -> ref NativeString helper
-  if (ctx.wasiPendingFdReadHelper && !ctx.funcMap.has("__wasi_read_stdin_all")) {
-    emitWasiReadStdinAllHelper(ctx);
   }
 }
 
@@ -4365,12 +4353,10 @@ const WASI_WRITE_SCRATCH_START = 128 * 1024;
  *
  * Strategy: flatten any AnyString (FlatString / ConsString / Utf8String) to a
  * NativeString via the existing __str_flatten helper, then copy the low byte
- * of each i16 code unit into linear memory and issue a single fd_write. This
- * mirrors readStdin's byte-per-i16 model (#1481), so a `readStdin()` →
- * `console.log` round-trip is byte-exact for ASCII / Latin-1 content (the
- * Native Messaging JSON case). Non-Latin-1 code points are truncated to their
- * low byte — acceptable for the protocol use-case and consistent with how
- * stdin bytes are stored.
+ * of each i16 code unit into linear memory and issue a single fd_write. The
+ * round-trip is byte-exact for ASCII / Latin-1 content (the Native Messaging
+ * JSON case). Non-Latin-1 code points are truncated to their low byte —
+ * acceptable for the protocol use-case.
  *
  * Param 0 is typed `ref NativeString` so callers can hand us a value compiled
  * as `{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }` directly; __str_flatten
@@ -4912,180 +4898,6 @@ function emitWasiSleepMsHelper(ctx: CodegenContext): void {
     name: "__wasi_sleep_ms",
     typeIdx: funcTypeIdx,
     locals: [],
-    body,
-    exported: false,
-  });
-}
-
-/**
- * Emit __wasi_read_stdin_all() -> ref NativeString.
- *
- * Loops fd_read on fd=0 into a linear-memory buffer starting at offset
- * `STDIN_BUF_START` (after the 1024-byte iovec scratch area), in chunks of
- * `CHUNK`, until fd_read reports nread=0 (EOF). The accumulated bytes are
- * copied into a fresh `__str_data` (i16) array and wrapped in a NativeString
- * struct.
- *
- * Memory layout (re-using the WASI scratch area 0..1023):
- *   [0..3]  = iovec.buf  (set per chunk)
- *   [4..7]  = iovec.buf_len
- *   [8..11] = nread (output from fd_read)
- *
- * The total buffer is hard-capped at MAX_BYTES to keep things simple — if
- * stdin exceeds this we stop reading and return what we have. The cap is
- * sized to fit comfortably inside the initial 1 page (64KB) of memory.
- */
-function emitWasiReadStdinAllHelper(ctx: CodegenContext): void {
-  // #1618: stdin buffer lives in its own page (64KB), above the page-0 string
-  // literal data segments, so fd_read can't clobber initialized literal bytes.
-  const STDIN_BUF_START = WASI_STDIN_BUF_START;
-  const CHUNK = 1024;
-  const MAX_BYTES = 60 * 1024; // ~60KB cap; fits in the dedicated stdin page
-
-  // () -> ref NativeString
-  const funcTypeIdx = addFuncType(ctx, [], [{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.funcMap.set("__wasi_read_stdin_all", funcIdx);
-
-  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
-  const strTypeIdx = ctx.nativeStrTypeIdx;
-
-  // locals: total(0), nread(1), dataArr(2), i(3), b(4)
-  const TOTAL = 0;
-  const NREAD = 1;
-  const DATA = 2;
-  const I = 3;
-  const B = 4;
-
-  const body: Instr[] = [
-    // total = 0
-    { op: "i32.const", value: 0 } as Instr,
-    { op: "local.set", index: TOTAL } as Instr,
-
-    // outer block to allow break-out
-    {
-      op: "block",
-      blockType: { kind: "empty" },
-      body: [
-        {
-          op: "loop",
-          blockType: { kind: "empty" },
-          body: [
-            // if (total >= MAX_BYTES) break;
-            { op: "local.get", index: TOTAL } as Instr,
-            { op: "i32.const", value: MAX_BYTES } as Instr,
-            { op: "i32.ge_u" } as Instr,
-            { op: "br_if", depth: 1 } as Instr,
-
-            // iovec.buf = STDIN_BUF_START + total at memory[0]
-            { op: "i32.const", value: 0 } as Instr,
-            { op: "i32.const", value: STDIN_BUF_START } as Instr,
-            { op: "local.get", index: TOTAL } as Instr,
-            { op: "i32.add" } as Instr,
-            { op: "i32.store", align: 2, offset: 0 } as Instr,
-
-            // iovec.buf_len = CHUNK at memory[4]
-            { op: "i32.const", value: 4 } as Instr,
-            { op: "i32.const", value: CHUNK } as Instr,
-            { op: "i32.store", align: 2, offset: 0 } as Instr,
-
-            // fd_read(fd=0, iovs=0, iovs_len=1, nread=8)
-            { op: "i32.const", value: 0 } as Instr,
-            { op: "i32.const", value: 0 } as Instr,
-            { op: "i32.const", value: 1 } as Instr,
-            { op: "i32.const", value: 8 } as Instr,
-            { op: "call", funcIdx: ctx.wasiFdReadIdx! } as Instr,
-            { op: "drop" } as Instr,
-
-            // nread = memory[8]
-            { op: "i32.const", value: 8 } as Instr,
-            { op: "i32.load", align: 2, offset: 0 } as Instr,
-            { op: "local.set", index: NREAD } as Instr,
-
-            // if (nread == 0) break;
-            { op: "local.get", index: NREAD } as Instr,
-            { op: "i32.eqz" } as Instr,
-            { op: "br_if", depth: 1 } as Instr,
-
-            // total += nread
-            { op: "local.get", index: TOTAL } as Instr,
-            { op: "local.get", index: NREAD } as Instr,
-            { op: "i32.add" } as Instr,
-            { op: "local.set", index: TOTAL } as Instr,
-
-            // continue
-            { op: "br", depth: 0 } as Instr,
-          ],
-        },
-      ],
-    },
-
-    // dataArr = array.new_default<__str_data>(total)
-    { op: "local.get", index: TOTAL } as Instr,
-    { op: "array.new_default", typeIdx: strDataTypeIdx } as Instr,
-    { op: "local.set", index: DATA } as Instr,
-
-    // i = 0
-    { op: "i32.const", value: 0 } as Instr,
-    { op: "local.set", index: I } as Instr,
-
-    // copy bytes: while (i < total) dataArr[i] = mem[STDIN_BUF_START+i]; i++
-    {
-      op: "block",
-      blockType: { kind: "empty" },
-      body: [
-        {
-          op: "loop",
-          blockType: { kind: "empty" },
-          body: [
-            // if (i >= total) break;
-            { op: "local.get", index: I } as Instr,
-            { op: "local.get", index: TOTAL } as Instr,
-            { op: "i32.ge_u" } as Instr,
-            { op: "br_if", depth: 1 } as Instr,
-
-            // b = i32.load8_u(STDIN_BUF_START + i)
-            { op: "i32.const", value: STDIN_BUF_START } as Instr,
-            { op: "local.get", index: I } as Instr,
-            { op: "i32.add" } as Instr,
-            { op: "i32.load8_u", align: 0, offset: 0 },
-            { op: "local.set", index: B } as Instr,
-
-            // dataArr[i] = b
-            { op: "local.get", index: DATA } as Instr,
-            { op: "local.get", index: I } as Instr,
-            { op: "local.get", index: B } as Instr,
-            { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
-
-            // i++
-            { op: "local.get", index: I } as Instr,
-            { op: "i32.const", value: 1 } as Instr,
-            { op: "i32.add" } as Instr,
-            { op: "local.set", index: I } as Instr,
-
-            { op: "br", depth: 0 } as Instr,
-          ],
-        },
-      ],
-    },
-
-    // return struct.new NativeString(total, 0, dataArr)
-    { op: "local.get", index: TOTAL } as Instr, // len
-    { op: "i32.const", value: 0 } as Instr, // off
-    { op: "local.get", index: DATA } as Instr, // data
-    { op: "struct.new", typeIdx: strTypeIdx } as Instr,
-  ];
-
-  ctx.mod.functions.push({
-    name: "__wasi_read_stdin_all",
-    typeIdx: funcTypeIdx,
-    locals: [
-      { name: "total", type: { kind: "i32" } },
-      { name: "nread", type: { kind: "i32" } },
-      { name: "dataArr", type: { kind: "ref", typeIdx: strDataTypeIdx } },
-      { name: "i", type: { kind: "i32" } },
-      { name: "b", type: { kind: "i32" } },
-    ],
     body,
     exported: false,
   });
@@ -8559,10 +8371,6 @@ function collectExternDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFil
       //   • WASI target → __wasi_*  syscall helpers (#1035)
       //   • non-WASI + allowFs → __node_fs_* JS-host imports (#1491)
       if (ctx.wasiNodeFsFuncs.has(name) && (ctx.wasi || ctx.allowFs)) continue;
-      // #1481: in WASI mode, readStdin() is a built-in routed to __wasi_read_stdin_all,
-      // not a host import — skip the env.readStdin stub so the codegen path in
-      // compileCallExpression takes over.
-      if (ctx.wasi && name === "readStdin") continue;
       // #1663: parseInt / parseFloat have no JS host under WASI / standalone —
       // skip the stub so the unified-collector finalize can emit the WasmGC
       // native scanners (registered under the same funcMap names) instead.

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -1,7 +1,7 @@
 // #1530 — Native Messaging host example compiles to a valid WASI module.
 //
 // The example under examples/native-messaging/host.ts demonstrates reading a
-// Chrome Native Messaging framed message off stdin (fd=0 via readStdin), routing
+// Chrome Native Messaging framed message off stdin (fd=0 via process.stdin.read), routing
 // debug to stderr (fd=2 via console.error), and emitting a JSON response on
 // stdout (fd=1). This test pins down that the example still compiles to a valid
 // WASI binary that imports only wasi_snapshot_preview1 — so a refactor of the
@@ -34,7 +34,7 @@ describe("#1530 Native Messaging host example", () => {
     const result = compile(src, { fileName: "host.ts", target: "wasi" });
     expect(result.success).toBe(true);
     expect(result.wat).toContain("wasi_snapshot_preview1");
-    expect(result.wat).toContain("fd_read"); // readStdin()
+    expect(result.wat).toContain("fd_read"); // process.stdin.read()
     expect(result.wat).toContain("fd_write"); // console.log / console.error
     // Standalone: no JS host env.* imports leak in.
     expect(result.wat).not.toContain('(import "env"');
@@ -123,22 +123,34 @@ describe("#1618/#1651 framed stdin→stdout round-trip", () => {
   }
 
   it("decodes a framed input and re-frames the response with a 4-byte LE prefix", () => {
-    // A self-contained host that mirrors the example: strip the 4-byte prefix,
-    // rebuild the body char-by-char from the decoded length, then write a framed
-    // response (binary length prefix via Uint8Array + JSON body via string).
+    // A self-contained host that mirrors the example: read the 4-byte prefix and
+    // then exactly the declared body bytes via process.stdin.read read-until
+    // loops, rebuild the body char-by-char, then write a framed response (binary
+    // length prefix via Uint8Array + JSON body via string).
     const src = `
-declare function readStdin(): string;
-declare const process: { stdout: { write(chunk: Uint8Array | string): void } };
+declare const process: {
+  stdin: { read(buf: Uint8Array, offset?: number): number };
+  stdout: { write(chunk: Uint8Array | string): void };
+};
 export function main(): void {
-  const framed = readStdin();
-  const b0 = framed.charCodeAt(0) & 0xff;
-  const b1 = framed.charCodeAt(1) & 0xff;
-  const b2 = framed.charCodeAt(2) & 0xff;
-  const b3 = framed.charCodeAt(3) & 0xff;
-  const len = b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
+  const header = new Uint8Array(4);
+  let got = 0;
+  while (got < 4) {
+    const n = process.stdin.read(header, got);
+    if (n <= 0) return;
+    got = got + n;
+  }
+  const len = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+  const bodyBuf = new Uint8Array(len);
+  let bgot = 0;
+  while (bgot < len) {
+    const n = process.stdin.read(bodyBuf, bgot);
+    if (n <= 0) break;
+    bgot = bgot + n;
+  }
   let body = "";
   for (let i = 0; i < len; i++) {
-    body = body + framed.charAt(4 + i);
+    body = body + String.fromCharCode(bodyBuf[i]);
   }
   const response = \`{"received":\${body}}\`;
   const rl = response.length;

--- a/tests/wasi-stdin.test.ts
+++ b/tests/wasi-stdin.test.ts
@@ -2,16 +2,20 @@ import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
 import { buildWasiPolyfill } from "../src/runtime.js";
 
-declare const readStdin: () => string;
+const PROCESS_DECL = `declare const process: {
+  stdin: { read(buf: Uint8Array, offset?: number): number };
+  stdout: { write(c: Uint8Array): void };
+};`;
 
-describe("WASI stdin via fd_read (#1481)", () => {
-  it("registers fd_read import when readStdin() is used", () => {
+describe("WASI stdin via fd_read (#1653)", () => {
+  it("registers fd_read import when process.stdin.read() is used", () => {
     const result = compile(
       `
-      declare function readStdin(): string;
+      ${PROCESS_DECL}
       export function main(): void {
-        const s = readStdin();
-        console.log(s);
+        const buf = new Uint8Array(4);
+        const n = process.stdin.read(buf, 0);
+        process.stdout.write(buf);
       }
       `,
       { target: "wasi" },
@@ -19,26 +23,25 @@ describe("WASI stdin via fd_read (#1481)", () => {
     expect(result.success).toBe(true);
     expect(result.wat).toContain("wasi_snapshot_preview1");
     expect(result.wat).toContain("fd_read");
-    // helper function should be present
-    expect(result.wat).toContain("__wasi_read_stdin_all");
     expect(result.binary.length).toBeGreaterThan(0);
   });
 
-  it("does NOT register fd_read when readStdin() is not used", () => {
+  it("does NOT register fd_read when process.stdin.read() is not used", () => {
     const result = compile(`console.log("no stdin here");`, { target: "wasi" });
     expect(result.success).toBe(true);
     expect(result.wat).not.toContain("fd_read");
-    expect(result.wat).not.toContain("__wasi_read_stdin_all");
   });
 
-  it("does not add WASI imports in default mode even with readStdin reference", () => {
-    // In non-wasi mode, `readStdin` is just an unknown identifier — and our
-    // codegen path is gated by ctx.wasi. The compile may fail (undefined
-    // function), but the important guarantee is no WASI imports leak in.
+  it("does not add WASI imports in default (non-wasi) mode", () => {
+    // In non-wasi mode the codegen path is gated by ctx.wasi, so no WASI
+    // imports should leak in.
     const result = compile(
       `
-      declare function readStdin(): string;
-      export function main(): string { return readStdin(); }
+      ${PROCESS_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        process.stdin.read(buf, 0);
+      }
       `,
     );
     // We don't care if it compiles; we only assert WASI imports are not added.

--- a/tests/wasi.test.ts
+++ b/tests/wasi.test.ts
@@ -10,8 +10,8 @@
 //
 // Scope:
 //   - fd_write fd=1 (console.log) and fd=2 (console.error / console.warn)
-//   - fd_read fd=0 (readStdin) — polyfill-level; e2e roundtripping through
-//     console.log currently boxes the string and is tracked separately.
+//   - fd_read fd=0 (process.stdin.read) — polyfill-level; the binary,
+//     incremental Node-API stdin read (#1653).
 //   - proc_exit (process.exit) — import-presence only; running
 //     process.exit(N) trips an i32/f64 mismatch in the current codegen,
 //     so e2e is covered once that's fixed.
@@ -218,17 +218,21 @@ describe("WASI: proc_exit (compile-time / ABI level)", () => {
 });
 
 describe("WASI: fd_read — stdin polyfill", () => {
-  // E2E readStdin() → console.log roundtrip currently surfaces a boxed
-  // string ("[object]") because the WASI string return path through
-  // console.log goes via the externref boxing helper; tracked separately.
+  // The binary, incremental Node-API stdin read (process.stdin.read, #1653).
   // We validate the polyfill itself + the import registration here.
 
-  it("emits fd_read import only when readStdin() is used", () => {
+  it("emits fd_read import only when process.stdin.read() is used", () => {
     const used = compile(
       `
-        declare function readStdin(): string;
-        const s = readStdin();
-        console.log("ignored");
+        declare const process: {
+          stdin: { read(buf: Uint8Array, offset?: number): number };
+          stdout: { write(c: Uint8Array): void };
+        };
+        export function main(): void {
+          const buf = new Uint8Array(4);
+          process.stdin.read(buf, 0);
+          process.stdout.write(buf);
+        }
       `,
       { target: "wasi" },
     );


### PR DESCRIPTION
## Summary

Removes the bespoke `readStdin()` compiler builtin and replaces every use with the standard Node API `process.stdin.read(buf, offset?)` (added in #1653).

`readStdin()` drained fd=0 to EOF and UTF-8-decoded the result to a string — losing binary fidelity and forcing a one-shot (non-looping) read. Per the project principle ("never invent bespoke compiler builtins; mimic standard Node.js / Web Worker APIs"), the deprecated path is now gone. The fd_read import is still registered (via `needsFdRead`) for `process.stdin.read`.

## Changes

- **src/codegen/expressions/calls.ts**: drop the `readStdin()` dispatch block.
- **src/codegen/index.ts**: drop the `readStdin()` detection, the `__wasi_read_stdin_all` registration + the `emitWasiReadStdinAllHelper` definition, and the `env.readStdin` import-skip.
- **src/codegen/context/types.ts**: drop the now-unused `wasiPendingFdReadHelper` flag.
- **examples/native-messaging/host.ts**: rewrite to a continuous `while (true)` port loop using `process.stdin.read` with a `readExact(buf, n)` helper that handles short reads and breaks on EOF; read the 4-byte LE header then exactly the declared body bytes.
- **examples/native-messaging/README.md**: update the host description + stale `run.sh` → `nm_js2wasm.sh` references (post-merge).
- **tests/{wasi-stdin,wasi,issue-1530}.test.ts**: replace `readStdin()` cases with `process.stdin.read` equivalents.

## Validation

- `tests/wasi-stdin.test.ts`, `tests/wasi.test.ts`, `tests/issue-1530.test.ts`, `tests/issue-1653-wasi-process-stdin-read.test.ts` — all pass (40 tests).
- The shipped `host.ts` round-trips byte-exactly (verified via the #1530 raw-WASI shim test and a local fd_read/fd_write simulation): stdout is the exact 55-byte frame, stderr is the clean `[host] received 17 chars, declared body length 13` line — matching `smoke-test.sh` / the `native-messaging-smoke` CI workflow exactly.
- `npx tsc --noEmit` clean. The 98 equivalence failures observed locally are all in `tests/equivalence/` files this PR does not touch (yield/generator/type-inference) — pre-existing baseline failures, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)