### PR TITLE
test(#1104): Phase 3 instanceof + throw/catch regression test; mark done

### DIFF
--- a/plan/issues/1104-wasm-native-error-construction-and.md
+++ b/plan/issues/1104-wasm-native-error-construction-and.md
@@ -1,9 +1,10 @@
 ---
 id: 1104
 title: "Wasm-native Error construction and stack traces without JS host"
-status: ready
+status: done
 created: 2026-04-12
-updated: 2026-05-08
+updated: 2026-06-03
+completed: 2026-06-03
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -278,3 +279,38 @@ Land Phase 1 alone first behind a smoke-test that confirms WASI module
 instantiation. Phases 2-3 should follow in separate PRs to keep blast
 radius small. Architect available to refine Phase 2 surgery in detail once
 Phase 1 lands.
+
+## Completion (sd-1665, 2026-06-03)
+
+**Status: done.** All acceptance criteria (Phases 1-3) are satisfied on main;
+Phase 4 (stack traces) is explicitly deferred per the issue (`error.stack`
+returns `undefined` is acceptable).
+
+Phases 1-3 landed under the #1473 standalone-error-ops umbrella (the
+host-independence sprint), not a dedicated #1104 PR — which is why this issue
+sat at `status: ready` despite being implemented:
+
+- **Phase 1 (construction):** `src/codegen/registry/error-types.ts`
+  (`emitWasiErrorConstructor`, `isWasiErrorName`, `getOrRegisterErrorStructType`,
+  `WASI_ERROR_NAMES` incl. AggregateError) + `declarations.ts:1351` gate
+  `(ctx.wasi || ctx.standalone) && isWasiErrorName(name)` → emits native
+  `__new_<Name>` building `$Error_struct {tag i32, name, message}` instead of
+  the `env.__new_<Name>` host import. `tests/issue-1104-phase1.test.ts` (passes).
+- **Phase 2 (.message / .name):** `property-access.ts:1042-1064` emits direct
+  `struct.get $Error_struct <field>` in WASI mode. `tests/issue-1104-phase2.test.ts`
+  (passes).
+- **Phase 3 (instanceof + throw/catch):** `expressions/identifiers.ts:1049-1067`
+  (`compileHostInstanceOf`) discriminates `$Error_struct` by `$tag` and walks the
+  #1325 `BUILTIN_PARENT` chain; the externref exception payload already round-trips
+  the struct ref through `throw`/`catch`. Verified instanceof (same/parent/sibling)
+  and throw/catch all compile in WASI mode with **zero env imports** and return
+  spec-correct values. Locked by the new **`tests/issue-1104-phase3.test.ts`**
+  (6 cases, this PR) — the one missing test for already-shipped behaviour.
+
+Acceptance checklist: `new <Error>("msg")` standalone-instantiates ✅; all 8
+constructors compile ✅; `.name`/`.message` correct ✅; `instanceof` correct ✅;
+throw/catch with Error subclasses works ✅. Phase 4 deferred.
+
+Follow-ups (out of scope, not blocking done): `Error.prototype.toString()`
+(`"name: message"`), `AggregateError.errors` field access, and option-2 stack
+traces remain for a future PR if needed.

--- a/tests/issue-1104-phase3.test.ts
+++ b/tests/issue-1104-phase3.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1104 Phase 3 — native Error instanceof + throw/catch (standalone mode).
+//
+// Phase 1 (PR #324) made `new Error(...)` build a `$Error_struct` in WASI
+// mode; Phase 2 wired `.message` / `.name` reads to `struct.get`. Phase 3
+// makes `error instanceof TypeError` and `try { throw new RangeError() }
+// catch (e) { e instanceof ... }` work standalone, driven by the
+// `$Error_struct` `$tag` field (#1325 builtin-type-tag registry) instead of
+// the `__instanceof` host import — which is unavailable with no JS host.
+//
+// Scope (this file locks the already-landed behaviour against regression):
+//   1. `e instanceof <SameError>` → true; `e instanceof Error` (parent) → true;
+//      `e instanceof <OtherError>` → false. Subclass tag-walk via BUILTIN_PARENT.
+//   2. `try { throw new <Error> } catch (e) { e instanceof <Error> }` round-trips
+//      the struct ref through the externref exception payload and back.
+//   3. The WASI module instantiates with NO `env` imports and the exported
+//      function returns the spec-correct i32 (1 = true, 0 = false).
+//   4. JS-host mode is unchanged — instanceof still routes through the host
+//      path there (control case).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function runWasi(src: string): Promise<number> {
+  const r = await compile(src, { target: "wasi" });
+  expect(r.success).toBe(true);
+  // Standalone: no JS host imports needed for Error instanceof / throw-catch.
+  const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(envImports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#1104 Phase 3 — native Error instanceof + throw/catch (standalone mode)", () => {
+  describe("WASI mode — instanceof", () => {
+    it("`e instanceof TypeError` is true for a TypeError", async () => {
+      expect(
+        await runWasi(`
+          export function test(): number {
+            const e = new TypeError("x");
+            return (e instanceof TypeError) ? 1 : 0;
+          }
+        `),
+      ).toBe(1);
+    });
+
+    it("`e instanceof Error` is true for a TypeError (parent-chain tag walk)", async () => {
+      expect(
+        await runWasi(`
+          export function test(): number {
+            const e = new TypeError("x");
+            return (e instanceof Error) ? 1 : 0;
+          }
+        `),
+      ).toBe(1);
+    });
+
+    it("`e instanceof RangeError` is false for a TypeError (sibling)", async () => {
+      expect(
+        await runWasi(`
+          export function test(): number {
+            const e = new TypeError("x");
+            return (e instanceof RangeError) ? 1 : 0;
+          }
+        `),
+      ).toBe(0);
+    });
+  });
+
+  describe("WASI mode — throw / catch", () => {
+    it("catch binds the thrown Error struct; instanceof on it holds", async () => {
+      expect(
+        await runWasi(`
+          export function test(): number {
+            try {
+              throw new RangeError("r");
+            } catch (e) {
+              return (e instanceof RangeError) ? 1 : 0;
+            }
+          }
+        `),
+      ).toBe(1);
+    });
+
+    it("caught Error is also instanceof Error (parent) in standalone mode", async () => {
+      expect(
+        await runWasi(`
+          export function test(): number {
+            try {
+              throw new SyntaxError("s");
+            } catch (e) {
+              return (e instanceof Error) ? 1 : 0;
+            }
+          }
+        `),
+      ).toBe(1);
+    });
+  });
+
+  describe("JS-host mode unchanged (control)", () => {
+    it("instanceof still compiles in default (JS-host) mode", async () => {
+      const r = await compile(
+        `
+          export function test(): number {
+            const e = new TypeError("x");
+            return (e instanceof TypeError) ? 1 : 0;
+          }
+        `,
+      );
+      expect(r.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## #1104 — Wasm-native Error construction (standalone mode): close out + Phase 3 test

Recon found that #1104's implementation (Phases 1-3) **already landed** on main under the #1473 host-independence umbrella, but the issue sat at `status: ready` and **Phase 3 had no dedicated test**. This PR adds the missing Phase 3 regression test and marks the issue done.

### What's already on main (verified)
- **Phase 1 (construction):** `src/codegen/registry/error-types.ts` (`emitWasiErrorConstructor`, `isWasiErrorName`, `getOrRegisterErrorStructType`, `WASI_ERROR_NAMES`) + `declarations.ts:1351` gate `(ctx.wasi || ctx.standalone) && isWasiErrorName(name)` → native `__new_<Name>` building `$Error_struct {tag, name, message}` instead of `env.__new_<Name>`. `tests/issue-1104-phase1.test.ts` passes.
- **Phase 2 (.message/.name):** `property-access.ts:1042-1064` emits direct `struct.get $Error_struct`. `tests/issue-1104-phase2.test.ts` passes.
- **Phase 3 (instanceof + throw/catch):** `expressions/identifiers.ts:1049-1067` discriminates `$Error_struct` by `$tag` and walks the #1325 `BUILTIN_PARENT` chain; the externref exception payload round-trips the struct ref through `throw`/`catch`.

### This PR
- **`tests/issue-1104-phase3.test.ts`** (6 cases): instanceof same/parent/sibling + try/throw/catch round-trip, all compiling in WASI mode with **zero env imports** and returning spec-correct i32 values (verified by instantiate+run against `{}`), plus a JS-host control case. Locks the already-shipped Phase 3 behaviour against regression.
- Marks `plan/issues/1104-...md` `status: done` with a completion note. **Phase 4 (stack traces) explicitly deferred** — `error.stack === undefined` is acceptable per the issue.

### Risk
Additive only — one new test file + issue-file status. No `src/` changes, so zero behaviour change and no test262/equivalence impact. `tsc --noEmit` clean; all 26 tests across the 3 phase files pass.

Acceptance criteria (Phases 1-3) all satisfied: standalone `new <Error>("msg")` ✅; all 8 constructors ✅; `.name`/`.message` ✅; `instanceof` ✅; throw/catch with Error subclasses ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)