### PR TITLE
docs(#1575): finalize Node.js builtin gap survey + file top-5 child issues

### DIFF
--- a/plan/issues/1575-node-builtin-gaps-survey.md
+++ b/plan/issues/1575-node-builtin-gaps-survey.md
@@ -1,9 +1,10 @@
 ---
 id: 1575
 title: "Node.js built-in module support — gap survey (js2wasm → npm)"
-status: in-review
+status: done
 created: 2026-05-20
-updated: 2026-06-02
+updated: 2026-06-03
+completed: 2026-06-03
 priority: high
 area: runtime, host-imports
 goal: npm-library-support
@@ -152,7 +153,7 @@ Ranking by (a) number of distinct target packages blocked, (b) breadth of
 the package class they unlock, (c) implementation effort needed for a
 **Tier 0** (smoke test — minimal surface) milestone.
 
-### 1. `node:path` — pure compute, blocks ESLint/prettier/axios/TS
+### 1. `node:path` — pure compute, blocks ESLint/prettier/axios/TS — child issue #1791
 
 - Why: every CLI assembles paths; `path.join`/`path.resolve`/`path.dirname`
   fire in every module loader. Pure-string functions — no I/O — so a
@@ -165,7 +166,7 @@ the package class they unlock, (c) implementation effort needed for a
   to medium.
 - Cross-ref: blocks #1400 (ESLint), #1032 (axios), TypeScript survey.
 
-### 2. `node:url` — URL/URLSearchParams, blocks ESLint/prettier/axios
+### 2. `node:url` — URL/URLSearchParams, blocks ESLint/prettier/axios — child issue #1792
 
 - Why: `new URL(...)`, `URL.fileURLToPath`, `URLSearchParams` are
   *constructor* shapes — not method calls on a require()'d object — so
@@ -182,7 +183,7 @@ the package class they unlock, (c) implementation effort needed for a
 - Cross-ref: ESLint module loader (file:// paths), axios request
   serialization.
 
-### 3. `node:buffer` + global `Buffer` — required by axios + crypto + zlib
+### 3. `node:buffer` + global `Buffer` — required by axios + crypto + zlib — child issue #1793
 
 - Why: Buffer underlies every `node:http` body, every `node:fs` non-utf8
   read, every `node:crypto` digest. Compiled code that touches *any* of
@@ -200,7 +201,7 @@ the package class they unlock, (c) implementation effort needed for a
   long-tail).
 - Cross-ref: #1032 (axios), zlib consumers, anything talking to fs binary.
 
-### 4. `node:events` / global `EventEmitter` — universal Node primitive
+### 4. `node:events` / global `EventEmitter` — universal Node primitive — child issue #1794
 
 - Why: every Node IO API (`fs.createReadStream`, `http.IncomingMessage`,
   `process` itself) is an `EventEmitter`. Subscribing from compiled code
@@ -223,7 +224,7 @@ the package class they unlock, (c) implementation effort needed for a
 - Cross-ref: unlocks #1032 (axios uses streams under the hood), prepares
   #640 (WASI HTTP) by exercising the same callback wiring.
 
-### 5. `node:http` (+ `node:https`) — direct unblocker for axios
+### 5. `node:http` (+ `node:https`) — direct unblocker for axios — child issue #1795
 
 - Why: axios is the highest-value real-world target on the backlog
   (#1032 high priority). HTTP is also a natural place to land **the
@@ -309,3 +310,40 @@ The four packages this work unblocks split cleanly along the matrix:
   alongside #1535 / #1470–#1474.
 - Web-platform globals (fetch, Web Streams, TextEncoder); see
   #1500/#1501 in the browser-host track.
+
+## Completion Summary (2026-06-03)
+
+Survey verified against current `main` and finalized.
+
+**Verification:**
+- `NODE_BUILTIN_MODULES` (`src/import-resolver.ts:16-50`) still has the same
+  33 entries the survey documented.
+- `registerNodeBuiltinImports` (`src/codegen/index.ts:9801`) still emits a
+  single opaque `__node_<module>: () -> externref` per builtin and binds it as
+  a declared global — confirming every "None" row.
+- `NODE_BUILTIN_FN_TYPED_STUBS` (`src/import-resolver.ts:68`) still only wires
+  `crypto.randomBytes` / `crypto.randomUUID`; `fs.readFileSync`/`writeFileSync`
+  remain the other typed-fn exception. No new builtin gained dedicated function
+  imports since 2026-06-02, so the Partial-vs-None classification in the matrix
+  is unchanged. No matrix rows needed upgrading.
+
+**Child issues filed** (top-5 highest-leverage `None`/`Partial` builtins from
+the "Top 5 highest-leverage builtins" section, ranked by blocked-package
+signal):
+
+| Child | Builtin | Why |
+|-------|---------|-----|
+| #1791 | `node:path` | pure compute; blocks ESLint/prettier/axios/TS; standalone-feasible |
+| #1792 | `node:url` | URL/URLSearchParams host constructors; ESLint/prettier/axios |
+| #1793 | `node:buffer` + global `Buffer` | underlies http/fs/crypto bodies; axios/zlib |
+| #1794 | `node:events` / `EventEmitter` | universal Node IO primitive; closure-callback contract |
+| #1795 | `node:http` (+https) | axios GET round-trip; depends_on #1793 + #1794 |
+
+Each child carries problem + Tier 0 acceptance criteria + a concrete
+implementation approach, mirroring the survey's per-builtin analysis. #1795 is
+explicitly `depends_on: [1793, 1794]` since the http response stream chain
+needs both Buffer and EventEmitter.
+
+Honourable-mention builtins (`util.promisify`, `assert`, `os.*`,
+`querystring`) are documented above but not filed as child issues yet — they
+are lower-leverage fast-follows once the top 5 land.

--- a/plan/issues/1791-node-path-builtin-impl.md
+++ b/plan/issues/1791-node-path-builtin-impl.md
@@ -1,0 +1,70 @@
+---
+id: 1791
+title: "node:path — typed host import + standalone TS-port fallback"
+status: ready
+sprint: Backlog
+created: 2026-06-03
+updated: 2026-06-03
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+parent: 1575
+related: [1044, 1471, 1472, 1494, 1400, 1032]
+---
+# node:path — typed host import + standalone TS-port fallback
+
+## Problem
+
+`node:path` is the single highest-leverage Node builtin gap (blocks ESLint,
+prettier, axios, TypeScript per the #1575 blocked-package matrix). Today it
+resolves to the opaque whole-module externref import `__node_path`
+(`registerNodeBuiltinImports`, `src/codegen/index.ts:9801`), so:
+
+- Named imports (`import { join } from "node:path"`) compile to a generic
+  `env` function stub `join`, never reaching the module object (see the
+  2026-06-02 validation note in #1575).
+- Standalone (WASI/browser) targets have no fallback at all — `path.join`
+  traps.
+
+`path` is pure string compute (no I/O), which makes it the cleanest builtin to
+give a real standalone implementation.
+
+## Acceptance criteria
+
+Tier 0 (smoke test — must pass on **both** JS-host and standalone WASI):
+
+- `path.join("/a", "b", "../c") === "/a/c"`
+- `path.basename("/foo/bar.ts", ".ts") === "bar"`
+- `path.dirname("/foo/bar.ts") === "/foo"`
+- `path.extname("/foo/bar.ts") === ".ts"`
+- `path.resolve("/a", "b") === "/a/b"`
+- `path.sep === "/"` (posix)
+- Both default-import (`import path from "node:path"`) and named-import
+  (`import { join } from "node:path"`) forms resolve to the same code.
+
+## Implementation approach
+
+1. **Standalone fallback (preferred path):** port the posix subset of Node's
+   `path` source into a TS shim compiled into the module — these are pure
+   string functions, mirroring the #1473 error-helper TS-port pattern. Wire it
+   so `import ... from "node:path"` binds to the shim's exports when no JS host
+   `require` is available.
+2. **Named-import recognition:** extend the `NODE_BUILTIN_FN_TYPED_STUBS` table
+   (`src/import-resolver.ts:68`) — or a new pure-compute path-shim resolver — so
+   `import { join } from "node:path"` no longer falls through to a generic
+   `env` stub.
+3. **JS-host fast path (optional):** for Node target, a `__nodefn__path__*`
+   host import can short-circuit to the real `require("path")` for win32
+   semantics; the standalone shim covers posix.
+4. Defer win32 path semantics and `path.posix`/`path.win32` namespace objects
+   to a follow-up; Tier 0 is posix-only.
+
+## Test
+
+`tests/issue-1791.test.ts` — compile each Tier 0 snippet and assert the
+returned value, once with default JS-host config and once with
+`--target wasi` (standalone).

--- a/plan/issues/1792-node-url-builtin-impl.md
+++ b/plan/issues/1792-node-url-builtin-impl.md
@@ -1,0 +1,58 @@
+---
+id: 1792
+title: "node:url — URL / URLSearchParams as host constructors"
+status: ready
+sprint: Backlog
+created: 2026-06-03
+updated: 2026-06-03
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+parent: 1575
+related: [1044, 1494, 1400, 1032]
+---
+# node:url — URL / URLSearchParams as host constructors
+
+## Problem
+
+`node:url` blocks ESLint, prettier, and axios (#1575 matrix). The current
+`__node_url` opaque-externref path cannot reach the most common usage forms
+because `URL` and `URLSearchParams` are **constructor** shapes, usually written
+as the WHATWG globals `new URL(...)` / `new URLSearchParams(...)` rather than
+method calls on a `require("url")` object. Codegen does not recognise these as
+extern classes, so `new URL(...)` does not lower to the host constructor.
+
+## Acceptance criteria
+
+Tier 0 (JS-host target — standalone deferred):
+
+- `new URL("./b", "file:///a/").pathname === "/b"`
+- `new URL("https://x.com/p?q=1").searchParams.get("q") === "1"`
+- `new URLSearchParams("a=1&a=2").getAll("a")` deep-equals `["1","2"]`
+- `url.fileURLToPath("file:///a/b.js")` returns `/a/b.js`
+- Both the global form (`new URL(...)`) and the import form
+  (`import { URL } from "node:url"`) resolve to the same host constructor.
+
+## Implementation approach
+
+1. Bind `URL` and `URLSearchParams` as **host constructors**, modeled on how
+   `Date` is wired (extern class with `new` lowering + method dispatch through
+   `__extern_method_call`). The WHATWG globals are present in both Node and
+   browsers, so the same binding serves both hosts.
+2. Recognise the global identifiers `URL` / `URLSearchParams` in codegen so
+   `new URL(...)` without an import still binds (they are ambient globals in TS
+   lib.dom / lib.node).
+3. Map `url.fileURLToPath` / `url.pathToFileURL` as named host imports
+   (`__nodefn__url__fileURLToPath`).
+4. Defer the standalone (WASI) fallback — a pure-TS URL parser port — to a
+   follow-up; it can share the percent-encode/decode helpers with a future
+   `querystring` shim.
+
+## Test
+
+`tests/issue-1792.test.ts` — compile each Tier 0 snippet under JS-host config
+and assert the result against the host's native `URL`.

--- a/plan/issues/1793-node-buffer-builtin-impl.md
+++ b/plan/issues/1793-node-buffer-builtin-impl.md
@@ -1,0 +1,59 @@
+---
+id: 1793
+title: "node:buffer + global Buffer — host class with from/concat/toString"
+status: ready
+sprint: Backlog
+created: 2026-06-03
+updated: 2026-06-03
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+parent: 1575
+related: [1044, 1032, 983]
+---
+# node:buffer + global Buffer — host class with from/concat/toString
+
+## Problem
+
+`Buffer` underlies every `node:http` body, every non-utf8 `node:fs` read, and
+every `node:crypto` digest (#1575 matrix: blocks axios, zlib consumers,
+crypto). It is also a **global**, not just an export of `require("buffer")`, so
+the opaque `__node_buffer` externref path cannot handle the common form at all
+— compiled code crashes on the first `Buffer.from(...)` because `Buffer` is not
+recognised as an extern class (contrast: `Date` is).
+
+## Acceptance criteria
+
+Tier 0 (JS-host target — standalone deferred):
+
+- `Buffer.from("hi", "utf-8").toString("utf-8") === "hi"`
+- `Buffer.concat([Buffer.from("a"), Buffer.from("b")]).length === 2`
+- `Buffer.from([104, 105]).toString() === "hi"`
+- `Buffer.alloc(4).length === 4`
+- Passing a `Uint8Array` to a host import takes a Buffer view in JS-land
+  without copying.
+- Both the global form (`Buffer.from(...)`) and the import form
+  (`import { Buffer } from "node:buffer"`) resolve to the same host class.
+
+## Implementation approach
+
+1. Recognise the global identifier `Buffer` in codegen as an extern class
+   (same machinery as `Date`), so static calls `Buffer.from` / `Buffer.alloc`
+   / `Buffer.concat` lower to host imports.
+2. Map `Buffer.prototype.{toString, slice, write, readUInt8, ...}` to
+   externref method dispatch via `__extern_method_call`.
+3. Provide a thin `Uint8Array` ↔ `Buffer` bridge so Wasm-side typed arrays can
+   cross the host boundary as Buffer views without a copy (see #983 for the
+   round-trip-argument hazard with stream callbacks).
+4. The encoding matrix (latin1/base64/hex/ucs2 …) is the long tail — Tier 0
+   covers utf-8 + byte-array only; remaining encodings are a follow-up.
+5. Standalone (WASI) Buffer is out of scope here — track alongside #1471/#1472.
+
+## Test
+
+`tests/issue-1793.test.ts` — compile each Tier 0 snippet under JS-host config
+and assert against the host's native `Buffer`.

--- a/plan/issues/1794-node-events-builtin-impl.md
+++ b/plan/issues/1794-node-events-builtin-impl.md
@@ -1,0 +1,67 @@
+---
+id: 1794
+title: "node:events / EventEmitter — host class + closure-callback contract"
+status: ready
+sprint: Backlog
+created: 2026-06-03
+updated: 2026-06-03
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+parent: 1575
+related: [1044, 1032, 1382, 983, 640]
+---
+# node:events / EventEmitter — host class + closure-callback contract
+
+## Problem
+
+`EventEmitter` is the universal Node IO primitive — `fs.createReadStream`,
+`http.IncomingMessage`, and `process` itself are all EventEmitters (#1575
+matrix: blocks essentially all Node IO code). Subscribing from compiled code
+requires passing a Wasm closure as a host-side callback. The `__extern_method_call`
+path can pass closures (#1382 wasm-closure JS bridge), but the receiver expects
+a `(arg) => ...` JS shape and the argument types (Buffer, Error) must round-trip
+cleanly (see #983). Today `node:events` is the opaque `__node_events` externref
+with no first-class EventEmitter recognition.
+
+## Acceptance criteria
+
+Tier 0 (JS-host target):
+
+```ts
+import { EventEmitter } from "node:events";
+const e = new EventEmitter();
+let got = 0;
+e.on("tick", (n: number) => { got = n; });
+e.emit("tick", 42); // got === 42
+```
+
+- `e.once(...)` fires exactly once.
+- `e.off(...)` / `removeListener` unsubscribes.
+- Both global-less import form and `events.EventEmitter` member form resolve to
+  the same host class.
+
+## Implementation approach
+
+1. Bind `EventEmitter` as a host-import constructor (extern class, `Date`
+   pattern).
+2. Establish the **closure-callback round-trip contract**: `e.on(name, fn)`
+   must register the compiled `fn` as a JS-callable that, when the host fires
+   it, marshals the event argument back across the boundary (numbers, strings
+   for Tier 0; Buffer/Error round-trip is the long pole — coordinate with
+   #1793 Buffer and #983).
+3. Standalone fallback is feasible later (EventEmitter is ~200 lines of pure
+   JS) — defer to a follow-up, but design the callback contract so it does not
+   assume a JS host.
+4. This unblocks the http Tier 0 (#1795) which consumes response streams via
+   `EventEmitter`, and exercises the same callback wiring #640 (WASI HTTP) will
+   need.
+
+## Test
+
+`tests/issue-1794.test.ts` — compile the Tier 0 snippet under JS-host config
+and assert `got === 42` plus once/off behavior.

--- a/plan/issues/1795-node-http-builtin-impl.md
+++ b/plan/issues/1795-node-http-builtin-impl.md
@@ -1,0 +1,68 @@
+---
+id: 1795
+title: "node:http (+ https) — GET round-trip host import (axios unblocker)"
+status: ready
+sprint: Backlog
+created: 2026-06-03
+updated: 2026-06-03
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+parent: 1575
+related: [1044, 1032, 640, 1500]
+depends_on: [1793, 1794]
+---
+# node:http (+ https) — GET round-trip host import (axios unblocker)
+
+## Problem
+
+axios (#1032, high priority) is the highest-value real-world target on the
+backlog and it requires `node:http`/`node:https`. Today both are the opaque
+`__node_http` / `__node_https` externref imports: `http.createServer` /
+`http.get` lower through `__extern_method_call`, but the response is an
+`EventEmitter` stream the compiled code cannot consume (no first-class
+EventEmitter — see #1794) and bodies are `Buffer`s the compiled code cannot
+unpack (no first-class Buffer — see #1793).
+
+## Acceptance criteria
+
+Tier 0 (JS-host target) — a single GET → string round-trip:
+
+```ts
+import { get } from "node:http";
+function fetchText(url: string, cb: (s: string) => void): void {
+  get(url, (res) => {
+    let body = "";
+    res.on("data", (chunk: any) => { body += chunk.toString(); });
+    res.on("end", () => cb(body));
+  });
+}
+```
+
+- Compiles, instantiates, and against a localhost test server returns the
+  served body string through `cb`.
+- `import { get } from "node:https"` resolves the same way (TLS plumbing is the
+  host's; no extra Wasm surface).
+
+## Implementation approach
+
+1. **Depends on #1793 (Buffer) and #1794 (EventEmitter)** — the response
+   `.on("data", chunk => chunk.toString())` chain needs both. Land those first.
+2. Wire `http.get` / `http.request` as host imports that return an
+   EventEmitter-shaped response object (reusing the #1794 callback contract).
+3. This is the natural place to land the **bidirectional host-import
+   contract**: Wasm passes a request descriptor out, host returns a response
+   stream, Wasm reads via EventEmitter.
+4. `createServer` and the full IncomingMessage/ServerResponse class surface are
+   out of scope for Tier 0 (client GET only).
+5. Standalone HTTP belongs to #640 (wasi:http/incoming-handler) — out of scope
+   here; browser fetch is the parallel #1500 track.
+
+## Test
+
+`tests/issue-1795.test.ts` — spin up a localhost server, compile the Tier 0
+`fetchText`, assert the returned body. Gate behind #1793 + #1794 landing.


### PR DESCRIPTION
Finalizes the \#1575 Node.js built-in module gap survey (was `status: in-review`).

## What this does

- **Verifies the matrix** against current `main`: `NODE_BUILTIN_MODULES` (src/import-resolver.ts:16-50) still has 33 entries; `registerNodeBuiltinImports` (src/codegen/index.ts:9801) still emits one opaque `__node_<module>: () -> externref` per builtin; only `crypto.randomBytes/randomUUID` + `fs.readFileSync/writeFileSync` have typed-fn stubs. No row changed level since 2026-06-02 — no matrix edits needed.
- **Files top-5 child issues** for the highest-leverage `None` builtins (ranked by the survey's blocked-package signal):
  - #6401 `node:path` — pure compute, standalone-feasible; blocks ESLint/prettier/axios/TS
  - #6402 `node:url` — URL/URLSearchParams host constructors
  - #6403 `node:buffer` + global `Buffer` — underlies http/fs/crypto bodies
  - #6404 `node:events`/`EventEmitter` — universal IO primitive + closure-callback contract
  - #6405 `node:http` (+https) — axios GET round-trip; `depends_on: [6403, 6404]`
- Each child has problem + Tier 0 acceptance criteria + implementation approach.
- Sets #1575 `status: done` with a `## Completion Summary`.

Docs/triage only — no compiler source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)