### PR TITLE
chore(sprint56): reconcile stale issue statuses + carry over #1629

### DIFF
--- a/plan/issues/1596-function-prototype-apply-call-not-accessible.md
+++ b/plan/issues/1596-function-prototype-apply-call-not-accessible.md
@@ -1,9 +1,10 @@
 ---
 id: 1596
 title: "Function.prototype.apply / .call not accessible on compiled Wasm functions (~46 fails)"
-status: in-progress
+status: done
 created: 2026-05-24
-updated: 2026-05-28
+updated: 2026-05-29
+completed: 2026-05-29
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -3,7 +3,7 @@ id: 1629
 title: "spec gap: Object.defineProperty — descriptor attribute fidelity (664 test262 fails, biggest single bucket)"
 status: ready
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-05-29
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -11,10 +11,22 @@ task_type: feature
 area: codegen, runtime
 language_feature: object
 goal: spec-completeness
-sprint: 56
+sprint: Backlog
 renumbered_from: 1335
 parent: 1328
 ---
+
+> **Sprint 56 close-out (2026-05-29):** carried over to Backlog. Two of the
+> three sub-clusters landed this sprint — **#1629a** (dynamic/non-literal
+> descriptor materialization, PR #835) and **#1629b** (`getOwnPropertyDescriptor`
+> attribute read-back for plain-object struct fields). The remaining residual is
+> **#1629c** — Array/Function *exotic* `defineProperty` semantics, the largest
+> sub-cluster, which overlaps **#1130** (`status: in-review`). Live baseline
+> `9ee8e921` (2026-05-29) still shows ~1,000 non-passing tests across the
+> `Object.defineProperty` / `getOwnPropertyDescriptor` family, so the umbrella is
+> **not** done. #1629c needs the attribute-table + struct-descriptor-read design
+> from the Implementation Plan below, gated behind / coordinated with #1130.
+
 # #1335 — Object.defineProperty: descriptor attribute fidelity
 
 ## Problem

--- a/plan/issues/821-bindingelement-null-guard-over-triggering.md
+++ b/plan/issues/821-bindingelement-null-guard-over-triggering.md
@@ -1,9 +1,10 @@
 ---
 id: 821
 title: "BindingElement null guard over-triggering"
-status: in-review
+status: done
 created: 2026-03-27
-updated: 2026-04-28
+updated: 2026-05-29
+completed: 2026-05-29
 priority: critical
 feasibility: medium
 reasoning_effort: high


### PR DESCRIPTION
Sprint 56 close-out bookkeeping (docs-only, plan/issues/).

- **#1596** Function.prototype.apply/call: `in-progress` → `done` (merged)
- **#821** BindingElement null guard: `in-review` → `done` (PR #643 merged)
- **#1629** Object.defineProperty umbrella → `sprint: Backlog`. #1629a (PR #835) + #1629b landed; residual **#1629c** (Array/Function exotic defineProperty, ~1000 family fails on baseline 9ee8e921, overlaps in-review #1130) carried over with a close-out note.

#820h/#820j were already `done` on main. After this, Sprint 56 has no stale-status issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)