### PR TITLE
fix(#1835): C-ABI string/array marshaling uses verified header offsets

### DIFF
--- a/plan/issues/1835-cabi-string-array-marshaling-wrong-offsets.md
+++ b/plan/issues/1835-cabi-string-array-marshaling-wrong-offsets.md
@@ -1,0 +1,68 @@
+---
+id: 1835
+title: "C-ABI string/array marshaling reads wrong header offsets (param + return)"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen-linear
+goal: correctness
+sprint: 59
+---
+# #1835 — C-ABI string/array marshaling uses wrong header layout
+
+## Symptom
+Any WASI/C export taking or returning `string`/`T[]` over the C ABI hands the host
+a wrong length and a pointer into the middle of the header → OOB reads / corrupted
+strings. The C ABI is effectively non-functional for string/array I/O.
+
+## Location
+`src/codegen-linear/c-abi.ts:269-273` computes return data ptr = `ptr+4` and loads
+length at `offset 0`. The verified linear layout (`src/codegen-linear/runtime.ts:505`)
+is `[header 8B][len:u32 @ +8][bytes @ +12]` → length is at `offset 8`, data at
+`ptr+12`. Param marshaling (`:231-246`) has the mirror problem — forwards a raw
+`(ptr,len)` where the internal function expects a header object. **Verified.**
+
+## Fix
+Return: load length at `offset 8`, data pointer offset `12`. Param: construct a
+runtime string/array object (e.g. `__str_from_data`) from `(ptr,len)` before calling
+the internal function. Also remove the dead scaffolding at `:262-263` (see #1848).
+
+## Resolution (2026-06-04)
+Fixed in `src/codegen-linear/c-abi.ts`, `src/codegen-linear/runtime.ts`,
+`src/compiler/output.ts`:
+
+- **Return marshaling**: now loads length at `+8` (`AGG_LEN_OFFSET`) and exposes
+  the data pointer at `headerPtr + STR_DATA_OFFSET (12)` for strings and
+  `headerPtr + ARR_DATA_OFFSET (16)` for arrays. String vs array offset is
+  selected from `info.result.semantic`. Offset constants are declared once in
+  c-abi.ts and documented as mirroring runtime.ts.
+- **Param marshaling**: a `string`/`array` C param arrives as a raw `(ptr, len)`
+  pair; the wrapper now rehydrates an internal header object by calling
+  `__str_from_data(ptr, len)` / `__arr_from_data(ptr, len)` before invoking the
+  internal function. `CabiParam` carries an `aggregate` discriminator so the
+  wrapper picks the right constructor.
+- Added the `__arr_from_data(dataPtr, len) → headerPtr` runtime helper to
+  `addArrayRuntime` (allocates `16 + len*4`, tags Array, sets len/cap, copies
+  `len` i32 elements).
+- Removed the dead `body.splice(body.length, 0)` no-op and unused `callIdx`
+  (partial #1848 sweep).
+- Wired `applyCabiTransform` to receive the typed AST so it can classify
+  string/array params/returns (they lower to i32 header pointers, otherwise
+  indistinguishable from numbers). TS-type inference only applies when the
+  declared param count matches the Wasm param count, so a prepended
+  `this`/closure slot falls back to scalar treatment.
+
+## Test Results
+`tests/issue-1835.test.ts` — 7/7 pass:
+- string return → `(dataPtr, len)` decodes to the correct UTF-8 (`"Hi"`, len 2;
+  `"hello world"`, len 11)
+- string param rehydrated → `lenOf("hello") === 5`; empty string → `0`
+- array return → `(dataPtr, len=3)`, elements `[10, 20, 30]` read directly
+- scalar `add(3, 4) === 7` unaffected
+- C header emits an out-param signature for the string return
+
+Existing `tests/c-abi.test.ts` (38) and linear-array/advanced/wasi suites stay green.

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -18,6 +18,33 @@
 
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
 
+// ── Linear-memory aggregate header layout (mirrors runtime.ts) ───────
+//
+// String: [header 8B][len:u32 @ +8][utf8 bytes @ +12...]
+// Array:  [header 8B][len:u32 @ +8][cap:u32 @ +12][elements: i32×cap @ +16...]
+//
+// These constants MUST stay in sync with addStringRuntime / addArrayRuntime
+// in src/codegen-linear/runtime.ts (#1835).
+const AGG_LEN_OFFSET = 8; // length field for both strings and arrays
+const STR_DATA_OFFSET = 12; // first UTF-8 byte of a string
+const ARR_DATA_OFFSET = 16; // first element of an array
+
+/** Locate a (defined or imported) function by name, returning its global func index. */
+function findFuncIndexByName(mod: WasmModule, name: string): number {
+  const numImportFuncs = mod.imports.filter((i) => i.desc.kind === "func").length;
+  // Imports first occupy indices [0, numImportFuncs); match by import name.
+  let importIdx = 0;
+  for (const imp of mod.imports) {
+    if (imp.desc.kind !== "func") continue;
+    if (imp.name === name) return importIdx;
+    importIdx++;
+  }
+  for (let i = 0; i < mod.functions.length; i++) {
+    if (mod.functions[i].name === name) return numImportFuncs + i;
+  }
+  return -1;
+}
+
 // ── Types ────────────────────────────────────────────────────────────
 
 /** Describes the TS-level semantic type of a parameter */
@@ -38,6 +65,12 @@ export interface CabiParam {
   sourceParamIdx: number;
   /** "ptr" | "len" for expanded params, "direct" for scalar */
   role: "direct" | "ptr" | "len";
+  /**
+   * For expanded (ptr/len) params, the underlying aggregate kind so the
+   * wrapper can pick the right runtime constructor (`__str_from_data` for
+   * strings, `__arr_from_data` for arrays). Undefined for scalar/direct.
+   */
+  aggregate?: "string" | "array";
 }
 
 /** C ABI return value descriptor */
@@ -77,12 +110,14 @@ export function mapParamsToCabi(params: ParamDef[]): CabiParam[] {
           wasmType: { kind: "i32" },
           sourceParamIdx: i,
           role: "ptr",
+          aggregate: p.semantic,
         });
         result.push({
           name: `${p.name}_len`,
           wasmType: { kind: "i32" },
           sourceParamIdx: i,
           role: "len",
+          aggregate: p.semantic,
         });
         break;
       case "boolean":
@@ -227,18 +262,32 @@ export function emitCabiWrappers(mod: WasmModule, exportInfos: CabiExportInfo[])
     // Build wrapper body
     const body: Instr[] = [];
 
-    // For each original parameter, reconstruct the value from C ABI params
+    // Resolve runtime constructors used to rehydrate string/array params from
+    // the raw (ptr, len) the C caller provides. They are always present for
+    // the linear target (addStringRuntime / addArrayRuntime run unconditionally).
+    const strFromDataIdx = findFuncIndexByName(mod, "__str_from_data");
+    const arrFromDataIdx = findFuncIndexByName(mod, "__arr_from_data");
+
+    // For each original parameter, reconstruct the value from C ABI params.
     let cabiParamIdx = 0;
     for (let origIdx = 0; origIdx < (origType.params?.length ?? 0); origIdx++) {
       const cabiParam = info.params[cabiParamIdx];
       if (cabiParam && cabiParam.role === "ptr") {
-        // String/array: the original function expects an i32 pointer.
-        // In C ABI, we pass (ptr, len). The original function already
-        // works with a pointer to the string/array header in linear memory.
-        // For C interop, the caller provides a raw data pointer + length.
-        // We just pass the pointer — the length is available separately.
-        body.push({ op: "local.get", index: cabiParamIdx });
-        cabiParamIdx += 2; // skip the len param
+        // String/array param: the C ABI passes a raw (data ptr, len) pair, but
+        // the internal function expects a pointer to a linear-memory header
+        // object. Reconstruct it by calling the matching runtime constructor.
+        const ctorIdx = cabiParam.aggregate === "array" ? arrFromDataIdx : strFromDataIdx;
+        if (ctorIdx >= 0) {
+          // __{str,arr}_from_data(dataPtr, len) -> header ptr
+          body.push({ op: "local.get", index: cabiParamIdx }); // ptr
+          body.push({ op: "local.get", index: cabiParamIdx + 1 }); // len
+          body.push({ op: "call", funcIdx: ctorIdx });
+        } else {
+          // Constructor missing (should not happen for linear target) — fall
+          // back to forwarding the raw pointer to avoid emitting invalid Wasm.
+          body.push({ op: "local.get", index: cabiParamIdx });
+        }
+        cabiParamIdx += 2; // consumed both ptr and len
       } else {
         body.push({ op: "local.get", index: cabiParamIdx });
         cabiParamIdx++;
@@ -250,27 +299,23 @@ export function emitCabiWrappers(mod: WasmModule, exportInfos: CabiExportInfo[])
 
     // Handle return value marshaling
     if (info.result.semantic === "string" || info.result.semantic === "array") {
-      // The original function returns an i32 pointer to a string/array header.
-      // For C ABI, we need to return (ptr, len).
-      // The string header format: [length: i32 at offset 0] [data at offset 4]
-      // We load the length and compute the data pointer.
+      // The original function returns an i32 pointer to a string/array header:
+      //   string: [header 8B][len:u32 @ +8][utf8 bytes @ +12...]
+      //   array:  [header 8B][len:u32 @ +8][cap:u32 @ +12][elems @ +16...]
+      // For the C ABI we return (data ptr, len) so the host reads the payload
+      // directly without knowing the header layout (#1835).
+      const dataOffset = info.result.semantic === "array" ? ARR_DATA_OFFSET : STR_DATA_OFFSET;
       const retLocal = wrapperParamTypes.length;
-      // We need a local to store the returned pointer
       const wrapperLocals = [{ name: "__ret_ptr", type: { kind: "i32" } as ValType }];
 
-      // Store returned pointer
-      body.splice(body.length, 0); // placeholder
-      const callIdx = body.length - 1;
-      // Actually, we need to restructure: save the call result, then extract ptr and len
-      // Replace the end of body:
-      // After the call, the result (pointer) is on the stack
+      // After the call, the header pointer is on the stack.
+      // result[0] = data pointer = headerPtr + dataOffset
       body.push({ op: "local.tee", index: retLocal });
-      // Data pointer = ptr + 4 (skip the length header)
-      body.push({ op: "i32.const", value: 4 });
+      body.push({ op: "i32.const", value: dataOffset });
       body.push({ op: "i32.add" });
-      // Length = i32.load at ptr
+      // result[1] = length = i32.load at headerPtr + AGG_LEN_OFFSET
       body.push({ op: "local.get", index: retLocal });
-      body.push({ op: "i32.load", align: 2, offset: 0 });
+      body.push({ op: "i32.load", align: 2, offset: AGG_LEN_OFFSET });
 
       // Add the wrapper function with the extra local
       const wrapperFuncIdx = numImportFuncs + mod.functions.length;

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -344,6 +344,7 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
  * - __arr_get(ptr: i32, idx: i32) → i32
  * - __arr_set(ptr: i32, idx: i32, val: i32) → void
  * - __arr_len(ptr: i32) → i32
+ * - __arr_from_data(dataPtr: i32, len: i32) → i32 (header ptr)
  */
 export function addArrayRuntime(mod: WasmModule): void {
   const mallocIdx = findFuncIndex(mod, "__malloc");
@@ -440,6 +441,90 @@ export function addArrayRuntime(mod: WasmModule): void {
     { op: "local.get", index: 0 }, // ptr
     { op: "i32.load", align: 2, offset: 8 },
   ]);
+
+  // __arr_from_data(dataPtr: i32, len: i32) → i32 (array header ptr)
+  // Build an internal array object from a raw, contiguous block of `len`
+  // i32 elements at `dataPtr`. Used by the C ABI wrapper to rehydrate an
+  // array parameter passed as a (ptr, len) pair (#1835).
+  // Layout written: [header 8B][len:u32 @ +8][cap:u32 @ +12][elems @ +16...]
+  // extra locals: local 2 = ptr (result), local 3 = i (loop counter)
+  addRuntimeFunc(
+    mod,
+    "__arr_from_data",
+    [{ kind: "i32" }, { kind: "i32" }],
+    [{ kind: "i32" }],
+    [],
+    (firstLocalIdx) => {
+      const ptrLocal = firstLocalIdx;
+      const iLocal = firstLocalIdx + 1;
+      return [
+        // Allocate: 16 + len*4
+        { op: "i32.const", value: 16 },
+        { op: "local.get", index: 1 }, // len
+        { op: "i32.const", value: 4 },
+        { op: "i32.mul" },
+        { op: "i32.add" },
+        { op: "call", funcIdx: mallocIdx },
+        { op: "local.set", index: ptrLocal },
+        // Tag byte 0x01 (Array) at ptr+0
+        { op: "local.get", index: ptrLocal },
+        { op: "i32.const", value: 0x01 },
+        { op: "i32.store8", align: 0, offset: 0 },
+        // len at ptr+8
+        { op: "local.get", index: ptrLocal },
+        { op: "local.get", index: 1 },
+        { op: "i32.store", align: 2, offset: 8 },
+        // cap = len at ptr+12
+        { op: "local.get", index: ptrLocal },
+        { op: "local.get", index: 1 },
+        { op: "i32.store", align: 2, offset: 12 },
+        // Copy elements: for i=0; i<len; i++ { mem[ptr+16+i*4] = mem[dataPtr+i*4] }
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: iLocal },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                // break if i >= len
+                { op: "local.get", index: iLocal },
+                { op: "local.get", index: 1 }, // len
+                { op: "i32.ge_u" },
+                { op: "br_if", depth: 1 },
+                // dest addr = ptr + i*4 (offset 16 applied at store)
+                { op: "local.get", index: ptrLocal },
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 4 },
+                { op: "i32.mul" },
+                { op: "i32.add" },
+                // value = mem[dataPtr + i*4]
+                { op: "local.get", index: 0 }, // dataPtr
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 4 },
+                { op: "i32.mul" },
+                { op: "i32.add" },
+                { op: "i32.load", align: 2, offset: 0 },
+                // store at dest+16
+                { op: "i32.store", align: 2, offset: 16 },
+                // i++
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: iLocal },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        // Return ptr
+        { op: "local.get", index: ptrLocal },
+      ];
+    },
+    2,
+  ); // 2 extra locals
 
   // __arr_slice(arr: i32, start: i32, end: i32) → i32 (new array)
   // Creates a new array containing elements [start, end) from arr

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -725,7 +725,7 @@ export function compileSourceSync(
   // Step 2b: Apply C ABI transformations if requested
   let cHeader: string | undefined;
   if (options.abi === "c" && options.target === "linear") {
-    const cabiResult = applyCabiTransform(mod, options.moduleName ?? "module");
+    const cabiResult = applyCabiTransform(mod, options.moduleName ?? "module", ast);
     cHeader = cabiResult.cHeader;
   }
 

--- a/src/compiler/output.ts
+++ b/src/compiler/output.ts
@@ -2,8 +2,8 @@
 import { ts } from "../ts-api.js";
 import type { TypedAST } from "../checker/index.js";
 import { analyzeSource } from "../checker/index.js";
-import type { CabiExportInfo, ParamDef } from "../codegen-linear/c-abi.js";
-import { emitCabiWrappers, mapParamsToCabi, mapResultToCabi } from "../codegen-linear/c-abi.js";
+import type { CabiExportInfo, ParamDef, TsSemanticType } from "../codegen-linear/c-abi.js";
+import { emitCabiWrappers, inferSemantic, mapParamsToCabi, mapResultToCabi } from "../codegen-linear/c-abi.js";
 import { generateModule } from "../codegen/index.js";
 import { extractCHeaderExports, generateCHeader } from "../emit/c-header.js";
 import { emitObject } from "../emit/object.js";
@@ -13,12 +13,40 @@ import type { Instr, ValType, WasmModule } from "../ir/types.js";
 import { buildImportManifest, DOWNGRADE_DIAG_CODES } from "./import-manifest.js";
 import { hasExportModifier, pushSourceAnchoredDiagnostic } from "./validation.js";
 
+/** TS-level type text for an exported function's params + return. */
+interface CabiTsTypes {
+  paramTypes: (string | undefined)[];
+  returnType: string | undefined;
+}
+
+/**
+ * Collect TS param/return type text for each exported top-level function so
+ * the C ABI transform can classify string/array aggregates (which lower to
+ * an i32 header pointer indistinguishable from a plain number at the Wasm
+ * level). Keyed by exported function name (#1835).
+ */
+function collectCabiTsTypes(ast: TypedAST): Map<string, CabiTsTypes> {
+  const map = new Map<string, CabiTsTypes>();
+  const sf = ast.sourceFile;
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name && hasExportModifier(stmt)) {
+      const paramTypes = stmt.parameters.map((p) => p.type?.getText(sf));
+      map.set(stmt.name.text, {
+        paramTypes,
+        returnType: stmt.type?.getText(sf),
+      });
+    }
+  }
+  return map;
+}
+
 /**
  * Apply C ABI transformation to a compiled WasmModule.
  * Rewrites exported function signatures for C compatibility and generates a C header.
  */
-function applyCabiTransform(mod: WasmModule, moduleName: string): { cHeader: string } {
+function applyCabiTransform(mod: WasmModule, moduleName: string, ast?: TypedAST): { cHeader: string } {
   const numImportFuncs = mod.imports.filter((i) => i.desc.kind === "func").length;
+  const tsTypes = ast ? collectCabiTsTypes(ast) : new Map<string, CabiTsTypes>();
 
   // Build CabiExportInfo for each exported function
   const exportInfos: CabiExportInfo[] = [];
@@ -34,24 +62,45 @@ function applyCabiTransform(mod: WasmModule, moduleName: string): { cHeader: str
     const typeDef = mod.types[func.typeIdx];
     if (!typeDef || typeDef.kind !== "func") continue;
 
+    // String/array params + returns lower to i32 header pointers, so we can
+    // only distinguish them from plain numbers using the TS source types.
+    // Only apply TS-type inference when the declared param count matches the
+    // Wasm param count — otherwise a prepended `this`/closure param would skew
+    // the mapping, so we fall back to scalar treatment (#1835).
+    const declared = tsTypes.get(exp.name);
+    const useTsTypes = declared !== undefined && declared.paramTypes.length === typeDef.params.length;
+
     // Build ParamDefs from the function type
-    // In linear memory mode: f64 = number, i32 = pointer (string/array/object)
-    // We infer semantics from the function name and wasm types
     const paramDefs: ParamDef[] = typeDef.params.map((wt, i) => {
-      // Without TS type info at this stage, we infer from wasm types:
-      // f64 → number, i32 → could be string/array/object/boolean
-      // For now, treat all i32 params as direct (caller provides i32)
-      const semantic = wt.kind === "f64" ? ("number_f64" as const) : ("number_i32" as const);
+      let semantic: TsSemanticType;
+      if (useTsTypes) {
+        semantic = inferSemantic(wt, declared!.paramTypes[i]);
+        // string/array lower to i32; if the TS type disagrees with the Wasm
+        // type (e.g. a number that happens to be i32), inferSemantic already
+        // reconciles via the wasmType, so the result is consistent.
+      } else {
+        semantic = wt.kind === "f64" ? "number_f64" : "number_i32";
+      }
       return { name: `p${i}`, wasmType: wt, semantic };
     });
 
     const cabiParams = mapParamsToCabi(paramDefs);
-    const resultSemantic =
-      typeDef.results.length === 0
-        ? ("void" as const)
-        : typeDef.results[0].kind === "f64"
-          ? ("number_f64" as const)
-          : ("number_i32" as const);
+
+    let resultSemantic: TsSemanticType | "void";
+    if (typeDef.results.length === 0) {
+      resultSemantic = "void";
+    } else if (useTsTypes && declared!.returnType) {
+      const inferred = inferSemantic(typeDef.results[0], declared!.returnType);
+      // A string/array return must be backed by an i32 header pointer.
+      resultSemantic =
+        (inferred === "string" || inferred === "array") && typeDef.results[0].kind !== "i32"
+          ? typeDef.results[0].kind === "f64"
+            ? "number_f64"
+            : "number_i32"
+          : inferred;
+    } else {
+      resultSemantic = typeDef.results[0].kind === "f64" ? "number_f64" : "number_i32";
+    }
     const cabiResult = mapResultToCabi(typeDef.results.length > 0 ? typeDef.results[0] : null, resultSemantic);
 
     const cabiName = exp.name; // mangleCabiName is identity for simple names

--- a/tests/issue-1835.test.ts
+++ b/tests/issue-1835.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1835 — C ABI string/array marshaling must use the verified linear-memory
+// header layout:
+//   string: [header 8B][len:u32 @ +8][utf8 bytes @ +12...]
+//   array:  [header 8B][len:u32 @ +8][cap:u32 @ +12][elems:i32×cap @ +16...]
+//
+// Return marshaling exposes (data ptr, len); param marshaling rehydrates an
+// internal header object from a raw (ptr, len) pair via __str_from_data /
+// __arr_from_data.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function decodeStr(mem: WebAssembly.Memory, ptr: number, len: number): string {
+  return new TextDecoder().decode(new Uint8Array(mem.buffer, ptr, len));
+}
+
+function writeStr(mem: WebAssembly.Memory, ptr: number, s: string): number {
+  const bytes = new TextEncoder().encode(s);
+  new Uint8Array(mem.buffer, ptr, bytes.length).set(bytes);
+  return bytes.length;
+}
+
+describe("#1835 C ABI string return marshaling", () => {
+  it("returns (dataPtr, len) pointing at the UTF-8 bytes, not into the header", async () => {
+    const result = await compile(`export function greet(): string { return "Hi"; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const mem = instance.exports.memory as WebAssembly.Memory;
+    const greet = instance.exports.greet as () => [number, number];
+    const ret = greet();
+    expect(Array.isArray(ret)).toBe(true);
+    const [ptr, len] = ret;
+    expect(len).toBe(2);
+    expect(decodeStr(mem, ptr, len)).toBe("Hi");
+  });
+
+  it("reports the correct length for a multi-byte string", async () => {
+    const result = await compile(`export function s(): string { return "hello world"; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const mem = instance.exports.memory as WebAssembly.Memory;
+    const [ptr, len] = (instance.exports.s as () => [number, number])();
+    expect(len).toBe(11);
+    expect(decodeStr(mem, ptr, len)).toBe("hello world");
+  });
+
+  it("emits a (T*, len) out-param signature in the C header for string returns", async () => {
+    const result = await compile(`export function greet(): string { return "Hi"; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    // Two i32 results → header expresses the second as an out-pointer.
+    expect(result.cHeader).toContain("greet(");
+    expect(result.cHeader).toContain("out_0");
+  });
+});
+
+describe("#1835 C ABI string param marshaling", () => {
+  it("rehydrates a string param from a raw (ptr, len) pair", async () => {
+    const result = await compile(`export function lenOf(s: string): number { return s.length; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const mem = instance.exports.memory as WebAssembly.Memory;
+    // Scratch region clear of the runtime heap.
+    const ptr = 60000;
+    const len = writeStr(mem, ptr, "hello");
+    const out = (instance.exports.lenOf as (p: number, l: number) => number)(ptr, len);
+    expect(out).toBe(5);
+  });
+
+  it("handles an empty-string param", async () => {
+    const result = await compile(`export function lenOf(s: string): number { return s.length; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const out = (instance.exports.lenOf as (p: number, l: number) => number)(60000, 0);
+    expect(out).toBe(0);
+  });
+});
+
+describe("#1835 C ABI array return marshaling", () => {
+  it("returns (dataPtr, len) pointing at the element block, not into the header", async () => {
+    const result = await compile(`export function mk(): number[] { return [10, 20, 30]; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const mem = instance.exports.memory as WebAssembly.Memory;
+    const ret = (instance.exports.mk as () => [number, number])();
+    expect(Array.isArray(ret)).toBe(true);
+    const [ptr, len] = ret;
+    expect(len).toBe(3);
+    // Elements are stored as i32 in the linear array runtime.
+    const ints = new Int32Array(mem.buffer, ptr, len);
+    expect(Array.from(ints)).toEqual([10, 20, 30]);
+  });
+});
+
+describe("#1835 scalar returns remain unaffected", () => {
+  it("number return is still a single direct value", async () => {
+    const result = await compile(`export function add(a: number, b: number): number { return a + b; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    expect((instance.exports.add as (a: number, b: number) => number)(3, 4)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem (#1835)

The C ABI wrapper used the wrong linear-memory header layout for `string`/`T[]`
I/O, so any WASI/C export taking or returning a string/array handed the host a
wrong length and a pointer into the middle of the header → OOB reads / corrupted
strings. The C ABI was effectively non-functional for string/array I/O.

The verified linear layout (`src/codegen-linear/runtime.ts`):
- string: `[header 8B][len:u32 @ +8][utf8 bytes @ +12...]`
- array:  `[header 8B][len:u32 @ +8][cap:u32 @ +12][elems:i32×cap @ +16...]`

But `c-abi.ts` loaded length at offset 0 and exposed `ptr+4` on return, and
forwarded a raw `(ptr,len)` to internal functions that expect a header object.

## Fix

- **Return marshaling**: load length at `+8`, expose data pointer at `+12`
  (string) or `+16` (array), selected from `info.result.semantic`. Offset
  constants are declared once and documented as mirroring `runtime.ts`.
- **Param marshaling**: rehydrate a string/array header object from the raw
  `(ptr,len)` pair via `__str_from_data` / `__arr_from_data` before calling the
  internal function. `CabiParam` carries an `aggregate` discriminator so the
  wrapper picks the right constructor.
- Added the `__arr_from_data(dataPtr,len) → headerPtr` runtime helper to
  `addArrayRuntime`.
- Threaded the typed AST into `applyCabiTransform` so string/array params and
  returns (which lower to i32 header pointers, otherwise indistinguishable from
  numbers) are classified from TS source types. Inference only applies when the
  declared param count matches the Wasm param count, so a prepended
  `this`/closure slot falls back to scalar treatment.
- Removed the dead `body.splice(body.length, 0)` no-op + unused `callIdx`
  (partial #1848 sweep).

## Tests

`tests/issue-1835.test.ts` — 7/7 pass:
- string return → `(dataPtr, len)` decodes correctly (`"Hi"`/2, `"hello world"`/11)
- string param rehydrated → `lenOf("hello") === 5`; empty string → `0`
- array return → `(dataPtr, len=3)`, elements `[10, 20, 30]` read directly
- scalar `add(3, 4) === 7` unaffected; C header emits out-param for string return

Existing `tests/c-abi.test.ts` (38) and linear-array/advanced/wasi suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)