### PR TITLE
docs(#1087): mark done — iterative walker already landed (PR #343)

### DIFF
--- a/plan/issues/1087-codegen-iterative-walkinstructions-patchstructnewforaddedfield-to-stop-recursive.md
+++ b/plan/issues/1087-codegen-iterative-walkinstructions-patchstructnewforaddedfield-to-stop-recursive.md
@@ -1,9 +1,10 @@
 ---
 id: 1087
 title: "codegen: iterative walkInstructions + patchStructNewForAddedField to stop recursive walker composing with compile stack under tight CI stack budgets"
-status: ready
+status: done
 created: 2026-04-11
-updated: 2026-04-11
+updated: 2026-06-03
+completed: 2026-06-03
 priority: critical
 feasibility: easy
 reasoning_effort: low


### PR DESCRIPTION
## Summary

Issue #1087 (iterative `walkInstructions` + `patchInstrs` to stop recursive-walker/compile-stack composition under tight CI stack budgets) was **already implemented on main** by commit `74ed6e4ac`, merged via PR #343 on 2026-05-23.

Both target functions are confirmed iterative on current main:
- `walkInstructions` (`src/codegen/walk-instructions.ts`) — explicit frame-stack DFS, zero recursive self-calls
- `patchInstrs` inside `patchStructNewForAddedField` (`src/codegen/expressions/late-imports.ts:492`) — iterative work-queue

The issue frontmatter was stale at `status: ready`. This PR is a **frontmatter-only correction** to `status: done` (with `completed: 2026-06-03`). No code change.

## Why

The auto-dispatcher kept re-offering #1087 because its issue status hadn't been flipped to `done` after PR #343 merged. This closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)