### PR TITLE
fix(test262): publish standalone root-cause map

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -546,6 +546,8 @@ jobs:
           node scripts/build-test262-report.mjs \
             --input merged-reports/test262-standalone-results-merged.jsonl \
             --output merged-reports/test262-standalone-report-merged.json \
+            --target standalone \
+            --max-unclassified-root-causes 0 \
             --baseline-sha "${{ github.sha }}" \
             --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}

--- a/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
+++ b/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
@@ -1,7 +1,7 @@
 ---
 id: 1781
 title: "standalone test262 run must publish full JSONL and root-cause issue map"
-status: ready
+status: in-progress
 created: 2026-06-02
 updated: 2026-06-02
 priority: high
@@ -15,6 +15,8 @@ es_edition: n/a
 sprint: 58
 related: [1662, 1776, 1472, 682, 1474, 1599, 1387, 1778, 1782, 1591, 1623, 1665]
 origin: "Investigation of all failing standalone test262 tests found that the June 1 full standalone JSONL/report artifacts were generated but not retained, leaving only summary counts and five manually documented root-cause clusters."
+claimed_by: codex-developer
+claimed_at: 2026-06-02T20:53:11.407Z
 ---
 
 # #1781 - Standalone test262 run must publish full JSONL and root-cause issue map
@@ -160,6 +162,44 @@ No high-volume standalone failure family is unowned after this pass. The only
 new issue filed from the artifact is #1782 for numeric/BigInt separator
 literal values; other buckets already had root-cause issues and were refreshed
 where the latest artifact materially changed the evidence.
+
+## 2026-06-02 implementation findings
+
+Implemented the auditability layer for standalone test262 reporting:
+
+- `tests/test262-shared.ts` now writes stable `error_signature`,
+  `imports`, `host_import_leak_class`, and `reached_test` metadata into JSONL
+  rows when that information is available from the worker or fixture compile
+  path.
+- `scripts/test262-worker.mjs` returns summarized compile imports, a
+  host-import leak class, and whether the exported `test()` function was
+  reached.
+- `scripts/build-test262-report.mjs` now supports `--target standalone`,
+  emits `root_cause_map` for standalone reports, and fails when
+  `--max-unclassified-root-causes N` is exceeded.
+- `scripts/run-test262-vitest.sh` delegates report generation to the shared
+  report builder, so local standalone runs emit the same report schema as CI.
+- `.github/workflows/test262-sharded.yml` runs the standalone merged report
+  with `--max-unclassified-root-causes 0`, making unowned standalone failures a
+  required-check failure.
+
+Validation:
+
+- `pnpm test tests/issue-1781.test.ts`
+- `pnpm test tests/build-test262-report.test.ts`
+- `pnpm test tests/issue-1781.test.ts tests/build-test262-report.test.ts`
+- `bash -n scripts/run-test262-vitest.sh`
+- `node --check scripts/build-test262-report.mjs`
+- `node --check scripts/test262-worker.mjs`
+- `pnpm exec tsc --noEmit --pretty false`
+- Fetched
+  `https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.jsonl`
+  and ran:
+  `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-issue-1781.json --target standalone --max-unclassified-root-causes 0 --include-proposals`
+
+The fetched standalone artifact classified all 40,189 non-pass/non-skip rows
+with 0 unclassified rows across 43 root-cause buckets. No full local test262
+run was performed.
 
 ## Root Cause
 

--- a/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
+++ b/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
@@ -1,7 +1,7 @@
 ---
 id: 1781
 title: "standalone test262 run must publish full JSONL and root-cause issue map"
-status: in-progress
+status: in-review
 created: 2026-06-02
 updated: 2026-06-02
 priority: high
@@ -17,6 +17,7 @@ related: [1662, 1776, 1472, 682, 1474, 1599, 1387, 1778, 1782, 1591, 1623, 1665]
 origin: "Investigation of all failing standalone test262 tests found that the June 1 full standalone JSONL/report artifacts were generated but not retained, leaving only summary counts and five manually documented root-cause clusters."
 claimed_by: codex-developer
 claimed_at: 2026-06-02T20:53:11.407Z
+pr: 1045
 ---
 
 # #1781 - Standalone test262 run must publish full JSONL and root-cause issue map

--- a/scripts/build-test262-report.mjs
+++ b/scripts/build-test262-report.mjs
@@ -10,6 +10,8 @@ function parseArgs(argv) {
     includeProposals: false,
     baselineSha: "",
     baselineGeneratedAt: "",
+    target: "",
+    maxUnclassifiedRootCauses: undefined,
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -24,12 +26,22 @@ function parseArgs(argv) {
       args.baselineSha = argv[++i] || "";
     } else if (arg === "--baseline-generated-at") {
       args.baselineGeneratedAt = argv[++i] || "";
+    } else if (arg === "--target") {
+      args.target = argv[++i] || "";
+    } else if (arg === "--max-unclassified-root-causes") {
+      const raw = argv[++i] || "";
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        console.error(`Invalid --max-unclassified-root-causes value: ${raw}`);
+        process.exit(1);
+      }
+      args.maxUnclassifiedRootCauses = parsed;
     }
   }
 
   if (!args.input || !args.output) {
     console.error(
-      "Usage: node scripts/build-test262-report.mjs --input <results.jsonl> --output <report.json> [--include-proposals]",
+      "Usage: node scripts/build-test262-report.mjs --input <results.jsonl> --output <report.json> [--include-proposals] [--target standalone] [--max-unclassified-root-causes N]",
     );
     process.exit(1);
   }
@@ -61,8 +73,486 @@ function buildSummary(counter) {
   };
 }
 
+function inferTarget(args) {
+  if (args.target) return args.target;
+  return `${args.input} ${args.output}`.includes("standalone") ? "standalone" : "gc";
+}
+
+function textOf(record) {
+  return [
+    record.file,
+    record.category,
+    record.status,
+    record.error,
+    record.error_category,
+    record.error_signature,
+    record.host_import_leak_class,
+    Array.isArray(record.imports) ? record.imports.join(" ") : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function hasAny(text, patterns) {
+  return patterns.some((pattern) => {
+    if (typeof pattern === "string") return text.includes(pattern);
+    return pattern.test(text);
+  });
+}
+
+function pathHas(record, patterns) {
+  const path = `${record.file ?? ""} ${record.category ?? ""}`.toLowerCase();
+  return hasAny(path, patterns);
+}
+
+const STANDALONE_ROOT_CAUSE_BUCKETS = [
+  {
+    id: "numeric-separator-literal-values",
+    issues: ["#1782", "#53"],
+    label: "Numeric and BigInt separator literals evaluate to wrong values",
+    match: (record, text) =>
+      hasAny(text, ["numericseparator", "numeric-separator", "numeric separator", "bigint separator"]),
+  },
+  {
+    id: "import-proposal-syntax",
+    issues: ["#1315", "#1435"],
+    label: "import.defer / import.source proposal syntax and early errors",
+    match: (record, text) =>
+      pathHas(record, ["import-defer", "import-source", "source-phase", "defer-import"]) ||
+      hasAny(text, ["import.defer", "import.source", "source phase"]),
+  },
+  {
+    id: "temporal-proposal",
+    issues: ["#661"],
+    label: "Temporal proposal/polyfill gap",
+    match: (record) => pathHas(record, ["built-ins/temporal"]),
+  },
+  {
+    id: "disposable-stack",
+    issues: ["#1036", "#990"],
+    label: "DisposableStack / explicit resource management",
+    match: (record) => pathHas(record, ["disposablestack", "asyncdisposablestack", "explicit-resource-management"]),
+  },
+  {
+    id: "dynamic-import",
+    issues: ["#1089", "#1512"],
+    label: "Dynamic import unsupported / early errors",
+    match: (record, text) =>
+      pathHas(record, ["dynamic-import"]) || hasAny(text, ["__dynamic_import", "dynamic import"]),
+  },
+  {
+    id: "with-statement",
+    issues: ["#1387"],
+    label: "`with` statement dynamic-scope lowering residuals",
+    match: (record, text) =>
+      pathHas(record, ["language/statements/with"]) || hasAny(text, ["with statement", "with-scope"]),
+  },
+  {
+    id: "standalone-json-codec",
+    issues: ["#1599"],
+    label: "Standalone JSON parser/stringifier",
+    match: (record, text) =>
+      record.host_import_leak_class === "json" ||
+      pathHas(record, ["built-ins/json"]) ||
+      hasAny(text, ["json_parse", "json_stringify"]),
+  },
+  {
+    id: "standalone-regexp",
+    issues: ["#682", "#1474"],
+    label: "RegExp literals/constructor/String-RegExp paths still refused or missing native engine",
+    match: (record, text) =>
+      record.host_import_leak_class === "regexp" ||
+      pathHas(record, ["built-ins/regexp", "regexpstringiteratorprototype"]) ||
+      hasAny(text, ["regexp", "regular expression"]),
+  },
+  {
+    id: "issamevalue-invalid-wasm",
+    issues: ["#1776"],
+    label: "Residual standalone isSameValue invalid-Wasm validator failures",
+    match: (record, text) => hasAny(text, ["issamevalue", "samevalue"]),
+  },
+  {
+    id: "standalone-dynamic-object-property",
+    issues: ["#1472"],
+    label: "Standalone dynamic object/property operation gate",
+    match: (record, text) =>
+      record.host_import_leak_class === "dynamic_object_property" ||
+      hasAny(text, [
+        "__extern_",
+        "__object_",
+        "__defineproperty",
+        "__get_builtin",
+        "__new_plain_object",
+        "__register_",
+        "__proto_method_call",
+        "dynamic object",
+        "no dependency provided for imported function",
+      ]),
+  },
+  {
+    id: "standalone-iterator-protocol",
+    issues: ["#1665", "#681", "#1718"],
+    label: "Generic iterator protocol still needs a pure-Wasm standalone path",
+    match: (record, text) =>
+      record.host_import_leak_class === "iterator_protocol" ||
+      pathHas(record, [
+        "built-ins/iterator",
+        "iteratorprototype",
+        "arrayiteratorprototype",
+        "stringiteratorprototype",
+        "mapiteratorprototype",
+        "setiteratorprototype",
+        "language/statements/for-of",
+      ]) ||
+      hasAny(text, ["iterator", "__iterator", "__array_from_iter"]),
+  },
+  {
+    id: "generator-async-iteration",
+    issues: ["#680", "#1665"],
+    label: "Generators and async iteration",
+    match: (record, text) =>
+      pathHas(record, ["generator", "asyncgenerator", "for-await"]) || hasAny(text, ["generator", "async iterator"]),
+  },
+  {
+    id: "class-prototype-private-descriptor",
+    issues: ["#1591", "#1365", "#1364"],
+    label: "Class element, prototype, private-name, and descriptor reconciliation gaps",
+    match: (record, text) =>
+      pathHas(record, [
+        "language/classes",
+        "language/statements/class",
+        "language/expressions/class",
+        "/class/",
+        "private",
+        "computed-property-names",
+        "built-ins/object/getownpropertydescriptor",
+      ]) || hasAny(text, ["private", "class element", "prototype", "property descriptor", "getownpropertydescriptor"]),
+  },
+  {
+    id: "object-to-primitive",
+    issues: ["#1525", "#1525b", "#1759"],
+    label: "ToPrimitive / object-to-string dispatch residuals",
+    match: (record, text) => hasAny(text, ["toprimitive", "to primitive", "valueof", "tostring", "symbol.toprimitive"]),
+  },
+  {
+    id: "array-typedarray-buffer",
+    issues: ["#1358", "#1461", "#1654"],
+    label: "Array, TypedArray, DataView, and buffer semantics",
+    match: (record) =>
+      pathHas(record, [
+        "built-ins/array/",
+        "built-ins/arraybuffer",
+        "built-ins/dataview",
+        "built-ins/typedarray",
+        "typedarrayconstructors",
+        "uint8array",
+        "int8array",
+        "float32array",
+        "float64array",
+      ]),
+  },
+  {
+    id: "object-property-semantics",
+    issues: ["#1472", "#176", "#281", "#1466"],
+    label: "Object/property/destructuring semantic mismatches behind the object model",
+    match: (record, text) =>
+      pathHas(record, ["built-ins/object", "language/destructuring", "object-"]) ||
+      hasAny(text, ["object.", "destructuring", "property"]),
+  },
+  {
+    id: "string-methods-coercion",
+    issues: ["#1105", "#1442", "#1381"],
+    label: "String methods and string coercion residuals in standalone",
+    match: (record) => pathHas(record, ["built-ins/string", "stringiteratorprototype", "language/literals/string"]),
+  },
+  {
+    id: "annex-b-function-eval",
+    issues: ["#1594", "#1050"],
+    label: "Annex B function/eval semantics",
+    match: (record) => pathHas(record, ["annexb"]),
+  },
+  {
+    id: "date-formatting-coercion",
+    issues: ["#1343"],
+    label: "Date prototype formatting/coercion",
+    match: (record) => pathHas(record, ["built-ins/date"]),
+  },
+  {
+    id: "number-parsing-formatting",
+    issues: ["#1335", "#1663", "#1689"],
+    label: "Number parsing, formatting, and coercion",
+    match: (record, text) =>
+      pathHas(record, ["built-ins/number", "parseint", "parsefloat"]) ||
+      hasAny(text, ["parseint", "parsefloat", "number."]),
+  },
+  {
+    id: "math-descriptors-coercion",
+    issues: ["#1732", "#562", "#160"],
+    label: "Math method descriptors and coercion edge cases",
+    match: (record) => pathHas(record, ["built-ins/math"]),
+  },
+  {
+    id: "function-object-semantics",
+    issues: ["#731", "#1732", "#1596"],
+    label: "Function object name/length/prototype/call semantics",
+    match: (record) =>
+      pathHas(record, ["built-ins/function", "language/function", "language/expressions/arrow-function"]),
+  },
+  {
+    id: "assignment-private-short-circuit",
+    issues: ["#334", "#1456", "#540"],
+    label: "Assignment targets, private refs, and short-circuit semantics",
+    match: (record) =>
+      pathHas(record, ["language/expressions/assignment", "language/expressions/logical", "short-circuit"]),
+  },
+  {
+    id: "map-set-weak-collections",
+    issues: ["#1103"],
+    label: "Wasm-native Map/Set/Weak collection semantics",
+    match: (record) => pathHas(record, ["built-ins/map", "built-ins/set", "built-ins/weakmap", "built-ins/weakset"]),
+  },
+  {
+    id: "eval-new-function",
+    issues: ["#1066", "#1073", "#990"],
+    label: "Eval and `new Function` semantics",
+    match: (record, text) =>
+      pathHas(record, ["eval-code", "built-ins/eval", "function-constructor"]) ||
+      hasAny(text, ["__extern_eval", "new function", "eval"]),
+  },
+  {
+    id: "arguments-object",
+    issues: ["#1511", "#1726"],
+    label: "Arguments object fidelity",
+    match: (record) => pathHas(record, ["arguments-object", "mapped-arguments", "unmapped-arguments"]),
+  },
+  {
+    id: "bigint-typed-path",
+    issues: ["#1644", "#1535"],
+    label: "Standalone BigInt host/typed-path residual",
+    match: (record, text) => pathHas(record, ["built-ins/bigint", "bigint"]) || hasAny(text, ["bigint"]),
+  },
+  {
+    id: "lexical-scope-tdz-declarations",
+    issues: ["#1128", "#990", "#1726"],
+    label: "Lexical scope, TDZ, and declaration semantics",
+    match: (record, text) =>
+      pathHas(record, [
+        "block-scope",
+        "identifier-resolution",
+        "scope",
+        "let",
+        "const",
+        "built-ins/global",
+        "language/global-code",
+      ]) || hasAny(text, ["tdz", "referenceerror"]),
+  },
+  {
+    id: "promise-async",
+    issues: ["#1326c", "#1116", "#1694"],
+    label: "Promise and async standalone semantics",
+    match: (record, text) =>
+      pathHas(record, ["built-ins/promise", "asyncfunction", "async-function"]) || hasAny(text, ["promise", "async"]),
+  },
+  {
+    id: "module-semantics",
+    issues: ["#1046", "#1527"],
+    label: "Module semantics and harness export shape",
+    match: (record) => pathHas(record, ["module-code", "language/import", "language/export"]),
+  },
+  {
+    id: "tail-call-control-flow",
+    issues: ["#602", "#787"],
+    label: "Tail-call/control-flow loop semantics, including compile timeouts",
+    match: (record, text) =>
+      record.status === "compile_timeout" ||
+      pathHas(record, ["tail-call", "language/statements", "control-flow"]) ||
+      hasAny(text, ["completion value"]),
+  },
+  {
+    id: "syntax-reference-errors",
+    issues: ["#927", "#1435", "#990"],
+    label: "Missing parse/early/runtime SyntaxError or ReferenceError",
+    match: (record, text) =>
+      record.error_category === "syntax_error" ||
+      pathHas(record, [
+        "language/asi",
+        "language/directive-prologue",
+        "language/comments",
+        "line-terminators",
+        "reserved-words",
+      ]) ||
+      hasAny(text, [
+        "syntaxerror",
+        "referenceerror",
+        "early error",
+        "hashbang",
+        "duplicate identifier",
+        "a class may only have one constructor",
+        "class constructor may not",
+      ]),
+  },
+  {
+    id: "template-literals",
+    issues: ["#1759", "#836"],
+    label: "Template literal and tagged-template semantics",
+    match: (record) => pathHas(record, ["template", "tagged-template"]),
+  },
+  {
+    id: "unicode-identifiers",
+    issues: ["#832", "#270"],
+    label: "Unicode/reserved-word identifier handling",
+    match: (record, text) =>
+      pathHas(record, ["unicode", "identifier", "reserved"]) || hasAny(text, ["unicode", "reserved word"]),
+  },
+  {
+    id: "completion-control-flow",
+    issues: ["#787", "#1378"],
+    label: "Completion values and control-flow semantics",
+    match: (record) => pathHas(record, ["break", "continue", "return", "switch", "try", "throw"]),
+  },
+  {
+    id: "extern-class-metadata",
+    issues: ["#812", "#1559"],
+    label: "Extern class dependency metadata",
+    match: (record, text) => hasAny(text, ["extern class", "dependency metadata", "extern_class"]),
+  },
+  {
+    id: "super-spread-receiver",
+    issues: ["#843", "#1551"],
+    label: "`super`, spread, and receiver-evaluation semantics",
+    match: (record) => pathHas(record, ["super", "spread", "optional-chaining", "new-target"]),
+  },
+  {
+    id: "sharedarraybuffer-atomics",
+    issues: ["#674", "#1354"],
+    label: "SharedArrayBuffer / Atomics backlog",
+    match: (record) => pathHas(record, ["sharedarraybuffer", "atomics"]),
+  },
+  {
+    id: "new-spread-optional-chain",
+    issues: ["#1519", "#1609", "#1603"],
+    label: "`new`, spread, and optional-chaining semantics",
+    match: (record) => pathHas(record, ["language/expressions/new", "optional-chaining", "spread"]),
+  },
+  {
+    id: "function-bind-descriptors",
+    issues: ["#1038", "#1732"],
+    label: "Function.prototype.bind / function-object descriptors",
+    match: (record) => pathHas(record, ["function/prototype/bind", "bind/"]),
+  },
+  {
+    id: "illegal-cast-boundary",
+    issues: ["#826", "#1623"],
+    label: "Illegal-cast/type-boundary residual",
+    match: (record, text) => hasAny(text, ["illegal cast", "ref.cast", "cast failure"]),
+  },
+  {
+    id: "null-undefined-typeerror",
+    issues: ["#820"],
+    label: "Null/undefined TypeError lowering residual",
+    match: (record, text) => hasAny(text, ["null/undefined", "dereferencing a null", "undefined access"]),
+  },
+  {
+    id: "invalid-wasm-boundaries",
+    issues: ["#1623", "#1666", "#1525b"],
+    label: "Invalid Wasm at type/coercion boundaries, late globals, and trampolines",
+    match: (record, text) =>
+      record.error_category === "wasm_compile" ||
+      hasAny(text, [
+        "invalid wasm",
+        "compiling function",
+        "type mismatch",
+        "not a subtype",
+        "trampoline",
+        "late global",
+        "wasm_compile",
+      ]),
+  },
+  {
+    id: "misc-spec-tail",
+    issues: ["#1577", "#779"],
+    label: "Miscellaneous low-volume spec-completeness tail",
+    match: (record, text) =>
+      hasAny(text, [
+        "assertion_fail",
+        "exception_in_test",
+        "returned #",
+        "runtime_error",
+        "range_error",
+        "rangeerror",
+        "maximum call stack",
+        "typeerror",
+      ]),
+  },
+];
+
+function emptyRootCauseBucket(bucket) {
+  return {
+    id: bucket.id,
+    issues: bucket.issues,
+    label: bucket.label,
+    count: 0,
+    statuses: createCounts(),
+    error_categories: {},
+    sample_files: [],
+    sample_signatures: [],
+  };
+}
+
+function addSample(samples, value, limit = 5) {
+  if (!value || samples.includes(value) || samples.length >= limit) return;
+  samples.push(value);
+}
+
+function recordRootCauseHit(target, record) {
+  target.count++;
+  target.statuses.total++;
+  target.statuses[record.status] = (target.statuses[record.status] ?? 0) + 1;
+  if (record.error_category) {
+    target.error_categories[record.error_category] = (target.error_categories[record.error_category] ?? 0) + 1;
+  }
+  addSample(target.sample_files, record.file);
+  addSample(target.sample_signatures, record.error_signature ?? record.error);
+}
+
+function buildStandaloneRootCauseMap(records, maxUnclassified) {
+  const buckets = STANDALONE_ROOT_CAUSE_BUCKETS.map(emptyRootCauseBucket);
+  const byId = new Map(buckets.map((bucket) => [bucket.id, bucket]));
+  const unclassified = {
+    id: "unclassified",
+    issues: [],
+    label: "Unclassified standalone failures",
+    count: 0,
+    statuses: createCounts(),
+    error_categories: {},
+    sample_files: [],
+    sample_signatures: [],
+  };
+
+  for (const record of records) {
+    const text = textOf(record);
+    const bucketDef = STANDALONE_ROOT_CAUSE_BUCKETS.find((bucket) => bucket.match(record, text));
+    if (bucketDef) {
+      recordRootCauseHit(byId.get(bucketDef.id), record);
+    } else {
+      recordRootCauseHit(unclassified, record);
+    }
+  }
+
+  return {
+    target: "standalone",
+    total_non_pass_non_skip: records.length,
+    classified: records.length - unclassified.count,
+    unclassified_threshold: maxUnclassified ?? null,
+    buckets: buckets.filter((bucket) => bucket.count > 0),
+    unclassified,
+  };
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  const target = inferTarget(args);
 
   const statuses = createCounts();
   const officialStatuses = createCounts();
@@ -75,6 +565,7 @@ async function main() {
     ["annex_b", createCounts()],
     ["proposal", createCounts()],
   ]);
+  const rootCauseRecords = [];
 
   const rl = createInterface({
     input: createReadStream(args.input),
@@ -118,6 +609,9 @@ async function main() {
     if (status === "skip" && record.error) {
       skipReasons.set(record.error, (skipReasons.get(record.error) ?? 0) + 1);
     }
+    if (target === "standalone" && status !== "pass" && status !== "skip") {
+      rootCauseRecords.push(record);
+    }
   }
 
   // #106 — split totals by ECMAScript-current-standard vs proposals.
@@ -138,6 +632,7 @@ async function main() {
     baseline_generated_at: args.baselineGeneratedAt || new Date().toISOString(),
     baseline_sha: args.baselineSha || "",
     mode: {
+      target,
       include_proposals: args.includeProposals ? 1 : 0,
       label: args.includeProposals ? "official test262 + proposals" : "official test262 (default scope)",
     },
@@ -173,7 +668,22 @@ async function main() {
     skip_reasons: Object.fromEntries([...skipReasons.entries()].sort(([a], [b]) => a.localeCompare(b))),
   };
 
+  if (target === "standalone") {
+    report.root_cause_map = buildStandaloneRootCauseMap(rootCauseRecords, args.maxUnclassifiedRootCauses);
+  }
+
   writeFileSync(args.output, JSON.stringify(report, null, 2));
+
+  if (
+    target === "standalone" &&
+    args.maxUnclassifiedRootCauses !== undefined &&
+    report.root_cause_map.unclassified.count > args.maxUnclassifiedRootCauses
+  ) {
+    console.error(
+      `Standalone root-cause map has ${report.root_cause_map.unclassified.count} unclassified failures; threshold is ${args.maxUnclassifiedRootCauses}.`,
+    );
+    process.exitCode = 1;
+  }
 
   // #1201 — also write a standalone categories file at
   // `<output-dir>/test262-categories.json` for clients that only need
@@ -182,7 +692,8 @@ async function main() {
   // report and avoids the indirection of "fetch report.json then read
   // .categories". Same schema as `report.categories`.
   const outputDir = args.output.replace(/[^/\\]+$/, "");
-  const categoriesPath = outputDir + "test262-categories.json";
+  const categoriesFile = target === "standalone" ? "test262-standalone-categories.json" : "test262-categories.json";
+  const categoriesPath = outputDir + categoriesFile;
   const categoriesPayload = {
     timestamp: report.timestamp,
     baseline_generated_at: report.baseline_generated_at,

--- a/scripts/compiler-pool.ts
+++ b/scripts/compiler-pool.ts
@@ -37,6 +37,9 @@ export interface TestResult {
   status: "pass" | "fail" | "compile_error" | "compile_timeout" | "compiled" | "skip";
   error?: string;
   errorCodes?: number[];
+  imports?: string[];
+  hostImportLeakClass?: string;
+  reachedTest?: boolean;
   ret?: number;
   compileMs?: number;
   execMs?: number;

--- a/scripts/run-test262-vitest.sh
+++ b/scripts/run-test262-vitest.sh
@@ -272,79 +272,28 @@ JSONL_FILE="$RESULTS_DIR/${RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl"
 REPORT_FILE="$RESULTS_DIR/${RESULT_PREFIX}-report-${RUN_TIMESTAMP}.json"
 COMPLETED=false
 if [ -f "$JSONL_FILE" ] && [ -s "$JSONL_FILE" ]; then
-  python3 -c "
-import json
-from collections import Counter
-
-statuses = Counter()
-official_statuses = Counter()
-strict_counts = Counter()
-cats = {}
-errors = Counter()
-skips = Counter()
-scope_counts = {
-    'standard': Counter(),
-    'annex_b': Counter(),
-    'proposal': Counter(),
-}
-
-with open('$JSONL_FILE') as f:
-    for line in f:
-        r = json.loads(line)
-        s = r['status']
-        statuses[s] += 1
-        scope = r.get('scope', 'standard')
-        scope_counts.setdefault(scope, Counter())
-        scope_counts[scope][s] += 1
-        if r.get('scope_official', scope != 'proposal'):
-            official_statuses[s] += 1
-            if r.get('strict', 'both') != 'no':
-                strict_counts[s] += 1
-        cat = r.get('category', 'unknown')
-        if cat not in cats:
-            cats[cat] = {'pass': 0, 'fail': 0, 'compile_error': 0, 'compile_timeout': 0, 'skip': 0, 'total': 0}
-        cats[cat][s] = cats[cat].get(s, 0) + 1
-        cats[cat]['total'] += 1
-        if r.get('error_category'):
-            errors[r['error_category']] += 1
-        if s == 'skip' and r.get('error'):
-            skips[r['error']] += 1
-
-def build_summary(counter):
-    return {
-        'total': sum(counter.values()),
-        'pass': counter.get('pass', 0),
-        'fail': counter.get('fail', 0),
-        'compile_error': counter.get('compile_error', 0),
-        'compile_timeout': counter.get('compile_timeout', 0),
-        'skip': counter.get('skip', 0),
-        'compilable': counter.get('pass', 0) + counter.get('fail', 0),
-        'stale': 0,
-    }
-
-report = {
-    'timestamp': '$(date -Iseconds)',
-    'mode': {
-        'target': '$TEST262_TARGET',
-        'include_proposals': ${INCLUDE_PROPOSALS},
-        'label': 'official test262 + proposals' if ${INCLUDE_PROPOSALS} else 'official test262 (default scope)',
-    },
-    'summary': build_summary(official_statuses),
-    'official_summary': build_summary(official_statuses),
-    'full_summary': build_summary(statuses),
-    'strict_summary': build_summary(strict_counts),
-    'scope_summaries': {name: build_summary(counter) for name, counter in sorted(scope_counts.items())},
-    'categories': [{'name': n, **c} for n, c in sorted(cats.items())],
-    'error_categories': dict(errors),
-    'skip_reasons': dict(skips),
-}
-
-with open('$REPORT_FILE', 'w') as f:
-    json.dump(report, f, indent=2)
-
-s = report['summary']
-print('Report: %d pass / %d total (%.1f%%)' % (s['pass'], s['total'], s['pass']/s['total']*100))
-" && COMPLETED=true
+  report_args=(
+    scripts/build-test262-report.mjs
+    --input "$JSONL_FILE"
+    --output "$REPORT_FILE"
+    --target "$TEST262_TARGET"
+    --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  )
+  if [ "$INCLUDE_PROPOSALS" = "1" ]; then
+    report_args+=(--include-proposals)
+  fi
+  if [ "$TEST262_TARGET" = "standalone" ]; then
+    report_args+=(--max-unclassified-root-causes "${TEST262_MAX_UNCLASSIFIED_ROOT_CAUSES:-0}")
+  fi
+  if node "${report_args[@]}"; then
+    PASS_SUMMARY=$(node -e "const d=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')); const s=d.summary; console.log('Report: '+s.pass+' pass / '+s.total+' total ('+(s.total ? (s.pass/s.total*100).toFixed(1) : '0.0')+'%)')" "$REPORT_FILE")
+    echo "$PASS_SUMMARY"
+    COMPLETED=true
+  else
+    report_status=$?
+    echo "Report generation failed with exit status $report_status"
+    exit "$report_status"
+  fi
 fi
 
 # ── Stop memory monitor ──────────────────────────────────────────

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -786,6 +786,44 @@ function compileTargetFromMessage(target) {
   return target === "linear" || target === "wasi" || target === "standalone" ? target : undefined;
 }
 
+function summarizeImportName(desc) {
+  if (!desc || typeof desc !== "object") return undefined;
+  const moduleName = desc.module ?? desc.moduleName ?? desc.module_name ?? "env";
+  const name = desc.name ?? desc.field ?? desc.fieldName ?? desc.importName;
+  if (!name) return undefined;
+  return `${moduleName}::${name}`;
+}
+
+function summarizeImports(imports) {
+  if (!Array.isArray(imports)) return [];
+  return [...new Set(imports.map(summarizeImportName).filter(Boolean))].sort();
+}
+
+function classifyHostImportLeak(importNames) {
+  if (!Array.isArray(importNames) || importNames.length === 0) return undefined;
+  const joined = importNames.join(" ");
+  if (/__extern_|__object_|__defineProperty|__get_builtin|__new_plain_object|__register_|__proto_method_call/.test(joined)) {
+    return "dynamic_object_property";
+  }
+  if (/__iterator|__array_from_iter|__gen_|generator|async_iterator/.test(joined)) return "iterator_protocol";
+  if (/RegExp_|regexp/i.test(joined)) return "regexp";
+  if (/JSON_/i.test(joined)) return "json";
+  if (/__extern_eval|__dynamic_import|Function_new/.test(joined)) return "dynamic_code";
+  if (/wasm:js-string/.test(joined)) return "js_string";
+  if (/wasi_snapshot_preview1/.test(joined)) return "wasi";
+  return "host_import";
+}
+
+function buildResultMetadata(result, reachedTest) {
+  const imports = summarizeImports(result?.imports);
+  const hostImportLeakClass = classifyHostImportLeak(imports);
+  return {
+    ...(imports.length > 0 ? { imports } : {}),
+    ...(hostImportLeakClass ? { hostImportLeakClass } : {}),
+    reachedTest,
+  };
+}
+
 function makeWorkerRecycleError(reason) {
   const err = new Error(reason);
   err.workerRecycleReason = reason;
@@ -1037,6 +1075,7 @@ process.on("message", async (msg) => {
     return;
   }
   const compileMs = performance.now() - compileStart;
+  const compileMetadata = buildResultMetadata(result, false);
 
   const hasErrors = !result.success || result.errors.some((e) => e.severity === "error");
 
@@ -1073,6 +1112,7 @@ process.on("message", async (msg) => {
         status: hasEarlyError ? "pass" : "pass",
         compileMs,
         errorCodes,
+        ...compileMetadata,
       });
     } else {
       sendResult({
@@ -1081,6 +1121,7 @@ process.on("message", async (msg) => {
         error: errMsg || "unknown",
         errorCodes,
         compileMs,
+        ...compileMetadata,
       });
     }
     return;
@@ -1092,6 +1133,7 @@ process.on("message", async (msg) => {
       status: "pass",
       compileMs,
       errorCodes: result.errors.filter((e) => e.code).map((e) => e.code),
+      ...compileMetadata,
     });
     return;
   }
@@ -1105,7 +1147,7 @@ process.on("message", async (msg) => {
         writeFileSync(msg.metaPath, JSON.stringify({ ok: false, error: errMsg, compileMs, bundle_hash: BUNDLE_HASH }));
       } catch {}
     }
-    sendResult({ id, status: "compile_error", error: errMsg, compileMs });
+    sendResult({ id, status: "compile_error", error: errMsg, compileMs, ...compileMetadata });
     return;
   }
 
@@ -1129,7 +1171,7 @@ process.on("message", async (msg) => {
 
   // Compile-only mode: done
   if (!execute) {
-    sendResult({ id, status: "compiled", compileMs });
+    sendResult({ id, status: "compiled", compileMs, ...compileMetadata });
     return;
   }
 
@@ -1146,10 +1188,11 @@ process.on("message", async (msg) => {
         status: "fail",
         error: `expected parse/early ${expectedErrorType || "error"} but compiled and instantiated successfully`,
         compileMs,
+        ...compileMetadata,
       });
     } catch {
       // Instantiation failed — pass (Wasm validation caught the error)
-      sendResult({ id, status: "pass", compileMs });
+      sendResult({ id, status: "pass", compileMs, ...compileMetadata });
     }
     return;
   }
@@ -1175,12 +1218,13 @@ process.on("message", async (msg) => {
           instantiateError: true,
           compileMs,
           execMs,
+          ...compileMetadata,
         });
         return;
       }
 
       if (isRuntimeNegative) {
-        sendResult({ id, status: "pass", compileMs, execMs, runtimeNegativePass: true });
+        sendResult({ id, status: "pass", compileMs, execMs, runtimeNegativePass: true, ...compileMetadata });
         return;
       }
 
@@ -1192,6 +1236,7 @@ process.on("message", async (msg) => {
         instantiateError: true,
         compileMs,
         execMs,
+        ...compileMetadata,
       });
       return;
     }
@@ -1209,6 +1254,7 @@ process.on("message", async (msg) => {
         error: "no test export",
         compileMs,
         execMs: performance.now() - execStart,
+        ...compileMetadata,
       });
       return;
     }
@@ -1227,16 +1273,17 @@ process.on("message", async (msg) => {
           compileMs,
           execMs,
           runtimeNegativeNoThrow: true,
+          ...buildResultMetadata(result, true),
         });
       } else {
-        sendResult({ id, status: ret === 1 ? "pass" : "fail", ret, compileMs, execMs });
+        sendResult({ id, status: ret === 1 ? "pass" : "fail", ret, compileMs, execMs, ...buildResultMetadata(result, true) });
       }
       return;
     } catch (execErr) {
       const execMs = performance.now() - execStart;
 
       if (isRuntimeNegative) {
-        sendResult({ id, status: "pass", compileMs, execMs, runtimeNegativePass: true });
+        sendResult({ id, status: "pass", compileMs, execMs, runtimeNegativePass: true, ...buildResultMetadata(result, true) });
         return;
       }
 
@@ -1257,6 +1304,7 @@ process.on("message", async (msg) => {
         isException: true,
         compileMs,
         execMs,
+        ...buildResultMetadata(result, true),
       });
       return;
     }
@@ -1278,6 +1326,7 @@ process.on("message", async (msg) => {
         isException: true,
         compileMs,
         execMs: performance.now() - execStart,
+        ...compileMetadata,
       });
     } else {
       sendResult({
@@ -1286,6 +1335,7 @@ process.on("message", async (msg) => {
         error: outerErr.message ?? String(outerErr),
         compileMs,
         execMs: performance.now() - execStart,
+        ...compileMetadata,
       });
     }
     return;

--- a/tests/issue-1781.test.ts
+++ b/tests/issue-1781.test.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+function writeJsonl(path: string, records: Record<string, unknown>[]) {
+  writeFileSync(path, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+}
+
+function buildReport(input: string, output: string, extraArgs: string[] = []) {
+  execFileSync(
+    "node",
+    ["scripts/build-test262-report.mjs", "--input", input, "--output", output, "--target", "standalone", ...extraArgs],
+    { cwd: process.cwd(), stdio: "pipe" },
+  );
+  return JSON.parse(readFileSync(output, "utf-8"));
+}
+
+describe("#1781 standalone test262 artifact root-cause map", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it("builds a standalone root-cause map from JSONL failure metadata", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-1781-"));
+    const input = join(tmpDir, "test262-standalone-results.jsonl");
+    const output = join(tmpDir, "test262-standalone-report.json");
+
+    writeJsonl(input, [
+      {
+        file: "test/language/expressions/literal/pass.js",
+        category: "language/expressions/literal",
+        status: "pass",
+        scope: "standard",
+        scope_official: true,
+        strict: "both",
+        reached_test: true,
+      },
+      {
+        file: "test/built-ins/Object/dynamic-get.js",
+        category: "built-ins/Object",
+        status: "compile_error",
+        error: "No dependency provided for imported function env::__extern_get",
+        error_category: "wasm_compile",
+        error_signature: "wasm_compile:No dependency provided for imported function env::__extern_get",
+        imports: ["env::__extern_get"],
+        host_import_leak_class: "dynamic_object_property",
+        reached_test: false,
+        scope: "standard",
+        scope_official: true,
+        strict: "both",
+      },
+      {
+        file: "test/built-ins/RegExp/prototype/test/basic.js",
+        category: "built-ins/RegExp",
+        status: "fail",
+        error: "returned 2",
+        error_category: "assertion_fail",
+        error_signature: "assertion_fail:returned #",
+        reached_test: true,
+        scope: "standard",
+        scope_official: true,
+        strict: "both",
+      },
+    ]);
+
+    const report = buildReport(input, output, ["--max-unclassified-root-causes", "0"]);
+
+    expect(report.mode.target).toBe("standalone");
+    expect(report.summary.total).toBe(3);
+    expect(report.root_cause_map.total_non_pass_non_skip).toBe(2);
+    expect(report.root_cause_map.classified).toBe(2);
+    expect(report.root_cause_map.unclassified.count).toBe(0);
+
+    const byId = new Map(report.root_cause_map.buckets.map((bucket: any) => [bucket.id, bucket]));
+    expect(byId.get("standalone-dynamic-object-property").issues).toContain("#1472");
+    expect(byId.get("standalone-regexp").issues).toContain("#682");
+    expect(byId.get("standalone-dynamic-object-property").sample_signatures).toContain(
+      "wasm_compile:No dependency provided for imported function env::__extern_get",
+    );
+  });
+
+  it("fails the explicit standalone unclassified threshold", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-1781-threshold-"));
+    const input = join(tmpDir, "test262-standalone-results.jsonl");
+    const output = join(tmpDir, "test262-standalone-report.json");
+
+    writeJsonl(input, [
+      {
+        file: "test/new-area/new-root-cause.js",
+        category: "new-area",
+        status: "fail",
+        error: "brand new diagnostic",
+        error_category: "other",
+        error_signature: "other:brand new diagnostic",
+        reached_test: true,
+        scope: "standard",
+        scope_official: true,
+        strict: "both",
+      },
+    ]);
+
+    expect(() => buildReport(input, output, ["--max-unclassified-root-causes", "0"])).toThrow();
+    const report = JSON.parse(readFileSync(output, "utf-8"));
+    expect(report.root_cause_map.unclassified.count).toBe(1);
+    expect(report.root_cause_map.unclassified.sample_files).toContain("test/new-area/new-root-cause.js");
+  });
+
+  it("wires local and CI standalone report generation to the shared checked builder", () => {
+    const localRunner = readFileSync("scripts/run-test262-vitest.sh", "utf-8");
+    expect(localRunner).toContain("scripts/build-test262-report.mjs");
+    expect(localRunner).toContain('--target "$TEST262_TARGET"');
+    expect(localRunner).toContain("--max-unclassified-root-causes");
+    expect(localRunner).toContain("TEST262_MAX_UNCLASSIFIED_ROOT_CAUSES:-0");
+
+    const shardedWorkflow = readFileSync(".github/workflows/test262-sharded.yml", "utf-8");
+    expect(shardedWorkflow).toContain("--input merged-reports/test262-standalone-results-merged.jsonl");
+    expect(shardedWorkflow).toContain("--target standalone");
+    expect(shardedWorkflow).toContain("--max-unclassified-root-causes 0");
+  });
+});

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -243,6 +243,72 @@ class ConformanceError extends Error {
   }
 }
 
+type RecordMetadata = {
+  imports?: string[];
+  hostImportLeakClass?: string;
+  reachedTest?: boolean;
+};
+
+function normalizeErrorSignature(status: string, errorCategory: string | undefined, error: string | undefined) {
+  if (!error) return undefined;
+  const normalized = error
+    .replace(/\bL\d+:\d+/g, "L#:##")
+    .replace(/\bL\d+\b/g, "L#")
+    .replace(/@\+\d+/g, "@+#")
+    .replace(/0x[0-9a-f]+/gi, "0x#")
+    .replace(/\b\d+(?:\.\d+)?\b/g, "#")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240);
+  return `${errorCategory ?? status}:${normalized}`;
+}
+
+function summarizeImportName(desc: any): string | undefined {
+  if (!desc || typeof desc !== "object") return undefined;
+  const moduleName = desc.module ?? desc.moduleName ?? desc.module_name ?? "env";
+  const name = desc.name ?? desc.field ?? desc.fieldName ?? desc.importName;
+  return name ? `${moduleName}::${name}` : undefined;
+}
+
+function summarizeImports(imports: any[] | undefined): string[] {
+  if (!Array.isArray(imports)) return [];
+  return [...new Set(imports.map(summarizeImportName).filter((name): name is string => Boolean(name)))].sort();
+}
+
+function classifyHostImportLeak(imports: string[] | undefined): string | undefined {
+  if (!imports || imports.length === 0) return undefined;
+  const joined = imports.join(" ");
+  if (
+    /__extern_|__object_|__defineProperty|__get_builtin|__new_plain_object|__register_|__proto_method_call/.test(joined)
+  ) {
+    return "dynamic_object_property";
+  }
+  if (/__iterator|__array_from_iter|__gen_|generator|async_iterator/.test(joined)) return "iterator_protocol";
+  if (/RegExp_|regexp/i.test(joined)) return "regexp";
+  if (/JSON_/i.test(joined)) return "json";
+  if (/__extern_eval|__dynamic_import|Function_new/.test(joined)) return "dynamic_code";
+  if (/wasm:js-string/.test(joined)) return "js_string";
+  if (/wasi_snapshot_preview1/.test(joined)) return "wasi";
+  return "host_import";
+}
+
+function metadataFromImports(imports: any[] | undefined, reachedTest: boolean): RecordMetadata {
+  const names = summarizeImports(imports);
+  return {
+    ...(names.length > 0 ? { imports: names } : {}),
+    ...(names.length > 0 ? { hostImportLeakClass: classifyHostImportLeak(names) } : {}),
+    reachedTest,
+  };
+}
+
+function metadataFromWorkerResult(result: TestResult, reachedTestFallback = false): RecordMetadata {
+  return {
+    ...(result.imports && result.imports.length > 0 ? { imports: result.imports } : {}),
+    ...(result.hostImportLeakClass ? { hostImportLeakClass: result.hostImportLeakClass } : {}),
+    reachedTest: result.reachedTest ?? reachedTestFallback,
+  };
+}
+
 function recordResult(
   file: string,
   category: string,
@@ -251,6 +317,7 @@ function recordResult(
   timing?: { compileMs?: number; execMs?: number },
   scopeInfo?: { scope: Test262Scope; official: boolean; reason?: string; strict?: "only" | "no" | "both" },
   retryInfo?: { retried?: boolean; retryCount?: number },
+  metadata?: RecordMetadata,
 ) {
   const errorCategory = status === "fail" || status === "compile_error" ? classifyError(error) : undefined;
 
@@ -261,6 +328,10 @@ function recordResult(
     status,
     error: error || undefined,
     error_category: errorCategory,
+    error_signature: normalizeErrorSignature(status, errorCategory, error),
+    imports: metadata?.imports && metadata.imports.length > 0 ? metadata.imports : undefined,
+    host_import_leak_class: metadata?.hostImportLeakClass,
+    reached_test: metadata?.reachedTest ?? false,
     compile_ms: timing?.compileMs !== undefined ? Math.round(timing.compileMs) : undefined,
     exec_ms: timing?.execMs !== undefined ? Math.round(timing.execMs) : undefined,
     scope: scopeInfo?.scope ?? "standard",
@@ -506,18 +577,39 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   skipSemanticDiagnostics: true,
                   target: TEST262_TARGET,
                 });
+                const compileRecordMetadata = metadataFromImports(result.imports, false);
+                const reachedRecordMetadata = metadataFromImports(result.imports, true);
                 if (!result.success || result.binary.length === 0) {
                   if (isNegative) {
-                    recordResult(relPath, category, "pass", undefined, undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "pass",
+                      undefined,
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      compileRecordMetadata,
+                    );
                   } else {
                     const errMsg = result.errors.map((e: any) => `L${e.line}:${e.column} ${e.message}`).join("; ");
-                    recordResult(relPath, category, "compile_error", errMsg, undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "compile_error",
+                      errMsg,
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      compileRecordMetadata,
+                    );
                   }
                   return;
                 }
                 // Execute the compiled binary in-process (fixture tests are rare,
                 // in-process execution is acceptable for 172 tests).
                 const buildImports = await getBuildImports();
+                let reachedFixtureTest = false;
                 try {
                   const importObj = buildImports(result.imports, undefined, result.stringPool);
                   const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
@@ -533,12 +625,31 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                       // compiler is permissive and produces a module without
                       // a `test` export, which we count as the expected
                       // failure outcome — the test module never formed.
-                      recordResult(relPath, category, "pass", undefined, undefined, scopeInfo);
+                      recordResult(
+                        relPath,
+                        category,
+                        "pass",
+                        undefined,
+                        undefined,
+                        scopeInfo,
+                        undefined,
+                        compileRecordMetadata,
+                      );
                     } else {
-                      recordResult(relPath, category, "compile_error", "no test export", undefined, scopeInfo);
+                      recordResult(
+                        relPath,
+                        category,
+                        "compile_error",
+                        "no test export",
+                        undefined,
+                        scopeInfo,
+                        undefined,
+                        compileRecordMetadata,
+                      );
                     }
                     return;
                   }
+                  reachedFixtureTest = true;
                   const ret = testFn();
                   if (isNegative) {
                     // Negative parse/resolution test compiled, instantiated,
@@ -552,6 +663,8 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                       `expected ${meta.negative!.phase} ${meta.negative!.type} but compiled, instantiated, and ran (returned ${ret})`,
                       undefined,
                       scopeInfo,
+                      undefined,
+                      reachedRecordMetadata,
                     );
                     return;
                   }
@@ -564,19 +677,58 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                       `expected runtime ${meta.negative!.type} but execution succeeded`,
                       undefined,
                       scopeInfo,
+                      undefined,
+                      reachedRecordMetadata,
                     );
                   } else if (ret === 1 || ret === 1.0) {
-                    recordResult(relPath, category, "pass", undefined, undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "pass",
+                      undefined,
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      reachedRecordMetadata,
+                    );
                   } else {
-                    recordResult(relPath, category, "fail", `returned ${ret}`, undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "fail",
+                      `returned ${ret}`,
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      reachedRecordMetadata,
+                    );
                   }
                 } catch (execErr: any) {
+                  const execRecordMetadata = metadataFromImports(result.imports, reachedFixtureTest);
                   if (isRuntimeNegative || isNegative) {
                     // For isNegative (parse/early/resolution), Wasm validation
                     // or a thrown start-function counts as the expected error.
-                    recordResult(relPath, category, "pass", undefined, undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "pass",
+                      undefined,
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      execRecordMetadata,
+                    );
                   } else {
-                    recordResult(relPath, category, "fail", String(execErr), undefined, scopeInfo);
+                    recordResult(
+                      relPath,
+                      category,
+                      "fail",
+                      String(execErr),
+                      undefined,
+                      scopeInfo,
+                      undefined,
+                      execRecordMetadata,
+                    );
                   }
                 }
               } catch (e: any) {
@@ -588,7 +740,16 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                 // is the only JSONL entry, matching the non-FIXTURE path
                 // which has no outer catch.
                 if (e instanceof ConformanceError) throw e;
-                recordResult(relPath, category, "compile_error", e.message ?? String(e), undefined, scopeInfo);
+                recordResult(
+                  relPath,
+                  category,
+                  "compile_error",
+                  e.message ?? String(e),
+                  undefined,
+                  scopeInfo,
+                  undefined,
+                  { reachedTest: false },
+                );
               }
               return;
             }
@@ -616,7 +777,16 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
 
             // Map worker result to recordResult
             if (r.status === "pass") {
-              recordResult(relPath, category, "pass", undefined, timing, scopeInfo);
+              recordResult(
+                relPath,
+                category,
+                "pass",
+                undefined,
+                timing,
+                scopeInfo,
+                undefined,
+                metadataFromWorkerResult(r, true),
+              );
               return;
             }
 
@@ -648,7 +818,16 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                 const retryInfo = { retried: true, retryCount: 1 };
 
                 if (retry.status === "pass") {
-                  recordResult(relPath, category, "pass", undefined, retryTiming, scopeInfo, retryInfo);
+                  recordResult(
+                    relPath,
+                    category,
+                    "pass",
+                    undefined,
+                    retryTiming,
+                    scopeInfo,
+                    retryInfo,
+                    metadataFromWorkerResult(retry, true),
+                  );
                   return;
                 }
                 if (retry.status === "fail") {
@@ -656,19 +835,46 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   // fail with the retry error message (preserves the new
                   // signal rather than the timeout-shaped one).
                   const error = retry.error ? adjustErrorLines(retry.error, lineAdjustOffset) : "fail after retry";
-                  recordResult(relPath, category, "fail", error, retryTiming, scopeInfo, retryInfo);
+                  recordResult(
+                    relPath,
+                    category,
+                    "fail",
+                    error,
+                    retryTiming,
+                    scopeInfo,
+                    retryInfo,
+                    metadataFromWorkerResult(retry, true),
+                  );
                   return;
                 }
                 // compile_error or another compile_timeout on retry → record
                 // the retry status (with retried flag) so we can distinguish
                 // genuine-slow tests from flakes in baseline analysis.
                 const retryError = retry.error ? adjustErrorLines(retry.error, lineAdjustOffset) : retry.status;
-                recordResult(relPath, category, retry.status, retryError, retryTiming, scopeInfo, retryInfo);
+                recordResult(
+                  relPath,
+                  category,
+                  retry.status,
+                  retryError,
+                  retryTiming,
+                  scopeInfo,
+                  retryInfo,
+                  metadataFromWorkerResult(retry, false),
+                );
                 return;
               }
 
               const error = r.error ? adjustErrorLines(r.error, lineAdjustOffset) : r.status;
-              recordResult(relPath, category, r.status, error, timing, scopeInfo);
+              recordResult(
+                relPath,
+                category,
+                r.status,
+                error,
+                timing,
+                scopeInfo,
+                undefined,
+                metadataFromWorkerResult(r, false),
+              );
               return;
             }
 
@@ -714,12 +920,30 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                 }
               }
 
-              recordResult(relPath, category, "fail", error, timing, scopeInfo);
+              recordResult(
+                relPath,
+                category,
+                "fail",
+                error,
+                timing,
+                scopeInfo,
+                undefined,
+                metadataFromWorkerResult(r, true),
+              );
               return;
             }
 
             // Fallback
-            recordResult(relPath, category, r.status || "fail", r.error || "unknown", timing, scopeInfo);
+            recordResult(
+              relPath,
+              category,
+              r.status || "fail",
+              r.error || "unknown",
+              timing,
+              scopeInfo,
+              undefined,
+              metadataFromWorkerResult(r, false),
+            );
           },
           90_000,
         );


### PR DESCRIPTION
## What changed

- Enriched standalone test262 JSONL rows with `error_signature`, summarized `imports`, `host_import_leak_class`, and `reached_test` metadata.
- Added a standalone `root_cause_map` to `scripts/build-test262-report.mjs` with mapped buckets, samples, and an explicit unclassified threshold gate.
- Routed local standalone report generation through the shared report builder and added the zero-unclassified gate to the sharded standalone CI report step.
- Added focused issue coverage in `tests/issue-1781.test.ts`.

## Validation

- `pnpm test tests/issue-1781.test.ts`
- `pnpm test tests/build-test262-report.test.ts`
- `pnpm test tests/issue-1781.test.ts tests/build-test262-report.test.ts`
- `bash -n scripts/run-test262-vitest.sh`
- `node --check scripts/build-test262-report.mjs`
- `node --check scripts/test262-worker.mjs`
- `pnpm exec tsc --noEmit --pretty false`
- Fetched `test262-standalone-current.jsonl` from `loopdive/js2wasm-baselines` and rebuilt the standalone report with `--max-unclassified-root-causes 0`; all 40,189 non-pass/non-skip rows classified, 0 unclassified.

No full local test262 run was performed.
