### PR TITLE
docs: frame js2wasm as an open foundation, not a commercial product

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -4,11 +4,10 @@ By contributing to `js2wasm`, you represent that you have the legal right to sub
 
 You grant **Loopdive GmbH** an irrevocable, worldwide, perpetual, sublicensable license to use, reproduce, modify, distribute, relicense, and otherwise exploit your contribution under any license terms.
 
-This includes use in:
+This grant exists so the project can be stewarded sustainably over the long term. It includes use in:
 
-- the Apache 2.0 with LLVM Exceptions community distribution
-- commercial licenses
-- proprietary partner integrations
-- private forks and negotiated infrastructure agreements
+- the Apache 2.0 with LLVM Exceptions distribution under which the project is released
+- future relicensing should open-source license standards evolve
+- whatever arrangements are needed to keep the project maintained and funded long-term
 
 If you do not agree to these terms, do not contribute to this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to js2wasm
 
-`js2wasm` is developed as the core compiler product of **Loopdive GmbH**. This guide covers the technical workflow and the contributor licensing terms required for accepted contributions.
+`js2wasm` is an open-source project stewarded by **Loopdive GmbH** — a technical foundation for the next generation of the internet, developed fully in the open. This guide covers the technical workflow and the contributor licensing terms required for accepted contributions.
 
 ## Development Setup
 
@@ -85,7 +85,7 @@ By contributing code, documentation, tests, or other material to this repository
 
 If you do not agree to these terms, do not submit a contribution.
 
-This CLA requirement exists so the project can maintain an Apache 2.0 with LLVM Exceptions community distribution while also supporting commercial and proprietary licensing arrangements for infrastructure partners.
+This CLA exists so Loopdive GmbH can sustainably steward the project over the long term — keeping it maintained, funded, and relicensable should open-source license standards evolve — while the source is distributed under the Apache 2.0 with LLVM Exceptions license.
 
 ### How acceptance is recorded (the `cla-check` gate)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC.
 
 `js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That avoids the runtime tax common in the interpreter-based and engine-embedding approaches — where a JavaScript interpreter or full engine is compiled to Wasm and shipped inside every module — and keeps the output aligned with Wasm-native deployment models.
 
-`js2wasm` is the core compiler product of **Loopdive GmbH**, released under **Apache License 2.0 with LLVM Exceptions** — and developed fully in the open, including its agentic engineering workflow. The repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.
+`js2wasm` is a free and open-source project developed by **Loopdive GmbH** and released under the **Apache License 2.0 with LLVM Exceptions**. It is a freely-licensed, open-source technical foundation and reusable building block, developed fully in the open, including its agentic engineering workflow. The repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.
 
 ## Value Proposition
 
@@ -395,24 +395,8 @@ The document is intended for senior engineers who are skeptical but curious. It 
 
 This repository is licensed under the **Apache License 2.0 with LLVM Exceptions**. See [LICENSE](./LICENSE).
 
-### Community License
-
 - Source code in this repository is available under **Apache-2.0 WITH LLVM-exception**
 - Community contributions are accepted under the contributor terms described in [CONTRIBUTING.md](./CONTRIBUTING.md)
-
-### Commercial Licensing
-
-Loopdive GmbH offers commercial licensing discussions for infrastructure partners that need:
-
-- proprietary integrations
-- closed-source redistribution rights
-- dedicated support or integration work
-- custom backends or hardware-accelerated targets
-- private deployment arrangements for platform partnerships
-
-This is the intended path for infrastructure vendors and strategic partners, including cloud, edge, browser, and silicon platform organizations evaluating deeper integration.
-
-Contact: `hello@loopdive.com`
 
 ## Testing
 

--- a/plan/log/progress/2026-03-18-strategy.md
+++ b/plan/log/progress/2026-03-18-strategy.md
@@ -1,5 +1,12 @@
 # Project Strategy — 2026-03-18
 
+> **Superseded (2026-05-31).** The commercial-revenue framing below (commercial
+> licenses, enterprise tiers, hosted compile API) reflects early exploratory
+> thinking and no longer represents the project's direction. js2wasm is a
+> fully-open technical foundation for the next-generation internet, deliberately
+> not run as a commercial product; all source is released under Apache 2.0 with
+> LLVM Exceptions. Retained as historical record only.
+
 ## Current state
 
 - **490 issues completed** in 8 days (613 commits)


### PR DESCRIPTION
## What

Reframes js2wasm's public-facing docs from "the core compiler product of Loopdive GmbH" to a fully-open technical foundation for the next-generation internet, released under Apache-2.0 WITH LLVM-exception.

- **README.md** — intro + license section: drop "core compiler product" and all commercial-product framing; state open-source / Apache-2.0.
- **CONTRIBUTING.md** — line 3 reframed to "open-source project stewarded by Loopdive GmbH"; CLA rationale (line 88) reframed around sustainable stewardship instead of "commercial and proprietary licensing arrangements for infrastructure partners."
- **CLA.md** — neutralized the commercial/proprietary *purpose examples* while **keeping the legal grant broad** (relicensing 'under any license terms') to preserve long-term funding/maintenance optionality.
- **plan/log/progress/2026-03-18-strategy.md** — added a dated "Superseded" banner marking the early commercial-revenue thinking as historical.

## Why

Openness is the adoption strategy for shared internet infrastructure, not a sacrifice — a commercial/proprietary compiler in this niche would not be adopted by industry, runtimes, or standards bodies. The docs now match that reality. The CLA's legal optionality is intentionally retained for sustainability.

Doc-only change; no code or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)