### PR TITLE
fix(#1866): route externref-dstr __extern_get through ensureLateImport (no env:: leak)

### DIFF
--- a/plan/issues/1866-js-compile-extern-get-undefined-import.md
+++ b/plan/issues/1866-js-compile-extern-get-undefined-import.md
@@ -1,10 +1,11 @@
 ---
 id: 1866
 title: "JS→WASM standalone: compiled .js host emits undefined `env::__extern_get` import"
-status: ready
-sprint: Backlog
+status: done
+sprint: 60
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-05
+completed: 2026-06-05
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -302,15 +302,12 @@ export function destructureParamObjectExternref(
   if (shouldEnsureLetConstFlags(opts)) {
     ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
   }
-  // Ensure __extern_get is available
+  // Ensure __extern_get is available (#1866: ensureLateImport routes to the
+  // native object-runtime impl under --target standalone — no leaked
+  // `env::__extern_get` host import — and to the host import in JS-host mode).
+  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
   let getIdx = ctx.funcMap.get("__extern_get");
-  if (getIdx === undefined) {
-    const importsBefore = ctx.numImportFuncs;
-    const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-    getIdx = ctx.funcMap.get("__extern_get");
-  }
   if (getIdx === undefined) return;
 
   const excludedKeys: string[] = [];

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -562,17 +562,17 @@ function compileDestructuringAssignment(
     // property, because the no-struct-fields path returned early without
     // touching any of the target identifiers.
     if (resultType.kind === "externref") {
-      let getIdx = ctx.funcMap.get("__extern_get");
-      if (getIdx === undefined) {
-        const importsBefore = ctx.numImportFuncs;
-        const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-        addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-        shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-        getIdx = ctx.funcMap.get("__extern_get");
-      }
+      // (#1866) Route `__extern_get` through `ensureLateImport` rather than a raw
+      // `addImport("env", …)`: under `--target standalone` that re-routes to the
+      // Wasm-native object-runtime impl (no `env::__extern_get` host import), so
+      // the module instantiates under wasmtime; in JS-host mode it adds the host
+      // import as before. A raw addImport leaks an undefined `env::__extern_get`
+      // that breaks the zero-JS-host guarantee.
+      ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
       const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
       flushLateImportShifts(ctx, fctx);
-      getIdx = ctx.funcMap.get("__extern_get");
+      const getIdx = ctx.funcMap.get("__extern_get");
 
       if (getIdx !== undefined && undefIdx !== undefined) {
         for (const prop of target.properties) {
@@ -1581,15 +1581,12 @@ function compileExternrefArrayDestructuringAssignment(
     }
   }
 
-  // Ensure __extern_get is available
+  // Ensure __extern_get is available (#1866: ensureLateImport routes to the
+  // native object-runtime impl under --target standalone — no leaked
+  // `env::__extern_get` host import — and to the host import in JS-host mode).
+  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
   let getIdx = ctx.funcMap.get("__extern_get");
-  if (getIdx === undefined) {
-    const importsBefore = ctx.numImportFuncs;
-    const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-    getIdx = ctx.funcMap.get("__extern_get");
-  }
   if (getIdx === undefined) return null;
 
   // Ensure __box_number is available (needed to convert index to externref)

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -17,7 +17,7 @@ import {
   isStrictContext,
 } from "../expressions/assignment.js";
 import { emitCoercedLocalSet, emitThrowTypeError } from "../expressions/helpers.js";
-import { shiftLateImportIndices } from "../expressions/late-imports.js";
+import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "../expressions/late-imports.js";
 import {
   addIteratorImports,
   ensureI32Condition,
@@ -2052,15 +2052,12 @@ function compileForOfAssignDestructuringExternref(
   expr: ts.ArrayLiteralExpression,
   elemLocal: number,
 ): void {
-  // Ensure __extern_get is available
+  // Ensure __extern_get is available (#1866: ensureLateImport routes to the
+  // native object-runtime impl under --target standalone — no leaked
+  // `env::__extern_get` host import — and to the host import in JS-host mode).
+  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
   let getIdx = ctx.funcMap.get("__extern_get");
-  if (getIdx === undefined) {
-    const importsBefore = ctx.numImportFuncs;
-    const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-    getIdx = ctx.funcMap.get("__extern_get");
-  }
   if (getIdx === undefined) return;
 
   // Ensure __box_number is available
@@ -2836,15 +2833,12 @@ function compileForOfIteratorAssignDestructuring(
   elemLocal: number,
   stmt: ts.ForOfStatement,
 ): void {
-  // Ensure __extern_get is available
+  // Ensure __extern_get is available (#1866: ensureLateImport routes to the
+  // native object-runtime impl under --target standalone — no leaked
+  // `env::__extern_get` host import — and to the host import in JS-host mode).
+  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
   let getIdx = ctx.funcMap.get("__extern_get");
-  if (getIdx === undefined) {
-    const importsBefore = ctx.numImportFuncs;
-    const getType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__extern_get", { kind: "func", typeIdx: getType });
-    shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
-    getIdx = ctx.funcMap.get("__extern_get");
-  }
   if (getIdx === undefined) return;
 
   if (ts.isObjectLiteralExpression(expr)) {

--- a/tests/issue-1866.test.ts
+++ b/tests/issue-1866.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1866 — a `--target standalone` build must NOT leak an `env::__extern_get`
+// host import (it is undefined under a bare WASI runtime and breaks the
+// zero-JS-host guarantee). The externref destructuring bypass sites
+// (destructureParamObjectExternref, compileDestructuringAssignment,
+// compileExternrefArrayDestructuringAssignment, the two for-of-assign
+// helpers) previously registered `__extern_get` via a raw
+// `addImport("env", …)`, which leaked the host import even under
+// `ctx.standalone`. The fix routes them through `ensureLateImport`, which
+// under `--target standalone` resolves to the Wasm-native object-runtime impl
+// (in OBJECT_RUNTIME_HELPER_NAMES) — no `env::` import. Same residual-host-leak
+// class as the just-landed #1203.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function envImports(bytes: Uint8Array): string[] {
+  const mod = new WebAssembly.Module(bytes);
+  return WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+describe("#1866 standalone externref-destructuring does not leak env::__extern_get", () => {
+  it("object-destructuring param over an `any` value compiles standalone with no env:: import", async () => {
+    // Routes through destructureParamObjectExternref → the `__extern_get`
+    // bypass site. The param is `any`, so codegen takes the externref
+    // dynamic-read path that used to emit `env::__extern_get`.
+    const src = `function f({ a, b }: any): number { return a + b; }
+      export function test(): number { const x: any = { a: 5, b: 6 }; return f(x); }`;
+    const r = await compile(src, { target: "standalone" });
+    expect(r.success, r.errors[0]?.message).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    expect(mod).toBeDefined();
+    const env = envImports(r.binary);
+    expect(env, `leaked env imports: ${env.join(", ")}`).not.toContain("__extern_get");
+    // Stronger zero-JS-host assertion: NO env:: import at all.
+    expect(env).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1866 (GitHub #389, guest271314) — a `--target standalone` build leaked an
undefined `env::__extern_get` host import, so the module failed to instantiate
under wasmtime and broke the zero-JS-host guarantee.

The externref destructuring **bypass sites** registered `__extern_get` via a raw
`addImport("env", "__extern_get", …)`:
- `destructureParamObjectExternref` (destructuring-params.ts)
- `compileDestructuringAssignment` object-dstr arm (assignment.ts)
- `compileExternrefArrayDestructuringAssignment` (assignment.ts)
- `compileForOfAssignDestructuringExternref` (loops.ts)
- `compileForOfIteratorAssignDestructuring` (loops.ts)

### Fix

All five route through `ensureLateImport(ctx, "__extern_get", …)` instead. Under
`ctx.standalone` that resolves to the Wasm-native object-runtime impl
(`__extern_get` ∈ `OBJECT_RUNTIME_HELPER_NAMES`) — **no `env::` import**; in
JS-host mode it adds the host import exactly as before. Same residual-host-leak
class as the just-landed #1203.

### Test

`tests/issue-1866.test.ts`: an object-destructuring param over an `any` value
compiles to a valid standalone module with **zero** `env::` imports.

## Deferred (NOT in this PR)

The headline `o[k]` computed-member-read case is **deferred to sd-1472c's #1472
Phase C**. It flows through property-access.ts (which already uses
`ensureLateImport`) but needs the native object-runtime to serve `__extern_get`
for the dynamic-read path — that is the dynamic-shape family proper, not these
bypass sites. This PR clears the dstr/loops/assignment-dstr leaks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)