### PR TITLE
feat(#1584) a4: try-throw VM (THROW/TRY_START/TRY_END + exceptionTable) (#245)

### DIFF
--- a/src/ir/backend/bytecode-vm.ts
+++ b/src/ir/backend/bytecode-vm.ts
@@ -56,6 +56,30 @@ export interface FuncEntry {
    * slots are lazily 0-init on first `LOAD` (same contract as `runBytecode`).
    */
   nLocals: number;
+  /**
+   * #1584 a4 try-throw: the STATIC per-function exception table (table-scan
+   * model). `THROW` scans it for the innermost entry whose `[tryStart, tryEnd)`
+   * covers the throwing pc, then truncates the value stack to `spAtEntry`, pushes
+   * the exn, and jumps to `catchTarget`. `TRY_START`/`TRY_END` are runtime
+   * no-ops (the table is authoritative). Array-of-objects with number-only
+   * fields (no `readonly`/nested-struct — same js2wasm-codegen accommodation as
+   * the FuncEntry array fields). `spAtEntry` is always 0 today (`try` is a
+   * statement-level node with an empty operand stack at entry), but it travels
+   * in the entry for correctness if a non-statement `try` ever appears.
+   */
+  exceptionTable: ExcEntry[];
+}
+
+/** One protected region in a {@link FuncEntry}'s {@link FuncEntry.exceptionTable}. */
+export interface ExcEntry {
+  /** Absolute code index of the region start (inclusive). */
+  tryStart: number;
+  /** Absolute code index of the region end (exclusive). */
+  tryEnd: number;
+  /** Absolute code index of the catch arm to jump to on a covered throw. */
+  catchTarget: number;
+  /** Value-stack depth at try-entry; the stack is truncated to this on catch. */
+  spAtEntry: number;
 }
 
 /**
@@ -123,6 +147,14 @@ export function runProgram(program: Program, args: readonly number[]): number {
     // array nested as a struct field traps when this VM is js2wasm-compiled.
     code: number[];
     constPool: number[];
+    // The function's exception table travels per-frame too, so a THROW that
+    // unwinds into a caller scans THAT caller's table (#1584 a4).
+    excTable: ExcEntry[];
+    // The call-site pc (the CALL/CALL_REF opcode index) in the caller. When a
+    // THROW unwinds into this caller, the region check uses the call-site — NOT
+    // the saved return `pc` (which is one-past the call, outside `[tryStart,
+    // tryEnd)`). Width-agnostic across CALL (2 slots) / CALL_REF (2 slots).
+    callSite: number;
   }
   const frames: Frame[] = [];
 
@@ -133,6 +165,9 @@ export function runProgram(program: Program, args: readonly number[]): number {
   }
   let code = entryFn.code;
   let constPool = entryFn.constPool;
+  // The currently-executing function's exception table (#1584 a4). Swapped on
+  // CALL/CALL_REF + restored on RET, just like `code`/`constPool`.
+  let excTable = entryFn.exceptionTable;
   // Entry locals: args copied into slots 0..arity-1 (the #1715 contract — the
   // entry behaves like `runBytecode(args)`); slots above args.length are lazily
   // 0-init on first LOAD.
@@ -239,6 +274,7 @@ export function runProgram(program: Program, args: readonly number[]): number {
         locals = caller.locals;
         code = caller.code;
         constPool = caller.constPool;
+        excTable = caller.excTable;
         stack.push(result);
         break;
       }
@@ -298,12 +334,21 @@ export function runProgram(program: Program, args: readonly number[]): number {
         if (callee === undefined) {
           throw new Error(`bytecode-vm: CALL funcIdx ${funcIdx} out of range at pc ${pc - 2}`);
         }
-        // Save the caller, install the callee.
-        frames.push({ pc, locals, code, constPool });
+        // Save the caller, install the callee. callSite = the CALL opcode index
+        // (`pc - 2`: opcode + 1 inline operand have been consumed).
+        frames.push({
+          pc,
+          locals,
+          code,
+          constPool,
+          excTable,
+          callSite: pc - 2,
+        });
         const calleeLocals = popArgsIntoLocals(callee, stack);
         locals = calleeLocals;
         code = callee.code;
         constPool = callee.constPool;
+        excTable = callee.exceptionTable;
         pc = 0;
         break;
       }
@@ -322,11 +367,21 @@ export function runProgram(program: Program, args: readonly number[]): number {
         if (callee === undefined) {
           throw new Error(`bytecode-vm: CALL_REF funcref ${idx} out of range at pc ${pc - 2}`);
         }
-        frames.push({ pc, locals, code, constPool });
+        // callSite = the CALL_REF opcode index (`pc - 2`: opcode + 1 inline
+        // typeIdx operand consumed; the funcref came off the stack).
+        frames.push({
+          pc,
+          locals,
+          code,
+          constPool,
+          excTable,
+          callSite: pc - 2,
+        });
         const calleeLocals = popArgsIntoLocals(callee, stack);
         locals = calleeLocals;
         code = callee.code;
         constPool = callee.constPool;
+        excTable = callee.exceptionTable;
         pc = 0;
         break;
       }
@@ -368,6 +423,71 @@ export function runProgram(program: Program, args: readonly number[]): number {
         }
         const obj = heap[ref | 0]!;
         obj.fields[fieldIdx] = value;
+        break;
+      }
+      // ── #1584 a4 try-throw family (THROW / TRY_START / TRY_END) ──
+      // table-scan model: TRY_START/TRY_END are runtime no-ops (the per-function
+      // exceptionTable is authoritative); THROW unwinds to the innermost covering
+      // handler, popping call frames until a handler matches.
+      case OP.TRY_START:
+        // TRY_START <catchTarget>: no-op region marker; skip the inline operand.
+        pc++;
+        break;
+      case OP.TRY_END:
+        // TRY_END: no-op region marker (normal-exit boundary).
+        break;
+      case OP.THROW: {
+        // Pop the exception value, then unwind. The THROW opcode's own index is
+        // `pc - 1` (op was read with `code[pc++]`), and that is the pc used for
+        // region coverage. Walk: scan the current fn's exceptionTable for the
+        // INNERMOST covering entry (smallest [tryStart,tryEnd) with
+        // tryStart ≤ throwPc < tryEnd); on a hit, truncate the value stack to
+        // that region's spAtEntry, push the exn, jump to catchTarget. On a miss,
+        // pop the call frame (restoring the caller's pc/locals/code/constPool/
+        // excTable) and rescan the caller's table at its saved call-site pc.
+        // If the frame stack empties with no handler, the throw escapes the
+        // program: re-throw a host Error carrying the value (`runProgram` aborts).
+        const exn = stack.pop()!;
+        let throwPc = pc - 1; // index of the THROW (or the call-site after a pop)
+        for (;;) {
+          // Find the innermost covering handler in the current excTable.
+          let bestIdx = -1;
+          let bestSpan = Number.POSITIVE_INFINITY;
+          for (let i = 0; i < excTable.length; i++) {
+            const e = excTable[i]!;
+            if (e.tryStart <= throwPc && throwPc < e.tryEnd) {
+              const span = e.tryEnd - e.tryStart;
+              if (span < bestSpan) {
+                bestSpan = span;
+                bestIdx = i;
+              }
+            }
+          }
+          if (bestIdx >= 0) {
+            const handler = excTable[bestIdx]!;
+            // Truncate the value stack to the try-entry depth (spAtEntry), then
+            // push the exn for the catch arm to bind via STORE.
+            stack.length = handler.spAtEntry;
+            stack.push(exn);
+            pc = handler.catchTarget;
+            break;
+          }
+          // No handler here — unwind one frame.
+          if (frames.length === 0) {
+            throw new Error(`bytecode-vm: uncaught throw (value ${exn})`);
+          }
+          const caller = frames.pop()!;
+          // Restore the caller. The rescan uses the CALL-SITE pc (the index of
+          // the CALL/CALL_REF that entered the popped frame), which lies inside
+          // any covering try region — NOT the saved return `pc` (one-past the
+          // call, i.e. == tryEnd, which would fail the half-open coverage test).
+          locals = caller.locals;
+          code = caller.code;
+          constPool = caller.constPool;
+          excTable = caller.excTable;
+          throwPc = caller.callSite;
+          pc = caller.pc;
+        }
         break;
       }
       default:
@@ -413,6 +533,8 @@ export function runBytecode(code: readonly number[], constPool: readonly number[
         constPool: constPool.slice(),
         arity: args.length,
         nLocals: args.length,
+        // No try regions in the single-function #1715 numeric proof path.
+        exceptionTable: [],
       },
     ],
     entry: 0,

--- a/tests/ir-bytecode-wasmgc-vm.test.ts
+++ b/tests/ir-bytecode-wasmgc-vm.test.ts
@@ -124,6 +124,12 @@ function compileProgramModule(
     constPool: readonly number[];
     arity: number;
     nLocals: number;
+    exceptionTable?: ReadonlyArray<{
+      tryStart: number;
+      tryEnd: number;
+      catchTarget: number;
+      spAtEntry: number;
+    }>;
   }>,
   entry: number,
   argInit: readonly string[],
@@ -137,10 +143,16 @@ function compileProgramModule(
   src = src.replace(/\/\*\* Convenience[\s\S]*$/m, "");
   const params = entryParams.map((p) => `${p}: number`).join(", ");
   const fnLiterals = functions
-    .map(
-      (f) =>
-        `{ code: [${f.code.join(", ")}], constPool: [${f.constPool.join(", ")}], arity: ${f.arity}, nLocals: ${f.nLocals} }`,
-    )
+    .map((f) => {
+      // exceptionTable defaults to [] (no try regions); a4 cases pass entries.
+      const excEntries = (f.exceptionTable ?? [])
+        .map(
+          (e) =>
+            `{ tryStart: ${e.tryStart}, tryEnd: ${e.tryEnd}, catchTarget: ${e.catchTarget}, spAtEntry: ${e.spAtEntry} }`,
+        )
+        .join(", ");
+      return `{ code: [${f.code.join(", ")}], constPool: [${f.constPool.join(", ")}], arity: ${f.arity}, nLocals: ${f.nLocals}, exceptionTable: [${excEntries}] }`;
+    })
     .join(",\n    ");
   const entrySrc = `
 export function run(${params}): number {
@@ -448,12 +460,14 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
         constPool: main.constPool.slice(),
         arity: 2,
         nLocals: 2,
+        exceptionTable: [],
       },
       {
         code: add.code.slice(),
         constPool: add.constPool.slice(),
         arity: 2,
         nLocals: 2,
+        exceptionTable: [],
       },
     ];
     const program: Program = { functions, entry: 0 };
@@ -506,12 +520,14 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
         constPool: entry.constPool.slice(),
         arity: 2,
         nLocals: 2,
+        exceptionTable: [],
       },
       {
         code: add.code.slice(),
         constPool: add.constPool.slice(),
         arity: 2,
         nLocals: 2,
+        exceptionTable: [],
       },
     ];
     const program: Program = { functions, entry: 0 };
@@ -538,12 +554,14 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
           constPool: nullEntry.constPool.slice(),
           arity: 2,
           nLocals: 2,
+          exceptionTable: [],
         },
         {
           code: add.code.slice(),
           constPool: add.constPool.slice(),
           arity: 2,
           nLocals: 2,
+          exceptionTable: [],
         },
       ],
       entry: 0,
@@ -584,6 +602,7 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
           constPool: s.constPool.slice(),
           arity: 2,
           nLocals: 3,
+          exceptionTable: [],
         },
       ],
       entry: 0,
@@ -630,6 +649,7 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
           constPool: s.constPool.slice(),
           arity: 1,
           nLocals: 2,
+          exceptionTable: [],
         },
       ],
       entry: 0,
@@ -650,6 +670,7 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
           constPool: nullGet.constPool.slice(),
           arity: 0,
           nLocals: 0,
+          exceptionTable: [],
         },
       ],
       entry: 0,
@@ -670,7 +691,12 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
   //            LOAD 1; LOAD 0; CMP_LT          (i < n ? 1 : 0)
   //            JNZ header                       (loop back while i<n)
   //   LOAD 1; RET                               (return i)
-  it("a3: JNZ loop — host-VM == WasmGC-VM == JS for count(n) (do i++ while i<n)", async () => {
+  // NB: this drives a HAND-BUILT bytecode loop stream through both VMs — it does
+  // NOT lower a real loop FUNCTION through lower.ts end-to-end (loop-body i32/
+  // struct ops still hit the requireInstrSink fence, later families). So it
+  // proves the JNZ dispatch arm + a backward loop-back through the compiled
+  // Wasm-GC-VM, not end-to-end loop compilation.
+  it("a3: JNZ dispatch — host-VM == WasmGC-VM == JS for a hand-built do-while loop", async () => {
     const s = new BytecodeSink();
     emitNumberConst(0, s); // i = 0
     E.emitLocalSet(1, s); // STORE 1
@@ -701,6 +727,7 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
           constPool: s.constPool.slice(),
           arity: 1,
           nLocals: 2,
+          exceptionTable: [],
         },
       ],
       entry: 0,
@@ -716,6 +743,161 @@ describe("#1584 slice (b) — Wasm-GC-native dispatch loop (quadruple equivalenc
       expect(runProgram(program, [n]), `host count(${n})`).toBe(expected);
       expect(await runWasm(vmMod, "run", [n]), `wasm count(${n})`).toBe(expected);
     }
+  });
+
+  // ── #1584 a3 emitter stream-shape asserts (verbatim mirror of emitter2's a3
+  // proof streams) — block/loop/br/br_if resolve to JZ/JNZ/JMP + backpatched
+  // absolute targets, so the VM-side hand-built stream must equal the emitter's.
+  it("a3: emitter stream shapes — JNZ/JMP backpatch (canonical + nested De Bruijn)", () => {
+    // canonical `block{ loop{ cond; br_if 1(exit); body; br 0(continue) } }`:
+    //   LOAD 0; JNZ 8(exit); LOAD 1; JMP 0(header)
+    const canonical = new BytecodeSink();
+    E.emitLocalGet(0, canonical);
+    canonical.emit(OP.JNZ, 8);
+    E.emitLocalGet(1, canonical);
+    canonical.emit(OP.JMP, 0);
+    expect(canonical.code).toEqual([OP.LOAD, 0, OP.JNZ, 8, OP.LOAD, 1, OP.JMP, 0]);
+
+    // nested `block{loop{ block{loop{ br_if 1; br 0 }; br 0 }}}`:
+    //   LOAD 0; JNZ 6(inner exit); JMP 0(inner header); JMP 0(outer header)
+    const nested = new BytecodeSink();
+    E.emitLocalGet(0, nested);
+    nested.emit(OP.JNZ, 6);
+    nested.emit(OP.JMP, 0);
+    nested.emit(OP.JMP, 0);
+    expect(nested.code).toEqual([OP.LOAD, 0, OP.JNZ, 6, OP.JMP, 0, OP.JMP, 0]);
+  });
+
+  // ── #1584 a4 try-throw family (THROW / TRY_START / TRY_END) ──
+  // table-scan model: per-function exceptionTable, THROW unwinds to the innermost
+  // covering handler (and across CALL frames). TRY_START/TRY_END are no-ops.
+  // Runnable execution cases via the compiled VM (compileProgramModule now
+  // threads exceptionTable) plus an emitter stream-shape mirror.
+  it("a4: THROW/catch — host-VM == WasmGC-VM for try{throw 42}catch(e){return e}", async () => {
+    // TRY_START<ct>; CONST 42; THROW; TRY_END; JMP end; ct: STORE 0; LOAD 0; RET
+    const s = new BytecodeSink();
+    const tsIdx = s.here();
+    s.emit(OP.TRY_START, -1); // catchTarget backpatched
+    const protStart = s.here();
+    emitNumberConst(42, s);
+    s.emit(OP.THROW);
+    const protEnd = s.here();
+    s.emit(OP.TRY_END);
+    const toEnd = s.code.length;
+    s.emit(OP.JMP, -1);
+    const ct = s.here();
+    E.emitLocalSet(0, s); // bind e
+    E.emitLocalGet(0, s);
+    E.emitReturn(s);
+    s.code[toEnd + 1] = s.here(); // patch JMP→end
+    s.code[tsIdx + 1] = ct; // patch TRY_START catchTarget (informational)
+    const excTable = [{ tryStart: protStart, tryEnd: protEnd, catchTarget: ct, spAtEntry: 0 }];
+
+    const program: Program = {
+      functions: [
+        {
+          code: s.code.slice(),
+          constPool: s.constPool.slice(),
+          arity: 0,
+          nLocals: 1,
+          exceptionTable: excTable,
+        },
+      ],
+      entry: 0,
+    };
+    const vmMod = compileProgramModule(
+      [],
+      [
+        {
+          code: s.code,
+          constPool: s.constPool,
+          arity: 0,
+          nLocals: 1,
+          exceptionTable: excTable,
+        },
+      ],
+      0,
+      ["0"], // local 0 = e (0-init)
+    );
+    expect(runProgram(program, []), "host throw/catch").toBe(42);
+    expect(await runWasm(vmMod, "run", []), "wasm throw/catch").toBe(42);
+  });
+
+  it("a4: THROW unwinds across CALL frames; uncaught aborts the program", () => {
+    // B(): throw 7  (no handler).  A(): try{ CALL B }catch(e){ return e }.
+    const B = new BytecodeSink();
+    emitNumberConst(7, B);
+    B.emit(OP.THROW);
+    E.emitReturn(B);
+
+    const A = new BytecodeSink();
+    const tsIdx = A.here();
+    A.emit(OP.TRY_START, -1);
+    const protStart = A.here();
+    A.emit(OP.CALL, 1); // CALL B
+    const protEnd = A.here();
+    A.emit(OP.TRY_END);
+    const toEnd = A.code.length;
+    A.emit(OP.JMP, -1);
+    const ct = A.here();
+    E.emitLocalSet(0, A);
+    E.emitLocalGet(0, A);
+    E.emitReturn(A);
+    A.code[toEnd + 1] = A.here();
+    A.code[tsIdx + 1] = ct;
+
+    const caught: Program = {
+      functions: [
+        {
+          code: A.code.slice(),
+          constPool: A.constPool.slice(),
+          arity: 0,
+          nLocals: 1,
+          exceptionTable: [
+            {
+              tryStart: protStart,
+              tryEnd: protEnd,
+              catchTarget: ct,
+              spAtEntry: 0,
+            },
+          ],
+        },
+        {
+          code: B.code.slice(),
+          constPool: B.constPool.slice(),
+          arity: 0,
+          nLocals: 0,
+          exceptionTable: [],
+        },
+      ],
+      entry: 0,
+    };
+    expect(runProgram(caught, []), "throw across CALL → caught by A").toBe(7);
+
+    // Same B, but the entry has NO handler → the throw escapes the program.
+    const noHandler = new BytecodeSink();
+    noHandler.emit(OP.CALL, 1);
+    E.emitReturn(noHandler);
+    const uncaught: Program = {
+      functions: [
+        {
+          code: noHandler.code.slice(),
+          constPool: noHandler.constPool.slice(),
+          arity: 0,
+          nLocals: 0,
+          exceptionTable: [],
+        },
+        {
+          code: B.code.slice(),
+          constPool: B.constPool.slice(),
+          arity: 0,
+          nLocals: 0,
+          exceptionTable: [],
+        },
+      ],
+      entry: 0,
+    };
+    expect(() => runProgram(uncaught, []), "uncaught throw aborts").toThrow(/uncaught throw/);
   });
 
   // ── Sanity: the host VM still rejects malformed; the emitter rejects ops ──


### PR DESCRIPTION
## What

Wires the **a4 try-throw family** (`OP.THROW=29` / `TRY_START=30` / `TRY_END=31` + `BytecodeSink.exceptionTable`, landed by the emitter in #977) into the Wasm-GC VM as a **table-scan exception model** — the design locked with the emitter (b table-scan over a handler-stack, for robustness under finally-inlining's non-local-exit JMPs + clean compilation). VM-side counterpart of #251; task #245.

## VM changes (`src/ir/backend/bytecode-vm.ts`)

- **`FuncEntry.exceptionTable: ExcEntry[]`** (`ExcEntry = {tryStart, tryEnd, catchTarget, spAtEntry}`) — per-function STATIC table, number-only fields (no `readonly`/nested-struct, same #1748 codegen accommodation). `spAtEntry` is always 0 (`try` is a statement-level node, empty operand stack at entry).
- The running `excTable` swaps on `CALL`/`CALL_REF` + restores on `RET`, alongside `code`/`constPool`, and travels per-frame so a `THROW` unwinding into a caller scans **that caller's** table.
- **`TRY_START`/`TRY_END`** — runtime no-ops (the table is authoritative).
- **`THROW`** — pop exn → scan current fn's table for the **innermost** covering entry (smallest `[tryStart,tryEnd)` with `tryStart ≤ throwPc < tryEnd`) → truncate the value stack to `spAtEntry` → push exn → `pc=catchTarget`. No match → pop the call frame and rescan the **caller's** table at the saved call-site pc. Frames empty + no handler ⇒ throw a host `Error` carrying the value (program abort, length-guarded per #1747).
- **`Frame.callSite`** (the `CALL`/`CALL_REF` opcode index): the cross-frame rescan uses the call-site, NOT the saved return pc (which is one-past the call `== tryEnd`, failing the half-open coverage test). **Caught + fixed via an executable throw-across-CALL probe before this PR** — exactly the frame-unwind subtlety flagged during the design review.

## Tests (`tests/ir-bytecode-wasmgc-vm.test.ts`)

- **a4 THROW/catch** — host-VM == Wasm-GC-VM for `try{throw 42}catch(e){return e}` (the compiled VM, via `compileProgramModule` now threading `exceptionTable`).
- **a4 throw-across-CALL** (B throws, A catches → 7) + **uncaught-abort**.
- **a3 emitter stream-shape asserts** — canonical `[LOAD,0,JNZ,8,LOAD,1,JMP,0]` + nested De Bruijn `[LOAD,0,JNZ,6,JMP,0,JMP,0]` (verbatim mirror of the a3 emitter proofs).
- **a3 JNZ test renamed/clarified** — "JNZ dispatch … hand-built" — it proves the opcode, NOT end-to-end loop lowering (loop-body ops stay behind the `requireInstrSink` fence).

## Validation

- All **14** VM equivalence tests pass (11 prior + a3 stream-shape + 2 a4).
- tsc + biome clean; merged with current `main` (incl. a4 emitter #977).
- Net source diff: `bytecode-vm.ts` + the VM test only. No emitter edits — `OP`/`BytecodeSink`/`exceptionTable` consumed read-only.

With a1 (call) + a2 (struct) + a3 (control-flow) + a4 (try-throw) wired, the bytecode VM dispatches calls, heap objects, loops, **and exceptions** through the compiled Wasm-GC-VM arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)