### PR TITLE
fix(#1798): coerce IR return value to declared any/externref result

### DIFF
--- a/plan/issues/1798-explicit-any-return-new-class-wasm-validation.md
+++ b/plan/issues/1798-explicit-any-return-new-class-wasm-validation.md
@@ -1,0 +1,104 @@
+---
+id: 1798
+title: "explicit-any return + new C() → Wasm validation failure (IR return-tail misses return-type coercion)"
+status: done
+sprint: 58
+feasibility: medium
+depends_on: []
+goals: []
+completed: 2026-06-03
+---
+
+# #1798 — explicit `: any` return + `new C()` → Wasm validation failure
+
+## Problem
+
+```ts
+class C { x: number = 5; }
+export function f(): any { return new C(); }
+```
+
+fails Wasm validation at instantiation:
+
+```
+type error in return[0] (expected externref, got (ref null 5))
+```
+
+The function signature correctly declares an `externref` result (TS `any` →
+`externref`), but the emitted body returns the constructor's struct ref
+(`(ref $C)`) without coercing it to `externref`. The inferred-return form
+(no annotation) works because TS infers `C` and the function result type
+becomes the struct ref — there is then no mismatch.
+
+## Root cause (investigation)
+
+The failing body is produced by the **IR front-end** (`experimentalIR` is on
+by default in `compileSourceSync`). Dumping the IR-lowered module:
+
+- `f` has func type result `[externref]` (correct — `resolvePositionType`
+  maps `AnyKeyword → irVal externref`, `src/codegen/index.ts:438`).
+- `f`'s body is `[{call C_new}, {return}]`. `C_new` returns `(ref $C)`.
+  **No coercion** sits between the call result and `return`.
+
+The defect is in `src/ir/from-ast.ts` `lowerTail()` return handling
+(~line 574-578): it lowers the return expression with `cx.returnType` as an
+*advisory* hint, then terminates with `return [v]` **without reconciling the
+produced value's type against the declared result type**. For `new C()` the
+expression honestly yields an `IrType.class` (struct ref); the externref hint
+does not change that, so a `(ref $C) → externref` mismatch reaches `return`.
+
+This is broader than `new C()`. Every `: any`-returning IR-claimed function
+whose return value isn't already externref-shaped emitted invalid Wasm:
+
+| return form              | produced | declared | pre-fix result |
+|--------------------------|----------|----------|----------------|
+| `return 5`               | f64      | externref| FAIL (got f64) |
+| `return true`            | i32      | externref| FAIL (got i32) |
+| `return new C()`         | ref $C   | externref| FAIL (got ref) |
+| `return {a:1}`           | ref obj  | externref| FAIL (got ref) |
+| `return "hi"`            | externref (host strings) | externref | OK |
+| `return s` (string param)| externref | externref | OK |
+
+The IR verifier (`src/ir/verify.ts`) did **not** check return-value types
+against `func.resultTypes`, so the malformed body slipped past the
+verify gate that normally demotes bad IR functions to legacy.
+
+## Fix
+
+Two changes:
+
+1. **`src/ir/from-ast.ts` `lowerTail()` return path** — reconcile the lowered
+   return value with `cx.returnType` before terminating:
+   - When the declared result is `externref` and the produced value is
+     reference-shaped (class / object / closure / vec ref / ref_null /
+     native-string), coerce via `coerceYieldValueToExternref`
+     (`extern.convert_any`). This is the real fix for `new C()` / objects.
+   - When the produced value is a native scalar (`f64` / `i32`) but
+     `externref` is declared, **throw a clean "not in slice" fallback** so the
+     function reverts to the legacy path, which boxes numbers correctly via
+     `__box_number`. The IR has no number-box primitive yet; mirroring the
+     existing `lowerThrowStatement` deferral (line 4164) keeps numeric `any`
+     returns working without inventing one.
+
+2. **`src/ir/verify.ts`** — add a defense-in-depth check that every `return`
+   terminator's value types are assignment-compatible with the function's
+   declared `resultTypes`. A future return-type mismatch now demotes the
+   function to legacy at the verify gate instead of emitting invalid Wasm.
+
+### Why coerce rather than defer everything to legacy
+
+The directive is to keep `new C()` on the IR path with the canonical struct
+ref. `extern.convert_any` is the correct, zero-cost re-tag of any anyref
+subtype to externref — it is what the legacy `coerceType` ref→externref path
+emits too (`src/codegen/type-coercion.ts:1511`). The struct typeIdx the
+constructor produces is already canonical (`ctx.structMap.get(className)` in
+`new-super.ts:2950`); the original "fresh resolveWasmType mints a distinct
+typeIdx" hypothesis was not the actual mechanism — the IR path simply omitted
+the coercion. `extern.convert_any` is agnostic to the exact struct typeIdx, so
+compaction/renumbering cannot break it.
+
+## Acceptance criteria
+- `function f(): any { return new C(); }` compiles, instantiates, and runs.
+- Numeric / boolean `: any` returns still compile + instantiate (via legacy box).
+- No equivalence-test regressions.
+</content>

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -575,7 +575,8 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
       throw new Error(`ir/from-ast: Phase 1 return must have an expression in ${cx.funcName}`);
     }
     const v = lowerExpr(stmt.expression, cx, cx.returnType);
-    cx.builder.terminate({ kind: "return", values: [v] });
+    const vCoerced = coerceReturnValue(v, cx);
+    cx.builder.terminate({ kind: "return", values: [vCoerced] });
     return;
   }
   // Slice 14 (#1228) — void function tail: any non-return statement that
@@ -2718,6 +2719,65 @@ function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId 
     return value;
   }
   return cx.builder.emitCoerceToExternref(value);
+}
+
+/**
+ * #1798 — reconcile a lowered return value with the function's declared
+ * result type before terminating with `return`.
+ *
+ * The return expression is lowered with `cx.returnType` as an *advisory*
+ * hint, but several expression kinds honestly produce their concrete type
+ * regardless of the hint (most notably `new C()` → `IrType.class` (struct
+ * ref), object literals → struct ref). When the function declares `: any`
+ * (which `resolvePositionType` maps to `externref`, see
+ * `src/codegen/index.ts:438`), a `(ref $C) → externref` mismatch would reach
+ * `return` and the emitted body fails Wasm validation
+ * (`return[0] expected externref, got (ref null N)`).
+ *
+ * The legacy return path (`compileReturnStatement` →
+ * `coerceType(exprType, fctx.returnType)`) coerces here; the IR return-tail
+ * previously did not. This mirrors that coercion for the externref case:
+ *
+ *   - Declared result is `externref` and the value is reference-shaped
+ *     (class / object / closure / vec ref / ref_null / native-string) →
+ *     coerce via `coerceYieldValueToExternref` (`extern.convert_any`). This
+ *     is a zero-cost re-tag valid for any anyref subtype, agnostic to the
+ *     exact struct typeIdx (so type compaction cannot break it).
+ *   - Declared result is `externref` but the value is a native scalar
+ *     (`f64` / `i32`) → throw a clean "not in slice" fallback. Boxing a
+ *     number to externref needs `__box_number`; the IR has no box primitive
+ *     yet, and the legacy path boxes correctly. Deferring mirrors the
+ *     existing numeric-throw deferral in `lowerThrowStatement`.
+ *
+ * All other cases (matching kinds, already-externref values, non-externref
+ * declared results) pass through unchanged.
+ */
+function coerceReturnValue(value: IrValueId, cx: LowerCtx): IrValueId {
+  const declared = cx.returnType;
+  // Only the externref (TS `any`) declared-result case can mismatch here;
+  // native scalar / matching-ref returns already line up via the hint.
+  if (!declared || declared.kind !== "val" || declared.val.kind !== "externref") {
+    return value;
+  }
+  const actual = cx.builder.typeOf(value);
+  // Already externref — nothing to do.
+  if (actual.kind === "val" && actual.val.kind === "externref") {
+    return value;
+  }
+  // Native scalar → externref needs a number-box helper the IR lacks; defer
+  // the whole function to legacy (which boxes via __box_number).
+  const actualVal = asVal(actual);
+  if (actualVal && (actualVal.kind === "f64" || actualVal.kind === "i32" || actualVal.kind === "i64")) {
+    throw new Error(
+      `ir/from-ast: return of numeric ${actualVal.kind} into an 'any' (externref) result ` +
+        `needs the box helper — deferring to legacy in ${cx.funcName}`,
+    );
+  }
+  // Reference-shaped (class / object / closure / vec ref / ref_null /
+  // native-string) → extern.convert_any. `coerceYieldValueToExternref` is a
+  // no-op for host-strings (already externref) and re-tags all anyref
+  // subtypes otherwise.
+  return coerceYieldValueToExternref(value, cx);
 }
 
 /**

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -18,7 +18,8 @@
 // On failure, returns a list of `IrVerifyError`s rather than throwing, so
 // callers can decide whether to bail or fall back to the legacy path.
 
-import type { IrBlock, IrFunction, IrValueId } from "./nodes.js";
+import type { IrBlock, IrFunction, IrType, IrValueId } from "./nodes.js";
+import { asVal } from "./nodes.js";
 import type { ValType } from "./types.js";
 
 export interface IrVerifyError {
@@ -60,7 +61,81 @@ export function verifyIrFunction(func: IrFunction): IrVerifyError[] {
     }
   }
 
+  // #1798 — defense-in-depth: every `return` terminator's value types must be
+  // Wasm-assignment-compatible with the function's declared `resultTypes`.
+  // The from-ast layer is responsible for inserting the right coercions
+  // (e.g. `extern.convert_any` for ref → externref returns); if it ever omits
+  // one, the malformed body would otherwise slip past this gate and fail
+  // Wasm validation only at instantiate time. Flagging it here demotes the
+  // function to legacy (integration.ts skips functions with verify errors)
+  // instead of emitting an invalid module.
+  for (const block of func.blocks) {
+    const t = block.terminator;
+    if (t.kind !== "return") continue;
+    if (t.values.length !== func.resultTypes.length) {
+      errors.push({
+        message: `return arity ${t.values.length} != declared result arity ${func.resultTypes.length}`,
+        func: func.name,
+        block: block.id as number,
+      });
+      continue;
+    }
+    for (let i = 0; i < t.values.length; i++) {
+      const declared = func.resultTypes[i]!;
+      const actual = operandIrType(func, block, t.values[i]!, new Set());
+      if (!actual) continue; // not locally visible — SSA-scope check reports it
+      if (!returnTypeAssignable(actual, declared)) {
+        errors.push({
+          message:
+            `return[${i}] type ${describeKind(actual)} not assignable to declared ` +
+            `result ${describeKind(declared)}`,
+          func: func.name,
+          block: block.id as number,
+        });
+      }
+    }
+  }
+
   return errors;
+}
+
+/**
+ * #1798 — conservative Wasm-level assignment check for return values. Catches
+ * the divergences that produce invalid Wasm (scalar ↔ reference, or two
+ * different native scalars) while staying lenient on reference-shaped IrTypes
+ * — those all lower to `externref`-compatible refs and may legitimately flow
+ * into an `externref` (`any`) result without an SSA-visible coercion node
+ * (e.g. host-strings, already-externref values). False positives here would
+ * silently demote working IR functions to legacy, so the check only fires on
+ * an unambiguous mismatch.
+ */
+function returnTypeAssignable(actual: IrType, declared: IrType): boolean {
+  const a = asVal(actual);
+  const d = asVal(declared);
+  const isScalar = (v: ValType | null): boolean =>
+    !!v && (v.kind === "f64" || v.kind === "i32" || v.kind === "i64" || v.kind === "i8" || v.kind === "i16");
+
+  // Native scalar declared result: the value must be the same scalar kind.
+  if (isScalar(d)) {
+    if (!a) return false; // reference-shaped value into a scalar result — invalid
+    return a.kind === d!.kind;
+  }
+  // Native scalar value into a non-scalar (reference / externref) result —
+  // needs a box the IR doesn't emit; this is the #1798 numeric-`any` case the
+  // from-ast layer defers to legacy. Flag it so a future regression demotes.
+  if (isScalar(a)) {
+    return false;
+  }
+  // Both reference-shaped (or externref): treat as assignable. The lowerer's
+  // `extern.convert_any` re-tags any anyref subtype into externref, and an
+  // externref result accepts every reference IrType.
+  return true;
+}
+
+function describeKind(t: IrType): string {
+  const v = asVal(t);
+  if (v) return v.kind;
+  return t.kind;
 }
 
 function verifyBlock(func: IrFunction, block: IrBlock, defs: Set<IrValueId>, errors: IrVerifyError[]): void {

--- a/tests/issue-1798.test.ts
+++ b/tests/issue-1798.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1798 — explicit `: any` return + `new C()` → Wasm validation failure.
+ *
+ *   function f(): any { return new C(); }
+ *
+ * The function signature correctly declares an `externref` result (TS `any` →
+ * `externref`), but the IR front-end's return-tail (`lowerTail` in
+ * `src/ir/from-ast.ts`) terminated with the constructor's struct ref
+ * (`(ref $C)`) WITHOUT coercing it to `externref`. The module then failed Wasm
+ * validation at instantiate time:
+ *
+ *   type error in return[0] (expected externref, got (ref null N))
+ *
+ * Fix: the IR return-tail now reconciles the lowered value with the declared
+ * result type — reference-shaped values returned into an `any` (externref)
+ * result are coerced via `extern.convert_any`; numeric values defer to the
+ * legacy path (which boxes via `__box_number`). A defense-in-depth check in
+ * `src/ir/verify.ts` demotes any future return/result-type mismatch to legacy
+ * instead of emitting an invalid module.
+ *
+ * The inferred-return form (no annotation) always worked — included here as a
+ * guard that the fix didn't perturb the matching-type path.
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+describe("#1798 — explicit any return of new C()", () => {
+  it("compiles, instantiates, and the returned instance is usable", async () => {
+    const exports = await compileToWasm(`
+      class C { x: number = 5; constructor(v: number) { this.x = v; } }
+      function make(v: number): any { return new C(v); }
+      export function run(): number {
+        const obj = make(42) as C;
+        return obj.x;
+      }
+    `);
+    expect((exports.run as () => number)()).toBe(42);
+  });
+
+  it("any-return of an object literal validates and is usable", async () => {
+    const exports = await compileToWasm(`
+      function makeObj(): any { return { a: 11, b: 22 }; }
+      export function run(): number {
+        const o = makeObj() as { a: number; b: number };
+        return o.a + o.b;
+      }
+    `);
+    expect((exports.run as () => number)()).toBe(33);
+  });
+
+  it("numeric any-return still works (legacy box path)", async () => {
+    const exports = await compileToWasm(`
+      export function f(): any { return 5; }
+    `);
+    // f returns a boxed number externref; reading it back through JS yields 5.
+    expect((exports.f as () => unknown)()).toBe(5);
+  });
+
+  it("boolean any-return still works", async () => {
+    const exports = await compileToWasm(`
+      export function f(): any { return true; }
+    `);
+    expect((exports.f as () => unknown)()).toBe(true);
+  });
+
+  it("inferred class return type is unaffected", async () => {
+    const exports = await compileToWasm(`
+      class C { x: number = 7; }
+      function make(): C { return new C(); }
+      export function run(): number { return make().x; }
+    `);
+    expect((exports.run as () => number)()).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

```ts
class C { x: number = 5; }
export function f(): any { return new C(); }
```

failed Wasm validation at instantiation:

```
type error in return[0] (expected externref, got (ref null N))
```

`: any` return correctly declares an `externref` result, but the **IR front-end** (default `experimentalIR`) emitted the constructor's struct ref straight into `return` with no coercion.

## Root cause

`lowerTail()` in `src/ir/from-ast.ts` lowered the return expression with `cx.returnType` as an *advisory* hint, then terminated with `return [v]` **without reconciling** the produced value's type against the declared result. `new C()` honestly yields `(ref $C)`; the `externref` (any) result then mismatched at `return`. This affected every `: any`-returning IR-claimed function whose value wasn't already externref-shaped (`new C()`, object literals, numeric, boolean). The IR verifier didn't check return types, so the malformed body slipped past the gate that normally demotes bad IR functions to legacy.

The original "fresh `resolveWasmType` mints a distinct struct typeIdx → compaction drops it" hypothesis was not the mechanism — the constructor already uses the canonical `ctx.structMap` typeIdx; the IR path simply omitted the coercion.

## Fix

1. **`src/ir/from-ast.ts`** — `coerceReturnValue()` reconciles the lowered value with an externref-declared result:
   - reference-shaped (class / object / closure / vec ref / ref_null / native-string) → `extern.convert_any` (zero-cost re-tag, agnostic to the exact struct typeIdx so compaction can't break it).
   - native scalar (f64 / i32 / i64) → defer the function to legacy, which boxes via `__box_number` (the IR has no number-box primitive yet; mirrors the existing `lowerThrowStatement` numeric deferral).
2. **`src/ir/verify.ts`** — defense-in-depth: every `return` terminator's value types are now checked against `func.resultTypes`. A future mismatch demotes to legacy at the verify gate instead of emitting an invalid module.

## Tests

`tests/issue-1798.test.ts` — `new C()`, object-literal, numeric, boolean, and inferred-return forms. All pass.

## Regression check

Every class/IR/equivalence test failure I saw reproduces **identically on `origin/main`** (pre-existing standalone-harness import-wiring issues, not codegen). `tsc` clean, biome clean, IR fallback budget unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)