### PR TITLE
fix(#1720): inc/dec reference evaluation order on null base

### DIFF
--- a/plan/issues/1720-es3-incdec-reference-evaluation-order-null-base.md
+++ b/plan/issues/1720-es3-incdec-reference-evaluation-order-null-base.md
@@ -1,9 +1,10 @@
 ---
 id: 1720
 title: "ES3: prefix/postfix inc-dec reference is evaluated once before the null/undefined deref ('base[prop()]++')"
-status: ready
+status: done
 created: 2026-05-29
 updated: 2026-05-29
+completed: 2026-05-29
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -78,3 +79,72 @@ evaluated (computed key included) and `GetValue` attempted in spec order.
 
 Filed by product-owner test262 triage (ES3 / edition-0 view) 2026-05-29 against
 main baseline (`.test262-cache/test262-current.jsonl`, 48,117 records).
+
+
+## Implementation (landed)
+
+### Root cause (confirmed)
+
+`compileMemberIncDec` (`src/codegen/expressions/unary-updates.ts`) compiled the
+base of an `ElementAccessExpression`, and when the base resolved to `externref`
+(which is what a `null`-typed base produces) it took an early branch that
+`drop`ped the base and emitted `f64.const NaN` — **without ever compiling the
+property-key expression**. Two spec violations:
+
+1. The key sub-expression's side effects (`prop()`) were lost — `prop()` never
+   ran.
+2. A `null` base produced `NaN` instead of throwing `TypeError`.
+
+The sibling non-ref (numeric base) branch likewise skipped the key expression.
+
+### Fix
+
+In the externref element-access branch of `compileMemberIncDec`:
+
+1. Save the base externref to a temp local.
+2. Compile the property-key expression for its side effects, then `drop` it
+   (ToPropertyKey itself is skipped — GetValue throws first on a null base).
+3. Emit a runtime `ref.is_null` guard: null base → `emitThrowTypeError`
+   (a real `TypeError` instance, satisfying `e instanceof TypeError`);
+   non-null externref base → fall through to the existing `NaN` result.
+
+The TypeError throw is emitted into the real `fctx.body` first (so
+`emitThrowTypeError`'s late-import-shift bookkeeping patches the already-emitted
+instructions correctly), then the freshly-appended throw instrs are spliced out
+into the `if` then-body. Building the throw against a detached body skips the
+index shift on prior instrs and emits an index-corrupt module.
+
+The non-ref (numeric base) branch now also compiles the key for side effects
+(a numeric base can't be null, so no TypeError path applies there).
+
+### Test Results
+
+`tests/issue-1720.test.ts` (11 cases) — all pass:
+
+- property-key expression runs exactly once before the throw, for
+  postfix/prefix x `++`/`--`
+- null base throws (all four operators)
+- null base throws a `TypeError` *instance* (not NaN)
+- null base: key object's `toString` is NOT called (TypeError thrown first)
+- non-null externref property inc/dec still yields NaN (unchanged)
+
+Direct probe: `base[prop()]++` now invokes `prop()` once (was 0); the
+`base[prop]++` null-base case throws TypeError with `toString` uncalled.
+
+For the four `*_A6_T1.js` test262 files, the **second** assertion
+(`assert.throws(TypeError, …)` + toString-not-called) now passes. The
+**first** assertion (`assert.throws(DummyError, …)`) remains gated on a
+separate, pre-existing gap: `e instanceof <userConstructor>` returns false for
+a value thrown by `new DummyError()` (a non-Error user constructor). That
+`instanceof` limitation is independent of update-expression evaluation order.
+
+No regressions in the inc/dec suite (issue-260/378/319/1119/1379). The
+pre-existing private-class-field failures (issue-254, issue-334 `this.#count++`)
+reproduce identically on clean `main` HEAD and are unrelated (PropertyAccess
+path, not ElementAccess).
+
+### Files modified
+
+- `src/codegen/expressions/unary-updates.ts` — externref + non-ref
+  element-access branches in `compileMemberIncDec`.
+- `tests/issue-1720.test.ts` — new.

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -303,16 +303,52 @@ function compileMemberIncDec(
     if (!objResult) return null;
 
     // Externref element access: cannot do struct.get/struct.set on externref,
-    // gracefully emit NaN (incrementing a dynamic property produces NaN)
+    // gracefully emit NaN (incrementing a dynamic property produces NaN).
+    //
+    // #1720 — reference evaluation order on `base[key]++`. Per §13.4 the LHS
+    // MemberExpression is evaluated to a Reference *before* GetValue forces the
+    // ToNumeric coercion, and per §13.3.3 evaluating `base[key]` evaluates both
+    // the base sub-expression AND the property-key sub-expression (with their
+    // side effects) before the Reference is resolved. The old code dropped the
+    // base and emitted NaN without ever compiling the key expression, so a
+    // side-effecting key (`base[prop()]++`) silently skipped `prop()`. We now
+    // evaluate the key for its side effects, then — when the base is null at
+    // runtime — throw a TypeError (RequireObjectCoercible inside GetValue),
+    // which is observable *before* ToPropertyKey would call the key's
+    // `toString`. A non-null externref base still falls through to NaN.
     if (objResult.kind === "externref") {
-      fctx.body.push({ op: "drop" });
+      const elemBaseTmp = allocLocal(fctx, `__incdec_ebase_${fctx.locals.length}`, objResult);
+      fctx.body.push({ op: "local.set", index: elemBaseTmp });
+      // Evaluate the property-key expression for its side effects, then discard
+      // its value (ToPropertyKey itself is skipped — GetValue throws first when
+      // the base is null/undefined).
+      const keyResult = compileExpression(ctx, fctx, operand.argumentExpression);
+      if (keyResult) fctx.body.push({ op: "drop" });
+      // RequireObjectCoercible: null base -> TypeError before the update step.
+      fctx.body.push({ op: "local.get", index: elemBaseTmp });
+      fctx.body.push({ op: "ref.is_null" });
+      // Emit the TypeError throw into the REAL body first so emitThrowTypeError's
+      // late-import-shift bookkeeping (ensureLateImport + flushLateImportShifts)
+      // patches the already-emitted instructions correctly, then splice the
+      // freshly-appended throw instrs out into the `if` then-body. Building the
+      // throw against a detached body would skip the shift on prior instrs and
+      // emit an index-corrupt module (#1720).
+      const throwStart = fctx.body.length;
+      emitThrowTypeError(ctx, fctx, "TypeError: Cannot read properties of null (update target)");
+      const thenBody = fctx.body.splice(throwStart);
+      fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenBody });
+      // Non-null externref base: incrementing a dynamic property yields NaN.
       fctx.body.push({ op: "f64.const", value: NaN });
       return { kind: "f64" };
     }
 
     if (objResult.kind !== "ref" && objResult.kind !== "ref_null") {
-      // Non-ref element access: gracefully emit NaN
+      // Non-ref element access (numeric/i32 base): gracefully emit NaN.
+      // #1720 — still evaluate the property-key expression for its side effects
+      // (a numeric base can't be null, so no TypeError path applies here).
       fctx.body.push({ op: "drop" });
+      const keyResult = compileExpression(ctx, fctx, operand.argumentExpression);
+      if (keyResult) fctx.body.push({ op: "drop" });
       fctx.body.push({ op: "f64.const", value: NaN });
       return { kind: "f64" };
     }

--- a/tests/issue-1720.test.ts
+++ b/tests/issue-1720.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1720 — reference evaluation order for `++`/`--` on a member
+ * reference whose base is `null` / `undefined`: `base[prop()]++`.
+ *
+ * Per ECMA-262 §13.4 (UpdateExpression), the LeftHandSideExpression is first
+ * evaluated to a Reference, and only then does `GetValue` force the ToNumeric
+ * coercion. Evaluating the member reference `base[key]` (§13.3.3) evaluates
+ * BOTH the base sub-expression and the property-key sub-expression — with all
+ * their side effects — before the Reference is resolved. `GetValue` of a
+ * Reference whose base is `null`/`undefined` throws a **TypeError**
+ * (RequireObjectCoercible) BEFORE `ToPropertyKey` would coerce the key (so the
+ * key's `toString` is never called).
+ *
+ * Before this fix, the externref element-access path in
+ * `compileMemberIncDec` dropped the base and emitted `f64.const NaN`
+ * without ever compiling the property-key expression. So:
+ *   - `base[prop()]++` silently skipped `prop()` (its side effect was lost),
+ *   - a `null` base produced `NaN` instead of throwing TypeError.
+ *
+ * Test262 cases driving the fix (the `*_A6_T1.js` "evaluated exactly once"
+ * tests for all four update operators):
+ *   language/expressions/postfix-increment/S11.3.1_A6_T1.js
+ *   language/expressions/postfix-decrement/S11.3.2_A6_T1.js
+ *   language/expressions/prefix-increment/S11.4.4_A6_T1.js
+ *   language/expressions/prefix-decrement/S11.4.5_A6_T1.js
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function runWasm(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  const fn = exports.test as () => unknown;
+  return fn();
+}
+
+describe("#1720 — inc/dec reference evaluation order on null base", () => {
+  // The property-key expression's side effect must run even though the base is
+  // null and the update ultimately throws.
+  for (const op of ["++", "--"] as const) {
+    for (const fix of ["postfix", "prefix"] as const) {
+      const expr = fix === "postfix" ? `base[prop()]${op}` : `${op}base[prop()]`;
+      it(`${fix} ${op}: property-key expression runs once before the throw (${expr})`, async () => {
+        expect(
+          await runWasm(`export function test(): number {
+            var calls: number = 0;
+            var base: any = null;
+            var prop: any = function () { calls = calls + 1; return "k"; };
+            try { ${expr}; } catch (e) {}
+            return calls;
+          }`),
+        ).toBe(1);
+      });
+
+      it(`${fix} ${op}: null base throws (${expr})`, async () => {
+        expect(
+          await runWasm(`export function test(): number {
+            var base: any = null;
+            var threw: number = 0;
+            try { ${expr}; } catch (e) { threw = 1; }
+            return threw;
+          }`),
+        ).toBe(1);
+      });
+    }
+  }
+
+  it("null base throws a TypeError instance, not NaN", async () => {
+    expect(
+      await runWasm(`export function test(): number {
+        var base: any = null;
+        var isTE: number = 0;
+        try { base["k"]++; } catch (e) { isTE = (e instanceof TypeError) ? 1 : 0; }
+        return isTE;
+      }`),
+    ).toBe(1);
+  });
+
+  it("null base: property key's toString is NOT called (TypeError thrown first)", async () => {
+    // RequireObjectCoercible inside GetValue throws before ToPropertyKey, so a
+    // non-side-effecting object key's `toString` must never run.
+    expect(
+      await runWasm(`export function test(): number {
+        var base: any = null;
+        var tsCalled: number = 0;
+        var key: any = { toString: function () { tsCalled = 1; return "k"; } };
+        try { base[key]++; } catch (e) {}
+        return tsCalled;
+      }`),
+    ).toBe(0);
+  });
+
+  it("non-null externref base property inc/dec still yields NaN (unchanged)", async () => {
+    expect(
+      await runWasm(`export function test(): number {
+        var o: any = {};
+        var r: any = o["missing"]++;
+        return Number.isNaN(r) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1720 (Sprint 57 ES3 track). `base[prop()]++` / `--base[prop]` on a
`null`/`undefined` base must evaluate the property-key sub-expression (with its
side effects) and then throw a **TypeError** in spec order — per §13.4
(UpdateExpression) + §13.3.3 (EvaluatePropertyAccessWithExpressionKey). The
TypeError (RequireObjectCoercible inside GetValue) precedes ToPropertyKey, so
the key's `toString` is not called.

## Root cause

`compileMemberIncDec` (`src/codegen/expressions/unary-updates.ts`) compiled the
base of an element access, and when it resolved to `externref` (which a
`null`-typed base produces) took an early branch that `drop`ped the base and
emitted `f64.const NaN` **without ever compiling the property-key expression**.
So `base[prop()]++` silently skipped `prop()`'s side effect, and a null base
produced NaN instead of throwing.

## Fix

In the externref element-access branch:
1. Save the base externref to a temp.
2. Compile the property-key expression for side effects, then `drop` it.
3. `ref.is_null` guard → `emitThrowTypeError` (real TypeError instance) on null;
   non-null externref base falls through to the existing NaN result.

The throw is emitted into the real `fctx.body` first (so the late-import-shift
bookkeeping in `emitThrowTypeError` patches the already-emitted instrs), then
spliced into the `if` then-body. The non-ref (numeric base) branch also now
evaluates the key for side effects.

## Tests

`tests/issue-1720.test.ts` — 11 cases, all pass:
- property-key expression runs exactly once before the throw (postfix/prefix × `++`/`--`)
- null base throws (all four operators)
- null base throws a `TypeError` instance, not NaN
- null base: key object's `toString` is NOT called (TypeError first)
- non-null externref property inc/dec still yields NaN (unchanged)

For the four `*_A6_T1.js` test262 files, the second assertion (TypeError +
toString-not-called) now passes. The first assertion (`assert.throws(DummyError,
…)`) remains gated on a separate pre-existing gap — `e instanceof
<userConstructor>` for a thrown value — unrelated to evaluation order.

No regressions in the inc/dec suite (issue-260/378/319/1119/1379). Pre-existing
private-field failures (issue-254/334) reproduce on clean main and are unrelated
(PropertyAccess path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)