### PR TITLE
docs(#1899): file finalize funcIdx-authority contract (deferred hardening)

### DIFF
--- a/plan/agent-context/sd-1472c-329.md
+++ b/plan/agent-context/sd-1472c-329.md
@@ -1,0 +1,74 @@
+# #329 late-import func-index-shift — root cause + fix plan (sd-1472c)
+
+_2026-06-05. Resilience writeup so a fresh senior-dev can resume with zero loss._
+
+## Symptom
+`let g: any; g = function () {...}; g()` (separate decl + ASSIGNMENT) emits
+invalid Wasm under `--target standalone`/`wasi`:
+
+```
+Compiling function "__str_flatten" failed:
+  call[0] expected type (ref null 5), found i32.const of type i32
+```
+
+Initializer forms (`const f: any = fn` / `let f: any = fn`) are already valid
+(fixed by #1839/#1677/#1470). Only the assignment-expression path remained.
+Minimal repro: `let g:any; g=function(){return 42}; export function test():number{return g();}` --target standalone.
+
+## Root cause (traced via instrumented reconcile + addImport logging)
+The `let g` binding is initialized to `undefined` via the `env::__get_undefined`
+HOST import. Under native-strings that import is added **after** the
+native-string runtime helpers (`__str_flatten`/`__str_copy_tree`) were emitted
+mid-finalize. `reconcileNativeStrFinalizeShift`
+(src/codegen/expressions/late-imports.ts:355) runs **incrementally** — it
+re-bases `ctx.nativeStrHelperImportBase = ctx.numImportFuncs` each call and
+applies only the NEW delta (`added = numImportFuncs - base`). The extra
+post-helper import fires reconcile a THIRD time (base=1,numImportFuncs=2,
+added=+1), bumping the helper map AND the helper-body sibling calls again. The
+net result off-by-ones `__str_flatten`'s baked `call __str_copy_tree`.
+
+Observed firings (DBG329):
+- INIT:   reconcile(0,1,+1), reconcile(1,1,0)
+- ASSIGN: reconcile(0,1,+1), reconcile(1,1,0), reconcile(1,2,+1)   ← extra
+The extra is triggered by `env::__get_undefined` landing at import idx 1.
+
+The deeper invariant break (per tech-lead): reconcile assumes imports are
+**monotonic** (only added, never removed). `eliminateDeadImports`
+(dead-elimination.ts) can later REMOVE a now-dead late import, so the cumulative
+incremental deltas don't match the FINAL import count — add-then-remove churn.
+
+## Fix landed so far (PR #1225, commit 963f9b32d) — the TRIGGER removal
+`ensureGetUndefined` returns `undefined` under `ctx.nativeStrings`, so callers
+use the native `ref.null.extern` sentinel (undefined≡null in native-strings).
+This removes the post-helper `__get_undefined` host import (also a real
+standalone/wasi host-import LEAK) → no extra reconcile → assignment form
+validates. 11 lines, gated, GC byte-identical. tests/issue-329-assign-closure-lateshift.test.ts
+10/10. This is correct + valuable but TRIGGER-specific, not the class fix.
+
+## Fix plan — option (A) the DURABLE class fix (tech-lead decision, IMPLEMENT)
+Make `reconcileNativeStrFinalizeShift` resilient to add-then-remove churn by
+computing the shift ONCE from the FINAL `numImportFuncs` vs the ORIGINAL base,
+instead of incrementally re-basing. Concretely:
+- Stop re-basing `nativeStrHelperImportBase` on every call.
+- Track the **original** base (import count at first helper emit) separately and
+  immutably; only apply the shift once, at the LAST finalize call, using
+  `added = finalNumImportFuncs - originalBase`.
+- Make repeated reconcile calls idempotent (guard so only the final one shifts),
+  OR record the original base + already-applied total and apply only the residual.
+- Net-zero for the well-behaved monotonic case; correct for churn.
+
+Fallback (B) if (A) needs more surgery: re-resolve helper sibling-call indices
+by NAME at finalize-end (needs a target→name map; ~35 helper sibling-call sites
+each bake a captured sibling index — bigger). Both durable; prefer (A).
+
+Keep the #1225 trigger-removal too (independent leak fix). Add the
+`const f:any=function(){return 42}; f()` standalone regression test (permanent
+guard for the recurring #1677/#1839/#1886/#329 class; pairs with #1897 gate).
+
+## Note on #1209
+`validateFuncRefs` (the env-gated net) only catches OUT-OF-RANGE/-1 funcIdx, NOT
+this IN-RANGE-but-wrong-target case. Worth stating in the PR.
+
+## State
+- Worktree: /workspace/.claude/worktrees/issue-329-closure-any-lateshift (branch issue-329-closure-any-lateshift)
+- PR #1225 open (trigger-removal). (A) to be added on top in the same PR.

--- a/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
+++ b/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
@@ -1,0 +1,112 @@
+---
+id: 1899
+title: "finalize funcIdx-authority contract: reconcile↔dead-elim native-string helper sibling-call mismatch (late-shift class recurrence-proofing)"
+status: ready
+created: 2026-06-05
+priority: medium
+feasibility: hard
+task_type: refactor
+area: codegen
+goal: standalone-mode
+related: [329, 1677, 1809, 1839, 1886, 1891, 1257, 1888, 1209]
+---
+# #1899 — finalize funcIdx-authority contract (recurring late-shift class kill)
+
+**Architect input from sd-1472c's #329 trace. The architect ratifies the
+finalize funcIdx-authority contract; a senior-dev then implements (B) off it.
+Do NOT blind-implement — high blast radius (35 bake sites, every standalone/WASI
+string program). One careful change, not a guess.**
+
+## The recurring class (5th occurrence)
+A defined-function `call <funcIdx>` baked **mid-finalize** goes stale when
+finalize-time imports are added (and/or later removed), because the index space
+shifts under the already-baked call. Prior occurrences: #1677, #1809, #1839,
+#1886, #1891 (and the @@toPrimitive/#118 trigger), now #329. Each was patched
+point-wise; this issue ratifies the *contract* so it stops recurring.
+
+## Keystone (why it's worth a contract, not another point-fix)
+The SAME reconcile↔dead-elim funcIdx mismatch blocks three in-flight workstreams:
+- **#329** — `__str_flatten`→`__str_copy_tree` (native-string sibling call).
+- **#1888 S2** — `__apply_closure` baked calls into `__call_fn_method_N`.
+- **#1888 Slice 5 (live)** — accessor `__call_fn_method_N` baked calls.
+Fix the authority once → unblocks all three.
+
+## Trace / evidence (sd-1472c, --target standalone, instrumented)
+Repro: `let g: any; g = function () { return 42; }; export function test(): number { return g(); }`
+fails validation: `__str_flatten ... call[0] expected (ref null 5), found i32.const`.
+(`const f:any=fn` / `let f:any=fn` initializer forms are already valid.)
+
+`reconcileNativeStrFinalizeShift` (late-imports.ts:355) firings
+`(base, numImportFuncs, added)`:
+- INIT (valid):   `(0,1,+1)`, `(1,1,0)`
+- ASSIGN (broken): `(0,1,+1)`, `(1,1,0)`, **`(1,2,+1)`** ← extra
+
+The extra 3rd firing is triggered by `env::__get_undefined` (the `let g`
+undefined-init host import) landing at import idx 1 AFTER the native-string
+helpers were emitted mid-finalize.
+
+## Why the current design mis-handles it
+- `reconcileNativeStrFinalizeShift` runs **incrementally** and **re-bases**
+  `nativeStrHelperImportBase = numImportFuncs` each call, shifting helper-map
+  entries + helper-body sibling-calls UP by the per-call delta. It assumes
+  imports are **monotonic** (only added).
+- It is called at 5 points (index.ts:1050/1111/4308/4336/7886) **interleaved
+  with body compilation** — bodies emitted between calls bake `call <helper>`
+  reading the CURRENT (already-shifted) helper index. So the incremental shift
+  is **load-bearing**: a single end-of-finalize shift would break every body
+  emitted before the final import settles. (Option A is therefore NOT a small
+  change — see below.)
+- `eliminateDeadImports` (dead-elimination.ts:221, called index.ts:1504/4496)
+  can later **REMOVE** a now-dead finalize import and remap all call targets —
+  the add-then-remove churn the incremental monotonic reconcile cannot model.
+  The cumulative incremental deltas then disagree with the FINAL import count →
+  the baked sibling call is off-by-one.
+
+## Options
+- **(A) compute the shift ONCE from FINAL numImportFuncs vs original base.**
+  Net-zero for the monotonic case, correct for churn — BUT it fights the
+  load-bearing mid-stream incremental requirement (bodies emitted before the
+  final count need correct indices at their emit time). Not feasible as a small
+  change without restructuring when bodies are emitted vs when imports settle.
+- **(B) RECOMMENDED — post-dead-elim by-name re-resolution as the authority.**
+  After ALL finalize import churn (the last reconcile AND `eliminateDeadImports`)
+  settles, run one final pass that re-points every finalize-emitted helper body's
+  sibling-helper `call` to the authoritative `nativeStrHelpers.get(<name>)`
+  (and `funcMap.get(<name>)` for the broader set). Requires anchoring each
+  sibling call to a NAME, since `{op:"call",funcIdx}` carries no name today.
+  Two sub-approaches for the contract to choose:
+  - (B1) tag each helper sibling-call with `helperName` at the ~35 emit sites
+    (flatten→copyTree, slice→substring, includes→indexOf, trim→isWhitespace+
+    substring, padStart→concat+repeat+substring, repeat→concat, …), then the
+    final pass re-points by tag. Most explicit; touches 35 sites.
+  - (B2) build a stale-index→name reverse map snapshotted at each helper
+    registration, and re-point in the final pass. No emit-site changes; one
+    central map. Prefer if the contract finds it sound.
+
+## Contract questions for the architect
+1. Who OWNS finalize-emitted helper call-target resolution — reconcile (shift),
+   dead-elim (remap), or a final by-name authority pass? (Recommend: a final
+   by-name pass is the single source of truth; reconcile/dead-elim become
+   index-bookkeeping that the final pass overrides for helper sibling-calls.)
+2. Scope: native-string helpers only, or all finalize-emitted defined funcs
+   (so it also covers `__call_fn_method_N` for #1888 S2 + Slice 5)?
+3. B1 (tag at emit) vs B2 (central reverse map) — ratify one.
+4. Interaction with `flushLateImportShifts` (compilation-phase path) — confirm
+   the final pass doesn't double-shift compilation-phase baked calls.
+
+## Already landed (independent, keep)
+PR #1225 (#329 targeted fix): under `ctx.nativeStrings`, `ensureGetUndefined`
+returns undefined → callers use the native `ref.null.extern` sentinel instead of
+the `env::__get_undefined` host import. Removes THIS trigger + fixes a real
+standalone/wasi host-import leak. Regression test:
+`tests/issue-329-assign-closure-lateshift.test.ts`. #1899 is the durable
+class-level kill on top; #1225 does not block it.
+
+## Net / detection
+#1209's `validateFuncRefs` (src/emit/binary.ts, env-gated) only catches
+OUT-OF-RANGE/-1 funcIdx, NOT this IN-RANGE-but-wrong-target case. The #1899 fix
+is the real prevention; consider extending the guard to flag helper sibling-calls
+whose target name≠expected once the by-name authority exists.
+
+## Resilience
+Full context also in `plan/agent-context/sd-1472c-329.md`.


### PR DESCRIPTION
## #1899 — finalize funcIdx-authority contract (recurrence-proofing)

**Plan-only PR** — files the durable recurrence-proofing issue for the reconcile/dead-elim native-string helper sibling-call funcIdx mismatch (the recurring late-shift class: 5th occurrence — #1677/#1809/#1839/#1886/#1891, now #329). No source changes.

### What it captures
- sd-1472c's instrumented #329 trace: the `(0,1,+1)(1,1,0)(1,2,+1)` reconcile firings, with the extra third firing triggered by `env::__get_undefined` landing post-helper.
- Root cause: `reconcileNativeStrFinalizeShift` re-bases incrementally and assumes **monotonic** imports; `eliminateDeadImports` can later remove a now-dead import → cumulative deltas disagree with the final import count → off-by-one baked sibling-call.
- Options: **(A)** compute-shift-once (fights the load-bearing mid-stream incremental requirement); **(B, recommended)** post-dead-elim by-name re-resolution as the authority — sub-approaches B1 (tag-at-emit, ~35 sites) / B2 (central reverse-map). Plus four contract questions for the architect.

### Why DEFERRED (medium priority, not blocking)
The **acute triggers are being removed one-by-one** — #1224 (arg-coercion) merged, #1225 (`__get_undefined`) enqueued — so #1899 is recurrence-PROOFING, not a current blocker. We are deliberately **not** commissioning a 35-site refactor on spec.

### Decision gate
When #1888 **S2** is wired (`__apply_closure`'s baked `call __call_fn_method_N`):
- **If it does NOT trip the reconcile off-by-one** → #1899 stays filed as medium-pri hardening, done later, properly.
- **If it DOES trip it** → #1899 is proven on the critical path; an architect is spawned on the spot with this trace as input.

Also lands `plan/agent-context/sd-1472c-329.md` so the full trace survives session boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)