### PR TITLE
fix(#1729): instanceof Object true for WasmGC-struct values

### DIFF
--- a/plan/issues/1729-instanceof-object-struct-receiver.md
+++ b/plan/issues/1729-instanceof-object-struct-receiver.md
@@ -1,0 +1,80 @@
+---
+id: 1729
+title: "instanceof Object returns false for WasmGC-struct values (object literal / array / class instance / thrown value)"
+status: done
+created: 2026-05-29
+updated: 2026-05-29
+completed: 2026-05-29
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: instanceof, prototype-chain
+goal: test262-conformance
+related: [1455, 1366, 1720]
+---
+
+# #1729 — `instanceof Object` false for struct-backed values
+
+## Problem
+
+`<value> instanceof Object` returned **false** for compiler-native
+WasmGC-struct values — object literals, arrays, class instances — and for a
+caught thrown value (the #1720 `A6_T1` first-assertion that dev-c surfaced):
+
+```js
+const o = { x: 1 };       o instanceof Object        // was false (expected true)
+const a = [1, 2];         a instanceof Object        // was false
+class C {}                new C() instanceof Object  // was false
+try { throw { x: 1 }; } catch (e) { e instanceof Object } // was false
+```
+
+Per §7.3.20 OrdinaryHasInstance, every object's prototype chain reaches
+`Object.prototype`, so `instanceof Object` is true for all of them.
+
+## Root cause
+
+WasmGC-struct values are opaque externrefs at the host boundary. Two layers
+returned a spurious `false`:
+
+1. **Static evaluator** `tryStaticInstanceOf` (`identifiers.ts`): for an
+   object-literal LHS it fell through to `undefined` (runtime); for an array
+   LHS (`Array` symbol) it hit `isBuiltinSubtype("Array","Object")` → false
+   (no Array→Object chain edge); for a user-class instance it returned `false`
+   (no builtin parent).
+2. **Runtime** `__instanceof` (`runtime.ts`): `v instanceof globalThis.Object`
+   is false for an opaque struct externref, so the `any`-typed / thrown-value
+   path returned 0.
+
+## Fix (localized)
+
+- `tryStaticInstanceOf`: `ctorName === "Object"` is a universal yes for
+  (a) builtin-symbol LHS, (b) user-class-instance LHS (no builtin parent),
+  and (c) any provably non-primitive object type (object literals / arrays /
+  tuples). Guarded against primitives / null / undefined / any / unknown.
+- `__instanceof`: a non-null WasmGC-struct receiver with the `Object` RHS
+  returns 1 (covers the `any`-typed / thrown-value path). Primitives never
+  reach this branch as wasm structs, so `5 instanceof Object` stays false.
+
+Spec: ECMA-262 §7.3.20 OrdinaryHasInstance, §20.1.3.
+
+## Acceptance criteria
+
+- Object literal / array / class instance / thrown object / thrown array
+  `instanceof Object` → true. ✅
+- Thrown number / string `instanceof Object` → false. ✅
+- `array instanceof Array` still true; `obj instanceof Array` still false;
+  `Error instanceof Error` / `instanceof Object` still true. ✅
+- No regression in #1455 / #1366a / #1366b instanceof suites (24/24 pass).
+
+## Test Results
+
+- `tests/issue-1729.test.ts` — 9/9 pass.
+- `tests/issue-1455.test.ts` + `issue-1366a` + `issue-1366b` — 24/24 (no regression).
+- (`tests/instanceof.test.ts` fails 7/7 on a CLEAN checkout too — a pre-existing
+  harness issue unrelated to this change; user-class↔user-class instanceof is
+  untouched here.)
+
+## Source
+
+dev-b, from the #1720 A6_T1 instanceof-on-thrown-value gap (dev-c). Sprint 57.

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -860,11 +860,16 @@ function tryStaticInstanceOf(ctx: CodegenContext, expr: ts.BinaryExpression, cto
       if (builtinParent !== undefined) {
         return isBuiltinSubtype(builtinParent, ctorName);
       }
-      return false;
+      // (#1729) A user-class instance with no builtin parent is still an
+      // `instanceof Object` (its prototype chain ends at Object.prototype).
+      // Any other builtin RHS is false (a plain user struct isn't a Map/Array/…).
+      return ctorName === "Object";
     }
     // 2. LHS is itself a built-in (or matches the constructor's instance-type
-    //    name) — apply hierarchy reasoning.
+    //    name) — apply hierarchy reasoning. Every builtin instance is also an
+    //    `instanceof Object` (#1729), so Object is a universal yes here.
     if (isBuiltinTypeName(lhsSymbolName)) {
+      if (ctorName === "Object") return true;
       return isBuiltinSubtype(lhsSymbolName, ctorName);
     }
   }
@@ -874,6 +879,37 @@ function tryStaticInstanceOf(ctx: CodegenContext, expr: ts.BinaryExpression, cto
   //    TS type may be the wrapper, so we leave that to runtime.)
   if (isNumberType(leftTsType) || isBooleanType(leftTsType)) {
     return false;
+  }
+
+  // 4. (#1729) `<obj> instanceof Object` is true for every object value
+  //    (§7.3.20 OrdinaryHasInstance walks the prototype chain to
+  //    Object.prototype). WasmGC-struct-backed values — object literals,
+  //    arrays, tuples — are not real host objects, so the runtime
+  //    `__instanceof` falls through to a spurious `false`. Short-circuit to
+  //    `true` when the RHS is `Object` and the LHS is a provably non-primitive
+  //    object type. Guarded against primitives / null / undefined / any /
+  //    unknown so only definite objects qualify. (User-class instances are
+  //    handled by the `classTagMap` branch above, which returns before here.)
+  if (ctorName === "Object") {
+    const f = leftTsType.flags;
+    const isPrimitiveOrIndeterminate =
+      (f &
+        (ts.TypeFlags.Any |
+          ts.TypeFlags.Unknown |
+          ts.TypeFlags.NumberLike |
+          ts.TypeFlags.StringLike |
+          ts.TypeFlags.BooleanLike |
+          ts.TypeFlags.BigIntLike |
+          ts.TypeFlags.ESSymbolLike |
+          ts.TypeFlags.Null |
+          ts.TypeFlags.Undefined |
+          ts.TypeFlags.Void |
+          ts.TypeFlags.Never)) !==
+      0;
+    // Object literals, arrays, and tuples all carry the Object type flag.
+    if (!isPrimitiveOrIndeterminate && (f & ts.TypeFlags.Object) !== 0) {
+      return true;
+    }
   }
 
   return undefined;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7700,6 +7700,16 @@ assert._isSameValue = isSameValue;
               tag = _userClassParents.get(tag) ?? null;
             }
           }
+          // (#1729) `<obj> instanceof Object` is true for every object value
+          // (§7.3.20 walks the prototype chain to Object.prototype). A
+          // WasmGC-struct-backed value (object literal, array, class instance)
+          // arriving here as an opaque externref is an object — V8's
+          // `v instanceof Object` above returns false for the opaque ref, so
+          // recognise it explicitly. Only for the `Object` RHS; primitives
+          // never reach this branch as wasm structs.
+          if (ctorName === "Object" && v != null && _isWasmStruct(v)) {
+            return 1;
+          }
           return 0;
         };
       // (#1455) Tag an externref-backed user-class instance with the innermost

--- a/tests/issue-1729.test.ts
+++ b/tests/issue-1729.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1729 — `<value> instanceof Object` must be true for every object value
+ * (§7.3.20 OrdinaryHasInstance walks the prototype chain to
+ * Object.prototype). WasmGC-struct-backed values — object literals, arrays,
+ * class instances — are opaque externrefs at the host boundary, so both the
+ * static `instanceof` evaluator and the runtime `__instanceof` returned a
+ * spurious `false`. Surfaced via the #1720 A6_T1 "thrown value instanceof"
+ * assertion (dev-c).
+ *
+ * Two layers fixed:
+ *   - `tryStaticInstanceOf` (identifiers.ts): Object is a universal yes for
+ *     object-literal / array / builtin / user-class-instance LHS types.
+ *   - runtime `__instanceof` (runtime.ts): a WasmGC-struct receiver with the
+ *     `Object` RHS returns 1 (covers the `any`-typed / thrown-value path).
+ */
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const exports = await compileAndInstantiate(src);
+  return ((exports as any).test as () => number)();
+}
+
+describe("#1729 — instanceof Object for object values", () => {
+  it.each([
+    ["object literal", `const o = { x: 1 }; export function test(): number { return (o instanceof Object) ? 1 : 0; }`],
+    ["array", `const a = [1, 2]; export function test(): number { return (a instanceof Object) ? 1 : 0; }`],
+    [
+      "class instance",
+      `class C {} const c = new C(); export function test(): number { return (c instanceof Object) ? 1 : 0; }`,
+    ],
+    [
+      "thrown object literal (caught any)",
+      `export function test(): number { try { throw { x: 1 }; } catch (e) { return (e instanceof Object) ? 1 : 0; } }`,
+    ],
+    [
+      "thrown array (caught any)",
+      `export function test(): number { try { throw [1, 2]; } catch (e) { return (e instanceof Object) ? 1 : 0; } }`,
+    ],
+    [
+      "thrown Error instanceof Object",
+      `export function test(): number { try { throw new TypeError("x"); } catch (e) { return (e instanceof Object) ? 1 : 0; } }`,
+    ],
+  ])("%s instanceof Object is true", async (_label, src) => {
+    expect(await run(src)).toBe(1);
+  });
+
+  it.each([
+    [
+      "thrown number",
+      `export function test(): number { try { throw 5; } catch (e) { return (e instanceof Object) ? 1 : 0; } }`,
+    ],
+    [
+      "thrown string",
+      `export function test(): number { try { throw "x"; } catch (e) { return (e instanceof Object) ? 1 : 0; } }`,
+    ],
+  ])("%s instanceof Object is false", async (_label, src) => {
+    expect(await run(src)).toBe(0);
+  });
+
+  it("array instanceof Array still true; object literal instanceof Array still false", async () => {
+    expect(await run(`const a = [1, 2]; export function test(): number { return (a instanceof Array) ? 1 : 0; }`)).toBe(
+      1,
+    );
+    expect(
+      await run(`const o = { x: 1 }; export function test(): number { return (o instanceof Array) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`<value> instanceof Object` returned **false** for compiler-native WasmGC-struct values — object literals, arrays, class instances — and for caught thrown values (the #1720 A6_T1 first-assertion dev-c surfaced). Per §7.3.20 OrdinaryHasInstance, every object reaches `Object.prototype`, so `instanceof Object` must be true.

## Root cause

Struct values are opaque externrefs at the host boundary. Two layers returned a spurious false:
1. `tryStaticInstanceOf` (identifiers.ts) — object-literal fell through to runtime; array hit `isBuiltinSubtype("Array","Object")` → false; user-class instance returned false.
2. runtime `__instanceof` (runtime.ts) — `v instanceof globalThis.Object` is false for an opaque struct externref (the `any`-typed / thrown path).

## Fix (localized)

- `tryStaticInstanceOf`: `Object` is a universal yes for builtin-symbol / user-class-instance / non-primitive object-typed LHS (guarded against primitives/null/undefined/any/unknown).
- `__instanceof`: a non-null WasmGC-struct receiver with the `Object` RHS returns 1. Primitives never reach this as structs, so `5 instanceof Object` stays false.

Spec: ECMA-262 §7.3.20, §20.1.3.

## Tests

- `tests/issue-1729.test.ts` — 9/9 (obj/array/class/thrown-obj/thrown-array/Error → true; thrown number/string → false; Array-RHS unchanged)
- `tests/issue-1455.test.ts` + `issue-1366a` + `issue-1366b` — 24/24 (no regression)
- Note: `tests/instanceof.test.ts` fails 7/7 on a clean checkout too (pre-existing harness issue, unrelated; user-class↔user-class instanceof untouched here).

Closes #1729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)