### PR TITLE
docs(wasi): track Preview 3 stream semantics (#1774)

### DIFF
--- a/plan/issues/1774-wasi-preview3-async-stream-semantics.md
+++ b/plan/issues/1774-wasi-preview3-async-stream-semantics.md
@@ -1,0 +1,71 @@
+---
+id: 1774
+title: "wasi preview3 async stream semantics for Node stdout/stderr"
+status: ready
+created: 2026-06-01
+updated: 2026-06-01
+priority: medium
+feasibility: hard
+reasoning_effort: high
+es_edition: n/a
+language_feature: wasi
+task_type: architecture
+area: wasi
+goal: platform
+related: [389, 1651, 1484]
+depends_on: [1042, 1326, 1575]
+sprint: 58
+origin: "Follow-up from guest271314's PR #1016 comment on fd_write synchrony wording."
+---
+
+# #1774 - wasi preview3 async stream semantics for Node stdout/stderr
+
+## Problem
+
+#1766 landed a narrow compatibility shim for `process.stdout.write(...)` /
+`process.stderr.write(...)` under the current `wasi_snapshot_preview1` target.
+That path emits a direct `fd_write` host call, returns `true`, and accepts
+`once("drain", cb)` without modeling Node's EventEmitter or backpressure
+semantics.
+
+The implementation comment must not imply that the WASI Preview 1 specification
+mandates synchronous stream semantics for `fd_write` or `fd_read`. The current
+compiler behavior is an implementation shape of this target, not a general WASI
+statement. Full stream/backpressure support belongs with WASI 0.3 / Preview 3
+and the Component Model async ABI.
+
+## Current grounding
+
+- `--target wasi` currently imports from `wasi_snapshot_preview1` and lowers
+  stdout/stderr writes to direct `fd_write` calls.
+- WASI's public roadmap says 0.3 adds native async support to the Component
+  Model, including `stream<T>` and `future<T>` in function parameters and
+  results: https://wasi.dev/roadmap
+- The Component Model explainer marks async as outside the Preview 2 stability
+  milestone and part of a future gated feature set:
+  https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
+- The WASI I/O proposal is the right neighborhood for stream and pollable
+  behavior when mapping host I/O to component-model interfaces:
+  https://github.com/WebAssembly/wasi-io
+
+## Acceptance
+
+- Document the distinction between Preview-1-style direct host-call lowering
+  and spec-level async stream semantics.
+- Design how Node-compatible `Writable.write()` backpressure, `drain`, and
+  callback/error behavior can map to WASI 0.3 `stream<u8>` / `future` shapes.
+- Identify whether stdout/stderr should remain compile-away direct calls in
+  Preview 1 while a separate component-model backend handles async I/O.
+- Add tests or design fixtures that distinguish:
+  - current direct `fd_write` lowering with `write()` returning `true`;
+  - async backpressure/drain behavior when a WASI 0.3 stream backend exists;
+  - unsupported mixed-mode behavior with clear diagnostics.
+- Keep #1766's narrow shim intact until the compiler has a component-model
+  backend capable of expressing the async stream contract.
+
+## Notes
+
+This issue deliberately does not reopen #1766. #1766 is a pragmatic Preview 1
+compatibility fix. #1774 tracks the larger architecture needed to compile
+Node-style stream semantics onto the async component-model surface once the
+backend exists.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -135,6 +135,7 @@ fidelity → #1463) were NOT re-filed.
 - [#1769](../1769-generalize-nullable-primitive-unions.md) — Generalize nullable primitive union lowering and narrowing beyond the narrow `number | null` typed-array byte-write fix: sentinel-preserving representation plus reusable non-null flow proofs for arithmetic, calls, returns, and writes — medium, hard, **ready (sprint 58)**, follow-up to #1765
 - [#1767](../1767-native-messaging-64mib-memory-growth.md) — 64 MiB native-messaging stress run grows wasmtime memory toward OOM despite protocol-level chunking; opt-in stress harness added (from GitHub #389, 2026-06-01) — high, hard, **blocked (sprint 58)** on #1753
 - [#1768](../1768-allowjs-native-messaging-sendmessage-invalid-wasm.md) — Plain `.js` / allowJs native-messaging `sendMessage` compiles but emits invalid WASI wasm (`unknown global`, earlier `expected externref, found f64`) — high, medium, **DONE (sprint 58)**
+- [#1774](../1774-wasi-preview3-async-stream-semantics.md) — WASI 0.3 / Preview 3 async stream semantics for Node stdout/stderr: map `Writable.write()` backpressure, `drain`, callbacks, and errors onto component-model `stream<u8>` / `future` shapes when that backend exists (follow-up from PR #1016 comment, 2026-06-01) — medium, hard, **ready (sprint 58)**, depends on #1042/#1326/#1575
 
 ### String-hash warm perf — levers carved from #1746 umbrella (2026-05-31)
 

--- a/plan/issues/sprints/58.md
+++ b/plan/issues/sprints/58.md
@@ -45,6 +45,7 @@ native-messaging memory report, and allowJs sendMessage report below.
 | [#1769](../1769-generalize-nullable-primitive-unions.md) | generalize nullable primitive union lowering and narrowing | ready; follow-up to #1765 |
 | [#1767](../1767-native-messaging-64mib-memory-growth.md) | native-messaging 64 MiB run grows wasmtime memory toward OOM | blocked on #1753; stress harness done |
 | [#1768](../1768-allowjs-native-messaging-sendmessage-invalid-wasm.md) | allowJs native-messaging `sendMessage` emits invalid WASI wasm | done |
+| [#1774](../1774-wasi-preview3-async-stream-semantics.md) | WASI 0.3 / Preview 3 async stream semantics for Node stdout/stderr | ready; follow-up from PR #1016 comment |
 
 ## CI quality gate hardening
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1952,10 +1952,12 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (r) return r;
   }
 
-  // #1766: WASI fd_write is synchronous. Accept the Node stream backpressure
+  // #1766: In the current WASI Preview 1 lowering, process.std*.write()
+  // maps to a direct fd_write host call. Accept the Node stream backpressure
   // subscription shape so idiomatic `if (!stdout.write(...)) stdout.once("drain", cb)`
   // compiles without a JS-host EventEmitter import. Since write() returns true
-  // below, the drain callback is never needed on this path.
+  // below, the drain callback is never needed on this path. Track real WASI
+  // 0.3/Preview 3 async stream semantics separately in #1774.
   if (matchProcessStdStreamDrainOnce(ctx, fctx, expr)) {
     return VOID_RESULT;
   }


### PR DESCRIPTION
## Summary

- Clarifies the #1766 process.std*.write() drain shim comment so it describes the current wasi_snapshot_preview1 direct fd_write lowering, not a spec-level synchrony claim.
- Adds backlog/sprint tracking issue #1774 for WASI 0.3 / Preview 3 async stream semantics for Node stdout/stderr backpressure, drain, callbacks, and errors.
- Keeps generated website/public/graph-data.json out of this PR to avoid artifact churn while #1017 handles that separately.

## Validation

- pnpm run format:check
- pnpm run lint
- pnpm exec tsc --noEmit --pretty false --incremental false
- pnpm run check:issues
- git diff --check
- pre-push hook: typecheck + lint, format:check, issue integrity