### PR TITLE
test(#6407): regression-pin Array.prototype.<m>.call element read (already fixed on main)

### DIFF
--- a/plan/issues/6407-array-method-call-vec-receiver-element-retrieval.md
+++ b/plan/issues/6407-array-method-call-vec-receiver-element-retrieval.md
@@ -1,9 +1,10 @@
 ---
 id: 6407
 title: "Array.prototype.<m>.call(receiver, cb) never reads elements of a compiled $Vec / open-object receiver"
-status: ready
+status: done
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-05
+completed: 2026-06-05
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -14,6 +15,55 @@ sprint: 61
 blocks: [1828, 1830, 1831, 1832]
 ---
 # #6407 — `Array.prototype.<m>.call(receiver, …)` can't read elements of a compiled receiver
+
+## RESOLUTION (sd-s2, 2026-06-05) — ALREADY FIXED ON MAIN + regression-pinned
+
+The JS-host element-retrieval defect this issue describes is **already
+resolved on current `main`** (HEAD `7a14a48a2`). The dispatch routes a
+compiled-`$Vec` `.call` receiver to the element-aware typed
+`compileArrayMethodCall` path — verified by inspecting emitted imports:
+`Array.prototype.findIndex.call([10,20,30], …)`, `indexOf.call`, and
+`map.call` emit **neither** `__proto_method_call` **nor** `__extern_get_idx`,
+i.e. they no longer reach the opaque-externref host bridge. The headline
+symptom (`findIndex.call([10,20,30], x=>x===20)` → -1) and every other case
+the spec lists now agree with native JS. This was fixed by the array-method
+work that landed since the spec was written 2026-06-04 (the
+`#1828`/`#1830`/`#1831`/`#1832` family + dispatch routing).
+
+Verified working (all run through `assertEquivalent` = compile-to-Wasm vs
+native-JS equality) in **`tests/equivalence/issue-6407.test.ts`** (17 cases,
+added by this issue as a regression pin):
+
+- `findIndex` / `find` / `indexOf` / `includes` / `forEach` / `every` / `some`
+  / `map` / `filter` `.call` on a dense `$Vec` array literal `[10,20,30]`;
+- `findIndex` / `indexOf` `.call` on a **typed `number[]` variable** (the
+  `__vec_`/`__arr_` bailout path the spec's §(A) targeted — no longer broken);
+- `findIndex` `.call` on an **`any`-typed array** (the generic loop path);
+- `indexOf` `.call` on an **open-object numeric-key array-like**
+  `{0:10,1:20,2:30,length:3}` (the #6407b candidate — also working).
+
+**Slices 1 & 2 (JS-host dispatch + host backstop) are therefore moot** — no
+code change is needed for the JS-host path, only the regression test.
+
+### Standalone (`--target wasi` / `nativeStrings`) — NOT a #6407 gap
+
+The spec's §(C)/Slice 3 native `$Vec` arm: in `nativeStrings` mode the
+array-callback element boxing still routes through host `__box_number` /
+`__unbox_number` imports — **but this is true for a plain `arr.findIndex(...)`
+direct method call too**, not just the `.call` borrowed form. So it is a
+general standalone-array-callback boxing gap, NOT a `$Vec`-element-read gap
+specific to `Array.prototype.<m>.call`. It does not belong to #6407's thesis
+and is left to the broader standalone-array-callback boxing work. Noted in the
+test file header.
+
+### Impact on dependents
+
+`#1828` / `#1830` / `#1831` / `#1832` are now **verifiable** through this path
+(their fixes already merged; `#1830` is `done`, the other three have merged
+fix commits but stale `ready` status — a TaskList/issue-status reconcile, not
+new work). The combined String+Array borrowed-method brand table (#1888 follow-on)
+can ride on the existing element read for the Array arm — no #6407 impl gate
+remains for it in JS-host mode.
 
 ## Symptom (dev-w1, 2026-06-04)
 

--- a/tests/equivalence/issue-6407.test.ts
+++ b/tests/equivalence/issue-6407.test.ts
@@ -1,0 +1,206 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+/**
+ * #6407 — `Array.prototype.<m>.call(receiver, …)` element retrieval for a
+ * compiled receiver (`$Vec` array literal, typed array variable, `any`-typed
+ * array, or open-object numeric-key array-like).
+ *
+ * The spec (2026-06-04) reported that `Array.prototype.findIndex.call(
+ * [10,20,30], …)` returned -1 because the generic array-like loop / host
+ * `__proto_method_call` bridge could not read elements of an opaque compiled
+ * receiver. By the time this regression suite was added the JS-host element
+ * read was **already correct on main** — the array-method dispatch routes a
+ * compiled-vec `.call` receiver to the element-aware typed `compileArrayMethodCall`
+ * path (verified: no `__proto_method_call` / `__extern_get_idx` import is
+ * emitted for these). These cases therefore PIN the now-working behaviour so it
+ * cannot silently regress, and double as the verification harness for the four
+ * "correct-but-unverifiable" point-fixes #1828/#1830/#1831/#1832 cited.
+ *
+ * They run through `assertEquivalent`, which compiles the source to Wasm AND
+ * evaluates it as native JS, asserting the two agree.
+ *
+ * NOTE — standalone (`--target wasi` / `nativeStrings`) parity is intentionally
+ * NOT asserted here: in that mode array-callback element boxing still routes
+ * through the host `__box_number` / `__unbox_number` helpers for BOTH the
+ * `.call` form and a plain `arr.findIndex(...)` call, so it is a general
+ * standalone-array-callback boxing gap, not a `$Vec`-element-read gap specific
+ * to #6407. Tracked separately.
+ */
+describe("#6407 — Array.prototype.<m>.call on a compiled receiver (element read)", () => {
+  it("findIndex.call finds a dense element (headline symptom)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.findIndex.call([10, 20, 30], (x: number) => x === 20);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("findIndex.call returns -1 when absent", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.findIndex.call([10, 20, 30], (x: number) => x === 99);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("find.call returns the matching element", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.find.call([10, 20, 30], (x: number) => x === 20) as number;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("indexOf.call finds a dense element", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.indexOf.call([10, 20, 30], 20);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("includes.call reports membership", async () => {
+    // Coerced to number — a Wasm export marshals a boolean as i32 (1/0), so an
+    // `Object.is(1, true)` comparison in the equivalence harness would
+    // false-fail on a return-marshaling artifact unrelated to #6407's element
+    // read. The `? 1 : 0` projection asserts the element read + comparison are
+    // correct without tripping that artifact.
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.includes.call([10, 20, 30], 20) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("includes.call reports absence", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.includes.call([10, 20, 30], 99) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("forEach.call visits every element in order", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        let s = 0;
+        Array.prototype.forEach.call([10, 20, 30], (x: number) => { s += x; });
+        return s;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("every.call short-circuits correctly", async () => {
+    // `? 1 : 0` — see the includes.call note on boolean return marshaling.
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.every.call([10, 20, 30], (x: number) => x >= 10) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("every.call returns false when an element fails the predicate", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.every.call([10, 20, 30], (x: number) => x > 15) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("some.call short-circuits correctly", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.some.call([10, 20, 30], (x: number) => x === 30) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("some.call returns false when no element matches", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return Array.prototype.some.call([10, 20, 30], (x: number) => x === 999) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("map.call returns a fresh transformed array (sum the result)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const doubled = Array.prototype.map.call([10, 20, 30], (x: number) => x * 2) as number[];
+        let s = 0;
+        for (let i = 0; i < doubled.length; i++) s += doubled[i];
+        return s;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("filter.call retains matching elements (sum the result)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const kept = Array.prototype.filter.call([10, 20, 30], (x: number) => x > 15) as number[];
+        let s = 0;
+        for (let i = 0; i < kept.length; i++) s += kept[i];
+        return s;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  // --- receiver shapes beyond the array literal -------------------------------
+
+  it("findIndex.call on a typed number[] variable", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a: number[] = [10, 20, 30];
+        return Array.prototype.findIndex.call(a, (x: number) => x === 20);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("indexOf.call on a typed number[] variable", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a: number[] = [10, 20, 30];
+        return Array.prototype.indexOf.call(a, 30);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("findIndex.call on an any-typed array", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a: any = [10, 20, 30];
+        return Array.prototype.findIndex.call(a, (x: number) => x === 20);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("indexOf.call on an open-object numeric-key array-like", async () => {
+    // {0:..,1:..,2:..,length:3} — an open-object struct with integer-named
+    // props, NOT a $Vec. Reads through the per-field getter path; this is the
+    // #6407b candidate, confirmed working alongside the $Vec read.
+    await assertEquivalent(
+      `export function test(): number {
+        const o: any = { 0: 10, 1: 20, 2: 30, length: 3 };
+        return Array.prototype.indexOf.call(o, 20);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## #6407 — `Array.prototype.<m>.call(receiver, …)` element retrieval

**Finding: ALREADY FIXED on main. This PR adds regression coverage and closes
the issue.**

The element-retrieval defect #6407 describes (a compiled `$Vec` / open-object
`.call` receiver whose elements were never read, so `findIndex.call([10,20,30],
…)` returned -1) is **already resolved on current `main`** (HEAD `7a14a48a2`).
The array-method dispatch routes a compiled-`$Vec` `.call` receiver to the
element-aware typed `compileArrayMethodCall` path — verified by inspecting
emitted imports: `findIndex.call` / `indexOf.call` / `map.call` on a literal
emit **neither** `__proto_method_call` **nor** `__extern_get_idx`, i.e. they no
longer reach the opaque-externref host bridge. This landed with the
#1828/#1830/#1831/#1832 array-method work after the spec was written
2026-06-04.

Per the project "check before building" discipline, rather than implement the
now-moot Slices 1-2, this PR:

1. **Adds `tests/equivalence/issue-6407.test.ts`** (17 cases) as a regression
   pin. Each runs through `assertEquivalent`, which compiles to Wasm AND
   evaluates as native JS, asserting they agree — exactly the
   "correct-but-unverifiable" gap #6407 was meant to close. Coverage:
   - `findIndex`/`find`/`indexOf`/`includes`/`forEach`/`every`/`some`/`map`/
     `filter` `.call` on a dense `$Vec` literal `[10,20,30]`;
   - `findIndex`/`indexOf` `.call` on a **typed `number[]` variable** (the
     `__vec_`/`__arr_` bailout path the spec's §A targeted);
   - `findIndex` `.call` on an **`any`-typed array** (generic loop path);
   - `indexOf` `.call` on an **open-object numeric-key array-like**
     `{0:10,1:20,2:30,length:3}` (the #6407b candidate).
   Boolean-returning methods use a `? 1 : 0` projection to avoid the unrelated
   i32-vs-`boolean` export-marshaling artifact (the element read + comparison
   are what's under test).

2. **Closes the issue** (`status: done`) with a `RESOLUTION` section recording
   the finding and impact on dependents.

### Standalone (`--target wasi` / `nativeStrings`) — explicitly NOT a #6407 gap

In `nativeStrings` mode array-callback element boxing still routes through host
`__box_number` / `__unbox_number` imports — **but that is true for a plain
`arr.findIndex(...)` direct method call too**, not just the `.call` borrowed
form. So it is a general standalone-array-callback boxing gap, NOT a
`$Vec`-element-read gap specific to `Array.prototype.<m>.call`. Out of scope
here; documented in the test header for the next agent who picks up standalone
array-callback boxing.

### Impact on dependents

`#1828` / `#1830` / `#1831` / `#1832` are now **verifiable** through this path
(fixes already merged — `#1830` is `done`; the other three have merged fix
commits but stale `ready` status, a reconcile, not new work). The combined
String+Array borrowed-method brand table (#1888 follow-on) can ride on the
existing element read for the Array arm in JS-host mode — no #6407 impl gate
remains.

No source change. tsc clean. `tests/equivalence/issue-6407.test.ts`: 17/17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
