### PR TITLE
fix(#1820): IR path short-circuits && / || / ternary (no double-eval)

### DIFF
--- a/plan/issues/1820-ir-short-circuit-evaluates-both-operands.md
+++ b/plan/issues/1820-ir-short-circuit-evaluates-both-operands.md
@@ -1,9 +1,10 @@
 ---
 id: 1820
 title: "IR path: && || and ternary evaluate both operands (lost short-circuit + non-termination)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -31,4 +32,54 @@ Related Wasm-validity facet: a ref-typed ternary would emit untyped `select`
 Only `select`/`i32.and`/`i32.or` when both arms are provably side-effect-free
 (and numeric); otherwise lower to the short-circuiting `IrInstrIf` (exists) or
 throw to fall back to legacy.
+
+## Resolution
+Lowered `&&` / `||` and the ternary through the short-circuiting `IrInstrIf`
+unconditionally (rather than gating on a purity analysis), so the IR path is
+correct for ALL arms — pure or effectful:
+
+- `src/ir/from-ast.ts`
+  - `lowerConditional` (ternary): replaced eager `lowerExpr(whenTrue)` +
+    `lowerExpr(whenFalse)` + `emitSelect` with two `collectBodyInstrs(...)` arm
+    buffers combined via `emitIfElse`. Only the taken arm runs. The false arm
+    is hinted with the true arm's type (matching the `lowerNullish` carrier
+    convention).
+  - new `lowerLogicalAndOr`: intercepts `&&` / `||` at the top of `lowerBinary`
+    (before the eager operand lowering, like `??`). The right operand is
+    collected into its own body buffer and only runs on the branch that needs
+    it: `a && b` → `if a then b else a`; `a || b` → `if a then a else b`. Kept
+    the existing i32-operand scope (non-i32 throws clean fallback to legacy);
+    removed the now-dead `&&`/`||` switch cases and the unused `requireI32`.
+
+- `src/ir/lower.ts`
+  - **Root-cause fix for the carrier mis-emit**: the local-allocation pass
+    (`allocLocalForInstr`) recursed into `forof.*` / `try` / `while` / `for`
+    body buffers but NOT into value-producing `if` then/else arm buffers. SSA
+    values defined inside an arm and referenced cross-block (a nested-ternary
+    sub-result, or a const arm carrier) therefore got no Wasm local, so
+    `localIdx.get(...)` was undefined and the carrier emission mis-targeted an
+    unrelated local → invalid Wasm (`local.set[0] expected type i32, found
+    f64.const`). Added the `if` then/else recursion alongside the existing
+    buffer kinds. This also hardens the existing `emitIfElse` consumers
+    (`lowerNullish`, optional chaining) for non-trivial arms.
+
+## Test Results
+`tests/issue-1820.test.ts` — 6/6 pass. Reproduced on the unpatched baseline:
+- `fact(n) = n<=1 ? 1 : n*fact(n-1)`: baseline → "Maximum call stack size
+  exceeded" for every n (eager else-arm recursion); fixed → `fact(5)=120`,
+  `fact(10)=3628800`.
+- nested ternary `a>0 ? (a>10?100:10) : 0`: baseline (eager `select`) → `10`
+  (correct); the first short-circuit attempt regressed it to invalid Wasm until
+  the `lower.ts` `if`-arm local-allocation recursion was added — now `10`/`100`/`0`.
+- `&&` / `||` over bool operands: all four truth-table combinations correct.
+
+No regressions introduced:
+- IR equivalence suites (`ir-ternary/-if-else/-let-const/-nullish/-numeric-bool`)
+  show byte-for-byte the SAME pass/fail counts with and without this change. The
+  failing entries are a pre-existing test-harness gap (the suites' `ENV` omits
+  the `__box_number` import) reproduced identically on baseline — not caused by
+  this fix.
+- `pnpm run check:ir-fallbacks`: OK, no unintended bucket increase.
+- `ir-nullish-coalesce.test.ts`: 4/4 pass (confirms the `lower.ts` change
+  doesn't break existing `emitIfElse` consumers).
 

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3467,10 +3467,28 @@ function lowerConditional(expr: ts.ConditionalExpression, cx: LowerCtx): IrValue
   if (asVal(condType)?.kind !== "i32") {
     throw new Error(`ir/from-ast: ternary condition must be bool in ${cx.funcName}`);
   }
-  const whenTrue = lowerExpr(expr.whenTrue, cx, irVal({ kind: "f64" }));
-  const whenFalse = lowerExpr(expr.whenFalse, cx, irVal({ kind: "f64" }));
+
+  // #1820 — short-circuit semantics: only the selected arm may run. A prior
+  // implementation lowered both arms eagerly and combined them with Wasm
+  // `select`, which evaluates BOTH operands. That is fine for pure arms but
+  // wrong when an arm has side effects or recurses (e.g.
+  // `n <= 1 ? 1 : n * fact(n - 1)` recursed at the base case → non-termination).
+  // Lower each arm into its own body buffer and combine with `IrInstrIf`, so
+  // the lowerer emits a structured `if`/`else` that runs exactly one arm.
+  let whenTrue!: IrValueId;
+  const thenBody = cx.builder.collectBodyInstrs(() => {
+    whenTrue = lowerExpr(expr.whenTrue, cx, irVal({ kind: "f64" }));
+  });
   const ttype = cx.builder.typeOf(whenTrue);
+
+  // Hint the false arm with the true arm's type so both land on the same
+  // carrier (matches the `lowerNullish` convention).
+  let whenFalse!: IrValueId;
+  const elseBody = cx.builder.collectBodyInstrs(() => {
+    whenFalse = lowerExpr(expr.whenFalse, cx, ttype);
+  });
   const ftype = cx.builder.typeOf(whenFalse);
+
   const tVal = asVal(ttype);
   const fVal = asVal(ftype);
   if (!tVal || !fVal || tVal.kind !== fVal.kind) {
@@ -3478,7 +3496,15 @@ function lowerConditional(expr: ts.ConditionalExpression, cx: LowerCtx): IrValue
       `ir/from-ast: ternary branches have different types (${describeIrType(ttype)} vs ${describeIrType(ftype)}) in ${cx.funcName}`,
     );
   }
-  return cx.builder.emitSelect(cond, whenTrue, whenFalse, ttype);
+
+  return cx.builder.emitIfElse({
+    cond,
+    then: thenBody,
+    thenValue: whenTrue,
+    else: elseBody,
+    elseValue: whenFalse,
+    resultType: ttype,
+  });
 }
 
 function lowerPrefixUnary(expr: ts.PrefixUnaryExpression, cx: LowerCtx): IrValueId {
@@ -3520,6 +3546,17 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   // clean fallback for non-reference / mismatched-type operands.
   if (op === ts.SyntaxKind.QuestionQuestionToken) {
     return lowerNullish(expr, cx, hint);
+  }
+
+  // #1820 — `&&` / `||` short-circuit. A prior implementation lowered both
+  // operands eagerly and combined them with `i32.and` / `i32.or`, which
+  // evaluates the right operand unconditionally — losing JS short-circuit
+  // semantics (e.g. `guard && risky()` ran `risky()` even when `guard` was
+  // false). Lower the right operand into its own body buffer and combine with
+  // `IrInstrIf` so it runs only on the branch that needs it. Handled before
+  // the eager operand lowering below, like `??`.
+  if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
+    return lowerLogicalAndOr(expr, op, cx);
   }
 
   // Slice 11 (#1169n) — early fallback for ops the selector accepts
@@ -3669,16 +3706,9 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
       binop = isF64 ? "f64.ne" : "i32.ne";
       resultType = irVal({ kind: "i32" });
       break;
-    case ts.SyntaxKind.AmpersandAmpersandToken:
-      requireI32(isI32, "&&", cx.funcName);
-      binop = "i32.and";
-      resultType = irVal({ kind: "i32" });
-      break;
-    case ts.SyntaxKind.BarBarToken:
-      requireI32(isI32, "||", cx.funcName);
-      binop = "i32.or";
-      resultType = irVal({ kind: "i32" });
-      break;
+    // `&&` / `||` are intercepted at the top of `lowerBinary` (#1820) and
+    // lowered to a short-circuiting `IrInstrIf` before the eager operand
+    // lowering above — they never reach this switch.
     // Slice 11 (#1169n) — bitwise ops on f64 operands. Each lowers to
     // ToInt32 + i32 op + convert back; the lowerer's `case "binary"`
     // arm dispatches on the `js.*` prefix to emit the multi-instr
@@ -3802,12 +3832,69 @@ function lowerNullish(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): Ir
   });
 }
 
-function requireF64(isF64: boolean, op: string, fn: string): void {
-  if (!isF64) throw new Error(`ir/from-ast: operator '${op}' requires number operands in ${fn}`);
+/**
+ * #1820 — short-circuiting lowering for `&&` / `||`.
+ *
+ * The previous lowering eagerly evaluated both operands and combined them with
+ * `i32.and` / `i32.or`, running the right operand unconditionally. JS requires
+ * the right operand to be evaluated only when the left does not already decide
+ * the result:
+ *   - `a && b` → if `a` is truthy yield `b`, else yield `a` (the falsy value).
+ *   - `a || b` → if `a` is truthy yield `a`, else yield `b`.
+ *
+ * We keep the existing IR scope (both operands `i32`/bool); anything else
+ * throws clean fallback to legacy, exactly as the old `requireI32` did. The
+ * right operand is lowered into its own body buffer (only the taken branch
+ * runs it) and the two arms are combined with a structured `IrInstrIf`.
+ */
+function lowerLogicalAndOr(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: LowerCtx): IrValueId {
+  const isAnd = op === ts.SyntaxKind.AmpersandAmpersandToken;
+  const opName = isAnd ? "&&" : "||";
+
+  const lhs = lowerExpr(expr.left, cx, irVal({ kind: "i32" }));
+  const lhsType = cx.builder.typeOf(lhs);
+  if (asVal(lhsType)?.kind !== "i32") {
+    throw new Error(`ir/from-ast: operator '${opName}' requires bool operands in ${cx.funcName}`);
+  }
+
+  const resultType: IrType = irVal({ kind: "i32" });
+
+  // Lower the right operand into its own buffer so it executes only on the
+  // branch that needs it.
+  let rhs!: IrValueId;
+  const rhsBody = cx.builder.collectBodyInstrs(() => {
+    rhs = lowerExpr(expr.right, cx, resultType);
+  });
+  if (asVal(cx.builder.typeOf(rhs))?.kind !== "i32") {
+    throw new Error(`ir/from-ast: operator '${opName}' requires bool operands in ${cx.funcName}`);
+  }
+
+  // `cond = lhs`. For `&&`, the rhs is the then-arm (lhs truthy) and lhs is the
+  // else-arm value. For `||`, lhs is the then-arm value and rhs is the
+  // else-arm. The empty arm yields the already-materialized `lhs` (the lowerer
+  // records it as a cross-block use, like `lowerNullish`'s else arm).
+  if (isAnd) {
+    return cx.builder.emitIfElse({
+      cond: lhs,
+      then: rhsBody,
+      thenValue: rhs,
+      else: [],
+      elseValue: lhs,
+      resultType,
+    });
+  }
+  return cx.builder.emitIfElse({
+    cond: lhs,
+    then: [],
+    thenValue: lhs,
+    else: rhsBody,
+    elseValue: rhs,
+    resultType,
+  });
 }
 
-function requireI32(isI32: boolean, op: string, fn: string): void {
-  if (!isI32) throw new Error(`ir/from-ast: operator '${op}' requires bool operands in ${fn}`);
+function requireF64(isF64: boolean, op: string, fn: string): void {
+  if (!isF64) throw new Error(`ir/from-ast: operator '${op}' requires number operands in ${fn}`);
 }
 
 function typeOfValue(v: IrValueId, cx: LowerCtx): IrType {

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -545,6 +545,16 @@ export function lowerIrFunctionBody<S>(
       for (const sub of instr.body) allocLocalForInstr(sub);
       for (const sub of instr.update) allocLocalForInstr(sub);
     }
+    // #1820: walk into value-producing `if` then/else arm buffers. SSA values
+    // defined inside an arm that are referenced cross-block (e.g. the arm's
+    // carrier value, or a nested-ternary sub-result) need a Wasm local slot;
+    // without this recursion `localIdx.get(...)` is undefined and the carrier
+    // emission mis-targets an unrelated local. (Same recursion the for-of /
+    // try / loop buffers already get.)
+    if (instr.kind === "if") {
+      for (const sub of instr.then) allocLocalForInstr(sub);
+      for (const sub of instr.else) allocLocalForInstr(sub);
+    }
   };
   for (const block of func.blocks) {
     for (const instr of block.instrs) {

--- a/tests/issue-1820.test.ts
+++ b/tests/issue-1820.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+// #1820: the IR path lowered `&&` / `||` to `i32.and` / `i32.or` and the
+// ternary `a ? b : c` to Wasm `select` — all of which evaluate BOTH operands
+// eagerly. That loses JS short-circuit semantics:
+//   - `cond ? f() : g()` would call both `f()` and `g()`;
+//   - `function fact(n){ return n <= 1 ? 1 : n * fact(n - 1) }` recursed at the
+//     base case → unbounded recursion / stack overflow;
+//   - `guard && risky()` ran `risky()` even when `guard` was false.
+//
+// Fix: lower `&&` / `||` and the ternary through a short-circuiting
+// `IrInstrIf`, evaluating each arm/right-operand only on the branch that needs
+// it. A companion fix in `lower.ts` makes the local-allocation pass recurse
+// into the value-producing `if` arm buffers so SSA values defined inside an arm
+// (e.g. a nested-ternary sub-result, or an arm carrier constant) get a Wasm
+// local — without it the structured `if` carrier emission mis-targeted an
+// unrelated local and produced invalid Wasm.
+//
+// These run through the IR path (`experimentalIR: true`) using the
+// `importObject` the compiler builds, so number boxing imports resolve.
+
+async function irRun(source: string, fn: string, args: ReadonlyArray<number | boolean>): Promise<unknown> {
+  const r = await compile(source, { experimentalIR: true });
+  expect(r.success, `IR compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(
+    r.binary,
+    (r as unknown as { importObject: WebAssembly.Imports }).importObject,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](...args);
+}
+
+describe("#1820 IR path short-circuits && / || / ternary", () => {
+  it("recursive ternary terminates at the base case (no eager else-arm recursion)", async () => {
+    const src = `export function fact(n: number): number { return n <= 1 ? 1 : n * fact(n - 1); }`;
+    expect(await irRun(src, "fact", [1])).toBe(1);
+    expect(await irRun(src, "fact", [5])).toBe(120);
+    expect(await irRun(src, "fact", [10])).toBe(3628800);
+  });
+
+  it("simple ternary selects the right arm", async () => {
+    const src = `export function f(c: boolean): number { return c ? 11 : 22; }`;
+    expect(await irRun(src, "f", [true])).toBe(11);
+    expect(await irRun(src, "f", [false])).toBe(22);
+  });
+
+  it("nested ternary lowers to valid Wasm and selects correctly", async () => {
+    const src = `export function f(a: number): number { return a > 0 ? (a > 10 ? 100 : 10) : 0; }`;
+    expect(await irRun(src, "f", [7])).toBe(10);
+    expect(await irRun(src, "f", [15])).toBe(100);
+    expect(await irRun(src, "f", [-1])).toBe(0);
+  });
+
+  it("ternary embedded in arithmetic", async () => {
+    const src = `export function f(a: number): number { return 10 + (a > 0 ? a : -a); }`;
+    expect(await irRun(src, "f", [-3])).toBe(13);
+    expect(await irRun(src, "f", [5])).toBe(15);
+  });
+
+  it("&& yields the correct boolean for every combination", async () => {
+    const src = `export function f(a: boolean, b: boolean): boolean { return a && b; }`;
+    expect(await irRun(src, "f", [true, true])).toBe(1);
+    expect(await irRun(src, "f", [true, false])).toBe(0);
+    expect(await irRun(src, "f", [false, true])).toBe(0);
+    expect(await irRun(src, "f", [false, false])).toBe(0);
+  });
+
+  it("|| yields the correct boolean for every combination", async () => {
+    const src = `export function f(a: boolean, b: boolean): boolean { return a || b; }`;
+    expect(await irRun(src, "f", [true, true])).toBe(1);
+    expect(await irRun(src, "f", [true, false])).toBe(1);
+    expect(await irRun(src, "f", [false, true])).toBe(1);
+    expect(await irRun(src, "f", [false, false])).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #1820. IR lowering of `&&`, `||`, and the conditional operator now short-circuits — the right/untaken operand is no longer evaluated unconditionally, restoring correct semantics with side effects.

Implemented by a dev teammate (commit 597aed3a4); branch push stalled on the GitHub network hang — pushed + PR opened by tech lead. CI/merge owned by pr-maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)