### PR TITLE
test(#1739): pin String.prototype A7/A8 invariants — already green (stale baseline)

### DIFF
--- a/plan/issues/1739-string-prototype-method-function-object-invariants.md
+++ b/plan/issues/1739-string-prototype-method-function-object-invariants.md
@@ -1,9 +1,10 @@
 ---
 id: 1739
 title: "String.prototype methods fail not-a-constructor (A7) + .length-DontEnum (A8) invariants across the suite"
-status: ready
+status: done
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
+completed: 2026-05-30
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -66,3 +67,44 @@ specified), §17 (built-in function `length`/`name` are non-enumerable).
 Filed by #259 conformance-triage 2026-05-29. The value-semantics half of the
 substring/slice clusters is the localized #1731 (shipped); this issue tracks
 the cross-method function-object invariant half.
+
+---
+
+## 2026-05-30 — Smoke-test verdict: ALREADY GREEN on main (stale baseline). DONE.
+
+**Status: done — stale-baseline close, not a code fix.** Per the smoke-first
+directive, ran the `S15.5.4.*_A7` (not-a-constructor → TypeError) and `_A8`
+(`.length` own + non-enumerable) invariants against current `main` (HEAD
+`518d55808`) at the compiler level. BOTH rows are already green:
+
+- **A7 — 21/21 pass.** `var f = String.prototype.<m>; new f` throws a real
+  `TypeError` instance for every sampled method (indexOf, lastIndexOf, charAt,
+  charCodeAt, slice, substring, substr, toLowerCase, toUpperCase, concat,
+  includes, split, trim, valueOf, …). The not-a-constructor work already closed
+  this: `resolvesToNonConstructableValue` in
+  `src/codegen/expressions/new-super.ts` detects a `<x>.prototype.<method>`
+  initializer and routes `new f` through the `__construct` IsConstructor guard,
+  which throws a TypeError (#930 + #1528 + #1732-S1 new-site check).
+- **A8 — 14/14 pass.** `String.prototype.<m>.hasOwnProperty('length')` is true,
+  `propertyIsEnumerable('length')` is false, and `for-in` does not surface
+  `length`. The `test262_fail: ~40` count in the frontmatter was a **stale
+  jsonl baseline** entry.
+
+**Investigation note (false alarm avoided):** an early probe reported A7 as
+failing, but that was a *probe artifact* — it used
+`(String.prototype as any).indexOf` (an inner `as any` cast added to satisfy
+TS), and that wrapped shape defeats the `.prototype` detection in
+`resolvesToNonConstructableValue` (it sees an `AsExpression`, not a
+`PropertyAccessExpression` whose object is `<x>.prototype`). The real test262
+form — `var f = String.prototype.<m>` with no inner cast — passes. (If a future
+issue wants the cast-wrapped form to also reject, that is the same family as
+this guard's unwrap list, a small follow-up — but it is NOT what the A7 suite
+exercises, so it is out of scope here.)
+
+### What landed
+- `tests/issue-1739.test.ts` — a 28-case pin (14 A7 + 14 A8) mirroring the exact
+  test262 assertion shapes, LOCKING the green state against regression. No
+  compiler change.
+
+The `test262_fail: ~40` entry self-corrects on the next `promote-baseline` CI
+run (push to main); the pin guards the behaviour in the meantime.

--- a/tests/issue-1739.test.ts
+++ b/tests/issue-1739.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #1739 — String.prototype method function-object invariants.
+//
+// Smoke-tested 2026-05-30: BOTH the A7 (not-a-constructor → TypeError) and the
+// A8 (.length is an own, non-enumerable property) invariants are ALREADY GREEN
+// on main — the jsonl baseline that listed ~40 fails was STALE (A8 already
+// passed; A7 was closed by the not-a-constructor work, #930 + #1528 + #1732-S1's
+// new-site IsConstructor check, which routes `new String.prototype.<m>` through
+// the __construct guard that throws a real TypeError instance).
+//
+// This pin LOCKS that green state so it can't silently regress. It mirrors the
+// exact test262 `S15.5.4.*_A7` / `_A8` assertion shapes (which is why it uses
+// `var f = String.prototype.<m>` then `new f`, NOT an inner `as any` cast — the
+// cast shape defeats the prototype-method detection and is not what test262
+// does).
+
+// test262 `assert.throws(TypeError, fn)` shape: the TypeError-type check is
+// retained here (unlike the #930 pin's stripped variant) because A7's WHOLE
+// point is that the thrown error is a TypeError, not just any throw.
+const ASSERT_THROWS_TYPEERROR = `
+  let passed = 0;
+  function assert_throws_typeerror(fn: () => void): void {
+    try { fn(); } catch (e) { if (e instanceof TypeError) passed++; }
+  }
+`;
+
+// A representative slice of the String.prototype methods the A7/A8 clusters
+// cover. Same root cause across all of them, so a sample pins the row.
+const METHODS = [
+  "indexOf",
+  "lastIndexOf",
+  "charAt",
+  "charCodeAt",
+  "slice",
+  "substring",
+  "substr",
+  "toLowerCase",
+  "toUpperCase",
+  "concat",
+  "includes",
+  "split",
+  "trim",
+  "valueOf",
+];
+
+describe("#1739 — String.prototype function-object invariants (A7/A8)", () => {
+  // A7: `new String.prototype.<m>` must throw a TypeError (no [[Construct]]).
+  for (const m of METHODS) {
+    it(`A7: new String.prototype.${m} throws TypeError`, async () => {
+      const exports = await compileToWasm(`
+        ${ASSERT_THROWS_TYPEERROR}
+        export function test(): number {
+          const __FACTORY: any = String.prototype.${m};
+          assert_throws_typeerror(() => { const i = new __FACTORY(); });
+          return passed;
+        }
+      `);
+      expect(exports.test!()).toBe(1);
+    });
+  }
+
+  // A8: String.prototype.<m>.length is an own, non-enumerable property — present
+  // via hasOwnProperty, false under propertyIsEnumerable, and not surfaced by
+  // for-in.
+  for (const m of METHODS) {
+    it(`A8: String.prototype.${m}.length is own + non-enumerable`, async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const f: any = String.prototype.${m};
+          if (!f.hasOwnProperty("length")) return 10;
+          if (f.propertyIsEnumerable("length")) return 11;
+          let count = 0;
+          for (const p in f) { if (p === "length") count++; }
+          if (count !== 0) return 12;
+          return 1;
+        }
+      `);
+      expect(exports.test!()).toBe(1);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

**#1739 was already green on main — a stale-baseline close, not a code fix.** Per the smoke-first directive, I ran the `S15.5.4.*_A7` (not-a-constructor → `TypeError`) and `_A8` (`.length` own + non-enumerable) invariants for `String.prototype` methods against current `main`:

- **A7 — 21/21 pass.** `var f = String.prototype.<m>; new f` throws a real `TypeError`. Closed by the not-a-constructor work (#930 + #1528 + #1732-S1's new-site IsConstructor check) via `resolvesToNonConstructableValue` + the `__construct` guard in `src/codegen/expressions/new-super.ts`.
- **A8 — 14/14 pass.** `.length` is own (`hasOwnProperty`), non-enumerable (`propertyIsEnumerable` false), and not surfaced by `for-in`.

The `test262_fail: ~40` frontmatter count was a **stale jsonl baseline** entry — it self-corrects on the next `promote-baseline` CI run.

## What landed (no compiler change)
- `tests/issue-1739.test.ts` — **28 pins** (14 A7 + 14 A8) mirroring the exact test262 assertion shapes, to **lock the green state** against regression.
- `plan/issues/1739-…md` — `status: done` + smoke-test findings.

## Investigation note (false alarm avoided)
An early probe reported A7 as failing, but that was a **probe artifact**: it used `(String.prototype as any).indexOf` (an inner `as any` cast to satisfy TS), and that wrapped shape defeats the `.prototype` detection (it sees an `AsExpression`, not a `PropertyAccessExpression` whose object is `<x>.prototype`). The real test262 form — `var f = String.prototype.<m>` with no inner cast — passes. Documented in the issue so it isn't re-investigated.

## Validation
- 28/28 pins green (incl. post-merge with current main).
- `tsc` + `biome` clean; `check:issues` exit 0.
- Zero conformance risk: one new test file + one issue-doc edit; no compiler source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)