### PR TITLE
feat(#1886) Slice A: linear-safe Uint8Array escape analysis (gated, no codegen)

### DIFF
--- a/plan/issues/1886-linear-backed-uint8array-wasi-io.md
+++ b/plan/issues/1886-linear-backed-uint8array-wasi-io.md
@@ -1,7 +1,7 @@
 ---
 id: 1886
-title: "Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoid GC↔linear copies, match AssemblyScript"
-status: ready
+title: "Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoid GC↔linear copies, beat AssemblyScript on memory"
+status: in-progress
 sprint: Backlog
 created: 2026-06-04
 updated: 2026-06-04
@@ -31,15 +31,39 @@ js2wasm's `--target wasi` uses the **WasmGC backend**: `Uint8Array` is a GC
 array. But WASI `fd_read`/`fd_write` can only touch *linear* memory, so every
 read/write pays an element-wise copy js2wasm-side:
 - `fd_read` lands bytes in a linear scratch region → copied element-by-element
-  **into** the GC array;
+  **into** the GC array (`node-process-api.ts` `emitProcessStdinRead`, the
+  `array.set` loop);
 - the GC array is copied element-by-element **back** to linear memory →
-  `fd_write`.
+  `fd_write` (`index.ts` `ensureWasiWriteUint8ArrayHelper`, the `i32.store8`
+  loop).
 
-Plus the GC module needs `-W gc=y` and GC-heap setup (slower cold start — which
-dominates the 1 MiB `connectNative` benchmark). The streaming example host
-(landed) removes body retention and the slow `array.copy` (24 MB / ~0.42 s for
-64 MiB), but it **cannot** remove these GC↔linear copies — they're inherent to
-the WasmGC backend.
+The streaming example host (landed, #389) removes body retention and the slow
+`array.copy` (37 MB / ~0.50 s for 64 MiB), but it **cannot** remove these
+GC↔linear copies — they're inherent to a GC-array buffer.
+
+### Measured cost decomposition (wasmtime 45, 64 MiB `[null,...]`, this branch)
+
+| Workload | Wall | Peak RSS | What it isolates |
+|---|---|---|---|
+| AssemblyScript (linear buffer, zero-copy I/O + linear memmove) | 0.12–0.24 s | 147 MB | the syscall + linear-memmove floor |
+| js2wasm full native-messaging host (current merged, GC stream) | **0.50 s** | **37 MB** | I/O copies **+** GC frame-build loops |
+| js2wasm I/O-only (read 1 MiB GC window, echo it back — no reframe) | 0.27 s | 30 MB | the two GC↔linear I/O copies + 64 syscalls |
+| js2wasm write-only (echo a fixed 1 MiB GC buffer 64×) | **0.15 s** | 31 MB | the GC→linear **write** copy alone |
+
+**The lever this issue is actually pulling (corrects the original framing):**
+the win is **not** "hold the body in memory" (holding it in a *GC* array is both
+slower *and* fatter than the streaming window — confirmed by the team-lead's
+held-body measurement). The win is **getting the bytes out of the GC heap and
+into linear memory so `fd_read`/`fd_write` touch them with zero copy.** The
+write copy alone is ~0.15 s and the read copy is symmetric: the two GC↔linear
+I/O copies are ≈0.27 s of the 0.50 s — i.e. **the dominant, removable cost**.
+The remaining ~0.23 s is the per-element frame-build/carry loops, which are
+`array.get_u`/`array.set` today and become `i32.load8_u`/`i32.store8` once the
+buffer is linear-backed — comparable per-op, but they then feed `fd_write` with
+**no boundary copy at all**. So a correct #1886 should reach **~0.15–0.25 s at
+flat ~24–31 MB** — AS-class speed while *beating* AS on memory (no 147 MB
+linear body; we stream through a 1 MiB linear window). The target is **not**
+"match AS" — it's "AS speed, AS-beating memory."
 
 ## The optimization (not a global backend switch)
 
@@ -84,3 +108,225 @@ as an analysis-driven optimization rather than a target choice.
 - 64 MiB round-trip wall time within ~2× of the AssemblyScript host.
 - No correctness/behavior change for `Uint8Array` that does escape (GC fallback
   intact); existing tests + `smoke-test.sh` pass.
+
+## Implementation Plan (esch, 2026-06-04)
+
+### 0. Scope and guiding principle
+
+This is an **analysis-driven optimization inside the WasmGC front-end +
+codegen**, gated to `--target wasi` (and standalone with linear memory). It is
+**not** a switch to the `codegen-linear` backend (#1527) and **not** a global
+default change. GC stays the representation for every `Uint8Array`; a buffer is
+moved to a **linear (`ptr`, `len`)** representation only when analysis *proves*
+it is a pure I/O buffer that never needs GC. When proof fails — fall straight
+back to today's GC vec, byte-for-byte unchanged.
+
+The representation has to be **end-to-end consistent for a given buffer**: if
+`buf` is linear-backed, then `new Uint8Array(n)` for it, every `buf[i]`
+load/store, `buf.length`, and the `stdin.read(buf)` / `stdout.write(buf)`
+intrinsics must all agree on the linear form. We cannot make *only* the I/O
+intrinsics zero-copy while keeping the GC array for indexing — the bytes would
+live in two places. So the analysis decides per-buffer, and the whole
+representation switches together.
+
+### 1. Linear-safe escape/usage analysis (new module `src/codegen/linear-uint8-analysis.ts`)
+
+A pre-pass over the WASI source file that classifies each `Uint8Array` *binding*
+(`const`/`let`/`var` initialized from `new Uint8Array(...)`, and function
+**parameters** typed `Uint8Array`) as **linear-safe** or not.
+
+**Linear-safe predicate** — a binding is linear-safe iff *every* use of it is
+one of the allowed forms, and it never enters a GC-requiring context:
+
+Allowed uses:
+- element load/store: `b[i]` / `b[i] = v` (any index expr);
+- `b.length`;
+- `process.stdin.read(b)` / `process.stdin.read(b, off)`;
+- `process.stdout.write(b)` / `process.stderr.write(b)`;
+- passed as a call argument to a function whose corresponding **parameter is
+  itself linear-safe** (interprocedural threading — see fixpoint below);
+- `new Uint8Array(b)` is *not* allowed (it would view/copy — keep GC).
+
+Disqualifying (forces GC fallback):
+- stored into any object/array/struct field, a closure capture, a module
+  global, or `this.x = b`;
+- returned from a function (`return b`);
+- assigned to a binding of wider/`any`/`unknown`/union type;
+- used by any method other than the allowed I/O intrinsics (`.subarray`,
+  `.slice`, `.set`, `.fill`, `.indexOf`, spread `[...b]`, `for..of b`,
+  `Array.from(b)`, `JSON.stringify`, template interpolation, `===`/`==`
+  identity compare, `b instanceof`, `typeof`, etc.);
+- passed to a function parameter that is *not* linear-safe, or to any
+  externref/host-import boundary, or to an **exported** function's parameter
+  (export ABI is observable — keep GC);
+- reassigned to point at a different array, or aliased via destructuring.
+- aliasing: `const c = b;` then using `c` in a disqualifying way disqualifies
+  `b`. Treat any non-call-arg, non-index, non-`.length`, non-I/O reference
+  conservatively as an escape.
+
+**Interprocedural fixpoint** (the native-messaging host needs it — `buf` is
+threaded into `readExact`/`readAt`/`emitRun`):
+1. Seed: assume every `Uint8Array` parameter of every **non-exported** function
+   is *candidate* linear-safe; every exported function's `Uint8Array` params are
+   *not* linear-safe (observable ABI).
+2. Iterate to fixpoint: for each function, walk its body; a parameter loses
+   candidacy if used in any disqualifying way *or* passed to a callee parameter
+   that is currently non-linear-safe. A `new Uint8Array` binding is linear-safe
+   iff all its uses are allowed under the *current* parameter classification.
+3. Converge (monotone: only ever demote, never promote), then freeze.
+
+Output: a `Set<ts.Symbol>` of linear-safe **bindings** (locals + params) plus a
+`Set<funcSymbol→paramIndex[]>` map of which params are linear-backed, consumed
+by codegen. Conservative by construction — any uncertainty ⇒ not linear-safe.
+
+Keep this analysis **off by default** behind a context flag
+(`ctx.linearUint8 = true` only when `ctx.wasi`), so non-WASI builds are
+untouched and the blast radius is contained.
+
+### 2. Linear bump allocator (wire up the dead `$__wasi_bump_ptr`)
+
+`registerWasiImports` already declares a `$__wasi_bump_ptr` global
+(`index.ts:4578`) that is currently dead. Wire a real bump allocator:
+- Reserve a fixed linear region for linear-backed buffers **above** the existing
+  WASI scratch pages (`WASI_STDIN_BUF_START = 64 KiB`,
+  `WASI_WRITE_SCRATCH_START = 128 KiB`). Add `LINEAR_U8_ARENA_START = 192 KiB`
+  (page 3) and initialize `$__wasi_bump_ptr` to it.
+- New helper `__lin_u8_alloc(len: i32) -> i32` (emitted lazily, like the
+  write helpers): align `len` up to 8, `ptr = bump`, `bump += len`, `memory.grow`
+  if `bump` exceeds `memory.size` (reuse the `ceil(x/65536)=(x+65535)>>16`
+  page-growth idiom already used by the write helpers), return `ptr`. A
+  zero-init is **not** needed for `fd_read` buffers but `new Uint8Array(n)` is
+  spec'd zero-filled — linear memory is zero on grow, but a *reused* arena slot
+  is not; see arena-reset below.
+- **Arena reset (the per-port-loop reclamation):** the native-messaging buffers
+  (`header`, `one`, `buf`) are allocated once before the `while(true)` loop and
+  reused; the per-iteration `small`/`tmp`/`frame` are allocated *inside* the
+  loop. A naive bump-forever leaks ~`frame` per message → unbounded growth on a
+  long stream. **Reset rule:** when a linear-safe `new Uint8Array` appears
+  inside a loop body, snapshot the bump pointer at loop entry and rewind to it
+  at the bottom of each iteration (a `__lin_u8_arena_mark` / `__lin_u8_reset`
+  pair around the loop body). Justification: a buffer allocated *inside* an
+  iteration cannot legally outlive that iteration under the linear-safe
+  predicate (it doesn't escape, isn't returned, isn't captured), so rewinding at
+  the iteration boundary is sound. Buffers allocated *outside* the loop sit
+  below the mark and survive. For correctness of the zero-fill contract,
+  `new Uint8Array(n)` in a reused slot must `memory.fill(ptr, 0, len)` — cheap
+  vs the eliminated copies, and only when the source actually reads
+  before-write (we can keep it unconditional for safety in v1).
+  - **Phase the reset carefully**: v1 may allocate without reset (correct,
+    leaks on infinite streams) to land the zero-copy I/O win first, then add the
+    loop-scoped reset in a follow-up slice once the simpler path is proven. Flag
+    this in the PR.
+
+### 3. Codegen — linear-backed buffer representation
+
+Represent a linear-safe buffer as an **i32 local holding its `ptr`**, plus a
+companion i32 local holding its `len` (allocated alongside in `allocLocal`).
+Member/intrinsic lowering branches on "is this binding linear-safe?":
+
+- **`new Uint8Array(n)`** (`new-super.ts` ~2299/3024, the
+  `isNativeUint8Array` arm): if the binding is linear-safe, emit
+  `len = n; ptr = __lin_u8_alloc(n); memory.fill(ptr,0,n)` and bind the two i32
+  locals **instead of** `getOrRegisterVecType` + `array.new_default`. The
+  `new Uint8Array([a,b,c])` literal form: alloc `len=count`, then a sequence of
+  `i32.store8 ptr+k, literal`.
+- **`b[i]` read** (`property-access.ts` `compileElementAccessBody`): if `b` is
+  linear-safe, emit `i32.load8_u (ptr + i)` returning `{kind:"f64"}` after
+  `f64.convert_i32_u` to match the existing Uint8Array element value type (the
+  current GC path returns the byte widened to the array's element kind — keep
+  the *observable* numeric type identical).
+- **`b[i] = v`** (assignment compiler): `i32.store8 (ptr+i), trunc(v)&0xff`.
+- **`b.length`**: `local.get len` → `f64.convert_i32_u`.
+- **`process.stdin.read(b, off)`** (`node-process-api.ts`
+  `emitProcessStdinRead`): when `b` is linear-safe, **skip the `array.set` copy
+  loop entirely** — set the iovec base to `ptr + off`, length to `len - off`,
+  call `fd_read`, return `nread`. Zero element copies.
+- **`process.stdout.write(b)`** (`node-process-api.ts` →
+  `ensureWasiWriteUint8ArrayHelper`): when `b` is linear-safe, skip the
+  `i32.store8` staging copy — set the iovec base to `ptr`, length to `len`, call
+  `fd_write`. Zero element copies.
+- **Passing a linear-safe `b` to a linear-safe callee param**: pass the two i32s
+  (`ptr`, `len`) as two wasm params. This means linear-backed functions get a
+  *rewritten signature*: each linear-safe `Uint8Array` param becomes
+  `(ptr: i32, len: i32)`. Build the func type from the param classification map.
+  All call sites of such a function must agree — guaranteed because the analysis
+  froze the param set before codegen.
+
+**GC fallback**: when a binding is *not* in the linear-safe set, every site
+above takes the existing GC vec path **unchanged**. The new branches are
+strictly additive (`if (isLinearSafe(sym)) { …new… } else { …existing… }`), so
+non-WASI and any escaping `Uint8Array` are byte-identical to today.
+
+### 4. Files / functions to touch
+
+| File | Change |
+|---|---|
+| `src/codegen/linear-uint8-analysis.ts` (new) | the analysis pass + result types |
+| `src/codegen/context/types.ts` | add `linearUint8Set?: Set<ts.Symbol>`, `linearUint8Params?: Map<...>`, `linearU8BumpGlobalIdx`, arena constants to `CodegenContext` |
+| `src/codegen/index.ts` | run analysis when `ctx.wasi`; `LINEAR_U8_ARENA_START`; `__lin_u8_alloc` / arena-mark / reset helpers; init `$__wasi_bump_ptr`; add linear-write fast path in `ensureWasiWriteUint8ArrayHelper` (or a sibling `__wasi_fd_write_linear(ptr,len)`) |
+| `src/codegen/node-process-api.ts` | linear-safe branches in `emitProcessStdinRead` + the write dispatch in `tryCompileNodeProcessCall` |
+| `src/codegen/expressions/new-super.ts` | linear-backed `new Uint8Array(n)` / `new Uint8Array([..])` |
+| `src/codegen/property-access.ts` | linear-backed `b[i]` read in `compileElementAccessBody` |
+| assignment site (find the `array.set` element-assign path) | linear-backed `b[i] = v` |
+| `.length` member access | linear-backed length |
+| function-signature builder + call-arg lowering | rewrite linear-safe `Uint8Array` params to `(ptr,len)`; thread args |
+| `tests/issue-1886.test.ts` (new) | analysis unit tests (safe vs escaping) + emitted-wasm assertions (no `array.set`/`array.get_u` loop around `fd_read`/`fd_write` for the example) + execution equivalence |
+
+### 5. Downstream-effect checklist (senior-dev diligence)
+
+- **Stack balance / ValType**: `b[i]` must keep returning the same *observable*
+  value type the GC path returns (`f64` after the widen) so callers' arithmetic
+  is unchanged. Verify no stack-type mismatch by re-validating the emitted wasm.
+- **Function-index shifting**: `__lin_u8_alloc` and the linear write helper are
+  late-emitted lazily — they must register through `ctx.funcMap` and respect the
+  `addUnionImports`/late-import shift discipline (`ctx.currentFunc.body` shift),
+  exactly like the existing `__wasi_write_*` helpers. Do NOT cache a raw
+  `funcIdx` across a late import.
+- **Signature rewrite is the riskiest piece** — a linear-safe param becomes two
+  i32s. If *any* call site disagrees (e.g. a missed escape that should have
+  demoted the param), the module fails validation. The fixpoint must be
+  conservative and the codegen must consult the *same frozen* classification at
+  both the callee def and every call site. Add a verifier assertion: if a
+  function is linear-rewritten, every call to it in the module must be
+  linear-arg.
+- **`memory 3` → larger**: arena lives in page 3; `registerWasiImports` reserves
+  3 pages today. Bump the reserved minimum to 4 and let `memory.grow` handle the
+  rest (the write helpers already grow on demand).
+- **`one`/`header` tiny buffers**: still worth linear-backing (uniform path), but
+  the win is in `buf`/`frame`. No special-casing needed.
+- **Don't regress non-Uint8Array typed arrays**: the analysis only touches
+  `Uint8Array` under `noJsHost`/`wasi`; `Int32Array`/`Float64Array` stay GC.
+
+### 6. Expected result vs acceptance criteria
+
+- Emitted `.wat` for `nm_js2wasm.ts`: **no `array.set` loop** in the stdin-read
+  path and **no `i32.store8` staging loop** in the stdout-write path — `fd_read`
+  targets `ptr+off`, `fd_write` reads from `ptr` directly. (Baseline today: 49
+  `array.set`, 37 `array.get_u`; expect the I/O-path ones gone, frame-build
+  `array.*` replaced by `i32.load8_u`/`i32.store8`.)
+- 64 MiB round-trip wall ~0.15–0.25 s (from 0.50 s), peak RSS flat ~24–31 MB
+  (we do **not** hold the 64 MiB body — still streaming a 1 MiB linear window).
+  Within ~2× of AS on wall, **better** than AS on memory.
+- Escaping `Uint8Array` (stored in a struct, returned, captured): GC path
+  unchanged; existing typed-array tests + `examples/native-messaging/smoke-test.sh`
+  (if present) + a scoped equivalence subset pass.
+
+### 7. Phasing (slices for safe landing)
+
+- **Slice A** — analysis module + unit tests (no codegen change); prove it marks
+  every `nm_js2wasm.ts` buffer linear-safe and correctly *rejects* a crafted
+  escaping case. Lands behind the flag, gated off.
+- **Slice B** — linear allocator + `new`/index/`.length` codegen + the
+  intraprocedural buffers (`header`, `one`, `buf` in `main`). No signature
+  rewrite yet (so `readExact`/`emitRun` still take GC — but those are only the
+  small/parameter paths; measure the partial win).
+- **Slice C** — interprocedural signature rewrite so `readExact`/`readAt`/
+  `emitRun` take linear `(ptr,len)` params → full zero-copy I/O. This is where
+  the big number lands.
+- **Slice D** (optional follow-up) — loop-scoped arena reset for unbounded
+  streams.
+
+Slices A+B+C are the core of this issue; D can be a follow-up if the per-message
+allocation proves to leak on infinite streams (the benchmark sends one large
+message, so A–C suffice to hit the acceptance numbers, but D is needed for
+production correctness on long-lived ports — call it out in the PR).

--- a/plan/issues/1886-linear-backed-uint8array-wasi-io.md
+++ b/plan/issues/1886-linear-backed-uint8array-wasi-io.md
@@ -326,6 +326,20 @@ non-WASI and any escaping `Uint8Array` are byte-identical to today.
 - **Slice D** (optional follow-up) — loop-scoped arena reset for unbounded
   streams.
 
+**Landing plan (revised, esch 2026-06-05):** PR #1 = **Slice A** only (the
+analysis pass, wired behind `ctx.wasi`, with no codegen consumer — emitted
+WASI modules verified byte-identical to baseline via `cmp`). Tech lead approved
+splitting the risky signature-rewrite (Slice C) into its own PR; the same
+isolation logic applies to the codegen wiring (Slice B), so the bump allocator
++ `new`/index/`.length`/zero-copy I/O codegen lands as **PR #2** and the
+interprocedural signature rewrite as **PR #3**. This banks the analysis
+foundation (zero runtime risk) and keeps each codegen change independently
+reviewable + benchmarkable. The allocator design (page-4 arena at
+`LINEAR_U8_ARENA_START = 256 KiB`, a dedicated `$__lin_u8_arena_ptr` bump global
+— NOT the page-0 `$__wasi_bump_ptr`, which aliases string-literal data —
+emitted lazily reusing the #1856 align8 + page-grow idiom) is prototyped and
+typechecks; it ships with PR #2.
+
 Slices A+B+C are the core of this issue; D can be a follow-up if the per-message
 allocation proves to leak on infinite streams (the benchmark sends one large
 message, so A–C suffice to hit the acceptance numbers, but D is needed for

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -961,6 +961,17 @@ export interface CodegenContext {
   wasiPendingSleepMsHelper?: boolean;
   /** Set of node:fs functions used in this compilation unit (both WASI and JS-host fs paths). */
   wasiNodeFsFuncs: Set<string>;
+  /**
+   * #1886 — Linear-safe `Uint8Array` analysis result. Populated (WASI/standalone
+   * only) by `analyzeLinearUint8` as a pre-pass; `undefined` otherwise. Symbols
+   * in `linearUint8.safeBindings` are byte buffers proven to never escape the
+   * GC heap, so codegen backs them by linear memory (a `(ptr,len)` pair) with
+   * zero-copy `fd_read`/`fd_write`. Every consumer is additive — when this is
+   * `undefined` or a binding is absent, the existing GC-vec path is used
+   * unchanged. (Codegen consumers land in later slices; the analysis itself is
+   * side-effect free and safe to run unconditionally behind the WASI gate.)
+   */
+  linearUint8?: import("../linear-uint8-analysis.js").LinearUint8Result;
   /** Whether `node:fs` JS-host imports are permitted (non-WASI target only, #1491). */
   allowFs: boolean;
   /**

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts, forEachChild } from "../ts-api.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { analyzeLinearUint8 } from "./linear-uint8-analysis.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import {
   isBigIntType,
@@ -920,6 +921,11 @@ export function generateModule(
     // WASI target: register linear memory, bump pointer global, and WASI imports
     if (ctx.wasi) {
       registerWasiImports(ctx, ast.sourceFile);
+      // #1886 — pre-pass: classify which `Uint8Array` buffers are pure I/O
+      // (never escape the GC heap) so they can be backed by linear memory with
+      // zero-copy fd_read/fd_write. Side-effect free; codegen consumers are
+      // additive (empty result ⇒ emitted module identical to today).
+      ctx.linearUint8 = analyzeLinearUint8(ast.checker, ast.sourceFile);
     }
 
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()

--- a/src/codegen/linear-uint8-analysis.ts
+++ b/src/codegen/linear-uint8-analysis.ts
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1886 — Linear-safe `Uint8Array` escape/usage analysis.
+ *
+ * A compile-time pre-pass (WASI / standalone only) that classifies each
+ * `Uint8Array` *binding* — a `const`/`let`/`var` initialised from
+ * `new Uint8Array(...)`, or a function **parameter** typed `Uint8Array` — as
+ * **linear-safe** or not.
+ *
+ * A binding is linear-safe iff it is a pure byte-I/O buffer: it never escapes
+ * to a context that needs the WasmGC heap (stored in a struct/array/global,
+ * captured by a closure, returned, compared by identity, iterated, copied via
+ * `.subarray`/`.slice`/`.set`, JSON-stringified, …) and its *only* uses are:
+ *   - element load/store `b[i]` / `b[i] = v`
+ *   - `b.length`
+ *   - `process.stdin.read(b)` / `process.stdin.read(b, off)`
+ *   - `process.stdout.write(b)` / `process.stderr.write(b)`
+ *   - being passed as a call argument to a function whose corresponding
+ *     parameter is *itself* linear-safe (interprocedural threading).
+ *
+ * For such bindings #1886 backs them by **linear memory** (a `(ptr, len)`
+ * pair) instead of a GC vec, so `fd_read`/`fd_write` touch them with zero
+ * GC↔linear copies. When the predicate cannot prove safety, the binding stays
+ * a GC array — today's behaviour, byte-for-byte. The analysis is therefore
+ * deliberately **conservative**: any use it does not explicitly recognise as
+ * safe demotes the binding (and, transitively, any parameter it flows into).
+ *
+ * Output ({@link LinearUint8Result}) is consumed by codegen:
+ *   - `safeBindings` — the locals + params backed by linear memory.
+ *   - `linearParams` — per-function, which parameter indices are linear (so
+ *     the function's wasm signature can be rewritten `Uint8Array → (ptr,len)`
+ *     and every call site lowered consistently).
+ *
+ * This module performs **no** codegen and has no side effects on the module;
+ * it is safe to run unconditionally behind the `--target wasi` gate (see
+ * {@link analyzeLinearUint8} caller in `index.ts`). The codegen consumers are
+ * additive (`if (isLinearSafe(sym)) {…linear…} else {…existing GC…}`), so when
+ * the result set is empty the emitted module is identical to today.
+ */
+import { ts } from "../ts-api.js";
+
+/** Result of the linear-safe `Uint8Array` analysis (frozen before codegen). */
+export interface LinearUint8Result {
+  /**
+   * Symbols of every binding (local variable or parameter) proven linear-safe.
+   * Codegen consults this by `checker.getSymbolAtLocation(idNode)`.
+   */
+  safeBindings: Set<ts.Symbol>;
+  /**
+   * For each function whose signature is linear-rewritten, the set of
+   * parameter indices that are linear-backed. Keyed by the function's own
+   * symbol. Callers use this to lower call arguments to `(ptr, len)` pairs and
+   * to rewrite the callee's wasm param list.
+   */
+  linearParams: Map<ts.Symbol, Set<number>>;
+}
+
+/** A function-like declaration we model in the interprocedural fixpoint. */
+type FnDecl = ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction | ts.MethodDeclaration;
+
+function isFnDecl(node: ts.Node): node is FnDecl {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node)
+  );
+}
+
+/** True when a TS type is exactly `Uint8Array` (not a union, not a view alias). */
+function isUint8ArrayType(checker: ts.TypeChecker, type: ts.Type): boolean {
+  // A bare `Uint8Array` has the `Uint8Array` symbol. Reject unions / `any` /
+  // `unknown` / `ArrayBuffer`-typed and `Uint8Array | ArrayBuffer` (the host
+  // boundary shape) — those are not provably plain byte buffers.
+  if (type.isUnion()) return false;
+  const sym = type.getSymbol() ?? type.aliasSymbol;
+  return sym?.name === "Uint8Array";
+}
+
+function isUint8ArrayNode(checker: ts.TypeChecker, node: ts.Expression): boolean {
+  return isUint8ArrayType(checker, checker.getTypeAtLocation(node));
+}
+
+/** `new Uint8Array(...)` (the constructor target resolves to `Uint8Array`). */
+function isNewUint8Array(expr: ts.Node): expr is ts.NewExpression {
+  return ts.isNewExpression(expr) && ts.isIdentifier(expr.expression) && expr.expression.text === "Uint8Array";
+}
+
+/**
+ * Recognise `process.std{in.read,out.write,err.write}(buf, …)` and return the
+ * argument index that carries the buffer (0 for both), or `-1` if this is not a
+ * std-stream I/O call. We only match the global `process` shape the WASI
+ * lowering supports (`node-process-api.ts`); a local `process` shadow makes
+ * this not match (the conservative path).
+ */
+function ioBufferArgIndex(call: ts.CallExpression): number {
+  const callee = call.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return -1;
+  const method = callee.name.text;
+  const stream = callee.expression;
+  if (!ts.isPropertyAccessExpression(stream)) return -1;
+  const streamName = stream.name.text;
+  const root = stream.expression;
+  if (!(ts.isIdentifier(root) && root.text === "process")) return -1;
+  if (streamName === "stdin" && method === "read") return 0;
+  if ((streamName === "stdout" || streamName === "stderr") && method === "write") return 0;
+  return -1;
+}
+
+/**
+ * Resolve the callee `FnDecl` + symbol of a direct call `f(args)` where `f` is
+ * a plain identifier bound to a user function. Returns `null` for any indirect /
+ * method / unresolved callee (which is conservatively treated as an escape).
+ */
+function resolveDirectCallee(
+  checker: ts.TypeChecker,
+  call: ts.CallExpression,
+): { sym: ts.Symbol; decl: FnDecl } | null {
+  const callee = call.expression;
+  if (!ts.isIdentifier(callee)) return null;
+  const sym = checker.getSymbolAtLocation(callee);
+  if (!sym) return null;
+  const decls = sym.getDeclarations() ?? [];
+  for (const d of decls) {
+    if (isFnDecl(d)) return { sym, decl: d };
+    // `const f = (…) => …` / `const f = function(){}` — the symbol's decl is
+    // the variable; unwrap its initializer.
+    if (ts.isVariableDeclaration(d) && d.initializer && isFnDecl(d.initializer)) {
+      return { sym, decl: d.initializer };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the linear-safe analysis for a WASI source file.
+ *
+ * Algorithm (monotone, terminates — classifications only ever demote):
+ *  1. Collect every candidate binding: `new Uint8Array(...)` variable inits and
+ *     `Uint8Array` parameters of non-exported user functions. Exported
+ *     functions' params are NOT candidates (their ABI is observable).
+ *  2. Seed every candidate as linear-safe.
+ *  3. Fixpoint: walk each function body. A candidate binding/param is demoted
+ *     if it has any disqualifying use, OR is passed to a callee parameter that
+ *     is currently demoted. Repeat until no demotions occur in a full pass.
+ *  4. Freeze: the survivors are the linear-safe set.
+ */
+export function analyzeLinearUint8(checker: ts.TypeChecker, sourceFile: ts.SourceFile): LinearUint8Result {
+  // candidate bindings (locals + params), seeded safe; demote on disqualifying use.
+  const safe = new Set<ts.Symbol>();
+  // function symbol → its FnDecl (for param-index lookup) + whether exported.
+  const fnDecls = new Map<ts.Symbol, FnDecl>();
+  // function symbol → param symbols (index-aligned) that are Uint8Array candidates.
+  const fnParamSyms = new Map<ts.Symbol, (ts.Symbol | undefined)[]>();
+
+  // ---- Pass 1: collect candidates -----------------------------------------
+  const collect = (node: ts.Node): void => {
+    if (isNewUint8Array(node)) {
+      // the binding this `new Uint8Array` initialises (if any) — handled at
+      // the VariableDeclaration so we know the declared symbol.
+    }
+    if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
+      if (isNewUint8Array(node.initializer) || isUint8ArrayNode(checker, node.initializer)) {
+        const sym = checker.getSymbolAtLocation(node.name);
+        // only `new Uint8Array(...)` inits are linear-candidates; an init from
+        // another expression (a returned/aliased array) is left to the escape
+        // checks (it will not be a `new` site we can back linearly).
+        if (sym && isNewUint8Array(node.initializer)) safe.add(sym);
+      }
+    }
+    if (isFnDecl(node)) {
+      const fnSym = fnSymbolOf(checker, node);
+      if (fnSym) {
+        fnDecls.set(fnSym, node);
+        const exported = isExportedFn(node);
+        const paramSyms: (ts.Symbol | undefined)[] = [];
+        for (const p of node.parameters) {
+          let pSym: ts.Symbol | undefined;
+          if (ts.isIdentifier(p.name) && isUint8ArrayNode(checker, p.name)) {
+            pSym = checker.getSymbolAtLocation(p.name);
+            // Exported functions: params are observable ABI — never candidates.
+            if (pSym && !exported && !p.dotDotDotToken) safe.add(pSym);
+          }
+          paramSyms.push(pSym);
+        }
+        fnParamSyms.set(fnSym, paramSyms);
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(sourceFile);
+
+  // ---- Pass 2..N: fixpoint demotion ----------------------------------------
+  // For each candidate symbol, scan all references; a reference in a
+  // disqualifying position demotes it. Iterate until stable (a demotion can
+  // cascade: demoting a param means args flowing into it are re-examined).
+  let changed = true;
+  while (changed) {
+    changed = false;
+    // Walk the whole file once; at every identifier that refers to a candidate
+    // symbol, classify the use. We re-walk on each iteration because parameter
+    // demotions change the safety of call-argument uses.
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node)) {
+        const sym = checker.getSymbolAtLocation(node);
+        if (sym && safe.has(sym) && !isBindingSite(node)) {
+          if (!isAllowedUse(checker, node, safe, fnDecls, fnParamSyms)) {
+            safe.delete(sym);
+            changed = true;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  // ---- Freeze: derive per-function linear param sets -----------------------
+  const linearParams = new Map<ts.Symbol, Set<number>>();
+  for (const [fnSym, paramSyms] of fnParamSyms) {
+    const idxs = new Set<number>();
+    paramSyms.forEach((pSym, i) => {
+      if (pSym && safe.has(pSym)) idxs.add(i);
+    });
+    if (idxs.size > 0) linearParams.set(fnSym, idxs);
+  }
+
+  return { safeBindings: safe, linearParams };
+}
+
+/** The function's own symbol (for declarations and `const f = …` forms). */
+function fnSymbolOf(checker: ts.TypeChecker, node: FnDecl): ts.Symbol | undefined {
+  if (ts.isFunctionDeclaration(node) && node.name) return checker.getSymbolAtLocation(node.name);
+  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) return checker.getSymbolAtLocation(node.name);
+  // function/arrow expression assigned to a variable: the variable's symbol.
+  const parent = node.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+    return checker.getSymbolAtLocation(parent.name);
+  }
+  // named function expression
+  if (ts.isFunctionExpression(node) && node.name) return checker.getSymbolAtLocation(node.name);
+  return undefined;
+}
+
+function isExportedFn(node: FnDecl): boolean {
+  const mods = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  if (mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return true;
+  // `export const f = …`
+  let p: ts.Node | undefined = node.parent;
+  while (p && (ts.isVariableDeclaration(p) || ts.isVariableDeclarationList(p))) p = p.parent;
+  if (p && ts.isVariableStatement(p)) {
+    const sMods = ts.getModifiers(p);
+    if (sMods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return true;
+  }
+  return false;
+}
+
+/** True if this identifier is its own declaration name (not a use). */
+function isBindingSite(id: ts.Identifier): boolean {
+  const p = id.parent;
+  return (
+    (ts.isVariableDeclaration(p) && p.name === id) ||
+    (ts.isParameter(p) && p.name === id) ||
+    (ts.isFunctionDeclaration(p) && p.name === id) ||
+    (ts.isBindingElement(p) && p.name === id)
+  );
+}
+
+/**
+ * Classify a single *use* (identifier reference) of a candidate buffer.
+ * Returns true iff the use is one of the allowed linear-safe forms given the
+ * CURRENT classification of parameters (so a demoted callee param makes a
+ * call-arg use unsafe on the next iteration).
+ */
+function isAllowedUse(
+  checker: ts.TypeChecker,
+  id: ts.Identifier,
+  safe: Set<ts.Symbol>,
+  fnDecls: Map<ts.Symbol, FnDecl>,
+  fnParamSyms: Map<ts.Symbol, (ts.Symbol | undefined)[]>,
+): boolean {
+  const p = id.parent;
+
+  // b[i]  /  b[i] = v   (element access — the buffer is the object, not index)
+  if (ts.isElementAccessExpression(p) && p.expression === id) return true;
+  // (b)[i] grouped — TS folds parens; handle defensively below via parent walk.
+
+  // b.length  (the only allowed property)
+  if (ts.isPropertyAccessExpression(p) && p.expression === id) {
+    return p.name.text === "length";
+  }
+
+  // call argument: either an I/O intrinsic, or a linear-safe callee param.
+  if (ts.isCallExpression(p) && p.expression !== id) {
+    const argIdx = p.arguments.indexOf(id);
+    if (argIdx < 0) return false; // appears in callee position somehow → unsafe
+    // process.std*.{read,write}(buf …)
+    const ioIdx = ioBufferArgIndex(p);
+    if (ioIdx === argIdx) return true;
+    // direct user call → corresponding param must be currently linear-safe.
+    const resolved = resolveDirectCallee(checker, p);
+    if (!resolved) return false;
+    const paramSyms = fnParamSyms.get(resolved.sym);
+    if (!paramSyms) return false;
+    const calleeParamSym = paramSyms[argIdx];
+    return !!(calleeParamSym && safe.has(calleeParamSym));
+  }
+
+  // Parenthesised buffer: `(b)[i]`, `(b).length` — unwrap one paren level.
+  if (ts.isParenthesizedExpression(p)) {
+    // Re-classify the paren as if it were the buffer reference.
+    return isAllowedUse(checker, p as unknown as ts.Identifier, safe, fnDecls, fnParamSyms);
+  }
+
+  // Everything else is a potential escape:
+  //   return b / yield b / b as T / [b] / {x:b} / f.call(b) / obj.m(b) /
+  //   const c = b / b === x / typeof b / spread / for..of / template / etc.
+  return false;
+}

--- a/tests/issue-1886.test.ts
+++ b/tests/issue-1886.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1886 — Linear-safe `Uint8Array` escape/usage analysis (Slice A).
+ *
+ * These tests exercise the analysis in isolation (no codegen): given a TS
+ * source, which `Uint8Array` bindings does it prove linear-safe, and which
+ * does it correctly reject? The analysis must mark every buffer in the
+ * native-messaging host linear-safe (including the ones threaded through
+ * helper-function parameters) and must reject buffers that escape to a
+ * GC-requiring context.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { analyzeLinearUint8 } from "../src/codegen/linear-uint8-analysis.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Compile `src` to a Program in-memory and run the analysis on it. */
+function analyze(src: string): { safeNames: Set<string>; linearParamFns: Map<string, number[]> } {
+  const fileName = "test.ts";
+  const sourceFileObj = ts.createSourceFile(fileName, src, ts.ScriptTarget.ES2022, true);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) =>
+      name === fileName ? sourceFileObj : ts.createSourceFile(name, "", ts.ScriptTarget.ES2022, true),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "",
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (n) => n === fileName || n === "lib.d.ts",
+    readFile: (n) => (n === fileName ? src : ""),
+  };
+  const program = ts.createProgram([fileName], { noLib: true, target: ts.ScriptTarget.ES2022 }, host);
+  const checker = program.getTypeChecker();
+  const sf = program.getSourceFile(fileName)!;
+  const result = analyzeLinearUint8(checker, sf);
+
+  const safeNames = new Set<string>();
+  for (const sym of result.safeBindings) safeNames.add(sym.name);
+  const linearParamFns = new Map<string, number[]>();
+  for (const [fnSym, idxs] of result.linearParams) linearParamFns.set(fnSym.name, [...idxs].sort());
+  return { safeNames, linearParamFns };
+}
+
+describe("#1886 linear-safe Uint8Array analysis", () => {
+  it("marks a plain indexed I/O buffer linear-safe", () => {
+    const { safeNames } = analyze(`
+      declare const process: {
+        stdin: { read(b: Uint8Array, off?: number): number };
+        stdout: { write(b: Uint8Array): void };
+      };
+      export function main(): void {
+        const buf = new Uint8Array(16);
+        process.stdin.read(buf, 0);
+        let x = buf[0];
+        buf[1] = 42;
+        const n = buf.length;
+        process.stdout.write(buf);
+      }
+    `);
+    expect(safeNames.has("buf")).toBe(true);
+  });
+
+  it("rejects a buffer stored into an object (escapes to GC)", () => {
+    const { safeNames } = analyze(`
+      export function main(): void {
+        const buf = new Uint8Array(16);
+        const holder: { b: Uint8Array } = { b: buf };
+        buf[0] = 1;
+      }
+    `);
+    expect(safeNames.has("buf")).toBe(false);
+  });
+
+  it("rejects a buffer returned from a function", () => {
+    const { safeNames } = analyze(`
+      function make(): Uint8Array {
+        const buf = new Uint8Array(16);
+        buf[0] = 1;
+        return buf;
+      }
+      export function main(): void { make(); }
+    `);
+    expect(safeNames.has("buf")).toBe(false);
+  });
+
+  it("rejects a buffer aliased then escaped", () => {
+    const { safeNames } = analyze(`
+      declare const sink: { keep(x: Uint8Array): void };
+      export function main(): void {
+        const buf = new Uint8Array(16);
+        buf[0] = 1;
+        const alias = buf;
+        sink.keep(alias);
+      }
+    `);
+    // 'buf' is referenced by `const alias = buf` — a copy-into-binding escape.
+    expect(safeNames.has("buf")).toBe(false);
+  });
+
+  it("rejects a buffer used via .subarray / .slice", () => {
+    const { safeNames } = analyze(`
+      export function main(): void {
+        const buf = new Uint8Array(16);
+        buf[0] = 1;
+        const part = buf.subarray(0, 4);
+      }
+    `);
+    expect(safeNames.has("buf")).toBe(false);
+  });
+
+  it("threads linear-safety through a helper parameter (interprocedural)", () => {
+    const { safeNames, linearParamFns } = analyze(`
+      declare const process: {
+        stdin: { read(b: Uint8Array, off?: number): number };
+      };
+      function readExact(buf: Uint8Array, n: number): boolean {
+        let got = 0;
+        while (got < n) {
+          const r = process.stdin.read(buf, got);
+          if (r <= 0) return false;
+          got = got + r;
+        }
+        return true;
+      }
+      export function main(): void {
+        const header = new Uint8Array(4);
+        readExact(header, 4);
+      }
+    `);
+    expect(safeNames.has("header")).toBe(true);
+    expect(safeNames.has("buf")).toBe(true); // the helper param
+    expect(linearParamFns.get("readExact")).toEqual([0]);
+  });
+
+  it("demotes the caller buffer when the helper param escapes", () => {
+    const { safeNames } = analyze(`
+      declare const sink: { keep(x: Uint8Array): void };
+      function leak(buf: Uint8Array): void { sink.keep(buf); }
+      export function main(): void {
+        const header = new Uint8Array(4);
+        leak(header);
+      }
+    `);
+    // 'buf' escapes (passed to host import) → demoted; the arg into it
+    // (`header`) is then a pass-to-non-linear-param → also demoted.
+    expect(safeNames.has("buf")).toBe(false);
+    expect(safeNames.has("header")).toBe(false);
+  });
+
+  it("does not make an exported function's Uint8Array param linear (observable ABI)", () => {
+    const { safeNames, linearParamFns } = analyze(`
+      declare const process: { stdout: { write(b: Uint8Array): void } };
+      export function writeIt(buf: Uint8Array): void {
+        process.stdout.write(buf);
+      }
+    `);
+    expect(safeNames.has("buf")).toBe(false);
+    expect(linearParamFns.has("writeIt")).toBe(false);
+  });
+
+  it("classifies every buffer in the native-messaging host as linear-safe", () => {
+    const nmPath = resolve(here, "../examples/native-messaging/nm_js2wasm.ts");
+    const src = readFileSync(nmPath, "utf-8");
+    const { safeNames, linearParamFns } = analyze(src);
+    // Buffers declared in main + the per-frame temporaries.
+    for (const name of ["header", "one", "buf", "small", "tmp", "frame", "src"]) {
+      expect(safeNames.has(name), `expected '${name}' linear-safe`).toBe(true);
+    }
+    // Helper params that carry buffers must be linear-rewritten.
+    expect(linearParamFns.get("readExact")).toContain(0);
+    expect(linearParamFns.get("readAt")).toContain(0);
+    expect(linearParamFns.get("decodeLength")).toContain(0);
+    expect(linearParamFns.get("emitRun")).toContain(0);
+  });
+});


### PR DESCRIPTION
## #1886 Slice A — linear-safe `Uint8Array` escape/usage analysis

Foundation for the linear-backed `Uint8Array` optimization (#1886). This PR
lands **only the analysis pass**, wired behind the `--target wasi` gate with
**no codegen consumer yet** — so emitted WASI modules are byte-identical to
baseline (verified via `cmp` on the native-messaging host). The bump allocator
+ codegen wiring (Slice B) and the interprocedural signature rewrite (Slice C)
follow as separate PRs, per tech-lead guidance to isolate the codegen risk.

### What it does
`src/codegen/linear-uint8-analysis.ts` — an interprocedural fixpoint that
classifies each `Uint8Array` binding (a `new Uint8Array(...)` local, or a
non-exported function's `Uint8Array` parameter) as **linear-safe** iff its only
uses are `b[i]` / `b[i] = v`, `b.length`, `process.std*.{read,write}`, or being
threaded into a callee parameter that is itself linear-safe. Any other use
(stored in a struct/array/global, returned, captured, aliased, `.subarray`/
`.slice`, an exported-fn param, etc.) demotes it — and the demotion cascades to
arguments flowing into demoted params. Conservative by construction: any
uncertainty ⇒ GC.

Result is stored on `ctx.linearUint8` (`{ safeBindings, linearParams }`).

### Why it's safe to land now
- Runs only when `ctx.wasi`.
- **Side-effect free** — no module mutation, no codegen branch consumes it yet.
- Verified: WASI compile of `examples/native-messaging/nm_js2wasm.ts` is
  `cmp`-equal to the pre-change baseline binary.
- `tsc` clean; `tests/wasi.test.ts` 24/24 pass (no regression from the pre-pass).

### Tests
`tests/issue-1886.test.ts` (9 cases): safe vs escaping bindings (object-store /
return / alias / `.subarray`), interprocedural threading + demotion cascade,
exported-ABI exclusion, and the full native-messaging host (asserts all 7
buffers + the 4 helper params `readExact`/`readAt`/`decodeLength`/`emitRun` are
classified linear-safe).

### Context / measured framing
The implementation plan in `plan/issues/1886-linear-backed-uint8array-wasi-io.md`
has the measured cost decomposition (64 MiB, wasmtime 45): baseline GC host
0.50 s / 37 MB; the two GC↔linear I/O copies are ~0.27 s of that (write-copy
alone measured 0.15 s) — the dominant removable cost. Target after B+C:
~0.15–0.25 s at flat ~24–31 MB (AS speed, beating AS on memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)