### PR TITLE
fix(#1732): Math.* ToNumber(Symbol) must throw TypeError (§7.1.4)

### DIFF
--- a/plan/issues/1732-builtin-method-value-construct-brand-and-descriptors.md
+++ b/plan/issues/1732-builtin-method-value-construct-brand-and-descriptors.md
@@ -479,3 +479,31 @@ Tests: `tests/issue-1732-s2.test.ts` (6) — `new Math.f16round`/`Math.sumPrecis
 S1 tests stay green. Closes test262
 `built-ins/Math/f16round/not-a-constructor.js` and the analogous newer-method
 not-a-constructor cases.
+
+## Symbol-coercion sub-fix — Math.* ToNumber(Symbol) throws TypeError (2026-06-03)
+
+Distinct from the [[Construct]]-brand and namespace-call work above: a separate
+spec-conformance gap surfaced while investigating `Math.*` argument handling.
+`Math.abs/floor/ceil/sqrt/round/sign/max/min/pow/clz32/...` run **ToNumber** on
+their arguments (§21.3.2.x → §7.1.4 *ToNumber*). ToNumber of a **Symbol** MUST
+throw a `TypeError` (§7.1.4 step 5). Compiled `Math.abs(Symbol())` instead
+returned a garbage number.
+
+**Root cause.** `compileSymbolCall` (`src/codegen/literals.ts`) lowers a Symbol
+to an **i32 id** (the symbol counter). `compileMathCall` compiles each argument
+with an `f64Hint`, and an i32 symbol id coerces straight to f64 — the raw
+counter leaks as the result, never routing through `__unbox_number` (which *does*
+throw on a real boxed Symbol, hence `const s: any = Symbol(); Math.abs(s)`
+already threw correctly — only the statically-symbol-typed argument slipped).
+
+**Fix** (`src/codegen/expressions/builtins.ts::compileMathCall`): before the
+method-specific lowering, scan the arguments for a `symbol`-typed one
+(`isSymbolType`). If found, evaluate every argument up to and including it for
+side effects in source order, then `emitThrowTypeError(..., "Cannot convert a
+Symbol value to a number")` — exactly mirroring the existing `Number(Symbol())`
+guard at `calls.ts:7506`. Override-free numeric Math paths are untouched
+(`Math.abs(-5)`, `Math.max(1,2,3)`, NaN propagation all verified intact).
+
+Tests: `tests/issue-1732-math-symbol-coercion.test.ts` (18) — 12 Symbol-throw
+cases across the unary/variadic/binary Math methods + 6 numeric regression
+guards (incl. `Math.max(NaN,1)` NaN propagation). All green; tsc clean.

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -3,7 +3,7 @@
  * Host built-in compilation: console, Date, Math, and WASI output.
  */
 import { ts } from "../../ts-api.js";
-import { isBooleanType, isNumberType, isStringType } from "../../checker/type-mapper.js";
+import { isBooleanType, isNumberType, isStringType, isSymbolType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
@@ -14,6 +14,7 @@ import { ensureNativeStringExternBridge } from "../native-strings.js";
 import type { InnerResult } from "../shared.js";
 import { compileExpression, VOID_RESULT } from "../shared.js";
 import { compileStringLiteral } from "../string-ops.js";
+import { emitThrowTypeError } from "./helpers.js";
 import { isStaticNaN, tryStaticToNumber } from "./misc.js";
 
 // ── Builtins ─────────────────────────────────────────────────────────
@@ -1985,6 +1986,21 @@ function compileMathCall(
   };
 
   const f64Hint: ValType = { kind: "f64" };
+
+  // ToNumber(Symbol) must throw TypeError (§7.1.4 step 5). Symbols lower to i32
+  // ids, so the f64Hint coercion path would silently leak the id as a number
+  // (e.g. `Math.abs(Symbol())` returned the raw counter). Detect a symbol-typed
+  // argument, evaluate every argument up to and including it for side effects in
+  // source order, then throw — matching how `Number(Symbol())` is handled.
+  const symbolArgIdx = expr.arguments.findIndex((a) => isSymbolType(ctx.checker.getTypeAtLocation(a)));
+  if (symbolArgIdx >= 0) {
+    for (let i = 0; i <= symbolArgIdx; i++) {
+      const t = compileExpression(ctx, fctx, expr.arguments[i]!);
+      if (t !== null) fctx.body.push({ op: "drop" });
+    }
+    emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a number");
+    return { kind: "f64" };
+  }
 
   if (method === "round" && expr.arguments.length >= 1) {
     // JS Math.round: compare frac = x - floor(x) to 0.5.

--- a/tests/issue-1732-math-symbol-coercion.test.ts
+++ b/tests/issue-1732-math-symbol-coercion.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #1732 (Symbol-coercion sub-fix) — Math.* methods run ToNumber on their
+// arguments (§7.1.4). ToNumber of a Symbol MUST throw TypeError (step 5).
+// Symbols lower to i32 ids, so the f64-hint coercion path used to leak the id
+// as a plain number instead of throwing (e.g. `Math.abs(Symbol())` returned the
+// raw symbol counter). `compileMathCall` now detects a symbol-typed argument and
+// throws, mirroring how `Number(Symbol())` is handled.
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.js", allowJs: true, skipSemanticDiagnostics: true });
+  if (!r.success) throw new Error("CE: " + (r.errors[0]?.message ?? "unknown"));
+  const built = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, built);
+  (built as { setExports?: (e: WebAssembly.Exports) => void }).setExports?.(instance.exports);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+// Returns -1 when a TypeError is thrown (the correct spec result), -2 for any
+// other error, or the raw numeric result when nothing throws (the bug).
+const guard = (call: string) =>
+  `export function test() { try { return ${call}; } catch (e) { return e instanceof TypeError ? -1 : -2; } }`;
+
+describe("issue #1732 — Math.* ToNumber(Symbol) throws TypeError", () => {
+  for (const call of [
+    "Math.abs(Symbol())",
+    "Math.floor(Symbol())",
+    "Math.ceil(Symbol())",
+    "Math.sqrt(Symbol())",
+    "Math.trunc(Symbol())",
+    "Math.round(Symbol())",
+    "Math.sign(Symbol())",
+    "Math.max(1, Symbol())",
+    "Math.max(Symbol(), 1)",
+    "Math.min(Symbol(), 9)",
+    "Math.pow(2, Symbol())",
+    "Math.clz32(Symbol())",
+  ]) {
+    it(`${call} throws TypeError`, async () => {
+      expect(await run(guard(call))).toBe(-1);
+    });
+  }
+
+  // Regression guard: numeric Math.* paths must be unaffected.
+  it("Math.abs(-5) === 5", async () => {
+    expect(await run("export function test() { return Math.abs(-5); }")).toBe(5);
+  });
+  it("Math.max(1,2,3) === 3", async () => {
+    expect(await run("export function test() { return Math.max(1, 2, 3); }")).toBe(3);
+  });
+  it("Math.min(4,2,8) === 2", async () => {
+    expect(await run("export function test() { return Math.min(4, 2, 8); }")).toBe(2);
+  });
+  it("Math.round(2.6) === 3", async () => {
+    expect(await run("export function test() { return Math.round(2.6); }")).toBe(3);
+  });
+  it("Math.pow(2,10) === 1024", async () => {
+    expect(await run("export function test() { return Math.pow(2, 10); }")).toBe(1024);
+  });
+  it("Math.max(NaN, 1) is NaN (NaN propagation intact)", async () => {
+    expect(await run("export function test() { return Math.max(NaN, 1); }")).toBeNaN();
+  });
+});


### PR DESCRIPTION
## Summary

`Math.abs/floor/ceil/sqrt/round/sign/max/min/pow/clz32/...` run **ToNumber** on their arguments. ToNumber of a **Symbol** must throw `TypeError` (ECMA-262 §7.1.4 step 5). Compiled `Math.abs(Symbol())` instead returned a garbage number.

## Root cause

`compileSymbolCall` lowers a Symbol to an **i32 id** (the symbol counter). `compileMathCall` compiles each argument with an `f64Hint`, and an i32 symbol id coerces straight to f64 — the raw counter leaks as the result, never routing through `__unbox_number` (which *does* throw on a real boxed Symbol; hence `const s: any = Symbol(); Math.abs(s)` already threw — only the statically-symbol-typed argument slipped through).

## Fix

In `compileMathCall` (`src/codegen/expressions/builtins.ts`), before the method-specific lowering: scan arguments for a `symbol`-typed one (`isSymbolType`); if found, evaluate every argument up to and including it for side effects in source order, then `emitThrowTypeError(..., "Cannot convert a Symbol value to a number")` — mirroring the existing `Number(Symbol())` guard at `calls.ts:7506`. Override-free numeric Math paths are byte-identical.

This is the **Symbol-coercion** half of #1732, distinct from the namespace call-as-function half (`Math()`/`JSON()`/...) that landed separately.

## Tests

`tests/issue-1732-math-symbol-coercion.test.ts` (18) — 12 Symbol-throw cases across unary/variadic/binary Math methods + 6 numeric regression guards (incl. `Math.max(NaN,1)` NaN propagation). All green; `tsc --noEmit` clean. The 3 pre-existing `symbol-basic` equivalence failures are on the branch base (well-known-Symbol Number coercion), unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)