### PR TITLE
fix(generators): restore standalone fallback imports

### DIFF
--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1257,8 +1257,10 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // claims a generator function (#1169f). The helper is idempotent —
   // guards on `ctx.funcMap.has("__gen_create_buffer")` internally.
   if (state.generatorFound) {
-    if (!((ctx.standalone || ctx.wasi) && !sourceNeedsGeneratorHostImports(ctx, state.sourceFile))) {
-      addGeneratorImports(ctx);
+    const needsNoJsHostFallback =
+      (ctx.standalone || ctx.wasi) && sourceNeedsGeneratorHostImports(ctx, state.sourceFile);
+    if (!(ctx.standalone || ctx.wasi) || needsNoJsHostFallback) {
+      addGeneratorImports(ctx, { allowNoJsHost: needsNoJsHostFallback });
     }
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7877,8 +7877,8 @@ export function addArrayIteratorImports(ctx: CodegenContext): void {
  *   - `__gen_result_done`     (externref) → i32
  *   - `__get_caught_exception` () → externref  (for the body's try/catch wrapper)
  */
-export function addGeneratorImports(ctx: CodegenContext): void {
-  if (ctx.standalone || ctx.wasi) return;
+export function addGeneratorImports(ctx: CodegenContext, options?: { allowNoJsHost?: boolean }): void {
+  if ((ctx.standalone || ctx.wasi) && !options?.allowNoJsHost) return;
   // Guard: only register once
   if (ctx.funcMap.has("__gen_create_buffer")) return;
 

--- a/tests/issue-680.test.ts
+++ b/tests/issue-680.test.ts
@@ -96,6 +96,22 @@ describe("#680 Wasm-native generator state machines", () => {
     expect(exports.run()).toBe(1212);
   });
 
+  it("registers helper imports for standalone generator fallback bodies", async () => {
+    const result = await compileStandalone(`
+      class C {
+        *method(): Generator<number> {}
+      }
+
+      export function run(): number {
+        return 1;
+      }
+    `);
+
+    expect(envImportNames(result)).toContain("__gen_create_buffer");
+    expect(envImportNames(result)).toContain("__create_generator");
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
   it("keeps the JS host eager-buffer fallback outside standalone targets", async () => {
     const result = await compile(`
       function* gen(): Generator<number> {


### PR DESCRIPTION
## Summary

- Restore generator helper import registration for standalone/WASI fallback generator paths that cannot use the native state-machine lowering.
- Keep native-supported standalone generators import-free by requiring an explicit no-JS-host fallback opt-in.
- Add #680 regression coverage for standalone generator fallback bodies producing valid Wasm.

## Root Cause

PR #1052 added native standalone generator lowering, but the shared generator import registrar started returning early for standalone/WASI. Fallback generator bodies could still be emitted in those targets, so they produced unresolved helper calls such as `call undefined`, which showed up as invalid Wasm and dropped the standalone Test262 baseline by 35 passes.

## Validation

- `node node_modules/vitest/dist/cli.js run tests/issue-680.test.ts`
- Filtered standalone Test262 run over the 36 known regressed paths: 36/36 passed
- `pnpm exec prettier --check src/codegen/index.ts src/codegen/declarations.ts tests/issue-680.test.ts`
- `pnpm exec biome lint src/codegen/index.ts src/codegen/declarations.ts tests/issue-680.test.ts --diagnostic-level=error`
- `git diff --check`
- Pre-push hook: typecheck, lint, format:check, issue integrity

Co-authored-by: Codex <codex@openai.com>