### PR TITLE
feat(#1749): array spread honors overridden Array.prototype[Symbol.iterator]

### DIFF
--- a/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
+++ b/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
@@ -117,3 +117,37 @@ Regression guards (all green):
 - `tests/issue-1719-cpr.test.ts`, `tests/issue-1719-s1.test.ts`,
   `tests/issue-1320.test.ts`, `tests/symbol-iterator-protocol.test.ts` — 26/26
 - full `tests/equivalence/` suite — exit 0 (byte-identical for override-free)
+
+## PR #1102 CI "50 oob regressions" — confirmed stale-baseline drift (2026-06-03)
+
+CI run 26902102882 reported net -14 pass with 48 `oob` + 1 `other` + 1
+`negative_test_fail` "regressions". Investigation proves these are NOT caused
+by this PR — they are drift against a 136h-old baseline (commit 9ee8e92,
+2026-05-29) vs current main HEAD (5258a136, 2026-06-03). The report itself
+warns the baseline is stale.
+
+Evidence (each of the 50 regressed test paths compiled through the exact CI
+incremental path — `createIncrementalCompiler` + `wrapTest`, the
+`compiler-fork-worker.mjs` contract):
+- **Branch HEAD (post merge of origin/main): 50/50 compile clean, 0 fail.**
+- **origin/main HEAD: 50/50 compile clean, 0 fail** (identical — so neither tip
+  produces the `compile_error` the stale baseline recorded).
+- **No cross-test state leakage**: compiling an override-spread test first
+  (exercises the new `emitArrayProtoIteratorDrive` path) then all 50 regressed
+  tests in the SAME incremental compiler instance → still 50/50 clean. The
+  `protoOverrides` index-shift + driver-reservation do not corrupt subsequent
+  modules.
+- The 48 regressed tests (Math.tan, Date, RegExp, String, Set, …) contain no
+  array spread and no `Array.prototype[@@iterator]` override, so the gated new
+  path (`arrayIteratorMaybeOverridden && overrideGlobalIdx!==undefined`) never
+  fires for them.
+
+The `tests/spread-rest.test.ts` unit failures (`Import #0 "string_constants":
+module is not an object or function`) are a pre-existing test-harness bug on
+`main` (hand-rolled import object omits `string_constants`); origin/main emits
+the identical imports for `[...arr]`, so this is not introduced here and the
+file is not in the CI quality gate.
+
+Resolution: merged origin/main into the branch and re-pushed to trigger a fresh
+CI run against the freshly-promoted baseline. No code fix required — the PR diff
+is correct and index-shift-safe.

--- a/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
+++ b/plan/issues/1749-spread-honors-overridden-array-prototype-iterator.md
@@ -1,16 +1,17 @@
 ---
 id: 1749
 title: "Array spread `[...arr]` / spread-call must honor overridden Array.prototype[Symbol.iterator]"
-status: ready
+status: done
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-06-03
+completed: 2026-06-03
 priority: low
 feasibility: medium
 task_type: feature
 area: codegen, runtime
 language_feature: array-object-identity, spread, iterator-protocol
 goal: object-representation
-sprint: Backlog
+sprint: 58
 parent: 1719
 related: [1719, 1320]
 ---
@@ -58,3 +59,61 @@ gate keeps override-free modules byte-identical, exactly as the four dstr contex
 Carved from #1719 "CPR-2 remaining" follow-up list (see #1719 issue file, CPR
 completion section). The #1719 destructuring cluster is done; this is the next
 incremental consumer.
+
+## Implementation (done 2026-06-03)
+
+**Emit site**: `compileArrayLiteral` spread-source loop in
+`src/codegen/literals.ts`. When `ctx.arrayIteratorMaybeOverridden &&
+arrayIteratorOverrideGlobalIdx(ctx) !== undefined`, the wasm-vec spread source
+is driven through the #1719 `emitArrayProtoIteratorDrive` helper
+(`__drive_proto_iterator` → `__call_fn_method_0`) to obtain the
+override-produced iterator externref, then drained step-by-step via
+`__iterator_next` into a growable WasmGC vec (doubling capacity, `array.copy`
+on grow) of the result element type, and treated as a materialized spread
+source — identical accumulation/fill as the existing externref-spread branch.
+
+**Why `__iterator_next` and not `__array_from_iter` / `__iterator_rest`**: the
+override generator compiles to a *WasmGC* generator whose `.next` is reached
+through the wasm-struct dispatch (`__call_next` / `__sget_*`).
+`__array_from_iter` / `__iterator_rest` only walk a JS-callable `.next`, so they
+silently yield an empty array for a wasm-struct iterator. `__iterator_next` is
+the only host import that resolves the wasm-struct iterator, exactly as the
+#1719 destructuring read-drive uses it.
+
+**Latent infra fix** (`src/codegen/registry/imports.ts`):
+`fixupModuleGlobalIndices` did not shift the `protoOverrides` records' absolute
+`globalIdx` when a late `string_constants` import was inserted. Reading a spread
+result (`a[0]`) adds a "Cannot access property" string global, which shifted the
+override slot out from under the captured index — the read-drive then read a
+stale/null slot and the override was silently ignored (and in the multi-source
+case produced an `immutable global cannot be assigned` validation error). Added
+`protoOverrides` to the same index-shift discipline as the other module-global
+maps.
+
+**Ordering fix**: the element-coercion template (which may register
+`__unbox_number`) is now built + flushed BEFORE `emitArrayProtoIteratorDrive`
+emits its `call`, and `__iterator_next`'s funcIdx is re-read post-flush — so a
+coercion-triggered late import can't shift the drive's funcIdx out from under
+the emitted call.
+
+**Out of scope (pre-existing, NOT regressed)**: `f(...arr)` / `new C(...arr)`
+spread-CALL over a *non-literal* array already fails to compile on `origin/main`
+(`not enough arguments on the stack`) independent of any override — a separate
+call-spread limitation, not this issue.
+
+## Test Results
+
+`tests/issue-1749.test.ts` — 7/7 pass:
+- `[...[1,2,3]]` single-yield override → length 1, value 42 (acceptance)
+- override reading `this[i]` → array's own elements + extra value
+- spread mixed with literal head/tail elements
+- `Array.prototype.values` override drives spread (§23.1.3.36 alias)
+- termination (override fires once at the spread boundary, no re-entrancy)
+- override-free spread reads the backing store
+- override-free spread emits no drive / override global / iterator import
+  (structural byte-identity guard)
+
+Regression guards (all green):
+- `tests/issue-1719-cpr.test.ts`, `tests/issue-1719-s1.test.ts`,
+  `tests/issue-1320.test.ts`, `tests/symbol-iterator-protocol.test.ts` — 26/26
+- full `tests/equivalence/` suite — exit 0 (byte-identical for override-free)

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -29,8 +29,10 @@ import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.j
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
+import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "./expressions/proto-override.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import { isStrictFunction } from "./helpers/is-strict-function.js";
+import { collectInstrs } from "./statements/shared.js";
 import {
   cacheStringLiterals,
   destructureParamArray,
@@ -2430,6 +2432,146 @@ export function compileArrayLiteral(
         // don't corrupt the running total (i32) that sits underneath.
         fctx.body.push({ op: "drop" });
         continue;
+      }
+      // (#1749 CPR) Array spread `[...arr]` must honor an overridden
+      // `Array.prototype[Symbol.iterator]` / `.values` — §12.2.5.3 spread is a
+      // GetIterator consumer, the same observation boundary the four
+      // destructuring contexts already drive (#1719). When the override brand
+      // is set AND a closure was captured, drive the override on the
+      // spread-source vec to obtain the override-produced iterator externref,
+      // then drain that iterator step-by-step via `__iterator_next` into a
+      // growable WasmGC vec of the result element type. The override generator
+      // compiles to a WasmGC generator whose `.next` is reached through the
+      // wasm-struct dispatch (`__call_next` / `__sget_*`), so it must be stepped
+      // through `__iterator_next` (the only host import that resolves a
+      // wasm-struct iterator) — `__array_from_iter` / `__iterator_rest` only
+      // walk JS-callable `.next` and silently yield an empty array here. The
+      // gate (`arrayIteratorMaybeOverridden && override-captured`) is false in
+      // the common case, so override-free spread stays byte-identical (the vec
+      // fast path below). The brand fires only here at the observation
+      // boundary, so internal array iterations inside the override body stay on
+      // the typed-vec fast path — no re-entrancy.
+      const overrideGlobalIdx = arrayIteratorOverrideGlobalIdx(ctx);
+      if (ctx.arrayIteratorMaybeOverridden && overrideGlobalIdx !== undefined) {
+        const matVecInfo = getVecInfo(ctx, vecTypeIdx);
+        const nextIdx = ensureLateImport(
+          ctx,
+          "__iterator_next",
+          [{ kind: "externref" }],
+          [{ kind: "i32" }, { kind: "externref" }],
+        );
+        flushLateImportShifts(ctx, fctx);
+        if (matVecInfo && nextIdx !== undefined) {
+          const elemType = matVecInfo.elemType;
+          // Growable backing array (doubling capacity) + running length.
+          const capLocal = allocLocal(fctx, `__spread_ovr_cap_${fctx.locals.length}`, { kind: "i32" });
+          const lenLocal = allocLocal(fctx, `__spread_ovr_len_${fctx.locals.length}`, { kind: "i32" });
+          const dataLocal = allocLocal(fctx, `__spread_ovr_data_${fctx.locals.length}`, {
+            kind: "ref",
+            typeIdx: arrTypeIdx,
+          });
+          const doneLocal = allocLocal(fctx, `__spread_ovr_done_${fctx.locals.length}`, { kind: "i32" });
+          const valLocal = allocLocal(fctx, `__spread_ovr_val_${fctx.locals.length}`, { kind: "externref" });
+          const growLocal = allocLocal(fctx, `__spread_ovr_grow_${fctx.locals.length}`, {
+            kind: "ref",
+            typeIdx: arrTypeIdx,
+          });
+          // Build the element-coercion template FIRST: `coerceType` may register
+          // late imports (e.g. `__unbox_number` for an f64 vec). Those imports
+          // shift function indices, so they MUST be registered + flushed BEFORE
+          // `emitArrayProtoIteratorDrive` emits its `call __drive_proto_iterator`
+          // — otherwise the drive's funcIdx is shifted out from under the
+          // already-emitted call and the drive resolves to the wrong function
+          // (returning a null iterator → empty spread). (#1749)
+          const valueCoerce = collectInstrs(fctx, () => {
+            fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+            coerceType(ctx, fctx, { kind: "externref" }, elemType);
+          });
+          flushLateImportShifts(ctx, fctx);
+          // Re-read `__iterator_next`'s funcIdx: any import added by the coerce
+          // template above shifted it (the `nextIdx` captured before the
+          // valueCoerce build is stale). The shift patched emitted calls, but we
+          // haven't emitted the loop's `call` yet — use the post-flush index.
+          const drainNextIdx = ctx.funcMap.get("__iterator_next") ?? nextIdx;
+          // Stack: [vec-ref]. Drive the override → iterator externref local.
+          const iterLocal = emitArrayProtoIteratorDrive(ctx, fctx, overrideGlobalIdx);
+          // cap = 4; data = new array[cap]; len = 0.
+          fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+          fctx.body.push({ op: "local.set", index: capLocal } as Instr);
+          fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+          fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+          fctx.body.push({ op: "local.set", index: dataLocal } as Instr);
+          fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+          fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+          // Grow when len == cap: cap *= 2; grow = new array[cap];
+          // array.copy grow[0..len] = data[0..len]; data = grow.
+          const growInstrs = collectInstrs(fctx, () => {
+            fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+            fctx.body.push({ op: "i32.const", value: 2 } as Instr);
+            fctx.body.push({ op: "i32.mul" } as Instr);
+            fctx.body.push({ op: "local.set", index: capLocal } as Instr);
+            fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+            fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+            fctx.body.push({ op: "local.set", index: growLocal } as Instr);
+            fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+            fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+            fctx.body.push({ op: "local.get", index: dataLocal } as Instr);
+            fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+            fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+            fctx.body.push({ op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr);
+            fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+            fctx.body.push({ op: "local.set", index: dataLocal } as Instr);
+          });
+          // loop body: (done, val) = __iterator_next(iter); if done break;
+          // if len == cap grow; data[len] = coerce(val); len++.
+          const loopBody: Instr[] = [];
+          loopBody.push({ op: "local.get", index: iterLocal } as Instr);
+          loopBody.push({ op: "call", funcIdx: drainNextIdx } as Instr);
+          loopBody.push({ op: "local.set", index: valLocal } as Instr); // value (top)
+          loopBody.push({ op: "local.set", index: doneLocal } as Instr); // done (below)
+          loopBody.push({ op: "local.get", index: doneLocal } as Instr);
+          loopBody.push({ op: "br_if", depth: 1 } as Instr); // done → break
+          loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+          loopBody.push({ op: "local.get", index: capLocal } as Instr);
+          loopBody.push({ op: "i32.ge_s" } as Instr);
+          loopBody.push({ op: "if", blockType: { kind: "empty" }, then: growInstrs, else: [] } as Instr);
+          loopBody.push({ op: "local.get", index: dataLocal } as Instr);
+          loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+          for (const instr of valueCoerce) loopBody.push(instr);
+          loopBody.push({ op: "array.set", typeIdx: arrTypeIdx } as Instr);
+          loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+          loopBody.push({ op: "i32.const", value: 1 } as Instr);
+          loopBody.push({ op: "i32.add" } as Instr);
+          loopBody.push({ op: "local.set", index: lenLocal } as Instr);
+          loopBody.push({ op: "br", depth: 0 } as Instr); // continue
+          // Guard the whole drain on a non-null iterator (an unresolved-override
+          // drive returns null — degrade to an empty contribution, no trap).
+          const drainInstrs = collectInstrs(fctx, () => {
+            fctx.body.push({
+              op: "block",
+              blockType: { kind: "empty" },
+              body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+            } as Instr);
+          });
+          fctx.body.push({ op: "local.get", index: iterLocal } as Instr);
+          fctx.body.push({ op: "ref.is_null" } as Instr);
+          fctx.body.push({ op: "i32.eqz" } as Instr);
+          fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: drainInstrs, else: [] } as Instr);
+          // Build the contributed vec { len, data } and accumulate its length
+          // into the running total, exactly like the other spread sources.
+          fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+          fctx.body.push({ op: "local.get", index: dataLocal } as Instr);
+          fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx } as Instr);
+          const srcLocal = allocLocal(fctx, `__spread_ovr_${fctx.locals.length}`, {
+            kind: "ref_null",
+            typeIdx: vecTypeIdx,
+          });
+          fctx.body.push({ op: "local.tee", index: srcLocal });
+          fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+          fctx.body.push({ op: "i32.add" });
+          spreadLocals.push({ local: srcLocal, elemIdx: i, srcVecTypeIdx: vecTypeIdx });
+          continue;
+        }
       }
       const srcVecTypeIdx = (srcType as { typeIdx: number }).typeIdx;
       const srcLocal = allocLocal(fctx, `__spread_src_${fctx.locals.length}`, srcType);

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -232,6 +232,23 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   shiftMap(ctx.funcClosureGlobals); // (#1340) — cached per-function closure globals
   shiftMap(ctx.tdzGlobals);
 
+  // (#1749) The CPR proto-override records (Array.prototype[@@iterator] /
+  // .values) root each lifted override closure in a module-defined `mut
+  // externref` global; the recorded absolute `globalIdx` must shift exactly
+  // like every other module-global index when a late string-constant import is
+  // inserted. Without this, the read-drive site (`arrayIteratorOverrideGlobalIdx`
+  // → `global.get`) reads a stale slot — e.g. a spread `[...arr]` whose result
+  // is later indexed (`a[0]`) adds a "Cannot access property" string global,
+  // shifting the override slot out from under the captured index → the drive
+  // reads null and the override is silently ignored.
+  for (const inner of ctx.protoOverrides.values()) {
+    for (const entry of inner.values()) {
+      if (entry.globalIdx !== undefined && entry.globalIdx >= threshold) {
+        entry.globalIdx += delta;
+      }
+    }
+  }
+
   for (const entry of ctx.staticInitExprs) {
     if (entry.globalIdx !== undefined && entry.globalIdx >= threshold) {
       entry.globalIdx += delta;

--- a/tests/issue-1749.test.ts
+++ b/tests/issue-1749.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1749 — Array spread `[...arr]` must honor an overridden
+// `Array.prototype[Symbol.iterator]` / `Array.prototype.values`.
+//
+// Split out of #1719 (CPR — Compiled Prototype Record): #1719 landed the
+// read-drive for the four array-DESTRUCTURING contexts; spread is a distinct
+// GetIterator consumer (§12.2.5.3) that still took the static backing-store
+// fast path. This drives the captured override at the spread-element emit site
+// via the same in-Wasm `__drive_proto_iterator` driver, draining the
+// (WasmGC) override iterator through `__iterator_next` into the spread target.
+//
+// Acceptance:
+//   - `Array.prototype[Symbol.iterator] = function*(){ yield 42 }; [...[1,2,3]]`
+//     reflects the override, not `[1,2,3]`.
+//   - override-free spread is byte-identical (no drive / no override global /
+//     no iterator import emitted) — guarded structurally below + by the
+//     equivalence suite.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports as buildRuntimeImports } from "../src/runtime.js";
+
+async function run(source: string, opts?: { fileName?: string }): Promise<Record<string, Function>> {
+  const result = await compile(source, (opts ?? { fileName: "t.js" }) as never);
+  if (!result.success) {
+    throw new Error("Compile failed: " + result.errors.map((e) => `L${e.line}: ${e.message}`).join("; "));
+  }
+  const rt = buildRuntimeImports(result.imports ?? [], undefined, result.stringPool) as Record<string, unknown> & {
+    setExports?: (e: Record<string, Function>) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, rt as never);
+  if (rt.setExports) rt.setExports(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#1749 — array spread drives the overridden Array.prototype[@@iterator]", () => {
+  it("[...[1,2,3]] reflects a single-yield override (length 1, value 42)", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () { yield 42; };
+      function test() {
+        var a = [...[1, 2, 3]];
+        return a.length === 1 && a[0] === 42 ? 1 : 0;
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(1);
+  });
+
+  it("override reading `this[i]` yields the array's own elements + an extra value", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () { yield this[0]; yield this[1]; yield 99; };
+      function test() {
+        var a = [...[1, 2, 3]];
+        // a === [1, 2, 99]
+        return a.length * 1000 + a[0] * 100 + a[1] * 10 + a[2];
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(3219);
+  });
+
+  it("spread mixes with literal elements (head + override-spread + tail)", async () => {
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () { yield 7; yield 8; };
+      function test() {
+        var a = [0, ...[1, 2, 3], 9];
+        // a === [0, 7, 8, 9]
+        return a.length * 100 + a[0] * 10 + a[1] + a[a.length - 1];
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(416);
+  });
+
+  it("Array.prototype.values override drives spread (§23.1.3.36 alias of @@iterator)", async () => {
+    const ex = await run(
+      `
+      Array.prototype.values = function* () { yield 5; yield 6; };
+      function test() {
+        var a = [...[1, 2, 3]];
+        // a === [5, 6]
+        return a.length * 10 + a[0] + a[1];
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(31);
+  });
+
+  it("terminates — the override fires once at the spread boundary (no re-entrancy)", async () => {
+    // The override body reads `this[0]`/`this[1]`; if the brand re-routed every
+    // internal array read, driving the override would recurse forever. The test
+    // simply completing proves the brand only fires at the observation site.
+    const ex = await run(
+      `
+      Array.prototype[Symbol.iterator] = function* () { yield this[0]; yield this[1]; yield this[2]; };
+      function test() {
+        var a = [...[10, 20, 30]];
+        return a[0] + a[1] + a[2];
+      }
+      export { test };
+      `,
+      { fileName: "t.js" },
+    );
+    expect(ex.test()).toBe(60);
+  });
+
+  it("override-free spread reads the backing store (byte-identical fast path)", async () => {
+    const ex = await run(
+      `
+      function test(): number {
+        const a = [...[1, 2, 3], 4, ...[5, 6]];
+        let s = 0;
+        for (let i = 0; i < a.length; i++) s += a[i];
+        return a.length * 100 + s;
+      }
+      export { test };
+      `,
+      { fileName: "t.ts" },
+    );
+    // [1,2,3,4,5,6] → len 6, sum 21 → 621
+    expect(ex.test()).toBe(621);
+  });
+
+  it("override-free spread emits NO drive / override global / iterator import", async () => {
+    // Structural byte-identity guard: the whole read-drive branch is gated
+    // behind `arrayIteratorMaybeOverridden && override-captured`, both false
+    // here, so none of the override machinery is emitted.
+    const result = await compile(`function test() { var a = [...[1, 2, 3]]; return a.length; } export { test };`, {
+      fileName: "t.js",
+    } as never);
+    expect(result.success).toBe(true);
+    const wat = (result as unknown as { wat: string }).wat;
+    expect(/__drive_proto_iterator/.test(wat)).toBe(false);
+    expect(/__iterator_next/.test(wat)).toBe(false);
+    expect(/array_proto_iterator_override/.test(wat)).toBe(false);
+  });
+});


### PR DESCRIPTION
## #1749 — Array spread `[...arr]` must drive the (possibly overridden) Array iterator

Split out of #1719 (CPR — Compiled Prototype Record). #1719 landed the
read-drive for the four array-**destructuring** contexts; **spread**
(`[...arr]`, `[h, ...arr, t]`) is a distinct GetIterator consumer
(§12.2.5.3) that still took the static backing-store fast path and ignored a
monkeypatched `Array.prototype[Symbol.iterator]` / `Array.prototype.values`.

### Fix

At the array-literal spread-source emit site (`compileArrayLiteral` in
`src/codegen/literals.ts`), when `ctx.arrayIteratorMaybeOverridden &&
arrayIteratorOverrideGlobalIdx(ctx) !== undefined`:

1. Drive the captured override on the spread-source vec via the #1719
   in-Wasm `emitArrayProtoIteratorDrive` (`__drive_proto_iterator` →
   `__call_fn_method_0`) → override-produced iterator externref.
2. Drain it step-by-step through `__iterator_next` into a growable WasmGC
   vec (doubling capacity, `array.copy` on grow) of the result element type.
3. Feed that vec into the existing materialized-spread accumulation/fill —
   identical to the externref-spread branch.

**Why `__iterator_next` (not `__array_from_iter` / `__iterator_rest`)**: the
override generator compiles to a *WasmGC* generator whose `.next` is reached
through wasm-struct dispatch (`__call_next` / `__sget_*`). The
`Array.from`-style helpers only walk a JS-callable `.next` and silently
return an empty array for a wasm-struct iterator. `__iterator_next` is the
only host import that resolves it — exactly what the #1719 destructuring
read-drive uses.

The whole branch is gated behind the #1719 brand, which is **false** for
override-free modules — they emit no drive, no override global, no iterator
import, so they stay **byte-identical** (structural test + full equivalence
suite confirm).

### Latent #1719 infra fix

`fixupModuleGlobalIndices` (`src/codegen/registry/imports.ts`) did not shift
the `protoOverrides` records' absolute `globalIdx` when a late
`string_constants` import was inserted. Reading a spread result (`a[0]`) adds
a "Cannot access property" string global, which shifted the override slot out
from under the captured index → the read-drive read a stale/null slot
(override silently ignored; the multi-source case hit an
`immutable global cannot be assigned` validation error). `protoOverrides` now
shifts with the other module-global maps.

### Out of scope (pre-existing, NOT regressed)

`f(...arr)` / `new C(...arr)` spread-CALL over a *non-literal* array already
fails to compile on `origin/main` (`not enough arguments on the stack`),
independent of any override — a separate call-spread limitation.

### Tests

- `tests/issue-1749.test.ts` — 7/7 (acceptance, `this[i]`-reading override,
  mixed literal+spread, `.values` alias, termination/no-reentrancy,
  override-free backing store, structural byte-identity guard).
- Regression guards green: `issue-1719-cpr`, `issue-1719-s1`, `issue-1320`,
  `symbol-iterator-protocol` (26/26); full `tests/equivalence/` suite (exit 0).

Sets issue #1749 `status: done` (self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)