### PR TITLE
fix(dashboard): serve issue markdown in dev + bare-id links + reliable live-reload

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -394,4 +394,19 @@ if (hasDashboardBundle) {
 // client-side via the URL /plan/issues/<slug>.md
 copyDirectoryIfExists(join(PLAN_DIR, "issues"), join(PAGES_DIST, "plan", "issues"));
 
+// Write a lightweight id → filename index next to the copied issue files so the
+// dashboard issue page can resolve a bare id (?slug=681) to its full filename.
+// (Dev serves the equivalent on the fly via website/playground/vite-plugin-dashboard.ts.)
+{
+  const issuesOut = join(PAGES_DIST, "plan", "issues");
+  if (existsSync(issuesOut)) {
+    const idIndex = {};
+    for (const name of readdirSync(issuesOut)) {
+      const m = name.match(/^(\d+[a-z]?)(?:-.*)?\.md$/i);
+      if (m) idIndex[m[1]] = name.replace(/\.md$/, "");
+    }
+    writeFileSync(join(issuesOut, "index.json"), JSON.stringify(idIndex));
+  }
+}
+
 console.log(`GitHub Pages artifact ready at ${PAGES_DIST}`);

--- a/website/dashboard/issue.html
+++ b/website/dashboard/issue.html
@@ -180,6 +180,31 @@
     </article>
 
     <script>
+      // Fetch an issue's markdown. `slug` may be a full filename stem
+      // (681-pure-wasm-…) or a bare issue id (681 / 1525b). Resolution works in
+      // both modes:
+      //   dev  — the dashboard Vite plugin serves /plan/issues/*.md from the
+      //          repo root and prefix-resolves bare ids to <id>-*.md
+      //   prod — scripts/build-pages.js copies plan/issues into the site and
+      //          writes index.json (id → filename) for the bare-id fallback
+      async function fetchIssueMarkdown(slug) {
+        // 1) Try the slug directly (full filename, or a bare id the dev plugin
+        //    prefix-resolves).
+        let response = await fetch(`/plan/issues/${slug}.md`);
+        if (response.ok) return await response.text();
+
+        // 2) Fall back: treat the slug as a bare id and resolve via index.json.
+        const index = await fetch("/plan/issues/index.json")
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null);
+        if (index && index[slug]) {
+          response = await fetch(`/plan/issues/${index[slug]}.md`);
+          if (response.ok) return await response.text();
+        }
+
+        throw new Error(`Issue not found: ${slug}`);
+      }
+
       async function loadIssue() {
         // Extract slug from URL query parameter
         const params = new URLSearchParams(window.location.search);
@@ -194,29 +219,7 @@
         document.getElementById("issue-num").textContent = `#${slug.split("-")[0]}`;
 
         try {
-          // Try fetching the markdown file from multiple possible locations
-          // Production: /plan/issues/<slug>.md
-          // Development: ../../plan/issues/<slug>.md (relative from dashboard/issue.html)
-          const paths = [`/plan/issues/${slug}.md`, `../../plan/issues/${slug}.md`];
-
-          let markdown = null;
-          let lastError = null;
-
-          for (const path of paths) {
-            try {
-              const response = await fetch(path);
-              if (response.ok) {
-                markdown = await response.text();
-                break;
-              }
-            } catch (err) {
-              lastError = err;
-            }
-          }
-
-          if (!markdown) {
-            throw new Error(`Issue not found. Tried: ${paths.join(", ")}`);
-          }
+          const markdown = await fetchIssueMarkdown(slug);
 
           // Remove frontmatter
           const contentStart = markdown.indexOf("---", 3) + 3;

--- a/website/playground/vite-plugin-dashboard.ts
+++ b/website/playground/vite-plugin-dashboard.ts
@@ -489,6 +489,23 @@ export function dashboardPlugin(): Plugin {
         }
       }
 
+      // fs.watch({recursive:true}) silently no-ops on Linux/containers (Node's
+      // recursive mode isn't supported there), which is why dashboard live
+      // updates stopped firing — change events never reach onFileChange, so the
+      // SSE "refresh" is never broadcast. Vite's own chokidar watcher is
+      // reliable cross-platform, so register the repo-root source dirs (they
+      // live outside Vite's website/ root, so add() is required) and route their
+      // changes through the same debounced handler. Watch SOURCES only
+      // (plan/ + benchmarks/results) — never dashboard/data, which is the
+      // regenerated OUTPUT and would otherwise loop.
+      const chokidarRoots = [join(projectRoot, "plan"), join(projectRoot, "benchmarks/results")].filter(existsSync);
+      for (const dir of chokidarRoots) server.watcher.add(dir);
+      server.watcher.on("all", (_event, changedPath) => {
+        if (typeof changedPath === "string" && chokidarRoots.some((d) => changedPath.startsWith(d))) {
+          onFileChange("change", changedPath);
+        }
+      });
+
       // SSE endpoint for live updates — no upgrade dance, works through Vite middleware
       server.middlewares.use("/dashboard-sse", (req, res) => {
         res.writeHead(200, {
@@ -597,6 +614,50 @@ _es.onmessage = (e) => {
         if (url.pathname === "/api/dashboard/burndown") {
           res.setHeader("Content-Type", "application/json");
           res.end(JSON.stringify(loadBurndown()));
+          return;
+        }
+
+        // Lightweight id → slug index so the issue detail page can resolve a
+        // bare id (?slug=681) to its full filename. Generated on the fly in
+        // dev; scripts/build-pages.js writes the static equivalent for prod.
+        if (url.pathname === "/plan/issues/index.json") {
+          const map: Record<string, string> = {};
+          for (const f of readdirSync(join(projectRoot, "plan", "issues"))) {
+            const m = f.match(/^(\d+[a-z]?)(?:-.*)?\.md$/i);
+            if (m) map[m[1]] = f.replace(/\.md$/, "");
+          }
+          res.setHeader("Content-Type", "application/json");
+          res.setHeader("Cache-Control", "no-cache");
+          res.end(JSON.stringify(map));
+          return;
+        }
+
+        // Raw issue markdown for the dashboard issue detail page (issue.html).
+        // plan/issues/ lives at the repo root, OUTSIDE Vite's website/ root, so
+        // a plain fetch('/plan/issues/<slug>.md') would 404 in dev. In
+        // production scripts/build-pages.js copies plan/issues into the
+        // published site, so the same URL resolves statically there.
+        if (url.pathname.startsWith("/plan/issues/") && url.pathname.endsWith(".md")) {
+          const slug = decodeURIComponent(url.pathname.slice("/plan/issues/".length, -".md".length));
+          // Flat issue filenames only — reject path traversal (no "/", no "..").
+          if (/^[\w.-]+$/.test(slug) && !slug.includes("..")) {
+            const dir = join(projectRoot, "plan", "issues");
+            let filePath = join(dir, `${slug}.md`);
+            // Bare id (e.g. "681" or "1525b") → first matching "<id>-*.md".
+            if (!existsSync(filePath) && /^\d+[a-z]?$/i.test(slug)) {
+              const match = readdirSync(dir).find((f) => new RegExp(`^${slug}(?:-.*)?\\.md$`, "i").test(f));
+              if (match) filePath = join(dir, match);
+            }
+            if (existsSync(filePath)) {
+              res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+              res.setHeader("Cache-Control", "no-cache");
+              res.end(readFileSync(filePath, "utf-8"));
+              return;
+            }
+          }
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end(`Issue not found: ${slug}`);
           return;
         }
 


### PR DESCRIPTION
Three dashboard dev-experience fixes (follow-up to #1214/#1217).

## 1. Serve issue markdown in dev
`plan/issues/` lives at the repo root, **outside** Vite's `website/` root, so the issue detail page's `fetch('/plan/issues/<slug>.md')` 404'd in dev. Added a dashboard-plugin middleware that serves it from the repo root (mirrors the existing `adrPlugin`). Production already works via `build-pages.js` copying `plan/issues` into the site.

## 2. Bare-id issue links
`issue.html` now resolves `?slug=681` (a bare issue id) as well as the full `?slug=681-pure-wasm-…` filename — it tries the slug directly, then falls back to an id→filename `index.json`. The dev middleware prefix-resolves bare ids and serves `index.json` on the fly; `build-pages.js` writes the static `index.json` for prod.

## 3. Reliable live-reload
`fs.watch({recursive:true})` silently no-ops on Linux/containers, so dashboard change events never fired and the SSE `refresh` was never broadcast (timeline/board didn't auto-update). Registered the repo-root source dirs (`plan/`, `benchmarks/results`) with Vite's chokidar watcher and routed changes through the same debounced handler. Sources only — never `dashboard/data` (the regenerated output) — to avoid a regen loop.

## Test plan
- `npm run dev`, open `/dashboard/`, click a card → issue renders.
- Visit `issue.html?slug=681` (bare id) → resolves and renders.
- Edit a `plan/issues/*.md` → dashboard auto-refreshes (no manual reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)