### PR TITLE
fix(#1748): lower readonly array struct fields to vec, not externref

### DIFF
--- a/plan/issues/1748-readonly-nested-array-field-traps-on-indexed-read.md
+++ b/plan/issues/1748-readonly-nested-array-field-traps-on-indexed-read.md
@@ -1,9 +1,10 @@
 ---
 id: 1748
 title: "readonly array as a nested struct field traps on indexed read (compiled WasmGC)"
-status: ready
+status: done
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-06-03
+completed: 2026-06-03
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -68,3 +69,25 @@ compiled code isn't forced to drop the modifier.
 - Found via the slice-(b) "compile the dispatch loop itself" arm.
 - See [[1747]] for a sibling codegen trap found in the same investigation
   (`[].pop()` on an empty array).
+
+## Resolution (2026-06-03)
+
+Root cause: a `readonly T[]` / `ReadonlyArray<T>` type has the TS checker
+symbol name `"ReadonlyArray"`, not `"Array"`. `resolveWasmType`
+(`src/codegen/index.ts`) only matched `sym?.name === "Array"` when lowering a
+type to the vec ref `ref_null $vec_<elem>`. A `ReadonlyArray`-typed struct
+field therefore fell through to the anonymous-struct / externref path while the
+object literal's array value was still built as a vec — the two
+representations mismatched and indexed reads trapped.
+
+Fix (all `src/codegen/index.ts`):
+1. `resolveWasmType` — match `sym?.name === "Array" || === "ReadonlyArray"`.
+2. IR `resolvePositionType` — unwrap the `readonly` `TypeOperatorNode` to its
+   inner type, and accept `ReadonlyArray<T>` in the `Array<T>` reference arm
+   (keeps the IR path active rather than falling back to legacy).
+
+`ensureStructForType` already guarded `ReadonlyArray` (so it never built an
+anon struct for the field); the missing half was `resolveWasmType` picking the
+vec type for the field slot. Tests: `tests/issue-1748.test.ts` (4 cases —
+nested `readonly number[]`, `ReadonlyArray<number>`, `readonly string[]`,
+plain control). IR fallback gate + tsc clean.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -429,6 +429,13 @@ function resolvePositionType(
   classShapes?: ReadonlyMap<string, import("../ir/nodes.js").IrClassShape>,
 ): IrType {
   if (node) {
+    // `readonly T[]` parses as a `readonly`-TypeOperatorNode wrapping the array
+    // type. `readonly` is a TS-only modifier with no runtime representation, so
+    // resolve the inner type directly (parallels the ReadonlyArray handling in
+    // resolveWasmType — #1748).
+    if (ts.isTypeOperatorNode(node) && node.operator === ts.SyntaxKind.ReadonlyKeyword) {
+      return resolvePositionType(node.type, mapped, ctx, classShapes);
+    }
     if (node.kind === ts.SyntaxKind.NumberKeyword) return irVal({ kind: "f64" });
     if (node.kind === ts.SyntaxKind.BooleanKeyword) return irVal({ kind: "i32" });
     if (node.kind === ts.SyntaxKind.StringKeyword) return { kind: "string" };
@@ -487,7 +494,11 @@ function resolvePositionType(
       }
       // Slice 6 part 2 (#1181) — `Array<T>` TypeReferenceNode resolves
       // to a vec ref, parallel to the `T[]` ArrayTypeNode arm above.
-      if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.text === "Array") {
+      if (
+        ts.isTypeReferenceNode(node) &&
+        ts.isIdentifier(node.typeName) &&
+        (node.typeName.text === "Array" || node.typeName.text === "ReadonlyArray")
+      ) {
         const typeArgs = node.typeArguments;
         if (typeArgs && typeArgs.length === 1) {
           const elemIr = resolvePositionType(typeArgs[0]!, undefined, ctx, classShapes);
@@ -8251,7 +8262,12 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
   // in the lib as `declare var Array: ArrayConstructor` which would match externref
   if (tsType.flags & ts.TypeFlags.Object) {
     const sym = (tsType as ts.TypeReference).symbol ?? (tsType as ts.Type).symbol;
-    if (sym?.name === "Array") {
+    // `readonly T[]` / `ReadonlyArray<T>` lower identically to `T[]` — `readonly`
+    // is a TS-only modifier with no runtime representation. Without this, a
+    // ReadonlyArray-typed struct field falls through to the anonymous-struct /
+    // externref path and mismatches the vec the array literal builds, trapping
+    // on indexed read (#1748).
+    if (sym?.name === "Array" || sym?.name === "ReadonlyArray") {
       const typeArgs = ctx.checker.getTypeArguments(tsType as ts.TypeReference);
       const elemTsType = typeArgs[0];
       const elemWasm: ValType = elemTsType

--- a/tests/issue-1748.test.ts
+++ b/tests/issue-1748.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile error: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports.run as () => number)();
+}
+
+describe("#1748 readonly array struct fields", () => {
+  it("readonly number[] nested struct field reads back on indexed access", async () => {
+    expect(
+      await run(`
+interface FE { code: readonly number[]; arity: number; }
+interface PG { functions: readonly FE[]; entry: number; }
+export function run(): number {
+  const program: PG = { functions: [{ code: [7, 2], arity: 1 }], entry: 0 };
+  const entryFn = program.functions[program.entry];
+  return entryFn.code[0];
+}`),
+    ).toBe(7);
+  });
+
+  it("ReadonlyArray<T> field form lowers identically to T[]", async () => {
+    expect(
+      await run(`
+interface FE { code: ReadonlyArray<number>; arity: number; }
+export function run(): number {
+  const f: FE = { code: [9, 2], arity: 1 };
+  return f.code[0];
+}`),
+    ).toBe(9);
+  });
+
+  it("readonly string[] field preserves element identity", async () => {
+    expect(
+      await run(`
+interface S { names: readonly string[]; }
+export function run(): number {
+  const s: S = { names: ["a", "bb"] };
+  return s.names[1].length;
+}`),
+    ).toBe(2);
+  });
+
+  it("plain (non-readonly) nested array field still works", async () => {
+    expect(
+      await run(`
+interface FE { code: number[]; arity: number; }
+interface PG { functions: FE[]; entry: number; }
+export function run(): number {
+  const program: PG = { functions: [{ code: [7, 2], arity: 1 }], entry: 0 };
+  return program.functions[program.entry].code[0];
+}`),
+    ).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

A `readonly T[]` / `ReadonlyArray<T>` array typed as a nested struct field traps at runtime on indexed read in compiled WasmGC. The identical code with a plain `T[]` field works.

```ts
interface FE { code: readonly number[]; arity: number; }
interface PG { functions: readonly FE[]; entry: number; }
export function run(): number {
  const program: PG = { functions: [{ code: [7, 2], arity: 1 }], entry: 0 };
  return program.functions[program.entry].code[0]; // traps; expected 7
}
```

## Root cause

A `readonly T[]` type carries the TS checker symbol name `"ReadonlyArray"`, not `"Array"`. `resolveWasmType` (`src/codegen/index.ts`) only matched `sym?.name === "Array"` when lowering a type to the vec ref `ref_null $vec_<elem>`. A ReadonlyArray-typed struct field therefore fell through to the anonymous-struct / externref path, while the object literal's array value was still built as a vec — the two representations mismatched and indexed reads trapped. (`ensureStructForType` already guarded `ReadonlyArray`; the missing half was the field-slot type.)

## Fix

`src/codegen/index.ts`:
1. `resolveWasmType` — match `sym?.name === "Array" || === "ReadonlyArray"`.
2. IR `resolvePositionType` — unwrap the `readonly` `TypeOperatorNode` to its inner type, and accept `ReadonlyArray<T>` in the `Array<T>` reference arm (keeps the IR path active rather than falling back to legacy).

`readonly` is a TS-only modifier with no runtime representation, so it lowers identically to the non-readonly form.

## Tests

`tests/issue-1748.test.ts` — 4 cases: nested `readonly number[]` (returns 7), `ReadonlyArray<number>` (9), `readonly string[]` element identity (2), plain non-readonly control (7). IR fallback gate + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)