### PR TITLE
fix(#389): native-messaging 1 MiB body — byte-write memory-grow guard + raw-Uint8Array 3-symbol host

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -40,22 +40,37 @@ trailing newline. The two stdout gaps that previously blocked this are closed
 | Emit the **binary 4-byte LE length prefix** on stdout | works | `process.stdout.write(new Uint8Array([…]))` writes raw bytes (incl. NUL) verbatim to fd=1 (#1651) |
 
 The response is framed with `process.stdout.write` — a `Uint8Array` for the
-binary length prefix, then the JSON body string — mirroring the Node.js host
-API used by the AssemblyScript reference (`nm_assemblyscript.ts`). It is a
-drop-in Chrome host; the only external dependency is a WASI preview1 runtime to
-launch it (see "Run it" below).
+binary length prefix, then the body bytes — mirroring the Node.js host API used
+by the reference hosts (`nm_assemblyscript.ts`, `nm_javy.js`, `nm_qjs_wasi.js`).
+It is a drop-in Chrome host; the only external dependency is a WASI preview1
+runtime to launch it (see "Run it" below).
 
 ## The host source
 
-[`host.ts`](./host.ts) runs a continuous `while (true)` port loop: it reads the
-4-byte length prefix then exactly the declared body bytes via
-`process.stdin.read` read-until loops (a `readExact` helper handles short
-reads), logs diagnostics to **stderr** (so they never corrupt the stdout
-protocol stream), and writes a framed JSON response, looping until stdin
-reaches EOF. The application logic — here, a **strict echo** that writes the
-received body back verbatim, byte-for-byte, with no wrapper and no added bytes
-(so the stdin→stdout round-trip is directly observable) — is the part you'd
-replace for a real host that parses the body and builds a structured response.
+[`host.ts`](./host.ts) follows the **3-symbol shape** the reference hosts use
+across runtimes:
+
+- **`getMessage()`** — reads the 4-byte little-endian length header, then
+  exactly that many body bytes, via `process.stdin.read` read-until loops (a
+  `readExact` helper handles short reads). It returns the body as a raw
+  **`Uint8Array`** (a zero-length buffer signals EOF / a truncated frame). The
+  body is **never** decoded to a JS string, so it round-trips byte-exactly at
+  any size — including megabyte-scale messages (#389).
+- **`sendMessage(message)`** — frames a `Uint8Array` body: writes the 4-byte LE
+  length prefix, then the body bytes, to stdout with no trailing newline. Large
+  bodies grow linear memory as needed (#389/#1723).
+- **`main()`** — the continuous port loop: `const m = getMessage();
+  sendMessage(m);`, looping until `getMessage()` returns an empty body.
+
+Diagnostics go to **stderr** (so they never corrupt the stdout protocol
+stream). The application logic — here, a **strict echo** that sends the received
+body back verbatim, byte-for-byte, with no wrapper and no added bytes (so the
+stdin→stdout round-trip is directly observable) — lives entirely in the loop
+body and is the part you'd replace for a real host that decodes `message`,
+dispatches on a command field, and frames a structured response with
+`sendMessage()`. Carrying the body as bytes (rather than a string) is also
+forward-compatible with Chromium's in-progress `Uint8Array` Native Messaging
+support — the protocol body is fundamentally a byte buffer.
 
 ## Build to `.wasm`
 
@@ -75,6 +90,33 @@ runs on any standards-compliant WASI preview1 runtime.
 
 > The `-o` flag is an **output directory**, not a filename. js2wasm names the
 > output after the input basename (`host.wasm`).
+
+### What is `out/host.imports.js`?
+
+Alongside `host.wasm`, js2wasm emits **`host.imports.js`** (plus `host.d.ts`).
+It is the **generated host-imports glue** a compiled module needs when you
+instantiate it from a JavaScript host. It re-exports `createImports`,
+`instantiateBytes`, and `instantiateFromUrl` from the `js2wasm` runtime package,
+wiring up the module's import manifest and string pool:
+
+```js
+import { instantiateBytes } from "./out/host.imports.js";
+const { instance } = await instantiateBytes(wasmBytes, deps, options);
+instance.exports.main();
+```
+
+For **this** example it is **not used at runtime**: the Native Messaging host
+is a fully standalone `--target wasi` module whose only imports are the WASI
+preview1 syscalls (`fd_read`/`fd_write`), which the runtime — `wasmtime`,
+`wasmer`, `wazero`, or Node's WASI — supplies directly. So the `nm_js2wasm.sh`
+wrapper launches `host.wasm` under a WASI runtime and `host.imports.js` is
+never imported.
+
+The glue file is emitted unconditionally by the compiler because the **same
+module can also be driven from a JS host** (e.g. instantiated in the browser or
+in Node via `WebAssembly.instantiate`), where the import wiring it provides is
+required. Treat it as the JS-host on-ramp for the module; for the standalone
+WASI path it is a harmless extra artifact you can ignore or delete.
 
 ## Run it under a WASI runtime
 

--- a/examples/native-messaging/host.ts
+++ b/examples/native-messaging/host.ts
@@ -16,16 +16,26 @@
 //              header then exactly the declared body length.
 //   - stdout : process.stdout.write(bytes|str) writes raw bytes / a string to
 //              fd=1 with NO trailing newline (#1651) — used for the binary
-//              4-byte length prefix and the JSON body. console.log(str) also
-//              writes runtime strings correctly now (#1618).
+//              4-byte length prefix and the message body. Large raw-byte
+//              writes (>= 1 MiB) grow linear memory as needed (#389/#1723) so a
+//              megabyte-scale body round-trips byte-exactly.
 //   - stderr : console.error / console.warn write to fd=2 (#1493) — use these
 //              for debug output so they never corrupt the stdout protocol stream
 //
-// This is a drop-in Chrome host: it reads each framed JSON message off stdin,
-// builds a JSON response, and writes it back to stdout with the correct
-// 4-byte little-endian length prefix, looping until stdin reaches EOF. Run it
-// with the wrapper in run.sh under wasmtime/wasmer to exercise the
-// read -> process -> respond loop end to end.
+// This is a drop-in Chrome host modelled on the 3-symbol shape guest271314
+// uses across runtimes (`nm_assemblyscript.ts`, `nm_javy.js`, `nm_qjs_wasi.js`):
+//
+//   getMessage()         — read the 4-byte LE header, then exactly N body bytes
+//   sendMessage(message) — frame with the LE length prefix + write stdout
+//   main()               — the port loop: const m = getMessage(); sendMessage(m);
+//
+// The body is carried as a raw `Uint8Array` end-to-end and echoed back verbatim
+// (the strict #930 round-trip echo) — it is NOT decoded to a JS string, so the
+// bytes are preserved exactly regardless of size or content (#389). A real host
+// would decode `message` with a UTF-8 reader, dispatch on a command field, and
+// frame a fresh response with sendMessage(). Carrying bytes (not a string) is
+// also forward-compatible with Chromium's in-progress Uint8Array Native
+// Messaging support — the protocol body is fundamentally a byte buffer.
 
 declare const process: {
   stdin: { read(buf: Uint8Array, offset?: number): number };
@@ -53,56 +63,56 @@ function decodeLength(header: Uint8Array): number {
   return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
 }
 
-// Build a string from the declared body bytes, one byte per code unit (the
-// Native Messaging JSON body is ASCII/UTF-8 framed by byte length).
-function bodyToString(body: Uint8Array, length: number): string {
-  let s = "";
-  let i = 0;
-  while (i < length) {
-    s = s + String.fromCharCode(body[i]);
-    i = i + 1;
-  }
-  return s;
+// getMessage() — read one framed Native Messaging message: the 4-byte LE length
+// header, then exactly that many body bytes. Returns the raw body `Uint8Array`,
+// or a zero-length buffer on EOF (peer closed stdin) so the port loop can stop.
+// The body is kept as raw bytes — never stringified — so it round-trips
+// byte-exactly at any size (#389).
+function getMessage(): Uint8Array {
+  const header = new Uint8Array(4);
+  // 4-byte LE length prefix. EOF here = clean shutdown → empty body.
+  if (!readExact(header, 4)) return new Uint8Array(0);
+  const declaredLen = decodeLength(header);
+
+  // Read exactly the declared body bytes. A truncated body (EOF mid-frame)
+  // also terminates the loop, signalled as an empty body.
+  const body = new Uint8Array(declaredLen);
+  if (!readExact(body, declaredLen)) return new Uint8Array(0);
+
+  // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
+  // protocol stream. Chrome ignores the host's stderr. The frame is the 4-byte
+  // LE prefix plus the declared body, so total bytes consumed is 4 + declaredLen.
+  console.error(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}`);
+  return body;
 }
 
-// Write a framed Native Messaging response: the 4-byte little-endian length
-// prefix followed by the JSON body, both on stdout (fd=1), no newline.
-function writeMessage(body: string): void {
-  const len = body.length;
+// sendMessage(message) — write a framed Native Messaging response: the 4-byte
+// little-endian length prefix followed by the body bytes, both on stdout (fd=1),
+// no trailing newline. The body is written as raw bytes so it is byte-exact for
+// any payload, including a megabyte-scale message (#389).
+function sendMessage(message: Uint8Array): void {
+  const len = message.length;
   // Binary 4-byte LE length prefix via raw-byte stdout (#1651).
   process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
-  // JSON body — runtime string, written verbatim with no trailing newline.
-  process.stdout.write(body);
+  // Body — raw bytes, written verbatim with no trailing newline. The write
+  // helper grows linear memory for large bodies (#389/#1723).
+  process.stdout.write(message);
 }
 
 export function main(): void {
-  // Long-lived port loop: read framed messages off stdin until EOF. A short
-  // read inside readExact is retried; a zero-byte read means the peer closed
-  // stdin, so we break and exit.
-  const header = new Uint8Array(4);
+  // Long-lived port loop: read framed messages off stdin until EOF, echoing
+  // each one back verbatim. getMessage() returns a zero-length body at EOF (or a
+  // truncated frame), which terminates the loop.
+  //
+  // Strict echo: the received body is sent back byte-for-byte, with no wrapper
+  // and no added bytes. This makes the demo a true round-trip proof — what
+  // Chrome sends in is exactly what comes back out, so the stdin->stdout
+  // fidelity of the WASI build is directly observable. A real host would instead
+  // decode `message`, dispatch on a command field, and frame a structured
+  // response with sendMessage().
   while (true) {
-    // 4-byte LE length prefix. EOF here = clean shutdown.
-    if (!readExact(header, 4)) break;
-    const declaredLen = decodeLength(header);
-
-    // Read exactly the declared body bytes. A truncated body (EOF mid-frame)
-    // also terminates the loop.
-    const body = new Uint8Array(declaredLen);
-    if (!readExact(body, declaredLen)) break;
-    const bodyStr = bodyToString(body, declaredLen);
-
-    // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
-    // protocol stream. Chrome ignores the host's stderr. The frame is the
-    // 4-byte LE prefix plus the declared body, so the total bytes consumed is
-    // 4 + declaredLen.
-    console.error(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}`);
-
-    // Strict echo: write the received body back verbatim, byte-for-byte, with
-    // no wrapper and no added bytes. This makes the demo a true round-trip
-    // proof — what Chrome sends in is exactly what comes back out, so the
-    // stdin->stdout fidelity of the WASI build is directly observable.
-    // A real host would instead parse `bodyStr`, dispatch on a command field,
-    // and build a structured response here.
-    writeMessage(bodyStr);
+    const message = getMessage();
+    if (message.length === 0) break;
+    sendMessage(message);
   }
 }

--- a/plan/issues/1530-wasi-native-messaging-host-example.md
+++ b/plan/issues/1530-wasi-native-messaging-host-example.md
@@ -1,9 +1,10 @@
 ---
 id: 1530
 title: "wasi: Native Messaging host example (Chrome extension integration)"
-status: in-progress
+status: done
 created: 2026-05-20
-updated: 2026-05-24
+updated: 2026-05-29
+completed: 2026-05-29
 priority: medium
 feasibility: medium
 reasoning_effort: low

--- a/plan/issues/1733-native-messaging-bytes-body-and-large-uint8array-write-overflow.md
+++ b/plan/issues/1733-native-messaging-bytes-body-and-large-uint8array-write-overflow.md
@@ -1,0 +1,104 @@
+---
+id: 1733
+title: "Native Messaging host: 1 MiB body corruption — byte-write helpers miss the memory-grow guard; refactor host to raw-Uint8Array 3-symbol API"
+status: done
+created: 2026-05-29
+updated: 2026-05-29
+completed: 2026-05-29
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, runtime, docs
+language_feature: wasi, stdout-write, uint8array, arraybuffer
+goal: real-world-compat, wasi-completeness
+sprint: 57
+parent: 389
+related: [389, 887, 1530, 1651, 1655, 1723]
+reporter: guest271314
+---
+# #1733 — Native Messaging 1 MiB body corruption + raw-byte API refactor
+
+## Problem
+
+Reported by guest271314 against the Native Messaging host (parent #389), tested
+in WASI/standalone mode. A small framed message round-trips fine, but a **1 MiB**
+framed message comes back corrupt:
+
+```
+declared body length 1048576
+message: [null, null, … 209615+ items]
+```
+
+#1723 already fixed the **string-write** path for large responses (ConsString
+downcast + `__wasi_write_any_string` memory-grow guard). This issue covers the
+remaining gap on the **raw-byte** write path, plus a host-source refactor that
+removes the lossy string round-trip entirely.
+
+## Root cause
+
+`ensureWasiWriteUint8ArrayHelper` and `ensureWasiWriteArrayBufferHelper`
+(`src/codegen/index.ts`) stage the body bytes into linear memory at
+`WASI_WRITE_SCRATCH_START` (128 KiB, page 2), one byte at a time, then issue a
+single `fd_write`. The module reserves only **3 pages (192 KiB)** by default, so
+a ~1 MiB `process.stdout.write(Uint8Array)` writes far past the end of memory.
+
+The string-write helper got the memory-grow guard in #1723
+(`neededPages = ceil((SCRATCH_START + len) / 65536); if (neededPages >
+memory.size) memory.grow(...)`), but these two **byte-write siblings were
+missed** — so a large raw-byte write traps `memory access out of bounds` (or,
+under a bump allocator that reuses memory, silently corrupts the output, which
+is what produced guest's `[null, …]`).
+
+Reproduced directly: a minimal `main()` that builds a 1 MiB `Uint8Array` and
+calls `process.stdout.write(buf)`, compiled `--target wasi`, traps
+`memory access out of bounds`. After the fix it writes 1,048,576 byte-exact
+bytes.
+
+## Fix
+
+1. **`ensureWasiWriteUint8ArrayHelper` + `ensureWasiWriteArrayBufferHelper`
+   (`src/codegen/index.ts`)** — add the same `memory.grow` guard the
+   string-write helper has (#1723): compute `neededPages` from
+   `WASI_WRITE_SCRATCH_START + len` and grow linear memory before staging. Adds
+   one `needPages` i32 local to each helper.
+
+2. **`examples/native-messaging/host.ts`** — refactor to the **3-symbol API**
+   the reference hosts (`nm_assemblyscript.ts`, `nm_javy.js`, `nm_qjs_wasi.js`)
+   use across runtimes:
+   - `getMessage()` — read the 4-byte LE header then exactly N body bytes,
+     return the body as a raw **`Uint8Array`** (empty buffer = EOF / truncated
+     frame). The body is **never** decoded to a JS string, so it round-trips
+     byte-exactly at any size and avoids building a million-node ConsString rope.
+   - `sendMessage(message)` — frame a `Uint8Array` body: LE length prefix +
+     raw body bytes to stdout, no trailing newline.
+   - `main()` — the port loop: `const m = getMessage(); sendMessage(m);` until
+     an empty body. Strict verbatim echo preserved (#930). Carrying bytes is
+     also forward-compatible with Chromium's in-progress `Uint8Array` Native
+     Messaging support.
+
+3. **`examples/native-messaging/README.md`** — document the 3-symbol API and add
+   a section explaining `out/host.imports.js` (the generated WASI/JS-host imports
+   glue; not used by the standalone WASI launch path, emitted for the JS-host
+   on-ramp).
+
+## Tests
+
+`tests/issue-1530.test.ts`:
+- `echoes a 1 MiB framed body byte-exactly (#389 large-message regression)` —
+  drives the shipped example through the raw-byte WASI shim with a 1 MiB body
+  (0..250 byte ramp), asserts the 4-byte LE prefix declares 1 MiB and the
+  response body is byte-identical.
+- `writes a 1 MiB Uint8Array to stdout without trapping` — minimal compiler-side
+  regression: a large `process.stdout.write(Uint8Array)` no longer traps.
+
+The pre-existing #1530 compile/validity tests and the 13-byte round-trip test
+stay green; the smoke-test (`smoke-test.sh`) stderr/stdout assertions are
+unchanged (`getMessage()` keeps the exact `[host] received 17 chars, declared
+body length 13` debug line).
+
+## Result
+
+Fixed. Native Messaging host round-trips byte-exactly for 13 B, 1 KiB, 64 KiB,
+256 KiB, and 1 MiB bodies; the body is carried as raw bytes end-to-end with no
+lossy stringify.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4972,11 +4972,12 @@ export function ensureWasiWriteUint8ArrayHelper(
 
   const fd = useStderr ? 2 : 1;
 
-  // param: arr(0); locals: len(1), data(2), i(3)
+  // param: arr(0); locals: len(1), data(2), i(3), needPages(4)
   const ARR = 0;
   const LEN = 1;
   const DATA = 2;
   const I = 3;
+  const NEED_PAGES = 4;
 
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -4987,6 +4988,42 @@ export function ensureWasiWriteUint8ArrayHelper(
     { op: "local.get", index: ARR } as Instr,
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
     { op: "local.set", index: LEN } as Instr,
+
+    // #389/#1723: grow linear memory if the staging buffer
+    // [WASI_WRITE_SCRATCH_START .. WASI_WRITE_SCRATCH_START+len) would overflow
+    // the current memory size. The module reserves only 3 pages by default, so a
+    // ~1 MiB raw-byte write (the Native Messaging large-message case) writes far
+    // past page 2 and traps "memory access out of bounds" without this guard —
+    // the same fix the string-write helper got in #1723 but that this and the
+    // ArrayBuffer-write sibling were missing, which is what corrupted/dropped
+    // guest271314's 1 MiB framed message.
+    //
+    //   neededPages = ceil((WASI_WRITE_SCRATCH_START + len) / 65536)
+    //               = (WASI_WRITE_SCRATCH_START + len + 65535) >> 16
+    // i32.shr_u keeps the page count non-negative for lengths near 2^31.
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 65535 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 16 } as Instr,
+    { op: "i32.shr_u" } as Instr,
+    { op: "local.set", index: NEED_PAGES } as Instr,
+    // if (needPages > memory.size) memory.grow(needPages - memory.size)
+    { op: "local.get", index: NEED_PAGES } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEED_PAGES } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
 
     // data = arr.data (field 1)
     { op: "local.get", index: ARR } as Instr,
@@ -5060,6 +5097,7 @@ export function ensureWasiWriteUint8ArrayHelper(
       { name: "len", type: { kind: "i32" } },
       { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
       { name: "i", type: { kind: "i32" } },
+      { name: "needPages", type: { kind: "i32" } },
     ],
     body,
     exported: false,
@@ -5094,11 +5132,12 @@ export function ensureWasiWriteArrayBufferHelper(
 
   const fd = useStderr ? 2 : 1;
 
-  // param: buf(0); locals: len(1), data(2), i(3)
+  // param: buf(0); locals: len(1), data(2), i(3), needPages(4)
   const BUF = 0;
   const LEN = 1;
   const DATA = 2;
   const I = 3;
+  const NEED_PAGES = 4;
 
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -5109,6 +5148,34 @@ export function ensureWasiWriteArrayBufferHelper(
     { op: "local.get", index: BUF } as Instr,
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
     { op: "local.set", index: LEN } as Instr,
+
+    // #389/#1723: grow linear memory if the staging buffer would overflow the
+    // current memory size (only 3 pages reserved by default). A ~1 MiB
+    // ArrayBuffer write to stdout otherwise traps "memory access out of bounds".
+    // Mirrors the string-write helper's #1723 guard.
+    //   neededPages = (WASI_WRITE_SCRATCH_START + len + 65535) >> 16
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 65535 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 16 } as Instr,
+    { op: "i32.shr_u" } as Instr,
+    { op: "local.set", index: NEED_PAGES } as Instr,
+    { op: "local.get", index: NEED_PAGES } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEED_PAGES } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
 
     // data = buf.data (field 1)
     { op: "local.get", index: BUF } as Instr,

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -183,4 +183,125 @@ export function main(): void {
     expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
     expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
   });
+
+  // #389 — the shipped host echoes a 1 MiB framed body byte-for-byte.
+  // guest271314 reported that a 1 MiB message came back corrupt (an array of
+  // `null`s). Root cause: the raw-byte stdout write helper
+  // (`__wasi_write_uint8array`) staged the body into linear memory at
+  // WASI_WRITE_SCRATCH_START without growing memory first — only 3 pages
+  // (192 KiB) are reserved by default, so a ~1 MiB write ran past the end of
+  // memory and trapped / corrupted the output. The host now carries the body
+  // as a raw Uint8Array (no lossy String.fromCharCode stringify) and the write
+  // helper grows memory like the string-write path already did (#1723).
+  //
+  // We build a frame whose body is non-trivial bytes (a repeating 0..250 ramp,
+  // so any truncation, zeroing, or aliasing shows up as a byte mismatch) and
+  // assert the response is the exact same 1 MiB body with the right prefix.
+  it("echoes a 1 MiB framed body byte-exactly (#389 large-message regression)", () => {
+    const src = readFileSync(hostPath, "utf-8");
+    const result = compile(src, { fileName: "host.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+
+    const SIZE = 1024 * 1024; // 1 MiB
+    const body = new Uint8Array(SIZE);
+    for (let i = 0; i < SIZE; i++) body[i] = i % 251;
+    const input = new Uint8Array(4 + SIZE);
+    new DataView(input.buffer).setUint32(0, SIZE, true);
+    input.set(body, 4);
+
+    const out = runWasiRaw(result.binary, input);
+    // 4-byte LE prefix declares the full 1 MiB length…
+    expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(SIZE);
+    // …and the body is the exact same bytes, with no truncation/null-fill.
+    const respBody = out.subarray(4);
+    expect(respBody.length).toBe(SIZE);
+    let firstMismatch = -1;
+    for (let i = 0; i < SIZE; i++) {
+      if (respBody[i] !== body[i]) {
+        firstMismatch = i;
+        break;
+      }
+    }
+    expect(firstMismatch).toBe(-1);
+  });
+});
+
+// #389 — direct regression for the compiler-side bug: a large
+// process.stdout.write(Uint8Array) under --target wasi must grow linear memory
+// so the staged bytes don't run past the end of memory. Before the fix this
+// trapped "memory access out of bounds" at ~1 MiB (the byte-write helpers were
+// missing the memory.grow guard the string-write helper got in #1723). This is
+// independent of the Native Messaging example shape.
+describe("#389 large raw-byte stdout write grows memory", () => {
+  function runWriteOnly(binary: Uint8Array): Uint8Array {
+    const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+    const writes: Uint8Array[] = [];
+    const wasi = {
+      fd_read(): number {
+        return 0;
+      },
+      fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+        const view = new DataView(ref.mem!.buffer);
+        let total = 0;
+        for (let i = 0; i < iovsLen; i++) {
+          const ptr = view.getUint32(iovs + i * 8, true);
+          const len = view.getUint32(iovs + i * 8 + 4, true);
+          if (fd === 1) writes.push(Uint8Array.from(new Uint8Array(ref.mem!.buffer, ptr, len)));
+          total += len;
+        }
+        view.setUint32(nwritten, total, true);
+        return 0;
+      },
+      proc_exit(code: number): void {
+        throw new Error(`proc_exit(${code})`);
+      },
+      random_get(): number {
+        return 0;
+      },
+      clock_time_get(): number {
+        return 0;
+      },
+    };
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+      wasi_snapshot_preview1: wasi,
+      env: {},
+    });
+    ref.mem = inst.exports.memory as WebAssembly.Memory;
+    (inst.exports.main as () => void)();
+    const total = writes.reduce((n, b) => n + b.length, 0);
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const b of writes) {
+      out.set(b, off);
+      off += b.length;
+    }
+    return out;
+  }
+
+  it("writes a 1 MiB Uint8Array to stdout without trapping", () => {
+    const src = `
+declare const process: {
+  stdout: { write(chunk: Uint8Array | string): void };
+};
+export function main(): void {
+  const n = 1048576;
+  const buf = new Uint8Array(n);
+  let i = 0;
+  while (i < n) { buf[i] = (i % 251); i = i + 1; }
+  process.stdout.write(buf);
+}`;
+    const result = compile(src, { fileName: "u8write.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+
+    const out = runWriteOnly(result.binary);
+    expect(out.length).toBe(1048576);
+    let firstMismatch = -1;
+    for (let i = 0; i < out.length; i++) {
+      if (out[i] !== i % 251) {
+        firstMismatch = i;
+        break;
+      }
+    }
+    expect(firstMismatch).toBe(-1);
+  });
 });


### PR DESCRIPTION
Closes the 1 MiB body corruption guest271314 reported against the Native Messaging host (parent #389), plus the requested host refactor and docs. Tracked as #1733; finishes the #1530 example.

## Root cause (1 MiB null-corruption)

A small framed message round-trips fine; a 1 MiB one came back as an array of nulls. `ensureWasiWriteUint8ArrayHelper` and `ensureWasiWriteArrayBufferHelper` (`src/codegen/index.ts`) stage the body bytes into linear memory at `WASI_WRITE_SCRATCH_START` (page 2) one byte at a time, then `fd_write` once — **without growing memory first**. Only 3 pages (192 KiB) are reserved, so a ~1 MiB `process.stdout.write(Uint8Array)` writes past the end of memory and traps `memory access out of bounds` (or, under a bump allocator that reuses memory, silently corrupts the output). The string-write helper got this memory-grow guard in #1723; these two byte-write siblings were missed.

Reproduced directly: a minimal `main()` building a 1 MiB `Uint8Array` and calling `process.stdout.write(buf)` traps before the fix; byte-exact after.

## Changes

- **`src/codegen/index.ts`** — add the #1723 `memory.grow` guard
  (`neededPages = ceil((WASI_WRITE_SCRATCH_START + len) / 65536)`) to both byte-write helpers (Uint8Array + ArrayBuffer), with one added `needPages` i32 local each.
- **`examples/native-messaging/host.ts`** — refactor to the 3-symbol API the reference hosts use (`getMessage()` / `sendMessage(message)` / `main()`), carrying the body as a raw `Uint8Array` end-to-end. No lossy `String.fromCharCode` stringify, no million-node ConsString rope. Strict verbatim echo (#930) preserved; the exact stderr debug line is unchanged so `smoke-test.sh` stays green. Byte-oriented so it is forward-compatible with Chromium’s in-progress Uint8Array Native Messaging.
- **`examples/native-messaging/README.md`** — document the 3-symbol API and add a section explaining `out/host.imports.js` (the generated WASI/JS-host imports glue — not used by the standalone WASI launch path; emitted for the JS-host on-ramp).
- **`tests/issue-1530.test.ts`** — +2 regression tests: a 1 MiB framed body echoes byte-exactly through the shipped example; a minimal 1 MiB `process.stdout.write(Uint8Array)` no longer traps.

## Validation

- `tests/issue-1530.test.ts`: 7/7 pass (was 5).
- `tsc --noEmit`: clean. `biome lint` on changed files: clean.
- `node scripts/update-issues.mjs --check`: clean (no dup IDs).
- Local raw-byte WASI shim: host round-trips byte-exactly at 13 B, 1 KiB, 64 KiB, 256 KiB, 1 MiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)