### PR TITLE
chore: mark #1713 + #1714 done (merged, status lagged)

### DIFF
--- a/plan/issues/1713-ir-backend-emitter-trait-seam.md
+++ b/plan/issues/1713-ir-backend-emitter-trait-seam.md
@@ -1,7 +1,8 @@
 ---
 id: 1713
 title: "IR backend-trait: audit WasmGC bias in lower.ts + define BackendEmitter seam"
-status: in-progress
+status: done
+completed: 2026-05-29
 created: 2026-05-29
 updated: 2026-05-29
 priority: high

--- a/plan/issues/1714-ir-two-backend-proof-linear.md
+++ b/plan/issues/1714-ir-two-backend-proof-linear.md
@@ -1,7 +1,8 @@
 ---
 id: 1714
 title: "Lower one IR node kind through the BackendEmitter trait to BOTH WasmGC and linear"
-status: in-progress
+status: done
+completed: 2026-05-29
 created: 2026-05-29
 updated: 2026-05-29
 priority: high


### PR DESCRIPTION
PRs #911 (#1713 BackendEmitter trait) and #928 (#1714 vec→both backends) merged but their issue files stayed in-progress. Flips both to done. Docs-only.