### PR TITLE
fix(website): pin public benchmarks to JS host

### DIFF
--- a/.claude/hooks/check-worktree-path.sh
+++ b/.claude/hooks/check-worktree-path.sh
@@ -23,9 +23,9 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
-# Only intercept `git worktree add`. Other worktree subcommands and any
-# non-git command pass through.
-if ! echo "$CMD" | grep -qE '(^|[;&|])[[:space:]]*git[[:space:]]+worktree[[:space:]]+add'; then
+# Only intercept `git worktree add` (including `git -C <dir> worktree add`).
+# Other worktree subcommands and any non-git command pass through.
+if ! echo "$CMD" | grep -qE '(^|[;&|])[[:space:]]*git([[:space:]][^;&|]+)*[[:space:]]+worktree[[:space:]]+add'; then
   exit 0
 fi
 

--- a/.claude/hooks/provision-worktree.sh
+++ b/.claude/hooks/provision-worktree.sh
@@ -1,30 +1,21 @@
 #!/bin/sh
-# Provision agent worktrees with node_modules so the pre-push hooks
-# (typecheck, prettier format:check, lint) actually run.
+# PostToolUse hook: provision new worktrees with shared heavyweight deps.
 #
-# Why: agent worktrees are created with `git worktree add` and come up WITHOUT
-# node_modules. The pre-push hook then errors ("tsc: not found"), so agents
-# `--no-verify` past it — which also skips lint-staged + format:check, so
-# formatting / type drift reaches CI instead of being caught locally (see the
-# #914 prettier-drift miss, 2026-05-29). Symlinking the main checkout's
-# node_modules into each worktree is fast (no per-worktree install) and gives
-# the worktree the SAME pinned tool versions as CI (npx-fetched versions can
-# format differently).
-#
-# Wired as a PostToolUse hook on `git worktree add`; also safe to run manually.
-# Scans all worktrees and symlinks node_modules where missing (idempotent).
+# Wired on `git worktree add`; also safe to run manually. Delegates to the
+# repo script so agent worktrees, Codex worktrees, and test worktrees share the
+# same behavior.
 
-MAIN="/workspace"
-[ -d "$MAIN/node_modules" ] || exit 0   # nothing to share yet
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/provision-worktree-deps.sh"
 
-# Enumerate worktrees from the main checkout; symlink node_modules where absent.
-git -C "$MAIN" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' | while read -r wt; do
-  [ "$wt" = "$MAIN" ] && continue
-  [ -d "$wt" ] || continue
-  # Skip if node_modules already present (real dir OR existing symlink).
-  [ -e "$wt/node_modules" ] && continue
-  if ln -s "$MAIN/node_modules" "$wt/node_modules" 2>/dev/null; then
-    echo "[provision-worktree] linked node_modules -> $wt"
-  fi
-done
+if [ -x "$SCRIPT" ]; then
+  exec "$SCRIPT"
+fi
+
+if [ -f "$SCRIPT" ]; then
+  exec sh "$SCRIPT"
+fi
+
+echo "[provision-worktree] missing $SCRIPT; skipping"
 exit 0

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,6 +12,7 @@
 - **NEVER force-push or rewrite published history on public `main`** — append-only; fix forward via revert PRs (it already broke guest271314's pull). See [feedback_public_main_append_only.md](feedback_public_main_append_only.md).
 - **NEVER merge an external-contributor PR without a recorded affirmative CLA acceptance** — `cla-check.yml` is a placeholder stub; hold guest271314's #589 until a real CLA accept. See [feedback_cla_gate.md](feedback_cla_gate.md).
 - **Mimic standard Node.js / Web Worker APIs; never invent bespoke compiler builtins** (no `readStdin`/`writeStdout`). See [feedback_mimic_node_worker_apis.md](feedback_mimic_node_worker_apis.md).
+- **PR titles and Codex commits use repo convention** — PR titles are `type(scope): concise summary` without `[codex]`; Codex-authored commits include `Co-authored-by: Codex <codex@openai.com>`. See [feedback_pr_title_coauthor_conventions.md](feedback_pr_title_coauthor_conventions.md).
 
 ## Single source of truth
 - Team setup, memory budget, spawn config, communication protocol: **`plan/method/team-setup.md`**
@@ -70,6 +71,7 @@
 ### Testing
 - [feedback_trigger_deploy_pages.md](feedback_trigger_deploy_pages.md) — After any [skip ci] baseline refresh, manually trigger deploy-pages.yml so GitHub Pages shows the new pass rate
 - [feedback_test262_worktree.md](feedback_test262_worktree.md) — Test262 in worktree, not main wc
+- [feedback_worktree_symlink_dependencies.md](feedback_worktree_symlink_dependencies.md) — Symlink `test262` and `node_modules` into new worktrees
 - [feedback_test262_recheck.md](feedback_test262_recheck.md) — Default --recheck for test262, npm test for vitest
 - [feedback_test262_skip_issues.md](feedback_test262_skip_issues.md) — Every skip filter must have an issue
 - [feedback_never_delete_test_data.md](feedback_never_delete_test_data.md) — Never delete test data/cache/runs without asking

--- a/.claude/memory/feedback_pr_title_coauthor_conventions.md
+++ b/.claude/memory/feedback_pr_title_coauthor_conventions.md
@@ -7,7 +7,8 @@ description: "Follow project PR title conventions and add Codex co-author traile
 
 When creating or updating PRs in this project, follow the established project PR
 title style: a specific conventional-commit-style title such as
-`fix(scope): concise summary` that names the real change.
+`fix(scope): concise summary` that names the real change. Do not prefix PR
+titles with `[codex]`.
 
 For Codex-authored commits/PR updates, include a co-author trailer for Codex:
 

--- a/.claude/memory/feedback_worktree_symlink_dependencies.md
+++ b/.claude/memory/feedback_worktree_symlink_dependencies.md
@@ -1,0 +1,25 @@
+---
+name: feedback_worktree_symlink_dependencies
+description: Symlink heavyweight local dependencies when creating worktrees
+type: feedback
+---
+
+When creating a repo worktree, always symlink heavyweight local dependencies
+from the canonical workspace instead of leaving empty directories:
+
+- `test262`
+- `node_modules`
+
+**Why:** Page builds, edition generation, test262 tooling, and local package
+scripts expect populated `test262/test` and installed dependencies. Empty
+directories make validation fail later with misleading "missing checkout" or
+"node_modules missing" errors.
+
+**How to apply:** The automatic path is
+`scripts/provision-worktree-deps.sh`, wired through
+`.claude/hooks/provision-worktree.sh` after `git worktree add`. Run
+`pnpm run worktree:provision` manually to repair existing worktrees. Since
+`test262` is a git submodule path, keep `test262/` as a directory and symlink
+its populated contents from the canonical workspace; `node_modules` can be a
+direct symlink. If the canonical workspace does not have `test262` or
+`node_modules` populated yet, initialize/install them there first.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,7 +114,7 @@
       },
       {
         "matcher": "Bash",
-        "if": "Bash(git worktree add*)",
+        "if": "Bash(*worktree add*)",
         "hooks": [
           {
             "type": "command",
@@ -157,7 +157,7 @@
       },
       {
         "matcher": "Bash",
-        "if": "Bash(git worktree add*)",
+        "if": "Bash(*worktree add*)",
         "hooks": [
           {
             "type": "command",

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Current Test262 conformance and benchmark numbers are tracked in one place and
 change frequently — see **[STATUS.md](./STATUS.md)** for the live figures, the
 [Playground](https://loopdive.github.io/js2wasm/playground/), and the
 [Roadmap](./ROADMAP.md). The single auto-updated conformance figure (refreshed
-by CI on every merge) is below; everything else links to STATUS.md rather than
-duplicating numbers that go stale.
+by CI on every merge) is for the JS-host path; everything else links to
+STATUS.md rather than duplicating numbers that go stale. Standalone
+(no-JS-host) pass-rate and benchmark figures are intentionally omitted from the
+README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
 **test262 conformance**: 30,214 / 43,135 (70.0 %) — baseline 9ee8e921, 2026-05-29T00:58:42Z
@@ -69,8 +71,8 @@ standalone path are all still hardening. What exists today:
   [STATUS.md](./STATUS.md) for the current figure)
 - a public browser playground
 - continuous conformance and benchmark reporting on every change
-- a standalone (no-JS-host) path that is in progress and not yet the primary
-  conformance target
+- a standalone (no-JS-host) path that is in progress; its public numeric
+  baselines are paused here until the current regression is fixed
 
 Treat it as a tech demo to evaluate the approach, not as something to deploy.
 
@@ -299,8 +301,8 @@ arbitrary real-world npm package runs unchanged.
 - standard-library built-ins — many are implemented, but not the full surface;
   some methods are missing or only handle the common overloads
 - `Map`, `Set`, `RegExp`, `JSON` — present but not fully spec-complete
-- standalone (no-JS-host) mode — actively in progress; conformance there is
-  lower than the JS-host figure and it is not yet the primary path
+- standalone (no-JS-host) mode — actively in progress; standalone numeric
+  baselines are temporarily omitted here while the current regression is fixed
 - getters/setters and other highly dynamic patterns — limited
 
 **Not yet** (intentionally unsupported or out of scope today):
@@ -331,9 +333,9 @@ Yes, and the live figure is in [STATUS.md](./STATUS.md) and the
 [Test262 report](./benchmarks/results/report.html) rather than rounded up here.
 Two caveats matter more than the number: Test262 measures the ECMAScript
 *language* spec, **not** Web APIs, host/Node.js behavior, or whether an arbitrary
-npm package runs unchanged; and the standalone (no-JS-host) path is less complete
-than the JS-host path. A high pass rate is necessary but not sufficient for "runs
-real JavaScript."
+npm package runs unchanged; and standalone (no-JS-host) figures are omitted here
+until the current regression is fixed. A high pass rate is necessary but not
+sufficient for "runs real JavaScript."
 
 **Won't you eventually re-implement a JavaScript engine?**
 That is the real risk, treated as an empirical question, not a solved one. The

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "scripts": {
     "new:issue-id": "node scripts/next-issue-id.mjs",
+    "worktree:provision": "bash scripts/provision-worktree-deps.sh",
     "build": "vite build --config vite.config.lib.ts",
     "build:playground": "vite build --config website/playground/vite.config.ts",
     "dev": "pnpm run build:compiler-bundle && (pnpm run dashboard:watch &) && vite serve --config website/playground/vite.config.ts",

--- a/scripts/equivalence-gate.mjs
+++ b/scripts/equivalence-gate.mjs
@@ -35,6 +35,9 @@ const UPDATE = args.includes("--update");
 const SHARD = process.env.SHARD || ""; // e.g. "1/8"
 // When merging shard partials instead of running vitest directly.
 const MERGE_DIR = process.env.MERGE_PARTIALS_DIR || "";
+// Equivalence shards can peak around 1 GB; regular vitest runs keep the
+// repository default 512 MB fork heap unless they opt in through this env var.
+const EQUIVALENCE_FORK_HEAP_MB = process.env.EQUIVALENCE_FORK_HEAP_MB || "1024";
 
 /** Stable id for a test: "<relative file> :: <full test name>". */
 function testId(fileRelPath, fullName) {
@@ -65,7 +68,11 @@ function runVitest() {
     cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "inherit", "inherit"],
-    env: { ...process.env, CI: "1" },
+    env: {
+      ...process.env,
+      CI: "1",
+      VITEST_FORK_MAX_OLD_SPACE_SIZE: process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || EQUIVALENCE_FORK_HEAP_MB,
+    },
     maxBuffer: 256 * 1024 * 1024,
   });
   // vitest exits non-zero on test failures — that's expected; we parse the report.

--- a/scripts/provision-worktree-deps.sh
+++ b/scripts/provision-worktree-deps.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# Symlink heavyweight local dependencies into git worktrees.
+#
+# Usage:
+#   scripts/provision-worktree-deps.sh [worktree ...]
+#
+# With no worktree arguments, all registered worktrees for the canonical
+# workspace are scanned. Existing populated directories are left untouched;
+# empty placeholder directories are replaced with symlinks.
+
+set -u
+
+say() {
+  echo "[provision-worktree-deps] $*"
+}
+
+resolve_repo() {
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null || true
+}
+
+SOURCE_ROOT="${JS2_WORKTREE_SOURCE:-}"
+if [ -n "$SOURCE_ROOT" ]; then
+  SOURCE_ROOT="$(resolve_repo "$SOURCE_ROOT")"
+fi
+if [ -z "$SOURCE_ROOT" ] && [ -d /workspace ]; then
+  SOURCE_ROOT="$(resolve_repo /workspace)"
+fi
+if [ -z "$SOURCE_ROOT" ]; then
+  SOURCE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [ -z "$SOURCE_ROOT" ]; then
+  say "no git repo found; skipping"
+  exit 0
+fi
+
+is_empty_dir() {
+  [ -d "$1" ] && [ ! -L "$1" ] && [ -z "$(find "$1" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]
+}
+
+dep_available() {
+  case "$1" in
+    node_modules) [ -d "$SOURCE_ROOT/node_modules" ] ;;
+    test262) [ -d "$SOURCE_ROOT/test262/test" ] ;;
+    *) return 1 ;;
+  esac
+}
+
+link_dep() {
+  wt="$1"
+  dep="$2"
+  src="$SOURCE_ROOT/$dep"
+  dst="$wt/$dep"
+
+  dep_available "$dep" || {
+    say "source $dep unavailable at $src; skipping"
+    return 0
+  }
+
+  [ "$wt" = "$SOURCE_ROOT" ] && return 0
+  [ -d "$wt" ] || return 0
+
+  if [ "$dep" = "test262" ]; then
+    link_test262 "$wt" "$src" "$dst"
+    return 0
+  fi
+
+  if [ -L "$dst" ]; then
+    current="$(readlink "$dst" 2>/dev/null || true)"
+    if [ "$current" = "$src" ]; then
+      return 0
+    fi
+    say "leaving existing $dep symlink in $wt -> $current"
+    return 0
+  fi
+
+  if [ -e "$dst" ]; then
+    if is_empty_dir "$dst"; then
+      rmdir "$dst" 2>/dev/null || {
+        say "could not remove empty $dst; skipping"
+        return 0
+      }
+    else
+      say "leaving existing non-empty $dst"
+      return 0
+    fi
+  fi
+
+  if ln -s "$src" "$dst" 2>/dev/null; then
+    say "linked $dep -> $wt"
+  else
+    say "failed to link $dep into $wt"
+  fi
+}
+
+link_test262() {
+  wt="$1"
+  src="$2"
+  dst="$3"
+
+  if [ -L "$dst" ]; then
+    rm "$dst" 2>/dev/null || {
+      say "could not remove $dst symlink; skipping"
+      return 0
+    }
+  fi
+
+  if [ -e "$dst" ] && [ ! -d "$dst" ]; then
+    say "leaving existing non-directory $dst"
+    return 0
+  fi
+
+  mkdir -p "$dst" 2>/dev/null || {
+    say "could not create $dst; skipping"
+    return 0
+  }
+
+  linked=0
+  for entry in "$src"/* "$src"/.[!.]* "$src"/..?*; do
+    [ -e "$entry" ] || continue
+    base="$(basename "$entry")"
+    [ "$base" = "." ] && continue
+    [ "$base" = ".." ] && continue
+    [ "$base" = ".git" ] && continue
+    [ -e "$dst/$base" ] || [ -L "$dst/$base" ] && continue
+    if ln -s "$entry" "$dst/$base" 2>/dev/null; then
+      linked=$((linked + 1))
+    fi
+  done
+
+  if [ "$linked" -gt 0 ]; then
+    say "linked test262 contents -> $wt"
+  fi
+}
+
+provision_one() {
+  wt="$1"
+  link_dep "$wt" node_modules
+  link_dep "$wt" test262
+}
+
+if [ "$#" -gt 0 ]; then
+  for wt in "$@"; do
+    provision_one "$wt"
+  done
+else
+  git -C "$SOURCE_ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' | while read -r wt; do
+    provision_one "$wt"
+  done
+fi
+
+exit 0

--- a/scripts/run-test262-retro.sh
+++ b/scripts/run-test262-retro.sh
@@ -63,9 +63,7 @@ run_one() {
   git -C "$ROOT_DIR" worktree add "$wt" "$commit" --detach --quiet
   trap 'git -C "$ROOT_DIR" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"' RETURN
 
-  rm -rf "$wt/node_modules" "$wt/test262"
-  ln -s "$ROOT_DIR/node_modules" "$wt/node_modules"
-  ln -s "$ROOT_DIR/test262" "$wt/test262"
+  bash "$ROOT_DIR/scripts/provision-worktree-deps.sh" "$wt"
 
   mkdir -p "$wt/benchmarks"
   rm -rf "$wt/benchmarks/results"

--- a/scripts/run-test262-vitest.sh
+++ b/scripts/run-test262-vitest.sh
@@ -146,9 +146,7 @@ fi
 
 # Symlink heavy directories to avoid duplication
 if [ "$USE_WORKTREE" = "1" ]; then
-  rm -rf "$WT_DIR/node_modules" "$WT_DIR/test262"
-  ln -s "$MAIN_DIR/node_modules" "$WT_DIR/node_modules"
-  ln -s "$MAIN_DIR/test262" "$WT_DIR/test262"
+  bash "$MAIN_DIR/scripts/provision-worktree-deps.sh" "$WT_DIR"
 fi
 
 # Verify symlinks

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+const forkMaxOldSpaceSize = process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || "512";
+
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
@@ -12,7 +14,7 @@ export default defineConfig({
         singleFork: false,
         maxForks: 1,
         minForks: 0,
-        execArgv: ["--max-old-space-size=512", "--expose-gc"],
+        execArgv: [`--max-old-space-size=${forkMaxOldSpaceSize}`, "--expose-gc"],
       },
     },
     // Lets describe.concurrent tests run up to 32 at once — CompilerPool limits

--- a/website/index.html
+++ b/website/index.html
@@ -1616,10 +1616,12 @@
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
+              <!-- JS-host switch retained for later re-enable; disabled while standalone regression is fixed.
               <label class="feat-toggle">
                 <input type="checkbox" id="host-support-toggle" checked />
                 <span>JS host</span>
               </label>
+              -->
               <label class="feat-toggle">
                 <input type="checkbox" id="strict-only-toggle" />
                 <span>Strict mode</span>
@@ -3259,7 +3261,9 @@ match (value) {
             both runtimes to their baseline tier — the no-optimizing-JIT execution path that matters for cold-start,
             multi-tenant edge runtimes, and engines without a top tier. The right chart is the production setup — both
             runtimes use their full optimizing pipeline. Press the button to run the benchmark in your browser including
-            additional DOM benchmarks.
+            additional DOM benchmarks. These public website benchmarks run in a JS host: the compiled Wasm is
+            instantiated by the js2wasm JavaScript runtime and compared with the same source running in V8.
+            Standalone/WASI benchmark figures are hidden until the current regression is fixed.
           </p>
           <div class="conformance-diagrams">
             <div class="diagram-panel">
@@ -3882,8 +3886,9 @@ console.log(instance.exports.run()); // &rarr; 55</pre
                   <strong>not</strong>
                   cover Web APIs, Node.js or other host behavior, or whether an arbitrary real-world npm package runs
                   unchanged. A high pass rate is necessary but not sufficient for &ldquo;runs real JavaScript.&rdquo;
-                  Second, the standalone (no-JS-host) path is less complete than the JS-host path. Check the per-feature
-                  report before relying on anything specific.
+                  Second, the public website figures are currently pinned to the JS-host path; standalone
+                  (no-JS-host) figures are hidden until the current regression is fixed. Check the per-feature report
+                  before relying on anything specific.
                 </p>
               </div>
             </details>
@@ -4050,6 +4055,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
     <script type="module" src="./components/site-nav.js"></script>
     <script type="module" src="./components/t262-charts.js"></script>
     <script type="module" src="./components/perf-benchmark-chart.js"></script>
+    <!-- Standalone/WASI benchmark loader retained for later re-enable; disabled while standalone regression is fixed.
     <script>
       (async () => {
         const group = document.getElementById("wasmtime-bench-group");
@@ -4079,6 +4085,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         }
       })();
     </script>
+    -->
     <script src="./components/trend-chart.js"></script>
 
     <script>
@@ -4588,7 +4595,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
       // Feature table toggles
       (function () {
         const strictToggle = document.getElementById("strict-only-toggle");
-        const hostToggle = document.getElementById("host-support-toggle");
+        // const hostToggle = document.getElementById("host-support-toggle");
         const tables = document.querySelector(".feat-tables");
         if (tables) {
           const hostRows = Array.from(document.querySelectorAll(".feat-row")).filter((row) =>
@@ -4604,21 +4611,24 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           });
           const sync = () => {
             if (strictToggle) tables.classList.toggle("strict-only", strictToggle.checked);
-            if (hostToggle) tables.classList.toggle("host-off", !hostToggle.checked);
-            const hostEnabled = hostToggle ? hostToggle.checked : true;
+            // if (hostToggle) tables.classList.toggle("host-off", !hostToggle.checked);
+            // const hostEnabled = hostToggle ? hostToggle.checked : true;
             hostRows.forEach((row) => {
               const badge = row.querySelector(".feat-badge");
               if (!(badge instanceof HTMLElement)) return;
               const origClass = badge.dataset.origClass || "";
               const origText = badge.dataset.origText || "";
               badge.className = "feat-badge";
-              if (hostEnabled) {
-                if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
-                badge.textContent = origText;
-              } else {
-                badge.classList.add("none");
-                badge.textContent = "×";
-              }
+              // JS-host switch branch retained for later re-enable:
+              // if (hostEnabled) {
+              //   if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
+              //   badge.textContent = origText;
+              // } else {
+              //   badge.classList.add("none");
+              //   badge.textContent = "×";
+              // }
+              if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
+              badge.textContent = origText;
             });
             if (typeof window.updateEditionPassBars === "function") {
               window.updateEditionPassBars();
@@ -4629,7 +4639,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           };
           sync();
           strictToggle?.addEventListener("change", sync);
-          hostToggle?.addEventListener("change", sync);
+          // hostToggle?.addEventListener("change", sync);
         }
       })();
 
@@ -4882,15 +4892,11 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const donutSlot = document.getElementById("conformance-donut-slot");
         const editionTimeline = document.getElementById("conformance-edition-timeline");
         const strictToggle = document.getElementById("strict-only-toggle");
-        const hostToggle = document.getElementById("host-support-toggle");
+        // const hostToggle = document.getElementById("host-support-toggle");
         const rateEl = document.getElementById("compat-pass-rate");
         const rateLabelEl = document.getElementById("compat-pass-rate-label");
         if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
 
-        const STANDALONE_TEST262_REPORT_URLS = [
-          "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
-          "./benchmarks/results/test262-standalone-report.json",
-        ];
         const donutStyle = "--t262-bg: var(--bg, #060a14)";
         const renderDonut = (summary, captionMain = "ECMAScript", captionSub = "conformance") => {
           const pass = Number(summary?.pass ?? 0);
@@ -4912,19 +4918,6 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           donut.setAttribute("caption-sub", captionSub);
           donut.setAttribute("style", donutStyle);
           updateHeadlineStat({ pass, fail, ce, skip, total }, captionMain, captionSub);
-        };
-        const renderUnavailable = (captionMain, captionSub, detail) => {
-          donutSlot.innerHTML = `
-            <div class="conformance-unavailable" role="status" aria-live="polite">
-              <div>
-                <div class="conformance-unavailable-value">Unavailable</div>
-                <div class="conformance-unavailable-title">${captionMain}</div>
-                <div class="conformance-unavailable-title">${captionSub}</div>
-                <div class="conformance-unavailable-copy">${detail}</div>
-              </div>
-            </div>
-          `;
-          updateHeadlineUnavailable(captionMain, captionSub, detail);
         };
         const normalizeSummary = (summary, fallback = {}) => {
           const pass = Number(summary?.pass ?? fallback.pass ?? 0);
@@ -4950,21 +4943,6 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           rateEl.textContent = `${pct}%`;
           rateLabelEl.textContent = `${captionMain} ${captionSub}: ${pass.toLocaleString()} / ${total.toLocaleString()} test262 tests passing`;
         };
-        const updateHeadlineUnavailable = (captionMain, captionSub, detail) => {
-          if (!rateEl || !rateLabelEl) return;
-          window.__conformanceHeadlineHydrated = true;
-          rateEl.textContent = "Unavailable";
-          rateLabelEl.textContent = `${captionMain} ${captionSub}: ${detail}`;
-        };
-        const hasUsableSummary = (summary) => {
-          const pass = Number(summary?.pass ?? 0);
-          const total = Number(summary?.total ?? 0);
-          return Number.isFinite(pass) && Number.isFinite(total) && total > 0;
-        };
-        const summaryHasStaleResults = (summary) => {
-          const stale = Number(summary?.stale ?? 0);
-          return Number.isFinite(stale) && stale > 0;
-        };
         const statusRatio = (filtered, base, key) => {
           const baseValue = Number(base?.[key] ?? 0);
           if (baseValue <= 0) return 1;
@@ -4977,112 +4955,148 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           const skip = Math.round(summary.skip * ratios.skip);
           return { pass, fail, ce, skip, total: pass + fail + ce + skip };
         };
-        const fetchJson = async (url) => {
-          const resp = await fetch(url);
-          if (!resp.ok) throw new Error(`unavailable: ${url}`);
-          return resp.json();
-        };
-        const standalonePayloadFromHostReport = (report) => {
-          if (report?.standalone?.summary || report?.standalone?.official_summary) {
-            return report.standalone;
-          }
-          if (report?.standalone_summary || report?.standalone_full_summary || report?.standalone_strict_summary) {
-            return {
-              summary: report.standalone_summary,
-              official_summary: report.standalone_summary,
-              full_summary: report.standalone_full_summary,
-              strict_summary: report.standalone_strict_summary,
-              edition_summaries: report.standalone_edition_summaries,
-            };
-          }
-          return null;
-        };
-        const loadStandaloneReport = async (hostReport) => {
-          const embedded = standalonePayloadFromHostReport(hostReport);
-          if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
-            return { report: embedded, source: "test262-current.json" };
-          }
-          for (const url of STANDALONE_TEST262_REPORT_URLS) {
-            try {
-              const report = await fetchJson(url);
-              if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
-                return { report, source: url };
-              }
-            } catch {
-              // Try the next configured source.
-            }
-          }
-          return null;
-        };
-        const getNamedSummary = (report, names) => {
-          for (const name of names) {
-            if (hasUsableSummary(report?.[name])) return report[name];
-          }
-          return null;
-        };
-        const getStandaloneEditionSummary = (report, scope, strictOnly) => {
-          const editionMaps = [
-            strictOnly ? report?.strict_edition_summaries : null,
-            strictOnly ? report?.standalone_strict_edition_summaries : null,
-            report?.edition_summaries,
-            report?.standalone_edition_summaries,
-          ].filter(Boolean);
-          for (const map of editionMaps) {
-            const candidate = map?.[scope] ?? map?.[normalizeEditionLabel(scope)];
-            if (hasUsableSummary(candidate)) return candidate;
-          }
-
-          const editionRows = [
-            strictOnly ? report?.strict_editions : null,
-            strictOnly ? report?.standalone_strict_editions : null,
-            report?.editions,
-            report?.standalone_editions,
-          ].filter(Array.isArray);
-          for (const rows of editionRows) {
-            const candidate = rows.find((row) => {
-              const label = String(row?.edition ?? row?.rawEdition ?? row?.label ?? "");
-              return label === scope || normalizeEditionLabel(label) === normalizeEditionLabel(scope);
-            });
-            if (hasUsableSummary(candidate)) return candidate;
-          }
-          return null;
-        };
-        const getStandaloneSummary = (standaloneData, scope, strictOnly) => {
-          if (!standaloneData?.report) {
-            return {
-              summary: null,
-              reason: "No standalone test262 baseline has been published for this build.",
-            };
-          }
-          const report = standaloneData.report;
-          let summary = null;
-          if (scope === "overall") {
-            summary = strictOnly
-              ? getNamedSummary(report, ["strict_summary", "standalone_strict_summary"])
-              : getNamedSummary(report, ["summary", "official_summary", "standalone_summary"]);
-          } else if (scope === "overall+proposal") {
-            summary = strictOnly
-              ? getNamedSummary(report, ["strict_full_summary", "standalone_strict_full_summary"])
-              : getNamedSummary(report, ["full_summary", "standalone_full_summary"]);
-          } else {
-            summary = getStandaloneEditionSummary(report, scope, strictOnly);
-          }
-
-          if (!hasUsableSummary(summary)) {
-            return {
-              summary: null,
-              reason: `Standalone test262 data is not available for ${strictOnly ? "strict " : ""}${scope} scope yet.`,
-            };
-          }
-          if (summaryHasStaleResults(summary)) {
-            return {
-              summary: null,
-              reason: `Standalone test262 data is stale for ${strictOnly ? "strict " : ""}${scope} scope.`,
-            };
-          }
-          return { summary: normalizeSummary(summary), reason: "", source: standaloneData.source };
-        };
-
+        /*
+         * Disabled JS-host switch path retained for later re-enable after the
+         * standalone regression is fixed.
+         *
+         * const STANDALONE_TEST262_REPORT_URLS = [
+         *   "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
+         *   "./benchmarks/results/test262-standalone-report.json",
+         * ];
+         * const renderUnavailable = (captionMain, captionSub, detail) => {
+         *   donutSlot.innerHTML = `
+         *     <div class="conformance-unavailable" role="status" aria-live="polite">
+         *       <div>
+         *         <div class="conformance-unavailable-value">Unavailable</div>
+         *         <div class="conformance-unavailable-title">${captionMain}</div>
+         *         <div class="conformance-unavailable-title">${captionSub}</div>
+         *         <div class="conformance-unavailable-copy">${detail}</div>
+         *       </div>
+         *     </div>
+         *   `;
+         *   updateHeadlineUnavailable(captionMain, captionSub, detail);
+         * };
+         * const updateHeadlineUnavailable = (captionMain, captionSub, detail) => {
+         *   if (!rateEl || !rateLabelEl) return;
+         *   window.__conformanceHeadlineHydrated = true;
+         *   rateEl.textContent = "Unavailable";
+         *   rateLabelEl.textContent = `${captionMain} ${captionSub}: ${detail}`;
+         * };
+         * const hasUsableSummary = (summary) => {
+         *   const pass = Number(summary?.pass ?? 0);
+         *   const total = Number(summary?.total ?? 0);
+         *   return Number.isFinite(pass) && Number.isFinite(total) && total > 0;
+         * };
+         * const summaryHasStaleResults = (summary) => {
+         *   const stale = Number(summary?.stale ?? 0);
+         *   return Number.isFinite(stale) && stale > 0;
+         * };
+         * const fetchJson = async (url) => {
+         *   const resp = await fetch(url);
+         *   if (!resp.ok) throw new Error(`unavailable: ${url}`);
+         *   return resp.json();
+         * };
+         * const standalonePayloadFromHostReport = (report) => {
+         *   if (report?.standalone?.summary || report?.standalone?.official_summary) {
+         *     return report.standalone;
+         *   }
+         *   if (report?.standalone_summary || report?.standalone_full_summary || report?.standalone_strict_summary) {
+         *     return {
+         *       summary: report.standalone_summary,
+         *       official_summary: report.standalone_summary,
+         *       full_summary: report.standalone_full_summary,
+         *       strict_summary: report.standalone_strict_summary,
+         *       edition_summaries: report.standalone_edition_summaries,
+         *     };
+         *   }
+         *   return null;
+         * };
+         * const loadStandaloneReport = async (hostReport) => {
+         *   const embedded = standalonePayloadFromHostReport(hostReport);
+         *   if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
+         *     return { report: embedded, source: "test262-current.json" };
+         *   }
+         *   for (const url of STANDALONE_TEST262_REPORT_URLS) {
+         *     try {
+         *       const report = await fetchJson(url);
+         *       if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
+         *         return { report, source: url };
+         *       }
+         *     } catch {
+         *       // Try the next configured source.
+         *     }
+         *   }
+         *   return null;
+         * };
+         * const getNamedSummary = (report, names) => {
+         *   for (const name of names) {
+         *     if (hasUsableSummary(report?.[name])) return report[name];
+         *   }
+         *   return null;
+         * };
+         * const getStandaloneEditionSummary = (report, scope, strictOnly) => {
+         *   const editionMaps = [
+         *     strictOnly ? report?.strict_edition_summaries : null,
+         *     strictOnly ? report?.standalone_strict_edition_summaries : null,
+         *     report?.edition_summaries,
+         *     report?.standalone_edition_summaries,
+         *   ].filter(Boolean);
+         *   for (const map of editionMaps) {
+         *     const candidate = map?.[scope] ?? map?.[normalizeEditionLabel(scope)];
+         *     if (hasUsableSummary(candidate)) return candidate;
+         *   }
+         *
+         *   const editionRows = [
+         *     strictOnly ? report?.strict_editions : null,
+         *     strictOnly ? report?.standalone_strict_editions : null,
+         *     report?.editions,
+         *     report?.standalone_editions,
+         *   ].filter(Array.isArray);
+         *   for (const rows of editionRows) {
+         *     const candidate = rows.find((row) => {
+         *       const label = String(row?.edition ?? row?.rawEdition ?? row?.label ?? "");
+         *       return label === scope || normalizeEditionLabel(label) === normalizeEditionLabel(scope);
+         *     });
+         *     if (hasUsableSummary(candidate)) return candidate;
+         *   }
+         *   return null;
+         * };
+         * const getStandaloneSummary = (standaloneData, scope, strictOnly) => {
+         *   if (!standaloneData?.report) {
+         *     return {
+         *       summary: null,
+         *       reason: "No standalone test262 baseline has been published for this build.",
+         *     };
+         *   }
+         *   const report = standaloneData.report;
+         *   let summary = null;
+         *   if (scope === "overall") {
+         *     summary = strictOnly
+         *       ? getNamedSummary(report, ["strict_summary", "standalone_strict_summary"])
+         *       : getNamedSummary(report, ["summary", "official_summary", "standalone_summary"]);
+         *   } else if (scope === "overall+proposal") {
+         *     summary = strictOnly
+         *       ? getNamedSummary(report, ["strict_full_summary", "standalone_strict_full_summary"])
+         *       : getNamedSummary(report, ["full_summary", "standalone_full_summary"]);
+         *   } else {
+         *     summary = getStandaloneEditionSummary(report, scope, strictOnly);
+         *   }
+         *
+         *   if (!hasUsableSummary(summary)) {
+         *     return {
+         *       summary: null,
+         *       reason: `Standalone test262 data is not available for ${strictOnly ? "strict " : ""}${scope} scope yet.`,
+         *     };
+         *   }
+         *   if (summaryHasStaleResults(summary)) {
+         *     return {
+         *       summary: null,
+         *       reason: `Standalone test262 data is stale for ${strictOnly ? "strict " : ""}${scope} scope.`,
+         *     };
+         *   }
+         *   return { summary: normalizeSummary(summary), reason: "", source: standaloneData.source };
+         * };
+         */
         try {
           const reportResp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!reportResp.ok) throw new Error("conformance data unavailable");
@@ -5109,23 +5123,24 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             withProposal.ce !== overall.ce ||
             withProposal.skip !== overall.skip ||
             withProposal.total !== overall.total;
-          const standaloneData = await loadStandaloneReport(report);
+          // const standaloneData = await loadStandaloneReport(report);
 
           let lastDetail = null;
           const conformanceOptions = () => {
             const strictOnly = strictToggle ? strictToggle.checked : false;
-            const hostEnabled = hostToggle ? hostToggle.checked : true;
+            // const hostEnabled = hostToggle ? hostToggle.checked : true;
             return {
               strictOnly,
-              hostEnabled,
-              captionSub:
-                strictOnly && !hostEnabled
-                  ? "strict standalone conformance"
-                  : strictOnly
-                    ? "strict conformance"
-                    : hostEnabled
-                      ? "conformance"
-                      : "standalone conformance",
+              // hostEnabled,
+              // captionSub:
+              //   strictOnly && !hostEnabled
+              //     ? "strict standalone conformance"
+              //     : strictOnly
+              //       ? "strict conformance"
+              //       : hostEnabled
+              //         ? "conformance"
+              //         : "standalone conformance",
+              captionSub: strictOnly ? "strict conformance" : "conformance",
             };
           };
           const applyConformanceOptions = (summary, { exactStrictSummary = null } = {}) => {
@@ -5141,17 +5156,17 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             return { summary: next, options };
           };
           const renderSelectedConformance = (scope, hostSummary, captionMain, { exactStrictSummary = null } = {}) => {
-            const options = conformanceOptions();
-            if (!options.hostEnabled) {
-              const standalone = getStandaloneSummary(standaloneData, scope, options.strictOnly);
-              if (!standalone.summary) {
-                renderUnavailable(captionMain, options.captionSub, standalone.reason);
-                return;
-              }
-              renderDonut(standalone.summary, captionMain, options.captionSub);
-              return;
-            }
-            const { summary } = applyConformanceOptions(hostSummary, { exactStrictSummary });
+            // const options = conformanceOptions();
+            // if (!options.hostEnabled) {
+            //   const standalone = getStandaloneSummary(standaloneData, scope, options.strictOnly);
+            //   if (!standalone.summary) {
+            //     renderUnavailable(captionMain, options.captionSub, standalone.reason);
+            //     return;
+            //   }
+            //   renderDonut(standalone.summary, captionMain, options.captionSub);
+            //   return;
+            // }
+            const { summary, options } = applyConformanceOptions(hostSummary, { exactStrictSummary });
             renderDonut(summary, captionMain, options.captionSub);
           };
           const applyScopeFromDetail = (detail) => {
@@ -5183,7 +5198,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             if (lastDetail) applyScopeFromDetail(lastDetail);
           };
           strictToggle?.addEventListener("change", window.updateConformanceDonut);
-          hostToggle?.addEventListener("change", window.updateConformanceDonut);
+          // hostToggle?.addEventListener("change", window.updateConformanceDonut);
 
           editionTimeline.addEventListener("edition-change", (event) => {
             applyScopeFromDetail(event.detail);
@@ -5311,13 +5326,22 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
       (function hydrateEditionPassBars() {
         const strictToggle = document.getElementById("strict-only-toggle");
-        const hostToggle = document.getElementById("host-support-toggle");
+        // const hostToggle = document.getElementById("host-support-toggle");
 
-        const scoreRow = (row, hostEnabled) => {
+        // Host-aware scoring retained for later re-enable:
+        // const scoreRow = (row, hostEnabled) => {
+        //   const badge = row.querySelector(".feat-badge");
+        //   const usesHost = !!row.querySelector(".feat-host");
+        //   if (!badge) return 0;
+        //   if (usesHost && !hostEnabled) return 0;
+        //   if (badge.classList.contains("full")) return 1;
+        //   if (badge.classList.contains("partial")) return 0.5;
+        //   return 0;
+        // };
+
+        const scoreRow = (row) => {
           const badge = row.querySelector(".feat-badge");
-          const usesHost = !!row.querySelector(".feat-host");
           if (!badge) return 0;
-          if (usesHost && !hostEnabled) return 0;
           if (badge.classList.contains("full")) return 1;
           if (badge.classList.contains("partial")) return 0.5;
           return 0;
@@ -5356,7 +5380,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
         const renderHeuristicEditionPassBars = () => {
           const strictOnly = strictToggle ? strictToggle.checked : false;
-          const hostEnabled = hostToggle ? hostToggle.checked : true;
+          // const hostEnabled = hostToggle ? hostToggle.checked : true;
 
           document.querySelectorAll(".feat-section").forEach((section) => {
             const header = ensureEditionLabel(section)?.el;
@@ -5369,7 +5393,8 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             });
 
             const total = rows.length;
-            const score = rows.reduce((sum, row) => sum + scoreRow(row, hostEnabled), 0);
+            // const score = rows.reduce((sum, row) => sum + scoreRow(row, hostEnabled), 0);
+            const score = rows.reduce((sum, row) => sum + scoreRow(row), 0);
             const pct = total > 0 ? Math.round((score / total) * 100) : 0;
             const fill = bar.querySelector(".feat-edition-passbar-fill");
             const text = bar.querySelector(".feat-edition-passbar-text");


### PR DESCRIPTION
## What changed

- Hide the public JS-host toggle and pin the website conformance/benchmark display to JS-host data.
- Document that website benchmarks run in a JS host and hide standalone/WASI benchmark figures until the standalone regression is fixed.
- Update README language to omit standalone pass-rate and benchmark numbers for now.
- Add reusable worktree dependency provisioning for `node_modules` and `test262`, wired into worktree hooks and test262 worktree scripts.

## Why

Standalone/no-JS-host figures currently have a regression, so the public-facing docs and website should avoid showing stale or misleading standalone numbers. New worktrees also need populated heavyweight dependencies automatically so build and test tooling does not fail later with empty placeholder directories.

## Validation

- `bash -n scripts/provision-worktree-deps.sh .claude/hooks/provision-worktree.sh .claude/hooks/check-worktree-path.sh scripts/run-test262-vitest.sh scripts/run-test262-retro.sh`
- JSON parse check for `package.json` and `.claude/settings.json`
- temp worktree provisioning smoke test for `node_modules` and `test262/test`
- `git diff --check`
- `pnpm run build:pages` passed; it emitted the existing bundling/chunk-size warnings.
- pre-push hook passed typecheck, lint, format check, and issue integrity.
