### PR TITLE
fix(#1730): module-level const arrow internal call traps 'illegal cast'

### DIFF
--- a/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
+++ b/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
@@ -137,3 +137,52 @@ Surfaced while fixing #1727 (async-call NaN). The async-arrow equivalence case
 was attributed to async but is a general module-const-arrow dispatch bug;
 split out so #1727 ships the actual Promise-wrap fix without expanding into
 closure-ABI work.
+
+---
+
+## 2026-05-30 — sdev-vm checkpoint: trapping global.get refined; fix site differs from handoff
+
+Reproduced cleanly on current main (`const f=(x)=>x*2; main(){return f(21)}` →
+"illegal cast"; `g=f; g(21)` → 42). Dumped the WAT for the repro — the exact
+trap is:
+
+```wat
+;; receiver load (CORRECT, post-shift):
+global.get 4          ;; the closure struct value
+local.tee 0
+;; ... null-check on receiver ...
+;; callee RE-RESOLUTION for the funcref operand (STALE):
+global.get 3          ;; <-- BUG: should be `global.get 4`. global 3 = "" string-const import
+any.convert_extern
+ref.cast null (ref null 6)   ;; casts the string-const externref → closure struct → TRAP
+```
+
+So the receiver load is shifted correctly but the **callee re-resolution**
+`global.get` kept its pre-shift index (3 instead of 4). A late string-constant
+import (`gimport$3`) shifted the import-global indices; the receiver-load
+participated in the shift but the funcref-re-resolution `global.get` did not.
+
+**Refinement vs the handoff (important for whoever finishes this):** the trap is
+NOT emitted via `emitGuardedFuncRefCast` (I added a stderr trace at all
+`emitGuardedFuncRefCast` call sites in calls.ts — none fired for this repro), and
+it is NOT the #1395 callback-arrow arg-block at `calls.ts:~10094` (that path is
+already `pushBody`-wrapped). The WAT signature — `struct.get <s> 0` + inline
+`ref.test (ref <f>)` + `(if (result (ref null <f>)))` funcref-extract + `call_ref`
+— is the **closure-dispatch path**, and the stale `global.get` is the
+**module-const-arrow singleton-cache re-resolution** (`global.get cacheGlobalIdx`
+in `src/codegen/closures.ts` ~3452–3595, the `compileArrowAsClosure` cache
+materialization). That `global.get` is emitted into a body that the late-import
+global-index shifter (`shiftLateImportIndices`/`fixupModuleGlobalIndices`, which
+walks `currentFunc.body` + `savedBodies` + `liveBodies`) does not visit.
+
+**Fix direction (unchanged in spirit, corrected in location):** register the
+body that holds the cache-re-resolution `global.get` in the set the shifter
+walks (`savedBodies`/`liveBodies`), OR resolve the cache global into an OUTER-body
+local once (like `g=f` does — `g=f; g(21)` works precisely because the load lands
+in the outer body which IS shifted). The latter (hoist the funcref load to a
+local in the already-tracked outer body) is likely the smaller, safer fix and
+avoids a double-shift risk from a wrong savedBodies registration.
+
+Status: handed back — sdev-vm pivoted to the #1584 VM op-family dispatch (higher
+priority; sdev-emitter2's families landing). No code change committed; the
+refined root-cause + WAT above is the resume point.

--- a/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
+++ b/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
@@ -73,6 +73,57 @@ than `ctx.moduleGlobals.get("f")` (`global$0`). The wrapper-types branch at
 `emitGuardedRefCast` → saved to a local) is the *correct* shape — the failing
 path is a *different* arm that loads self from a sentinel.
 
+## ROOT CAUSE (senior-dev, 2026-05-30) — late-import global-index shift misses the call_ref arg-block
+
+Full `$main` dump of the failing case: the closure receiver `(local.get $0)`
+IS correct (loaded from `global$0` earlier, the `throw (global.get $gimport$3)`
+on the receiver null-check is also *correct* — gimport$3 is the legitimate
+property-access-TypeError message). The trap is in the **call_ref's second
+operand**, a `(block (result f64) …)` that RE-RESOLVES the callee to build the
+funcref operand `$2`:
+
+```wat
+(call_ref $1
+  (local.get $0)                       ;; receiver — correct
+  (block (result f64)
+    (local.set $scratch (f64.const 21))
+    (global.set $global$3 (i32.const 1))
+    (if (ref.is_null (local.tee $0
+          (ref.cast (ref null $0)
+            (any.convert_extern (global.get $gimport$3)))))   ;; ← STALE INDEX
+      (then (throw $tag$0 (global.get $gimport$3))))
+    (if (ref.is_null (local.tee $2 ( … struct.get $0 0 (local.get $0) … )))
+      (then (throw $tag$0 (global.get $gimport$3))))
+    (local.get $scratch))
+  (local.get $2))                       ;; funcref
+```
+
+The `global.get` inside that arg-block was emitted as `global.get <f's
+global>` (= `global$0`, the closure), but a string-constant import (the
+"Cannot access property on null or undefined" message → `gimport$3`) was added
+**late**, shifting the import-global indices. The late-import global-index
+shifter (`shiftLateImportIndices` / `fixupModuleGlobalIndices`, which walks
+`ctx.currentFunc.body` + `fctx.savedBodies` only) did **not** visit this
+arg-block's body, so its `global.get` index stayed stale and now points at
+`gimport$3` instead of `global$0`. Then `ref.cast (ref null $0)` of that
+garbage value traps `illegal cast`. This is exactly the bug class the `#1395`
+comment at `calls.ts:~10079` describes and partially fixed for ONE arm — the
+direct module-const-arrow arg-block arm is NOT covered.
+
+**Fix direction:** ensure the call_ref argument-block body for this dispatch
+arm is tracked in `fctx.savedBodies` (or otherwise visited by the late-import
+global-index shifter) — mirror the `#1395` `pushBody`/`savedBodies` pattern
+at `calls.ts:10094`. Find which arm builds the `(block (result T))` 2nd
+operand for the direct-identifier closure call and confirm its body is in
+`savedBodies` before late imports are added. Why `const g = f; g(21)` works:
+the intermediate-local store does NOT build a separate arg-block re-resolving
+the callee — it loads `global$0` into a local once, in the OUTER body, which
+the shifter does visit.
+
+Verify with `tests/equivalence/async-function.test.ts` (un-skip the #1729/#1730
+case) + the sync `f(21)→42` case, and watch the equivalence shards for any
+late-import-heavy function regressing.
+
 ## Repro / acceptance
 
 - `const f = (x:number):number => x*2; main(){ return f(21); }` → 42 (no trap).

--- a/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
+++ b/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
@@ -47,6 +47,32 @@ inline arrow / passed-as-arg paths, which work). Lives in `src/codegen/closures.
 closure call_ref dispatch (the `ref.cast typeIdx structTypeIdx` at the call
 site, see closures.ts ~1699 / dispatch ref.cast), not in the async wrap.
 
+## Further narrowing (senior-dev, 2026-05-30)
+
+Reproduced the trap and bisected the two call shapes:
+
+- **`f(21)` (direct call)** → TRAPS `illegal cast`.
+- **`const g = f; g(21)` (via intermediate local)** → WORKS (returns 42).
+
+The intermediate-local path loads the callee correctly:
+`local.set $0 (extern.convert_any (global.get $global$0))` — `global$0` holds
+the closure struct `(struct.new $0 (ref.func $__closure))`.
+
+The direct-call path instead emits, inside the `call_ref` argument region, a
+self re-resolution that **casts the wrong global**:
+`ref.cast (ref null $0) (any.convert_extern (global.get $gimport$3))` where
+`gimport$3` is the imported `"TypeError: Cannot access property…"` message
+string global — the direct-call self-load grabs a garbage global instead of
+`global$0`, then `ref.cast` to the closure struct type traps.
+
+So the defect is in the **direct `Identifier(args)` dispatch for a
+module-`const`-bound arrow** (`src/codegen/expressions/calls.ts`): the
+closure-self/receiver load resolves the callee from the wrong global rather
+than `ctx.moduleGlobals.get("f")` (`global$0`). The wrapper-types branch at
+~7996 (`compileExpression(expr.expression)` → `any.convert_extern` →
+`emitGuardedRefCast` → saved to a local) is the *correct* shape — the failing
+path is a *different* arm that loads self from a sentinel.
+
 ## Repro / acceptance
 
 - `const f = (x:number):number => x*2; main(){ return f(21); }` → 42 (no trap).

--- a/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
+++ b/plan/issues/1730-module-const-arrow-internal-call-illegal-cast.md
@@ -1,9 +1,10 @@
 ---
 id: 1730
 title: "internal call to a module-level `const` arrow traps with illegal cast"
-status: ready
+status: done
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-30
+completed: 2026-05-30
 priority: medium
 task_type: bugfix
 area: codegen
@@ -186,3 +187,49 @@ avoids a double-shift risk from a wrong savedBodies registration.
 Status: handed back — sdev-vm pivoted to the #1584 VM op-family dispatch (higher
 priority; sdev-emitter2's families landing). No code change committed; the
 refined root-cause + WAT above is the resume point.
+
+## FIXED (senior-dev sdev-cpr2, 2026-05-30, branch issue-1730-const-arrow)
+
+The trapping site is `compileClosureCall` in
+`src/codegen/expressions/calls-closures.ts` (NOT the `emitCachedFuncClosureAccess`
+cache path, NOT the `calls.ts` callable-param ladder). For a module-`const`-bound
+arrow whose `__mod_<name>` global stores a **typed closure ref** (`(ref null
+$struct)`, not externref), `effectiveLocalIdx` stays undefined, so the inner
+`pushClosureRef` helper emits `global.get moduleIdx` directly. `pushClosureRef`
+is called **twice** — once for the receiver/self (before args) and once for the
+funcref re-resolution (after args).
+
+`moduleIdx` was captured **once** as a `const` at function entry
+(`calls-closures.ts:34`). While the call arguments compile (between the two
+pushes), a late string-constant import is added — for this repro the function
+name `f` itself becomes a `string_constants` import — which runs
+`fixupModuleGlobalIndices` (`registry/imports.ts:129`). That shifter:
+- bumps every module-global index by +1, INCLUDING rewriting the
+  already-emitted receiver `global.get` in `fctx.body` (3→4 ✓), and
+- updates the `ctx.moduleGlobals` map (3→4 ✓).
+
+But the **second** `pushClosureRef` then emits a NEW `global.get` using the
+**stale captured `const moduleIdx`** (still 3), AFTER the shift already ran, so
+the shifter never visits it. Index 3 now points at the late string-constant
+import global (an externref), and the subsequent funcref-extract / `ref.cast`
+of that value to the closure struct traps `illegal cast`. WAT confirmed:
+pre-fix the funcref-resolution `global.get 3` vs the receiver `global.get 4`;
+post-fix both are `global.get 4`.
+
+`g = f; g(21)` works because the intermediate-local store loads `__mod_f` into
+an outer-body local once (which the shifter does visit), so the call dispatches
+through the local — never re-resolving the global a second time post-shift.
+
+**Fix (the safer of the two directions above, generalized):** re-read
+`ctx.moduleGlobals.get(varName)` on **every** `pushClosureRef` instead of reusing
+the captured `const moduleIdx` (`?? moduleIdx!` as a fallback for the rare case
+the name left the map). One-site change; reads the live, already-shifted map so
+the index is always current. No new savedBodies registration → no double-shift
+risk.
+
+**Verified:** `const f=(x:number):number=>x*2; main(){return f(21)}` → 42 (was
+trap); async variant `const double = async (x)=>x*2; main(){return double(21)}`
+→ 42 (the originally-skipped `tests/equivalence/async-function.test.ts` case,
+now un-skipped); two distinct module-const arrows + multi-call cases → correct;
+`g=f; g(21)` control still 42. Regression test `tests/issue-1730.test.ts`
+(5 cases). Full `tests/equivalence/` suite + tsc clean.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -89,7 +89,23 @@ export function compileClosureCall(
     if (effectiveLocalIdx !== undefined) {
       fctx.body.push({ op: "local.get", index: effectiveLocalIdx });
     } else {
-      fctx.body.push({ op: "global.get", index: moduleIdx! });
+      // (#1730) Re-resolve the module-global index from `ctx.moduleGlobals` on
+      // every push instead of reusing the `const moduleIdx` captured at entry.
+      // A late string-constant import added while compiling the call arguments
+      // (between the receiver push at the top and this funcref-re-resolution
+      // push) shifts every module-global index by +1 and rewrites the
+      // ALREADY-EMITTED `global.get` in `fctx.body` via `fixupModuleGlobalIndices`
+      // (which also updates the `ctx.moduleGlobals` map). The stale captured
+      // `moduleIdx` would emit a NEW `global.get` with the pre-shift index
+      // AFTER the shift already ran, so the shifter never visits it — the
+      // index then points at the late-added string-constant import global and
+      // `ref.cast` of that externref to the closure struct traps "illegal cast"
+      // (a module-level `const`-bound arrow called internally, #1730). Reading
+      // the live map mirrors why `g = f; g(21)` works: the intermediate-local
+      // path resolves through a local whose load lands in the outer body the
+      // shifter does visit.
+      const liveModuleIdx = ctx.moduleGlobals.get(varName) ?? moduleIdx!;
+      fctx.body.push({ op: "global.get", index: liveModuleIdx });
     }
     // Null-check → TypeError instead of trap on struct.get (#728, #441)
     emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: info.structTypeIdx });

--- a/tests/equivalence/async-function.test.ts
+++ b/tests/equivalence/async-function.test.ts
@@ -74,12 +74,15 @@ describe("Async function support (synchronous compilation)", () => {
     expect(exports.main()).toBe(30);
   });
 
-  // #1729: calling a module-level `const` arrow internally traps with "illegal
-  // cast" at the closure dispatch site — independent of async (a SYNC
-  // `const f = (x:number):number => x*2; main(){ return f(21); }` traps the
-  // same way). NOT a #1727 Promise-wrap issue (the #1727 fix correctly skips
-  // the wrap here; the value path is fine). Tracked separately in #1729.
-  it.skip("async arrow function (#1729 module-const-arrow dispatch)", async () => {
+  // #1730: calling a module-level `const` arrow internally USED to trap with
+  // "illegal cast" at the closure dispatch site — independent of async (a SYNC
+  // `const f = (x:number):number => x*2; main(){ return f(21); }` trapped the
+  // same way). Root cause: a late string-constant import added while compiling
+  // the call arguments shifted every module-global index, but the funcref
+  // re-resolution in `compileClosureCall` reused a stale captured `moduleIdx`,
+  // emitting `global.get <pre-shift>` that pointed at the late import global.
+  // Fixed by re-reading `ctx.moduleGlobals` on each closure-ref push.
+  it("async arrow function (#1730 module-const-arrow dispatch)", async () => {
     const src = `
       const double = async (x: number): Promise<number> => x * 2;
       export function main(): number {

--- a/tests/issue-1730.test.ts
+++ b/tests/issue-1730.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #1730 — calling a module-level `const`-bound arrow internally (wasm `call_ref`
+// dispatch, not the export boundary) used to trap with "illegal cast". A late
+// string-constant import added while compiling the call arguments shifted every
+// module-global index, but the funcref re-resolution in `compileClosureCall`
+// reused a stale captured `moduleIdx`, emitting a `global.get` that pointed at
+// the late import global instead of the closure's `__mod_<name>`. The cast of
+// that string externref to the closure struct trapped. Fixed by re-reading
+// `ctx.moduleGlobals` on each closure-ref push.
+describe("#1730 module-level const arrow internal call", () => {
+  it("direct call to a sync module-const arrow returns the right value", async () => {
+    const src = `
+      const f = (x: number): number => x * 2;
+      export function main(): number { return f(21); }
+    `;
+    const exports = await compileToWasm(src);
+    expect(exports.main()).toBe(42);
+  });
+
+  it("intermediate-local alias still works (regression control)", async () => {
+    const src = `
+      const f = (x: number): number => x * 2;
+      export function main(): number { const g = f; return g(21); }
+    `;
+    const exports = await compileToWasm(src);
+    expect(exports.main()).toBe(42);
+  });
+
+  it("async module-const arrow called internally returns the awaited value", async () => {
+    const src = `
+      const double = async (x: number): Promise<number> => x * 2;
+      export function main(): number { return double(21) as any as number; }
+    `;
+    const exports = await compileToWasm(src);
+    expect(exports.main()).toBe(42);
+  });
+
+  it("two distinct module-const arrows called internally", async () => {
+    const src = `
+      const f = (x: number): number => x * 2;
+      const g = (x: number): number => x + 100;
+      export function main(): number { return f(21) + g(0); }
+    `;
+    const exports = await compileToWasm(src);
+    expect(exports.main()).toBe(142);
+  });
+
+  it("module-const arrow called more than once", async () => {
+    const src = `
+      const f = (x: number): number => x * 2;
+      export function main(): number { return f(10) + f(11); }
+    `;
+    const exports = await compileToWasm(src);
+    expect(exports.main()).toBe(42);
+  });
+});


### PR DESCRIPTION
Rescued from sdev-cpr2 (fix done + locally verified, agent stalled on a throttle before opening the PR).

**Root cause:** `compileClosureCall` reused a stale `moduleIdx` for the funcref re-resolution after a late string-constant import shifted import-global indices; the shifter (`fixupModuleGlobalIndices`) never revisited the freshly-emitted `global.get`, so it pointed at the wrong global → illegal cast.

**Fix:** re-read `ctx.moduleGlobals` on each closure-ref push (one-line) so the index is post-shift correct. `f(21)`→42, async variant→42 (equivalence case un-skipped), control `g=f;g(21)` still 42, +scoped regression test. CI runs the full equivalence suite as the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)