### PR TITLE
docs(#1828): reroute — .call receiver reads broken, not a localized fix

### DIFF
--- a/plan/issues/1828-array-like-find-map-hole-handling.md
+++ b/plan/issues/1828-array-like-find-map-hole-handling.md
@@ -5,11 +5,12 @@ status: ready
 created: 2026-06-04
 updated: 2026-06-04
 priority: medium
-feasibility: medium
+feasibility: hard
 task_type: bugfix
 area: codegen
 goal: correctness
 sprint: 59
+needs: architect-or-senior-dev
 ---
 # #1828 — array-like find/findIndex/map hole handling
 
@@ -30,4 +31,48 @@ preserves length / holes). Dense arrays are unaffected.
 ## Fix
 Drop `gatedBody` for find/findIndex; write mapped values by index into a length-`len`
 result (leave holes) instead of push.
+
+## Investigation (2026-06-04, dev-w1) — NOT a localized fix; reclassified `hard`
+
+The hole-handling corrections this issue describes are **necessary but not
+sufficient**. The array-like `Array.prototype.<m>.call(receiver, cb)` path in
+`src/codegen/array-methods.ts` is broken one layer deeper: it **never reads any
+element correctly** for the receivers in scope, so fixing the hole gates alone
+changes nothing observable.
+
+### Root cause found
+- `__extern_get_idx(obj, i)` (`src/runtime.ts:5190`) does `obj[i]`. The
+  externref passed as the `.call` receiver for a compiled array/object is a
+  **WasmGC `$Vec` / open-object struct**, not a JS-indexable value, so `obj[i]`
+  is always `undefined`.
+- Confirmed end-to-end (all on current main, JS-host `gc` target):
+  - `({length:3,0:1,2:3})[2]` read back via the receiver → **NaN** (the numeric
+    index isn't even retrievable — a separate object-literal numeric-key storage
+    gap).
+  - `Array.prototype.findIndex.call([10,20,30], x=>x===20)` → **-1** (spec 1),
+    i.e. a **dense** real-array receiver also fails. So the defect is upstream of
+    holes entirely: the receiver's elements are unreadable through
+    `__extern_get_idx`.
+
+### What I implemented and then reverted (kept the branch clean)
+The localized parts described above DO compile and DON'T regress dense
+*non-.call* arrays (`[1,2,3].findIndex(...)`, `[1,2,3].map(...)` stay correct):
+- find/findIndex: drop `gatedBody`, decrement the inner `if`'s `br` depth 3→2.
+- map: add `__js_array_new_len(len)` + `__js_array_set_idx(arr,i,val)` host
+  helpers (`src/runtime.ts`), pre-size the result to `len`, keep the
+  HasProperty gate, set present indices by index.
+
+But because no element is readable on the `.call` receiver, every
+behavioral case still returns `-1` / `0` / `NaN`, so there is no test that can
+prove the fix. Reverted rather than ship an unverifiable PR.
+
+### Reroute
+Before #1828 can land, the array-like `.call` **receiver-retrieval** path must
+be fixed so `__extern_get_idx` / `__extern_length` read compiled `$Vec` /
+open-object struct receivers (convert the receiver to a JS-accessible
+array/object at the `.call` boundary, or route index reads through the WasmGC
+element accessor). That is an architect/senior-dev sized change spanning the
+receiver-conversion at the `.call` site plus the runtime accessors — not a
+localized array-methods edit. Recommend architect spec; the hole-logic patch
+above can land as a follow-up slice once receiver reads work.
 


### PR DESCRIPTION
## Investigation result (NOT a code fix)

#1828 asked to fix array-like find/findIndex/map **hole** handling on `.call` receivers. Investigation shows it is **not a localized fix**: the array-like `Array.prototype.<m>.call(receiver, cb)` path never reads any element correctly, so fixing the hole gates alone changes nothing observable.

### Root cause
`__extern_get_idx(obj, i)` (`src/runtime.ts:5190`) does `obj[i]`, but the externref passed as the `.call` receiver for a compiled array/object is a WasmGC `$Vec` / open-object struct, not a JS-indexable value — so `obj[i]` is always `undefined`.

Confirmed end-to-end on current main (JS-host `gc` target):
- `Array.prototype.findIndex.call([10,20,30], x=>x===20)` → **-1** (spec 1) — even a **dense** real-array receiver fails. The defect is upstream of holes entirely.
- `({length:3,0:1,2:3})[2]` read via the receiver → **NaN** (a separate object-literal numeric-key storage gap).

### What I tried (and reverted)
A localized hole-logic patch (drop `gatedBody` for find/findIndex + decrement the inner `br` depth 3→2; map via new `__js_array_new_len`/`__js_array_set_idx` host helpers, set by index) **compiles and does not regress dense non-`.call` arrays**, but every behavioral `.call` case still returns -1/0/NaN because the receiver elements are unreadable. Reverted rather than ship an unverifiable PR.

### Reroute
The `.call` **receiver-retrieval** path must be fixed first (convert the compiled `$Vec`/open-object receiver to a JS-accessible array/object at the `.call` boundary, or route index reads through the WasmGC element accessor). Architect/senior-dev sized. Reclassified `feasibility: hard`, `needs: architect-or-senior-dev`. Issue stays `ready` (now blocked); findings documented in the issue file. The hole-logic patch can land as a follow-up slice once receiver reads work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)