### PR TITLE
fix(#1843): align R_WASM_TAG_INDEX_LEB on 10 (emitter matched reader)

### DIFF
--- a/plan/issues/1843-reloc-tag-index-leb-mismatch.md
+++ b/plan/issues/1843-reloc-tag-index-leb-mismatch.md
@@ -1,9 +1,10 @@
 ---
 id: 1843
 title: "R_WASM_TAG_INDEX_LEB mismatch between emitter (11) and reader (10)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: low
 task_type: bugfix
@@ -21,4 +22,22 @@ relocation written by the emitter (11) is parsed by the reader as unknown.
 
 ## Fix
 Align both on `10` — correct `opcodes.ts:480`.
+
+## Resolution
+Changed `RELOC.R_WASM_TAG_INDEX_LEB` in `src/emit/opcodes.ts` from `11` to `10`
+(LLVM canonical; historically `R_WASM_EVENT_INDEX_LEB`). The reader
+(`src/link/reader.ts`) already used `10`, and slot `10` was unused on the
+emitter side (table jumped 9 → 11), so there is no collision. The single
+emitter use site (`src/emit/object.ts:889`, `throw` tag relocation) now writes
+the value the reader parses.
+
+### Test Results
+- `tests/issue-1843.test.ts` (2, all pass): pins `R_WASM_TAG_INDEX_LEB === 10`
+  on both sides, plus a cross-table guard that asserts **every** reloc type
+  defined on both the emitter and the reader uses the same number — preventing
+  future drift (the root cause here).
+- `tests/object-file.test.ts` (12) green.
+- `tests/linker-e2e.test.ts` fails 3 tests identically on clean main
+  (`WasmEncoder_i64 ... local.tee` self-compilation error) — a pre-existing
+  failure unrelated to this change (verified by stash-diff).
 

--- a/src/emit/opcodes.ts
+++ b/src/emit/opcodes.ts
@@ -477,7 +477,10 @@ export const RELOC = {
   R_WASM_GLOBAL_INDEX_LEB: 7,
   R_WASM_FUNCTION_OFFSET_I32: 8,
   R_WASM_SECTION_OFFSET_I32: 9,
-  R_WASM_TAG_INDEX_LEB: 11,
+  // #1843 — LLVM canonical for the tag-index relocation is 10 (historically
+  // R_WASM_EVENT_INDEX_LEB). This was 11, so a tag relocation written by the
+  // emitter was parsed as unknown by `src/link/reader.ts` (which uses 10).
+  R_WASM_TAG_INDEX_LEB: 10,
 } as const;
 
 /** Symbol flags for the linking section symbol table */

--- a/tests/issue-1843.test.ts
+++ b/tests/issue-1843.test.ts
@@ -1,0 +1,33 @@
+// #1843 — the LLVM-style relocation type numbers must agree between the
+// emitter (`RELOC` in src/emit/opcodes.ts) and the linker reader
+// (`R_WASM_*` constants in src/link/reader.ts).
+//
+// They had drifted on the tag relocation: the emitter wrote
+// `R_WASM_TAG_INDEX_LEB = 11` while the reader expected `10` (the LLVM
+// canonical, historically R_WASM_EVENT_INDEX_LEB). A tag relocation written
+// by the emitter was therefore parsed as an unknown type by the reader.
+// These tests pin the tag value and guard against any future drift across the
+// whole shared reloc set.
+import { describe, expect, it } from "vitest";
+import { RELOC } from "../src/emit/opcodes.js";
+import * as reader from "../src/link/reader.js";
+
+describe("#1843 — emitter/reader relocation type numbers agree", () => {
+  it("R_WASM_TAG_INDEX_LEB is 10 on both sides (LLVM canonical)", () => {
+    expect(RELOC.R_WASM_TAG_INDEX_LEB).toBe(10);
+    expect(reader.R_WASM_TAG_INDEX_LEB).toBe(10);
+    expect(RELOC.R_WASM_TAG_INDEX_LEB).toBe(reader.R_WASM_TAG_INDEX_LEB);
+  });
+
+  it("every reloc type defined on both sides uses the same number", () => {
+    const readerConsts = reader as unknown as Record<string, unknown>;
+    const mismatches: string[] = [];
+    for (const [name, emitterValue] of Object.entries(RELOC)) {
+      const readerValue = readerConsts[name];
+      if (typeof readerValue === "number" && readerValue !== emitterValue) {
+        mismatches.push(`${name}: emitter=${emitterValue} reader=${readerValue}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1843.

## Defect

`src/emit/opcodes.ts` defined `RELOC.R_WASM_TAG_INDEX_LEB = 11`, but
`src/link/reader.ts` defines `R_WASM_TAG_INDEX_LEB = 10` (the LLVM canonical
value, historically `R_WASM_EVENT_INDEX_LEB`). A tag relocation written by the
emitter (`src/emit/object.ts:889`, the `throw` tag relocation) was therefore
parsed as an **unknown** relocation type by the reader. Latent — the object/
linker path is not yet in production — but a real, verified disagreement.

## Fix

Corrected the emitter constant to `10`. Slot `10` was unused on the emitter
side (the table jumped `9 → 11`), so there is no collision with another reloc
type. The single use site now writes the value the reader parses.

## Tests

`tests/issue-1843.test.ts` (2, all pass):
- pins `R_WASM_TAG_INDEX_LEB === 10` on both the emitter and the reader;
- a **cross-table guard** that asserts every reloc type defined on both sides
  uses the same number — this catches future drift, the root cause here.

`tests/object-file.test.ts` (12) green. `tests/linker-e2e.test.ts` fails 3
tests identically on clean `main` (`WasmEncoder_i64 ... local.tee`
self-compilation error) — a pre-existing failure unrelated to this change
(verified by stash-diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)