### PR TITLE
fix(#1838): raise compile error for try/catch in linear backend

### DIFF
--- a/plan/issues/1838-linear-backend-trycatch-miscompile.md
+++ b/plan/issues/1838-linear-backend-trycatch-miscompile.md
@@ -1,9 +1,10 @@
 ---
 id: 1838
 title: "Linear backend silently miscompiles try/catch (throw -> unreachable, catch dropped)"
-status: ready
+status: done
 created: 2026-06-04
 updated: 2026-06-04
+completed: 2026-06-04
 priority: medium
 feasibility: medium
 task_type: bugfix
@@ -26,4 +27,28 @@ clause; `:682-685` lowers `throw` to `unreachable`. The emitter supports EH
 ## Fix
 Emit the EH `try`/`catch` instructions, or raise a compile error for `try/catch` in
 standalone mode rather than silently miscompiling.
+
+## Resolution
+Took the safety option (raise a compile error) — full Wasm-EH lowering through
+the linear backend is a larger feature deferred to a follow-up. In
+`src/codegen-linear/index.ts`, the `try` statement handler now:
+- **throws** a `try/catch is not yet supported by the linear/standalone
+  backend …` Error when the statement has a `catchClause`. (Throws rather than
+  `ctx.errors.push` because the linear backend's `ctx.errors` are NOT surfaced
+  into the compile result — a push would still silently miscompile. The
+  `compiler.ts` try/catch around `generateLinearM(ulti)Module` converts the
+  thrown Error into a `Codegen error:` failed result with `success: false`.)
+- **inlines `try { ... } finally { ... }`** (no `catchClause`) as before — there
+  is no handler to drop, and the `finally` block always runs, so inlining both
+  blocks is correct.
+
+The bare `throw → unreachable` lowering is left as-is: a `throw` with no
+enclosing handler traps, which matches the documented MVP limitation; the
+critical defect was the **silently dropped catch handler**.
+
+### Test Results
+- `tests/issue-1838.test.ts` (4, all pass): try/catch → compile error (not a
+  silent miscompile); try/catch/finally → compile error; try/finally → compiles
+  and runs both blocks (`x === 6`); the default WasmGC backend (which has real
+  EH) still compiles try/catch normally (scope guard).
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -667,12 +667,36 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
     // switch (expr) { case ...: ... }
     compileSwitchStatement(ctx, fctx, stmt);
   } else if (ts.isTryStatement(stmt)) {
-    // Compile try body inline (wasm has no exception handling in MVP).
-    // The catch clause is skipped — wasm traps are not catchable.
-    for (const s of stmt.tryBlock.statements) {
-      compileStatement(ctx, fctx, s);
+    // #1838 — the linear backend does not yet lower JS exception handling. The
+    // previous behaviour silently inlined the try body and DISCARDED the catch
+    // clause, so `try { throw e } catch (e) { handler }` ran the (unreachable)
+    // throw and never the handler — a silent divergence from JS with no
+    // diagnostic. Until the EH `try`/`catch` lowering (the emitter supports it,
+    // src/emit/binary.ts) is wired through this backend, raise a clear compile
+    // error rather than miscompile. A try with no catch (try/finally) is still
+    // safe to inline: the finally always runs and there is no handler to drop.
+    if (stmt.catchClause) {
+      // Throw rather than push to ctx.errors: the linear backend's ctx.errors
+      // are not surfaced into the compile result, so a push would still
+      // silently miscompile. The compiler.ts try/catch around
+      // generateLinearM(ulti)Module converts a thrown Error into a
+      // `Codegen error:` failed result, which is what we want.
+      throw new Error(
+        "try/catch is not yet supported by the linear/standalone backend — emitting it " +
+          "would silently drop the catch handler (#1838). A Wasm-EH try/catch lowering is " +
+          "the planned fix; a bare `try { ... }` with only `finally` is supported.",
+      );
+    } else {
+      // try { ... } finally { ... } — no handler to lose; inline both blocks.
+      for (const s of stmt.tryBlock.statements) {
+        compileStatement(ctx, fctx, s);
+      }
+      if (stmt.finallyBlock) {
+        for (const s of stmt.finallyBlock.statements) {
+          compileStatement(ctx, fctx, s);
+        }
+      }
     }
-    // Skip catch clause — it would only fire on JS exceptions
   } else if (ts.isExpressionStatement(stmt)) {
     compileExpression(ctx, fctx, stmt.expression);
     // Only drop if the expression produces a value

--- a/tests/issue-1838.test.ts
+++ b/tests/issue-1838.test.ts
@@ -1,0 +1,48 @@
+// #1838 — the linear/standalone backend silently miscompiled try/catch: it
+// inlined the try body and DISCARDED the catch clause, so
+// `try { throw e } catch (e) { handler }` ran the (unreachable) throw and never
+// the handler — silent divergence from JS with no diagnostic.
+//
+// Until a Wasm-EH try/catch lowering lands, the backend now raises a clear
+// compile error for try/catch instead of miscompiling. A try/finally (no
+// catch handler to lose) still compiles and inlines both blocks.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#1838 — linear backend try/catch", () => {
+  it("raises a compile error for try/catch instead of silently dropping the handler", async () => {
+    const src = `export function test(): number { try { return 1; } catch (e) { return 2; } }`;
+    const r = await compile(src, { fileName: "t.ts", target: "linear" });
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => /try\/catch is not yet supported by the linear/.test(e.message))).toBe(true);
+  });
+
+  it("raises a compile error for try/catch/finally too", async () => {
+    const src = `export function test(): number { try { return 1; } catch (e) { return 2; } finally { } }`;
+    const r = await compile(src, { fileName: "t.ts", target: "linear" });
+    expect(r.success).toBe(false);
+  });
+
+  it("still compiles try/finally (no catch handler to lose) and runs both blocks", async () => {
+    const src = `
+      export function test(): number {
+        let x = 0;
+        try { x = 5; } finally { x = x + 1; }
+        return x;
+      }
+    `;
+    const r = await compile(src, { fileName: "t.ts", target: "linear" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+    expect((instance.exports.test as () => number)()).toBe(6);
+  });
+
+  it("WasmGC (default) backend still compiles try/catch normally", async () => {
+    // Guard: the fix is scoped to the linear backend; the default WasmGC path
+    // (which has real EH) must be unaffected.
+    const src = `export function test(): number { try { return 1; } catch (e) { return 2; } }`;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The linear/standalone backend silently miscompiled `try/catch`: it inlined the try body and **discarded** the catch clause, so `try { throw e } catch (e) { handler }` ran the (unreachable) `throw` and never the handler — a silent divergence from JS with no diagnostic.

Until a full Wasm-EH `try/catch` lowering lands, the `try` statement handler now:
- **throws** a `try/catch is not yet supported by the linear/standalone backend …` Error when the statement has a `catchClause`. (Throws rather than `ctx.errors.push` because the linear backend's `ctx.errors` are NOT surfaced into the compile result; `compiler.ts`'s catch around `generateLinearM(ulti)Module` converts the thrown Error into a `Codegen error:` failed result with `success: false`.)
- **inlines `try/finally`** (no `catchClause`) as before — no handler to drop, and the `finally` block always runs.

The bare `throw → unreachable` lowering is left as-is (a `throw` with no enclosing handler traps, matching the documented MVP limitation).

## Tests
`tests/issue-1838.test.ts` (4, all pass):
- try/catch → compile error (not a silent miscompile)
- try/catch/finally → compile error
- try/finally → compiles and runs both blocks (`x === 6`)
- WasmGC (default) backend still compiles try/catch normally (scope guard)

Closes #1838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)