### PR TITLE
feat(#1584) a3: control-flow family (block/loop/br/br_if) behind BackendEmitter trait

### DIFF
--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -108,6 +108,12 @@ export const OP = {
   STRUCT_NEW: 25, // STRUCT_NEW <fieldCount> ; pop fieldCount vals (field0 deepest), alloc heap obj, push ref
   STRUCT_GET: 26, // STRUCT_GET <fieldIdx>   ; pop structRef, push obj.fields[fieldIdx]
   STRUCT_SET: 27, // STRUCT_SET <fieldIdx>   ; pop value, pop structRef, obj.fields[fieldIdx]=value
+  // ── (a3) control-flow family (#1584 §2a) — the structured `block`/`loop`/`br`/
+  // `br_if` family lowers AWAY in the emitter to JZ/JNZ/JMP + backpatch labels
+  // (issue §1c/§2a). The only new VM opcode is JNZ — the exact dual of JZ — so
+  // `br_if`'s "branch if truthy" needs no `eqz`+`JZ` dance. block/loop add NO
+  // opcode (they resolve to backpatched JMP/JNZ/JZ targets at splice time).
+  JNZ: 28, //   JNZ <target>         ; pop c; if c != 0 goto target  (maps from emitBrIf / br_if)
 } as const;
 
 export type Opcode = (typeof OP)[keyof typeof OP];
@@ -121,6 +127,17 @@ export type Opcode = (typeof OP)[keyof typeof OP];
 export class BytecodeSink {
   readonly code: number[] = [];
   readonly constPool: number[] = [];
+
+  /**
+   * (a3 #1584) Structured-branch backpatch list. A `br` / `br_if` (`emitBr` /
+   * `emitBrIf`) emits a `JMP` / `JNZ` placeholder whose target is the construct
+   * `depth` levels out (De Bruijn) — UNKNOWN until the enclosing `block`/`loop`
+   * splices this sink. Each entry pins the operand slot + its outward depth.
+   * `emitBlock`/`emitLoop` resolve depth-0 entries (this construct) and carry
+   * deeper ones outward (depth-1). A sink with a non-empty list at function exit
+   * is an internal error (a `br` with no enclosing construct).
+   */
+  readonly pendingBranches: { slot: number; depth: number }[] = [];
 
   /** Intern an f64 immediate into the constant pool, returning its index. */
   internConst(value: number): number {
@@ -145,7 +162,9 @@ export class BytecodeSink {
    * Emit a jump whose target is not yet known; returns the code index of the
    * *operand slot* to backpatch once the target is known.
    */
-  emitJumpPlaceholder(op: typeof OP.JZ | typeof OP.JMP): number {
+  emitJumpPlaceholder(
+    op: typeof OP.JZ | typeof OP.JMP | typeof OP.JNZ,
+  ): number {
     this.code.push(op, -1); // -1 = unpatched
     return this.code.length - 1; // index of the operand slot
   }
@@ -156,33 +175,67 @@ export class BytecodeSink {
   }
 
   /**
+   * (a3 #1584) Record a structured branch (`br`/`br_if`) whose target is the
+   * construct `depth` levels out. The placeholder jump was just emitted; `slot`
+   * is its operand index. Resolved by the enclosing `emitBlock`/`emitLoop`.
+   */
+  recordPendingBranch(slot: number, depth: number): void {
+    this.pendingBranches.push({ slot, depth });
+  }
+
+  /**
    * #1584: append another sink's code at the current position, relocating its
    * internal jump targets into this sink's address space and remapping its
    * const-pool indices into this sink's pool. Used by the production
    * `BytecodeEmitter.emitIf` to splice already-lowered `if`-arm buffers (the
    * real `lower.ts` builds each arm into its own sink, exactly as it builds the
-   * WasmGC `if`'s `then`/`else` as separate `Instr[]`). Arms must be
-   * self-contained — an unpatched jump in a spliced arm is an internal error.
+   * WasmGC `if`'s `then`/`else` as separate `Instr[]`).
+   *
+   * (a3) An arm may carry UNPATCHED structured branches (`br`/`br_if` in
+   * `pendingBranches`) bound for an enclosing `block`/`loop`. Those slots
+   * relocate by `+base` and their depth-tagged entries migrate onto THIS sink's
+   * `pendingBranches` so the enclosing construct can resolve them. A leftover
+   * unpatched jump that is NOT a recorded structured branch is still an internal
+   * error (a forward `if`/`block` exit the owner forgot to patch).
    */
   spliceArm(arm: BytecodeSink): void {
     const base = this.code.length;
     const code = arm.code;
+    // Operand-slot → outward-depth for the arm's structured branches, so we can
+    // recognise an unpatched jump as a legitimate pending branch (vs an error).
+    const armPending = new Map<number, number>();
+    for (const pb of arm.pendingBranches) armPending.set(pb.slot, pb.depth);
     let i = 0;
     while (i < code.length) {
       const op = code[i++] as Opcode;
       switch (op) {
         case OP.CONST: {
           const localPoolIdx = code[i++]!;
-          this.code.push(OP.CONST, this.internConst(arm.constPool[localPoolIdx]!));
+          this.code.push(
+            OP.CONST,
+            this.internConst(arm.constPool[localPoolIdx]!),
+          );
           break;
         }
         case OP.JZ:
-        case OP.JMP: {
+        case OP.JMP:
+        case OP.JNZ: {
+          const slot = i; // operand index in the arm's code
           const target = code[i++]!;
+          const relocSlot = this.code.length + 1; // operand index after we push `op`
           if (target < 0) {
-            throw new Error("BytecodeSink.spliceArm: arm contains an unpatched jump (internal error)");
+            const depth = armPending.get(slot);
+            if (depth === undefined) {
+              throw new Error(
+                "BytecodeSink.spliceArm: arm contains an unpatched jump (internal error)",
+              );
+            }
+            // Carry the structured branch outward, relocated into this sink.
+            this.code.push(op, -1);
+            this.pendingBranches.push({ slot: relocSlot, depth });
+          } else {
+            this.code.push(op, target + base);
           }
-          this.code.push(op, target + base);
           break;
         }
         // Single-inline-operand opcodes (a local / global / const / func /
@@ -259,7 +312,8 @@ function binopToOpcode(op: IrBinop): Opcode {
 function unopToOpcode(op: IrUnop): Opcode {
   if (op === "f64.neg") return OP.NEG;
   throw new Error(
-    `BytecodeEmitter: unary '${op}' not in the #1584 production subset (f64.neg). ` + `See plan/issues/1584 §2a.`,
+    `BytecodeEmitter: unary '${op}' not in the #1584 production subset (f64.neg). ` +
+      `See plan/issues/1584 §2a.`,
   );
 }
 
@@ -299,7 +353,11 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     );
   }
 
-  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: BytecodeSink): void {
+  emitConst(
+    instr: Extract<IrInstr, { kind: "const" }>,
+    funcName: string,
+    out: BytecodeSink,
+  ): void {
     const v = instr.value;
     switch (v.kind) {
       case "i32":
@@ -313,7 +371,9 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
       case "i64":
       case "null":
       case "undefined":
-        throw new Error(`BytecodeEmitter: const '${v.kind}' not in the #1584 numeric subset (${funcName})`);
+        throw new Error(
+          `BytecodeEmitter: const '${v.kind}' not in the #1584 numeric subset (${funcName})`,
+        );
     }
   }
 
@@ -379,7 +439,12 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
    * `blockType` is ignored (the bytecode VM is untyped over boxed values); it is
    * part of the trait signature for the WasmGC realization.
    */
-  emitIf(_blockType: BlockType, then: BytecodeSink, els: BytecodeSink, out: BytecodeSink): void {
+  emitIf(
+    _blockType: BlockType,
+    then: BytecodeSink,
+    els: BytecodeSink,
+    out: BytecodeSink,
+  ): void {
     const toElse = out.emitJumpPlaceholder(OP.JZ);
     out.spliceArm(then);
     const toEnd = out.emitJumpPlaceholder(OP.JMP);
@@ -388,14 +453,78 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     out.patch(toEnd, out.here());
   }
 
-  emitBr(_depth: number, _out: BytecodeSink): void {
-    throw new Error("BytecodeEmitter: emitBr (multi-block CFG) not in the #1584 subset — see §2a control-flow family.");
+  // ---- (a3) control-flow family (#1584 §2a) — `block`/`loop`/`br`/`br_if`
+  // lower AWAY to JZ/JNZ/JMP + backpatch labels. The VM gains exactly one
+  // opcode (JNZ); block/loop add none (issue §1c/§2a). Targets are intra-
+  // function absolute code indices in the SAME address space `emitIf` uses.
+
+  // `br depth` — unconditional branch to the construct `depth` levels out. We
+  // emit a JMP placeholder and record it as a pending structured branch; the
+  // enclosing `emitLoop` (depth→header) / `emitBlock` (depth→exit) patches it.
+  emitBr(depth: number, out: BytecodeSink): void {
+    const slot = out.emitJumpPlaceholder(OP.JMP);
+    out.recordPendingBranch(slot, depth);
   }
 
-  emitBrIf(_depth: number, _out: BytecodeSink): void {
-    throw new Error(
-      "BytecodeEmitter: emitBrIf (multi-block CFG) not in the #1584 subset — see §2a control-flow family.",
-    );
+  // `br_if depth` — branch to the construct `depth` levels out IF the popped
+  // condition is truthy. JNZ is the dual of JZ, so `br_if` needs no `eqz`. The
+  // placeholder is recorded as a pending structured branch (same as `br`).
+  emitBrIf(depth: number, out: BytecodeSink): void {
+    const slot = out.emitJumpPlaceholder(OP.JNZ);
+    out.recordPendingBranch(slot, depth);
+  }
+
+  /**
+   * Structured `block`. Splices the pre-lowered `body` sink at the current
+   * position, then resolves the body's pending structured branches: a branch
+   * with `depth === 0` targets THIS block, so it jumps to the block's EXIT (the
+   * code position just past the spliced body); deeper branches belong to an
+   * outer construct and migrate outward with `depth - 1`. `blockType` is ignored
+   * (the VM is untyped over boxed values) — it is part of the trait signature
+   * for the WasmGC realization.
+   */
+  emitBlock(
+    _blockType: BlockType,
+    body: BytecodeSink,
+    out: BytecodeSink,
+  ): void {
+    const firstNew = out.pendingBranches.length;
+    out.spliceArm(body);
+    this.resolveSplicedBranches(out, firstNew, out.here());
+  }
+
+  /**
+   * Structured `loop`. Like `emitBlock`, but a `depth === 0` branch targets the
+   * loop HEADER (the code position where the body begins) — `br 0` is "continue"
+   * — so the back-edge target is captured BEFORE the splice.
+   */
+  emitLoop(_blockType: BlockType, body: BytecodeSink, out: BytecodeSink): void {
+    const header = out.here();
+    const firstNew = out.pendingBranches.length;
+    out.spliceArm(body);
+    this.resolveSplicedBranches(out, firstNew, header);
+  }
+
+  /**
+   * Resolve the structured branches `spliceArm` just migrated onto `out`
+   * (`out.pendingBranches[firstNew..]`): patch each `depth === 0` branch to
+   * `selfTarget` (block exit / loop header) and drop it; decrement the depth of
+   * each deeper branch so the next-outer construct resolves it. Entries added
+   * before `firstNew` (already-pending outer branches) are untouched.
+   */
+  private resolveSplicedBranches(
+    out: BytecodeSink,
+    firstNew: number,
+    selfTarget: number,
+  ): void {
+    const migrated = out.pendingBranches.splice(firstNew);
+    for (const pb of migrated) {
+      if (pb.depth === 0) {
+        out.patch(pb.slot, selfTarget);
+      } else {
+        out.pendingBranches.push({ slot: pb.slot, depth: pb.depth - 1 });
+      }
+    }
   }
 
   // ---- (a1) call family (#1584 §2a) — the first migrated family -----------
@@ -419,26 +548,44 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
   // STRUCT_NEW carries the field COUNT (the untyped VM needs no typeIdx, only
   // how many to pop); STRUCT_GET/SET carry the numeric field INDEX (lower.ts
   // resolves name→fieldIdx via the layout, so the VM gets the index directly).
-  emitAggregateNew(_layout: IrObjectStructLowering, fieldCount: number, out: BytecodeSink): void {
+  emitAggregateNew(
+    _layout: IrObjectStructLowering,
+    fieldCount: number,
+    out: BytecodeSink,
+  ): void {
     out.emit(OP.STRUCT_NEW, fieldCount);
   }
 
-  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
+  emitFieldGet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: BytecodeSink,
+  ): void {
     out.emit(OP.STRUCT_GET, layout.fieldIdx(name));
   }
 
-  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
+  emitFieldSet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: BytecodeSink,
+  ): void {
     out.emit(OP.STRUCT_SET, layout.fieldIdx(name));
   }
 
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------
   emitVecLen(): void {
-    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
+    throw new Error(
+      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
+    );
   }
   emitVecDataPtr(): void {
-    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
+    throw new Error(
+      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
+    );
   }
   emitElemGet(): void {
-    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
+    throw new Error(
+      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
+    );
   }
 }

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -162,9 +162,7 @@ export class BytecodeSink {
    * Emit a jump whose target is not yet known; returns the code index of the
    * *operand slot* to backpatch once the target is known.
    */
-  emitJumpPlaceholder(
-    op: typeof OP.JZ | typeof OP.JMP | typeof OP.JNZ,
-  ): number {
+  emitJumpPlaceholder(op: typeof OP.JZ | typeof OP.JMP | typeof OP.JNZ): number {
     this.code.push(op, -1); // -1 = unpatched
     return this.code.length - 1; // index of the operand slot
   }
@@ -211,10 +209,7 @@ export class BytecodeSink {
       switch (op) {
         case OP.CONST: {
           const localPoolIdx = code[i++]!;
-          this.code.push(
-            OP.CONST,
-            this.internConst(arm.constPool[localPoolIdx]!),
-          );
+          this.code.push(OP.CONST, this.internConst(arm.constPool[localPoolIdx]!));
           break;
         }
         case OP.JZ:
@@ -226,9 +221,7 @@ export class BytecodeSink {
           if (target < 0) {
             const depth = armPending.get(slot);
             if (depth === undefined) {
-              throw new Error(
-                "BytecodeSink.spliceArm: arm contains an unpatched jump (internal error)",
-              );
+              throw new Error("BytecodeSink.spliceArm: arm contains an unpatched jump (internal error)");
             }
             // Carry the structured branch outward, relocated into this sink.
             this.code.push(op, -1);
@@ -312,8 +305,7 @@ function binopToOpcode(op: IrBinop): Opcode {
 function unopToOpcode(op: IrUnop): Opcode {
   if (op === "f64.neg") return OP.NEG;
   throw new Error(
-    `BytecodeEmitter: unary '${op}' not in the #1584 production subset (f64.neg). ` +
-      `See plan/issues/1584 §2a.`,
+    `BytecodeEmitter: unary '${op}' not in the #1584 production subset (f64.neg). ` + `See plan/issues/1584 §2a.`,
   );
 }
 
@@ -353,11 +345,7 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     );
   }
 
-  emitConst(
-    instr: Extract<IrInstr, { kind: "const" }>,
-    funcName: string,
-    out: BytecodeSink,
-  ): void {
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: BytecodeSink): void {
     const v = instr.value;
     switch (v.kind) {
       case "i32":
@@ -371,9 +359,7 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
       case "i64":
       case "null":
       case "undefined":
-        throw new Error(
-          `BytecodeEmitter: const '${v.kind}' not in the #1584 numeric subset (${funcName})`,
-        );
+        throw new Error(`BytecodeEmitter: const '${v.kind}' not in the #1584 numeric subset (${funcName})`);
     }
   }
 
@@ -439,12 +425,7 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
    * `blockType` is ignored (the bytecode VM is untyped over boxed values); it is
    * part of the trait signature for the WasmGC realization.
    */
-  emitIf(
-    _blockType: BlockType,
-    then: BytecodeSink,
-    els: BytecodeSink,
-    out: BytecodeSink,
-  ): void {
+  emitIf(_blockType: BlockType, then: BytecodeSink, els: BytecodeSink, out: BytecodeSink): void {
     const toElse = out.emitJumpPlaceholder(OP.JZ);
     out.spliceArm(then);
     const toEnd = out.emitJumpPlaceholder(OP.JMP);
@@ -483,11 +464,7 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
    * (the VM is untyped over boxed values) — it is part of the trait signature
    * for the WasmGC realization.
    */
-  emitBlock(
-    _blockType: BlockType,
-    body: BytecodeSink,
-    out: BytecodeSink,
-  ): void {
+  emitBlock(_blockType: BlockType, body: BytecodeSink, out: BytecodeSink): void {
     const firstNew = out.pendingBranches.length;
     out.spliceArm(body);
     this.resolveSplicedBranches(out, firstNew, out.here());
@@ -512,11 +489,7 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
    * each deeper branch so the next-outer construct resolves it. Entries added
    * before `firstNew` (already-pending outer branches) are untouched.
    */
-  private resolveSplicedBranches(
-    out: BytecodeSink,
-    firstNew: number,
-    selfTarget: number,
-  ): void {
+  private resolveSplicedBranches(out: BytecodeSink, firstNew: number, selfTarget: number): void {
     const migrated = out.pendingBranches.splice(firstNew);
     for (const pb of migrated) {
       if (pb.depth === 0) {
@@ -548,44 +521,26 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
   // STRUCT_NEW carries the field COUNT (the untyped VM needs no typeIdx, only
   // how many to pop); STRUCT_GET/SET carry the numeric field INDEX (lower.ts
   // resolves name→fieldIdx via the layout, so the VM gets the index directly).
-  emitAggregateNew(
-    _layout: IrObjectStructLowering,
-    fieldCount: number,
-    out: BytecodeSink,
-  ): void {
+  emitAggregateNew(_layout: IrObjectStructLowering, fieldCount: number, out: BytecodeSink): void {
     out.emit(OP.STRUCT_NEW, fieldCount);
   }
 
-  emitFieldGet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: BytecodeSink,
-  ): void {
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
     out.emit(OP.STRUCT_GET, layout.fieldIdx(name));
   }
 
-  emitFieldSet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: BytecodeSink,
-  ): void {
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: BytecodeSink): void {
     out.emit(OP.STRUCT_SET, layout.fieldIdx(name));
   }
 
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------
   emitVecLen(): void {
-    throw new Error(
-      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
-    );
+    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
   emitVecDataPtr(): void {
-    throw new Error(
-      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
-    );
+    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
   emitElemGet(): void {
-    throw new Error(
-      "BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.",
-    );
+    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
 }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -103,11 +103,7 @@ export interface BackendEmitter<S = Instr[]> {
 
   // ---- scalars / locals / globals / control flow (Phase-1 stage 1) ----
   /** Emit a `const` IR instr's literal op(s). Delegates to the shared free fn. */
-  emitConst(
-    instr: Extract<IrInstr, { kind: "const" }>,
-    funcName: string,
-    out: S,
-  ): void;
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: S): void;
   /** Pass-through binary op (`f64.add`, `i32.eq`, `i32.and`, ...). Bitwise
    * `js.*` ops are lowered earlier in lower.ts and never reach here. */
   emitBinary(op: IrBinop, out: S): void;
@@ -156,11 +152,7 @@ export interface BackendEmitter<S = Instr[]> {
   emitToExternref?(out: Instr[]): void;
   emitFromExternref?(layout: { typeIdx: number } | IrType, out: Instr[]): void;
   emitFuncRef?(funcIdx: number, out: Instr[]): void;
-  emitClosureNew?(
-    layout: IrClosureLowering,
-    captureCount: number,
-    out: Instr[],
-  ): void;
+  emitClosureNew?(layout: IrClosureLowering, captureCount: number, out: Instr[]): void;
   emitClosureFuncGet?(layout: IrClosureLowering, out: Instr[]): void;
   emitCaptureGet?(layout: IrClosureLowering, index: number, out: Instr[]): void;
   emitRefCellNew?(layout: IrRefCellLowering, out: Instr[]): void;
@@ -184,21 +176,9 @@ export interface BackendEmitter<S = Instr[]> {
   // `STRUCT_SET` over a VM heap (struct ref ≡ f64(heapIndex), null ≡ f64(-1)).
   /** Allocate an aggregate from `fieldCount` values already on the stack
    * (canonical field order, field0 deepest); leaves the new struct ref. */
-  emitAggregateNew(
-    layout: IrObjectStructLowering,
-    fieldCount: number,
-    out: S,
-  ): void;
+  emitAggregateNew(layout: IrObjectStructLowering, fieldCount: number, out: S): void;
   /** struct ref on stack -> the named field's value. */
-  emitFieldGet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: S,
-  ): void;
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
   /** struct ref + value on stack -> writes the named field (void). */
-  emitFieldSet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: S,
-  ): void;
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
 }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -103,7 +103,11 @@ export interface BackendEmitter<S = Instr[]> {
 
   // ---- scalars / locals / globals / control flow (Phase-1 stage 1) ----
   /** Emit a `const` IR instr's literal op(s). Delegates to the shared free fn. */
-  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: S): void;
+  emitConst(
+    instr: Extract<IrInstr, { kind: "const" }>,
+    funcName: string,
+    out: S,
+  ): void;
   /** Pass-through binary op (`f64.add`, `i32.eq`, `i32.and`, ...). Bitwise
    * `js.*` ops are lowered earlier in lower.ts and never reach here. */
   emitBinary(op: IrBinop, out: S): void;
@@ -123,6 +127,21 @@ export interface BackendEmitter<S = Instr[]> {
   emitBr(depth: number, out: S): void;
   emitBrIf(depth: number, out: S): void;
 
+  // ---- (a3) control-flow family — MIGRATED behind the trait (#1584 §2a) ----
+  // The structured `block` / `loop` wrappers. The caller (real `lower.ts`)
+  // pre-lowers the wrapped region into its own sink (via `newSink()`), embedding
+  // any `br` / `br_if` whose `depth` counts block/loop nesting outward (De Bruijn).
+  // WasmGc realizes them as byte-identical `{op:"block",body}` / `{op:"loop",body}`
+  // — the WasmGC `Instr` stream is unchanged. Bytecode realizes them by splicing
+  // `body` and resolving its pending `br`/`br_if` jumps to `JZ`/`JNZ`/`JMP` with
+  // backpatched targets (block ⇒ forward exit label, loop ⇒ backward header
+  // label), exactly as `emitIf` already lowers structured `if` (issue §1c/§2a:
+  // "loop / block / br_if … lowered to JZ/JNZ/JMP + backpatch labels").
+  /** Wrap `body` in a structured block; `body` was built via `newSink()`. */
+  emitBlock(blockType: BlockType, body: S, out: S): void;
+  /** Wrap `body` in a structured loop; `body` was built via `newSink()`. */
+  emitLoop(blockType: BlockType, body: S, out: S): void;
+
   // ---- NOT YET MOVED (declared for #1714+ staging; see issue Scope) ----
   // The following are part of the full seam the spec audited but are NOT
   // routed through the trait in Phase 1 (#1713). They remain inline in
@@ -137,7 +156,11 @@ export interface BackendEmitter<S = Instr[]> {
   emitToExternref?(out: Instr[]): void;
   emitFromExternref?(layout: { typeIdx: number } | IrType, out: Instr[]): void;
   emitFuncRef?(funcIdx: number, out: Instr[]): void;
-  emitClosureNew?(layout: IrClosureLowering, captureCount: number, out: Instr[]): void;
+  emitClosureNew?(
+    layout: IrClosureLowering,
+    captureCount: number,
+    out: Instr[],
+  ): void;
   emitClosureFuncGet?(layout: IrClosureLowering, out: Instr[]): void;
   emitCaptureGet?(layout: IrClosureLowering, index: number, out: Instr[]): void;
   emitRefCellNew?(layout: IrRefCellLowering, out: Instr[]): void;
@@ -161,9 +184,21 @@ export interface BackendEmitter<S = Instr[]> {
   // `STRUCT_SET` over a VM heap (struct ref ≡ f64(heapIndex), null ≡ f64(-1)).
   /** Allocate an aggregate from `fieldCount` values already on the stack
    * (canonical field order, field0 deepest); leaves the new struct ref. */
-  emitAggregateNew(layout: IrObjectStructLowering, fieldCount: number, out: S): void;
+  emitAggregateNew(
+    layout: IrObjectStructLowering,
+    fieldCount: number,
+    out: S,
+  ): void;
   /** struct ref on stack -> the named field's value. */
-  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
+  emitFieldGet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: S,
+  ): void;
   /** struct ref + value on stack -> writes the named field (void). */
-  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
+  emitFieldSet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: S,
+  ): void;
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -166,6 +166,13 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   emitBrIf(): void {
     notImplemented("emitBrIf");
   }
+  // (a3) control-flow family (#1584 §2a) — out of the #1714 vec-proof scope.
+  emitBlock(): void {
+    notImplemented("emitBlock");
+  }
+  emitLoop(): void {
+    notImplemented("emitLoop");
+  }
   // (a2) struct/object family (#1584 §2a) — out of the #1714 vec-proof scope.
   emitAggregateNew(): void {
     notImplemented("emitAggregateNew");

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -19,11 +19,7 @@ import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
-import type {
-  IrClassLowering,
-  IrObjectStructLowering,
-  IrVecLowering,
-} from "./handles.js";
+import type { IrClassLowering, IrObjectStructLowering, IrVecLowering } from "./handles.js";
 
 export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // #1584: sink = Instr[]. The factory returns a plain array and the raw escape
@@ -60,11 +56,7 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 
   // ---- scalars / locals / globals / control flow ----------------------
 
-  emitConst(
-    instr: Extract<IrInstr, { kind: "const" }>,
-    funcName: string,
-    out: Instr[],
-  ): void {
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: Instr[]): void {
     // Delegate to the shared free function (unchanged) so the const-lowering
     // logic stays in one place. The arg order is the free fn's
     // `(instr, out, funcName)` -- the trait method's order is
@@ -121,12 +113,7 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "unreachable" });
   }
 
-  emitIf(
-    blockType: BlockType,
-    then: Instr[],
-    els: Instr[],
-    out: Instr[],
-  ): void {
+  emitIf(blockType: BlockType, then: Instr[], els: Instr[], out: Instr[]): void {
     out.push({ op: "if", blockType, then, else: els });
   }
 
@@ -168,19 +155,11 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // object.new/get/set arms of lower.ts. The WasmGC stream is unchanged; this
   // moves the push behind the trait so the bytecode backend realizes the same
   // intent as OP.STRUCT_NEW / STRUCT_GET / STRUCT_SET over a VM heap.
-  emitAggregateNew(
-    layout: IrObjectStructLowering,
-    _fieldCount: number,
-    out: Instr[],
-  ): void {
+  emitAggregateNew(layout: IrObjectStructLowering, _fieldCount: number, out: Instr[]): void {
     out.push({ op: "struct.new", typeIdx: layout.typeIdx });
   }
 
-  emitFieldGet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: Instr[],
-  ): void {
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
     out.push({
       op: "struct.get",
       typeIdx: structTypeIdxOf(layout),
@@ -188,11 +167,7 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     });
   }
 
-  emitFieldSet(
-    layout: IrObjectStructLowering | IrClassLowering,
-    name: string,
-    out: Instr[],
-  ): void {
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
     out.push({
       op: "struct.set",
       typeIdx: structTypeIdxOf(layout),
@@ -202,8 +177,6 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 }
 
 /** The WasmGC struct typeIdx for an object (`typeIdx`) or class (`structTypeIdx`). */
-function structTypeIdxOf(
-  layout: IrObjectStructLowering | IrClassLowering,
-): number {
+function structTypeIdxOf(layout: IrObjectStructLowering | IrClassLowering): number {
   return "typeIdx" in layout ? layout.typeIdx : layout.structTypeIdx;
 }

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -19,7 +19,11 @@ import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
-import type { IrClassLowering, IrObjectStructLowering, IrVecLowering } from "./handles.js";
+import type {
+  IrClassLowering,
+  IrObjectStructLowering,
+  IrVecLowering,
+} from "./handles.js";
 
 export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // #1584: sink = Instr[]. The factory returns a plain array and the raw escape
@@ -56,7 +60,11 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 
   // ---- scalars / locals / globals / control flow ----------------------
 
-  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: Instr[]): void {
+  emitConst(
+    instr: Extract<IrInstr, { kind: "const" }>,
+    funcName: string,
+    out: Instr[],
+  ): void {
     // Delegate to the shared free function (unchanged) so the const-lowering
     // logic stays in one place. The arg order is the free fn's
     // `(instr, out, funcName)` -- the trait method's order is
@@ -113,7 +121,12 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "unreachable" });
   }
 
-  emitIf(blockType: BlockType, then: Instr[], els: Instr[], out: Instr[]): void {
+  emitIf(
+    blockType: BlockType,
+    then: Instr[],
+    els: Instr[],
+    out: Instr[],
+  ): void {
     out.push({ op: "if", blockType, then, else: els });
   }
 
@@ -123,6 +136,19 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 
   emitBrIf(depth: number, out: Instr[]): void {
     out.push({ op: "br_if", depth });
+  }
+
+  // ---- (a3) control-flow family (#1584 §2a) — byte-identical to the prior
+  // inline `out.push({op:"block"...})` / `{op:"loop"...}` in lower.ts's fenced
+  // loop arms. The WasmGC stream is unchanged; this only moves the push behind
+  // the trait so the bytecode backend can realize the same intent as
+  // JZ/JNZ/JMP + backpatch labels.
+  emitBlock(blockType: BlockType, body: Instr[], out: Instr[]): void {
+    out.push({ op: "block", blockType, body });
+  }
+
+  emitLoop(blockType: BlockType, body: Instr[], out: Instr[]): void {
+    out.push({ op: "loop", blockType, body });
   }
 
   // ---- (a1) call family (#1584 §2a) — byte-identical to the prior inline
@@ -142,11 +168,19 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   // object.new/get/set arms of lower.ts. The WasmGC stream is unchanged; this
   // moves the push behind the trait so the bytecode backend realizes the same
   // intent as OP.STRUCT_NEW / STRUCT_GET / STRUCT_SET over a VM heap.
-  emitAggregateNew(layout: IrObjectStructLowering, _fieldCount: number, out: Instr[]): void {
+  emitAggregateNew(
+    layout: IrObjectStructLowering,
+    _fieldCount: number,
+    out: Instr[],
+  ): void {
     out.push({ op: "struct.new", typeIdx: layout.typeIdx });
   }
 
-  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+  emitFieldGet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: Instr[],
+  ): void {
     out.push({
       op: "struct.get",
       typeIdx: structTypeIdxOf(layout),
@@ -154,7 +188,11 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     });
   }
 
-  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+  emitFieldSet(
+    layout: IrObjectStructLowering | IrClassLowering,
+    name: string,
+    out: Instr[],
+  ): void {
     out.push({
       op: "struct.set",
       typeIdx: structTypeIdxOf(layout),
@@ -164,6 +202,8 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 }
 
 /** The WasmGC struct typeIdx for an object (`typeIdx`) or class (`structTypeIdx`). */
-function structTypeIdxOf(layout: IrObjectStructLowering | IrClassLowering): number {
+function structTypeIdxOf(
+  layout: IrObjectStructLowering | IrClassLowering,
+): number {
   return "typeIdx" in layout ? layout.typeIdx : layout.structTypeIdx;
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1407,7 +1407,8 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.lengthSlot),
         });
         loopBody.push({ op: "i32.ge_s" });
-        loopBody.push({ op: "br_if", depth: 1 });
+        // #1584 (a3): control-flow ops route through the trait.
+        emitter.emitBrIf(1, loopBody as unknown as S);
 
         // element = data[counter]
         loopBody.push({ op: "local.get", index: slotWasmIdx(instr.dataSlot) });
@@ -1451,20 +1452,12 @@ export function lowerIrFunctionBody<S>(
         });
 
         // br 0 (continue)
-        loopBody.push({ op: "br", depth: 0 });
+        emitter.emitBr(0, loopBody as unknown as S);
 
-        // Wrap in block { loop { ... } }
-        wasmOut.push({
-          op: "block",
-          blockType: { kind: "empty" },
-          body: [
-            {
-              op: "loop",
-              blockType: { kind: "empty" },
-              body: loopBody,
-            },
-          ],
-        });
+        // Wrap in block { loop { ... } } via the trait (#1584 a3).
+        const loopWrap: Instr[] = [];
+        emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
+        emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
         return;
       }
       // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
@@ -1547,7 +1540,8 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.elementSlot),
         }); // externref value (top)
         // if (done) br 1 (exit) — done (i32) is now on top of the stack
-        loopBody.push({ op: "br_if", depth: 1 });
+        // #1584 (a3): control-flow ops route through the trait.
+        emitter.emitBrIf(1, loopBody as unknown as S);
 
         // Body instrs (same materialisation pattern as forof.vec).
         for (const bodyInstr of instr.body) {
@@ -1564,20 +1558,12 @@ export function lowerIrFunctionBody<S>(
         }
 
         // br 0 (continue)
-        loopBody.push({ op: "br", depth: 0 });
+        emitter.emitBr(0, loopBody as unknown as S);
 
-        // block { loop { ... } }
-        wasmOut.push({
-          op: "block",
-          blockType: { kind: "empty" },
-          body: [
-            {
-              op: "loop",
-              blockType: { kind: "empty" },
-              body: loopBody,
-            },
-          ],
-        });
+        // block { loop { ... } } via the trait (#1584 a3).
+        const loopWrap: Instr[] = [];
+        emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
+        emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
 
         // Normal-exit close: iter.return(iter). Note this runs only on
         // normal loop exit (done=true). Abrupt exits (break/return)
@@ -1767,7 +1753,8 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.lengthSlot),
         });
         loopBody.push({ op: "i32.ge_s" });
-        loopBody.push({ op: "br_if", depth: 1 });
+        // #1584 (a3): control-flow ops route through the trait.
+        emitter.emitBrIf(1, loopBody as unknown as S);
 
         // element = __str_charAt(str, counter)
         loopBody.push({ op: "local.get", index: slotWasmIdx(instr.strSlot) });
@@ -1808,20 +1795,12 @@ export function lowerIrFunctionBody<S>(
         });
 
         // br 0 (continue)
-        loopBody.push({ op: "br", depth: 0 });
+        emitter.emitBr(0, loopBody as unknown as S);
 
-        // block { loop { ... } }
-        wasmOut.push({
-          op: "block",
-          blockType: { kind: "empty" },
-          body: [
-            {
-              op: "loop",
-              blockType: { kind: "empty" },
-              body: loopBody,
-            },
-          ],
-        });
+        // block { loop { ... } } via the trait (#1584 a3).
+        const loopWrap: Instr[] = [];
+        emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
+        emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
         return;
       }
       // Slice 10 (#1169i) — extern class ops. All five forms delegate to
@@ -1925,9 +1904,10 @@ export function lowerIrFunctionBody<S>(
         emitBodyBuffer(instr.cond, loopBody);
 
         // 2. Push the cond value, invert (i32.eqz), then br_if 1 to exit.
+        //    #1584 (a3): the control-flow ops route through the trait.
         emitValue(instr.condValue, loopBody as unknown as S);
         loopBody.push({ op: "i32.eqz" });
-        loopBody.push({ op: "br_if", depth: 1 });
+        emitter.emitBrIf(1, loopBody as unknown as S);
 
         // 3. Body instructions.
         emitBodyBuffer(instr.body, loopBody);
@@ -1938,20 +1918,12 @@ export function lowerIrFunctionBody<S>(
         }
 
         // 5. Continue back to the loop header.
-        loopBody.push({ op: "br", depth: 0 });
+        emitter.emitBr(0, loopBody as unknown as S);
 
-        // 6. Wrap in `block { loop { ... } }`.
-        wasmOut.push({
-          op: "block",
-          blockType: { kind: "empty" },
-          body: [
-            {
-              op: "loop",
-              blockType: { kind: "empty" },
-              body: loopBody,
-            },
-          ],
-        });
+        // 6. Wrap in `block { loop { ... } }` via the trait (#1584 a3).
+        const loopWrap: Instr[] = [];
+        emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
+        emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
         return;
       }
       // (#1373b Phase C Slice 1) Async / await IR node lowering.

--- a/tests/ir-bytecode-proof.test.ts
+++ b/tests/ir-bytecode-proof.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
-import { BytecodeEmitter, BytecodeSink, OP } from "../src/ir/backend/bytecode-emitter.js";
+import {
+  BytecodeEmitter,
+  BytecodeSink,
+  OP,
+} from "../src/ir/backend/bytecode-emitter.js";
 import { runSink } from "../src/ir/backend/bytecode-vm.js";
 import type { IrObjectStructLowering } from "../src/ir/backend/handles.js";
-import { type IrFunction, type IrLowerResolver, asBlockId, asValueId, irVal } from "../src/ir/index.js";
+import {
+  type IrFunction,
+  type IrLowerResolver,
+  asBlockId,
+  asValueId,
+  irVal,
+} from "../src/ir/index.js";
 // #1584 (a0-tail): the REAL production lowerer, generic over the sink. The arm
 // at the bottom of this file drives it (not a hand-lowerer) through a
 // BytecodeEmitter for the #1715 three functions — the (a0) acceptance criterion.
@@ -36,15 +46,26 @@ import { buildImports } from "../src/runtime.js";
 // The WasmGC arm DOES go through the real compiler (`compile()`), so the
 // equivalence pins the bytecode result against production WasmGC lowering.
 
-async function runWasmGc(src: string, fn: string, args: number[]): Promise<number> {
+async function runWasmGc(
+  src: string,
+  fn: string,
+  args: number[],
+): Promise<number> {
   const r = compile(src, { fileName: "test.ts" });
   if (!r.success) throw new Error(`compile error: ${r.errors[0]?.message}`);
   const imports = buildImports(r.imports, undefined, r.stringPool);
   const { instance } = await WebAssembly.instantiate(r.binary, imports);
-  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
-    (imports as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  if (
+    typeof (imports as { setExports?: (e: unknown) => void }).setExports ===
+    "function"
+  ) {
+    (imports as { setExports: (e: unknown) => void }).setExports(
+      instance.exports,
+    );
   }
-  const f = (instance.exports as Record<string, (...a: number[]) => number>)[fn];
+  const f = (instance.exports as Record<string, (...a: number[]) => number>)[
+    fn
+  ];
   return f(...args);
 }
 
@@ -153,12 +174,16 @@ describe("#1584 — bytecode-emitter triple equivalence (production trait surfac
   it("out-of-subset ops throw with a clear #1584 message", () => {
     const s = new BytecodeSink();
     // js-bitwise / i32 logical families have not migrated behind the trait yet.
-    expect(() => E.emitBinary("js.bitor", s)).toThrow(/not in the #1584 production subset/);
-    expect(() => E.emitUnary("i32.eqz", s)).toThrow(/not in the #1584 production subset/);
-    // The raw-Instr escape hatch rejects an Instr for an unrealized op family.
-    expect(() => E.pushRaw(s, { op: "struct.get", typeIdx: 0, fieldIdx: 0 })).toThrow(
-      /out of the #1584 production subset/,
+    expect(() => E.emitBinary("js.bitor", s)).toThrow(
+      /not in the #1584 production subset/,
     );
+    expect(() => E.emitUnary("i32.eqz", s)).toThrow(
+      /not in the #1584 production subset/,
+    );
+    // The raw-Instr escape hatch rejects an Instr for an unrealized op family.
+    expect(() =>
+      E.pushRaw(s, { op: "struct.get", typeIdx: 0, fieldIdx: 0 }),
+    ).toThrow(/out of the #1584 production subset/);
   });
 });
 
@@ -195,7 +220,11 @@ function numericResolver(): IrLowerResolver {
 
 /** Lower a hand-built IR function to a bytecode sink via the REAL lowerer. */
 function lowerToBytecode(fn: IrFunction): BytecodeSink {
-  return lowerIrFunctionBody<BytecodeSink>(fn, numericResolver(), new BytecodeEmitter()).body;
+  return lowerIrFunctionBody<BytecodeSink>(
+    fn,
+    numericResolver(),
+    new BytecodeEmitter(),
+  ).body;
 }
 
 describe("#1584 (a0-tail) — REAL lower.ts drives the bytecode sink (triple equivalence)", () => {
@@ -433,7 +462,11 @@ describe("#1584 (a1) — real lower.ts drives OP.CALL through the BytecodeEmitte
       valueCount: 3,
     };
 
-    const sink = lowerIrFunctionBody<BytecodeSink>(main, callResolver(1), new BytecodeEmitter()).body;
+    const sink = lowerIrFunctionBody<BytecodeSink>(
+      main,
+      callResolver(1),
+      new BytecodeEmitter(),
+    ).body;
     // The call's result is single-use in the return, so it inlines: the body is
     //   LOAD 0 ; LOAD 1 ; CALL 1 ; RET
     expect(sink.code).toEqual([OP.LOAD, 0, OP.LOAD, 1, OP.CALL, 1, OP.RET]);
@@ -502,6 +535,138 @@ describe("#1584 (a2) — BytecodeEmitter realizes the struct/object family", () 
     arm.emit(OP.STRUCT_SET, 1);
     const dest = new BytecodeSink();
     dest.spliceArm(arm);
-    expect(dest.code).toEqual([OP.STRUCT_NEW, 2, OP.STRUCT_GET, 0, OP.STRUCT_SET, 1]);
+    expect(dest.code).toEqual([
+      OP.STRUCT_NEW,
+      2,
+      OP.STRUCT_GET,
+      0,
+      OP.STRUCT_SET,
+      1,
+    ]);
+  });
+});
+
+// ── #1584 (a3) control-flow family — block / loop / br / br_if → JZ/JNZ/JMP ──
+//
+// The structured `block`/`loop`/`br`/`br_if` family compiles AWAY in the
+// BytecodeEmitter to JZ/JNZ/JMP + backpatch labels (issue §1c/§2a; `emitIf`
+// already demonstrates the pattern for `if`). The only new VM opcode is JNZ —
+// the exact dual of JZ — so `br_if`'s "branch if truthy" needs no `eqz`+`JZ`.
+// `block`/`loop` add NO opcode (they resolve to backpatched targets at splice).
+//
+// These emitter-side tests (my lane) assert the lowering: `br`/`br_if` emit a
+// JMP/JNZ placeholder + a depth-tagged pending branch; `emitLoop` resolves a
+// depth-0 branch to the loop HEADER (back-edge / continue); `emitBlock` resolves
+// a depth-0 branch to the block EXIT (forward / break). The De Bruijn depth is
+// decremented as branches cross each enclosing construct outward. The matching
+// `OP.JNZ` VM dispatch arm is sdev-vm's slice (exercised in the VM unit tests).
+describe("#1584 (a3) — BytecodeEmitter realizes the control-flow family", () => {
+  it("emitBr / emitBrIf emit JMP / JNZ placeholders + record a depth-tagged pending branch", () => {
+    const E = new BytecodeEmitter();
+    const s = new BytecodeSink();
+    E.emitBr(0, s);
+    E.emitBrIf(2, s);
+    // Two placeholder jumps, both unpatched (-1) until an enclosing construct resolves them.
+    expect(s.code).toEqual([OP.JMP, -1, OP.JNZ, -1]);
+    expect(s.pendingBranches).toEqual([
+      { slot: 1, depth: 0 }, // the JMP operand slot
+      { slot: 3, depth: 2 }, // the JNZ operand slot
+    ]);
+  });
+
+  it("emitLoop resolves a depth-0 branch to the loop HEADER (back-edge / continue)", () => {
+    const E = new BytecodeEmitter();
+    const body = new BytecodeSink();
+    body.emit(OP.LOAD, 0);
+    E.emitBr(0, body); // `br 0` — continue, targets the loop header
+    const out = new BytecodeSink();
+    E.emitLoop({ kind: "empty" }, body, out);
+    // header = position the body begins = 0; the JMP back-edge patches to 0.
+    expect(out.code).toEqual([OP.LOAD, 0, OP.JMP, 0]);
+    expect(out.pendingBranches).toEqual([]); // depth-0 fully resolved
+  });
+
+  it("emitBlock resolves a depth-0 branch to the block EXIT (forward / break)", () => {
+    const E = new BytecodeEmitter();
+    const body = new BytecodeSink();
+    E.emitBrIf(0, body); // `br_if 0` — exit-if, targets the block end
+    body.emit(OP.LOAD, 1);
+    const out = new BytecodeSink();
+    E.emitBlock({ kind: "empty" }, body, out);
+    // exit = position past the spliced body = 4; the JNZ patches to 4.
+    expect(out.code).toEqual([OP.JNZ, 4, OP.LOAD, 1]);
+    expect(out.pendingBranches).toEqual([]);
+  });
+
+  it("the canonical loop `block{ loop{ cond; br_if 1; body; br 0 } }` backpatches both targets", () => {
+    // Mirrors the 4 fenced loop arms in lower.ts (forof.vec/iter/string, for/while).
+    const E = new BytecodeEmitter();
+    const loopBody = new BytecodeSink();
+    loopBody.emit(OP.LOAD, 0); // cond (truthy ⇒ exit)
+    E.emitBrIf(1, loopBody); // br_if 1 — exit the enclosing BLOCK
+    loopBody.emit(OP.LOAD, 1); // body
+    E.emitBr(0, loopBody); // br 0 — continue the LOOP
+
+    const loopWrap = new BytecodeSink();
+    E.emitLoop({ kind: "empty" }, loopBody, loopWrap);
+    const out = new BytecodeSink();
+    E.emitBlock({ kind: "empty" }, loopWrap, out);
+
+    // JNZ (br_if 1) → block exit = 8 (past the whole loop);
+    // JMP (br 0)    → loop header = 0 (back-edge to cond).
+    expect(out.code).toEqual([OP.LOAD, 0, OP.JNZ, 8, OP.LOAD, 1, OP.JMP, 0]);
+    expect(out.pendingBranches).toEqual([]); // every structured branch resolved
+  });
+
+  it("nested loops resolve each `br`/`br_if` to its own construct (De Bruijn depth)", () => {
+    // outer block{ loop{ inner block{ loop{ br_if 1(inner exit); br 0(inner cont) };
+    //                                   br 0(outer cont) } } }
+    // Validates depth decrement as branches cross constructs outward.
+    const E = new BytecodeEmitter();
+
+    const innerBody = new BytecodeSink();
+    innerBody.emit(OP.LOAD, 0);
+    E.emitBrIf(1, innerBody); // exit inner block
+    E.emitBr(0, innerBody); // continue inner loop
+    const innerLoopWrap = new BytecodeSink();
+    E.emitLoop({ kind: "empty" }, innerBody, innerLoopWrap);
+    const innerBlockOut = new BytecodeSink();
+    E.emitBlock({ kind: "empty" }, innerLoopWrap, innerBlockOut);
+    // After inner block fully resolves, no pending branches escape it.
+    expect(innerBlockOut.pendingBranches).toEqual([]);
+
+    // Now wrap the inner block in the outer loop, appending an outer `br 0`.
+    const outerBody = new BytecodeSink();
+    outerBody.spliceArm(innerBlockOut);
+    E.emitBr(0, outerBody); // continue outer loop
+    const outerLoopWrap = new BytecodeSink();
+    E.emitLoop({ kind: "empty" }, outerBody, outerLoopWrap);
+    const out = new BytecodeSink();
+    E.emitBlock({ kind: "empty" }, outerLoopWrap, out);
+
+    // inner: LOAD 0; JNZ → inner-block exit (6); JMP → inner-loop header (0)
+    // outer: JMP → outer-loop header (0); outer-block exit unused here
+    expect(out.code).toEqual([OP.LOAD, 0, OP.JNZ, 6, OP.JMP, 0, OP.JMP, 0]);
+    expect(out.pendingBranches).toEqual([]);
+  });
+
+  it("spliceArm carries an UNPATCHED structured branch outward (relocated) but still rejects a stray unpatched jump", () => {
+    // A pending br to an as-yet-unseen enclosing construct survives a splice.
+    const E = new BytecodeEmitter();
+    const inner = new BytecodeSink();
+    inner.emit(OP.LOAD, 9);
+    E.emitBr(3, inner); // depth 3 — far outer construct, stays pending
+    const mid = new BytecodeSink();
+    mid.emit(OP.DROP);
+    mid.spliceArm(inner);
+    // The JMP relocated by +base (base=1 ⇒ operand slot 3) and its depth survives.
+    expect(mid.code).toEqual([OP.DROP, OP.LOAD, 9, OP.JMP, -1]);
+    expect(mid.pendingBranches).toEqual([{ slot: 4, depth: 3 }]);
+
+    // A non-structured unpatched jump (no pending-branch record) is still an error.
+    const bad = new BytecodeSink();
+    bad.code.push(OP.JZ, -1); // hand-forged unpatched JZ, not recorded
+    const dest = new BytecodeSink();
+    expect(() => dest.spliceArm(bad)).toThrow(/unpatched jump/);
   });
 });

--- a/tests/ir-bytecode-proof.test.ts
+++ b/tests/ir-bytecode-proof.test.ts
@@ -1,19 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
-import {
-  BytecodeEmitter,
-  BytecodeSink,
-  OP,
-} from "../src/ir/backend/bytecode-emitter.js";
+import { BytecodeEmitter, BytecodeSink, OP } from "../src/ir/backend/bytecode-emitter.js";
 import { runSink } from "../src/ir/backend/bytecode-vm.js";
 import type { IrObjectStructLowering } from "../src/ir/backend/handles.js";
-import {
-  type IrFunction,
-  type IrLowerResolver,
-  asBlockId,
-  asValueId,
-  irVal,
-} from "../src/ir/index.js";
+import { type IrFunction, type IrLowerResolver, asBlockId, asValueId, irVal } from "../src/ir/index.js";
 // #1584 (a0-tail): the REAL production lowerer, generic over the sink. The arm
 // at the bottom of this file drives it (not a hand-lowerer) through a
 // BytecodeEmitter for the #1715 three functions — the (a0) acceptance criterion.
@@ -46,26 +36,15 @@ import { buildImports } from "../src/runtime.js";
 // The WasmGC arm DOES go through the real compiler (`compile()`), so the
 // equivalence pins the bytecode result against production WasmGC lowering.
 
-async function runWasmGc(
-  src: string,
-  fn: string,
-  args: number[],
-): Promise<number> {
+async function runWasmGc(src: string, fn: string, args: number[]): Promise<number> {
   const r = compile(src, { fileName: "test.ts" });
   if (!r.success) throw new Error(`compile error: ${r.errors[0]?.message}`);
   const imports = buildImports(r.imports, undefined, r.stringPool);
   const { instance } = await WebAssembly.instantiate(r.binary, imports);
-  if (
-    typeof (imports as { setExports?: (e: unknown) => void }).setExports ===
-    "function"
-  ) {
-    (imports as { setExports: (e: unknown) => void }).setExports(
-      instance.exports,
-    );
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(instance.exports);
   }
-  const f = (instance.exports as Record<string, (...a: number[]) => number>)[
-    fn
-  ];
+  const f = (instance.exports as Record<string, (...a: number[]) => number>)[fn];
   return f(...args);
 }
 
@@ -174,16 +153,12 @@ describe("#1584 — bytecode-emitter triple equivalence (production trait surfac
   it("out-of-subset ops throw with a clear #1584 message", () => {
     const s = new BytecodeSink();
     // js-bitwise / i32 logical families have not migrated behind the trait yet.
-    expect(() => E.emitBinary("js.bitor", s)).toThrow(
-      /not in the #1584 production subset/,
-    );
-    expect(() => E.emitUnary("i32.eqz", s)).toThrow(
-      /not in the #1584 production subset/,
-    );
+    expect(() => E.emitBinary("js.bitor", s)).toThrow(/not in the #1584 production subset/);
+    expect(() => E.emitUnary("i32.eqz", s)).toThrow(/not in the #1584 production subset/);
     // The raw-Instr escape hatch rejects an Instr for an unrealized op family.
-    expect(() =>
-      E.pushRaw(s, { op: "struct.get", typeIdx: 0, fieldIdx: 0 }),
-    ).toThrow(/out of the #1584 production subset/);
+    expect(() => E.pushRaw(s, { op: "struct.get", typeIdx: 0, fieldIdx: 0 })).toThrow(
+      /out of the #1584 production subset/,
+    );
   });
 });
 
@@ -220,11 +195,7 @@ function numericResolver(): IrLowerResolver {
 
 /** Lower a hand-built IR function to a bytecode sink via the REAL lowerer. */
 function lowerToBytecode(fn: IrFunction): BytecodeSink {
-  return lowerIrFunctionBody<BytecodeSink>(
-    fn,
-    numericResolver(),
-    new BytecodeEmitter(),
-  ).body;
+  return lowerIrFunctionBody<BytecodeSink>(fn, numericResolver(), new BytecodeEmitter()).body;
 }
 
 describe("#1584 (a0-tail) — REAL lower.ts drives the bytecode sink (triple equivalence)", () => {
@@ -462,11 +433,7 @@ describe("#1584 (a1) — real lower.ts drives OP.CALL through the BytecodeEmitte
       valueCount: 3,
     };
 
-    const sink = lowerIrFunctionBody<BytecodeSink>(
-      main,
-      callResolver(1),
-      new BytecodeEmitter(),
-    ).body;
+    const sink = lowerIrFunctionBody<BytecodeSink>(main, callResolver(1), new BytecodeEmitter()).body;
     // The call's result is single-use in the return, so it inlines: the body is
     //   LOAD 0 ; LOAD 1 ; CALL 1 ; RET
     expect(sink.code).toEqual([OP.LOAD, 0, OP.LOAD, 1, OP.CALL, 1, OP.RET]);
@@ -535,14 +502,7 @@ describe("#1584 (a2) — BytecodeEmitter realizes the struct/object family", () 
     arm.emit(OP.STRUCT_SET, 1);
     const dest = new BytecodeSink();
     dest.spliceArm(arm);
-    expect(dest.code).toEqual([
-      OP.STRUCT_NEW,
-      2,
-      OP.STRUCT_GET,
-      0,
-      OP.STRUCT_SET,
-      1,
-    ]);
+    expect(dest.code).toEqual([OP.STRUCT_NEW, 2, OP.STRUCT_GET, 0, OP.STRUCT_SET, 1]);
   });
 });
 


### PR DESCRIPTION
## #1584 (a3) — control-flow op-family migration

Fourth op-family slice of the #1584 bytecode-interpreter migration (after a0-tail/a1/a2). Routes the structured `block` / `loop` / `br` / `br_if` ops through the `BackendEmitter` trait instead of raw `out.push({op})` in lower.ts's 4 fenced loop arms.

### What changed
- **emitter.ts**: add `emitBlock` / `emitLoop` to the trait (`emitBr`/`emitBrIf` were already declared since a0). New surface owned by the (a0) emitter slice per §2a.
- **wasmgc-emitter.ts**: byte-identical realizations — `{op:"block",blockType,body}` / `{op:"loop",blockType,body}`. **The WasmGC `Instr` stream is UNCHANGED** — nested `emitLoop`+`emitBlock` reproduce the exact `block{ loop{...} }` tree the inline arms built.
- **linear-emitter.ts**: `notImplemented` stubs (out of the #1714 vec-proof scope).
- **bytecode-emitter.ts**: the control-flow family compiles **away** to `JZ/JNZ/JMP` + backpatch labels (issue §1c/§2a). Adds **one** new VM opcode `JNZ = 28` (the dual of `JZ`, so `br_if` needs no `eqz`+`JZ`). `block`/`loop` add **no** opcode. `br`/`br_if` emit a placeholder + a De-Bruijn-depth-tagged pending branch on `BytecodeSink`; `emitLoop` resolves depth-0 to the loop **header** (back-edge), `emitBlock` to the block **exit** (forward); deeper branches migrate outward with `depth-1`. `spliceArm` now relocates an unpatched structured branch and carries its depth.
- **lower.ts**: the 4 loop arms (forof.vec / forof.iter / forof.string / for+while.loop) route `br_if`/`br`/`loop`/`block` through the trait. The `requireInstrSink` fence **stays** — the loop-internal i32 ops (local.get / i32.add / struct.get) belong to later families, so a full loop function still can't route to bytecode end-to-end after a3. WasmGC byte-identity preserved.
- **ir-bytecode-proof.test.ts**: 6 a3 tests drive `emitBlock`/`emitLoop`/`emitBr`/`emitBrIf` directly (a1/a2 style), asserting the `JZ/JNZ/JMP` backpatch stream — incl. the canonical loop pattern and nested-loop De Bruijn depth resolution.

The VM-side `case OP.JNZ` dispatch is **sdev-vm's** slice (opcode contract delivered: `JNZ = 28`).

### Validation
- `tsc --noEmit` clean
- ir-fallback budget unchanged (0 deltas — a3 doesn't change which functions take the IR path)
- proof test **19/19** green (6 new a3 tests)
- equivalence suite: **73 fail / 1382 pass** on BOTH this branch and the a2 base; **28 failing files byte-identical** (diff empty) → **0 regressions, 0 new passes**. WasmGC output byte-identical.

DRAFT until final-against-current-main per draft-until-final discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)