### PR TITLE
feat(#1629 S6): native Object.defineProperty data descriptor under --target standalone

### DIFF
--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -749,6 +749,25 @@ asserting the getter fires.
 > (non-literal) descriptor objects (`__defineProperty_desc`) and
 > `Object.getOwnPropertyDescriptor` native read-back also remain follow-ups.
 >
+> **Follow-on slice — native `hasOwnProperty`/`propertyIsEnumerable` for struct
+> receivers (from sd-846-slice3's #1591 investigation):**
+> `Object.prototype.hasOwnProperty.call(receiver, key)` (and
+> `propertyIsEnumerable`) currently routes to the JS-host `__proto_method_call`
+> import at `src/codegen/expressions/calls.ts` Case 2a (`typeName === "Object"`),
+> so it refuses under `--target standalone`. With the #1629 native descriptor
+> model in place, this becomes a localized routing slice: at the Case-2a site,
+> when `ctx.standalone && typeName === "Object" && methodName ∈
+> {hasOwnProperty, propertyIsEnumerable}`, lower to a new native helper built
+> on the already-present `$Object`/`$PropEntry` primitives — `hasOwnProperty`
+> reuses `__extern_has_idx` (own-slot probe, tombstone-aware), and
+> `propertyIsEnumerable` reads the matched `$PropEntry.$flags & FLAG_ENUMERABLE`
+> (returning `false` for a missing key rather than throwing). Both take the
+> coerced receiver→`$Object` (lenient: non-object receiver → ToObject already
+> handled upstream) and the key string. No `$PropEntry` layout change needed —
+> the enumerable bit and own-slot probe already exist. This is the natural
+> dispatch-layer extension of S6 and should be cut as its own net-≥0 PR after
+> S6 lands.
+>
 > **Tests:** `tests/issue-1629-S6.test.ts` (6 cases: full-attr define +
 > read-back, omitted-attr defaults, coexist with dynamic set/get, redefine
 > overwrite, null-throw TypeError, table grow/rehash). No-regression: the

--- a/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
+++ b/plan/issues/1629-spec-gap-object-defineproperty-descriptor-attributes.md
@@ -708,6 +708,53 @@ required so the feature is not host-only.
 `--target wasi` smoke test compiling a `defineProperty({get})` program and
 asserting the getter fires.
 
+> **S6 STATUS — data-descriptor sub-slice DONE (2026-06-03, senior-developer).**
+> `Object.defineProperty(obj, key, { value, writable?, enumerable?,
+> configurable? })` (and `Reflect.defineProperty` for a data descriptor) now
+> lowers to a **native** `__defineProperty_value` on the #1472 Phase B
+> `$Object`/`$PropEntry` runtime under `--target standalone`, instead of
+> refusing (#1472 Phase A). Zero `env::__defineProperty*` host imports; modules
+> instantiate with an empty import object.
+>
+> **What shipped (`src/codegen/object-runtime.ts`, `late-imports.ts`,
+> `object-ops.ts`):**
+> 1. New native helper `__defineProperty_value(obj, key, value, flags:f64) ->
+>    externref` — structurally a sibling of `__extern_set`: unwrap obj→$Object
+>    (lenient no-op on non-object), translate the host f64 flag word
+>    (`computeRuntimeFlags`: value bits 0/1/2) to the native `$PropEntry.flags`
+>    (`FLAG_WRITABLE/ENUMERABLE/CONFIGURABLE` — same bit positions), grow at the
+>    0.7 load factor, then `__obj_insert`. The existing native `__extern_get`
+>    reads the value back; no `$PropEntry` layout change was needed for the
+>    data path (value+flags slots already exist).
+> 2. Added `__defineProperty_value` to `OBJECT_RUNTIME_HELPER_NAMES` so
+>    `ensureLateImport` routes it native (the routing check precedes the
+>    `STANDALONE_REFUSED_IMPORT` `__defineProperty*` refusal, so the name in both
+>    sets resolves native first).
+>
+> **Latent bug fixed (shared, host + standalone): `emitObjectArgNullGuard`
+> (object-ops.ts) emitted `global.get index: stringGlobalMap.get(msg)` which is
+> the `-1` nativeStrings sentinel** → `Invalid global index: 4294967295` at
+> instantiate. This was dormant because the Object.* null-guard was previously
+> unreachable under standalone (defineProperty refused before reaching it). Now
+> the guard materializes its message via `stringConstantExternrefInstrs` (inline
+> `$NativeString` under nativeStrings, host `string_constants` global otherwise)
+> — same canonical fix family as #1623. `Object.defineProperty(null, …)` now
+> throws a catchable TypeError in standalone.
+>
+> **Deferred to S6 follow-up (NOT this slice):** accessor descriptors
+> (`{ get, set }`) — `__defineProperty_accessor` stays in `STANDALONE_REFUSED_IMPORT`.
+> Native accessor support needs `$PropEntry` accessor slots (`$get`/`$set` anyref
+> + isAccessor flag) and `call_ref` invocation on the stored closure at the read
+> site — the WasmGC analogue of the host `_maybeWrapCallable` path. Dynamic
+> (non-literal) descriptor objects (`__defineProperty_desc`) and
+> `Object.getOwnPropertyDescriptor` native read-back also remain follow-ups.
+>
+> **Tests:** `tests/issue-1629-S6.test.ts` (6 cases: full-attr define +
+> read-back, omitted-attr defaults, coexist with dynamic set/get, redefine
+> overwrite, null-throw TypeError, table grow/rehash). No-regression: the
+> existing #1472 (21) + #1629 S1/S2/S3 (23) suites stay green; host-mode
+> defineProperty still compiles.
+
 ## Cross-cutting risks & guardrails (apply to every slice)
 
 1. **Object hot path** — S3 is the danger. The accessor-read shim must be

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -19,6 +19,7 @@ import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType, getOrRegisterVecType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, compileStatement, ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { compileNativeStringLiteral, compileStringLiteral } from "./string-ops.js";
 import { getVecInfo } from "./type-coercion.js";
 
@@ -312,14 +313,20 @@ function emitNonObjectArgGuard(
 function emitObjectArgNullGuard(ctx: CodegenContext, fctx: FunctionContext, localIdx: number): void {
   const message = "TypeError: Object method called on null or undefined";
   addStringConstantGlobal(ctx, message);
-  const strIdx = ctx.stringGlobalMap.get(message)!;
   const tagIdx = ensureExnTag(ctx);
+  // Materialize the message via stringConstantExternrefInstrs so it works in
+  // both backends: a host `string_constants` global, OR — under nativeStrings
+  // (auto-on for --target standalone/wasi) — an inline-built `$NativeString`.
+  // The previous `global.get` of `stringGlobalMap.get(message)` emitted index
+  // -1 (the nativeStrings sentinel) → "Invalid global index: 4294967295" at
+  // instantiate. This surfaced once #1629 S6 let Object.defineProperty reach
+  // this guard under standalone instead of refusing at compile time.
   fctx.body.push({ op: "local.get", index: localIdx });
   fctx.body.push({ op: "ref.is_null" });
   fctx.body.push({
     op: "if",
     blockType: { kind: "empty" },
-    then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+    then: [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx } as Instr],
     else: [],
   });
 }

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1755,6 +1755,125 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __defineProperty_value (#1629 S6 — native data-descriptor define) ─────
+  //
+  // `Object.defineProperty(obj, key, { value, writable?, enumerable?,
+  // configurable? })` and `Reflect.defineProperty` for a DATA descriptor under
+  // `--target standalone`. In JS-host mode this is the `env::__defineProperty_value`
+  // host import backed by the JS descriptor sidecar; standalone has no host, so we
+  // store the value + attribute flags directly into the `$Object`/`$PropEntry`
+  // runtime that the native `__extern_get` already reads back.
+  //
+  // The compiler passes `flags` as an f64 in the host encoding
+  // (`computeRuntimeFlags`, object-ops.ts):
+  //   bit 0: writable          bit 3: writable specified
+  //   bit 1: enumerable        bit 4: enumerable specified
+  //   bit 2: configurable      bit 5: configurable specified
+  //   bit 6: is accessor       bit 7: has value
+  // We translate to the native `$PropEntry.flags` bits (FLAG_WRITABLE / _ENUMERABLE
+  // / _CONFIGURABLE). Per CompletePropertyDescriptor (ES §6.2.6.4) a NEW
+  // property's omitted attributes default to false — and the host f64 encoding
+  // already reflects that (an unspecified attr has neither its specified-bit nor
+  // its value-bit set, so the `& value-bit` test yields 0 → false). So the
+  // translation is a straight per-attribute mask of bits 0/1/2 onto the native
+  // bit positions, which happen to coincide (native WRITABLE=0x1, ENUMERABLE=0x2,
+  // CONFIGURABLE=0x4 == host value bits 0,1,2). The only divergence from
+  // __extern_set is the explicit flag word instead of FLAG_DEFAULT.
+  //
+  // Accessor descriptors (`{ get, set }`, host flag bit 6) are NOT handled here —
+  // they stay refused under standalone (deferred S6 follow-up: accessor slots +
+  // call_ref invocation). The accessor path keeps emitting __defineProperty_accessor,
+  // which remains in STANDALONE_REFUSED_IMPORT.
+  //
+  // params: 0=obj 1=key 2=value 3=flagsF64
+  // locals: 4=o(ref null $Object) 5=any(anyref) 6=cap 7=load 8=nflags(i32) 9=hf(i32)
+  {
+    const NATIVE_ATTR_MASK = FLAG_WRITABLE | FLAG_ENUMERABLE | FLAG_CONFIGURABLE; // 0x07
+    const body: Instr[] = [
+      // any = any.convert_extern(obj) ; if !$Object → return obj (lenient no-op,
+      // matches the host import returning O unchanged)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 5 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      },
+      // o = cast<$Object>(any)
+      { op: "local.get", index: 5 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 4 },
+      // hf = trunc_s(flagsF64)  (the host encoding is a small non-negative int)
+      { op: "local.get", index: 3 },
+      { op: "i32.trunc_f64_s" },
+      { op: "local.set", index: 9 },
+      // nflags = hf & (WRITABLE|ENUMERABLE|CONFIGURABLE)
+      // Host value bits 0/1/2 line up with native FLAG_* bit positions, so a
+      // direct mask is the translation. (Specified/hasValue/accessor bits 3-7
+      // are dropped.)
+      { op: "local.get", index: 9 },
+      { op: "i32.const", value: NATIVE_ATTR_MASK },
+      { op: "i32.and" },
+      { op: "local.set", index: 8 },
+      // load = o.count + o.tombstones ; cap = o.props.len ; grow at LF 0.7
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 2 },
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 3 },
+      { op: "i32.add" },
+      { op: "local.set", index: 7 },
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "array.len" },
+      { op: "local.set", index: 6 },
+      // if (load + 1) * 10 >= cap * 7 → grow
+      { op: "local.get", index: 7 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "i32.const", value: 10 },
+      { op: "i32.mul" },
+      { op: "local.get", index: 6 },
+      { op: "i32.const", value: 7 },
+      { op: "i32.mul" },
+      { op: "i32.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 4 }, { op: "ref.as_non_null" }, { op: "call", funcIdx: objGrowIdx }],
+      },
+      // __obj_insert(o, key, any.convert_extern(value), nflags)
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      { op: "any.convert_extern" },
+      { op: "local.get", index: 8 },
+      { op: "call", funcIdx: objInsertIdx },
+      // return obj (host import returns O)
+      { op: "local.get", index: 0 },
+    ];
+    registerNative(
+      "__defineProperty_value",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "f64" }],
+      [{ kind: "externref" }],
+      [
+        { name: "o", type: objRefNull },
+        { name: "any", type: { kind: "anyref" } },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "load", type: { kind: "i32" } },
+        { name: "nflags", type: { kind: "i32" } },
+        { name: "hf", type: { kind: "i32" } },
+      ],
+      body,
+    );
+  }
+
   // ── Object integrity predicates (#1472 Phase B Blocker A Half 1, PR #1074) ─
   //
   // __object_isFrozen / __object_isSealed / __object_isExtensible read the
@@ -1851,4 +1970,9 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__object_isFrozen",
   "__object_isSealed",
   "__object_isExtensible",
+  // #1629 S6 — native data-descriptor define (Object.defineProperty /
+  // Reflect.defineProperty with a { value, writable?, enumerable?, configurable? }
+  // descriptor). Accessor descriptors stay refused (see the __defineProperty_value
+  // note in ensureObjectRuntime).
+  "__defineProperty_value",
 ]);

--- a/tests/issue-1629-S6.test.ts
+++ b/tests/issue-1629-S6.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1629 S6 — standalone/WASI descriptor parity.
+ *
+ * `Object.defineProperty(obj, key, { value, writable?, enumerable?,
+ * configurable? })` (a DATA descriptor) now lowers to the Wasm-native
+ * `__defineProperty_value` helper on the #1472 Phase B `$Object`/`$PropEntry`
+ * open-object runtime, instead of refusing under `--target standalone` (#1472
+ * Phase A). The value + attribute flags are stored into the property entry and
+ * read back by the existing native `__extern_get`. Zero `env::__defineProperty*`
+ * host imports; the module instantiates with an empty import object.
+ *
+ * Accessor descriptors (`{ get, set }`) are NOT in this slice — they remain
+ * refused under standalone (deferred S6 follow-up: $PropEntry accessor slots +
+ * call_ref invocation).
+ */
+
+const DEFINE_PROP_IMPORTS = /^env::__defineProperty/;
+
+function assertNoDefinePropertyHostImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  const hits = labels.filter((l) => DEFINE_PROP_IMPORTS.test(l));
+  expect(hits, `--target standalone leaked ${hits.join(", ")}`).toEqual([]);
+}
+
+async function run(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoDefinePropertyHostImports(r.imports);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#1629 S6 — native Object.defineProperty (data descriptor) under --target standalone", () => {
+  it("defines a data property with full attributes and reads it back", async () => {
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = {};
+          Object.defineProperty(o, "x", { value: 42, writable: true, enumerable: true, configurable: true });
+          return o.x as number;
+        }
+      `),
+    ).toBe(42);
+  });
+
+  it("defines a data property with omitted attributes (CompletePropertyDescriptor defaults)", async () => {
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = {};
+          Object.defineProperty(o, "y", { value: 7 });
+          return o.y as number;
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("coexists with plain dynamic property set/get on the same object", async () => {
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = {};
+          o.a = 10;
+          Object.defineProperty(o, "b", { value: 32 });
+          return (o.a as number) + (o.b as number);
+        }
+      `),
+    ).toBe(42);
+  });
+
+  it("redefining an existing key via defineProperty overwrites the value", async () => {
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = {};
+          o.k = 1;
+          Object.defineProperty(o, "k", { value: 5 });
+          return o.k as number;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("Object.defineProperty on null throws a catchable TypeError (native null-guard)", async () => {
+    // The shared object-arg null guard materializes its message via
+    // stringConstantExternrefInstrs (a nativeStrings-safe inline $NativeString),
+    // not a host string_constants global — so the throw path is valid Wasm in
+    // standalone. Returns 99 when the TypeError is caught.
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = null;
+          try {
+            Object.defineProperty(o, "x", { value: 1 });
+            return 0;
+          } catch (e) {
+            return 99;
+          }
+        }
+      `),
+    ).toBe(99);
+  });
+
+  it("multiple defineProperty calls grow/rehash the native table correctly", async () => {
+    expect(
+      await run(`
+        export function run(): number {
+          const o: any = {};
+          Object.defineProperty(o, "p0", { value: 0 });
+          Object.defineProperty(o, "p1", { value: 1 });
+          Object.defineProperty(o, "p2", { value: 2 });
+          Object.defineProperty(o, "p3", { value: 3 });
+          Object.defineProperty(o, "p4", { value: 4 });
+          Object.defineProperty(o, "p5", { value: 5 });
+          Object.defineProperty(o, "p6", { value: 6 });
+          Object.defineProperty(o, "p7", { value: 7 });
+          Object.defineProperty(o, "p8", { value: 8 });
+          return (o.p0 as number) + (o.p7 as number) + (o.p8 as number);
+        }
+      `),
+    ).toBe(15);
+  });
+});


### PR DESCRIPTION
## #1629 S6 — standalone/WASI descriptor parity (data-descriptor sub-slice)

Implements the **S6 data-descriptor path** of the unified Object
property-descriptor model (`plan/issues/1629-...`). Now that the #1472 Phase B
open-object runtime (`$Object`/`$PropEntry`/`$PropMap`, native new/get/set/
delete/keys/values/freeze) has landed, `Object.defineProperty(obj, key,
{ value, writable?, enumerable?, configurable? })` (and `Reflect.defineProperty`
for a data descriptor) lowers to a **Wasm-native `__defineProperty_value`**
under `--target standalone`, instead of refusing at compile time (#1472 Phase A).

### What changed

- **`src/codegen/object-runtime.ts`** — new native helper
  `__defineProperty_value(obj, key, value, flags:f64) -> externref`,
  structurally a sibling of `__extern_set`: unwrap obj→`$Object` (lenient no-op
  on non-object), translate the host f64 flag word (`computeRuntimeFlags` value
  bits 0/1/2) to the native `$PropEntry.flags` bits
  (`FLAG_WRITABLE/ENUMERABLE/CONFIGURABLE` — same positions), grow at the 0.7
  load factor, then `__obj_insert`. Registered in `OBJECT_RUNTIME_HELPER_NAMES`
  so `ensureLateImport` routes it native (that check precedes the
  `STANDALONE_REFUSED_IMPORT` `__defineProperty*` refusal). No `$PropEntry`
  layout change needed for the data path — value+flags slots already exist; the
  existing native `__extern_get` reads the value back.

- **`src/codegen/object-ops.ts`** — `emitObjectArgNullGuard` now materializes
  its TypeError message via `stringConstantExternrefInstrs` instead of a raw
  `global.get` of `stringGlobalMap.get(msg)`, which under `nativeStrings`
  (auto-on for standalone/wasi) is the `-1` sentinel → `Invalid global index:
  4294967295` at instantiate. This latent bug was dormant because the Object.*
  null-guard was unreachable under standalone until defineProperty stopped
  refusing. Same canonical fix family as #1623.

### Scope / deferred

Accessor descriptors (`{ get, set }`) stay refused under standalone —
`__defineProperty_accessor` remains in `STANDALONE_REFUSED_IMPORT`. Native
accessor support needs `$PropEntry` accessor slots + `call_ref` invocation and
is a deferred S6 follow-up (so are dynamic `__defineProperty_desc` and native
`getOwnPropertyDescriptor` read-back). `#1629` umbrella stays open.

### Tests

`tests/issue-1629-S6.test.ts` — 6 cases: full-attr define + read-back,
omitted-attr CompletePropertyDescriptor defaults, coexist with dynamic set/get,
redefine overwrite, `defineProperty(null,…)` throws catchable TypeError, table
grow/rehash. No-regression: existing #1472 (21) + #1629 S1/S2/S3 (23) suites
stay green; host-mode defineProperty still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)