### PR TITLE
feat(#1761): self-healing merge-queue watchdog (auto-recover from merge_group dispatch wedge)

### DIFF
--- a/.github/workflows/merge-queue-watchdog.yml
+++ b/.github/workflows/merge-queue-watchdog.yml
@@ -1,0 +1,59 @@
+name: Merge-queue watchdog
+
+# WHY: GitHub's merge queue periodically wedges — PRs sit in AWAITING_CHECKS and
+# ZERO merge_group runs dispatch, with no githubstatus.com incident (#1761, ~4x
+# in 24h). The one proven recovery is a ~10-minute disable of the merge_queue
+# rule in the branch ruleset, then restore (see
+# .claude/memory/feedback_wedged_merge_queue_reset). This watchdog detects the
+# wedge and performs that reset automatically, idempotently and rate-limited.
+#
+# The recover path needs Administration:write to edit the ruleset. If MQ_ADMIN_TOKEN
+# is wired it takes the clean reset path; otherwise it falls back to draining the
+# stuck green head with `gh pr merge --admin --merge` (a logged gate bypass).
+
+on:
+  schedule:
+    # every 15 min — must be > the script's 600s sleep + API time, single-flight
+    # concurrency below prevents overlap if a recovery run is still sleeping.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Detect + log decision only, no mutation"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+concurrency:
+  group: mq-watchdog
+  cancel-in-progress: false
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25 # recover path sleeps 600s; leave margin for API + restore
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/merge-queue-watchdog.mjs
+            scripts/enqueue-green-prs.mjs
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Run merge-queue watchdog
+        env:
+          # Prefer an admin-capable PAT for the ruleset-reset path. AUTO_ENQUEUE_TOKEN
+          # is the existing queue-ops PAT; if it lacks Administration:write the script
+          # auto-detects and falls back to the admin-merge drain. GITHUB_TOKEN is the
+          # last resort (fallback path only).
+          GH_TOKEN: ${{ secrets.MQ_ADMIN_TOKEN || secrets.AUTO_ENQUEUE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '1' || '0' }}
+        run: node scripts/merge-queue-watchdog.mjs

--- a/docs/runbooks/merge-queue-wedge.md
+++ b/docs/runbooks/merge-queue-wedge.md
@@ -1,0 +1,95 @@
+# Runbook: merge-queue wedge (no `merge_group` dispatch)
+
+**Issue:** #1761 · **Memory:** `.claude/memory/feedback_wedged_merge_queue_reset.md`
+· **Related:** #1758 (trigger reduction)
+
+## Symptom
+
+PRs enqueue and sit in `AWAITING_CHECKS` (or `QUEUED`) forever; **zero
+`merge_group` workflow runs fire**. Ordinary PR CI (`pull_request` / `push` /
+`schedule`) keeps running fine and **githubstatus.com shows no incident**. This
+is GitHub-side queue-processor state, not our config — it has recurred ~4× in
+24h.
+
+## Confirm it's a real wedge (not a slow head)
+
+```bash
+# Newest merge_group run — compare its created_at to the oldest stuck entry's enqueuedAt.
+gh api '/repos/loopdive/js2/actions/runs?event=merge_group&per_page=1' \
+  | jq '.workflow_runs[0] | {name, created_at, head_branch, conclusion}'
+
+# Oldest queue entry + state + enqueuedAt:
+gh api graphql -f query='{ repository(owner:"loopdive",name:"js2"){
+  mergeQueue(branch:"main"){ entries(first:20){ nodes {
+    enqueuedAt state position pullRequest { number } } } } } }' \
+  | jq '.data.repository.mergeQueue.entries.nodes'
+```
+
+**WEDGED** = oldest entry is `AWAITING_CHECKS`, enqueued > ~20 min ago, AND no
+`merge_group` run was _created_ since that `enqueuedAt`. If a `merge_group` run
+created at/after the oldest enqueue exists, the dispatcher is alive (just slow) —
+do **not** reset.
+
+## Automatic recovery — the watchdog
+
+`.github/workflows/merge-queue-watchdog.yml` runs `scripts/merge-queue-watchdog.mjs`
+every 15 min (and on `workflow_dispatch`). It applies the detect logic above and,
+when WEDGED, performs the proven recovery automatically:
+
+1. **Ruleset reset (preferred, needs `Administration:write`):** back up ruleset
+   `16700772`, PUT it with the `merge_queue` rule removed (keeping
+   `required_status_checks`), **sleep 600 s** (a quick toggle does NOT work),
+   restore the original verbatim, then re-enqueue green PRs.
+2. **Admin-merge drain (fallback, only contents/PR write):** `gh pr merge
+<stuck-green-head> --admin --merge` to drain the wedged head, logged as a gate
+   bypass. Unblocks humans but does NOT fix the processor.
+
+**Guards (idempotent / rate-limited):** aborts if the `merge_queue` rule is
+already absent (a reset is mid-flight) or if the ruleset was updated within the
+last 30 min (cooldown). Single-flight via `concurrency: mq-watchdog`.
+
+**Dry run on demand:**
+
+```bash
+DRY_RUN=1 node scripts/merge-queue-watchdog.mjs
+# or: gh workflow run merge-queue-watchdog.yml -f dry_run=true
+```
+
+### Enabling the clean reset path
+
+Editing the ruleset needs **`Administration:write`**, which the default
+`GITHUB_TOKEN` lacks. The workflow uses
+`secrets.MQ_ADMIN_TOKEN || secrets.AUTO_ENQUEUE_TOKEN || secrets.GITHUB_TOKEN`.
+If no admin-capable token is present, only the fallback drain runs. **Wire a
+fine-grained PAT/App token with `Administration:write` as `MQ_ADMIN_TOKEN`** to
+enable the proper reset.
+
+## Manual recovery (if the watchdog is disabled / failing)
+
+1. Back up: `gh api /repos/loopdive/js2/rulesets/16700772 > /tmp/ruleset.json`
+2. PUT a payload of `{name,target,enforcement,conditions,bypass_actors,rules}`
+   with the `merge_queue` rule removed from `rules[]`.
+3. **Wait ~10 minutes** (not seconds — GitHub must fully drain the queue state).
+4. Re-PUT the original `/tmp/ruleset.json` rules verbatim.
+5. Re-enqueue: `node scripts/enqueue-green-prs.mjs`. Watch for a `merge_group`
+   run on the next `gh-readonly-queue/main/pr-N-…` ref to confirm dispatch.
+
+Interim while wedged: `gh pr merge <N> --admin --merge` on a fully-green PR only.
+Clean up orphaned `gh-readonly-queue/main/pr-*` refs for already-merged PRs.
+
+## Root cause — file a GitHub Support ticket
+
+The watchdog is **recovery**, not a fix. The recurring `merge_group`
+non-dispatch with clean config and no incident is a GitHub-side bug; only a
+**GitHub Support ticket** gets it fixed at the source. Include: the confirming
+queries above, the matching required-check names from the last good
+`merge_group` run, ~4 wedge timestamps in 24h, and that githubstatus.com showed
+no incident. (Needs the org's support portal — maintainer action.)
+
+## Config levers to reduce wedge frequency (trial after the watchdog is live)
+
+The queue is **serial** (`max_entries_to_build = 1`). Worth confirming
+`check_response_timeout_minutes` is not unbounded (so a dead head times out and
+recycles instead of holding the serial slot), and trialing
+`grouping_strategy: ALLGREEN` with a small batch to reduce per-PR serial poking
+(#1758). Trial these only once the watchdog provides a safety net.

--- a/plan/issues/1761-merge-queue-watchdog-self-healing.md
+++ b/plan/issues/1761-merge-queue-watchdog-self-healing.md
@@ -1,0 +1,154 @@
+---
+id: 1761
+title: "self-healing merge-queue watchdog — auto-recover from merge_group dispatch wedge"
+status: in-progress
+created: 2026-05-31
+updated: 2026-05-31
+priority: high
+feasibility: hard
+task_type: feature
+area: ci-infra
+goal: platform
+related: [1758, 1756]
+depends_on: []
+sprint: Backlog
+---
+
+# #1761 — self-healing merge-queue watchdog
+
+## Problem
+
+GitHub's merge queue periodically stops dispatching `merge_group` events: PRs
+enqueue and sit forever in `AWAITING_CHECKS`, **zero `merge_group` workflow runs
+fire**, while ordinary `pull_request` / `push` / `schedule` Actions keep working
+and githubstatus.com shows no incident. It is GitHub-side queue-processor state,
+not our config. This has wedged **~4× in 24h** (see #1758 for the latest two and
+the trigger analysis).
+
+Confirmation each time:
+
+```
+gh api '/repos/loopdive/js2/actions/runs?event=merge_group&per_page=1'
+```
+
+shows no run newer than the oldest stuck entry's `enqueuedAt`.
+
+#1758 made auto-enqueue **surgical** to reduce the _trigger_ (the high-frequency
+serial-queue poke). This issue adds the _recovery_ automation: a watchdog that
+detects the wedge and performs the proven reset with no human in the loop.
+
+## The one proven manual recovery (see `feedback_wedged_merge_queue_reset`)
+
+1. Back up ruleset **16700772** verbatim.
+2. PUT a payload that **omits the `merge_queue` rule** but keeps
+   `required_status_checks` (+ identical name/target/enforcement/conditions/
+   bypass_actors).
+3. **Wait ~10 minutes** — a quick toggle does NOT work; GitHub must fully drain
+   the queue-processor state.
+4. Re-PUT the **original** ruleset (restore the captured backup verbatim).
+5. Re-enqueue the green PRs.
+
+## Deliverable
+
+1. **`scripts/merge-queue-watchdog.mjs`** — detect + recover (idempotent,
+   rate-limited, `DRY_RUN=1` supported).
+2. **`.github/workflows/merge-queue-watchdog.yml`** — schedule every ~15 min +
+   `workflow_dispatch`; single-flight concurrency; `timeout-minutes: 25` (the
+   recover path sleeps 600 s).
+3. **`docs/runbooks/merge-queue-wedge.md`** — symptom, auto-watchdog, manual
+   fallback.
+
+## Detect logic
+
+WEDGED iff **all** hold:
+
+- The merge queue has ≥1 entry.
+- The **oldest** entry is `AWAITING_CHECKS` and was `enqueuedAt`
+  > `WEDGE_THRESHOLD_MIN` (env, default 20) minutes ago.
+- **No `merge_group` Actions run was created since that `enqueuedAt`.**
+
+The third clause is the load-bearing one: it distinguishes a normally-building
+head (merge_group runs ARE firing, just slow) from a provably dead dispatcher.
+We never recover on a slow-but-live queue.
+
+## Recovery path chosen — and the auth crux
+
+Editing ruleset 16700772 needs **repo-admin** (`Administration: write`). The
+default `GITHUB_TOKEN` cannot. The repo already ships an admin-capable PAT in
+Actions as **`AUTO_ENQUEUE_TOKEN`** (used by `auto-enqueue.yml`); whether _that_
+specific token carries `Administration: write` is not knowable from a secret
+name alone, so the script **auto-detects** capability at runtime:
+
+- **Preferred path — ruleset reset** (`MQ_ADMIN_TOKEN` / `ADMIN_TOKEN` /
+  `AUTO_ENQUEUE_TOKEN` with admin): back up → disable `merge_queue` rule → sleep
+  600 s → restore verbatim → re-enqueue green PRs. The clean, complete recovery.
+  The script probes admin by reading the ruleset and confirming the token can
+  write it (a dry PUT of the _unchanged_ ruleset is the capability probe; on
+  403 it falls back).
+- **Fallback path — gate-bypass drain** (only contents/PR-write available):
+  `gh pr merge <stuck-green-head> --admin --merge` to drain the wedged head,
+  **only** when that PR's required PR-level checks are green. Clearly logged as a
+  gate bypass. This unblocks humans but does NOT fix the queue processor; the
+  next enqueue may re-wedge until an admin token enables the reset path.
+
+**Recommendation:** wire a fine-grained PAT/App token with
+`Administration: write` (e.g. `MQ_ADMIN_TOKEN`) into repo secrets so the
+watchdog always takes the clean reset path. The fallback is a stopgap.
+
+## Idempotency / rate-limiting
+
+- If the `merge_queue` rule is **already absent** from the ruleset → a reset is
+  mid-flight (or the rule is mis-configured) → **abort, do nothing**. (This is
+  exactly the live state during a maintainer reset; the watchdog must not capture
+  a queue-less ruleset as its "original" baseline and restore a broken config.)
+- If the ruleset `updated_at` is within the last **~30 min** → a reset just ran →
+  **abort** (cooldown). `updated_at` is the marker; no external state needed.
+- Workflow `concurrency: { group: mq-watchdog, cancel-in-progress: false }`
+  guarantees single-flight across the 15-min schedule and the 10-min sleep.
+
+## Validation
+
+- `DRY_RUN=1 node scripts/merge-queue-watchdog.mjs` prints a correct
+  WEDGED/healthy decision against the live queue, no mutation.
+- Lint/format clean; valid YAML.
+
+## GitHub Support ticket (maintainer action — I cannot file this)
+
+The only thing that fixes the **root cause** is a GitHub Support ticket: report
+recurring `merge_group` non-dispatch (queue accepts enqueues, builds no merge
+group), clean ruleset config, required-check names matching the last good
+merge_group run, and **no githubstatus.com incident**. Include the confirming
+query above and ~4 wedge timestamps in 24h. Filing needs the org's support
+portal, which only the maintainer can access.
+
+## Config changes that would reduce wedge frequency (notes, not the deliverable)
+
+Observed `merge_queue` is **serial** (`max_entries_to_build = 1` per #1758).
+Levers worth trialing once the watchdog provides a safety net:
+
+- **`check_response_timeout_minutes`** — if set very high, a stuck head holds the
+  serial slot indefinitely; a saner value (e.g. matching the longest required
+  check + margin) lets GitHub time out and recycle a dead head instead of
+  wedging. Worth confirming the current value and lowering it.
+- **`grouping_strategy: ALLGREEN` + a small batch** (`max_entries_to_build: 2–3`,
+  `min_entries_to_merge` with a short `min_entries_to_merge_wait_minutes`) —
+  reduces the per-PR serial poking that #1758 implicates as the trigger; a wedge
+  on a batch still drains via timeout rather than stranding one-at-a-time.
+  These are config trials to run **after** the watchdog lands (so a bad trial
+  self-heals). Not changed here.
+
+## Implementation notes (why, not just what)
+
+- **Restore-from-captured-backup, never reconstruct.** The `merge_queue` rule's
+  exact params (timeouts, grouping, batch sizes) are not stored anywhere in the
+  repo; the script captures the live ruleset _before_ disabling and restores that
+  exact object. Hardcoding params would silently drift the queue config on every
+  recovery.
+- **Order of guards matters.** The "`merge_queue` rule already absent" guard must
+  run _before_ capturing the baseline, else a watchdog that fires during a
+  maintainer reset would snapshot the queue-less ruleset and "restore" a
+  permanently queue-disabled main.
+- **Detect is conservative by construction** — three ANDed clauses, the last
+  requiring provable dispatcher death. False-negative (miss a wedge for one
+  15-min cycle) is acceptable; false-positive (reset a healthy queue, 10-min
+  outage) is not.

--- a/scripts/merge-queue-watchdog.mjs
+++ b/scripts/merge-queue-watchdog.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+// merge-queue-watchdog.mjs — detect + auto-recover a wedged GitHub merge queue.
+//
+// THE WEDGE (#1761, ~4x in 24h): GitHub's merge queue periodically stops
+// dispatching `merge_group` events. PRs enqueue and sit forever in
+// `AWAITING_CHECKS` while ZERO `merge_group` workflow runs fire — ordinary
+// pull_request/push/schedule Actions keep working and githubstatus.com shows no
+// incident. It is GitHub-side queue-processor state, not our config.
+//
+// THE PROVEN MANUAL RECOVERY (see .claude/memory/feedback_wedged_merge_queue_reset):
+//   1. back up ruleset RULESET_ID verbatim
+//   2. PUT a payload OMITTING the `merge_queue` rule (keep required_status_checks
+//      + identical name/target/enforcement/conditions/bypass_actors)
+//   3. WAIT ~10 minutes (a quick toggle does NOT work — GitHub must fully drain
+//      the queue-processor state)
+//   4. re-PUT the ORIGINAL ruleset (restore the captured backup verbatim)
+//   5. re-enqueue the green PRs
+// This script automates exactly that, idempotently and rate-limited.
+//
+// AUTH CRUX: editing the ruleset needs repo-admin (Administration:write). The
+// default GITHUB_TOKEN cannot. We auto-detect: if the token can write the
+// ruleset we take the clean RESET path; otherwise we fall back to draining the
+// stuck green head with `gh pr merge --admin --merge` (a logged gate bypass that
+// unblocks humans but does NOT fix the processor). Wiring an admin PAT
+// (MQ_ADMIN_TOKEN) into Actions enables the proper reset path.
+//
+// ENV:
+//   GH_REPO              owner/name (default loopdive/js2)
+//   RULESET_ID           ruleset to toggle (default 16700772)
+//   WEDGE_THRESHOLD_MIN  oldest-entry age before we call it wedged (default 20)
+//   RESET_COOLDOWN_MIN   skip if ruleset updated_at within this window (default 30)
+//   DISABLE_WAIT_SEC     how long to leave merge_queue rule OFF (default 600)
+//   DRY_RUN=1            detect + log decision, NO mutation
+//   GH_TOKEN / GITHUB_TOKEN  auth (admin preferred; PR-write enables fallback)
+//
+// Runs in .github/workflows/merge-queue-watchdog.yml (schedule + dispatch) and
+// by hand: `DRY_RUN=1 node scripts/merge-queue-watchdog.mjs`.
+
+import { execFileSync } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const REPO = process.env.GH_REPO || "loopdive/js2";
+const [OWNER, NAME] = REPO.split("/");
+const RULESET_ID = process.env.RULESET_ID || "16700772";
+const WEDGE_THRESHOLD_MIN = Number(process.env.WEDGE_THRESHOLD_MIN || 20);
+const RESET_COOLDOWN_MIN = Number(process.env.RESET_COOLDOWN_MIN || 30);
+const DISABLE_WAIT_SEC = Number(process.env.DISABLE_WAIT_SEC || 600);
+const DRY = process.env.DRY_RUN === "1" || process.argv.includes("--dry-run");
+
+const MINUTE = 60 * 1000;
+const now = () => Date.now();
+const ageMin = (iso) => (now() - new Date(iso).getTime()) / MINUTE;
+const log = (...a) => console.log(...a);
+
+// IMPORTANT: invoke gh via execFileSync with an ARG ARRAY — never a shell
+// string. GraphQL queries contain `$id`/`$signal` which a shell would expand to
+// empty, producing "Expected VAR_SIGN" parse errors. Arrays bypass the shell.
+function gh(args, { allowFail = false } = {}) {
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (e) {
+    if (allowFail) {
+      const err = new Error(String(e.stderr || e.message || e));
+      err.stderr = String(e.stderr || "");
+      err.status = e.status;
+      throw err;
+    }
+    throw e;
+  }
+}
+function graphql(query, vars = {}) {
+  const args = ["api", "graphql", "-f", `query=${query}`];
+  for (const [k, v] of Object.entries(vars)) args.push("-f", `${k}=${v}`);
+  return JSON.parse(gh(args));
+}
+
+// ---------------------------------------------------------------------------
+// DETECT
+// ---------------------------------------------------------------------------
+
+// Oldest merge-queue entry (lowest position) + its state/enqueuedAt.
+function oldestQueueEntry() {
+  const r = graphql(
+    `{ repository(owner:"${OWNER}",name:"${NAME}"){ mergeQueue(branch:"main"){
+        entries(first:50){ nodes { enqueuedAt state position pullRequest { number } } } } } }`,
+  );
+  const nodes = r?.data?.repository?.mergeQueue?.entries?.nodes || [];
+  if (nodes.length === 0) return null;
+  // position can be null while forming; sort by enqueuedAt asc as the tiebreak.
+  nodes.sort((a, b) => {
+    const pa = a.position ?? Number.MAX_SAFE_INTEGER;
+    const pb = b.position ?? Number.MAX_SAFE_INTEGER;
+    if (pa !== pb) return pa - pb;
+    return new Date(a.enqueuedAt) - new Date(b.enqueuedAt);
+  });
+  return { entry: nodes[0], count: nodes.length };
+}
+
+// Most recent merge_group Actions run's created_at (ISO), or null if none ever.
+function latestMergeGroupRunCreatedAt() {
+  const r = JSON.parse(gh(["api", `/repos/${REPO}/actions/runs?event=merge_group&per_page=1`]));
+  const run = (r.workflow_runs || [])[0];
+  return run ? run.created_at : null;
+}
+
+// Returns { wedged: bool, reason, entry, queueCount, lastRunAt }.
+function detect() {
+  const oldest = oldestQueueEntry();
+  if (!oldest) {
+    return { wedged: false, reason: "queue empty — nothing to recover" };
+  }
+  const { entry, count } = oldest;
+  const lastRunAt = latestMergeGroupRunCreatedAt();
+  const oldestAge = ageMin(entry.enqueuedAt);
+
+  if (entry.state !== "AWAITING_CHECKS") {
+    return {
+      wedged: false,
+      reason: `oldest entry state is ${entry.state}, not AWAITING_CHECKS — queue is progressing`,
+      entry,
+      queueCount: count,
+      lastRunAt,
+    };
+  }
+  if (oldestAge < WEDGE_THRESHOLD_MIN) {
+    return {
+      wedged: false,
+      reason: `oldest entry only ${oldestAge.toFixed(1)}m old (< ${WEDGE_THRESHOLD_MIN}m threshold) — give it time`,
+      entry,
+      queueCount: count,
+      lastRunAt,
+    };
+  }
+  // Load-bearing clause: a merge_group run CREATED at/after this entry's
+  // enqueuedAt means dispatch is alive (just slow) → NOT wedged.
+  if (lastRunAt && new Date(lastRunAt) >= new Date(entry.enqueuedAt)) {
+    return {
+      wedged: false,
+      reason: `merge_group run dispatched ${ageMin(lastRunAt).toFixed(1)}m ago (>= oldest enqueue) — dispatcher alive, just slow`,
+      entry,
+      queueCount: count,
+      lastRunAt,
+    };
+  }
+  return {
+    wedged: true,
+    reason: `oldest entry (PR #${entry.pullRequest?.number}) AWAITING_CHECKS for ${oldestAge.toFixed(1)}m and NO merge_group run since its enqueue (${lastRunAt ? `last run ${ageMin(lastRunAt).toFixed(1)}m ago` : "no merge_group runs ever"}) — dispatcher dead`,
+    entry,
+    queueCount: count,
+    lastRunAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RULESET helpers
+// ---------------------------------------------------------------------------
+
+function getRuleset() {
+  return JSON.parse(gh(["api", `/repos/${REPO}/rulesets/${RULESET_ID}`]));
+}
+
+// PUT payload GitHub accepts: name/target/enforcement/conditions/bypass_actors/rules.
+function putPayload(rs, rules) {
+  return JSON.stringify({
+    name: rs.name,
+    target: rs.target,
+    enforcement: rs.enforcement,
+    conditions: rs.conditions,
+    bypass_actors: rs.bypass_actors,
+    rules,
+  });
+}
+
+function putRuleset(rs, rules) {
+  const body = putPayload(rs, rules);
+  return JSON.parse(
+    execFileSync("gh", ["api", "--method", "PUT", `/repos/${REPO}/rulesets/${RULESET_ID}`, "--input", "-"], {
+      input: body,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }),
+  );
+}
+
+// Capability probe: can this token write the ruleset? Re-PUT it UNCHANGED.
+// A 403 (no Administration:write) throws → caller falls back. A success is a
+// genuine no-op (identical rules) so this is safe to run unconditionally.
+function canWriteRuleset(rs) {
+  try {
+    putRuleset(rs, rs.rules);
+    return true;
+  } catch (e) {
+    const msg = String(e.stderr || e.message || e);
+    if (/403|Resource not accessible|Administration/i.test(msg)) return false;
+    throw e; // unexpected error — surface it
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RECOVER — ruleset reset path (preferred)
+// ---------------------------------------------------------------------------
+
+async function recoverViaRulesetReset(rs) {
+  const withoutMQ = rs.rules.filter((r) => r.type !== "merge_queue");
+  log(`[reset] disabling merge_queue rule (keeping ${withoutMQ.map((r) => r.type).join(", ")})`);
+  putRuleset(rs, withoutMQ);
+  log(`[reset] merge_queue rule OFF. Waiting ${DISABLE_WAIT_SEC}s for GitHub to drain queue state...`);
+  await sleep(DISABLE_WAIT_SEC * 1000);
+  log(`[reset] restoring ORIGINAL ruleset verbatim (${rs.rules.length} rules)`);
+  putRuleset(rs, rs.rules); // restore captured backup exactly
+  // verify merge_queue is back
+  const after = getRuleset();
+  const restored = after.rules.some((r) => r.type === "merge_queue");
+  if (!restored) {
+    log(`[reset] WARNING: merge_queue rule NOT present after restore — manual check needed`);
+  } else {
+    log(`[reset] merge_queue rule restored ✓`);
+  }
+  reEnqueueGreen();
+  log(`[reset] done. Watch for a merge_group run on the next enqueued PR's pr-N ref.`);
+}
+
+// Re-feed the queue after the reset using the existing surgical sweep.
+function reEnqueueGreen() {
+  try {
+    log(`[reset] re-enqueuing green PRs via enqueue-green-prs.mjs`);
+    const out = execFileSync("node", ["scripts/enqueue-green-prs.mjs"], { encoding: "utf8", env: { ...process.env } });
+    log(out.trim());
+  } catch (e) {
+    log(`[reset] re-enqueue sweep failed (non-fatal): ${String(e.stderr || e.message || e).split("\n")[0]}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RECOVER — gate-bypass drain (fallback, no admin token)
+// ---------------------------------------------------------------------------
+
+function recoverViaAdminMerge(entry) {
+  const n = entry.pullRequest?.number;
+  if (!n) {
+    log(`[drain] oldest entry has no PR number — cannot admin-merge. Escalate.`);
+    return;
+  }
+  // Only drain when the PR's required PR-level checks are green.
+  const checks = JSON.parse(
+    gh(["pr", "view", String(n), "--repo", REPO, "--json", "statusCheckRollup,mergeStateStatus"]),
+  );
+  const rollup = checks.statusCheckRollup || [];
+  const failing = rollup.filter(
+    (c) => (c.conclusion && !["SUCCESS", "NEUTRAL", "SKIPPED"].includes(c.conclusion)) || c.state === "FAILURE",
+  );
+  if (failing.length > 0) {
+    log(`[drain] PR #${n} has ${failing.length} non-green check(s) — refusing gate bypass. Escalate.`);
+    return;
+  }
+  log(
+    `[drain] GATE BYPASS: no admin token for ruleset reset. Admin-merging stuck green head PR #${n} to drain the wedged queue.`,
+  );
+  log(
+    `[drain] NOTE: this unblocks humans but does NOT fix the queue processor — wire MQ_ADMIN_TOKEN for the proper reset.`,
+  );
+  gh(["pr", "merge", String(n), "--repo", REPO, "--admin", "--merge"]);
+  log(`[drain] PR #${n} admin-merged.`);
+}
+
+// ---------------------------------------------------------------------------
+// MAIN
+// ---------------------------------------------------------------------------
+
+async function main() {
+  log(`merge-queue-watchdog: repo=${REPO} ruleset=${RULESET_ID} threshold=${WEDGE_THRESHOLD_MIN}m dry=${DRY}`);
+
+  const d = detect();
+  log(`DETECT: ${d.wedged ? "WEDGED" : "healthy"} — ${d.reason}`);
+  if (d.queueCount != null) log(`  queue entries: ${d.queueCount}, oldest enqueuedAt: ${d.entry?.enqueuedAt}`);
+  if (!d.wedged) {
+    log("No action.");
+    return;
+  }
+
+  // ---- idempotency / rate-limit guards (BEFORE capturing any baseline) ----
+  const rs = getRuleset();
+  const hasMQ = rs.rules.some((r) => r.type === "merge_queue");
+  if (!hasMQ) {
+    log(
+      `GUARD: merge_queue rule already ABSENT from ruleset — a reset is mid-flight (or misconfigured). Aborting to avoid snapshotting a queue-less baseline.`,
+    );
+    return;
+  }
+  const sinceUpdate = ageMin(rs.updated_at);
+  if (sinceUpdate < RESET_COOLDOWN_MIN) {
+    log(
+      `GUARD: ruleset updated ${sinceUpdate.toFixed(1)}m ago (< ${RESET_COOLDOWN_MIN}m cooldown) — a recent reset is settling. Aborting.`,
+    );
+    return;
+  }
+
+  if (DRY) {
+    const admin = "(not probed in DRY_RUN)";
+    log(`DRY_RUN: would RECOVER. Admin-write capability: ${admin}.`);
+    log(`DRY_RUN: preferred path = ruleset reset (disable merge_queue ${DISABLE_WAIT_SEC}s → restore → re-enqueue).`);
+    log(`DRY_RUN: fallback path  = admin-merge stuck green head PR #${d.entry?.pullRequest?.number}.`);
+    log("DRY_RUN: no mutation performed.");
+    return;
+  }
+
+  // ---- recover: prefer ruleset reset, fall back to admin-merge ----
+  if (canWriteRuleset(rs)) {
+    log(`RECOVER via RULESET RESET (admin token available).`);
+    await recoverViaRulesetReset(rs);
+  } else {
+    log(`RECOVER via ADMIN-MERGE DRAIN (no Administration:write — ruleset reset unavailable).`);
+    recoverViaAdminMerge(d.entry);
+  }
+}
+
+main().catch((e) => {
+  console.error(`merge-queue-watchdog FAILED: ${String(e.stderr || e.message || e)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

A self-healing watchdog for the GitHub merge queue. The queue periodically wedges — PRs sit in `AWAITING_CHECKS` with **zero `merge_group` runs dispatched**, no githubstatus.com incident (~4× in 24h). The one proven recovery is a ~10-min disable of the `merge_queue` ruleset rule, then restore. This automates detect + recovery so the wedge self-heals without human intervention.

Closes #1761.

## Files

- **`scripts/merge-queue-watchdog.mjs`** — detect + recover.
  - **DETECT** (conservative, 3 ANDed clauses): oldest queue entry is `AWAITING_CHECKS`, enqueued > `WEDGE_THRESHOLD_MIN` (default 20) min ago, **and** no `merge_group` Actions run was *created* since that `enqueuedAt`. The last clause distinguishes a provably-dead dispatcher from a slow-but-live one — we never reset a healthy queue.
  - **RECOVER** — prefers the **ruleset reset** (back up ruleset 16700772 → PUT with `merge_queue` rule removed → `sleep 600s` → restore the captured original verbatim → re-enqueue green PRs). The script restores the *captured backup*, never reconstructs params, so recovery can't drift the queue config. **Falls back** to draining the stuck green head via `gh pr merge <N> --admin --merge` (logged gate bypass) when no admin token is available.
  - **Idempotent / rate-limited**: aborts if the `merge_queue` rule is already absent (a reset is mid-flight) or if the ruleset `updated_at` is within the last 30 min (cooldown). `DRY_RUN=1` supported.
- **`.github/workflows/merge-queue-watchdog.yml`** — schedule every 15 min + `workflow_dispatch` (with a `dry_run` input); `concurrency: { group: mq-watchdog, cancel-in-progress: false }` (single-flight across the 10-min sleep); `timeout-minutes: 25`.
- **`docs/runbooks/merge-queue-wedge.md`** — symptom, auto-watchdog, manual fallback, and the GitHub Support recommendation.
- **`plan/issues/1761-...md`** — issue with full rationale + implementation notes.

## Auth (the crux)

Editing ruleset 16700772 needs **`Administration: write`**, which the default `GITHUB_TOKEN` lacks. The workflow uses `secrets.MQ_ADMIN_TOKEN || secrets.AUTO_ENQUEUE_TOKEN || secrets.GITHUB_TOKEN`, and the script **auto-detects** capability at runtime (a no-op re-PUT of the unchanged ruleset is the probe; 403 → fall back to the admin-merge drain). **Recommendation:** wire a fine-grained PAT/App token with `Administration: write` as `MQ_ADMIN_TOKEN` so the clean reset path is always available — the fallback only drains one head and doesn't fix the processor.

## Validation

- `DRY_RUN=1 node scripts/merge-queue-watchdog.mjs` against the live queue prints correct decisions (verified against both an empty queue and a 3-entry recovering queue: `DETECT: healthy — oldest entry only N.Nm old (< 20m threshold)`).
- 6/6 detect decision branches asserted (empty / building / young / slow-but-alive / dead-dispatcher / no-runs-ever).
- Prettier-clean; node `--check` passes.

## Root cause — maintainer action

The watchdog is **recovery, not a fix**. The recurring `merge_group` non-dispatch with clean config and no incident is GitHub-side; the issue recommends filing a **GitHub Support ticket** (needs the org's support portal — I cannot file it).

## Do not enqueue

Per the task, this PR is **not** enqueued — and the irony is the queue may currently be wedged. The maintainer is resetting in parallel and will land this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)