### PR TITLE
fix(#1740): padStart/padEnd omitted fillString defaults to space (S57 triage-2)

### DIFF
--- a/plan/issues/1740-padstart-padend-default-fillstring-space.md
+++ b/plan/issues/1740-padstart-padend-default-fillstring-space.md
@@ -1,0 +1,54 @@
+---
+id: 1740
+title: "String.prototype.padStart/padEnd omitted fillString defaults to 'null' instead of space"
+status: done
+created: 2026-05-29
+completed: 2026-05-29
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: string-methods
+goal: test262-conformance
+sprint: 57
+related: [1739]
+---
+# #1740 — padStart/padEnd default fillString must be a space
+
+## Problem
+
+`'abc'.padStart(6)` (fillString omitted) returned `"nulabc"` instead of
+`"   abc"`. Per §22.1.3.17 StringPad, when `fillString` is `undefined` it is
+set to `" "` (a single space).
+
+In JS-host mode the string-method dispatch (`src/codegen/expressions/calls.ts`)
+padded the missing `fillString` externref argument with `ref.null.extern`, so
+the host `string_padStart` received JS `null`, which ToString-coerces to
+`"null"` → the pad used "nul"/"null".
+
+## Fix
+
+`padStart`/`padEnd` added to the `padsUndefined` set in `calls.ts` (alongside
+`endsWith`/`lastIndexOf`), so the omitted pad arg is passed as JS `undefined`
+(via `__get_undefined`). The host then calls `s.padStart(n)` and the native JS
+spec default `" "` applies.
+
+## Test Results
+
+`tests/issue-1740.test.ts` — 6 cases pass:
+- `'abc'.padStart(6)` → `"   abc"`, `'abc'.padEnd(6)` → `"abc   "`
+- explicit fill unchanged (`'x'.padStart(4,'12')` → `"121x"`)
+- target ≤ length returns unchanged
+- multi-char fill truncates (`'abc'.padStart(7,'def')` → `"defdabc"`)
+
+test262 `built-ins/String/prototype/padStart` and `padEnd` each go 6→7
+runtime-pass locally (the `fill-string-omitted` + `normal-operation` cases).
+No regression in `endsWith`/`lastIndexOf` (share the same branch).
+
+The remaining padStart/padEnd test262 failures are TS-type-check CEs from
+intentionally wrong-typed args (symbol/boolean) — tracked under #1741.
+
+## Files modified
+
+- `src/codegen/expressions/calls.ts` — add padStart/padEnd to `padsUndefined`.
+- `tests/issue-1740.test.ts` — new.

--- a/plan/issues/1741-typechecker-rejects-test262-wrong-typed-builtin-args.md
+++ b/plan/issues/1741-typechecker-rejects-test262-wrong-typed-builtin-args.md
@@ -1,0 +1,73 @@
+---
+id: 1741
+title: "TS type-checker CEs on test262 intentionally-wrong-typed builtin method args"
+status: backlog
+created: 2026-05-29
+priority: medium
+feasibility: hard
+task_type: bugfix
+area: checker
+language_feature: type-checking
+goal: test262-conformance
+sprint: Backlog
+related: [1740, 1445]
+---
+# #1741 — type-checker rejects test262 wrong-typed builtin args
+
+## Problem
+
+A large share of `built-ins/{String,Array,Math,Number}/prototype/*` test262
+FAILs are **compile errors from our TypeScript type-checker**, not runtime
+defects. test262 deliberately passes spec-relevant *wrong-typed* arguments to
+builtin methods to exercise the runtime coercion / abrupt-completion paths:
+
+```
+Argument of type 'symbol' is not assignable to parameter of type 'number'.
+Argument of type 'boolean' is not assignable to parameter of type 'number'.
+Argument of type 'null' is not assignable to parameter of type ...
+Argument of type '{ valueOf(): number }' is not assignable to parameter ...
+Argument of type '1' is not assignable to parameter of type 'never'.
+```
+
+These are valid JS — the spec says the method ToNumber/ToString/ToInteger-
+coerces the arg at runtime (or throws a *runtime* TypeError, which several
+of these tests assert via `assert.throws`). Our pipeline rejects them at
+compile time before codegen, so the test can never reach its runtime
+assertion.
+
+Observed during the Sprint 57 triage-2 bounded sweep across
+String.prototype.{padStart,padEnd,at,repeat}, Array.prototype.{at,fill,
+includes}, Math.{expm1,log1p,cbrt} — the dominant non-representation FAIL
+bucket in those categories was this type-check CE class (5–15 CEs per
+category).
+
+## Root-cause hypothesis
+
+The compiler runs TS semantic diagnostics and treats argument-assignability
+errors on builtin lib signatures (lib.es*.d.ts) as hard compile errors. For
+test262 (which is spec-conformance JS, not type-checked TS), these
+assignability errors on *builtin* method calls should be downgraded — the
+runtime path already coerces (e.g. `compileStringIntegerArg` →
+ToInteger/ToNumber, #1445 throws the spec TypeError for bigint/symbol). The
+test harness (`wrapTest`) or the compile entrypoint could relax
+arg-assignability diagnostics for known builtin-method call sites (or test262
+mode could compile with `noImplicitAny`/assignability relaxed), letting the
+runtime coercion + spec-throw logic decide.
+
+## Scope / caution
+
+This is a checker-policy change with broad blast radius (could mask real user
+type errors). Needs an architect call on *where* to relax (test262-mode only?
+builtin call sites only? a diagnostic allowlist?) and how to keep it from
+weakening normal compile-time safety. Sized hard; not a localized dev fix.
+
+## Acceptance criteria
+
+- test262 builtin-method cases with intentionally-wrong-typed args reach their
+  runtime assertion instead of CE-ing.
+- Real user-code type errors are NOT masked outside test262 mode.
+- Net test262 gain across the String/Array/Number/Math prototype categories.
+
+## Source
+
+Filed from Sprint 57 triage-2 (dev-c) bounded FAIL sweep, 2026-05-29.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6888,7 +6888,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           // Pad missing externref position args with JS undefined (via
           // `__get_undefined`) so the host sees the spec-correct "not passed"
           // value instead of `null`.
-          const padsUndefined = method === "endsWith" || method === "lastIndexOf";
+          // #1740 — padStart/padEnd: an OMITTED fillString must default to a
+          // single space " " (§22.1.3.17 StringPad: if fillString is
+          // undefined, set it to " "). Padding the missing externref arg with
+          // `ref.null.extern` makes the host see JS `null`, which ToString-
+          // coerces to "null" → e.g. `"abc".padStart(6)` returned "nulabc"
+          // instead of "   abc". Pass JS `undefined` so the host applies the
+          // spec default. (Same null-vs-undefined distinction as endsWith.)
+          const padsUndefined =
+            method === "endsWith" || method === "lastIndexOf" || method === "padStart" || method === "padEnd";
           let undefIdx: number | undefined;
           if (padsUndefined) {
             undefIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);

--- a/tests/issue-1740.test.ts
+++ b/tests/issue-1740.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1740 — String.prototype.padStart / padEnd with an OMITTED fillString
+ * must default to a single space " " (§22.1.3.17 StringPad: if fillString is
+ * undefined, set it to " ").
+ *
+ * In JS-host mode the string-method dispatch padded the missing `fillString`
+ * externref arg with `ref.null.extern`, so the host saw JS `null`, which
+ * ToString-coerces to "null" — `"abc".padStart(6)` returned "nulabc" instead
+ * of "   abc". The fix passes JS `undefined` (via `__get_undefined`) for the
+ * omitted pad arg, the same null-vs-undefined distinction already applied to
+ * `endsWith` / `lastIndexOf`, so the host applies the spec default " ".
+ *
+ * test262 cases driving the fix:
+ *   built-ins/String/prototype/padStart/fill-string-omitted.js
+ *   built-ins/String/prototype/padStart/normal-operation.js
+ *   built-ins/String/prototype/padEnd/fill-string-omitted.js
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { getTestSandbox } from "./test262-runner.js";
+
+async function runWasm(source: string): Promise<unknown> {
+  const result = compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool, { globalSandbox: getTestSandbox() });
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports.test as () => unknown)();
+}
+
+describe("#1740 — padStart/padEnd default fillString is a space", () => {
+  it("padStart with omitted fill pads with spaces", async () => {
+    expect(await runWasm(`export function test(): string { return "abc".padStart(6); }`)).toBe("   abc");
+  });
+
+  it("padEnd with omitted fill pads with spaces", async () => {
+    expect(await runWasm(`export function test(): string { return "abc".padEnd(6); }`)).toBe("abc   ");
+  });
+
+  it("padStart with explicit fill is unchanged", async () => {
+    expect(await runWasm(`export function test(): string { return "x".padStart(4, "12"); }`)).toBe("121x");
+  });
+
+  it("padEnd with explicit fill is unchanged", async () => {
+    expect(await runWasm(`export function test(): string { return "x".padEnd(4, "12"); }`)).toBe("x121");
+  });
+
+  it("padStart with target <= length returns the string unchanged", async () => {
+    expect(await runWasm(`export function test(): string { return "hello".padStart(3); }`)).toBe("hello");
+  });
+
+  it("padStart multi-char fill truncates to fit (omitted-fill sibling case)", async () => {
+    expect(await runWasm(`export function test(): string { return "abc".padStart(7, "def"); }`)).toBe("defdabc");
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 57 triage-2 (dev-c): one localized non-representation test262 win + sized issues for the rest.

**Fix #1740** — `'abc'.padStart(6)` (fillString omitted) returned `"nulabc"` instead of `"   abc"`. Per §22.1.3.17 StringPad, an `undefined` fillString defaults to a single space `" "`. In JS-host mode the string-method dispatch padded the missing fillString externref with `ref.null.extern` → host saw JS `null` → ToString `"null"`. Adding `padStart`/`padEnd` to the `padsUndefined` set in `calls.ts` (alongside `endsWith`/`lastIndexOf`) passes JS `undefined` so the host applies the spec default.

## Verification

`tests/issue-1740.test.ts` — 6 cases pass (omitted-fill → spaces, explicit fill unchanged, target≤len, multi-char truncate). `built-ins/String/prototype/{padStart,padEnd}` each +1 runtime-pass locally. No regression in `endsWith`/`lastIndexOf` (shared branch).

## Triage issues filed

- **#1741** (Backlog) — TS type-checker CEs on test262 intentionally-wrong-typed builtin method args (symbol/boolean/null/`{valueOf}`). This was the dominant non-representation FAIL bucket across the String/Array/Number/Math prototype categories I swept — valid JS the spec coerces/throws at runtime, but our checker CEs at compile time before codegen. Needs an architect call on a test262-mode / builtin-call-site assignability relaxation (broad blast radius).

Bounded per the task: one fix PR + sized issue file. Excluded the owned clusters (object-representation #1629/#1719/#1732/#1130/#1320, async-CPS #1042, generators #1665).

🤖 Generated with [Claude Code](https://claude.com/claude-code)