### PR TITLE
feat(#1719 CPR-2): for-of-head + parameter array dstr drive overridden @@iterator

### DIFF
--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -32,6 +32,17 @@ import {
   valTypesMatch,
 } from "./shared.js";
 import { buildVecFromExternref, getVecInfo } from "./type-coercion.js";
+import { arrayIteratorOverrideGlobalIdx } from "./expressions/proto-override.js";
+// (#1719 CPR-2) `arrayDstrNeedsIdentity` / `tryEmitArrayProtoIteratorReadDrive` /
+// `syncDestructuredLocalsToGlobals` live in statements/destructuring.ts, which
+// already imports `destructureParamArray` from here — a module cycle. ESM
+// resolves it because these references are used at call time (inside
+// `destructureParamArray`), never at module-init.
+import {
+  arrayDstrNeedsIdentity,
+  syncDestructuredLocalsToGlobals,
+  tryEmitArrayProtoIteratorReadDrive,
+} from "./statements/destructuring.js";
 
 /**
  * Detect array binding patterns that, per ECMA-262 §13.3.3.6, perform no
@@ -815,6 +826,24 @@ export function destructureParamArray(
   if (shouldEnsureLetConstFlags(opts)) {
     ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
   }
+
+  // (#1719 CPR-2) Parameter / externref-decl array destructuring: when the
+  // program overrode Array.prototype[@@iterator] and `paramType` is a real array
+  // (not a string), drive the captured override from the value local instead of
+  // the backing-store / __array_from_iter lane (§8.5.2). The typed-vec *decl*
+  // case never reaches here — `compileArrayDestructuring` runs its own drive and
+  // returns before delegating — so this covers exactly the parameter-dstr and
+  // externref-decl lanes. Strictly gated behind the brand + a captured override
+  // (both clear in the common case ⇒ byte-identical). The value lives in
+  // `paramIdx`, so feed the shared decl read-drive that local.
+  if (arrayDstrNeedsIdentity(ctx, false) && arrayIteratorOverrideGlobalIdx(ctx) !== undefined) {
+    ensureBindingLocals(ctx, fctx, pattern);
+    if (tryEmitArrayProtoIteratorReadDrive(ctx, fctx, pattern, paramType, paramIdx)) {
+      if (isDecl) syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+      return;
+    }
+  }
+
   if (paramType.kind !== "ref" && paramType.kind !== "ref_null") {
     // externref parameters: convert to vec struct before destructuring (#647)
     // The externref may wrap any vec type at runtime (e.g. __vec_f64 from [1,2,3]

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -90,20 +90,27 @@ export function arrayDstrNeedsIdentity(ctx: CodegenContext, isStringRHS: boolean
  * array iterations inside the override body stay on the typed-vec fast path — no
  * re-entrancy / no infinite loop.
  */
-function tryEmitArrayProtoIteratorReadDrive(
+export function tryEmitArrayProtoIteratorReadDrive(
   ctx: CodegenContext,
   fctx: FunctionContext,
   pattern: ts.ArrayBindingPattern,
   resultType: ValType,
+  /**
+   * (#1719 CPR-2) When provided, the array value is read from this local instead
+   * of consumed from the stack — lets the for-of-head / parameter dstr sites
+   * (whose value lives in a local) reuse this exact drive+drain. `undefined` ⇒
+   * the decl-dstr caller's convention (vec ref already on the stack).
+   */
+  srcLocal?: number,
 ): boolean {
   const overrideGlobalIdx = arrayIteratorOverrideGlobalIdx(ctx);
   if (overrideGlobalIdx === undefined) return false;
 
-  // CPR-1 shape gate: only plain identifiers (+ optional default) and elisions.
+  // CPR shape gate: only plain identifiers (+ optional default) and elisions.
   for (const el of pattern.elements) {
     if (ts.isOmittedExpression(el)) continue;
-    if (el.dotDotDotToken) return false; // rest → CPR-2
-    if (!ts.isIdentifier(el.name)) return false; // nested → CPR-2
+    if (el.dotDotDotToken) return false; // rest → follow-up
+    if (!ts.isIdentifier(el.name)) return false; // nested → follow-up
   }
 
   // Pre-register __iterator_next (the for-of multi-value drain shape) BEFORE
@@ -118,10 +125,24 @@ function tryEmitArrayProtoIteratorReadDrive(
   flushLateImportShifts(ctx, fctx);
   if (nextIdx === undefined) return false;
 
-  // Stash the vec ref, then drive the override into an iterator local.
-  const vecLocal = allocLocal(fctx, `__cpr_vec_${fctx.locals.length}`, resultType);
-  fctx.body.push({ op: "local.set", index: vecLocal });
-  fctx.body.push({ op: "local.get", index: vecLocal });
+  // Put the array value on the stack: from `srcLocal` (for-of / param convention)
+  // or from a fresh stash of the already-on-stack vec ref (decl convention). The
+  // value may be a vec ref OR an externref (for-of elements are often externref);
+  // `emitArrayProtoIteratorDrive` does `extern.convert_any`, which only accepts
+  // an anyref/(ref any) — so an externref source must be converted first.
+  if (srcLocal !== undefined) {
+    const srcType = getLocalType(fctx, srcLocal) ?? ({ kind: "externref" } as ValType);
+    fctx.body.push({ op: "local.get", index: srcLocal });
+    if (srcType.kind === "externref") {
+      // externref → anyref so the drive's `extern.convert_any` (any→extern) is
+      // the right direction. (#1719 CPR-2)
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+    }
+  } else {
+    const vecLocal = allocLocal(fctx, `__cpr_vec_${fctx.locals.length}`, resultType);
+    fctx.body.push({ op: "local.set", index: vecLocal });
+    fctx.body.push({ op: "local.get", index: vecLocal });
+  }
   const iterLocal = emitArrayProtoIteratorDrive(ctx, fctx, overrideGlobalIdx);
   const doneLocal = allocLocal(fctx, `__cpr_done_${fctx.locals.length}`, { kind: "i32" });
   const valLocal = allocLocal(fctx, `__cpr_val_${fctx.locals.length}`, { kind: "externref" });

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -126,52 +126,72 @@ function tryEmitArrayProtoIteratorReadDrive(
   const doneLocal = allocLocal(fctx, `__cpr_done_${fctx.locals.length}`, { kind: "i32" });
   const valLocal = allocLocal(fctx, `__cpr_val_${fctx.locals.length}`, { kind: "externref" });
 
-  for (const el of pattern.elements) {
-    // Advance the iterator: (done, value) = __iterator_next(iter).
-    fctx.body.push({ op: "local.get", index: iterLocal });
-    fctx.body.push({ op: "call", funcIdx: nextIdx });
-    fctx.body.push({ op: "local.set", index: valLocal }); // value (top)
-    fctx.body.push({ op: "local.set", index: doneLocal }); // done (below)
+  // Build the per-element drain into a buffer, then guard it on a non-null
+  // iterator. If the override drive returns null (e.g. the closure dispatch
+  // couldn't resolve the override — a TS-cast `(Array.prototype as any)[…]`
+  // generator whose compiled shape the arity-0 dispatcher doesn't match), the
+  // bindings stay at their TDZ/zero defaults rather than trapping on
+  // `__iterator_next(null)`. The 71 `.js` test262 cases resolve a real iterator;
+  // this guard only makes the unresolved-override edge degrade gracefully.
+  const drainInstrs: Instr[] = collectInstrs(fctx, () => {
+    for (const el of pattern.elements) {
+      // Advance the iterator: (done, value) = __iterator_next(iter).
+      fctx.body.push({ op: "local.get", index: iterLocal });
+      fctx.body.push({ op: "call", funcIdx: nextIdx });
+      fctx.body.push({ op: "local.set", index: valLocal }); // value (top)
+      fctx.body.push({ op: "local.set", index: doneLocal }); // done (below)
 
-    if (ts.isOmittedExpression(el) || !ts.isIdentifier(el.name)) continue; // elision: just advance
+      if (ts.isOmittedExpression(el) || !ts.isIdentifier(el.name)) continue; // elision: just advance
 
-    const name = el.name.text;
-    const localIdx = fctx.localMap.get(name);
-    if (localIdx === undefined) continue;
-    const localType = getLocalType(fctx, localIdx) ?? ({ kind: "externref" } as ValType);
+      const name = el.name.text;
+      const localIdx = fctx.localMap.get(name);
+      if (localIdx === undefined) continue;
+      const localType = getLocalType(fctx, localIdx) ?? ({ kind: "externref" } as ValType);
 
-    // value-present arm: coerce `value` externref → the binding's local type.
-    const assignFromValue: Instr[] = collectInstrs(fctx, () => {
-      fctx.body.push({ op: "local.get", index: valLocal });
-      coerceType(ctx, fctx, { kind: "externref" }, localType);
-      fctx.body.push({ op: "local.set", index: localIdx });
-    });
-
-    // done / default arm: if the element has `= init`, evaluate it; else leave
-    // the local at its zero/undefined default (already TDZ-initialised upstream).
-    let defaultArm: Instr[] = [];
-    if (el.initializer) {
-      defaultArm = collectInstrs(fctx, () => {
-        const initType = compileExpression(ctx, fctx, el.initializer!);
-        if (initType) {
-          if (!valTypesMatch(initType, localType)) coerceType(ctx, fctx, initType, localType);
-          fctx.body.push({ op: "local.set", index: localIdx });
-        }
+      // value-present arm: coerce `value` externref → the binding's local type.
+      const assignFromValue: Instr[] = collectInstrs(fctx, () => {
+        fctx.body.push({ op: "local.get", index: valLocal });
+        coerceType(ctx, fctx, { kind: "externref" }, localType);
+        fctx.body.push({ op: "local.set", index: localIdx });
       });
+
+      // done / default arm: if the element has `= init`, evaluate it; else leave
+      // the local at its zero/undefined default (already TDZ-initialised upstream).
+      let defaultArm: Instr[] = [];
+      if (el.initializer) {
+        defaultArm = collectInstrs(fctx, () => {
+          const initType = compileExpression(ctx, fctx, el.initializer!);
+          if (initType) {
+            if (!valTypesMatch(initType, localType)) coerceType(ctx, fctx, initType, localType);
+            fctx.body.push({ op: "local.set", index: localIdx });
+          }
+        });
+      }
+      // ECMA-262 §8.5.2: when the iterator step is done, the value is `undefined`
+      // and the binding takes its default if present. We model that with the
+      // `done` flag: done ⇒ default arm, else ⇒ assign drained value. (A
+      // present-but-`undefined` value also triggers the default per dstr-binding
+      // semantics; CPR-2 folds that in — the 71 tests yield concrete values.)
+      fctx.body.push({ op: "local.get", index: doneLocal });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: defaultArm,
+        else: assignFromValue,
+      } as Instr);
     }
-    // ECMA-262 §8.5.2: when the iterator step is done, the value is `undefined`
-    // and the binding takes its default if present. We model that with the
-    // `done` flag: done ⇒ default arm, else ⇒ assign drained value. (A
-    // present-but-`undefined` value also triggers the default per dstr-binding
-    // semantics; CPR-2 folds that in — the 71 tests yield concrete values.)
-    fctx.body.push({ op: "local.get", index: doneLocal });
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "empty" },
-      then: defaultArm,
-      else: assignFromValue,
-    } as Instr);
-  }
+  });
+
+  // if (iter !== null) { drain }
+  fctx.body.push({ op: "local.get", index: iterLocal });
+  fctx.body.push({ op: "ref.is_null" } as Instr);
+  fctx.body.push({ op: "i32.eqz" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: drainInstrs,
+    else: [],
+  } as Instr);
   return true;
 }
 

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -37,6 +37,7 @@ import {
 } from "../shared.js";
 import {
   compileArrayDestructuring,
+  arrayDstrNeedsIdentity,
   compileExternrefArrayDestructuringDecl,
   compileExternrefObjectDestructuringDecl,
   compileObjectDestructuring,
@@ -45,7 +46,9 @@ import {
   ensureAsyncIterator,
   ensureExternIsUndefined,
   syncDestructuredLocalsToGlobals,
+  tryEmitArrayProtoIteratorReadDrive,
 } from "./destructuring.js";
+import { arrayIteratorOverrideGlobalIdx } from "../expressions/proto-override.js";
 import { adjustRethrowDepth, collectInstrs, restoreBlockScopedShadows, saveBlockScopedShadows } from "./shared.js";
 import { collectPatternBindingNames } from "./tdz.js";
 
@@ -1243,6 +1246,19 @@ function compileForOfDestructuring(
     }); // end null guard for for-of object destructuring
   } else if (ts.isArrayBindingPattern(pattern)) {
     // Array destructuring in for-of: for (var [a, b] of arr)
+    // (#1719 CPR-2) When the program overrode Array.prototype's @@iterator and
+    // the per-element array is destructured, drive the override instead of the
+    // backing store (§8.5.2). Strictly gated behind the brand + a captured
+    // override; both clear in the common case ⇒ byte-identical. The element
+    // value lives in `elemLocal`, so feed the shared decl read-drive that local.
+    if (
+      arrayDstrNeedsIdentity(ctx, false) &&
+      arrayIteratorOverrideGlobalIdx(ctx) !== undefined &&
+      tryEmitArrayProtoIteratorReadDrive(ctx, fctx, pattern, elemType, elemLocal)
+    ) {
+      syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+      return;
+    }
     // Element may be a vec struct (array wrapper) OR a tuple struct.
     // Handle externref elements: use __extern_get to extract indexed properties
     if (elemType.kind !== "ref" && elemType.kind !== "ref_null") {

--- a/tests/issue-1719-cpr.test.ts
+++ b/tests/issue-1719-cpr.test.ts
@@ -72,6 +72,46 @@ describe("#1719 CPR — array destructuring drives the overridden Array.prototyp
     expect(ex.test()).toBe(60);
   });
 
+  it("for-of head array destructuring drives the override per element (CPR-2)", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () {
+        yield this[0];
+        yield this[1];
+        yield 42;
+      };
+      function test() {
+        var z = 0;
+        for (var [a, b, c] of [[1, 2, 3]]) { z = c; }
+        return z;
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(42);
+  });
+
+  it("for-of head drive terminates over multiple outer elements (CPR-2)", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () {
+        yield this[0];
+        yield this[1];
+        yield this[2];
+      };
+      function test() {
+        var total = 0;
+        for (var [a, b, c] of [[10, 20, 30], [1, 2, 3]]) { total += a + b + c; }
+        return total;
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(66);
+  });
+
   it("override-free array destructuring still reads the backing store", async () => {
     const ex = await run(
       `

--- a/tests/issue-1719-cpr.test.ts
+++ b/tests/issue-1719-cpr.test.ts
@@ -112,6 +112,23 @@ describe("#1719 CPR — array destructuring drives the overridden Array.prototyp
     expect(ex.test()).toBe(66);
   });
 
+  it("parameter array destructuring drives the override (CPR-2)", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () {
+        yield this[0];
+        yield this[1];
+        yield 42;
+      };
+      function take([a, b, z]) { return z; }
+      function test() { return take([1, 2, 3]); }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(42);
+  });
+
   it("override-free array destructuring still reads the backing store", async () => {
     const ex = await run(
       `


### PR DESCRIPTION
## What

Extends the **CPR-1 read-drive** (landed via #963 — declaration array-dstr drives an overridden `Array.prototype[@@iterator]`) to the two remaining high-value #1719 contexts:

- **for-of-head dstr** (`for (var [a,b,z] of [[…]])`) → the per-element array observes the override. z=42 (was 3), terminates over multi-element outer iteration.
- **parameter dstr** (`function([a,b,z]){}`) → z=42 (was `undefined` — the disproved `__array_from_iter` externref lane).

Plus the **null-guard** hardening (a null override iterator from a dispatch-miss degrades to TDZ defaults instead of trapping `__iterator_next(null)`).

## How (per-site additive, CPR-1 untouched)

One shared `tryEmitArrayProtoIteratorReadDrive(..., srcLocal?)` (already on main from CPR-1) gains an optional `srcLocal`: when set it reads the array from that local (converting externref→anyref so the drive's `extern.convert_any` is the right direction) instead of consuming the stack. Two new gate sites call it:
- `src/codegen/statements/loops.ts` (for-of-head array dstr) — value in `elemLocal`.
- `src/codegen/destructuring-params.ts` (parameter / externref-decl dstr) — value in `paramIdx`. The typed-vec *decl* case never reaches here (`compileArrayDestructuring` drives + returns before delegating), so no double-fire.

Both gated identically behind the brand + a captured override ⇒ **byte-identical when clear**. The cross-module cycle (`statements/destructuring` ↔ `destructuring-params`) resolves under ESM (call-time refs, not module-init).

## Tests / safety

- `tests/issue-1719-cpr.test.ts`: +for-of-head (z=42), +for-of multi-element termination (66), +parameter (z=42) — all green; existing decl + override-free cases unchanged.
- 29/29 across CPR + S1 + IR-dstr-params suites post-merge-with-main; #1016/#1021 guards green; tsc clean.

## Scope

This + CPR-1 (already on main) close the **decl + for-of + parameter** dstr subsets of the 71 `*-ary-ptrn-*-iter-val-array-prototype.js`. Remaining tracked follow-ups (NOT in this PR): assignment-dstr (`[a,b]=arr`, separate `assignment.ts:317` path), spread (not in the 71), TS-cast wrapper-strip (non-test262 dispatch-miss).

> Draft so the merge-queue auto-enqueue doesn't race the head-sync again (it merged #963 at a stale SHA). Ready for admin-merge once green.

Refs #1719. Spec §7.4.2 GetIterator, §8.5.2 IteratorBindingInitialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)