### PR TITLE
fix(#329): native undefined sentinel under native-strings — closure-into-any assignment late-shift

### DIFF
--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -465,8 +465,19 @@ export function flushLateImportShifts(ctx: CodegenContext, fctx: FunctionContext
  * Ensure the __get_undefined host import exists, returning its funcIdx.
  * This import returns the actual JS `undefined` value as externref,
  * allowing Wasm to distinguish null from undefined at runtime.
+ *
+ * Under native-strings mode (auto-on for `--target standalone`/`wasi`) there is
+ * no JS host to satisfy this import, and undefined is conflated with null (same
+ * convention as `__extern_is_undefined` → bare `ref.is_null`). Returning
+ * `undefined` here makes callers fall back to the native `ref.null.extern`
+ * sentinel via `emitUndefined`, which (a) keeps standalone host-import-free and
+ * (b) avoids adding a late import *after* the native-string helpers were emitted
+ * — that post-helper import otherwise drives `reconcileNativeStrFinalizeShift`
+ * an extra time and off-by-ones the baked `__str_flatten`→`__str_copy_tree`
+ * call (#329: `let g: any; g = function(){…}; g()` invalid wasm).
  */
 export function ensureGetUndefined(ctx: CodegenContext): number | undefined {
+  if (ctx.nativeStrings) return undefined;
   return ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
 }
 

--- a/tests/issue-329-assign-closure-lateshift.test.ts
+++ b/tests/issue-329-assign-closure-lateshift.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #329 — late-import func-index-shift for a function expression assigned to an
+ * `any` binding via a *separate assignment* (not an initializer).
+ *
+ * `let g: any; g = function () {...}; g()` baked the closure-wrapper call target
+ * before the native-string helpers (`__str_flatten` / `__str_copy_tree`) were
+ * appended/shifted, so under `--target standalone` the module failed validation:
+ *
+ *   Compiling function "__str_flatten" failed:
+ *   call[0] expected type (ref null 5), found i32.const of type i32
+ *
+ * The *initializer* forms (`const f: any = fn` / `let f: any = fn`) were already
+ * fixed (#1839/#1677/#1470); only the assignment-expression path remained.
+ */
+
+const initOk = `const f: any = function () { return 42; };
+export function test(): number { return f(); }`;
+
+const assignBug = `let g: any; g = function () { return 42; };
+export function test(): number { return g(); }`;
+
+const assignStr = `let g: any; g = function () { return "ab".length; };
+export function test(): number { return g(); }`;
+
+async function compileValidate(src: string, target: "standalone" | "wasi" | "gc") {
+  const r = await compile(src, { target });
+  expect(r.errors ?? []).toEqual([]);
+  await WebAssembly.compile(r.binary); // throws on the stale-funcIdx invalid wasm
+  return r;
+}
+
+describe("#329 assignment-form closure late-shift", () => {
+  for (const target of ["standalone", "wasi", "gc"] as const) {
+    it(`initializer form stays valid [${target}]`, async () => {
+      await compileValidate(initOk, target);
+    });
+    it(`assignment form compiles + validates [${target}]`, async () => {
+      await compileValidate(assignBug, target);
+    });
+    it(`assignment form with string body [${target}]`, async () => {
+      await compileValidate(assignStr, target);
+    });
+  }
+
+  it("assignment-form closure runs and returns 42 (standalone)", async () => {
+    const r = await compileValidate(assignBug, "standalone");
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test: () => number }).test()).toBe(42);
+  });
+});


### PR DESCRIPTION
## Problem

`let g: any; g = function () {...}; g()` emitted **invalid Wasm** under
`--target standalone` / `--target wasi`:

```
Compiling function "__str_flatten" failed:
  call[0] expected type (ref null 5), found i32.const of type i32
```

This is the #329 closure-into-`any` late-shift, in its still-live **assignment**
form. The *initializer* forms (`const f: any = fn` / `let f: any = fn`) were
already fixed by #1839/#1677/#1470; only the separate-declaration-then-assignment
form remained.

## Root cause (traced via instrumented reconcile + addImport logging)

`let g` initializes the binding to `undefined` via the `env::__get_undefined`
**host import**. Under native-strings that import is added *after* the
native-string runtime helpers (`__str_flatten`/`__str_copy_tree`) were emitted
mid-finalize, which triggers `reconcileNativeStrFinalizeShift` an **extra time**
and off-by-ones the baked `__str_flatten`→`__str_copy_tree` call (the
#1839/#1886 late-shift class). The initializer forms never emit `__get_undefined`,
so they don't hit the extra reconcile.

## Fix

`ensureGetUndefined` returns `undefined` under `ctx.nativeStrings`, so callers
fall back to the native `ref.null.extern` sentinel via `emitUndefined`
(undefined≡null in native-strings — the same convention as
`__extern_is_undefined` → bare `ref.is_null`). This:
- **eliminates a standalone/wasi host-import leak** — `__get_undefined` should
  never be a host import there; and
- **removes the post-helper late import** that drives the extra reconcile, so
  the assignment form validates.

No behavior change in JS-host/GC mode (gated on `ctx.nativeStrings`). The
`array-methods.ts` caller already handles an `undefined` return (falls back to
`defaultValueInstrs` → `ref.null.extern` for externref = the same value as the
native undefined sentinel).

## Verification

- `tests/issue-329-assign-closure-lateshift.test.ts` — assignment form (number +
  string bodies) and initializer form across {standalone,wasi,gc}, plus a
  standalone run returning 42. **10/10 pass** (assignment+wasi forms failed
  pre-fix).
- `tsc --noEmit` + `biome lint` clean.
- `issue-1021-null-vs-undefined` 5/5; native-strings/standalone suites unchanged
  vs clean main. (The `array-rest-destructuring.test.ts` vite-transform failure
  is pre-existing on main, confirmed on a fresh main worktree — not introduced
  here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)