### PR TITLE
docs(#1719): root-cause array-dstr overridden-iterator → escalate to architect

### DIFF
--- a/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
+++ b/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
@@ -1,11 +1,12 @@
 ---
 id: 1719
 title: "Array destructuring ignores overridden Array.prototype[Symbol.iterator] ('items[Symbol.iterator] must be a function', 71 fails)"
-status: ready
+status: blocked
+blocked_on: needs-architect-spec
 created: 2026-05-29
 updated: 2026-05-29
 priority: high
-feasibility: medium
+feasibility: hard
 task_type: bugfix
 area: codegen
 language_feature: destructuring-iterator-protocol
@@ -73,3 +74,58 @@ Spec: [§7.4.2 GetIterator](https://tc39.es/ecma262/#sec-getiterator),
 
 Filed by product-owner test262 triage 2026-05-29 against main baseline
 (`.test262-cache/test262-current.jsonl`, 48,117 records).
+
+## Root cause — confirmed (dev-a, 2026-05-29)
+
+Reproduced. Hypothesis confirmed; exact site pinned to
+`compileArrayDestructuring` in `src/codegen/statements/destructuring.ts`.
+
+When the destructuring RHS resolves to a **known vec or tuple struct** (the
+common typed-`T[]` case — `resultType` is a `ref`/`ref_null` to a WasmGC vec
+struct), control reaches the fast path at **destructuring.ts:862-876** which
+stashes the struct ref and delegates to `destructureParamArray(...mode:"decl")`.
+That helper walks the WasmGC **backing store directly** (`array.get` / per-field
+`struct.get` on the `{length,data}` vec) — it **never calls GetIterator and
+never reads `@@iterator`** off the value's prototype chain. So a
+module-monkeypatched `Array.prototype[Symbol.iterator]` (or
+`Array.prototype.values`) is silently ignored.
+
+Only the **externref branch** (`compileExternrefArrayDestructuringDecl`, used
+for `resultType.kind === "externref"` / unknown structs at destructuring.ts:794,
+824-827, 849-852) performs a real GetIterator (RequireObjectCoercible +
+`@@iterator` + `.next()`, throw-propagating, #1454). The typed-vec/tuple fast
+path and the f64/i32-box path go straight to the backing-store walk.
+
+The failing `*-iter-val-array-prototype.js` cases compile their RHS as a typed
+array → hit the fast path → override ignored → wrong values or the
+`%Array%.from … items[Symbol.iterator] … be a function` bridge error.
+
+### Why this is NOT a localized fix (scope flag → architect)
+
+The fast path is the **hot, common-case** array-destructuring lane shared by
+declaration dstr, parameter dstr (`destructureParamArray`), for-of bindings,
+and the loop paths. Honouring an overridden prototype iterator needs one of:
+
+1. **Compile-time intactness gate** (preferred): a module pre-scan sets a
+   `ctx`-level flag when `Array.prototype[Symbol.iterator]` /
+   `Array.prototype.values` is ever assigned (or `Object.defineProperty`'d);
+   when set, the vec/tuple fast-path sites coerce to externref and delegate to
+   the existing `compileExternrefArrayDestructuringDecl` GetIterator lane.
+   Touches `compileArrayDestructuring`, `destructureParamArray`, the param lanes,
+   and for-of. Zero perf/behavior change when the flag is clear (the common
+   case); full §8.5.2 fidelity when set.
+2. **Always GetIterator**: drop the fast path — large perf + behavioral
+   regression risk across the dstr suites #1016/#1021/#1024/#1025/#1320
+   explicitly guard. Not advisable.
+
+Either is broad codegen-core surgery on the dstr hot path, not a ~1-file change.
+Per the dev guardrail this warrants an **architect spec** (precision of the
+pre-scan, the for-of interaction, and the perf gate need sign-off before a dev
+lands it). Spec refs: §7.4.2 GetIterator, §8.5.2 IteratorBindingInitialization,
+§13.15.5.3 DestructuringAssignmentEvaluation.
+
+Repro (worktree `issue-1719-array-dstr-iterator`): override
+`Array.prototype[Symbol.iterator]` with a generator yielding a *different* 3rd
+value (`42`), then `const [x,y,z] = [1,2,3]` — `z` resolves to the backing
+store, not the override. Direct compile confirms the typed-vec fast path is
+taken (the externref GetIterator lane is never reached for a typed array RHS).


### PR DESCRIPTION
## What

Recon for #1719 (array destructuring ignores overridden `Array.prototype[Symbol.iterator]`, 71 fails). **Docs/issue-only — no compiler code.** Reproduced, pinned the exact site, and escalated to architect per the dev guardrail (the fix is broad codegen-core surgery, not localized).

## Root cause (confirmed)

`compileArrayDestructuring` (`src/codegen/statements/destructuring.ts:862-876`): when the RHS is a known vec/tuple struct (the common typed-`T[]` case), it delegates to `destructureParamArray` which walks the WasmGC backing store directly (`array.get`/`struct.get`) and **never calls GetIterator** — so a monkeypatched `Array.prototype[Symbol.iterator]`/`Array.prototype.values` is ignored. Only the externref branch (`compileExternrefArrayDestructuringDecl`) does a spec GetIterator.

## Why escalated (not landed inline)

The fast path is the hot, common-case dstr lane shared by decl/param/for-of/loops. Honouring the override needs either a compile-time intactness gate (module pre-scan flag → route fast path to the externref GetIterator lane when the prototype iterator may be overridden) or dropping the fast path entirely. Both are broad codegen-core changes on the dstr hot path with explicit no-regression constraints (#1016/#1021/#1024/#1025/#1320). Per the dev guardrail → architect spec.

The issue file documents the pinned site, both design options, and a suggested spec shape (the intactness-gate is the clean design). `status: blocked` / `blocked_on: needs-architect-spec`, `feasibility: hard`.

Does not close #1719 — unblocks it for an architect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)