### PR TITLE
fix(#1702): residual strict-mode `this` — fn-expr direct-call + nested fn-decl in class method

### DIFF
--- a/plan/issues/1702-strict-this-nested-and-class-method-residuals.md
+++ b/plan/issues/1702-strict-this-nested-and-class-method-residuals.md
@@ -1,0 +1,117 @@
+---
+id: 1702
+title: "Residual strict-mode `this` regressions: function-expression direct-call + nested fn-decl in class method"
+status: done
+sprint: 56
+goal: core-semantics
+parent: 1636
+area: codegen
+feasibility: medium
+created: 2026-05-29
+completed: 2026-05-29
+---
+
+# Residual strict-mode `this` (the #873 / #895 follow-up)
+
+Follow-up to PR #895 / #1636-S1. A baseline-diff investigation found the pass
+rate dropped 70.40% → 70.05% from PR #873 (#1636-S1, `ThisKeyword`
+over-reading `__current_this`). PR #895 recovered most of it (→ 70.24%) but
+**66 residual test262 regressions** persisted on main, all the SAME
+strict-mode-`this` root cause #895 only partially fixed.
+
+## The two failing shapes
+
+### Shape 1 — `language/function-code/10.4.3-1-*-s` (34 cases)
+In strict code, a function invoked with no receiver must see
+`this === undefined`. The test262 runner (`wrapTest`) wraps the test body in
+`export function test() { … }`, so a top-level `var f1 = function () { … }`
+becomes a **local closure** inside `test()`:
+
+```js
+"use strict";
+var f1 = function () {
+    function f() { return typeof this; }
+    return (f()==="undefined") && ((typeof this)==="undefined");
+}
+assert(f1());   // f1 itself: `this` must be undefined
+```
+
+The outer function-expression body carries `readsCurrentThis: true` (set on
+EVERY lifted closure so a host `JSON.stringify` `toJSON`/replacer dispatch can
+observe the installed receiver via `__current_this`). But for a **direct**
+`f1()` call, `__current_this` is never installed — it holds its
+`ref.null.extern` initial value. The pre-fix `global.get` surfaced raw JS
+`null`, so `typeof this === "object"` and `this === undefined` was `false`.
+
+### Shape 2 — `class/dstr/*meth-*ary-elision-iter` (32 cases)
+Class method bodies are always strict. A nested `function inner() { … }`
+declared inside a method was lifted with the method's `this` (the instance)
+threaded in as a **capture param**, so `inner()` saw the instance instead of
+the spec `undefined`. A `FunctionDeclaration` establishes its OWN `this`
+binding (ECMA-262 §10.2.1.1 OrdinaryCallBindThis) — it never lexically
+captures the enclosing `this` the way an arrow function does. The
+array-destructuring-with-elision-over-iterator param was incidental; the
+real corruption was the wrong `this` inside the strict method body.
+
+## Root cause + fix
+
+Two independent code paths feed the same wrong-`this` symptom:
+
+1. **`src/codegen/expressions.ts`** — the `ThisKeyword` handler. The
+   `readsCurrentThis` fallback (#1636-S1 / #895) did a raw
+   `global.get __current_this`. A host receiver is always a **non-null**
+   externref, so the null/non-null distinction cleanly separates the two reach
+   paths. **Fix**: null-guard the read — `__current_this != null ? it :
+   undefined`. Additive to #895's gating: it only changes the *value* the
+   existing `readsCurrentThis` branch yields when the global is null; it never
+   widens which bodies read the global. Array.prototype.{every,…} callbacks and
+   top-level strict `this` (#873/#895-fixed) are unaffected (they bind `this`
+   via a local or never set `readsCurrentThis`).
+
+2. **`src/codegen/statements/nested-declarations.ts`** — the capture loop for a
+   nested `FunctionDeclaration` iterated `referencedNames` (which includes
+   `"this"`) and captured the outer `this` when the enclosing fctx had a `this`
+   local (always true inside a method/ctor). **Fix**: skip `this`/`super` —
+   a `FunctionDeclaration` is not a lexical-`this` form. `ThisKeyword` then
+   falls through to the `undefined` / `__current_this` resolution, correct for
+   a free function. (Arrow functions are compiled in `closures.ts`, which keeps
+   lexical `this` capture — this branch only handles `FunctionDeclaration`s.)
+
+## Why it can't regress the #895-fixed cases
+- Top-level strict `this` and `"use strict"` directive-prologue functions bind
+  `this` differently / don't take the `readsCurrentThis` branch — unchanged.
+- Array.prototype callbacks dispatched by the host install a **non-null**
+  receiver into `__current_this`; the null-guard passes it straight through.
+- The only behavior change for the `readsCurrentThis` branch is: a **null**
+  global now yields `undefined` instead of JS `null`. That is the spec-correct
+  result for a strict free function with no receiver, and matches the
+  pre-#1636-S1 fallback. One #1636-S1 unit test that asserted the buggy `null`
+  was updated to assert `undefined`.
+
+## Repro (confirmed before fix → after fix)
+Using the exact test262 wrap (`buildImports` harness):
+- `10.4.3-1-30-s` shape: `-1` (FAIL) → `1` (PASS)
+- class-method nested-fn `typeof this`: `"object"` → `"undefined"`
+- strict fn-expr `this === undefined`: `false` → `true`
+- elision-iter method callCount: stays `1` (the over-count symptom resolved)
+
+## Files
+- `src/codegen/expressions.ts` — ThisKeyword null-guard on the
+  `readsCurrentThis` / `__current_this` read.
+- `src/codegen/statements/nested-declarations.ts` — skip `this`/`super` capture
+  for nested function declarations.
+- `tests/issue-1702-strict-this.test.ts` — 7 regression tests (both shapes).
+- `tests/issue-1636-s1-tojson-this.test.ts` — updated the one unit test that
+  asserted the old buggy `null` to assert the spec-correct `undefined`.
+
+## Notes / out of scope
+- A SEPARATE pre-existing bug exists for **module-global** function
+  expressions / arrows (`const f = function(){…}` at module top level, called
+  by name): the direct-call site reloads the callee via a stale/off-by-one
+  global index (`global.get` of a string-constant global) → `illegal cast` at
+  runtime. This pre-dates #1340/#1636-S1 (reproduced at `e5f1dc720`) and is
+  NOT a strict-`this` issue. It is what makes the `tests/function-expressions`
+  and `tests/equivalence/arrow-call-apply` module-level cases fail on clean
+  main too. Tracked separately — not in scope for #1702.
+
+Expected impact: ~+66 test262 (recover toward ~70.40%).

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -800,7 +800,50 @@ function compileExpressionInner(ctx: CodegenContext, fctx: FunctionContext, expr
     // callback bodies that the host can dispatch, leaving direct-call `this`
     // to fall through to `undefined` as before.
     if (fctx.readsCurrentThis && ctx.currentThisGlobalIdx >= 0) {
+      // (#1702) Null-guard the `__current_this` read. A lifted closure body can
+      // be reached two ways:
+      //   (a) host dispatch via `__call_fn_method_N` — installs a real receiver
+      //       (a non-null externref) into `__current_this` before the call_ref;
+      //   (b) a *direct* call (`f1()` where `f1` is a closure local / module
+      //       global) — which never installs anything, so `__current_this` still
+      //       holds its `ref.null.extern` initial value (or a leftover from an
+      //       unrelated host dispatch that has since been restored to null).
+      //
+      // #1636-S1 / #895 narrowed this fallback to `readsCurrentThis` bodies, but
+      // for the *direct-call* case the raw `global.get` surfaces JS `null`, not
+      // the spec-correct `undefined`. That made strict free-function /
+      // function-expression `this` observe `null` (`typeof this === "object"`,
+      // `this === undefined` ⇒ false), regressing the residual
+      // `language/function-code/10.4.3-1-*-s` + class-method strict-`this`
+      // shapes (#873 follow-up).
+      //
+      // The receiver a host installs is always a non-null externref, so the
+      // null/non-null distinction cleanly separates the two reach paths: when
+      // the global is non-null use it (host dispatch), otherwise fall through to
+      // `undefined` (direct call — `undefined` for strict, and the prior
+      // pre-#1636-S1 fallback for sloppy free functions). This is additive to
+      // #895's gating: it only changes the *value* the existing
+      // `readsCurrentThis` branch yields when the global is null, never widening
+      // which bodies read the global. The Array.prototype.{every,…} callbacks
+      // and top-level strict `this` (#873/#895-fixed) are unaffected — those
+      // either bind `this` via a local or do not set `readsCurrentThis`.
+      const thisTmp = allocTempLocal(fctx, { kind: "externref" });
       fctx.body.push({ op: "global.get", index: ctx.currentThisGlobalIdx } as Instr);
+      fctx.body.push({ op: "local.tee", index: thisTmp });
+      fctx.body.push({ op: "ref.is_null" });
+      const elseBody: Instr[] = [{ op: "local.get", index: thisTmp }];
+      const savedBody = fctx.body;
+      const thenBody: Instr[] = [];
+      fctx.body = thenBody;
+      emitUndefined(ctx, fctx);
+      fctx.body = savedBody;
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: thenBody,
+        else: elseBody,
+      } as unknown as Instr);
+      releaseTempLocal(fctx, thisTmp);
       return { kind: "externref" };
     }
     emitUndefined(ctx, fctx);

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -249,6 +249,21 @@ export function compileNestedFunctionDeclaration(
   }[] = [];
   for (const name of referencedNames) {
     if (ownLocals.has(name)) continue;
+    // (#1702) A nested `FunctionDeclaration` establishes its OWN `this`
+    // binding per ECMA-262 §10.2.1.1 (OrdinaryCallBindThis) — `this` is
+    // never lexically captured the way an arrow function inherits it. When
+    // such a function is invoked without a receiver (e.g. a plain `inner()`
+    // call inside a class method body or another function), its `this` is
+    // `undefined` in strict code, NOT the enclosing method's receiver.
+    // Capturing the outer `this` here threaded the method's instance into
+    // the lifted body as param 0, so `inner()` saw the instance instead of
+    // `undefined` — the class-method half of the #873/#895 strict-`this`
+    // residual. Skipping `this`/`super` lets `ThisKeyword` fall through to
+    // the `undefined` / `__current_this` resolution path, which is correct
+    // for a free function. (Arrow functions are compiled via closures.ts,
+    // which keeps lexical `this` capture — this branch only handles
+    // `FunctionDeclaration`s.)
+    if (name === "this" || name === "super") continue;
     const localIdx = fctx.localMap.get(name);
     if (localIdx === undefined) continue;
     if (ctx.funcMap.has(name)) continue;

--- a/tests/issue-1636-s1-tojson-this.test.ts
+++ b/tests/issue-1636-s1-tojson-this.test.ts
@@ -189,11 +189,18 @@ describe("#1636-S1 __call_fn_method_N — host-supplied `this` for Wasm closures
     expect(callFnMethod0(null, closure)).toBe(baseline);
   });
 
-  it("__current_this defaults to null when no __call_fn_method_N invocation has happened", async () => {
-    // Invoking the closure via __call_fn_0 (no `this` threading) reads
-    // the initial global value, which is `ref.null.extern` — surfaced to
-    // JS as null. This is the only observable semantic shift for free
-    // closures that previously fell through to `undefined`.
+  it("free closure with no installed receiver resolves `this` to undefined (#1702)", async () => {
+    // Invoking the closure via __call_fn_0 (no `this` threading) leaves the
+    // `__current_this` global at its `ref.null.extern` initial value. The
+    // first cut of #1636-S1 surfaced that raw null to JS, but a free function
+    // / function-expression that reads `this` with no installed receiver must
+    // observe the spec default — `undefined` for a strict free function (and
+    // the pre-#1636-S1 `undefined` fallback for sloppy) — NOT `null`
+    // (`typeof null === "object"`, `null === undefined` ⇒ false). #1702
+    // null-guards the `__current_this` read so the direct-call path yields
+    // `undefined`; only a host-installed (non-null) receiver flows through.
+    // This fixed the residual `language/function-code/10.4.3-1-*-s` +
+    // class-method strict-`this` test262 cases (the #873/#895 follow-up).
     const src = `
       const probe3 = function (): any {
         return this;
@@ -205,6 +212,6 @@ describe("#1636-S1 __call_fn_method_N — host-supplied `this` for Wasm closures
     const getProbe3 = exp.getProbe3 as () => unknown;
     const closure = getProbe3();
     const callFn0 = exp.__call_fn_0 as (closure: unknown) => unknown;
-    expect(callFn0(closure)).toBe(null);
+    expect(callFn0(closure)).toBe(undefined);
   });
 });

--- a/tests/issue-1702-strict-this.test.ts
+++ b/tests/issue-1702-strict-this.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1702 — residual strict-mode `this` regressions (the #873 / #895 follow-up).
+ *
+ * A rigorous baseline-diff after #895 found 66 test262 cases still failing on
+ * the SAME strict-`this` root cause #895 only partially fixed, in two shapes:
+ *
+ *  1. `language/function-code/10.4.3-1-*-s` (34 cases) — in strict code, a
+ *     function invoked with no receiver must see `this === undefined`. The
+ *     failing form is the test262 wrapper turning `var f1 = function () { … }`
+ *     into a LOCAL closure inside `export function test()`. That outer
+ *     function-expression body carries `readsCurrentThis: true` (set on every
+ *     lifted closure so a host `toJSON`/replacer dispatch can observe the
+ *     installed receiver), but for a *direct* `f1()` call `__current_this` is
+ *     never installed and holds its `ref.null.extern` initial value. The raw
+ *     `global.get` surfaced JS `null`, so `typeof this` was `"object"` and
+ *     `this === undefined` was `false`.
+ *
+ *  2. `language/{expressions,statements}/class/dstr/*meth-*ary-elision-iter`
+ *     (32 cases) — class method bodies are always strict. A nested
+ *     `function inner() { … }` declared inside a method was lifted with the
+ *     method's `this` (the instance) threaded in as a capture param, so
+ *     `inner()`'s `this` was the instance instead of the spec `undefined`.
+ *     A `FunctionDeclaration` establishes its OWN `this` binding
+ *     (§10.2.1.1) — it never lexically captures the enclosing `this` the
+ *     way an arrow does.
+ *
+ * Fix (additive to #895, never widening which bodies read the global):
+ *  - `expressions.ts` ThisKeyword: null-guard the `__current_this` read so the
+ *    direct-call path yields `undefined`; only a host-installed (non-null)
+ *    receiver flows through.
+ *  - `nested-declarations.ts`: skip `this`/`super` when collecting captures for
+ *    a nested `FunctionDeclaration`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = compile(src);
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown> & {
+    setExports?: (e: Record<string, Function>) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#1702 — residual strict-mode `this` (10.4.3-1-*-s + class-method shapes)", () => {
+  it("shape 1: strict function-expression sees `this === undefined` (10.4.3-1-30-s)", async () => {
+    // Exact test262 wrap of the 10.4.3-1-30-s pattern: onlyStrict prepends
+    // "use strict", the body becomes a local inside `export function test()`.
+    expect(
+      await run(`"use strict";
+        export function test(): number {
+          var f1 = function () {
+            function f() { return typeof this; }
+            return (f() === "undefined") && ((typeof this) === "undefined");
+          };
+          if (!(f1())) { return -1; }
+          return 1;
+        }`),
+    ).toBe(1);
+  });
+
+  it("shape 1: strict function-expression `typeof this` is 'undefined', not 'object'", async () => {
+    expect(
+      await run(`"use strict";
+        export function test(): string {
+          var f1 = function () { return typeof this; };
+          return f1();
+        }`),
+    ).toBe("undefined");
+  });
+
+  it("shape 1: strict function-expression `this === undefined` is true (not null)", async () => {
+    expect(
+      await run(`"use strict";
+        export function test(): boolean {
+          var f1 = function () { return this === undefined; };
+          return f1();
+        }`),
+    ).toBe(1);
+  });
+
+  it("shape 2: nested fn-decl in a class method sees `this === undefined`", async () => {
+    expect(
+      await run(`
+        export function test(): string {
+          class C {
+            m(): string {
+              function inner(): string { return typeof this; }
+              return inner();
+            }
+          }
+          return new C().m();
+        }`),
+    ).toBe("undefined");
+  });
+
+  it("shape 2: the class method's own `this` is still the instance (not regressed)", async () => {
+    expect(
+      await run(`
+        export function test(): string {
+          class C { m(): string { return typeof this; } }
+          return new C().m();
+        }`),
+    ).toBe("object");
+  });
+
+  it("shape 2: elision-iter destructuring param method advances the iterator exactly once", async () => {
+    // The class/dstr meth-ary-elision-iter symptom: the method must run once
+    // (callCount === 1). The strict-`this` corruption inside the body
+    // previously over-counted; with the fix the body runs cleanly.
+    expect(
+      await run(`
+        let callCount = 0;
+        class C { m([, x]: any) { callCount += 1; return x; } }
+        function* g() { yield 1; yield 2; yield 3; }
+        export function test(): number {
+          new C().m(g());
+          return callCount;
+        }`),
+    ).toBe(1);
+  });
+
+  it("nested fn-decl `this` inside a plain strict function is also undefined", async () => {
+    expect(
+      await run(`"use strict";
+        export function test(): string {
+          function outer(): string {
+            function inner(): string { return typeof this; }
+            return inner();
+          }
+          return outer();
+        }`),
+    ).toBe("undefined");
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #873 / #895 / #1636-S1. A baseline-diff found **66 residual test262 regressions** on main, all the same strict-mode-`this` root cause #895 only partially fixed, in two shapes.

### Shape 1 — `language/function-code/10.4.3-1-*-s` (34 cases)
A strict function-expression called with no receiver must see `this === undefined`. The test262 wrapper turns `var f1 = function () {…}` into a local closure inside `export function test()`. That body carries `readsCurrentThis: true` (so a host `toJSON`/replacer dispatch can observe the installed receiver), but a **direct** `f1()` call never installs `__current_this` — it holds its `ref.null.extern` initial value. The raw `global.get` surfaced JS `null`, so `typeof this === "object"` and `this === undefined` was `false`.

**Fix** (`src/codegen/expressions.ts`, ThisKeyword): null-guard the `__current_this` read. A host receiver is always non-null, so only a host-installed receiver flows through; a null global yields `undefined`. Additive to #895's gating — only changes the *value* the existing `readsCurrentThis` branch yields when the global is null, never widening which bodies read it.

### Shape 2 — `class/dstr/*meth-*ary-elision-iter` (32 cases)
Class method bodies are always strict. A nested `function inner(){…}` was lifted with the method's `this` (the instance) threaded in as a capture param, so `inner()` saw the instance instead of the spec `undefined`. A `FunctionDeclaration` establishes its OWN `this` (ECMA-262 §10.2.1.1) — it never lexically captures the enclosing `this`.

**Fix** (`src/codegen/statements/nested-declarations.ts`): skip `this`/`super` in the nested-fn-decl capture loop. `ThisKeyword` then resolves to the free-function path. (Arrows are compiled in `closures.ts` and keep lexical `this` capture — this branch only handles `FunctionDeclaration`s.)

## Why it can't regress #895-fixed cases
- Top-level strict `this` / directive-prologue functions bind `this` differently and don't take the `readsCurrentThis` branch — unchanged.
- Array.prototype.{every,filter,forEach,map,reduce,some} callbacks dispatched by the host install a **non-null** receiver; the null-guard passes it straight through.
- The only behavior change: a **null** `__current_this` now yields `undefined` instead of JS `null` — the spec-correct value for a strict free function, matching the pre-#1636-S1 fallback. The one #1636-S1 unit test that asserted the buggy `null` was updated to assert `undefined`.

## Tests
- `tests/issue-1702-strict-this.test.ts` — 7 new regression tests (both shapes), all pass.
- `tests/issue-1636-s1-tojson-this.test.ts` — updated the stale `null` assertion to `undefined`.
- `tests/issue-1636s1-this-regression.test.ts` — still green.
- Typecheck clean; lint clean on changed files.

## Out of scope
A separate **pre-existing** bug for module-global function expressions / arrows (`const f = function(){…}` at module top level, called by name) reloads the callee via a stale global index → `illegal cast`. Reproduced at `e5f1dc720` (pre-#1340/#1636-S1), unrelated to strict-`this`. Tracked separately.

Expected impact: ~+66 test262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)