### PR TITLE
fix(#1836): standalone Number() parses 0o/0O octal and 0b/0B binary prefixes

### DIFF
--- a/plan/issues/1836-standalone-number-string-conformance.md
+++ b/plan/issues/1836-standalone-number-string-conformance.md
@@ -1,7 +1,7 @@
 ---
 id: 1836
 title: "Standalone Number<->String conformance gaps (0o/0b, toFixed 1e21, exponential, fractional radix, whitespace, ToNumber) (residual #1335)"
-status: ready
+status: in-progress
 created: 2026-06-04
 updated: 2026-06-04
 priority: high
@@ -34,4 +34,26 @@ path; JS-host delegates to V8 and is correct.
 Add octal/binary prefix arms; add the 1e21 / exponential branches; emit fractional
 radix digits; extend the whitespace predicate; emit a spec StringToNumber routine as
 the standalone ToNumber fallback (not parseFloat).
+
+## Progress (2026-06-04)
+
+### Slice 1 — DONE: octal/binary prefix parsing (§7.1.4.1)
+Fixed in `src/codegen/parse-number-native.ts` (`emitRadixPrefixParse`). Refactored
+`buildArm` to be self-conditioned (reads `data[i+1]` and uses the prefix-letter
+test as its own `if` condition) so three arms (`0x/0X`→16, `0o/0O`→8, `0b/0B`→2)
+can be sequenced inside the shared `0`-prefix guard; a non-matching arm is a no-op
+and falls through. Added `C_LC_B/C_UC_B/C_LC_O/C_UC_O` char-code constants.
+- `Number("0o17")`/`"0O17"` → 15; `Number("0b101")`/`"0B101"` → 5
+- `Number("0x1F")` → 31 unchanged; `Number("0o8")`/`"0b2"`/`"0o"` → NaN
+- `Number("-0x1F")` etc. → NaN (NonDecimalIntegerLiteral is unsigned)
+- `Number("08")` → 8 (leading-zero decimal, not legacy octal)
+Tests: `tests/issue-1836.test.ts` (8 tests). No regression in
+`tests/issue-1335-standalone.test.ts` (8) / `tests/issue-49-*` (7).
+
+### Residual defects (not in this PR — track as follow-up slices)
+- `(1e21).toFixed(2)` bogus 22-digit integer — `number-format-native.ts:894`. §21.1.3.3.
+- `(1e-7).toString()`→`"0"`, `(1e21).toString()` lacks `e` — `number-format-native.ts:470`. §6.1.6.1.20.
+- `(3.5).toString(2)` traps — fractional radix unimplemented (`:713`).
+- whitespace set misses U+FEFF, U+2028/2029, most Zs — `parse-number-native.ts:61`. §19.2.4/.5.
+- `+"12abc"` ToNumber(String) — VERIFIED already returns NaN on current main; appears fixed.
 

--- a/src/codegen/parse-number-native.ts
+++ b/src/codegen/parse-number-native.ts
@@ -33,11 +33,15 @@ const C_DOT = 46;
 const C_ZERO = 48;
 const C_NINE = 57;
 const C_UC_A = 65;
+const C_UC_B = 66;
 const C_UC_E = 69;
+const C_UC_O = 79;
 const C_UC_X = 88;
 const C_UC_Z = 90;
 const C_LC_A = 97;
+const C_LC_B = 98;
 const C_LC_E = 101;
+const C_LC_O = 111;
 const C_LC_X = 120;
 const C_LC_Z = 122;
 
@@ -834,100 +838,100 @@ function emitRadixPrefixParse(
   L_SAW: number,
   strDataTypeIdx: number,
 ): Instr[] {
-  const buildArm = (lc: number, uc: number, radix: number): Instr => ({
-    op: "if",
-    blockType: { kind: "empty" },
-    then: [
-      // second char is lc/uc?
-      { op: "local.get", index: L_DATA },
-      { op: "local.get", index: L_I },
-      { op: "i32.const", value: 1 },
-      { op: "i32.add" },
-      { op: "array.get_u", typeIdx: strDataTypeIdx },
-      { op: "local.tee", index: L_C },
-      { op: "i32.const", value: lc },
-      { op: "i32.eq" },
-      { op: "local.get", index: L_C },
-      { op: "i32.const", value: uc },
-      { op: "i32.eq" },
-      { op: "i32.or" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "i32.const", value: radix },
-          { op: "local.set", index: L_RADIX },
-          // advance past "0x"
-          { op: "local.get", index: L_I },
-          { op: "i32.const", value: 2 },
-          { op: "i32.add" },
-          { op: "local.set", index: L_I },
-          // require at least one digit
-          { op: "local.get", index: L_I },
-          { op: "local.get", index: L_END },
-          { op: "i32.ge_s" },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [{ op: "f64.const", value: NaN }, { op: "return" }],
-          },
-          { op: "f64.const", value: 0 },
-          { op: "local.set", index: L_RESULT },
-          // digit loop over [i, end)
-          {
-            op: "block",
-            blockType: { kind: "empty" },
-            body: [
-              {
-                op: "loop",
-                blockType: { kind: "empty" },
-                body: [
+  // Build a single prefix arm. Self-conditioned: it reads data[i+1] and uses
+  // the (== lc || == uc) test as its own `if` condition, so multiple arms can
+  // be sequenced inside the shared `0`-prefix guard — a non-matching arm is a
+  // no-op and control falls through to the next arm.
+  const buildArm = (lc: number, uc: number, radix: number): Instr[] => [
+    // second char is lc/uc?
+    { op: "local.get", index: L_DATA },
+    { op: "local.get", index: L_I },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "local.tee", index: L_C },
+    { op: "i32.const", value: lc },
+    { op: "i32.eq" },
+    { op: "local.get", index: L_C },
+    { op: "i32.const", value: uc },
+    { op: "i32.eq" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "i32.const", value: radix },
+        { op: "local.set", index: L_RADIX },
+        // advance past "0x"/"0o"/"0b"
+        { op: "local.get", index: L_I },
+        { op: "i32.const", value: 2 },
+        { op: "i32.add" },
+        { op: "local.set", index: L_I },
+        // require at least one digit
+        { op: "local.get", index: L_I },
+        { op: "local.get", index: L_END },
+        { op: "i32.ge_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+        },
+        { op: "f64.const", value: 0 },
+        { op: "local.set", index: L_RESULT },
+        // digit loop over [i, end)
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: L_I },
+                { op: "local.get", index: L_END },
+                { op: "i32.ge_s" },
+                { op: "br_if", depth: 1 },
+                ...([
+                  { op: "local.get", index: L_DATA },
                   { op: "local.get", index: L_I },
-                  { op: "local.get", index: L_END },
-                  { op: "i32.ge_s" },
-                  { op: "br_if", depth: 1 },
-                  ...([
-                    { op: "local.get", index: L_DATA },
-                    { op: "local.get", index: L_I },
-                    { op: "array.get_u", typeIdx: strDataTypeIdx },
-                    { op: "local.set", index: L_C },
-                  ] as Instr[]),
-                  ...emitDigitValue(L_C, L_DIG),
-                  // invalid digit or >= radix → NaN
-                  { op: "local.get", index: L_DIG },
-                  { op: "i32.const", value: 0 },
-                  { op: "i32.lt_s" },
-                  { op: "local.get", index: L_DIG },
-                  { op: "i32.const", value: radix },
-                  { op: "i32.ge_s" },
-                  { op: "i32.or" },
-                  {
-                    op: "if",
-                    blockType: { kind: "empty" },
-                    then: [{ op: "f64.const", value: NaN }, { op: "return" }],
-                  },
-                  { op: "local.get", index: L_RESULT },
-                  { op: "f64.const", value: radix },
-                  { op: "f64.mul" },
-                  { op: "local.get", index: L_DIG },
-                  { op: "f64.convert_i32_s" },
-                  { op: "f64.add" },
-                  { op: "local.set", index: L_RESULT },
-                  { op: "local.get", index: L_I },
-                  { op: "i32.const", value: 1 },
-                  { op: "i32.add" },
-                  { op: "local.set", index: L_I },
-                  { op: "br", depth: 0 },
-                ],
-              },
-            ],
-          },
-          { op: "local.get", index: L_RESULT },
-          { op: "return" },
-        ],
-      },
-    ],
-  });
+                  { op: "array.get_u", typeIdx: strDataTypeIdx },
+                  { op: "local.set", index: L_C },
+                ] as Instr[]),
+                ...emitDigitValue(L_C, L_DIG),
+                // invalid digit or >= radix → NaN
+                { op: "local.get", index: L_DIG },
+                { op: "i32.const", value: 0 },
+                { op: "i32.lt_s" },
+                { op: "local.get", index: L_DIG },
+                { op: "i32.const", value: radix },
+                { op: "i32.ge_s" },
+                { op: "i32.or" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+                },
+                { op: "local.get", index: L_RESULT },
+                { op: "f64.const", value: radix },
+                { op: "f64.mul" },
+                { op: "local.get", index: L_DIG },
+                { op: "f64.convert_i32_s" },
+                { op: "f64.add" },
+                { op: "local.set", index: L_RESULT },
+                { op: "local.get", index: L_I },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: L_I },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        { op: "local.get", index: L_RESULT },
+        { op: "return" },
+      ],
+    },
+  ];
   void L_SAW;
   return [
     // guard: sign==1 (no sign consumed) && i+1 < end && data[i]=='0'
@@ -946,7 +950,14 @@ function emitRadixPrefixParse(
     { op: "i32.const", value: C_ZERO },
     { op: "i32.eq" },
     { op: "i32.and" },
-    buildArm(C_LC_X, C_UC_X, 16),
+    // §7.1.4.1 StringToNumber: 0x/0X → hex, 0o/0O → octal, 0b/0B → binary.
+    // Each arm re-reads data[i+1] and only acts on its prefix letter, so a
+    // non-matching arm is a no-op and control falls through to the next.
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...buildArm(C_LC_X, C_UC_X, 16), ...buildArm(C_LC_O, C_UC_O, 8), ...buildArm(C_LC_B, C_UC_B, 2)],
+    },
   ];
 }
 

--- a/tests/issue-1836.test.ts
+++ b/tests/issue-1836.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1836 — standalone Number<->String conformance.
+// Slice: ToNumber(String) octal (0o/0O) and binary (0b/0B) prefix parsing in
+// the no-JS-host path (§7.1.4.1 StringToNumber → NonDecimalIntegerLiteral).
+// Previously only the hex (0x/0X) prefix was handled; octal/binary returned NaN.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function evalStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors[0]?.message).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#1836 standalone Number() octal/binary prefix", () => {
+  it("parses 0o / 0O octal literals", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("0o17"); }`)).toBe(15);
+    expect(await evalStandalone(`export function test(): number { return Number("0O17"); }`)).toBe(15);
+    expect(await evalStandalone(`export function test(): number { return Number("0o0"); }`)).toBe(0);
+    expect(await evalStandalone(`export function test(): number { return Number("0o777"); }`)).toBe(511);
+  });
+
+  it("parses 0b / 0B binary literals", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("0b101"); }`)).toBe(5);
+    expect(await evalStandalone(`export function test(): number { return Number("0B101"); }`)).toBe(5);
+    expect(await evalStandalone(`export function test(): number { return Number("0b0"); }`)).toBe(0);
+    expect(await evalStandalone(`export function test(): number { return Number("0b1111"); }`)).toBe(15);
+  });
+
+  it("still parses 0x / 0X hex literals (no regression)", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("0x1F"); }`)).toBe(31);
+    expect(await evalStandalone(`export function test(): number { return Number("0XfF"); }`)).toBe(255);
+  });
+
+  it("returns NaN for digits out of range for the radix", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("0o8"); }`)).toBeNaN();
+    expect(await evalStandalone(`export function test(): number { return Number("0b2"); }`)).toBeNaN();
+  });
+
+  it("returns NaN when the prefix has no following digit", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("0o"); }`)).toBeNaN();
+    expect(await evalStandalone(`export function test(): number { return Number("0b"); }`)).toBeNaN();
+  });
+
+  it("returns NaN for a signed non-decimal literal (spec: NonDecimalIntegerLiteral is unsigned)", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("-0x1F"); }`)).toBeNaN();
+    expect(await evalStandalone(`export function test(): number { return Number("-0o17"); }`)).toBeNaN();
+    expect(await evalStandalone(`export function test(): number { return Number("-0b101"); }`)).toBeNaN();
+  });
+
+  it("treats a leading-zero decimal as decimal, not octal", async () => {
+    // "08" is a decimal StrNumericLiteral (8), NOT legacy octal.
+    expect(await evalStandalone(`export function test(): number { return Number("08"); }`)).toBe(8);
+    expect(await evalStandalone(`export function test(): number { return Number("017"); }`)).toBe(17);
+  });
+
+  it("parses plain decimal strings unchanged", async () => {
+    expect(await evalStandalone(`export function test(): number { return Number("17"); }`)).toBe(17);
+    expect(await evalStandalone(`export function test(): number { return Number("0"); }`)).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #1836 (partial — octal/binary literal parsing slice). Standalone `Number()` now handles `0o`/`0O` and `0b`/`0B` prefixes.

Implemented by a dev teammate (commit a2b224004); branch push stalled on the current GitHub network hang — pushed + PR opened by tech lead. CI/merge owned by pr-maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)