### PR TITLE
fix(#1847): for-of tentative rollback restores localMap, not just locals

### DIFF
--- a/plan/issues/1847-forof-rollback-localmap-not-restored.md
+++ b/plan/issues/1847-forof-rollback-localmap-not-restored.md
@@ -1,9 +1,10 @@
 ---
 id: 1847
 title: "for-of tentative rollback truncates fctx.locals but does not restore fctx.localMap"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: low
 task_type: bugfix
@@ -24,4 +25,37 @@ unbalanced.
 ## Fix
 Snapshot/restore `fctx.localMap` (and `tempFreeList`) alongside `locals.length`, or
 delete names allocated since the snapshot.
+
+## Resolution
+
+Added `snapshotLocals(fctx)` / `restoreLocals(fctx, snap)` to
+`src/codegen/context/locals.ts`:
+- `snapshotLocals` captures `locals.length` + the set of `localMap` names
+  present at snapshot time.
+- `restoreLocals` truncates `fctx.locals` back to the snapshot length, deletes
+  every `localMap` name added since (whose slot the truncation removes), and
+  prunes any `tempFreeList` bucket entry pointing past the new locals length
+  (so the temp-reuse path can't hand out a dead slot). It deliberately does
+  **not** touch `fctx.body` — callers truncate that themselves (the rollback
+  body length is site-specific and captured separately).
+
+Converted the four `fctx.locals.length =` rollback sites in
+`src/codegen/statements/loops.ts` to snapshot/restore:
+- `arrayValuesReceiverForForOf` (`.values()` receiver type probe),
+- `compileForOfArrayTentative` (both the confirmed-vec and not-a-vec rollbacks),
+- `compileForOfIterator` (standalone/WASI iterator fallback rollback).
+
+The body-only error-rollback sites (`compileForOfString` / `compileForOfArray`
+error paths) only truncate `fctx.body` and allocate no locals before the error,
+so they are not part of this defect and are unchanged.
+
+### Test Results
+- `tests/issue-1847.test.ts` (4, all pass): restore drops post-snapshot
+  localMap entries; re-allocating the same name after restore reuses an
+  in-range slot the map agrees with; tempFreeList entries past the truncated
+  vector are pruned; end-to-end two-consecutive-for-of compile produces valid
+  Wasm returning 180.
+- For-of generator / iterator suites green (the 3 `for-of-*destructuring*`
+  files that failed to load are a pre-existing missing-`./helpers.js` harness
+  issue, unrelated).
 

--- a/src/codegen/context/locals.ts
+++ b/src/codegen/context/locals.ts
@@ -15,6 +15,62 @@ export function allocLocal(fctx: FunctionContext, name: string, type: ValType): 
   return index;
 }
 
+/**
+ * #1847 — snapshot of the local-allocation state, for tentative compilation
+ * that may be rolled back. Captures the locals-vector length so callers can
+ * truncate, plus the `localMap` names present at snapshot time so we can drop
+ * any name `allocLocal` added afterwards (whose slot the truncation removes).
+ *
+ * Tentative-compile sites previously truncated `fctx.locals.length` (and
+ * `fctx.body.length`) but left `fctx.localMap` pointing at slots past the
+ * truncated vector — an unbalanced state. Snapshot/restore keeps the three in
+ * sync.
+ */
+export interface LocalsSnapshot {
+  readonly localsLen: number;
+  /** Names present in `localMap` at snapshot time (keys are stable strings). */
+  readonly mapNames: ReadonlySet<string>;
+}
+
+export function snapshotLocals(fctx: FunctionContext): LocalsSnapshot {
+  return {
+    localsLen: fctx.locals.length,
+    mapNames: new Set(fctx.localMap.keys()),
+  };
+}
+
+/**
+ * #1847 — undo allocations made since `snap`: truncate the locals vector and
+ * delete every `localMap` name that wasn't present at snapshot time. Does NOT
+ * touch `fctx.body` — callers truncate that themselves (the body length to
+ * roll back to is site-specific and often captured separately).
+ *
+ * `tempFreeList` is left as-is on purpose: it only ever holds indices that were
+ * valid at allocation time, and the temp-local reuse path keys buckets by type;
+ * a rolled-back tentative compile that released a temp would have pushed a slot
+ * index that is now beyond `locals.length`. To keep the free-list from handing
+ * out a truncated slot, we prune any bucket entry that points past the new
+ * locals length.
+ */
+export function restoreLocals(fctx: FunctionContext, snap: LocalsSnapshot): void {
+  if (fctx.locals.length > snap.localsLen) {
+    fctx.locals.length = snap.localsLen;
+  }
+  // Drop localMap names added after the snapshot.
+  for (const name of fctx.localMap.keys()) {
+    if (!snap.mapNames.has(name)) fctx.localMap.delete(name);
+  }
+  // Prune any temp-free-list entries that now point past the truncated vector.
+  if (fctx.tempFreeList) {
+    const maxValid = fctx.params.length + snap.localsLen;
+    for (const bucket of fctx.tempFreeList.values()) {
+      for (let i = bucket.length - 1; i >= 0; i--) {
+        if (bucket[i]! >= maxValid) bucket.splice(i, 1);
+      }
+    }
+  }
+}
+
 function valTypeKey(type: ValType): string {
   switch (type.kind) {
     case "ref":

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -8,7 +8,7 @@ import { forEachChild, ts } from "../../ts-api.js";
 import { collectReferencedIdentifiers } from "../closures.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError, reportErrorNoNode } from "../context/errors.js";
-import { allocLocal, getLocalType } from "../context/locals.js";
+import { allocLocal, getLocalType, restoreLocals, snapshotLocals } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import {
@@ -2381,10 +2381,10 @@ function arrayValuesReceiverForForOf(
 
   // Confirm the receiver lowers to a vec struct without leaving any code behind.
   const bodyLenBefore = fctx.body.length;
-  const localsLenBefore = fctx.locals.length;
+  const localsSnap = snapshotLocals(fctx); // #1847
   const recvType = compileExpression(ctx, fctx, callee.expression);
   fctx.body.length = bodyLenBefore;
-  fctx.locals.length = localsLenBefore;
+  restoreLocals(fctx, localsSnap); // #1847 — also drops stale localMap entries
   if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) return undefined;
   if (getArrTypeIdxFromVec(ctx, recvType.typeIdx) < 0) return undefined;
   return callee.expression;
@@ -2576,7 +2576,7 @@ function compileForOfArrayTentative(
   const iterableExpr = iterableOverride ?? stmt.expression;
   // Tentatively compile just the expression to discover its Wasm type
   const bodyLenBefore = fctx.body.length;
-  const localsLenBefore = fctx.locals.length;
+  const localsSnap = snapshotLocals(fctx); // #1847
   const exprType = compileExpression(ctx, fctx, iterableExpr);
 
   // Check if it compiled to a ref to a vec struct (not just any struct —
@@ -2588,7 +2588,7 @@ function compileForOfArrayTentative(
       // Confirmed vec struct — undo the tentative compilation and use the
       // full array path (which compiles the expression again with proper setup)
       fctx.body.length = bodyLenBefore;
-      fctx.locals.length = localsLenBefore;
+      restoreLocals(fctx, localsSnap); // #1847
       compileForOfArray(ctx, fctx, stmt, iterableOverride);
       return true;
     }
@@ -2596,7 +2596,7 @@ function compileForOfArrayTentative(
 
   // Not a vec struct — undo tentative compilation, let caller use iterator path
   fctx.body.length = bodyLenBefore;
-  fctx.locals.length = localsLenBefore;
+  restoreLocals(fctx, localsSnap); // #1847
   return false;
 }
 
@@ -3439,7 +3439,7 @@ function findStructFieldsByTypeIdx(
 function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForOfStatement): void {
   // Compile the iterable expression
   const bodyLenBefore = fctx.body.length;
-  const localsLenBefore = fctx.locals.length;
+  const localsSnap = snapshotLocals(fctx); // #1847
   const iterableType = compileExpression(ctx, fctx, stmt.expression);
   if (!iterableType) {
     reportError(ctx, stmt, "for-of: failed to compile iterable expression");
@@ -3483,7 +3483,7 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   // Fallback: host-delegated iterator protocol
   if (ctx.standalone || ctx.wasi) {
     fctx.body.length = bodyLenBefore;
-    fctx.locals.length = localsLenBefore;
+    restoreLocals(fctx, localsSnap); // #1847
     reportError(
       ctx,
       stmt,

--- a/tests/issue-1847.test.ts
+++ b/tests/issue-1847.test.ts
@@ -1,0 +1,95 @@
+// #1847 — for-of tentative rollback must restore fctx.localMap, not just
+// truncate fctx.locals.
+//
+// The tentative for-of paths (compileForOfArrayTentative, the .values()
+// receiver probe, the standalone iterator fallback) compile the iterable
+// expression to discover its type, then roll back. They truncated
+// `fctx.locals.length` but left `fctx.localMap` entries pointing past the
+// truncated vector — an unbalanced state. `snapshotLocals`/`restoreLocals`
+// (src/codegen/context/locals.ts) keep the two in sync. These tests pin the
+// helper's contract plus an end-to-end compile that exercises the rollback.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { allocLocal, snapshotLocals, restoreLocals } from "../src/codegen/context/locals.js";
+import type { FunctionContext } from "../src/codegen/context/types.js";
+
+function makeFctx(): FunctionContext {
+  // Minimal fctx shape for the locals helpers (they only touch
+  // params/locals/localMap/tempFreeList).
+  return {
+    params: [],
+    locals: [],
+    localMap: new Map<string, number>(),
+    body: [],
+    labelMap: new Map(),
+  } as unknown as FunctionContext;
+}
+
+describe("#1847 — snapshotLocals/restoreLocals keep locals + localMap in sync", () => {
+  it("restore drops localMap entries for locals allocated after the snapshot", () => {
+    const fctx = makeFctx();
+    allocLocal(fctx, "outer", { kind: "i32" }); // index 0 — pre-snapshot
+    const snap = snapshotLocals(fctx);
+
+    // Tentative allocations.
+    allocLocal(fctx, "__forof_vec_1", { kind: "externref" });
+    allocLocal(fctx, "__forof_idx_2", { kind: "i32" });
+    expect(fctx.locals.length).toBe(3);
+    expect(fctx.localMap.has("__forof_vec_1")).toBe(true);
+
+    restoreLocals(fctx, snap);
+
+    // locals truncated back to the snapshot length...
+    expect(fctx.locals.length).toBe(1);
+    // ...and the post-snapshot localMap entries are gone (no stale slots).
+    expect(fctx.localMap.has("__forof_vec_1")).toBe(false);
+    expect(fctx.localMap.has("__forof_idx_2")).toBe(false);
+    // ...while the pre-snapshot entry is intact.
+    expect(fctx.localMap.get("outer")).toBe(0);
+  });
+
+  it("re-allocating the same name after restore reuses a valid (in-range) slot", () => {
+    const fctx = makeFctx();
+    const snap = snapshotLocals(fctx);
+    const first = allocLocal(fctx, "__forof_vec", { kind: "externref" }); // 0
+    restoreLocals(fctx, snap);
+    const second = allocLocal(fctx, "__forof_vec", { kind: "externref" }); // 0 again
+    // Without the localMap restore the map would still point at the stale slot;
+    // with it, the re-allocation gets a fresh, in-range index and the map agrees.
+    expect(second).toBe(first);
+    expect(fctx.localMap.get("__forof_vec")).toBe(second);
+    expect(second).toBeLessThan(fctx.params.length + fctx.locals.length);
+  });
+
+  it("restore prunes tempFreeList entries that point past the truncated vector", () => {
+    const fctx = makeFctx();
+    const snap = snapshotLocals(fctx);
+    const idx = allocLocal(fctx, "__tmp_0", { kind: "i32" }); // index 0
+    // Simulate a temp released during the tentative compile.
+    fctx.tempFreeList = new Map([["i32", [idx]]]);
+    restoreLocals(fctx, snap);
+    // The freed slot (0) is now past the truncated locals length (0), so it
+    // must be pruned — otherwise allocTempLocal could hand out a dead slot.
+    expect(fctx.tempFreeList.get("i32")).toEqual([]);
+  });
+
+  it("end-to-end: two consecutive for-of loops over the same array compile to valid Wasm", async () => {
+    // Exercises the tentative for-of path twice with the same temp names — if
+    // localMap held stale entries, the second loop's slot indices would be
+    // wrong and the module would fail Wasm validation.
+    const src = `
+      export function test(): number {
+        const arr: number[] = [10, 20, 30];
+        let sum = 0;
+        for (const x of arr) { sum += x; }
+        for (const y of arr) { sum += y * 2; }
+        return sum;
+      }
+    `;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+    expect((instance.exports.test as () => number)()).toBe(180);
+  });
+});


### PR DESCRIPTION
Closes #1847.

## Defect

The tentative for-of paths in `src/codegen/statements/loops.ts` compile the
iterable expression to discover its type, then roll back — truncating
`fctx.locals.length` (and `fctx.body.length`) but **not** `fctx.localMap`.
`allocLocal` mutates `localMap`, so after rollback stale entries pointed past
the truncated locals vector — an unbalanced state. Practical risk was low
(temp names key off `locals.length`) but the invariant was broken.

## Fix

Added `snapshotLocals(fctx)` / `restoreLocals(fctx, snap)` to
`src/codegen/context/locals.ts`:
- `snapshotLocals` captures `locals.length` + the set of `localMap` names
  present at snapshot time.
- `restoreLocals` truncates `fctx.locals` back, deletes every `localMap` name
  added since (whose slot the truncation removes), and prunes any
  `tempFreeList` bucket entry pointing past the new locals length (so the
  temp-reuse path can't hand out a dead slot). It deliberately does **not**
  touch `fctx.body` — callers truncate that themselves (the rollback body
  length is site-specific and captured separately).

Converted the four locals-truncating rollback sites:
- `arrayValuesReceiverForForOf` (`.values()` receiver type probe)
- `compileForOfArrayTentative` (confirmed-vec + not-a-vec rollbacks)
- `compileForOfIterator` (standalone/WASI iterator fallback rollback)

The body-only error-rollback sites (`compileForOfString` /
`compileForOfArray` error paths) allocate no locals before erroring, so they
are not part of this defect and are unchanged.

## Tests

`tests/issue-1847.test.ts` (4, all pass):
- restore drops post-snapshot `localMap` entries;
- re-allocating the same name after restore reuses an in-range slot the map
  agrees with;
- `tempFreeList` entries past the truncated vector are pruned;
- end-to-end: two consecutive for-of loops over the same array compile to
  valid Wasm returning 180 (exercises the tentative path twice with the same
  temp names — would mis-index if `localMap` were stale).

For-of generator/iterator suites green. (The 3 `for-of-*destructuring*` test
files that fail to load reference a missing `./helpers.js` — a pre-existing
harness issue, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)