### PR TITLE
fix(wasi): validate allowJs native sendMessage (#1768)

### DIFF
--- a/plan/issues/1768-allowjs-native-messaging-sendmessage-invalid-wasm.md
+++ b/plan/issues/1768-allowjs-native-messaging-sendmessage-invalid-wasm.md
@@ -1,0 +1,120 @@
+---
+id: 1768
+title: "allowJs native-messaging sendMessage emits invalid WASI wasm"
+status: done
+created: 2026-06-01
+updated: 2026-06-01
+completed: 2026-06-01
+priority: high
+feasibility: medium
+reasoning_effort: high
+es_edition: multi
+language_feature: allowjs
+task_type: bug
+area: compiler
+goal: platform
+related: [389, 80, 1061, 1654, 1753]
+depends_on: []
+sprint: 58
+origin: "GitHub #389 guest271314 comment 2026-06-01T00:17:59Z"
+---
+
+# #1768 — allowJs native-messaging `sendMessage` emits invalid WASI wasm
+
+## Problem
+
+guest271314 transpiled the working TypeScript native-messaging host to plain
+JavaScript with both `tsc` and `bun build`, then compiled that `.js` input:
+
+```sh
+node ~/bin/js2wasm.js nm_js2wasm.js --wit --target wasi -o .
+```
+
+The compile step emitted `.wasm`, `.wat`, `.d.ts`, `.imports.js`, and `.wit`,
+but wasmtime rejected the generated module in `sendMessage`:
+
+```text
+Error: failed to compile: wasm[0]::function[36]::sendMessage
+
+Caused by:
+    0: WebAssembly translation error
+    1: Invalid input WebAssembly code at offset 7741:
+       unknown global: global index out of bounds
+```
+
+He also saw the earlier pre-pull failure shape:
+
+```text
+Invalid input WebAssembly code at offset 7044:
+type mismatch: expected externref, found f64
+```
+
+The same host logic works from the TypeScript source. Plain JavaScript input is
+a first-class expectation for `js2wasm`, so this needs its own allowJs regression
+track rather than being folded into the TypeScript native-messaging example.
+
+Source: <https://github.com/loopdive/js2/issues/389#issuecomment-4588674539>
+
+## Repro shape
+
+The failing JavaScript includes:
+
+- `new Uint8Array(...)` allocation for frame headers and output frames.
+- `message.subarray(...)`, `message.indexOf(...)`, and `output.set(...)`.
+- nullable/sentinel `prepend` / `append` control flow.
+- `process.stdin.read(...)` and `process.stdout.write(...)`.
+- `console.error` numeric-template telemetry.
+
+The minimization should start from the reporter's transpiled
+`readExact` / `decodeLength` / `getMessage` / `sendMessage` / `main` source and
+reduce until the invalid `sendMessage` body is isolated.
+
+## Scope
+
+- Add a minimized allowJs regression test using `.js` input and `--target wasi`.
+- Ensure the generated module validates under the same wasmtime feature flags
+  used by the native-messaging smoke tests.
+- Root-cause why the allowJs path diverges from the typed TypeScript source:
+  likely typed-array inference, nullable sentinel inference, native-string
+  telemetry, or stale standalone/WASI global emission.
+- Keep #1654's fixed ArrayBuffer/DataView path from regressing; this report has
+  the same "unknown global" surface symptom but is JS-input-specific.
+
+## Acceptance
+
+- The minimized `.js` repro compiles and instantiates under wasmtime.
+- The full transpiled native-messaging host compiles to valid WASI wasm.
+- No validator failures (`unknown global: global index out of bounds` or
+  `expected externref, found f64`) are emitted from the allowJs `sendMessage`
+  path.
+- A regression test pins both compile-time success and real-runtime validation.
+
+## 2026-06-01 minimization/fix notes
+
+- Added `tests/issue-1768.test.ts` with a minimized plain `.js` allowJs
+  `sendMessage` shape: `new Uint8Array`, `message.indexOf`,
+  `message.subarray`, `output.set`, and `process.stdout.write` under
+  `target: "wasi"`. The test validates the wasm module, rejects `env` imports,
+  runs it with a small WASI `fd_write` shim, and checks the framed stdout bytes.
+- Root cause 1: WASI/native string constants use `-1` sentinels in
+  `ctx.stringGlobalMap`; several dynamic property/method fallback paths still
+  emitted `global.get` for those sentinels. Replacing those with
+  `stringConstantExternrefInstrs(...)` removes the invalid
+  `global index out of bounds` wasm.
+- Root cause 2: allowJs parameters can be inferred to wasm vec refs from call
+  sites while the TypeScript receiver type remains `any`. Array/typed-array
+  method dispatch now consults the actual wasm local/global/probe type before
+  giving up, and `TypedArray#set` does the same for its source argument.
+- Root cause 3: `const body = message.subarray(...)` was hoisted as
+  `externref`, forcing the vec through the generic iterable conversion path.
+  The let/const hoist pass now infers vec results for `.slice`/`.subarray`
+  initializers when the receiver is already a wasm vec, and variable
+  initialization uses the already-hoisted local type as the expected type.
+- Scoped validation passes:
+  `node node_modules/vitest/dist/cli.js run tests/issue-1768.test.ts`.
+- Neighboring typed-array stream checks:
+  `tests/issue-1664.test.ts` and `tests/issue-1766.test.ts` pass in a combined
+  run. The same combined run exposed an existing `tests/issue-1655...`
+  ArrayBuffer helper validation failure (`__wasi_write_arraybuffer` uses local
+  index 4 without declaring that local), which appears separate from #1768 and
+  likely belongs with the ongoing ArrayBuffer/memory-growth work.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -127,6 +127,7 @@ fidelity → #1463) were NOT re-filed.
 - [#1753](../1753-native-messaging-64mib-chunked-streaming.md) — Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming (on the byte-native loop; builds on #1655) — medium, medium, **ready (sprint 58)**
 - [#1755](../1755-uint8array-arraybuffer-generic-annotation.md) — `Uint8Array<ArrayBuffer>` generic type annotation not accepted (from GitHub #389) — medium, medium, **ready (sprint 58)**
 - [#1759](../1759-wasi-native-number-to-string-bridge-gap.md) — WASI `process.stderr.write` numeric-template → native number→string bridge gap (from GitHub #389) — medium, medium, **ready (sprint 58)**
+- [#1768](../1768-allowjs-native-messaging-sendmessage-invalid-wasm.md) — Plain `.js` / allowJs native-messaging `sendMessage` compiles but emits invalid WASI wasm (`unknown global`, earlier `expected externref, found f64`) — high, medium, **DONE (sprint 58)**
 
 ### String-hash warm perf — levers carved from #1746 umbrella (2026-05-31)
 

--- a/plan/issues/sprints/58.md
+++ b/plan/issues/sprints/58.md
@@ -30,7 +30,8 @@ prioritisation, and architect routing continue at S58 planning.
 
 Still-open guest271314 reports tracked under GitHub issue #389. The native
 messaging host body-corruption and WASI itoa fixes landed in S57 (#1733/#1723/
-#1724); these five are the remaining gaps.
+#1724). The first five rows are the already-known S58 gaps; the June 1, 2026
+comment adds the new allowJs sendMessage report below.
 
 | ID | Title | Status |
 |----|-------|--------|
@@ -39,6 +40,7 @@ messaging host body-corruption and WASI itoa fixes landed in S57 (#1733/#1723/
 | [#1753](../1753-native-messaging-64mib-chunked-streaming.md) | native-messaging 64 MiB chunked streaming | ready |
 | [#1755](../1755-uint8array-arraybuffer-generic-annotation.md) | `Uint8Array<ArrayBuffer>` generic annotation | ready |
 | [#1759](../1759-wasi-native-number-to-string-bridge-gap.md) | WASI `process.stderr.write` numeric-template → native number→string bridge gap | ready |
+| [#1768](../1768-allowjs-native-messaging-sendmessage-invalid-wasm.md) | allowJs native-messaging `sendMessage` emits invalid WASI wasm | done |
 
 ## Benchmark fidelity track
 

--- a/plan/log/issues-log.md
+++ b/plan/log/issues-log.md
@@ -510,3 +510,4 @@ sprint: 0
 | 943 | 2026-04-04 | Test262 runner instability investigation resolved into deterministic compiler + narrower runner follow-ups | Sprint-37 |
 | 882 | 2026-04-09 | Test262 runner: sharded parallel execution with merged reports | Sprint-40 |
 | 884 | 2026-04-09 | CI: GitHub Actions test262 on every PR | Sprint-40 |
+| 1768 | 2026-06-01 | allowJs native-messaging sendMessage shape now emits valid WASI wasm; fixed native-string sentinel fallbacks and vec inference for subarray/set | Sprint-58 |

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -319,6 +319,14 @@ export function resolveArrayInfo(
   // methods are dispatched via compileNativeStringMethodCall instead.
   if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0 && isStringType(tsType)) return null;
   const wasmType = resolveWasmType(ctx, tsType);
+  return resolveArrayInfoFromWasmType(ctx, wasmType);
+}
+
+function resolveArrayInfoFromWasmType(
+  ctx: CodegenContext,
+  wasmType: ValType | undefined,
+): { vecTypeIdx: number; arrTypeIdx: number; elemType: ValType } | null {
+  if (!wasmType) return null;
   if (wasmType.kind !== "ref" && wasmType.kind !== "ref_null") return null;
   const vecTypeIdx = (wasmType as { typeIdx: number }).typeIdx;
   const vecDef = ctx.mod.types[vecTypeIdx];
@@ -330,6 +338,38 @@ export function resolveArrayInfo(
   const arrDef = ctx.mod.types[arrTypeIdx];
   if (!arrDef || arrDef.kind !== "array") return null;
   return { vecTypeIdx, arrTypeIdx, elemType: arrDef.element };
+}
+
+function inferExpressionWasmType(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+  allowProbe = true,
+): ValType | undefined {
+  if (ts.isIdentifier(expr)) {
+    const name = expr.text;
+    const localIdx = fctx.localMap.get(name);
+    if (localIdx !== undefined) return getLocalType(fctx, localIdx);
+    const gIdx = ctx.moduleGlobals.get(name);
+    if (gIdx !== undefined) return ctx.mod.globals[localGlobalIdx(ctx, gIdx)]?.type;
+  }
+
+  if (!allowProbe) return undefined;
+  const savedLen = fctx.body.length;
+  const probeResult = compileExpression(ctx, fctx, expr);
+  fctx.body.length = savedLen;
+  return probeResult ?? undefined;
+}
+
+function resolveArrayInfoForExpression(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+  tsType: ts.Type,
+): { vecTypeIdx: number; arrTypeIdx: number; elemType: ValType } | null {
+  return (
+    resolveArrayInfo(ctx, tsType) ?? resolveArrayInfoFromWasmType(ctx, inferExpressionWasmType(ctx, fctx, expr, false))
+  );
 }
 
 /**
@@ -2346,7 +2386,10 @@ export function compileArrayMethodCall(
     overrideMethodName ?? (ts.isPropertyAccessExpression(propAccess) ? propAccess.name.text : undefined);
   if (!methodName || !ARRAY_METHODS.has(methodName)) return undefined;
 
-  const arrInfo = resolveArrayInfo(ctx, receiverType);
+  const receiverExpr = propAccess.expression;
+  const arrInfo =
+    resolveArrayInfo(ctx, receiverType) ??
+    resolveArrayInfoFromWasmType(ctx, inferExpressionWasmType(ctx, fctx, receiverExpr, false));
   if (!arrInfo) return undefined;
 
   let { vecTypeIdx, arrTypeIdx, elemType } = arrInfo;
@@ -2361,7 +2404,6 @@ export function compileArrayMethodCall(
   // `[0, true].lastIndexOf(...)` infers i32 elements during construction,
   // but resolveArrayInfo resolves (number|boolean)[] → __vec_externref.
   // Probe-compile the receiver to determine the actual Wasm type (#826).
-  const receiverExpr = ts.isPropertyAccessExpression(propAccess) ? propAccess.expression : undefined;
   if (receiverExpr) {
     // Fast path: check the Wasm local/global type directly
     let actualType: ValType | undefined;
@@ -5858,7 +5900,7 @@ function compileTypedArraySet(
   // the caller continues to the host-import path).
   const srcNode = callExpr.arguments[0]!;
   const srcTsType = ctx.checker.getTypeAtLocation(srcNode);
-  const srcArrInfo = resolveArrayInfo(ctx, srcTsType);
+  const srcArrInfo = resolveArrayInfoForExpression(ctx, fctx, srcNode, srcTsType);
   if (!srcArrInfo) return null;
 
   const srcVecTypeIdx = srcArrInfo.vecTypeIdx;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -979,12 +979,7 @@ function emitWrapperDynamicMethodCall(
 
   // Push method name as a string constant.
   addStringConstantGlobal(ctx, methodName);
-  const methodNameIdx = ctx.stringGlobalMap.get(methodName);
-  if (methodNameIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: methodNameIdx } as Instr);
-  } else {
-    compileStringLiteral(ctx, fctx, methodName);
-  }
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
 
   // Empty args array: __js_array_new() → externref.
   fctx.body.push({ op: "call", funcIdx: arrNewIdx });
@@ -2926,21 +2921,11 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             if (protoCallIdx !== undefined && arrNewIdx !== undefined && arrPushIdx !== undefined) {
               // Push typeName string
               addStringConstantGlobal(ctx, typeName);
-              const typeNameIdx = ctx.stringGlobalMap.get(typeName);
-              if (typeNameIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: typeNameIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, typeName);
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, typeName));
 
               // Push methodName string
               addStringConstantGlobal(ctx, methodName);
-              const methodNameIdx = ctx.stringGlobalMap.get(methodName);
-              if (methodNameIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: methodNameIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, methodName);
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
 
               // Compile receiver (first argument to .call).
               // (#1442) When the receiver's static TS type is `boolean`, the
@@ -7178,12 +7163,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             if (receiverIsBuiltin && getBuiltinIdx !== undefined) {
               const builtinName = (propAccess.expression as ts.Identifier).text;
               addStringConstantGlobal(ctx, builtinName);
-              const strIdx = ctx.stringGlobalMap.get(builtinName);
-              if (strIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-              } else {
-                compileStringLiteral(ctx, fctx, builtinName);
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, builtinName));
               fctx.body.push({ op: "call", funcIdx: getBuiltinIdx });
               recvType = { kind: "externref" };
             } else {
@@ -7215,12 +7195,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             // Push receiver, method name, args array → call __extern_method_call
             fctx.body.push({ op: "local.get", index: recvLocal });
             addStringConstantGlobal(ctx, methodName);
-            const strIdx = ctx.stringGlobalMap.get(methodName);
-            if (strIdx !== undefined) {
-              fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-            } else {
-              compileStringLiteral(ctx, fctx, methodName);
-            }
+            fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
             fctx.body.push({ op: "local.get", index: argsLocal });
             fctx.body.push({ op: "call", funcIdx: methodCallIdx });
             return { kind: "externref" };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -19,7 +19,7 @@ import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, type IrFallbackReason } from "../ir/select.js";
 import { createCodegenContext } from "./context/create-context.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
-import { allocLocal } from "./context/locals.js";
+import { allocLocal, getLocalType } from "./context/locals.js";
 import type {
   ClosureInfo,
   CodegenContext,
@@ -42,7 +42,7 @@ import {
 import { emitInlineMathFunctions } from "./math-helpers.js";
 import { finalizeMethodTrampolines } from "./closures.js";
 import { peepholeOptimize } from "./peephole.js";
-import { addImport, addStringConstantGlobal } from "./registry/imports.js";
+import { addImport, addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
 import {
   addFuncType,
@@ -10352,6 +10352,37 @@ function getLoopBodyNode(loop: ts.Node): ts.Node | undefined {
   return undefined;
 }
 
+function isVecStructType(ctx: CodegenContext, type: ValType | undefined): type is ValType & { typeIdx: number } {
+  if (!type || (type.kind !== "ref" && type.kind !== "ref_null")) return false;
+  const def = ctx.mod.types[type.typeIdx];
+  return def?.kind === "struct" && def.fields[0]?.name === "length" && def.fields[1]?.name === "data";
+}
+
+function inferLetConstInitializerWasmType(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  initializer: ts.Expression | undefined,
+): ValType | null {
+  if (!initializer || !ts.isCallExpression(initializer) || !ts.isPropertyAccessExpression(initializer.expression)) {
+    return null;
+  }
+  const methodName = initializer.expression.name.text;
+  if (methodName !== "subarray" && methodName !== "slice") return null;
+
+  const receiver = initializer.expression.expression;
+  let receiverType: ValType | undefined;
+  if (ts.isIdentifier(receiver)) {
+    const localIdx = fctx.localMap.get(receiver.text);
+    if (localIdx !== undefined) receiverType = getLocalType(fctx, localIdx);
+    else {
+      const globalIdx = ctx.moduleGlobals.get(receiver.text);
+      if (globalIdx !== undefined) receiverType = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type;
+    }
+  }
+  receiverType ??= resolveWasmType(ctx, ctx.checker.getTypeAtLocation(receiver));
+  return isVecStructType(ctx, receiverType) ? { kind: "ref_null", typeIdx: receiverType.typeIdx } : null;
+}
+
 function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement): void {
   if (ts.isVariableStatement(stmt)) {
     const list = stmt.declarationList;
@@ -10393,7 +10424,7 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
           ? { kind: "externref" }
           : isI32Coerced
             ? { kind: "i32" }
-            : resolveWasmType(ctx, varType);
+            : (inferLetConstInitializerWasmType(ctx, fctx, decl.initializer) ?? resolveWasmType(ctx, varType));
         allocLocal(fctx, name, wasmType);
         // Only add TDZ flag if static analysis can't prove all accesses are safe
         if (needsTdzFlag(ctx, decl)) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -684,12 +684,7 @@ export function emitExternrefToStructGet(
       externGetFallback.push({ op: "extern.convert_any" } as Instr);
       // Push property name string
       addStringConstantGlobal(ctx, propName);
-      const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-      if (strGlobalIdx !== undefined) {
-        externGetFallback.push({ op: "global.get", index: strGlobalIdx } as Instr);
-      } else {
-        externGetFallback.push({ op: "ref.null.extern" } as Instr);
-      }
+      externGetFallback.push(...stringConstantExternrefInstrs(ctx, propName));
       externGetFallback.push({ op: "call", funcIdx: getIdx } as Instr);
       // Coerce externref result to the expected result type
       if (resultType.kind === "f64") {
@@ -1267,12 +1262,7 @@ export function compilePropertyAccess(
     // Emit: __extern_get(__get_globalThis(), key) -> externref
     fctx.body.push({ op: "call", funcIdx: gtFuncIdx });
     addStringConstantGlobal(ctx, propName);
-    const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-    if (strGlobalIdx !== undefined) {
-      fctx.body.push({ op: "global.get", index: strGlobalIdx });
-    } else {
-      fctx.body.push({ op: "ref.null.extern" });
-    }
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
     if (getIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: getIdx });
     }
@@ -1393,21 +1383,11 @@ export function compilePropertyAccess(
       if (getBuiltinIdx !== undefined && getIdx !== undefined) {
         // Push builtin name string, call __get_builtin to get the real JS object
         addStringConstantGlobal(ctx, builtinName);
-        const builtinStrIdx = ctx.stringGlobalMap.get(builtinName);
-        if (builtinStrIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: builtinStrIdx });
-        } else {
-          compileStringLiteral(ctx, fctx, builtinName);
-        }
+        fctx.body.push(...stringConstantExternrefInstrs(ctx, builtinName));
         fctx.body.push({ op: "call", funcIdx: getBuiltinIdx });
         // Push property name string, call __extern_get to read the property
         addStringConstantGlobal(ctx, propName);
-        const propStrIdx = ctx.stringGlobalMap.get(propName);
-        if (propStrIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: propStrIdx });
-        } else {
-          compileStringLiteral(ctx, fctx, propName);
-        }
+        fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
         fctx.body.push({ op: "call", funcIdx: getIdx });
         return { kind: "externref" };
       }
@@ -2579,7 +2559,6 @@ export function compilePropertyAccess(
 
           // If proto is non-null, call __extern_get(proto, propName)
           addStringConstantGlobal(ctx, propName);
-          const strGlobalIdx = ctx.stringGlobalMap.get(propName);
 
           fctx.body.push({ op: "local.get", index: protoLocal });
           fctx.body.push({ op: "ref.is_null" });
@@ -2590,9 +2569,7 @@ export function compilePropertyAccess(
             then: protoDefaultInstrs,
             else: [
               { op: "local.get", index: protoLocal } as Instr,
-              ...(strGlobalIdx !== undefined
-                ? [{ op: "global.get", index: strGlobalIdx } as Instr]
-                : [{ op: "ref.null.extern" } as Instr]),
+              ...stringConstantExternrefInstrs(ctx, propName),
               { op: "call", funcIdx: getIdx } as Instr,
               ...(effectiveResult.kind === "f64" && unboxIdx !== undefined
                 ? [{ op: "call", funcIdx: unboxIdx } as Instr]
@@ -2628,12 +2605,7 @@ export function compilePropertyAccess(
             coerceType(ctx, fctx, recvType, { kind: "externref" });
           }
           addStringConstantGlobal(ctx, propName);
-          const strIdx = ctx.stringGlobalMap.get(propName);
-          if (strIdx !== undefined) {
-            fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-          } else {
-            fctx.body.push({ op: "ref.null.extern" });
-          }
+          fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
           fctx.body.push({ op: "call", funcIdx: getIdx });
 
           // Unbox if the expected type is numeric
@@ -2841,12 +2813,7 @@ export function compilePropertyAccess(
           // Build the __extern_get fallback instructions
           const externGetFallback: Instr[] = [{ op: "local.get", index: objTmp } as Instr];
           addStringConstantGlobal(ctx, propName);
-          const strGlobalIdxExt = ctx.stringGlobalMap.get(propName);
-          if (strGlobalIdxExt !== undefined) {
-            externGetFallback.push({ op: "global.get", index: strGlobalIdxExt } as Instr);
-          } else {
-            externGetFallback.push({ op: "ref.null.extern" } as Instr);
-          }
+          externGetFallback.push(...stringConstantExternrefInstrs(ctx, propName));
           externGetFallback.push({ op: "call", funcIdx: getIdx } as Instr);
           if (resultWasm.kind === "f64" && unboxIdx !== undefined) {
             externGetFallback.push({ op: "call", funcIdx: unboxIdx } as Instr);
@@ -2950,12 +2917,7 @@ export function compilePropertyAccess(
           fctx.body.push({ op: "extern.convert_any" });
         }
         addStringConstantGlobal(ctx, propName);
-        const strGIdx856 = ctx.stringGlobalMap.get(propName);
-        if (strGIdx856 !== undefined) {
-          fctx.body.push({ op: "global.get", index: strGIdx856 });
-        } else {
-          fctx.body.push({ op: "ref.null.extern" });
-        }
+        fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
         fctx.body.push({ op: "call", funcIdx: getIdx856 });
         if (accessWasm.kind === "f64") {
           if (unboxIdx856 !== undefined) fctx.body.push({ op: "call", funcIdx: unboxIdx856 });

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -6,7 +6,7 @@ import { ts, forEachChild } from "../../ts-api.js";
 import { isStringType, isVoidType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { reportError } from "../context/errors.js";
-import { allocLocal } from "../context/locals.js";
+import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { emitCoercedLocalSet, noJsHost } from "../expressions/helpers.js";
 import { emitUndefined } from "../expressions/late-imports.js";
@@ -644,22 +644,40 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         const prevElemOverride = ctxAny._i32ElemArrayOverride;
         if (isI32SpecializedArray) ctxAny._i32ElemArrayOverride = true;
         let resultType: ValType | null;
+        const initializerExpectedType = getLocalType(fctx, localIdx) ?? wasmType;
         try {
-          resultType = compileExpression(ctx, fctx, decl.initializer, wasmType);
+          resultType = compileExpression(ctx, fctx, decl.initializer, initializerExpectedType);
         } finally {
           ctxAny._i32ElemArrayOverride = prevElemOverride;
         }
         stackType = resultType ?? wasmType;
+        if (
+          resultType &&
+          wasmType.kind === "externref" &&
+          (resultType.kind === "ref" || resultType.kind === "ref_null") &&
+          !isVar &&
+          !(fctx.tdzFlagLocals?.has(name) ?? false) &&
+          localIdx >= fctx.params.length
+        ) {
+          const localSlot = fctx.locals[localIdx - fctx.params.length];
+          if (localSlot?.type.kind === "externref") {
+            localSlot.type =
+              resultType.kind === "ref"
+                ? { kind: "ref_null", typeIdx: (resultType as { typeIdx: number }).typeIdx }
+                : resultType;
+          }
+        }
         // Coerce if the expression produced a type that doesn't match the local
-        if (resultType && !valTypesMatch(resultType, wasmType)) {
+        const targetType = getLocalType(fctx, localIdx) ?? wasmType;
+        if (resultType && !valTypesMatch(resultType, targetType)) {
           const bodyLenBeforeCoerce = fctx.body.length;
-          coerceType(ctx, fctx, resultType, wasmType);
+          coerceType(ctx, fctx, resultType, targetType);
           // Only update stackType if coercion actually emitted instructions.
           // If coerceType was a no-op (e.g. unrelated struct types), keep
           // the original resultType so emitCoercedLocalSet can detect the
           // mismatch and update the local's declared type accordingly.
           if (fctx.body.length > bodyLenBeforeCoerce) {
-            stackType = wasmType; // after coercion, stack is wasmType
+            stackType = targetType; // after coercion, stack is targetType
           }
         }
       }

--- a/tests/issue-1768.test.ts
+++ b/tests/issue-1768.test.ts
@@ -1,0 +1,117 @@
+// #1768 — allowJs Native Messaging sendMessage-shaped code must emit valid WASI Wasm.
+//
+// guest271314 reported that a TypeScript Native Messaging host compiled to
+// valid WASI Wasm, but the equivalent plain JavaScript produced an invalid
+// module in `sendMessage` (`unknown global: global index out of bounds`, and
+// before pulling, `type mismatch: expected externref, found f64`). The JS input
+// path is first-class, so keep this regression as allowJs/.js source.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileWasiJs(source: string) {
+  return await compile(source, {
+    fileName: "nm_js2wasm.js",
+    allowJs: true,
+    target: "wasi",
+    optimize: 0,
+  });
+}
+
+function runWasiCaptureStdout(binary: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const captured: number[] = [];
+  const wasi = {
+    fd_read(): number {
+      return 0;
+    },
+    fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = new DataView(ref.mem!.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (fd === 1) {
+          for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        }
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = instance.exports.memory as WebAssembly.Memory;
+  (instance.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+describe("#1768 allowJs Native Messaging sendMessage validates under --target wasi", () => {
+  it("validates and runs sendMessage with Uint8Array subarray/indexOf/set/stdout.write", async () => {
+    const source = `
+      function sendMessage(message) {
+        let prepend = null;
+        let append = null;
+        const open = message.indexOf(91);
+        const close = message.indexOf(93);
+
+        if (open !== 0) {
+          prepend = 91;
+        }
+        if (close === -1) {
+          append = 93;
+        }
+
+        const bodyStart = open === -1 ? 0 : open;
+        const body = message.subarray(bodyStart, message.length);
+        const prefixLength = prepend === null ? 0 : 1;
+        const suffixLength = append === null ? 0 : 1;
+        const responseLength = prefixLength + body.length + suffixLength;
+        const output = new Uint8Array(4 + responseLength);
+
+        output[0] = responseLength & 255;
+        output[1] = (responseLength >> 8) & 255;
+        output[2] = (responseLength >> 16) & 255;
+        output[3] = (responseLength >> 24) & 255;
+
+        let cursor = 4;
+        if (prepend !== null) {
+          output[cursor] = prepend;
+          cursor = cursor + 1;
+        }
+
+        output.set(body, cursor);
+        cursor = cursor + body.length;
+
+        if (append !== null) {
+          output[cursor] = append;
+        }
+
+        process.stdout.write(output);
+      }
+
+      export function main() {
+        const message = new Uint8Array([123, 34, 111, 107, 34, 58, 49, 125]);
+        sendMessage(message);
+      }
+    `;
+
+    const result = await compileWasiJs(source);
+    expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+    expect(result.wat).not.toContain('(import "env"');
+
+    const out = runWasiCaptureStdout(result.binary);
+    expect(Array.from(out)).toEqual([10, 0, 0, 0, 91, 123, 34, 111, 107, 34, 58, 49, 125, 93]);
+  });
+});

--- a/website/public/graph-data.json
+++ b/website/public/graph-data.json
@@ -10671,8 +10671,8 @@
       "id": "747",
       "title": "Escape analysis for stack allocation",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [
         "1586",
@@ -10980,9 +10980,9 @@
       "id": "779a",
       "title": "class/dstr method-tramp residual (gen / async-gen / private / static) (~727 fails)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "property-model",
@@ -11019,8 +11019,8 @@
       "id": "779d",
       "title": "Object-literal destructuring (non-class, non-for-of) residuals (~132 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -11032,9 +11032,9 @@
       "id": "779e",
       "title": "arguments-object mapped / trailing-comma / sloppy-strict residuals (~161 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "property-model",
@@ -11123,9 +11123,9 @@
       "id": "786",
       "title": "- Multi-assertion failures: returned N > 2 (~1,183 tests)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "core-semantics",
@@ -11695,8 +11695,8 @@
       "id": "820d",
       "title": "class/dstr async-gen-meth default-init `unresolvable` illegal cast",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -11708,9 +11708,9 @@
       "id": "820h",
       "title": "DisposableStack / AsyncDisposableStack brand-check and protocol stubs (~74 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "async-model",
@@ -11721,9 +11721,9 @@
       "id": "820j",
       "title": "(Async)GeneratorPrototype brand check + receiver TypeError (~36 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "async-model",
@@ -11734,8 +11734,8 @@
       "id": "820k",
       "title": "Object.* receiver TypeError on null/undefined (ToObject step) (~39 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -11744,12 +11744,50 @@
       "test262_fail": 39
     },
     {
-      "id": "821",
-      "title": "BindingElement null guard over-triggering",
-      "priority": "critical",
+      "id": "820l",
+      "title": "arguments object: extra positional args beyond declared formals not retained (~61 fails)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 61
+    },
+    {
+      "id": "820m",
+      "title": "NamedEvaluation: anonymous class/function value not named from binding key (~12 fails, fn-name-class + __proto__-fn-name)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 12
+    },
+    {
+      "id": "820n",
+      "title": "#820 umbrella status 2026-05-28: residual 868 fails (down from 1318), recommendation to close umbrella post-#820l/#820m",
+      "priority": "low",
       "status": "ready",
       "raw_status": "ready",
       "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "planning",
+      "cluster": "planning"
+    },
+    {
+      "id": "821",
+      "title": "BindingElement null guard over-triggering",
+      "priority": "critical",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "core-semantics",
@@ -12269,7 +12307,7 @@
       "title": "Promise executor and property-assigned functions not compiled as host callbacks",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -13954,8 +13992,20 @@
     },
     {
       "id": "983",
-      "title": "WasmGC objects leak to JS host as opaque values (1,087 FAIL)",
+      "title": "WasmGC objects leak to JS host as opaque values (re-baselined: 0 literal-opaque FAIL)",
       "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
+      "depends_on": [],
+      "files": [],
+      "goal": "async-model",
+      "cluster": "async-model"
+    },
+    {
+      "id": "983d",
+      "title": "Live-mirror write-back: host mutations to a WasmGC struct's proxy sidecar never reach the struct field (~11 Array.prototype.*.call fails)",
+      "priority": "medium",
       "status": "ready",
       "raw_status": "ready",
       "sprint": "Backlog",
@@ -13963,7 +14013,7 @@
       "files": [],
       "goal": "async-model",
       "cluster": "async-model",
-      "test262_fail": 1087
+      "test262_fail": 11
     },
     {
       "id": "984",
@@ -15633,8 +15683,8 @@
       "id": "1116",
       "title": "Promise resolution and async error handling (210 tests)",
       "priority": "critical",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [
         "944"
@@ -15649,8 +15699,8 @@
       "id": "1116b",
       "title": "Promise subclass: Wasm-compiled class extends Promise must be a valid JS constructor (Wasm-class-as-JS-ctor bridge)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -15824,7 +15874,7 @@
       "title": "Array methods — getter-observing property access on indices and length",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -18328,8 +18378,8 @@
       "id": "1312",
       "title": "Async recursive function (next() compose pattern) — Unhandled rejection",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18352,8 +18402,8 @@
       "id": "1314",
       "title": "Wasm codegen: __closure_N stack underflow — call emits wrong argument count",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18401,8 +18451,8 @@
       "id": "1318",
       "title": "test harness: 'returned N' bare exit code — capture last assertion detail (~8,900 vague failures)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18413,9 +18463,9 @@
       "id": "1319",
       "title": "Cannot convert object to primitive — Symbol.toPrimitive / valueOf / toString chain incomplete (234 failures)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "50",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -18426,7 +18476,7 @@
       "title": "Runtime bridge: Array.from(externref) / Iterator.from(externref) doesn't preserve own [Symbol.iterator] on plain JS objects (4 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18437,8 +18487,8 @@
       "id": "1321",
       "title": "Number.prototype formatting methods (toString/toFixed/toPrecision/toExponential) rely on JS host unnecessarily",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18535,8 +18585,8 @@
       "id": "1328",
       "title": "RegExp host-mode: Symbol.match / matchAll protocol spec compliance (101 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18548,7 +18598,7 @@
       "title": "RegExp host-mode: Symbol.replace / replaceAll protocol spec compliance (110 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18559,8 +18609,8 @@
       "id": "1330",
       "title": "RegExp host-mode: Symbol.search protocol spec compliance (37 fails)",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18571,8 +18621,8 @@
       "id": "1331",
       "title": "RegExp host-mode: Symbol.split protocol spec compliance (123 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18583,8 +18633,8 @@
       "id": "1332",
       "title": "RegExp host-mode: prototype method edge cases (exec, test, flag accessors, RegExpStringIterator)",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18595,8 +18645,8 @@
       "id": "1333",
       "title": "RegExp host-mode: Pre-ES6 (S15.10) tests + annexB legacy accessors",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18643,8 +18693,8 @@
       "id": "1337",
       "title": "spec gap: Function.prototype.bind/toString + Function/internals (175 + 7 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18656,7 +18706,7 @@
       "title": "spec gap: Array.from / Array.of constructor semantics (39 test262 fails, wasm_compile dominant)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18667,8 +18717,8 @@
       "id": "1339",
       "title": "spec gap: AggregateError + SuppressedError errors-iterable + cause coercion (37 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18679,8 +18729,8 @@
       "id": "1340",
       "title": "spec gap: Iterator.prototype helpers wasm_compile errors (89 of 245 fails)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18704,7 +18754,7 @@
       "title": "spec gap: Date.prototype string formatters and parsers (174 of 485 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "in-progress",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18715,20 +18765,22 @@
       "id": "1344",
       "title": "spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
-      "depends_on": [],
+      "depends_on": [
+        "1665"
+      ],
       "files": [],
       "goal": "spec-completeness",
       "cluster": "spec-completeness"
     },
     {
       "id": "1345",
-      "title": "spec gap: Reflect.* invariant checks mirror internal-method bugs (83 test262 fails)",
+      "title": "spec gap: Reflect.* invariant checks mirror internal-method bugs (46 test262 fails as of 2026-05-28)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18751,8 +18803,8 @@
       "id": "1347",
       "title": "spec gap: for-of doesn't IteratorClose on body throw (portion of 389 fails)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18775,8 +18827,8 @@
       "id": "1349",
       "title": "spec gap: BigInt typed-path eager f64 assumptions (47 test262 fails, 4 illegal_cast + 13 runtime)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "wont-fix",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18785,10 +18837,10 @@
     },
     {
       "id": "1350",
-      "title": "spec gap: ArrayBuffer resizable + TypedArray detached-buffer guards (100 + 39 test262 fails)",
+      "title": "spec gap: ArrayBuffer resizable + TypedArray detached-buffer guards (100 + 39 test262 fails) — DUPLICATE of #1645",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -18799,8 +18851,8 @@
       "id": "1352",
       "title": "RegExp exec result: wasmGC string struct ≠ externref string in strict equality (S15.10.2 cluster)",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "~",
       "depends_on": [],
       "files": [],
@@ -19246,7 +19298,7 @@
       "priority": "medium",
       "status": "ready",
       "raw_status": "ready",
-      "sprint": "52",
+      "sprint": "58",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -19391,8 +19443,8 @@
       "id": "1399",
       "title": "chore: fix 9 biome lint errors in src/runtime.ts",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "null",
       "depends_on": [],
       "files": [],
@@ -19798,8 +19850,8 @@
       "id": "1471",
       "title": "host-independence: eliminate JS host boxing/unboxing for standalone Wasm",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -19810,8 +19862,8 @@
       "id": "1472",
       "title": "host-independence: eliminate JS host object/property ops for standalone Wasm",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -19822,8 +19874,8 @@
       "id": "1473",
       "title": "host-independence: eliminate JS host error/exception ops for standalone Wasm",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -19834,8 +19886,8 @@
       "id": "1474",
       "title": "host-independence: eliminate JS host RegExp for standalone Wasm",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -20050,9 +20102,9 @@
       "id": "1511",
       "title": "spec gap: arguments object — mapped semantics, descriptors, trailing-comma length",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "review",
-      "sprint": "52",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -20073,10 +20125,10 @@
     {
       "id": "1513",
       "title": "spec gap: Reflect — TypeError on non-object/Symbol target + abrupt-completion propagation",
-      "priority": "high",
+      "priority": "medium",
       "status": "ready",
       "raw_status": "review",
-      "sprint": "52",
+      "sprint": "Backlog",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -20193,8 +20245,8 @@
       "id": "1523",
       "title": "test262 harness: provide `$262` host-object API (createRealm / detachArrayBuffer / agent / global)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -20215,19 +20267,32 @@
       "id": "1525",
       "title": "spec gap: built-in coercion paths throw 'Cannot convert object to primitive value' eagerly",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
       "cluster": "sprint-52"
     },
     {
+      "id": "1525b",
+      "title": "ToPrimitive residuals: object-method trampoline invalid Wasm + §7.1.1.1 step-6 TypeError",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "review",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 142
+    },
+    {
       "id": "1526",
       "title": "spec gap: BigInt + Number mixed arithmetic should throw spec TypeError, not host error",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20237,8 +20302,8 @@
       "id": "1527",
       "title": "module-code: ambiguous-export & re-export tests fail with 'no test export'",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -20249,7 +20314,7 @@
       "title": "spec gap: non-constructor TypeError — Promise.all / allSettled species and executor paths",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "in-progress",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20259,12 +20324,12 @@
       "id": "1529",
       "title": "codegen: 'illegal cast' umbrella at closure & destructuring parameter boundaries",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
-      "cluster": "sprint-Backlog"
+      "cluster": "sprint-56"
     },
     {
       "id": "1530",
@@ -20273,7 +20338,10 @@
       "status": "done",
       "raw_status": "done",
       "sprint": "55",
-      "depends_on": [],
+      "depends_on": [
+        "1653",
+        "1654"
+      ],
       "files": [],
       "goal": "wasi-completeness",
       "cluster": "wasi-completeness"
@@ -20282,8 +20350,8 @@
       "id": "1531",
       "title": "JSX syntax is not parsed when compiling .tsx/.jsx input",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20392,8 +20460,8 @@
       "id": "1540",
       "title": "JSX runtime: bind _jsx/_jsxs/_Fragment as host import (default) and standalone stub",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [
         "1531"
@@ -20420,7 +20488,7 @@
       "priority": "high",
       "status": "ready",
       "raw_status": "ready",
-      "sprint": "52",
+      "sprint": "58",
       "depends_on": [],
       "files": [],
       "goal": "test262-conformance",
@@ -20431,8 +20499,8 @@
       "id": "1543",
       "title": "Async-generator method with destructured default params throws illegal cast instead of expected error",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20444,8 +20512,8 @@
       "id": "1544",
       "title": "for-of / for-await-of destructuring of iterator results throws illegal cast",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20457,8 +20525,8 @@
       "id": "1550",
       "title": "spec gap: dstr-binding default initializer evaluated when value is non-undefined (`init-skipped` pattern)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20481,20 +20549,21 @@
       "id": "1552",
       "title": "spec gap: catch parameter destructuring (`try/dstr`) — share dstr-binding helper with function decls",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
-      "cluster": "spec-completeness"
+      "cluster": "spec-completeness",
+      "compiler_errors": 1
     },
     {
       "id": "1553",
       "title": "spec gap: let/const/var destructuring declarations — residuals after #1432/#1450/#1454/#1550",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20517,8 +20586,8 @@
       "id": "1553b",
       "title": "decl-dstr: route typed-struct object declaration through destructureParamObject (decl-mode)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -20529,8 +20598,8 @@
       "id": "1553c",
       "title": "decl-dstr: route externref-fallback object declaration through destructureParamObject (decl-mode)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -20541,8 +20610,8 @@
       "id": "1553d",
       "title": "decl-dstr: route array declaration (typed-vec + externref) through destructureParamArray (decl-mode)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -20565,8 +20634,8 @@
       "id": "1554",
       "title": "cli: --standalone should reject --allow-fs (logically mutually exclusive flags)",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "52",
       "depends_on": [],
       "files": [],
@@ -20687,8 +20756,8 @@
       "id": "1564",
       "title": "ToNumeric: Symbol argument must throw TypeError (§7.1.3 step 3)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -20726,25 +20795,25 @@
       "id": "1567",
       "title": "Builtin subclass prototype splice leaks side effects (TypedArray length descriptor + RegExp brand)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
-      "cluster": "sprint-Backlog"
+      "cluster": "sprint-56"
     },
     {
       "id": "1568",
       "title": "Object(BigInt) and Object(Symbol) must auto-box to wrappers (typeof === \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"object\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\")",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [
         "1129"
       ],
       "files": [],
-      "cluster": "sprint-Backlog"
+      "cluster": "sprint-56"
     },
     {
       "id": "1569",
@@ -20867,9 +20936,9 @@
       "id": "1580",
       "title": "string-hash benchmark: wasm-validator pre-existing bug + uncompetitive hot runtime",
       "priority": "high",
-      "status": "done",
-      "raw_status": "done",
-      "sprint": "54",
+      "status": "ready",
+      "raw_status": "in-progress",
+      "sprint": "58",
       "depends_on": [],
       "files": [],
       "goal": "performance",
@@ -20947,8 +21016,8 @@
       "id": "1586",
       "title": "IR preparation: explicit allocation sites with stable identity and metadata hooks",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -20959,8 +21028,8 @@
       "id": "1587",
       "title": "Static analysis pass: ownership and access semantics on IR values",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [
         "1586"
@@ -20973,8 +21042,8 @@
       "id": "1588",
       "title": "String encoding tracking: prove UTF-8 guarantees for zero-copy Component Model interop",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "in-progress",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [
         "1586"
@@ -20998,8 +21067,8 @@
       "id": "1589a",
       "title": "Fix object-literal field-type inference + __extern_has_idx null semantics for Array.prototype.{indexOf,lastIndexOf}.call on length=2^32 array-likes",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -21019,10 +21088,10 @@
     },
     {
       "id": "1591",
-      "title": "class/elements: same-line / stacked member definitions lost or reordered (~294 fails)",
+      "title": "class/elements: WasmGC-struct ↔ host own-property/identity reconciliation gaps (~294 fails)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21034,9 +21103,9 @@
       "id": "1592",
       "title": "Array pattern elision holes and rest-array in destructuring consume wrong iterator step (~305 fails)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21047,9 +21116,9 @@
       "id": "1593",
       "title": "Destructuring default initializer triggers on null — spec requires undefined-only check (~165 fails)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21060,9 +21129,9 @@
       "id": "1594",
       "title": "AnnexB strict function-code / class name-binding TDZ: ReferenceError not thrown (~100 fails)",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21073,8 +21142,8 @@
       "id": "1595",
       "title": "ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable not implemented (~40 fails)",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21086,9 +21155,9 @@
       "id": "1596",
       "title": "Function.prototype.apply / .call not accessible on compiled Wasm functions (~46 fails)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21099,8 +21168,8 @@
       "id": "1597",
       "title": "host-indep: gate __throw_reference_error in standalone mode",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -21112,7 +21181,7 @@
       "title": "host-indep: pure-Wasm String.fromCharCode / fromCodePoint in standalone mode",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -21123,8 +21192,8 @@
       "id": "1599",
       "title": "host-indep: JSON.parse / JSON.stringify in standalone mode",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -21135,9 +21204,9 @@
       "id": "1600",
       "title": "FinalizationRegistry: host-delegate (JS mode) + no-op standalone stub (~12 CEs)",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "Backlog",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "npm-library-support",
@@ -21148,8 +21217,8 @@
       "id": "1601",
       "title": "codegen: Array.prototype reduce/reduceRight/map/filter callback paths emit invalid wasm (stack underflow at local.set/if/array.set)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21160,8 +21229,8 @@
       "id": "1602",
       "title": "codegen: call-site argument coercion emits invalid wasm (call expected externref, found f64/other)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21172,8 +21241,8 @@
       "id": "1603",
       "title": "codegen: optional-chaining short-circuit emits invalid wasm (ref.is_null expected i32, found ref)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21184,8 +21253,8 @@
       "id": "1604",
       "title": "codegen: String case methods (toUpperCase/toLowerCase/toLocale*) return i32 into f64 comparison — invalid wasm",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21196,8 +21265,8 @@
       "id": "1605",
       "title": "codegen: class computed-property-name / setter param-scope emits invalid wasm (local.tee externref mismatch)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21208,8 +21277,8 @@
       "id": "1606",
       "title": "codegen crash: 'Cannot read properties of undefined (reading declarations)' on object-literal expressions",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21220,8 +21289,8 @@
       "id": "1607",
       "title": "codegen crash: 'Maximum call stack size exceeded' on use-before-initialization (TDZ) in declaration statements",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21232,8 +21301,8 @@
       "id": "1608",
       "title": "codegen crash: 'Cannot set properties of undefined (setting typeIdx)' on Array push/pop/shift/join/unshift",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21244,8 +21313,8 @@
       "id": "1609",
       "title": "codegen: non-literal spread argument in new-expression not supported",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21256,8 +21325,8 @@
       "id": "1610",
       "title": "codegen: for-of over non-array iterables rejected ('for-of requires an array expression')",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21268,8 +21337,8 @@
       "id": "1611",
       "title": "parser: lexical declaration in single-statement context rejected for valid newline-separated cases",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21280,8 +21349,8 @@
       "id": "1612",
       "title": "parser: top-level-await with array-literal operand misparsed as element access ('should take an argument')",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21292,8 +21361,8 @@
       "id": "1613",
       "title": "codegen: for-in head with binding pattern / non-identifier rejected ('for-in variable must be an identifier')",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21304,8 +21373,8 @@
       "id": "1614",
       "title": "codegen: Set set-method intrinsics missing ('Cannot find method size/...' on parent class Set)",
       "priority": "low",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21328,8 +21397,8 @@
       "id": "1616",
       "title": "Flatten issue files into a stable location; sprint membership via frontmatter only",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "55",
       "depends_on": [],
       "files": [],
@@ -21352,8 +21421,8 @@
       "id": "1618",
       "title": "wasi: console.log of a runtime string emits corrupted [object] placeholder",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "ready",
+      "raw_status": "review",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21376,8 +21445,8 @@
       "id": "1620",
       "title": "$IteratorResult struct: eliminate __iterator_done/__iterator_value host imports (runtime wiring gap)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "56",
       "depends_on": [],
       "files": [],
@@ -21412,8 +21481,8 @@
       "id": "1623",
       "title": "codegen: invalid Wasm binary at type-boundary coercion (extern/anyref + struct ref types)",
       "priority": "high",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "ready",
+      "raw_status": "review",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21471,8 +21540,8 @@
       "id": "1628",
       "title": "wasi: raw-byte stdout primitive (writeStdout(bytes)) for binary protocols",
       "priority": "medium",
-      "status": "backlog",
-      "raw_status": "backlog",
+      "status": "done",
+      "raw_status": "wont-fix",
       "sprint": "Backlog",
       "depends_on": [],
       "files": [],
@@ -21485,7 +21554,19 @@
       "priority": "high",
       "status": "ready",
       "raw_status": "ready",
-      "sprint": "50",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1629a",
+      "title": "Object.defineProperty dynamic (non-literal) descriptor materialization",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21495,9 +21576,9 @@
       "id": "1630",
       "title": "spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
-      "sprint": "50",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
@@ -21507,8 +21588,8 @@
       "id": "1631",
       "title": "spec gap: Object.create(proto, descriptors) ignores descriptor map (162 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21519,8 +21600,8 @@
       "id": "1632",
       "title": "spec gap: Function.prototype.bind/toString + Function/internals (175 + 7 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21531,8 +21612,8 @@
       "id": "1633",
       "title": "spec gap: Array.from / Array.of constructor semantics (39 test262 fails, wasm_compile dominant)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21544,7 +21625,7 @@
       "title": "spec gap: AggregateError + SuppressedError errors-iterable + cause coercion (37 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21555,8 +21636,8 @@
       "id": "1635",
       "title": "spec gap: Iterator.prototype helpers wasm_compile errors (89 of 245 fails)",
       "priority": "high",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21568,7 +21649,7 @@
       "title": "spec gap: JSON.stringify replacer/toJSON/property-list (49 of 66 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "in-progress",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21579,8 +21660,8 @@
       "id": "1637",
       "title": "spec gap: Boolean wrapper + Symbol coercion TypeErrors (24 + 45 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21592,7 +21673,7 @@
       "title": "spec gap: Date.prototype string formatters and parsers (174 of 485 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21604,7 +21685,7 @@
       "title": "spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21613,10 +21694,10 @@
     },
     {
       "id": "1640",
-      "title": "spec gap: Reflect.* invariant checks mirror internal-method bugs (83 test262 fails)",
+      "title": "spec gap: Reflect.* invariant checks mirror internal-method bugs (47 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21628,7 +21709,7 @@
       "title": "spec gap: yield in nested try/finally + yield expression evaluation order (46 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21652,7 +21733,7 @@
       "title": "spec gap: class static initialization order + private field semantics (significant share of 1500+ class fails)",
       "priority": "high",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21676,7 +21757,7 @@
       "title": "spec gap: ArrayBuffer resizable + TypedArray detached-buffer guards (100 + 39 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21688,7 +21769,7 @@
       "title": "spec gap: Set methods (union/intersection/etc.) accept any set-like argument (101 test262 fails)",
       "priority": "medium",
       "status": "ready",
-      "raw_status": "ready",
+      "raw_status": "review",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21711,8 +21792,8 @@
       "id": "1648",
       "title": "spec gap: Object.create(proto, descriptors) ignores descriptor map (162 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "done",
+      "raw_status": "done",
       "sprint": "50",
       "depends_on": [],
       "files": [],
@@ -21723,13 +21804,1307 @@
       "id": "1649",
       "title": "spec gap: Boolean wrapper + Symbol coercion TypeErrors (24 + 45 test262 fails)",
       "priority": "medium",
-      "status": "ready",
-      "raw_status": "ready",
+      "status": "blocked",
+      "raw_status": "blocked",
       "sprint": "50",
       "depends_on": [],
       "files": [],
       "goal": "spec-completeness",
       "cluster": "spec-completeness"
+    },
+    {
+      "id": "1650",
+      "title": "Component Model string boundary: encode-import selection (Edge B) on the encoding annotation",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1588"
+      ],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1651",
+      "title": "wasi: process.stdout.write(str|Uint8Array) → fd_write (no newline, raw bytes)",
+      "priority": "high",
+      "status": "ready",
+      "raw_status": "review",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "wasi-completeness",
+      "cluster": "wasi-completeness"
+    },
+    {
+      "id": "1652",
+      "title": "Fix native-messaging README build command (npx js2wasm not found on fresh clone)",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1653",
+      "title": "wasi: process.stdin.read(buffer, offset?) — binary incremental stdin read into a typed buffer",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1654"
+      ],
+      "files": [],
+      "goal": "wasi-completeness",
+      "cluster": "wasi-completeness"
+    },
+    {
+      "id": "1654",
+      "title": "wasi: DataView/ArrayBuffer-backed TypedArrays emit an invalid wasm module under --target wasi",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "wasi-completeness",
+      "cluster": "wasi-completeness"
+    },
+    {
+      "id": "1655",
+      "title": "wasi: process.stdout.write(ArrayBuffer) — accept ArrayBuffer arg, not only Uint8Array literal",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1654"
+      ],
+      "files": [],
+      "goal": "wasi-completeness",
+      "cluster": "wasi-completeness"
+    },
+    {
+      "id": "1656",
+      "title": "Consolidate all website/frontend files under website/",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1657",
+      "title": "Skip merge_group test262 shards for non-src changes (keep required check green)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "review",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1658",
+      "title": "Destructured/scalar function-parameter default not applied (returns wrong value)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1659"
+      ],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1659",
+      "title": "CI does not run tests/equivalence/ (OOM) — genuine equivalence regressions land silently",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1660",
+      "title": "Replace placeholder cla-check with a real CLA signature/approval gate",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-Backlog"
+    },
+    {
+      "id": "1661",
+      "title": "README programmatic-API example fails: instantiate(binary, {}) but default mode requires host imports",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1662",
+      "title": "audit: standalone (--target wasi) host-import leaks per construct + remaining-gap map",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1663",
+      "title": "host-indep: pure-Wasm parseInt / parseFloat / Number(string) in standalone mode",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1664",
+      "title": "host-indep: residual __extern_* / __register_* / __iterator* / __array_* leaks after #1472",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1665",
+      "title": "host-indep: Wasm-native generators (retire __gen_* / __create_generator host scheduler)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1666",
+      "title": "bug: --target wasi emits INVALID wasm for class/closure/callback/number→string/regex/generator/typed-array (native helper type mismatch + unbound late global)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1667",
+      "title": "DX: compile() should return a ready-to-pass import object for default/JS-host mode",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-Backlog"
+    },
+    {
+      "id": "1668",
+      "title": "CI catastrophic-regression guard — block merge-queue on large test262 pass drops",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "review",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1669",
+      "title": "codegen: object-method trampoline forwards args without coercion → invalid wasm (regressed by #1602)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "goal": "compiler-correctness",
+      "cluster": "compiler-correctness"
+    },
+    {
+      "id": "1670",
+      "title": "Atomics negative tests trap with `illegal cast` (regressed by #1654 / PR #599)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1671",
+      "title": "object-method trampoline / direct dispatch lost the real receiver → ~200 runtime null-derefs (completes #1669/#621)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "goal": "compiler-correctness",
+      "cluster": "compiler-correctness"
+    },
+    {
+      "id": "1672",
+      "title": "async / async-gen object+class method trampolines must return the real result, not null (completes #1671)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [
+        "1671"
+      ],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1673",
+      "title": "super.<method>() on a built-in parent class fails to compile",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1674",
+      "title": "GetSetRecord set-like consumption: .size NaN, coercion count, has/keys callable checks",
+      "priority": "low",
+      "status": "blocked",
+      "raw_status": "blocked",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1675",
+      "title": "built-ins/Set residual fails — 63 non-passing after set-like fix (split from #1646)",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "compiler_errors": 7
+    },
+    {
+      "id": "1677",
+      "title": "Signature A: native string helper func-index shift unification (__str_flatten/__str_to_extern call[k] type mismatch under --target wasi)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1678",
+      "title": "externref-typed array/rest binding default not recognised by Array.isArray",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
+      "depends_on": [],
+      "files": [],
+      "goal": "property-model",
+      "cluster": "property-model",
+      "test262_fail": 727
+    },
+    {
+      "id": "1679",
+      "title": "Stress test: compile acorn.js — `new this(...)` dynamic constructor unsupported",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "real-world-compat",
+      "cluster": "real-world-compat"
+    },
+    {
+      "id": "1680",
+      "title": "Private setter write falls through to struct-field write — stacked private accessors cross-talk (~132 fails)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 132
+    },
+    {
+      "id": "1680b",
+      "title": "Private getter/method read missing PrivateBrandCheck — TypeError not thrown for non-brand receiver",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1681",
+      "title": "Static private accessor reached through inner closure emits invalid Wasm (extern.convert_any) / infinite recursion (~10 fails)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 10
+    },
+    {
+      "id": "1682",
+      "title": "Derived constructor must call super() for builtin subclasses (WeakMap/Promise/Object) — missing ReferenceError",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "55",
+      "depends_on": [],
+      "files": [],
+      "cluster": "sprint-55"
+    },
+    {
+      "id": "1684",
+      "title": "Iterator-result object literal `{ value, done }` from a nested closure reads back value=0 / done never truthy (closure-backed iterator value round-trip)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-conformance",
+      "cluster": "spec-conformance"
+    },
+    {
+      "id": "1686",
+      "title": "built-ins/Set residual fails — 63 non-passing after set-like fix (split from #1646)",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "compiler_errors": 7
+    },
+    {
+      "id": "1687",
+      "title": "spec gap: eager generator model can't thread .next(arg) / .throw() / .return() into yield (44/63 yield fails)",
+      "priority": "high",
+      "status": "blocked",
+      "raw_status": "blocked",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "compiler_errors": 1
+    },
+    {
+      "id": "1688",
+      "title": "Symbol→string implicit coercion must throw TypeError (value-representation gap, split from #1637)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "wont-fix",
+      "sprint": "56",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1689",
+      "title": "Number(string) returns 0 under --target wasi — missing native StringToNumber",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-mode",
+      "cluster": "standalone-mode"
+    },
+    {
+      "id": "1690",
+      "title": "Stress test: compile acorn.mjs — invalid Wasm in isInAstralSet (f64 op reads global array ref)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1690b",
+      "title": "Inner function `var x` aliases module-level `__mod_x` global instead of allocating a function-local",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1691",
+      "title": "yield* does not delegate throw()/return() to the inner iterator (eager-generator model gap)",
+      "priority": "medium",
+      "status": "blocked",
+      "raw_status": "blocked",
+      "sprint": "",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1693",
+      "title": "multi-funcref-dispatch (#1131) missing return-type coercion — emits invalid Wasm on full-module axios/utils.js (mis-presented as `&&` fallthru bug)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "npm-library-support",
+      "cluster": "npm-library-support"
+    },
+    {
+      "id": "1694",
+      "title": "Promise.any/all/allSettled/race: non-Promise capability `this` + extends-Promise codegen (~50 fails)",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1695",
+      "title": "DisposableStack/AsyncDisposableStack prototype methods — deferred-callback writeback fires too early (23 fails)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 23
+    },
+    {
+      "id": "1696",
+      "title": "dynamic-import eval-script-code fixture resolution + sloppy redecl (18 CE tests)",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "conformance-hygiene",
+      "cluster": "conformance-hygiene",
+      "compiler_errors": 18
+    },
+    {
+      "id": "1697",
+      "title": "static method `this.X = v` write not routed to staticProps global — public + private (asymmetric with read path)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 12
+    },
+    {
+      "id": "1698",
+      "title": "ArrayBuffer.prototype.slice() not implemented in --target wasi (dual-mode gap, same shape as #1654)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "wasi-completeness",
+      "cluster": "wasi-completeness"
+    },
+    {
+      "id": "1700",
+      "title": "TypedArray as exported Wasm function param fails JS↔Wasm marshalling (TypeError: type incompatibility)",
+      "priority": "high",
+      "status": "ready",
+      "raw_status": "in-progress",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "native-messaging, host-interop",
+      "cluster": "native-messaging, host-interop"
+    },
+    {
+      "id": "1701",
+      "title": "Assignment destructuring residuals — empty pattern + non-iterable RHS + iterator close",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "54",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1702",
+      "title": "Residual strict-mode `this` regressions: function-expression direct-call + nested fn-decl in class method",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "56",
+      "depends_on": [],
+      "files": [],
+      "goal": "core-semantics",
+      "cluster": "core-semantics"
+    },
+    {
+      "id": "1710",
+      "title": "acorn dogfood harness: compile + validate + differential-AST vs node-acorn",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1711",
+      "title": "acorn failure-surface triage: bucket harness output + file sized child issues",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [
+        "1710"
+      ],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1712",
+      "title": "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn",
+      "priority": "high",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "58",
+      "depends_on": [
+        "1710",
+        "1711"
+      ],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1713",
+      "title": "IR backend-trait: audit WasmGC bias in lower.ts + define BackendEmitter seam",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "backend-agnostic-ir",
+      "cluster": "backend-agnostic-ir"
+    },
+    {
+      "id": "1714",
+      "title": "Lower one IR node kind through the BackendEmitter trait to BOTH WasmGC and linear",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [
+        "1713"
+      ],
+      "files": [],
+      "goal": "backend-agnostic-ir",
+      "cluster": "backend-agnostic-ir"
+    },
+    {
+      "id": "1715",
+      "title": "Minimal bytecode emitter + dispatch loop for an IR subset (backend-agnostic proof point)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [
+        "1713"
+      ],
+      "files": [],
+      "goal": "backend-agnostic-ir",
+      "cluster": "backend-agnostic-ir"
+    },
+    {
+      "id": "1716",
+      "title": "spec gap (RESIDUAL of #1090/#1525): 'Cannot convert object to primitive value' still thrown in 111 coercion paths",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 111
+    },
+    {
+      "id": "1717",
+      "title": "ArrayBuffer.prototype.slice not implemented ('slice is not a function', 17 fails)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 17
+    },
+    {
+      "id": "1718",
+      "title": "Iterator sequencing helpers (Iterator.concat / zip / zipKeyed) + Iterator.prototype.flatMap not implemented (101 fails)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "compiler_errors": 262,
+      "test262_fail": 101
+    },
+    {
+      "id": "1719",
+      "title": "Array destructuring ignores overridden Array.prototype[Symbol.iterator] ('items[Symbol.iterator] must be a function', 71 fails)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "object-representation",
+      "cluster": "object-representation",
+      "test262_fail": 71
+    },
+    {
+      "id": "1720",
+      "title": "ES3: prefix/postfix inc-dec reference is evaluated once before the null/undefined deref ('base[prop()]++')",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 10
+    },
+    {
+      "id": "1721",
+      "title": "ES3 (RESIDUAL of #1455): 'class extends Function' / 'class extends Object' instanceof returns false",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 4
+    },
+    {
+      "id": "1722",
+      "title": "ES3: AssignmentTargetType early SyntaxError not raised (parenthesized object/array literal as assignment target)",
+      "priority": "low",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 4
+    },
+    {
+      "id": "1723",
+      "title": "writeMessage cast failure on multi-segment / large message (ConsString downcast + fixed-staging overflow)",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "real-world-compat, spec-completeness",
+      "cluster": "real-world-compat, spec-completeness"
+    },
+    {
+      "id": "1724",
+      "title": "WASI number formatting corrupts string constants (itoa scratch aliases data segments)",
+      "priority": "critical",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "real-world-compat, spec-completeness",
+      "cluster": "real-world-compat, spec-completeness"
+    },
+    {
+      "id": "1725",
+      "title": "acorn dogfood: __fnctor_<Ctor>_new emits any.convert_extern on a ref.cast-null struct ref → invalid Wasm",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1726",
+      "title": "spec gap: mapped `arguments` exotic-object representation (§10.4.4)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1727",
+      "title": "internal async-function call result wrapped in Promise then unboxed → NaN",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1728",
+      "title": "ES5: compound assignment to unresolvable reference must throw ReferenceError",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1729",
+      "title": "instanceof Object returns false for WasmGC-struct values (object literal / array / class instance / thrown value)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1730",
+      "title": "internal call to a module-level `const` arrow traps with illegal cast",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1731",
+      "title": "String.prototype.substring()/slice() with no args returns '' instead of the whole string",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1732",
+      "title": "spec gap: builtin method values lack [[Construct]]-absent brand + own length/name descriptors (~40 String.prototype A7/A8 fails)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1632",
+        "1665"
+      ],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness",
+      "test262_fail": 40
+    },
+    {
+      "id": "1733",
+      "title": "Native Messaging host: 1 MiB body corruption — byte-write helpers miss the memory-grow guard; refactor host to raw-Uint8Array 3-symbol API",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "real-world-compat, wasi-completeness",
+      "cluster": "real-world-compat, wasi-completeness"
+    },
+    {
+      "id": "1734",
+      "title": "acorn dogfood: __closure_11 emits unguarded struct.get on a call result of the wrong struct type → invalid Wasm",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1735",
+      "title": "Number.prototype.toExponential(NaN) collides with no-arg sentinel — returns variable digits instead of ToInteger(NaN)=0",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance",
+      "test262_fail": 1
+    },
+    {
+      "id": "1736",
+      "title": "ArrayBuffer.prototype.byteLength returns NaN in JS-host mode",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1737",
+      "title": "Uint8Array(arrayBuffer) does not alias the ArrayBuffer's backing store (JS-host)",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1738",
+      "title": "DataView.prototype.set* (setUint8 etc.) 'not a function' in JS-host mode",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1739",
+      "title": "String.prototype methods fail not-a-constructor (A7) + .length-DontEnum (A8) invariants across the suite",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1740",
+      "title": "String.prototype.padStart/padEnd omitted fillString defaults to 'null' instead of space",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1741",
+      "title": "TS type-checker CEs on test262 intentionally-wrong-typed builtin method args",
+      "priority": "medium",
+      "status": "backlog",
+      "raw_status": "backlog",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1742",
+      "title": "Closure `this`-receiver member reads trap 'illegal cast' when `this` is a compiled vec/struct (CPR prerequisite, shared with #1629)",
+      "priority": "high",
+      "status": "ready",
+      "raw_status": "in-progress",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "test262-conformance",
+      "cluster": "test262-conformance"
+    },
+    {
+      "id": "1743",
+      "title": "Bytecode VM: coordinated stack → register+accumulator encoding flip",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [
+        "1584"
+      ],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1744",
+      "title": "string-builder build-loop perf: close the remaining gap on StarlingMonkey / the JS lane",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "performance",
+      "cluster": "performance"
+    },
+    {
+      "id": "1745",
+      "title": "acorn dogfood: __closure_37 global.set expects f64, found if of (ref null 3) → invalid Wasm",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "self-hosting-dogfood",
+      "cluster": "self-hosting-dogfood"
+    },
+    {
+      "id": "1746",
+      "title": "string-hash: reach (and beat) warm-V8 via AOT analysis — i32 path, const-eval, presize, SIMD, loop fusion/unroll",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "57",
+      "depends_on": [],
+      "files": [],
+      "goal": "performance",
+      "cluster": "performance"
+    },
+    {
+      "id": "1747",
+      "title": "Array.prototype.pop() on an empty array traps instead of returning undefined (compiled WasmGC)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-correctness",
+      "cluster": "standalone-correctness"
+    },
+    {
+      "id": "1748",
+      "title": "readonly array as a nested struct field traps on indexed read (compiled WasmGC)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "standalone-correctness",
+      "cluster": "standalone-correctness"
+    },
+    {
+      "id": "1749",
+      "title": "Array spread `[...arr]` / spread-call must honor overridden Array.prototype[Symbol.iterator]",
+      "priority": "low",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "object-representation",
+      "cluster": "object-representation"
+    },
+    {
+      "id": "1750",
+      "title": "TS-cast form `(Array.prototype as any)[Symbol.iterator] = fn` not captured by CPR write-arm",
+      "priority": "low",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "object-representation",
+      "cluster": "object-representation"
+    },
+    {
+      "id": "1751",
+      "title": "WIT generator emits an incomplete world: hardcoded package name + no WASI imports",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1752",
+      "title": "TextEncoder / TextDecoder runtime API (standalone + WASI)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1753",
+      "title": "Native-messaging host: 64 MiB read/write via ≤1 MiB chunked streaming",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1754",
+      "title": "Build-from-repo: packages/index re-exports unresolved @loopdive/js2",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1755",
+      "title": "TS annotation: Uint8Array<ArrayBuffer> generic typed-array form not handled",
+      "priority": "low",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1757",
+      "title": "Migrate the public compile() API to async (embed binaryen via await import)",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1758",
+      "title": "auto-enqueue churn wedges the serial merge queue — make the sweep surgical",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1759",
+      "title": "native number→string missing on the WASI/standalone string-concat path (process.stderr/stdout.write of numeric template emits invalid module)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1760",
+      "title": "wasm warm-runtime benchmark lane: in-process repeated-measure (current cold−baseline subtraction is noise-dominated)",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1761",
+      "title": "perf(string-hash): presize string-build buffer from static loop-trip-count to kill reallocs + per-append cap-check",
+      "priority": "high",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1762",
+      "title": "perf(strings): linear-memory string backing for the build/hash hot path — drop the WasmGC (array i16) GC barrier",
+      "priority": "high",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "spec-completeness",
+      "cluster": "spec-completeness"
+    },
+    {
+      "id": "1763",
+      "title": "Remove dead sync binaryen createRequire path + bare require(node:fs) residual in optimize.ts",
+      "priority": "medium",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "Backlog",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1764",
+      "title": "wasmtime bench: model production edge-serverless per-request instantiation (warm engine), not full process spawns",
+      "priority": "medium",
+      "status": "ready",
+      "raw_status": "ready",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
+    },
+    {
+      "id": "1768",
+      "title": "allowJs native-messaging sendMessage emits invalid WASI wasm",
+      "priority": "high",
+      "status": "done",
+      "raw_status": "done",
+      "sprint": "58",
+      "depends_on": [],
+      "files": [],
+      "goal": "platform",
+      "cluster": "platform"
     }
   ],
   "links": [
@@ -22106,6 +23481,10 @@
       "target": "1326c"
     },
     {
+      "source": "1665",
+      "target": "1344"
+    },
+    {
       "source": "1388",
       "target": "1394"
     },
@@ -22116,6 +23495,14 @@
     {
       "source": "268",
       "target": "153"
+    },
+    {
+      "source": "1653",
+      "target": "1530"
+    },
+    {
+      "source": "1654",
+      "target": "1530"
     },
     {
       "source": "1474",
@@ -22166,6 +23553,46 @@
       "target": "1588"
     },
     {
+      "source": "1588",
+      "target": "1650"
+    },
+    {
+      "source": "1654",
+      "target": "1653"
+    },
+    {
+      "source": "1654",
+      "target": "1655"
+    },
+    {
+      "source": "1659",
+      "target": "1658"
+    },
+    {
+      "source": "1671",
+      "target": "1672"
+    },
+    {
+      "source": "1710",
+      "target": "1711"
+    },
+    {
+      "source": "1710",
+      "target": "1712"
+    },
+    {
+      "source": "1711",
+      "target": "1712"
+    },
+    {
+      "source": "1713",
+      "target": "1714"
+    },
+    {
+      "source": "1713",
+      "target": "1715"
+    },
+    {
       "source": "171",
       "target": "172"
     },
@@ -22176,6 +23603,18 @@
     {
       "source": "265",
       "target": "173"
+    },
+    {
+      "source": "1632",
+      "target": "1732"
+    },
+    {
+      "source": "1665",
+      "target": "1732"
+    },
+    {
+      "source": "1584",
+      "target": "1743"
     },
     {
       "source": "241",
@@ -22736,6 +24175,7 @@
         "972",
         "973",
         "983",
+        "983d",
         "984",
         "986",
         "1012",
@@ -22770,6 +24210,21 @@
         "1227",
         "1259"
       ]
+    },
+    {
+      "id": "backend-agnostic-ir",
+      "title": "backend-agnostic-ir",
+      "status": "active",
+      "target": "A documented backend-trait seam in `src/ir/lower.ts`; at least one node kind lowered through that seam to two backends; one proof point of a non-WasmGC backend",
+      "depends_on": [
+        "compiler-architecture"
+      ],
+      "issues": [
+        "1713",
+        "1714",
+        "1715"
+      ],
+      "track": "supporting / architecture track (parallel to conformance)"
     },
     {
       "id": "builtin-methods",
@@ -23357,7 +24812,8 @@
         "1219",
         "1224",
         "1236",
-        "1256"
+        "1256",
+        "1702"
       ]
     },
     {
@@ -23767,7 +25223,8 @@
         "1576",
         "1600",
         "1619",
-        "1647"
+        "1647",
+        "1693"
       ],
       "track": "supporting track"
     },
@@ -23838,7 +25295,9 @@
         "1269",
         "1270",
         "1290",
-        "1580"
+        "1580",
+        "1744",
+        "1746"
       ],
       "track": "parallel — does not block conformance goals."
     },
@@ -23913,7 +25372,20 @@
         "1585",
         "1586",
         "1587",
-        "1588"
+        "1588",
+        "1650",
+        "1751",
+        "1752",
+        "1753",
+        "1754",
+        "1755",
+        "1757",
+        "1758",
+        "1759",
+        "1760",
+        "1763",
+        "1764",
+        "1768"
       ],
       "track": "parallel — does not block conformance goals."
     },
@@ -23971,8 +25443,31 @@
         "1113",
         "1114",
         "1130",
-        "1169d"
+        "1169d",
+        "1678"
       ]
+    },
+    {
+      "id": "self-hosting-dogfood",
+      "title": "self-hosting-dogfood",
+      "status": "active",
+      "target": "Compiled-to-Wasm acorn parses a representative `.js` file and emits an AST structurally equal to node-acorn's on the same input",
+      "depends_on": [
+        "compilable",
+        "crash-free",
+        "standalone-mode"
+      ],
+      "issues": [
+        "1690",
+        "1690b",
+        "1710",
+        "1711",
+        "1712",
+        "1725",
+        "1734",
+        "1745"
+      ],
+      "track": "supporting / dogfood track (parallel to conformance)"
     },
     {
       "id": "spec-completeness",
@@ -24036,6 +25531,8 @@
         "779",
         "785",
         "791",
+        "820l",
+        "820m",
         "825",
         "826",
         "832",
@@ -24186,6 +25683,7 @@
         "1517",
         "1518",
         "1519",
+        "1525b",
         "1550",
         "1551",
         "1552",
@@ -24211,6 +25709,7 @@
         "1626",
         "1627",
         "1629",
+        "1629a",
         "1630",
         "1631",
         "1632",
@@ -24229,7 +25728,27 @@
         "1645",
         "1646",
         "1648",
-        "1649"
+        "1649",
+        "1658",
+        "1659",
+        "1673",
+        "1674",
+        "1675",
+        "1680",
+        "1680b",
+        "1681",
+        "1686",
+        "1687",
+        "1688",
+        "1691",
+        "1694",
+        "1695",
+        "1697",
+        "1701",
+        "1732",
+        "1743",
+        "1761",
+        "1762"
       ]
     },
     {
@@ -24294,7 +25813,14 @@
         "1326",
         "1326c",
         "1335",
-        "1353"
+        "1353",
+        "1662",
+        "1663",
+        "1664",
+        "1665",
+        "1666",
+        "1677",
+        "1689"
       ],
       "track": "parallel — does not block conformance goals."
     },
@@ -24697,6 +26223,10 @@
     },
     {
       "goal": "async-model",
+      "issue": "983d"
+    },
+    {
+      "goal": "async-model",
       "issue": "984"
     },
     {
@@ -24826,6 +26356,18 @@
     {
       "goal": "async-model",
       "issue": "1259"
+    },
+    {
+      "goal": "backend-agnostic-ir",
+      "issue": "1713"
+    },
+    {
+      "goal": "backend-agnostic-ir",
+      "issue": "1714"
+    },
+    {
+      "goal": "backend-agnostic-ir",
+      "issue": "1715"
     },
     {
       "goal": "builtin-methods",
@@ -26892,6 +28434,10 @@
       "issue": "1256"
     },
     {
+      "goal": "core-semantics",
+      "issue": "1702"
+    },
+    {
       "goal": "correctness",
       "issue": "1143"
     },
@@ -28140,6 +29686,10 @@
       "issue": "1647"
     },
     {
+      "goal": "npm-library-support",
+      "issue": "1693"
+    },
+    {
       "goal": "observability",
       "issue": "880"
     },
@@ -28334,6 +29884,14 @@
     {
       "goal": "performance",
       "issue": "1580"
+    },
+    {
+      "goal": "performance",
+      "issue": "1744"
+    },
+    {
+      "goal": "performance",
+      "issue": "1746"
     },
     {
       "goal": "platform",
@@ -28588,6 +30146,58 @@
       "issue": "1588"
     },
     {
+      "goal": "platform",
+      "issue": "1650"
+    },
+    {
+      "goal": "platform",
+      "issue": "1751"
+    },
+    {
+      "goal": "platform",
+      "issue": "1752"
+    },
+    {
+      "goal": "platform",
+      "issue": "1753"
+    },
+    {
+      "goal": "platform",
+      "issue": "1754"
+    },
+    {
+      "goal": "platform",
+      "issue": "1755"
+    },
+    {
+      "goal": "platform",
+      "issue": "1757"
+    },
+    {
+      "goal": "platform",
+      "issue": "1758"
+    },
+    {
+      "goal": "platform",
+      "issue": "1759"
+    },
+    {
+      "goal": "platform",
+      "issue": "1760"
+    },
+    {
+      "goal": "platform",
+      "issue": "1763"
+    },
+    {
+      "goal": "platform",
+      "issue": "1764"
+    },
+    {
+      "goal": "platform",
+      "issue": "1768"
+    },
+    {
       "goal": "property-model",
       "issue": "69"
     },
@@ -28770,6 +30380,42 @@
     {
       "goal": "property-model",
       "issue": "1169d"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1678"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1690"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1690b"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1710"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1711"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1712"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1725"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1734"
+    },
+    {
+      "goal": "self-hosting-dogfood",
+      "issue": "1745"
     },
     {
       "goal": "spec-completeness",
@@ -28970,6 +30616,14 @@
     {
       "goal": "spec-completeness",
       "issue": "791"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "820l"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "820m"
     },
     {
       "goal": "spec-completeness",
@@ -29573,6 +31227,10 @@
     },
     {
       "goal": "spec-completeness",
+      "issue": "1525b"
+    },
+    {
+      "goal": "spec-completeness",
       "issue": "1550"
     },
     {
@@ -29673,6 +31331,10 @@
     },
     {
       "goal": "spec-completeness",
+      "issue": "1629a"
+    },
+    {
+      "goal": "spec-completeness",
       "issue": "1630"
     },
     {
@@ -29746,6 +31408,86 @@
     {
       "goal": "spec-completeness",
       "issue": "1649"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1658"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1659"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1673"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1674"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1675"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1680"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1680b"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1681"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1686"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1687"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1688"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1691"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1694"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1695"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1697"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1701"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1732"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1743"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1761"
+    },
+    {
+      "goal": "spec-completeness",
+      "issue": "1762"
     },
     {
       "goal": "standalone-mode",
@@ -29958,6 +31700,34 @@
     {
       "goal": "standalone-mode",
       "issue": "1353"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1662"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1663"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1664"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1665"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1666"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1677"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1689"
     },
     {
       "goal": "symbol-protocol",
@@ -30691,6 +32461,10 @@
     },
     {
       "goal": "generator-model",
+      "issue": "983d"
+    },
+    {
+      "goal": "generator-model",
       "issue": "984"
     },
     {
@@ -30820,6 +32594,18 @@
     {
       "goal": "generator-model",
       "issue": "1259"
+    },
+    {
+      "goal": "compiler-architecture",
+      "issue": "1713"
+    },
+    {
+      "goal": "compiler-architecture",
+      "issue": "1714"
+    },
+    {
+      "goal": "compiler-architecture",
+      "issue": "1715"
     },
     {
       "goal": "core-semantics",
@@ -31899,6 +33685,10 @@
     },
     {
       "goal": "compilable",
+      "issue": "1702"
+    },
+    {
+      "goal": "compilable",
       "issue": "1143"
     },
     {
@@ -32902,6 +34692,10 @@
       "issue": "1647"
     },
     {
+      "goal": "core-semantics",
+      "issue": "1693"
+    },
+    {
       "goal": "platform",
       "issue": "111"
     },
@@ -33234,6 +35028,10 @@
       "issue": "1647"
     },
     {
+      "goal": "platform",
+      "issue": "1693"
+    },
+    {
       "goal": "core-semantics",
       "issue": "25"
     },
@@ -33416,6 +35214,14 @@
     {
       "goal": "core-semantics",
       "issue": "1580"
+    },
+    {
+      "goal": "core-semantics",
+      "issue": "1744"
+    },
+    {
+      "goal": "core-semantics",
+      "issue": "1746"
     },
     {
       "goal": "standalone-mode",
@@ -33670,6 +35476,58 @@
       "issue": "1588"
     },
     {
+      "goal": "standalone-mode",
+      "issue": "1650"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1751"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1752"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1753"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1754"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1755"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1757"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1758"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1759"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1760"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1763"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1764"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1768"
+    },
+    {
       "goal": "core-semantics",
       "issue": "69"
     },
@@ -33854,6 +35712,106 @@
       "issue": "1169d"
     },
     {
+      "goal": "core-semantics",
+      "issue": "1678"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1690"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1690b"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1710"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1711"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1712"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1725"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1734"
+    },
+    {
+      "goal": "compilable",
+      "issue": "1745"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1690"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1690b"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1710"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1711"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1712"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1725"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1734"
+    },
+    {
+      "goal": "crash-free",
+      "issue": "1745"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1690"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1690b"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1710"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1711"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1712"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1725"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1734"
+    },
+    {
+      "goal": "standalone-mode",
+      "issue": "1745"
+    },
+    {
       "goal": "async-model",
       "issue": "10"
     },
@@ -34052,6 +36010,14 @@
     {
       "goal": "async-model",
       "issue": "791"
+    },
+    {
+      "goal": "async-model",
+      "issue": "820l"
+    },
+    {
+      "goal": "async-model",
+      "issue": "820m"
     },
     {
       "goal": "async-model",
@@ -34655,6 +36621,10 @@
     },
     {
       "goal": "async-model",
+      "issue": "1525b"
+    },
+    {
+      "goal": "async-model",
       "issue": "1550"
     },
     {
@@ -34755,6 +36725,10 @@
     },
     {
       "goal": "async-model",
+      "issue": "1629a"
+    },
+    {
+      "goal": "async-model",
       "issue": "1630"
     },
     {
@@ -34828,6 +36802,86 @@
     {
       "goal": "async-model",
       "issue": "1649"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1658"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1659"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1673"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1674"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1675"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1680"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1680b"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1681"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1686"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1687"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1688"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1691"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1694"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1695"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1697"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1701"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1732"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1743"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1761"
+    },
+    {
+      "goal": "async-model",
+      "issue": "1762"
     },
     {
       "goal": "symbol-protocol",
@@ -35028,6 +37082,14 @@
     {
       "goal": "symbol-protocol",
       "issue": "791"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "820l"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "820m"
     },
     {
       "goal": "symbol-protocol",
@@ -35631,6 +37693,10 @@
     },
     {
       "goal": "symbol-protocol",
+      "issue": "1525b"
+    },
+    {
+      "goal": "symbol-protocol",
       "issue": "1550"
     },
     {
@@ -35731,6 +37797,10 @@
     },
     {
       "goal": "symbol-protocol",
+      "issue": "1629a"
+    },
+    {
+      "goal": "symbol-protocol",
       "issue": "1630"
     },
     {
@@ -35804,6 +37874,86 @@
     {
       "goal": "symbol-protocol",
       "issue": "1649"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1658"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1659"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1673"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1674"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1675"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1680"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1680b"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1681"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1686"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1687"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1688"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1691"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1694"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1695"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1697"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1701"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1732"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1743"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1761"
+    },
+    {
+      "goal": "symbol-protocol",
+      "issue": "1762"
     },
     {
       "goal": "builtin-methods",
@@ -36004,6 +38154,14 @@
     {
       "goal": "builtin-methods",
       "issue": "791"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "820l"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "820m"
     },
     {
       "goal": "builtin-methods",
@@ -36607,6 +38765,10 @@
     },
     {
       "goal": "builtin-methods",
+      "issue": "1525b"
+    },
+    {
+      "goal": "builtin-methods",
       "issue": "1550"
     },
     {
@@ -36707,6 +38869,10 @@
     },
     {
       "goal": "builtin-methods",
+      "issue": "1629a"
+    },
+    {
+      "goal": "builtin-methods",
       "issue": "1630"
     },
     {
@@ -36780,6 +38946,86 @@
     {
       "goal": "builtin-methods",
       "issue": "1649"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1658"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1659"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1673"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1674"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1675"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1680"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1680b"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1681"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1686"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1687"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1688"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1691"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1694"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1695"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1697"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1701"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1732"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1743"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1761"
+    },
+    {
+      "goal": "builtin-methods",
+      "issue": "1762"
     },
     {
       "goal": "property-model",
@@ -36980,6 +39226,14 @@
     {
       "goal": "property-model",
       "issue": "791"
+    },
+    {
+      "goal": "property-model",
+      "issue": "820l"
+    },
+    {
+      "goal": "property-model",
+      "issue": "820m"
     },
     {
       "goal": "property-model",
@@ -37583,6 +39837,10 @@
     },
     {
       "goal": "property-model",
+      "issue": "1525b"
+    },
+    {
+      "goal": "property-model",
       "issue": "1550"
     },
     {
@@ -37683,6 +39941,10 @@
     },
     {
       "goal": "property-model",
+      "issue": "1629a"
+    },
+    {
+      "goal": "property-model",
       "issue": "1630"
     },
     {
@@ -37756,6 +40018,86 @@
     {
       "goal": "property-model",
       "issue": "1649"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1658"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1659"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1673"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1674"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1675"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1680"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1680b"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1681"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1686"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1687"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1688"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1691"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1694"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1695"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1697"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1701"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1732"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1743"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1761"
+    },
+    {
+      "goal": "property-model",
+      "issue": "1762"
     },
     {
       "goal": "iterator-protocol",
@@ -37970,6 +40312,34 @@
       "issue": "1353"
     },
     {
+      "goal": "iterator-protocol",
+      "issue": "1662"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1663"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1664"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1665"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1666"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1677"
+    },
+    {
+      "goal": "iterator-protocol",
+      "issue": "1689"
+    },
+    {
       "goal": "generator-model",
       "issue": "34"
     },
@@ -38180,6 +40550,34 @@
     {
       "goal": "generator-model",
       "issue": "1353"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1662"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1663"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1664"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1665"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1666"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1677"
+    },
+    {
+      "goal": "generator-model",
+      "issue": "1689"
     },
     {
       "goal": "iterator-protocol",


### PR DESCRIPTION
## Summary

Fixes #1768 from GitHub #389 by preserving vec typing for allowJs `subarray`/`set` flows and emitting valid native-string externref constants in fallback property and method paths.

## Validation

- `pnpm exec vitest run tests/issue-1768.test.ts tests/issue-1664.test.ts`
- `pnpm exec tsc --noEmit --pretty false --incremental false`
- `pnpm exec prettier --check ...`
- `git diff --check`
- pre-push typecheck/lint/format/issue-integrity hooks