### PR TITLE
fix(#1718): Iterator static-helper arity + property descriptors

### DIFF
--- a/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
+++ b/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
@@ -112,6 +112,38 @@ the same #1320 iterator-identity chain — carve + escalate per the issue
 guardrail if they need the compiled-value↔host-iterator foundation.
 
 
+## S2 (landed 2026-06-03) — static-helper arity + property descriptors
+
+Localized spec-compliance fix in `src/runtime.ts`
+(`_installIteratorHelperPolyfills`). The polyfilled `Iterator.from` / `zip` /
+`zipKeyed` / `concat` were installed via raw `Object.defineProperty`, so the
+TS optional param (`options?`) inflated the function `.length` to **2** —
+§17/§27 mandate `1` for `from`/`zip`/`zipKeyed` and `0` for the variadic
+`concat`. Their own `length`/`name` data-properties were also left with the
+default `writable:true`, failing the test262 `verifyProperty` checks.
+
+Added `_installStaticHelper(target, name, length, impl)` (mirrors the existing
+`_installBuiltinMethod`): resets `fn.length`/`fn.name` to spec values with
+`{writable:false, enumerable:false, configurable:true}` and installs the
+property on `Iterator` with `{writable:true, enumerable:false,
+configurable:true}` (§17 default data-property attributes). Converted the four
+static installs to use it. Runtime iteration behaviour unchanged.
+
+Result (host-runner tally, this Node which ships only native `flatMap`):
+`zip` 8→9, `zipKeyed` 8→9 (the `length.js` `verifyProperty` cases now pass),
+`concat`/`flatMap` unchanged, **no regressions**. Unit test:
+`tests/issue-1718-static-arity.test.ts` (18 cases).
+
+**Remaining (bridge-blocked, NOT this slice):** the dominant residual buckets
+are `Iterator helper: argument is not iterable` (concat ~18, zipKeyed ~16) and
+`flatMap is not a function` (~7). These all reduce to the same root cause:
+a **compiled object literal / generator carrying a `[Symbol.iterator]` (or
+`flatMap`) method is opaque to the host polyfill** — the well-known-symbol
+method and the `%Iterator.prototype%` chain don't survive the
+compiled-value↔host boundary. That is the #1320 / #1665 iterator-bridge
+foundation (`related: [1320]`), explicitly escalated as needs-architect and
+out of a localized dev's scope. Issue stays `ready` for those slices.
+
 ### Type-check lib (lib.esnext.iterator.d.ts) — DEFERRED
 
 Adding lib.esnext.iterator.d.ts to the checker lib set (src/checker/index.ts)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -122,6 +122,41 @@ function _installBuiltinMethod(
 }
 
 /**
+ * Install a static helper (e.g. `Iterator.zip`) with spec-correct property
+ * descriptors. The function's own `length` and `name` are reset to the
+ * spec-mandated values with attributes `{writable:false, enumerable:false,
+ * configurable:true}` (§17 — built-in function `length`/`name`), and the
+ * property on `target` itself is `{writable:true, enumerable:false,
+ * configurable:true}` (§17 default data-property attributes). TS optional
+ * params (`options?`) inflate `fn.length`, so we override it explicitly.
+ */
+function _installStaticHelper(
+  target: object,
+  name: string,
+  length: number,
+  impl: (this: any, ...args: any[]) => any,
+): void {
+  Object.defineProperty(impl, "length", {
+    value: length,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  Object.defineProperty(impl, "name", {
+    value: name,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  Object.defineProperty(target, name, {
+    value: impl,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+/**
  * Build `%IteratorPrototype%` (spec §27.1.2). Its sole own property is
  * `[Symbol.iterator]()` which returns `this`. `%GeneratorPrototype%` inherits
  * from it so generators are iterable. (#1639) We build it explicitly rather
@@ -553,12 +588,8 @@ function _installIteratorHelperPolyfills(): void {
   }
 
   if (typeof I.from !== "function") {
-    Object.defineProperty(I, "from", {
-      value: function from(iterable: any) {
-        return _getFlattenable(iterable);
-      },
-      writable: true,
-      configurable: true,
+    _installStaticHelper(I, "from", 1, function from(iterable: any) {
+      return _getFlattenable(iterable);
     });
   }
 
@@ -829,194 +860,182 @@ function _installIteratorHelperPolyfills(): void {
   }
 
   if (typeof I.zip !== "function") {
-    Object.defineProperty(I, "zip", {
-      value: function zip(iterables: any, options?: any) {
-        if (iterables == null) {
-          throw new TypeError("Iterator.zip: iterables required");
+    _installStaticHelper(I, "zip", 1, function zip(iterables: any, options?: any) {
+      if (iterables == null) {
+        throw new TypeError("Iterator.zip: iterables required");
+      }
+      const mode: string = (options && options.mode) || "shortest";
+      if (mode !== "shortest" && mode !== "longest" && mode !== "strict") {
+        throw new TypeError("Iterator.zip: invalid mode " + String(mode));
+      }
+      const padding: any[] = options && options.padding ? Array.from(options.padding) : [];
+      const iters: any[] = [];
+      // Open all iterators eagerly; on failure, close already-opened ones.
+      try {
+        for (const iterable of iterables) {
+          iters.push(_getFlattenable(iterable));
         }
-        const mode: string = (options && options.mode) || "shortest";
-        if (mode !== "shortest" && mode !== "longest" && mode !== "strict") {
-          throw new TypeError("Iterator.zip: invalid mode " + String(mode));
+      } catch (e) {
+        for (const it of iters) {
+          try {
+            it.return?.();
+          } catch {}
         }
-        const padding: any[] = options && options.padding ? Array.from(options.padding) : [];
-        const iters: any[] = [];
-        // Open all iterators eagerly; on failure, close already-opened ones.
-        try {
-          for (const iterable of iterables) {
-            iters.push(_getFlattenable(iterable));
-          }
-        } catch (e) {
-          for (const it of iters) {
+        throw e;
+      }
+      const closed: boolean[] = iters.map(() => false);
+      let exhausted = false;
+
+      function closeAllExcept(except: number): void {
+        for (let i = 0; i < iters.length; i++) {
+          if (i !== except && !closed[i]) {
+            closed[i] = true;
             try {
-              it.return?.();
+              iters[i].return?.();
             } catch {}
           }
-          throw e;
         }
-        const closed: boolean[] = iters.map(() => false);
-        let exhausted = false;
+      }
 
-        function closeAllExcept(except: number): void {
+      return _makeHelperIterator(
+        function next() {
+          if (exhausted || iters.length === 0) return { value: undefined, done: true };
+          const tuple: any[] = new Array(iters.length);
+          let liveCount = 0;
           for (let i = 0; i < iters.length; i++) {
-            if (i !== except && !closed[i]) {
-              closed[i] = true;
-              try {
-                iters[i].return?.();
-              } catch {}
+            if (closed[i]) {
+              tuple[i] = padding[i];
+              continue;
             }
-          }
-        }
-
-        return _makeHelperIterator(
-          function next() {
-            if (exhausted || iters.length === 0) return { value: undefined, done: true };
-            const tuple: any[] = new Array(iters.length);
-            let liveCount = 0;
-            for (let i = 0; i < iters.length; i++) {
-              if (closed[i]) {
-                tuple[i] = padding[i];
-                continue;
-              }
-              let r: any;
-              try {
-                r = iters[i].next();
-              } catch (e) {
+            let r: any;
+            try {
+              r = iters[i].next();
+            } catch (e) {
+              exhausted = true;
+              closeAllExcept(i);
+              throw e;
+            }
+            if (r && r.done) {
+              closed[i] = true;
+              if (mode === "shortest") {
                 exhausted = true;
                 closeAllExcept(i);
-                throw e;
+                return { value: undefined, done: true };
               }
-              if (r && r.done) {
-                closed[i] = true;
-                if (mode === "shortest") {
-                  exhausted = true;
-                  closeAllExcept(i);
-                  return { value: undefined, done: true };
-                }
-                if (mode === "strict") {
-                  // Strict: every other iterator must also be done.
-                  for (let j = 0; j < iters.length; j++) {
-                    if (j === i || closed[j]) continue;
-                    let r2: any;
-                    try {
-                      r2 = iters[j].next();
-                    } catch (e) {
-                      closeAllExcept(-1);
-                      throw e;
-                    }
-                    if (r2 && !r2.done) {
-                      closeAllExcept(-1);
-                      throw new RangeError("Iterator.zip strict mode: length mismatch");
-                    }
-                    closed[j] = true;
+              if (mode === "strict") {
+                // Strict: every other iterator must also be done.
+                for (let j = 0; j < iters.length; j++) {
+                  if (j === i || closed[j]) continue;
+                  let r2: any;
+                  try {
+                    r2 = iters[j].next();
+                  } catch (e) {
+                    closeAllExcept(-1);
+                    throw e;
                   }
-                  exhausted = true;
-                  return { value: undefined, done: true };
+                  if (r2 && !r2.done) {
+                    closeAllExcept(-1);
+                    throw new RangeError("Iterator.zip strict mode: length mismatch");
+                  }
+                  closed[j] = true;
                 }
-                tuple[i] = padding[i];
-              } else {
-                tuple[i] = r.value;
-                liveCount++;
+                exhausted = true;
+                return { value: undefined, done: true };
               }
+              tuple[i] = padding[i];
+            } else {
+              tuple[i] = r.value;
+              liveCount++;
             }
-            if (mode === "longest" && liveCount === 0) {
-              exhausted = true;
-              return { value: undefined, done: true };
-            }
-            return { value: tuple, done: false };
-          },
-          function returnFn() {
+          }
+          if (mode === "longest" && liveCount === 0) {
             exhausted = true;
-            closeAllExcept(-1);
             return { value: undefined, done: true };
-          },
-        );
-      },
-      writable: true,
-      configurable: true,
+          }
+          return { value: tuple, done: false };
+        },
+        function returnFn() {
+          exhausted = true;
+          closeAllExcept(-1);
+          return { value: undefined, done: true };
+        },
+      );
     });
   }
 
   if (typeof I.zipKeyed !== "function") {
-    Object.defineProperty(I, "zipKeyed", {
-      value: function zipKeyed(iterables: any, options?: any) {
-        if (iterables == null || typeof iterables !== "object") {
-          throw new TypeError("Iterator.zipKeyed: iterables must be an object");
-        }
-        const keys = Object.keys(iterables);
-        const iterArr: any[] = keys.map((k) => iterables[k]);
-        const zipped = (I as any).zip(iterArr, options);
-        return _makeHelperIterator(
-          function next() {
-            const r = zipped.next();
-            if (r.done) return { value: undefined, done: true };
-            const out: any = {};
-            for (let i = 0; i < keys.length; i++) out[keys[i]!] = r.value[i];
-            return { value: out, done: false };
-          },
-          function returnFn() {
-            try {
-              zipped.return?.();
-            } catch {}
-            return { value: undefined, done: true };
-          },
-        );
-      },
-      writable: true,
-      configurable: true,
+    _installStaticHelper(I, "zipKeyed", 1, function zipKeyed(iterables: any, options?: any) {
+      if (iterables == null || typeof iterables !== "object") {
+        throw new TypeError("Iterator.zipKeyed: iterables must be an object");
+      }
+      const keys = Object.keys(iterables);
+      const iterArr: any[] = keys.map((k) => iterables[k]);
+      const zipped = (I as any).zip(iterArr, options);
+      return _makeHelperIterator(
+        function next() {
+          const r = zipped.next();
+          if (r.done) return { value: undefined, done: true };
+          const out: any = {};
+          for (let i = 0; i < keys.length; i++) out[keys[i]!] = r.value[i];
+          return { value: out, done: false };
+        },
+        function returnFn() {
+          try {
+            zipped.return?.();
+          } catch {}
+          return { value: undefined, done: true };
+        },
+      );
     });
   }
 
   if (typeof I.concat !== "function") {
-    Object.defineProperty(I, "concat", {
-      value: function concat(...iterables: any[]) {
-        // Eagerly validate the iterable-ness of each argument; open lazily.
-        for (const iterable of iterables) {
-          if (iterable == null) {
-            throw new TypeError("Iterator.concat: argument is null or undefined");
-          }
-          const sym = iterable[Symbol.iterator];
-          if (typeof sym !== "function" && typeof iterable.next !== "function") {
-            throw new TypeError("Iterator.concat: argument is not iterable");
-          }
+    _installStaticHelper(I, "concat", 0, function concat(...iterables: any[]) {
+      // Eagerly validate the iterable-ness of each argument; open lazily.
+      for (const iterable of iterables) {
+        if (iterable == null) {
+          throw new TypeError("Iterator.concat: argument is null or undefined");
         }
-        let idx = 0;
-        let current: any = null;
-        return _makeHelperIterator(
-          function next() {
-            while (true) {
-              if (current == null) {
-                if (idx >= iterables.length) return { value: undefined, done: true };
-                current = _getFlattenable(iterables[idx++]);
-              }
-              let r: any;
-              try {
-                r = current.next();
-              } catch (e) {
-                current = null;
-                idx = iterables.length;
-                throw e;
-              }
-              if (r && r.done) {
-                current = null;
-                continue;
-              }
-              return r;
+        const sym = iterable[Symbol.iterator];
+        if (typeof sym !== "function" && typeof iterable.next !== "function") {
+          throw new TypeError("Iterator.concat: argument is not iterable");
+        }
+      }
+      let idx = 0;
+      let current: any = null;
+      return _makeHelperIterator(
+        function next() {
+          while (true) {
+            if (current == null) {
+              if (idx >= iterables.length) return { value: undefined, done: true };
+              current = _getFlattenable(iterables[idx++]);
             }
-          },
-          function returnFn() {
-            if (current != null) {
-              try {
-                current.return?.();
-              } catch {}
+            let r: any;
+            try {
+              r = current.next();
+            } catch (e) {
+              current = null;
+              idx = iterables.length;
+              throw e;
             }
-            idx = iterables.length;
-            current = null;
-            return { value: undefined, done: true };
-          },
-        );
-      },
-      writable: true,
-      configurable: true,
+            if (r && r.done) {
+              current = null;
+              continue;
+            }
+            return r;
+          }
+        },
+        function returnFn() {
+          if (current != null) {
+            try {
+              current.return?.();
+            } catch {}
+          }
+          idx = iterables.length;
+          current = null;
+          return { value: undefined, done: true };
+        },
+      );
     });
   }
 

--- a/tests/issue-1718-static-arity.test.ts
+++ b/tests/issue-1718-static-arity.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #1718 — Iterator sequencing static helpers (Iterator.from/zip/zipKeyed/concat)
+ * must carry spec-correct `length`/`name`/property descriptors (§17).
+ *
+ * The polyfill in `_installIteratorHelperPolyfills` previously installed these
+ * via raw `Object.defineProperty`, so a TS optional param (`options?`) inflated
+ * the function `.length` to 2 (spec mandates 1 for zip/zipKeyed, 1 for from,
+ * 0 for the variadic concat). It also left the function's own `length`/`name`
+ * as the default writable descriptor. This regressed the test262
+ * `built-ins/Iterator/{zip,zipKeyed}/length.js` `verifyProperty` checks.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { buildImports } from "../src/runtime.ts";
+
+beforeAll(() => {
+  // Installs the ES2025 Iterator helper polyfills on globalThis.Iterator.
+  buildImports([], undefined, []);
+});
+
+const I = (globalThis as any).Iterator;
+
+describe("#1718 static helper arity + descriptors", () => {
+  it.each([
+    ["from", 1],
+    ["zip", 1],
+    ["zipKeyed", 1],
+    ["concat", 0],
+  ])("Iterator.%s has spec length %i", (name, len) => {
+    expect(typeof I[name]).toBe("function");
+    expect(I[name].length).toBe(len);
+  });
+
+  it.each(["from", "zip", "zipKeyed", "concat"])(
+    "Iterator.%s length is non-writable/non-enumerable/configurable",
+    (name) => {
+      const d = Object.getOwnPropertyDescriptor(I[name], "length")!;
+      expect(d.writable).toBe(false);
+      expect(d.enumerable).toBe(false);
+      expect(d.configurable).toBe(true);
+    },
+  );
+
+  it.each(["from", "zip", "zipKeyed", "concat"])("Iterator.%s name matches and is non-writable", (name) => {
+    expect(I[name].name).toBe(name);
+    const d = Object.getOwnPropertyDescriptor(I[name], "name")!;
+    expect(d.writable).toBe(false);
+    expect(d.enumerable).toBe(false);
+    expect(d.configurable).toBe(true);
+  });
+
+  it.each(["from", "zip", "zipKeyed", "concat"])(
+    "Iterator.%s property is writable/non-enumerable/configurable (§17 default)",
+    (name) => {
+      const d = Object.getOwnPropertyDescriptor(I, name)!;
+      expect(d.writable).toBe(true);
+      expect(d.enumerable).toBe(false);
+      expect(d.configurable).toBe(true);
+    },
+  );
+
+  it("runtime behaviour preserved: concat flattens iterables in order", () => {
+    let sum = 0;
+    for (const x of I.concat([1, 2], [3])) sum += x;
+    expect(sum).toBe(6);
+  });
+
+  it("runtime behaviour preserved: zip pairs shortest", () => {
+    let sum = 0;
+    for (const pair of I.zip([
+      [1, 2],
+      [3, 4],
+    ]))
+      sum += pair[0] + pair[1];
+    expect(sum).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
Localized spec-compliance fix for the ES2025 Iterator sequencing static helpers (#1718). `Iterator.from` / `zip` / `zipKeyed` / `concat` polyfills were installed via raw `Object.defineProperty`, so the TS optional `options?` param inflated the function `.length` to **2** — §17/§27 mandate **1** for `from`/`zip`/`zipKeyed` and **0** for the variadic `concat`. Their own `length`/`name` data-properties were also left with the default `writable:true`, failing the test262 `built-ins/Iterator/{zip,zipKeyed}/length.js` `verifyProperty` checks.

## Change
- New `_installStaticHelper(target, name, length, impl)` in `src/runtime.ts` (mirrors `_installBuiltinMethod`): resets `fn.length`/`fn.name` with `{writable:false, enumerable:false, configurable:true}`, installs the property with the §17 default `{writable:true, enumerable:false, configurable:true}`.
- Converted the four static installs to use it. Runtime iteration behaviour unchanged.

## Result
Host-runner tally: `zip` 8→9, `zipKeyed` 8→9, `concat`/`flatMap` unchanged, **no regressions**. Unit test `tests/issue-1718-static-arity.test.ts` (18 cases).

## Out of scope
Remaining #1718 buckets (concat/zipKeyed `argument is not iterable`, flatMap `is not a function`) are the #1320/#1665 compiled-object↔host iterator bridge; #1718 stays `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)