### PR TITLE
feat(#1584) a2: migrate struct/object family behind BackendEmitter trait (stacked on a1)

### DIFF
--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -56,6 +56,7 @@
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
+import type { IrClassLowering, IrObjectStructLowering } from "./handles.js";
 
 // ── Opcodes ───────────────────────────────────────────────────────────────
 // A flat `number[]` instruction stream. Each opcode is one int; inline operands
@@ -100,6 +101,13 @@ export const OP = {
   // f64(-1) (CALL_REF on -1 traps). See sdev-vm coordination + issue §2a.
   CALL: 23, //     CALL <funcIdx>     ; pop arity args, run functions[funcIdx], push result
   CALL_REF: 24, // CALL_REF <typeIdx> ; pop funcref(top)+arity args, run functions[idx], push result
+  // ── (a2) struct/object family (#1584 §2a) — heap-backed structs. A struct
+  // ref ≡ f64(heapIndex) into a VM-global heap of `{fields:number[]}`; null ≡
+  // f64(-1) (STRUCT_GET/SET on -1 traps). The struct field that holds a funcref
+  // stores f64(tableIndex) (a1's invariant) so CALL_REF dispatches it.
+  STRUCT_NEW: 25, // STRUCT_NEW <fieldCount> ; pop fieldCount vals (field0 deepest), alloc heap obj, push ref
+  STRUCT_GET: 26, // STRUCT_GET <fieldIdx>   ; pop structRef, push obj.fields[fieldIdx]
+  STRUCT_SET: 27, // STRUCT_SET <fieldIdx>   ; pop value, pop structRef, obj.fields[fieldIdx]=value
 } as const;
 
 export type Opcode = (typeof OP)[keyof typeof OP];
@@ -188,6 +196,9 @@ export class BytecodeSink {
         case OP.GLOBAL_SET:
         case OP.CALL:
         case OP.CALL_REF:
+        case OP.STRUCT_NEW:
+        case OP.STRUCT_GET:
+        case OP.STRUCT_SET:
           this.code.push(op, code[i++]!);
           break;
         // Zero-operand opcodes.
@@ -402,6 +413,22 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
   // null ≡ f64(-1) which traps. `typeIdx` is informational (func-type id).
   emitCallRef(funcTypeIdx: number, out: BytecodeSink): void {
     out.emit(OP.CALL_REF, funcTypeIdx);
+  }
+
+  // ---- (a2) struct/object family (#1584 §2a) — heap-backed structs --------
+  // STRUCT_NEW carries the field COUNT (the untyped VM needs no typeIdx, only
+  // how many to pop); STRUCT_GET/SET carry the numeric field INDEX (lower.ts
+  // resolves name→fieldIdx via the layout, so the VM gets the index directly).
+  emitAggregateNew(_layout: IrObjectStructLowering, fieldCount: number, out: BytecodeSink): void {
+    out.emit(OP.STRUCT_NEW, fieldCount);
+  }
+
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
+    out.emit(OP.STRUCT_GET, layout.fieldIdx(name));
+  }
+
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
+    out.emit(OP.STRUCT_SET, layout.fieldIdx(name));
   }
 
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -130,10 +130,7 @@ export interface BackendEmitter<S = Instr[]> {
   // closure / ref-coercion) have a stable signature to migrate against and
   // #1714 knows the shape of the not-yet-moved surface. A `WasmGcEmitter`
   // need not implement them until its group is wired.
-  emitAggregateNew?(layout: IrObjectStructLowering, fieldCount: number, out: Instr[]): void;
   emitBox?(layout: IrUnionLowering, out: Instr[]): void;
-  emitFieldGet?(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void;
-  emitFieldSet?(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void;
   emitUnbox?(layout: IrUnionLowering, out: Instr[]): void;
   emitTagLoad?(layout: IrUnionLowering, out: Instr[]): void;
   emitNull?(irType: IrType, out: Instr[]): void;
@@ -156,4 +153,17 @@ export interface BackendEmitter<S = Instr[]> {
   emitCall(funcIdx: number, out: S): void;
   /** Indirect call through a typed funcref already on the stack. */
   emitCallRef(funcTypeIdx: number, out: S): void;
+
+  // ---- (a2) struct/object family — MIGRATED behind the trait (#1584 §2a) ---
+  // The object struct ops (object.new / object.get / object.set). WasmGc/Linear
+  // realize them as byte-identical `{op:"struct.new"}` / `{op:"struct.get"}` /
+  // `{op:"struct.set"}`; Bytecode realizes `OP.STRUCT_NEW` / `STRUCT_GET` /
+  // `STRUCT_SET` over a VM heap (struct ref ≡ f64(heapIndex), null ≡ f64(-1)).
+  /** Allocate an aggregate from `fieldCount` values already on the stack
+   * (canonical field order, field0 deepest); leaves the new struct ref. */
+  emitAggregateNew(layout: IrObjectStructLowering, fieldCount: number, out: S): void;
+  /** struct ref on stack -> the named field's value. */
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
+  /** struct ref + value on stack -> writes the named field (void). */
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -166,6 +166,16 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   emitBrIf(): void {
     notImplemented("emitBrIf");
   }
+  // (a2) struct/object family (#1584 §2a) — out of the #1714 vec-proof scope.
+  emitAggregateNew(): void {
+    notImplemented("emitAggregateNew");
+  }
+  emitFieldGet(): void {
+    notImplemented("emitFieldGet");
+  }
+  emitFieldSet(): void {
+    notImplemented("emitFieldSet");
+  }
   // (a1) call family (#1584 §2a) — out of the #1714 linear vec-proof scope;
   // fail loudly until the linear backend wires its call lowering.
   emitCall(): void {

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -19,7 +19,7 @@ import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
-import type { IrVecLowering } from "./handles.js";
+import type { IrClassLowering, IrObjectStructLowering, IrVecLowering } from "./handles.js";
 
 export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // #1584: sink = Instr[]. The factory returns a plain array and the raw escape
@@ -136,4 +136,34 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   emitCallRef(funcTypeIdx: number, out: Instr[]): void {
     out.push({ op: "call_ref", typeIdx: funcTypeIdx });
   }
+
+  // ---- (a2) struct/object family (#1584 §2a) — byte-identical to the prior
+  // inline `out.push({op:"struct.new"/"struct.get"/"struct.set"...})` in the
+  // object.new/get/set arms of lower.ts. The WasmGC stream is unchanged; this
+  // moves the push behind the trait so the bytecode backend realizes the same
+  // intent as OP.STRUCT_NEW / STRUCT_GET / STRUCT_SET over a VM heap.
+  emitAggregateNew(layout: IrObjectStructLowering, _fieldCount: number, out: Instr[]): void {
+    out.push({ op: "struct.new", typeIdx: layout.typeIdx });
+  }
+
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+    out.push({
+      op: "struct.get",
+      typeIdx: structTypeIdxOf(layout),
+      fieldIdx: layout.fieldIdx(name),
+    });
+  }
+
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+    out.push({
+      op: "struct.set",
+      typeIdx: structTypeIdxOf(layout),
+      fieldIdx: layout.fieldIdx(name),
+    });
+  }
+}
+
+/** The WasmGC struct typeIdx for an object (`typeIdx`) or class (`structTypeIdx`). */
+function structTypeIdxOf(layout: IrObjectStructLowering | IrClassLowering): number {
+  return "typeIdx" in layout ? layout.typeIdx : layout.structTypeIdx;
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -996,8 +996,10 @@ export function lowerIrFunctionBody<S>(
         // shape.fields, which is also the WasmGC struct's declared field
         // order. The builder enforces value-count parity with shape arity,
         // so this loop always produces the right stack shape.
+        // (a2) struct/object family (#1584 §2a): route through emitAggregateNew
+        // — byte-identical {op:"struct.new"} on WasmGC, OP.STRUCT_NEW on bytecode.
         for (const v of instr.values) emitValue(v, out);
-        emitter.pushRaw(out, { op: "struct.new", typeIdx: obj.typeIdx });
+        emitter.emitAggregateNew(obj, instr.values.length, out);
         return;
       }
       case "object.get": {
@@ -1011,12 +1013,10 @@ export function lowerIrFunctionBody<S>(
         if (!obj) {
           throw new Error(`ir/lower: resolver cannot lower object<${describeShape(valueIrType.shape)}> (${func.name})`);
         }
+        // (a2): route through emitFieldGet — byte-identical {op:"struct.get"}
+        // on WasmGC, OP.STRUCT_GET <fieldIdx> on bytecode.
         emitValue(instr.value, out);
-        emitter.pushRaw(out, {
-          op: "struct.get",
-          typeIdx: obj.typeIdx,
-          fieldIdx: obj.fieldIdx(instr.name),
-        });
+        emitter.emitFieldGet(obj, instr.name, out);
         return;
       }
       case "object.set": {
@@ -1030,13 +1030,11 @@ export function lowerIrFunctionBody<S>(
         if (!obj) {
           throw new Error(`ir/lower: resolver cannot lower object<${describeShape(valueIrType.shape)}> (${func.name})`);
         }
+        // (a2): route through emitFieldSet — byte-identical {op:"struct.set"}
+        // on WasmGC, OP.STRUCT_SET <fieldIdx> on bytecode.
         emitValue(instr.value, out);
         emitValue(instr.newValue, out);
-        emitter.pushRaw(out, {
-          op: "struct.set",
-          typeIdx: obj.typeIdx,
-          fieldIdx: obj.fieldIdx(instr.name),
-        });
+        emitter.emitFieldSet(obj, instr.name, out);
         return;
       }
       // Slice 3 (#1169c): closure / ref-cell ops.

--- a/tests/ir-bytecode-proof.test.ts
+++ b/tests/ir-bytecode-proof.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { BytecodeEmitter, BytecodeSink, OP } from "../src/ir/backend/bytecode-emitter.js";
 import { runSink } from "../src/ir/backend/bytecode-vm.js";
+import type { IrObjectStructLowering } from "../src/ir/backend/handles.js";
 import { type IrFunction, type IrLowerResolver, asBlockId, asValueId, irVal } from "../src/ir/index.js";
 // #1584 (a0-tail): the REAL production lowerer, generic over the sink. The arm
 // at the bottom of this file drives it (not a hand-lowerer) through a
@@ -458,5 +459,49 @@ describe("#1584 (a1) — real lower.ts drives OP.CALL through the BytecodeEmitte
     const dest = new BytecodeSink();
     dest.spliceArm(arm);
     expect(dest.code).toEqual([OP.LOAD, 0, OP.CALL, 5, OP.CALL_REF, 2]);
+  });
+});
+
+// ── #1584 (a2) struct/object family — STRUCT_NEW / STRUCT_GET / STRUCT_SET ──
+//
+// The full bytecode==WasmGC==JS round-trip for object.new/get/set needs the
+// VM's heap (sdev-vm's slice — struct ref ≡ f64(heapIndex)). These emitter-side
+// tests (my lane) assert the BytecodeEmitter realizes the (a2) trait primitives
+// as the right opcodes: STRUCT_NEW carries the field COUNT; STRUCT_GET/SET carry
+// the numeric field INDEX (lower.ts resolves name→fieldIdx via the layout).
+
+/** Minimal object-struct layout: field name → index in declaration order. */
+function objLayout(fields: string[]): IrObjectStructLowering {
+  return { typeIdx: 99, fieldIdx: (name: string) => fields.indexOf(name) };
+}
+
+describe("#1584 (a2) — BytecodeEmitter realizes the struct/object family", () => {
+  it("emitAggregateNew emits OP.STRUCT_NEW with the field count", () => {
+    const E = new BytecodeEmitter();
+    const s = new BytecodeSink();
+    E.emitAggregateNew(objLayout(["x", "y"]), 2, s);
+    expect(s.code).toEqual([OP.STRUCT_NEW, 2]);
+  });
+
+  it("emitFieldGet / emitFieldSet emit OP.STRUCT_GET / STRUCT_SET with the resolved field index", () => {
+    const E = new BytecodeEmitter();
+    const layout = objLayout(["x", "y", "z"]);
+    const g = new BytecodeSink();
+    E.emitFieldGet(layout, "y", g);
+    expect(g.code).toEqual([OP.STRUCT_GET, 1]);
+
+    const s = new BytecodeSink();
+    E.emitFieldSet(layout, "z", s);
+    expect(s.code).toEqual([OP.STRUCT_SET, 2]);
+  });
+
+  it("spliceArm relocates STRUCT_NEW / STRUCT_GET / STRUCT_SET as single-operand opcodes", () => {
+    const arm = new BytecodeSink();
+    arm.emit(OP.STRUCT_NEW, 2);
+    arm.emit(OP.STRUCT_GET, 0);
+    arm.emit(OP.STRUCT_SET, 1);
+    const dest = new BytecodeSink();
+    dest.spliceArm(arm);
+    expect(dest.code).toEqual([OP.STRUCT_NEW, 2, OP.STRUCT_GET, 0, OP.STRUCT_SET, 1]);
   });
 });


### PR DESCRIPTION
## #1584 (a2) — struct/object op-family migration  ·  STACKED ON #970 (a1)

Base is the a1 branch (`issue-1584-a1-call`) so this shows only the a2 delta.
**After a1 (#970) merges, re-target this to `main`.**

### What changed
- **emitter.ts**: `emitAggregateNew(layout,fieldCount)` / `emitFieldGet(layout,name)` /
  `emitFieldSet(layout,name)` promoted to **required** generic-`S` trait methods.
- **WasmGcEmitter**: implements all three, **byte-identical** `{op:"struct.new"}` /
  `{op:"struct.get"}` / `{op:"struct.set"}` (`structTypeIdxOf` handles object vs class).
- **LinearEmitter**: `notImplemented` stubs.
- **BytecodeEmitter**: `OP.STRUCT_NEW=25` / `STRUCT_GET=26` / `STRUCT_SET=27`
  (STRUCT_NEW carries the field count; GET/SET the resolved field index). struct
  ref ≡ `f64(heapIndex)`, null ≡ `f64(-1)`; `spliceArm` relocates them.
- **lower.ts**: `object.new` → `emitAggregateNew`; `object.get` → `emitFieldGet`;
  `object.set` → `emitFieldSet`. box/closure/refcell/class/promise structs stay
  `pushRaw` (their own families).
- **test**: emitter-side STRUCT_NEW/GET/SET opcode assertions + spliceArm.

### Correctness / byte-identity
- **Full equivalence suite failing-set byte-for-byte IDENTICAL to base `681410302`**
  (a1 HEAD) — 0 regressions, WasmGC byte-identical (diffed sorted FAIL lists).
- `tsc` clean · ir-fallback budget zero-delta · biome clean · all 13 proof tests green.

### Cross-family invariant (locked with sdev-vm)
heap = VM-global `{fields:number[]}[]`; struct ref ≡ `f64(heapIndex)`, null ≡
`f64(-1)`. A struct field holding a funcref stores `f64(tableIndex)` (a1's
invariant) so `STRUCT_GET`→`CALL_REF` dispatches a real closure once a2+a5 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)