### PR TITLE
chore(infra): provision worktree node_modules + format:check in pre-push

### DIFF
--- a/.claude/hooks/provision-worktree.sh
+++ b/.claude/hooks/provision-worktree.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Provision agent worktrees with node_modules so the pre-push hooks
+# (typecheck, prettier format:check, lint) actually run.
+#
+# Why: agent worktrees are created with `git worktree add` and come up WITHOUT
+# node_modules. The pre-push hook then errors ("tsc: not found"), so agents
+# `--no-verify` past it — which also skips lint-staged + format:check, so
+# formatting / type drift reaches CI instead of being caught locally (see the
+# #914 prettier-drift miss, 2026-05-29). Symlinking the main checkout's
+# node_modules into each worktree is fast (no per-worktree install) and gives
+# the worktree the SAME pinned tool versions as CI (npx-fetched versions can
+# format differently).
+#
+# Wired as a PostToolUse hook on `git worktree add`; also safe to run manually.
+# Scans all worktrees and symlinks node_modules where missing (idempotent).
+
+MAIN="/workspace"
+[ -d "$MAIN/node_modules" ] || exit 0   # nothing to share yet
+
+# Enumerate worktrees from the main checkout; symlink node_modules where absent.
+git -C "$MAIN" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' | while read -r wt; do
+  [ "$wt" = "$MAIN" ] && continue
+  [ -d "$wt" ] || continue
+  # Skip if node_modules already present (real dir OR existing symlink).
+  [ -e "$wt/node_modules" ] && continue
+  if ln -s "$MAIN/node_modules" "$wt/node_modules" 2>/dev/null; then
+    echo "[provision-worktree] linked node_modules -> $wt"
+  fi
+done
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -135,6 +135,17 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "if": "Bash(git worktree add*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/provision-worktree.sh",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "FileChanged": [

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -138,6 +138,29 @@ fi
 rm -f "$tmp_tc" "$tmp_lint"
 echo "Pre-push: typecheck + lint OK."
 
+# ---------- (3b) prettier format check -----------------------------------
+#
+# Catch formatting drift locally — this is the SAME gate CI's `quality` job
+# runs (`pnpm run format:check` = prettier --check). Previously formatting
+# only got caught in CI (e.g. #914's typeof-delete.ts drift) because the
+# on-edit/lint-staged prettier is best-effort + bypassable. Worktrees now get
+# node_modules symlinked (provision-worktree.sh) so the PINNED prettier runs
+# here — matching CI exactly. Skip with --no-verify (CI is the backstop).
+
+if grep -q '"format:check"' package.json 2>/dev/null; then
+  echo "Pre-push: prettier format:check ..."
+  fmt_out=$(pnpm run format:check 2>&1)
+  if [ $? -ne 0 ]; then
+    echo "Pre-push: format:check FAILED. Offending files:"
+    echo "$fmt_out" | grep -iE '\[warn\]|^\S+\.ts$' | head -30
+    echo ""
+    echo "Fix with: pnpm run format:write   (or: npx prettier --write <file>)"
+    echo "Then re-push. (Or --no-verify to defer to CI.)"
+    exit 1
+  fi
+  echo "Pre-push: format:check OK."
+fi
+
 # ---------- (4) sync conformance numbers in docs -------------------------
 #
 # Keeps README.md / ROADMAP.md / CLAUDE.md / plan/goals/goal-graph.md in


### PR DESCRIPTION
Closes the loop behind #914'\''s CI-only prettier miss + the recurring `--no-verify` habit.

1. **`.claude/hooks/provision-worktree.sh`** — symlinks the main checkout'\''s `node_modules` into every worktree missing it (idempotent; PINNED tool versions = CI). Wired as a **PostToolUse hook on `git worktree add`** so new worktrees auto-provision. (Smoke-tested: linked 8 existing worktrees.)
2. **`.husky/pre-push` (3b)** — adds `pnpm run format:check` (the SAME prettier gate CI'\''s quality job runs). With `node_modules` now present, the pre-push typecheck+lint+format actually run → drift caught locally, removing the reason to `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)