### PR TITLE
fix(#1842): none heap-type 0x6e→0x71; add noextern/nofunc

### DIFF
--- a/plan/issues/1842-none-heaptype-constant-collides-with-any.md
+++ b/plan/issues/1842-none-heaptype-constant-collides-with-any.md
@@ -1,9 +1,10 @@
 ---
 id: 1842
 title: "none heap-type constant collides with any (0x6e); noextern/nofunc missing"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: low
 task_type: bugfix
@@ -24,4 +25,20 @@ WebAssembly GC binary/types — abstract heap-type encodings.
 
 ## Fix
 `none: 0x71`; add `noextern: 0x72`, `nofunc: 0x73`.
+
+## Resolution
+Corrected `TYPE.none` in `src/emit/opcodes.ts` from `0x6e` (which aliased
+`TYPE.any`) to `0x71`, and added `noextern: 0x72` / `nofunc: 0x73`. Verified
+`0x71/0x72/0x73` were free within the `TYPE` table (the same bytes appear in the
+unrelated OP / SIMD opcode tables, different namespaces). `TYPE.none` has no
+current emitter use site (latent), so no behavior changes today — this removes
+the landmine for future bottom-type emission.
+
+### Test Results
+- `tests/issue-1842.test.ts` (3, all pass): `none/noextern/nofunc` use the spec
+  bottom-type bytes; `none` no longer collides with `any`; the abstract
+  heap-type bytes match the spec table (`any=0x6e, eq=0x6d, i31=0x6c,
+  struct=0x6b, array=0x6a`; `funcref=0x70` distinct from the `func` type-def
+  tag `0x60`).
+- `tests/object-file.test.ts` (12) green — no emit regression.
 

--- a/src/emit/opcodes.ts
+++ b/src/emit/opcodes.ts
@@ -441,7 +441,13 @@ export const TYPE = {
   i31: 0x6c,
   struct_ht: 0x6b,
   array_ht: 0x6a,
-  none: 0x6e, // alias – bottom of ref hierarchy
+  // #1842 — WasmGC abstract bottom heap types. `none` is the bottom of the
+  // `any` hierarchy and MUST be 0x71; it previously aliased `any` (0x6e), which
+  // would mis-encode any future bottom-type emission. `noextern`/`nofunc`
+  // (bottoms of the extern/func hierarchies) were absent entirely.
+  none: 0x71,
+  noextern: 0x72,
+  nofunc: 0x73,
   v128: 0x7b,
   i8: 0x78,
   i16: 0x77,

--- a/tests/issue-1842.test.ts
+++ b/tests/issue-1842.test.ts
@@ -1,0 +1,30 @@
+// #1842 — the WasmGC abstract heap-type byte encodings in `TYPE`
+// (src/emit/opcodes.ts) must match the spec. `none` previously aliased `any`
+// (both 0x6e), and the bottom types `noextern`/`nofunc` were missing entirely.
+// Spec (WebAssembly GC, abstract heap types — single-byte forms):
+//   func=0x70, extern=0x6f, any=0x6e, eq=0x6d, i31=0x6c, struct=0x6b,
+//   array=0x6a, none=0x71, noextern=0x72, nofunc=0x73.
+import { describe, expect, it } from "vitest";
+import { TYPE } from "../src/emit/opcodes.js";
+
+describe("#1842 — WasmGC abstract heap-type encodings", () => {
+  it("none/noextern/nofunc use the spec bottom-type bytes", () => {
+    expect(TYPE.none).toBe(0x71);
+    expect((TYPE as Record<string, number>).noextern).toBe(0x72);
+    expect((TYPE as Record<string, number>).nofunc).toBe(0x73);
+  });
+
+  it("none no longer collides with any (the original defect)", () => {
+    expect(TYPE.none).not.toBe(TYPE.any);
+    expect(TYPE.any).toBe(0x6e);
+  });
+
+  it("the abstract heap-type bytes match the spec table", () => {
+    expect(TYPE.any).toBe(0x6e);
+    expect(TYPE.eq).toBe(0x6d);
+    expect(TYPE.i31).toBe(0x6c);
+    expect(TYPE.struct_ht).toBe(0x6b);
+    expect(TYPE.array_ht).toBe(0x6a);
+    expect(TYPE.func).toBe(0x60); // heap-type form lives at 0x70; func type-def tag is 0x60
+  });
+});


### PR DESCRIPTION
Closes #1842.

## Defect

`TYPE.none` in `src/emit/opcodes.ts` was `0x6e` — the **same byte as
`TYPE.any`** — so any future WasmGC bottom-type emission would mis-encode
`none` as `any`. The bottom types `noextern`/`nofunc` were absent entirely.

Per the WasmGC abstract heap-type spec (single-byte forms): `none = 0x71`,
`noextern = 0x72`, `nofunc = 0x73`.

## Fix

Corrected `none` to `0x71` and added `noextern: 0x72` / `nofunc: 0x73`. The
bytes were free within the `TYPE` table (the same values appear in the
unrelated OP / SIMD opcode tables — different namespaces). `TYPE.none` has no
current emitter use site (latent), so there is no behavior change today — this
removes the landmine for future bottom-type emission.

## Tests

`tests/issue-1842.test.ts` (3, all pass):
- `none/noextern/nofunc` use the spec bottom-type bytes;
- `none` no longer collides with `any` (the original defect);
- the abstract heap-type table matches the spec
  (`any=0x6e, eq=0x6d, i31=0x6c, struct=0x6b, array=0x6a`; `funcref=0x70`
  distinct from the `func` type-def tag `0x60`).

`tests/object-file.test.ts` (12) green — no emit regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)