### PR TITLE
test: real-world compile-coverage suites (ESM, Web/WASI/Node/Deno, frameworks)

### DIFF
--- a/plan/issues/6407-wasi-process-exit-invalid-binary.md
+++ b/plan/issues/6407-wasi-process-exit-invalid-binary.md
@@ -1,0 +1,97 @@
+---
+id: 6407
+title: "WASI process.exit(code) emits an invalid binary (i32/f64 stack mismatch in trunc)"
+status: ready
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: wasi-process-exit
+goal: correctness
+---
+# #6407 — WASI `process.exit(code)` emits an invalid binary
+
+## Problem
+
+Compiling `process.exit(N)` with `--target wasi` (`{ target: "wasi" }`)
+reports `success: true` but produces a module that **fails
+`WebAssembly.validate()`**. Instantiating it throws:
+
+```
+CompileError: WebAssembly.compile(): Compiling function #1:"__module_init"
+failed: i32.trunc_sat_f64_s[0] expected type f64, found i32.const of type i32
+```
+
+Reproduces for every code value (`process.exit(0)`, `(1)`, `(42)`), with or
+without a preceding `console.log`. The existing `tests/wasi-target.test.ts`
+only asserts that the WAT text contains `proc_exit`, so it never exercised
+binary validity and did not catch this.
+
+```ts
+const r = await compile(
+  `declare const process: { exit(code: number): void }; process.exit(0);`,
+  { target: "wasi" },
+);
+r.success;                          // true
+WebAssembly.validate(r.binary);     // false  <-- bug
+```
+
+## Root cause
+
+`src/codegen/expressions/calls.ts:3180-3186` (the WASI `process.exit`
+special case):
+
+```ts
+if (expr.arguments.length >= 1) {
+  compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "i32" }); // pushes i32
+  const argType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+  if (isNumberType(argType)) {
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);          // expects f64
+  }
+}
+```
+
+The argument is compiled with expected type `{ kind: "i32" }`, so
+`compileExpression` already coerces the value to an `i32` on the stack (for a
+literal it emits `i32.const 0`). The code then *also* pushes
+`i32.trunc_sat_f64_s`, which expects an **f64** operand — but the stack holds
+an `i32`. Hence the validation failure. The `i32`-expected compile and the
+`f64→i32` truncation are mutually exclusive; the code does both.
+
+`proc_exit` itself takes an `i32` (`addFuncType(ctx, [{ kind: "i32" }], …)`,
+`src/codegen/index.ts:4716-4720`), so the call target type is correct — only
+the operand lowering is wrong.
+
+## Fix (one of)
+
+1. **Drop the redundant truncation** — `compileExpression(…, { kind: "i32" })`
+   already delivers an `i32`, so remove the `i32.trunc_sat_f64_s` push
+   entirely. Simplest, and correct for the common literal/number-expression
+   case.
+2. **Truncate from f64** — compile the argument with `{ kind: "f64" }` and keep
+   the `i32.trunc_sat_f64_s`. Equivalent result; matches the apparent original
+   intent of "the expression might produce f64."
+
+Either makes the stack types line up. Prefer (1) unless there is a reason the
+argument must round-trip through f64.
+
+## Acceptance criteria
+
+- `WebAssembly.validate()` returns `true` for `process.exit(0)`,
+  `process.exit(1)`, `process.exit(42)` under `--target wasi`.
+- The module still imports `wasi_snapshot_preview1.proc_exit` and calls it
+  with the correct code.
+- A binary-validity assertion guards the WASI `process.exit` path (so a WAT-only
+  test can't mask a regression again).
+
+## Test sentinel already in place
+
+`tests/real-world-wasi.test.ts` carries an `it.fails(...)` sentinel asserting
+`WebAssembly.validate(...) === true` for `process.exit(0)`. It passes while the
+bug stands and will flip to a hard failure once codegen is fixed — at which
+point remove the `.fails` modifier (and the explanatory comment) so it becomes
+a normal regression guard.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -205,3 +205,10 @@ defense-in-depth, and cleanup:
 - [#1847](../1847-forof-rollback-localmap-not-restored.md) — for-of tentative rollback doesn't restore `fctx.localMap` (robustness) — low, low, **backlog**
 - [#1848](../1848-dead-code-sweep.md) — dead-code sweep: identical branches, unused locals/params, obsolete scaffolding — low, low, **backlog**
 - [#1849](../1849-duplicate-logic-refactor.md) — refactor diverged copy-paste (super dispatch, closure drainers, `resolveVec`, `__extern_has`, typed-default) — low, medium, **backlog**
+
+### Real-world test coverage findings (2026-06-04)
+
+Found while adding `tests/real-world-*.test.ts` (real-world code patterns
+test262 doesn't cover: ESM, Web/WASI/Node/Deno APIs, Hono/React/Express):
+
+- [#6407](../6407-wasi-process-exit-invalid-binary.md) — WASI `process.exit(code)` emits an invalid binary: the exit code is compiled as i32 but an `i32.trunc_sat_f64_s` (expects f64) is pushed on top (`calls.ts:3180-3186`); `wasi-target.test.ts` only checks WAT so missed it. Sentinel via `it.fails` in `real-world-wasi.test.ts` — medium, easy, **ready (backlog)**

--- a/tests/real-world-frameworks.test.ts
+++ b/tests/real-world-frameworks.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "vitest";
+import { compileValid } from "./real-world-helpers.js";
+
+/**
+ * Real-world frameworks: Hono, React, Express.
+ *
+ * test262 is pure ECMAScript conformance — it has no notion of a web
+ * framework. These lock in that idiomatic framework source (routing,
+ * middleware, hooks, request/response handlers) flows through the import
+ * resolver's host-stub path and still compiles to a valid Wasm module. The
+ * framework packages are not bundled; their symbols become host imports.
+ */
+describe("real-world: Hono (edge web framework)", () => {
+  it("compiles routing, params, and json/text responses", async () => {
+    await compileValid(`
+      import { Hono } from "hono";
+      const app = new Hono();
+      app.get("/", (c: any) => c.text("Hello Hono!"));
+      app.get("/users/:id", (c: any) => c.json({ id: c.req.param("id") }));
+      app.post("/users", async (c: any) => {
+        const body = await c.req.json();
+        return c.json({ created: true, name: body.name }, 201);
+      });
+      export default app;
+    `);
+  });
+
+  it("compiles middleware (app.use) with a next() chain", async () => {
+    await compileValid(`
+      import { Hono } from "hono";
+      const app = new Hono();
+      app.use("*", async (c: any, next: any) => {
+        const start = Date.now();
+        await next();
+        c.header("X-Response-Time", String(Date.now() - start));
+      });
+      app.get("/health", (c: any) => c.json({ ok: true }));
+      export default app;
+    `);
+  });
+});
+
+describe("real-world: React (hooks + components)", () => {
+  it("compiles a function component using useState", async () => {
+    await compileValid(`
+      import { useState } from "react";
+      export function Counter(initial: number): number {
+        const [count, setCount] = useState(initial);
+        setCount(count + 1);
+        return count;
+      }
+    `);
+  });
+
+  it("compiles a custom hook using useState + useEffect", async () => {
+    await compileValid(`
+      import { useState, useEffect } from "react";
+      export function useTick(start: number): number {
+        const [tick, setTick] = useState(start);
+        useEffect(() => {
+          setTick(tick + 1);
+        }, []);
+        return tick;
+      }
+    `);
+  });
+});
+
+describe("real-world: Express (Node web framework)", () => {
+  it("compiles routing with req/res handlers", async () => {
+    await compileValid(`
+      import express from "express";
+      const app = express();
+      app.get("/", (req: any, res: any) => {
+        res.send("Hello World");
+      });
+      app.get("/users/:id", (req: any, res: any) => {
+        res.status(200).json({ id: req.params.id });
+      });
+      app.listen(3000);
+      export function port(): number {
+        return 3000;
+      }
+    `);
+  });
+
+  it("compiles app.use() middleware", async () => {
+    await compileValid(`
+      import express from "express";
+      const app = express();
+      app.use((req: any, res: any, next: any) => {
+        next();
+      });
+      app.post("/echo", (req: any, res: any) => {
+        res.json({ received: true });
+      });
+      export function ready(): number {
+        return 1;
+      }
+    `);
+  });
+});

--- a/tests/real-world-helpers.ts
+++ b/tests/real-world-helpers.ts
@@ -1,0 +1,61 @@
+import { compile, type CompileOptions, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * Shared helpers for the `real-world-*.test.ts` suites (#1575-adjacent).
+ *
+ * These tests cover code patterns that test262 (the ECMAScript conformance
+ * suite) does **not** exercise: ES module import/export wiring, host Web APIs
+ * (`fetch`, `URL`, `TextEncoder`, …), runtime APIs (WASI / Node / Deno), and
+ * popular frameworks (Hono, React, Express). The point is to lock in that
+ * idiomatic real-world source *compiles to a valid Wasm module* and wires up
+ * the expected host-import boundary — not to re-run the JS engine semantics
+ * that test262 already covers.
+ *
+ * This module deliberately does NOT import `vitest`, so it can be imported
+ * from any test file (and re-used from probes) without tripping vitest's
+ * "internal state" guard.
+ */
+
+/** Compile real-world TS source with a `.ts` virtual filename (enables the
+ *  npm/Node import-resolver paths). Returns the raw {@link CompileResult}. */
+export function compileReal(source: string, opts: CompileOptions = {}): Promise<CompileResult> {
+  return compile(source, { fileName: "test.ts", ...opts });
+}
+
+/** Compile and assert the module is producible and the binary validates.
+ *  Throws with the compiler diagnostics on failure so the test message is
+ *  actionable. Returns the {@link CompileResult} for further assertions on
+ *  `.wat` / `.imports`. */
+export async function compileValid(source: string, opts: CompileOptions = {}): Promise<CompileResult> {
+  const result = await compileReal(source, opts);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  if (!WebAssembly.validate(result.binary)) {
+    throw new Error(`WebAssembly.validate() rejected the binary\nWAT:\n${result.wat}`);
+  }
+  return result;
+}
+
+/** Names of the host (`env.*`) imports the module requests — handy for
+ *  asserting that a real-world snippet lowered to the expected host boundary
+ *  (e.g. `fetch` -> `env.fetch`, `crypto.randomUUID()` -> `env.__crypto_random_uuid`). */
+export function hostImportNames(result: CompileResult): string[] {
+  return (result.imports ?? []).filter((i) => i.module === "env").map((i) => i.name);
+}
+
+/** Compile, instantiate with the faithful runtime host imports, and return
+ *  the exports. `deps` supplies host globals (e.g. `{ crypto }`, a mock
+ *  `document`) that the runtime resolves opaque externref calls against. */
+export async function instantiate(
+  source: string,
+  deps: Record<string, unknown> = {},
+  opts: CompileOptions = {},
+): Promise<Record<string, Function>> {
+  const result = await compileValid(source, opts);
+  const imports = buildImports(result.imports, deps, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}

--- a/tests/real-world-modules.test.ts
+++ b/tests/real-world-modules.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { compileValid, instantiate } from "./real-world-helpers.js";
+
+/**
+ * Real-world ES module import / export wiring.
+ *
+ * test262 runs each file as a standalone script/module and never exercises
+ * the *bundler-facing* surface real apps depend on: a module that re-exports,
+ * aliases, mixes default + named exports, or pulls symbols in from another
+ * package. These assert that idiomatic module source compiles to a valid Wasm
+ * module and that the exported functions are callable.
+ */
+describe("real-world: ES modules (import / export)", () => {
+  it("compiles mixed default + named exports and runs them", async () => {
+    const exports = await instantiate(`
+      export const TAX_RATE = 0.2;
+      export function withTax(price: number): number {
+        return price * (1 + TAX_RATE);
+      }
+      export default function net(gross: number): number {
+        return gross / (1 + TAX_RATE);
+      }
+    `);
+    expect(exports.withTax(100)).toBe(120);
+  });
+
+  it("compiles export lists with `as` aliases and runs the alias", async () => {
+    const exports = await instantiate(`
+      function multiply(a: number, b: number): number {
+        return a * b;
+      }
+      function subtract(a: number, b: number): number {
+        return a - b;
+      }
+      export { multiply as product, subtract };
+    `);
+    expect(exports.product(4, 5)).toBe(20);
+    expect(exports.subtract(9, 4)).toBe(5);
+  });
+
+  it("compiles a named import from a bare package specifier", async () => {
+    // `import { Hono } from "hono"` is rewritten to a host-import stub by the
+    // import resolver; the module must still produce a valid binary.
+    await compileValid(`
+      import { Hono } from "hono";
+      export function makeApp(): number {
+        const app = new Hono();
+        return 1;
+      }
+    `);
+  });
+
+  it("compiles a default import from a bare package specifier", async () => {
+    await compileValid(`
+      import express from "express";
+      export function makeApp(): number {
+        const app = express();
+        return 1;
+      }
+    `);
+  });
+
+  it("compiles a namespace import from a node: builtin", async () => {
+    await compileValid(`
+      import * as path from "node:path";
+      export function join2(a: string, b: string): string {
+        return path.join(a, b);
+      }
+    `);
+  });
+
+  it("compiles renamed named imports", async () => {
+    await compileValid(
+      `
+      import { readFileSync as read } from "node:fs";
+      export function load(p: string): string {
+        return read(p, "utf8");
+      }
+    `,
+      { allowFs: true },
+    );
+  });
+
+  it("compiles a module that both imports and re-exports", async () => {
+    await compileValid(`
+      import { useState } from "react";
+      export { useState };
+      export function Counter(): number {
+        const [count] = useState(0);
+        return count;
+      }
+    `);
+  });
+});

--- a/tests/real-world-node-deno.test.ts
+++ b/tests/real-world-node-deno.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { compileValid, hostImportNames } from "./real-world-helpers.js";
+
+/**
+ * Real-world server-runtime APIs: Node.js and Deno.
+ *
+ * Neither runtime's API surface is part of the ECMAScript spec, so test262
+ * never covers `process`, `Buffer`, `node:*` builtins, or the `Deno.*`
+ * namespace. These assert that idiomatic Node/Deno source compiles to a valid
+ * Wasm module and routes the runtime calls through the host-import boundary.
+ */
+describe("real-world: Node.js APIs", () => {
+  it("compiles node:path imports", async () => {
+    await compileValid(`
+      import { join, basename, extname } from "node:path";
+      export function describe(p: string): string {
+        return join(basename(p), extname(p));
+      }
+    `);
+  });
+
+  it("compiles node:fs readFileSync (with allowFs)", async () => {
+    await compileValid(
+      `
+        import { readFileSync } from "node:fs";
+        export function read(p: string): string {
+          return readFileSync(p, "utf8");
+        }
+      `,
+      { allowFs: true },
+    );
+  });
+
+  it("compiles node:crypto randomUUID", async () => {
+    await compileValid(`
+      import { randomUUID } from "node:crypto";
+      export function id(): string {
+        return randomUUID();
+      }
+    `);
+  });
+
+  it("lowers process.env access to a host import", async () => {
+    const result = await compileValid(`
+      declare const process: { env: Record<string, string> };
+      export function home(): string {
+        return process.env.HOME;
+      }
+    `);
+    expect(hostImportNames(result)).toContain("__get_process_env");
+  });
+
+  it("compiles process.stdout.write", async () => {
+    await compileValid(`
+      declare const process: { stdout: { write(s: string): void } };
+      export function log(line: string): void {
+        process.stdout.write(line);
+      }
+    `);
+  });
+
+  it("compiles Buffer.from(...).length", async () => {
+    await compileValid(`
+      export function byteLength(s: string): number {
+        return Buffer.from(s, "utf8").length;
+      }
+    `);
+  });
+});
+
+describe("real-world: Deno APIs", () => {
+  it("compiles Deno.cwd()", async () => {
+    await compileValid(`
+      declare const Deno: { cwd(): string };
+      export function pwd(): string {
+        return Deno.cwd();
+      }
+    `);
+  });
+
+  it("compiles Deno.env.get()", async () => {
+    await compileValid(`
+      declare const Deno: { env: { get(key: string): string | undefined } };
+      export function home(): string | undefined {
+        return Deno.env.get("HOME");
+      }
+    `);
+  });
+
+  it("compiles Deno.readTextFile() with await", async () => {
+    await compileValid(`
+      declare const Deno: { readTextFile(p: string): Promise<string> };
+      export async function size(p: string): Promise<number> {
+        const text = await Deno.readTextFile(p);
+        return text.length;
+      }
+    `);
+  });
+
+  it("compiles a Deno.serve() handler returning a Response", async () => {
+    await compileValid(`
+      declare const Deno: { serve(handler: (req: any) => any): void };
+      export function start(): void {
+        Deno.serve((req: any) => new Response("ok"));
+      }
+    `);
+  });
+});

--- a/tests/real-world-wasi.test.ts
+++ b/tests/real-world-wasi.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * Real-world WASI command-line programs (`--target wasi`).
+ *
+ * test262 targets a JS engine; it never covers compiling to a standalone WASI
+ * module that talks to the host via `wasi_snapshot_preview1` (fd_write,
+ * proc_exit, args, …). These pin down that ordinary "CLI tool" source lowers
+ * to the WASI ABI and produces a valid, instantiable module.
+ */
+describe("real-world: WASI command-line programs", () => {
+  it("lowers console.log to fd_write and produces a valid module", async () => {
+    const result = await compile(
+      `
+        export function main(): void {
+          let sum = 0;
+          for (let i = 1; i <= 10; i++) sum += i;
+          console.log("sum:", sum);
+        }
+      `,
+      { target: "wasi" },
+    );
+    expect(result.success).toBe(true);
+    expect(result.wat).toContain("wasi_snapshot_preview1");
+    expect(result.wat).toContain("fd_write");
+    expect(result.wat).not.toContain("console_log");
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("exports memory and _start for the WASI runtime", async () => {
+    const result = await compile(`console.log("hello, wasi");`, { target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(result.wat).toContain('(export "memory"');
+    expect(result.wat).toContain('(export "_start"');
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("reads process.argv as a valid WASI module", async () => {
+    const result = await compile(
+      `
+        declare const process: { argv: string[] };
+        export function argc(): number {
+          return process.argv.length;
+        }
+      `,
+      { target: "wasi" },
+    );
+    expect(result.success).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("lowers process.exit to proc_exit", async () => {
+    const result = await compile(
+      `
+        declare const process: { exit(code: number): void };
+        console.log("bye");
+        process.exit(0);
+      `,
+      { target: "wasi" },
+    );
+    expect(result.success).toBe(true);
+    expect(result.wat).toContain("proc_exit");
+  });
+
+  // KNOWN BUG (#6407): process.exit(N) under --target wasi currently emits an
+  // invalid module — the exit-code argument is compiled as an i32 but then an
+  // `i32.trunc_sat_f64_s` (which expects f64) is pushed on top of it
+  // (src/codegen/expressions/calls.ts:3180-3186). `it.fails` keeps this
+  // documented and *passing* while the bug stands; it will flip to a hard
+  // failure once codegen is fixed, prompting removal of the `.fails` modifier.
+  // The existing wasi-target.test.ts only checks WAT text, so it never caught
+  // this.
+  it.fails("process.exit currently produces an invalid binary (known codegen bug)", async () => {
+    const result = await compile(
+      `
+        declare const process: { exit(code: number): void };
+        process.exit(0);
+      `,
+      { target: "wasi" },
+    );
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("does not emit WASI imports under the default gc target", async () => {
+    const result = await compile(`console.log("hello");`);
+    expect(result.success).toBe(true);
+    expect(result.wat).not.toContain("wasi_snapshot_preview1");
+    expect(result.wat).not.toContain("fd_write");
+  });
+});

--- a/tests/real-world-web-apis.test.ts
+++ b/tests/real-world-web-apis.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { compileValid, hostImportNames, instantiate } from "./real-world-helpers.js";
+
+/**
+ * Real-world browser / Web-platform APIs.
+ *
+ * These globals (`fetch`, `URL`, `TextEncoder`, `crypto`, timers, the DOM…)
+ * are not part of the ECMAScript spec, so test262 never touches them. Real
+ * apps use them constantly. The compiler lowers each to a host-import at the
+ * Wasm boundary; these tests pin down that the lowering produces a valid
+ * module and requests the expected `env.*` import.
+ */
+describe("real-world: Web APIs", () => {
+  it("lowers fetch() to a host import and awaits a Response", async () => {
+    const result = await compileValid(`
+      export async function fetchLength(url: string): Promise<number> {
+        const res = await fetch(url);
+        const text = await res.text();
+        return text.length;
+      }
+    `);
+    const hosts = hostImportNames(result);
+    expect(hosts).toContain("fetch");
+    expect(hosts).toContain("Response_text");
+  });
+
+  it("lowers timers to host imports", async () => {
+    const result = await compileValid(`
+      export function schedule(): void {
+        setTimeout(() => {
+          console.log("tick");
+        }, 100);
+      }
+    `);
+    expect(hostImportNames(result)).toContain("__timer_set_timeout");
+  });
+
+  it("compiles TextEncoder().encode()", async () => {
+    await compileValid(`
+      export function byteLength(s: string): number {
+        return new TextEncoder().encode(s).length;
+      }
+    `);
+  });
+
+  it("compiles URL parsing", async () => {
+    await compileValid(`
+      export function hostname(u: string): string {
+        return new URL(u).hostname;
+      }
+    `);
+  });
+
+  it("runs crypto.randomUUID() through the host boundary", async () => {
+    const result = await compileValid(`
+      declare const crypto: { randomUUID(): string };
+      export function id(): string {
+        return crypto.randomUUID();
+      }
+    `);
+    expect(hostImportNames(result)).toContain("__crypto_random_uuid");
+
+    const exports = await instantiate(
+      `
+        declare const crypto: { randomUUID(): string };
+        export function id(): string {
+          return crypto.randomUUID();
+        }
+      `,
+      { crypto },
+    );
+    const uuid = exports.id() as string;
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("compiles assorted Web globals (structuredClone, queueMicrotask, btoa, AbortController)", async () => {
+    await compileValid(`
+      export function clone(o: any): any {
+        return structuredClone(o);
+      }
+      export function micro(): void {
+        queueMicrotask(() => {});
+      }
+      export function base64(s: string): string {
+        return btoa(s);
+      }
+      export function abortable(): any {
+        const c = new AbortController();
+        c.abort();
+        return c.signal;
+      }
+    `);
+  });
+
+  it("compiles a Headers map", async () => {
+    await compileValid(`
+      export function header(name: string, value: string): string | null {
+        const h = new Headers();
+        h.set(name, value);
+        return h.get(name);
+      }
+    `);
+  });
+
+  it("runs DOM manipulation against a host document", async () => {
+    const makeEl = (): Record<string, any> => {
+      const el: Record<string, any> = {
+        style: {},
+        textContent: "",
+        children: [] as any[],
+        append(child: any) {
+          el.children.push(child);
+          return child;
+        },
+      };
+      return el;
+    };
+    const body = makeEl();
+    const document = { createElement: () => makeEl(), body };
+
+    const exports = await instantiate(
+      `
+        declare const document: any;
+        export function render(label: string): number {
+          const box = document.createElement("div");
+          box.textContent = label;
+          box.style.color = "red";
+          document.body.append(box);
+          return 1;
+        }
+      `,
+      { document },
+    );
+
+    expect(exports.render("Hello")).toBe(1);
+    expect(body.children).toHaveLength(1);
+    expect(body.children[0].textContent).toBe("Hello");
+    expect(body.children[0].style.color).toBe("red");
+  });
+});


### PR DESCRIPTION
## What

Adds **37 tests across six files** covering idiomatic real-world code that **test262 does not exercise** — the conformance suite runs pure ECMAScript, so it never touches module wiring, host platform APIs, or frameworks.

| File | Tests | Covers |
|------|-------|--------|
| `tests/real-world-modules.test.ts` | 7 | default+named exports, `export { x as y }` aliases, named/default/namespace/renamed imports from bare & `node:` specifiers, import-and-re-export |
| `tests/real-world-web-apis.test.ts` | 8 | `fetch`→`env.fetch`, timers, `TextEncoder`, `URL`, `crypto.randomUUID` (**runs**, asserts UUID shape), `structuredClone`/`btoa`/`AbortController`, `Headers`, DOM against a mock `document` (**runs**) |
| `tests/real-world-wasi.test.ts` | 6 | `console.log`→`fd_write`, `_start`/`memory` exports, `process.argv`, `process.exit`→`proc_exit`, gc-target negative check |
| `tests/real-world-node-deno.test.ts` | 10 | `node:path`/`node:fs`/`node:crypto`, `process.env`→`env.__get_process_env`, `process.stdout.write`, `Buffer.from`; `Deno.cwd`/`env.get`/`readTextFile`/`serve` |
| `tests/real-world-frameworks.test.ts` | 6 | Hono (routing/params/json/middleware), React (`useState`/`useEffect` hooks), Express (req/res routing + `app.use`) |
| `tests/real-world-helpers.ts` | — | shared `compileValid` / `instantiate` / `hostImportNames` (not a `.test.ts`, so vitest skips it) |

Tests assert that real-world source **compiles to a valid Wasm module** and lowers to the **expected host-import boundary** (the repo's established idiom — cf. `wasi-target`, `react-hooks`, `dom-style-assignment`). A handful go further and **instantiate + run** where the host wiring is reliable (modules, `crypto.randomUUID`, DOM). Every snippet was empirically verified to compile before being asserted on.

## Bug found + filed: #6407

`process.exit(code)` under `--target wasi` reports `success: true` but emits an **invalid** binary — the exit code is compiled as `i32` and then an `i32.trunc_sat_f64_s` (which expects f64) is pushed on top of it (`src/codegen/expressions/calls.ts:3180-3186`). The existing `wasi-target.test.ts` only checks WAT text, so it never caught this. Captured here as an `it.fails` sentinel in `real-world-wasi.test.ts` that **passes while the bug stands and flips to a hard failure once codegen is fixed** (prompting removal of `.fails`). Tracking issue `plan/issues/6407-wasi-process-exit-invalid-binary.md` + backlog entry included.

## Validation

- `vitest run` on all five suites: **37 passed** (against fresh `origin/main`)
- `prettier --check`, `biome lint`, `tsc --noEmit`: clean (lint-staged also ran on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)