### PR TITLE
fix(ci): promote-baseline atomically syncs conformance docs (#1522)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -891,6 +891,17 @@ jobs:
             echo "ABORT: report looks corrupt (pass=$PASS total=$TOTAL). Not committing to main."
             exit 0
           fi
+          # Sync the conformance numbers baked into the prose docs to match the
+          # freshly-promoted test262-current.json. This is the ONLY writer of
+          # the number on main, so it must update everything derived from it
+          # ATOMICALLY in the same commit — otherwise main goes out of sync the
+          # instant the baseline bumps, and every in-flight PR that reaches the
+          # merge-queue head is dropped by the `quality` gate's
+          # sync:conformance:check (it validates the PR merged with main, where
+          # the number has moved but the PR's docs haven't). See #1522 + the
+          # 2026-05-29 merge-queue drops of #895/#896.
+          node scripts/sync-conformance-numbers.mjs || \
+            echo "WARN: sync-conformance-numbers failed (non-fatal) — docs may drift"
           stage_files() {
             git add -f benchmarks/results/test262-current.json \
               benchmarks/results/test262-report.json \
@@ -898,6 +909,10 @@ jobs:
             # editions JSON is regenerated into public/ by the earlier step
             [ -f public/benchmarks/results/test262-editions.json ] && \
               git add -f public/benchmarks/results/test262-editions.json || true
+            # Conformance numbers in prose docs (synced just above). Staged so
+            # the number and its derived docs land in ONE atomic commit.
+            git add -f README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md \
+              2>/dev/null || true
           }
           stage_files
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Problem

`promote-baseline` is the **sole writer** of the test262 conformance number on `main`, but its "Commit refreshed summary JSON to main repo" step only staged the JSON artifacts — never the prose docs (README/ROADMAP/CLAUDE/goal-graph) that the `quality` gate's `sync:conformance:check` validates.

So every baseline bump left main's docs trailing the number, and every in-flight PR that reached the merge-queue head was validated against the new number it didn't carry → **dropped**. This dropped #895 and #896 on 2026-05-29.

## Fix

Run `sync-conformance-numbers.mjs` and stage the 4 docs in the **same commit** that promotes the JSON, so the number and everything derived from it move atomically. main stays self-consistent; merges inherit it.

Follow-up to #896 (pre-push hook), which only covered the local-push path. This closes the main-side gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)