### PR TITLE
triage(#1711): acorn failure-surface lap 1 — file #1724 ctor coercion blocker

### DIFF
--- a/plan/goals/self-hosting-dogfood.md
+++ b/plan/goals/self-hosting-dogfood.md
@@ -61,8 +61,21 @@ differential test, not a green compile.
 | **1690** | acorn.mjs invalid Wasm: f64.lt reads global array ref (index-shift) | Backlog | done | high |
 | **1690b** | inner `var x` aliases module-level global (scoping) | Backlog | done | high |
 | **1710** | acorn dogfood harness: compile + validate + differential-AST vs node-acorn | 57 | ready | high |
-| **1711** | acorn failure-surface triage: bucket + file sized child issues | 57 | ready | high |
+| **1711** | acorn failure-surface triage: bucket + file sized child issues | 57 | done | high |
 | **1712** | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | 57 | backlog | high |
+| **1724** | acorn: `__fnctor_<Ctor>_new` emits `any.convert_extern` on a `ref.cast`-null struct ref → invalid Wasm (next blocker, from #1711 triage) | Backlog | ready | high |
+
+## Triage lap 1 (#1711, 2026-05-29)
+
+First harness run on main (29bc76539, acorn 8.16.0): `compile()` succeeds but
+the binary fails `WebAssembly.compile()` at `__fnctor_Parser_new`
+(`any.convert_extern[0] expected externref, found ref.cast null of type
+(ref null 94)`). This is the **third** acorn blocker in sequence (after #1679,
+#1690) and the sole gate on the surface — all 5 AST-diff fixtures are skipped
+because the binary is invalid. Filed as **#1724** (codegen-acceptance, HIGH
+real-world weight: it's the `Parser` constructor on acorn's hot path). No
+runtime-AST-divergence gaps are observable until #1724 lands; re-run the
+harness then for lap 2. Full triage table in #1711.
 
 ## Success criteria
 

--- a/plan/goals/self-hosting-dogfood.md
+++ b/plan/goals/self-hosting-dogfood.md
@@ -63,7 +63,7 @@ differential test, not a green compile.
 | **1710** | acorn dogfood harness: compile + validate + differential-AST vs node-acorn | 57 | ready | high |
 | **1711** | acorn failure-surface triage: bucket + file sized child issues | 57 | done | high |
 | **1712** | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | 57 | backlog | high |
-| **1724** | acorn: `__fnctor_<Ctor>_new` emits `any.convert_extern` on a `ref.cast`-null struct ref → invalid Wasm (next blocker, from #1711 triage) | Backlog | ready | high |
+| **1725** | acorn: `__fnctor_<Ctor>_new` emits `any.convert_extern` on a `ref.cast`-null struct ref → invalid Wasm (next blocker, from #1711 triage) | Backlog | ready | high |
 
 ## Triage lap 1 (#1711, 2026-05-29)
 
@@ -72,9 +72,9 @@ the binary fails `WebAssembly.compile()` at `__fnctor_Parser_new`
 (`any.convert_extern[0] expected externref, found ref.cast null of type
 (ref null 94)`). This is the **third** acorn blocker in sequence (after #1679,
 #1690) and the sole gate on the surface — all 5 AST-diff fixtures are skipped
-because the binary is invalid. Filed as **#1724** (codegen-acceptance, HIGH
+because the binary is invalid. Filed as **#1725** (codegen-acceptance, HIGH
 real-world weight: it's the `Parser` constructor on acorn's hot path). No
-runtime-AST-divergence gaps are observable until #1724 lands; re-run the
+runtime-AST-divergence gaps are observable until #1725 lands; re-run the
 harness then for lap 2. Full triage table in #1711.
 
 ## Success criteria

--- a/plan/issues/1711-acorn-failure-surface-triage.md
+++ b/plan/issues/1711-acorn-failure-surface-triage.md
@@ -1,9 +1,11 @@
 ---
 id: 1711
 title: "acorn failure-surface triage: bucket harness output + file sized child issues"
-status: ready
+status: done
+completed: 2026-05-29
 created: 2026-05-29
 updated: 2026-05-29
+child_issues: [1724]
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -76,3 +78,39 @@ PO/architect triage task, not a code-fix task.
 - Child issues filed here inherit `goal: self-hosting-dogfood` and may be
   pulled into Sprint 57 if small enough, or deferred to the backlog with a
   real-world-weight tag for a later sprint.
+
+## Triage results — run 2026-05-29 (acorn 8.16.0, main 29bc76539)
+
+Harness: `pnpm run dogfood:acorn` → `tests/dogfood/report/acorn-surface.json`.
+
+**Headline:** `compile()` `success=true` (827,839-byte binary, 471
+diagnostics) but `WebAssembly.compile()` **INVALID** — the binary does not
+validate, so all 5 runtime-AST-diff fixtures are skipped. The surface is
+therefore dominated by a **single codegen-acceptance blocker**; no
+runtime-divergence (AST) data is reachable until it clears.
+
+### Failure-surface table
+
+| # | Surface entry | Class | Count | Root cause | Tracking | Size | RW weight |
+|---|---------------|-------|------:|-----------|----------|------|-----------|
+| 1 | `WebAssembly.compile(): __fnctor_Parser_new failed: any.convert_extern[0] expected externref, found ref.cast null of type (ref null 94)` | codegen-acceptance (invalid Wasm) | 1 (blocks all) | functor-constructor body emits `any.convert_extern` on a `ref.cast`-narrowed struct ref instead of `extern.convert_any` from anyref | **NEW → #1724** | M | **HIGH** (Parser ctor = acorn hot path; gates everything) |
+| 2 | `Property 'X' does not exist on type 'Y'` | ts-property-noise | 464 | untyped JS through TS checker | not filed — known noise (#1679/#1690) | — | — |
+| 3 | `Object is possibly 'undefined'` | ts-possibly-null | 3 | same untyped-JS checker noise | not filed — known noise | — | — |
+| 4 | `comparison … types 'number' and 'string' have no overlap` (1); `body of statement cannot be the empty statement` (1); `Operator 'X' cannot be applied to types 'X' and 'X'` (2) | "other" diagnostics | 4 | TS-checker diagnostics on untyped acorn JS; **not** `success:false` errors (compile succeeded) | not filed — non-blocking diagnostics | — | — |
+| 5 | runtime AST divergence (per-node, per-option) | runtime-divergence | 0 observed | **unreachable** — binary invalid, run+diff skipped | re-run after #1724 lands | — | — |
+
+### Conclusions
+
+- **One** genuine, un-tracked root cause → filed as **#1724** (functor
+  constructor `any.convert_extern` on non-extern ref). It is the sole gate on
+  the entire acorn surface.
+- The prior two acorn blockers are **closed**: #1679 (`new this(...)`) and
+  #1690 (`isInAstralSet` stale module-global index). #1724 is the third in the
+  sequence, distinct from both (different function, different validator error).
+- **No runtime-divergence (AST) gaps are observable yet** — they are the
+  higher-value, harder-to-find class (acceptance #3), but they only become
+  reachable once #1724 makes the binary validate. This issue is re-run each
+  dogfood lap; the next run after #1724 lands is expected to expose the AST
+  layer for the 5 fixtures (`arith/class/control/fn/strings`).
+- The oracle self-check passed (`identicalSourcesEqual && differingSourcesDivergent`),
+  so the diff harness itself is sound — the skip is purely the red binary.

--- a/plan/issues/1711-acorn-failure-surface-triage.md
+++ b/plan/issues/1711-acorn-failure-surface-triage.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-05-29
 created: 2026-05-29
 updated: 2026-05-29
-child_issues: [1724]
+child_issues: [1725]
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -93,24 +93,24 @@ runtime-divergence (AST) data is reachable until it clears.
 
 | # | Surface entry | Class | Count | Root cause | Tracking | Size | RW weight |
 |---|---------------|-------|------:|-----------|----------|------|-----------|
-| 1 | `WebAssembly.compile(): __fnctor_Parser_new failed: any.convert_extern[0] expected externref, found ref.cast null of type (ref null 94)` | codegen-acceptance (invalid Wasm) | 1 (blocks all) | functor-constructor body emits `any.convert_extern` on a `ref.cast`-narrowed struct ref instead of `extern.convert_any` from anyref | **NEW → #1724** | M | **HIGH** (Parser ctor = acorn hot path; gates everything) |
+| 1 | `WebAssembly.compile(): __fnctor_Parser_new failed: any.convert_extern[0] expected externref, found ref.cast null of type (ref null 94)` | codegen-acceptance (invalid Wasm) | 1 (blocks all) | functor-constructor body emits `any.convert_extern` on a `ref.cast`-narrowed struct ref instead of `extern.convert_any` from anyref | **NEW → #1725** | M | **HIGH** (Parser ctor = acorn hot path; gates everything) |
 | 2 | `Property 'X' does not exist on type 'Y'` | ts-property-noise | 464 | untyped JS through TS checker | not filed — known noise (#1679/#1690) | — | — |
 | 3 | `Object is possibly 'undefined'` | ts-possibly-null | 3 | same untyped-JS checker noise | not filed — known noise | — | — |
 | 4 | `comparison … types 'number' and 'string' have no overlap` (1); `body of statement cannot be the empty statement` (1); `Operator 'X' cannot be applied to types 'X' and 'X'` (2) | "other" diagnostics | 4 | TS-checker diagnostics on untyped acorn JS; **not** `success:false` errors (compile succeeded) | not filed — non-blocking diagnostics | — | — |
-| 5 | runtime AST divergence (per-node, per-option) | runtime-divergence | 0 observed | **unreachable** — binary invalid, run+diff skipped | re-run after #1724 lands | — | — |
+| 5 | runtime AST divergence (per-node, per-option) | runtime-divergence | 0 observed | **unreachable** — binary invalid, run+diff skipped | re-run after #1725 lands | — | — |
 
 ### Conclusions
 
-- **One** genuine, un-tracked root cause → filed as **#1724** (functor
+- **One** genuine, un-tracked root cause → filed as **#1725** (functor
   constructor `any.convert_extern` on non-extern ref). It is the sole gate on
   the entire acorn surface.
 - The prior two acorn blockers are **closed**: #1679 (`new this(...)`) and
-  #1690 (`isInAstralSet` stale module-global index). #1724 is the third in the
+  #1690 (`isInAstralSet` stale module-global index). #1725 is the third in the
   sequence, distinct from both (different function, different validator error).
 - **No runtime-divergence (AST) gaps are observable yet** — they are the
   higher-value, harder-to-find class (acceptance #3), but they only become
-  reachable once #1724 makes the binary validate. This issue is re-run each
-  dogfood lap; the next run after #1724 lands is expected to expose the AST
+  reachable once #1725 makes the binary validate. This issue is re-run each
+  dogfood lap; the next run after #1725 lands is expected to expose the AST
   layer for the 5 fixtures (`arith/class/control/fn/strings`).
 - The oracle self-check passed (`identicalSourcesEqual && differingSourcesDivergent`),
   so the diff harness itself is sound — the skip is purely the red binary.

--- a/plan/issues/1724-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
+++ b/plan/issues/1724-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
@@ -1,0 +1,111 @@
+---
+id: 1724
+title: "acorn dogfood: __fnctor_<Ctor>_new emits any.convert_extern on a ref.cast-null struct ref → invalid Wasm"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, type-coercion
+language_feature: function-constructors, this-property-assignment, ref-coercion
+goal: self-hosting-dogfood
+sprint: Backlog
+parent: 1711
+related: [1690, 1679, 1710, 1284, 1298]
+---
+# #1724 — acorn functor constructor emits `any.convert_extern` on a non-extern ref → invalid Wasm
+
+## Problem
+
+This is the current top blocker on the acorn dogfood loop (#1710/#1711),
+surfaced **behind** the now-fixed #1679 (`new this(...)`) and #1690
+(`isInAstralSet` global-index shift). `compile(acorn.mjs)` returns
+`success=true` with **0 genuine errors** (471 diagnostics, all TS JS-noise —
+see "Not a blocker" below), but the emitted binary **fails
+`WebAssembly.compile()`**:
+
+```
+WebAssembly.compile(): Compiling function #110:"__fnctor_Parser_new" failed:
+  any.convert_extern[0] expected type externref, found ref.cast null of type (ref null 94)
+  @+202078
+```
+
+The whole acorn surface is gated on this: the dogfood harness skips all 5
+runtime-AST-diff fixtures because the binary never validates
+(`binaryValidates:false`).
+
+## Root cause (hypothesis — to confirm)
+
+`__fnctor_Parser_new` is the synthetic **function-constructor functor** emitted
+by `compileFunctionConstructor` in `src/codegen/expressions/new-super.ts:812+`
+(`structName = \`__fnctor_${funcName}\``). The constructor body compiles
+acorn's `this.X = …` assignments into `struct.set`s on the `__fnctor_Parser`
+struct, and at some point coerces a value to `externref` via
+`any.convert_extern`.
+
+`any.convert_extern` requires an **anyref/any-subtype** operand. The validator
+reports the operand is instead a `ref.cast null (ref null 94)` — i.e. a value
+that has already been cast to a **concrete nullable struct ref** (type index
+94), not left as anyref. Emitting `any.convert_extern` directly on a
+`(ref null <struct>)` is ill-typed: the correct lowering for ref → externref is
+`extern.convert_any` (per CLAUDE.md "Type Coercion" — `ref/ref_null → externref:
+extern.convert_any`), OR the value should not have been `ref.cast`-narrowed
+before the conversion.
+
+So the defect is a **ref→externref coercion site in the functor-constructor
+body** (or a shared `coerceType` path it routes through) that:
+  (a) uses `any.convert_extern` where `extern.convert_any` is required, or
+  (b) narrows a struct-typed `this.X` value with `ref.cast null` and then feeds
+      it to the externref conversion without the round-trip through anyref.
+
+This is the same *family* as #1284 / #1298 (typed struct field ↔ extern
+roundtrip), but the trigger is the functor-constructor lowering specifically,
+not a general typed-dict path — confirm whether the fix belongs in
+`new-super.ts` constructor-body emission or in `type-coercion.ts coerceType`.
+
+## How to reproduce
+
+```bash
+# from a worktree branched off origin/main (the harness is in tests/dogfood/)
+pnpm run dogfood:acorn
+# → compile() success=true, 471 diagnostics; WebAssembly.compile() FAILS with
+#   the any.convert_extern[0] error on __fnctor_Parser_new (above).
+```
+
+A minimal in-repo reducer is **part of this issue's work**: reduce acorn's
+`Parser` static-factory + `this.X = …` body to the smallest function-style
+class (promoted into `ctx.classSet` via `Object.defineProperties(prototype,…)`
++ `prototype.X = …`, as #1679 notes) whose `__fnctor_<C>_new` reproduces the
+`any.convert_extern` validation failure. Pin it as `tests/issue-1723.test.ts`
+(compile + `WebAssembly.compile` must succeed).
+
+## Acceptance criteria
+
+1. `WebAssembly.compile()` of compiled `acorn.mjs` no longer fails on
+   `__fnctor_Parser_new` (the harness `binaryValidates` flips to `true`, and
+   the run+diff fixtures stop being skipped for this reason).
+2. The ref→externref coercion in the functor-constructor body emits a
+   well-typed sequence (`extern.convert_any` from anyref, or no spurious
+   `ref.cast null` before the conversion).
+3. A minimal `tests/issue-1723.test.ts` reproducer compiles AND validates.
+4. No regression in the existing function-constructor / `new`-expression
+   test262 buckets or `tests/equivalence.test.ts`.
+
+## Classification (per #1711 triage)
+
+- **codegen-acceptance** gap (won't validate) — highest-priority class: it
+  blocks ALL downstream runtime-divergence discovery for acorn.
+- **Real-world weight: HIGH** — `Parser` construction is acorn's hottest path
+  (every `parse()` entry instantiates it via `new this(...)`); nothing in acorn
+  runs until this validates.
+
+## Notes / scope
+
+- Out of scope: the 464 `Property 'X' does not exist on type 'Y'` +
+  3 `Object is possibly 'undefined'` + 4 misc TS diagnostics — all untyped-JS
+  checker noise per #1679/#1690, NOT compile blockers (`success` stays `true`).
+- Validator offset `@+202078` and function index `#110` are pin-specific
+  (acorn 8.16.0, `tests/dogfood/fixtures/acorn-8.16.0.tgz`); the *symbol*
+  `__fnctor_Parser_new` is the stable anchor.

--- a/plan/issues/1725-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
+++ b/plan/issues/1725-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
@@ -1,5 +1,5 @@
 ---
-id: 1724
+id: 1725
 title: "acorn dogfood: __fnctor_<Ctor>_new emits any.convert_extern on a ref.cast-null struct ref → invalid Wasm"
 status: ready
 created: 2026-05-29
@@ -15,7 +15,7 @@ sprint: Backlog
 parent: 1711
 related: [1690, 1679, 1710, 1284, 1298]
 ---
-# #1724 — acorn functor constructor emits `any.convert_extern` on a non-extern ref → invalid Wasm
+# #1725 — acorn functor constructor emits `any.convert_extern` on a non-extern ref → invalid Wasm
 
 ## Problem
 


### PR DESCRIPTION
## What

Sprint 57 dogfood track. Ran the #1710 acorn harness (`pnpm run dogfood:acorn`)
against current main (acorn 8.16.0), triaged the failure surface, and filed the
one genuine un-tracked blocker as a child issue. **Planning/triage only — no
compiler code changes** (per #1711 acceptance #4).

## Findings

`compile(acorn.mjs)` → `success=true` (827 KB binary, 471 diagnostics, all TS
JS-noise) but `WebAssembly.compile()` **rejects** the binary:

```
__fnctor_Parser_new failed: any.convert_extern[0] expected externref,
  found ref.cast null of type (ref null 94)
```

This is the **third** acorn blocker in sequence (after #1679 `new this(...)` and
#1690 `isInAstralSet` index-shift, both `done`) and the **sole gate** on the
surface — all 5 AST-diff fixtures skip because the binary is invalid. No
runtime-divergence (AST) gaps are observable until it clears.

## Changes

- **`plan/issues/1724-…md` (NEW)** — child issue for the functor-constructor
  `any.convert_extern`-on-non-extern-ref coercion bug. Codegen-acceptance class,
  HIGH real-world weight (`Parser` ctor is acorn's hot path). Includes the
  validator error, the suspected site (`new-super.ts:812+` functor ctor body),
  the `extern.convert_any` vs `any.convert_extern` hypothesis, acceptance
  criteria, and a note that the minimal reducer is part of the fix work.
- **`plan/issues/1711-…md`** — full triage table (every surface entry → root
  cause → tracking → size → real-world weight); known TS-noise buckets
  explicitly listed as "not filed, reason: …"; status → `done`.
- **`plan/goals/self-hosting-dogfood.md`** — lap-1 result recorded; #1724 added
  to the issues table.

## Notes
- The harness report (`tests/dogfood/report/acorn-surface.json`) is gitignored
  and not committed.
- #1724 numbered to avoid colliding with the in-flight `issue-1723-nativemsg-bugs`
  branch.

Closes #1711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)