### PR TITLE
fix(#1320 blocker): register box helpers before emitting struct field getters

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1659,6 +1659,41 @@ function _emitStructFieldGettersInner(ctx: CodegenContext): void {
 
   if (fieldMap.size === 0) return;
 
+  // (#1320) A getter that returns a numeric/boolean field as externref boxes it
+  // via __box_number / __box_boolean. Those helpers are registered lazily at
+  // boxing call-sites during expression compilation — but a module whose only
+  // numeric/boolean struct field is read *exclusively through the host* (e.g. a
+  // function returns `{ value, done }` to JS, which then reads `.done`) never
+  // hits such a call-site, so the helpers are still absent here. Without them
+  // the getter fell through to `drop; ref.null.extern` and `__sget_done`
+  // returned null (and `__sget_<num>` would have boxed as a number — #1788).
+  // Register the union helpers (which include __box_number / __box_boolean)
+  // BEFORE any getter funcIdx is computed, so the emitted getters reference the
+  // final post-shift indices. addUnionImports is idempotent (hasUnionImports
+  // guard), uses the immediate finalize-phase index shift, and in
+  // standalone/WASI mode routes to the Wasm-native helper bodies (no env::*
+  // import). We only call it when at least one field bucket would emit a box
+  // call (an extern-mode bucket carrying a numeric/boolean field), so a module
+  // with no such fields stays byte-identical.
+  let needsBox = false;
+  for (const entries of fieldMap.values()) {
+    const hasF64 = entries.some((e) => e.fieldType.kind === "f64");
+    const hasI32 = entries.some((e) => e.fieldType.kind === "i32");
+    const hasRef = entries.some((e) => e.fieldType.kind !== "f64" && e.fieldType.kind !== "i32");
+    const hasBool = entries.some((e) => e.fieldType.kind === "i32" && (e.fieldType as { boolean?: true }).boolean);
+    const allF64 = hasF64 && !hasI32 && !hasRef;
+    const allI32 = hasI32 && !hasF64 && !hasRef && !hasBool;
+    // f64-only / i32-only buckets return the raw value (no box call). Only a
+    // mixed/boolean (extern-mode) bucket carrying a numeric or boolean field
+    // emits a __box_number / __box_boolean call.
+    if (allF64 || allI32) continue;
+    if (hasF64 || hasI32 || hasBool) {
+      needsBox = true;
+      break;
+    }
+  }
+  if (needsBox) addUnionImports(ctx);
+
   // Find __box_number import for numeric boxing (may be undefined)
   const boxNumIdx = ctx.funcMap.get("__box_number");
   // (#1788) __box_boolean for boolean-branded i32 fields — boxes the stored i32

--- a/tests/issue-1320-sget-host-box.test.ts
+++ b/tests/issue-1320-sget-host-box.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1320 blocker — `__sget_<field>` returns null for a numeric/boolean
+ * struct field when the field is read *exclusively through the host*.
+ *
+ * The exported struct-field getters (`__sget_done` etc.) box numeric/boolean
+ * fields via `__box_number` / `__box_boolean`. Those helpers are registered
+ * lazily at in-body boxing call-sites. A module that builds a `{ value, done }`
+ * record and hands it to the host (which then reads `.done` via the getter)
+ * without any in-body boxing site never registered the helpers, so the getter
+ * fell through to `drop; ref.null.extern` and returned null. This broke the
+ * iterator-result host bridge that #1320 (Array.from) depends on.
+ *
+ * Fix: register the union box helpers in `emitStructFieldGetters` before any
+ * getter funcIdx is computed, whenever a field bucket would emit a box call.
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function run(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  return (exports.test as () => unknown)();
+}
+
+describe("#1320 — struct field getter boxes for host reads (no in-body box site)", () => {
+  it("boolean `done` field read via host round-trips as boolean (not null)", async () => {
+    // `r` is handed to the host as an opaque struct; the host reads `.done`
+    // through `__sget_done`. No in-body boxing site exists for `done`.
+    expect(
+      await run(`
+        export function test(): string {
+          const r: { value: number; done: boolean } = { value: 42, done: true };
+          const o: any = r;
+          return typeof o.done;
+        }
+      `),
+    ).toBe("boolean");
+  });
+
+  it("boolean `done` field strict-equals true via host read", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const r: { value: number; done: boolean } = { value: 7, done: true };
+          const o: any = r;
+          return o.done === true ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("numeric `value` field read via host round-trips as number (not null)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const r: { count: number; flag: boolean } = { count: 99, flag: false };
+          const o: any = r;
+          return o.count;
+        }
+      `),
+    ).toBe(99);
+  });
+
+  it("JSON.stringify of an iterator-result-shaped struct surfaces both fields", async () => {
+    // JSON.stringify walks the struct via the host getters — the regression
+    // path. Before the fix `done` serialized as null.
+    expect(
+      await run(`
+        export function test(): string {
+          const r: { value: number; done: boolean } = { value: 5, done: false };
+          return JSON.stringify(r);
+        }
+      `),
+    ).toBe('{"value":5,"done":false}');
+  });
+});


### PR DESCRIPTION
## Problem

`__sget_<field>` struct-field getters returned **null** for a numeric/boolean field when that field is read **exclusively through the host** (e.g. a function builds a `{ value, done }` record and hands it to JS, which then reads `.done` via the getter). `dev-1749-fix` root-caused `__sget_done` returning null; this is the underlying defect.

## Root cause

The getters box numeric/boolean fields via `__box_number` / `__box_boolean`. Those helpers are registered **lazily at in-body boxing call-sites** during expression compilation. A module with no such in-body site never registered them, so `emitStructFieldGetters` (which runs in the finalize tail) read `undefined` from `funcMap`. The extern-mode getter then fell through to `drop; ref.null.extern` → **null** (a numeric field would have boxed as a *number*). This is the latent gap the #1788 boolean-brand getter branch inherited, and it blocks the iterator-result host bridge #1320 (Array.from) depends on.

Verified empirically: at the getter-emit phase both `boxNumIdx` and `boxBoolIdx` were `undefined` for a module that only returns a struct to the host.

## Fix

In `_emitStructFieldGettersInner`, call `addUnionImports(ctx)` (idempotent via `hasUnionImports`; uses the finalize-phase immediate index shift; routes to Wasm-native helper bodies under `--standalone`/`--target wasi`) **before any getter funcIdx is computed** — but only when at least one field bucket would emit a box call (an extern-mode bucket carrying a numeric or boolean field). Modules with no such fields stay **byte-identical**.

## Tests

New `tests/issue-1320-sget-host-box.test.ts` exercises host reads with no in-body box site:
- boolean `done` field round-trips as **boolean** (not null), and `=== true`
- numeric field round-trips as **number** (not null)
- `JSON.stringify` of an iterator-result-shaped struct surfaces both fields

`tests/issue-1788.test.ts` unchanged (5/5). Typecheck clean. The 3 pre-existing `object-mutability` stub failures are present on baseline `cca26c66c` (verified by stashing this change) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)