### PR TITLE
fix(runtime): bridge generators to iterator helpers

### DIFF
--- a/plan/issues/1665-standalone-native-generators.md
+++ b/plan/issues/1665-standalone-native-generators.md
@@ -1,18 +1,20 @@
 ---
 id: 1665
 title: "host-indep: Wasm-native generators (retire __gen_* / __create_generator host scheduler)"
-status: ready
+status: in-progress
 created: 2026-05-25
-updated: 2026-06-02
+updated: 2026-06-03
 priority: medium
 feasibility: hard
 task_type: feature
 area: codegen, standalone
 language_feature: generators, iterators
 goal: standalone-mode
-sprint: Backlog
+sprint: 58
 required_by: [1344, 1732]
 related: [1662, 1376, 1103, 1320, 1340, 1464, 1718]
+claimed_by: codex-developer
+claimed_at: 2026-06-02T22:53:01.322Z
 ---
 # #1665 — Wasm-native generators for standalone mode
 
@@ -470,3 +472,35 @@ link via prototype so resolution is lazy and single-sourced.
 - Local unit: a `function*` whose `.map(f).toArray()` round-trips, and
   `Object.getPrototypeOf(Object.getPrototypeOf(g.prototype))` identity
   assertion (regression guard for the `setPrototypeOf` re-base).
+
+## Implementation update — 2026-06-03
+
+Landed the iterator-prototype bridge slice, not the full standalone-native
+generator state machine:
+
+- `src/runtime.ts` now links the compiler-owned `%IteratorPrototype%` to the
+  helper-bearing `Iterator.prototype` when the host provides one, preserving
+  the object identity that generator-prototype tests inspect.
+- The same install path now creates a compiler-owned `Iterator` fallback when
+  the host lacks one and installs missing prototype helpers
+  (`map`, `filter`, `take`, `drop`, `flatMap`, `toArray`, `forEach`, `some`,
+  `every`, `find`, `reduce`) per method.
+- `src/codegen/host-import-allowlist.ts` now assigns the `__gen_*` /
+  `__create_generator*` entries to #1665 instead of the stale #1376 IR
+  fallback gate.
+- `tests/issue-1665.test.ts` covers compiled generator `.map(...).toArray()`,
+  the `%IteratorPrototype%` re-base identity, and the allowlist ownership.
+
+Scoped validation:
+
+- `node node_modules/vitest/dist/cli.js run tests/issue-1665.test.ts`
+- `node node_modules/vitest/dist/cli.js run tests/issue-1665.test.ts tests/issue-1639.test.ts tests/issue-1718-flatmap.test.ts tests/host-import-allowlist-gate.test.ts`
+
+Remaining standalone work:
+
+- The eager JS-host generator scheduler remains in place; `__gen_*` and
+  `__create_generator*` are still allowlisted until the shared native
+  `$Iterator` / generator state-machine lowering lands.
+- A mis-scoped `pnpm test -- tests/issue-1665.test.ts` run invoked the broad
+  suite, reported unrelated existing failures, and ended with a Vitest worker
+  OOM. The direct scoped commands above passed.

--- a/plan/issues/1665-standalone-native-generators.md
+++ b/plan/issues/1665-standalone-native-generators.md
@@ -1,7 +1,8 @@
 ---
 id: 1665
 title: "host-indep: Wasm-native generators (retire __gen_* / __create_generator host scheduler)"
-status: in-progress
+status: in-review
+pr: 1050
 created: 2026-05-25
 updated: 2026-06-03
 priority: medium

--- a/src/codegen/host-import-allowlist.ts
+++ b/src/codegen/host-import-allowlist.ts
@@ -284,24 +284,24 @@ export const HOST_IMPORT_ALLOWLIST: readonly HostImportAllowlistEntry[] = [
     reason: "Host trampolines for invoking JS callbacks (__call_1_i32, __call_2_f64, ...); #1470.",
   },
 
-  // ---- #1376 Generator helpers (retired as part of IR fallback budget) ----
+  // ---- #1665 Generator helpers (retired by Wasm-native generator lowering) ----
   {
     kind: "prefix",
     name: "__gen_",
-    trackingIssue: 1376,
-    reason: "Generator scheduler primitives implemented JS-side; native path tracked in #1376.",
+    trackingIssue: 1665,
+    reason: "Generator scheduler primitives implemented JS-side; native path tracked in #1665.",
   },
   {
     kind: "prefix",
     name: "__create_generator",
-    trackingIssue: 1376,
-    reason: "Sync generator constructor host-side; #1376.",
+    trackingIssue: 1665,
+    reason: "Sync generator constructor host-side; #1665.",
   },
   {
     kind: "prefix",
     name: "__create_async_generator",
-    trackingIssue: 1376,
-    reason: "Async generator constructor host-side; #1376.",
+    trackingIssue: 1665,
+    reason: "Async generator constructor host-side; #1665.",
   },
 
   // ---- #1632a Function.prototype.bind / .apply / .call (host-delegated) ----

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -480,9 +480,34 @@ let _iteratorHelpersInstalled = false;
 function _installIteratorHelperPolyfills(): void {
   if (_iteratorHelpersInstalled) return;
   _iteratorHelpersInstalled = true;
-  const I: any = (globalThis as any).Iterator;
-  if (typeof I !== "function" || typeof I.prototype !== "object" || I.prototype == null) return;
-  const Iproto: any = I.prototype;
+  const compilerIteratorProto = _getIteratorPrototype();
+  let I: any = (globalThis as any).Iterator;
+  if (typeof I !== "function" || typeof I.prototype !== "object" || I.prototype == null) {
+    I = function Iterator(this: any) {
+      throw new TypeError("Iterator is not a constructor");
+    };
+    I.prototype = compilerIteratorProto;
+    Object.defineProperty(globalThis, "Iterator", {
+      value: I,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  const Iproto: any = typeof I.prototype === "object" && I.prototype != null ? I.prototype : compilerIteratorProto;
+
+  if (Iproto !== compilerIteratorProto) {
+    let wouldCycle = false;
+    for (let p = Iproto; p != null; p = Object.getPrototypeOf(p)) {
+      if (p === compilerIteratorProto) {
+        wouldCycle = true;
+        break;
+      }
+    }
+    if (!wouldCycle && Object.getPrototypeOf(compilerIteratorProto) !== Iproto) {
+      Object.setPrototypeOf(compilerIteratorProto, Iproto);
+    }
+  }
 
   // ES2025 GetIteratorFlattenable — accepts an iterable OR a raw iterator.
   function _getFlattenable(obj: any): any {
@@ -512,6 +537,295 @@ function _installIteratorHelperPolyfills(): void {
       return this;
     };
     return obj;
+  }
+
+  function _requireIteratorReceiver(receiver: any, name: string): any {
+    if (receiver == null || typeof receiver.next !== "function") {
+      throw new TypeError("Iterator.prototype." + name + " called on non-iterator");
+    }
+    return receiver;
+  }
+
+  function _closeIterator(iter: any): void {
+    try {
+      iter?.return?.();
+    } catch {}
+  }
+
+  if (typeof I.from !== "function") {
+    Object.defineProperty(I, "from", {
+      value: function from(iterable: any) {
+        return _getFlattenable(iterable);
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  if (typeof Iproto.map !== "function") {
+    _installBuiltinMethod(Iproto, "map", 1, function (this: any, mapper: any) {
+      const outer = _requireIteratorReceiver(this, "map");
+      if (typeof mapper !== "function") {
+        throw new TypeError("Iterator.prototype.map: mapper is not a function");
+      }
+      let counter = 0;
+      let done = false;
+      return _makeHelperIterator(
+        function next() {
+          if (done) return { value: undefined, done: true };
+          const r = outer.next();
+          if (r && r.done) {
+            done = true;
+            return { value: undefined, done: true };
+          }
+          try {
+            return { value: mapper(r.value, counter++), done: false };
+          } catch (e) {
+            done = true;
+            _closeIterator(outer);
+            throw e;
+          }
+        },
+        function returnFn() {
+          done = true;
+          _closeIterator(outer);
+          return { value: undefined, done: true };
+        },
+      );
+    });
+  }
+
+  if (typeof Iproto.filter !== "function") {
+    _installBuiltinMethod(Iproto, "filter", 1, function (this: any, predicate: any) {
+      const outer = _requireIteratorReceiver(this, "filter");
+      if (typeof predicate !== "function") {
+        throw new TypeError("Iterator.prototype.filter: predicate is not a function");
+      }
+      let counter = 0;
+      let done = false;
+      return _makeHelperIterator(
+        function next() {
+          if (done) return { value: undefined, done: true };
+          while (true) {
+            const r = outer.next();
+            if (r && r.done) {
+              done = true;
+              return { value: undefined, done: true };
+            }
+            let keep: any;
+            try {
+              keep = predicate(r.value, counter++);
+            } catch (e) {
+              done = true;
+              _closeIterator(outer);
+              throw e;
+            }
+            if (keep) return { value: r.value, done: false };
+          }
+        },
+        function returnFn() {
+          done = true;
+          _closeIterator(outer);
+          return { value: undefined, done: true };
+        },
+      );
+    });
+  }
+
+  if (typeof Iproto.take !== "function") {
+    _installBuiltinMethod(Iproto, "take", 1, function (this: any, limit: any) {
+      const outer = _requireIteratorReceiver(this, "take");
+      let remaining = Number(limit);
+      if (!Number.isFinite(remaining)) remaining = Infinity;
+      remaining = Math.trunc(remaining);
+      if (remaining < 0) throw new RangeError("Iterator.prototype.take: limit must be non-negative");
+      let done = false;
+      return _makeHelperIterator(
+        function next() {
+          if (done || remaining <= 0) {
+            done = true;
+            return { value: undefined, done: true };
+          }
+          remaining--;
+          const r = outer.next();
+          if (r && r.done) {
+            done = true;
+            return { value: undefined, done: true };
+          }
+          return { value: r.value, done: false };
+        },
+        function returnFn() {
+          done = true;
+          _closeIterator(outer);
+          return { value: undefined, done: true };
+        },
+      );
+    });
+  }
+
+  if (typeof Iproto.drop !== "function") {
+    _installBuiltinMethod(Iproto, "drop", 1, function (this: any, limit: any) {
+      const outer = _requireIteratorReceiver(this, "drop");
+      let remaining = Number(limit);
+      if (!Number.isFinite(remaining)) remaining = Infinity;
+      remaining = Math.trunc(remaining);
+      if (remaining < 0) throw new RangeError("Iterator.prototype.drop: limit must be non-negative");
+      let done = false;
+      return _makeHelperIterator(
+        function next() {
+          if (done) return { value: undefined, done: true };
+          while (remaining > 0) {
+            remaining--;
+            const skipped = outer.next();
+            if (skipped && skipped.done) {
+              done = true;
+              return { value: undefined, done: true };
+            }
+          }
+          const r = outer.next();
+          if (r && r.done) {
+            done = true;
+            return { value: undefined, done: true };
+          }
+          return { value: r.value, done: false };
+        },
+        function returnFn() {
+          done = true;
+          _closeIterator(outer);
+          return { value: undefined, done: true };
+        },
+      );
+    });
+  }
+
+  if (typeof Iproto.toArray !== "function") {
+    _installBuiltinMethod(Iproto, "toArray", 0, function (this: any) {
+      const iter = _requireIteratorReceiver(this, "toArray");
+      const out: any[] = [];
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return out;
+        out.push(r.value);
+      }
+    });
+  }
+
+  if (typeof Iproto.forEach !== "function") {
+    _installBuiltinMethod(Iproto, "forEach", 1, function (this: any, fn: any) {
+      const iter = _requireIteratorReceiver(this, "forEach");
+      if (typeof fn !== "function") {
+        throw new TypeError("Iterator.prototype.forEach: callback is not a function");
+      }
+      let counter = 0;
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return undefined;
+        try {
+          fn(r.value, counter++);
+        } catch (e) {
+          _closeIterator(iter);
+          throw e;
+        }
+      }
+    });
+  }
+
+  if (typeof Iproto.some !== "function") {
+    _installBuiltinMethod(Iproto, "some", 1, function (this: any, predicate: any) {
+      const iter = _requireIteratorReceiver(this, "some");
+      if (typeof predicate !== "function") {
+        throw new TypeError("Iterator.prototype.some: predicate is not a function");
+      }
+      let counter = 0;
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return false;
+        try {
+          if (predicate(r.value, counter++)) {
+            _closeIterator(iter);
+            return true;
+          }
+        } catch (e) {
+          _closeIterator(iter);
+          throw e;
+        }
+      }
+    });
+  }
+
+  if (typeof Iproto.every !== "function") {
+    _installBuiltinMethod(Iproto, "every", 1, function (this: any, predicate: any) {
+      const iter = _requireIteratorReceiver(this, "every");
+      if (typeof predicate !== "function") {
+        throw new TypeError("Iterator.prototype.every: predicate is not a function");
+      }
+      let counter = 0;
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return true;
+        try {
+          if (!predicate(r.value, counter++)) {
+            _closeIterator(iter);
+            return false;
+          }
+        } catch (e) {
+          _closeIterator(iter);
+          throw e;
+        }
+      }
+    });
+  }
+
+  if (typeof Iproto.find !== "function") {
+    _installBuiltinMethod(Iproto, "find", 1, function (this: any, predicate: any) {
+      const iter = _requireIteratorReceiver(this, "find");
+      if (typeof predicate !== "function") {
+        throw new TypeError("Iterator.prototype.find: predicate is not a function");
+      }
+      let counter = 0;
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return undefined;
+        try {
+          if (predicate(r.value, counter++)) {
+            _closeIterator(iter);
+            return r.value;
+          }
+        } catch (e) {
+          _closeIterator(iter);
+          throw e;
+        }
+      }
+    });
+  }
+
+  if (typeof Iproto.reduce !== "function") {
+    _installBuiltinMethod(Iproto, "reduce", 1, function (this: any, reducer: any, initial?: any) {
+      const iter = _requireIteratorReceiver(this, "reduce");
+      if (typeof reducer !== "function") {
+        throw new TypeError("Iterator.prototype.reduce: reducer is not a function");
+      }
+      let counter = 0;
+      let acc: any = initial;
+      if (arguments.length < 2) {
+        const first = iter.next();
+        if (first && first.done) {
+          throw new TypeError("Iterator.prototype.reduce: empty iterator with no initial value");
+        }
+        acc = first.value;
+        counter = 1;
+      }
+      for (;;) {
+        const r = iter.next();
+        if (r && r.done) return acc;
+        try {
+          acc = reducer(acc, r.value, counter++);
+        } catch (e) {
+          _closeIterator(iter);
+          throw e;
+        }
+      }
+    });
   }
 
   if (typeof I.zip !== "function") {

--- a/tests/issue-1665.test.ts
+++ b/tests/issue-1665.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1665 — generator / iterator bridge slice.
+ *
+ * Full Wasm-native generator state machines remain the long-term standalone
+ * track. This slice fixes the host-mode prototype bridge that issue #1665
+ * identified as the shared design point: compiled generators keep their own
+ * `%IteratorPrototype%` identity, but helper methods resolve through the
+ * helper-bearing `Iterator.prototype` surface.
+ */
+import { describe, expect, it } from "vitest";
+
+import { HOST_IMPORT_ALLOWLIST } from "../src/codegen/host-import-allowlist.js";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+async function makeCompiledGenerator(): Promise<IterableIterator<number>> {
+  const exports = await compileAndInstantiate(`
+    export function make(): any {
+      function* gen() {
+        yield 1;
+        yield 2;
+      }
+      return gen();
+    }
+  `);
+  return (exports.make as () => IterableIterator<number>)();
+}
+
+describe("#1665 generator iterator bridge", () => {
+  it("compiled generators resolve Iterator.prototype helpers", async () => {
+    const iter = await makeCompiledGenerator();
+
+    expect(typeof (iter as any).map).toBe("function");
+    expect((iter as any).map((x: number) => x * 2).toArray()).toEqual([2, 4]);
+  });
+
+  it("preserves the compiler-owned %IteratorPrototype% object while linking helpers above it", async () => {
+    const iter = await makeCompiledGenerator();
+    const generatorFunctionPrototype = Object.getPrototypeOf(iter);
+    const generatorPrototype = Object.getPrototypeOf(generatorFunctionPrototype);
+    const compilerIteratorPrototype = Object.getPrototypeOf(generatorPrototype);
+
+    expect(Object.prototype.hasOwnProperty.call(compilerIteratorPrototype, Symbol.iterator)).toBe(true);
+    expect(compilerIteratorPrototype[Symbol.iterator].call(iter)).toBe(iter);
+
+    const hostIterator = (globalThis as any).Iterator;
+    if (typeof hostIterator === "function" && hostIterator.prototype !== compilerIteratorPrototype) {
+      expect(Object.getPrototypeOf(compilerIteratorPrototype)).toBe(hostIterator.prototype);
+    } else {
+      expect(typeof compilerIteratorPrototype.map).toBe("function");
+      expect(hostIterator?.prototype).toBe(compilerIteratorPrototype);
+    }
+  });
+
+  it("tracks generator host-scheduler imports under #1665, not the stale #1376 IR gate", () => {
+    const generatorEntries = HOST_IMPORT_ALLOWLIST.filter(
+      (entry) =>
+        entry.name === "__gen_" || entry.name === "__create_generator" || entry.name === "__create_async_generator",
+    );
+
+    expect(generatorEntries.map((entry) => [entry.name, entry.trackingIssue])).toEqual([
+      ["__gen_", 1665],
+      ["__create_generator", 1665],
+      ["__create_async_generator", 1665],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Link the compiler-owned `%IteratorPrototype%` to the helper-bearing `Iterator.prototype` while preserving the generator prototype identity inspected by test262.
- Install compiler-owned fallback iterator helpers when the host lacks `Iterator` or individual helper methods.
- Move `__gen_*` / `__create_generator*` host-import allowlist ownership from the stale #1376 IR gate to #1665 and document the remaining native-generator work.

## Validation

- `node node_modules/vitest/dist/cli.js run tests/issue-1665.test.ts`
- `node node_modules/vitest/dist/cli.js run tests/issue-1665.test.ts tests/issue-1639.test.ts tests/issue-1718-flatmap.test.ts tests/host-import-allowlist-gate.test.ts`

## Notes

This is the iterator-prototype bridge slice from #1665. The eager JS-host generator scheduler remains in place; the full standalone-native generator state-machine lowering remains follow-up work under #1665.