### PR TITLE
feat(#1574): §2.4 sound monomorphize clone re-inference

### DIFF
--- a/plan/issues/1574-ir-improvement-spec.md
+++ b/plan/issues/1574-ir-improvement-spec.md
@@ -9,6 +9,7 @@ sprint: Backlog
 owner: architect
 related: 1131, 1167a, 1167b, 1167c, 1126, 1231, 1169, 1370, 1373
 ---
+
 # IR Type Analysis & Optimization Pass Improvements
 
 A research document scoping concrete, file/line-anchored improvements to the
@@ -32,17 +33,17 @@ Reading order for a dev picking up any item below:
 The middle-end IR (`src/ir/nodes.ts`) carries an `IrType` discriminated union
 that covers:
 
-| `IrType.kind`  | Storage                              | Where it's produced                                                |
-|----------------|--------------------------------------|--------------------------------------------------------------------|
-| `val { val }`  | a `ValType` (i32, i64, f32, f64, …)  | leaf nodes, arithmetic, comparison                                 |
-| `val { signed }` (#1126 Stage 1) | `i32` w/ signedness fact | `js.bit*` chains, comparisons, conversions                         |
-| `string`       | backend-resolved (extern or `$AnyString`) | string literals, `string.concat`                              |
-| `object { shape }` | `(ref $S)` for canonicalised struct | object literals, propagated #1231 inference                       |
-| `closure { signature }` | `(ref $base)` + subtype for captures | function expressions / arrow fns                              |
-| `class { shape }` | `(ref $ClassStruct)`                | `new ClassName(...)` (#1169d)                                      |
-| `extern { className }` | `externref`                     | `extern.new`, `extern.regex` (#1169i)                              |
-| `union { members }` | `$union_<members>` tagged struct | propagation (`f64 \| bool`), `box`/`unbox`/`tag.test`              |
-| `boxed { inner }` | `$box_<inner>` ref-cell struct      | mutable closure captures                                           |
+| `IrType.kind`                    | Storage                                   | Where it's produced                                   |
+| -------------------------------- | ----------------------------------------- | ----------------------------------------------------- |
+| `val { val }`                    | a `ValType` (i32, i64, f32, f64, …)       | leaf nodes, arithmetic, comparison                    |
+| `val { signed }` (#1126 Stage 1) | `i32` w/ signedness fact                  | `js.bit*` chains, comparisons, conversions            |
+| `string`                         | backend-resolved (extern or `$AnyString`) | string literals, `string.concat`                      |
+| `object { shape }`               | `(ref $S)` for canonicalised struct       | object literals, propagated #1231 inference           |
+| `closure { signature }`          | `(ref $base)` + subtype for captures      | function expressions / arrow fns                      |
+| `class { shape }`                | `(ref $ClassStruct)`                      | `new ClassName(...)` (#1169d)                         |
+| `extern { className }`           | `externref`                               | `extern.new`, `extern.regex` (#1169i)                 |
+| `union { members }`              | `$union_<members>` tagged struct          | propagation (`f64 \| bool`), `box`/`unbox`/`tag.test` |
+| `boxed { inner }`                | `$box_<inner>` ref-cell struct            | mutable closure captures                              |
 
 Propagation (`src/ir/propagate.ts`) computes a per-function `TypeMap` over a
 seven-element lattice (`unknown / f64 / i32 / u32 / bool / string / object /
@@ -79,7 +80,7 @@ cap to guarantee termination.
    under a hard guard: "body instructions do NOT consume any parameter as an
    operand" (lines 28-34). The guard structurally rules out the most
    valuable monomorphization targets — typed helpers like
-   `function add(a, b) { return a + b; }` — because their bodies *do*
+   `function add(a, b) { return a + b; }` — because their bodies _do_
    consume `a` and `b`. Re-inferring `resultType` after clone-time param
    substitution is the listed follow-up; it has not landed.
 
@@ -162,6 +163,7 @@ arm.
    per-function `typeOf` map.
 
 **Mechanism.**
+
 - Add a new `IrType` overlay on `IrBlock` (sibling to `blockArgs`) called
   `narrowings: ReadonlyMap<IrValueId, IrType>`.
 - In `from-ast.ts`'s `lowerIfStatement`, before recursing into either arm,
@@ -181,7 +183,7 @@ arm.
 (`scripts/ir-fallback-baseline.json` line 4 — 22 unintended) includes a
 known cluster of functions that use `if (typeof x === 'string')` to guard
 string operations. A best-guess estimate is **5–8 functions claimed back**
-into the IR. Bigger win: the *already-claimed* IR functions that use
+into the IR. Bigger win: the _already-claimed_ IR functions that use
 narrowing today emit one `__unbox_number` / `extern.convert_any` per use of
 the narrowed variable; expect ~2-5% Wasm size reduction in code that uses
 union-typed locals.
@@ -246,12 +248,14 @@ i32 atom with `signed: undefined`) that represents "we know the storage is
 i32 but we've forgotten the domain." Operations that depend on signedness
 (`shr_s` vs `shr_u`, signed vs unsigned compare) check for the unspecified
 atom and either:
+
 - Emit the signed variant (matching JS `| 0` semantics) when the consumer
   doesn't care, OR
 - Insert an explicit re-sign coercion (`i32` is bit-identical to `u32`, so
   the coercion is free — just a typing fact, no Wasm op).
 
 **Mechanism.**
+
 - Add `signed: "signed" | "unsigned" | "either"` to the `i32` lattice atom.
 - `join(i32-signed, i32-unsigned)` → `i32-either`.
 - Joining `i32-either` with `f64` still widens to `f64` (Wasm storage
@@ -275,7 +279,9 @@ matching read in `from-ast.ts`'s bit-op lowerer.
 params" guard as a hard requirement. A callee like:
 
 ```ts
-function add(a, b) { return a + b; }
+function add(a, b) {
+  return a + b;
+}
 ```
 
 uses params as operands and is excluded — even though the call sites have
@@ -296,6 +302,7 @@ If the re-inference cannot type the body (e.g. produces a `dynamic` atom),
 abandon the clone — fall back to legacy behavior for the call site.
 
 **Mechanism.**
+
 - Add `reinferTypes(fn: IrFunction, paramOverride: IrType[]): IrFunction | null`
   in `src/ir/passes/monomorphize.ts`. Returns `null` when re-inference
   fails.
@@ -376,6 +383,7 @@ instruction. The constant-folder propagates this through `ref.is_null` →
 short-circuit chains.
 
 **Mechanism.**
+
 - Add `{ kind: "ref-non-null"; producer: IrValueId }` to `IrConst`.
 - In `constant-fold.ts`, when the producing instruction is
   `class.new` / `object.new` / `extern.new` / `array.new` / `closure.new`,
@@ -560,6 +568,7 @@ distinct ops.
 after constant-fold and before lower.
 
 **Patterns:**
+
 - `i32.mul x C` where `C` is a power of 2 → `i32.shl x log2(C)`
 - `i32.mul x 1` → `x`
 - `i32.mul x 0` → `i32.const 0`
@@ -572,7 +581,7 @@ after constant-fold and before lower.
 
 **Expected impact.** Mostly compiler-side wins (smaller IR → faster
 later passes). Wasm size: ~0.5%; runtime: Binaryen does these too at
--O2+, so end-binary impact is negligible. The win is in *unoptimized*
+-O2+, so end-binary impact is negligible. The win is in _unoptimized_
 output, useful when `--optimize` isn't on.
 
 **Difficulty.** Easy.
@@ -620,6 +629,7 @@ emits `return_call` instead of `call + return`. The IR already supports
 post-inline and post-monomorphize so we see the final call graph.
 
 **Patterns recognized.**
+
 - Terminator block ends in `call f` immediately followed by `return v`
   where `v` is the call result and the call has all args fully
   materialized in the same block.
@@ -682,6 +692,7 @@ already handles the analogous `ref.cast + ref.as_non_null` case.
 
 **Mechanism (Wasm-IR level).** In `src/codegen/peephole.ts`, add a
 Pattern 7:
+
 ```
 local.set N    ;; an externref
 local.get N
@@ -737,6 +748,7 @@ definition to the loop's pre-header.
 local-CSE (§3.3) so the dominant CSE opportunities are already collapsed.
 
 **Caveats.**
+
 - Side-effecting ops (call, global.set, raw.wasm) are never hoistable.
 - Loops in our IR are represented as `for.loop` / `while.loop` / `forof.*`
   instructions whose `body` is an instruction buffer (`lower.ts:1714-1773`)
@@ -757,9 +769,11 @@ that lookup simpler than a typical LICM.
 ### 3.9 Pass: switch-table generation from dense if-else chains
 
 **What it does.** Recognise patterns like
+
 ```ts
 if (n === 0) return a; else if (n === 1) return b; else if …
 ```
+
 and emit a `br_table` instead of a cascade of `i32.eq + br_if`. The IR
 doesn't represent `br_table` yet (only `br_table` in the `types.ts` Instr
 union as a no-immediate placeholder; `select.ts` doesn't even claim
@@ -767,6 +781,7 @@ union as a no-immediate placeholder; `select.ts` doesn't even claim
 
 **Pipeline position.** New pass; AND a feature gate at the selector level
 to claim `SwitchStatement`. Both pieces needed; recommend in this order:
+
 1. Selector slice for `SwitchStatement` lowering to a chain of `br_if`s
    (no perf gain on its own).
 2. This pass to consolidate into `br_table`.
@@ -794,6 +809,7 @@ doesn't emit the redundant op at all. New IR pass
 `src/ir/passes/cast-elimination.ts`, run after local-CSE.
 
 **Patterns.**
+
 - `ref.cast T` on a value already typed as `(ref T)` → no-op.
 - `ref.cast T` on a value of type `(ref U)` where `U <: T` → no-op.
 - `ref.cast T` immediately after `ref.test T → bool: true (constant)` →
@@ -821,6 +837,7 @@ is a single `struct.get`.
 
 This already works for `IrType.class` (`lower.ts:1112-1138`,
 `class.get`/`class.set`/`class.call`). What does NOT work:
+
 - Property accesses lowered through `extern { className: "Map" }` (which
   go through `extern.prop` host calls — fine, that's the contract for
   pseudo-extern classes).
@@ -837,7 +854,9 @@ members, and `struct.get` directly on the common supertype's fields.
 
 ```ts
 type Shape = Circle | Square;
-function area(s: Shape): number { return s.kind === "circle" ? Math.PI * s.r * s.r : s.s * s.s; }
+function area(s: Shape): number {
+  return s.kind === "circle" ? Math.PI * s.r * s.r : s.s * s.s;
+}
 ```
 
 — today `area` falls back. With this feature, claim back **~5 functions
@@ -912,32 +931,32 @@ machinery — design with care. Reasonable target post-#1238.
 
 Sort key: `(claim-back functions × Wasm-size delta × confidence) / difficulty`.
 
-| Rank | Title                                                                   | Impact (claims / size) | Difficulty | Depends on |
-|------|-------------------------------------------------------------------------|------------------------|------------|------------|
-| 1    | §2.4 Re-infer resultType in monomorphize clones                         | 10-30 / 2-5%           | Medium     | —          |
-| 2    | §2.1 Typeof control-flow narrowing                                      | 5-8 / 2-5%             | Medium     | per-block overlay |
-| 3    | §3.3 Local CSE within basic block                                       | 0 / 2-4%               | Easy-med   | —          |
-| 4    | §2.2 Non-null narrowing                                                 | 1-2 / 3-5%             | Easy       | §2.1 overlay |
-| 5    | §3.4 Tail-call optimization (return_call)                               | 0 / stack savings      | Medium     | —          |
-| 6    | §3.6 extern.convert_any / any.convert_extern round-trip elimination     | 0 / 1-3%               | Medium     | —          |
-| 7    | §2.5 Locals in propagation TypeMap                                      | 2-4 / 0.5%             | Easy       | —          |
-| 8    | §2.6 Symbolic ref-non-null lattice                                      | 0 / 0.5-1%             | Easy       | —          |
-| 9    | §3.1 Dead-arm elimination in `IrInstrIf`                                | 0 / <1%                | Medium     | —          |
-| 10   | §3.5 Closure-call devirtualization                                      | 0 / 1-3% (hot)         | Medium     | —          |
-| 11   | §3.10 IR-level ref.cast elimination                                     | 0 / 0.5-1%             | Easy       | §2.6       |
-| 12   | §3.2 Strength reduction                                                 | 0 / <0.5%              | Easy       | —          |
-| 13   | §3.7 Short-circuit folding                                              | 0 / <0.5%              | Trivial    | §3.1       |
-| 14   | §2.10 TS-checker per-expression narrowing pass-through                  | 8-15 / 2-4%            | Hard       | —          |
-| 15   | §4.1 Field-access devirt on monomorphic receivers (union<class>)        | 5+ / 2-3%              | Hard       | lattice extension |
-| 16   | §3.8 LICM                                                               | 0 / 1-2% (hot loops)   | Medium     | §3.3       |
-| 17   | §3.9 Switch-table generation                                            | 0 / 5-15% (switch hot) | Hard       | selector slice |
-| 18   | §2.3 Lattice i32 vs u32 join refinement                                 | 0 / <0.5%              | Easy       | —          |
-| 19   | §2.8 Iterate CF + DCE post-inline                                       | 0 / 0.3-1%             | Trivial    | —          |
-| 20   | §2.7 Cross-function arg-narrowing call-site refinement                  | depends on §2.4        | Easy       | §2.4       |
-| 21   | §4.5 Devirtualized iterator protocol                                    | 0 / depends            | Medium     | extern-class work |
-| 22   | §2.9 Branded primitives (defensive)                                     | 0 / 0                  | Easy       | — (defer)  |
-| 23   | §4.2 Escape analysis                                                    | 0 / GC pressure        | Hard       | — (defer)  |
-| 24   | §4.3 Sub-struct inlining                                                | 0 / GC pressure        | Hard       | — (defer)  |
+| Rank | Title                                                               | Impact (claims / size) | Difficulty | Depends on        |
+| ---- | ------------------------------------------------------------------- | ---------------------- | ---------- | ----------------- |
+| 1    | §2.4 Re-infer resultType in monomorphize clones                     | 10-30 / 2-5%           | Medium     | —                 |
+| 2    | §2.1 Typeof control-flow narrowing                                  | 5-8 / 2-5%             | Medium     | per-block overlay |
+| 3    | §3.3 Local CSE within basic block                                   | 0 / 2-4%               | Easy-med   | —                 |
+| 4    | §2.2 Non-null narrowing                                             | 1-2 / 3-5%             | Easy       | §2.1 overlay      |
+| 5    | §3.4 Tail-call optimization (return_call)                           | 0 / stack savings      | Medium     | —                 |
+| 6    | §3.6 extern.convert_any / any.convert_extern round-trip elimination | 0 / 1-3%               | Medium     | —                 |
+| 7    | §2.5 Locals in propagation TypeMap                                  | 2-4 / 0.5%             | Easy       | —                 |
+| 8    | §2.6 Symbolic ref-non-null lattice                                  | 0 / 0.5-1%             | Easy       | —                 |
+| 9    | §3.1 Dead-arm elimination in `IrInstrIf`                            | 0 / <1%                | Medium     | —                 |
+| 10   | §3.5 Closure-call devirtualization                                  | 0 / 1-3% (hot)         | Medium     | —                 |
+| 11   | §3.10 IR-level ref.cast elimination                                 | 0 / 0.5-1%             | Easy       | §2.6              |
+| 12   | §3.2 Strength reduction                                             | 0 / <0.5%              | Easy       | —                 |
+| 13   | §3.7 Short-circuit folding                                          | 0 / <0.5%              | Trivial    | §3.1              |
+| 14   | §2.10 TS-checker per-expression narrowing pass-through              | 8-15 / 2-4%            | Hard       | —                 |
+| 15   | §4.1 Field-access devirt on monomorphic receivers (union<class>)    | 5+ / 2-3%              | Hard       | lattice extension |
+| 16   | §3.8 LICM                                                           | 0 / 1-2% (hot loops)   | Medium     | §3.3              |
+| 17   | §3.9 Switch-table generation                                        | 0 / 5-15% (switch hot) | Hard       | selector slice    |
+| 18   | §2.3 Lattice i32 vs u32 join refinement                             | 0 / <0.5%              | Easy       | —                 |
+| 19   | §2.8 Iterate CF + DCE post-inline                                   | 0 / 0.3-1%             | Trivial    | —                 |
+| 20   | §2.7 Cross-function arg-narrowing call-site refinement              | depends on §2.4        | Easy       | §2.4              |
+| 21   | §4.5 Devirtualized iterator protocol                                | 0 / depends            | Medium     | extern-class work |
+| 22   | §2.9 Branded primitives (defensive)                                 | 0 / 0                  | Easy       | — (defer)         |
+| 23   | §4.2 Escape analysis                                                | 0 / GC pressure        | Hard       | — (defer)         |
+| 24   | §4.3 Sub-struct inlining                                            | 0 / GC pressure        | Hard       | — (defer)         |
 
 ---
 
@@ -946,16 +965,16 @@ Sort key: `(claim-back functions × Wasm-size delta × confidence) / difficulty`
 Cherry-picked from the backlog. A dev with no prior IR exposure can
 implement any of these in a session by following the linked spec section.
 
-| # | Title | Section | Expected outcome |
-|---|-------|---------|------------------|
-| Q1 | Iterate CF + DCE in post-inline integration loop | §2.8 | Single 5-line change in `integration.ts:354`; small Wasm size win. |
-| Q2 | Symbolic ref-non-null lattice for `IrConst` | §2.6 | Add one `IrConst` variant + ~10 lines in `constant-fold.ts`. Eliminates `?.` overhead on `new` results. |
-| Q3 | Strength reduction pass | §3.2 | New 60-line file; pure rewrite, no IR-shape changes. |
-| Q4 | Lattice `i32 vs u32 join` refinement | §2.3 | One-field-on-atom change + 3 callsites in `propagate.ts`. |
-| Q5 | Local CSE within basic block (`global.get`-only fast slice) | §3.3 | Start with the safest pure ops (`global.get`, `const`); extend later. ~150 LOC. |
-| Q6 | Locals in propagation TypeMap | §2.5 | Single function in `propagate.ts` (~30 lines). Claims back a handful of functions. |
-| Q7 | Short-circuit folding for `i32.and`/`i32.or` with known boolean operand | §3.7 | 20 lines in `BINARY_FOLD_TABLE` of `constant-fold.ts`. |
-| Q8 | Dead-arm collapse for `IrInstrIf` with const cond | §3.1 (subset: don't rebuild SSA) | Punt on full splice; just record the dead arm in DCE liveness so its instructions get reaped. ~50 LOC. |
+| #   | Title                                                                   | Section                          | Expected outcome                                                                                        |
+| --- | ----------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Q1  | Iterate CF + DCE in post-inline integration loop                        | §2.8                             | Single 5-line change in `integration.ts:354`; small Wasm size win.                                      |
+| Q2  | Symbolic ref-non-null lattice for `IrConst`                             | §2.6                             | Add one `IrConst` variant + ~10 lines in `constant-fold.ts`. Eliminates `?.` overhead on `new` results. |
+| Q3  | Strength reduction pass                                                 | §3.2                             | New 60-line file; pure rewrite, no IR-shape changes.                                                    |
+| Q4  | Lattice `i32 vs u32 join` refinement                                    | §2.3                             | One-field-on-atom change + 3 callsites in `propagate.ts`.                                               |
+| Q5  | Local CSE within basic block (`global.get`-only fast slice)             | §3.3                             | Start with the safest pure ops (`global.get`, `const`); extend later. ~150 LOC.                         |
+| Q6  | Locals in propagation TypeMap                                           | §2.5                             | Single function in `propagate.ts` (~30 lines). Claims back a handful of functions.                      |
+| Q7  | Short-circuit folding for `i32.and`/`i32.or` with known boolean operand | §3.7                             | 20 lines in `BINARY_FOLD_TABLE` of `constant-fold.ts`.                                                  |
+| Q8  | Dead-arm collapse for `IrInstrIf` with const cond                       | §3.1 (subset: don't rebuild SSA) | Punt on full splice; just record the dead arm in DCE liveness so its instructions get reaped. ~50 LOC.  |
 
 For each quick-win, the dev workflow is:
 
@@ -964,7 +983,7 @@ For each quick-win, the dev workflow is:
 3. Add a test case in `tests/ir/` (mirroring existing tests for the pass).
 4. Implement + verify.
 5. Run `pnpm run check:ir-fallbacks` to confirm no fallback regressions
-   (Q6 should *reduce* counts, others should be neutral).
+   (Q6 should _reduce_ counts, others should be neutral).
 6. Run `npm test -- tests/equivalence.test.ts` for the affected scope.
 
 ---
@@ -987,6 +1006,7 @@ of two stages:
    - LICM AFTER local-CSE (so hoisted ops aren't redundant with hoisted siblings).
 
 Every pass must:
+
 - Return the same `IrFunction` / `IrModule` reference if it made no changes
   (so the surrounding loop can detect fixpoint via `Object.is`).
 - Preserve the verifier invariants (`verifyIrFunction` runs after every
@@ -1021,4 +1041,56 @@ Every pass must:
 
 ---
 
-*End of spec.*
+## Implementation log
+
+### §2.4 — Re-infer resultType in monomorphize clones (landed, sound subset)
+
+`src/ir/passes/monomorphize.ts`. The pre-#1574 pass refused to clone any
+callee whose body consumed a parameter as an operand. This relaxes that
+gate: param-consuming single-block bodies are now eligible, and
+`cloneWithParamTypes` re-types the clone body under the substituted params
+via `reinferCloneBody` → `reinferInstr` → `reinferBinary`/`reinferUnary`.
+A clone is **abandoned** (the call-site group stays on the original callee)
+the moment any param-tainted instruction can't be soundly re-typed.
+
+**Soundness boundary (important — narrows the spec's §2.4 estimate).** A
+Wasm arithmetic/comparison op consumes its operands' EXACT ValType off the
+value stack; there is no implicit numeric coercion at the IR→Wasm boundary.
+So `f64.add` is only valid on two f64 operands — cloning a numeric helper
+`add(a, b) { return a + b; }` for an i32 tuple would emit `f64.add` on i32
+operands (invalid Wasm) unless an `f64.convert_i32_s` is inserted. Inserting
+those conversions is a **separate operand-coercion layer (future work)**, so
+the re-inferer requires exact operand-storage match and abandons any clone
+that would change an arithmetic operand's storage type. The spec's flagship
+"numeric helper cloned across f64/i32 → 10-30 functions" estimate is
+therefore **not reachable without that coercion layer**.
+
+**What the sound subset DOES unlock** (strictly additive, never invalid Wasm):
+
+- identity-like bodies (param flows only to `return`/`call`) — already
+  cloneable pre-#1574; re-inference is a no-op for them;
+- **reference-polymorphic ops** — `ref.is_null` accepts any reference
+  operand, and `select` over a shared ref supertype — so a param-consuming
+  body using those can now be cloned per call-site _reference_ type
+  (e.g. `isNull(x) { return x == null }` specialised for externref vs a
+  struct ref). This is the genuine new capability.
+
+Tests: `tests/ir/phase3c.test.ts` — negative (`f64.add`/i32 tuple →
+abandoned, call site stays on original) + positive (`ref.is_null` body
+cloned across two reference tuples, both verify). IR fallback gate
+unchanged (this pass affects emitted-Wasm quality, not selection).
+
+**Follow-ups (not done here):**
+
+- Operand-coercion layer in clones (insert `f64.convert_i32_s` etc.) to
+  unlock the numeric-helper case — own issue, larger scope.
+- `param-type-not-resolvable` straggler (`addBenchCard`'s `fn: () => number`
+  in `website/playground/examples/benchmarks/helpers.ts`) needs closure-typed
+  params end-to-end through the selector+lowerer; not a propagation fix.
+- §2.5 (locals in TypeMap) was already implemented in `propagate.ts`
+  (`walkBodyForReturns` tracks `let`/`const` initializers) — the spec's
+  "current behavior" text for it is stale.
+
+---
+
+_End of spec._

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -26,19 +26,38 @@
 //
 //   - non-recursive (not part of any SCC, including self-loops)
 //   - single-block body
-//   - body instructions do NOT consume any parameter as an operand.
-//     Rationale: if a callee's `f64.add(param, const)` is retyped from
-//     `param: f64` to `param: externref`, the instruction's operand type
-//     no longer matches the operator — producing invalid Wasm. V1 rejects
-//     such callees; later phases will re-infer instruction resultTypes
-//     under the retyped params.
 //   - body size ≤ MAX_CALLEE_SIZE
+//   - terminator is a single-value `return`
 //   - there exist ≥ 2 distinct argument-type tuples across its call sites
 //   - distinct tuple count ≤ MAX_VARIANTS_PER_CALLEE
 //
-// The operand-free-of-params guard is narrow BUT covers the common
-// "identity-like" polymorphic helpers (return-param, return-const) that
-// pure-numeric code paths boxed-and-unboxed through on the legacy path.
+// #1574 §2.4 — re-infer resultType in clones (relax the operand guard)
+// ====================================================================
+//
+// The original V1 guard ALSO required that "body instructions do NOT
+// consume any parameter as an operand." Rationale: if a callee's
+// `f64.add(param, const)` is retyped from `param: f64` to `param:
+// externref`, the operand type no longer matches the operator —
+// producing invalid Wasm. That guard structurally ruled out the most
+// valuable monomorphization targets — typed helpers like
+// `function add(a, b) { return a + b; }` whose bodies DO consume their
+// params.
+//
+// We now RELAX (not drop) that guard. When a clone's params are
+// substituted, we walk the clone body and re-infer each instruction's
+// `resultType` from the substituted operand types via `reinferCloneBody`.
+// Crucially the re-inferer is SOUND, not optimistic: for every
+// param-consuming instruction it verifies the operator actually accepts
+// the substituted operand type (e.g. `f64.add` rejects a non-numeric
+// operand). If any instruction cannot be soundly retyped — or uses an
+// op-kind the re-inferer doesn't model — the whole clone is ABANDONED
+// (`reinferCloneBody` returns null) and that call-site group stays on the
+// original callee / legacy path. This keeps the pass strictly additive:
+// it can only ever turn a boxed polymorphic call into a typed one, never
+// emit invalid Wasm.
+//
+// The original "identity-like" helpers (return-param, return-const) still
+// clone — they're the degenerate case where re-inference is a no-op.
 //
 // Growth guard (pass-end)
 // =======================
@@ -56,6 +75,8 @@
 
 import {
   asBlockId,
+  irTypeEquals,
+  type IrBinop,
   type IrBlock,
   type IrFuncRef,
   type IrFunction,
@@ -63,6 +84,7 @@ import {
   type IrModule,
   type IrParam,
   type IrType,
+  type IrUnop,
   type IrValueId,
 } from "../nodes.js";
 import type { ValType } from "../types.js";
@@ -240,23 +262,41 @@ export function monomorphize(mod: IrModule, registry?: AllocSiteRegistry): Monom
 
   // -------------------------------------------------------------------------
   // Step 5 — build clones (fresh IrFunctions).
+  //
+  // #1574 §2.4 — `cloneWithParamTypes` can now return null when the clone's
+  // body can't be soundly re-typed under the substituted params. Such a
+  // specialization is ABANDONED: we record its name so Step 6 leaves the
+  // matching call sites pointing at the original callee. The growth guard
+  // (Step 4) already accounted for it pessimistically; abandoning only
+  // shrinks the actual growth, so the budget stays satisfied.
   // -------------------------------------------------------------------------
   const clonedFuncs: IrFunction[] = [];
   const cloneSignatures = new Map<string, MonomorphizeCloneSignature>();
+  const abandonedClones = new Set<string>();
   for (const [calleeName, plans] of planByCallee) {
     const callee = byName.get(calleeName)!;
     for (const plan of plans) {
-      const { fn: clone, returnType } = cloneWithParamTypes(callee, plan.cloneName, plan.argTypes, registry);
-      clonedFuncs.push(clone);
+      const result = cloneWithParamTypes(callee, plan.cloneName, plan.argTypes, registry);
+      if (result === null) {
+        abandonedClones.add(plan.cloneName);
+        continue;
+      }
+      clonedFuncs.push(result.fn);
       cloneSignatures.set(plan.cloneName, {
         params: plan.argTypes,
-        returnType,
+        returnType: result.returnType,
       });
     }
   }
 
+  // If every planned clone was abandoned, the pass made no changes.
+  if (clonedFuncs.length === 0) {
+    return { module: mod, cloneSignatures: new Map() };
+  }
+
   // -------------------------------------------------------------------------
-  // Step 6 — rewrite call sites in their source functions.
+  // Step 6 — rewrite call sites in their source functions. Skip edits for
+  // abandoned clones — their call sites keep targeting the original callee.
   // -------------------------------------------------------------------------
   interface Edit {
     readonly blockIdx: number;
@@ -266,6 +306,7 @@ export function monomorphize(mod: IrModule, registry?: AllocSiteRegistry): Monom
   const edits = new Map<string, Edit[]>();
   for (const [, plans] of planByCallee) {
     for (const plan of plans) {
+      if (abandonedClones.has(plan.cloneName)) continue;
       for (const call of plan.calls) {
         let arr = edits.get(call.callerName);
         if (!arr) {
@@ -371,27 +412,27 @@ function buildLocalTypeOf(fn: IrFunction): (v: IrValueId) => IrType | null {
 // ---------------------------------------------------------------------------
 
 /**
- * A callee is safely cloneable iff:
+ * A callee is structurally cloneable iff:
  *   - single-block
  *   - body ≤ MAX_CALLEE_SIZE instructions
- *   - body instructions do NOT reference any parameter as an operand
- *     (so retyping params cannot invalidate any operation)
  *   - terminator is a `return` (and single-block means that's the only
  *     terminator shape)
+ *
+ * #1574 §2.4 — the old "body instructions do NOT reference any parameter
+ * as an operand" guard lived here. It is GONE: param-consuming bodies are
+ * now eligible. Soundness moves to clone-construction time —
+ * `reinferCloneBody` re-types every instruction under the substituted
+ * params and abandons the clone (returns null) if any op can't be soundly
+ * retyped. This gate stays purely structural so a typed helper like
+ * `add(a, b) { return a + b; }` reaches the per-tuple re-inference step
+ * (where it succeeds for numeric tuples and is rejected for, e.g., an
+ * externref tuple). See `cloneWithParamTypes`.
  */
 function isMonomorphizable(fn: IrFunction): boolean {
   if (fn.blocks.length !== 1) return false;
   const block = fn.blocks[0]!;
   if (block.instrs.length > MAX_CALLEE_SIZE) return false;
   if (block.terminator.kind !== "return") return false;
-
-  const paramIds = new Set<IrValueId>();
-  for (const p of fn.params) paramIds.add(p.value);
-  for (const instr of block.instrs) {
-    for (const u of collectUses(instr)) {
-      if (paramIds.has(u)) return false;
-    }
-  }
   return true;
 }
 
@@ -476,50 +517,38 @@ function uniquifyName(base: string, used: ReadonlySet<string>): string {
 
 /**
  * Deep-copy `callee` into a new IrFunction with `cloneName`, retyping each
- * parameter to the corresponding entry in `newParamTypes`. Also computes
- * and returns the clone's single return type (V1 restricts clones to
- * single-return, single-block shapes).
+ * parameter to the corresponding entry in `newParamTypes`, and re-inferring
+ * every body instruction's `resultType` under the substituted params
+ * (#1574 §2.4). Returns the clone + its single return type, or `null` when
+ * re-inference fails — see `reinferCloneBody` for the soundness contract.
  *
- * Because `isMonomorphizable` guarantees no instruction consumes a param as
- * an operand, instruction-level resultTypes remain valid verbatim. Only the
- * function's own params (and downstream `fn.resultTypes`) shift.
+ * A `null` return means "this specialization is not safe to clone": the
+ * caller skips the clone and the call-site group stays on the original
+ * callee / legacy path. Never throws on a re-inference failure — only on
+ * structural invariants (arity, terminator shape) that the gate already
+ * guaranteed.
  */
 function cloneWithParamTypes(
   callee: IrFunction,
   cloneName: string,
   newParamTypes: readonly IrType[],
   registry?: AllocSiteRegistry,
-): { fn: IrFunction; returnType: IrType } {
+): { fn: IrFunction; returnType: IrType } | null {
   if (newParamTypes.length !== callee.params.length) {
     throw new Error(
       `ir/monomorphize: param-arity mismatch cloning ${callee.name}: expected ${callee.params.length}, got ${newParamTypes.length}`,
     );
   }
 
-  // Param SSA ids are preserved verbatim (isMonomorphizable ensured nothing
-  // in the body consumes them as operands, so no renaming is needed).
+  // Param SSA ids are preserved verbatim. The body may now consume them as
+  // operands (#1574 §2.4) — re-inference handles the retyped operands.
   const newParams: IrParam[] = callee.params.map((p, i) => ({
     value: p.value,
     type: newParamTypes[i]!,
     name: p.name,
   }));
 
-  // Blocks are copied with terminator / instrs untouched. Single-block
-  // invariant guarantees there is exactly one.
   const oldBlock = callee.blocks[0]!;
-  const newBlock: IrBlock = {
-    id: asBlockId(0),
-    blockArgs: oldBlock.blockArgs,
-    blockArgTypes: oldBlock.blockArgTypes,
-    // Fork allocation ids per specialization — a clone is a distinct runtime
-    // allocation set, so its alloc sites must not share the source's ids
-    // (#1586 fork rule). `forkAllocInInstr` is a no-op for non-alloc instrs and
-    // when no registry is wired, preserving the prior shallow-copy behavior.
-    instrs: oldBlock.instrs.map((i) => forkAllocInInstr(i, registry)),
-    terminator: oldBlock.terminator,
-  };
-
-  // Compute return type from the (single) return terminator.
   const term = oldBlock.terminator;
   if (term.kind !== "return") {
     throw new Error(`ir/monomorphize: clone ${cloneName} has non-return terminator`);
@@ -527,8 +556,35 @@ function cloneWithParamTypes(
   if (term.values.length !== 1) {
     throw new Error(`ir/monomorphize: clone ${cloneName} has ${term.values.length} return values; V1 requires 1`);
   }
+
+  // Re-infer the body under the substituted params. A null result means an
+  // instruction could not be soundly retyped — abandon this clone.
+  const reinferred = reinferCloneBody(oldBlock.instrs, newParams);
+  if (reinferred === null) return null;
+
+  // Fork allocation ids per specialization — a clone is a distinct runtime
+  // allocation set, so its alloc sites must not share the source's ids
+  // (#1586 fork rule). `forkAllocInInstr` is a no-op for non-alloc instrs and
+  // when no registry is wired, preserving the prior shallow-copy behavior.
+  const newInstrs = reinferred.instrs.map((i) => forkAllocInInstr(i, registry));
+
+  const newBlock: IrBlock = {
+    id: asBlockId(0),
+    blockArgs: oldBlock.blockArgs,
+    blockArgTypes: oldBlock.blockArgTypes,
+    instrs: newInstrs,
+    terminator: oldBlock.terminator,
+  };
+
+  // Return type = type of the single returned value under the new typing.
   const returnValueId = term.values[0]!;
-  const returnType = deriveReturnType(returnValueId, newParams, oldBlock.instrs, callee);
+  const returnType = reinferred.typeOf.get(returnValueId);
+  if (!returnType) {
+    // The returned value has no resolvable type post-substitution (e.g. a
+    // block arg, which V1 single-block clones never have). Abandon rather
+    // than emit a clone whose result type we can't name.
+    return null;
+  }
 
   const fn: IrFunction = {
     name: cloneName,
@@ -541,28 +597,277 @@ function cloneWithParamTypes(
   return { fn, returnType };
 }
 
+// ---------------------------------------------------------------------------
+// #1574 §2.4 — sound clone-body re-inference
+// ---------------------------------------------------------------------------
+
 /**
- * Determine the return type of a monomorphized clone. Because the clone's
- * body instructions don't consume params, the return value is either:
- *   - a parameter → return type = retyped param type
- *   - an instruction result → return type = that instr's resultType
- *   - a block arg → entry block has no args in V1; this shouldn't happen
+ * Result of re-inferring a clone body: the rewritten instructions (with
+ * fresh `resultType`s where they shifted) plus a `valueId → IrType` map
+ * covering params + every instruction result, used to type the return
+ * value.
  */
-function deriveReturnType(
-  returnId: IrValueId,
-  newParams: readonly IrParam[],
-  instrs: readonly IrInstr[],
-  callee: IrFunction,
-): IrType {
-  for (const p of newParams) {
-    if (p.value === returnId) return p.type;
+interface ReinferredBody {
+  readonly instrs: readonly IrInstr[];
+  readonly typeOf: ReadonlyMap<IrValueId, IrType>;
+}
+
+/**
+ * Re-type a single-block clone body under substituted param types. Walks
+ * the instruction list in order, maintaining a `valueId → IrType` map
+ * seeded with the retyped params; for each value-producing instruction it
+ * recomputes the result type from its (possibly retyped) operands and
+ * VERIFIES the operator accepts those operand types.
+ *
+ * Returns null — abandoning the clone — when ANY of:
+ *   - an instruction consumes a value whose type isn't in the map yet
+ *     (shouldn't happen in verified SSA, defensive);
+ *   - an operator's operand type became incompatible under substitution
+ *     (e.g. `f64.add` on a non-numeric operand);
+ *   - the instruction kind is outside the modelled set AND it consumes a
+ *     retyped param (conservative: we only clone bodies we can fully
+ *     re-verify).
+ *
+ * Instructions whose operands are all param-independent keep their original
+ * `resultType` verbatim — re-inference is a no-op for them, matching the
+ * pre-#1574 "identity-like helper" behaviour.
+ */
+function reinferCloneBody(instrs: readonly IrInstr[], params: readonly IrParam[]): ReinferredBody | null {
+  const typeOf = new Map<IrValueId, IrType>();
+  for (const p of params) typeOf.set(p.value, p.type);
+
+  // Which SSA values are (transitively) derived from a substituted param.
+  // Only these need operator re-verification; param-independent instrs are
+  // copied verbatim (their original resultType is still valid).
+  const paramTainted = new Set<IrValueId>();
+  for (const p of params) paramTainted.add(p.value);
+
+  const out: IrInstr[] = [];
+  for (const instr of instrs) {
+    const uses = collectUses(instr);
+    const consumesTainted = uses.some((u) => paramTainted.has(u));
+
+    if (!consumesTainted) {
+      // Param-independent: result type is unchanged. Record it and copy.
+      if (instr.result !== null && instr.resultType) typeOf.set(instr.result, instr.resultType);
+      out.push(instr);
+      continue;
+    }
+
+    // This instruction depends on a substituted param — re-infer + verify.
+    const inferred = reinferInstr(instr, typeOf);
+    if (inferred === null) return null; // unsound under substitution — abandon
+
+    out.push(inferred.instr);
+    if (inferred.instr.result !== null && inferred.resultType) {
+      typeOf.set(inferred.instr.result, inferred.resultType);
+      paramTainted.add(inferred.instr.result);
+    }
   }
-  for (const inst of instrs) {
-    if (inst.result === returnId && inst.resultType) return inst.resultType;
+
+  return { instrs: out, typeOf };
+}
+
+// #1574 §2.4 soundness model
+// ===========================
+//
+// A Wasm arithmetic/comparison op consumes its operands' EXACT ValType off
+// the value stack — there is NO implicit numeric coercion at the IR→Wasm
+// boundary. `f64.add` requires two f64s; if a clone's substituted param is
+// i32, the body's `f64.add` would be invalid Wasm unless an
+// `f64.convert_i32_s` is inserted (a separate operand-coercion feature, out
+// of scope here). So the re-inferer requires every typed-op operand to
+// EXACTLY match the storage type the op already consumed. This correctly
+// ABANDONS any clone that would change an arithmetic operand's storage
+// type, guaranteeing the pass never emits invalid Wasm. The sound wins it
+// keeps:
+//   - identity-like bodies (param flows only to return / call) — re-inference
+//     is a no-op (these were already cloneable pre-#1574);
+//   - reference-polymorphic ops (`ref.is_null`, `select` over a shared ref
+//     supertype) where the substituted operand is still a valid operand.
+
+function isF64Val(t: IrType): boolean {
+  return t.kind === "val" && t.val.kind === "f64";
+}
+
+function isI32Val(t: IrType): boolean {
+  // `bool` lattice values lower to i32 storage too — any `val` whose
+  // ValType.kind is "i32" qualifies (the `signed` fact is irrelevant for
+  // storage; the op tag already encoded signed-vs-unsigned).
+  return t.kind === "val" && t.val.kind === "i32";
+}
+
+const IR_F64: IrType = { kind: "val", val: { kind: "f64" } };
+const IR_I32: IrType = { kind: "val", val: { kind: "i32" } };
+
+/**
+ * Re-infer the result type of one param-tainted instruction and verify the
+ * operator accepts its (retyped) operands. Returns the (possibly rewritten)
+ * instruction plus its new result type, or null when the substitution makes
+ * the op unsound. Conservatively returns null for any instruction kind not
+ * explicitly modelled — those are never cloned when param-tainted.
+ *
+ * The modelled set is the pure value-computation subset that polymorphic
+ * numeric helpers actually use: binary / unary / select / box / unbox /
+ * tag.test. Everything else (calls, memory ops, control flow) is rejected
+ * when param-tainted so we never silently emit an operator/operand mismatch.
+ */
+function reinferInstr(
+  instr: IrInstr,
+  typeOf: ReadonlyMap<IrValueId, IrType>,
+): { instr: IrInstr; resultType: IrType } | null {
+  switch (instr.kind) {
+    case "binary": {
+      const lt = typeOf.get(instr.lhs);
+      const rt = typeOf.get(instr.rhs);
+      if (!lt || !rt) return null;
+      const rty = reinferBinary(instr.op, lt, rt);
+      if (rty === null) return null;
+      return { instr: { ...instr, resultType: rty }, resultType: rty };
+    }
+    case "unary": {
+      const ot = typeOf.get(instr.rand);
+      if (!ot) return null;
+      const rty = reinferUnary(instr.op, ot);
+      if (rty === null) return null;
+      return { instr: { ...instr, resultType: rty }, resultType: rty };
+    }
+    case "select": {
+      // Condition is an i32 bool; both arms must agree post-substitution.
+      const ct = typeOf.get(instr.condition);
+      const tt = typeOf.get(instr.whenTrue);
+      const ft = typeOf.get(instr.whenFalse);
+      if (!ct || !tt || !ft) return null;
+      if (!isI32Val(ct)) return null; // condition must stay a bool
+      if (!irTypeEquals(tt, ft)) return null; // arms must have identical Wasm type
+      return { instr: { ...instr, resultType: tt }, resultType: tt };
+    }
+    // box / unbox / tag.test carry an explicit target/tag ValType that is
+    // independent of the operand's substituted type. A substituted operand
+    // changes whether the box is still VALID (the value's type must be a
+    // member of the union), which we cannot re-verify here without the
+    // union registry — so conservatively abandon when these consume a
+    // tainted operand. (Polymorphic numeric helpers don't box internally;
+    // this only forgoes an exotic case, never miscompiles one.)
+    case "box":
+    case "unbox":
+    case "tag.test":
+      return null;
+    default:
+      // Any other instruction kind consuming a substituted param is outside
+      // the modelled set — abandon the clone rather than risk an unverified
+      // operator/operand mismatch.
+      return null;
   }
-  // Fall back to the callee's original declared return type.
-  if (callee.resultTypes.length >= 1) return callee.resultTypes[0]!;
-  throw new Error(`ir/monomorphize: cannot determine return type for clone of ${callee.name}`);
+}
+
+/**
+ * Result type of a binary op under (possibly retyped) operand types, or
+ * null when the op no longer accepts the operands. Mirrors the lowerer's
+ * 1:1 op→Wasm mapping: the op tag already fixes the expected operand
+ * domain, so re-inference is mostly a verification that the substituted
+ * operands still inhabit that domain.
+ */
+function reinferBinary(op: IrBinop, lt: IrType, rt: IrType): IrType | null {
+  switch (op) {
+    // f64 arithmetic → f64. BOTH operands must already be exactly f64 on the
+    // stack — there's no implicit widening. A substituted operand that
+    // changed away from f64 (to i32, a ref, etc.) is rejected: the body
+    // would emit `f64.add` on a non-f64 stack value (invalid Wasm).
+    case "f64.add":
+    case "f64.sub":
+    case "f64.mul":
+    case "f64.div":
+      if (!isF64Val(lt) || !isF64Val(rt)) return null;
+      return IR_F64;
+    // f64 comparisons → i32 bool. Operands must be exactly f64.
+    case "f64.eq":
+    case "f64.ne":
+    case "f64.lt":
+    case "f64.le":
+    case "f64.gt":
+    case "f64.ge":
+      if (!isF64Val(lt) || !isF64Val(rt)) return null;
+      return IR_I32;
+    // i32 ops: operands must be exactly i32-storage. bool lowers to i32.
+    case "i32.eq":
+    case "i32.ne":
+    case "i32.and":
+    case "i32.or":
+    case "i32.lt_s":
+    case "i32.le_s":
+    case "i32.gt_s":
+    case "i32.ge_s":
+    case "i32.lt_u":
+    case "i32.le_u":
+    case "i32.gt_u":
+    case "i32.ge_u":
+      if (!isI32Val(lt) || !isI32Val(rt)) return null;
+      return IR_I32;
+    // js.* bitwise composite ops are lowered as a ToInt32-dance on f64
+    // operands, returning f64. The lowering dispatch keys off the operand
+    // IrTypes (#1126 Stage 3 emits the native i32 path when both are i32),
+    // so changing an operand's storage type would silently switch the
+    // emitted op sequence. Only clone when operands are exactly f64 (the
+    // composite path) and keep the f64 result.
+    case "js.bitand":
+    case "js.bitor":
+    case "js.bitxor":
+    case "js.shl":
+    case "js.shr_s":
+    case "js.shr_u":
+      if (!isF64Val(lt) || !isF64Val(rt)) return null;
+      return IR_F64;
+    default:
+      return null;
+  }
+}
+
+/** Result type of a unary op under a retyped operand, or null when unsound. */
+function reinferUnary(op: IrUnop, ot: IrType): IrType | null {
+  switch (op) {
+    // f64 unary ops consume an f64 off the stack — operand must be exactly f64.
+    case "f64.neg":
+    case "f64.abs":
+    case "f64.sqrt":
+    case "f64.floor":
+    case "f64.ceil":
+    case "f64.trunc":
+      if (!isF64Val(ot)) return null;
+      return IR_F64;
+    case "i32.eqz":
+      if (!isI32Val(ot)) return null;
+      return IR_I32;
+    case "i32.trunc_sat_f64_s":
+      if (!isF64Val(ot)) return null;
+      return IR_I32;
+    case "ref.is_null":
+      // `ref.is_null` accepts ANY reference operand and returns i32 — this is
+      // the one genuinely ref-polymorphic op, so a clone whose param was
+      // retyped from one reference type to another stays sound. A numeric
+      // substitution (f64/i32) is invalid (ref.is_null needs a ref).
+      if (
+        ot.kind === "val" &&
+        (ot.val.kind === "ref" ||
+          ot.val.kind === "ref_null" ||
+          ot.val.kind === "externref" ||
+          ot.val.kind === "funcref")
+      ) {
+        return IR_I32;
+      }
+      if (
+        ot.kind === "string" ||
+        ot.kind === "object" ||
+        ot.kind === "class" ||
+        ot.kind === "extern" ||
+        ot.kind === "closure"
+      ) {
+        return IR_I32;
+      }
+      return null;
+    default:
+      return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/ir/phase3c.test.ts
+++ b/tests/ir/phase3c.test.ts
@@ -25,6 +25,7 @@ import {
   verifyIrFunction,
   type IrFunction,
   type IrInstr,
+  type IrType,
   type IrLowerResolver,
   type IrUnionLowering,
   type IrValueId,
@@ -201,9 +202,21 @@ describe("#1167c — monomorphize (unit)", () => {
     expect(result.cloneSignatures.size).toBe(0);
   });
 
-  it("skips callees whose body reads a param as an operand", () => {
-    // `double(n) = n + n` — `f64.add` consumes the param. Retyping to
-    // externref would invalidate the operator. isMonomorphizable rejects.
+  it("#1574 §2.4: abandons a param-arithmetic clone that would retype an f64 operand to i32", () => {
+    // `double(n) = n + n` — `f64.add` consumes the param. Called with an f64
+    // tuple and an i32 tuple. The canonical tuple sort puts `v:f64` before
+    // `v:i32`, so the f64 tuple keeps the original callee (no clone) and the
+    // i32 tuple is the clone CANDIDATE. Cloning it would leave the body's
+    // `f64.add` consuming i32 operands off the stack — INVALID Wasm (there's
+    // no implicit i32→f64 widening at the IR→Wasm boundary). `reinferBinary`
+    // returns null for `f64.add` on a non-f64 operand, so the clone is
+    // abandoned and the i32 call site stays on the original callee. Net: no
+    // clones.
+    //
+    // (Pre-#1574 the operand-free gate rejected the whole callee earlier; the
+    // observable "no clones" result is unchanged, but the rejection now
+    // happens at clone-construction time via the soundness check — which is
+    // what lets the SOUND ref-polymorphic case below succeed.)
     const doubler: IrFunction = {
       name: "double",
       params: [{ value: id(0), type: F64, name: "n" }],
@@ -230,10 +243,76 @@ describe("#1167c — monomorphize (unit)", () => {
       valueCount: 2,
     };
     const callerA = makeCallerPassingParam("run_a", "double", F64);
-    const callerB = makeCallerPassingParam("run_b", "double", EXTERNREF);
+    const callerB = makeCallerPassingParam("run_b", "double", I32);
 
     const result = monomorphize({ functions: [doubler, callerA, callerB] });
     expect(result.cloneSignatures.size).toBe(0);
+    // The unsound i32 call site must remain pointing at the original callee.
+    const callerBAfter = result.module.functions.find((f) => f.name === "run_b")!;
+    const bCall = callerBAfter.blocks[0]!.instrs.find((i) => i.kind === "call")! as Extract<IrInstr, { kind: "call" }>;
+    expect(bCall.target.name).toBe("double");
+  });
+
+  it("#1574 §2.4: clones a param-consuming ref.is_null body across reference tuples", () => {
+    // `isNull(x) = ref.is_null(x)` consumes the param. `ref.is_null` is the
+    // one genuinely ref-polymorphic op — valid for ANY reference operand —
+    // so substituting the param from externref to a struct ref keeps the
+    // body sound, and re-inference produces a distinct, valid clone. The
+    // result type (i32 bool) is unchanged across tuples; the param type
+    // shifts. This is the real capability §2.4 unlocks: a param-consuming
+    // body cloned per call-site reference type without invalid Wasm.
+    const STRUCT_REF: IrType = irVal({ kind: "ref", typeIdx: 7 });
+    const isNull: IrFunction = {
+      name: "isNull",
+      params: [{ value: id(0), type: EXTERNREF, name: "x" }],
+      resultTypes: [I32],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [{ kind: "unary", op: "ref.is_null", rand: id(0), result: id(1), resultType: I32 }],
+          terminator: { kind: "return", values: [id(1)] },
+        },
+      ],
+      exported: false,
+      valueCount: 2,
+    };
+    // Caller A passes an externref param; caller B passes a struct ref param.
+    // Both flow their param straight into isNull → two distinct ref tuples.
+    const callerExt = makeCallerPassingParam("run_ext", "isNull", EXTERNREF);
+    const callerStruct = makeCallerPassingParam("run_struct", "isNull", STRUCT_REF);
+    // Callers return i32 (the isNull result), not their param — fix the
+    // call-result type so the module verifies.
+    const fixCaller = (c: IrFunction): IrFunction => ({
+      ...c,
+      resultTypes: [I32],
+      blocks: c.blocks.map((b) => ({
+        ...b,
+        instrs: b.instrs.map((i) => (i.kind === "call" ? { ...i, resultType: I32 } : i)),
+      })),
+    });
+
+    const result = monomorphize({
+      functions: [isNull, fixCaller(callerExt), fixCaller(callerStruct)],
+    });
+
+    // One clone (first tuple keeps the original). The clone's param is the
+    // non-original reference type; its result type stays i32.
+    expect(result.cloneSignatures.size).toBe(1);
+    const cloneName = [...result.cloneSignatures.keys()][0]!;
+    expect(cloneName.startsWith("isNull$")).toBe(true);
+    const sig = result.cloneSignatures.get(cloneName)!;
+    expect(sig.returnType).toEqual(I32);
+    // The clone's param is a reference type (externref or the struct ref),
+    // not a numeric — and the clone body verifies.
+    const cloneFn = result.module.functions.find((f) => f.name === cloneName)!;
+    expect(cloneFn.params[0]!.type.kind).toBe("val");
+    expect(verifyIrFunction(cloneFn)).toEqual([]);
+    // The re-typed clone's ref.is_null result type is still i32.
+    const cloneInstr = cloneFn.blocks[0]!.instrs[0]! as Extract<IrInstr, { kind: "unary" }>;
+    expect(cloneInstr.op).toBe("ref.is_null");
+    expect(cloneInstr.resultType).toEqual(I32);
   });
 
   it("growth guard: fan-out that exceeds 1.5× module budget is rejected", () => {


### PR DESCRIPTION
## #1574 §2.4 — Re-infer resultType in monomorphize clones (sound subset)

`src/ir/passes/monomorphize.ts`. Relaxes the pass's "body must not consume any parameter as an operand" gate so param-consuming single-block callees become eligible for cloning. `cloneWithParamTypes` now re-types the clone body under the substituted params via `reinferCloneBody` → `reinferInstr` → `reinferBinary`/`reinferUnary`, and **abandons** the clone (the call-site group stays on the original callee) whenever any param-tainted instruction can't be soundly re-typed.

### Soundness model (this narrows the spec's §2.4 estimate)
Wasm arithmetic/comparison ops consume their operands' **exact** ValType off the stack — there's no implicit numeric coercion at the IR→Wasm boundary. So cloning `add(a,b){return a+b}` for an i32 tuple would leave `f64.add` consuming i32 operands → invalid Wasm, unless an `f64.convert_i32_s` is inserted (a separate operand-coercion layer, **future work**). The re-inferer therefore requires exact operand-storage match and abandons any clone that would change an arithmetic operand's storage type. **Strictly additive: never emits invalid Wasm.**

### What the sound subset unlocks
- identity-like bodies (param flows only to return/call) — already cloneable; re-inference is a no-op;
- **reference-polymorphic ops** (`ref.is_null`, `select` over a shared ref supertype) — a param-consuming body using those can now be cloned per call-site *reference* type. This is the genuine new capability.

### Tests
`tests/ir/phase3c.test.ts`:
- negative: `double(n)=n+n` called with f64+i32 tuples → i32 clone abandoned (would retype an f64 operand), call site stays on original;
- positive: `isNull(x)=ref.is_null(x)` called with externref + struct-ref tuples → one valid clone, result stays i32, body verifies.

IR fallback gate unchanged (this pass affects emitted-Wasm quality, not selection). Typecheck clean. The pre-existing `__box_number` LinkErrors in the local inline-small/passes/ir-*-equivalence suites are environment-related (no host import object supplied) and fail identically on the base — confirmed via `git stash`; this change adds zero new failures.

Full implementation notes + follow-ups (operand-coercion layer; closure-typed-param straggler; §2.5-already-done) recorded in `plan/issues/1574-ir-improvement-spec.md`. The issue stays `status: ready` (it's a multi-item research backlog, not a single deliverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)