### PR TITLE
chore(workspace): preserve session memory + #1636-S1 strict-this regression note

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -41,6 +41,7 @@
 - [feedback_bypass_permissions.md](feedback_bypass_permissions.md) — Always use bypassPermissions mode when spawning agents
 - [feedback_dev_self_serve_tasklist.md](feedback_dev_self_serve_tasklist.md) — Devs claim next task from TaskList after merge; no re-dispatch
 - [feedback_tasklist_always_populated.md](feedback_tasklist_always_populated.md) — Populate TaskList at sprint start AND whenever a new issue is added mid-sprint; empty queue = agents spin idle
+- [feedback_sprint_autofill_es3_es5.md](feedback_sprint_autofill_es3_es5.md) — When sprint queue runs dry, auto-pull ES3/ES5-fixing tasks into the current sprint
 - [feedback_compact_before_sprint.md](feedback_compact_before_sprint.md) — Run /compact at sprint boundaries to reset context and control token burn
 - [feedback_context_discipline.md](feedback_context_discipline.md) — Don't re-check state; split planning/execution sessions; write handoffs to plan/agent-context/tech-lead.md
 - [feedback_team_comm_channels.md](feedback_team_comm_channels.md) — Dev status via TaskUpdate not verbose SendMessage; shutdown handoffs via agent-context files
@@ -92,6 +93,7 @@
 - [feedback_nothing_impossible.md](feedback_nothing_impossible.md) — Don't label features impossible — find the compilation strategy
 - [feedback_compile_away.md](feedback_compile_away.md) — Compile away, don't emulate — resolve JS semantics statically, zero runtime overhead
 - [feedback_mimic_node_worker_apis.md](feedback_mimic_node_worker_apis.md) — No bespoke builtins (readStdin/writeStdout); expose standard Node.js (process.stdin/stdout) / Web Worker (postMessage) APIs and compile them to WASI
+- [feedback_external_comments_first_person.md](feedback_external_comments_first_person.md) — GitHub/external comments in first-person singular ("I"), never "we"
 - [feedback_no_nuclear_option.md](feedback_no_nuclear_option.md) — Never take destructive shortcuts without consent
 - [feedback_wait_for_answer.md](feedback_wait_for_answer.md) — Ask then STOP — never act on assumed "yes" in the same message
 - [feedback_check_before_cleanup.md](feedback_check_before_cleanup.md) — Check worktree diffs before removing

--- a/.claude/memory/feedback_external_comments_first_person.md
+++ b/.claude/memory/feedback_external_comments_first_person.md
@@ -1,0 +1,14 @@
+---
+name: feedback_external_comments_first_person
+description: "Write GitHub / external-facing comments in first-person singular (\"I\"), never \"we\""
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8d9a5e7c-ee71-42b6-8e54-753ae07c8f9f
+---
+
+When drafting GitHub issue/PR comments or any external-facing message (e.g. replies to guest271314 on issue #389), use **first-person singular — "I", "my"** — not "we"/"our". "We" reads funny in this context.
+
+**Why:** the project lead's stated preference (2026-05-29) — the maintainer voice should be singular, not a royal/team "we".
+
+**How to apply:** before posting any external comment, sweep for "we"/"our"/"us" and rewrite as "I"/"my"/"me" where it reads naturally. Still never post to an external contributor's issue without the lead's explicit go-ahead ([[feedback_no_github_issue_comments]]).

--- a/.claude/memory/feedback_no_github_issue_comments.md
+++ b/.claude/memory/feedback_no_github_issue_comments.md
@@ -12,7 +12,7 @@ Two related rules about GitHub issues:
 **1. Never mutate user-opened GitHub issues without explicit consent.**
 Don't post comments to, edit, close, or reopen GitHub issues opened by external users (contributors, guests, reporters) without the user's explicit consent in the current conversation.
 
-**Why:** The user was annoyed when the tech lead posted a status update to issue #389 (opened by guest271314) without being asked. It looked presumptuous toward the reporter.
+**Why:** The user was annoyed when the tech lead posted a status update to issue #389 (opened by guest271314) without being asked. It looked presumptuous toward the reporter. Reinforced 2026-05-29: "dont auto reply, always ask for my consent!" — consent is **per-reply and does NOT carry over**. Even when the user says "let's address issue #389 comment X," that authorizes the *internal* work (code fix, PR) but NOT posting a reply; always draft the reply and ask for explicit consent before each `gh issue comment` / `gh api ... comments` POST.
 
 **2. Do NOT create GitHub issues for internal tracking — use `plan/issues/<id>-slug.md`.**
 This project tracks all work in markdown issue files under `plan/issues/`, NOT in GitHub Issues. When a new issue/task is needed, create the `.md` file (frontmatter: id, title, status, priority, etc.) and add it to the dependency graph / backlog. Do not run `gh issue create`.

--- a/.claude/memory/feedback_sprint_autofill_es3_es5.md
+++ b/.claude/memory/feedback_sprint_autofill_es3_es5.md
@@ -1,0 +1,14 @@
+---
+name: feedback_sprint_autofill_es3_es5
+description: "When the sprint TaskList runs dry, auto-pull ES3/ES5-fixing tasks into the current sprint"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8d9a5e7c-ee71-42b6-8e54-753ae07c8f9f
+---
+
+When the current sprint's claimable TaskList runs out of work (no unowned, unblocked, non-parked tasks left), **pull in tasks that fix ES3 or ES5 test262 failures** rather than letting devs idle — promote ES3/ES5 conformance issues from the backlog into the active sprint (set `sprint: <N>`) and `TaskCreate` them.
+
+**Why:** the project lead wants the sprint kept continuously fed with high-value conformance work; ES3/ES5 (edition 0 and edition 5) buckets are well-scoped, mostly self-contained, and a reliable refill source. Set as a /goal on 2026-05-29.
+
+**How to apply:** identify ES3/ES5 failures via `scripts/generate-editions.ts` (edition 0 = "≤ ES3", edition 5 = ES5) against the cached baseline JSONL; cross-check tracked issues; flip open ES3/ES5 issue frontmatter to the current sprint and add to the TaskList. Regressions of `done` ES-core issues (e.g. ToPrimitive [[reference_error_analysis]]) rank highest. Only triggers on a dry queue — don't displace in-flight sprint work.

--- a/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
+++ b/plan/issues/1636-spec-gap-json-stringify-replacer-tojson.md
@@ -315,3 +315,22 @@ The 2026-05-27 escalation framed this as "no localized patch." The slices above 
 Spec deliverable: this section. Implementation order: 1 → 2 → 3 → 4. Slice 5 belongs in a sibling issue (it surfaces a pre-existing brand-loss bug that affects more than JSON). Any developer (not necessarily senior-dev) can pick up Slice 2 / 3 / 4 individually once Slice 1 lands. Slice 1 itself is senior-dev work (closure-ABI codegen).
 
 Status returning to `ready` — escalation block above remains valid until Slice 1 has an owner; once Slice 1 lands, status flips to `in-progress` and subsequent slices are carved as child issues `#1636-S2`, `#1636-S3`, `#1636-S4`.
+
+## ⚠️ Slice 1 caused a strict-`this` regression — guard Slices 2/3 (2026-05-29)
+
+Slice 1's `__call_fn_method_N` this-threading (PR #873) shipped a
+`__current_this` **fallback** that leaked a `this` value into **strict-mode**
+functions that must observe `undefined`. Net **−101 test262** at the #873
+merge (171 regressions / 70 fixes), clustered in `language/function-code`
+(strict `this`), `language/directive-prologue`, and `built-ins/Array`
+(`every`/`some` thisArg threading) — `'this' had incorrect value!`,
+`typeof this` ≠ `"undefined"`, `innerThisCorrect` failures.
+
+Fixed by **PR #895** — gated the `__current_this` fallback to
+**host-dispatchable closures only**; ~139 tests recovered in exactly those
+clusters. Confirmed via per-test baseline diff (investigation 2026-05-29).
+
+**Guard for Slices 2/3:** any further this-val threading must NOT install a
+`this` for a call site whose target is a strict-mode function. Add a strict-mode
+regression test (a strict fn asserting `this === undefined`) to the slice's
+test set before merging.


### PR DESCRIPTION
Preserves the genuinely-useful uncommitted `.claude/memory/` state from `/workspace` so the shared checkout can be cleaned + fast-forwarded (it had drifted 46 commits behind). **Memory/docs only.**

- `MEMORY.md`: +2 index entries
- `feedback_no_github_issue_comments.md`: consent-is-per-reply reinforcement
- `feedback_external_comments_first_person.md` (new): first-person-'I' rule
- `feedback_sprint_autofill_es3_es5.md` (new): ES3/ES5 sprint autofill rule
- `plan/issues/1636`: note that Slice-1 `__call_fn_method_N` (#873) caused a −101 strict-`this` regression fixed by #895 — guard for Slices 2/3.

`settings.json` deliberately excluded: `/workspace`'s copy was stale (missing the #903 prune + #926 provision-worktree hooks); main's is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)