### PR TITLE
fix(#1902 / #1888 S6-c): Math/Number constants reach native f64.const under standalone

### DIFF
--- a/plan/issues/1902-s6c-math-number-constants-standalone.md
+++ b/plan/issues/1902-s6c-math-number-constants-standalone.md
@@ -1,0 +1,87 @@
+---
+id: 1902
+title: "Math/Number constant reads refuse under --target standalone (__get_builtin pre-empts native f64.const) [#1888 S6-c]"
+status: done
+created: 2026-06-05
+updated: 2026-06-05
+completed: 2026-06-05
+priority: high
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: builtin-property-access
+goal: standalone-mode
+sprint: 61
+---
+# #1888 S6-c — Math/Number constants reach native f64.const under standalone
+
+## Symptom (sd-s2 S6 recon 2026-06-05)
+
+Under `--target standalone`, reading a Math or Number constant fails to compile:
+
+```ts
+export function run(): number { return Math.PI; }            // Codegen error: '__get_builtin' … not supported
+export function run(): number { return Number.MAX_SAFE_INTEGER; } // same
+export function run(): number { return Math.PI * 2; }        // same
+```
+
+`Math.abs(-5)` (a method **call**) works — that's a separate call-site path. Only
+the `Builtin.<constant>` **property-read-as-value** path refuses.
+
+## Root cause
+
+`src/codegen/property-access.ts` has a generic `Builtin.prop` shortcut (the
+`BUILTIN_CTOR_NAMES` block, ~line 1478) that calls
+`ensureLateImport(ctx, "__get_builtin", …)`. Under standalone, `__get_builtin`
+is NOT in `OBJECT_RUNTIME_HELPER_NAMES`, so it hits the
+`refuseStandaloneObjectImport` gate and fails-loud. That shortcut sits **above**
+the pure-Wasm `f64.const` handlers for Math constants (`PI`/`E`/…, ~line 2299)
+and Number constants (`MAX_SAFE_INTEGER`/…, ~line 2317) — so those handlers were
+**dead code under standalone**. A program that has a perfectly good native
+`f64.const` lowering was turned into a hard compile refusal.
+
+(The earlier S6a recon concluded these were "already native" — that was true for
+gc/host, where `__get_builtin` is a real host import that resolves. On the
+standalone lane we actually measure, they were broken.)
+
+## Fix (delivered — option: defer to native constant emitter)
+
+`src/codegen/property-access.ts`:
+- Added `hasNativeBuiltinConstantHandler(builtinName, propName)` — true for the
+  Math/Number f64 constants that have a downstream `f64.const` emitter.
+- Gated the `__get_builtin` shortcut: under `ctx.standalone`, when the read is a
+  native constant, skip the shortcut so control reaches the `f64.const` handler
+  (`const deferToNativeConstant = ctx.standalone && hasNativeBuiltinConstantHandler(...)`).
+
+**Scope:** Math/Number f64 constants only. `Symbol.<wellKnown>` also has a
+downstream emitter (an `i32.const` symbol id) but its i32 result does not yet
+compose with every consumer under standalone — e.g. `Symbol.iterator !== undefined`
+would compare i32 against an externref `undefined` → **invalid Wasm**. Leaving
+the shortcut to keep refusing-loud for Symbol is strictly safer (refuse-loud >
+silent-wrong); native Symbol value-reads are deferred to **S6-b**.
+
+## Acceptance (all met)
+
+- `Math.PI` → 3.141592653589793, `Math.E + Math.SQRT2`, `Number.MAX_SAFE_INTEGER`,
+  `Number.EPSILON`, `Math.PI * 2` all compile + run correctly under standalone,
+  module `valid=true`, zero `env::__get_builtin` leak.
+- `typeof Math.PI === "number"` still holds (typeof path unaffected).
+- gc/host + wasi byte-unchanged (gate is `ctx.standalone`-only; wasi is not
+  standalone, so it keeps its existing — separately-tracked — `__get_builtin`
+  behavior).
+- Guardrail: genuine `Builtin.method` value-reads (Array.isArray, Object.keys,
+  JSON.stringify, Reflect.has, String.fromCharCode) still refuse-loud — S6-c
+  does NOT widen to non-constant builtin reads (those are the S6-b lever).
+- Test: `tests/issue-1888-s6c.test.ts` (7 cases).
+
+## Follow-on
+
+**S6-b** — the real builtins-as-static-globals layer: make `Builtin.staticMethod`
+value-reads (and Symbol well-knowns) resolve to native `$Object`/vtable globals
+under standalone instead of refusing. S6-c is the constant-only prerequisite
+slice that de-risks the reorder and fixes a standalone bug today.
+
+## Owner / lane
+
+sd-s2 — property-access.ts builtin lane. Disjoint from #1901 (literals.ts) — no
+merge conflict.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -86,6 +86,53 @@ function getWellKnownSymbolId(name: string): number | undefined {
 }
 
 /**
+ * (#1888 S6-c) Math/Number constant property names that have a Wasm-native
+ * fall-through emitter further down in `compileMemberRead` (the `f64.const`
+ * handlers for `Math.PI` / `Number.MAX_SAFE_INTEGER` & co.). These MUST be
+ * reachable: under `--target standalone` the generic `Builtin.prop` →
+ * `__get_builtin` branch above them refuses-loud (the open-object runtime does
+ * not expose `__get_builtin`), so without an exclusion `Math.PI` etc. fail to
+ * compile even though a pure-Wasm `f64.const` lowering exists. Keep this set in
+ * sync with the `mathConstants` / `numberConstants` tables below (the single
+ * source of truth is those tables; this mirror only decides whether the
+ * `__get_builtin` shortcut must yield to them). Symbol well-knowns
+ * (`Symbol.iterator` etc.) are covered separately via `getWellKnownSymbolId`.
+ */
+const MATH_CONSTANT_PROPS = new Set(["PI", "E", "LN2", "LN10", "SQRT2", "SQRT1_2", "LOG2E", "LOG10E"]);
+const NUMBER_CONSTANT_PROPS = new Set([
+  "EPSILON",
+  "MAX_SAFE_INTEGER",
+  "MIN_SAFE_INTEGER",
+  "MAX_VALUE",
+  "MIN_VALUE",
+  "POSITIVE_INFINITY",
+  "NEGATIVE_INFINITY",
+  "NaN",
+]);
+
+/**
+ * True when `<builtinName>.<propName>` has a Wasm-native **f64 constant**
+ * emitter downstream in `compileMemberRead` that the `__get_builtin` shortcut
+ * must not pre-empt. Keeps the standalone path host-import-free for the
+ * numeric-constant reads we can already lower natively (Math.PI →
+ * `f64.const`, Number.MAX_SAFE_INTEGER → `f64.const`).
+ *
+ * Scoped to Math/Number f64 constants ONLY. `Symbol.<wellKnown>` also has a
+ * downstream emitter (an `i32.const` symbol id), but that i32 result does not
+ * yet compose safely with every consumer under standalone — e.g.
+ * `Symbol.iterator !== undefined` would compare an i32 against an externref
+ * `undefined`, producing **invalid Wasm**. Leaving the `__get_builtin` shortcut
+ * to keep refusing-loud for Symbol is strictly safer than emitting an invalid
+ * module (refuse-loud > silent-wrong); native Symbol value-reads are deferred
+ * to the S6-b builtins-as-globals lever.
+ */
+function hasNativeBuiltinConstantHandler(builtinName: string, propName: string): boolean {
+  if (builtinName === "Math") return MATH_CONSTANT_PROPS.has(propName);
+  if (builtinName === "Number") return NUMBER_CONSTANT_PROPS.has(propName);
+  return false;
+}
+
+/**
  * (#1337) True when `expr` is the syntactic shape `<receiver>.bind(...)`.
  */
 function isDirectBindCall(expr: ts.Expression): boolean {
@@ -1474,7 +1521,17 @@ export function compilePropertyAccess(
       "BigUint64Array",
     ]);
     const isShadowed = fctx.localMap.has(builtinName) || (fctx.boxedCaptures?.has(builtinName) ?? false);
-    if (BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed) {
+    // (#1888 S6-c) Under --target standalone, `__get_builtin` refuses-loud (the
+    // open-object runtime does not expose it). For builtin constant reads that
+    // already have a pure-Wasm fall-through emitter below (Math.PI →
+    // `f64.const`, Number.MAX_SAFE_INTEGER → `f64.const`, Symbol.iterator →
+    // `i32.const`), this shortcut would pre-empt that native lowering and turn a
+    // compilable program into a hard refusal. Skip it for those (builtin, prop)
+    // pairs so control reaches the constant emitter. gc/host is unaffected
+    // (`__get_builtin` is a real host import there and the early shortcut +
+    // the later constant handler are observationally identical for these reads).
+    const deferToNativeConstant = ctx.standalone && hasNativeBuiltinConstantHandler(builtinName, propName);
+    if (BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed && !deferToNativeConstant) {
       const getBuiltinIdx = ensureLateImport(ctx, "__get_builtin", [{ kind: "externref" }], [{ kind: "externref" }]);
       const getIdx = ensureLateImport(
         ctx,

--- a/tests/issue-1888-s6c.test.ts
+++ b/tests/issue-1888-s6c.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1888 S6-c — Math/Number constant reads must reach their native f64.const
+ * emitter under `--target standalone`.
+ *
+ * Defect: the generic `Builtin.prop` → `__get_builtin` shortcut in
+ * property-access.ts fires for ANY builtin-constructor identifier and, under
+ * standalone, refuses-loud (the open-object runtime does not expose
+ * `__get_builtin`). It sits ABOVE the pure-Wasm `f64.const` handlers for
+ * `Math.PI` / `Number.MAX_SAFE_INTEGER` & co., so those handlers were dead code
+ * under standalone — `Math.PI` failed to compile even though a native lowering
+ * exists. S6-c gates the shortcut to defer to the native constant emitter for
+ * Math/Number f64 constants under standalone.
+ *
+ * Behaviour assertions: correct value + zero host imports + valid module.
+ * Symbol well-knowns are intentionally NOT covered here (their i32-const result
+ * does not yet compose with every consumer — see hasNativeBuiltinConstantHandler).
+ */
+
+const BANNED = [/^env::__get_builtin/, /^env::__extern_/, /^env::__object_/, /^env::__new_plain_object/];
+function assertNoHostObjectImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of BANNED) {
+    const hits = labels.filter((l) => re.test(l));
+    expect(hits, `--target standalone leaked ${re} (got ${hits.join(", ")})`).toEqual([]);
+  }
+}
+type NumExports = Record<string, () => number>;
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoHostObjectImports(r.imports);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as NumExports).run();
+}
+
+describe("#1888 S6-c — Math/Number constants reach native f64.const under standalone", () => {
+  it("Math.PI returns 3.141592653589793 (was a __get_builtin refusal)", async () => {
+    expect(await runStandalone(`export function run(): number { return Math.PI; }`)).toBe(Math.PI);
+  });
+
+  it("Math.E and Math.SQRT2 are native", async () => {
+    expect(await runStandalone(`export function run(): number { return Math.E + Math.SQRT2; }`)).toBe(
+      Math.E + Math.SQRT2,
+    );
+  });
+
+  it("Number.MAX_SAFE_INTEGER is native", async () => {
+    expect(await runStandalone(`export function run(): number { return Number.MAX_SAFE_INTEGER; }`)).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("Number.EPSILON is native", async () => {
+    expect(await runStandalone(`export function run(): number { return Number.EPSILON; }`)).toBe(Number.EPSILON);
+  });
+
+  it("Math.PI composes in arithmetic (Math.PI * 2)", async () => {
+    expect(await runStandalone(`export function run(): number { return Math.PI * 2; }`)).toBe(Math.PI * 2);
+  });
+
+  it("typeof Math.PI === 'number' (typeof path unaffected, still works)", async () => {
+    expect(await runStandalone(`export function run(): number { return typeof Math.PI === "number" ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("guardrail: genuine Builtin.method value-read (Array.isArray) still refuses-loud (S6-b lever, not S6-c)", async () => {
+    const r = await compile(`export function run(): number { const f: any = Array.isArray; return f([1]) ? 1 : 0; }`, {
+      target: "standalone",
+    });
+    // S6-c must NOT accidentally widen to non-constant builtin reads; those stay
+    // refused until S6-b lands. (A clean compile error, not invalid Wasm.)
+    expect(r.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## #1888 S6-c (tracked as #1902) — Math/Number constants refuse under `--target standalone`

### Problem
Under `--target standalone`, reading a Math or Number constant fails to **compile**:

```ts
export function run(): number { return Math.PI; }                 // Codegen error: '__get_builtin' … not supported
export function run(): number { return Number.MAX_SAFE_INTEGER; } // same
export function run(): number { return Math.PI * 2; }            // same
```

`Math.abs(-5)` (a method **call**) works — separate call-site path. Only the `Builtin.<constant>` property-read-as-value path refuses.

### Root cause
`src/codegen/property-access.ts` has a generic `Builtin.prop` → `__get_builtin` shortcut (the `BUILTIN_CTOR_NAMES` block) that fires for any builtin-constructor identifier. Under standalone, `__get_builtin` is not in `OBJECT_RUNTIME_HELPER_NAMES`, so it hits the refuse-loud gate. That shortcut sits **above** the pure-Wasm `f64.const` Math/Number-constant handlers — making them **dead code** under standalone. A program with a perfectly good native lowering became a hard refusal.

(The earlier S6a "already native" conclusion held for gc/host, where `__get_builtin` is a real host import. On the standalone lane we measure, they were broken.)

### Fix
- `hasNativeBuiltinConstantHandler(builtinName, propName)` — true for Math/Number f64 constants.
- Gate the shortcut: `deferToNativeConstant = ctx.standalone && hasNativeBuiltinConstantHandler(...)` → fall through to the `f64.const` emitter.

### Scope (deliberate)
Math/Number f64 constants **only**. `Symbol.<wellKnown>` also has a downstream emitter (`i32.const` symbol id) but its i32 result doesn't yet compose with every consumer under standalone (e.g. `Symbol.iterator !== undefined` would compare i32 vs externref `undefined` → **invalid Wasm**). Keeping the shortcut refusing-loud for Symbol is strictly safer than invalid Wasm; native Symbol / `Builtin.staticMethod` value-reads are the **S6-b** follow-on.

### Validation
`tests/issue-1888-s6c.test.ts` (7): Math.PI→3.141592653589793, Math.E+SQRT2, Number.MAX_SAFE_INTEGER, Number.EPSILON, Math.PI*2, `typeof Math.PI==="number"`, + guardrail that `Array.isArray`-as-value still refuses-loud. tsc clean; `biome lint src tests scripts --diagnostic-level=error` exit 0; `issue-1472` standalone suite 60/60. gc/host + wasi byte-unchanged (gate is `ctx.standalone`-only). The 6 pre-existing `math-inline.test.ts` failures + `helpers.js` suite-load errors reproduce identically on origin/main (unrelated infra/gc-host gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)