### PR TITLE
feat(#1472 Phase C): native prototype-chain ops for standalone

### DIFF
--- a/plan/issues/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/1472-no-js-host-object-property-ops.md
@@ -940,3 +940,41 @@ helpers (the externref result loses its static type), and `Array.prototype.
 filter.call(arrayLike, …)` emits a module with independent standalone gaps. The
 helpers build correct structures (verified via the typed for-of consumer); the
 element-readback routing belongs with the Blocker A receiver-dispatch slice.
+
+## Phase C Slice — prototype-chain ops (sd-1472c, 2026-06-05)
+
+Branch `issue-1472c-proto` off origin/main. Native getPrototypeOf / Object.create
+/ isPrototypeOf over the existing `$Object.$proto` field (field 0). The runtime
+already *walks* the chain (`__extern_get`/`__extern_has`); these expose it.
+
+### What landed (`src/codegen/object-runtime.ts`)
+- `__getPrototypeOf(externref) -> externref` (ES §20.1.2.12): `$Object` →
+  `extern.convert_any($proto)` (may be null); non-`$Object` → null.
+- `__object_create(externref proto) -> externref` (ES §20.1.2.2): fresh empty
+  `$Object` (new `$PropMap(INITIAL_CAP)`, count/tombstones/flags = 0) with
+  `$proto` = (proto is `$Object` ? cast : null). `Object.create(null)` passes a
+  null externref ⇒ `$proto` stays null. (The descriptors 2nd arg is materialised
+  separately by the existing call site.)
+- `__isPrototypeOf(externref obj, externref candidate) -> i32` (ES §20.1.3.3):
+  walk `candidate.$proto` and `ref.eq` each level against obj; 1 if found, else 0.
+- All three added to `OBJECT_RUNTIME_HELPER_NAMES` (routed under `ctx.standalone`
+  before the Phase A `__getPrototypeOf`/`__isPrototypeOf` refuse gate). No imports
+  added ⇒ no index shift.
+
+### Proven (`tests/issue-1472.test.ts`, instantiate-and-run, empty imports)
+- `Object.create(proto)` + `Object.getPrototypeOf(o) === proto` + inherited read
+  through the chain → 8; zero `env::__getPrototypeOf`/`__object_create` imports.
+- `Object.getPrototypeOf({})` → null (bare open object has null `$proto` in
+  standalone — no built-in Object.prototype graph) → 5.
+
+### Deliberately NOT in this slice
+- **`Object.setPrototypeOf(o, p)`** is *stubbed* at its call site (`calls.ts`
+  ~L3857) in ALL modes — it drops the proto arg and returns obj, so a native
+  `__object_setPrototypeOf` would be dead code. Wiring the `$proto` write needs a
+  dual-mode change to that stubbed call site (a separate follow-up).
+- **`obj.isPrototypeOf(x)`** (the bare method-call form) routes through
+  `__proto_method_call` (open-`any` method dispatch), still refused — the native
+  `__isPrototypeOf` func is in place for when that dispatch lands.
+- Primitive receivers (`getPrototypeOf(5)` → Number.prototype) return null —
+  acceptable, since standalone ships no built-in prototype graph (the broader
+  `__get_builtin` architectural item).

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1094,6 +1094,182 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   }
   const objVecPushIdx = ctx.funcMap.get("__objvec_push")!;
 
+  // ── Prototype-chain ops (#1472 Phase C) ──────────────────────────────────
+  //
+  // The $Object struct already carries the [[Prototype]] in field 0 ($proto,
+  // ref null $Object) and __extern_get/__extern_has already walk it. These four
+  // helpers expose the chain directly. All operate purely on the $proto field;
+  // non-$Object / null receivers return a lenient null/0 (never throw into
+  // Wasm — the receiver-dispatch / ToObject checks live at the call site).
+
+  // __getPrototypeOf(externref) -> externref (ES §20.1.2.12):
+  //   $Object → extern.convert_any($proto) (may be null); non-$Object → null.
+  {
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: objectTypeIdx },
+          { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 0 },
+          { op: "extern.convert_any" },
+        ],
+        else: [{ op: "ref.null.extern" }],
+      },
+    ];
+    registerNative(
+      "__getPrototypeOf",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+      [{ name: "any", type: { kind: "anyref" } }],
+      body,
+    );
+  }
+
+  // __object_create(externref proto) -> externref (ES §20.1.2.2):
+  //   fresh empty $Object with $proto = (proto is $Object ? proto : null).
+  //   Object.create(null) passes a null externref → $proto stays null.
+  //   (The descriptors second arg is materialised separately by the call site.)
+  {
+    const body: Instr[] = [
+      // props = new $PropMap(INITIAL_CAP) (all null)
+      { op: "ref.null", typeIdx: propEntryTypeIdx },
+      { op: "i32.const", value: INITIAL_CAP },
+      { op: "array.new", typeIdx: propMapTypeIdx },
+      { op: "local.set", index: 2 },
+      // proto = (any.convert_extern(arg) is $Object ? cast : null)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: objRefNull },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: objectTypeIdx },
+        ],
+        else: [{ op: "ref.null", typeIdx: objectTypeIdx }],
+      },
+      // struct.new $Object {proto, props, count=0, tombstones=0, flags=0}
+      { op: "local.get", index: 2 },
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "struct.new", typeIdx: objectTypeIdx },
+      { op: "extern.convert_any" },
+    ];
+    registerNative(
+      "__object_create",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "props", type: propMapRef },
+      ],
+      body,
+    );
+  }
+
+  // NOTE: `Object.setPrototypeOf(o, p)` is NOT wired to a native helper here —
+  // the call site (calls.ts ~L3857) currently *stubs* it in ALL modes (drops the
+  // proto arg, returns obj), so a native `__object_setPrototypeOf` would be dead
+  // code. Wiring the mutation (write `$proto`) requires changing that stubbed
+  // call site under a dual-mode gate, which is a separate follow-up slice.
+
+  // __isPrototypeOf(externref obj, externref candidate) -> i32 (ES §20.1.3.3):
+  //   1 iff obj appears in candidate's prototype chain. Walk candidate.$proto
+  //   and ref.eq each level against obj. Non-$Object obj/candidate → 0.
+  //
+  // params: 0=obj(externref) 1=candidate(externref)
+  // locals: 2=target(ref null $Object) 3=cur(ref null $Object) 4=any(anyref)
+  {
+    const body: Instr[] = [
+      // target = (obj is $Object ? cast : null); if null → 0
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 4 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 4 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 2 },
+      // cur = (candidate is $Object ? cast : null)
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 4 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: objRefNull },
+        then: [
+          { op: "local.get", index: 4 },
+          { op: "ref.cast", typeIdx: objectTypeIdx },
+        ],
+        else: [{ op: "ref.null", typeIdx: objectTypeIdx }],
+      },
+      { op: "local.set", index: 3 },
+      // walk: cur = cur.$proto ; if cur == null → 0 ; if cur === target → 1
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if cur == null break (candidate had no [[Prototype]])
+              { op: "local.get", index: 3 },
+              { op: "ref.is_null" },
+              { op: "br_if", depth: 1 },
+              // cur = cur.$proto
+              { op: "local.get", index: 3 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 0 },
+              { op: "local.set", index: 3 },
+              // if cur == null break (reached end of chain)
+              { op: "local.get", index: 3 },
+              { op: "ref.is_null" },
+              { op: "br_if", depth: 1 },
+              // if ref.eq(cur, target) → 1
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: 2 },
+              { op: "ref.eq" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+              },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "i32.const", value: 0 },
+    ];
+    registerNative(
+      "__isPrototypeOf",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      [
+        { name: "target", type: objRefNull },
+        { name: "cur", type: objRefNull },
+        { name: "any", type: { kind: "anyref" } },
+      ],
+      body,
+    );
+  }
+
   // ── __object_keys(externref obj) -> externref ────────────────────────────
   //
   // ES §20.1.2.18 — own enumerable string keys, insertion-order-ish (we walk
@@ -2066,4 +2242,10 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   // descriptor). Accessor descriptors stay refused (see the __defineProperty_value
   // note in ensureObjectRuntime).
   "__defineProperty_value",
+  // #1472 Phase C — prototype-chain ops over $Object.$proto (field 0):
+  // getPrototypeOf / Object.create / isPrototypeOf. (setPrototypeOf is stubbed at
+  // its call site in all modes, so it is intentionally NOT routed here.)
+  "__getPrototypeOf",
+  "__object_create",
+  "__isPrototypeOf",
 ]);

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -459,6 +459,53 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
     expect(wat).toMatch(/\(func \$__extern_has_idx\b/);
   });
 
+  it("Phase C: Object.create + getPrototypeOf round-trip native over $Object.$proto", async () => {
+    // #1472 Phase C — prototype-chain ops over $Object.$proto (field 0).
+    // Object.create(proto) builds a fresh $Object whose $proto is `proto`;
+    // Object.getPrototypeOf reads it back. The reified prototype still resolves
+    // inherited properties through __extern_get's existing proto-walk. Both
+    // helpers are native; zero object host imports leak.
+    const source = `
+        export function run(): number {
+          const proto: any = {};
+          const kt = "tag";
+          proto[kt] = 7;
+          const o: any = Object.create(proto);
+          const p: any = Object.getPrototypeOf(o);
+          // p === proto identity + inherited read via the chain → 1 + 7 = 8
+          return (p === proto ? 1 : 0) + (p[kt] as number);
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__getPrototypeOf")).toBe(false);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__object_create")).toBe(false);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(8);
+  });
+
+  it("Phase C: getPrototypeOf of a bare open object yields the null prototype", async () => {
+    // A bare `{}` open object has a null $proto in standalone (no built-in
+    // Object.prototype graph). Object.getPrototypeOf returns null → 5.
+    const source = `
+        export function run(): number {
+          const o: any = {};
+          o["x"] = 1;
+          const p: any = Object.getPrototypeOf(o);
+          return p === null ? 5 : 0;
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__getPrototypeOf")).toBe(false);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(5);
+  });
+
   it("destructuring defaults refuse __extern_is_undefined instead of leaking the host import", async () => {
     const r = await compile(
       `


### PR DESCRIPTION
## #1472 Phase C — standalone prototype-chain ops

Native `Object.getPrototypeOf` / `Object.create` / `isPrototypeOf` over the existing `$Object.$proto` field (field 0), eliminating those standalone refusals. The `$Object` runtime already *walks* the chain (`__extern_get` / `__extern_has`); these helpers expose it directly.

### What changed (`src/codegen/object-runtime.ts`)
- **`__getPrototypeOf(externref) -> externref`** (ES §20.1.2.12): `$Object` → `extern.convert_any($proto)` (may be null); non-`$Object` → null.
- **`__object_create(externref proto) -> externref`** (ES §20.1.2.2): fresh empty `$Object` (`$PropMap(INITIAL_CAP)`, count/tombstones/flags = 0) with `$proto` = (proto is `$Object` ? cast : null). `Object.create(null)` → null `$proto`. The descriptors 2nd arg is materialised separately by the existing call site.
- **`__isPrototypeOf(externref obj, externref candidate) -> i32`** (ES §20.1.3.3): walk `candidate.$proto`, `ref.eq` each level against obj.
- All three added to `OBJECT_RUNTIME_HELPER_NAMES` (routed under `ctx.standalone` before the Phase A refuse gate). No imports added ⇒ no index shift.

### Validation
- 2 new instantiate-and-run tests in `tests/issue-1472.test.ts` (empty imports, Node WasmGC): `Object.create(proto)` + `getPrototypeOf(o) === proto` + inherited read through the chain → 8; `getPrototypeOf({})` → null (bare open object has null `$proto` in standalone) → 5. Zero `env::__getPrototypeOf` / `__object_create` imports.
- `npx tsc --noEmit` clean; prettier + biome clean (via lint-staged). GC/host path unchanged (`ctx.standalone`-gated).

### Out of scope
- `Object.setPrototypeOf(o, p)` is *stubbed* at its call site (`calls.ts` ~L3857) in ALL modes (drops proto, returns obj) — a native helper would be dead code; wiring the `$proto` write needs a dual-mode change to that stub (separate follow-up).
- `obj.isPrototypeOf(x)` method-call form routes through `__proto_method_call` (open-`any` method dispatch), still refused — the native func is in place for when that dispatch lands.
- Primitive receivers (`getPrototypeOf(5)` → Number.prototype) return null — standalone ships no built-in prototype graph (the broader `__get_builtin` architectural item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)