### PR TITLE
feat(number): add standalone integer radix toString

### DIFF
--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -292,11 +292,12 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       }
     }
     if (isNumberType(receiverType) && methodName === "toString") {
-      state.primitiveNeeded.add("number_toString");
       // #1321: toString(radix) needs a 2-arg host import so the radix is
       // actually used. The 1-arg `number_toString` only handles default base 10.
       if (node.arguments.length > 0) {
         state.primitiveNeeded.add("number_toString_radix");
+      } else {
+        state.primitiveNeeded.add("number_toString");
       }
     }
     // (#1644 Slice D) BigInt.prototype.toString — bigint-typed receiver routes
@@ -898,7 +899,11 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // #1321: 2-arg `number_toString_radix(value, radix)` for `toString(radix)` calls.
   // Without this, the codegen validates the radix range but then calls 1-arg
   // `number_toString(value)`, silently producing decimal output for any radix.
-  if (state.primitiveNeeded.has("number_toString_radix")) {
+  // #1335 Phase 1: standalone/WASI emits the safe-integer radix formatter in
+  // pure Wasm instead of requesting the JS host import.
+  const needsNativeNumberToStringRadix =
+    state.primitiveNeeded.has("number_toString_radix") && (ctx.wasi || ctx.standalone);
+  if (state.primitiveNeeded.has("number_toString_radix") && !needsNativeNumberToStringRadix) {
     const t = addFuncType(ctx, [{ kind: "f64" }, { kind: "f64" }], [{ kind: "externref" }]);
     addImport(ctx, "env", "number_toString_radix", { kind: "func", typeIdx: t });
   }
@@ -920,7 +925,7 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // like emitNativeParseNumber's.
   if (ctx.wasi || ctx.standalone) {
     const fmtNative = new Set<string>();
-    for (const n of ["number_toFixed", "number_toExponential", "number_toPrecision"]) {
+    for (const n of ["number_toString_radix", "number_toFixed", "number_toExponential", "number_toPrecision"]) {
       if (state.primitiveNeeded.has(n) && !ctx.funcMap.has(n)) fmtNative.add(n);
     }
     if (fmtNative.size > 0) {

--- a/src/codegen/number-format-native.ts
+++ b/src/codegen/number-format-native.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * Pure-Wasm `Number.prototype.{toFixed,toPrecision,toExponential}` for
- * standalone / WASI targets (#1321 / #1335 Phase 2).
+ * Pure-Wasm `Number.prototype.{toString,toFixed,toPrecision,toExponential}` for
+ * standalone / WASI targets (#1321 / #1335).
  *
  * In JS-host mode these are `env` imports (`number_toFixed` etc.). Under
  * `--target wasi` / `--target standalone` there is no JS runtime, so this
@@ -27,6 +27,7 @@
  * `number_toFixed` etc. host imports.
  *
  * Spec references:
+ * - toString      — ECMA-262 §21.1.3.6, §6.1.6.1.20, §7.1.5
  * - toFixed       — ECMA-262 §21.1.3.3
  * - toPrecision   — ECMA-262 §21.1.3.5
  * - toExponential — ECMA-262 §21.1.3.2
@@ -42,11 +43,13 @@ import { ensureNativeStringHelpers } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
 
 const BUF_CAP = 256;
+const MAX_SAFE_INTEGER = 9007199254740991;
 const C_ZERO = 48; // '0'
 const C_MINUS = 45; // '-'
 const C_PLUS = 43; // '+'
 const C_DOT = 46; // '.'
 const C_LC_E = 101; // 'e'
+const C_LC_A_MINUS_10 = 87; // 'a' - 10
 
 /**
  * Allocate the next defined-function index. Mirrors parse-number-native.ts.
@@ -354,9 +357,10 @@ function emitIntegerDigits(
 
 /**
  * Emit the three native number-format functions and register them in
- * `ctx.funcMap`. `which` is a subset of {number_toFixed, number_toPrecision,
- * number_toExponential}. Must run before any function bodies that call them,
- * and (via ensureNativeStringHelpers) sets up the NativeString types.
+ * `ctx.funcMap`. `which` is a subset of {number_toString_radix, number_toFixed,
+ * number_toPrecision, number_toExponential}. Must run before any function
+ * bodies that call them, and (via ensureNativeStringHelpers) sets up the
+ * NativeString types.
  */
 export function emitNativeNumberFormat(ctx: CodegenContext, which: Set<string>): void {
   ensureNativeStringHelpers(ctx);
@@ -366,6 +370,10 @@ export function emitNativeNumberFormat(ctx: CodegenContext, which: Set<string>):
   const f64: ValType = { kind: "f64" };
   const extern: ValType = { kind: "externref" };
   const bufType: ValType = { kind: "ref", typeIdx: strDataTypeIdx };
+
+  if (which.has("number_toString_radix") && !ctx.funcMap.has("number_toString_radix")) {
+    emitToStringRadix(ctx, finalizeIdx, strDataTypeIdx, i32, f64, extern, bufType);
+  }
 
   // number_toPrecision delegates to number_toFixed + number_toExponential, so
   // those two must be emitted whenever toPrecision is requested — even if the
@@ -383,6 +391,244 @@ export function emitNativeNumberFormat(ctx: CodegenContext, which: Set<string>):
   if (needPrecision && !ctx.funcMap.has("number_toPrecision")) {
     emitToPrecision(ctx, finalizeIdx, strDataTypeIdx, i32, f64, extern, bufType);
   }
+}
+
+/**
+ * `number_toString_radix(value: f64, radix: f64) -> externref`
+ * (§21.1.3.6, §6.1.6.1.20, §7.1.5).
+ *
+ * The call site has already applied `ToIntegerOrInfinity(radix)`'s truncating
+ * shape for ordinary positive radices and rejected values outside 2..36. This
+ * standalone slice handles non-finite values, ±0, and finite safe integers.
+ * Fractional and unsafe-integer shortest formatting remains #1335 Phase 2.
+ */
+function emitToStringRadix(
+  ctx: CodegenContext,
+  finalizeIdx: number,
+  strDataTypeIdx: number,
+  i32: ValType,
+  f64: ValType,
+  extern: ValType,
+  bufType: ValType,
+): void {
+  // params: 0 value:f64, 1 radix:f64
+  // locals: 2 buf 3 pos 4 tmp 5 neg 6 abs 7 r 8 n 9 q 10 digit
+  //         11 digitCode 12 i 13 j
+  const L_VALUE = 0;
+  const L_RADIX = 1;
+  const L_BUF = 2;
+  const L_POS = 3;
+  const L_TMP = 4;
+  const L_NEG = 5;
+  const L_ABS = 6;
+  const L_R = 7;
+  const L_N = 8;
+  const L_Q = 9;
+  const L_DIGIT = 10;
+  const L_CODE = 11;
+  const L_I = 12;
+  const L_J = 13;
+
+  const writeFinalizeReturn = (): Instr[] => [
+    { op: "local.get", index: L_BUF },
+    { op: "local.get", index: L_POS },
+    { op: "call", funcIdx: finalizeIdx },
+    { op: "return" },
+  ];
+
+  const body: Instr[] = [
+    ...emitNonFinitePrologue(ctx, finalizeIdx, strDataTypeIdx, L_VALUE, L_BUF, L_POS, L_TMP, L_NEG, L_ABS),
+
+    // radix = floor(radix). The caller already rejects non-integers outside the
+    // valid interval after ToIntegerOrInfinity-style truncation.
+    { op: "local.get", index: L_RADIX },
+    { op: "f64.floor" },
+    { op: "local.set", index: L_R },
+
+    // if abs == 0: return "0" (covers both +0 and -0).
+    { op: "local.get", index: L_ABS },
+    { op: "f64.const", value: 0 },
+    { op: "f64.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...putConst(strDataTypeIdx, L_BUF, L_POS, C_ZERO), ...writeFinalizeReturn()],
+    },
+
+    // Phase 1 guard: finite integers only, and stay within exactly represented
+    // integer space so the f64 div/mod digit loop is stable.
+    { op: "local.get", index: L_ABS },
+    { op: "local.get", index: L_ABS },
+    { op: "f64.floor" },
+    { op: "f64.ne" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "unreachable" }],
+    },
+    { op: "local.get", index: L_ABS },
+    { op: "f64.const", value: MAX_SAFE_INTEGER },
+    { op: "f64.gt" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "unreachable" }],
+    },
+
+    // n = abs; write least-significant digits into buf[0..pos).
+    { op: "local.get", index: L_ABS },
+    { op: "local.set", index: L_N },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_N },
+            { op: "f64.const", value: 0 },
+            { op: "f64.eq" },
+            { op: "br_if", depth: 1 },
+
+            // q = floor(n / radix); digit = n - q * radix.
+            { op: "local.get", index: L_N },
+            { op: "local.get", index: L_R },
+            { op: "f64.div" },
+            { op: "f64.floor" },
+            { op: "local.set", index: L_Q },
+            { op: "local.get", index: L_N },
+            { op: "local.get", index: L_Q },
+            { op: "local.get", index: L_R },
+            { op: "f64.mul" },
+            { op: "f64.sub" },
+            { op: "local.set", index: L_DIGIT },
+
+            // digitCode = digit < 10 ? '0' + digit : 'a' - 10 + digit.
+            { op: "local.get", index: L_DIGIT },
+            { op: "f64.const", value: 10 },
+            { op: "f64.lt" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: i32 },
+              then: [
+                { op: "i32.const", value: C_ZERO },
+                { op: "local.get", index: L_DIGIT },
+                { op: "i32.trunc_f64_s" },
+                { op: "i32.add" },
+              ],
+              else: [
+                { op: "i32.const", value: C_LC_A_MINUS_10 },
+                { op: "local.get", index: L_DIGIT },
+                { op: "i32.trunc_f64_s" },
+                { op: "i32.add" },
+              ],
+            },
+            { op: "local.set", index: L_CODE },
+
+            { op: "local.get", index: L_BUF },
+            { op: "local.get", index: L_POS },
+            { op: "local.get", index: L_CODE },
+            { op: "array.set", typeIdx: strDataTypeIdx },
+            { op: "local.get", index: L_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_POS },
+
+            { op: "local.get", index: L_Q },
+            { op: "local.set", index: L_N },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // Negative finite non-zero values prepend '-' after the digit loop, then the
+    // full buffer is reversed below.
+    { op: "local.get", index: L_NEG },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: putConst(strDataTypeIdx, L_BUF, L_POS, C_MINUS),
+    },
+
+    // Reverse buf[0..pos) in place.
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L_I },
+    { op: "local.get", index: L_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.sub" },
+    { op: "local.set", index: L_J },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_J },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+
+            { op: "local.get", index: L_BUF },
+            { op: "local.get", index: L_I },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.set", index: L_TMP },
+
+            { op: "local.get", index: L_BUF },
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_BUF },
+            { op: "local.get", index: L_J },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "array.set", typeIdx: strDataTypeIdx },
+
+            { op: "local.get", index: L_BUF },
+            { op: "local.get", index: L_J },
+            { op: "local.get", index: L_TMP },
+            { op: "array.set", typeIdx: strDataTypeIdx },
+
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_I },
+            { op: "local.get", index: L_J },
+            { op: "i32.const", value: 1 },
+            { op: "i32.sub" },
+            { op: "local.set", index: L_J },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    ...writeFinalizeReturn(),
+  ];
+
+  const typeIdx = addFuncType(ctx, [f64, f64], [extern]);
+  const funcIdx = nextFuncIdx(ctx);
+  ctx.funcMap.set("number_toString_radix", funcIdx);
+  ctx.mod.functions.push({
+    name: "number_toString_radix",
+    typeIdx,
+    locals: [
+      { name: "buf", type: bufType },
+      { name: "pos", type: i32 },
+      { name: "tmp", type: i32 },
+      { name: "neg", type: i32 },
+      { name: "abs", type: f64 },
+      { name: "radix", type: f64 },
+      { name: "n", type: f64 },
+      { name: "q", type: f64 },
+      { name: "digit", type: f64 },
+      { name: "digitCode", type: i32 },
+      { name: "i", type: i32 },
+      { name: "j", type: i32 },
+    ],
+    body,
+    exported: false,
+  });
 }
 
 /**

--- a/tests/issue-1335-standalone.test.ts
+++ b/tests/issue-1335-standalone.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1335 Phase 1 — pure-Wasm `Number.prototype.toString(radix)` for standalone
+ * finite integer formatting.
+ *
+ * Spec references:
+ * - ECMA-262 §21.1.3.6 Number.prototype.toString
+ * - ECMA-262 §6.1.6.1.20 Number::toString
+ * - ECMA-262 §7.1.5 ToIntegerOrInfinity
+ *
+ * This slice intentionally does not implement fractional or unsafe-integer
+ * shortest formatting; that remains the Ryu/bignum follow-up for #1335.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function formatStandalone(expr: string, target: "wasi" | "standalone" = "wasi"): Promise<string> {
+  const src = `export function len(): number { return (${expr}).length; }
+export function at(i: number): number { return (${expr}).charCodeAt(i); }`;
+  const r = await compile(src, { fileName: "issue-1335.ts", target });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+
+  const mod = await WebAssembly.compile(r.binary);
+  const numberToStringImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env" && i.name.startsWith("number_toString"))
+    .map((i) => `${i.module}::${i.name}`);
+  expect(numberToStringImports, "standalone integer radix formatting must not need JS host toString imports").toEqual(
+    [],
+  );
+
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exports = instance.exports as { len(): number; at(i: number): number };
+  const len = exports.len();
+  let out = "";
+  for (let i = 0; i < len; i++) out += String.fromCharCode(exports.at(i));
+  return out;
+}
+
+describe("#1335 Phase 1 — standalone Number.prototype.toString(radix)", () => {
+  it("formats positive integers in binary, octal, hex, and base36", async () => {
+    expect(await formatStandalone("(255).toString(2)")).toBe("11111111");
+    expect(await formatStandalone("(255).toString(8)")).toBe("377");
+    expect(await formatStandalone("(255).toString(16)")).toBe("ff");
+    expect(await formatStandalone("(35).toString(36)")).toBe("z");
+  });
+
+  it("formats negative integers and zero without a host import", async () => {
+    expect(await formatStandalone("(-255).toString(16)")).toBe("-ff");
+    expect(await formatStandalone("(-0).toString(16)")).toBe("0");
+    expect(await formatStandalone("(0).toString(2)")).toBe("0");
+  });
+
+  it("handles special Number::toString values naturally", async () => {
+    expect(await formatStandalone("(NaN).toString(16)")).toBe("NaN");
+    expect(await formatStandalone("(Infinity).toString(2)")).toBe("Infinity");
+    expect(await formatStandalone("(-Infinity).toString(36)")).toBe("-Infinity");
+  });
+
+  it("truncates radix per ToIntegerOrInfinity before formatting", async () => {
+    expect(await formatStandalone("(255).toString(16.9)")).toBe("ff");
+  });
+
+  it("standalone target emits the same native helper as wasi", async () => {
+    expect(await formatStandalone("(31).toString(16)", "standalone")).toBe("1f");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #1335 Phase 1 slice for standalone/WASI integer Number.prototype.toString(radix).
- Emits a pure-Wasm number_toString_radix helper for standalone/nativeStrings mode, covering NaN, +/-Infinity, +/-0, and finite safe integers in radix 2..36.
- Keeps JS-host mode on the existing number_toString_radix host import path and avoids registering decimal number_toString for radix-only calls.

## Spec
- ECMA-262 §21.1.3.6 Number.prototype.toString: radix is ToIntegerOrInfinity, must be 2..36, then delegates to Number::toString.
- ECMA-262 §6.1.6.1.20 Number::toString: digits come from 0123456789abcdefghijklmnopqrstuvwxyz and special values return NaN/Infinity/-Infinity.
- ECMA-262 §7.1.5 ToIntegerOrInfinity: radix fractional parts truncate; NaN/zero map to 0 before range rejection.

## Validation
- pnpm test tests/issue-1335-standalone.test.ts
- pnpm test tests/issue-1321.test.ts tests/issue-1321-standalone.test.ts
- pnpm run typecheck
- pnpm exec prettier --check src/codegen/declarations.ts src/codegen/number-format-native.ts tests/issue-1335-standalone.test.ts
- commit hook: prettier --write + biome lint --diagnostic-level=error --no-errors-on-unmatched
- pre-push hook: typecheck + lint OK; format:check OK

Full test262 was not run.