### PR TITLE
fix(types): erase generic typed-array annotations (#1755)

### DIFF
--- a/plan/issues/1755-uint8array-arraybuffer-generic-annotation.md
+++ b/plan/issues/1755-uint8array-arraybuffer-generic-annotation.md
@@ -1,9 +1,9 @@
 ---
 id: 1755
 title: "TS annotation: Uint8Array<ArrayBuffer> generic typed-array form not handled"
-status: ready
+status: done
 created: 2026-05-30
-updated: 2026-05-31
+updated: 2026-06-02
 priority: low
 feasibility: medium
 task_type: bug
@@ -13,6 +13,7 @@ goal: platform
 related: [389, 1752, 1700]
 depends_on: []
 sprint: 58
+completed: 2026-06-02
 ---
 
 # #1755 — `Uint8Array<ArrayBuffer>` generic annotation
@@ -54,3 +55,24 @@ non-generic `Uint8Array`.
 
 Low priority (annotation ergonomics, not a runtime correctness gap) but cheap if
 it's a small type-resolver erase. Distinct from #1700 (TypedArray export ABI).
+
+## Implementation Summary
+
+- What was done: Erased generic typed-array type-node annotations in the WasmGC
+  IR position resolver so `Uint8Array<ArrayBuffer>` and sibling typed-array
+  forms lower like their bare annotations. Normalized the linear backend's
+  existing `Uint8Array` annotation text checks so `Uint8Array<ArrayBuffer>` is
+  tagged as the same collection kind as bare `Uint8Array`.
+- What worked: The TypeScript checker already preserved typed-array symbols for
+  export-signature classification and legacy `resolveWasmType`; the fix only
+  needed the explicit type-node/text paths that bypass those symbol checks.
+  Focused coverage now exercises WasmGC host marshalling, standalone, WASI, and
+  the linear backend's collection-kind tagging.
+- What didn't work: No alternate lowering strategy was needed; the
+  `<ArrayBufferLike>` argument is purely compile-time metadata for js2wasm.
+- Files changed: `src/codegen/index.ts`, `src/codegen-linear/index.ts`,
+  `tests/issue-1755.test.ts`, `plan/log/issues-log.md`, and this issue file.
+- Tests: `npm test -- tests/issue-1755.test.ts`; `npm test --
+  tests/issue-1700.test.ts tests/issue-1752.test.ts tests/issue-1755.test.ts`;
+  `npx prettier --check src/codegen/index.ts src/codegen-linear/index.ts
+  tests/issue-1755.test.ts`.

--- a/plan/log/issues-log.md
+++ b/plan/log/issues-log.md
@@ -516,3 +516,4 @@ sprint: 0
 | 1773 | 2026-06-01 | Dependency graph data is now generated during Pages builds and published to labs instead of tracked as public source JSON | Sprint-58 |
 | 1767 | 2026-06-01 | Native-messaging large responses now use bounded <=1 MiB frames with guarded stress validation for the reported 64 MiB array path | Sprint-58 |
 | 1753 | 2026-06-02 | Native-messaging host now reads large requests as <=1 MiB continuation frames up to 64 MiB and responds with <=1 MiB byte-exact chunks using bounded ArrayBuffer aggregation | Sprint-58 |
+| 1755 | 2026-06-02 | Generic typed-array annotations such as Uint8Array<ArrayBuffer> now erase to the bare typed-array lowering across IR, export metadata, and the existing linear Uint8Array collection tagging paths | Sprint-58 |

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -24,6 +24,15 @@ const CLASS_TYPE_TAG = 5;
 /** Data segment base address — must be below HEAP_START (1024) */
 const DATA_SEGMENT_BASE = 64;
 
+function isUint8ArrayTypeText(text: string): boolean {
+  return /^Uint8Array(?:<.*>)?$/.test(text.replace(/\s+/g, ""));
+}
+
+function isNumberArrayOrUint8ArrayUnionText(text: string): boolean {
+  const parts = text.split("|").map((part) => part.trim());
+  return parts.length === 2 && parts.includes("number[]") && parts.some(isUint8ArrayTypeText);
+}
+
 /**
  * Generate a WasmModule using the linear-memory backend.
  * Compiles TS functions to standard Wasm with i32/f64 values.
@@ -1504,7 +1513,7 @@ function classifyFieldType(
     collKinds.set(propName, "Array");
     return "i32";
   }
-  if (typeStr === "Uint8Array" || typeStr.includes("Uint8Array")) {
+  if (isUint8ArrayTypeText(typeStr) || typeStr.includes("Uint8Array")) {
     collKinds.set(propName, "Uint8Array");
     return "i32";
   }
@@ -2118,7 +2127,7 @@ function detectCollectionKind(ctx: LinearContext, decl: ts.VariableDeclaration):
   if (decl.type) {
     const text = decl.type.getText();
     if (text === "number[]" || text.startsWith("Array<")) return "Array";
-    if (text === "Uint8Array") return "Uint8Array";
+    if (isUint8ArrayTypeText(text)) return "Uint8Array";
     if (text.startsWith("Map<") || text === "Map") return "Map";
     if (text.startsWith("Set<") || text === "Set") return "Set";
   }
@@ -2148,7 +2157,7 @@ function detectCollectionKind(ctx: LinearContext, decl: ts.VariableDeclaration):
       const rawType = ctx.checker.getTypeAtLocation(decl.initializer);
       const type = ctx.checker.getNonNullableType(rawType);
       const typeStr = ctx.checker.typeToString(type);
-      if (typeStr === "Uint8Array" || typeStr.includes("Uint8Array")) return "Uint8Array";
+      if (isUint8ArrayTypeText(typeStr) || typeStr.includes("Uint8Array")) return "Uint8Array";
       if (typeStr.startsWith("Map<") || typeStr === "Map") return "Map";
       if (typeStr.startsWith("Set<") || typeStr === "Set") return "Set";
       if (typeStr === "number[]" || typeStr.endsWith("[]") || typeStr.startsWith("Array<")) return "Array";
@@ -2195,7 +2204,7 @@ function getExprCollectionKind(
     const rawType = ctx.checker.getTypeAtLocation(expr);
     const type = ctx.checker.getNonNullableType(rawType);
     const typeStr = ctx.checker.typeToString(type);
-    if (typeStr === "Uint8Array" || typeStr.includes("Uint8Array")) return "Uint8Array";
+    if (isUint8ArrayTypeText(typeStr) || typeStr.includes("Uint8Array")) return "Uint8Array";
     if (typeStr.startsWith("Map<") || typeStr === "Map") return "Map";
     if (typeStr.startsWith("Set<") || typeStr === "Set") return "Set";
     if (typeStr.endsWith("[]") || typeStr.startsWith("Array<")) return "Array";
@@ -3728,7 +3737,7 @@ function scanClassDeclaration(ctx: LinearContext, classDecl: ts.ClassDeclaration
         const typeText = member.type.getText();
         if (typeText.endsWith("[]") || typeText.startsWith("Array<")) {
           fieldCollectionKinds.set(fieldName, "Array");
-        } else if (typeText === "Uint8Array") {
+        } else if (isUint8ArrayTypeText(typeText)) {
           fieldCollectionKinds.set(fieldName, "Uint8Array");
         } else if (typeText.startsWith("Map<") || typeText === "Map") {
           fieldCollectionKinds.set(fieldName, "Map");
@@ -4346,7 +4355,7 @@ function collectModuleGlobals(ctx: LinearContext, sf: ts.SourceFile): void {
         const text = decl.type.getText();
         if (text.startsWith("Set<") || text === "Set") ctx.moduleCollectionTypes.set(name, "Set");
         else if (text.startsWith("Map<") || text === "Map") ctx.moduleCollectionTypes.set(name, "Map");
-        else if (text === "Uint8Array") ctx.moduleCollectionTypes.set(name, "Uint8Array");
+        else if (isUint8ArrayTypeText(text)) ctx.moduleCollectionTypes.set(name, "Uint8Array");
         else if (text.endsWith("[]") || text.startsWith("Array<")) ctx.moduleCollectionTypes.set(name, "Array");
       }
     }
@@ -4467,7 +4476,7 @@ function detectParamCollectionTypes(
     // Check explicit type annotation
     if (param.type) {
       const text = param.type.getText();
-      if (text === "number[] | Uint8Array" || text === "Uint8Array | number[]") {
+      if (isNumberArrayOrUint8ArrayUnionText(text)) {
         fctx.collectionTypes.set(paramName, "ArrayOrUint8Array");
         continue;
       }
@@ -4475,7 +4484,7 @@ function detectParamCollectionTypes(
         fctx.collectionTypes.set(paramName, "Array");
         continue;
       }
-      if (text === "Uint8Array") {
+      if (isUint8ArrayTypeText(text)) {
         fctx.collectionTypes.set(paramName, "Uint8Array");
         continue;
       }
@@ -4492,11 +4501,11 @@ function detectParamCollectionTypes(
     try {
       const type = ctx.checker.getTypeAtLocation(param);
       const typeStr = ctx.checker.typeToString(type);
-      if (typeStr === "number[] | Uint8Array" || typeStr === "Uint8Array | number[]") {
+      if (isNumberArrayOrUint8ArrayUnionText(typeStr)) {
         fctx.collectionTypes.set(paramName, "ArrayOrUint8Array");
         continue;
       }
-      if (typeStr === "Uint8Array") {
+      if (isUint8ArrayTypeText(typeStr)) {
         fctx.collectionTypes.set(paramName, "Uint8Array");
         continue;
       }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -136,6 +136,11 @@ export const TYPED_ARRAY_NAMES: ReadonlySet<string> = new Set([
   "Float64Array",
 ]);
 
+function typedArrayNameFromTypeNode(node: ts.TypeNode): string | null {
+  if (!ts.isTypeReferenceNode(node) || !ts.isIdentifier(node.typeName)) return null;
+  return TYPED_ARRAY_NAMES.has(node.typeName.text) ? node.typeName.text : null;
+}
+
 /**
  * (#1700) Classify a TS type at an export boundary for the runtime
  * `wrapExports` marshalling step. The Wasm signature for `Uint8Array` and
@@ -440,6 +445,14 @@ function resolvePositionType(
           const cs = classShapes.get(ref.text);
           if (cs) return { kind: "class", shape: cs };
         }
+      }
+      // TypedArray<TArrayBuffer> (TS 5.7+) carries an ArrayBufferLike type
+      // argument that is erased at runtime. Lower it exactly like the bare
+      // typed-array annotation.
+      if (typedArrayNameFromTypeNode(node)) {
+        const elemWasm: ValType = { kind: "f64" };
+        const vecIdx = getOrRegisterVecType(ctx, "f64", elemWasm);
+        return irVal({ kind: "ref_null", typeIdx: vecIdx });
       }
       // Slice 6 part 2 (#1181) — `Array<T>` TypeReferenceNode resolves
       // to a vec ref, parallel to the `T[]` ArrayTypeNode arm above.

--- a/tests/issue-1755.test.ts
+++ b/tests/issue-1755.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+
+function expectCompileSuccess(result: CompileResult): void {
+  expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
+}
+
+async function instantiateWithRuntime(result: CompileResult): Promise<WebAssembly.Instance> {
+  expectCompileSuccess(result);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return instance;
+}
+
+function instantiateNoImports(result: CompileResult): WebAssembly.Exports {
+  expectCompileSuccess(result);
+  return new WebAssembly.Instance(new WebAssembly.Module(result.binary), {}).exports;
+}
+
+describe("#1755 Uint8Array<ArrayBuffer> generic typed-array annotation", () => {
+  it("erases the generic argument in param, return, variable, and field positions", async () => {
+    const result = await compile(`
+      class Holder {
+        bytes: Uint8Array<ArrayBuffer>;
+
+        constructor(bytes: Uint8Array<ArrayBuffer>) {
+          this.bytes = bytes;
+        }
+
+        get(): Uint8Array<ArrayBuffer> {
+          const local: Uint8Array<ArrayBuffer> = this.bytes;
+          return local;
+        }
+      }
+
+      export function echo(input: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> {
+        const holder = new Holder(input);
+        return holder.get();
+      }
+    `);
+
+    expectCompileSuccess(result);
+    expect(result.exportSignatures?.echo).toEqual({
+      params: ["uint8array"],
+      result: "uint8array",
+    });
+
+    const instance = await instantiateWithRuntime(result);
+    const exports = wrapExports(instance.exports, { signatures: result.exportSignatures });
+    const out = exports.echo(new Uint8Array([7, 8, 9]));
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out as Uint8Array)).toEqual([7, 8, 9]);
+  });
+
+  it("accepts sibling typed-array generics as typed-array annotations", async () => {
+    const result = await compile(`
+      export function echoI32(input: Int32Array<ArrayBuffer>): Int32Array<ArrayBuffer> {
+        const local: Int32Array<ArrayBuffer> = input;
+        return local;
+      }
+
+      export function echoF64(input: Float64Array<ArrayBuffer>): Float64Array<ArrayBuffer> {
+        return input;
+      }
+    `);
+
+    expectCompileSuccess(result);
+    expect(result.exportSignatures?.echoI32).toEqual({
+      params: ["typed-array"],
+      result: "typed-array",
+    });
+    expect(result.exportSignatures?.echoF64).toEqual({
+      params: ["typed-array"],
+      result: "typed-array",
+    });
+  });
+
+  it("compiles the #389 encodeMessage shape with a generic Uint8Array return", async () => {
+    const result = await compile(`
+      const encoder: TextEncoder = new TextEncoder();
+
+      function encodeMessage(message: object): Uint8Array<ArrayBuffer> {
+        return encoder.encode(JSON.stringify(message));
+      }
+
+      export function encodedLength(): number {
+        return encodeMessage({ ok: true }).length;
+      }
+    `);
+
+    expectCompileSuccess(result);
+  });
+
+  it("accepts Uint8Array<ArrayBuffer> in standalone and WASI modes", async () => {
+    const source = `
+      export function encodedLength(): number {
+        const bytes: Uint8Array<ArrayBuffer> = new TextEncoder().encode("ok");
+        return bytes.length;
+      }
+    `;
+
+    for (const target of ["standalone", "wasi"] as const) {
+      const result = await compile(source, { fileName: `issue-1755-${target}.ts`, target });
+      const exports = instantiateNoImports(result) as { encodedLength: () => number };
+      expect(exports.encodedLength()).toBe(2);
+    }
+  });
+
+  it("accepts Uint8Array<ArrayBuffer> collection annotations in the linear backend", async () => {
+    const result = await compile(
+      `
+        class Holder {
+          bytes: Uint8Array<ArrayBuffer>;
+
+          constructor(bytes: Uint8Array<ArrayBuffer>) {
+            this.bytes = bytes;
+          }
+
+          get(): Uint8Array<ArrayBuffer> {
+            return this.bytes;
+          }
+        }
+
+        function firstPlusLength(input: Uint8Array<ArrayBuffer>): number {
+          return input[0] + input.length;
+        }
+
+        export function test(): number {
+          const bytes: Uint8Array<ArrayBuffer> = new Uint8Array(3);
+          bytes[0] = 40;
+          const holder = new Holder(bytes);
+          return firstPlusLength(holder.get());
+        }
+      `,
+      { target: "linear" },
+    );
+
+    const exports = instantiateNoImports(result) as { test: () => number };
+    expect(exports.test()).toBe(43);
+  });
+});


### PR DESCRIPTION
## Summary

- Erase TypeScript generic typed-array annotations such as `Uint8Array<ArrayBuffer>` in WasmGC position type resolution.
- Normalize the linear backend's `Uint8Array` annotation detection so generic forms keep the existing collection lowering.
- Add focused #1755 coverage for param, return, variable, field, sibling typed arrays, standalone/WASI, TextEncoder encode shape, and linear target behavior.

## Validation

- `npm test -- tests/issue-1755.test.ts`
- `npm test -- tests/issue-1700.test.ts tests/issue-1752.test.ts tests/issue-1755.test.ts`
- `npx prettier --check src/codegen/index.ts src/codegen-linear/index.ts tests/issue-1755.test.ts`
- Pre-push hook: typecheck + lint, format check, issue integrity

Co-authored-by: Codex <codex@openai.com>