### PR TITLE
fix(#1819): logical assignment reads globals at module-local index

### DIFF
--- a/plan/issues/1819-logical-assignment-global-index-offset.md
+++ b/plan/issues/1819-logical-assignment-global-index-offset.md
@@ -1,0 +1,62 @@
+---
+id: 1819
+title: "Logical assignment (??= ||= &&=) reads globals at wrong (un-offset) index"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: high
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: 59
+---
+# #1819 — logical-assignment reads globals at the wrong index
+
+## Symptom
+With import globals present (string pool etc.), `g ??= x` / `g ||= x` / `g &&= x`
+on a captured/module ref-typed global mis-evaluates (skips the null/undefined
+branch because `varType` wrongly falls back to f64).
+
+## Location
+`src/codegen/expressions/assignment.ts:3159` and `:3170` use the raw absolute
+index `ctx.mod.globals[capturedIdx]` / `[moduleIdx]`. Every other access in the
+file wraps with `localGlobalIdx(ctx, …)` (lines 260/276/590/2198/2236/2594/4536/
+4568). `localGlobalIdx` subtracts `numImportGlobals`. **Verified by hand.**
+
+## Fix
+`ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)]` and likewise for `moduleIdx`.
+
+## Resolution
+Applied the two-line fix at `assignment.ts:3159` / `:3170` in
+`compileIdentifierLogicalAssignment`. Both now wrap the absolute Wasm global
+index with `localGlobalIdx(ctx, …)` before indexing the module-globals array,
+matching every other global access in the file.
+
+Root cause: `ctx.capturedGlobals` / `ctx.moduleGlobals` store the *absolute*
+Wasm global index (import globals included). `ctx.mod.globals` is the
+module-defined-globals array, which excludes import globals. Indexing it with
+the absolute index lands on the wrong slot (or off the end) once any string
+literal adds `string_constants` import globals, so the resolved `type` was
+wrong → `varType` fell back to f64 → the null/undefined short-circuit branch was
+either skipped (wrong runtime value, e.g. `??=` returned the stale `null`) or
+emitted with an f64-typed `if` condition where i32 was expected (invalid Wasm,
+`||=` / `&&=`).
+
+## Test Results
+`tests/issue-1819.test.ts` — 7/7 pass with the fix. Verified each case FAILS on
+the unpatched baseline:
+- `??=` (module string|null): baseline returned `"nullxyz"` (skipped null branch)
+  → fixed returns `"setxyz"`.
+- `||=` / `&&=` (module number): baseline produced invalid Wasm
+  (`if[0] expected type i32, found global.get of type f64`) → fixed compiles and
+  short-circuits correctly.
+- `??=` on a captured global inside a closure: baseline `"nullzzz"` → fixed
+  `"viaClosurezzz"`.
+
+Pre-existing unrelated failures in `tests/logical-assignment.test.ts` (11/11,
+`Import #0 "string_constants": module is not an object or function`) reproduce
+identically on the unpatched baseline — a test-harness instantiation gap, not a
+regression from this change.
+

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -3156,7 +3156,7 @@ export function compileLogicalAssignment(
   if (!storage) {
     const capturedIdx = ctx.capturedGlobals.get(name);
     if (capturedIdx !== undefined) {
-      const globalDef = ctx.mod.globals[capturedIdx];
+      const globalDef = ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)];
       storage = {
         kind: "captured",
         index: capturedIdx,
@@ -3167,7 +3167,7 @@ export function compileLogicalAssignment(
   if (!storage) {
     const moduleIdx = ctx.moduleGlobals.get(name);
     if (moduleIdx !== undefined) {
-      const globalDef = ctx.mod.globals[moduleIdx];
+      const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
       storage = {
         kind: "module",
         index: moduleIdx,

--- a/tests/issue-1819.test.ts
+++ b/tests/issue-1819.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #1819: logical assignment (??= ||= &&=) on a module-level / captured global
+// read the global's type from `ctx.mod.globals[absIdx]` using the *absolute*
+// Wasm global index instead of the module-local index. When import globals are
+// present (e.g. the string-constant pool from any string literal), the
+// module-globals array is offset by `numImportGlobals`, so the lookup landed on
+// the wrong slot — or off the end. That produced a wrong `varType` (falling
+// back to f64), which either:
+//   - skipped the null/undefined short-circuit branch (wrong runtime value), or
+//   - emitted an `if` condition typed f64 where i32 was expected (invalid Wasm).
+//
+// Fix: wrap both lookups with `localGlobalIdx(ctx, …)` (= absIdx -
+// numImportGlobals), matching every other global access in assignment.ts.
+// Repro requires at least one string literal so the string-constant import
+// globals shift the module-globals array.
+
+async function run(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "t.ts" });
+  expect(r.success, `Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(
+    r.binary,
+    (r as unknown as { importObject: WebAssembly.Imports }).importObject,
+  );
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1819 logical assignment reads module/captured globals at the right index", () => {
+  it("??= on a module string|null global takes the null branch (string pool present)", async () => {
+    const out = await run(`
+      let g: string | null = null;
+      const pad = "xyz"; // forces string-constant import globals
+      export function test(): string {
+        g ??= "set";
+        return (g as string) + pad;
+      }
+    `);
+    expect(out).toBe("setxyz");
+  });
+
+  it("??= on an already-set module global keeps the existing value", async () => {
+    const out = await run(`
+      let g: string | null = "orig";
+      const pad = "_q";
+      export function test(): string {
+        g ??= "fallback";
+        return (g as string) + pad;
+      }
+    `);
+    expect(out).toBe("orig_q");
+  });
+
+  it("||= on a module number global compiles to valid Wasm and short-circuits", async () => {
+    const out = await run(`
+      let n = 0;
+      const pad = "abc";
+      export function test(): number {
+        n ||= 42;
+        return n;
+      }
+    `);
+    expect(out).toBe(42);
+  });
+
+  it("||= on a truthy module number global keeps the existing value", async () => {
+    const out = await run(`
+      let n = 7;
+      const pad = "abc";
+      export function test(): number {
+        n ||= 42;
+        return n;
+      }
+    `);
+    expect(out).toBe(7);
+  });
+
+  it("&&= on a truthy module number global assigns the RHS", async () => {
+    const out = await run(`
+      let m = 7;
+      const pad = "abc";
+      export function test(): number {
+        m &&= 99;
+        return m;
+      }
+    `);
+    expect(out).toBe(99);
+  });
+
+  it("&&= on a falsy module number global short-circuits to the existing value", async () => {
+    const out = await run(`
+      let m = 0;
+      const pad = "abc";
+      export function test(): number {
+        m &&= 99;
+        return m;
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("??= on a captured global inside a closure takes the null branch", async () => {
+    const out = await run(`
+      const pad = "zzz";
+      let g: string | null = null;
+      function inner(): string {
+        g ??= "viaClosure";
+        return (g as string) + pad;
+      }
+      export function test(): string {
+        return inner();
+      }
+    `);
+    expect(out).toBe("viaClosurezzz");
+  });
+});


### PR DESCRIPTION
## Problem (#1819)

`??=` / `||=` / `&&=` on a module-level or captured global looked up the
global's type from `ctx.mod.globals[absIdx]` using the **absolute** Wasm global
index instead of the module-local index. `ctx.capturedGlobals` / `ctx.moduleGlobals`
store the absolute index (import globals included); `ctx.mod.globals` is the
module-defined-globals array (import globals excluded), so when any string
literal adds `string_constants` import globals the lookup lands on the wrong
slot — or off the end.

The wrong slot yields a wrong `type`, so `varType` falls back to f64. That
either:
- skips the null/undefined short-circuit branch → wrong runtime value
  (`g ??= "set"` returned the stale `null`), or
- emits an f64-typed `if` condition where i32 is expected → **invalid Wasm**
  (`||=` / `&&=`: `if[0] expected type i32, found global.get of type f64`).

## Fix

Wrap both lookups in `compileIdentifierLogicalAssignment`
(`src/codegen/expressions/assignment.ts:3159` / `:3170`) with
`localGlobalIdx(ctx, …)` (= `absIdx - numImportGlobals`), matching every other
global access in the file (lines 260/276/590/2198/2236/2594/4536/4568).

Two-line change.

## Tests

`tests/issue-1819.test.ts` — 7 cases, all green. Each was verified to **FAIL on
the unpatched baseline**:
- `??=` module `string|null`: baseline `"nullxyz"` (skipped null branch) → `"setxyz"`
- `||=` / `&&=` module number: baseline produced invalid Wasm → now compiles + short-circuits
- `??=` captured global in a closure: baseline `"nullzzz"` → `"viaClosurezzz"`

Pre-existing unrelated failures in `tests/logical-assignment.test.ts` (11/11,
`Import #0 "string_constants": module is not an object or function`) reproduce
identically on the unpatched baseline — a test-harness instantiation gap, not a
regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)