### PR TITLE
fix(generators): resume native yields through finally

### DIFF
--- a/plan/issues/1346-spec-gap-yield-in-try-finally.md
+++ b/plan/issues/1346-spec-gap-yield-in-try-finally.md
@@ -1,7 +1,7 @@
 ---
 id: 1346
 title: "spec gap: yield in nested try/finally + yield expression evaluation order (46 test262 fails)"
-status: in-progress
+status: in-review
 created: 2026-05-08
 updated: 2026-06-06
 priority: medium
@@ -16,6 +16,7 @@ parent: 1328
 related: [1665, 1042, 1620, 1320]
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:10:15.635Z
+pr: 1246
 ---
 # #1346 — yield expression: try/finally + evaluation order
 

--- a/plan/issues/1346-spec-gap-yield-in-try-finally.md
+++ b/plan/issues/1346-spec-gap-yield-in-try-finally.md
@@ -1,9 +1,9 @@
 ---
 id: 1346
 title: "spec gap: yield in nested try/finally + yield expression evaluation order (46 test262 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-06-06
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -14,6 +14,8 @@ goal: spec-completeness
 sprint: 60
 parent: 1328
 related: [1665, 1042, 1620, 1320]
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:10:15.635Z
 ---
 # #1346 — yield expression: try/finally + evaluation order
 
@@ -265,3 +267,42 @@ yield suspends, so the partial results survive the suspension).
 > Slice 0 belongs to a **senior-dev** as a design task, not a routine dev pickup.
 > The other four sprint-59 specs (#1818/#1644/#1320/#1348/#6407) are
 > dev-claimable; this one should be senior-dev-gated on Slice 0 first.
+
+## Implementation Update — 2026-06-06
+
+Implemented the first suspendable-generator slice on the existing
+`generators-native.ts` substrate, following ECMA-262 2026 §15.5.5
+(`YieldExpression`) and §27.5.3.4/§27.5.3.6 (`GeneratorResumeAbrupt` /
+`GeneratorYield`):
+
+- Added native generator state fields for `sent`, `mode`, and `abrupt` values.
+- Added state-struct spill slots for simple `const x = yield n` bindings so
+  `.next(value)` becomes the yield expression result after resumption.
+- Taught `.next(value)` to store the sent value before calling the resume
+  function.
+- Taught `.return(value)` to resume suspended-yield states with
+  `mode=return`; suspended-start and completed states still complete
+  immediately.
+- Added simple `try/finally` planning for non-yielding finalizers so a
+  `.return(value)` from a yield inside `try` runs pending `finally` statements
+  before completing.
+
+Scope intentionally remains native-generator-only (`standalone` / `wasi`) and
+numeric-yield-only. The eager JS-host buffer path still cannot satisfy the full
+test262 cluster because it has no real suspension point. Remaining full-issue
+work:
+
+- `yield*` delegation forwarding (`return`/`throw`) is still not implemented.
+- `throw()` injection is still not implemented for native generators.
+- Yield operands inside arbitrary call/array expressions still need the broader
+  expression-spill lowering described in Slice C.
+- Full `language/expressions/yield` pass-rate was not rerun locally; this
+  workspace's `test262/` directory is empty, and the task rules prohibit full
+  local test262.
+
+Focused validation added in `tests/issue-1346.test.ts`:
+
+- `.next(value)` feeds sequential `yield` expression results.
+- `.return(value)` at a yield inside `try` runs the pending `finally`.
+- Normal resume after a yield inside `try` runs `finally`.
+- `.return(value)` before the first `.next()` does not enter the generator body.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -144,6 +144,16 @@ export interface NativeGeneratorInfo {
   paramTypes: ValType[];
   /** Field index where captured params start in the state struct. */
   paramFieldOffset: number;
+  /** Field index for the value passed to `.next(value)`. */
+  sentFieldIdx: number;
+  /** Field index for resume mode: 0 = next, 1 = return. */
+  modeFieldIdx: number;
+  /** Field index for the value passed to `.return(value)`. */
+  abruptFieldIdx: number;
+  /** Function-local names spilled into the state struct across suspensions. */
+  spillNames: string[];
+  /** Field index where spilled locals start in the state struct. */
+  spillFieldOffset: number;
   /** Number of top-level yield suspension points. */
   yieldCount: number;
   /** Terminal state value. */

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -18,15 +18,27 @@ import { addFuncType } from "./registry/types.js";
 import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
 
 const STATE_FIELD = 0;
+const SENT_FIELD = 1;
+const MODE_FIELD = 2;
+const ABRUPT_FIELD = 3;
 const RESULT_VALUE_FIELD = 0;
 const RESULT_DONE_FIELD = 1;
-const PARAM_FIELD_OFFSET = 1;
+const PARAM_FIELD_OFFSET = 4;
 const MAX_NATIVE_GENERATOR_STATES = 256;
 
 interface NativeGeneratorSegment {
+  resumeBindings: string[];
+  abruptResume?: {
+    finalizers: readonly ts.Statement[][];
+  };
   statements: ts.Statement[];
   yieldExpr?: ts.YieldExpression;
   returnStmt?: ts.ReturnStatement;
+}
+
+interface NativeGeneratorPlan {
+  segments: NativeGeneratorSegment[];
+  spills: string[];
 }
 
 function noJsHostTarget(ctx: CodegenContext): boolean {
@@ -57,50 +69,128 @@ function statementContainsYield(stmt: ts.Statement): boolean {
   return found;
 }
 
-function buildNativeGeneratorSegments(
-  ctx: CodegenContext,
-  decl: ts.FunctionDeclaration,
-): NativeGeneratorSegment[] | null {
+function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclaration): NativeGeneratorPlan | null {
   if (!decl.body) return null;
   const segments: NativeGeneratorSegment[] = [];
+  const spills: string[] = [];
+  const spillSet = new Set<string>();
   let current: ts.Statement[] = [];
+  let pendingResumeBindings: string[] = [];
+  let pendingAbruptResume: NativeGeneratorSegment["abruptResume"] | undefined;
 
-  for (const stmt of decl.body.statements) {
-    if (stmt.kind === ts.SyntaxKind.EmptyStatement) continue;
+  const addSpill = (name: string): void => {
+    if (spillSet.has(name)) return;
+    spillSet.add(name);
+    spills.push(name);
+  };
 
-    if (ts.isExpressionStatement(stmt) && ts.isYieldExpression(stmt.expression)) {
-      const yieldExpr = stmt.expression;
-      if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return null;
-      segments.push({ statements: current, yieldExpr });
-      current = [];
-      continue;
+  const pushSegment = (yieldExpr: ts.YieldExpression | undefined, returnStmt: ts.ReturnStatement | undefined): void => {
+    segments.push({
+      resumeBindings: pendingResumeBindings,
+      abruptResume: pendingAbruptResume,
+      statements: current,
+      yieldExpr,
+      returnStmt,
+    });
+    pendingResumeBindings = [];
+    pendingAbruptResume = undefined;
+    current = [];
+  };
+
+  const emitYieldSegment = (
+    yieldExpr: ts.YieldExpression,
+    bindSentTo: string | undefined,
+    activeFinalizers: readonly ts.Statement[][],
+  ): boolean => {
+    if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return false;
+    pushSegment(yieldExpr, undefined);
+    pendingAbruptResume = {
+      // GeneratorResumeAbrupt resumes at the suspended yield with a return
+      // completion. Any enclosing finally blocks run nearest-first.
+      finalizers: [...activeFinalizers].reverse(),
+    };
+    if (bindSentTo) {
+      addSpill(bindSentTo);
+      pendingResumeBindings = [bindSentTo];
     }
+    return true;
+  };
 
-    if (ts.isReturnStatement(stmt)) {
-      if (!isNumericExpression(ctx, stmt.expression)) return null;
-      segments.push({ statements: current, returnStmt: stmt });
-      current = [];
-      break;
+  const tryYieldDeclaration = (stmt: ts.Statement): { name: string; yieldExpr: ts.YieldExpression } | null => {
+    if (!ts.isVariableStatement(stmt)) return null;
+    if (stmt.declarationList.declarations.length !== 1) return null;
+    const declStmt = stmt.declarationList.declarations[0]!;
+    if (!ts.isIdentifier(declStmt.name)) return null;
+    if (!declStmt.initializer || !ts.isYieldExpression(declStmt.initializer)) return null;
+    return { name: declStmt.name.text, yieldExpr: declStmt.initializer };
+  };
+
+  const statementsAreYieldFree = (statements: readonly ts.Statement[]): boolean =>
+    statements.every((stmt) => !statementContainsYield(stmt));
+
+  const visitStatements = (
+    statements: readonly ts.Statement[],
+    activeFinalizers: readonly ts.Statement[][],
+  ): boolean => {
+    for (const stmt of statements) {
+      if (stmt.kind === ts.SyntaxKind.EmptyStatement) continue;
+
+      if (ts.isExpressionStatement(stmt) && ts.isYieldExpression(stmt.expression)) {
+        if (!emitYieldSegment(stmt.expression, undefined, activeFinalizers)) return false;
+        continue;
+      }
+
+      const yieldedDeclaration = tryYieldDeclaration(stmt);
+      if (yieldedDeclaration) {
+        if (!emitYieldSegment(yieldedDeclaration.yieldExpr, yieldedDeclaration.name, activeFinalizers)) return false;
+        continue;
+      }
+
+      if (ts.isTryStatement(stmt)) {
+        if (stmt.catchClause || !stmt.finallyBlock) return false;
+        if (!statementsAreYieldFree(stmt.finallyBlock.statements)) return false;
+        if (!visitStatements(stmt.tryBlock.statements, [...activeFinalizers, [...stmt.finallyBlock.statements]])) {
+          return false;
+        }
+        current.push(...stmt.finallyBlock.statements);
+        continue;
+      }
+
+      if (ts.isReturnStatement(stmt)) {
+        if (statementContainsYield(stmt) || !isNumericExpression(ctx, stmt.expression)) return false;
+        pushSegment(undefined, stmt);
+        current = [];
+        break;
+      }
+
+      // Phase 1 allows ordinary expression statements in a segment so side
+      // effects before a yield stay lazy. Declarations/control flow need spill
+      // analysis and are left to follow-up phases.
+      if (ts.isExpressionStatement(stmt) && !statementContainsYield(stmt)) {
+        current.push(stmt);
+        continue;
+      }
+
+      return false;
     }
+    return true;
+  };
 
-    // Phase 1 allows ordinary expression statements in a segment so side
-    // effects before a yield stay lazy. Declarations/control flow need spill
-    // analysis and are left to follow-up phases.
-    if (ts.isExpressionStatement(stmt) && !statementContainsYield(stmt)) {
-      current.push(stmt);
-      continue;
-    }
+  if (!visitStatements(decl.body.statements, [])) return null;
 
-    return null;
-  }
-
-  if (current.length > 0 || segments.length === 0 || segments.at(-1)?.returnStmt === undefined) {
-    segments.push({ statements: current });
+  if (
+    current.length > 0 ||
+    pendingResumeBindings.length > 0 ||
+    pendingAbruptResume !== undefined ||
+    segments.length === 0 ||
+    segments.at(-1)?.returnStmt === undefined
+  ) {
+    pushSegment(undefined, undefined);
   }
 
   const yieldCount = segments.filter((s) => s.yieldExpr !== undefined).length;
   if (yieldCount > MAX_NATIVE_GENERATOR_STATES) return null;
-  return segments;
+  return { segments, spills };
 }
 
 export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.FunctionDeclaration): boolean {
@@ -113,8 +203,8 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.Functio
   for (const param of decl.parameters) {
     if (param.dotDotDotToken || !ts.isIdentifier(param.name)) return false;
   }
-  const segments = buildNativeGeneratorSegments(ctx, decl);
-  return segments !== null && segments.some((s) => s.yieldExpr !== undefined);
+  const plan = buildNativeGeneratorPlan(ctx, decl);
+  return plan !== null && plan.segments.some((s) => s.yieldExpr !== undefined);
 }
 
 export function sourceNeedsGeneratorHostImports(ctx: CodegenContext, sourceFile: ts.SourceFile): boolean {
@@ -176,17 +266,30 @@ export function registerNativeGenerator(
   if (existing) return existing;
   if (!isNativeGeneratorCandidate(ctx, decl)) return null;
 
-  const segments = buildNativeGeneratorSegments(ctx, decl);
-  if (!segments) return null;
+  const plan = buildNativeGeneratorPlan(ctx, decl);
+  if (!plan) return null;
 
   const resultTypeIdx = ensureNativeGeneratorResultType(ctx);
   const paramNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
-  const stateFields: FieldDef[] = [{ name: "state", type: { kind: "i32" }, mutable: true }];
+  const stateFields: FieldDef[] = [
+    { name: "state", type: { kind: "i32" }, mutable: true },
+    { name: "sent", type: { kind: "f64" }, mutable: true },
+    { name: "mode", type: { kind: "i32" }, mutable: true },
+    { name: "abrupt", type: { kind: "f64" }, mutable: true },
+  ];
   for (let i = 0; i < paramTypes.length; i++) {
     stateFields.push({
       name: `param_${paramNames[i] ?? i}`,
       type: paramTypes[i]!,
       mutable: false,
+    });
+  }
+  const spillFieldOffset = PARAM_FIELD_OFFSET + paramTypes.length;
+  for (const spill of plan.spills) {
+    stateFields.push({
+      name: `spill_${spill}`,
+      type: { kind: "f64" },
+      mutable: true,
     });
   }
 
@@ -197,7 +300,7 @@ export function registerNativeGenerator(
   ctx.typeIdxToStructName.set(stateTypeIdx, stateName);
   ctx.structFields.set(stateName, stateFields);
 
-  const yieldCount = segments.filter((s) => s.yieldExpr !== undefined).length;
+  const yieldCount = plan.segments.filter((s) => s.yieldExpr !== undefined).length;
   const info: NativeGeneratorInfo = {
     functionName,
     decl,
@@ -206,6 +309,11 @@ export function registerNativeGenerator(
     paramNames,
     paramTypes,
     paramFieldOffset: PARAM_FIELD_OFFSET,
+    sentFieldIdx: SENT_FIELD,
+    modeFieldIdx: MODE_FIELD,
+    abruptFieldIdx: ABRUPT_FIELD,
+    spillNames: plan.spills,
+    spillFieldOffset,
     yieldCount,
     doneState: yieldCount + 1,
   };
@@ -230,6 +338,65 @@ function setState(info: NativeGeneratorInfo, state: number): Instr[] {
     { op: "local.get", index: 0 },
     { op: "i32.const", value: state },
     { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+  ];
+}
+
+function setMode(info: NativeGeneratorInfo, mode: number): Instr[] {
+  return [
+    { op: "local.get", index: 0 },
+    { op: "i32.const", value: mode },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+  ];
+}
+
+function setStateFieldFromLocal(
+  info: NativeGeneratorInfo,
+  selfLocal: number,
+  fieldIdx: number,
+  valueLocal: number,
+): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "local.get", index: valueLocal },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx },
+  ];
+}
+
+function setStateI32FromConst(info: NativeGeneratorInfo, selfLocal: number, fieldIdx: number, value: number): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "i32.const", value },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx },
+  ];
+}
+
+function nativeReturnResultFromLocal(info: NativeGeneratorInfo, valueLocal: number): Instr[] {
+  return [
+    { op: "local.get", index: valueLocal },
+    { op: "i32.const", value: 1 },
+    { op: "struct.new", typeIdx: info.resultTypeIdx },
+  ];
+}
+
+function storeSpills(info: NativeGeneratorInfo, fctx: FunctionContext): Instr[] {
+  const body: Instr[] = [];
+  for (let i = 0; i < info.spillNames.length; i++) {
+    const localIdx = fctx.localMap.get(info.spillNames[i]!);
+    if (localIdx === undefined) continue;
+    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: localIdx });
+    body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
+  }
+  return body;
+}
+
+function returnAbruptResult(info: NativeGeneratorInfo): Instr[] {
+  return [
+    ...setState(info, info.doneState),
+    { op: "local.get", index: 0 },
+    { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
+    { op: "i32.const", value: 1 },
+    { op: "struct.new", typeIdx: info.resultTypeIdx },
   ];
 }
 
@@ -265,24 +432,68 @@ function compileSegment(
   const body: Instr[] = [];
   fctx.body = body;
 
+  if (segment.abruptResume) {
+    const abruptBody: Instr[] = [];
+    const savedAbruptBody = fctx.body;
+    fctx.body = abruptBody;
+    for (const finalizer of segment.abruptResume.finalizers) {
+      for (const stmt of finalizer) {
+        compileStatement(ctx, fctx, stmt);
+      }
+    }
+    abruptBody.push(...storeSpills(info, fctx));
+    abruptBody.push(...returnAbruptResult(info));
+    abruptBody.push({ op: "return" });
+    fctx.body = savedAbruptBody;
+
+    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx });
+    body.push({ op: "i32.const", value: 1 });
+    body.push({ op: "i32.eq" });
+    body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: abruptBody,
+      else: [],
+    });
+  }
+
+  for (const name of segment.resumeBindings) {
+    const localIdx = fctx.localMap.get(name);
+    const spillIdx = info.spillNames.indexOf(name);
+    if (localIdx === undefined || spillIdx < 0) continue;
+    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.sentFieldIdx });
+    body.push({ op: "local.set", index: localIdx });
+    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: localIdx });
+    body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + spillIdx });
+  }
+
   for (const stmt of segment.statements) {
     compileStatement(ctx, fctx, stmt);
   }
 
   if (segment.yieldExpr) {
     const tmp = emitExpressionAsF64(ctx, fctx, segment.yieldExpr.expression);
+    body.push(...storeSpills(info, fctx));
     body.push(...setState(info, yieldIndex + 1));
+    body.push(...setMode(info, 0));
     body.push({ op: "local.get", index: tmp });
     body.push({ op: "i32.const", value: 0 });
     body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
   } else if (segment.returnStmt) {
     const tmp = emitExpressionAsF64(ctx, fctx, segment.returnStmt.expression);
+    body.push(...storeSpills(info, fctx));
     body.push(...setState(info, info.doneState));
+    body.push(...setMode(info, 0));
     body.push({ op: "local.get", index: tmp });
     body.push({ op: "i32.const", value: 1 });
     body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
   } else {
+    body.push(...storeSpills(info, fctx));
     body.push(...setState(info, info.doneState));
+    body.push(...setMode(info, 0));
     body.push(...emptyResult(info));
   }
 
@@ -348,8 +559,15 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     resumeFctx.body.push({ op: "local.set", index: localIdx });
   }
 
-  const segments = buildNativeGeneratorSegments(ctx, info.decl);
-  if (!segments) {
+  for (let i = 0; i < info.spillNames.length; i++) {
+    const localIdx = allocLocal(resumeFctx, info.spillNames[i]!, { kind: "f64" });
+    resumeFctx.body.push({ op: "local.get", index: 0 });
+    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
+    resumeFctx.body.push({ op: "local.set", index: localIdx });
+  }
+
+  const plan = buildNativeGeneratorPlan(ctx, info.decl);
+  if (!plan) {
     reportError(ctx, info.decl, "Internal error: native generator plan disappeared during emission");
     resumeFctx.body.push(...emptyResult(info));
   } else {
@@ -357,7 +575,7 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     ctx.currentFunc = resumeFctx;
     try {
       let yieldIndex = 0;
-      const cases = segments.map((segment) => {
+      const cases = plan.segments.map((segment) => {
         const caseBody = compileSegment(ctx, resumeFctx, info, segment, yieldIndex);
         if (segment.yieldExpr) yieldIndex++;
         return caseBody;
@@ -388,8 +606,14 @@ export function compileNativeGeneratorFunction(
 ): void {
   ensureNativeGeneratorResumeFunction(ctx, info);
   fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "f64.const", value: NaN });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "f64.const", value: NaN });
   for (let i = 0; i < decl.parameters.length; i++) {
     fctx.body.push({ op: "local.get", index: i });
+  }
+  for (let i = 0; i < info.spillNames.length; i++) {
+    fctx.body.push({ op: "f64.const", value: NaN });
   }
   fctx.body.push({ op: "struct.new", typeIdx: info.stateTypeIdx });
 }
@@ -437,7 +661,10 @@ function compileDirectNativeGeneratorMethod(
   fctx.body.push({ op: "local.set", index: selfLocal });
 
   if (methodName === "next") {
-    compileIgnoredArgs(ctx, fctx, args);
+    const sentTmp = emitExpressionAsF64(ctx, fctx, args[0]);
+    compileIgnoredArgs(ctx, fctx, args.slice(1));
+    fctx.body.push(...setStateFieldFromLocal(info, selfLocal, info.sentFieldIdx, sentTmp));
+    fctx.body.push(...setStateI32FromConst(info, selfLocal, info.modeFieldIdx, 0));
     fctx.body.push({ op: "local.get", index: selfLocal });
     fctx.body.push({ op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) });
     return { kind: "ref", typeIdx: info.resultTypeIdx };
@@ -445,13 +672,40 @@ function compileDirectNativeGeneratorMethod(
 
   if (methodName === "return") {
     const valueTmp = emitExpressionAsF64(ctx, fctx, args[0]);
-    fctx.body.push({ op: "local.get", index: selfLocal });
-    fctx.body.push({ op: "i32.const", value: info.doneState });
-    fctx.body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
-    fctx.body.push({ op: "local.get", index: valueTmp });
-    fctx.body.push({ op: "i32.const", value: 1 });
-    fctx.body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
     compileIgnoredArgs(ctx, fctx, args.slice(1));
+    fctx.body.push({ op: "local.get", index: selfLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "i32.eq" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref", typeIdx: info.resultTypeIdx } },
+      then: [
+        ...setStateI32FromConst(info, selfLocal, STATE_FIELD, info.doneState),
+        ...setStateI32FromConst(info, selfLocal, info.modeFieldIdx, 0),
+        ...nativeReturnResultFromLocal(info, valueTmp),
+      ],
+      else: [
+        { op: "local.get", index: selfLocal },
+        { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+        { op: "i32.const", value: info.doneState },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "ref", typeIdx: info.resultTypeIdx } },
+          then: [
+            ...setStateI32FromConst(info, selfLocal, info.modeFieldIdx, 0),
+            ...nativeReturnResultFromLocal(info, valueTmp),
+          ],
+          else: [
+            ...setStateFieldFromLocal(info, selfLocal, info.abruptFieldIdx, valueTmp),
+            ...setStateI32FromConst(info, selfLocal, info.modeFieldIdx, 1),
+            { op: "local.get", index: selfLocal },
+            { op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) },
+          ],
+        },
+      ],
+    });
     return { kind: "ref", typeIdx: info.resultTypeIdx };
   }
 
@@ -480,17 +734,73 @@ function buildNativeGeneratorDispatch(
       thenBody = [
         { op: "local.get", index: anyLocal },
         { op: "ref.cast", typeIdx: info.stateTypeIdx },
+        { op: "local.get", index: valueLocal! },
+        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.sentFieldIdx },
+        { op: "local.get", index: anyLocal },
+        { op: "ref.cast", typeIdx: info.stateTypeIdx },
+        { op: "i32.const", value: 0 },
+        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+        { op: "local.get", index: anyLocal },
+        { op: "ref.cast", typeIdx: info.stateTypeIdx },
         { op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) },
       ];
     } else {
       thenBody = [
         { op: "local.get", index: anyLocal },
         { op: "ref.cast", typeIdx: info.stateTypeIdx },
-        { op: "i32.const", value: info.doneState },
-        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
-        { op: "local.get", index: valueLocal! },
-        { op: "i32.const", value: 1 },
-        { op: "struct.new", typeIdx: info.resultTypeIdx },
+        { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+        { op: "i32.const", value: 0 },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: resultType },
+          then: [
+            { op: "local.get", index: anyLocal },
+            { op: "ref.cast", typeIdx: info.stateTypeIdx },
+            { op: "i32.const", value: info.doneState },
+            { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+            { op: "local.get", index: anyLocal },
+            { op: "ref.cast", typeIdx: info.stateTypeIdx },
+            { op: "i32.const", value: 0 },
+            { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+            { op: "local.get", index: valueLocal! },
+            { op: "i32.const", value: 1 },
+            { op: "struct.new", typeIdx: info.resultTypeIdx },
+          ],
+          else: [
+            { op: "local.get", index: anyLocal },
+            { op: "ref.cast", typeIdx: info.stateTypeIdx },
+            { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+            { op: "i32.const", value: info.doneState },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: resultType },
+              then: [
+                { op: "local.get", index: anyLocal },
+                { op: "ref.cast", typeIdx: info.stateTypeIdx },
+                { op: "i32.const", value: 0 },
+                { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+                { op: "local.get", index: valueLocal! },
+                { op: "i32.const", value: 1 },
+                { op: "struct.new", typeIdx: info.resultTypeIdx },
+              ],
+              else: [
+                { op: "local.get", index: anyLocal },
+                { op: "ref.cast", typeIdx: info.stateTypeIdx },
+                { op: "local.get", index: valueLocal! },
+                { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
+                { op: "local.get", index: anyLocal },
+                { op: "ref.cast", typeIdx: info.stateTypeIdx },
+                { op: "i32.const", value: 1 },
+                { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+                { op: "local.get", index: anyLocal },
+                { op: "ref.cast", typeIdx: info.stateTypeIdx },
+                { op: "call", funcIdx: ensureNativeGeneratorResumeFunction(ctx, info) },
+              ],
+            },
+          ],
+        },
       ];
     }
     return [
@@ -538,11 +848,9 @@ export function tryCompileNativeGeneratorMethodCall(
   fctx.body.push({ op: "local.set", index: anyLocal });
 
   let valueLocal: number | undefined;
-  if (methodName === "return") {
+  if (methodName === "return" || methodName === "next") {
     valueLocal = emitExpressionAsF64(ctx, fctx, args[0]);
     compileIgnoredArgs(ctx, fctx, args.slice(1));
-  } else {
-    compileIgnoredArgs(ctx, fctx, args);
   }
 
   fctx.body.push(...buildNativeGeneratorDispatch(ctx, anyLocal, methodName, valueLocal));

--- a/tests/issue-1346.test.ts
+++ b/tests/issue-1346.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1346 — first native-generator slice for YieldExpression evaluation.
+//
+// ECMA-262 §15.5.5 evaluates `yield expr` by evaluating `expr`, yielding that
+// value, then using the next resumption completion as the value of the yield
+// expression. §27.5.3.4 resumes a suspended generator with a return completion
+// for `.return(value)`, which must run any active `finally` blocks before the
+// generator completes.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const HOST_GEN_ITER_RE = /^(__gen_|__create_generator|__create_async_generator|__iterator)/;
+
+async function instantiateStandalone(source: string): Promise<{
+  exports: Record<string, Function>;
+  imports: string[];
+}> {
+  const result = await compile(source, { fileName: "issue-1346.ts", target: "standalone" });
+  expect(result.success, result.success ? "" : `compile error: ${result.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(result.binary);
+  const imports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env" && HOST_GEN_ITER_RE.test(i.name))
+    .map((i) => `${i.module}::${i.name}`);
+  const instance = await WebAssembly.instantiate(mod, {});
+  return { exports: instance.exports as Record<string, Function>, imports };
+}
+
+describe("#1346 native generator yield expression order", () => {
+  it("uses values passed to .next(value) as sequential yield-expression results", async () => {
+    const { exports, imports } = await instantiateStandalone(`
+      function* gen(): Generator<number, number, number> {
+        const a: number = yield 1;
+        const b: number = yield 2;
+        return a * 10 + b;
+      }
+
+      export function run(): number {
+        const g = gen();
+        const r1 = g.next();
+        const r2 = g.next(4);
+        const r3 = g.next(7);
+        return r1.value * 10000 + r2.value * 1000 + r3.value * 10 + (r3.done ? 1 : 0);
+      }
+    `);
+
+    expect(imports).toEqual([]);
+    expect((exports.run as () => number)()).toBe(12471);
+  });
+
+  it("runs a pending finally when .return(value) resumes at a suspended yield", async () => {
+    const { exports, imports } = await instantiateStandalone(`
+      let log = 0;
+
+      function* gen(): Generator<number, number, number> {
+        try {
+          log = log + 1;
+          yield 5;
+          log = log + 100;
+        } finally {
+          log = log + 10;
+        }
+        return log;
+      }
+
+      export function run(): number {
+        const g = gen();
+        const first = g.next();
+        const ret = g.return(77);
+        const after = g.next();
+        return log * 10000 + first.value * 1000 + (ret.done ? 100 : 0) + ret.value + (after.done ? 1 : 0);
+      }
+    `);
+
+    expect(imports).toEqual([]);
+    expect((exports.run as () => number)()).toBe(115178);
+  });
+
+  it("runs finally on the normal resume path after a yield in try", async () => {
+    const { exports, imports } = await instantiateStandalone(`
+      let log = 0;
+
+      function* gen(): Generator<number, number, number> {
+        try {
+          yield 1;
+          log = log + 2;
+        } finally {
+          log = log + 10;
+        }
+        return log;
+      }
+
+      export function run(): number {
+        const g = gen();
+        g.next();
+        const r = g.next(0);
+        return r.value + (r.done ? 100 : 0);
+      }
+    `);
+
+    expect(imports).toEqual([]);
+    expect((exports.run as () => number)()).toBe(112);
+  });
+
+  it("does not enter the body when .return(value) is called before the first next", async () => {
+    const { exports, imports } = await instantiateStandalone(`
+      let log = 0;
+
+      function* gen(): Generator<number, number, number> {
+        try {
+          log = 1;
+          yield 2;
+        } finally {
+          log = 10;
+        }
+        return log;
+      }
+
+      export function run(): number {
+        const g = gen();
+        const r = g.return(33);
+        return log * 100 + r.value + (r.done ? 1000 : 0);
+      }
+    `);
+
+    expect(imports).toEqual([]);
+    expect((exports.run as () => number)()).toBe(1033);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the first #1346 suspendable-generator slice on the existing Wasm-native generator state machine:

- adds `sent`, `mode`, and `abrupt` fields to native generator state
- spills simple `const x = yield n` bindings across suspension so `.next(value)` becomes the yield-expression result
- resumes suspended yields through pending non-yielding `finally` blocks on `.return(value)`
- keeps the eager JS-host generator buffer path unchanged

## Spec

Follows ECMA-262 2026 §15.5.5 `YieldExpression`, §27.5.3.4 `GeneratorResumeAbrupt`, and §27.5.3.6 `GeneratorYield` for this native-generator slice.

## Scope and Follow-Up

This is intentionally limited to standalone/WASI native generators with numeric yields. Full #1346 still needs `yield*` return/throw forwarding, `.throw()` injection, and arbitrary expression operand spills for call/array yield positions. The local `test262/` checkout is empty, so I did not run the full `language/expressions/yield` subset locally.

## Validation

- `npm test -- tests/issue-1346.test.ts`
- `npm test -- tests/issue-680.test.ts tests/issue-1665-standalone-generator-forof.test.ts`
- `npm run typecheck`

Co-authored-by: Codex <codex@openai.com>
