### PR TITLE
fix(#1105): String.prototype.at out-of-range returns undefined

### DIFF
--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -444,7 +444,15 @@ export function compileBinaryExpression(
       // Strict: refs can be null but never undefined
       // Loose: null == undefined, so ref.is_null covers both
       if (valType.kind === "ref" || valType.kind === "ref_null") {
-        if ((isStrictEqOp || isStrictNeqOp) && nullSideIsUndefinedId) {
+        // #1105: a nullable native-string ref models `string | undefined`
+        // (e.g. String.prototype.at out-of-range → undefined). For that ONE
+        // type, a null ref IS the `undefined` value, so `x === undefined`
+        // must reduce to ref.is_null rather than the always-false struct rule
+        // below. Gate strictly on the AnyString type index so class-instance
+        // struct refs keep `struct === undefined → false` semantics.
+        const isNullableNativeString =
+          valType.kind === "ref_null" && ctx.nativeStrings && valType.typeIdx === ctx.anyStrTypeIdx;
+        if ((isStrictEqOp || isStrictNeqOp) && nullSideIsUndefinedId && !isNullableNativeString) {
           // struct === undefined → always false; struct !== undefined → always true
           fctx.body.push({ op: "drop" });
           fctx.body.push({ op: "i32.const", value: isStrictNeqOp ? 1 : 0 });

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -14,7 +14,11 @@ import { allocLocal } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { emitThrowTypeError, getFuncParamTypes, noJsHost } from "./expressions/helpers.js";
 import { addStringImports, addUnionImports, flatStringType, nativeStringType, resolveWasmType } from "./index.js";
-import { ensureNativeStringExternBridge, stringConstantExternrefInstrs } from "./native-strings.js";
+import {
+  ensureNativeStringExternBridge,
+  nativeStringTypeNullable,
+  stringConstantExternrefInstrs,
+} from "./native-strings.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterTemplateVecType, getOrRegisterVecType } from "./registry/types.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts, registerCompileStringLiteral } from "./shared.js";
@@ -1613,12 +1617,33 @@ export function compileNativeStringMethodCall(
         { op: "local.set", index: idxTmp },
       ],
     } as Instr);
-    // Call charAt helper with adjusted index
-    fctx.body.push({ op: "local.get", index: strTmp });
+    // ECMA-262 §22.1.3.1 String.prototype.at: after resolving a relative
+    // index, an out-of-range position (idx < 0 || idx >= len) yields
+    // `undefined`, NOT the empty string that `charAt` returns. Represent that
+    // `undefined` as a null native-string ref; the strict-equality path treats
+    // a null AnyString-typed ref as undefined-equal (binary-ops.ts).
+    const charAtIdx = ctx.nativeStrHelpers.get("__str_charAt")!;
     fctx.body.push({ op: "local.get", index: idxTmp });
-    const funcIdx = ctx.nativeStrHelpers.get("__str_charAt")!;
-    fctx.body.push({ op: "call", funcIdx });
-    return nativeStringType(ctx);
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "i32.lt_s" });
+    fctx.body.push({ op: "local.get", index: idxTmp });
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({ op: "i32.ge_s" });
+    fctx.body.push({ op: "i32.or" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: nativeStringTypeNullable(ctx) },
+      then: [
+        // Out of range → undefined (null AnyString ref).
+        { op: "ref.null", typeIdx: ctx.anyStrTypeIdx },
+      ],
+      else: [
+        { op: "local.get", index: strTmp },
+        { op: "local.get", index: idxTmp },
+        { op: "call", funcIdx: charAtIdx },
+      ],
+    } as Instr);
+    return nativeStringTypeNullable(ctx);
   }
 
   // substring: native helper

--- a/tests/issue-1105-at-oob.test.ts
+++ b/tests/issue-1105-at-oob.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1105 — String.prototype.at out-of-range index must return `undefined`,
+// not the empty string `charAt` produces.
+//
+// Spec reference:
+// - ECMA-262 §22.1.3.1 String.prototype.at: after ToIntegerOrInfinity and the
+//   relative-index adjustment, "If k < 0 or k ≥ len, return undefined."
+//
+// In nativeStrings/standalone mode `.at()` returns a native string ref. We model
+// the `undefined` result as a null AnyString ref; the strict-equality path
+// (binary-ops.ts) treats a null AnyString-typed ref as undefined-equal, while
+// class-instance struct refs keep `struct === undefined → false`.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function compileNativeRuntime(source: string): Promise<Record<string, unknown>> {
+  const result = await compile(source, {
+    fast: true,
+    nativeStrings: true,
+    testRuntime: true,
+    fileName: "issue-1105-at-oob.ts",
+  });
+  expect(result.success, result.errors.map((err) => err.message).join("\n")).toBe(true);
+
+  const imports = buildImports(result.imports, ENV_STUB, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, unknown>;
+}
+
+describe("#1105 String.prototype.at out-of-range → undefined", () => {
+  it("returns the indexed code unit for in-range positive and negative indices", async () => {
+    const exports = await compileNativeRuntime(`
+      export function atPos(): number {
+        return "hello".at(1)!.charCodeAt(0);
+      }
+      export function atNeg(): number {
+        return "hello".at(-1)!.charCodeAt(0);
+      }
+    `);
+    expect((exports.atPos as () => number)()).toBe(101); // 'e'
+    expect((exports.atNeg as () => number)()).toBe(111); // 'o'
+  });
+
+  it("returns undefined (null native string) for out-of-range indices", async () => {
+    const exports = await compileNativeRuntime(`
+      export function oobHigh(): number {
+        return "hi".at(5) === undefined ? 1 : 0;
+      }
+      export function oobNegBig(): number {
+        return "hi".at(-9) === undefined ? 1 : 0;
+      }
+      export function inRangeDefined(): number {
+        return "hi".at(0) === undefined ? 1 : 0;
+      }
+      export function inRangeNeqUndefined(): number {
+        return "hi".at(1) !== undefined ? 1 : 0;
+      }
+    `);
+    expect((exports.oobHigh as () => number)()).toBe(1);
+    expect((exports.oobNegBig as () => number)()).toBe(1);
+    expect((exports.inRangeDefined as () => number)()).toBe(0);
+    expect((exports.inRangeNeqUndefined as () => number)()).toBe(1);
+  });
+
+  it("does not change `struct === undefined` semantics for class instances", async () => {
+    // Regression guard: the equality refinement is gated on the AnyString type
+    // index, so a class-instance struct ref must still compare always-false.
+    const exports = await compileNativeRuntime(`
+      class C { x = 1; }
+      export function classNeqUndefined(): number {
+        const c = new C();
+        return (c as unknown) === undefined ? 1 : 0;
+      }
+    `);
+    expect((exports.classNeqUndefined as () => number)()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #1058 (native `.concat()`). Completes the Tier-1 `.at()` semantics for #1105.

`String.prototype.at` was lowered as `charAt`, so an out-of-range index returned an empty string instead of `undefined`. Per ECMA-262 §22.1.3.1: after the relative-index adjustment, "If k < 0 or k ≥ len, return undefined."

## Changes

- **`src/codegen/string-ops.ts`** — after the negative-index adjustment, bounds-check `idx < 0 || idx >= len`. Out-of-range emits a **null AnyString ref** (modelling `undefined`); in-range calls `__str_charAt`. `.at()` now returns the nullable native-string type.
- **`src/codegen/binary-ops.ts`** — the strict-equality path short-circuits `ref/ref_null === undefined` to always-false (correct for class-instance structs). Refine it so a **null ref of the AnyString type** reduces to `ref.is_null`, gated strictly on `ctx.nativeStrings && valType.typeIdx === ctx.anyStrTypeIdx`. Class-instance `struct === undefined` keeps always-false semantics (regression-guarded in tests).
- **`tests/issue-1105-at-oob.test.ts`** — in-range pos/neg, OOB-high, OOB-negative, in-range-defined, and a class-struct `=== undefined` regression guard.

## Validation

`npm test -- tests/issue-1105-at-oob.test.ts tests/issue-1105.test.ts tests/native-strings-standalone.test.ts tests/native-strings.test.ts` → **104 passed**. `tsc --noEmit` clean; `biome lint` clean on changed files.

Smoke-tested: `"hi".at(5) === undefined` → true; `"hello".at(-1)` → 'o'; `(classInstance as unknown) === undefined` → still false.

## Note

Branched off `origin/main` while #1058 (concat) is still in the merge queue; the two changes touch disjoint code regions and compose once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)