### PR TITLE
docs(memory): require explicit main pushes

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -107,6 +107,7 @@
 - [feedback_sprint_tags.md](feedback_sprint_tags.md) — Tag sprint-N/begin at start, sprint/N at end
 - [feedback_no_stash_before_merge.md](feedback_no_stash_before_merge.md) — Never stash before merge, commit first
 - [feedback_no_git_stash_in_worktree.md](feedback_no_git_stash_in_worktree.md) — NEVER `git stash` in a worktree; stash stack is shared across worktrees, concurrent agents clobber each other
+- [feedback_explicit_main_push.md](feedback_explicit_main_push.md) — Only push to main when the user explicitly asks for that exact push each time
 - [feedback_regression_analysis.md](feedback_regression_analysis.md) — Regressions may be false-positive exposure, not real regressions; `pass → compile_timeout` is runner-load flake unless baseline compile >5s
 
 Most project context lives in `/workspace/CLAUDE.md`.

--- a/.claude/memory/feedback_explicit_main_push.md
+++ b/.claude/memory/feedback_explicit_main_push.md
@@ -1,0 +1,6 @@
+# Explicit Main Pushes
+
+Only push to `main` when the user explicitly asks for that exact direct push in
+the current turn. Do not infer permission from prior direct pushes, broad
+"push" wording, or surrounding urgency. Default to a branch/PR path unless the
+user clearly says to push to `main` this time.


### PR DESCRIPTION
## Summary
- Record that direct pushes to main require an explicit per-turn request
- Add the new memory note to the repo memory index

## Verification
- Pre-push hook passed on branch push: typecheck + lint, format check, issue integrity