### PR TITLE
fix(json): clarify standalone JSON refusal

### DIFF
--- a/plan/issues/1599-json-standalone.md
+++ b/plan/issues/1599-json-standalone.md
@@ -1,9 +1,10 @@
 ---
 id: 1599
 title: "host-indep: JSON.parse / JSON.stringify in standalone mode"
-status: done
+status: in-progress
+owner: Copernicus
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-06-01
 priority: medium
 feasibility: hard
 reasoning_effort: max
@@ -11,9 +12,10 @@ task_type: feature
 area: codegen, runtime
 language_feature: json
 goal: standalone-wasm
-sprint: 55
+sprint: 58
 related: [1474, 1539]
 ---
+
 # #1599 — JSON standalone: refuse-and-document then pure-Wasm implementation
 
 ## Problem
@@ -23,7 +25,7 @@ related: [1474, 1539]
 
 ```ts
 addImport(ctx, "env", "JSON_stringify", { kind: "func", typeIdx }); // line 1065
-addImport(ctx, "env", "JSON_parse",     { kind: "func", typeIdx }); // line 1069
+addImport(ctx, "env", "JSON_parse", { kind: "func", typeIdx }); // line 1069
 ```
 
 Any standalone/WASI module that calls `JSON.parse(s)` or `JSON.stringify(v)` fails
@@ -32,6 +34,17 @@ at instantiation with `unknown import env::JSON_stringify`.
 JSON is one of the most common serialization primitives in npm packages. Without it,
 modules that do any serialization (config parsing, API responses, logging) cannot
 run standalone.
+
+## Evidence: real standalone test262 run 2026-06-01
+
+Artifacts:
+`benchmarks/results/test262-standalone-report-20260601-213702.json` and
+`benchmarks/results/test262-standalone-results-20260601-213702.jsonl`.
+
+Standalone result: 4,368 / 43,106 passing (10.1%) versus the canonical JS-host
+baseline of 30,480 / 43,106 (70.7%). JSON unsupported appears in 134
+non-exclusive standalone failures. Phase 1 refusal avoids host imports; Phase 2
+needs the pure-Wasm parser/stringifier to recover this test262 surface.
 
 ## Phase 1 — Refuse-and-document (fast follow to #1474 pattern)
 
@@ -54,9 +67,12 @@ At the call sites in `string-ops.ts` / `expressions/calls.ts` that lower
 
 ```ts
 if (ctx.standalone) {
-  reportError(ctx, expr,
+  reportError(
+    ctx,
+    expr,
     "JSON.stringify / JSON.parse is not supported in --target standalone (#1599). " +
-    "Use a pure-JS serializer compiled with js2wasm, or avoid JSON in WASI targets.");
+      "Use a pure-JS serializer compiled with js2wasm, or avoid JSON in WASI targets.",
+  );
   return null;
 }
 ```
@@ -116,12 +132,14 @@ number   := '-'? int frac? exp?
 ## Files
 
 ### Phase 1
+
 - `src/codegen/declarations.ts` lines 1065, 1069 — add `ctx.standalone` guard
 - Call sites for `JSON.stringify` / `JSON.parse` in `src/codegen/expressions/calls.ts`
   — add `reportError` when `ctx.standalone`
-- `tests/issue-1593-json-standalone-refuse.test.ts` — refusal tests
+- `tests/issue-1599-json-standalone-refuse.test.ts` — refusal tests
 
 ### Phase 2
+
 - `src/codegen/wasm-helpers/json-stringify.ts` — serialiser helper emitter
 - `src/codegen/wasm-helpers/json-parse.ts` — recursive-descent parser helper emitter
 - `src/codegen/declarations.ts` — wire up helpers when `ctx.standalone && state.jsonNeed*`
@@ -129,11 +147,13 @@ number   := '-'? int frac? exp?
 ## Acceptance criteria
 
 ### Phase 1
+
 - `--target standalone` module using `JSON.parse` or `JSON.stringify` fails at
   compile time with a clear error referencing #1599.
 - No `env::JSON_parse` or `env::JSON_stringify` in standalone output.
 
 ### Phase 2
+
 - `JSON.stringify({a: 1, b: [2, 3]})` returns `'{"a":1,"b":[2,3]}'` in standalone.
 - `JSON.parse('{"x":42}').x === 42` in standalone.
 - Passes `test/built-ins/JSON/*` test262 subset under `--target standalone`.
@@ -149,6 +169,7 @@ Phase 2: ~350 LOC (serialiser + parser helper emitters), hard. No external toolc
 (pure-Wasm codec) remains a follow-up.
 
 ### What landed
+
 - `src/codegen/declarations.ts` — `env::JSON_stringify` / `env::JSON_parse`
   imports are now gated on `!(ctx.wasi || ctx.standalone)`. No JSON host import
   is registered in standalone / WASI output. (Both targets lack the JS host;
@@ -160,18 +181,31 @@ Phase 2: ~350 LOC (serialiser + parser helper emitters), hard. No external toolc
   the pure-Wasm primitive slice (#1324), emit a `reportError` whose message
   starts with `Codegen error:` (required to flip `CompileResult.success` to
   `false` per `src/compiler.ts`) referencing #1599.
-- `tests/issue-1599-json-standalone-refuse.test.ts` — 11 tests: refusal of
-  object/array/string stringify + all parse (standalone AND wasi), no
+- `tests/issue-1599-json-standalone-refuse.test.ts` — 12 tests: refusal of
+  object/array/string/number stringify + all parse (standalone AND wasi), no
   `env::JSON_*` import emitted, primitive `null`/`true` stringify still compiles
   standalone, and default JS-host mode unchanged.
 
+### Spec anchors
+
+- ECMA-262 §25.5.2 `JSON.parse` and §25.5.2.1 `ParseJSON`: full standalone
+  support must parse ECMA-404 JSON text to ECMAScript values and throw
+  `SyntaxError` for invalid JSON text.
+- ECMA-262 §25.5.4 `JSON.stringify` and §25.5.4.2
+  `SerializeJSONProperty`: full standalone support must return a UTF-16 JSON
+  String or `undefined`, with `null`/boolean/number/string/object/array rules
+  and `TypeError` for BigInt/cycles. Phase 1 intentionally refuses shapes that
+  would otherwise route to the JS host.
+
 ### Acceptance criteria — Phase 1
+
 - ✅ `--target standalone`/`wasi` module using non-primitive `JSON.stringify`
   or any `JSON.parse` fails at compile time with a clear `#1599` error + source
   location.
 - ✅ No `env::JSON_parse` / `env::JSON_stringify` in standalone/wasi output.
 
 ### Notes for Phase 2 (follow-up — NOT in this PR)
+
 - The primitive `JSON.stringify` slice (#1324) covers `null` / `undefined` /
   `boolean` standalone, but **`number` is NOT standalone-safe**: that slice
   lowers via `env::number_toString`, a host import absent in standalone/wasi.
@@ -182,3 +216,9 @@ Phase 2: ~350 LOC (serialiser + parser helper emitters), hard. No external toolc
   (`json-stringify.ts`) + recursive-descent parser (`json-parse.ts`) over the
   WasmGC value graph. Acceptance: `JSON.stringify({a:1,b:[2,3]})` →
   `'{"a":1,"b":[2,3]}'` and `JSON.parse('{"x":42}').x === 42` standalone.
+
+### Validation — 2026-06-01
+
+- `pnpm exec vitest run tests/issue-1599-json-standalone-refuse.test.ts` —
+  12 tests passed after adding the standalone `JSON.stringify(number)` refusal
+  regression case.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -299,17 +299,17 @@ function resolveClosureInfoFromLocal(
 
 /**
  * (#1324 primitives slice) Try to emit `JSON.stringify(arg)` for a
- * statically-typed primitive value as pure Wasm — no JS host call.
+ * statically-typed primitive value without the `JSON_stringify` JS host call.
  *
  * Supported shapes (all leave an externref string on the stack):
  *   - `null`       → string `"null"`
- *   - `undefined`  → undefined (ref.null.extern) — per spec §25.5.2,
+ *   - `undefined`  → undefined (ref.null.extern) — per spec §25.5.4.2,
  *                    `JSON.stringify(undefined)` returns `undefined`,
  *                    not the string "null"
  *   - `boolean`    → string `"true"` or `"false"`
- *   - `number`     → result of `number_toString(value)`, except
+ *   - `number`     → result of `number_toString(value)` when available, except
  *                    `NaN`/`±Infinity` serialize to the string `"null"`
- *                    per §25.5.2 step 11
+ *                    per §25.5.4.2 step 9
  *
  * Deferred to #1353 (full architect spec):
  *   - `string`  — needs runtime JSON-escape helper
@@ -4961,8 +4961,10 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
       const method = propAccess.name.text;
       if ((method === "stringify" || method === "parse") && expr.arguments.length >= 1) {
         // (#1324 primitives slice) For JSON.stringify of statically-typed
-        // primitive values (null / undefined / boolean / number), emit the
-        // result as pure Wasm so standalone-mode (no JS host) builds work.
+        // primitive values (null / undefined / boolean, plus number when the
+        // target has a number_toString helper), emit the result without the
+        // JSON_stringify host import. Standalone/WASI number stringify falls
+        // through to the #1599 refusal until Phase 2 has pure-Wasm formatting.
         // Object/array/string/bigint cases fall through to the existing
         // JSON_stringify host import — full pure-Wasm shape walking is
         // tracked under #1353 (architect-spec follow-up).
@@ -4970,7 +4972,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
           if (tryEmitJsonStringifyPrimitive(ctx, fctx, expr.arguments[0]!)) {
             // Compile remaining args (replacer, space) for their side
             // effects only — primitive stringify ignores them per spec
-            // §25.5.2 (replacer doesn't observe primitives, space only
+            // §25.5.4 (replacer doesn't observe primitives, space only
             // affects nested output).
             for (let i = 1; i < expr.arguments.length; i++) {
               const t = compileExpression(ctx, fctx, expr.arguments[i]!);
@@ -4982,7 +4984,7 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
         // (#1599 Phase 1) Refuse-and-document: in standalone (no-JS-host) /
         // WASI mode there is no `env::JSON_*` host import to fall back to.
         // The primitive `JSON.stringify` slice above (#1324) already handles
-        // null / undefined / boolean / number as pure Wasm; everything else
+        // null / undefined / boolean as pure Wasm; everything else
         // (objects, arrays, strings, and all `JSON.parse`) needs the pure-Wasm
         // codec from Phase 2, which is not yet implemented. Emit a clear
         // compile error rather than a module that traps at instantiation.
@@ -4991,8 +4993,8 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
             ctx,
             expr,
             `Codegen error: JSON.${method} of this value is not yet supported in --target standalone/wasi (#1599). ` +
-              `Pure-Wasm JSON.stringify of null/undefined/boolean/number works standalone; ` +
-              `objects, arrays, strings, and JSON.parse require the Phase 2 pure-Wasm codec (#1599 Phase 2). ` +
+              `Pure-Wasm JSON.stringify of null/undefined/boolean works standalone; ` +
+              `numbers, objects, arrays, strings, and JSON.parse require the Phase 2 pure-Wasm codec (#1599 Phase 2). ` +
               `Avoid JSON for these shapes in standalone/WASI targets for now.`,
           );
           return null;

--- a/tests/issue-1599-json-standalone-refuse.test.ts
+++ b/tests/issue-1599-json-standalone-refuse.test.ts
@@ -16,8 +16,9 @@ import { compile } from "../src/index.js";
  *   - emits a clear `#1599` compile error at the call site for any shape not
  *     covered by the pure-Wasm primitive `JSON.stringify` slice (#1324).
  *
- * The primitive `JSON.stringify` slice (null / undefined / boolean / number)
- * is still lowered to pure Wasm and continues to compile standalone.
+ * The primitive `JSON.stringify` slice (null / undefined / boolean) is still
+ * lowered to pure Wasm and continues to compile standalone. Number stringify
+ * is refused here until it has a pure-Wasm number-to-string path.
  *
  * Phase 2 (a pure-Wasm JSON codec for objects / arrays / strings / parse) is
  * tracked in the issue file as a follow-up.
@@ -47,6 +48,11 @@ describe("#1599 --target standalone refuses unsupported JSON shapes", () => {
 
   it("rejects JSON.stringify of a string", async () => {
     await expectRefused(`export function f(s: string): string { return JSON.stringify(s); }`);
+  });
+
+  it("rejects JSON.stringify of a number until Phase 2 adds pure-Wasm number formatting", async () => {
+    const r = await expectRefused(`export function f(n: number): string { return JSON.stringify(n); }`);
+    expect(r.errors.some((e) => /numbers, objects, arrays, strings, and JSON\.parse/.test(e.message))).toBe(true);
   });
 
   it("rejects JSON.parse", async () => {


### PR DESCRIPTION
Links #1599.

## Summary
- Clarify the standalone/WASI JSON refusal diagnostic so `JSON.stringify(number)` is explicitly treated as Phase 2 work instead of described as standalone-safe.
- Add focused `issue-1599` coverage for standalone number stringify refusal and the diagnostic wording.
- Update the issue notes with ECMA-262 `JSON.parse` / `JSON.stringify` anchors, findings, and validation.

## Validation
- `node /Users/thomas/.codex/worktrees/867e/ts2wasm/node_modules/vitest/dist/cli.js run tests/issue-1599-json-standalone-refuse.test.ts` — passed: 1 test file, 12 tests.
- Push hook via `env PATH=/Users/thomas/.codex/worktrees/867e/ts2wasm/node_modules/.bin:$PATH git push -u https://github.com/loopdive/js2.git codex/1599-json-standalone-refuse` — passed typecheck + lint, prettier format:check, and issue integrity.

Full test262 was not run.
