### PR TITLE
infra(#1081): index test262 runs by commit hash for merge-base diffs

### DIFF
--- a/.github/workflows/test262-cache-prune.yml
+++ b/.github/workflows/test262-cache-prune.yml
@@ -1,0 +1,87 @@
+# #1081 — Weekly retention prune for the commit-hash-indexed test262 run cache.
+#
+# The promote-baseline job (test262-sharded.yml) writes runs/<sha>.{json,jsonl}
+# into the loopdive/js2wasm-baselines repo on every push to main. Without
+# pruning, that directory grows unbounded (~1.5 MB per run). This workflow
+# applies the retention policy from plan/issues/1081-index-test262-runs-by-commit.md:
+#   - keep sprint-tagged commits forever
+#   - keep entries newer than 30 days
+#   - evict older non-tagged entries
+#   - LRU-evict oldest survivors once total exceeds the 500 MB cap
+#
+# Runs weekly (and on demand). Commits the cleanup back to the baselines repo.
+name: test262 run-cache prune (#1081)
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List evictions without deleting"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo (for sprint tags + prune script)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # need tags to derive sprint-tagged SHAs
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+
+      - name: Clone baselines repo
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git clone --depth=1 git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
+
+      - name: Derive sprint-tagged SHAs (kept forever)
+        id: keep
+        run: |
+          # Collect the full 40-char SHA for every sprint/* tag. These run-cache
+          # entries are immune to eviction so historical sprint comparisons and
+          # retroactive bisect stay possible.
+          KEEP=$(git tag -l 'sprint/*' 'sprint-*/begin' | while read -r t; do
+            git rev-parse "$t^{commit}" 2>/dev/null
+          done | sort -u | paste -sd, -)
+          echo "shas=$KEEP" >> "$GITHUB_OUTPUT"
+          echo "Sprint-tagged SHAs to keep: ${KEEP:-<none>}"
+
+      - name: Prune run cache
+        run: |
+          DRY="${{ inputs.dry_run }}"
+          ARGS="--runs-dir /tmp/js2wasm-baselines/runs --keep-shas '${{ steps.keep.outputs.shas }}'"
+          if [ "$DRY" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          eval node scripts/prune-run-cache.mjs $ARGS
+
+      - name: Commit and push cleanup
+        if: ${{ inputs.dry_run != true }}
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          cd /tmp/js2wasm-baselines
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No run-cache entries pruned."
+          else
+            git commit -m "chore(test262): prune commit-hash run cache (#1081)"
+            git push
+          fi

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -656,6 +656,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # #1081 — need full history + the test262 submodule SHA so we can
+          # resolve the PR's merge-base and read the current test262 version
+          # for the hash-indexed cache lookup below.
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -702,6 +708,31 @@ jobs:
             echo "baseline_ts=0" >> "$GITHUB_OUTPUT"
             echo "baseline_sha=unknown" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Load cached baseline for merge-base (#1081)
+        id: merge_base_cache
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: |
+          # #1081 — prefer the hash-indexed run cache for the PR's merge-base
+          # over the moving "latest main" pointer fetched above. On a cache HIT
+          # this overwrites benchmarks/results/test262-current.jsonl with the
+          # merge-base's exact results, so the regression diff attributes only
+          # the PR's own commits. On a MISS it leaves the latest-main baseline
+          # in place and warns. Never fails the build.
+          if [ ! -d /tmp/js2wasm-baselines/runs ]; then
+            echo "::warning::#1081 baselines clone has no runs/ dir yet — using latest-main baseline."
+            echo "cache=miss" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || echo "")
+          TEST262_VERSION=$(git submodule status test262 2>/dev/null | awk '{print $1}' | tr -d '+-' || echo "")
+          echo "Merge-base: ${MERGE_BASE:-<unknown>}; test262 version: ${TEST262_VERSION:-<unknown>}"
+          node scripts/resolve-merge-base-baseline.mjs \
+            --baselines-dir /tmp/js2wasm-baselines \
+            --merge-base "$MERGE_BASE" \
+            --test262-version "$TEST262_VERSION" \
+            --dest benchmarks/results/test262-current.jsonl || \
+            echo "::warning::#1081 merge-base resolution errored (non-fatal); keeping latest-main baseline."
 
       - name: Check baseline staleness (#1235)
         id: staleness
@@ -952,6 +983,21 @@ jobs:
             console.log('Skipped duplicate entry (same pass/total as last run)');
           }
           "
+
+          # #1081 — write the commit-hash-indexed run cache entry. This lets a
+          # PR's regression-gate diff against main *at the PR's merge-base*
+          # instead of the moving "latest main" pointer, eliminating drift
+          # attribution. The summary carries test262_version so a stale-corpus
+          # entry can be rejected on read.
+          TEST262_VERSION=$(git -C "${{ github.workspace }}" submodule status test262 2>/dev/null | awk '{print $1}' | tr -d '+-' || echo "")
+          node scripts/write-run-cache.mjs \
+            --report /tmp/js2wasm-baselines/test262-current.json \
+            --jsonl  /tmp/js2wasm-baselines/test262-current.jsonl \
+            --sha    "${{ github.sha }}" \
+            --runs-dir /tmp/js2wasm-baselines/runs \
+            --ref    "${{ github.ref }}" \
+            --run-id "${{ github.run_id }}" \
+            --test262-version "$TEST262_VERSION" || echo "::warning::#1081 run-cache write failed (non-fatal)"
 
           # Commit and push to baselines repo
           cd /tmp/js2wasm-baselines

--- a/benchmarks/runs/README.md
+++ b/benchmarks/runs/README.md
@@ -1,0 +1,85 @@
+# Commit-hash-indexed test262 run cache (#1081)
+
+> **Where the data lives:** the `<sha>.{json,jsonl}` files described here are
+> stored in the **`loopdive/js2wasm-baselines`** repo under `runs/`, *not* in
+> this main repo. This directory holds only the docs. Keeping the cache out of
+> the main repo avoids bloating every clone (each run is ~1.5 MB; ~150 retained
+> ≈ 225 MB). See [`CLAUDE.md` → Baseline files](../../CLAUDE.md) for how the
+> baselines repo is wired.
+
+## Why this exists
+
+A PR's regression-gate must compare its test262 results against **main at the
+PR's merge-base commit** — not against a moving "latest main" pointer. When the
+single `test262-current.jsonl` baseline drifts between its last refresh and a
+PR's CI run, tests that flipped on main since then show up as PR-caused
+regressions even though the PR didn't touch them.
+
+This cache eliminates that drift: every push to main writes the run's results
+keyed by the commit SHA they were produced against, so a PR can load the exact
+baseline for its merge-base. Reported regressions become precisely
+`results(merge-base) → results(HEAD)`.
+
+## Layout
+
+```
+runs/index.json          — trend-graph history (unchanged; never pruned)
+runs/<commit-sha>.json   — summary: pass/fail/CE counts, run metadata, per-category breakdown
+runs/<commit-sha>.jsonl  — per-test results for that commit
+```
+
+`<commit-sha>` is `github.sha` of main at the time the sharded run ran.
+
+### `<sha>.json` schema
+
+```jsonc
+{
+  "sha": "ef179253b...",
+  "ref": "refs/heads/main",
+  "pass": 30214, "fail": 11775, "compile_error": 1124,
+  "compile_timeout": 4, "skip": 18, "total": 43135,
+  "strict_pass": 9000, "strict_total": 12000,
+  "run_id": "24289351335",
+  "run_started_at": null,
+  "run_duration_seconds": null,
+  "test262_version": "<test262-submodule-sha>",  // guards against stale-corpus cache hits
+  "categories": { "language/statements/for-of": { "pass": 134, "fail": 12, "compile_error": 0, "total": 146 }, ... }
+}
+```
+
+The per-category breakdown enables fast diff queries without loading the 1.5 MB
+jsonl.
+
+## How it flows
+
+1. **Write** — `promote-baseline` (`.github/workflows/test262-sharded.yml`)
+   calls `scripts/write-run-cache.mjs` after refreshing the latest-main
+   baseline, writing `runs/<github.sha>.{json,jsonl}` into the baselines repo.
+   Corrupt reports (pass < 1000 or total < 40000) are declined, never written.
+2. **Read** — the PR `regression-gate` job calls
+   `scripts/resolve-merge-base-baseline.mjs`: it computes
+   `git merge-base origin/main HEAD`, and if `runs/<merge-base>.jsonl` exists
+   **and** its `test262_version` matches the PR's test262 submodule, it uses
+   that as the diff baseline. Otherwise it warns (cache MISS) and falls back to
+   the latest-main `test262-current.jsonl`. A miss never fails the build.
+3. **Prune** — `.github/workflows/test262-cache-prune.yml` runs weekly:
+   sprint-tagged commits are kept forever; entries older than 30 days are
+   evicted; once total exceeds 500 MB the oldest survivors are LRU-evicted.
+
+## Non-goals
+
+- This cache is **main-only** — PR-branch runs are ephemeral and never cached.
+- It is **not required for correctness**: a miss falls back to the prior
+  behavior. The cache is a performance + drift-elimination enhancement.
+- `test262-current.jsonl` stays as the human-readable "latest main" pointer; the
+  hash-indexed files are authoritative for merge-base diffs.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| `scripts/write-run-cache.mjs` | Build `<sha>.json` + copy `<sha>.jsonl` (promote-baseline). |
+| `scripts/resolve-merge-base-baseline.mjs` | Pick merge-base cache entry vs. latest-main fallback (PR gate). |
+| `scripts/prune-run-cache.mjs` | Apply retention policy (weekly prune). |
+
+Unit tests: `tests/issue-1081.test.ts`.

--- a/plan/issues/1081-index-test262-runs-by-commit.md
+++ b/plan/issues/1081-index-test262-runs-by-commit.md
@@ -1,9 +1,10 @@
 ---
 id: 1081
 title: "Index test262 runs by commit hash — enable merge-base comparisons without re-running"
-status: ready
+status: done
+completed: 2026-06-03
 created: 2026-04-11
-updated: 2026-04-11
+updated: 2026-06-03
 priority: critical
 feasibility: medium
 reasoning_effort: medium
@@ -200,3 +201,36 @@ without loading the full 1.5 MB jsonl.
   on historical commits.
 - Every PR that touches code but isn't the merge-base itself benefits
   from this cache automatically — no dev workflow changes required.
+
+## Implementation note — 2026-06-03
+
+Shipped as three pure, unit-tested Node helpers plus workflow wiring; the
+cache physically lives in the `loopdive/js2wasm-baselines` repo (out of the
+main repo to avoid clone bloat), consistent with the existing baseline-JSONL
+split (#1528).
+
+- `scripts/write-run-cache.mjs` — builds `runs/<sha>.json` (summary + per-
+  category breakdown + `test262_version`) and copies `runs/<sha>.jsonl`.
+  Declines corrupt reports (pass < 1000 or total < 40000). Called from the
+  `promote-baseline` job after the `runs/index.json` update.
+- `scripts/resolve-merge-base-baseline.mjs` — in the PR `regression-gate` job,
+  computes `git merge-base origin/main HEAD`, and on a cache hit (entry exists
+  AND its `test262_version` matches the PR's submodule) overwrites
+  `benchmarks/results/test262-current.jsonl` with the merge-base's exact
+  results. A miss warns (`::warning::#1081 … MISS`) and keeps the latest-main
+  baseline — never fails the build. The `regression-gate` checkout was changed
+  to `fetch-depth: 0` + `submodules: recursive` so merge-base + test262 version
+  are resolvable.
+- `scripts/prune-run-cache.mjs` + `.github/workflows/test262-cache-prune.yml`
+  — weekly retention: sprint-tagged SHAs (derived from `sprint/*` /
+  `sprint-*/begin` tags) kept forever; non-tagged entries older than 30 days
+  evicted; LRU eviction once total exceeds the 500 MB cap.
+- `benchmarks/runs/README.md` documents the layout, schema, flow, and policy.
+- Unit tests: `tests/issue-1081.test.ts` (11 tests, green) cover summary build,
+  corrupt-report rejection, cache hit/miss/version-mismatch, and the eviction
+  planner (age, sprint-pin immunity, LRU cap). End-to-end smoke of all three
+  scripts against a synthetic baselines dir confirmed hit/miss/prune behavior.
+
+`diff-test262.ts` was left untouched (it already takes two arbitrary JSONL
+files — per the non-goals). #1077 is now redundant per the issue's Relationship
+section and can be closed separately.

--- a/scripts/prune-run-cache.mjs
+++ b/scripts/prune-run-cache.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1081 — Retention prune for the commit-hash-indexed test262 run cache.
+//
+// Operates on a baselines-repo `runs/` directory containing `<sha>.json` +
+// `<sha>.jsonl` pairs (plus `index.json`, which is never pruned). Policy
+// (per plan/issues/1081-index-test262-runs-by-commit.md §Retention):
+//
+//   - Keep: entries whose commit is sprint-tagged (passed via --keep-shas),
+//     forever.
+//   - Keep: entries newer than --max-age-days (default 30).
+//   - Evict: entries older than --max-age-days that are NOT sprint-tagged.
+//   - Cap: after age eviction, if total size still exceeds --max-bytes
+//     (default 500 MB), evict oldest-first (LRU by file mtime) until under cap,
+//     skipping --keep-shas.
+//
+// This script only removes files; committing the cleanup is the workflow's job.
+//
+// Usage:
+//   node scripts/prune-run-cache.mjs --runs-dir <dir> \
+//     [--max-age-days 30] [--max-bytes 524288000] \
+//     [--keep-shas <sha1,sha2,...>] [--dry-run]
+
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      args[key] = val;
+    }
+  }
+  return args;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute which SHA entries to evict. Pure function over an entry list for
+ * unit testing; the caller supplies entries with { sha, bytes, mtimeMs }.
+ *
+ * @returns {string[]} SHAs to evict
+ */
+export function planEvictions(entries, opts) {
+  const now = opts.now ?? Date.now();
+  const maxAgeMs = (opts.maxAgeDays ?? 30) * DAY_MS;
+  const maxBytes = opts.maxBytes ?? 500 * 1024 * 1024;
+  const keep = new Set(opts.keepShas ?? []);
+
+  const evict = new Set();
+
+  // Phase 1: age-based eviction (sprint-tagged entries are immune).
+  for (const e of entries) {
+    if (keep.has(e.sha)) continue;
+    if (now - e.mtimeMs > maxAgeMs) evict.add(e.sha);
+  }
+
+  // Phase 2: size cap — sum surviving entries, LRU-evict oldest until under cap.
+  const survivors = entries.filter((e) => !evict.has(e.sha)).sort((a, b) => a.mtimeMs - b.mtimeMs); // oldest first
+  let total = survivors.reduce((sum, e) => sum + e.bytes, 0);
+  for (const e of survivors) {
+    if (total <= maxBytes) break;
+    if (keep.has(e.sha)) continue;
+    evict.add(e.sha);
+    total -= e.bytes;
+  }
+
+  return [...evict];
+}
+
+function collectEntries(runsDir) {
+  const files = readdirSync(runsDir);
+  const bySha = new Map();
+  for (const f of files) {
+    const m = /^([0-9a-f]{7,40})\.(json|jsonl)$/.exec(f);
+    if (!m) continue;
+    const sha = m[1];
+    const full = join(runsDir, f);
+    const st = statSync(full);
+    const cur = bySha.get(sha) ?? { sha, bytes: 0, mtimeMs: 0, files: [] };
+    cur.bytes += st.size;
+    cur.mtimeMs = Math.max(cur.mtimeMs, st.mtimeMs);
+    cur.files.push(full);
+    bySha.set(sha, cur);
+  }
+  return [...bySha.values()];
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const runsDir = args["runs-dir"];
+  if (!runsDir || !existsSync(runsDir)) {
+    console.log(`prune-run-cache: runs dir ${runsDir} missing — nothing to prune.`);
+    process.exit(0);
+  }
+  const dryRun = args["dry-run"] === "true" || args["dry-run"] === true;
+  const keepShas = (args["keep-shas"] && args["keep-shas"] !== "true" ? args["keep-shas"] : "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const entries = collectEntries(runsDir);
+  const evictShas = new Set(
+    planEvictions(entries, {
+      maxAgeDays: args["max-age-days"] ? Number(args["max-age-days"]) : 30,
+      maxBytes: args["max-bytes"] ? Number(args["max-bytes"]) : undefined,
+      keepShas,
+    }),
+  );
+
+  let freed = 0;
+  for (const e of entries) {
+    if (!evictShas.has(e.sha)) continue;
+    for (const f of e.files) {
+      freed += statSync(f).size;
+      if (!dryRun) rmSync(f);
+    }
+    console.log(`${dryRun ? "[dry-run] would evict" : "evicted"} run cache entry ${e.sha}`);
+  }
+  const remaining = entries.length - evictShas.size;
+  console.log(
+    `prune-run-cache: ${evictShas.size} entries ${dryRun ? "would be " : ""}evicted (${(freed / 1024 / 1024).toFixed(1)} MB), ${remaining} retained.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/resolve-merge-base-baseline.mjs
+++ b/scripts/resolve-merge-base-baseline.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1081 — Resolve which test262 baseline JSONL a PR's regression-gate should
+// diff against, preferring the commit-hash-indexed cache entry for the PR's
+// merge-base over the moving "latest main" pointer.
+//
+// Logic:
+//   1. Given the merge-base SHA and a checkout of the baselines repo, look for
+//      runs/<merge-base-sha>.jsonl + runs/<merge-base-sha>.json.
+//   2. Cache HIT: the entry's test262_version must match the current
+//      submodule SHA (else the baseline is for a different test262 corpus and
+//      would shadow real regressions — spec §Risks: cache shadowing). On a
+//      match, emit the cached jsonl as the baseline.
+//   3. Cache MISS (or version mismatch): fall back to test262-current.jsonl,
+//      print a warning so cache-miss frequency is observable.
+//
+// Output: prints `baseline_path=<abs>` and `cache=hit|miss` to GITHUB_OUTPUT
+// when present, and always echoes a human-readable line to stdout. Never
+// fails the build — a miss is a performance regression, not a correctness one.
+//
+// Usage:
+//   node scripts/resolve-merge-base-baseline.mjs \
+//     --baselines-dir /tmp/js2wasm-baselines \
+//     --merge-base <sha> \
+//     [--test262-version <submodule-sha>] \
+//     [--dest benchmarks/results/test262-current.jsonl]
+
+import { appendFileSync, copyFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      args[key] = val;
+    }
+  }
+  return args;
+}
+
+function emitOutput(key, value) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) appendFileSync(out, `${key}=${value}\n`);
+}
+
+/**
+ * Decide whether the cached entry for `mergeBase` is usable.
+ * Exported for unit testing.
+ *
+ * @returns {{ hit: boolean; reason: string }}
+ */
+export function evaluateCacheEntry(baselinesDir, mergeBase, currentTest262Version) {
+  const jsonlPath = join(baselinesDir, "runs", `${mergeBase}.jsonl`);
+  const jsonPath = join(baselinesDir, "runs", `${mergeBase}.json`);
+  if (!mergeBase || !existsSync(jsonlPath)) {
+    return { hit: false, reason: "no cache entry for merge-base" };
+  }
+  // Version guard: only honor the cache when the test262 corpus matches.
+  if (currentTest262Version && existsSync(jsonPath)) {
+    try {
+      const meta = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      if (meta.test262_version && meta.test262_version !== currentTest262Version) {
+        return {
+          hit: false,
+          reason: `cache test262_version ${meta.test262_version} != current ${currentTest262Version}`,
+        };
+      }
+    } catch {
+      return { hit: false, reason: "cache summary JSON unreadable" };
+    }
+  }
+  return { hit: true, reason: "merge-base cache entry present and version-compatible" };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const baselinesDir = args["baselines-dir"];
+  const mergeBase = args["merge-base"] && args["merge-base"] !== "true" ? args["merge-base"] : "";
+  const test262Version = args["test262-version"] && args["test262-version"] !== "true" ? args["test262-version"] : "";
+  const dest = args.dest && args.dest !== "true" ? args.dest : "benchmarks/results/test262-current.jsonl";
+
+  if (!baselinesDir) {
+    console.error(
+      "usage: resolve-merge-base-baseline.mjs --baselines-dir <dir> --merge-base <sha> [--test262-version <sha>] [--dest <path>]",
+    );
+    process.exit(2);
+  }
+
+  const { hit, reason } = evaluateCacheEntry(baselinesDir, mergeBase, test262Version);
+
+  if (hit) {
+    const cached = join(baselinesDir, "runs", `${mergeBase}.jsonl`);
+    copyFileSync(cached, dest);
+    console.log(`#1081 merge-base cache HIT: using runs/${mergeBase}.jsonl as baseline (${reason}).`);
+    emitOutput("cache", "hit");
+    emitOutput("baseline_path", dest);
+    return;
+  }
+
+  // Miss: leave whatever the prior fetch step already placed at `dest`
+  // (test262-current.jsonl). Warn so cache-miss frequency is trackable.
+  console.log(
+    `::warning::#1081 merge-base cache MISS (${reason}); falling back to latest-main baseline. Drift attribution may be imprecise for this PR.`,
+  );
+  emitOutput("cache", "miss");
+  emitOutput("baseline_path", dest);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/write-run-cache.mjs
+++ b/scripts/write-run-cache.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1081 — Write a commit-hash-indexed test262 run cache entry.
+//
+// Given a merged test262 report JSON, a merged results JSONL, and the commit
+// SHA the run was performed against, this writes two side-files into the
+// baselines repo's `runs/` directory:
+//
+//   runs/<sha>.json   — summary (pass/fail/CE counts, run metadata, categories)
+//   runs/<sha>.jsonl  — per-test results (copied verbatim)
+//
+// These hash-indexed files let a PR's CI compare against main *at the PR's
+// merge-base commit* instead of against a moving "latest main" pointer,
+// eliminating drift attribution. See plan/issues/1081-index-test262-runs-by-commit.md.
+//
+// Usage:
+//   node scripts/write-run-cache.mjs \
+//     --report  <merged-report.json> \
+//     --jsonl   <merged-results.jsonl> \
+//     --sha     <commit-sha> \
+//     --runs-dir <baselines-repo>/runs \
+//     [--ref refs/heads/main] \
+//     [--run-id 123] [--run-started-at ISO] [--run-duration-seconds N] \
+//     [--test262-version <submodule-sha>]
+//
+// Exit codes:
+//   0 — cache entry written (or intentionally skipped as corrupt)
+//   2 — bad arguments / filesystem error
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      args[key] = val;
+    }
+  }
+  return args;
+}
+
+// Reject obviously-corrupt reports so a bad run never poisons the cache that
+// every subsequent merge-base PR diff would trust (spec §Risks: cache corruption).
+const MIN_PASS = 1000;
+const MIN_TOTAL = 40000;
+
+/**
+ * Build the summary object written to runs/<sha>.json.
+ * Exported for unit testing.
+ */
+export function buildRunSummary(report, meta) {
+  const s = report.summary ?? {};
+  const strict = report.strict_summary ?? {};
+  const categories = {};
+  // The report's `categories` map is { "<path>": { pass, fail, total, ... } }.
+  // Persist it verbatim (minus any nested noise) so merge-base diffs can do
+  // fast per-category queries without loading the 1.5 MB jsonl.
+  for (const [k, v] of Object.entries(report.categories ?? {})) {
+    if (v && typeof v === "object") {
+      categories[k] = {
+        pass: v.pass ?? 0,
+        fail: v.fail ?? 0,
+        compile_error: v.compile_error ?? 0,
+        total: v.total ?? 0,
+      };
+    }
+  }
+  return {
+    sha: meta.sha,
+    ref: meta.ref ?? "refs/heads/main",
+    pass: s.pass ?? 0,
+    fail: s.fail ?? 0,
+    compile_error: s.compile_error ?? 0,
+    compile_timeout: s.compile_timeout ?? 0,
+    skip: s.skip ?? 0,
+    total: s.total ?? 0,
+    strict_pass: strict.pass ?? 0,
+    strict_total: strict.total ?? 0,
+    run_id: meta.runId ?? null,
+    run_started_at: meta.runStartedAt ?? null,
+    run_duration_seconds: meta.runDurationSeconds ?? null,
+    test262_version: meta.test262Version ?? null,
+    categories,
+  };
+}
+
+export function isCorrupt(summary) {
+  return summary.pass < MIN_PASS || summary.total < MIN_TOTAL;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reportPath = args.report;
+  const jsonlPath = args.jsonl;
+  const sha = args.sha;
+  const runsDir = args["runs-dir"];
+
+  if (!reportPath || !jsonlPath || !sha || !runsDir) {
+    console.error(
+      "usage: write-run-cache.mjs --report <json> --jsonl <jsonl> --sha <sha> --runs-dir <dir> [--ref ...] [--run-id ...] [--run-started-at ...] [--run-duration-seconds ...] [--test262-version ...]",
+    );
+    process.exit(2);
+  }
+  if (!existsSync(reportPath) || !existsSync(jsonlPath)) {
+    console.error(`write-run-cache: missing input (report=${reportPath} jsonl=${jsonlPath})`);
+    process.exit(2);
+  }
+
+  const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+  const summary = buildRunSummary(report, {
+    sha,
+    ref: args.ref,
+    runId: args["run-id"] === "true" ? null : args["run-id"],
+    runStartedAt: args["run-started-at"] === "true" ? null : args["run-started-at"],
+    runDurationSeconds:
+      args["run-duration-seconds"] && args["run-duration-seconds"] !== "true"
+        ? Number(args["run-duration-seconds"])
+        : null,
+    test262Version: args["test262-version"] === "true" ? null : args["test262-version"],
+  });
+
+  if (isCorrupt(summary)) {
+    console.error(
+      `write-run-cache: report looks corrupt (pass=${summary.pass} total=${summary.total}); not writing cache entry for ${sha}.`,
+    );
+    // Exit 0: a corrupt run is not a CI failure here — the promote step has
+    // its own abort guard; we simply decline to poison the hash cache.
+    process.exit(0);
+  }
+
+  mkdirSync(runsDir, { recursive: true });
+  const jsonOut = join(runsDir, `${sha}.json`);
+  const jsonlOut = join(runsDir, `${sha}.jsonl`);
+  writeFileSync(jsonOut, JSON.stringify(summary, null, 2));
+  copyFileSync(jsonlPath, jsonlOut);
+  console.log(`write-run-cache: wrote ${jsonOut} and ${jsonlOut} (pass=${summary.pass}/${summary.total}).`);
+}
+
+// Only run main() when invoked directly, not when imported for tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/issue-1081.test.ts
+++ b/tests/issue-1081.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1081 — commit-hash-indexed test262 run cache.
+//
+// Unit tests for the pure helpers that back the workflow steps:
+//   - buildRunSummary / isCorrupt (write-run-cache.mjs)
+//   - evaluateCacheEntry (resolve-merge-base-baseline.mjs)
+//   - planEvictions (prune-run-cache.mjs)
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildRunSummary, isCorrupt } from "../scripts/write-run-cache.mjs";
+import { evaluateCacheEntry } from "../scripts/resolve-merge-base-baseline.mjs";
+import { planEvictions } from "../scripts/prune-run-cache.mjs";
+
+describe("#1081 write-run-cache buildRunSummary", () => {
+  const report = {
+    summary: { total: 43135, pass: 30214, fail: 11775, compile_error: 1124, compile_timeout: 4, skip: 18 },
+    strict_summary: { pass: 9000, total: 12000 },
+    categories: {
+      "language/statements/for-of": { pass: 134, fail: 12, compile_error: 0, total: 146 },
+      "built-ins/Array": { pass: 500, fail: 50, compile_error: 5, total: 555 },
+    },
+  };
+
+  it("captures summary counts and metadata keyed by sha", () => {
+    const s = buildRunSummary(report, {
+      sha: "ef179253babc",
+      ref: "refs/heads/main",
+      runId: "24289351335",
+      runStartedAt: "2026-04-11T17:55:12Z",
+      runDurationSeconds: 320,
+      test262Version: "63829c6d925e",
+    });
+    expect(s.sha).toBe("ef179253babc");
+    expect(s.pass).toBe(30214);
+    expect(s.total).toBe(43135);
+    expect(s.compile_error).toBe(1124);
+    expect(s.strict_pass).toBe(9000);
+    expect(s.run_id).toBe("24289351335");
+    expect(s.test262_version).toBe("63829c6d925e");
+  });
+
+  it("persists a per-category breakdown for fast diffs", () => {
+    const s = buildRunSummary(report, { sha: "abc1234" });
+    expect(s.categories["language/statements/for-of"]).toEqual({
+      pass: 134,
+      fail: 12,
+      compile_error: 0,
+      total: 146,
+    });
+  });
+
+  it("flags corrupt reports below the sanity floor", () => {
+    expect(isCorrupt(buildRunSummary({ summary: { pass: 10, total: 100 } }, { sha: "x" }))).toBe(true);
+    expect(isCorrupt(buildRunSummary(report, { sha: "x" }))).toBe(false);
+  });
+});
+
+describe("#1081 resolve-merge-base-baseline evaluateCacheEntry", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rc-"));
+    mkdirSync(join(dir, "runs"), { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const sha = "deadbeef1234";
+
+  function writeEntry(test262Version?: string) {
+    writeFileSync(join(dir, "runs", `${sha}.jsonl`), '{"test":"a","result":"pass"}\n');
+    writeFileSync(
+      join(dir, "runs", `${sha}.json`),
+      JSON.stringify({ sha, pass: 30000, total: 43000, test262_version: test262Version ?? null }),
+    );
+  }
+
+  it("HIT when the merge-base entry exists and versions match", () => {
+    writeEntry("v262");
+    expect(evaluateCacheEntry(dir, sha, "v262")).toEqual({
+      hit: true,
+      reason: expect.stringContaining("present"),
+    });
+  });
+
+  it("MISS when no entry exists for the merge-base", () => {
+    expect(evaluateCacheEntry(dir, "nonexistent", "v262").hit).toBe(false);
+  });
+
+  it("MISS when the cached test262_version differs from current", () => {
+    writeEntry("v261");
+    const r = evaluateCacheEntry(dir, sha, "v262");
+    expect(r.hit).toBe(false);
+    expect(r.reason).toContain("test262_version");
+  });
+
+  it("HIT when no version is supplied (version guard is opt-in)", () => {
+    writeEntry("v261");
+    expect(evaluateCacheEntry(dir, sha, "").hit).toBe(true);
+  });
+});
+
+describe("#1081 prune-run-cache planEvictions", () => {
+  const now = Date.parse("2026-06-03T00:00:00Z");
+  const daysAgo = (n: number) => now - n * 24 * 60 * 60 * 1000;
+  const MB = 1024 * 1024;
+
+  it("evicts entries older than max-age but keeps recent ones", () => {
+    const entries = [
+      { sha: "recent", bytes: 1 * MB, mtimeMs: daysAgo(5) },
+      { sha: "old", bytes: 1 * MB, mtimeMs: daysAgo(40) },
+    ];
+    const evict = planEvictions(entries, { now, maxAgeDays: 30, maxBytes: 500 * MB });
+    expect(evict).toEqual(["old"]);
+  });
+
+  it("never evicts sprint-tagged shas even when old", () => {
+    const entries = [{ sha: "sprintcommit", bytes: 1 * MB, mtimeMs: daysAgo(400) }];
+    const evict = planEvictions(entries, { now, maxAgeDays: 30, keepShas: ["sprintcommit"] });
+    expect(evict).toEqual([]);
+  });
+
+  it("LRU-evicts oldest survivors when over the byte cap", () => {
+    const entries = [
+      { sha: "a", bytes: 200 * MB, mtimeMs: daysAgo(3) },
+      { sha: "b", bytes: 200 * MB, mtimeMs: daysAgo(2) },
+      { sha: "c", bytes: 200 * MB, mtimeMs: daysAgo(1) },
+    ];
+    // 600 MB total, cap 500 MB → oldest ("a") evicted to get under.
+    const evict = planEvictions(entries, { now, maxAgeDays: 30, maxBytes: 500 * MB });
+    expect(evict).toEqual(["a"]);
+  });
+
+  it("keeps sprint-tagged shas even under cap pressure", () => {
+    const entries = [
+      { sha: "sprint", bytes: 400 * MB, mtimeMs: daysAgo(10) },
+      { sha: "newer", bytes: 200 * MB, mtimeMs: daysAgo(1) },
+    ];
+    // 600 MB, cap 500 MB. Oldest is the sprint commit but it is immune, so
+    // the next-oldest non-pinned ("newer") is evicted instead.
+    const evict = planEvictions(entries, { now, maxAgeDays: 30, maxBytes: 500 * MB, keepShas: ["sprint"] });
+    expect(evict).toEqual(["newer"]);
+  });
+});


### PR DESCRIPTION
## What

Implements #1081 — a commit-hash-indexed test262 run cache so a PR's regression-gate compares against **main at the PR's merge-base commit** instead of the moving "latest main" pointer. This eliminates drift attribution: reported regressions become exactly `results(merge-base) → results(HEAD)`.

The cache lives in the `loopdive/js2wasm-baselines` repo under `runs/` (out of the main repo, consistent with the #1528 baseline-JSONL split).

## Changes

- **`scripts/write-run-cache.mjs`** — `promote-baseline` writes `runs/<github.sha>.{json,jsonl}` after refreshing the latest-main baseline. The `.json` summary carries per-category counts + `test262_version`. Corrupt reports (pass < 1000 / total < 40000) are declined.
- **`scripts/resolve-merge-base-baseline.mjs`** — PR `regression-gate` computes `git merge-base origin/main HEAD`; on a version-compatible cache hit it diffs against that exact commit's results, else warns (`::warning::#1081 … MISS`) and falls back to latest-main. Never fails the build. The gate's checkout now uses `fetch-depth: 0` + `submodules: recursive`.
- **`scripts/prune-run-cache.mjs`** + **`.github/workflows/test262-cache-prune.yml`** — weekly retention: sprint-tagged SHAs kept forever, non-tagged entries >30d evicted, LRU eviction above the 500 MB cap.
- **`benchmarks/runs/README.md`** — layout, schema, flow, policy.

## Tests

- `tests/issue-1081.test.ts` — 11 unit tests (summary build, corrupt-report rejection, cache hit/miss/version-mismatch, eviction planner incl. age + sprint-pin immunity + LRU cap). All green.
- End-to-end smoke of all three scripts against a synthetic baselines dir confirmed hit/miss/prune behavior (cached merge-base baseline is used on a hit — the issue's synthetic-PR acceptance criterion).

`diff-test262.ts` untouched (per non-goals). #1077 becomes redundant per the issue's Relationship section.

Issue #1081 set to `status: done` in this PR (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)