### PR TITLE
fix(#1832): recognise destructured-param names in new-fn-expr capture check

### DIFF
--- a/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
+++ b/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
@@ -26,3 +26,25 @@ patterns never match, so the name is added to `captures`.
 Use `collectBindingPatternNames`/`isOwnParamName` (already exported from
 closures.ts) instead of the identifier-only check.
 
+## Progress (2026-06-04, dev-w1) — capture-detection fixed; path has a broader gap
+
+Applied the documented fix: `new-super.ts:1084` now calls
+`isOwnParamName(funcExpr, name)` (from `src/codegen/closures.ts`, which already
+recurses through object/array binding patterns) instead of the identifier-only
+`p.name.text === name` check. A name bound by a destructured param is no longer
+mis-classified as a free variable and captured from an outer scope. Typechecks
+clean.
+
+**Why status stays `ready` (partial):** I could not build a passing behavioral
+repro. The whole `new (function (...) { this.X = ... })(args)` path
+(`compileNewFunctionExpression`) traps at runtime (`WebAssembly.Exception`)
+**even for a plain identifier param** (`new (function(a){this.r=a})(7)`) — on
+both pristine main and with this fix — so a separate constructor-invocation /
+`this`-assignment lowering gap in that path masks the capture-detection fix.
+The capture-detection change is the correct localized fix for the issue's
+stated root cause and cannot regress (it only *widens* what counts as an own
+param), but verifying the end-to-end symptom needs the broader
+`compileNewFunctionExpression` runtime path fixed first (senior-dev/architect
+sized). Same shape as #1828/#1830/#1831 this sprint: a correct localized
+runtime/codegen fix sitting under a broader unreachable path.
+

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -5,7 +5,12 @@ import type { FieldDef, Instr, ValType } from "../../ir/types.js";
  */
 import { isSymbolType } from "../../checker/type-mapper.js";
 import { forEachChild, ts } from "../../ts-api.js";
-import { collectReferencedIdentifiers, collectWrittenIdentifiers, emitFuncRefAsClosure } from "../closures.js";
+import {
+  collectReferencedIdentifiers,
+  collectWrittenIdentifiers,
+  emitFuncRefAsClosure,
+  isOwnParamName,
+} from "../closures.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
@@ -1081,8 +1086,12 @@ function compileNewFunctionExpression(
     const localIdx = fctx.localMap.get(name);
     if (localIdx === undefined) continue;
     if (ctx.funcMap.has(name)) continue;
-    const isOwnParam = funcExpr.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === name);
-    if (isOwnParam) continue;
+    // #1832 — `isOwnParamName` recognises names bound by a destructuring
+    // (object/array binding) parameter, not just identifier params. The old
+    // identifier-only check missed `function({a}){ return a }`, so a
+    // destructured param name was wrongly treated as a free variable and
+    // captured from an outer scope that also declared it.
+    if (isOwnParamName(funcExpr, name)) continue;
     if (name === "arguments") continue;
     const type =
       localIdx < fctx.params.length


### PR DESCRIPTION
## Problem

`compileNewFunctionExpression` (`src/codegen/expressions/new-super.ts:1084`) used an identifier-only own-param check (`p.name.text === name`), so a name bound by a destructured param (`function({a}){...}`) never matched and was wrongly treated as a free variable — captured from an outer scope that also declared `a`, shadowing the param.

## Fix

Use `isOwnParamName(funcExpr, name)` (already exported from `src/codegen/closures.ts`; recurses through object/array binding patterns) instead of the identifier-only check. Pure widening of the own-param test — typechecks clean, cannot regress.

## Scope — issue stays `ready` (partial / handoff)

I could not build a passing behavioral repro: the broader `new (function (...) { this.X = ... })(args)` path traps at runtime (`WebAssembly.Exception`) **even for a plain identifier param** — on both pristine main and with this fix — so a separate constructor-invocation / `this`-assignment lowering gap in `compileNewFunctionExpression` masks the capture-detection fix. This PR is the correct localized fix for the issue's stated root cause; the broader path needs senior-dev/architect work to verify end-to-end. **Handoff PR — does NOT set status:done.** Findings documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)