### PR TITLE
feat(#1599): pure-Wasm runtime JSON.stringify(string) for standalone (Phase 2 slice a)

### DIFF
--- a/plan/issues/1599-json-standalone.md
+++ b/plan/issues/1599-json-standalone.md
@@ -1,7 +1,7 @@
 ---
 id: 1599
 title: "host-indep: JSON.parse / JSON.stringify in standalone mode"
-status: in-review
+status: ready
 created: 2026-05-24
 updated: 2026-06-03
 priority: high
@@ -306,3 +306,65 @@ standalone/WASI while keeping unsupported dynamic JSON on the existing clear
 
 - `pnpm exec vitest run tests/issue-1599.test.ts tests/issue-1599-json-standalone-refuse.test.ts`
   — 20 tests passed.
+
+## Status — Phase 2 Slice (a): runtime `JSON.stringify(string)` (pure-Wasm)
+
+The first **runtime** (value-dependent) Phase 2 slice landed: `JSON.stringify(s)`
+where `s` is a runtime string value now lowers to a pure-Wasm helper in
+`--target standalone` / `--target wasi`, with **no** `env::JSON_stringify` host
+import.
+
+### What changed
+
+- `src/codegen/json-runtime.ts` (new) — `emitJsonQuoteString(ctx)` emits
+  `__json_quote_string(s: externref) -> ref $NativeString`: flattens the input
+  `$AnyString`, two-pass (size then fill) over its `[off, off+len)` UTF-16 code
+  units into a fresh `$__str_data` buffer, applying ECMA-262 §25.5.4.3
+  `QuoteJSONString` escaping — `"`→`\"`, `\`→`\\`, the short escapes
+  `\b \t \n \f \r`, and every other control char U+0000–U+001F as `\u00XX`.
+  Returns the result as a **native string ref** (matching `compileStringLiteral`
+  in nativeStrings mode) so downstream string ops (`===`, return) see the type
+  they expect rather than an over-wrapped externref.
+- `src/codegen/index.ts` — `collectPrimitiveMethodImports` pre-pass detects
+  `JSON.stringify(<string-typed arg>)` under standalone/wasi and pre-registers
+  `__json_quote_string` up-front (stable defined-function index, no mid-body
+  shift).
+- `src/codegen/expressions/calls.ts` — `tryEmitJsonStringifyPrimitive` now
+  handles the `StringLike` case for standalone/wasi via `__json_quote_string`;
+  JS-host mode still falls through to `JSON_stringify` (it observes
+  replacer/space/toJSON, which the helper does not).
+- `tests/issue-1599-runtime.test.ts` (new) — 6 wasmtime/WebAssembly round-trip
+  tests: plain string, quote+backslash, short control escapes, `\u00XX`
+  control escapes, empty runtime string, and "no `env::JSON_stringify` import".
+- `tests/issue-1599-json-standalone-refuse.test.ts` — the obsolete
+  "rejects JSON.stringify of a dynamic string" case flipped to
+  `expectAccepted` (string stringify is now implemented).
+
+### Spec anchors
+
+- ECMA-262 §25.5.4 `JSON.stringify`, §25.5.4.3 `QuoteJSONString`.
+
+### Validation — 2026-06-03
+
+- `pnpm exec vitest run tests/issue-1599.test.ts tests/issue-1599-json-standalone-refuse.test.ts tests/issue-1599-runtime.test.ts`
+  — 26 tests passed.
+
+### Phase 2 remaining (follow-ups — NOT in this slice)
+
+1. **Runtime `JSON.parse(s)` → primitive `$AnyValue`** (number/bool/null):
+   feasible now via the host-free `$AnyValue` tagged union
+   (`src/codegen/any-helpers.ts`). Carved as a dev follow-up.
+2. **Runtime `JSON.parse(s)` → string**: blocked on a cross-cutting change —
+   the shared `$AnyValue` strict-equals helper (`__any_strict_eq` in
+   `any-helpers.ts`) degrades the tag-5 (string) branch to `i32.const 0` when
+   the wasm:js-string `equals` import is absent (i.e. standalone), so a parsed
+   string returned as `$AnyValue` compares unequal. Needs a native
+   `__str_equals` (exists, `native-strings.ts`) fallback in that branch, storing
+   the parsed string in `refval`. **Senior-dev owned** (edits shared runtime
+   equality semantics).
+3. **Object/array graphs** (parse→objects, stringify of object/array graphs):
+   blocked on the Wasm-native open-object runtime (#1472 Phase B). Sequence
+   after it lands.
+
+`status` stays `ready` because Phase 2 (full dynamic codec) is not complete;
+this slice only adds runtime string stringify.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -55,6 +55,7 @@ import {
 } from "../index.js";
 import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
 import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
+import { emitJsonQuoteString } from "../json-runtime.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -452,7 +453,28 @@ function tryEmitJsonStringifyPrimitive(
     return resultType;
   }
 
-  // string / bigint / unhandled — fall through to the host import. Full
+  // string / String — standalone/WASI have no JSON_stringify host import.
+  // Emit the pure-Wasm `__json_quote_string` runtime helper (#1599 Phase 2):
+  // it scans the runtime string's UTF-16 code units and produces a
+  // JSON-quoted $NativeString per §25.5.4.3 QuoteJSONString. In JS-host mode
+  // we fall through to the JSON_stringify import (it observes replacer/space
+  // and toJSON, which the helper does not).
+  if ((ctx.standalone || ctx.wasi) && flags & ts.TypeFlags.StringLike) {
+    const argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
+    if (argResult === null) return undefined;
+    if (argResult.kind !== "externref") {
+      coerceType(ctx, fctx, argResult, { kind: "externref" });
+    }
+    const quoteIdx = emitJsonQuoteString(ctx);
+    flushLateImportShifts(ctx, fctx);
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__json_quote_string") ?? quoteIdx } as Instr);
+    // __json_quote_string returns a native string ref (matches compileStringLiteral
+    // in nativeStrings mode), so downstream string ops (===, return) see the same
+    // type they expect rather than an over-wrapped externref.
+    return nativeStringType(ctx);
+  }
+
+  // bigint / unhandled — fall through to the host import. Full
   // pure-Wasm support tracked under #1353.
   return undefined;
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -92,6 +92,7 @@ import {
   nativeStringType,
   nativeStringTypeNullable,
 } from "./native-strings.js";
+import { emitJsonQuoteString } from "./json-runtime.js";
 
 // ── Re-exports for public API compatibility ─────────────────────────────────
 export {
@@ -5571,6 +5572,21 @@ function collectPrimitiveMethodImports(ctx: CodegenContext, sourceFile: ts.Sourc
       if (isNumberType(receiverType) && methodName === "toString") {
         needed.add("number_toString");
       }
+      // (#1599 Phase 2) JSON.stringify(<string>) in standalone/WASI lowers to
+      // the pure-Wasm `__json_quote_string` helper. Pre-register it here (before
+      // body compilation) so its defined-function index is stable.
+      if (
+        (ctx.standalone || ctx.wasi) &&
+        ts.isIdentifier(prop.expression) &&
+        prop.expression.text === "JSON" &&
+        methodName === "stringify" &&
+        node.arguments.length === 1
+      ) {
+        const jsonArgT = ctx.checker.getTypeAtLocation(node.arguments[0]!);
+        if ((jsonArgT.flags & ts.TypeFlags.StringLike) !== 0) {
+          needed.add("__json_quote_string");
+        }
+      }
       if (isNumberType(receiverType) && methodName === "toFixed") {
         needed.add("number_toFixed");
       }
@@ -5683,6 +5699,10 @@ function collectPrimitiveMethodImports(ctx: CodegenContext, sourceFile: ts.Sourc
     // In native strings mode, __str_compare Wasm helper handles this — no host import needed
     const t = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
     addImport(ctx, "env", "string_compare", { kind: "func", typeIdx: t });
+  }
+  if (needed.has("__json_quote_string")) {
+    // (#1599 Phase 2) emit the pure-Wasm runtime JSON string quoter up-front.
+    emitJsonQuoteString(ctx);
   }
 }
 

--- a/src/codegen/json-runtime.ts
+++ b/src/codegen/json-runtime.ts
@@ -1,0 +1,392 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Pure-Wasm runtime JSON helpers for standalone / WASI targets (#1599 Phase 2).
+ *
+ * Phase 2A (`json-standalone.ts`) folds *statically known* JSON literal graphs
+ * at compile time. This module adds the first *runtime* (value-dependent) JSON
+ * primitive that needs no JS host: `JSON.stringify(s)` of a **runtime string
+ * value**. The serialiser scans the flattened UTF-16 code units of the input
+ * `$AnyString` and emits a JSON-quoted `$NativeString` per ECMA-262 §25.5.4.3
+ * `QuoteJSONString`:
+ *
+ *   - wrap in `"`…`"`
+ *   - escape `"`  → `\"`
+ *   - escape `\`  → `\\`
+ *   - escape `\b` (U+0008), `\t` (U+0009), `\n` (U+000A), `\f` (U+000C),
+ *     `\r` (U+000D) with their short forms
+ *   - escape every other control char U+0000–U+001F as `\u00XX`
+ *   - copy all other code units verbatim
+ *
+ * Result is returned as an `externref` (the WasmGC `$NativeString` widened via
+ * `extern.convert_any`), matching how every other standalone string-producing
+ * builtin returns its value.
+ *
+ * The remaining dynamic Phase 2 surface — `JSON.parse` of runtime text into
+ * `$AnyValue` primitives, and `JSON.stringify` of runtime object/array graphs —
+ * is documented as a follow-up in the #1599 issue file. Object/array graphs
+ * need the Wasm-native open-object runtime (#1472 Phase B); string `JSON.parse`
+ * needs the shared `$AnyValue` string-equals helper to fall back to native
+ * `__str_equals` in standalone mode (cross-cutting runtime change).
+ *
+ * Spec references:
+ * - ECMA-262 §25.5.4   `JSON.stringify`
+ * - ECMA-262 §25.5.4.3 `QuoteJSONString`
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
+import { addFuncType } from "./registry/types.js";
+
+const C_QUOTE = 34; // '"'
+const C_BACKSLASH = 92; // '\'
+const C_BS = 8; // backspace  -> \b
+const C_TAB = 9; // tab        -> \t
+const C_LF = 10; // line feed  -> \n
+const C_FF = 12; // form feed  -> \f
+const C_CR = 13; // carriage   -> \r
+const C_LC_B = 98; // 'b'
+const C_LC_T = 116; // 't'
+const C_LC_N = 110; // 'n'
+const C_LC_F = 102; // 'f'
+const C_LC_R = 114; // 'r'
+const C_LC_U = 117; // 'u'
+const C_ZERO = 48; // '0'
+const C_LC_A_MINUS_10 = 87; // 'a' - 10  (for hex digit a-f)
+
+/**
+ * Emit `__json_quote_string(s: externref) -> externref` and register it in
+ * `ctx.funcMap`. Idempotent. Must run after `ensureNativeStringHelpers` (called
+ * here) so `__str_flatten` exists, and before any function body that calls it.
+ *
+ * Algorithm: flatten the input to a `$NativeString`, walk its `[off, off+len)`
+ * code units twice — first to size the output buffer, then to fill it — so the
+ * output `$__str_data` is allocated exactly once at the right capacity.
+ */
+export function emitJsonQuoteString(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__json_quote_string");
+  if (existing !== undefined) return existing;
+
+  ensureNativeStringHelpers(ctx);
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+  const strTypeIdx = ctx.nativeStrTypeIdx; // $NativeString (FlatString): len, off, data
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx; // (array (mut i16))
+  const i32: ValType = { kind: "i32" };
+  const extern: ValType = { kind: "externref" };
+
+  const strRef = nativeStringType(ctx);
+  const typeIdx = addFuncType(ctx, [extern], [strRef]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__json_quote_string", funcIdx);
+
+  // params: 0 s:externref
+  // locals:
+  //  1 flat:ref $NativeString   2 data:ref $__str_data   3 end:i32   4 i:i32
+  //  5 c:i32   6 outLen:i32   7 out:ref $__str_data   8 w:i32 (write cursor)
+  //  9 off:i32  10 nib:i32 (scratch nibble)
+  const L_FLAT = 1;
+  const L_DATA = 2;
+  const L_END = 3;
+  const L_I = 4;
+  const L_C = 5;
+  const L_OUTLEN = 6;
+  const L_OUT = 7;
+  const L_W = 8;
+  const L_OFF = 9;
+  const L_NIB = 10;
+
+  // c = data[i]
+  const getC: Instr[] = [
+    { op: "local.get", index: L_DATA },
+    { op: "local.get", index: L_I },
+    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: L_C },
+  ];
+
+  // append code unit (value pushed by `valueInstrs`) into out[w]; w++
+  const put = (valueInstrs: Instr[]): Instr[] => [
+    { op: "local.get", index: L_OUT },
+    { op: "local.get", index: L_W },
+    ...valueInstrs,
+    { op: "array.set", typeIdx: strDataTypeIdx },
+    { op: "local.get", index: L_W },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: L_W },
+  ];
+  const putConst = (v: number): Instr[] => put([{ op: "i32.const", value: v }]);
+
+  // c == code  (leaves i32 bool)
+  const cEq = (code: number): Instr[] => [
+    { op: "local.get", index: L_C },
+    { op: "i32.const", value: code },
+    { op: "i32.eq" },
+  ];
+
+  // Shared preamble: flatten s, load data/off, compute end = off + len.
+  const preamble: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+    { op: "call", funcIdx: flattenIdx },
+    { op: "ref.cast", typeIdx: strTypeIdx },
+    { op: "local.set", index: L_FLAT },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // data
+    { op: "local.set", index: L_DATA },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.set", index: L_OFF },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // len
+    { op: "local.get", index: L_OFF },
+    { op: "i32.add" },
+    { op: "local.set", index: L_END }, // end = off + len (exclusive)
+  ];
+
+  // width(c): '"','\',\b\t\n\f\r -> 2 ; other ctrl (<0x20) -> 6 ; else 1
+  const widthExpr: Instr[] = [
+    ...cEq(C_QUOTE),
+    ...cEq(C_BACKSLASH),
+    { op: "i32.or" },
+    ...cEq(C_BS),
+    { op: "i32.or" },
+    ...cEq(C_TAB),
+    { op: "i32.or" },
+    ...cEq(C_LF),
+    { op: "i32.or" },
+    ...cEq(C_FF),
+    { op: "i32.or" },
+    ...cEq(C_CR),
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      then: [{ op: "i32.const", value: 2 }],
+      else: [
+        { op: "local.get", index: L_C },
+        { op: "i32.const", value: 0x20 },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: i32 },
+          then: [{ op: "i32.const", value: 6 }],
+          else: [{ op: "i32.const", value: 1 }],
+        },
+      ],
+    } as unknown as Instr,
+  ];
+
+  // Pass 1: outLen = 2 + Σ width(c)
+  const sizingLoop: Instr[] = [
+    { op: "i32.const", value: 2 },
+    { op: "local.set", index: L_OUTLEN },
+    { op: "local.get", index: L_OFF },
+    { op: "local.set", index: L_I },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_END },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...getC,
+            { op: "local.get", index: L_OUTLEN },
+            ...widthExpr,
+            { op: "i32.add" },
+            { op: "local.set", index: L_OUTLEN },
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  // Allocate out buffer (outLen), w=0, write opening quote.
+  const allocOut: Instr[] = [
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: L_OUTLEN },
+    { op: "array.new", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: L_OUT },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L_W },
+    ...putConst(C_QUOTE),
+  ];
+
+  // short escape: backslash + letter
+  const emitShort = (letter: number): Instr[] => [...putConst(C_BACKSLASH), ...putConst(letter)];
+
+  // \u00XX for control chars (c is 0x00..0x1f so high hex nibbles are 0,0,0..1)
+  const emitUnicode: Instr[] = [
+    ...putConst(C_BACKSLASH),
+    ...putConst(C_LC_U),
+    ...putConst(C_ZERO),
+    ...putConst(C_ZERO),
+    // high nibble = (c >> 4) & 0xf  → always 0 or 1 → '0'+n
+    ...put([
+      { op: "local.get", index: L_C },
+      { op: "i32.const", value: 4 },
+      { op: "i32.shr_u" },
+      { op: "i32.const", value: 0xf },
+      { op: "i32.and" },
+      { op: "i32.const", value: C_ZERO },
+      { op: "i32.add" },
+    ]),
+    // low nibble = c & 0xf  → '0'+n (n<10) else 'a'+(n-10)
+    ...put([
+      { op: "local.get", index: L_C },
+      { op: "i32.const", value: 0xf },
+      { op: "i32.and" },
+      { op: "local.tee", index: L_NIB },
+      { op: "i32.const", value: 10 },
+      { op: "i32.lt_s" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: i32 },
+        then: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_ZERO }, { op: "i32.add" }],
+        else: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_LC_A_MINUS_10 }, { op: "i32.add" }],
+      } as unknown as Instr,
+    ]),
+  ];
+
+  // copy verbatim
+  const emitVerbatim: Instr[] = put([{ op: "local.get", index: L_C }]);
+
+  // per-char dispatch (nested if/else chain on c)
+  const fillCharDispatch: Instr[] = [
+    ...cEq(C_QUOTE),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: emitShort(C_QUOTE),
+      else: [
+        ...cEq(C_BACKSLASH),
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: emitShort(C_BACKSLASH),
+          else: [
+            ...cEq(C_BS),
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: emitShort(C_LC_B),
+              else: [
+                ...cEq(C_TAB),
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: emitShort(C_LC_T),
+                  else: [
+                    ...cEq(C_LF),
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: emitShort(C_LC_N),
+                      else: [
+                        ...cEq(C_FF),
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: emitShort(C_LC_F),
+                          else: [
+                            ...cEq(C_CR),
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: emitShort(C_LC_R),
+                              else: [
+                                { op: "local.get", index: L_C },
+                                { op: "i32.const", value: 0x20 },
+                                { op: "i32.lt_s" },
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: emitUnicode,
+                                  else: emitVerbatim,
+                                } as unknown as Instr,
+                              ],
+                            } as unknown as Instr,
+                          ],
+                        } as unknown as Instr,
+                      ],
+                    } as unknown as Instr,
+                  ],
+                } as unknown as Instr,
+              ],
+            } as unknown as Instr,
+          ],
+        } as unknown as Instr,
+      ],
+    } as unknown as Instr,
+  ];
+
+  // Pass 2: fill
+  const fillLoop: Instr[] = [
+    { op: "local.get", index: L_OFF },
+    { op: "local.set", index: L_I },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_END },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...getC,
+            ...fillCharDispatch,
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    ...putConst(C_QUOTE), // closing quote
+  ];
+
+  // Build result $NativeString(len=outLen, off=0, data=out) and widen.
+  const finalize: Instr[] = [
+    { op: "local.get", index: L_OUTLEN },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: L_OUT },
+    { op: "struct.new", typeIdx: strTypeIdx },
+  ];
+
+  const body: Instr[] = [...preamble, ...sizingLoop, ...allocOut, ...fillLoop, ...finalize];
+
+  ctx.mod.functions.push({
+    name: "__json_quote_string",
+    typeIdx,
+    locals: [
+      { count: 1, type: { kind: "ref", typeIdx: strTypeIdx } }, // L_FLAT
+      { count: 1, type: { kind: "ref", typeIdx: strDataTypeIdx } }, // L_DATA
+      { count: 1, type: i32 }, // L_END
+      { count: 1, type: i32 }, // L_I
+      { count: 1, type: i32 }, // L_C
+      { count: 1, type: i32 }, // L_OUTLEN
+      { count: 1, type: { kind: "ref", typeIdx: strDataTypeIdx } }, // L_OUT
+      { count: 1, type: i32 }, // L_W
+      { count: 1, type: i32 }, // L_OFF
+      { count: 1, type: i32 }, // L_NIB
+    ],
+    body,
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  return funcIdx;
+}

--- a/tests/issue-1599-json-standalone-refuse.test.ts
+++ b/tests/issue-1599-json-standalone-refuse.test.ts
@@ -50,8 +50,8 @@ describe("#1599 --target standalone refuses dynamic unsupported JSON shapes", ()
     await expectRefused(`export function f(a: number[]): string { return JSON.stringify(a); }`);
   });
 
-  it("rejects JSON.stringify of a dynamic string", async () => {
-    await expectRefused(`export function f(s: string): string { return JSON.stringify(s); }`);
+  it("compiles JSON.stringify of a dynamic string (#1599 Phase 2 — pure-Wasm __json_quote_string)", async () => {
+    await expectAccepted(`export function f(s: string): string { return JSON.stringify(s); }`);
   });
 
   it("compiles JSON.stringify of a dynamic number", async () => {

--- a/tests/issue-1599-runtime.test.ts
+++ b/tests/issue-1599-runtime.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function assertNoJsonHostImports(result) {
+  const labels = result.imports.map((i) => i.module + "::" + i.name);
+  expect(labels.filter((l) => /env::JSON_(parse|stringify)/.test(l))).toEqual([]);
+}
+
+async function runStandalone(body) {
+  const src = "export function test(): number {\n" + body + "\n}";
+  const result = await compile(src, { target: "standalone" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoJsonHostImports(result);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports.test();
+}
+
+describe("#1599 Phase 2 — runtime JSON.stringify(string) standalone", () => {
+  it("quotes a plain runtime string", async () => {
+    const r = await runStandalone(`
+      let s: string = "hel";
+      s = s + "lo";
+      return JSON.stringify(s) === '"hello"' ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("escapes quote and backslash", async () => {
+    // build 'a"b\c' at runtime: 'a"' + 'b' + '\\' + 'c'
+    const r = await runStandalone(`
+      let s: string = 'a"';
+      s = s + 'b' + '\\\\' + 'c';
+      return JSON.stringify(s) === '"a\\\\"b\\\\\\\\c"' ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("escapes the short control chars b t n f r", async () => {
+    const r = await runStandalone(`
+      let s: string = "\\b\\t";
+      s = s + "\\n\\f\\r";
+      return JSON.stringify(s) === '"\\\\b\\\\t\\\\n\\\\f\\\\r"' ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("escapes other control chars as uXXXX", async () => {
+    const r = await runStandalone(`
+      let s: string = "\\u0000\\u0001";
+      s = s + "\\u001f";
+      return JSON.stringify(s) === '"\\\\u0000\\\\u0001\\\\u001f"' ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("returns just quotes for the empty runtime string", async () => {
+    const r = await runStandalone(`
+      let s: string = "x";
+      s = s.slice(1);
+      return JSON.stringify(s) === '""' ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("does not pull in env::JSON_stringify for runtime string stringify", async () => {
+    const result = await compile("export function test(s: string): string { return JSON.stringify(s); }", {
+      target: "standalone",
+    });
+    expect(result.success).toBe(true);
+    assertNoJsonHostImports(result);
+  });
+});


### PR DESCRIPTION
## Summary

First **runtime** (value-dependent) Phase 2 slice for #1599: `JSON.stringify(s)` of a runtime string value now lowers to a pure-Wasm helper in `--target standalone` / `--target wasi`, with **no** `env::JSON_stringify` host import.

Previously a runtime `JSON.stringify(<string>)` in standalone/WASI hit the #1599 Phase 1 refusal. It now compiles to native Wasm.

## What changed

- **`src/codegen/json-runtime.ts`** (new) — `emitJsonQuoteString(ctx)` emits `__json_quote_string(s: externref) -> ref $NativeString`: flattens the input `$AnyString`, two passes (size then fill) over `[off, off+len)` UTF-16 code units into a fresh `$__str_data` buffer, applying ECMA-262 §25.5.4.3 `QuoteJSONString` escaping — `"`→`\"`, `\`→`\\`, short escapes `\b \t \n \f \r`, and other control chars U+0000–U+001F as `\u00XX`. Returns a **native string ref** (matching `compileStringLiteral` in nativeStrings mode) so `===`/return see the expected type.
- **`src/codegen/index.ts`** — `collectPrimitiveMethodImports` pre-registers the helper for `JSON.stringify(<string-typed arg>)` under standalone/wasi (stable defined-function index, no mid-body shift).
- **`src/codegen/expressions/calls.ts`** — `tryEmitJsonStringifyPrimitive` handles the `StringLike` case via the helper; JS-host mode still falls through to `JSON_stringify`.
- **`tests/issue-1599-runtime.test.ts`** (new) — 6 round-trip tests.
- **`tests/issue-1599-json-standalone-refuse.test.ts`** — dynamic-string case flipped to accepted.

## Spec
ECMA-262 §25.5.4 `JSON.stringify`, §25.5.4.3 `QuoteJSONString`.

## Validation
`pnpm exec vitest run tests/issue-1599.test.ts tests/issue-1599-json-standalone-refuse.test.ts tests/issue-1599-runtime.test.ts` — 26 passed.

## Scope / follow-ups (issue stays `status: ready` — Phase 2 not complete)
- Runtime `JSON.parse` → primitive `$AnyValue` (number/bool/null) — dev follow-up.
- Runtime `JSON.parse` → string — needs shared `$AnyValue` string-equals native fallback (senior-dev).
- Object/array graphs — blocked on #1472 Phase B open-object runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)