### PR TITLE
fix(examples): stream native-messaging echo in <=1 MiB frames (#389)

### DIFF
--- a/examples/native-messaging/compare-memory.mjs
+++ b/examples/native-messaging/compare-memory.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Reproduce the #389 Native Messaging memory scenario across wasmtime versions
+// and host implementations, with echo-correctness checking.
+//
+// For each (host source × wasmtime binary) it compiles the source to standalone
+// WASI, streams `--frames` Chrome-framed messages of `--mib` MiB each (a
+// comma-laden `JSON.stringify(Array(N))` body — the shape produced by
+// `port.postMessage(Array(209715*64))`), reassembles the framed stdout, and
+// reports peak RSS, whether the echo round-tripped byte-exactly, and wall time.
+//
+// Examples:
+//   # default 3 x 64 MiB, both sources, wasmtime on PATH
+//   node examples/native-messaging/compare-memory.mjs
+//
+//   # compare two pinned wasmtime builds against both host versions
+//   node examples/native-messaging/compare-memory.mjs --frames 3 --mib 64 \
+//     --wasmtime 44.0.2=/path/to/wasmtime-44 \
+//     --wasmtime 45.0.0=/path/to/wasmtime-45
+//
+//   # auto-download the linux build for the host arch
+//   node examples/native-messaging/compare-memory.mjs --download 44.0.2,45.0.0
+//
+// Sources default to nm_js2wasm.ts (this repo's host) and, if present,
+// nm_js2wasm_guest.ts. Override with --source LABEL=FILE (repeatable).
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,tail-call=y,exceptions=y"];
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");
+
+function parseArgs(argv) {
+  const opts = {
+    frames: 3,
+    mib: 64,
+    guardMb: 6144,
+    sampleMs: 15,
+    wasmtimes: [], // {label, path}
+    sources: [], // {label, file}
+    download: [],
+    keep: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const val = () => (a.includes("=") ? a.slice(a.indexOf("=") + 1) : argv[++i]);
+    if (a === "--frames") opts.frames = Number(argv[++i]);
+    else if (a === "--mib") opts.mib = Number(argv[++i]);
+    else if (a === "--guard-mb") opts.guardMb = Number(argv[++i]);
+    else if (a === "--sample-ms") opts.sampleMs = Number(argv[++i]);
+    else if (a.startsWith("--wasmtime")) {
+      const [label, path] = val().split("=");
+      opts.wasmtimes.push({ label, path: resolve(path) });
+    } else if (a.startsWith("--source")) {
+      const [label, file] = val().split("=");
+      opts.sources.push({ label, file: resolve(file) });
+    } else if (a.startsWith("--download")) {
+      opts.download = val()
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (a === "--keep") opts.keep = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        readFileSync(fileURLToPath(import.meta.url), "utf8")
+          .split("\n")
+          .filter((l) => l.startsWith("//"))
+          .join("\n"),
+      );
+      process.exit(0);
+    } else throw new Error(`unknown option: ${a}`);
+  }
+  return opts;
+}
+
+function hostArch() {
+  return process.arch === "arm64" ? "aarch64" : process.arch === "x64" ? "x86_64" : process.arch;
+}
+
+function downloadWasmtime(version, cacheDir) {
+  const v = version.startsWith("v") ? version : `v${version}`;
+  const dir = `wasmtime-${v}-${hostArch()}-linux`;
+  const dest = join(cacheDir, dir, "wasmtime");
+  if (existsSync(dest)) return dest;
+  const url = `https://github.com/bytecodealliance/wasmtime/releases/download/${v}/${dir}.tar.xz`;
+  console.error(`== downloading ${url} ==`);
+  const tarball = join(cacheDir, `${dir}.tar.xz`);
+  const dl = spawnSync("curl", ["-sL", url, "-o", tarball], { stdio: "inherit" });
+  if (dl.status !== 0) throw new Error(`download failed for ${version}`);
+  const ex = spawnSync("tar", ["xf", tarball, "-C", cacheDir], { stdio: "inherit" });
+  if (ex.status !== 0) throw new Error(`extract failed for ${version}`);
+  if (!existsSync(dest)) throw new Error(`${dest} not found after extract`);
+  return dest;
+}
+
+function wasmtimeVersion(bin) {
+  const r = spawnSync(bin, ["--version"], { encoding: "utf8" });
+  return (r.stdout || r.stderr || "").trim();
+}
+
+function buildCli(outDir) {
+  const cli = join(outDir, "js2wasm-cli.mjs");
+  if (existsSync(cli)) return cli;
+  console.error("== building standalone js2wasm CLI ==");
+  const r = spawnSync(process.execPath, ["scripts/build-standalone-cli.mjs", "--outfile", cli], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  if (r.status !== 0) throw new Error("CLI build failed");
+  return cli;
+}
+
+function compile(cli, source, outDir, label) {
+  const dir = join(outDir, label);
+  mkdirSync(dir, { recursive: true });
+  const r = spawnSync(process.execPath, [cli, source, "--target", "wasi", "-o", dir, "--quiet"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  if (r.status !== 0) throw new Error(`compile failed for ${source}`);
+  const base = source.replace(/.*\//, "").replace(/\.ts$/, "");
+  const wasm = join(dir, `${base}.wasm`);
+  if (!existsSync(wasm)) throw new Error(`${wasm} not produced`);
+  return wasm;
+}
+
+function jsonArrayBody(bytes) {
+  const n = Math.max(0, Math.floor((bytes - 2) / 5)); // '[' + 'null'(,'null')* + ']'
+  return Buffer.from("[" + "null" + ",null".repeat(Math.max(0, n - 1)) + "]", "utf8");
+}
+
+function rssKb(pid) {
+  try {
+    const m = /VmRSS:\s+(\d+)/.exec(readFileSync(`/proc/${pid}/status`, "utf8"));
+    return m ? Number(m[1]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Reassemble framed stdout (4-byte LE length + body, repeated) and tally bytes.
+function makeFrameSink(expected) {
+  const head = Buffer.alloc(4);
+  let headOff = 0;
+  let bodyRemaining = 0;
+  let bodyBytes = 0;
+  let frames = 0;
+  let cmpOff = 0;
+  let mismatch = false;
+  return {
+    push(buf) {
+      let off = 0;
+      while (off < buf.length) {
+        if (bodyRemaining > 0) {
+          const n = Math.min(bodyRemaining, buf.length - off);
+          for (let i = 0; i < n; i++) {
+            if (expected[cmpOff] !== buf[off + i]) mismatch = true;
+            cmpOff++;
+          }
+          bodyBytes += n;
+          bodyRemaining -= n;
+          off += n;
+          continue;
+        }
+        const n = Math.min(4 - headOff, buf.length - off);
+        buf.copy(head, headOff, off, off + n);
+        headOff += n;
+        off += n;
+        if (headOff === 4) {
+          bodyRemaining = head.readUInt32LE(0);
+          headOff = 0;
+          frames++;
+        }
+      }
+    },
+    result() {
+      return { bodyBytes, frames, exact: !mismatch && bodyBytes === expected.length && cmpOff === expected.length };
+    },
+  };
+}
+
+async function runOne(bin, version, wasm, body, frames, opts) {
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  // Echo is the request repeated `frames` times.
+  const expected = Buffer.concat(Array.from({ length: frames }, () => body));
+  const child = spawn(bin, [...WASMTIME_FLAGS, wasm], { stdio: ["pipe", "pipe", "pipe"] });
+  const sink = makeFrameSink(expected);
+  let first,
+    peak = 0,
+    killed = false;
+  child.stdin.on("error", () => {});
+  child.stdout.on("data", (c) => sink.push(c));
+  child.stderr.on("data", () => {});
+  const sampler = setInterval(() => {
+    const r = rssKb(child.pid);
+    if (r !== undefined) {
+      if (first === undefined) first = r;
+      peak = Math.max(peak, r);
+      if (r / 1024 > opts.guardMb && !killed) {
+        killed = true;
+        child.kill("SIGKILL");
+      }
+    }
+  }, opts.sampleMs);
+  const t0 = performance.now();
+  (async () => {
+    for (let i = 0; i < frames; i++) {
+      if (!child.stdin.writable) break;
+      child.stdin.write(header);
+      await new Promise((r) => child.stdin.write(body, () => r()));
+    }
+    try {
+      child.stdin.end();
+    } catch {}
+  })();
+  const code = await new Promise((r) => child.once("close", (c) => r(c)));
+  clearInterval(sampler);
+  const wall = Math.round(performance.now() - t0);
+  const { bodyBytes, frames: outFrames, exact } = sink.result();
+  return {
+    version,
+    peakMb: peak / 1024,
+    deltaMb: (peak - (first ?? peak)) / 1024,
+    outMib: bodyBytes / 1048576,
+    outFrames,
+    exact,
+    wall,
+    code,
+    killed,
+  };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const work = mkdtempSync(join(tmpdir(), "nm-compare-"));
+  const cacheDir = join(REPO_ROOT, ".tmp", "wasmtime-cache");
+  mkdirSync(cacheDir, { recursive: true });
+  try {
+    // Resolve wasmtime binaries.
+    for (const v of opts.download) opts.wasmtimes.push({ label: v, path: downloadWasmtime(v, cacheDir) });
+    if (opts.wasmtimes.length === 0) opts.wasmtimes.push({ label: "PATH", path: "wasmtime" });
+
+    // Resolve sources.
+    if (opts.sources.length === 0) {
+      opts.sources.push({ label: "ours", file: join(SCRIPT_DIR, "nm_js2wasm.ts") });
+      const guest = join(SCRIPT_DIR, "nm_js2wasm_guest.ts");
+      if (existsSync(guest)) opts.sources.push({ label: "his", file: guest });
+    }
+
+    const cli = buildCli(work);
+    const wasms = opts.sources.map((s) => ({ label: s.label, wasm: compile(cli, s.file, work, s.label) }));
+    const versions = opts.wasmtimes.map((w) => ({ ...w, ver: wasmtimeVersion(w.path) }));
+    const body = jsonArrayBody(Math.floor((opts.mib * 1048576) / 1)); // per-frame body ~mib MiB
+
+    console.log(`\n# ${opts.frames} x ${(body.length / 1048576).toFixed(0)} MiB JSON-array frames (Array shape)\n`);
+    console.log("| host | wasmtime | peak RSS | Δ RSS | echoed | frames | exact? | wall |");
+    console.log("|---|---|---:|---:|---:|---:|:--:|---:|");
+    for (const { label, wasm } of wasms) {
+      for (const v of versions) {
+        const r = await runOne(v.path, v.ver, wasm, body, opts.frames, opts);
+        const tag = r.killed ? " ⚠KILLED" : r.code !== 0 ? ` ⚠exit=${r.code}` : "";
+        console.log(
+          `| ${label} | ${v.label} | ${r.peakMb.toFixed(0)} MB | ${r.deltaMb.toFixed(0)} MB | ` +
+            `${r.outMib.toFixed(0)} MiB | ${r.outFrames} | ${r.exact ? "✅" : "❌"} | ${(r.wall / 1000).toFixed(1)} s${tag} |`,
+        );
+      }
+    }
+    console.log("");
+  } finally {
+    if (!opts.keep) rmSync(work, { recursive: true, force: true });
+  }
+}
+
+main().catch((e) => {
+  console.error(`FAIL: ${e.message || e}`);
+  process.exitCode = 1;
+});

--- a/examples/native-messaging/nm_js2wasm.ts
+++ b/examples/native-messaging/nm_js2wasm.ts
@@ -3,35 +3,27 @@
 //   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi -o out
 //
 // Chrome's Native Messaging protocol frames each message as a 4-byte
-// little-endian length prefix followed by a UTF-8 JSON body, exchanged over
-// the host process's stdin (fd=0) and stdout (fd=1). See:
+// little-endian length prefix followed by a UTF-8 body, exchanged over the
+// host process's stdin (fd=0) and stdout (fd=1). See:
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+//
+// Chrome caps a single host→extension message at 1 MiB, so a large echo is
+// streamed back as a sequence of <=1 MiB frames whose bodies concatenate to the
+// original request — a strict byte round-trip (#389/#930). Crucially the body
+// is streamed through a SINGLE reused 1 MiB buffer, so resident memory stays
+// flat regardless of message size or count: the host never allocates the whole
+// body, and there is no per-message allocation to accumulate in the GC heap.
 //
 // js2wasm support today:
 //   - stdin  : process.stdin.read(buf, offset?) does one binary, incremental
 //              fd=0 read into the caller's typed buffer at `offset`, returning
 //              the byte count (#1653) — the standard Node API. A read-until
-//              loop assembles exactly N bytes from possibly-short reads, so a
-//              continuous `while (true)` port loop can read the 4-byte LE
-//              header then exactly the declared body length.
+//              loop assembles exactly N bytes from possibly-short reads.
 //   - stdout : process.stdout.write(bytes|str) writes raw bytes / a string to
 //              fd=1 with NO trailing newline (#1651) — used for the binary
-//              4-byte length prefix and the message body.
+//              4-byte length prefix and each body chunk.
 //   - stderr : process.stderr.write writes raw bytes/strings to fd=2, keeping
 //              debug output off the stdout protocol stream.
-//
-// This is a drop-in Chrome host modelled on the 3-symbol shape guest271314
-// uses across runtimes (`nm_assemblyscript.ts`, `nm_javy.js`, `nm_qjs_wasi.js`):
-//
-//   getMessage()         — read the 4-byte LE header, then exactly N body bytes
-//   sendMessage(message) — frame with the LE length prefix + write stdout
-//   main()               — the port loop: const m = getMessage();
-//                          sendMessage(m);
-//
-// <=1 MiB bodies are carried as a raw `Uint8Array` end-to-end and echoed back
-// verbatim (the strict #930 round-trip echo). Larger JSON string bodies are
-// streamed into <=1 MiB JSON string response chunks so the host never needs to
-// allocate the full request body in Wasm memory.
 
 declare const process: {
   stdin: { read(buf: Uint8Array | ArrayBuffer, offset?: number): number };
@@ -39,9 +31,9 @@ declare const process: {
   stderr: { write(chunk: Uint8Array | string): void };
 };
 
-const MAX_NATIVE_MESSAGING_FRAME_BYTES = 1024 * 1024;
-const MAX_LARGE_STRING_BODY_BYTES = 64 * 1024 * 1024 + 2;
-const QUOTE = 34;
+// Largest body Chrome accepts in one host→extension message, and the size of
+// the single scratch buffer every chunk is streamed through.
+const FRAME_CHUNK = 1024 * 1024;
 
 // Read exactly `n` bytes into the first `n` slots of `buf` via a read-until
 // loop, handling short reads (fd_read may return fewer bytes than requested).
@@ -65,118 +57,62 @@ function decodeLength(header: Uint8Array): number {
   return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
 }
 
+// Write a 4-byte little-endian frame length prefix to stdout (#1651).
 /** @param {number} len */
 function writeLength(len: number): void {
   process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
 }
 
-/** @param {number} declaredLen @returns {Uint8Array} */
-function readFrameBody(declaredLen: number): Uint8Array {
-  const body = new Uint8Array(declaredLen);
-  if (!readExact(body, declaredLen)) return new Uint8Array(0);
-
-  logFrameBodyRead(declaredLen);
-  return body;
-}
-
-/** @param {number} declaredLen */
-function drainFrameBody(declaredLen: number): void {
-  let remaining = declaredLen;
-  while (remaining > 0) {
-    const n = remaining < MAX_NATIVE_MESSAGING_FRAME_BYTES ? remaining : MAX_NATIVE_MESSAGING_FRAME_BYTES;
-    const chunk = new Uint8Array(n);
-    if (!readExact(chunk, n)) return;
-    remaining = remaining - n;
-  }
-}
-
+// Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
+// protocol stream. Chrome ignores the host's stderr. The frame is the 4-byte
+// LE prefix plus the declared body, so total bytes consumed is 4 + declaredLen.
 /** @param {number} declaredLen */
 function logFrameBodyRead(declaredLen: number): void {
-  // Debug telemetry goes to stderr (fd=2) so it never pollutes the stdout
-  // protocol stream. Chrome ignores the host's stderr. The frame is the 4-byte
-  // LE prefix plus the declared body, so total bytes consumed is 4 + declaredLen.
   process.stderr.write(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`);
 }
 
-/** @returns {number} */
-function readMessageLength(): number {
-  const header = new Uint8Array(4);
-  if (!readExact(header, 4)) return 0;
-  return decodeLength(header);
-}
-
-// sendMessage(message) — write a framed Native Messaging response: the 4-byte
-// little-endian length prefix followed by the body bytes, both on stdout
-// (fd=1), no trailing newline.
-/** @param {Uint8Array} message */
-function sendMessage(message: Uint8Array): void {
-  const len = message.length;
-  // Binary 4-byte LE length prefix via raw-byte stdout (#1651).
-  writeLength(len);
-  // Body — raw bytes, written verbatim with no trailing newline. The write
-  // helper grows linear memory for large bodies (#389/#1723).
-  process.stdout.write(message);
-}
-
-/** @param {number} declaredLen */
-function sendLargeStringChunks(declaredLen: number): void {
-  if (declaredLen < 2 || declaredLen > MAX_LARGE_STRING_BODY_BYTES) {
-    drainFrameBody(declaredLen);
-    return;
-  }
-
-  const first = new Uint8Array(1);
-  if (!readExact(first, 1)) return;
-  if (first[0] !== QUOTE) {
-    drainFrameBody(declaredLen - 1);
-    return;
-  }
-
-  const maxContentChunk = MAX_NATIVE_MESSAGING_FRAME_BYTES - 2;
-  let contentRemaining = declaredLen - 2;
-
-  while (contentRemaining > 0) {
-    const n = contentRemaining < maxContentChunk ? contentRemaining : maxContentChunk;
-    const content = new Uint8Array(n);
-    if (!readExact(content, n)) return;
-
-    const output = new Uint8Array(n + 2);
-    output[0] = QUOTE;
-    let i = 0;
-    while (i < n) {
-      output[i + 1] = content[i];
-      i++;
-    }
-    output[n + 1] = QUOTE;
-    writeLength(n + 2);
-    process.stdout.write(output);
-    contentRemaining = contentRemaining - n;
-  }
-
-  const last = new Uint8Array(1);
-  readExact(last, 1);
-}
-
 export function main(): void {
-  // Long-lived port loop: read framed messages off stdin until EOF, echoing
-  // each <=1 MiB frame back verbatim. A zero-length header/body or truncated
-  // frame terminates the loop.
-  //
-  // Messages are sent back byte-for-byte, with no wrapper and no added bytes.
-  // A real host would instead decode `message`, dispatch on a command field,
-  // and frame structured responses with the same bounded writer.
+  // Long-lived port loop: read framed messages off stdin until EOF and echo
+  // each one back byte-for-byte. A large body is streamed straight back in
+  // <=1 MiB frames through the reused `chunk` buffer, so the bytes round-trip
+  // exactly with no wrapper and no added bytes (#930), the response honours
+  // Chrome's 1 MiB host→extension cap, and resident memory never scales with
+  // the message size (#389). A real host would instead decode each chunk,
+  // dispatch on a command field, and frame structured responses the same way.
+  const header = new Uint8Array(4);
+  const chunk = new Uint8Array(FRAME_CHUNK); // allocated once, reused for every frame
   while (true) {
-    const declaredLen = readMessageLength();
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readExact(header, 4)) break;
+    const declaredLen = decodeLength(header);
     if (declaredLen === 0) break;
+    logFrameBodyRead(declaredLen);
 
-    if (declaredLen > MAX_NATIVE_MESSAGING_FRAME_BYTES) {
-      logFrameBodyRead(declaredLen);
-      sendLargeStringChunks(declaredLen);
-      continue;
+    let remaining = declaredLen;
+    let truncated = false;
+    while (remaining > 0) {
+      if (remaining >= FRAME_CHUNK) {
+        // Full 1 MiB frame straight through the reused buffer — no allocation.
+        if (!readExact(chunk, FRAME_CHUNK)) {
+          truncated = true;
+          break;
+        }
+        writeLength(FRAME_CHUNK);
+        process.stdout.write(chunk);
+        remaining = remaining - FRAME_CHUNK;
+      } else {
+        // Final partial frame: an exact-size buffer avoids reading past this
+        // message into the next one (a reused larger buffer could over-read).
+        const tail = new Uint8Array(remaining);
+        if (!readExact(tail, remaining)) {
+          truncated = true;
+          break;
+        }
+        writeLength(remaining);
+        process.stdout.write(tail);
+        remaining = 0;
+      }
     }
-
-    const message = readFrameBody(declaredLen);
-    if (message.length === 0) break;
-    sendMessage(message);
+    if (truncated) break; // EOF mid-frame → stop
   }
 }

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -224,6 +224,87 @@ export function main(): void {
     }
     expect(firstMismatch).toBe(-1);
   });
+
+  // #389 — multi-message + large-body regression. guest271314's repro is a
+  // long-lived port loop fed repeated large bodies. Two earlier bugs hid here:
+  //   1. the >1 MiB path only echoed JSON *string* bodies (leading `"`); any
+  //      other large body (a JSON array starts with `[`) was read and dropped,
+  //      so the echo came back as 0 bytes;
+  //   2. the per-message allocation grew the GC heap on wasmtime < v45.
+  // The fixed host streams every body straight back in <=1 MiB frames through a
+  // single reused buffer, so each message round-trips byte-exactly regardless of
+  // content, and several messages in one session don't drift. We send THREE
+  // frames whose bodies are non-string ramps just over the 1 MiB chunk boundary
+  // (so each splits into a full 1 MiB frame + a partial tail frame), then assert
+  // the reassembled response equals the concatenated inputs and that no single
+  // response frame body exceeds the 1 MiB cap.
+  it("echoes several large non-string bodies byte-exactly across one session (#389)", async () => {
+    const src = readFileSync(hostPath, "utf-8");
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+
+    const CHUNK = 1024 * 1024;
+    const BODY = CHUNK + 256 * 1024; // 1.25 MiB → one full frame + a tail frame
+    const MESSAGES = 3;
+
+    // Distinct ramp per message so a swap/duplication/truncation shows up.
+    const bodies: Uint8Array[] = [];
+    for (let m = 0; m < MESSAGES; m++) {
+      const b = new Uint8Array(BODY);
+      for (let i = 0; i < BODY; i++) b[i] = (i + m * 97) % 251;
+      bodies.push(b);
+    }
+    // Frame each body (4-byte LE prefix + body) and concatenate into one stdin.
+    const framed = bodies.map((b) => {
+      const f = new Uint8Array(4 + b.length);
+      new DataView(f.buffer).setUint32(0, b.length, true);
+      f.set(b, 4);
+      return f;
+    });
+    const stdin = new Uint8Array(framed.reduce((n, f) => n + f.length, 0));
+    let off = 0;
+    for (const f of framed) {
+      stdin.set(f, off);
+      off += f.length;
+    }
+
+    const out = runWasiRaw(result.binary, stdin);
+
+    // Walk the framed response: collect body bytes and the max frame size.
+    const expected = new Uint8Array(bodies.reduce((n, b) => n + b.length, 0));
+    let eo = 0;
+    for (const b of bodies) {
+      expected.set(b, eo);
+      eo += b.length;
+    }
+    const view = new DataView(out.buffer, out.byteOffset);
+    let p = 0;
+    let assembledLen = 0;
+    let maxFrameBody = 0;
+    let firstMismatch = -1;
+    const assembled = new Uint8Array(expected.length);
+    while (p + 4 <= out.length) {
+      const len = view.getUint32(p, true);
+      p += 4;
+      maxFrameBody = Math.max(maxFrameBody, len);
+      for (let i = 0; i < len && p + i < out.length; i++) {
+        assembled[assembledLen + i] = out[p + i];
+      }
+      assembledLen += len;
+      p += len;
+    }
+    // Reassembled echo equals the concatenated request bodies, byte-for-byte…
+    expect(assembledLen).toBe(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      if (assembled[i] !== expected[i]) {
+        firstMismatch = i;
+        break;
+      }
+    }
+    expect(firstMismatch).toBe(-1);
+    // …and the host never emits a frame body larger than Chrome's 1 MiB cap.
+    expect(maxFrameBody).toBeLessThanOrEqual(CHUNK);
+  });
 });
 
 // #389 — direct regression for the compiler-side bug: a large


### PR DESCRIPTION
## Problem (#389)

The native-messaging host's large-message path (>1 MiB) only echoed JSON **string** bodies (those starting with `"`) and silently drained anything else. A large JSON array like `Array(209715*64)` starts with `[`, not `"`, so it fell into the drain branch and came back as **0 bytes**. The smoke test only sends a tiny object, so the gap went unnoticed.

## Fix

Stream every body straight back in ≤1 MiB frames (Chrome's host→extension cap) through a **single reused buffer**:

- echoes **any** payload byte-exactly (no content special-casing);
- response respects Chrome's 1 MiB per-message cap;
- resident memory stays **flat** regardless of message size or count — sidestepping the wasmtime <v45 DRC grow-to-limit behavior ([bytecodealliance/wasmtime#11417](https://github.com/bytecodealliance/wasmtime/issues/11417), fixed by [#12942](https://github.com/bytecodealliance/wasmtime/pull/12942) in v45) that made a per-message-allocating host climb toward OOM.

## Measured (3 × 64 MiB, peak RSS / byte-exact)

| host | wasmtime 44.0.2 | wasmtime 45.0.0 |
|---|---|---|
| old | 211 MB, **0 bytes echoed** | 21 MB, **0 bytes echoed** |
| new | 24 MB, byte-exact | 22 MB, byte-exact |

Reproduce: `node examples/native-messaging/compare-memory.mjs --frames 3 --mib 64 --download 44.0.2,45.0.0`

## Changes

- `examples/native-messaging/nm_js2wasm.ts` — streaming reused-buffer echo.
- `examples/native-messaging/compare-memory.mjs` — comparison harness across wasmtime builds / host versions, with echo byte-exactness checking.
- `tests/issue-1530.test.ts` — multi-message large-non-string-body regression test (the gap that let this through). Smoke test (`smoke-test.sh`) still passes; 1 MiB and multi×1.25 MiB round-trip byte-exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)