### PR TITLE
fix(#1136): native Array.prototype.findLast / findLastIndex

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -2392,6 +2392,8 @@ const ARRAY_METHODS = new Set([
   "forEach",
   "find",
   "findIndex",
+  "findLast",
+  "findLastIndex",
   "some",
   "every",
   "entries",
@@ -2638,6 +2640,18 @@ export function compileArrayMethodCall(
       result =
         elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "externref"
           ? compileArrayFindIndex(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
+          : undefined;
+      break;
+    case "findLast":
+      result =
+        elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "externref"
+          ? compileArrayFindLast(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
+          : undefined;
+      break;
+    case "findLastIndex":
+      result =
+        elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "externref"
+          ? compileArrayFindLastIndex(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
           : undefined;
       break;
     case "some":
@@ -5872,6 +5886,197 @@ function compileArrayFindIndex(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: fiResTmp });
+  return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+}
+
+/**
+ * Reverse-iteration setup for findLast/findLastIndex (§23.1.3.12/.13): start the
+ * cursor at len-1 instead of 0. Reuses `setupArrayLoop`'s vec/data/len read, then
+ * overwrites `iTmp = len - 1`. Pair with `loopExitCheckReverse`/`loopDecrement`.
+ */
+function setupArrayLoopReverse(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+  tag: string,
+): ArrayLoopLocals {
+  const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, tag);
+  // i = len - 1 (setupArrayLoop left it at 0).
+  fctx.body.push({ op: "local.get", index: loop.lenTmp });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "i32.sub" });
+  fctx.body.push({ op: "local.set", index: loop.iTmp });
+  return loop;
+}
+
+/** Reverse loop-exit check: if (i < 0) br 1. */
+function loopExitCheckReverse(loop: ArrayLoopLocals): Instr[] {
+  return [
+    { op: "local.get", index: loop.iTmp } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.lt_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+  ];
+}
+
+/** Reverse i-- / br 0 at the end of each iteration. */
+function loopDecrement(loop: ArrayLoopLocals): Instr[] {
+  return [
+    { op: "local.get", index: loop.iTmp } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.sub" } as Instr,
+    { op: "local.set", index: loop.iTmp } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+}
+
+/**
+ * arr.findLast(cb) -> iterate from the last index toward 0, return the first
+ * element whose callback result is truthy, else undefined (NaN in non-fast mode).
+ * Mirror of compileArrayFind but reverse-iterating (§23.1.3.12).
+ */
+function compileArrayFindLast(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  if (emitCallbackTypeCheck(ctx, fctx, callExpr, "Array.prototype.findLast")) {
+    fctx.body.push({ op: "unreachable" });
+    return elemType;
+  }
+
+  const setup = setupArrayCallback(ctx, fctx, callExpr, "findLast", "findLast");
+  if (!setup) return null;
+
+  const elemTmpLocal = allocLocal(fctx, `__arr_findLast_el_${fctx.locals.length}`, elemType);
+
+  const loop = setupArrayLoopReverse(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "findLast");
+
+  const callAndCheck = buildCallAndCheck(
+    ctx,
+    fctx,
+    setup,
+    elemType,
+    vecTypeIdx,
+    arrTypeIdx,
+    loop,
+    { kind: "local", index: elemTmpLocal },
+    "truthy",
+  );
+
+  const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
+  const findResTmp = allocLocal(fctx, `__arr_findLast_res_${fctx.locals.length}`, findResType);
+  if (ctx.fast) {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  } else {
+    fctx.body.push({ op: "f64.const", value: 0 });
+    fctx.body.push({ op: "f64.const", value: 0 });
+    fctx.body.push({ op: "f64.div" }); // NaN (undefined sentinel)
+  }
+  fctx.body.push({ op: "local.set", index: findResTmp });
+
+  const loopBody: Instr[] = [
+    ...loopExitCheckReverse(loop),
+
+    { op: "local.get", index: loop.dataTmp } as Instr,
+    { op: "local.get", index: loop.iTmp } as Instr,
+    { op: loop.getOp, typeIdx: arrTypeIdx } as Instr,
+    { op: "local.set", index: elemTmpLocal } as Instr,
+
+    ...callAndCheck,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: elemTmpLocal } as Instr,
+        ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+        { op: "local.set", index: findResTmp } as Instr,
+        { op: "br", depth: 2 } as Instr,
+      ],
+    } as Instr,
+
+    ...loopDecrement(loop),
+  ];
+
+  emitArrayLoop(fctx, loopBody);
+
+  fctx.body.push({ op: "local.get", index: findResTmp });
+  return ctx.fast ? elemType : { kind: "f64" };
+}
+
+/**
+ * arr.findLastIndex(cb) -> reverse-iterate, return index (f64/i32) of the last
+ * element whose callback result is truthy, else -1. Mirror of compileArrayFindIndex
+ * but reverse-iterating (§23.1.3.13).
+ */
+function compileArrayFindLastIndex(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  if (emitCallbackTypeCheck(ctx, fctx, callExpr, "Array.prototype.findLastIndex")) {
+    fctx.body.push({ op: "unreachable" });
+    return { kind: "i32" };
+  }
+
+  const setup = setupArrayCallback(ctx, fctx, callExpr, "findLastIndex", "fli");
+  if (!setup) return null;
+
+  const loop = setupArrayLoopReverse(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "fli");
+
+  const callAndCheck = buildCallAndCheck(
+    ctx,
+    fctx,
+    setup,
+    elemType,
+    vecTypeIdx,
+    arrTypeIdx,
+    loop,
+    { kind: "inline" },
+    "truthy",
+  );
+
+  const fliResType: ValType = ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  const fliResTmp = allocLocal(fctx, `__arr_fli_res_${fctx.locals.length}`, fliResType);
+  if (ctx.fast) {
+    fctx.body.push({ op: "i32.const", value: -1 });
+  } else {
+    fctx.body.push({ op: "f64.const", value: -1 });
+  }
+  fctx.body.push({ op: "local.set", index: fliResTmp });
+
+  const loopBody: Instr[] = [
+    ...loopExitCheckReverse(loop),
+
+    ...callAndCheck,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: loop.iTmp } as Instr,
+        ...(ctx.fast ? [] : [{ op: "f64.convert_i32_s" } as Instr]),
+        { op: "local.set", index: fliResTmp } as Instr,
+        { op: "br", depth: 2 } as Instr,
+      ],
+    } as Instr,
+
+    ...loopDecrement(loop),
+  ];
+
+  emitArrayLoop(fctx, loopBody);
+
+  fctx.body.push({ op: "local.get", index: fliResTmp });
   return ctx.fast ? { kind: "i32" } : { kind: "f64" };
 }
 

--- a/tests/issue-1136-findlast.test.ts
+++ b/tests/issue-1136-findlast.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #1136 residual: Array.prototype.findLast / findLastIndex were absent from the
+// array-method dispatch (no method-list entry, no compile case) even though the
+// runtime callback-arity table already knew them — so `arr.findLast(cb)` fell
+// through to a non-native path and produced wrong results. They are now native
+// reverse-iteration mirrors of find/findIndex (§23.1.3.12 / §23.1.3.13).
+//
+// Uses the compiler's own importObject (default JS-host mode) so the closure
+// call_ref bridges for the predicate are wired exactly as production callers see.
+async function runNumber(src: string): Promise<number> {
+  const r = await compile(src, { skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject = (r as unknown as { importObject?: WebAssembly.Imports }).importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#1136 Array.prototype.findLast / findLastIndex", () => {
+  it("findLast returns the LAST element passing the predicate (not the first)", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [1, 2, 3, 4];
+          return a.findLast((x: number): boolean => x % 2 === 1);
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("findLast returns undefined (NaN) when no element matches", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [2, 4, 6];
+          const v = a.findLast((x: number): boolean => x % 2 === 1);
+          return Number.isNaN(v) ? -99 : (v as number);
+        }
+      `),
+    ).toBe(-99);
+  });
+
+  it("findLastIndex returns the index of the LAST match", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [1, 2, 3, 4];
+          return a.findLastIndex((x: number): boolean => x % 2 === 1);
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("findLastIndex returns -1 when no element matches", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [2, 4, 6];
+          return a.findLastIndex((x: number): boolean => x % 2 === 1);
+        }
+      `),
+    ).toBe(-1);
+  });
+
+  it("findLast on a single-element array returns that element when it matches", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [7];
+          return a.findLast((x: number): boolean => x > 0);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("does not regress find/findIndex (forward iteration still returns first match)", async () => {
+    expect(
+      await runNumber(`
+        export function f(): number {
+          const a: number[] = [1, 2, 3, 4];
+          return a.find((x: number): boolean => x % 2 === 1) * 10 + a.findIndex((x: number): boolean => x % 2 === 1);
+        }
+      `),
+    ).toBe(10); // find→1, findIndex→0  =>  1*10 + 0
+  });
+});


### PR DESCRIPTION
## fix(#1136): native Array.prototype.findLast / findLastIndex

`Array.prototype.findLast` / `findLastIndex` were **absent from the array-method
dispatch** in `array-methods.ts` — not in the `ARRAY_METHODS` set and no compile
case — so `arr.findLast(cb)` fell through to a non-native path and produced wrong
results. (The runtime callback-arity table at `runtime.ts:1570-1571` already knew
them, but nothing routed to it.)

### Fix (array-methods.ts, dev-lane, no object-runtime.ts)
- `compileArrayFindLast` / `compileArrayFindLastIndex` — reverse-iteration mirrors
  of `compileArrayFind` / `compileArrayFindIndex` (§23.1.3.12 / §23.1.3.13).
- `setupArrayLoopReverse` starts the cursor at `len-1`; `loopExitCheckReverse`
  breaks at `i < 0`; `loopDecrement` steps `i--`. Same `buildCallAndCheck` closure
  `call_ref` machinery + f64/i32 result conventions as the forward variants.
- Added `findLast`/`findLastIndex` to `ARRAY_METHODS` + dispatch cases.
- `findLast` returns the last truthy-callback element (undefined→NaN when none);
  `findLastIndex` returns its index (-1 when none). `find`/`findIndex` unchanged.

### Tests
`tests/issue-1136-findlast.test.ts` — 6 cases (last-match, no-match, index, single-elem,
find/findIndex non-regression), all passing. tsc clean, IR fallback gate OK.

### Recon notes (for the stale-issue reconciliation)
- #1136 was marked `status: done` but `findLast`/`findLastIndex` were never wired;
  `flat`/`flatMap` ARE wired (JS-host-delegated via `__array_flat`/`__array_flatMap`
  in runtime.ts) and work in the real test262 host harness.
- `tests/functional-array-methods.test.ts` is **broken on main** (stale env harness:
  missing `string_constants` import + no `skipSemanticDiagnostics`) — 23/24 fail
  WITHOUT this change. New tests therefore use the compiler's own importObject pattern.
- Separately observed (NOT in this PR): default `[10,2,1].sort()` sorts numerically,
  not lexicographically — #1816's default-ToString-compare residual. Flagging for a
  follow-up; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
