### PR TITLE
fix(#1721): class extends Function/Object — instanceof residual of #1455

### DIFF
--- a/plan/issues/1721-es3-subclass-function-object-instanceof.md
+++ b/plan/issues/1721-es3-subclass-function-object-instanceof.md
@@ -1,9 +1,10 @@
 ---
 id: 1721
 title: "ES3 (RESIDUAL of #1455): 'class extends Function' / 'class extends Object' instanceof returns false"
-status: ready
+status: done
 created: 2026-05-29
 updated: 2026-05-29
+completed: 2026-05-29
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -39,19 +40,35 @@ TypedArrays, DataView, WeakRef) via the `__tag_user_class` tag chain — but
 These are edition-0 sputnik-style tests (no es5id/esid/feature tag), classified
 ≤ ES3 by `scripts/generate-editions.ts`.
 
-## Root-cause hypothesis
+## Root cause (confirmed)
 
-`src/codegen/builtin-tags.ts` `BUILTIN_TYPE_TAGS` /
-`BUILTIN_PARENTS_HOST_CONSTRUCTIBLE` do not list `Function` and `Object`. A class
-that `extends Function`/`Object` therefore is not externref-backed / not tagged,
-so the runtime `__instanceof` tag-chain walk added in #1455 never matches.
-`Object` (ordinary object parent) and `Function` (callable parent) are special
-cases: `extends Object` should produce an ordinary subclass whose prototype chain
-reaches `Object.prototype`; `extends Function` produces a callable subclass whose
-chain reaches `Function.prototype`.
+Three coupled gaps, all anchored on `Object` / `Function` being absent from the
+#1455 registration:
+
+1. `src/codegen/builtin-tags.ts` — `Object` / `Function` were in
+   `BUILTIN_TYPE_TAGS` but **not** in `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`, so a
+   class that `extends Function`/`Object` was not externref-backed / not tagged,
+   and the runtime `__instanceof` tag-chain walk added in #1455 never matched.
+2. `src/runtime.ts` — the `extern_class new` resolver's `builtinCtors` map had
+   `Number`/`Boolean`/`String` but not `Object` / `Function`, so `super()`
+   lowering to `__new_Object()` / `__new_Function()` threw "No dependency
+   provided for extern class".
+3. `src/codegen/expressions/identifiers.ts` `tryStaticInstanceOf` walks the
+   parent through `isBuiltinSubtype(builtinParent, ctorName)`. With no
+   `Function -> Object` edge in `BUILTIN_PARENT`, a subclass of Function
+   statically reported `instanceof Object === false`.
 
 Spec: [§10.2.1 / §15.7.14 ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation),
 [§7.3.20 OrdinaryHasInstance](https://tc39.es/ecma262/#sec-ordinaryhasinstance).
+
+## Fix
+
+- Added `Object`, `Function` to `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`
+  (`builtin-tags.ts`).
+- Added `Object`, `Function` to the runtime `builtinCtors` map (`runtime.ts`).
+- Added the `Function -> Object` edge to `BUILTIN_PARENT` (`builtin-tags.ts`) —
+  the one provably-true (never false-negative) `instanceof Object` chain edge;
+  the other builtins' Object edges are deliberately left to runtime.
 
 ## Example failing tests
 
@@ -63,8 +80,14 @@ Spec: [§10.2.1 / §15.7.14 ClassDefinitionEvaluation](https://tc39.es/ecma262/#
 ## Acceptance criteria
 
 - All four `subclass-Function` / `subclass-Object` tests pass (`instanceof Sub`
-  and `instanceof Function`/`Object` both true).
-- No regression in #1455's subclass-builtins tests (Map/TypedArray/WeakMap/etc.).
+  and `instanceof Function`/`Object` both true). ✅
+- No regression in #1455's subclass-builtins tests (Map/TypedArray/WeakMap/etc.). ✅
+
+## Test Results
+
+- `tests/issue-1721.test.ts` — 4/4 pass (Object, Function, class-expression
+  Object, subclass-of-Object instance method).
+- `tests/issue-1455.test.ts` — 9/9 pass (no regression).
 
 ## Source
 

--- a/src/codegen/builtin-tags.ts
+++ b/src/codegen/builtin-tags.ts
@@ -105,6 +105,12 @@ export type BuiltinTypeName = keyof typeof BUILTIN_TYPE_TAGS;
  * incomplete chain data).
  */
 const BUILTIN_PARENT: Partial<Record<BuiltinTypeName, BuiltinTypeName>> = {
+  // #1721 — `Function` descends from `Object`, so a subclass of Function is
+  // statically an instance of Object too (every function IS an object). This
+  // is the one chain edge that produces a provably-true (never false-negative)
+  // `instanceof Object` result, so it is safe to record here even though the
+  // module deliberately leaves the other builtins' Object edges to runtime.
+  Function: "Object",
   TypeError: "Error",
   RangeError: "Error",
   SyntaxError: "Error",
@@ -221,6 +227,13 @@ export const BUILTIN_PARENTS_HOST_CONSTRUCTIBLE: ReadonlySet<BuiltinTypeName> = 
   "Number",
   "String",
   "Date",
+  // #1721 — root constructors. `class Sub extends Object {}` / `extends
+  // Function {}` lower to `new Object()` / `new Function()` so the instance is
+  // a real host object/function whose [[Prototype]] is then set to
+  // `Sub.prototype`. Missed by #1455 (which registered Map/TypedArray/etc. but
+  // not the two roots), so `new Sub() instanceof Sub` returned false for both.
+  "Object",
+  "Function",
 ]);
 
 /**

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3761,6 +3761,13 @@ function resolveImport(
           Number,
           Boolean,
           String,
+          // (#1721) Root constructors so `class Sub extends Object {}` /
+          // `extends Function {}` route through `__new_Object()` /
+          // `__new_Function()` instead of throwing "No dependency provided for
+          // extern class". The instance's [[Prototype]] is then set to
+          // `Sub.prototype` by `__set_subclass_proto`.
+          Object,
+          Function,
           // (#1366b) Array and Promise added so `class Sub extends Array {}` /
           // `class Sub extends Promise {}` route through `__new_Array(arg)` /
           // `__new_Promise(executor)` host imports. Without these entries the

--- a/tests/issue-1721.test.ts
+++ b/tests/issue-1721.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1721 — `class Sub extends Object {}` / `class Sub extends Function {}` must
+ * satisfy `new Sub() instanceof Sub` (and the parent / Object chain), per
+ * §10.2.1 / §20.1.2 / §20.2.2.
+ *
+ * Residual of #1455, which registered Map / TypedArray / WeakMap / DataView /
+ * WeakRef (and the wrapper types + Date) as host-constructible subclassable
+ * parents but missed the two roots `Object` and `Function`. Without them:
+ *   - `Object` / `Function` were absent from
+ *     `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`, so `class Sub extends Object {}`
+ *     produced a plain WasmGC struct, never externref-backed, and
+ *     `instanceof Sub` returned false.
+ *   - `Object` / `Function` were absent from the runtime `builtinCtors` map,
+ *     so the `extern_class new` resolver threw "No dependency provided".
+ *   - The static `instanceof` evaluator had no `Function -> Object` edge, so a
+ *     subclass of Function reported `instanceof Object === false`.
+ *
+ * Fix (all in builtin-tags.ts + runtime.ts):
+ *   - Added `Object`, `Function` to `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`.
+ *   - Added `Object`, `Function` to the runtime `builtinCtors` map.
+ *   - Added the `Function -> Object` edge to `BUILTIN_PARENT` so a subclass of
+ *     Function is statically an instance of Object too.
+ */
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const exports = await compileAndInstantiate(src);
+  return ((exports as any).test as () => number)();
+}
+
+describe("#1721 — subclass of Object / Function instanceof", () => {
+  it("class extends Object — instanceof Sub and Object both pass", async () => {
+    const src = `
+class Subclass extends Object {}
+const sub = new Subclass();
+export function test(): number {
+  const a: number = sub instanceof Subclass ? 1 : 0;
+  const b: number = sub instanceof Object ? 1 : 0;
+  return (a << 1) | b;
+}`;
+    expect(await run(src)).toBe(3);
+  });
+
+  it("class extends Function — instanceof Sub, Function, Object all pass", async () => {
+    const src = `
+class Subclass extends Function {}
+const sub = new Subclass();
+export function test(): number {
+  const a: number = sub instanceof Subclass ? 1 : 0;
+  const b: number = sub instanceof Function ? 1 : 0;
+  const c: number = sub instanceof Object ? 1 : 0;
+  return (a << 2) | (b << 1) | c;
+}`;
+    expect(await run(src)).toBe(7);
+  });
+
+  it("class expression extends Object — instanceof checks pass", async () => {
+    const src = `
+const Subclass = class extends Object {}
+const sub = new Subclass();
+export function test(): number {
+  const a: number = sub instanceof Subclass ? 1 : 0;
+  const b: number = sub instanceof Object ? 1 : 0;
+  return (a << 1) | b;
+}`;
+    expect(await run(src)).toBe(3);
+  });
+
+  it("subclass of Object carries its own instance method", async () => {
+    const src = `
+class Subclass extends Object {
+  mine(): number { return 7; }
+}
+const sub = new Subclass();
+export function test(): number {
+  return sub instanceof Subclass && sub.mine() === 7 ? 1 : 0;
+}`;
+    expect(await run(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`class Sub extends Object {}` and `class Sub extends Function {}` returned `false` for `new Sub() instanceof Sub` (~4 test262 fails under `language/.../class/.../subclass-builtins/`). Residual of #1455, which registered Map/TypedArray/WeakMap/DataView/WeakRef + wrapper types + Date as subclassable builtin parents but missed the two roots.

## Root cause

Three coupled gaps, all from `Object`/`Function` being absent from #1455's registration:

1. `builtin-tags.ts` — `Object`/`Function` were in `BUILTIN_TYPE_TAGS` but **not** `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`, so the subclass wasn't externref-backed/tagged and the #1455 `__instanceof` tag-chain walk never matched.
2. `runtime.ts` — the `extern_class new` `builtinCtors` map had Number/Boolean/String but not Object/Function, so `super()` lowering to `__new_Object()`/`__new_Function()` threw "No dependency provided".
3. `identifiers.ts` `tryStaticInstanceOf` walks the parent via `isBuiltinSubtype`; with no `Function -> Object` edge, a subclass of Function statically reported `instanceof Object === false`.

## Fix

- Add `Object`, `Function` to `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE` (builtin-tags.ts)
- Add the `Function -> Object` edge to `BUILTIN_PARENT` (builtin-tags.ts) — the one provably-true Object chain edge; others stay runtime-resolved
- Add `Object`, `Function` to the runtime `builtinCtors` map (runtime.ts)

Spec: ECMA-262 §10.2.1 ClassDefinitionEvaluation, §7.3.20 OrdinaryHasInstance.

## Tests

- `tests/issue-1721.test.ts` — 4/4 pass (Object, Function incl. `instanceof Object`, class-expression, subclass-of-Object instance method)
- `tests/issue-1455.test.ts` — 9/9 pass (no regression)

Closes #1721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)