### PR TITLE
fix(codegen): keep array destructure fallback visible to late shifts

### DIFF
--- a/plan/issues/1891-gen-method-dstr-stale-funcidx-array-set.md
+++ b/plan/issues/1891-gen-method-dstr-stale-funcidx-array-set.md
@@ -1,7 +1,7 @@
 ---
 id: 1891
 title: "standalone: generator-method destructuring param emits invalid Wasm (array.set externref vs (ref null N)) — over-shifted funcIdx after generator-body late imports"
-status: in-progress
+status: in-review
 created: 2026-06-05
 updated: 2026-06-06
 priority: high
@@ -14,6 +14,7 @@ sprint: 60
 related: [1890, 1839, 1602, 1886, 1530]
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:09:55.112Z
+pr: 1248
 ---
 # #1891 — generator-method dstr param uses an over-shifted funcIdx → invalid Wasm
 
@@ -84,7 +85,7 @@ catches a `call` whose resolved target type mismatches the consuming op.
 
 ## Final findings
 
-Implemented in branch `symphony/1891`.
+Implemented in branch `symphony/1891`; review PR: #1248.
 
 The local repro refined the stale-index shape: in the array externref conversion
 path, `destructureParamArray` built fallback calls to `__extern_length` /

--- a/plan/issues/1891-gen-method-dstr-stale-funcidx-array-set.md
+++ b/plan/issues/1891-gen-method-dstr-stale-funcidx-array-set.md
@@ -1,9 +1,9 @@
 ---
 id: 1891
 title: "standalone: generator-method destructuring param emits invalid Wasm (array.set externref vs (ref null N)) — over-shifted funcIdx after generator-body late imports"
-status: ready
+status: in-progress
 created: 2026-06-05
-updated: 2026-06-05
+updated: 2026-06-06
 priority: high
 feasibility: medium
 task_type: bugfix
@@ -12,6 +12,8 @@ language_feature: generators, destructuring-params, late-imports
 goal: standalone-mode
 sprint: 60
 related: [1890, 1839, 1602, 1886, 1530]
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:09:55.112Z
 ---
 # #1891 — generator-method dstr param uses an over-shifted funcIdx → invalid Wasm
 
@@ -79,3 +81,30 @@ catches a `call` whose resolved target type mismatches the consuming op.
   module and run.
 - No regression in non-generator dstr / dstr-param suites.
 - A standalone unit test for `*gen([a, ...rest])` and `*gen([a, b])`.
+
+## Final findings
+
+Implemented in branch `symphony/1891`.
+
+The local repro refined the stale-index shape: in the array externref conversion
+path, `destructureParamArray` built fallback calls to `__extern_length` /
+`__extern_get_idx`, then recursively entered the typed vec destructuring path.
+That typed path manually swapped into a detached `destructInstrs` buffer and
+kept the new buffer visible to late-import fixups, but it did not keep the
+previous body visible. When `emitBoundsCheckedArrayGetUndef` later added the
+`__get_undefined` import, the real native object-runtime helper slots shifted,
+but the fallback calls in the previous body stayed stale-low and landed on the
+adjacent object helper slots.
+
+Fix: route both nullable tuple and vec destructuring body swaps through the
+existing `pushBody` / `popBody` helper so the active destructuring buffer and the
+saved previous body are both reachable to `shiftLateImportIndices`.
+
+Validation:
+- `node node_modules/vitest/dist/cli.js run tests/issue-1891.test.ts`
+- `node node_modules/vitest/dist/cli.js run tests/issue-1891.test.ts tests/issue-1314.test.ts tests/issue-1553d.test.ts tests/equivalence/basic-destructuring.test.ts tests/equivalence/destructuring-type-coercion.test.ts tests/generator-method-destructuring.test.ts`
+
+Note: an accidental broad `pnpm test -- tests/issue-1891.test.ts` invocation
+expanded beyond the target file and eventually OOMed after reporting unrelated
+baseline failures. The scoped direct Vitest commands above are the relevant
+validation for this issue.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -1281,13 +1281,15 @@ export function destructureParamArray(
       if (isNullable && pattern.elements.length > 0) {
         addStringConstantGlobal(ctx, "Cannot destructure 'null' or 'undefined'");
       }
-      const savedBody = fctx.body;
-      const destructInstrs: Instr[] = [];
+      let savedBody: Instr[] | undefined;
+      let destructInstrs: Instr[] = [];
       if (isNullable) {
-        // Keep `destructInstrs` reachable to index fixups while it is the
-        // active emission buffer (#1553d — see vec path note below).
-        fctx.savedBodies.push(destructInstrs);
-        fctx.body = destructInstrs;
+        // Keep both sides of the body swap reachable to index fixups. Late
+        // imports can be triggered while emitting `destructInstrs`; callers such
+        // as the externref conversion path have already populated the previous
+        // body with call indices that must shift too (#1891).
+        savedBody = pushBody(fctx);
+        destructInstrs = fctx.body;
       }
 
       for (let i = 0; i < pattern.elements.length; i++) {
@@ -1348,8 +1350,7 @@ export function destructureParamArray(
 
       // Close null guard — throw TypeError when null (JS spec)
       if (isNullable) {
-        fctx.savedBodies.pop();
-        fctx.body = savedBody;
+        popBody(fctx, savedBody!);
         if (destructInstrs.length > 0) {
           // When param is null (e.g. empty array cast failed), apply element defaults
           const nullDefaultInstrs: Instr[] = [];
@@ -1420,17 +1421,15 @@ export function destructureParamArray(
   if (isNullable && pattern.elements.length > 0) {
     addStringConstantGlobal(ctx, "Cannot destructure 'null' or 'undefined'");
   }
-  const savedBody = fctx.body;
-  const destructInstrs: Instr[] = [];
+  let savedBody: Instr[] | undefined;
+  let destructInstrs: Instr[] = [];
   if (isNullable) {
-    // Keep `destructInstrs` reachable to global/late-import index fixups while
-    // it is the active emission buffer. `fixupModuleGlobalIndices` and
-    // `shiftLateImportIndices` walk `ctx.currentFunc.body` (= the restored
-    // outer `savedBody`) plus `savedBodies`; a raw `fctx.body = destructInstrs`
-    // swap leaves the new buffer invisible to those walks, so a function-call
-    // default (`[x = f()]`, where `f` adds a late import) corrupts indices.
-    fctx.savedBodies.push(destructInstrs);
-    fctx.body = destructInstrs;
+    // Keep both sides of the body swap reachable to global/late-import index
+    // fixups. `destructInstrs` is the active body, while the saved body may
+    // already contain call indices emitted by the externref conversion fallback
+    // before this recursive typed destructure runs (#1891).
+    savedBody = pushBody(fctx);
+    destructInstrs = fctx.body;
   }
 
   for (let i = 0; i < pattern.elements.length; i++) {
@@ -1664,8 +1663,7 @@ export function destructureParamArray(
   // Close null guard — throw TypeError when null (JS spec)
   // Skip for empty `[]` patterns (#225).
   if (isNullable) {
-    fctx.savedBodies.pop();
-    fctx.body = savedBody;
+    popBody(fctx, savedBody!);
     if (destructInstrs.length > 0 && pattern.elements.length > 0) {
       fctx.body.push({ op: "local.get", index: paramIdx });
       fctx.body.push({ op: "ref.is_null" } as Instr);

--- a/tests/issue-1891.test.ts
+++ b/tests/issue-1891.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-1891.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(result.binary)).resolves.toBeDefined();
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#1891 — standalone generator-method destructuring params keep call indices stable", () => {
+  it("array rest parameter validates and executes", async () => {
+    const value = await runStandalone(`
+      let seen = 0;
+      class C {
+        *gen([a, ...rest]: any) {
+          seen = a + rest[0];
+          yield seen;
+        }
+      }
+      export function run(): number {
+        new C().gen([2, 5]).next();
+        return seen;
+      }
+    `);
+    expect(value).toBe(7);
+  });
+
+  it("array parameter without rest validates and executes", async () => {
+    const value = await runStandalone(`
+      let seen = 0;
+      class C {
+        *gen([a, b]: any) {
+          seen = a * 10 + b;
+          yield a;
+        }
+      }
+      export function run(): number {
+        new C().gen([3, 4]).next();
+        return seen;
+      }
+    `);
+    expect(value).toBe(34);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1891 by routing nullable tuple and vec destructuring body swaps through the shared body stack. That keeps both the active destructuring buffer and the previously emitted externref conversion fallback visible to late-import function-index fixups.

## Root Cause

The standalone generator-method array destructuring path built fallback calls to `__extern_length` / `__extern_get_idx`, then recursively entered typed vec destructuring. The typed path manually swapped into a detached `destructInstrs` buffer and only kept that new buffer visible. A later `__get_undefined` import shifted the real helper slots, while the fallback calls in the previous body stayed stale and landed on adjacent object-runtime helpers, producing invalid Wasm at `array.set`.

## Validation

- `node node_modules/vitest/dist/cli.js run tests/issue-1891.test.ts`
- `node node_modules/vitest/dist/cli.js run tests/issue-1891.test.ts tests/issue-1314.test.ts tests/issue-1553d.test.ts tests/equivalence/basic-destructuring.test.ts tests/equivalence/destructuring-type-coercion.test.ts tests/generator-method-destructuring.test.ts`
- Post-merge with `origin/main`: same scoped multi-file Vitest command passed.

Note: an accidental broad `pnpm test -- tests/issue-1891.test.ts` invocation expanded beyond the target file and eventually OOMed after unrelated baseline failures. The direct Vitest file-list commands above are the scoped validation for this PR.
