### PR TITLE
feat(regexp): scaffold standalone native engine ABI

### DIFF
--- a/plan/issues/682-regexp-standalone-mode-native-engine.md
+++ b/plan/issues/682-regexp-standalone-mode-native-engine.md
@@ -1,18 +1,31 @@
 ---
 id: 682
 title: "RegExp standalone mode: native engine or embedded library for non-JS targets"
-status: ready
+status: in-progress
+owner: Raman
 created: 2026-03-20
-updated: 2026-04-28
+updated: 2026-06-01
 priority: medium
 feasibility: hard
 reasoning_effort: max
 goal: standalone-mode
-sprint: Backlog
+sprint: 58
 files:
   src/codegen/expressions.ts:
     new:
       - "standalone-mode RegExp lowering to a native engine or embedded regexp backend"
+  src/codegen/regexp-standalone.ts:
+    new:
+      - "typed native standalone RegExp ABI scaffold and engine availability hook"
+  src/codegen/context/types.ts:
+    new:
+      - "nullable CodegenContext.standaloneRegExpEngine hook"
+  src/codegen/context/create-context.ts:
+    new:
+      - "initialize standaloneRegExpEngine to null while #1474 gate remains closed"
+  tests/issue-682-regexp-standalone-abi.test.ts:
+    new:
+      - "pins closed gate and non-JS-host ABI shape"
 ---
 # #682 — RegExp standalone mode: native engine or embedded library for non-JS targets
 
@@ -28,6 +41,17 @@ completion work is tracked separately in `#1002`.
 
 In standalone mode (wasmtime/WASI/native strings), there is no JS `RegExp`
 object to delegate to. We need an embedded regex backend.
+
+## Evidence: real standalone test262 run 2026-06-01
+
+Artifacts:
+`benchmarks/results/test262-standalone-report-20260601-213702.json` and
+`benchmarks/results/test262-standalone-results-20260601-213702.jsonl`.
+
+Standalone result: 4,368 / 43,106 passing (10.1%) versus the canonical JS-host
+baseline of 30,480 / 43,106 (70.7%). RegExp unsupported appears in 1,882
+non-exclusive failures, confirming that a native RegExp backend is now a
+material standalone test262 root cause rather than only a portability gap.
 
 ## Goal
 
@@ -135,6 +159,36 @@ standalone subset.
 starting with **QuickJS libregexp** (option 5) extracted as a C
 file compiled to wasm via wasi-sdk; QuickJS libregexp is the only
 candidate with explicit JS-spec semantics.)
+
+### Implementation note — 2026-06-01 first mergeable slice
+
+Added an implementation-neutral scaffold in `src/codegen/regexp-standalone.ts`
+and threaded `CodegenContext.standaloneRegExpEngine` as a nullable hook
+initialized to `null`. This deliberately keeps #1474's standalone refusal gate
+closed while establishing the future native-engine contract:
+
+- selected engine kind: `quickjs-libregexp`
+- ABI version: `1`
+- in-module native symbols only, not JS-host imports:
+  `__re_compile`, `__re_exec`, `__re_free`, `__re_group_start`,
+  `__re_group_end`
+- pointer/handle ABI shape pinned as `i32` values for the first slice
+
+The scaffold does not implement RegExp semantics yet and does not alter the
+current `RegExp` constructor, literal, or `String.prototype` RegExp-argument
+refusals. Next slice can link/register the embedded engine and then open the
+#1474 gate by querying `hasStandaloneRegExpEngine(...)`.
+
+Validation for this slice:
+
+- `pnpm exec prettier --write src/codegen/regexp-standalone.ts src/codegen/context/types.ts src/codegen/context/create-context.ts tests/issue-682-regexp-standalone-abi.test.ts`
+  - result: passed
+- `pnpm run typecheck`
+  - result: passed
+- `pnpm exec vitest run tests/issue-682-regexp-standalone-abi.test.ts tests/issue-1474-standalone-regex-refuse.test.ts`
+  - result: passed, 2 files / 18 tests
+
+Full test262 was not run; this was intentionally limited to scoped checks.
 
 ### Phase 0 — Decision and ABI
 

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -160,6 +160,9 @@ export function createCodegenContext(
     funcClosureGlobals: new Map(),
     wasi: options?.wasi ?? false,
     standalone: options?.standalone ?? false,
+    // #682 — native standalone RegExp engine hook. Keep closed until the
+    // embedded engine is linked; #1474 owns today's refusal diagnostics.
+    standaloneRegExpEngine: null,
     // (#1373b Slice 1) Scaffolding only — hardcoded false. Future slices
     // expose a CLI/option flag once the CPS lowering is parity-tested.
     supportsAsyncIr: false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -8,6 +8,7 @@
  */
 import { ts } from "../../ts-api.js";
 import type { FieldDef, Instr, LocalDef, SourcePos, ValType, WasmModule } from "../../ir/types.js";
+import type { StandaloneRegExpEngineConfig } from "../regexp-standalone.js";
 
 export interface CodegenError {
   message: string;
@@ -806,6 +807,9 @@ export interface CodegenContext {
    *  compile-error so a single source construct emits at most one error per
    *  import name. Lazily initialized in late-imports.ts. */
   standaloneRefusedImports?: Set<string>;
+  /** (#682) Native standalone RegExp engine hook. Null until the embedded
+   *  engine/link step lands; #1474 keeps owning the current refusal gate. */
+  standaloneRegExpEngine: StandaloneRegExpEngineConfig | null;
   /**
    * (#1373b) When true, async functions flow through the IR's CPS lowering
    * (Phase C). When false (default), the IR selector buckets async functions

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #682 — Standalone RegExp native-engine ABI scaffold.
+ *
+ * This file intentionally does not lower RegExp semantics yet. #1474 owns the
+ * current standalone refusal gate; this module gives the future native engine
+ * slice a typed, non-JS-host contract to plug into when an embedded backend is
+ * linked into the generated Wasm module.
+ */
+import type { ValType } from "../ir/types.js";
+
+export const STANDALONE_REGEXP_ABI_VERSION = 1;
+
+export const STANDALONE_REGEXP_ENGINE_KIND = "quickjs-libregexp" as const;
+
+export type StandaloneRegExpEngineKind = typeof STANDALONE_REGEXP_ENGINE_KIND;
+
+export interface StandaloneRegExpAbiFunction {
+  /**
+   * Function name expected in the generated module. These are in-module
+   * symbols, not `env` JS-host imports.
+   */
+  name: string;
+  params: readonly ValType[];
+  results: readonly ValType[];
+}
+
+export interface StandaloneRegExpEngineConfig {
+  kind: StandaloneRegExpEngineKind;
+  abiVersion: typeof STANDALONE_REGEXP_ABI_VERSION;
+  functions: typeof STANDALONE_REGEXP_ABI;
+}
+
+export interface StandaloneRegExpEngineState {
+  standaloneRegExpEngine?: StandaloneRegExpEngineConfig | null;
+}
+
+const I32 = { kind: "i32" } as const satisfies ValType;
+
+/**
+ * Minimal ABI boundary for the first native engine slice. Lowering code should
+ * only query this contract after #1474's refusal gate is opened.
+ */
+export const STANDALONE_REGEXP_ABI = {
+  compile: {
+    name: "__re_compile",
+    params: [I32, I32, I32],
+    results: [I32],
+  },
+  exec: {
+    name: "__re_exec",
+    params: [I32, I32, I32, I32],
+    results: [I32],
+  },
+  free: {
+    name: "__re_free",
+    params: [I32],
+    results: [],
+  },
+  groupStart: {
+    name: "__re_group_start",
+    params: [I32, I32],
+    results: [I32],
+  },
+  groupEnd: {
+    name: "__re_group_end",
+    params: [I32, I32],
+    results: [I32],
+  },
+} as const satisfies Record<string, StandaloneRegExpAbiFunction>;
+
+export function quickJsLibRegexpEngineConfig(): StandaloneRegExpEngineConfig {
+  return {
+    kind: STANDALONE_REGEXP_ENGINE_KIND,
+    abiVersion: STANDALONE_REGEXP_ABI_VERSION,
+    functions: STANDALONE_REGEXP_ABI,
+  };
+}
+
+export function getStandaloneRegExpEngine(state: StandaloneRegExpEngineState): StandaloneRegExpEngineConfig | null {
+  return state.standaloneRegExpEngine ?? null;
+}
+
+export function hasStandaloneRegExpEngine(state: StandaloneRegExpEngineState): boolean {
+  return getStandaloneRegExpEngine(state) !== null;
+}

--- a/tests/issue-682-regexp-standalone-abi.test.ts
+++ b/tests/issue-682-regexp-standalone-abi.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import {
+  getStandaloneRegExpEngine,
+  hasStandaloneRegExpEngine,
+  quickJsLibRegexpEngineConfig,
+  STANDALONE_REGEXP_ABI,
+  STANDALONE_REGEXP_ABI_VERSION,
+  STANDALONE_REGEXP_ENGINE_KIND,
+} from "../src/codegen/regexp-standalone.js";
+
+describe("#682 standalone RegExp native-engine ABI scaffold", () => {
+  it("keeps the engine gate closed by default", () => {
+    expect(getStandaloneRegExpEngine({})).toBeNull();
+    expect(getStandaloneRegExpEngine({ standaloneRegExpEngine: null })).toBeNull();
+    expect(hasStandaloneRegExpEngine({})).toBe(false);
+  });
+
+  it("describes the selected QuickJS libregexp engine without enabling lowering", () => {
+    const engine = quickJsLibRegexpEngineConfig();
+
+    expect(engine.kind).toBe(STANDALONE_REGEXP_ENGINE_KIND);
+    expect(engine.abiVersion).toBe(STANDALONE_REGEXP_ABI_VERSION);
+    expect(engine.functions).toBe(STANDALONE_REGEXP_ABI);
+    expect(hasStandaloneRegExpEngine({ standaloneRegExpEngine: engine })).toBe(true);
+  });
+
+  it("uses in-module native symbols rather than JS-host RegExp imports", () => {
+    const functionNames = Object.values(STANDALONE_REGEXP_ABI).map((fn) => fn.name);
+
+    expect(functionNames).toEqual(["__re_compile", "__re_exec", "__re_free", "__re_group_start", "__re_group_end"]);
+    expect(functionNames.every((name) => name.startsWith("__re_"))).toBe(true);
+    expect(functionNames.some((name) => name.startsWith("RegExp_"))).toBe(false);
+  });
+
+  it("pins the first-slice pointer-sized ABI shape", () => {
+    expect(STANDALONE_REGEXP_ABI.compile.params.map((p) => p.kind)).toEqual(["i32", "i32", "i32"]);
+    expect(STANDALONE_REGEXP_ABI.compile.results.map((p) => p.kind)).toEqual(["i32"]);
+
+    expect(STANDALONE_REGEXP_ABI.exec.params.map((p) => p.kind)).toEqual(["i32", "i32", "i32", "i32"]);
+    expect(STANDALONE_REGEXP_ABI.exec.results.map((p) => p.kind)).toEqual(["i32"]);
+
+    expect(STANDALONE_REGEXP_ABI.free.params.map((p) => p.kind)).toEqual(["i32"]);
+    expect(STANDALONE_REGEXP_ABI.free.results).toEqual([]);
+  });
+});


### PR DESCRIPTION
Issue: [#682 standalone RegExp native engine scaffold](https://github.com/loopdive/js2/blob/main/plan/issues/682-regexp-standalone-mode-native-engine.md)

## Summary

- Add a typed standalone RegExp ABI scaffold for the selected `quickjs-libregexp` path.
- Thread a nullable `CodegenContext.standaloneRegExpEngine` hook, initialized to `null`.
- Keep the #1474 standalone RegExp refusal gate closed; this PR adds no RegExp semantics.
- Add focused scaffold tests that pin the closed gate and non-JS-host `__re_*` ABI shape.
- Update the #682 issue file with findings, spec references, and validation notes.

## Validation

- `pnpm exec prettier --write src/codegen/regexp-standalone.ts src/codegen/context/types.ts src/codegen/context/create-context.ts tests/issue-682-regexp-standalone-abi.test.ts` — passed
- `pnpm run typecheck` — passed
- `pnpm exec vitest run tests/issue-682-regexp-standalone-abi.test.ts tests/issue-1474-standalone-regex-refuse.test.ts` — passed, 2 files / 18 tests
- pre-push hook — passed: typecheck + lint, format check, issue integrity

Full test262 was not run.
