### PR TITLE
fix(wasi): support stdout write drain shim (#1766)

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1672,6 +1672,22 @@ function matchProcessStdStreamWrite(
   return { useStderr: streamName === "stderr" };
 }
 
+function matchProcessStdStreamDrainOnce(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
+  if (!ctx.wasi) return false;
+  if (expr.questionDotToken || expr.arguments.length !== 2) return false;
+  const onceAccess = expr.expression;
+  if (!ts.isPropertyAccessExpression(onceAccess) || onceAccess.name.text !== "once") return false;
+  const streamAccess = onceAccess.expression;
+  if (!ts.isPropertyAccessExpression(streamAccess)) return false;
+  const streamName = streamAccess.name.text;
+  if (streamName !== "stdout" && streamName !== "stderr") return false;
+  const procIdent = streamAccess.expression;
+  if (!ts.isIdentifier(procIdent) || procIdent.text !== "process") return false;
+  if (fctx.localMap.has("process") || (fctx.boxedCaptures?.has("process") ?? false)) return false;
+  const eventArg = expr.arguments[0]!;
+  return ts.isStringLiteralLike(eventArg) && eventArg.text === "drain";
+}
+
 /**
  * Statically flatten an array literal's elements into a positional argument
  * list, expanding spreads of nested array literals (`[...[a, b]]` → `a, b`).
@@ -1941,6 +1957,14 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (r) return r;
   }
 
+  // #1766: WASI fd_write is synchronous. Accept the Node stream backpressure
+  // subscription shape so idiomatic `if (!stdout.write(...)) stdout.once("drain", cb)`
+  // compiles without a JS-host EventEmitter import. Since write() returns true
+  // below, the drain callback is never needed on this path.
+  if (matchProcessStdStreamDrainOnce(ctx, fctx, expr)) {
+    return VOID_RESULT;
+  }
+
   // #1651 (GitHub #572): process.stdout.write(x) / process.stderr.write(x)
   // under --target wasi → write x to fd=1 / fd=2 with NO trailing newline
   // (unlike console.log). Supersedes the bespoke `writeStdout` builtin from
@@ -1975,7 +1999,8 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           const writeStrIdx = ensureWasiWriteAnyStringHelper(ctx, useStderr);
           if (writeStrIdx >= 0) {
             fctx.body.push({ op: "call", funcIdx: writeStrIdx } as Instr);
-            return VOID_RESULT;
+            fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+            return { kind: "i32" };
           }
         }
         // Fallback: drop to keep the stack balanced.
@@ -2015,7 +2040,8 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         : ensureWasiWriteUint8ArrayHelper(ctx, vecTypeIdx, useStderr);
       if (helperIdx >= 0) {
         fctx.body.push({ op: "call", funcIdx: helperIdx } as Instr);
-        return VOID_RESULT;
+        fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+        return { kind: "i32" };
       }
       if (argType) fctx.body.push({ op: "drop" } as Instr);
       return VOID_RESULT;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5374,6 +5374,7 @@ export function ensureWasiWriteArrayBufferHelper(
       { name: "len", type: { kind: "i32" } },
       { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } },
       { name: "i", type: { kind: "i32" } },
+      { name: "needPages", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/tests/issue-1766.test.ts
+++ b/tests/issue-1766.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function runWasiCaptureFd(binary: Uint8Array, fd: number): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const captured: number[] = [];
+  const view = () => new DataView(ref.mem!.buffer);
+  const wasi = {
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const memView = view();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = memView.getUint32(iovs + i * 8, true);
+        const len = memView.getUint32(iovs + i * 8 + 4, true);
+        if (wfd === fd) for (const b of new Uint8Array(ref.mem!.buffer, ptr, len)) captured.push(b);
+        total += len;
+      }
+      memView.setUint32(nwritten, total, true);
+      return 0;
+    },
+    fd_read(_fd: number, _iovs: number, _iovsLen: number, nread: number): number {
+      view().setUint32(nread, 0, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  return Uint8Array.from(captured);
+}
+
+describe("#1766 process stdout/stderr synchronous WASI stream compatibility", () => {
+  it("returns true from process.stdout.write and compiles once('drain') without host EventEmitter imports", async () => {
+    const src = `declare const process: {
+      stdout: {
+        write(chunk: Uint8Array | string): boolean;
+        once(event: string, cb: () => void): void;
+      };
+    };
+
+    export function main(): void {
+      if (!process.stdout.write(new Uint8Array([65]))) {
+        process.stdout.once("drain", () => {
+          process.stdout.write(new Uint8Array([66]));
+        });
+      }
+    }`;
+
+    const result = await compile(src, { fileName: "issue-1766.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(result.wat).not.toContain("__extern_method_call");
+    expect(result.wat).not.toContain("__extern_get_method");
+    expect(Array.from(runWasiCaptureFd(result.binary, 1))).toEqual([65]);
+  });
+
+  it("returns true from string writes too", async () => {
+    const src = `declare const process: {
+      stdout: { write(chunk: Uint8Array | string): boolean };
+    };
+
+    export function main(): void {
+      if (process.stdout.write("A")) {
+        process.stdout.write("B");
+      }
+    }`;
+
+    const result = await compile(src, { fileName: "issue-1766-string.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(new TextDecoder().decode(runWasiCaptureFd(result.binary, 1))).toBe("AB");
+  });
+});


### PR DESCRIPTION
## Summary

- Return `true` from the synchronous WASI lowering for `process.stdout.write(...)` and `process.stderr.write(...)`.
- Accept `process.stdout.once("drain", cb)` / `process.stderr.once("drain", cb)` as a no-op compatibility path under WASI, avoiding generic EventEmitter host imports.
- Add focused regression coverage for the Node-style backpressure guard and string-write truthiness.
- Declare the missing `needPages` local in the ArrayBuffer write helper, which the adjacent write regression suite exercises.

## Why

Issue #1766 is blocked for full async/EventEmitter stream semantics, but WASI `fd_write` is synchronous today. Returning `true` and accepting the unreachable `once("drain")` branch lets idiomatic Node backpressure guards compile without requiring full stream/event support.

## Validation

- `pnpm exec vitest run tests/issue-1766.test.ts tests/issue-1618-1651-wasi-stdout.test.ts tests/issue-1655-wasi-arraybuffer-write.test.ts`
- Pre-push hook: typecheck, lint, format check, issue integrity

Full async/EventEmitter semantics remain tracked separately by #1766/#1042/#1326/#1575.