### PR TITLE
docs(#1895): minimal .wat GC array.copy vs linear memory.copy benchmark

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,3 @@
+# Build artifact — assembled from gc-array-copy.wat by the harnesses (binaryen).
+# Not committed (the repo routes *.wasm to Git LFS; this is a throwaway).
+gc-array-copy.wasm

--- a/bench/gc-array-copy.wat
+++ b/bench/gc-array-copy.wat
@@ -1,0 +1,66 @@
+(module
+  ;; Minimal repro (#1895): copy N bytes three ways, measure each.
+  ;;   1) native array.copy on an i8 WasmGC array
+  ;;   2) element loop (array.get_u / array.set)
+  ;;   3) linear memory.copy (the baseline #1886 moves toward)
+  ;;
+  ;; Two ways to drive it:
+  ;;   - Node/V8: call alloc(N) once, then time each bench_*(rounds) (see run-node.mjs).
+  ;;   - wasmtime CLI: call a self-contained run_*(N, rounds) (alloc + loop) so a
+  ;;     single --invoke does everything, e.g.:
+  ;;       time wasmtime -W all-proposals=y --invoke 'run_arraycopy 16777216 1' gc-array-copy.wasm
+  ;; N <= 32 MiB so src+dst also fit in the 64 MiB linear memory.
+  (type $bytes (array (mut i8)))
+
+  ;; 64 MiB linear memory (1024 * 64 KiB) — holds src [0,N) and dst [N,2N).
+  (memory (export "mem") 1024)
+
+  (global $src (mut (ref null $bytes)) (ref.null $bytes))
+  (global $dst (mut (ref null $bytes)) (ref.null $bytes))
+  (global $n   (mut i32) (i32.const 0))
+
+  (func $alloc (export "alloc") (param $size i32)
+    (global.set $n   (local.get $size))
+    (global.set $src (array.new_default $bytes (local.get $size)))
+    (global.set $dst (array.new_default $bytes (local.get $size))))
+
+  ;; R rounds of native array.copy(dst[0..], src[0..], n)
+  (func $bench_arraycopy (export "bench_arraycopy") (param $rounds i32)
+    (loop $r
+      (array.copy $bytes $bytes
+        (ref.as_non_null (global.get $dst)) (i32.const 0)
+        (ref.as_non_null (global.get $src)) (i32.const 0)
+        (global.get $n))
+      (local.set $rounds (i32.sub (local.get $rounds) (i32.const 1)))
+      (br_if $r (local.get $rounds))))
+
+  ;; R rounds of element-by-element GC copy
+  (func $bench_elemloop (export "bench_elemloop") (param $rounds i32)
+    (local $i i32)
+    (loop $r
+      (local.set $i (i32.const 0))
+      (block $done
+        (loop $c
+          (br_if $done (i32.ge_u (local.get $i) (global.get $n)))
+          (array.set $bytes (ref.as_non_null (global.get $dst)) (local.get $i)
+            (array.get_u $bytes (ref.as_non_null (global.get $src)) (local.get $i)))
+          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+          (br $c)))
+      (local.set $rounds (i32.sub (local.get $rounds) (i32.const 1)))
+      (br_if $r (local.get $rounds))))
+
+  ;; R rounds of linear memory.copy: src=[0,N) -> dst=[N,2N) (non-overlapping)
+  (func $bench_memcopy (export "bench_memcopy") (param $rounds i32)
+    (loop $r
+      (memory.copy (global.get $n) (i32.const 0) (global.get $n))
+      (local.set $rounds (i32.sub (local.get $rounds) (i32.const 1)))
+      (br_if $r (local.get $rounds))))
+
+  ;; Self-contained drivers for `wasmtime --invoke` (alloc + R rounds in one call).
+  (func (export "run_arraycopy") (param $size i32) (param $rounds i32)
+    (call $alloc (local.get $size)) (call $bench_arraycopy (local.get $rounds)))
+  (func (export "run_elemloop") (param $size i32) (param $rounds i32)
+    (call $alloc (local.get $size)) (call $bench_elemloop (local.get $rounds)))
+  (func (export "run_memcopy") (param $size i32) (param $rounds i32)
+    (call $alloc (local.get $size)) (call $bench_memcopy (local.get $rounds)))
+)

--- a/bench/run-node.mjs
+++ b/bench/run-node.mjs
@@ -1,0 +1,32 @@
+// #1895 — assemble gc-array-copy.wat and benchmark the three copy paths under
+// Node/V8 (WasmGC). Prints MiB/s for array.copy, element-loop, linear memory.copy.
+// Usage: node bench/run-node.mjs [N_bytes] [rounds]
+//
+// Uses the `binaryen` dep to assemble the .wat (it parses the GC text format and
+// emits .wasm). If you have wasm-tools/wat2wasm you can instead pre-assemble:
+//   wasm-tools parse bench/gc-array-copy.wat -o bench/gc-array-copy.wasm
+import { readFileSync } from "node:fs";
+import binaryen from "binaryen";
+
+const N = Number(process.argv[2]) || 16 * 1024 * 1024; // 16 MiB
+const R = Number(process.argv[3]) || 50;
+
+const mod = binaryen.parseText(readFileSync(new URL("./gc-array-copy.wat", import.meta.url), "utf8"));
+mod.setFeatures(binaryen.Features.All); // GC + ref-types + bulk-memory (+ deps)
+if (!mod.validate()) throw new Error("module failed binaryen validation");
+const { instance } = await WebAssembly.instantiate(mod.emitBinary(), {});
+const { alloc, bench_arraycopy, bench_elemloop, bench_memcopy } = instance.exports;
+
+alloc(N);
+console.log(`Node ${process.version} (V8 WasmGC) — N=${(N / 1048576).toFixed(0)} MiB, ${R} rounds`);
+for (const [name, fn] of [
+  ["array.copy", bench_arraycopy],
+  ["elem-loop", bench_elemloop],
+  ["memory.copy", bench_memcopy],
+]) {
+  fn(1); // warm
+  const t = performance.now();
+  fn(R);
+  const sec = (performance.now() - t) / 1000;
+  console.log(`  ${name.padEnd(12)} ${((N * R) / 1048576 / sec).toFixed(0).padStart(7)} MiB/s`);
+}

--- a/bench/run-wasmtime.mjs
+++ b/bench/run-wasmtime.mjs
@@ -1,0 +1,44 @@
+// #1895 — benchmark the three copy paths under wasmtime, on the SAME module.
+// Assembles gc-array-copy.wat -> gc-array-copy.wasm (via binaryen) if needed, then
+// drives the self-contained run_*(N, rounds) exports via `wasmtime run --invoke`,
+// timing the process. For the GC paths it subtracts two round-counts to cancel
+// fixed startup+compile+alloc overhead; linear memory.copy is measured absolutely
+// (too fast for the difference method to be stable).
+//
+// Usage: node bench/run-wasmtime.mjs /path/to/wasmtime [N_bytes]
+// Requires a GC-capable wasmtime (tested on 44.0.2 and 45.0.0).
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import binaryen from "binaryen";
+
+const WT = process.argv[2];
+if (!WT) {
+  console.error("usage: node run-wasmtime.mjs <wasmtime-binary> [N_bytes]");
+  process.exit(1);
+}
+const WAT = fileURLToPath(new URL("./gc-array-copy.wat", import.meta.url));
+const WASM = fileURLToPath(new URL("./gc-array-copy.wasm", import.meta.url));
+if (!existsSync(WASM)) {
+  const mod = binaryen.parseText(readFileSync(WAT, "utf8"));
+  mod.setFeatures(binaryen.Features.All);
+  if (!mod.validate()) throw new Error("module failed binaryen validation");
+  writeFileSync(WASM, Buffer.from(mod.emitBinary()));
+}
+
+const N = Number(process.argv[3]) || 16 * 1024 * 1024;
+const MiB = N / 1048576;
+const FLAGS = ["run", "-W", "gc=y,function-references=y", "--invoke"];
+
+const time = (fn, rounds) => {
+  const t = process.hrtime.bigint();
+  execFileSync(WT, [...FLAGS, fn, WASM, String(N), String(rounds)], { stdio: "ignore" });
+  return Number(process.hrtime.bigint() - t) / 1e9;
+};
+const diffTput = (fn, r1, r2) => MiB / ((time(fn, r2) - time(fn, r1)) / (r2 - r1));
+const absTput = (fn, r) => (MiB * r) / time(fn, r);
+
+console.log(`${WT.split("/").pop()} — N=${MiB.toFixed(0)} MiB`);
+console.log(`  array.copy   ${diffTput("run_arraycopy", 1, 2).toFixed(0).padStart(7)} MiB/s`);
+console.log(`  elem-loop    ${diffTput("run_elemloop", 5, 15).toFixed(0).padStart(7)} MiB/s`);
+console.log(`  memory.copy  ${absTput("run_memcopy", 2000).toFixed(0).padStart(7)} MiB/s`);

--- a/plan/issues/1886-linear-backed-uint8array-wasi-io.md
+++ b/plan/issues/1886-linear-backed-uint8array-wasi-io.md
@@ -2,7 +2,7 @@
 id: 1886
 title: "Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoid GC↔linear copies, beat AssemblyScript on memory"
 status: in-progress
-sprint: Backlog
+sprint: 61
 created: 2026-06-04
 updated: 2026-06-05
 slice_b_status: done

--- a/plan/issues/1895-wat-gc-array-copy-vs-linear-perf.md
+++ b/plan/issues/1895-wat-gc-array-copy-vs-linear-perf.md
@@ -1,0 +1,88 @@
+---
+id: 1895
+title: "Minimal .wat repro: WasmGC i8 array.copy vs element-loop vs linear memory.copy throughput (wasmtime vs Node/V8)"
+status: ready
+sprint: Backlog
+created: 2026-06-05
+updated: 2026-06-05
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: investigation
+area: runtime-perf
+language_feature: typed-arrays
+goal: performance
+related: [1863, 1886, 389]
+---
+# #1895 — Minimal `.wat` repro: GC `array.copy` vs element-loop vs linear `memory.copy`
+
+## Problem
+
+While optimizing the Native Messaging host (#389) and designing linear-backed
+`Uint8Array` (#1886), we measured that **`array.copy` on an i8 WasmGC array is
+dramatically slower than a hand-rolled element loop under wasmtime** — the native
+bulk op, which is *supposed* to be the fast path, collapses. That single fact
+drove a real design decision: the merged host builds each frame with an element
+loop instead of `subarray` (which lowers to `array.copy`) specifically to avoid
+this cliff (#1863).
+
+This issue captures a **clean, minimal, self-contained `.wat`** that reproduces
+the gap in isolation (no compiler, no js2wasm) and compares the *identical*
+module across **wasmtime v44.0.2 (CI-pinned)**, **wasmtime v45.0.0**, and
+**Node.js / V8** — to establish whether the cliff is wasmtime-specific or general
+WasmGC.
+
+## The repro (committed under `bench/`)
+
+- `bench/gc-array-copy.wat` — minimal module: an i8 GC array `(array (mut i8))`,
+  exports `alloc(N)` + three internally-rounded benches (`bench_arraycopy`,
+  `bench_elemloop`, `bench_memcopy`) and self-contained `run_*(N, rounds)`
+  drivers (alloc + loop) so a single `wasmtime --invoke` does everything.
+- `bench/run-node.mjs` — assembles the `.wat` (via the `binaryen` dep) and times
+  each path under Node/V8. `node bench/run-node.mjs [N] [rounds]`.
+- `bench/run-wasmtime.mjs` — assembles the `.wat` (via `binaryen`) then drives
+  the resulting `.wasm` under a given wasmtime (difference-of-two-round-counts to
+  cancel startup/compile/alloc; memory.copy measured absolutely).
+  `node bench/run-wasmtime.mjs /path/to/wasmtime [N]`.
+
+Note: `wasm-tools`/`wat2wasm` aren't in this container, so both harnesses assemble
+via the `binaryen` dep (which parses the GC text format) — the compiled `.wasm` is
+a gitignored build artifact, not committed. With a GC-capable `wasm-tools`/
+`wat2wasm` you can pre-assemble `bench/gc-array-copy.wasm` instead.
+
+## Results (measured 2026-06-05, N = 16 MiB)
+
+| copy path | wasmtime v44.0.2 | wasmtime v45.0.0 | Node/V8 (25.x) |
+|---|---:|---:|---:|
+| **`array.copy`** (i8 GC) | **7 MiB/s** | **8 MiB/s** | **17,513 MiB/s** |
+| `elem-loop` (GC get/set) | 214 MiB/s | 244 MiB/s | 1,221 MiB/s |
+| `memory.copy` (linear) | 23,567 MiB/s | 23,812 MiB/s | 24,719 MiB/s |
+
+### Conclusion
+
+- **The `array.copy` cliff is wasmtime-specific.** wasmtime's i8 `array.copy`
+  runs at **~7–8 MiB/s** — about **30× slower than even a naive element loop in
+  the same runtime**, and **~2,200× slower than V8's `array.copy`** (17.5 GiB/s).
+  V8's native bulk op is fast and competitive with its own `memory.copy`, exactly
+  as expected; wasmtime has a pathological slow path for i8 `array.copy`.
+- **Linear `memory.copy` is fast and consistent everywhere** (~24 GiB/s on all
+  three) — confirming #1886's strategy of routing provably-I/O-only `Uint8Array`
+  buffers to linear memory, and validating the host's element-loop workaround
+  (#1863) as the right call *for wasmtime*.
+- Secondary: wasmtime's GC element-loop (~214–244 MiB/s) is also ~5× slower than
+  V8's (~1,221) — general WasmGC immaturity in wasmtime — but `array.copy` is the
+  egregious outlier worth escalating.
+- v44→v45 did not move `array.copy` materially.
+
+## Remaining follow-up (gated on sign-off)
+
+File an **upstream wasmtime issue**: i8 GC `array.copy` is ~30× slower than an
+element loop and ~2,200× slower than V8, on the minimal `.wat` here. Do NOT open
+the upstream issue without sign-off (per project policy on external issues);
+reuse the `.tmp/wasmtime-gc-bug/` scratch notes.
+
+## Notes / prior art
+
+- #1863 records the original measurement and the host's element-loop workaround.
+- #1886 (linear-backed `Uint8Array`) is the compiler-side fix that routes I/O
+  buffers to `memory.copy`/zero-copy and sidesteps GC `array.copy` entirely.


### PR DESCRIPTION
Adds **#1895** — a self-contained minimal `.wat` reproducing the WasmGC i8 `array.copy` slowness, with cross-runtime numbers, so the design choices in #1863/#1886 rest on a runtime-level measurement.

## Files (`bench/`)
- `gc-array-copy.wat` — minimal module: i8 GC array, `alloc(N)` + `bench_*`/`run_*` for `array.copy`, element-loop, and linear `memory.copy`.
- `run-node.mjs` / `run-wasmtime.mjs` — assemble the `.wat` via the `binaryen` dep and time each path (the compiled `.wasm` is a gitignored build artifact, not committed — `*.wasm` is LFS-routed).

## Measured (16 MiB)
| copy path | wasmtime v44 | wasmtime v45 | Node/V8 |
|---|---:|---:|---:|
| **`array.copy`** (i8 GC) | **7 MiB/s** | **8 MiB/s** | **17,513 MiB/s** |
| `elem-loop` | 214 | 244 | 1,221 |
| `memory.copy` (linear) | 23,567 | 23,812 | 24,719 |

**Conclusion:** the `array.copy` cliff is **wasmtime-specific** — ~2,200× slower than V8 and ~30× slower than even a naive element loop in the same runtime. Linear `memory.copy` is fast everywhere (~24 GiB/s), validating #1886's linear-backing strategy and the host's element-loop workaround (#1863).

This is already a **known, open upstream item**: wasmtime [#13386](https://github.com/bytecodealliance/wasmtime/issues/13386) — `array.fill` was optimized to a `memset` libcall (PR #13382), and optimizing `array.copy` *for more collectors* is the remaining open task (i.e. `array.copy` is still per-byte on the default collector). So no new upstream issue is needed; this repro can be attached as a data point if/when we comment there (gated on sign-off).

Also schedules **#1886** Slice C/D (interprocedural rewrite — the headline host speedup) to **sprint 61**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)