### PR TITLE
docs(#1764): measured cold-cost anatomy (module is 1.4 KB, not 800 KB)

### DIFF
--- a/plan/issues/1764-wasmtime-bench-production-serverless-scenarios.md
+++ b/plan/issues/1764-wasmtime-bench-production-serverless-scenarios.md
@@ -166,6 +166,39 @@ context/instance from a warm engine (µs–ms)."** Expected effect:
   is a much closer race than process boot vs process boot, which is the
   honest story.
 
+## Measured cold-cost anatomy (2026-05-31, aarch64 dev container, wasmtime 44)
+
+Direct measurement decomposing the `string-hash` cold number — to correct the
+prior (wrong) assumption that it reflected a large module. **It does not: the
+module is tiny; cold is dominated by fixed per-instance `wasmtime run`
+instantiation, not module weight or AOT slowness.**
+
+- `string-hash.js` source: 28 lines / 601 B.
+- Compiled module (`target: wasi, nativeStrings, optimize: 3`): **1.4 KB wasm**
+  (gzip 0.7 KB). Precompiled artifact: **201 KB `.cwasm`** (native code +
+  wasmtime AOT format overhead).
+- **Bare `wasmtime run` of an empty no-op module: ~2 ms** (warm disk cache) —
+  i.e. wasmtime's own process startup is *not* the bottleneck.
+- Cold `wasmtime run --allow-precompiled --invoke run` (best-of-3):
+  - `run(1)`   (≈zero compute): **24 ms**
+  - `run(1000)`               : **22 ms**
+  - `run(50000)` (heavy build+hash): **56 ms**
+
+**Interpretation:** `run(1)` does essentially no work yet costs ~24 ms, so
+**~22 ms is fixed per-instance instantiation overhead** over the ~2 ms bare
+floor — loading the precompiled module + building the **WasmGC heap / type
+definitions** + **WASI** context init + linear-memory growth + first-touch page
+faults. Only the jump to 56 ms at n=50000 is actual compute. The published
+~30 ms cold ≈ this ~22 ms fixed instantiate + the workload run once.
+
+**Why this matters for the two-lane redesign above:** that ~22 ms is precisely
+what a warm-engine / pre-instantiated-module / Wizer-snapshot model removes —
+dropping cold toward the ~2 ms floor and revealing AOT's real cold-start lead
+(which the current fresh-instantiate-per-call measurement masks). It is also
+why the interpreter lanes cluster at ~28–31 ms: they pay the analogous
+per-instance engine-setup cost. So Lane B (Wasm pre-instantiated pool) should
+report this ~22 ms instantiate cost **once at pool warm-up**, not per request.
+
 ## Acceptance criteria
 
 - [ ] **Company-agnostic labels** throughout the harness header and landing


### PR DESCRIPTION
Adds a measured cold-cost decomposition to #1764, correcting an earlier wrong assumption that the string-hash cold number reflected a large module.

**Measured (aarch64 dev container, wasmtime 44):**
- string-hash module = **1.4 KB** wasm (gzip 0.7 KB) / 201 KB precompiled cwasm
- bare empty `wasmtime run` = **~2 ms** (startup is *not* the bottleneck)
- `run(1)` cold = **24 ms** (≈zero compute) ⇒ **~22 ms fixed per-instance instantiation** (WasmGC heap/type setup + WASI init + memory growth + first-touch)
- `run(50000)` = 56 ms (the only part that's real compute)

So cold ≈ ~22 ms fixed instantiate + workload-once — not module weight, not AOT slowness. This is exactly what Lane B's pre-instantiated/warm-engine model removes (pay it once at pool warm-up, not per request).

Plan-doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)