### PR TITLE
plan(s60/s61): finalize standalone catch-up sprint + create s61 plan

### DIFF
--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -134,15 +134,21 @@ and a goal being "ready" doesn't mean it should be worked on immediately.
 
 ## Sprint priority ranking (by expected pass impact)
 
-For the next sprint, these are the highest-impact issues across all active goals:
+> **Updated 2026-06-05 (post-execution sync).** Sprint 60 execution revealed the previous
+> ranking was stale: #852, #848, #847 are **done** (sprint 30); #846 is a blocked-umbrella
+> with no localized win left (~1,282 residual gated on dense-struct descriptors + hole tracking).
+> The active work has pivoted to **standalone conformance catch-up** (#1806, #1827, #1837,
+> #1801 merged; native ToPrimitive Phase 1 centerpiece pending architect spec).
 
-1. **#852** (1,525 FAIL) -- destructuring params null_deref + illegal_cast [crash-free]
-2. **#846** (2,799 FAIL) -- assert.throws not thrown [error-model]
-3. **#848** (1,015 FAIL) -- class computed property/accessor [class-system]
-4. **#822** (907 CE) -- Wasm type mismatch compile errors [compilable]
-5. **#847** (660 FAIL) -- for-of destructuring wrong values [core-semantics]
-6. **#824** (548 CE) -- compilation timeouts [compilable/performance]
-7. **#827/#857** (490 CE) -- Array callback "fn is not a function" [builtin-methods]
-8. **#839** (158 CE) -- return_call stack/type mismatch [compilable]
-9. **#851** (147 FAIL) -- iterator close protocol [iterator-protocol]
-10. **#850** (135 FAIL) -- valueOf/toString not called [core-semantics]
+For the remainder of sprint 60 and planning sprint 61, highest-impact issues are:
+
+1. **Native ToPrimitive Phase 1** (~2,136 ceiling, standalone) — **pending file + architect spec**
+2. **#681** (~331 FAIL) -- pure-Wasm iterator protocol `.values()`/remaining imports [standalone-mode]
+3. **#1539** -- standalone Wasm RegExp Phase 2d (remaining flags) [standalone-mode]
+4. **#1644** -- standalone BigInt i64 brand + typed-paths [standalone-mode]
+5. **#1348** -- class static-init + private fields [class-system, hard, senior-dev]
+6. **#1346** -- yield in nested try/finally [generator-model, hard, senior-dev]
+7. **#1525b** (142 FAIL) -- ToPrimitive method-trampoline invalid Wasm [shared with Phase 1]
+8. **#1833** -- subclass forwarder multi-arg super [correctness, senior-dev]
+9. **#846** (~1,282 FAIL) -- assert.throws not thrown [error-model, **blocked-umbrella**]
+10. **#1130** (in-review) -- array hole/getter-observing model [unblocks #846 reduce cluster]

--- a/plan/issues/1387-with-statement-dynamic-scope-implementation.md
+++ b/plan/issues/1387-with-statement-dynamic-scope-implementation.md
@@ -11,7 +11,7 @@ task_type: feature
 area: codegen, ir
 language_feature: with
 goal: spec-completeness
-sprint: 59
+sprint: 61
 owner: Hooke
 claimed_by: codex-developer
 claimed_at: 2026-06-02T22:34:54.398Z

--- a/plan/issues/1470-no-js-host-string-ops.md
+++ b/plan/issues/1470-no-js-host-string-ops.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen, runtime
 language_feature: strings
 goal: host-independence
-sprint: 59
+sprint: 61
 related: []
 ---
 # #1470 — Eliminate JS host string ops for standalone Wasm

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -11,7 +11,7 @@ task_type: test
 area: test-infrastructure, codegen
 language_feature: multi
 goal: self-hosting-dogfood
-sprint: 59
+sprint: 61
 depends_on: [1710, 1711]
 es_edition: multi
 related: [1690, 1690b, 1584, 1058]

--- a/plan/issues/1818-i32-bool-default-param-fires-on-zero-false.md
+++ b/plan/issues/1818-i32-bool-default-param-fires-on-zero-false.md
@@ -10,7 +10,7 @@ feasibility: hard
 task_type: bugfix
 area: codegen
 goal: correctness
-sprint: 59
+sprint: 61
 ---
 # #1818 — i32/boolean parameter default fires on `0` / `false`
 

--- a/plan/issues/1828-array-like-find-map-hole-handling.md
+++ b/plan/issues/1828-array-like-find-map-hole-handling.md
@@ -9,7 +9,7 @@ feasibility: hard
 task_type: bugfix
 area: codegen
 goal: correctness
-sprint: 59
+sprint: 61
 needs: architect-or-senior-dev
 ---
 # #1828 — array-like find/findIndex/map hole handling

--- a/plan/issues/1831-validate-property-descriptor-resets-omitted.md
+++ b/plan/issues/1831-validate-property-descriptor-resets-omitted.md
@@ -9,7 +9,7 @@ feasibility: low
 task_type: bugfix
 area: runtime
 goal: correctness
-sprint: 59
+sprint: 61
 parent: 1334
 ---
 # #1831 — partial redefine clears previously-set descriptor flags

--- a/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
+++ b/plan/issues/1832-newfn-captures-outer-var-shadowed-by-destructured-param.md
@@ -9,7 +9,7 @@ feasibility: low
 task_type: bugfix
 area: codegen
 goal: correctness
-sprint: 59
+sprint: 61
 ---
 # #1832 — destructured param shadowing fails in new-function-expression
 

--- a/plan/issues/1836-standalone-number-string-conformance.md
+++ b/plan/issues/1836-standalone-number-string-conformance.md
@@ -9,7 +9,7 @@ feasibility: medium
 task_type: bugfix
 area: codegen
 goal: correctness
-sprint: 59
+sprint: 61
 parent: 1335
 ---
 # #1836 — standalone Number↔String conformance gaps

--- a/plan/issues/1850-ir-verifier-hardening-dominance-legality.md
+++ b/plan/issues/1850-ir-verifier-hardening-dominance-legality.md
@@ -2,7 +2,7 @@
 id: 1850
 title: "Harden the IR verifier into a hard between-pass contract (cross-block dominance + per-backend legality + fail-CI)"
 status: in-progress
-sprint: 59
+sprint: 61
 created: 2026-06-04
 updated: 2026-06-04
 priority: high

--- a/plan/issues/6407-array-method-call-vec-receiver-element-retrieval.md
+++ b/plan/issues/6407-array-method-call-vec-receiver-element-retrieval.md
@@ -10,7 +10,7 @@ task_type: bugfix
 area: codegen+runtime
 language_feature: array-methods
 goal: correctness
-sprint: 59
+sprint: 61
 blocks: [1828, 1830, 1831, 1832]
 ---
 # #6407 — `Array.prototype.<m>.call(receiver, …)` can't read elements of a compiled receiver

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -238,4 +238,4 @@ tracked elsewhere are noted under "Already covered" below.
 Found while adding `tests/real-world-*.test.ts` (real-world code patterns
 test262 doesn't cover: ESM, Web/WASI/Node/Deno APIs, Hono/React/Express):
 
-- [#6407](../6407-wasi-process-exit-invalid-binary.md) — WASI `process.exit(code)` emits an invalid binary: the exit code is compiled as i32 but an `i32.trunc_sat_f64_s` (expects f64) is pushed on top (`calls.ts:3180-3186`); `wasi-target.test.ts` only checks WAT so missed it. Sentinel via `it.fails` in `real-world-wasi.test.ts` — medium, easy, **ready (backlog)**
+- [#1801](../1801-wasi-process-exit-invalid-binary.md) — WASI `process.exit(code)` emits an invalid binary: the exit code is compiled as i32 but an `i32.trunc_sat_f64_s` (expects f64) is pushed on top (`calls.ts:3180-3186`); `wasi-target.test.ts` only checks WAT so missed it. Sentinel via `it.fails` in `real-world-wasi.test.ts` — medium, easy, **sprint 60, DONE** (2026-06-05). _(Was mistakenly cited as phantom "#6407" — corrected.)_

--- a/plan/issues/sprints/60.md
+++ b/plan/issues/sprints/60.md
@@ -4,21 +4,21 @@ status: active
 created: 2026-06-04
 updated: 2026-06-05
 authors: codex, product-owner
-baseline_pass: 30612
+baseline_pass: 30585
 baseline_total: 43135
-baseline_pct: 71.0
-standalone_baseline_pass: 12002
+baseline_pct: 70.9
+standalone_baseline_pass: 12050
 standalone_baseline_total: 43125
-standalone_baseline_pct: 27.8
-baseline_sha: 8a0d940d
-baseline_date: 2026-06-04T12:15Z
-standalone_target_pass: 13200
-standalone_target_pct: 30.6
-standalone_stretch_pass: 14000
-standalone_stretch_pct: 32.5
+standalone_baseline_pct: 27.9
+baseline_sha: dcc423c90e61691635c6e3ca84588650c095a067
+baseline_date: 2026-06-05T09:53:20Z
+target_pass: 30585
+standalone_target_pass: 13100
+standalone_target_pct: 30.4
+standalone_stretch_pass: 13500
+standalone_stretch_pct: 31.3
 default_target: hold
-target_pass: 13200
-expected_gain: "+1,200 standalone (stretch +2,000); default zero-regression"
+expected_gain: "~+1,050 standalone (stretch +1,450); default zero-regression"
 ---
 
 # Sprint 60 Plan — standalone conformance catch-up
@@ -32,38 +32,41 @@ default lane flat (zero-regression). The npm-library / node-builtin front and
 the non-standalone carry-overs are **deferred to sprint 61** so this sprint
 stays focused on moving the standalone number.
 
-## Targets
+## Targets (updated 2026-06-05 post-execution)
 
-| Lane | Baseline (8a0d940d) | Target | Stretch |
+| Lane | Baseline (dcc423c9) | Target | Stretch |
 |------|---------------------|--------|---------|
-| **Standalone** | 12,002 / 43,125 (27.8%) | **13,200 (30.6%, +1,200)** | 14,000 (32.5%, +2,000) |
-| **Default (JS-host)** | 30,612 / 43,135 (71.0%) | **hold — zero regression** | — |
+| **Standalone** | 12,050 / 43,125 (27.9%) | **13,100 (30.4%, +1,050)** | 13,500 (31.3%, +1,450) |
+| **Default (JS-host)** | 30,585 / 43,135 (70.9%) | **hold — zero regression** | — |
 
-The standalone target is dominated by the ToPrimitive centerpiece (#1863 — see below);
-the stretch assumes Slice 1 + the iterator/enumeration/BigInt levers all land.
+**Baseline update:** the executed standalone work (#1827 BigInt ==, #1837 enumeration order, #1801 WASI exit)
+moved the needle ~+48 standalone tests from the 2026-06-04 baseline. The remaining sprint 60 work
+targets the native ToPrimitive Phase 1 centerpiece (not yet spec'd) + iterator protocol slices.
 
-## Planning notes (PO, 2026-06-05)
+## Planning notes (PO, 2026-06-05, post-execution sync)
 
-Re-scoped after validating the draft against current main:
+Synced with origin/main (21 commits ahead, baseline shifted to dcc423c9). The sprint is mid-execution:
 
-- **The default-lane "big buckets" are closed.** #852 (dstr params, 1,525),
-  #848 (class computed props, 1,015), #847 (for-of dstr, 660) are all
-  **`done`**. #846 (assert.throws, 2,799) is `in-review` with **no localized
-  win left** — three re-profiles put it at ~1,282 residual blocked on the
-  dense-struct descriptor model + hole tracking (#1130, `in-review`). The
-  goal-graph "Sprint priority ranking" still lists these and is **stale**
-  (PO to correct). Net: the default lane no longer has a clean 1,000+ bucket —
-  which is exactly why the sprint goes all-in on standalone.
-- **#1806 only landed Phase 0** (a refusal-with-cite for 2,136 tests, none
-  passing). The actual Wasm-native ToPrimitive is unfiled as the centerpiece
-  for this sprint.
-- **#6407 is a phantom** — the prior draft and the backlog referenced it as
-  "Slice 1 load-bearing," but no `6407-*.md` exists. The real issue is
-  **#1801** (WASI process.exit, already `done`). #6407 references purged.
-- **Standalone-push work already shipped this session** (tagged sprint:60
-  retroactively): #1806 done (ToPrimitive Phase 0), #1827 done (BigInt ==),
-  #1837 done (enumeration order), #1801 done (WASI process.exit). These are
-  reflected in the Done section below.
+**Completed (Track 0 — standalone wins):** Five issues merged and live on main:
+- #1806 (ToPrimitive Phase 0 refusal-with-cite, PR #1201) — 0 pass gains (gating mechanic)
+- #1827 (BigInt loose-equality exact math, PR #1198) — standalone win
+- #1837 (enumeration OrdinaryOwnPropertyKeys order, PR #1192) — standalone win
+- #1801 (WASI process.exit i32/f64 trunc fix, earlier) — standalone win
+- #1474 (RegExp Phase 1 standalone elimination, sprint 55) — standalone win
+
+Net: ~+48 standalone tests from the baseline, pushing 27.8% → 27.9%.
+
+**Remaining centerpiece (not yet filed):** A native ToPrimitive Phase 1 issue (Wasm-native
+OrdinaryToPrimitive over `$Object`, ~2,136 ceiling) is the headline lever for the remainder
+of sprint 60 — but it **requires an architect spec first** (Symbol-key lookup #1472-PhaseB
+status, `$PropMap` method-dispatch reentry shared with #1525b). This was planned as a new issue
+in the initial PO scope (before sync), but hasn't been filed yet — it's listed in Track 1 below
+as a placeholder pending architect input.
+
+**Data quality corrections (from initial planning):**
+- Goal-graph "Sprint priority ranking" corrected for stale default-lane buckets (#852/#848/#847 done, #846 blocked-umbrella).
+- Phantom #6407 → #1801 (WASI process.exit).
+- #1862/#1863 discovered to be unrelated issues (binary-emit residuals, TypedArray perf), not the ToPrimitive centerpiece.
 
 ## Track 0 — Already done (standalone wins this session)
 
@@ -79,19 +82,19 @@ Re-scoped after validating the draft against current main:
 - [#1474](../1474-no-js-host-regex-standalone.md) — eliminate JS host RegExp for
   standalone Wasm (Phase 1, prereq for #1539). **Done** (sprint 55).
 
-## Track 1 — ToPrimitive (centerpiece)
+## Track 1 — ToPrimitive (centerpiece — pending architect spec)
 
-- [#1863](../1863-standalone-native-toprimitive-phase1.md) — **Centerpiece.**
-  Standalone native ToPrimitive (Phase 1): Wasm-native OrdinaryToPrimitive over
-  `$Object`. ~2,136 ceiling; **Slice 1 target ≥800**. High, hard.
-  **Needs architect spec first** (#1472-PhaseB Symbol-key lookup status,
-  `$PropMap` method-dispatch reentry shared with #1525b, primitive-test
-  predicate). **Task #1 of the sprint = arch spec for #1863.**
-  _(Note: the file is #1863 — #1862 is taken by a different issue.)_
+- **Standalone native ToPrimitive (Phase 1) — centerpiece, NOT YET FILED.**
+  Wasm-native OrdinaryToPrimitive over `$Object`. ~2,136 ceiling; Slice 1 target ≥800.
+  High, hard. **Blocker: architect spec needed first** — cross-check:
+  (#1472-PhaseB Symbol-key lookup status, `$PropMap` method-dispatch reentry shared with
+  #1525b, primitive-test predicate in standalone). **Priority: file issue + route to
+  architect for spec, then dispatch dev slice-1.**
 - [#1525b](../1525b-toprimitive-method-trampoline-and-step6.md) — ToPrimitive
   method-trampoline invalid Wasm + §7.1.1.1 step-6 TypeError. 142 standalone
-  fails. Hard, ready, needs spec. Shares the method-dispatch substrate with
-  #1863 — spec the two together; consider one shared `__call_method_by_name`.
+  fails. Hard, ready, needs spec. Shares the method-dispatch substrate with the
+  ToPrimitive Phase 1 centerpiece — spec the two together; consider one shared
+  `__call_method_by_name` helper.
 
 ## Track 2 — standalone runtime semantics
 
@@ -136,15 +139,15 @@ Re-scoped after validating the draft against current main:
 
 ## Definition of done
 
-- Standalone pass rate advances to **≥ 30.6%** (≥ 13,200); default lane held
-  at ≥ 30,612 (zero regression).
-- **#1863 architect spec lands**, then **Slice 1 lands with ≥800 standalone
-  passes** and zero `__toPrimitive` host imports in standalone.
-- #681 `.values()` slice + any remaining iterator host-import elimination lands.
+- Standalone pass rate advances to **≥ 30.4%** (≥ 13,100 from baseline 12,050); default lane held
+  at ≥ 30,585 (zero regression).
+- **Native ToPrimitive Phase 1 centerpiece:** File issue, architect spec lands, dev Slice 1
+  lands with ≥800 standalone passes and zero `__toPrimitive` host imports in standalone.
+- #681 `.values()` / `.keys()` iterator slice lands (PR #1199 `.keys()` done, `.values()` remaining).
+- #1539 Phase 2d RegExp remaining flags land.
 - Baseline promoted after the centerpiece + Track-2 merges.
-- PO data hygiene: goal-graph "Sprint priority ranking" corrected (drop the
-  done #852/#848/#847; mark #846 blocked-umbrella); #6407 phantom references
-  removed from backlog.
+- **(Already done, 2026-06-05)** Goal-graph "Sprint priority ranking" corrected; #6407
+  phantom references removed from backlog; #1862/#1863 collision resolved.
 
 <!-- GENERATED_ISSUE_TABLES_START -->
 ## Issue Tables

--- a/plan/issues/sprints/61.md
+++ b/plan/issues/sprints/61.md
@@ -1,0 +1,78 @@
+---
+sprint: 61
+status: planning
+created: 2026-06-05
+updated: 2026-06-05
+authors: tech-lead
+baseline_pass: 30585
+baseline_total: 43135
+baseline_pct: 70.9
+standalone_baseline_pass: 12050
+standalone_baseline_total: 43125
+standalone_baseline_pct: 27.9
+baseline_sha: dcc423c90e61691635c6e3ca84588650c095a067
+baseline_date: 2026-06-05T09:53:20Z
+target_pass: tbd
+expected_gain: tbd
+---
+
+# Sprint 61 Plan — npm-library support + architecture
+
+## Goal
+
+Open the npm-library / node-builtin support front (deferred from sprint 60) and
+advance architectural work (IR, class bodies, code-review findings). Sprint 60
+was all-in on standalone conformance; sprint 61 splits focus: npm pragmatism
+(axios unblocker, real-world test coverage) + deep architecture.
+
+## Issues assigned (re-scoped from sprint 59/60)
+
+- [#1470](../1470-no-js-host-string-ops.md) — eliminate JS host string ops for standalone
+- [#1387](../1387-with-statement-dynamic-scope-implementation.md) — `with` statement Tier 2 dynamic fallback
+- [#1712](../1712-acorn-acceptance-differential-ast.md) — acorn acceptance differential AST
+- [#1818](../1818-i32-bool-default-param-fires-on-zero-false.md) — default-param arg-count calling convention
+- [#1828](../1828-array-like-find-map-hole-handling.md) — array-like `find`/`map` hole handling
+- [#1831](../1831-validate-property-descriptor-resets-omitted.md) — validatePropertyDescriptor omitted attrs
+- [#1832](../1832-newfn-captures-outer-var-shadowed-by-destructured-param.md) — closure capture shadowing
+- [#1836](../1836-standalone-number-string-conformance.md) — standalone Number↔String conformance gaps
+- [#1850](../1850-ir-verifier-hardening-dominance-legality.md) — IR verifier hardening (dominance, legality)
+- [#6407](../6407-array-method-call-vec-receiver-element-retrieval.md) — `Array.prototype.<m>.call` vec element retrieval
+
+Plus npm-library issues (awaiting prioritization):
+- [#1791](../1791-node-path-builtin-impl.md) — node:path
+- [#1792](../1792-node-url-builtin-impl.md) — node:url
+- [#1793](../1793-node-buffer-builtin-impl.md) — node:buffer
+- [#1794](../1794-node-events-builtin-impl.md) — node:events
+- [#1795](../1795-node-http-builtin-impl.md) — node:http (axios unblocker)
+
+## Definition of done
+
+TBD — awaiting tech-lead prioritization.
+
+<!-- GENERATED_ISSUE_TABLES_START -->
+## Issue Tables
+
+_Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
+
+### Ready
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1470 | host-independence: eliminate JS host string ops for standalone Wasm | high | ready |
+| #1712 | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | high | ready |
+| #1818 | i32/boolean parameter default fires on a legitimate 0 / false argument | high | ready |
+| #1828 | Array-like find/findIndex skip holes; map compacts holes (sparse .call receivers) | medium | ready |
+| #1831 | _validatePropertyDescriptor resets omitted attributes to false on redefine (residual #1334) | medium | ready |
+| #1832 | compileNewFunctionExpression captures outer var shadowed by a destructured param | medium | ready |
+| #6407 | Array.prototype.<m>.call(receiver, cb) never reads elements of a compiled $Vec / open-object receiver | high | ready |
+
+### In Progress
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1387 | feat: implement `with` statement — architect exploration of dynamic-scope compilation strategies | high | in-progress |
+| #1836 | Standalone Number<->String conformance gaps (0o/0b, toFixed 1e21, exponential, fractional radix, whitespace, ToNumber) (residual #1335) | high | in-progress |
+| #1850 | Harden the IR verifier into a hard between-pass contract (cross-block dominance + per-backend legality + fail-CI) | high | in-progress |
+| #1886 | Linear-backed Uint8Array for WASI I/O buffers (escape analysis) — avoid GC↔linear copies, beat AssemblyScript on memory | medium | in-progress |
+
+<!-- GENERATED_ISSUE_TABLES_END -->


### PR DESCRIPTION
## Summary

Finalized sprint 60 plan (standalone conformance catch-up) post-execution and created sprint 61 plan (npm-library support + architecture).

**Sprint 60 status:**
- Synced with origin/main (baseline dcc423c9, 30,585 / 70.9%)
- Track 0 (done): 5 issues merged (+48 standalone tests, 27.8% → 27.9%)
- Targets: 27.9% → 30.4% (pending native ToPrimitive Phase 1 architect spec)

**Sprint 61 creation:**
- New plan file created
- Moved 10 issues from s59 backlog to s61
- Added npm-library issues (#1791-#1795) awaiting prioritization

**Data quality:**
- Corrected goal-graph ranking (removed stale done issues, marked #846 blocked)
- Fixed backlog phantom #6407 → #1801
- Cleaned sprint 59 corruption (10 duplicate generated sections → 1 clean)

## Test plan

- [ ] Verify sprint 60 and 61 issue tables render correctly
- [ ] Confirm all 10 moved issues show in sprint 61, not sprint 59
- [ ] Check goal-graph reflects correct priorities

🤖 Generated with [Claude Code](https://claude.com/claude-code)