### PR TITLE
fix: make promote-baseline push race-tolerant (fetch+rebase+retry) (#1861)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1008,7 +1008,35 @@ jobs:
             echo "No baseline changes to push."
           else
             git commit -m "chore(test262): refresh baselines — ${PASS}/${TOTAL} host, ${STANDALONE_PASS}/${STANDALONE_TOTAL} standalone (${{ github.sha }})"
-            git push
+            # The baselines repo can advance under us when two promote-baseline
+            # runs (from concurrent main pushes) race. Retry with
+            # fetch + rebase so the refreshed baseline lands on top of the
+            # concurrent run instead of being dropped (#1861). The clone is
+            # shallow (--depth=1); --unshallow on first fetch so the rebase has
+            # a merge base.
+            BR=$(git rev-parse --abbrev-ref HEAD)
+            BASELINE_PUSHED=0
+            for attempt in 1 2 3 4 5; do
+              git fetch --unshallow origin "$BR" 2>/dev/null \
+                || git fetch origin "$BR"
+              if ! git rebase --autostash "origin/$BR"; then
+                git rebase --abort || true
+                echo "baselines rebase failed (attempt ${attempt}) — retrying"
+                sleep $((attempt * 5))
+                continue
+              fi
+              if git push origin "HEAD:$BR"; then
+                echo "Pushed baselines (attempt ${attempt})."
+                BASELINE_PUSHED=1
+                break
+              fi
+              echo "baselines push race lost (attempt ${attempt}) — refetching and retrying"
+              sleep $((attempt * 5))
+            done
+            if [ "$BASELINE_PUSHED" != "1" ]; then
+              echo "::error::Failed to push baselines after 5 attempts (persistent, not a transient race)."
+              exit 1
+            fi
           fi
 
       # RESTORED (2026-05-25): commit the small summary JSON files back to main.
@@ -1094,11 +1122,39 @@ jobs:
             echo "Only volatile test262 report metadata changed — skipping main commit."
             exit 0
           fi
+          # Commit the staged summary JSON. The [skip ci] trailer prevents the
+          # push from re-triggering the shard matrix. (This commit was dropped
+          # by d630e3a04 when the step switched from the PR flow to a direct
+          # push — without it, `git push HEAD:main` carried the unmodified
+          # checkout and the committed baseline never moved. See #1861.)
+          git commit -m "chore(test262): refresh sharded baseline — ${PASS}/${TOTAL} pass [skip ci]"
           # Push directly to main — the checkout uses persist-credentials so
-          # github-actions[bot] can write. The [skip ci] trailer prevents the
-          # push from re-triggering the shard matrix.
-          git push origin HEAD:main
-          echo "Pushed baseline directly to main (${PASS}/${TOTAL} pass)."
+          # github-actions[bot] can write. Under heavy merge-queue throughput
+          # main advances between this job's checkout and the push, so a plain
+          # `git push origin HEAD:main` is rejected ("fetch first") and the
+          # refresh is silently dropped (#1861). Retry with fetch + rebase so
+          # the freshly-committed baseline lands on top of concurrent merges.
+          PUSHED=0
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            if ! git rebase --autostash origin/main; then
+              git rebase --abort || true
+              echo "rebase onto origin/main failed (attempt ${attempt}) — retrying"
+              sleep $((attempt * 5))
+              continue
+            fi
+            if git push origin HEAD:main; then
+              echo "Pushed baseline directly to main (${PASS}/${TOTAL} pass, attempt ${attempt})."
+              PUSHED=1
+              break
+            fi
+            echo "push race lost (attempt ${attempt}) — refetching and retrying"
+            sleep $((attempt * 5))
+          done
+          if [ "$PUSHED" != "1" ]; then
+            echo "::error::Failed to push refreshed baseline to main after 5 attempts (persistent, not a transient race)."
+            exit 1
+          fi
 
       - name: Audit forced baseline refresh
         if: github.event_name == 'workflow_dispatch' && inputs.force_baseline_refresh == true && inputs.confirm_force == 'YES'

--- a/plan/issues/1861-promote-baseline-push-race.md
+++ b/plan/issues/1861-promote-baseline-push-race.md
@@ -1,0 +1,88 @@
+---
+id: 1861
+title: "promote-baseline never refreshes main: missing commit + push race freezes the test262 baseline"
+status: in-progress
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: high
+feasibility: easy
+reasoning_effort: low
+task_type: infrastructure
+area: tooling
+language_feature: compiler-internals
+goal: ci-hardening
+related: [1528, 1522, 1668, 1218]
+---
+# #1861 — promote-baseline never refreshes main (missing commit + push race)
+
+## Problem
+
+The `promote-baseline` job in `.github/workflows/test262-sharded.yml` (job
+name **"promote merged report to main baseline"**) is the *only* writer of the
+committed test262 baseline (`benchmarks/results/test262-current.json`) on
+`main`, and the only pusher of the regression-gate baseline JSONL to
+`loopdive/js2wasm-baselines`. It has been failing to refresh the baseline,
+which froze the committed summary at commit `9ee8e92` for ~146h. A stale
+baseline makes the PR `check for test262 regressions` gate produce
+false-positive regressions on PR after PR (#1132, #1135).
+
+Two distinct defects in the **"Commit refreshed summary JSON to main repo"**
+step:
+
+1. **Missing `git commit`.** Commit `d630e3a04` switched this step from the
+   PR-based flow to a direct push but deleted the `git commit` line along with
+   the branch/PR plumbing. The current step does `stage_files` (git add) → diff
+   checks → `git push origin HEAD:main`, with **no commit in between**. The
+   staged baseline changes are never committed, so the push (even when it
+   succeeds) carries the unmodified checkout. The committed baseline on `main`
+   therefore never moves.
+
+2. **Push race, no retry.** Even with a commit, `git push origin HEAD:main`
+   races the merge queue: under heavy throughput `main` advances between the
+   job's `checkout` and its push, and the push is rejected:
+
+   ```
+   ! [rejected]  HEAD -> main (fetch first)
+   error: failed to push some refs to 'https://github.com/loopdive/js2'
+   hint: Updates were rejected because the remote contains work that you do not have locally.
+   ```
+
+   There is no fetch/rebase/retry, so a single lost race drops the refresh
+   entirely.
+
+The baselines-repo push (**"Push baseline artifacts to js2wasm-baselines
+repo"**) can lose the same race against a concurrent promote-baseline run on a
+separate `main` push, and also lacks a retry.
+
+## Fix
+
+In `.github/workflows/test262-sharded.yml` `promote-baseline` job, **only the
+push machinery** is touched (no threshold / shard-count / regression-gate
+logic changes):
+
+- **"Commit refreshed summary JSON to main repo"**: actually `git commit` the
+  staged summary JSON (restoring the `[skip ci]` trailer so the push does not
+  re-trigger the shard matrix), then wrap the push in a
+  fetch → `rebase --autostash` → push retry loop (5 attempts, linear backoff).
+  The locally-generated JSON is committed *before* the loop so the rebase
+  replays the baseline commit onto the advanced `origin/main`. A persistent
+  failure after all retries exits non-zero (only the transient race is
+  swallowed).
+- **"Push baseline artifacts to js2wasm-baselines repo"**: wrap its
+  commit + `git push` in the same fetch → `rebase --autostash` → push retry
+  loop against the baselines repo (`--unshallow` on first fetch so the rebase
+  has a merge base; falls back to a plain fetch on later attempts).
+
+The existing remote/auth (persist-credentials for main; SSH deploy key for the
+baselines repo) is unchanged — this fix is complementary to the auth switch in
+the past PR #490, addressing the fast-forward race rather than authentication.
+
+## Acceptance criteria
+
+- A push to `main` that changes test262 results updates
+  `benchmarks/results/test262-current.json` on `main` within one
+  promote-baseline run.
+- A push race (`fetch first` rejection) is retried, not dropped.
+- A persistent (non-race) push failure still fails the step.
+- No change to conformance thresholds, shard counts, or regression-gate logic.


### PR DESCRIPTION
## Problem

The `promote-baseline` job in `.github/workflows/test262-sharded.yml` (job name **"promote merged report to main baseline"**) is the *only* writer of the committed test262 baseline (`benchmarks/results/test262-current.json`) on `main`, and the only pusher of the regression-gate baseline JSONL to `loopdive/js2wasm-baselines`. It stopped refreshing the baseline (frozen at `9ee8e92` for ~146h), which makes the PR `check for test262 regressions` gate emit false-positive regressions PR after PR (#1132, #1135).

Two distinct defects in the **"Commit refreshed summary JSON to main repo"** step:

1. **Missing commit.** Commit `d630e3a04` switched this step from the PR-based flow to a direct push but deleted the `git commit` line along with the branch/PR plumbing. The step did `stage_files` (git add) -> diff/metadata checks -> `git push origin HEAD:main`, with **no commit in between** — so the staged baseline JSON was never committed and the push carried the unmodified checkout. The committed baseline on `main` therefore never moved.

2. **Push race, no retry.** Even with a commit, `git push origin HEAD:main` races the merge queue: under heavy throughput `main` advances between the job's checkout and its push, and the push is rejected:

   ```
   ! [rejected]  HEAD -> main (fetch first)
   error: failed to push some refs to 'https://github.com/loopdive/js2'
   hint: Updates were rejected because the remote contains work that you do not have locally.
   ```

   There was no fetch/rebase/retry, so a single lost race dropped the refresh entirely. The baselines-repo push can lose the same race against a concurrent promote-baseline run and also lacked a retry.

## Fix

Only the push machinery is touched — no threshold / shard-count / regression-gate changes.

- **"Commit refreshed summary JSON to main repo"**: restore the commit (with the `[skip ci]` trailer so the push does not re-trigger the shard matrix), then wrap the push in a `fetch -> rebase --autostash -> push` retry loop (5 attempts, linear backoff). The baseline is committed *before* the loop so the rebase replays it onto the advanced `origin/main`. A persistent (non-race) failure after all retries exits non-zero — only the transient race is swallowed.
- **"Push baseline artifacts to js2wasm-baselines repo"**: wrap its push in the same loop (`--unshallow` on first fetch since the clone is `--depth=1`, falling back to a plain fetch on later attempts).

Existing auth is unchanged: `persist-credentials` for `main`, SSH deploy key for the baselines repo. This is complementary to the auth switch in the past PR #490 — it addresses the fast-forward **race**, not authentication.

## Acceptance criteria

- A push to `main` that changes test262 results updates `benchmarks/results/test262-current.json` on `main` within one promote-baseline run.
- A `fetch first` push race is retried, not dropped.
- A persistent (non-race) push failure still fails the step.
- No change to conformance thresholds, shard counts, or regression-gate logic.

Tracked in `plan/issues/1861-promote-baseline-push-race.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
