### PR TITLE
fix(#1845): IR propagate — sound && / || result type; seed i32/u32

### DIFF
--- a/plan/issues/1845-ir-propagate-bool-overclaim-seedconcrete.md
+++ b/plan/issues/1845-ir-propagate-bool-overclaim-seedconcrete.md
@@ -1,9 +1,10 @@
 ---
 id: 1845
 title: "IR propagate: && / || over-claim BOOL; seedConcrete omits i32/u32"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: low
 task_type: bugfix
@@ -24,4 +25,34 @@ sprint: 59
 ## Fix
 Infer `BOOL` for `&&`/`||` only when both operands are concretely `bool` (treat
 `unknown` as dynamic / join); include i32/u32 in `seedConcrete` (or document why not).
+
+## Resolution
+`src/ir/propagate.ts`:
+- **`&&`/`||` rule** (was `boolCompatible(l) && boolCompatible(r) ? BOOL : DYNAMIC`):
+  `a && b` / `a || b` evaluate to one of the *operand values* (ECMAScript
+  §13.13/§13.14), not a coerced boolean. New rule: `BOOL` only when both operands
+  are concretely `bool`; if either side is `unknown`/`dynamic` → `DYNAMIC` (can't
+  prove the result shape — `join` would optimistically adopt the other side);
+  otherwise `join(l, r)` (the tightest sound type for "one of two concrete
+  values", e.g. `f64 && f64 → f64`). This stops a non-boolean param/return being
+  seeded as `bool` and then lowered with `i32.and`/`i32.or`.
+- **`seedConcrete`**: added `i32`/`u32` alongside `f64`/`bool`/`string`/`object`,
+  so an integer-domain seed retains authority over an unresolved (`dynamic`) body
+  return once integer-domain seeding is enabled (`JS2WASM_IR_I32_DOMAIN=1`).
+  Currently latent (the TS checker seeds `number` → `f64`), fixed for correctness.
+
+## Test Results
+`tests/issue-1845.test.ts` (4 cases, exercises `_internals.inferExpr` with a
+custom param lattice scope):
+- both operands concretely bool → BOOL (preserved).
+- `unknown && bool` / `bool || unknown` / `unknown && unknown` → DYNAMIC (was the
+  BOOL over-claim).
+- `f64 && f64` / `f64 || f64` → F64 (was DYNAMIC — now the tighter sound join).
+- mixed `f64 && bool` → never BOOL.
+
+Pre-fix: the unknown-over-claim and the f64-join cases fail (verified by reverting
+the rule). Post-fix: 4/4 pass. `ir-propagate-i32*.test.ts` and
+`ir-frontend-widening.test.ts` remain green; pre-existing unrelated IR equivalence
+harness failures (`__box_number` LinkError; `func.params is not iterable`) are
+identical with and without this change.
 

--- a/src/ir/propagate.ts
+++ b/src/ir/propagate.ts
@@ -312,8 +312,18 @@ export function buildTypeMap(sourceFile: ts.SourceFile, checker: ts.TypeChecker)
       }
       let newReturn: LatticeType = seed.returnType;
       if (fn.body) {
+        // #1845 — a concrete seed keeps its authority over a `dynamic` body
+        // inference (our expression inference is deliberately narrow, so
+        // `dynamic` usually just means "couldn't see through the local
+        // structure"). The integer subdomains `i32`/`u32` are every bit as
+        // concrete as `f64`/`bool`/`string`/`object` and must be listed here
+        // too — otherwise, once integer-domain seeding is enabled
+        // (`JS2WASM_IR_I32_DOMAIN=1`), an i32/u32 seed would be silently
+        // widened to `dynamic` by an unresolved body return.
         const seedConcrete =
           seed.returnType.kind === "f64" ||
+          seed.returnType.kind === "i32" ||
+          seed.returnType.kind === "u32" ||
           seed.returnType.kind === "bool" ||
           seed.returnType.kind === "string" ||
           seed.returnType.kind === "object";
@@ -614,7 +624,20 @@ function inferExpr(
         return DYNAMIC;
       case ts.SyntaxKind.AmpersandAmpersandToken:
       case ts.SyntaxKind.BarBarToken:
-        return boolCompatible(l) && boolCompatible(r) ? BOOL : DYNAMIC;
+        // #1845 — `a && b` / `a || b` evaluate to one of the *operand values*
+        // (per ECMAScript §13.13/§13.14 ShortCircuit), NOT a coerced boolean.
+        // The previous rule claimed `BOOL` whenever both sides were merely
+        // `boolCompatible`, which also accepts `unknown` — so an unresolved
+        // (possibly non-boolean) param/return got seeded as `bool`, and
+        // `lowerBinary` would then emit `i32.and`/`i32.or` on a non-integer
+        // value. Sound rule: the tightest type is the join of the two operand
+        // values, but only when both are *concrete* — `unknown` on either side
+        // means we cannot prove the result's shape (`join` would optimistically
+        // adopt the other side's type), so it falls to `DYNAMIC`.
+        if (l.kind === "unknown" || r.kind === "unknown" || l.kind === "dynamic" || r.kind === "dynamic") {
+          return DYNAMIC;
+        }
+        return join(l, r);
       default:
         return DYNAMIC;
     }

--- a/tests/issue-1845.test.ts
+++ b/tests/issue-1845.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1845 — IR type-propagation soundness for `&&` / `||`.
+//
+// `a && b` / `a || b` evaluate to one of the OPERAND VALUES (ECMAScript
+// §13.13/§13.14 ShortCircuit), not a coerced boolean. The previous rule
+// (`boolCompatible(l) && boolCompatible(r) ? BOOL : DYNAMIC`) over-claimed
+// `BOOL` because `boolCompatible` also accepts `unknown` — so an unresolved
+// (possibly non-boolean) operand was seeded as `bool`, and `lowerBinary`
+// would then emit `i32.and`/`i32.or` on a non-integer value.
+//
+// New rule: `BOOL` only when both operands are concretely `bool`; otherwise
+// the result is `join(l, r)` of the two concrete operand values, and
+// `unknown`/`dynamic` on either side falls to `DYNAMIC`.
+
+import { describe, expect, it } from "vitest";
+import * as ts from "typescript";
+
+import { _internals, type LatticeType } from "../src/ir/propagate.js";
+
+const { inferExpr, F64, BOOL, UNKNOWN, DYNAMIC } = _internals;
+
+function inferLogical(exprSrc: string, params: ReadonlyArray<{ name: string; type: LatticeType }>): LatticeType {
+  const paramList = params.map((p) => `${p.name}: number`).join(", ");
+  const sourceText = `function _wrap(${paramList}) { return ${exprSrc}; }`;
+  const sf = ts.createSourceFile("_wrap.ts", sourceText, ts.ScriptTarget.Latest, true);
+  const fn = sf.statements[0];
+  if (!ts.isFunctionDeclaration(fn) || !fn.body) throw new Error("test setup: bad source");
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) throw new Error("test setup: no return");
+  const scope = new Map<string, LatticeType>();
+  for (const p of params) scope.set(p.name, p.type);
+  return inferExpr(stmt.expression, scope, new Map());
+}
+
+describe("#1845 — && / || propagation soundness", () => {
+  it("infers BOOL when both operands are concretely bool", () => {
+    expect(
+      inferLogical("a && b", [
+        { name: "a", type: BOOL },
+        { name: "b", type: BOOL },
+      ]),
+    ).toEqual(BOOL);
+    expect(
+      inferLogical("a || b", [
+        { name: "a", type: BOOL },
+        { name: "b", type: BOOL },
+      ]),
+    ).toEqual(BOOL);
+  });
+
+  it("does NOT over-claim BOOL when an operand is unknown", () => {
+    // The regression: `boolCompatible(unknown)` was true, so this returned
+    // BOOL — seeding a possibly-non-boolean value as bool. Must be DYNAMIC.
+    expect(
+      inferLogical("a && b", [
+        { name: "a", type: UNKNOWN },
+        { name: "b", type: BOOL },
+      ]),
+    ).toEqual(DYNAMIC);
+    expect(
+      inferLogical("a || b", [
+        { name: "a", type: BOOL },
+        { name: "b", type: UNKNOWN },
+      ]),
+    ).toEqual(DYNAMIC);
+    expect(
+      inferLogical("a && b", [
+        { name: "a", type: UNKNOWN },
+        { name: "b", type: UNKNOWN },
+      ]),
+    ).toEqual(DYNAMIC);
+  });
+
+  it("joins concrete numeric operands instead of dropping to DYNAMIC", () => {
+    // Both f64 → the result is one of two f64 values, so the sound (and
+    // tighter) type is F64. The old rule returned DYNAMIC here.
+    expect(
+      inferLogical("a && b", [
+        { name: "a", type: F64 },
+        { name: "b", type: F64 },
+      ]),
+    ).toEqual(F64);
+    expect(
+      inferLogical("a || b", [
+        { name: "a", type: F64 },
+        { name: "b", type: F64 },
+      ]),
+    ).toEqual(F64);
+  });
+
+  it("never claims BOOL for a mixed bool/non-bool pair", () => {
+    // f64 && bool: the result is either an f64 or a bool — definitely not a
+    // guaranteed boolean. Must not be BOOL (it joins to a union here).
+    const r = inferLogical("a && b", [
+      { name: "a", type: F64 },
+      { name: "b", type: BOOL },
+    ]);
+    expect(r).not.toEqual(BOOL);
+  });
+});


### PR DESCRIPTION
Fixes #1845. IR type propagation: short-circuit `&&`/`||` no longer over-claims BOOL when an operand is numeric; `seedConcrete` seeds i32/u32 paths.

Implemented by dev-1 (commit e7434ff59); branch push stalled twice on a GitHub network hang — pushed + PR opened by tech lead. CI/merge owned by pr-maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)