### PR TITLE
docs(issues): file 2026-06-04 compiler code-review findings (#1815-#1849)

### DIFF
--- a/plan/code-review/2026-06-04-compiler-review.md
+++ b/plan/code-review/2026-06-04-compiler-review.md
@@ -1,0 +1,325 @@
+# Compiler code review — 2026-06-04
+
+Scope: full read-only review of the compiler (`src/`, ~180k LOC) for **correctness
+bugs**, **redundancies/dead code**, and **conformance against the ECMAScript and
+WebAssembly specs**. Conducted via 11 parallel review passes (7 module-focused +
+4 spec-conformance) on `main` @ `f692249d`; the highest-impact findings were
+re-verified by hand against the cited source.
+
+Findings are grouped by **reachability**, because the codebase has a common
+JS-host path plus several latent paths (standalone/WASI, the `.o` linker, and
+some dead modules). Each finding lists the tracking issue filed on 2026-06-04.
+
+Several findings are **residuals of issues already marked `done`** (#1361 sort,
+#1334 defineProperty, #1335 number-format, #1798 IR return-type) — the original
+fix was incomplete or has regressed; the new issue cites the original.
+
+---
+
+## Summary
+
+| # | Issue | Sev | Area | Path |
+|---|-------|-----|------|------|
+| 1 | #1815 | high | `splice` drops inserted items | JS-host |
+| 2 | #1816 | high | `sort` ignores comparator; default not lexicographic (residual #1361) | JS-host |
+| 3 | #1817 | high | `>>>` i32 fast-path produces signed result | JS-host |
+| 4 | #1818 | high | i32/boolean default param fires on `0`/`false` | JS-host |
+| 5 | #1819 | high | logical-assignment reads globals at wrong index | JS-host |
+| 6 | #1820 | high | IR `&&`/`||`/ternary evaluate both operands | JS-host (IR) |
+| 7 | #1821 | med | `delete obj.prop` always returns `true`; `delete obj["k"]` skips sidecar | JS-host |
+| 8 | #1822 | med | `String#replace`/`replaceAll` ignore `$` substitution patterns | JS-host |
+| 9 | #1823 | med | `String#normalize(form)` evaluates arg before receiver | JS-host |
+| 10 | #1824 | med | `super` as a value returns wrong static type | JS-host |
+| 11 | #1825 | med | i32 fast-mode `%` emits trapping `i32.rem_s` | JS-host (fast) |
+| 12 | #1826 | med | `OrdinaryToPrimitive`: `valueOf` returning `undefined` treated as absent | JS-host |
+| 13 | #1827 | med | BigInt loose-equality loses precision / wrong semantics | JS-host |
+| 14 | #1828 | med | array-like `find`/`findIndex` skip holes; `map` compacts holes | JS-host |
+| 15 | #1829 | high | `marshalTypedArrayArgs` byte-masks non-`Uint8Array` typed arrays | JS-host |
+| 16 | #1830 | med | well-known-symbol range off-by-one excludes `Symbol.matchAll` | JS-host |
+| 17 | #1831 | med | `_validatePropertyDescriptor` resets omitted attrs on redefine (residual #1334) | JS-host |
+| 18 | #1832 | med | `compileNewFunctionExpression` captures outer var shadowed by destructured param | JS-host |
+| 19 | #1833 | med | implicit subclass forwarder truncates multi-arg `super(...)` | JS-host |
+| 20 | #1834 | med | vec element-write index uses trapping `i32.trunc_f64_s` | JS-host |
+| 21 | #1835 | high | C-ABI string/array marshaling reads wrong header offsets | WASI/standalone |
+| 22 | #1836 | high | standalone Number↔String conformance gaps (residual #1335) | standalone |
+| 23 | #1837 | med | standalone enumeration order is hash-bucket order | standalone |
+| 24 | #1838 | med | linear backend silently miscompiles `try/catch` | standalone |
+| 25 | #1839 | med | late string-import index shift omits init body / helpers / start func | JS-host (nativeStrings) |
+| 26 | #1840 | low | linker `writeLEB128` truncates growing indices; rewrite gaps | latent (linker) |
+| 27 | #1841 | low | element-section flag bitfield only handles active flag-0 | latent (linker) |
+| 28 | #1842 | low | `none` heap-type constant collides with `any` | latent (emit) |
+| 29 | #1843 | low | `R_WASM_TAG_INDEX_LEB` emitter/reader mismatch (11 vs 10) | latent (linker) |
+| 30 | #1844 | low | IR `verify` doesn't recurse nested if/try/loop buffers (residual #1798) | defense-in-depth |
+| 31 | #1845 | low | IR propagate: `&&`/`||` over-claim `BOOL`; `seedConcrete` omits i32/u32 | latent (IR) |
+| 32 | #1846 | low | minor `typeof` notes (i64→"number" in `with`; externref→null) | minor |
+| 33 | #1847 | low | for-of tentative rollback doesn't restore `fctx.localMap` | robustness |
+| 34 | #1848 | — | dead-code sweep (identical branches, unused locals/params) | redundancy |
+| 35 | #1849 | — | duplicate-logic refactor (diverged copy-paste) | redundancy |
+
+---
+
+## 1. Reachable correctness bugs (common JS-host path)
+
+### #1815 — `Array.prototype.splice` drops inserted items (high)
+`src/codegen/array-methods.ts:4421` (`compileArraySplice`), dispatch `:2574`.
+Reads only `start`/`deleteCount`; never reads `arguments[2..]`. `[1,2,3].splice(1,1,'a','b')`
+→ `[1,3]` instead of `[1,'a','b',3]`. ECMAScript §23.1.3.30. `toSpliced` already
+implements item insertion correctly (`:2899`) — reuse that shape.
+
+### #1816 — `Array.prototype.sort` ignores a user comparator; default sort is numeric, not lexicographic (high) — residual of #1361 (done, s51)
+`src/codegen/array-methods.ts:5781-5816` + `src/codegen/timsort.ts`.
+A callable `(a,b)=>b-a` passes the non-callable guard then is discarded →
+`[3,1,2].sort((a,b)=>b-a)` yields `[1,2,3]`. No-arg `[10,9,1].sort()` must compare
+by ToString per §23.1.3.30 (`"1","10","9"`) but sorts numerically. The only test
+asserts "doesn't throw," which masked the regression. `ensureTimsortHelper` takes
+no comparator and hard-codes `i32.lt_s`/`f64.lt`. Fix: thread the comparator
+funcref through `call_ref`, and ToString-compare in the no-arg case.
+
+### #1817 — `>>>` i32 fast path produces a signed result (high)
+`src/codegen/binary-ops.ts:1334`/`:1318`. `isI32PureExpr` admits `>>>`; the i32
+result is later widened with `f64.convert_i32_s`, so `(x >>> 0)` with the high bit
+set yields a *negative* float. The slow path correctly uses `f64.convert_i32_u`.
+§6.1.6.1 / ToUint32. Fix: exclude `>>>` from the i32-pure fast path (or convert via
+`_u` when the consumer wants f64).
+
+### #1818 — i32/boolean parameter default fires on a legitimate `0`/`false` (high)
+`src/codegen/closures.ts:767`, `src/codegen/class-bodies.ts:1076`. Uses `i32.eqz`
+as the "argument missing" sentinel. `function f(b=true){}; f(false)` → `b===true`;
+`function f(n:number=5){}; f(0)` → `5`. The f64 path correctly uses a NaN self-test;
+the array/object-pattern paths already *skip* the check for i32 (closures.ts:714).
+Fix: don't emit a default check for plain i32/boolean params (thread an explicit
+arg-present flag instead of reusing `0`).
+
+### #1819 — logical-assignment (`??=`/`||=`/`&&=`) reads globals at the wrong index (high)
+`src/codegen/expressions/assignment.ts:3159` & `:3170`. Uses raw absolute index
+`ctx.mod.globals[capturedIdx]` while every other access in the file wraps with
+`localGlobalIdx(ctx, …)` (verified: lines 260/276/590/2198/2236/2594/4536/4568).
+When import globals exist, `varType` falls back to f64, so a ref-typed global skips
+the null/undefined branch and mis-evaluates. **Verified by hand.**
+
+### #1820 — IR short-circuit operators evaluate both sides (high)
+`src/ir/from-ast.ts:3464` (ternary → `select`) and `:3676` (`&&`/`||` →
+`i32.and`/`i32.or`). The selector admits `CallExpression` arms, so `cond ? f() : g()`
+calls **both**, and `n<=1 ? 1 : n*fact(n-1)` recurses at the base case
+(non-termination). `p!==null && p.use()` loses its guard. Related Wasm-validity facet:
+a ref-typed ternary would emit untyped `select` (0x1B), invalid for reference operands
+(needs typed `0x1C`) — `src/emit/binary.ts:704`. Fix: only `select` when both arms are
+provably side-effect-free **and** numeric; otherwise lower to the short-circuiting
+`IrInstrIf` (already exists) or fall back to legacy.
+
+### #1821 — `delete obj.prop` always returns `true`; `delete obj["k"]` skips sidecar cleanup (med)
+`src/codegen/typeof-delete.ts:127` (struct fast path drops `__delete_property`'s
+result, pushes `i32.const 1` → reports success on non-configurable props; spec
+`false`/strict throw) and `:192` (`delete obj["literal"]` omits the `__delete_property`
+sidecar that `delete obj.prop` performs, so `hasOwnProperty` diverges between the two
+syntaxes). §13.5.1. Fix: return the helper result for struct fields; mirror the sidecar
+in the element-access arm.
+
+### #1822 — `String#replace`/`replaceAll` ignore `$` substitution patterns (med)
+`src/codegen/native-strings.ts:3217`/`:3294`. Replacement concatenated verbatim;
+ignores `$$`/`$&`/`` $` ``/`$'` (§22.1.3.19 GetSubstitution). `"abc".replace("b","$&$&")`
+→ `"a$&$&c"` instead of `"abbc"`. `replaceAll("","-")` also returns the input unchanged
+instead of interleaving. Fix: expand `$` patterns against the match before concat.
+
+### #1823 — `String#normalize(form)` evaluates the argument before the receiver (med)
+`src/codegen/string-ops.ts:2110`. For a non-literal form, compiles+drops the arg then
+compiles the receiver — reversing spec left-to-right order (§13.3.6 / §22.1.3.13).
+Fix: compile the receiver first (into a temp), then the arg.
+
+### #1824 — `super` used as a value returns the wrong static type (med)
+`src/codegen/expressions.ts:1249`. Uses `fctx.locals[selfIdx]` where the convention
+(used by the `this` branch at `:861`) is `fctx.params[selfIdx]` for param indices. The
+emitted `local.get` is correct; the returned ValType is an unrelated local's, which can
+mis-drive coercion of a bare `super` value. Fix: mirror the ThisKeyword indexing.
+
+### #1825 — i32 fast-mode `%` emits trapping `i32.rem_s` (med)
+`src/codegen/binary-ops.ts:2337`, reachable via the i32 fast path (`%` is not excluded
+the way `/`/`**` are). `x % 0` traps instead of `NaN`; `INT_MIN % -1` traps. §6.1.6.1.6
+Number::remainder. Fix: route `%` through `emitModulo`, or guard with `b==0`/`INT_MIN/-1`.
+
+### #1826 — `OrdinaryToPrimitive`: `valueOf` returning `undefined` treated as "absent" (med)
+`src/runtime.ts:1943`. `tryMethod` returns JS `undefined` both for "absent/returned object"
+and a real `undefined` primitive; the caller then tries `toString`. §7.1.1.1 steps 5-6.
+`{valueOf(){return undefined}, toString(){return "x"}} + ""` → `"x"` instead of `"undefined"`.
+Fix: use a distinct sentinel for absent.
+
+### #1827 — BigInt loose-equality loses precision / wrong semantics (med)
+`src/codegen/binary-ops.ts:976`. `BigInt == String` uses `parseFloat` instead of
+StringToBigInt (`12n == "12px"` → `true`; spec `false`). `BigInt == Number` collapses
+both to f64 (`9007199254740993n == 9007199254740992` → `true`; spec `false`). §7.2.13.
+Fix: route BigInt×String through a StringToBigInt helper; compare BigInt×Number by exact
+mathematical value (i64.eq when integral & in range).
+
+### #1828 — array-like `find`/`findIndex` skip holes; `map` compacts holes (med)
+`src/codegen/array-methods.ts:824` (find/findIndex wrap body in `gatedBody`, skipping
+holes — spec visits them as `undefined`, §23.1.3.9/.10) and `:937` (map appends via
+`__js_array_push`, compacting holes and shifting indices — spec preserves length,
+§23.1.3.20). Only affects sparse array-like `.call` receivers; dense arrays are fine.
+
+### #1829 — `marshalTypedArrayArgs` byte-masks non-`Uint8Array` typed arrays (high)
+`src/runtime.ts:9855-9876`. Accepts both `"uint8array"` and `"typed-array"`, then writes
+each element with `& 0xff` (line 9874). For `Int16Array`/`Int32Array`/`Float32Array`/
+`Float64Array` (classified `"typed-array"`) this truncates every value to its low byte,
+silently corrupting args. The vec store is f64, so full precision would round-trip. Fix:
+apply `& 0xff` only for `"uint8array"`; write `src[j]` unmasked otherwise.
+
+### #1830 — well-known-symbol range off-by-one excludes `Symbol.matchAll` (med)
+`src/runtime.ts:3102`/`:3188`/`:5222`. `_symbolIdToKeys` maps IDs 1-15 (15 = `@@matchAll`),
+but `_safeGet`/`_safeSet`/`__extern_has` gate on `<= 14`. `struct[Symbol.matchAll]`
+get/set/`in` falls through to numeric access and misses the symbol-keyed property. The
+comment still says "1-12". Fix: bound on `<= 15` (or derive from `_symbolIdToKeys.size`).
+
+### #1831 — `_validatePropertyDescriptor` resets omitted attributes on redefine (med) — residual of #1334 (done, s50)
+`src/runtime.ts:1262-1272`. `newFlags` is built from truthiness of each attribute, so an
+omitted attribute contributes `0`; when `existing` is configurable it returns `newFlags`
+directly, clearing previously-set `writable`/`enumerable`/`configurable`. §10.1.6.3 keeps
+absent fields. `Object.defineProperty(o,"k",{value:5})` after `o.k` was enumerable/writable
+clears those flags. Fix: start from `existing` and only overwrite explicitly-present fields.
+
+### #1832 — `compileNewFunctionExpression` captures outer var shadowed by a destructured param (med)
+`src/codegen/expressions/new-super.ts:1084`. `isOwnParam` only matches identifier params,
+so `function({a}){…a…}` doesn't recognize `a` as own; an outer `a` is captured and shadows
+the param. Fix: use `collectBindingPatternNames`/`isOwnParamName` (already exported).
+
+### #1833 — implicit subclass forwarder truncates multi-arg `super(...)` (med)
+`src/codegen/class-bodies.ts:1103-1131`. For `class Sub extends DataView {}` the synthetic
+forwarder declares one externref `__arg0` and forwards only the first arg, so
+`new Sub(buf,0,16)` drops `0` and `16`. Implicit derived constructors must forward all
+args. (Noted as deferred #1366c, which has no file.) Fix: forward the full arg list.
+
+### #1834 — vec element-write index uses trapping `i32.trunc_f64_s` (med)
+`src/codegen/expressions/assignment.ts:1805` (and `:2305` for `arr.length = N`). Converts
+the destructuring element-access index with the trapping op; every other index/length
+conversion uses `i32.trunc_sat_f64_s` (`:3012,:3685,:4170,:5538`). A NaN/non-integer index
+traps the module. Fix: use the saturating op.
+
+---
+
+## 2. Standalone / WASI bugs (supported targets)
+
+### #1835 — C-ABI string/array marshaling reads the wrong header offsets (high)
+`src/codegen-linear/c-abi.ts:269-273` computes return data ptr = `ptr+4` and length at
+`offset 0`, but the verified linear layout is `[header 8B][len:u32 @ +8][bytes @ +12]`
+(`src/codegen-linear/runtime.ts:505`) → should be `offset 8` and `ptr+12`. Param marshaling
+(`:231`) has the mirror problem (forwards a raw `(ptr,len)` where the callee expects a
+header object). The C ABI is effectively non-functional for string/array I/O. **Verified.**
+
+### #1836 — standalone Number↔String conformance gaps (high) — residual of #1335 (done, s58)
+All in the no-JS-host (standalone/WASI) path; JS-host is correct.
+- `Number("0o17")`/`Number("0b101")` → `NaN` — only the hex prefix is handled
+  (`src/codegen/parse-number-native.ts:949`). §7.1.4.1.
+- `(1e21).toFixed(2)` emits a bogus 22-digit integer — no `≥1e21 → ToString` branch
+  (`src/codegen/number-format-native.ts:894`). §21.1.3.3.
+- `(1e-7).toString()`→`"0"`, `(1e21).toString()` lacks `e` — no exponential path
+  (`number-format-native.ts:470`). §6.1.6.1.20.
+- `(3.5).toString(2)` **traps** (`unreachable`) — fractional radix unimplemented (`:713`).
+- `parseInt`/`parseFloat`/`Number` whitespace set misses BOM, U+2028/2029, most Zs
+  (`parse-number-native.ts:61`).
+- `+"12abc"` → `12` instead of `NaN` — ToNumber(String) falls back to `parseFloat`
+  (`src/codegen/type-coercion.ts:1748`).
+
+### #1837 — standalone enumeration order is hash-bucket order (med)
+`src/codegen/object-runtime.ts:1097`. `Object.keys`/`values`/`entries`/for-in/spread/
+`JSON.stringify` in standalone violate §10.1.11 (integer keys ascending, then insertion).
+JS-host mode delegates to native and is correct. Fix: emit integer keys sorted ascending,
+then string keys in insertion order (needs an insertion-sequence field).
+
+### #1838 — linear backend silently miscompiles `try/catch` (med)
+`src/codegen-linear/index.ts:669`. The catch clause is discarded and `throw` →
+`unreachable`, so `try{throw}catch{}` traps instead of recovering, with no diagnostic.
+Fix: emit EH `try`/`catch`, or raise a compile error in standalone mode.
+
+### #1839 — late string-import index shift omits init body / helpers / start func (med)
+`src/codegen/index.ts:6138`. `addStringImports` hand-rolls the func-index shift and misses
+`pendingInitBody`, `nativeStrHelpers`, and `startFuncIdx` that the canonical
+`shiftLateImportIndices` covers. If the first string use is inside a function body (not
+module-init), `__module_init` can call the wrong funcs; also bites plain `--nativeStrings`
+in host mode. Fix: call `shiftLateImportIndices` (single source of truth).
+
+---
+
+## 3. Latent bugs (paths not currently wired) — backlog
+
+### #1840 — linker `writeLEB128` truncates growing indices; `call_indirect`/`memory` rewrite gaps (low)
+`src/link/linker.ts:514/533/552`. Relocations rewritten into the original byte width; a
+1-byte index resolving to ≥128 loses its high bits. Also `call_indirect` table index isn't
+symbol-resolved, and `memory.size/grow` immediate is overwritten as a single raw byte.
+Real linkers pad reloc immediates to 5 bytes. Latent: the `.o` linker isn't in the
+production compile path.
+
+### #1841 — element-section flag bitfield only handles active flag-0 (low)
+`src/link/reader.ts:471` mis-parses passive(1)/declarative(3) segments (consumes a bogus
+tableidx, always scans for an offset-expr); `src/link/linker.ts:401` re-emits everything as
+active flag 0x00. WebAssembly binary §element. Latent (only active flag-0 is fed today).
+
+### #1842 — `none` heap-type constant collides with `any` (low)
+`src/emit/opcodes.ts:444` `none: 0x6e` equals `:439` `any: 0x6e` (spec `none=0x71`).
+`noextern`/`nofunc` are also missing. `TYPE.none` isn't emitted today, so latent — but a
+landmine. **Verified.**
+
+### #1843 — `R_WASM_TAG_INDEX_LEB` emitter/reader mismatch (low)
+`src/emit/opcodes.ts:480` = `11` vs `src/link/reader.ts:136` = `10` (LLVM canonical `10`).
+Tag-index relocations can't round-trip. **Verified.** Fix: align both on `10`.
+
+### #1844 — IR `verify` doesn't recurse into nested if/try/loop buffers (low) — residual of #1798 (done, s58)
+`src/ir/verify.ts:393` (`operandIrType`) and `:141` (`verifyBlock`/`collectUses`) only scan
+top-level block instrs, not nested `then`/`else`/`try`/`forof`/loop body buffers — while
+`registerInstrDefs` in lower.ts does. So the #1798 return-type gate and SSA checks have a
+hole exactly where control flow nests; a mismatch inside an `if` arm slips past the verifier
+to instantiate-time (or a hard lower throw instead of a clean legacy fallback). Defense-in-depth.
+
+### #1845 — IR propagate minor: `&&`/`||` over-claim `BOOL`; `seedConcrete` omits i32/u32 (low)
+`src/ir/propagate.ts:615` infers `BOOL` for `a && b`/`a || b` when operands are
+`boolCompatible` incl. optimistic `unknown`, but the result is the operand value, not a
+boolean — can seed a non-boolean as `bool`. `:315` `seedConcrete` omits i32/u32 (currently
+inert, latent once integer seeding is added).
+
+### #1846 — minor `typeof` notes (low)
+`staticTypeofForWasmType` maps i64→"number" (`src/codegen/typeof-delete.ts:831`), reachable
+only via `with`-bindings (near-nil impact); the externref branch can return `null` for some
+non-undefined object operands (`:684`, low confidence). §13.5.3.
+
+### #1847 — for-of tentative rollback doesn't restore `fctx.localMap` (low)
+`src/codegen/statements/loops.ts:2590` (and siblings). Rollbacks truncate `fctx.locals`/
+`fctx.body` but not `fctx.localMap` (which `allocLocal` mutates), leaving stale entries
+pointing past the truncated vector. Practical risk is low (temp names are keyed off
+`locals.length`), but it's unbalanced state. Fix: snapshot/restore `localMap` + `tempFreeList`.
+
+---
+
+## 4. Redundancies / dead code — backlog
+
+### #1848 — dead-code sweep
+Verified one-liners and dead scaffolding:
+- `src/codegen/type-coercion.ts:1065` — `from.kind==="ref_null" ? {anyref} : {anyref}`, both arms identical. **Verified.**
+- `src/emit/binary.ts:440-444` — `if (...) {...} else {...}` both call the same `encodeTypeDef`. **Verified.**
+- `src/codegen/stack-balance.ts:687` — `const fixups = 0` never reassigned; final `return fixups` always 0.
+- `src/ir/from-ast.ts:793` — `const writes = new Set()` created then discarded.
+- `src/codegen-linear/c-abi.ts:262-263` — `body.splice(body.length,0)` no-op + unused `callIdx`; plus dead `exportReplacements`/`mangleCabiName` (`:177`), and the `externalImports` placeholder in `linker.ts:225`.
+- `src/codegen/expressions/unary-updates.ts:718` — `const isIncrement = false` constant-folds dead ternary arms in the `--` path.
+- `src/compiler/validation.ts:448` — `const opStart` assigned, never read.
+- `src/codegen/binary-ops.ts:2552` — `compileModulo` ignores both params.
+- `src/codegen/type-coercion.ts:73,988` — deprecated `CompileStringLiteralFn` param of `coerceType` is unused.
+- `src/codegen/statements/loops.ts:2398` — obsolete `__str_charAt` name-rescan (the comment's premise is no longer true since #1677); plus dead default-separator `else` in native `split` (`src/codegen/string-ops.ts:1994`).
+- `src/emit/binary.ts` `encodeTypeDef` sub-branch dup; `src/link/linker.ts:417` unused `funcCounter`.
+
+### #1849 — duplicate-logic refactor (diverged copy-paste — bug-magnets)
+- `compileSuperElementMethodCall` ≈ `compileSuperMethodCall` (`new-super.ts:322` vs `:202`); fallbacks already differ.
+- Two closure-iterable drainers with different loop caps/field resolution (`runtime.ts:1626` vs `:1720`).
+- `resolveVec` duplicated verbatim (`ir/integration.ts:864` & `:985`).
+- `__extern_has` `in`-operator block emitted twice (`binary-ops.ts:648` & `:730`).
+- ~7× copy-pasted "emit typed default value" block in the super-access helpers (`new-super.ts`); `defaultValueInstrs`/`pushDefaultValue` already exist.
+- `operandValType`/`operandIrType` carry an unused `localDefs` param (`ir/verify.ts:393`).
+
+---
+
+## What was checked and is correct
+
+Recorded so these aren't re-litigated: ToInt32/ToUint32 modulo-2³² + sign; shift-count
+masking; `Number::remainder` edge cases (`-0`, `x%Infinity`); `**` special cases; `+`
+ToPrimitive "default" hint; SameValue/SameValueZero `-0`/NaN; strict-eq via `f64.eq`;
+`includes` SameValueZero vs `indexOf` strict-eq; `reduce` empty-no-init TypeError;
+LEB128 minimal encoding, memarg log2 alignment, section ordering, struct/array/rec/sub
+GC encodings; `__malloc` alignment; `fromCharCode` ToUint16; call-site RangeError
+validation for `toFixed`/`toExponential`/`toPrecision`/`toString` radix; native parseInt
+0x-prefix/radix-clamp; `__str_to_number` full-match requirement.

--- a/plan/issues/1815-array-splice-drops-inserted-items.md
+++ b/plan/issues/1815-array-splice-drops-inserted-items.md
@@ -1,0 +1,36 @@
+---
+id: 1815
+title: "Array.prototype.splice drops inserted items (3+ args ignored)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1815 — `Array.prototype.splice` drops inserted items
+
+## Symptom
+`[1,2,3].splice(1,1,'a','b')` returns/leaves `[1,3]` instead of `[1,'a','b',3]`.
+Inserted elements vanish.
+
+## Location
+`src/codegen/array-methods.ts:4421` (`compileArraySplice`) reads only `start`
+(arg 0) and `deleteCount` (arg 1); never reads `arguments[2..]`. Dispatch at
+`:2574` calls it unconditionally with no bail for 3+ args.
+
+## Spec
+ECMAScript §23.1.3.30 — insertion is core to splice.
+
+## Fix
+When `arguments.length > 2`, grow the backing array by `(items - delCount)`,
+shift the tail, and write the item values at `start`. `toSpliced` already
+implements this correctly (`:2899`) — reuse that shape. Or bail to host for the
+insertion case as an interim.
+
+## Acceptance
+`[1,2,3].splice(1,1,'a','b')` → array becomes `[1,'a','b',3]`, returns `[2]`.
+

--- a/plan/issues/1816-array-sort-comparator-ignored-default-numeric.md
+++ b/plan/issues/1816-array-sort-comparator-ignored-default-numeric.md
@@ -1,0 +1,36 @@
+---
+id: 1816
+title: "Array.prototype.sort ignores user comparator; default sort numeric not lexicographic (residual #1361)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+parent: 1361
+---
+# #1816 — `Array.prototype.sort` ignores comparator + wrong default order
+
+Residual of #1361 (marked done, sprint 51): the comparator is still ignored.
+
+## Symptom
+- `[3,1,2].sort((a,b)=>b-a)` → `[1,2,3]` (comparator dropped).
+- `[10,9,1].sort()` → `[1,9,10]` instead of `[1,10,9]` (default must ToString-compare).
+
+## Location
+`src/codegen/array-methods.ts:5781-5816` validates a statically-non-callable
+comparator (throws) but otherwise calls `ensureTimsortHelper`
+(`src/codegen/timsort.ts`), which takes no comparator and hard-codes
+`i32.lt_s`/`f64.lt`. The only test asserts "doesn't throw," masking it.
+
+## Spec
+ECMAScript §23.1.3.30 / SortIndexedProperties / CompareArrayElements.
+
+## Fix
+Thread the comparator funcref/closure into the sort and invoke via `call_ref`;
+in the no-arg case compare by ToString (UTF-16 code units). Add a test that
+asserts the resulting order, not just no-throw.
+

--- a/plan/issues/1817-ushr-i32-fast-path-signed-result.md
+++ b/plan/issues/1817-ushr-i32-fast-path-signed-result.md
@@ -1,0 +1,32 @@
+---
+id: 1817
+title: ">>> in i32 fast path produces a signed result (negative for high-bit values)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1817 — `>>>` i32 fast path produces a signed result
+
+## Symptom
+`(x >>> 0)` where `x` has the high bit set yields a *negative* float instead of
+the correct large unsigned value (0..2^32-1).
+
+## Location
+`src/codegen/binary-ops.ts:1318`/`:1334`. `isI32PureExpr` accepts `>>>` as
+i32-pure; the i32 result is later widened with `f64.convert_i32_s`
+(type-coercion.ts:1330). The non-fast path (`compileBitwiseBinaryOp`, `:2548`)
+correctly uses `f64.convert_i32_u`.
+
+## Spec
+ToUint32 — `>>>` result is unsigned.
+
+## Fix
+Exclude `GreaterThanGreaterThanGreaterThanToken` from the i32-pure fast path, or
+emit `f64.convert_i32_u` when the consumer wants f64.
+

--- a/plan/issues/1818-i32-bool-default-param-fires-on-zero-false.md
+++ b/plan/issues/1818-i32-bool-default-param-fires-on-zero-false.md
@@ -1,0 +1,32 @@
+---
+id: 1818
+title: "i32/boolean parameter default fires on a legitimate 0 / false argument"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1818 — i32/boolean parameter default fires on `0` / `false`
+
+## Symptom
+- `function f(b=true){return b}; f(false)` → `true`.
+- `function f(n:number=5){return n}; f(0)` (n narrowed to i32) → `5`.
+
+## Location
+`src/codegen/closures.ts:767-770` and `src/codegen/class-bodies.ts:1076-1083`
+use `i32.eqz` as the "argument missing" sentinel; booleans resolve to i32
+(`type-mapper.ts:55`). The f64 path correctly uses a NaN self-test, and the
+array/object-pattern paths already *skip* the check for i32 (closures.ts:714).
+
+## Spec
+Default applies only when the argument is `undefined`.
+
+## Fix
+Don't emit a default check for plain i32/boolean params; thread an explicit
+arg-present flag instead of reusing `0` as the missing sentinel.
+

--- a/plan/issues/1819-logical-assignment-global-index-offset.md
+++ b/plan/issues/1819-logical-assignment-global-index-offset.md
@@ -1,0 +1,29 @@
+---
+id: 1819
+title: "Logical assignment (??= ||= &&=) reads globals at wrong (un-offset) index"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1819 — logical-assignment reads globals at the wrong index
+
+## Symptom
+With import globals present (string pool etc.), `g ??= x` / `g ||= x` / `g &&= x`
+on a captured/module ref-typed global mis-evaluates (skips the null/undefined
+branch because `varType` wrongly falls back to f64).
+
+## Location
+`src/codegen/expressions/assignment.ts:3159` and `:3170` use the raw absolute
+index `ctx.mod.globals[capturedIdx]` / `[moduleIdx]`. Every other access in the
+file wraps with `localGlobalIdx(ctx, …)` (lines 260/276/590/2198/2236/2594/4536/
+4568). `localGlobalIdx` subtracts `numImportGlobals`. **Verified by hand.**
+
+## Fix
+`ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)]` and likewise for `moduleIdx`.
+

--- a/plan/issues/1820-ir-short-circuit-evaluates-both-operands.md
+++ b/plan/issues/1820-ir-short-circuit-evaluates-both-operands.md
@@ -1,0 +1,34 @@
+---
+id: 1820
+title: "IR path: && || and ternary evaluate both operands (lost short-circuit + non-termination)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: ir
+goal: correctness
+sprint: 59
+---
+# #1820 — IR `&&`/`||`/ternary evaluate both operands
+
+## Symptom
+- `cond ? f() : g()` calls **both** `f()` and `g()`.
+- `function fact(n){return n<=1 ? 1 : n*fact(n-1)}` recurses at the base case → non-termination.
+- `p !== null && p.use()` runs the right side even when the guard is false.
+
+## Location
+`src/ir/from-ast.ts:3464` lowers ternary to `emitSelect` (Wasm `select`, eager);
+`:3676` lowers `&&`/`||` to `i32.and`/`i32.or`. The selector (`src/ir/select.ts`)
+admits `CallExpression` arms. `safeSelection` (codegen/index.ts:1225) only filters
+on type-resolvability, not effect-safety.
+
+Related Wasm-validity facet: a ref-typed ternary would emit untyped `select`
+(0x1B), invalid for reference operands (needs typed `0x1C`) — `src/emit/binary.ts:704`.
+
+## Fix
+Only `select`/`i32.and`/`i32.or` when both arms are provably side-effect-free
+(and numeric); otherwise lower to the short-circuiting `IrInstrIf` (exists) or
+throw to fall back to legacy.
+

--- a/plan/issues/1821-delete-always-true-and-element-skips-sidecar.md
+++ b/plan/issues/1821-delete-always-true-and-element-skips-sidecar.md
@@ -1,0 +1,33 @@
+---
+id: 1821
+title: "delete obj.prop always returns true; delete obj['k'] skips __delete_property sidecar"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1821 — `delete` struct fast-path defects
+
+## Symptom
+- `delete obj.nonConfigurable` returns `true` (spec: `false`, strict throw).
+- `delete obj["x"]` and `delete obj.x` diverge: only the property-access form
+  removes the `Object.defineProperty` descriptor, so `hasOwnProperty("x")` differs.
+
+## Location
+`src/codegen/typeof-delete.ts:127-185` drops `__delete_property`'s result and
+pushes `i32.const 1`. `:192-214` (element-access arm) omits the `__delete_property`
+sidecar that the property-access arm performs (added #1334). The general path
+(`:216-291`) correctly returns the helper result.
+
+## Spec
+ECMAScript §13.5.1.
+
+## Fix
+Return the `__delete_property` result for struct fields; mirror the sidecar in the
+element-access arm.
+

--- a/plan/issues/1822-string-replace-ignores-dollar-substitution.md
+++ b/plan/issues/1822-string-replace-ignores-dollar-substitution.md
@@ -1,0 +1,31 @@
+---
+id: 1822
+title: "String#replace/replaceAll ignore $ substitution patterns ($$, $&, $`, $')"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1822 — `String#replace`/`replaceAll` don't expand `$` patterns
+
+## Symptom
+- `"abc".replace("b","$&$&")` → `"a$&$&c"` instead of `"abbc"`.
+- `"a-b".replace("-","$$")` → `"a$$b"` instead of `"a$b"`.
+- `"ab".replaceAll("","-")` → `"ab"` instead of `"-a-b-"` (empty-search interleaving).
+
+## Location
+`src/codegen/native-strings.ts:3217` (`__str_replace`) and `:3294`
+(`__str_replaceAll`) concat the replacement verbatim.
+
+## Spec
+ECMAScript §22.1.3.19 GetSubstitution.
+
+## Fix
+Scan the replacement for `$` and expand `$$`/`$&`/`` $` ``/`$'` against the match;
+special-case empty-search interleaving in replaceAll.
+

--- a/plan/issues/1823-string-normalize-arg-before-receiver.md
+++ b/plan/issues/1823-string-normalize-arg-before-receiver.md
@@ -1,0 +1,29 @@
+---
+id: 1823
+title: "String#normalize(form) evaluates argument before receiver (wrong eval order)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1823 — `String#normalize(form)` evaluates arg before receiver
+
+## Symptom
+For `s.normalize(form)` with side-effecting `s` and `form`, observable order is
+reversed (arg evaluated before receiver).
+
+## Location
+`src/codegen/string-ops.ts:2110-2134`: for a non-literal form it compiles+drops
+the argument (`:2129`) then compiles the receiver (`:2134`).
+
+## Spec
+ECMAScript §13.3.6 / §22.1.3.13 — receiver first, then argument.
+
+## Fix
+Compile the receiver into a temp first, then compile/validate/drop the form argument.
+

--- a/plan/issues/1824-super-as-value-wrong-static-type.md
+++ b/plan/issues/1824-super-as-value-wrong-static-type.md
@@ -1,0 +1,29 @@
+---
+id: 1824
+title: "super used as a value returns the wrong static ValType (local indexing bug)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1824 — `super` used as a value returns the wrong static type
+
+## Symptom
+A bare `super` used as a value emits the correct `local.get` but reports the type
+of an unrelated local (or undefined → externref), which can mis-drive downstream
+coercion.
+
+## Location
+`src/codegen/expressions.ts:1249`: `const selfType = fctx.locals[selfIdx]` where
+`selfIdx = localMap.get("this")`. The correct convention (ThisKeyword branch at
+`:861-865`) is `fctx.params[selfIdx]` when `selfIdx < fctx.params.length`. `this`
+is param 0, so `fctx.locals[0]` is a non-param local.
+
+## Fix
+Mirror the ThisKeyword indexing (params array for param indices).
+

--- a/plan/issues/1825-i32-fast-mode-modulo-traps.md
+++ b/plan/issues/1825-i32-fast-mode-modulo-traps.md
@@ -1,0 +1,31 @@
+---
+id: 1825
+title: "i32 fast-mode % emits trapping i32.rem_s (x % 0 traps instead of NaN)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: compilable
+sprint: 59
+---
+# #1825 — i32 fast-mode `%` emits trapping `i32.rem_s`
+
+## Symptom
+In fast / native-i32 mode, `a % b` with `b == 0` traps (Wasm), and
+`-2147483648 % -1` traps. JS yields `NaN` and `0` respectively.
+
+## Location
+`src/codegen/binary-ops.ts:2337-2339` (`compileI32BinaryOp` PercentToken →
+`i32.rem_s`), reachable via the i32 fast-path dispatch (`isDivOrPow` excludes `/`
+and `**` but **not** `%`).
+
+## Spec
+ECMAScript §6.1.6.1.6 Number::remainder (d=0 ⇒ NaN; no overflow concept).
+
+## Fix
+Exclude `%` from the i32 fast path (route to `emitModulo`), or guard the i32 path
+with `b==0` and `INT_MIN/-1` checks.
+

--- a/plan/issues/1826-toprimitive-valueof-undefined-treated-absent.md
+++ b/plan/issues/1826-toprimitive-valueof-undefined-treated-absent.md
@@ -1,0 +1,32 @@
+---
+id: 1826
+title: "OrdinaryToPrimitive treats valueOf/toString returning undefined as method-absent"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: runtime
+goal: correctness
+sprint: 59
+---
+# #1826 — `valueOf` returning `undefined` is treated as "absent"
+
+## Symptom
+`({valueOf(){return undefined}, toString(){return "x"}}) + ""` → `"x"` instead of
+`"undefined"` — a method legitimately returning the primitive `undefined` is
+skipped and the next method is consulted.
+
+## Location
+`src/runtime.ts:1943-2036`: `tryMethod` returns JS `undefined` both for
+"absent / returned an object" and a real `undefined` primitive; the caller
+(`:2026-2036`) treats `undefined` as "try the next method."
+
+## Spec
+ECMAScript §7.1.1.1 OrdinaryToPrimitive steps 5-6 (any non-Object return is the result).
+
+## Fix
+Use a distinct sentinel (unique symbol) for "absent / returned object" so a real
+`undefined` primitive return is honored.
+

--- a/plan/issues/1827-bigint-loose-equality-precision.md
+++ b/plan/issues/1827-bigint-loose-equality-precision.md
@@ -1,0 +1,32 @@
+---
+id: 1827
+title: "BigInt loose-equality loses precision / wrong semantics (== String, == Number)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1827 — BigInt loose-equality precision / semantics
+
+## Symptom
+- `12n == "12px"` → `true` (spec `false` — StringToBigInt rejects trailing garbage).
+- `9007199254740993n == 9007199254740992` → `true` (spec `false` — distinct ℝ values).
+
+## Location
+`src/codegen/binary-ops.ts:976-1034`. BigInt×String uses `parseFloat` on the
+string + `f64.convert_i64_s` on the BigInt; BigInt×Number collapses both to f64
+and uses `f64.eq`.
+
+## Spec
+ECMAScript §7.2.13 IsLooselyEqual — BigInt×String via StringToBigInt; BigInt×Number
+by exact mathematical-value equality.
+
+## Fix
+Route BigInt×String through a StringToBigInt-based helper; compare BigInt×Number by
+exact value (i64.eq when the Number is integral and in i64 range, else exact/host).
+

--- a/plan/issues/1828-array-like-find-map-hole-handling.md
+++ b/plan/issues/1828-array-like-find-map-hole-handling.md
@@ -1,0 +1,33 @@
+---
+id: 1828
+title: "Array-like find/findIndex skip holes; map compacts holes (sparse .call receivers)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1828 — array-like find/findIndex/map hole handling
+
+## Symptom
+With an array-like `.call` receiver `{length:3, 0:1, 2:3}` (index 1 a hole):
+- `Array.prototype.findIndex.call(o, x=>x===undefined)` → `-1` (spec `1`).
+- `Array.prototype.map.call(o, x=>x*2).length` → `2` (spec `3`, holes preserved).
+
+## Location
+`src/codegen/array-methods.ts:824-895` wraps find/findIndex bodies in `gatedBody`
+(HasProperty) — but spec visits holes as `undefined`. `:937-987` map builds the
+result via `__js_array_push`, compacting holes and shifting indices.
+
+## Spec
+ECMAScript §23.1.3.9/.10 (find/findIndex visit every index), §23.1.3.20 (map
+preserves length / holes). Dense arrays are unaffected.
+
+## Fix
+Drop `gatedBody` for find/findIndex; write mapped values by index into a length-`len`
+result (leave holes) instead of push.
+

--- a/plan/issues/1829-marshal-typedarray-byte-mask.md
+++ b/plan/issues/1829-marshal-typedarray-byte-mask.md
@@ -1,0 +1,30 @@
+---
+id: 1829
+title: "marshalTypedArrayArgs byte-masks every element, corrupting non-Uint8Array typed arrays"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: low
+task_type: bugfix
+area: runtime
+goal: correctness
+sprint: 59
+---
+# #1829 — typed-array argument marshaling truncates to bytes
+
+## Symptom
+Passing an `Int16Array`/`Int32Array`/`Float32Array`/`Float64Array` to a compiled
+export silently corrupts every element (truncated to its low byte), producing
+wrong results, not an error.
+
+## Location
+`src/runtime.ts:9855-9876`: the loop accepts both `kind==="uint8array"` and
+`kind==="typed-array"`, then writes `vecSetByte(vec, j, src[j]! & 0xff)` (`:9874`).
+The `& 0xff` is only correct for `Uint8Array`. The vec backing store is f64, so
+full precision would otherwise round-trip.
+
+## Fix
+Apply `& 0xff` only when `kind==="uint8array"`; for `"typed-array"` write `src[j]`
+unmasked via the vec setter.
+

--- a/plan/issues/1830-wellknown-symbol-range-excludes-matchall.md
+++ b/plan/issues/1830-wellknown-symbol-range-excludes-matchall.md
@@ -1,0 +1,27 @@
+---
+id: 1830
+title: "Well-known-symbol range guard off-by-one excludes Symbol.matchAll (ID 15)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: runtime
+goal: correctness
+sprint: 59
+---
+# #1830 — `Symbol.matchAll` never routed on WasmGC structs
+
+## Symptom
+`struct[Symbol.matchAll]` get/set/`in` falls through to numeric-index access and
+misses the symbol-keyed property.
+
+## Location
+`_symbolIdToKeys` (`src/runtime.ts:3035-3051`) maps IDs 1-15 (15 = `@@matchAll`),
+but `_safeGet` (`:3102`), `_safeSet` (`:3188`), and `__extern_has` (`:5222`) gate
+on `key >= 1 && key <= 14`. The `_safeGet` comment still says "1-12".
+
+## Fix
+Change all three bounds to `<= 15` (or derive from `_symbolIdToKeys.size`).
+

--- a/plan/issues/1831-validate-property-descriptor-resets-omitted.md
+++ b/plan/issues/1831-validate-property-descriptor-resets-omitted.md
@@ -1,0 +1,35 @@
+---
+id: 1831
+title: "_validatePropertyDescriptor resets omitted attributes to false on redefine (residual #1334)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: runtime
+goal: correctness
+sprint: 59
+parent: 1334
+---
+# #1831 — partial redefine clears previously-set descriptor flags
+
+Residual of #1334 (marked done, sprint 50).
+
+## Symptom
+After `o.k` is enumerable/writable, `Object.defineProperty(o,"k",{value:5})` clears
+`enumerable`/`writable`/`configurable` instead of preserving the absent fields.
+
+## Location
+`src/runtime.ts:1262-1272`: `newFlags` built from truthiness of each
+`desc.writable/enumerable/configurable` (omitted ⇒ 0); when `existing` is
+configurable, `:1272` returns `newFlags` directly.
+
+## Spec
+ECMAScript §10.1.6.3 ValidateAndApplyPropertyDescriptor — absent fields are kept.
+Scope: the WasmGC-struct sidecar fallback.
+
+## Fix
+When `existing !== undefined`, start from `existing` and only overwrite flags whose
+descriptor field is explicitly present (`desc.writable !== undefined`, etc.).
+

--- a/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
+++ b/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
@@ -1,0 +1,28 @@
+---
+id: 1832
+title: "compileNewFunctionExpression captures outer var shadowed by a destructured param"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1832 — destructured param shadowing fails in new-function-expression
+
+## Symptom
+`function({a}){ return a }` where an outer scope also has `a`: the body reads the
+captured outer `a` instead of the param bound by destructuring.
+
+## Location
+`src/codegen/expressions/new-super.ts:1084`: `isOwnParam` is
+`parameters.some(p => ts.isIdentifier(p.name) && p.name.text === name)` — binding
+patterns never match, so the name is added to `captures`.
+
+## Fix
+Use `collectBindingPatternNames`/`isOwnParamName` (already exported from
+closures.ts) instead of the identifier-only check.
+

--- a/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
+++ b/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
@@ -1,0 +1,31 @@
+---
+id: 1833
+title: "Implicit subclass constructor forwarder truncates multi-arg super(...)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1833 — implicit derived constructor forwards only the first arg
+
+## Symptom
+`class Sub extends DataView {}; new Sub(buf, 0, 16)` constructs the parent with
+only `buf` — `0` and `16` are dropped.
+
+## Location
+`src/codegen/class-bodies.ts:1103-1131` (pre-reg `:345-354`): the synthetic
+forwarder declares a single externref `__arg0` and forwards only the first
+argument to `__new_<Parent>`.
+
+## Spec
+An implicit derived constructor is `constructor(...args){ super(...args) }`.
+(Was deferred as #1366c, which has no file.)
+
+## Fix
+Forward the full argument list (rest/vec) to the parent constructor.
+

--- a/plan/issues/1834-vec-element-write-trapping-trunc.md
+++ b/plan/issues/1834-vec-element-write-trapping-trunc.md
@@ -1,0 +1,27 @@
+---
+id: 1834
+title: "Vec element-write/length index uses trapping i32.trunc_f64_s instead of saturating"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: compilable
+sprint: 59
+---
+# #1834 — element-write index uses trapping truncation
+
+## Symptom
+A NaN / non-integer / out-of-range index in destructuring element-assignment (or
+`arr.length = N`) traps the module instead of being clamped.
+
+## Location
+`src/codegen/expressions/assignment.ts:1805` (element-access index) and `:2305`
+(`arr.length = N`) use `i32.trunc_f64_s`. Every other index/length conversion in
+the file uses `i32.trunc_sat_f64_s` (`:3012,:3685,:4170,:5538`).
+
+## Fix
+Use `i32.trunc_sat_f64_s` to match the rest of the file.
+

--- a/plan/issues/1835-cabi-string-array-marshaling-wrong-offsets.md
+++ b/plan/issues/1835-cabi-string-array-marshaling-wrong-offsets.md
@@ -1,0 +1,32 @@
+---
+id: 1835
+title: "C-ABI string/array marshaling reads wrong header offsets (param + return)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen-linear
+goal: correctness
+sprint: 59
+---
+# #1835 — C-ABI string/array marshaling uses wrong header layout
+
+## Symptom
+Any WASI/C export taking or returning `string`/`T[]` over the C ABI hands the host
+a wrong length and a pointer into the middle of the header → OOB reads / corrupted
+strings. The C ABI is effectively non-functional for string/array I/O.
+
+## Location
+`src/codegen-linear/c-abi.ts:269-273` computes return data ptr = `ptr+4` and loads
+length at `offset 0`. The verified linear layout (`src/codegen-linear/runtime.ts:505`)
+is `[header 8B][len:u32 @ +8][bytes @ +12]` → length is at `offset 8`, data at
+`ptr+12`. Param marshaling (`:231-246`) has the mirror problem — forwards a raw
+`(ptr,len)` where the internal function expects a header object. **Verified.**
+
+## Fix
+Return: load length at `offset 8`, data pointer offset `12`. Param: construct a
+runtime string/array object (e.g. `__str_from_data`) from `(ptr,len)` before calling
+the internal function. Also remove the dead scaffolding at `:262-263` (see #1848).
+

--- a/plan/issues/1836-standalone-number-string-conformance.md
+++ b/plan/issues/1836-standalone-number-string-conformance.md
@@ -1,0 +1,37 @@
+---
+id: 1836
+title: "Standalone Number<->String conformance gaps (0o/0b, toFixed 1e21, exponential, fractional radix, whitespace, ToNumber) (residual #1335)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+parent: 1335
+---
+# #1836 — standalone Number↔String conformance gaps
+
+Residual of #1335 (marked done, sprint 58). All in the no-JS-host (standalone/WASI)
+path; JS-host delegates to V8 and is correct.
+
+## Defects
+- `Number("0o17")`/`Number("0b101")` → `NaN` — only hex prefix handled
+  (`src/codegen/parse-number-native.ts:949`). §7.1.4.1.
+- `(1e21).toFixed(2)` emits a bogus 22-digit integer — no `≥1e21 → ToString` branch
+  (`src/codegen/number-format-native.ts:894`). §21.1.3.3.
+- `(1e-7).toString()`→`"0"`, `(1e21).toString()` lacks `e` — no exponential path
+  (`number-format-native.ts:470`). §6.1.6.1.20.
+- `(3.5).toString(2)` **traps** (`unreachable`) — fractional radix unimplemented (`:713`).
+- `parseInt`/`parseFloat`/`Number` whitespace set misses U+FEFF, U+2028/2029, most Zs
+  (`parse-number-native.ts:61`). §19.2.4/.5.
+- `+"12abc"` → `12` instead of `NaN` — ToNumber(String) falls back to `parseFloat`
+  (`src/codegen/type-coercion.ts:1748`).
+
+## Fix
+Add octal/binary prefix arms; add the 1e21 / exponential branches; emit fractional
+radix digits; extend the whitespace predicate; emit a spec StringToNumber routine as
+the standalone ToNumber fallback (not parseFloat).
+

--- a/plan/issues/1837-standalone-enumeration-order-hash-bucket.md
+++ b/plan/issues/1837-standalone-enumeration-order-hash-bucket.md
@@ -1,0 +1,32 @@
+---
+id: 1837
+title: "Standalone Object.keys/for-in/JSON enumeration is hash-bucket order, not spec order"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1837 — standalone enumeration order violates spec
+
+## Symptom
+Standalone-mode `Object.keys`/`values`/`entries`/for-in/spread/`JSON.stringify`
+emit keys in hash-bucket order. `o.b=1;o.a=2;o["2"]=3;o["1"]=4; Object.keys(o)`
+should be `["1","2","b","a"]`. JS-host mode is correct.
+
+## Location
+`src/codegen/object-runtime.ts:1097-1202` (`__object_keys`) walks open-hash slots
+`0..cap` and pushes in bucket order (comment admits "hash order").
+
+## Spec
+ECMAScript §10.1.11.1 OrdinaryOwnPropertyKeys — integer-index keys ascending, then
+string keys in insertion order, then symbols.
+
+## Fix
+Track an insertion sequence in the prop entry; emit integer keys sorted ascending
+first, then remaining string keys in insertion order.
+

--- a/plan/issues/1838-linear-backend-trycatch-miscompile.md
+++ b/plan/issues/1838-linear-backend-trycatch-miscompile.md
@@ -1,0 +1,29 @@
+---
+id: 1838
+title: "Linear backend silently miscompiles try/catch (throw -> unreachable, catch dropped)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen-linear
+goal: correctness
+sprint: 59
+---
+# #1838 — linear backend drops `try/catch`
+
+## Symptom
+In the linear/standalone backend, `try { throw e } catch (e) { handler }` traps
+(via `unreachable`) instead of running the handler — silent divergence from JS, no
+diagnostic.
+
+## Location
+`src/codegen-linear/index.ts:669-676` inlines the try body and discards the catch
+clause; `:682-685` lowers `throw` to `unreachable`. The emitter supports EH
+`try`/`catch`/`throw` (`src/emit/binary.ts:1095-1120`).
+
+## Fix
+Emit the EH `try`/`catch` instructions, or raise a compile error for `try/catch` in
+standalone mode rather than silently miscompiling.
+

--- a/plan/issues/1839-add-string-imports-shift-omits-targets.md
+++ b/plan/issues/1839-add-string-imports-shift-omits-targets.md
@@ -1,0 +1,32 @@
+---
+id: 1839
+title: "addStringImports late-index shift omits pendingInitBody / nativeStrHelpers / startFuncIdx"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1839 — late string-import shift misses targets
+
+## Symptom
+When the first string usage occurs inside a function body (not module-init), the
+module-init body's `call`/`ref.func` indices are not bumped, so `__module_init`
+calls the wrong functions. Also bites plain `--nativeStrings` in JS-host mode
+(`nativeStrHelpers` left stale).
+
+## Location
+`src/codegen/index.ts:6138-6220` (`addStringImports`) hand-rolls the func-index
+shift but, unlike the canonical `shiftLateImportIndices`
+(`src/codegen/expressions/late-imports.ts:174-203`) and `addUnionImports`
+(`:7572-7602`), omits `ctx.pendingInitBody`, `ctx.nativeStrHelpers`, and
+`ctx.mod.startFuncIdx`.
+
+## Fix
+Replace the inline shift with a call to `shiftLateImportIndices` (single source of
+truth), or add the three missing shift targets.
+

--- a/plan/issues/1840-linker-leb-truncation-and-rewrite-gaps.md
+++ b/plan/issues/1840-linker-leb-truncation-and-rewrite-gaps.md
@@ -1,0 +1,31 @@
+---
+id: 1840
+title: "Linker writeLEB128 truncates growing indices; call_indirect/memory rewrite gaps"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: medium
+task_type: bugfix
+area: link
+goal: correctness
+sprint: Backlog
+---
+# #1840 — linker relocation rewrite defects (latent)
+
+Latent: the `.o` linker is not in the production compile path today.
+
+## Defects
+- `src/link/linker.ts:514/533/552` rewrite relocations into the *original* byte
+  width; an index originally 1 byte (<128) that resolves to ≥128 is silently
+  truncated. Real linkers pad reloc immediates to 5 bytes.
+- `call_indirect` (0x11) table index is offset but never `resolveIndex`-resolved
+  (`:537`).
+- `memory.size`/`memory.grow` (0x3f/0x40) immediate is overwritten as a single raw
+  byte — wrong for offsets >127 and assumes 1-byte width.
+
+## Fix
+Emit relocatable `.o` immediates at fixed 5-byte width (or re-encode the body when a
+rewritten LEB grows); route the table index through `resolveIndex`; rewrite the
+memory immediate via read/writeLEB128.
+

--- a/plan/issues/1841-element-section-flag-bitfield.md
+++ b/plan/issues/1841-element-section-flag-bitfield.md
@@ -1,0 +1,31 @@
+---
+id: 1841
+title: "Element-section flag bitfield: parser/emitter only handle active flag-0 (passive/declarative corrupt)"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: medium
+task_type: bugfix
+area: link
+goal: correctness
+sprint: Backlog
+---
+# #1841 — element-section flags mis-handled (latent)
+
+Latent: only active flag-0 segments are fed to the linker today.
+
+## Defects
+- `src/link/reader.ts:471-501` (`parseElementSection`): `flags & 0x02` consumes a
+  bogus tableidx for declarative (0x03); always scans for an offset-expr (passive/
+  declarative have none) → desyncs the cursor.
+- `src/link/linker.ts:401` re-emits every segment as active flag 0x00, discarding
+  the original mode (declarative `ref.func` declarations become active table inits).
+
+## Spec
+WebAssembly binary — Element Section flag cases 0-7.
+
+## Fix
+Switch on the exact flag value per the spec table; carry the flag through
+`ElementEntry` and re-emit the original mode.
+

--- a/plan/issues/1842-none-heaptype-constant-collides-with-any.md
+++ b/plan/issues/1842-none-heaptype-constant-collides-with-any.md
@@ -1,0 +1,27 @@
+---
+id: 1842
+title: "none heap-type constant collides with any (0x6e); noextern/nofunc missing"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: bugfix
+area: emit
+goal: correctness
+sprint: Backlog
+---
+# #1842 — `none` heap-type constant is wrong (latent)
+
+## Defect
+`src/emit/opcodes.ts:444` defines `none: 0x6e`, the same byte as `any: 0x6e` (`:439`).
+Spec: `none = 0x71`, `noextern = 0x72`, `nofunc = 0x73`. `noextern`/`nofunc` are
+absent entirely. **Verified.** Latent — `TYPE.none` is not emitted today — but a
+landmine for any future bottom-type emission.
+
+## Spec
+WebAssembly GC binary/types — abstract heap-type encodings.
+
+## Fix
+`none: 0x71`; add `noextern: 0x72`, `nofunc: 0x73`.
+

--- a/plan/issues/1843-reloc-tag-index-leb-mismatch.md
+++ b/plan/issues/1843-reloc-tag-index-leb-mismatch.md
@@ -1,0 +1,24 @@
+---
+id: 1843
+title: "R_WASM_TAG_INDEX_LEB mismatch between emitter (11) and reader (10)"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: bugfix
+area: link
+goal: correctness
+sprint: Backlog
+---
+# #1843 — tag-index relocation type number disagrees (latent)
+
+## Defect
+`src/emit/opcodes.ts:480` defines `R_WASM_TAG_INDEX_LEB: 11`, but
+`src/link/reader.ts:136` defines it as `10` (LLVM canonical is `10`). A tag
+relocation written by the emitter (11) is parsed by the reader as unknown.
+**Verified.** Latent (linker path not in production).
+
+## Fix
+Align both on `10` — correct `opcodes.ts:480`.
+

--- a/plan/issues/1844-ir-verify-no-nested-buffer-recursion.md
+++ b/plan/issues/1844-ir-verify-no-nested-buffer-recursion.md
@@ -1,0 +1,32 @@
+---
+id: 1844
+title: "IR verify doesn't recurse into nested if/try/loop buffers (return-type gate + SSA holes) (residual #1798)"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: medium
+task_type: bugfix
+area: ir
+goal: correctness
+sprint: 59
+parent: 1798
+---
+# #1844 — IR verifier has a control-flow-nesting hole
+
+Defense-in-depth residual of #1798 (marked done, sprint 58).
+
+## Defect
+`src/ir/verify.ts:393-414` (`operandIrType`) and `:141-237`
+(`verifyBlock`/`collectUses`) scan only top-level `b.instrs`, never descending into
+nested `then`/`else`/`try`/`catch`/`finally`/`forof`/loop body buffers — while
+`registerInstrDefs` in lower.ts (`:347-376`) does. So the #1798 return-type
+assignability gate is bypassed for values defined inside those buffers
+(`actual===null` → `continue`), and SSA single-def/use-before-def invariants inside
+nested bodies are unchecked. A mismatch surfaces at instantiate-time (or a hard
+lower throw) instead of a clean legacy fallback.
+
+## Fix
+Make the verifier recurse into nested instr buffers (reuse the `registerInstrDefs`
+traversal).
+

--- a/plan/issues/1845-ir-propagate-bool-overclaim-seedconcrete.md
+++ b/plan/issues/1845-ir-propagate-bool-overclaim-seedconcrete.md
@@ -1,0 +1,27 @@
+---
+id: 1845
+title: "IR propagate: && / || over-claim BOOL; seedConcrete omits i32/u32"
+status: ready
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: bugfix
+area: ir
+goal: correctness
+sprint: 59
+---
+# #1845 — IR type-propagation minor unsoundness
+
+## Defects
+- `src/ir/propagate.ts:615-617`: `a && b` / `a || b` infer `BOOL` whenever operands
+  are `boolCompatible` (incl. optimistic `unknown`), but the result is the operand
+  value, not a boolean — can seed a non-boolean param/return as `bool`, then
+  `lowerBinary` emits `i32.and`/`i32.or` on it.
+- `:315-319`: `seedConcrete` is true only for f64/bool/string/object, not i32/u32 —
+  currently inert, latent once integer-domain seeding is added.
+
+## Fix
+Infer `BOOL` for `&&`/`||` only when both operands are concretely `bool` (treat
+`unknown` as dynamic / join); include i32/u32 in `seedConcrete` (or document why not).
+

--- a/plan/issues/1846-minor-typeof-conformance-notes.md
+++ b/plan/issues/1846-minor-typeof-conformance-notes.md
@@ -1,0 +1,28 @@
+---
+id: 1846
+title: "Minor typeof conformance: i64->'number' in with-bindings; externref->null fallthrough"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: Backlog
+---
+# #1846 — minor `typeof` conformance notes
+
+## Defects
+- `src/codegen/typeof-delete.ts:831` (`staticTypeofForWasmType`) maps i64 → "number"
+  instead of "bigint" — reachable only via `with`-bindings, near-nil impact.
+- `:684-690` the externref branch can `return null` for some non-undefined object
+  operands (low confidence; verify against union operands).
+
+## Spec
+ECMAScript §13.5.3 typeof table.
+
+## Fix
+Add `if (kind==="i64") return "bigint"` before the f64 case; ensure the externref
+branch returns "object" (or routes to runtime) for known non-undefined objects.
+

--- a/plan/issues/1847-forof-rollback-localmap-not-restored.md
+++ b/plan/issues/1847-forof-rollback-localmap-not-restored.md
@@ -1,0 +1,27 @@
+---
+id: 1847
+title: "for-of tentative rollback truncates fctx.locals but does not restore fctx.localMap"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: Backlog
+---
+# #1847 — for-of rollback leaves stale localMap entries
+
+## Defect
+`src/codegen/statements/loops.ts:2590-2599` (and siblings `:2615/2624/2632`,
+`compileForOfString` `:2432`, `compileForOfIterator` `:3485`) roll back
+`fctx.body.length` and `fctx.locals.length` but not `fctx.localMap` (which
+`allocLocal` mutates). Stale entries then point past the truncated locals vector.
+Practical risk is low (temp names are keyed off `locals.length`), but the state is
+unbalanced.
+
+## Fix
+Snapshot/restore `fctx.localMap` (and `tempFreeList`) alongside `locals.length`, or
+delete names allocated since the snapshot.
+

--- a/plan/issues/1848-dead-code-sweep.md
+++ b/plan/issues/1848-dead-code-sweep.md
@@ -1,0 +1,32 @@
+---
+id: 1848
+title: "Dead-code sweep: identical branches, unused locals/params, obsolete scaffolding"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: low
+task_type: chore
+area: codegen
+goal: maintainability
+sprint: Backlog
+---
+# #1848 — dead-code sweep
+
+Verified dead code / no-op branches found in the 2026-06-04 review:
+
+- `src/codegen/type-coercion.ts:1065` — `from.kind==="ref_null" ? {anyref} : {anyref}` (both arms identical). **Verified.**
+- `src/emit/binary.ts:440-444` — `if (...) {...} else {...}` both call the same `encodeTypeDef`. **Verified.**
+- `src/codegen/stack-balance.ts:687` — `const fixups = 0` never reassigned; final `return fixups` always 0.
+- `src/ir/from-ast.ts:793` — `const writes = new Set()` created then discarded.
+- `src/codegen-linear/c-abi.ts:262-263` — `body.splice(body.length,0)` no-op + unused `callIdx`; `:177` dead `exportReplacements`/`mangleCabiName`; `src/link/linker.ts:225` `externalImports` placeholder; `:417` unused `funcCounter`.
+- `src/codegen/expressions/unary-updates.ts:718` — `const isIncrement = false` constant-folds dead ternary arms.
+- `src/compiler/validation.ts:448` — `const opStart` assigned, never read.
+- `src/codegen/binary-ops.ts:2552` — `compileModulo` ignores both params.
+- `src/codegen/type-coercion.ts:73,988` — deprecated `CompileStringLiteralFn` param of `coerceType` unused.
+- `src/codegen/statements/loops.ts:2398` — obsolete `__str_charAt` name-rescan (premise false since #1677).
+- `src/codegen/string-ops.ts:1994` — unreachable default-separator `else` in native `split`.
+
+## Fix
+Remove each; for the identical-branch cases collapse to the single statement.
+

--- a/plan/issues/1849-duplicate-logic-refactor.md
+++ b/plan/issues/1849-duplicate-logic-refactor.md
@@ -1,0 +1,32 @@
+---
+id: 1849
+title: "Refactor diverged copy-paste (super dispatch, closure drainers, resolveVec, extern_has, typed-default)"
+status: backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: medium
+task_type: refactor
+area: codegen
+goal: maintainability
+sprint: Backlog
+---
+# #1849 — consolidate diverged duplicate logic (bug-magnets)
+
+Duplicated logic that has already partially diverged, found in the 2026-06-04 review:
+
+- `compileSuperElementMethodCall` ≈ `compileSuperMethodCall`
+  (`src/codegen/expressions/new-super.ts:322` vs `:202`); no-class/no-parent
+  fallbacks already differ. Extract one shared helper.
+- Two closure-iterable drainers with different loop caps / field resolution
+  (`src/runtime.ts:1626` vs `:1720`). Unify with a strategy param.
+- `resolveVec` duplicated verbatim (`src/ir/integration.ts:864` & `:985`).
+- `__extern_has` `in`-operator block emitted twice (`src/codegen/binary-ops.ts:648` & `:730`).
+- ~7× copy-pasted "emit typed default value" block in the super-access helpers
+  (`new-super.ts`); `defaultValueInstrs`/`pushDefaultValue` already exist.
+- `operandValType`/`operandIrType` carry an unused `localDefs` param
+  (`src/ir/verify.ts:393`).
+
+## Fix
+Extract shared helpers; replace the typed-default blocks with `pushDefaultValue`.
+

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -187,3 +187,21 @@ time (the i32 hash path lever is DONE and already faster/char than V8). Two size
 
 - [#1761](../1761-string-build-buffer-presize-static-trip-count.md) — Presize the string-build buffer from a static loop trip count to kill the reallocs + per-append cap-check (top AOT win, measured #1 of remaining levers) — **high**, medium, **ready (sprint 59)**
 - [#1762](../1762-linear-memory-string-backing-build-hash-hot-path.md) — Linear-memory string backing for the build/hash hot path — drop the WasmGC `(array i16)` GC barrier (strategic ceiling; dual-backend like #679/#682/#1714) — **high**, hard, **ready, likely needs arch spec**
+
+### Code-review findings — latent + redundancy (2026-06-04)
+
+From the full-codebase review on 2026-06-04
+(`plan/code-review/2026-06-04-compiler-review.md`). Reachable correctness bugs
+went into sprint 59 (#1815–#1839); these are latent (not-yet-wired paths),
+defense-in-depth, and cleanup:
+
+- [#1840](../1840-linker-leb-truncation-and-rewrite-gaps.md) — linker `writeLEB128` truncates growing indices; `call_indirect`/`memory` rewrite gaps (latent — `.o` linker) — low, medium, **backlog**
+- [#1841](../1841-element-section-flag-bitfield.md) — element-section flag bitfield only handles active flag-0 (latent — linker) — low, medium, **backlog**
+- [#1842](../1842-none-heaptype-constant-collides-with-any.md) — `none` heap-type constant collides with `any` (0x6e); `noextern`/`nofunc` missing (latent — emit) — low, low, **backlog**
+- [#1843](../1843-reloc-tag-index-leb-mismatch.md) — `R_WASM_TAG_INDEX_LEB` emitter (11) vs reader (10) mismatch (latent — linker) — low, low, **backlog**
+- [#1844](../1844-ir-verify-no-nested-buffer-recursion.md) — IR `verify` doesn't recurse nested if/try/loop buffers; return-type gate + SSA holes (residual #1798, defense-in-depth) — low, medium, **backlog**
+- [#1845](../1845-ir-propagate-bool-overclaim-seedconcrete.md) — IR propagate: `&&`/`||` over-claim `BOOL`; `seedConcrete` omits i32/u32 — low, low, **backlog**
+- [#1846](../1846-minor-typeof-conformance-notes.md) — minor `typeof`: i64→"number" in `with`-bindings; externref→null fallthrough — low, low, **backlog**
+- [#1847](../1847-forof-rollback-localmap-not-restored.md) — for-of tentative rollback doesn't restore `fctx.localMap` (robustness) — low, low, **backlog**
+- [#1848](../1848-dead-code-sweep.md) — dead-code sweep: identical branches, unused locals/params, obsolete scaffolding — low, low, **backlog**
+- [#1849](../1849-duplicate-logic-refactor.md) — refactor diverged copy-paste (super dispatch, closure drainers, `resolveVec`, `__extern_has`, typed-default) — low, medium, **backlog**

--- a/plan/issues/sprints/59.md
+++ b/plan/issues/sprints/59.md
@@ -50,6 +50,43 @@ largest new standalone lever (2,136 tests). Plus carry-over polish.
 - [#1761](../1761-string-build-buffer-presize-static-trip-count.md) — string-build buffer presize — ready.
 - [#1777](../1777-landing-es-edition-slider-2026-notch-thumb-offset.md) — landing page ES2026 slider notch + thumb drift — ready, easy.
 
+## P2 — code-review bugs (2026-06-04)
+
+Filed from the full-codebase review on 2026-06-04
+(`plan/code-review/2026-06-04-compiler-review.md`). Real correctness bugs;
+redundancy/latent findings (#1840–#1849) went to Backlog.
+
+**Reachable (JS-host default lane):**
+
+- [#1815](../1815-array-splice-drops-inserted-items.md) — `splice` drops inserted items (3+ args). High.
+- [#1816](../1816-array-sort-comparator-ignored-default-numeric.md) — `sort` ignores comparator; default not lexicographic (residual #1361). High.
+- [#1817](../1817-ushr-i32-fast-path-signed-result.md) — `>>>` i32 fast path produces a signed result. High.
+- [#1818](../1818-i32-bool-default-param-fires-on-zero-false.md) — i32/boolean default param fires on `0`/`false`. High.
+- [#1819](../1819-logical-assignment-global-index-offset.md) — `??=`/`||=`/`&&=` read globals at wrong index. High.
+- [#1820](../1820-ir-short-circuit-evaluates-both-operands.md) — IR `&&`/`||`/ternary evaluate both operands. High.
+- [#1821](../1821-delete-always-true-and-element-skips-sidecar.md) — `delete obj.prop` always returns true; `delete obj["k"]` skips sidecar. Med.
+- [#1822](../1822-string-replace-ignores-dollar-substitution.md) — `replace`/`replaceAll` ignore `$` patterns. Med.
+- [#1823](../1823-string-normalize-arg-before-receiver.md) — `normalize(form)` evaluates arg before receiver. Med.
+- [#1824](../1824-super-as-value-wrong-static-type.md) — `super` as a value returns wrong static type. Med.
+- [#1825](../1825-i32-fast-mode-modulo-traps.md) — i32 fast-mode `%` emits trapping `i32.rem_s`. Med.
+- [#1826](../1826-toprimitive-valueof-undefined-treated-absent.md) — `valueOf` returning `undefined` treated as absent. Med.
+- [#1827](../1827-bigint-loose-equality-precision.md) — BigInt loose-equality precision/semantics. Med.
+- [#1828](../1828-array-like-find-map-hole-handling.md) — array-like `find`/`findIndex` skip holes; `map` compacts holes. Med.
+- [#1829](../1829-marshal-typedarray-byte-mask.md) — `marshalTypedArrayArgs` byte-masks non-`Uint8Array` typed arrays. High.
+- [#1830](../1830-wellknown-symbol-range-excludes-matchall.md) — symbol range off-by-one excludes `Symbol.matchAll`. Med.
+- [#1831](../1831-validate-property-descriptor-resets-omitted.md) — `_validatePropertyDescriptor` resets omitted attrs (residual #1334). Med.
+- [#1832](../1832-newfn-captures-outer-var-shadowed-by-destructured-param.md) — captures outer var shadowed by destructured param. Med.
+- [#1833](../1833-implicit-subclass-forwarder-truncates-super-args.md) — implicit subclass forwarder truncates multi-arg `super`. Med.
+- [#1834](../1834-vec-element-write-trapping-trunc.md) — element-write index uses trapping `i32.trunc_f64_s`. Med.
+
+**Standalone / WASI (supported targets):**
+
+- [#1835](../1835-cabi-string-array-marshaling-wrong-offsets.md) — C-ABI string/array marshaling wrong header offsets. High.
+- [#1836](../1836-standalone-number-string-conformance.md) — standalone Number↔String conformance gaps (residual #1335). High.
+- [#1837](../1837-standalone-enumeration-order-hash-bucket.md) — standalone enumeration order is hash-bucket. Med.
+- [#1838](../1838-linear-backend-trycatch-miscompile.md) — linear backend silently miscompiles `try/catch`. Med.
+- [#1839](../1839-add-string-imports-shift-omits-targets.md) — late string-import index shift omits init body / helpers / start func. Med.
+
 ## Definition of done
 
 - All P1 crash clusters cleared (#1808, #1809).
@@ -58,6 +95,32 @@ largest new standalone lever (2,136 tests). Plus carry-over polish.
 - Baseline promoted after P1/P2 merges.
 
 <!-- GENERATED_ISSUE_TABLES_START -->
+## Issue Tables
+
+_Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
+
+### Ready
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1470 | host-independence: eliminate JS host string ops for standalone Wasm | high | ready |
+| #1525b | ToPrimitive residuals: object-method trampoline invalid Wasm + §7.1.1.1 step-6 TypeError | medium | ready |
+| #1712 | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | high | ready |
+| #1761 | perf(string-hash): presize string-build buffer from static loop-trip-count to kill reallocs + per-append cap-check | high | ready |
+| #1777 | landing page ES edition slider shows ES2026 notch and thumb drifts off ticks | medium | ready |
+| #1805 | 75 negative_test_fail: early-error enforcement gaps after #774/#927 | medium | ready |
+| #1806 | standalone: 2,136 tests fail with 'Cannot convert object to primitive value' | high | ready |
+| #1807 | standalone: 277 async-generator tests emit invalid Wasm in isSameValue (#1776 residual) | medium | ready |
+| #1808 | Binary emit error: offset is out of bounds — emitBinary() crash on 276 tests | high | ready |
+| #1809 | late-import shift walker misses method-trampoline funcIdx pointing at import (#1525b regression) | high | ready |
+| #1815 | Array.prototype.splice drops inserted items (3+ args ignored) | high | ready |
+| #1816 | Array.prototype.sort ignores user comparator; default sort numeric not lexicographic (residual #1361) | high | ready |
+| #1817 | >>> in i32 fast path produces a signed result (negative for high-bit values) | high | ready |
+| #1818 | i32/boolean parameter default fires on a legitimate 0 / false argument | high | ready |
+| #1819 | Logical assignment (??= \|\|= &&=) reads globals at wrong (un-offset) index | high | ready |
+| #1820 | IR path: && \|\| and ternary evaluate both operands (lost short-circuit + non-termination) | high | ready |
+| #1821 | delete obj.prop always returns true; delete obj['k'] skips __delete_property sidecar | medium | ready |
+| #1822 | String#replace/replaceAll ignore $ substitution patterns ($, <!-- GENERATED_ISSUE_TABLES_START -->
 ## Issue Tables
 
 _Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
@@ -73,5 +136,130 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | Issue | Title | Priority | Status |
 |---|---|---|---|
 | #1777 | landing page ES edition slider shows ES2026 notch and thumb drifts off ticks | medium | ready |
+
+<!-- GENERATED_ISSUE_TABLES_END -->, ---
+sprint: 59
+status: active
+created: 2026-06-02
+updated: 2026-06-04
+authors: codex
+baseline_pass: 30521
+baseline_total: 43135
+baseline_pct: 70.8
+standalone_baseline_pass: 10948
+standalone_baseline_total: 43128
+standalone_baseline_pct: 25.4
+baseline_sha: f692249d
+baseline_date: 2026-06-03T22:28Z
+target_pass: tbd
+expected_gain: tbd
+---
+
+# Sprint 59 Plan — harvest fixes + early-error enforcement
+
+## Goal
+
+Fix concrete error patterns surfaced by `/harvest-errors` on 2026-06-04.
+Two default-lane codegen crashes (#1808, #1809) are high-priority (290 + 157
+tests, should be fast wins). The standalone ToPrimitive gap (#1806) is the
+largest new standalone lever (2,136 tests). Plus carry-over polish.
+
+## P1 — codegen crashes (default lane)
+
+- [#1808](../1808-binary-emit-offset-out-of-bounds-codegen-crash.md) — `Binary emit error: offset is out of bounds` — **290 tests**. emitBinary() back-patch overflow. High, medium.
+- [#1809](../1809-method-trampoline-shift-walker-misses-import-funcidx.md) — `pendingMethodTrampolines` shift walker misses import funcIdx — **157 tests**. #1525b regression. High, medium.
+
+## P2 — standalone conformance (harvest 2026-06-04)
+
+- [#1806](../1806-standalone-toprimitive-cannot-convert-object.md) — standalone `Cannot convert object to primitive value` — **2,136 tests** (839 CE + 1,297 runtime). ToPrimitive not implemented in standalone. High, medium.
+- [#1807](../1807-standalone-issamevalue-async-gen-wasm-type-mismatch.md) — standalone isSameValue Wasm call type mismatch for async-generator params — **277 tests**. Residual after #1776. Medium, medium.
+- [#1805](../1805-negative-test-fail-early-error-enforcement-gaps.md) — 75 negative_test_fail early-error gaps (import-attrs dup key, TDZ, dstr rest) — Medium, medium.
+
+## P2 — carry-in (unfinished from s57/s58)
+
+- [#1387](../1387-with-statement-dynamic-scope-implementation.md) — `with` statement Tier 2 dynamic fallback — in-progress (Tier 1 merged; Tier 2 hard).
+- [#1525b](../1525b-toprimitive-method-trampoline-and-step6.md) — ToPrimitive trampoline invalid Wasm + §7.1.1.1 step-6 TypeError — ready.
+- [#1539](../1539-wasm-native-regex-engine-regress.md) — standalone RegExp Phase 2: flags u/v/d/m/s via regress — in-progress, **1,052 tests**.
+- [#681](../681-pure-wasm-iterator-protocol-eliminate.md) — standalone iterator protocol remaining 4 host imports — in-progress, **777 tests**.
+- [#1470](../1470-no-js-host-string-ops.md) — eliminate JS host string ops for standalone — ready, high impact.
+
+## P3 — carry-over polish
+
+- [#1712](../1712-acorn-acceptance-differential-ast.md) — Acorn AST-equality dogfood acceptance — ready.
+- [#1761](../1761-string-build-buffer-presize-static-trip-count.md) — string-build buffer presize — ready.
+- [#1777](../1777-landing-es-edition-slider-2026-notch-thumb-offset.md) — landing page ES2026 slider notch + thumb drift — ready, easy.
+
+## P2 — code-review bugs (2026-06-04)
+
+Filed from the full-codebase review on 2026-06-04
+(`plan/code-review/2026-06-04-compiler-review.md`). Real correctness bugs;
+redundancy/latent findings (#1840–#1849) went to Backlog.
+
+**Reachable (JS-host default lane):**
+
+- [#1815](../1815-array-splice-drops-inserted-items.md) — `splice` drops inserted items (3+ args). High.
+- [#1816](../1816-array-sort-comparator-ignored-default-numeric.md) — `sort` ignores comparator; default not lexicographic (residual #1361). High.
+- [#1817](../1817-ushr-i32-fast-path-signed-result.md) — `>>>` i32 fast path produces a signed result. High.
+- [#1818](../1818-i32-bool-default-param-fires-on-zero-false.md) — i32/boolean default param fires on `0`/`false`. High.
+- [#1819](../1819-logical-assignment-global-index-offset.md) — `??=`/`||=`/`&&=` read globals at wrong index. High.
+- [#1820](../1820-ir-short-circuit-evaluates-both-operands.md) — IR `&&`/`||`/ternary evaluate both operands. High.
+- [#1821](../1821-delete-always-true-and-element-skips-sidecar.md) — `delete obj.prop` always returns true; `delete obj["k"]` skips sidecar. Med.
+- [#1822](../1822-string-replace-ignores-dollar-substitution.md) — `replace`/`replaceAll` ignore `$` patterns. Med.
+- [#1823](../1823-string-normalize-arg-before-receiver.md) — `normalize(form)` evaluates arg before receiver. Med.
+- [#1824](../1824-super-as-value-wrong-static-type.md) — `super` as a value returns wrong static type. Med.
+- [#1825](../1825-i32-fast-mode-modulo-traps.md) — i32 fast-mode `%` emits trapping `i32.rem_s`. Med.
+- [#1826](../1826-toprimitive-valueof-undefined-treated-absent.md) — `valueOf` returning `undefined` treated as absent. Med.
+- [#1827](../1827-bigint-loose-equality-precision.md) — BigInt loose-equality precision/semantics. Med.
+- [#1828](../1828-array-like-find-map-hole-handling.md) — array-like `find`/`findIndex` skip holes; `map` compacts holes. Med.
+- [#1829](../1829-marshal-typedarray-byte-mask.md) — `marshalTypedArrayArgs` byte-masks non-`Uint8Array` typed arrays. High.
+- [#1830](../1830-wellknown-symbol-range-excludes-matchall.md) — symbol range off-by-one excludes `Symbol.matchAll`. Med.
+- [#1831](../1831-validate-property-descriptor-resets-omitted.md) — `_validatePropertyDescriptor` resets omitted attrs (residual #1334). Med.
+- [#1832](../1832-newfn-captures-outer-var-shadowed-by-destructured-param.md) — captures outer var shadowed by destructured param. Med.
+- [#1833](../1833-implicit-subclass-forwarder-truncates-super-args.md) — implicit subclass forwarder truncates multi-arg `super`. Med.
+- [#1834](../1834-vec-element-write-trapping-trunc.md) — element-write index uses trapping `i32.trunc_f64_s`. Med.
+
+**Standalone / WASI (supported targets):**
+
+- [#1835](../1835-cabi-string-array-marshaling-wrong-offsets.md) — C-ABI string/array marshaling wrong header offsets. High.
+- [#1836](../1836-standalone-number-string-conformance.md) — standalone Number↔String conformance gaps (residual #1335). High.
+- [#1837](../1837-standalone-enumeration-order-hash-bucket.md) — standalone enumeration order is hash-bucket. Med.
+- [#1838](../1838-linear-backend-trycatch-miscompile.md) — linear backend silently miscompiles `try/catch`. Med.
+- [#1839](../1839-add-string-imports-shift-omits-targets.md) — late string-import index shift omits init body / helpers / start func. Med.
+
+## Definition of done
+
+- All P1 crash clusters cleared (#1808, #1809).
+- #1806 emits tracking cite for all 2,136 tests (Phase 0).
+- #1539 Phase 2 flags and #681 iterator protocol ship.
+- Baseline promoted after P1/P2 merges.
+
+, ) | medium | ready |
+| #1823 | String#normalize(form) evaluates argument before receiver (wrong eval order) | medium | ready |
+| #1824 | super used as a value returns the wrong static ValType (local indexing bug) | medium | ready |
+| #1825 | i32 fast-mode % emits trapping i32.rem_s (x % 0 traps instead of NaN) | medium | ready |
+| #1826 | OrdinaryToPrimitive treats valueOf/toString returning undefined as method-absent | medium | ready |
+| #1827 | BigInt loose-equality loses precision / wrong semantics (== String, == Number) | medium | ready |
+| #1828 | Array-like find/findIndex skip holes; map compacts holes (sparse .call receivers) | medium | ready |
+| #1829 | marshalTypedArrayArgs byte-masks every element, corrupting non-Uint8Array typed arrays | high | ready |
+| #1830 | Well-known-symbol range guard off-by-one excludes Symbol.matchAll (ID 15) | medium | ready |
+| #1831 | _validatePropertyDescriptor resets omitted attributes to false on redefine (residual #1334) | medium | ready |
+| #1832 | compileNewFunctionExpression captures outer var shadowed by a destructured param | medium | ready |
+| #1833 | Implicit subclass constructor forwarder truncates multi-arg super(...) | medium | ready |
+| #1834 | Vec element-write/length index uses trapping i32.trunc_f64_s instead of saturating | medium | ready |
+| #1835 | C-ABI string/array marshaling reads wrong header offsets (param + return) | high | ready |
+| #1836 | Standalone Number<->String conformance gaps (0o/0b, toFixed 1e21, exponential, fractional radix, whitespace, ToNumber) (residual #1335) | high | ready |
+| #1837 | Standalone Object.keys/for-in/JSON enumeration is hash-bucket order, not spec order | medium | ready |
+| #1838 | Linear backend silently miscompiles try/catch (throw -> unreachable, catch dropped) | medium | ready |
+| #1839 | addStringImports late-index shift omits pendingInitBody / nativeStrHelpers / startFuncIdx | medium | ready |
+| #1844 | IR verify doesn't recurse into nested if/try/loop buffers (return-type gate + SSA holes) (residual #1798) | low | ready |
+| #1845 | IR propagate: && / \|\| over-claim BOOL; seedConcrete omits i32/u32 | low | ready |
+
+### In Progress
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #681 | Pure Wasm iterator protocol (eliminate 5 host imports) | high | in-progress |
+| #1387 | feat: implement `with` statement — architect exploration of dynamic-scope compilation strategies | high | in-progress |
+| #1539 | Standalone Wasm RegExp engine via regress (Phase 2 of #1474) | high | in-progress |
 
 <!-- GENERATED_ISSUE_TABLES_END -->


### PR DESCRIPTION
## What

Files the findings from a full read-only code review of the compiler (`src/`, ~180k LOC) conducted on 2026-06-04 — covering correctness bugs, redundancies, and **ECMAScript + WebAssembly spec conformance**.

The complete prioritized report (locations, spec citations, repros, fixes, and a verified-correct list) is in **`plan/code-review/2026-06-04-compiler-review.md`**.

## Issues filed (35: #1815–#1849)

**25 real correctness bugs → sprint 59** (`status: ready`):
- **20 reachable on the default JS-host lane** — incl. `splice` dropping inserted items (#1815), `sort` ignoring comparators (#1816), `>>>` signedness (#1817), i32/bool default params firing on `0`/`false` (#1818), logical-assignment global indexing (#1819), IR `&&`/`||`/ternary evaluating both sides (#1820), `delete` always returning true (#1821), typed-array arg byte-masking (#1829), `Symbol.matchAll` off-by-one (#1830).
- **5 standalone/WASI** — C-ABI header offsets (#1835), standalone number/string conformance (#1836), enumeration order (#1837), linear `try/catch` (#1838), late-import shift (#1839).

**10 latent + redundancy → backlog** (`status: backlog`) — linker LEB/element/reloc (#1840–1843), IR verifier nesting gap (#1844), minor notes (#1845–1847), dead-code sweep (#1848), duplicate-logic refactor (#1849).

Four issues are **residuals of issues already marked `done`** — #1361 (sort), #1334 (defineProperty), #1335 (number-format), #1798 (IR return-type) — each new issue cites the original.

## Scope / safety

- **`plan/` only** — no source or test changes. Zero conformance/runtime impact.
- Sprint-59 doc gets a "code-review bugs" prose section + regenerated issue table (`scripts/sync-sprint-issue-tables.mjs`); `backlog/backlog.md` gets a code-review section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)