### PR TITLE
feat(#1888 Slice 3): standalone Type.prototype.<m>.call borrowed dispatch

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2859,6 +2859,93 @@ function compileCallExpression(
             );
             return null;
           }
+          // (#1888 Slice 3) Standalone borrowed-method dispatch
+          // `Type.prototype.<m>.call(recv, …args)` (ES §7.3.14 Call). The host
+          // `__proto_method_call` is refused under --target standalone (no JS
+          // runtime). Per the "compile away" principle, typeName + methodName
+          // are compile-time constants here, so we dispatch STATICALLY by
+          // synthesising `recv.<m>(…args)` and routing it through the native
+          // member-call path — no new runtime helper, no funcIdx shift.
+          //   - String: route to compileNativeStringMethodCall, which coerces
+          //     the borrowed receiver to a native string ($NativeString brand)
+          //     and emits the __str_* fast path. The covered method set is the
+          //     ones whose native helper round-trips correctly (see below).
+          //   - Object.hasOwnProperty: synthesise the bare call, which already
+          //     has a clean native standalone path (compilePropertyIntrospection
+          //     → __hasOwnProperty). Other Object methods (isPrototypeOf /
+          //     propertyIsEnumerable / valueOf) and Array/Number/Boolean/Function
+          //     have no clean native borrowed path yet → refuse-loud below
+          //     (Array brand arm rides on #6407; isPrototypeOf bare-path leak is
+          //     a separate follow-on). Never a silent-wrong answer.
+          if (ctx.standalone && expr.arguments.length >= 1 && !isBuiltinRegExpPrototype) {
+            // Native String methods whose __str_* helper + return marshaling
+            // round-trip correctly standalone (verified end-to-end). Methods
+            // outside this set refuse-loud rather than risk a wrong result.
+            const STANDALONE_STR_PROTO_METHODS = new Set<string>([
+              "charAt",
+              "charCodeAt",
+              "codePointAt",
+              "indexOf",
+              "lastIndexOf",
+              "includes",
+              "startsWith",
+              "endsWith",
+              "toUpperCase",
+              "toLowerCase",
+              "trim",
+              "trimStart",
+              "trimEnd",
+              "concat",
+              "repeat",
+              "padStart",
+              "padEnd",
+              "substring",
+              "slice",
+              "at",
+            ]);
+            const synthesizeBorrowedCall = (): { prop: ts.PropertyAccessExpression; call: ts.CallExpression } => {
+              const receiverArg = expr.arguments[0]!;
+              const restArgs = Array.from(expr.arguments).slice(1);
+              const sProp = ts.factory.createPropertyAccessExpression(receiverArg, methodName);
+              ts.setTextRange(sProp, innerExpr);
+              (sProp as unknown as { parent: ts.Node }).parent = expr;
+              const sCall = ts.factory.createCallExpression(sProp, undefined, restArgs);
+              ts.setTextRange(sCall, expr);
+              (sCall as unknown as { parent: ts.Node }).parent = expr.parent;
+              return { prop: sProp, call: sCall };
+            };
+
+            if (typeName === "String" && STANDALONE_STR_PROTO_METHODS.has(methodName)) {
+              const { prop, call } = synthesizeBorrowedCall();
+              const strResult = compileNativeStringMethodCall(ctx, fctx, call, prop, methodName);
+              if (strResult !== null) return strResult;
+              // Native string path declined (unexpected shape) — fall through
+              // to the refuse-loud below rather than the host import.
+            } else if (typeName === "Object" && methodName === "hasOwnProperty") {
+              // Object.prototype.hasOwnProperty.call(o, k) → o.hasOwnProperty(k),
+              // which routes to the native __hasOwnProperty (own-only presence).
+              const { prop, call } = synthesizeBorrowedCall();
+              const hasOwnResult = compilePropertyIntrospection(ctx, fctx, prop, call);
+              if (hasOwnResult !== null) return hasOwnResult;
+            }
+
+            // Unsupported (typeName, methodName) under standalone: refuse-loud,
+            // never leak the host import or return a silent-wrong value.
+            const cite =
+              typeName === "Array"
+                ? "the Array brand arm rides on #6407 ($Vec element retrieval)"
+                : typeName === "Object"
+                  ? "only Object.prototype.hasOwnProperty.call is wired (isPrototypeOf/propertyIsEnumerable/valueOf are a follow-on)"
+                  : "this prototype's borrowed-method brand arm is not yet native";
+            reportError(
+              ctx,
+              expr,
+              `Codegen error: ${typeName}.prototype.${methodName}.call(...) is not yet ` +
+                `supported in --target standalone (#1888 Slice 3/4) — ${cite}. ` +
+                `Recompile without --target standalone, or call the method directly on a typed receiver.`,
+            );
+            return null;
+          }
           if (
             (typeName === "String" ||
               typeName === "Number" ||

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -1050,3 +1050,119 @@ describe("#1888 Slice 2 — standalone open-any method dispatch", () => {
     expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
   });
 });
+
+/**
+ * #1888 Slice 3 — standalone borrowed-method dispatch
+ * `Type.prototype.<m>.call(recv, …args)` (ES §7.3.14 Call).
+ *
+ * The host `__proto_method_call` is refused under --target standalone (no JS
+ * runtime). Per "compile away, don't emulate", the dispatch is done STATICALLY
+ * at the call site (calls.ts) because typeName + methodName are compile-time
+ * constants: the borrowed call is synthesised as `recv.<m>(…args)` and routed
+ * through the native member-call path — no new runtime helper, no funcIdx shift.
+ *
+ * Covered now: the String brand arm (synthesised → compileNativeStringMethodCall
+ * → native __str_* over a $NativeString-branded receiver) and the
+ * Object.prototype.hasOwnProperty arm (→ native __hasOwnProperty). Everything
+ * else (Array — rides on #6407; Object isPrototypeOf/propertyIsEnumerable/valueOf
+ * — a separate follow-on) refuses-loud with a #1888 cite, never silent-wrong.
+ *
+ * String-returning methods are asserted via a numeric projection (`.length` /
+ * `charCodeAt`) since a $NativeString export return is opaque to the bare
+ * `WebAssembly.instantiate` harness (same pattern as the Blocker-B Slice-2 tests).
+ */
+describe("#1888 Slice 3 — standalone Type.prototype.<m>.call borrowed dispatch", () => {
+  const STD = { target: "standalone" as const, nativeStrings: true };
+  type NumExports = Record<string, () => number>;
+
+  it("String.prototype.indexOf.call routes native (i32 result), zero host imports", async () => {
+    const r = await compile(`export function run(): number { return String.prototype.indexOf.call("abc", "b"); }`, STD);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__proto_method_call")).toBe(false);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(1);
+  });
+
+  it("String.prototype.includes.call routes native (bool result)", async () => {
+    const r = await compile(
+      `export function run(): number { return String.prototype.includes.call("hello", "ell") ? 1 : 0; }`,
+      STD,
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(1);
+  });
+
+  it("String.prototype.toUpperCase.call result is correct (charCodeAt projection)", async () => {
+    const r = await compile(
+      `export function run(): number { const s = String.prototype.toUpperCase.call("hi"); return s.charCodeAt(0); }`,
+      STD,
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(72); // 'H'
+  });
+
+  it("String.prototype.slice.call result is correct (length + charCodeAt projection)", async () => {
+    const r = await compile(
+      `export function run(): number { const s = String.prototype.slice.call("hello", 1, 3); return s.length * 1000 + s.charCodeAt(0); }`,
+      STD,
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(2101); // "el": len 2, 'e'=101
+  });
+
+  it("Object.prototype.hasOwnProperty.call routes to native __hasOwnProperty (own-only)", async () => {
+    const r = await compile(
+      `export function run(): number {
+        const o: any = {};
+        const k = "key";
+        o[k] = 1;
+        return (Object.prototype.hasOwnProperty.call(o, k) ? 1 : 0) +
+               (Object.prototype.hasOwnProperty.call(o, "absent") ? 10 : 0);
+      }`,
+      STD,
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__proto_method_call")).toBe(false);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(1);
+  });
+
+  it("Array.prototype.push.call refuses-loud (rides on #6407, no silent-wrong)", async () => {
+    const r = await compile(
+      `export function run(): number { const a: any = []; Array.prototype.push.call(a, 5); return 1; }`,
+      STD,
+    );
+    expect(r.success).toBe(false);
+    const joined = r.errors.map((e) => e.message).join("\n");
+    expect(joined).toMatch(/#1888 Slice 3\/4/);
+    expect(joined).toMatch(/#6407/);
+  });
+
+  it("Object.prototype.isPrototypeOf.call refuses-loud (deferred follow-on, not silent-wrong)", async () => {
+    const r = await compile(
+      `export function run(): number { const p: any = {}; const o: any = {}; return Object.prototype.isPrototypeOf.call(p, o) ? 1 : 0; }`,
+      STD,
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/#1888 Slice 3\/4/);
+  });
+
+  it("default target (gc) still uses the host __proto_method_call bridge (dual-mode unchanged)", async () => {
+    const r = await compile(`export function run(): number { return String.prototype.indexOf.call("abc", "b"); }`, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.some((i) => i.module === "env" && i.name === "__proto_method_call")).toBe(true);
+  });
+});


### PR DESCRIPTION
## #1888 Slice 3 — standalone `Type.prototype.<m>.call` borrowed-method dispatch

Wires the **standalone** path for the borrowed-method form
`Type.prototype.<m>.call(recv, …args)` (ES §7.3.14 Call). The host
`__proto_method_call` import is refused under `--target standalone`
(no JS runtime), so before this PR every such call refused-loud.

### Deliberate design: static call-site dispatch (compile away, don't emulate)

This deviates from building a new runtime helper, on purpose — and the
tech lead endorsed it. At this call site, `typeName` and `methodName` are
**compile-time constants** (they come from the `String`/`Object`/… prototype
property access). So instead of routing through a generic
`__proto_method_call(typeName, methodName, recv, args)` runtime dispatcher,
we synthesise the equivalent member call `recv.<m>(…args)` and run it through
the **existing native member-call path**.

- **No new runtime helper** — zero added `OBJECT_RUNTIME_HELPER_NAMES`.
- **No funcIdx index-shift** — no late import, so no reserve/fill machinery.
- The branch is gated on `ctx.standalone`; GC/host mode is **byte-unchanged**
  (still emits the host `__proto_method_call` bridge — see the dual-mode test).

### Brand arms wired

- **String** (the real near-term value — ~22% / 156 entries): synthesised
  call → `compileNativeStringMethodCall` over a `$NativeString`-coerced
  receiver → native `__str_*` fast path. Covered method set is the helpers
  that round-trip correctly standalone: `charAt`, `charCodeAt`, `codePointAt`,
  `indexOf`, `lastIndexOf`, `includes`, `startsWith`, `endsWith`,
  `toUpperCase`, `toLowerCase`, `trim`/`trimStart`/`trimEnd`, `concat`,
  `repeat`, `padStart`, `padEnd`, `substring`, `slice`, `at`.
- **`Object.prototype.hasOwnProperty`**: synthesised → `compilePropertyIntrospection`
  → native `__hasOwnProperty` (own-only presence). The freebie Object arm.

### Refuse-loud (never silent-wrong)

Everything else emits a `Codegen error:` with a `#1888` cite rather than a
wrong answer or a leaked host import:

- **`Array.prototype.*`** — the brand arm rides on **#6407** (`$Vec` element
  retrieval); the error cites both `#1888 Slice 3/4` and `#6407`.
- **Object `isPrototypeOf` / `propertyIsEnumerable` / `valueOf`** — deferred
  follow-on. `isPrototypeOf` is left **unwired deliberately**: wiring it would
  reach the separate `env::Object_isPrototypeOf` bare-path leak bug, which is
  out of scope here.

### Tests

`tests/issue-1472.test.ts` — 8 new cases under
`describe("#1888 Slice 3 …")`:
- String `indexOf`/`includes` native (i32/bool, zero env leaks).
- String `toUpperCase`/`slice` correctness via numeric projection
  (`.length`/`charCodeAt`) — a `$NativeString` export return is opaque to the
  bare `WebAssembly.instantiate` harness, same pattern as the Blocker-B
  Slice-2 tests.
- `Object.hasOwnProperty.call` → native `__hasOwnProperty` (own-only).
- `Array.push.call` + `Object.isPrototypeOf.call` refuse-loud.
- gc-mode still emits the host `__proto_method_call` bridge (dual-mode unchanged).

Full `tests/issue-1472.test.ts` suite: **53/53 pass**. `tsc` clean.

### Follow-ons

- **#6407** → then the Array brand arm rides on it (I take #6407 next).
- Object `isPrototypeOf`/`propertyIsEnumerable`/`valueOf` borrowed arms after
  the `env::Object_isPrototypeOf` bare-path bug is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
