### PR TITLE
fix(#1718): zip/zipKeyed GetOptionsObject validation

### DIFF
--- a/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
+++ b/plan/issues/1718-iterator-sequencing-helpers-concat-zip-flatmap.md
@@ -132,7 +132,16 @@ static installs to use it. Runtime iteration behaviour unchanged.
 Result (host-runner tally, this Node which ships only native `flatMap`):
 `zip` 8→9, `zipKeyed` 8→9 (the `length.js` `verifyProperty` cases now pass),
 `concat`/`flatMap` unchanged, **no regressions**. Unit test:
-`tests/issue-1718-static-arity.test.ts` (18 cases).
+`tests/issue-1718-static-arity.test.ts`.
+
+**Also in S2 — GetOptionsObject validation (+2 tests).** `zip`/`zipKeyed`
+silently treated a non-object `options` argument (`null`, boolean, number,
+string, symbol, bigint) as "no options" instead of throwing. Added
+`_getOptionsObject(options)` per the iterator-sequencing/joint-iteration
+proposal (`undefined` → null-proto object; Object → as-is; else TypeError)
+and applied it in `zip` (which `zipKeyed` delegates through). Flips
+`built-ins/Iterator/{zip,zipKeyed}/options.js` → pass; no iteration involved
+so this is independent of the #1320 bridge.
 
 **Remaining (bridge-blocked, NOT this slice):** the dominant residual buckets
 are `Iterator helper: argument is not iterable` (concat ~18, zipKeyed ~16) and

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -564,6 +564,16 @@ function _installIteratorHelperPolyfills(): void {
     return it;
   }
 
+  // ES2025 GetOptionsObject (iterator-sequencing / joint-iteration proposal):
+  // undefined → fresh null-proto object; Object → returned as-is; any other
+  // value (null, boolean, number, string, symbol, bigint) throws TypeError.
+  function _getOptionsObject(options: any): any {
+    if (options === undefined) return Object.create(null);
+    if (typeof options === "object" && options !== null) return options;
+    if (typeof options === "function") return options;
+    throw new TypeError("Iterator options must be undefined or an object");
+  }
+
   function _makeHelperIterator(nextFn: () => any, returnFn: (v?: any) => any): any {
     const obj: any = Object.create(Iproto);
     obj.next = nextFn;
@@ -864,7 +874,8 @@ function _installIteratorHelperPolyfills(): void {
       if (iterables == null) {
         throw new TypeError("Iterator.zip: iterables required");
       }
-      const mode: string = (options && options.mode) || "shortest";
+      options = _getOptionsObject(options);
+      const mode: string = options.mode || "shortest";
       if (mode !== "shortest" && mode !== "longest" && mode !== "strict") {
         throw new TypeError("Iterator.zip: invalid mode " + String(mode));
       }

--- a/tests/issue-1718-static-arity.test.ts
+++ b/tests/issue-1718-static-arity.test.ts
@@ -74,3 +74,23 @@ describe("#1718 static helper arity + descriptors", () => {
     expect(sum).toBe(10);
   });
 });
+
+describe("#1718 zip/zipKeyed GetOptionsObject validation", () => {
+  // ES2025 GetOptionsObject: options must be undefined or an Object; any other
+  // value throws TypeError (test262 Iterator/{zip,zipKeyed}/options.js).
+  const invalid = [null, true, "", Symbol(), 0, 0n];
+
+  it.each(invalid)("Iterator.zipKeyed({}, %o) throws TypeError", (bad) => {
+    expect(() => I.zipKeyed({}, bad)).toThrow(TypeError);
+  });
+
+  it.each(invalid)("Iterator.zip([], %o) throws TypeError", (bad) => {
+    expect(() => I.zip([], bad)).toThrow(TypeError);
+  });
+
+  it("accepts undefined and object options", () => {
+    expect(() => I.zipKeyed({})).not.toThrow();
+    expect(() => I.zipKeyed({}, undefined)).not.toThrow();
+    expect(() => I.zipKeyed({}, {})).not.toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to PR #1092 (which merged the static-helper arity/descriptor fix). That PR landed before this commit registered, so this opens a fresh PR for the remaining localized slice.

## What
`Iterator.zip` / `Iterator.zipKeyed` silently coerced a non-object `options` argument (`null`, boolean, number, string, symbol, bigint) to 'no options' instead of throwing. Per the iterator-sequencing / joint-iteration proposal, **GetOptionsObject(options)** must:
- `undefined` → fresh null-proto object
- Object → return as-is
- anything else → throw **TypeError**

Added `_getOptionsObject()` in `_installIteratorHelperPolyfills` and applied it in `zip` (which `zipKeyed` delegates through).

## Result
Flips `built-ins/Iterator/{zip,zipKeyed}/options.js` → pass (+2). No iteration involved, so independent of the #1320 compiled-object↔host iterator bridge. JS-host-only runtime polyfill change.

## Tests
`tests/issue-1718-static-arity.test.ts` — added a `GetOptionsObject validation` describe block (zip + zipKeyed reject all 6 invalid option types, accept undefined/object). Full file 31 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)