### PR TITLE
ci(hooks): check committed issue dependencies pre-push (#1771)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -194,8 +194,10 @@ fi
 # filename-prefix != frontmatter-id and fails CI's #1616 integrity gate ~2 min
 # later. The key is we check the COMMITTED tree (`git show HEAD:<file>`), NOT the
 # working tree — the working tree looks fine in exactly this case, which is why
-# the agents' local `check:issues` falsely passed. Also runs the full
-# check:issues for dup-IDs / broken links. Skip the whole hook with --no-verify.
+# the agents' local `check:issues` falsely passed. Also checks committed-tree
+# dependencies so uncommitted sibling issue files cannot hide a dangling
+# depends_on, then runs the full check:issues for dup-IDs / broken links.
+# Skip the whole hook with --no-verify.
 
 if command -v node > /dev/null 2>&1 && [ -d plan/issues ]; then
   issue_block=0
@@ -225,7 +227,20 @@ if command -v node > /dev/null 2>&1 && [ -d plan/issues ]; then
     fi
   done
 
-  # (5b) full integrity gate (duplicate IDs, broken path links) — working tree.
+  # (5b) committed-tree graph integrity. This catches the PR-quality failure
+  # where an uncommitted sibling issue file makes the working tree look valid,
+  # but the pushed commit has a dangling depends_on.
+  if [ -f scripts/check-committed-issue-integrity.mjs ]; then
+    if ! node scripts/check-committed-issue-integrity.mjs HEAD > /tmp/.prepush_issues_committed 2>&1; then
+      echo ""
+      echo "PRE-PUSH BLOCKED: committed issue integrity gate (#1616) failed:"
+      tail -30 /tmp/.prepush_issues_committed
+      issue_block=1
+    fi
+    rm -f /tmp/.prepush_issues_committed
+  fi
+
+  # (5c) full integrity gate (duplicate IDs, broken path links) — working tree.
   if grep -q '"check:issues"' package.json 2>/dev/null; then
     if ! node scripts/update-issues.mjs --check > /tmp/.prepush_issues 2>&1; then
       echo ""

--- a/plan/issues/1771-prepush-issue-integrity-committed-tree.md
+++ b/plan/issues/1771-prepush-issue-integrity-committed-tree.md
@@ -1,0 +1,49 @@
+---
+id: 1771
+title: "pre-push issue integrity can miss committed dangling dependencies"
+status: done
+created: 2026-06-01
+updated: 2026-06-01
+completed: 2026-06-01
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: infrastructure
+area: ci
+goal: platform
+related: [1616, 1769]
+depends_on: []
+sprint: 58
+origin: "Project lead feedback after PR #1013 quality gate failed on a dangling depends_on."
+---
+
+# #1771 - pre-push issue integrity can miss committed dangling dependencies
+
+## Problem
+
+PR #1013 failed the GitHub Actions `quality` job in `pnpm run check:issues`
+because #1769 declared `depends_on: [1765]`, but #1765's issue file lives in a
+separate unmerged PR.
+
+That should have failed before push. The existing pre-push hook runs the full
+working-tree issue check, but a dirty worktree can contain uncommitted sibling
+issue files that make the local check pass while the pushed commit still fails
+CI.
+
+## Acceptance
+
+- Pre-push checks issue dependency integrity against the committed tree being
+  pushed, not only the current working tree.
+- Dangling `depends_on` references are blocked locally even when the working
+  tree contains uncommitted files that would satisfy the dependency.
+- The existing working-tree `check:issues` remains in place for duplicate IDs,
+  broken links, and normal local feedback.
+
+## Implementation notes
+
+- Added `scripts/check-committed-issue-integrity.mjs`, which reads issue files
+  directly from a git tree (`HEAD` by default) using `git ls-tree` / `git show`.
+- The pre-push hook now calls that committed-tree checker before the existing
+  working-tree `scripts/update-issues.mjs --check` gate.
+- The checker validates duplicate issue IDs, filename/frontmatter ID mismatch,
+  and dangling `depends_on` edges in the committed tree.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -54,6 +54,10 @@ From the dev-1553b destructuring-lane verification sweep.
 - [#1658](../1658-destructured-function-param-default-not-applied.md) — Destructured/scalar **function-parameter** default not applied: returns 30 where 40 is expected on the real runtime (distinct from the object/array decl-mode #1553b/#1553d which are done) — high, medium, **ready**. NOT currently caught by CI (see #1659); depends on #1659 for gating.
 - [#1659](../1659-ci-equivalence-tests-not-run.md) — CI does not run `tests/equivalence/` (OOMs in runner) so genuine equivalence regressions (e.g. #1658) land silently. Options: shard like test262 / constrained workers / `--no-threads` / separate scheduled job. Sub-item: fix `__extern_get` harness-fidelity gap in `tests/equivalence/helpers.ts` so the suite runs clean — high, medium, **ready**. Gates CI-visibility of #1658.
 
+## CI quality gate hardening (2026-06-01)
+
+- [#1771](../1771-prepush-issue-integrity-committed-tree.md) — Pre-push issue integrity must check the committed tree so dangling `depends_on` edges cannot be masked by uncommitted sibling issue files — medium, easy, **DONE (sprint 58)**.
+
 ## Sprint 55 — repo structure / website (2026-05-24)
 
 - [#1656](../1656-group-website-files-into-website-dir.md) — Consolidate all website/frontend files under `website/` (components, dashboard, playground, index.html, public, frame-nav-sync.js, images, vite.config.ts, CNAME) — medium, medium, **ready (sprint 55)**. Needs architect spec (`arch(#1656)`) before dev; lands as one PR. Related: #1583, #1590.

--- a/plan/issues/sprints/58.md
+++ b/plan/issues/sprints/58.md
@@ -40,6 +40,12 @@ messaging host body-corruption and WASI itoa fixes landed in S57 (#1733/#1723/
 | [#1755](../1755-uint8array-arraybuffer-generic-annotation.md) | `Uint8Array<ArrayBuffer>` generic annotation | ready |
 | [#1759](../1759-wasi-native-number-to-string-bridge-gap.md) | WASI `process.stderr.write` numeric-template → native number→string bridge gap | ready |
 
+## CI quality gate hardening
+
+| ID | Title | Status |
+|----|-------|--------|
+| [#1771](../1771-prepush-issue-integrity-committed-tree.md) | pre-push issue integrity checks committed-tree dependencies | done |
+
 ## Benchmark fidelity track
 
 Make the landing-page edge-serverless benchmark **honest and

--- a/scripts/check-committed-issue-integrity.mjs
+++ b/scripts/check-committed-issue-integrity.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Check issue metadata from a committed git tree, independent of the working tree.
+
+import { execFileSync } from "node:child_process";
+import { basename, dirname } from "node:path";
+
+const ref = process.argv[2] || "HEAD";
+
+const NON_ISSUE_BASENAMES = new Set([
+  "1034-report.md",
+  "82-findings.md",
+  "1578-test262-analysis.md",
+  "backlog.md",
+  "index.md",
+  "log.md",
+  "analysis-2026-03-25.md",
+  "sprint-1.md",
+  "sprint-2.md",
+  "sprint-3.md",
+]);
+
+const EXPLICIT_ISSUE_BASENAMES = new Set(["512-illegal-cast-closures.md"]);
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+function isIssueFile(file) {
+  const name = basename(file);
+  if (NON_ISSUE_BASENAMES.has(name)) return false;
+  if (EXPLICIT_ISSUE_BASENAMES.has(name)) return true;
+  if (dirname(file) === "plan/issues/sprints" && /^\d+\.md$/.test(name)) return false;
+  return /^\d+[a-z]?(?:[-_].+)?\.md$/i.test(name);
+}
+
+function filenameIssueId(file) {
+  return (
+    basename(file)
+      .match(/^(\d+[a-z]?)/i)?.[1]
+      .toLowerCase() || ""
+  );
+}
+
+function frontmatter(text) {
+  return text.match(/^---\n([\s\S]*?)\n---\n?/)?.[1] || "";
+}
+
+function readScalar(fm, key) {
+  const line = fm.match(new RegExp(`^${key}:\\s*(.*)$`, "m"))?.[1]?.trim() || "";
+  return line.replace(/^["']|["']$/g, "").trim();
+}
+
+function readInlineArray(fm, key) {
+  const raw = readScalar(fm, key);
+  const match = raw.match(/^\[(.*)\]$/);
+  if (!match) return [];
+  return match[1]
+    .split(",")
+    .map((part) =>
+      part
+        .trim()
+        .replace(/^["']|["']$/g, "")
+        .toLowerCase(),
+    )
+    .filter(Boolean);
+}
+
+function showFile(file) {
+  return git(["show", `${ref}:${file}`]);
+}
+
+let files = [];
+try {
+  files = git(["ls-tree", "-r", "--name-only", ref, "--", "plan/issues"])
+    .split("\n")
+    .filter((file) => file && isIssueFile(file));
+} catch (error) {
+  console.error(`Unable to inspect issue files at ${ref}: ${error.message}`);
+  process.exit(1);
+}
+
+const byId = new Map();
+const duplicates = new Map();
+const idMismatches = [];
+const edges = [];
+
+for (const file of files) {
+  const text = showFile(file);
+  const fm = frontmatter(text);
+  const fileId = filenameIssueId(file);
+  const id = (readScalar(fm, "id") || fileId).toLowerCase();
+  if (!id) continue;
+
+  if (fileId && id !== fileId) {
+    idMismatches.push({ file, filename: fileId, frontmatter: id });
+  }
+  if (byId.has(id)) {
+    if (!duplicates.has(id)) duplicates.set(id, [byId.get(id)]);
+    duplicates.get(id).push(file);
+  } else {
+    byId.set(id, file);
+  }
+
+  for (const dep of readInlineArray(fm, "depends_on")) {
+    edges.push({ file, dep });
+  }
+}
+
+const dangling = edges.filter(({ dep }) => !byId.has(dep));
+
+if (duplicates.size || idMismatches.length || dangling.length) {
+  console.log(`Committed issue integrity failed for ${ref}:`);
+  if (duplicates.size) {
+    console.log(`\nDUPLICATE IDs (${duplicates.size}):`);
+    for (const [id, entries] of duplicates) {
+      console.log(`  #${id}:`);
+      for (const file of entries) console.log(`    ${file}`);
+    }
+  }
+  if (idMismatches.length) {
+    console.log(`\nFILENAME/FRONTMATTER ID MISMATCH (${idMismatches.length}):`);
+    for (const { file, filename, frontmatter } of idMismatches) {
+      console.log(`  ${file}: filename prefix=${filename}, frontmatter id=${frontmatter}`);
+    }
+  }
+  if (dangling.length) {
+    console.log(`\nDANGLING depends_on (${dangling.length}):`);
+    for (const { file, dep } of dangling) console.log(`  ${file} -> #${dep} (not found in ${ref})`);
+  }
+  process.exit(1);
+}
+
+console.log(`Committed issue integrity OK for ${ref} (${byId.size} issues indexed).`);


### PR DESCRIPTION
## Summary

Fixes #1771 after PR #1013 showed that `check:issues` could still fail only in GitHub Actions: the pre-push hook now runs a committed-tree issue integrity checker before the existing working-tree issue check.

The new checker reads issue files from `HEAD` via `git ls-tree` / `git show`, so uncommitted sibling issue files cannot mask dangling `depends_on` edges.

## Validation

- `node --check scripts/check-committed-issue-integrity.mjs`
- `node scripts/check-committed-issue-integrity.mjs HEAD`
- `node scripts/check-committed-issue-integrity.mjs refs/codex-tmp/1769-remote-head` fails with the old dangling #1765 dependency
- `pnpm exec prettier --check scripts/check-committed-issue-integrity.mjs`
- `pnpm run check:issues`
- `pnpm run lint`
- pre-push typecheck/lint/format/issue-integrity hooks