### PR TITLE
fix(#1824): super-as-value reads static ValType from params, not locals

### DIFF
--- a/plan/issues/1824-super-as-value-wrong-static-type.md
+++ b/plan/issues/1824-super-as-value-wrong-static-type.md
@@ -1,9 +1,10 @@
 ---
 id: 1824
 title: "super used as a value returns the wrong static ValType (local indexing bug)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: medium
 feasibility: low
 task_type: bugfix
@@ -26,4 +27,17 @@ is param 0, so `fctx.locals[0]` is a non-param local.
 
 ## Fix
 Mirror the ThisKeyword indexing (params array for param indices).
+
+## Resolution (2026-06-04)
+
+The SuperKeyword branch in `src/codegen/expressions.ts` now mirrors the
+ThisKeyword branch (`:861-865`): when `selfIdx < fctx.params.length` it returns
+`fctx.params[selfIdx].type`, otherwise it indexes
+`fctx.locals[selfIdx - fctx.params.length]`. The old `fctx.locals[selfIdx]`
+read an unrelated non-param local (or undefined → externref) since `this` is
+param 0.
+
+Tests: `tests/issue-1824-super-as-value.test.ts` — `super.method()`,
+`super.getX()` reading `this.field`, and a three-level chained-super case all
+compile to valid modules and return the inherited values (2 / 18 / 111).
 

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -1246,8 +1246,16 @@ function compileExpressionInner(
     const selfIdx = fctx.localMap.get("this");
     if (selfIdx !== undefined) {
       fctx.body.push({ op: "local.get", index: selfIdx });
-      const selfType = fctx.locals[selfIdx];
-      if (selfType) return selfType.type;
+      // (#1824) `this` is param 0, so its ValType lives in `fctx.params`, not
+      // `fctx.locals`. Mirror the ThisKeyword branch: params for param-range
+      // indices, locals (offset by the param count) otherwise. The old
+      // `fctx.locals[selfIdx]` read an unrelated non-param local (or undefined),
+      // which mis-drove downstream coercion of a bare `super` value.
+      if (selfIdx < fctx.params.length) {
+        return fctx.params[selfIdx]!.type;
+      }
+      const localDef = fctx.locals[selfIdx - fctx.params.length];
+      if (localDef) return localDef.type;
     }
     fctx.body.push({ op: "ref.null.extern" });
     return { kind: "externref" };

--- a/tests/issue-1824-super-as-value.test.ts
+++ b/tests/issue-1824-super-as-value.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1824 — a bare `super` used as a value reported the wrong static ValType.
+ *
+ * The SuperKeyword branch in `src/codegen/expressions.ts` emitted the correct
+ * `local.get` for `this` (param 0) but read its type from `fctx.locals[selfIdx]`
+ * — yet `this` is a *parameter*, so its ValType lives in `fctx.params`, not
+ * `fctx.locals`. `fctx.locals[0]` is an unrelated non-param local (or
+ * undefined → externref), which mis-drove downstream coercion of the `super`
+ * receiver. The fix mirrors the ThisKeyword branch: params for param-range
+ * indices, locals offset by the param count otherwise.
+ *
+ * Observable effect: methods that route through the super receiver
+ * (`super.method()`, `super.prop`) compile to a valid module and return the
+ * inherited value.
+ */
+
+async function run(source: string): Promise<number> {
+  const r = await compile(source, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#1824 super used as a value has the correct static type", () => {
+  it("super.method() returns the inherited method result", async () => {
+    expect(
+      await run(`
+        class A { greet(): number { return 1; } }
+        class B extends A { greet(): number { return super.greet() + 1; } }
+        export function test(): number { return new B().greet(); }
+      `),
+    ).toBe(2);
+  });
+
+  it("super.method() observes the parent reading this.field", async () => {
+    expect(
+      await run(`
+        class A { x: number = 5; getX(): number { return this.x; } }
+        class B extends A { x: number = 9; getX(): number { return super.getX() * 2; } }
+        export function test(): number { return new B().getX(); }
+      `),
+    ).toBe(18);
+  });
+
+  it("chained super calls across three levels compile and run", async () => {
+    expect(
+      await run(`
+        class A { v(): number { return 1; } }
+        class B extends A { v(): number { return super.v() + 10; } }
+        class C extends B { v(): number { return super.v() + 100; } }
+        export function test(): number { return new C().v(); }
+      `),
+    ).toBe(111);
+  });
+});


### PR DESCRIPTION
## Problem

A bare `super` used as a value emitted the correct `local.get` for `this` (param 0) but reported its static ValType from `fctx.locals[selfIdx]` — an unrelated non-param local (or undefined → externref). `this` is a **parameter**, so its type lives in `fctx.params`. The wrong type mis-drove downstream coercion of the `super` receiver.

## Fix

`src/codegen/expressions.ts` SuperKeyword branch now mirrors the ThisKeyword branch (`:861-865`): `fctx.params[selfIdx].type` for param-range indices, `fctx.locals[selfIdx - fctx.params.length]` otherwise.

## Verification

`tests/issue-1824-super-as-value.test.ts` — `super.method()`, `super.getX()` reading `this.field`, and a three-level chained-super case all compile to valid modules and return the inherited values (2 / 18 / 111).

Sets issue frontmatter `status: done` + `completed: 2026-06-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)