### PR TITLE
fix(#846): RequireObjectCoercible for empty/nested object destructuring

### DIFF
--- a/plan/issues/846-assert-throws-not-thrown-built.md
+++ b/plan/issues/846-assert-throws-not-thrown-built.md
@@ -1,16 +1,17 @@
 ---
 id: 846
 title: "assert.throws not thrown: built-in methods accept invalid arguments silently (2,799 tests)"
-status: ready
+status: in-review
 created: 2026-03-28
-updated: 2026-04-28
+updated: 2026-06-03
 priority: critical
 feasibility: hard
 reasoning_effort: max
 goal: core-semantics
-sprint: Backlog
+sprint: 58
 parent: 779
 test262_fail: 2799
+pr: PENDING
 ---
 # #846 -- assert.throws not thrown: built-in methods accept invalid arguments silently (2,799 tests)
 
@@ -279,3 +280,82 @@ localized fix.
 are the already-dispatched child issues (#1594, #1592, #1553, #820 family).
 The only genuinely new, isolated micro-bucket is array-`length` RangeError
 (~28) — too small to be worth a standalone PR under the ≥200 target.
+
+## Slice landed (sd-1472, 2026-06-03): RequireObjectCoercible for empty/nested object patterns
+
+### Fresh re-profile vs the stale 2026-05-21/05-27 notes
+Most of the overlapping child issues cited above are now **done** on main
+(#1594, #1592, #1553, #1543, #1630), so the residual #846 surface shifted.
+Re-profiling the 2026-05-28 baseline jsonl found **1,282** remaining
+`assert.throws(ErrType,…)`-not-thrown failures (down from 2,799). Within the
+destructuring slice there is one clean, spec-localized root cause worth a
+standalone PR:
+
+**Destructuring a `null`/`undefined` value through an EMPTY object pattern did
+not throw.** Confirmed via probe: `let {} = null`, `let {} = undefined`,
+`const {} = null`, `for (const {} of [null])`, and the nested form
+`{ w: {} } = { w: null }` all silently succeeded; `let {a} = null` (non-empty)
+already threw correctly.
+
+### Root cause (WHY)
+Per **ECMA-262 8.6.2 BindingInitialization**, the production
+`BindingPattern : ObjectBindingPattern` runs `Perform ?
+RequireObjectCoercible(value)` as **step 1** — *before* the inner
+`ObjectBindingPattern : { }` rule (which "Return unused"). So the coercibility
+check fires even for `{}`. The codegen had a confidently-wrong comment
+(introduced under #225 / #1553c) claiming the empty pattern performs "no
+property access and therefore no RequireObjectCoercible", and short-circuited
+the empty object-binding-decl path (`compileExternrefObjectDestructuringDecl`)
+*before* the null/undefined guard. The fixture
+`statements/const/dstr/obj-init-null.js` documents the trap: its `info:` block
+cites `ObjectBindingPattern : { } → Return NormalCompletion(empty)` yet asserts
+a TypeError — because the *outer* `BindingPattern` wrapper does the
+RequireObjectCoercible. The parameter path (`destructureParamObject`, guard at
+the externref branch before its empty short-circuit) and the assignment path
+(`emitExternrefAssignDestructureGuard`, fixed under #1701) were already correct;
+only the binding-declaration + the empty-nested paths were not.
+
+### Changes (2 files, surgical)
+1. `src/codegen/statements/destructuring.ts` —
+   `compileExternrefObjectDestructuringDecl`: emit
+   `emitExternrefDestructureGuard(tmpLocal)` (the existing null + JS-undefined
+   RequireObjectCoercible guard) before the empty-pattern short-circuit. Fixes
+   `let/const/var {} = null|undefined` AND the for-of binding-pattern path
+   (loops.ts routes for-of object binding patterns through this same helper).
+   The guard fires only for null/undefined, so coercible primitives
+   (`{} = 5`, `{} = "s"`) still pass — verified.
+2. `src/codegen/destructuring-params.ts` —
+   `destructureParamObjectExternref` nested-element handler: drop the
+   `element.name.elements.length > 0` gate so the nested coercibility guard
+   also fires for empty nested patterns (`{ w: {} } = { w: null }`). Spec-clean:
+   the guard is null/undefined-only.
+
+### Considered and deliberately deferred (higher risk, separate root cause)
+- **Array-assignment non-iterable** (`for ([] of [1])`, `[] = 5`): needs a
+  `GetIterator` probe (calling `value[Symbol.iterator]()` then IteratorClose)
+  on the empty/elision array path. The empty-array path intentionally skips
+  `__array_from_iter` to avoid advancing generators; adding iterability without
+  that side effect is a distinct change. ~12 for-of + a few assignment tests.
+- **Typed-struct static-`null` nested** (`for (var {w:{x}=d} of [{w:null}])`):
+  the `[{w:null}]` literal is constant-folded and the inner destructure is
+  optimized away before any guard site; chasing this through the
+  `compileForOfDestructuring` typed/vec paths added **3 false "regressions"**
+  in one attempt and zero validated wins, so it was reverted. ~6 tests.
+
+### Validation
+- New equivalence test `tests/equivalence/destructuring-require-object-coercible.test.ts`
+  (10 cases) — all pass.
+- Existing destructuring equivalence suites: 97/97 pass.
+- **Delta**: of 146 baseline-failing dstr-noncoercible candidates, **38 now
+  pass** (object RequireObjectCoercible family across const/let/var binding
+  decls, for-of object binding patterns, nested empty object patterns).
+- **Regressions**: 0 real. Broad sweeps via the test262 runner on
+  baseline-PASSING tests: 400-test dstr sample 392/400 (8 apparent failures all
+  reproduce on clean main HEAD = pre-existing baseline drift, `it.next is not a
+  function` / iterator-elision, unrelated to coercibility), 200/200
+  nested-pattern, 235/238 for-of-nested (the 3 `*-ary-init-iter-no-close` also
+  fail on clean main = drift). `tsc --noEmit` clean; `check:ir-fallbacks` OK.
+
+**Umbrella remains open** — this is one slice. Remaining mergeable buckets:
+array-assignment GetIterator, array-`length` RangeError (~28), and the
+descriptor-model work under #1630.

--- a/plan/issues/846-assert-throws-not-thrown-built.md
+++ b/plan/issues/846-assert-throws-not-thrown-built.md
@@ -11,7 +11,7 @@ goal: core-semantics
 sprint: 58
 parent: 779
 test262_fail: 2799
-pr: PENDING
+pr: 1098
 ---
 # #846 -- assert.throws not thrown: built-in methods accept invalid arguments silently (2,799 tests)
 

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -487,13 +487,16 @@ export function destructureParamObjectExternref(
         }
       }
 
-      // Per ECMA-262 §13.15.5.5 RequireObjectCoercible / §8.4.2 GetIterator,
-      // destructuring null/undefined through a non-empty nested pattern must
-      // throw TypeError. Emit the guard BEFORE recursing so we throw even when
-      // the nested destructure path silently no-ops on null (#1225).
-      if (element.name.elements.length > 0) {
-        emitExternrefDestructureGuard(ctx, fctx, nestedLocal);
-      }
+      // Per ECMA-262 8.6.2 BindingInitialization, both
+      // `BindingPattern : ObjectBindingPattern` (RequireObjectCoercible) and
+      // `BindingPattern : ArrayBindingPattern` (GetIterator) run their
+      // coercibility step FIRST — even for an empty nested pattern `{}` / `[]`.
+      // So `{ w: {} } = { w: null }` and `{ w: [] } = { w: null }` must throw
+      // TypeError. Emit the null/undefined guard unconditionally (the prior
+      // `length > 0` gate skipped empty nested patterns — #846). The guard only
+      // fires for null/undefined, so coercible primitive values still pass.
+      // (#1225 / #846)
+      emitExternrefDestructureGuard(ctx, fctx, nestedLocal);
 
       if (ts.isObjectBindingPattern(element.name)) {
         destructureParamObjectExternref(ctx, fctx, nestedLocal, element.name, opts);

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -23,6 +23,7 @@ import {
   buildDestructureNullThrow,
   destructureParamArray,
   destructureParamObject,
+  emitExternrefDestructureGuard,
 } from "../destructuring-params.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { emitWasiErrorConstructor } from "../registry/error-types.js";
@@ -876,13 +877,22 @@ export function compileExternrefObjectDestructuringDecl(
   const tmpLocal = allocLocal(fctx, `__ext_obj_destruct_${fctx.locals.length}`, resultType);
   fctx.body.push({ op: "local.set", index: tmpLocal });
 
-  // Per ECMA-262 §13.15.5.5, an empty ObjectBindingPattern `{}` performs no
-  // property access and therefore no RequireObjectCoercible: `const {} = null`
-  // must NOT throw. `destructureParamObject` emits an unconditional
-  // null/undefined guard for externref sources, so we must short-circuit the
-  // empty pattern here before delegating (the binding-locals pre-pass is a
-  // no-op for an empty pattern). (#1553c — preserves twin behaviour.)
+  // Per ECMA-262 8.6.2 BindingInitialization, the production
+  // `BindingPattern : ObjectBindingPattern` runs `Perform ?
+  // RequireObjectCoercible(value)` as step 1 — BEFORE the inner
+  // `ObjectBindingPattern : { }` rule (which returns unused). So `const {} =
+  // null` / `const {} = undefined` MUST throw a TypeError, while `const {} = 5`
+  // must NOT (a number is object-coercible). The earlier blanket short-circuit
+  // (#846) skipped the coercibility check for empty patterns, silently
+  // accepting null/undefined — observably wrong (test262
+  // dstr-binding/obj-init-null + for-of/dstr/const-obj-init-*). Emit the same
+  // null/undefined RequireObjectCoercible guard that the parameter path
+  // (`destructureParamObject`) and assignment path
+  // (`emitExternrefAssignDestructureGuard`) already use, then short-circuit the
+  // no-property-access empty body. The guard only fires for null/undefined, so
+  // primitive sources still pass through unchanged. (#846)
   if (pattern.elements.length === 0) {
+    emitExternrefDestructureGuard(ctx, fctx, tmpLocal);
     ensureBindingLocals(ctx, fctx, pattern);
     return;
   }

--- a/tests/equivalence/destructuring-require-object-coercible.test.ts
+++ b/tests/equivalence/destructuring-require-object-coercible.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.ts";
+
+// #846 — Destructuring a `null`/`undefined` value must throw TypeError, even
+// for an EMPTY object binding pattern.
+//
+// Per ECMA-262 8.6.2 BindingInitialization, the production
+//   `BindingPattern : ObjectBindingPattern`
+// runs `Perform ? RequireObjectCoercible(value)` as STEP 1 — before the inner
+// `ObjectBindingPattern : { }` rule (which returns unused). So `const {} = null`
+// and `const {} = undefined` MUST throw, while `const {} = 5` must NOT (a number
+// is object-coercible). Earlier codegen short-circuited empty object patterns
+// and silently accepted null/undefined (test262 dstr-binding/obj-init-null +
+// for-of/dstr/const-obj-init-*). The wasm path and JS reference must agree.
+describe("#846 destructuring RequireObjectCoercible (empty object patterns)", () => {
+  const cases: { name: string; body: string }[] = [
+    { name: "let {} = null throws", body: `let o: any = null; let {} = o; r = 1;` },
+    { name: "let {} = undefined throws", body: `let o: any = undefined; let {} = o; r = 1;` },
+    { name: "const {} = null throws", body: `const o: any = null; const {} = o; r = 1;` },
+    { name: "let {} = 5 is coercible (no throw)", body: `let o: any = 5; let {} = o; r = 1;` },
+    { name: "let {} = 'str' is coercible (no throw)", body: `let o: any = "s"; let {} = o; r = 1;` },
+    { name: "let {a} = null throws", body: `let o: any = null; let {a} = o; r = 1;` },
+    { name: "for-of const {} of [null] throws", body: `for (const {} of [(null as any)]) {} r = 1;` },
+    { name: "for-of const {} of [undefined] throws", body: `for (const {} of [(undefined as any)]) {} r = 1;` },
+    { name: "for-of const {} of [5] coercible (no throw)", body: `for (const {} of [(5 as any)]) {} r = 1;` },
+    // nested empty object pattern over an externref null value
+    { name: "nested {w:{}} of {w:null} throws", body: `let o: any = { w: null }; let { w: {} } = o; r = 1;` },
+  ];
+
+  for (const { name, body } of cases) {
+    it(name, async () => {
+      await assertEquivalent(
+        `export function test(): number {
+          let r = 0;
+          try { ${body} } catch (e) { r = (e instanceof TypeError) ? 2 : 3; }
+          return r;
+        }`,
+        [{ fn: "test", args: [] }],
+      );
+    });
+  }
+});


### PR DESCRIPTION
## #846 slice — empty/nested object destructuring must throw TypeError on null/undefined

Destructuring a `null`/`undefined` value through an **empty** object binding
pattern silently succeeded instead of throwing. Per ECMA-262 §8.6.2
BindingInitialization, `BindingPattern : ObjectBindingPattern` runs
`Perform ? RequireObjectCoercible(value)` as **step 1** — *before* the inner
`ObjectBindingPattern : { }` rule (which "Return unused"). So `const {} = null`
and `const {} = undefined` must throw a `TypeError`, while `{} = 5` (a coercible
primitive) must not.

### Root cause
A confidently-wrong comment (from #225 / #1553c) claimed an empty `{}` performs
"no property access and therefore no RequireObjectCoercible" and short-circuited
the empty object-binding-decl path *before* the null/undefined guard. The
parameter path (`destructureParamObject`) and assignment path
(`emitExternrefAssignDestructureGuard`, #1701) were already correct; only the
binding-declaration + empty-nested paths were not.

### Changes (2 source files, surgical)
- `src/codegen/statements/destructuring.ts` — emit the existing
  `emitExternrefDestructureGuard` (null + JS-undefined RequireObjectCoercible)
  in `compileExternrefObjectDestructuringDecl` before the empty-pattern
  short-circuit. Also covers the for-of object binding-pattern path (loops.ts
  routes through this helper).
- `src/codegen/destructuring-params.ts` — drop the `length > 0` gate so the
  nested coercibility guard fires for empty nested patterns too
  (`{ w: {} } = { w: null }`). Guard is null/undefined-only, so coercible
  primitives still pass.

### Validation
- New `tests/equivalence/destructuring-require-object-coercible.test.ts` (10
  cases) — pass.
- 109 existing destructuring/for-of equivalence tests — pass.
- **Delta**: of 146 baseline-failing dstr-noncoercible candidates, **38 now
  pass** (object RequireObjectCoercible across const/let/var binding decls,
  for-of object binding patterns, nested empty object patterns).
- **0 real regressions**: re-ran baseline-PASSING samples via the test262
  runner — 392/400 dstr (8 apparent failures reproduce on clean `main` HEAD =
  pre-existing baseline drift, iterator-elision / `it.next is not a function`,
  unrelated to coercibility), 200/200 nested-pattern, 235/238 for-of-nested
  (the 3 `*-ary-init-iter-no-close` also fail on clean main = drift).
- `tsc --noEmit` clean; `check:ir-fallbacks` OK.

Deliberately deferred to follow-up slices (different root cause, higher risk):
array-assignment non-iterable `GetIterator` (`for ([] of [1])`, `[] = 5`) and
typed-struct static-`null` nested cases. **Umbrella #846 stays open.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)