### PR TITLE
fix(arrays): preserve undefined from empty pop

### DIFF
--- a/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
+++ b/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
@@ -1,7 +1,7 @@
 ---
 id: 1747
 title: "Array.prototype.pop() on an empty array traps instead of returning undefined (compiled WasmGC)"
-status: in-progress
+status: in-review
 created: 2026-05-30
 updated: 2026-06-02
 priority: medium
@@ -15,6 +15,7 @@ sprint: 58
 related: [1584, 1748]
 claimed_by: codex-developer
 claimed_at: 2026-06-02T20:53:18.030Z
+pr: 1044
 ---
 # #1747 — `[].pop()` on an empty array traps instead of returning `undefined`
 

--- a/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
+++ b/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
@@ -1,7 +1,7 @@
 ---
 id: 1747
 title: "Array.prototype.pop() on an empty array traps instead of returning undefined (compiled WasmGC)"
-status: ready
+status: in-progress
 created: 2026-05-30
 updated: 2026-06-02
 priority: medium
@@ -13,6 +13,8 @@ language_feature: array-pop, empty-array, undefined
 goal: standalone-correctness
 sprint: 58
 related: [1584, 1748]
+claimed_by: codex-developer
+claimed_at: 2026-06-02T20:53:18.030Z
 ---
 # #1747 — `[].pop()` on an empty array traps instead of returning `undefined`
 
@@ -64,3 +66,25 @@ code doesn't hit the same trap.
   codegen path.
 - See [[1748]] for a sibling codegen trap found in the same investigation
   (`readonly` nested array field).
+
+## Implementation notes
+
+- Verified ECMA-262 §23.1.3.22 (`Array.prototype.pop`) and §23.1.3.27
+  (`Array.prototype.shift`): both return `undefined` immediately when
+  `length = 0`.
+- Current branch already guarded the raw array read, so the reproduced failure
+  was no longer an out-of-bounds trap; it was an observable wrong result for
+  `number[]` because the intrinsic returned the primitive element type and
+  could not carry `undefined`.
+- Updated `pop`/`shift` lowering to use an `externref` result when the call's
+  TypeScript return includes `undefined` and no numeric expected type is
+  requesting the old primitive path. Empty arrays initialize that result to JS
+  `undefined`; non-empty numeric elements are boxed before storing into the
+  result local.
+- Left discarded calls (`arr.pop();`) on the primitive path because their
+  returned value is not observable and this avoids unnecessary late imports.
+
+## Validation
+
+- `pnpm vitest run tests/issue-1747.test.ts tests/issue-1377.test.ts tests/array-oob-bounds-check.test.ts`
+- `pnpm run typecheck`

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -171,6 +171,42 @@ function isReceiverNonNull(expr: ts.Expression, checker: ts.TypeChecker): boolea
   return false;
 }
 
+function typeIncludesUndefined(type: ts.Type): boolean {
+  if ((type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0) return true;
+  if (type.isUnion()) return type.types.some((member) => typeIncludesUndefined(member));
+  return false;
+}
+
+function shouldReturnUndefinedCapableResult(
+  ctx: CodegenContext,
+  callExpr: ts.CallExpression,
+  expectedType?: ValType,
+): boolean {
+  let parent: ts.Node | undefined = callExpr.parent;
+  while (
+    parent &&
+    (ts.isParenthesizedExpression(parent) ||
+      ts.isAsExpression(parent) ||
+      ts.isTypeAssertionExpression(parent) ||
+      ts.isNonNullExpression(parent))
+  ) {
+    parent = parent.parent;
+  }
+  if (parent && ts.isExpressionStatement(parent)) return false;
+  if (expectedType && expectedType.kind !== "externref" && expectedType.kind !== "ref_extern") return false;
+  return typeIncludesUndefined(ctx.checker.getTypeAtLocation(callExpr));
+}
+
+function arrayElementToExternrefInstrs(ctx: CodegenContext, fctx: FunctionContext, elemType: ValType): Instr[] {
+  if (elemType.kind === "i16") {
+    return coercionInstrs(ctx, { kind: "i32" }, { kind: "externref" }, fctx);
+  }
+  if (elemType.kind === "f32") {
+    return [{ op: "f64.promote_f32" } as Instr, ...coercionInstrs(ctx, { kind: "f64" }, { kind: "externref" }, fctx)];
+  }
+  return coercionInstrs(ctx, elemType, { kind: "externref" }, fctx);
+}
+
 // ── Bounds-checked array access ───────────────────────────────────────
 
 /**
@@ -2381,6 +2417,7 @@ export function compileArrayMethodCall(
   callExpr: ts.CallExpression,
   receiverType: ts.Type,
   overrideMethodName?: string,
+  expectedType?: ValType,
 ): ValType | null | undefined | typeof VOID_RESULT {
   const methodName =
     overrideMethodName ?? (ts.isPropertyAccessExpression(propAccess) ? propAccess.name.text : undefined);
@@ -2510,10 +2547,10 @@ export function compileArrayMethodCall(
       result = compileArrayPush(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "pop":
-      result = compileArrayPop(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+      result = compileArrayPop(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType, expectedType);
       break;
     case "shift":
-      result = compileArrayShift(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+      result = compileArrayShift(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType, expectedType);
       break;
     case "slice":
       result = compileArraySlice(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
@@ -3760,25 +3797,27 @@ function compileArrayPop(
   ctx: CodegenContext,
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
-  _callExpr: ts.CallExpression,
+  callExpr: ts.CallExpression,
   vecTypeIdx: number,
   arrTypeIdx: number,
   elemType: ValType,
+  expectedType?: ValType,
 ): ValType | null {
+  const resultType: ValType = shouldReturnUndefinedCapableResult(ctx, callExpr, expectedType)
+    ? { kind: "externref" }
+    : elemType;
   const vecTmp = allocLocal(fctx, `__arr_pop_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const newLenTmp = allocLocal(fctx, `__arr_pop_nl_${fctx.locals.length}`, { kind: "i32" });
-  const resultTmp = allocLocal(fctx, `__arr_pop_res_${fctx.locals.length}`, elemType);
+  const resultTmp = allocLocal(fctx, `__arr_pop_res_${fctx.locals.length}`, resultType);
 
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
   const lenTmp = allocLocal(fctx, `__arr_pop_len_${fctx.locals.length}`, { kind: "i32" });
 
-  // (#1377) Initialize result to JS `undefined` for externref/anyref element
-  // types so empty-array `arr.pop()` returns spec-compliant undefined (not
-  // the wasm default `ref.null.extern`, which JS sees as `null`). f64 keeps
-  // its NaN default (matches `[].pop()` returning undefined which coerces
-  // to NaN in numeric context). i32 keeps 0 (best-effort; never mixed with
-  // null arrays).
-  if (elemType.kind === "externref" || elemType.kind === "anyref") {
+  // ECMA-262 §23.1.3.22: when length is 0, pop sets length to +0 and
+  // returns undefined. Preserve the old primitive result only for numeric
+  // hint contexts; otherwise use an externref result that can carry
+  // undefined for the Array<T>.pop(): T | undefined signature.
+  if (resultType.kind === "externref" || resultType.kind === "anyref") {
     emitUndefined(ctx, fctx);
     fctx.body.push({ op: "local.set", index: resultTmp });
   }
@@ -3808,6 +3847,7 @@ function compileArrayPop(
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
     { op: "local.get", index: newLenTmp } as Instr,
     { op: getOp, typeIdx: arrTypeIdx } as Instr,
+    ...(resultType.kind === "externref" ? arrayElementToExternrefInstrs(ctx, fctx, elemType) : []),
     { op: "local.set", index: resultTmp } as Instr,
     // Decrement length: vec.length = newLen
     { op: "local.get", index: vecTmp } as Instr,
@@ -3819,7 +3859,7 @@ function compileArrayPop(
 
   // Return result (default value if empty, popped value if non-empty)
   fctx.body.push({ op: "local.get", index: resultTmp });
-  return elemType;
+  return resultType;
 }
 
 /**
@@ -3829,22 +3869,25 @@ function compileArrayShift(
   ctx: CodegenContext,
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
-  _callExpr: ts.CallExpression,
+  callExpr: ts.CallExpression,
   vecTypeIdx: number,
   arrTypeIdx: number,
   elemType: ValType,
+  expectedType?: ValType,
 ): ValType | null {
+  const resultType: ValType = shouldReturnUndefinedCapableResult(ctx, callExpr, expectedType)
+    ? { kind: "externref" }
+    : elemType;
   const vecTmp = allocLocal(fctx, `__arr_sft_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_sft_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const lenTmp = allocLocal(fctx, `__arr_sft_len_${fctx.locals.length}`, { kind: "i32" });
   const newLenTmp = allocLocal(fctx, `__arr_sft_nl_${fctx.locals.length}`, { kind: "i32" });
-  const resultTmp = allocLocal(fctx, `__arr_sft_res_${fctx.locals.length}`, elemType);
+  const resultTmp = allocLocal(fctx, `__arr_sft_res_${fctx.locals.length}`, resultType);
 
   const getOp = elemType.kind === "i16" ? "array.get_s" : "array.get";
 
-  // (#1377) Initialize result to JS `undefined` for externref/anyref so
-  // empty-array `arr.shift()` returns spec-compliant undefined.
-  if (elemType.kind === "externref" || elemType.kind === "anyref") {
+  // ECMA-262 §23.1.3.27 mirrors pop's empty-array branch for shift.
+  if (resultType.kind === "externref" || resultType.kind === "anyref") {
     emitUndefined(ctx, fctx);
     fctx.body.push({ op: "local.set", index: resultTmp });
   }
@@ -3873,6 +3916,7 @@ function compileArrayShift(
     { op: "local.get", index: dataTmp } as Instr,
     { op: "i32.const", value: 0 } as Instr,
     { op: getOp, typeIdx: arrTypeIdx } as Instr,
+    ...(resultType.kind === "externref" ? arrayElementToExternrefInstrs(ctx, fctx, elemType) : []),
     { op: "local.set", index: resultTmp } as Instr,
     // newLen = len - 1
     { op: "local.get", index: lenTmp } as Instr,
@@ -3896,7 +3940,7 @@ function compileArrayShift(
 
   // Return result (default value if empty, shifted value if non-empty)
   fctx.body.push({ op: "local.get", index: resultTmp });
-  return elemType;
+  return resultType;
 }
 
 /**

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -579,7 +579,7 @@ function compileExpressionBody(
   const bodyLenBefore = fctx.body.length;
   let result: InnerResult;
   try {
-    result = compileExpressionInner(ctx, fctx, expr);
+    result = compileExpressionInner(ctx, fctx, expr, expectedType);
   } catch (e) {
     fctx.body.length = bodyLenBefore;
     const msg = e instanceof Error ? e.message : String(e);
@@ -768,7 +768,12 @@ export function coerceType(
   return coerceTypeImpl(ctx, fctx, from, to, toPrimitiveHint);
 }
 
-function compileExpressionInner(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): InnerResult {
+function compileExpressionInner(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+  expectedType?: ValType,
+): InnerResult {
   if (ts.isNumericLiteral(expr)) {
     const value = Number(expr.text.replace(/_/g, ""));
     if (ctx.fast && Number.isInteger(value) && value >= -2147483648 && value <= 2147483647) {
@@ -1023,12 +1028,12 @@ function compileExpressionInner(ctx: CodegenContext, fctx: FunctionContext, expr
   }
 
   if (ts.isParenthesizedExpression(expr)) {
-    return compileExpressionInner(ctx, fctx, expr.expression);
+    return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 
   if (ts.isCallExpression(expr)) {
     const callStart = fctx.body.length;
-    const callResult = compileCallExpression(ctx, fctx, expr);
+    const callResult = compileCallExpression(ctx, fctx, expr, expectedType);
     if (fctx.pendingCallbackWritebacks && fctx.pendingCallbackWritebacks.length > 0) {
       fctx.body.push(...fctx.pendingCallbackWritebacks);
       fctx.pendingCallbackWritebacks = undefined;
@@ -1125,15 +1130,15 @@ function compileExpressionInner(ctx: CodegenContext, fctx: FunctionContext, expr
   }
 
   if (ts.isAsExpression(expr)) {
-    return compileExpressionInner(ctx, fctx, expr.expression);
+    return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 
   if (ts.isNonNullExpression(expr)) {
-    return compileExpressionInner(ctx, fctx, expr.expression);
+    return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 
   if (ts.isAwaitExpression(expr)) {
-    return compileExpressionInner(ctx, fctx, expr.expression);
+    return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 
   if (ts.isYieldExpression(expr)) {
@@ -1208,7 +1213,7 @@ function compileExpressionInner(ctx: CodegenContext, fctx: FunctionContext, expr
   }
 
   if (ts.isSpreadElement(expr as any)) {
-    return compileExpressionInner(ctx, fctx, (expr as any as ts.SpreadElement).expression);
+    return compileExpressionInner(ctx, fctx, (expr as any as ts.SpreadElement).expression, expectedType);
   }
 
   reportError(ctx, expr, `Unsupported expression: ${ts.SyntaxKind[expr.kind]}`);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1668,7 +1668,12 @@ function flattenStaticArrayElements(arr: ts.ArrayLiteralExpression): ts.Expressi
   return out;
 }
 
-function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
+function compileCallExpression(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  expectedType?: ValType,
+): InnerResult {
   // Optional chaining on calls: obj?.method()
   if (expr.questionDotToken && ts.isPropertyAccessExpression(expr.expression)) {
     return compileOptionalCallExpression(ctx, fctx, expr);
@@ -6123,7 +6128,15 @@ function compileCallExpression(ctx: CodegenContext, fctx: FunctionContext, expr:
 
     // Array method calls
     {
-      const arrMethodResult = compileArrayMethodCall(ctx, fctx, propAccess, expr, receiverType);
+      const arrMethodResult = compileArrayMethodCall(
+        ctx,
+        fctx,
+        propAccess,
+        expr,
+        receiverType,
+        undefined,
+        expectedType,
+      );
       if (arrMethodResult !== undefined) return arrMethodResult;
     }
 

--- a/tests/issue-1747.test.ts
+++ b/tests/issue-1747.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<WebAssembly.Exports> {
+  const r = await compile(src);
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => e.message).join(", ")}\n${r.wat}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const m = await WebAssembly.instantiate(r.binary, imports);
+  const setExports = (imports as { setExports?: (exports: WebAssembly.Exports) => void }).setExports;
+  if (typeof setExports === "function") setExports(m.instance.exports);
+  return m.instance.exports;
+}
+
+describe("#1747 - Array.prototype.pop on empty arrays", () => {
+  it("number[].pop() on an empty array returns undefined", async () => {
+    const ex = await instantiate(`
+      export function run(): number {
+        const a: number[] = [];
+        const x = a.pop();
+        if (x === undefined) return 1;
+        return -1;
+      }
+    `);
+    expect((ex.run as () => number)()).toBe(1);
+  });
+
+  it("number[].shift() on an empty array returns undefined", async () => {
+    const ex = await instantiate(`
+      export function run(): number {
+        const a: number[] = [];
+        const x = a.shift();
+        if (x === undefined) return 1;
+        return -1;
+      }
+    `);
+    expect((ex.run as () => number)()).toBe(1);
+  });
+
+  it("number[].pop() still returns the last number for non-empty arrays", async () => {
+    const ex = await instantiate(`
+      export function run(): number {
+        const a: number[] = [10, 20, 30];
+        const x = a.pop();
+        if (x === undefined) return -1;
+        return x;
+      }
+    `);
+    expect((ex.run as () => number)()).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve observable `undefined` from empty `number[].pop()` and `number[].shift()` by using an `externref` result when the call-site type includes `undefined`.
- Keep numeric expected-type and discarded-call paths on the existing primitive lowering.
- Add focused regression coverage for #1747.

## Root Cause

The existing intrinsic guarded the raw array read, but it still returned the primitive element type for `number[]`. That meant the empty-array path could not carry the ECMA-262 §23.1.3.22 / §23.1.3.27 `undefined` result into `x === undefined` checks.

## Validation

- `pnpm vitest run tests/issue-1747.test.ts tests/issue-1377.test.ts tests/array-oob-bounds-check.test.ts`
- `pnpm run typecheck`