### PR TITLE
fix(ci): baseline PRs use --admin --merge instead of --auto

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -929,8 +929,8 @@ jobs:
             --base main \
             --head "$BRANCH" 2>&1)
           echo "Opened baseline PR: $PR_URL"
-          gh pr merge --auto "$BRANCH" 2>/dev/null || \
-            echo "::warning::auto-merge enable failed — PR may need manual queue."
+          gh pr merge --admin --merge "$BRANCH" 2>/dev/null || \
+            echo "::warning::admin-merge failed — PR may need manual merge."
 
       - name: Audit forced baseline refresh
         if: github.event_name == 'workflow_dispatch' && inputs.force_baseline_refresh == true && inputs.confirm_force == 'YES'


### PR DESCRIPTION
## Problem

`gh pr merge --auto` enqueues baseline PRs in the merge queue. The merge queue waits for required checks that **never fire** because baseline commits use `[skip ci]`. Result: baseline PRs stack up indefinitely — we had 5 stacked today (#888–#892).

## Fix

Switch to `gh pr merge --admin --merge` which merges immediately without waiting for the queue. This is appropriate because:
- These are automated, CI-generated commits (github-actions bot)
- The content is already validated (the test262 run that produced them already passed)
- The only file changed is `benchmarks/results/test262-current.json` (JSON summary)

## Before / After

```diff
- gh pr merge --auto "$BRANCH" 2>/dev/null || \
-   echo "::warning::auto-merge enable failed — PR may need manual queue."
+ gh pr merge --admin --merge "$BRANCH" 2>/dev/null || \
+   echo "::warning::admin-merge failed — PR may need manual merge."
```