### PR TITLE
fix(#1898): __object_create struct.new omits nextSeq — P0 standalone regression (-1,805)

### DIFF
--- a/plan/issues/1898-standalone-object-create-nextseq-regression.md
+++ b/plan/issues/1898-standalone-object-create-nextseq-regression.md
@@ -1,0 +1,78 @@
+---
+id: 1898
+title: "standalone REGRESSION: __object_create struct.new omits nextSeq → invalid Wasm for all open-object programs"
+status: done
+created: 2026-06-05
+completed: 2026-06-05
+priority: critical
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen, runtime
+language_feature: objects, standalone
+goal: standalone-mode, host-independence
+sprint: 59
+related: [1472, 1196, 1837]
+---
+# #1898 — Standalone __object_create struct.new omits nextSeq (P0 regression)
+
+## Symptom
+
+Standalone test262 regressed hard immediately after #1196 (native
+prototype-chain ops) merged: **28.94% → 24.76% (pass 12,481 → 10,676,
+−1,805)**, with `compile_error` jumping **+5,582 (21,854 → 27,436)** and
+`compile_timeout` only 10 — a real codegen break, not CI-load flake. The
+default (gc) lane was unaffected. It slipped through because the standalone
+lane is not a merge-gating check (`merge_group` runs only the default lane +
+`quality`).
+
+```
+WebAssembly.compile(): Compiling function #N:"__object_create" failed:
+  not enough arguments on the stack for struct.new (need 6, got 5)
+```
+
+## Root cause
+
+`#1837` added a 6th field (`nextSeq`) to the `$Object` struct
+(`{proto, props, count, tombstones, flags, nextSeq}`). `#1196` (commit
+`c696b1ffc` "feat(#1472 Phase C): native prototype-chain ops") added the
+native `__object_create` helper whose `struct.new $Object` pushed only **5**
+operands (`proto, props, 0, 0, 0`) — missing the `nextSeq` push. The sibling
+`__new_plain_object` already had the correct 6 operands.
+
+Because `ensureObjectRuntime` emits **all** open-object runtime helpers
+unconditionally (including `__object_create`), every standalone program that
+touches the open-object runtime — even one that never calls `Object.create`,
+e.g. `const o: any = {}; o["y"] = 2;` — got an invalid module. That broke the
+whole standalone object-runtime surface.
+
+Confirmed: only two `struct.new $Object` sites exist
+(`src/codegen/object-runtime.ts`): `__new_plain_object` (line 332, correct)
+and `__object_create` (line 1204, the broken one). #1211 (#1866 `__extern_get`
+externref re-route, merged just before) touches no `struct.new $Object` — ruled
+out.
+
+## Fix
+
+Add the missing `{ op: "i32.const", value: 0 }, // nextSeq` push to
+`__object_create`'s `struct.new $Object` body so it supplies all 6 fields —
+matching `__new_plain_object`. One-line fix-forward.
+
+(PR #1195 — in/hasOwn, in CI — already carries this same fix bundled with its
+feature; this is the minimal standalone-unblocking fix-forward so the −1,805
+passes are restored immediately rather than waiting on #1195's larger payload.
+The two are identical/idempotent and merge cleanly.)
+
+## Test
+
+`tests/issue-1898.test.ts` (new): a bare open-object standalone program +
+`Object.create` both instantiate (empty imports) without a `struct.new` arity
+error; default-gc path unaffected. A stale operand count fails at
+`WebAssembly.compile`, so a green run guards every `struct.new $Object` site.
+
+## Acceptance criteria
+
+- [x] Bare open-object standalone program compiles to a valid module.
+- [x] `Object.create(proto)` builds a valid 6-field `$Object` standalone.
+- [x] Default (gc) lane unaffected.
+- [x] tsc clean; new regression test green.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1196,11 +1196,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         ],
         else: [{ op: "ref.null", typeIdx: objectTypeIdx }],
       },
-      // struct.new $Object {proto, props, count=0, tombstones=0, flags=0}
+      // struct.new $Object {proto, props, count=0, tombstones=0, flags=0, nextSeq=0}
       { op: "local.get", index: 2 },
       { op: "i32.const", value: 0 },
       { op: "i32.const", value: 0 },
       { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 }, // nextSeq (#1837) — #1196 omitted this, breaking standalone (#1898)
       { op: "struct.new", typeIdx: objectTypeIdx },
       { op: "extern.convert_any" },
     ];

--- a/tests/issue-1898.test.ts
+++ b/tests/issue-1898.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #1898 — Standalone regression: __object_create's `struct.new $Object` shipped
+// 5 operands while $Object has 6 fields (after #1837 added `nextSeq`), so EVERY
+// standalone program that triggers the open-object runtime emitted an invalid
+// module ("not enough arguments on the stack for struct.new (need 6, got 5)").
+// `ensureObjectRuntime` emits `__object_create` unconditionally, so even a
+// program that never calls `Object.create` was broken — this regressed the
+// whole standalone test262 lane (-1,805 pass, +5,582 compile_error) right after
+// #1196 (native prototype-chain ops) merged.
+//
+// These guards instantiate the binary with empty imports: a stale operand count
+// fails at WebAssembly.compile, so a green run proves all `struct.new $Object`
+// sites supply the full 6 fields.
+describe("#1898 — standalone $Object struct.new arity (nextSeq) regression guard", () => {
+  it("a bare open-object program compiles to a valid standalone module", async () => {
+    // Computed-key write forces the open $Object runtime (defeats closed-struct
+    // inference). This is the minimal repro that broke on #1196's main.
+    const source = `
+      export function run(): number {
+        const o: any = {};
+        o["y"] = 2;
+        return o["y"] as number;
+      }
+    `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(2);
+  });
+
+  it("Object.create builds a valid $Object (6-field struct.new) standalone", async () => {
+    // __object_create is the site that lost the nextSeq operand in #1196.
+    const source = `
+      export function run(): number {
+        const proto: any = {};
+        proto["a"] = 3;
+        const o: any = Object.create(proto);
+        // inherited read through the proto chain → 3
+        return o["a"] as number;
+      }
+    `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(3);
+  });
+
+  it("default (gc) target object program is unaffected", async () => {
+    // The open-object runtime is standalone-gated; the gc path never emits
+    // __object_create. Guard that the default lane stays green either way.
+    const source = `
+      export function run(): number {
+        const o: any = {};
+        o["k"] = 5;
+        return o["k"] as number;
+      }
+    `;
+    const r = await compile(source); // default gc target
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## P0 — restores ~1,805 standalone test262 passes

Standalone test262 regressed **28.94% → 24.76% (pass 12,481 → 10,676, −1,805)** with
`compile_error +5,582` immediately after #1196 (native prototype-chain ops) merged.
Default (gc) lane unaffected; standalone isn't a merge-gating check, so it slipped through.

### Root cause
#1837 grew `$Object` to 6 fields (added `nextSeq`). #1196 (commit `c696b1ffc`) added
`__object_create` whose `struct.new $Object` pushed only **5** operands
(`proto, props, 0, 0, 0`) — missing the `nextSeq` push the sibling `__new_plain_object`
already had. Since `ensureObjectRuntime` emits `__object_create` **unconditionally**
(standalone-gated), **every** standalone program touching the open-object runtime — even
`const o:any={}; o["y"]=2;` which never calls `Object.create` — emitted an invalid module:

```
Compiling function #N:"__object_create" failed:
  not enough arguments on the stack for struct.new (need 6, got 5)
```

### Fix
Add the missing `nextSeq: 0` push so `__object_create`'s `struct.new` supplies all 6
fields (matching `__new_plain_object`). One-line fix-forward.

Verified: only two `struct.new $Object` sites exist (`object-runtime.ts:332`
`__new_plain_object`, `:1205` `__object_create`); both now 6-operand. #1211
(`__extern_get` re-route) touches no `struct.new` — ruled out.

### Relationship to #1195
PR #1195 (in/hasOwn, in CI) carries this identical fix bundled with its feature. This
minimal fix-forward restores the −1,805 passes **immediately** rather than waiting on
#1195's larger payload. The two changes are identical/idempotent and merge cleanly.

### Test
`tests/issue-1898.test.ts` (new, 3 tests): bare open-object + `Object.create` both
instantiate (empty imports) without a `struct.new` arity error; default-gc path
unaffected. A stale operand count fails `WebAssembly.compile`, guarding every
`struct.new $Object` site. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)