### PR TITLE
ci(standalone): gate merges on standalone test262 regression

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -593,6 +593,86 @@ jobs:
             exit 1
           fi
 
+      # #1897 — HARD standalone-regression guard. Mirrors the host
+      # catastrophic guard above, but for the STANDALONE lane and at a much
+      # TIGHTER floor. Lives INSIDE the REQUIRED "merge shard reports" check so
+      # it blocks the merge queue with no branch-protection change (the
+      # standalone shards already run in the same 57×2 matrix and the merged
+      # standalone JSONL is already built two steps up; this step is just a
+      # diff + fail).
+      #
+      # Why a separate, tighter guard instead of folding into the host one:
+      # the standalone lane was silently regressed ~1,800 passes (+5,582
+      # compile_error) by a #1196 merge because the only hard guard looked at
+      # the host JSONL alone (cf. the gap this issue closes). The host guard's
+      # 200-test catastrophic threshold is far too loose to catch the more
+      # common case of a few-hundred-pass standalone slide.
+      #
+      # Floor-holding semantics: we diff against the standalone baseline that
+      # `promote-baseline` refreshes on every push to main, so the gate pins
+      # whatever floor standalone is CURRENTLY at — it never blocks a PR that
+      # leaves standalone unchanged (net 0) or improves it (net > 0). It only
+      # fails a PR that drops the standalone net below the tolerance. As the
+      # standalone fixes land, the baseline rises and the gate holds the new,
+      # higher floor automatically.
+      #
+      # Flake handling: `diff-test262.ts` already EXCLUDES `compile_timeout`
+      # transitions (the known standalone CI-load flake) from its
+      # "Regressions with wasm-hash change" count. So the net we gate on is
+      # already flake-free; STANDALONE_REGRESSION_TOLERANCE only absorbs
+      # residual baseline drift (corpus-version skew, env::-import
+      # nondeterminism). Measured real run-to-run standalone drift was 0
+      # regressions / +3 improvements, so 15 sits well above the noise floor.
+      #
+      # net = improvements − regressions_with_wasm_hash_change
+      # fail when net < −STANDALONE_REGRESSION_TOLERANCE.
+      - name: Standalone regression guard (#1897)
+        if: env.SHARDS_RAN == 'true'
+        env:
+          STANDALONE_REGRESSION_TOLERANCE: "15"
+        run: |
+          # Reuse the baselines clone from the catastrophic guard above (same
+          # job, same runner). Re-clone defensively if that step was skipped
+          # or the clone failed.
+          if [ ! -d /tmp/cat-baselines ]; then
+            git clone --depth=1 https://github.com/loopdive/js2wasm-baselines.git /tmp/cat-baselines 2>/dev/null || true
+          fi
+          if [ ! -f /tmp/cat-baselines/test262-standalone-current.jsonl ]; then
+            echo "::warning::No standalone baseline JSONL available — skipping standalone guard (first seed)."
+            exit 0
+          fi
+          if [ ! -s merged-reports/test262-standalone-results-merged.jsonl ]; then
+            echo "::error::standalone merged JSONL missing/empty — cannot evaluate standalone guard."
+            exit 1
+          fi
+          set +e
+          npx tsx scripts/diff-test262.ts /tmp/cat-baselines/test262-standalone-current.jsonl \
+            merged-reports/test262-standalone-results-merged.jsonl --quiet > /tmp/standalone-diff.txt 2>&1
+          diff_exit=$?
+          set -e
+          if [ "$diff_exit" -gt 1 ]; then
+            echo "::error::diff-test262 (standalone) failed (exit $diff_exit) — cannot evaluate standalone guard."
+            cat /tmp/standalone-diff.txt
+            exit "$diff_exit"
+          fi
+          # Pull the flake-filtered regression count and the improvement count
+          # straight out of the diff report, then compute net ourselves so the
+          # threshold logic is explicit (the script's own exit code uses a
+          # net<0 gate with no drift tolerance, which is too strict for a
+          # gating check on the standalone lane).
+          REG=$(grep -oE 'Regressions with wasm-hash change: [0-9]+' /tmp/standalone-diff.txt | grep -oE '[0-9]+' | head -1)
+          IMP=$(grep -oE 'Improvements \(other → pass\): [0-9]+' /tmp/standalone-diff.txt | grep -oE '[0-9]+' | head -1)
+          CT=$(grep -oE 'Compile timeouts \(pass → compile_timeout\): [0-9]+' /tmp/standalone-diff.txt | grep -oE '[0-9]+' | head -1)
+          REG="${REG:-0}"; IMP="${IMP:-0}"; CT="${CT:-0}"
+          NET=$((IMP - REG))
+          echo "Standalone guard: improvements=${IMP}, wasm-change regressions=${REG} (compile_timeout flake=${CT}, excluded), net=${NET} (tolerance −${STANDALONE_REGRESSION_TOLERANCE})."
+          if [ "$NET" -lt "$((0 - STANDALONE_REGRESSION_TOLERANCE))" ]; then
+            echo "::error::STANDALONE test262 regression: net ${NET} (improvements ${IMP} − regressions ${REG}) is below the −${STANDALONE_REGRESSION_TOLERANCE} tolerance. The standalone lane regressed against the current baseline floor and this blocks the merge queue. compile_timeout flake is already excluded; this is a real standalone conformance drop. See #1897."
+            echo "----- standalone regression report (first 60 lines) -----"
+            head -60 /tmp/standalone-diff.txt
+            exit 1
+          fi
+
       # #1668 — HARD stale-baseline guard. The catastrophic guard above (and the
       # advisory regression-gate) are only as trustworthy as the baseline they
       # diff against. The baseline is refreshed per-merge by the promote-baseline

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -32,7 +32,7 @@ case-sensitive and whitespace-sensitive.
 | Check name | Workflow file | What it gates |
 |---|---|---|
 | `cheap gate (main-ancestor + lint)` | `.github/workflows/test262-sharded.yml` | fast pre-flight: lint + typecheck on the PR branch (cheap reject before running the test262 matrix) |
-| `merge shard reports` | `.github/workflows/test262-sharded.yml` | aggregates the 16 test262 shards into a single pass/fail signal — the authoritative conformance gate (replaces the legacy `regression-gate` / rolling-baseline approach) |
+| `merge shard reports` | `.github/workflows/test262-sharded.yml` | aggregates the 57 test262 shards into a single pass/fail signal — the authoritative conformance gate (replaces the legacy `regression-gate` / rolling-baseline approach). Hosts the HARD inline guards: the host catastrophic-regression guard (#1668), the **standalone net-regression guard (#1897)**, and the stale-baseline guard (#1668) — see §3 |
 | `quality` | `.github/workflows/ci.yml` | lint, format check, typecheck, IR fallback budget (#1376), planning-artifact regen |
 
 ### Optional / informational checks (NOT required to merge)
@@ -116,6 +116,53 @@ Two test262 workflows currently run on PRs:
 
 For one-off sharded runs outside the normal PR/merge_group path,
 `workflow_dispatch` is the supported entry point.
+
+### Both lanes are gated — host AND standalone (#1897)
+
+The 57-shard matrix runs **two** test262 targets per chunk: `js-host` (the
+default WasmGC/gc lane) and `standalone` (`--target standalone
+--no-host-imports nativeStrings`, the pure-Wasm lane). `merge shard reports`
+merges **both** sets of shard artifacts and builds both reports, then runs
+three HARD inline guards. Because a failing step inside `merge shard reports`
+fails the required check, all three guards gate the merge queue **without
+any additional required-check name** — no branch-protection change is needed
+to enforce them.
+
+| Inline guard | Lane | Fails when | Tolerance |
+|---|---|---|---|
+| Catastrophic regression guard (#1668) | host | `Regressions with wasm-hash change` > 200 vs `test262-current.jsonl` | high (200) — only a codegen/harness catastrophe trips it |
+| **Standalone regression guard (#1897)** | **standalone** | net (`improvements − wasm-change regressions`) < −15 vs `test262-standalone-current.jsonl` | tight (15) — holds the current standalone floor |
+| Stale-baseline guard (#1668) | both | baselines JSONL > 50 commits behind main HEAD (promotion pipeline broken) | n/a |
+
+**Why the standalone guard is separate and tighter.** Before #1897 the merge
+queue gated only the host lane. The standalone lane runs in the same matrix
+and its merged report is built, but nothing failed the merge when standalone
+regressed — it was only measured *post-merge* by the non-gating
+`promote-baseline` job. A #1196 merge regressed standalone ~1,800 passes
+(+5,582 `compile_error`) and slipped straight through, because the host
+catastrophic guard's 200-test threshold never sees the standalone JSONL.
+#1897 closes that gap with a standalone-specific net-regression guard at a
+much tighter floor.
+
+**Floor-holding, not absolute-target.** The standalone guard diffs against
+`test262-standalone-current.jsonl` — the moving standalone baseline that
+`promote-baseline` refreshes on every push to main. So it pins **whatever
+floor standalone is currently at**: a PR that leaves standalone unchanged
+(net 0) or improves it (net > 0) always passes; only a PR that drops the
+standalone net below tolerance fails. As standalone fixes land and the
+baseline rises, the gate automatically holds the new, higher floor. This is
+why the gate can be enforced even while standalone is below its long-term
+target — it never blocks an improving or neutral PR.
+
+**Flake tolerance.** The known standalone CI flake is `compile_timeout` under
+load (tests near the 30s compile boundary flapping with runner pressure).
+`scripts/diff-test262.ts` already **excludes** `compile_timeout` transitions
+from its `Regressions with wasm-hash change` count, so the net the guard
+gates on is structurally flake-free. The −15 tolerance only absorbs residual
+baseline drift (corpus-version skew, `env::`-import nondeterminism); measured
+real run-to-run standalone drift was 0 regressions / +3 improvements, so 15
+sits well above the noise floor. The threshold is tunable via the
+`STANDALONE_REGRESSION_TOLERANCE` env on the guard step.
 
 ---
 
@@ -233,7 +280,7 @@ behaviour can be flipped without touching the JS script.
 | Required check | Workflow | What it protects against |
 |---|---|---|
 | `cheap gate (main-ancestor + lint)` | `test262-sharded.yml` | fast pre-flight reject: lint + typecheck on the PR branch before any test262 shard runs. Catches obvious failures cheaply and stops the queue from spending compute on a doomed PR. |
-| `merge shard reports` | `test262-sharded.yml` | semantic conformance: aggregates the 16 sharded test262 runs into a single pass/fail. Authoritative gate via the `batch=1` serial merge queue — each PR validated on its own merge_group ref with no ALLGREEN hiding. |
+| `merge shard reports` | `test262-sharded.yml` | semantic conformance, **both lanes**: aggregates the 57 sharded test262 runs (host + standalone) into a single pass/fail. Authoritative gate via the `batch=1` serial merge queue — each PR validated on its own merge_group ref with no ALLGREEN hiding. Hosts the host catastrophic guard (#1668), the standalone net-regression guard (#1897), and the stale-baseline guard (#1668) — see §3. |
 | `quality` | `ci.yml` | source quality regressions: lint, formatting, typecheck failures, IR fallback budget exceeded (#1376), planning-artifact regeneration. Also runs the "origin/main is merged into branch" pre-check that catches stale PR branches. |
 
 The CODEOWNERS file gates **who** can approve. The required checks gate

--- a/plan/issues/1897-ci-standalone-regression-gate.md
+++ b/plan/issues/1897-ci-standalone-regression-gate.md
@@ -1,0 +1,149 @@
+---
+id: 1897
+slug: ci-standalone-regression-gate
+title: "Gate merges on standalone test262 regression"
+status: in-progress
+sprint: 60
+goal: standalone-mode
+area: ci
+priority: high
+feasibility: hard
+created: 2026-06-05
+owner: sd-ci-gate
+---
+
+# ci: gate merges on standalone test262 regression
+
+## Problem
+
+The merge queue only gates the **default (js-host / gc)** test262 lane. The
+**standalone** lane runs in the same sharded matrix (`test262-sharded.yml`,
+57 chunks × 2 targets) and its merged report is built, but **nothing fails
+the merge when the standalone pass-count regresses**. Standalone conformance
+is measured *post-merge* by the `promote-baseline` job, which is non-gating.
+
+The cost of this gap is concrete: a #1196 merge regressed standalone by
+~1,800 passes (+5,582 `compile_error`) and slipped straight through because
+the only hard, required guard inside `merge shard reports` — the
+catastrophic-regression guard (#1668) — diffs **only the host lane**
+(`test262-current.jsonl`). Standalone went from ~28-29% to 24.76% (10,676
+pass) with a green merge queue.
+
+## Root-cause analysis
+
+`merge shard reports` (the required check) already:
+
+1. Merges the 57 standalone shard artifacts into
+   `merged-reports/test262-standalone-results-merged.jsonl`.
+2. Builds `merged-reports/test262-standalone-report-merged.json`
+   (`--target standalone`).
+
+…but the two HARD guards that live inside the required check (the #1668
+catastrophic-regression guard and the stale-baseline guard) only ever look
+at the **host** JSONL. There is no standalone analog. The advisory
+`regression-gate` job also diffs host-only and is not required anyway.
+
+So the standalone merged JSONL is produced and then **discarded** for gating
+purposes. Closing the gap is a *diff + fail* step, not new infrastructure.
+
+## Design
+
+### Where the gate lives — inside the existing required check
+
+Add a **standalone net-regression guard step** to the `merge shard reports`
+job, immediately after "Build merged standalone test262 report" and beside
+the host catastrophic guard (#1668). This is deliberate:
+
+- `merge shard reports` is **already a required check** on the merge queue.
+  A failing step inside it fails the required check, so the gate is enforced
+  on `merge_group` **with zero branch-protection changes**. No new
+  required-check name has to be registered (and no admin creds needed to
+  apply branch protection).
+- The standalone shards **already run in parallel** with the host shards in
+  the same matrix — sharding for speed is reused for free; the gate adds no
+  CI compute beyond one fast `diff-test262.ts` invocation.
+- It mirrors the host catastrophic guard's pattern exactly, so the location
+  is consistent and well understood.
+
+This is the answer to the "make it required" requirement: rather than add a
+*new* required job (which would need a branch-protection admin push and would
+duplicate the standalone shard run), we **extend the existing required check
+to also gate standalone**. `docs/ci-policy.md` §1/§7 are updated so the
+required check's responsibility is documented, and a short note in
+`scripts/enable-branch-protection.sh` records that no new context is needed.
+
+### What it compares — the standalone baseline floor
+
+`scripts/diff-test262.ts` is already **target-agnostic** — it keys on the
+`file` field line-by-line and computes regressions/improvements/net. Verified
+it runs unmodified on the standalone JSONL (self-diff → net 0; perturbed
+diff → correct regression/improvement/CT split). So the guard diffs:
+
+```
+baseline:  /tmp/cat-baselines/test262-standalone-current.jsonl   (baselines repo)
+candidate: merged-reports/test262-standalone-results-merged.jsonl (this run)
+```
+
+The baselines clone is reused from the host catastrophic-guard step (same
+job, same runner, `/tmp/cat-baselines` persists across steps).
+
+Because the baseline is the **moving** standalone floor maintained by
+`promote-baseline` on every push to main, the gate **holds whatever floor
+standalone is currently at**:
+
+- A PR that does not touch standalone → net 0 → passes.
+- A PR that *improves* standalone → net > 0 → passes.
+- A PR that *regresses* standalone below tolerance → net < −tol → **fails**.
+
+This is exactly the timing requirement: it must NOT block the in-flight
+standalone-fix PRs while standalone is still at 24.76%. It compares against
+the *current* baseline floor, not an absolute target. Once sd-1888's fix
+lands and `promote-baseline` refreshes the baseline upward, the gate holds
+the new, higher floor. (The gate should land **after** the regression is
+fixed so the floor it pins is the restored ~28-29%, not the regressed
+24.76%.)
+
+### Flake tolerance — net-per-test, not exact equality
+
+The known standalone flake is `compile_timeout` under CI load (tests near
+the 30s compile boundary flapping with runner load). `diff-test262.ts`
+already excludes `compile_timeout` transitions from its
+`Regressions with wasm-hash change` count, so the guard reads that filtered
+line:
+
+```
+net = improvements − regressions_with_wasm_hash_change
+```
+
+and fails when `net < −STANDALONE_REGRESSION_TOLERANCE`. The tolerance
+(default **15**) absorbs residual baseline drift (corpus-version skew,
+`env::`-import nondeterminism). Measured real run-to-run standalone drift
+between two consecutive baseline snapshots was **0 regressions / +3
+improvements**, so 15 is comfortably above the noise floor while still
+catching the ~1,800-pass class of regression this issue exists to stop.
+
+The compile_timeout flake is excluded *structurally* (by the diff script),
+not by the tolerance — the tolerance only covers drift, matching the host
+gate's philosophy.
+
+## Acceptance criteria
+
+- [x] A guard step inside the required `merge shard reports` job diffs the
+      merged standalone JSONL against the standalone baseline and fails the
+      check on net-negative standalone regression beyond tolerance.
+- [x] Sharded (reuses the existing 57-chunk standalone matrix — no extra run).
+- [x] `compile_timeout` flake excluded; tolerance covers drift only.
+- [x] Skips cleanly on the no-shards merge_group path (`SHARDS_RAN != true`)
+      and when the standalone baseline is not yet seeded (first run).
+- [x] `docs/ci-policy.md` documents that `merge shard reports` now also
+      gates standalone; `scripts/enable-branch-protection.sh` notes no new
+      required context is needed.
+- [x] No new branch-protection admin action required (the gate rides the
+      already-required `merge shard reports` check).
+
+## Notes for the merge queue / timing
+
+This gate pins the *current* standalone baseline floor. It is safe to land
+while standalone is below target as long as the regression that dropped it
+to 24.76% has been restored first (sd-1888), so the floor it holds is the
+restored value. The gate never blocks an improving PR.

--- a/scripts/enable-branch-protection.sh
+++ b/scripts/enable-branch-protection.sh
@@ -55,10 +55,19 @@ done
 # Each entry is a GitHub check name (the value of the `name:` field on the job
 # in the workflow YAML, OR the workflow `name:` if the job doesn't override).
 # Names are case-sensitive and whitespace-sensitive.
+#
+# NOTE (#1897): the STANDALONE test262 lane is gated by an inline guard step
+# *inside* the already-required `merge shard reports` job, NOT by a separate
+# required check. The standalone shards already run in the same 57×2 matrix and
+# the merged standalone JSONL is built in that job; the guard step diffs it
+# against the standalone baseline and fails the (required) check on a
+# net-negative standalone regression beyond tolerance. So gating standalone
+# needed NO new entry here and NO branch-protection re-apply — it rides the
+# `merge shard reports` context. See docs/ci-policy.md §3.
 # -----------------------------------------------------------------------------
 REQUIRED_CHECKS=(
   "cheap gate (main-ancestor + lint)"    # test262-sharded.yml — fast pre-flight reject
-  "merge shard reports"                  # test262-sharded.yml — authoritative test262 gate
+  "merge shard reports"                  # test262-sharded.yml — authoritative test262 gate (host + standalone, #1897)
   "quality"                              # ci.yml — lint, format, typecheck, IR budget
 )
 


### PR DESCRIPTION
## Summary

The merge queue only gated the **host (gc)** test262 lane. The **standalone**
lane runs in the same 57×2 sharded matrix and its merged report is built, but
nothing failed the merge when standalone regressed — it was only measured
*post-merge* by the non-gating `promote-baseline` job. A #1196 merge regressed
standalone ~1,800 passes (+5,582 `compile_error`) and slipped straight through,
because the only HARD guard inside the required `merge shard reports` check (the
host catastrophic guard #1668) diffs the **host** JSONL alone.

This adds a HARD **standalone net-regression guard** step inside the
already-required `merge shard reports` job, beside the host catastrophic guard.

## Design

- **Where**: a new step in `merge shard reports` (the existing required check),
  right after "Build merged standalone test262 report" and the host
  catastrophic guard. A failing step fails the required check, so the gate is
  enforced on the merge queue with **zero branch-protection changes** — no new
  required-check name to register, no admin re-apply needed. Required check name
  is still `merge shard reports`.
- **Sharded for free**: the standalone shards already run in parallel with the
  host shards; the guard adds one fast `diff-test262.ts` invocation.
- **What it compares**: diffs the merged standalone JSONL against
  `test262-standalone-current.jsonl` (the moving standalone baseline that
  `promote-baseline` maintains). `scripts/diff-test262.ts` is already
  target-agnostic (verified — runs unmodified on the standalone JSONL).
- **Floor-holding**: because it diffs the *current* baseline, it pins whatever
  floor standalone is at — a PR that leaves standalone unchanged (net 0) or
  improves it (net > 0) always passes; only a regression below tolerance fails.
  Safe to land while standalone is below its long-term target; it never blocks
  an improving/neutral PR. As fixes land the baseline rises and the gate holds
  the new floor.
- **Flake tolerance**: `diff-test262.ts` already **excludes** `compile_timeout`
  (the known standalone CI-load flake) from its `Regressions with wasm-hash
  change` count, so the net is structurally flake-free. The −15 tolerance only
  absorbs baseline drift; measured real run-to-run standalone drift was 0
  regressions / +3 improvements. Tunable via `STANDALONE_REGRESSION_TOLERANCE`.

  net = improvements − wasm-change regressions; fail when net < −15.

## Validation

Ran the exact YAML-embedded guard script end-to-end against the real standalone
baseline (10,871 pass) across:

| case | net | result |
|---|---|---|
| self-diff (no change) | 0 | PASS |
| pure improvement (+50) | +50 | PASS |
| 100 compile_timeout flakes, no real regression | 0 (flake excluded) | PASS |
| net −15 (== tolerance) | −15 | PASS |
| net −16 (> tolerance) | −16 | **FAIL** |
| catastrophic 1,800-pass regression (the #1196 case) | −1,800 | **FAIL** |
| empty merged JSONL | — | **FAIL** (errors, doesn't silently pass) |
| missing standalone baseline (first seed) | — | skip (warning) |

Skips cleanly on the no-shards merge_group path (`SHARDS_RAN != 'true'`), matching
the other two guards.

## Files

- `.github/workflows/test262-sharded.yml` — standalone regression guard step (#1897)
- `docs/ci-policy.md` — document both-lane gating + the three inline guards (§3, §7)
- `scripts/enable-branch-protection.sh` — note no new required context is needed
- `plan/issues/1897-ci-standalone-regression-gate.md` — design + root-cause analysis

## Timing note

This gate pins the *current* standalone baseline floor. Per the directive, it
should land **after** the regression that dropped standalone to 24.76% is
restored (sd-1888), so the floor it holds is the restored value — but the gate
itself is safe to merge any time since it never blocks an improving/neutral PR.

Closes #1897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>