### PR TITLE
fix(#1105): native String.prototype.concat dispatch for standalone

### DIFF
--- a/plan/issues/1105-wasm-native-string-method-implementations.md
+++ b/plan/issues/1105-wasm-native-string-method-implementations.md
@@ -1,9 +1,10 @@
 ---
 id: 1105
 title: "Wasm-native String method implementations for standalone mode"
-status: in-review
+status: done
 created: 2026-04-12
-updated: 2026-06-02
+updated: 2026-06-03
+completed: 2026-06-03
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -223,3 +224,40 @@ Remaining scope:
   rules.
 - Unicode case-mapping tables, locale behavior, and RegExp-dependent methods
   remain outside this focused implementation pass.
+
+## Implementation Update — 2026-06-03 (Tier 1 complete)
+
+- Closed the last Tier 1 gap: `String.prototype.concat` had no native
+  dispatch. In standalone/nativeStrings mode it fell through to the JS-host
+  `string_concat` import and trapped at runtime with an "illegal cast" while
+  marshaling native↔extern.
+- `compileNativeStringMethodCall` (`src/codegen/string-ops.ts`) now lowers
+  `concat` natively: the receiver becomes the accumulator and each argument is
+  coerced to a native string and folded through the existing `__str_concat`
+  helper (ECMA-262 §22.1.3.4, left-to-right). Handles the variadic and no-arg
+  (`"x".concat()` → receiver) forms.
+- Added `"concat"` to the `NATIVE_STR_METHODS` set in
+  `src/codegen/declarations.ts` so the `string_concat` host import is no longer
+  registered (it was the one place still emitting it, matching the already-present
+  entry in `src/codegen/index.ts`). Standalone modules now carry zero `string_*`
+  host imports for concat.
+- Smoke-tested the full Tier 1 surface in standalone mode (23 cases):
+  charAt, charCodeAt, codePointAt, at, indexOf, lastIndexOf, includes,
+  startsWith, endsWith, slice, substring, trim/trimStart/trimEnd, padStart,
+  padEnd, repeat, toLowerCase, toUpperCase, split (string sep, incl. empty),
+  and concat — all pass. Tier 1 acceptance (≥70% String.prototype) met.
+
+### Known residual (tracked, not Tier 1 blocker)
+
+- `String.prototype.at` out-of-range index returns an empty native string
+  rather than `undefined` (it mirrors the legacy `charAt` empty-string
+  behavior). Spec §22.1.3.1 wants `undefined` for OOB. Representing `undefined`
+  from a native-string-returning helper needs nullable-string plumbing — a
+  broader change deferred beyond this Tier 1 pass.
+- Tier 2 (RegExp-dependent: match/matchAll/search, RegExp-arg
+  replace/replaceAll/split) remains blocked on the native regex engine (#1539).
+
+Scoped validation (in worktree):
+
+- `npm test -- tests/issue-1105.test.ts tests/native-strings-standalone.test.ts tests/native-strings.test.ts tests/issue-1105-charcodeat.test.ts tests/host-import-allowlist-gate.test.ts` → 117 passed
+- `tsc --noEmit` clean; `biome lint` clean on changed files.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1030,6 +1030,7 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
       "padEnd",
       "toLowerCase",
       "toUpperCase",
+      "concat",
       "replace",
       "replaceAll",
       "split",

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -1621,6 +1621,26 @@ export function compileNativeStringMethodCall(
     return nativeStringType(ctx);
   }
 
+  // concat: native helper. ECMA-262 §22.1.3.4 — coerce each argument with
+  // ToString and append, left to right, to the receiver. `__str_concat(a, b)`
+  // joins two AnyString refs; chain it across the (possibly variadic) argument
+  // list so standalone mode never reaches the host `string_concat` import.
+  if (method === "concat") {
+    const concatIdx = ctx.nativeStrHelpers.get("__str_concat")!;
+    // Receiver is the running accumulator.
+    compileExpression(ctx, fctx, propAccess.expression);
+    if (expr.arguments.length === 0) {
+      // `"x".concat()` returns the receiver unchanged.
+      return nativeStringType(ctx);
+    }
+    for (const arg of expr.arguments) {
+      // Accumulator is already on the stack; push the next operand and join.
+      compileExpression(ctx, fctx, arg, nativeStringType(ctx));
+      fctx.body.push({ op: "call", funcIdx: concatIdx });
+    }
+    return nativeStringType(ctx);
+  }
+
   // substring: native helper
   if (method === "substring") {
     compileExpression(ctx, fctx, propAccess.expression);

--- a/tests/issue-1105.test.ts
+++ b/tests/issue-1105.test.ts
@@ -139,4 +139,46 @@ describe("#1105 native String method helpers", () => {
 
     expect((exports.repeatLen as () => number)()).toBe(6);
   });
+
+  it("concatenates via the native helper without requesting string_concat", async () => {
+    // ECMA-262 §22.1.3.4 String.prototype.concat: ToString each argument, then
+    // append left-to-right. Standalone mode must lower this to the native
+    // __str_concat chain and never reach the JS-host `string_concat` import.
+    const result = await compile(
+      `
+      export function concatTwo(): number {
+        return "ab".concat("cd").length;
+      }
+      `,
+      { target: "standalone", fileName: "issue-1105-concat.ts" },
+    );
+    expect(result.success, result.errors.map((err) => err.message).join("\n")).toBe(true);
+    expect(envStringMethodImports(result.imports)).toEqual([]);
+    expect(result.wat).not.toContain("wasm:js-string");
+
+    const exports = await compileNativeRuntime(`
+      export function concatTwo(): number {
+        return "ab".concat("cd").length;
+      }
+
+      export function concatVariadic(): number {
+        return "a".concat("b", "c", "d").length;
+      }
+
+      export function concatNoArgs(): number {
+        return "abc".concat().length;
+      }
+
+      export function concatCharAt(): number {
+        const a = "xy";
+        const b = "z";
+        return a.concat(b).charCodeAt(2);
+      }
+    `);
+
+    expect((exports.concatTwo as () => number)()).toBe(4);
+    expect((exports.concatVariadic as () => number)()).toBe(4);
+    expect((exports.concatNoArgs as () => number)()).toBe(3);
+    expect((exports.concatCharAt as () => number)()).toBe(122);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the last Tier 1 gap for #1105 (Wasm-native String methods in standalone mode).

After PR #1046 the Tier 1 surface was ~95% complete, but `String.prototype.concat` had no native dispatch: in standalone/`nativeStrings` mode it fell through to the JS-host `string_concat` import and trapped at runtime with an "illegal cast" during native↔extern marshaling.

## Changes

- **`src/codegen/string-ops.ts`** — `compileNativeStringMethodCall` now lowers `concat` natively. The receiver is the accumulator; each argument is coerced to a native string and folded through the existing `__str_concat` helper, left-to-right per ECMA-262 §22.1.3.4. Handles variadic (`"a".concat("b","c")`) and no-arg (`"x".concat()` → receiver) forms.
- **`src/codegen/declarations.ts`** — add `"concat"` to `NATIVE_STR_METHODS` so the `string_concat` host import is no longer registered (matching the entry already present in `index.ts`). Standalone modules now carry zero `string_*` host imports for concat.
- **`tests/issue-1105.test.ts`** — standalone concat coverage: asserts no `string_*` import / no `wasm:js-string`, plus runtime checks for two-arg, variadic, no-arg, and charAt-of-result forms.

## Validation

Smoke-tested the full Tier 1 surface in standalone mode (23 cases: charAt, charCodeAt, codePointAt, at, indexOf, lastIndexOf, includes, startsWith, endsWith, slice, substring, trim/trimStart/trimEnd, padStart, padEnd, repeat, toLowerCase, toUpperCase, split incl. empty-sep, concat) — all pass. Tier 1 acceptance (≥70% String.prototype) met.

Scoped tests (worktree): `npm test -- tests/issue-1105.test.ts tests/native-strings-standalone.test.ts tests/native-strings.test.ts tests/issue-1105-charcodeat.test.ts tests/host-import-allowlist-gate.test.ts` → **117 passed**. `tsc --noEmit` clean; `biome lint` clean on changed files.

## Known residuals (tracked, not Tier 1 blockers)

- `String.prototype.at` out-of-range index returns an empty native string instead of `undefined` (mirrors legacy `charAt`); proper `undefined` needs nullable-string plumbing — deferred.
- Tier 2 (RegExp-dependent methods) remains blocked on the native regex engine (#1539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)