### PR TITLE
fix(#1823): String#normalize(form) evaluates receiver before argument

### DIFF
--- a/plan/issues/1823-string-normalize-arg-before-receiver.md
+++ b/plan/issues/1823-string-normalize-arg-before-receiver.md
@@ -1,7 +1,8 @@
 ---
 id: 1823
 title: "String#normalize(form) evaluates argument before receiver (wrong eval order)"
-status: ready
+status: done
+completed: 2026-06-04
 created: 2026-06-04
 updated: 2026-06-04
 priority: medium
@@ -26,4 +27,20 @@ ECMAScript §13.3.6 / §22.1.3.13 — receiver first, then argument.
 
 ## Fix
 Compile the receiver into a temp first, then compile/validate/drop the form argument.
+
+## Resolution (2026-06-04)
+
+`src/codegen/string-ops.ts` `normalize` handler (non-literal-form arm): compile
+the receiver (`propAccess.expression`) first into a fresh temp local of the
+receiver's compiled type (`local.set`), then compile + drop the form argument
+(still evaluated for its side effects, now AFTER the receiver), then
+`local.get` the temp back as the identity result. The static-literal RangeError
+arm and the no-argument arm are unchanged. Note the code location had shifted
+to ~L2374 (issue cited L2110-2134).
+
+Test: `tests/issue-1823.test.ts` (4, all pass) — a side-effecting receiver and
+form each stamp a monotonic tick; asserts `recvAt < formAt` (the old order gave
+`recvAt > formAt`); plus a guard that the form is still evaluated for side
+effects, and two identity checks (literal + non-literal valid form return the
+receiver unchanged). `tsc`/`biome`/`prettier` clean.
 

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2387,11 +2387,21 @@ export function compileNativeStringMethodCall(
           return null;
         }
       }
-      // For non-literal args, compile and drop (can't validate at compile time)
+      // #1823 — evaluation order: the receiver (`this`) is evaluated BEFORE the
+      // argument per §13.3 / §22.1.3.13. Compile the receiver into a temp first
+      // (preserving its side effects in order), then compile + drop the form
+      // argument (still evaluated for its side effects, after the receiver),
+      // then read the receiver temp back as the (identity) result.
+      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      const recvValType = (recvType ?? nativeStringType(ctx)) as ValType;
+      const recvLocal = allocLocal(fctx, `__normalize_recv_${fctx.locals.length}`, recvValType);
+      fctx.body.push({ op: "local.set", index: recvLocal });
       const argType = compileExpression(ctx, fctx, formArg);
       if (argType) {
         fctx.body.push({ op: "drop" });
       }
+      fctx.body.push({ op: "local.get", index: recvLocal });
+      return recvType;
     }
     return compileExpression(ctx, fctx, propAccess.expression);
   }

--- a/tests/issue-1823.test.ts
+++ b/tests/issue-1823.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1823 — `String.prototype.normalize(form)` evaluation order.
+ *
+ * Per §13.3 (MemberExpression Call) the receiver (`this`) is evaluated BEFORE
+ * the argument list (§22.1.3.13). The codegen for `s.normalize(form)` with a
+ * non-literal `form` previously compiled+dropped the argument FIRST, then the
+ * receiver, reversing the observable order for side-effecting `s` / `form`.
+ *
+ * The fix compiles the receiver into a temp first, then the argument, then
+ * reads the receiver back (normalize is identity for already-NFC ASCII).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runReturnNumber(src: string): Promise<number> {
+  const r: any = await compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    const msg = r.errors.map((e: any) => e.message).join("\n");
+    throw new Error(`compile failed:\n${msg}`);
+  }
+  const imports: any = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await instantiateWasm(r.binary, imports.env, imports.string_constants);
+  return ((instance.exports as any).test as () => number)();
+}
+
+describe("#1823 String#normalize(form) evaluation order", () => {
+  it("evaluates the receiver before the form argument", async () => {
+    // `tick` is bumped by each side-effecting producer. The receiver producer
+    // records its tick into `recvAt`, the form producer into `formAt`. Spec
+    // order ⇒ recvAt < formAt. The old (buggy) order produced recvAt > formAt.
+    const src = `
+      let tick: number = 0;
+      let recvAt: number = 0;
+      let formAt: number = 0;
+      function recv(): string { tick = tick + 1; recvAt = tick; return "abc"; }
+      function form(): string { tick = tick + 1; formAt = tick; return "NFC"; }
+      recv().normalize(form());
+      export function test(): number { return recvAt < formAt ? 1 : 0; }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+
+  it("still evaluates the form argument for its side effects", async () => {
+    const src = `
+      let formEvaluated: boolean = false;
+      function form(): string { formEvaluated = true; return "NFC"; }
+      "abc".normalize(form());
+      export function test(): number { return formEvaluated ? 1 : 0; }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+
+  it("normalize returns the receiver string unchanged (identity for NFC ASCII)", async () => {
+    const src = `
+      export function test(): number {
+        const s: string = "hello";
+        const n: string = s.normalize("NFC");
+        return n === "hello" ? 1 : 0;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+
+  it("normalize with a non-literal valid form returns the receiver unchanged", async () => {
+    const src = `
+      function form(): string { return "NFC"; }
+      export function test(): number {
+        const n: string = "world".normalize(form());
+        return n === "world" ? 1 : 0;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1823 — `String#normalize(form)` evaluation order

For `s.normalize(form)` with a non-literal `form`, codegen compiled + dropped
the form argument **first**, then the receiver — reversing the observable
evaluation order for side-effecting `s` / `form`. Per §13.3 / §22.1.3.13 the
receiver (`this`) is evaluated before the argument list.

### Fix
`src/codegen/string-ops.ts` normalize handler: compile the receiver into a
fresh temp local first (preserving its side effects in order), then compile +
drop the form argument (still evaluated, after the receiver), then read the
receiver temp back as the identity result. Static-literal RangeError arm and
no-arg arm unchanged.

### Tests
`tests/issue-1823.test.ts` (4, all green): a side-effecting receiver/form each
stamp a monotonic tick; asserts `recvAt < formAt` (the old order gave
`recvAt > formAt`); plus a form-side-effect guard and two identity checks
(literal + non-literal valid form return the receiver unchanged).
`tsc`/`biome`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)