### PR TITLE
fix(#1831): preserve omitted descriptor attributes on partial redefine (store)

### DIFF
--- a/plan/issues/1831-validate-property-descriptor-resets-omitted.md
+++ b/plan/issues/1831-validate-property-descriptor-resets-omitted.md
@@ -33,3 +33,33 @@ Scope: the WasmGC-struct sidecar fallback.
 When `existing !== undefined`, start from `existing` and only overwrite flags whose
 descriptor field is explicitly present (`desc.writable !== undefined`, etc.).
 
+## Progress (2026-06-04, dev-w1) — store fixed; readback is a separate slice
+
+Fixed `_validatePropertyDescriptor` (`src/runtime.ts`) per §10.1.6.3: `newFlags`
+now seeds from the existing descriptor and overwrites only the
+explicitly-present fields (data↔accessor kind included); on first definition,
+omitted attributes still default to false. A partial redefine like
+`Object.defineProperty(o,"k",{value:5})` no longer clears a previously-set
+writable/enumerable/configurable in the **stored** sidecar descriptor.
+
+**Verified (no regression)**: value-update and first-definition-defaults pass;
+a non-enumerable property stays out of `Object.keys` across a partial redefine;
+all 37 tests across the #1629* / #1364a descriptor suites stay green.
+(`tests/object-define-property*.test.ts` fail only to *collect* — pre-existing
+missing `tests/helpers.js`, unrelated to this change, identical pristine vs
+fixed.)
+
+**Why status stays `ready` (partial):** the user-visible symptom
+(`Object.getOwnPropertyDescriptor(o,"k").enumerable` reading back the preserved
+flag on a **plain object literal**) is NOT resolved by the store fix alone — on
+these receivers the descriptor *readback* goes through a separate path that does
+not consult the sidecar flag store (a #1629-family enumeration/readback gap;
+same shape as #1828/#1830 where the runtime-sidecar fix sits under an
+unreachable readback path). The store fix here is the correct, no-regression
+prerequisite; the readback wiring (route `getOwnPropertyDescriptor` /
+enumeration on plain-object-literal receivers through `_wasmPropDescs`) is a
+follow-up slice for senior-dev/architect.
+
+Tests: `tests/issue-1831-redefine-descriptor-flags.test.ts` (3 — value update,
+non-enumerable-preserved-via-`Object.keys`, first-def-defaults).
+

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1259,17 +1259,41 @@ function _validatePropertyDescriptor(
   existingValue?: any,
 ): number {
   const existing = descs.get(_normalizeDescKey(prop));
-  // Compute new flags — for Object.defineProperty, unspecified attributes default to false
-  let newFlags = _SC_DEFINED;
-  if (desc.writable) newFlags |= _SC_WRITABLE;
-  if (desc.enumerable) newFlags |= _SC_ENUMERABLE;
-  if (desc.configurable) newFlags |= _SC_CONFIGURABLE;
-  if (desc.get !== undefined || desc.set !== undefined) newFlags |= _SC_ACCESSOR;
+
+  // Compute new flags. ECMA-262 §10.1.6.3 ValidateAndApplyPropertyDescriptor:
+  // a *redefine* keeps every attribute the descriptor omits — only fields
+  // explicitly present in `desc` overwrite the existing descriptor (#1831).
+  // On first definition, omitted attributes default to false. The previous code
+  // rebuilt the flags purely from `desc` truthiness, so a partial redefine like
+  // `Object.defineProperty(o,"k",{value:5})` wrongly cleared a previously-set
+  // writable/enumerable/configurable.
+  let newFlags = existing === undefined ? _SC_DEFINED : existing | _SC_DEFINED;
+  // helper: set/clear `bit` when the descriptor field is present; on first
+  // definition, an omitted field defaults to false (cleared).
+  const applyFlag = (present: boolean, value: boolean | undefined, bit: number): void => {
+    if (present) {
+      newFlags = value ? newFlags | bit : newFlags & ~bit;
+    } else if (existing === undefined) {
+      newFlags &= ~bit;
+    }
+  };
+  applyFlag(desc.writable !== undefined, desc.writable, _SC_WRITABLE);
+  applyFlag(desc.enumerable !== undefined, desc.enumerable, _SC_ENUMERABLE);
+  applyFlag(desc.configurable !== undefined, desc.configurable, _SC_CONFIGURABLE);
+  // Data<->accessor kind: explicit get/set ⇒ accessor; explicit value/writable
+  // ⇒ data; otherwise keep the existing kind (or default data on first def).
+  if (desc.get !== undefined || desc.set !== undefined) {
+    newFlags |= _SC_ACCESSOR;
+  } else if (desc.value !== undefined || desc.writable !== undefined) {
+    newFlags &= ~_SC_ACCESSOR;
+  } else if (existing === undefined) {
+    newFlags &= ~_SC_ACCESSOR;
+  }
 
   if (existing === undefined) return newFlags; // First definition
 
   const isConfigurable = !!(existing & _SC_CONFIGURABLE);
-  if (isConfigurable) return newFlags; // Configurable — any change OK
+  if (isConfigurable) return newFlags; // Configurable — change OK (omitted fields preserved above)
 
   // Non-configurable: validate constraints (ES spec 9.1.6.3 step 7)
   if (desc.configurable === true) {

--- a/tests/issue-1831-redefine-descriptor-flags.test.ts
+++ b/tests/issue-1831-redefine-descriptor-flags.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1831 — `_validatePropertyDescriptor` (the WasmGC-struct sidecar fallback)
+ * rebuilt the stored attribute flags purely from `desc` truthiness, so a
+ * *partial* redefine like `Object.defineProperty(o,"k",{value:5})` cleared a
+ * previously-set writable/enumerable/configurable.
+ *
+ * ECMA-262 §10.1.6.3 ValidateAndApplyPropertyDescriptor: a redefine keeps every
+ * attribute the descriptor omits; only fields explicitly present overwrite the
+ * existing descriptor. On first definition, omitted attributes default to false.
+ *
+ * The fix seeds the flags from the existing descriptor and overwrites only
+ * explicitly-present fields. These cases assert the observable, reachable
+ * behaviour: a partial value-only redefine keeps the value and does not crash;
+ * a first definition still defaults omitted attributes to false; a non-
+ * enumerable property stays out of `Object.keys` across a partial redefine.
+ *
+ * NOTE: `Object.getOwnPropertyDescriptor` readback of these sidecar flags on a
+ * *plain object literal* goes through a separate path that does not yet consult
+ * the descriptor store (a #1629-family enumeration/readback gap), so the
+ * descriptor-attribute readback itself is not asserted here.
+ */
+
+async function run(source: string): Promise<number> {
+  const r = await compile(source, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#1831 partial redefine preserves omitted descriptor attributes", () => {
+  it("partial value-only redefine updates the value", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "k", { value: 1, enumerable: true, writable: true, configurable: true });
+          Object.defineProperty(o, "k", { value: 5 });
+          return o.k as number;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("a non-enumerable property stays out of Object.keys across a partial redefine", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "k", { value: 1, enumerable: false, configurable: true });
+          Object.defineProperty(o, "k", { value: 5 }); // partial — must keep enumerable:false
+          return Object.keys(o).length;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("first definition with omitted attributes does not crash and keeps the value", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "k", { value: 7 });
+          return o.k as number;
+        }
+      `),
+    ).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

`_validatePropertyDescriptor` (WasmGC-struct sidecar fallback, `src/runtime.ts`) rebuilt the stored attribute flags purely from `desc` truthiness, so a *partial* redefine like `Object.defineProperty(o,"k",{value:5})` cleared a previously-set writable/enumerable/configurable. ECMA-262 §10.1.6.3: a redefine keeps every attribute the descriptor omits.

## Fix

`newFlags` now seeds from the existing descriptor and overwrites only the explicitly-present fields (data↔accessor kind included). First definition still defaults omitted attributes to false.

## Verification

No regression: all 37 tests across the #1629* / #1364a descriptor suites stay green. `tests/issue-1831-redefine-descriptor-flags.test.ts` (3): value-update, non-enumerable-preserved-across-partial-redefine (via `Object.keys`), first-def-defaults. (`tests/object-define-property*.test.ts` fail only to *collect* — pre-existing missing `tests/helpers.js`, identical pristine vs fixed.)

## Scope — issue stays `ready` (partial)

This fixes the descriptor **store**. The user-visible symptom (`Object.getOwnPropertyDescriptor(o,"k").enumerable` reading back the preserved flag on a **plain object literal**) needs the descriptor **readback** path too — on these receivers it goes through a separate path that doesn't consult the sidecar store (a #1629-family enumeration/readback gap; same shape as #1828/#1830). The readback wiring is a follow-up slice for senior-dev/architect; findings + the precise reroute are documented in the issue. **This PR is a handoff — does NOT set status:done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)