### PR TITLE
feat(#1584) a4: try-throw family (try/throw/rethrow) behind BackendEmitter trait

### DIFF
--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -114,6 +114,18 @@ export const OP = {
   // `br_if`'s "branch if truthy" needs no `eqz`+`JZ` dance. block/loop add NO
   // opcode (they resolve to backpatched JMP/JNZ/JZ targets at splice time).
   JNZ: 28, //   JNZ <target>         ; pop c; if c != 0 goto target  (maps from emitBrIf / br_if)
+  // ── (a4) try-throw family (#1584 §2a) — exception handling via a per-function
+  // STATIC `exceptionTable` (table-scan model, sdev-vm locked). THROW unwinds:
+  // scan the current fn's table for the innermost {tryStart ≤ pc < tryEnd}, on a
+  // hit truncate the value stack to that entry's `spAtEntry` (always 0 — try is
+  // a statement-level node, empty operand stack at entry), push the exn, jump to
+  // `catchTarget`; no hit ⇒ pop the call frame and rescan the caller (mirrors
+  // Wasm unwind); frames empty ⇒ abort with the thrown value. TRY_START/TRY_END
+  // are RUNTIME NO-OP region markers (the table is authoritative) kept so the
+  // stream is self-describing + region boundaries are testable.
+  THROW: 29, //     THROW              ; pop exn; unwind to innermost covering handler (table-scan)
+  TRY_START: 30, // TRY_START <catchTarget> ; no-op marker (region start; table carries coverage)
+  TRY_END: 31, //   TRY_END            ; no-op marker (region end; normal-exit boundary)
 } as const;
 
 export type Opcode = (typeof OP)[keyof typeof OP];
@@ -139,6 +151,23 @@ export class BytecodeSink {
    */
   readonly pendingBranches: { slot: number; depth: number }[] = [];
 
+  /**
+   * (a4 #1584) Per-function exception table (table-scan model, §1c). One entry
+   * per `try` region: the protected code range `[tryStart, tryEnd)` (absolute
+   * code indices), the `catchTarget` THROW jumps to on a covered throw, and
+   * `spAtEntry` — the value-stack depth to truncate to on catch (always 0: a
+   * `try` is a statement-level node lowered at empty operand-stack depth).
+   * The VM scans this for the innermost covering entry on THROW; TRY_START/
+   * TRY_END are runtime no-ops (the table is authoritative). Travels with the
+   * function on its FuncEntry, alongside `code`/`constPool`.
+   */
+  readonly exceptionTable: {
+    tryStart: number;
+    tryEnd: number;
+    catchTarget: number;
+    spAtEntry: number;
+  }[] = [];
+
   /** Intern an f64 immediate into the constant pool, returning its index. */
   internConst(value: number): number {
     // Linear scan is fine — proof-grade, programs are tiny.
@@ -162,7 +191,7 @@ export class BytecodeSink {
    * Emit a jump whose target is not yet known; returns the code index of the
    * *operand slot* to backpatch once the target is known.
    */
-  emitJumpPlaceholder(op: typeof OP.JZ | typeof OP.JMP | typeof OP.JNZ): number {
+  emitJumpPlaceholder(op: typeof OP.JZ | typeof OP.JMP | typeof OP.JNZ | typeof OP.TRY_START): number {
     this.code.push(op, -1); // -1 = unpatched
     return this.code.length - 1; // index of the operand slot
   }
@@ -231,6 +260,13 @@ export class BytecodeSink {
           }
           break;
         }
+        // (a4) TRY_START carries an inline <catchTarget> that is a code POSITION
+        // in the arm's address space — relocate it by +base like a jump target.
+        // (The exceptionTable below is the VM-authoritative copy; this inline
+        // operand is the self-describing marker, kept consistent.)
+        case OP.TRY_START:
+          this.code.push(op, code[i++]! + base);
+          break;
         // Single-inline-operand opcodes (a local / global / const / func /
         // type index). CALL <funcIdx> / CALL_REF <typeIdx> carry exactly one
         // inline operand (no relocation needed — function/type indices are
@@ -247,11 +283,21 @@ export class BytecodeSink {
         case OP.STRUCT_SET:
           this.code.push(op, code[i++]!);
           break;
-        // Zero-operand opcodes.
+        // Zero-operand opcodes (incl. (a4) THROW / TRY_END).
         default:
           this.code.push(op);
           break;
       }
+    }
+    // (a4) Relocate the arm's exception table into this sink's address space.
+    // tryStart/tryEnd/catchTarget are code positions in the arm → shift by +base.
+    for (const e of arm.exceptionTable) {
+      this.exceptionTable.push({
+        tryStart: e.tryStart + base,
+        tryEnd: e.tryEnd + base,
+        catchTarget: e.catchTarget + base,
+        spAtEntry: e.spAtEntry,
+      });
     }
   }
 }
@@ -533,33 +579,80 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     out.emit(OP.STRUCT_SET, layout.fieldIdx(name));
   }
 
-  // ---- (a4) try-throw family (#1584 §2a) — VM realization pending ----------
-  // The bytecode realization is THROW + TRY_START/TRY_END + an `exceptionTable`
-  // sink field (issue §1c/§2a). The exact opcode wiring is gated on sdev-vm's
-  // VM exception-model choice (handler-stack vs table-scan) — see the a4 contract.
-  // Until that lands these throw so a try/throw function is surfaced as "out of
-  // the #1584 subset" on the bytecode path (the try arms in lower.ts are fenced
-  // by requireInstrSink anyway, so this boundary is exact, not a regression).
-  emitThrow(_tagIdx: number, _out: BytecodeSink): void {
-    throw new Error(
-      "BytecodeEmitter: emitThrow (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
-    );
+  // ---- (a4) try-throw family (#1584 §2a) — table-scan exception model -------
+  // sdev-vm-locked: per-function STATIC exceptionTable + THROW unwinds to the
+  // innermost covering entry (frame-walking across CALL); TRY_START/TRY_END are
+  // runtime no-op region markers (the table is authoritative). The thrown value
+  // is a single boxed JSValue on the stack; catch binds it via STORE; rethrow =
+  // re-push the caught value + THROW; finally is compiled away in lower.ts.
+
+  // `throw v` — v already on the stack; THROW pops it and unwinds to the
+  // innermost handler covering the current pc (table-scan), walking call frames.
+  emitThrow(_tagIdx: number, out: BytecodeSink): void {
+    out.emit(OP.THROW);
   }
-  emitRethrow(_depth: number, _out: BytecodeSink): void {
-    throw new Error(
-      "BytecodeEmitter: emitRethrow (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
-    );
+
+  // `rethrow 0` — re-throw the currently-caught value. lower.ts only emits
+  // depth 0 (the immediately-enclosing handler's caught value, still bound to
+  // the payload slot). The caught value is already on the stack at the rethrow
+  // point in our lowering (the catch_all/finally arm leaves it there before
+  // rethrow), so this is a bare THROW. `depth` is informational (single tag).
+  emitRethrow(_depth: number, out: BytecodeSink): void {
+    out.emit(OP.THROW);
   }
+
+  /**
+   * Structured `try`. Table-scan realization:
+   *
+   *   TRY_START <catchTarget>     ; no-op marker
+   *   <tryBody>
+   *   TRY_END                     ; no-op marker (end of protected region)
+   *   JMP endLabel                ; normal exit skips the handler
+   *   catchTarget: <handler>      ; THROW lands here (VM pushed exn, truncated sp)
+   *   endLabel:
+   *
+   * + an exceptionTable entry {tryStart, tryEnd, catchTarget, spAtEntry:0}.
+   * The protected region is [tryStart, tryEnd) = the spliced tryBody (between the
+   * markers). spAtEntry is 0: `try` is a statement-level node lowered at empty
+   * operand-stack depth, so on catch the VM truncates back to the empty base.
+   *
+   * Handler selection: our system has ONE exception tag (`__exn`), so a thrown
+   * value always matches a source `catch` if present; `catchAll` (emitted for
+   * the finally-leak path) is the handler only when there is no `catch`. With a
+   * single tag, `catchAll`-alongside-`catch` is the unreachable non-`__exn`
+   * leak path — we still splice it after the catch for structural fidelity, but
+   * `catchTarget` points at the live handler.
+   */
   emitTry(
     _blockType: BlockType,
-    _body: BytecodeSink,
-    _catches: { tagIdx: number; body: BytecodeSink }[],
-    _catchAll: BytecodeSink | undefined,
-    _out: BytecodeSink,
+    body: BytecodeSink,
+    catches: { tagIdx: number; body: BytecodeSink }[],
+    catchAll: BytecodeSink | undefined,
+    out: BytecodeSink,
   ): void {
-    throw new Error(
-      "BytecodeEmitter: emitTry (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
-    );
+    // TRY_START marker carries the (forward) catchTarget — backpatched below.
+    const catchTargetSlot = out.emitJumpPlaceholder(OP.TRY_START);
+    const tryStart = out.here();
+    out.spliceArm(body);
+    const tryEnd = out.here();
+    out.emit(OP.TRY_END);
+    // Normal exit skips the handler.
+    const toEnd = out.emitJumpPlaceholder(OP.JMP);
+    // Handler entry — THROW jumps here with the exn pushed + sp truncated.
+    const catchTarget = out.here();
+    out.patch(catchTargetSlot, catchTarget);
+    // The live handler: the source `catch` if present, else the `catchAll`
+    // (try/finally-only). When both exist, `catchAll` is the unreachable
+    // non-`__exn` leak path, spliced after for fidelity.
+    if (catches.length > 0) {
+      out.spliceArm(catches[0]!.body);
+      if (catchAll) out.spliceArm(catchAll);
+    } else if (catchAll) {
+      out.spliceArm(catchAll);
+    }
+    out.patch(toEnd, out.here());
+    // Record the static table entry (innermost-covering selection on THROW).
+    out.exceptionTable.push({ tryStart, tryEnd, catchTarget, spAtEntry: 0 });
   }
 
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -533,6 +533,35 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     out.emit(OP.STRUCT_SET, layout.fieldIdx(name));
   }
 
+  // ---- (a4) try-throw family (#1584 §2a) — VM realization pending ----------
+  // The bytecode realization is THROW + TRY_START/TRY_END + an `exceptionTable`
+  // sink field (issue §1c/§2a). The exact opcode wiring is gated on sdev-vm's
+  // VM exception-model choice (handler-stack vs table-scan) — see the a4 contract.
+  // Until that lands these throw so a try/throw function is surfaced as "out of
+  // the #1584 subset" on the bytecode path (the try arms in lower.ts are fenced
+  // by requireInstrSink anyway, so this boundary is exact, not a regression).
+  emitThrow(_tagIdx: number, _out: BytecodeSink): void {
+    throw new Error(
+      "BytecodeEmitter: emitThrow (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
+    );
+  }
+  emitRethrow(_depth: number, _out: BytecodeSink): void {
+    throw new Error(
+      "BytecodeEmitter: emitRethrow (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
+    );
+  }
+  emitTry(
+    _blockType: BlockType,
+    _body: BytecodeSink,
+    _catches: { tagIdx: number; body: BytecodeSink }[],
+    _catchAll: BytecodeSink | undefined,
+    _out: BytecodeSink,
+  ): void {
+    throw new Error(
+      "BytecodeEmitter: emitTry (try-throw family) VM realization pending sdev-vm exception-model — see §2a (a4).",
+    );
+  }
+
   // ---- vec (array) primitives — out of the #1584 numeric subset -----------
   emitVecLen(): void {
     throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -181,4 +181,24 @@ export interface BackendEmitter<S = Instr[]> {
   emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
   /** struct ref + value on stack -> writes the named field (void). */
   emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: S): void;
+
+  // ---- (a4) try-throw family — MIGRATED behind the trait (#1584 §2a) --------
+  // The exception ops (throw / try / rethrow). The caller (real `lower.ts`)
+  // pre-lowers the try/catch/finally regions into their own sinks (via
+  // `newSink()`), exactly as it builds the WasmGC `try`'s body/catch/catchAll as
+  // separate `Instr[]`. WasmGc realizes them byte-identically (`{op:"throw"}` /
+  // `{op:"try",body,catches,catchAll}` / `{op:"rethrow"}`); Bytecode realizes
+  // `OP.THROW` / `OP.TRY_START`+`TRY_END` + an `exceptionTable` sink field
+  // (issue §1c/§2a). Finally semantics are compiled away in `lower.ts` (inlined
+  // on every exit path + an inner try/catch_all+rethrow), so neither backend
+  // needs a finally concept — both only see throw/try/catch_all/rethrow.
+  /** Throw the exception value already on the stack via the `__exn` tag. */
+  emitThrow(tagIdx: number, out: S): void;
+  /** Re-throw the currently-caught exception (`depth` levels out; lower.ts
+   * only emits depth 0 today). */
+  emitRethrow(depth: number, out: S): void;
+  /** Structured try. `body` / each catch `body` / `catchAll` are pre-lowered
+   * into their own sinks (built via `newSink()`). `catches[i].tagIdx` selects
+   * the handler by exception tag. */
+  emitTry(blockType: BlockType, body: S, catches: { tagIdx: number; body: S }[], catchAll: S | undefined, out: S): void;
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -173,6 +173,16 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   emitLoop(): void {
     notImplemented("emitLoop");
   }
+  // (a4) try-throw family (#1584 §2a) — out of the #1714 vec-proof scope.
+  emitThrow(): void {
+    notImplemented("emitThrow");
+  }
+  emitRethrow(): void {
+    notImplemented("emitRethrow");
+  }
+  emitTry(): void {
+    notImplemented("emitTry");
+  }
   // (a2) struct/object family (#1584 §2a) — out of the #1714 vec-proof scope.
   emitAggregateNew(): void {
     notImplemented("emitAggregateNew");

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -174,6 +174,35 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
       fieldIdx: layout.fieldIdx(name),
     });
   }
+
+  // ---- (a4) try-throw family (#1584 §2a) — byte-identical to the prior inline
+  // `out.push({op:"throw"...})` / `{op:"try"...}` / `{op:"rethrow"...}` in the
+  // exception arms of lower.ts. The WasmGC stream is unchanged; this only moves
+  // the push behind the trait so the bytecode backend realizes the same intent
+  // as OP.THROW / OP.TRY_START+TRY_END + the exceptionTable.
+  emitThrow(tagIdx: number, out: Instr[]): void {
+    out.push({ op: "throw", tagIdx });
+  }
+
+  emitRethrow(depth: number, out: Instr[]): void {
+    out.push({ op: "rethrow", depth });
+  }
+
+  emitTry(
+    blockType: BlockType,
+    body: Instr[],
+    catches: { tagIdx: number; body: Instr[] }[],
+    catchAll: Instr[] | undefined,
+    out: Instr[],
+  ): void {
+    out.push({
+      op: "try",
+      blockType,
+      body,
+      catches,
+      ...(catchAll ? { catchAll } : {}),
+    });
+  }
 }
 
 /** The WasmGC struct typeIdx for an object (`typeIdx`) or class (`structTypeIdx`). */

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1581,7 +1581,8 @@ export function lowerIrFunctionBody<S>(
           throw new Error(`ir/lower: resolver cannot resolve __exn tag for throw (${func.name})`);
         }
         emitValue(instr.value, out);
-        emitter.pushRaw(out, { op: "throw", tagIdx });
+        // #1584 (a4): throw routes through the trait.
+        emitter.emitThrow(tagIdx, out);
         return;
       }
       case "try": {
@@ -1652,18 +1653,19 @@ export function lowerIrFunctionBody<S>(
           if (instr.finallyBody) {
             // Wrap user catch body in an inner try/catch_all so a throw
             // inside the catch body still runs finally before propagating.
+            // #1584 (a4): the inner try + rethrow route through the trait.
             const innerBody: Instr[] = [];
             emitBodyBuffer(instr.catchClause.body, innerBody);
             const innerCatchAll: Instr[] = [];
             emitBodyBuffer(instr.finallyBody, innerCatchAll);
-            innerCatchAll.push({ op: "rethrow", depth: 0 });
-            catchBody.push({
-              op: "try",
-              blockType: { kind: "empty" },
-              body: innerBody,
-              catches: [],
-              catchAll: innerCatchAll,
-            });
+            emitter.emitRethrow(0, innerCatchAll as unknown as S);
+            emitter.emitTry(
+              { kind: "empty" },
+              innerBody as unknown as S,
+              [],
+              innerCatchAll as unknown as S,
+              catchBody as unknown as S,
+            );
             // Normal-exit from catch: inline finally.
             emitBodyBuffer(instr.finallyBody, catchBody);
           } else {
@@ -1684,17 +1686,18 @@ export function lowerIrFunctionBody<S>(
           // emits it because finally MUST run on EVERY exit path.
           const ca: Instr[] = [];
           emitBodyBuffer(instr.finallyBody, ca);
-          ca.push({ op: "rethrow", depth: 0 });
+          emitter.emitRethrow(0, ca as unknown as S);
           catchAll = ca;
         }
 
-        wasmOut.push({
-          op: "try",
-          blockType: { kind: "empty" },
-          body: tryBody,
-          catches,
-          ...(catchAll ? { catchAll } : {}),
-        });
+        // #1584 (a4): the structured try routes through the trait.
+        emitter.emitTry(
+          { kind: "empty" },
+          tryBody as unknown as S,
+          catches as unknown as { tagIdx: number; body: S }[],
+          catchAll as unknown as S | undefined,
+          wasmOut as unknown as S,
+        );
         return;
       }
       // Slice 6 part 4 (#1183) — string for-of (native-strings mode).
@@ -2058,7 +2061,8 @@ export function lowerIrFunctionBody<S>(
             typeIdx: promiseTypeIdx,
             fieldIdx: 1,
           } as Instr);
-          rejectedBranch.push({ op: "throw", tagIdx: exnTagIdx } as Instr);
+          // #1584 (a4): throw routes through the trait.
+          emitter.emitThrow(exnTagIdx, rejectedBranch as unknown as S);
         }
         rejectedBranch.push({ op: "unreachable" } as Instr);
         // PENDING / fall-through marker. Slice 2 (#1373b) replaces with

--- a/tests/ir-bytecode-proof.test.ts
+++ b/tests/ir-bytecode-proof.test.ts
@@ -630,3 +630,80 @@ describe("#1584 (a3) — BytecodeEmitter realizes the control-flow family", () =
     expect(() => dest.spliceArm(bad)).toThrow(/unpatched jump/);
   });
 });
+
+// ── #1584 (a4) try-throw family — THROW + TRY_START/TRY_END + exceptionTable ──
+//
+// The exception ops (throw / try / rethrow) realize via a per-function STATIC
+// `exceptionTable` (table-scan model, sdev-vm-locked): THROW unwinds to the
+// innermost covering entry (walking call frames); TRY_START/TRY_END are runtime
+// no-op region markers (the table is authoritative). The thrown value is a
+// single boxed JSValue on the stack; rethrow = re-push + THROW; finally is
+// compiled away in lower.ts. These emitter-side tests (my lane) assert the
+// BytecodeEmitter lowering; the OP.THROW/TRY_* VM dispatch is sdev-vm's slice.
+describe("#1584 (a4) — BytecodeEmitter realizes the try-throw family", () => {
+  it("emitThrow / emitRethrow emit OP.THROW (rethrow = re-push caught value + THROW)", () => {
+    const E = new BytecodeEmitter();
+    const t = new BytecodeSink();
+    E.emitThrow(7, t); // tagIdx is informational (single __exn tag)
+    expect(t.code).toEqual([OP.THROW]);
+
+    const r = new BytecodeSink();
+    E.emitRethrow(0, r);
+    expect(r.code).toEqual([OP.THROW]);
+  });
+
+  it("emitTry (catch) lowers to TRY_START/body/TRY_END/JMP-end/catchTarget + a table entry", () => {
+    // try { LOAD 0 } catch (x) { STORE 1; LOAD 1 }
+    const E = new BytecodeEmitter();
+    const body = new BytecodeSink();
+    body.emit(OP.LOAD, 0);
+    const catchBody = new BytecodeSink();
+    catchBody.emit(OP.STORE, 1); // bind payload
+    catchBody.emit(OP.LOAD, 1);
+    const out = new BytecodeSink();
+    E.emitTry({ kind: "empty" }, body, [{ tagIdx: 5, body: catchBody }], undefined, out);
+
+    // TRY_START<catchTarget=7>; LOAD 0; TRY_END; JMP<end=11>; STORE 1; LOAD 1
+    expect(out.code).toEqual([OP.TRY_START, 7, OP.LOAD, 0, OP.TRY_END, OP.JMP, 11, OP.STORE, 1, OP.LOAD, 1]);
+    // Protected region [tryStart=2, tryEnd=4) = the spliced body; spAtEntry=0.
+    expect(out.exceptionTable).toEqual([{ tryStart: 2, tryEnd: 4, catchTarget: 7, spAtEntry: 0 }]);
+  });
+
+  it("emitTry (finally-only / catchAll) routes the catchAll arm as the handler", () => {
+    // try { LOAD 0 } finally { LOAD 9; rethrow }  → catchAll = [LOAD 9, THROW]
+    const E = new BytecodeEmitter();
+    const body = new BytecodeSink();
+    body.emit(OP.LOAD, 0);
+    const catchAll = new BytecodeSink();
+    catchAll.emit(OP.LOAD, 9);
+    E.emitRethrow(0, catchAll); // finally re-throws on the leak path
+    const out = new BytecodeSink();
+    E.emitTry({ kind: "empty" }, body, [], catchAll, out);
+
+    expect(out.code).toEqual([OP.TRY_START, 7, OP.LOAD, 0, OP.TRY_END, OP.JMP, 10, OP.LOAD, 9, OP.THROW]);
+    expect(out.exceptionTable).toEqual([{ tryStart: 2, tryEnd: 4, catchTarget: 7, spAtEntry: 0 }]);
+  });
+
+  it("spliceArm relocates a nested try's code AND its exceptionTable by +base", () => {
+    // An inner try built into its own sink, then spliced into a larger sink:
+    // its TRY_START<catchTarget> operand + its table entries all shift by +base.
+    const E = new BytecodeEmitter();
+    const innerBody = new BytecodeSink();
+    innerBody.emit(OP.LOAD, 0);
+    const innerCatch = new BytecodeSink();
+    innerCatch.emit(OP.DROP);
+    const arm = new BytecodeSink();
+    E.emitTry({ kind: "empty" }, innerBody, [{ tagIdx: 5, body: innerCatch }], undefined, arm);
+    // arm: [TRY_START,7, LOAD,0, TRY_END, JMP,8, DROP], table {2,4,7,0}
+    expect(arm.code).toEqual([OP.TRY_START, 7, OP.LOAD, 0, OP.TRY_END, OP.JMP, 8, OP.DROP]);
+    expect(arm.exceptionTable).toEqual([{ tryStart: 2, tryEnd: 4, catchTarget: 7, spAtEntry: 0 }]);
+
+    const dest = new BytecodeSink();
+    dest.emit(OP.LOAD, 3); // base = 2 before the splice
+    dest.spliceArm(arm);
+    // Code relocated by +2: TRY_START operand 7→9, JMP operand 8→10.
+    expect(dest.code).toEqual([OP.LOAD, 3, OP.TRY_START, 9, OP.LOAD, 0, OP.TRY_END, OP.JMP, 10, OP.DROP]);
+    // Table entry relocated by +2.
+    expect(dest.exceptionTable).toEqual([{ tryStart: 4, tryEnd: 6, catchTarget: 9, spAtEntry: 0 }]);
+  });
+});


### PR DESCRIPTION
## #1584 (a4) — try-throw op-family migration

Fifth op-family slice of the #1584 bytecode-interpreter migration (after a0-tail/a1/a2/a3). Routes the exception ops (`throw` / `try` / `rethrow`) through the `BackendEmitter` trait instead of raw `out.push({op})`.

### What changed
- **emitter.ts**: add `emitThrow` / `emitRethrow` / `emitTry` to the trait. `emitTry` takes pre-lowered `body` / `catches[].body` / `catchAll` sinks (built via `newSink()`), exactly as `lower.ts` builds the WasmGC `try`'s body/catch/catchAll as separate `Instr[]`.
- **wasmgc-emitter.ts**: byte-identical realizations — `{op:"throw",tagIdx}` / `{op:"rethrow",depth}` / `{op:"try",blockType,body,catches,...(catchAll?{catchAll}:{})}`. **The WasmGC `Instr` stream is UNCHANGED** (emitTry reproduces the exact object literal the inline arm built, incl. the conditional catchAll spread).
- **linear-emitter.ts**: `notImplemented` stubs (out of #1714 vec-proof scope).
- **bytecode-emitter.ts**: the bytecode realization uses the **table-scan exception model** locked with sdev-vm. New opcodes `THROW=29` / `TRY_START=30` / `TRY_END=31`; `BytecodeSink` gains a per-function `exceptionTable: {tryStart,tryEnd,catchTarget,spAtEntry}[]`. `THROW` unwinds to the innermost covering entry (walking call frames); `TRY_START`/`TRY_END` are runtime **no-op** region markers (the static table is authoritative). `spAtEntry` is always 0 (`try` is a statement-level node lowered at empty operand-stack depth). `spliceArm` relocates the TRY_START inline catchTarget AND the table entries by `+base`.
- **lower.ts**: `case "throw"` (+ await-arm reject branch), `case "try"` (outer try, the nested inner-try for finally, both rethrow sites) route through the trait. The `requireInstrSink` fence **stays** (try-internal ops belong to other families). WasmGC byte-identity preserved.
- **ir-bytecode-proof.test.ts**: 4 new a4 tests — `emitThrow`/`emitRethrow` → `OP.THROW`; the canonical try/catch stream + table entry; try/finally (catchAll) routing; and `spliceArm` relocating a nested try's code + exceptionTable by `+base`.

Finally semantics are compiled away in `lower.ts` (inlined on every exit + an inner try/catch_all+rethrow), so neither backend needs a finally concept. The matching `OP.THROW`/`TRY_*` VM dispatch (frame-unwind + table scan) is **sdev-vm's** slice (contract locked: (b) table-scan, (i) no-op markers, (b1) spAtEntry-in-table, smallest-range innermost).

### Validation
- `tsc --noEmit` clean
- ir-fallback budget unchanged (0 deltas)
- proof test **23/23** green (4 new a4 tests) + sdev-vm's VM test 11/11 = **34/34**
- full equivalence: **73 fail / 1382 pass** on BOTH this branch and the a4 base; **28 failing files byte-identical** (diff empty) → **0 regressions** on the WasmGC path
- prettier-clean (committed content verified)

DRAFT until final-against-current-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)