### PR TITLE
arch(#1387): reframe with-statement as IR-proven static routing + dynamic fallback

### DIFF
--- a/plan/issues/1387-with-statement-dynamic-scope-implementation.md
+++ b/plan/issues/1387-with-statement-dynamic-scope-implementation.md
@@ -3,9 +3,9 @@ id: 1387
 title: "feat: implement `with` statement — architect exploration of dynamic-scope compilation strategies"
 status: ready
 created: 2026-05-08
-updated: 2026-05-21
+updated: 2026-05-31
 priority: medium
-feasibility: hard
+feasibility: medium  # Tier 1 (IR-proven static routing) is medium and dispatchable; Tier 2 (dynamic fallback) is hard and overlaps the object-representation ceiling — slice & ship Tier 1 first.
 reasoning_effort: max
 task_type: feature
 area: codegen, ir
@@ -50,499 +50,359 @@ must either:
   a dynamic dispatch, OR
 - Refuse to handle the case statically and fall back to an interpreter path.
 
-## Possible approaches for the architect to evaluate
+## Approach: prove-or-demote (project lead's direction, 2026-05-31)
 
-### A — Pure externref slow-path body
+> "With our IR-based static analysis we should prove the actual shape and, if not
+> possible, fall back to a more dynamic representation."
 
-Compile the `with` body with all variables accessed via `__extern_get` / `__extern_set` on a
-runtime scope chain. The body emits no typed locals for variables that might be shadowed by `obj`.
+`with` is **not a special case** — it is one more instance of the compiler's general
+**prove-or-demote** pattern: static types lower to typed locals; what we cannot prove
+demotes to the dynamic (`externref`) representation. The lexical/property ambiguity of a
+`with` body is exactly the shape-uncertainty the IR's static analysis exists to resolve.
 
-Requires a runtime scope-chain object: `{ obj, outer }` threaded through the body. Every
-identifier read becomes:
+The decision is driven by a single IR fact: **can we prove `obj` has a *closed shape*** —
+a statically-known, complete key set + prototype + `@@unscopables` filter that cannot change
+between the `with` head and the references in its body? If yes, every bare-identifier
+reference is resolved at compile time to either a property access or the lexical binding
+(Tier 1, zero runtime cost). If no, the body demotes to the dynamic-object representation,
+reusing the existing `__extern_has`/`__extern_get`/`__extern_set` machinery (Tier 2).
 
-```
-if (obj hasOwn x) return obj.x
-else return outer lookup x
-```
+The old "evaluate approaches A–E" framing and its hybrid A+B slow-path plan are **superseded**
+by this two-tier design. (A's purely-syntactic free-identifier walk is folded into Tier 2 as
+the demotion path; B's "no overlap" fast path is generalised and made *sound* by Tier 1's
+closedness requirement — see §1 on why closedness, not "has at least these keys", is the
+load-bearing fact.)
 
-Expensive but correct for the common case (`with(document){}`, `with(Math){}`).
-
-**IR connection**: the IR path already emits `externref`-typed code for opaque objects. A `with`
-body could be compiled with all ambient variables boxed as `externref`, which the IR integrates
-naturally for its existing externref functions.
-
-### B — Static analysis for non-overlapping names
-
-If the body of `with` uses no identifiers that could plausibly be properties of `obj` (e.g., all
-local variables in the `with` body are uniquely named and `obj`'s type is known to be a plain
-`{}` with no matching keys), fall back to normal compilation. This is a narrower but zero-overhead
-fast path.
-
-### C — Desugar to a closure call
-
-Transform:
-```js
-with (obj) { stmt }
-```
-into:
-```js
-(function(__scope__) { with(__scope__) { stmt } }).call(obj);
-```
-Then compile the inner function body in "dynamic receiver" mode using the IR's existing
-`this`-access patterns. Less general but reuses existing infrastructure.
-
-### D — WASI / standalone mode: flat rejection + strict-mode CE
-
-In standalone mode (no JS host), `with` is rejected with a clean compile error explaining
-strict mode incompatibility. In JS-host mode, the approaches above apply.
-
-### E — Delegate to JS host for `with` bodies
-
-Emit the `with` body as a JS string template and invoke it via `__eval_with_scope` host import.
-Only viable in JS-host mode; defeats standalone goals. Last resort.
-
-## Acceptance criteria for the architect spec
-
-1. Evaluate approaches A–E above (and any others). Identify which are feasible in the current
-   architecture and at what cost.
-2. For the most viable approach, write a concrete implementation plan:
-   - Which files change (`src/codegen/statements.ts` for the `with` emitter, etc.)
-   - What new runtime infrastructure is needed (scope-chain struct, imports)
-   - How to lift the skip filter in `tests/test262-runner.ts`
-3. Estimate test262 yield (currently 294 CE → target: most passing or skip→pass).
-4. Flag if the implementation requires IR path dependency and why.
-
-## Related
-
-- `with` skip filter: `tests/test262-runner.ts` (grep `WithStatement` or `with`)
-- Eval skip (similar dynamic-scope problem): `plan/issues/1262-eval-static-string-compile-time.md`
-- IR externref path: `src/ir/`
-- CLAUDE.md architecture principle: "compile away, don't emulate — resolve JS semantics statically"
-  — `with` may require a principled exception to this rule for the body scope lookup.
+The old approach table is retained at the bottom for provenance (§9), but is **not** the plan.
 
 ---
 
-## Implementation Plan (architect, 2026-05-20)
+## Tier 1 — IR-proven static routing (primary path, the common case)
 
-### 0. Summary / chosen strategy
+When the IR can prove `obj` has a **closed shape**, we resolve every free-identifier reference in
+the body entirely at compile time. No runtime probe, no slow mode, no externref boxing — the
+`with` evaporates and the body is plain typed codegen.
 
-**Hybrid A + B**, JS-host-only.
+### 1. The decision: HasBinding, and why *closedness* is load-bearing
 
-- **B (static fast-path), enabled by default**: when a syntactic walk of the
-  `with` body finds **zero free identifiers** whose name could plausibly be a
-  property of `obj` (a name that is not a binding of an enclosing lexical
-  scope), compile the body as if the `with` were a plain block. Zero overhead,
-  spec-correct for that case.
-- **A (dynamic slow-path)**: for every other `with` body, emit a runtime
-  property probe at each free-identifier read/write site:
-  `__with_lookup(scope, "name")` → returns either the externref value from
-  `scope` (when `HasBinding` is true after the `@@unscopables` filter) or the
-  sentinel `__WITH_MISS` for "not present, fall through to outer scope".
-- **C/D/E rejected** for now (rationale below).
+For each free identifier `x` referenced in the body, the spec (§9.1.1.2.1 `HasBinding` for an
+Object Environment Record, used by §14.11 `WithStatement`) requires:
 
-This compiles `with` end-to-end in JS-host mode (`--target js`), gives a clear
-"compile error: `with` requires JS host" in WASI / standalone mode (D), and
-preserves the *strict-mode parse error* path that's already wired in
-`src/compiler/validation.ts:657`.
+```
+HasBinding(objEnvRec, x)  ≡  HasProperty(obj, x)        (§7.3.12 — own + full prototype chain)
+                             AND NOT IsTruthy(unscopables[x])   (when obj[@@unscopables] is set)
+```
 
-### 0a. Why A+B and not C, D, E alone
+- If `HasBinding` is **true** → rewrite the reference to a property access: read `obj.x`,
+  write `obj.x = …`, `typeof obj.x`, `delete obj.x`.
+- If `HasBinding` is **false** → leave the reference as the lexical binding `x` (the outer
+  local/global), exactly as if no `with` were present.
 
-| Approach | Verdict | Why |
+**The load-bearing requirement is CLOSEDNESS, not "has at least these keys."** To route `x` to
+the *lexical* binding we must prove `HasProperty(obj, x)` is **false** — i.e. that `x` is
+**absent** from `obj` *and its entire prototype chain*. A type that merely guarantees the
+presence of some keys is insufficient: tsc structural types are **open** (excess properties are
+permitted; a value typed `{a: number}` may carry an `x` at runtime). Proving absence requires a
+**complete, sealed** key-set — every key `obj` can possibly answer to, with nothing addable.
+
+> Concretely: `with({a, b}) { x }` can only route `x` to the lexical binding if we know the
+> object's key set is *exactly* `{a, b}` (plus `Object.prototype`'s keys, which the
+> `@@unscopables` step and own-vs-inherited handling cover) and that nothing mutates it before
+> the reference. tsc's `{a:number,b:number}` does not give us that — provenance does.
+
+### 2. Where closedness comes from — *provenance*, tracked on the IR value
+
+Closedness is a **provenance fact carried on the IR value**, computed by the IR's static
+analysis — **not** read off tsc's structural type (which is open and excess-property-permitting).
+A value qualifies for Tier 1 when its provenance is one of:
+
+1. **Object literal** — `with({a, b}) {…}`. The literal's complete key set is syntactically
+   visible. Lowered today by `lowerObjectLiteral` → `object.new` with an `IrObjectShape`
+   (`src/ir/from-ast.ts:1670`); that shape's `fields` list **is** the closed key set.
+2. **`Object.freeze` / sealed objects** — the key set is frozen post-construction. The legacy
+   codegen already tracks this in `ctx.frozenVars` / `ctx.sealedVars`
+   (`src/codegen/context/types.ts:865-866`); the IR equivalent is a `frozen`/`sealed`
+   provenance bit on the value.
+3. **Well-known builtins with fixed shape** — `Math`, `JSON`. Their key sets are constants
+   known to the compiler. (`with(Math){ sin(x) }` → `Math.sin(x)`.)
+4. **Compiler-constructed objects whose entire lifecycle is statically visible** — an
+   `object.new` value that (a) never escapes the function, (b) is never the target of a
+   dynamic key add (`obj[k]=…`), `delete obj[k]`, or `Object.defineProperty`, and (c) never
+   has its prototype reassigned, between its construction and the `with` references.
+
+Provenance is necessary but not sufficient on its own: it must be paired with a
+**no-mutation-across-body** proof (§3) so the closed shape that held at the `with` head still
+holds at each reference.
+
+### 3. The IR closed-shape fact (the new analysis this issue introduces)
+
+Add a per-value **closed-shape fact** to the IR's shape/type map, computed by a new analysis pass
+under `src/ir/analysis/` (sibling to `escape.ts` / `ownership.ts`), consumed at the `with`
+lowering site in `src/ir/lower.ts`. The fact:
+
+```ts
+// src/ir/analysis/closed-shape.ts (NEW) — inference-only, like escape.ts/ownership.ts:
+//   writes to a reserved AllocSiteRegistry namespace, never mutates the IR.
+interface ClosedShapeFact {
+  readonly closed: boolean;          // false ⇒ Tier 2 demote (TOP of the lattice)
+  readonly keys: ReadonlySet<string>;// complete own-key set (only meaningful when closed)
+  readonly proto: ProtoShape;        // "object-prototype" | "null" | "known-builtin:<name>" | "unknown"
+  readonly unscopables:              // @@unscopables resolution
+    | { kind: "none" }               //   obj[@@unscopables] provably absent
+    | { kind: "static"; blocked: ReadonlySet<string> } // statically-known blocked keys
+    | { kind: "dynamic" };           //   present but not statically resolvable ⇒ forces Tier 2
+}
+```
+
+Three sub-analyses feed it (all already have IR scaffolding to build on):
+
+- **(a) Key-set + prototype derivation.** From the value's provenance (§2):
+  - `object.new` → `IrObjectShape.fields` gives `keys`; prototype is `Object.prototype`
+    (`proto: "object-prototype"`). `IrObjectShape` already exists
+    (`src/ir/nodes.ts:100`, canonical sorted field list) — the analysis reads it directly.
+  - frozen/sealed value → keys from the construction site + frozen bit.
+  - `Math`/`JSON` builtin → constant key tables in the compiler.
+  - The **prototype shape** matters because `HasProperty` walks the chain: for an object-literal
+    object, `obj.toString`/`obj.valueOf`/`obj.hasOwnProperty` etc. resolve **true** via
+    `Object.prototype` — they must route to a property access (or be `@@unscopables`-blocked),
+    not the lexical binding. The analysis must therefore fold the **fixed `Object.prototype`
+    key set** into `HasProperty` for the common object-literal case.
+
+- **(b) Immutability / no-mutation-across-body check.** A dataflow walk from the `with` head over
+  the body that **invalidates** (sets `closed = false`) on any operation that could add/remove a
+  key or change the proto of `obj`:
+  - dynamic key write `obj[k] = …` with non-constant `k`, `delete obj[k]`,
+    `Object.defineProperty(obj, …)`, `Object.assign(obj, …)`, `obj.__proto__ = …` /
+    `Object.setPrototypeOf(obj, …)`,
+  - `obj` (or an alias) passed to an **opaque call** that could mutate it.
+
+  This is precisely what the existing **escape / ownership analysis already computes**
+  (`src/ir/analysis/escape.ts` + `ownership.ts`, #747/#1587). An `object.new` classified
+  `local` (`EscapeClass = "local"`, "never escapes; lifetime bounded by the function") with no
+  key-mutating instruction in its access set is the canonical Tier-1 candidate. We **reuse**
+  the escape classification as the no-mutation gate; we do **not** invent a parallel pass.
+  > **Prerequisite (call this out, do not assume):** the escape pass classifies *allocation
+  > escape* but does **not yet** track *property/proto mutation* as an access tag in the access
+  > lattice. The closed-shape analysis needs a "key-set-mutating access" tag added to the access
+  > lattice in `src/ir/analysis/lattice.ts` (powerset-of-access-ops, join = union). If that tag
+  > does not exist, **adding it is a Tier-1 prerequisite** — see §6.
+
+- **(c) `@@unscopables` resolution.** For object literals and builtins, `obj[@@unscopables]` is
+  provably absent (`{ kind: "none" }`) → no blocking. If a literal explicitly sets
+  `[Symbol.unscopables]: {…}` with a static initializer, resolve `blocked` at compile time
+  (`{ kind: "static", blocked }`). A **dynamic** `@@unscopables` (computed/opaque) forces
+  `{ kind: "dynamic" }` → demote to Tier 2.
+
+### 4. Tier-1 lowering (how the fact is consumed at the `with` site)
+
+In the AST→IR lowerer (`src/ir/from-ast.ts`) add a `WithStatement` case (it is currently absent →
+the node demotes to legacy, which CEs). It:
+
+1. Lowers `stmt.expression` to a value `objV`, queries `ClosedShapeFact` for `objV`.
+2. If `closed === true`: enter Tier-1 mode. Collect the body's free identifiers (an identifier
+   whose binding resolves *outside* the body's own lexical scope — `var`/`function`-hoisted names
+   and inner `let`/`const` are **bound**, never free, so they are never rewritten; see edge cases).
+   For each free identifier `x`, compute `HasBinding` from the fact:
+   - `present = keys.has(x) || protoHasKey(proto, x)`, then apply the `@@unscopables` filter.
+   - If `HasBinding(x)` → emit the reference as a **member access on `objV`**: read →
+     `object.get objV "x"` (or `class.get`/builtin getter); write → `object.set objV "x" rhs`;
+     `typeof`/`delete` → the member-access form. These are existing IR instrs — no new lowering.
+   - Else → emit the reference as the **lexical binding** unchanged.
+3. The `with` itself produces **no runtime construct** — no scope object, no probe, no `externref`.
+   The body is ordinary typed IR. A null/undefined `obj` is a compile-time error in the
+   closed-shape case only when the closed value is statically `null`/`undefined` (rare); otherwise
+   the spec's §14.11.2 `ToObject`/TypeError-on-null is handled by Tier 2 when the value is opaque.
+
+Spec citation: the rewrite is a sound static realization of §14.11 step "let newEnv be
+NewObjectEnvironment(obj, …)" + §9.1.1.1 `GetBindingValue` / §9.1.1.5 `SetMutableBinding` —
+because the binding-resolution that those records perform dynamically is, under proven closedness,
+**constant** across the body, so it is folded into codegen.
+
+### Tier-1 feasibility: **medium, dispatchable**
+
+Tier 1 ships the bulk of the ~294 skipped `with` tests — the `with(Math)`/`with(JSON)`/
+`with({literal})`/`with(frozenConst)` forms that dominate the dedicated suite — at **zero**
+runtime cost and with **no** dependency on the object-representation ceiling. It is the
+recommended first slice. Its only real prerequisite is the access-lattice mutation tag (§6); the
+key-set derivation and `@@unscopables` static resolution are new but self-contained, and the
+no-mutation gate is a *consumer* of the existing escape pass, not a new whole-program analysis.
+
+---
+
+## Tier 2 — dynamic fallback (secondary path)
+
+When the IR **cannot** prove a closed shape — an opaque/externref target (`with(JSON.parse(s))`,
+`with(document)`), a body that mutates `obj`'s keys/proto, a dynamic `@@unscopables`, or any value
+whose provenance is not in §2 — the body **demotes to the dynamic-object representation**. Each bare
+identifier read/write routes at runtime through `HasBinding`/get/set on `obj`'s dynamic-property
+machinery, falling through to the lexical binding on a miss.
+
+### 5. Reuse the existing dynamic-property machinery — do not invent a parallel one
+
+The runtime primitives already exist and are the **same** ones the dynamic-object /
+object-representation work uses (#1719 CPR computed-property-read track, #1130 getter-observing
+property reads, the `__defineProperty_*` / dynamic descriptor path):
+
+- `__extern_has(obj, key) → i32` — `src/runtime.ts:4891`. This is **HasProperty** (§7.3.12), not
+  yet **HasBinding** — it does *not* apply the `@@unscopables` filter. Tier 2 needs a thin
+  `__with_has(obj, key)` wrapper that = `__extern_has` **AND NOT** truthy
+  `obj[@@unscopables][key]` (spec §9.1.1.2.1 steps 3–5). This is the **only** new host import
+  Tier 2 needs; everything else is reuse.
+- `__extern_get(obj, key) → externref` — `src/runtime.ts:4726`. The read primitive.
+- `__extern_set(obj, key, val)` — `src/runtime.ts:4738`. The write primitive.
+
+Per-reference lowering (dynamic mode), for a free identifier `x`:
+
+```
+read x   →  if __with_has(obj, "x") then __extern_get(obj, "x") else <lexical x>
+write x  →  if __with_has(obj, "x") then __extern_set(obj, "x", v) else <lexical x = v>
+```
+
+The "miss → lexical" fallthrough is emitted by lowering the original lexical reference inline in
+the `else` arm. Nested `with(a) with(b){…}` expands to a compile-time-nested `if/else` chain,
+innermost-first (each scope is a distinct value; no runtime scope-chain object is needed because
+the nesting is lexically fixed).
+
+### Standalone vs JS-host split (dual-mode, per CLAUDE.md)
+
+- **JS-host mode** (`--target js`): host objects like `with(document)` need the host-import
+  `in`/get/set — `__with_has`/`__extern_get`/`__extern_set` route through the JS proxy and see the
+  real host property table. This is the primary Tier-2 path.
+- **Standalone / WASI mode** (`--target wasi`, no JS host): there is no host to answer `in`/get/set
+  against an opaque externref. For a **Wasm-constructed** dynamic object (the dynamic-object
+  representation track), the Wasm-native dynamic property lookup serves the same role. For a
+  genuinely **host** target (`with(document)`) in standalone mode there is no host — that sub-case
+  stays a clean `CE` ("with on a host object requires --target js"). This is the rare residual,
+  **not** the default: literals/builtins are Tier 1, and Wasm-constructed dynamic objects use the
+  native lookup.
+
+### Tier-2 feasibility: **hard, deferred — overlaps the object-representation ceiling**
+
+Tier 2's correctness is bounded by how complete the dynamic-object representation is for
+compiled values (the convergent #1719/#1130/#1320/#1732 ceiling: compiled WasmGC values are not
+host JS objects). It should **follow the dynamic-representation track**, not block Tier 1. The
+`@@unscopables`-aware `__with_has` wrapper and the per-reference if/else lowering are
+straightforward; the hard part is the underlying dynamic representation, which is shared work.
+
+---
+
+## Recommended slicing
+
+1. **Ship Tier 1 first** (`feasibility: medium`, dispatchable now): IR closed-shape fact +
+   static routing. Covers `with(Math)`, `with(JSON)`, `with({literal})`, `with(Object.freeze(…))`
+   — the bulk of the dedicated `with` suite — at zero runtime cost. Prerequisite: access-lattice
+   mutation tag (§6).
+2. **Tier 2 follows the dynamic-representation track** (`feasibility: hard`): demote opaque/
+   mutated/dynamic-`@@unscopables` bodies through `__with_has` + `__extern_get`/`__extern_set`,
+   reusing #1719/#1130 machinery. Add the `__with_has` `@@unscopables` wrapper here.
+3. **Residual CE** only for the genuinely unsupportable sub-cases (host object in standalone
+   mode; a closure that captures a `with`-scoped name across a function boundary — see edge cases).
+   This must be the *rare residual*, not the default.
+
+> **Strict mode is unchanged**: `with` in strict-mode/module/class code is already a parse-time
+> early error (`src/compiler/validation.ts:667`, §14.11.1). Both tiers only ever see sloppy-mode
+> bodies; keep that gate.
+
+---
+
+## 6. Prerequisites & risks (call out, do not assume)
+
+- **IR access-lattice "key-set-mutating access" tag (Tier-1 prerequisite).** The escape/ownership
+  analysis (`src/ir/analysis/{escape,ownership,lattice}.ts`) classifies *allocation escape* and
+  records an **access set** (powerset lattice, `src/ir/analysis/lattice.ts`), but does not today
+  have an access tag meaning "this op can add/remove a key or change the proto of the value." The
+  no-mutation-across-body gate (§3b) needs that tag. **If it does not exist, adding it is a
+  prerequisite for Tier 1** — it is a small, local extension of the existing access lattice
+  (add a tag; mark `obj[k]=`, `delete`, `defineProperty`, `setPrototypeOf`, opaque-call as
+  setting it; join = set union), not a new pass. Flag for the dev as the first sub-task.
+- **No general escape analysis gap beyond the above.** The "lifetime statically visible / does not
+  escape" half is already provided by `escape.ts` (`EscapeClass = "local"`). We are consumers, so
+  there is no missing whole-program analysis — only the mutation-tag extension above.
+- **`WithStatement` is absent from the IR lowerer today** — `src/ir/from-ast.ts` has no case, so
+  the node currently demotes to legacy and CEs. Tier 1 adds the case; until then nothing routes
+  through the new fact.
+- **`@@unscopables` static resolution** is new but bounded: object literals and `Math`/`JSON`
+  have no `@@unscopables` (`{ kind: "none" }`); only an explicit static
+  `[Symbol.unscopables]: {…}` needs evaluation; anything dynamic forces Tier 2.
+- **Provenance must come from the IR value, not tsc.** The single biggest correctness risk is
+  using tsc's open structural type as if it were closed. The spec is explicit that this is
+  unsound (excess properties). The analysis must derive `keys`/`proto` only from §2 provenance.
+
+## 7. Edge cases & spec-correctness checklist
+
+| Case | Tier-1 handling | Tier-2 handling |
 |---|---|---|
-| **A (pure dynamic)** | ✅ Used as fallback | Spec-correct, covers all 174 noStrict tests including the `delete this.x`-mid-`with` reference-stability tests. Cost per identifier ~ one host call, acceptable for a sloppy-mode legacy feature. |
-| **B (static no-overlap)** | ✅ Used as fast path | Zero runtime cost when the analyzer proves no shadowing. Common case for hand-rolled `with(Math)` style. |
-| **C (desugar to `(function(scope){…}).call(obj)`)** | ❌ Rejected | Doesn't actually solve the lookup problem — inside the function body we still need dynamic dispatch on `scope`'s properties. Just renames the problem and breaks `var` hoisting / `this` capture. |
-| **D (flat rejection in standalone)** | ✅ Adopted as the WASI/--target wasi branch of A | A `with` body in standalone mode has no host to call `__extern_get` against. Emit the existing `Unsupported statement` CE message but with a clearer "with requires --target js" reason. |
-| **E (delegate body to JS host)** | ❌ Rejected | Would require source-level reflection of the `with` body, defeats every benefit of WasmGC compilation, and is a bigger maintenance liability than A. |
+| `with` body declares `var foo` / `function foo(){}` | `foo` hoists to the function's variable env → it is a **bound** (not free) ident → never rewritten; `obj.foo` does **not** win (§9.1.1.2). (S12.10-0-1.) | Same — bound idents are never probed. |
+| inner `let`/`const` in the body | block-scoped binding → bound, never rewritten. | Same. |
+| `obj.toString`/inherited `Object.prototype` keys | `HasProperty` walks the prototype; proto key set is folded in → routes to `obj.toString` unless `@@unscopables`-blocked. Tier 1 **must** include `Object.prototype` keys, else it wrongly routes them lexical. | `__with_has` (= `in`) already walks the chain. |
+| `obj` is `null`/`undefined` | If the closed value is statically null → compile error. | `with(null)` per §14.11.2 → TypeError at entry; `__with_has(null,…)` returns 0 but we must throw at the head — emit a null guard via `__throw_type_error`. |
+| `obj` is a primitive (`with(2)`) | `ToObject(2)` shape is the Number wrapper — only Tier-1-eligible if we model the wrapper's keys; otherwise demote. | `Object(obj)` inside the host primitives covers it (12.10-2-1). |
+| `delete x` through `with` | rewrite to `delete obj.x` when `HasBinding`, else lexical `delete`. | `__with_has` then `__extern_set`/delete shim, else lexical delete. |
+| `typeof x` through `with` | rewrite to `typeof obj.x` when `HasBinding`, else lexical `typeof` (so `typeof undeclared` doesn't throw). | probe then `typeof __extern_get`, else lexical. |
+| compound assign `x ^= 3` / reference stability (S11.13.2_A5.10_T3) | Tier 1 resolves the base once at compile time → naturally stable. | resolve the base once on read, store rhs in a temp, write back via the *same* `obj` ref — stable even if a getter deletes the prop mid-eval. Document this. |
+| dynamic `obj[k]=…` / `delete` / proto reassign inside body | invalidates closedness → **demote whole body to Tier 2**. | native dynamic handling. |
+| dynamic `@@unscopables` | forces Tier 2. | `__with_has` reads `obj[@@unscopables]` at runtime. |
+| nested `with(a) with(b)` | per-scope HasBinding resolved innermost-first at compile time. | compile-time-nested if/else chain, innermost-first. |
+| closure capturing a `with`-scoped name across a function boundary | The object env record IS on the lexical chain, so a nested closure *does* see it. Tier 1 only rewrites references **lexically inside** the body; a name captured by an inner function is not rewritten there → **incorrect**. v1 demotes such bodies to Tier 2, or emits a residual CE if Tier 2 can't model the captured scope. <5 test262 tests; track as follow-up. | Same caveat — the inner function would need the `obj` ref threaded as a capture. |
+| `eval` inside `with` | already CE (eval) — no interaction. | unchanged. |
+| `with` inside generator/async | straight-line if/else or static rewrite; no function boundary → fine. | fine. |
 
-### 1. Test-yield estimate
+## 8. Test yield & regression gate
 
-| Source | Tests CE today (`Unsupported statement: WithStatement`) | Expected post-implementation |
-|---|---:|---:|
-| `language/statements/with/` — dedicated suite, ~174 noStrict + 7 strict negatives | 155 (some hit later CE before WithStatement) | ~150 pass + 7 already-passing strict-negative parse tests |
-| `language/expressions/compound-assignment/` (assignment-semantics through `with`) | 44 | ~40 pass |
-| `language/statements/function/` — function declarations inside `with` | 14 | ~12 pass |
-| `built-ins/Proxy/has/` — Proxy traps via `with` | 9 | needs Proxy; expect to remain CE/FAIL (not blocked by this issue) |
-| `language/expressions/{prefix,postfix}-{in,de}crement` + `compound-assignment` + `assignment` + `delete` through `with` LHS | ~20 | ~15 pass |
-| Other (dynamic-import, async generators, etc. that happen to embed `with`) | ~50 | mixed — these CE for other reasons too; expect modest gains (~10–15 pass) |
-| **Total** | **294 CE** | **~225–240 pass, remainder still CE/FAIL for unrelated reasons** |
+| Source | CE today (`Unsupported statement: WithStatement`) | Tier 1 | Tier 1+2 |
+|---|---:|---:|---:|
+| `language/statements/with/` (dedicated, ~174 noStrict + 7 strict negatives) | ~155 | most literal/builtin forms pass | nearly all |
+| compound-assignment / increment / delete / typeof through `with` LHS | ~64 | partial (closed-shape LHS) | most |
+| Proxy traps via `with` (`built-ins/Proxy/has/`) | ~9 | — (needs Proxy) | — |
+| Other (embed `with` incidentally, CE for other reasons too) | ~50 | modest | modest |
+| **Total** | **294 CE** | **target +120–160 net pass** | **target +200+ net pass** |
 
-Conservative regression-gate target: **+200 net pass** on test262 after this lands.
+Regression gate (per slice):
+1. `pnpm test -- tests/equivalence.test.ts` — green (no codegen regression).
+2. Add hand-rolled equivalence tests: `with(Math){…}`, `with({a,b}){…}`, `with(Object.freeze(o)){…}`,
+   nested `with`, `@@unscopables` block — assert against Node.js reference output.
+3. Scoped `pnpm test:262 --include language/statements/with` — expect newly-passing, 0 newly-failing.
+4. Full sharded test262 in CI — net pass ≥ +120 for Tier 1; no single bucket regression > 5.
 
-### 2. Files changed
+## 9. Superseded approach table (provenance only — NOT the plan)
 
-#### 2a. New file `src/codegen/statements/with-statement.ts` (~250 LOC)
+The original exploration evaluated five approaches; they are folded into the two tiers above and
+retained here only for history.
 
-The compiler for `WithStatement`. Exposes:
-
-```ts
-export function compileWithStatement(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  stmt: ts.WithStatement,
-): void;
-```
-
-It does:
-
-1. **Standalone gate**. If `ctx.options.target === "wasi"` or
-   `ctx.options.standalone === true`, call
-   `reportError(ctx, stmt, "with statement requires JS host (--target js); see #1387")`
-   and return.
-2. Compile `stmt.expression` → externref (use `coerceType` if needed); store in
-   a fresh local `__with_scope_<depth>` (allocated via `allocLocal`).
-3. **Static fast-path probe** (approach B): call a new helper
-   `analyzeWithBodyShadowing(ctx, fctx, stmt.statement)` which returns
-   `{ kind: "static" } | { kind: "dynamic", freeIdents: Set<string> }`. The
-   analyzer walks the body collecting every `ts.Identifier` that
-   (a) is a free reference (i.e. `ctx.checker.getSymbolAtLocation` returns
-   nothing, OR returns a symbol declared outside the body's lexical scope), and
-   (b) is in an expression / assignment / update / delete / typeof position,
-   not a declaration name, label, or member-access RHS. If the set is empty:
-   - Push the with-scope local onto `fctx.withScopeStack` (see §2b).
-   - Compile the body via `compileStatement` exactly as today.
-   - Pop the stack.
-   - Done. No runtime overhead — fast-path.
-4. **Dynamic slow-path** (approach A):
-   - Push the with-scope local index onto `fctx.withScopeStack`.
-   - Push the set of free identifiers onto a parallel
-     `fctx.withFreeIdentsStack` so `compileIdentifier` / `compileAssignment`
-     can cheaply test "is this name a candidate for `with` interception in the
-     current scope?".
-   - `compileStatement(ctx, fctx, stmt.statement)` — the body emitters now
-     consult the with-stack (see §2c).
-   - Pop both stacks.
-5. **Block-scoped name save/restore**: `with` does not introduce its own
-   lexical environment for `let`/`const` inside the body — the body is a
-   normal `Block`. The existing `saveBlockScopedShadows` mechanism in
-   `compileStatement` already handles that, so reuse the block compilation
-   path inside compileWithStatement instead of iterating statements ourselves.
-
-#### 2b. Modify `src/codegen/context/types.ts`
-
-Add to `FunctionContext` (around line 165, with the other narrowing fields):
-
-```ts
-/**
- * (#1387) Stack of local indices holding the externref `obj` for each
- * lexically-enclosing `with (obj)` block. Innermost = last element.
- * Empty/undefined when not inside any `with`. Consulted by
- * compileIdentifier / compileAssignment to gate the runtime property probe.
- */
-withScopeStack?: number[];
-/**
- * (#1387) Parallel to `withScopeStack`: each entry is the set of free
- * identifier names in that with-body that the static analyzer flagged as
- * "needs runtime probe". An identifier read whose name is NOT in any
- * scope's set can skip the probe entirely (we proved it can't shadow).
- * Innermost = last element.
- */
-withFreeIdentsStack?: Set<string>[];
-```
-
-Init both in every `FunctionContext` constructor site — grep for
-`labelMap: new Map()` (every place that creates one needs both new fields
-omitted, since they're optional, but if you find any other narrowing fields
-being explicitly defaulted to `new Set()`, mirror that pattern).
-
-#### 2c. Modify `src/codegen/expressions/identifiers.ts`
-
-Function `compileIdentifier` (line 326). At the very top, BEFORE the
-string-builder check, insert a `with`-scope probe:
-
-```ts
-// (#1387) `with` dynamic scope: if we're inside any `with (obj)` block and
-// this identifier is a free reference (not a static local in the body),
-// dispatch through __with_lookup which tries every enclosing scope object
-// in reverse order and falls through to the static binding on miss.
-if (fctx.withScopeStack && fctx.withScopeStack.length > 0) {
-  if (identifierNeedsWithProbe(fctx, name)) {
-    return emitWithLookupRead(ctx, fctx, id, name);
-  }
-}
-```
-
-Add helper `identifierNeedsWithProbe(fctx, name)`: returns true iff `name` is
-present in any of the per-with `withFreeIdentsStack` sets. (Fast — Set.has on
-a usually-small set.)
-
-Add helper `emitWithLookupRead(ctx, fctx, id, name)`:
-- Push the with-scope local for each enclosing `with`, innermost-first, as an
-  externref (or null sentinel via `ref.null.extern` for "no more scopes" — see
-  §3 for the runtime convention; in v1 we pass only the innermost and let
-  miss-fall-through to outer scopes happen by recursive emit, see below).
-- For multiple stacked `with`s the simplest correct codegen is to nest:
-  emit `__with_lookup(innermost, name, /*fallback closure*/ ...)`. To avoid
-  function-pointer fallbacks (we don't want to spawn a closure per ident),
-  expand the chain at compile time:
-  ```wasm
-  ;; pseudocode for `with(a) with(b) { x }` with innermost = b
-  local.get $__with_scope_b
-  global.get $__strconst_x
-  call $__with_has        ;; returns 1 if b has own x (post-unscopables)
-  if (result externref)
-    local.get $__with_scope_b
-    global.get $__strconst_x
-    call $__extern_get
-  else
-    local.get $__with_scope_a
-    global.get $__strconst_x
-    call $__with_has
-    if (result externref)
-      local.get $__with_scope_a
-      global.get $__strconst_x
-      call $__extern_get
-    else
-      ;; original identifier lookup fallthrough
-      <emit normal compileIdentifier body for name>
-    end
-  end
-  ```
-- The "normal compileIdentifier body" for the fallthrough is implemented by
-  *temporarily* clearing `fctx.withScopeStack` to `[]`, recursively calling
-  `compileIdentifier`, then restoring it. (Same trick the boxedCaptures path
-  could use — straightforward.)
-- Result type: always `externref` for the dynamic path. Caller sites that
-  expect f64 (e.g. arithmetic) will go through the existing
-  externref→f64 coercion in `coerceType`.
-
-#### 2d. Modify `src/codegen/expressions/assignment.ts`
-
-Function `compileAssignment` (line 86). After the `ts.isIdentifier(expr.left)`
-check enters (line 99) and before the `constBindings` check (line 102),
-insert the symmetric write-side probe:
-
-```ts
-if (fctx.withScopeStack && fctx.withScopeStack.length > 0
-    && identifierNeedsWithProbe(fctx, expr.left.text)) {
-  return emitWithLookupWrite(ctx, fctx, expr);
-}
-```
-
-`emitWithLookupWrite`:
-- Evaluate `expr.right` once into a temp local (externref).
-- Walk the `withScopeStack` from innermost to outermost; for each, emit
-  `__with_has(scope_i, name)` and, on true, emit
-  `__extern_set(scope_i, name, value)` and produce the value.
-- On miss in all scopes, fall through to the normal identifier-assignment
-  path (recursively, with the stack temporarily cleared).
-- Compound assignment (`x ^= 3` from the spec test above) flows through
-  `compileCompoundAssignment` which itself calls `compileAssignment` for the
-  store leg; no separate change needed there *as long as* the read leg also
-  routes through `emitWithLookupRead` (which it does — read uses
-  compileIdentifier).
-- **Reference-stability subtlety** (S11.13.2_A5.10_T3): the spec test
-  expects the compound assignment to use the *originally-resolved* base
-  even if the property is `delete`d mid-evaluation. Our slow-path naturally
-  does the right thing because we resolve once on read, store the value in
-  a temp, compute, then store back using `__extern_set` which uses the
-  same scope object reference — independent of whether the property was
-  deleted in between. **Document this in the function comment**; it's the
-  one place where naive "re-probe on write" would silently break a known
-  test.
-
-#### 2e. Modify `src/codegen/statements.ts`
-
-After the `ts.isTryStatement` branch (line 207), before the function-decl
-branch (line 212), add:
-
-```ts
-if (ts.isWithStatement(stmt)) {
-  markStatementPos(ctx, fctx, stmt, () => compileWithStatement(ctx, fctx, stmt));
-  return;
-}
-```
-
-Import `compileWithStatement` from `./statements/with-statement.js`.
-
-#### 2f. Modify `src/runtime.ts`
-
-Add three new host imports inside the `instantiate` proxy alongside
-`__extern_get` (around line 2322):
-
-```ts
-if (name === "__with_has") {
-  // Spec §9.1.1.2.1 (HasBinding for an object Environment Record):
-  // 1. Let foundBinding be ? HasProperty(O, N).
-  // 2. If foundBinding is false, return false.
-  // 3. If O.[[Symbol.unscopables]] is undefined, return true.
-  // 4. Let blocked be ? ToBoolean(unscopables[N]).
-  // 5. Return !blocked.
-  return (obj: any, key: string): number => {
-    if (obj == null) return 0;
-    let has: boolean;
-    try { has = key in Object(obj); } catch { return 0; }
-    if (!has) return 0;
-    let unsc: any;
-    try { unsc = (obj as any)[Symbol.unscopables]; } catch { return 1; }
-    if (unsc == null) return 1;
-    return unsc[key] ? 0 : 1;
-  };
-}
-// Optional: __with_get(obj, key) that combines __with_has + __extern_get
-// in one host call. Worth adding if perf measurements show the two-call
-// pattern hot.
-```
-
-(We already have `__extern_get` and `__extern_set` so no new write helper
-is needed.)
-
-#### 2g. Modify `src/compiler/validation.ts`
-
-Line 657: the strict-mode early-error is correct, keep it. **Remove** any
-hidden filter that bails out before reaching `compileWithStatement` in
-sloppy-mode code (grep `isWithStatement` — there's a third hit at line
-2556 and 3295, both diagnostic-only; both stay).
-
-#### 2h. Modify `tests/test262-runner.ts`
-
-No skip filter exists for `with` currently (verified by reading
-`shouldSkip` at line 306). Nothing to remove — tests just begin passing
-once the compiler stops emitting CE. The runner's `noStrict` wrapping
-already strips `"use strict"` (see existing handling), so no change there.
-
-#### 2i. Modify `src/codegen/index.ts`
-
-Where late imports are registered (grep `__extern_get` registration sites
-~line 7300, and `__throw_reference_error` etc.). Add a small helper
-`ensureWithHasImport(ctx, fctx)` that mirrors the existing
-`ensureLateImport` pattern; the new `with-statement.ts` calls it once per
-function that contains a slow-path `with`. **Crucial**: it MUST go through
-`shiftLateImportIndices` / `flushLateImportShifts` — adding an import
-mid-function shifts every funcIdx in `fctx.body`, which is exactly the
-foot-gun called out in CLAUDE.md ("addUnionImports shifts function
-indices").
-
-### 3. Wasm IR pattern (full example)
-
-Source:
-```js
-with (o) {
-  st_p1 = p1;
-}
-```
-
-Free idents flagged for probe: `st_p1`, `p1` (assuming both resolve to
-outer module scope; `o` is a normal local read).
-
-Emitted (slow-path):
-
-```wasm
-;; --- evaluate `o` once, store in __with_scope_0 ---
-(local.get $o_local)
-(local.set $__with_scope_0)
-;; --- BODY: st_p1 = p1 ---
-;; RHS — read of `p1` through with-scope
-(local.get $__with_scope_0)
-(global.get $__strconst_p1)
-(call $__with_has)
-(if (result externref)
-  (then
-    (local.get $__with_scope_0)
-    (global.get $__strconst_p1)
-    (call $__extern_get))
-  (else
-    ;; Normal compileIdentifier emission for p1 (e.g. a module global read)
-    (global.get $__moduleglobal_p1)
-    (call $__box_number)))   ;; coerce f64→externref since slow-path returns externref
-(local.set $__tmp_rhs)
-;; LHS write — st_p1 through with-scope
-(local.get $__with_scope_0)
-(global.get $__strconst_st_p1)
-(call $__with_has)
-(if
-  (then
-    (local.get $__with_scope_0)
-    (global.get $__strconst_st_p1)
-    (local.get $__tmp_rhs)
-    (call $__extern_set))
-  (else
-    ;; Normal assignment to module global st_p1
-    (local.get $__tmp_rhs)
-    (call $__unbox_to_f64)
-    (global.set $__moduleglobal_st_p1)))
-```
-
-### 4. Edge cases & spec-correctness checklist
-
-| Case | Handling |
+| Approach | Disposition under the two-tier plan |
 |---|---|
-| Strict mode (`"use strict"` or any module/class body) | Already errored in `validation.ts:657`; we never reach the codegen. |
-| `with` body declares `var foo` | `var` hoists to the enclosing function — the `var` binding wins over `obj.foo` per §9.1.1.2 (`var` creates the binding in the variable Environment, not the object Environment). The static analyzer must therefore treat `foo` as a *bound* (not free) ident in this case — so the probe is skipped automatically. **Spec test S12.10-0-1 covered.** |
-| `delete x` inside `with` | If `x` is a probe-candidate, emit `__with_has` and on hit emit `__extern_delete(scope, x)`; on miss fall through to normal `delete` handling. Needs one extra host import `__with_delete` or piggyback on existing `Reflect.deleteProperty` shim. Defer to follow-up issue if scope-creep — `delete` through `with` is ~4 test262 tests. |
-| `typeof x` inside `with` | Same probe; on hit emit `typeof __extern_get(...)`; on miss fall through. The fallthrough is what makes `typeof undeclared` not throw — that path already exists in `compileTypeofExpression`. |
-| `obj` is null / undefined | `with(null) { ... }` per §14.11.2 throws TypeError at the with-statement entry. Insert a null guard immediately after step 2 of `compileWithStatement` that throws TypeError. Use the existing `__throw_type_error` import. |
-| `obj` is a primitive (`with(2)`) | Per spec, ToObject(2) is performed first. The host's `Object(2)` does this implicitly inside `__with_has` via `Object(obj)`. (Test 12.10-2-1 — covered.) |
-| `obj.foo` is a getter that mutates `obj` (deletes a property) | Reference stability — covered in §2d. |
-| `@@unscopables` filter | Implemented in `__with_has` per spec §9.1.1.2.1. Test files: `language/statements/with/unscopables-*`. |
-| Nested `with(a) with(b)` | Compile-time-expanded `if/else` chain, innermost-first (see IR pattern). |
-| `with` containing function declaration | Hoisting of nested `function f(){}` happens before body codegen, so `f` is in the variable Environment, not the object Environment — flagged as bound, probe skipped. Matches §14.11.7. |
-| `eval` inside `with` | Already CE for unrelated reasons (eval) — no interaction. |
-| `with` inside generator / async | Body containing `yield` / `await` works because the slow-path emits straight-line Wasm with no function boundary; the generator transform already supports if/else. Add to v1 test plan but expect to pass. |
-| Closure capturing a free ident from inside a `with` body | The slow-path probe is purely at the read/write *site* — a nested function/arrow does NOT inherit the `with` scope (per spec §9.1.1.2: the object environment record IS pushed on the lexical environment, so closures DO see it). **This is the one hard case.** v1 will NOT support it correctly — emit a warning `with: identifier %s captured by nested closure may not see the with-scope binding (#1387 follow-up)`. Track as separate issue; <5 test262 tests touch this. |
+| **A — pure externref slow-path body** | Subsumed by **Tier 2**, but gated by closedness: A is only emitted when Tier 1 *cannot* prove a closed shape, and reuses `__extern_*` rather than a bespoke `__with_lookup` scope-chain. |
+| **B — static analysis for non-overlapping names** | Generalised and made *sound* by **Tier 1**: B's "no overlap" intuition is replaced by the **closedness** requirement (prove *absence*, not just presence), driven by IR provenance rather than a syntactic name walk. |
+| **C — desugar to `(function(scope){…}).call(obj)`** | Rejected (unchanged): renames the lookup problem, breaks `var` hoisting / `this` capture. |
+| **D — flat rejection in standalone** | Retained as the **residual CE** only for host objects in standalone mode; literals/builtins/Wasm-objects do not need it. |
+| **E — delegate body to JS host (`eval`-style)** | Rejected (unchanged): defeats WasmGC compilation. |
 
-### 5. Regression gate
+## Related
 
-1. Run `pnpm test -- tests/equivalence.test.ts` — must stay green (no `with`
-   tests there but verifies no codegen regression).
-2. Run `pnpm test:262 --include language/statements/with` locally —
-   expect ~150 newly-passing tests, 0 newly-failing.
-3. Full sharded test262 in CI — net pass delta ≥ +200, no single bucket
-   regression > 5.
-4. Snapshot the slow-path size cost: before merge, run
-   `wc -c` on `dist/runtime-*.wasm` for the sample `with`-containing
-   playground example; document in commit message.
+- `with` skip filter / runner: `tests/test262-runner.ts` (no `with` skip filter exists today —
+  tests begin passing once the compiler stops emitting CE; verified at `shouldSkip`).
+- Strict-mode early error (keep): `src/compiler/validation.ts:667` (§14.11.1).
+- IR shape & analysis: `src/ir/nodes.ts:100` (`IrObjectShape`), `src/ir/analysis/escape.ts`,
+  `src/ir/analysis/ownership.ts`, `src/ir/analysis/lattice.ts`, `src/ir/from-ast.ts:1670`
+  (`lowerObjectLiteral`), `src/ir/lower.ts`.
+- Frozen/sealed provenance (legacy): `src/codegen/context/types.ts:865-866`
+  (`frozenVars` / `sealedVars`).
+- Dynamic-property runtime (Tier 2 reuse): `src/runtime.ts:4726` (`__extern_get`), `:4738`
+  (`__extern_set`), `:4891` (`__extern_has`).
+- Object-representation ceiling (bounds Tier 2): #1719, #1130, #1320, #1732.
+- Eval (similar dynamic-scope problem): `plan/issues/1262-eval-static-string-compile-time.md`.
+- CLAUDE.md: "compile away, don't emulate" + dual-mode (JS host optional) — Tier 1 *compiles the
+  `with` away*; Tier 2 is the principled dynamic fallback for the unprovable residual.
 
-### 6. LOC estimate
+## Acceptance criteria for the architect spec
 
-| File | LOC added | LOC modified |
-|---|---:|---:|
-| `src/codegen/statements/with-statement.ts` (new) | ~250 | 0 |
-| `src/codegen/expressions/identifiers.ts` | ~60 (helpers + probe call) | ~5 |
-| `src/codegen/expressions/assignment.ts` | ~80 (write probe + temp) | ~5 |
-| `src/codegen/statements.ts` | ~5 | ~1 |
-| `src/codegen/context/types.ts` | ~12 (fields + comments) | 0 |
-| `src/codegen/index.ts` | ~25 (`ensureWithHasImport` helper) | ~3 |
-| `src/runtime.ts` | ~25 (`__with_has` shim, optional `__with_delete`) | 0 |
-| Tests: hand-rolled equivalence test for `with(o){…}` | ~80 | 0 |
-| **Total** | **~535 LOC** | **~14 LOC** |
-
-Estimated effort: 1 senior dev, 2–3 days. Architecturally moderate; the
-risk concentrates in (a) the late-import shift inside slow-path codegen
-(must use `shiftLateImportIndices` everywhere) and (b) the closure-capture
-follow-up which v1 explicitly punts on.
-
-### 7. Open questions for the dev who picks this up
-
-1. The free-identifier analyzer (§2a step 3) needs `ctx.checker` access from
-   a syntactic walk — confirm `getSymbolAtLocation` works on free idents
-   inside a `WithStatement` (TS sometimes refuses to type-check `with`
-   bodies). If it doesn't, fall back to a name-based heuristic: any
-   `Identifier` text that is not in `fctx.localMap`, not in
-   `fctx.boxedCaptures`, not in `ctx.moduleGlobals`, not a known global,
-   gets probed. The over-conservative heuristic is fine — it just emits
-   slightly slower code, never incorrect code.
-2. The TypeScript parser may reject `with` in `.ts` files even outside
-   strict mode (depends on `allowJs`). Verify with a probe in `.tmp/`:
-   ```ts
-   // .tmp/probe-with.ts
-   var o = {x: 1};
-   with (o) { console.log(x); }
-   ```
-   If TS refuses, route `with` through the `.js` allowJs path that
-   `tests/test262-runner.ts` already uses. The runner already strips
-   `"use strict"` per the `noStrict` flag handling.
-3. Confirm `markStatementPos` works on `WithStatement` for source maps —
-   should be a no-op concern but worth one source-mapped breakpoint test.
-
-### 8. Follow-up issues (do NOT block this PR)
-
-- `#1387-follow-up-a`: `delete x` through `with` scope (4 tests).
-- `#1387-follow-up-b`: closure captures of `with`-scoped names (edge case,
-  <5 tests). Requires lifting the with-scope into a closure-captured
-  externref slot.
-- `#1387-follow-up-c`: `__with_get` host fusion (perf) — combine
-  `__with_has` + `__extern_get` into a single host call returning a
-  sentinel for miss. Only do this if perf telemetry shows the slow-path
-  hot.
-
+1. ✅ Reframed as prove-or-demote with two tiers (Tier 1 IR-proven static routing; Tier 2 dynamic
+   fallback), driven by an IR closed-shape fact.
+2. ✅ Defined the IR closed-shape fact (`ClosedShapeFact`: closed bit, key set, proto shape,
+   `@@unscopables`), its three sub-analyses, the IR structures/passes it touches, and where it is
+   computed and consumed.
+3. ✅ Connected Tier 2 to the existing dynamic-property machinery (`__extern_has`/get/set,
+   #1719/#1130) and noted the standalone-vs-JS-host split.
+4. ✅ Re-graded feasibility (Tier 1 medium/dispatchable; Tier 2 hard/deferred) and recommended
+   slicing.
+5. ✅ Called out the IR prerequisite (access-lattice mutation tag) rather than assuming it.


### PR DESCRIPTION
Rewrites the `## Implementation Plan` in `plan/issues/1387-with-statement-dynamic-scope-implementation.md` around a **prove-or-demote** design driven by the IR's static analysis, per the project lead's direction. **Plan doc only — no compiler code changes.**

## Two tiers

**Tier 1 — IR-proven static routing (medium, dispatchable).** When the IR proves `obj` has a **closed shape**, each free-identifier reference is resolved at compile time via `HasBinding` (= `HasProperty` + `@@unscopables`, §9.1.1.2.1) to either `obj.x` or the lexical binding. Zero runtime cost — the `with` evaporates. The load-bearing fact is **closedness** (prove *absence* of a key), which comes from **IR provenance** (object literals, `Object.freeze`/sealed, `Math`/`JSON`, statically-visible compiler-constructed objects) — **not** tsc's open, excess-property-permitting structural types.

Specs a new **`ClosedShapeFact`** (closed bit, complete key set, prototype shape, `@@unscopables` resolution) computed by a new inference-only pass `src/ir/analysis/closed-shape.ts` (sibling to `escape.ts`/`ownership.ts`), consuming the existing escape/ownership analysis as the no-mutation-across-body gate, consumed at the `with` lowering site in `from-ast.ts`/`lower.ts`.

**Tier 2 — dynamic fallback (hard, deferred).** Unprovable bodies (opaque/externref targets, mutated keys/proto, dynamic `@@unscopables`) demote to the dynamic-object representation, **reusing** `__extern_has`/`__extern_get`/`__extern_set` (#1719/#1130) — only a thin `@@unscopables`-aware `__with_has` wrapper is new. Notes the standalone-vs-JS-host split. Bounded by the object-representation ceiling, so it follows the dynamic-representation track.

## Prerequisite called out (not assumed)
The no-mutation gate needs an **access-lattice "key-set-mutating access" tag** added to `src/ir/analysis/lattice.ts` — the escape pass tracks allocation escape but not key/proto mutation as an access tag. Flagged as the first Tier-1 sub-task.

## Feasibility re-grade
`hard` → `medium` (Tier 1, dispatchable now) + `hard` (Tier 2, deferred). Recommends shipping Tier 1 first — it covers the bulk of the ~294 skipped `with` tests (literal/builtin forms) at zero runtime cost. Status kept `ready`.

Do NOT enqueue — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)