### PR TITLE
fix(#1844): IR verifier recurses into nested if/try/loop buffers

### DIFF
--- a/plan/issues/1844-ir-verify-no-nested-buffer-recursion.md
+++ b/plan/issues/1844-ir-verify-no-nested-buffer-recursion.md
@@ -1,0 +1,64 @@
+---
+id: 1844
+title: "IR verify doesn't recurse into nested if/try/loop buffers (return-type gate + SSA holes) (residual #1798)"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: low
+feasibility: medium
+task_type: bugfix
+area: ir
+goal: correctness
+sprint: 59
+parent: 1798
+---
+# #1844 — IR verifier has a control-flow-nesting hole
+
+Defense-in-depth residual of #1798 (marked done, sprint 58).
+
+## Defect
+`src/ir/verify.ts:393-414` (`operandIrType`) and `:141-237`
+(`verifyBlock`/`collectUses`) scan only top-level `b.instrs`, never descending into
+nested `then`/`else`/`try`/`catch`/`finally`/`forof`/loop body buffers — while
+`registerInstrDefs` in lower.ts (`:347-376`) does. So the #1798 return-type
+assignability gate is bypassed for values defined inside those buffers
+(`actual===null` → `continue`), and SSA single-def/use-before-def invariants inside
+nested bodies are unchecked. A mismatch surfaces at instantiate-time (or a hard
+lower throw) instead of a clean legacy fallback.
+
+## Fix
+Make the verifier recurse into nested instr buffers (reuse the `registerInstrDefs`
+traversal).
+
+## Resolution
+Added two helpers to `src/ir/verify.ts`:
+- `nestedBuffers(instr)` — yields the direct nested instruction buffers carried
+  by an instr (then/else, loop cond/body/update, for-of body,
+  try/catch/finally), mirroring `registerInstrDefs` in lower.ts.
+- `forEachInstrDeep(instr, visit)` — recurses an instr and all its nested
+  buffers.
+
+Three consumers now recurse:
+1. **`operandIrType`** — `forEachInstrDeep` over every block's instrs, so a value
+   defined inside a nested buffer (e.g. a try body or if-arm) is found instead of
+   returning `null` and silently `continue`-ing past the #1798 return-type gate.
+2. **`verifyBlock`** — its straight-line walk was refactored into a recursive
+   `walkBuffer` that threads the same `localDefs`/`defs` accumulator into nested
+   buffers, so SSA duplicate-def + use-before-def + box/unbox/tag.test structural
+   checks all fire inside nested bodies. `while.loop`/`for.loop` walk their `cond`
+   buffer before validating the `condValue` use (the value is produced by the cond
+   buffer), avoiding a spurious use-before-def.
+
+## Test Results
+`tests/issue-1844.test.ts` (4 cases):
+- valid value defined inside an if-arm and returned via the if result → verifies clean (no false positive).
+- duplicate SSA def inside a nested if-arm → flagged (was missed pre-fix).
+- i32 value defined inside a try body returned from an f64-result function → #1798 return-type gate now fires (was bypassed pre-fix).
+- use-before-def inside a nested if-arm → flagged (was missed pre-fix).
+
+Pre-fix: 3/4 fail (the three bug cases slip past the verifier). Post-fix: 4/4 pass.
+IR-path smoke: `function f(a){ if(a>0){let x=a*2;return x;} else {return 0;} }` compiles
+through `experimentalIR` and runs correctly (f(5)=10, f(-3)=0). No demotion regression.
+Pre-existing unrelated IR test-harness failures (`__box_number` LinkError;
+`func.params is not iterable`) are identical with and without this change.

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -18,9 +18,49 @@
 // On failure, returns a list of `IrVerifyError`s rather than throwing, so
 // callers can decide whether to bail or fall back to the legacy path.
 
-import type { IrBlock, IrFunction, IrType, IrValueId } from "./nodes.js";
+import type { IrBlock, IrFunction, IrInstr, IrType, IrValueId } from "./nodes.js";
 import { asVal } from "./nodes.js";
 import type { ValType } from "./types.js";
+
+/**
+ * #1844 — Yield every direct nested instruction buffer carried by `instr`
+ * (then/else arms, loop cond/body/update, for-of bodies, try/catch/finally
+ * bodies). These buffers hold SSA defs and uses that live in their own
+ * emission-internal scope but must still satisfy the global SSA single-def
+ * invariant and the #1798 return-type gate. Mirrors the traversal in
+ * `registerInstrDefs` (lower.ts) so the verifier and lowerer agree on which
+ * buffers exist; if a new buffer-bearing instr kind is added, extend both.
+ */
+function nestedBuffers(instr: IrInstr): readonly (readonly IrInstr[])[] {
+  switch (instr.kind) {
+    case "if":
+      return [instr.then, instr.else];
+    case "forof.vec":
+    case "forof.iter":
+    case "forof.string":
+      return [instr.body];
+    case "while.loop":
+      return [instr.cond, instr.body];
+    case "for.loop":
+      return [instr.cond, instr.body, instr.update];
+    case "try": {
+      const bufs: (readonly IrInstr[])[] = [instr.body];
+      if (instr.catchClause) bufs.push(instr.catchClause.body);
+      if (instr.finallyBody) bufs.push(instr.finallyBody);
+      return bufs;
+    }
+    default:
+      return [];
+  }
+}
+
+/** Recursively visit `instr` and every instruction inside its nested buffers. */
+function forEachInstrDeep(instr: IrInstr, visit: (i: IrInstr) => void): void {
+  visit(instr);
+  for (const buf of nestedBuffers(instr)) {
+    for (const sub of buf) forEachInstrDeep(sub, visit);
+  }
+}
 
 export interface IrVerifyError {
   readonly message: string;
@@ -150,75 +190,112 @@ function verifyBlock(func: IrFunction, block: IrBlock, defs: Set<IrValueId>, err
     defs.add(arg);
   }
 
+  // Walk this block's instruction buffer, threading a `localDefs` set that
+  // accumulates every SSA value defined so far in straight-line order. #1844:
+  // nested if/try/loop/for-of buffers are walked recursively with the same
+  // accumulator so (a) their SSA single-def invariant is enforced against the
+  // global `defs` set, (b) use-before-def inside a nested body sees params,
+  // the enclosing block args, and outer values defined before the nesting
+  // instr, and (c) box/unbox/tag.test structural checks fire inside them too.
   const localDefs = new Set<IrValueId>();
-  for (const instr of block.instrs) {
-    // Use-before-def check within block (params + block args always count).
-    const uses = collectUses(instr);
-    for (const u of uses) {
-      const isParam = func.params.some((p) => p.value === u);
-      const isBlockArg = block.blockArgs.includes(u);
-      const isEarlier = localDefs.has(u);
-      if (!isParam && !isBlockArg && !isEarlier) {
-        errors.push({
-          message: `use of SSA value ${u} before def in block ${block.id as number}`,
-          func: func.name,
-          block: block.id as number,
-        });
-      }
+  const checkUse = (u: IrValueId): void => {
+    const isParam = func.params.some((p) => p.value === u);
+    const isBlockArg = block.blockArgs.includes(u);
+    const isEarlier = localDefs.has(u);
+    if (!isParam && !isBlockArg && !isEarlier) {
+      errors.push({
+        message: `use of SSA value ${u} before def in block ${block.id as number}`,
+        func: func.name,
+        block: block.id as number,
+      });
     }
+  };
+  const walkBuffer = (instrs: readonly IrInstr[]): void => {
+    for (const instr of instrs) {
+      // `while.loop` / `for.loop` surface `condValue` in `collectUses`, but
+      // that value is *produced by the cond buffer* (which `collectUses` for
+      // these kinds does not contain). Walk the cond buffer first so its def
+      // is registered before we validate the `condValue` use — otherwise it
+      // would spuriously read as use-before-def. (#1844)
+      if (instr.kind === "while.loop" || instr.kind === "for.loop") {
+        walkBuffer(instr.cond);
+      }
 
-    // Structural checks for the newly-added tagged-union instructions.
-    // These are type-system-level, not SSA-scope — misuse should surface
-    // here rather than silently lowering to a trap.
-    if (instr.kind === "box") {
-      if (instr.toType.kind !== "union") {
-        errors.push({
-          message: `box target must be a union IrType, got ${instr.toType.kind}`,
-          func: func.name,
-          block: block.id as number,
-        });
-      } else {
-        // box requires the operand's ValType to be a member of the union.
-        const operandT = operandValType(func, block, instr.value, localDefs);
-        if (operandT && !unionContains(instr.toType.members, operandT)) {
+      // Use-before-def check (params + block args always count). Nested-body
+      // uses additionally see anything registered in `localDefs` so far,
+      // which by construction includes the outer values defined before the
+      // enclosing nesting instr.
+      for (const u of collectUses(instr)) checkUse(u);
+
+      // Structural checks for the tagged-union instructions. These are
+      // type-system-level, not SSA-scope — misuse should surface here rather
+      // than silently lowering to a trap.
+      if (instr.kind === "box") {
+        if (instr.toType.kind !== "union") {
           errors.push({
-            message: `box operand type ${operandT.kind} is not a member of union<${instr.toType.members.map((m) => m.kind).join(",")}>`,
+            message: `box target must be a union IrType, got ${instr.toType.kind}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        } else {
+          // box requires the operand's ValType to be a member of the union.
+          const operandT = operandValType(func, block, instr.value, localDefs);
+          if (operandT && !unionContains(instr.toType.members, operandT)) {
+            errors.push({
+              message: `box operand type ${operandT.kind} is not a member of union<${instr.toType.members.map((m) => m.kind).join(",")}>`,
+              func: func.name,
+              block: block.id as number,
+            });
+          }
+        }
+      }
+      if (instr.kind === "unbox" || instr.kind === "tag.test") {
+        // value's defining IrType must be a union whose members contain `tag`.
+        const operandIr = operandIrType(func, block, instr.value, localDefs);
+        if (operandIr && operandIr.kind !== "union") {
+          errors.push({
+            message: `${instr.kind} operand must be a union IrType, got ${operandIr.kind}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        } else if (operandIr && !unionContains(operandIr.members, instr.tag)) {
+          errors.push({
+            message: `${instr.kind} tag ${instr.tag.kind} is not a member of union<${operandIr.members.map((m) => m.kind).join(",")}>`,
             func: func.name,
             block: block.id as number,
           });
         }
       }
-    }
-    if (instr.kind === "unbox" || instr.kind === "tag.test") {
-      // value's defining IrType must be a union whose members contain `tag`.
-      const operandIr = operandIrType(func, block, instr.value, localDefs);
-      if (operandIr && operandIr.kind !== "union") {
-        errors.push({
-          message: `${instr.kind} operand must be a union IrType, got ${operandIr.kind}`,
-          func: func.name,
-          block: block.id as number,
-        });
-      } else if (operandIr && !unionContains(operandIr.members, instr.tag)) {
-        errors.push({
-          message: `${instr.kind} tag ${instr.tag.kind} is not a member of union<${operandIr.members.map((m) => m.kind).join(",")}>`,
-          func: func.name,
-          block: block.id as number,
-        });
-      }
-    }
 
-    if (instr.result !== null) {
-      if (defs.has(instr.result)) {
-        errors.push({
-          message: `duplicate SSA def for value ${instr.result}`,
-          func: func.name,
-          block: block.id as number,
-        });
+      if (instr.result !== null) {
+        if (defs.has(instr.result)) {
+          errors.push({
+            message: `duplicate SSA def for value ${instr.result}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+        defs.add(instr.result);
+        localDefs.add(instr.result);
       }
-      defs.add(instr.result);
-      localDefs.add(instr.result);
+
+      // Descend into the remaining nested buffers (if-arms, loop body/update,
+      // for-of bodies, try/catch/finally). The nesting instr's own result is
+      // registered before we descend so an arm body may reference it. The
+      // loop `cond` buffer was already walked above, so skip it here.
+      if (instr.kind === "while.loop") {
+        walkBuffer(instr.body);
+      } else if (instr.kind === "for.loop") {
+        walkBuffer(instr.body);
+        walkBuffer(instr.update);
+      } else {
+        for (const buf of nestedBuffers(instr)) {
+          walkBuffer(buf);
+        }
+      }
     }
-  }
+  };
+  walkBuffer(block.instrs);
 
   // Terminator uses must resolve to params/blockargs/local defs.
   const termUses = collectTerminatorUses(block);
@@ -401,9 +478,17 @@ function operandIrType(
   }
   // Scan all blocks — the SSA invariant allows earlier-defined values from
   // predecessor blocks to be used here. A full dominator check is Phase-3.
+  // #1844: descend into nested if/try/loop/for-of buffers so a value defined
+  // inside one of them (e.g. an `if`-arm result feeding a `return`) is found
+  // here instead of returning `null` and silently bypassing the #1798
+  // return-type assignability gate.
+  let found: import("./nodes.js").IrType | null = null;
   for (const b of func.blocks) {
     for (const inst of b.instrs) {
-      if (inst.result === v && inst.resultType) return inst.resultType;
+      forEachInstrDeep(inst, (i) => {
+        if (found === null && i.result === v && i.resultType) found = i.resultType;
+      });
+      if (found !== null) return found;
     }
   }
   // Block args of the containing block carry types in `blockArgTypes`.

--- a/tests/issue-1844.test.ts
+++ b/tests/issue-1844.test.ts
@@ -1,0 +1,202 @@
+// #1844 — IR verifier must recurse into nested if/try/loop buffers.
+//
+// Before this fix, `verifyIrFunction` scanned only top-level `block.instrs`.
+// Values defined inside `then`/`else`/`try`/`catch`/`finally`/loop buffers
+// were invisible to:
+//   1. the #1798 return-type assignability gate (`operandIrType` returned
+//      `null` → the gate silently `continue`d), and
+//   2. the SSA single-def / use-before-def invariants.
+// So a malformed nested body slipped past the verifier and failed Wasm
+// validation only at instantiate time (or threw in the lowerer) instead of
+// demoting cleanly to legacy. These tests pin the recursion.
+
+import { describe, expect, it } from "vitest";
+
+import { asBlockId, asValueId, irVal, verifyIrFunction, type IrFunction, type IrInstr } from "../src/ir/index.js";
+
+const F64 = irVal({ kind: "f64" });
+const I32 = irVal({ kind: "i32" });
+
+function constF64(id: number, value: number): IrInstr {
+  return {
+    kind: "const",
+    value: { kind: "f64", value },
+    result: asValueId(id),
+    resultType: F64,
+  };
+}
+
+function constI32(id: number, value: number): IrInstr {
+  return {
+    kind: "const",
+    value: { kind: "i32", value },
+    result: asValueId(id),
+    resultType: I32,
+  };
+}
+
+describe("#1844 — IR verifier recurses into nested buffers", () => {
+  it("accepts a value defined inside an if-arm and returned via the if result", () => {
+    // function f(): f64 {
+    //   const cond = ...;  (id 1, supplied as param-free precomputed bool)
+    //   const r = if (cond) { const a = 1; a } else { const b = 2; b };
+    //   return r;
+    // }
+    const cond = asValueId(1);
+    const a = asValueId(2);
+    const b = asValueId(3);
+    const r = asValueId(4);
+    const fn: IrFunction = {
+      name: "f",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            { kind: "const", value: { kind: "bool", value: true }, result: cond, resultType: irVal({ kind: "i32" }) },
+            {
+              kind: "if",
+              cond,
+              then: [constF64(2, 1)],
+              thenValue: a,
+              else: [constF64(3, 2)],
+              elseValue: b,
+              result: r,
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [r] },
+        },
+      ],
+      exported: false,
+      valueCount: 8,
+    };
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("flags a duplicate SSA def that lives inside a nested if-arm", () => {
+    // value id 2 is defined twice: once at top level, once inside an if-arm.
+    const cond = asValueId(1);
+    const dup = asValueId(2);
+    const elseV = asValueId(3);
+    const ifRes = asValueId(4);
+    const fn: IrFunction = {
+      name: "dupNested",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            { kind: "const", value: { kind: "bool", value: true }, result: cond, resultType: irVal({ kind: "i32" }) },
+            constF64(2, 9), // top-level def of id 2
+            {
+              kind: "if",
+              cond,
+              then: [constF64(2, 1)], // duplicate def of id 2 inside the arm
+              thenValue: dup,
+              else: [constF64(3, 2)],
+              elseValue: elseV,
+              result: ifRes,
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [ifRes] },
+        },
+      ],
+      exported: false,
+      valueCount: 8,
+    };
+    const errors = verifyIrFunction(fn);
+    expect(errors.some((e) => e.message.includes("duplicate SSA def for value"))).toBe(true);
+  });
+
+  it("fires the #1798 return-type gate on a value defined inside a try body", () => {
+    // function g(): f64 { try { const x = <i32 1>; return x; } ... }
+    // The returned value `x` is i32 but the declared result is f64 — invalid.
+    // Pre-fix this slipped past because `operandIrType` never scanned the try
+    // body, returned null, and the gate `continue`d.
+    const x = asValueId(1);
+    const fn: IrFunction = {
+      name: "g",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            {
+              kind: "try",
+              body: [constI32(1, 1)],
+              result: null,
+              resultType: null,
+            },
+          ],
+          // The return references a value defined inside the try body.
+          terminator: { kind: "return", values: [x] },
+        },
+      ],
+      exported: false,
+      valueCount: 8,
+    };
+    const errors = verifyIrFunction(fn);
+    expect(errors.some((e) => e.message.includes("not assignable to declared result"))).toBe(true);
+  });
+
+  it("flags use-before-def inside a nested if-arm", () => {
+    // Inside the if-arm, an instruction references an SSA value (id 7) that is
+    // never defined anywhere — must be reported, not silently ignored.
+    const cond = asValueId(1);
+    const undef = asValueId(7);
+    const sum = asValueId(2);
+    const elseV = asValueId(3);
+    const ifRes = asValueId(4);
+    const fn: IrFunction = {
+      name: "useBeforeDefNested",
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            { kind: "const", value: { kind: "bool", value: true }, result: cond, resultType: irVal({ kind: "i32" }) },
+            {
+              kind: "if",
+              cond,
+              // `binary` uses id 7 (undef) and id 7 again — never defined.
+              then: [
+                {
+                  kind: "binary",
+                  op: "f64.add",
+                  lhs: undef,
+                  rhs: undef,
+                  result: sum,
+                  resultType: F64,
+                } as IrInstr,
+              ],
+              thenValue: sum,
+              else: [constF64(3, 2)],
+              elseValue: elseV,
+              result: ifRes,
+              resultType: F64,
+            },
+          ],
+          terminator: { kind: "return", values: [ifRes] },
+        },
+      ],
+      exported: false,
+      valueCount: 8,
+    };
+    const errors = verifyIrFunction(fn);
+    expect(errors.some((e) => e.message.includes("before def"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The IR verifier (`src/ir/verify.ts`) scanned only top-level `block.instrs` and never descended into nested `then`/`else`/`try`/`catch`/`finally`/`for-of`/loop body buffers — while `registerInstrDefs` in `lower.ts` does. So:
- the #1798 return-type assignability gate was **bypassed** for values defined inside those buffers (`operandIrType` returned `null` → the gate silently `continue`d), and
- the SSA single-def / use-before-def invariants inside nested bodies were unchecked.

A malformed nested body slipped past the verifier and failed Wasm validation only at instantiate time (or threw in the lowerer) instead of demoting cleanly to legacy. Defense-in-depth residual of #1798.

## Fix
- Add `nestedBuffers(instr)` + `forEachInstrDeep(instr, visit)` mirroring the buffer traversal in `registerInstrDefs` (lower.ts).
- `operandIrType` recurses into nested buffers, so a value defined inside an if-arm / try body / loop body is found instead of returning `null` and bypassing the #1798 gate.
- `verifyBlock`'s straight-line walk is refactored into a recursive `walkBuffer` that threads the same `localDefs`/`defs` accumulator into nested buffers — SSA duplicate-def, use-before-def, and box/unbox/tag.test structural checks now fire inside nested bodies.
- `while.loop`/`for.loop` walk their `cond` buffer before validating the `condValue` use (the value is produced by the cond buffer), avoiding a spurious use-before-def.

## Tests
`tests/issue-1844.test.ts` (4 cases): valid nested-if return (no false positive), duplicate SSA def inside an if-arm, i32 value defined in a try body returned from an f64-result function (#1798 gate), use-before-def inside an if-arm.

Pre-fix: 3/4 fail (the bug cases slip past the verifier). Post-fix: 4/4 pass. Verified the failing cases reproduce on unmodified `verify.ts`.

No demotion regression: a nested-if IR-path function still compiles via `experimentalIR` and runs correctly (`f(5)=10`, `f(-3)=0`). Pre-existing unrelated IR test-harness failures (`__box_number` LinkError; `func.params is not iterable`) are identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)