### PR TITLE
feat(#1888 Slice 5): native accessor-descriptor runtime layer (groundwork)

### DIFF
--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -58,16 +58,26 @@
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { ensureNativeStringHelpers } from "./native-strings.js";
+import { ensureNativeStringHelpers, nativeStringLiteralInstrs } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
+import { addUnionImportsViaRegistry } from "./shared.js";
 
 /** Initial `$PropMap` capacity. Must be a power of two (mask = cap - 1). */
 const INITIAL_CAP = 8;
+
+/** WasmGC `none` bottom heap type (signed-LEB 0x6e = -18). `ref.null none` is a
+ *  subtype of `anyref`, used to push a null into the `$PropEntry.$get/$set`
+ *  anyref slots on the data path (#1888 Slice 5). */
+const NONE_HEAP = -18;
 
 /** `$PropEntry.$flags` bit layout. */
 const FLAG_WRITABLE = 0x01;
 const FLAG_ENUMERABLE = 0x02;
 const FLAG_CONFIGURABLE = 0x04;
+// #1888 Slice 5 — accessor descriptor: when set, the entry's value is replaced
+// by the `$get`/`$set` funcref-bearing slots (fields 4/5). 0x08 is the first
+// free bit (0x10/0x20/0x40 remain free; 0x80 = TOMBSTONE).
+const FLAG_ACCESSOR = 0x08;
 const FLAG_TOMBSTONE = 0x80;
 /** Default for a data property created by `o.x = v` — w/e/c all true. */
 const FLAG_DEFAULT = FLAG_WRITABLE | FLAG_ENUMERABLE | FLAG_CONFIGURABLE;
@@ -137,6 +147,16 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       // only so the field can be filled by struct.new at any callsite; it is
       // never rewritten after creation.
       { name: "seq", type: { kind: "i32" }, mutable: true },
+      // #1888 Slice 5 — accessor get/set slots. Non-null only when
+      // (flags & FLAG_ACCESSOR); the boxed getter/setter closure is held as an
+      // anyref (closures are per-signature structs dispatched dynamically, so
+      // there is no single typed closure ref to use here). On the data path
+      // both are null — zero behavioural change for non-accessor properties.
+      // Appended LAST so existing field indices 0-3 (key/value/flags/seq) are
+      // unchanged (R3 migration note); the single `struct.new $PropEntry` site
+      // (__obj_insert) pushes two `ref.null any` for these.
+      { name: "get", type: { kind: "anyref" }, mutable: true },
+      { name: "set", type: { kind: "anyref" }, mutable: true },
     ],
   });
 
@@ -603,13 +623,16 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
                   { op: "i32.const", value: OBJ_FLAG_NONEXTENSIBLE },
                   { op: "i32.and" },
                   { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
-                  // arr[i] = struct.new $PropEntry { keyStr, value, flags, seq }
+                  // arr[i] = struct.new $PropEntry { keyStr, value, flags, seq,
+                  //                                   get=null, set=null }
                   { op: "local.get", index: 5 },
                   { op: "local.get", index: 8 },
                   { op: "local.get", index: 11 },
                   { op: "local.get", index: 2 },
                   { op: "local.get", index: 3 },
                   { op: "local.get", index: 4 }, // seq (#1837)
+                  { op: "ref.null", typeIdx: NONE_HEAP }, // get (#1888 S5) — data path: null
+                  { op: "ref.null", typeIdx: NONE_HEAP }, // set (#1888 S5) — data path: null
                   { op: "struct.new", typeIdx: propEntryTypeIdx },
                   { op: "array.set", typeIdx: propMapTypeIdx },
                   // o.count++
@@ -2659,6 +2682,326 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __defineProperty_accessor (#1888 Slice 5 — native accessor-descriptor STORE) ─
+  //
+  // `Object.defineProperty(obj, key, { get?, set?, enumerable?, configurable? })`
+  // and `Reflect.defineProperty` for an ACCESSOR descriptor under standalone /
+  // WASI. The JS-host path is the `env::__defineProperty_accessor` import backed
+  // by the JS descriptor sidecar; standalone has no host, so we store the boxed
+  // getter/setter closures + attribute flags directly into the `$PropEntry`
+  // accessor slots ($get field 4 / $set field 5).
+  //
+  // RUNTIME-LAYER GROUNDWORK (#1888 Slice 5). This + the native
+  // `__getOwnPropertyDescriptor` below + the R3 `$PropEntry.$get/$set` layout are
+  // the foundation for accessor descriptors under standalone. They are NOT yet
+  // reached end-to-end (see the call-site note below), so they bank ~0 test262 on
+  // their own — the value is de-risking the R3 layout change in isolation +
+  // providing the runtime target the wiring follow-up calls.
+  //
+  // FOLLOW-UPS (both #329-gated — the late-shift / host-free-closure funcIdx
+  // stability fix being driven now):
+  //   - Call-site wiring: `Object.defineProperty(o,k,{get,set})` (object-ops.ts)
+  //     compiles getter/setter via `compileArrowAsCallback` → `__make_getter_callback`
+  //     (a JS-host import). Routing those to HOST-FREE closures so they reach this
+  //     helper (and the GOPD readback can see real getter/setter) needs the #329
+  //     funcIdx-stability fix.
+  //   - LIVE get/set invocation on member read/write — the accessor arms in
+  //     `__extern_get` / `__extern_set` invoke `$get`/`$set` with the original
+  //     receiver bound as `this` via `__call_fn_method_0/1` (#1636-S1); also rides
+  //     sd-1472c's #1224 `__call_fn_N` externref-arg coercion fix (now landed).
+  //
+  // Flag translation matches __defineProperty_value (host value bits 0/1/2 →
+  // native FLAG_WRITABLE/_ENUMERABLE/_CONFIGURABLE) — but an accessor has no
+  // writable attribute (ES §6.2.6.1), so we additionally OR in FLAG_ACCESSOR and
+  // leave WRITABLE masked off via the same NATIVE_ATTR_MASK (the host accessor
+  // encoding never sets bit 0). The data $value slot is cleared to null.
+  //
+  // params: 0=obj 1=key 2=getter(externref) 3=setter(externref) 4=flagsF64
+  // locals: 5=o(ref null $Object) 6=any(anyref) 7=cap 8=load 9=nflags(i32) 10=hf(i32) 11=seq 12=e(ref null $PropEntry)
+  {
+    const NATIVE_ATTR_MASK = FLAG_ENUMERABLE | FLAG_CONFIGURABLE; // 0x06 — accessors carry no WRITABLE
+    const body: Instr[] = [
+      // any = any.convert_extern(obj) ; if !$Object → return obj (lenient no-op)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 6 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      },
+      // o = cast<$Object>(any)
+      { op: "local.get", index: 6 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 5 },
+      // hf = trunc_s(flagsF64)
+      { op: "local.get", index: 4 },
+      { op: "i32.trunc_f64_s" },
+      { op: "local.set", index: 10 },
+      // nflags = (hf & (ENUMERABLE|CONFIGURABLE)) | FLAG_ACCESSOR
+      { op: "local.get", index: 10 },
+      { op: "i32.const", value: NATIVE_ATTR_MASK },
+      { op: "i32.and" },
+      { op: "i32.const", value: FLAG_ACCESSOR },
+      { op: "i32.or" },
+      { op: "local.set", index: 9 },
+      // load = o.count + o.tombstones ; cap = o.props.len ; grow at LF 0.7
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 2 },
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 3 },
+      { op: "i32.add" },
+      { op: "local.set", index: 8 },
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "array.len" },
+      { op: "local.set", index: 7 },
+      // if (load + 1) * 10 >= cap * 7 → grow
+      { op: "local.get", index: 8 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "i32.const", value: 10 },
+      { op: "i32.mul" },
+      { op: "local.get", index: 7 },
+      { op: "i32.const", value: 7 },
+      { op: "i32.mul" },
+      { op: "i32.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 5 }, { op: "ref.as_non_null" }, { op: "call", funcIdx: objGrowIdx }],
+      },
+      // seq = o.nextSeq ; o.nextSeq = seq + 1  (#1837)
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 5 },
+      { op: "local.set", index: 11 },
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 11 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 5 },
+      // __obj_insert(o, key, ref.null any, nflags, seq) — value slot stays null
+      // for an accessor; this creates the entry (or updates flags in place) and
+      // handles growth/tombstone reuse in one place.
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "ref.null", typeIdx: NONE_HEAP },
+      { op: "local.get", index: 9 },
+      { op: "local.get", index: 11 },
+      { op: "call", funcIdx: objInsertIdx },
+      // e = __obj_find(o, key) — re-locate the just-inserted/updated entry to
+      // write the accessor slots. (__obj_insert does not take get/set params.)
+      // It is always non-null here: either we just created it, or the update-in-
+      // place branch matched an existing live entry. The only way to get null is
+      // a non-extensible object refusing a NEW key — in which case there are no
+      // accessor slots to write, so the null-guarded if is a correct no-op.
+      { op: "local.get", index: 5 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: 12 },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // e.get = any.convert_extern(getter) ; e.set = any.convert_extern(setter)
+          // A null externref (absent get/set) converts to a null anyref, which
+          // GOPD reads back as `undefined` for that half of the descriptor.
+          { op: "local.get", index: 12 },
+          { op: "ref.as_non_null" },
+          { op: "local.get", index: 2 },
+          { op: "any.convert_extern" },
+          { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 4 },
+          { op: "local.get", index: 12 },
+          { op: "ref.as_non_null" },
+          { op: "local.get", index: 3 },
+          { op: "any.convert_extern" },
+          { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 5 },
+          // e.value = null (clear any prior data value — accessors hold no value)
+          { op: "local.get", index: 12 },
+          { op: "ref.as_non_null" },
+          { op: "ref.null", typeIdx: NONE_HEAP },
+          { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+        ],
+      },
+      // return obj (host import returns O)
+      { op: "local.get", index: 0 },
+    ];
+    registerNative(
+      "__defineProperty_accessor",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "f64" }],
+      [{ kind: "externref" }],
+      [
+        { name: "o", type: objRefNull },
+        { name: "any", type: { kind: "anyref" } },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "load", type: { kind: "i32" } },
+        { name: "nflags", type: { kind: "i32" } },
+        { name: "hf", type: { kind: "i32" } },
+        { name: "seq", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+      ],
+      body,
+    );
+  }
+
+  // ── __getOwnPropertyDescriptor (#1888 Slice 5 — native descriptor read-back) ─
+  //
+  // `Object.getOwnPropertyDescriptor(obj, key)` / `Reflect.getOwnPropertyDescriptor`
+  // under standalone. Reads the own `$PropEntry` for `key` and materialises a
+  // descriptor `$Object`:
+  //   accessor (flags & FLAG_ACCESSOR) → { get, set, enumerable, configurable }
+  //   data                            → { value, writable, enumerable, configurable }
+  // A missing own property, or a non-`$Object` receiver, returns `undefined`
+  // (the null externref). This is the read side of the Slice-5 store/round-trip:
+  // a getter/setter installed via `__defineProperty_accessor` reads back here as
+  // `{ get, set, … }`. The boxed getter/setter come straight out of the
+  // `$PropEntry.$get/$set` anyref slots via `extern.convert_any` (a null anyref —
+  // an absent half — reads back as `undefined`).
+  //
+  // Descriptor keys ("get"/"set"/"value"/"writable"/"enumerable"/"configurable")
+  // are materialised as native `$NativeString`s (standalone forces nativeStrings)
+  // and handed to `__extern_set` as externref — `$NativeString <: $AnyString`, so
+  // the insert's `ref.cast $AnyString` succeeds. Attribute booleans are boxed via
+  // `__box_boolean` (registered through addUnionImportsViaRegistry, same defined-
+  // func, no-index-shift invariant as the rest of this runtime).
+  //
+  // params: 0=obj(externref) 1=key(externref)
+  // locals: 2=any(anyref) 3=o(ref null $Object) 4=e(ref null $PropEntry)
+  //         5=fl(i32) 6=desc(externref)
+  {
+    // __box_boolean is needed for the attribute flags — register the union
+    // helpers (idempotent; defined funcs, no index shift) and resolve it.
+    addUnionImportsViaRegistry(ctx);
+    const boxBoolIdx = ctx.funcMap.get("__box_boolean")!;
+    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+
+    // `__extern_set(desc, "<key>", <value externref>)` — desc is in local 6.
+    // `valueInstrs` must leave one externref on the stack.
+    const setKey = (key: string, valueInstrs: Instr[]): Instr[] => [
+      { op: "local.get", index: 6 }, // desc (externref)
+      // key: native string → externref
+      ...nativeStringLiteralInstrs(ctx, key),
+      { op: "extern.convert_any" } as Instr,
+      ...valueInstrs,
+      { op: "call", funcIdx: externSetIdx },
+    ];
+
+    // Box `(e.flags & MASK) != 0` as a JS boolean externref.
+    const boolAttr = (mask: number): Instr[] => [
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+      { op: "i32.const", value: mask },
+      { op: "i32.and" },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ne" },
+      { op: "call", funcIdx: boxBoolIdx },
+    ];
+
+    const body: Instr[] = [
+      // any = any.convert_extern(obj) ; if !$Object → return undefined (null)
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 2 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "ref.null.extern" }, { op: "return" }],
+      },
+      // o = cast<$Object>(any) ; e = __obj_find(o, key)
+      { op: "local.get", index: 2 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.tee", index: 3 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: 4 },
+      // if e == null → return undefined (own property does not exist)
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "ref.null.extern" }, { op: "return" }],
+      },
+      // fl = e.flags
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+      { op: "local.set", index: 5 },
+      // desc = __new_plain_object()
+      { op: "call", funcIdx: newPlainObjectIdx },
+      { op: "local.set", index: 6 },
+      // accessor vs data branch
+      { op: "local.get", index: 5 },
+      { op: "i32.const", value: FLAG_ACCESSOR },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        // accessor: { get, set, enumerable, configurable }
+        then: [
+          // desc.get = extern.convert_any(e.get)  (null anyref → undefined)
+          ...setKey("get", [
+            { op: "local.get", index: 4 },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 4 },
+            { op: "extern.convert_any" } as Instr,
+          ]),
+          // desc.set = extern.convert_any(e.set)
+          ...setKey("set", [
+            { op: "local.get", index: 4 },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 5 },
+            { op: "extern.convert_any" } as Instr,
+          ]),
+        ],
+        // data: { value, writable }
+        else: [
+          // desc.value = extern.convert_any(e.value)
+          ...setKey("value", [
+            { op: "local.get", index: 4 },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+            { op: "extern.convert_any" } as Instr,
+          ]),
+          // desc.writable = box(fl & FLAG_WRITABLE)
+          ...setKey("writable", boolAttr(FLAG_WRITABLE)),
+        ],
+      },
+      // common: enumerable, configurable
+      ...setKey("enumerable", boolAttr(FLAG_ENUMERABLE)),
+      ...setKey("configurable", boolAttr(FLAG_CONFIGURABLE)),
+      // return desc
+      { op: "local.get", index: 6 },
+    ];
+    registerNative(
+      "__getOwnPropertyDescriptor",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "o", type: objRefNull },
+        { name: "e", type: entryRefNull },
+        { name: "fl", type: { kind: "i32" } },
+        { name: "desc", type: { kind: "externref" } },
+      ],
+      body,
+    );
+  }
+
   // ── Object integrity predicates (#1472 Phase B Blocker A Half 1, PR #1074) ─
   //
   // __object_isFrozen / __object_isSealed / __object_isExtensible read the
@@ -2843,9 +3186,22 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__object_freeze",
   // #1629 S6 — native data-descriptor define (Object.defineProperty /
   // Reflect.defineProperty with a { value, writable?, enumerable?, configurable? }
-  // descriptor). Accessor descriptors stay refused (see the __defineProperty_value
-  // note in ensureObjectRuntime).
+  // descriptor).
   "__defineProperty_value",
+  // #1888 Slice 5 — native accessor-descriptor STORE ({ get?, set? }): stores
+  // the boxed getter/setter into $PropEntry.$get/$set + FLAG_ACCESSOR.
+  "__defineProperty_accessor",
+  // #1888 Slice 5 — native getOwnPropertyDescriptor: reads the $PropEntry back
+  // and builds a descriptor `$Object` (accessor → { get, set, enumerable,
+  // configurable }, data → { value, writable, enumerable, configurable };
+  // missing own prop / non-$Object receiver → undefined). RUNTIME-LAYER
+  // GROUNDWORK: both this and __defineProperty_accessor are not yet reached
+  // end-to-end under standalone — the accessor define call-site compiles
+  // getter/setter via the __make_getter_callback JS bridge, and that call-site
+  // routing (host-free closures → __defineProperty_accessor) plus live get/set
+  // invocation are #329-gated follow-ups. Landing the helpers + the R3
+  // $PropEntry $get/$set layout now de-risks the layout change in isolation.
+  "__getOwnPropertyDescriptor",
   // #1472 Phase C — `x === undefined` / default-parameter / destructuring-default
   // undefinedness check. Native impl is `ref.is_null` (standalone conflates
   // undefined and null, same as __typeof_undefined). This is the single largest

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -778,4 +778,110 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
     );
     expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
   });
+
+  // ── #1888 Slice 5 — native accessor-descriptor RUNTIME LAYER (groundwork) ──
+  //
+  // Slice 5 adds the runtime groundwork for accessor descriptors under
+  // --target standalone: the `$PropEntry.$get/$set` anyref slots + FLAG_ACCESSOR
+  // (R3 layout), the native `__defineProperty_accessor` store helper, and the
+  // native `__getOwnPropertyDescriptor` read-back (builds a descriptor $Object).
+  //
+  // These tests pin the runtime layer: accessor `defineProperty` compiles
+  // host-free + validates + instantiates, and the GOPD helper routes native
+  // (no `env::__getOwnPropertyDescriptor` import). The helpers are not yet
+  // reached end-to-end — the call-site routing (compiling getter/setter as
+  // host-free closures so they reach `__defineProperty_accessor` instead of the
+  // `__make_getter_callback` JS bridge) plus live get/set invocation are
+  // #329-gated follow-ups. Landing the helpers + R3 layout now de-risks the
+  // layout change in isolation. (~0 test262 on its own; pure foundation.)
+
+  it("Phase 5: accessor defineProperty compiles + validates host-free under standalone", async () => {
+    const source = `
+        export function run(): number {
+          const o: any = {};
+          // Accessor descriptor — getter + setter, both enumerable/configurable.
+          Object.defineProperty(o, "x", {
+            get() { return 1; },
+            set(_v: any) {},
+            enumerable: true,
+            configurable: true,
+          });
+          // The store must not disturb a sibling DATA property written before
+          // and after the accessor define (entry-slot reuse / table integrity).
+          o.before = 11;
+          Object.defineProperty(o, "y", { get() { return 2; } });
+          o.after = 31;
+          return (o.before as number) + (o.after as number);
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__defineProperty_accessor")).toBe(false);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    // The accessor stores don't clobber the data path: 11 + 31 = 42.
+    expect((instance.exports as Record<string, () => number>).run()).toBe(42);
+  });
+
+  it("Phase 5: getter-only and setter-only accessor descriptors both store + instantiate", async () => {
+    // A descriptor with only `get` (no `set`) and one with only `set` (no `get`)
+    // both store: the absent half is a null externref → null anyref in the
+    // $PropEntry slot. Must compile + validate + instantiate host-free.
+    const source = `
+        export function run(): number {
+          const o: any = {};
+          Object.defineProperty(o, "getterOnly", { get() { return 7; }, configurable: true });
+          Object.defineProperty(o, "setterOnly", { set(_v: any) {}, configurable: true });
+          o.sentinel = 5;
+          return o.sentinel as number;
+        }
+      `;
+    const r = await compile(source, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(5);
+  });
+
+  it("Phase 5: getOwnPropertyDescriptor on an externref receiver routes to the native helper (no host import)", async () => {
+    // The dynamic getOwnPropertyDescriptor path (non-struct/non-literal receiver)
+    // routes to the native `__getOwnPropertyDescriptor` runtime helper under
+    // standalone instead of leaking the `env::__getOwnPropertyDescriptor` host
+    // import — it reads the $PropEntry back and builds a descriptor $Object. This
+    // pins the runtime layer (helper emits as a DEFINED function, host-free); it
+    // is not yet reached for accessor *stores* (the call-site routing that
+    // compiles getter/setter as host-free closures is a #329-gated follow-up).
+    const r = await compile(
+      `
+        export function f(o: any, k: string): any {
+          return Object.getOwnPropertyDescriptor(o, k);
+        }
+      `,
+      { target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__getOwnPropertyDescriptor")).toBe(false);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const wat = (r as unknown as { wat?: string }).wat ?? "";
+    expect(wat).toMatch(/\(func \$__getOwnPropertyDescriptor\b/);
+  });
+
+  it("default target (gc) still routes accessor defineProperty through the host import", async () => {
+    // Regression guard: standalone is opt-in. Default (gc) mode keeps the
+    // JS-host descriptor sidecar for accessor descriptors.
+    const r = await compile(
+      `
+        export function f(o: any): any {
+          Object.defineProperty(o, "x", { get() { return 1; } });
+          return o;
+        }
+      `,
+      {},
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__defineProperty_accessor")).toBe(true);
+  });
 });


### PR DESCRIPTION
## #1888 Slice 5 — accessor-descriptor RUNTIME LAYER (groundwork)

Wasm-native runtime foundation for accessor property descriptors under
`--target standalone` (#1888 / #1472 Phase C). Pure foundation — see scope note.

### What lands
- **`$PropEntry` R3 layout**: appended `$get`(field 4) / `$set`(field 5) anyref
  slots + `FLAG_ACCESSOR`. Single `struct.new $PropEntry` site (`__obj_insert`)
  updated; fields 0-3 unchanged. Verified zero-regression on the data path.
- **`__defineProperty_accessor`** (native store): find-or-insert via
  `__obj_insert`, set `FLAG_ACCESSOR`, store getter→$get / setter→$set
  (`any.convert_extern`; an absent half is a null externref → null anyref →
  reads back `undefined`), clear `$value`.
- **`__getOwnPropertyDescriptor`** (native descriptor-object read-back):
  `__new_plain_object` + native-string keys + `__box_boolean`; accessor →
  `{get,set,enumerable,configurable}`, data →
  `{value,writable,enumerable,configurable}`, missing own prop / non-`$Object`
  receiver → `undefined`.
- Both routed via `OBJECT_RUNTIME_HELPER_NAMES` (standalone native path; GC/host
  modes unchanged — conservative dual-mode).

### Scope / value (be clear-eyed)
This is **RUNTIME-LAYER GROUNDWORK** and banks **~0 test262 on its own** — the
helpers are not yet reached end-to-end. Its value is (a) landing the R3
`$PropEntry` layout change **isolated + verified** (the riskiest part), and (b)
being the runtime target the wiring follow-ups call.

**Follow-ups** (now unblocked by the #329 cluster — #1224/#1225/#1226):
- **Call-site wiring**: `Object.defineProperty(o,k,{get,set})` compiles
  getter/setter via `compileArrowAsCallback` → `__make_getter_callback` (JS-host
  import). Route to **host-free closures** so they reach
  `__defineProperty_accessor` (and GOPD sees real get/set).
- **Live get/set**: accessor arms in `__extern_get`/`__extern_set` invoke
  `$get`/`$set` via `__call_fn_method_0/1` (#1636-S1), `this`=receiver.
These are the ~2.7k accessor lever.

### Tests
3 Phase-5 cases in `tests/issue-1472.test.ts`: accessor `defineProperty`
compiles host-free + validates + instantiates; getter-only/setter-only both
store; GOPD routes to the native helper (no `env::__getOwnPropertyDescriptor`).
tsc clean; full `tests/issue-1472.test.ts` green (39/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)