### PR TITLE
feat(#1539): add standalone regex split slice

### DIFF
--- a/plan/issues/1539-wasm-native-regex-engine-regress.md
+++ b/plan/issues/1539-wasm-native-regex-engine-regress.md
@@ -1,7 +1,7 @@
 ---
 id: 1539
 title: "Standalone Wasm RegExp engine via regress (Phase 2 of #1474)"
-status: in-progress
+status: in-review
 created: 2026-05-20
 updated: 2026-06-06
 priority: high
@@ -16,6 +16,7 @@ depends_on: [1474]
 related: [1474, 682, 1535]
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:09:50.202Z
+pr: 1247
 ---
 # #1539 — Standalone Wasm RegExp engine via regress (Phase 2 of #1474)
 

--- a/plan/issues/1539-wasm-native-regex-engine-regress.md
+++ b/plan/issues/1539-wasm-native-regex-engine-regress.md
@@ -3,7 +3,7 @@ id: 1539
 title: "Standalone Wasm RegExp engine via regress (Phase 2 of #1474)"
 status: in-progress
 created: 2026-05-20
-updated: 2026-06-03
+updated: 2026-06-06
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -14,6 +14,8 @@ goal: standalone-wasm
 sprint: 60
 depends_on: [1474]
 related: [1474, 682, 1535]
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:09:50.202Z
 ---
 # #1539 — Standalone Wasm RegExp engine via regress (Phase 2 of #1474)
 
@@ -542,3 +544,29 @@ Tests: `tests/issue-1539-standalone-regex.test.ts` (75 dual-run `.search`
 cases vs native + var-bound/`new RegExp` arg forms), narrowed the `s.search`
 refusal in `tests/issue-1474-standalone-regex-refuse.test.ts` to a
 compiles-OK assertion.
+
+## Implementation Notes (codex-developer, 2026-06-06) — Phase 2c non-capturing `String.prototype.split`
+
+Landed `String.prototype.split(/re/)` in standalone mode for backend-created
+static RegExp separators on the existing pure-WasmGC VM. The helper
+`__regex_split` mirrors the native string split vec shape (`ref_<AnyString>`)
+and uses `__regex_search` to find separator spans, returning a native
+`string[]` without `env.RegExp_new`, `env.string_split`, or `env.__make_iterable`
+imports.
+
+- Scope: regex literal / trusted var-bound RegExp / `new RegExp("static")`,
+  non-capturing separators only, no `limit` argument, and separators that cannot
+  match the empty string. This avoids silently mis-modeling capture interleaving
+  and zero-width split edge cases until the capture-array follow-up lands.
+- Refactor: consolidated standalone regex flag/subset validation so literal
+  struct emission and string-method routing share the same `g/i/y/m/s` support
+  and `u/v/d` refusal diagnostics.
+- Tests: extended `tests/issue-1539-standalone-regex.test.ts` with split
+  equivalence cases vs native RegExp plus var-bound / constructor forms and
+  narrowed refusals for capture groups, `limit`, and empty-match separators.
+  Updated `tests/issue-1474-standalone-regex-refuse.test.ts` so the now-supported
+  `split` and literal-replacement `replace` paths compile.
+
+Still open for #1539: capture-array materialization for `.exec`/`.match` and
+capture-interleaved `split`, `$`/function replacement semantics, `matchAll`, and
+the `d`/`u`/`v` plus lookaround/backreference/property-escape work.

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -16,11 +16,11 @@
  */
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { addFuncType, getOrRegisterArrayType } from "./registry/types.js";
+import { addFuncType, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
 import { ReOp } from "./regex/bytecode.js";
-// NOTE: `__regex_replace` (below) reuses the native string helpers
-// `__str_substring` + `__str_concat` (registered by ensureNativeStringHelpers)
-// and returns a `$NativeString` — no array boundary, so no host import.
+// NOTE: `__regex_replace` / `__regex_split` (below) reuse the native string
+// helpers registered by ensureNativeStringHelpers and never import a JS RegExp
+// or String.prototype host shim.
 
 /** The frame struct holds one backtrack alternative, exactly like vm.ts. */
 const RE_FRAME_STRUCT = "__ReFrame";
@@ -1152,6 +1152,225 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     exported: false,
   };
   ctx.mod.functions.push(fn);
+  return funcIdx;
+}
+
+/**
+ * Emit `__regex_split(prog, classTable, nGroups, strData, strOff, strLen,
+ * subject) -> ref $vec_nstr` (#1539 Phase 2c).
+ *
+ * This is the non-capturing, non-empty-match split slice. The call site refuses
+ * capture groups and nullable separators so this helper can use the same simple
+ * boundary loop as the native string splitter: append the substring before each
+ * separator match, advance past the consumed separator, then append the tail.
+ */
+export function ensureRegexSplit(ctx: CodegenContext): number {
+  const existing = ctx.nativeRegexHelpers.get("__regex_split");
+  if (existing !== undefined) return existing;
+
+  const searchIdx = ensureRegexSearch(ctx);
+  const i32Arr = regexI32ArrayType(ctx);
+  const strDataIdx = ctx.nativeStrDataTypeIdx;
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  const strDataRef: ValType = { kind: "ref", typeIdx: strDataIdx };
+  const i32ArrRef: ValType = { kind: "ref", typeIdx: i32Arr };
+
+  const nstrElemKey = `ref_${anyStrTypeIdx}`;
+  const nstrElemType: ValType = { kind: "ref_null", typeIdx: anyStrTypeIdx };
+  const nstrArrTypeIdx = getOrRegisterArrayType(ctx, nstrElemKey, nstrElemType);
+  const nstrVecTypeIdx = getOrRegisterVecType(ctx, nstrElemKey, nstrElemType);
+  const nstrVecRef: ValType = { kind: "ref", typeIdx: nstrVecTypeIdx };
+
+  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
+  if (substringIdx === undefined) {
+    throw new Error("__regex_split requires __str_substring (#682 native string helpers)");
+  }
+
+  const typeIdx = addFuncType(
+    ctx,
+    [
+      i32ArrRef, // prog
+      i32ArrRef, // classTable
+      { kind: "i32" }, // nGroups
+      strDataRef, // strData
+      { kind: "i32" }, // strOff
+      { kind: "i32" }, // strLen
+      strRef, // subject (flattened)
+    ],
+    [nstrVecRef],
+  );
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.nativeRegexHelpers.set("__regex_split", funcIdx);
+
+  // params
+  const PROG = 0,
+    CTAB = 1,
+    NGROUPS = 2,
+    SDATA = 3,
+    SOFF = 4,
+    SLEN = 5,
+    SUBJ = 6;
+  // locals
+  const NSLOTS = 7;
+  const CAPS = 8;
+  const POS = 9;
+  const LASTEND = 10;
+  const RARR = 11;
+  const RLEN = 12;
+  const RCAP = 13;
+  const NEWARR = 14;
+  const PART = 15;
+  const MSTART = 16;
+  const MEND = 17;
+
+  const appendPart = (): Instr[] => [
+    // Grow result if needed.
+    { op: "local.get", index: RLEN },
+    { op: "local.get", index: RCAP },
+    { op: "i32.ge_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: RCAP },
+        { op: "i32.const", value: 2 },
+        { op: "i32.mul" },
+        { op: "local.set", index: RCAP },
+        { op: "local.get", index: RCAP },
+        { op: "array.new_default", typeIdx: nstrArrTypeIdx },
+        { op: "local.set", index: NEWARR },
+        { op: "local.get", index: NEWARR },
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: RARR },
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: RLEN },
+        {
+          op: "array.copy",
+          dstTypeIdx: nstrArrTypeIdx,
+          srcTypeIdx: nstrArrTypeIdx,
+        },
+        { op: "local.get", index: NEWARR },
+        { op: "local.set", index: RARR },
+      ],
+    } as Instr,
+    // resultArr[resultLen] = part
+    { op: "local.get", index: RARR },
+    { op: "local.get", index: RLEN },
+    { op: "local.get", index: PART },
+    { op: "array.set", typeIdx: nstrArrTypeIdx },
+    { op: "local.get", index: RLEN },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: RLEN },
+  ];
+
+  const body: Instr[] = [
+    // nSlots = 2 * nGroups; caps = array.new_default(nSlots)
+    { op: "local.get", index: NGROUPS },
+    { op: "i32.const", value: 2 },
+    { op: "i32.mul" },
+    { op: "local.set", index: NSLOTS },
+    { op: "local.get", index: NSLOTS },
+    { op: "array.new_default", typeIdx: i32Arr },
+    { op: "local.set", index: CAPS },
+    // result array starts at cap 8; pos = lastEnd = 0.
+    { op: "i32.const", value: 8 },
+    { op: "array.new_default", typeIdx: nstrArrTypeIdx },
+    { op: "local.set", index: RARR },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: RLEN },
+    { op: "i32.const", value: 8 },
+    { op: "local.set", index: RCAP },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: POS },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: LASTEND },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if pos > slen: break
+            { op: "local.get", index: POS },
+            { op: "local.get", index: SLEN },
+            { op: "i32.gt_s" },
+            { op: "br_if", depth: 1 },
+            // if !__regex_search(... pos, sticky=0 ...): break
+            { op: "local.get", index: PROG },
+            { op: "local.get", index: CTAB },
+            { op: "local.get", index: NSLOTS },
+            { op: "local.get", index: SDATA },
+            { op: "local.get", index: SOFF },
+            { op: "local.get", index: SLEN },
+            { op: "local.get", index: POS },
+            { op: "i32.const", value: 0 },
+            { op: "local.get", index: CAPS },
+            { op: "call", funcIdx: searchIdx },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            // mstart = caps[0]; mend = caps[1]
+            { op: "local.get", index: CAPS },
+            { op: "i32.const", value: 0 },
+            { op: "array.get", typeIdx: i32Arr },
+            { op: "local.set", index: MSTART },
+            { op: "local.get", index: CAPS },
+            { op: "i32.const", value: 1 },
+            { op: "array.get", typeIdx: i32Arr },
+            { op: "local.set", index: MEND },
+            // part = substring(subject, lastEnd, mstart); append(part)
+            { op: "local.get", index: SUBJ },
+            { op: "local.get", index: LASTEND },
+            { op: "local.get", index: MSTART },
+            { op: "call", funcIdx: substringIdx },
+            { op: "local.set", index: PART },
+            ...appendPart(),
+            // lastEnd = mend; pos = mend (nullable patterns are refused at call site)
+            { op: "local.get", index: MEND },
+            { op: "local.set", index: LASTEND },
+            { op: "local.get", index: MEND },
+            { op: "local.set", index: POS },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // Append final tail: substring(subject, lastEnd, slen)
+    { op: "local.get", index: SUBJ },
+    { op: "local.get", index: LASTEND },
+    { op: "local.get", index: SLEN },
+    { op: "call", funcIdx: substringIdx },
+    { op: "local.set", index: PART },
+    ...appendPart(),
+    // return struct.new(resultLen, resultArr)
+    { op: "local.get", index: RLEN },
+    { op: "local.get", index: RARR },
+    { op: "ref.as_non_null" },
+    { op: "struct.new", typeIdx: nstrVecTypeIdx },
+  ];
+
+  ctx.mod.functions.push({
+    name: "__regex_split",
+    typeIdx,
+    locals: [
+      { name: "nslots", type: { kind: "i32" } },
+      { name: "caps", type: i32ArrRef },
+      { name: "pos", type: { kind: "i32" } },
+      { name: "lastEnd", type: { kind: "i32" } },
+      { name: "resultArr", type: { kind: "ref_null", typeIdx: nstrArrTypeIdx } },
+      { name: "resultLen", type: { kind: "i32" } },
+      { name: "resultCap", type: { kind: "i32" } },
+      { name: "newArr", type: { kind: "ref_null", typeIdx: nstrArrTypeIdx } },
+      { name: "part", type: { kind: "ref_null", typeIdx: anyStrTypeIdx } },
+      { name: "mstart", type: { kind: "i32" } },
+      { name: "mend", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
   return funcIdx;
 }
 

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -9,10 +9,11 @@
  * (`native-regex.ts`). The literal-substring case is now the `CHAR`-only
  * degenerate path of the VM. See the issue's "Implementation Notes (sd-1539)".
  *
- * Phase 2a slice: `RegExp` literals / `new RegExp(staticPattern, staticFlags)`
- * and `RegExp.prototype.test`. Dynamic patterns, `.exec`/`.match`/`.search`/
- * `.replace`/`.split`, and fancy features stay narrowed refusals citing the
- * later phase.
+ * Current slice: `RegExp` literals / `new RegExp(staticPattern, staticFlags)`,
+ * `RegExp.prototype.test`, `String.prototype.search`, literal-string
+ * `replace`/`replaceAll`, and non-capturing regex `split`. Dynamic patterns,
+ * `.exec`/`.match`/`matchAll`, capture-materializing string methods, and fancy
+ * features stay narrowed refusals citing the later phase.
  */
 import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
@@ -20,8 +21,15 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
 import { ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
-import { ensureRegexReplace, ensureRegexSearch, i32ArrayLiteralInstrs, regexI32ArrayType } from "./native-regex.js";
 import {
+  ensureRegexReplace,
+  ensureRegexSearch,
+  ensureRegexSplit,
+  i32ArrayLiteralInstrs,
+  regexI32ArrayType,
+} from "./native-regex.js";
+import {
+  type CompiledRegex,
   parseFlags,
   RegexUnsupportedError,
   RE_FLAG_G,
@@ -31,6 +39,7 @@ import {
   RE_FLAG_Y,
 } from "./regex/bytecode.js";
 import { compilePattern, RepeatTooLargeError } from "./regex/compile.js";
+import { search as regexSearch } from "./regex/vm.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
@@ -123,6 +132,10 @@ export function hasStandaloneRegExpEngine(state: StandaloneRegExpEngineState): b
 }
 
 const STANDALONE_REGEXP_STRUCT_NAME = "__StandaloneRegExp";
+// Supported standalone flags for the current pure-WasmGC VM slice: g/i/y from
+// Phase 2a plus m/s from Phase 2c. u/v/d remain code-point/indices follow-ups.
+const SUPPORTED_STANDALONE_FLAGS = RE_FLAG_G | RE_FLAG_I | RE_FLAG_Y | RE_FLAG_M | RE_FLAG_S;
+
 function reportStandaloneRegExpUnsupported(ctx: CodegenContext, node: ts.Node, detail: string): void {
   reportError(
     ctx,
@@ -306,6 +319,77 @@ function staticStringValue(ctx: CodegenContext, expr: ts.Expression): string | n
   return null;
 }
 
+interface StaticRegExpPatternFlags {
+  pattern: string;
+  flags: string;
+}
+
+/**
+ * Recover the pattern+flags of a static / backend-created RegExp expression:
+ * `/…/flags`, `new RegExp("…", "flags")`, `RegExp("…", "flags")`, or a
+ * trusted binding initialized to one of those forms.
+ */
+function staticRegExpPatternFlags(ctx: CodegenContext, expr: ts.Expression): StaticRegExpPatternFlags | null {
+  const unwrapped = stripStaticWrapper(expr);
+  if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+    const text = (unwrapped as ts.RegularExpressionLiteral).text;
+    const lastSlash = text.lastIndexOf("/");
+    return {
+      pattern: lastSlash >= 0 ? text.slice(1, lastSlash) : text,
+      flags: lastSlash >= 0 ? text.slice(lastSlash + 1) : "",
+    };
+  }
+  if (ts.isNewExpression(unwrapped) || (ts.isCallExpression(unwrapped) && !unwrapped.questionDotToken)) {
+    const callee = stripStaticWrapper(unwrapped.expression);
+    if (!ts.isIdentifier(callee) || !isGlobalRegExpIdentifier(ctx, callee)) return null;
+    const patternArg = unwrapped.arguments?.[0];
+    const flagsArg = unwrapped.arguments?.[1];
+    const pattern = patternArg === undefined ? "" : staticStringValue(ctx, patternArg);
+    const flags = flagsArg === undefined ? "" : staticStringValue(ctx, flagsArg);
+    if (pattern === null || flags === null) return null;
+    return { pattern: pattern ?? "", flags: flags ?? "" };
+  }
+  if (ts.isIdentifier(unwrapped)) {
+    const sym = ctx.checker.getSymbolAtLocation(unwrapped);
+    if (!sym) return null;
+    const decl = sym.getDeclarations()?.find((d) => ts.isVariableDeclaration(d)) as ts.VariableDeclaration | undefined;
+    if (!decl?.initializer || !isTrustedBackendCreatedRegExpBinding(ctx, decl, sym)) return null;
+    return staticRegExpPatternFlags(ctx, decl.initializer);
+  }
+  return null;
+}
+
+function compileStaticStandaloneRegExp(
+  ctx: CodegenContext,
+  pattern: string,
+  flags: string,
+  node: ts.Node,
+): CompiledRegex | null {
+  let flagBits: number;
+  try {
+    flagBits = parseFlags(flags);
+  } catch (e) {
+    reportStandaloneRegExpUnsupported(ctx, node, describeRegexError(e, `flags ${JSON.stringify(flags)}`));
+    return null;
+  }
+
+  const refusedFlags = flagBits & ~SUPPORTED_STANDALONE_FLAGS;
+  if (refusedFlags !== 0) {
+    reportStandaloneRegExpUnsupported(ctx, node, `flags ${JSON.stringify(flags)} (u/v/d are #1539 Phase 2d)`);
+    return null;
+  }
+
+  try {
+    return compilePattern(pattern, flagBits);
+  } catch (e) {
+    if (e instanceof RegexUnsupportedError || e instanceof RepeatTooLargeError) {
+      reportStandaloneRegExpUnsupported(ctx, node, e.message);
+      return null;
+    }
+    throw e;
+  }
+}
+
 /**
  * The `$NativeRegExp` struct (#1539). Holds the flags bitfield, the
  * capture-group count, the compiled bytecode program, the class table, and the
@@ -363,34 +447,8 @@ function emitStandaloneRegExpStruct(
   flags: string,
   node: ts.Node,
 ): ValType | null {
-  let flagBits: number;
-  try {
-    flagBits = parseFlags(flags);
-  } catch (e) {
-    reportStandaloneRegExpUnsupported(ctx, node, describeRegexError(e, `flags ${JSON.stringify(flags)}`));
-    return null;
-  }
-  // Supported flags: g (global), i (case-insensitive, ASCII fold), y (sticky),
-  // m (multiline — `^`/`$` at line boundaries, #1539 Phase 2c), and s (dotAll —
-  // `.` matches line terminators, #1539 Phase 2c). The unicode `u`/`v`
-  // (code-point semantics) and indices `d` flags remain deferred (Phase 2d).
-  const SUPPORTED_FLAGS = RE_FLAG_G | RE_FLAG_I | RE_FLAG_Y | RE_FLAG_M | RE_FLAG_S;
-  const refusedFlags = flagBits & ~SUPPORTED_FLAGS;
-  if (refusedFlags !== 0) {
-    reportStandaloneRegExpUnsupported(ctx, node, `flags ${JSON.stringify(flags)} (u/v/d are #1539 Phase 2d)`);
-    return null;
-  }
-
-  let compiled;
-  try {
-    compiled = compilePattern(pattern, flagBits);
-  } catch (e) {
-    if (e instanceof RegexUnsupportedError || e instanceof RepeatTooLargeError) {
-      reportStandaloneRegExpUnsupported(ctx, node, e.message);
-      return null;
-    }
-    throw e;
-  }
+  const compiled = compileStaticStandaloneRegExp(ctx, pattern, flags, node);
+  if (compiled === null) return null;
 
   const typeIdx = ensureStandaloneRegExpStruct(ctx);
   // field 0: flags
@@ -719,26 +777,7 @@ export function tryCompileStandaloneStringSearch(
  * Returns `null` when the flags can't be statically determined.
  */
 function staticRegExpFlags(ctx: CodegenContext, expr: ts.Expression): string | null {
-  const unwrapped = stripStaticWrapper(expr);
-  if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) {
-    const text = (unwrapped as ts.RegularExpressionLiteral).text;
-    const lastSlash = text.lastIndexOf("/");
-    return lastSlash >= 0 ? text.slice(lastSlash + 1) : "";
-  }
-  if (ts.isNewExpression(unwrapped) || (ts.isCallExpression(unwrapped) && !unwrapped.questionDotToken)) {
-    const callee = stripStaticWrapper(unwrapped.expression);
-    if (!ts.isIdentifier(callee) || !isGlobalRegExpIdentifier(ctx, callee)) return null;
-    const flagsArg = unwrapped.arguments?.[1];
-    if (flagsArg === undefined) return "";
-    const flags = staticStringValue(ctx, flagsArg);
-    return flags === null ? null : (flags ?? "");
-  }
-  if (ts.isIdentifier(unwrapped)) {
-    const sym = ctx.checker.getSymbolAtLocation(unwrapped);
-    const decl = sym?.getDeclarations()?.find((d) => ts.isVariableDeclaration(d)) as ts.VariableDeclaration | undefined;
-    if (decl?.initializer) return staticRegExpFlags(ctx, decl.initializer);
-  }
-  return null;
+  return staticRegExpPatternFlags(ctx, expr)?.flags ?? null;
 }
 
 /**
@@ -852,4 +891,106 @@ export function tryCompileStandaloneStringReplace(
   fctx.body.push({ op: "i32.const", value: globalReplace ? 1 : 0 });
   fctx.body.push({ op: "call", funcIdx: replaceIdx });
   return nativeStringType(ctx);
+}
+
+function regexCanMatchEmpty(compiled: CompiledRegex): boolean {
+  return regexSearch(compiled.prog, compiled.classTable, compiled.nGroups, "", 0, false) !== null;
+}
+
+/**
+ * `String.prototype.split(re)` in standalone mode (#1539 Phase 2c) —
+ * non-capturing, non-nullable static RegExp separator only.
+ *
+ * Capturing-group split has extra result interleaving semantics, and nullable
+ * separators need the full SplitMatch/AdvanceStringIndex edge-case handling.
+ * Both stay narrowed refusals until the capture-array/string-method follow-up.
+ */
+export function tryCompileStandaloneStringSplit(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "split") return undefined;
+
+  if (!isStringLikeArg(ctx, propAccess.expression)) return undefined;
+  if (expr.arguments.length === 0) return undefined;
+  const reExpr = expr.arguments[0]!;
+  const reType = ctx.checker.getTypeAtLocation(reExpr);
+  if (!isGlobalRegExpType(reType) && !isKnownBackendCreatedRegExpReceiver(ctx, reExpr)) {
+    return undefined; // not a RegExp arg -> native string split / generic path
+  }
+
+  if (expr.arguments.length !== 1) {
+    reportStandaloneRegExpUnsupported(ctx, expr.arguments[1] ?? expr, "String.prototype.split(RegExp, limit)");
+    return null;
+  }
+
+  const meta = staticRegExpPatternFlags(ctx, reExpr);
+  if (meta === null) {
+    reportStandaloneRegExpUnsupported(ctx, reExpr, "String.prototype.split with dynamic RegExp separators");
+    return null;
+  }
+
+  const compiled = compileStaticStandaloneRegExp(ctx, meta.pattern, meta.flags, reExpr);
+  if (compiled === null) return null;
+  if (compiled.nGroups !== 1) {
+    reportStandaloneRegExpUnsupported(ctx, reExpr, "String.prototype.split with capturing groups (#1539 Phase 2b/2c)");
+    return null;
+  }
+  if (regexCanMatchEmpty(compiled)) {
+    reportStandaloneRegExpUnsupported(
+      ctx,
+      reExpr,
+      "String.prototype.split with empty-match separators (#1539 Phase 2c)",
+    );
+    return null;
+  }
+
+  if (!hasStandaloneRegExpEngine(ctx)) {
+    reportStandaloneRegExpUnsupported(ctx, expr, "String.prototype.split without an enabled standalone engine");
+    return null;
+  }
+
+  ensureNativeStringHelpers(ctx);
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  if (flattenIdx === undefined) {
+    reportError(ctx, expr, "Codegen error: standalone RegExp backend missing native string helpers (#682).");
+    return null;
+  }
+  const splitIdx = ensureRegexSplit(ctx);
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+
+  const loaded = loadStandaloneRegExpStruct(ctx, fctx, reExpr);
+  if (loaded === null) return null;
+  const { regexpLocal, structTypeIdx } = loaded;
+
+  const subjType = compileExpression(ctx, fctx, propAccess.expression, nativeStringType(ctx));
+  if (subjType?.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  fctx.body.push({ op: "call", funcIdx: flattenIdx });
+  const subjLocal = allocLocal(fctx, `__re_split_subj_${fctx.locals.length}`, { kind: "ref", typeIdx: strTypeIdx });
+  fctx.body.push({ op: "local.set", index: subjLocal });
+
+  // __regex_split(prog, classTable, nGroups, subjData, subjOff, subjLen, subject)
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG });
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_CLASS_TABLE });
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
+  fctx.body.push({ op: "local.get", index: subjLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }); // data
+  fctx.body.push({ op: "local.get", index: subjLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }); // off
+  fctx.body.push({ op: "local.get", index: subjLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }); // len
+  fctx.body.push({ op: "local.get", index: subjLocal });
+  fctx.body.push({ op: "call", funcIdx: splitIdx });
+
+  const nstrVecTypeIdx = ctx.vecTypeMap.get(`ref_${ctx.anyStrTypeIdx}`);
+  if (nstrVecTypeIdx === undefined) {
+    reportError(ctx, expr, "Codegen error: standalone RegExp split missing native string vec type (#1539).");
+    return null;
+  }
+  return { kind: "ref", typeIdx: nstrVecTypeIdx };
 }

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -21,7 +21,11 @@ import {
   nativeStringTypeNullable,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
-import { tryCompileStandaloneStringReplace, tryCompileStandaloneStringSearch } from "./regexp-standalone.js";
+import {
+  tryCompileStandaloneStringReplace,
+  tryCompileStandaloneStringSearch,
+  tryCompileStandaloneStringSplit,
+} from "./regexp-standalone.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterTemplateVecType, getOrRegisterVecType } from "./registry/types.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts, registerCompileStringLiteral } from "./shared.js";
@@ -2440,9 +2444,10 @@ export function compileNativeStringMethodCall(
     return compileExpression(ctx, fctx, propAccess.expression);
   }
 
-  // #1474 — These host-routed string methods build/consume a JS RegExp under
-  // the hood. There is no Wasm-native regex engine yet, so refuse in
-  // --target standalone (Phase 1: refuse-and-document).
+  // #1474/#1539 — These host-routed string methods build/consume a JS RegExp
+  // under the hood. In --target standalone, route the supported static RegExp
+  // slices through the pure-WasmGC matcher first, then refuse the remaining
+  // host/symbol-protocol forms with a clean diagnostic.
   //   - match / matchAll / search: the spec coerces the (string) argument to a
   //     RegExp, so they always route through the host regex engine.
   //   - replace / replaceAll / split: only when the first argument needs
@@ -2464,6 +2469,14 @@ export function compileNativeStringMethodCall(
   if (ctx.standalone && (method === "replace" || method === "replaceAll")) {
     const replaceResult = tryCompileStandaloneStringReplace(ctx, fctx, expr, propAccess);
     if (replaceResult !== undefined) return replaceResult;
+  }
+
+  // #1539 Phase 2c — `String.prototype.split(/re/)` against a backend-created
+  // static, non-capturing, non-nullable RegExp routes through the pure-WasmGC
+  // matcher and returns the same native string vec shape as string split.
+  if (ctx.standalone && method === "split") {
+    const splitResult = tryCompileStandaloneStringSplit(ctx, fctx, expr, propAccess);
+    if (splitResult !== undefined) return splitResult;
   }
 
   if (ctx.standalone) {

--- a/tests/issue-1474-standalone-regex-refuse.test.ts
+++ b/tests/issue-1474-standalone-regex-refuse.test.ts
@@ -31,8 +31,8 @@ async function expectRefused(src: string): Promise<ReturnType<typeof compile>> {
 // #1539 Phase 2a narrowed these refusals: a static-pattern `RegExp.prototype.
 // test` now compiles to the pure-WasmGC backtracking VM (see
 // tests/issue-1539-standalone-regex.test.ts). The cases below are the residual
-// forms that are STILL refused — dynamic patterns, the String.prototype
-// regex-coercing methods (Phase 2c), and out-of-subset pattern features.
+// forms that are STILL refused — dynamic patterns, capture-materializing
+// String.prototype regex methods, and out-of-subset pattern features.
 describe("#1474/#1539 --target standalone still refuses (narrowed)", () => {
   it("rejects new RegExp(dynamicPattern, ...)", async () => {
     await expectRefused(`export function f(p: string): boolean { return new RegExp(p, "g").test("x"); }`);
@@ -60,12 +60,18 @@ describe("#1474/#1539 --target standalone still refuses (narrowed)", () => {
     expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
   });
 
-  it("rejects s.split(regexArg) — Phase 2c", async () => {
-    await expectRefused(`export function f(s: string): number { const r = /,/; return s.split(r).length; }`);
+  it("compiles s.split(regexArg) — non-capturing Phase 2c slice", async () => {
+    const r = await compile(`export function f(s: string): number { const r = /,/; return s.split(r).length; }`, {
+      target: "standalone",
+    });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
   });
 
-  it("rejects s.replace(regexArg, ...) — Phase 2c", async () => {
-    await expectRefused(`export function f(s: string): string { const r = /a/g; return s.replace(r, "b"); }`);
+  it("compiles s.replace(regexArg, literal) — Phase 2c slice", async () => {
+    const r = await compile(`export function f(s: string): string { const r = /a/g; return s.replace(r, "b"); }`, {
+      target: "standalone",
+    });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
   });
 
   it("emits no env::RegExp_new import when refused", async () => {

--- a/tests/issue-1539-standalone-regex.test.ts
+++ b/tests/issue-1539-standalone-regex.test.ts
@@ -133,6 +133,69 @@ describe("#1539 standalone String.prototype.search — no JS host, matches nativ
   });
 });
 
+async function standaloneSplit(pattern: string, flags: string, input: string): Promise<string[]> {
+  const inLit = JSON.stringify(input);
+  const src = `
+    const __parts: string[] = ${inLit}.split(/${pattern}/${flags});
+    export function count(): number { return __parts.length; }
+    export function len(i: number): number { return __parts[i]!.length; }
+    export function at(i: number, j: number): number { return __parts[i]!.charCodeAt(j); }
+  `;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostRegex = WebAssembly.Module.imports(mod).filter((i) => /RegExp|string_split|__make_iterable/.test(i.name));
+  expect(hostRegex, "no RegExp/string_split/iterable host import in standalone").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { count(): number; len(i: number): number; at(i: number, j: number): number };
+  const out: string[] = [];
+  for (let i = 0; i < ex.count(); i++) {
+    let part = "";
+    for (let j = 0; j < ex.len(i); j++) part += String.fromCharCode(ex.at(i, j));
+    out.push(part);
+  }
+  return out;
+}
+
+describe("#1539 standalone String.prototype.split — no JS host, matches native", () => {
+  const splitCases: Array<{ p: string; f: string; input: string }> = [
+    { p: ",", f: "", input: "a,b,c" },
+    { p: "[;,] *", f: "", input: "a, b; c" },
+    { p: "-+", f: "", input: "one--two---three" },
+    { p: "\\d+", f: "", input: "abc123def45" },
+    { p: "x", f: "i", input: "startXmidXend" },
+    { p: "^b$", f: "m", input: "a\nb\nc" },
+  ];
+  for (const { p, f, input } of splitCases) {
+    it(`${JSON.stringify(input)}.split(/${p}/${f})`, async () => {
+      expect(await standaloneSplit(p, f, input)).toEqual(input.split(new RegExp(p, f)));
+    });
+  }
+
+  it("var-bound RegExp argument", async () => {
+    const src = `
+      const re = /,+/;
+      const __parts: string[] = "a,,b,c".split(re);
+      export function run(): number { return __parts.length * 10 + __parts[1]!.length; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { run(): number }).run()).toBe(31);
+  });
+
+  it("new RegExp(...) argument", async () => {
+    const src = `
+      const __parts: string[] = "a--b-c".split(new RegExp("-+"));
+      export function run(): number { return __parts.length * 10 + __parts[2]!.length; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { run(): number }).run()).toBe(31);
+  });
+});
+
 describe("#1539 standalone narrowed refusals (Phase 2a)", () => {
   async function expectRefused(src: string): Promise<void> {
     const r = await compile(src, { target: "standalone" });
@@ -158,5 +221,14 @@ describe("#1539 standalone narrowed refusals (Phase 2a)", () => {
   });
   it("refuses indices flag (d, Phase 2d)", async () => {
     await expectRefused(`export function f(s: string): boolean { return /^a/d.test(s); }`);
+  });
+  it("refuses regex split with capturing groups", async () => {
+    await expectRefused(`export function f(s: string): number { return s.split(/(,)/).length; }`);
+  });
+  it("refuses regex split with a limit argument", async () => {
+    await expectRefused(`export function f(s: string): number { return s.split(/,/, 2).length; }`);
+  });
+  it("refuses regex split with empty-match separators", async () => {
+    await expectRefused(`export function f(s: string): number { return s.split(/a*/).length; }`);
   });
 });


### PR DESCRIPTION
## Summary

Adds the next #1539 standalone RegExp slice: `String.prototype.split(/re/)` for backend-created static RegExp separators in `--target standalone`.

- emits `__regex_split`, a pure-WasmGC helper that reuses `__regex_search` and returns the same native string vec shape as string split
- routes static non-capturing regex split before the old host-regex refusal, with no `RegExp_new`, `string_split`, or `__make_iterable` imports
- keeps capturing groups, `limit`, and empty-match separators as narrowed refusals until capture-array and zero-width split semantics land
- consolidates standalone regex flag/subset validation shared by literal struct emission and string-method routing

## Validation

- `pnpm exec prettier --check src/codegen/native-regex.ts src/codegen/regexp-standalone.ts src/codegen/string-ops.ts tests/issue-1474-standalone-regex-refuse.test.ts tests/issue-1539-standalone-regex.test.ts`
- `pnpm exec biome lint src/codegen/native-regex.ts src/codegen/regexp-standalone.ts src/codegen/string-ops.ts tests/issue-1474-standalone-regex-refuse.test.ts tests/issue-1539-standalone-regex.test.ts --diagnostic-level=error`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm vitest run tests/issue-1539-standalone-regex.test.ts tests/issue-1539-standalone-regex-replace.test.ts tests/issue-1474-standalone-regex-refuse.test.ts tests/regex-bytecode.test.ts`
