### PR TITLE
fix(#1629 S1): consolidate descriptor read-back for GOPD/GOPDs

### DIFF
--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -381,6 +381,33 @@ order (integer-index ascending, then insertion-order strings, then symbols).
 **Tests**: `getOwnPropertyDescriptors/*` (18), the `15.2.3.6-3-*` GOPD
 read-back subset.
 
+> **S1 STATUS — DONE (2026-05-29, dev-b).** Implemented in `src/runtime.ts`:
+> the canonical `_readOwnDescriptor(obj, prop, exports)` reader (sidecar
+> value/accessor → proto/static method allowlists → bare struct field via
+> `__sget_<key>` with default data flags) and `_ownStructKeys(obj, exports)`
+> own-key enumeration (mirrors `__getOwnPropertyNames` + `__getOwnPropertySymbols`;
+> a host-proxy `Reflect.ownKeys` does **not** surface typed struct fields, so a
+> dedicated enumerator is required). The single-key `__getOwnPropertyDescriptor`
+> now delegates to `_readOwnDescriptor`, and `__object_getOwnPropertyDescriptors`
+> is a loop over `_ownStructKeys` + `_readOwnDescriptor` (was: bare
+> `Object.getOwnPropertyDescriptors(obj)`, which returned `{}` for WasmGC
+> structs). Both forms now agree on bare fields, sidecar (defineProperty'd)
+> data/accessor props, and class methods. Tests: `tests/issue-1629-S1.test.ts`.
+>
+> The inline-literal `__record_desc` bullet was **not needed for agreement**:
+> `getOwnPropertyDescriptors` always routes through the runtime
+> `_readOwnDescriptor` reader (never the compile-time `ctx.definedPropertyFlags`
+> shortcut), and `defineProperty` already populates the `_wasmPropDescs` /
+> `_wasmStructProps` sidecar that the reader consults — so single-key and plural
+> read the same source. Two adjacent pre-existing defects observed and left to
+> their owners (out of S1 scope): (1) compiled member *dot*-access into a
+> struct-shaped descriptor result (`ds.a.value`) reads as a struct field rather
+> than a host property — a codegen member-access issue, not descriptor
+> read-back; bracket access and returning the whole object to the host both
+> work; (2) module-top-level `defineProperty` runs in the wasm start function
+> before `setExports`, so the dynamic-descriptor materialization throws
+> (start-fn/exports timing, #1629a / #1320 family). S2/S3 remain open.
+
 ### S2 — ToPropertyDescriptor / descriptor-validation completeness  *(est. +25–40)*
 
 **Goal**: `15.2.3.6-3-*` (ToPropertyDescriptor, 178 fails) and the

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2964,6 +2964,153 @@ function _getClassMethodBridge(classObj: object, name: string): Function {
   return fn;
 }
 
+/**
+ * (#1629 S1) Canonical own-property-descriptor reader for a WasmGC struct.
+ *
+ * This is the single read-back path shared by `Object.getOwnPropertyDescriptor`
+ * (single key) and `Object.getOwnPropertyDescriptors` (all keys). It resolves
+ * a descriptor from the three storage sites in spec-precedence order:
+ *   1. sidecar (`_wasmStructProps` value + `_wasmPropDescs` flags) — covers any
+ *      property that has been touched by `defineProperty` / dynamic write,
+ *      including accessor descriptors (`_SC_ACCESSOR`);
+ *   2. registered class proto-/static-method allowlists — spec method flags;
+ *   3. the bare WasmGC struct field via the exported `__sget_<key>` getter, with
+ *      default data-property flags (the zero-overhead fast path for fields that
+ *      were never `defineProperty`'d — the no-regression guarantee).
+ *
+ * Returns a PropertyDescriptor object, or `undefined` when `prop` is not an own
+ * property of `obj`. Caller is responsible for the non-struct fast path
+ * (`Object.getOwnPropertyDescriptor`) and for `ToPropertyKey` on `prop`.
+ */
+function _readOwnDescriptor(
+  obj: any,
+  prop: string | symbol,
+  exports: Record<string, Function> | undefined,
+): PropertyDescriptor | undefined {
+  // 1. Sidecar (dynamically added / defineProperty'd props).
+  const sc = _wasmStructProps.get(obj);
+  if (sc && prop in sc) {
+    const descs = _wasmPropDescs.get(obj);
+    const flags = descs?.get(_normalizeDescKey(prop)) ?? _SC_WRITABLE | _SC_ENUMERABLE | _SC_CONFIGURABLE | _SC_DEFINED;
+    if (flags & _SC_ACCESSOR) {
+      if (typeof prop === "symbol") {
+        const accessor = _wasmStructAccessors.get(obj)?.get(prop) as
+          | { get?: () => any; set?: (v: any) => void }
+          | undefined;
+        return {
+          get: accessor?.get,
+          set: accessor?.set,
+          enumerable: !!(flags & _SC_ENUMERABLE),
+          configurable: !!(flags & _SC_CONFIGURABLE),
+        };
+      }
+      return {
+        get: (sc as any)[`__get_${prop}`],
+        set: (sc as any)[`__set_${prop}`],
+        enumerable: !!(flags & _SC_ENUMERABLE),
+        configurable: !!(flags & _SC_CONFIGURABLE),
+      };
+    }
+    return {
+      value: (sc as any)[prop as any],
+      writable: !!(flags & _SC_WRITABLE),
+      enumerable: !!(flags & _SC_ENUMERABLE),
+      configurable: !!(flags & _SC_CONFIGURABLE),
+    };
+  }
+  const propStr = String(prop);
+  // 2a. Registered class prototype method (#1364a): spec non-enumerable,
+  // configurable, writable.
+  const protoMethods = _prototypeMethodNames.get(obj);
+  if (protoMethods !== undefined && protoMethods.includes(propStr) && !_isDeletedClassProp(obj, propStr)) {
+    return {
+      value: _getProtoMethodBridge(obj, propStr),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    };
+  }
+  // 2b. Registered class-object static method (#1395).
+  const staticMethods = _staticMethodNames.get(obj);
+  if (staticMethods !== undefined && staticMethods.includes(propStr) && !_isDeletedClassProp(obj, propStr)) {
+    return {
+      value: _getClassMethodBridge(obj, propStr),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    };
+  }
+  // 3. Bare struct field via exported getter — zero-overhead data-property path.
+  const fieldNames = _getStructFieldNames(obj, exports) ?? [];
+  if (fieldNames.includes(propStr)) {
+    const getter = exports?.[`__sget_${propStr}`];
+    const value = typeof getter === "function" ? getter(obj) : undefined;
+    const descs = _wasmPropDescs.get(obj);
+    const flags = descs?.get(propStr) ?? _SC_WRITABLE | _SC_ENUMERABLE | _SC_CONFIGURABLE | _SC_DEFINED;
+    return {
+      value,
+      writable: !!(flags & _SC_WRITABLE),
+      enumerable: !!(flags & _SC_ENUMERABLE),
+      configurable: !!(flags & _SC_CONFIGURABLE),
+    };
+  }
+  return undefined; // not an own property
+}
+
+/**
+ * (#1629 S1) Own-key enumeration for a WasmGC struct, mirroring the union of
+ * `__getOwnPropertyNames` (string keys) and `__getOwnPropertySymbols`. Used by
+ * `Object.getOwnPropertyDescriptors`, which must visit every own key.
+ *
+ * `Reflect.ownKeys(_wrapForHost(obj))` can NOT be used here: the host proxy's
+ * `ownKeys` trap does not expose the typed WasmGC struct fields (they are only
+ * reachable via `_getStructFieldNames` + `__sget_<key>`), so a plain struct
+ * would enumerate as `[]`.
+ */
+function _ownStructKeys(obj: any, exports: Record<string, Function> | undefined): (string | symbol)[] {
+  const keys: (string | symbol)[] = [];
+  const push = (k: string | symbol) => {
+    if (!keys.includes(k)) keys.push(k);
+  };
+  // String keys: class allowlist OR struct field names, then sidecar + native.
+  const protoMethods = _prototypeMethodNames.get(obj);
+  const staticMethods = _staticMethodNames.get(obj);
+  if (protoMethods !== undefined) {
+    for (const n of protoMethods) if (!_isDeletedClassProp(obj, n)) push(n);
+  } else if (staticMethods !== undefined) {
+    for (const n of staticMethods) if (!_isDeletedClassProp(obj, n)) push(n);
+  } else {
+    for (const n of _getStructFieldNames(obj, exports) ?? []) push(n);
+  }
+  const sc = _wasmStructProps.get(obj);
+  if (sc) {
+    for (const k of Object.getOwnPropertyNames(sc)) {
+      if (k.startsWith("__get_") || k.startsWith("__set_")) continue;
+      push(k);
+    }
+  }
+  // Native JS string props added directly to the struct object.
+  try {
+    for (const k of Object.getOwnPropertyNames(obj)) push(k);
+  } catch {
+    // ignore if not enumerable on this object
+  }
+  // Symbol keys: sidecar symbols + accessor-table symbols + native symbols.
+  if (sc) {
+    for (const s of Object.getOwnPropertySymbols(sc)) push(s);
+  }
+  const acc = _wasmStructAccessors.get(obj);
+  if (acc) {
+    for (const s of acc.keys()) if (typeof s === "symbol") push(s);
+  }
+  try {
+    for (const s of Object.getOwnPropertySymbols(obj)) push(s);
+  } catch {
+    // ignore
+  }
+  return keys;
+}
+
 function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): any {
   if (obj == null || typeof obj !== "object") return obj;
   if (!_isWasmStruct(obj)) return obj;
@@ -5566,85 +5713,9 @@ assert._isSameValue = isSameValue;
           if (!_isWasmStruct(obj)) {
             return Object.getOwnPropertyDescriptor(obj, prop);
           }
-          // WasmGC struct: check sidecar properties first (dynamically added props)
-          const sc = _wasmStructProps.get(obj);
-          if (sc && prop in sc) {
-            const descs = _wasmPropDescs.get(obj);
-            const flags =
-              descs?.get(_normalizeDescKey(prop)) ?? _SC_WRITABLE | _SC_ENUMERABLE | _SC_CONFIGURABLE | _SC_DEFINED;
-            if (flags & _SC_ACCESSOR) {
-              if (typeof prop === "symbol") {
-                const accessor = _wasmStructAccessors.get(obj)?.get(prop);
-                return {
-                  get: accessor?.get,
-                  set: accessor?.set,
-                  enumerable: !!(flags & _SC_ENUMERABLE),
-                  configurable: !!(flags & _SC_CONFIGURABLE),
-                };
-              }
-              return {
-                get: sc[`__get_${prop}`],
-                set: sc[`__set_${prop}`],
-                enumerable: !!(flags & _SC_ENUMERABLE),
-                configurable: !!(flags & _SC_CONFIGURABLE),
-              };
-            }
-            return {
-              value: sc[prop],
-              writable: !!(flags & _SC_WRITABLE),
-              enumerable: !!(flags & _SC_ENUMERABLE),
-              configurable: !!(flags & _SC_CONFIGURABLE),
-            };
-          }
-          // Check struct fields via exported getters
-          const exports = callbackState?.getExports();
-          const fieldNames = _getStructFieldNames(obj, exports) ?? [];
-          const propStr = String(prop);
-          // #1364a — registered class prototype + proto-method allowlist:
-          // class instance methods are spec-non-enumerable, configurable,
-          // writable. Without this arm, `Object.getOwnPropertyDescriptor(
-          // C.prototype, "m")` returned `undefined` (key isn't in fields/
-          // sidecar) and `verifyProperty`-style tests under
-          // `language/{statements,expressions}/class/elements/` failed at
-          // their first descriptor lookup. Returns a method descriptor
-          // backed by the cached bridge so subsequent
-          // `assert.sameValue(c.m, C.prototype.m)` assertions also pass.
-          const protoMethods = _prototypeMethodNames.get(obj);
-          if (protoMethods !== undefined && protoMethods.includes(propStr) && !_isDeletedClassProp(obj, propStr)) {
-            return {
-              value: _getProtoMethodBridge(obj, propStr),
-              writable: true,
-              enumerable: false,
-              configurable: true,
-            };
-          }
-          // (#1395) Static-method receiver: when `obj` is a registered class
-          // object (lazily materialized by `emitLazyClassObjectGet`),
-          // `Object.getOwnPropertyDescriptor(C, "m")` must return a method
-          // descriptor with the spec-correct flags. Mirrors the
-          // proto-methods arm above.
-          const staticMethods = _staticMethodNames.get(obj);
-          if (staticMethods !== undefined && staticMethods.includes(propStr) && !_isDeletedClassProp(obj, propStr)) {
-            return {
-              value: _getClassMethodBridge(obj, propStr),
-              writable: true,
-              enumerable: false,
-              configurable: true,
-            };
-          }
-          if (fieldNames.includes(propStr)) {
-            const getter = exports?.[`__sget_${propStr}`];
-            const value = typeof getter === "function" ? getter(obj) : undefined;
-            const descs = _wasmPropDescs.get(obj);
-            const flags = descs?.get(propStr) ?? _SC_WRITABLE | _SC_ENUMERABLE | _SC_CONFIGURABLE | _SC_DEFINED;
-            return {
-              value,
-              writable: !!(flags & _SC_WRITABLE),
-              enumerable: !!(flags & _SC_ENUMERABLE),
-              configurable: !!(flags & _SC_CONFIGURABLE),
-            };
-          }
-          return undefined; // not an own property
+          // (#1629 S1) WasmGC struct: single canonical read-back path, shared
+          // with Object.getOwnPropertyDescriptors.
+          return _readOwnDescriptor(obj, prop, callbackState?.getExports());
         };
       if (name === "__getOwnPropertyNames")
         return (obj: any) => {
@@ -6222,8 +6293,30 @@ assert._isSameValue = isSameValue;
       // Object.fromEntries(iterable) — create object from entries (#965)
       if (name === "__object_fromEntries") return (iterable: any): any => Object.fromEntries(iterable);
       // Object.getOwnPropertyDescriptors(obj) — all own descriptors (#965)
+      // (#1629 S1) For WasmGC structs, enumerate own keys and read each
+      // descriptor through the same canonical path as the single-key
+      // Object.getOwnPropertyDescriptor, so the two agree on struct fields,
+      // sidecar (defineProperty'd) props, accessors, and class methods.
       if (name === "__object_getOwnPropertyDescriptors")
-        return (obj: any): any => Object.getOwnPropertyDescriptors(obj);
+        return (obj: any): any => {
+          // ES §20.1.2.9 → ToObject(O) (§7.1.18) throws on null/undefined.
+          if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
+          if (!_isWasmStruct(obj)) return Object.getOwnPropertyDescriptors(obj);
+          const exports = callbackState?.getExports();
+          const result: Record<string | symbol, PropertyDescriptor> = {};
+          for (const key of _ownStructKeys(obj, exports)) {
+            const desc = _readOwnDescriptor(obj, key, exports);
+            if (desc !== undefined) {
+              // Per spec, the result is an ordinary object whose own
+              // properties are enumerable, writable, configurable data
+              // properties holding each descriptor object. Plain assignment
+              // creates exactly such a property and keeps the keys reachable
+              // by the host property-get path that compiled member access uses.
+              (result as any)[key] = desc;
+            }
+          }
+          return result;
+        };
       // Object.groupBy(iterable, keyFn) — ES2024 grouping (#965)
       // (#1382) keyFn is invoked as `keyFn(value, index)` — arity 2.
       // Wrap Wasm-closure keyFn before handing it to the native engine.

--- a/tests/issue-1629-S1.test.ts
+++ b/tests/issue-1629-S1.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #1629 descriptor slice S1 — storage consolidation + the canonical
+// Object.getOwnPropertyDescriptor / Object.getOwnPropertyDescriptors read-back.
+//
+// S1 unifies the descriptor read path so the single-key and the plural form
+// agree on bare struct fields, sidecar (defineProperty'd) props, and accessors.
+// These tests assert the *host-observable* descriptor objects the runtime
+// produces — exactly what a test262 `return`-style harness inspects.
+//
+// Notes on scope:
+//   * Compiled member access *into* the returned descriptor object
+//     (`ds.a.value` where `ds` carries a struct-shaped TS type) is a separate,
+//     pre-existing codegen concern and is intentionally not exercised here.
+//   * All object construction + defineProperty calls are kept *inside* `test()`
+//     so they run post-instantiation (after setExports). Module-top-level
+//     defineProperty runs in the wasm start function before the struct getters
+//     are wired — a pre-existing start-fn/exports-timing limitation outside S1.
+
+async function runHost(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile error: ${r.errors[0]?.message}`);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  // Make __sget_* struct getters discoverable to the runtime, as the real
+  // test262 runner does after instantiation.
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#1629 S1 — getOwnPropertyDescriptors read-back", () => {
+  it("returns spec descriptors for bare struct fields (zero-overhead fast path)", async () => {
+    const ds = (await runHost(
+      `export function test(): any { const o = { a: 1, b: 2 }; return Object.getOwnPropertyDescriptors(o) as any; }`,
+    )) as Record<string, PropertyDescriptor>;
+    expect(Object.keys(ds).sort()).toEqual(["a", "b"]);
+    expect(ds.a).toEqual({ value: 1, writable: true, enumerable: true, configurable: true });
+    expect(ds.b).toEqual({ value: 2, writable: true, enumerable: true, configurable: true });
+  });
+
+  it("agrees with single-key getOwnPropertyDescriptor on a bare field", async () => {
+    const single = await runHost(
+      `export function test(): any { const o = { a: 1, b: 2 }; return Object.getOwnPropertyDescriptor(o, "a") as any; }`,
+    );
+    const ds = (await runHost(
+      `export function test(): any { const o = { a: 1, b: 2 }; return Object.getOwnPropertyDescriptors(o) as any; }`,
+    )) as Record<string, PropertyDescriptor>;
+    expect(ds.a).toEqual(single);
+  });
+
+  it("reflects defineProperty'd flags on an existing field — single and plural agree (S1 contract)", async () => {
+    // The core S1 guarantee: the single-key and plural read-back paths agree.
+    const body = `const o = { a: 1 };
+       Object.defineProperty(o, "a", { value: 5, writable: false, enumerable: false });`;
+    const single = (await runHost(
+      `export function test(): any { ${body} return Object.getOwnPropertyDescriptor(o, "a") as any; }`,
+    )) as PropertyDescriptor;
+    const ds = (await runHost(
+      `export function test(): any { ${body} return Object.getOwnPropertyDescriptors(o) as any; }`,
+    )) as Record<string, PropertyDescriptor>;
+    // The explicitly-set flags are reflected; both forms produce the same descriptor.
+    expect(single).toMatchObject({ value: 5, writable: false, enumerable: false });
+    expect(ds.a).toEqual(single);
+  });
+
+  it("includes a dynamically-added (defineProperty) property in the plural form", async () => {
+    const ds = (await runHost(
+      `export function test(): any {
+         const o: any = { a: 1 };
+         Object.defineProperty(o, "y", { value: 9, enumerable: false, writable: true });
+         return Object.getOwnPropertyDescriptors(o) as any;
+       }`,
+    )) as Record<string, PropertyDescriptor>;
+    expect(Object.keys(ds).sort()).toEqual(["a", "y"]);
+    expect(ds.a).toEqual({ value: 1, writable: true, enumerable: true, configurable: true });
+    expect(ds.y).toMatchObject({ value: 9, writable: true, enumerable: false });
+  });
+
+  it("getOwnPropertyDescriptors throws TypeError on null/undefined (ToObject)", async () => {
+    await expect(
+      runHost(`export function test(): any { return Object.getOwnPropertyDescriptors(null as any) as any; }`),
+    ).rejects.toThrow();
+    await expect(
+      runHost(`export function test(): any { return Object.getOwnPropertyDescriptors(undefined as any) as any; }`),
+    ).rejects.toThrow();
+  });
+
+  it("returns an empty object for a struct with no own keys", async () => {
+    const ds = (await runHost(
+      `export function test(): any { return Object.getOwnPropertyDescriptors({} as any) as any; }`,
+    )) as Record<string, PropertyDescriptor>;
+    expect(Object.keys(ds)).toEqual([]);
+  });
+
+  it("still delegates to native for plain non-struct host values", async () => {
+    const ds = (await runHost(
+      `export function test(): any { return Object.getOwnPropertyDescriptors([1, 2] as any) as any; }`,
+    )) as Record<string, PropertyDescriptor>;
+    // Array own keys: indices + length.
+    expect(ds["0"]).toEqual({ value: 1, writable: true, enumerable: true, configurable: true });
+    expect(ds["1"]).toEqual({ value: 2, writable: true, enumerable: true, configurable: true });
+    expect(ds.length).toMatchObject({ value: 2, writable: true });
+  });
+});


### PR DESCRIPTION
**Descriptor slice S1 of #1629** — storage consolidation +
`Object.getOwnPropertyDescriptor` / `Object.getOwnPropertyDescriptors` read-back.

## What

Adds a single canonical descriptor reader and own-key enumerator in
`src/runtime.ts`, and routes both descriptor read APIs through them so the
single-key and plural forms agree on every define path.

- **`_readOwnDescriptor(obj, prop, exports)`** — sidecar value/accessor
  (`_wasmStructProps` + `_wasmPropDescs` / `_wasmStructAccessors`) → proto/static
  class-method allowlists → bare struct field via `__sget_<key>` with default
  data-property flags. The bare-field path is the zero-overhead fast path for
  never-`defineProperty`'d props — the no-regression guarantee.
- **`_ownStructKeys(obj, exports)`** — own-key enumeration mirroring
  `__getOwnPropertyNames` + `__getOwnPropertySymbols`. A host-proxy
  `Reflect.ownKeys` does **not** surface typed WasmGC struct fields, so plain
  structs would otherwise enumerate as `[]`.
- **`__object_getOwnPropertyDescriptors`** was a bare
  `Object.getOwnPropertyDescriptors(obj)` (returned `{}` for WasmGC structs);
  now a loop over `_ownStructKeys` + `_readOwnDescriptor`, with the spec
  ToObject `TypeError` on null/undefined and native delegation for
  non-struct values.
- **`__getOwnPropertyDescriptor`** single-key handler now delegates to the
  shared reader — pure refactor, no behavior change.

## Scope

Strictly S1. Does **not** touch S3's accessor-aware read path. Two adjacent
pre-existing defects observed and left to their owners (documented in the
issue file): compiled member *dot*-access into a struct-shaped descriptor
result (`ds.a.value`) reads as a struct field (codegen member-access, not
read-back), and module-top-level `defineProperty` runs in the wasm start
function before `setExports` (#1629a / #1320 start-fn/exports timing).

## Tests

`tests/issue-1629-S1.test.ts` (7 cases) — host-observable descriptor objects,
single↔plural agreement, defineProperty'd flags, dynamic-add, ToObject throw,
empty struct, native-array delegation. Existing `issue-1629b`, `issue-1364a`,
`define-property-patterns`, `issue-786`, `issue-1648`, `issue-1395`,
`issue-1364b`, `issue-1462`, `issue-1567` all green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)