### PR TITLE
docs(#1694): independent re-validation #2 — residual is compiled-class-value host repr

### DIFF
--- a/plan/issues/1694-promise-subclass-capability.md
+++ b/plan/issues/1694-promise-subclass-capability.md
@@ -163,3 +163,35 @@ Do **not** carve a separate ctx-non-object fix — that behaviour is already
 correct. When #1632b's representation lands, re-run the
 `built-ins/Promise/{all,allSettled,any,race}/*ctor*` / `*species*` suites to
 confirm the A.i `resolve-from-same-constructor` family flips.
+
+## Independent re-validation #2 (2026-06-03, sd-846-slice3) — confirms the gap is the compiled-class-value host representation
+
+Re-built `dist/` from a fresh `origin/main` merge and re-probed via the
+`compile()` + `buildImports(result.imports, {}, result.stringPool)` two-step
+(the same harness `tests/promise-combinators.test.ts` uses). Findings:
+
+| Probe | Result | Reading |
+|---|---|---|
+| `Promise.all.call(5, [])` (ctx-non-object) | sentinel `1` | **TypeError thrown correctly** — spec step-2 enforced. Confirms re-validation #1. |
+| `Promise.all.call(NotPromise, […])`, `NotPromise` a compiled fn (A.i) | sentinel `1` | **TypeError thrown** — *spec-correct* for a non-constructor `C` (`ctx-non-ctor`). The `*resolve-from-same-constructor*` family wants a real subclass `C` to succeed — that path is the representation gap below, not the combinator. |
+| `typeof (X)` for `class X extends Promise {}` referenced as a value | `"object"` | the compiled class **value** is a WasmGC-struct proxy, **not** the host `Promise` subclass. |
+| `(X).all` (static method on the class value) | throws `WebAssembly.Exception` | the static method is **not resolvable** on the wasm-struct class value when the class is used as an expression. |
+
+**Root cause (confirmed at `src/runtime.ts:3592` `_wrapForHost`):** the host
+proxy `target` is `Object.create(null)` — a plain (non-callable) object. A JS
+`Proxy` can only carry `apply`/`construct` traps when its target is itself
+callable, so the wrapped compiled class/fn is neither `[[Call]]`- nor
+`[[Construct]]`-able. V8's `Construct(C, [executor])` inside
+`Promise.METHOD.call(C, …)` therefore rejects it. Identical to the `#1632b`
+bound-/host-callable-value representation gap and the `#820m`/`#1690`
+class-as-value family.
+
+**Net:** no tractable Promise-layer slice exists. The combinator code is
+spec-correct; every residual `#1694` failure (B, A.ii, A.i `*ctor*`/`*species*`)
+is gated on the **central compiled-value host representation** — `_wrapForHost`
+must produce a `function`/`Proxy(function, …)` target with `apply` + `construct`
+traps that dispatch through the `__call_fn_N` / `__construct_*` exports, owned by
+`#1632b`. **Keep `#1694` `status: backlog` + `needs_architect_spec: true`; do not
+carve a Promise-only fix.** Re-run
+`built-ins/Promise/{all,allSettled,any,race}/*ctor*`/`*species*` once `#1632b`'s
+representation lands.


### PR DESCRIPTION
Independent re-validation of #1694 (Promise.any/all/allSettled/race subclass capability) against a fresh `origin/main` build, following team-lead dispatch.

## Finding

Confirms and strengthens the prior re-validation (#1117, merged): the Promise combinator runtime (`_resolveCtor → Promise.METHOD.call(C, _toIterable(arr))`) is **already spec-correct** for every capability `C` with a usable host representation. `ctx-non-object`/`ctx-non-ctor` throw TypeError correctly.

The sole residual is `_wrapForHost` (runtime.ts:3592) wrapping a compiled class/fn value in a non-callable `Object.create(null)` proxy target — no `apply`/`construct` trap, so V8's `Construct(C, [executor])` rejects it. That is the **central #1632b / #820m host-callable-constructible representation gap, NOT a Promise-layer fix**.

## Probe evidence (fresh dist/ build)

| Probe | Result | Reading |
|---|---|---|
| `Promise.all.call(5, [])` | TypeError | correct (step-2) |
| `Promise.all.call(compiledFn, […])` | TypeError | correct for non-ctor |
| `typeof (class X extends Promise {})` as value | `"object"` | wasm-struct proxy, not host subclass |
| `(X).all` static method | `WebAssembly.Exception` | not resolvable on class value |

## Outcome

No tractable Promise-layer slice exists. **Keeps #1694 `backlog` + `needs_architect_spec`.** Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)