### PR TITLE
fix(#1716): ToPrimitive residual — ToPropertyKey + host-ctor arg coercion

### DIFF
--- a/plan/issues/1716-spec-gap-toprimitive-residual-object-property-key-coercion.md
+++ b/plan/issues/1716-spec-gap-toprimitive-residual-object-property-key-coercion.md
@@ -1,9 +1,10 @@
 ---
 id: 1716
 title: "spec gap (RESIDUAL of #1090/#1525): 'Cannot convert object to primitive value' still thrown in 111 coercion paths"
-status: ready
+status: done
 created: 2026-05-29
 updated: 2026-05-29
+completed: 2026-05-29
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -90,3 +91,66 @@ property-key** and **RegExp/JSON/Date** coercion sites #1442 does not.
 
 Filed by product-owner test262 triage 2026-05-29 against main baseline
 (`.test262-cache/test262-current.jsonl`, 48,117 records).
+
+## Resolution (senior-dev, 2026-05-29)
+
+**Diagnosis: NEVER-COVERED, not a regression.** #1319 fixed `_hostToPrimitive`
+(the callbackState-aware OrdinaryToPrimitive walker) and that path works today —
+`String(obj)` with a user `toString` already passed. What was never wired:
+
+1. **ToPropertyKey (§7.1.19)** — `_safeGet`/`_safeSet`/`__extern_has` and the
+   `Object.*`/`Reflect.*` runtime handlers coerced an object key via
+   `_toPrimitiveSync(key, "string")` **without** `callbackState` (or a bare
+   `String(prop)`). `_toPrimitiveSync` with no exports cannot dispatch a WasmGC
+   closure, so a key whose `valueOf`/`toString`/`@@toPrimitive` is a compiled
+   method collapsed to `"[object Object]"` and the lookup silently missed; the
+   `Object.*` handlers passed the opaque struct straight to native, which threw.
+2. **A class's `[Symbol.toPrimitive]` *method*** had **no runtime dispatch
+   export at all.** `valueOf`/`toString` compile to `__call_<name>` 1-arg
+   dispatchers (emitted by `emitToPrimitiveMethodExports`) that
+   `_hostToPrimitive`'s loop picks up; the exotic `@@toPrimitive` method (which
+   takes a hint) was only emitted for `@@iterator`/`next`, so it was unreachable
+   from the runtime. The reference to `__call_@@toPrimitive` in `_toPrimitive`
+   (runtime.ts) was dead — the export never existed.
+3. **Host-constructor object args** — `new RegExp(obj)` / `new Date(obj)` /
+   `new String(obj)` / `new Number(obj)` passed the opaque struct to V8's
+   constructor, which ran its own ToString/ToPrimitive and threw before reaching
+   the compiled methods.
+
+**Fix (reuses #1319/#1525, no duplication):**
+- `src/codegen/index.ts` — new `emitToPrimitiveMethodExport`: emits a 2-arg
+  `__call_@@toPrimitive(self, hint) -> externref` dispatch wrapper (called in
+  both `generateModule` and `generateMultiModule`). Skips entries whose hint
+  param isn't externref (nativeStrings standalone path is JS-host-free), keeping
+  Wasm validation green in every mode.
+- `src/runtime.ts`:
+  - `_toPrimitiveSync` gained an optional `callbackState`; for WasmGC structs it
+    now defers to `_hostToPrimitive` (the #1319 walker) instead of the
+    "[object Object]" sentinel.
+  - `_hostToPrimitive` now probes the new `__call_@@toPrimitive(self, hint)`
+    export for the method-shorthand `[Symbol.toPrimitive]` shape (the sidecar
+    slot is empty for class methods).
+  - new `_toPropertyKey(key, callbackState)` helper (§7.1.19) applied at
+    `__defineProperty_{desc,value,accessor}`, `__getOwnPropertyDescriptor`,
+    `__object_hasOwn`, and all six `Reflect.*` key handlers.
+  - `_safeGet`/`_safeSet`/`__extern_get`/`__extern_set`/`__extern_has` thread
+    `callbackState` into the key coercion.
+  - the `extern_class` constructor coerces WasmGC struct args through
+    `_hostToPrimitive` for RegExp/Date/String/Number (Boolean excluded — it runs
+    ToBoolean, not ToPrimitive).
+
+A §7.1.1.1 step-6 violation (a coercion method returning an object) still throws
+TypeError on every path — spec-correct.
+
+**No-regression evidence:** #1319 (3), #1525 (10), #1525b (5), #1442 (10),
+#1629a/b (8), #1630 (5), object-methods, object-keys-values-entries all stay
+green alongside the new #1716 suite (10). The class-methods/iterators test files
+fail identically on clean origin/main (their `{ env: {} }` harness omits
+`string_constants`) — pre-existing, not touched by this change.
+
+**Test:** `tests/issue-1716.test.ts` (10 tests) — property-key valueOf/@@toPrimitive,
+Object.getOwnPropertyDescriptor/defineProperty with object keys, String/RegExp/Date
+object args, the step-6 TypeError guard, and the #1319 "defined method still wins"
+guard.
+
+PR: see implementation PR. Expected impact: ~+111 (the unified cluster).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1198,6 +1198,10 @@ export function generateModule(
     // Emit __call_@@iterator export for runtime Symbol.iterator dispatch on WasmGC structs
     emitIteratorMethodExport(ctx);
 
+    // (#1716) Emit __call_@@toPrimitive(self, hint) for runtime ToPrimitive
+    // dispatch of a class's [Symbol.toPrimitive] *method* on opaque structs.
+    emitToPrimitiveMethodExport(ctx);
+
     // Emit __call_fn_0 export for calling zero-arg closures from JS (#851)
     emitClosureCallExport(ctx);
 
@@ -1871,6 +1875,126 @@ function emitIteratorMethodExport(ctx: CodegenContext): void {
 
   emitMethodDispatch("@@iterator", "__call_@@iterator");
   emitMethodDispatch("next", "__call_next");
+}
+
+/**
+ * (#1716) Emit `__call_@@toPrimitive(self, hint) -> externref` — a 2-arg
+ * dispatch wrapper so the runtime can invoke a class's `[Symbol.toPrimitive]`
+ * *method* on an opaque WasmGC struct.
+ *
+ * Unlike valueOf/toString (which compile to `__call_<name>` 1-arg dispatchers
+ * emitted by `emitToPrimitiveMethodExports` and picked up by `_hostToPrimitive`'s
+ * OrdinaryToPrimitive loop), the exotic @@toPrimitive method takes the ToPrimitive
+ * hint string and had NO runtime dispatch export — so ToPropertyKey (object used
+ * as a property key) and String()/RegExp()/Date() object-arg coercion on such a
+ * key/arg silently fell through to the opaque-struct "[object Object]" sentinel
+ * (the §7.1.1 residual tracked in #1716). The method body is registered as
+ * `${structName}_@@toPrimitive(self, hint)`; we ref.test `self` against each
+ * such struct and forward the externref hint.
+ *
+ * The dispatch forwards the runtime-supplied hint as an externref (the JS-host
+ * string backend's representation). In nativeStrings mode the hint param is a
+ * WasmGC `(ref $string)` i16 array we cannot synthesize from the externref
+ * inline, and the runtime that calls `__call_@@toPrimitive` is JS-host-only and
+ * never runs in the standalone nativeStrings path — so such entries are skipped
+ * to keep Wasm validation green in every mode.
+ */
+function emitToPrimitiveMethodExport(ctx: CodegenContext): void {
+  const mod = ctx.mod;
+  const methodSuffix = "@@toPrimitive";
+  const exportName = "__call_@@toPrimitive";
+  const entries: { typeIdx: number; funcIdx: number; resultType: ValType }[] = [];
+
+  for (const [structName] of ctx.structFields) {
+    const typeIdx = ctx.structMap.get(structName);
+    if (typeIdx === undefined) continue;
+    if (
+      structName.startsWith("Wrapper") ||
+      structName === "$AnyValue" ||
+      structName.startsWith("__vec_") ||
+      structName.startsWith("__arr_")
+    )
+      continue;
+
+    const funcIdx = ctx.funcMap.get(`${structName}_${methodSuffix}`);
+    if (funcIdx === undefined) continue;
+
+    const funcDef = mod.functions[funcIdx - ctx.numImportFuncs];
+    const funcType = funcDef ? mod.types[funcDef.typeIdx] : undefined;
+    const resultType: ValType =
+      funcType && funcType.kind === "func" && funcType.results.length > 0
+        ? funcType.results[0]!
+        : { kind: "externref" };
+
+    // The hint param is param[1] (param[0] is `self`). Only forward when it is
+    // an externref; skip nativeStrings string-ref params (see doc comment).
+    const hintParamType =
+      funcType && funcType.kind === "func" && funcType.params.length > 1 ? funcType.params[1] : undefined;
+    if (hintParamType !== undefined && hintParamType.kind !== "externref") continue;
+
+    entries.push({ typeIdx, funcIdx, resultType });
+  }
+
+  if (entries.length === 0) return;
+
+  const dispatchTypeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+    "$call_method_2arg_type",
+  );
+
+  const funcIdx = ctx.numImportFuncs + mod.functions.length;
+  const body: Instr[] = [];
+  // local 2 = any.convert_extern(self)
+  body.push({ op: "local.get", index: 0 });
+  body.push({ op: "any.convert_extern" } as Instr);
+  body.push({ op: "local.set", index: 2 } as Instr);
+
+  let current: Instr[] = [{ op: "ref.null.extern" } as Instr];
+
+  for (const entry of entries) {
+    const testAndCall: Instr[] = [
+      { op: "local.get", index: 2 } as Instr,
+      { op: "ref.cast", typeIdx: entry.typeIdx } as Instr,
+      { op: "local.get", index: 1 } as Instr, // hint (externref)
+      { op: "call", funcIdx: entry.funcIdx } as Instr,
+    ];
+
+    if (entry.resultType.kind === "ref" || entry.resultType.kind === "ref_null") {
+      testAndCall.push({ op: "extern.convert_any" } as Instr);
+    } else if (entry.resultType.kind === "f64") {
+      const boxIdx = ctx.funcMap.get("__box_number");
+      if (boxIdx !== undefined) testAndCall.push({ op: "call", funcIdx: boxIdx } as Instr);
+    } else if (entry.resultType.kind === "i32") {
+      testAndCall.push({ op: "f64.convert_i32_s" } as Instr);
+      const boxIdx = ctx.funcMap.get("__box_number");
+      if (boxIdx !== undefined) testAndCall.push({ op: "call", funcIdx: boxIdx } as Instr);
+    }
+
+    current = [
+      { op: "local.get", index: 2 } as Instr,
+      { op: "ref.test", typeIdx: entry.typeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: testAndCall,
+        else: current,
+      } as Instr,
+    ];
+  }
+
+  body.push(...current);
+
+  mod.functions.push({
+    name: exportName,
+    typeIdx: dispatchTypeIdx,
+    locals: [{ name: "__any", type: { kind: "anyref" } }],
+    body,
+    exported: true,
+  } as WasmFunction);
+
+  mod.exports.push({ name: exportName, desc: { kind: "func", index: funcIdx } });
 }
 
 /**
@@ -3969,6 +4093,10 @@ export function generateMultiModule(
 
     // Emit __call_toString/__call_valueOf exports for ToPrimitive dispatch.
     emitToPrimitiveMethodExports(ctx);
+
+    // (#1716) Emit __call_@@toPrimitive(self, hint) for runtime ToPrimitive
+    // dispatch of a class's [Symbol.toPrimitive] *method* on opaque structs.
+    emitToPrimitiveMethodExport(ctx);
 
     // #1326c Phase 1C-A — export __drain_microtasks BEFORE WASI _start so the
     // _start wrapper (which appends a drain call) can find its funcIdx.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1569,10 +1569,31 @@ function _toPrimitive(
  * because we can't dispatch through Wasm exports without callbackState.
  * For regular JS objects, uses V8's native valueOf/toString which throws TypeError
  * per spec if neither produces a primitive.
+ *
+ * (#1716) When a `callbackState` IS supplied (e.g. ToPropertyKey on an object
+ * key inside `_safeGet`/`_safeSet`/`__extern_has`), route WasmGC structs through
+ * `_hostToPrimitive` — the callbackState-aware OrdinaryToPrimitive walker built
+ * for #1319/#1090 — so that a key/arg whose `valueOf` / `toString` /
+ * `Symbol.toPrimitive` is a compiled WasmGC closure is actually invoked instead
+ * of falling through to the opaque-struct "[object Object]" sentinel. This reuses
+ * the existing machinery rather than duplicating the dispatch logic; a §7.1.1.1
+ * step-6 violation (method returns an object) still throws TypeError, which is
+ * the spec-correct outcome for the property-key path too.
  */
-function _toPrimitiveSync(v: any, hint: "number" | "string" | "default"): any {
+function _toPrimitiveSync(
+  v: any,
+  hint: "number" | "string" | "default",
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): any {
   if (v == null || typeof v !== "object") return v;
-  const prim = _toPrimitive(v, hint);
+  // (#1716) With exports available, defer to the full OrdinaryToPrimitive walker
+  // so WasmGC-closure valueOf/toString/@@toPrimitive get dispatched. It returns
+  // "[object Object]" for a no-method struct and throws only on the spec
+  // step-6 violation — both correct here.
+  if (callbackState && _isWasmStruct(v)) {
+    return _hostToPrimitive(v, hint, callbackState);
+  }
+  const prim = _toPrimitive(v, hint, callbackState);
   if (prim !== undefined) return prim;
   // WasmGC structs: JS property access fails on opaque structs, but they may
   // have compiled valueOf/toString that _toPrimitive couldn't dispatch without
@@ -1592,6 +1613,29 @@ function _toPrimitiveSync(v: any, hint: "number" | "string" | "default"): any {
     }
   }
   throw new TypeError("Cannot convert object to primitive value");
+}
+
+/**
+ * (#1716) ToPropertyKey (§7.1.19): coerce a value intended as a property key.
+ * For a WasmGC-struct key, run ToPrimitive(hint "string") via the
+ * callbackState-aware walker so a key with a compiled `valueOf` / `toString` /
+ * `[Symbol.toPrimitive]` is invoked — then ToString the resulting primitive.
+ * Symbols pass through unchanged (they ARE valid property keys). Non-struct
+ * values are returned as-is; native `Object.defineProperty` etc. then apply
+ * their own ToPropertyKey, which is correct for plain JS objects.
+ *
+ * Used by the Object.* / Reflect.* runtime intent handlers that forward a raw
+ * key to a native operation that would otherwise throw "Cannot convert object
+ * to primitive value" on an opaque struct key.
+ */
+function _toPropertyKey(key: any, callbackState?: { getExports: () => Record<string, Function> | undefined }): any {
+  if (key == null || typeof key !== "object") return key;
+  if (typeof key === "symbol") return key;
+  if (!_isWasmStruct(key)) return key;
+  const prim = _toPrimitiveSync(key, "string", callbackState);
+  if (typeof prim === "symbol") return prim;
+  // ToString the primitive (numbers/booleans/etc. → string key per §7.1.19).
+  return prim == null ? prim : typeof prim === "string" ? prim : String(prim);
 }
 
 /**
@@ -1668,6 +1712,33 @@ function _hostToPrimitive(
     }
     // Non-callable Symbol.toPrimitive
     throw new TypeError("Cannot convert object to primitive value");
+  }
+
+  // (#1716) A class that defines `[Symbol.toPrimitive]` as a *method* compiles
+  // the method to a struct-method export `__call_@@toPrimitive`, but does NOT
+  // populate the sidecar `Symbol.toPrimitive` slot — so neither the proxy
+  // property read nor the sidecar check above finds it. `_toPrimitive` only
+  // reaches its `__call_@@toPrimitive` dispatch when the sidecar slot is set, so
+  // the method-shorthand shape was silently missed here (the residual the
+  // property-key / arg paths hit). Probe the struct-method export directly,
+  // mirroring §7.1.1 step 2 (exotic @@toPrimitive consulted before
+  // valueOf/toString).
+  if (_isWasmStruct(raw) && callbackState) {
+    const exports = callbackState.getExports();
+    const callTP = exports?.["__call_@@toPrimitive"];
+    if (typeof callTP === "function") {
+      try {
+        const result = callTP(raw, hint);
+        if (result == null || typeof result !== "object") return result;
+        // Exotic @@toPrimitive returned an object → §7.1.1 step 5 TypeError.
+        throw new TypeError("Cannot convert object to primitive value");
+      } catch (e: any) {
+        // Only a Wasm type-mismatch trap (wrong struct variant) is swallowed so
+        // we can fall through to valueOf/toString; user throws + the TypeError
+        // above propagate.
+        if (!(e instanceof WebAssembly.RuntimeError)) throw e;
+      }
+    }
   }
 
   // OrdinaryToPrimitive §7.1.1.1
@@ -2536,11 +2607,15 @@ function _resolveNamespacedClass(
 }
 
 /** Safe property get: works on both JS objects and WasmGC structs. */
-function _safeGet(obj: any, key: any): any {
+function _safeGet(obj: any, key: any, callbackState?: { getExports: () => Record<string, Function> | undefined }): any {
   if (obj == null) return undefined;
-  // Coerce WasmGC struct keys to primitives via ToPrimitive (#1090)
+  // Coerce WasmGC struct keys to primitives via ToPrimitive (#1090, #1716).
+  // Passing callbackState lets a key with a WasmGC-closure valueOf / toString /
+  // @@toPrimitive be dispatched (ToPropertyKey §7.1.19 → ToPrimitive §7.1.1);
+  // without it the opaque struct collapses to "[object Object]" and the lookup
+  // silently misses.
   if (key != null && typeof key === "object" && _isWasmStruct(key)) {
-    const prim = _toPrimitiveSync(key, "string");
+    const prim = _toPrimitiveSync(key, "string", callbackState);
     if (prim != null && typeof prim !== "object") key = prim;
   }
   // Well-known symbol ID (i32 from compiler): only apply to WasmGC structs.
@@ -2608,11 +2683,21 @@ function _safeGet(obj: any, key: any): any {
  * `Reflect.set`, and `Object.defineProperty` data writes (#1630). Callers
  * that don't pass `exports` get the prior sidecar-only behaviour.
  */
-function _safeSet(obj: any, key: any, val: any, exports?: Record<string, Function>): void {
+function _safeSet(
+  obj: any,
+  key: any,
+  val: any,
+  exports?: Record<string, Function>,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): void {
   if (obj == null) return;
-  // Coerce WasmGC struct keys to primitives via ToPrimitive (#1090)
+  // Coerce WasmGC struct keys to primitives via ToPrimitive (#1090, #1716).
+  // Prefer the explicit callbackState; fall back to wrapping `exports` so a
+  // WasmGC-closure key method can still be dispatched when only exports is in
+  // scope at the call site.
   if (key != null && typeof key === "object" && _isWasmStruct(key)) {
-    const prim = _toPrimitiveSync(key, "string");
+    const cbState = callbackState ?? (exports ? { getExports: () => exports } : undefined);
+    const prim = _toPrimitiveSync(key, "string", cbState);
     if (prim != null && typeof prim !== "object") key = prim;
   }
   // Well-known symbol ID (i32 from compiler): store under both real Symbol and "@@name".
@@ -3857,11 +3942,41 @@ function resolveImport(
           intent.className === "Float64Array" ||
           intent.className === "BigInt64Array" ||
           intent.className === "BigUint64Array";
+        // (#1716) Constructors that run ToPrimitive / ToString on their
+        // arguments (rather than consuming them as iterables / buffers / struct
+        // identities). When a WasmGC struct is passed as such an arg, V8's
+        // native `new Ctor(struct)` invokes ToString/ToPrimitive on the opaque
+        // struct and throws "Cannot convert object to primitive value" — it
+        // can't reach the compiled valueOf / toString / @@toPrimitive. Coerce
+        // these struct args through `_hostToPrimitive` (the #1319 OrdinaryToPrimitive
+        // walker) FIRST so the user methods run. RegExp/Date/String use a "string"/
+        // "default" ToString-shaped coercion; Number uses "number".
+        // NB: `Boolean` is deliberately excluded — `new Boolean(obj)` applies
+        // ToBoolean (every object is truthy), NOT ToPrimitive, so coercing the
+        // struct to a primitive could flip the result. Iterable/buffer consumers
+        // are excluded too — they need the struct identity, not a primitive.
+        const coercesArgsToPrimitive =
+          intent.className === "RegExp" ||
+          intent.className === "Date" ||
+          intent.className === "String" ||
+          intent.className === "Number";
+        const argCoercionHint: "number" | "string" | "default" =
+          intent.className === "Number" ? "number" : intent.className === "Date" ? "default" : "string";
         return (...args: any[]) => {
           if (!isWrapperCtor) {
             let len = args.length;
             while (len > 0 && args[len - 1] == null) len--;
             args = args.slice(0, len);
+          }
+          if (coercesArgsToPrimitive && args.length > 0) {
+            for (let i = 0; i < args.length; i++) {
+              const a = args[i];
+              if (a != null && typeof a === "object" && _isWasmStruct(a)) {
+                // Throws TypeError per §7.1.1 step 6 if no chain yields a
+                // primitive — the spec-correct outcome here too.
+                args[i] = _hostToPrimitive(a, argCoercionHint, callbackState);
+              }
+            }
           }
           if (isIterableCtor && args.length > 0 && args[0] != null) {
             const exports = callbackState?.getExports();
@@ -4337,7 +4452,7 @@ assert._isSameValue = isSameValue;
       }
       if (name === "__extern_get")
         return (obj: any, key: any) => {
-          const val = _safeGet(obj, key);
+          const val = _safeGet(obj, key, callbackState);
           if (val !== undefined) return val;
           // Try struct getter exports as fallback for WasmGC opaque fields
           if (typeof key === "string") {
@@ -4355,7 +4470,7 @@ assert._isSameValue = isSameValue;
           // "object is not a function". Wrap it via __call_fn_<arity> so
           // host-driven invocation reaches the closure body.
           const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
-          _safeSet(obj, key, wrappedVal);
+          _safeSet(obj, key, wrappedVal, undefined, callbackState);
         };
       if (name === "__extern_length")
         return (obj: any) => {
@@ -4503,9 +4618,9 @@ assert._isSameValue = isSameValue;
       if (name === "__extern_has")
         return (obj: any, key: any): number => {
           if (obj == null) return 0;
-          // WasmGC struct keys → primitive via ToPrimitive (mirrors _safeGet)
+          // WasmGC struct keys → primitive via ToPrimitive (mirrors _safeGet, #1716)
           if (key != null && typeof key === "object" && _isWasmStruct(key)) {
-            const prim = _toPrimitiveSync(key, "string");
+            const prim = _toPrimitiveSync(key, "string", callbackState);
             if (prim != null && typeof prim !== "object") key = prim;
           }
           try {
@@ -5176,7 +5291,10 @@ assert._isSameValue = isSameValue;
           if (obj == null || (typeof obj !== "object" && typeof obj !== "function")) {
             throw new TypeError("Object.defineProperty called on non-object");
           }
-          const key = prop != null ? String(prop) : "";
+          // (#1716) ToPropertyKey on a struct key invokes its valueOf/toString/
+          // @@toPrimitive instead of collapsing to "[object Object]".
+          prop = _toPropertyKey(prop, callbackState);
+          const key = typeof prop === "symbol" ? prop : prop != null ? String(prop) : "";
           // Field reader that round-trips both plain JS objects (native `o[f]`,
           // which fires accessors / walks the prototype chain per
           // ToPropertyDescriptor) and WasmGC structs (sidecar + the compiled
@@ -5229,6 +5347,7 @@ assert._isSameValue = isSameValue;
           if (obj == null || (typeof obj !== "object" && typeof obj !== "function")) {
             throw new TypeError("Object.defineProperty called on non-object");
           }
+          prop = _toPropertyKey(prop, callbackState); // (#1716) ToPropertyKey on struct key
           const desc: PropertyDescriptor = {};
           if (flags & (1 << 7)) desc.value = _maybeWrapCallableUnknownArity(value, callbackState);
           if (flags & (1 << 3)) desc.writable = !!(flags & 1);
@@ -5265,6 +5384,7 @@ assert._isSameValue = isSameValue;
           if (obj == null || (typeof obj !== "object" && typeof obj !== "function")) {
             throw new TypeError("Object.defineProperty called on non-object");
           }
+          prop = _toPropertyKey(prop, callbackState); // (#1716) ToPropertyKey on struct key
           // (#1382) When the accessor descriptor's `get`/`set` is a Wasm
           // closure struct (not a JS function), wrap it into a JS Function
           // so subsequent property reads/writes invoke through the
@@ -5434,6 +5554,7 @@ assert._isSameValue = isSameValue;
       if (name === "__getOwnPropertyDescriptor")
         return (obj: any, prop: any) => {
           if (obj == null) return undefined;
+          prop = _toPropertyKey(prop, callbackState); // (#1716) ToPropertyKey on struct key
           // Non-WasmGC objects: native JS handles it
           if (!_isWasmStruct(obj)) {
             return Object.getOwnPropertyDescriptor(obj, prop);
@@ -6065,8 +6186,10 @@ assert._isSameValue = isSameValue;
       if (name === "__get_builtin") return (n: string) => (globalThis as any)[n];
       // Object.hasOwn(obj, key) — ES2022 static method (#965)
       if (name === "__object_hasOwn")
-        return (obj: any, key: any): number =>
-          (Object.hasOwn ? Object.hasOwn(obj, key) : Object.prototype.hasOwnProperty.call(obj, key)) ? 1 : 0;
+        return (obj: any, key: any): number => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
+          return (Object.hasOwn ? Object.hasOwn(obj, key) : Object.prototype.hasOwnProperty.call(obj, key)) ? 1 : 0;
+        };
       // Object.is(x, y) — SameValue comparison (#965)
       if (name === "__object_is") return (x: any, y: any): number => (Object.is(x, y) ? 1 : 0);
       // Object.assign(target, ...sources) — shallow copy (#965)
@@ -6109,6 +6232,7 @@ assert._isSameValue = isSameValue;
       // host MOP operations can enumerate / mutate their sidecar fields.
       if (name === "__reflect_get")
         return (target: any, key: any, receiver: any): any => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           const r =
@@ -6121,6 +6245,7 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__reflect_set")
         return (target: any, key: any, value: any, receiver: any): number => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           const v = _isWasmStruct(value) ? _wrapForHost(value, exports) : value;
@@ -6134,18 +6259,21 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__reflect_has")
         return (target: any, key: any): number => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           return Reflect.has(t, key) ? 1 : 0;
         };
       if (name === "__reflect_deleteProperty")
         return (target: any, key: any): number => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           return Reflect.deleteProperty(t, key) ? 1 : 0;
         };
       if (name === "__reflect_defineProperty")
         return (target: any, key: any, desc: any): number => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           const d = _isWasmStruct(desc) ? _wrapForHost(desc, exports) : desc;
@@ -6153,6 +6281,7 @@ assert._isSameValue = isSameValue;
         };
       if (name === "__reflect_getOwnPropertyDescriptor")
         return (target: any, key: any): any => {
+          key = _toPropertyKey(key, callbackState); // (#1716) ToPropertyKey on struct key
           const exports = callbackState?.getExports();
           const t = _isWasmStruct(target) ? _wrapForHost(target, exports) : target;
           return Reflect.getOwnPropertyDescriptor(t, key);
@@ -8066,7 +8195,7 @@ assert._isSameValue = isSameValue;
       return (v: any) => (v ? 1 : 0);
     case "extern_get":
       return (obj: any, key: any) => {
-        const val = _safeGet(obj, key);
+        const val = _safeGet(obj, key, callbackState);
         if (val !== undefined) {
           // (#779c) Sandbox-aware constructor identity. When a
           // `globalSandbox` is supplied (test262 per-test realm isolation),
@@ -8119,7 +8248,7 @@ assert._isSameValue = isSameValue;
         // (#860) Wrap closure-as-value before storing — see __extern_set
         // binding above. Mirrors the by-name path.
         const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
-        _safeSet(obj, key, wrappedVal);
+        _safeSet(obj, key, wrappedVal, undefined, callbackState);
       };
     case "host_eq":
       // #1065 — strict equality for two externref operands that the GC path

--- a/tests/issue-1716.test.ts
+++ b/tests/issue-1716.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1716 — ToPrimitive residual: "Cannot convert object to primitive value" in
+// the property-key and built-in-arg coercion paths.
+//
+// #1319 / #1090 / #1525 wired ToPrimitive into the *direct* coercion sites
+// (`String(obj)`, template spans, arithmetic ref→f64) through `_hostToPrimitive`
+// in src/runtime.ts, the callbackState-aware OrdinaryToPrimitive walker. But two
+// families of call sites were never routed through it, so they still threw:
+//
+//   1. ToPropertyKey (§7.1.19): an object used as a property key — `obj[key]`,
+//      `Object.getOwnPropertyDescriptor/defineProperty(obj, key)`, `Reflect.*`.
+//      `_safeGet`/`_safeSet`/the Object.* + Reflect.* runtime handlers coerced
+//      the key via `_toPrimitiveSync` *without* callbackState (or a bare
+//      `String(prop)`), so a key whose valueOf/toString/@@toPrimitive is a
+//      compiled WasmGC closure collapsed to "[object Object]" and the lookup
+//      silently missed (or native defineProperty threw on the opaque struct).
+//
+//   2. ToString/ToPrimitive of an object argument to a host constructor that
+//      coerces its arg — `new RegExp(obj)`, `new Date(obj)`, `new String(obj)`,
+//      `new Number(obj)`. V8's `new Ctor(struct)` runs its own ToPrimitive on
+//      the opaque struct and threw, never reaching the compiled methods.
+//
+// Two-part fix, REUSING #1319's machinery rather than duplicating it:
+//   - runtime.ts: `_toPrimitiveSync` now accepts callbackState and defers to
+//     `_hostToPrimitive` for structs; a new `_toPropertyKey` helper applies
+//     §7.1.19 at the property-key handlers; the extern_class constructor coerces
+//     struct args for RegExp/Date/String/Number.
+//   - codegen/index.ts: emits `__call_@@toPrimitive(self, hint)` so the runtime
+//     can dispatch a class's `[Symbol.toPrimitive]` *method* (valueOf/toString
+//     already had `__call_<name>` dispatchers; the exotic method did not).
+//
+// A §7.1.1.1 step-6 violation (a coercion method returning an object) still
+// throws TypeError — that is the spec-correct outcome on these paths too, so the
+// regression guard asserts it.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<Record<string, Function>> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  new WebAssembly.Module(r.binary);
+  const imports: any = buildImports(r.imports, undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof imports.setExports === "function") imports.setExports(inst.instance.exports);
+  return inst.instance.exports as Record<string, Function>;
+}
+
+describe("#1716 — ToPropertyKey coercion (object used as property key)", () => {
+  it("obj[key] where key has valueOf/toString invokes the method", async () => {
+    const exports = await run(`
+      class Key {
+        valueOf(): string { return "k" as any; }
+        toString(): string { return "k"; }
+      }
+      export function test(): string {
+        const o: any = {};
+        o["k"] = "hit";
+        return o[new Key() as any];
+      }
+    `);
+    expect(exports.test!()).toBe("hit");
+  });
+
+  it("obj[key] where key defines [Symbol.toPrimitive] as a method", async () => {
+    const exports = await run(`
+      class Key {
+        [Symbol.toPrimitive](hint: string): string { return "k"; }
+      }
+      export function test(): string {
+        const o: any = {};
+        o["k"] = "hit2";
+        return o[new Key() as any];
+      }
+    `);
+    expect(exports.test!()).toBe("hit2");
+  });
+
+  it("Object.getOwnPropertyDescriptor with an object key", async () => {
+    const exports = await run(`
+      class K { toString(): string { return "k"; } }
+      export function test(): number {
+        const o: any = { k: 42 };
+        const d: any = Object.getOwnPropertyDescriptor(o, new K() as any);
+        return d.value as number;
+      }
+    `);
+    expect(exports.test!()).toBe(42);
+  });
+
+  it("Object.defineProperty with an object key", async () => {
+    const exports = await run(`
+      class K { toString(): string { return "dyn"; } }
+      export function test(): number {
+        const o: any = {};
+        Object.defineProperty(o, new K() as any, { value: 99, enumerable: true });
+        return o.dyn as number;
+      }
+    `);
+    expect(exports.test!()).toBe(99);
+  });
+
+  it("step-6 violation: object key whose @@toPrimitive returns an object throws TypeError", async () => {
+    const exports = await run(`
+      class Bad { [Symbol.toPrimitive](hint: string): any { return {}; } }
+      export function test(): string {
+        const o: any = {};
+        return o[new Bad() as any];
+      }
+    `);
+    expect(() => exports.test!()).toThrow();
+  });
+});
+
+describe("#1716 — host-constructor object-argument coercion", () => {
+  it("String(obj) consults @@toPrimitive with the string hint", async () => {
+    const exports = await run(`
+      class B { [Symbol.toPrimitive](h: string): string { return h === "string" ? "S" : "N"; } }
+      export function test(): string { return String(new B() as any); }
+    `);
+    expect(exports.test!()).toBe("S");
+  });
+
+  it("new RegExp(obj) coerces the source via toString", async () => {
+    const exports = await run(`
+      class P { toString(): string { return "ab+"; } }
+      export function test(): string {
+        const r = new RegExp(new P() as any);
+        return r.source;
+      }
+    `);
+    expect(exports.test!()).toBe("ab+");
+  });
+
+  it("new Date(obj) coerces a numeric valueOf to a timestamp", async () => {
+    const exports = await run(`
+      class T { valueOf(): number { return 0; } }
+      export function test(): number {
+        const d = new Date(new T() as any);
+        return d.getTime();
+      }
+    `);
+    expect(exports.test!()).toBe(0);
+  });
+});
+
+describe("#1716 — regression guard: defined methods still win, no spurious coercion", () => {
+  it("class WITH valueOf is still invoked correctly (guards #1319 path)", async () => {
+    const exports = await run(`
+      class Boxed {
+        v: number;
+        constructor(v: number) { this.v = v; }
+        valueOf(): number { return this.v; }
+      }
+      export function test(): number {
+        return ((new Boxed(42) as any) - 0) + 1;
+      }
+    `);
+    expect(exports.test!()).toBe(43);
+  });
+
+  it("no-method object key falls back to a string key (does not throw)", async () => {
+    const exports = await run(`
+      class Bare { x: number = 1; }
+      export function test(): number {
+        const o: any = {};
+        o[new Bare() as any] = 7;
+        // The key stringifies to a stable "[object Object]"-shaped key; reading
+        // it back with the same kind of key must round-trip without throwing.
+        return o[new Bare() as any] as number;
+      }
+    `);
+    expect(() => exports.test!()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## #1716 — "Cannot convert object to primitive value" residual (111 test262 fails)

### Diagnosis: never-covered, not a regression
#1319 fixed the callbackState-aware `_hostToPrimitive` walker and the *direct*
coercion sites (`String(obj)`, template spans, arithmetic ref→f64) — those still
work (`String(obj)` with a user `toString` already passed). Two families of call
sites were simply never routed through that machinery:

1. **ToPropertyKey (§7.1.19)** — `obj[key]`, `Object.getOwnPropertyDescriptor/
   defineProperty`, `Reflect.*` coerced an object key via `_toPrimitiveSync`
   **without** `callbackState` (or a bare `String(prop)`). With no exports,
   `_toPrimitiveSync` can't dispatch a WasmGC closure, so a key whose
   `valueOf`/`toString`/`@@toPrimitive` is a compiled method collapsed to
   `"[object Object]"` (lookup misses) — or the `Object.*` handlers passed the
   opaque struct to native, which threw.
2. **A class's `[Symbol.toPrimitive]` *method*** had **no runtime dispatch export
   at all**. `valueOf`/`toString` compile to `__call_<name>` 1-arg dispatchers
   that `_hostToPrimitive` picks up; the exotic 2-arg `@@toPrimitive` method was
   only emitted for `@@iterator`/`next`.
3. **Host-constructor object args** — `new RegExp/Date/String/Number(obj)` passed
   the opaque struct to V8, which ran its own ToString/ToPrimitive and threw.

### Fix (reuses #1319/#1525, no duplication)
- **`src/codegen/index.ts`** — new `emitToPrimitiveMethodExport` emits a 2-arg
  `__call_@@toPrimitive(self, hint) -> externref` dispatch (in both
  `generateModule` and `generateMultiModule`). Skips entries whose hint param
  isn't externref, so nativeStrings/WASI Wasm validation stays green (that
  runtime is JS-host-free).
- **`src/runtime.ts`** —
  - `_toPrimitiveSync` gained an optional `callbackState`; for structs it defers
    to `_hostToPrimitive` instead of the `"[object Object]"` sentinel.
  - `_hostToPrimitive` probes `__call_@@toPrimitive` for the method-shorthand
    `[Symbol.toPrimitive]` shape (sidecar slot is empty for class methods).
  - new `_toPropertyKey(key, callbackState)` helper applied at
    `__defineProperty_{desc,value,accessor}`, `__getOwnPropertyDescriptor`,
    `__object_hasOwn`, and all six `Reflect.*` key handlers.
  - `_safeGet`/`_safeSet`/`__extern_get`/`__extern_set`/`__extern_has` thread
    `callbackState`.
  - `extern_class` ctor coerces struct args via `_hostToPrimitive` for
    RegExp/Date/String/Number (Boolean excluded — it runs ToBoolean).

A §7.1.1.1 step-6 violation (coercion method returns an object) still throws
TypeError on every path — spec-correct.

### No-regression evidence (local)
`tsc --noEmit` clean. Green: #1319 (3), #1525 (10), #1525b (5), #1442 (10),
#1629a/b (8), #1630 (5), object-methods, object-keys-values-entries, **+ new
#1716 (10)**. The class-methods/iterators test files fail identically on clean
origin/main (their `{ env: {} }` harness omits `string_constants`) — pre-existing,
untouched by this change.

### Expected impact
~+111 test262 (Object/String/RegExp/JSON/Date/DataView coercion cluster) if the
cluster is unified. **Regression-prone area — please confirm a full-CI net read
(net_per_test ≥ 0, no new ToPrimitive/coercion-bucket regressions) before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)