### PR TITLE
docs(#1719): mark CPR destructuring read-drive done + carve #1749/#1750 follow-ups

### DIFF
--- a/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
+++ b/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
@@ -1,9 +1,11 @@
 ---
 id: 1719
 title: "Array destructuring ignores overridden Array.prototype[Symbol.iterator] ('items[Symbol.iterator] must be a function', 71 fails)"
-status: in-progress
+status: done
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
+completed: 2026-05-30
+followups: [1749, 1750]
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -967,3 +969,48 @@ alias rides for free (`arrayIteratorOverrideGlobalIdx` checks both keys).
 Each is "add the gate at site N + call the shared helper + a scoped test". Awaiting
 tech-lead a/b: (a) land CPR-1 PR now + CPR-2 follow-up (lets CI measure the real
 per-context split of the 71), or (b) build all CPR-2 into this branch first.
+
+## DONE — CPR destructuring read-drive complete across all 4 contexts (sendev, 2026-05-30)
+
+The destructuring cluster — the 71 `*-iter-val-array-prototype.js` fails — is
+**closed**. Array destructuring now drives the (possibly overridden)
+`Array.prototype[Symbol.iterator]` / `Array.prototype.values` in **all four**
+destructuring contexts, each via the same proven `emitArrayProtoIteratorDrive`
+helper, all gated behind `ctx.arrayIteratorMaybeOverridden && arrayIteratorOverrideGlobalIdx(ctx) !== undefined`
+so override-free modules stay byte-identical:
+
+| Context | Site | Landed in |
+|---------|------|-----------|
+| **declaration** `var [a,b,z]=arr` | `compileArrayDestructuring` / `tryEmitArrayProtoIteratorReadDrive` (statements/destructuring.ts) | PR #963 (CPR-1) |
+| **for-of-head** `for (const [a,b] of xs)` | `compileForOfDestructuring` (statements/loops.ts) | PR #968 (CPR-2) |
+| **parameter** `function f([a,b]) {}` | `destructureParamArray` (codegen/destructuring-params.ts) | PR #968 (CPR-2) |
+| **assignment** `[a,b,z]=arr` | `tryEmitArrayProtoIteratorAssignDrive` + `compileArrayDestructuringAssignment` (expressions/assignment.ts) | PR #976 (CPR-2 final) |
+
+Proof in every context: `Array.prototype[Symbol.iterator]=function*(){…yield 42}`
++ the matching destructure → bound `z===42` (was `3`), and the override fires once
+at the observation boundary (internal array iterations stay on the typed-vec fast
+path, so it TERMINATES — no re-entrancy). Override-free modules byte-identical;
+`tests/issue-1719-cpr.test.ts` (7 tests: decl z=42 / decl termination /
+for-of-head z=42 / for-of multi-element termination / parameter z=42 /
+assignment z=42 / override-free) green; #1016/#1021/#1320 dstr guards unaffected.
+
+**Write-arm + drive mechanism (the keystone):** the override assignment
+(`Array.prototype[k]=fn`, dropped at compile time normally) is captured by
+`maybeCaptureArrayProtoOverride` into a rooted `mut externref` module global keyed
+in `ctx.protoOverrides`; the dedicated `__drive_proto_iterator` driver
+(option (a), placeholder-funcIdx reserved at body-compile, body filled in
+post-processing as a thin wrapper over `__call_fn_method_0`) installs/restores
+`__current_this` and dispatches the override; the resulting compiled-generator
+iterator is drained with the multi-value `__iterator_next` host import. See
+`src/codegen/expressions/proto-override.ts`.
+
+### Genuinely-remaining follow-ups (OUT of the original 71 — tracked, not regressions)
+
+- **#1749** — spread (`[...arr]`, `f(...arr)`, `new C(...arr)`) is a separate
+  `GetIterator` consumer with its own emit site; none of the 71 are spread. Reuse
+  `emitArrayProtoIteratorDrive` at the spread-element site.
+- **#1750** — the TS-cast assignment form `(Array.prototype as any)[Symbol.iterator]=fn`
+  is not captured by the write-arm (paren/`as` wrapper). A naive wrapper-strip was
+  reverted because the cast-form closure misses arity-0 `__call_fn_method_0`
+  dispatch (null iterator); the null-guard keeps it falling back cleanly. Hand-written
+  shape, not in test262.

--- a/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
+++ b/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
@@ -1,0 +1,61 @@
+---
+id: 1749
+title: "Array spread `[...arr]` / spread-call must honor overridden Array.prototype[Symbol.iterator]"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: low
+feasibility: medium
+task_type: feature
+area: codegen, runtime
+language_feature: array-object-identity, spread, iterator-protocol
+goal: object-representation
+sprint: Backlog
+related: [1719, 1320]
+parent: 1719
+---
+
+# #1749 — Spread must drive the (possibly overridden) Array iterator
+
+## Problem
+
+Split out of #1719 (CPR — Compiled Prototype Record). The #1719 work landed the
+read-drive for all four **destructuring** contexts (declaration, for-of-head,
+parameter, assignment) so array destructuring now honors a monkeypatched
+`Array.prototype[Symbol.iterator]` / `Array.prototype.values` override. **Spread**
+(`[...arr]`, `f(...arr)`, `new C(...arr)`) is a separate consumer of `GetIterator`
+and was NOT part of the 71 `*-iter-val-array-prototype.js` destructuring fails, so
+it was deliberately left out of the #1719 PRs.
+
+Spread over an array whose prototype iterator is overridden still takes the static
+backing-store fast path and ignores the override — same root cause as #1719, but a
+different emit site.
+
+## Why this is genuinely out of the original 71
+
+The 71 tests #1719 closed are all array-**destructuring** patterns. Spread is a
+distinct grammar production with its own codegen path; none of the 71 exercise it.
+This is tracked as a follow-up, not a regression.
+
+## Fix direction
+
+Reuse the already-proven CPR read-drive helper
+`emitArrayProtoIteratorDrive` (`src/codegen/expressions/proto-override.ts`) at the
+spread-element emit site, gated identically behind
+`ctx.arrayIteratorMaybeOverridden && arrayIteratorOverrideGlobalIdx(ctx) !== undefined`.
+The drive yields an iterator externref; drain it with `__iterator_next` collecting
+elements into the spread target (array literal build / call-argument vector). The
+gate keeps override-free modules byte-identical, exactly as the four dstr contexts do.
+
+## Acceptance
+
+- `Array.prototype[Symbol.iterator] = function*(){ yield 42 }; const a = [...[1,2,3]];`
+  → `a` reflects the override, not `[1,2,3]`.
+- Override-free spread emits byte-identical Wasm (no regression on
+  `tests/equivalence.test.ts`).
+
+## Source
+
+Carved from #1719 "CPR-2 remaining" follow-up list (see #1719 issue file, CPR
+completion section). The #1719 destructuring cluster is done; this is the next
+incremental consumer.

--- a/plan/issues/1750-ts-cast-form-array-proto-iterator-override-not-captured.md
+++ b/plan/issues/1750-ts-cast-form-array-proto-iterator-override-not-captured.md
@@ -1,0 +1,70 @@
+---
+id: 1750
+title: "TS-cast form `(Array.prototype as any)[Symbol.iterator] = fn` not captured by CPR write-arm"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: low
+feasibility: medium
+task_type: feature
+area: codegen, runtime
+language_feature: array-object-identity, iterator-protocol, type-assertion
+goal: object-representation
+sprint: Backlog
+related: [1719]
+parent: 1719
+---
+
+# #1750 — CPR write-arm must capture the TS-cast assignment form
+
+## Problem
+
+Split out of #1719 (CPR). The CPR write-arm
+(`maybeCaptureArrayProtoOverride`, `src/codegen/expressions/proto-override.ts`)
+captures `Array.prototype[Symbol.iterator] = fn` and `Array.prototype.values = fn`
+into a rooted module global so destructuring can drive the override. It does NOT
+capture the **TypeScript cast form**:
+
+```ts
+(Array.prototype as any)[Symbol.iterator] = function*(){ yield 42 };
+```
+
+Here the assignment target is a `ParenthesizedExpression` wrapping an
+`AsExpression`, not a bare `ElementAccessExpression` on `Array.prototype`. The
+write-arm's target-shape match does not see through the cast wrapper, so the
+override is dropped at compile time (the S2 "assignment evaporates" path), and a
+subsequent destructure reads the backing store (`z === 3`, not `42`).
+
+## History — why a naive wrapper-strip was reverted
+
+A first attempt widened the target match to strip the `as`/paren wrapper. It made
+the write-arm **capture** the override, but the read-drive then trapped
+("Cannot read properties of null"): the cast-form generator closure was not
+resolved by the arity-0 `__call_fn_method_0` dispatch, yielding a null iterator.
+The wrapper-strip was reverted (the cast form is NOT in the 71 test262 fails —
+it's a hand-written shape) and the null-guard (`if (iter !== null)`) was kept so
+the cast form falls back cleanly to the fast path instead of trapping.
+
+## Fix direction (deferred)
+
+Two coupled pieces, both needed:
+1. **Write-arm**: see through `ParenthesizedExpression`/`AsExpression` wrappers
+   when matching the assignment target against `Array.prototype[...]`.
+2. **Read-drive dispatch**: the cast-form generator closure must register a
+   funcref type that `__call_fn_method_0` can resolve — investigate why the
+   cast-form closure misses arity-0 dispatch (the bare-form closure resolves
+   fine). Without (2), (1) alone re-introduces the null-iterator trap.
+
+This is dispatch-plumbing, not in the conformance-critical path; deferred until
+the bare-form CPR is fully banked.
+
+## Acceptance
+
+- `(Array.prototype as any)[Symbol.iterator] = function*(){ yield 42 };
+  var [a,b,z] = [1,2,3];` → `z === 42`.
+- No regression: bare-form CPR (the #1719 four contexts) stays green;
+  override-free modules stay byte-identical.
+
+## Source
+
+Carved from #1719 CPR follow-ups (see #1719 issue file, CPR completion section).

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -110,7 +110,7 @@ fidelity → #1463) were NOT re-filed.
 - [#1716](../1716-spec-gap-toprimitive-residual-object-property-key-coercion.md) — **RESIDUAL of done #1090/#1319/#1525**: `Cannot convert object to primitive value` still thrown in 111 paths (Object property-key + String/RegExp/JSON/Date `this`-value coercion) — **high**, medium, **ready**
 - [#1717](../1717-arraybuffer-prototype-slice-not-implemented.md) — `ArrayBuffer.prototype.slice` not implemented (`slice is not a function`, 17 fails) — medium, medium, **ready**
 - [#1718](../1718-iterator-sequencing-helpers-concat-zip-flatmap.md) — Iterator sequencing helpers (`Iterator.concat`/`zip`/`zipKeyed`) + `Iterator.prototype.flatMap` not implemented (101 fails; distinct from done #1340) — medium, hard, **ready**
-- [#1719](../1719-array-destructuring-ignores-overridden-array-prototype-iterator.md) — Array destructuring ignores overridden `Array.prototype[Symbol.iterator]` (`items[Symbol.iterator]` must be a function, 71 fails) — **high**, medium, **ready**
+- ~~[#1719](../1719-array-destructuring-ignores-overridden-array-prototype-iterator.md) — Array destructuring ignores overridden `Array.prototype[Symbol.iterator]` (`items[Symbol.iterator]` must be a function, 71 fails)~~ — **DONE** 2026-05-30 (CPR read-drive across decl/for-of/param/assignment, PRs #963/#968/#976). Follow-ups: #1749 (spread), #1750 (TS-cast form).
 
 ### ES3 / edition-0 conformance → Sprint 57 (Track 3)
 


### PR DESCRIPTION
Closes out #1719 (the CPR / Compiled Prototype Record cluster). The 71 `*-iter-val-array-prototype.js` **array-destructuring** fails are fixed: destructuring now drives the (possibly overridden) `Array.prototype[Symbol.iterator]` / `.values` across **all four** contexts — declaration (PR #963), for-of-head + parameter (PR #968), assignment (PR #976) — each via the shared `emitArrayProtoIteratorDrive` helper, gated so override-free modules stay byte-identical.

## Docs-only

- `plan/issues/1719-*.md`: `status: in-progress -> done`, `completed: 2026-05-30`, `followups: [1749, 1750]`; appended a CPR completion section (per-context landing table + write-arm/drive mechanism).
- `plan/issues/1749-*.md` (new): spread `[...arr]` — a separate `GetIterator` consumer, genuinely **not** in the 71.
- `plan/issues/1750-*.md` (new): TS-cast form `(Array.prototype as any)[Symbol.iterator]=fn` not captured by the write-arm; hand-written shape, not in test262 (naive wrapper-strip was reverted, null-guard keeps fallback clean).
- `backlog.md`: strike #1719 done.

No source changes. Draft per draft-until-final; tech-lead admin-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)