### PR TITLE
feat(#1886 Slice B): intraprocedural linear-backed Uint8Array codegen

### DIFF
--- a/plan/issues/1886-linear-backed-uint8array-wasi-io.md
+++ b/plan/issues/1886-linear-backed-uint8array-wasi-io.md
@@ -4,7 +4,7 @@ title: "Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoi
 status: in-progress
 sprint: Backlog
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-05
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -21,6 +21,16 @@ related: [1863, 1527, 389]
 the `.wat` shows why, and it points at a concrete, *targeted* optimization.
 
 ## Why AssemblyScript is faster (measured + confirmed from its `.wat`)
+
+> **Framing correction (esch 2026-06-05):** the original issue title/body framed
+> this as "hold the body in memory to beat AS." That is **wrong** and the title
+> is kept only for issue continuity. The team-lead's held-GC-body measurement
+> confirmed that holding the 64 MiB body in a **GC array** is both *slower* and
+> *fatter* than streaming a 1 MiB window — retention is not the lever. **The
+> lever is getting the bytes out of the GC heap and into linear memory so
+> `fd_read`/`fd_write` touch them with zero copy** (and so element ops are
+> `i32.load8_u`/`i32.store8` against that same linear region). We *beat* AS on
+> memory precisely by NOT holding the body — we stream a small linear window.
 
 AssemblyScript uses **linear memory exclusively** — no WasmGC, no `array.new`/
 `array.copy`/`struct.new`. Its message buffer *is* linear memory, so `fd_read`
@@ -313,34 +323,115 @@ non-WASI and any escaping `Uint8Array` are byte-identical to today.
 
 ### 7. Phasing (slices for safe landing)
 
-- **Slice A** — analysis module + unit tests (no codegen change); prove it marks
-  every `nm_js2wasm.ts` buffer linear-safe and correctly *rejects* a crafted
-  escaping case. Lands behind the flag, gated off.
-- **Slice B** — linear allocator + `new`/index/`.length` codegen + the
-  intraprocedural buffers (`header`, `one`, `buf` in `main`). No signature
-  rewrite yet (so `readExact`/`emitRun` still take GC — but those are only the
-  small/parameter paths; measure the partial win).
+- **Slice A** — analysis module + unit tests (no codegen change). **DONE**
+  (merged): marks every `nm_js2wasm.ts` buffer linear-safe and rejects crafted
+  escaping cases; wired behind `ctx.wasi`, byte-identical to baseline.
+- **Slice B** — linear allocator + `new`/index/`.length`/zero-copy-I/O codegen,
+  **intraprocedural only**. **DONE** (this PR).
 - **Slice C** — interprocedural signature rewrite so `readExact`/`readAt`/
-  `emitRun` take linear `(ptr,len)` params → full zero-copy I/O. This is where
-  the big number lands.
-- **Slice D** (optional follow-up) — loop-scoped arena reset for unbounded
-  streams.
+  `emitRun` take linear `(ptr,len)` params → full zero-copy I/O. **NOT STARTED.**
+- **Slice D** — zero-copy direct-slice write + loop-scoped arena reset.
+  **NOT STARTED.**
 
-**Landing plan (revised, esch 2026-06-05):** PR #1 = **Slice A** only (the
-analysis pass, wired behind `ctx.wasi`, with no codegen consumer — emitted
-WASI modules verified byte-identical to baseline via `cmp`). Tech lead approved
-splitting the risky signature-rewrite (Slice C) into its own PR; the same
-isolation logic applies to the codegen wiring (Slice B), so the bump allocator
-+ `new`/index/`.length`/zero-copy I/O codegen lands as **PR #2** and the
-interprocedural signature rewrite as **PR #3**. This banks the analysis
-foundation (zero runtime risk) and keeps each codegen change independently
-reviewable + benchmarkable. The allocator design (page-4 arena at
-`LINEAR_U8_ARENA_START = 256 KiB`, a dedicated `$__lin_u8_arena_ptr` bump global
-— NOT the page-0 `$__wasi_bump_ptr`, which aliases string-literal data —
-emitted lazily reusing the #1856 align8 + page-grow idiom) is prototyped and
-typechecks; it ships with PR #2.
+## Slice B — what landed (esch 2026-06-05)
 
-Slices A+B+C are the core of this issue; D can be a follow-up if the per-message
-allocation proves to leak on infinite streams (the benchmark sends one large
-message, so A–C suffice to hit the acceptance numbers, but D is needed for
-production correctness on long-lived ports — call it out in the PR).
+Intraprocedural linear backing for a `new Uint8Array(...)` **local**. A buffer
+qualifies (`isLocalLinearNewBinding` in `src/codegen/linear-uint8-codegen.ts`)
+iff Slice-A proved it linear-safe AND, additionally for Slice B:
+1. it is a `new Uint8Array(...)` **local** (not a param — params stay GC);
+2. it is used **only intraprocedurally** — `b[i]`, `b.length`, and the I/O
+   intrinsics `process.std*.{read,write}(b)` only. A buffer passed to a **user
+   function** is rejected here even though Slice A admits it (Slice A's
+   permissive set is forward-looking to Slice C's signature rewrite; Slice B has
+   no callee-signature rewrite, so a `(ptr,len)` local cannot cross a GC-typed
+   call ABI);
+3. it is **allocated at most once per run** (`isAllocatedAtMostOnce`) — not
+   inside a loop, and its enclosing function is the module entry or is called at
+   most once and never from a loop. This is the **bump-arena leak guard**: the
+   arena is monotonic (no free) until Slice D, so a per-iteration `new` would
+   leak ~1 MiB/iteration. Buffers that fail this stay GC-backed.
+
+Codegen: `(ptr,len)` i32 locals via a lazily-emitted `__lin_u8_alloc(len)->ptr`
+bump allocator over a dedicated page-4 arena global `$__lin_u8_arena_ptr`
+(NOT the page-0 `$__wasi_bump_ptr`, which aliases string-literal data). `b[i]` →
+`i32.load8_u`, `b[i]=v` → `i32.store8`, `b.length` → the `len` local,
+`stdin.read`/`stdout.write` → zero-copy `fd_read`/`fd_write` against `ptr`.
+
+**Two root-caused codegen bugs fixed (the WIP's validation failure):**
+1. **Allocator funcIdx desync → bare `ref.null extern` in a void fn.** The WIP
+   pre-emitted `__lin_u8_alloc` *before* `collectAllSourceImports`. `addImport`
+   does NOT shift already-registered defined functions, so every later import
+   shifted the module's import/defined boundary and left `call __lin_u8_alloc`
+   pointing at an *import* (e.g. `__extern_get`, 2 params/1 result). That made
+   the function's net stack delta `-1`; `stackBalance`'s function-level
+   `fixBranch(expected=0)` then saw the body as "short one value" and, for an
+   empty block type, pushed a `ref.null extern` to fill it — leaving a value on
+   the stack at the end of a void `main` → invalid wasm
+   (`expected externref, found i32`). **Fix:** emit `__lin_u8_alloc` in the
+   deferred-helper zone (alongside `emitToUint32Helper`/`emitDeferredWasiHelpers`,
+   after `collectAllSourceImports`, before the final
+   `reconcileNativeStrFinalizeShift` and before user functions), so its index is
+   stable and any residual drift is reconciled by the native-string regime.
+2. **Predicate mismatch → spurious `__extern_get`/`__str_flatten` desync.** The
+   hoist pre-pass skipped the GC `$buf` local using the *raw* Slice-A
+   `safeBindings` set, but the declaration-site lowering used the tighter Slice-B
+   predicate. For a buffer Slice A admitted but Slice B declined (e.g. the nm
+   host's `buf`, threaded through `readExact`), the GC local was skipped yet the
+   binding fell back to the GC path with no storage → it pulled in GC extern
+   helpers against a missing local and desynced `__str_flatten`. **Fix:** the
+   hoist-skip now uses the same `isLocalLinearNewBinding` predicate.
+
+**Result.** `probe_u8` (single buffer in `main`) is fully linear-backed and
+round-trips correctly under wasmtime **v44** and **v45** (stdin `0x41` →
+`buf[0]=(0x41+1)&255=0x42` → stdout, rest zero-filled). The native-messaging
+host (`nm_js2wasm.ts`) is **byte-identical** to current main (`cmp` passes):
+every one of its buffers either escapes via a helper param (Slice C territory)
+or is allocated per-frame in a loop (Slice D territory), so Slice B correctly
+declines all of them and emits no allocator/arena — h2h on v44/v45 is unchanged
+(`validJSON=true match=true`, 65 frames, flat ~24 MB on v45). **The host speedup
+is therefore NOT in Slice B** — it requires Slice C (cross-function `(ptr,len)`)
+and Slice D (zero-copy direct-slice write + arena reset). Slice B lands the
+allocator + intraprocedural codegen + the two index-shift fixes as a safe
+foundation.
+
+## Slice C — interprocedural signature rewrite (NOT STARTED — the host win)
+
+Rewrite each linear-safe `Uint8Array` **parameter** of a non-exported function to
+a `(ptr: i32, len: i32)` pair, and thread linear args as two i32s at every call
+site. This is what unlocks the nm host: `readExact`/`readAt`/`emitRun` currently
+receive `buf` as a GC vec, forcing the buffer GC-backed; once they take
+`(ptr,len)`, `buf` in `main` becomes linear and the whole read/build/write path
+is zero-copy. Risk (per §5): the rewrite must consult the *same frozen*
+classification at the callee def and every call site — a single missed escape
+that should have demoted the param makes the module fail validation. Add a
+verifier assertion: a linear-rewritten function must have linear args at every
+call. Slice A already froze `linearParams` (funcSym → linear param indices) for
+exactly this consumer.
+
+## Slice D — zero-copy direct-slice write + loop-scoped arena reset (NOT STARTED)
+
+Two related follow-ons, landable together once B+C make the host buffers linear:
+
+1. **Loop-scoped arena reset** (lifts Slice B's allocate-at-most-once guard).
+   The bump arena is monotonic today. Snapshot `$__lin_u8_arena_ptr` at loop
+   entry and rewind to it at the bottom of each iteration (`__lin_u8_arena_mark`
+   / `__lin_u8_reset`). Sound because a linear-safe buffer allocated *inside* an
+   iteration cannot escape it. `new Uint8Array(n)` into a reused slot must then
+   `memory.fill(ptr,0,len)` to honour the zero-fill contract. This lets
+   per-frame buffers (`frame`, `small`, `tmp`) be linear-backed without leaking,
+   and lets the nm host's `emitRun` frame buffer go linear.
+
+2. **Zero-copy direct-slice write.** Once a buffer is linear-backed, drop
+   `emitRun`'s per-frame element-copy entirely and write the run's bytes
+   DIRECTLY from the linear window: `stdout.write("[")`, a zero-copy `fd_write`
+   of `buf[start .. start+runLen)`, `stdout.write("]")`. Clean API (no bespoke
+   builtin): linear-backed `Uint8Array.prototype.subarray(start,end)` returns a
+   zero-copy VIEW (`ptr+offset`, `len`) over the same arena — not a copy — and
+   `process.stdout.write(view)` does `fd_write` from `view.ptr+view.offset` for
+   `view.len`. "The fastest copy is the one you don't do" — this beats AS (which
+   does one memmove into its output buffer) on both wall and memory.
+
+**Sequencing:** Slice B (this) → Slice C (interprocedural signature rewrite) →
+Slice D (arena reset + zero-copy direct-slice write). Acceptance for C+D: the nm
+host h2h reaches AS-class wall (~0.15–0.25 s) at flat ~24–31 MB, with
+`emitRun`'s per-frame copy gone and no arena leak on long-lived streams.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -390,6 +390,22 @@ export interface FunctionContext {
       presized?: boolean; // #1761: true when buffer presized; appends skip cap-check
     }
   >;
+  /**
+   * #1886 Slice B — live linear-backed `Uint8Array` buffers in this function,
+   * keyed by binding name. A buffer proven linear-safe by the #1886 analysis
+   * (`ctx.linearUint8.safeBindings`) is represented as a `(ptr, len)` pair of
+   * i32 locals instead of a GC vec, so `buf[i]`, `buf.length`, and
+   * `process.std*.{read,write}(buf)` operate on linear memory with zero
+   * GC↔linear copies. Absent entry ⇒ the binding uses the existing GC-vec path
+   * unchanged.
+   */
+  linearU8Buffers?: Map<
+    string,
+    {
+      ptrLocalIdx: number; // i32 — base byte offset into the page-4 linear arena
+      lenLocalIdx: number; // i32 — element length (== byte length for Uint8Array)
+    }
+  >;
 }
 
 /** Context shared across all codegen. */
@@ -972,6 +988,19 @@ export interface CodegenContext {
    * side-effect free and safe to run unconditionally behind the WASI gate.)
    */
   linearUint8?: import("../linear-uint8-analysis.js").LinearUint8Result;
+  /**
+   * #1886 Slice B — Func index of the lazily-emitted
+   * `__lin_u8_alloc(len:i32)->i32` bump allocator for linear-backed Uint8Array
+   * buffers (`undefined` = not yet emitted). Allocates from a dedicated page-4
+   * arena pointed at by `$__lin_u8_arena_ptr` (NOT the page-0 string-literal
+   * `$__wasi_bump_ptr`, which would alias literal data). Reuses the #1856
+   * align8 + on-demand `memory.grow` idiom (see `codegen-linear/runtime.ts
+   * addRuntime`), emitted here because the WasmGC front-end owns its own
+   * memory/globals and cannot call the linear backend's module bootstrap.
+   */
+  linearU8AllocFuncIdx?: number;
+  /** #1886 Slice B — global index of the page-4 linear-U8 arena bump pointer. */
+  linearU8ArenaGlobalIdx?: number;
   /** Whether `node:fs` JS-host imports are permitted (non-WASI target only, #1491). */
   allowFs: boolean;
   /**

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -6,6 +6,7 @@ import { ts, forEachChild } from "../../ts-api.js";
 import { isBooleanType, isExternalDeclaredClass, isStringType } from "../../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet, resolveArrayInfo } from "../array-methods.js";
+import { tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
 import { emitModulo, emitToInt32 } from "../binary-ops.js";
 import { pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
@@ -2576,6 +2577,12 @@ function compileElementAssignment(
   target: ts.ElementAccessExpression,
   value: ts.Expression,
 ): InnerResult {
+  // #1886 Slice B: linear-backed Uint8Array write `buf[i] = v` →
+  // i32.store8(ptr+i, trunc(v)). Only fires for a registered linear-safe
+  // buffer; any other target falls through to the GC element-assign path.
+  const linU8Set = tryEmitLinearU8ElementSet(ctx, fctx, target, value);
+  if (linU8Set !== null) return linU8Set;
+
   // Handle ClassName[key] = value for static setter accessors and static properties (#848)
   if (ts.isIdentifier(target.expression)) {
     const objName = target.expression.text;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2,6 +2,7 @@
 import { ts, forEachChild } from "../ts-api.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { analyzeLinearUint8 } from "./linear-uint8-analysis.js";
+import { isLocalLinearNewBinding, sourceHasLinearBackedUint8 } from "./linear-uint8-codegen.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import {
   isBigIntType,
@@ -926,6 +927,10 @@ export function generateModule(
       // zero-copy fd_read/fd_write. Side-effect free; codegen consumers are
       // additive (empty result ⇒ emitted module identical to today).
       ctx.linearUint8 = analyzeLinearUint8(ast.checker, ast.sourceFile);
+      // #1886 Slice B: the `__lin_u8_alloc` bump allocator is emitted in the
+      // deferred-helper zone below (after collectAllSourceImports + the final
+      // reconcileNativeStrFinalizeShift, before user functions), NOT here.
+      // See the emit site near emitToUint32Helper / emitDeferredWasiHelpers.
     }
 
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()
@@ -1041,6 +1046,32 @@ export function generateModule(
     // funcMap, and addImport callers earlier in this pipeline (lib-globals
     // scan adding `eval` / `parseInt`) do not shift defined-func entries.
     emitDeferredWasiHelpers(ctx);
+
+    // #1886 Slice B — emit the `__lin_u8_alloc` bump allocator in this same
+    // deferred-helper zone (alongside __toUint32 / the WASI write helpers) for
+    // BOTH reasons those helpers live here:
+    //   1. It is AFTER `collectAllSourceImports`, so its absolute funcMap index
+    //      is not silently invalidated by later `addImport` calls — `addImport`
+    //      does NOT shift already-registered defined functions (see the
+    //      emitToUint32Helper note above). Emitting it before the import scan
+    //      (the original Slice-B WIP) left every linear `new Uint8Array(n)`
+    //      `call __lin_u8_alloc` pointing at the wrong (import) slot, which
+    //      desynced the function stack so badly the void-fn finalizer appended a
+    //      bare `ref.null extern` (#1886 Slice-B validation failure).
+    //   2. It is BEFORE the trailing `reconcileNativeStrFinalizeShift` below,
+    //      so if any later import is added between here and user-function
+    //      compilation, the SAME reconcile that keeps `__str_flatten` & the
+    //      other native-string helpers' indices correct also fixes up this
+    //      helper's `call`/funcMap entry — avoiding the `__str_flatten` type
+    //      desync the deferred emitters are carefully sequenced around.
+    // Idempotent and a no-op when no `new Uint8Array` binding actually qualifies
+    // for Slice-B linear backing (`sourceHasLinearBackedUint8` applies the full
+    // intraprocedural + allocated-at-most-once predicate, so e.g. the
+    // native-messaging host — whose buffers all flow through helper params —
+    // emits NO allocator and stays byte-identical to today).
+    if (ctx.wasi && sourceHasLinearBackedUint8(ctx, ast.sourceFile)) {
+      ensureLinearU8AllocHelper(ctx);
+    }
 
     // Emit wrapper valueOf functions (after all imports registered, before user funcs)
     emitWrapperValueOfFunctions(ctx);
@@ -4588,6 +4619,12 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   });
   ctx.wasiBumpPtrGlobalIdx = bumpGlobalIdx;
 
+  // #1886 Slice B — the dedicated page-4 arena bump-pointer global
+  // (`__lin_u8_arena_ptr`) for linear-backed Uint8Array buffers is registered
+  // ON DEMAND in `ensureLinearU8AllocHelper` (deferred-helper zone), gated on a
+  // buffer actually qualifying for Slice-B backing. A WASI module with no linear
+  // buffer therefore stays byte-identical to today (no stray unused global).
+
   // Check if source uses console.log/warn/error, process.exit, or node:fs functions
   let needsFdWrite = false;
   let needsConsoleStderr = false;
@@ -5073,6 +5110,121 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
  */
 export const WASI_STDIN_BUF_START = 64 * 1024;
 const WASI_WRITE_SCRATCH_START = 128 * 1024;
+
+/**
+ * #1886 Slice B — start of the linear-backed `Uint8Array` arena (page 4,
+ * 256 KiB). It sits above the page-2 write scratch with page 3 left as a guard,
+ * so a proven-I/O-only buffer never aliases the iovec scratch, string-literal
+ * data, the stdin buffer, or the write scratch. The arena grows on demand via
+ * `memory.grow` in `__lin_u8_alloc`.
+ */
+const LINEAR_U8_ARENA_START = 256 * 1024;
+
+/**
+ * #1886 Slice B — Ensure the `__lin_u8_alloc(len: i32) -> i32` bump allocator
+ * exists and return its function index (lazy, emitted on first linear-backed
+ * `new Uint8Array`). Allocates `align8(len)` bytes from the page-4 linear arena
+ * pointed at by `$__lin_u8_arena_ptr`, growing memory on demand, and returns
+ * the (8-byte-aligned) base pointer. Mirrors the #1856 align8 + page-grow idiom
+ * from `codegen-linear/runtime.ts`; emitted here because the WasmGC front-end
+ * owns its own memory/globals and cannot call the linear backend bootstrap.
+ *
+ * NOTE: the returned region is NOT explicitly zero-filled — `memory.grow`
+ * zeroes fresh pages, and the arena today only ever grows (no reset yet, see
+ * Slice D), so every byte handed out is freshly-grown zero memory, satisfying
+ * the `new Uint8Array(n)` zero-fill contract. A future arena reset (Slice D)
+ * that reuses slots must `memory.fill` callers' buffers.
+ */
+export function ensureLinearU8AllocHelper(ctx: CodegenContext): number {
+  if (ctx.linearU8AllocFuncIdx !== undefined) return ctx.linearU8AllocFuncIdx;
+  if (!ctx.wasi) return -1;
+
+  // Register the dedicated page-4 arena bump-pointer global ON DEMAND, here in
+  // the deferred-helper zone, so a WASI module with no Slice-B linear buffer is
+  // byte-identical to today (no stray unused global). Safe to register now: this
+  // helper is emitted before any user-function body compiles, so no compiled
+  // body's global index can shift under it. Starts at LINEAR_U8_ARENA_START
+  // (page 4) so it never aliases the page-0 string-literal data, the stdin
+  // buffer, or the write scratch; the region grows on demand via memory.grow.
+  if (ctx.linearU8ArenaGlobalIdx === undefined) {
+    const u8ArenaGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: "__lin_u8_arena_ptr",
+      type: { kind: "i32" },
+      mutable: true,
+      init: [{ op: "i32.const", value: LINEAR_U8_ARENA_START } as Instr],
+    });
+    ctx.linearU8ArenaGlobalIdx = u8ArenaGlobalIdx;
+  }
+
+  const arenaGlobal = ctx.linearU8ArenaGlobalIdx;
+  // param: len(0); locals: ret(1), next(2)
+  const LEN = 0;
+  const RET = 1;
+  const NEXT = 2;
+  const PAGE = 65536;
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "i32" }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__lin_u8_alloc", funcIdx);
+
+  const body: Instr[] = [
+    // ret = arena_ptr
+    { op: "global.get", index: arenaGlobal } as Instr,
+    { op: "local.set", index: RET } as Instr,
+    // next = align8(ret + len) = (ret + len + 7) & ~7
+    { op: "local.get", index: RET } as Instr,
+    { op: "local.get", index: LEN } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: 7 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.const", value: -8 } as Instr,
+    { op: "i32.and" } as Instr,
+    { op: "local.set", index: NEXT } as Instr,
+    // if (next > memory.size * PAGE) grow by ceil((next - cur)/PAGE)
+    { op: "local.get", index: NEXT } as Instr,
+    { op: "memory.size" } as Instr,
+    { op: "i32.const", value: PAGE } as Instr,
+    { op: "i32.mul" } as Instr,
+    { op: "i32.gt_u" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: NEXT } as Instr,
+        { op: "memory.size" } as Instr,
+        { op: "i32.const", value: PAGE } as Instr,
+        { op: "i32.mul" } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "i32.const", value: PAGE - 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "i32.const", value: PAGE } as Instr,
+        { op: "i32.div_u" } as Instr,
+        { op: "memory.grow" } as Instr,
+        { op: "drop" } as Instr,
+      ],
+    } as Instr,
+    // arena_ptr = next
+    { op: "local.get", index: NEXT } as Instr,
+    { op: "global.set", index: arenaGlobal } as Instr,
+    // return ret
+    { op: "local.get", index: RET } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: "__lin_u8_alloc",
+    typeIdx: funcTypeIdx,
+    locals: [
+      { name: "ret", type: { kind: "i32" } },
+      { name: "next", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+
+  ctx.linearU8AllocFuncIdx = funcIdx;
+  return funcIdx;
+}
 
 /**
  * #1618: Ensure __wasi_write_any_string(s: ref NativeString) -> void exists and
@@ -10723,6 +10875,26 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
       // #1210: skip declarations matched by detectStringBuilders — their
       // storage is replaced by a synthetic buffer triple at compile time.
       if (fctx.pendingStringBuilders?.has(decl)) continue;
+      // #1886 Slice B: skip linear-backed `new Uint8Array(...)` bindings — their
+      // storage is a synthetic (ptr,len) i32 pair set up at the declaration site
+      // (see tryEmitLinearU8New), and the name is intentionally kept out of
+      // localMap so reads route through `fctx.linearU8Buffers`. Pre-allocating a
+      // GC `(ref null …)` local here would leave a dangling uninitialised local
+      // (which the function finalizer then treats as a live value).
+      //
+      // Use the SAME predicate the declaration-site lowering uses
+      // (`isLocalLinearNewBinding`), not the raw Slice-A `safeBindings` set:
+      // Slice A admits buffers that flow into linear-safe callee params (a
+      // forward-looking Slice-C allowance), but Slice B only linear-backs
+      // buffers used purely intraprocedurally AND allocated at most once.
+      // Skipping the GC local for a binding that then FALLS BACK to the GC `new
+      // Uint8Array` path (because it is passed to a user function / allocated in
+      // a loop) would leave it with no storage and pull in GC extern helpers
+      // against a missing local (observed: spurious `__extern_get` /
+      // `__str_flatten` desync in the native-messaging host).
+      if (ctx.linearUint8 && ts.isIdentifier(decl.name) && isLocalLinearNewBinding(ctx, decl.name)) {
+        continue;
+      }
       if (ts.isIdentifier(decl.name)) {
         const name = decl.name.text;
         if (fctx.localMap.has(name)) continue;

--- a/src/codegen/linear-uint8-codegen.ts
+++ b/src/codegen/linear-uint8-codegen.ts
@@ -1,0 +1,530 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1886 Slice B — codegen for linear-backed `Uint8Array` buffers.
+ *
+ * A buffer proven linear-safe by the #1886 analysis (`ctx.linearUint8`, Slice A)
+ * is represented as a `(ptr, len)` pair of i32 locals rather than a WasmGC vec
+ * struct. This module owns the per-function buffer registry
+ * (`fctx.linearU8Buffers`) and the small emit helpers the four wiring sites call:
+ *
+ *   - `tryEmitLinearU8New`  — `new Uint8Array(n)` / `new Uint8Array([..])` →
+ *     bind `(ptr=__lin_u8_alloc(n), len=n)` instead of `array.new_default`.
+ *   - `tryEmitLinearU8ElementGet` — `b[i]` → `i32.load8_u (ptr+i)` widened to f64
+ *     (the observable element value type the GC path also returns).
+ *   - `tryEmitLinearU8ElementSet` — `b[i] = v` → `i32.store8 (ptr+i), trunc(v)`.
+ *   - `tryEmitLinearU8Length` — `b.length` → `len` widened to f64.
+ *
+ * All entry points are **additive guards**: they return `false`/`null` unless
+ * the receiver is a registered linear-safe buffer, so any other `Uint8Array`
+ * (escaping, non-WASI, or not yet bound here) falls through to the existing GC
+ * path unchanged. Slice B is intraprocedural-only — buffers threaded through
+ * function *parameters* keep the GC path until the Slice C signature rewrite.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { ensureLinearU8AllocHelper } from "./index.js";
+import { compileExpression } from "./shared.js";
+
+/**
+ * True when this `Uint8Array` binding (variable or param) was proven linear-safe
+ * by Slice A. Resolves the identifier's symbol and consults
+ * `ctx.linearUint8.safeBindings`. Returns false outside WASI or when the
+ * analysis didn't run.
+ */
+export function isLinearSafeBinding(ctx: CodegenContext, node: ts.Node): boolean {
+  if (!ctx.linearUint8) return false;
+  if (!ts.isIdentifier(node)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(node);
+  return !!sym && ctx.linearUint8.safeBindings.has(sym);
+}
+
+/** Look up the (ptr, len) locals for a linear-backed buffer identifier, if bound. */
+function lookupBuffer(fctx: FunctionContext, node: ts.Node): { ptrLocalIdx: number; lenLocalIdx: number } | undefined {
+  if (!fctx.linearU8Buffers || !ts.isIdentifier(node)) return undefined;
+  return fctx.linearU8Buffers.get(node.text);
+}
+
+/**
+ * `process.std{in.read,out.write,err.write}(buf, …)` argument index carrying the
+ * buffer (0), or -1 if `call` is not a recognised std-stream I/O intrinsic. These
+ * are the only call sites Slice B can linear-back, because the WASI lowering reads
+ * `(ptr,len)` directly (zero-copy) rather than passing a GC vec across a call ABI.
+ * Mirrors `ioBufferArgIndex` in linear-uint8-analysis.ts.
+ */
+function ioIntrinsicBufferArgIndex(call: ts.CallExpression): number {
+  const callee = call.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return -1;
+  const method = callee.name.text;
+  const stream = callee.expression;
+  if (!ts.isPropertyAccessExpression(stream)) return -1;
+  const streamName = stream.name.text;
+  const root = stream.expression;
+  if (!(ts.isIdentifier(root) && root.text === "process")) return -1;
+  if (streamName === "stdin" && method === "read") return 0;
+  if ((streamName === "stdout" || streamName === "stderr") && method === "write") return 0;
+  return -1;
+}
+
+/** The function-like (or source-file) node that lexically encloses `node`. */
+function enclosingFunctionOf(node: ts.Node): ts.Node {
+  let n: ts.Node | undefined = node.parent;
+  while (n) {
+    if (
+      ts.isFunctionDeclaration(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isArrowFunction(n) ||
+      ts.isMethodDeclaration(n) ||
+      ts.isSourceFile(n)
+    ) {
+      return n;
+    }
+    n = n.parent;
+  }
+  return node.getSourceFile();
+}
+
+/** True if `node` is lexically inside a loop body within its enclosing function. */
+function isInsideLoop(node: ts.Node, stopAt: ts.Node): boolean {
+  let n: ts.Node | undefined = node.parent;
+  while (n && n !== stopAt) {
+    if (
+      ts.isForStatement(n) ||
+      ts.isForOfStatement(n) ||
+      ts.isForInStatement(n) ||
+      ts.isWhileStatement(n) ||
+      ts.isDoStatement(n)
+    ) {
+      return true;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
+/**
+ * Slice B's bump arena (`__lin_u8_alloc`) is monotonic — it never frees within a
+ * program run (arena reset is Slice D). So a `new Uint8Array(...)` that can run
+ * more than once would leak linear memory on every iteration (observed: the
+ * native-messaging host's per-frame `frame` buffer growing the arena ~1 MiB ×
+ * frames). Until Slice D adds a stack/scope reset, Slice B only linear-backs an
+ * allocation that is provably executed AT MOST ONCE per run:
+ *   - the `new` is not lexically inside a loop in its own function, AND
+ *   - its enclosing function is the module entry (compiled once) OR is never
+ *     *called* from inside a loop and is not called more than once.
+ * A buffer that fails this stays GC-backed (byte-identical to today), so the
+ * host keeps its flat-memory guarantee; the per-frame win lands in Slice C/D.
+ */
+function isAllocatedAtMostOnce(checker: ts.TypeChecker, decl: ts.VariableDeclaration): boolean {
+  const fn = enclosingFunctionOf(decl);
+  // (1) the allocation must not be inside a loop in its own function.
+  if (isInsideLoop(decl, fn)) return false;
+  // The module entry (top-level / source-file scope) runs once.
+  if (ts.isSourceFile(fn)) return true;
+  // (2) the enclosing function must not be invoked from a loop, and must be
+  // called at most once across the whole program. Resolve the function symbol
+  // and scan every reference: a call ref inside a loop, or >1 call site,
+  // disqualifies it (conservative — indirect/aliased calls can't be bounded).
+  const fnName = ts.isFunctionDeclaration(fn) || ts.isMethodDeclaration(fn) ? fn.name : undefined;
+  if (!fnName || !ts.isIdentifier(fnName)) return false; // anonymous / arrow / expr — can't bound call sites
+  const fnSym = checker.getSymbolAtLocation(fnName);
+  if (!fnSym) return false;
+
+  let callCount = 0;
+  let calledInLoop = false;
+  const sf = decl.getSourceFile();
+  const scan = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      if (checker.getSymbolAtLocation(node.expression) === fnSym) {
+        callCount++;
+        if (isInsideLoop(node, enclosingFunctionOf(node))) calledInLoop = true;
+        // also a loop in any ancestor function chain would matter, but the
+        // conservative single-call-site cap below already excludes the common
+        // re-entry shapes; keep this simple + sound.
+      }
+    }
+    ts.forEachChild(node, scan);
+  };
+  scan(sf);
+  return callCount <= 1 && !calledInLoop;
+}
+
+/**
+ * True when every reference to `sym` inside its declaring function is a use Slice
+ * B can lower *intraprocedurally*: `b[i]` / `b[i] = v`, `b.length`, or an
+ * I/O-intrinsic argument (`process.std*.{read,write}(b)`). A reference passed to
+ * any **user function** (even one whose corresponding param Slice A proved
+ * linear-safe) disqualifies the buffer here: Slice B does NOT rewrite callee
+ * signatures (that is Slice C), so the callee still receives a GC vec while this
+ * binding would be a `(ptr,len)` pair — a representation split the call ABI can't
+ * bridge. Slice A's `safeBindings` is deliberately permissive (it admits the
+ * cross-function flow for Slice C); this is the Slice-B-only tightening the
+ * findings called for.
+ */
+function isUsedOnlyIntraprocedurally(ctx: CodegenContext, sym: ts.Symbol): boolean {
+  const decl = sym.getDeclarations?.()?.[0];
+  if (!decl) return false;
+  // The enclosing function/source whose body holds all of this local's uses.
+  let scope: ts.Node = decl;
+  while (
+    scope.parent &&
+    !ts.isFunctionDeclaration(scope) &&
+    !ts.isFunctionExpression(scope) &&
+    !ts.isArrowFunction(scope) &&
+    !ts.isMethodDeclaration(scope) &&
+    !ts.isSourceFile(scope)
+  ) {
+    scope = scope.parent;
+  }
+
+  let ok = true;
+  const visit = (node: ts.Node): void => {
+    if (!ok) return;
+    if (ts.isIdentifier(node) && ctx.checker.getSymbolAtLocation(node) === sym) {
+      const p = node.parent;
+      // binding site (the `const b = …` name itself) — not a use.
+      if (ts.isVariableDeclaration(p) && p.name === node) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      // b[i] / b[i] = v   (buffer is the object, not the index)
+      if (ts.isElementAccessExpression(p) && p.expression === node) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      // b.length (the only allowed property read)
+      if (ts.isPropertyAccessExpression(p) && p.expression === node && p.name.text === "length") {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      // I/O-intrinsic argument: process.std*.{read,write}(b, …)
+      if (ts.isCallExpression(p) && p.expression !== node) {
+        const argIdx = p.arguments.indexOf(node as ts.Expression);
+        if (argIdx >= 0 && ioIntrinsicBufferArgIndex(p) === argIdx) {
+          ts.forEachChild(node, visit);
+          return;
+        }
+      }
+      // Any other use — incl. a user-function call argument — escapes Slice B.
+      ok = false;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(scope);
+  return ok;
+}
+
+/**
+ * Slice B is intraprocedural: a binding qualifies for linear backing here only
+ * if it is a `new Uint8Array(...)` *local* (not a parameter — params stay GC
+ * until the Slice C signature rewrite). The Slice-A set includes params AND
+ * locals that flow into linear-safe callee params (forward-looking to Slice C),
+ * so Slice B additionally requires (a) the declaration to be a
+ * `VariableDeclaration` initialised by `new Uint8Array(...)`, and (b) the
+ * binding to be used ONLY intraprocedurally (no user-function call argument) —
+ * see `isUsedOnlyIntraprocedurally`.
+ */
+export function isLocalLinearNewBinding(ctx: CodegenContext, nameNode: ts.Identifier): boolean {
+  if (!isLinearSafeBinding(ctx, nameNode)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(nameNode);
+  if (!sym) return false;
+  const decls = sym.getDeclarations() ?? [];
+  const newDecl = decls.find(
+    (d): d is ts.VariableDeclaration =>
+      ts.isVariableDeclaration(d) &&
+      !!d.initializer &&
+      ts.isNewExpression(d.initializer) &&
+      ts.isIdentifier(d.initializer.expression) &&
+      d.initializer.expression.text === "Uint8Array",
+  );
+  if (!newDecl) return false;
+  if (!isUsedOnlyIntraprocedurally(ctx, sym)) return false;
+  // Bump-arena leak guard until Slice D's arena reset: only back allocations
+  // provably executed at most once per run (see isAllocatedAtMostOnce).
+  return isAllocatedAtMostOnce(ctx.checker, newDecl);
+}
+
+/**
+ * True iff at least one `const/let x = new Uint8Array(...)` binding in the source
+ * actually qualifies for Slice-B linear backing (`isLocalLinearNewBinding`). Used
+ * to gate the eager `__lin_u8_alloc` emit: if nothing qualifies, the helper is
+ * never emitted (no dead code) and — since no `call __lin_u8_alloc` site exists —
+ * the funcMap-shift hazard the eager emit defends against cannot arise either.
+ * Walks the whole file once; cheap relative to compilation.
+ */
+export function sourceHasLinearBackedUint8(ctx: CodegenContext, sourceFile: ts.SourceFile): boolean {
+  if (!ctx.linearUint8 || ctx.linearUint8.safeBindings.size === 0) return false;
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isNewExpression(node.initializer) &&
+      isLocalLinearNewBinding(ctx, node.name)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * `new Uint8Array(n)` / `new Uint8Array([a,b,…])` for a linear-safe local being
+ * declared as `nameNode`. Allocates `(ptr, len)` i32 locals, calls
+ * `__lin_u8_alloc(n)`, and (for the array-literal form) stores the literal
+ * bytes. Registers the buffer in `fctx.linearU8Buffers` and leaves NOTHING on
+ * the value stack (the binding lives in the two i32 locals). Returns true if it
+ * handled the `new`; false to fall through to the GC path.
+ *
+ * Caller contract: invoked from the variable-declaration lowering for a
+ * `const/let x = new Uint8Array(...)` where `isLocalLinearNewBinding(x)` holds.
+ */
+export function tryEmitLinearU8New(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  nameNode: ts.Identifier,
+  newExpr: ts.NewExpression,
+): boolean {
+  if (!isLocalLinearNewBinding(ctx, nameNode)) return false;
+  const allocIdx = ensureLinearU8AllocHelper(ctx);
+  if (allocIdx < 0) return false;
+
+  const args = newExpr.arguments ?? ([] as unknown as ts.NodeArray<ts.Expression>);
+  const ptrLocal = allocLocal(fctx, `__linu8_ptr_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  const lenLocal = allocLocal(fctx, `__linu8_len_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+
+  // Array-literal form: `new Uint8Array([a, b, c])` — length = element count,
+  // then store each (constant or computed) byte.
+  if (args.length === 1 && ts.isArrayLiteralExpression(args[0]!)) {
+    const elems = args[0]!.elements;
+    fctx.body.push({ op: "i32.const", value: elems.length } as Instr);
+    fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: elems.length } as Instr);
+    fctx.body.push({ op: "call", funcIdx: allocIdx } as Instr);
+    fctx.body.push({ op: "local.set", index: ptrLocal } as Instr);
+    elems.forEach((el, i) => {
+      // address = ptr + i
+      fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+      if (i > 0) {
+        fctx.body.push({ op: "i32.const", value: i } as Instr);
+        fctx.body.push({ op: "i32.add" } as Instr);
+      }
+      // value = trunc(elem) — element expr compiled in f64 then truncated to a byte.
+      compileExpression(ctx, fctx, el, { kind: "f64" });
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+      fctx.body.push({ op: "i32.store8", align: 0, offset: 0 } as Instr);
+    });
+    registerBuffer(fctx, nameNode.text, ptrLocal, lenLocal);
+    return true;
+  }
+
+  // Length form: `new Uint8Array(n)` (or `new Uint8Array()` ⇒ 0).
+  if (args.length >= 1) {
+    compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+  // ptr = __lin_u8_alloc(len)
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "call", funcIdx: allocIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: ptrLocal } as Instr);
+  registerBuffer(fctx, nameNode.text, ptrLocal, lenLocal);
+  return true;
+}
+
+function registerBuffer(fctx: FunctionContext, name: string, ptrLocalIdx: number, lenLocalIdx: number): void {
+  if (!fctx.linearU8Buffers) fctx.linearU8Buffers = new Map();
+  fctx.linearU8Buffers.set(name, { ptrLocalIdx, lenLocalIdx });
+}
+
+/**
+ * `b[i]` read for a linear-backed buffer → `i32.load8_u (ptr + trunc(i))`,
+ * widened to f64 to match the observable element value type the GC path
+ * returns. Returns the result ValType, or `null` if `b` is not linear-backed.
+ */
+export function tryEmitLinearU8ElementGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.ElementAccessExpression,
+): ValType | null {
+  const buf = lookupBuffer(fctx, expr.expression);
+  if (!buf) return null;
+  // address = ptr + trunc(index)
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.load8_u", align: 0, offset: 0 } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * `b[i] = v` for a linear-backed buffer → `i32.store8 (ptr + trunc(i)),
+ * trunc(v) & 0xff`. Returns the assigned value's ValType (f64) and **leaves the
+ * assigned value on the stack** (the assignment-expression result, matching the
+ * GC `array.set` path which returns `local.get valLocal`). Returns `null` if `b`
+ * is not a linear-backed buffer (caller falls through to GC).
+ *
+ * Evaluation order matches JS + the GC path: index expression first, then the
+ * value expression, then the store.
+ */
+export function tryEmitLinearU8ElementSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.ElementAccessExpression,
+  valueExpr: ts.Expression,
+): ValType | null {
+  const buf = lookupBuffer(fctx, target.expression);
+  if (!buf) return null;
+  // Allocate the result/addr temps up-front so their slot indices are fixed
+  // before the nested index/value sub-expressions compile (those allocate their
+  // own temps as they go). Each sub-expression is fully evaluated into a temp
+  // before the next is compiled, so no stash ever interleaves with another
+  // expression's temp usage on the value stack (#1886).
+  const addrLocal = allocLocal(fctx, `__linu8_addr_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  const valLocal = allocLocal(fctx, `__linu8_val_${fctx.locals.length}`, {
+    kind: "f64",
+  });
+
+  // addr = ptr + trunc(index)  (index evaluated first, per JS + the GC path)
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  compileExpression(ctx, fctx, target.argumentExpression, { kind: "f64" });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "local.set", index: addrLocal } as Instr);
+  // val = v (kept as f64 for the assignment-expression result)
+  compileExpression(ctx, fctx, valueExpr, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+  // mem[addr] = (u8) trunc(val) — low byte kept by i32.store8.
+  fctx.body.push({ op: "local.get", index: addrLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i32.store8", align: 0, offset: 0 } as Instr);
+  // assignment-expression result = the assigned value (f64).
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  return { kind: "f64" };
+}
+
+/** `b.length` for a linear-backed buffer → `len` widened to f64. */
+export function tryEmitLinearU8Length(fctx: FunctionContext, expr: ts.PropertyAccessExpression): ValType | null {
+  if (expr.name.text !== "length") return null;
+  const buf = lookupBuffer(fctx, expr.expression);
+  if (!buf) return null;
+  fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+  return { kind: "f64" };
+}
+
+/** Accessor used by the WASI I/O intrinsics to get a buffer's (ptr, len) locals. */
+export function getLinearU8Buffer(
+  fctx: FunctionContext,
+  node: ts.Node,
+): { ptrLocalIdx: number; lenLocalIdx: number } | undefined {
+  return lookupBuffer(fctx, node);
+}
+
+/**
+ * Zero-copy `process.stdin.read(buf, off?)` for a linear-backed buffer.
+ * `fd_read` targets `ptr + off` directly (no GC↔linear element-copy loop) and
+ * returns the byte count (f64). Returns `null` if `buf` is not linear-backed.
+ *
+ * Layout reuse: the iovec lives at memory[0..7] and nwritten/nread at
+ * memory[8..11] — the same scratch slots the existing `__wasi_write_*` helpers
+ * and the GC stdin-read path use.
+ */
+export function tryEmitLinearU8StdinRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  fdReadIdx: number,
+): ValType | null {
+  const buf = lookupBuffer(fctx, expr.arguments[0]!);
+  if (!buf) return null;
+
+  // off = arg1 (trunc) or 0
+  const offLocal = allocLocal(fctx, `__linu8_rdoff_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  if (expr.arguments.length >= 2) {
+    compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: offLocal } as Instr);
+
+  // iovec.buf = ptr + off   (memory[0])
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // iovec.buf_len = len - off   (memory[4])
+  fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+  fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+  fctx.body.push({ op: "i32.sub" } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // fd_read(fd=0, iovs=0, iovs_len=1, nread=8) — bytes land directly in linear
+  // memory at ptr+off (zero copy).
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "call", funcIdx: fdReadIdx } as Instr);
+  fctx.body.push({ op: "drop" } as Instr);
+  // return nread (memory[8]) as f64
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "i32.load", align: 2, offset: 0 } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * Zero-copy `process.stdout/stderr.write(buf)` for a linear-backed buffer.
+ * `fd_write` reads straight from `ptr` for `len` bytes — no GC→linear staging
+ * copy. Returns `true` if handled (and leaves the i32 `1` write-result on the
+ * stack, matching the GC write path), `null` if `buf` is not linear-backed.
+ */
+export function tryEmitLinearU8StdWrite(
+  fctx: FunctionContext,
+  bufArg: ts.Expression,
+  fdWriteIdx: number,
+  useStderr: boolean,
+): boolean {
+  const buf = lookupBuffer(fctx, bufArg);
+  if (!buf) return false;
+  const fd = useStderr ? 2 : 1;
+  // iovec.buf = ptr (memory[0])
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // iovec.buf_len = len (memory[4])
+  fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+  fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // fd_write(fd, iovs=0, iovs_len=1, nwritten=8) — reads directly from ptr.
+  fctx.body.push({ op: "i32.const", value: fd } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "call", funcIdx: fdWriteIdx } as Instr);
+  fctx.body.push({ op: "drop" } as Instr);
+  return true;
+}

--- a/src/codegen/node-process-api.ts
+++ b/src/codegen/node-process-api.ts
@@ -24,6 +24,7 @@ import {
 } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
+import { tryEmitLinearU8StdinRead, tryEmitLinearU8StdWrite } from "./linear-uint8-codegen.js";
 
 export function tryCompileNodeProcessCall(
   ctx: CodegenContext,
@@ -50,6 +51,20 @@ export function tryCompileNodeProcessCall(
 
   const { useStderr } = stdoutWrite;
   const argExpr = expr.arguments[0]!;
+
+  // #1886 Slice B: zero-copy `process.std*.write(buf)` for a linear-backed
+  // Uint8Array — fd_write reads straight from `ptr` for `len` bytes (no
+  // GC→linear staging copy). Only fires for a registered linear-safe buffer.
+  if (ctx.wasiFdWriteIdx !== undefined && ctx.wasiFdWriteIdx >= 0) {
+    if (tryEmitLinearU8StdWrite(fctx, argExpr, ctx.wasiFdWriteIdx, useStderr)) {
+      // Match the GC Uint8Array write path's contract: push `1` (write
+      // succeeded) and return i32, so the expression-statement wrapper drops it
+      // exactly like the GC path. (#1886)
+      fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+      return { kind: "i32" };
+    }
+  }
+
   const argTsType = ctx.checker.getTypeAtLocation(argExpr);
   if (isStringType(argTsType)) {
     const compiled = compileExpression(ctx, fctx, argExpr);
@@ -162,6 +177,11 @@ function matchProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr:
 function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult | null {
   const fdReadIdx = ctx.wasiFdReadIdx;
   if (fdReadIdx === undefined || fdReadIdx < 0) return null;
+
+  // #1886 Slice B: when the buffer arg is a linear-backed Uint8Array, fd_read
+  // straight into `ptr+off` — no GC↔linear element-copy loop.
+  const linRead = tryEmitLinearU8StdinRead(ctx, fctx, expr, fdReadIdx);
+  if (linRead !== null) return linRead;
 
   const bufType = compileExpression(ctx, fctx, expr.arguments[0]!);
   if (!bufType || (bufType.kind !== "ref" && bufType.kind !== "ref_null") || !("typeIdx" in bufType)) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -26,6 +26,7 @@ import { patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
+import { tryEmitLinearU8ElementGet, tryEmitLinearU8Length } from "./linear-uint8-codegen.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -975,6 +976,12 @@ export function compilePropertyAccess(
   if (expr.questionDotToken) {
     return compileOptionalPropertyAccess(ctx, fctx, expr);
   }
+
+  // #1886 Slice B: linear-backed Uint8Array `buf.length` → the len i32 local
+  // (widened to f64). Only fires for a registered linear-safe buffer; any other
+  // receiver falls through to the GC property-access path unchanged.
+  const linU8Len = tryEmitLinearU8Length(fctx, expr);
+  if (linU8Len !== null) return linU8Len;
 
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const propName = ts.isPrivateIdentifier(expr.name) ? "__priv_" + expr.name.text.slice(1) : expr.name.text;
@@ -3314,6 +3321,12 @@ export function compileElementAccess(
 ): ValType | null {
   const jsonParseElementType = tryEmitJsonParseElementAccess(ctx, fctx, expr);
   if (jsonParseElementType !== undefined) return jsonParseElementType;
+
+  // #1886 Slice B: linear-backed Uint8Array read `buf[i]` → i32.load8_u(ptr+i).
+  // Only fires when `buf` is a registered linear-safe buffer in this function;
+  // every other receiver falls through to the GC element-access path unchanged.
+  const linU8Get = tryEmitLinearU8ElementGet(ctx, fctx, expr);
+  if (linU8Get !== null) return linU8Get;
 
   // Handle super[expr] — access parent class property via computed key on `this`
   if (expr.expression.kind === ts.SyntaxKind.SuperKeyword) {

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -20,6 +20,7 @@ import { compileArrayDestructuring, compileObjectDestructuring } from "./destruc
 import { emitLocalTdzInit, emitTdzInit } from "./tdz.js";
 import { ensureNativeStringHelpers } from "../native-strings.js";
 import { compileStringBuilderInit } from "../string-builder.js";
+import { tryEmitLinearU8New } from "../linear-uint8-codegen.js";
 
 function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): ValType | null {
   if (!ts.isIdentifier(decl.name)) return null;
@@ -299,6 +300,22 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       // (compileStringBuilderInit didn't set localMap, so emitTdzInit only
       // touches the flag local if one was already allocated by the hoist
       // pre-pass.)
+      emitTdzInit(ctx, fctx, name);
+      continue;
+    }
+
+    // #1886 Slice B: linear-backed Uint8Array. When the analysis proved this
+    // `new Uint8Array(...)` binding is a pure I/O buffer that never escapes the
+    // GC heap, back it by linear memory (a (ptr,len) pair) instead of a GC vec.
+    // Like the string-builder path above, the binding name is intentionally NOT
+    // placed in `localMap` — element-access/.length/I/O reads route through
+    // `fctx.linearU8Buffers` (see linear-uint8-codegen.ts). The TDZ flag, if the
+    // hoist pre-pass allocated one, is marked initialised.
+    if (
+      decl.initializer &&
+      ts.isNewExpression(decl.initializer) &&
+      tryEmitLinearU8New(ctx, fctx, decl.name, decl.initializer)
+    ) {
       emitTdzInit(ctx, fctx, name);
       continue;
     }

--- a/tests/issue-1886-slice-b.test.ts
+++ b/tests/issue-1886-slice-b.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1886 Slice B — codegen for linear-backed `Uint8Array` buffers.
+ *
+ * Slice A (a separate test file) proves WHICH buffers are linear-safe. Slice B
+ * is the codegen that backs a qualifying `new Uint8Array(n)` *local* by a
+ * `(ptr,len)` pair in linear memory instead of a WasmGC vec, lowering `b[i]` /
+ * `b[i] = v` / `b.length` to `i32.load8_u` / `i32.store8` / a `len` local, and
+ * `process.std*.{read,write}(b)` to zero-copy `fd_read` / `fd_write`.
+ *
+ * These tests assert three things:
+ *   1. The lowering FIRES for an intraprocedural, allocate-once buffer (the .wat
+ *      shows `i32.store8` / `i32.load8_u` and no GC `array.set`/`$buf` local in
+ *      the user function) AND the module VALIDATES — the original Slice-B WIP
+ *      produced a void function ending in a bare `ref.null extern` (#1886).
+ *   2. The lowering is CORRECT at runtime: a stdin → `buf[i]` r/w → stdout
+ *      round-trip produces the right bytes.
+ *   3. The Slice-B-only constraints hold (escape / multi-alloc / param-threaded
+ *      buffers stay GC-backed), so a WASI program with no qualifying buffer is
+ *      byte-identical to today.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile `source` with `--target wasi` and return the binary + .wat text. */
+async function compileWasi(source: string): Promise<{ binary: Uint8Array; wat: string }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success || !result.binary) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  return { binary: result.binary, wat: result.wat ?? "" };
+}
+
+/**
+ * Minimal raw-byte WASI host: preloads stdin and captures every fd_write byte
+ * (no line buffering, so binary output is observable). Returns the captured
+ * stdout/stderr bytes after running the module's exported `main`.
+ */
+async function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Promise<{ stdout: Uint8Array; stderr: Uint8Array }> {
+  // Mutable state held in a const holder (the host closures are only invoked
+  // after `state.memory` is set, but they capture it by reference).
+  const state: { memory: WebAssembly.Memory | undefined; stdinPos: number } = {
+    memory: undefined,
+    stdinPos: 0,
+  };
+  const out: number[] = [];
+  const err: number[] = [];
+
+  const wasi = {
+    fd_read(fd: number, iovs: number, _iovsLen: number, nread: number): number {
+      const memory = state.memory;
+      if (fd !== 0 || !memory) return -1;
+      const view = new DataView(memory.buffer);
+      const ptr = view.getUint32(iovs, true);
+      const len = view.getUint32(iovs + 4, true);
+      const n = Math.min(len, stdin.length - state.stdinPos);
+      new Uint8Array(memory.buffer, ptr, n).set(stdin.subarray(state.stdinPos, state.stdinPos + n));
+      state.stdinPos += n;
+      view.setUint32(nread, n, true);
+      return 0;
+    },
+    fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const memory = state.memory;
+      if (!memory) return -1;
+      const view = new DataView(memory.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const bytes = new Uint8Array(memory.buffer, ptr, len);
+        const sink = fd === 2 ? err : out;
+        for (const b of bytes) sink.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit() {},
+    fd_close: () => 0,
+    fd_seek: () => 0,
+    fd_fdstat_get: () => 0,
+    environ_get: () => 0,
+    environ_sizes_get: () => 0,
+    clock_time_get: () => 0,
+    random_get: () => 0,
+    poll_oneoff: () => 0,
+    path_open: () => 0,
+  };
+
+  const module = await WebAssembly.compile(binary);
+  const instance = await WebAssembly.instantiate(module, {
+    wasi_snapshot_preview1: wasi,
+  });
+  const exports = instance.exports as Record<string, unknown>;
+  state.memory = exports.memory as WebAssembly.Memory;
+  const main = exports.main as (() => void) | undefined;
+  if (main) main();
+  return { stdout: new Uint8Array(out), stderr: new Uint8Array(err) };
+}
+
+const IO_DECL = `
+declare const process: {
+  stdin: { read(b: Uint8Array, off?: number): number };
+  stdout: { write(b: Uint8Array): void };
+};
+`;
+
+describe("#1886 Slice B — linear-backed Uint8Array codegen", () => {
+  it("element-set-only void main validates (no trailing ref.null extern)", async () => {
+    // The original WIP left a bare `ref.null extern` at the end of this void
+    // function (a value on the stack at function exit) → invalid wasm. Validating
+    // (WebAssembly.compile throws on invalid) is the regression gate.
+    const { binary, wat } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(8);
+        buf[0] = (buf[0] + 1) & 255;
+      }
+    `);
+    await expect(WebAssembly.compile(binary)).resolves.toBeDefined();
+    // The lowering fired: store8 present, no GC vec write in main.
+    expect(wat).toContain("i32.store8");
+  });
+
+  it("lowers buf[i] r/w + I/O to linear ops (store8/load8, no GC $buf local)", async () => {
+    const { wat } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(8);
+        process.stdin.read(buf, 0);
+        buf[0] = (buf[0] + 1) & 255;
+        process.stdout.write(buf);
+      }
+    `);
+    const mainBody = wat.slice(wat.indexOf("(func $main"), wat.indexOf("(func $__box_number"));
+    expect(mainBody).toContain("i32.store8");
+    expect(mainBody).toContain("i32.load8_u");
+    // GC element ops must NOT appear in the linear path.
+    expect(mainBody).not.toContain("array.set");
+    expect(mainBody).not.toContain("array.get");
+    // The bump allocator + page-4 arena global are emitted.
+    expect(wat).toContain("__lin_u8_alloc");
+    expect(wat).toContain("__lin_u8_arena_ptr");
+  });
+
+  it("round-trips correctly: stdin byte 0x41 → buf[0]=(0x41+1)&255=0x42 → stdout", async () => {
+    const { binary } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(8);
+        process.stdin.read(buf, 0);
+        buf[0] = (buf[0] + 1) & 255;
+        process.stdout.write(buf);
+      }
+    `);
+    const { stdout } = await runWasiRaw(binary, new Uint8Array([0x41]));
+    expect(stdout.length).toBe(8);
+    expect(stdout[0]).toBe(0x42); // 'A' + 1 = 'B'
+    expect(Array.from(stdout.subarray(1))).toEqual([0, 0, 0, 0, 0, 0, 0]); // rest zero-filled
+  });
+
+  it("reads buf.length from the linear len local", async () => {
+    const { binary } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(5);
+        const one = new Uint8Array(1);
+        one[0] = buf.length & 255;
+        process.stdout.write(one);
+      }
+    `);
+    const { stdout } = await runWasiRaw(binary, new Uint8Array([]));
+    expect(stdout.length).toBe(1);
+    expect(stdout[0]).toBe(5);
+  });
+
+  it("multiple linear writes in one loop sum correctly (sanity)", async () => {
+    const { binary } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        let i = 0;
+        while (i < 4) {
+          buf[i] = (i + 1) & 255;
+          i = i + 1;
+        }
+        process.stdout.write(buf);
+      }
+    `);
+    const { stdout } = await runWasiRaw(binary, new Uint8Array([]));
+    expect(Array.from(stdout)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("escaping Uint8Array (returned from its function) stays GC-backed and compiles", async () => {
+    // A buffer that escapes the GC heap (here: returned to the caller) must NOT
+    // be linear-backed — it compiles via the GC vec path. The module validates
+    // and no linear backing is emitted for the escaping buffer.
+    const { binary, wat } = await compileWasi(`${IO_DECL}
+      function makeBuf(): Uint8Array {
+        const buf = new Uint8Array(4);
+        buf[0] = 7;
+        return buf; // escape → GC path
+      }
+      export function main(): void {
+        const b = makeBuf();
+        process.stdout.write(b);
+      }
+    `);
+    await expect(WebAssembly.compile(binary)).resolves.toBeDefined();
+    // The returned buffer is GC-backed: no linear (ptr,len) locals anywhere.
+    expect(wat).not.toContain("__linu8_ptr_");
+  });
+
+  it("buffer threaded through a helper-function param stays GC-backed (Slice B is intraprocedural)", async () => {
+    // The native-messaging host shape: a buffer passed to a user function. Slice
+    // B must NOT linear-back it (no callee-signature rewrite until Slice C), so
+    // no allocator is emitted and the module is byte-identical to GC-backed.
+    const { binary, wat } = await compileWasi(`${IO_DECL}
+      function fill(b: Uint8Array): void { b[0] = 9; }
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        fill(buf);
+        process.stdout.write(buf);
+      }
+    `);
+    await expect(WebAssembly.compile(binary)).resolves.toBeDefined();
+    // No linear backing kicked in for a param-threaded buffer.
+    expect(wat).not.toContain("__lin_u8_alloc");
+    expect(wat).not.toContain("__linu8_ptr_");
+  });
+
+  it("buffer allocated inside a loop stays GC-backed (bump arena has no reset until Slice D)", async () => {
+    const { wat } = await compileWasi(`${IO_DECL}
+      export function main(): void {
+        let i = 0;
+        while (i < 3) {
+          const tmp = new Uint8Array(2);
+          tmp[0] = i & 255;
+          process.stdout.write(tmp);
+          i = i + 1;
+        }
+      }
+    `);
+    // Allocate-once guard: a loop-body new must not be linear-backed.
+    expect(wat).not.toContain("__lin_u8_alloc");
+  });
+
+  it("WASI program with no Uint8Array is unaffected (no arena global, no allocator)", async () => {
+    const { wat } = await compileWasi(`console.log("plain wasi");`);
+    expect(wat).not.toContain("__lin_u8_arena_ptr");
+    expect(wat).not.toContain("__lin_u8_alloc");
+  });
+});


### PR DESCRIPTION
## #1886 Slice B — intraprocedural linear-backed `Uint8Array` codegen

Slice A (escape analysis) is merged. This is **Slice B**: the codegen that backs
a qualifying `new Uint8Array(...)` **local** by a `(ptr,len)` pair in linear
memory instead of a WasmGC vec — `b[i]` → `i32.load8_u`, `b[i]=v` →
`i32.store8`, `b.length` → a `len` local, and `process.std*.{read,write}(b)` →
zero-copy `fd_read`/`fd_write`. GC fallback is intact for every other
`Uint8Array`.

### Root cause of the WIP's wasm-validation failure (fixed)

The WIP failed validation with a void `main` ending in a bare `ref.null extern`
(`expected externref, found i32`). Two distinct bugs:

1. **Allocator funcIdx desync.** The WIP pre-emitted `__lin_u8_alloc` *before*
   `collectAllSourceImports`. `addImport` does **not** shift already-registered
   defined functions, so later imports shifted the import/defined boundary and
   left `call __lin_u8_alloc` pointing at an *import*. The wrong arity made the
   function's net stack delta `-1`; `stackBalance`'s function-level
   `fixBranch(expected=0)` then pushed a `ref.null extern` into the
   empty-block-typed void body to "fill" the perceived missing value → a value
   on the stack at function exit → invalid. **Fix:** emit `__lin_u8_alloc` in
   the deferred-helper zone (after the import scan, before the final
   native-string reconcile + user functions), matching
   `emitToUint32Helper`/`emitDeferredWasiHelpers`.
2. **Predicate mismatch.** The hoist pre-pass skipped the GC `$buf` local on the
   raw Slice-A `safeBindings` set, while the declaration site used the tighter
   Slice-B predicate. A buffer Slice A admitted but Slice B declined was left
   with no storage and pulled in GC extern helpers, desyncing `__str_flatten`.
   Both sites now share `isLocalLinearNewBinding`.

### Slice B scope (strictly intraprocedural + leak-free)

A buffer is linear-backed only if it is (1) a `new Uint8Array(...)` local,
(2) used **only intraprocedurally** (no user-function call argument — that needs
Slice C's signature rewrite), and (3) **allocated at most once per run** (not in
a loop; enclosing fn called ≤1× and never from a loop) — the bump arena has no
reset until Slice D. The arena global is registered on demand, so a WASI module
with no linear buffer is byte-identical to today.

### Validation

- `probe_u8` (single buffer in `main`) is linear-backed and round-trips
  correctly under wasmtime **v44** and **v45** (stdin `0x41` →
  `buf[0]=(0x41+1)&255=0x42` → stdout, rest zero-filled).
- `examples/native-messaging/nm_js2wasm.ts` compiles **byte-identical** to main
  (`cmp` passes). All its buffers escape via helper params (Slice C) or are
  per-frame-in-loop (Slice D), so Slice B correctly declines them; h2h on v44/v45
  is unchanged (`validJSON=true match=true`, 65 frames, flat ~24 MB on v45).
  **The host speedup is Slice C/D, not Slice B.**
- New `tests/issue-1886-slice-b.test.ts` (9 tests): validation, `buf[i]` r/w +
  I/O round-trip, `.length`, loop writes, and the escape/param/loop GC-fallback
  guards. `tests/issue-1886.test.ts` + `tests/wasi.test.ts` green.

Issue file: corrected the overstated "hold the body to beat AS" framing (linear
is the lever, not retention) and added `## Slice C` (interprocedural signature
rewrite — the host win) + `## Slice D` (zero-copy subarray view + arena reset)
sections. #1886 stays `in-progress` (Slices C/D remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)