### PR TITLE
test(ci): cover standalone test262 regression gate

### DIFF
--- a/plan/issues/1897-ci-standalone-regression-gate.md
+++ b/plan/issues/1897-ci-standalone-regression-gate.md
@@ -10,6 +10,9 @@ priority: high
 feasibility: hard
 created: 2026-06-05
 owner: sd-ci-gate
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:10:00.109Z
+updated: 2026-06-06
 ---
 
 # ci: gate merges on standalone test262 regression
@@ -147,3 +150,24 @@ This gate pins the *current* standalone baseline floor. It is safe to land
 while standalone is below target as long as the regression that dropped it
 to 24.76% has been restored first (sd-1888), so the floor it holds is the
 restored value. The gate never blocks an improving PR.
+
+## Codex implementation note
+
+2026-06-06: Verified the standalone guard is wired inside the required
+`merge shard reports` job and added `tests/issue-1897.test.ts` to lock the CI
+contract:
+
+- guard order: after the merged standalone report is built, before stale
+  baseline validation;
+- guard inputs: `test262-standalone-current.jsonl` vs
+  `test262-standalone-results-merged.jsonl`;
+- guard decision: `improvements - wasm-changing regressions` with
+  `compile_timeout` counted only as excluded flake; and
+- policy docs / branch-protection script: standalone rides the existing
+  `merge shard reports` required context, so no new required check is needed.
+
+Scoped validation:
+
+- `pnpm test tests/issue-1897.test.ts`
+- `pnpm exec biome lint tests/issue-1897.test.ts --diagnostic-level=error`
+- `pnpm exec prettier --check tests/issue-1897.test.ts`

--- a/plan/issues/1897-ci-standalone-regression-gate.md
+++ b/plan/issues/1897-ci-standalone-regression-gate.md
@@ -2,7 +2,7 @@
 id: 1897
 slug: ci-standalone-regression-gate
 title: "Gate merges on standalone test262 regression"
-status: in-progress
+status: in-review
 sprint: 60
 goal: standalone-mode
 area: ci
@@ -13,6 +13,7 @@ owner: sd-ci-gate
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:10:00.109Z
 updated: 2026-06-06
+pr: 1245
 ---
 
 # ci: gate merges on standalone test262 regression

--- a/tests/issue-1897.test.ts
+++ b/tests/issue-1897.test.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname ?? ".", "..");
+
+function readRepo(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function standaloneGuardBlock(): string {
+  const workflow = readRepo(".github/workflows/test262-sharded.yml");
+  const start = workflow.indexOf("- name: Standalone regression guard (#1897)");
+  const end = workflow.indexOf("- name: Stale-baseline guard (#1668)", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workflow.slice(start, end);
+}
+
+function writeJsonl(path: string, entries: unknown[]) {
+  writeFileSync(path, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n");
+}
+
+describe("#1897 standalone test262 merge gate", () => {
+  it("runs inside the required merge-report job after the standalone report is built", () => {
+    const workflow = readRepo(".github/workflows/test262-sharded.yml");
+    const standaloneReport = workflow.indexOf("- name: Build merged standalone test262 report");
+    const standaloneGuard = workflow.indexOf("- name: Standalone regression guard (#1897)");
+    const staleGuard = workflow.indexOf("- name: Stale-baseline guard (#1668)");
+
+    expect(standaloneReport).toBeGreaterThanOrEqual(0);
+    expect(standaloneGuard).toBeGreaterThan(standaloneReport);
+    expect(staleGuard).toBeGreaterThan(standaloneGuard);
+
+    const mergeReportJob = workflow.slice(workflow.indexOf("merge-report:"), workflow.indexOf("  regression-gate:"));
+    expect(mergeReportJob).toContain("name: merge shard reports");
+    expect(mergeReportJob).toContain("- name: Standalone regression guard (#1897)");
+  });
+
+  it("diffs the merged standalone JSONL against the standalone baseline with no extra shard run", () => {
+    const guard = standaloneGuardBlock();
+
+    expect(guard).toContain("if: env.SHARDS_RAN == 'true'");
+    expect(guard).toContain('STANDALONE_REGRESSION_TOLERANCE: "15"');
+    expect(guard).toContain("/tmp/cat-baselines/test262-standalone-current.jsonl");
+    expect(guard).toContain("merged-reports/test262-standalone-results-merged.jsonl");
+    expect(guard).toContain("No standalone baseline JSONL available");
+    expect(guard).toContain("standalone merged JSONL missing/empty");
+    expect(guard).not.toContain("node node_modules/vitest/dist/cli.js run");
+  });
+
+  it("gates on improvements minus wasm-changing regressions, with compile_timeout only reported as excluded flake", () => {
+    const guard = standaloneGuardBlock();
+
+    expect(guard).toContain("diff_exit");
+    expect(guard).toContain('if [ "$diff_exit" -gt 1 ]; then');
+    expect(guard).toContain("Regressions with wasm-hash change: [0-9]+");
+    expect(guard).toContain("Improvements \\(other \u2192 pass\\): [0-9]+");
+    expect(guard).toContain("Compile timeouts \\(pass \u2192 compile_timeout\\): [0-9]+");
+    expect(guard).toContain("NET=$((IMP - REG))");
+    expect(guard).toContain('if [ "$NET" -lt "$((0 - STANDALONE_REGRESSION_TOLERANCE))" ]; then');
+    expect(guard).toContain("STANDALONE test262 regression");
+  });
+
+  it("documents that standalone rides the existing required check, not a new branch-protection context", () => {
+    const policy = readRepo("docs/ci-policy.md");
+    const branchProtection = readRepo("scripts/enable-branch-protection.sh");
+
+    expect(policy).toContain("Standalone regression guard (#1897)");
+    expect(policy).toContain("no branch-protection change is needed");
+    expect(branchProtection).toContain("NO new entry here and NO branch-protection re-apply");
+    expect(branchProtection).toContain('"merge shard reports"');
+    expect(branchProtection).not.toContain('"standalone regression guard"');
+  });
+
+  it("diff-test262 emits the flake-filtered counts consumed by the standalone guard", () => {
+    const dir = mkdtempSync(join(tmpdir(), "issue-1897-diff-"));
+    try {
+      const baseline = join(dir, "baseline.jsonl");
+      const candidate = join(dir, "candidate.jsonl");
+      writeJsonl(baseline, [
+        { file: "real-regression.js", status: "pass", wasm_sha: "aaaaaaaaaaaa" },
+        { file: "real-improvement.js", status: "compile_error", wasm_sha: null },
+        { file: "timeout-flake.js", status: "pass", wasm_sha: "cccccccccccc" },
+        { file: "same-wasm-noise.js", status: "pass", wasm_sha: "dddddddddddd" },
+      ]);
+      writeJsonl(candidate, [
+        { file: "real-regression.js", status: "compile_error", error_category: "wasm_compile", wasm_sha: null },
+        { file: "real-improvement.js", status: "pass", wasm_sha: "bbbbbbbbbbbb" },
+        { file: "timeout-flake.js", status: "compile_timeout", wasm_sha: null },
+        { file: "same-wasm-noise.js", status: "fail", wasm_sha: "dddddddddddd" },
+      ]);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--experimental-strip-types", "scripts/diff-test262.ts", baseline, candidate, "--quiet"],
+        { cwd: ROOT, encoding: "utf-8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("=== Improvements (other \u2192 pass): 1 ===");
+      expect(result.stdout).toContain("=== Compile timeouts (pass \u2192 compile_timeout): 1 ===");
+      expect(result.stdout).toContain("=== Wasm-identical noise (pass \u2192 other, same wasm_sha): 1 ===");
+      expect(result.stdout).toContain("=== Regressions with wasm-hash change: 1 ===");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused #1897 coverage for the standalone test262 guard inside the required `merge shard reports` check.
- Lock the guard ordering, standalone baseline/candidate inputs, net-regression tolerance parsing, and branch-protection policy note.
- Exercise `diff-test262.ts` with synthetic JSONL to verify compile-timeout and wasm-identical flips are excluded from the guard's regression count.

## Validation

- `pnpm test tests/issue-1897.test.ts`
- `pnpm exec biome lint tests/issue-1897.test.ts --diagnostic-level=error`
- `pnpm exec prettier --check tests/issue-1897.test.ts`
- pre-push hook: typecheck, lint, format check, issue integrity
