### PR TITLE
docs(memory): isolate Esch teammate work

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -30,6 +30,7 @@
 - [feedback_architect_worktree_isolation.md](feedback_architect_worktree_isolation.md) — Always spawn architects with isolation:worktree — they stall and request respawn without it
 - [feedback_dev_limit.md](feedback_dev_limit.md) — Max 4 devs as teammates, test file naming, merge method
 - [feedback_dev_agents_worktree.md](feedback_dev_agents_worktree.md) — ALL writing agents must use worktree isolation
+- [feedback_esch_teammate_separate_worktree_branch.md](feedback_esch_teammate_separate_worktree_branch.md) — Keep Esch teammate work in its own dedicated worktree and branch
 - [feedback_serialize_cherry_picks.md](feedback_serialize_cherry_picks.md) — Wait for wave to finish, then batch merge (not cherry-pick)
 - [feedback_always_cd_workspace.md](feedback_always_cd_workspace.md) — Git safety: cd /workspace, verify main, never work from agent worktrees
 - [feedback_usage_limit.md](feedback_usage_limit.md) — Stop dispatching above 90% context usage

--- a/.claude/memory/feedback_esch_teammate_separate_worktree_branch.md
+++ b/.claude/memory/feedback_esch_teammate_separate_worktree_branch.md
@@ -1,0 +1,24 @@
+---
+name: Esch teammate worktree isolation
+description: Keep any Esch teammate work in its own dedicated worktree and branch; never mix it into Codex or other teammate branches.
+type: feedback
+---
+
+When working with or taking over work from the `esch` teammate, keep that work
+in a separate dedicated git worktree and branch.
+
+**How to apply:**
+
+- Create or use an `esch/...` or otherwise clearly named branch for Esch-owned
+  work.
+- Put the checkout in its own worktree under the current session's
+  `.codex/worktrees/` area.
+- Do not commit Esch changes on a Codex issue branch, the root checkout, or
+  another teammate's branch.
+- If Codex needs to build on Esch's work, open a separate Codex branch from the
+  correct base and merge/cherry-pick intentionally instead of editing Esch's
+  branch in place.
+
+**Why:** Esch teammate work must remain reviewable and attributable on its own
+branch. Mixing it into another session's branch makes diffs hard to audit and
+creates the same shared-worktree collision the user explicitly wants to avoid.


### PR DESCRIPTION
## Summary

- Adds repo memory that esch teammate work must stay in its own dedicated worktree and branch.
- Indexes that memory in .claude/memory/MEMORY.md under Team & agents.
- Calls out that Codex should not commit Esch work on Codex issue branches, the root checkout, or another teammate branch.

## Validation

- git diff --check
- pre-push hook: typecheck + lint, format:check, issue integrity