### PR TITLE
arch(descriptor-model): unified Object property-descriptor implementation spec

### DIFF
--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -14,7 +14,17 @@ goal: spec-completeness
 sprint: Backlog
 renumbered_from: 1335
 parent: 1328
+related: [1629a, 1629b, 1629c, 1630, 1631, 1130, 1364b]
 ---
+
+> **UNIFIED DESCRIPTOR-MODEL SPEC (architect, 2026-05-29).** The single
+> coherent implementation plan for the whole Object property-descriptor
+> family is the **"## Unified Implementation Plan — Object property-descriptor
+> model"** section at the bottom of this file. It supersedes the per-sub-cluster
+> notes above as the *sequencing* authority; the older sections remain as the
+> historical record of #1629a/#1629b (both merged) and the original mis-scoped
+> investigations. Tech lead schedules the slices (S1–S6); each is
+> independently shippable and net-positive on full CI.
 
 > **Sprint 56 close-out (2026-05-29):** carried over to Backlog. Two of the
 > three sub-clusters landed this sprint — **#1629a** (dynamic/non-literal
@@ -190,3 +200,450 @@ arg0 is an identifier, falling back to the shape table. Tests:
 overrides + default preservation, all green). Does not address
 sub-clusters #1629a (dynamic descriptor) or #1629c (Array/Function
 exotic) — those remain open.
+
+---
+
+# Unified Implementation Plan — Object property-descriptor model
+
+> Architect, 2026-05-29. Authoritative sequencing plan for the entire
+> `Object.{defineProperty,defineProperties,create,getOwnPropertyDescriptor,
+> getOwnPropertyDescriptors}` family plus Array/Function exotic
+> `defineProperty`. Branch each slice off fresh `origin/main`. Read this
+> top-to-bottom before claiming any slice — the slices share one model and
+> must land in order S1→S6 (each gated on the prior to avoid regressions).
+
+## Live baseline (results JSONL, HEAD `9ee8e921`, 2026-05-29)
+
+| bucket | pass | fail | other | total | rate |
+|--------|-----:|-----:|------:|------:|-----:|
+| `Object/defineProperty`            | 497 | 623 | 11 | 1131 | 43.9% |
+| `Object/defineProperties`          | 301 | 328 |  3 |  632 | 47.6% |
+| `Object/create`                    | 169 | 146 |  5 |  320 | 52.8% |
+| `Object/getOwnPropertyDescriptor`  | 266 |  43 |  1 |  310 | 85.8% |
+| `Object/getOwnPropertyDescriptors` |   8 |   8 |  2 |   18 | 44.4% |
+| **family total**                   | **1241** | **1148** | **22** | **2411** | 51.5% |
+
+Plus the ~80-test `Array/prototype/*` getter-observing cluster (#1130,
+`in-review`) which depends on the same accessor-read primitive S3 introduces.
+
+Fail-prefix breakdown (non-pass only): `defineProperty:15.2.3.6-4` 427,
+`defineProperty:15.2.3.6-3` 178, `defineProperties:15.2.3.7-6` 171,
+`defineProperties:15.2.3.7-5` 146, `defineProperty:15.2.3.6-2` 8, rest <10.
+
+Failure-mode histogram (sampled across the family, dominant first):
+1. **`accessed !== true`** (~70) — `defineProperty(o,k,{get})` then `o.k`
+   reads the struct field directly, the accessor never fires. *(read-back gap)*
+2. **`overrideData` / data not overwritten** (~50) — dynamic data descriptor
+   stored in the JS sidecar, but compiled `struct.get` reads the original
+   field value. *(write-back gap)*
+3. **`afterDeleted` / redefine-then-read** (~45) — same struct read-back gap
+   after `delete` + redefine.
+4. **`Expected TypeError, got "Expected an exception"`** (~60) — invariant
+   not enforced: a non-configurable/non-writable redefine that must throw
+   silently succeeds (the receiver is an exotic or the validation path is
+   not reached for that receiver kind).
+5. **`Getter/Setter must be a function: [object Object]`** (~16) — descriptor
+   `get`/`set` arrives as a WasmGC closure struct, not a JS callable.
+6. **`RangeError` on `length` redefine** (~3 named + within c4) — Array exotic
+   `length` validation (ArraySetLength).
+
+## Root cause (one model, three storage sites that disagree)
+
+There are **three** places a property's value+attributes can live, and the
+compiled read path only ever consults the first:
+
+- **(a) the WasmGC struct field** — `struct.get`/`struct.set`. This is what
+  compiled `o.k` reads/writes for a statically-typed plain-object receiver.
+  It has *no* attribute storage; every field is implicitly
+  `{writable,enumerable,configurable:true}` and is always a *data* property.
+- **(b) the JS-side descriptor sidecar** — `_wasmPropDescs`
+  (`src/runtime.ts:450`, per-object `Map<key,flags>` with bits
+  `_SC_WRITABLE|_SC_ENUMERABLE|_SC_CONFIGURABLE|_SC_DEFINED|_SC_ACCESSOR`,
+  defined at 763-767), the accessor store `_wasmStructAccessors` (457), and
+  the value sidecar `_wasmStructProps`. Populated by the runtime
+  `__defineProperty_*` helpers and read by host-side MOP operations
+  (`getOwnPropertyDescriptor`, `Object.keys`, `JSON.stringify`, the
+  `_wrapForHost` proxy traps).
+- **(c) compile-time tables** — `ctx.definedPropertyFlags`
+  (keyed `"varName:propName"`, set in `object-ops.ts`) and
+  `ctx.shapePropFlags` (per-struct-type, built post-body). Used by the
+  `getOwnPropertyDescriptor` / `propertyIsEnumerable` fast paths in
+  `expressions/calls.ts`.
+
+The runtime model (b) is already **substantially correct**: ToPropertyDescriptor
+(`_toPropertyDescriptorValidate`, runtime.ts:851) and ValidateAndApply
+(`_validatePropertyDescriptor`, runtime.ts:792) implement the ES §10.1.6.3
+invariants, freeze/seal flips them correctly, and #1629a/#1629b/#1631 wired the
+dynamic-descriptor and GOPD-read-back paths. **The unsolved problem is that
+compiled code bypasses (b) entirely**: it reads/writes the struct field (a)
+directly, so an accessor defined via `defineProperty` is invisible to a
+subsequent compiled `o.k`, and a dynamic data write lands only in the sidecar
+that compiled reads never consult. #1630 fixed the *write* direction for the
+host→struct path (`__sset_` setters); the missing direction is **struct read →
+descriptor model** when a property has a non-default descriptor.
+
+## The unified descriptor model (target end-state)
+
+**Single source of truth = the runtime sidecar (b), reached uniformly via a
+`[[Get]]`/`[[Set]]`/`[[DefineOwnProperty]]` shim whenever a property is known
+to carry a non-default descriptor.** Fast-path direct `struct.get`/`struct.set`
+is *retained* for the overwhelmingly common case of a never-`defineProperty`'d
+property (zero overhead, no regression). The model is the same in host mode and
+standalone/WASI mode; only the *backing primitive* differs:
+
+- **Host mode**: sidecar maps keyed on the JS object identity
+  (`_wasmPropDescs`/`_wasmStructAccessors`/`_wasmStructProps`), exactly as
+  today. Accessor invocation goes through `_maybeWrapCallable` so WasmGC
+  closure get/set become JS callables.
+- **Standalone/WASI mode** (no JS host): the same per-object descriptor table
+  is a WasmGC structure attached to the object — `(type $DescEntry (struct
+  (field $key (ref string)) (field $flags i32) (field $value (mut anyref))
+  (field $get (mut anyref)) (field $set (mut anyref))))` held in a
+  `(array (mut (ref null $DescEntry)))` reachable from the object via a
+  side `WeakMap`-equivalent: a global `(array (mut (ref null any)))` keyed by a
+  per-object monotonic id stored in a hidden i32 field, OR — simpler and
+  preferred for S1 — a dedicated `$DescSidecar` field appended to the object
+  struct, `null` until the first non-default define. Flags bit layout is
+  identical to the runtime `_SC_*` constants so the two modes share the
+  ValidateAndApply logic (port `_validatePropertyDescriptor` to a Wasm
+  function in S5; until then standalone falls back to the host helper when a
+  JS host is present and is documented-degraded otherwise).
+
+The **distinction key** that decides fast-path vs shim is a per-(receiver,
+property) "has-non-default-descriptor" bit:
+- **Compile time**: `ctx.definedPropertyFlags` already records every property a
+  given variable had `defineProperty` called on. Extend it to also record
+  *accessor-ness* (it stores flags; add the `_SC_ACCESSOR` bit at the
+  define site) so codegen can decide at the *read* site whether to emit the
+  accessor-aware shim.
+- **Runtime** (dynamic receiver / unknown at compile time): the sidecar's
+  presence of an entry for the key *is* the bit. The shim checks
+  `_wasmPropDescs.get(o)?.has(key)` (host) / `$DescSidecar != null` lookup
+  (standalone) and only then diverges from the field.
+
+This mirrors the existing **class-accessor** mechanism (`ctx.classAccessorSet`
++ `__<Struct>_get_<prop>` call in `property-access.ts:870-883`) — that is the
+exact pattern S3 generalises from class-declared accessors to
+`defineProperty`-declared ones.
+
+**Coordination with #1726 arguments-exotic / `[[ParameterMap]]`**: there is no
+`1726-*` file on disk yet. When it lands, its mapped-arguments model is a
+*separate exotic* `[[DefineOwnProperty]]` (CreateMappedArgumentsObject, ES
+§10.4.4) whose entries alias the formal-parameter slots. It must **reuse** the
+S1 descriptor-sidecar storage and the S3 accessor-read shim, but install its
+own per-index getter/setter pair (the parameter map) rather than the generic
+data field. Do **not** fork a second descriptor representation — the arguments
+exotic is a *producer* of sidecar accessor entries, consumed by the same shim.
+Flag the dependency in #1726 when it is written; until then S1–S6 are
+arguments-agnostic.
+
+## Slice sequence (S1–S6) — each independently shippable, net ≥ 0
+
+> Sequencing rule: S1 unifies storage, S2 the descriptor-read API, S3 the
+> compiled read path (the big lever), S4 invariants, S5 Array/Function exotics
+> (#1629c), S6 standalone parity. S3 depends on S1+S2; S5 depends on S4. Each
+> slice carries its own `tests/issue-1629-S{n}.test.ts` and must show full-CI
+> `net ≥ 0` with no single Object/Reflect bucket regressing > 0.
+
+### S1 — Consolidate descriptor storage + GOPD/GOPDs read-back  *(est. +35–55)*
+
+**Goal**: one canonical per-object descriptor table feeds *all* descriptor
+read APIs; `getOwnPropertyDescriptor`/`getOwnPropertyDescriptors` return
+spec-correct attributes for every define path (literal, dynamic, accessor).
+
+**Files**: `src/runtime.ts`, `src/codegen/expressions/calls.ts`,
+`src/codegen/object-ops.ts`.
+
+- Make `getOwnPropertyDescriptors` (`Object/getOwnPropertyDescriptors`,
+  8 fails) a thin loop over `ownKeys` + the existing single-key GOPD helper —
+  it currently has no dedicated path. Emit/route to a runtime
+  `__getOwnPropertyDescriptors(obj)` that returns a plain JS object mapping
+  each own key to the descriptor object built by the existing GOPD logic.
+- Unify the three compile-time/runtime read sources behind a single runtime
+  reader `_readOwnDescriptor(obj, key) -> PropertyDescriptor | undefined` that
+  checks, in order: accessor sidecar (`_wasmStructAccessors`) → value+flags
+  sidecar (`_wasmPropDescs` + `_wasmStructProps`) → live struct field via
+  `__sget_<key>` with default data flags. The existing GOPD fast path in
+  `calls.ts` (consults `ctx.definedPropertyFlags`, see #1629b note above) stays
+  as the compile-time shortcut; this is its runtime fallback for dynamic
+  receivers.
+- Ensure `defineProperty`'s inline-literal path *also* writes the sidecar
+  entry (today it only updates `ctx.definedPropertyFlags`/`shapePropFlags`) so
+  GOPD-via-runtime and GOPD-via-compile-time agree. The
+  `priorExistingFlags`/`newFlags` computation in `object-ops.ts:1137-1180`
+  already derives the right flags — additionally call the runtime
+  `__record_desc(obj, key, flags, valueOrAccessor)` so (b) is populated.
+
+**Edge cases**: Symbol keys (use `_normalizeDescKey`); a property defined then
+`delete`d must drop its sidecar entry; GOPDs ordering = `[[OwnPropertyKeys]]`
+order (integer-index ascending, then insertion-order strings, then symbols).
+
+**Tests**: `getOwnPropertyDescriptors/*` (18), the `15.2.3.6-3-*` GOPD
+read-back subset.
+
+### S2 — ToPropertyDescriptor / descriptor-validation completeness  *(est. +25–40)*
+
+**Goal**: `15.2.3.6-3-*` (ToPropertyDescriptor, 178 fails) and the
+`15.2.3.7-5/6-*` defineProperties coalescing clusters pass. This is the
+"descriptor *input* parsing" half; S1 was the "descriptor *output*" half.
+
+**Files**: `src/runtime.ts` (`_toPropertyDescriptorValidate`, 851;
+`_validatePropertyDescriptor`, 792), `src/codegen/object-ops.ts`
+(`compileObjectDefineProperties`, the dynamic fallback at ~2597).
+
+- `_toPropertyDescriptorValidate` already covers the data/accessor-mix
+  TypeError, getter/setter-must-be-callable, and field coalescing. Audit
+  against ES §10.1.6.3 step-by-step for the residual `15.2.3.6-3` fails:
+  - **HasProperty vs Get order** — the spec reads `enumerable`,
+    `configurable`, `value`, `writable`, `get`, `set` in that fixed order,
+    each guarded by HasProperty. When the descriptor is a *Proxy or exotic*,
+    the trap-invocation count/order is observable. Route through the host
+    `Object.getOwnPropertyDescriptor`-equivalent ordering for externref
+    descriptors; for struct descriptors the `getField` closure order must
+    match.
+  - **`defineProperties` Properties coercion** — ToObject(Properties), then
+    `[[OwnPropertyKeys]]` filtered to enumerable, building a *descriptor list*
+    first and only *then* applying (ES §20.1.2.3 / 19.1.2.3.1
+    ObjectDefineProperties: two-pass — gather all, validate all, then apply).
+    The current `__defineProperties` path applies as it iterates; convert to
+    gather-then-apply so a later-key validation TypeError doesn't leave
+    earlier keys mutated.
+- Wire the `wrapCallable` (`_maybeWrapCallable`) path #1629a added so struct
+  closure get/set never surface the `[object Object]` callable error (16 fails,
+  failure-mode 5).
+
+**Edge cases**: descriptor with getter that throws (must propagate); Symbol
+descriptor keys; `__proto__` as a data key (not prototype) in the descriptor.
+
+**Tests**: `defineProperty/15.2.3.6-3-*`, `defineProperties/15.2.3.7-{5,6}-*`,
+the `property-description-must-be-an-object-not-*` set.
+
+### S3 — Accessor-aware compiled read/write path  *(est. +90–140, the big lever)*
+
+**Goal**: a property carrying a non-default descriptor (accessor, or
+dynamically-written data value) is read/written through the descriptor model
+by *compiled* code, not the raw struct field. Kills failure-modes 1/2/3
+(`accessed !== true`, `overrideData`, `afterDeleted`) — the largest cluster.
+Also unblocks #1130 (Array getter-observing iteration shares this primitive).
+
+**Files**: `src/codegen/property-access.ts` (`compilePropertyAccess` ~971,
+`compileElementAccess`, the struct-field read at 884-915), the assignment
+lowering in `src/codegen/expressions.ts`/`statements.ts`,
+`src/codegen/object-ops.ts`.
+
+- **Read site** (`o.k` / `o[k]`): at compile time, if
+  `ctx.definedPropertyFlags` has an entry for `(receiverVar, k)` whose flags
+  include `_SC_ACCESSOR`, OR the receiver type is `any`/externref/unknown,
+  emit the **accessor-aware shim** instead of the bare `struct.get`:
+  ```wasm
+  ;; shim: prefer descriptor model when an entry exists, else fast field read
+  local.get $obj
+  <prop-as-externref>
+  call $__get_via_descriptor      ;; runtime: returns sidecar accessor result
+                                  ;; (invokes get()) / sidecar value / sentinel
+  ;; if sentinel "no-entry": fall through to struct.get fast path
+  ```
+  Model on the **existing class-accessor dispatch** in
+  `property-access.ts:870-883` (`ctx.classAccessorSet` + `__<Struct>_get_<p>`
+  call) — generalise it from class-declared accessors to a
+  `ctx.definedAccessorProps` set populated at the `defineProperty` site.
+  Where the receiver is statically a known struct **with no recorded
+  accessor/dynamic-descriptor for `k`**, keep the bare `struct.get`
+  (zero-overhead fast path — this is the no-regression guarantee).
+- **Runtime `__get_via_descriptor(obj, key)`**: host import that consults
+  `_wasmStructAccessors` (invoke getter via `_maybeWrapCallable`), then
+  `_wasmStructProps`/`_wasmPropDescs` value, then returns a distinguished
+  "no-entry" sentinel (a private externref singleton) so the compiled fast
+  path can branch. Symmetric `__set_via_descriptor(obj,key,val)` invokes a
+  sidecar setter or honours non-writable (no-op / throw-in-strict).
+- **Write site** (`o.k = v`): if `(receiverVar,k)` is accessor → call the
+  setter via `__set_via_descriptor`; if it is a recorded non-writable data
+  prop → strict-mode TypeError / sloppy no-op; else `struct.set` fast path
+  *and* keep the sidecar value in sync (so a later GOPD/host read agrees) via
+  the `__sset_` + `__record_desc` pair from S1/#1630.
+
+**Edge cases**: getter that mutates `o` re-entrantly; accessor defined on the
+*prototype* (must walk the chain — defer cross-prototype to #1364b, scope S3
+to own-property accessors); `delete o.k` must clear `definedAccessorProps` and
+the sidecar so the field fast-path resumes; element access `o[i]` with computed
+key where `i` is a known accessor index.
+
+**Risk**: this touches the property hot path. Mitigation: the shim is emitted
+**only** when the compile-time descriptor table says the property is
+non-default, or the receiver type is dynamic; the dense statically-typed
+struct path is byte-identical to today. Add a micro-benchmark to
+`benchmarks/` (struct field read in a tight loop) and confirm no codegen change
+for the no-descriptor case (diff the emitted Wasm for a plain `{a:0}.a` read).
+
+**Tests**: `defineProperty/15.2.3.6-4-*` plain-object subset (~the 188
+function-free / 83 plain of c4), `tests/issue-1629-S3.test.ts`
+(accessor read-back, dynamic data overwrite, delete-then-read). Re-run #1130
+suite — expect incidental gains.
+
+### S4 — Invariant enforcement on define (configurable/writable/extensible)  *(est. +40–70)*
+
+**Goal**: `defineProperty`/`defineProperties` throw `TypeError` exactly when ES
+§10.1.6.3 ValidateAndApplyPropertyDescriptor mandates (failure-mode 4,
+`Expected TypeError, got "Expected an exception"`, ~60). The runtime
+`_validatePropertyDescriptor` already implements this for the sidecar; the gap
+is that it is **not consulted** when the receiver is a typed struct whose
+property was never sidecar-recorded (so `existing === undefined` → "first
+definition" → no validation).
+
+**Files**: `src/runtime.ts` (`_validatePropertyDescriptor`, the
+`__defineProperty_*` helpers), `src/codegen/object-ops.ts`.
+
+- On **every** `defineProperty`, seed the sidecar with the property's *current*
+  effective descriptor *before* validating, so a struct field that exists with
+  default `{writable,enumerable,configurable:true}` is treated as an existing
+  configurable data property (redefine OK), while a property previously made
+  non-configurable via an earlier define correctly rejects. This requires S1's
+  "inline-literal path also writes the sidecar" so the first define of a
+  literal property is recorded.
+- `preventExtensions`/`seal`/`freeze` already flip flags (runtime.ts:4726-4763).
+  Add the **non-extensible new-property** rejection: defining a *new* key on a
+  non-extensible object throws (currently the new-key path skips the check —
+  see `nonExtensibleVars` guard in `object-ops.ts:1142`, extend to the runtime
+  helper for dynamic receivers).
+- Honour `Reflect.defineProperty` returning `false` (vs throwing) — same
+  validation, different failure surface; ensure both call sites share
+  `_validatePropertyDescriptor`.
+
+**Edge cases**: SameValue for non-writable redefine with equal value (already
+in `_validatePropertyDescriptor:839`); data↔accessor flip on non-configurable;
+`writable:false` then `writable:false` again (idempotent, no throw).
+
+**Tests**: `defineProperty/15.2.3.6-4-*` invariant subset, `freeze`/`seal`/
+`preventExtensions` redefine-throws cases, `Reflect/defineProperty/*`.
+
+### S5 — Array & Function exotic `defineProperty` (#1629c)  *(est. +120–180)*
+
+**Goal**: ES §10.4.2 (Array exotic `[[DefineOwnProperty]]`) and §10.2.4
+(Function `length`/`name` non-writable-configurable) semantics. ~156 array +
+~33 function fails in c4. Depends on S4 (invariant engine) being in place.
+
+**Files**: `src/runtime.ts`, `src/codegen/object-ops.ts`
+(`maybeEmitVecLengthGrowth`, 159; the externref/array define path),
+`src/codegen/array-methods.ts` (length read via [[Get]] for #1130 overlap).
+
+- **Array `length` exotic** (ES §10.4.2.4 ArraySetLength):
+  - `defineProperty(arr, "length", desc)` with a numeric value: ToUint32 must
+    equal ToNumber (else `RangeError` — failure-mode 6); if new len < old,
+    delete indices ≥ newLen *in descending order*, stopping (and setting len to
+    last+1) if a non-configurable index blocks the truncation; `writable:false`
+    makes `length` non-writable (subsequent index sets beyond it fail).
+  - In host mode, real JS arrays already implement this — route
+    `defineProperty(realArray, "length", ...)` straight to native
+    `Object.defineProperty` (the `_isArray` branch). The bug is the compiler
+    *intercepts* array receivers via `maybeEmitVecLengthGrowth` and the typed
+    `__vec_*` path, which bypasses native length semantics. Fix: when the
+    receiver is an array and the key is `"length"` or a canonical numeric
+    index, prefer the runtime `__defineProperty_desc` → native path over the
+    typed fast path; keep the typed fast path only for the
+    grow-by-index-assignment common case where no descriptor attributes differ
+    from default.
+  - **Array index exotic**: defining index `P` ≥ length on a non-writable-length
+    array → reject; defining a valid index updates length; an accessor on an
+    index makes array methods observe it (this is the #1130 link — S3's
+    accessor-read shim must apply to `arr[i]`).
+- **Function exotics** (ES §10.2.4): `length` and `name` are
+  `{writable:false, enumerable:false, configurable:true}`. `defineProperty(fn,
+  "length", {value})` is allowed (configurable) but `writable:true` on a
+  redefine without configurable-change rules apply. In host mode route function
+  receivers to native `Object.defineProperty`; the gap is the compiler treating
+  a compiled function (a WasmGC closure struct) as a plain struct — detect
+  `_isCallable`/closure receivers in the define path and route to the runtime
+  helper that operates on the host function wrapper.
+- **Bound functions**: defer `[[BoundTargetFunction]]` length composition to the
+  existing bound-function work (runtime.ts:6202) — scope S5 to plain
+  function/array exotics.
+
+**Edge cases**: `Object.defineProperty(arr, "0", {get})` then `arr.map(...)`
+(needs S3 accessor-read on indices); sparse array length truncation with a
+non-configurable hole; `arguments` exotic is **out of scope** (→ #1726, reuses
+S1/S3, separate exotic).
+
+**Risk**: highest-blast-radius slice (Array hot path + array-methods). Land
+**after** S3/S4 so the accessor-read primitive and invariant engine exist.
+Watch `Array/prototype/*` and `Array/length` buckets for regression; the
+typed `__vec_*` fast path for plain dense arrays must stay byte-identical.
+
+**Tests**: `defineProperty/15.2.3.6-4-*` array/function subset,
+`defineProperty/redefine-length-*`, `Array/prototype/*` (#1130), `Function/*`
+length/name prop-desc tests.
+
+### S6 — Standalone/WASI descriptor parity  *(est. +0 test262, dual-mode debt)*
+
+**Goal**: the descriptor model works without a JS host (per the dual-mode
+architecture principle). No new test262 (the runner uses host mode) but
+required so the feature is not host-only.
+
+**Files**: `src/runtime.ts` (the helpers being ported), a new
+`src/codegen/descriptor-runtime.ts` or additions to `object-ops.ts`.
+
+- Implement the `$DescSidecar` WasmGC field + `(array (ref null $DescEntry))`
+  table described in "The unified descriptor model" above, attached to
+  object structs lazily.
+- Port `_validatePropertyDescriptor` (pure flag logic, no host calls) to a
+  Wasm function so S4 invariants hold standalone.
+- `__get_via_descriptor`/`__set_via_descriptor`/`__record_desc` get
+  Wasm-native bodies that read/write the WasmGC table; accessor get/set are
+  `call_ref` on the stored closure refs.
+- Until S6 lands, standalone mode degrades gracefully: define records flags but
+  cannot invoke accessors without a host — document the gap in
+  `docs/architecture/` and gate behind the existing nativeStrings/standalone
+  detection.
+
+**Tests**: extend `tests/equivalence/` standalone variants; add a
+`--target wasi` smoke test compiling a `defineProperty({get})` program and
+asserting the getter fires.
+
+## Cross-cutting risks & guardrails (apply to every slice)
+
+1. **Object hot path** — S3 is the danger. The accessor-read shim must be
+   emitted *only* when the compile-time descriptor table flags the property as
+   non-default, or the receiver is dynamic. Prove no-regression by diffing the
+   emitted Wasm for a plain `{a:0}.a` read before/after; add a tight-loop
+   struct-read micro-benchmark to `benchmarks/`.
+2. **Full-CI net ≥ 0 per slice, mandatory.** Each PR runs full sharded
+   test262; `dev-self-merge` gate: `net_per_test > 0`, no single
+   `built-ins/Object/*` or `built-ins/Reflect/*` or `built-ins/Array/*` bucket
+   regressing. S5 specifically watch `Array/prototype/*` and `Array/length`.
+3. **Reflect parity** — `Reflect.{get,set,defineProperty,
+   getOwnPropertyDescriptor,ownKeys}` share the same model; a slice that fixes
+   `Object.X` must not diverge from `Reflect.X`. Add the matching Reflect test
+   path to each slice's scoped check.
+4. **Proxy interaction** — descriptor traps on a Proxy descriptor argument
+   (S2) and Proxy receivers (deferred) — keep `_wrapForHost`/`_hostProxyReverse`
+   semantics intact; do not let the sidecar shadow a Proxy trap.
+5. **Symbol keys** — every storage/read site uses `_normalizeDescKey`; never
+   stringify a Symbol into a template-literal export name (`__sget_`/`__sset_`
+   are string-key only by construction — Symbols stay sidecar-only).
+6. **Sidecar/field sync** — after S1 every define writes both the struct field
+   (when applicable, via `__sset_`) and the sidecar (`__record_desc`); a read
+   that consults one must agree with the other. The single canonical reader
+   `_readOwnDescriptor` (S1) is the reconciliation point.
+
+## Dependency order (for the tech lead)
+
+```
+S1 (storage + GOPD/GOPDs)  ──┐
+S2 (ToPropertyDescriptor)  ──┼──> S3 (compiled accessor read/write)  ──┐
+                              │                                         ├─> S5 (#1629c Array/Fn exotic)
+                             S4 (invariant enforcement) ────────────────┘
+S6 (standalone parity) depends on S1+S3+S4 (port to Wasm); no test262 gate.
+```
+
+S1 and S2 are parallelisable (different files mostly: S1 in calls.ts/runtime
+GOPD, S2 in runtime ToPropertyDescriptor). S3 needs both. S4 can run alongside
+S3 (different concern: validation vs read path) but must land before S5.
+#1130 should be re-tested after S3 and likely closes as incidental.
+
+## Aggregate estimate
+
+Conservative sum of per-slice lower bounds ≈ **+310** family tests; optimistic
+upper bounds ≈ **+525**, plus the ~80 #1130 Array-getter tests unblocked by S3.
+The family has 1,148 current fails, so the plan targets roughly 30–45% of the
+remaining gap landing across S1–S5 (the residual is cross-prototype descriptor
+inheritance #1364b, Proxy receivers, and bound-function exotics, all separate
+workstreams).


### PR DESCRIPTION
## Summary

Adds the single coherent **S1–S6 implementation plan** for the entire Object property-descriptor family to the #1629 umbrella issue (`plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md`). This is the largest single test262 lever — ~1,148 current fails across `Object/{defineProperty,defineProperties,create,getOwnPropertyDescriptor,getOwnPropertyDescriptors}` plus the ~80-test #1130 Array-getter cluster.

The work is **partially done** (#1629a dynamic-descriptor materialization, #1629b GOPD read-back, #1631 create descriptor-map all merged); this spec sequences the **remaining** work as one model rather than restarting.

## What the spec contains

- **Assessment** of what #1629a/#1629b/#1631 already provide and the precise residual: the runtime descriptor sidecar (`_wasmPropDescs`/`_wasmStructAccessors`, ValidateAndApply, ToPropertyDescriptor) is substantially correct, but **compiled code bypasses it** — `struct.get`/`struct.set` read/write the raw field, so accessors defined via `defineProperty` are invisible to a later `o.k` and dynamic data writes land only in the sidecar.
- **Unified descriptor model**: one canonical per-object table (JS sidecar in host mode, WasmGC `$DescEntry` table in standalone/WASI), shared `_SC_*` flag layout, fast-path direct field access retained for never-`defineProperty`'d properties (no-regression guarantee). Coordinates with (does not conflict with) the future #1726 arguments-exotic `[[ParameterMap]]` model.
- **Six independently-shippable slices** (S1 storage+GOPDs, S2 ToPropertyDescriptor, S3 accessor-aware compiled read/write — the big lever, S4 invariant enforcement, S5 Array/Function exotic = #1629c, S6 standalone parity) with per-slice file/function targets, Wasm IR patterns, edge cases, test-count estimates, and a dependency DAG.
- **Risk section**: full-CI net ≥ 0 mandated per slice; S3/S5 flagged as object/array hot-path; Reflect parity and Symbol-key/Proxy guardrails.

## Slice estimates

| slice | scope | est. test262 |
|-------|-------|-------------:|
| S1 | storage consolidation + GOPD/GOPDs | +35–55 |
| S2 | ToPropertyDescriptor / defineProperties coalescing | +25–40 |
| S3 | accessor-aware compiled read/write (the lever) | +90–140 |
| S4 | invariant enforcement (configurable/writable/extensible) | +40–70 |
| S5 | Array/Function exotic defineProperty (#1629c) | +120–180 |
| S6 | standalone/WASI parity | +0 (dual-mode debt) |

Aggregate ≈ **+310 to +525** family tests, plus ~80 #1130 Array-getter tests unblocked by S3.

Docs-only. `status: ready`, `sprint: Backlog` (large; tech lead schedules slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)