### PR TITLE
fix(landing): show real standalone test262 rate (#1778)

### DIFF
--- a/plan/issues/1778-landing-standalone-test262-pass-rate-real-number.md
+++ b/plan/issues/1778-landing-standalone-test262-pass-rate-real-number.md
@@ -1,0 +1,126 @@
+---
+id: 1778
+title: "landing page JS-host toggle should show real standalone test262 pass rate"
+status: done
+created: 2026-06-02
+updated: 2026-06-02
+completed: 2026-06-02
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: landing-page
+language_feature: n/a
+goal: developer-experience
+es_edition: n/a
+related: [925, 959, 1201, 1583, 1662, 1777]
+sprint: 58
+origin: "Project lead report on 2026-06-02: when the JS host checkbox is unchecked on the landing page, the pass-rate stat should show the real standalone-mode test262 number instead of an estimate."
+---
+
+# #1778 - landing page JS-host toggle should show real standalone test262 pass rate
+
+## Problem
+
+The landing-page conformance view has a JS host checkbox next to the test262 pass-rate donut. When that checkbox is unchecked, the UI should show the real standalone-mode test262 pass count and pass percentage.
+
+Today the page appears to derive the no-host number by scaling the default JS-host pass count from feature-row host support:
+
+- hostOffPassScale() computes a ratio from feature row badges.
+- applyHostMode() applies that ratio to summary.pass.
+- The donut caption then labels the result as a standalone estimate.
+
+That is useful as a rough feature-level hint, but it is not the real standalone test262 result. The public pass-rate surface should not invent a standalone number when a measured standalone baseline is available or can be published.
+
+## Likely source
+
+The relevant page code is in website/index.html, especially:
+
+- #host-support-toggle
+- #compat-pass-rate / #compat-pass-rate-label when the headline stats are enabled
+- hydrateConformanceEditionFilter()
+- hostOffPassScale()
+- applyHostMode()
+- applyConformanceOptions()
+- window.updateConformanceDonut
+
+The current data fetch uses:
+
+https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json
+
+The fix likely needs a real standalone-mode baseline artifact, either in the same baselines payload or in a separate published JSON file. Do not infer standalone pass/fail counts from feature badges.
+
+## Acceptance criteria
+
+- With JS host checked, the landing page keeps showing the current default/JS-host test262 pass rate and count.
+- With JS host unchecked, the landing page shows the real standalone-mode test262 pass rate and count.
+- The donut, headline pass-rate stat, pass-count copy, and caption/subtitle all agree on the same selected mode.
+- The no-host label no longer presents the metric as a standalone estimate when real standalone data is being shown.
+- If real standalone data is unavailable, stale, or missing for the selected scope, the UI exposes an explicit unavailable/stale/fallback state instead of silently showing an invented estimate.
+- Strict-mode and edition/proposal scope filters continue to work with the selected host mode, or clearly document unsupported combinations in the UI behavior.
+- Add a focused DOM/browser regression check if the repo already has a suitable path; otherwise document manual verification by toggling JS host on the landing page.
+
+## Non-goals
+
+- Running a new full standalone test262 baseline inside this issue unless producing/publishing the data artifact is required for the UI fix.
+- Changing compiler behavior or standalone lowering semantics.
+- Reworking the entire feature table host-support model.
+
+## Implementation notes - 2026-06-02
+
+The worktree was missing this issue file, but it exists in planning commit
+`17c0fe7a236079fa2653b6e890e920536fb696a8`. Restored the issue file on this
+implementation branch before closing it.
+
+Root cause confirmed in `website/index.html`: host-off mode used
+`hostOffPassScale()` and `applyHostMode()` to multiply the JS-host pass count by
+a feature-row badge heuristic, then labelled the result as a standalone
+estimate. That violated the public data contract because the pass count was not
+from a standalone test262 run.
+
+Fix:
+
+- Removed the feature-row heuristic from the conformance donut path.
+- Added a standalone data loader that prefers embedded standalone fields in
+  `test262-current.json`, then tries a future baselines artifact at
+  `test262-standalone-current.json`, then falls back to the published local
+  `./benchmarks/results/test262-standalone-report.json`.
+- Added `website/public/benchmarks/results/test262-standalone-report.json` and
+  `public/benchmarks/results/test262-standalone-report.json` with the measured
+  Sprint 58 standalone result: 4,368 / 43,106 (10.1%) from
+  `test262-standalone-report-20260601-213702.json`.
+- Marked that summary artifact as `summary_only` because the full generated
+  standalone report/JSONL is not committed and the sprint notes preserved only
+  the measured pass/total summary. The donut maps the non-pass remainder into
+  the fail segment for geometry rather than inventing CE/skip buckets.
+- Added an explicit unavailable state for standalone strict/proposal/edition
+  scopes when no measured standalone summary exists for that selected scope.
+- Updated `scripts/build-pages.js` so the standalone report is copied into the
+  Pages artifact.
+
+Focused validation:
+
+```bash
+pnpm exec vitest run tests/issue-1778.test.ts
+```
+
+No full local test262 run was performed.
+
+## Codex verification update - 2026-06-02
+
+Confirmed the landing-page host-off conformance path no longer calls the
+feature-row heuristic and instead renders from standalone baseline data. Added a
+small follow-up hardening pass so stale standalone summaries render the explicit
+unavailable state, and so the optional headline pass-rate stat is updated from
+the same selected summary as the donut when that stat block is present.
+
+Focused validation:
+
+```bash
+pnpm exec vitest run tests/issue-1778.test.ts
+pnpm exec prettier --check tests/issue-1778.test.ts scripts/build-pages.js
+```
+
+`pnpm exec prettier --check website/index.html` still reports formatting drift
+for the full pre-existing HTML page, so no broad page reformat was applied. No
+full local test262 run was performed.

--- a/public/benchmarks/results/test262-standalone-report.json
+++ b/public/benchmarks/results/test262-standalone-report.json
@@ -1,0 +1,45 @@
+{
+  "timestamp": "2026-06-01T21:37:02Z",
+  "baseline_generated_at": "2026-06-01T21:37:02Z",
+  "mode": {
+    "target": "standalone",
+    "label": "standalone no-JS-host test262",
+    "summary_only": true
+  },
+  "summary": {
+    "total": 43106,
+    "pass": 4368,
+    "fail": 38738,
+    "compile_error": 0,
+    "compile_timeout": 0,
+    "skip": 0,
+    "compilable": 43106,
+    "stale": 0,
+    "summary_only": true
+  },
+  "official_summary": {
+    "total": 43106,
+    "pass": 4368,
+    "fail": 38738,
+    "compile_error": 0,
+    "compile_timeout": 0,
+    "skip": 0,
+    "compilable": 43106,
+    "stale": 0,
+    "summary_only": true
+  },
+  "source": {
+    "artifacts": [
+      "benchmarks/results/test262-standalone-report-20260601-213702.json",
+      "benchmarks/results/test262-standalone-results-20260601-213702.jsonl"
+    ],
+    "documented_in": [
+      "plan/issues/1776-standalone-issamevalue-externref-invalid-wasm.md",
+      "plan/issues/1472-no-js-host-object-property-ops.md",
+      "plan/issues/682-regexp-standalone-mode-native-engine.md",
+      "plan/issues/1599-json-standalone.md",
+      "plan/issues/1387-with-statement-dynamic-scope-implementation.md"
+    ],
+    "note": "The full generated artifacts are not committed; sprint 58 issue notes preserved the measured pass/total summary only."
+  }
+}

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -280,6 +280,12 @@ const test262ReportSource = resolvePreferredFile(
   join(BENCHMARKS_RESULTS_DIR, "test262-report.json"),
   latestNamedFile(BENCHMARKS_RESULTS_DIR, "test262-report-", ".json"),
 );
+const test262StandaloneReportSource = resolvePreferredFileOrNull(
+  join(PUBLIC_BENCH, "test262-standalone-report.json"),
+  join(BENCHMARKS_RESULTS_DIR, "test262-standalone-report.json"),
+  join(ROOT, "public", "benchmarks", "results", "test262-standalone-report.json"),
+  latestNamedFile(BENCHMARKS_RESULTS_DIR, "test262-standalone-report-", ".json"),
+);
 const test262ResultsSource = resolvePreferredFileOrNull(
   // #1528 — the JSONL is no longer committed; prefer the cache fetched
   // from `loopdive/js2wasm-baselines` if present, then the public/ copy
@@ -295,6 +301,9 @@ const test262RunsIndexSource = resolvePreferredFileOrNull(
   join(PUBLIC_BENCH, "runs", "index.json"),
 );
 copyFile(test262ReportSource, join(PAGES_DIST, "benchmarks", "results", "test262-report.json"));
+if (test262StandaloneReportSource) {
+  copyFile(test262StandaloneReportSource, join(PAGES_DIST, "benchmarks", "results", "test262-standalone-report.json"));
+}
 if (test262ResultsSource) {
   copyFile(test262ResultsSource, join(PAGES_DIST, "benchmarks", "results", "test262-results.jsonl"));
 }

--- a/tests/issue-1778.test.ts
+++ b/tests/issue-1778.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname ?? ".", "..");
+
+function readRepo(path: string): string {
+  return readFileSync(join(ROOT, path), "utf-8");
+}
+
+function snippetBetween(source: string, startNeedle: string, endNeedle: string): string {
+  const start = source.indexOf(startNeedle);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endNeedle, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("#1778 landing standalone test262 pass rate", () => {
+  it("does not derive standalone conformance from feature-row badge heuristics", () => {
+    const html = readRepo("website/index.html");
+
+    expect(html).not.toContain("hostOffPassScale");
+    expect(html).not.toContain("applyHostMode");
+    expect(html).not.toContain("standalone estimate");
+    expect(html).toContain("standalone conformance");
+    expect(html).toContain("getStandaloneSummary");
+    expect(html).toContain("renderUnavailable");
+  });
+
+  it("publishes the measured standalone summary used by the host-off toggle", () => {
+    const websiteReport = readRepo("website/public/benchmarks/results/test262-standalone-report.json");
+    const publicReport = readRepo("public/benchmarks/results/test262-standalone-report.json");
+    const report = JSON.parse(websiteReport);
+
+    expect(JSON.parse(publicReport)).toEqual(report);
+    expect(report.mode.target).toBe("standalone");
+    expect(report.mode.summary_only).toBe(true);
+    expect(report.summary.pass).toBe(4368);
+    expect(report.summary.total).toBe(43106);
+    expect(report.summary.fail).toBe(report.summary.total - report.summary.pass);
+    expect(((report.summary.pass / report.summary.total) * 100).toFixed(1)).toBe("10.1");
+    expect(report.source.artifacts).toContain("benchmarks/results/test262-standalone-report-20260601-213702.json");
+  });
+
+  it("landing page fetches real standalone data and exposes unavailable or stale states", () => {
+    const html = readRepo("website/index.html");
+
+    expect(html).toContain("test262-standalone-current.json");
+    expect(html).toContain("./benchmarks/results/test262-standalone-report.json");
+    expect(html).toContain("standalone_summary");
+    expect(html).toContain("No standalone test262 baseline has been published");
+    expect(html).toContain("Standalone test262 data is not available");
+    expect(html).toContain("summaryHasStaleResults");
+    expect(html).toContain("Standalone test262 data is stale");
+  });
+
+  it("host-off render path uses the standalone summary and keeps headline stats in sync", () => {
+    const html = readRepo("website/index.html");
+    const hostOffBranch = snippetBetween(
+      html,
+      "if (!options.hostEnabled) {",
+      "const { summary } = applyConformanceOptions",
+    );
+
+    expect(hostOffBranch).toContain("getStandaloneSummary(standaloneData, scope, options.strictOnly)");
+    expect(hostOffBranch).toContain("renderUnavailable(captionMain, options.captionSub, standalone.reason)");
+    expect(hostOffBranch).toContain("renderDonut(standalone.summary, captionMain, options.captionSub)");
+    expect(hostOffBranch).not.toContain("hostSummary");
+    expect(hostOffBranch).not.toContain("applySummaryRatios");
+    expect(html).toContain("updateHeadlineStat({ pass, fail, ce, skip, total }, captionMain, captionSub)");
+    expect(html).toContain("updateHeadlineUnavailable(captionMain, captionSub, detail)");
+    expect(html).toContain("window.__conformanceHeadlineHydrated");
+  });
+
+  it("pages build copies the standalone report into the deployed benchmark results", () => {
+    const buildPages = readRepo("scripts/build-pages.js");
+
+    expect(buildPages).toContain("test262StandaloneReportSource");
+    expect(buildPages).toContain("test262-standalone-report.json");
+  });
+});

--- a/website/index.html
+++ b/website/index.html
@@ -1064,6 +1064,34 @@
       .feat-toggle input {
         accent-color: var(--fg-soft);
       }
+      .conformance-unavailable {
+        min-height: 360px;
+        display: grid;
+        place-items: center;
+        max-width: 380px;
+        margin: 0 auto;
+        text-align: center;
+        color: var(--fg-faint);
+      }
+      .conformance-unavailable-value {
+        font-size: 2rem;
+        font-weight: 800;
+        color: var(--fg);
+        margin-bottom: 8px;
+      }
+      .conformance-unavailable-title {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-soft);
+      }
+      .conformance-unavailable-copy {
+        max-width: 280px;
+        margin-top: 10px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
       .feat-tables.strict-only .feat-row[data-sloppy] {
         display: none;
       }
@@ -4618,9 +4646,11 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const labelEl = document.getElementById("compat-pass-rate-label");
         if (!rateEl || !labelEl) return;
         try {
+          if (window.__conformanceHeadlineHydrated) return;
           const resp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!resp.ok) return;
           const report = await resp.json();
+          if (window.__conformanceHeadlineHydrated) return;
           // Use strict-mode summary (tests compatible with ES modules) when available
           const s = report?.strict_summary ?? report?.summary;
           const pass = Number(s?.pass ?? 0);
@@ -4853,8 +4883,14 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const editionTimeline = document.getElementById("conformance-edition-timeline");
         const strictToggle = document.getElementById("strict-only-toggle");
         const hostToggle = document.getElementById("host-support-toggle");
+        const rateEl = document.getElementById("compat-pass-rate");
+        const rateLabelEl = document.getElementById("compat-pass-rate-label");
         if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
 
+        const STANDALONE_TEST262_REPORT_URLS = [
+          "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
+          "./benchmarks/results/test262-standalone-report.json",
+        ];
         const donutStyle = "--t262-bg: var(--bg, #060a14)";
         const renderDonut = (summary, captionMain = "ECMAScript", captionSub = "conformance") => {
           const pass = Number(summary?.pass ?? 0);
@@ -4875,17 +4911,59 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           donut.setAttribute("caption-main", captionMain);
           donut.setAttribute("caption-sub", captionSub);
           donut.setAttribute("style", donutStyle);
+          updateHeadlineStat({ pass, fail, ce, skip, total }, captionMain, captionSub);
+        };
+        const renderUnavailable = (captionMain, captionSub, detail) => {
+          donutSlot.innerHTML = `
+            <div class="conformance-unavailable" role="status" aria-live="polite">
+              <div>
+                <div class="conformance-unavailable-value">Unavailable</div>
+                <div class="conformance-unavailable-title">${captionMain}</div>
+                <div class="conformance-unavailable-title">${captionSub}</div>
+                <div class="conformance-unavailable-copy">${detail}</div>
+              </div>
+            </div>
+          `;
+          updateHeadlineUnavailable(captionMain, captionSub, detail);
         };
         const normalizeSummary = (summary, fallback = {}) => {
           const pass = Number(summary?.pass ?? fallback.pass ?? 0);
-          const fail = Number(summary?.fail ?? fallback.fail ?? 0);
+          const skip = Number(summary?.skip ?? fallback.skip ?? 0);
           const ce =
             Number(summary?.ce ?? 0) ||
             Number(summary?.compile_error ?? 0) + Number(summary?.compile_timeout ?? 0) ||
             Number(fallback.ce ?? 0);
-          const skip = Number(summary?.skip ?? fallback.skip ?? 0);
-          const total = Number(summary?.total ?? fallback.total ?? pass + fail + ce + skip);
+          const explicitFail = Number(summary?.fail ?? fallback.fail);
+          const total = Number(
+            summary?.total ?? fallback.total ?? pass + (Number.isFinite(explicitFail) ? explicitFail : 0) + ce + skip,
+          );
+          const fail = Number.isFinite(explicitFail) ? explicitFail : Math.max(0, total - pass - ce - skip);
           return { pass, fail, ce, skip, total };
+        };
+        const updateHeadlineStat = (summary, captionMain, captionSub) => {
+          if (!rateEl || !rateLabelEl) return;
+          const pass = Number(summary?.pass ?? 0);
+          const total = Number(summary?.total ?? 0);
+          if (!Number.isFinite(pass) || !Number.isFinite(total) || total <= 0) return;
+          const pct = ((pass / total) * 100).toFixed(1);
+          window.__conformanceHeadlineHydrated = true;
+          rateEl.textContent = `${pct}%`;
+          rateLabelEl.textContent = `${captionMain} ${captionSub}: ${pass.toLocaleString()} / ${total.toLocaleString()} test262 tests passing`;
+        };
+        const updateHeadlineUnavailable = (captionMain, captionSub, detail) => {
+          if (!rateEl || !rateLabelEl) return;
+          window.__conformanceHeadlineHydrated = true;
+          rateEl.textContent = "Unavailable";
+          rateLabelEl.textContent = `${captionMain} ${captionSub}: ${detail}`;
+        };
+        const hasUsableSummary = (summary) => {
+          const pass = Number(summary?.pass ?? 0);
+          const total = Number(summary?.total ?? 0);
+          return Number.isFinite(pass) && Number.isFinite(total) && total > 0;
+        };
+        const summaryHasStaleResults = (summary) => {
+          const stale = Number(summary?.stale ?? 0);
+          return Number.isFinite(stale) && stale > 0;
         };
         const statusRatio = (filtered, base, key) => {
           const baseValue = Number(base?.[key] ?? 0);
@@ -4899,36 +4977,110 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           const skip = Math.round(summary.skip * ratios.skip);
           return { pass, fail, ce, skip, total: pass + fail + ce + skip };
         };
-        const featureRowScore = (row, hostEnabled) => {
-          const badge = row.querySelector(".feat-badge");
-          if (!badge) return 0;
-          if (!hostEnabled && row.querySelector(".feat-host")) return 0;
-          const savedClasses = badge.dataset.origClass || Array.from(badge.classList).join(" ");
-          const classNames = new Set(savedClasses.split(/\s+/).filter(Boolean));
-          if (classNames.has("full")) return 1;
-          if (classNames.has("partial")) return 0.5;
-          return 0;
+        const fetchJson = async (url) => {
+          const resp = await fetch(url);
+          if (!resp.ok) throw new Error(`unavailable: ${url}`);
+          return resp.json();
         };
-        const hostOffPassScale = () => {
-          const strictOnly = strictToggle ? strictToggle.checked : false;
-          const rows = Array.from(document.querySelectorAll(".feat-row")).filter(
-            (row) => !(strictOnly && row.hasAttribute("data-sloppy")),
-          );
-          const hostOnScore = rows.reduce((sum, row) => sum + featureRowScore(row, true), 0);
-          if (hostOnScore <= 0) return 1;
-          const hostOffScore = rows.reduce((sum, row) => sum + featureRowScore(row, false), 0);
-          return Math.max(0, Math.min(1, hostOffScore / hostOnScore));
+        const standalonePayloadFromHostReport = (report) => {
+          if (report?.standalone?.summary || report?.standalone?.official_summary) {
+            return report.standalone;
+          }
+          if (report?.standalone_summary || report?.standalone_full_summary || report?.standalone_strict_summary) {
+            return {
+              summary: report.standalone_summary,
+              official_summary: report.standalone_summary,
+              full_summary: report.standalone_full_summary,
+              strict_summary: report.standalone_strict_summary,
+              edition_summaries: report.standalone_edition_summaries,
+            };
+          }
+          return null;
         };
-        const applyHostMode = (summary) => {
-          const hostEnabled = hostToggle ? hostToggle.checked : true;
-          if (hostEnabled) return summary;
-          const nextPass = Math.round(summary.pass * hostOffPassScale());
-          const movedToFail = Math.max(0, summary.pass - nextPass);
-          return {
-            ...summary,
-            pass: nextPass,
-            fail: summary.fail + movedToFail,
-          };
+        const loadStandaloneReport = async (hostReport) => {
+          const embedded = standalonePayloadFromHostReport(hostReport);
+          if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
+            return { report: embedded, source: "test262-current.json" };
+          }
+          for (const url of STANDALONE_TEST262_REPORT_URLS) {
+            try {
+              const report = await fetchJson(url);
+              if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
+                return { report, source: url };
+              }
+            } catch {
+              // Try the next configured source.
+            }
+          }
+          return null;
+        };
+        const getNamedSummary = (report, names) => {
+          for (const name of names) {
+            if (hasUsableSummary(report?.[name])) return report[name];
+          }
+          return null;
+        };
+        const getStandaloneEditionSummary = (report, scope, strictOnly) => {
+          const editionMaps = [
+            strictOnly ? report?.strict_edition_summaries : null,
+            strictOnly ? report?.standalone_strict_edition_summaries : null,
+            report?.edition_summaries,
+            report?.standalone_edition_summaries,
+          ].filter(Boolean);
+          for (const map of editionMaps) {
+            const candidate = map?.[scope] ?? map?.[normalizeEditionLabel(scope)];
+            if (hasUsableSummary(candidate)) return candidate;
+          }
+
+          const editionRows = [
+            strictOnly ? report?.strict_editions : null,
+            strictOnly ? report?.standalone_strict_editions : null,
+            report?.editions,
+            report?.standalone_editions,
+          ].filter(Array.isArray);
+          for (const rows of editionRows) {
+            const candidate = rows.find((row) => {
+              const label = String(row?.edition ?? row?.rawEdition ?? row?.label ?? "");
+              return label === scope || normalizeEditionLabel(label) === normalizeEditionLabel(scope);
+            });
+            if (hasUsableSummary(candidate)) return candidate;
+          }
+          return null;
+        };
+        const getStandaloneSummary = (standaloneData, scope, strictOnly) => {
+          if (!standaloneData?.report) {
+            return {
+              summary: null,
+              reason: "No standalone test262 baseline has been published for this build.",
+            };
+          }
+          const report = standaloneData.report;
+          let summary = null;
+          if (scope === "overall") {
+            summary = strictOnly
+              ? getNamedSummary(report, ["strict_summary", "standalone_strict_summary"])
+              : getNamedSummary(report, ["summary", "official_summary", "standalone_summary"]);
+          } else if (scope === "overall+proposal") {
+            summary = strictOnly
+              ? getNamedSummary(report, ["strict_full_summary", "standalone_strict_full_summary"])
+              : getNamedSummary(report, ["full_summary", "standalone_full_summary"]);
+          } else {
+            summary = getStandaloneEditionSummary(report, scope, strictOnly);
+          }
+
+          if (!hasUsableSummary(summary)) {
+            return {
+              summary: null,
+              reason: `Standalone test262 data is not available for ${strictOnly ? "strict " : ""}${scope} scope yet.`,
+            };
+          }
+          if (summaryHasStaleResults(summary)) {
+            return {
+              summary: null,
+              reason: `Standalone test262 data is stale for ${strictOnly ? "strict " : ""}${scope} scope.`,
+            };
+          }
+          return { summary: normalizeSummary(summary), reason: "", source: standaloneData.source };
         };
 
         try {
@@ -4957,6 +5109,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             withProposal.ce !== overall.ce ||
             withProposal.skip !== overall.skip ||
             withProposal.total !== overall.total;
+          const standaloneData = await loadStandaloneReport(report);
 
           let lastDetail = null;
           const conformanceOptions = () => {
@@ -4967,12 +5120,12 @@ console.log(instance.exports.run()); // &rarr; 55</pre
               hostEnabled,
               captionSub:
                 strictOnly && !hostEnabled
-                  ? "strict standalone estimate"
+                  ? "strict standalone conformance"
                   : strictOnly
                     ? "strict conformance"
                     : hostEnabled
                       ? "conformance"
-                      : "standalone estimate",
+                      : "standalone conformance",
             };
           };
           const applyConformanceOptions = (summary, { exactStrictSummary = null } = {}) => {
@@ -4985,7 +5138,21 @@ console.log(instance.exports.run()); // &rarr; 55</pre
                   ? applySummaryRatios(next, strictRatios)
                   : next;
             }
-            return { summary: applyHostMode(next), options };
+            return { summary: next, options };
+          };
+          const renderSelectedConformance = (scope, hostSummary, captionMain, { exactStrictSummary = null } = {}) => {
+            const options = conformanceOptions();
+            if (!options.hostEnabled) {
+              const standalone = getStandaloneSummary(standaloneData, scope, options.strictOnly);
+              if (!standalone.summary) {
+                renderUnavailable(captionMain, options.captionSub, standalone.reason);
+                return;
+              }
+              renderDonut(standalone.summary, captionMain, options.captionSub);
+              return;
+            }
+            const { summary } = applyConformanceOptions(hostSummary, { exactStrictSummary });
+            renderDonut(summary, captionMain, options.captionSub);
           };
           const applyScopeFromDetail = (detail) => {
             if (!detail) return;
@@ -4997,22 +5164,19 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             const currentScope = detail.scope || "overall";
             window.__conformanceEditionScope = currentScope;
             if (currentScope === "overall") {
-              const { summary, options } = applyConformanceOptions(overall, { exactStrictSummary: strictSummary });
-              renderDonut(summary, "ECMAScript", options.captionSub);
+              renderSelectedConformance("overall", overall, "ECMAScript", { exactStrictSummary: strictSummary });
               applyFeatureEditionScope("overall");
               return;
             }
             if (currentScope === "overall+proposal") {
-              const { summary, options } = applyConformanceOptions(withProposal);
-              renderDonut(summary, "ECMAScript + proposals", options.captionSub);
+              renderSelectedConformance("overall+proposal", withProposal, "ECMAScript + proposals");
               applyFeatureEditionScope("overall+proposal");
               return;
             }
 
             const scope = detail.scopeMap instanceof Map ? detail.scopeMap.get(currentScope) : null;
             if (!scope) return;
-            const { summary, options } = applyConformanceOptions(scope.summary);
-            renderDonut(summary, scope.captionMain, options.captionSub);
+            renderSelectedConformance(currentScope, scope.summary, scope.captionMain);
             applyFeatureEditionScope(currentScope);
           };
           window.updateConformanceDonut = () => {

--- a/website/public/benchmarks/results/test262-standalone-report.json
+++ b/website/public/benchmarks/results/test262-standalone-report.json
@@ -1,0 +1,45 @@
+{
+  "timestamp": "2026-06-01T21:37:02Z",
+  "baseline_generated_at": "2026-06-01T21:37:02Z",
+  "mode": {
+    "target": "standalone",
+    "label": "standalone no-JS-host test262",
+    "summary_only": true
+  },
+  "summary": {
+    "total": 43106,
+    "pass": 4368,
+    "fail": 38738,
+    "compile_error": 0,
+    "compile_timeout": 0,
+    "skip": 0,
+    "compilable": 43106,
+    "stale": 0,
+    "summary_only": true
+  },
+  "official_summary": {
+    "total": 43106,
+    "pass": 4368,
+    "fail": 38738,
+    "compile_error": 0,
+    "compile_timeout": 0,
+    "skip": 0,
+    "compilable": 43106,
+    "stale": 0,
+    "summary_only": true
+  },
+  "source": {
+    "artifacts": [
+      "benchmarks/results/test262-standalone-report-20260601-213702.json",
+      "benchmarks/results/test262-standalone-results-20260601-213702.jsonl"
+    ],
+    "documented_in": [
+      "plan/issues/1776-standalone-issamevalue-externref-invalid-wasm.md",
+      "plan/issues/1472-no-js-host-object-property-ops.md",
+      "plan/issues/682-regexp-standalone-mode-native-engine.md",
+      "plan/issues/1599-json-standalone.md",
+      "plan/issues/1387-with-statement-dynamic-scope-implementation.md"
+    ],
+    "note": "The full generated artifacts are not committed; sprint 58 issue notes preserved the measured pass/total summary only."
+  }
+}


### PR DESCRIPTION
## Summary
- use measured standalone test262 data for the landing page JS-host-off pass-rate display
- publish the standalone summary artifact into the Pages output path
- add focused regression coverage for the standalone conformance summary path

## Checks
- pnpm exec vitest run tests/issue-1778.test.ts
- pnpm exec prettier --check tests/issue-1778.test.ts scripts/build-pages.js
- pre-push: typecheck + lint, format:check, issue integrity

Generated by Symphony/Codex.