### PR TITLE
fix(#1896 prereq): coerce externref closure-call args to internal ref domain

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2759,6 +2759,55 @@ function emitClosureCallExport4(ctx: CodegenContext): void {
 }
 
 /**
+ * #1896 — Decide whether a host-supplied `externref` closure-call argument must
+ * be lowered out of the extern domain before it feeds the closure's `call_ref`.
+ *
+ * The `__call_fn_<arity>` / `__call_fn_method_<arity>` exports take all user
+ * args as `externref` (the host ABI). The lifted closure funcref, however,
+ * declares each user param with the closure's *internal* ValType. Under the
+ * native-strings backends a `string` param lowers to `(ref null $AnyString)`
+ * (a concrete struct ref), so the raw `externref` arg mismatches `call_ref`
+ * and the module fails validation. In `wasm:js-string` (gc) mode the string
+ * param ValType *is* `externref`, so no conversion is needed.
+ *
+ * Returns true for non-extern reference param kinds (`anyref`/`eqref`/`ref`/
+ * `ref_null`); false for `externref`/`ref_extern` (already extern-side) and for
+ * the numeric/value kinds (handled by the f64/i32 unbox branches at the call
+ * site, or simply not reference args).
+ */
+function needsExternToAnyForClosureParam(paramType: ValType): boolean {
+  switch (paramType.kind) {
+    case "anyref":
+    case "eqref":
+    case "ref":
+    case "ref_null":
+      return true;
+    default:
+      // externref / ref_extern (already extern), funcref, and value types.
+      return false;
+  }
+}
+
+/**
+ * #1896 — Lower an `externref` closure-call arg into the internal ref domain
+ * expected by the closure funcref's declared param ValType. `any.convert_extern`
+ * moves externref → anyref (engine-level identity); for a *concrete* ref param
+ * (`ref`/`ref_null` to a struct type, e.g. `(ref null $AnyString)`) a following
+ * `ref.cast` narrows anyref → the exact param type so `call_ref` typechecks.
+ * `anyref`/`eqref` params need no cast. Caller must have checked
+ * `needsExternToAnyForClosureParam(paramType)` first.
+ */
+function externToClosureParamRef(paramType: ValType): Instr[] {
+  const ops: Instr[] = [{ op: "any.convert_extern" } as Instr];
+  if (paramType.kind === "ref") {
+    ops.push({ op: "ref.cast", typeIdx: paramType.typeIdx } as Instr);
+  } else if (paramType.kind === "ref_null") {
+    ops.push({ op: "ref.cast_null", typeIdx: paramType.typeIdx } as Instr);
+  }
+  return ops;
+}
+
+/**
  * Emit __call_fn_<arity> export (#1382): call an N-arg WasmGC closure from
  * JS. Takes (externref closure, externref arg0, ..., externref arg<arity-1>)
  * and returns externref. Used by `__array_from`, `__proto_method_call`, and
@@ -2904,8 +2953,17 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
             ops.push({ op: "call", funcIdx: unboxIdx } as Instr);
             ops.push({ op: "i32.trunc_f64_s" });
           }
+        } else if (needsExternToAnyForClosureParam(paramType)) {
+          // The host-facing param is `externref`, but the closure funcref
+          // declares this reference param as a non-extern ref type (anyref or
+          // a WasmGC struct ref — e.g. a native-strings `string` lowers to
+          // `(ref null $AnyString)`). Lower the host externref to the internal
+          // ref domain so the subsequent `call_ref` typechecks. In
+          // `wasm:js-string` (gc) mode string params ARE externref, so this
+          // branch is skipped and the arg passes raw.
+          ops.push(...externToClosureParamRef(paramType));
         }
-        // externref: no conversion
+        // externref param: no conversion
       }
       return ops;
     };
@@ -3161,6 +3219,12 @@ function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number): void 
             ops.push({ op: "call", funcIdx: unboxIdx } as Instr);
             ops.push({ op: "i32.trunc_f64_s" });
           }
+        } else if (needsExternToAnyForClosureParam(paramType)) {
+          // See emitClosureCallExportN: a non-extern reference param (anyref /
+          // WasmGC struct ref, e.g. a native-strings `string`) needs the host
+          // externref lowered into the internal ref domain before `call_ref`.
+          // Skipped in gc mode where string params are already externref.
+          ops.push(...externToClosureParamRef(paramType));
         }
       }
       return ops;

--- a/tests/issue-1896-callfn-ref-arg.test.ts
+++ b/tests/issue-1896-callfn-ref-arg.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1896 prerequisite — `__call_fn_N` / `__call_fn_method_N` argument coercion.
+ *
+ * A closure stored in an `any` (or handed off as a callback) is invoked via the
+ * `__call_fn_<arity>` export, whose host-facing params are all `externref`. The
+ * lifted closure funcref, however, declares its *reference-typed* user params as
+ * `anyref` (under the native-strings backends a `string` param lowers to
+ * `(ref null $AnyString)` which widens to `anyref`, NOT `externref`). The
+ * dispatcher pushed the host externref arg RAW into `call_ref`, so the verifier
+ * rejected the module:
+ *
+ *   Compiling function "__call_fn_2" failed:
+ *   any.convert_extern[0] expected type externref, found ... of type anyref
+ *
+ * In WasmGC (`wasm:js-string`) mode the string param's funcref ValType *is*
+ * externref, so the raw arg type-checked and the bug stayed hidden. The fix
+ * inserts `any.convert_extern` (externref → anyref) for non-externref reference
+ * params before they feed `call_ref`, in both `emitClosureCallExportN` and
+ * `emitClosureMethodCallExportN`.
+ */
+
+const TARGETS = ["gc", "standalone", "wasi"] as const;
+
+async function compileValidateRun(src: string, target: (typeof TARGETS)[number]) {
+  const r = await compile(src, { target });
+  expect(r.errors ?? []).toEqual([]);
+  // WebAssembly.compile throws on an invalid module — the core regression guard.
+  await WebAssembly.compile(r.binary);
+  return r;
+}
+
+describe("#1896 prereq: __call_fn ref-arg coercion", () => {
+  // The original failing shapes: closure-into-`any`, called with ref-typed args.
+  for (const target of TARGETS) {
+    it(`2-arg string closure-into-any compiles+validates [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (a: string, b: string) { return a + b; };
+         export function test(): string { return f("p", "q"); }`,
+        target,
+      );
+    });
+
+    it(`2-arg string closure, no-op body [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (a: string, b: string) { return a; };
+         export function test(): string { return f("p", "q"); }`,
+        target,
+      );
+    });
+
+    it(`3-arg mixed (string,number,string) closure-into-any [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (a: string, n: number, c: string) { return a + c; };
+         export function test(): string { return f("p", 1, "q"); }`,
+        target,
+      );
+    });
+
+    it(`4-arg all-string closure-into-any [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (a: string, b: string, c: string, d: string) { return a + b + c + d; };
+         export function test(): string { return f("p", "q", "r", "s"); }`,
+        target,
+      );
+    });
+
+    // Regression-guard the shapes that already worked, so the fix stays additive.
+    it(`1-arg string closure stays valid [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (s: string) { return s + "!"; };
+         export function test(): string { return f("hi"); }`,
+        target,
+      );
+    });
+
+    it(`2-arg number closure stays valid [${target}]`, async () => {
+      await compileValidateRun(
+        `const f: any = function (a: number, b: number) { return a + b; };
+         export function test(): number { return f(1, 2); }`,
+        target,
+      );
+    });
+  }
+
+  // Runtime correctness under standalone (no host imports → empty importObject).
+  // The closure takes ref-typed (string) args — exercising the coercion fix —
+  // but returns a number so the result is host-readable without a string-decode
+  // shim (standalone returns native-string structs the JS host can't stringify).
+  it("2-arg string-arg closure-into-any runs and returns derived number (standalone)", async () => {
+    const r = await compileValidateRun(
+      `const f: any = function (a: string, b: string): number { return a.length + b.length; };
+       export function test(): number { return f("ab", "cde"); }`,
+      "standalone",
+    );
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const out = (instance.exports as { test: () => number }).test();
+    expect(out).toBe(5); // "ab".length (2) + "cde".length (3)
+  });
+});


### PR DESCRIPTION
## Problem

The `__call_fn_<arity>` / `__call_fn_method_<arity>` exports take all user args
as `externref` (host ABI), but the lifted closure funcref declares reference-typed
params with the closure's *internal* ValType. Under the native-strings backends
(`--target standalone` / `--target wasi`) a `string` param lowers to
`(ref null $AnyString)`, so the raw `externref` arg mismatched `call_ref` and the
module failed validation:

```
Compiling function "__call_fn_2" failed:
  any.convert_extern[0] expected type externref, found ... of type anyref
  call_ref[1] expected type (ref null 5), found any.convert_extern of type anyref
```

In `wasm:js-string` (gc) mode the string param ValType *is* `externref`, so the
bug stayed hidden — only **arity-2+ closures carrying string/object params under
native-strings** tripped it (1-arg and pure-number closures were fine in all
modes). This breaks any function-valued-`any` (or func-ref callback) with
ref-typed params in standalone/wasi, and is a **prerequisite for #1896 / #1888 S1**
(whose `__apply_closure` dispatches through these exports).

## Fix

`buildArgConversion` in both `emitClosureCallExportN` and
`emitClosureMethodCallExportN` now lowers a non-extern reference param via
`any.convert_extern` + an optional `ref.cast` to the concrete struct type
(`externToClosureParamRef`). Numeric params (f64/i32 unbox) and genuine
`externref` params are unchanged, so **gc mode and the number path are
byte-identical**.

## Verification

- `tests/issue-1896-callfn-ref-arg.test.ts` — arity 1..4 × {number,string} ×
  {gc,standalone,wasi} compile+validate, plus a standalone runtime check
  returning a host-readable number. **19/19 pass** (all 9 standalone/wasi shapes
  failed pre-fix).
- `tsc --noEmit` + `biome lint` clean.
- Closure/HOF suite (issue-1382/1596, flatmap-closure, illegal-cast-closures-585,
  optional-direct-closure-call, fast-arrays, array-inline-return) **identical to
  clean origin/main** — 8 pre-existing failures, 0 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)