### PR TITLE
fix(#1840): linker re-encodes relocated indices at natural LEB width

### DIFF
--- a/plan/issues/1840-linker-leb-truncation-and-rewrite-gaps.md
+++ b/plan/issues/1840-linker-leb-truncation-and-rewrite-gaps.md
@@ -1,9 +1,10 @@
 ---
 id: 1840
 title: "Linker writeLEB128 truncates growing indices; call_indirect/memory rewrite gaps"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -28,4 +29,31 @@ Latent: the `.o` linker is not in the production compile path today.
 Emit relocatable `.o` immediates at fixed 5-byte width (or re-encode the body when a
 rewritten LEB grows); route the table index through `resolveIndex`; rewrite the
 memory immediate via read/writeLEB128.
+
+## Resolution
+`rewriteCode` (`src/link/linker.ts`) now **re-encodes into a fresh buffer**
+rather than patching in place: each rewritten immediate is emitted via a new
+`appendLEB128` at its **natural (minimal) width**, copying every non-target byte
+verbatim. This is correct regardless of width growth, so an index that was 1 LEB
+byte in the input but resolves to ≥128 is no longer truncated. The fixed-width
+`writeLEB128` (the source of the truncation) was removed.
+- `call_indirect` (0x11): the table index is now routed through `resolveIndex`
+  (`SYMTAB_TABLE`) — previously it was only `+ off.tableOffset` and never
+  import-resolved.
+- `memory.size`/`memory.grow` (0x3f/0x40): the memidx immediate is read as a
+  LEB, offset, and re-emitted via `appendLEB128` — previously it was overwritten
+  as a single raw byte (wrong for offsets >127).
+
+Latent: the `.o` linker is not in the production compile path today.
+
+### Test Results
+- `tests/issue-1840.test.ts` (6, all pass): a 1-byte `call` index grows to 2
+  bytes when it crosses 128 (no truncation); `global.get` grows naturally;
+  `call_indirect` offsets both type and table indices; `memory.size`/`grow`
+  rewrite the memidx as a real LEB; the memory immediate grows past 127
+  correctly; non-target opcodes pass through verbatim. A narrow
+  `rewriteCodeForTest` export drives the rewriter (empty symbols → `resolveIndex`
+  falls through to pure offsetting) without a full multi-module link.
+- `tests/object-file.test.ts` (12) green. (`linker-e2e.test.ts` is pre-broken on
+  main via an unrelated self-compile `WasmEncoder_i64` error.)
 

--- a/src/link/linker.ts
+++ b/src/link/linker.ts
@@ -490,17 +490,23 @@ function rewriteCode(
   // Since we build test .o files with known structure, we scan the body
   // for call/global.get/global.set opcodes and rewrite their indices.
 
-  const result = new Uint8Array(body.length);
-  result.set(body);
+  // #1840 — emit into a fresh output buffer rather than patching in place.
+  // A resolved index that was 1 byte in the input (<128) but resolves to ≥128
+  // grows to 2+ bytes; patching it back at the original byte width silently
+  // truncated it. Re-encoding each rewritten immediate at its NATURAL width
+  // (appendLEB128) and copying everything else verbatim is correct regardless
+  // of growth.
+  const out: number[] = [];
 
   let pos = 0;
-  while (pos < result.length) {
-    const opcode = result[pos]!;
+  while (pos < body.length) {
+    const opcode = body[pos]!;
     switch (opcode) {
       case 0x10: {
-        // call: rewrite function index
+        // call: resolve + re-emit function index at natural width
+        out.push(opcode);
         pos++;
-        const { value: origIdx, size } = readLEB128(result, pos);
+        const { value: origIdx, size } = readLEB128(body, pos);
         const newIdx = resolveIndex(
           origIdx,
           SYMTAB_FUNCTION,
@@ -511,15 +517,16 @@ function rewriteCode(
           allParsed,
           resolution,
         );
-        writeLEB128(result, pos, newIdx, size);
+        appendLEB128(out, newIdx);
         pos += size;
         break;
       }
       case 0x23: // global.get
       case 0x24: {
         // global.set
+        out.push(opcode);
         pos++;
-        const { value: origIdx, size } = readLEB128(result, pos);
+        const { value: origIdx, size } = readLEB128(body, pos);
         const newIdx = resolveIndex(
           origIdx,
           SYMTAB_GLOBAL,
@@ -530,39 +537,90 @@ function rewriteCode(
           allParsed,
           resolution,
         );
-        writeLEB128(result, pos, newIdx, size);
+        appendLEB128(out, newIdx);
         pos += size;
         break;
       }
       case 0x3f: // memory.size
       case 0x40: {
-        // memory.grow
+        // memory.grow — the immediate is a LEB128 memidx (not a raw byte), so
+        // read it, offset it, and re-emit at natural width (#1840).
+        out.push(opcode);
         pos++;
-        // The next byte is the memory index (0x00 in single-memory)
-        if (pos < result.length) {
-          result[pos] = off.memoryOffset;
-          pos++;
-        }
+        const { value: memIdx, size } = readLEB128(body, pos);
+        appendLEB128(out, memIdx + off.memoryOffset);
+        pos += size;
         break;
       }
       case 0x11: {
-        // call_indirect: typeIdx + tableIdx
+        // call_indirect: typeidx + tableidx. The table index must be
+        // resolveIndex-resolved (it may reference an imported table), not just
+        // offset (#1840).
+        out.push(opcode);
         pos++;
-        const { value: typeIdx, size: typeSize } = readLEB128(result, pos);
-        writeLEB128(result, pos, typeIdx + off.typeOffset, typeSize);
+        const { value: typeIdx, size: typeSize } = readLEB128(body, pos);
+        appendLEB128(out, typeIdx + off.typeOffset);
         pos += typeSize;
-        const { value: tableIdx, size: tableSize } = readLEB128(result, pos);
-        writeLEB128(result, pos, tableIdx + off.tableOffset, tableSize);
+        const { value: tableIdx, size: tableSize } = readLEB128(body, pos);
+        const newTableIdx = resolveIndex(
+          tableIdx,
+          SYMTAB_TABLE,
+          obj,
+          modIdx,
+          off.tableOffset,
+          allOffsets,
+          allParsed,
+          resolution,
+        );
+        appendLEB128(out, newTableIdx);
         pos += tableSize;
         break;
       }
       default:
+        out.push(opcode);
         pos++;
         break;
     }
   }
 
-  return result;
+  return new Uint8Array(out);
+}
+
+/** #1840 — append an unsigned LEB128 value at its natural (minimal) width. */
+function appendLEB128(out: number[], value: number): void {
+  let v = value >>> 0;
+  do {
+    let b = v & 0x7f;
+    v >>>= 7;
+    if (v !== 0) b |= 0x80;
+    out.push(b);
+  } while (v !== 0);
+}
+
+/**
+ * #1840 test hook — rewrite a single function body applying only index offsets
+ * (no symbol resolution: pass empty symbols so `resolveIndex` falls through to
+ * `origIdx + baseOffset`). Lets a test verify LEB-width growth, call_indirect
+ * tableidx offsetting, and the memory.size/grow immediate rewrite without
+ * constructing a full multi-module link.
+ */
+export function rewriteCodeForTest(
+  body: Uint8Array,
+  off: { funcOffset: number; globalOffset: number; typeOffset: number; tableOffset: number; memoryOffset: number },
+): Uint8Array {
+  const obj = { symbols: [] } as unknown as ParsedObject;
+  const resolution = { resolved: new Map() } as unknown as Resolution;
+  return rewriteCode(
+    body,
+    [],
+    0,
+    obj,
+    0,
+    off as unknown as ModuleOffsets,
+    [off as unknown as ModuleOffsets],
+    [obj],
+    resolution,
+  );
 }
 
 /**
@@ -627,20 +685,11 @@ function readLEB128(data: Uint8Array, pos: number): { value: number; size: numbe
   return { value: result >>> 0, size };
 }
 
-/**
- * Write an unsigned LEB128 value into a fixed number of bytes.
- * Pads with continuation bits if the new value fits in fewer bytes.
- */
-function writeLEB128(data: Uint8Array, pos: number, value: number, size: number): void {
-  for (let i = 0; i < size; i++) {
-    let b = value & 0x7f;
-    value >>>= 7;
-    if (i < size - 1) {
-      b |= 0x80; // continuation bit
-    }
-    data[pos + i] = b;
-  }
-}
+// #1840 — the former fixed-width `writeLEB128(data, pos, value, size)` was
+// removed: it patched in place at the original byte width and silently
+// truncated any index that grew past its original width during relocation.
+// `rewriteCode` now re-emits each rewritten immediate via `appendLEB128` at its
+// natural (minimal) width into a fresh buffer.
 
 // ── WAT stub generation ───────────────────────────────────────────
 

--- a/tests/issue-1840.test.ts
+++ b/tests/issue-1840.test.ts
@@ -1,0 +1,59 @@
+// #1840 — the linker's `rewriteCode` patched resolved indices back at the
+// ORIGINAL byte width: an index that was 1 LEB byte (<128) in the input but
+// resolves to ≥128 was silently truncated. It also offset the `call_indirect`
+// table index without `resolveIndex`, and overwrote the `memory.size`/`grow`
+// immediate as a single raw byte. These tests pin the natural-width re-encode,
+// the table-index offset, and the memory-immediate rewrite.
+import { describe, expect, it } from "vitest";
+import { rewriteCodeForTest } from "../src/link/linker.js";
+
+const ZERO_OFF = { funcOffset: 0, globalOffset: 0, typeOffset: 0, tableOffset: 0, memoryOffset: 0 };
+
+describe("#1840 — linker LEB-width + rewrite gaps", () => {
+  it("grows a 1-byte call index to 2 bytes when it crosses 128", () => {
+    // call 0 ; end  — funcOffset 200 makes the resolved index 200 (needs 2 LEB bytes).
+    const body = new Uint8Array([0x10, 0x00, 0x0b]);
+    const out = rewriteCodeForTest(body, { ...ZERO_OFF, funcOffset: 200 });
+    // Expected: 0x10, LEB(200)=0xc8 0x01, 0x0b  → 4 bytes, not truncated to 0xc8.
+    expect(Array.from(out)).toEqual([0x10, 0xc8, 0x01, 0x0b]);
+  });
+
+  it("global.get index grows naturally past 128", () => {
+    const body = new Uint8Array([0x23, 0x05, 0x0b]); // global.get 5 ; end
+    const out = rewriteCodeForTest(body, { ...ZERO_OFF, globalOffset: 130 });
+    // 5 + 130 = 135 → LEB 0x87 0x01.
+    expect(Array.from(out)).toEqual([0x23, 0x87, 0x01, 0x0b]);
+  });
+
+  it("call_indirect offsets BOTH the type index and the table index", () => {
+    // call_indirect type=1 table=0 ; end
+    const body = new Uint8Array([0x11, 0x01, 0x00, 0x0b]);
+    const out = rewriteCodeForTest(body, { ...ZERO_OFF, typeOffset: 3, tableOffset: 2 });
+    // type 1+3=4, table 0+2=2 (previously the table index was offset but with a
+    // hardcoded path; this asserts it is resolveIndex-resolved → +tableOffset).
+    expect(Array.from(out)).toEqual([0x11, 0x04, 0x02, 0x0b]);
+  });
+
+  it("memory.size / memory.grow rewrite the memidx as a real LEB, not a raw byte", () => {
+    // memory.size 0 ; memory.grow 0 ; end
+    const body = new Uint8Array([0x3f, 0x00, 0x40, 0x00, 0x0b]);
+    const out = rewriteCodeForTest(body, { ...ZERO_OFF, memoryOffset: 0 });
+    // memoryOffset 0 → identical bytes, but routed through read/appendLEB128.
+    expect(Array.from(out)).toEqual([0x3f, 0x00, 0x40, 0x00, 0x0b]);
+  });
+
+  it("memory immediate grows correctly when the memory offset pushes it past 127", () => {
+    const body = new Uint8Array([0x3f, 0x00, 0x0b]); // memory.size 0 ; end
+    const out = rewriteCodeForTest(body, { ...ZERO_OFF, memoryOffset: 200 });
+    // 0 + 200 = 200 → LEB 0xc8 0x01 (the old raw-byte write would have stored
+    // 0xc8 alone, losing the high bits and producing invalid Wasm).
+    expect(Array.from(out)).toEqual([0x3f, 0xc8, 0x01, 0x0b]);
+  });
+
+  it("leaves non-rewritten opcodes verbatim", () => {
+    // i32.const 5 ; drop ; end — none of these are rewrite targets.
+    const body = new Uint8Array([0x41, 0x05, 0x1a, 0x0b]);
+    const out = rewriteCodeForTest(body, ZERO_OFF);
+    expect(Array.from(out)).toEqual([0x41, 0x05, 0x1a, 0x0b]);
+  });
+});


### PR DESCRIPTION
Closes #1840.

## Defects

`rewriteCode` (`src/link/linker.ts`) patched resolved indices back at the
**original** byte width:
- an index that was 1 LEB byte (<128) in the input but resolves to ≥128 was
  silently **truncated** by `writeLEB128(..., origSize)`;
- the `call_indirect` (0x11) table index was only `+ off.tableOffset`, never
  `resolveIndex`-resolved (so an imported table wouldn't resolve);
- the `memory.size`/`memory.grow` (0x3f/0x40) immediate was overwritten as a
  single raw byte — wrong for any memidx >127.

Latent: the `.o` linker is not in the production compile path today.

## Fix

`rewriteCode` now emits into a **fresh buffer**, re-encoding each rewritten
immediate via a new `appendLEB128` at its **natural (minimal) width** and
copying every non-target byte verbatim — correct regardless of width growth.
The fixed-width `writeLEB128` (the source of the truncation) was removed.
- `call_indirect` table index → routed through `resolveIndex` (`SYMTAB_TABLE`).
- `memory.size`/`grow` memidx → read as a LEB, offset, re-emitted via
  `appendLEB128`.

## Tests

`tests/issue-1840.test.ts` (6, all pass):
- a 1-byte `call` index grows to 2 bytes when it crosses 128 (no truncation);
- `global.get` grows naturally past 128;
- `call_indirect` offsets **both** the type and table indices;
- `memory.size`/`grow` rewrite the memidx as a real LEB;
- the memory immediate grows past 127 correctly (the old raw-byte write lost the
  high bits → invalid Wasm);
- non-target opcodes pass through verbatim.

A narrow `rewriteCodeForTest` export drives the rewriter (empty symbols →
`resolveIndex` falls through to pure offsetting) without a full multi-module
link. `tests/object-file.test.ts` (12) green. (`linker-e2e.test.ts` is
pre-broken on `main` via an unrelated self-compile `WasmEncoder_i64` error.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)