### PR TITLE
docs(#809): mark done — native-strings.ts extraction already landed

### DIFF
--- a/plan/issues/809-extract-native-string-helpers-from.md
+++ b/plan/issues/809-extract-native-string-helpers-from.md
@@ -1,9 +1,10 @@
 ---
 id: 809
 title: "Extract native string helpers from index.ts → native-strings.ts"
-status: ready
+status: done
 created: 2026-03-26
-updated: 2026-04-28
+updated: 2026-06-04
+completed: 2026-06-04
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -35,3 +36,21 @@ subtask_of: 688
 `ensureNativeStringHelpers` is a self-contained monster — it registers types and helper functions for WasmGC string arrays. Called once during module setup. The type accessor functions (`nativeStringType` etc.) are simple getters exported for use by other modules.
 
 ## Complexity: S (despite line count — it's one big function + 4 tiny ones)
+
+## Resolution (2026-06-04)
+
+Already done on main. The extraction this issue describes has landed
+incrementally over prior sprints:
+
+- `src/codegen/native-strings.ts` (5,933 lines) now holds
+  `ensureNativeStringHelpers`, `nativeStringType`, `nativeStringTypeNullable`,
+  and `flatStringType` (defined at lines 203 / 15 / 185 / 192).
+- `registerNativeStringTypes` was extracted to
+  `src/codegen/registry/types.ts:200` (called from
+  `src/codegen/context/create-context.ts:212`).
+- `src/codegen/index.ts` imports these from `./native-strings.js`
+  (lines 89-96) and re-exports them for public-API compatibility
+  (lines 100-115). No local definition of any of the five functions
+  remains in `index.ts`.
+
+No code change required — closing as done.


### PR DESCRIPTION
## Summary

#809 asked to extract the native string helpers from `src/codegen/index.ts` into a new `src/codegen/native-strings.ts`. **This is already done on main** — closing the issue as such, no code change.

## Evidence
- `src/codegen/native-strings.ts` (5,933 lines) defines `ensureNativeStringHelpers` (L203), `nativeStringType` (L15), `nativeStringTypeNullable` (L185), `flatStringType` (L192).
- `registerNativeStringTypes` was extracted to `src/codegen/registry/types.ts:200` (called from `src/codegen/context/create-context.ts:212`).
- `src/codegen/index.ts` imports these from `./native-strings.js` (L89-96) and re-exports them for public-API compatibility (L100-115). No local definition of any of the five functions remains in `index.ts`.

Sets issue frontmatter `status: done` + `completed: 2026-06-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)