### PR TITLE
feat(#1472 Phase B Blocker B Slice 2): standalone enumeration consumer

### DIFF
--- a/plan/issues/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/1472-no-js-host-object-property-ops.md
@@ -770,3 +770,30 @@ slice, NOT this foundation:
    member-access on `any` to `__extern_length` / `__extern_get_idx`.
 `__object_values` / `__object_entries` / `__object_assign` / `__for_in_keys`
 stack trivially on the `$ObjVec` + `__objvec_*` primitives added here.
+
+## Phase B Blocker B Slice 2 — enumeration consumer (sd-1472, 2026-06-03)
+
+Branch `issue-1472-blocker-b-slice2` off origin/main (post-#1075). Wires the
+typed enumeration *consumer* chain to the native `$ObjVec` foundation so
+`Object.keys(o)` results are usable host-free in standalone.
+
+### What landed
+- `src/codegen/type-coercion.ts` `buildVecFromExternref`: under `ctx.standalone`,
+  SKIP the host-only `env::__array_from_iter` materialization (the source is
+  already an indexable externref — the `$ObjVec` from Object.keys/values/entries)
+  and read elements via the native `__extern_get_idx(obj, f64(idx))` instead of
+  `__extern_get(obj, boxed-index)` (the native `__extern_get` casts its key to
+  `$AnyString` and would trap on a boxed number). JS-host path unchanged.
+- `src/codegen/property-access.ts` `.length` block: under `ctx.standalone`, when
+  the receiver type is `any`/`unknown` and no vec fast-path matched, route
+  `.length` to the native `__extern_length` (the `$ObjVec` length reader) instead
+  of falling through to `__extern_get("length")`. JS-host path unchanged.
+- `tests/issue-1472.test.ts`: (a) `const ks: string[] = Object.keys(o); for…of`
+  validates + leaks zero `__array_from_iter`/object/array host imports; (b)
+  `(ks.length)` on an `any` routes to native `__extern_length`, validates, emits
+  it as a defined fn.
+
+### Validation
+- `tests/issue-1472.test.ts` — 15 pass. No gc-mode regression: issue-1471,
+  issue-1664, and the externref-array-destructuring / array-rest-destructuring /
+  for-of-array-destructuring / arguments-object equivalence suites all green.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2121,6 +2121,37 @@ export function compilePropertyAccess(
       // Undo the compiled expression if it didn't match
       fctx.body.length = savedLen;
     }
+    // #1472 Phase B Blocker B Slice 2 — standalone `.length` on an `any`/unknown
+    // receiver. None of the vec fast-paths matched, so the receiver is an opaque
+    // externref at runtime (e.g. the $ObjVec result of `Object.keys(o)` stored
+    // in an `any`). In standalone, `__extern_length` is the native $ObjVec
+    // reader (Blocker B Slice 1), so routing here keeps `.length` host-free and
+    // correct instead of falling through to `__extern_get("length")` (which the
+    // native `__extern_get` would mis-handle by casting "length" → key lookup,
+    // yielding 0). JS-host mode is unchanged (this gate is standalone-only; the
+    // host path's generic `__extern_get("length")` already works there).
+    if (ctx.standalone) {
+      const isAnyOrUnknown = (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+      if (isAnyOrUnknown) {
+        const exprResult = compileExpression(ctx, fctx, expr.expression);
+        if (exprResult) {
+          if (exprResult.kind !== "externref") {
+            coerceType(ctx, fctx, exprResult, { kind: "externref" });
+          }
+          const lenFn = ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
+          flushLateImportShifts(ctx, fctx);
+          if (lenFn !== undefined) {
+            fctx.body.push({ op: "call", funcIdx: lenFn } as Instr);
+            if (ctx.fast) fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
+          // No helper available — drop and yield 0.
+          fctx.body.push({ op: "drop" } as Instr);
+          fctx.body.push({ op: ctx.fast ? "i32.const" : "f64.const", value: 0 } as Instr);
+          return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+        }
+      }
+    }
   }
 
   // Handle .raw on tagged template strings arrays (template vec struct)

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -200,11 +200,31 @@ export function buildVecFromExternref(
   flushLateImportShifts(ctx, fctx);
   const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
   flushLateImportShifts(ctx, fctx);
-  // Materialize iterables (generators, custom @@iterator) via Array.from so
-  // the length/indexed-access loop below walks a real array. Throws from
-  // iterator .next() propagate to the caller (#1150).
-  const iterIdx = ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
-  flushLateImportShifts(ctx, fctx);
+  // #1472 Phase B Blocker B Slice 2 — standalone enumeration consumer.
+  //
+  // `__array_from_iter` is a JS-host import (it invokes the Symbol.iterator
+  // protocol via the runtime). In standalone there is no host, and the source
+  // we are coercing here is already an indexable externref — the native
+  // `$ObjVec` produced by `__object_keys`/`values`/`entries` (Slice 1), which
+  // `__extern_length` + `__extern_get_idx` read directly. So under
+  // `ctx.standalone` we SKIP the materialization step (pass the externref
+  // through unchanged) and read it with the native indexed accessor below,
+  // never leaking `env::__array_from_iter`. (Generators / custom @@iterator
+  // standalone materialization is a separate slice — those don't reach an
+  // $ObjVec source.) The JS-host path is unchanged.
+  const useNativeObjVec = ctx.standalone;
+  const iterIdx = useNativeObjVec
+    ? undefined
+    : ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+  if (!useNativeObjVec) flushLateImportShifts(ctx, fctx);
+  // In standalone, indexed reads go through the native `__extern_get_idx`
+  // (f64 index → element) instead of `__extern_get(obj, boxed-index)` — the
+  // native `__extern_get` casts its key to $AnyString and would trap on a
+  // boxed number. (#1472 Phase B Blocker B Slice 2)
+  const getIdxIdx = useNativeObjVec
+    ? ensureLateImport(ctx, "__extern_get_idx", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }])
+    : undefined;
+  if (useNativeObjVec) flushLateImportShifts(ctx, fctx);
 
   if (lenIdx === undefined || getIdx === undefined) {
     return [{ op: "ref.null", typeIdx: vecTypeIdx } as Instr];
@@ -304,14 +324,25 @@ export function buildVecFromExternref(
             { op: "local.get", index: arrLocal } as Instr,
             { op: "local.get", index: idxLocal } as Instr,
             { op: "local.get", index: matLocal } as Instr,
-            ...(boxIdx !== undefined
+            // Standalone: native __extern_get_idx(obj, f64(idx)) — reads the
+            // $ObjVec element by index without a boxed-string key. JS-host:
+            // __extern_get(obj, boxed-numeric-index) (host handles numeric keys).
+            ...(useNativeObjVec && getIdxIdx !== undefined
               ? [
                   { op: "local.get", index: idxLocal } as Instr,
                   { op: "f64.convert_i32_s" } as Instr,
-                  { op: "call", funcIdx: boxIdx } as Instr,
+                  { op: "call", funcIdx: getIdxIdx } as Instr,
                 ]
-              : [{ op: "ref.null.extern" } as Instr]),
-            { op: "call", funcIdx: getIdx } as Instr,
+              : [
+                  ...(boxIdx !== undefined
+                    ? [
+                        { op: "local.get", index: idxLocal } as Instr,
+                        { op: "f64.convert_i32_s" } as Instr,
+                        { op: "call", funcIdx: boxIdx } as Instr,
+                      ]
+                    : [{ op: "ref.null.extern" } as Instr]),
+                  { op: "call", funcIdx: getIdx } as Instr,
+                ]),
             ...buildElemCoerce(),
             { op: "array.set", typeIdx: vecInfo.arrTypeIdx } as Instr,
             { op: "local.get", index: idxLocal } as Instr,

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -236,6 +236,51 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
     expect(start).toBeGreaterThanOrEqual(0);
   });
 
+  it("Phase B Blocker B Slice 2: Object.keys(any) for-of consumer is host-free (no __array_from_iter)", async () => {
+    // #1472 Phase B Blocker B Slice 2 — the typed enumeration consumer chain.
+    // `const ks: string[] = Object.keys(o); for (const k of ks)` previously
+    // pulled in host-only env::__array_from_iter (via buildVecFromExternref) and
+    // emitted INVALID Wasm in standalone. The Slice 2 bypass: when the coerced
+    // source is already an indexable externref ($ObjVec from Object.keys), skip
+    // __array_from_iter and read it via the native __extern_get_idx. Module must
+    // validate and leak zero object/array host imports.
+    const source = `
+        export function n(o: any): number {
+          const ks: string[] = Object.keys(o);
+          let c = 0;
+          for (const k of ks) { c = c + 1; }
+          return c;
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(r.imports.some((i) => i.module === "env" && i.name.startsWith("__array_from"))).toBe(false);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    await WebAssembly.instantiate(r.binary, {});
+  });
+
+  it("Phase B Blocker B Slice 2: .length on an any value routes to native __extern_length", async () => {
+    // `(ks.length)` on an `any`-typed value previously fell through to
+    // __extern_get("length") (returns 0 / mis-handled by the native string-key
+    // __extern_get). Slice 2 routes a standalone `.length` on an any/unknown
+    // receiver to the native __extern_length (the $ObjVec length reader). Module
+    // validates, leaks no host imports, and emits __extern_length as a defined fn.
+    const source = `
+        export function m(o: any): number {
+          const ks: any = Object.keys(o);
+          return (ks.length as number);
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const wat = (r as unknown as { wat?: string }).wat ?? "";
+    expect(wat).toMatch(/\(func \$__extern_length\b/);
+    await WebAssembly.instantiate(r.binary, {});
+  });
+
   it("destructuring defaults refuse __extern_is_undefined instead of leaking the host import", async () => {
     const r = await compile(
       `


### PR DESCRIPTION
## #1472 Phase B Blocker B Slice 2 — enumeration consumer

Wires the typed enumeration *consumer* chain to the native `$ObjVec` foundation (#1075) so `Object.keys/values/entries` results are usable host-free in standalone. Stacks on Slice 1 (merged #1075).

### Changes
- `src/codegen/type-coercion.ts` `buildVecFromExternref`: under `ctx.standalone`, SKIP the host-only `env::__array_from_iter` materialization (the source is already the indexable `$ObjVec` from Object.keys/values/entries) and read elements via the native `__extern_get_idx(obj, f64(idx))` instead of `__extern_get(obj, boxed-index)` — the native `__extern_get` casts its key to `$AnyString` and would trap on a boxed number. **JS-host path unchanged.**
- `src/codegen/property-access.ts` `.length`: under `ctx.standalone`, route `.length` on an `any`/`unknown` receiver (no vec fast-path matched) to the native `__extern_length` instead of falling through to `__extern_get("length")`. **JS-host path unchanged.**
- `tests/issue-1472.test.ts`: (a) `const ks: string[] = Object.keys(o); for…of` validates + leaks zero `__array_from_iter`/object/array host imports; (b) `(ks.length)` on an `any` routes to native `__extern_length`.

### Before → after (standalone)
- for-of over `Object.keys(o):string[]`: leaked `env::__array_from_iter` + **invalid Wasm** → validates, **zero** host imports.
- `.length` on `any`: `__extern_get("length")` (wrong) → native `__extern_length`.

### Validation
- `tests/issue-1472.test.ts` — 15 pass. No gc-mode regression: issue-1471, issue-1664, externref-array-destructuring, array-rest-destructuring, for-of-array-destructuring, arguments-object equivalence suites all green. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)