### PR TITLE
fix(#1470): String(null/undefined/bool) emit valid module in standalone

### DIFF
--- a/plan/issues/1470-no-js-host-string-ops.md
+++ b/plan/issues/1470-no-js-host-string-ops.md
@@ -487,3 +487,46 @@ default (`gc`) and `fast`/`nativeStrings` host paths are unchanged.
 (`__str_from_mem`/`__str_to_mem`), full `__unbox_string` retargeting, the
 `string_method` ASCII-fold / refuse policy, and the spec-correct object
 `toString` dispatch (via #1472).
+
+### 2026-06-04 — `String(null/undefined/bool)` + no-arg `String()` standalone fix
+
+The `String()` builtin call handler (`src/codegen/expressions/calls.ts`
+~L7745) and the shared `emitBoolToString` helper (`src/codegen/string-ops.ts`
+~L900) pushed `global.get` of a JS-host string-constant global
+(`addStringConstantGlobal`) for the literal arms — `String()`, `String(null)`,
+`String(undefined)`, `String(<void>)`, and `String(<bool>)` /
+`bool.toString()`. Those globals are **never registered** in native-strings
+mode, so the index resolved to the `-1` sentinel (`4294967295`) and the module
+failed `WebAssembly.instantiate` / `wasmtime run` with **"Invalid global index:
+4294967295"** under `--target standalone` / `--target wasi`.
+
+- **Fix**: route every literal arm through `compileStringLiteral`, which
+  already branches on `ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0` and
+  materializes a `NativeString` GC struct inline (no host global). Made
+  `emitBoolToString` native-aware the same way (returns the selected
+  `NativeString` ref in native mode, the externref global in JS-host mode) and
+  threaded its return type back through both call sites so the result type
+  stays consistent. JS-host (`gc`) mode is unchanged — `compileStringLiteral`
+  still emits the externref `global.get` there.
+- **Side benefit**: the explicit `nativeStrings: true` ("fast-native") path,
+  which previously hit the same unbound-global defect for boolean concat /
+  `String(bool)`, now also works.
+
+**Verified** (compiled `--target standalone` + `wasi`, instantiated with an
+empty import object, read back via `.length`/`.charCodeAt`):
+
+| expression          | result      |
+|---------------------|-------------|
+| `String(true)`      | `"true"`    |
+| `String(false)`     | `"false"`   |
+| `String(null)`      | `"null"`    |
+| `String(undefined)` | `"undefined"`|
+| `String()`          | `""`        |
+| `String(42)`        | `"42"`      |
+| `b.toString()` (bool)| `"true"`   |
+
+Tests: `tests/issue-1470-string-coercion-standalone.test.ts` (4 cases —
+standalone + WASI + gc-default regression + explicit nativeStrings).
+`native-strings`, `native-strings-standalone`,
+`issue-1470-standalone-string-imports` (14) all green; default `gc` JS-host
+path unchanged.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7112,8 +7112,7 @@ function compileCallExpression(
       const method = propAccess.name.text;
       if (method === "toString") {
         compileExpression(ctx, fctx, propAccess.expression);
-        emitBoolToString(ctx, fctx);
-        return { kind: "externref" };
+        return emitBoolToString(ctx, fctx);
       }
       if (method === "valueOf") {
         // Boolean.valueOf() returns the boolean primitive — just compile the expression
@@ -7743,12 +7742,17 @@ function compileCallExpression(
 
     // String(x) — ToString coercion
     if (funcName === "String") {
+      // #1470: route every literal-string emission through compileStringLiteral
+      // so native-strings / standalone (`--target standalone` / WASI) materializes
+      // a NativeString GC struct inline. The old `addStringConstantGlobal` +
+      // `global.get` path reaches a JS-host string-constant global that is never
+      // registered in native-strings mode, so its index resolves to the -1
+      // sentinel and the module fails validation ("Invalid global index:
+      // 4294967295"). In JS-host mode compileStringLiteral keeps the existing
+      // global.get behaviour, so this is a no-op there.
       if (expr.arguments.length === 0) {
         // String() with no args → ""
-        addStringConstantGlobal(ctx, "");
-        const emptyIdx = ctx.stringGlobalMap.get("")!;
-        fctx.body.push({ op: "global.get", index: emptyIdx });
-        return { kind: "externref" };
+        return compileStringLiteral(ctx, fctx, "", expr) ?? { kind: "externref" };
       }
 
       // Check if argument is a null/undefined literal before compiling
@@ -7761,36 +7765,26 @@ function compileCallExpression(
 
       if (strArg0IsNull) {
         // String(null) → "null"
-        addStringConstantGlobal(ctx, "null");
-        const nullGIdx = ctx.stringGlobalMap.get("null")!;
-        fctx.body.push({ op: "global.get", index: nullGIdx });
-        return { kind: "externref" };
+        return compileStringLiteral(ctx, fctx, "null", strArg0) ?? { kind: "externref" };
       }
 
       if (strArg0IsUndefined) {
         // String(undefined) → "undefined"
-        addStringConstantGlobal(ctx, "undefined");
-        const undefGIdx = ctx.stringGlobalMap.get("undefined")!;
-        fctx.body.push({ op: "global.get", index: undefGIdx });
-        return { kind: "externref" };
+        return compileStringLiteral(ctx, fctx, "undefined", strArg0) ?? { kind: "externref" };
       }
 
       const argType = compileExpression(ctx, fctx, strArg0);
 
       if (argType === null) {
         // String(void-expr) → "undefined"
-        addStringConstantGlobal(ctx, "undefined");
-        const undefGIdx = ctx.stringGlobalMap.get("undefined")!;
-        fctx.body.push({ op: "global.get", index: undefGIdx });
-        return { kind: "externref" };
+        return compileStringLiteral(ctx, fctx, "undefined", strArg0) ?? { kind: "externref" };
       }
 
       if (argType?.kind === "i32") {
         // Check if it's a boolean type → "true"/"false"
         const argTsType = ctx.checker.getTypeAtLocation(strArg0);
         if (isBooleanType(argTsType)) {
-          emitBoolToString(ctx, fctx);
-          return { kind: "externref" };
+          return emitBoolToString(ctx, fctx);
         }
         // number (i32) → string via f64 conversion
         const toStrIdx = ctx.funcMap.get("number_toString");
@@ -7814,19 +7808,13 @@ function compileCallExpression(
         // Check TS type to determine what this externref actually is
         const argTsType = ctx.checker.getTypeAtLocation(strArg0);
         if (argTsType.flags & ts.TypeFlags.Null) {
-          // Drop the ref.null.extern, push "null" constant
+          // Drop the ref.null.extern, push "null" constant (#1470: native-aware)
           fctx.body.push({ op: "drop" });
-          addStringConstantGlobal(ctx, "null");
-          const nullGIdx = ctx.stringGlobalMap.get("null")!;
-          fctx.body.push({ op: "global.get", index: nullGIdx });
-          return { kind: "externref" };
+          return compileStringLiteral(ctx, fctx, "null", strArg0) ?? { kind: "externref" };
         }
         if (argTsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) {
           fctx.body.push({ op: "drop" });
-          addStringConstantGlobal(ctx, "undefined");
-          const undefGIdx = ctx.stringGlobalMap.get("undefined")!;
-          fctx.body.push({ op: "global.get", index: undefGIdx });
-          return { kind: "externref" };
+          return compileStringLiteral(ctx, fctx, "undefined", strArg0) ?? { kind: "externref" };
         }
         if (isStringType(argTsType)) {
           // Already a string — return as-is

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -897,8 +897,25 @@ export function compileTaggedTemplateExpression(
  * Emit wasm code to convert a boolean (i32) on the stack to a string.
  * Produces "true" or "false" string constant (externref) via if/else.
  */
-export function emitBoolToString(ctx: CodegenContext, fctx: FunctionContext): void {
-  // Ensure "true" and "false" string constants are registered
+export function emitBoolToString(ctx: CodegenContext, fctx: FunctionContext): ValType {
+  // Native-strings / standalone (#1470): JS-host string-constant globals are
+  // never registered (their global index resolves to the -1 sentinel and the
+  // module fails validation with "Invalid global index: 4294967295"). Select
+  // a NativeString GC struct in each arm instead, built inline by
+  // `compileNativeStringLiteral`.
+  if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+    const trueInstrs = nativeStringLiteralInstrs(ctx, "true");
+    const falseInstrs = nativeStringLiteralInstrs(ctx, "false");
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: nativeStringType(ctx) },
+      then: trueInstrs,
+      else: falseInstrs,
+    } as Instr);
+    return nativeStringType(ctx);
+  }
+
+  // JS-host mode: "true" / "false" are externref string-constant globals.
   addStringConstantGlobal(ctx, "true");
   addStringConstantGlobal(ctx, "false");
 
@@ -912,6 +929,7 @@ export function emitBoolToString(ctx: CodegenContext, fctx: FunctionContext): vo
     then: [{ op: "global.get", index: trueIdx }],
     else: [{ op: "global.get", index: falseIdx }],
   } as any);
+  return { kind: "externref" };
 }
 
 // ── Batched string concat chains ─────────────────────────────────────

--- a/tests/issue-1470-string-coercion-standalone.test.ts
+++ b/tests/issue-1470-string-coercion-standalone.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1470 — `String(...)` coercion of `null` / `undefined` / boolean / no-arg
+ * must produce a valid module under `--target standalone` (and WASI).
+ *
+ * The `String()` builtin call handler and `emitBoolToString` previously pushed
+ * `global.get` of a JS-host string-constant global (`addStringConstantGlobal`).
+ * Those globals are never registered in native-strings mode, so the index
+ * resolved to the -1 sentinel and the module failed validation with
+ * `Invalid global index: 4294967295`. The fix routes the literal emissions
+ * through `compileStringLiteral`, which materializes a `NativeString` GC
+ * struct inline when native-strings is active.
+ *
+ * These cases instantiate with an EMPTY import object (proving no JS host is
+ * needed) and read the resulting strings back via `.length` / `.charCodeAt`.
+ */
+
+const SRC = `
+  export function strBool(): number { const t = String(true); return t.length * 1000 + t.charCodeAt(0); }
+  export function strFalse(): number { const t = String(false); return t.length * 1000 + t.charCodeAt(0); }
+  export function strNull(): number { const t = String(null); return t.length * 1000 + t.charCodeAt(0); }
+  export function strUndef(): number { const t = String(undefined); return t.length * 1000 + t.charCodeAt(0); }
+  export function strEmpty(): number { const t = String(); return t.length; }
+  export function strNum(): number { const t = String(42); return t.length * 1000 + t.charCodeAt(0); }
+  export function boolToString(): number { const b = true; const t = b.toString(); return t.length * 1000 + t.charCodeAt(0); }
+`;
+
+// "true"  → len 4, 't'=116 → 4116
+// "false" → len 5, 'f'=102 → 5102
+// "null"  → len 4, 'n'=110 → 4110
+// "undefined" → len 9, 'u'=117 → 9117
+// ""      → len 0
+// "42"    → len 2, '4'=52  → 2052
+const EXPECTED: Record<string, number> = {
+  strBool: 4116,
+  strFalse: 5102,
+  strNull: 4110,
+  strUndef: 9117,
+  strEmpty: 0,
+  strNum: 2052,
+  boolToString: 4116,
+};
+
+async function instantiateStandalone(source: string, target: "standalone" | "wasi") {
+  const r = await compile(source, { target });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JS-host string-coercion imports must leak.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of [/^env::__unbox_string$/, /^env::__extern_toString$/, /^wasm:js-string::/]) {
+    expect(
+      labels.filter((l) => re.test(l)),
+      `leaked ${re}`,
+    ).toEqual([]);
+  }
+  // Empty import object — proves the module is JS-host-free.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#1470 String() coercion of null/undefined/bool/empty — standalone", () => {
+  it("produces a valid standalone module for every literal coercion", async () => {
+    const ex = await instantiateStandalone(SRC, "standalone");
+    for (const [fn, want] of Object.entries(EXPECTED)) {
+      expect(ex[fn]!(), `String coercion ${fn}`).toBe(want);
+    }
+  });
+
+  it("produces a valid WASI module for every literal coercion", async () => {
+    const ex = await instantiateStandalone(SRC, "wasi");
+    for (const [fn, want] of Object.entries(EXPECTED)) {
+      expect(ex[fn]!(), `WASI String coercion ${fn}`).toBe(want);
+    }
+  });
+
+  it("default (gc / JS-host) mode keeps correct String() coercion", async () => {
+    // Regression guard: the JS-host path must keep returning the same values.
+    const r = await compile(SRC, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+    const ex = instance.exports as Record<string, () => number>;
+    for (const [fn, want] of Object.entries(EXPECTED)) {
+      expect(ex[fn]!(), `gc-mode String coercion ${fn}`).toBe(want);
+    }
+  });
+
+  it("explicit nativeStrings:true also coerces null/bool without unbound globals", async () => {
+    const r = await compile(SRC, { nativeStrings: true } as Parameters<typeof compile>[1]);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, (r.importObject ?? {}) as WebAssembly.Imports);
+    const ex = instance.exports as Record<string, () => number>;
+    expect(ex.strBool!()).toBe(EXPECTED.strBool);
+    expect(ex.strNull!()).toBe(EXPECTED.strNull);
+    expect(ex.boolToString!()).toBe(EXPECTED.boolToString);
+  });
+});


### PR DESCRIPTION
## Problem (slice of #1470)

Under `--target standalone` / `--target wasi`, `String(true)`, `String(false)`, `String(null)`, `String(undefined)`, `String()`, and `b.toString()` (bool) produced an **invalid module** that failed `WebAssembly.instantiate` / `wasmtime run` with:

```
Invalid global index: 4294967295
```

The `String()` builtin handler (`src/codegen/expressions/calls.ts`) and the shared `emitBoolToString` helper (`src/codegen/string-ops.ts`) pushed `global.get` of a JS-host string-constant global (`addStringConstantGlobal`). Those globals are never registered in native-strings mode, so the index resolved to the `-1` sentinel (`4294967295`).

## Fix

- Route every literal arm (`""`/`"null"`/`"undefined"` + the externref null/undefined sub-cases) through `compileStringLiteral`, which already branches on `ctx.nativeStrings` and materializes a `NativeString` GC struct inline.
- Make `emitBoolToString` native-aware: it now selects a `NativeString` ref in each arm under native strings, returns its `ValType`, and both call sites (`String(bool)`, `bool.toString()`) thread that type back instead of hard-coding `externref`.
- JS-host (`gc`) mode is unchanged — `compileStringLiteral` still emits the externref `global.get` there. Also fixes the explicit `nativeStrings: true` fast-native path, which hit the same defect.

## Verification

Compiled `--target standalone` + `wasi`, instantiated with an **empty import object**, read back via `.length`/`.charCodeAt`: `String(true)`→`true`, `String(false)`→`false`, `String(null)`→`null`, `String(undefined)`→`undefined`, `String()`→`""`, `String(42)`→`42`, `b.toString()`→`true`.

Tests: `tests/issue-1470-string-coercion-standalone.test.ts` (standalone + WASI + gc-default regression + explicit nativeStrings). `native-strings` (86), `native-strings-standalone` (10), `issue-1470-standalone-string-imports` (14) all green; default `gc` JS-host path unchanged.

This is a slice of #1470 (string-method ToString policy). Issue stays `ready` — the pure-Wasm UTF-8 codec, full `__unbox_string` retargeting, and `string_method` ASCII-fold policy remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)