### PR TITLE
chore(plan): close sprint 59 (repair corrupted doc) + file ToPrimitive centerpiece #1900

### DIFF
--- a/plan/issues/1900-standalone-native-toprimitive-phase1.md
+++ b/plan/issues/1900-standalone-native-toprimitive-phase1.md
@@ -1,0 +1,127 @@
+---
+id: 1900
+title: "standalone native ToPrimitive (Phase 1): Wasm-native OrdinaryToPrimitive over $Object (~2,136 ceiling)"
+status: ready
+created: 2026-06-05
+updated: 2026-06-05
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, type-coercion, standalone
+language_feature: to-primitive, symbol-toprimitive, abstract-operations
+goal: standalone-mode
+sprint: 60
+parent: 1806
+related: [1806, 1525b, 1472, 850, 1253, 1716]
+needs_arch_spec: true
+---
+# #1900 — Standalone native ToPrimitive (Phase 1)
+
+> **Sprint 60 centerpiece.** This is the single largest standalone-lane lever
+> in the tree. **Needs an architect spec before dev dispatch** (see
+> *## Needs Architect Spec* below) — route to architect first.
+
+## Problem
+
+#1806 (done) landed **Phase 0**: a clean standalone *refusal* for the
+`__toPrimitive` host import. All **2,136** standalone test262 records that hit
+object→primitive coercion now compile-fail with a `#1806`-citing message
+instead of an opaque `Cannot convert object to primitive value`. The refusal
+made the failures trackable but did **not** make any of them pass.
+
+**Phase 1 (this issue)** implements a **Wasm-native ToPrimitive** over the
+`$Object` WasmGC struct so these tests run without any JS host. This is the
+ceiling that unblocks the bulk of the standalone object-coercion surface:
+arithmetic/relational/equality operators, template literals, `String(obj)`,
+property-key coercion, and `JSON.stringify` all funnel through ToPrimitive.
+
+**Baseline**: standalone 12,002 / 43,125 (27.8%), sha `8a0d940d`, 2026-06-04.
+
+## Spec
+
+- [§7.1.1 ToPrimitive](https://tc39.es/ecma262/#sec-toprimitive) — the
+  `Symbol.toPrimitive` exotic-method short-circuit + hint plumbing
+  (`"default"` / `"number"` / `"string"`).
+- [§7.1.1.1 OrdinaryToPrimitive](https://tc39.es/ecma262/#sec-ordinarytoprimitive)
+  — the `valueOf`/`toString` method-name ordering by hint, each called via
+  `Call`, first primitive result wins, else throw **TypeError**.
+- Implement from fetched spec text, not memory; cite the section in the commit
+  (per `feedback_spec_first_fixes`).
+
+## Fix approach (from #1806 Option B, to be refined by architect)
+
+Implement `__toPrimitive_number` / `__toPrimitive_string` (and the `"default"`
+hint, which routes to the number ordering except for `Date`) as pure-Wasm
+functions operating on the `$Object` struct:
+
+1. **`Symbol.toPrimitive` lookup** — if the object carries a
+   `[[Symbol.toPrimitive]]` entry, call it with the hint string and require a
+   primitive result (else TypeError). Requires Symbol-keyed property lookup on
+   `$Object` — **Phase B of #1472**; confirm its current state before relying
+   on it (this is the main cross-issue dependency the spec must resolve).
+2. **OrdinaryToPrimitive** — for the number hint try `valueOf()` then
+   `toString()`; for the string hint reverse the order. Each is a `$PropMap`
+   method dispatch returning a value that must be tested for primitive-ness
+   (`__is_primitive`), first primitive wins.
+3. **TypeError** on no-primitive — emit a real `__new_TypeError` instance
+   (standalone in-module constructor via `emitWasiErrorConstructor`), matching
+   the instance-shape requirement that `assert.throws`/`instanceof` checks rely
+   on (see #846 slice-2 note on real-instance exceptions).
+
+## Entry points (chokepoint already identified by #1806)
+
+- `src/codegen/type-coercion.ts` — `toPrimitiveHostCallInstrs` /
+  `emitToPrimitiveHostCall`: the ~6 sites that currently funnel to the host
+  import. In standalone mode these must emit a `call $__toPrimitive_{number,string}`
+  to the new Wasm functions instead of refusing.
+- `src/codegen/expressions/late-imports.ts` —
+  `refuseStandaloneToPrimitive` (the Phase-0 guard). Phase 1 replaces this
+  refusal with the native call when the native path can handle the object;
+  keep a narrowed refusal only for genuinely unsupported shapes
+  (e.g. Symbol-keyed exotic where #1472 Phase B is absent).
+- `src/runtime.ts` / standalone helper emit — where `__new_TypeError` /
+  `emitWasiErrorConstructor` live for the no-primitive throw.
+
+## Decomposition (architect to confirm slice boundaries)
+
+- **Slice 1 — OrdinaryToPrimitive (valueOf/toString), no Symbol.toPrimitive.**
+  Number + string hint over `$Object` with `valueOf`/`toString` method
+  dispatch + primitive test + TypeError. This is the bulk of the 2,136 (most
+  tests use plain `valueOf`/`toString`, not `Symbol.toPrimitive`). Largest,
+  load-bearing slice.
+- **Slice 2 — `Symbol.toPrimitive` short-circuit.** Gated on #1472 Phase B
+  (Symbol-keyed lookup). Smaller test volume; can land after Slice 1.
+- **Slice 3 — hint = `"default"` + `Date` exception** and the
+  template-literal / property-key / JSON call sites that pass a non-number,
+  non-string hint.
+
+## Acceptance criteria
+
+- Standalone OrdinaryToPrimitive over `$Object` structs runs with **zero**
+  `__toPrimitive`/`__to_primitive` host imports (verify via the
+  host-import-allowlist gate).
+- The no-primitive path throws a real `TypeError` *instance* (passes both the
+  outer `assert.throws(TypeError, …)` and an inner `e instanceof TypeError`).
+- **Slice 1 target: ≥ 800 of the 2,136 standalone records pass.**
+- JS-host (GC) lane unchanged — no regression in the default lane.
+- New `tests/issue-1900*.test.ts` covering: numeric-hint `obj - 0`,
+  string-hint `` `${obj}` ``, `valueOf` returning object then `toString`
+  fallback, both returning objects → TypeError, and a `Symbol.toPrimitive`
+  object (Slice 2).
+
+## Needs Architect Spec
+
+This is `feasibility: hard` and touches the standalone object/property model.
+Before dev dispatch the architect must pin down:
+
+1. **#1472 Phase B status** — is Symbol-keyed lookup on `$Object` available? If
+   not, Slice 2 is deferred and Slice 1 must narrow its refusal precisely.
+2. **`$PropMap` method-dispatch reentry** — calling `valueOf`/`toString` from
+   inside a codegen helper (the trampoline concern that #1525b hit: invalid
+   Wasm when the dispatched method is itself a late/trampolined function).
+   Coordinate with **#1525b** — they share the method-dispatch substrate and
+   may want a single shared `__call_method_by_name` helper.
+3. **Primitive-test predicate** — the exact `$Object` discriminants for
+   "is primitive" in standalone (number/string/boolean/bigint/symbol/undefined
+   /null) without a host roundtrip.

--- a/plan/issues/sprints/59.md
+++ b/plan/issues/sprints/59.md
@@ -1,8 +1,9 @@
 ---
 sprint: 59
-status: active
+status: closed
 created: 2026-06-02
-updated: 2026-06-04
+updated: 2026-06-05
+closed: 2026-06-05
 authors: codex
 baseline_pass: 30521
 baseline_total: 43135
@@ -93,173 +94,27 @@ redundancy/latent findings (#1840–#1849) went to Backlog.
 - #1806 emits tracking cite for all 2,136 tests (Phase 0).
 - #1539 Phase 2 flags and #681 iterator protocol ship.
 - Baseline promoted after P1/P2 merges.
+
+## Retrospective (closed 2026-06-05)
+
+Sprint 59 was never formally closed when sprint 60 planning began — no
+`sprint/59` tag, frontmatter left `status: active`, no retrospective, and the
+generated issue-table block had been corrupted by a doubled
+`sync-sprint-issue-tables.mjs` write (the entire document was duplicated, 265
+lines). This close repairs the file.
+
+**Outcome: 40 / 58 issues done.** Both P1 crash clusters (#1808, #1809)
+cleared; the ToPrimitive Phase 0 refusal (#1806) and the entire 2026-06-04
+code-review bug batch (#1815–#1839) landed. Approx. movement over the sprint
+window: default lane 30,521 → ~30,612 (70.8% → ~71.0%); standalone 10,948 →
+~12,002 (25.4% → ~27.8%), driven by the code-review standalone fixes.
+
+**Carryover:** the unfinished issues were reassigned during sprint 60/61
+planning (adopted into sprint 60, or deferred to sprint 61 / backlog) — see
+`sprints/60.md` and `sprints/61.md` for their current homes. The standalone
+ToPrimitive centerpiece, drafted but unfiled during s60 planning, is now filed
+as **#1900** (`1900-standalone-native-toprimitive-phase1.md`); #1862 and #1863
+are unrelated issues.
 
 <!-- GENERATED_ISSUE_TABLES_START -->
-## Issue Tables
-
-_Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
-
-### Ready
-
-| Issue | Title | Priority | Status |
-|---|---|---|---|
-| #1470 | host-independence: eliminate JS host string ops for standalone Wasm | high | ready |
-| #1525b | ToPrimitive residuals: object-method trampoline invalid Wasm + §7.1.1.1 step-6 TypeError | medium | ready |
-| #1712 | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | high | ready |
-| #1761 | perf(string-hash): presize string-build buffer from static loop-trip-count to kill reallocs + per-append cap-check | high | ready |
-| #1777 | landing page ES edition slider shows ES2026 notch and thumb drifts off ticks | medium | ready |
-| #1805 | 75 negative_test_fail: early-error enforcement gaps after #774/#927 | medium | ready |
-| #1806 | standalone: 2,136 tests fail with 'Cannot convert object to primitive value' | high | ready |
-| #1807 | standalone: 277 async-generator tests emit invalid Wasm in isSameValue (#1776 residual) | medium | ready |
-| #1808 | Binary emit error: offset is out of bounds — emitBinary() crash on 276 tests | high | ready |
-| #1809 | late-import shift walker misses method-trampoline funcIdx pointing at import (#1525b regression) | high | ready |
-| #1815 | Array.prototype.splice drops inserted items (3+ args ignored) | high | ready |
-| #1816 | Array.prototype.sort ignores user comparator; default sort numeric not lexicographic (residual #1361) | high | ready |
-| #1817 | >>> in i32 fast path produces a signed result (negative for high-bit values) | high | ready |
-| #1818 | i32/boolean parameter default fires on a legitimate 0 / false argument | high | ready |
-| #1819 | Logical assignment (??= \|\|= &&=) reads globals at wrong (un-offset) index | high | ready |
-| #1820 | IR path: && \|\| and ternary evaluate both operands (lost short-circuit + non-termination) | high | ready |
-| #1821 | delete obj.prop always returns true; delete obj['k'] skips __delete_property sidecar | medium | ready |
-| #1822 | String#replace/replaceAll ignore $ substitution patterns ($, <!-- GENERATED_ISSUE_TABLES_START -->
-## Issue Tables
-
-_Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
-
-### Backlog
-
-| Issue | Title | Priority | Status |
-|---|---|---|---|
-| #1712 | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | high | backlog |
-
-### Ready
-
-| Issue | Title | Priority | Status |
-|---|---|---|---|
-| #1777 | landing page ES edition slider shows ES2026 notch and thumb drifts off ticks | medium | ready |
-
-<!-- GENERATED_ISSUE_TABLES_END -->, ---
-sprint: 59
-status: active
-created: 2026-06-02
-updated: 2026-06-04
-authors: codex
-baseline_pass: 30521
-baseline_total: 43135
-baseline_pct: 70.8
-standalone_baseline_pass: 10948
-standalone_baseline_total: 43128
-standalone_baseline_pct: 25.4
-baseline_sha: f692249d
-baseline_date: 2026-06-03T22:28Z
-target_pass: tbd
-expected_gain: tbd
----
-
-# Sprint 59 Plan — harvest fixes + early-error enforcement
-
-## Goal
-
-Fix concrete error patterns surfaced by `/harvest-errors` on 2026-06-04.
-Two default-lane codegen crashes (#1808, #1809) are high-priority (290 + 157
-tests, should be fast wins). The standalone ToPrimitive gap (#1806) is the
-largest new standalone lever (2,136 tests). Plus carry-over polish.
-
-## P1 — codegen crashes (default lane)
-
-- [#1808](../1808-binary-emit-offset-out-of-bounds-codegen-crash.md) — `Binary emit error: offset is out of bounds` — **290 tests**. emitBinary() back-patch overflow. High, medium.
-- [#1809](../1809-method-trampoline-shift-walker-misses-import-funcidx.md) — `pendingMethodTrampolines` shift walker misses import funcIdx — **157 tests**. #1525b regression. High, medium.
-
-## P2 — standalone conformance (harvest 2026-06-04)
-
-- [#1806](../1806-standalone-toprimitive-cannot-convert-object.md) — standalone `Cannot convert object to primitive value` — **2,136 tests** (839 CE + 1,297 runtime). ToPrimitive not implemented in standalone. High, medium.
-- [#1807](../1807-standalone-issamevalue-async-gen-wasm-type-mismatch.md) — standalone isSameValue Wasm call type mismatch for async-generator params — **277 tests**. Residual after #1776. Medium, medium.
-- [#1805](../1805-negative-test-fail-early-error-enforcement-gaps.md) — 75 negative_test_fail early-error gaps (import-attrs dup key, TDZ, dstr rest) — Medium, medium.
-
-## P2 — carry-in (unfinished from s57/s58)
-
-- [#1387](../1387-with-statement-dynamic-scope-implementation.md) — `with` statement Tier 2 dynamic fallback — in-progress (Tier 1 merged; Tier 2 hard).
-- [#1525b](../1525b-toprimitive-method-trampoline-and-step6.md) — ToPrimitive trampoline invalid Wasm + §7.1.1.1 step-6 TypeError — ready.
-- [#1539](../1539-wasm-native-regex-engine-regress.md) — standalone RegExp Phase 2: flags u/v/d/m/s via regress — in-progress, **1,052 tests**.
-- [#681](../681-pure-wasm-iterator-protocol-eliminate.md) — standalone iterator protocol remaining 4 host imports — in-progress, **777 tests**.
-- [#1470](../1470-no-js-host-string-ops.md) — eliminate JS host string ops for standalone — ready, high impact.
-
-## P3 — carry-over polish
-
-- [#1712](../1712-acorn-acceptance-differential-ast.md) — Acorn AST-equality dogfood acceptance — ready.
-- [#1761](../1761-string-build-buffer-presize-static-trip-count.md) — string-build buffer presize — ready.
-- [#1777](../1777-landing-es-edition-slider-2026-notch-thumb-offset.md) — landing page ES2026 slider notch + thumb drift — ready, easy.
-
-## P2 — code-review bugs (2026-06-04)
-
-Filed from the full-codebase review on 2026-06-04
-(`plan/code-review/2026-06-04-compiler-review.md`). Real correctness bugs;
-redundancy/latent findings (#1840–#1849) went to Backlog.
-
-**Reachable (JS-host default lane):**
-
-- [#1815](../1815-array-splice-drops-inserted-items.md) — `splice` drops inserted items (3+ args). High.
-- [#1816](../1816-array-sort-comparator-ignored-default-numeric.md) — `sort` ignores comparator; default not lexicographic (residual #1361). High.
-- [#1817](../1817-ushr-i32-fast-path-signed-result.md) — `>>>` i32 fast path produces a signed result. High.
-- [#1818](../1818-i32-bool-default-param-fires-on-zero-false.md) — i32/boolean default param fires on `0`/`false`. High.
-- [#1819](../1819-logical-assignment-global-index-offset.md) — `??=`/`||=`/`&&=` read globals at wrong index. High.
-- [#1820](../1820-ir-short-circuit-evaluates-both-operands.md) — IR `&&`/`||`/ternary evaluate both operands. High.
-- [#1821](../1821-delete-always-true-and-element-skips-sidecar.md) — `delete obj.prop` always returns true; `delete obj["k"]` skips sidecar. Med.
-- [#1822](../1822-string-replace-ignores-dollar-substitution.md) — `replace`/`replaceAll` ignore `$` patterns. Med.
-- [#1823](../1823-string-normalize-arg-before-receiver.md) — `normalize(form)` evaluates arg before receiver. Med.
-- [#1824](../1824-super-as-value-wrong-static-type.md) — `super` as a value returns wrong static type. Med.
-- [#1825](../1825-i32-fast-mode-modulo-traps.md) — i32 fast-mode `%` emits trapping `i32.rem_s`. Med.
-- [#1826](../1826-toprimitive-valueof-undefined-treated-absent.md) — `valueOf` returning `undefined` treated as absent. Med.
-- [#1827](../1827-bigint-loose-equality-precision.md) — BigInt loose-equality precision/semantics. Med.
-- [#1828](../1828-array-like-find-map-hole-handling.md) — array-like `find`/`findIndex` skip holes; `map` compacts holes. Med.
-- [#1829](../1829-marshal-typedarray-byte-mask.md) — `marshalTypedArrayArgs` byte-masks non-`Uint8Array` typed arrays. High.
-- [#1830](../1830-wellknown-symbol-range-excludes-matchall.md) — symbol range off-by-one excludes `Symbol.matchAll`. Med.
-- [#1831](../1831-validate-property-descriptor-resets-omitted.md) — `_validatePropertyDescriptor` resets omitted attrs (residual #1334). Med.
-- [#1832](../1832-newfn-captures-outer-var-shadowed-by-destructured-param.md) — captures outer var shadowed by destructured param. Med.
-- [#1833](../1833-implicit-subclass-forwarder-truncates-super-args.md) — implicit subclass forwarder truncates multi-arg `super`. Med.
-- [#1834](../1834-vec-element-write-trapping-trunc.md) — element-write index uses trapping `i32.trunc_f64_s`. Med.
-
-**Standalone / WASI (supported targets):**
-
-- [#1835](../1835-cabi-string-array-marshaling-wrong-offsets.md) — C-ABI string/array marshaling wrong header offsets. High.
-- [#1836](../1836-standalone-number-string-conformance.md) — standalone Number↔String conformance gaps (residual #1335). High.
-- [#1837](../1837-standalone-enumeration-order-hash-bucket.md) — standalone enumeration order is hash-bucket. Med.
-- [#1838](../1838-linear-backend-trycatch-miscompile.md) — linear backend silently miscompiles `try/catch`. Med.
-- [#1839](../1839-add-string-imports-shift-omits-targets.md) — late string-import index shift omits init body / helpers / start func. Med.
-
-## Definition of done
-
-- All P1 crash clusters cleared (#1808, #1809).
-- #1806 emits tracking cite for all 2,136 tests (Phase 0).
-- #1539 Phase 2 flags and #681 iterator protocol ship.
-- Baseline promoted after P1/P2 merges.
-
-, ) | medium | ready |
-| #1823 | String#normalize(form) evaluates argument before receiver (wrong eval order) | medium | ready |
-| #1824 | super used as a value returns the wrong static ValType (local indexing bug) | medium | ready |
-| #1825 | i32 fast-mode % emits trapping i32.rem_s (x % 0 traps instead of NaN) | medium | ready |
-| #1826 | OrdinaryToPrimitive treats valueOf/toString returning undefined as method-absent | medium | ready |
-| #1827 | BigInt loose-equality loses precision / wrong semantics (== String, == Number) | medium | ready |
-| #1828 | Array-like find/findIndex skip holes; map compacts holes (sparse .call receivers) | medium | ready |
-| #1829 | marshalTypedArrayArgs byte-masks every element, corrupting non-Uint8Array typed arrays | high | ready |
-| #1830 | Well-known-symbol range guard off-by-one excludes Symbol.matchAll (ID 15) | medium | ready |
-| #1831 | _validatePropertyDescriptor resets omitted attributes to false on redefine (residual #1334) | medium | ready |
-| #1832 | compileNewFunctionExpression captures outer var shadowed by a destructured param | medium | ready |
-| #1833 | Implicit subclass constructor forwarder truncates multi-arg super(...) | medium | ready |
-| #1834 | Vec element-write/length index uses trapping i32.trunc_f64_s instead of saturating | medium | ready |
-| #1835 | C-ABI string/array marshaling reads wrong header offsets (param + return) | high | ready |
-| #1836 | Standalone Number<->String conformance gaps (0o/0b, toFixed 1e21, exponential, fractional radix, whitespace, ToNumber) (residual #1335) | high | ready |
-| #1837 | Standalone Object.keys/for-in/JSON enumeration is hash-bucket order, not spec order | medium | ready |
-| #1838 | Linear backend silently miscompiles try/catch (throw -> unreachable, catch dropped) | medium | ready |
-| #1839 | addStringImports late-index shift omits pendingInitBody / nativeStrHelpers / startFuncIdx | medium | ready |
-| #1844 | IR verify doesn't recurse into nested if/try/loop buffers (return-type gate + SSA holes) (residual #1798) | low | ready |
-| #1845 | IR propagate: && / \|\| over-claim BOOL; seedConcrete omits i32/u32 | low | ready |
-
-### In Progress
-
-| Issue | Title | Priority | Status |
-|---|---|---|---|
-| #681 | Pure Wasm iterator protocol (eliminate 5 host imports) | high | in-progress |
-| #1387 | feat: implement `with` statement — architect exploration of dynamic-scope compilation strategies | high | in-progress |
-| #1539 | Standalone Wasm RegExp engine via regress (Phase 2 of #1474) | high | in-progress |
-
 <!-- GENERATED_ISSUE_TABLES_END -->

--- a/plan/issues/sprints/60.md
+++ b/plan/issues/sprints/60.md
@@ -84,11 +84,12 @@ as a placeholder pending architect input.
 
 ## Track 1 — ToPrimitive (centerpiece — pending architect spec)
 
-- **Standalone native ToPrimitive (Phase 1) — centerpiece, NOT YET FILED.**
-  Wasm-native OrdinaryToPrimitive over `$Object`. ~2,136 ceiling; Slice 1 target ≥800.
-  High, hard. **Blocker: architect spec needed first** — cross-check:
+- [#1900](../1900-standalone-native-toprimitive-phase1.md) — **centerpiece.**
+  Standalone native ToPrimitive (Phase 1): Wasm-native OrdinaryToPrimitive over
+  `$Object`. ~2,136 ceiling; Slice 1 target ≥800. High, hard.
+  **Blocker: architect spec needed first** — cross-check:
   (#1472-PhaseB Symbol-key lookup status, `$PropMap` method-dispatch reentry shared with
-  #1525b, primitive-test predicate in standalone). **Priority: file issue + route to
+  #1525b, primitive-test predicate in standalone). **Priority: route to
   architect for spec, then dispatch dev slice-1.**
 - [#1525b](../1525b-toprimitive-method-trampoline-and-step6.md) — ToPrimitive
   method-trampoline invalid Wasm + §7.1.1.1 step-6 TypeError. 142 standalone


### PR DESCRIPTION
Two residual sprint-planning defects the PO's live reconciliation did not cover. Scoped tight to avoid racing the PO (which owns issue sprint-membership across 59/60/61).

## 1. Close sprint 59 + repair corruption
`sprints/59.md` was still `status: active` and **corrupted** — the generated issue-table block had been doubled by a bad `sync-sprint-issue-tables.mjs` write (the whole 265-line doc was duplicated). Reconstructed a single clean doc, set `status: closed`, added a retrospective (40/58 done). Issue carryover is left to the PO (sprints 60/61), so the retrospective is membership-neutral.

## 2. File the ToPrimitive centerpiece as #1900
The s60 centerpiece had no issue file — `sprints/60.md` said *"NOT YET FILED"* (after the earlier #1862/#1863 collisions, both unrelated issues). Filed it as **#1900** and linked it from the s60 Track-1 bullet (architect-spec-first framing preserved — exactly what the s60 plan asked for: *"file issue + route to architect"*).

`sprint/59` tag applied to main after merge. Planning-only (no code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)