### PR TITLE
fix(#1868): linear backend must fail compile, not emit invalid wasm

### DIFF
--- a/benchmarks/harness.ts
+++ b/benchmarks/harness.ts
@@ -183,11 +183,26 @@ async function runStrategy(def: BenchmarkDef, strategy: Strategy): Promise<Bench
     return null;
   }
 
-  // Timed runs
-  for (let i = 0; i < iterations; i++) {
-    const t0 = performance.now();
-    fn();
-    timings.push(performance.now() - t0);
+  // Timed runs.
+  //
+  // Guard the same way as warmup (#1868): a strategy can pass warmup yet trap
+  // mid-loop — e.g. the linear-memory backend's bump allocator exhausts memory
+  // after many `split`/concat iterations, surfacing as a `memory access out of
+  // bounds` RuntimeError. Whether that trap lands in warmup (caught) or in a
+  // later timed iteration is non-deterministic across V8 versions, so an
+  // unguarded timed loop made the whole benchmark suite abort fatally on CI
+  // (Node 26) while passing locally (Node 25). Catching it here downgrades a
+  // mid-run trap to a skipped strategy, matching warmup's behaviour.
+  try {
+    for (let i = 0; i < iterations; i++) {
+      const t0 = performance.now();
+      fn();
+      timings.push(performance.now() - t0);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`\n    [${strategy} skipped (runtime, mid-loop): ${msg.split("\n")[0]}]\n`);
+    return null;
   }
 
   timings.sort((a, b) => a - b);

--- a/plan/issues/1868-linear-backend-swallows-codegen-errors-invalid-wasm.md
+++ b/plan/issues/1868-linear-backend-swallows-codegen-errors-invalid-wasm.md
@@ -1,0 +1,102 @@
+---
+id: 1868
+title: "Linear backend swallows codegen errors → emits invalid wasm with success:true (Refresh Benchmarks CI crash)"
+status: done
+created: 2026-06-04
+updated: 2026-06-04
+completed: 2026-06-04
+priority: high
+feasibility: easy
+task_type: bugfix
+area: codegen-linear
+goal: correctness
+sprint: 59
+---
+# #1868 — linear backend emits structurally invalid wasm while reporting success
+
+## Symptom
+
+The `benchmark-refresh.yml` workflow (job step "Refresh benchmark artifacts",
+`pnpm run refresh:benchmarks`) failed on every push to `main` from ~12:14 on
+2026-06-04 onward (10+ consecutive commits). The first step,
+`benchmarks/run.ts`, crashed fatally on the `string/split` benchmark:
+
+```
+[parse exception: popping from empty stack (at 0:3158)] Fatal: error in parsing wasm binary
+RuntimeError: memory access out of bounds
+   at runStrategy (benchmarks/harness.ts:189)
+```
+
+Two distinct failure modes were tangled together:
+
+1. **Invalid wasm with `success: true`.** Several string/array benchmarks that
+   use `String.prototype.repeat` (`concat-long`, `indexOf`, `includes`,
+   `replace`, `case-convert`, …) compile in the **linear-memory** backend to a
+   binary that fails `WebAssembly.compile` —
+   `function #43:"run": not enough arguments on the stack for local.set (need 1,
+   got 0)`. Binaryen prints `[parse exception: popping from empty stack]` while
+   trying to optimize it.
+
+2. **Fatal runtime trap in the harness timed loop.** `string/split` lowers to
+   *valid* wasm but its linear-memory bump allocator exhausts memory after many
+   `csv.split(",")` iterations and traps with `memory access out of bounds`.
+   Whether that trap lands in the harness **warmup** loop (caught, strategy
+   skipped) or in the **timed** loop (`harness.ts:189`, NOT guarded) is
+   non-deterministic across V8 versions — so the suite passed locally on
+   Node 25 but aborted fatally on CI's Node 26.
+
+## Root cause
+
+`src/codegen-linear/index.ts` accumulates unsupported-construct diagnostics
+into `ctx.errors` (e.g. `compileMethodCall` pushes `Unsupported method call:
+.repeat()`), but it pushes **no value onto the Wasm stack** before returning.
+The following `local.set` / `local.tee` / `call` then underflows the stack —
+producing structurally invalid wasm.
+
+Crucially, `compiler.ts` **never read** those linear-backend errors. The
+WasmGC path returns `{ module, errors }` and bails with `success: false` on any
+`Codegen error:`; the linear path returned only a bare `WasmModule` and its
+`ctx.errors` were dropped on the floor. So `compile(...)` reported
+`success: true` with an invalid binary — the worst failure mode (a downstream
+consumer crashes instead of getting a clean compile error).
+
+The harness's **timed** loop (`benchmarks/harness.ts`) lacked the try/catch the
+**warmup** loop already had, so a mid-run runtime trap aborted the whole suite.
+
+## Fix
+
+- `src/ir/types.ts`: add optional `WasmModule.codegenErrors`.
+- `src/codegen-linear/index.ts`: both `generateLinearModule` and
+  `generateLinearMultiModule` surface `ctx.errors` via `mod.codegenErrors`.
+- `src/compiler.ts`: new `collectLinearCodegenErrors(mod, errors)` helper; all
+  three linear call sites now fail the compile (`success: false`) when the
+  linear backend reported errors, mirroring the WasmGC path. Unsupported
+  constructs now yield a clean compile error instead of invalid wasm.
+- `benchmarks/harness.ts`: wrap the timed-run loop in the same try/catch as
+  warmup, so a mid-loop runtime trap downgrades to a skipped strategy instead
+  of aborting the entire benchmark suite.
+
+This is a targeted compiler-correctness fix, not a benchmark edit — the
+benchmark sources are valid TS; the linear backend simply doesn't lower
+`repeat`/`replace`, and must say so honestly.
+
+## Regression window
+
+The linear backend itself did not change in the window; the symptom surfaced
+because the OOB trap timing shifted between warmup (caught) and the timed loop
+(fatal) on CI's Node 26. The underlying invalid-wasm/error-swallow bug is
+latent — `success: true` + invalid binary predates the window. Both are fixed
+here.
+
+## Validation
+
+- `tests/issue-1868.test.ts` — 7 tests: unsupported linear constructs now
+  return `success: false` with a `Codegen error:`; no `success: true` binary
+  fails `WebAssembly.compile`; supported string ops (`indexOf`, `split`) still
+  compile to valid, runnable wasm.
+- All 67 existing `tests/linear-*.test.ts` pass (no over-triggering).
+- `pnpm run refresh:benchmarks` completes (exit 0); `benchmarks/run.ts` no
+  longer aborts — unsupported linear strategies print a clean
+  `[linear-memory skipped: Compilation failed]` and `split`'s mid-loop OOB
+  prints `[linear-memory skipped (runtime, mid-loop): …]`.
+- `tsc --noEmit` clean; prettier + biome clean.

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -175,6 +175,10 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
 
   emitClosureTable(ctx);
 
+  // Surface codegen diagnostics so compiler.ts fails the compile rather than
+  // emitting a structurally invalid binary for unsupported constructs (#1868).
+  if (ctx.errors.length > 0) mod.codegenErrors = ctx.errors;
+
   return mod;
 }
 
@@ -331,6 +335,10 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
   }
 
   emitClosureTable(ctx);
+
+  // Surface codegen diagnostics so compiler.ts fails the compile rather than
+  // emitting a structurally invalid binary for unsupported constructs (#1868).
+  if (ctx.errors.length > 0) mod.codegenErrors = ctx.errors;
 
   return mod;
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -11,6 +11,7 @@ import { getNullablePrimitiveInfo } from "./checker/type-mapper.js";
 import { generateLinearModule, generateLinearMultiModule } from "./codegen-linear/index.js";
 import { resetCompileDepth } from "./codegen/expressions.js";
 import { generateModule, generateMultiModule } from "./codegen/index.js";
+import type { WasmModule } from "./ir/types.js";
 import {
   buildImportManifest,
   checkJsTypeCoverage,
@@ -37,6 +38,37 @@ import { optimizeBinaryAsync } from "./optimize.js";
 import { generateWit } from "./wit-generator.js";
 export { compileToObjectSource } from "./compiler/output.js";
 export type { ObjectCompileResult } from "./compiler/output.js";
+
+/**
+ * Propagate codegen diagnostics raised by the linear-memory backend (#1868).
+ *
+ * The WasmGC backend returns `{ module, errors }` and the caller fails the
+ * compile when any `Codegen error:` is present. The linear-memory backend
+ * historically only returned a `WasmModule` and accumulated its
+ * unsupported-construct diagnostics into `ctx.errors`, which the compiler
+ * never read — so an unhandled construct (e.g. `String.prototype.repeat`)
+ * silently produced a structurally invalid binary (a stack-underflowing
+ * `local.set`/`local.tee`) while reporting `success: true`. That invalid
+ * wasm then crashed downstream consumers (the benchmark harness, #1868).
+ *
+ * `mod.codegenErrors` now surfaces those diagnostics. Returns `true` when the
+ * linear backend reported at least one error (after copying them into
+ * `errors`), telling the caller to bail with `success: false` instead of
+ * emitting the invalid binary.
+ */
+function collectLinearCodegenErrors(mod: WasmModule, errors: CompileError[]): boolean {
+  const diags = mod.codegenErrors;
+  if (!diags || diags.length === 0) return false;
+  for (const err of diags) {
+    errors.push({
+      message: err.message.startsWith("Codegen error:") ? err.message : `Codegen error: ${err.message}`,
+      line: err.line,
+      column: err.column,
+      severity: "error",
+    });
+  }
+  return true;
+}
 
 const HARD_TS_DIAG_CODES = new Set([
   2322, // "Type 'X' is not assignable to type 'Y'"
@@ -649,6 +681,22 @@ export function compileSourceSync(
   try {
     if (useLinear) {
       mod = generateLinearModule(ast, { exposeArenaReset: options.allocator === "arena-reset" });
+      // Fail the compile on unsupported linear-backend constructs instead of
+      // emitting a structurally invalid binary (#1868).
+      if (collectLinearCodegenErrors(mod, errors)) {
+        return {
+          binary: new Uint8Array(0),
+          wat: "",
+          dts: "",
+          importsHelper: "",
+          success: false,
+          errors,
+          stringPool: [],
+          imports: [],
+          hasMain: false,
+          hasTopLevelStatements: false,
+        };
+      }
     } else {
       const result = generateModule(ast, {
         sourceMap: emitSourceMap,
@@ -945,6 +993,22 @@ export async function compileMultiSource(
   try {
     if (useLinear) {
       mod = generateLinearMultiModule(multiAst, { exposeArenaReset: options.allocator === "arena-reset" });
+      // Fail the compile on unsupported linear-backend constructs instead of
+      // emitting a structurally invalid binary (#1868).
+      if (collectLinearCodegenErrors(mod, errors)) {
+        return {
+          binary: new Uint8Array(0),
+          wat: "",
+          dts: "",
+          importsHelper: "",
+          success: false,
+          errors,
+          stringPool: [],
+          imports: [],
+          hasMain: false,
+          hasTopLevelStatements: false,
+        };
+      }
     } else {
       const result = generateMultiModule(multiAst, {
         sourceMap: emitSourceMap,
@@ -1203,6 +1267,22 @@ export async function compileFilesSource(entryPath: string, options: CompileOpti
   try {
     if (useLinear) {
       mod = generateLinearMultiModule(multiAst, { exposeArenaReset: options.allocator === "arena-reset" });
+      // Fail the compile on unsupported linear-backend constructs instead of
+      // emitting a structurally invalid binary (#1868).
+      if (collectLinearCodegenErrors(mod, errors)) {
+        return {
+          binary: new Uint8Array(0),
+          wat: "",
+          dts: "",
+          importsHelper: "",
+          success: false,
+          errors,
+          stringPool: [],
+          imports: [],
+          hasMain: false,
+          hasTopLevelStatements: false,
+        };
+      }
     } else {
       const result = generateMultiModule(multiAst, {
         sourceMap: emitSourceMap,

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -51,6 +51,15 @@ export interface WasmModule {
    * TypedArray types.
    */
   exportSignatures?: Record<string, ExportSignature>;
+  /**
+   * Codegen diagnostics produced while lowering this module (#1868). The
+   * linear-memory backend (`generateLinearModule` / `generateLinearMultiModule`)
+   * accumulates unsupported-construct errors into its `ctx.errors` array; it
+   * surfaces them here so `compiler.ts` can fail the compile instead of
+   * emitting a structurally invalid binary (e.g. a stack-underflowing
+   * `local.set` after an unhandled `String.prototype.repeat`).
+   */
+  codegenErrors?: { message: string; line: number; column: number }[];
 }
 
 /** TS-level kind hint for a single export parameter or result (#1700). */

--- a/tests/issue-1868.test.ts
+++ b/tests/issue-1868.test.ts
@@ -1,0 +1,75 @@
+// #1868 — the linear-memory backend must never report `success: true` while
+// emitting a structurally invalid binary.
+//
+// Root cause: `generateLinearModule` / `generateLinearMultiModule` accumulate
+// unsupported-construct diagnostics into `ctx.errors`, but `compiler.ts` never
+// read them. An unhandled string method such as `String.prototype.repeat`
+// pushed an error and returned WITHOUT leaving a value on the Wasm stack, so
+// the following `local.set` / `local.tee` / `call` underflowed the stack. The
+// compiler then handed back `{ success: true, binary }` where the binary fails
+// `WebAssembly.compile` ("not enough arguments on the stack for local.set").
+// That invalid wasm crashed the benchmark harness (Refresh Benchmarks CI).
+//
+// Fix: surface `ctx.errors` via `mod.codegenErrors` and fail the compile
+// (`success: false`) instead of emitting the invalid binary.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// Constructs the linear backend does NOT lower. Each previously produced an
+// invalid binary with `success: true`.
+const UNSUPPORTED_LINEAR = [
+  ['"x".repeat(n) bound to a const', `export function run(): number { const c = "x".repeat(8); return c.length; }`],
+  ['"x".repeat(n) inline', `export function run(): number { return "ab".repeat(4).length; }`],
+  ["indexOf after repeat", `export function run(): number { const h = "ab".repeat(10); return h.indexOf("a"); }`],
+  [
+    "String.prototype.replace",
+    `export function run(): number { const t = "the quick brown fox"; return t.replace("fox", "cat").length; }`,
+  ],
+] as const;
+
+describe("#1868 — linear backend never emits invalid wasm with success:true", () => {
+  for (const [label, src] of UNSUPPORTED_LINEAR) {
+    it(`reports success:false for ${label}`, async () => {
+      const result = await compile(src, { target: "linear" });
+      // The compile must fail rather than emit a structurally invalid binary.
+      expect(result.success, `expected compile to fail for unsupported construct, got success=true`).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors.some((e) => /Codegen error:/.test(e.message))).toBe(true);
+    });
+  }
+
+  it("does NOT emit a success:true binary that fails WebAssembly.compile", async () => {
+    for (const [, src] of UNSUPPORTED_LINEAR) {
+      const result = await compile(src, { target: "linear" });
+      if (result.success) {
+        // If a future change DOES lower the construct, the emitted binary
+        // must at minimum be structurally valid.
+        await expect(WebAssembly.compile(result.binary)).resolves.toBeDefined();
+      }
+    }
+  });
+
+  // Supported linear constructs must keep compiling to VALID, runnable wasm —
+  // the error-propagation change must not over-trigger.
+  it("still compiles supported string ops to valid, runnable wasm", async () => {
+    const result = await compile(`export function run(): number { const h = "abcdef"; return h.indexOf("c"); }`, {
+      target: "linear",
+    });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    expect((instance.exports as Record<string, Function>).run()).toBe(2);
+  });
+
+  it("string/split compiles to valid wasm (the benchmark that crashed CI)", async () => {
+    // split itself lowers fine; the CI crash was a runtime OOB in the bump
+    // allocator over many iterations, not invalid codegen. The binary must
+    // still be structurally valid + a single call must run.
+    const result = await compile(
+      `export function run(): number { const csv = "a,b,c,d"; const parts = csv.split(","); return parts.length; }`,
+      { target: "linear" },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    expect((instance.exports as Record<string, Function>).run()).toBe(4);
+  });
+});


### PR DESCRIPTION
## Symptom

`benchmark-refresh.yml` (step "Refresh benchmark artifacts", `pnpm run refresh:benchmarks`) has failed on **every push to main since ~12:14 2026-06-04** (10+ commits). `benchmarks/run.ts` aborts fatally on `string/split`:

```
[parse exception: popping from empty stack (at 0:3158)] Fatal: error in parsing wasm binary
RuntimeError: memory access out of bounds
   at runStrategy (benchmarks/harness.ts:189)
```

## Root cause

Two tangled bugs in the **linear-memory** backend path:

1. **Invalid wasm with `success: true`.** `src/codegen-linear/index.ts` pushes unsupported-construct diagnostics into `ctx.errors` (e.g. `Unsupported method call: .repeat()`) but leaves **nothing on the Wasm stack** before returning — so the following `local.set`/`local.tee`/`call` underflows (`function #43:"run": not enough arguments on the stack for local.set`). Worse, `compiler.ts` **never read** those linear-backend errors (the WasmGC path does), so `compile()` returned `success: true` with a structurally invalid binary. Benchmarks using `String.prototype.repeat`/`replace` (`concat-long`, `indexOf`, `includes`, `replace`, `case-convert`, …) hit this.

2. **Fatal mid-loop runtime trap.** `string/split` lowers to *valid* linear wasm but its bump allocator OOBs after many iterations. Whether the trap lands in the harness **warmup** loop (caught) or the **timed** loop (`harness.ts:189`, unguarded) is non-deterministic across V8 — so the suite passed on local Node 25 but aborted on CI Node 26.

## Fix

- `src/ir/types.ts`: add optional `WasmModule.codegenErrors`.
- `src/codegen-linear/index.ts`: both `generateLinearModule` / `generateLinearMultiModule` surface `ctx.errors` via `mod.codegenErrors`.
- `src/compiler.ts`: `collectLinearCodegenErrors()` helper; all three linear call sites now fail the compile (`success: false`) on backend errors, mirroring the WasmGC path. Unsupported constructs yield a clean compile error instead of invalid wasm.
- `benchmarks/harness.ts`: guard the timed loop like warmup so a mid-loop runtime trap downgrades to a skipped strategy instead of aborting the suite.

Targeted **compiler-correctness** fix — the benchmark sources are valid TS; the linear backend simply doesn't lower `repeat`/`replace` and must now say so honestly rather than emit a stack-underflowing binary.

## Validation

- `tests/issue-1868.test.ts` (7 tests) green — unsupported linear constructs now return `success: false` + `Codegen error:`; no `success: true` binary fails `WebAssembly.compile`; `indexOf`/`split` still compile to valid runnable wasm.
- All 67 existing `tests/linear-*.test.ts` green (no over-triggering).
- `pnpm run refresh:benchmarks` completes (exit 0); `benchmarks/run.ts` no longer aborts.
- `tsc --noEmit` / prettier / biome clean.

Closes #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)