### PR TITLE
fix(#1735): toExponential/toPrecision(NaN) must use ToInteger(NaN)=0, not the no-arg sentinel

### DIFF
--- a/plan/issues/1735-toexponential-nan-fractiondigits-sentinel-collision.md
+++ b/plan/issues/1735-toexponential-nan-fractiondigits-sentinel-collision.md
@@ -1,0 +1,66 @@
+---
+id: 1735
+title: "Number.prototype.toExponential(NaN) collides with no-arg sentinel — returns variable digits instead of ToInteger(NaN)=0"
+status: done
+created: 2026-05-29
+completed: 2026-05-29
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: number-formatting
+goal: test262-conformance
+sprint: Backlog
+test262_fail: 1
+test262_category: built-ins/Number/prototype/toExponential
+related: [49, 1321, 1731]
+---
+
+# #1735 — toExponential(NaN) wrongly treated as no-arg (sentinel collision)
+
+## Problem
+
+`(123.456).toExponential(NaN)` returns `"1.23456e+2"` (variable digits) instead
+of the spec-correct `"1e+2"` (0 fraction digits).
+
+Per ECMA-262 [§21.1.3.3](https://tc39.es/ecma262/#sec-number.prototype.toexponential)
+step 5, `f = ToIntegerOrInfinity(fractionDigits)`, and
+[ToIntegerOrInfinity(NaN)](https://tc39.es/ecma262/#sec-tointegerorinfinity) is
+**+0** (§7.1.5). So an explicit `NaN` argument must format with 0 fraction
+digits, identical to `toExponential(0)`.
+
+## Root cause
+
+The `number_toExponential` / `number_toPrecision` runtime helpers in
+`src/runtime.ts` overload `NaN` as a **"no argument supplied" sentinel** — the
+codegen no-arg branch in `src/codegen/expressions/calls.ts` pushes
+`f64.const NaN` and the helper does `isNaN(d) ? v.toExponential() : v.toExponential(d)`
+(#1321). When the user passes an *explicit* `NaN` (or a computed `0/0`), it
+carries the same bits as the sentinel, so it is wrongly handled as no-arg
+(variable digits) rather than ToInteger(NaN)=0 (one digit).
+
+## Fix
+
+Normalise the digits/precision f64 local **NaN → 0** in the arg-present branch
+(both `toExponential` and `toPrecision`), before the range check + call, via a
+self-compare `select` (`d == d` is false only for NaN). This reserves the NaN
+sentinel strictly for the zero-argument codegen branch, with no host-side
+change. Added a `normalizeNaNToZero(fctx, f64Local)` helper next to
+`coerceNumberMethodArgToF64` in `src/codegen/expressions/calls.ts`.
+
+For `toPrecision`, NaN→0 then trips the existing RangeError gate (0 ∉ [1,100]),
+matching V8: `(1.5).toPrecision(NaN)` throws RangeError (already asserted by the
+#49 regression guard, which continues to pass).
+
+## Acceptance criteria
+
+- `(123.456).toExponential(NaN)` → `"1e+2"`, `(0).toExponential(NaN)` → `"0e+0"`.
+- Genuine no-arg `(123.456).toExponential()` → `"1.23456e+2"` (unchanged).
+- `(1.5).toPrecision(NaN)` still throws RangeError (#49 guard intact).
+- test262 `Number/prototype/toExponential/tointeger-fractiondigits.js` improves.
+
+## Source
+
+Filed by dev-a from a value-semantics test262 triage pass 2026-05-29.
+Implemented + tested in `tests/issue-1735.test.ts` (6 cases) alongside the #49
+regression guard (7 cases) — all 13 pass.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -256,6 +256,30 @@ function coerceNumberMethodArgToF64(ctx: CodegenContext, fctx: FunctionContext, 
 }
 
 /**
+ * (#1735) Normalise an f64 local holding a Number.prototype.{toExponential,
+ * toPrecision} digits/precision argument so that NaN becomes 0, matching
+ * ToIntegerOrInfinity (§7.1.5 / §21.1.3.{3,5} step 5: NaN → +0).
+ *
+ * The `number_toExponential` / `number_toPrecision` runtime helpers overload
+ * NaN as their "no argument supplied" sentinel (the codegen no-arg branch
+ * pushes `f64.const NaN`). Without this normalisation an *explicit* NaN
+ * argument (`(1).toExponential(NaN)`, `(1).toExponential(0/0)`) carries the
+ * same bits as the sentinel and is wrongly handled as no-arg. Rewriting the
+ * local in place — `local = (d == d) ? d : 0` via `f64.eq` self-compare (false
+ * only for NaN) feeding `select` — keeps the subsequent range-check and call
+ * reading a spec-correct value with no host-side change.
+ */
+function normalizeNaNToZero(fctx: FunctionContext, f64Local: number): void {
+  fctx.body.push({ op: "local.get", index: f64Local }); // val-if-true: d
+  fctx.body.push({ op: "f64.const", value: 0 }); // val-if-false: 0
+  fctx.body.push({ op: "local.get", index: f64Local });
+  fctx.body.push({ op: "local.get", index: f64Local });
+  fctx.body.push({ op: "f64.eq" }); // condition: d == d (0 only when NaN)
+  fctx.body.push({ op: "select" });
+  fctx.body.push({ op: "local.set", index: f64Local });
+}
+
+/**
  * Look up closure info for a variable by checking if its local type
  * is a ref to a known closure struct. Handles cases like:
  *   var f = function() { ... }; f();
@@ -6512,6 +6536,14 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         const precLocal = allocLocal(fctx, `__toPrecision_prec_${fctx.locals.length}`, { kind: "f64" });
         fctx.body.push({ op: "local.set", index: precLocal });
 
+        // (#1735) §21.1.3.5 step 5: p = ToIntegerOrInfinity(precision), NaN → 0.
+        // The `number_toPrecision` runtime helper uses NaN as its "no precision
+        // supplied" sentinel, so an explicit NaN precision (`(1).toPrecision(NaN)`)
+        // must be normalised to 0 here so it isn't mistaken for no-arg. (A 0
+        // precision then trips the RangeError gate below — 0 is out of [1,100] —
+        // which matches V8: explicit NaN precision throws RangeError.)
+        normalizeNaNToZero(fctx, precLocal);
+
         // Re-push receiver for the runtime call.
         fctx.body.push({ op: "local.get", index: recvLocalP });
 
@@ -6594,6 +6626,17 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         coerceNumberMethodArgToF64(ctx, fctx, compileExpression(ctx, fctx, expr.arguments[0]!));
         const digitsLocal = allocLocal(fctx, `__toExponential_digits_${fctx.locals.length}`, { kind: "f64" });
         fctx.body.push({ op: "local.set", index: digitsLocal });
+
+        // (#1735) §21.1.3.3 step 5: f = ToIntegerOrInfinity(fractionDigits),
+        // which maps NaN → 0. The `number_toExponential` runtime helper reads
+        // NaN as its "no argument supplied" sentinel (see else-branch below),
+        // so an *explicit* NaN argument — e.g. `(1).toExponential(NaN)` or
+        // `(1).toExponential(0/0)` — must be normalised to 0 here, otherwise it
+        // collides with the sentinel and is wrongly treated as no-arg (variable
+        // digits) instead of 0 digits. Spec: explicit NaN → 0 → "Ne+E"; genuine
+        // no-arg → variable digits. test262
+        // Number/prototype/toExponential/tointeger-fractiondigits.js.
+        normalizeNaNToZero(fctx, digitsLocal);
 
         // Re-push receiver for the runtime call.
         fctx.body.push({ op: "local.get", index: recvLocalE });

--- a/tests/issue-1735.test.ts
+++ b/tests/issue-1735.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #1735 — Number.prototype.toExponential(NaN) must use ToIntegerOrInfinity,
+ * which maps NaN → 0, NOT the codegen "no argument" sentinel.
+ *
+ * Per ECMA-262 §21.1.3.3 step 5, `f = ToIntegerOrInfinity(fractionDigits)`,
+ * and ToIntegerOrInfinity(NaN) is +0 (§7.1.5). So `(123.456).toExponential(NaN)`
+ * must format with 0 fraction digits → "1e+2", distinct from the genuine
+ * no-argument call `(123.456).toExponential()` → "1.23456e+2" (variable digits).
+ *
+ * Pre-fix bug: codegen passes the f64 fractionDigits straight to the
+ * `number_toExponential` runtime helper, which overloads NaN as its "no
+ * argument supplied" sentinel (the no-arg codegen branch pushes `f64.const
+ * NaN`). An *explicit* NaN argument therefore carried the same bits as the
+ * sentinel and was wrongly treated as no-arg, returning variable digits.
+ *
+ * Fix: codegen normalises the digits/precision f64 local NaN → 0 (via a
+ * self-compare `select`) before the range check + call, so the sentinel is
+ * reserved strictly for the zero-argument case.
+ *
+ * Test262 affected:
+ *   - built-ins/Number/prototype/toExponential/tointeger-fractiondigits.js
+ *
+ * Regression guard for the no-arg sentinel (#1321) and the non-finite-receiver
+ * gate (#49) lives in tests/issue-49-number-format-nonfinite.test.ts —
+ * `(1.5).toPrecision(NaN)` STILL throws RangeError (NaN→0, 0 ∉ [1,100]).
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runFn(source: string, exportName: string): Promise<unknown> {
+  const r = compile(source, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message ?? "?"}`);
+  const importResult = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, importResult as any);
+  importResult.setExports?.(instance.exports as any);
+  return (instance.exports as any)[exportName]();
+}
+
+describe("#1735 — toExponential(NaN) uses ToInteger(NaN)=0, not the no-arg sentinel", () => {
+  it("(123.456).toExponential(NaN) → '1e+2' (0 fraction digits)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(Number.NaN); }`;
+    expect(await runFn(src, "r")).toBe("1e+2");
+  });
+
+  it("(123.456).toExponential(0/0) → '1e+2' (computed NaN coerces to 0)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(0 / 0); }`;
+    expect(await runFn(src, "r")).toBe("1e+2");
+  });
+
+  it("(0).toExponential(NaN) → '0e+0'", async () => {
+    const src = `export function r(): string { return (0).toExponential(Number.NaN); }`;
+    expect(await runFn(src, "r")).toBe("0e+0");
+  });
+
+  // The genuine no-argument call must STILL give variable digits — the
+  // NaN→0 normalisation only runs in the arg-present branch, so the no-arg
+  // sentinel (variable digits) is preserved.
+  it("(123.456).toExponential() (no arg) → '1.23456e+2' (variable digits, unchanged)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(); }`;
+    expect(await runFn(src, "r")).toBe("1.23456e+2");
+  });
+
+  it("explicit integer arg unchanged: (123.456).toExponential(2) → '1.23e+2'", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(2); }`;
+    expect(await runFn(src, "r")).toBe("1.23e+2");
+  });
+
+  it("explicit (123.456).toExponential(0) → '1e+2' (same as NaN→0)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(0); }`;
+    expect(await runFn(src, "r")).toBe("1e+2");
+  });
+});


### PR DESCRIPTION
## Problem

`(123.456).toExponential(NaN)` returned `"1.23456e+2"` (variable digits) instead of the spec-correct `"1e+2"` (0 fraction digits). Per ECMA-262 [§21.1.3.3](https://tc39.es/ecma262/#sec-number.prototype.toexponential) step 5, `f = ToIntegerOrInfinity(fractionDigits)`, and `ToIntegerOrInfinity(NaN)` is **+0** (§7.1.5) — so an explicit `NaN` must format with 0 fraction digits, identical to `toExponential(0)`.

## Root cause

The `number_toExponential` / `number_toPrecision` runtime helpers overload `NaN` as a **"no argument supplied" sentinel** (the no-arg codegen branch pushes `f64.const NaN`, #1321). An *explicit* `NaN` (or computed `0/0`) carried the same bits as the sentinel and was wrongly handled as no-arg.

## Fix

Add `normalizeNaNToZero(fctx, f64Local)` next to `coerceNumberMethodArgToF64` in `src/codegen/expressions/calls.ts`, called in the **arg-present** branch of both `toExponential` and `toPrecision`, before the range check + call. It rewrites the f64 local `NaN → 0` via a self-compare `select` (`d == d` is false only for NaN). This reserves the NaN sentinel strictly for the zero-argument branch — **no host-side change**.

For `toPrecision`, `NaN → 0` then trips the existing RangeError gate (0 ∉ [1,100]), matching V8 — `(1.5).toPrecision(NaN)` still throws (the #49 regression guard).

## Tests

- `tests/issue-1735.test.ts` — 6 cases (explicit NaN → `1e+2`, `0/0` → `1e+2`, `0e+0`, no-arg variable-digits unchanged, integer args unchanged).
- `tests/issue-49-number-format-nonfinite.test.ts` — 7 guard cases (incl. `toPrecision(NaN)` throws).
- **All 13 pass.**

Improves test262 `Number/prototype/toExponential/tointeger-fractiondigits.js`. Localized value-semantics fix, no representation dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)