### PR TITLE
fix(#389): native-messaging host echoes stdin verbatim (no wrapper)

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -52,8 +52,10 @@ launch it (see "Run it" below).
 `process.stdin.read` read-until loops (a `readExact` helper handles short
 reads), logs diagnostics to **stderr** (so they never corrupt the stdout
 protocol stream), and writes a framed JSON response, looping until stdin
-reaches EOF. The application logic — here, echoing the received body inside a
-wrapper object — is the part you'd replace for a real host.
+reaches EOF. The application logic — here, a **strict echo** that writes the
+received body back verbatim, byte-for-byte, with no wrapper and no added bytes
+(so the stdin→stdout round-trip is directly observable) — is the part you'd
+replace for a real host that parses the body and builds a structured response.
 
 ## Build to `.wasm`
 

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -97,10 +97,12 @@ export function main(): void {
     // 4 + declaredLen.
     console.error(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}`);
 
-    // Application logic: echo the received JSON body back inside a wrapper
-    // object. Real hosts would parse `bodyStr`, dispatch on a command field,
-    // and build a structured response.
-    const response = `{"received":${bodyStr},"runtime":"js2wasm+wasi"}`;
-    writeMessage(response);
+    // Strict echo: write the received body back verbatim, byte-for-byte, with
+    // no wrapper and no added bytes. This makes the demo a true round-trip
+    // proof — what Chrome sends in is exactly what comes back out, so the
+    // stdin->stdout fidelity of the WASI build is directly observable.
+    // A real host would instead parse `bodyStr`, dispatch on a command field,
+    // and build a structured response here.
+    writeMessage(bodyStr);
   }
 }

--- a/examples/native-messaging/smoke-test.sh
+++ b/examples/native-messaging/smoke-test.sh
@@ -41,9 +41,11 @@ echo "== Running under wasmtime ($(wasmtime --version)) =="
 printf "$FRAME" | wasmtime $WASMTIME_FLAGS "$WASM" >"$STDOUT_FILE" 2>"$STDERR_FILE"
 
 # ---- Expected stdout frame -------------------------------------------------
-# Body is the echo wrapper the host builds; its length is the LE prefix.
-EXPECTED_BODY='{"received":{"ping":true},"runtime":"js2wasm+wasi"}'
-BODY_LEN=${#EXPECTED_BODY}            # 51 → prefix 0x33 0x00 0x00 0x00 (computed, not hardcoded)
+# Strict echo: the response body is the received body verbatim, byte-for-byte.
+# So the expected stdout body equals the input body and its length (13) is the
+# LE prefix — a true round-trip with no added bytes.
+EXPECTED_BODY='{"ping":true}'
+BODY_LEN=${#EXPECTED_BODY}            # 13 → prefix 0x0d 0x00 0x00 0x00 (computed, not hardcoded)
 EXPECTED_STDOUT_FILE="$OUT_DIR/expected_stdout.bin"
 {
   # 4-byte little-endian uint32 length prefix.

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -176,8 +176,10 @@ export function main(): void {
     const result = compile(src, { fileName: "host.ts", target: "wasi" });
     expect(result.success).toBe(true);
 
+    // The shipped host echoes the received body verbatim (byte-for-byte, no
+    // wrapper), so the response body equals the input body exactly.
     const out = runWasiRaw(result.binary, frame('{"cmd":"ping"}'));
-    const expectedBody = '{"received":{"cmd":"ping"},"runtime":"js2wasm+wasi"}';
+    const expectedBody = '{"cmd":"ping"}';
     expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
     expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
   });


### PR DESCRIPTION
## What

@guest271314 [pointed out](https://github.com/loopdive/js2/issues/389#issuecomment-4569986127) that the native-messaging example doesn't strictly echo the input — `host.ts` wrapped the received body:

```js
`{"received":${bodyStr},"runtime":"js2wasm+wasi"}`
```

…adding bytes. The whole point of the demo is to prove a **byte-exact stdin→stdout round-trip** through the WASI build, and the wrapper obscured that.

## Change

- `host.ts`: application logic is now a **strict echo** — `writeMessage(bodyStr)` re-frames and returns the received body verbatim, byte-for-byte, no wrapper, no added bytes. ("A real host would parse/dispatch/build a structured response here" kept as a comment.)
- `smoke-test.sh`: `EXPECTED_BODY` is now the input body (`{"ping":true}`, 13-byte frame) — a true round-trip assertion.
- `tests/issue-1530.test.ts`: shipped-example assertion expects verbatim echo (`{"cmd":"ping"}`). Inline synthetic-host framing unit test left as-is.
- `README.md`: describes the strict-echo behavior.

## Verification

`npx vitest run tests/issue-1530.test.ts` → 5/5 pass; the compiled shipped host round-trips `{"cmd":"ping"}` byte-for-byte under the WASI polyfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)