### PR TITLE
docs(architecture): compiler-design lessons + structure/language review; file follow-up issues #1850-1859

### DIFF
--- a/docs/architecture/compiler-design-lessons.md
+++ b/docs/architecture/compiler-design-lessons.md
@@ -1,0 +1,544 @@
+# What we can learn from general compiler design
+
+> A vendor-neutral synthesis of durable patterns from production language
+> runtimes, optimizing-compiler infrastructure, the SSA/IR literature, and
+> ahead-of-time source→bytecode compilers — distilled into recommendations
+> for **this** compiler (typed SSA middle-end with block arguments,
+> late-resolved symbolic refs, multiple backends behind a `BackendEmitter`
+> trait, staged AST-kind adoption gated by a fallback ratchet).
+>
+> Companion to [`codegen-axes.md`](codegen-axes.md). That doc tells you
+> *which axis your change is on*; this one tells you *which direction the
+> field says to push*. No competitor projects are named — only the patterns
+> that recur across all of them, with our own architecture as the subject.
+>
+> Read time ~15 min. The TL;DR is the next section; the prioritized action
+> table is at the bottom.
+
+---
+
+## The one idea everything else hangs on
+
+A dynamically-typed runtime spends enormous machinery **discovering at run
+time** what our compiler **already knows at compile time from TypeScript
+types**: object shapes, monomorphic call targets, numeric widths, whether a
+value can be `null`. The single most transferable lesson is therefore *not*
+"copy what fast runtimes do." It is:
+
+> **Keep the *code shape* a fast runtime arrives at (fixed-slot structs,
+> direct calls, unboxed arithmetic) — and delete the *discovery machinery*
+> that gets it there (type feedback, inline caches, speculation,
+> deoptimization, tiering).**
+
+Static types are the runtime's "profile data," handed to us for free and
+known to be total. Our job is to *compile the dynamism away* — exactly the
+project's existing `feedback_compile_away` principle — and fall back to a
+general dynamic representation only where the types genuinely run out.
+
+Everything below is a corollary of that idea or of the discipline needed to
+sustain a staged migration toward it.
+
+---
+
+## Where we already align with the consensus (don't re-litigate these)
+
+These are settled questions in the field, and our existing choices are the
+*modern* answers. Flag for new contributors so they aren't re-opened:
+
+1. **CFG + SSA with block arguments** is the representation the field
+   converged on. The most aggressive graph-based alternative
+   ("everything floats, recover an order later") was tried at the largest
+   scale and **abandoned** for a conventional CFG+SSA form: cited reasons
+   were an unintuitive mental model, fragile effect-ordering bugs that hid
+   for months, cache-unfriendly traversal, and ~2× compile time — with the
+   move back *halving* compile time and making bugs tractable. Our IR is
+   already block-argument SSA. **Do not drift toward a "sea of nodes" for
+   "more optimization freedom."** We delegate heavy optimization downstream
+   (see R8), so that freedom would be pure cost.
+
+2. **Block arguments over Φ-nodes.** Representationally identical, but Φ
+   carries special cases (must cluster at block top, parallel-execution
+   semantics, function params as a *separate* concept, positional operand↔
+   predecessor coupling) that block arguments define away. Our entry block's
+   arguments *are* the function parameters — one concept, not two — and
+   merge values are ordinary typed parameters threaded through branches,
+   which suits our **late symbolic-ref resolution** perfectly.
+
+3. **A typed IR replacing accumulated direct-codegen hacks.** With *N*
+   backends, direct AST→target codegen costs `features × targets` untyped
+   special-cases; a typed mid-level waist collapses that to
+   `features + targets` typed, verifiable passes. We have two real backends
+   (three emitters) — so this abstraction is *justified by genuine variety*,
+   not speculation.
+
+4. **A host-optional dual mode with standalone fallbacks** (dual string
+   backend, dual RegExp backend). The field's rule for host imports matches
+   ours exactly (R9).
+
+5. **Delegating heavy optimization to a mature external optimizer.** Correct
+   division of labor (R8).
+
+If you find yourself arguing against one of these, the burden of proof is
+high — the field has the receipts.
+
+---
+
+## Recommendations
+
+Each is: **the general pattern → why it matters → our current state →
+concrete action.** Priority tags: **[P1]** do soon / high leverage,
+**[P2]** worthwhile, **[P3]** opportunistic.
+
+### R1 — Treat the IR verifier as a hard contract between every pass [P1]
+
+**Pattern.** Define a formal IR invariant verifier and run it *between
+passes*: each pass may **assume** valid input and **must** produce valid
+output. A pass that emits invalid IR has a bug, attributed to *that pass* —
+not to whatever consumes the garbage three layers later. Keep checks *local*
+(don't walk def-use chains in the verifier); when many passes re-check the
+same thing, promote it into the verifier or into the IR type.
+
+**Why.** This is the single highest-leverage practice for a staged
+migration. The fallback ratchet measures *coverage*; the verifier measures
+*correctness of what was covered*. It turns "malformed Wasm reached the
+backend" into an immediate, localized failure.
+
+**Our state — already started, finish it.** `src/ir/verify.ts`
+(`verifyIrFunction`) already enforces SSA single-definition, use-before-def,
+one-terminator-per-block, branch-arg arity against target signatures, and
+symbolic-refs-only (no raw indices). It is already invoked pre- and
+post-pass in `integration.ts` (including `postErrors` after optimization).
+This is exactly the right backbone.
+
+**Action.**
+- Close the explicit Phase 2 gaps in `verify.ts`: **cross-block use /
+  dominance** ("every use is dominated by its def") is currently a TODO.
+  Until it lands, a whole class of SSA-violation bugs is invisible.
+- Add a **per-backend legality check** at the emit boundary: "is this IR
+  legal for *this* target?" (e.g. a struct-allocation node is legal under
+  the GC backend, illegal under linear where it must be rewritten). This
+  catches "fine for one backend, illegal for another" at the IR boundary
+  instead of as a downstream Wasm-validation failure.
+- Make verifier failure **fail CI in debug/test builds**, not just feed the
+  fallback decision. A demotion-on-verify-failure that nobody counts is a
+  silent bug (see R6).
+
+### R2 — Make illegal IR states unrepresentable in the type, not merely detected [P1]
+
+**Pattern.** Prefer encoding an invariant in the data type (so an illegal
+combination is *unconstructible*) over a runtime assert (so it's only
+*detected*). "Make illegal states unrepresentable." Every invariant the host
+type system enforces is one you never verify at runtime and never debug.
+
+**Why.** It shrinks the verifier surface and eliminates whole bug classes at
+the source. It's the structural complement to R1.
+
+**Our state.** The discriminated `IrType` union is the right lever; we
+already lean on exhaustive `switch`. Some states are still "valid by
+convention."
+
+**Action.**
+- Make the **"not-yet-resolved symbolic ref"** a *distinct variant* from a
+  resolved one, so no backend can accidentally lower an unresolved ref —
+  the late-resolution state lives in the types, not in a side flag.
+- Keep boxing/representation choices (`val` / `union` / `boxed`) as
+  *distinct variants carrying only their legal fields*, so an ill-typed
+  combination (e.g. an `externref` where an i32 is structurally required)
+  can't be constructed.
+- Audit `as unknown as Instr` casts (CLAUDE.md tracks ~158): each is a hole
+  in this guarantee. Bank them down as the `Instr` union grows (already
+  tracked as #1526) — every retired cast is an invariant moved into the type.
+
+### R3 — Finish the strangler migration: drive each bucket to zero, then delete the legacy path [P1]
+
+**Pattern.** Incremental replacement of a legacy path is a *strangler-fig*:
+a façade routes each unit to new-or-legacy, the system keeps shipping, and
+the migration **terminates** by *removing* legacy responsibilities — not by
+keeping two paths forever. The flag lifecycle per unit is **opt-in →
+default → mandatory (legacy deleted)**. The step teams skip — and regret —
+is the last one.
+
+**Why.** A fallback retained indefinitely becomes load-bearing again; the
+dual-path maintenance cost never ends; and a *silent* fallback masks the
+fact that the new path is broken, so your adoption metric stalls invisibly.
+
+**Our state — textbook-correct mechanics, the missing discipline is
+finishing.** The per-AST-kind dispatcher *is* the façade. The fallback-budget
+ratchet (`pnpm run check:ir-fallbacks`, `scripts/ir-fallback-baseline.json`)
+is the right antidote to silent masking: every demotion increments a
+*counted* bucket, CI fails if an *unintended* bucket grows, "deferred"
+buckets are an explicit decision. The `--update-on-decrease` ratchet banks
+gains automatically. The endgame — a zeroed bucket gets promoted into
+`STRICT_IR_REASONS` so any future regression is a *hard error*, not a silent
+legacy fallback — is exactly the correct termination condition (#1530).
+
+**Action.**
+- Keep prosecuting the **unintended** buckets to zero (`body-shape-rejected`,
+  `external-call`, `call-graph-closure`, the type-resolution family,
+  `class-method`) per the owners/dates in `ir-adoption.md`. This is already
+  the plan; the lesson from the field is simply: *it is the whole game —
+  don't let it stall at "good enough with a fallback."*
+- Phase out the **demote-to-warning escape hatch**
+  (`src/codegen/index.ts:889–896`) on schedule (#1530). The end state is
+  *two* states per node kind — "IR owns it" or "deferred, by decision" —
+  with **no third silent "claimed it then fell back" state.**
+
+### R4 — Make the `BackendEmitter` trait an explicit *legalization* boundary, with state in the IR [P2]
+
+**Pattern.** Lower *progressively* through levels; at the target boundary,
+**legalize**: declare what each target's legal op/type set is, then rewrite
+illegal ops into legal ones (or fail loudly listing what couldn't be
+converted). Split **type-legalization** (map abstract types to a target's
+value types) from **op-legalization** (rewrite unsupported ops). Keep all
+lowering state **in the IR**, inspectable and verifiable at every step — not
+in opaque side-tables. Prefer many small, individually-testable lowering
+steps.
+
+**Why.** Target-specific constraints get handled in *one declarative place*
+instead of leaking `if (target === …)` into every pass. "Is lowering
+finished?" becomes a checkable predicate ("only legal ops remain"), not a
+vibe. State-in-IR is what makes a multi-backend pipeline debuggable: you can
+dump the module right before each backend diverges and diff it.
+
+**Our state.** The `BackendEmitter` trait (`src/ir/backend/emitter.ts`) with
+`wasmgc-emitter`, `linear-emitter`, and a `bytecode-emitter` is precisely
+this seam, and the "vec" group already proves it abstracts a real second/
+third backend (#1714). `type-coercion.ts` is, in effect, our type-legalizer
+(externref boxing, i32↔f64, null/undefined-in-f64-context).
+
+**Action.**
+- Frame each backend explicitly as a **legality declaration + lowering
+  pattern set**, not a hand-rolled switch. Two (now three) "conversion
+  targets"; the same mid-level node is legal/illegal differently per target.
+- Lift `type-coercion.ts` into an explicit **type-converter** consulted by
+  the legalization step, so "what value type does `IrType X` become on
+  backend Y" has one home.
+- Insert at least one **backend-neutral, Wasm-shaped level** (calls, locals,
+  structured control resolved; object representation still abstract) *above*
+  the GC-struct-vs-linear-load/store split, and run shared folding/peephole
+  there once for all backends (ties into R8).
+- Continue migrating the aggregate/closure/ref-coercion groups behind the
+  trait (#1713) — the remaining inline `struct.new`/`struct.get`/`ref.cast`
+  in `lower.ts` are the legalization leaks to close.
+
+### R5 — Value representation should be *per-backend*; keep the typed mainline unboxed [P2]
+
+**Pattern.** A uniform tagged value word (NaN-boxing; small-int tagging) is
+the right tool *only for the genuinely dynamic residue*. For typed code,
+**specialize on the static type and never box in the common case**; the
+boxed/tagged form is a *boundary interchange* representation, not the
+*compute* representation. The three dynamic-value strategies (uniform
+NaN-boxed word / parallel value+tag locals / per-type specialization) trade
+the same three axes — codegen complexity, runtime speed, binary size — and
+resolve **differently on different backends**.
+
+**Why.** Numbers dominate hot code; boxing them is the difference between
+native arithmetic and an allocation per op. And a uniform word that's right
+for a linear-memory dynamic path is the *wrong* default on a host-GC backend
+that has reference types and small-int-in-a-reference for free.
+
+**Our state.** `coerceType` already keeps the f64 fast path unboxed and
+boxes only at the boundary (`__box_number`, `extern.convert_any`, emitting
+`f64.const 0/NaN` directly for null/undefined in f64 context to dodge the
+externref roundtrip). This is the correct instinct.
+
+**Action.**
+- Make the **per-backend** choice explicit at the trait: on the **GC
+  backend**, prefer real `ref` types + `ref.cast`/`br_on_cast` (let the
+  engine's type info replace a hand-carried tag for proven-monomorphic
+  values; fall back to a boxed `anyref`/`i31ref` + tag only on the dynamic
+  path — `i31ref` gives small-int-in-a-reference for free). On the **linear
+  backend**, a value-`f64` + type-`i32` parallel-locals scheme is the
+  natural dynamic representation.
+- Hold the line that the boxed form is *interchange only*: unbox at the
+  static-type boundary for the whole typed region (we can do at compile time
+  what a runtime does per-loop-iteration). Resist "make everything a
+  reference" on the GC backend.
+
+### R6 — Never let a fallback or demotion be silent; bucket "compiler error / malformed output" separately from "unsupported" [P1]
+
+**Pattern.** A silent fallback ships *something that works* while hiding that
+the new path is broken — the single most insidious failure of an incremental
+migration. Every demotion must increment a **counted, reason-bucketed**
+metric. Separately, track **"compiler crashed / emitted malformed output"**
+as a first-class *stability* bucket, distinct from **"feature not yet
+supported."** Conflating them hides regressions behind expected gaps.
+
+**Why.** Coverage and stability are different signals. "We don't support
+`Proxy`" is a roadmap fact; "we emitted invalid Wasm for a `for` loop" is a
+bug. A dashboard that merges them can't see the bug.
+
+**Our state.** The fallback budget already buckets demotions by reason and
+fails on unintended growth (good). The test262 dashboard is bucketed.
+
+**Action.**
+- Ensure the test262 / conformance dashboard keeps a **hard-error bucket**
+  ("compiler error" / "malformed Wasm") that is watched as a *stability*
+  metric and gated, *separately* from the informational "unsupported
+  feature" count. Aim to keep the hard-error bucket near-zero; treat any
+  growth as a release-blocking regression, not a coverage statistic.
+- Tie this to R1: a verifier failure on a claimed function must land in the
+  hard-error bucket, never be quietly swallowed.
+
+### R7 — Layer the test strategy; add cross-backend differential testing [P1]
+
+**Pattern.** The highest-yield compiler correctness method is **differential
+/ equivalence testing against a reference oracle** (compile-and-run, compare
+to a trusted implementation) — it turns the undecidable "is this correct?"
+into the tractable "does it match?". Layer on: **conformance** as a
+non-regressing ratchet; **UB-free random program generation** (a generator
+that avoids undefined/unspecified behavior, or its "wrong" outputs drown the
+real bugs); **equivalence-modulo-inputs** self-oracles (inject provably-dead
+code; output must not change); and **automated validity-preserving
+minimization** so every failure arrives as a small repro.
+
+**Why.** A reference oracle is what makes large-scale automated testing
+possible at all. Minimization is what makes a fuzz/conformance failure
+*actionable* (nobody debugs a 2000-line repro).
+
+**Our state.** the `tests/equivalence/` suite (compile-and-run-vs-reference,
+plus the IR-specific `tests/ir-*-equivalence.test.ts`) is the right backbone;
+the test262 baseline regression gate is the conformance
+ratchet, and the project already validates the baseline (spot-checking that
+"pass" entries still pass on HEAD) so it can't drift into false greens.
+
+**Action.**
+- Add a **cross-backend differential test** — compile the same TS to the GC
+  backend *and* the linear backend and assert identical observable output.
+  This is **nearly free** given the dual backend and catches
+  backend-specific lowering bugs a single-oracle test can't. (Now three
+  emitters: GC vs linear vs bytecode-VM is a three-way oracle.)
+- Invest in a **UB-free TS program generator.** TS is far closer to
+  UB-free than low-level languages, so a *sound* generator is markedly
+  easier here than the prior art it's modeled on — an unusually high-ROI
+  bet for us.
+- Wire **automatic minimization** (remove statements/branches, re-run the
+  equivalence oracle, keep reductions that still mismatch *and* still
+  typecheck) to fire on any equivalence failure, attaching a minimal repro
+  to the failing node kind.
+- Run equivalence tests **both before and after** the external optimizer —
+  miscompiles hide on either side of that boundary.
+
+### R8 — Do the cheap SSA optimizations yourself once for all backends; delegate the heavy/order-sensitive ones [P2]
+
+**Pattern.** The high-ROI, low-cost optimizations are **DCE, constant
+folding/propagation, copy propagation, GVN, and conservative inlining** —
+all cheap on SSA. Run them at the **mid-level once**, so *every* backend and
+the downstream optimizer receive smaller, canonical IR. Don't try to *solve*
+phase ordering; adopt the pragmatic recipe of re-running the cheap
+canonicalizer after the structural passes. Leave aggressive, order-sensitive
+optimization (loop transforms, register/local coloring, machine peepholes)
+to a mature external optimizer.
+
+**Why.** Reimplementing aggressive optimization is enormous effort with high
+miscompile risk; an external optimizer has absorbed that cost and is tested
+at scale. The mid-end's contract is *correct + canonical + small*; the
+external pass makes it *fast*.
+
+**Our state.** We integrate an external Wasm optimizer via
+`src/optimize.ts` (the `-O`/`--optimize` flag) and keep a focused peephole
+pass for patterns we uniquely know (dropping redundant `ref.as_non_null`
+after `ref.cast`). Correct division of labor.
+
+**Action.**
+- Run a short, **fixed mid-level cleanup pipeline** (fold + copy-prop + DCE,
+  re-run after lowering/inlining) at the backend-neutral level from R4, so
+  both backends benefit before they diverge.
+- Keep inlining **conservative** (small / single-call-site) — the external
+  optimizer does the aggressive version.
+- The external optimizer's dedicated **GC-optimization** passes benefit the
+  GC backend disproportionately; keep leaning on them there.
+
+### R9 — Gate host imports by "hot-or-expensive, always with a standalone fallback" [P2]
+
+**Pattern.** A host import is justified **only** when (i) the operation is
+hot enough that a call-boundary hurts, **or** (ii) re-implementing it
+standalone is disproportionately expensive — **and even then, always behind
+a standalone fallback.** Prefer the platform's reserved-namespace builtins
+(engine-recognized at compile time, polyfillable) over bespoke imports.
+
+**Why.** Host imports buy completeness and speed cheaply but cost
+portability and grow the host-dependency surface. The discipline keeps the
+standalone (pure-Wasm) mode coherent.
+
+**Our state.** This *is* our "JS host optional" principle and CLAUDE.md's
+"don't add new host imports without a standalone fallback" rule. The dual
+string backend (`nativeStrings` i16 arrays vs `wasm:js-string`) and dual
+RegExp backend are exact instances.
+
+**Action.**
+- Apply the gate consciously to new work: the strongest host-import
+  candidates by this rule are **RegExp and BigInt** (expensive to
+  reimplement, well-served by the host); the weakest are **arithmetic and
+  simple array ops** (keep standalone). Strings sit in between — keep the
+  host fast path as default under a JS host, auto-fall-back to i16 arrays
+  for standalone/WASI (already wired).
+
+### R10 — Cooperate with the host collector where one exists; own linear memory only when layout demands it; don't build a pluggable GC [P2]
+
+**Pattern.** Don't ship a garbage collector into an environment that already
+has one. Where the host provides a GC, hand it object lifetime (fixed-field
+managed structs) — smaller binaries, free cross-boundary cycle collection,
+no GC-on-GC interference, and proper closures via reference/function types.
+Own linear memory only when you need layout control the managed model
+forbids (interior pointers, packed buffers, typed-array backing, arenas).
+And **don't** build an "interchangeable GC strategy" abstraction — the field
+consensus is that supporting tracing and reference-counting as swappable is
+*not viable* (reference counting can't collect cycles, so you bolt on
+tracing anyway); pick one.
+
+**Why.** This *is* the WasmGC-vs-linear axis, articulated by the platform
+itself, and it validates keeping both backends. The GC subsystem is the
+most-redesigned part of every compiler in this space — over-abstracting it
+is a documented trap.
+
+**Our state.** The two backends already encode this. CLAUDE.md correctly
+frames them as *alternatives, not rivals* — GC backend for browser/WasmGC,
+linear for WASI/Component-Model.
+
+**Action.**
+- Keep the **GC backend the default where a host GC exists**; reserve
+  linear for WASI/standalone and layout-control features.
+- For the linear backend's reclamation, if/when needed, pick **one** fixed
+  strategy (e.g. tracing, or RC-with-a-cycle-collector) — not a pluggable
+  abstraction. A bump/arena "allocate-and-exit" mode is a near-free win for
+  short-lived WASI programs (most conformance programs allocate and exit).
+- Lean into the closure advantage: managed reference/function types let us
+  do closures *properly* (our ref-cell capture pattern,
+  `struct (field $value (mut T))`) where linear-only designs were stuck.
+
+### R11 — Keep compile-time-constant metadata *off* the SSA dataflow [P3]
+
+**Pattern.** Distinguish two channels on an IR node: **operands** (runtime
+SSA values, in the use-def graph) and **attributes** (compile-time-constant
+facts — a comparison predicate, an alignment, a literal's payload, a
+backend/feature flag). Keep constants in the attribute channel so they ride
+along to whichever backend needs them *without* polluting use-def reasoning
+or coercion logic.
+
+**Why.** It keeps the dataflow graph clean (SSA analyses don't trip over
+non-values) while keeping the metadata attached and verifiable.
+
+**Our state.** We carry native-type annotations (`type i32 = number`),
+`nativeStrings`, string-backend selection, etc. — these are exactly the
+"attribute, not operand" facts.
+
+**Action.** When adding IR nodes, carry such compile-time facts as
+**node metadata/attributes**, not as synthetic SSA operands. (Closed type
+union is the right call for a single-source-language compiler — keep it; the
+lesson here is only the operand-vs-attribute split.)
+
+---
+
+## Anti-patterns: roads the field already mapped and turned back from
+
+Stated vendor-neutrally; each is a documented, reversed decision somewhere.
+
+- **Sea-of-nodes for "optimization freedom."** Abandoned at scale: messy
+  mental model, fragile effect chains, scheduling/cache waste, ~2× compile
+  time. We're already CFG+SSA — stay there.
+- **A global whole-program type-inference layer every function pays for.**
+  Deleted in favor of *local* type information: it bloated memory, taxed GC,
+  forced serialized (non-parallel) compilation, and added complexity for
+  benefit only in hot code. For us: lean on **TS annotations + local type
+  propagation**; reach for whole-program analysis (e.g. class-hierarchy
+  analysis for devirtualization) only where it pays, and keep it optional.
+- **Attaching type information where it has no operational meaning.** A
+  famous multi-year migration removed pointee-types from pointers because
+  they carried no real semantics; the fix was to put the access type on the
+  *operation* (load/store) instead. For us: keep memory-access **width/type
+  on the linear-backend load/store op**, not on a "typed pointer."
+- **"Any value" sentinels (undef/poison-style).** Under-specified values
+  that may read differently at each use are an optimization minefield and a
+  recurring miscompile source; the long arc is to *remove* them. Our
+  `VOID_RESULT` is fine because it's a **typed, total "no value"** marker,
+  not an "any value." Keep it that way — never introduce a value that
+  legitimately differs per use.
+- **Semantics-erasure during lowering.** When the linear backend lowers
+  managed references or strings to raw bytes, ensure nothing downstream
+  assumes a property the lowering silently dropped (the classic
+  lose-provenance-through-`memcpy` miscompile). This is where a dual backend
+  is most exposed; let the verifier (R1) record enough to forbid it.
+- **Globally-uniqued *mutable* IR state.** It blocks parallel compilation
+  after the fact. Keep IR nodes **immutable-by-replacement** (rewrite by
+  producing new nodes, as canonicalization does) — easier to verify, and it
+  keeps the door open for the project's parallel-compile model
+  (`COMPILER_POOL_SIZE`).
+- **An indefinitely-retained legacy fallback.** It quietly becomes
+  load-bearing again. Finish the strangler (R3).
+
+---
+
+## What deliberately does NOT transfer (we are AOT and statically typed)
+
+Resist cargo-culting runtime machinery. None of these should be built:
+
+| Runtime-only mechanism | Why it doesn't apply to us |
+|---|---|
+| **Multi-tier JIT / on-stack replacement / frame swapping** | We emit one artifact and never recompile a *running* frame. (The only analogue is a *build-time* `-O` choice — already have it.) |
+| **Runtime type feedback / shape discovery** | Static types *are* the feedback, known at compile time and total. Nothing to observe. |
+| **Speculation + deoptimization** | No interpreter tier to bail to. Building it would import the worst runtime failure modes (deopt loops, the megamorphic cliff) for zero benefit. |
+| **Inline caches for typed access** | A typed `struct.get` needs no cache. Only the genuinely dynamic `any`/reflective residue could want a tiny per-site cache — last resort, not a default. |
+| **A universal NaN-boxed / tagged value word for the typed mainline** | Only relevant to the dynamic residue, and even there the GC backend's `anyref`/`i31ref` is the better primitive (R5). |
+
+**But these *static* analogues of runtime tricks DO transfer and we should
+exploit them:** **devirtualization** (compile a call to a direct `call` when
+the receiver type pins one target; vtable/`call_ref` only for genuinely
+polymorphic sites), **monomorphization** (specialize generics per
+instantiation at compile time — bounded code-size cost, zero runtime cost),
+and **guards that *trap* rather than deoptimize** (`ref.cast`/`ref.test`,
+bounds checks, null checks emitted only where types can't prove the fact).
+
+A related boundary lesson: **pure-AOT inference has a hard ceiling** — object
+shape/deep type analysis can't always be resolved statically, and the JIT
+escape hatch (inline caches) isn't available to us. So the **dynamic-fallback
+path is permanent and load-bearing**, not temporary scaffolding. Ratchet a
+bucket to zero (R3) *only* for kinds whose semantics are statically
+decidable; the genuinely-dynamic residue keeps a correct, reasonably-fast
+general path forever.
+
+---
+
+## Don't over-abstract *forward*
+
+We have two/three *real* backends, so the `BackendEmitter` trait is shaped by
+genuine variety — justified, not premature. The caution runs the other way:
+**don't pre-build trait surface for a hypothetical fourth target we don't
+have.** Add an emitter method only when a concrete backend needs it; let a
+lowering rule be duplicated across two node kinds until a third appears, then
+factor the shared helper. "Prefer duplication over the wrong abstraction"
+applies *inside* each backend even though the cross-backend seam itself has
+earned its keep.
+
+---
+
+## Prioritized action table
+
+| # | Action | Priority | Anchors in our tree |
+|---|--------|----------|---------------------|
+| R1 | Close `verify.ts` cross-block/dominance gap; add per-backend legality check; fail CI on verify error | **P1** | `src/ir/verify.ts`, `src/ir/integration.ts` |
+| R2 | Move invariants into the `IrType` union (distinct unresolved-ref variant); retire `as unknown as Instr` casts | **P1** | `src/ir/nodes.ts`, #1526 |
+| R3 | Keep driving unintended fallback buckets to zero; phase out the demote-to-warning hatch; promote zeroed buckets to hard errors | **P1** | `check:ir-fallbacks`, `src/codegen/index.ts:889–896`, #1530, `ir-adoption.md` |
+| R6 | Keep a separate hard-error ("malformed/compiler-error") stability bucket on the conformance dashboard | **P1** | test262 dashboard, baseline gate |
+| R7 | Add cross-backend differential tests; build a UB-free TS generator; auto-minimize on failure; test pre+post optimizer | **P1** | `tests/equivalence/`, three emitters |
+| R4 | Frame each backend as a legality declaration + pattern set; lift `type-coercion.ts` into an explicit type-converter; add a backend-neutral mid-level; finish trait migration | **P2** | `src/ir/backend/`, `type-coercion.ts`, #1713/#1714 |
+| R5 | Make value representation explicitly per-backend (typed refs/`i31ref` on GC; f64+tag on linear); keep typed mainline unboxed | **P2** | `coerceType`, `BackendEmitter` |
+| R8 | Run cheap SSA cleanup (fold/copy-prop/DCE/GVN) once at the mid-level; keep delegating heavy opt | **P2** | `src/optimize.ts`, `src/codegen/peephole.ts` |
+| R9 | Apply the host-import gate consciously (RegExp/BigInt yes; arithmetic no; always a fallback) | **P2** | dual string/RegExp backends, #679/#682 |
+| R10 | GC backend default where a host GC exists; one fixed linear-GC strategy (+ bump mode); lean into proper closures | **P2** | `src/codegen/` vs `src/codegen-linear/` |
+| R11 | Carry compile-time-constant facts as node attributes, not SSA operands | **P3** | `src/ir/nodes.ts` |
+| — | Don't pre-abstract for a 4th backend; duplicate until the rule-of-three | **P3** | `src/ir/backend/emitter.ts` |
+
+---
+
+## How this was assembled
+
+The patterns above are the points of **convergence** across four
+independent research streams (multi-level IR infrastructure; production
+language-runtime architecture; ahead-of-time source→Wasm compilers; and the
+foundational SSA / nanopass / compiler-testing literature). A lesson earned
+its place here when it recurred across streams *and* mapped onto a concrete
+seam in our tree. The strongest signals — block-argument SSA over
+sea-of-nodes, the verifier-between-passes contract, the strangler+ratchet
+migration, and per-backend value representation — were each corroborated by
+multiple, unrelated sources, which is why they sit at P1.

--- a/docs/architecture/structure-and-language-assessment.md
+++ b/docs/architecture/structure-and-language-assessment.md
@@ -130,7 +130,7 @@ budget.
 
 Now tracked (the god-file debt is already #1098/#1172):
 
-1. **Backend naming symmetry** — **#1858** — rename so neither backend reads
+1. **Backend naming symmetry** — **#1860** — rename so neither backend reads
    as the "default" (`backend/gc` + `backend/linear`). `maintainability`,
    low effort. Consider bundling with #1172 to avoid a standalone large
    rename.

--- a/docs/architecture/structure-and-language-assessment.md
+++ b/docs/architecture/structure-and-language-assessment.md
@@ -1,0 +1,140 @@
+# Assessment: file/folder structure & language choice
+
+> An expert-consensus assessment of **this compiler's** repository structure
+> and its implementation-language choice, grounded in a survey of the actual
+> tree (2026-06-04). Companion to
+> [`compiler-design-lessons.md`](compiler-design-lessons.md) (general
+> patterns) and [`codegen-axes.md`](codegen-axes.md) (the two-axis model).
+> Vendor-neutral: no competitor projects are named — only the patterns.
+
+## What was surveyed
+
+- `src/` is **~181k lines of TypeScript** across:
+  `checker/ → ir/ → codegen/ + codegen-linear/ → emit/ → link/ → runtime/`
+  (plus `compiler/`).
+- Language/build: **TypeScript**, `target: ES2022`, `module: ESNext`, ESM,
+  `strict: true`; built with Vite (lib) + esbuild (bundle); tested with
+  vitest; optimization delegated to Binaryen (`wasm-opt`); scripts via `tsx`.
+- Largest source files (lines): `codegen/expressions/calls.ts` **11,092**;
+  `codegen/index.ts` **10,986**; `runtime.ts` **10,092**;
+  `codegen/array-methods.ts` 6,479; `codegen/expressions/assignment.ts`
+  5,620; `codegen/native-strings.ts` 5,613; `codegen-linear/index.ts` 4,822;
+  `ir/from-ast.ts` 4,406.
+
+---
+
+## Folder structure — strong skeleton, debt concentrated in a few god-files
+
+### What the consensus would praise
+
+- **Textbook phase separation.** The `src/` layout maps cleanly onto the
+  classic pipeline: front-end (`checker`), middle-end (`ir`), pluggable
+  backends (`codegen` = WasmGC, `codegen-linear` = linear memory), binary
+  `emit`, a real object-file `link`er, and `runtime`. This is the
+  "narrow waist with the IR in the middle, backends hanging off it" shape the
+  IR literature endorses — and, crucially, **the directory layout matches the
+  documented conceptual model** (rarer than it should be).
+- **The architecture is written down** (`codegen-axes.md`, `ir-adoption.md`),
+  and the two axes (front-end: direct vs IR; backend: WasmGC vs linear) are
+  explicit. "Is the mental model documented, and does the tree reflect it?"
+  is heavily weighted by reviewers — this passes.
+- **Clean top-level hygiene** — `tests/ docs/ plan/ scripts/ benchmarks/
+  website/` all live outside `src/`.
+
+### What they'd flag
+
+- **God-files (the #1 structural concern).** `calls.ts` (11k), `codegen/
+  index.ts` (11k), `runtime.ts` (10k), `array-methods.ts` (6.5k),
+  `assignment.ts` (5.6k). The consensus threshold for "a change can be
+  understood in isolation" is ~1–2k lines; these are 5–10× over, driving
+  review cost, merge-conflict rate, and the loss of the nanopass
+  "understood-in-isolation" property. This is the visible *"hacks accumulate
+  in direct codegen"* symptom — **already tracked** as #1098 (hack inventory)
+  and #1172 (modularity audit), and it's exactly what the typed-IR migration
+  is meant to dissolve. Known debt, not a blind spot — but it's the
+  highest-friction part of the tree.
+- **Two parallel mega `index.ts`** (`codegen/` 11k + `codegen-linear/` 4.8k)
+  are the `features × targets` duplication the typed-IR waist is designed to
+  collapse — structure faithfully reflecting an in-progress migration.
+- **Asymmetric backend naming.** `codegen/` (unmarked default) vs
+  `codegen-linear/` (suffixed) subtly encodes "linear is secondary," which
+  contradicts the project's own stated principle that the two backends are
+  *alternatives, not rivals*. A neutral pairing (`backend/wasmgc` +
+  `backend/linear`, or at minimum `codegen-wasmgc/`) would make the tree say
+  what the doc says. Minor but real. *(Note: a large directory rename is a
+  history/merge-conflict cost on a busy tree — weigh against the clarity
+  gain; may be best bundled with the #1172 modularity work.)*
+- **Ambiguous `compiler/` vs `codegen/` vs `emit/` boundaries** for a
+  newcomer. A one-line module-header / `README` per `src/` subdir stating its
+  contract is cheap and pays off (ties to the `contributor-readiness` goal).
+
+### Structure grade
+
+Strong, idiomatic skeleton; the debt is concentrated in a handful of
+oversized direct-codegen files, which is already on the roadmap to dissolve
+via the IR. The cheap, net-new, not-yet-tracked items are the **backend
+naming asymmetry** and **per-subdir module-contract READMEs**.
+
+---
+
+## Language choice (TypeScript) — well-justified, near-canonical for this compiler
+
+The expert heuristic is *"match the implementation language to your dominant
+leverage point."* For a TS→Wasm compiler, that point is decisive:
+
+### Why it's the right call here
+
+- **The `typescript` package is reused as the front-end** — its parser, AST,
+  and type checker. The single most expensive component of a TS→Wasm compiler
+  (a correct TS parser + type system) is **eliminated**. Rewriting in a
+  systems language would mean reimplementing or FFI-wrapping that checker.
+  This alone justifies the choice.
+- **Source language == implementation language → self-hosting is on the
+  table** (there's a `self-hosting-dogfood` goal and a `dogfood:acorn`
+  harness). A genuine strategic asset.
+- **Largest contributor pool** (matters for an open Wasm/JS-adjacent project)
+  and **first-class Binaryen bindings**. Fast iteration (vitest/tsx/esbuild).
+
+### The honest tradeoffs
+
+- **TS's type system is unsound and structural** — not the ideal substrate
+  for "make illegal states unrepresentable." No true sum types / exhaustive
+  pattern-matching (simulated with discriminated unions + `never`), and the
+  escape hatches surface concretely as the **~158 `as unknown as Instr`
+  casts** (#1095) — TS fighting the IR model. A nominal-ADT language would
+  catch more compiler bugs at compile time and make the nanopass style less
+  boilerplate-heavy. **The compensating discipline is already in place:**
+  discriminated unions + the runtime IR verifier (`src/ir/verify.ts`) buy
+  back the guarantees the type system can't give — which is exactly why
+  hardening the verifier (R1 / #1850) is high-value, and why retiring the
+  cast budget (#1095) matters.
+- **Performance / memory ceiling.** A compiler is alloc-heavy; a GC'd Node
+  runtime has throughput and heap ceilings a systems language doesn't — felt
+  already as OOM on the full suite and `COMPILER_POOL_SIZE` budgeting. Fine
+  at current scale. If it ever bottlenecks, the escape valves are
+  self-hosting hot paths to Wasm, or a small perf-critical core in a systems
+  language — neither warranted yet.
+
+### Verdict
+
+For a TS→Wasm compiler specifically, TypeScript is a defensible, near-
+canonical choice: the front-end reuse + self-hosting upside dominates the
+weaker compile-time guarantees and the runtime ceiling. The discipline that
+makes it work is precisely what's already in flight — a strong IR verifier
+(compensating for TS's unsoundness) and retiring the `as unknown as` cast
+budget.
+
+---
+
+## Cheap, net-new follow-ups surfaced by this assessment
+
+Now tracked (the god-file debt is already #1098/#1172):
+
+1. **Backend naming symmetry** — **#1858** — rename so neither backend reads
+   as the "default" (`backend/gc` + `backend/linear`). `maintainability`,
+   low effort. Consider bundling with #1172 to avoid a standalone large
+   rename.
+2. **Per-`src/`-subdir module-contract READMEs** — **#1859** — one short
+   header per subdir (`checker`, `ir`, `codegen`, `codegen-linear`, `emit`,
+   `link`, `runtime`, `compiler`) stating its responsibility and what it
+   may/may not depend on. `contributor-readiness`, low effort.

--- a/plan/issues/1850-ir-verifier-hardening-dominance-legality.md
+++ b/plan/issues/1850-ir-verifier-hardening-dominance-legality.md
@@ -1,0 +1,64 @@
+---
+id: 1850
+title: "Harden the IR verifier into a hard between-pass contract (cross-block dominance + per-backend legality + fail-CI)"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: infrastructure
+area: ir
+language_feature: compiler-internals
+goal: correctness
+related: [1844, 1798, 1131, 1376, 1530]
+---
+# #1850 — Harden the IR verifier into a hard between-pass contract
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R1** (P1).
+
+## Problem
+
+`src/ir/verify.ts` (`verifyIrFunction`) already enforces a strong subset —
+SSA single-definition, use-before-def *within* a block, one terminator per
+block, branch-arg arity against target signatures, symbolic-refs-only — and
+is already invoked pre/post-pass in `integration.ts`. This is the right
+backbone, but it has documented gaps that let whole bug classes through:
+
+1. **Cross-block use / dominance is a Phase-2 TODO.** The header comment in
+   `verify.ts` explicitly defers "every use is dominated by its def" across
+   blocks. Until it lands, an SSA value used on a path where it isn't
+   dominated by its definition is invisible to the verifier.
+2. **No nested-buffer recursion** — already filed as **#1844** (verify
+   doesn't recurse nested `if`/`try`/`loop` buffers; return-type gate + SSA
+   holes, residual of #1798). This issue is the umbrella; #1844 is one slice.
+3. **No per-backend legality check.** The verifier validates "is this valid
+   IR" but not "is this IR legal for *this* target." A node legal under the
+   WasmGC backend but illegal under linear memory (or vice versa) is only
+   caught downstream as a malformed-Wasm validation failure, far from the
+   producing pass.
+4. **Verifier failure feeds the fallback, but isn't gated.** A verify
+   failure on a claimed function silently demotes to legacy; it should also
+   surface as a hard-error (see #1853 / R6) so it can't mask a real IR bug.
+
+## Recommendation
+
+Treat the verifier as a hard contract: every pass assumes valid input and
+must produce valid output; a verify failure is attributed to the producing
+pass. Keep checks **local** (don't walk def-use chains for unrelated
+invariants); when many passes re-check the same thing, push it into the
+verifier or into the `IrType` (see #1851/R2).
+
+## Acceptance criteria
+
+- [ ] `verifyIrFunction` checks **cross-block dominance** (every use is
+      dominated by its def along all CFG paths), closing the Phase-2 TODO.
+- [ ] Nested if/try/loop buffer recursion lands (absorbs **#1844**).
+- [ ] A **per-backend legality pass** runs at the emit boundary for each
+      `BackendEmitter` (WasmGC / linear / bytecode), rejecting IR that uses
+      ops/types not legal for that target with a clear, localized error.
+- [ ] In test/CI builds, a verifier failure on a **claimed** function fails
+      the build (lands in the hard-error stability bucket of #1853), rather
+      than silently demoting.
+- [ ] Equivalence + test262 suites stay green; no new fallback-budget growth.

--- a/plan/issues/1851-backendemitter-legalization-boundary-type-converter.md
+++ b/plan/issues/1851-backendemitter-legalization-boundary-type-converter.md
@@ -1,0 +1,61 @@
+---
+id: 1851
+title: "Make BackendEmitter an explicit legalization boundary + extract a declared type-converter; add a backend-neutral mid-level"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [1713, 1714, 1715, 1185, 1168]
+---
+# #1851 — BackendEmitter as an explicit legalization boundary
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R4** (P2).
+
+## Problem
+
+The `BackendEmitter` trait (`src/ir/backend/emitter.ts`, with `wasmgc-`,
+`linear-`, and `bytecode-emitter`) is the right seam, and the "vec" group
+already routes through it to multiple backends (#1713/#1714/#1715). But the
+backend boundary is still partly a hand-rolled lowering rather than an
+explicit *legalization* step:
+
+- `lower.ts` still emits `struct.new`/`struct.get`/`ref.cast` **inline** for
+  the aggregate/closure/ref-coercion groups (tracked under #1713's migration
+  order) — these are legalization leaks below the trait.
+- `type-coercion.ts` is, in effect, our type-legalizer (externref boxing,
+  i32↔f64, null/undefined-in-f64-context), but it isn't modeled as a
+  *declared* type-converter consulted by the boundary.
+- There is no single backend-neutral, Wasm-shaped mid-level (calls/locals/
+  structured control resolved, object representation still abstract) where
+  shared folding/peephole can run **once** before the GC-struct vs
+  linear-load/store split.
+
+## Recommendation
+
+Model each backend as a **legality declaration + lowering-pattern set**
+(which ops/types are legal; how illegal ones are rewritten) rather than an
+imperative switch. "Is lowering finished?" becomes the checkable predicate
+"only legal ops remain" (pairs with the per-backend legality check in
+#1850/R1). Keep all lowering state **in the IR**, inspectable at every step —
+not in opaque side tables.
+
+## Acceptance criteria
+
+- [ ] `type-coercion.ts` logic is reachable as a **declared type-converter**
+      (`IrType` → backend value type) the boundary consults, with one home
+      per backend.
+- [ ] A **backend-neutral mid-level** exists above the struct-vs-linear
+      split; shared fold/peephole (see #1853-adjacent / R8 via #1167a) runs
+      there once for all backends.
+- [ ] The remaining inline `struct.new`/`struct.get`/`ref.cast` in `lower.ts`
+      (aggregate/closure/ref-coercion groups) route through the trait
+      (continues #1713's migration order).
+- [ ] No behavior change: equivalence + test262 green; cross-backend
+      differential test (#1854) passes for the migrated groups.

--- a/plan/issues/1852-per-backend-value-representation.md
+++ b/plan/issues/1852-per-backend-value-representation.md
@@ -1,0 +1,58 @@
+---
+id: 1852
+title: "Make dynamic-value representation explicitly per-backend (typed refs / i31ref on WasmGC; f64-value + i32-tag on linear)"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [1168, 1713, 1714, 1851]
+---
+# #1852 — Per-backend value representation for the dynamic residue
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R5** (P2).
+
+## Problem
+
+A uniform tagged value word (NaN-boxing, small-int tagging) is the right
+tool **only for the genuinely dynamic residue** (`any`, reflective access,
+heterogeneous unions). For typed code we already specialize on the static
+type and keep the f64 fast path unboxed (`coerceType`: `__box_number`,
+`extern.convert_any`, emitting `f64.const 0/NaN` directly for null/undefined
+in f64 context). The gap: the **dynamic-residue representation is not chosen
+per backend**, even though the right choice differs:
+
+- **WasmGC backend:** real `ref` types + `ref.cast`/`br_on_cast` let the
+  engine's type info replace a hand-carried tag for proven-monomorphic
+  values; `i31ref` gives small-int-in-a-reference *for free*; fall back to a
+  boxed `anyref` + tag only on the truly dynamic path.
+- **Linear backend:** a value-`f64` + type-`i32` parallel-locals scheme is
+  the natural dynamic representation; a uniform tagged word is the fallback.
+
+A single cross-backend representation forces one backend onto the other's
+worst case.
+
+## Recommendation
+
+Make the dynamic-value lowering a **per-backend decision at the
+`BackendEmitter` seam** (depends on #1851). Hold the line that the boxed/
+tagged form is **interchange only**: unbox at the static-type boundary for
+the whole typed region (we can do at compile time what a runtime does per
+loop iteration). On the GC backend, resist "make everything a reference."
+
+## Acceptance criteria
+
+- [ ] The IR `IrType` `union`/`boxed` lowering dispatches to a per-backend
+      representation via the trait (GC: typed ref / `i31ref` / boxed
+      `anyref`; linear: f64-value + i32-tag).
+- [ ] Typed mainline stays unboxed on both backends (no regression in
+      emitted-Wasm size/op-count for typed numeric kernels).
+- [ ] `i31ref` used for small-int dynamic values on the GC backend.
+- [ ] Cross-backend differential test (#1854) confirms identical observable
+      behavior across the two representations.

--- a/plan/issues/1853-conformance-hard-error-stability-bucket.md
+++ b/plan/issues/1853-conformance-hard-error-stability-bucket.md
@@ -1,0 +1,48 @@
+---
+id: 1853
+title: "Track a separate hard-error (compiler-crash / malformed-Wasm) stability bucket on the conformance dashboard, distinct from unsupported-feature"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: observability
+related: [1376, 1850]
+---
+# #1853 — Separate hard-error stability bucket on the conformance dashboard
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R6** (P1).
+
+## Problem
+
+Coverage and stability are different signals that are easy to conflate.
+"We don't support `Proxy` yet" is a roadmap fact; "we crashed / emitted
+invalid Wasm compiling a `for` loop" is a **bug**. A dashboard that merges
+"compiler error / malformed output" into the same not-passing total as
+"unsupported feature" cannot see a stability regression hiding behind an
+expected gap. The fallback budget already buckets *IR demotions* by reason;
+the same discipline should apply to *conformance outcomes*.
+
+## Recommendation
+
+Keep a first-class **hard-error bucket** ("compiler error" / "malformed
+Wasm" / verifier-failure-on-claimed-function from #1850) on the test262 /
+conformance dashboard, watched as a *stability* metric and **gated**,
+separately from the informational "unsupported feature" count. Target:
+keep the hard-error bucket near-zero; treat any growth as a
+release-blocking regression, not a coverage statistic.
+
+## Acceptance criteria
+
+- [ ] Conformance reporting distinguishes `compiler_error` / `malformed_wasm`
+      (and verifier-failure) outcomes from `unsupported_feature` outcomes.
+- [ ] The hard-error bucket is surfaced on the dashboard and has a CI gate
+      that fails on growth (mirrors the IR fallback-budget ratchet, #1376).
+- [ ] A verifier failure on a claimed function (#1850) routes into this
+      bucket rather than being silently swallowed.
+- [ ] Baseline recorded; current hard-error count documented as the ceiling.

--- a/plan/issues/1854-cross-backend-differential-testing.md
+++ b/plan/issues/1854-cross-backend-differential-testing.md
@@ -1,0 +1,50 @@
+---
+id: 1854
+title: "Cross-backend differential testing harness — same TS to WasmGC / linear / bytecode-VM must produce identical observable output"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: test
+area: testing
+language_feature: n/a
+goal: test-infrastructure
+related: [1714, 1715, 1851, 1852]
+---
+# #1854 — Cross-backend differential testing harness
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R7a** (P1).
+
+## Problem
+
+The `tests/equivalence/` suite compiles-and-runs against a JS/TS reference
+oracle (the right backbone). But we now have **three** lowering paths behind
+the `BackendEmitter` trait (WasmGC, linear memory, bytecode-VM), and nothing
+asserts they agree with **each other**. A backend-specific lowering bug
+(e.g. a linear-memory layout error, or a divergent boxing choice from #1852)
+that produces wrong-but-not-crashing output can pass the single-oracle test
+on whichever backend the test happens to run.
+
+## Recommendation
+
+Add a **cross-backend differential test**: compile the same TS program to
+each available backend and assert **identical observable output**. This is
+nearly free given the dual/triple backend and catches the exact class of
+backend-divergence bugs the reference oracle alone can miss. It also becomes
+the regression guard for the per-backend value representation (#1852) and the
+trait-migration work (#1851).
+
+## Acceptance criteria
+
+- [ ] A test helper compiles a TS source to WasmGC **and** linear (and, where
+      applicable, the bytecode-VM) and diffs observable results (return value,
+      stdout, thrown errors).
+- [ ] Seeded from a representative corpus (numeric kernels, strings, objects,
+      arrays, control flow, closures) — start with the existing equivalence
+      corpus.
+- [ ] A divergence fails the test with a minimal-enough repro pointer
+      (full minimization is #1855).
+- [ ] Wired into CI; runtime kept modest (subset corpus if needed).

--- a/plan/issues/1855-ub-free-ts-fuzzer-and-minimization.md
+++ b/plan/issues/1855-ub-free-ts-fuzzer-and-minimization.md
@@ -1,0 +1,54 @@
+---
+id: 1855
+title: "UB-free TypeScript program generator + automated validity-preserving test-case minimization for equivalence failures"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: test
+area: testing
+language_feature: n/a
+goal: test-infrastructure
+related: [1854]
+---
+# #1855 — UB-free TS fuzzer + automated minimization
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R7b** (P2).
+
+## Problem
+
+Hand-written equivalence tests cover the cases we *thought of*. The
+highest-yield way to find wrong-code bugs in a compiler is **random program
+generation + differential testing**, but it only works if the generator
+avoids undefined/unspecified behavior (otherwise its "wrong" outputs drown
+the real bugs), and if failures are **minimized** automatically (nobody
+debugs a 2000-line repro). TypeScript is far closer to UB-free than the
+low-level languages this technique was pioneered on, so a *sound* generator
+is markedly easier here — an unusually high-ROI bet.
+
+## Recommendation
+
+1. **UB-free TS program generator** producing well-typed TS within our
+   supported subset, fed into the reference oracle and the cross-backend
+   differential harness (#1854). Optionally add an equivalence-modulo-inputs
+   mode (inject provably-dead code / identity transforms; output must not
+   change) as a self-oracle that needs no reference.
+2. **Automated validity-preserving minimization**: on any equivalence /
+   differential failure, iteratively remove statements/branches and re-run
+   the oracle, keeping only reductions that **still mismatch** *and* **still
+   typecheck** (the validity predicate is "still valid TS in our subset").
+   Fire automatically and attach a minimal repro to the failing node kind.
+
+## Acceptance criteria
+
+- [ ] Generator emits well-typed TS in the supported subset; emitted programs
+      have deterministic, reference-defined output (no reliance on
+      unspecified behavior).
+- [ ] Generated corpus runs through the reference oracle and #1854.
+- [ ] A minimizer reduces a failing case to a small repro while preserving
+      both the mismatch and type-validity.
+- [ ] Minimization is wired to fire on equivalence/differential failures.
+- [ ] (Optional) EMI self-oracle mode implemented.

--- a/plan/issues/1856-linear-bump-arena-allocator-mode.md
+++ b/plan/issues/1856-linear-bump-arena-allocator-mode.md
@@ -1,0 +1,54 @@
+---
+id: 1856
+title: "Bump/arena allocator mode for short-lived linear-memory programs (allocate-and-exit), plus commit to one fixed linear-GC strategy"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: performance
+area: codegen
+language_feature: compiler-internals
+goal: standalone-mode
+related: [1662]
+---
+# #1856 — Bump/arena allocator mode for short-lived linear programs
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R10** (P2).
+
+## Problem
+
+On the **linear-memory backend** (`src/codegen-linear/`) we own allocation.
+The field consensus on memory management for AOT-to-Wasm is twofold:
+
+1. **Don't build a pluggable/interchangeable GC.** Supporting tracing and
+   reference-counting as swappable strategies is documented as *not viable*
+   (RC can't collect cycles, so you bolt on tracing anyway). Pick one fixed
+   strategy.
+2. **A bump/arena "allocate-and-never-free" mode is a near-free win for
+   short-lived programs.** Most conformance / CLI-style WASI programs
+   allocate and exit; for them, a tracing collector is pure overhead and
+   code size. (On the **WasmGC backend** this whole problem is delegated to
+   the host GC — see the doc's R10 / the codegen-axes backend split.)
+
+## Recommendation
+
+- Add a **bump/arena allocator mode** for the linear backend, selected for
+  short-lived/standalone programs (allocate from a growing region, free
+  nothing, rely on process exit to reclaim). Smallest-binary, fastest path.
+- For programs that genuinely need reclamation, commit to **one** fixed
+  strategy (tracing, or RC-with-a-cycle-collector) — **not** a pluggable
+  abstraction.
+
+## Acceptance criteria
+
+- [ ] A bump/arena allocator mode exists for `--target wasi` / standalone
+      short-lived programs, with no reclamation overhead and minimal code.
+- [ ] Mode selection is explicit (flag or heuristic) and documented.
+- [ ] A decision is recorded for the reclaiming linear-GC strategy (single
+      strategy, not pluggable); if not yet needed, the issue notes it as
+      deferred with the rationale.
+- [ ] Standalone equivalence tests stay green; binary-size win measured for a
+      representative short-lived program.

--- a/plan/issues/1857-ir-attributes-vs-operands-convention.md
+++ b/plan/issues/1857-ir-attributes-vs-operands-convention.md
@@ -1,0 +1,47 @@
+---
+id: 1857
+title: "Carry compile-time-constant facts as IR node attributes, not synthetic SSA operands"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: easy
+reasoning_effort: low
+task_type: refactor
+area: ir
+language_feature: compiler-internals
+goal: maintainability
+related: [1851]
+---
+# #1857 — Attribute vs operand split in the IR
+
+**Source:** [`docs/architecture/compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md) — recommendation **R11** (P3).
+
+## Problem
+
+A durable IR-design hygiene rule distinguishes two channels on a node:
+**operands** (runtime SSA values, part of the use-def graph) and
+**attributes** (compile-time-constant facts — a comparison predicate, an
+alignment, a literal's payload, a backend/feature flag, a native-type
+annotation). Keeping genuinely-constant facts in the *attribute* channel
+keeps them attached and verifiable **without** polluting use-def reasoning,
+SSA analyses, or coercion logic. We already carry such facts (native-type
+annotations like `type i32 = number`, `nativeStrings`, string-backend
+selection); the goal is to make "attribute, not operand" an explicit,
+enforced convention as new IR nodes are added.
+
+## Recommendation
+
+When adding or revising IR nodes, carry compile-time-constant facts as
+**node metadata/attributes**, never as synthetic SSA operands. (The closed
+`IrType` union stays — it's the right call for a single-source-language
+compiler; this issue is only about the operand-vs-attribute split.)
+
+## Acceptance criteria
+
+- [ ] Document the operand-vs-attribute rule in the IR contributor notes
+      (`src/ir/` and/or `codegen-axes.md`).
+- [ ] Audit existing IR nodes for compile-time facts smuggled in as operands;
+      move any found into an attribute channel.
+- [ ] New-node review checklist includes the operand-vs-attribute check.

--- a/plan/issues/1858-backend-naming-symmetry-gc-linear.md
+++ b/plan/issues/1858-backend-naming-symmetry-gc-linear.md
@@ -1,0 +1,73 @@
+---
+id: 1858
+title: "Backend naming symmetry — rename codegen/ + codegen-linear/ to backend/gc + backend/linear (neither reads as the default)"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1172, 1527, 1713]
+---
+# #1858 — Backend naming symmetry (`backend/gc` + `backend/linear`)
+
+**Source:** [`docs/architecture/structure-and-language-assessment.md`](../../docs/architecture/structure-and-language-assessment.md) — follow-up 1.
+
+## Problem
+
+The two backends are documented as **alternatives, not rivals** — the choice
+depends on the target (browser/WasmGC vs WASI/linear), and *both stay*
+([`codegen-axes.md`](../../docs/architecture/codegen-axes.md), CLAUDE.md
+"Architecture Principles"). But the directory naming contradicts that
+principle:
+
+- `src/codegen/` — the **unmarked default** (WasmGC lowering)
+- `src/codegen-linear/` — the **suffixed, secondary-reading** one
+
+The asymmetry quietly encodes "linear is the afterthought," which is exactly
+the framing the architecture rejects. The tree should say what the doc says.
+
+## Proposal
+
+Rename to a symmetric pair under a shared parent so neither backend reads as
+primary:
+
+- `src/codegen/`         → `src/backend/gc/`
+- `src/codegen-linear/`  → `src/backend/linear/`
+
+### Open question for the implementer / architect
+
+There is **already** a `src/ir/backend/` directory (the `BackendEmitter`
+trait + `wasmgc-`/`linear-`/`bytecode-emitter`). A new top-level
+`src/backend/` risks confusion with `src/ir/backend/`. Resolve before
+executing — options:
+- `src/backend/{gc,linear}/` (as requested) + a note distinguishing it from
+  `src/ir/backend/` (the IR-level emitter trait), or
+- `src/codegen/{gc,linear}/` (keeps the `codegen` root, avoids the clash).
+
+Decide as part of this issue; the **symmetry** is the requirement, the exact
+parent name is the detail.
+
+## Cost / caveats
+
+- **Wide import churn** — every importer of the two backend roots updates.
+- **Doc/path updates** — `codegen-axes.md`, `compiler-design-lessons.md`,
+  `structure-and-language-assessment.md`, CLAUDE.md "Project Structure", and
+  any tooling/scripts that grep these paths.
+- **Merge-conflict pressure** on a busy tree — best landed as a single
+  mechanical commit during a quiet window, or **bundled with the #1172
+  modularity audit** rather than as a standalone churn.
+- Pure rename: **no behavior change.**
+
+## Acceptance criteria
+
+- [ ] Backend directories are symmetric (`gc` + `linear`), neither suffixed
+      as secondary; the `src/ir/backend/` naming clash is resolved/noted.
+- [ ] All imports, docs, CLAUDE.md paths, and path-sensitive tooling updated.
+- [ ] No behavior change: equivalence + test262 green; diff is move+rename
+      only.

--- a/plan/issues/1859-per-subdir-module-contract-readmes.md
+++ b/plan/issues/1859-per-subdir-module-contract-readmes.md
@@ -1,0 +1,56 @@
+---
+id: 1859
+title: "Per-src-subdir module-contract READMEs (checker, ir, codegen, codegen-linear, emit, link, runtime, compiler)"
+status: backlog
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: low
+feasibility: easy
+reasoning_effort: low
+task_type: docs
+area: docs
+language_feature: compiler-internals
+goal: contributor-readiness
+related: [1172, 1858, 1527]
+---
+# #1859 — Per-subdir module-contract READMEs
+
+**Source:** [`docs/architecture/structure-and-language-assessment.md`](../../docs/architecture/structure-and-language-assessment.md) — follow-up 2.
+
+## Problem
+
+The `src/` layout is a clean pipeline (`checker → ir → codegen +
+codegen-linear → emit → link → runtime`, plus `compiler/`), but the
+boundaries between several subdirs are **not self-evident to a newcomer** —
+e.g. what is the difference in responsibility between `compiler/`, `codegen/`,
+and `emit/`? The conceptual model lives in
+[`codegen-axes.md`](../../docs/architecture/codegen-axes.md) /
+[`compiler-design-lessons.md`](../../docs/architecture/compiler-design-lessons.md),
+but a reader landing in a subdir has no local signpost. This is friction
+against the `contributor-readiness` goal.
+
+## Proposal
+
+Add a short **module-contract header per `src/` subdir** — either a
+`src/<dir>/README.md` or a top-of-`index.ts` doc block — stating, in a few
+lines each:
+
+1. **Responsibility** — what this module owns (one sentence).
+2. **Inputs / outputs** — what it consumes and produces (e.g. "AST → IR",
+   "IR → WasmGC `Instr[]`", "`Instr[]` → binary bytes").
+3. **May depend on / must NOT depend on** — the allowed dependency direction,
+   so layering violations are obvious in review (e.g. `ir/` must not import
+   from a concrete backend; backends depend on `ir/`, not vice versa).
+4. **Link** to the relevant architecture doc section.
+
+Subdirs to cover: `checker/`, `ir/`, `codegen/`, `codegen-linear/`, `emit/`,
+`link/`, `runtime/`, `compiler/` (rename-aware if #1858 lands first).
+
+## Acceptance criteria
+
+- [ ] Each `src/` subdir has a concise module-contract README / header
+      (responsibility, in/out, dependency direction, doc link).
+- [ ] The stated dependency directions match reality (spot-check imports; no
+      claimed-forbidden edge actually exists).
+- [ ] Linked from `codegen-axes.md` as the per-module index.

--- a/plan/issues/1859-per-subdir-module-contract-readmes.md
+++ b/plan/issues/1859-per-subdir-module-contract-readmes.md
@@ -12,7 +12,7 @@ task_type: docs
 area: docs
 language_feature: compiler-internals
 goal: contributor-readiness
-related: [1172, 1858, 1527]
+related: [1172, 1860, 1527]
 ---
 # #1859 — Per-subdir module-contract READMEs
 
@@ -45,7 +45,7 @@ lines each:
 4. **Link** to the relevant architecture doc section.
 
 Subdirs to cover: `checker/`, `ir/`, `codegen/`, `codegen-linear/`, `emit/`,
-`link/`, `runtime/`, `compiler/` (rename-aware if #1858 lands first).
+`link/`, `runtime/`, `compiler/` (rename-aware if #1860 lands first).
 
 ## Acceptance criteria
 

--- a/plan/issues/1860-backend-naming-symmetry-gc-linear.md
+++ b/plan/issues/1860-backend-naming-symmetry-gc-linear.md
@@ -1,5 +1,5 @@
 ---
-id: 1858
+id: 1860
 title: "Backend naming symmetry — rename codegen/ + codegen-linear/ to backend/gc + backend/linear (neither reads as the default)"
 status: backlog
 sprint: Backlog
@@ -14,7 +14,7 @@ language_feature: compiler-internals
 goal: maintainability
 related: [1172, 1527, 1713]
 ---
-# #1858 — Backend naming symmetry (`backend/gc` + `backend/linear`)
+# #1860 — Backend naming symmetry (`backend/gc` + `backend/linear`)
 
 **Source:** [`docs/architecture/structure-and-language-assessment.md`](../../docs/architecture/structure-and-language-assessment.md) — follow-up 1.
 

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -205,3 +205,24 @@ defense-in-depth, and cleanup:
 - [#1847](../1847-forof-rollback-localmap-not-restored.md) — for-of tentative rollback doesn't restore `fctx.localMap` (robustness) — low, low, **backlog**
 - [#1848](../1848-dead-code-sweep.md) — dead-code sweep: identical branches, unused locals/params, obsolete scaffolding — low, low, **backlog**
 - [#1849](../1849-duplicate-logic-refactor.md) — refactor diverged copy-paste (super dispatch, closure drainers, `resolveVec`, `__extern_has`, typed-default) — low, medium, **backlog**
+
+### Compiler-design lessons — architectural recommendations (2026-06-04)
+
+From [`docs/architecture/compiler-design-lessons.md`](../../../docs/architecture/compiler-design-lessons.md)
+(vendor-neutral synthesis of general compiler/IR/runtime patterns) and
+[`docs/architecture/structure-and-language-assessment.md`](../../../docs/architecture/structure-and-language-assessment.md)
+(structure + language review). Net-new issues only; recommendations already
+tracked elsewhere are noted under "Already covered" below.
+
+- [#1850](../1850-ir-verifier-hardening-dominance-legality.md) — R1: harden the IR verifier into a hard between-pass contract (cross-block dominance + per-backend legality + fail-CI; umbrella over #1844) — high, medium, **backlog**
+- [#1851](../1851-backendemitter-legalization-boundary-type-converter.md) — R4: make `BackendEmitter` an explicit legalization boundary, extract a declared type-converter, add a backend-neutral mid-level — medium, hard, **backlog**
+- [#1852](../1852-per-backend-value-representation.md) — R5: per-backend dynamic-value representation (typed refs / `i31ref` on WasmGC; f64-value + i32-tag on linear) — medium, hard, **backlog**
+- [#1853](../1853-conformance-hard-error-stability-bucket.md) — R6: separate hard-error (compiler-crash / malformed-Wasm) stability bucket on the conformance dashboard — high, easy, **backlog**
+- [#1854](../1854-cross-backend-differential-testing.md) — R7a: cross-backend differential testing harness (WasmGC / linear / bytecode-VM must agree) — high, medium, **backlog**
+- [#1855](../1855-ub-free-ts-fuzzer-and-minimization.md) — R7b: UB-free TS program generator + automated validity-preserving minimization — medium, hard, **backlog**
+- [#1856](../1856-linear-bump-arena-allocator-mode.md) — R10: bump/arena allocator mode for short-lived linear programs; commit to one fixed linear-GC strategy — medium, medium, **backlog**
+- [#1857](../1857-ir-attributes-vs-operands-convention.md) — R11: carry compile-time-constant facts as IR node attributes, not synthetic SSA operands — low, easy, **backlog**
+- [#1858](../1858-backend-naming-symmetry-gc-linear.md) — structure review: rename `codegen/` + `codegen-linear/` → `backend/gc` + `backend/linear` so neither backend reads as the default (pure rename; consider bundling with #1172) — low, medium, **backlog**
+- [#1859](../1859-per-subdir-module-contract-readmes.md) — structure review: per-`src/`-subdir module-contract READMEs (responsibility, in/out, dependency direction) — low, easy, **backlog**
+
+**Already covered (no new issue):** R2 (make illegal states unrepresentable / retire `as unknown as Instr`) → **#1095**; R3 (finish the strangler: drive fallback buckets to zero, promote to strict) → **#1376** + the per-bucket program (#1370 done, #1371 done, #1372, #1373…) tracked in `plan/log/ir-adoption.md`; R8 (cheap mid-level SSA cleanup: fold/DCE/simplify-cfg + conservative inline) → **#1167a** / **#1167b**; R9 (host-import gate) → standing CLAUDE.md rule + audit **#1662**.


### PR DESCRIPTION
## What

Two vendor-neutral architecture docs synthesising durable compiler / IR /
runtime design patterns, an assessment of our own structure + language
choice, and the **net-new follow-up issues** they surface (#1850–1859).
Docs/planning only — **no source change**.

### Docs added
- `docs/architecture/compiler-design-lessons.md` — general patterns distilled into 11 prioritised recommendations (R1–R11), an anti-patterns section, an "AOT-doesn't-apply" list (so nobody cargo-cults JIT machinery), and a prioritised action table. Grounded in our actual tree (IR verifier `src/ir/verify.ts`, the three-emitter `BackendEmitter` trait, the fallback-budget ratchet, `type-coercion.ts`).
- `docs/architecture/structure-and-language-assessment.md` — expert-consensus review of the `src/` layout (phase-separated skeleton; 10–11k-line god-file debt; backend-naming asymmetry) and the TypeScript implementation choice (front-end reuse via the `typescript` package + self-hosting upside vs. unsound types / runtime ceiling; the `as unknown as Instr` cast tax).

### Issues filed (net-new only)
| # | Rec | Summary |
|---|-----|---------|
| #1850 | R1 | Harden the IR verifier into a hard between-pass contract (cross-block dominance + per-backend legality + fail-CI; umbrella over #1844) |
| #1851 | R4 | Make `BackendEmitter` an explicit legalization boundary + declared type-converter + backend-neutral mid-level |
| #1852 | R5 | Per-backend dynamic-value representation (typed refs / `i31ref` on WasmGC; f64-value + i32-tag on linear) |
| #1853 | R6 | Separate hard-error (compiler-crash / malformed-Wasm) stability bucket on the conformance dashboard |
| #1854 | R7a | Cross-backend differential testing harness (WasmGC / linear / bytecode-VM must agree) |
| #1855 | R7b | UB-free TS program generator + automated validity-preserving minimization |
| #1856 | R10 | Bump/arena allocator mode for short-lived linear programs; one fixed linear-GC strategy |
| #1857 | R11 | Carry compile-time-constant facts as IR node attributes, not synthetic SSA operands |
| #1858 | — | Backend naming symmetry: `codegen/` + `codegen-linear/` → `backend/gc` + `backend/linear` |
| #1859 | — | Per-`src/`-subdir module-contract READMEs |

`backlog.md` updated with both sections.

### Already tracked (cross-referenced, **not** duplicated)
- R2 (illegal-states-unrepresentable / retire `as unknown as Instr`) → **#1095**
- R3 (finish the strangler: drive fallback buckets to zero → strict) → **#1376** + the per-bucket program in `plan/log/ir-adoption.md`
- R8 (cheap mid-level SSA cleanup) → **#1167a** / **#1167b**
- R9 (host-import gate) → standing CLAUDE.md rule + audit **#1662**

## Why
Captures the research requested into durable, actionable architecture docs and a prioritised backlog, so the lessons outlive this conversation.

## Notes
- Vendor-neutral by design — no competitor projects named (verified by grep).
- All-new files + a `backlog.md` append; nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)