### PR TITLE
plan(sprint57): acorn dogfood + backend-agnostic IR

### DIFF
--- a/plan/goals/backend-agnostic-ir.md
+++ b/plan/goals/backend-agnostic-ir.md
@@ -1,0 +1,111 @@
+# Goal: backend-agnostic-ir
+
+**The typed middle-end IR (`src/ir/`) is decoupled from any single backend, so it can lower to (1) WasmGC today, (2) linear memory, and (3) a future bytecode interpreter — without the IR presuming WasmGC.**
+
+- **Status**: Active
+- **Track**: Supporting / architecture track (parallel to conformance)
+- **Target**: A documented backend-trait seam in `src/ir/lower.ts`; at least one node kind lowered through that seam to two backends; one proof point of a non-WasmGC backend.
+- **Dependencies**: `compiler-architecture` (activatable). Builds on #1131 (SSA IR), #1527/codegen-axes doc, #1530 (phase out the warning fallback).
+
+## Why
+
+The codegen-axes doc (`docs/architecture/codegen-axes.md`) names two orthogonal
+axes and makes one explicit admission:
+
+> Today, IR adoption gives you a typed front-end on a **WasmGC backend**. The
+> architecture admits an IR adoption on the linear backend (a
+> `lower-linear.ts` sibling), but no AST node kind has demanded it yet.
+
+In other words: the IR's `lower.ts` (~2,460 lines) emits `struct.new`,
+`struct.get`, `array.get`, `ref.cast` *inline in its node switch*. There is no
+backend boundary — the IR-node→Wasm-op mapping is hardcoded to WasmGC. The doc
+itself lists the exact leak points (the "Current hidden bias" table). This is
+acceptable as a one-backend-old state, but it blocks two strategic directions:
+
+1. **The bytecode interpreter (#1584)** needs the IR to be lowerable to a
+   *non-Wasm* target (a bytecode opcode stream executed by a dispatch loop).
+   That is impossible while lowering is hardwired to emit Wasm GC ops.
+2. **IR adoption on the linear backend** — `src/codegen-linear/` reads the AST
+   directly today, duplicating front-end work the IR already does. Routing
+   linear lowering through the IR removes that duplication for the node kinds
+   where the front-end concern is identical and only the *op emission* differs.
+
+The user's intent is to make the IR's instruction contract **backend-agnostic**
+so a backend is a *visitor over IR nodes*, not a hardcoded switch arm. The IR
+declares *what* (build a closure cell, read a vec element, box a scalar); the
+backend decides *how* (WasmGC struct vs linear-memory offset vs bytecode op).
+
+## Approach
+
+This is a multi-sprint goal. Sprint 57 lands the first three issues — the
+audit/seam, one two-backend proof, and a minimal bytecode proof point:
+
+1. **Audit + seam definition** (#1713, `feasibility: hard`, needs architect
+   spec) — enumerate every WasmGC-specific emission in `lower.ts` against the
+   codegen-axes "hidden bias" table; define a `BackendEmitter` trait (the set
+   of operations a backend must implement: `emitStructNew`, `emitFieldGet`,
+   `emitArrayGet`, `emitBoxScalar`, `emitCallRef`, …) that captures the
+   *intent* of each emission without naming Wasm ops. Deliver the trait
+   interface + a `WasmGcEmitter` implementation that is behavior-identical to
+   today's inline emission (pure refactor, zero conformance delta).
+2. **Two-backend proof** (#1714) — pick ONE already-IR-owned, structurally
+   simple node kind (recommend the vec/array length+element-read path, which
+   `lower.ts` already lowers and which has a clean linear analogue) and lower
+   it through the trait to BOTH the WasmGC emitter and a new
+   `src/ir/lower-linear.ts` emitter. Prove the same IR node produces correct
+   output on both backends via a focused equivalence test. This is the first
+   node kind to "demand" the linear lift the codegen-axes doc anticipates.
+3. **Bytecode proof point** (#1715) — a minimal bytecode emitter + TS dispatch
+   loop for a *tiny* IR subset (arithmetic + locals + return + one branch),
+   proving the trait can target a non-Wasm backend. This is the de-risking
+   first slice of #1584's Phase 1, scoped down to "does the seam admit a
+   bytecode backend at all" — NOT the full interpreter.
+4. **#1530 alignment** (tracked, not a sprint-57 issue) — driving IR-owned
+   node kinds forward feeds backend-agnosticism: a kind can only be lowered by
+   multiple backends once it is IR-owned end-to-end.
+
+## The bytecode-vs-extend-linear decision
+
+Both #1714 (extend linear coverage via the trait) and #1715 (bytecode proof)
+are in scope for Sprint 57 because they de-risk *different* claims:
+
+- **#1714 (linear-via-trait)** proves the trait abstracts a backend that
+  *already exists and is exercised by WASI*. Low risk, high architectural
+  payoff, directly retires front-end duplication. This is the **primary**
+  proof point — it must land.
+- **#1715 (bytecode)** proves the trait can target a backend with a
+  *fundamentally different execution model* (dispatch loop, not structured
+  Wasm). Higher risk, scoped to a throwaway-grade minimal subset, gated behind
+  #1713. This is the **stretch** proof point — it validates the #1584
+  direction before that 8–12 week investment is committed.
+
+Reasoning: extending the linear backend is the higher-value *first* proof
+because it is grounded in a real, shipping target (WASI) and immediately
+removes duplicated front-end work, whereas the bytecode interpreter is a large
+speculative investment. But doing a *minimal* bytecode slice in the same sprint
+is cheap insurance: if the trait cannot cleanly express a bytecode target, we
+learn that for ~1 issue of effort instead of discovering it 8 weeks into #1584.
+
+## Issues
+
+| # | Title | Sprint | Status | Priority |
+|---|-------|--------|--------|----------|
+| **1124** | Audit current codegen IR / define minimal SSA middle-end | 42 | done | high |
+| **1131** | Middle-end SSA IR: implementation plan | 43 | ready | high |
+| **1530** | Phase out the IR demote-to-warning fallback channel | Backlog | ready | high |
+| **1584** | Wasm-GC-native bytecode interpreter (acorn + eval) | Backlog | ready | medium |
+| **1713** | IR backend-trait: audit WasmGC bias + define BackendEmitter seam | 57 | ready | high |
+| **1714** | Lower one IR node kind through the trait to BOTH WasmGC and linear | 57 | backlog | high |
+| **1715** | Minimal bytecode emitter + dispatch loop for an IR subset (proof point) | 57 | backlog | medium |
+
+## Success criteria
+
+- `lower.ts` no longer emits WasmGC ops inline for the audited node kinds;
+  emission goes through a `BackendEmitter` trait whose `WasmGcEmitter`
+  implementation is behavior-identical (zero conformance delta).
+- At least one node kind is provably lowered to two backends (WasmGC + linear)
+  from the same IR.
+- A minimal bytecode backend exists as a proof point, executing a tiny IR
+  subset through a dispatch loop, validating the #1584 direction.
+- The codegen-axes "hidden bias" table is updated to reflect which leaks are
+  now behind the trait.

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -85,6 +85,19 @@ and a goal being "ready" doesn't mean it should be worked on immediately.
    +--------------+      +--------------+
    Depends on:           Independent
    standalone-mode
+
+   +-------------------+   +----------------------+
+   | self-hosting-     |   | backend-agnostic-ir  |
+   |   dogfood         |   | (IR independent of   |
+   | (compile acorn,   |   |  backend: WasmGC /   |
+   |  diff vs node)    |   |  linear / bytecode)  |
+   +-------------------+   +----------------------+
+   Depends on:             Depends on:
+   compilable (met)        compiler-architecture
+   crash-free (partial)    (activatable)
+   ── both feed #1584 (in-Wasm bytecode interpreter), which needs ──
+   ── compiled-acorn (self-hosting-dogfood) AND a non-Wasm IR     ──
+   ── backend (backend-agnostic-ir) ──
 ```
 
 ## Goal Status Summary
@@ -108,6 +121,8 @@ and a goal being "ready" doesn't mean it should be worked on immediately.
 | **performance** | Activatable | faster output | core-semantics | #743, #773, #745, #744, #824 (timeouts) |
 | **platform** | Blocked | edge deploy | standalone-mode | #639, #640, #641, #644 |
 | **refactoring** | Independent | maintainability | -- | #688, #741, #788, #803-#811 |
+| **self-hosting-dogfood** | Active (s57) | compiled acorn AST == node-acorn | compilable (met), crash-free (partial) | #1710 (harness), #1711 (triage), #1712 (acceptance); #1679/#1690/#1690b done |
+| **backend-agnostic-ir** | Active (s57) | IR lowers to 2+ backends via a trait | compiler-architecture | #1713 (trait seam, hard, arch-spec), #1714 (linear proof), #1715 (bytecode proof); feeds #1584 |
 
 ## How to use this
 

--- a/plan/goals/self-hosting-dogfood.md
+++ b/plan/goals/self-hosting-dogfood.md
@@ -1,0 +1,76 @@
+# Goal: self-hosting-dogfood
+
+**The compiler can compile real, idiomatic ES-module codebases — starting with acorn, the parser the compiler itself depends on — to Wasm and run them correctly.**
+
+- **Status**: Active
+- **Track**: Supporting / dogfood track (parallel to conformance)
+- **Target**: Compiled-to-Wasm acorn parses a representative `.js` file and emits an AST structurally equal to node-acorn's on the same input.
+- **Dependencies**: `compilable` (met), `crash-free` (partial). Shares value-representation and builtins with `standalone-mode` but is not blocked on it.
+
+## Why
+
+test262 is a synthetic corpus: each case is small, hand-written, and exercises
+one feature in isolation. Real codebases combine features at scale, in
+idioms test262 never produces — deep prototype chains, 700-element module
+globals indexed in hot loops, recursive-descent parsers, `new this()`
+static factories, regex-heavy scanners, Maps/Sets, getters/setters.
+
+acorn (MIT, ~6.3k-line pure-ESM JavaScript parser, no native deps) is the
+ideal first dogfood target for three reasons:
+
+1. **It is the compiler's own front-end dependency** — compiling it is the
+   literal "compiler compiles its own parser" milestone, and a hard
+   prerequisite for the in-Wasm bytecode interpreter (#1584, goal
+   `backend-agnostic-ir`) that needs a runtime parser.
+2. **It surfaces interaction bugs test262 cannot** — already proven and
+   **already fixed**: #1679 (`new this(...)`), #1690 (global-array-ref
+   index-shift in `f64.lt`), #1690b (`var` shadowing a module global) are all
+   `done`. Each was a real compiler defect found *only* at full-module scale —
+   which is the whole point of the dogfood. With those three cleared, the next
+   lap needs a harness to find what remains.
+3. **It has a built-in oracle** — node-acorn. Differential testing against the
+   reference parser on the same input gives a crisp, automatable pass/fail for
+   runtime correctness, not just "compiles to valid Wasm".
+
+This goal is **iterative**: attempt to compile acorn → capture the failure
+surface (compile errors + runtime divergences vs node-acorn) → triage into
+concrete sized issues → fix → re-attempt. The acceptance milestone is a green
+differential test, not a green compile.
+
+## Approach
+
+1. **Harness** (#1710) — a reproducible, in-repo harness that compiles each
+   acorn module, validates the binary, runs it in standalone + JS-host mode,
+   and diffs its AST output against node-acorn on a fixture corpus. Captures
+   the failure surface as structured data (compile-error category, validation
+   error, runtime divergence) so triage is mechanical.
+2. **Prior blockers** (#1679, #1690, #1690b) — all `done`; the harness must
+   regression-guard them so they cannot silently come back.
+3. **Triage milestone** (#1711) — run the harness, bucket the surface, file
+   one sized child issue per distinct gap. This is the issue that converts the
+   harness output into the backlog.
+4. **Acceptance milestone** (#1712) — compiled acorn parses a representative
+   `.js` file and emits a structurally-equal AST to node-acorn. This is the
+   goal's definition of done for the first dogfood lap.
+
+## Issues
+
+| # | Title | Sprint | Status | Priority |
+|---|-------|--------|--------|----------|
+| **1679** | acorn: `new this(...)` dynamic constructor | Backlog | done | medium |
+| **1690** | acorn.mjs invalid Wasm: f64.lt reads global array ref (index-shift) | Backlog | done | high |
+| **1690b** | inner `var x` aliases module-level global (scoping) | Backlog | done | high |
+| **1710** | acorn dogfood harness: compile + validate + differential-AST vs node-acorn | 57 | ready | high |
+| **1711** | acorn failure-surface triage: bucket + file sized child issues | 57 | ready | high |
+| **1712** | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | 57 | backlog | high |
+
+## Success criteria
+
+- A reproducible harness exists in-repo (not `.tmp/` scratch) that any agent
+  can run to reproduce the acorn failure surface.
+- The failure surface is triaged into sized, independently-dispatchable issues.
+- The acceptance milestone (#1712) passes: compiled acorn, run on a fixture
+  `.js` source, produces an AST structurally equal to node-acorn's.
+- Every distinct gap acorn exposes is captured as an issue (not lost in a
+  scratch buffer), feeding the conformance backlog with real-world-weighted
+  priorities.

--- a/plan/issues/1690-acorn-isinastralset-global-array-f64-mismatch.md
+++ b/plan/issues/1690-acorn-isinastralset-global-array-f64-mismatch.md
@@ -11,9 +11,9 @@ reasoning_effort: high
 task_type: bugfix
 area: codegen, import-bookkeeping
 language_feature: arrays, globals, closures, number-arithmetic
-goal: real-world-compat
+goal: self-hosting-dogfood
 sprint: Backlog
-related: [1679, 1677, 1666, 1618, 1314]
+related: [1679, 1677, 1666, 1618, 1314, 1710, 1711, 1712]
 note: "Surfaced behind #1679. With #1679's `new this(...)` blocker gone on current main (e622751f7), acorn.mjs now compiles to success=true with 0 errors but emits INVALID Wasm — the next blocker. Distinct from #1679 (which is codegen-acceptance only)."
 ---
 

--- a/plan/issues/1690b-var-shadows-module-global.md
+++ b/plan/issues/1690b-var-shadows-module-global.md
@@ -11,10 +11,10 @@ reasoning_effort: medium
 task_type: bugfix
 area: codegen, identifier-resolution, scoping
 language_feature: var-hoisting, function-scope, shadowing
-goal: real-world-compat
+goal: self-hosting-dogfood
 sprint: Backlog
 parent: 1690
-related: [1690]
+related: [1690, 1710, 1711, 1712]
 note: "Carved from #1690 — root-cause work on the acorn.mjs stress test surfaced two distinct defects. Defect #1 (this issue) is a runtime-semantics scoping bug independent of the f64/array-ref Wasm-validation issue tracked under #1690 itself."
 ---
 # #1690b — Inner `var x` aliases module-level `__mod_x` global (identifier-resolution layer)

--- a/plan/issues/1710-acorn-dogfood-harness.md
+++ b/plan/issues/1710-acorn-dogfood-harness.md
@@ -35,10 +35,12 @@ regression guard once a gap is fixed.
 
 Build a committed harness that mechanizes the dogfood loop:
 
-1. **Acquire acorn deterministically** — pin a specific acorn version
-   (8.16.0, matching #1690) via a vendored copy under `tests/fixtures/acorn/`
-   or a pinned `npm pack` step, so the harness is hermetic and version-stable.
-   Do NOT depend on a live network fetch at test time.
+1. **Acquire acorn deterministically** — **DECISION (2026-05-29, project lead):
+   use a pinned `npm pack` step** at harness setup (acorn 8.16.0, matching
+   #1690), not a vendored source copy. Pin the exact version + integrity so the
+   harness is reproducible; resolve the packed tarball into the harness's
+   fixture dir at setup time. Do NOT depend on an unpinned live network fetch at
+   test time (CI may have no network mid-run — fetch happens at setup/install).
 2. **Compile** each acorn entry module (`acorn.mjs`) via the programmatic
    `compile(src, { fileName: "acorn.mjs" })` API and record:
    - compile `success` + the categorized error list (collapse the known TS
@@ -98,5 +100,5 @@ the decision in the harness).
   *follow-up* (likely a #1711 child) — JS-host execution is the first lap so we
   separate "does acorn run correctly at all" from "does it run host-free".
 - Keep the oracle dependency (node-acorn) as a `devDependency` pinned to the
-  same version as the vendored compiled-acorn source, so the two parsers are
+  same version as the `npm pack`-resolved compiled-acorn source, so the two parsers are
   the same acorn and any divergence is a *compiler* bug, not a version skew.

--- a/plan/issues/1710-acorn-dogfood-harness.md
+++ b/plan/issues/1710-acorn-dogfood-harness.md
@@ -1,0 +1,102 @@
+---
+id: 1710
+title: "acorn dogfood harness: compile + validate + differential-AST vs node-acorn"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: test
+area: tooling, test-infrastructure
+language_feature: n/a
+es_edition: multi
+goal: self-hosting-dogfood
+sprint: 57
+related: [1679, 1690, 1690b, 1584, 1058]
+---
+# #1710 — acorn dogfood harness: compile + validate + differential-AST vs node-acorn
+
+## Problem
+
+acorn has already surfaced three real compiler defects (#1679 `new this`,
+#1690 invalid-Wasm index-shift, #1690b var-shadow), but every investigation so
+far has used throwaway scratch files under `.tmp/acorn/` (`probe.mjs`,
+`repro*.mjs`). There is **no committed, reproducible harness** that any agent
+can run to regenerate the acorn failure surface, and no automated oracle for
+*runtime* correctness — the scratch probes only check `WebAssembly.compile()`
+validation, not whether compiled acorn produces the *right AST*.
+
+Without a harness, the dogfood loop is not repeatable: each agent re-derives
+the repro, the failure surface is never captured as data, and there is no
+regression guard once a gap is fixed.
+
+## Goal
+
+Build a committed harness that mechanizes the dogfood loop:
+
+1. **Acquire acorn deterministically** — pin a specific acorn version
+   (8.16.0, matching #1690) via a vendored copy under `tests/fixtures/acorn/`
+   or a pinned `npm pack` step, so the harness is hermetic and version-stable.
+   Do NOT depend on a live network fetch at test time.
+2. **Compile** each acorn entry module (`acorn.mjs`) via the programmatic
+   `compile(src, { fileName: "acorn.mjs" })` API and record:
+   - compile `success` + the categorized error list (collapse the known TS
+     `Property does not exist` JS-noise warnings into one bucket — they are not
+     blockers, per #1679/#1690).
+   - `WebAssembly.compile(binary)` validation result + the first validator
+     error verbatim (the surface that exposed #1690).
+3. **Run + differentially test** — when the binary validates, instantiate it
+   (JS-host mode is acceptable for the first lap; standalone is a follow-up),
+   call acorn's `parse(source, options)` on a small fixture corpus of `.js`
+   inputs, and structurally compare the resulting AST to **node-acorn**'s AST
+   on the identical input. Report the first divergence (path + expected vs
+   actual node).
+4. **Emit a structured surface report** — write a machine-readable summary
+   (JSON) of `{ compile_errors[], validation_error|null, ast_divergences[] }`
+   so #1711 (triage) can bucket it mechanically. Print a human summary too.
+
+## Fixture corpus
+
+Start tiny and idiomatic — enough to exercise the parser's hot paths without
+a huge oracle diff:
+
+- `tests/fixtures/acorn-inputs/arith.js` — `const x = 1 + 2 * (3 - 4);`
+- `tests/fixtures/acorn-inputs/fn.js` — a function decl + arrow + default param
+- `tests/fixtures/acorn-inputs/class.js` — a small class with a method + getter
+- `tests/fixtures/acorn-inputs/control.js` — `if`/`for`/`while`/`try` mix
+- `tests/fixtures/acorn-inputs/strings.js` — template literal + regex literal
+
+Each fixture is parsed by both compiled-acorn and node-acorn with the same
+`ecmaVersion`/`sourceType` options; ASTs are compared with a structural deep
+equal that ignores `start`/`end`/position fields if those prove noisy (note
+the decision in the harness).
+
+## Acceptance criteria
+
+1. A committed harness (e.g. `tests/dogfood/acorn-harness.mjs` + a thin
+   `tests/dogfood/acorn.test.ts` wrapper, OR a `scripts/dogfood-acorn.mjs`
+   invoked by an npm script `pnpm run dogfood:acorn`) reproduces the current
+   acorn failure surface deterministically from a clean checkout, with **no
+   network access at run time** (acorn pinned/vendored).
+2. The harness emits a structured JSON surface report and a human-readable
+   summary covering: compile-error categories, the `WebAssembly.compile`
+   validation result, and per-fixture AST divergence (or "structurally equal").
+3. On current main the harness **runs to completion and reports** the known
+   #1690 validation failure (it does not crash the harness) — i.e. it is robust
+   to the surface being red.
+4. The harness is documented in the issue/sprint doc and referenced from
+   #1711 (triage) and #1712 (acceptance) as the shared tool.
+5. Does NOT itself attempt to fix any compiler bug — pure tooling. Must not
+   regress test262 (it adds test infra only).
+
+## Notes / scope
+
+- This is the keystone for the `self-hosting-dogfood` goal: #1711 consumes its
+  output, #1712 reuses its differential-AST comparison as the acceptance gate.
+- Standalone (`--target wasi`) execution of compiled acorn is explicitly a
+  *follow-up* (likely a #1711 child) — JS-host execution is the first lap so we
+  separate "does acorn run correctly at all" from "does it run host-free".
+- Keep the oracle dependency (node-acorn) as a `devDependency` pinned to the
+  same version as the vendored compiled-acorn source, so the two parsers are
+  the same acorn and any divergence is a *compiler* bug, not a version skew.

--- a/plan/issues/1711-acorn-failure-surface-triage.md
+++ b/plan/issues/1711-acorn-failure-surface-triage.md
@@ -1,0 +1,78 @@
+---
+id: 1711
+title: "acorn failure-surface triage: bucket harness output + file sized child issues"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: planning
+area: triage
+language_feature: n/a
+es_edition: multi
+goal: self-hosting-dogfood
+sprint: 57
+depends_on: [1710]
+related: [1690, 1690b, 1679]
+---
+# #1711 — acorn failure-surface triage: bucket harness output + file sized child issues
+
+## Problem
+
+The #1710 harness produces a structured failure surface (compile errors,
+validation errors, AST divergences) for compiled acorn. That surface is raw
+data; it must be turned into an actionable, sized backlog. Without triage, the
+dogfood loop stalls — devs cannot pick up "fix acorn" as a single issue (it is
+many distinct gaps), and the real-world-weighted priority signal is lost.
+
+## Goal
+
+Run the #1710 harness against current main, bucket every distinct failure into
+a root-cause category, and file one sized child issue per category. This is a
+PO/architect triage task, not a code-fix task.
+
+## Method
+
+1. Run `pnpm run dogfood:acorn` (or equivalent from #1710) on current main.
+2. For each entry in the surface report:
+   - **Compile errors** — collapse the known TS JS-noise warnings (the
+     `Property X does not exist on type Y` bucket from #1679/#1690 — NOT
+     blockers). For genuine `success:false` errors, group by error message
+     stem (e.g. "Unsupported new expression", "type-resolution-failure").
+   - **Validation errors** — group by validator message class (the #1690
+     `f64.lt expected f64, found global.get` is the index-shift class). Check
+     each against existing index-shift issues (#1618, #1677, #1314) before
+     filing a new one.
+   - **AST divergences** — group by the construct that diverges (a specific
+     node kind, a specific option like `locations`, a numeric/precision issue).
+3. For each distinct, *un-tracked* root cause, create a sized child issue
+   (`/create-issue`) with: a minimal repro reduced from the acorn site (not the
+   whole 6k-line file), the spec citation, the affected source files, an
+   estimated size, and `goal: self-hosting-dogfood`, `parent: 1711`.
+4. Cross-link: any cause already covered by an open issue (#1690, #1690b, or a
+   conformance bucket) gets noted in the triage table, NOT re-filed.
+5. Order the resulting child issues by **real-world weight** — a gap acorn hits
+   in a hot path (scanner, identifier classification) outranks a rarely-hit
+   one, independent of raw test262 count.
+
+## Acceptance criteria
+
+1. A triage table is written into this issue (and the dogfood goal file)
+   mapping every distinct failure-surface entry → root cause → tracking issue
+   (existing or newly filed) → size estimate → real-world weight.
+2. Every genuine, un-tracked root cause has a sized child issue filed with a
+   minimal repro and spec citation. Known/noise buckets are explicitly listed
+   as "not filed, reason: …".
+3. The triage distinguishes *codegen-acceptance* gaps (won't compile / invalid
+   Wasm) from *runtime-divergence* gaps (compiles + validates but wrong AST) —
+   the latter are the higher-value, harder-to-find class.
+4. No compiler code changes (planning/triage only).
+
+## Notes / scope
+
+- This issue is the bridge between the harness (#1710) and the fixes. It runs
+  *after* #1710 lands and is re-run each dogfood lap as new gaps are cleared.
+- Child issues filed here inherit `goal: self-hosting-dogfood` and may be
+  pulled into Sprint 57 if small enough, or deferred to the backlog with a
+  real-world-weight tag for a later sprint.

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -1,0 +1,77 @@
+---
+id: 1712
+title: "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn"
+status: backlog
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: test
+area: test-infrastructure, codegen
+language_feature: multi
+es_edition: multi
+goal: self-hosting-dogfood
+sprint: 57
+depends_on: [1710, 1711]
+related: [1690, 1690b, 1584, 1058]
+---
+# #1712 — Acceptance milestone: compiled acorn parses a representative .js with a structurally-equal AST
+
+## Problem
+
+This is the **definition of done for the first dogfood lap** of the
+`self-hosting-dogfood` goal. All the other acorn issues (#1710 harness, #1711
+triage, #1690, #1690b, and #1711's children) exist to make this one pass.
+
+The milestone: take the #1710 harness, compile acorn to Wasm, instantiate it,
+parse a representative real `.js` source file, and assert the produced AST is
+**structurally equal** to node-acorn's AST on the identical input. This is the
+end-to-end proof that "the compiler can compile its own parser and run it
+correctly" — not just compile it to valid Wasm.
+
+## Why it's `feasibility: hard` and depends on others
+
+The three known full-module blockers are **already fixed**: #1679
+(`new this`), #1690 (invalid-Wasm index-shift), #1690b (var-shadow) are all
+`done`. So acorn may already compile to a *valid, instantiable* binary on
+current main — but "valid Wasm" is not "correct AST". The remaining risk is
+*runtime divergence*: compiled acorn instantiates and runs but produces a
+subtly wrong AST (off-by-one positions, a dropped node, a mis-coerced numeric
+field). Those bugs are exactly what the #1710 harness + #1711 triage exist to
+surface, and any of them blocks this acceptance.
+
+So #1712 is the *integration gate*: it flips from `backlog` to `ready` once
+#1710 (harness) lands and #1711 (triage) confirms either zero divergences (in
+which case #1712 may pass immediately) or a tractable set of fixes. It is the
+track's north star; whether it lands *within* s57 depends on what #1711
+surfaces. The optimistic case — given the known blockers are cleared — is that
+#1712 passes early and the sprint pivots to widening the fixture corpus.
+
+## Acceptance criteria
+
+1. A committed test (extending the #1710 harness) compiles acorn to Wasm,
+   instantiates it (JS-host mode acceptable for this lap), and calls
+   `parse(fixtureSource, { ecmaVersion, sourceType })`.
+2. The compiled-acorn AST is **structurally deep-equal** to node-acorn's AST on
+   the same `fixtureSource` for at least one non-trivial representative `.js`
+   file (e.g. a real ~100–300 line module mixing functions, classes, control
+   flow, template literals, and regex — a reduced slice of a real library).
+3. The comparison is documented: which fields are compared, which (if any)
+   position fields are normalized, and why.
+4. The test is wired so it can run in CI without network access (acorn pinned
+   per #1710) and is fast enough not to bloat the suite (single representative
+   file, not the whole acorn test262 corpus).
+5. No test262 regression.
+
+## Notes / scope
+
+- A passing #1712 is the trigger to (a) widen the fixture corpus for a second
+  dogfood lap (more libraries), and (b) unblock #1584's "compile acorn as the
+  runtime parser" dependency — the interpreter needs exactly this artifact.
+- Standalone (`--target wasi`) acorn execution is a *second-lap* extension, not
+  part of this acceptance (JS-host first to isolate codegen correctness from
+  host-import gaps).
+- Status starts `backlog`; the tech lead flips it to `ready` once the blocking
+  issues merge. Do NOT dispatch a dev to "make #1712 pass" directly — it is an
+  integration gate, satisfied by fixing its dependencies.

--- a/plan/issues/1713-ir-backend-emitter-trait-seam.md
+++ b/plan/issues/1713-ir-backend-emitter-trait-seam.md
@@ -1,0 +1,108 @@
+---
+id: 1713
+title: "IR backend-trait: audit WasmGC bias in lower.ts + define BackendEmitter seam"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: ir, codegen, architecture
+language_feature: n/a
+es_edition: n/a
+goal: backend-agnostic-ir
+sprint: 57
+related: [1131, 1527, 1530, 1584, 1714, 1715]
+needs_architect_spec: true
+---
+# #1713 — IR backend-trait: audit WasmGC bias in `lower.ts` + define a `BackendEmitter` seam
+
+## Problem
+
+`src/ir/lower.ts` (~2,460 lines) is the IR→Wasm emission pass. It emits WasmGC
+ops (`struct.new`, `struct.get`, `struct.set`, `array.get`, `ref.cast`,
+`array.new_fixed`, …) **inline in its per-IR-node switch**. There is no backend
+boundary: the mapping from IR-node intent ("read field N of this object",
+"build a closure cell", "box a scalar") to concrete WasmGC ops is hardcoded.
+
+The codegen-axes doc (`docs/architecture/codegen-axes.md`, "Current hidden bias
+in `src/ir/`" table) already enumerates the leak points and states the intent:
+
+> The architecture admits an IR adoption on the linear backend (a
+> `lower-linear.ts` sibling) … When [a node kind demands it], the lift becomes
+> worth the cost.
+
+This issue does that lift's *foundation*: extract a `BackendEmitter` trait so a
+backend becomes a visitor over IR-node emission intents, not a hardcoded switch
+arm. It blocks both #1714 (lower one kind to two backends) and #1715 (bytecode
+proof) — neither can proceed until the seam exists.
+
+## Why `feasibility: hard` / needs architect spec
+
+This touches the central IR emission pass. The risk is a behavior-changing
+refactor regressing test262. The design questions that need an architect spec
+before any dev work:
+
+1. **Granularity of the trait.** Too fine (one method per Wasm op) and it's
+   just a renamed `Instr` constructor — no abstraction. Too coarse (one method
+   per IR node kind) and each backend re-implements the whole switch. The right
+   level is *semantic emission primitives*: `emitStructNew(layout, fields)`,
+   `emitFieldGet(layout, fieldName)`, `emitFieldSet`, `emitArrayGet(elemType)`,
+   `emitArrayLen`, `emitBoxScalar(valType)`, `emitUnboxScalar`,
+   `emitClosureCell`, `emitCallRef(sig)`, `emitConst`, `emitLocalGet/Set`,
+   `emitBranch`, `emitReturn`. The architect must enumerate the actual set by
+   walking `lower.ts`'s emission sites and clustering them.
+2. **Where layout decisions live.** The WasmGC layout (`union.typeIdx`,
+   `obj.fieldIdx(name)`, `vec.arrayTypeIdx`) is computed in the alloc-registry
+   passes. The trait must take *abstract layout handles* (a struct identity, a
+   field name) and let the backend resolve them to its representation (a WasmGC
+   typeIdx vs a linear-memory offset vs a bytecode constant-pool index). The
+   spec must decide what the layout-handle type is and how the `WasmGcEmitter`
+   maps it back to today's `typeIdx`/`fieldIdx`.
+3. **Type representation at the seam.** `IrType` is already backend-neutral
+   (`nodes.ts` separates it from `ValType`). Confirm the trait consumes
+   `IrType`/abstract layout handles, never raw `ValType`/`typeIdx`, except
+   inside `WasmGcEmitter`.
+
+## Scope (Sprint 57)
+
+Phase 1 — the seam + behavior-identical WasmGC implementation. NOT a second
+backend (that's #1714/#1715).
+
+1. Architect writes `## Implementation Plan` enumerating the emission primitive
+   set, the layout-handle abstraction, and the `lower.ts` call sites that move
+   behind each primitive (with line refs against current main).
+2. Define `BackendEmitter` interface (likely `src/ir/backend/emitter.ts`).
+3. Implement `WasmGcEmitter implements BackendEmitter` (likely
+   `src/ir/backend/wasmgc-emitter.ts`) that produces the *exact same* `Instr`
+   stream `lower.ts` produces today.
+4. Refactor `lower.ts` to route emission through the trait instance instead of
+   pushing `Instr`s inline, for the node kinds the spec covers. (The spec may
+   stage this — not every node kind must move in one PR; the audit defines the
+   order. A partial but clean seam is acceptable as long as the moved kinds are
+   100% behind the trait and the rest are explicitly flagged as not-yet-moved.)
+5. Update the codegen-axes "Current hidden bias" table to mark which leaks are
+   now behind the trait.
+
+## Acceptance criteria
+
+1. A `BackendEmitter` trait exists, consumed by `lower.ts`; a `WasmGcEmitter`
+   implements it.
+2. **Zero conformance delta** — this is a pure refactor. test262 pass count is
+   unchanged (±0 net; any change is a bug). The IR fallback budget
+   (`pnpm run check:ir-fallbacks`) does not grow.
+3. The emission primitives the spec enumerated are routed through the trait;
+   `lower.ts` no longer pushes WasmGC `Instr`s inline for those node kinds.
+4. The codegen-axes doc "Current hidden bias" table is updated.
+5. The architect spec (`## Implementation Plan`) is committed in this issue
+   before dev dispatch.
+
+## Notes / scope
+
+- This is the enabling refactor. It must NOT try to also add a second backend
+  — that scope is #1714 (linear) and #1715 (bytecode), which depend on this.
+- Keep `src/ir/types.ts` (the shared Wasm `Instr` union) as-is — per the
+  codegen-axes doc it is shared Wasm-encoding bookkeeping, not IR coupling. The
+  trait sits *above* `Instr`; `WasmGcEmitter` still produces `Instr`.
+- Reasoning effort high; route to architect for the spec before any dev claims.

--- a/plan/issues/1714-ir-two-backend-proof-linear.md
+++ b/plan/issues/1714-ir-two-backend-proof-linear.md
@@ -1,0 +1,84 @@
+---
+id: 1714
+title: "Lower one IR node kind through the BackendEmitter trait to BOTH WasmGC and linear"
+status: backlog
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: ir, codegen-linear, architecture
+language_feature: arrays
+es_edition: n/a
+goal: backend-agnostic-ir
+sprint: 57
+depends_on: [1713]
+related: [1131, 1527, 1530]
+needs_architect_spec: true
+---
+# #1714 — Lower one IR node kind through the trait to BOTH WasmGC and linear
+
+## Problem
+
+#1713 defines the `BackendEmitter` trait and a `WasmGcEmitter`. That proves the
+seam *exists* but not that it *abstracts* anything — a single-implementation
+trait is just indirection. This issue is the proof that the seam is genuinely
+backend-agnostic: take ONE IR-owned node kind and lower it, from the same IR,
+to two structurally different backends.
+
+This is the first AST node kind to "demand" the linear-backend IR lift the
+codegen-axes doc anticipates ("no AST node kind has demanded it yet").
+
+## Recommended node kind: the vec (array) length + element-read path
+
+`lower.ts` already lowers vec length and element access via
+`struct.get $vec $length` and `struct.get $vec $data` + `array.get` (see the
+`vec.*` emission sites around `lower.ts:1204–1336`). This kind is ideal because:
+
+- It is already IR-owned (no front-end work needed).
+- It has a clean linear analogue: length is a header field at a fixed offset;
+  element read is `i32.load`/`f64.load` from `base + i*stride` (the
+  codegen-axes "new array method" worked example uses exactly this contrast).
+- It is small and self-contained — a focused equivalence test can prove it.
+
+The architect spec may substitute a different kind if the audit (#1713) shows a
+cleaner candidate, but the criteria are: already IR-owned, structurally simple,
+and with a well-understood linear-memory representation.
+
+## Scope
+
+1. Implement `src/ir/lower-linear.ts` with a `LinearEmitter implements
+   BackendEmitter` — but ONLY for the emission primitives the chosen node kind
+   needs (NOT the whole trait; the other primitives may `throw not-implemented`
+   with a clear marker for follow-up).
+2. Wire the IR lowering so that, for the chosen node kind, the active backend
+   (selected by target: WasmGC vs linear) picks the right emitter. The same IR
+   node feeds both.
+3. Equivalence test: a small program whose hot path is the chosen node kind
+   (e.g. sum-of-array-elements), compiled and run under both the WasmGC target
+   and the linear/WASI target, producing identical results.
+
+## Acceptance criteria
+
+1. `src/ir/lower-linear.ts` exists with a `LinearEmitter` covering the chosen
+   node kind's primitives.
+2. The *same IR node* for the chosen kind lowers correctly to WasmGC (existing
+   behavior, unchanged) AND to linear memory (new), selected by target.
+3. A focused equivalence test compiles a program exercising the chosen kind to
+   both targets and asserts identical runtime results.
+4. Zero conformance delta on the WasmGC path (the refactor must not regress the
+   existing lowering). Linear path correctness proven by the new test.
+5. The codegen-axes doc is updated to record that this node kind is now
+   lowered through the trait to two backends (it is the first such kind).
+
+## Notes / scope
+
+- Status `backlog` → flips to `ready` once #1713 merges (the trait must exist
+  first). Listed in Sprint 57 as the primary backend-agnostic proof point.
+- Deliberately ONE node kind. Do NOT attempt to route all of `lower.ts`'s vec
+  or object handling to linear — that is a multi-sprint follow-up. The value
+  here is *proving the seam abstracts a real second backend*, not coverage.
+- This is the higher-value of the two s57 backend proofs (vs #1715 bytecode)
+  because the linear backend is a real shipping target (WASI) and this directly
+  retires front-end duplication between `src/ir/` and `src/codegen-linear/`.

--- a/plan/issues/1715-ir-bytecode-proof-point.md
+++ b/plan/issues/1715-ir-bytecode-proof-point.md
@@ -1,0 +1,99 @@
+---
+id: 1715
+title: "Minimal bytecode emitter + dispatch loop for an IR subset (backend-agnostic proof point)"
+status: backlog
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: ir, runtime, architecture
+language_feature: n/a
+es_edition: n/a
+goal: backend-agnostic-ir
+sprint: 57
+depends_on: [1713]
+related: [1584, 1131, 1714]
+needs_architect_spec: true
+---
+# #1715 — Minimal bytecode emitter + dispatch loop for an IR subset (proof point)
+
+## Problem
+
+#1584 proposes a full Wasm-GC-native bytecode interpreter (8–12 weeks, register
++ accumulator, ~120–150 opcodes, eval/Function support, Acorn runtime parser).
+That is a large speculative investment. Before committing to it, we need to
+de-risk the single architectural claim it rests on:
+
+> Can the typed IR be lowered to a non-Wasm execution target (a bytecode stream
+> run by a dispatch loop) through the same backend seam that targets WasmGC?
+
+This issue answers that for **one issue's worth of effort** by building a
+*minimal, throwaway-grade* bytecode backend for a tiny IR subset. It is the
+proof point gating the #1584 decision — if the #1713 trait cannot cleanly
+express a bytecode target, we learn it now, not 8 weeks in.
+
+## Scope — deliberately minimal
+
+Cover ONLY this IR subset (the smallest set that proves dispatch works):
+
+- integer/f64 arithmetic (`add`, `sub`, `mul`)
+- local get/set
+- `const`
+- `return`
+- ONE conditional branch (`br_if` → the IR's existing two-arm tail shape)
+
+NO objects, NO arrays, NO closures, NO calls, NO strings, NO exceptions. Those
+are #1584's job. The subset is exactly what `lower.ts` already handles for a
+function like `function f(a, b) { return a > 0 ? a + b : a - b; }`.
+
+## Approach
+
+1. `BytecodeEmitter implements BackendEmitter` (from #1713) — but only the
+   primitives the subset needs; the rest `throw not-supported-in-proof`. It
+   emits a flat opcode array (a simple stack or register encoding — the
+   architect spec picks; register+accumulator per #1584's ADR direction is
+   preferred so the proof informs that design, but a stack machine is
+   acceptable for the proof if simpler).
+2. A dispatch loop — written in TypeScript (so it can later itself be compiled
+   by js2wasm per #1584), executing the opcode array against a small frame
+   (locals array + accumulator/operand stack), returning a number.
+3. A test: for a handful of in-subset functions, the bytecode-interpreted
+   result equals the WasmGC-compiled result equals the plain-JS result. This
+   triple equivalence is the proof.
+
+## Acceptance criteria
+
+1. A `BytecodeEmitter` exists behind the #1713 trait, emitting opcodes for the
+   minimal IR subset listed above.
+2. A TypeScript dispatch loop executes those opcodes and returns correct
+   numeric results.
+3. A test proves, for ≥3 in-subset functions (one arithmetic, one with a local,
+   one with the conditional branch), that bytecode-interpreted output ==
+   WasmGC output == JS output.
+4. The opcode encoding choice (stack vs register+accumulator) and findings are
+   written up in the issue — this is the input the #1584 ADR consumes.
+5. Zero conformance delta (the WasmGC path is untouched; this adds a parallel
+   experimental backend behind a flag, not a default path).
+
+## Decision this proof informs
+
+- **If clean** — the #1713 trait genuinely abstracts execution model, not just
+  Wasm-op selection. #1584 Phase 1 is greenlit on a sound foundation, and its
+  opcode-set ADR builds on this proof's encoding findings.
+- **If the trait fights the bytecode target** — we capture exactly where (the
+  issue write-up), feed it back into a #1713 trait revision, and re-scope #1584
+  before committing the multi-week investment.
+
+## Notes / scope
+
+- Status `backlog` → `ready` once #1713 merges. This is the **stretch** s57
+  backend proof; #1714 (linear) is the primary and must land first if capacity
+  is tight.
+- Throwaway-grade is fine and intended. The deliverable is *knowledge + a green
+  triple-equivalence test*, not production code. Keep it behind an explicit
+  experimental flag so it never affects default compilation.
+- This is explicitly the first, scoped-down slice of #1584's Phase 1 step 3–4
+  ("bytecode emitter as a second IR backend" + "dispatch loop in TypeScript"),
+  reduced to the minimum that validates the seam.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,25 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## Sprint 57 — acorn dogfood + backend-agnostic IR (2026-05-29)
+
+Architectural sprint (no pass-count target; zero-regression guard). Goals:
+[`self-hosting-dogfood`](../../goals/self-hosting-dogfood.md),
+[`backend-agnostic-ir`](../../goals/backend-agnostic-ir.md). Plan:
+[sprints/57.md](../sprints/57.md).
+
+Track 1 — acorn dogfood:
+- [#1710](../1710-acorn-dogfood-harness.md) — acorn harness: compile + validate + diff-AST vs node-acorn — high, medium, **ready (s57)**.
+- [#1711](../1711-acorn-failure-surface-triage.md) — triage harness surface → file sized child issues — high, medium, **ready (s57)**, depends on #1710.
+- [#1712](../1712-acorn-acceptance-differential-ast.md) — acceptance: compiled acorn AST == node-acorn — high, hard, **backlog→ready** after #1710/#1711.
+- Prior blockers #1679/#1690/#1690b are **done**.
+
+Track 2 — backend-agnostic IR (all need architect spec; #1713 blocking):
+- [#1713](../1713-ir-backend-emitter-trait-seam.md) — BackendEmitter trait + WasmGC bias audit + WasmGcEmitter (pure refactor, zero conformance delta) — high, hard, **ready (s57), needs arch spec**.
+- [#1714](../1714-ir-two-backend-proof-linear.md) — lower one IR node kind to BOTH WasmGC + linear via the trait (primary proof) — high, hard, **backlog→ready** after #1713.
+- [#1715](../1715-ir-bytecode-proof-point.md) — minimal bytecode emitter + dispatch loop for an IR subset (stretch proof) — medium, hard, **backlog→ready** after #1713.
+- Feeds [#1584](../1584-wasm-gc-native-interpreter.md) (in-Wasm bytecode interpreter) — gated on both tracks + #1712.
+
 ## Standalone (--target wasi) host-import audit (2026-05-25) — goal `standalone-mode`
 
 Empirical per-construct audit of remaining JS-host (`env.*`) leaks under `--target wasi`. Audit record: [#1662](../1662-standalone-host-import-audit.md) (done). Each genuine remaining leak is owned by a tracking issue; new gaps filed where the cited issue was closed without coverage or no native-engine issue existed. Already-tracked: Map/Set → #1103, number→string → #1335, RegExp → #682/#1474, closures/callbacks → #1470, JSON Phase 2 → #1599. Expected/wont-fix (not filed): eval, Proxy, with, dynamic import, full Intl collation.

--- a/plan/issues/sprints/57.md
+++ b/plan/issues/sprints/57.md
@@ -1,0 +1,161 @@
+---
+sprint: 57
+status: planned
+created: 2026-05-29
+authors: product-owner
+baseline_pass: 30214
+baseline_total: 43135
+baseline_pct: 70.0
+target_pass: n/a (architectural sprint)
+expected_gain: n/a
+---
+
+# Sprint 57 Plan — acorn dogfood + backend-agnostic IR
+
+## Goal
+
+Sprint 57 is **architectural / dogfooding**, not a test262-bucket grind. Two
+strategic tracks, each advancing a long-term capability the synthetic
+conformance corpus cannot drive:
+
+1. **Self-hosting dogfood** (goal `self-hosting-dogfood`) — make the compiler
+   compile its own parser, acorn, and run it *correctly* (AST structurally
+   equal to node-acorn). The three known full-module blockers (#1679, #1690,
+   #1690b) are already fixed; this sprint builds the repeatable harness, triages
+   whatever remains, and lands the acceptance gate.
+
+2. **Backend-agnostic IR** (goal `backend-agnostic-ir`) — decouple the typed IR
+   (`src/ir/lower.ts`) from WasmGC so it can lower to WasmGC (today), linear
+   memory, and a future bytecode interpreter, via a `BackendEmitter` trait.
+   This sprint defines the seam and proves it abstracts two real backends.
+
+The two tracks converge on **#1584** (the in-Wasm bytecode interpreter): it
+needs *both* compiled-acorn (track 1) as its runtime parser AND a non-Wasm IR
+backend (track 2). Sprint 57 de-risks #1584 before that 8–12 week investment is
+committed.
+
+## Baseline
+
+- **Baseline (s57 open):** 30,214 / 43,135 = **70.0%** (CI run 9ee8e921,
+  2026-05-29).
+- This sprint has **no pass-count target** — it is architecture + tooling. The
+  conformance guard is "**zero regression**": every issue must hold test262 net
+  ≥ 0 and not grow the IR fallback budget. Pass-rate gains, if any, come as a
+  side effect of triage child-issues (#1711) that may fix real codegen gaps.
+
+## Track 1 — acorn dogfood
+
+Iterative loop: harness → triage → fix → acceptance.
+
+| ID | Title | Feasibility | Status | Arch spec? | Depends on |
+|----|-------|-------------|--------|-----------|------------|
+| [#1710](../1710-acorn-dogfood-harness.md) | acorn dogfood harness (compile + validate + diff-AST vs node-acorn) | medium | ready | no | — |
+| [#1711](../1711-acorn-failure-surface-triage.md) | triage harness surface → file sized child issues | medium | no (PO/arch triage) | no | #1710 |
+| [#1712](../1712-acorn-acceptance-differential-ast.md) | acceptance: compiled acorn AST == node-acorn on a representative .js | hard | backlog→ready after #1710/#1711 | no | #1710, #1711 |
+
+Done/prior (regression-guarded by #1710): #1679, #1690, #1690b.
+
+**Sequencing:** #1710 first (keystone tooling) → #1711 runs the harness and
+triages → #1712 flips to ready once triage confirms either zero divergence
+(passes immediately) or a tractable fix set. #1711 may file new sprint-57
+child issues if small enough; otherwise they land in the backlog tagged by
+real-world weight.
+
+## Track 2 — backend-agnostic IR
+
+Seam → two-backend proof (primary) + bytecode proof (stretch).
+
+| ID | Title | Feasibility | Status | Arch spec? | Depends on |
+|----|-------|-------------|--------|-----------|------------|
+| [#1713](../1713-ir-backend-emitter-trait-seam.md) | BackendEmitter trait: audit WasmGC bias + define seam + WasmGcEmitter | hard | ready | **YES — required before dev** | — |
+| [#1714](../1714-ir-two-backend-proof-linear.md) | lower one IR node kind to BOTH WasmGC + linear via the trait | hard | ready→after #1713 | **YES** | #1713 |
+| [#1715](../1715-ir-bytecode-proof-point.md) | minimal bytecode emitter + dispatch loop for an IR subset (proof) | hard | backlog→after #1713 | **YES** | #1713 |
+
+**Sequencing:** #1713 is the gate — the architect writes the implementation
+spec (trait granularity, layout-handle abstraction, which `lower.ts` sites
+move) *before any dev claims it*. #1713 is a pure refactor (zero conformance
+delta). Once it merges, #1714 (primary) and #1715 (stretch) can run in
+parallel — they target different emitters and share only the trait interface.
+
+**Why both #1714 and #1715:** they de-risk different claims. #1714 proves the
+trait abstracts a *real shipping backend* (linear/WASI) and retires front-end
+duplication — high value, must land. #1715 proves the trait can target a
+*fundamentally different execution model* (dispatch loop) for ~1 issue of
+effort — cheap insurance against discovering the trait can't express bytecode
+8 weeks into #1584. If capacity is tight, #1714 lands first; #1715 is the
+stretch.
+
+## PO call: bytecode interpreter vs. extend linear backend
+
+**Recommendation: do the linear-via-trait proof (#1714) as the primary first
+proof point, and a *minimal* bytecode proof (#1715) as a scoped stretch.**
+
+Reasoning:
+- Extending the linear backend through the trait is grounded in a target that
+  *already ships* (WASI). It immediately removes duplicated front-end work
+  between `src/ir/` and `src/codegen-linear/`, and the codegen-axes doc already
+  anticipates exactly this lift ("no AST node kind has demanded it yet" — #1714
+  makes one demand it). Low risk, high architectural payoff.
+- The full bytecode interpreter (#1584) is an 8–12 week speculative investment.
+  Committing to it on an unproven seam is the risk. A *minimal* bytecode slice
+  (#1715) validates the single architectural claim #1584 rests on — "the trait
+  can target a non-Wasm backend" — for one issue of effort. That is the
+  responsible way to greenlight (or re-scope) #1584.
+- So: primary value from the safe, shipping-backend proof; cheap insurance from
+  the minimal bytecode proof; defer the big interpreter build (#1584) until both
+  proofs are green and #1712 yields a compiled acorn it can use as a parser.
+
+## Needs architect spec before dev dispatch
+
+1. **#1713** — `BackendEmitter` trait. Hard, central IR refactor. Architect
+   must enumerate the emission-primitive set by walking `lower.ts`, define the
+   layout-handle abstraction, and stage which node kinds move behind the trait.
+   **Blocking** — no dev claims #1713 until the `## Implementation Plan` lands.
+2. **#1714** — depends on #1713's trait shape; the spec should name the chosen
+   node kind (recommended: vec length + element read) and the `LinearEmitter`
+   primitives it needs.
+3. **#1715** — depends on #1713; the spec should pin the opcode encoding
+   (stack vs register+accumulator) so the proof informs the #1584 ADR.
+
+#1710 (harness) and #1711 (triage) do NOT need an architect spec — #1710 is
+test tooling, #1711 is PO/architect triage. #1712 is an integration gate, not
+a dev task.
+
+## Dispatch manifest (for tech lead)
+
+- **Parallelisable from start:** #1710 (tooling, no dep) and the #1713 architect
+  spec (architect writes spec while #1710 dev builds the harness). Different
+  agents, different files.
+- **Serial within track 1:** #1710 → #1711 → #1712.
+- **Serial within track 2:** #1713 (merge) → then #1714 + #1715 in parallel.
+- **Architect spec is the long pole** for track 2 — write #1713's spec first so
+  the refactor can start as early as possible; #1714/#1715 specs can follow.
+- **Conformance guard:** every track-2 PR must show zero test262 regression and
+  no IR-fallback-budget growth (`pnpm run check:ir-fallbacks`). #1713 especially
+  is a pure refactor — any pass-count delta is a bug.
+
+## Open questions for the user (strategy forks)
+
+1. **acorn pinning** (#1710): vendor a copy of acorn 8.16.0 under
+   `tests/fixtures/`, or pin via `npm pack` in the harness setup? Vendoring is
+   hermetic but adds ~100KB of third-party source to the repo. Recommendation:
+   vendor (hermetic, no network in CI), with a clear provenance note.
+2. **#1715 opcode encoding**: register+accumulator (per #1584's stated
+   direction, so the proof informs that ADR) vs. a simpler stack machine (less
+   code for a throwaway proof). Recommendation: register+accumulator if it adds
+   little proof-grade cost, else stack — architect's call in the spec.
+3. **Sprint scope realism**: track 2 is three `hard` issues gated on one
+   architect spec. If the team has limited Opus capacity, do we (a) land #1713 +
+   #1714 only and defer #1715 to s58, or (b) attempt all three? Recommendation:
+   commit to #1713 + #1714; treat #1715 as stretch.
+4. **#1584 trigger**: confirm the gate to *start* #1584 is "both s57 proofs
+   green AND #1712 yields a usable compiled-acorn", not earlier. The bytecode
+   interpreter is the convergence point of both tracks; starting it before the
+   proofs is the risk this sprint exists to retire.
+
+## Theme
+
+**Dogfood + decouple.** Compile the compiler's own parser and prove it right
+(track 1); make the IR backend-agnostic so it can someday *be* an interpreter
+(track 2). Both tracks de-risk the in-Wasm bytecode interpreter (#1584) without
+committing to its multi-week build.

--- a/plan/issues/sprints/57.md
+++ b/plan/issues/sprints/57.md
@@ -136,22 +136,23 @@ a dev task.
 
 ## Open questions for the user (strategy forks)
 
-1. **acorn pinning** (#1710): vendor a copy of acorn 8.16.0 under
-   `tests/fixtures/`, or pin via `npm pack` in the harness setup? Vendoring is
-   hermetic but adds ~100KB of third-party source to the repo. Recommendation:
-   vendor (hermetic, no network in CI), with a clear provenance note.
+1. **acorn pinning** (#1710): **RESOLVED (2026-05-29, project lead): pinned
+   `npm pack` at harness setup** (acorn 8.16.0), not a vendored source copy.
+   Keeps third-party source out of the repo; pin exact version + integrity and
+   resolve the tarball at setup time (no unpinned network fetch mid-test).
 2. **#1715 opcode encoding**: register+accumulator (per #1584's stated
    direction, so the proof informs that ADR) vs. a simpler stack machine (less
-   code for a throwaway proof). Recommendation: register+accumulator if it adds
-   little proof-grade cost, else stack — architect's call in the spec.
-3. **Sprint scope realism**: track 2 is three `hard` issues gated on one
-   architect spec. If the team has limited Opus capacity, do we (a) land #1713 +
-   #1714 only and defer #1715 to s58, or (b) attempt all three? Recommendation:
-   commit to #1713 + #1714; treat #1715 as stretch.
+   code for a throwaway proof). **RESOLVED (2026-05-29, project lead): deferred
+   to the #1713/#1715 architect** — the spec author picks the encoding the IR
+   seam most naturally expresses.
+3. **Sprint scope realism**: **RESOLVED (2026-05-29, project lead): commit to
+   #1713 + #1714; #1715 (minimal bytecode proof) is STRETCH** — attempted only
+   if #1713/#1714 land with time to spare.
 4. **#1584 trigger**: confirm the gate to *start* #1584 is "both s57 proofs
    green AND #1712 yields a usable compiled-acorn", not earlier. The bytecode
    interpreter is the convergence point of both tracks; starting it before the
-   proofs is the risk this sprint exists to retire.
+   proofs is the risk this sprint exists to retire. *(Carried as the standing
+   #1584 entry gate; revisit at s57 close.)*
 
 ## Theme
 

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -4,6 +4,30 @@ Issues organized by dependency order -- work items at the top are ready now,
 items below unlock when their dependencies complete. No sprint batching needed:
 pick any "ready" item and start.
 
+## Sprint 57 — acorn dogfood + backend-agnostic IR (added 2026-05-29)
+
+Architectural sprint. Two tracks; conformance guard is zero-regression.
+
+**Track 1 — self-hosting-dogfood** (compile + run acorn correctly):
+
+| #     | Title | Priority | Feasibility | Status | Depends on |
+|-------|-------|----------|-------------|--------|------------|
+| 1710  | acorn dogfood harness (compile + validate + diff-AST vs node-acorn) | high | medium | Ready | — |
+| 1711  | triage harness surface → file sized child issues | high | medium | Ready | #1710 |
+| 1712  | acceptance: compiled acorn AST == node-acorn on a representative .js | high | hard | Backlog→ready after #1710/#1711 | #1710, #1711 |
+
+Prior acorn blockers #1679 / #1690 / #1690b are **done** (regression-guarded by #1710).
+
+**Track 2 — backend-agnostic-ir** (decouple IR from WasmGC):
+
+| #     | Title | Priority | Feasibility | Status | Depends on |
+|-------|-------|----------|-------------|--------|------------|
+| 1713  | BackendEmitter trait: audit WasmGC bias + seam + WasmGcEmitter | high | hard | Ready — **needs architect spec first** | — |
+| 1714  | lower one IR node kind to BOTH WasmGC + linear via the trait | high | hard | Backlog→ready after #1713 | #1713 (**arch spec**) |
+| 1715  | minimal bytecode emitter + dispatch loop for an IR subset (proof) | medium | hard | Backlog→ready after #1713 | #1713 (**arch spec**) |
+
+Feeds #1584 (in-Wasm bytecode interpreter) — gated on both tracks + #1712.
+
 ## Sprint 50 Extension (added 2026-05-07)
 
 Pulled into S50 alongside the original closure/dispatch cohort. Direct-dispatch items have no architect dependency; spec items wait on architect.


### PR DESCRIPTION
## Sprint 57 plan (docs-only, under `plan/`)

Architectural sprint with two strategic tracks. No test262 pass-count target — the conformance guard is **zero regression** + no IR-fallback-budget growth.

### Track 1 — self-hosting-dogfood (compile the compiler's own parser)
Goal: compile acorn to Wasm and run it *correctly* (AST structurally equal to node-acorn).
- **#1710** acorn harness — compile + `WebAssembly.compile` validate + differential-AST vs node-acorn on a pinned fixture corpus (ready, medium)
- **#1711** triage harness surface → file sized child issues (ready, medium, dep #1710)
- **#1712** acceptance: compiled acorn AST == node-acorn on a representative `.js` (backlog→ready, hard, integration gate)
- Prior acorn blockers **#1679 / #1690 / #1690b are already done** — re-homed to the goal; #1710 regression-guards them.
- New goal: `plan/goals/self-hosting-dogfood.md`

### Track 2 — backend-agnostic-ir (decouple `src/ir/lower.ts` from WasmGC)
Goal: a `BackendEmitter` trait so the IR can lower to WasmGC (today), linear memory, and a future bytecode interpreter.
- **#1713** BackendEmitter trait: audit the WasmGC bias in `lower.ts` + define the seam + a behavior-identical `WasmGcEmitter` (ready, **hard — needs architect spec before dev**, pure refactor / zero conformance delta)
- **#1714** lower ONE IR node kind to BOTH WasmGC + linear via the trait — **primary** proof (backlog→ready after #1713, hard)
- **#1715** minimal bytecode emitter + dispatch loop for a tiny IR subset — **stretch** proof that de-risks **#1584** (backlog→ready after #1713, hard)
- New goal: `plan/goals/backend-agnostic-ir.md`

Both tracks converge on **#1584** (in-Wasm bytecode interpreter), which needs compiled-acorn (track 1) AND a non-Wasm IR backend (track 2). This sprint de-risks #1584 before its 8–12 week build is committed.

### PO call: bytecode-interpreter vs. extend-linear-backend
Recommend **linear-via-trait (#1714) as the primary first proof** (grounded in a real shipping target, WASI; retires `src/ir/` ↔ `src/codegen-linear/` front-end duplication) + a **minimal bytecode proof (#1715) as cheap insurance** that the trait can express a non-Wasm execution model before committing to #1584. Full reasoning + open questions in `plan/issues/sprints/57.md`.

### Files
- New goals: `self-hosting-dogfood.md`, `backend-agnostic-ir.md`
- New issues: #1710–#1715
- New sprint doc: `plan/issues/sprints/57.md`
- Updated: `goal-graph.md` (DAG + status table), `dependency-graph.md`, `backlog/backlog.md`, #1690/#1690b (re-homed to dogfood goal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)