### PR TITLE
fix(#1728): compound assignment to unresolvable reference throws ReferenceError

### DIFF
--- a/plan/issues/1728-es5-compound-assign-unresolvable-referror.md
+++ b/plan/issues/1728-es5-compound-assign-unresolvable-referror.md
@@ -1,0 +1,75 @@
+---
+id: 1728
+title: "ES5: compound assignment to unresolvable reference must throw ReferenceError"
+status: done
+created: 2026-05-29
+updated: 2026-05-29
+completed: 2026-05-29
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: compound-assignment, reference-error
+goal: test262-conformance
+es_edition: 5
+test262_category: language/expressions/compound-assignment
+related: [1607]
+---
+
+# #1728 — ES5: compound assignment to unresolvable reference
+
+## Problem
+
+`language/expressions/compound-assignment/S11.13.2_A2.1_T3.*` (es5id
+11.13.2_A2.1_T3.*) require that a compound assignment whose LHS is an
+unresolvable reference throws **ReferenceError**:
+
+```js
+try { var z = (x += 1); throw new Test262Error(); }  // x undeclared
+catch (e) { assert(e instanceof ReferenceError); }
+```
+
+We silently no-op'd (`x += 1` returned 0, no throw), so the test's `catch`
+never fired and the assertion failed. Surfaced bucketing the ES5 (es5id)
+edition failures (compound-assignment was the largest LOCALIZED bucket, ~98
+es5id failures; the bigger Object.defineProperty/create buckets are the
+architect-gated descriptor model).
+
+## Root cause
+
+Per §13.15.2 CompoundAssignmentEvaluation step 1.c, `lval = GetValue(lref)`
+runs *before* the RHS; GetValue on an unresolvable reference throws
+ReferenceError (§6.2.4) in both strict and sloppy mode. The compound-identifier
+codegen (`src/codegen/expressions/assignment.ts`, the `localIdx === undefined`
+branch) instead **auto-allocated a zero local** for the unknown name — a
+graceful fallback that masked the unresolvable-reference error. The plain
+*read* path already throws correctly (`identifiers.ts`), and the simple-assign
+path already has the §6.2.4 PutValue guard; only compound assignment was
+missing the GetValue-unresolvable throw.
+
+## Fix
+
+In the compound-identifier `localIdx === undefined` branch: if the LHS
+identifier has **no resolved symbol** (`checker.getSymbolAtLocation` is
+undefined) AND is not a module-global / captured-global, it is genuinely
+undeclared — emit `emitThrowReferenceError("<name> is not defined")` instead of
+auto-allocating. Names with a symbol (hoisted `var`, outer-scope bindings,
+builtins) keep the graceful auto-allocate path. ~10 LOC, one branch.
+
+Spec: ECMA-262 §13.15.2 CompoundAssignmentEvaluation, §6.2.4 GetValue/PutValue.
+
+## Acceptance criteria
+
+- `x += 1` (and `-= *= /= %=` etc.) with undeclared `x` throws ReferenceError. ✅
+- Declared local / param / module-global / string compound assignment unchanged. ✅
+- No regression in the compound-assignment equivalence suites. ✅
+
+## Test Results
+
+- `tests/issue-1728.test.ts` — 9/9 pass.
+- `tests/equivalence/compound-assignment-{coercion,property,nonref-element}.test.ts`
+  — 18/18 (no regression).
+
+## Source
+
+dev-b ES5 edition-bucket triage 2026-05-29 (Sprint 57 ES3/ES5 track).

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -34,6 +34,7 @@ import { findExternInfoForMember, patchStructNewForDynamicField } from "./extern
 import {
   classifyPrivateMember,
   emitCoercedLocalSet,
+  emitThrowReferenceError,
   emitThrowString,
   emitThrowTypeError,
   getFuncParamTypes,
@@ -4315,6 +4316,22 @@ export function compileCompoundAssignment(
 
   let localIdx = fctx.localMap.get(name);
   if (localIdx === undefined) {
+    // §13.15.2 CompoundAssignmentEvaluation step 1.c: `lval = GetValue(lref)`
+    // runs before the RHS is evaluated. GetValue on an *unresolvable*
+    // reference throws ReferenceError (§6.2.4). A name that reaches here with
+    // no local / captured-global / module-global / const binding AND no
+    // resolved symbol from the checker is genuinely undeclared (e.g.
+    // `x += 1` with no `x` in scope) — throw rather than silently
+    // auto-allocating a zero local. Names with a symbol (hoisted `var`,
+    // outer-scope bindings, builtins) keep the graceful auto-allocate path.
+    const lhsSym = ctx.checker.getSymbolAtLocation(expr.left);
+    if (lhsSym === undefined && !ctx.moduleGlobals.has(name) && ctx.capturedGlobals.get(name) === undefined) {
+      emitThrowReferenceError(ctx, fctx, `${name} is not defined`);
+      // After throw the stack is polymorphic; push a sentinel so callers that
+      // expect a compound-assignment result value (f64) typecheck.
+      fctx.body.push({ op: "f64.const", value: 0 });
+      return { kind: "f64" };
+    }
     // Graceful fallback: auto-allocate a local for the unknown identifier
     // so compound assignments work correctly (the variable is initialized
     // to the appropriate zero value).

--- a/tests/issue-1728.test.ts
+++ b/tests/issue-1728.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1728 — Compound assignment to an unresolvable reference must throw
+ * ReferenceError (ES5 es5id 11.13.2_A2.1_T3.* family).
+ *
+ * Per §13.15.2 CompoundAssignmentEvaluation, step 1.c evaluates
+ * `lval = GetValue(lref)` *before* the RHS; GetValue on an unresolvable
+ * reference throws ReferenceError (§6.2.4). Previously the compound-identifier
+ * codegen silently auto-allocated a zero local for an undeclared name, so
+ * `x += 1` no-op'd instead of throwing.
+ *
+ * Declared targets (local / param / module global / outer-scope) keep working.
+ */
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const exports = await compileAndInstantiate(src);
+  return ((exports as any).test as () => number)();
+}
+
+describe("#1728 — compound assignment to unresolvable reference throws ReferenceError", () => {
+  it.each([
+    ["+=", "x += 1"],
+    ["-=", "x -= 1"],
+    ["*=", "x *= 2"],
+    ["/=", "x /= 2"],
+    ["%=", "x %= 2"],
+  ])("undeclared %s throws ReferenceError", async (_op, stmt) => {
+    const src = `
+export function test(): number {
+  try { ${stmt}; return 0; }
+  catch (e) { return (e instanceof ReferenceError) ? 1 : 2; }
+}`;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("declared local compound assignment still works", async () => {
+    expect(await run(`export function test(): number { let a = 10; a += 5; return a; }`)).toBe(15);
+  });
+
+  it("parameter compound assignment still works", async () => {
+    expect(
+      await run(`function g(n: number): number { n += 3; return n; } export function test(): number { return g(7); }`),
+    ).toBe(10);
+  });
+
+  it("module-global compound assignment still works", async () => {
+    expect(
+      await run(`let m = 1; function bump(): void { m += 4; } export function test(): number { bump(); return m; }`),
+    ).toBe(5);
+  });
+
+  it("string compound assignment still works", async () => {
+    expect(await run(`export function test(): number { let s = ""; s += "ab"; return s.length; }`)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

`x += 1` (and `-= *= /= %=` …) with an **undeclared** `x` silently no-op'd instead of throwing ReferenceError, failing the ES5 `language/expressions/compound-assignment/S11.13.2_A2.1_T3.*` family (es5id 11.13.2_A2.1_T3.*). Largest LOCALIZED bucket from the ES5 edition-failure triage (~98 es5id tests).

## Root cause

Per §13.15.2 CompoundAssignmentEvaluation step 1.c, `lval = GetValue(lref)` runs **before** the RHS; GetValue on an unresolvable reference throws ReferenceError (§6.2.4). The compound-identifier codegen (`assignment.ts`, `localIdx === undefined` branch) **auto-allocated a zero local** for an unknown name — a graceful fallback that masked the unresolvable-reference error. The plain *read* path and the simple-*assign* path already throw correctly; only compound assignment was missing the GetValue-unresolvable throw.

## Fix

In that branch: if the LHS identifier has no resolved symbol (`checker.getSymbolAtLocation` undefined) and is not a module/captured global, emit `emitThrowReferenceError("<name> is not defined")` instead of auto-allocating. Hoisted `var` / outer-scope / builtins (which carry a symbol) keep the graceful path. ~10 LOC, one branch.

Spec: ECMA-262 §13.15.2, §6.2.4.

## Tests

- `tests/issue-1728.test.ts` — 9/9 (5 reject ops + local/param/module-global/string still work)
- `tests/equivalence/compound-assignment-{coercion,property,nonref-element}.test.ts` — 18/18 (no regression)

Closes #1728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)