### PR TITLE
chore(infra): commit rate-limit retry resilience so it reaches agent worktrees

### DIFF
--- a/.claude/hooks/teammate-idle-retry.sh
+++ b/.claude/hooks/teammate-idle-retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# TeammateIdle retry hook (#rate-limit resilience).
+#
+# Re-engages a teammate that went idle WHILE it still owns an in-progress task —
+# the signature of a transient server-side throttle stall (the SDK exhausted its
+# retries and the teammate fell idle with work still to do). Emits a "retry" nudge
+# (exit 2 = blocking feedback) so the teammate resumes without the lead hand-nudging.
+#
+# SAFE BY DEFAULT: exits 0 (allow idle) on ANY uncertainty, so legitimate idle and
+# shutdown_request-driven exits are NEVER blocked. A teammate being shut down has its
+# task marked completed/reassigned first, so it owns no in-progress task -> idle allowed.
+# Hard cap of 3 re-engages per teammate prevents infinite loops on a genuinely-stuck agent.
+payload="$(cat 2>/dev/null || true)"
+name="$(printf '%s' "$payload" | jq -r '.teammate_name // .teammate // .name // .from // empty' 2>/dev/null || true)"
+[ -z "${name:-}" ] && exit 0   # can't identify the teammate -> allow idle (safe no-op)
+
+# Hard cap: at most 3 auto-retries per teammate, then allow idle so the lead intervenes.
+safe="${name//[^a-zA-Z0-9_-]/_}"
+cnt_file="${CLAUDE_CODE_TMPDIR:-/tmp}/idle-retry-${safe}.cnt"
+n="$(cat "$cnt_file" 2>/dev/null || echo 0)"
+case "$n" in ''|*[!0-9]*) n=0 ;; esac
+[ "$n" -ge 3 ] && exit 0
+
+# Re-engage ONLY if the teammate owns an in_progress task (has work -> it stalled, not
+# finished). grep pre-filters task files mentioning the name; jq confirms owner+status.
+owns=0
+for f in $(grep -rl "\"${name}\"" "$HOME"/.claude/tasks/ 2>/dev/null || true); do
+  [ -f "$f" ] || continue
+  o="$(jq -r '.owner // empty' "$f" 2>/dev/null || true)"
+  s="$(jq -r '.status // empty' "$f" 2>/dev/null || true)"
+  if [ "$o" = "$name" ] && [ "$s" = "in_progress" ]; then owns=1; break; fi
+done
+[ "$owns" -eq 0 ] && exit 0   # no owned in-progress task -> legitimate idle/shutdown, allow it
+
+echo $((n + 1)) > "$cnt_file" 2>/dev/null || true
+printf '%s\n' '{"systemMessage":"Likely a transient server-side throttle (not your usage limit). Retry your last request and resume your in-progress task. If you are genuinely blocked (not throttled), message the lead instead."}'
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,13 +5,27 @@
     "refreshInterval": 30
   },
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_MAX_RETRIES": "20",
+    "API_TIMEOUT_MS": "900000"
   },
   "permissions": {
     "defaultMode": "bypassPermissions",
     "allow": ["Bash(*)"]
   },
   "hooks": {
+    "TeammateIdle": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/teammate-idle-retry.sh",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",


### PR DESCRIPTION
## Why

The retry config (`CLAUDE_CODE_MAX_RETRIES=20`, `API_TIMEOUT_MS`, the `TeammateIdle` re-engage hook) only ever lived as **uncommitted edits in the `/workspace` checkout**. Consequences:
1. It was **wiped on every sync** to origin/main (happened 3× this session).
2. It **never actually applied to teammate agents** — they spawn in worktrees branched from `origin/main`, which lacked it entirely. So the throttle resilience was protecting only the lead session, never the agents that were getting rate-limited.

Committing it to `main` fixes both: every clone and worktree gets it.

## What
- `env`: `CLAUDE_CODE_MAX_RETRIES=20` + `API_TIMEOUT_MS=900000` — ride out server-side 429/529 throttles (Claude Code auto-retries with backoff).
- `hooks.TeammateIdle` → `.claude/hooks/teammate-idle-retry.sh` — re-engages a teammate that idles **while still owning an in_progress task** (the throttle-stall signature). Safe-by-default (exits 0 on any uncertainty, never blocks shutdown_request exits), hard-capped at 3 re-engages per teammate.
- `bgIsolation` stays `worktree` — the `none` flip is a temporary in-session unblock, deliberately not committed.

## Test
Docs/infra only (no `src/` change). Also serves as the live validation that the **merge queue is dispatching again** after its reset this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)