### PR TITLE
fix(#1896): standalone typeof recognises closure wrappers (defect-1 typeof half)

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1471,6 +1471,11 @@ export function generateModule(
     // non-vec structs — JS cannot tell them apart without this probe).
     emitIsClosureExport(ctx);
 
+    // #1896: teach standalone __typeof_function/__typeof_object to recognise
+    // closure wrapper structs (closures registered after the typeof helpers were
+    // synthesised mid-compile). Edits the helper bodies in place — no funcIdx churn.
+    fillStandaloneTypeofClosureArms(ctx);
+
     // Emit __call_toString/__call_valueOf exports for ToPrimitive dispatch (#866)
     emitToPrimitiveMethodExports(ctx);
 
@@ -3293,12 +3298,17 @@ function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number): void 
  * choose between callable-wrapping (#1308) and `_wasmToPlain` marshaling
  * (#1504). No-op when the module has no closures.
  */
-function emitIsClosureExport(ctx: CodegenContext): void {
+/**
+ * Collect the deduped set of closure base-wrapper struct type indices from
+ * `ctx.closureInfoByTypeIdx`. Concrete closure subtypes (with captures) share
+ * their funcref signature with the base wrapper post-V8 canonicalisation, so a
+ * `ref.test` against the base catches all of them. Walks each registered
+ * closure struct up to its root (superTypeIdx === -1). (#1896 — shared by
+ * `emitIsClosureExport` and the standalone `__typeof_function`/`__typeof_object`
+ * closure-recognition arms.)
+ */
+function collectClosureBaseWrapperTypeIdxs(ctx: CodegenContext): number[] {
   const mod = ctx.mod;
-
-  // Collect base wrapper struct types (deduped). Concrete closure subtypes
-  // share their funcref signature with the base wrapper post-V8 canonicalisation,
-  // so ref.test against the base catches all of them.
   const baseTypeIdxs: number[] = [];
   const seenBase = new Set<number>();
   for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
@@ -3320,6 +3330,16 @@ function emitIsClosureExport(ctx: CodegenContext): void {
       baseTypeIdxs.push(root);
     }
   }
+  return baseTypeIdxs;
+}
+
+function emitIsClosureExport(ctx: CodegenContext): void {
+  const mod = ctx.mod;
+
+  // Collect base wrapper struct types (deduped). Concrete closure subtypes
+  // share their funcref signature with the base wrapper post-V8 canonicalisation,
+  // so ref.test against the base catches all of them.
+  const baseTypeIdxs = collectClosureBaseWrapperTypeIdxs(ctx);
   if (baseTypeIdxs.length === 0) return;
 
   const isClosureTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$is_closure_type");
@@ -3354,6 +3374,93 @@ function emitIsClosureExport(ctx: CodegenContext): void {
     name: "__is_closure",
     desc: { kind: "func", index: funcIdx },
   });
+}
+
+/**
+ * #1896 — teach the standalone/WASI native `__typeof_function` and
+ * `__typeof_object` helpers to recognise closure wrapper structs.
+ *
+ * Those helpers are synthesised by `addUnionImportsAsNativeFuncs`, which runs
+ * once on the first `addUnionImports` call — frequently *mid-compile*, before
+ * every closure type has been registered in `ctx.closureInfoByTypeIdx`. Baking
+ * the base-wrapper set at registration time would therefore miss later-registered
+ * closures. Instead we rewrite the two helper bodies HERE, at finalize, after all
+ * closures are registered (same late timing as `emitIsClosureExport`). We locate
+ * the functions by name in `ctx.mod.functions` and splice in `ref.test` arms over
+ * the closure base wrappers — no funcIdx churn (we edit existing bodies in place).
+ *
+ * - `__typeof_function`: was `i32.const 0` (wrong — a stored standalone closure
+ *   is callable). Now: `any.convert_extern` then chained `ref.test` over each
+ *   closure base wrapper; return 1 on first match, else 0.
+ * - `__typeof_object`: add a closure-base-wrapper `ref.test` guard that returns 0
+ *   (a callable is `"function"`, never `"object"`) BEFORE the final non-null
+ *   `i32.const 1`, so a wrapper read back from an open-object slot is not
+ *   mis-classified as `"object"`.
+ *
+ * No-op unless native-strings (the helpers only exist then) and at least one
+ * closure base wrapper was registered.
+ */
+function fillStandaloneTypeofClosureArms(ctx: CodegenContext): void {
+  if (!ctx.nativeStrings) return;
+  const baseTypeIdxs = collectClosureBaseWrapperTypeIdxs(ctx);
+  if (baseTypeIdxs.length === 0) return;
+
+  const fnByName = (name: string): WasmFunction | undefined =>
+    ctx.mod.functions.find((f) => (f as { name?: string }).name === name) as WasmFunction | undefined;
+
+  // Chained `ref.test` arms over the anyref-converted param in local 0/1. Each
+  // arm returns `matchValue` on hit. Caller supplies the param→anyref local.
+  const closureTestArms = (anyLocalIdx: number, matchValue: number): Instr[] => {
+    const arms: Instr[] = [];
+    for (const t of baseTypeIdxs) {
+      arms.push({ op: "local.get", index: anyLocalIdx } as Instr);
+      arms.push({ op: "ref.test", typeIdx: t } as Instr);
+      arms.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: matchValue } as Instr, { op: "return" } as Instr],
+      } as Instr);
+    }
+    return arms;
+  };
+
+  // --- __typeof_function: param(0) externref → 1 if closure wrapper else 0.
+  const tf = fnByName("__typeof_function");
+  if (tf) {
+    // Ensure an anyref local exists for the converted param (local index 1).
+    if (tf.locals.length === 0) {
+      tf.locals.push({ name: "$any_temp", type: { kind: "anyref" } });
+    }
+    tf.body = [
+      { op: "local.get", index: 0 } as Instr,
+      { op: "ref.is_null" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 } as Instr, { op: "return" } as Instr],
+      } as Instr,
+      { op: "local.get", index: 0 } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 1 } as Instr,
+      ...closureTestArms(1, 1),
+      { op: "i32.const", value: 0 } as Instr,
+    ];
+  }
+
+  // --- __typeof_object: insert closure-exclusion (return 0) before the trailing
+  // non-null `i32.const 1`. The existing body already converts the param to
+  // anyref into local 1 (`$any_temp`) for its boxed-primitive guards, so reuse it.
+  const to = fnByName("__typeof_object");
+  if (to) {
+    const b = to.body;
+    // The body ends with `{ i32.const 1 }` (the "non-null → object" fallthrough).
+    // Splice the closure-exclusion arms immediately before that terminal const.
+    const lastIdx = b.length - 1;
+    const last = b[lastIdx] as { op?: string; value?: number } | undefined;
+    if (last && last.op === "i32.const" && last.value === 1) {
+      b.splice(lastIdx, 0, ...closureTestArms(1, 0));
+    }
+  }
 }
 
 /**
@@ -4458,6 +4565,10 @@ export function generateMultiModule(
 
     // #1504: emit __is_closure for wrapExports discrimination.
     emitIsClosureExport(ctx);
+
+    // #1896: teach standalone __typeof_function/__typeof_object to recognise
+    // closure wrapper structs (edits helper bodies in place — no funcIdx churn).
+    fillStandaloneTypeofClosureArms(ctx);
 
     // Emit __call_toString/__call_valueOf exports for ToPrimitive dispatch.
     emitToPrimitiveMethodExports(ctx);

--- a/tests/issue-1896-typeof-closure.test.ts
+++ b/tests/issue-1896-typeof-closure.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1896 defect-1 (typeof half) — standalone/WASI `__typeof_function` /
+ * `__typeof_object` must recognise stored closure wrapper structs.
+ *
+ * Under `--target standalone` / `--target wasi` (native strings) a closure is
+ * lowered to a WasmGC wrapper struct. When such a closure is held in an
+ * `any`-typed binding (or an open-object slot) and read back dynamically, the
+ * `typeof` operator routes through the native `__typeof_function` /
+ * `__typeof_object` helpers synthesised by `addUnionImportsAsNativeFuncs`.
+ *
+ * Before this fix those helpers were stubs:
+ *   - `__typeof_function` returned a hard `0` → a stored closure reported
+ *     `typeof !== "function"` (it fell through to `"object"`).
+ *   - `__typeof_object` returned `1` for *any* non-null, non-boxed-primitive
+ *     externref → a closure wrapper read from an open slot was mis-classified
+ *     as `"object"`.
+ *
+ * `fillStandaloneTypeofClosureArms` (src/codegen/index.ts) rewrites both helper
+ * bodies at finalize — after every closure type is registered in
+ * `ctx.closureInfoByTypeIdx` — to `ref.test` the closure base-wrapper set:
+ *   - `__typeof_function`: any.convert_extern then chained `ref.test` over each
+ *     closure base wrapper → 1 on first match, else 0.
+ *   - `__typeof_object`: a closure-base-wrapper `ref.test` guard returning 0
+ *     (a callable is `"function"`, never `"object"`) before the terminal
+ *     non-null `i32.const 1`.
+ *
+ * The fix is no-op outside native-strings (the helpers only exist there) and
+ * when no closure base wrapper was registered.
+ *
+ * Tests use the *dynamic* typeof path (closure stored in an `any` slot / open
+ * object property) so the value flows through the native helper rather than
+ * being statically resolved to `"function"` at compile time.
+ */
+
+async function runStandalone(src: string, target: "standalone" | "wasi"): Promise<number> {
+  const r = await compile(src, { target });
+  expect(
+    r.success,
+    `compile failed (${target}):\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  // Standalone / WASI binaries take no JS-host imports beyond an empty env.
+  const { instance } = await WebAssembly.instantiate(r.binary, { env: {} });
+  return (instance.exports as Record<string, (...a: unknown[]) => number>).test();
+}
+
+const TARGETS: Array<"standalone" | "wasi"> = ["standalone", "wasi"];
+
+describe("#1896 standalone typeof recognises closure wrappers", () => {
+  for (const target of TARGETS) {
+    describe(`target=${target}`, () => {
+      it("closure held in an `any` slot reports typeof 'function'", async () => {
+        const src = `
+          export function test(): number {
+            const f = (x: number): number => x * 2;
+            const a: any = f;
+            return (typeof a === "function") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(1);
+      });
+
+      it("capturing closure in an `any` slot reports typeof 'function'", async () => {
+        const src = `
+          export function test(): number {
+            let k = 7;
+            const f = (): number => k;
+            const a: any = f;
+            return (typeof a === "function") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(1);
+      });
+
+      it("plain object in an `any` slot is NOT 'function'", async () => {
+        const src = `
+          export function test(): number {
+            const o: any = { a: 1 };
+            return (typeof o === "function") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(0);
+      });
+
+      it("plain object in an `any` slot reports typeof 'object'", async () => {
+        const src = `
+          export function test(): number {
+            const o: any = { a: 1 };
+            return (typeof o === "object") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(1);
+      });
+
+      it("number in an `any` slot is NOT 'function'", async () => {
+        const src = `
+          export function test(): number {
+            const x: any = 7;
+            return (typeof x === "function") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(0);
+      });
+
+      it("string in an `any` slot is NOT 'function'", async () => {
+        const src = `
+          export function test(): number {
+            const s: any = "hi";
+            return (typeof s === "function") ? 1 : 0;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(0);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## #1896 defect-1 (typeof half)

Under `--target standalone` / `--target wasi` (native strings) a closure is lowered to a WasmGC wrapper struct. When such a closure is held in an `any`-typed binding (or open-object slot) and read back **dynamically**, the `typeof` operator routes through the native `__typeof_function` / `__typeof_object` helpers synthesised by `addUnionImportsAsNativeFuncs`. Those helpers were stubs:

- `__typeof_function` returned a hard `0` → a stored closure reported `typeof !== "function"` (the defect-1 bug).
- `__typeof_object` returned `1` for *any* non-null, non-boxed-primitive externref → a closure wrapper read from a slot was mis-classified as `"object"`.

## Fix

`fillStandaloneTypeofClosureArms` (src/codegen/index.ts) rewrites both helper bodies **at finalize** — after every closure type is registered in `ctx.closureInfoByTypeIdx` (same late timing as `emitIsClosureExport`, because `addUnionImports` fires mid-compile before all closures exist). It locates the helpers by name in `ctx.mod.functions` and splices `ref.test` arms over the closure base wrappers, with **no funcIdx churn** (existing bodies edited in place):

- `__typeof_function`: `ref.is_null` → 0, else `any.convert_extern` + chained `ref.test` over each closure base wrapper → 1 on first match, else 0.
- `__typeof_object`: a closure-base-wrapper `ref.test` guard returning 0 (a callable is `"function"`, never `"object"`) before the terminal non-null `i32.const 1`.

No-op outside native-strings (the helpers only exist there) and when no closure base wrapper was registered. Extracts `collectClosureBaseWrapperTypeIdxs` (shared with the `__is_closure` export). **index.ts only** — clear of the object-runtime.ts open-any work.

## Why this matters

This is the S2 unblocker on the #1888 standalone open-any dispatch path: `o.m()` method dispatch and `__call_fn` ref dispatch need a closure stored in an open slot to report `typeof === "function"`.

## Test

`tests/issue-1896-typeof-closure.test.ts` (12 tests, standalone + wasi):
- closure / capturing-closure in `any` slot → `typeof "function"`
- plain object → `typeof "object"` and NOT `"function"`
- number / string → NOT `"function"`

Confirmed **failing on clean main** (anyClosure `typeof "function"` → 0) and **passing with the fix**.

`tsc --noEmit` clean, biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)