### PR TITLE
fix(#1815): Array.prototype.splice inserts items (3+ args)

### DIFF
--- a/plan/issues/1815-array-splice-drops-inserted-items.md
+++ b/plan/issues/1815-array-splice-drops-inserted-items.md
@@ -1,9 +1,10 @@
 ---
 id: 1815
 title: "Array.prototype.splice drops inserted items (3+ args ignored)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -33,4 +34,22 @@ insertion case as an interim.
 
 ## Acceptance
 `[1,2,3].splice(1,1,'a','b')` → array becomes `[1,'a','b',3]`, returns `[2]`.
+
+## Resolution
+`compileArraySplice` (`src/codegen/array-methods.ts`) now branches on
+`insertCount = max(0, arguments.length - 2)`. When items are inserted it
+rebuilds the backing array (`newLen = len - delCount + insertCount`), copies
+head + items + tail into it, and writes the new data array + length back into
+the **same** vec struct (in-place mutation preserved). This handles growth
+(`insertCount > delCount`), shrink, and equal-size replacement. The deleted-
+elements return value is unchanged. The delete-only path (no items) keeps the
+original in-place tail-shift, which cannot exceed capacity.
+
+## Test Results
+`tests/issue-1815.test.ts` — 5/5 pass:
+- `[1,2,3].splice(1,1,7,8)` → `[1,7,8,3]`, removed `[2]`
+- `[1,2,3,4,5].splice(2,2,9)` → `[1,2,9,5]`, removed `[3,4]` (shrink)
+- `[1,2,3].splice(1,0,8,9)` → `[1,8,9,2,3]`, removed `[]` (pure insert/grow)
+- `[1,2,3].splice(3,0,4,5)` → `[1,2,3,4,5]`, removed `[]` (append)
+- `[1,2,3,4].splice(1,2)` → `[1,4]`, removed `[2,3]` (delete-only, unchanged path)
 

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4450,6 +4450,16 @@ function compileArraySplice(
   const tailCountTmp = allocLocal(fctx, `__arr_spl_tc_${fctx.locals.length}`, { kind: "i32" });
   const tailStartTmp = allocLocal(fctx, `__arr_spl_ts_${fctx.locals.length}`, { kind: "i32" });
 
+  // #1815 — items to insert at `start` (arguments[2..]). When present, the
+  // backing array must be rebuilt (it may need to grow), so we cannot use the
+  // in-place tail-shift path that only works when newLen <= len.
+  const insertCount = Math.max(0, callExpr.arguments.length - 2);
+  const newData =
+    insertCount > 0
+      ? allocLocal(fctx, `__arr_spl_ndata_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx })
+      : -1;
+  const writeTmp = insertCount > 0 ? allocLocal(fctx, `__arr_spl_w_${fctx.locals.length}`, { kind: "i32" }) : -1;
+
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);
   fctx.body.push({ op: "local.tee", index: vecTmp });
@@ -4517,19 +4527,71 @@ function compileArraySplice(
   fctx.body.push({ op: "local.set", index: tailCountTmp });
   emitClampNonNeg(fctx, tailCountTmp);
 
-  // Shift tail left in-place: array.copy data[start..start+tailCount] = data[tailStart..tailStart+tailCount]
-  emitArrayCopy(fctx, arrTypeIdx, dataTmp, startTmp, dataTmp, tailStartTmp, tailCountTmp);
+  if (insertCount > 0) {
+    // #1815 — insertion path: rebuild the backing array in place.
+    // newLen = len - delCount + insertCount  (= start + insertCount + tailCount)
+    fctx.body.push({ op: "local.get", index: startTmp });
+    fctx.body.push({ op: "i32.const", value: insertCount });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.get", index: tailCountTmp });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.set", index: newLenTmp });
 
-  // newLen = len - delCount
-  fctx.body.push({ op: "local.get", index: lenTmp });
-  fctx.body.push({ op: "local.get", index: delCountTmp });
-  fctx.body.push({ op: "i32.sub" });
-  fctx.body.push({ op: "local.set", index: newLenTmp });
+    // newData = array.new_default(newLen)
+    fctx.body.push({ op: "local.get", index: newLenTmp });
+    fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+    fctx.body.push({ op: "local.set", index: newData });
 
-  // Update vec length
-  fctx.body.push({ op: "local.get", index: vecTmp });
-  fctx.body.push({ op: "local.get", index: newLenTmp });
-  fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+    // Part 1: head — newData[0..start] = data[0..start]
+    emitArrayCopy(fctx, arrTypeIdx, newData, null, dataTmp, null, startTmp);
+
+    // Part 2: items — newData[start..start+insertCount] = arguments[2..]
+    fctx.body.push({ op: "local.get", index: startTmp });
+    fctx.body.push({ op: "local.set", index: writeTmp });
+    for (let i = 0; i < insertCount; i++) {
+      fctx.body.push({ op: "local.get", index: newData });
+      fctx.body.push({ op: "local.get", index: writeTmp });
+      compileExpression(ctx, fctx, callExpr.arguments[2 + i]!, _elemType);
+      fctx.body.push({ op: "array.set", typeIdx: arrTypeIdx });
+      if (i < insertCount - 1) {
+        fctx.body.push({ op: "local.get", index: writeTmp });
+        fctx.body.push({ op: "i32.const", value: 1 });
+        fctx.body.push({ op: "i32.add" });
+        fctx.body.push({ op: "local.set", index: writeTmp });
+      }
+    }
+
+    // Part 3: tail — newData[start+insertCount..] = data[tailStart..tailStart+tailCount]
+    fctx.body.push({ op: "local.get", index: startTmp });
+    fctx.body.push({ op: "i32.const", value: insertCount });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.set", index: writeTmp });
+    emitArrayCopy(fctx, arrTypeIdx, newData, writeTmp, dataTmp, tailStartTmp, tailCountTmp);
+
+    // Write new backing array + length back into the same vec struct (in place)
+    fctx.body.push({ op: "local.get", index: vecTmp });
+    fctx.body.push({ op: "local.get", index: newData });
+    fctx.body.push({ op: "ref.as_non_null" });
+    fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 });
+    fctx.body.push({ op: "local.get", index: vecTmp });
+    fctx.body.push({ op: "local.get", index: newLenTmp });
+    fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  } else {
+    // No insertion: shift tail left in-place (newLen <= len, capacity suffices).
+    // array.copy data[start..start+tailCount] = data[tailStart..tailStart+tailCount]
+    emitArrayCopy(fctx, arrTypeIdx, dataTmp, startTmp, dataTmp, tailStartTmp, tailCountTmp);
+
+    // newLen = len - delCount
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({ op: "local.get", index: delCountTmp });
+    fctx.body.push({ op: "i32.sub" });
+    fctx.body.push({ op: "local.set", index: newLenTmp });
+
+    // Update vec length
+    fctx.body.push({ op: "local.get", index: vecTmp });
+    fctx.body.push({ op: "local.get", index: newLenTmp });
+    fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  }
 
   // Return new vec with deleted elements: { delCount, delData }
   fctx.body.push({ op: "local.get", index: delCountTmp });

--- a/tests/issue-1815.test.ts
+++ b/tests/issue-1815.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+// #1815 — Array.prototype.splice dropped inserted items (arguments[2..]).
+// `[1,2,3].splice(1,1,'a','b')` left `[1,3]` instead of `[1,'a','b',3]`.
+// compileArraySplice only read start + deleteCount and never the items, and
+// the in-place tail-shift path could not grow the backing array. The fix
+// rebuilds the backing array when items are inserted (ECMAScript §23.1.3.30).
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+// Pack arr + removed into one number: arrLen, each arr elem, remLen, each removed
+// elem — all single-digit in these fixtures.
+function fixture(setup: string): string {
+  return `
+    export function test(): number {
+      ${setup}
+      let acc = arr.length;
+      for (let i = 0; i < arr.length; i = i + 1) acc = acc * 10 + arr[i];
+      acc = acc * 10 + removed.length;
+      for (let i = 0; i < removed.length; i = i + 1) acc = acc * 10 + removed[i];
+      return acc;
+    }
+  `;
+}
+
+describe("#1815 — splice inserts items (3+ args)", () => {
+  it("replaces 1 element with 2 inserted items", async () => {
+    // [1,2,3].splice(1,1,7,8) -> arr [1,7,8,3], removed [2] -> 4 1 7 8 3 1 2
+    const src = fixture(`const arr = [1, 2, 3]; const removed = arr.splice(1, 1, 7, 8);`);
+    expect(await run(src)).toBe(4178312);
+  });
+
+  it("deletes more than it inserts (shrinks)", async () => {
+    // [1,2,3,4,5].splice(2,2,9) -> arr [1,2,9,5], removed [3,4] -> 4 1 2 9 5 2 3 4
+    const src = fixture(`const arr = [1, 2, 3, 4, 5]; const removed = arr.splice(2, 2, 9);`);
+    expect(await run(src)).toBe(41295234);
+  });
+
+  it("pure insertion (deleteCount 0) grows the array", async () => {
+    // [1,2,3].splice(1,0,8,9) -> arr [1,8,9,2,3], removed [] -> 5 1 8 9 2 3 0
+    const src = fixture(`const arr = [1, 2, 3]; const removed = arr.splice(1, 0, 8, 9);`);
+    expect(await run(src)).toBe(5189230);
+  });
+
+  it("appends when start === length", async () => {
+    // [1,2,3].splice(3,0,4,5) -> arr [1,2,3,4,5], removed [] -> 5 1 2 3 4 5 0
+    const src = fixture(`const arr = [1, 2, 3]; const removed = arr.splice(3, 0, 4, 5);`);
+    expect(await run(src)).toBe(5123450);
+  });
+
+  it("still works for delete-only splice (no items)", async () => {
+    // [1,2,3,4].splice(1,2) -> arr [1,4], removed [2,3] -> 2 1 4 2 2 3
+    const src = fixture(`const arr = [1, 2, 3, 4]; const removed = arr.splice(1, 2);`);
+    expect(await run(src)).toBe(214223);
+  });
+});


### PR DESCRIPTION
## Problem
`Array.prototype.splice` dropped inserted items. `[1,2,3].splice(1,1,7,8)`
left `[1,3]` instead of `[1,7,8,3]` — `compileArraySplice` only read `start`
(arg 0) and `deleteCount` (arg 1), never `arguments[2..]`, and the in-place
tail-shift path could not grow the backing array.

## Fix
`compileArraySplice` (`src/codegen/array-methods.ts`) now branches on
`insertCount = max(0, arguments.length - 2)`:

- **Insertion path** (`insertCount > 0`): rebuild the backing array
  (`newLen = len - delCount + insertCount`), copy head + inserted items + tail,
  and write the new data array + length back into the **same** vec struct so
  in-place mutation semantics are preserved. Handles grow / shrink /
  equal-size / append uniformly (reuses the proven `toSpliced` shape).
- **Delete-only path** (no items): unchanged — keeps the capacity-safe in-place
  tail shift.

The deleted-elements return value is unchanged. ECMAScript §23.1.3.30.

## Tests
`tests/issue-1815.test.ts` — 5/5 pass (replace, shrink, pure insert, append,
delete-only guard).

Pre-existing failures in `tests/array-methods.test.ts` /
`tests/array-capacity.test.ts` (missing `__box_number` in their hand-rolled
import objects + a stale TS `shift` test) were confirmed identical on
`origin/main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)