### PR TITLE
docs(#1591): re-profile class-elements gap — Cluster A works in JS-host; standalone __proto_method_call is the real blocker

### DIFF
--- a/plan/issues/1591-class-elements-same-line-multi-definition.md
+++ b/plan/issues/1591-class-elements-same-line-multi-definition.md
@@ -3,7 +3,8 @@ id: 1591
 title: "class/elements: WasmGC-struct ↔ host own-property/identity reconciliation gaps (~294 fails)"
 status: blocked
 created: 2026-05-24
-updated: 2026-06-02
+updated: 2026-06-03
+depends_on: [1472]
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -309,3 +310,52 @@ object, and private statics live keyed on the constructor. **Depends on 1591c.**
   the failure cause. `status` set to `blocked` pending sub-issue creation
   (1591a–e). No open `depends_on` — #1364 (the descriptor-infra prerequisite)
   already merged 2026-05-20.
+
+## 2026-06-03 senior-dev re-profile — Cluster A is NOT the gap; standalone-mode `__proto_method_call` is
+
+Re-investigated against current `main` (HEAD 815592da2) to scope a 1591a slice.
+**Cluster A (instance-field own-property visibility) already works in JS-host
+mode.** Earlier framing that `hasOwnProperty`/`getOwnPropertyDescriptor`/`Object.keys`
+fail on instance fields was a *test-harness artifact*, not a compiler defect:
+
+- `Object.getOwnPropertyDescriptor(c, "field")` → correct
+  `{value, writable:true, enumerable:true, configurable:true}`.
+- `Object.prototype.hasOwnProperty.call(c, "field")` → **true**,
+  `Object.keys(c)` → **`["field","other"]`**, `propertyIsEnumerable` → **true** —
+  *but only when the host wires `imports.setExports(instance.exports)`*. The
+  runtime's `_readOwnDescriptor` / proxy `getOwnPropertyDescriptor` traps resolve
+  struct fields via `_getStructFieldNames` + `__sget_<key>`, which require the
+  exports table. The real test262 runner DOES call `setExports`
+  (`tests/test262-runner.ts:3120`), so JS-host conformance for Cluster A is
+  already correct. Probes that omit `setExports` produce false negatives
+  (`__struct_field_names(c)` returns `"field,other"` but `__sget_*` is unreachable).
+
+**The genuine 1,660-row standalone gap is a hard COMPILE ERROR, not a runtime
+reconciliation miss.** In `--target standalone`, `Object.prototype.<method>.call(receiver, …)`
+always lowers to the JS-host `__proto_method_call` import
+(`src/codegen/expressions/calls.ts:2737-2862`), which is rejected:
+> `'__proto_method_call' (dynamic-shape object/property operation) is not yet
+> supported in --target standalone (#1472 Phase B).`
+`__hasOwnProperty` / `__object_hasOwn` are still classified as JS-host late
+imports (`src/codegen/expressions/late-imports.ts:70`), so even direct
+`c.hasOwnProperty(k)` does not yet compile standalone.
+
+### Revised fix direction (supersedes 1591a-as-runtime-materialization)
+
+The class-elements standalone family is **blocked on the #1472 Phase C native
+MOP routing** (Reflect.* + Object.prototype.* dispatch to the Wasm-native open-object
+runtime), which is in flight on **task #274** (`feat(#1472 Phase C): Reflect.*
+standalone routing`). The concrete next slice for 1591 is a codegen change at
+`calls.ts:2737`: when `ctx.standalone && typeName === "Object"` and `methodName ∈
+{hasOwnProperty, propertyIsEnumerable, isPrototypeOf}`, route to the native
+runtime helper instead of `__proto_method_call`; and a parallel
+`Object.keys`/`getOwnPropertyNames(struct)` native-enumeration emit (reusing the
+Phase B Blocker B Slice 2 enumeration consumer, task #261). These depend on Phase C
+landing its receiver→native-MOP plumbing first to avoid duplicating the dispatch
+layer. **Recommend keeping #1591 `blocked` on #1472 Phase C** rather than cutting a
+1591a runtime-materialization slice — there is no runtime materialization bug to fix.
+
+- No source changes in this pass; this is a re-profile correcting the scope.
+  The 294 host-mode `class/elements` count predates the descriptor-infra
+  (#1364/#1629) landings and should be re-measured; the 1,660 standalone rows
+  are the load-bearing number and are Phase-C-gated.


### PR DESCRIPTION
## Summary

Re-investigated #1591 (class-elements WasmGC↔host own-property reconciliation, 1,660 standalone rows) against current `main` to scope an implementation slice. The investigation **corrects the issue's scope** and records a `depends_on: [1472]`.

## Findings

**Cluster A (instance-field own-property visibility) is NOT broken in JS-host mode.**
The prior framing — that `hasOwnProperty` / `getOwnPropertyDescriptor` / `Object.keys` fail on class instance fields — was a **test-harness artifact**. Verified empirically:
- `Object.getOwnPropertyDescriptor(c, "field")` → correct `{value, writable:true, enumerable:true, configurable:true}`.
- `hasOwnProperty.call(c, "field")` → `true`, `Object.keys(c)` → `["field","other"]`, `propertyIsEnumerable` → `true` — **once `imports.setExports(instance.exports)` is wired**. The runtime resolves struct fields via `_getStructFieldNames` + `__sget_<key>`, which need the exports table. The real test262 runner already calls `setExports` (`tests/test262-runner.ts:3120`), so JS-host conformance is already correct. Probes omitting `setExports` produce false negatives.

**The load-bearing 1,660 standalone rows are a hard COMPILE ERROR, not a runtime miss.**
In `--target standalone`, `Object.prototype.<m>.call(receiver, …)` always lowers to the JS-host `__proto_method_call` import (`src/codegen/expressions/calls.ts:2737-2862`), which is rejected:
> `'__proto_method_call' (dynamic-shape object/property operation) is not yet supported in --target standalone (#1472 Phase B).`

`__hasOwnProperty` / `__object_hasOwn` remain JS-host late imports (`late-imports.ts:70`), so even direct `c.hasOwnProperty(k)` does not compile standalone.

## Conclusion

The class-elements standalone family is **blocked on #1472 Phase C native MOP routing** (in flight on task #274). There is **no runtime materialization bug** to fix — cutting a 1591a runtime-materialization slice would be wasted work. Recorded `depends_on: [1472]`, kept `status: blocked`, and documented the concrete `calls.ts:2737` routing change as the Phase-C-gated next slice.

## Changes

- `plan/issues/1591-…md`: +51 lines re-profile section + `depends_on: [1472]`. **No source changes** — zero regression risk.

Refs #1591, #1472.