### PR TITLE
fix(#1616): resolve 4 duplicate issue IDs breaking main's quality gate

### DIFF
--- a/plan/issues/1736-arraybuffer-bytelength-nan-jshost.md
+++ b/plan/issues/1736-arraybuffer-bytelength-nan-jshost.md
@@ -1,5 +1,5 @@
 ---
-id: 1728
+id: 1736
 title: "ArrayBuffer.prototype.byteLength returns NaN in JS-host mode"
 status: backlog
 created: 2026-05-29
@@ -12,7 +12,7 @@ goal: test262-conformance
 sprint: Backlog
 related: [1717, 1700, 1350]
 ---
-# #1728 — ArrayBuffer byteLength returns NaN in JS-host mode
+# #1736 — ArrayBuffer byteLength returns NaN in JS-host mode
 
 ## Problem
 

--- a/plan/issues/1737-typedarray-over-arraybuffer-aliasing-jshost.md
+++ b/plan/issues/1737-typedarray-over-arraybuffer-aliasing-jshost.md
@@ -1,5 +1,5 @@
 ---
-id: 1729
+id: 1737
 title: "Uint8Array(arrayBuffer) does not alias the ArrayBuffer's backing store (JS-host)"
 status: backlog
 created: 2026-05-29
@@ -12,7 +12,7 @@ goal: test262-conformance
 sprint: Backlog
 related: [1717, 1700, 1350]
 ---
-# #1729 — TypedArray view over ArrayBuffer does not alias the buffer (JS-host)
+# #1737 — TypedArray view over ArrayBuffer does not alias the buffer (JS-host)
 
 ## Problem
 

--- a/plan/issues/1738-dataview-setters-not-a-function-jshost.md
+++ b/plan/issues/1738-dataview-setters-not-a-function-jshost.md
@@ -1,5 +1,5 @@
 ---
-id: 1730
+id: 1738
 title: "DataView.prototype.set* (setUint8 etc.) 'not a function' in JS-host mode"
 status: backlog
 created: 2026-05-29
@@ -12,7 +12,7 @@ goal: test262-conformance
 sprint: Backlog
 related: [1717, 1654, 1700]
 ---
-# #1730 — DataView setters are 'not a function' in JS-host mode
+# #1738 — DataView setters are 'not a function' in JS-host mode
 
 ## Problem
 

--- a/plan/issues/1739-string-prototype-method-function-object-invariants.md
+++ b/plan/issues/1739-string-prototype-method-function-object-invariants.md
@@ -1,5 +1,5 @@
 ---
-id: 1732
+id: 1739
 title: "String.prototype methods fail not-a-constructor (A7) + .length-DontEnum (A8) invariants across the suite"
 status: ready
 created: 2026-05-29
@@ -15,7 +15,7 @@ es_edition: 5
 test262_fail: ~40
 related: [930, 1632, 1731]
 ---
-# #1732 — String.prototype method function-object invariants (A7 not-a-constructor, A8 .length DontEnum)
+# #1739 — String.prototype method function-object invariants (A7 not-a-constructor, A8 .length DontEnum)
 
 ## Problem
 


### PR DESCRIPTION
main's `quality` check (Issue integrity gate #1616) was **RED** — 4 issue IDs each had two files, failing `--check: 4 duplicate IDs` and blocking every PR (incl. the merge queue's quality re-check). Collisions came from the session's id-collision pattern + admin-merges that bypassed the gate.

Renumbered the colliding (recent jshost-triage / duplicate) member of each pair to fresh IDs, keeping the canonical/referenced file:
- 1728 → keep `es5-compound-assign`; `arraybuffer-bytelength-jshost` → **1736**
- 1729 → keep `instanceof-object-struct`; `typedarray-aliasing-jshost` → **1737**
- 1730 → keep `module-const-arrow`; `dataview-setters-jshost` → **1738**
- 1732 → keep `builtin-method-value` (the $FuncObj spec referenced by #941/#942/#1719/#1320/#1130); `string-prototype-method-invariants` → **1739**

Gate passes locally (0 dup, 0 broken links, 0 mismatch). Docs/planning-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)