### PR TITLE
feat(#1584) a1: multi-frame call-stack VM (CALL/CALL_REF) (#245)

### DIFF
--- a/src/ir/backend/bytecode-vm.ts
+++ b/src/ir/backend/bytecode-vm.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
-// Bytecode dispatch loop (#1715) — the TypeScript stack VM that executes the
-// opcode stream {@link BytecodeEmitter} produces.
+// Bytecode dispatch loop (#1715 / #1584) — the TypeScript stack VM that executes
+// the opcode stream {@link BytecodeEmitter} produces.
 //
 // Written in plain TypeScript ON PURPOSE: #1584's eventual design is to compile
 // the dispatch loop itself with js2wasm, so the loop must be expressible in the
@@ -13,33 +13,117 @@
 // then declared locals); the operand stack is a `number[]`. Booleans are 1.0 /
 // 0.0 (matching the emitter's CMP_* ops and JS truthiness for the JZ branch).
 // All values are JS numbers (f64) — the #1715 subset is numeric only.
+//
+// #1584 a1 (call family): the single-function `runBytecode` generalises to a
+// MULTI-FRAME call-stack machine, `runProgram`, over a function table. A
+// `CALL`/`CALL_REF` pushes a call frame (saving the caller's pc/locals/code/
+// constPool) and installs the callee's; `RET` pops the frame and resumes the
+// caller with the callee's top-of-stack pushed. `runBytecode`/`runSink` stay as
+// the single-function entry (the bottom frame) for the #1715 numeric proofs.
+//
+// Cross-family value representation (locked with the emitter, see issue §2a):
+//   - funcref ≡ f64(tableIndex)  — a function reference is the f64 of its index
+//     in `program.functions`. null-funcref ≡ f64(-1); `CALL_REF` on -1 traps.
+//   The stack/locals domain stays homogeneous f64; this is safe because the
+//   bytecode is well-typed by construction (lower.ts only emits `CALL_REF` on a
+//   slot it statically knows is a funcref — the Wasm type system upstream
+//   guarantees it), so the VM does not tag-check.
 
 import { type BytecodeSink, OP } from "./bytecode-emitter.js";
 
 /**
- * Run a compiled bytecode program.
- *
- * @param code      flat opcode + inline-operand stream (`sink.code`)
- * @param constPool f64 immediates referenced by `OP.CONST <poolIdx>` (`sink.constPool`)
- * @param args      initial values of locals 0..n-1 (the function parameters);
- *                  any higher local index used by STORE/LOAD is lazily 0-init.
- * @returns the number left on the stack by `OP.RET`
+ * One entry in a {@link Program}'s function table. A function lowers to its own
+ * {@link BytecodeSink} (own `code` + own `constPool` + own jump address-space),
+ * so a call switches BOTH `code` and `constPool` and the call frame restores
+ * both on return.
  */
-export function runBytecode(code: readonly number[], constPool: readonly number[], args: readonly number[]): number {
-  const locals: number[] = args.slice();
-  // Module globals (GLOBAL_GET/SET), lazily 0-initialised on first access —
-  // mirrors the `locals` lazy-init contract. The #1715 numeric subset has no
-  // globals; this is here for the production op set.
+export interface FuncEntry {
+  // NOTE: array-typed fields are `number[]`, NOT `readonly number[]`. When this
+  // VM is itself compiled by js2wasm (the slice-(b) Wasm-GC-VM arm), a `readonly`
+  // array nested as a struct field lowers to an immutable WasmGC array variant
+  // whose nested-field read after an index TRAPS. Plain `number[]` lowers
+  // correctly. (The VM never mutates these, so dropping `readonly` is a codegen
+  // accommodation, not a semantic change.)
+  /** The function's opcode stream (`sink.code`). */
+  code: number[];
+  /** The function's f64 immediate pool (`sink.constPool`). */
+  constPool: number[];
+  /** Declared parameter count — `CALL` pops this many args (arity not inline). */
+  arity: number;
+  /**
+   * Local-slot count (params + declared locals). A call installs a fresh
+   * `locals[nLocals]` seeded `locals[0..arity-1]` with the popped args; higher
+   * slots are lazily 0-init on first `LOAD` (same contract as `runBytecode`).
+   */
+  nLocals: number;
+}
+
+/**
+ * A whole compiled program: a function table plus the entry function index.
+ * `runProgram` runs `functions[entry]` as the bottom frame.
+ */
+export interface Program {
+  // `functions` is `FuncEntry[]` (not `readonly`) for the same js2wasm-codegen
+  // reason as FuncEntry's fields above.
+  functions: FuncEntry[];
+  entry: number;
+}
+
+/** Bounded step guard — turns a malformed stream (missing RET / bad backpatch)
+ *  into a clear failure instead of a hang. Proof programs are tiny.
+ *  (No numeric `_` separator — the js2wasm parser that compiles this file for
+ *  the slice-(b) Wasm-GC-VM arm rejects them.) */
+const MAX_STEPS = 1000000;
+
+/** Sentinel f64 value for a null function reference (`CALL_REF` traps on it). */
+const NULL_FUNCREF = -1;
+
+/**
+ * Run a whole {@link Program} — the multi-frame call-stack VM (#1584 a1).
+ *
+ * @param program  function table + entry index
+ * @param args     initial values of the entry function's locals 0..arity-1
+ * @returns the number the entry function's `RET` leaves on the stack
+ */
+export function runProgram(program: Program, args: readonly number[]): number {
+  const { functions } = program;
+
+  // VM-global state (outlives any single frame): module globals
+  // (GLOBAL_GET/SET), lazily 0-init on first access.
   const globals: number[] = [];
+
+  // The operand stack is shared across frames (Wasm-style: a callee pops its
+  // args from / pushes its result onto the same value stack). Locals/pc/code/
+  // constPool are per-frame.
   const stack: number[] = [];
+
+  // Call-frame stack: each entry is the SUSPENDED caller's state, restored on
+  // RET. The currently-executing function's state lives in the mutable locals
+  // below (not on this stack until it calls out).
+  interface Frame {
+    pc: number;
+    locals: number[];
+    // `number[]` not `readonly number[]` — see the FuncEntry note: a `readonly`
+    // array nested as a struct field traps when this VM is js2wasm-compiled.
+    code: number[];
+    constPool: number[];
+  }
+  const frames: Frame[] = [];
+
+  // Install the entry function as the bottom (currently-executing) frame.
+  const entryFn = functions[program.entry];
+  if (entryFn === undefined) {
+    throw new Error(`bytecode-vm: entry funcIdx ${program.entry} out of range`);
+  }
+  let code = entryFn.code;
+  let constPool = entryFn.constPool;
+  // Entry locals: args copied into slots 0..arity-1 (the #1715 contract — the
+  // entry behaves like `runBytecode(args)`); slots above args.length are lazily
+  // 0-init on first LOAD.
+  let locals: number[] = args.slice();
   let pc = 0;
 
-  // Bounded loop guard — proof programs are tiny + non-looping; this only trips
-  // on a malformed stream (missing RET / bad backpatch), turning a hang into a
-  // clear failure for the test.
   let steps = 0;
-  const MAX_STEPS = 1_000_000;
-
   for (;;) {
     if (++steps > MAX_STEPS) throw new Error("bytecode-vm: step budget exceeded (malformed program?)");
     const op = code[pc++];
@@ -114,8 +198,26 @@ export function runBytecode(code: readonly number[], constPool: readonly number[
       case OP.JMP:
         pc = code[pc++]!;
         break;
-      case OP.RET:
-        return stack.pop()!;
+      case OP.RET: {
+        // Pop this frame's result. If there is no caller, it's the program
+        // result. Otherwise restore the caller (pc/locals/code/constPool) and
+        // push the callee's result onto the (shared) caller stack.
+        //
+        // NOTE: check `frames.length` BEFORE popping — `[].pop()` on an empty
+        // array TRAPS when this VM is itself compiled by js2wasm (a WasmGC array
+        // out-of-bounds, not a JS `undefined`). The entry function's RET hits
+        // this empty case on every program exit, so the length guard is load-
+        // bearing for the slice-(b) compiled-VM arm, not just defensive.
+        const result = stack.pop()!;
+        if (frames.length === 0) return result;
+        const caller = frames.pop()!;
+        pc = caller.pc;
+        locals = caller.locals;
+        code = caller.code;
+        constPool = caller.constPool;
+        stack.push(result);
+        break;
+      }
       // ── #1584 production additions (DIV..UNREACHABLE) — wired in lockstep with
       // the emitter's OP enum (sdev-emitter owns OP; the VM realizes each). ──
       case OP.DIV: {
@@ -162,13 +264,99 @@ export function runBytecode(code: readonly number[], constPool: readonly number[
         // loudly (the standalone-Wasm analogue is `unreachable`; the host VM
         // throws so the equivalence test sees a clean failure, not a hang).
         throw new Error(`bytecode-vm: UNREACHABLE executed at pc ${pc - 1}`);
+      // ── #1584 a1 call family (CALL / CALL_REF) ──
+      case OP.CALL: {
+        // CALL <funcIdx>: direct call. Args are already on the stack (arg0
+        // deepest). Arity is NOT inline — read it from the callee's table entry
+        // (mirrors Wasm `call $f`, where arity comes from the func type).
+        const funcIdx = code[pc++]!;
+        const callee = functions[funcIdx];
+        if (callee === undefined) {
+          throw new Error(`bytecode-vm: CALL funcIdx ${funcIdx} out of range at pc ${pc - 2}`);
+        }
+        // Save the caller, install the callee.
+        frames.push({ pc, locals, code, constPool });
+        const calleeLocals = popArgsIntoLocals(callee, stack);
+        locals = calleeLocals;
+        code = callee.code;
+        constPool = callee.constPool;
+        pc = 0;
+        break;
+      }
+      case OP.CALL_REF: {
+        // CALL_REF <typeIdx>: indirect call through a funcref ON TOP of the
+        // stack (lower.ts emits the funcref last). The typeIdx operand is
+        // informational (arity/validation); the dispatch target is the funcref.
+        // funcref ≡ f64(tableIndex); null ≡ f64(-1) traps.
+        pc++; // consume the (informational) typeIdx operand
+        const funcref = stack.pop()!;
+        if (funcref === NULL_FUNCREF) {
+          throw new Error(`bytecode-vm: CALL_REF on null funcref at pc ${pc - 2}`);
+        }
+        const idx = funcref | 0; // f64 -> i32 table index
+        const callee = functions[idx];
+        if (callee === undefined) {
+          throw new Error(`bytecode-vm: CALL_REF funcref ${idx} out of range at pc ${pc - 2}`);
+        }
+        frames.push({ pc, locals, code, constPool });
+        const calleeLocals = popArgsIntoLocals(callee, stack);
+        locals = calleeLocals;
+        code = callee.code;
+        constPool = callee.constPool;
+        pc = 0;
+        break;
+      }
       default:
         throw new Error(`bytecode-vm: unknown opcode ${op} at pc ${pc - 1}`);
     }
   }
 }
 
-/** Convenience: run a {@link BytecodeSink}'s program. */
+/**
+ * Pop a callee's `arity` args off the shared stack (arg0 was pushed first, so
+ * it is deepest) into a fresh `locals[0..arity-1]`. Higher local slots are
+ * lazily 0-init on first `LOAD` (same as `seedLocals`).
+ */
+function popArgsIntoLocals(callee: FuncEntry, stack: number[]): number[] {
+  const calleeLocals: number[] = [];
+  for (let i = callee.arity - 1; i >= 0; i--) {
+    calleeLocals[i] = stack.pop()!;
+  }
+  return calleeLocals;
+}
+
+/**
+ * Run a single compiled bytecode function (the #1715 numeric proof entry).
+ * Implemented as a one-function {@link Program} so the single- and multi-frame
+ * paths share one dispatch loop.
+ *
+ * @param code      flat opcode + inline-operand stream (`sink.code`)
+ * @param constPool f64 immediates referenced by `OP.CONST <poolIdx>` (`sink.constPool`)
+ * @param args      initial values of locals 0..n-1 (the function parameters);
+ *                  any higher local index used by STORE/LOAD is lazily 0-init.
+ * @returns the number left on the stack by `OP.RET`
+ */
+export function runBytecode(code: readonly number[], constPool: readonly number[], args: readonly number[]): number {
+  // arity = args.length so the entry seeds exactly the provided args; nLocals
+  // is unbounded in practice (lazy 0-init), so any sufficiently large value
+  // works — use args.length as the floor (higher slots lazily appear).
+  // `.slice()` into mutable `number[]` for the FuncEntry fields (which are
+  // `number[]`, not `readonly`, for the js2wasm-codegen reason noted above).
+  const program: Program = {
+    functions: [
+      {
+        code: code.slice(),
+        constPool: constPool.slice(),
+        arity: args.length,
+        nLocals: args.length,
+      },
+    ],
+    entry: 0,
+  };
+  return runProgram(program, args);
+}
+
+/** Convenience: run a {@link BytecodeSink}'s program as a single function. */
 export function runSink(sink: BytecodeSink, args: readonly number[]): number {
   return runBytecode(sink.code, sink.constPool, args);
 }

--- a/tests/ir-bytecode-wasmgc-vm.test.ts
+++ b/tests/ir-bytecode-wasmgc-vm.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { BytecodeEmitter, BytecodeSink, OP } from "../src/ir/backend/bytecode-emitter.js";
-import { runSink } from "../src/ir/backend/bytecode-vm.js";
+import { type FuncEntry, type Program, runProgram, runSink } from "../src/ir/backend/bytecode-vm.js";
 import type { BlockType } from "../src/ir/types.js";
 import { buildImports } from "../src/runtime.js";
 
@@ -85,8 +85,12 @@ function compileVmModule(
   let src = readFileSync(VM_FILE, "utf8");
   // 1. drop every import line (host-only).
   src = src.replace(/^import\b[^\n]*\n/gm, "");
-  // 2. inline OP.NAME numeric values.
-  for (const [name, value] of Object.entries(OP)) {
+  // 2. inline OP.NAME numeric values. Replace LONGER names first: some opcode
+  //    names are prefixes of others (e.g. `CALL` is a prefix of `CALL_REF`, and
+  //    `GLOBAL_GET`/`GLOBAL_SET` share `GLOBAL`), and `replaceAll` on the prefix
+  //    would corrupt the longer token (`OP.CALL_REF` -> `23_REF`). Descending
+  //    name length guarantees the longest match is substituted first.
+  for (const [name, value] of Object.entries(OP).sort((a, b) => b[0].length - a[0].length)) {
     src = src.replaceAll(`OP.${name}`, String(value));
   }
   // 3. drop the runSink convenience (BytecodeSink-typed -> out of subset). It is
@@ -103,6 +107,52 @@ export function run(${params}): number {
 }
 `;
   return src + entry;
+}
+
+/**
+ * Multi-function variant of {@link compileVmModule} (#1584 a1). Builds a
+ * `Program` (function table + entry) in-module and calls `runProgram`, so the
+ * compiled-VM arm exercises the CALL family. Same four transforms as
+ * `compileVmModule`; the appended entry constructs each `FuncEntry` literal and
+ * the `Program` wrapper inline (the #1700 export-ABI constraint: object/array
+ * params can't cross the boundary, so the program is built inside the module).
+ */
+function compileProgramModule(
+  entryParams: readonly string[],
+  functions: ReadonlyArray<{
+    code: readonly number[];
+    constPool: readonly number[];
+    arity: number;
+    nLocals: number;
+  }>,
+  entry: number,
+  argInit: readonly string[],
+): string {
+  let src = readFileSync(VM_FILE, "utf8");
+  src = src.replace(/^import\b[^\n]*\n/gm, "");
+  for (const [name, value] of Object.entries(OP).sort((a, b) => b[0].length - a[0].length)) {
+    src = src.replaceAll(`OP.${name}`, String(value));
+  }
+  // Drop the trailing BytecodeSink-typed convenience helper (out of subset).
+  src = src.replace(/\/\*\* Convenience[\s\S]*$/m, "");
+  const params = entryParams.map((p) => `${p}: number`).join(", ");
+  const fnLiterals = functions
+    .map(
+      (f) =>
+        `{ code: [${f.code.join(", ")}], constPool: [${f.constPool.join(", ")}], arity: ${f.arity}, nLocals: ${f.nLocals} }`,
+    )
+    .join(",\n    ");
+  const entrySrc = `
+export function run(${params}): number {
+  const functions: FuncEntry[] = [
+    ${fnLiterals}
+  ];
+  const program: Program = { functions: functions, entry: ${entry} };
+  const args: number[] = [${argInit.join(", ")}];
+  return runProgram(program, args);
+}
+`;
+  return src + entrySrc;
 }
 
 // ── Compile + run a WasmGC export taking only number params ────────────────
@@ -370,6 +420,135 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
         expect(await runWasm(mod, "run", [a]), `wasm global(${a})`).toBe(a * 3);
       }
     }
+  });
+
+  // ── #1584 a1 call family: CALL (direct) + CALL_REF (indirect via funcref) ──
+  // The VM becomes a multi-frame call-stack machine over a function table.
+  // PROGRAM A drives a direct CALL between two functions through BOTH the host
+  // VM (runProgram) and the compiled VM (compileProgramModule), asserting
+  // host-VM == Wasm-GC-VM == JS. PROGRAM B drives CALL_REF over a synthesized
+  // funcref-on-stack; the null-funcref (f64(-1)) case must trap.
+  it("a1: CALL — host-VM == WasmGC-VM == JS for main(a,b)=add(a,b)", async () => {
+    // functions[1] = add(a,b) = a + b   →  LOAD 0; LOAD 1; ADD; RET
+    const add = new BytecodeSink();
+    E.emitLocalGet(0, add);
+    E.emitLocalGet(1, add);
+    E.emitBinary("f64.add", add);
+    E.emitReturn(add);
+    // functions[0] = main(a,b) = add(a,b)  →  LOAD 0; LOAD 1; CALL 1; RET
+    const main = new BytecodeSink();
+    E.emitLocalGet(0, main);
+    E.emitLocalGet(1, main);
+    main.emit(OP.CALL, 1); // CALL funcIdx 1 (add)
+    E.emitReturn(main);
+
+    const functions: FuncEntry[] = [
+      {
+        code: main.code.slice(),
+        constPool: main.constPool.slice(),
+        arity: 2,
+        nLocals: 2,
+      },
+      {
+        code: add.code.slice(),
+        constPool: add.constPool.slice(),
+        arity: 2,
+        nLocals: 2,
+      },
+    ];
+    const program: Program = { functions, entry: 0 };
+    const js = (a: number, b: number): number => a + b;
+
+    const vmMod = compileProgramModule(
+      ["a", "b"],
+      functions.map((f) => ({
+        code: f.code,
+        constPool: f.constPool,
+        arity: f.arity,
+        nLocals: f.nLocals,
+      })),
+      0,
+      ["a", "b"],
+    );
+
+    for (const [a, b] of [
+      [2, 3],
+      [-5, 10],
+      [0.5, 0.25],
+      [100, -100],
+    ]) {
+      const expected = js(a, b);
+      expect(runProgram(program, [a, b]), `host CALL add(${a},${b})`).toBe(expected);
+      expect(await runWasm(vmMod, "run", [a, b]), `wasm CALL add(${a},${b})`).toBe(expected);
+    }
+  });
+
+  it("a1: CALL_REF — host-VM dispatches funcref≡f64(tableIdx); null≡f64(-1) traps", async () => {
+    // functions[1] = add(a,b) = a + b. functions[0] = entry that pushes
+    // a, b, then the funcref f64(1) on top, then CALL_REF.
+    const add = new BytecodeSink();
+    E.emitLocalGet(0, add);
+    E.emitLocalGet(1, add);
+    E.emitBinary("f64.add", add);
+    E.emitReturn(add);
+
+    // entry: LOAD 0; LOAD 1; CONST f64(1) [funcref=tableIdx 1]; CALL_REF <typeIdx>; RET
+    const entry = new BytecodeSink();
+    E.emitLocalGet(0, entry);
+    E.emitLocalGet(1, entry);
+    emitNumberConst(1, entry); // funcref ≡ f64(1)
+    entry.emit(OP.CALL_REF, 0); // typeIdx operand is informational
+    E.emitReturn(entry);
+
+    const functions: FuncEntry[] = [
+      {
+        code: entry.code.slice(),
+        constPool: entry.constPool.slice(),
+        arity: 2,
+        nLocals: 2,
+      },
+      {
+        code: add.code.slice(),
+        constPool: add.constPool.slice(),
+        arity: 2,
+        nLocals: 2,
+      },
+    ];
+    const program: Program = { functions, entry: 0 };
+
+    for (const [a, b] of [
+      [2, 3],
+      [-5, 10],
+      [7, 7],
+    ]) {
+      expect(runProgram(program, [a, b]), `host CALL_REF add(${a},${b})`).toBe(a + b);
+    }
+
+    // null-funcref: push f64(-1) then CALL_REF → must trap.
+    const nullEntry = new BytecodeSink();
+    E.emitLocalGet(0, nullEntry);
+    E.emitLocalGet(1, nullEntry);
+    emitNumberConst(-1, nullEntry); // null funcref sentinel
+    nullEntry.emit(OP.CALL_REF, 0);
+    E.emitReturn(nullEntry);
+    const nullProgram: Program = {
+      functions: [
+        {
+          code: nullEntry.code.slice(),
+          constPool: nullEntry.constPool.slice(),
+          arity: 2,
+          nLocals: 2,
+        },
+        {
+          code: add.code.slice(),
+          constPool: add.constPool.slice(),
+          arity: 2,
+          nLocals: 2,
+        },
+      ],
+      entry: 0,
+    };
+    expect(() => runProgram(nullProgram, [1, 2]), "null funcref CALL_REF traps").toThrow(/null funcref/);
   });
 
   // ── Sanity: the host VM still rejects malformed; the emitter rejects ops ──


### PR DESCRIPTION
## What

Generalizes the bytecode VM (`src/ir/backend/bytecode-vm.ts`) from the single-function `runBytecode` into a **multi-frame call-stack machine** `runProgram` over a function table, realizing the **a1 call family** (`OP.CALL=23` / `OP.CALL_REF=24`, landed by the emitter in #970). This is the VM-side counterpart of #248; task #245.

## VM changes

- New top-level input: `Program = { functions: FuncEntry[], entry }`; `FuncEntry = { code, constPool, arity, nLocals }` — per-function sinks, each with its own code stream + const-pool + jump address-space.
- `runProgram` maintains a **call-frame stack**. `CALL <funcIdx>` / `CALL_REF <typeIdx>` pop the callee's `arity` args (arg0 deepest), push a frame saving the caller's `(pc, locals, code, constPool)`, and install the callee's; `RET` pops the frame and pushes the callee's TOS onto the (shared) caller stack — or returns the program result at the bottom frame. Mirrors Wasm `call`/`call_ref`.
- **funcref ≡ f64(tableIndex)**, **null-funcref ≡ f64(-1)** (CALL_REF on -1 traps). Cross-family invariant locked with the emitter so a2 struct fields / a5 ref.cast produce dispatchable funcrefs.
- `runBytecode` / `runSink` preserved as the single-function entry (a one-function `Program`), so the #1715 numeric proofs are unchanged.

## Two js2wasm-codegen accommodations

This VM is **itself compiled by js2wasm** for the slice-(b) Wasm-GC-VM equivalence arm, which surfaced two real codegen behaviors (both documented inline):

1. **`RET` length-guards `frames` before popping.** `[].pop()` on an empty WasmGC array **traps** (out-of-bounds) rather than returning `undefined`. The entry function's `RET` hits the empty-frames case on *every* program exit, so `if (frames.length === 0) return result;` is load-bearing, not defensive.
2. **`FuncEntry`/`Frame` array fields are `number[]`, NOT `readonly number[]`.** A `readonly` array nested as a struct field lowers to an immutable WasmGC array variant whose nested-field read after an index **traps**. Plain `number[]` lowers correctly. (The VM never mutates these — dropping `readonly` is a codegen accommodation, not a semantic change.)

## Tests (`tests/ir-bytecode-wasmgc-vm.test.ts`)

- **a1 CALL** — host-VM == Wasm-GC-VM == JS for `main(a,b)=add(a,b)` (direct call between two functions, proven through the compiled VM via the new `compileProgramModule` helper that builds the `Program` in-module).
- **a1 CALL_REF** — host-VM dispatches `funcref≡f64(tableIdx)`; null `f64(-1)` traps.
- Fixes a latent bug in the test's OP-inlining transform: opcode names that are prefixes of others (`CALL` ⊂ `CALL_REF`) corrupted the longer token (`OP.CALL_REF` → `23_REF`); now replaces by descending name length.

## Validation

- All **8** VM equivalence tests pass (6 prior + 2 new a1).
- tsc + biome clean; merged with current `main` (incl. a2 #971).
- Net source diff: `bytecode-vm.ts` + the VM test only. No emitter (`bytecode-emitter.ts`) edits — `OP` / `BytecodeSink` consumed read-only.

Encoding stays STACK (reg+acc is the later coordinated slice-a bump). `closure.call` round-trip awaits a2 (struct.get) + a5 (ref.cast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)