### PR TITLE
chore(sprint): close S57, roll open + GH#389 issues to S58 + retrospective

### DIFF
--- a/plan/issues/1542-class-method-dstr-default-not-applied.md
+++ b/plan/issues/1542-class-method-dstr-default-not-applied.md
@@ -3,11 +3,11 @@ id: 1542
 title: "Class method destructured-pattern param default not applied; throws \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"Cannot destructure null\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" instead"
 status: ready
 created: 2026-05-20
-updated: 2026-05-29
+updated: 2026-05-31
 priority: high
 feasibility: hard
 goal: test262-conformance
-sprint: 57
+sprint: 58
 parent: 820
 test262_fail: 134
 ---

--- a/plan/issues/1580-string-hash-benchmark-wasm-validator-error-and-poor-perf.md
+++ b/plan/issues/1580-string-hash-benchmark-wasm-validator-error-and-poor-perf.md
@@ -3,7 +3,7 @@ id: 1580
 title: "string-hash benchmark: wasm-validator pre-existing bug + uncompetitive hot runtime"
 status: in-progress
 created: 2026-05-21
-updated: 2026-05-30
+updated: 2026-05-31
 completed: 2026-05-23
 priority: high
 feasibility: medium
@@ -12,7 +12,7 @@ task_type: performance
 area: codegen
 language_feature: strings
 goal: performance
-sprint: 57
+sprint: 58
 related: [1175, 1178, 1210, 1184]
 origin: surfaced again by 4-lane competitive benchmark refresh
 ---

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -3,7 +3,7 @@ id: 1712
 title: "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn"
 status: backlog
 created: 2026-05-29
-updated: 2026-05-29
+updated: 2026-05-31
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -12,7 +12,7 @@ area: test-infrastructure, codegen
 language_feature: multi
 es_edition: multi
 goal: self-hosting-dogfood
-sprint: 57
+sprint: 58
 depends_on: [1710, 1711]
 related: [1690, 1690b, 1584, 1058]
 ---

--- a/plan/issues/1742-closure-this-receiver-vec-struct-member-read-guard.md
+++ b/plan/issues/1742-closure-this-receiver-vec-struct-member-read-guard.md
@@ -3,14 +3,14 @@ id: 1742
 title: "Closure `this`-receiver member reads trap 'illegal cast' when `this` is a compiled vec/struct (CPR prerequisite, shared with #1629)"
 status: in-progress
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-05-31
 priority: high
 feasibility: medium
 task_type: bugfix
 area: codegen
 language_feature: this-receiver-binding
 goal: test262-conformance
-sprint: 57
+sprint: 58
 related: [1719, 1629, 1636]
 ---
 

--- a/plan/issues/1751-wit-generator-incomplete-world-package-imports.md
+++ b/plan/issues/1751-wit-generator-incomplete-world-package-imports.md
@@ -3,7 +3,7 @@ id: 1751
 title: "WIT generator emits an incomplete world: hardcoded package name + no WASI imports"
 status: ready
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-05-31
 priority: medium
 feasibility: medium
 task_type: feature
@@ -11,7 +11,7 @@ area: wit-generator
 goal: platform
 related: [600, 639, 389]
 depends_on: []
-sprint: Backlog
+sprint: 58
 ---
 
 # #1751 — WIT generator emits an incomplete world

--- a/plan/issues/1752-textencoder-textdecoder-runtime-api.md
+++ b/plan/issues/1752-textencoder-textdecoder-runtime-api.md
@@ -3,7 +3,7 @@ id: 1752
 title: "TextEncoder / TextDecoder runtime API (standalone + WASI)"
 status: ready
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-05-31
 priority: medium
 feasibility: medium
 task_type: feature
@@ -12,7 +12,7 @@ language_feature: web-api
 goal: platform
 related: [389, 1588, 1655]
 depends_on: []
-sprint: Backlog
+sprint: 58
 ---
 
 # #1752 — TextEncoder / TextDecoder runtime API

--- a/plan/issues/1753-native-messaging-64mib-chunked-streaming.md
+++ b/plan/issues/1753-native-messaging-64mib-chunked-streaming.md
@@ -3,7 +3,7 @@ id: 1753
 title: "Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming"
 status: ready
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-05-31
 priority: medium
 feasibility: medium
 task_type: feature
@@ -11,7 +11,7 @@ area: examples
 goal: platform
 related: [389, 1655, 1700, 1752]
 depends_on: []
-sprint: Backlog
+sprint: 58
 ---
 
 # #1753 — Native-messaging host: 64 MiB chunked streaming

--- a/plan/issues/1755-uint8array-arraybuffer-generic-annotation.md
+++ b/plan/issues/1755-uint8array-arraybuffer-generic-annotation.md
@@ -3,7 +3,7 @@ id: 1755
 title: "TS annotation: Uint8Array<ArrayBuffer> generic typed-array form not handled"
 status: ready
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-05-31
 priority: low
 feasibility: medium
 task_type: bug
@@ -12,7 +12,7 @@ language_feature: typed-arrays
 goal: platform
 related: [389, 1752, 1700]
 depends_on: []
-sprint: Backlog
+sprint: 58
 ---
 
 # #1755 — `Uint8Array<ArrayBuffer>` generic annotation

--- a/plan/issues/1759-wasi-native-number-to-string-bridge-gap.md
+++ b/plan/issues/1759-wasi-native-number-to-string-bridge-gap.md
@@ -12,7 +12,7 @@ language_feature: template-literals
 goal: platform
 related: [389, 985]
 depends_on: []
-sprint: Backlog
+sprint: 58
 ---
 
 # #1759 — WASI native number→string bridge gap

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -12,7 +12,7 @@ Architectural sprint (no pass-count target; zero-regression guard). Goals:
 Track 1 — acorn dogfood:
 - [#1710](../1710-acorn-dogfood-harness.md) — acorn harness: compile + validate + diff-AST vs node-acorn — high, medium, **ready (s57)**.
 - [#1711](../1711-acorn-failure-surface-triage.md) — triage harness surface → file sized child issues — high, medium, **ready (s57)**, depends on #1710.
-- [#1712](../1712-acorn-acceptance-differential-ast.md) — acceptance: compiled acorn AST == node-acorn — high, hard, **backlog→ready** after #1710/#1711.
+- [#1712](../1712-acorn-acceptance-differential-ast.md) — acceptance: compiled acorn AST == node-acorn — high, hard, **carried to sprint 58** (#1710/#1711 done; unblocked by #1745).
 - Prior blockers #1679/#1690/#1690b are **done**.
 
 Track 2 — backend-agnostic IR (all need architect spec; #1713 blocking):
@@ -122,6 +122,8 @@ fidelity → #1463) were NOT re-filed.
 
 ### Platform / Component Model & runtime (from GitHub #389)
 
-- [#1751](../1751-wit-generator-incomplete-world-package-imports.md) — WIT generator emits an incomplete world: hardcoded `local:module` package + no `import` side (vs `wasm-tools`-extracted component WIT) — medium, medium, **ready**
-- [#1752](../1752-textencoder-textdecoder-runtime-api.md) — `TextEncoder`/`TextDecoder` runtime API (UTF-8, standalone + WASI; builds on #1588) — medium, medium, **ready**
-- [#1753](../1753-native-messaging-64mib-chunked-streaming.md) — Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming (on the byte-native loop; builds on #1655) — medium, medium, **ready**
+- [#1751](../1751-wit-generator-incomplete-world-package-imports.md) — WIT generator emits an incomplete world: hardcoded `local:module` package + no `import` side (vs `wasm-tools`-extracted component WIT) — medium, medium, **ready (sprint 58)**
+- [#1752](../1752-textencoder-textdecoder-runtime-api.md) — `TextEncoder`/`TextDecoder` runtime API (UTF-8, standalone + WASI; builds on #1588) — medium, medium, **ready (sprint 58)**
+- [#1753](../1753-native-messaging-64mib-chunked-streaming.md) — Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming (on the byte-native loop; builds on #1655) — medium, medium, **ready (sprint 58)**
+- [#1755](../1755-uint8array-arraybuffer-generic-annotation.md) — `Uint8Array<ArrayBuffer>` generic type annotation not accepted (from GitHub #389) — medium, medium, **ready (sprint 58)**
+- [#1759](../1759-wasi-native-number-to-string-bridge-gap.md) — WASI `process.stderr.write` numeric-template → native number→string bridge gap (from GitHub #389) — medium, medium, **ready (sprint 58)**

--- a/plan/issues/sprints/57.md
+++ b/plan/issues/sprints/57.md
@@ -1,8 +1,9 @@
 ---
 sprint: 57
-status: active
+status: closed
 created: 2026-05-29
 started: 2026-05-29
+closed: 2026-05-31
 authors: product-owner
 baseline_pass: 30214
 baseline_total: 43135
@@ -188,3 +189,81 @@ block the track-1/track-2 architecture work.
 (track 1); make the IR backend-agnostic so it can someday *be* an interpreter
 (track 2). Both tracks de-risk the in-Wasm bytecode interpreter (#1584) without
 committing to its multi-week build.
+
+---
+
+# Sprint 57 — Retrospective (closed 2026-05-31)
+
+Baseline at open: 30,214 / 43,135 (70.0%), CI run 9ee8e921. This was an
+architectural / dogfooding sprint with no pass-count target; the guard was
+"zero regression". The sprint delivered against both strategic tracks and
+picked up several adjacent wins.
+
+## What landed
+
+**#1584 — backend-agnostic VM / bytecode-interpreter migration (the headline).**
+Both s57 IR proofs (#1713 trait seam, #1714 two-backend lower, #1715 minimal
+bytecode emitter) merged, then #1584 advanced far beyond the planned "minimal
+proof": the call-family (CALL/CALL_REF, multi-frame call-stack VM),
+struct/object family (STRUCT_NEW/GET/SET), control-flow family
+(block/loop/br/br_if, JNZ), and the try-throw family (THROW/TRY_START/TRY_END
++ exceptionTable, table-scan exception model) were all migrated behind the
+`BackendEmitter` trait and realized as bytecode running on a real VM dispatch
+loop — `lower.ts` now drives the bytecode path directly. This validated the
+seam against a fundamentally different execution model, exactly the claim the
+sprint existed to de-risk.
+
+**#1719 — compiled-prototype-record (CPR) cluster.** CPR-2 finished: assignment
+array destructuring, parameter / externref-decl array dstr, and for-of-head
+array dstr now all drive the overridden `@@iterator`, with null-guards on the
+override read path.
+
+**String-hash perf (#1746 + #1760).** #1746 lever-1 landed the i32 hash path on
+linear memory to close the warm-V8 gap via AOT analysis; #1760 added an
+in-process warm lane for the wasm-host benchmark, fixing the measurement
+methodology so the perf claim is honestly benchmarked. #1744 (string-builder
+build-loop perf) also closed its remaining gap vs StarlingMonkey.
+
+**#1757 — async `compile()` migration (closes GH #986).** The `compile()` API
+became async across source, playground, scripts, and benchmarks; binaryen is
+now embedded in standalone bundles; follow-up fixes (#992, #998) caught the
+non-test callers that the phased migration missed.
+
+**Acorn self-hosting dogfood.** #1710 (harness: compile + validate + diff-AST
+vs node-acorn) and #1711 (failure-surface triage) landed; #1745 fixed a closure
+var-hoist (`global.set f64` vs `ref`) blocker so compiled acorn now compiles and
+validates past `__closure_37`. #1712 (full AST-equality acceptance gate) remains
+the open acceptance criterion — carried to S58.
+
+**Merge-queue stabilization (#1758).** Auto-enqueue sweep made surgical (grace
+window + queue back-off + single-flight) to stop the stranded-PR / re-enqueue
+churn seen at s57 open.
+
+**Native-messaging host (#389 / #1733 / #1723 / #1724).** Byte-write helpers
+hardened against 1 MiB body corruption (#1733), ConsString cast + large-message
+overflow in writeMessage fixed (#1723), and WASI number-formatting itoa-scratch
+string-constant aliasing fixed (#1724). #985 routed numeric debug output to
+`console.error` under WASI.
+
+**ES3 edition quick wins.** #1511 (mapped-arguments descriptors + trailing-comma
+length), #1720 (inc/dec reference evaluated once before null deref), #1721
+(`class extends Function`/`Object` instanceof), #1722 (AssignmentTargetType
+early SyntaxError), plus #1740 (padStart/padEnd default fillString).
+
+## Carry-overs to Sprint 58
+
+- **#1542** (ready) — class-method destructured-param default not applied; hard,
+  prior fix reverted with a -1219 regression, needs a fresh approach.
+- **#1580** (in-progress) — string-hash benchmark wasm validator error + poor
+  perf; partially addressed by #1746/#1760, residual open.
+- **#1712** (backlog) — acorn full-module AST-equality acceptance gate; the
+  track-1 acceptance criterion, now unblocked by #1745.
+- **#1742** (in-progress) — closure `this`-receiver vec/struct member-read guard.
+
+## Notes
+
+- Conformance guard held: the architectural work was net-neutral on test262 by
+  design; pass-rate movement came from the ES3 and native-messaging bucket
+  fixes, not the IR/VM refactors.
+- `sprint/57` git tag is deferred to the tech lead until the remaining in-flight
+  PRs land.

--- a/plan/issues/sprints/58.md
+++ b/plan/issues/sprints/58.md
@@ -1,0 +1,48 @@
+---
+sprint: 58
+status: planning
+created: 2026-05-31
+authors: product-owner
+baseline_pass: 30214
+baseline_total: 43135
+baseline_pct: 70.0
+target_pass: tbd
+expected_gain: tbd
+---
+
+# Sprint 58 Plan (stub)
+
+Stub created at S57 close (2026-05-31). Carries the open S57 work plus the
+still-open guest271314 / GH #389 native-messaging follow-ups. Full goal framing,
+prioritisation, and architect routing to be added at S58 planning.
+
+## Carried over from Sprint 57
+
+| ID | Title | Status | Notes |
+|----|-------|--------|-------|
+| [#1542](../1542-class-method-dstr-default-not-applied.md) | class-method destructured-param default not applied | ready | hard; prior fix reverted with -1219 regression — needs a fresh approach |
+| [#1580](../1580-string-hash-benchmark-wasm-validator-error-and-poor-perf.md) | string-hash benchmark wasm validator error + poor perf | in-progress | partially addressed by #1746/#1760; residual open |
+| [#1712](../1712-acorn-acceptance-differential-ast.md) | acorn acceptance: compiled AST == node-acorn | backlog | track-1 acceptance gate; unblocked by #1745 |
+| [#1742](../1742-closure-this-receiver-vec-struct-member-read-guard.md) | closure `this`-receiver vec/struct member-read guard | in-progress | |
+
+## GH #389 native-messaging follow-ups
+
+Still-open guest271314 reports tracked under GitHub issue #389. The native
+messaging host body-corruption and WASI itoa fixes landed in S57 (#1733/#1723/
+#1724); these five are the remaining gaps.
+
+| ID | Title | Status |
+|----|-------|--------|
+| [#1751](../1751-wit-generator-incomplete-world-package-imports.md) | WIT generator emits incomplete world (hardcoded pkg, no WASI imports) | ready |
+| [#1752](../1752-textencoder-textdecoder-runtime-api.md) | TextEncoder / TextDecoder runtime API | ready |
+| [#1753](../1753-native-messaging-64mib-chunked-streaming.md) | native-messaging 64 MiB chunked streaming | ready |
+| [#1755](../1755-uint8array-arraybuffer-generic-annotation.md) | `Uint8Array<ArrayBuffer>` generic annotation | ready |
+| [#1759](../1759-wasi-native-number-to-string-bridge-gap.md) | WASI `process.stderr.write` numeric-template → native number→string bridge gap | ready |
+
+## To be planned
+
+- Goal framing + prioritisation (value × unblocking).
+- Architect routing for hard issues (#1542, #1712).
+- #1584 continuation scope (the VM/bytecode-interpreter migration advanced well
+  in S57 — decide the S58 increment).
+- test262 baseline refresh + any new pass-count target.

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -12,9 +12,9 @@ Architectural sprint. Two tracks; conformance guard is zero-regression.
 
 | #     | Title | Priority | Feasibility | Status | Depends on |
 |-------|-------|----------|-------------|--------|------------|
-| 1710  | acorn dogfood harness (compile + validate + diff-AST vs node-acorn) | high | medium | Ready | — |
-| 1711  | triage harness surface → file sized child issues | high | medium | Ready | #1710 |
-| 1712  | acceptance: compiled acorn AST == node-acorn on a representative .js | high | hard | Backlog→ready after #1710/#1711 | #1710, #1711 |
+| 1710  | acorn dogfood harness (compile + validate + diff-AST vs node-acorn) | high | medium | Done (s57) | — |
+| 1711  | triage harness surface → file sized child issues | high | medium | Done (s57) | #1710 |
+| 1712  | acceptance: compiled acorn AST == node-acorn on a representative .js | high | hard | Carried to sprint 58 (unblocked by #1745) | #1710, #1711 |
 
 Prior acorn blockers #1679 / #1690 / #1690b are **done** (regression-guarded by #1710).
 


### PR DESCRIPTION
Plan-docs-only sprint-close admin for Sprint 57.

## Changes
- **Rolled 4 open Sprint-57 issues → Sprint 58** (frontmatter \`sprint: 57\` → \`58\`): #1542 (ready), #1580 (in-progress), #1712 (backlog), #1742 (in-progress).
- **Added 5 still-open GitHub #389 native-messaging follow-ups → Sprint 58** (\`sprint: Backlog\` → \`58\`): #1751, #1752, #1753, #1755, #1759.
- **Sprint 57 retrospective** appended to \`plan/issues/sprints/57.md\` (status → closed). Themes: #1584 Wasm-GC bytecode-interpreter migration; #1719 compiled-prototype-record cluster; string-hash perf (#1746 i32 path + #1760 warm-bench methodology); #1757 async \`compile()\` (closes GH #986); acorn dogfood (#1710/#1711/#1745); merge-queue stabilization (#1758); native-messaging host (#389/#1733/#1723/#1724); ES3 quick wins.
- **Sprint 58 planning stub** at \`plan/issues/sprints/58.md\` (carry-overs + a "GH #389 native-messaging follow-ups" group).
- **Housekeeping**: backlog + dependency-graph sprint annotations updated for the moved issues.

Sprint \`sprint/57\` git tag is **deferred to the tech lead** until the remaining in-flight PRs land. Do NOT enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)