### PR TITLE
fix: ES edition support table — stack checkmark / % / host label without overlap

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1275,7 +1275,16 @@
       .feat-row:hover .feat-name {
         color: #fff;
       }
+      /* The `host` label sits directly under the badge glyph in grid
+         column 1. It used to be `position: absolute` (left/top hard-coded),
+         which reserved no flow space and spilled past its row — overlapping
+         the next row's badge and the adjacent edition header's pass `%`.
+         Placing it as an in-flow grid item in column 1, row 2 makes the row
+         grow to contain badge + label so the ✓ / % / host stack cleanly. */
       .feat-host {
+        grid-column: 1;
+        grid-row: 2;
+        justify-self: center;
         font-family: var(--mono);
         font-size: 8px;
         font-weight: 600;
@@ -1283,12 +1292,18 @@
         color: inherit;
         background: none;
         padding: 0;
-        position: absolute;
-        left: 39px;
-        top: 34px;
-        transform: translateX(-50%);
-        line-height: 1.6;
+        margin-top: 2px;
+        line-height: 1.4;
+        text-align: center;
         white-space: nowrap;
+      }
+      /* Anchor the badge to row 1 of column 1 so the host label lands on the
+         row below it (not beside the feature name). Harmless on rows without
+         a host label (they only occupy row 1 of column 1 anyway), so no
+         `:has()` scoping is needed. */
+      .feat-badge {
+        grid-column: 1;
+        grid-row: 1;
       }
       .feat-badge.full + .feat-host {
         color: #4ade80;
@@ -1447,7 +1462,7 @@
           <h1
             id="hero-title"
             data-texts='["An ahead-of-time JavaScript compiler.", "Compile JavaScript without embedding a JS engine.",
-            "JavaScript compiled ahead of time, for fast cold starts and speed.", "Reduce supply chain attack surface with module sandboxing.", "Target existing Javascript code, not a new language."]'
+            "Tiny modules that start and run fast.", "Reduce supply chain attack surface with module sandboxing.", "Target existing Javascript code, not a new language."]'
           >
             <span class="hero-title-shell">
               <span class="hero-title-measure" aria-hidden="true"></span>


### PR DESCRIPTION
## Problem

In the **ES edition feature-support table** on the landing page
(`website/index.html`), the per-row **host** label overlapped the
adjacent content: it sat on top of the next row's `✓`/`⚠` badge and the
adjacent edition header's pass **percentage** (`.feat-edition-passbar-text`).

## Root cause

`.feat-host` was absolutely positioned inside the (relatively-positioned)
`.feat-row`:

```css
.feat-host {
  position: absolute;
  left: 39px;
  top: 34px;
  transform: translateX(-50%);
}
```

`top: 34px` placed the ~13px-tall label at y∈[34,47] within a row whose
own content box is only ~43px tall, so its bottom spilled ~4px past the
row into the following row's badge, and — for the first host-row under an
edition header — collided with the header's pass `%` (header has only a
6px bottom margin and the absolute label reserves **zero** flow space).

## Fix (layout only — no data/label changes)

Stop absolutely-positioning `.feat-host`. Make it an **in-flow grid item
in column 1, row 2**, directly under the badge glyph; pin `.feat-badge`
to **column 1, row 1**. The `.feat-row` grid track now grows to contain
both, so the `✓` checkmark, the pass `%` (`.feat-badge-pct`, already a
flex-column child of the badge), and the `host` label form a clean
vertical stack and never overlap.

```css
.feat-host {
  grid-column: 1;
  grid-row: 2;
  justify-self: center;
  /* ...font unchanged... */
  margin-top: 2px;
  line-height: 1.4;
  text-align: center;
  white-space: nowrap;
}
.feat-badge { grid-column: 1; grid-row: 1; }
```

### Responsive

The grid template (`30px 1fr 24px`) and the `.feat-row`/`.feat-host`/
`.feat-badge` rules are **constant across breakpoints** — no `@media`
block overrides them (the only feat-table media rule at `max-width:980px`
touches `.feat-panel` columns and `<pre>` wrapping). So mobile (≤414px)
is unaffected by this change; column 1 stacks the same way at every width.

### No build step needed

`website/index.html` is itself the served/deployed landing page (see the
`deploy:registry-home` script, which copies `website/index.html`
verbatim). The static feat rows are hand-authored in this file;
`scripts/generate-editions.ts` only writes JSON edition data and never
rewrites the `.feat-host` markup. So the source edit is the artifact —
nothing to regenerate.

## Also (bundled per tech-lead request, same file to avoid racing two PRs on `index.html`)

Swapped one rotating hero tagline:
`"JavaScript compiled ahead of time, for fast cold starts and speed."`
→ `"Tiny modules that start and run fast."` (same JSON-array element
structure/quoting as its siblings; trailing period kept).

## Visual verification

⚠️ **Could not render a screenshot in this container.** Playwright 1.60.0
+ chromium are installed, but chromium fails to launch — its required
system libraries (`libnss3`, `libnspr4`, `libgbm.so.1`, `libasound2`,
`libatk-1.0`, `libxkbcommon`, …) are absent from the container and
require root (`apt-get`) to install, which this environment does not
grant. I verified the fix by direct CSS/grid geometry analysis (above)
rather than a rendered before/after. The change is layout-only and
reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)