### PR TITLE
feat(#1472 Phase B S1): Wasm-native open-object runtime core (new/get/set)

### DIFF
--- a/plan/issues/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/1472-no-js-host-object-property-ops.md
@@ -1,7 +1,7 @@
 ---
 id: 1472
 title: "host-independence: eliminate JS host object/property ops for standalone Wasm"
-status: in-review
+status: in-progress
 pr: 1047
 created: 2026-05-20
 updated: 2026-06-03
@@ -552,3 +552,69 @@ When `ctx.standalone` is set:
   before Phase B so the open-object runtime can `throw` real
   TypeErrors on `Object.freeze`-violation, etc.
 - #1474 is independent.
+
+## Phase B Slice 1 — IMPLEMENTED 2026-06-03 (senior-dev)
+
+The Wasm-native open-object runtime core (object creation + own/proto property
+get/set) now lowers `--target standalone` open objects to a pure-WasmGC
+open-hash-map. No more refuse-and-document for the `__new_plain_object` /
+`__extern_get` / `__extern_set` triad — the top-3 standalone failure helpers
+(15,597 + 5,008 + 5,414 raw mentions).
+
+### What landed
+- `src/codegen/object-runtime.ts` (NEW, ~570 LOC of emitter): registers the
+  `$Object` / `$PropMap` / `$PropEntry` WasmGC types and the helper functions
+  `__obj_hash`, `__obj_find`, `__obj_insert`, `__obj_grow` (internal) plus the
+  three externref-signatured public helpers `__new_plain_object`,
+  `__extern_get`, `__extern_set`. Open addressing with linear probing, FNV-1a
+  hash over the flattened string's UTF-16 code units, 0.7 load-factor grow +
+  rehash, tombstone bit reserved for the delete slice.
+- `src/codegen/expressions/late-imports.ts`: `ensureLateImport` routes the three
+  public names through `ensureObjectRuntime(ctx)` under `ctx.standalone`,
+  mirroring the #1471 `UNION_NATIVE_HELPER_NAMES` boxing-helper pattern. Sits
+  BEFORE the Phase A `refuseStandaloneObjectImport` gate so those names compile
+  instead of refusing. WASI is intentionally NOT routed yet.
+- `src/codegen/context/types.ts`: `objectRuntimeTypes?: ObjectRuntimeTypes`
+  caches the type indices for later slices.
+
+### Why this design (root-cause, not symptom)
+The decisive insight is that the entire existing JS-host object machinery treats
+objects as **externref** and looks helpers up by NAME via `ensureLateImport`
+then emits a plain `call funcIdx`. By giving the native helpers the **exact same
+name + externref-based signature** as the host imports and wrapping the
+`$Object` struct to externref via `extern.convert_any` (a no-op at the engine
+level, the same trick `__box_number` uses), EVERY existing call site in
+`object-ops.ts` / `property-access.ts` / `literals.ts` resolves to the native
+function with **zero per-call-site retargeting**. This avoids the fragile
+per-site `if (ctx.standalone) … else …` edits the original plan sketched, and
+it sidesteps the late-import index-shift machinery entirely: the helpers are
+emitted as DEFINED functions (no imports added), so their funcIdx sits above
+every existing function and no shift is required (same invariant as
+`addUnionImportsAsNativeFuncs`).
+
+Keys arrive as externref holding a `$NativeString` (standalone auto-enables
+nativeStrings). The runtime reuses the existing `__str_flatten` (cons→flat) and
+`__str_equals` native string helpers for keying, so it inherits correct
+UTF-16 comparison and never needs a JS host.
+
+### Validation
+- `tests/issue-1472.test.ts` (9 tests, all green): the Phase A "open object
+  refuses" assertion is replaced by two Phase B end-to-end tests that
+  `WebAssembly.instantiate(r.binary, {})` (empty imports) and execute under
+  Node's WasmGC engine: new/set/get returns 42; property update + 15-key
+  grow/rehash returns 24. Closed-shape struct + class-instance + Proxy-refusal +
+  default-GC regression guards still pass. `assertNoHostObjectImports` confirms
+  zero leaked `env::__extern_*` / `__new_plain_object` imports.
+- `npx tsc --noEmit` clean; `biome lint` clean on the three changed files.
+- `tests/wasi.test.ts` (24 tests) green — WASI path untouched (not routed).
+
+### Follow-up slices (still refuse under standalone)
+- `__extern_get_idx` / `__extern_length` (indexed/array-like access)
+- `__delete_property` (tombstone is already reserved in `$PropEntry.flags`)
+- `__hasOwnProperty` / `__object_keys|values|entries` / `__object_assign`
+- `__for_in_*` (for-in enumeration over `$PropMap`, insertion order)
+- `__defineProperty_*` + descriptor reflection (flags field is in place)
+- `__get_builtin` / `__extern_method_call` (vtable dispatch)
+- Prototype chain is already walked by `__extern_get`; `__getPrototypeOf` /
+  `instanceof` / `isPrototypeOf` helpers are a thin follow-up over the `$proto`
+  field.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -9,6 +9,7 @@
 import { ts } from "../../ts-api.js";
 import type { FieldDef, Instr, LocalDef, SourcePos, ValType, WasmModule } from "../../ir/types.js";
 import type { StandaloneRegExpEngineConfig } from "../regexp-standalone.js";
+import type { ObjectRuntimeTypes } from "../object-runtime.js";
 
 export interface CodegenError {
   message: string;
@@ -862,6 +863,11 @@ export interface CodegenContext {
    *  compile-error so a single source construct emits at most one error per
    *  import name. Lazily initialized in late-imports.ts. */
   standaloneRefusedImports?: Set<string>;
+  /** (#1472 Phase B) Type indices for the Wasm-native open-object runtime
+   *  ($Object / $PropMap / $PropEntry), allocated once by ensureObjectRuntime
+   *  in object-runtime.ts. Undefined until first open-object op under
+   *  --target standalone. */
+  objectRuntimeTypes?: ObjectRuntimeTypes;
   /** (#682) Native standalone RegExp engine hook. Standalone mode currently
    *  enables the reduced literal-substring backend; null means RegExp lowering
    *  must stay on the explicit #1474 refusal path. */

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -12,6 +12,7 @@ import { reportErrorNoNode } from "../context/errors.js";
 import { addImport } from "../registry/imports.js";
 import { addFuncType } from "../registry/types.js";
 import { addUnionImportsViaRegistry } from "../shared.js";
+import { ensureObjectRuntime, OBJECT_RUNTIME_HELPER_NAMES } from "../object-runtime.js";
 
 /**
  * #1471: helper names that `addUnionImports` provides Wasm-native
@@ -256,6 +257,21 @@ export function ensureLateImport(
   // #1472 object/property refusal family below.
   if ((ctx.wasi || ctx.standalone) && UNION_NATIVE_HELPER_NAMES.has(name)) {
     addUnionImportsViaRegistry(ctx);
+    return ctx.funcMap.get(name);
+  }
+  // #1472 Phase B — under --target standalone, the open-object property ops
+  // (__new_plain_object / __extern_get / __extern_set) have Wasm-native
+  // implementations emitted by ensureObjectRuntime (object-runtime.ts), backed
+  // by a $Object/$PropMap/$PropEntry open-hash-map instead of the JS-host
+  // WeakMap sidecars. Route here so the module needs no unsatisfiable env::*
+  // host import. ensureObjectRuntime is idempotent and registers every name in
+  // OBJECT_RUNTIME_HELPER_NAMES in funcMap as a DEFINED function (no import is
+  // added, so no index shift is required — same invariant as the #1471 boxing
+  // helpers above). This keeps every existing externref-based call site
+  // unchanged. (WASI is intentionally NOT routed here yet — it retains the
+  // host-import object machinery until the standalone path is proven.)
+  if (ctx.standalone && OBJECT_RUNTIME_HELPER_NAMES.has(name)) {
+    ensureObjectRuntime(ctx);
     return ctx.funcMap.get(name);
   }
   // #1472 Phase A — refuse dynamic-shape object/property host imports under

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1,0 +1,803 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1472 Phase B — Wasm-native open-object runtime for `--target standalone`.
+ *
+ * Open objects (plain object literals, `any`-typed property access) are the
+ * single largest standalone-mode failure cluster (26,880 primary rows). In
+ * JS-host mode they route through a family of `env::__extern_*` /
+ * `env::__object_*` host imports backed by JS WeakMap sidecars; in standalone
+ * there is no JS runtime to satisfy those imports. Phase A refuses such code at
+ * compile time. Phase B (this module) replaces the sidecars with a pure-WasmGC
+ * open-hash-map so dynamic object semantics work with zero host calls.
+ *
+ * ## Representation
+ *
+ * ```
+ * (type $PropEntry (struct
+ *   (field $key   (ref $AnyString))            ;; immutable property key
+ *   (field $value (mut anyref))                ;; property value (boxed)
+ *   (field $flags (mut i32))))                 ;; writable/enumerable/configurable/tombstone
+ *
+ * (type $PropMap (array (mut (ref null $PropEntry))))   ;; open-addressing table
+ *
+ * (type $Object (struct
+ *   (field $proto      (mut (ref null $Object)))
+ *   (field $props      (mut (ref $PropMap)))
+ *   (field $count      (mut i32))              ;; live entries (excl. tombstones)
+ *   (field $tombstones (mut i32))              ;; dead entries pending rehash
+ *   (field $flags      (mut i32))))            ;; extensible/frozen/sealed bits
+ * ```
+ *
+ * ## Integration strategy (why no per-call-site retargeting)
+ *
+ * The existing JS-host call sites treat objects as `externref` and look the
+ * helper up by name via `ensureLateImport(ctx, "__extern_get", …)` then emit a
+ * plain `call funcIdx`. To avoid touching every call site (and the index-shift
+ * machinery they rely on), the native helpers registered here keep the **exact
+ * same name and externref-based signature** as the host imports:
+ *
+ *   - `__new_plain_object()                          -> externref`
+ *   - `__extern_get(externref obj, externref key)    -> externref`
+ *   - `__extern_set(externref obj, externref key, externref value) -> void`
+ *
+ * Internally a `$Object` struct is wrapped to externref via `extern.convert_any`
+ * (a no-op at the engine level, same trick `__box_number` uses) and unwrapped
+ * via `any.convert_extern` + `ref.cast $Object`. So `ensureLateImport` can route
+ * these names here under `ctx.standalone` exactly like the #1471 boxing helpers
+ * (`UNION_NATIVE_HELPER_NAMES`), and the call sites are byte-for-byte unchanged.
+ *
+ * Keys arrive as `externref` holding a `$NativeString` (standalone auto-enables
+ * nativeStrings, so a string literal key is `extern.convert_any(ref
+ * $NativeString)`). We `ref.cast $AnyString` + `__str_flatten` to a
+ * `$NativeString` for hashing and reuse the existing `__str_equals` for
+ * comparison.
+ *
+ * Closed-shape struct access (the `getFieldEntry` fast path) never reaches this
+ * runtime — it emits `struct.get`/`struct.set` directly and never calls
+ * `ensureLateImport` for these names.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { ensureNativeStringHelpers } from "./native-strings.js";
+import { addFuncType } from "./registry/types.js";
+
+/** Initial `$PropMap` capacity. Must be a power of two (mask = cap - 1). */
+const INITIAL_CAP = 8;
+
+/** `$PropEntry.$flags` bit layout. */
+const FLAG_WRITABLE = 0x01;
+const FLAG_ENUMERABLE = 0x02;
+const FLAG_CONFIGURABLE = 0x04;
+const FLAG_TOMBSTONE = 0x80;
+/** Default for a data property created by `o.x = v` — w/e/c all true. */
+const FLAG_DEFAULT = FLAG_WRITABLE | FLAG_ENUMERABLE | FLAG_CONFIGURABLE;
+
+/**
+ * Type indices for the open-object runtime structs/arrays, allocated once per
+ * module by `ensureObjectRuntime`. Stored on the context so subsequent slices
+ * (keys/values/delete/for-in) can reference the same types.
+ */
+export interface ObjectRuntimeTypes {
+  propEntryTypeIdx: number;
+  propMapTypeIdx: number;
+  objectTypeIdx: number;
+}
+
+/**
+ * Idempotently register the open-object runtime types + helper functions as
+ * defined Wasm functions in `ctx.funcMap` (under the host-import names the call
+ * sites already look up). Safe to call repeatedly; only the first call emits.
+ *
+ * MUST run after `ensureNativeStringHelpers` (it depends on `__str_flatten` /
+ * `__str_equals` and the `$NativeString` type indices) — we call it here to
+ * guarantee that. Because this path adds only DEFINED functions (no imports),
+ * the freshly-allocated func indices sit above every existing function and no
+ * index shift is required (same invariant as `addUnionImportsAsNativeFuncs`).
+ */
+export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
+  if (ctx.objectRuntimeTypes) return ctx.objectRuntimeTypes;
+
+  // Dependencies: native string helpers (flatten + equals) and the string type
+  // indices they populate.
+  ensureNativeStringHelpers(ctx);
+
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const nativeStrTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+
+  // --- 1. Register the three struct/array types. ---
+  const propEntryTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$PropEntry",
+    fields: [
+      { name: "key", type: { kind: "ref", typeIdx: anyStrTypeIdx }, mutable: false },
+      { name: "value", type: { kind: "anyref" }, mutable: true },
+      { name: "flags", type: { kind: "i32" }, mutable: true },
+    ],
+  });
+
+  const propMapTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "array",
+    name: "$PropMap",
+    element: { kind: "ref_null", typeIdx: propEntryTypeIdx },
+    mutable: true,
+  });
+
+  const objectTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$Object",
+    fields: [
+      { name: "proto", type: { kind: "ref_null", typeIdx: objectTypeIdx }, mutable: true },
+      { name: "props", type: { kind: "ref", typeIdx: propMapTypeIdx }, mutable: true },
+      { name: "count", type: { kind: "i32" }, mutable: true },
+      { name: "tombstones", type: { kind: "i32" }, mutable: true },
+      { name: "flags", type: { kind: "i32" }, mutable: true },
+    ],
+  });
+
+  const types: ObjectRuntimeTypes = { propEntryTypeIdx, propMapTypeIdx, objectTypeIdx };
+  ctx.objectRuntimeTypes = types;
+
+  // Common ValTypes.
+  const objRef: ValType = { kind: "ref", typeIdx: objectTypeIdx };
+  const objRefNull: ValType = { kind: "ref_null", typeIdx: objectTypeIdx };
+  const propMapRef: ValType = { kind: "ref", typeIdx: propMapTypeIdx };
+  const entryRefNull: ValType = { kind: "ref_null", typeIdx: propEntryTypeIdx };
+  const anyStrRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  const nativeStrRef: ValType = { kind: "ref", typeIdx: nativeStrTypeIdx };
+
+  // Helper: register a defined function, return its funcIdx.
+  const registerNative = (
+    name: string,
+    paramTypes: ValType[],
+    resultTypes: ValType[],
+    locals: { name: string; type: ValType }[],
+    body: Instr[],
+  ): number => {
+    const typeIdx = addFuncType(ctx, paramTypes, resultTypes);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.funcMap.set(name, funcIdx);
+    ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false });
+    return funcIdx;
+  };
+
+  // Look up an already-emitted native string helper.
+  const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+  const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals")!;
+
+  // ── $__obj_hash(externref key) -> i32 ────────────────────────────────────
+  //
+  // FNV-1a over the UTF-16 code units of the flattened string. The key is an
+  // externref holding a $NativeString/$AnyString; convert + cast + flatten,
+  // then read len/off/data and fold. Returns a non-negative i32 hash.
+  //
+  // locals: 1=str(ref $NativeString) 2=data(ref $strData) 3=len 4=off 5=i 6=h
+  {
+    const FNV_OFFSET = 0x811c9dc5 | 0;
+    const FNV_PRIME = 0x01000193;
+    const body: Instr[] = [
+      // str = flatten(cast<$AnyString>(any.convert_extern(key)))
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: anyStrTypeIdx },
+      { op: "call", funcIdx: strFlattenIdx },
+      { op: "local.tee", index: 1 },
+      // len = str.len ; off = str.off ; data = str.data
+      { op: "struct.get", typeIdx: nativeStrTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: 3 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: nativeStrTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: 4 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: nativeStrTypeIdx, fieldIdx: 2 },
+      { op: "local.set", index: 2 },
+      // h = FNV_OFFSET ; i = 0
+      { op: "i32.const", value: FNV_OFFSET },
+      { op: "local.set", index: 6 },
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 5 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if i >= len break
+              { op: "local.get", index: 5 },
+              { op: "local.get", index: 3 },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 },
+              // h = (h ^ data[off + i]) * FNV_PRIME
+              { op: "local.get", index: 6 },
+              { op: "local.get", index: 2 },
+              { op: "local.get", index: 4 },
+              { op: "local.get", index: 5 },
+              { op: "i32.add" },
+              { op: "array.get_u", typeIdx: strDataTypeIdx },
+              { op: "i32.xor" },
+              { op: "i32.const", value: FNV_PRIME },
+              { op: "i32.mul" },
+              { op: "local.set", index: 6 },
+              // i++
+              { op: "local.get", index: 5 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 5 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // return h & 0x7fffffff  (non-negative; masking happens at call sites too)
+      { op: "local.get", index: 6 },
+      { op: "i32.const", value: 0x7fffffff },
+      { op: "i32.and" },
+    ];
+    registerNative(
+      "__obj_hash",
+      [{ kind: "externref" }],
+      [{ kind: "i32" }],
+      [
+        { name: "str", type: nativeStrRef },
+        { name: "data", type: { kind: "ref", typeIdx: strDataTypeIdx } },
+        { name: "len", type: { kind: "i32" } },
+        { name: "off", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "h", type: { kind: "i32" } },
+      ],
+      body,
+    );
+  }
+  const objHashIdx = ctx.funcMap.get("__obj_hash")!;
+
+  // ── __new_plain_object() -> externref ────────────────────────────────────
+  //
+  // struct.new $Object { proto: null, props: new $PropMap[INITIAL_CAP], count:
+  // 0, tombstones: 0, flags: 0 }, then extern.convert_any.
+  {
+    const body: Instr[] = [
+      { op: "ref.null", typeIdx: objectTypeIdx }, // proto
+      { op: "i32.const", value: INITIAL_CAP }, // props: array.new_default count
+      { op: "array.new_default", typeIdx: propMapTypeIdx },
+      { op: "i32.const", value: 0 }, // count
+      { op: "i32.const", value: 0 }, // tombstones
+      { op: "i32.const", value: 0 }, // flags
+      { op: "struct.new", typeIdx: objectTypeIdx },
+      { op: "extern.convert_any" },
+    ];
+    registerNative("__new_plain_object", [], [{ kind: "externref" }], [], body);
+  }
+
+  // ── $__obj_find(ref $Object, externref key) -> ref null $PropEntry ────────
+  //
+  // Linear-probing lookup in the object's OWN props table (no proto walk).
+  // Returns the matching live entry, or null if absent. Tombstoned entries
+  // (FLAG_TOMBSTONE set) are skipped but do not terminate the probe (they are
+  // "deleted but occupied" slots in open addressing).
+  //
+  // params: 0=o(ref $Object) 1=key(externref)
+  // locals: 2=arr(ref $PropMap) 3=cap 4=mask 5=i 6=e(ref null $PropEntry) 7=fkey(ref $NativeString)
+  {
+    const body: Instr[] = [
+      // fkey = flatten(cast<$AnyString>(any.convert_extern(key)))
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: anyStrTypeIdx },
+      { op: "call", funcIdx: strFlattenIdx },
+      { op: "local.set", index: 7 },
+      // arr = o.props ; cap = arr.len ; mask = cap - 1
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "local.tee", index: 2 },
+      { op: "array.len" },
+      { op: "local.tee", index: 3 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.sub" },
+      { op: "local.set", index: 4 },
+      // i = hash(key) & mask
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objHashIdx },
+      { op: "local.get", index: 4 },
+      { op: "i32.and" },
+      { op: "local.set", index: 5 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // e = arr[i]
+              { op: "local.get", index: 2 },
+              { op: "local.get", index: 5 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.tee", index: 6 },
+              // if e == null → key absent → return null
+              { op: "ref.is_null" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [{ op: "ref.null", typeIdx: propEntryTypeIdx }, { op: "return" }],
+              },
+              // if !(e.flags & TOMBSTONE) && str_equals(flatten(e.key), fkey) → return e
+              { op: "local.get", index: 6 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+              { op: "i32.const", value: FLAG_TOMBSTONE },
+              { op: "i32.and" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // flatten(e.key)
+                  { op: "local.get", index: 6 },
+                  { op: "ref.as_non_null" },
+                  { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+                  { op: "call", funcIdx: strFlattenIdx },
+                  { op: "local.get", index: 7 },
+                  { op: "call", funcIdx: strEqualsIdx },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [{ op: "local.get", index: 6 }, { op: "return" }],
+                  },
+                ],
+              },
+              // i = (i + 1) & mask ; loop
+              { op: "local.get", index: 5 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.get", index: 4 },
+              { op: "i32.and" },
+              { op: "local.set", index: 5 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "ref.null", typeIdx: propEntryTypeIdx },
+    ];
+    registerNative(
+      "__obj_find",
+      [objRef, { kind: "externref" }],
+      [entryRefNull],
+      [
+        { name: "arr", type: propMapRef },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "mask", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+        { name: "fkey", type: nativeStrRef },
+      ],
+      body,
+    );
+  }
+  const objFindIdx = ctx.funcMap.get("__obj_find")!;
+
+  // ── __extern_get(externref obj, externref key) -> externref ──────────────
+  //
+  // Unwrap obj to $Object (return null on non-object), walk the own-property
+  // entry then the prototype chain. Property values are stored as anyref;
+  // convert back to externref for the result.
+  //
+  // params: 0=obj(externref) 1=key(externref)
+  // locals: 2=o(ref null $Object) 3=e(ref null $PropEntry) 4=any(anyref)
+  {
+    const body: Instr[] = [
+      // any = any.convert_extern(obj)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 4 },
+      // if !ref.test $Object → not one of our objects → return null
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "ref.null.extern" }, { op: "return" }],
+      },
+      // o = cast<$Object>(any)
+      { op: "local.get", index: 4 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 2 },
+      // proto-walk loop
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if o == null break
+              { op: "local.get", index: 2 },
+              { op: "ref.is_null" },
+              { op: "br_if", depth: 1 },
+              // e = __obj_find(o, key)
+              { op: "local.get", index: 2 },
+              { op: "ref.as_non_null" },
+              { op: "local.get", index: 1 },
+              { op: "call", funcIdx: objFindIdx },
+              { op: "local.tee", index: 3 },
+              // if e != null → return extern.convert_any(e.value)
+              { op: "ref.is_null" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 3 },
+                  { op: "ref.as_non_null" },
+                  { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+                  { op: "extern.convert_any" },
+                  { op: "return" },
+                ],
+              },
+              // o = o.proto ; loop
+              { op: "local.get", index: 2 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 0 },
+              { op: "local.set", index: 2 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // not found anywhere → null
+      { op: "ref.null.extern" },
+    ];
+    registerNative(
+      "__extern_get",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "o", type: objRefNull },
+        { name: "e", type: entryRefNull },
+        { name: "any", type: { kind: "anyref" } },
+      ],
+      body,
+    );
+  }
+
+  // ── $__obj_insert(ref $Object, externref key, anyref value, i32 flags) ────
+  //
+  // Insert-or-update on the OWN table. Caller is responsible for growing the
+  // table BEFORE calling when the load factor is exceeded (see __extern_set).
+  // On update of a LIVE entry with the same key, overwrites value + flags.
+  //
+  // params: 0=o(ref $Object) 1=key(externref) 2=value(anyref) 3=flags
+  // locals: 4=arr(ref $PropMap) 5=cap 6=mask 7=i 8=e(ref null $PropEntry) 9=fkey(ref $NativeString) 10=keyStr(ref $AnyString)
+  {
+    const body: Instr[] = [
+      // keyStr = cast<$AnyString>(any.convert_extern(key)) ; fkey = flatten(keyStr)
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: anyStrTypeIdx },
+      { op: "local.tee", index: 10 },
+      { op: "call", funcIdx: strFlattenIdx },
+      { op: "local.set", index: 9 },
+      // arr = o.props ; cap = arr.len ; mask = cap - 1
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "local.tee", index: 4 },
+      { op: "array.len" },
+      { op: "local.tee", index: 5 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.sub" },
+      { op: "local.set", index: 6 },
+      // i = hash(key) & mask
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objHashIdx },
+      { op: "local.get", index: 6 },
+      { op: "i32.and" },
+      { op: "local.set", index: 7 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // e = arr[i]
+              { op: "local.get", index: 4 },
+              { op: "local.get", index: 7 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.tee", index: 8 },
+              // empty slot → create new entry here
+              { op: "ref.is_null" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // arr[i] = struct.new $PropEntry { keyStr, value, flags }
+                  { op: "local.get", index: 4 },
+                  { op: "local.get", index: 7 },
+                  { op: "local.get", index: 10 },
+                  { op: "local.get", index: 2 },
+                  { op: "local.get", index: 3 },
+                  { op: "struct.new", typeIdx: propEntryTypeIdx },
+                  { op: "array.set", typeIdx: propMapTypeIdx },
+                  // o.count++
+                  { op: "local.get", index: 0 },
+                  { op: "local.get", index: 0 },
+                  { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 2 },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 2 },
+                  { op: "return" },
+                ],
+              },
+              // occupied + LIVE + key matches → update in place
+              // str_equals(flatten(e.key), fkey)
+              { op: "local.get", index: 8 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+              { op: "call", funcIdx: strFlattenIdx },
+              { op: "local.get", index: 9 },
+              { op: "call", funcIdx: strEqualsIdx },
+              // AND not a tombstone
+              { op: "local.get", index: 8 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+              { op: "i32.const", value: FLAG_TOMBSTONE },
+              { op: "i32.and" },
+              { op: "i32.eqz" },
+              { op: "i32.and" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // e.value = value ; e.flags = flags ; return (update in place)
+                  { op: "local.get", index: 8 },
+                  { op: "ref.as_non_null" },
+                  { op: "local.get", index: 2 },
+                  { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+                  { op: "local.get", index: 8 },
+                  { op: "ref.as_non_null" },
+                  { op: "local.get", index: 3 },
+                  { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+                  { op: "return" },
+                ],
+              },
+              // collision → i = (i + 1) & mask ; loop
+              { op: "local.get", index: 7 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.get", index: 6 },
+              { op: "i32.and" },
+              { op: "local.set", index: 7 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+    ];
+    registerNative(
+      "__obj_insert",
+      [objRef, { kind: "externref" }, { kind: "anyref" }, { kind: "i32" }],
+      [],
+      [
+        { name: "arr", type: propMapRef },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "mask", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+        { name: "fkey", type: nativeStrRef },
+        { name: "keyStr", type: anyStrRef },
+      ],
+      body,
+    );
+  }
+  const objInsertIdx = ctx.funcMap.get("__obj_insert")!;
+
+  // ── $__obj_grow(ref $Object) -> void ─────────────────────────────────────
+  //
+  // Double the capacity and rehash live (non-tombstone) entries into a fresh
+  // table. Resets tombstones to 0 and replays entries through __obj_insert
+  // against the NEW table (count reset to 0 first so inserts re-accumulate it).
+  //
+  // params: 0=o(ref $Object)
+  // locals: 1=old(ref $PropMap) 2=newCap 3=i 4=oldLen 5=e(ref null $PropEntry)
+  {
+    const body: Instr[] = [
+      // old = o.props ; oldLen = old.len ; newCap = oldLen * 2
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "local.tee", index: 1 },
+      { op: "array.len" },
+      { op: "local.tee", index: 4 },
+      { op: "i32.const", value: 2 },
+      { op: "i32.mul" },
+      { op: "local.set", index: 2 },
+      // o.props = new $PropMap[newCap] ; o.count = 0 ; o.tombstones = 0
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 2 },
+      { op: "array.new_default", typeIdx: propMapTypeIdx },
+      { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "local.get", index: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 2 },
+      { op: "local.get", index: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 3 },
+      // for i in 0..oldLen: replay live entries
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 3 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: 4 },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 },
+              // e = old[i]
+              { op: "local.get", index: 1 },
+              { op: "local.get", index: 3 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.tee", index: 5 },
+              // if e != null && !(e.flags & TOMBSTONE): re-insert
+              { op: "ref.is_null" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 5 },
+                  { op: "ref.as_non_null" },
+                  { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+                  { op: "i32.const", value: FLAG_TOMBSTONE },
+                  { op: "i32.and" },
+                  { op: "i32.eqz" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      // __obj_insert(o, extern.convert_any(e.key), e.value, e.flags)
+                      { op: "local.get", index: 0 },
+                      { op: "local.get", index: 5 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+                      { op: "extern.convert_any" },
+                      { op: "local.get", index: 5 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+                      { op: "local.get", index: 5 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+                      { op: "call", funcIdx: objInsertIdx },
+                    ],
+                  },
+                ],
+              },
+              // i++
+              { op: "local.get", index: 3 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 3 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+    ];
+    registerNative(
+      "__obj_grow",
+      [objRef],
+      [],
+      [
+        { name: "old", type: propMapRef },
+        { name: "newCap", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "oldLen", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+      ],
+      body,
+    );
+  }
+  const objGrowIdx = ctx.funcMap.get("__obj_grow")!;
+
+  // ── __extern_set(externref obj, externref key, externref value) -> void ──
+  //
+  // Unwrap obj to $Object (no-op on non-object — matches host leniency), grow
+  // if the load factor is too high, then insert/update with default data-prop
+  // flags. Value is stored as anyref via any.convert_extern.
+  //
+  // params: 0=obj 1=key 2=value
+  // locals: 3=o(ref null $Object) 4=cap 5=load 6=any(anyref)
+  {
+    const body: Instr[] = [
+      // any = any.convert_extern(obj)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 6 },
+      // if !ref.test $Object → silently no-op (host import is lenient too)
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "return" }],
+      },
+      // o = cast<$Object>(any)
+      { op: "local.get", index: 6 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 3 },
+      // load = o.count + o.tombstones ; cap = o.props.len
+      { op: "local.get", index: 3 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 2 },
+      { op: "local.get", index: 3 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 3 },
+      { op: "i32.add" },
+      { op: "local.set", index: 5 },
+      { op: "local.get", index: 3 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "array.len" },
+      { op: "local.set", index: 4 },
+      // if (load + 1) * 10 >= cap * 7 → grow  (load factor 0.7)
+      { op: "local.get", index: 5 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "i32.const", value: 10 },
+      { op: "i32.mul" },
+      { op: "local.get", index: 4 },
+      { op: "i32.const", value: 7 },
+      { op: "i32.mul" },
+      { op: "i32.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 3 }, { op: "ref.as_non_null" }, { op: "call", funcIdx: objGrowIdx }],
+      },
+      // __obj_insert(o, key, any.convert_extern(value), FLAG_DEFAULT)
+      { op: "local.get", index: 3 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      { op: "any.convert_extern" },
+      { op: "i32.const", value: FLAG_DEFAULT },
+      { op: "call", funcIdx: objInsertIdx },
+    ];
+    registerNative(
+      "__extern_set",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [],
+      [
+        { name: "o", type: objRefNull },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "load", type: { kind: "i32" } },
+        { name: "any", type: { kind: "anyref" } },
+      ],
+      body,
+    );
+  }
+
+  return types;
+}
+
+/**
+ * Names of the object-runtime host imports that `ensureObjectRuntime` provides
+ * Wasm-native implementations for. `ensureLateImport` routes these here under
+ * `ctx.standalone` (mirrors `UNION_NATIVE_HELPER_NAMES` for the #1471 boxing
+ * helpers) so existing call sites resolve to the native func with no per-site
+ * change. Internal helpers (`__obj_hash`, `__obj_find`, `__obj_insert`,
+ * `__obj_grow`) are NOT in this set — they are never requested via
+ * `ensureLateImport`.
+ */
+export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
+  "__new_plain_object",
+  "__extern_get",
+  "__extern_set",
+]);

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -80,23 +80,45 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
     assertNoHostObjectImports(r.imports);
   });
 
-  it("dynamic property add on an any-typed object refuses with a #1472 Phase B error", async () => {
-    const r = await compile(
-      `
-        export function leak(): number {
-          const o: any = { x: 1 };
-          o.y = 2;
-          return o.y;
+  it("Phase B: dynamic property add/read on an any-typed object compiles native + runs", async () => {
+    // #1472 Phase B — open-object new/get/set now lower to the Wasm-native
+    // $Object open-hash-map runtime instead of refusing. The module must carry
+    // zero env::__extern_* / __new_plain_object host imports and instantiate +
+    // run with an empty import object.
+    const source = `
+        export function run(): number {
+          const o: any = {};
+          o.x = 41;
+          o.y = (o.x as number) + 1;
+          return o.y as number;
         }
-      `,
-      { target: "standalone" },
-    );
-    expect(r.success).toBe(false);
-    const joined = r.errors.map((e) => e.message).join("\n");
-    expect(joined).toMatch(/standalone/);
-    expect(joined).toMatch(/#1472 Phase B/);
-    // The refusal must NOT leak the host import into the module.
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
     assertNoHostObjectImports(r.imports);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__new_plain_object")).toBe(false);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(42);
+  });
+
+  it("Phase B: property update + table grow/rehash run correctly", async () => {
+    const source = `
+        export function run(): number {
+          const o: any = {};
+          o.a = 1; o.a = 2; o.a = 3;
+          o.k0=0; o.k1=1; o.k2=2; o.k3=3; o.k4=4; o.k5=5; o.k6=6; o.k7=7;
+          o.k8=8; o.k9=9; o.k10=10; o.k11=11; o.k12=12; o.k13=13; o.k14=14;
+          return (o.a as number) + (o.k0 as number) + (o.k7 as number) + (o.k14 as number);
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    // 3 (final o.a) + 0 + 7 + 14 = 24
+    expect((instance.exports as Record<string, () => number>).run()).toBe(24);
   });
 
   it("destructuring defaults refuse __extern_is_undefined instead of leaking the host import", async () => {


### PR DESCRIPTION
## #1472 Phase B Slice 1 — Wasm-native open-object runtime core

The single biggest `--target standalone` test262 lever. Phase A refused open-object ops with a clear diagnostic; this slice replaces the JS-host WeakMap sidecars with a **pure-WasmGC open-hash-map** for the top-3 failure helpers (`__new_plain_object`, `__extern_get`, `__extern_set` — 15.6k + 5.0k + 5.4k raw failure-row mentions in the latest standalone artifact).

### What landed
- **`src/codegen/object-runtime.ts`** (new): registers `$Object` / `$PropMap` / `$PropEntry` WasmGC types and the helpers `__obj_hash`, `__obj_find`, `__obj_insert`, `__obj_grow` (internal) + `__new_plain_object` / `__extern_get` / `__extern_set` (public). Open addressing, linear probing, FNV-1a hash over the flattened key's UTF-16 code units, 0.7 load-factor grow+rehash, tombstone bit reserved for the delete slice.
- **`src/codegen/expressions/late-imports.ts`**: `ensureLateImport` routes the three public names through `ensureObjectRuntime(ctx)` under `ctx.standalone`, mirroring the #1471 `UNION_NATIVE_HELPER_NAMES` boxing pattern. Sits before the Phase A refusal gate. WASI is intentionally not routed yet.
- **`src/codegen/context/types.ts`**: `objectRuntimeTypes?` caches the type indices for later slices.

### Why this design (no per-call-site retargeting)
The existing JS-host object machinery treats objects as **externref** and looks helpers up by NAME via `ensureLateImport`. By giving the native helpers the **same name + externref signature** as the host imports (wrapping `$Object` to externref via `extern.convert_any`, an engine-level no-op — the `__box_number` trick), **every existing call site in `object-ops.ts` / `property-access.ts` / `literals.ts` resolves to the native function unchanged**. The helpers are DEFINED functions (no imports added), so their funcIdx sits above all existing functions and no index shift is required (same invariant as `addUnionImportsAsNativeFuncs`). Keys reuse the existing `__str_flatten` / `__str_equals` native string helpers.

### Validation
- `tests/issue-1472.test.ts` (9 tests, green): the Phase A "open object refuses" assertion is replaced by two Phase B end-to-end tests that `WebAssembly.instantiate(r.binary, {})` (empty imports) and execute under Node's WasmGC engine — new/set/get → 42; property update + 15-key grow/rehash → 24. Closed-shape struct, class-instance, Proxy-refusal, and default-GC regression guards still pass; `assertNoHostObjectImports` confirms zero leaked imports.
- `tsc --noEmit` clean, `biome lint` clean, `tests/wasi.test.ts` (24) green (WASI path untouched).

### Follow-up slices (still refuse under standalone)
delete / keys / values / entries / for-in / defineProperty + descriptor reflection / Object.* / `__get_builtin` + vtable dispatch. The prototype chain is already walked by `__extern_get`; the `$PropEntry.flags` + tombstone fields are reserved for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)