### PR TITLE
feat(#1103a): native Map dispatch slice 1 (standalone/WASI)

### DIFF
--- a/plan/issues/1103-wasm-native-map-set-weakmap.md
+++ b/plan/issues/1103-wasm-native-map-set-weakmap.md
@@ -408,3 +408,63 @@ Commit `4a4735eec` — runtime core, `tsc --noEmit` clean.
 `__hash_anyref` local layout is fixed post-hoc by `fixHashLocals` (indices
 1=nv,2=bits,3=h,4=i,5=flat,6=data,7=len). `nativeStrDataFieldIdx` reads the
 NativeString struct's last ref field for the i16 backing array.
+
+## Wiring recon (sd-1665, 2026-06-03) — #1103a dispatch, ready to implement
+
+PR #1072 merged the dormant runtime core. Mapped the exact wiring needed to
+make it live. Key correction to the earlier plan: gating only the
+`registerBuiltinExternClasses` Map entry (index.ts:8670) is **insufficient** —
+`Map` is ALSO registered as an externClass via the lib `.d.ts` scan, so
+`new Map()` still emits `Map_new`/`Map_get`/`Map_set`/`Map_get_size` host
+imports and the standalone module fails to instantiate
+(`env` not satisfiable). The wiring must intercept at the **call sites**,
+mirroring the RegExp native-backend precedent.
+
+Merged runtime API (src/codegen/map-runtime.ts, via `ensureMapHelpers(ctx)` →
+`ctx.mapHelpers`): `__map_new() -> ref$Map`, `__map_get(ref$Map, anyref)
+-> anyref`, `__map_set(ref$Map, anyref, anyref) -> ref$Map`,
+`__map_has -> i32`, `__map_delete -> i32`, `__map_size -> i32`,
+`__map_clear -> ()`, `__map_iter_new(ref$Map, i32 kind) -> ref$MapIter`,
+`__map_iter_next(ref$MapIter) -> ref$MapIterResult {value:anyref, done:i32}`.
+NOTE: there is **no `__map_new_from_arr`** in the merged core — `new Map(iter)`
+needs that helper added (slice 2) or a no-arg-only slice 1.
+
+Wiring points (all gate on `ctx.nativeStrings`):
+1. **index.ts:8670** — gate `registerBuiltinExternClasses` Map entry off when
+   nativeStrings (so the fallback path doesn't re-add it). Also prevent the
+   lib-scan externClass from driving dispatch — simplest: leave it registered
+   but intercept BEFORE the externClass path at the call sites (mirrors RegExp,
+   which keeps its externClass but the calls.ts:1885 `if
+   (!ctx.externClasses.has("RegExp"))` peephole routes `new RegExp` to the
+   native engine first).
+2. **calls.ts ~1885-1888** (`${externInfo.importPrefix}_new`) — add a
+   `className === "Map" && ctx.nativeStrings` branch BEFORE the externClass
+   `_new` emission: `ensureMapHelpers(ctx)`, then for no-arg `new Map()` emit
+   `call __map_new` (result `ref $Map`, store as the Map's wasm type, NOT
+   externref). The result type must propagate as `ref $ctx.mapTypeIdx` so the
+   member-dispatch site recognizes it.
+3. **property-access.ts ~953** (method dispatch, `${importPrefix}_get_*`) and
+   the member-call path — when the receiver type is `ref $Map` (or
+   className==="Map" && nativeStrings), branch to
+   `ctx.mapHelpers.get("__map_"+method)`: `.get/.set/.has/.delete/.clear` map
+   1:1; `.size` getter → `__map_size`. Key/value cross the anyref boundary:
+   number key → box via `__box_number` then `any.convert_extern`-free (it's
+   already anyref after box+convert); the runtime's `__hash_anyref` /
+   `__same_value_zero` handle boxed numbers/strings. `.get` returns anyref →
+   coerce to the binding's expected type (unbox_number for numeric).
+4. **loops.ts** for-of recognition of `ref $Map` → `__map_iter_new` +
+   `__map_iter_next` (slice 2; mirror the #1665 native-generator for-of driver
+   shape — read `{value,done}` from `$MapIterResult`).
+5. **$__obj_hash** hidden field on user structs (slice 2) — only needed for
+   OBJECT keys; numeric/string keys work via the runtime hash without it.
+
+Slice plan:
+- **Slice 1** (this PR): no-arg `new Map()` + `.set/.get/.has/.delete/.size/
+  .clear` for number/string keys. Gate + calls.ts intercept + property-access
+  dispatch + key/value boxing. Unit test: `m.set/get/has/size` round-trip
+  standalone, zero `Map_*` host imports.
+- **Slice 2**: for-of/forEach iteration, `new Map(iterable)` (needs
+  `__map_new_from_arr`), object keys ($__obj_hash), Set (#1103b).
+
+Status: wiring fully mapped + de-risked (confirmed gate-alone insufficient via
+probe). Ready to implement slice 1 on branch issue-1103a-map-wiring.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -56,7 +56,6 @@ import {
 import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
 import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
 import { emitJsonQuoteString } from "../json-runtime.js";
-import { ensureMapHelpers } from "../map-runtime.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -1902,29 +1901,10 @@ function compileCallExpression(
     }
   }
 
-  // (#1103a) Native Map construction in standalone / nativeStrings mode.
-  // `Map` is registered as an externClass via the lib .d.ts scan, so without
-  // this interception `new Map()` would emit a `Map_new` host import that
-  // standalone modules can't satisfy. Route to the WasmGC-native Map runtime
-  // (src/codegen/map-runtime.ts) instead. Result is `ref $Map` so member-call
-  // dispatch (compileExternMethodCall) recognizes the receiver. Slice 1:
-  // no-arg `new Map()` only — the iterable-constructor form needs
-  // `__map_new_from_arr` (not yet in the runtime core), so a `new Map(iter)`
-  // falls through to the host path (host mode) / refusal (standalone) for now.
-  if (
-    !expr.questionDotToken &&
-    ts.isIdentifier(expr.expression) &&
-    expr.expression.text === "Map" &&
-    ctx.nativeStrings &&
-    (expr.arguments?.length ?? 0) === 0
-  ) {
-    ensureMapHelpers(ctx);
-    const mapNewIdx = ctx.mapHelpers.get("__map_new");
-    if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
-      fctx.body.push({ op: "call", funcIdx: mapNewIdx });
-      return { kind: "ref", typeIdx: ctx.mapTypeIdx };
-    }
-  }
+  // (#1103a) Note: `new Map()` is a NewExpression handled in
+  // expressions/new-super.ts (compileNewExpression), not here. Bare `Map(...)`
+  // without `new` is not valid for Map, so there is no call-expression
+  // interception to add.
 
   // `Object(x)` called without `new` — ECMAScript §20.1.1.1 / §7.1.18 ToObject.
   // Per spec: Object() / Object(null) / Object(undefined) → fresh empty object;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -56,6 +56,7 @@ import {
 import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
 import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
 import { emitJsonQuoteString } from "../json-runtime.js";
+import { ensureMapHelpers } from "../map-runtime.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -1898,6 +1899,30 @@ function compileCallExpression(
       const finalIdx = ctx.funcMap.get(importName) ?? funcIdx;
       fctx.body.push({ op: "call", funcIdx: finalIdx });
       return { kind: "externref" };
+    }
+  }
+
+  // (#1103a) Native Map construction in standalone / nativeStrings mode.
+  // `Map` is registered as an externClass via the lib .d.ts scan, so without
+  // this interception `new Map()` would emit a `Map_new` host import that
+  // standalone modules can't satisfy. Route to the WasmGC-native Map runtime
+  // (src/codegen/map-runtime.ts) instead. Result is `ref $Map` so member-call
+  // dispatch (compileExternMethodCall) recognizes the receiver. Slice 1:
+  // no-arg `new Map()` only — the iterable-constructor form needs
+  // `__map_new_from_arr` (not yet in the runtime core), so a `new Map(iter)`
+  // falls through to the host path (host mode) / refusal (standalone) for now.
+  if (
+    !expr.questionDotToken &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Map" &&
+    ctx.nativeStrings &&
+    (expr.arguments?.length ?? 0) === 0
+  ) {
+    ensureMapHelpers(ctx);
+    const mapNewIdx = ctx.mapHelpers.get("__map_new");
+    if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+      fctx.body.push({ op: "call", funcIdx: mapNewIdx });
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx };
     }
   }
 

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -10,6 +10,7 @@ import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, ExternClassInfo, FunctionContext, RestParamInfo } from "../context/types.js";
 import { getArrTypeIdxFromVec } from "../index.js";
+import { tryCompileNativeMapMethodCall } from "../map-runtime.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
@@ -45,6 +46,18 @@ function compileExternMethodCall(
   const receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
   const className = receiverType.getSymbol()?.name;
   const methodName = propAccess.name.text;
+
+  // (#1103a) Native Map method dispatch in standalone / nativeStrings mode.
+  // `Map` is registered as an externClass via the lib .d.ts scan, so without
+  // this interception `m.set(...)` etc. would emit `Map_set` host imports the
+  // standalone runtime can't satisfy. Route to the WasmGC-native Map runtime
+  // (src/codegen/map-runtime.ts) instead. Mirrors the RegExp construction
+  // interception in calls.ts. Falls through (undefined) for unsupported
+  // methods so the generic extern/host path still applies in JS-host mode.
+  if (className === "Map" && ctx.nativeStrings) {
+    const mapResult = tryCompileNativeMapMethodCall(ctx, fctx, propAccess, callExpr);
+    if (mapResult !== undefined) return mapResult;
+  }
 
   if (!className) return null;
 

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -9,7 +9,7 @@ import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, ExternClassInfo, FunctionContext, RestParamInfo } from "../context/types.js";
-import { getArrTypeIdxFromVec } from "../index.js";
+import { addUnionImports, getArrTypeIdxFromVec } from "../index.js";
 import { tryCompileNativeMapMethodCall } from "../map-runtime.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
 import type { InnerResult } from "../shared.js";
@@ -55,6 +55,10 @@ function compileExternMethodCall(
   // interception in calls.ts. Falls through (undefined) for unsupported
   // methods so the generic extern/host path still applies in JS-host mode.
   if (className === "Map" && ctx.nativeStrings) {
+    // Register box/unbox helpers up front (as native funcs in standalone mode)
+    // so the Map dispatch never adds an import mid-body — a late import would
+    // retrigger the #1677 native-string finalize-shift and corrupt __str_flatten.
+    addUnionImports(ctx);
     const mapResult = tryCompileNativeMapMethodCall(ctx, fctx, propAccess, callExpr);
     if (mapResult !== undefined) return mapResult;
   }

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -12,12 +12,14 @@ import type { CodegenContext, FunctionContext } from "../context/types.js";
 import {
   addFuncType,
   addStringConstantGlobal,
+  addUnionImports,
   ensureExnTag,
   getArrTypeIdxFromVec,
   getOrRegisterRefCellType,
   getOrRegisterVecType,
   resolveWasmType,
 } from "../index.js";
+import { ensureMapHelpers } from "../map-runtime.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import {
@@ -1537,6 +1539,28 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       }
       fctx.body.push({ op: "ref.null.extern" } as Instr);
       return { kind: "externref" };
+    }
+  }
+
+  // (#1103a) `new Map()` in standalone / nativeStrings mode → the WasmGC-native
+  // Map runtime (map-runtime.ts) instead of a `Map_new` host import. `new Map()`
+  // is a NewExpression, so the interception must live here (not in the
+  // call-expression compiler). Slice 1: no-arg form only — `new Map(iterable)`
+  // needs `__map_new_from_arr` (slice 2) and falls through. Returns `ref $Map`
+  // so the binding/receiver is typed (see resolveWasmType Map case + the
+  // method/.size dispatch in extern.ts / property-access.ts).
+  if (
+    ctx.nativeStrings &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Map" &&
+    (expr.arguments?.length ?? 0) === 0
+  ) {
+    addUnionImports(ctx);
+    ensureMapHelpers(ctx);
+    const mapNewIdx = ctx.mapHelpers.get("__map_new");
+    if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+      fctx.body.push({ op: "call", funcIdx: mapNewIdx });
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx };
     }
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -32,6 +32,7 @@ import type {
 } from "./context/types.js";
 import type { NodeBuiltinImport } from "../import-resolver.js";
 import { eliminateDeadImports } from "./dead-elimination.js";
+import { ensureMapRuntimeTypes } from "./map-runtime.js";
 import { emitUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
 import {
@@ -8238,6 +8239,16 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       return { kind: "ref", typeIdx: dateTypeIdx };
     }
 
+    // (#1103a) Map → WasmGC native Map struct (`$Map`) in standalone /
+    // nativeStrings mode. Mirrors Date above — a `Map`-typed binding/param
+    // becomes `ref $Map` so `new Map()` stores directly and method/.size
+    // dispatch reads a typed receiver (no externref round-trip / illegal cast).
+    // JS-host mode keeps Map as an externref-backed externClass (falls through).
+    if (sym?.name === "Map" && ctx.nativeStrings) {
+      ensureMapRuntimeTypes(ctx);
+      if (ctx.mapTypeIdx >= 0) return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+    }
+
     // Check externref AFTER Array check — Array is declared in lib but should use wasm GC arrays
     if (isExternalDeclaredClass(tsType, ctx.checker)) return { kind: "externref" };
 
@@ -8666,8 +8677,16 @@ export function registerBuiltinExternClasses(ctx: CodegenContext): void {
     });
   }
 
-  // Map methods
-  if (!ctx.externClasses.has("Map")) {
+  // Map methods.
+  // (#1103a) In standalone / nativeStrings mode, `Map` is served by the
+  // WasmGC-native runtime (src/codegen/map-runtime.ts), intercepted at the
+  // new-expression / method-call / .size sites. Registering it as an
+  // externClass here would eagerly emit a `Map_new` host import the standalone
+  // module can't satisfy, so skip registration in that mode. JS-host mode keeps
+  // the externClass path unchanged. (Slice 1 covers number/string keys with
+  // new/get/set/has/delete/clear/size; forEach / iteration / new Map(iterable)
+  // are slice 2 — those fall through and currently have no standalone path.)
+  if (!ctx.externClasses.has("Map") && !ctx.nativeStrings) {
     const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
     methods.set("get", externMethod(1));
     methods.set("set", externMethod(2));
@@ -9254,6 +9273,12 @@ const ERROR_TYPES_SKIP = new Set([
 function collectExternFromDeclareVar(ctx: CodegenContext, decl: ts.VariableDeclaration): void {
   const className = (decl.name as ts.Identifier).text;
   if (ERROR_TYPES_SKIP.has(className)) return;
+  // (#1103a) In standalone / nativeStrings mode, `Map` is served by the
+  // WasmGC-native runtime (map-runtime.ts) intercepted at the call sites.
+  // Skip registering it as an externClass from the lib `declare var Map`
+  // declaration — otherwise `registerExternClassImports` eagerly emits a
+  // `Map_new` host import the standalone module can't satisfy.
+  if (className === "Map" && ctx.nativeStrings) return;
   if (ctx.externClasses.has(className)) return;
 
   const symbol = ctx.checker.getSymbolAtLocation(decl.name);

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -28,7 +28,7 @@ import type { Instr, StructTypeDef, ArrayTypeDef, ValType } from "../ir/types.js
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
-import { compileExpression, ensureLateImport, VOID_RESULT } from "./shared.js";
+import { compileExpression, VOID_RESULT } from "./shared.js";
 
 /** WasmGC `eq` abstract heap type, signed-LEB `0x6d` = -19. Used for ref.eq on
  *  object keys (only GC eqrefs can be compared by identity). */
@@ -158,13 +158,6 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
   if (ctx.mapHelpersEmitted) return;
   ctx.mapHelpersEmitted = true;
   ensureMapRuntimeTypes(ctx);
-
-  // (#1103a) The runtime and the call-site wiring box/unbox numeric keys &
-  // values through `__box_number` / `__unbox_number`. Import them up front
-  // (at module-setup time, before any function body is compiled) so the
-  // per-call wiring never triggers a mid-expression late-import index shift.
-  ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
-  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
 
   const anyref: ValType = { kind: "anyref" };
   const i32: ValType = { kind: "i32" };
@@ -926,19 +919,28 @@ function coerceArgToAnyref(ctx: CodegenContext, fctx: FunctionContext, t: ValTyp
     fctx.body.push({ op: "ref.null", typeIdx: NONE_HEAP });
     return;
   }
+  // __box_number must already be registered (the call sites call
+  // addUnionImports before dispatching — see the #1103a note in
+  // tryCompileNativeMapMethodCall). Looking it up (vs ensureLateImport) avoids
+  // adding an import mid-function-body, which would retrigger the #1677
+  // native-string finalize-shift and corrupt __str_flatten.
   switch (t.kind) {
     case "f64": {
-      const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
-      fctx.body.push({ op: "call", funcIdx: boxIdx });
-      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      const boxIdx = ctx.funcMap.get("__box_number");
+      if (boxIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: boxIdx });
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+      }
       return;
     }
     case "i32": {
       // boolean / small int → box as number for now (slice 1 number/string).
       fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
-      const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
-      fctx.body.push({ op: "call", funcIdx: boxIdx });
-      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      const boxIdx = ctx.funcMap.get("__box_number");
+      if (boxIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: boxIdx });
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+      }
       return;
     }
     case "externref":

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -23,9 +23,12 @@
  * Everything here is emitted lazily and only when the native-collections path
  * is active (`ctx.standalone || ctx.wasi`). The JS-host path is untouched.
  */
+import { ts } from "../ts-api.js";
 import type { Instr, StructTypeDef, ArrayTypeDef, ValType } from "../ir/types.js";
-import type { CodegenContext } from "./context/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import type { InnerResult } from "./shared.js";
+import { compileExpression, ensureLateImport, VOID_RESULT } from "./shared.js";
 
 /** WasmGC `eq` abstract heap type, signed-LEB `0x6d` = -19. Used for ref.eq on
  *  object keys (only GC eqrefs can be compared by identity). */
@@ -155,6 +158,13 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
   if (ctx.mapHelpersEmitted) return;
   ctx.mapHelpersEmitted = true;
   ensureMapRuntimeTypes(ctx);
+
+  // (#1103a) The runtime and the call-site wiring box/unbox numeric keys &
+  // values through `__box_number` / `__unbox_number`. Import them up front
+  // (at module-setup time, before any function body is compiled) so the
+  // per-call wiring never triggers a mid-expression late-import index shift.
+  ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
 
   const anyref: ValType = { kind: "anyref" };
   const i32: ValType = { kind: "i32" };
@@ -900,6 +910,151 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
       body,
     );
   }
+}
+
+/**
+ * (#1103a) Coerce a freshly-compiled Map key/value argument to `anyref` — the
+ * uniform slot type the runtime stores. Numbers arrive as `f64` and are boxed
+ * via `__box_number` (the contract `__same_value_zero` / `__hash_anyref`
+ * assume); native strings and other GC refs are already anyref subtypes;
+ * externrefs externalize via `any.convert_extern`.
+ */
+function coerceArgToAnyref(ctx: CodegenContext, fctx: FunctionContext, t: ValType | null): void {
+  if (t === null) {
+    // Absent value (e.g. compileExpression produced nothing) — push a null
+    // `none`-typed ref (subtype of anyref), matching the runtime's ABSENT.
+    fctx.body.push({ op: "ref.null", typeIdx: NONE_HEAP });
+    return;
+  }
+  switch (t.kind) {
+    case "f64": {
+      const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+      fctx.body.push({ op: "call", funcIdx: boxIdx });
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      return;
+    }
+    case "i32": {
+      // boolean / small int → box as number for now (slice 1 number/string).
+      fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+      const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+      fctx.body.push({ op: "call", funcIdx: boxIdx });
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      return;
+    }
+    case "externref":
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      return;
+    default:
+      // GC struct refs (native strings, $Map, etc.) and anyref/eqref are
+      // already anyref subtypes — no conversion needed.
+      return;
+  }
+}
+
+/**
+ * (#1103a) Intercept a `Map.prototype.*` method call in standalone /
+ * `nativeStrings` mode and route it to the WasmGC-native Map runtime
+ * (`ensureMapHelpers`). Mirrors the RegExp pre-externClass interception in
+ * `expressions/calls.ts`: returns the result `InnerResult` when handled, or
+ * `undefined` to let the generic extern/host path proceed.
+ *
+ * Slice 1 covers `set` / `get` / `has` / `delete` / `clear` for number and
+ * string keys/values. `forEach` / `for-of` and `new Map(iterable)` are slice 2
+ * (need the `$MapIter` drive + `__map_new_from_arr`).
+ *
+ * Receiver and arguments are compiled here (the caller has not pushed them).
+ */
+export function tryCompileNativeMapMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  const methodName = propAccess.name.text;
+  const handled =
+    methodName === "set" ||
+    methodName === "get" ||
+    methodName === "has" ||
+    methodName === "delete" ||
+    methodName === "clear";
+  if (!handled) return undefined;
+
+  ensureMapHelpers(ctx);
+  const helperName = `__map_${methodName}`;
+  const helperIdx = ctx.mapHelpers.get(helperName);
+  if (helperIdx === undefined || ctx.mapTypeIdx < 0) return undefined;
+
+  // Receiver → `ref $Map`. compileExpression yields the receiver's ValType;
+  // it must be the native Map struct (recorded by the `new Map()` site / a
+  // `Map`-typed binding). If it comes through as externref/anyref, cast it.
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (recvType === null) return undefined;
+  if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
+    // Wrong struct — not our Map; bail so the generic path can try.
+    return undefined;
+  }
+
+  const args = callExpr.arguments;
+  switch (methodName) {
+    case "get":
+    case "has":
+    case "delete": {
+      const kt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
+      coerceArgToAnyref(ctx, fctx, kt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // get → anyref value; has/delete → i32 (boolean).
+      return methodName === "get" ? ({ kind: "anyref" } as ValType) : ({ kind: "i32" } as ValType);
+    }
+    case "set": {
+      const kt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
+      coerceArgToAnyref(ctx, fctx, kt);
+      const vt = args.length > 1 ? compileExpression(ctx, fctx, args[1]!) : null;
+      coerceArgToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // __map_set returns `ref $Map` (the map itself) — chainable.
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
+    }
+    case "clear": {
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // __map_clear is void → undefined result.
+      return VOID_RESULT;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * (#1103a) Intercept the `Map.prototype.size` accessor in standalone /
+ * `nativeStrings` mode → `__map_size` (returns i32). Receiver is compiled
+ * here. Returns the result ValType when handled, else `undefined`.
+ */
+export function tryCompileNativeMapSizeGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: ts.Expression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  ensureMapHelpers(ctx);
+  const sizeIdx = ctx.mapHelpers.get("__map_size");
+  if (sizeIdx === undefined || ctx.mapTypeIdx < 0) return undefined;
+  const recvType = compileExpression(ctx, fctx, receiver);
+  if (recvType === null) return undefined;
+  if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
+    return undefined;
+  }
+  fctx.body.push({ op: "call", funcIdx: sizeIdx });
+  return { kind: "i32" } as ValType;
 }
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -25,6 +25,7 @@ import {
 import { patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
+import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -2997,6 +2998,14 @@ function compileExternPropertyGet(
 ): ValType | null {
   const className = objType.getSymbol()?.name;
   if (!className) return null;
+
+  // (#1103a) Native Map `.size` accessor in standalone / nativeStrings mode →
+  // `__map_size` instead of the `Map_get_size` host import. Mirrors the method
+  // interception in expressions/extern.ts.
+  if (className === "Map" && propName === "size" && ctx.nativeStrings) {
+    const sizeResult = tryCompileNativeMapSizeGet(ctx, fctx, expr.expression);
+    if (sizeResult !== undefined) return sizeResult as ValType;
+  }
 
   // Walk inheritance chain to find the class that declares the property
   const resolvedInfo = findExternInfoForMember(ctx, className, propName, "property");

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3003,6 +3003,7 @@ function compileExternPropertyGet(
   // `__map_size` instead of the `Map_get_size` host import. Mirrors the method
   // interception in expressions/extern.ts.
   if (className === "Map" && propName === "size" && ctx.nativeStrings) {
+    addUnionImports(ctx);
     const sizeResult = tryCompileNativeMapSizeGet(ctx, fctx, expr.expression);
     if (sizeResult !== undefined) return sizeResult as ValType;
   }

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -1617,6 +1617,22 @@ export function coerceType(
     fctx.body.push({ op: "any.convert_extern" } as Instr);
     return;
   }
+  // anyref → f64 (#1103a): a value read out of a native collection (e.g.
+  // `Map.prototype.get` returns anyref) used in numeric context. Numbers are
+  // stored boxed (`__box_number` externref converted to anyref), so externalize
+  // back to externref then unbox. Mirrors the `externref → f64` arm.
+  if (from.kind === "anyref" && to.kind === "f64") {
+    addUnionImports(ctx);
+    const unboxIdx = ctx.funcMap.get("__unbox_number");
+    if (unboxIdx !== undefined) {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+      fctx.body.push({ op: "call", funcIdx: unboxIdx });
+      return;
+    }
+    fctx.body.push({ op: "drop" } as Instr);
+    fctx.body.push({ op: "f64.const", value: 0 });
+    return;
+  }
   // externref → eqref: any.convert_extern (eqref is subtype of anyref)
   if (from.kind === "externref" && to.kind === "eqref") {
     fctx.body.push({ op: "any.convert_extern" } as Instr);

--- a/tests/issue-1103a-standalone-map.test.ts
+++ b/tests/issue-1103a-standalone-map.test.ts
@@ -1,0 +1,117 @@
+// #1103a — Wasm-native Map dispatch (standalone / nativeStrings).
+//
+// dev-1776 landed the dormant native Map runtime core (map-runtime.ts, PR
+// #1072) — an ordered WasmGC hash table. This file is the regression net for
+// the *wiring* that routes `new Map()` + `.set/.get/.has/.delete/.clear/.size`
+// onto that runtime under `--target wasi`, instead of the `Map_*` host imports
+// the externClass path would emit (which a pure-Wasm engine can't satisfy).
+//
+// Slice 1 scope: no-arg `new Map()`, number + native-string keys/values,
+// get/set/has/delete/clear/size. for-of / forEach / `new Map(iterable)` are
+// slice 2 and intentionally not covered here.
+//
+// Each test compiles with `target: "wasi"` and asserts (a) the module is valid
+// Wasm, (b) it carries ZERO `Map_*` host imports (wiring routes onto the native
+// runtime, not the host externClass path), and (c) it returns the expected
+// value when instantiated against the WASI polyfill and run.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+/** Compile `source` with `--target wasi`, run `test()`, return its value. */
+async function runMap(source: string): Promise<{ value: number; mapImports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const mapImports = WebAssembly.Module.imports(module).filter((i) => /^Map_/.test(i.name)).length;
+
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, mapImports, valid };
+}
+
+describe("#1103a native Map dispatch (standalone)", () => {
+  it("set + get for number keys/values — host-import-free", async () => {
+    const { value, mapImports, valid } = await runMap(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 10);
+         m.set(2, 20);
+         return (m.get(1) as number) + (m.get(2) as number);
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(mapImports).toBe(0);
+    expect(value).toBe(30);
+  });
+
+  it("size + overwrite — host-import-free", async () => {
+    const { value, mapImports, valid } = await runMap(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 10);
+         m.set(2, 20);
+         m.set(1, 99); // overwrite, not a new entry
+         return m.size; // 2
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(mapImports).toBe(0);
+    expect(value).toBe(2);
+  });
+
+  it("has + delete + clear — host-import-free", async () => {
+    const { value, mapImports, valid } = await runMap(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 10);
+         m.set(2, 20);
+         let acc = 0;
+         if (m.has(2)) acc += 100;       // 100
+         if (m.delete(2)) acc += 1000;   // 1100
+         if (!m.has(2)) acc += 10;       // 1110
+         acc += m.size;                  // + 1  = 1111
+         return acc;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(mapImports).toBe(0);
+    expect(value).toBe(1111);
+  });
+
+  it("string keys with number values — host-import-free", async () => {
+    const { value, mapImports, valid } = await runMap(
+      `export function test(): number {
+         const m = new Map<string, number>();
+         m.set("a", 1);
+         m.set("b", 2);
+         return (m.get("a") as number) + (m.get("b") as number) + m.size; // 1 + 2 + 2
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(mapImports).toBe(0);
+    expect(value).toBe(5);
+  });
+
+  it("method-heavy program emits zero Map_* host imports and valid Wasm", async () => {
+    const { mapImports, valid } = await runMap(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 1); m.set(2, 2); m.set(3, 3);
+         m.delete(2);
+         m.has(1);
+         m.clear();
+         return m.size;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(mapImports).toBe(0);
+  });
+});


### PR DESCRIPTION
Wires the dormant WasmGC-native `Map` runtime (`src/codegen/map-runtime.ts`, dev-1776 PR #1072 — an ordered hash table) into standalone / `--target wasi` codegen. Until now the runtime had **zero callers**; this is the first thing to drive it.

## Scope (slice 1)
`new Map()` (no-arg) + `set` / `get` / `has` / `delete` / `clear` / `size`, for **number** and **native-string** keys/values. Host-import-free under `--target wasi`.

Out of scope (slice 2 / #1103b): `for-of` / `forEach`, `new Map(iterable)` (needs `__map_new_from_arr`), object keys, Set/WeakMap/WeakSet.

## Wiring points
- **`new-super.ts` `compileNewExpression`**: `new Map()` → `__map_new`, returns `ref $Map`. (`new Map()` is a NewExpression, so the interception lives here, not in the call-expression compiler.)
- **`index.ts` `resolveWasmType`**: `Map` type → `ref $Map` under `nativeStrings` (mirrors the `Date` precedent), so the binding/receiver is typed and there is no externref round-trip / `ref.cast` trap.
- **`extern.ts` `compileExternMethodCall`**: `m.set/get/has/delete/clear` → `tryCompileNativeMapMethodCall` (new helper in `map-runtime.ts`) with anyref key/value boxing.
- **`property-access.ts` `compileExternPropertyGet`**: `m.size` → `__map_size`.
- **`type-coercion.ts`**: new `anyref → f64` arm (`extern.convert_any` + `__unbox_number`) so `Map.get()` results unbox for numeric use.
- **`index.ts`**: skip `Map` externClass registration (`registerBuiltinExternClasses` + `collectExternFromDeclareVar`) under `nativeStrings` — eliminates the dead `Map_new` host import. **JS-host mode keeps the externClass path unchanged.**

## Root causes fixed along the way
1. Adding `__box_number` as a **late import mid-body** retriggered the #1677 native-string finalize-shift and corrupted `__str_flatten`. Fixed by calling `addUnionImports()` up front at each Map dispatch site (native funcs under wasi, no shift).
2. Local `m` was typed `externref` (Map = external-declared class) → `new Map()` value dropped + `ref.cast` trap. Fixed by the `resolveWasmType` Map case.
3. The `new Map()` interception was initially in `calls.ts` (call expr) but `new Map()` is a NewExpression → moved to `new-super.ts`.

## Tests
`tests/issue-1103a-standalone-map.test.ts` — 5 tests, compiled `--target wasi`, instantiated against the WASI polyfill and **run**: returns 30 / 2 / 1111 / 5 and asserts zero `Map_*` imports + valid Wasm. All 24 `tests/wasi.test.ts` green. JS-host Map unchanged (still `Map_new` externClass — verified). `tsc --noEmit` + `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)