### PR TITLE
docs(#1320): architect spec for standalone iterator (GetIterator/Step/Close) bridge

### DIFF
--- a/plan/issues/1320-array-from-externref-iterator-bridge.md
+++ b/plan/issues/1320-array-from-externref-iterator-bridge.md
@@ -1,18 +1,18 @@
 ---
 id: 1320
 title: "Runtime bridge: Array.from(externref) / Iterator.from(externref) doesn't preserve own [Symbol.iterator] on plain JS objects (4 test262 fails)"
-status: in-review
+status: ready
 created: 2026-05-07
-updated: 2026-05-27
+updated: 2026-06-04
 priority: medium
 feasibility: medium
 reasoning_effort: medium
 task_type: bugfix
-area: runtime
+area: runtime+codegen
 language_feature: iterators, externref, Array.from
 goal: spec-conformance
-sprint: 50
-related: [1154]
+sprint: 59
+related: [1154, 1665, 1472, 1620, 1633, 1684]
 ---
 # #1320 — Array.from / Iterator.from runtime bridge drops own [Symbol.iterator]
 
@@ -203,3 +203,203 @@ structure that does materialize.
 (closure-return struct readback) — they cannot go green at the host-bridge
 layer. Status `in-review` for the partial PR; residual tracked in #1684 +
 the iterator-bridge family (#1620/#1633).
+
+## Architect Spec — standalone (no-JS-host) GetIterator / IteratorStep / IteratorClose bridge (2026-06-04)
+
+**Scope note.** The investigation above is the **JS-host** `Array.from` /
+`Iterator.from` bridge (in-review, gated on #1684). This section is the
+**orthogonal standalone (`--target wasi` / `nativeStrings`) iteration protocol**
+the host imports cannot cover — the lead's "generic GetIterator/IteratorStep/
+IteratorClose bridge for standalone." It is a distinct, dev-claimable deliverable
+(sprint 59) and does NOT depend on #1684 (that's a JS-host closure-return readback
+bug). Track it as sub-issue **#1320-standalone**.
+
+### Root cause (standalone gap)
+
+The iteration protocol is delivered by four **JS host imports** registered in
+`addIteratorImports` (`src/codegen/index.ts:8035-8067`):
+
+- `__iterator(externref) → externref` — `obj[Symbol.iterator]()`
+- `__iterator_next(externref) → (i32 done, externref value)` — multi-value
+  (#1620: a freshly-built `$IteratorResult` struct cannot survive the JS hop, so
+  the two primitives cross the ABI instead)
+- `__iterator_return(externref) → void` — IteratorClose
+- `__iterator_rest(externref) → externref` — drain remainder for `[...rest]`
+
+Under standalone/WASI there is no JS host, so any for-of / spread / array-dstr
+over a **non-Array iterable** (a generator, a class with `[Symbol.iterator]`, a
+Map/Set, a custom iterator) has no protocol. Today the compiler **errors out**:
+`array-methods.ts:3090-3098` (`compileArrayIteratorMethod`) reports
+`Codegen error: #681 standalone/WASI ... still requires JS-host iterator
+helpers`. Direct-array for-of works (index loop, no imports —
+`collectIteratorImports`/`index.ts:7993`), and native generators have their own
+state-machine drive (`generators-native.ts`), but the **generic object-iterable
+protocol** is host-only.
+
+This is the same dual-mode-completeness gap as #1665 (native generators, DONE)
+and #1472 (native open-object runtime, DONE) — both already established the
+WasmGC-native runtime patterns this bridge builds on.
+
+### Design: a native iteration protocol over compiled iterators
+
+The protocol consumer side already exists generically (for-of loop, spread,
+array-dstr all call `__iterator` / `__iterator_next` / `__iterator_return`).
+The fix is to make those four operations resolve to **Wasm-native helpers**
+when `ctx.standalone || ctx.wasi`, exactly mirroring the dual-mode funcMap
+pattern used by `__box_bigint` (#1644), native strings (#679), native RegExp
+(#682). The native helpers operate on the compiler's own iterator
+representations — they do NOT need a host because a standalone iterable is
+always one of a known set of compiled shapes:
+
+1. **A compiled class instance with a `[Symbol.iterator]` method** — the method
+   is a Wasm closure/method returning an iterator object (another compiled
+   struct with a `.next` method). Drive via `call_ref` (the mechanism
+   `_drainWasmClosureIterable` uses on the host side, but emitted as Wasm).
+2. **A native generator** — already has `__gen_resume_<g>` returning
+   `__NativeGeneratorResult_f64 {value:f64, done:i32}`
+   (`generators-native.ts:148-167`). The bridge's `IteratorStep` reads that
+   struct directly.
+3. **A native Map/Set iterator** (#1103) / **$ObjVec enumeration** (#1472
+   Blocker B) — already have entry-walking helpers; the bridge wraps them.
+4. **A `$Vec` array** — direct index loop (already host-free).
+
+### The native iterator-record representation
+
+Define one GC struct that unifies the four shapes behind a `next`-style
+interface, mirroring `__NativeGeneratorResult` but for the *iterator object*:
+
+```
+(type $IterRec (struct
+  (field $kind i32)          ;; 0=closure-iter, 1=native-gen, 2=map/set, 3=vec
+  (field $obj  (ref null any));; the underlying iterator object / gen state / vec
+  (field $idx  (mut i32))))   ;; cursor for vec/map shapes
+(type $IterResult (struct (field $value externref) (field $done i32)))
+```
+
+- `$IterResult` is the **internal** step result — value as externref (boxed via
+  `coerceType`), done as i32. It NEVER crosses a host boundary (standalone), so
+  the #1620 struct-survival problem does not apply here.
+
+### Changes
+
+**File: src/codegen/index.ts — `addIteratorImports` (`:8035`)**
+- Split into `addIteratorImports` (JS-host, unchanged) and a new
+  `ensureNativeIteratorRuntime(ctx)` that registers the four operations as
+  **Wasm functions** (`registerNative`, the pattern in `object-runtime.ts`):
+  `__iterator`, `__iterator_next`, `__iterator_return`, `__iterator_rest`.
+  Gate the choice at the single `collectIteratorImports` call site and at any
+  `addIteratorImports` caller: `if (ctx.standalone || ctx.wasi)
+  ensureNativeIteratorRuntime(ctx); else addIteratorImports(ctx);`. Because the
+  consumer code looks the operations up by the SAME funcMap names, no consumer
+  changes are needed — they transparently bind to native fns in standalone.
+
+**File: new src/codegen/iterator-native.ts (or fold into generators-native.ts)**
+- `getOrRegisterIterRecType(ctx)` / `getOrRegisterIterResultType(ctx)` — lazy GC
+  type registration (mirror `ensureNativeGeneratorResultType`,
+  `generators-native.ts:148`).
+- `__iterator(obj) → externref` native body — **GetIterator (§7.4.1)**:
+  - `ref.test` obj against native-generator state struct → wrap kind=1.
+  - `ref.test` against the class-instance struct types that have a
+    `[Symbol.iterator]` method → call that method via `call_ref`, wrap the
+    returned iterator object as kind=0.
+  - `ref.test` against Map/Set iterator / `$ObjVec` → kind=2.
+  - `ref.test` against `$Vec` → kind=3, idx=0.
+  - else → `__throw_type_error` ("not iterable", §7.4.1 step 5).
+  - Return the `$IterRec` (as externref via `extern.convert_any`).
+- `__iterator_next(iterRec) → (i32 done, externref value)` native body —
+  **IteratorStep + IteratorValue (§7.4.5/§7.4.6)**: switch on `$kind`:
+  - kind=1: `__gen_resume_<g>` → read `{value,done}`; box value f64→externref.
+  - kind=0: `call_ref` the iterator object's `.next` closure → read the result
+    object's `value`/`done` via the open-object getter (the #1472 native
+    `__extern_get_idx`/field read, NOT the host `_safeGet`).
+  - kind=2: advance the Map/Set/$ObjVec cursor, read entry.
+  - kind=3: `idx < $Vec.len` ? element + idx++ : done=1.
+  - Keep the multi-value `(i32, externref)` shape so the consumer code is
+    byte-identical to the host path.
+- `__iterator_return(iterRec) → void` — **IteratorClose (§7.4.8)**: for kind=0,
+  if the iterator object has a `.return` method (open-object getter lookup),
+  `call_ref` it; else no-op. kinds 1/2/3 have no user `return` → no-op.
+- `__iterator_rest(iterRec) → externref` — drain remaining into a fresh `$Vec`
+  by looping `__iterator_next` until done; reuse the `$ObjVec`→`$Vec`
+  materialization from #1472 Blocker B Slice 2.
+
+**File: src/codegen/array-methods.ts — `compileArrayIteratorMethod` (`:3090`)**
+- Replace the `reportError` standalone bailout with the native path: register
+  `ensureNativeIteratorRuntime(ctx)` and emit the native `entries`/`keys`/
+  `values` iterator-record over the `$Vec` (kind=3 with an index-pair shape for
+  `entries`). This is the concrete consumer that the error currently blocks.
+
+### Wasm IR pattern (IteratorStep for kind=0 closure-iterator)
+
+```wasm
+;; __iterator_next(iterRec) — kind=0 arm
+local.get $rec
+struct.get $IterRec $obj          ;; iterator object (ref any)
+ref.cast (ref $SomeIterStruct)
+;; load + call its .next closure (open-object getter or known method idx)
+... call_ref $next_funcTypeIdx ... ;; → result object (ref)
+local.tee $resObj
+;; done = resObj.done   (open-object i32/bool field read, #1472 native getter)
+... → i32 done
+local.get $resObj
+;; value = resObj.value (→ externref, boxed)
+... → externref value
+;; multi-value return (done, value)
+```
+
+### Edge cases
+
+- **Non-iterable** → TypeError at GetIterator (§7.4.1 step 5), via the native
+  `__throw_type_error` path (#1473, already standalone).
+- **IteratorClose on early exit** (for-of `break` / throw): the consumer already
+  calls `__iterator_return`; the native body must run the user `.return` for
+  kind=0 and swallow nothing (§7.4.8 — a throw from `.return` during a normal
+  close propagates; during an abrupt close the original completion wins). Flag
+  this completion-precedence subtlety for the dev — it's the one place the
+  native body must match §7.4.8 exactly.
+- **`.next` returns a non-object** → TypeError (§7.4.5 step 3) — `ref.test` the
+  result against the open-object/struct types; if it fails, throw.
+- **Generators interop**: kind=1 reuses the existing native-gen drive — do NOT
+  duplicate the state machine; just adapt its `{value,done}` struct to the
+  `(i32,externref)` multi-value shape.
+
+### Slice breakdown
+
+- **Slice 1 — native runtime skeleton + `$Vec`/native-gen kinds (3 & 1).**
+  `ensureNativeIteratorRuntime`, `$IterRec`/`$IterResult` types, GetIterator +
+  IteratorStep for the two host-free shapes already present (Vec index loop,
+  native generator). Unblocks standalone for-of/spread over arrays + generators
+  and removes the `array-methods.ts:3094` error for `entries`/`keys`/`values`.
+  ~180 LOC.
+- **Slice 2 — closure-iterator kind (0).** Class instances / objects with a
+  `[Symbol.iterator]` method driven via `call_ref` + open-object result
+  readback. The standalone analog of `_drainWasmClosureIterable`. ~150 LOC.
+- **Slice 3 — Map/Set/$ObjVec kind (2) + IteratorClose + rest.**
+  `__iterator_return` user-`.return` dispatch, `__iterator_rest` drain. ~120 LOC.
+- Slice 1 is load-bearing and independently shippable (clears the hard
+  standalone error + the array-iterator-method family). 2/3 widen coverage to
+  custom iterables and close.
+
+### Test files to verify (compile with `nativeStrings:true` / `--target wasi`)
+
+- `tests/issue-1320-standalone.test.ts`: standalone for-of over (a) array,
+  (b) generator, (c) class with `[Symbol.iterator]`, (d) Map; spread `[...gen]`;
+  array-dstr `const [a,b] = iterable`; early `break` runs `.return`.
+- test262 under `--target wasi`: `language/statements/for-of/*`,
+  `built-ins/Array/from/*`, `built-ins/Iterator/*` — confirm the standalone
+  error no longer fires and direct-iterable cases pass.
+
+### Risk / conflicts
+
+- No new host imports — all four operations become emitted Wasm fns in
+  standalone, satisfying the dual-mode rule. JS-host mode is untouched (it keeps
+  the existing imports). ✓
+- File overlap: `index.ts` (`addIteratorImports` split), `array-methods.ts`
+  (the `:3090` error site), new `iterator-native.ts`, and the native runtime
+  in `object-runtime.ts` / `generators-native.ts` it reuses. Coordinate with any
+  in-flight #1665/#1472 follow-ups in the merge queue.
+- Depends on (already-DONE): #1665 (native generator `{value,done}` struct),
+  #1472 Blocker B (native `$Vec` build/iterate, `__extern_get_idx` native arm),
+  #1473 (native throw). All merged — Slice 1 is unblocked now.
+- Does NOT depend on #1684 (that gates the JS-host `iter-cstm-ctor` case, a
+  different layer).


### PR DESCRIPTION
Adds the standalone iterator-protocol spec to #1320.

**Scope:** the issue's prior content is the **JS-host** `Array.from`/`Iterator.from` bridge (in-review, gated on #1684). This section is the orthogonal **standalone (`--target wasi`/`nativeStrings`)** iteration protocol — the lead's "generic GetIterator/IteratorStep/IteratorClose bridge for standalone." Distinct, dev-claimable, does NOT depend on #1684.

**Root cause:** the four protocol ops `__iterator`/`__iterator_next`/`__iterator_return`/`__iterator_rest` are `env` host imports (`index.ts:8035`). Standalone has no JS host, so for-of/spread/array-dstr over a non-Array iterable hard-errors (`array-methods.ts:3094`, "#681 still requires JS-host iterator helpers").

**Design:** dual-mode `ensureNativeIteratorRuntime(ctx)` binds the SAME funcMap names to emitted Wasm functions in standalone (consumer code unchanged — same pattern as `__box_bigint`/native strings/native RegExp). A `$IterRec`/`$IterResult` WasmGC representation unifies 4 compiled iterable shapes (closure-iterator / native-generator / map-set / vec), built on the already-DONE #1665 (native gen `{value,done}`), #1472 Blocker B (native `$Vec` iterate), #1473 (native throw).

3 slices (Slice 1 = Vec + native-gen, load-bearing, clears the hard error). Wasm IR pattern, dual-mode test plan, and the §7.4.8 IteratorClose completion-precedence subtlety flagged for the dev. No new host imports.

Docs-only. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)