### PR TITLE
perf(examples): stream native-messaging re-chunk through a reused buffer (#389)

### DIFF
--- a/examples/native-messaging/nm_js2wasm.ts
+++ b/examples/native-messaging/nm_js2wasm.ts
@@ -15,19 +15,25 @@
 //   2. A single host->extension message is capped at 1 MiB.
 //
 // So a large message — e.g. `port.postMessage(Array(209715*64))`, ~64 MiB of
-// `[null,null,...]` — can neither be echoed in one frame nor split at raw byte
-// boundaries (that yields invalid-JSON fragments). This host re-chunks a large
-// JSON **array** into a sequence of <=1 MiB valid JSON arrays whose elements,
-// concatenated by the receiver, reproduce the original array. A message that
-// already fits in one frame is echoed verbatim. Chunks are written as
-// `[` + `subarray` view + `]`, so no per-frame copy of the body is made.
+// `[null,null,...]` — is re-chunked into a sequence of <=1 MiB valid JSON arrays
+// whose elements, concatenated by the receiver, reproduce the original array.
+// A message that already fits in one frame is echoed verbatim.
+//
+// This host STREAMS the re-chunk through a single reused 1 MiB buffer: it never
+// holds the whole body, so resident memory stays flat (~a couple MiB) regardless
+// of message size or count. It also never calls `Uint8Array.prototype.subarray`
+// — under wasmtime that lowers to a native `array.copy` that is ~14x slower than
+// an element loop on i8 GC arrays — each frame is built with an element loop into
+// an exact-size buffer and written whole. Reads fill the buffer to its exact
+// capacity (or use an exact-size buffer for the final partial batch), so a read
+// can never pull bytes past the current message into the next one.
 //
 // js2wasm support today:
 //   - stdin  : process.stdin.read(buf, offset?) does one binary, incremental
 //              fd=0 read into the caller's typed buffer at `offset`, returning
 //              the byte count (#1653). A read-until loop assembles exactly N.
 //   - stdout : process.stdout.write(bytes|str) writes raw bytes to fd=1 with NO
-//              trailing newline (#1651) — the 4-byte LE prefix and body bytes.
+//              trailing newline (#1651).
 //   - stderr : process.stderr.write writes to fd=2, off the protocol stream.
 
 declare const process: {
@@ -36,21 +42,37 @@ declare const process: {
   stderr: { write(chunk: Uint8Array | string): void };
 };
 
-// Largest body Chrome accepts in one host->extension message.
+// Largest body Chrome accepts in one host->extension message, and the size of
+// the single scratch buffer the whole stream flows through.
 const FRAME_CHUNK = 1024 * 1024;
+const MAX_RUN = FRAME_CHUNK - 2; // leave room for the framing `[` and `]`
 const COMMA = 44; // ,
 const OPEN_BRACKET = 91; // [
 const CLOSE_BRACKET = 93; // ]
 
-// Read exactly `n` bytes into the first `n` slots of `buf` via a read-until
-// loop, handling short reads (fd_read may return fewer bytes than requested).
-// Returns false on EOF (a read of <= 0 bytes before `n` were assembled).
+// Read exactly `n` bytes into buf[0..n). Over-read-safe only when buf.length
+// === n (the read can't exceed the buffer; caller guarantees the stream has at
+// least `n` bytes left for this message).
 /** @param {Uint8Array} buf @param {number} n @returns {boolean} */
 function readExact(buf: Uint8Array, n: number): boolean {
   let got = 0;
   while (got < n) {
     const r = process.stdin.read(buf, got);
     if (r <= 0) return false; // EOF or error
+    got = got + r;
+  }
+  return true;
+}
+
+// Read exactly `n` bytes into buf[start..start+n). Over-read-safe only when
+// (buf.length - start) === n, so a single read can never pull bytes past `n`
+// (and thus never into the next message).
+/** @param {Uint8Array} buf @param {number} start @param {number} n @returns {boolean} */
+function readAt(buf: Uint8Array, start: number, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = process.stdin.read(buf, start + got);
+    if (r <= 0) return false;
     got = got + r;
   }
   return true;
@@ -75,10 +97,29 @@ function logFrameBodyRead(declaredLen: number): void {
   process.stderr.write(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`);
 }
 
+// Emit one frame: `[` + src[start..start+runLen) + `]`, built whole with an
+// element loop and written in one go (no subarray / no array.copy).
+/** @param {Uint8Array} src @param {number} start @param {number} runLen */
+function emitRun(src: Uint8Array, start: number, runLen: number): void {
+  const frame = new Uint8Array(runLen + 2);
+  frame[0] = OPEN_BRACKET;
+  let k = 0;
+  while (k < runLen) {
+    frame[k + 1] = src[start + k];
+    k = k + 1;
+  }
+  frame[runLen + 1] = CLOSE_BRACKET;
+  writeLength(runLen + 2);
+  process.stdout.write(frame);
+}
+
 export function main(): void {
   // Long-lived port loop: read framed JSON messages off stdin until EOF and
   // echo each one back as valid JSON within Chrome's 1 MiB per-message cap.
   const header = new Uint8Array(4);
+  const one = new Uint8Array(1);
+  const buf = new Uint8Array(FRAME_CHUNK); // reused read/window buffer
+
   while (true) {
     // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
     if (!readExact(header, 4)) break;
@@ -86,52 +127,90 @@ export function main(): void {
     if (declaredLen === 0) break;
     logFrameBodyRead(declaredLen);
 
-    const body = new Uint8Array(declaredLen);
-    if (!readExact(body, declaredLen)) break;
-
     if (declaredLen <= FRAME_CHUNK) {
       // Already a single valid JSON message within the cap — echo verbatim.
+      const small = new Uint8Array(declaredLen);
+      if (!readExact(small, declaredLen)) break;
       writeLength(declaredLen);
-      process.stdout.write(body);
+      process.stdout.write(small);
       continue;
     }
 
-    // Large JSON array `[elem,elem,...,elem]`: emit a sequence of valid JSON
-    // arrays `[elem,...]`, each <=1 MiB, split only at top-level commas so every
-    // frame parses and the receiver can rebuild the original by concatenation.
-    const maxRun = FRAME_CHUNK - 2; // leave room for the framing `[` and `]`
-    let i = 1; // skip the leading `[`
-    const end = declaredLen - 1; // index of the trailing `]`
-    while (i < end) {
-      let stop = i + maxRun;
-      if (stop >= end) {
-        stop = end;
+    // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
+    // `[run]` frames. Consume the leading `[`; the trailing `]` is read last.
+    if (!readExact(one, 1)) break; // the `[`
+    let interiorRemaining = declaredLen - 2; // interior bytes (excludes `[` and `]`)
+    let fill = 0; // carry bytes held at buf[0..fill) (a partial element, no comma)
+    let truncated = false;
+
+    while (interiorRemaining > 0) {
+      const need = FRAME_CHUNK - fill; // fill the buffer exactly (over-read-safe)
+      if (interiorRemaining >= need) {
+        if (!readAt(buf, fill, need)) {
+          truncated = true;
+          break;
+        }
+        fill = FRAME_CHUNK;
+        interiorRemaining = interiorRemaining - need;
+        // Emit one frame up to the last comma within [0, MAX_RUN); carry the rest.
+        let last = MAX_RUN;
+        while (last > 0 && buf[last - 1] !== COMMA) last = last - 1;
+        let runLen: number;
+        let consumed: number;
+        if (last === 0) {
+          // No comma in [0, MAX_RUN): a single element exceeds the cap — emit
+          // MAX_RUN raw (degenerate; only for elements > ~1 MiB).
+          runLen = MAX_RUN;
+          consumed = MAX_RUN;
+        } else {
+          runLen = last - 1; // exclude the comma at last-1
+          consumed = last; // skip the comma too
+        }
+        emitRun(buf, 0, runLen);
+        // Shift the leftover buf[consumed..fill) to the front (small for typical
+        // element sizes — one element plus the 2 cap bytes).
+        const rem = fill - consumed;
+        let m = 0;
+        while (m < rem) {
+          buf[m] = buf[consumed + m];
+          m = m + 1;
+        }
+        fill = rem;
       } else {
-        // Back up to the last comma in [i, stop) so a frame never splits an
-        // element; the run [i, stop) is then a whole number of elements.
-        let c = stop;
-        while (c > i && body[c - 1] !== COMMA) c = c - 1;
-        if (c > i) stop = c - 1; // exclude the comma itself
+        // Final interior batch: read exactly interiorRemaining (exact-size temp,
+        // over-read-safe), append to the carry, then drain to frames.
+        const tmp = new Uint8Array(interiorRemaining);
+        if (!readExact(tmp, interiorRemaining)) {
+          truncated = true;
+          break;
+        }
+        let t = 0;
+        while (t < interiorRemaining) {
+          buf[fill + t] = tmp[t];
+          t = t + 1;
+        }
+        fill = fill + interiorRemaining;
+        interiorRemaining = 0;
+        // Drain buf[0..fill) into <=MAX_RUN frames at comma boundaries; the last
+        // frame ends exactly at fill (the array has no trailing comma).
+        let startPos = 0;
+        while (startPos < fill) {
+          let stop = startPos + MAX_RUN;
+          if (stop >= fill) {
+            stop = fill;
+          } else {
+            let c = stop;
+            while (c > startPos && buf[c - 1] !== COMMA) c = c - 1;
+            if (c > startPos) stop = c - 1;
+          }
+          emitRun(buf, startPos, stop - startPos);
+          startPos = stop;
+          if (startPos < fill && buf[startPos] === COMMA) startPos = startPos + 1;
+        }
+        fill = 0;
       }
-      // Frame body = `[` + body[i..stop) + `]` (a valid JSON array). Build it
-      // with an element-wise copy into an exact-size buffer and write the whole
-      // buffer once. We deliberately avoid `body.subarray(i, stop)`: under
-      // wasmtime the native `array.copy` it lowers to runs ~14x slower than this
-      // element loop for i8 GC arrays (#1863), while a whole-array stdout write
-      // hits the fast path.
-      const runLen = stop - i;
-      const frame = new Uint8Array(runLen + 2);
-      frame[0] = OPEN_BRACKET;
-      let k = 0;
-      while (k < runLen) {
-        frame[k + 1] = body[i + k];
-        k = k + 1;
-      }
-      frame[runLen + 1] = CLOSE_BRACKET;
-      writeLength(runLen + 2);
-      process.stdout.write(frame);
-      i = stop;
-      if (i < end && body[i] === COMMA) i = i + 1; // step over the separator
     }
+    if (truncated) break; // EOF mid-frame → stop
+    if (!readExact(one, 1)) break; // the trailing `]`
   }
 }

--- a/plan/issues/1886-linear-backed-uint8array-wasi-io.md
+++ b/plan/issues/1886-linear-backed-uint8array-wasi-io.md
@@ -1,0 +1,86 @@
+---
+id: 1886
+title: "Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoid GC↔linear copies, match AssemblyScript"
+status: ready
+sprint: Backlog
+created: 2026-06-04
+updated: 2026-06-04
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: typed-arrays
+goal: performance
+related: [1863, 1527, 389]
+---
+# #1886 — Linear-backed `Uint8Array` for WASI I/O buffers
+
+**Source:** GitHub issue #389. guest271314's AssemblyScript host
+(`nm_assemblyscript_component.wat`) is faster than js2wasm on the same workload;
+the `.wat` shows why, and it points at a concrete, *targeted* optimization.
+
+## Why AssemblyScript is faster (measured + confirmed from its `.wat`)
+
+AssemblyScript uses **linear memory exclusively** — no WasmGC, no `array.new`/
+`array.copy`/`struct.new`. Its message buffer *is* linear memory, so `fd_read`
+reads **directly into** it and `fd_write` writes **directly from** it: **zero
+copies**, no GC-heap instantiation.
+
+js2wasm's `--target wasi` uses the **WasmGC backend**: `Uint8Array` is a GC
+array. But WASI `fd_read`/`fd_write` can only touch *linear* memory, so every
+read/write pays an element-wise copy js2wasm-side:
+- `fd_read` lands bytes in a linear scratch region → copied element-by-element
+  **into** the GC array;
+- the GC array is copied element-by-element **back** to linear memory →
+  `fd_write`.
+
+Plus the GC module needs `-W gc=y` and GC-heap setup (slower cold start — which
+dominates the 1 MiB `connectNative` benchmark). The streaming example host
+(landed) removes body retention and the slow `array.copy` (24 MB / ~0.42 s for
+64 MiB), but it **cannot** remove these GC↔linear copies — they're inherent to
+the WasmGC backend.
+
+## The optimization (not a global backend switch)
+
+Selectively back a `Uint8Array` by **linear memory** when analysis proves it is
+a plain I/O buffer that does not need GC — keep GC arrays everywhere else.
+
+A `new Uint8Array(n)` is "linear-safe" iff it never escapes to a GC-requiring
+use (stored in a GC struct/array, returned as a ref, captured, etc.) and is only
+indexed / passed to `process.stdin.read` / `process.stdout.write`. For such an
+array:
+- allocate it in **linear memory** as `(ptr, len)`;
+- `process.stdin.read(buf, off)` → `fd_read` straight into `ptr+off` (no copy);
+- `process.stdout.write(buf)` → `fd_write` straight from `ptr` (no copy);
+- `buf[i]` → a linear load/store.
+
+When the analysis can't prove safety, fall back to the GC array (today's
+behavior). GC stays the default; linear is used only where it's a pure buffer —
+"without changing this for cases where it's not needed." Stays within the
+"mimic standard Node APIs" rule: it's a transparent optimization of plain
+`Uint8Array` + `process.stdin/stdout`, no bespoke builtin.
+
+## What it requires
+
+1. **Escape/usage analysis** for typed arrays — mark a `Uint8Array`
+   "linear-safe" iff it never escapes to a GC-requiring context. (The
+   typed-array slice of general escape analysis.)
+2. **A linear allocator** for these buffers — the WASI output already has a
+   linear memory and a (currently dead) `$__wasi_bump_ptr` global; wire up a
+   real bump/arena (a per-port-loop arena reset suits short-lived I/O buffers).
+3. **Codegen** so indexing + the `stdin.read`/`stdout.write` intrinsics operate
+   on a linear-backed array, with a clean GC fallback.
+
+Overlaps the `codegen-linear` backend (#1527) and general escape analysis, but
+as an analysis-driven optimization rather than a target choice.
+
+## Acceptance criteria
+
+- A WASI byte-I/O host (e.g. `examples/native-messaging/nm_js2wasm.ts`) whose
+  `Uint8Array` buffers are provably I/O-only compiles with **no GC↔linear
+  copies** on the read/write path; verified in the `.wat` (no element-wise
+  GC→linear loop around `fd_read`/`fd_write`).
+- 64 MiB round-trip wall time within ~2× of the AssemblyScript host.
+- No correctness/behavior change for `Uint8Array` that does escape (GC fallback
+  intact); existing tests + `smoke-test.sh` pass.


### PR DESCRIPTION
Follow-up to #1167. The merged valid-JSON host was correct but held the whole array body (~148 MB for a 64 MiB message). This streams the re-chunk through a single reused 1 MiB buffer — lean *and* Chrome-correct.

## Change
- Stream the array interior through one reused 1 MiB buffer with partial-element carry; emit valid ≤1 MiB `[...]` frames built via an element loop (no `subarray`/`array.copy`).
- Over-read-safe reads: fill-to-exact-capacity for full chunks, exact-size buffer for the final partial batch — a read never crosses into the next message.

## Result (64 MiB `Array(209715*64)`, wasmtime 45)
| host | wall | peak RSS | valid JSON |
|---|---|---|:--:|
| byte-chunk (guest's zip / old #1103) | 0.28 s | 21 MB | ❌ (Chrome rejects) |
| merged valid-JSON (#1167) | 0.52 s | 148 MB | ✅ |
| **this (streaming valid-JSON)** | **0.42 s** | **24 MB** | ✅ |

Flat ~24 MB across 3×64 MiB (195 frames, reassembles to 40,265,280 elements). 8/8 `issue-1530` tests + `smoke-test.sh` pass; edge cases (just-over-1 MiB, mid sizes, verbatim small) verified.

## Also files #1886
Why AssemblyScript is still faster (from its `.wat`): its buffer **is** linear memory, so `fd_read`/`fd_write` are zero-copy. js2wasm's WasmGC `Uint8Array` pays a GC↔linear copy each way. #1886 proposes selectively backing provably-I/O-only `Uint8Array`s by linear memory (escape analysis) to close that gap — without a global backend switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)