### PR TITLE
fix(#1825,#1834,#1826): i32 % trap guard; saturating vec-write trunc; ToPrimitive undefined sentinel

### DIFF
--- a/plan/issues/1825-i32-fast-mode-modulo-traps.md
+++ b/plan/issues/1825-i32-fast-mode-modulo-traps.md
@@ -1,0 +1,42 @@
+---
+id: 1825
+title: "i32 fast-mode % emits trapping i32.rem_s (x % 0 traps instead of NaN)"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: compilable
+sprint: 59
+---
+# #1825 — i32 fast-mode `%` emits trapping `i32.rem_s`
+
+## Symptom
+In fast / native-i32 mode, `a % b` with `b == 0` traps (Wasm), and
+`-2147483648 % -1` traps. JS yields `NaN` and `0` respectively.
+
+## Location
+`src/codegen/binary-ops.ts` (`compileI32BinaryOp` PercentToken →
+`i32.rem_s`), reachable via the i32 fast-path dispatch (`isDivOrPow` excludes `/`
+and `**` but **not** `%`).
+
+## Spec
+ECMAScript §6.1.6.1.6 Number::remainder (d=0 ⇒ NaN; no overflow concept).
+
+## Fix
+Routed the `%` i32 fast path through a new `emitSafeI32Rem(fctx)` helper in
+`binary-ops.ts`. It guards both trapping cases of `i32.rem_s`:
+- `b == 0` → emit `0` (JS yields NaN; i32 fast mode has no NaN representation,
+  and the i32 truncation of NaN is 0).
+- `a == INT_MIN && b == -1` → emit `0` (the mathematically-correct result; bare
+  `i32.rem_s` traps on signed overflow here).
+Otherwise emits `i32.rem_s` as before. Result type stays `i32` so no downstream
+signature changes.
+
+## Test Results
+`tests/issue-1825.test.ts` — i32 fast-mode modulo block (5 cases): normal `%`,
+negative-dividend sign, `% 0` (returns 0, no trap), `INT_MIN % -1` (returns 0,
+no trap), and `% 0` with computed operands inside a loop. All pass.

--- a/plan/issues/1826-toprimitive-valueof-undefined-treated-absent.md
+++ b/plan/issues/1826-toprimitive-valueof-undefined-treated-absent.md
@@ -1,0 +1,58 @@
+---
+id: 1826
+title: "OrdinaryToPrimitive treats valueOf/toString returning undefined as method-absent"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: runtime
+goal: correctness
+sprint: 59
+---
+# #1826 — `valueOf` returning `undefined` is treated as "absent"
+
+## Symptom
+`({valueOf(){return undefined}, toString(){return "x"}}) + ""` → `"x"` instead of
+`"undefined"` — a method legitimately returning the primitive `undefined` is
+skipped and the next method is consulted.
+
+## Location
+`src/runtime.ts`: `tryMethod` (inside `_toPrimitive`) returned JS `undefined`
+both for "absent / returned an object / dispatch trapped" and a real `undefined`
+primitive; the caller treated `undefined` as "try the next method."
+
+## Spec
+ECMAScript §7.1.1.1 OrdinaryToPrimitive steps 5-6 (any non-Object return is the result).
+
+## Fix
+Introduced a module-private `_PRIM_ABSENT` unique-symbol sentinel. `tryMethod`
+now returns `_PRIM_ABSENT` for the absent / returned-object / dispatch-trapped
+cases, and the produced primitive (including a real `undefined`) otherwise. The
+valueOf/toString selection in `_toPrimitive` checks `!== _PRIM_ABSENT` so a
+method that returns the primitive `undefined` is honored rather than skipped.
+
+## Notes / residual depth (out of scope here)
+The cited `tryMethod` distinction is fixed. Fully observing it end-to-end on the
+common surface syntaxes is gated on two adjacent concerns that are **not** part
+of this issue:
+- The 13 `_toPrimitive` callers branch on `prim !== undefined` (not the
+  sentinel), so the function's external contract still collapses to `undefined`
+  for not-found. A follow-up could thread `_PRIM_ABSENT` through those callers
+  (higher risk: a leaked symbol into `String()` throws), but that exceeds this
+  issue's scope.
+- A WasmGC closure returning `undefined` marshals to host `null` at the
+  Wasm↔host boundary, so `String(o)` on a struct whose method returns
+  `undefined` currently yields `"null"` — a separate marshaling concern.
+- Many `+ ""` / `String()` forms are statically folded in codegen (no runtime
+  ToPrimitive call) by the #1470 any→string work, so they bypass this path.
+
+## Test Results
+Existing ToPrimitive regression suites pass unchanged with the sentinel:
+`tests/issue-1253`, `tests/issue-1319`, `tests/issue-1716`, `tests/issue-1090`,
+`tests/issue-850`, `tests/issue-866`, `tests/issue-983-opaque`, `tests/issue-1434`,
+`tests/issue-1732-math-symbol-coercion`. `tests/issue-1128` test #2 was a stale
+expectation documenting a since-fixed (#1470) limitation; updated to the
+spec-correct `"hello world"`.

--- a/plan/issues/1834-vec-element-write-trapping-trunc.md
+++ b/plan/issues/1834-vec-element-write-trapping-trunc.md
@@ -1,0 +1,33 @@
+---
+id: 1834
+title: "Vec element-write/length index uses trapping i32.trunc_f64_s instead of saturating"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: medium
+feasibility: low
+task_type: bugfix
+area: codegen
+goal: compilable
+sprint: 59
+---
+# #1834 — element-write index uses trapping truncation
+
+## Symptom
+A NaN / non-integer / out-of-range index in destructuring element-assignment (or
+`arr.length = N`) traps the module instead of being clamped.
+
+## Location
+`src/codegen/expressions/assignment.ts` — the element-access index path and the
+`arr.length = N` path used `i32.trunc_f64_s`. Every other index/length
+conversion in the file uses `i32.trunc_sat_f64_s`.
+
+## Fix
+Both sites now emit `i32.trunc_sat_f64_s`, matching the rest of the file:
+NaN/Infinity/out-of-range clamp instead of trapping.
+
+## Test Results
+`tests/issue-1825.test.ts` — vec write-index block (3 cases): `arr.length = NaN`
+→ 0 (no trap), `arr.length = 1e30` → clamps to i32 max (no trap), normal
+`arr.length = 2` → 2. All pass.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -2335,7 +2335,12 @@ function compileI32BinaryOp(
       fctx.body.push({ op: "i32.mul" });
       return { kind: "i32" };
     case ts.SyntaxKind.PercentToken:
-      fctx.body.push({ op: "i32.rem_s" });
+      // Guard the trapping cases of i32.rem_s. Wasm traps on `b == 0` and on
+      // `INT_MIN % -1` (signed overflow). JS yields NaN and 0 respectively; in
+      // i32 fast mode the result is an i32 (no NaN representation), so emit 0
+      // for both trapping cases (0 is the mathematically-correct INT_MIN % -1
+      // result, and truncating JS's NaN result to i32 is also 0). See #1825.
+      emitSafeI32Rem(fctx);
       return { kind: "i32" };
     case ts.SyntaxKind.EqualsEqualsEqualsToken:
     case ts.SyntaxKind.EqualsEqualsToken:
@@ -2605,6 +2610,53 @@ export function emitModulo(fctx: FunctionContext): void {
     then: thenInstrs,
     else: elseInstrs,
   });
+  releaseTempLocal(fctx, tmpA);
+  releaseTempLocal(fctx, tmpB);
+}
+
+/**
+ * Emit `a % b` on i32 operands without the Wasm traps of bare `i32.rem_s`.
+ *
+ * `i32.rem_s` traps when `b == 0` and on the signed-overflow case
+ * `INT_MIN % -1`. JS yields NaN and 0 respectively for the corresponding
+ * Number operation; in i32 fast mode the result must be an i32 (no NaN
+ * representation), so we emit 0 for both trapping cases. 0 is the
+ * mathematically-correct value for `INT_MIN % -1`, and the i32 truncation of
+ * JS's NaN result is also 0, so this is the least-surprising i32 behaviour.
+ *
+ * Stack: [a_i32, b_i32] -> [result_i32]. See #1825.
+ */
+export function emitSafeI32Rem(fctx: FunctionContext): void {
+  const tmpB = allocTempLocal(fctx, { kind: "i32" });
+  const tmpA = allocTempLocal(fctx, { kind: "i32" });
+  fctx.body.push({ op: "local.set", index: tmpB });
+  fctx.body.push({ op: "local.set", index: tmpA });
+
+  // safeToRem = (b != 0) && !(a == INT_MIN && b == -1)
+  // b == 0  -> trap (div by zero)
+  fctx.body.push({ op: "local.get", index: tmpB });
+  fctx.body.push({ op: "i32.eqz" });
+  // a == INT_MIN
+  fctx.body.push({ op: "local.get", index: tmpA });
+  fctx.body.push({ op: "i32.const", value: -2147483648 });
+  fctx.body.push({ op: "i32.eq" });
+  // b == -1
+  fctx.body.push({ op: "local.get", index: tmpB });
+  fctx.body.push({ op: "i32.const", value: -1 });
+  fctx.body.push({ op: "i32.eq" });
+  // (a == INT_MIN) & (b == -1)
+  fctx.body.push({ op: "i32.and" });
+  // (b == 0) | (overflow)  -> the "trapping" condition
+  fctx.body.push({ op: "i32.or" });
+
+  // if (trapping) 0 else a % b
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "i32.const", value: 0 }],
+    else: [{ op: "local.get", index: tmpA }, { op: "local.get", index: tmpB }, { op: "i32.rem_s" }],
+  });
+
   releaseTempLocal(fctx, tmpA);
   releaseTempLocal(fctx, tmpB);
 }

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -1802,7 +1802,10 @@ function emitAssignToTarget(
       const idxResult = compileExpression(ctx, fctx, target.argumentExpression);
       if (!idxResult) return;
       if (idxResult.kind === "f64") {
-        fctx.body.push({ op: "i32.trunc_f64_s" } as Instr);
+        // Saturating truncation: NaN/Infinity/out-of-range indices clamp
+        // instead of trapping the module. Matches every other index/length
+        // conversion in this file (#1834).
+        fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
       }
       const idxTmp = allocLocal(fctx, `__dstr_idx_${fctx.locals.length}`, {
         kind: "i32",
@@ -2302,7 +2305,10 @@ function compilePropertyAssignment(
       // Convert f64 to i32 if needed
       const newLenTmp = allocLocal(fctx, `__arr_len_set_nl_${fctx.locals.length}`, { kind: "i32" });
       if (valType.kind === "f64") {
-        fctx.body.push({ op: "i32.trunc_f64_s" as any });
+        // Saturating truncation: NaN/Infinity/out-of-range lengths clamp
+        // instead of trapping the module. Matches every other length
+        // conversion in this file (#1834).
+        fctx.body.push({ op: "i32.trunc_sat_f64_s" as any });
       }
       fctx.body.push({ op: "local.set", index: newLenTmp });
       // Set vec.length = newLen

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1866,6 +1866,15 @@ function _sidecarDelete(obj: any, key: any): boolean {
 }
 
 /**
+ * Sentinel for OrdinaryToPrimitive's `tryMethod`: distinguishes "method is
+ * absent / returned an Object / dispatch trapped" (try the next method) from a
+ * method that legitimately returned the primitive `undefined`. Without it, a
+ * real `undefined` return is wrongly treated as "absent" and the next method is
+ * consulted (#1826). Per §7.1.1.1 steps 5-6, any non-Object return is the result.
+ */
+const _PRIM_ABSENT: unique symbol = Symbol("toPrimitive-method-absent");
+
+/**
  * ToPrimitive for WasmGC structs (#850).
  *
  * Implements the JS ToPrimitive abstract operation for opaque WasmGC struct
@@ -1939,7 +1948,11 @@ function _toPrimitive(
 
   const exports = callbackState?.getExports();
 
-  // Helper: try valueOf or toString from sidecar then Wasm exports
+  // Helper: try valueOf or toString from sidecar then Wasm exports.
+  // Returns the produced primitive (including a real `undefined`!) or the
+  // `_PRIM_ABSENT` sentinel when the method is absent, returned an Object, or
+  // dispatch trapped — only then should the caller consult the next method
+  // (§7.1.1.1 steps 5-6, #1826).
   const tryMethod = (name: string): any => {
     // Sidecar property (set via __extern_set)
     // User-thrown errors propagate — spec requires assert.throws to observe them.
@@ -1948,7 +1961,7 @@ function _toPrimitive(
       const prim = scFn.call(raw);
       if (prim == null || typeof prim !== "object") return prim;
       // Returned an object — not a valid primitive, try next method
-      return undefined;
+      return _PRIM_ABSENT;
     }
     // Sidecar value is a WasmGC closure struct — dispatch via generic callers (#1090)
     if (scFn != null && typeof scFn === "object" && _isWasmStruct(scFn) && exports) {
@@ -1958,7 +1971,7 @@ function _toPrimitive(
         try {
           const prim = callFn0(scFn);
           if (prim == null || typeof prim !== "object") return prim;
-          return undefined; // returned an object — not valid
+          return _PRIM_ABSENT; // returned an object — not valid
         } catch (e: any) {
           if (!(e instanceof WebAssembly.RuntimeError)) throw e;
         }
@@ -1969,7 +1982,7 @@ function _toPrimitive(
         try {
           const prim = callFn(raw);
           if (prim == null || typeof prim !== "object") return prim;
-          return undefined;
+          return _PRIM_ABSENT;
         } catch (e: any) {
           if (!(e instanceof WebAssembly.RuntimeError)) throw e;
         }
@@ -1985,7 +1998,7 @@ function _toPrimitive(
         try {
           field = sget(raw);
         } catch (e: any) {
-          if (e instanceof WebAssembly.RuntimeError) return undefined;
+          if (e instanceof WebAssembly.RuntimeError) return _PRIM_ABSENT;
           throw e;
         }
         if (typeof field === "function") {
@@ -2019,20 +2032,22 @@ function _toPrimitive(
         }
       }
     }
-    return undefined;
+    return _PRIM_ABSENT;
   };
 
-  // Per JS spec: "string" hint -> toString first; "number"/"default" -> valueOf first
+  // Per JS spec: "string" hint -> toString first; "number"/"default" -> valueOf first.
+  // A method that produces ANY primitive (including `undefined`) is the result;
+  // only `_PRIM_ABSENT` means "consult the next method" (#1826).
   if (hint === "string") {
     const ts = tryMethod("toString");
-    if (ts !== undefined) return ts;
+    if (ts !== _PRIM_ABSENT) return ts;
     const vo = tryMethod("valueOf");
-    if (vo !== undefined) return vo;
+    if (vo !== _PRIM_ABSENT) return vo;
   } else {
     const vo = tryMethod("valueOf");
-    if (vo !== undefined) return vo;
+    if (vo !== _PRIM_ABSENT) return vo;
     const ts = tryMethod("toString");
-    if (ts !== undefined) return ts;
+    if (ts !== _PRIM_ABSENT) return ts;
   }
 
   return undefined;

--- a/tests/issue-1128.test.ts
+++ b/tests/issue-1128.test.ts
@@ -21,21 +21,19 @@ describe("#1128 — OrdinaryToPrimitive TypeError per §7.1.1.1", () => {
     expect(result).toBe("hello");
   });
 
-  test("_toPrimitiveSync falls back to [object Object] for WasmGC structs without sidecar", async () => {
-    // String concatenation uses _toPrimitiveSync in the concat host import.
-    // _toPrimitiveSync doesn't have callbackState, so it can't dispatch through
-    // Wasm exports. For WasmGC structs, it falls back to "[object Object]" which
-    // is safe (no crash, no TypeError) even though the struct has a compiled toString.
-    // This is a known limitation — full ToPrimitive requires callbackState.
+  test("string concat resolves a compiled toString to its return value", async () => {
+    // Previously a documented limitation: `_toPrimitiveSync` (used by the concat
+    // host import) had no callbackState and fell back to "[object Object]" for a
+    // WasmGC struct with a compiled toString. The #1470 any→string work now
+    // resolves the struct's toString at compile time, so this folds to the
+    // spec-correct "hello world".
     const result = await compileAndRun(`
       export function test(): string {
         const obj = { toString() { return "world"; } };
         return "hello " + obj;
       }
     `);
-    // Pre-existing limitation: _toPrimitiveSync can't dispatch compiled toString
-    // without callbackState, so falls back to "[object Object]".
-    expect(result).toBe("hello [object Object]");
+    expect(result).toBe("hello world");
   });
 
   test("_toPrimitiveSync throws TypeError for JS objects without valueOf/toString", () => {

--- a/tests/issue-1825.test.ts
+++ b/tests/issue-1825.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runFast(source: string, exportName = "test"): Promise<any> {
+  const result = await compile(source, { fast: true });
+  if (!result.success) throw new Error(result.errors.map((e) => e.message).join("\n"));
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env);
+  return (instance.exports[exportName] as Function)();
+}
+
+async function run(source: string, exportName = "test"): Promise<any> {
+  const result = await compile(source);
+  if (!result.success) throw new Error(result.errors.map((e) => e.message).join("\n"));
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env);
+  return (instance.exports[exportName] as Function)();
+}
+
+// #1825 — i32 fast-mode `%` must not emit a trapping i32.rem_s.
+describe("#1825 — i32 fast-mode modulo does not trap", () => {
+  it("normal modulo still works", async () => {
+    expect(await runFast(`export function test(): number { return 10 % 3; }`)).toBe(1);
+  });
+
+  it("negative dividend modulo (sign of dividend)", async () => {
+    expect(await runFast(`export function test(): number { return -7 % 3; }`)).toBe(-1);
+  });
+
+  it("modulo by zero does not trap (returns 0 in i32 mode)", async () => {
+    // JS yields NaN; i32 fast mode has no NaN, so the guard returns 0 instead
+    // of trapping the module.
+    const src = `export function test(): number { let a = 10; let b = 0; return a % b; }`;
+    expect(await runFast(src)).toBe(0);
+  });
+
+  it("INT_MIN % -1 does not trap (overflow guard, result 0)", async () => {
+    const src = `export function test(): number { let a = -2147483648; let b = -1; return a % b; }`;
+    expect(await runFast(src)).toBe(0);
+  });
+
+  it("modulo by zero with computed operands does not trap", async () => {
+    const src = `export function test(): number {
+      let total = 0;
+      for (let i = 0; i < 4; i++) {
+        let d = i - 2; // hits 0 when i === 2
+        total = total + (10 % d);
+      }
+      return total;
+    }`;
+    // i=0: 10%-2=0 ; i=1: 10%-1=0 ; i=2: 10%0=0(guard) ; i=3: 10%1=0
+    expect(await runFast(src)).toBe(0);
+  });
+});
+
+// #1834 — element-write / length-set index uses saturating truncation.
+describe("#1834 — vec write index uses saturating truncation", () => {
+  it("arr.length = NaN does not trap", async () => {
+    const src = `export function test(): number {
+      const arr = [1, 2, 3];
+      arr.length = NaN;
+      return arr.length;
+    }`;
+    // trunc_sat(NaN) === 0
+    expect(await run(src)).toBe(0);
+  });
+
+  it("arr.length = Infinity does not trap", async () => {
+    const src = `export function test(): number {
+      const arr = [1, 2, 3];
+      arr.length = 1e30;
+      return arr.length;
+    }`;
+    // trunc_sat clamps to i32 max instead of trapping
+    expect(await run(src)).toBe(2147483647);
+  });
+
+  it("normal arr.length set still works", async () => {
+    const src = `export function test(): number {
+      const arr = [1, 2, 3, 4, 5];
+      arr.length = 2;
+      return arr.length;
+    }`;
+    expect(await run(src)).toBe(2);
+  });
+});


### PR DESCRIPTION
Three scoped sprint-59 codegen/runtime correctness fixes (task #99).

## #1825 — i32 fast-mode `%` traps
In fast/native-i32 mode `a % b` lowered to bare `i32.rem_s`, which **traps** on
`b == 0` and on the signed-overflow case `INT_MIN % -1` (JS yields NaN and 0).
Routed the `%` i32 path through a new `emitSafeI32Rem(fctx)` in
`src/codegen/binary-ops.ts` that guards both cases and emits `0` (no NaN
representation in i32 mode; `0` is also the exact `INT_MIN % -1` result). Result
type stays `i32`.

## #1834 — trapping truncation on vec write index / length
`src/codegen/expressions/assignment.ts` used trapping `i32.trunc_f64_s` for the
destructuring element-write index and for `arr.length = N`, while every other
index/length conversion in the file uses saturating `i32.trunc_sat_f64_s`. Both
sites now use the saturating form, so NaN/Infinity/out-of-range clamp instead of
trapping the module.

## #1826 — ToPrimitive treats a `undefined` return as method-absent
`tryMethod` inside `_toPrimitive` (`src/runtime.ts`) returned JS `undefined` for
both "method absent / returned an object / dispatch trapped" and a method that
legitimately returned the primitive `undefined`, so the selection logic skipped
a real `undefined` and consulted the next method (§7.1.1.1 steps 5-6). Added a
`_PRIM_ABSENT` unique-symbol sentinel: `tryMethod` returns it for the absent
cases and the produced primitive (incl. `undefined`) otherwise; the
valueOf/toString selection checks `!== _PRIM_ABSENT`. (Residual depth — the 13
`_toPrimitive` callers' own `!== undefined` checks and the Wasm→host
`undefined`→`null` marshaling — is documented in the issue file as out of scope.)

## Tests
- New `tests/issue-1825.test.ts` (8 cases): i32 `% 0` / `INT_MIN % -1` / loop no
  longer trap; `arr.length = NaN`/`1e30` clamp; normal `%` and `arr.length` still
  correct.
- `tests/issue-1128.test.ts` test #2 updated: its expectation documented a
  since-fixed (#1470 any→string) limitation; now asserts the spec-correct
  `"hello world"` (the concat is statically folded; not from this PR's runtime
  change).
- Regression-checked unchanged: issue-1253/1319/1716/1090 ToPrimitive suites.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)