### PR TITLE
fix(native-strings): stabilize standalone string methods

### DIFF
--- a/plan/issues/1105-wasm-native-string-method-implementations.md
+++ b/plan/issues/1105-wasm-native-string-method-implementations.md
@@ -1,7 +1,7 @@
 ---
 id: 1105
 title: "Wasm-native String method implementations for standalone mode"
-status: ready
+status: in-progress
 created: 2026-04-12
 updated: 2026-06-02
 priority: high
@@ -12,12 +12,15 @@ language_feature: string-methods
 goal: standalone-mode
 sprint: 58
 es_edition: multi
+claimed_by: codex-developer
+claimed_at: 2026-06-02T20:52:56.870Z
 ---
+
 # #1105 — Wasm-native String method implementations for standalone mode
 
 ## Problem
 
-The `--nativeStrings` flag stores strings as WasmGC i16 arrays instead of wasm:js-string, but string *methods* (split, replace, match, indexOf, slice, trim, etc.) are still delegated to the JS host via `string_*` host imports in runtime.ts. In standalone mode, these methods are unavailable.
+The `--nativeStrings` flag stores strings as WasmGC i16 arrays instead of wasm:js-string, but string _methods_ (split, replace, match, indexOf, slice, trim, etc.) are still delegated to the JS host via `string_*` host imports in runtime.ts. In standalone mode, these methods are unavailable.
 
 ## Current state
 
@@ -30,7 +33,9 @@ The `--nativeStrings` flag stores strings as WasmGC i16 arrays instead of wasm:j
 Implement string methods as Wasm functions operating on `(array i16)`:
 
 ### Tier 1 — Pure array operations (no RegExp dependency)
+
 These can be implemented purely in terms of i16 array operations:
+
 - `charAt`, `charCodeAt`, `codePointAt`
 - `indexOf`, `lastIndexOf`, `includes`, `startsWith`, `endsWith`
 - `slice`, `substring`
@@ -43,13 +48,16 @@ These can be implemented purely in terms of i16 array operations:
 - `at`
 
 ### Tier 2 — RegExp-dependent (depends on #682)
+
 These need a standalone RegExp engine:
+
 - `match`, `matchAll`
 - `replace`, `replaceAll` (with RegExp pattern)
 - `search`
 - `split` (with RegExp separator)
 
 ### Tier 3 — Locale-dependent
+
 - `localeCompare`, `toLocaleLowerCase`, `toLocaleUpperCase`
 - These may need ICU data or simplified locale handling
 
@@ -82,6 +90,7 @@ infrastructure and the first three methods as exemplars.)
 `src/codegen/native-strings.ts` (existing). Add per-method emitter
 functions invoked from `compileMemberCall` in
 `src/codegen/expressions.ts` when:
+
 1. `ctx.nativeStrings || ctx.wasi` is true.
 2. Receiver static type is `string`.
 3. Method name is in the Tier-1 list.
@@ -122,19 +131,19 @@ sorted i32 array constant; use binary search.
 
 ### Method coverage — Tier 1 (all in scope for this issue)
 
-| Method | LOC est | Special notes |
-|--------|---------|---------------|
-| charAt, charCodeAt, codePointAt | 30 | bounds-check returns NaN |
-| at | 20 | negative index |
-| indexOf, lastIndexOf, includes | 40 each | naive O(nm); Boyer-Moore later |
-| startsWith, endsWith | 25 each | |
-| slice, substring | 40 each | substring has min/max swap |
-| trim, trimStart, trimEnd | 30 each | whitespace constant table |
-| padStart, padEnd | 35 each | pad-string repeat handling |
-| repeat | 25 | overflow check; throws RangeError if > 2^28 |
-| concat | 30 | accepts varargs; length sum |
-| split (string sep) | 50 | empty-sep → codepoint split |
-| toUpperCase, toLowerCase | 60 + table | Unicode case mapping |
+| Method                          | LOC est    | Special notes                               |
+| ------------------------------- | ---------- | ------------------------------------------- |
+| charAt, charCodeAt, codePointAt | 30         | bounds-check returns NaN                    |
+| at                              | 20         | negative index                              |
+| indexOf, lastIndexOf, includes  | 40 each    | naive O(nm); Boyer-Moore later              |
+| startsWith, endsWith            | 25 each    |                                             |
+| slice, substring                | 40 each    | substring has min/max swap                  |
+| trim, trimStart, trimEnd        | 30 each    | whitespace constant table                   |
+| padStart, padEnd                | 35 each    | pad-string repeat handling                  |
+| repeat                          | 25         | overflow check; throws RangeError if > 2^28 |
+| concat                          | 30         | accepts varargs; length sum                 |
+| split (string sep)              | 50         | empty-sep → codepoint split                 |
+| toUpperCase, toLowerCase        | 60 + table | Unicode case mapping                        |
 
 ### Unicode case mapping
 
@@ -183,3 +192,35 @@ Acceptance: Tier 1 ≥70% pass rate.
 - **Spec edge cases**: ToString coercion on arg objects (e.g. arg
   with `Symbol.toPrimitive`) needs #1525 — for now, fail with
   TypeError when arg is a wasmgc object.
+
+## Implementation Update — 2026-06-02
+
+- Stabilized the existing native string helper path for standalone Tier 1
+  coverage instead of adding host imports.
+- Search-style methods (`indexOf`, `lastIndexOf`, `includes`,
+  `startsWith`, `endsWith`) now stage receiver, search value, and position
+  arguments in locals before calling native helpers. This keeps the fast-mode
+  stack-balance pass from inserting numeric coercions into string literal
+  construction and also handles omitted search values as `"undefined"`.
+- Native `repeat` and `normalize` RangeError paths now materialize throw
+  messages as native string constants rather than reading `stringGlobalMap`
+  sentinel globals.
+- Native `codePointAt` now checks bounds before array access and combines
+  valid UTF-16 surrogate pairs. The f64 lowering returns `NaN` for
+  out-of-range positions.
+- Native IR lowering for `indexOf` and `includes` falls back to the legacy
+  member-call path so these helpers keep the native receiver/search/position
+  staging above.
+
+Scoped validation:
+
+- `pnpm exec vitest run tests/issue-1105.test.ts --reporter=dot`
+- `pnpm exec vitest run tests/issue-1105.test.ts tests/native-strings.test.ts tests/issue-1105-charcodeat.test.ts tests/native-strings-standalone.test.ts --reporter=dot`
+- `pnpm exec vitest run tests/issue-1232.test.ts tests/issue-1470-standalone-string-imports.test.ts tests/host-import-allowlist-gate.test.ts --reporter=dot`
+
+Remaining scope:
+
+- Full test262 Tier 1 coverage was not run locally per scoped validation
+  rules.
+- Unicode case-mapping tables, locale behavior, and RegExp-dependent methods
+  remain outside this focused implementation pass.

--- a/plan/issues/1105-wasm-native-string-method-implementations.md
+++ b/plan/issues/1105-wasm-native-string-method-implementations.md
@@ -1,7 +1,7 @@
 ---
 id: 1105
 title: "Wasm-native String method implementations for standalone mode"
-status: in-progress
+status: in-review
 created: 2026-04-12
 updated: 2026-06-02
 priority: high
@@ -14,6 +14,7 @@ sprint: 58
 es_edition: multi
 claimed_by: codex-developer
 claimed_at: 2026-06-02T20:52:56.870Z
+pr: 1046
 ---
 
 # #1105 — Wasm-native String method implementations for standalone mode

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -14,7 +14,7 @@ import { allocLocal } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { emitThrowTypeError, getFuncParamTypes, noJsHost } from "./expressions/helpers.js";
 import { addStringImports, addUnionImports, flatStringType, nativeStringType, resolveWasmType } from "./index.js";
-import { ensureNativeStringExternBridge } from "./native-strings.js";
+import { ensureNativeStringExternBridge, stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterTemplateVecType, getOrRegisterVecType } from "./registry/types.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts, registerCompileStringLiteral } from "./shared.js";
@@ -1471,11 +1471,9 @@ function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg
     fctx.body.push({ op: "i32.const", value: 0 });
     return;
   }
-  const argType = compileExpression(ctx, fctx, arg, { kind: "f64" });
+  const argType = compileExpression(ctx, fctx, arg, { kind: "i32" });
   if (!argType) {
     fctx.body.push({ op: "i32.const", value: 0 });
-  } else if (argType.kind === "f64") {
-    fctx.body.push({ op: "i32.trunc_sat_f64_s" });
   } else if (argType.kind === "i64") {
     // BigInt fell through static detection (e.g. `any` widened to bigint).
     // Drop the i64 and throw TypeError per §7.1.4.
@@ -1503,6 +1501,26 @@ export function compileNativeStringMethodCall(
 
   // Helper: emit a flatten call to convert ref $AnyString → ref $NativeString
   const emitFlatten = () => fctx.body.push({ op: "call", funcIdx: flattenIdx });
+  const compileStringValueToLocal = (value: ts.Expression | undefined, fallback: string, name: string): number => {
+    const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, nativeStringType(ctx));
+    if (value) {
+      compileExpression(ctx, fctx, value, nativeStringType(ctx));
+    } else {
+      compileStringLiteral(ctx, fctx, fallback);
+    }
+    fctx.body.push({ op: "local.set", index: local });
+    return local;
+  };
+  const compileIntegerValueToLocal = (value: ts.Expression | undefined, fallback: number, name: string): number => {
+    const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, { kind: "i32" });
+    if (value) {
+      compileStringIntegerArg(ctx, fctx, value);
+    } else {
+      fctx.body.push({ op: "i32.const", value: fallback });
+    }
+    fctx.body.push({ op: "local.set", index: local });
+    return local;
+  };
 
   // charCodeAt: inline array.get_u with offset (must flatten first).
   // ECMA-262 §22.1.3.3: ToIntegerOrInfinity(pos), then return NaN when
@@ -1651,104 +1669,65 @@ export function compileNativeStringMethodCall(
 
   // indexOf: native helper
   if (method === "indexOf") {
-    compileExpression(ctx, fctx, propAccess.expression);
-    emitFlatten();
-    // search string arg
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]!);
-      emitFlatten();
-    } else {
-      fctx.body.push({ op: "ref.null", typeIdx: strTypeIdx });
-    }
-    // fromIndex arg (ToInteger per spec — throws TypeError on BigInt/Symbol)
-    if (expr.arguments.length > 1) {
-      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0 });
-    }
+    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_indexOf_recv");
+    const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_indexOf_search");
+    const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_indexOf_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_indexOf")!;
+    fctx.body.push({ op: "local.get", index: receiverLocal });
+    fctx.body.push({ op: "local.get", index: searchLocal });
+    fctx.body.push({ op: "local.get", index: fromLocal });
     fctx.body.push({ op: "call", funcIdx });
     return { kind: "i32" };
   }
 
   // lastIndexOf: native helper
   if (method === "lastIndexOf") {
-    compileExpression(ctx, fctx, propAccess.expression);
-    emitFlatten();
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]!);
-      emitFlatten();
-    } else {
-      fctx.body.push({ op: "ref.null", typeIdx: strTypeIdx });
-    }
-    if (expr.arguments.length > 1) {
-      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0x7fffffff });
-    }
+    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_lastIndexOf_recv");
+    const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_lastIndexOf_search");
+    const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0x7fffffff, "__str_lastIndexOf_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_lastIndexOf")!;
+    fctx.body.push({ op: "local.get", index: receiverLocal });
+    fctx.body.push({ op: "local.get", index: searchLocal });
+    fctx.body.push({ op: "local.get", index: fromLocal });
     fctx.body.push({ op: "call", funcIdx });
     return { kind: "i32" };
   }
 
   // includes: native helper
   if (method === "includes") {
-    compileExpression(ctx, fctx, propAccess.expression);
-    emitFlatten();
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]!);
-      emitFlatten();
-    } else {
-      fctx.body.push({ op: "ref.null", typeIdx: strTypeIdx });
-    }
-    if (expr.arguments.length > 1) {
-      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0 });
-    }
+    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_includes_recv");
+    const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_includes_search");
+    const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_includes_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_includes")!;
+    fctx.body.push({ op: "local.get", index: receiverLocal });
+    fctx.body.push({ op: "local.get", index: searchLocal });
+    fctx.body.push({ op: "local.get", index: fromLocal });
     fctx.body.push({ op: "call", funcIdx });
     return { kind: "i32" };
   }
 
   // startsWith: native helper
   if (method === "startsWith") {
-    compileExpression(ctx, fctx, propAccess.expression);
-    emitFlatten();
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]!);
-      emitFlatten();
-    } else {
-      fctx.body.push({ op: "ref.null", typeIdx: strTypeIdx });
-    }
-    if (expr.arguments.length > 1) {
-      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0 });
-    }
+    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_startsWith_recv");
+    const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_startsWith_search");
+    const posLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_startsWith_pos");
     const funcIdx = ctx.nativeStrHelpers.get("__str_startsWith")!;
+    fctx.body.push({ op: "local.get", index: receiverLocal });
+    fctx.body.push({ op: "local.get", index: searchLocal });
+    fctx.body.push({ op: "local.get", index: posLocal });
     fctx.body.push({ op: "call", funcIdx });
     return { kind: "i32" };
   }
 
   // endsWith: native helper
   if (method === "endsWith") {
-    compileExpression(ctx, fctx, propAccess.expression);
-    emitFlatten();
-    // suffix arg
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]!);
-      emitFlatten();
-    } else {
-      fctx.body.push({ op: "ref.null", typeIdx: strTypeIdx });
-    }
-    // endPosition arg — default to string length
-    if (expr.arguments.length > 1) {
-      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0x7fffffff });
-    }
+    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_endsWith_recv");
+    const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_endsWith_search");
+    const endLocal = compileIntegerValueToLocal(expr.arguments[1], 0x7fffffff, "__str_endsWith_end");
     const funcIdx = ctx.nativeStrHelpers.get("__str_endsWith")!;
+    fctx.body.push({ op: "local.get", index: receiverLocal });
+    fctx.body.push({ op: "local.get", index: searchLocal });
+    fctx.body.push({ op: "local.get", index: endLocal });
     fctx.body.push({ op: "call", funcIdx });
     return { kind: "i32" };
   }
@@ -1792,12 +1771,11 @@ export function compileNativeStringMethodCall(
         {
           const rangeErrMsg = "RangeError: Invalid count value";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
             else: [],
           });
         }
@@ -1984,28 +1962,103 @@ export function compileNativeStringMethodCall(
   }
 
   // codePointAt: like charCodeAt but returns f64 (code point value)
-  // For BMP characters (most common), codePoint === charCode.
-  // Full surrogate pair handling would be more complex, but this covers most test262 cases.
+  // ECMA-262 §22.1.3.4 delegates to CodePointAt: out-of-range produces
+  // undefined in JS. This numeric lowering uses NaN as the existing f64
+  // sentinel, and combines a valid UTF-16 surrogate pair when one starts at
+  // position.
   if (method === "codePointAt") {
     compileExpression(ctx, fctx, propAccess.expression);
     emitFlatten();
     const tmpLocal = allocLocal(fctx, "__codePointAt_tmp", flatStringType(ctx));
     fctx.body.push({ op: "local.set", index: tmpLocal });
-    // Push data ref (field 2)
-    fctx.body.push({ op: "local.get", index: tmpLocal });
-    fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }); // .data
-    // Compute off + idx
-    fctx.body.push({ op: "local.get", index: tmpLocal });
-    fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }); // .off
+    const idxLocal = allocLocal(fctx, `__codePointAt_idx_${fctx.locals.length}`, { kind: "i32" });
     if (expr.arguments.length > 0) {
       compileStringIntegerArg(ctx, fctx, expr.arguments[0]!);
     } else {
       fctx.body.push({ op: "i32.const", value: 0 });
     }
-    fctx.body.push({ op: "i32.add" }); // off + idx
-    fctx.body.push({ op: "array.get_u", typeIdx: strDataTypeIdx });
-    // Convert i32 code unit to f64
-    fctx.body.push({ op: "f64.convert_i32_u" });
+    fctx.body.push({ op: "local.set", index: idxLocal });
+    const firstLocal = allocLocal(fctx, `__codePointAt_first_${fctx.locals.length}`, { kind: "i32" });
+    const secondLocal = allocLocal(fctx, `__codePointAt_second_${fctx.locals.length}`, { kind: "i32" });
+
+    fctx.body.push({ op: "local.get", index: idxLocal });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "i32.lt_s" });
+    fctx.body.push({ op: "local.get", index: idxLocal });
+    fctx.body.push({ op: "local.get", index: tmpLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 });
+    fctx.body.push({ op: "i32.ge_s" });
+    fctx.body.push({ op: "i32.or" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: NaN }],
+      else: [
+        { op: "local.get", index: tmpLocal },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+        { op: "local.get", index: tmpLocal },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+        { op: "local.get", index: idxLocal },
+        { op: "i32.add" },
+        { op: "array.get_u", typeIdx: strDataTypeIdx },
+        { op: "local.tee", index: firstLocal },
+        { op: "i32.const", value: 0xd800 },
+        { op: "i32.ge_u" },
+        { op: "local.get", index: firstLocal },
+        { op: "i32.const", value: 0xdbff },
+        { op: "i32.le_u" },
+        { op: "i32.and" },
+        { op: "local.get", index: idxLocal },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.get", index: tmpLocal },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
+        { op: "i32.lt_s" },
+        { op: "i32.and" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "f64" } },
+          then: [
+            { op: "local.get", index: tmpLocal },
+            { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+            { op: "local.get", index: tmpLocal },
+            { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+            { op: "local.get", index: idxLocal },
+            { op: "i32.add" },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.tee", index: secondLocal },
+            { op: "i32.const", value: 0xdc00 },
+            { op: "i32.ge_u" },
+            { op: "local.get", index: secondLocal },
+            { op: "i32.const", value: 0xdfff },
+            { op: "i32.le_u" },
+            { op: "i32.and" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "f64" } },
+              then: [
+                { op: "local.get", index: firstLocal },
+                { op: "i32.const", value: 0xd800 },
+                { op: "i32.sub" },
+                { op: "i32.const", value: 10 },
+                { op: "i32.shl" },
+                { op: "local.get", index: secondLocal },
+                { op: "i32.const", value: 0xdc00 },
+                { op: "i32.sub" },
+                { op: "i32.add" },
+                { op: "i32.const", value: 0x10000 },
+                { op: "i32.add" },
+                { op: "f64.convert_i32_u" },
+              ],
+              else: [{ op: "local.get", index: firstLocal }, { op: "f64.convert_i32_u" }],
+            },
+          ],
+          else: [{ op: "local.get", index: firstLocal }, { op: "f64.convert_i32_u" }],
+        },
+      ],
+    } as Instr);
     return { kind: "f64" };
   }
 
@@ -2021,9 +2074,8 @@ export function compileNativeStringMethodCall(
           // Static RangeError — emit unconditional throw
           const rangeErrMsg = "RangeError: The normalization form should be one of NFC, NFD, NFKC, NFKD";
           addStringConstantGlobal(ctx, rangeErrMsg);
-          const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
           const tagIdx = ensureExnTag(ctx);
-          fctx.body.push({ op: "global.get", index: strIdx } as Instr);
+          fctx.body.push(...stringConstantExternrefInstrs(ctx, rangeErrMsg));
           fctx.body.push({ op: "throw", tagIdx } as Instr);
           return null;
         }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2437,6 +2437,9 @@ function lowerStringMethodCall(
   }
 
   const useNative = cx.resolver?.nativeStrings?.() === true;
+  if (useNative && (methodName === "indexOf" || methodName === "includes")) {
+    return null;
+  }
   const funcName = useNative ? `__str_${methodName}` : `string_${methodName}`;
 
   // Build the argument list. params[0] is always the receiver

--- a/tests/issue-1105.test.ts
+++ b/tests/issue-1105.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1105 — Wasm-native String.prototype methods in nativeStrings/standalone mode.
+//
+// Spec references:
+// - ECMA-262 §22.1.3.9 String.prototype.indexOf: StringIndexOf + -1 for not-found.
+// - ECMA-262 §22.1.3.22 String.prototype.split: string separators produce an Array of substrings.
+// - ECMA-262 §22.1.3.32 String.prototype.trim: returns TrimString(string, start+end).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+function envStringMethodImports(imports: Array<{ module: string; name: string }>): string[] {
+  return imports.filter((imp) => imp.module === "env" && imp.name.startsWith("string_")).map((imp) => imp.name);
+}
+
+async function compileNativeRuntime(
+  source: string,
+  options: { fast?: boolean } = {},
+): Promise<Record<string, unknown>> {
+  const result = await compile(source, {
+    fast: options.fast ?? true,
+    nativeStrings: true,
+    testRuntime: true,
+    fileName: "issue-1105.ts",
+  });
+  expect(result.success, result.errors.map((err) => err.message).join("\n")).toBe(true);
+  expect(envStringMethodImports(result.imports)).toEqual([]);
+
+  const imports = buildImports(result.imports, ENV_STUB, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, unknown>;
+}
+
+describe("#1105 native String method helpers", () => {
+  it("does not request JS-host string method imports for standalone Tier 1 methods", async () => {
+    const result = await compile(
+      `
+      export function indexOfAcceptance(): number {
+        return "hello".indexOf("ll");
+      }
+
+      export function splitAcceptance(): number {
+        const parts = "hello world".split(" ");
+        return parts.length * 100 + parts[0].length * 10 + parts[1].length;
+      }
+
+      export function trimAcceptance(): number {
+        return "  hello  ".trim().length;
+      }
+
+      export function codePointAcceptance(): number {
+        return "😀".codePointAt(0)!;
+      }
+      `,
+      { target: "standalone", fileName: "issue-1105-standalone.ts" },
+    );
+
+    expect(result.success, result.errors.map((err) => err.message).join("\n")).toBe(true);
+    expect(envStringMethodImports(result.imports)).toEqual([]);
+    expect(result.wat).not.toContain("wasm:js-string");
+  });
+
+  it("runs indexOf, split, and trim acceptance cases through native Wasm helpers", async () => {
+    const exports = await compileNativeRuntime(`
+      export function indexOfAcceptance(): number {
+        return "hello".indexOf("ll");
+      }
+
+      export function splitAcceptance(): number {
+        const parts = "hello world".split(" ");
+        return parts.length * 100 + parts[0].length * 10 + parts[1].length;
+      }
+
+      export function trimAcceptance(): number {
+        return "  hello  ".trim().length;
+      }
+
+      export function codePointAcceptance(): number {
+        return "😀".codePointAt(0)!;
+      }
+
+    `);
+
+    expect((exports.indexOfAcceptance as () => number)()).toBe(2);
+    expect((exports.splitAcceptance as () => number)()).toBe(255);
+    expect((exports.trimAcceptance as () => number)()).toBe(5);
+    expect((exports.codePointAcceptance as () => number)()).toBe(0x1f600);
+  });
+
+  it("returns the native numeric sentinel for out-of-range codePointAt before fast i32 coercion", async () => {
+    const exports = await compileNativeRuntime(
+      `
+      export function codePointOutOfRange(): number {
+        return "abc".codePointAt(9)!;
+      }
+      `,
+      { fast: false },
+    );
+
+    expect(Number.isNaN((exports.codePointOutOfRange as () => number)())).toBe(true);
+  });
+
+  it("keeps native string method numeric arguments stack-valid in fast mode", async () => {
+    const exports = await compileNativeRuntime(`
+      export function indexFrom(): number {
+        return "abcabc".indexOf("abc", 1);
+      }
+
+      export function startsAt(): number {
+        return "hello world".startsWith("world", 6) ? 1 : 0;
+      }
+
+      export function includesBranch(): number {
+        return "hello world".includes("world") ? 1 : 0;
+      }
+    `);
+
+    expect((exports.indexFrom as () => number)()).toBe(3);
+    expect((exports.startsAt as () => number)()).toBe(1);
+    expect((exports.includesBranch as () => number)()).toBe(1);
+  });
+
+  it("validates repeat without emitting invalid native string globals", async () => {
+    const exports = await compileNativeRuntime(`
+      export function repeatLen(): number {
+        return "ab".repeat(3).length;
+      }
+    `);
+
+    expect((exports.repeatLen as () => number)()).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
- stabilize native string helper lowering for standalone Tier 1 methods without adding env string imports
- stage search-method receiver/search/position args in locals to avoid fast-mode stack-balance corruption
- fix native RangeError string materialization and codePointAt bounds/surrogate handling

## Validation
- pnpm exec vitest run tests/issue-1105.test.ts --reporter=dot
- pnpm exec vitest run tests/issue-1105.test.ts tests/native-strings.test.ts tests/issue-1105-charcodeat.test.ts tests/native-strings-standalone.test.ts --reporter=dot
- pnpm exec vitest run tests/issue-1232.test.ts tests/issue-1470-standalone-string-imports.test.ts tests/host-import-allowlist-gate.test.ts --reporter=dot

Issue: #1105