### PR TITLE
feat(#1472 Phase C): native __extern_is_undefined for standalone

### DIFF
--- a/plan/issues/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/1472-no-js-host-object-property-ops.md
@@ -940,3 +940,61 @@ helpers (the externref result loses its static type), and `Array.prototype.
 filter.call(arrayLike, …)` emits a module with independent standalone gaps. The
 helpers build correct structures (verified via the typed for-of consumer); the
 element-readback routing belongs with the Blocker A receiver-dispatch slice.
+
+## Phase C Slice — `__extern_is_undefined` native (sd-1472c, 2026-06-05)
+
+Branch `issue-1472c-is-undefined` off origin/main. Routes the single largest
+remaining standalone-refusal helper (`__extern_is_undefined`, ~6.6k tests in the
+live standalone run) to a native Wasm function instead of the Phase A refusal.
+
+### Root cause / design
+`__extern_is_undefined` is the undefinedness predicate behind every
+default-parameter / destructuring-default fire (`function-body.ts`,
+`closures.ts`, `class-bodies.ts`, `statements/destructuring.ts`) and the
+`x === undefined` / `x == null` comparisons over an externref value
+(`binary-ops.ts`). The JS-host import is `(v) => (v === undefined ? 1 : 0)` —
+it distinguishes JS `undefined` (a *defined* externref minted by
+`__get_undefined`) from `null`. Standalone has **no** `__get_undefined`:
+`emitUndefined` (late-imports.ts) falls back to `ref.null.extern`, so the
+runtime represents BOTH `undefined` and `null` as the null externref. The
+standalone `__typeof_undefined` helper (`addUnionImportsAsNativeFuncs` in
+index.ts) already encodes exactly this conflation as a bare `ref.is_null`.
+
+So the correct native `__extern_is_undefined` under standalone is the **same**
+`ref.is_null` — internally consistent with `__typeof_undefined`, and exactly
+the predicate the callers want: a missing/omitted argument arrives as the null
+externref (the same value `undefined` lowers to), so `ref.is_null` applies the
+binding default in precisely the "value is undefined" cases (§14.3.3
+Keyed/Iterator BindingInitialization defaults fire when the bound value is
+`undefined`).
+
+### What landed
+- `src/codegen/object-runtime.ts`: registers `__extern_is_undefined(externref)
+  -> i32` as a DEFINED function (`local.get 0; ref.is_null`) and adds it to
+  `OBJECT_RUNTIME_HELPER_NAMES` so `ensureLateImport` auto-routes it through
+  `ensureObjectRuntime` under `ctx.standalone` (the routing check sits *before*
+  the Phase A `__extern_*` refuse gate). No imports added ⇒ no index shift.
+- `tests/issue-1472.test.ts`: replaced the now-stale "destructuring defaults
+  *refuse* `__extern_is_undefined`" Phase A test with two Phase C
+  instantiate-and-run tests — a destructuring default `[x = 7, y = 9]` over
+  `[5]` (→ 14) and a default-valued object parameter `f()` (→ 42). Both leak
+  **zero** `env::__extern_is_undefined` / object host imports and run under
+  Node's WasmGC engine with empty imports.
+
+### Scoping note (deliberately NOT in this slice)
+`x === undefined` where `x` is an **optional `number`** param does NOT route
+through this helper in EITHER mode (gc or standalone) — the param lowers to f64
+with a NaN sentinel, so the comparison resolves on the f64 side (verified: gc
+mode never binds `__extern_is_undefined` for that shape, and returns the same
+result). That f64/NaN optional-number representation is a separate pre-existing
+limitation, independent of this slice.
+
+### Pre-existing failure NOT touched by this slice
+The "Phase B Slice 3: Object.assign … (no host array imports)" test in
+`tests/issue-1472.test.ts` **already fails on clean origin/main HEAD**
+(confirmed by stashing all edits): the `Object.assign(t, ...sources)`
+computed-key path still builds the variadic sources list with the JS-host
+`__js_array_new`/`__js_array_push` under standalone instead of the native
+`$ObjVec` builders. This is a regression that predates this branch and belongs
+to a separate Object.assign call-site-retargeting follow-up — left untouched
+here to keep this slice's regression surface clean.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -2000,6 +2000,32 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   emitSetFlags("__object_seal", OBJ_FLAG_NONEXTENSIBLE | OBJ_FLAG_SEALED);
   emitSetFlags("__object_freeze", OBJ_FLAG_NONEXTENSIBLE | OBJ_FLAG_SEALED | OBJ_FLAG_FROZEN);
 
+  // ── __extern_is_undefined(externref) -> i32 (#1472 Phase C) ───────────────
+  //
+  // The JS-host import is `(v) => (v === undefined ? 1 : 0)` — it distinguishes
+  // JS `undefined` (a defined externref produced by `__get_undefined`) from
+  // `null` (a null reference). Standalone has no `__get_undefined`: `emitUndefined`
+  // falls back to `ref.null.extern`, so the runtime represents BOTH `undefined`
+  // and `null` as the null externref. The standalone `__typeof_undefined` helper
+  // (addUnionImportsAsNativeFuncs) already encodes this same conflation as a bare
+  // `ref.is_null`. We mirror it here so the two are internally consistent.
+  //
+  // This is exactly the predicate every caller wants in standalone: the
+  // default-parameter / destructuring-default paths (function-body.ts,
+  // closures.ts, class-bodies.ts, destructuring.ts) and `x === undefined`
+  // (binary-ops.ts) use `__extern_is_undefined` to decide whether to apply a
+  // default — and a missing/omitted argument arrives as the null externref, the
+  // same value `undefined` lowers to. So `ref.is_null` applies the default in
+  // precisely the "value is undefined" cases, matching §14.3.3 (keyed/iterator
+  // binding initialization defaults fire when the bound value is `undefined`).
+  registerNative(
+    "__extern_is_undefined",
+    [{ kind: "externref" }],
+    [{ kind: "i32" }],
+    [],
+    [{ op: "local.get", index: 0 }, { op: "ref.is_null" }],
+  );
+
   // Silence "declared but never used" for ValType aliases reserved for the
   // values/entries/assign slices that stack on this foundation.
   void objVecRef;
@@ -2066,4 +2092,9 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   // descriptor). Accessor descriptors stay refused (see the __defineProperty_value
   // note in ensureObjectRuntime).
   "__defineProperty_value",
+  // #1472 Phase C — `x === undefined` / default-parameter / destructuring-default
+  // undefinedness check. Native impl is `ref.is_null` (standalone conflates
+  // undefined and null, same as __typeof_undefined). This is the single largest
+  // remaining standalone-refusal helper (~6.6k tests).
+  "__extern_is_undefined",
 ]);

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -459,21 +459,50 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
     expect(wat).toMatch(/\(func \$__extern_has_idx\b/);
   });
 
-  it("destructuring defaults refuse __extern_is_undefined instead of leaking the host import", async () => {
-    const r = await compile(
-      `
-        export function pick(a: any[]): any {
-          const [x = 1] = a;
-          return x;
+  it("Phase C: __extern_is_undefined routes native (ref.is_null) — destructuring default compiles + runs", async () => {
+    // #1472 Phase C — the undefinedness predicate is the single largest remaining
+    // standalone-refusal helper (~6.6k tests). It now lowers to the native
+    // `__extern_is_undefined` (a bare `ref.is_null`), matching standalone's
+    // undefined≡null conflation (same as `__typeof_undefined`). A destructuring
+    // default `[x = 1]` over an empty array binds the default (the slot is
+    // missing ⇒ undefined ⇒ ref.is_null true); a provided element is kept.
+    const source = `
+        export function run(): number {
+          function pick(a: number[]): number {
+            const [x = 7, y = 9] = a;
+            return x + y;
+          }
+          // a=[5]: x=5 (provided), y=9 (default) → 14
+          return pick([5]);
         }
-      `,
-      { target: "standalone" },
-    );
-    expect(r.success).toBe(false);
-    const joined = r.errors.map((e) => e.message).join("\n");
-    expect(joined).toMatch(/__extern_is_undefined/);
-    expect(joined).toMatch(/#1472 Phase B/);
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // The helper is provided natively — no env::__extern_is_undefined host import.
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__extern_is_undefined")).toBe(false);
     assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(14);
+  });
+
+  it("Phase C: default parameter applies when arg omitted under standalone (runs native)", async () => {
+    // Default-parameter initialization (§9.2.1 / §10.2.11 IteratorBindingInitialization)
+    // checks the bound value via __extern_is_undefined for externref-typed params.
+    // A default-valued object param exercises the externref path end-to-end.
+    const source = `
+        export function run(): number {
+          function f(o: { a: number } = { a: 41 }): number { return o.a + 1; }
+          return f();   // omitted ⇒ default {a:41} ⇒ 42
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__extern_is_undefined")).toBe(false);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(42);
   });
 
   it("new Proxy fails explicitly in standalone mode without leaking proxy host imports", async () => {


### PR DESCRIPTION
## #1472 Phase C — standalone `__extern_is_undefined`

Routes the **single largest remaining standalone object/property refusal helper** (`__extern_is_undefined`, ~6.6k tests in the live standalone run) to a Wasm-native function instead of the Phase A refuse-and-document gate.

### Root cause
`__extern_is_undefined` is the undefinedness predicate behind every default-parameter / destructuring-default fire and the `x === undefined` / `x == null` comparison over an externref value. The JS-host import is `(v) => (v === undefined ? 1 : 0)` — it distinguishes JS `undefined` (a *defined* externref from `__get_undefined`) from `null`.

Standalone has **no** `__get_undefined`: `emitUndefined` falls back to `ref.null.extern`, so the runtime represents BOTH `undefined` and `null` as the null externref. The standalone `__typeof_undefined` helper already encodes this conflation as a bare `ref.is_null`. The correct native `__extern_is_undefined` is therefore the same `ref.is_null` — internally consistent, and exactly the predicate every caller wants: a missing/omitted argument arrives as the null externref (the value `undefined` lowers to), so `ref.is_null` applies the binding default in precisely the value-is-undefined cases (ECMA-262 §14.3.3).

### What changed
- **`src/codegen/object-runtime.ts`**: register `__extern_is_undefined(externref) -> i32` as a DEFINED func (`local.get 0; ref.is_null`) + add to `OBJECT_RUNTIME_HELPER_NAMES` so `ensureLateImport` auto-routes it under `ctx.standalone` (before the Phase A `__extern_*` refuse gate). No imports added ⇒ no index shift (same invariant as the prior Phase B slices).
- **`tests/issue-1472.test.ts`**: replace the now-stale Phase-A "refuse" test with two Phase C instantiate-and-run tests (destructuring default → 14; default object param → 42), each asserting zero `env::__extern_is_undefined` / object host imports and running under Node's WasmGC engine with empty imports.

GC/host path is **unchanged** — the new func is only reached under `ctx.standalone`.

### Validation
- `npx tsc --noEmit` clean; prettier + biome clean (via lint-staged).
- New Phase C tests green; end-to-end probe confirms default-param / destructuring-default / default-object-param compile native + run correctly with zero leaked imports.

### Out of scope (documented in issue file)
- `x === undefined` over an **optional `number`** param resolves on the f64/NaN side in BOTH gc and standalone (pre-existing, unrelated).
- The "Phase B Slice 3: Object.assign (no host array imports)" test **already fails on clean origin/main** (the Object.assign computed-key path still builds the sources list with `__js_array_new`/`__js_array_push` under standalone) — a separate pre-existing regression, left untouched here to keep this slice's surface clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)