### PR TITLE
fix(#1817): >>> stays unsigned — exclude from i32-result fast paths

### DIFF
--- a/plan/issues/1817-ushr-i32-fast-path-signed-result.md
+++ b/plan/issues/1817-ushr-i32-fast-path-signed-result.md
@@ -1,9 +1,10 @@
 ---
 id: 1817
 title: ">>> in i32 fast path produces a signed result (negative for high-bit values)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -29,4 +30,31 @@ ToUint32 — `>>>` result is unsigned.
 ## Fix
 Exclude `GreaterThanGreaterThanGreaterThanToken` from the i32-pure fast path, or
 emit `f64.convert_i32_u` when the consumer wants f64.
+
+## Resolution
+`>>>` is now excluded as the **result** op from both i32-result fast paths in
+`src/codegen/binary-ops.ts`:
+- `bitwiseI32` (the non-flatten i32-pure path) no longer fires for `>>>`.
+- `tryFlattenBinaryChain`'s i32 branch routes `>>>` to `compileNumericBinaryOp`.
+
+Both now fall through to `compileBitwiseBinaryOp`, which uses the unsigned
+`f64.convert_i32_u`. `>>>` remains a valid i32-pure **leaf** (`isI32PureExpr`),
+so nested chains like `(x >>> 3) & mask` keep the fast path — there the
+intermediate i32 bit pattern feeds another bitwise op and is never
+signed-widened to f64.
+
+Note: this closes a **latent** gap. In current codegen every reachable `>>>`
+already routed through `compileBitwiseBinaryOp` (verified by WAT dump:
+`i32.shr_u` + `f64.convert_i32_u` in fast mode, native-i32, and chains), so
+there is no observable behaviour change today — but the `compileI32BinaryOp`
+`>>>` arm (bare `i32.shr_u` → signed widen) was a footgun that a future tweak
+to the i32-pure predicate could have silently activated. The guards make that
+impossible.
+
+## Test Results
+`tests/issue-1817.test.ts` — 8/8 pass (high-bit `-1 >>> 0` → 4294967295,
+`-2147483648 >>> 0` → 2147483648, `-8 >>> 1`, positive values, fast-mode
+single + chain, native-i32, nested `(x>>>4)&255`). No new failures in
+`bitwise.test.ts` / `i32-fast-mode.test.ts` (15 pre-existing harness failures
+confirmed identical on origin/main).
 

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -187,8 +187,17 @@ function tryFlattenBinaryChain(
       rightType = { kind: "f64" };
     }
 
-    // i32 path: fast mode or native type annotations
-    if ((ctx.fast || allNativeI32) && resultType.kind === "i32" && rightType.kind === "i32") {
+    // i32 path: fast mode or native type annotations.
+    // #1817: `>>>` must NOT use compileI32BinaryOp here — its bare i32 result
+    // (`i32.shr_u`) is later widened with the signed `f64.convert_i32_s`,
+    // dropping ToUint32's unsignedness. compileNumericBinaryOp routes `>>>`
+    // through compileBitwiseBinaryOp, which uses `f64.convert_i32_u`.
+    if (
+      (ctx.fast || allNativeI32) &&
+      op !== ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken &&
+      resultType.kind === "i32" &&
+      rightType.kind === "i32"
+    ) {
       resultType = compileI32BinaryOp(ctx, fctx, op, expr);
     } else {
       resultType = compileNumericBinaryOp(ctx, fctx, op, expr);
@@ -1331,7 +1340,20 @@ export function compileBinaryExpression(
     wrappedInToInt32 && isI32PureExpr(expr.left) && isI32PureExpr(expr.right) && outerMulI32Safe;
   // Bitwise op with i32-pure operands: emit native i32 op directly,
   // skipping the f64-ToInt32 round-trip in compileBitwiseBinaryOp.
-  const bitwiseI32 = isBitwiseOpKind(op) && isI32PureExpr(expr.left) && isI32PureExpr(expr.right);
+  //
+  // #1817: `>>>` is excluded as the *result* op. compileI32BinaryOp returns a
+  // bare i32 for `>>>` (`i32.shr_u`), which the consumer widens to f64 with the
+  // signed `f64.convert_i32_s` — wrong, since ToUint32 makes `>>>` unsigned
+  // (a high-bit result would read back negative). Routing `>>>` through
+  // compileBitwiseBinaryOp instead uses `f64.convert_i32_u`. `>>>` stays a
+  // valid i32-pure *leaf* (isI32PureExpr) so nested chains like `(x >>> 3) & m`
+  // keep the fast path — there the intermediate i32 bit pattern feeds another
+  // bitwise op and is never signed-widened.
+  const bitwiseI32 =
+    isBitwiseOpKind(op) &&
+    op !== ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken &&
+    isI32PureExpr(expr.left) &&
+    isI32PureExpr(expr.right);
   const numericHint: ValType | undefined = isNumericOp
     ? {
         kind:

--- a/tests/issue-1817.test.ts
+++ b/tests/issue-1817.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "./src/index.js";
+import { buildImports } from "./src/runtime.js";
+
+// #1817 — `>>>` (unsigned right shift) must yield an unsigned (ToUint32) result.
+// The i32-pure fast path (compileI32BinaryOp / tryFlattenBinaryChain) returned a
+// bare i32 for `>>>` that the consumer widened with the *signed* f64.convert_i32_s,
+// so a high-bit result read back negative. `>>>` now always routes through
+// compileBitwiseBinaryOp (f64.convert_i32_u). ECMAScript ToUint32 (§7.1.7).
+
+async function run(source: string, opts: Record<string, unknown> = {}): Promise<number> {
+  const result = await compile(source, opts);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#1817 — >>> produces an unsigned result", () => {
+  it("(-1 >>> 0) === 4294967295", async () => {
+    expect(await run(`export function test(): number { const x = -1; return x >>> 0; }`)).toBe(4294967295);
+  });
+
+  it("high-bit value: (-2147483648 >>> 0) === 2147483648", async () => {
+    expect(await run(`export function test(): number { const x = -2147483648; return x >>> 0; }`)).toBe(2147483648);
+  });
+
+  it("(-8 >>> 1) === 2147483644", async () => {
+    expect(await run(`export function test(): number { const x = -8; return x >>> 1; }`)).toBe(2147483644);
+  });
+
+  it("positive value unaffected: (16 >>> 2) === 4", async () => {
+    expect(await run(`export function test(): number { const x = 16; return x >>> 2; }`)).toBe(4);
+  });
+
+  it("fast mode: runtime (-1 >>> 0) === 4294967295", async () => {
+    const src = `export function shr(a: number, b: number): number { return a >>> b; } export function test(): number { return shr(-1, 0); }`;
+    expect(await run(src, { fast: true })).toBe(4294967295);
+  });
+
+  it("fast-mode chain a >>> b >>> c stays unsigned", async () => {
+    const src = `export function shr2(a: number, b: number, c: number): number { return a >>> b >>> c; } export function test(): number { return shr2(-1, 0, 0); }`;
+    expect(await run(src, { fast: true })).toBe(4294967295);
+  });
+
+  it("native i32 annotation: (-1 >>> 0) === 4294967295", async () => {
+    const src = `type i32 = number; export function shr(x: i32): number { return x >>> 0; } export function test(): number { return shr(-1); }`;
+    expect(await run(src)).toBe(4294967295);
+  });
+
+  it("nested chain keeps fast path: ((-1 >>> 4) & 255) === 255", async () => {
+    expect(await run(`export function test(): number { const x = -1; return (x >>> 4) & 255; }`)).toBe(255);
+  });
+});


### PR DESCRIPTION
## Problem
`>>>` (unsigned right shift) could yield a **signed** result. `compileI32BinaryOp`
returns a bare i32 for `>>>` (`i32.shr_u`); the consumer widens it to f64 with the
signed `f64.convert_i32_s`, so a high-bit result (e.g. `-1 >>> 0`) would read back
as a negative float instead of `4294967295`. ECMAScript ToUint32 (§7.1.7) requires
the result to be unsigned.

## Fix
Exclude `>>>` as the **result** op from both i32-result fast paths in
`src/codegen/binary-ops.ts`:
- `bitwiseI32` (non-flatten i32-pure path) no longer fires for `>>>`.
- `tryFlattenBinaryChain`'s i32 branch routes `>>>` to `compileNumericBinaryOp`.

Both fall through to `compileBitwiseBinaryOp`, which uses the unsigned
`f64.convert_i32_u`. `>>>` stays a valid i32-pure **leaf** (`isI32PureExpr`), so
nested chains like `(x >>> 3) & mask` keep the fast path — the intermediate i32
bit pattern feeds another bitwise op and is never signed-widened.

## Note — latent fix
Every currently-reachable `>>>` already routed through `compileBitwiseBinaryOp`
(verified by WAT: `i32.shr_u` + `f64.convert_i32_u` in fast mode, native-i32,
and chains), so there is **no observable behaviour change today**. This closes
the footgun in `compileI32BinaryOp`'s `>>>` arm before a future tweak to the
i32-pure predicate could silently activate it.

## Tests
`tests/issue-1817.test.ts` — 8/8 pass (high-bit `-1 >>> 0`, `-2147483648 >>> 0`,
`-8 >>> 1`, positive values, fast-mode single + chain, native-i32, nested
`(x>>>4)&255`).

Pre-existing failures in `bitwise.test.ts` / `i32-fast-mode.test.ts` (missing
boxing imports in their hand-rolled harness + WAT-snapshot drift) were confirmed
identical on `origin/main` (15 failed / 12 passed both ways) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)