### PR TITLE
po: file #1751 (WIT generator incompleteness) + #1752 (TextEncoder) from GH #389

### DIFF
--- a/plan/issues/1751-wit-generator-incomplete-world-package-imports.md
+++ b/plan/issues/1751-wit-generator-incomplete-world-package-imports.md
@@ -1,0 +1,76 @@
+---
+id: 1751
+title: "WIT generator emits an incomplete world: hardcoded package name + no WASI imports"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: medium
+feasibility: medium
+task_type: feature
+area: wit-generator
+goal: platform
+related: [600, 639, 389]
+depends_on: []
+sprint: Backlog
+---
+
+# #1751 — WIT generator emits an incomplete world
+
+## Context
+
+Reported by an external contributor on GitHub #389 (native-messaging host).
+Compiling `nm_typescript.ts` with `--wit` produces:
+
+```wit
+package local:module;
+
+world module {
+  export main: func();
+}
+```
+
+Compared to what `wasm-tools component wit` extracts for the equivalent
+AssemblyScript / Javy components
+([nm_assemblyscript_component.wit](https://github.com/guest271314/native-messaging-webassembly/blob/main/nm_assemblyscript_component.wit),
+[nm_javy_component.wit](https://github.com/guest271314/native-messaging-webassembly/blob/main/nm_javy_component.wit)),
+which carry a meaningful package name and the full import/export surface, our
+output is thin.
+
+`#600` (done) added WIT generation from TS types; this issue tracks the
+**completeness gaps** in that output. `export main: func()` is actually
+*correct* (in the native-messaging host, `main` is the only exported function;
+`getMessage`/`sendMessage` are internal) — the real gaps are:
+
+## Gaps
+
+1. **Hardcoded package name.** `WitGeneratorOptions.packageName` defaults to
+   `"local:module"` and there's no CLI way to set it. Real components name the
+   package (e.g. `native-messaging-host:native-messaging-javy`). Add a
+   `--wit-package <ns:name[@version]>` flag and/or derive a sensible default
+   from the output filename instead of the literal `local:module`.
+   (`src/wit-generator.ts` ~line 25 / 90.)
+
+2. **No `import` side.** The generated `world` lists only `export`s. A WASI
+   target module actually *imports* host interfaces (`wasi:cli`, `wasi:io`,
+   `fd_write`/`fd_read`/`proc_exit`, plus any `__*` host imports). A faithful
+   WIT world should declare those imports so the file reflects the module's
+   real interface and round-trips against `wasm-tools`. Emit the import surface
+   the compiled module declares (the same set `index.ts` adds for the target).
+
+3. **(stretch) Round-trip parity check.** Add a test that compiles a small
+   program with `--wit`, builds the component, and asserts our emitted WIT
+   matches (modulo formatting) what `wasm-tools component wit` extracts.
+
+## Out of scope
+
+- Wrapping the core module into an actual deployable Component (canonical ABI
+  adapter) — that's **#639**.
+- String-encoding boundary selection — **#1650**.
+
+## Acceptance
+
+- `--wit-package` (or filename-derived default) replaces the literal
+  `local:module`.
+- The emitted `world` includes the module's `import`s, not just exports.
+- A regression test covers the native-messaging host shape (`export main` +
+  WASI imports) and ideally a `wasm-tools` round-trip.

--- a/plan/issues/1752-textencoder-textdecoder-runtime-api.md
+++ b/plan/issues/1752-textencoder-textdecoder-runtime-api.md
@@ -1,0 +1,59 @@
+---
+id: 1752
+title: "TextEncoder / TextDecoder runtime API (standalone + WASI)"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: medium
+feasibility: medium
+task_type: feature
+area: runtime
+language_feature: web-api
+goal: platform
+related: [389, 1588, 1655]
+depends_on: []
+sprint: Backlog
+---
+
+# #1752 — TextEncoder / TextDecoder runtime API
+
+## Context
+
+Surfaced on GitHub #389 (native-messaging host). The contributor's host wants
+an `encodeMessage` helper:
+
+```ts
+const encoder: TextEncoder = new TextEncoder();
+function encodeMessage(message: object): Uint8Array {
+  return encoder.encode(JSON.stringify(message));
+}
+```
+
+so the host can **produce** messages (host → client) rather than only echo back
+bytes it received. We don't expose `TextEncoder` / `TextDecoder` yet, so this
+pattern doesn't compile in standalone / WASI mode.
+
+## Scope
+
+Implement the WHATWG Encoding API surface the native-messaging use-case needs,
+Wasm-native (no JS host dependency) so it works under `--target wasi`:
+
+- `new TextEncoder()` + `encoder.encode(string): Uint8Array` — UTF-8 encode.
+- `encoder.encodeInto(string, Uint8Array): {read, written}` (stretch).
+- `new TextDecoder([label])` + `decoder.decode(BufferSource): string` — UTF-8
+  decode (at least `utf-8`; label validation can be minimal).
+
+This builds directly on **#1588** (UTF-8/WTF-16 string-encoding tracking) and
+its `__str_to_utf8` transcoder primitive (ADR-0015) — `TextEncoder.encode` is
+essentially that transcoder behind the standard API, and `TextDecoder.decode`
+is its inverse. Pairs with #1655 (WASI `process.stdout.write(Uint8Array|ArrayBuffer)`).
+
+## Acceptance
+
+- `new TextEncoder().encode(str)` returns a correct UTF-8 `Uint8Array` (incl.
+  multi-byte + surrogate-pair code points) in standalone + WASI modes.
+- `new TextDecoder().decode(bytes)` round-trips encode→decode.
+- Mirrors the standard Web/Node API exactly (no bespoke builtin), per the
+  "mimic standard APIs" rule.
+- Regression test covering ASCII, multi-byte (é, 你, 😀), and round-trip;
+  ideally compiles the #389 `encodeMessage` shape.

--- a/plan/issues/1753-native-messaging-64mib-chunked-streaming.md
+++ b/plan/issues/1753-native-messaging-64mib-chunked-streaming.md
@@ -1,0 +1,52 @@
+---
+id: 1753
+title: "Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming"
+status: ready
+created: 2026-05-30
+updated: 2026-05-30
+priority: medium
+feasibility: medium
+task_type: feature
+area: examples
+goal: platform
+related: [389, 1655, 1700, 1752]
+depends_on: []
+sprint: Backlog
+---
+
+# #1753 — Native-messaging host: 64 MiB chunked streaming
+
+## Context
+
+Follow-up from GitHub #389 (native-messaging host). The 1 MiB null-corruption
+bug is fixed (#945) and the host is now `Uint8Array`-native end-to-end
+(`getMessage`/`sendMessage`/`main`). The remaining piece the contributor asked
+for is the **large-payload** path: Chrome Native Messaging caps a single message
+the **extension** sends at ~1 MiB, but a **host** may send up to 64 MiB — and a
+large response must be delivered as a sequence of ≤1 MiB framed messages.
+
+The byte-native loop makes this straightforward: it's a chunking layer on top of
+the existing frame writer, not new compiler work.
+
+## Scope
+
+- **Write path:** `sendMessage` (or a `sendLarge`/streaming helper) splits a body
+  >1 MiB into ≤1 MiB framed chunks (each with its own 4-byte LE length header),
+  written back-to-back; the extension reassembles.
+- **Read path:** the host reads and concatenates successive framed messages up to
+  the 64 MiB ceiling (guard against runaway sizes).
+- Stays `Uint8Array`/`ArrayBuffer`-native (no lossy string round-trip), building
+  on #1655 (`process.stdout.write(Uint8Array|ArrayBuffer)`).
+
+## Acceptance
+
+- A 64 MiB payload round-trips host↔client as ≤1 MiB chunks, byte-exact.
+- Memory stays bounded (chunked, not a single 64 MiB linear-memory staging
+  region) — verify no OOB/`memory.grow` blow-up like the original 1 MiB bug.
+- Regression test at the chunk boundary (exactly 1 MiB, 1 MiB+1) and at 64 MiB.
+
+## Notes
+
+This is an **example/protocol** completeness item, not a conformance fix. The
+#389 thread stays open as the public feedback channel; this issue is internal
+tracking so the large-payload work doesn't get lost.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -123,3 +123,4 @@ fidelity → #1463) were NOT re-filed.
 
 - [#1751](../1751-wit-generator-incomplete-world-package-imports.md) — WIT generator emits an incomplete world: hardcoded `local:module` package + no `import` side (vs `wasm-tools`-extracted component WIT) — medium, medium, **ready**
 - [#1752](../1752-textencoder-textdecoder-runtime-api.md) — `TextEncoder`/`TextDecoder` runtime API (UTF-8, standalone + WASI; builds on #1588) — medium, medium, **ready**
+- [#1753](../1753-native-messaging-64mib-chunked-streaming.md) — Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming (on the byte-native loop; builds on #1655) — medium, medium, **ready**

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -118,3 +118,8 @@ fidelity → #1463) were NOT re-filed.
 - [#1721](../1721-es3-subclass-function-object-instanceof.md) — ES3 (residual of #1455): `class extends Function`/`extends Object` instanceof returns false (4 fails) — medium, medium, **ready (sprint 57)**
 - [#1722](../1722-es3-assignmenttargettype-early-syntaxerror.md) — ES3: AssignmentTargetType early SyntaxError not raised (yield/arrow as assignment target, 4 fails) — low, medium, **ready (sprint 57)**
 - [#1511](../1511-spec-gap-arguments-object-mapped-and-trailing-comma.md) — **MOVED to sprint 57** (was sprint 52): arguments object mapped semantics / descriptors / trailing-comma length — covers the ES3 mapped-arguments cluster (~19 edition-0 fails) — high, medium, **review**
+
+### Platform / Component Model & runtime (from GitHub #389)
+
+- [#1751](../1751-wit-generator-incomplete-world-package-imports.md) — WIT generator emits an incomplete world: hardcoded `local:module` package + no `import` side (vs `wasm-tools`-extracted component WIT) — medium, medium, **ready**
+- [#1752](../1752-textencoder-textdecoder-runtime-api.md) — `TextEncoder`/`TextDecoder` runtime API (UTF-8, standalone + WASI; builds on #1588) — medium, medium, **ready**


### PR DESCRIPTION
Two platform issues triaged from external contributor feedback on GitHub #389 (native-messaging host):

- **#1751** — `--wit` emits an incomplete world: hardcoded `local:module` package name + no `import` side, vs the `wasm-tools`-extracted component WIT. (`export main` itself is correct — `main` is the only export.) Gaps: package naming (`--wit-package`/derived) + emitting the module's WASI imports. Distinct from #639 (canonical-ABI adapter).
- **#1752** — `TextEncoder`/`TextDecoder` runtime API (UTF-8, standalone + WASI), so host-side `encodeMessage()` compiles. Builds on #1588's transcoder.

Plan-only (issue files + backlog). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)