### PR TITLE
fix(#1732-S2): new <Math|JSON|Reflect|Atomics>.<method>() must throw TypeError

### DIFF
--- a/plan/issues/1732-builtin-method-value-construct-brand-and-descriptors.md
+++ b/plan/issues/1732-builtin-method-value-construct-brand-and-descriptors.md
@@ -449,3 +449,34 @@ where the method type resolves to `any`. Fold a `<Math|JSON|Reflect|Atomics>.
 <method>` member-access arm into the S2 PR (same file). The f16round
 `value-conversion.js` fail is a missing test262 harness include
 (`byteConversionValues`), not a compiler bug.
+
+## S2 landed (dev-a, 2026-05-29)
+
+**S2 scope refined during implementation.** The A8 own-`length`/`name`
+descriptor family (the slice's nominal target) is **already green on main** —
+all 14 `String.prototype/*/S15.5.4.*_A8.js` tests pass post-#941/#936. The
+host-method values resolve through `__get_builtin`/`__extern_get` and carry
+correct descriptors, `hasOwnProperty('length')`/`propertyIsEnumerable('length')`
+return true/false correctly, and `for-in` routes through the host key path that
+already honors non-enumerability (verified: the `for (p in
+String.prototype.charAt)` count-0 assertion passes). So **no codegen change was
+needed for A8** — the jsonl baseline listing them as failing was pre-#941/stale.
+
+The one genuinely-unfixed gap in S2's scope was the **`new
+<NonCtorNamespace>.<method>()` not-a-constructor arm**: `new Math.f16round()` /
+`new Math.sumPrecise()` returned instead of throwing TypeError, because those
+methods are newer than the bundled TS lib → type `any` → slip past the
+Pattern 2 (call-sigs/no-construct-sigs) guard → reach the unknown-ctor path that
+never performs [[Construct]]. Fixed with a Pattern-1 extension in
+`src/codegen/expressions/new-super.ts` keyed on the receiver **namespace name**
+(`Math`/`JSON`/`Reflect`/`Atomics`), making it lib-version-independent — it
+fires for any current or future method on those namespaces. The existing
+`new Math.abs()` (Pattern 2) and `new Math()` (namespace guard) paths are
+untouched. JS-host realization, no `$FuncObj` struct (that's S3/S4).
+
+Tests: `tests/issue-1732-s2.test.ts` (6) — `new Math.f16round`/`Math.sumPrecise`
+/`Reflect.has`/`JSON.parse` throw TypeError; regression guards confirm
+`new Math.abs()` and `new Math()` still throw. The 14 A8 tests stay green; #1732
+S1 tests stay green. Closes test262
+`built-ins/Math/f16round/not-a-constructor.js` and the analogous newer-method
+not-a-constructor cases.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1583,6 +1583,27 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         fctx.body.push({ op: "ref.null.extern" });
         return { kind: "externref" };
       }
+      // (#1732 S2) `new <NonCtorNamespace>.<method>()` — a method pulled off a
+      // non-constructor namespace object (Math/JSON/Reflect/Atomics). Every such
+      // method is an ordinary function with no [[Construct]] (§21.3/§25.5/§28.1/
+      // §25.4), so `new` must throw TypeError. Pattern 2 below only fires when
+      // the TS lib KNOWS the method has call-sigs/no-construct-sigs; methods
+      // NEWER than the bundled lib (e.g. `Math.f16round`, `Math.sumPrecise`)
+      // resolve to `any`, slip past Pattern 2, and reach the unknown-ctor path
+      // which never performs [[Construct]] and so wrongly returns instead of
+      // throwing (test262 built-ins/Math/f16round/not-a-constructor.js etc.).
+      // Keying on the namespace NAME makes the guard lib-version-independent —
+      // it fires for any current or future Math/JSON/Reflect/Atomics method. The
+      // receiver-name match is intentionally narrow to those four built-ins
+      // (the same discipline as the namespace-identifier guard below).
+      if (ts.isIdentifier(obj)) {
+        const NS_NON_CONSTRUCTORS = new Set(["Math", "JSON", "Reflect", "Atomics"]);
+        if (NS_NON_CONSTRUCTORS.has(obj.text)) {
+          emitThrowTypeError(ctx, fctx, "is not a constructor");
+          fctx.body.push({ op: "ref.null.extern" });
+          return { kind: "externref" };
+        }
+      }
     }
 
     // Pattern 2: TypeScript knows the expression has call sigs but no construct sigs.

--- a/tests/issue-1732-s2.test.ts
+++ b/tests/issue-1732-s2.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #1732 S2 — `new <NonCtorNamespace>.<method>()` must throw TypeError.
+ *
+ * A method pulled off a non-constructor namespace object (Math / JSON / Reflect
+ * / Atomics) is an ordinary function with no [[Construct]] (§21.3 / §25.5 /
+ * §28.1 / §25.4), so `new` on it must throw TypeError (§7.3.13 Construct →
+ * IsConstructor). The compile-time Pattern 2 guard in new-super.ts only fires
+ * when the TS lib KNOWS the method has call-sigs / no-construct-sigs; methods
+ * NEWER than the bundled lib — `Math.f16round`, `Math.sumPrecise` — resolve to
+ * `any`, slip past Pattern 2, and reached the unknown-ctor path that never
+ * performed [[Construct]] (so `new Math.f16round()` returned instead of
+ * throwing — test262 built-ins/Math/f16round/not-a-constructor.js etc.).
+ *
+ * S2 fix: a Pattern-1 extension keyed on the receiver NAMESPACE NAME
+ * (Math/JSON/Reflect/Atomics), so it fires for any current or future method on
+ * those namespaces regardless of lib version.
+ *
+ * NOTE: the A8 own-`length`/`name` descriptor + for-in family this slice
+ * nominally targeted is already green on main (host method values carry correct
+ * descriptors and route for-in through the host key path post-#941/#936), so
+ * S2's only codegen change is this namespace-method not-a-constructor arm.
+ *
+ * Assertion style: the `new` throw crosses the JS boundary as a raw
+ * `WebAssembly.Exception`, NOT a JS `TypeError`. So we catch INSIDE the
+ * compiled module and check `e instanceof TypeError` there (returning 1) — the
+ * exact `assert.throws(TypeError, …)` shape test262 uses, and the only way to
+ * observe that the thrown value is a real TypeError instance.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// Returns 1 iff `new <newExpr>` throws and the caught value is a TypeError;
+// 0 if no throw; 2 if a non-TypeError was thrown.
+async function newThrowsTypeError(newExpr: string): Promise<unknown> {
+  const src = `export function test(): number { try { var x = new ${newExpr}; return 0; } catch (e) { return (e instanceof TypeError) ? 1 : 2; } }`;
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`CE: ${r.errors[0]?.message ?? "?"}`);
+  const io = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, io as any);
+  (io as any).setExports?.(instance.exports);
+  return (instance.exports as any).test();
+}
+
+describe("#1732 S2 — new on a non-constructor namespace method throws TypeError", () => {
+  it("new Math.f16round() → TypeError (method newer than TS lib, type any)", async () => {
+    expect(await newThrowsTypeError("(Math.f16round as any)(1)")).toBe(1);
+  });
+
+  it("new Math.sumPrecise() → TypeError (also lib-unknown)", async () => {
+    expect(await newThrowsTypeError("(Math.sumPrecise as any)([])")).toBe(1);
+  });
+
+  it("new Reflect.has() → TypeError", async () => {
+    expect(await newThrowsTypeError(`(Reflect.has as any)({}, "x")`)).toBe(1);
+  });
+
+  it("new JSON.parse() → TypeError", async () => {
+    expect(await newThrowsTypeError(`(JSON.parse as any)("1")`)).toBe(1);
+  });
+
+  // ── Regression guards: lib-known namespace methods + the namespace itself ──
+
+  it("new Math.abs() still throws TypeError (lib-known, Pattern 2)", async () => {
+    expect(await newThrowsTypeError("(Math.abs as any)(1)")).toBe(1);
+  });
+
+  it("new Math() (the namespace itself) still throws TypeError", async () => {
+    expect(await newThrowsTypeError("Math()")).toBe(1);
+  });
+});


### PR DESCRIPTION
Slice S2 of the #1732 function-object representation work.

## Problem

`new Math.f16round()` / `new Math.sumPrecise()` returned a value instead of throwing `TypeError`. These methods are **newer than the bundled TS lib**, so their type resolves to `any` → they slip past the Pattern 2 (call-sigs/no-construct-sigs) guard in `new-super.ts` → reach the unknown-ctor fall-through which never performs `[[Construct]]`. Per ECMA-262 §7.3.13 Construct → IsConstructor, `new` on a namespace method (no `[[Construct]]` per §21.3/§25.5/§28.1/§25.4) must throw.

## Fix

A Pattern-1 extension in `src/codegen/expressions/new-super.ts` keyed on the receiver **namespace name** (`Math`/`JSON`/`Reflect`/`Atomics`) — **lib-version-independent**, so it fires for any current or future method on those namespaces, including ones the TS lib doesn't know. Emits the real-TypeError throw path. The existing `new Math.abs()` (Pattern 2) and `new Math()` (namespace-identifier guard) paths are untouched.

## Scope note — A8 was already green

The A8 own-`length`/`name` descriptor family this slice nominally targeted is **already green on main**: all 14 `String.prototype/*/S15.5.4.*_A8.js` tests pass post-#941/#936 (host method values carry correct descriptors; `hasOwnProperty`/`propertyIsEnumerable` return correctly; `for-in` routes through the host key path honoring non-enumerability). The jsonl baseline that listed them failing predated #941. **No codegen change needed for A8.** JS-host only, no `$FuncObj` struct (S3/S4).

## Tests

- `tests/issue-1732-s2.test.ts` (6) — `new Math.f16round`/`Math.sumPrecise`/`Reflect.has`/`JSON.parse` throw a real `TypeError` (`e instanceof TypeError` verified inside the module); regression guards confirm `new Math.abs()` + `new Math()` still throw.
- A8 14/14 stays green; #1732-S1 tests stay green; typecheck clean.

Closes test262 `built-ins/Math/f16round/not-a-constructor.js` and the analogous newer-method not-a-constructor cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)