### PR TITLE
test(nodejs): guard builtin gap survey

### DIFF
--- a/plan/issues/1575-node-builtin-gaps-survey.md
+++ b/plan/issues/1575-node-builtin-gaps-survey.md
@@ -1,7 +1,7 @@
 ---
 id: 1575
 title: "Node.js built-in module support — gap survey (js2wasm → npm)"
-status: ready
+status: in-progress
 created: 2026-05-20
 updated: 2026-06-02
 priority: high
@@ -11,6 +11,8 @@ sprint: 58
 required_by: [1766, 1774]
 owner: tech-lead
 related: [1032, 1033, 1044, 1287, 1289, 1400, 1471, 1472, 1473, 1474, 1480, 1481, 1482, 1483, 1484, 1490, 1491, 1492, 1493, 1494, 1535, 640]
+claimed_by: codex-developer
+claimed_at: 2026-06-02T20:53:04.188Z
 ---
 # Node.js built-in module support — gap survey
 
@@ -125,6 +127,24 @@ It also fails *on Node* when:
   with a Buffer argument the Wasm side can't unpack — see #983).
 - The return value is a stream the Wasm code tries to consume by
   property access on a hot path.
+
+### 2026-06-02 validation note
+
+Added `tests/issue-1575.test.ts` as an executable survey guard. It confirms:
+
+- `NODE_BUILTIN_MODULES` currently covers 33 normalized builtin module names.
+- Default builtin imports for unsupported modules (`path`, `http`, `events`)
+  still route through opaque whole-module imports (`__node_<module>` with
+  `node_builtin` intent).
+- Typed single-function exceptions remain limited to the current `fs`
+  (`readFileSync`/`writeFileSync`, gated by `allowFs`) and `crypto`
+  (`randomBytes`/`randomUUID`) paths.
+- Unsupported named imports are an even sharper npm gap than the default import
+  path: `import { join } from "node:path"` and
+  `import { createHash } from "node:crypto"` compile today as generic env
+  function stubs (`join`, `createHash`) rather than `node_builtin` or
+  `node_builtin_fn` imports. Follow-up builtin work should therefore cover both
+  default/namespace and named-import forms.
 
 ## Top 5 highest-leverage builtins to invest in
 

--- a/plan/issues/1575-node-builtin-gaps-survey.md
+++ b/plan/issues/1575-node-builtin-gaps-survey.md
@@ -1,7 +1,7 @@
 ---
 id: 1575
 title: "Node.js built-in module support — gap survey (js2wasm → npm)"
-status: in-progress
+status: in-review
 created: 2026-05-20
 updated: 2026-06-02
 priority: high
@@ -13,6 +13,7 @@ owner: tech-lead
 related: [1032, 1033, 1044, 1287, 1289, 1400, 1471, 1472, 1473, 1474, 1480, 1481, 1482, 1483, 1484, 1490, 1491, 1492, 1493, 1494, 1535, 640]
 claimed_by: codex-developer
 claimed_at: 2026-06-02T20:53:04.188Z
+pr: 1043
 ---
 # Node.js built-in module support — gap survey
 

--- a/tests/issue-1575.test.ts
+++ b/tests/issue-1575.test.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1575 - Node.js builtin module gap survey guard.
+//
+// These tests do not claim new builtin support. They pin the current import
+// routing surface that the survey depends on: recognized builtin specifiers,
+// opaque whole-module host imports for default imports, the two typed-function
+// exception families, and the sharper gap for unsupported named imports.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { isNodeBuiltin, NODE_BUILTIN_MODULES, preprocessImports } from "../src/import-resolver.js";
+
+const SURVEYED_NODE_BUILTINS = [
+  "http",
+  "https",
+  "http2",
+  "url",
+  "querystring",
+  "stream",
+  "stream/web",
+  "events",
+  "buffer",
+  "zlib",
+  "util",
+  "path",
+  "process",
+  "net",
+  "tls",
+  "fs",
+  "crypto",
+  "os",
+  "child_process",
+  "assert",
+  "dns",
+  "dgram",
+  "cluster",
+  "readline",
+  "string_decoder",
+  "timers",
+  "tty",
+  "vm",
+  "worker_threads",
+  "perf_hooks",
+  "async_hooks",
+  "diagnostics_channel",
+  "console",
+] as const;
+
+function expectSuccessfulCompile(result: CompileResult): void {
+  expect(
+    result.errors.filter((e) => e.severity === "error"),
+    result.errors.map((e) => e.message).join("\n"),
+  ).toEqual([]);
+  expect(result.success).toBe(true);
+}
+
+describe("#1575 - Node.js builtin gap survey", () => {
+  it("keeps the surveyed builtin matrix aligned with the resolver table", () => {
+    expect(new Set(NODE_BUILTIN_MODULES)).toEqual(new Set(SURVEYED_NODE_BUILTINS));
+    expect(NODE_BUILTIN_MODULES.size).toBe(33);
+
+    for (const builtin of SURVEYED_NODE_BUILTINS) {
+      expect(isNodeBuiltin(builtin), builtin).toBe(true);
+      expect(isNodeBuiltin(`node:${builtin}`), `node:${builtin}`).toBe(true);
+    }
+  });
+
+  it("preprocessImports records default, namespace, and named builtin imports", () => {
+    const result = preprocessImports(`
+      import path from "node:path";
+      import * as http from "http";
+      import { EventEmitter } from "node:events";
+      export const marker = 1;
+    `);
+
+    expect(result.nodeBuiltins).toEqual([
+      { localName: "path", moduleName: "path" },
+      { localName: "http", moduleName: "http" },
+      { localName: "EventEmitter", moduleName: "events", namedBindings: ["EventEmitter"] },
+    ]);
+    expect(result.source).not.toContain("import path");
+    expect(result.source).not.toContain("import * as http");
+    expect(result.source).not.toContain("import { EventEmitter }");
+  });
+
+  it("routes unsupported default builtin imports through opaque __node_<module> imports", async () => {
+    const result = await compile(
+      `
+        import path from "node:path";
+        import http from "node:http";
+        import events from "node:events";
+
+        export function touch(): any {
+          const h = http;
+          const e = events;
+          return path.join("a", "b") || h || e;
+        }
+      `,
+      { fileName: "issue-1575-default-builtins.ts" },
+    );
+
+    expectSuccessfulCompile(result);
+
+    const moduleImports = result.imports
+      .filter((imp) => imp.intent.type === "node_builtin")
+      .map((imp) => [imp.name, imp.intent.moduleName]);
+
+    expect(moduleImports).toEqual([
+      ["__node_path", "path"],
+      ["__node_http", "http"],
+      ["__node_events", "events"],
+    ]);
+
+    const typedImports = result.imports.filter(
+      (imp) => imp.intent.type === "node_builtin_fn" && ["path", "http", "events"].includes(imp.intent.moduleName),
+    );
+    expect(typedImports).toEqual([]);
+  });
+
+  it("keeps the current typed-function exceptions limited to fs and crypto", async () => {
+    const cryptoResult = await compile(
+      `
+        import { randomBytes, randomUUID } from "node:crypto";
+
+        export function main(): number {
+          return randomBytes(4).length + randomUUID().length;
+        }
+      `,
+      { fileName: "issue-1575-crypto.ts" },
+    );
+    expectSuccessfulCompile(cryptoResult);
+
+    expect(
+      cryptoResult.imports
+        .filter((imp) => imp.intent.type === "node_builtin_fn")
+        .map((imp) => [imp.name, imp.intent.moduleName, imp.intent.name]),
+    ).toEqual([
+      ["__nodefn__crypto__randomBytes", "crypto", "randomBytes"],
+      ["__nodefn__crypto__randomUUID", "crypto", "randomUUID"],
+    ]);
+
+    const fsResult = await compile(
+      `
+        import { readFileSync } from "node:fs";
+
+        export function read(path: string): any {
+          return readFileSync(path, "utf-8");
+        }
+      `,
+      { allowFs: true, fileName: "issue-1575-fs.ts" },
+    );
+    expectSuccessfulCompile(fsResult);
+
+    expect(
+      fsResult.imports
+        .filter((imp) => imp.intent.type === "node_builtin_fn")
+        .map((imp) => [imp.name, imp.intent.moduleName, imp.intent.name]),
+    ).toEqual([["__node_fs_readFileSync", "fs", "readFileSync"]]);
+  });
+
+  it("documents the unsupported named-import gap for common npm builtins", async () => {
+    const result = await compile(
+      `
+        import { join } from "node:path";
+        import { createHash } from "node:crypto";
+
+        export function touch(): any {
+          return join("a", "b") || createHash("sha256");
+        }
+      `,
+      { fileName: "issue-1575-named-gap.ts" },
+    );
+
+    expectSuccessfulCompile(result);
+
+    expect(result.imports.find((imp) => imp.name === "join")?.intent).toEqual({ type: "builtin", name: "join" });
+    expect(result.imports.find((imp) => imp.name === "createHash")?.intent).toEqual({
+      type: "builtin",
+      name: "createHash",
+    });
+
+    expect(result.imports.some((imp) => imp.intent.type === "node_builtin" && imp.intent.moduleName === "path")).toBe(
+      false,
+    );
+    expect(
+      result.imports.some(
+        (imp) =>
+          imp.intent.type === "node_builtin_fn" &&
+          ((imp.intent.moduleName === "path" && imp.intent.name === "join") ||
+            (imp.intent.moduleName === "crypto" && imp.intent.name === "createHash")),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused #1575 survey tests for the Node builtin resolver table, opaque `__node_<module>` imports, and the current fs/crypto typed-function exceptions.
- Capture the unsupported named-import gap for common npm builtins such as `node:path` `join` and `node:crypto` `createHash`.
- Document the validation finding in the issue file for follow-up builtin implementation work.

## Validation

- `pnpm test tests/issue-1575.test.ts`
- `pnpm exec prettier --check tests/issue-1575.test.ts`
- `pnpm exec biome lint tests/issue-1575.test.ts --diagnostic-level=error`
- `pnpm run check:issues`
- pre-push hook: typecheck + lint, format check, issue integrity
