### PR TITLE
[codex] Add relocatable standalone CLI bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added: relocatable standalone CLI bundle (#1775, GH #986 follow-up)
+
+- Added `pnpm run build:standalone-cli`, which writes
+  `dist/js2wasm-standalone.mjs` for `deno compile` / `bun build --compile`
+  workflows. This build bundles the core compiler dependencies and injects
+  TypeScript's `lib.*.d.ts` files into the existing bundled-lib hook, so the
+  generated file does not need to stay next to `node_modules/typescript/lib`.
+- Standalone bundles now get the package version injected at build time, so
+  `--version` does not rely on `../package.json` after the file is moved.
+- Binaryen is now an optional peer/dev dependency and is no longer bundled into
+  the standalone CLI artifact; `-O` can use an installed `binaryen` package or a
+  `wasm-opt` binary on PATH, and the emitted `.wasm` can be optimized afterward.
+- The standalone docs now recommend `--minify`, which brings the no-Binaryen
+  bundle down to roughly 8.5 MB before native runtime embedding.
+
 ### Breaking: `compile()` API is now async (#1757)
 
 - The public compiler entry points — `compile`, `compileMulti`, `compileFiles`,

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Programmatic API:
 > **Breaking change (#1757):** `compile()` (and `compileMulti`, `compileFiles`,
 > `compileToWat`, `compileProject`, `createIncrementalCompiler().compile`) now
 > return a `Promise` — `await` them. This lets the optional Binaryen optimizer
-> load via `await import("binaryen")`, so it can be embedded in a
-> `bun build --compile` / `deno compile` standalone binary (GH #986).
+> load lazily only when `optimize` is requested, without forcing standalone
+> bundles to embed Binaryen (GH #986).
 
 ```ts
 import { compile } from "js2wasm";
@@ -167,6 +167,25 @@ if (result.success) {
   console.log((instance.exports as any).add(2, 3)); // → 5
 }
 ```
+
+Standalone CLI bundle:
+
+```bash
+pnpm run build:standalone-cli -- --minify
+deno compile -A --no-check -o js2wasm dist/js2wasm-standalone.mjs
+# or:
+bun build --compile --target=node --outfile js2wasm dist/js2wasm-standalone.mjs
+```
+
+`build:standalone-cli` creates a relocatable `dist/js2wasm-standalone.mjs`
+bundle for native-executable workflows. Unlike the normal npm library build, it
+bundles the core compiler dependencies and embeds TypeScript's `lib.*.d.ts`
+declarations, so the generated file does not need to remain next to
+`node_modules/typescript/lib` after it is moved or compiled. The `--ts7`
+preview backend and Binaryen optimizer remain development/optimization opt-ins
+and are not bundled into this standalone artifact. If you use `-O` with the
+standalone CLI, install `binaryen` next to the runner or put `wasm-opt` on PATH;
+you can also run `wasm-opt` directly on the emitted `.wasm` afterward.
 
 ### Compile modes and imports
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,22 @@
   "engines": {
     "node": ">=20"
   },
+  "peerDependencies": {
+    "binaryen": "^125.0.0",
+    "bun": ">=1.3.14",
+    "deno": ">=2.8.1"
+  },
+  "peerDependenciesMeta": {
+    "binaryen": {
+      "optional": true
+    },
+    "bun": {
+      "optional": true
+    },
+    "deno": {
+      "optional": true
+    }
+  },
   "scripts": {
     "new:issue-id": "node scripts/next-issue-id.mjs",
     "build": "vite build --config vite.config.lib.ts",
@@ -81,6 +97,7 @@
     "refresh:benchmarks:no-jit": "pnpm run build:compiler-bundle && node scripts/generate-playground-benchmark-sidebar-no-jit.mjs",
     "refresh:benchmarks:wasmtime": "pnpm run build:compiler-bundle && node scripts/generate-wasmtime-hot-runtime.mjs",
     "build:compiler-bundle": "esbuild scripts/compiler-bundle-entry.ts --bundle --platform=node --format=esm --outfile=scripts/compiler-bundle.mjs --external:typescript --external:binaryen --external:@typescript/native-preview --external:@typescript/native-preview/*",
+    "build:standalone-cli": "node scripts/build-standalone-cli.mjs",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts' 'scripts/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts' 'scripts/**/*.ts'",
     "lint": "biome lint --diagnostic-level=error",
@@ -102,7 +119,6 @@
     "reconcile:tasks": "node scripts/reconcile-tasklist.mjs"
   },
   "dependencies": {
-    "binaryen": "^125.0.0",
     "typescript": "^5.7"
   },
   "devDependencies": {
@@ -113,6 +129,9 @@
     "@types/node": "^22",
     "@typescript/native-preview": "^7.0.0-dev.20260502.1",
     "axios": "^1.16.1",
+    "binaryen": "^125.0.0",
+    "bun": "1.3.14",
+    "deno": "2.8.1",
     "esbuild": "^0.25.12",
     "eslint": "^10.0.3",
     "hono": "^4.12.16",

--- a/plan/issues/1775-standalone-cli-bundle-embeds-ts-libs.md
+++ b/plan/issues/1775-standalone-cli-bundle-embeds-ts-libs.md
@@ -1,0 +1,68 @@
+---
+id: 1775
+title: "standalone CLI bundle embeds TypeScript lib declarations"
+status: done
+created: 2026-06-01
+updated: 2026-06-01
+completed: 2026-06-01
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: infrastructure
+area: tooling
+language_feature: packaging
+goal: platform
+sprint: 58
+es_edition: n/a
+related: [986, 1757, 1763]
+origin: "Follow-up from GitHub #986 comments about moved Bun/Deno standalone bundles looking for node_modules/typescript/lib."
+---
+
+# #1775 - standalone CLI bundle embeds TypeScript lib declarations
+
+## Problem
+
+GH #986's original `require("binaryen")` bundling failure is fixed by the async
+optimizer path (#1757/#1763), but the standalone executable flow still has a
+second portability gap: TypeScript lib declarations are read from
+`node_modules/typescript/lib` at runtime unless the embedding environment
+preloads them.
+
+That means a single-file `js2wasm.js` bundle can compile while it remains next
+to `node_modules`, then fail or degrade after it is moved to another filesystem
+or compiled with `deno compile`.
+
+## Scope
+
+- Provide a supported CLI bundle build command for relocatable executable
+  workflows.
+- Inject the TypeScript `lib.*.d.ts` files into the generated bundle at build
+  time using the existing `__js2wasmTsLibFiles` hook.
+- Avoid relying on `package.json` at runtime for `--version` in the generated
+  bundle.
+- Keep the normal npm library build unchanged for TypeScript, while treating
+  Binaryen as an optional optimizer dependency instead of a required compiler
+  dependency.
+
+## Acceptance
+
+- `pnpm run build:standalone-cli` writes `dist/js2wasm-standalone.mjs`.
+- The generated bundle preloads TypeScript lib declaration text and can be
+  moved away from `node_modules`.
+- `--version` in that bundle uses an injected package version rather than
+  `createRequire("../package.json")`.
+- Regression coverage checks both lib-file prelude generation and the public
+  `preloadLibFiles()` path under a no-filesystem environment.
+
+## Implementation notes
+
+- Added `scripts/build-standalone-cli.mjs`, an esbuild-based bundle path that
+  discovers all installed `typescript/lib/lib.*.d.ts` files and injects them
+  into `globalThis.__js2wasmTsLibFiles` through esbuild's banner.
+- Added `preloadLibFiles()` as a public API and cache invalidation hook for
+  embedders that want to provide lib declaration text explicitly.
+- Added `__JS2WASM_CLI_VERSION__` compile-time injection support so standalone
+  bundles do not need `package.json` at runtime.
+- Marked Binaryen as an optional peer/dev dependency and kept it out of the
+  standalone bundle; `-O` can still use an installed `binaryen` package or a
+  `wasm-opt` binary on PATH.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      binaryen:
-        specifier: ^125.0.0
-        version: 125.0.0
       typescript:
         specifier: ^5.7
         version: 5.9.3
@@ -36,6 +33,15 @@ importers:
       axios:
         specifier: ^1.16.1
         version: 1.16.1
+      binaryen:
+        specifier: ^125.0.0
+        version: 125.0.0
+      bun:
+        specifier: 1.3.14
+        version: 1.3.14
+      deno:
+        specifier: 2.8.1
+        version: 2.8.1
       esbuild:
         specifier: ^0.25.12
         version: 0.25.12
@@ -223,6 +229,38 @@ packages:
     resolution: {integrity: sha512-ziWmovyu1jQl9TsKlfC2bwuUZwxVPFHlX4fOqTzxhgS76jITIo45nzODEwPgU+jjmOr8F3YX2V2wAChC5NKujg==}
     engines: {node: '>=16'}
     hasBin: true
+
+  '@deno/darwin-arm64@2.8.1':
+    resolution: {integrity: sha512-p6fzxeWjH+oXJzvGPXtkCxZ6xXJCXrUpXCOagWfMmZT653AlNNQuQTZ4XIDKW8IhIxzhy56nyKnXuHlR+osQJQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@deno/darwin-x64@2.8.1':
+    resolution: {integrity: sha512-xnoFzMk5GOafiCQFUT+78UlKVPDEKKgm2mBsvyJ7S51ZvkMWsAPzgRm1WN42NGzohG0DwOipyXamqT9KVjUt0A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@deno/linux-arm64-glibc@2.8.1':
+    resolution: {integrity: sha512-yqp2hCQQUnhZW9idEBAtqwo/hugQV73fk01mOGYNJUKRDiI03nmNQJgf4tOb9nhzefWXQC9MotBkTYkXzbvzEw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@deno/linux-x64-glibc@2.8.1':
+    resolution: {integrity: sha512-Ll7SBJaQhMbFISt3Rl9uZD0uV/6sOly8VbMTDFDrD1irp+OU7iVfBUjDa0WoUGzbnj8nT7+eKbgSmpN5RNTTCA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@deno/win32-arm64@2.8.1':
+    resolution: {integrity: sha512-y7VePzD+seIyWYFQW3HtXEw7Fwphe5ldAssjNilYf1RaOHEx+fQcZskXi+RsusHfS8aDANQQK//4F0qLQpGj5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@deno/win32-x64@2.8.1':
+    resolution: {integrity: sha512-Ru22HMSjqttCOXW+7+LG39h45Z1t828E0EgovCIoqlFJSx7zSDSL3N7iz+VBuFd0cr60hPSnbcoWlTKMaHFwEA==}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -584,6 +622,86 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@oven/bun-darwin-aarch64@1.3.14':
+    resolution: {integrity: sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64@1.3.14':
+    resolution: {integrity: sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-freebsd-aarch64@1.3.14':
+    resolution: {integrity: sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@oven/bun-freebsd-x64@1.3.14':
+    resolution: {integrity: sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oven/bun-linux-aarch64-android@1.3.14':
+    resolution: {integrity: sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oven/bun-linux-aarch64-musl@1.3.14':
+    resolution: {integrity: sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-aarch64@1.3.14':
+    resolution: {integrity: sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-android@1.3.14':
+    resolution: {integrity: sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg==}
+    cpu: [x64]
+    os: [android]
+
+  '@oven/bun-linux-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.14':
+    resolution: {integrity: sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl@1.3.14':
+    resolution: {integrity: sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64@1.3.14':
+    resolution: {integrity: sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-windows-aarch64@1.3.14':
+    resolution: {integrity: sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oven/bun-windows-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oven/bun-windows-x64@1.3.14':
+    resolution: {integrity: sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-parser/binding-android-arm64@0.76.0':
     resolution: {integrity: sha512-1XJW/16CDmF5bHE7LAyPPmEEVnxSadDgdJz+xiLqBrmC4lfAeuAfRw3HlOygcPGr+AJsbD4Z5sFJMkwjbSZlQg==}
@@ -1158,6 +1276,12 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bun@1.3.14:
+    resolution: {integrity: sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, android, freebsd, win32]
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1289,6 +1413,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  deno@2.8.1:
+    resolution: {integrity: sha512-aj6iZAldzpqhcSmtRnvloD6EAcMJuH3egQyiWYYDJM31sawryI+/Lc1STaZDd2I1JOapdMfUz5bsmpiS+m45PQ==}
+    hasBin: true
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2429,6 +2557,24 @@ snapshots:
       '@bytecodealliance/wizer-linux-x64': 10.0.0
       '@bytecodealliance/wizer-win32-x64': 10.0.0
 
+  '@deno/darwin-arm64@2.8.1':
+    optional: true
+
+  '@deno/darwin-x64@2.8.1':
+    optional: true
+
+  '@deno/linux-arm64-glibc@2.8.1':
+    optional: true
+
+  '@deno/linux-x64-glibc@2.8.1':
+    optional: true
+
+  '@deno/win32-arm64@2.8.1':
+    optional: true
+
+  '@deno/win32-x64@2.8.1':
+    optional: true
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2710,6 +2856,54 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oven/bun-darwin-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-darwin-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-darwin-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-freebsd-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-freebsd-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64-android@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64-musl@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-android@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-musl@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-x64@1.3.14':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.76.0':
@@ -3199,6 +3393,25 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bun@1.3.14:
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.14
+      '@oven/bun-darwin-x64': 1.3.14
+      '@oven/bun-darwin-x64-baseline': 1.3.14
+      '@oven/bun-freebsd-aarch64': 1.3.14
+      '@oven/bun-freebsd-x64': 1.3.14
+      '@oven/bun-linux-aarch64': 1.3.14
+      '@oven/bun-linux-aarch64-android': 1.3.14
+      '@oven/bun-linux-aarch64-musl': 1.3.14
+      '@oven/bun-linux-x64': 1.3.14
+      '@oven/bun-linux-x64-android': 1.3.14
+      '@oven/bun-linux-x64-baseline': 1.3.14
+      '@oven/bun-linux-x64-musl': 1.3.14
+      '@oven/bun-linux-x64-musl-baseline': 1.3.14
+      '@oven/bun-windows-aarch64': 1.3.14
+      '@oven/bun-windows-x64': 1.3.14
+      '@oven/bun-windows-x64-baseline': 1.3.14
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3330,6 +3543,15 @@ snapshots:
       gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
+
+  deno@2.8.1:
+    optionalDependencies:
+      '@deno/darwin-arm64': 2.8.1
+      '@deno/darwin-x64': 2.8.1
+      '@deno/linux-arm64-glibc': 2.8.1
+      '@deno/linux-x64-glibc': 2.8.1
+      '@deno/win32-arm64': 2.8.1
+      '@deno/win32-x64': 2.8.1
 
   dequal@2.0.3: {}
 

--- a/scripts/build-standalone-cli.mjs
+++ b/scripts/build-standalone-cli.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Build a relocatable single-file CLI bundle for Bun/Deno/native executable flows.
+// The normal library build keeps TypeScript external for npm usage.
+// This build intentionally bundles TypeScript and injects TypeScript lib
+// declarations so the resulting file can be moved away from node_modules.
+// Binaryen remains optional because it is only used for wasm-opt post-processing.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..");
+const DEFAULT_OUTFILE = "dist/js2wasm-standalone.mjs";
+
+export function discoverTypeScriptLibNames(libDir = resolveTypeScriptLibDir()) {
+  return readdirSync(libDir)
+    .filter((name) => /^lib\..*\.d\.ts$/.test(name))
+    .sort();
+}
+
+export function resolveTypeScriptLibDir(root = ROOT) {
+  const require = createRequire(pathToFileURL(resolve(root, "package.json")));
+  return dirname(require.resolve("typescript/lib/lib.d.ts"));
+}
+
+export function readTypeScriptLibFiles({
+  libDir = resolveTypeScriptLibDir(),
+  names = discoverTypeScriptLibNames(libDir),
+} = {}) {
+  const files = {};
+  for (const name of names) {
+    const path = resolve(libDir, name);
+    if (!existsSync(path)) {
+      throw new Error(`TypeScript lib file not found: ${path}`);
+    }
+    files[name] = readFileSync(path, "utf8");
+  }
+  return files;
+}
+
+export function createTsLibGlobalPrelude(options = {}) {
+  const files = readTypeScriptLibFiles(options);
+  return [
+    'import { createRequire as __js2wasmCreateRequire } from "node:module";',
+    'import { dirname as __js2wasmDirname } from "node:path";',
+    'import { fileURLToPath as __js2wasmFileURLToPath } from "node:url";',
+    "const require = __js2wasmCreateRequire(import.meta.url);",
+    "const __filename = __js2wasmFileURLToPath(import.meta.url);",
+    "const __dirname = __js2wasmDirname(__filename);",
+    "globalThis.__js2wasmTsLibFiles = {",
+    "  ...(globalThis.__js2wasmTsLibFiles ?? globalThis.__ts2wasmTsLibFiles ?? {}),",
+    `  ...${JSON.stringify(files)},`,
+    "};",
+    "",
+  ].join("\n");
+}
+
+function readPackageJson(root = ROOT) {
+  return JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+}
+
+export async function buildStandaloneCli({
+  root = ROOT,
+  outfile = DEFAULT_OUTFILE,
+  minify = false,
+  sourcemap = false,
+} = {}) {
+  const esbuild = await import("esbuild");
+  const packageJson = readPackageJson(root);
+  const outPath = resolve(root, outfile);
+  mkdirSync(dirname(outPath), { recursive: true });
+
+  await esbuild.build({
+    absWorkingDir: root,
+    entryPoints: ["src/cli.ts"],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node20",
+    outfile: outPath,
+    minify,
+    sourcemap,
+    legalComments: "none",
+    mainFields: ["module", "main"],
+    banner: {
+      js: createTsLibGlobalPrelude({ libDir: resolveTypeScriptLibDir(root) }),
+    },
+    define: {
+      __JS2WASM_CLI_VERSION__: JSON.stringify(packageJson.version),
+    },
+    external: ["binaryen", "@typescript/native-preview", "@typescript/native-preview/*"],
+    logLevel: "info",
+  });
+
+  console.log(`Standalone CLI bundle written to ${relative(root, outPath)}`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    outfile: DEFAULT_OUTFILE,
+    minify: false,
+    sourcemap: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--outfile" || arg === "-o") {
+      const value = argv[++i];
+      if (!value) throw new Error(`${arg} requires a path`);
+      options.outfile = value;
+    } else if (arg.startsWith("--outfile=")) {
+      options.outfile = arg.slice("--outfile=".length);
+    } else if (arg === "--minify") {
+      options.minify = true;
+    } else if (arg === "--sourcemap") {
+      options.sourcemap = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm run build:standalone-cli -- [options]
+
+Build a relocatable js2wasm CLI bundle at ${DEFAULT_OUTFILE}.
+
+Options:
+  -o, --outfile <path>  Output bundle path (default: ${DEFAULT_OUTFILE})
+  --minify             Minify the generated JavaScript
+  --sourcemap          Emit a source map
+  -h, --help           Show this help`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+    } else {
+      await buildStandaloneCli(options);
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -9,11 +9,38 @@ import { getDefaultEnvironment } from "../env.js";
 // which lets embedders import the checker without forcing the whole module
 // graph through async initialization.
 
+type TsLibGlobal = {
+  __js2wasmTsLibFiles?: Record<string, string>;
+  __ts2wasmTsLibFiles?: Record<string, string>;
+};
+
 function getBundledLibFiles(): Record<string, string> | undefined {
-  const files =
-    (globalThis as { __js2wasmTsLibFiles?: unknown; __ts2wasmTsLibFiles?: unknown }).__js2wasmTsLibFiles ??
-    (globalThis as { __ts2wasmTsLibFiles?: unknown }).__ts2wasmTsLibFiles;
+  const globalObject = globalThis as TsLibGlobal;
+  const files = globalObject.__js2wasmTsLibFiles ?? globalObject.__ts2wasmTsLibFiles;
   return files && typeof files === "object" ? (files as Record<string, string>) : undefined;
+}
+
+export function preloadLibFiles(files: Record<string, string>): void {
+  const globalObject = globalThis as TsLibGlobal;
+  globalObject.__js2wasmTsLibFiles = {
+    ...(globalObject.__js2wasmTsLibFiles ?? globalObject.__ts2wasmTsLibFiles ?? {}),
+    ...files,
+  };
+
+  for (const name of Object.keys(files)) {
+    Reflect.deleteProperty(LIB_FILES, name);
+    for (const key of Array.from(LIB_SOURCE_FILES.keys())) {
+      if (key.startsWith(`${name}:`)) {
+        LIB_SOURCE_FILES.delete(key);
+      }
+    }
+  }
+  Reflect.deleteProperty(LIB_FILES, "lib.d.ts");
+  for (const key of Array.from(LIB_SOURCE_FILES.keys())) {
+    if (key.startsWith("lib.d.ts:")) {
+      LIB_SOURCE_FILES.delete(key);
+    }
+  }
 }
 
 function getPath() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,16 @@ import { createRequire } from "node:module";
 import { readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 
+declare const __JS2WASM_CLI_VERSION__: string | undefined;
+
+function getCliVersion(): string {
+  const bundledVersion = typeof __JS2WASM_CLI_VERSION__ === "string" ? __JS2WASM_CLI_VERSION__ : undefined;
+  if (bundledVersion) return bundledVersion;
+  const require = createRequire(import.meta.url);
+  const pkg = require("../package.json") as { version?: string };
+  return pkg.version ?? "0.0.0";
+}
+
 const args = process.argv.slice(2);
 
 // `--ts7` swaps the parser/checker frontend to `@typescript/native-preview`
@@ -18,9 +28,7 @@ const { compile } = await import("./index.js");
 const { buildDefaultDefines } = await import("./compiler/define-substitution.js");
 
 if (args.includes("--version") || args.includes("-v")) {
-  const require = createRequire(import.meta.url);
-  const pkg = require("../package.json");
-  console.log(pkg.version);
+  console.log(getCliVersion());
   process.exit(0);
 }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -259,9 +259,9 @@ function detectNodeFsImports(source: string): Set<string> {
  * Orchestrates the full compilation pipeline:
  * TS Source → tsc Parser+Checker → Codegen → Binary + WAT
  *
- * Async because the optional Binaryen optimizer is lazy-loaded via
- * `await import("binaryen")` (#1757 / GH #986) so it can be embedded in a
- * `bun build --compile` / `deno compile` standalone binary.
+ * Async because the optional Binaryen optimizer is lazy-loaded only when
+ * wasm-opt is requested (#1757 / GH #986), so normal compilation and
+ * standalone bundles do not need to embed Binaryen.
  */
 export async function compileSource(
   source: string,
@@ -655,8 +655,8 @@ export function compileSourceSync(
   }
 
   // Step 3b: Optimize binary with Binaryen (optional) — applied by the async
-  // compileSource wrapper, not here (the optimizer is lazy-loaded via
-  // `await import("binaryen")`, #1757). This synchronous core ignores
+  // compileSource wrapper, not here (the optimizer is lazy-loaded only when
+  // wasm-opt is requested, #1757). This synchronous core ignores
   // options.optimize.
 
   // Step 4: Emit WAT (optional)

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,6 +418,7 @@ export function createIncrementalCompiler(defaultOptions?: CompileOptions): {
 }
 
 export { getBarePackageName, ModuleResolver, resolveAllImports } from "./resolve.js";
+export { preloadLibFiles } from "./checker/index.js";
 export { getEntryExportNames, treeshake } from "./treeshake.js";
 export { generateWit } from "./wit-generator.js";
 export type { WitGeneratorOptions } from "./wit-generator.js";

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -3,7 +3,7 @@
  * Post-processing pass using Binaryen's wasm-opt optimizer.
  *
  * Tries two strategies in order:
- * 1. The `binaryen` npm package (if installed as an optional dependency)
+ * 1. The `binaryen` npm package (if installed as an optional peer dependency)
  * 2. A system `wasm-opt` binary on PATH
  *
  * If neither is available, returns the original binary unchanged and emits a warning.
@@ -141,10 +141,10 @@ function isBrowserLikeRuntime(): boolean {
  * migration every live caller goes through this async path, and the sync
  * variant only kept alive a dead `createRequire("binaryen")` branch — the
  * exact bundler hazard #986/#1756 set out to remove. The `binaryen` package
- * is loaded via `await import("binaryen")` (see `getBinaryenModule`), which
- * is the import form bundlers can legitimately follow for standalone
- * embedding; the system `wasm-opt` CLI fallback still uses the dynamic
- * node-builtin shim that bundlers intentionally cannot statically resolve.
+ * is loaded lazily at runtime (see `getBinaryenModule`) without making
+ * bundlers embed it in standalone artifacts; the system `wasm-opt` CLI
+ * fallback still uses the dynamic node-builtin shim that bundlers
+ * intentionally cannot statically resolve.
  */
 export async function optimizeBinaryAsync(binary: Uint8Array, options: OptimizeOptions = {}): Promise<OptimizeResult> {
   const level = options.level ?? 3;
@@ -198,7 +198,11 @@ async function getBinaryenModule(): Promise<any | null> {
     }
 
     try {
-      const mod = await import("binaryen");
+      // Keep Binaryen optional. A string-literal dynamic import makes esbuild,
+      // Bun, and Deno treat the package as a bundle input, adding ~13.5 MB to
+      // standalone artifacts even though wasm-opt is only a post-compile pass.
+      const specifier = (globalObject.__js2wasmBinaryenModuleSpecifier as string | undefined) ?? "binaryen";
+      const mod = await import(/* @vite-ignore */ specifier);
       return mod.default ?? mod;
     } catch {
       return null;

--- a/tests/issue-1775-standalone-cli-bundle.test.ts
+++ b/tests/issue-1775-standalone-cli-bundle.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getLibSourceFile } from "../src/checker/index.js";
+import { setDefaultEnvironment, type Environment } from "../src/env.js";
+import { preloadLibFiles } from "../src/index.js";
+import { ts } from "../src/ts-api.js";
+import {
+  createTsLibGlobalPrelude,
+  discoverTypeScriptLibNames,
+  readTypeScriptLibFiles,
+} from "../scripts/build-standalone-cli.mjs";
+
+const NO_NODE_ENV: Environment = { fs: null, path: null, url: null, module: null };
+
+describe("#1775 standalone CLI bundle support", () => {
+  afterEach(() => {
+    setDefaultEnvironment(null);
+  });
+
+  it("discovers and serializes TypeScript lib files for the standalone prelude", () => {
+    const dir = mkdtempSync(join(tmpdir(), "js2-standalone-libs-"));
+    try {
+      writeFileSync(join(dir, "lib.es5.d.ts"), "interface Number {}\n");
+      writeFileSync(join(dir, "lib.dom.d.ts"), "interface Document {}\n");
+      writeFileSync(join(dir, "README.txt"), "ignored\n");
+
+      const names = discoverTypeScriptLibNames(dir);
+      expect(names).toEqual(["lib.dom.d.ts", "lib.es5.d.ts"]);
+
+      const files = readTypeScriptLibFiles({ libDir: dir, names });
+      expect(files["lib.es5.d.ts"]).toContain("interface Number");
+      expect(files["lib.dom.d.ts"]).toContain("interface Document");
+
+      const prelude = createTsLibGlobalPrelude({ libDir: dir, names });
+      expect(prelude).toContain("createRequire");
+      expect(prelude).toContain("__filename");
+      expect(prelude).toContain("__dirname");
+      expect(prelude).toContain("__js2wasmTsLibFiles");
+      expect(prelude).toContain("lib.es5.d.ts");
+      expect(prelude).toContain("interface Document");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preloadLibFiles feeds the checker without filesystem or module resolution", () => {
+    setDefaultEnvironment(NO_NODE_ENV);
+    const libName = "lib.js2wasm-standalone-test.d.ts";
+    const source = "interface StandaloneBundleSentinel { value: string; }\n";
+
+    preloadLibFiles({ [libName]: source });
+
+    const sourceFile = getLibSourceFile(libName, ts.ScriptTarget.ES2022);
+    expect(sourceFile?.text).toBe(source);
+  });
+});


### PR DESCRIPTION
## Summary
- add an esbuild-based `build:standalone-cli` path that embeds TypeScript lib declarations and injects the CLI version, so the generated CLI bundle can run away from `node_modules`
- make `binaryen` an optional optimizer peer/dev dependency instead of bundling it into the standalone artifact; `-O` can still use installed `binaryen` or `wasm-opt` on `PATH`
- add docs, changelog notes, and regression coverage for TypeScript lib preloading

## Size notes
- minified no-Binaryen standalone JS bundle: 8,906,501 bytes raw, 1,873,371 bytes gzip, 1,348,357 bytes brotli
- Bun native executable from that bundle: 74,410,082 bytes
- Deno native executable from that bundle: 84,049,618 bytes
- playground comparison after `pnpm run build:playground`: TypeScript chunk is 5,921,076 bytes raw / 1,340,204 gzip, playground chunk is 2,133,278 bytes raw / 425,730 gzip

## Validation
- `pnpm exec biome lint --diagnostic-level=error --no-errors-on-unmatched src/checker/index.ts src/cli.ts src/compiler.ts src/index.ts src/optimize.ts scripts/build-standalone-cli.mjs tests/issue-1775-standalone-cli-bundle.test.ts`
- `node node_modules/vitest/dist/cli.js run tests/issue-1775-standalone-cli-bundle.test.ts tests/wasm-opt-optimize.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run build:playground`
- `pnpm run build:standalone-cli -- --minify --outfile /private/tmp/js2wasm-standalone-doc-command.mjs`
- Bun/Deno native version and smoke compile checks

Refs #986.
Plan: `plan/issues/1775-standalone-cli-bundle-embeds-ts-libs.md`