### PR TITLE
chore(devcontainer): install wasmtime v44 (arch-aware) + xz-utils

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zsh \
   man-db \
   unzip \
+  xz-utils \
   gnupg2 \
   gh \
   iptables \
@@ -67,6 +68,25 @@ RUN ARCH=$(dpkg --print-architecture) && \
   wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
   sudo dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
   rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# wasmtime CLI — runs the warm-runtime perf benchmarks (#1580/#1746) that
+# refresh the committed landing-page benchmark JSON, and the native-messaging
+# smoke test. Pinned to v44 to match CI
+# (.github/workflows/native-messaging-smoke.yml); do NOT switch to
+# --all-proposals (v44 rejects stack-switching). Arch-aware: amd64->x86_64,
+# arm64->aarch64.
+ARG WASMTIME_VERSION=v44.0.0
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in \
+    amd64) WT_ARCH=x86_64 ;; \
+    arm64) WT_ARCH=aarch64 ;; \
+    *) echo "unsupported arch: $ARCH" && exit 1 ;; \
+  esac && \
+  WT_DIR="wasmtime-${WASMTIME_VERSION}-${WT_ARCH}-linux" && \
+  wget -O- "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${WT_DIR}.tar.xz" | tar xJ && \
+  mv "${WT_DIR}/wasmtime" /usr/local/bin/wasmtime && \
+  rm -rf "${WT_DIR}" && \
+  /usr/local/bin/wasmtime --version
 
 COPY .tmux.conf /home/node/.tmux.conf
 RUN chown node:node /home/node/.tmux.conf


### PR DESCRIPTION
Adds the `wasmtime` CLI to the devcontainer image so the warm-runtime perf benchmarks (#1580/#1746) that refresh the committed landing-page benchmark JSON can run in-container. Without it, the string-hash perf win (PR #990) is stuck as a draft because the warm-ms number can't be regenerated locally.

- Pinned to **v44.0.0**, matching CI (`.github/workflows/native-messaging-smoke.yml`). v44 supports the GC / function-references / tail-call / exceptions proposals our modules use; do **not** switch to `--all-proposals` (v44 rejects stack-switching).
- **Arch-aware** (`amd64`→`x86_64`, `arm64`→`aarch64`) so it builds on both CI (x86_64) and Apple-Silicon dev containers (aarch64).
- Adds `xz-utils` for the `.tar.xz` tarball.
- **Verified live** on this aarch64 container: `wasmtime 44.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)