### PR TITLE
fix(#1629 S3): route inline defineProperty-accessor STORE to runtime sidecar

### DIFF
--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -3,7 +3,7 @@ id: 1629
 title: "spec gap: Object.defineProperty — descriptor attribute fidelity (664 test262 fails, biggest single bucket)"
 status: ready
 created: 2026-05-08
-updated: 2026-05-29
+updated: 2026-05-30
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -532,6 +532,64 @@ for the no-descriptor case (diff the emitted Wasm for a plain `{a:0}.a` read).
 function-free / 83 plain of c4), `tests/issue-1629-S3.test.ts`
 (accessor read-back, dynamic data overwrite, delete-then-read). Re-run #1130
 suite — expect incidental gains.
+
+> **S3 STATUS — first sub-slice DONE (2026-05-30, senior-developer).** Shipped
+> the inline `defineProperty`-accessor **STORE contract** fix (the verified
+> `const o:any={z:0}; Object.defineProperty(o,"p",{get(){return 42}}); o.p`
+> returns `undefined` bug). Root cause (confirmed by probe): the accessor branch
+> in `compileObjectDefineProperty` (`src/codegen/object-ops.ts:914`) compiled a
+> dead `${structName}_get_<prop>` Wasm function + `classAccessorSet` and
+> EARLY-RETURNED, feeding **no** runtime sidecar — so the getter lived in neither
+> `_wasmStructProps[obj]["__get_<prop>"]` nor `_wasmStructAccessors`, the slots
+> `_safeGet` / `_readOwnDescriptor` / GOPD consult.
+>
+> **Fix (two files, ~50 lines):**
+> 1. `src/codegen/object-ops.ts` — gate the inline accessor branch on a new
+>    `receiverIsStaticStruct` bit (= struct resolved *without* the `any`/externref
+>    define-site rescue fallbacks, i.e. the same resolution strength the read
+>    site `resolveStructNameForExpr` has). **Statically-typed receivers**
+>    (class instances, typed objects) keep the compiled-getter fast path
+>    unchanged — that path IS reachable from their reads, and removing it
+>    regressed the #459 accessor suite by 6 in a first attempt. **`const o:any`
+>    receivers** (resolved only via fallbacks 1–3) now fall through to the
+>    existing `emitExternDefinePropertyNoValue`, which already mirrors get/set
+>    into the runtime `__defineProperty_accessor` import (closure-wrapped via
+>    `_maybeWrapCallable` / `__call_fn_N`) — the symmetric mirror the data-value
+>    path always emitted. One write reconciles `_safeGet`, GOPD, and
+>    `_readOwnDescriptor`.
+> 2. `src/runtime.ts` `__defineProperty_accessor` — one defensive line for the
+>    **data→accessor flip**: drop a stale plain value at `sc[prop]` before
+>    installing the getter, so `_sidecarGet` (checked before `__get_<prop>` in
+>    `_safeGet`) cannot shadow the new accessor.
+>
+> **WHY this shape, not the architect's approach (A) verbatim:** (A) proposed a
+> *new* `emitExternDefinePropertyAccessor` helper, but the exact plumbing it
+> describes (compile get/set via `compileArrowAsCallback({needsThis:true})` →
+> `__defineProperty_accessor`) **already exists** in
+> `emitExternDefinePropertyNoValue` — the bug was purely that the early-returning
+> struct branch *intercepted* the accessor case before reaching it. Routing
+> through the existing helper is strictly less code and reuses proven plumbing.
+>
+> **Fixed (verified by `tests/issue-1629-S3.test.ts`, 10 cases):** getter on
+> dot / bracket / dynamic-key reads of an `any` receiver; getter with `this`
+> receiver (works — `_maybeWrapCallable` binds `this` for getters, contrary to
+> the dropped-`this` note which only affects the broader closure-arity path);
+> getter closing over scope; get-only / set-only / get+set; data→accessor flip
+> via bracket read; GOPD read-back (`{get:fn, set:undefined, enumerable:false,
+> configurable:false}`).
+>
+> **Still deferred to the broader S3 read-shim / representation foundation
+> (#1130/#1320), NOT in this slice — confirmed PRE-EXISTING on main, not
+> regressed:** (1) `o.k` **dot**-access on a *statically-known struct field*
+> redefined as an accessor lowers to a direct `struct.get` that never touches
+> `_safeGet` (bracket/dynamic reads of the same prop DO work); (2) `o.k = v`
+> **setter invocation** on an `any` receiver does not fire (write-side
+> `_safeSet`→`__set_<prop>` gap, independent of this STORE fix); (3) host-side
+> *raw JS* `o.p` access on a returned opaque WasmGC struct externref (same
+> limitation the data path has — the sidecar is only consulted by compiled
+> `_safeGet`, not native V8 access). No-regression confirmed: the #459 /
+> defineProperty / object-literal-getter equivalence suites match baseline
+> exactly (3 pre-existing fails, unchanged).
 
 ### S4 — Invariant enforcement on define (configurable/writable/extensible)  *(est. +40–70)*
 

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -850,6 +850,20 @@ export function compileObjectDefineProperty(
     resolveStructName(ctx, objTsType) ||
     (ts.isIdentifier(objArg) ? ctx.widenedVarStructMap.get(objArg.text) : undefined);
 
+  // (#1629 S3) Whether the receiver is *statically* struct-typed — i.e. resolved
+  // WITHOUT the `any`/externref rescue fallbacks 1-3 below. This is the same
+  // strength of resolution the *read* site (`resolveStructNameForExpr` in
+  // property-access.ts) has, so when it is set the compiled accessor fast path
+  // (`${structName}_get_<prop>` + `classAccessorSet`) is reachable from reads and
+  // must be kept. When it is unset (the `const o:any = {...}` case, resolved only
+  // via the define-site-only fallbacks), reads route through `__extern_get` /
+  // `_safeGet`, which the synthesized compiled getter can NOT serve — those must
+  // instead mirror the accessor into the runtime sidecar (the working
+  // `emitExternDefinePropertyNoValue` → `__defineProperty_accessor` path). Splitting
+  // on this bit fixes the `const o:any` accessor-get bug without regressing the
+  // statically struct-typed (class-instance) accessor path.
+  const receiverIsStaticStruct = structName !== undefined;
+
   // Fallback 1: resolve struct name from the local variable's Wasm type.
   // This handles cases where the TS type is `any` but the local holds a struct ref.
   if (!structName && ts.isIdentifier(objArg)) {
@@ -907,11 +921,36 @@ export function compileObjectDefineProperty(
 
   // ── Getter/setter path ──────────────────────────────────────────────
   // Object.defineProperty(obj, "prop", { get() {...}, set(v) {...} })
-  // Compile as struct accessor methods, analogous to object literal getters/setters.
-  // Take the struct path whenever a struct is known — accessor properties don't need fieldIdx >= 0
-  // because they compile as Wasm functions (not struct fields). Property assignment uses the
-  // classAccessorSet to route o.foo = v to the compiled setter Wasm function.
-  if ((getNode || setNode) && !valueExpr && structName && structTypeIdx !== undefined && propName) {
+  //
+  // (#1629 S3) For a *statically struct-typed* receiver (a class instance / typed
+  // object — `receiverIsStaticStruct`) this branch compiles the getter/setter into
+  // a `${structName}_get_<prop>` Wasm function + `classAccessorSet` registration,
+  // which the read site dispatches via `compilePropertyAccess`'s class-accessor
+  // path. That read site resolves the same `structName`, so the compiled fast
+  // path is reachable and stays — removing it regresses the #459 accessor suite.
+  //
+  // For a `const o:any = {...}` receiver, by contrast, `structName` was resolved
+  // ONLY via the define-site rescue fallbacks 1-3 below, which the *read* site
+  // (`resolveStructNameForExpr`) lacks. Such reads lower to `__extern_get` /
+  // `_safeGet`, which the synthesized compiled getter can NOT serve — so the old
+  // unconditional early-return left the getter in neither
+  // `_wasmStructProps[obj]["__get_<prop>"]` nor `_wasmStructAccessors`, and
+  // `o.p` / `o["p"]` / `o[k]` / host reads returned `undefined`. We now fall
+  // those through (below) to `emitExternDefinePropertyNoValue`, which mirrors
+  // get/set into the runtime `__defineProperty_accessor` import (closure-wrapped
+  // via `_maybeWrapCallable` / the unconditional `__call_fn_<n>` bridge, validated
+  // by `_validatePropertyDescriptor`, written to the canonical sidecar slot
+  // `_safeGet` / S1 `_readOwnDescriptor` / GOPD all consult). One write reconciles
+  // every reader — the symmetric mirror the data-value path already emits via
+  // `__defineProperty_value`.
+  if (
+    receiverIsStaticStruct &&
+    (getNode || setNode) &&
+    !valueExpr &&
+    structName &&
+    structTypeIdx !== undefined &&
+    propName
+  ) {
     // Compile obj and save to local
     const objType = compileExpression(ctx, fctx, objArg);
     if (!objType) return null;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5582,6 +5582,16 @@ assert._isSameValue = isSameValue;
                   // Also mark in sidecar so property enumeration knows it exists
                   _sidecarSet(obj, prop, undefined);
                 } else {
+                  // (#1629 S3) data→accessor flip: if a prior data
+                  // `defineProperty` mirrored a plain value into the value
+                  // sidecar at `sc[prop]`, it would shadow the new getter —
+                  // `_safeGet` consults `_sidecarGet` (which reads `sc[prop]`)
+                  // *before* the `__get_<prop>` getter. Drop the stale value so
+                  // the accessor wins. (A bare struct field's value lives in the
+                  // struct, not `sc`, so this is a no-op in the common case.)
+                  if ((desc.get || desc.set) && prop in sc && typeof sc[prop as string] !== "function") {
+                    delete sc[prop as string];
+                  }
                   if (desc.get) sc[`__get_${prop}`] = desc.get;
                   if (desc.set) sc[`__set_${prop}`] = desc.set;
                   // Mark the property key as "own" for hasOwnProperty checks.

--- a/tests/issue-1629-S3.test.ts
+++ b/tests/issue-1629-S3.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #1629 descriptor slice S3 (first sub-slice) — the inline
+// `Object.defineProperty(o, k, {get/set})` STORE contract.
+//
+// Verified bug: `const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return 42}}); o.p`
+// returned `undefined`. The accessor branch in `compileObjectDefineProperty`
+// (src/codegen/object-ops.ts) used to compile a dead `${structName}_get_p` Wasm
+// function + `classAccessorSet` and EARLY-RETURN — feeding *no* runtime sidecar.
+// The getter therefore lived in neither `_wasmStructProps[obj]["__get_p"]` nor
+// `_wasmStructAccessors` — the canonical slot the read-side `_safeGet`, S1's
+// `_readOwnDescriptor`, and `getOwnPropertyDescriptor` all consult. The fix
+// disables that dead branch so the accessor case falls through to the existing
+// `emitExternDefinePropertyNoValue`, which mirrors get/set into the runtime
+// `__defineProperty_accessor` import (the symmetric mirror the data-value path
+// already emits). One write reconciles all reader entry points.
+//
+// Spec basis: §20.1.2.4 Object.defineProperty, §10.1.6.1/.3
+// OrdinaryDefineOwnProperty + ValidateAndApply, §10.1.8.1 OrdinaryGet accessor
+// branch, §6.2.6.4 CompletePropertyDescriptor (omitted enumerable/configurable
+// default to false).
+//
+// Scope (matches the architect S3-slice spec): the verified externref-backed
+// (`const o:any`) case, whose reads route through the host `_safeGet` path.
+// Two reads are EXPLICITLY DEFERRED to the broader S3 read-shim / representation
+// foundation and are NOT asserted here:
+//   * `o.k` *dot*-access on a statically-known struct field redefined as an
+//     accessor — lowers to a direct `struct.get` that never touches `_safeGet`
+//     (the read-site struct resolver is weaker than the define-site one). Bracket
+//     and dynamic-key reads of the same property DO route through `_safeGet` and
+//     are covered below.
+//   * `o.k = v` setter invocation — the runtime accessor `this`-binding through
+//     `_maybeWrapCallable` is a pre-existing write-side gap (documented at
+//     runtime.ts ~5550), not part of this STORE-contract slice.
+
+async function runHost(src: string): Promise<unknown> {
+  const r = compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile error: ${r.errors[0]?.message}`);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#1629 S3 — inline defineProperty accessor STORE", () => {
+  it("getter fires on dot read (o.p)", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return 42}}); return o.p; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it('getter fires on bracket read (o["p"])', async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return 42}}); return o["p"]; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("getter fires on forced-dynamic read (o[k])", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; const k = "p"; Object.defineProperty(o,"p",{get(){return 42}}); return o[k]; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("getter receives the receiver as `this`", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:7}; Object.defineProperty(o,"p",{get(){return this.z}}); return o.p; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("getter closes over its defining scope", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const cap = 13; const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return cap}}); return o.p; }`,
+      ),
+    ).toBe(13);
+  });
+
+  it("get-only accessor: get fires, no setter installed", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return 5}}); return o.p; }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("set-only accessor: reading returns undefined (OrdinaryGet [[Get]] undefined)", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"p",{set(v){}}); return o.p; }`,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("get+set accessor: get fires", async () => {
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"p",{get(){return 1},set(v){}}); return o.p; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("data→accessor flip: bracket read fires the new getter, not the stale field value", async () => {
+    // `z` starts as a data field (value 0). Redefining it as an accessor must
+    // make a subsequent read fire the getter. The runtime accessor handler drops
+    // any stale value-sidecar entry so `_sidecarGet` (checked before the getter)
+    // can't shadow it. Bracket access routes through `_safeGet`; the dot-access
+    // form is the deferred direct-`struct.get` case (see file header).
+    expect(
+      await runHost(
+        `export function test(): any { const o:any = {z:0}; Object.defineProperty(o,"z",{get(){return 9}}); return o["z"]; }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("GOPD read-back for a bare {get(){}} accessor (S1 consistency)", async () => {
+    // §20.1.2.4 / CompletePropertyDescriptor: omitted enumerable/configurable
+    // default to false; set defaults to undefined; get is a function.
+    // (Booleans returned through the `any` ABI surface as i32 0/1, so assert the
+    // descriptor's own enumerable/configurable rather than a compiled `===`.)
+    expect(
+      await runHost(
+        `export function test(): any {
+           const o:any = {z:0};
+           Object.defineProperty(o,"p",{get(){return 1}});
+           const d = Object.getOwnPropertyDescriptor(o,"p") as any;
+           return [typeof d.get, typeof d.set, d.enumerable, d.configurable];
+         }`,
+      ),
+    ).toEqual(["function", "undefined", false, false]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the verified #1629-S3 accessor-get bug: `const o:any={z:0}; Object.defineProperty(o,"p",{get(){return 42}}); o.p` returned `undefined` (should be `42`). Holds for `o.p`, `o["p"]`, forced-dynamic `o[k]`, and the closure/`this` getter forms.

## Root cause

The accessor branch in `compileObjectDefineProperty` (`src/codegen/object-ops.ts`) compiled a dead `${structName}_get_<prop>` Wasm function + `classAccessorSet` registration and **early-returned**, feeding no runtime sidecar. The getter landed in neither `_wasmStructProps[obj]["__get_<prop>"]` nor `_wasmStructAccessors` — the canonical slots the read-side `_safeGet`, S1's `_readOwnDescriptor`, and `getOwnPropertyDescriptor` all consult. For a `const o:any` (externref) receiver, reads route through `_safeGet`, which found nothing → `undefined`.

## Fix (2 files, localized)

- **`src/codegen/object-ops.ts`** — gate the inline accessor branch on a new `receiverIsStaticStruct` bit (struct resolved **without** the `any`/externref define-site rescue fallbacks — the same resolution strength the read site `resolveStructNameForExpr` has). Statically-typed receivers (class instances) **keep** the compiled-getter fast path, which IS reachable from their reads. `const o:any` receivers fall through to the existing `emitExternDefinePropertyNoValue`, which mirrors get/set into the runtime `__defineProperty_accessor` import (closure-wrapped via `_maybeWrapCallable` / the unconditional `__call_fn_N` bridge). One write reconciles all four reader entry points — the symmetric mirror the data-value path already emits via `__defineProperty_value`.
- **`src/runtime.ts`** `__defineProperty_accessor` — one defensive line for the data→accessor flip: drop a stale plain value at `sc[prop]` before installing the getter so `_sidecarGet` (checked first in `_safeGet`) can't shadow the new accessor.

This realizes the architect's S3-slice approach via the *existing* runtime plumbing rather than a new helper (the bug was purely the struct branch intercepting before that path).

## Spec
ES2026 §20.1.2.4 Object.defineProperty, §10.1.6.1/.3 OrdinaryDefineOwnProperty + ValidateAndApply, §10.1.8.1 OrdinaryGet accessor branch, §6.2.6.4 CompletePropertyDescriptor.

## Tests
`tests/issue-1629-S3.test.ts` (10 cases): getter dot/bracket/dynamic reads, getter-`this`, getter-closure, get-only / set-only / get+set, data→accessor flip (bracket), GOPD read-back.

**No regression**: the #459 accessor / defineProperty / object-literal-getter equivalence suites match baseline exactly (the 2-3 remaining fails — Reflect.construct, object-literal setter-write, preventExtensions-then-defineProperty — are pre-existing on main).

## Deferred (per architect S3-slice scope, confirmed pre-existing — NOT regressed)
- `o.k` **dot**-access on a statically-known struct field redefined as accessor (direct `struct.get`, never touches `_safeGet`; bracket/dynamic reads work).
- `o.k = v` **setter invocation** on an `any` receiver (write-side `_safeSet`→`__set_<prop>` gap).
- Host-side raw JS `o.p` on a returned opaque WasmGC struct (same limitation the data path has).

These belong to the broader S3 read-shim / representation foundation (#1130/#1320).

Closes the S3 first sub-slice of #1629 (umbrella stays open for S4-S6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)