### PR TITLE
chore: harden next-issue-id allocator vs stray IDs + renumber WASI process.exit bug to #1859

### DIFF
--- a/plan/issues/1859-wasi-process-exit-invalid-binary.md
+++ b/plan/issues/1859-wasi-process-exit-invalid-binary.md
@@ -1,0 +1,101 @@
+---
+id: 1859
+title: "WASI process.exit(code) emits an invalid binary (i32/f64 stack mismatch in trunc)"
+status: ready
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: wasi-process-exit
+goal: correctness
+related: [1858]
+---
+# #1859 — WASI `process.exit(code)` emits an invalid binary
+
+> Renumbered from a stray `6407-*` id (see #1858 allocator-hygiene note). Example
+> of the audit's "no `WebAssembly.validate()` in the pipeline → silent invalid
+> binary" theme.
+
+## Problem
+
+Compiling `process.exit(N)` with `--target wasi` (`{ target: "wasi" }`)
+reports `success: true` but produces a module that **fails
+`WebAssembly.validate()`**. Instantiating it throws:
+
+```
+CompileError: WebAssembly.compile(): Compiling function #1:"__module_init"
+failed: i32.trunc_sat_f64_s[0] expected type f64, found i32.const of type i32
+```
+
+Reproduces for every code value (`process.exit(0)`, `(1)`, `(42)`), with or
+without a preceding `console.log`. The existing `tests/wasi-target.test.ts`
+only asserts that the WAT text contains `proc_exit`, so it never exercised
+binary validity and did not catch this.
+
+```ts
+const r = await compile(
+  `declare const process: { exit(code: number): void }; process.exit(0);`,
+  { target: "wasi" },
+);
+r.success;                          // true
+WebAssembly.validate(r.binary);     // false  <-- bug
+```
+
+## Root cause
+
+`src/codegen/expressions/calls.ts` (the WASI `process.exit` special case):
+
+```ts
+if (expr.arguments.length >= 1) {
+  compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "i32" }); // pushes i32
+  const argType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+  if (isNumberType(argType)) {
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);          // expects f64
+  }
+}
+```
+
+The argument is compiled with expected type `{ kind: "i32" }`, so
+`compileExpression` already coerces the value to an `i32` on the stack (for a
+literal it emits `i32.const 0`). The code then *also* pushes
+`i32.trunc_sat_f64_s`, which expects an **f64** operand — but the stack holds
+an `i32`. Hence the validation failure. The `i32`-expected compile and the
+`f64→i32` truncation are mutually exclusive; the code does both.
+
+`proc_exit` itself takes an `i32` (`addFuncType(ctx, [{ kind: "i32" }], …)`,
+`src/codegen/index.ts`), so the call target type is correct — only the operand
+lowering is wrong. (Re-verify exact line numbers before editing.)
+
+## Fix (one of)
+
+1. **Drop the redundant truncation** — `compileExpression(…, { kind: "i32" })`
+   already delivers an `i32`, so remove the `i32.trunc_sat_f64_s` push
+   entirely. Simplest, and correct for the common literal/number-expression
+   case.
+2. **Truncate from f64** — compile the argument with `{ kind: "f64" }` and keep
+   the `i32.trunc_sat_f64_s`. Equivalent result; matches the apparent original
+   intent of "the expression might produce f64."
+
+Either makes the stack types line up. Prefer (1) unless there is a reason the
+argument must round-trip through f64.
+
+## Acceptance criteria
+
+- `WebAssembly.validate()` returns `true` for `process.exit(0)`,
+  `process.exit(1)`, `process.exit(42)` under `--target wasi`.
+- The module still imports `wasi_snapshot_preview1.proc_exit` and calls it
+  with the correct code.
+- A binary-validity assertion guards the WASI `process.exit` path (so a WAT-only
+  test can't mask a regression again).
+
+## Test sentinel already in place
+
+`tests/real-world-wasi.test.ts` carries an `it.fails(...)` sentinel asserting
+`WebAssembly.validate(...) === true` for `process.exit(0)`. It passes while the
+bug stands and will flip to a hard failure once codegen is fixed — at which
+point remove the `.fails` modifier (and the explanatory comment) so it becomes
+a normal regression guard.

--- a/scripts/next-issue-id.mjs
+++ b/scripts/next-issue-id.mjs
@@ -33,17 +33,52 @@ function sh(cmd) {
   return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
 }
 
-try { sh("git fetch origin --quiet"); } catch { /* offline */ }
-
-try { addFrom(readdirSync("plan/issues").join("\n")); } catch { /* skip */ }
+try {
+  sh("git fetch origin --quiet");
+} catch {
+  /* offline */
+}
 
 try {
-  const refs = sh("git for-each-ref --format='%(refname)' refs/remotes/origin")
-    .split("\n").filter(Boolean);
-  for (const ref of refs) {
-    try { addFrom(sh(`git ls-tree -r ${ref} --name-only -- plan/issues`)); } catch { /* skip */ }
-  }
-} catch { /* no remotes */ }
+  addFrom(readdirSync("plan/issues").join("\n"));
+} catch {
+  /* skip */
+}
 
-const max = ids.size ? Math.max(...ids) : 0;
+try {
+  const refs = sh("git for-each-ref --format='%(refname)' refs/remotes/origin").split("\n").filter(Boolean);
+  for (const ref of refs) {
+    try {
+      addFrom(sh(`git ls-tree -r ${ref} --name-only -- plan/issues`));
+    } catch {
+      /* skip */
+    }
+  }
+} catch {
+  /* no remotes */
+}
+
+// Exclude outlier ids separated from the main body by a large gap. A single
+// stray out-of-range file (e.g. a mis-typed `6406`/`6407` when the real range
+// is ~1800) must not poison `max + 1` and hand out a 6408 — that mis-allocation
+// is exactly what #1858 hit. Real issue numbering increments by 1 and never
+// jumps more than a few dozen, so anything beyond GAP above the running max is
+// treated as a stray and ignored (logged to stderr for visibility).
+const GAP = 1000;
+const sorted = [...ids].sort((a, b) => a - b);
+let max = 0;
+const ignored = [];
+for (const id of sorted) {
+  if (max > 0 && id - max > GAP) {
+    ignored.push(...sorted.filter((x) => x >= id));
+    break;
+  }
+  max = id;
+}
+if (ignored.length) {
+  process.stderr.write(
+    `next-issue-id: ignoring ${ignored.length} out-of-range stray id(s) ` +
+      `(>${GAP} above the contiguous body): ${ignored.join(", ")}\n`,
+  );
+}
 process.stdout.write(`${max + 1}\n`);


### PR DESCRIPTION
Issue-ID hygiene follow-up to #1858 (the allocator returned **6408** for that issue because stray out-of-range files poisoned its `max+1` scan).

## 1. Harden `scripts/next-issue-id.mjs`
Exclude outlier IDs separated from the contiguous body by a **>1000 gap**, so a single stray out-of-range file can no longer drag the next ID into the 6xxx range. Ignored IDs are logged to stderr. Real issue numbering increments by 1 (max observed gap in the live range is 31), so 1000 is a safe cliff.

Before: `6408` (poisoned by stray `6406`/`6407`). After: `1860`, with stderr `ignoring 2 out-of-range stray id(s) ... 6406, 6407`.

## 2. Renumber the genuine stray `6407 → #1859`
`6407-wasi-process-exit-invalid-binary` was a real, well-specified WASI bug that only ever existed as a **local untracked file with a wrong 6xxx ID**. Refiled properly as `plan/issues/1859-wasi-process-exit-invalid-binary.md`. It documents `process.exit(code)` under `--target wasi` emitting a binary that fails `WebAssembly.validate()` — a concrete instance of the #1858 "no `validate()` in the pipeline" theme (a test sentinel already exists in `tests/real-world-wasi.test.ts`).

`6406` needed no renumber — it's **already filed on `main` as #1804**; its `6406-*` leftovers live only on stale merged branches, which the hardening now neutralizes.

## Scope
`scripts/` + `plan/`. No compiler source changes. `pnpm run check:issues` passes; hardened allocator verified to return 1860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)