### PR TITLE
feat(#1584) a2: struct/object VM dispatch (STRUCT_NEW/GET/SET) (#245)

### DIFF
--- a/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
+++ b/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
@@ -1,0 +1,66 @@
+---
+id: 1747
+title: "Array.prototype.pop() on an empty array traps instead of returning undefined (compiled WasmGC)"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen, arrays, standalone
+language_feature: array-pop, empty-array, undefined
+goal: standalone-correctness
+sprint: Backlog
+related: [1584, 1748]
+---
+# #1747 — `[].pop()` on an empty array traps instead of returning `undefined`
+
+## Problem
+
+When js2wasm compiles `Array.prototype.pop()` on an **empty** array, the
+generated WasmGC code traps (an array out-of-bounds access) instead of
+producing the JS-spec `undefined`. Per ECMA-262 §23.1.3.22, `pop()` on a
+length-0 array returns `undefined` and leaves length at 0 — it must not throw.
+
+This is a standalone-mode correctness bug independent of #1584; it was
+surfaced while building the #1584 bytecode VM (whose `runProgram` `RET` arm
+pops a frame stack that is empty on every program exit).
+
+## Repro
+
+```ts
+export function run(): number {
+  const a: number[] = [];
+  const x = a.pop(); // should be `undefined`; instead the module traps
+  if (x === undefined) return 1;
+  return -1;
+}
+```
+
+Compiling this with `compile()` and instantiating, then calling `run()`,
+throws a `WebAssembly.Exception` (an out-of-bounds trap) rather than returning
+`1`. Host JS / `tsx` returns `1`.
+
+## Expected
+
+`[].pop()` lowers to a guarded read: if `length === 0`, push the `undefined`
+representation (do not index `array[length-1]`); otherwise pop normally. The
+same guard applies to `shift()` on an empty array (likely the same defect —
+worth checking in the fix).
+
+## Workaround (in #1584)
+
+The #1584 VM avoids the trap by length-guarding before popping
+(`if (frames.length === 0) return result;` rather than relying on
+`frames.pop() === undefined`). That workaround is correct for the VM but the
+underlying `pop()` codegen should produce spec `undefined` so other compiled
+code doesn't hit the same trap.
+
+## Notes
+
+- Found via the slice-(b) "compile the dispatch loop itself" arm — the VM is
+  itself compiled by js2wasm, so its `[].pop()` usage exercised the real
+  codegen path.
+- See [[1748]] for a sibling codegen trap found in the same investigation
+  (`readonly` nested array field).

--- a/plan/issues/1748-readonly-nested-array-field-traps-on-indexed-read.md
+++ b/plan/issues/1748-readonly-nested-array-field-traps-on-indexed-read.md
@@ -1,0 +1,70 @@
+---
+id: 1748
+title: "readonly array as a nested struct field traps on indexed read (compiled WasmGC)"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen, structs, arrays, type-coercion
+language_feature: readonly-array, struct-field, indexed-read
+goal: standalone-correctness
+sprint: Backlog
+related: [1584, 1747]
+---
+# #1748 — `readonly` array as a nested struct field traps on indexed read
+
+## Problem
+
+When an interface/object field is typed `readonly T[]` (e.g.
+`readonly number[]`) and the object is itself an element of an array, reading
+an element of that nested field after indexing the outer array **traps** at
+runtime in the compiled WasmGC module. The identical code with a plain
+(non-`readonly`) `T[]` field compiles and runs correctly. The `readonly`
+modifier changes how the array field is lowered (apparently to an immutable
+WasmGC array variant) and the nested-field read mismatches, producing a trap.
+
+This is a standalone-mode correctness bug independent of #1584; it was
+surfaced while building the #1584 bytecode VM (whose function table is an
+array of structs with array-typed `code`/`constPool` fields).
+
+## Repro
+
+```ts
+interface FE { code: readonly number[]; arity: number; }      // TRAPS
+interface PG { functions: readonly FE[]; entry: number; }
+export function run(): number {
+  const program: PG = { functions: [{ code: [7, 2], arity: 1 }], entry: 0 };
+  const entryFn = program.functions[program.entry];
+  return entryFn.code[0]; // expected 7; the compiled module traps here
+}
+```
+
+Changing both field types to non-`readonly` (`code: number[]`,
+`functions: FE[]`) makes the identical logic return `7`. Bisected: the trap
+appears only with `readonly` on the **nested array field that is read after an
+index**; `readonly` on a top-level local array, or a scalar `readonly` field,
+does not trap.
+
+## Expected
+
+`readonly T[]` should lower identically to `T[]` for read access — `readonly`
+is a TypeScript-only compile-time modifier with no runtime representation
+difference. The fix is likely in the array-type lowering / struct-field type
+resolution: treat `readonly T[]` as `T[]` for the WasmGC array type (or emit
+the same `array.get` regardless of the `readonly` flag).
+
+## Workaround (in #1584)
+
+The #1584 VM drops `readonly` from `FuncEntry`/`Frame`/`Program` array fields
+(plain `number[]`), which lowers correctly. The VM never mutates them, so this
+is safe — but the codegen should handle `readonly` array fields so other
+compiled code isn't forced to drop the modifier.
+
+## Notes
+
+- Found via the slice-(b) "compile the dispatch loop itself" arm.
+- See [[1747]] for a sibling codegen trap found in the same investigation
+  (`[].pop()` on an empty array).

--- a/src/ir/backend/bytecode-vm.ts
+++ b/src/ir/backend/bytecode-vm.ts
@@ -78,6 +78,9 @@ const MAX_STEPS = 1000000;
 /** Sentinel f64 value for a null function reference (`CALL_REF` traps on it). */
 const NULL_FUNCREF = -1;
 
+/** Sentinel f64 value for a null struct reference (`STRUCT_GET`/`SET` trap). */
+const NULL_STRUCT = -1;
+
 /**
  * Run a whole {@link Program} — the multi-frame call-stack VM (#1584 a1).
  *
@@ -91,6 +94,19 @@ export function runProgram(program: Program, args: readonly number[]): number {
   // VM-global state (outlives any single frame): module globals
   // (GLOBAL_GET/SET), lazily 0-init on first access.
   const globals: number[] = [];
+
+  // VM-global heap (#1584 a2, STRUCT_NEW/GET/SET). A heap object is a record
+  // with a `fields` array; `heap[i]` is the object at heap index `i`. A struct
+  // reference is encoded as f64(heapIndex) on the stack/locals/fields domain
+  // (the cross-family invariant locked with the emitter: null-struct ≡ f64(-1)).
+  // The heap is VM-global, NOT per-frame — returned structs outlive the frame
+  // that created them. A struct field holding a funcref stores f64(tableIndex)
+  // (a1's funcref encoding), so STRUCT_GET of a closure's func field yields a
+  // value CALL_REF can dispatch (the closure.call bridge, once a5 ref.cast lands).
+  interface HeapObject {
+    fields: number[];
+  }
+  const heap: HeapObject[] = [];
 
   // The operand stack is shared across frames (Wasm-style: a callee pops its
   // args from / pushes its result onto the same value stack). Locals/pc/code/
@@ -304,6 +320,46 @@ export function runProgram(program: Program, args: readonly number[]): number {
         code = callee.code;
         constPool = callee.constPool;
         pc = 0;
+        break;
+      }
+      // ── #1584 a2 struct/object family (STRUCT_NEW / STRUCT_GET / STRUCT_SET) ──
+      // Heap objects live in the VM-global `heap`; a struct ref ≡ f64(heapIndex);
+      // null-struct ≡ f64(-1) (GET/SET on it traps). Field values are plain f64s
+      // (a funcref field stores f64(tableIndex) — the a1 bridge).
+      case OP.STRUCT_NEW: {
+        // STRUCT_NEW <fieldCount>: pop fieldCount values (field0 deepest, pushed
+        // in canonical field order), allocate a heap object, push its ref.
+        const fieldCount = code[pc++]!;
+        const fields: number[] = [];
+        for (let i = fieldCount - 1; i >= 0; i--) {
+          fields[i] = stack.pop()!;
+        }
+        heap.push({ fields });
+        stack.push(heap.length - 1); // f64(heapIndex)
+        break;
+      }
+      case OP.STRUCT_GET: {
+        // STRUCT_GET <fieldIdx>: pop structRef, push obj.fields[fieldIdx].
+        const fieldIdx = code[pc++]!;
+        const ref = stack.pop()!;
+        if (ref === NULL_STRUCT) {
+          throw new Error(`bytecode-vm: STRUCT_GET on null struct at pc ${pc - 2}`);
+        }
+        const obj = heap[ref | 0]!;
+        stack.push(obj.fields[fieldIdx]!);
+        break;
+      }
+      case OP.STRUCT_SET: {
+        // STRUCT_SET <fieldIdx>: stack [structRef, value] (value on top); pop
+        // value, pop structRef, obj.fields[fieldIdx] = value, push nothing.
+        const fieldIdx = code[pc++]!;
+        const value = stack.pop()!;
+        const ref = stack.pop()!;
+        if (ref === NULL_STRUCT) {
+          throw new Error(`bytecode-vm: STRUCT_SET on null struct at pc ${pc - 2}`);
+        }
+        const obj = heap[ref | 0]!;
+        obj.fields[fieldIdx] = value;
         break;
       }
       default:

--- a/tests/ir-bytecode-wasmgc-vm.test.ts
+++ b/tests/ir-bytecode-wasmgc-vm.test.ts
@@ -551,6 +551,112 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
     expect(() => runProgram(nullProgram, [1, 2]), "null funcref CALL_REF traps").toThrow(/null funcref/);
   });
 
+  // ── #1584 a2 struct/object family: STRUCT_NEW / STRUCT_GET / STRUCT_SET ──
+  // Heap objects (VM-global), struct ref ≡ f64(heapIndex), null ≡ f64(-1).
+  // mk(a,b){ const o = {x:a, y:b}; return o.x + o.y } proves host-VM ==
+  // Wasm-GC-VM == JS for new + read; a STRUCT_SET round-trip and a null-struct
+  // trap round out the family.
+  it("a2: STRUCT_NEW/GET — host-VM == WasmGC-VM == JS for mk(a,b)={x:a,y:b}; x+y", async () => {
+    // field0 = x, field1 = y (canonical order). Sequence:
+    //   LOAD 0(a); LOAD 1(b); STRUCT_NEW 2 -> ref      ; STORE 2 (o)
+    //   LOAD 2; STRUCT_GET 0 (o.x)
+    //   LOAD 2; STRUCT_GET 1 (o.y)
+    //   ADD; RET
+    const s = new BytecodeSink();
+    E.emitLocalGet(0, s); // a  (field0 = x)
+    E.emitLocalGet(1, s); // b  (field1 = y)
+    s.emit(OP.STRUCT_NEW, 2); // -> struct ref on stack
+    E.emitLocalSet(2, s); // o = ref (local 2)
+    E.emitLocalGet(2, s);
+    s.emit(OP.STRUCT_GET, 0); // o.x
+    E.emitLocalGet(2, s);
+    s.emit(OP.STRUCT_GET, 1); // o.y
+    E.emitBinary("f64.add", s);
+    E.emitReturn(s);
+    const js = (a: number, b: number): number => {
+      const o = { x: a, y: b };
+      return o.x + o.y;
+    };
+    const program: Program = {
+      functions: [
+        {
+          code: s.code.slice(),
+          constPool: s.constPool.slice(),
+          arity: 2,
+          nLocals: 3,
+        },
+      ],
+      entry: 0,
+    };
+    const vmMod = compileProgramModule(
+      ["a", "b"],
+      [{ code: s.code, constPool: s.constPool, arity: 2, nLocals: 3 }],
+      0,
+      ["a", "b", "0"], // args[0]=a, args[1]=b, args[2]=o (struct local, 0-init)
+    );
+    for (const [a, b] of [
+      [2, 3],
+      [-5, 10],
+      [0.5, 0.25],
+      [100, -100],
+    ]) {
+      const expected = js(a, b);
+      expect(runProgram(program, [a, b]), `host struct(${a},${b})`).toBe(expected);
+      expect(await runWasm(vmMod, "run", [a, b]), `wasm struct(${a},${b})`).toBe(expected);
+    }
+  });
+
+  it("a2: STRUCT_SET round-trip + null-struct (f64(-1)) traps", () => {
+    // set(a){ const o={x:0}; o.x = a*3; return o.x } → field0 = x.
+    //   CONST 0; STRUCT_NEW 1 -> ref; STORE 1 (o)
+    //   LOAD 1; LOAD 0; CONST 3; MUL; STRUCT_SET 0   (o.x = a*3; stack [ref,val])
+    //   LOAD 1; STRUCT_GET 0; RET
+    const s = new BytecodeSink();
+    emitNumberConst(0, s); // initial x = 0
+    s.emit(OP.STRUCT_NEW, 1);
+    E.emitLocalSet(1, s); // o (local 1)
+    E.emitLocalGet(1, s); // ref (deeper)
+    E.emitLocalGet(0, s); // a
+    emitNumberConst(3, s);
+    E.emitBinary("f64.mul", s); // a*3 (value on top)
+    s.emit(OP.STRUCT_SET, 0); // o.x = a*3
+    E.emitLocalGet(1, s);
+    s.emit(OP.STRUCT_GET, 0); // o.x
+    E.emitReturn(s);
+    const program: Program = {
+      functions: [
+        {
+          code: s.code.slice(),
+          constPool: s.constPool.slice(),
+          arity: 1,
+          nLocals: 2,
+        },
+      ],
+      entry: 0,
+    };
+    for (const a of [3, -4, 0, 1.5]) {
+      expect(runProgram(program, [a]), `host struct-set(${a})`).toBe(a * 3);
+    }
+
+    // null-struct: push f64(-1) then STRUCT_GET → must trap.
+    const nullGet = new BytecodeSink();
+    emitNumberConst(-1, nullGet); // null struct ref
+    nullGet.emit(OP.STRUCT_GET, 0);
+    E.emitReturn(nullGet);
+    const nullProgram: Program = {
+      functions: [
+        {
+          code: nullGet.code.slice(),
+          constPool: nullGet.constPool.slice(),
+          arity: 0,
+          nLocals: 0,
+        },
+      ],
+      entry: 0,
+    };
+    expect(() => runProgram(nullProgram, []), "null struct STRUCT_GET traps").toThrow(/null struct/);
+  });
+
   // ── Sanity: the host VM still rejects malformed; the emitter rejects ops ──
   // outside the #1584 production subset. (The subset has grown with #958:
   // f64.div / f64.ne are now IN-subset, so the out-of-subset probe uses ops the


### PR DESCRIPTION
## What

Wires the **a2 struct/object family** (`OP.STRUCT_NEW=25` / `STRUCT_GET=26` / `STRUCT_SET=27`, landed by the emitter in #971) into the Wasm-GC VM dispatch loop. VM-side counterpart of #249; task #245.

## VM changes (`src/ir/backend/bytecode-vm.ts`)

- New VM-global **`heap: { fields: number[] }[]`** (alongside `globals[]`). Heap objects outlive the frame that created them (returned structs), so the heap is VM-global, not per-frame.
- **Struct ref ≡ f64(heapIndex)**, **null-struct ≡ f64(-1)** (GET/SET on it traps) — the cross-family invariant locked with the emitter. A struct field holding a funcref stores `f64(tableIndex)` (a1's encoding), so `STRUCT_GET` of a closure's func field yields a value `CALL_REF` can dispatch — the `closure.call` bridge, realized once a5 ref.cast lands.
- `STRUCT_NEW <fieldCount>`: pop `fieldCount` values (field0 deepest), alloc heap object, push `f64(heapIndex)`. `STRUCT_GET <fieldIdx>`: pop ref, push `fields[fieldIdx]`. `STRUCT_SET <fieldIdx>`: stack `[ref, value]`, mutate field.

## Tests (`tests/ir-bytecode-wasmgc-vm.test.ts`)

- **a2 STRUCT_NEW/GET** — host-VM == Wasm-GC-VM == JS for `mk(a,b){const o={x:a,y:b};return o.x+o.y}` (heap alloc + field read through the compiled VM).
- **a2 STRUCT_SET round-trip** + null-struct `f64(-1)` STRUCT_GET traps.

## Also: two standalone codegen bugs filed

Per tech-lead request, files two codegen gaps found while building the #1584 VM (independent of #1584):
- **#1747** — `[].pop()` on an empty array traps instead of returning `undefined`.
- **#1748** — a `readonly` array nested as a struct field traps on indexed read.

## Validation

- All **10** VM equivalence tests pass (8 prior + 2 new a2).
- tsc + biome clean; fresh off `main` (a1 #970 + a2 #971 in).
- Net source diff: `bytecode-vm.ts` + the VM test (+ the two issue files). No emitter edits — `OP` / `BytecodeSink` consumed read-only.

JNZ=28 (a3's one VM op) lands separately once the a3 emitter is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)