### PR TITLE
fix(#1722): parenthesized object/array literal is not a valid assignment target

### DIFF
--- a/plan/issues/1722-es3-assignmenttargettype-early-syntaxerror.md
+++ b/plan/issues/1722-es3-assignmenttargettype-early-syntaxerror.md
@@ -1,9 +1,10 @@
 ---
 id: 1722
-title: "ES3: AssignmentTargetType early SyntaxError not raised (yield / arrow-function as assignment target)"
-status: ready
+title: "ES3: AssignmentTargetType early SyntaxError not raised (parenthesized object/array literal as assignment target)"
+status: done
 created: 2026-05-29
 updated: 2026-05-29
+completed: 2026-05-29
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -21,52 +22,62 @@ related: [1091, 402]
 
 ## Problem (edition ≤ ES3, negative parse tests)
 
-Four `language/expressions/assignmenttargettype/*` tests are negative
-(`phase: parse`, `type: SyntaxError`) and we **compile + instantiate them
-successfully** instead of rejecting at parse time:
-
-```
-expected parse/early SyntaxError but compiled and instantiated successfully
-```
-
-The constructs assert that certain productions have AssignmentTargetType
-"invalid" and therefore cannot be the target of an assignment:
+`language/expressions/assignmenttargettype/*` negative tests (`phase: parse`,
+`type: SyntaxError`) compiled + instantiated successfully instead of being
+rejected at parse time:
 
 ```js
-yield x = 1;                        // direct-yieldexpression-0
-() => {} = 1;  /* arrow */          // direct-arrowfunction-1
-async () => {} = 1;                 // direct-asyncarrowfunction-1
+() => ({}) = 1;        // direct-arrowfunction-1
+async () => ({}) = 1;  // direct-asyncarrowfunction-1
+({}) = 1;              // parenthesized ObjectLiteral as target
 ```
 
-#1091 and #402 (both `done`) improved early-error detection broadly but did not
-cover these AssignmentTargetType cases.
+All reduce to the same defect: a **parenthesized** ObjectLiteral / ArrayLiteral
+is treated as a valid destructuring AssignmentPattern target. Per the spec a
+CoverParenthesizedExpressionAndArrowParameterList cannot be refined to an
+AssignmentPattern, so `({}) = 1` is an early SyntaxError. (Confirmed against
+Node: `({}) = 1` and `({a:1}) = 1` throw `SyntaxError: Invalid left-hand side
+in assignment`, while `[] = 1` and `({} = 1)` are valid.)
 
-## Root-cause hypothesis
+## Root cause (confirmed)
 
-The parser/early-error pass does not consult Static Semantics:
-AssignmentTargetType (§13.x) before accepting an `AssignmentExpression` whose
-LHS is a `YieldExpression`, `ArrowFunction`, or `AsyncArrowFunction` — all of
-which are `invalid` targets and must produce a SyntaxError at parse time.
+`isInvalidAssignmentTarget` in `src/compiler/validation.ts` unwrapped
+parentheses **before** the destructuring check, so a parenthesized object/array
+literal reached the `allowDestructuring` branch and was wrongly accepted. The
+destructuring forms are only valid when they appear *directly* as the LHS.
 
-Spec: [§13.15.1 Static Semantics: AssignmentTargetType / Early Errors](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors),
+## Fix
+
+`src/compiler/validation.ts` — test the destructuring object/array-literal
+forms on the **original** (un-unwrapped) node before stripping parens; only
+identifiers / property access / element access remain valid through parens
+(`(x) = 1` stays valid, `({}) = 1` becomes an error). One-function change.
+
+Spec: [§13.15.1 Static Semantics: Early Errors](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors),
 [§13.x AssignmentTargetType](https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype).
-
-## Example failing tests
-
-- `test/language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
-- `test/language/expressions/assignmenttargettype/direct-arrowfunction-1.js`
-- `test/language/expressions/assignmenttargettype/direct-asyncarrowfunction-1.js`
 
 ## Acceptance criteria
 
-- The three example negative tests are rejected with a parse-phase SyntaxError
-  (they now count as `pass`).
-- No regression in #1091 / #402 early-error tests.
+- `direct-arrowfunction-1` / `direct-asyncarrowfunction-1` rejected with a
+  parse-phase SyntaxError. ✅
+- `({}) = 1`, `({a:1}) = 1`, `() => (1 = 1)` rejected. ✅
+- No regression: `[a,b] = x`, `({a} = x)`, `(x) = 1`, chained `a=b=c` still
+  accepted (equivalence destructuring + assignment suites 19/19 pass). ✅
 
-## Notes
+## Residual (out of scope)
 
-Low value (4 tests) but a crisp, edition-0-scoped early-error gap; bundled into
-the Sprint 57 ES3 conformance track.
+`yield x = 1;` (`direct-yieldexpression-0`) is a separate gap — `yield` at the
+top level of a script is an Identifier and `yield x` is two adjacent
+expressions, which TypeScript's parser accepts but Node rejects with
+`Unexpected identifier 'x'`. That is a yield-context parse issue, not an
+AssignmentTargetType one; not addressed here.
+
+## Test Results
+
+- `tests/issue-1722.test.ts` — 10/10 pass (5 reject cases, 5 accept cases).
+- `tests/issue-1611.test.ts` early-error suite — 14/14 (no regression).
+- `tests/equivalence/basic-destructuring.test.ts` +
+  `assignment-expression-value.test.ts` — 19/19 (no regression).
 
 ## Source
 

--- a/src/compiler/validation.ts
+++ b/src/compiler/validation.ts
@@ -343,18 +343,25 @@ function detectEarlyErrors(sourceFile: ts.SourceFile): CompileError[] {
    * property/element access are valid — no destructuring patterns.
    */
   function isInvalidAssignmentTarget(node: ts.Expression, allowDestructuring = false): boolean {
+    // (#1722) A destructuring AssignmentPattern is only a valid target when it
+    // appears *directly* as the LHS — a parenthesized object/array literal
+    // (`({}) = 1`, `({a:1}) = 1`) is NOT a valid target and is an early
+    // SyntaxError per §13.15.1 (CoverParenthesizedExpression cannot be
+    // refined to an AssignmentPattern). So test the destructuring forms on
+    // the un-unwrapped node before stripping parens. Note `({} = 1)` is fine
+    // because there the parens wrap the whole assignment, not the pattern.
+    if (allowDestructuring) {
+      if (ts.isObjectLiteralExpression(node)) return false;
+      if (ts.isArrayLiteralExpression(node)) return false;
+    }
     let expr: ts.Node = node;
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
-    // Valid: identifiers, property access, element access
+    // Valid: identifiers, property access, element access (parens are
+    // transparent for these — `(x) = 1` / `(o.p) = 1` are valid).
     if (ts.isIdentifier(expr)) return false;
     if (ts.isPropertyAccessExpression(expr)) return false;
     if (ts.isElementAccessExpression(expr)) return false;
-    // Valid only in simple assignment: destructuring patterns
-    if (allowDestructuring) {
-      if (ts.isObjectLiteralExpression(expr)) return false;
-      if (ts.isArrayLiteralExpression(expr)) return false;
-    }
-    // Everything else is invalid
+    // Everything else (incl. parenthesized object/array literals) is invalid.
     return true;
   }
 

--- a/tests/issue-1722.test.ts
+++ b/tests/issue-1722.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1722 — Static Semantics: AssignmentTargetType early SyntaxError.
+ *
+ * A parenthesized ObjectLiteral / ArrayLiteral is NOT a valid assignment
+ * target — `({}) = 1`, `({a:1}) = 1`, and the arrow-body forms
+ * `() => ({}) = 1` / `async () => ({}) = 1` are early SyntaxErrors per
+ * §13.15.1 (a CoverParenthesizedExpression cannot be refined to an
+ * AssignmentPattern). Previously these compiled + instantiated.
+ *
+ * The valid destructuring AssignmentPattern target appears *directly* as the
+ * LHS (`[a,b] = x`, `({a} = x)`), so those must still be accepted. Parentheses
+ * remain transparent for simple targets (`(x) = 1`).
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+function rejects(src: string): boolean {
+  const r = compile(src, { fileName: "test.ts" });
+  return r.success === false;
+}
+
+describe("#1722 — AssignmentTargetType early SyntaxError", () => {
+  it.each(["() => ({}) = 1;", "async () => ({}) = 1;", "({}) = 1;", "({a:1}) = 1;", "() => (1 = 1);"])(
+    "rejects invalid assignment target: %j",
+    (src) => {
+      expect(rejects(src)).toBe(true);
+    },
+  );
+
+  it.each([
+    "let x = 0; x = 1;",
+    "let x = 0; (x) = 1;",
+    "let a = 0, b = 0; [a, b] = [1, 2];",
+    "let a = 0; ({ a } = { a: 1 });",
+    "let y = 0; const f = () => (y = 1); f();",
+  ])("still accepts valid assignment target: %j", (src) => {
+    expect(rejects(src)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`() => ({}) = 1`, `async () => ({}) = 1`, and `({}) = 1` compiled+instantiated instead of raising an early SyntaxError (~4 test262 fails under `language/expressions/assignmenttargettype/`). Per §13.15.1 a CoverParenthesizedExpression cannot be refined to an AssignmentPattern, so a *parenthesized* object/array literal is not a valid assignment target (confirmed against Node: `({}) = 1` throws, `[] = 1` / `({} = 1)` are fine).

## Root cause

`isInvalidAssignmentTarget` (src/compiler/validation.ts) stripped parentheses **before** the destructuring check, so a parenthesized object/array literal reached the `allowDestructuring` branch and was accepted. The destructuring AssignmentPattern is only valid when it appears *directly* as the LHS.

## Fix

One-function change: test the object/array-literal destructuring forms on the **original** node before unwrapping parens. Identifier / property / element access stay valid through parens (`(x) = 1`), and bare `[a,b] = x` / `({a} = x)` remain valid.

Spec: ECMA-262 §13.15.1 Static Semantics: Early Errors; §13.x AssignmentTargetType.

## Tests

- `tests/issue-1722.test.ts` — 10/10 (5 reject, 5 accept)
- `tests/issue-1611.test.ts` early-error suite — 14/14 (no regression)
- equivalence `basic-destructuring` + `assignment-expression-value` — 19/19 (no regression)

## Residual (out of scope)

`yield x = 1` (`direct-yieldexpression-0`) is a separate yield-context parse gap (TS accepts `yield x` as adjacent expressions; Node rejects). Documented in the issue, not addressed here.

Closes #1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)