### PR TITLE
po: triage untracked test262 failure causes — 7 new issues

### DIFF
--- a/plan/issues/1511-spec-gap-arguments-object-mapped-and-trailing-comma.md
+++ b/plan/issues/1511-spec-gap-arguments-object-mapped-and-trailing-comma.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen
 language_feature: arguments-object
 goal: spec-completeness
-sprint: 52
+sprint: 57
 related: [1364, 1432]
 ---
 # #1511 — arguments object fidelity

--- a/plan/issues/1716-spec-gap-toprimitive-residual-object-property-key-coercion.md
+++ b/plan/issues/1716-spec-gap-toprimitive-residual-object-property-key-coercion.md
@@ -1,0 +1,92 @@
+---
+id: 1716
+title: "spec gap (RESIDUAL of #1090/#1525): 'Cannot convert object to primitive value' still thrown in 111 coercion paths"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: toprimitive-coercion
+goal: test262-conformance
+sprint: Backlog
+es_edition: multi
+test262_fail: 111
+test262_category: built-ins/Object, built-ins/String, built-ins/RegExp, built-ins/JSON, built-ins/Date, built-ins/DataView
+related: [1090, 1319, 1525, 1442]
+---
+
+# #1716 — ToPrimitive residual: 'Cannot convert object to primitive value' (111 fails)
+
+## Problem (RESIDUAL / possible regression)
+
+THREE closed issues already targeted this exact error string —
+#1090 ("ToPrimitive 'Cannot convert object to primitive value' — 161 FAIL",
+`done` 2026-04-14), #1319 ("Symbol.toPrimitive / valueOf / toString chain
+incomplete — 234 failures", `done` sprint 56), and #1525 ("built-in coercion
+paths throw eagerly", `done` 2026-05-28) — yet **111 tests still fail at runtime
+with `Cannot convert object to primitive value`**. This is a residual (and
+partly a regression-surface) of those closed issues — the fixes did not cover
+every coercion site. #1319 was the most recent and broadest; the 111 here are
+its residual.
+
+Normalized signature: `runtime_error :: Cannot convert object to primitive value`.
+
+### Distribution (actionable, Temporal/deferred excluded)
+
+| Directory | Count |
+|-----------|------:|
+| built-ins/Object (getOwnPropertyDescriptor, create, defineProperty/-ies) | 39 |
+| built-ins/String/prototype (trim/trimStart/trimEnd this-value coercion) | 26 |
+| built-ins/RegExp/prototype (Symbol.split / Symbol.replace species/ctor) | 14 |
+| built-ins/JSON (stringify replacer coercion) | 4 |
+| built-ins/Date/prototype | 4 |
+| built-ins/DataView | 4 |
+
+## Root-cause hypothesis
+
+The remaining sites are **ToPropertyKey / ToString of an object property key**
+and **`this`-value ToString coercion** in built-in methods. When an object's
+property key (or `this`) only defines `Symbol.toPrimitive` / `valueOf` /
+`toString` returning a primitive — or returns an object so the next method must
+be tried — our coercion helper throws immediately instead of walking the
+OrdinaryToPrimitive method list (§7.1.1 ToPrimitive → §7.1.1.1
+OrdinaryToPrimitive: try `valueOf` then `toString`, or the `@@toPrimitive`
+exotic method first). #1090/#1525 fixed the *argument* coercion paths but not
+the *property-key* (§7.1.19 ToPropertyKey → §13.2.4 PropertyDefinitionEvaluation)
+and `this`-value (§22.1.3.x RequireObjectCoercible → ToString) paths.
+
+Spec: [§7.1.1 ToPrimitive](https://tc39.es/ecma262/#sec-toprimitive),
+[§7.1.1.1 OrdinaryToPrimitive](https://tc39.es/ecma262/#sec-ordinarytoprimitive),
+[§7.1.19 ToPropertyKey](https://tc39.es/ecma262/#sec-topropertykey).
+
+## Example failing tests
+
+- `test/built-ins/String/prototype/trimStart/this-value-object-toprimitive-meth-priority.js`
+  (asserts `Symbol.toPrimitive` is consulted before `toString`/`valueOf`)
+- `test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-42.js`
+  (object property key coerced via ToString)
+- `test/built-ins/Object/create/15.2.3.5-4-235.js`
+- `test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-non-obj.js`
+- `test/built-ins/JSON/stringify/replacer-array-number-object.js`
+
+## Acceptance criteria
+
+- The five example tests above pass.
+- The `Cannot convert object to primitive value` runtime-error bucket drops from
+  111 to ≤ 30 (allowing for genuinely-deferred Temporal/Symbol edge cases).
+- No regression in the previously-fixed #1090 / #1525 example tests.
+
+## Notes
+
+Flagged as a **residual/regression** of `done` issues #1090 and #1525 — higher
+priority than a brand-new gap because the cause was supposedly fixed. Coordinate
+with #1442 (String.prototype RequireObjectCoercible + ToString), which is in
+`review` and overlaps the String subset; this issue owns the **Object
+property-key** and **RegExp/JSON/Date** coercion sites #1442 does not.
+
+## Source
+
+Filed by product-owner test262 triage 2026-05-29 against main baseline
+(`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1717-arraybuffer-prototype-slice-not-implemented.md
+++ b/plan/issues/1717-arraybuffer-prototype-slice-not-implemented.md
@@ -1,0 +1,65 @@
+---
+id: 1717
+title: "ArrayBuffer.prototype.slice not implemented ('slice is not a function', 17 fails)"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: arraybuffer
+goal: test262-conformance
+sprint: Backlog
+es_edition: 2015
+test262_fail: 17
+test262_category: built-ins/ArrayBuffer
+related: [1645, 1595]
+---
+
+# #1717 — ArrayBuffer.prototype.slice not implemented (17 fails)
+
+## Problem
+
+All 17 tests under `built-ins/ArrayBuffer/prototype/slice/*` fail at runtime
+with `slice is not a function`. The method is simply not present on our
+ArrayBuffer prototype / not routed by codegen.
+
+Normalized signature: `wasm_compile :: slice is not a function` (raised at the
+call site when the resolved method is undefined).
+
+The existing open ArrayBuffer issues do **not** cover this:
+- #1645 (in-review) — resizable buffers + detached-buffer guards
+- #1595 (blocked) — `transfer` / `transferToFixedLength` / `transferToImmutable`
+
+`slice` is a separate, core ES2015 method that none of them implement.
+
+## Root-cause hypothesis
+
+`ArrayBuffer.prototype.slice(start, end)` (§25.1.6.x) is unimplemented. It must:
+1. RequireObjectCoercible / IsArrayBuffer brand-check on `this`.
+2. ToIntegerOrInfinity(start), ToIntegerOrInfinity(end) with the usual
+   relative-index clamping against `[[ArrayBufferByteLength]]`.
+3. Use SpeciesConstructor (`@@species`) to allocate the new buffer.
+4. CopyDataBlockBytes the selected range; throw TypeError if the species ctor
+   returns a detached or too-small buffer.
+
+Spec: [§25.1.6.3 ArrayBuffer.prototype.slice](https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice).
+
+## Example failing tests
+
+- `test/built-ins/ArrayBuffer/prototype/slice/end-default-if-absent.js`
+- `test/built-ins/ArrayBuffer/prototype/slice/negative-start.js`
+- `test/built-ins/ArrayBuffer/prototype/slice/number-conversion.js`
+- `test/built-ins/ArrayBuffer/prototype/slice/end-exceeds-length.js`
+
+## Acceptance criteria
+
+- `ArrayBuffer.prototype.slice` is callable and the four example tests pass.
+- The `slice is not a function` bucket for `built-ins/ArrayBuffer` drops to 0.
+- No regression in existing ArrayBuffer / TypedArray tests.
+
+## Source
+
+Filed by product-owner test262 triage 2026-05-29 against main baseline
+(`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
+++ b/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
@@ -1,0 +1,83 @@
+---
+id: 1718
+title: "Iterator sequencing helpers (Iterator.concat / zip / zipKeyed) + Iterator.prototype.flatMap not implemented (101 fails)"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: hard
+task_type: bugfix
+area: codegen
+language_feature: iterator-helpers
+goal: test262-conformance
+sprint: Backlog
+es_edition: 2025
+test262_fail: 101
+test262_category: built-ins/Iterator
+related: [1340, 1320]
+---
+
+# #1718 — Iterator sequencing helpers + Iterator.prototype.flatMap (101 fails)
+
+## Problem
+
+101 tests under `built-ins/Iterator/*` fail because newer iterator helpers are
+unimplemented or mis-routed:
+
+| Helper | Symptom | Approx count |
+|--------|---------|------:|
+| `Iterator.concat` | `Iterator helper: argument is not iterable` / `Iterator.concat: argument is not iterable` | ~20 |
+| `Iterator.zip` / `Iterator.zipKeyed` | `Iterator helper: argument is not iterable` | ~50 |
+| `Iterator.prototype.flatMap` | `flatMap is not a function` | ~31 |
+
+This is **distinct from #1340** (`done` 2026-05-28), which fixed `wasm_compile`
+errors in the *existing* Iterator.prototype helpers (map/filter/take/drop/etc.).
+The **iterator-sequencing** static methods (`Iterator.concat`, `Iterator.zip`,
+`Iterator.zipKeyed` — TC39 iterator-sequencing proposal, ES2025-era) and
+`Iterator.prototype.flatMap` are either not defined or fall through to a path
+that rejects valid iterables.
+
+Note: `Array.prototype.flatMap` (#1136, done) is a different method — this is the
+**Iterator** helper.
+
+## Root-cause hypothesis
+
+- `Iterator.concat(...items)` / `Iterator.zip(iterables)` /
+  `Iterator.zipKeyed(iterables)` are missing static methods on the Iterator
+  constructor; the generic "iterator helper" dispatch wrongly reports "argument
+  is not iterable" because the iterable-coercion (GetIteratorFlattenable /
+  GetIteratorDirect) step is not implemented for these inputs.
+- `Iterator.prototype.flatMap` is absent from the Iterator prototype method
+  table, so the property resolves to undefined and the call traps.
+
+Spec:
+[Iterator.prototype.flatMap §27.1.4.x](https://tc39.es/ecma262/#sec-iteratorprototype.flatmap),
+[iterator-sequencing proposal (Iterator.concat / zip / zipKeyed)](https://tc39.es/proposal-iterator-sequencing/).
+
+## Example failing tests
+
+- `test/built-ins/Iterator/concat/fresh-iterator-result.js`
+- `test/built-ins/Iterator/concat/get-iterator-method-only-once.js`
+- `test/built-ins/Iterator/zipKeyed/options.js`
+- `test/built-ins/Iterator/prototype/flatMap/callable.js`
+- `test/built-ins/Iterator/prototype/flatMap/flattens-iterable.js`
+
+## Acceptance criteria
+
+- `Iterator.prototype.flatMap` is callable; the `flatMap is not a function`
+  bucket → 0 (≥ 25 of 31 flatMap tests pass).
+- `Iterator.concat` and `Iterator.zip`/`zipKeyed` accept valid iterables (no more
+  spurious "argument is not iterable"); ≥ 40 of the ~70 concat/zip tests pass.
+- No regression in #1340's now-passing Iterator helper tests.
+
+## Notes
+
+`zip`/`zipKeyed` are a Stage proposal but **not** on the CLAUDE.md skip-filter
+list (the deferred features are eval/with/Proxy/SAB/Temporal/WeakRef/FinReg/
+dynamic-import/TLA). `flatMap` is shipped ES; prioritise it first. Feasibility
+`hard` because the generator-backed helper lowering is involved (see #1340 lineage).
+
+## Source
+
+Filed by product-owner test262 triage 2026-05-29 against main baseline
+(`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
+++ b/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
@@ -1,0 +1,75 @@
+---
+id: 1719
+title: "Array destructuring ignores overridden Array.prototype[Symbol.iterator] ('items[Symbol.iterator] must be a function', 71 fails)"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring-iterator-protocol
+goal: test262-conformance
+sprint: Backlog
+es_edition: 2015
+test262_fail: 71
+test262_category: language/expressions, language/statements
+related: [1016, 1320, 1021]
+---
+
+# #1719 — Array destructuring must use the (possibly overridden) Array iterator (71 fails)
+
+## Problem
+
+71 tests fail with:
+
+```
+%Array%.from requires that the property of the first argument,
+items[Symbol.iterator], when exists, be a function
+```
+
+All are `*-iter-val-array-prototype.js` array-destructuring tests across
+`language/expressions/{class,object,function,async-generator}/dstr/` and
+`language/statements/{class,for,for-of,function,generators}/dstr/`. Each test
+overrides `Array.prototype[Symbol.iterator]` (or `Array.prototype.values`) with
+a custom generator and asserts that **array destructuring uses the overridden
+iterator**.
+
+## Root-cause hypothesis
+
+ArrayAssignmentPattern / ArrayBindingPattern destructuring (§8.5.2
+IteratorBindingInitialization / §13.15.5.3 DestructuringAssignmentEvaluation)
+must call `GetIterator(rhs)` which reads `rhs[Symbol.iterator]` **dynamically at
+runtime**. Our codegen takes a fast static path for array RHS values that
+iterates the backing store directly (or calls a fixed `%Array%.from`-style
+bridge) and therefore **ignores a user-monkeypatched `Array.prototype[Symbol.
+iterator]`**. When the test replaces the prototype iterator with a value the
+fast path doesn't recognise, the bridge reports "items[Symbol.iterator] … be a
+function" instead of invoking the override.
+
+The fix is to route array destructuring through a real `GetIterator` that reads
+the live `@@iterator` method off the value's prototype chain (honouring
+overrides), rather than a compile-time-specialised array walk — at least when
+the static type cannot prove the prototype iterator is intact.
+
+Spec: [§7.4.2 GetIterator](https://tc39.es/ecma262/#sec-getiterator),
+[§8.5.2 IteratorBindingInitialization](https://tc39.es/ecma262/#sec-runtime-semantics-iteratorbindinginitialization).
+
+## Example failing tests
+
+- `test/language/expressions/function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js`
+- `test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js`
+- `test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-iter-val-array-prototype.js`
+- `test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-iter-val-array-prototype.js`
+
+## Acceptance criteria
+
+- The four example tests pass.
+- The `iter-val-array-prototype` cluster drops from 71 to ≤ 10.
+- No regression in the broad destructuring fixes (#1016, #1021, #1024, #1025)
+  nor in #1320 (Array.from(externref) iterator bridge).
+
+## Source
+
+Filed by product-owner test262 triage 2026-05-29 against main baseline
+(`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1720-es3-incdec-reference-evaluation-order-null-base.md
+++ b/plan/issues/1720-es3-incdec-reference-evaluation-order-null-base.md
@@ -1,0 +1,80 @@
+---
+id: 1720
+title: "ES3: prefix/postfix inc-dec reference is evaluated once before the null/undefined deref ('base[prop()]++')"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: update-expression-reference-eval-order
+goal: test262-conformance
+sprint: 57
+es_edition: 0
+test262_fail: 10
+test262_category: language/expressions/postfix-increment, postfix-decrement, prefix-increment, prefix-decrement
+related: [1379]
+---
+
+# #1720 — ES3: UpdateExpression reference evaluated exactly once, before deref
+
+## Problem (edition ≤ ES3, sputnik S11.x)
+
+The legacy sputnik tests `S11.3.1_A6`, `S11.3.2_A6`, `S11.4.4_A6`, `S11.4.5_A6`
+(postfix-increment, postfix-decrement, prefix-increment, prefix-decrement) fail
+(`returned 2` — the assertion `assert.throws(DummyError, …)` did not see the
+expected error). Pattern:
+
+```js
+function DummyError() {}
+assert.throws(DummyError, function () {
+  var base = null;
+  var prop = function () { throw new DummyError(); };
+  base[prop()]++;          // prop() must run (and throw DummyError) FIRST
+});
+assert.throws(TypeError, function () {
+  var base = null;
+  var prop = { toString() { throw new Test262Error("evaluated"); } };
+  base[prop]++;            // GetValue(base) throws TypeError before ToPropertyKey
+});
+```
+
+This is distinct from #1379 (`done`, "unary inc/dec on null/undefined/string"),
+which fixed the *value/type* coercion of inc/dec. The gap here is the
+**evaluation order of the reference**: the MemberExpression operand must be
+evaluated exactly once (§13.4.x UpdateExpression → §13.3.3
+EvaluatePropertyAccessWithExpressionKey), so `prop()` runs and throws before any
+null-deref, and in the second case the base GetValue throws TypeError before the
+property key is coerced.
+
+Spec: [§13.4.2 Postfix Increment](https://tc39.es/ecma262/#sec-postfix-increment-operator),
+[§13.4.4 Prefix Increment](https://tc39.es/ecma262/#sec-prefix-increment-operator),
+[§13.3.3 EvaluatePropertyAccessWithExpressionKey](https://tc39.es/ecma262/#sec-evaluate-property-access-with-expression-key).
+
+## Root-cause hypothesis
+
+Our codegen lowers `base[prop()]++` by emitting the null-base check (or a fast
+trap) before fully evaluating the computed key expression `prop()`, so the
+DummyError thrown inside `prop()` is shadowed by our own null-deref handling /
+the operation returns the wrong completion. The reference must be fully
+evaluated (computed key included) and `GetValue` attempted in spec order.
+
+## Example failing tests
+
+- `test/language/expressions/postfix-increment/S11.3.1_A6_T1.js`
+- `test/language/expressions/postfix-increment/S11.3.1_A6_T2.js`
+- `test/language/expressions/prefix-increment/S11.4.4_A6_T1.js`
+- `test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js`
+- `test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js`
+
+## Acceptance criteria
+
+- All `S11.3.1_A6`, `S11.3.2_A6`, `S11.4.4_A6`, `S11.4.5_A6` (T1/T2) tests pass
+  (≈ 10 tests).
+- No regression in #1379's now-passing inc/dec tests.
+
+## Source
+
+Filed by product-owner test262 triage (ES3 / edition-0 view) 2026-05-29 against
+main baseline (`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1721-es3-subclass-function-object-instanceof.md
+++ b/plan/issues/1721-es3-subclass-function-object-instanceof.md
@@ -1,0 +1,72 @@
+---
+id: 1721
+title: "ES3 (RESIDUAL of #1455): 'class extends Function' / 'class extends Object' instanceof returns false"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: subclass-builtins-instanceof
+goal: test262-conformance
+sprint: 57
+es_edition: 0
+test262_fail: 4
+test262_category: language/expressions/class/subclass-builtins, language/statements/class/subclass-builtins
+related: [1455, 1366]
+---
+
+# #1721 — ES3: subclassing Function / Object — instanceof on the subclass fails
+
+## Problem (edition ≤ ES3, residual of #1455)
+
+Four tests fail:
+
+```js
+const Subclass = class extends Function {};
+const sub = new Subclass();
+assert(sub instanceof Subclass);   // ours: fails (returned 2)
+assert(sub instanceof Function);
+```
+
+and the same with `extends Object`. #1455 (`done`) implemented instanceof for
+subclassing the *exotic* builtins it enumerated (Map, WeakMap, all concrete
+TypedArrays, DataView, WeakRef) via the `__tag_user_class` tag chain — but
+**`Function` and `Object` were not added** to the builtin-parent registry, so
+`new Subclass() instanceof Subclass` is false.
+
+These are edition-0 sputnik-style tests (no es5id/esid/feature tag), classified
+≤ ES3 by `scripts/generate-editions.ts`.
+
+## Root-cause hypothesis
+
+`src/codegen/builtin-tags.ts` `BUILTIN_TYPE_TAGS` /
+`BUILTIN_PARENTS_HOST_CONSTRUCTIBLE` do not list `Function` and `Object`. A class
+that `extends Function`/`Object` therefore is not externref-backed / not tagged,
+so the runtime `__instanceof` tag-chain walk added in #1455 never matches.
+`Object` (ordinary object parent) and `Function` (callable parent) are special
+cases: `extends Object` should produce an ordinary subclass whose prototype chain
+reaches `Object.prototype`; `extends Function` produces a callable subclass whose
+chain reaches `Function.prototype`.
+
+Spec: [§10.2.1 / §15.7.14 ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation),
+[§7.3.20 OrdinaryHasInstance](https://tc39.es/ecma262/#sec-ordinaryhasinstance).
+
+## Example failing tests
+
+- `test/language/expressions/class/subclass-builtins/subclass-Function.js`
+- `test/language/expressions/class/subclass-builtins/subclass-Object.js`
+- `test/language/statements/class/subclass-builtins/subclass-Function.js`
+- `test/language/statements/class/subclass-builtins/subclass-Object.js`
+
+## Acceptance criteria
+
+- All four `subclass-Function` / `subclass-Object` tests pass (`instanceof Sub`
+  and `instanceof Function`/`Object` both true).
+- No regression in #1455's subclass-builtins tests (Map/TypedArray/WeakMap/etc.).
+
+## Source
+
+Filed by product-owner test262 triage (ES3 / edition-0 view) 2026-05-29 against
+main baseline (`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/1722-es3-assignmenttargettype-early-syntaxerror.md
+++ b/plan/issues/1722-es3-assignmenttargettype-early-syntaxerror.md
@@ -1,0 +1,74 @@
+---
+id: 1722
+title: "ES3: AssignmentTargetType early SyntaxError not raised (yield / arrow-function as assignment target)"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: low
+feasibility: medium
+task_type: bugfix
+area: parser
+language_feature: assignment-target-type-early-error
+goal: test262-conformance
+sprint: 57
+es_edition: 0
+test262_fail: 4
+test262_category: language/expressions/assignmenttargettype
+related: [1091, 402]
+---
+
+# #1722 — ES3: AssignmentTargetType static semantics — missing early SyntaxError
+
+## Problem (edition ≤ ES3, negative parse tests)
+
+Four `language/expressions/assignmenttargettype/*` tests are negative
+(`phase: parse`, `type: SyntaxError`) and we **compile + instantiate them
+successfully** instead of rejecting at parse time:
+
+```
+expected parse/early SyntaxError but compiled and instantiated successfully
+```
+
+The constructs assert that certain productions have AssignmentTargetType
+"invalid" and therefore cannot be the target of an assignment:
+
+```js
+yield x = 1;                        // direct-yieldexpression-0
+() => {} = 1;  /* arrow */          // direct-arrowfunction-1
+async () => {} = 1;                 // direct-asyncarrowfunction-1
+```
+
+#1091 and #402 (both `done`) improved early-error detection broadly but did not
+cover these AssignmentTargetType cases.
+
+## Root-cause hypothesis
+
+The parser/early-error pass does not consult Static Semantics:
+AssignmentTargetType (§13.x) before accepting an `AssignmentExpression` whose
+LHS is a `YieldExpression`, `ArrowFunction`, or `AsyncArrowFunction` — all of
+which are `invalid` targets and must produce a SyntaxError at parse time.
+
+Spec: [§13.15.1 Static Semantics: AssignmentTargetType / Early Errors](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors),
+[§13.x AssignmentTargetType](https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype).
+
+## Example failing tests
+
+- `test/language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
+- `test/language/expressions/assignmenttargettype/direct-arrowfunction-1.js`
+- `test/language/expressions/assignmenttargettype/direct-asyncarrowfunction-1.js`
+
+## Acceptance criteria
+
+- The three example negative tests are rejected with a parse-phase SyntaxError
+  (they now count as `pass`).
+- No regression in #1091 / #402 early-error tests.
+
+## Notes
+
+Low value (4 tests) but a crisp, edition-0-scoped early-error gap; bundled into
+the Sprint 57 ES3 conformance track.
+
+## Source
+
+Filed by product-owner test262 triage (ES3 / edition-0 view) 2026-05-29 against
+main baseline (`.test262-cache/test262-current.jsonl`, 48,117 records).

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -98,3 +98,23 @@ both others); #1653 is the keystone for the read side + continuous loop.
 - [#1564](1564-toNumeric-symbol-throws-typeError.md) — ToNumeric: Symbol → TypeError — ~12 fails, easy
 
 - [#1600](1600-finalizationregistry-host-delegate-noop-stub.md) — FinalizationRegistry host-delegate (JS mode, like WeakRef) + no-op standalone stub; clears ~12 CEs. Faithful standalone finalization stays out of scope (→ #1101).
+
+## Test262 triage — untracked failure causes (PO, 2026-05-29)
+
+New issues from a fresh main-baseline (`.test262-cache/test262-current.jsonl`,
+48,117 records) root-cause triage. Dedup'd against all open issues; clusters
+already covered by open issues (dstr WasmGC type-mismatch → #1556/#1623;
+Promise non-constructor → #1528/#1694; Set set-like → #1627/#1646/#1674; bind
+fidelity → #1463) were NOT re-filed.
+
+- [#1716](../1716-spec-gap-toprimitive-residual-object-property-key-coercion.md) — **RESIDUAL of done #1090/#1319/#1525**: `Cannot convert object to primitive value` still thrown in 111 paths (Object property-key + String/RegExp/JSON/Date `this`-value coercion) — **high**, medium, **ready**
+- [#1717](../1717-arraybuffer-prototype-slice-not-implemented.md) — `ArrayBuffer.prototype.slice` not implemented (`slice is not a function`, 17 fails) — medium, medium, **ready**
+- [#1718](../1718-iterator-sequencing-helpers-concat-zip-flatmap.md) — Iterator sequencing helpers (`Iterator.concat`/`zip`/`zipKeyed`) + `Iterator.prototype.flatMap` not implemented (101 fails; distinct from done #1340) — medium, hard, **ready**
+- [#1719](../1719-array-destructuring-ignores-overridden-array-prototype-iterator.md) — Array destructuring ignores overridden `Array.prototype[Symbol.iterator]` (`items[Symbol.iterator]` must be a function, 71 fails) — **high**, medium, **ready**
+
+### ES3 / edition-0 conformance → Sprint 57 (Track 3)
+
+- [#1720](../1720-es3-incdec-reference-evaluation-order-null-base.md) — ES3: prefix/postfix inc-dec reference evaluated once before null deref (`base[prop()]++`, sputnik S11.x, ~10 fails) — medium, medium, **ready (sprint 57)**
+- [#1721](../1721-es3-subclass-function-object-instanceof.md) — ES3 (residual of #1455): `class extends Function`/`extends Object` instanceof returns false (4 fails) — medium, medium, **ready (sprint 57)**
+- [#1722](../1722-es3-assignmenttargettype-early-syntaxerror.md) — ES3: AssignmentTargetType early SyntaxError not raised (yield/arrow as assignment target, 4 fails) — low, medium, **ready (sprint 57)**
+- [#1511](../1511-spec-gap-arguments-object-mapped-and-trailing-comma.md) — **MOVED to sprint 57** (was sprint 52): arguments object mapped semantics / descriptors / trailing-comma length — covers the ES3 mapped-arguments cluster (~19 edition-0 fails) — high, medium, **review**

--- a/plan/issues/sprints/57.md
+++ b/plan/issues/sprints/57.md
@@ -121,6 +121,33 @@ Reasoning:
 test tooling, #1711 is PO/architect triage. #1712 is an integration gate, not
 a dev task.
 
+## Track 3 — ES3 conformance (edition-0 quick wins)
+
+Added by PO test262 triage (2026-05-29). The ≤ES3 edition has only **37 failing
+tests** (86% pass) but they are crisp, low-risk, dev-claimable bugs in
+legacy/sputnik-style coverage — good filler work that does not compete with the
+two architectural tracks. These are developer-claimable (`fix(...)`), not
+architect-gated.
+
+| ID | Title | Feasibility | Status | Edition-0 fails |
+|----|-------|-------------|--------|-----:|
+| #1511 | arguments object — mapped semantics, descriptors, trailing-comma length (moved from sprint 52) | medium | review | ~19 |
+| #1720 | inc/dec reference evaluated once before null deref (`base[prop()]++`) | medium | ready | ~10 |
+| #1721 | `class extends Function`/`extends Object` instanceof (residual of #1455) | medium | ready | 4 |
+| #1722 | AssignmentTargetType early SyntaxError (yield/arrow as assignment target) | medium | ready | 4 |
+
+- **#1511** is already implemented and in `review` — confirm/land it; it owns the
+  largest ES3 cluster (mapped-arguments non-configurable/non-writable
+  defineProperty + delete).
+- **#1720** is spec eval-order; pairs naturally with the done #1379 inc/dec value
+  fix.
+- **#1721** is a small registry addition on top of done #1455 (add `Function`,
+  `Object` to the builtin-parent tag registry).
+- **#1722** is parser early-error work (low value, 4 tests) — stretch.
+
+Conformance guard applies (net ≥ 0). All four are bucket-grind quick wins; none
+block the track-1/track-2 architecture work.
+
 ## Dispatch manifest (for tech lead)
 
 - **Parallelisable from start:** #1710 (tooling, no dep) and the #1713 architect


### PR DESCRIPTION
Root-cause triage of the current main baseline (\`.test262-cache/test262-current.jsonl\`, 48,117 records; 16,391 non-pass). Bucketed by normalized error signature, dedup'd against all 283 open issues + the CLAUDE.md skip-filters.

## New issues (7) + 1 moved

**Backlog (non-ES3):**
- **#1716** ToPrimitive `Cannot convert object to primitive value` — 111 fails. **RESIDUAL/regression of done #1090/#1319/#1525.** Object property-key + String/RegExp/JSON/Date this-value coercion.
- **#1717** `ArrayBuffer.prototype.slice` not implemented — 17 fails.
- **#1718** Iterator sequencing helpers (`Iterator.concat`/`zip`/`zipKeyed`) + `Iterator.prototype.flatMap` — 101 fails (distinct from done #1340).
- **#1719** Array destructuring ignores overridden `Array.prototype[Symbol.iterator]` — 71 fails.

**Sprint 57 — ES3 / edition-0 (Track 3):**
- **#1720** inc/dec reference evaluated once before null deref (`base[prop()]++`, sputnik S11.x) — ~10 fails.
- **#1721** `class extends Function`/`extends Object` instanceof — residual of done #1455 — 4 fails.
- **#1722** AssignmentTargetType early SyntaxError (yield/arrow as assignment target) — 4 fails.
- **#1511** moved sprint 52 → 57 (mapped-arguments ES3 cluster, ~19 edition-0 fails) — already in review.

## ES3 / edition-0 view
Ran \`scripts/generate-editions.ts\`: ≤ES3 = 274 tests, **37 failing** (86% pass). Buckets: mapped-arguments (~19 → #1511), inc/dec eval-order (~10 → #1720), subclass Function/Object (4 → #1721), AssignmentTargetType early errors (4 → #1722), plus 2 module-code (deferred).

## Dedup — NOT re-filed (already covered by open issues)
- dstr WasmGC type-mismatch (208 compile errors) → #1556 + #1623
- Promise `[object Object] is not a constructor` (98) → #1528 + #1694
- Set set-like `.size is NaN` (21) → #1627/#1646/#1674
- `Bind must be called on a function` (30) → #1463 (bind fidelity)
- `Cannot destructure null/undefined` (182) → same root cause as #1556

## Deferred per skip-filter (no issue)
Temporal, SharedArrayBuffer, Atomics, ShadowRealm, FinalizationRegistry, eval-code, with, dynamic-import (import.defer/import.source).

Docs-only under \`plan/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)