### PR TITLE
fix(#1731): substring()/slice() with no args return the whole string

### DIFF
--- a/plan/issues/1731-string-substring-slice-no-arg-returns-empty.md
+++ b/plan/issues/1731-string-substring-slice-no-arg-returns-empty.md
@@ -1,0 +1,61 @@
+---
+id: 1731
+title: "String.prototype.substring()/slice() with no args returns '' instead of the whole string"
+status: done
+completed: 2026-05-29
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: string-methods
+goal: test262-conformance
+sprint: Backlog
+es_edition: 2015
+related: [1248]
+---
+# #1731 — substring()/slice() with no args returns "" (missing-end length default)
+
+## Problem
+
+`"hello".substring()` and `"hello".slice()` (no arguments) return `""` instead
+of the whole string `"hello"`.
+
+Per ECMA-262 §22.1.3.24 (`String.prototype.substring(start, end)`) the missing
+`end` defaults to the string length (`len`), and missing `start` →
+ToIntegerOrInfinity(undefined) = 0; §22.1.3.21 (`slice`) is analogous. So a
+no-arg call must return the entire string.
+
+## Root cause
+
+`compileCallExpression` string-method path in
+`src/codegen/expressions/calls.ts` (~6790). The #1248 "default missing `end`
+to `s.length`" logic (`needsLengthDefault`) only fired for **`args.length ===
+1`**. For the **no-arg** case it never triggered, so the generic
+argument-padding loop pushed `f64.const 0` for *both* the missing `start` and
+the missing `end` → the host import called `s.substring(0, 0)` → `""`.
+
+## Fix
+
+Widen the `needsLengthDefault` guard from `args.length === 1` to
+`args.length <= 1`. The pad loop's existing `pi === 2` branch then supplies
+`s.length` for the missing `end`, and the missing `start` (`pi === 1`) keeps
+its correct `0` default. One-arg, two-arg, and substring's swapped-arg paths
+are unchanged.
+
+## Acceptance criteria
+
+- `"hello".substring()` / `"hello".slice()` return `"hello"`.
+- `"".substring()` / `"".slice()` return `""`.
+- No regression in the single-arg (#1248), two-arg, or swapped-arg cases.
+
+## Test Results
+
+`tests/issue-substring-noarg.test.ts` — 5 cases (no-arg substring/slice, empty
+string, single-arg #1248 regression guard, two-arg + swapped-arg guard). All
+pass. `prettier --check` clean.
+
+Localized one-line guard change. Found via the #259 conformance-triage of the
+`built-ins/String/prototype/{substring,slice}` FAIL clusters
+(`S15.5.4.{13,15}_A1*` value-semantics tests).

--- a/plan/issues/1732-string-prototype-method-function-object-invariants.md
+++ b/plan/issues/1732-string-prototype-method-function-object-invariants.md
@@ -1,0 +1,68 @@
+---
+id: 1732
+title: "String.prototype methods fail not-a-constructor (A7) + .length-DontEnum (A8) invariants across the suite"
+status: ready
+created: 2026-05-29
+updated: 2026-05-29
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: builtin-function-objects, string-methods
+goal: test262-conformance
+sprint: Backlog
+es_edition: 5
+test262_fail: ~40
+related: [930, 1632, 1731]
+---
+# #1732 — String.prototype method function-object invariants (A7 not-a-constructor, A8 .length DontEnum)
+
+## Problem
+
+Across nearly every `built-ins/String/prototype/<method>/` cluster, the
+recurring residual failures are the standard ES5 function-object invariant
+tests, NOT value semantics:
+
+- **`S15.5.4.*_A7.js`** — `String.prototype.<method>` cannot be used as a
+  constructor: `new String.prototype.indexOf` must throw `TypeError`
+  ([§20.2.3 / §10.2 — built-in methods have no `[[Construct]]`]).
+- **`S15.5.4.*_A8.js`** — `String.prototype.<method>.length` exists, is an own
+  property, and is **non-enumerable** (`propertyIsEnumerable('length')` false;
+  `for-in` does not surface it).
+
+These recur in: `indexOf`, `substring`, `slice`, `charAt`, `lastIndexOf`,
+`includes`, `concat`, `toLowerCase`/`toUpperCase`/`toLocale*case`, etc. —
+roughly 2 fails per method × ~20 methods (~40 total), all the same two root
+causes.
+
+## Root-cause hypothesis
+
+Compiled `String.prototype` methods are emitted as host-imported / wasmGC
+shims that are not materialized as real inspectable **builtin function
+objects**: they (a) do not reject `new` with a TypeError (no `[[Construct]]`
+guard — same family as the now-fixed #930 for `Array`/built-in methods), and
+(b) expose no own, non-enumerable `length` property when accessed via
+`String.prototype.<method>`.
+
+This is the **function-object materialization** gap for built-in
+String.prototype methods — related to the bound-function / function.prototype
+representation work (#1632) and the #930 not-a-constructor detection. It is a
+shared cause, so a single fix (materialize String.prototype methods as builtin
+function objects with a non-enumerable `length` and no `[[Construct]]`) clears
+the whole `A7`/`A8` row at once.
+
+Spec: §20.2 (function objects), §10.2.4 (built-ins lack `[[Construct]]` unless
+specified), §17 (built-in function `length`/`name` are non-enumerable).
+
+## Acceptance criteria
+
+- `new String.prototype.indexOf` (and the other methods) throws `TypeError`.
+- `String.prototype.<method>.length` is an own, non-enumerable property; the
+  `*_A7.js` and `*_A8.js` clusters flip to pass.
+- No regression in String value-semantics tests or in #930.
+
+## Source
+
+Filed by #259 conformance-triage 2026-05-29. The value-semantics half of the
+substring/slice clusters is the localized #1731 (shipped); this issue tracks
+the cross-method function-object invariant half.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6789,9 +6789,16 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         // when padding the missing `end` arg.
         const args = expr.arguments;
         const paramTypes = getFuncParamTypes(ctx, funcIdx);
+        // #1248 + no-arg: substring/slice with a missing `end` (0 OR 1 args)
+        // default `end` to `s.length` per §22.1.3.24 (substring: end ?? len) /
+        // §22.1.3.21 (slice: ToIntegerOrInfinity(end ?? len)). With only the
+        // single-arg case handled, `s.substring()` / `s.slice()` padded BOTH
+        // start and end to 0 → host called `s.substring(0, 0)` → "" instead of
+        // the whole string. The pad loop's `pi === 2` branch supplies s.length
+        // for the missing end; the missing start (pi === 1) correctly pads to 0.
         const needsLengthDefault =
           (method === "substring" || method === "slice") &&
-          args.length === 1 &&
+          args.length <= 1 &&
           paramTypes !== undefined &&
           paramTypes.length === 3;
         let savedReceiverLocal: number | undefined;

--- a/tests/issue-substring-noarg.test.ts
+++ b/tests/issue-substring-noarg.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// String.prototype.substring()/slice() with NO arguments must default the
+// missing `end` to the string length and return the whole string
+// (§22.1.3.24 substring: end defaults to len; §22.1.3.21 slice:
+// ToIntegerOrInfinity(end ?? len)). Previously the missing-`end` length
+// default only fired for the single-arg case, so the no-arg call padded BOTH
+// start and end to 0 → "s".substring(0,0) → "" instead of the whole string.
+
+async function evalStr(expr: string): Promise<unknown> {
+  const exports = await compileToWasm(`export function test(): string { return ${expr}; }`);
+  return (exports as { test: () => unknown }).test();
+}
+
+describe("String.prototype.substring/slice missing-end default", () => {
+  it("substring() with no args returns the whole string", async () => {
+    expect(await evalStr(`"hello".substring()`)).toBe("hello");
+  });
+
+  it("slice() with no args returns the whole string", async () => {
+    expect(await evalStr(`"hello".slice()`)).toBe("hello");
+  });
+
+  it("substring()/slice() on an empty string returns empty", async () => {
+    expect(await evalStr(`"".substring()`)).toBe("");
+    expect(await evalStr(`"".slice()`)).toBe("");
+  });
+
+  it("does not regress the single-arg missing-end default (#1248)", async () => {
+    expect(await evalStr(`"hello".substring(1)`)).toBe("ello");
+    expect(await evalStr(`"hello".slice(1)`)).toBe("ello");
+  });
+
+  it("does not regress the two-arg or swapped-arg cases", async () => {
+    expect(await evalStr(`"hello".substring(1, 3)`)).toBe("el");
+    expect(await evalStr(`"hello".slice(1, 3)`)).toBe("el");
+    expect(await evalStr(`"hello".substring(3, 1)`)).toBe("el"); // substring swaps
+  });
+});


### PR DESCRIPTION
## What

Sprint 57 conformance triage (#259). One localized fix + two filed issues.

`"hello".substring()` and `"hello".slice()` (no arguments) returned `""` instead of `"hello"`. Per ECMA-262 §22.1.3.24 (substring) / §22.1.3.21 (slice), a missing `end` defaults to the string length and missing `start` → 0, so a no-arg call returns the whole string.

## Root cause + fix

`src/codegen/expressions/calls.ts` string-method path: the #1248 "default missing `end` to `s.length`" logic (`needsLengthDefault`) only fired for `args.length === 1`. The no-arg case fell through to the generic padding loop which pushed `0` for **both** start and end → host called `s.substring(0, 0)` → `""`.

Fix: widen the guard `args.length === 1` → `args.length <= 1`. The pad loop's existing `pi === 2` branch supplies `s.length` for the missing end; the missing start (`pi === 1`) keeps its correct `0`. One-line change.

## Tests

`tests/issue-substring-noarg.test.ts` — 5 cases: no-arg substring/slice, empty string, single-arg (#1248) regression guard, two-arg + swapped-arg guard. All pass; `prettier --check` clean.

## Also filed (triage backlog refill)

- **#1731** (this fix) — status:done.
- **#1732** (ready) — the cross-method `String.prototype` function-object invariant cluster (`*_A7` not-a-constructor + `*_A8` `.length`-DontEnum, ~40 fails across indexOf/substring/slice/charAt/case-methods/…). Separate function-object materialization concern (related to #930/#1632), not this localized fix.

Closes #1731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)