### PR TITLE
feat(dashboard): make kanban cards clickable to view issue details

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -390,4 +390,8 @@ if (hasDashboardBundle) {
   );
 }
 
+// Copy plan/issues markdown files so dashboard issue.html can fetch them
+// client-side via the URL /plan/issues/<slug>.md
+copyDirectoryIfExists(join(PLAN_DIR, "issues"), join(PAGES_DIST, "plan", "issues"));
+
 console.log(`GitHub Pages artifact ready at ${PAGES_DIST}`);

--- a/website/dashboard/build-data.js
+++ b/website/dashboard/build-data.js
@@ -156,9 +156,11 @@ function loadIssues() {
       const sprintsIdx = dirSegments.lastIndexOf("sprints");
       const sprintFromDir =
         sprintsIdx >= 0 && sprintsIdx + 1 < dirSegments.length - 1 ? dirSegments[sprintsIdx + 1] : "";
+      const slug = f.replace(".md", "");
       return {
         id,
         title,
+        slug,
         priority: fm.priority || "medium",
         feasibility: fm.feasibility || "",
         depends_on: fm.depends_on || [],

--- a/website/dashboard/index.html
+++ b/website/dashboard/index.html
@@ -398,14 +398,17 @@
       }
 
       .kanban-card {
+        display: block;
         padding: 12px;
         border: 1px solid rgba(255, 255, 255, 0.12);
         background: rgba(255, 255, 255, 0.025);
         margin-bottom: 8px;
-        cursor: default;
+        cursor: pointer;
         transition:
           background 0.18s ease,
           border-color 0.18s ease;
+        color: inherit;
+        text-decoration: none;
       }
 
       .kanban-card:hover {
@@ -882,13 +885,14 @@
           meta += `<span class="tag ${priority}" title="${prioTips[priority] || ""}">${priority}</span>`;
         if (feasibility && feasibility !== "medium")
           meta += `<span class="tag ${feasibility === "hard" ? "high" : "low"}" title="${feasTips[feasibility] || ""}">${feasibility}</span>`;
-        return `<div class="kanban-card">
+        const slug = fm.slug || `${id}`;
+        return `<a class="kanban-card" href="issue.html?slug=${slug}">
         <div class="title">${title}</div>
         <div class="card-footer">
           <div class="issue-num">#${id}</div>
           <div class="card-meta">${meta}</div>
         </div>
-      </div>`;
+      </a>`;
       }
 
       function getLatestSprint(sprints) {

--- a/website/dashboard/issue.html
+++ b/website/dashboard/issue.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Issue Detail — js2wasm</title>
+    <link rel="icon" href="../js2logo.svg" type="image/svg+xml" />
+    <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #060a14;
+        --fg: #ffffff;
+        --fg-soft: rgba(255, 255, 255, 0.78);
+        --fg-faint: rgba(255, 255, 255, 0.55);
+        --line-strong: rgba(255, 255, 255, 0.22);
+        --line: rgba(255, 255, 255, 0.14);
+        --surface: rgba(255, 255, 255, 0.04);
+        --surface-hover: rgba(255, 255, 255, 0.08);
+        --link: #8ab4ff;
+        --link-hover: #b8cdff;
+        --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg-soft);
+        font-family: var(--font);
+        font-size: 16px;
+        line-height: 1.65;
+      }
+      body {
+        max-width: 820px;
+        margin: 0 auto;
+        padding: 104px 28px 96px;
+      }
+      .breadcrumb {
+        font-size: 13px;
+        color: var(--fg-faint);
+        margin-bottom: 24px;
+      }
+      .breadcrumb a {
+        color: var(--link);
+        text-decoration: none;
+        transition: color 0.15s ease;
+      }
+      .breadcrumb a:hover {
+        color: var(--link-hover);
+      }
+      .breadcrumb span {
+        margin: 0 6px;
+        color: var(--fg-faint);
+      }
+      a {
+        color: var(--link);
+        text-decoration: none;
+        border-bottom: 1px solid transparent;
+        transition:
+          color 0.15s ease,
+          border-color 0.15s ease;
+      }
+      a:hover {
+        color: var(--link-hover);
+        border-bottom-color: currentColor;
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: var(--fg);
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      h1 {
+        font-size: 1.9rem;
+        line-height: 1.25;
+        margin: 0 0 28px;
+      }
+      h2 {
+        font-size: 1.25rem;
+        margin: 36px 0 12px;
+        padding-top: 8px;
+      }
+      h3 {
+        font-size: 1.05rem;
+        margin: 28px 0 10px;
+      }
+      p,
+      li {
+        color: var(--fg-soft);
+      }
+      p {
+        margin: 0 0 16px;
+      }
+      ul,
+      ol {
+        padding-left: 1.4em;
+        margin: 0 0 16px;
+      }
+      li {
+        margin: 4px 0;
+      }
+      strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+      em {
+        color: var(--fg-soft);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.92em;
+        background: var(--surface);
+        padding: 1px 6px;
+        border-radius: 4px;
+        color: var(--fg);
+      }
+      pre {
+        background: var(--surface);
+        padding: 16px;
+        border-radius: 4px;
+        overflow-x: auto;
+        margin: 0 0 16px;
+      }
+      pre code {
+        background: none;
+        padding: 0;
+        border-radius: 0;
+        color: var(--fg-soft);
+      }
+      blockquote {
+        border-left: 3px solid var(--line-strong);
+        margin: 16px 0;
+        padding-left: 12px;
+        color: var(--fg-faint);
+      }
+      table {
+        border-collapse: collapse;
+        margin: 16px 0;
+        width: 100%;
+      }
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 8px 12px;
+        text-align: left;
+      }
+      th {
+        background: var(--surface);
+        color: var(--fg);
+      }
+      .loading {
+        color: var(--fg-faint);
+        font-size: 14px;
+      }
+      .error {
+        color: #f87171;
+        background: rgba(248, 113, 113, 0.1);
+        border: 1px solid rgba(248, 113, 113, 0.3);
+        padding: 16px;
+        border-radius: 4px;
+        margin: 20px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="breadcrumb">
+      <a href="./">Dashboard</a>
+      <span>/</span>
+      <span id="issue-num">Issue</span>
+    </div>
+    <article id="content">
+      <div class="loading">Loading issue...</div>
+    </article>
+
+    <script>
+      async function loadIssue() {
+        // Extract slug from URL query parameter
+        const params = new URLSearchParams(window.location.search);
+        const slug = params.get("slug");
+
+        if (!slug) {
+          document.getElementById("content").innerHTML =
+            '<div class="error">Invalid issue URL. Missing slug parameter.</div>';
+          return;
+        }
+
+        document.getElementById("issue-num").textContent = `#${slug.split("-")[0]}`;
+
+        try {
+          // Fetch the markdown file
+          const response = await fetch(`/plan/issues/${slug}.md`);
+          if (!response.ok) {
+            throw new Error(`Issue not found (${response.status})`);
+          }
+          const markdown = await response.text();
+
+          // Remove frontmatter
+          const contentStart = markdown.indexOf("---", 3) + 3;
+          const content = markdown.substring(contentStart).trim();
+
+          // Render markdown to HTML
+          const html = marked.parse(content);
+
+          // Display the rendered content
+          document.getElementById("content").innerHTML = html;
+        } catch (error) {
+          document.getElementById("content").innerHTML =
+            `<div class="error"><strong>Error loading issue:</strong> ${escapeHtml(error.message)}</div>`;
+          console.error("Failed to load issue:", error);
+        }
+      }
+
+      function escapeHtml(text) {
+        const map = {
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#039;",
+        };
+        return text.replace(/[&<>"']/g, (c) => map[c]);
+      }
+
+      // Load issue when DOM is ready
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", loadIssue);
+      } else {
+        loadIssue();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Add slug field to issue data (build-data.js)
- Make kanban cards clickable with links to issue detail page
- Create new issue.html that renders markdown on-demand client-side
- Copy plan/issues directory during build for client-side fetching

## How it works

Users can now click kanban cards to view the full issue markdown rendered as HTML. The markdown is fetched and rendered client-side using marked.js for better performance.

## Test plan

- [ ] Dashboard builds successfully
- [ ] Kanban cards are clickable
- [ ] Clicking a card navigates to issue.html?slug=<slug>
- [ ] Issue detail page loads and renders markdown
- [ ] Breadcrumb navigation back to dashboard works

🤖 Generated with [Claude Code](https://claude.com/claude-code)