### PR TITLE
feat(generators): add native sequential state machines

### DIFF
--- a/plan/issues/680-wasm-native-generators-state-machines.md
+++ b/plan/issues/680-wasm-native-generators-state-machines.md
@@ -1,9 +1,9 @@
 ---
 id: 680
 title: "Wasm-native generators (state machines) with optional JS host fallback"
-status: in-progress
+status: in-review
 created: 2026-03-20
-updated: 2026-06-02
+updated: 2026-06-03
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -19,6 +19,7 @@ files:
       - "yield compiles to state save + return, next() resumes from saved state"
 claimed_by: codex-developer
 claimed_at: 2026-06-02T22:52:32.748Z
+pr: 1052
 ---
 # #680 — Wasm-native generators (state machines) with optional JS host fallback
 

--- a/plan/issues/680-wasm-native-generators-state-machines.md
+++ b/plan/issues/680-wasm-native-generators-state-machines.md
@@ -1,9 +1,9 @@
 ---
 id: 680
 title: "Wasm-native generators (state machines) with optional JS host fallback"
-status: ready
+status: in-progress
 created: 2026-03-20
-updated: 2026-04-28
+updated: 2026-06-02
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -17,6 +17,8 @@ files:
   src/codegen/expressions.ts:
     breaking:
       - "yield compiles to state save + return, next() resumes from saved state"
+claimed_by: codex-developer
+claimed_at: 2026-06-02T22:52:32.748Z
 ---
 # #680 — Wasm-native generators (state machines) with optional JS host fallback
 
@@ -220,6 +222,27 @@ Acceptance per phase:
 - Phase 1: ≥60% of test262 generator tests pass.
 - Phase 2: ≥85%.
 - Phase 3: ≥95%.
+
+## Implementation notes — 2026-06-03
+
+- Added a Phase 1 Wasm-native generator path for standalone/WASI targets:
+  top-level non-async `function*` declarations with sequential numeric
+  `yield` statements and optional numeric `return` lower to a WasmGC state
+  struct plus a generated resume function.
+- Native `.next()` / `.return(value)` calls dispatch directly to the generated
+  resume/state update path, and `IteratorResult.value` / `.done` lower to
+  `struct.get` on the native result struct.
+- Generator parameters are copied into the state struct at construction so
+  simple yielded expressions can read them across suspension.
+- The existing eager JS-host generator buffer path remains active for default
+  JS-host builds. Standalone/WASI no longer registers `__gen_*` /
+  `__create_generator` imports; unsupported generator shapes receive a scoped
+  compile diagnostic instead of silently depending on JS host helpers.
+
+Validation:
+
+- `pnpm exec vitest run tests/issue-680.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
 
 ### Dependencies
 

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -92,6 +92,8 @@ export function createCodegenContext(
     asyncFunctions: new Set(),
     generatorFunctions: new Set(),
     generatorYieldType: new Map(),
+    nativeGeneratorResultTypeIdx: -1,
+    nativeGenerators: new Map(),
     moduleGlobals: new Map(),
     moduleInitStatements: [],
     nestedFuncCaptures: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -125,6 +125,30 @@ export interface ClosureInfo {
   paramTypes: ValType[];
 }
 
+/** Metadata for a generator lowered to an in-module WasmGC state machine (#680). */
+export interface NativeGeneratorInfo {
+  /** Source-level generator function name. */
+  functionName: string;
+  /** Original declaration; used to emit the resume function lazily. */
+  decl: ts.FunctionDeclaration;
+  /** Per-generator state struct type index. */
+  stateTypeIdx: number;
+  /** Shared IteratorResult-like struct type index. */
+  resultTypeIdx: number;
+  /** Absolute function index for the generated resume function, once emitted. */
+  resumeFuncIdx?: number;
+  /** Parameter names copied into the state struct at construction time. */
+  paramNames: string[];
+  /** Parameter value types copied into the state struct at construction time. */
+  paramTypes: ValType[];
+  /** Field index where captured params start in the state struct. */
+  paramFieldOffset: number;
+  /** Number of top-level yield suspension points. */
+  yieldCount: number;
+  /** Terminal state value. */
+  doneState: number;
+}
+
 export type NullishExclusion = "null" | "undefined" | "nullish";
 
 export interface NullGuardFact {
@@ -569,6 +593,10 @@ export interface CodegenContext {
   generatorFunctions: Set<string>;
   /** Map from generator function name → yield element type */
   generatorYieldType: Map<string, ValType>;
+  /** Shared native generator IteratorResult-like struct type index, or -1 before registration. */
+  nativeGeneratorResultTypeIdx: number;
+  /** Function declarations lowered to Wasm-native generator state machines (#680). */
+  nativeGenerators: Map<string, NativeGeneratorInfo>;
   /**
    * Function declarations pre-registered during module-pass eager class body
    * compilation. The entry has a reserved `mod.functions` slot and signature,

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -52,6 +52,11 @@ import {
 import { ensureNativeStringExternBridge, ensureNativeStringHelpers } from "./native-strings.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
+import {
+  isNativeGeneratorCandidate,
+  registerNativeGenerator,
+  sourceNeedsGeneratorHostImports,
+} from "./generators-native.js";
 import { emitWasiErrorConstructor, isWasiErrorName } from "./registry/error-types.js";
 import { addImport, addStringConstantGlobal, localGlobalIdx, nextModuleGlobalIdx } from "./registry/imports.js";
 import {
@@ -692,7 +697,8 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       ts.isFunctionDeclaration(node) &&
       node.asteriskToken &&
       node.body &&
-      !hasDeclareModifier(node)
+      !hasDeclareModifier(node) &&
+      !((ctx.standalone || ctx.wasi) && isNativeGeneratorCandidate(ctx, node))
     ) {
       state.unionFound = true;
     }
@@ -1251,7 +1257,9 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // claims a generator function (#1169f). The helper is idempotent —
   // guards on `ctx.funcMap.has("__gen_create_buffer")` internally.
   if (state.generatorFound) {
-    addGeneratorImports(ctx);
+    if (!((ctx.standalone || ctx.wasi) && !sourceNeedsGeneratorHostImports(ctx, state.sourceFile))) {
+      addGeneratorImports(ctx);
+    }
   }
 
   // ── collectIteratorImports finalize ──
@@ -2275,7 +2283,8 @@ function registerBodylessFunctionDeclaration(
       }
       params.push(wasmType);
     }
-    results = [{ kind: "externref" }];
+    const nativeGenerator = registerNativeGenerator(ctx, stmt, name, params);
+    results = nativeGenerator ? [{ kind: "ref", typeIdx: nativeGenerator.stateTypeIdx }] : [{ kind: "externref" }];
   } else if (resolved) {
     params = resolved.params;
     results = resolved.results;
@@ -2758,7 +2767,8 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
           }
           params.push(wasmType);
         }
-        results = [{ kind: "externref" }]; // Returns a JS Generator object
+        const nativeGenerator = registerNativeGenerator(ctx, stmt, name, params);
+        results = nativeGenerator ? [{ kind: "ref", typeIdx: nativeGenerator.stateTypeIdx }] : [{ kind: "externref" }]; // JS-host fallback returns a Generator object
       } else if (resolved) {
         // Use call-site resolved types for generic functions
         params = resolved.params;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -107,6 +107,7 @@ import { analyzeTdzAccessByPos, emitLocalTdzCheck, emitStaticTdzThrow } from "./
 import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
+import { tryCompileNativeGeneratorMethodCall } from "../generators-native.js";
 import {
   ensureNativeStringExternBridge,
   ensureTextEncodingHelpers,
@@ -5430,6 +5431,14 @@ function compileCallExpression(
     // Generator method calls: gen.next(), gen.return(value), gen.throw(error)
     if (isGeneratorType(receiverType)) {
       const methodName = propAccess.name.text;
+      const nativeResult = tryCompileNativeGeneratorMethodCall(
+        ctx,
+        fctx,
+        propAccess.expression,
+        methodName,
+        expr.arguments,
+      );
+      if (nativeResult !== undefined) return nativeResult;
       if (methodName === "next") {
         compileExpression(ctx, fctx, propAccess.expression);
         const funcIdx = ctx.funcMap.get("__gen_next");
@@ -6894,6 +6903,14 @@ function compileCallExpression(
 
       if (isAnyOrExternref) {
         const methodName = propAccess.name.text;
+        const nativeResult = tryCompileNativeGeneratorMethodCall(
+          ctx,
+          fctx,
+          propAccess.expression,
+          methodName,
+          expr.arguments,
+        );
+        if (nativeResult !== undefined) return nativeResult;
 
         // Generator protocol: .next(), .return(value), .throw(error) on any/externref
         // These are very common in test262 generator tests where variables are typed as `any`.

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -42,6 +42,7 @@ import { isStrictFunction } from "./helpers/is-strict-function.js";
 import { detectStringBuilders } from "./string-builder.js";
 import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
+import { compileNativeGeneratorFunction } from "./generators-native.js";
 
 /** Maximum number of instructions for a function body to be considered inlinable */
 export const INLINE_MAX_INSTRS = 10;
@@ -846,78 +847,90 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   }
 
   if (isGenerator) {
-    // Generator function: eagerly evaluate body, collect yields into a JS array,
-    // then wrap it with __create_generator to return a Generator-like object.
-    // Body is wrapped in try/catch to defer thrown exceptions to first next() (#928).
-    const bufferLocal = allocLocal(fctx, "__gen_buffer", { kind: "externref" });
-    const pendingThrowLocal = allocLocal(fctx, "__gen_pending_throw", { kind: "externref" });
+    const nativeGenerator = ctx.nativeGenerators.get(func.name);
+    if (nativeGenerator) {
+      compileNativeGeneratorFunction(ctx, fctx, decl, nativeGenerator);
+    } else if (ctx.standalone || ctx.wasi) {
+      reportError(
+        ctx,
+        decl,
+        "Codegen error: native generator lowering currently supports only sequential numeric yields in standalone/WASI targets (#680). Recompile with a JS host target for complex generator shapes.",
+      );
+      fctx.body.push({ op: "ref.null.extern" });
+    } else {
+      // Generator function: eagerly evaluate body, collect yields into a JS array,
+      // then wrap it with __create_generator to return a Generator-like object.
+      // Body is wrapped in try/catch to defer thrown exceptions to first next() (#928).
+      const bufferLocal = allocLocal(fctx, "__gen_buffer", { kind: "externref" });
+      const pendingThrowLocal = allocLocal(fctx, "__gen_pending_throw", { kind: "externref" });
 
-    // Create buffer: __gen_buffer = __gen_create_buffer()
-    const createBufIdx = ctx.funcMap.get("__gen_create_buffer")!;
-    fctx.body.push({ op: "call", funcIdx: createBufIdx });
-    fctx.body.push({ op: "local.set", index: bufferLocal });
-    fctx.body.push({ op: "ref.null.extern" });
-    fctx.body.push({ op: "local.set", index: pendingThrowLocal });
+      // Create buffer: __gen_buffer = __gen_create_buffer()
+      const createBufIdx = ctx.funcMap.get("__gen_create_buffer")!;
+      fctx.body.push({ op: "call", funcIdx: createBufIdx });
+      fctx.body.push({ op: "local.set", index: bufferLocal });
+      fctx.body.push({ op: "ref.null.extern" });
+      fctx.body.push({ op: "local.set", index: pendingThrowLocal });
 
-    // Wrap the generator body in a block so that `return` statements inside
-    // the body can `br` out to the generator creation code instead of
-    // using the wasm `return` opcode (which would skip __create_generator).
-    // Use pushBody/popBody so the outer body stays reachable for global-index
-    // fixups when new string-constant imports are added during body compilation.
-    const savedGenBody = pushBody(fctx);
+      // Wrap the generator body in a block so that `return` statements inside
+      // the body can `br` out to the generator creation code instead of
+      // using the wasm `return` opcode (which would skip __create_generator).
+      // Use pushBody/popBody so the outer body stays reachable for global-index
+      // fixups when new string-constant imports are added during body compilation.
+      const savedGenBody = pushBody(fctx);
 
-    // Set generator return depth for correct `br` depth in nested contexts
-    fctx.generatorReturnDepth = 0;
+      // Set generator return depth for correct `br` depth in nested contexts
+      fctx.generatorReturnDepth = 0;
 
-    // Push a block label level so return can break out
-    fctx.blockDepth++;
-    for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]!++;
-    for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]!++;
+      // Push a block label level so return can break out
+      fctx.blockDepth++;
+      for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]!++;
+      for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]!++;
 
-    if (decl.body) {
-      hoistVarDeclarations(ctx, fctx, decl.body.statements);
-      hoistLetConstWithTdz(ctx, fctx, decl.body.statements);
-      hoistFunctionDeclarations(ctx, fctx, decl.body.statements);
-      for (const stmt of decl.body.statements) {
-        compileStatement(ctx, fctx, stmt);
+      if (decl.body) {
+        hoistVarDeclarations(ctx, fctx, decl.body.statements);
+        hoistLetConstWithTdz(ctx, fctx, decl.body.statements);
+        hoistFunctionDeclarations(ctx, fctx, decl.body.statements);
+        for (const stmt of decl.body.statements) {
+          compileStatement(ctx, fctx, stmt);
+        }
       }
+
+      fctx.blockDepth--;
+      for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]!--;
+      for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]!--;
+      fctx.generatorReturnDepth = undefined;
+
+      // Restore outer body and wrap compiled body in a try/catch(block)
+      const bodyInstrs = fctx.body;
+      popBody(fctx, savedGenBody);
+
+      // Wrap generator body block in try/catch to capture exceptions as pending throw
+      const tagIdx = ensureExnTag(ctx);
+      const getCaughtIdx = ctx.funcMap.get("__get_caught_exception");
+      const catchBody: Instr[] = [{ op: "local.set", index: pendingThrowLocal }];
+      const catchAllBody: Instr[] =
+        getCaughtIdx !== undefined
+          ? [{ op: "call", funcIdx: getCaughtIdx } as Instr, { op: "local.set", index: pendingThrowLocal }]
+          : [];
+      fctx.body.push({
+        op: "try",
+        blockType: { kind: "empty" },
+        body: [{ op: "block", blockType: { kind: "empty" }, body: bodyInstrs }],
+        catches: [{ tagIdx, body: catchBody }],
+        catchAll: catchAllBody.length > 0 ? catchAllBody : undefined,
+      });
+
+      // Return __create_generator or __create_async_generator depending on async flag.
+      // Note: ctx.asyncFunctions excludes async generators (by design), so we check
+      // the AST node directly to detect async function* declarations.
+      const isAsyncGenerator = hasAsyncModifier(decl);
+      const createGenName = isAsyncGenerator ? "__create_async_generator" : "__create_generator";
+      const createGenIdx = ctx.funcMap.get(createGenName)!;
+      fctx.body.push({ op: "local.get", index: bufferLocal });
+      fctx.body.push({ op: "local.get", index: pendingThrowLocal });
+      fctx.body.push({ op: "call", funcIdx: createGenIdx });
+      // The externref Generator object is now on the stack as the return value
     }
-
-    fctx.blockDepth--;
-    for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]!--;
-    for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]!--;
-    fctx.generatorReturnDepth = undefined;
-
-    // Restore outer body and wrap compiled body in a try/catch(block)
-    const bodyInstrs = fctx.body;
-    popBody(fctx, savedGenBody);
-
-    // Wrap generator body block in try/catch to capture exceptions as pending throw
-    const tagIdx = ensureExnTag(ctx);
-    const getCaughtIdx = ctx.funcMap.get("__get_caught_exception");
-    const catchBody: Instr[] = [{ op: "local.set", index: pendingThrowLocal }];
-    const catchAllBody: Instr[] =
-      getCaughtIdx !== undefined
-        ? [{ op: "call", funcIdx: getCaughtIdx } as Instr, { op: "local.set", index: pendingThrowLocal }]
-        : [];
-    fctx.body.push({
-      op: "try",
-      blockType: { kind: "empty" },
-      body: [{ op: "block", blockType: { kind: "empty" }, body: bodyInstrs }],
-      catches: [{ tagIdx, body: catchBody }],
-      catchAll: catchAllBody.length > 0 ? catchAllBody : undefined,
-    });
-
-    // Return __create_generator or __create_async_generator depending on async flag.
-    // Note: ctx.asyncFunctions excludes async generators (by design), so we check
-    // the AST node directly to detect async function* declarations.
-    const isAsyncGenerator = hasAsyncModifier(decl);
-    const createGenName = isAsyncGenerator ? "__create_async_generator" : "__create_generator";
-    const createGenIdx = ctx.funcMap.get(createGenName)!;
-    fctx.body.push({ op: "local.get", index: bufferLocal });
-    fctx.body.push({ op: "local.get", index: pendingThrowLocal });
-    fctx.body.push({ op: "call", funcIdx: createGenIdx });
-    // The externref Generator object is now on the stack as the return value
   } else {
     // Compile body statements
     if (decl.body) {

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -1,0 +1,599 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Wasm-native generator lowering (#680).
+ *
+ * This is the Phase 1 state-machine path for no-JS-host targets. It handles
+ * simple, top-level sequential `function*` declarations with numeric yields and
+ * an optional numeric `return`. More complex generator shapes keep using the
+ * legacy JS-host buffer path when a JS host is available.
+ */
+import { ts } from "../ts-api.js";
+import { isBooleanType, isNumberType } from "../checker/type-mapper.js";
+import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext, NativeGeneratorInfo } from "./context/types.js";
+import { reportError } from "./context/errors.js";
+import { addFuncType } from "./registry/types.js";
+import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
+
+const STATE_FIELD = 0;
+const RESULT_VALUE_FIELD = 0;
+const RESULT_DONE_FIELD = 1;
+const PARAM_FIELD_OFFSET = 1;
+const MAX_NATIVE_GENERATOR_STATES = 256;
+
+interface NativeGeneratorSegment {
+  statements: ts.Statement[];
+  yieldExpr?: ts.YieldExpression;
+  returnStmt?: ts.ReturnStatement;
+}
+
+function noJsHostTarget(ctx: CodegenContext): boolean {
+  return ctx.standalone || ctx.wasi;
+}
+
+function sanitizeTypeName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_$]/g, "_");
+}
+
+function isNumericExpression(ctx: CodegenContext, expr: ts.Expression | undefined): boolean {
+  if (!expr) return true;
+  const t = ctx.checker.getTypeAtLocation(expr);
+  return isNumberType(t) || isBooleanType(t);
+}
+
+function statementContainsYield(stmt: ts.Statement): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (ts.isYieldExpression(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(stmt, visit);
+  return found;
+}
+
+function buildNativeGeneratorSegments(
+  ctx: CodegenContext,
+  decl: ts.FunctionDeclaration,
+): NativeGeneratorSegment[] | null {
+  if (!decl.body) return null;
+  const segments: NativeGeneratorSegment[] = [];
+  let current: ts.Statement[] = [];
+
+  for (const stmt of decl.body.statements) {
+    if (stmt.kind === ts.SyntaxKind.EmptyStatement) continue;
+
+    if (ts.isExpressionStatement(stmt) && ts.isYieldExpression(stmt.expression)) {
+      const yieldExpr = stmt.expression;
+      if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return null;
+      segments.push({ statements: current, yieldExpr });
+      current = [];
+      continue;
+    }
+
+    if (ts.isReturnStatement(stmt)) {
+      if (!isNumericExpression(ctx, stmt.expression)) return null;
+      segments.push({ statements: current, returnStmt: stmt });
+      current = [];
+      break;
+    }
+
+    // Phase 1 allows ordinary expression statements in a segment so side
+    // effects before a yield stay lazy. Declarations/control flow need spill
+    // analysis and are left to follow-up phases.
+    if (ts.isExpressionStatement(stmt) && !statementContainsYield(stmt)) {
+      current.push(stmt);
+      continue;
+    }
+
+    return null;
+  }
+
+  if (current.length > 0 || segments.length === 0 || segments.at(-1)?.returnStmt === undefined) {
+    segments.push({ statements: current });
+  }
+
+  const yieldCount = segments.filter((s) => s.yieldExpr !== undefined).length;
+  if (yieldCount > MAX_NATIVE_GENERATOR_STATES) return null;
+  return segments;
+}
+
+export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.FunctionDeclaration): boolean {
+  if (!noJsHostTarget(ctx)) return false;
+  if (!decl.name || !decl.body || !decl.asteriskToken) return false;
+  const modifiers = ts.canHaveModifiers(decl) ? ts.getModifiers(decl) : undefined;
+  if (modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword || m.kind === ts.SyntaxKind.DeclareKeyword)) {
+    return false;
+  }
+  for (const param of decl.parameters) {
+    if (param.dotDotDotToken || !ts.isIdentifier(param.name)) return false;
+  }
+  const segments = buildNativeGeneratorSegments(ctx, decl);
+  return segments !== null && segments.some((s) => s.yieldExpr !== undefined);
+}
+
+export function sourceNeedsGeneratorHostImports(ctx: CodegenContext, sourceFile: ts.SourceFile): boolean {
+  let found = false;
+  let needsHost = false;
+
+  function visit(node: ts.Node): void {
+    if (needsHost) return;
+    if (ts.isFunctionDeclaration(node) && node.asteriskToken && node.body) {
+      found = true;
+      if (!isNativeGeneratorCandidate(ctx, node)) needsHost = true;
+      return;
+    }
+    if (ts.isFunctionExpression(node) && node.asteriskToken) {
+      found = true;
+      needsHost = true;
+      return;
+    }
+    if (ts.isMethodDeclaration(node) && node.asteriskToken && node.body) {
+      found = true;
+      needsHost = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  ts.forEachChild(sourceFile, visit);
+  return found && needsHost;
+}
+
+export function ensureNativeGeneratorResultType(ctx: CodegenContext): number {
+  if (ctx.nativeGeneratorResultTypeIdx >= 0) return ctx.nativeGeneratorResultTypeIdx;
+  const existing = ctx.structMap.get("__NativeGeneratorResult_f64");
+  if (existing !== undefined) {
+    ctx.nativeGeneratorResultTypeIdx = existing;
+    return existing;
+  }
+
+  const fields: FieldDef[] = [
+    { name: "value", type: { kind: "f64" }, mutable: false },
+    { name: "done", type: { kind: "i32" }, mutable: false },
+  ];
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: "__NativeGeneratorResult_f64", fields });
+  ctx.structMap.set("__NativeGeneratorResult_f64", typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, "__NativeGeneratorResult_f64");
+  ctx.structFields.set("__NativeGeneratorResult_f64", fields);
+  ctx.nativeGeneratorResultTypeIdx = typeIdx;
+  return typeIdx;
+}
+
+export function registerNativeGenerator(
+  ctx: CodegenContext,
+  decl: ts.FunctionDeclaration,
+  functionName: string,
+  paramTypes: ValType[],
+): NativeGeneratorInfo | null {
+  const existing = ctx.nativeGenerators.get(functionName);
+  if (existing) return existing;
+  if (!isNativeGeneratorCandidate(ctx, decl)) return null;
+
+  const segments = buildNativeGeneratorSegments(ctx, decl);
+  if (!segments) return null;
+
+  const resultTypeIdx = ensureNativeGeneratorResultType(ctx);
+  const paramNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
+  const stateFields: FieldDef[] = [{ name: "state", type: { kind: "i32" }, mutable: true }];
+  for (let i = 0; i < paramTypes.length; i++) {
+    stateFields.push({
+      name: `param_${paramNames[i] ?? i}`,
+      type: paramTypes[i]!,
+      mutable: false,
+    });
+  }
+
+  const stateName = `__GenState_${sanitizeTypeName(functionName)}`;
+  const stateTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: stateName, fields: stateFields });
+  ctx.structMap.set(stateName, stateTypeIdx);
+  ctx.typeIdxToStructName.set(stateTypeIdx, stateName);
+  ctx.structFields.set(stateName, stateFields);
+
+  const yieldCount = segments.filter((s) => s.yieldExpr !== undefined).length;
+  const info: NativeGeneratorInfo = {
+    functionName,
+    decl,
+    stateTypeIdx,
+    resultTypeIdx,
+    paramNames,
+    paramTypes,
+    paramFieldOffset: PARAM_FIELD_OFFSET,
+    yieldCount,
+    doneState: yieldCount + 1,
+  };
+  ctx.nativeGenerators.set(functionName, info);
+  return info;
+}
+
+function emptyResult(info: NativeGeneratorInfo): Instr[] {
+  return emptyResultForType(info.resultTypeIdx);
+}
+
+function emptyResultForType(resultTypeIdx: number): Instr[] {
+  return [
+    { op: "f64.const", value: 0 },
+    { op: "i32.const", value: 1 },
+    { op: "struct.new", typeIdx: resultTypeIdx },
+  ];
+}
+
+function setState(info: NativeGeneratorInfo, state: number): Instr[] {
+  return [
+    { op: "local.get", index: 0 },
+    { op: "i32.const", value: state },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+  ];
+}
+
+function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression | undefined): number {
+  if (!expr) {
+    const tmp = allocLocal(fctx, `__gen_value_${fctx.locals.length}`, { kind: "f64" });
+    fctx.body.push({ op: "f64.const", value: NaN });
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
+
+  const resultType = compileExpression(ctx, fctx, expr, { kind: "f64" });
+  if (resultType === null) {
+    fctx.body.push({ op: "f64.const", value: NaN });
+  } else if (resultType.kind === "i32") {
+    fctx.body.push({ op: "f64.convert_i32_s" });
+  } else if (!valTypesMatch(resultType, { kind: "f64" })) {
+    coerceType(ctx, fctx, resultType, { kind: "f64" });
+  }
+  const tmp = allocLocal(fctx, `__gen_value_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: tmp });
+  return tmp;
+}
+
+function compileSegment(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: NativeGeneratorInfo,
+  segment: NativeGeneratorSegment,
+  yieldIndex: number,
+): Instr[] {
+  const saved = fctx.body;
+  const body: Instr[] = [];
+  fctx.body = body;
+
+  for (const stmt of segment.statements) {
+    compileStatement(ctx, fctx, stmt);
+  }
+
+  if (segment.yieldExpr) {
+    const tmp = emitExpressionAsF64(ctx, fctx, segment.yieldExpr.expression);
+    body.push(...setState(info, yieldIndex + 1));
+    body.push({ op: "local.get", index: tmp });
+    body.push({ op: "i32.const", value: 0 });
+    body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+  } else if (segment.returnStmt) {
+    const tmp = emitExpressionAsF64(ctx, fctx, segment.returnStmt.expression);
+    body.push(...setState(info, info.doneState));
+    body.push({ op: "local.get", index: tmp });
+    body.push({ op: "i32.const", value: 1 });
+    body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+  } else {
+    body.push(...setState(info, info.doneState));
+    body.push(...emptyResult(info));
+  }
+
+  fctx.body = saved;
+  return body;
+}
+
+function buildDispatch(info: NativeGeneratorInfo, cases: Instr[][], defaultBody: Instr[]): Instr[] {
+  function caseAt(index: number): Instr[] {
+    if (index >= cases.length) return defaultBody;
+    const elseBody = caseAt(index + 1);
+    return [
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+      { op: "i32.const", value: index },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "ref", typeIdx: info.resultTypeIdx } },
+        then: cases[index]!,
+        else: elseBody,
+      },
+    ];
+  }
+  return caseAt(0);
+}
+
+export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: NativeGeneratorInfo): number {
+  if (info.resumeFuncIdx !== undefined) return info.resumeFuncIdx;
+
+  const fnName = `__gen_resume_${sanitizeTypeName(info.functionName)}`;
+  const existing = ctx.funcMap.get(fnName);
+  if (existing !== undefined) {
+    info.resumeFuncIdx = existing;
+    return existing;
+  }
+
+  const selfType: ValType = { kind: "ref", typeIdx: info.stateTypeIdx };
+  const resultType: ValType = { kind: "ref", typeIdx: info.resultTypeIdx };
+  const typeIdx = addFuncType(ctx, [selfType], [resultType], `${fnName}_type`);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  info.resumeFuncIdx = funcIdx;
+  ctx.funcMap.set(fnName, funcIdx);
+
+  const resumeFctx: FunctionContext = {
+    name: fnName,
+    params: [{ name: "__gen_self", type: selfType }],
+    locals: [],
+    localMap: new Map([["__gen_self", 0]]),
+    returnType: resultType,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+
+  for (let i = 0; i < info.paramTypes.length; i++) {
+    const localIdx = allocLocal(resumeFctx, info.paramNames[i]!, info.paramTypes[i]!);
+    resumeFctx.body.push({ op: "local.get", index: 0 });
+    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.paramFieldOffset + i });
+    resumeFctx.body.push({ op: "local.set", index: localIdx });
+  }
+
+  const segments = buildNativeGeneratorSegments(ctx, info.decl);
+  if (!segments) {
+    reportError(ctx, info.decl, "Internal error: native generator plan disappeared during emission");
+    resumeFctx.body.push(...emptyResult(info));
+  } else {
+    const savedFunc = ctx.currentFunc;
+    ctx.currentFunc = resumeFctx;
+    try {
+      let yieldIndex = 0;
+      const cases = segments.map((segment) => {
+        const caseBody = compileSegment(ctx, resumeFctx, info, segment, yieldIndex);
+        if (segment.yieldExpr) yieldIndex++;
+        return caseBody;
+      });
+      const defaultBody = [...setState(info, info.doneState), ...emptyResult(info)];
+      resumeFctx.body.push(...buildDispatch(info, cases, defaultBody));
+    } finally {
+      ctx.currentFunc = savedFunc;
+    }
+  }
+
+  const fn: WasmFunction = {
+    name: fnName,
+    typeIdx,
+    locals: resumeFctx.locals,
+    body: resumeFctx.body,
+    exported: false,
+  };
+  ctx.mod.functions.push(fn);
+  return funcIdx;
+}
+
+export function compileNativeGeneratorFunction(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  decl: ts.FunctionDeclaration,
+  info: NativeGeneratorInfo,
+): void {
+  ensureNativeGeneratorResumeFunction(ctx, info);
+  fctx.body.push({ op: "i32.const", value: 0 });
+  for (let i = 0; i < decl.parameters.length; i++) {
+    fctx.body.push({ op: "local.get", index: i });
+  }
+  fctx.body.push({ op: "struct.new", typeIdx: info.stateTypeIdx });
+}
+
+function nativeInfoForStateType(ctx: CodegenContext, typeIdx: number): NativeGeneratorInfo | undefined {
+  for (const info of ctx.nativeGenerators.values()) {
+    if (info.stateTypeIdx === typeIdx) return info;
+  }
+  return undefined;
+}
+
+function isNativeResultType(ctx: CodegenContext, type: ValType | null): boolean {
+  return (
+    !!type &&
+    (type.kind === "ref" || type.kind === "ref_null") &&
+    ctx.nativeGeneratorResultTypeIdx >= 0 &&
+    type.typeIdx === ctx.nativeGeneratorResultTypeIdx
+  );
+}
+
+function compileIgnoredArgs(ctx: CodegenContext, fctx: FunctionContext, args: readonly ts.Expression[]): void {
+  for (const arg of args) {
+    const argType = compileExpression(ctx, fctx, arg);
+    if (argType !== null) fctx.body.push({ op: "drop" });
+  }
+}
+
+function compileDirectNativeGeneratorMethod(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: NativeGeneratorInfo,
+  receiverType: ValType,
+  methodName: string,
+  args: readonly ts.Expression[],
+): ValType | null | undefined {
+  if (methodName === "throw") return undefined;
+
+  if (receiverType.kind === "ref_null") {
+    fctx.body.push({ op: "ref.as_non_null" });
+  }
+  const selfLocal = allocLocal(fctx, `__native_gen_self_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: info.stateTypeIdx,
+  });
+  fctx.body.push({ op: "local.set", index: selfLocal });
+
+  if (methodName === "next") {
+    compileIgnoredArgs(ctx, fctx, args);
+    fctx.body.push({ op: "local.get", index: selfLocal });
+    fctx.body.push({ op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) });
+    return { kind: "ref", typeIdx: info.resultTypeIdx };
+  }
+
+  if (methodName === "return") {
+    const valueTmp = emitExpressionAsF64(ctx, fctx, args[0]);
+    fctx.body.push({ op: "local.get", index: selfLocal });
+    fctx.body.push({ op: "i32.const", value: info.doneState });
+    fctx.body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
+    fctx.body.push({ op: "local.get", index: valueTmp });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+    compileIgnoredArgs(ctx, fctx, args.slice(1));
+    return { kind: "ref", typeIdx: info.resultTypeIdx };
+  }
+
+  return undefined;
+}
+
+function buildNativeGeneratorDispatch(
+  ctx: CodegenContext,
+  anyLocal: number,
+  methodName: string,
+  valueLocal?: number,
+): Instr[] {
+  const infos = Array.from(ctx.nativeGenerators.values());
+  const resultType: ValType = { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
+  const fallback: Instr[] = [
+    { op: "f64.const", value: 0 },
+    { op: "i32.const", value: 1 },
+    { op: "struct.new", typeIdx: ctx.nativeGeneratorResultTypeIdx },
+  ];
+
+  function branch(index: number): Instr[] {
+    if (index >= infos.length) return fallback;
+    const info = infos[index]!;
+    let thenBody: Instr[];
+    if (methodName === "next") {
+      thenBody = [
+        { op: "local.get", index: anyLocal },
+        { op: "ref.cast", typeIdx: info.stateTypeIdx },
+        { op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) },
+      ];
+    } else {
+      thenBody = [
+        { op: "local.get", index: anyLocal },
+        { op: "ref.cast", typeIdx: info.stateTypeIdx },
+        { op: "i32.const", value: info.doneState },
+        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+        { op: "local.get", index: valueLocal! },
+        { op: "i32.const", value: 1 },
+        { op: "struct.new", typeIdx: info.resultTypeIdx },
+      ];
+    }
+    return [
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx: info.stateTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: resultType },
+        then: thenBody,
+        else: branch(index + 1),
+      },
+    ];
+  }
+  return branch(0);
+}
+
+export function tryCompileNativeGeneratorMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverExpr: ts.Expression,
+  methodName: string,
+  args: readonly ts.Expression[],
+): ValType | null | undefined {
+  if (methodName !== "next" && methodName !== "return") return undefined;
+  if (ctx.nativeGenerators.size === 0) return undefined;
+
+  const receiverType = compileExpression(ctx, fctx, receiverExpr);
+  if (receiverType && (receiverType.kind === "ref" || receiverType.kind === "ref_null")) {
+    const info = nativeInfoForStateType(ctx, receiverType.typeIdx);
+    if (info) {
+      return compileDirectNativeGeneratorMethod(ctx, fctx, info, receiverType, methodName, args);
+    }
+  }
+
+  if (receiverType?.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" });
+  } else if (!receiverType || (receiverType.kind !== "anyref" && receiverType.kind !== "eqref")) {
+    if (receiverType !== null) fctx.body.push({ op: "drop" });
+    compileIgnoredArgs(ctx, fctx, args);
+    fctx.body.push(...emptyResultForType(ensureNativeGeneratorResultType(ctx)));
+    return { kind: "ref", typeIdx: ctx.nativeGeneratorResultTypeIdx };
+  }
+
+  const anyLocal = allocLocal(fctx, `__native_gen_any_${fctx.locals.length}`, { kind: "anyref" });
+  fctx.body.push({ op: "local.set", index: anyLocal });
+
+  let valueLocal: number | undefined;
+  if (methodName === "return") {
+    valueLocal = emitExpressionAsF64(ctx, fctx, args[0]);
+    compileIgnoredArgs(ctx, fctx, args.slice(1));
+  } else {
+    compileIgnoredArgs(ctx, fctx, args);
+  }
+
+  fctx.body.push(...buildNativeGeneratorDispatch(ctx, anyLocal, methodName, valueLocal));
+  return { kind: "ref", typeIdx: ctx.nativeGeneratorResultTypeIdx };
+}
+
+export function tryCompileNativeGeneratorResultProperty(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  resultExpr: ts.Expression,
+  propName: string,
+): ValType | null | undefined {
+  if (propName !== "value" && propName !== "done") return undefined;
+  if (ctx.nativeGeneratorResultTypeIdx < 0) return undefined;
+
+  const resultType = compileExpression(ctx, fctx, resultExpr);
+  if (isNativeResultType(ctx, resultType)) {
+    if (resultType?.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" });
+    fctx.body.push({
+      op: "struct.get",
+      typeIdx: ctx.nativeGeneratorResultTypeIdx,
+      fieldIdx: propName === "value" ? RESULT_VALUE_FIELD : RESULT_DONE_FIELD,
+    });
+    return propName === "value" ? { kind: "f64" } : { kind: "i32" };
+  }
+
+  if (resultType?.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" });
+  } else if (!resultType || (resultType.kind !== "anyref" && resultType.kind !== "eqref")) {
+    if (resultType !== null) fctx.body.push({ op: "drop" });
+    fctx.body.push(propName === "value" ? { op: "f64.const", value: 0 } : { op: "i32.const", value: 1 });
+    return propName === "value" ? { kind: "f64" } : { kind: "i32" };
+  }
+
+  const anyLocal = allocLocal(fctx, `__native_gen_result_${fctx.locals.length}`, { kind: "anyref" });
+  fctx.body.push({ op: "local.set", index: anyLocal });
+  const fieldType: ValType = propName === "value" ? { kind: "f64" } : { kind: "i32" };
+  fctx.body.push({ op: "local.get", index: anyLocal });
+  fctx.body.push({ op: "ref.test", typeIdx: ctx.nativeGeneratorResultTypeIdx });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: fieldType },
+    then: [
+      { op: "local.get", index: anyLocal },
+      { op: "ref.cast", typeIdx: ctx.nativeGeneratorResultTypeIdx },
+      {
+        op: "struct.get",
+        typeIdx: ctx.nativeGeneratorResultTypeIdx,
+        fieldIdx: propName === "value" ? RESULT_VALUE_FIELD : RESULT_DONE_FIELD,
+      },
+    ],
+    else: [propName === "value" ? { op: "f64.const", value: 0 } : { op: "i32.const", value: 1 }],
+  });
+  return fieldType;
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7878,6 +7878,7 @@ export function addArrayIteratorImports(ctx: CodegenContext): void {
  *   - `__get_caught_exception` () → externref  (for the body's try/catch wrapper)
  */
 export function addGeneratorImports(ctx: CodegenContext): void {
+  if (ctx.standalone || ctx.wasi) return;
   // Guard: only register once
   if (ctx.funcMap.has("__gen_create_buffer")) return;
 

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -24,6 +24,7 @@ import {
 } from "./expressions/helpers.js";
 import { patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
+import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -2275,6 +2276,8 @@ export function compilePropertyAccess(
 
   // Handle IteratorResult property access: .value and .done
   if (isIteratorResultType(objType) || isGeneratorIteratorResultLike(ctx, objType, propName)) {
+    const nativeResult = tryCompileNativeGeneratorResultProperty(ctx, fctx, expr.expression, propName);
+    if (nativeResult !== undefined) return nativeResult;
     if (propName === "value") {
       compileExpression(ctx, fctx, expr.expression);
       // Check the expected value type from the IteratorResult<T>

--- a/tests/issue-680.test.ts
+++ b/tests/issue-680.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function envImportNames(result: { imports: { module: string; name: string }[] }): string[] {
+  return result.imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, { fileName: "issue-680.ts", target: "standalone" });
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    );
+  }
+  return result;
+}
+
+async function instantiateStandalone(source: string): Promise<Record<string, Function>> {
+  const result = await compileStandalone(source);
+  const instance = await WebAssembly.instantiate(new WebAssembly.Module(result.binary), {});
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#680 Wasm-native generator state machines", () => {
+  it("lowers sequential numeric yields without generator host imports", async () => {
+    const result = await compileStandalone(`
+      function* gen(): Generator<number> {
+        yield 1;
+        yield 2;
+        return 3;
+      }
+
+      export function run(): number {
+        const g = gen();
+        const a = g.next();
+        const b = g.next();
+        const c = g.next();
+        const d = g.next();
+        return a.value * 1000 + b.value * 100 + c.value * 10 + (c.done ? 4 : 0) + (d.done ? 1 : 0);
+      }
+    `);
+
+    expect(envImportNames(result).filter((name) => name.startsWith("__gen_") || name === "__create_generator")).toEqual(
+      [],
+    );
+    expect(result.wat).toContain("__GenState_gen");
+
+    const instance = await WebAssembly.instantiate(new WebAssembly.Module(result.binary), {});
+    expect((instance.exports as Record<string, Function>).run()).toBe(1235);
+  });
+
+  it("persists parameters in the native generator state struct", async () => {
+    const exports = await instantiateStandalone(`
+      function* gen(start: number): Generator<number> {
+        yield start;
+        yield start + 1;
+        return start + 2;
+      }
+
+      export function run(): number {
+        const g = gen(5);
+        const a = g.next();
+        const b = g.next();
+        const c = g.next();
+        return a.value * 100 + b.value * 10 + c.value + (c.done ? 1000 : 0);
+      }
+    `);
+
+    expect(exports.run()).toBe(1567);
+  });
+
+  it("runs generator body effects lazily on next", async () => {
+    const exports = await instantiateStandalone(`
+      let hits = 0;
+
+      function tick(): number {
+        hits = hits + 1;
+        return hits;
+      }
+
+      function* gen(): Generator<number> {
+        yield tick();
+        yield tick();
+      }
+
+      export function run(): number {
+        const g = gen();
+        const before = hits;
+        const a = g.next();
+        const afterOne = hits;
+        const b = g.next();
+        return before * 10000 + afterOne * 1000 + hits * 100 + a.value * 10 + b.value;
+      }
+    `);
+
+    expect(exports.run()).toBe(1212);
+  });
+
+  it("keeps the JS host eager-buffer fallback outside standalone targets", async () => {
+    const result = await compile(`
+      function* gen(): Generator<number> {
+        yield 1;
+      }
+      export function run(): number {
+        return gen().next().value;
+      }
+    `);
+
+    expect(result.success).toBe(true);
+    expect(envImportNames(result)).toContain("__create_generator");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Phase 1 Wasm-native generator path for standalone/WASI targets using WasmGC state structs and generated resume functions.
- Route native generator `.next()` / `.return(value)` and `IteratorResult.value` / `.done` through in-module state/result structs.
- Keep the existing eager JS-host generator fallback for default host builds, while no-host targets avoid `__gen_*` / `__create_generator` imports for the supported subset.

## Spec Notes

- Implements the supported sequential-yield subset against ECMA-262 §27.5.3.3 GeneratorResume and §27.5.3.6 GeneratorYield.

## Validation

- `pnpm exec vitest run tests/issue-680.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Pre-push hook: typecheck, lint, format:check, issue integrity

Co-authored-by: Codex <codex@openai.com>
