### PR TITLE
feat(#1584) a1: migrate call op-family (emitCall/emitCallRef) behind BackendEmitter trait

### DIFF
--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -93,6 +93,13 @@ export const OP = {
   SELECT: 20, // SELECT              ; pop cond, pop b, pop a, push (cond != 0) ? a : b
   DROP: 21, //  DROP                 ; pop and discard
   UNREACHABLE: 22, // UNREACHABLE    ; trap (malformed / dead code path)
+  // ── (a1) call family (#1584 §2a) — multi-function VM (program wrapper +
+  // call-frame stack). Both mirror Wasm `call`/`call_ref` exactly: one inline
+  // operand, args already on the stack (arg0 deepest), callee arity NOT inline
+  // (read from the function-table entry). funcref ≡ f64(tableIndex), null ≡
+  // f64(-1) (CALL_REF on -1 traps). See sdev-vm coordination + issue §2a.
+  CALL: 23, //     CALL <funcIdx>     ; pop arity args, run functions[funcIdx], push result
+  CALL_REF: 24, // CALL_REF <typeIdx> ; pop funcref(top)+arity args, run functions[idx], push result
 } as const;
 
 export type Opcode = (typeof OP)[keyof typeof OP];
@@ -170,12 +177,17 @@ export class BytecodeSink {
           this.code.push(op, target + base);
           break;
         }
-        // Single-inline-operand opcodes (a local / global / const index).
+        // Single-inline-operand opcodes (a local / global / const / func /
+        // type index). CALL <funcIdx> / CALL_REF <typeIdx> carry exactly one
+        // inline operand (no relocation needed — function/type indices are
+        // program-global, not arm-local like jump targets/const-pool).
         case OP.LOAD:
         case OP.STORE:
         case OP.TEE:
         case OP.GLOBAL_GET:
         case OP.GLOBAL_SET:
+        case OP.CALL:
+        case OP.CALL_REF:
           this.code.push(op, code[i++]!);
           break;
         // Zero-operand opcodes.
@@ -373,6 +385,23 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     throw new Error(
       "BytecodeEmitter: emitBrIf (multi-block CFG) not in the #1584 subset — see §2a control-flow family.",
     );
+  }
+
+  // ---- (a1) call family (#1584 §2a) — the first migrated family -----------
+  // The args are already on the stack (caller-owns-operand-order, same as
+  // WasmGC). `OP.CALL <funcIdx>` carries ONE inline operand; the callee arity
+  // is NOT inline — the VM reads it from the function-table entry, mirroring
+  // Wasm `call $f`. The multi-function VM (program wrapper + call-frame stack)
+  // is sdev-vm's slice (see issue §2a + the locked contract).
+  emitCall(funcIdx: number, out: BytecodeSink): void {
+    out.emit(OP.CALL, funcIdx);
+  }
+
+  // `OP.CALL_REF <typeIdx>` — the funcref is already on top of the stack
+  // (lower.ts pushes the callee/funcref LAST). funcref ≡ f64(tableIndex),
+  // null ≡ f64(-1) which traps. `typeIdx` is informational (func-type id).
+  emitCallRef(funcTypeIdx: number, out: BytecodeSink): void {
+    out.emit(OP.CALL_REF, funcTypeIdx);
   }
 
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -146,6 +146,14 @@ export interface BackendEmitter<S = Instr[]> {
   emitRefCellNew?(layout: IrRefCellLowering, out: Instr[]): void;
   emitRefCellGet?(layout: IrRefCellLowering, out: Instr[]): void;
   emitRefCellSet?(layout: IrRefCellLowering, out: Instr[]): void;
-  emitCall?(funcIdx: number, out: Instr[]): void;
-  emitCallRef?(funcTypeIdx: number, out: Instr[]): void;
+
+  // ---- (a1) call family — MIGRATED behind the trait (#1584 §2a) -----------
+  // The first op-family to move from inline `lower.ts` pushes to typed trait
+  // primitives. WasmGc/Linear realize them as byte-identical `{op:"call"}` /
+  // `{op:"call_ref"}`; Bytecode realizes `OP.CALL` / `OP.CALL_REF`. Generic
+  // over the sink `S` (the a0-tail seam) so both backends drive the same arms.
+  /** Direct call to compiled function `funcIdx`. Args already on the stack. */
+  emitCall(funcIdx: number, out: S): void;
+  /** Indirect call through a typed funcref already on the stack. */
+  emitCallRef(funcTypeIdx: number, out: S): void;
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -29,8 +29,8 @@
 // selected by which emitter `lower.ts` was handed. That is the proof.
 
 import type { Instr, ValType } from "../types.js";
-import type { LinearVecLowering } from "./handles.js";
 import type { BackendEmitter } from "./emitter.js";
+import type { LinearVecLowering } from "./handles.js";
 
 /** Byte offset of the `len:u32` field in the linear array header. */
 const LINEAR_ARRAY_LEN_OFFSET = 8;
@@ -92,7 +92,11 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
 
   emitVecLen(layout: LinearVecLowering, out: Instr[]): void {
     // base ptr on stack → load the u32 len field.
-    out.push({ op: "i32.load", align: 2, offset: LINEAR_ARRAY_LEN_OFFSET } as Instr);
+    out.push({
+      op: "i32.load",
+      align: 2,
+      offset: LINEAR_ARRAY_LEN_OFFSET,
+    } as Instr);
   }
 
   emitVecDataPtr(layout: LinearVecLowering, out: Instr[]): void {
@@ -108,7 +112,11 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "i32.const", value: stride });
     out.push({ op: "i32.mul" });
     out.push({ op: "i32.add" });
-    out.push({ op: linearLoadOp(layout.elementValType), align: stride === 8 ? 3 : 2, offset: 0 } as Instr);
+    out.push({
+      op: linearLoadOp(layout.elementValType),
+      align: stride === 8 ? 3 : 2,
+      offset: 0,
+    } as Instr);
   }
 
   // ---- everything else: out of #1714 scope, fail loudly -------------------
@@ -157,5 +165,13 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   }
   emitBrIf(): void {
     notImplemented("emitBrIf");
+  }
+  // (a1) call family (#1584 §2a) — out of the #1714 linear vec-proof scope;
+  // fail loudly until the linear backend wires its call lowering.
+  emitCall(): void {
+    notImplemented("emitCall");
+  }
+  emitCallRef(): void {
+    notImplemented("emitCallRef");
   }
 }

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -18,8 +18,8 @@
 import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
-import type { IrVecLowering } from "./handles.js";
 import type { BackendEmitter } from "./emitter.js";
+import type { IrVecLowering } from "./handles.js";
 
 export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // #1584: sink = Instr[]. The factory returns a plain array and the raw escape
@@ -35,11 +35,19 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // ---- vec (array) ----------------------------------------------------
 
   emitVecLen(layout: IrVecLowering, out: Instr[]): void {
-    out.push({ op: "struct.get", typeIdx: layout.vecStructTypeIdx, fieldIdx: layout.lengthFieldIdx });
+    out.push({
+      op: "struct.get",
+      typeIdx: layout.vecStructTypeIdx,
+      fieldIdx: layout.lengthFieldIdx,
+    });
   }
 
   emitVecDataPtr(layout: IrVecLowering, out: Instr[]): void {
-    out.push({ op: "struct.get", typeIdx: layout.vecStructTypeIdx, fieldIdx: layout.dataFieldIdx });
+    out.push({
+      op: "struct.get",
+      typeIdx: layout.vecStructTypeIdx,
+      fieldIdx: layout.dataFieldIdx,
+    });
   }
 
   emitElemGet(layout: IrVecLowering, out: Instr[]): void {
@@ -115,5 +123,17 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 
   emitBrIf(depth: number, out: Instr[]): void {
     out.push({ op: "br_if", depth });
+  }
+
+  // ---- (a1) call family (#1584 §2a) — byte-identical to the prior inline
+  // `out.push({op:"call"...})` / `{op:"call_ref"...}` in lower.ts. The WasmGC
+  // stream is unchanged; this only moves the push behind the trait so the
+  // bytecode backend can realize the same intent as OP.CALL / OP.CALL_REF.
+  emitCall(funcIdx: number, out: Instr[]): void {
+    out.push({ op: "call", funcIdx });
+  }
+
+  emitCallRef(funcTypeIdx: number, out: Instr[]): void {
+    out.push({ op: "call_ref", typeIdx: funcTypeIdx });
   }
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -698,11 +698,10 @@ export function lowerIrFunctionBody<S>(
         emitter.emitConst(instr, func.name, out);
         return;
       case "call": {
+        // (a1) call family (#1584 §2a): route through the typed emitCall
+        // primitive — byte-identical {op:"call"} on WasmGC, OP.CALL on bytecode.
         for (const a of instr.args) emitValue(a, out);
-        emitter.pushRaw(out, {
-          op: "call",
-          funcIdx: resolver.resolveFunc(instr.target),
-        });
+        emitter.emitCall(resolver.resolveFunc(instr.target), out);
         return;
       }
       case "global.get":
@@ -1101,8 +1100,12 @@ export function lowerIrFunctionBody<S>(
         // which avoids a circular type reference between the struct and
         // its lifted func type). `call_ref` requires a typed funcref, so
         // we emit `ref.cast` to convert.
+        // The struct.get (a2 struct family) + ref.cast (a5 ref-coercion) before
+        // this stay on pushRaw until their families migrate; only the terminal
+        // call_ref is the (a1) call family → typed emitCallRef (byte-identical
+        // {op:"call_ref"} on WasmGC, OP.CALL_REF on bytecode).
         emitter.pushRaw(out, { op: "ref.cast", typeIdx: cl.funcTypeIdx });
-        emitter.pushRaw(out, { op: "call_ref", typeIdx: cl.funcTypeIdx });
+        emitter.emitCallRef(cl.funcTypeIdx, out);
         return;
       }
       case "refcell.new": {

--- a/tests/ir-bytecode-proof.test.ts
+++ b/tests/ir-bytecode-proof.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
-import { BytecodeEmitter, BytecodeSink } from "../src/ir/backend/bytecode-emitter.js";
+import { BytecodeEmitter, BytecodeSink, OP } from "../src/ir/backend/bytecode-emitter.js";
 import { runSink } from "../src/ir/backend/bytecode-vm.js";
 import { type IrFunction, type IrLowerResolver, asBlockId, asValueId, irVal } from "../src/ir/index.js";
 // #1584 (a0-tail): the REAL production lowerer, generic over the sink. The arm
@@ -370,5 +370,93 @@ describe("#1584 (a0-tail) — REAL lower.ts drives the bytecode sink (triple equ
       expect(runSink(sink, [a, b])).toBe(js(a, b));
       expect(await runWasmGc(src, "h", [a, b])).toBe(js(a, b));
     }
+  });
+});
+
+// ── #1584 (a1) call family — real lower.ts emits OP.CALL / OP.CALL_REF ───────
+//
+// The full bytecode==WasmGC==JS round-trip for a multi-function program needs
+// the VM's program-wrapper + call-frame stack (sdev-vm's slice — `runProgram`).
+// This emitter-side test (my lane) asserts the REAL `lowerIrFunctionBody`
+// routes the `call` IR node and `closure.call`'s terminal through the typed
+// emitCall/emitCallRef primitives, so the BytecodeEmitter produces the right
+// opcode stream: `... CALL <funcIdx>` / `... CALL_REF <typeIdx>`. The locked
+// contract (sdev-vm): args on stack arg0-deepest, callee arity from the
+// function-table entry, funcref ≡ f64(tableIndex), null ≡ f64(-1).
+
+/** Resolver that maps any func ref to a fixed table index, for call lowering. */
+function callResolver(funcIdx: number): IrLowerResolver {
+  let nextTypeIdx = 0;
+  return {
+    resolveFunc: () => funcIdx,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in the a1 call subset");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in the a1 call subset");
+    },
+    internFuncType: () => nextTypeIdx++,
+  };
+}
+
+describe("#1584 (a1) — real lower.ts drives OP.CALL through the BytecodeEmitter", () => {
+  it("a `call` IR node lowers to `LOAD args…; CALL <funcIdx>; RET`", () => {
+    // main(a, b): return add(a, b)  where `add` resolves to table index 1.
+    //   %2 = call add(%0, %1)
+    //   return %2
+    const main: IrFunction = {
+      name: "main",
+      params: [
+        { value: asValueId(0), type: F64, name: "a" },
+        { value: asValueId(1), type: F64, name: "b" },
+      ],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "call",
+              target: { kind: "func", name: "add" },
+              args: [asValueId(0), asValueId(1)],
+              result: asValueId(2),
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [asValueId(2)] },
+        },
+      ],
+      exported: true,
+      valueCount: 3,
+    };
+
+    const sink = lowerIrFunctionBody<BytecodeSink>(main, callResolver(1), new BytecodeEmitter()).body;
+    // The call's result is single-use in the return, so it inlines: the body is
+    //   LOAD 0 ; LOAD 1 ; CALL 1 ; RET
+    expect(sink.code).toEqual([OP.LOAD, 0, OP.LOAD, 1, OP.CALL, 1, OP.RET]);
+  });
+
+  it("BytecodeEmitter.emitCall / emitCallRef emit OP.CALL / OP.CALL_REF with their inline operand", () => {
+    const E = new BytecodeEmitter();
+    const s1 = new BytecodeSink();
+    E.emitCall(7, s1);
+    expect(s1.code).toEqual([OP.CALL, 7]);
+
+    const s2 = new BytecodeSink();
+    E.emitCallRef(3, s2);
+    expect(s2.code).toEqual([OP.CALL_REF, 3]);
+  });
+
+  it("spliceArm relocates CALL / CALL_REF as single-operand opcodes", () => {
+    // An if-arm containing a CALL keeps its inline operand after splice.
+    const arm = new BytecodeSink();
+    arm.emit(OP.LOAD, 0);
+    arm.emit(OP.CALL, 5);
+    arm.emit(OP.CALL_REF, 2);
+    const dest = new BytecodeSink();
+    dest.spliceArm(arm);
+    expect(dest.code).toEqual([OP.LOAD, 0, OP.CALL, 5, OP.CALL_REF, 2]);
   });
 });


### PR DESCRIPTION
## #1584 (a1) — call op-family migration

First of the (a1..a6) op-family migrations: moves the **call** family from
inline `lower.ts` `pushRaw` to typed `BackendEmitter` primitives, and adds the
bytecode opcodes so the multi-function VM (sdev-vm's slice) has a clean base.

### What changed
- **emitter.ts**: `emitCall(funcIdx)` / `emitCallRef(funcTypeIdx)` promoted from
  optional to **required** generic-`S` trait methods.
- **WasmGcEmitter**: implements both, **byte-identical** `{op:"call"}` /
  `{op:"call_ref"}`.
- **LinearEmitter**: `notImplemented` stubs (out of the #1714 vec-proof scope).
- **BytecodeEmitter**: `OP.CALL=23` / `OP.CALL_REF=24` (one inline operand each;
  args on stack arg0-deepest; callee arity from the function-table entry;
  funcref ≡ `f64(tableIndex)`, null ≡ `f64(-1)` which traps). `emitCall`/
  `emitCallRef` emit them; `spliceArm` relocates the single-operand opcodes.
- **lower.ts**: `case "call"` → `emitCall`; `closure.call` terminal → `emitCallRef`
  (the preceding `struct.get`/`ref.cast` stay on `pushRaw` until a2/a5 migrate).
- **test**: real `lowerIrFunctionBody(main, resolver, BytecodeEmitter)` on a
  `call` IR node emits `[LOAD 0, LOAD 1, CALL 1, RET]`; `emitCall`/`emitCallRef`
  + `spliceArm` opcode assertions.

### Correctness / byte-identity
- **Full equivalence suite failing-set byte-for-byte IDENTICAL to base
  `f6d05979f`** (0 regressions; WasmGC byte-identical — diffed sorted FAIL lists).
- `tsc` clean · ir-fallback budget zero-delta · biome clean · all 10 proof tests green.

### Cross-family contract (locked with sdev-vm)
Per-function sinks; program wrapper `{functions: FuncEntry[], entry}` with
`FuncEntry = {code, constPool, arity, nLocals}`; call-frame stack saves
`(pc, locals, code, constPool)`; funcref ≡ `f64(tableIndex)`, null ≡ `f64(-1)`.
sdev-vm builds the `runProgram` VM + call-frame machinery against this; the full
bytecode==WasmGC==JS round-trip lands in the VM-side equivalence test.

Draft until final-against-current-main; auto-enqueue is toggling, so admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)