### PR TITLE
fix(#1841): element-section flag bitfield — handle all flag cases 0-7

### DIFF
--- a/plan/issues/1841-element-section-flag-bitfield.md
+++ b/plan/issues/1841-element-section-flag-bitfield.md
@@ -1,9 +1,10 @@
 ---
 id: 1841
 title: "Element-section flag bitfield: parser/emitter only handle active flag-0 (passive/declarative corrupt)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -28,4 +29,29 @@ WebAssembly binary — Element Section flag cases 0-7.
 ## Fix
 Switch on the exact flag value per the spec table; carry the flag through
 `ElementEntry` and re-emit the original mode.
+
+## Resolution
+- `parseElementSection` (`src/link/reader.ts`) now decodes the full 3-bit flags
+  field per the spec's 8-case table: explicit tableidx only for flags 2 & 6;
+  active offset-expr only for flags 0/2/4/6 (`null` for passive/declarative);
+  elemkind/reftype byte for every flag except 0 & 4; payload `funcidx*` (0-3)
+  vs `expr*` (4-7). Expr payloads are captured as raw bytes (each `expr`
+  scanned to its `0x0b`) so they re-emit verbatim. This removes the cursor
+  desync that previously corrupted every following section for any non-0 flag.
+- `ElementEntry` carries `flags`, `offsetExpr: Uint8Array | null`,
+  `elemCount`, `kindByte: number | null`, and `elemExprs: Uint8Array | null`.
+- `linker.ts` re-emits each segment with its **original** flags/mode (offset/
+  tableidx/kindbyte/payload conditioned on the flag bits) instead of forcing
+  active flag-0 — declarative `ref.func` declarations no longer become active
+  table inits.
+
+### Test Results
+- `tests/issue-1841.test.ts` (9, all pass): a roundtrip parse for each flag
+  case 0-7 asserts the cursor lands exactly at the end (no desync) and the
+  recovered fields (flags / tableidx / offset presence / kindByte / payload)
+  are correct, plus a mixed three-segment body (active + declarative + passive-
+  expr) parses without drift. A narrow `parseElementSegmentsForTest` export
+  drives the parser without needing a full object file.
+- `tests/object-file.test.ts` (12) green. (`linker-e2e.test.ts` is pre-broken
+  on main via an unrelated self-compile `WasmEncoder_i64` error.)
 

--- a/src/link/linker.ts
+++ b/src/link/linker.ts
@@ -17,6 +17,7 @@ import {
   SYMTAB_FUNCTION,
   SYMTAB_GLOBAL,
   SYMTAB_TABLE,
+  type ElementEntry,
   type MemoryEntry,
   type ParsedObject,
   type RelocEntry,
@@ -378,19 +379,27 @@ function emitLinked(
   }
 
   // ── Element section ───────────────────────────────────────────
-  const allElements: {
-    tableIdx: number;
-    offsetExpr: Uint8Array;
-    funcIndices: number[];
-  }[] = [];
+  // #1841 — preserve each segment's original flags/mode. Previously every
+  // segment was re-emitted as active flag-0, discarding passive/declarative
+  // modes (declarative `ref.func` declarations would have become active table
+  // inits) and dropping explicit tableidx / expr-payload variants.
+  const allElements: ElementEntry[] = [];
   for (let modIdx = 0; modIdx < parsed.length; modIdx++) {
     const obj = parsed[modIdx]!;
     const off = offsets[modIdx]!;
     for (const elem of obj.elements) {
       allElements.push({
+        flags: elem.flags,
         tableIdx: elem.tableIdx + off.tableOffset,
         offsetExpr: elem.offsetExpr,
+        // Only funcidx payloads are re-indexed; expr payloads (flags 4-7) keep
+        // their raw bytes (they reference funcs by `ref.func` inside the expr,
+        // which the existing relocation path does not rewrite here — preserved
+        // verbatim, matching the pre-#1841 behavior of never producing them).
         funcIndices: elem.funcIndices.map((i) => i + off.funcOffset),
+        elemCount: elem.elemCount,
+        kindByte: elem.kindByte,
+        elemExprs: elem.elemExprs,
       });
     }
   }
@@ -398,11 +407,33 @@ function emitLinked(
     enc.section(SECTION.element, (s) => {
       s.u32(allElements.length);
       for (const elem of allElements) {
-        s.byte(0x00); // active, table 0, funcref
-        s.bytes(elem.offsetExpr);
-        s.u32(elem.funcIndices.length);
-        for (const idx of elem.funcIndices) {
-          s.u32(idx);
+        const flags = elem.flags;
+        s.u32(flags);
+        // Per the spec flag table (see parseElementSection): explicit tableidx
+        // for flags 2 & 6; active offset-expr for flags 0,2,4,6; elemkind/
+        // reftype byte for every flag except 0 & 4; payload funcidx* (0-3) or
+        // expr* (4-7).
+        const hasExplicitTable = (flags & 0x02) !== 0 && (flags & 0x01) === 0;
+        const isActive = (flags & 0x01) === 0;
+        const usesExprs = (flags & 0x04) !== 0;
+        const hasKindByte = flags !== 0 && flags !== 4;
+        if (hasExplicitTable) {
+          s.u32(elem.tableIdx);
+        }
+        if (isActive && elem.offsetExpr) {
+          s.bytes(elem.offsetExpr);
+        }
+        if (hasKindByte && elem.kindByte !== null) {
+          s.byte(elem.kindByte);
+        }
+        if (usesExprs && elem.elemExprs) {
+          s.u32(elem.elemCount);
+          s.bytes(elem.elemExprs);
+        } else {
+          s.u32(elem.funcIndices.length);
+          for (const idx of elem.funcIndices) {
+            s.u32(idx);
+          }
         }
       }
     });

--- a/src/link/reader.ts
+++ b/src/link/reader.ts
@@ -73,9 +73,39 @@ export interface ExportEntry {
 }
 
 export interface ElementEntry {
+  /**
+   * Raw element-segment flags field (#1841 — the 3-bit value 0-7 per the
+   * WebAssembly spec, not just active flag-0). Determines the segment mode
+   * (active / passive / declarative), whether a tableidx + offset-expr are
+   * present, and whether the payload is funcidx* or expr*.
+   */
+  flags: number;
   tableIdx: number;
-  offsetExpr: Uint8Array;
+  /**
+   * Active-segment offset constant-expression bytes (terminated by 0x0b),
+   * present only for active modes (flags 0, 2, 4, 6). `null` for
+   * passive/declarative (flags 1, 3, 5, 7), which have no offset.
+   */
+  offsetExpr: Uint8Array | null;
+  /**
+   * For funcidx-payload segments (flags 0-3): the resolved function indices.
+   * Empty for expr-payload segments (flags 4-7), which keep their raw
+   * expression bytes in `elemExprs` instead.
+   */
   funcIndices: number[];
+  /** Number of elements in the segment (funcidx count or expr count). */
+  elemCount: number;
+  /**
+   * elemkind (flags 1-3) or reftype (flags 5-7) byte, when the segment
+   * carries one explicitly. `null` for flag 0/4 (funcref implied).
+   */
+  kindByte: number | null;
+  /**
+   * For expr-payload segments (flags 4-7): the raw element-expression bytes
+   * (the `vec(expr)` body, excluding the leading count). Re-emitted verbatim.
+   * `null` for funcidx-payload segments.
+   */
+  elemExprs: Uint8Array | null;
 }
 
 export interface TagEntry {
@@ -468,36 +498,94 @@ function parseExportSection(r: ByteReader, _end: number, obj: ParsedObject): voi
   }
 }
 
+/**
+ * #1841 — parse the Element Section honoring the full 3-bit flags field (0-7)
+ * per the WebAssembly spec, not just active flag-0. The flag bits are:
+ *   bit0 (0x01): passive-or-declarative (no active table+offset)
+ *   bit1 (0x02): explicit tableidx (active) / declarative selector (passive)
+ *   bit2 (0x04): payload is element-expressions (expr*) and carries a reftype,
+ *                rather than funcidx* (which carries an elemkind for flags 1-3)
+ *
+ * The eight cases, with the fields that follow the flags byte:
+ *   0: e:expr  y*:funcidx          (active, table 0, funcref)
+ *   1: et:elemkind  y*:funcidx     (passive)
+ *   2: x:tableidx e:expr et:elemkind y*:funcidx  (active, explicit table)
+ *   3: et:elemkind  y*:funcidx     (declarative)
+ *   4: e:expr  el*:expr            (active, table 0, funcref expressions)
+ *   5: et:reftype  el*:expr        (passive)
+ *   6: x:tableidx e:expr et:reftype el*:expr      (active, explicit table)
+ *   7: et:reftype  el*:expr        (declarative)
+ * Reading the wrong fields for a non-0 flag previously desynced the cursor and
+ * corrupted every following section.
+ */
 function parseElementSection(r: ByteReader, _end: number, obj: ParsedObject): void {
   const count = r.u32();
   for (let i = 0; i < count; i++) {
     const flags = r.u32();
-    // Simple case: active element with table 0, funcref
+    const hasExplicitTable = (flags & 0x02) !== 0 && (flags & 0x01) === 0; // active w/ tableidx (2, 6)
+    const isActive = (flags & 0x01) === 0; // 0, 2, 4, 6
+    const usesExprs = (flags & 0x04) !== 0; // 4, 5, 6, 7
+    // elemkind/reftype byte is present for every flag except 0 and 4 (the two
+    // "active, table 0, funcref-implied" cases).
+    const hasKindByte = flags !== 0 && flags !== 4;
+
     let tableIdx = 0;
-    if (flags & 0x02) {
+    if (hasExplicitTable) {
       tableIdx = r.u32();
     }
-    // Read offset expression
-    const offsetStart = r.pos;
-    while (r.byte() !== 0x0b) {
-      // scan for end
-    }
-    const offsetExpr = r.data.slice(offsetStart, r.pos);
 
-    if (flags & 0x03) {
-      // Element kind or type
-      if (flags & 0x01) {
-        r.byte(); // element kind or ref type
+    let offsetExpr: Uint8Array | null = null;
+    if (isActive) {
+      const offsetStart = r.pos;
+      while (r.byte() !== 0x0b) {
+        // scan to the terminating `end` (0x0b) of the offset const-expr
       }
+      offsetExpr = r.data.slice(offsetStart, r.pos);
+    }
+
+    let kindByte: number | null = null;
+    if (hasKindByte) {
+      kindByte = r.byte(); // elemkind (funcidx variants) or reftype (expr variants)
     }
 
     const elemCount = r.u32();
     const funcIndices: number[] = [];
-    for (let j = 0; j < elemCount; j++) {
-      funcIndices.push(r.u32());
+    let elemExprs: Uint8Array | null = null;
+    if (usesExprs) {
+      // Payload is `vec(expr)` — capture the raw expression bytes verbatim so
+      // they can be re-emitted unchanged. Each expr is terminated by 0x0b.
+      const exprStart = r.pos;
+      for (let j = 0; j < elemCount; j++) {
+        while (r.byte() !== 0x0b) {
+          // scan to this expression's terminating `end`
+        }
+      }
+      elemExprs = r.data.slice(exprStart, r.pos);
+    } else {
+      for (let j = 0; j < elemCount; j++) {
+        funcIndices.push(r.u32());
+      }
     }
-    obj.elements.push({ tableIdx, offsetExpr, funcIndices });
+
+    obj.elements.push({ flags, tableIdx, offsetExpr, funcIndices, elemCount, kindByte, elemExprs });
   }
+}
+
+/**
+ * #1841 test hook — parse a raw element-section body (the bytes that follow the
+ * section id + size, i.e. starting at the segment count) and return the parsed
+ * segments plus the final cursor position. The cursor MUST land exactly at the
+ * end of `bytes`; any drift means a flag case desynced the reader. Kept narrow
+ * so the internal `ByteReader` / `parseElementSection` stay unexported.
+ */
+export function parseElementSegmentsForTest(bytes: Uint8Array): {
+  elements: ElementEntry[];
+  finalPos: number;
+} {
+  const r = new ByteReader(bytes, 0);
+  const obj = { elements: [] as ElementEntry[] } as unknown as ParsedObject;
+  parseElementSection(r, bytes.length, obj);
+  return { elements: obj.elements, finalPos: r.pos };
 }
 
 function parseCodeSection(r: ByteReader, _end: number, obj: ParsedObject): void {

--- a/tests/issue-1841.test.ts
+++ b/tests/issue-1841.test.ts
@@ -1,0 +1,134 @@
+// #1841 — the element-section parser (src/link/reader.ts) must honor the full
+// 3-bit flags field (0-7), not just active flag-0. Previously `flags & 0x02`
+// consumed a bogus tableidx for declarative (flag 3), and the parser always
+// scanned for an offset-expr even for passive/declarative segments (which have
+// none) — desyncing the cursor and corrupting every following section.
+//
+// These tests build a raw element-section body for each flag case, parse it,
+// and assert (a) the cursor lands exactly at the end (no desync) and (b) the
+// fields are recovered correctly.
+import { describe, expect, it } from "vitest";
+import { parseElementSegmentsForTest } from "../src/link/reader.js";
+
+// A minimal active offset const-expr: `i32.const 0` `end` = 0x41 0x00 0x0b.
+const OFFSET_EXPR = [0x41, 0x00, 0x0b];
+// A minimal element expression: `ref.func 0` `end` = 0xd2 0x00 0x0b.
+const REF_FUNC_EXPR = [0xd2, 0x00, 0x0b];
+const FUNCREF = 0x70; // elemkind / reftype byte
+
+function body(...segments: number[][]): Uint8Array {
+  return new Uint8Array([segments.length, ...segments.flat()]);
+}
+
+describe("#1841 — element-section flag bitfield (cases 0-7)", () => {
+  it("flag 0: active, table 0, funcref, funcidx*", () => {
+    const seg = [0x00, ...OFFSET_EXPR, 0x02, 0x05, 0x07]; // 2 funcs: 5, 7
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length); // no desync
+    expect(elements).toHaveLength(1);
+    expect(elements[0]!.flags).toBe(0);
+    expect(elements[0]!.tableIdx).toBe(0);
+    expect(elements[0]!.offsetExpr).not.toBeNull();
+    expect(elements[0]!.funcIndices).toEqual([5, 7]);
+    expect(elements[0]!.kindByte).toBeNull();
+  });
+
+  it("flag 1: passive, elemkind, funcidx*", () => {
+    const seg = [0x01, FUNCREF, 0x01, 0x09]; // elemkind=0x00 actually funcidx-kind 0x00? use 0x00
+    // elemkind for funcidx segments is 0x00; use that to be spec-faithful.
+    const segFixed = [0x01, 0x00, 0x01, 0x09];
+    const bytes = body(segFixed);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(1);
+    expect(elements[0]!.offsetExpr).toBeNull(); // passive — no offset
+    expect(elements[0]!.kindByte).toBe(0x00);
+    expect(elements[0]!.funcIndices).toEqual([9]);
+    void seg;
+  });
+
+  it("flag 2: active, explicit tableidx, elemkind, funcidx*", () => {
+    const seg = [0x02, 0x03, ...OFFSET_EXPR, 0x00, 0x02, 0x01, 0x02]; // table 3, kind 0, funcs 1,2
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length); // the bug consumed a bogus tableidx for 3, desyncing
+    expect(elements[0]!.flags).toBe(2);
+    expect(elements[0]!.tableIdx).toBe(3);
+    expect(elements[0]!.offsetExpr).not.toBeNull();
+    expect(elements[0]!.kindByte).toBe(0x00);
+    expect(elements[0]!.funcIndices).toEqual([1, 2]);
+  });
+
+  it("flag 3: declarative, elemkind, funcidx* (no tableidx, no offset)", () => {
+    const seg = [0x03, 0x00, 0x01, 0x04]; // kind 0, func 4
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    // The old code did `flags & 0x02` → read a bogus tableidx, then scanned for a
+    // non-existent offset-expr → ran off the end. This asserts the fix.
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(3);
+    expect(elements[0]!.tableIdx).toBe(0); // no explicit table for declarative
+    expect(elements[0]!.offsetExpr).toBeNull();
+    expect(elements[0]!.kindByte).toBe(0x00);
+    expect(elements[0]!.funcIndices).toEqual([4]);
+  });
+
+  it("flag 4: active, table 0, funcref, expr*", () => {
+    const seg = [0x04, ...OFFSET_EXPR, 0x01, ...REF_FUNC_EXPR];
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(4);
+    expect(elements[0]!.offsetExpr).not.toBeNull();
+    expect(elements[0]!.kindByte).toBeNull(); // funcref implied for flag 4
+    expect(elements[0]!.elemCount).toBe(1);
+    expect(elements[0]!.elemExprs).not.toBeNull();
+    expect(elements[0]!.funcIndices).toEqual([]);
+  });
+
+  it("flag 5: passive, reftype, expr*", () => {
+    const seg = [0x05, FUNCREF, 0x01, ...REF_FUNC_EXPR];
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(5);
+    expect(elements[0]!.offsetExpr).toBeNull();
+    expect(elements[0]!.kindByte).toBe(FUNCREF);
+    expect(elements[0]!.elemExprs).not.toBeNull();
+  });
+
+  it("flag 6: active, explicit tableidx, reftype, expr*", () => {
+    const seg = [0x06, 0x02, ...OFFSET_EXPR, FUNCREF, 0x01, ...REF_FUNC_EXPR];
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(6);
+    expect(elements[0]!.tableIdx).toBe(2);
+    expect(elements[0]!.offsetExpr).not.toBeNull();
+    expect(elements[0]!.kindByte).toBe(FUNCREF);
+    expect(elements[0]!.elemExprs).not.toBeNull();
+  });
+
+  it("flag 7: declarative, reftype, expr*", () => {
+    const seg = [0x07, FUNCREF, 0x02, ...REF_FUNC_EXPR, ...REF_FUNC_EXPR];
+    const bytes = body(seg);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements[0]!.flags).toBe(7);
+    expect(elements[0]!.offsetExpr).toBeNull();
+    expect(elements[0]!.kindByte).toBe(FUNCREF);
+    expect(elements[0]!.elemCount).toBe(2);
+    expect(elements[0]!.elemExprs).not.toBeNull();
+  });
+
+  it("multiple mixed segments parse without cursor drift", () => {
+    const active = [0x00, ...OFFSET_EXPR, 0x01, 0x00];
+    const declarative = [0x03, 0x00, 0x01, 0x01];
+    const passiveExpr = [0x05, FUNCREF, 0x01, ...REF_FUNC_EXPR];
+    const bytes = body(active, declarative, passiveExpr);
+    const { elements, finalPos } = parseElementSegmentsForTest(bytes);
+    expect(finalPos).toBe(bytes.length);
+    expect(elements.map((e) => e.flags)).toEqual([0, 3, 5]);
+  });
+});


### PR DESCRIPTION
Closes #1841.

## Defects

`parseElementSection` (`src/link/reader.ts`) only handled active flag-0:
- it did `flags & 0x02` → consumed a bogus tableidx for declarative (flag 3);
- it **always** scanned for an offset-expr, but passive/declarative segments
  (flags 1, 3, 5, 7) have none → desynced the cursor and corrupted every
  following section.

`linker.ts` re-emitted every segment as active flag-0, discarding the original
mode (declarative `ref.func` declarations became active table inits) and the
explicit-tableidx / expr-payload variants.

Latent: only active flag-0 segments are fed to the linker today.

## Fix

The parser now decodes the full 3-bit flags field per the spec's 8-case table:
- explicit tableidx for flags **2 & 6**;
- active offset-expr for flags **0/2/4/6** (`null` for passive/declarative);
- elemkind/reftype byte for every flag **except 0 & 4** (funcref implied);
- payload `funcidx*` (flags 0-3) vs `expr*` (flags 4-7, captured as raw bytes,
  each `expr` scanned to its `0x0b`, re-emitted verbatim).

`ElementEntry` carries `flags`, `offsetExpr: Uint8Array | null`, `elemCount`,
`kindByte: number | null`, `elemExprs: Uint8Array | null`. The linker re-emits
each segment in its **original** mode, conditioning the fields on the flag bits.

## Tests

`tests/issue-1841.test.ts` (9, all pass): a roundtrip parse for each flag case
0-7 asserts the cursor lands exactly at the end (no desync) and the recovered
fields (flags / tableidx / offset presence / kindByte / payload) are correct,
plus a mixed three-segment body (active + declarative + passive-expr) parses
without drift. A narrow `parseElementSegmentsForTest` export drives the parser
without needing a full object file.

`tests/object-file.test.ts` (12) green. (`linker-e2e.test.ts` is pre-broken on
`main` via an unrelated self-compile `WasmEncoder_i64` error.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)