### PR TITLE
fix(#1836): standalone exponential Number→String in toString() (§6.1.6.1.20)

### DIFF
--- a/plan/issues/1836-standalone-number-string-conformance.md
+++ b/plan/issues/1836-standalone-number-string-conformance.md
@@ -57,3 +57,26 @@ Tests: `tests/issue-1836.test.ts` (8 tests). No regression in
 - whitespace set misses U+FEFF, U+2028/2029, most Zs — `parse-number-native.ts:61`. §19.2.4/.5.
 - `+"12abc"` ToNumber(String) — VERIFIED already returns NaN on current main; appears fixed.
 
+### Slice — DONE: exponential Number→String in toString() (§6.1.6.1.20)
+`emitToString` (`number_toString`, `src/codegen/number-format-native.ts`) gained
+an exponential-notation regime. A guard right after the non-finite prologue routes
+`|x| >= 1e21 || (0 < |x| < 1e-6)` — exactly where V8 switches to `d[.ddd]e±N` — to
+a new `emitExponential` helper. The mantissa is normalised into [1,10) by iterative
+×/÷10 while tracking the decimal exponent (no `log10`; Wasm has none), biased by half
+a unit in the last emitted place for round-half-up, then 15 significant digits are
+emitted (the safe double-precision floor — more exposes binary-representation noise),
+trailing zeros and a bare `.` trimmed, followed by `e`, the sign, and the exponent
+magnitude rendered MSB-first via a hundreds/tens/ones decomposition (no reverse pass,
+so the write cursor is never corrupted). Three new locals added to `number_toString`
+(`exp` i32, `m` f64, `sd` i32).
+- `(1e21).toString()` → `"1e+21"` (was a 22-digit integer); `(1e-7)` → `"1e-7"` (was `"0"`)
+- `(1.5e-7)`/`(5e-7)`/`(1.234e-10)`/`(6.022e23)`/`(1.602e-19)` bit-exact with V8
+- round-half-up: `(1.1e-7)`→`"1.1e-7"`, `(9.5e-8)`→`"9.5e-8"` (not the `…9999…` truncation)
+- negatives, multi-digit exponents (`1e100`/`1e308`/`1e-100`) correct
+- no regression: `(1e-6)`→`"0.000001"`, `9.999e20`→long integer, ordinary ints/fractions unchanged
+Tests: `tests/issue-1836-exp.test.ts` (7 tests). No regression in
+`tests/issue-1335-standalone.test.ts` (8) / `tests/issue-49-*` (7) / `tests/issue-1836.test.ts` (8).
+Residual: bit-perfect shortest-round-trip (Grisu/Ryū) for 16-17-digit extremes at the
+double-range boundaries (max-double `1.797…e308`, denormals ~`1e-308`) — these print a
+last-digit-rounded approximation, not the V8 shortest string. That is #1335 Phase 2.
+

--- a/src/codegen/number-format-native.ts
+++ b/src/codegen/number-format-native.ts
@@ -400,6 +400,359 @@ export function emitNativeNumberFormat(ctx: CodegenContext, which: Set<string>):
 }
 
 /**
+ * #1836 — emit the §6.1.6.1.20 exponential-notation form `d[.ddd…]e±N` for a
+ * positive finite `abs` (the caller has already written any leading '-' decision
+ * to L_NEG and guarded `abs > 0`). Pure Wasm, no log10 (Wasm has none): the
+ * mantissa is normalised into [1,10) by iterative ×/÷10 while tracking the
+ * decimal exponent, then up to `SIG_DIGITS` significant digits are emitted
+ * (trailing zeros trimmed, the '.' dropped if none remain), followed by 'e', the
+ * exponent sign, and the exponent's decimal digits.
+ *
+ * The exponent magnitude is at most 3 decimal digits (|exp| <= 308 for a finite
+ * f64), so its digits are emitted MSB-first via a hundreds/tens/ones decomposition
+ * with leading-zero suppression — no reverse pass, so the buffer write cursor
+ * `L_POS` is never used as a shrinking high pointer.
+ *
+ * This is the bounded slice: it fixes the two concrete failures ((1e21) lacked
+ * 'e', (1e-7) collapsed to "0") and the wrong-output class for the exponential
+ * regime. Bit-perfect shortest-round-trip (Ryū/Grisu) remains #1335 Phase 2.
+ *
+ * Locals consumed: L_ABS (f64, in), L_NEG (i32, in), L_BUF (i16[]) / L_POS (i32)
+ * the write cursor, L_M (f64) normalised mantissa, L_EXP (i32) decimal exponent,
+ * L_SD (i32) significant-digit counter, L_DIGIT (f64) digit scratch, L_TMP (i32)
+ * exponent-magnitude scratch.
+ */
+function emitExponential(
+  strDataTypeIdx: number,
+  L: {
+    L_ABS: number;
+    L_NEG: number;
+    L_BUF: number;
+    L_POS: number;
+    L_EXP: number;
+    L_M: number;
+    L_SD: number;
+    L_DIGIT: number;
+    L_TMP: number; // exponent-magnitude scratch (i32)
+    finalizeIdx: number;
+  },
+): Instr[] {
+  // 15 significant digits is the safe precision floor for an IEEE-754 double
+  // (~15.95 decimal digits). Emitting more exposes the binary representation's
+  // noise (e.g. 9.5e-8 → 9.500000000000001e-8); 15 + round-half-up keeps the
+  // common exponential-regime values bit-exact with V8. Shortest-round-trip
+  // (Grisu/Ryū, which would also nail 16-17-digit extremes) is #1335 Phase 2.
+  const SIG_DIGITS = 15; // significant digits to emit (incl. the leading one)
+  // Half of the unit in the last emitted place, applied to the normalised
+  // mantissa in [1,10) before truncation so the final digit is rounded, not
+  // floored: 0.5 × 10^-(SIG_DIGITS-1).
+  const ROUND_BIAS = 0.5 * Math.pow(10, -(SIG_DIGITS - 1));
+
+  // Emit one mantissa digit: d = floor(L_M); write '0'+d; L_M = (L_M - d) * 10.
+  const emitMantissaDigit = (): Instr[] => [
+    { op: "local.get", index: L.L_M },
+    { op: "f64.floor" },
+    { op: "local.set", index: L.L_DIGIT },
+    { op: "local.get", index: L.L_BUF },
+    { op: "local.get", index: L.L_POS },
+    { op: "i32.const", value: C_ZERO },
+    { op: "local.get", index: L.L_DIGIT },
+    { op: "i32.trunc_f64_s" },
+    { op: "i32.add" },
+    { op: "array.set", typeIdx: strDataTypeIdx },
+    { op: "local.get", index: L.L_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: L.L_POS },
+    { op: "local.get", index: L.L_M },
+    { op: "local.get", index: L.L_DIGIT },
+    { op: "f64.sub" },
+    { op: "f64.const", value: 10 },
+    { op: "f64.mul" },
+    { op: "local.set", index: L.L_M },
+  ];
+
+  // The exponent's decimal digits (hundreds/tens/ones) are emitted inline at the
+  // tail of the returned body, with L_SD tracking "has a digit been printed yet"
+  // for leading-zero suppression — see the comment block there.
+
+  return [
+    // m = abs; exp = 0.
+    { op: "local.get", index: L.L_ABS },
+    { op: "local.set", index: L.L_M },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L.L_EXP },
+
+    // while m >= 10: m /= 10; exp++.
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L.L_M },
+            { op: "f64.const", value: 10 },
+            { op: "f64.lt" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: L.L_M },
+            { op: "f64.const", value: 10 },
+            { op: "f64.div" },
+            { op: "local.set", index: L.L_M },
+            { op: "local.get", index: L.L_EXP },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L.L_EXP },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // while m < 1: m *= 10; exp--.
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L.L_M },
+            { op: "f64.const", value: 1 },
+            { op: "f64.ge" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: L.L_M },
+            { op: "f64.const", value: 10 },
+            { op: "f64.mul" },
+            { op: "local.set", index: L.L_M },
+            { op: "local.get", index: L.L_EXP },
+            { op: "i32.const", value: 1 },
+            { op: "i32.sub" },
+            { op: "local.set", index: L.L_EXP },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // Round-half-up: bias the normalised mantissa by half a unit in the last
+    // emitted significant place, then re-normalise if the bias carried it to
+    // >= 10 (e.g. 9.999…95 → 10.0 → 1.0, exp++). Subsequent digit extraction is
+    // plain truncation, which now yields the rounded representation.
+    { op: "local.get", index: L.L_M },
+    { op: "f64.const", value: ROUND_BIAS },
+    { op: "f64.add" },
+    { op: "local.set", index: L.L_M },
+    { op: "local.get", index: L.L_M },
+    { op: "f64.const", value: 10 },
+    { op: "f64.ge" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: L.L_M },
+        { op: "f64.const", value: 10 },
+        { op: "f64.div" },
+        { op: "local.set", index: L.L_M },
+        { op: "local.get", index: L.L_EXP },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: L.L_EXP },
+      ],
+    },
+
+    // Leading '-' if negative.
+    { op: "local.get", index: L.L_NEG },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: putConst(strDataTypeIdx, L.L_BUF, L.L_POS, C_MINUS),
+    },
+
+    // Leading significant digit (the one before the '.').
+    ...emitMantissaDigit(),
+
+    // '.' then up to SIG_DIGITS-1 more digits.
+    ...putConst(strDataTypeIdx, L.L_BUF, L.L_POS, C_DOT),
+    { op: "i32.const", value: 1 },
+    { op: "local.set", index: L.L_SD },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L.L_SD },
+            { op: "i32.const", value: SIG_DIGITS },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...emitMantissaDigit(),
+            { op: "local.get", index: L.L_SD },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L.L_SD },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // Trim trailing '0' digits.
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L.L_POS },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: L.L_BUF },
+            { op: "local.get", index: L.L_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.sub" },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "i32.const", value: C_ZERO },
+            { op: "i32.ne" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: L.L_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.sub" },
+            { op: "local.set", index: L.L_POS },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // Drop a trailing '.' if all fractional digits were trimmed.
+    { op: "local.get", index: L.L_BUF },
+    { op: "local.get", index: L.L_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.sub" },
+    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "i32.const", value: C_DOT },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: L.L_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.sub" },
+        { op: "local.set", index: L.L_POS },
+      ],
+    },
+
+    // 'e'.
+    ...putConst(strDataTypeIdx, L.L_BUF, L.L_POS, C_LC_E),
+    // Exponent sign: '+' if exp >= 0 else '-'; then expmag = |exp| in L_TMP.
+    { op: "local.get", index: L.L_EXP },
+    { op: "i32.const", value: 0 },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...putConst(strDataTypeIdx, L.L_BUF, L.L_POS, C_MINUS),
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: L.L_EXP },
+        { op: "i32.sub" },
+        { op: "local.set", index: L.L_TMP },
+      ],
+      else: [
+        ...putConst(strDataTypeIdx, L.L_BUF, L.L_POS, C_PLUS),
+        { op: "local.get", index: L.L_EXP },
+        { op: "local.set", index: L.L_TMP },
+      ],
+    },
+    // Exponent digits, MSB-first. expmag (L_TMP) is 0..~308, i.e. at most three
+    // decimal digits, so render hundreds/tens/ones directly with leading-zero
+    // suppression (L_SD = "have we printed a digit yet"). No reverse pass, so the
+    // write cursor L_POS is never used as a shrinking high pointer.
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L.L_SD }, // L_SD: 0 until the first non-suppressed digit
+    // hundreds place: d = expmag / 100; if d != 0 print it and mark started.
+    { op: "local.get", index: L.L_TMP },
+    { op: "i32.const", value: 100 },
+    { op: "i32.div_u" },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ne" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: L.L_BUF },
+        { op: "local.get", index: L.L_POS },
+        { op: "i32.const", value: C_ZERO },
+        { op: "local.get", index: L.L_TMP },
+        { op: "i32.const", value: 100 },
+        { op: "i32.div_u" },
+        { op: "i32.add" },
+        { op: "array.set", typeIdx: strDataTypeIdx },
+        { op: "local.get", index: L.L_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: L.L_POS },
+        { op: "i32.const", value: 1 },
+        { op: "local.set", index: L.L_SD },
+      ],
+    },
+    // tens place: print if started OR the tens digit is non-zero.
+    { op: "local.get", index: L.L_SD },
+    { op: "local.get", index: L.L_TMP },
+    { op: "i32.const", value: 10 },
+    { op: "i32.div_u" },
+    { op: "i32.const", value: 10 },
+    { op: "i32.rem_u" },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ne" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: L.L_BUF },
+        { op: "local.get", index: L.L_POS },
+        { op: "i32.const", value: C_ZERO },
+        { op: "local.get", index: L.L_TMP },
+        { op: "i32.const", value: 10 },
+        { op: "i32.div_u" },
+        { op: "i32.const", value: 10 },
+        { op: "i32.rem_u" },
+        { op: "i32.add" },
+        { op: "array.set", typeIdx: strDataTypeIdx },
+        { op: "local.get", index: L.L_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: L.L_POS },
+      ],
+    },
+    // ones place: always printed (exponent has at least one digit).
+    { op: "local.get", index: L.L_BUF },
+    { op: "local.get", index: L.L_POS },
+    { op: "i32.const", value: C_ZERO },
+    { op: "local.get", index: L.L_TMP },
+    { op: "i32.const", value: 10 },
+    { op: "i32.rem_u" },
+    { op: "i32.add" },
+    { op: "array.set", typeIdx: strDataTypeIdx },
+    { op: "local.get", index: L.L_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: L.L_POS },
+
+    { op: "local.get", index: L.L_BUF },
+    { op: "local.get", index: L.L_POS },
+    { op: "call", funcIdx: L.finalizeIdx },
+    { op: "return" },
+  ] as Instr[];
+}
+
+/**
  * `number_toString(value: f64) -> externref`
  *
  * Host-compatible default radix-10 Number::toString for standalone/WASI. Safe
@@ -436,6 +789,9 @@ function emitToString(
   const L_POW = 10;
   const L_DIGIT = 11;
   const L_K = 12;
+  const L_EXP = 13; // decimal exponent for the exponential-notation regime
+  const L_M = 14; // mantissa normalised to [1,10)
+  const L_SD = 15; // significant-digit counter
 
   const finalizeReturn = (): Instr[] => [
     { op: "local.get", index: L_BUF },
@@ -446,6 +802,40 @@ function emitToString(
 
   const body: Instr[] = [
     ...emitNonFinitePrologue(ctx, finalizeIdx, strDataTypeIdx, L_VALUE, L_BUF, L_POS, L_TMP, L_NEG, L_ABS),
+
+    // §6.1.6.1.20 exponential-notation regime: ToString uses `d.dddde±N` when the
+    // decimal-point position falls outside (-6, 21]. We approximate that by the
+    // magnitude thresholds |x| >= 1e21 or 0 < |x| < 1e-6, which is exactly where
+    // V8 switches to exponential. (abs == 0 is already handled by the prologue's
+    // radix path below.) This eliminates (1e21).toString() rendering a 22-digit
+    // integer and (1e-7).toString() collapsing to "0".
+    { op: "local.get", index: L_ABS },
+    { op: "f64.const", value: 1e21 },
+    { op: "f64.ge" },
+    { op: "local.get", index: L_ABS },
+    { op: "f64.const", value: 0 },
+    { op: "f64.gt" },
+    { op: "local.get", index: L_ABS },
+    { op: "f64.const", value: 1e-6 },
+    { op: "f64.lt" },
+    { op: "i32.and" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: emitExponential(strDataTypeIdx, {
+        L_ABS,
+        L_NEG,
+        L_BUF,
+        L_POS,
+        L_EXP,
+        L_M,
+        L_SD,
+        L_DIGIT,
+        L_TMP,
+        finalizeIdx,
+      }),
+    },
 
     // Safe integers can reuse the radix-10 formatter exactly.
     { op: "local.get", index: L_ABS },
@@ -640,6 +1030,10 @@ function emitToString(
       { name: "pow", type: f64 },
       { name: "digit", type: f64 },
       { name: "k", type: i32 },
+      // #1836 exponential-notation regime (emitExponential):
+      { name: "exp", type: i32 }, // 13: decimal exponent
+      { name: "m", type: f64 }, // 14: mantissa normalised to [1,10)
+      { name: "sd", type: i32 }, // 15: significant-digit counter / exp-digit started flag
     ],
     body,
     exported: false,

--- a/tests/issue-1836-exp.test.ts
+++ b/tests/issue-1836-exp.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1836 (exponential residual) — standalone Number.prototype.toString() must use
+// exponential notation `d[.ddd]e±N` when the decimal point falls outside the
+// (-6, 21] window (§6.1.6.1.20). Previously the standalone/WASI formatter had no
+// exponential path, so (1e21).toString() rendered a 22-digit integer and
+// (1e-7).toString() collapsed to "0". This slice normalises the mantissa into
+// [1,10), emits 15 significant digits with round-half-up + trailing-zero trim,
+// then 'e', the exponent sign, and the exponent magnitude (MSB-first).
+//
+// Bit-perfect shortest-round-trip (Grisu/Ryū) for 16-17-digit extremes near the
+// double range boundaries (±1e308, denormals ~1e-308) remains #1335 Phase 2.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// Returns 1 iff (expr).toString() === expected, compared *inside* the module
+// (native strings are GC i16 arrays, not JS strings, so we can't compare across
+// the boundary directly).
+async function eqStr(expr: string, expected: string): Promise<number> {
+  const src = `export function test(): number { return ((${expr}).toString() === ${JSON.stringify(
+    expected,
+  )}) ? 1 : 0; }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors[0]?.message).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#1836 standalone toString() exponential notation (§6.1.6.1.20)", () => {
+  it("renders the large-magnitude regime (|x| >= 1e21) with e+N, not a long integer", async () => {
+    expect(await eqStr("1e21", "1e+21")).toBe(1);
+    expect(await eqStr("1e30", "1e+30")).toBe(1);
+    expect(await eqStr("1.25e22", "1.25e+22")).toBe(1);
+    expect(await eqStr("2.5e21", "2.5e+21")).toBe(1);
+  });
+
+  it("renders the small-magnitude regime (0 < |x| < 1e-6) with e-N, not '0'", async () => {
+    expect(await eqStr("1e-7", "1e-7")).toBe(1);
+    expect(await eqStr("1.5e-7", "1.5e-7")).toBe(1);
+    expect(await eqStr("5e-7", "5e-7")).toBe(1);
+    expect(await eqStr("1.234e-10", "1.234e-10")).toBe(1);
+  });
+
+  it("handles negative exponential values", async () => {
+    expect(await eqStr("-1e21", "-1e+21")).toBe(1);
+    expect(await eqStr("-1e-7", "-1e-7")).toBe(1);
+  });
+
+  it("rounds the last significant digit (round-half-up), not truncates", async () => {
+    // 1.1e-7 and 9.5e-8 are not exactly representable; truncating 15 digits would
+    // print 1.09999…e-7 / 9.49999…e-8. Round-half-up yields the V8 string.
+    expect(await eqStr("1.1e-7", "1.1e-7")).toBe(1);
+    expect(await eqStr("9.5e-8", "9.5e-8")).toBe(1);
+    expect(await eqStr("4.9e-8", "4.9e-8")).toBe(1);
+  });
+
+  it("emits multi-digit exponents MSB-first (hundreds/tens/ones)", async () => {
+    expect(await eqStr("1e100", "1e+100")).toBe(1);
+    expect(await eqStr("1e-100", "1e-100")).toBe(1);
+    expect(await eqStr("1e308", "1e+308")).toBe(1);
+    expect(await eqStr("6.022e23", "6.022e+23")).toBe(1);
+    expect(await eqStr("1.602e-19", "1.602e-19")).toBe(1);
+  });
+
+  it("does not switch to exponential at or inside the (-6, 21] boundary (no regression)", async () => {
+    // 1e-6 stays fixed ("0.000001"); 9.999e20 < 1e21 stays a plain integer.
+    expect(await eqStr("1e-6", "0.000001")).toBe(1);
+    expect(await eqStr("1e-5", "0.00001")).toBe(1);
+    expect(await eqStr("999900000000000000000", "999900000000000000000")).toBe(1);
+  });
+
+  it("leaves ordinary integer and fractional formatting unchanged (no regression)", async () => {
+    expect(await eqStr("255", "255")).toBe(1);
+    expect(await eqStr("100", "100")).toBe(1);
+    expect(await eqStr("0", "0")).toBe(1);
+    expect(await eqStr("3.14159", "3.14159")).toBe(1);
+    expect(await eqStr("-42", "-42")).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds the missing exponential-notation path to the no-JS-host `number_toString`
formatter (`src/codegen/number-format-native.ts`). §6.1.6.1.20 prescribes
`d[.ddd]e±N` when the decimal-point position falls outside the `(-6, 21]` window;
the standalone/WASI formatter previously had no such path, so:
- `(1e21).toString()` rendered a 22-digit integer instead of `"1e+21"`
- `(1e-7).toString()` collapsed to `"0"`

Residual of #1836 (the exponential slice listed in the issue's residual defects).

## How

`emitToString` routes `|x| >= 1e21 || (0 < |x| < 1e-6)` — exactly V8's exponential
threshold — to a new `emitExponential` helper:
- normalise the mantissa into `[1,10)` by iterative ×/÷10 tracking the decimal
  exponent (Wasm has no `log10`);
- round-half-up by biasing the mantissa with half a unit in the last emitted
  place, re-normalising if the bias carries to `>= 10`;
- emit **15 significant digits** (the safe IEEE-754 double precision floor — more
  exposes binary-representation noise like `9.5e-8 → 9.500000000000001e-8`), trim
  trailing zeros and a bare `.`;
- emit `'e'`, the exponent sign, then the exponent magnitude **MSB-first** via a
  hundreds/tens/ones decomposition — **no reverse pass**, so the buffer write
  cursor is never used as a shrinking pointer (the bug in the earlier WIP).

Three new locals on `number_toString` (`exp` i32, `m` f64, `sd` i32).

## Verification

`tests/issue-1836-exp.test.ts` (7 tests). Common exponential-regime values are
bit-exact with V8: `1e+21`, `1e-7`, `1.5e-7`, `5e-7`, `1.234e-10`, `6.022e+23`,
`1.602e-19`; round-half-up `1.1e-7`/`9.5e-8`; multi-digit exponents
`1e+100`/`1e+308`/`1e-100`; negatives. No regression at the `(-6,21]` boundary
(`1e-6` stays `"0.000001"`, `9.999e20` stays a plain integer) or for ordinary
integer/fractional output. Verified template-literal `${x}`, `String(x)`, and
`"" + x` all route through the fixed formatter.

No regression in `tests/issue-1335-standalone.test.ts` (8),
`tests/issue-49-number-format-nonfinite.test.ts` (7),
`tests/issue-1836.test.ts` (8).

## Scope / residual

Bit-perfect shortest-round-trip (Grisu/Ryū) for 16-17-digit extremes at the
double-range boundaries (max-double `1.797…e308`, denormals `~1e-308`) prints a
last-digit-rounded approximation, not the V8 shortest string — that is **#1335
Phase 2**. #1836 itself remains `in-progress` (the strict StringToNumber
`+"12abc"`→NaN residual is a separate slice), so this PR does **not** mark the
issue `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)