### PR TITLE
fix: await async compile() in non-test callers missed by #992 (dogfood harness + scripts)

### DIFF
--- a/benchmarks/cold-start/run-cold-start.mjs
+++ b/benchmarks/cold-start/run-cold-start.mjs
@@ -78,7 +78,7 @@ for (const pf of programFiles) {
 import { compile } from '${resolve(ROOT, "src/index.ts").replace(/\\/g, "/")}';
 import { readFileSync, writeFileSync } from 'fs';
 const src = readFileSync('${srcPath.replace(/\\/g, "/")}', 'utf8');
-const r = compile(src, { fileName: '${pf}' });
+const r = await compile(src, { fileName: '${pf}' });
 if (!r.success) {
   console.error('Compile failed:', r.errors?.[0]?.message);
   process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export interface CompileResult {
    * into a single object the caller passes directly:
    *
    * ```js
-   * const r = compile(src);
+   * const r = await compile(src);
    * const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
    * ```
    *
@@ -247,7 +247,7 @@ import { buildImports as buildImportsRuntime } from "./runtime.js";
  *
  * @example
  * ```ts
- * const result = compile(`
+ * const result = await compile(`
  *   export function add(a: number, b: number): number {
  *     return a + b;
  *   }
@@ -325,7 +325,7 @@ export async function compileMulti(
  * @example
  * ```ts
  * // Given: src/main.ts imports from src/utils.ts
- * const result = compileFiles("src/main.ts");
+ * const result = await compileFiles("src/main.ts");
  * // TypeScript resolves src/utils.ts automatically
  * ```
  */

--- a/tests/dogfood/acorn-harness.mjs
+++ b/tests/dogfood/acorn-harness.mjs
@@ -101,7 +101,7 @@ export async function runHarness({ quiet = false } = {}) {
   let result;
   let threw = null;
   try {
-    result = compile(acornSource, { fileName: "acorn.mjs" });
+    result = await compile(acornSource, { fileName: "acorn.mjs" });
   } catch (e) {
     threw = e instanceof Error ? `${e.message}` : String(e);
   }


### PR DESCRIPTION
## Problem

#992 (the #1757 async-compile migration) made `compile()` / `compileSource()` / `compileMulti()` / `compileFiles()` / `compileToWat()` async (they now return Promises). Its ts-morph codemod only rewrote `tests/**/*.test.ts` callers to `await`. It missed non-`.test.ts` consumers, which silently get a Promise where they expect a result.

## Fixes (caller-side `await` plumbing only — no compiler semantics changed)

- **`tests/dogfood/acorn-harness.mjs`** (confirmed breakage): the COMPILE stage called `compile(acornSource, {fileName})` synchronously and read `result.success` / `result.binary` off the unresolved Promise → `success=undefined`, `binary=0 bytes`. The harness reported "compiled, but binary INVALID / compile reported failure" for acorn even though acorn compiles fine in JS-host mode. This was a **false-negative dogfood gate**. Now `await`s the Promise (the enclosing `runHarness` is already `async`), so stages 2–5 run again.
- **`benchmarks/cold-start/run-cold-start.mjs`**: the generated per-program compile script read `r.success` / `r.binary` off the unresolved Promise (top-level ESM await context). Now `await`s.
- **`src/index.ts`**: corrected three JSDoc `@example` blocks that showed the now-async `compile()` / `compileFiles()` used synchronously.

## Verification

`pnpm run dogfood:acorn` now reports:

```
[dogfood] acorn@8.16.0 (pinned 4ce79c89be40…) — entry package/dist/acorn.mjs
[dogfood] compile() success=true in 28190ms — 471 diagnostics, binary 827843 bytes
[dogfood] WebAssembly.compile() FAILED: Compiling function #130:"__closure_37" failed: global.set[0] expected type f64, found if of type (ref null 3)
[dogfood] === acorn surface report ===
  "headline": "compiled, but binary INVALID (run+diff skipped — surface red)"
```

`compile success=true`, an 827 KB binary, and the harness proceeds to the VALIDATE stage — which surfaces the **separate, known #1745** closure `global.set` type error. That is the correct current state and is intentionally left untouched (not in scope here).

`prettier --check` passes on all touched files; `src/index.ts` typechecks clean (change is JSDoc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)