### PR TITLE
fix+refactor(#389): native-messaging 1 MiB byte-corruption + 3-symbol API + host.imports doc

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -76,6 +76,26 @@ runs on any standards-compliant WASI preview1 runtime.
 > The `-o` flag is an **output directory**, not a filename. js2wasm names the
 > output after the input basename (`host.wasm`).
 
+### What is `host.imports.js`?
+
+The build also emits `host.imports.js` (plus `host.d.ts` and `host.wat`). It is
+the **generated JS host-imports glue** for the module — a small ES module that
+re-exports `createImports()` / `instantiateBytes()` / `instantiateFromUrl()`
+helpers wired to the right import manifest and string pool for this `.wasm`.
+
+You do **not** need it to run the Native Messaging host: this build targets
+`--target wasi`, so `host.wasm` imports only `wasi_snapshot_preview1` and runs
+directly under wasmtime / wasmer / wazero (or Chrome's native-host launcher)
+with no JS at all — that is the whole point of the standalone WASI target.
+
+`host.imports.js` is for the **other** way to run the module — **embedding it in
+a JavaScript host** (a browser tab, a Node service, a Worker) instead of a WASI
+CLI runtime. There it supplies the `env` / `string_constants` imports the
+js2wasm runtime expects, so you can `import { instantiateFromUrl } from
+"./out/host.imports.js"` and drive the same compiled logic from JS. For the
+Chrome Native Messaging use case you can ignore it; ship just `host.wasm` and
+the launcher wrapper.
+
 ## Run it under a WASI runtime
 
 `nm_js2wasm.sh` wraps the runtime invocation. `wasmtime` is **not bundled** with this

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -16,16 +16,30 @@
 //              header then exactly the declared body length.
 //   - stdout : process.stdout.write(bytes|str) writes raw bytes / a string to
 //              fd=1 with NO trailing newline (#1651) — used for the binary
-//              4-byte length prefix and the JSON body. console.log(str) also
-//              writes runtime strings correctly now (#1618).
+//              4-byte length prefix and the body. Large bodies (≥1 MiB, the
+//              #389 case) now write byte-exact: the fd_write staging buffer
+//              grows linear memory on demand rather than overflowing the
+//              default 3-page reserve and corrupting the stream into nulls.
 //   - stderr : console.error / console.warn write to fd=2 (#1493) — use these
 //              for debug output so they never corrupt the stdout protocol stream
 //
-// This is a drop-in Chrome host: it reads each framed JSON message off stdin,
-// builds a JSON response, and writes it back to stdout with the correct
-// 4-byte little-endian length prefix, looping until stdin reaches EOF. Run it
-// with the wrapper in run.sh under wasmtime/wasmer to exercise the
-// read -> process -> respond loop end to end.
+// This is a drop-in Chrome host built around the cross-language 3-symbol
+// pattern guest271314 uses for Native Messaging hosts:
+//
+//   getMessage()       — read the 4-byte LE header, then exactly N body bytes
+//                        off stdin; return the raw body bytes (Uint8Array).
+//   sendMessage(body)  — frame `body` with a 4-byte LE length prefix and write
+//                        the prefix + body to stdout, no trailing newline.
+//   main()             — the long-lived `while (true)` port loop:
+//                        getMessage -> sendMessage, until stdin EOF.
+//
+// The body flows as raw **bytes** (Uint8Array) end to end — never lossily
+// stringified — so it is binary-safe at any size and forward-compatible with
+// Chromium's in-progress Uint8Array-over-Native-Messaging support
+// (https://issues.chromium.org/issues/497341241). The loop is a strict
+// verbatim echo (#930): what the extension sends in comes back out byte-for-
+// byte. A real host would parse the body, dispatch on a command field, and
+// build a structured response inside `main` between getMessage and sendMessage.
 
 declare const process: {
   stdin: { read(buf: Uint8Array, offset?: number): number };
@@ -47,62 +61,56 @@ function readExact(buf: Uint8Array, n: number): boolean {
   return true;
 }
 
-// Decode the little-endian uint32 length that Chrome wrote as the first 4
-// bytes of the frame.
-function decodeLength(header: Uint8Array): number {
-  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+// getMessage — read one framed Native Messaging message off stdin and return
+// its raw body bytes, or an empty Uint8Array on EOF / clean shutdown.
+//
+// The frame is a 4-byte little-endian uint32 length prefix followed by exactly
+// that many body bytes. The body is returned as a `Uint8Array` (raw bytes), not
+// a string, so binary payloads and large (≥1 MiB) bodies are preserved exactly.
+// EOF on the header read is a clean shutdown signal; a truncated body (EOF
+// mid-frame) returns empty too. The port loop distinguishes "message" from
+// "EOF" by the returned length.
+function getMessage(): Uint8Array {
+  const header = new Uint8Array(4);
+  if (!readExact(header, 4)) return new Uint8Array(0); // EOF at frame boundary
+  // Little-endian uint32 length Chrome wrote as the first 4 bytes.
+  const declaredLen = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+  const body = new Uint8Array(declaredLen);
+  if (declaredLen > 0 && !readExact(body, declaredLen)) return new Uint8Array(0); // truncated
+  return body;
 }
 
-// Build a string from the declared body bytes, one byte per code unit (the
-// Native Messaging JSON body is ASCII/UTF-8 framed by byte length).
-function bodyToString(body: Uint8Array, length: number): string {
-  let s = "";
-  let i = 0;
-  while (i < length) {
-    s = s + String.fromCharCode(body[i]);
-    i = i + 1;
-  }
-  return s;
-}
-
-// Write a framed Native Messaging response: the 4-byte little-endian length
-// prefix followed by the JSON body, both on stdout (fd=1), no newline.
-function writeMessage(body: string): void {
-  const len = body.length;
+// sendMessage — write a framed Native Messaging response: the 4-byte little-
+// endian length prefix followed by the body bytes, both on stdout (fd=1), no
+// newline. `message` is raw bytes; its byte length is the prefix, so the frame
+// is binary-exact regardless of content or size.
+function sendMessage(message: Uint8Array): void {
+  const len = message.length;
   // Binary 4-byte LE length prefix via raw-byte stdout (#1651).
   process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
-  // JSON body — runtime string, written verbatim with no trailing newline.
-  process.stdout.write(body);
+  // Body — raw bytes, written verbatim with no trailing newline. The stdout
+  // helper grows linear memory for large bodies so ≥1 MiB writes are byte-exact
+  // (#389).
+  process.stdout.write(message);
 }
 
 export function main(): void {
   // Long-lived port loop: read framed messages off stdin until EOF. A short
-  // read inside readExact is retried; a zero-byte read means the peer closed
-  // stdin, so we break and exit.
-  const header = new Uint8Array(4);
+  // read inside readExact is retried; a header read returning EOF (empty body)
+  // means the peer closed stdin, so we break and exit.
   while (true) {
-    // 4-byte LE length prefix. EOF here = clean shutdown.
-    if (!readExact(header, 4)) break;
-    const declaredLen = decodeLength(header);
-
-    // Read exactly the declared body bytes. A truncated body (EOF mid-frame)
-    // also terminates the loop.
-    const body = new Uint8Array(declaredLen);
-    if (!readExact(body, declaredLen)) break;
-    const bodyStr = bodyToString(body, declaredLen);
+    const message = getMessage();
+    if (message.length === 0) break; // EOF / clean shutdown
 
     // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
-    // protocol stream. Chrome ignores the host's stderr. The frame is the
-    // 4-byte LE prefix plus the declared body, so the total bytes consumed is
-    // 4 + declaredLen.
-    console.error(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}`);
+    // protocol stream. Chrome ignores the host's stderr. The frame consumed is
+    // the 4-byte LE prefix plus the body, so total bytes = 4 + message.length.
+    console.error(`[host] received ${4 + message.length} bytes, body length ${message.length}`);
 
-    // Strict echo: write the received body back verbatim, byte-for-byte, with
-    // no wrapper and no added bytes. This makes the demo a true round-trip
-    // proof — what Chrome sends in is exactly what comes back out, so the
-    // stdin->stdout fidelity of the WASI build is directly observable.
-    // A real host would instead parse `bodyStr`, dispatch on a command field,
-    // and build a structured response here.
-    writeMessage(bodyStr);
+    // Strict verbatim echo (#930): send the received body back byte-for-byte,
+    // no wrapper and no added bytes — a true round-trip proof that the WASI
+    // build's stdin->stdout fidelity holds at any size (including the 1 MiB
+    // #389 case). A real host would build a structured response here instead.
+    sendMessage(message);
   }
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4972,11 +4972,12 @@ export function ensureWasiWriteUint8ArrayHelper(
 
   const fd = useStderr ? 2 : 1;
 
-  // param: arr(0); locals: len(1), data(2), i(3)
+  // param: arr(0); locals: len(1), data(2), i(3), needPages(4)
   const ARR = 0;
   const LEN = 1;
   const DATA = 2;
   const I = 3;
+  const NEED_PAGES = 4;
 
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -4987,6 +4988,37 @@ export function ensureWasiWriteUint8ArrayHelper(
     { op: "local.get", index: ARR } as Instr,
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
     { op: "local.set", index: LEN } as Instr,
+
+    // (#389) grow linear memory if the staging buffer
+    // [WASI_WRITE_SCRATCH_START .. +len) would overflow current memory. The
+    // module reserves only 3 pages by default, so a >128 KiB Uint8Array (e.g. a
+    // 1 MiB Native Messaging payload) stages far past page 2 and otherwise
+    // corrupts/traps — the large-message byte-corruption guest271314 reported on
+    // #389. Mirror the string-writer guard (#1723): neededPages =
+    // ceil((SCRATCH_START + len) / 65536) == (SCRATCH_START + len + 65535) >> 16,
+    // shr_u so a length near 2^31 still yields a non-negative page count.
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 65535 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 16 } as Instr,
+    { op: "i32.shr_u" } as Instr,
+    { op: "local.set", index: NEED_PAGES } as Instr,
+    { op: "local.get", index: NEED_PAGES } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEED_PAGES } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
 
     // data = arr.data (field 1)
     { op: "local.get", index: ARR } as Instr,
@@ -5060,6 +5092,7 @@ export function ensureWasiWriteUint8ArrayHelper(
       { name: "len", type: { kind: "i32" } },
       { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
       { name: "i", type: { kind: "i32" } },
+      { name: "needPages", type: { kind: "i32" } },
     ],
     body,
     exported: false,
@@ -5094,11 +5127,12 @@ export function ensureWasiWriteArrayBufferHelper(
 
   const fd = useStderr ? 2 : 1;
 
-  // param: buf(0); locals: len(1), data(2), i(3)
+  // param: buf(0); locals: len(1), data(2), i(3), needPages(4)
   const BUF = 0;
   const LEN = 1;
   const DATA = 2;
   const I = 3;
+  const NEED_PAGES = 4;
 
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -5109,6 +5143,32 @@ export function ensureWasiWriteArrayBufferHelper(
     { op: "local.get", index: BUF } as Instr,
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
     { op: "local.set", index: LEN } as Instr,
+
+    // (#389) grow linear memory if the staging buffer would overflow current
+    // memory — same large-payload guard as the Uint8Array/string writers
+    // (#1723). neededPages = ceil((SCRATCH_START + len) / 65536).
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 65535 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 16 } as Instr,
+    { op: "i32.shr_u" } as Instr,
+    { op: "local.set", index: NEED_PAGES } as Instr,
+    { op: "local.get", index: NEED_PAGES } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEED_PAGES } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
 
     // data = buf.data (field 1)
     { op: "local.get", index: BUF } as Instr,
@@ -5181,6 +5241,7 @@ export function ensureWasiWriteArrayBufferHelper(
       { name: "len", type: { kind: "i32" } },
       { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
       { name: "i", type: { kind: "i32" } },
+      { name: "needPages", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -183,4 +183,39 @@ export function main(): void {
     expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
     expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
   });
+
+  // #389 — a 1 MiB framed body must round-trip byte-exact. guest271314
+  // reported that a 1 MiB message came back as an array of NULLs: the
+  // `process.stdout.write(Uint8Array)` fd_write staging buffer
+  // (ensureWasiWriteUint8ArrayHelper) lacked the memory.grow guard the string
+  // writer has (#1723), so any body past the default 3-page reserve overflowed
+  // — corrupting/trapping. The fix grows linear memory to fit the staging
+  // buffer before copying. This drives the SHIPPED host (Uint8Array body path)
+  // with a 1 MiB payload and asserts the echo is byte-identical with zero nulls.
+  it("round-trips a 1 MiB framed body byte-exactly (no NULL corruption) — #389", () => {
+    const src = readFileSync(hostPath, "utf-8");
+    const result = compile(src, { fileName: "host.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+
+    const N = 1024 * 1024; // 1 MiB
+    const body = new Uint8Array(N).fill(0x61); // 'a' — guest's {"0":97} byte
+    const input = new Uint8Array(4 + N);
+    new DataView(input.buffer).setUint32(0, N, true);
+    input.set(body, 4);
+
+    const out = runWasiRaw(result.binary, input);
+    // 4-byte LE prefix declares the full 1 MiB length…
+    expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(N);
+    // …and the echoed body is exactly N bytes, all 'a', with no NULLs/garbage.
+    const echoed = out.subarray(4);
+    expect(echoed.length).toBe(N);
+    let nulls = 0;
+    let nonA = 0;
+    for (let i = 0; i < echoed.length; i++) {
+      if (echoed[i] === 0) nulls++;
+      else if (echoed[i] !== 0x61) nonA++;
+    }
+    expect(nulls).toBe(0);
+    expect(nonA).toBe(0);
+  });
 });


### PR DESCRIPTION
Addresses guest271314's #389 test feedback. Three coherent changes to `examples/native-messaging/`.

## (a) BUG fix — large-payload byte corruption (the core change)

A 1 MiB framed message round-tripped as an array of NULLs (guest's report); under a non-zeroing runtime the same path traps `memory access out of bounds`.

**Root cause:** `process.stdout.write(Uint8Array | ArrayBuffer)` under `--target wasi` stages the bytes into a fixed scratch region (`WASI_WRITE_SCRATCH_START` = 128 KiB, page 2) before a single `fd_write`. The string writer grows linear memory to fit the staging buffer (#1723), but `ensureWasiWriteUint8ArrayHelper` / `ensureWasiWriteArrayBufferHelper` in `src/codegen/index.ts` **lacked that guard** — so any body past the default 3-page reserve overflowed.

**Fix:** add the identical `neededPages = ceil((SCRATCH_START + len) / 65536)` `memory.grow` guard to both byte-array writers before they stage. `≥1 MiB` writes are now byte-exact.

Verified locally: pre-fix a 1 MiB Uint8Array write traps OOB; post-fix the shipped host round-trips 1 MiB byte-for-byte with **zero nulls**.

## (b) REFACTOR — guest's cross-language 3-symbol pattern

`host.ts` now uses `getMessage()` (read 4-byte LE header + exactly N body bytes, return raw `Uint8Array`) / `sendMessage(message)` (LE-frame + stdout write) / `main()` (the `while(1)` getMessage→sendMessage loop). The body flows as **raw bytes** end to end — never lossily stringified — so it's binary-safe at any size and forward-compatible with Chromium's in-progress Uint8Array-over-Native-Messaging ([issues.chromium.org/issues/497341241](https://issues.chromium.org/issues/497341241)). Keeps the strict verbatim echo (#930).

## (c) DOC — `host.imports.js`

New README section: it's the generated JS host-imports glue, **not** needed for the WASI/wasmtime path (`host.wasm` imports only `wasi_snapshot_preview1`); it's for embedding the module in a JS host instead.

## Tests

- `tests/issue-1530.test.ts` gains a **1 MiB byte-exact round-trip regression** driving the shipped host's Uint8Array path (asserts zero nulls/garbage). All 6 issue-1530 tests pass.
- `tests/wasi.test.ts` 24/24 pass; typecheck clean.
- `smoke-test.sh` unchanged (runs under wasmtime in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)