### PR TITLE
fix(#1723,#1724): WASI string-constant corruption + writeMessage cast/overflow

### DIFF
--- a/plan/issues/1723-writemessage-cons-string-cast-and-large-message-overflow.md
+++ b/plan/issues/1723-writemessage-cons-string-cast-and-large-message-overflow.md
@@ -1,0 +1,134 @@
+---
+id: 1723
+title: "writeMessage cast failure on multi-segment / large message (ConsString downcast + fixed-staging overflow)"
+status: done
+created: 2026-05-29
+updated: 2026-05-29
+completed: 2026-05-29
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen, runtime
+language_feature: wasi, native-strings, stdout-write
+goal: real-world-compat, spec-completeness
+sprint: 57
+parent: 389
+related: [389, 887, 1618, 1651, 1653, 1724]
+reporter: guest271314
+---
+# #1723 — writeMessage cast failure on a multi-segment / large message
+
+## Problem
+
+Reported by guest271314 against the Native Messaging host (parent #389), tested
+in WASI/standalone mode. A large (~1 MiB) response trapped on WRITE:
+
+```
+[host] received 1048580 chars, declared body length 1048576
+{ messageLength: 1048614 }
+Error: failed to run .../host.wasm
+  wasm backtrace:
+    0: writeMessage
+    1: main
+    2: _start
+  wasm trap: cast failure
+```
+
+#887 fixed READING large messages; WRITING a large response still trapped. He
+also found a low-N trigger: fails at `Array(13)`, works at `Array(12)`.
+
+## Reproduction
+
+Driving the compiled `examples/native-messaging/host.ts` through a WASI harness:
+- `Array(1)` → works (response stays a flat string).
+- `Array(12)`, `Array(13)`, `Array(100)`, `Array(209715)` (~1 MiB) → trapped
+  `illegal cast` in `writeMessage`, AFTER the stderr debug line was written.
+
+The `Array(12)`-works / `Array(13)`-fails boundary guest saw is a function of the
+*response* string staying flat vs becoming a rope at a given size — not the input
+count per se.
+
+## Root cause (TWO coordinated bugs)
+
+### Bug A1 — ConsString downcast at the `process.stdout.write(string)` call site
+
+`writeMessage` does `process.stdout.write(response)` where `response` is built by
+template interpolation: `` `{"received":${bodyStr},"runtime":"js2wasm+wasi"}` ``
+— a **ConsString** (rope, type `$ConsString`).
+
+Both string-write call sites emitted a `ref.cast` of the argument DOWN to the
+concrete `NativeString` type before calling the byte-writer helper:
+- `src/codegen/expressions/calls.ts` (`process.stdout/stderr.write(string)`)
+- `src/codegen/expressions/builtins.ts` (`emitWasiValueToStdout`, console writer)
+
+```
+local.get 0          ;; body : AnyString (could be Native OR Cons)
+ref.cast (ref $NativeString)   ;; ← TRAPS "illegal cast" when body is a ConsString
+call $__wasi_write_any_string
+```
+
+The author's comment assumed "`__str_flatten` accepts the supertype, so any
+non-flat tree is handled there" — but the downcast ran BEFORE flatten, so a rope
+trapped at the cast and never reached the flattening helper. The host worked only
+for tiny single-segment (still-flat) responses.
+
+### Bug A2 — fixed staging buffer overflows linear memory for large payloads
+
+`__wasi_write_any_string` stages the string bytes into `WASI_WRITE_SCRATCH_START`
+(128 KB, page 2) one byte at a time, then issues one `fd_write`. The module
+reserves only 3 pages (192 KB), so a ~1 MiB payload writes far past page 2 and
+traps `memory access out of bounds`. The stdin read staging buffer
+(`WASI_STDIN_BUF_START`, 64 KB, page 1) has the symmetric problem for a single
+large read.
+
+## Fix
+
+1. **`ensureWasiWriteAnyStringHelper` (`src/codegen/index.ts`)** — change the
+   helper param type from `NativeString` to the **AnyString supertype**. A
+   NativeString or ConsString satisfies AnyString directly, so no downcast is
+   needed; `__str_flatten` (which takes AnyString and collapses ropes) does the
+   real work inside.
+
+2. **Both call sites** (`calls.ts`, `builtins.ts`) — remove the
+   `ref.cast → NativeString`. For a nullable ref, emit `ref.as_non_null` only
+   (keeps the value's subtype intact while matching the helper's non-null param).
+
+3. **Memory growth guards** — before staging, both `__wasi_write_any_string`
+   (`index.ts`) and `emitProcessStdinRead` (`calls.ts`) compute
+   `neededPages = ceil((SCRATCH_START + len) / 65536)` and
+   `if (neededPages > memory.size) memory.grow(neededPages - memory.size)`.
+
+## Tests
+
+`tests/issue-1723.test.ts`:
+- a template-interpolated (ConsString) response writes without an illegal cast,
+- a ~1 MiB cons-string response round-trips (4-byte LE prefix + body), declared
+  length == actual body bytes (the #389 headline case, message length 1,048,614).
+
+## Result
+
+Fixed. Full Native Messaging round-trip verified for N = 1, 12, 13, 100, 1000,
+and 209,715 (~1 MiB): declared response length matches body bytes exactly.
+
+## Relationship to #1724
+
+Does NOT share a root cause with #1724 (string-constant corruption). #1724 is an
+itoa-scratch / data-segment memory aliasing. #1723 is a ConsString downcast +
+fixed-staging overflow. Fixed in the same PR but independent.
+
+## Follow-up (deferred) — `process.stdout/stderr.write(<string>)` in a minimal program
+
+While verifying the example-polish request (switch host.ts from `console.error`
+to `process.stderr.write` with the same protocol encoding), a SEPARATE
+pre-existing bug surfaced: a *minimal* program whose only string-write is
+`process.stdout.write("...")` or `process.stderr.write("...")` produces a
+malformed binary — `__str_to_extern` fails validation with
+`not enough arguments on the stack for call (need 4, got 2)`. This reproduces on
+clean `origin/main` (confirmed by stashing this PR's changes) and is unrelated to
+the cast/overflow fixes here. It does NOT affect `examples/native-messaging/host.ts`,
+which compiles correctly because its broader feature mix lays out the externref
+bridge differently. Because of this latent bug, the example-polish (swap
+`console.error` → `process.stderr.write`) is **deferred** — switching now would
+risk the example. Tracked as a separate codegen stack-balance issue in
+`__str_to_extern` (`ensureNativeStringExternBridge` / late-import shifting).

--- a/plan/issues/1724-wasi-itoa-scratch-aliases-string-constants.md
+++ b/plan/issues/1724-wasi-itoa-scratch-aliases-string-constants.md
@@ -1,0 +1,125 @@
+---
+id: 1724
+title: "WASI number formatting corrupts string constants (itoa scratch aliases data segments)"
+status: done
+created: 2026-05-29
+updated: 2026-05-29
+completed: 2026-05-29
+priority: critical
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen, runtime
+language_feature: wasi, native-strings, number-to-string
+goal: real-world-compat, spec-completeness
+sprint: 57
+parent: 389
+related: [389, 1618, 1651, 1723]
+reporter: guest271314
+---
+# #1724 — WASI number formatting corrupts string constants (silent data corruption)
+
+## Problem
+
+Reported by guest271314 against the Native Messaging host (parent #389), tested
+in WASI/standalone mode. The host's debug line mutated its OWN string literal
+across loop iterations:
+
+```
+[host] received 65 chars ...     (correct, 1st)
+[host] re61ived 10 chars ...     ← "ce" overwritten by "61"
+[host] re16ived 6 chars ...
+[host] re12ived 5 chars ...
+```
+
+The digits of the *previously-formatted* number overwrote the `"ce"` inside the
+literal `"received"` in the template `` `[host] received ${n} chars` ``. This is
+**silent data corruption** — the highest-severity class of bug — and is general,
+not native-messaging-specific.
+
+### Minimal repro (independent of host.ts)
+
+```ts
+export function main(): void {
+  let i = 0;
+  while (i < 5) {
+    const n = 60 + i;
+    console.error(`[host] received ${n} chars`);
+    i = i + 1;
+  }
+}
+```
+
+Compiled with `--target wasi`, stderr was:
+```
+[host] received 60 chars[host] re60ived 61 chars[host] re61ived 62 chars...
+```
+The `"received"` literal is clobbered at byte offsets 9/10 (its `c`/`e`).
+
+## Root cause
+
+The WASI integer-formatting helper `__wasi_write_i32` (and its `_stderr`
+variant) wrote its itoa digit buffer using `global.get $__wasi_bump_ptr` as the
+scratch base. That global **initialises to 1024**:
+
+```
+(global $__wasi_bump_ptr (mut i32) (i32.const 1024))
+```
+
+But string-literal data segments are *also* bump-allocated from offset **1024**
+upward (`wasiAllocStringData` in `src/codegen/expressions/builtins.ts` starts at
+1024 and grows). The bump pointer is never advanced past the data segments, so:
+
+- data segment `"[host] received "` occupies bytes **1024..1039**
+- itoa scratch = `buf_start(1024) .. buf_start+11(1035)`, digits written
+  right-to-left into ~1033..1035
+
+Formatting a number wrote its ASCII digits straight into the middle of the first
+string literal (`c`@1033, `e`@1034 → `6`,`0`). The two regions shared base 1024.
+
+This is the same family as #1618 (stdin buffer aliasing data segments, fixed by
+moving stdin to page 1) — the data/scratch collision was simply never closed for
+the itoa path.
+
+## Fix
+
+`src/codegen/expressions/builtins.ts` — `ensureWasiWriteI32Helper`:
+anchor the itoa scratch to the reserved low-scratch region instead of the bump
+pointer:
+
+```ts
+const WASI_ITOA_SCRATCH = 16; // above iovec(0..7)/nwritten(8..11), below
+                              // Math.random's offset-64 scratch, < 1024
+// buf_start = WASI_ITOA_SCRATCH  (was: global.get $__wasi_bump_ptr → 1024)
+```
+
+Offset 16 lives inside the 0..1023 area `registerWasiImports` reserves below the
+first data segment (which starts at 1024). It is above the iovec/nwritten that
+`__wasi_write_string` populates at memory[0..11], and `__wasi_write_string` sets
+its iovec at memory[0] *after* the digits are staged here and points the iovec
+back at this buffer, so there is no overlap during the write. 16 bytes covers the
+worst case (11 digits of a 32-bit int + sign).
+
+The f64 formatter routes through the i32 formatter (`i32.trunc_sat_f64_s; call
+__wasi_write_i32`), so fixing i32 fixes both.
+
+## Tests
+
+`tests/issue-1724.test.ts` — drives compiled WASI modules through a custom
+fd_write capture and asserts:
+- the `"received"` literal survives 5 interleaved number formats byte-for-byte
+  (and never matches `/re\d/`),
+- zero / negative / INT_MAX / large ints don't touch the surrounding literal,
+- a number written between two literals leaves both intact.
+
+## Result
+
+Fixed. stderr is now `[host] received 60 chars\n[host] received 61 chars\n...`
+with the literal intact across all iterations.
+
+## Notes
+
+- Does NOT share a root cause with #1723 (writeMessage cast failure). #1723 is a
+  `ref.cast` of a ConsString + a fixed-staging-buffer overflow; #1724 is an
+  itoa-scratch / data-segment memory aliasing. They were fixed together in one
+  PR but are independent bugs.

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -1628,23 +1628,30 @@ function emitWasiValueToStdout(
     isStringType(ctx.checker.getTypeAtLocation(node)) &&
     ctx.nativeStrTypeIdx >= 0
   ) {
-    // #1618: runtime string value (variable / concatenation / template span).
-    // The compiled value is a NativeString ref (or its AnyString supertype).
-    // Flatten + write its bytes to fd=1/fd=2 instead of dropping it and
-    // emitting the "[object]" placeholder. The value on the stack may be typed
-    // as the AnyString supertype after a concat; cast to NativeString so it
-    // matches the helper's param type (__str_flatten accepts the supertype, so
-    // any non-flat tree is handled there — but the static cast is required for
-    // the call to typecheck against the helper signature).
+    // #1618 / #1723: runtime string value (variable / concatenation / template
+    // span). The compiled value is a NativeString ref, a ConsString ref (a
+    // rope, produced by concat / template interpolation), or their AnyString
+    // supertype. Flatten + write its bytes to fd=1/fd=2 instead of dropping it
+    // and emitting the "[object]" placeholder.
+    //
+    // #1723 ROOT CAUSE: this used to `ref.cast` the value DOWN to NativeString
+    // before the call, on the assumption that "__str_flatten accepts the
+    // supertype, so any non-flat tree is handled there". But the downcast runs
+    // BEFORE flatten — so a ConsString value (the common case for any
+    // multi-segment response, e.g. the Native Messaging host's
+    // `{"received":${body},...}`) trapped with "illegal cast" at the call site,
+    // never reaching flatten. The host worked for tiny single-segment messages
+    // (still flat) and trapped once the response became a rope.
+    //
+    // FIX: `__wasi_write_any_string` now takes the AnyString supertype
+    // (see ensureWasiWriteAnyStringHelper), so NO downcast is needed — a
+    // NativeString or ConsString value is already a subtype of AnyString and
+    // passes directly. For a `ref_null` we only need the non-null guarantee;
+    // `ref.as_non_null` keeps the value's (sub)type intact instead of forcing
+    // it to NativeString. Flatten inside the helper collapses any rope.
     const refKind = exprType.kind;
-    if (
-      refKind === "ref" &&
-      "typeIdx" in exprType &&
-      (exprType as { typeIdx: number }).typeIdx !== ctx.nativeStrTypeIdx
-    ) {
-      fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
-    } else if (refKind === "ref_null") {
-      fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+    if (refKind === "ref_null") {
+      fctx.body.push({ op: "ref.as_non_null" } as Instr);
     }
     const writeAnyIdx = ensureWasiWriteAnyStringHelper(ctx, useStderr);
     if (writeAnyIdx >= 0) {
@@ -1674,6 +1681,24 @@ function emitWasiValueToStdout(
  * variant that routes the formatted digits through __wasi_write_string_stderr
  * (fd=2) instead of __wasi_write_string (fd=1).
  */
+/**
+ * Offset of the WASI integer-formatting (itoa) scratch buffer (#1724).
+ *
+ * Lives in the reserved low-scratch region (0..1023) that `registerWasiImports`
+ * keeps below the first string-literal data segment (which starts at 1024). We
+ * use offset 16 — above the iovec (memory[0..7]) and nwritten (memory[8..11])
+ * that `__wasi_write_string` populates, and below Math.random's offset-64
+ * scratch. 16 bytes is ample: a 32-bit int is at most 10 digits + sign = 11
+ * bytes, and the helper reserves a 11-byte window from this base.
+ *
+ * Previously the itoa buffer used `global.get $__wasi_bump_ptr`, which
+ * initialises to 1024 and is never advanced — colliding head-on with the
+ * string-literal data segments (also based at 1024). That overwrote literal
+ * bytes mid-string when a number was formatted between literal writes (#1724:
+ * `"received"` -> `"re60ived"`). Anchoring to 16 removes the aliasing.
+ */
+const WASI_ITOA_SCRATCH = 16;
+
 function ensureWasiWriteI32Helper(ctx: CodegenContext, useStderr: boolean = false): number {
   const helperName = useStderr ? "__wasi_write_i32_stderr" : "__wasi_write_i32";
   const writeStringHelperName = useStderr ? "__wasi_write_string_stderr" : "__wasi_write_string";
@@ -1703,8 +1728,10 @@ function ensureWasiWriteI32Helper(ctx: CodegenContext, useStderr: boolean = fals
   const tmpLocal = 5;
 
   body.push(
-    // buf_start = bump_ptr
-    { op: "global.get", index: ctx.wasiBumpPtrGlobalIdx } as Instr,
+    // buf_start = WASI_ITOA_SCRATCH (#1724). MUST NOT be the bump pointer
+    // (=1024), which aliases the string-literal data segments — see the
+    // WASI_ITOA_SCRATCH doc comment for the full root cause.
+    { op: "i32.const", value: WASI_ITOA_SCRATCH } as Instr,
     { op: "local.set", index: bufStartLocal } as Instr,
     // buf_pos = buf_start + 11 (write digits right-to-left, max 11 digits + sign)
     { op: "local.get", index: bufStartLocal } as Instr,

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1760,6 +1760,36 @@ function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: 
   fctx.body.push({ op: "i32.sub" } as Instr);
   fctx.body.push({ op: "local.set", index: capLocal });
 
+  // #1723: grow linear memory so the read staging buffer
+  // [WASI_STDIN_BUF_START .. WASI_STDIN_BUF_START+capacity) fits. The module
+  // reserves only 3 pages by default; a single large read (e.g. a ~1 MiB
+  // Native Messaging body read into one buffer) would otherwise write past the
+  // end of memory in fd_read and trap. neededPages = ceil((STDIN_BUF_START +
+  // capacity) / 65536) == (STDIN_BUF_START + capacity + 65535) >> 16.
+  const needPagesLocal = allocLocal(fctx, `__stdin_needPages_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
+  fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 65535 } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 16 } as Instr);
+  fctx.body.push({ op: "i32.shr_u" } as Instr);
+  fctx.body.push({ op: "local.set", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "memory.size" } as Instr);
+  fctx.body.push({ op: "i32.gt_u" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: needPagesLocal } as Instr,
+      { op: "memory.size" } as Instr,
+      { op: "i32.sub" } as Instr,
+      { op: "memory.grow" } as Instr,
+      { op: "drop" } as Instr,
+    ],
+  } as Instr);
+
   // iovec.buf = WASI_STDIN_BUF_START at memory[0]
   fctx.body.push({ op: "i32.const", value: 0 } as Instr);
   fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
@@ -1905,10 +1935,18 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         const compiled = compileExpression(ctx, fctx, argExpr);
         flushLateImportShifts(ctx, fctx);
         if (compiled && ctx.nativeStrTypeIdx >= 0) {
+          // #1723: do NOT downcast to NativeString here. The argument may be a
+          // ConsString (rope) — e.g. `process.stdout.write(`{"received":${x}}`)`
+          // in the Native Messaging host — and `ref.cast` to the concrete
+          // NativeString type TRAPS ("illegal cast") for a rope. The value
+          // trapped at the call BEFORE ever reaching the flattening helper, so
+          // the host worked only for tiny single-segment (still-flat) responses.
+          // `__wasi_write_any_string` now takes the AnyString supertype, which a
+          // NativeString or ConsString satisfies directly; it flattens any rope
+          // internally. We only assert non-null for a nullable ref so the value
+          // matches the helper's non-null param without changing its (sub)type.
           if (compiled.kind === "ref_null") {
-            fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
-          } else if (compiled.kind === "ref" && "typeIdx" in compiled && compiled.typeIdx !== ctx.nativeStrTypeIdx) {
-            fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx } as Instr);
+            fctx.body.push({ op: "ref.as_non_null" } as Instr);
           }
           const writeStrIdx = ensureWasiWriteAnyStringHelper(ctx, useStderr);
           if (writeStrIdx >= 0) {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4652,16 +4652,28 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
   const fd = useStderr ? 2 : 1;
   const strTypeIdx = ctx.nativeStrTypeIdx;
   const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+  // #1723: the param MUST be the AnyString supertype, NOT the concrete
+  // NativeString. A runtime concat / template span can be a ConsString (rope),
+  // and the caller hands us whatever the expression produced. If the param were
+  // typed NativeString, the call site would have to `ref.cast` the argument down
+  // to NativeString first — which TRAPS ("illegal cast") for a ConsString. By
+  // accepting AnyString here, both NativeString and ConsString pass without any
+  // downcast, and `__str_flatten` (which takes AnyString and collapses ropes)
+  // does the flattening internally. The original NativeString param + call-site
+  // downcast is exactly what made `writeMessage` trap on a multi-segment
+  // response in the Native Messaging host (#1723).
+  const anyStrTypeIdx = ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : strTypeIdx;
 
-  // param: s(0); locals: flat(1), len(2), off(3), data(4), i(5)
+  // param: s(0); locals: flat(1), len(2), off(3), data(4), i(5), needPages(6)
   const S = 0;
   const FLAT = 1;
   const LEN = 2;
   const OFF = 3;
   const DATA = 4;
   const I = 5;
+  const NEED_PAGES = 6;
 
-  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: strTypeIdx }], []);
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   ctx.funcMap.set(helperName, funcIdx);
 
@@ -4675,6 +4687,41 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
     { op: "local.get", index: FLAT } as Instr,
     { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 } as Instr,
     { op: "local.set", index: LEN } as Instr,
+
+    // #1723: grow linear memory if the staging buffer
+    // [WASI_WRITE_SCRATCH_START .. WASI_WRITE_SCRATCH_START+len) would overflow
+    // the current memory size. The module reserves only 3 pages by default, so
+    // a ~1 MiB response (the Native Messaging large-message case) writes far
+    // past page 2 and traps "memory access out of bounds" without this guard.
+    //
+    //   neededPages = ceil((WASI_WRITE_SCRATCH_START + len) / 65536)
+    //   if (memory.size < neededPages) memory.grow(neededPages - memory.size)
+    //
+    // ceil(x / 65536) == (x + 65535) >> 16. We `i32.shr_u` so a large length
+    // near 2^31 still computes a non-negative page count.
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 65535 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 16 } as Instr,
+    { op: "i32.shr_u" } as Instr,
+    { op: "local.set", index: NEED_PAGES } as Instr,
+    // if (needPages > memory.size) memory.grow(needPages - memory.size)
+    { op: "local.get", index: NEED_PAGES } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEED_PAGES } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
 
     // off = flat.off (field 1)
     { op: "local.get", index: FLAT } as Instr,
@@ -4756,6 +4803,7 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
       { name: "off", type: { kind: "i32" } },
       { name: "data", type: { kind: "ref", typeIdx: strDataTypeIdx } },
       { name: "i", type: { kind: "i32" } },
+      { name: "needPages", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/tests/issue-1723.test.ts
+++ b/tests/issue-1723.test.ts
@@ -1,0 +1,114 @@
+// #1723 — writeMessage cast failure on a multi-segment / large message.
+//
+// Reported by guest271314 against the Native Messaging host (parent #389). A
+// large response (~1 MiB) trapped with a WasmGC "cast failure" inside
+// writeMessage; small single-segment responses worked.
+//
+// ROOT CAUSE (two coordinated bugs):
+//   1. `process.stdout.write(<string>)` (and the console writer) emitted a
+//      `ref.cast` of the argument DOWN to the concrete NativeString type before
+//      calling the byte-writer helper. A runtime concat / template span (the
+//      response `{"received":${body},...}`) is a ConsString (rope), and the
+//      downcast TRAPS ("illegal cast") for a rope — the value never reached the
+//      flattening helper. The host only worked for tiny still-flat responses.
+//      FIX: `__wasi_write_any_string` now takes the AnyString supertype, so no
+//      downcast is needed; it flattens any rope internally.
+//   2. The string write staging buffer (and the stdin read staging buffer) are
+//      fixed in pages 1/2; a ~1 MiB payload overflowed linear memory and
+//      trapped "out of bounds". FIX: both paths now `memory.grow` to fit the
+//      payload before staging.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+const PROCESS_DECL = `declare const process: {
+  stdin: { read(buf: Uint8Array, offset?: number): number };
+  stdout: { write(chunk: Uint8Array | string): void };
+  stderr: { write(chunk: Uint8Array | string): void };
+};`;
+
+/** Run a WASI module's `main`, capturing fd=1 (stdout) bytes. */
+async function runCaptureStdout(source: string): Promise<number[]> {
+  const result = compile(source, { target: "wasi" });
+  expect(result.success).toBe(true);
+  const stdoutBytes: number[] = [];
+  const ref: { mem?: WebAssembly.Memory } = {};
+  const wasi = buildWasiPolyfill();
+  const imports = {
+    wasi_snapshot_preview1: new Proxy(wasi as unknown as Record<string, unknown>, {
+      get(target, prop) {
+        if (prop === "fd_write") {
+          return (fd: number, iovs: number, iovsLen: number, nwritten: number): number => {
+            const dv = new DataView(ref.mem!.buffer);
+            let total = 0;
+            for (let i = 0; i < iovsLen; i++) {
+              const ptr = dv.getUint32(iovs + i * 8, true);
+              const len = dv.getUint32(iovs + i * 8 + 4, true);
+              if (fd === 1) for (let j = 0; j < len; j++) stdoutBytes.push(dv.getUint8(ptr + j));
+              total += len;
+            }
+            dv.setUint32(nwritten, total, true);
+            return 0;
+          };
+        }
+        return (target as Record<string, unknown>)[prop as string];
+      },
+    }),
+  };
+  const module = await WebAssembly.compile(result.binary);
+  const instance = await WebAssembly.instantiate(module, imports);
+  ref.mem = (instance.exports as Record<string, unknown>).memory as WebAssembly.Memory;
+  wasi.setMemory(ref.mem);
+  (instance.exports as Record<string, () => void>).main?.();
+  return stdoutBytes;
+}
+
+describe("#1723 — process.stdout.write of a runtime cons-string must not trap", () => {
+  it("writes a template-interpolated (ConsString) response without an illegal cast", async () => {
+    // `{"received":${bodyStr},...}` is a rope. Before the fix this trapped.
+    const out = await runCaptureStdout(`
+      ${PROCESS_DECL}
+      function build(n: number): string {
+        let s = "";
+        let i = 0;
+        while (i < n) { s = s + String.fromCharCode(120); i = i + 1; }
+        return s;
+      }
+      export function main(): void {
+        const bodyStr = build(13);
+        const response = \`{"received":\${bodyStr},"runtime":"js2wasm+wasi"}\`;
+        process.stdout.write(response);
+      }
+    `);
+    expect(Buffer.from(out).toString("latin1")).toBe('{"received":xxxxxxxxxxxxx,"runtime":"js2wasm+wasi"}');
+  });
+
+  it("writes a large (~1 MiB) cons-string response (the #389 headline case)", async () => {
+    // Build ~1 MiB by repeated concat, embed in a wrapper template, write it
+    // with a 4-byte LE length prefix — exactly the Native Messaging frame.
+    const out = await runCaptureStdout(`
+      ${PROCESS_DECL}
+      function build(n: number): string {
+        let s = "";
+        let i = 0;
+        while (i < n) { s = s + "ABCDEFGH"; i = i + 1; }
+        return s;
+      }
+      export function main(): void {
+        const body = build(131072); // 131072 * 8 = 1,048,576 chars
+        const response = \`{"d":\${body}}\`;
+        const len = response.length;
+        process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
+        process.stdout.write(response);
+      }
+    `);
+    // First 4 bytes are the LE length prefix; the rest is the body.
+    const declared = (out[0]! | (out[1]! << 8) | (out[2]! << 16) | (out[3]! << 24)) >>> 0;
+    const bodyBytes = out.length - 4;
+    expect(bodyBytes).toBe(1048582); // {"d": + 1048576 + }
+    expect(declared).toBe(bodyBytes);
+    // Spot-check boundaries: starts with the wrapper, ends with the closing brace.
+    expect(Buffer.from(out.slice(4, 9)).toString("latin1")).toBe('{"d":');
+    expect(out[out.length - 1]).toBe(0x7d); // '}'
+  });
+});

--- a/tests/issue-1724.test.ts
+++ b/tests/issue-1724.test.ts
@@ -1,0 +1,109 @@
+// #1724 — string-constant backing-store corruption via WASI number formatting.
+//
+// Reported by guest271314 against the Native Messaging host (parent #389). The
+// debug line `[host] received ${n} chars` mutated its OWN literal across
+// iterations: "received" -> "re60ived" -> "re61ived" ... The digits of the
+// previously-formatted number overwrote the "ce" inside the "received" literal.
+//
+// ROOT CAUSE: the WASI integer-formatting helper (__wasi_write_i32) wrote its
+// itoa scratch digits at `global.get $__wasi_bump_ptr`, which initialises to
+// 1024 — the SAME offset where string-literal data segments begin
+// (wasiAllocStringData starts at 1024 and grows up). So formatting a number
+// clobbered bytes 1024..1035 of the first literal. The fix anchors the itoa
+// scratch to the reserved low-scratch region (offset 16), which never aliases
+// the data segments.
+//
+// These tests drive the compiled module through a custom fd_write capture
+// (separating fd=1/fd=2) and assert the literal text survives interleaved
+// number formatting byte-for-byte.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+/** Run a WASI module's `main`, capturing fd=1 (stdout) and fd=2 (stderr) bytes. */
+async function runWasi(source: string): Promise<{ stdout: string; stderr: string }> {
+  const result = compile(source, { target: "wasi" });
+  expect(result.success).toBe(true);
+  const stdoutBytes: number[] = [];
+  const stderrBytes: number[] = [];
+  const ref: { mem?: WebAssembly.Memory } = {};
+  const wasi = buildWasiPolyfill();
+  const imports = {
+    wasi_snapshot_preview1: new Proxy(wasi as unknown as Record<string, unknown>, {
+      get(target, prop) {
+        if (prop === "fd_write") {
+          return (fd: number, iovs: number, iovsLen: number, nwritten: number): number => {
+            const dv = new DataView(ref.mem!.buffer);
+            let total = 0;
+            const sink = fd === 2 ? stderrBytes : stdoutBytes;
+            for (let i = 0; i < iovsLen; i++) {
+              const ptr = dv.getUint32(iovs + i * 8, true);
+              const len = dv.getUint32(iovs + i * 8 + 4, true);
+              for (let j = 0; j < len; j++) sink.push(dv.getUint8(ptr + j));
+              total += len;
+            }
+            dv.setUint32(nwritten, total, true);
+            return 0;
+          };
+        }
+        return (target as Record<string, unknown>)[prop as string];
+      },
+    }),
+  };
+  const module = await WebAssembly.compile(result.binary);
+  const instance = await WebAssembly.instantiate(module, imports);
+  ref.mem = (instance.exports as Record<string, unknown>).memory as WebAssembly.Memory;
+  wasi.setMemory(ref.mem);
+  (instance.exports as Record<string, () => void>).main?.();
+  const dec = (b: number[]) => Buffer.from(b).toString("latin1");
+  return { stdout: dec(stdoutBytes), stderr: dec(stderrBytes) };
+}
+
+describe("#1724 — WASI number formatting must not corrupt string constants", () => {
+  it("the 'received' literal survives interleaved number formatting (the #389 repro)", async () => {
+    const { stderr } = await runWasi(`
+      export function main(): void {
+        let i = 0;
+        while (i < 5) {
+          const n = 60 + i;
+          console.error(\`[host] received \${n} chars\`);
+          i = i + 1;
+        }
+      }
+    `);
+    // Before the fix this was
+    //   "[host] received 60 chars\n[host] re60ived 61 chars\n[host] re61ived ..."
+    // console.error appends a trailing newline per call.
+    expect(stderr).toBe(
+      "[host] received 60 chars\n" +
+        "[host] received 61 chars\n" +
+        "[host] received 62 chars\n" +
+        "[host] received 63 chars\n" +
+        "[host] received 64 chars\n",
+    );
+    // Strong invariant: the substring "received" must appear once per line and
+    // never the corrupted "re<digits>ived" form.
+    expect(stderr).not.toMatch(/re\d/);
+    expect(stderr.match(/received/g)?.length).toBe(5);
+  });
+
+  it("formats zero, negatives, and large ints without touching the surrounding literal", async () => {
+    const { stderr } = await runWasi(`
+      export function main(): void {
+        console.error(\`A=\${0} B=\${-17} C=\${2147483647} D=\${1234567890} done\`);
+        console.error(\`literal stays clean\`);
+      }
+    `);
+    expect(stderr).toBe("A=0 B=-17 C=2147483647 D=1234567890 done\n" + "literal stays clean\n");
+  });
+
+  it("a number written between two literals leaves both literals intact", async () => {
+    const { stdout } = await runWasi(`
+      export function main(): void {
+        console.log(\`prefix-\${42}-suffix\`);
+      }
+    `);
+    // console.log appends a trailing newline; the body must be exact.
+    expect(stdout).toBe("prefix-42-suffix\n");
+  });
+});


### PR DESCRIPTION
Fixes two real compiler bugs reported by guest271314 against the Native Messaging host (parent #389), tested in WASI/standalone mode.

## #1724 — string-constant corruption (critical, silent data corruption)
The WASI integer formatter `__wasi_write_i32` wrote its itoa digit buffer at `global.get $__wasi_bump_ptr`, which initialises to **1024** — the same offset where string-literal data segments begin (`wasiAllocStringData` grows up from 1024). Formatting a number clobbered the first literal's bytes:

`[host] received ${n}` → `[host] re60ived 61 chars` (the `ce` of `received` overwritten by the prior number's digits).

**Fix** (`builtins.ts`): anchor the itoa scratch to the reserved low-scratch region (offset 16 — above iovec/nwritten at 0..11, below Math.random's offset-64 scratch, well under 1024). Same family as #1618.

## #1723 — writeMessage cast failure on multi-segment / large message
Two coordinated bugs:
- **A1 (ConsString downcast)**: both string-write call sites (`process.stdout/stderr.write(string)` in `calls.ts`, console writer in `builtins.ts`) emitted `ref.cast` of the argument **down** to the concrete `NativeString` type before the byte-writer. A template/concat response (`{"received":${body},...}`) is a `ConsString` (rope); the downcast **traps "illegal cast"** for a rope, before flatten runs. **Fix**: `__wasi_write_any_string` now takes the `AnyString` supertype (no downcast needed; it flattens any rope internally); call sites only `ref.as_non_null` a nullable ref.
- **A2 (fixed-staging overflow)**: the write staging buffer (page 2) and stdin read staging buffer (page 1) are fixed; a ~1 MiB payload overflowed the 3-page reservation and trapped out-of-bounds. **Fix**: both paths now `memory.grow` to fit the payload before staging.

## Verification
Full Native Messaging round-trip verified for N = 1, 12, 13, 100, 1000, and **209,715 (~1 MiB, message length 1,048,614 — the #389 headline case)**: declared response length matches body bytes exactly.

Tests: `tests/issue-1723.test.ts`, `tests/issue-1724.test.ts` (5 tests, all green). Typecheck + WASI suites green. The 12 pre-existing `imported-string-constants` / `concat-chain` failures and the 4 `wasi-environ`/`1480` failures are unrelated (confirmed identical on clean `origin/main`).

## Notes
- #1723 and #1724 do **not** share a root cause; fixed together in one PR, documented as independent in each issue file.
- Example-polish (swap `console.error` → `process.stderr.write` in `host.ts`) is **deferred**: a separate pre-existing `__str_to_extern` stack-balance bug breaks a *minimal* `process.std*.write(string)` program (confirmed on clean main); switching would risk the example. Documented as a follow-up in #1723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)