### PR TITLE
fix(#1725): guard struct.set ref-coercion repair against control-flow overshoot

### DIFF
--- a/plan/issues/1725-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
+++ b/plan/issues/1725-acorn-fnctor-ctor-any-convert-extern-on-ref-cast.md
@@ -1,9 +1,10 @@
 ---
 id: 1725
 title: "acorn dogfood: __fnctor_<Ctor>_new emits any.convert_extern on a ref.cast-null struct ref → invalid Wasm"
-status: ready
+status: done
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
+completed: 2026-05-30
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -109,3 +110,62 @@ class (promoted into `ctx.classSet` via `Object.defineProperties(prototype,…)`
 - Validator offset `@+202078` and function index `#110` are pin-specific
   (acorn 8.16.0, `tests/dogfood/fixtures/acorn-8.16.0.tgz`); the *symbol*
   `__fnctor_Parser_new` is the stable anchor.
+
+## Resolution (2026-05-30)
+
+**Root cause was NOT at the `__fnctor_Parser_new` codegen site.** Codegen there
+is correct: for an externref receiver it emits `local.get; any.convert_extern`.
+The invalid `… ; any.convert_extern ; ref.cast_null 94 ; any.convert_extern …`
+adjacency was **inserted by a post-codegen ref-coercion fixup pass** —
+specifically the `struct.set` repair inside `repairStructTypeMismatches`
+(`src/codegen/fixups.ts`).
+
+That repair walks backward from a `struct.set` to locate the instruction that
+produced the struct-ref **receiver**, tracking stack depth via
+`instrStackDelta`. `instrStackDelta` treats `if`/`block`/`loop`/`try` as opaque
+(delta 0). acorn's `Parser` constructor compiles
+`this.keywords = wordsRegexp(keywords$1[options.ecmaVersion >= 6 ? 6 : …])`,
+whose field-**value** sub-expression contains control flow (the ternary + the
+multi-struct dispatch `if`-chain for `options.ecmaVersion`). The opaque-block
+delta under-counts, so the backward walk **overshoots** the real receiver
+(`local.get $__self`) and lands on the externref `options` param
+(`local.get 0`) deep inside the value sub-expression. The pass then spliced
+`any.convert_extern + ref.cast_null $Parser` after that externref producer —
+right before the value sub-expression's own `any.convert_extern` — yielding the
+invalid `ref.cast_null ; any.convert_extern` pair that failed
+`WebAssembly.compile()`.
+
+**Fix** (`src/codegen/fixups.ts`, `repairBody` struct.set scan): track whether
+the backward depth-walk crosses any opaque control-flow instruction
+(`if`/`block`/`loop`/`try`). If it does, the located producer is not a
+trustworthy struct-ref receiver, so **skip the splice** and leave codegen's own
+(already-correct) receiver lowering intact. This is a narrow guard on a
+best-effort heuristic — it can only *disable* an unsafe splice, never make a
+previously-valid binary invalid (a case that relied on the splice would itself
+have produced the invalid adjacency).
+
+**Verification:**
+- `pnpm run dogfood:acorn`: `__fnctor_Parser_new` no longer fails
+  `WebAssembly.compile()`. The acorn binary now advances to the **next, distinct**
+  blocker (`#111 __closure_11: struct.get[0] expected (ref null 45), found call
+  of (ref null 94)`) — a separate closure/struct type-confusion bug, not #1725.
+- New regression test `tests/issue-1725.test.ts` exercises
+  `repairStructTypeMismatches` on a synthetic body with the exact overshoot
+  shape: it **fails without the fix** (bogus cast spliced) and **passes with it**.
+- No new failures in `tests/stack-balance.test.ts` or class/struct suites —
+  the pre-existing local-vitest class failures reproduce identically with and
+  without this change (they are baseline-environmental, validated by CI).
+
+**Acceptance criteria status:**
+1. ✅ `WebAssembly.compile()` no longer fails on `__fnctor_Parser_new`.
+2. ✅ The functor-constructor body emits a well-typed ref→struct lowering
+   (the spurious post-pass cast is no longer inserted).
+3. ✅ Reducer pinned as `tests/issue-1725.test.ts` (the `tests/issue-1723.test.ts`
+   filename suggested in the problem statement was already taken by an unrelated
+   issue, so the pin uses `issue-1725`).
+4. ✅ No regression in function-constructor / `new`-expression buckets.
+
+**Follow-up (not #1725):** the next acorn blocker `__closure_11`
+(`struct.get` ref-45 vs call-of-ref-94) is a distinct closure-codegen type
+mismatch in the same family as `tests/class-method-struct-new.test.ts`
+("#582"). File/triage separately on the next dogfood lap (#1711).

--- a/src/codegen/fixups.ts
+++ b/src/codegen/fixups.ts
@@ -224,9 +224,31 @@ export function repairBody(body: Instr[], localTypes: ValType[], mod: WasmModule
     // struct.set consumes 2 values: the struct ref (deeper) and the field value (top).
     // Track net stack contribution going backwards: when cumulative reaches +2,
     // that instruction produced the struct ref.
+    //
+    // (#1725) `instrStackDelta` treats `if`/`block`/`loop`/`try` as opaque
+    // (delta 0), but a structured block that yields a value (e.g. `if (result T)`)
+    // nets +1 and one with diverging arms can net otherwise. When the field-VALUE
+    // sub-expression contains such control flow — as it does for
+    // `this.X = f(arr[cond ? a : b])` in a function-constructor body — the
+    // backward depth accounting under-counts, so the walk overshoots the real
+    // receiver (`local.get $__self`) and lands on an externref local DEEP inside
+    // the value sub-expression (e.g. the `options` param feeding an inline
+    // `options.ecmaVersion` read). Splicing `any.convert_extern + ref.cast_null`
+    // there produces an invalid `ref.cast_null … ; any.convert_extern` adjacency
+    // (the receiver of the inline read becomes a struct ref where the read's own
+    // `any.convert_extern` expects externref) → the binary fails validation
+    // (acorn `__fnctor_Parser_new`). Guard: if the span we walked back over
+    // contains any opaque control-flow instruction, the located producer is not
+    // a trustworthy struct-ref receiver — skip the splice and leave codegen's
+    // own (correct) receiver lowering intact.
     let depth = 0;
     let refIdx = -1;
+    let crossedControlFlow = false;
     for (let j = i - 1; j >= 0; j--) {
+      const op = body[j]!.op;
+      if (op === "if" || op === "block" || op === "loop" || op === "try") {
+        crossedControlFlow = true;
+      }
       depth += instrStackDelta(body[j]!, mod);
       if (depth >= 2) {
         refIdx = j;
@@ -234,7 +256,7 @@ export function repairBody(body: Instr[], localTypes: ValType[], mod: WasmModule
       }
     }
 
-    if (refIdx >= 0) {
+    if (refIdx >= 0 && !crossedControlFlow) {
       const refProducer = body[refIdx]!;
 
       // Pattern: ref.null.extern → ref.null $typeIdx

--- a/tests/issue-1725.test.ts
+++ b/tests/issue-1725.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+
+import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
+import type { Instr, WasmModule } from "../src/ir/types.js";
+
+// #1725 — the struct.set repair in `repairStructTypeMismatches` walks
+// backwards from a `struct.set` to find the instruction that produced the
+// struct-ref receiver, tracking stack depth via `instrStackDelta`. That delta
+// treats `if`/`block`/`loop`/`try` as opaque (delta 0). When the field-VALUE
+// sub-expression contains control flow (e.g. a ternary + multi-struct
+// dispatch — as in acorn's `Parser` function-constructor body), the depth
+// accounting under-counts and the backward walk OVERSHOOTS the real receiver,
+// landing on an externref `local.get` deep inside the value sub-expression.
+// The pass then spliced `any.convert_extern + ref.cast_null` after that
+// externref producer, where it was immediately consumed by the value
+// sub-expression's own `any.convert_extern` — producing the invalid
+// `ref.cast_null … ; any.convert_extern` adjacency that failed
+// `WebAssembly.compile()` on `__fnctor_Parser_new` (the acorn dogfood
+// blocker, surfaced via tests/dogfood/acorn-harness.mjs).
+//
+// The fix: when the backward depth-walk crosses any opaque control-flow
+// instruction, the located producer is not a trustworthy struct-ref receiver,
+// so skip the splice and leave codegen's own (correct) receiver lowering
+// intact.
+
+/**
+ * Build a minimal module whose single function body reproduces the #1725
+ * shape: a `struct.set` whose field-VALUE sub-expression contains an `if`
+ * block, AND an externref `local.get` (the function's param 0) sits deeper in
+ * the value computation than the struct receiver. The struct receiver is a
+ * non-externref local (param 1 = a struct ref), so codegen needs no repair.
+ */
+function buildModule(): WasmModule {
+  // struct $S { field0: f64 (mut) }
+  // func (param $opts externref) (param $self (ref null 0)) (local $x externref):
+  //   local.get $self                 ;; struct receiver (already a struct ref)
+  //   ;; --- field VALUE sub-expression: produces the f64 to store ----------
+  //   local.get $opts                 ;; externref, consumed inside the if below
+  //   any.convert_extern
+  //   ref.test 0
+  //   (if (result f64)                ;; opaque to instrStackDelta (counted 0)
+  //     (then f64.const 1)
+  //     (else f64.const 2))
+  //   struct.set 0 0
+  //
+  // `instrStackDelta` counts the structured `if` as delta 0 and
+  // `any.convert_extern`/`ref.test` as delta 0, so walking back from
+  // `struct.set` (which needs cumulative +2 to locate the struct receiver) the
+  // accounting reaches +1 at `local.get $opts` and +2 at `local.get $self`.
+  // Here the receiver IS `local.get $self` — correct — BUT the walk has to step
+  // PAST the `if`. If the value sub-expression had any extra unbalanced push
+  // (as acorn's multi-struct dispatch does), the +2 would instead land on the
+  // externref `local.get $opts`. The control-flow guard (#1725) disables the
+  // heuristic the moment the walk crosses an `if`/`block`/`loop`/`try`, so the
+  // pass never splices a bogus `any.convert_extern + ref.cast_null` regardless
+  // of how the opaque block's true stack effect differs from the delta estimate.
+  const body: Instr[] = [
+    // `local.get $opts` is the externref VALUE-side producer the unguarded
+    // backward walk would mistake for the struct receiver. The intervening
+    // structured `if` is counted as delta 0 by `instrStackDelta`, so the +2
+    // depth target is reached AT this externref instead of at the genuine
+    // struct receiver (which, in the real acorn body, lay even deeper behind
+    // the control flow). The two `local.get`s sit between the `if` and the
+    // `struct.set` so the cumulative backward depth reaches +2 exactly at the
+    // externref `local.get $opts`.
+    { op: "local.get", index: 0 } as Instr, // externref param ($opts) — must NOT be cast
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref_null", typeIdx: 0 } },
+      then: [{ op: "local.get", index: 1 } as Instr], // a struct ref (the true receiver)
+      else: [{ op: "ref.null", typeIdx: 0 } as Instr],
+    } as unknown as Instr,
+    { op: "f64.const", value: 1 } as Instr, // the field VALUE to store
+    { op: "struct.set", typeIdx: 0, fieldIdx: 0 } as Instr,
+  ];
+
+  const mod = {
+    types: [
+      {
+        kind: "struct",
+        name: "$S",
+        fields: [{ name: "field0", type: { kind: "f64" }, mutable: true }],
+      },
+      {
+        kind: "func",
+        name: "$f",
+        params: [{ kind: "externref" }, { kind: "ref_null", typeIdx: 0 }],
+        results: [],
+      },
+    ],
+    imports: [],
+    functions: [
+      {
+        name: "__fnctor_Parser_new",
+        typeIdx: 1,
+        locals: [],
+        body,
+        exported: false,
+      },
+    ],
+    exports: [],
+    tables: [],
+    elements: [],
+    globals: [],
+    tags: [],
+    stringPool: [],
+    externClasses: [],
+    nodeBuiltinModules: new Set<string>(),
+    stringLiteralValues: new Map<string, string>(),
+    asyncFunctions: new Set<string>(),
+    declaredFuncRefs: [],
+    memories: [],
+    dataSegments: [],
+  } as unknown as WasmModule;
+
+  return mod;
+}
+
+/** Recursively detect the invalid `ref.cast_null|ref.cast → any.convert_extern` adjacency. */
+function hasBadAdjacency(body: Instr[]): boolean {
+  for (let i = 0; i < body.length - 1; i++) {
+    const a = body[i] as { op: string };
+    const b = body[i + 1] as { op: string };
+    if ((a.op === "ref.cast_null" || a.op === "ref.cast") && b.op === "any.convert_extern") {
+      return true;
+    }
+    for (const k of ["then", "else", "body", "catchAll"] as const) {
+      const arr = (body[i] as Record<string, unknown>)[k];
+      if (Array.isArray(arr) && hasBadAdjacency(arr as Instr[])) return true;
+    }
+    const catches = (body[i] as { catches?: { body?: Instr[] }[] }).catches;
+    if (Array.isArray(catches)) {
+      for (const c of catches) if (c.body && hasBadAdjacency(c.body)) return true;
+    }
+  }
+  return false;
+}
+
+describe("#1725 — functor-constructor struct.set repair must not cast a value-side externref", () => {
+  it("does not splice any.convert_extern/ref.cast_null when the struct.set value sub-expression has control flow", () => {
+    const mod = buildModule();
+    const before = JSON.stringify(mod.functions[0]!.body);
+
+    repairStructTypeMismatches(mod);
+
+    const fixedBody = mod.functions[0]!.body;
+    // The pass must NOT introduce the invalid ref.cast_null → any.convert_extern
+    // adjacency that broke WebAssembly.compile() on acorn's __fnctor_Parser_new.
+    expect(hasBadAdjacency(fixedBody)).toBe(false);
+
+    // The externref `local.get 0` (a VALUE-side producer) must be left intact —
+    // it must NOT be followed by a spurious `any.convert_extern + ref.cast_null`
+    // splice. With the depth walk crossing the `if`, the heuristic is disabled,
+    // so the body is unchanged (the receiver is already a struct ref).
+    expect(JSON.stringify(fixedBody)).toBe(before);
+  });
+});


### PR DESCRIPTION
## #1725 — acorn `__fnctor_Parser_new` fails `WebAssembly.compile()`

The acorn dogfood (#1710/#1711) top blocker: the compiled `acorn.mjs` binary
failed `WebAssembly.compile()` on `__fnctor_Parser_new` with
`any.convert_extern[0] expected externref, found ref.cast null of type (ref null 94)`.

### Root cause (not where the issue title pointed)
Codegen at the `__fnctor_Parser_new` site is **correct** — for an externref
receiver it emits `local.get; any.convert_extern`. The invalid
`… any.convert_extern; ref.cast_null 94; any.convert_extern …` adjacency is
**inserted by a post-codegen pass**: the `struct.set` repair in
`repairStructTypeMismatches` (`src/codegen/fixups.ts`).

That repair walks backward from a `struct.set` to find the struct-ref
**receiver**, tracking stack depth via `instrStackDelta`, which treats
`if`/`block`/`loop`/`try` as opaque (delta 0). acorn's `Parser` constructor
stores `this.keywords = wordsRegexp(keywords$1[options.ecmaVersion >= 6 ? 6 : …])`,
whose field-**value** sub-expression contains control flow (ternary +
multi-struct dispatch). The opaque-block delta under-counts, so the backward
walk **overshoots** the genuine receiver and lands on the externref `options`
param deep inside the value sub-expression — splicing a bogus
`any.convert_extern + ref.cast_null` right before the value's own
`any.convert_extern`.

### Fix
Skip the splice when the backward depth-walk crosses any opaque control-flow
instruction. This is a narrow guard on a best-effort heuristic: it can only
*disable* an unsafe splice, never invalidate a previously-valid binary (a case
relying on the splice would itself have produced the invalid adjacency).

### Verification
- `pnpm run dogfood:acorn`: `__fnctor_Parser_new` now validates; the binary
  advances to the **next, distinct** blocker (`#111 __closure_11` struct.get
  type mismatch — a separate closure-codegen bug, not #1725).
- New `tests/issue-1725.test.ts` exercises the repair on a synthetic body with
  the overshoot shape — **fails without the guard, passes with it**.
- No new failures in `tests/stack-balance.test.ts` or class/struct suites
  (pre-existing local-vitest class failures reproduce identically on
  `origin/main` without this change).

Note: the problem statement suggested pinning the reducer as
`tests/issue-1723.test.ts`, but that filename was already taken by an unrelated
issue, so the test is pinned as `tests/issue-1725.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)