### PR TITLE
test(#1782): pin standalone numeric/BigInt separator literal equality

### DIFF
--- a/plan/issues/1782-standalone-numeric-separator-literals-wrong-values.md
+++ b/plan/issues/1782-standalone-numeric-separator-literals-wrong-values.md
@@ -1,9 +1,10 @@
 ---
 id: 1782
 title: "standalone numeric and BigInt separator literals evaluate to wrong values"
-status: ready
+status: done
 created: 2026-06-02
-updated: 2026-06-02
+updated: 2026-06-03
+completed: 2026-06-03
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -80,3 +81,35 @@ re-parsing the token text.
 - Add focused regression coverage for binary, octal, hexadecimal, decimal,
   exponent, and BigInt separator literals.
 - Default JS-host mode does not regress on numeric separator literals.
+
+## Completion Summary (2026-06-03)
+
+**Root cause was NOT literal value lowering.** TypeScript resolves
+`NumericLiteral.text` to the already-decimal value (`0o0_1` → `.text === "1"`,
+`0x01_00` → `.text === "256"`), so `Number(text.replace(/_/g, ""))` in
+`src/codegen/expressions.ts` and the `BigInt(...)` path were always correct
+for every radix, uppercase prefix, exponent, and BigInt suffix. WAT dumps
+confirm correct constants: `0o0_1`→`1`, `0x01_00`→`256`, `1.0e+1_0`→`1e10`,
+`0x01_00n`→`256n`, `0b0_1n`→`1n`.
+
+**Actual defect:** the standalone `isSameValue` externref-equality path. The
+50 baseline failures (`returned 2` = the *second* `assert.sameValue`, which is
+the uppercase-prefix variant `0O…`/`0X…`/`0B…`) came from comparing two
+separator literals that were boxed to externref through the `any`-typed
+`assert.sameValue(actual, expected)` harness. The standalone externref `===`
+comparison emitted invalid/mismatched Wasm there.
+
+**Already fixed on current main** by #1776 (commit `1ff16008d` "standalone
+isSameValue externref equality emits invalid Wasm" + `554b116e4` "refresh
+externref equality late-import indices"). Verified by re-running the full
+bucket through `wrapTest` + `compile(target: "standalone")` + `buildImports` +
+instantiate: **52/52** value-checking tests now return `test() === 1`; the 57
+remaining `*-err.js` entries are negative SyntaxError tests (expected
+compile-errors), not value failures.
+
+**This PR is docs + regression coverage only — no source change.** Added
+`tests/issue-1782.test.ts` pinning the standalone separator-literal equality
+(decimal/hex/octal/binary integers + lower/upper prefixes, decimal/exponent
+floats, and all BigInt separator forms, each compared through an `any`-typed
+`sv()` to exercise the externref path) plus a JS-host no-regression check on
+uppercase-prefix value lowering.

--- a/tests/issue-1782.test.ts
+++ b/tests/issue-1782.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #1782: standalone numeric / BigInt separator literals evaluated to wrong
+// values in test262. Root cause was NOT literal lowering (TypeScript already
+// resolves `NumericLiteral.text` to the decimal value) but the standalone
+// `isSameValue` externref-equality path emitting a comparison that mismatched
+// when both operands were separator literals boxed to externref through an
+// `any`-typed parameter (the shape of test262's `assert.sameValue(a, b)`
+// harness). Fixed by #1776 / commit 1ff16008d. These tests pin the
+// separator-literal half of that behavior so it can't silently regress.
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, {
+    fileName: "t.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, `Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(true);
+  const importResult: any = buildImports(r.imports, undefined, r.stringPool, {});
+  const { instance } = await WebAssembly.instantiate(r.binary, importResult.imports ?? importResult);
+  if (importResult.setExports) importResult.setExports(instance.exports);
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+// Mirror the test262 harness: separator literals are passed through an
+// `any`-typed comparison (boxes to externref in standalone), and the function
+// reports the 1-based index of the first failing comparison, or 0 if all pass.
+const SAME_VALUE_DRIVER = `
+function sv(a: any, b: any): boolean { return a === b; }
+export function test(): number {
+  let n = 0;
+`;
+
+describe("#1782 standalone numeric separator literal equality", () => {
+  it("decimal / hex / octal / binary integer separators compare equal (any-boxed)", async () => {
+    const fail = await runStandalone(
+      SAME_VALUE_DRIVER +
+        `  n++; if (!sv(1_000, 1000)) return n;
+  n++; if (!sv(0o0_1, 0o01)) return n;
+  n++; if (!sv(0O0_1, 0O01)) return n;
+  n++; if (!sv(0x01_00, 0x0100)) return n;
+  n++; if (!sv(0X01_00, 0X0100)) return n;
+  n++; if (!sv(0b1010_0001, 0b10100001)) return n;
+  n++; if (!sv(0B1010_0001, 0B10100001)) return n;
+  return 0;
+}`,
+    );
+    expect(fail).toBe(0);
+  });
+
+  it("decimal / exponent float separators compare equal (any-boxed)", async () => {
+    const fail = await runStandalone(
+      SAME_VALUE_DRIVER +
+        `  n++; if (!sv(1_000.50, 1000.5)) return n;
+  n++; if (!sv(1.0e+1_0, 1.0e+10)) return n;
+  n++; if (!sv(1.0E+1_0, 1.0E+10)) return n;
+  return 0;
+}`,
+    );
+    expect(fail).toBe(0);
+  });
+
+  it("BigInt separators (decimal / hex / octal / binary, lower+upper prefix) compare equal", async () => {
+    const fail = await runStandalone(
+      SAME_VALUE_DRIVER +
+        `  n++; if (!sv(1_0n, 10n)) return n;
+  n++; if (!sv(0o0_1n, 0o01n)) return n;
+  n++; if (!sv(0O0_1n, 0O01n)) return n;
+  n++; if (!sv(0x01_00n, 0x0100n)) return n;
+  n++; if (!sv(0X01_00n, 0X0100n)) return n;
+  n++; if (!sv(0b0_1n, 0b01n)) return n;
+  n++; if (!sv(0B0_1n, 0B01n)) return n;
+  return 0;
+}`,
+    );
+    expect(fail).toBe(0);
+  });
+});
+
+describe("#1782 numeric separator literal values (JS-host, no regression)", () => {
+  async function runHost(source: string): Promise<number> {
+    const r = await compile(source, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    const importResult: any = buildImports(r.imports, undefined, r.stringPool, {});
+    const { instance } = await WebAssembly.instantiate(r.binary, importResult.imports ?? importResult);
+    if (importResult.setExports) importResult.setExports(instance.exports);
+    return (instance.exports as Record<string, () => number>).test();
+  }
+
+  it("uppercase radix prefixes lower to correct values in JS-host mode", async () => {
+    const fail = await runHost(
+      `export function test(): number {
+        let n = 0;
+        n++; if (0O0_1 !== 1) return n;
+        n++; if (0X01_00 !== 256) return n;
+        n++; if (0B1010_0001 !== 161) return n;
+        n++; if (1.0E+1_0 !== 1.0e+10) return n;
+        return 0;
+      }`,
+    );
+    expect(fail).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

#1782 reported 50 standalone test262 failures under `test/language/literals/{numeric,bigint}/numeric-separators/` (`returned 2`). Investigation shows the **literal value lowering was never the bug** — TypeScript resolves `NumericLiteral.text` to the decimal value (`0o0_1`→`"1"`, `0x01_00`→`"256"`), so `Number(text.replace(/_/g,""))` / `BigInt(...)` in `src/codegen/expressions.ts` always emitted correct constants for every radix, uppercase prefix, exponent, and BigInt suffix.

The actual defect was the **standalone `isSameValue` externref-equality path**: `returned 2` = the *second* `assert.sameValue` (the uppercase-prefix `0O…`/`0X…`/`0B…` variant), where two separator literals are boxed to externref through the `any`-typed harness and compared. That comparison emitted invalid/mismatched Wasm.

**Already fixed on main** by #1776 (commit `1ff16008d`) + `554b116e4`. Verified via the full pipeline (`wrapTest` → `compile(target:standalone)` → `buildImports` → instantiate): **52/52** value tests now return `test()===1`; the 57 `*-err.js` are expected negative SyntaxError tests.

## Changes (docs + regression coverage only — no source change)
- `tests/issue-1782.test.ts` — pins standalone separator-literal equality (decimal/hex/octal/binary integers with lower+upper prefixes, decimal/exponent floats, all BigInt separator forms, each through an `any`-typed comparison to exercise the externref path) + a JS-host no-regression check.
- `plan/issues/1782-…md` — `status: done`, completion summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)