### PR TITLE
fix(#1839): addStringImports late shift covers pendingInitBody/nativeStrHelpers/startFuncIdx

### DIFF
--- a/plan/issues/1839-add-string-imports-shift-omits-targets.md
+++ b/plan/issues/1839-add-string-imports-shift-omits-targets.md
@@ -1,9 +1,10 @@
 ---
 id: 1839
 title: "addStringImports late-index shift omits pendingInitBody / nativeStrHelpers / startFuncIdx"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -29,4 +30,31 @@ shift but, unlike the canonical `shiftLateImportIndices`
 ## Fix
 Replace the inline shift with a call to `shiftLateImportIndices` (single source of
 truth), or add the three missing shift targets.
+
+## Resolution
+Added the three missing shift targets to `addStringImports`'s inline shift in
+`src/codegen/index.ts`, matching `addUnionImports`:
+- `ctx.pendingInitBody` is now walked by `shiftFuncIndices` (after the
+  `liveBodies` walk) — when the first string usage is inside a function body,
+  the module-init body isn't reachable via `funcStack`/`liveBodies` yet, so its
+  `call`/`ref.func` indices were missed and `__module_init` called the wrong
+  functions.
+- `ctx.nativeStrHelpers` entries `>= importsBefore` move up by `delta` — this
+  map is read directly by string-lowering call sites and is not a copy of
+  `funcMap`, so it must be shifted on its own (was stale under plain
+  `--nativeStrings` JS-host mode).
+- `ctx.mod.startFuncIdx` moves if it was a defined function at/above the
+  insertion point.
+
+(Chose the targeted-addition approach over swapping to `shiftLateImportIndices`
+because that helper doesn't itself shift `startFuncIdx` and walks a broader body
+set — riskier given the in-flight #809 native-strings extraction on main.)
+
+### Test Results
+- `tests/issue-1839.test.ts` (3, all pass): module-init `call` resolves after a
+  late string-import shift triggered inside a function body (`moduleVal === 42`);
+  two module-init calls both stay correct; the string-concat function that
+  triggered the late import compiles + instantiates (helpers resolve to shifted
+  indices). All under `nativeStrings: true`.
+- End-to-end probe confirmed the wrong-function regression is gone.
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6199,6 +6199,14 @@ export function addStringImports(ctx: CodegenContext): void {
     for (const lb of ctx.liveBodies) {
       shiftFuncIndices(lb);
     }
+    // (#1839) The module-init body holds `call`/`ref.func` indices too. When
+    // the first string usage occurs inside a function body (not module-init),
+    // this body is NOT reachable via funcStack/liveBodies yet, so it would be
+    // missed and `__module_init` would call the wrong functions after the late
+    // string-import shift. Matches addUnionImports / shiftLateImportIndices.
+    if (ctx.pendingInitBody) {
+      shiftFuncIndices(ctx.pendingInitBody);
+    }
     for (const elem of ctx.mod.elements) {
       if (elem.funcIndices) {
         for (let i = 0; i < elem.funcIndices.length; i++) {
@@ -6216,6 +6224,21 @@ export function addStringImports(ctx: CodegenContext): void {
     for (const t of ctx.pendingMethodTrampolines) {
       if (t.methodFuncIdx >= importsBefore) t.methodFuncIdx += delta;
       if (t.trampolineFuncIdx >= importsBefore) t.trampolineFuncIdx += delta;
+    }
+    // (#1839) `nativeStrHelpers` is read directly by string-lowering call sites
+    // and helper emitters — it is NOT a copy of funcMap, so it must be shifted
+    // on its own. All entries are defined functions (>= numImportFuncs), so
+    // every entry >= importsBefore moves up by `delta`. Omitting this left the
+    // map stale under plain `--nativeStrings` JS-host mode.
+    for (const [name, idx] of ctx.nativeStrHelpers) {
+      if (idx >= importsBefore) {
+        ctx.nativeStrHelpers.set(name, idx + delta);
+      }
+    }
+    // (#1839) The module start function index also moves if it was a defined
+    // function at or above the insertion point. Matches addUnionImports.
+    if (ctx.mod.startFuncIdx !== undefined && ctx.mod.startFuncIdx >= importsBefore) {
+      ctx.mod.startFuncIdx += delta;
     }
   }
 }

--- a/tests/issue-1839.test.ts
+++ b/tests/issue-1839.test.ts
@@ -1,0 +1,67 @@
+// #1839 — addStringImports hand-rolled the late func-index shift but omitted
+// `ctx.pendingInitBody`, `ctx.nativeStrHelpers`, and `ctx.mod.startFuncIdx`
+// (unlike addUnionImports / shiftLateImportIndices).
+//
+// Symptom: when the first string usage occurs inside a FUNCTION body (not
+// module-init), the string imports are added late. The module-init body's
+// `call`/`ref.func` indices were not bumped, so `__module_init` called the
+// wrong functions. These end-to-end tests pin the corrected shift.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, fnName = "test"): Promise<number> {
+  const r = await compile(src, { fileName: "t.ts", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+  return (instance.exports[fnName] as () => number)();
+}
+
+describe("#1839 — late string-import shift keeps module-init + helpers correct", () => {
+  it("module-init call resolves after a late string-import shift triggered in a function body", async () => {
+    // helper() is called from module-init (initialising moduleVal). The FIRST
+    // string usage is inside greet() — this adds the string imports late, after
+    // module-init was already emitted. If pendingInitBody isn't shifted,
+    // __module_init calls the wrong function and moduleVal is corrupted.
+    const src = `
+      function helper(): number { return 42; }
+      export const moduleVal: number = helper();
+      export function greet(): string {
+        const a = "hello";
+        const b = "world";
+        return a + " " + b;
+      }
+      export function test(): number { return moduleVal; }
+    `;
+    expect(await run(src)).toBe(42);
+  });
+
+  it("two module-init calls both stay correct across the late shift", async () => {
+    const src = `
+      function a(): number { return 10; }
+      function b(): number { return 20; }
+      export const x: number = a();
+      export const y: number = b();
+      export function s(): string { return "z" + "z"; }
+      export function test(): number { return x + y; }
+    `;
+    expect(await run(src)).toBe(30);
+  });
+
+  it("string concat itself still works in the function that triggered the late import", async () => {
+    // The string helpers (nativeStrHelpers) must resolve to the shifted indices
+    // — if left stale, the concat would call the wrong function and trap or
+    // produce a wrong-typed result. We exercise the function purely for
+    // successful compile + instantiation (asserted in run()).
+    const src = `
+      function side(): number { return 7; }
+      export const m: number = side();
+      export function cat(): string {
+        const parts = "a" + "b" + "c";
+        return parts;
+      }
+      export function test(): number { return m; }
+    `;
+    expect(await run(src)).toBe(7);
+  });
+});


### PR DESCRIPTION
Closes #1839.

## Symptom

When the first string usage occurs inside a **function body** (not module-init),
the string imports are added late. `addStringImports` (`src/codegen/index.ts`)
hand-rolled the func-index shift but — unlike `addUnionImports` /
`shiftLateImportIndices` — omitted three targets:
- `ctx.pendingInitBody`: the module-init body's `call`/`ref.func` indices were
  not bumped, so `__module_init` called the **wrong functions**;
- `ctx.nativeStrHelpers`: left stale, biting plain `--nativeStrings` JS-host mode;
- `ctx.mod.startFuncIdx`.

## Fix

Added the three missing shift targets to the inline shift, matching
`addUnionImports`:
- `pendingInitBody` walked by `shiftFuncIndices` (after the `liveBodies` walk);
- every `nativeStrHelpers` entry `>= importsBefore` moves up by `delta` (it's
  read directly by string-lowering call sites, not a copy of `funcMap`);
- `startFuncIdx` moves if it was a defined function at/above the insertion point.

Chose the targeted-addition approach over swapping to `shiftLateImportIndices`
because that helper doesn't itself shift `startFuncIdx` and walks a broader body
set — riskier given the in-flight #809 native-strings extraction on main.

## Tests

`tests/issue-1839.test.ts` (3, all pass, under `nativeStrings: true`):
- module-init `call` resolves after a late shift triggered inside a function
  body (`moduleVal === 42` — the headline regression);
- two module-init calls both stay correct (`x + y === 30`);
- the string-concat function that triggered the late import compiles +
  instantiates (helpers resolve to the shifted indices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)