### PR TITLE
fix(#1821): delete struct fast-path returns spec result; element-arm mirrors sidecar

### DIFF
--- a/plan/issues/1821-delete-always-true-and-element-skips-sidecar.md
+++ b/plan/issues/1821-delete-always-true-and-element-skips-sidecar.md
@@ -1,9 +1,10 @@
 ---
 id: 1821
 title: "delete obj.prop always returns true; delete obj['k'] skips __delete_property sidecar"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: medium
 feasibility: medium
 task_type: bugfix

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -148,8 +148,12 @@ export function compileDeleteExpression(
           fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
 
           // (b) Sidecar / descriptor-map cleanup. Push receiver as externref +
-          // key as externref, then call __delete_property and drop its result —
-          // we always report `true` from the static struct-field path.
+          // key as externref, then call __delete_property and RETURN its result
+          // (#1821). The helper reports `false` (0) for a non-configurable
+          // descriptor entry (ECMA-262 §13.5.1 step 5) and `true` (1) otherwise
+          // — including a plain struct field with no descriptor (deletable).
+          // The previous code dropped the result and hardcoded `true`, so
+          // `delete obj.nonConfigurable` wrongly returned `true`.
           fctx.body.push({ op: "local.get", index: recvLocal });
           if (recvType.kind === "ref" || recvType.kind === "ref_null") {
             fctx.body.push({ op: "extern.convert_any" } as Instr);
@@ -171,11 +175,14 @@ export function compileDeleteExpression(
             flushLateImportShifts(ctx, fctx);
             if (delIdx !== undefined) {
               fctx.body.push({ op: "call", funcIdx: delIdx });
-              fctx.body.push({ op: "drop" });
-            } else {
-              fctx.body.push({ op: "drop" });
-              fctx.body.push({ op: "drop" });
+              // Leave __delete_property's i32 result on the stack as the
+              // `delete` expression value (spec-correct configurability check).
+              return { kind: "i32" };
             }
+            // No host import (standalone): drop receiver + key; struct.set
+            // already cleared the field, so report `true`.
+            fctx.body.push({ op: "drop" });
+            fctx.body.push({ op: "drop" });
           } else {
             // String literal failed (shouldn't happen for a static field name);
             // discard the receiver/key and continue.
@@ -203,9 +210,53 @@ export function compileDeleteExpression(
         const fieldIdx = fields.findIndex((f) => f.name === fieldName);
         if (fieldIdx !== -1 && fields[fieldIdx]!.mutable) {
           const fieldType = fields[fieldIdx]!.type;
-          compileExpression(ctx, fctx, inner.expression);
+          // (#1821) Mirror the property-access arm above: clear the struct
+          // field AND the sidecar/descriptor entry, then return
+          // __delete_property's result. The previous element-access arm only
+          // did the struct.set + hardcoded `true`, so `delete obj["x"]`
+          // diverged from `delete obj.x` — it left the `Object.defineProperty`
+          // descriptor in place (`hasOwnProperty("x")` stayed true) and
+          // reported `true` even for a non-configurable property.
+          const recvType = compileExpression(ctx, fctx, inner.expression);
+          if (!recvType) {
+            fctx.body.push({ op: "i32.const", value: 1 });
+            return { kind: "i32" };
+          }
+          const recvLocal = allocLocal(fctx, `__del_recv_${fctx.locals.length}`, recvType);
+          fctx.body.push({ op: "local.set", index: recvLocal });
+
+          // (a) struct.set with sentinel — restores the field to undefined.
+          fctx.body.push({ op: "local.get", index: recvLocal });
           emitDeleteSentinel(fctx, fieldType);
           fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
+
+          // (b) sidecar / descriptor-map cleanup, returning the helper result.
+          fctx.body.push({ op: "local.get", index: recvLocal });
+          if (recvType.kind === "ref" || recvType.kind === "ref_null") {
+            fctx.body.push({ op: "extern.convert_any" } as Instr);
+          } else if (recvType.kind !== "externref") {
+            fctx.body.push({ op: "drop" });
+            fctx.body.push({ op: "i32.const", value: 1 });
+            return { kind: "i32" };
+          }
+          const keyResult = compileStringLiteral(ctx, fctx, fieldName, inner.argumentExpression);
+          if (keyResult) {
+            const delIdx = ensureLateImport(
+              ctx,
+              "__delete_property",
+              [{ kind: "externref" }, { kind: "externref" }],
+              [{ kind: "i32" }],
+            );
+            flushLateImportShifts(ctx, fctx);
+            if (delIdx !== undefined) {
+              fctx.body.push({ op: "call", funcIdx: delIdx });
+              return { kind: "i32" };
+            }
+            fctx.body.push({ op: "drop" });
+            fctx.body.push({ op: "drop" });
+          } else {
+            fctx.body.push({ op: "drop" });
+          }
           fctx.body.push({ op: "i32.const", value: 1 });
           return { kind: "i32" };
         }

--- a/tests/issue-1821-delete-struct-fastpath.test.ts
+++ b/tests/issue-1821-delete-struct-fastpath.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1821 — `delete` struct fast-path defects (ECMAScript §13.5.1):
+ *  1. `delete obj.nonConfigurable` returned `true` (the property-access arm
+ *     dropped `__delete_property`'s result and hardcoded `i32.const 1`).
+ *  2. `delete obj["x"]` and `delete obj.x` diverged: the element-access arm
+ *     only did the struct.set sentinel and skipped the `__delete_property`
+ *     sidecar that the property-access arm performs (#1334), so the
+ *     `Object.defineProperty` descriptor survived and `hasOwnProperty("x")`
+ *     differed between the two forms.
+ *
+ * Fix: return `__delete_property`'s result from both arms (spec configurability
+ * result), and mirror the sidecar cleanup in the element-access arm.
+ */
+
+async function run(source: string): Promise<number> {
+  const r = await compile(source, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#1821 delete struct fast-path", () => {
+  it("delete of a plain (deletable) field returns true — dot and bracket", async () => {
+    expect(
+      await run(
+        `class C { x = 5; } export function test(): number { const o = new C(); return (delete (o as any).x) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+    expect(
+      await run(
+        `class C { x = 5; } export function test(): number { const o = new C(); return (delete (o as any)["x"]) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("delete of a non-configurable property returns false", async () => {
+    expect(
+      await run(`
+        class C { x = 5; }
+        export function test(): number {
+          const o: any = new C();
+          Object.defineProperty(o, "x", { configurable: false, value: 5 });
+          return (delete o.x) ? 1 : 0;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("delete obj['x'] removes the descriptor sidecar like delete obj.x (parity)", async () => {
+    const bracket = `
+      class C { x = 5; }
+      export function test(): number {
+        const o: any = new C();
+        Object.defineProperty(o, "x", { configurable: true, value: 5, enumerable: true });
+        delete o["x"];
+        return o.hasOwnProperty("x") ? 1 : 0;
+      }`;
+    const dot = bracket.replace('delete o["x"]', "delete o.x");
+    expect(await run(bracket), "bracket form leaves descriptor").toBe(0);
+    expect(await run(dot), "dot form leaves descriptor").toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem (ECMAScript §13.5.1)

`src/codegen/typeof-delete.ts`:
1. The **property-access** delete arm dropped `__delete_property`'s result and hardcoded `i32.const 1`, so `delete obj.nonConfigurable` wrongly returned `true`.
2. The **element-access** arm omitted the `__delete_property` sidecar the property-access arm performs (#1334), so `delete obj["x"]` left the `Object.defineProperty` descriptor in place and diverged from `delete obj.x` (`hasOwnProperty("x")` differed).

## Fix

Both arms now: save the receiver → `struct.set` sentinel → call `__delete_property` → **return its i32 result** (configurability-correct). A plain deletable field still returns `true` (the helper returns 1 when there's no non-configurable descriptor); standalone (no host import) falls back to `true` after the struct.set.

## Verification

`tests/issue-1821-delete-struct-fastpath.test.ts` (3): plain delete dot/bracket → `true`; non-configurable → `false`; dot/bracket parity on descriptor removal (`hasOwnProperty` false after both). No regression — `issue-1364b` delete suite green. (`tests/delete-operator.test.ts` fails only to *collect* — pre-existing missing `tests/helpers.js`, unrelated.)

Sets issue frontmatter `status: done` + `completed: 2026-06-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)