### PR TITLE
feat(json): add standalone static JSON slice

### DIFF
--- a/plan/issues/1599-json-standalone.md
+++ b/plan/issues/1599-json-standalone.md
@@ -1,7 +1,8 @@
 ---
 id: 1599
 title: "host-indep: JSON.parse / JSON.stringify in standalone mode"
-status: in-progress
+status: in-review
+pr: 1048
 created: 2026-05-24
 updated: 2026-06-03
 priority: high

--- a/plan/issues/1599-json-standalone.md
+++ b/plan/issues/1599-json-standalone.md
@@ -3,7 +3,7 @@ id: 1599
 title: "host-indep: JSON.parse / JSON.stringify in standalone mode"
 status: in-progress
 created: 2026-05-24
-updated: 2026-06-02
+updated: 2026-06-03
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -251,3 +251,58 @@ Phase 2: ~350 LOC (serialiser + parser helper emitters), hard. No external toolc
 - `pnpm exec vitest run tests/issue-1599-json-standalone-refuse.test.ts` —
   12 tests passed after adding the standalone `JSON.stringify(number)` refusal
   regression case.
+
+## Status — Phase 2A literal standalone slice implemented
+
+This branch implements the first runtime-host-independent JSON slice for
+standalone/WASI while keeping unsupported dynamic JSON on the existing clear
+`#1599` compile-error path.
+
+### What changed
+
+- `src/codegen/json-standalone.ts` adds a bounded static JSON evaluator:
+  - `JSON.stringify(<static JSON-compatible literal graph>)` is folded at
+    compile time and emitted as a native string, with runtime output fully
+    standalone.
+  - `JSON.parse(<static string literal>).prop` and `[index]` are parsed by the
+    compiler and lowered to Wasm constants/native strings.
+  - static JSON primitive parses (`"x"`, `42`, `true`, `null`) lower without
+    `env::JSON_parse`.
+- `src/codegen/declarations.ts` now registers `number_toString` for
+  `JSON.stringify(number)` so standalone/WASI use the existing pure-Wasm native
+  number formatter instead of refusing or importing `env::number_toString`.
+- `src/codegen/expressions/calls.ts` now returns the concrete emitted string
+  type for primitive/static JSON stringify. This also fixes the native-string
+  standalone path that previously could materialize string constants through
+  the `stringGlobalMap` sentinel as `global.get -1`.
+- `src/codegen/property-access.ts` bypasses the generic `__extern_get` path for
+  static `JSON.parse(...).prop` / `[index]` reads, so these forms do not pull in
+  JS-host property imports.
+- `tests/issue-1599.test.ts` covers the concrete standalone runtime examples:
+  `JSON.stringify({a:1,b:[2,3]})`, `JSON.parse('{"x":42}').x`, static array
+  parse indexing, string escaping, dynamic number stringify, and dynamic parse
+  refusal.
+- `tests/issue-1599-json-standalone-refuse.test.ts` was updated so dynamic
+  object/array/string stringify and dynamic parse still refuse, while the new
+  static/number slices compile without JSON host imports.
+
+### Current support boundary
+
+- Supported now: static JSON-compatible object/array/string/number/boolean/null
+  literal graphs for stringify; static JSON text property/index reads for parse;
+  dynamic number stringify.
+- Still refused: dynamic JSON text parsing and dynamic object/array/string value
+  walking. These still need the full WasmGC JSON value graph/parser/stringifier
+  described above before the full `test/built-ins/JSON/*` standalone subset can
+  be claimed.
+
+### Spec anchors
+
+- ECMA-262 §25.5.2 `JSON.parse` / `ParseJSON`.
+- ECMA-262 §25.5.4 `JSON.stringify`, especially §25.5.4.2
+  `SerializeJSONProperty` and §25.5.4.3 `QuoteJSONString`.
+
+### Validation — 2026-06-03
+
+- `pnpm exec vitest run tests/issue-1599.test.ts tests/issue-1599-json-standalone-refuse.test.ts`
+  — 20 tests passed.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -572,7 +572,16 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
     node.expression.expression.text === "JSON"
   ) {
     const method = node.expression.name.text;
-    if (method === "stringify") state.jsonNeedStringify = true;
+    if (method === "stringify") {
+      state.jsonNeedStringify = true;
+      const arg = node.arguments[0];
+      if (arg) {
+        const argType = ctx.checker.getTypeAtLocation(arg);
+        if (isNumberType(argType)) {
+          state.primitiveNeeded.add("number_toString");
+        }
+      }
+    }
     if (method === "parse") state.jsonNeedParse = true;
   }
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -51,6 +51,7 @@ import {
   resolveWasmType,
 } from "../index.js";
 import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
+import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -325,16 +326,20 @@ function resolveClosureInfoFromLocal(
  *   - `bigint`  — needs runtime check + TypeError throw
  *   - object / array — needs WasmGC shape walking
  *
- * Returns `true` and pushes an externref onto the wasm stack when
- * emission succeeded; returns `false` (no stack effect) otherwise so
+ * Returns the emitted type and pushes a string/undefined value onto the wasm
+ * stack when emission succeeded; returns `undefined` (no stack effect) otherwise so
  * the caller can fall through to the `JSON_stringify` host import.
  */
-function tryEmitJsonStringifyPrimitive(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): boolean {
+function tryEmitJsonStringifyPrimitive(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+): ValType | null | undefined {
   let argType: ts.Type;
   try {
     argType = ctx.checker.getTypeAtLocation(arg);
   } catch {
-    return false;
+    return undefined;
   }
   const flags = argType.flags;
 
@@ -348,14 +353,13 @@ function tryEmitJsonStringifyPrimitive(ctx: CodegenContext, fctx: FunctionContex
     ts.TypeFlags.Object |
     ts.TypeFlags.NonPrimitive |
     ts.TypeFlags.TypeParameter;
-  if (flags & ambiguousMask) return false;
+  if (flags & ambiguousMask) return undefined;
 
   // null literal
   if (flags & ts.TypeFlags.Null) {
     const t = compileExpression(ctx, fctx, arg);
     if (t) fctx.body.push({ op: "drop" } as Instr);
-    compileStringLiteral(ctx, fctx, "null", arg);
-    return true;
+    return compileStringLiteral(ctx, fctx, "null", arg);
   }
 
   // undefined / void — `JSON.stringify(undefined)` returns the JS
@@ -368,7 +372,7 @@ function tryEmitJsonStringifyPrimitive(ctx: CodegenContext, fctx: FunctionContex
     const t = compileExpression(ctx, fctx, arg);
     if (t) fctx.body.push({ op: "drop" } as Instr);
     emitUndefined(ctx, fctx);
-    return true;
+    return { kind: "externref" };
   }
 
   // boolean / true / false
@@ -376,32 +380,41 @@ function tryEmitJsonStringifyPrimitive(ctx: CodegenContext, fctx: FunctionContex
     const argResult = compileExpression(ctx, fctx, arg, { kind: "i32" });
     if (argResult === null) {
       // Failed to compile the arg as i32 — abandon (no stack effect from this fn).
-      return false;
+      return undefined;
     }
-    addStringConstantGlobal(ctx, "true");
-    addStringConstantGlobal(ctx, "false");
-    const trueIdx = ctx.stringGlobalMap.get("true");
-    const falseIdx = ctx.stringGlobalMap.get("false");
-    if (trueIdx === undefined || falseIdx === undefined) return false;
+    const savedBody = fctx.body;
+    fctx.body = [];
+    const trueType = compileStringLiteral(ctx, fctx, "true", arg);
+    const trueBody = fctx.body;
+    fctx.body = [];
+    const falseType = compileStringLiteral(ctx, fctx, "false", arg);
+    const falseBody = fctx.body;
+    fctx.body = savedBody;
+    const resultType = trueType ?? falseType ?? ({ kind: "externref" } as ValType);
     fctx.body.push({
       op: "if",
-      blockType: { kind: "val", type: { kind: "externref" } },
-      then: [{ op: "global.get", index: trueIdx } as Instr],
-      else: [{ op: "global.get", index: falseIdx } as Instr],
+      blockType: { kind: "val", type: resultType },
+      then: trueBody,
+      else: falseBody,
     } as Instr);
-    return true;
+    return resultType;
   }
 
   // number / numeric literal
   if (flags & ts.TypeFlags.NumberLike) {
     const numToStrIdx = ctx.funcMap.get("number_toString");
-    if (numToStrIdx === undefined) return false;
-    addStringConstantGlobal(ctx, "null");
-    const nullStrIdx = ctx.stringGlobalMap.get("null");
-    if (nullStrIdx === undefined) return false;
+    if (numToStrIdx === undefined) return undefined;
+    const savedBody = fctx.body;
+    fctx.body = [];
+    const nullType = compileStringLiteral(ctx, fctx, "null", arg);
+    const nullBody = fctx.body;
+    fctx.body = savedBody;
+    const resultType = (ctx.standalone || ctx.wasi ? nullType : ({ kind: "externref" } as ValType)) ?? {
+      kind: "externref",
+    };
 
     const argResult = compileExpression(ctx, fctx, arg, { kind: "f64" });
-    if (argResult === null) return false;
+    if (argResult === null) return undefined;
 
     // Stack: [f64 value]. Save to a local so we can both test for
     // finiteness AND pass to number_toString in the finite branch.
@@ -418,17 +431,26 @@ function tryEmitJsonStringifyPrimitive(ctx: CodegenContext, fctx: FunctionContex
 
     fctx.body.push({
       op: "if",
-      blockType: { kind: "val", type: { kind: "externref" } },
-      then: [{ op: "local.get", index: valLocal } as Instr, { op: "call", funcIdx: numToStrIdx } as Instr],
-      else: [{ op: "global.get", index: nullStrIdx } as Instr],
+      blockType: { kind: "val", type: resultType },
+      then: [
+        { op: "local.get", index: valLocal } as Instr,
+        { op: "call", funcIdx: numToStrIdx } as Instr,
+        ...(ctx.standalone || ctx.wasi
+          ? ([
+              { op: "any.convert_extern" } as Instr,
+              { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+            ] as Instr[])
+          : []),
+      ],
+      else: nullBody,
     } as Instr);
     releaseTempLocal(fctx, valLocal);
-    return true;
+    return resultType;
   }
 
   // string / bigint / unhandled — fall through to the host import. Full
   // pure-Wasm support tracked under #1353.
-  return false;
+  return undefined;
 }
 
 /**
@@ -5003,7 +5025,8 @@ function compileCallExpression(
         // JSON_stringify host import — full pure-Wasm shape walking is
         // tracked under #1353 (architect-spec follow-up).
         if (method === "stringify") {
-          if (tryEmitJsonStringifyPrimitive(ctx, fctx, expr.arguments[0]!)) {
+          const primitiveStringType = tryEmitJsonStringifyPrimitive(ctx, fctx, expr.arguments[0]!);
+          if (primitiveStringType !== undefined) {
             // Compile remaining args (replacer, space) for their side
             // effects only — primitive stringify ignores them per spec
             // §25.5.4 (replacer doesn't observe primitives, space only
@@ -5012,7 +5035,19 @@ function compileCallExpression(
               const t = compileExpression(ctx, fctx, expr.arguments[i]!);
               if (t) fctx.body.push({ op: "drop" } as Instr);
             }
-            return { kind: "externref" };
+            return primitiveStringType;
+          }
+          if ((ctx.standalone || ctx.wasi) && expr.arguments.length === 1) {
+            const staticStringType = tryEmitJsonStringifyStatic(ctx, fctx, expr.arguments[0]!);
+            if (staticStringType !== undefined) {
+              return staticStringType;
+            }
+          }
+        }
+        if (method === "parse" && (ctx.standalone || ctx.wasi)) {
+          const parsedType = tryEmitJsonParseLiteral(ctx, fctx, expr);
+          if (parsedType !== undefined) {
+            return parsedType;
           }
         }
         // (#1599 Phase 1) Refuse-and-document: in standalone (no-JS-host) /

--- a/src/codegen/json-standalone.ts
+++ b/src/codegen/json-standalone.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Bounded standalone JSON support for #1599.
+ *
+ * This is a runtime-host-independent slice: statically known JSON values are
+ * folded by the compiler and materialized as Wasm constants/native strings.
+ * Dynamic JSON text and dynamic object graphs still refuse in standalone/WASI
+ * until the full runtime parser/value representation lands.
+ */
+import { ts } from "../ts-api.js";
+import type { ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitUndefined } from "./expressions/late-imports.js";
+import { compileStringLiteral } from "./string-ops.js";
+
+type JsonStaticValue = null | boolean | number | string | JsonStaticValue[] | { [key: string]: JsonStaticValue };
+
+const UNSUPPORTED = Symbol("unsupported-json-static-value");
+type StaticResult = JsonStaticValue | typeof UNSUPPORTED;
+
+function unwrapTransparentExpression(expr: ts.Expression): ts.Expression {
+  let cur = expr;
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isTypeAssertionExpression(cur) ||
+    ts.isSatisfiesExpression(cur) ||
+    ts.isNonNullExpression(cur)
+  ) {
+    cur = cur.expression;
+  }
+  return cur;
+}
+
+function constInitializerForIdentifier(ctx: CodegenContext, expr: ts.Identifier): ts.Expression | undefined {
+  const sym = ctx.checker.getSymbolAtLocation(expr);
+  const decl = sym?.valueDeclaration;
+  if (!decl || !ts.isVariableDeclaration(decl) || !decl.initializer) return undefined;
+  const list = decl.parent;
+  if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.Const) === 0) return undefined;
+  return decl.initializer;
+}
+
+function staticStringValue(ctx: CodegenContext, expr: ts.Expression, seen = new Set<ts.Node>()): string | undefined {
+  const cur = unwrapTransparentExpression(expr);
+  if (ts.isStringLiteral(cur) || ts.isNoSubstitutionTemplateLiteral(cur)) return cur.text;
+  if (ts.isIdentifier(cur)) {
+    const init = constInitializerForIdentifier(ctx, cur);
+    if (init && !seen.has(init)) {
+      seen.add(init);
+      return staticStringValue(ctx, init, seen);
+    }
+  }
+  return undefined;
+}
+
+function staticPropertyName(ctx: CodegenContext, name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) return name.text;
+  if (ts.isNumericLiteral(name)) return String(Number(name.text));
+  if (ts.isComputedPropertyName(name)) return staticStringValue(ctx, name.expression);
+  return undefined;
+}
+
+function staticJsonValue(ctx: CodegenContext, expr: ts.Expression, seen = new Set<ts.Node>()): StaticResult {
+  const cur = unwrapTransparentExpression(expr);
+  if (seen.has(cur)) return UNSUPPORTED;
+  seen.add(cur);
+
+  if (cur.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (cur.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (cur.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (ts.isStringLiteral(cur) || ts.isNoSubstitutionTemplateLiteral(cur)) return cur.text;
+  if (ts.isNumericLiteral(cur)) return Number(cur.text.replace(/_/g, ""));
+
+  if (ts.isPrefixUnaryExpression(cur) && ts.isNumericLiteral(cur.operand)) {
+    const n = Number(cur.operand.text.replace(/_/g, ""));
+    if (cur.operator === ts.SyntaxKind.MinusToken) return -n;
+    if (cur.operator === ts.SyntaxKind.PlusToken) return n;
+  }
+
+  if (ts.isIdentifier(cur)) {
+    if (cur.text === "NaN") return NaN;
+    if (cur.text === "Infinity") return Infinity;
+    if (cur.text === "undefined") return UNSUPPORTED;
+    const init = constInitializerForIdentifier(ctx, cur);
+    if (init) return staticJsonValue(ctx, init, seen);
+  }
+
+  if (ts.isArrayLiteralExpression(cur)) {
+    const out: JsonStaticValue[] = [];
+    for (const element of cur.elements) {
+      if (ts.isSpreadElement(element) || ts.isOmittedExpression(element)) return UNSUPPORTED;
+      const value = staticJsonValue(ctx, element, seen);
+      if (value === UNSUPPORTED) return UNSUPPORTED;
+      out.push(value);
+    }
+    return out;
+  }
+
+  if (ts.isObjectLiteralExpression(cur)) {
+    const out: { [key: string]: JsonStaticValue } = {};
+    for (const prop of cur.properties) {
+      if (!ts.isPropertyAssignment(prop) && !ts.isShorthandPropertyAssignment(prop)) return UNSUPPORTED;
+      const key = ts.isShorthandPropertyAssignment(prop) ? prop.name.text : staticPropertyName(ctx, prop.name);
+      if (key === undefined) return UNSUPPORTED;
+      const valueExpr = ts.isShorthandPropertyAssignment(prop) ? prop.name : prop.initializer;
+      const value = staticJsonValue(ctx, valueExpr, seen);
+      if (value === UNSUPPORTED) return UNSUPPORTED;
+      out[key] = value;
+    }
+    return out;
+  }
+
+  return UNSUPPORTED;
+}
+
+function parsedJsonLiteral(ctx: CodegenContext, arg: ts.Expression): StaticResult {
+  const text = staticStringValue(ctx, arg);
+  if (text === undefined) return UNSUPPORTED;
+  try {
+    return JSON.parse(text) as JsonStaticValue;
+  } catch {
+    return UNSUPPORTED;
+  }
+}
+
+export function isJsonParseCall(expr: ts.Expression): expr is ts.CallExpression {
+  const cur = unwrapTransparentExpression(expr);
+  return (
+    ts.isCallExpression(cur) &&
+    ts.isPropertyAccessExpression(cur.expression) &&
+    ts.isIdentifier(cur.expression.expression) &&
+    cur.expression.expression.text === "JSON" &&
+    cur.expression.name.text === "parse" &&
+    cur.arguments.length >= 1
+  );
+}
+
+function emitJsonStaticValue(ctx: CodegenContext, fctx: FunctionContext, value: JsonStaticValue): ValType | null {
+  if (value === null) {
+    fctx.body.push({ op: "ref.null.extern" });
+    return { kind: "externref" };
+  }
+  if (typeof value === "boolean") {
+    fctx.body.push({ op: "i32.const", value: value ? 1 : 0 });
+    return { kind: "i32" };
+  }
+  if (typeof value === "number") {
+    fctx.body.push({ op: "f64.const", value });
+    return { kind: "f64" };
+  }
+  if (typeof value === "string") {
+    return compileStringLiteral(ctx, fctx, value);
+  }
+  return null;
+}
+
+export function tryEmitJsonStringifyStatic(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+): ValType | null | undefined {
+  const value = staticJsonValue(ctx, arg);
+  if (value === UNSUPPORTED) return undefined;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) return undefined;
+  return compileStringLiteral(ctx, fctx, serialized);
+}
+
+export function tryEmitJsonParseLiteral(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  call: ts.CallExpression,
+): ValType | null | undefined {
+  const value = parsedJsonLiteral(ctx, call.arguments[0]!);
+  if (value === UNSUPPORTED || (value !== null && typeof value === "object")) return undefined;
+  return emitJsonStaticValue(ctx, fctx, value);
+}
+
+export function tryEmitJsonParsePropertyAccess(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (!(ctx.standalone || ctx.wasi) || !isJsonParseCall(expr.expression)) return undefined;
+  const value = parsedJsonLiteral(ctx, expr.expression.arguments[0]!);
+  if (value === UNSUPPORTED || value === null || Array.isArray(value) || typeof value !== "object") return undefined;
+  if (!Object.prototype.hasOwnProperty.call(value, expr.name.text)) {
+    emitUndefined(ctx, fctx);
+    return { kind: "externref" };
+  }
+  return emitJsonStaticValue(ctx, fctx, value[expr.name.text]!);
+}
+
+export function tryEmitJsonParseElementAccess(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.ElementAccessExpression,
+): ValType | null | undefined {
+  if (!(ctx.standalone || ctx.wasi) || !isJsonParseCall(expr.expression)) return undefined;
+  const value = parsedJsonLiteral(ctx, expr.expression.arguments[0]!);
+  if (value === UNSUPPORTED) return undefined;
+
+  const keyExpr = unwrapTransparentExpression(expr.argumentExpression);
+  let selected: JsonStaticValue | undefined;
+  if (Array.isArray(value) && ts.isNumericLiteral(keyExpr)) {
+    selected = value[Number(keyExpr.text)];
+  } else if (value !== null && !Array.isArray(value) && typeof value === "object") {
+    const key = ts.isStringLiteral(keyExpr) || ts.isNoSubstitutionTemplateLiteral(keyExpr) ? keyExpr.text : undefined;
+    if (key !== undefined) selected = value[key];
+  }
+
+  if (selected === undefined) {
+    emitUndefined(ctx, fctx);
+    return { kind: "externref" };
+  }
+  return emitJsonStaticValue(ctx, fctx, selected);
+}

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -44,6 +44,7 @@ import {
   valTypesMatch,
 } from "./shared.js";
 import { coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
+import { tryEmitJsonParseElementAccess, tryEmitJsonParsePropertyAccess } from "./json-standalone.js";
 // Well-known Symbol IDs (inlined from literals.ts to avoid circular deps)
 const WELL_KNOWN_SYMBOLS: Record<string, number> = {
   iterator: 1,
@@ -975,6 +976,9 @@ export function compilePropertyAccess(
 
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const propName = ts.isPrivateIdentifier(expr.name) ? "__priv_" + expr.name.text.slice(1) : expr.name.text;
+
+  const jsonParsePropertyType = tryEmitJsonParsePropertyAccess(ctx, fctx, expr);
+  if (jsonParsePropertyType !== undefined) return jsonParsePropertyType;
 
   // TextEncoder/TextDecoder read-only Web API properties under no-host
   // targets. These instances are stateless placeholders; preserve receiver
@@ -3212,6 +3216,9 @@ export function compileElementAccess(
   fctx: FunctionContext,
   expr: ts.ElementAccessExpression,
 ): ValType | null {
+  const jsonParseElementType = tryEmitJsonParseElementAccess(ctx, fctx, expr);
+  if (jsonParseElementType !== undefined) return jsonParseElementType;
+
   // Handle super[expr] — access parent class property via computed key on `this`
   if (expr.expression.kind === ts.SyntaxKind.SuperKeyword) {
     return compileSuperElementAccess(ctx, fctx, expr);

--- a/tests/issue-1599-json-standalone-refuse.test.ts
+++ b/tests/issue-1599-json-standalone-refuse.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
 
 /**
- * #1599 Phase 1 — refuse-and-document for JSON in standalone / WASI mode.
+ * #1599 — standalone / WASI JSON host-import guard.
  *
  * `JSON.stringify` / `JSON.parse` of non-primitive shapes delegate to the JS
  * host imports `env::JSON_stringify` / `env::JSON_parse`. In `--target
@@ -14,14 +14,10 @@ import { compile } from "../src/index.js";
  * Phase 1 instead:
  *   - skips registering the `env::JSON_*` imports in standalone/wasi mode, and
  *   - emits a clear `#1599` compile error at the call site for any shape not
- *     covered by the pure-Wasm primitive `JSON.stringify` slice (#1324).
+ *     covered by pure-Wasm/static JSON slices.
  *
- * The primitive `JSON.stringify` slice (null / undefined / boolean) is still
- * lowered to pure Wasm and continues to compile standalone. Number stringify
- * is refused here until it has a pure-Wasm number-to-string path.
- *
- * Phase 2 (a pure-Wasm JSON codec for objects / arrays / strings / parse) is
- * tracked in the issue file as a follow-up.
+ * The primitive/static slices (null / undefined / boolean / number and static
+ * JSON-compatible literals) are lowered without a JSON host import.
  */
 
 async function expectRefused(
@@ -37,39 +33,46 @@ async function expectRefused(
   return r;
 }
 
-describe("#1599 --target standalone refuses unsupported JSON shapes", () => {
-  it("rejects JSON.stringify of an object", async () => {
-    await expectRefused(`export function f(): string { return JSON.stringify({ a: 1 }); }`);
+async function expectAccepted(src: string, target: "standalone" | "wasi" = "standalone") {
+  const r = await compile(src, { target });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.some((l) => /JSON_stringify|JSON_parse/.test(l))).toBe(false);
+  return r;
+}
+
+describe("#1599 --target standalone refuses dynamic unsupported JSON shapes", () => {
+  it("rejects JSON.stringify of a dynamic object", async () => {
+    await expectRefused(`export function f(o: { a: number }): string { return JSON.stringify(o); }`);
   });
 
-  it("rejects JSON.stringify of an array", async () => {
-    await expectRefused(`export function f(): string { return JSON.stringify([1, 2, 3]); }`);
+  it("rejects JSON.stringify of a dynamic array", async () => {
+    await expectRefused(`export function f(a: number[]): string { return JSON.stringify(a); }`);
   });
 
-  it("rejects JSON.stringify of a string", async () => {
+  it("rejects JSON.stringify of a dynamic string", async () => {
     await expectRefused(`export function f(s: string): string { return JSON.stringify(s); }`);
   });
 
-  it("rejects JSON.stringify of a number until Phase 2 adds pure-Wasm number formatting", async () => {
-    const r = await expectRefused(`export function f(n: number): string { return JSON.stringify(n); }`);
-    expect(r.errors.some((e) => /numbers, objects, arrays, strings, and JSON\.parse/.test(e.message))).toBe(true);
+  it("compiles JSON.stringify of a dynamic number", async () => {
+    await expectAccepted(`export function f(n: number): string { return JSON.stringify(n); }`);
   });
 
-  it("rejects JSON.parse", async () => {
+  it("rejects dynamic JSON.parse text", async () => {
     await expectRefused(`export function f(s: string): number { return JSON.parse(s).x; }`);
   });
 
-  it("rejects JSON.parse of a string literal", async () => {
-    await expectRefused(`export function f(): number { return JSON.parse('{"x":42}').x; }`);
+  it("compiles JSON.parse of a static string literal property read", async () => {
+    await expectAccepted(`export function f(): number { return JSON.parse('{"x":42}').x; }`);
   });
 
   it("also refuses under --target wasi", async () => {
-    await expectRefused(`export function f(): string { return JSON.stringify({ a: 1 }); }`, "wasi");
+    await expectRefused(`export function f(o: { a: number }): string { return JSON.stringify(o); }`, "wasi");
     await expectRefused(`export function f(s: string): number { return JSON.parse(s).x; }`, "wasi");
   });
 
   it("emits no env::JSON_* import when refused", async () => {
-    const r = await compile(`export function f(): string { return JSON.stringify({ a: 1 }); }`, {
+    const r = await compile(`export function f(o: { a: number }): string { return JSON.stringify(o); }`, {
       target: "standalone",
     });
     expect(r.success).toBe(false);
@@ -95,11 +98,12 @@ describe("#1599 primitive JSON.stringify slice still works standalone (#1324)", 
     await runStandalone(`export function f(): string { return JSON.stringify(true); }`, "true");
   });
 
-  // NOTE: JSON.stringify(number) is *not* standalone-safe even though it is a
-  // primitive — the #1324 slice lowers it through `env::number_toString`, a
-  // host import that does not exist in standalone/wasi mode. It is therefore
-  // correctly refused with the #1599 message (see refusal block above). The
-  // pure-Wasm number-to-string path is part of the Phase 2 follow-up.
+  it("JSON.stringify of a static object compiles standalone", async () => {
+    await runStandalone(
+      `export function f(): string { return JSON.stringify({ a: 1, b: [2, 3] }); }`,
+      '{"a":1,"b":[2,3]}',
+    );
+  });
 });
 
 describe("#1599 default (JS-host) mode unchanged", () => {

--- a/tests/issue-1599.test.ts
+++ b/tests/issue-1599.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function assertNoJsonHostImports(result: Awaited<ReturnType<typeof compile>>): void {
+  const labels = result.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.filter((l) => /env::JSON_(parse|stringify)/.test(l))).toEqual([]);
+}
+
+async function compileStandalone(src: string): Promise<Record<string, unknown>> {
+  const result = await compile(src, { target: "standalone" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoJsonHostImports(result);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as Record<string, unknown>;
+}
+
+describe("#1599 standalone JSON literal slice", () => {
+  it("stringifies a static object/array graph without env::JSON_stringify", async () => {
+    const exports = await compileStandalone(`
+      export function test(): number {
+        const s = JSON.stringify({ a: 1, b: [2, 3] });
+        return s === '{"a":1,"b":[2,3]}' ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("parses a static object literal and reads a property without env::JSON_parse", async () => {
+    const exports = await compileStandalone(`
+      export function test(): number {
+        return JSON.parse('{"x":42}').x === 42 ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("parses a static array literal and reads an index without env::JSON_parse", async () => {
+    const exports = await compileStandalone(`
+      export function test(): number {
+        return JSON.parse('[1,2,3]')[1] === 2 ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("stringifies static string literals with JSON escaping", async () => {
+    const exports = await compileStandalone(`
+      export function test(): number {
+        return JSON.stringify("hello\\n") === '"hello\\\\n"' ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("parses static primitive JSON text without env::JSON_parse", async () => {
+    const exports = await compileStandalone(`
+      export function test(): number {
+        return JSON.parse('null') === null && JSON.parse('42') === 42 ? 1 : 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("stringifies dynamic numbers through the native standalone number formatter", async () => {
+    const exports = await compileStandalone(`
+      export function test(n: number): number {
+        return JSON.stringify(n) === "42" ? 1 : 0;
+      }
+    `);
+    expect((exports.test as (n: number) => number)(42)).toBe(1);
+  });
+
+  it("still refuses dynamic JSON.parse text in standalone", async () => {
+    const result = await compile(`export function test(s: string): number { return JSON.parse(s).x; }`, {
+      target: "standalone",
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => /#1599/.test(e.message))).toBe(true);
+    assertNoJsonHostImports(result);
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone/WASI static JSON literal slice for `JSON.stringify` and `JSON.parse`
- compile static JSON object/array/string graphs and static parse property/index reads without `env::JSON_*` imports
- keep unsupported dynamic JSON standalone paths refused with #1599 diagnostics

## Validation
- `pnpm exec vitest run tests/issue-1599.test.ts tests/issue-1599-json-standalone-refuse.test.ts`

## Notes
- This is intentionally a bounded Phase 2A slice, aligned with ECMA-262 JSON parse/stringify semantics for the static values handled here. Dynamic JSON text parsing and dynamic object graph stringification remain future WasmGC runtime work.
