### PR TITLE
fix(#1829): typed-array arg marshalling no longer byte-truncates

### DIFF
--- a/plan/issues/1829-marshal-typedarray-byte-mask.md
+++ b/plan/issues/1829-marshal-typedarray-byte-mask.md
@@ -1,7 +1,8 @@
 ---
 id: 1829
 title: "marshalTypedArrayArgs byte-masks every element, corrupting non-Uint8Array typed arrays"
-status: ready
+status: done
+completed: 2026-06-04
 created: 2026-06-04
 updated: 2026-06-04
 priority: high
@@ -27,4 +28,32 @@ full precision would otherwise round-trip.
 ## Fix
 Apply `& 0xff` only when `kind==="uint8array"`; for `"typed-array"` write `src[j]`
 unmasked via the vec setter.
+
+## Resolution (2026-06-04)
+
+`src/runtime.ts` `marshalTypedArrayArgs`: gated the `& 0xff` on
+`kind === "uint8array"`; the `"typed-array"` catch-all now writes `src[j]`
+unmasked. `__vec_set_byte` widens its i32 value arg via `f64.convert_i32_u`
+into the f64 vec backing store, so unsigned-integer typed arrays
+(`Uint16Array` / `Uint32Array`) now round-trip up to 2^32-1 at full precision
+instead of being truncated to bytes.
+
+Test: `tests/issue-1829.test.ts` (4, all pass) compiles `Uint16Array` /
+`Uint32Array` exports, calls them via `wrapExports({ marshal: false })`, and
+reads the marshalled vec back with `__vec_get`/`__vec_len` to assert the real
+element values cross the boundary; a guard confirms `Uint8Array` still
+byte-masks (unchanged #1700 semantics). `tsc`/`biome`/`prettier` clean.
+
+### Known residual (separate follow-up)
+The wire setter `__vec_set_byte` is `(externref, i32, i32) -> ()` and converts
+the value with `f64.convert_i32_u` (**unsigned**). So:
+- `Int16Array` / `Int32Array` **negative** elements still become large
+  positives (e.g. -1 → 4294967295), and
+- `Float32Array` / `Float64Array` **fractional** elements are truncated to
+  integers.
+Full fidelity for signed/float typed arrays needs a dedicated full-precision
+vec setter (`__vec_set_f64(externref, i32, f64)`) emitted in codegen — a larger
+change than this localized runtime fix. This PR strictly improves on the prior
+"truncate every element to a byte" behaviour for the common unsigned-integer
+case; signed/float fidelity is left for a codegen follow-up.
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9868,10 +9868,17 @@ function marshalTypedArrayArgs(
     const src = arg as ArrayLike<number>;
     const len = src.length | 0;
     const vec = newVecF64(len);
+    // #1829 — only byte-mask for Uint8Array. For any other TypedArray the
+    // `& 0xff` truncated every element to its low byte, silently corrupting
+    // Uint16Array/Uint32Array (and signed/float) inputs. The vec backing store
+    // is f64 and `__vec_set_byte` widens its i32 value arg via
+    // `f64.convert_i32_u`, so an unmasked write round-trips unsigned integers
+    // up to 2^32-1 at full precision. (Signed-negative and fractional float
+    // elements still need a full-f64 vec setter — tracked as a follow-up; this
+    // strictly improves on truncating every element to a byte.)
+    const maskByte = kind === "uint8array";
     for (let j = 0; j < len; j++) {
-      // Mask to byte range — matches `new Uint8Array(arr)` indexed-write
-      // semantics (and __vec_set_byte's i32-byte contract).
-      vecSetByte(vec, j, src[j]! & 0xff);
+      vecSetByte(vec, j, maskByte ? src[j]! & 0xff : src[j]!);
     }
     out[i] = vec;
   }

--- a/tests/issue-1829.test.ts
+++ b/tests/issue-1829.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+
+/**
+ * #1829 — `marshalTypedArrayArgs` byte-masked EVERY element (`src[j] & 0xff`),
+ * not just `Uint8Array`. That silently corrupted `Uint16Array` / `Uint32Array`
+ * (and signed/float) arguments to a compiled export by truncating each element
+ * to its low byte. The fix masks only when the slot is classified
+ * `"uint8array"`; for the `"typed-array"` catch-all it writes the value
+ * unmasked. The vec backing store is f64 and `__vec_set_byte` widens its i32
+ * arg via `f64.convert_i32_u`, so unsigned-integer typed arrays now round-trip
+ * up to 2^32-1 at full precision.
+ *
+ * Tested at the arg boundary with `marshal: false` + `__vec_get`/`__vec_len`,
+ * which reads the element values that actually crossed into the Wasm vec
+ * (the return-side `typed-array` wrap is a separate v1 limitation — see
+ * classifyTypedArrayType notes).
+ */
+
+async function instantiate(r: CompileResult): Promise<WebAssembly.Instance> {
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return instance;
+}
+
+// Read every element that landed in the Wasm vec back out as a JS number.
+function readVec(instance: WebAssembly.Instance, vec: unknown): number[] {
+  const ex = instance.exports as Record<string, any>;
+  const vecLen = ex.__vec_len as (v: any) => number;
+  const vecGet = ex.__vec_get as (v: any, i: number) => unknown;
+  const n = vecLen(vec);
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) out.push(Number(vecGet(vec, i)));
+  return out;
+}
+
+describe("#1829 typed-array argument marshalling no longer byte-truncates", () => {
+  it("Uint16Array values above 255 cross the boundary unmasked", async () => {
+    const r = await compile(`export function echo(input: Uint16Array): Uint16Array { return input; }`);
+    expect(r.exportSignatures?.echo?.params).toEqual(["typed-array"]);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { marshal: false, signatures: r.exportSignatures });
+    // 256 & 0xff === 0, 4660 & 0xff === 52, 65535 & 0xff === 255 — the OLD
+    // behaviour would have produced [0, 52, 255]; we expect the real values.
+    const out = exports.echo(new Uint16Array([256, 4660, 65535]));
+    expect(readVec(instance, out)).toEqual([256, 4660, 65535]);
+  });
+
+  it("Uint32Array large values round-trip at full precision", async () => {
+    const r = await compile(`export function echo(input: Uint32Array): Uint32Array { return input; }`);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { marshal: false, signatures: r.exportSignatures });
+    const out = exports.echo(new Uint32Array([0, 65536, 4294967295]));
+    expect(readVec(instance, out)).toEqual([0, 65536, 4294967295]);
+  });
+
+  it("Uint8Array still byte-masks (unchanged #1700 semantics)", async () => {
+    const r = await compile(`export function echo(input: Uint8Array): Uint8Array { return input; }`);
+    expect(r.exportSignatures?.echo?.params).toEqual(["uint8array"]);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { marshal: false, signatures: r.exportSignatures });
+    // 256 → 0, 257 → 1, 511 → 255 (Uint8Array indexed-write semantics preserved)
+    const out = exports.echo(new Uint8Array([256, 257, 511]));
+    expect(readVec(instance, out)).toEqual([0, 1, 255]);
+  });
+
+  it("multi-arg: only the typed-array slot is marshalled, number passes through", async () => {
+    const r = await compile(`
+      export function blend(scale: number, buf: Uint16Array): Uint16Array { return buf; }
+    `);
+    expect(r.exportSignatures?.blend?.params).toEqual(["other", "typed-array"]);
+    const instance = await instantiate(r);
+    const exports = wrapExports(instance.exports, { marshal: false, signatures: r.exportSignatures });
+    const out = exports.blend(3, new Uint16Array([300, 4096]));
+    expect(readVec(instance, out)).toEqual([300, 4096]);
+  });
+});


### PR DESCRIPTION
## #1829 — typed-array argument marshalling truncated every element to a byte

`marshalTypedArrayArgs` (`src/runtime.ts`) byte-masked **every** element
(`src[j] & 0xff`), not just `Uint8Array`. That silently corrupted
`Uint16Array` / `Uint32Array` (and signed/float) arguments to a compiled
export — each element truncated to its low byte, wrong results, no error.

### Fix
Gate the `& 0xff` on `kind === "uint8array"`; the `"typed-array"` catch-all now
writes the value unmasked. `__vec_set_byte` widens its i32 value arg via
`f64.convert_i32_u` into the f64 vec backing store, so unsigned-integer typed
arrays round-trip up to 2^32-1 at full precision.

### Tests
`tests/issue-1829.test.ts` (4, all green): `Uint16Array`/`Uint32Array` values
above 255 cross the boundary unmasked (read back via `__vec_get`/`__vec_len`
under `marshal:false`); a guard confirms `Uint8Array` still byte-masks
(unchanged #1700 semantics). `tsc`/`biome`/`prettier` clean.

### Known residual (separate codegen follow-up)
The wire setter `__vec_set_byte` is `(externref, i32, i32)` and converts with
`f64.convert_i32_u` (**unsigned**), so `Int16Array`/`Int32Array` negatives still
become large positives and `Float32Array`/`Float64Array` fractionals are
truncated to integers. Full fidelity needs a `__vec_set_f64` setter emitted in
codegen — larger than this localized runtime fix. This PR strictly improves on
truncate-every-element-to-a-byte for the common unsigned-integer case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)