### PR TITLE
fix(bigint): add standalone BigInt carrier

### DIFF
--- a/plan/issues/1644-spec-gap-bigint-typed-paths.md
+++ b/plan/issues/1644-spec-gap-bigint-typed-paths.md
@@ -1,9 +1,9 @@
 ---
 id: 1644
 title: "spec gap: BigInt typed-path eager f64 assumptions (47 test262 fails, 4 illegal_cast + 13 runtime)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-27
+updated: 2026-06-06
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -14,6 +14,8 @@ goal: spec-completeness
 sprint: 60
 renumbered_from: 1350
 parent: 1328
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:10:20.967Z
 ---
 # #1350 — BigInt: typed paths assume f64 too eagerly
 
@@ -501,3 +503,36 @@ WASI-mode BigInt fails clear. Residual host-class items
 (`is-a-constructor`, wrapper-object) stay with #1568 (BigInt extern wrapper
 class) — explicitly out of #1644 scope per the Slice-B residual note above.
 
+## Implementation 2026-06-06 (codex-developer) — Slice E1 standalone carrier
+
+Landed the load-bearing standalone `$BigInt` carrier in the native union-helper
+path:
+
+- No-JS-host `__box_bigint(i64) -> externref`, `__to_bigint(externref) -> i64`,
+  `__bigint_ctor(externref) -> i64`, and `__typeof_bigint(externref) -> i32`
+  are registered as native funcs instead of env imports under WASI/standalone.
+- Native `typeof`, truthiness, object-type exclusion, and dynamic strict
+  equality now recognize the `$BigInt` struct, so a bigint can round-trip
+  through `any`/`externref` without falling back to boxed number semantics.
+- `BigInt("...")` string/no-substitution-template literal calls fold to
+  bigint-branded `i64.const` for decimal and prefixed numeric strings that fit
+  signed i64; malformed strings stay on the runtime path.
+
+Validation:
+
+- `npm test -- tests/issue-1644.test.ts` — pass (11 tests).
+- `npm test -- tests/issue-1644.test.ts tests/issue-1644-sliceb.test.ts tests/issue-1644-slice-d.test.ts` — pass (24 tests).
+- `pnpm run typecheck` — pass.
+- Scoped standalone test262 only:
+  `TEST262_TARGET=standalone TEST262_REPORTER=basic TEST262_LOCAL_SHARD_GLOB='tests/test262-local-shard[1-6].test.ts' TEST262_PATH_FILTER='built-ins/BigInt/constructor-from-hex-string.js|built-ins/BigInt/constructor-from-decimal-string.js|built-ins/BigInt/constructor-from-string-syntax-errors.js|built-ins/BigInt/non-integer-rangeerror.js|built-ins/BigInt/asIntN/bigint-tobigint.js|built-ins/BigInt/asUintN/bigint-tobigint.js' pnpm run test:262 -- --official-scope-only`
+  — report `2 pass / 6 total`. Passing: `constructor-from-string-syntax-errors.js`,
+  `non-integer-rangeerror.js`. Residual compile errors are the pre-existing
+  standalone dynamic built-in/property gap (`__get_builtin`, #1472) for
+  `asIntN`/`asUintN` harness access and object-to-primitive conversion for the
+  decimal/hex constructor harness assertions.
+
+Residual Slice E work after this PR:
+
+- Native standalone dynamic string parser for non-literal `BigInt(string)` inputs.
+- Native standalone `BigInt.prototype.toString(radix)` helper parity with Slice D
+  host imports.

--- a/plan/issues/1644-spec-gap-bigint-typed-paths.md
+++ b/plan/issues/1644-spec-gap-bigint-typed-paths.md
@@ -1,7 +1,7 @@
 ---
 id: 1644
 title: "spec gap: BigInt typed-path eager f64 assumptions (47 test262 fails, 4 illegal_cast + 13 runtime)"
-status: in-progress
+status: in-review
 created: 2026-05-08
 updated: 2026-06-06
 priority: medium
@@ -14,6 +14,7 @@ goal: spec-completeness
 sprint: 60
 renumbered_from: 1350
 parent: 1328
+pr: 1249
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:10:20.967Z
 ---

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1777,8 +1777,10 @@ export function compileBinaryExpression(
       addUnionImports(ctx);
       const typeofNum = ctx.funcMap.get("__typeof_number")!;
       const typeofBool = ctx.funcMap.get("__typeof_boolean")!;
+      const typeofBigint = ctx.funcMap.get("__typeof_bigint")!;
       const unboxNum = ctx.funcMap.get("__unbox_number")!;
       const unboxBool = ctx.funcMap.get("__unbox_boolean")!;
+      const toBigint = ctx.funcMap.get("__to_bigint")!;
 
       // Coerce both operands to externref temps (right is on top of stack).
       const rTmp = allocTempLocal(fctx, { kind: "externref" });
@@ -1827,39 +1829,58 @@ export function compileBinaryExpression(
                 { op: "i32.eq" } as Instr,
               ],
               else: [
-                // ── reference identity ──
-                // Both must be WasmGC eqref for ref.eq; otherwise unequal.
+                // ── bigint? ──
                 { op: "local.get", index: lTmp },
-                { op: "any.convert_extern" } as Instr,
+                { op: "call", funcIdx: typeofBigint } as Instr,
                 { op: "local.get", index: rTmp },
-                { op: "any.convert_extern" } as Instr,
-                ...(() => {
-                  const lAny = allocTempLocal(fctx, { kind: "anyref" });
-                  const rAny = allocTempLocal(fctx, { kind: "anyref" });
-                  const seq: Instr[] = [
-                    { op: "local.set", index: rAny },
-                    { op: "local.tee", index: lAny },
-                    { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
-                    { op: "local.get", index: rAny },
-                    { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
-                    { op: "i32.and" } as Instr,
-                    {
-                      op: "if",
-                      blockType: { kind: "val", type: { kind: "i32" } },
-                      then: [
-                        { op: "local.get", index: lAny },
-                        { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+                { op: "call", funcIdx: typeofBigint } as Instr,
+                { op: "i32.and" } as Instr,
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: { kind: "i32" } },
+                  then: [
+                    { op: "local.get", index: lTmp },
+                    { op: "call", funcIdx: toBigint },
+                    { op: "local.get", index: rTmp },
+                    { op: "call", funcIdx: toBigint },
+                    { op: "i64.eq" } as Instr,
+                  ],
+                  else: [
+                    // ── reference identity ──
+                    // Both must be WasmGC eqref for ref.eq; otherwise unequal.
+                    { op: "local.get", index: lTmp },
+                    { op: "any.convert_extern" } as Instr,
+                    { op: "local.get", index: rTmp },
+                    { op: "any.convert_extern" } as Instr,
+                    ...(() => {
+                      const lAny = allocTempLocal(fctx, { kind: "anyref" });
+                      const rAny = allocTempLocal(fctx, { kind: "anyref" });
+                      const seq: Instr[] = [
+                        { op: "local.set", index: rAny },
+                        { op: "local.tee", index: lAny },
+                        { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
                         { op: "local.get", index: rAny },
-                        { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
-                        { op: "ref.eq" } as Instr,
-                      ],
-                      else: [{ op: "i32.const", value: 0 }],
-                    } as Instr,
-                  ];
-                  releaseTempLocal(fctx, lAny);
-                  releaseTempLocal(fctx, rAny);
-                  return seq;
-                })(),
+                        { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
+                        { op: "i32.and" } as Instr,
+                        {
+                          op: "if",
+                          blockType: { kind: "val", type: { kind: "i32" } },
+                          then: [
+                            { op: "local.get", index: lAny },
+                            { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+                            { op: "local.get", index: rAny },
+                            { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+                            { op: "ref.eq" } as Instr,
+                          ],
+                          else: [{ op: "i32.const", value: 0 }],
+                        } as Instr,
+                      ];
+                      releaseTempLocal(fctx, lAny);
+                      releaseTempLocal(fctx, rAny);
+                      return seq;
+                    })(),
+                  ],
+                } as Instr,
               ],
             } as Instr,
           ],

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7865,6 +7865,20 @@ function compileCallExpression(
         fctx.body.push({ op: "i64.const", value: BigInt(litNum) } as Instr);
         return { kind: "i64", bigint: true };
       }
+      if (ts.isStringLiteral(litArg) || ts.isNoSubstitutionTemplateLiteral(litArg)) {
+        try {
+          const litBig = BigInt(litArg.text);
+          const minI64 = -(1n << 63n);
+          const maxI64 = (1n << 63n) - 1n;
+          if (litBig >= minI64 && litBig <= maxI64) {
+            fctx.body.push({ op: "i64.const", value: litBig } as Instr);
+            return { kind: "i64", bigint: true };
+          }
+        } catch {
+          // Keep malformed strings on the runtime path so JS-host mode throws
+          // the native SyntaxError and no-JS-host mode uses its native throw.
+        }
+      }
 
       const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
       if (argType?.kind === "i32") {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -49,7 +49,13 @@ import {
 import { emitInlineMathFunctions } from "./math-helpers.js";
 import { finalizeMethodTrampolines } from "./closures.js";
 import { peepholeOptimize } from "./peephole.js";
-import { addImport, addStringConstantGlobal, localGlobalIdx, nextModuleGlobalIdx } from "./registry/imports.js";
+import {
+  addImport,
+  addStringConstantGlobal,
+  ensureExnTag,
+  localGlobalIdx,
+  nextModuleGlobalIdx,
+} from "./registry/imports.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
 import {
   addFuncType,
@@ -97,6 +103,7 @@ import {
   flatStringType,
   nativeStringType,
   nativeStringTypeNullable,
+  stringConstantExternrefInstrs,
 } from "./native-strings.js";
 import { emitJsonQuoteString } from "./json-runtime.js";
 
@@ -7821,6 +7828,10 @@ export function addUnionImports(ctx: CodegenContext): void {
     kind: "func",
     typeIdx: typeofType,
   });
+  addImport(ctx, "env", "__typeof_bigint", {
+    kind: "func",
+    typeIdx: typeofType,
+  });
   addImport(ctx, "env", "__typeof_undefined", {
     kind: "func",
     typeIdx: typeofType,
@@ -7896,6 +7907,7 @@ export function addUnionImports(ctx: CodegenContext): void {
       "__typeof_number",
       "__typeof_string",
       "__typeof_boolean",
+      "__typeof_bigint",
       "__typeof_undefined",
       "__typeof_object",
       "__typeof_function",
@@ -8102,12 +8114,21 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
   });
 
+  const bigIntStructIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$BigInt",
+    fields: [{ name: "value", type: { kind: "i64", bigint: true }, mutable: false }],
+  });
+
   // 2. Pre-compute func types — addFuncType de-dupes by signature so
   //    repeated calls return the same typeIdx.
   const externrefToI32 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
   const externrefToF64 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "f64" }]);
+  const externrefToI64 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i64", bigint: true }]);
   const f64ToExternref = addFuncType(ctx, [{ kind: "f64" }], [{ kind: "externref" }]);
   const i32ToExternref = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "externref" }]);
+  const i64ToExternref = addFuncType(ctx, [{ kind: "i64", bigint: true }], [{ kind: "externref" }]);
   const externrefToExternref = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
 
   /**
@@ -8124,6 +8145,18 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.funcMap.set(name, funcIdx);
     ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false });
+  };
+
+  const throwNativeError = (errorName: "TypeError" | "RangeError" | "SyntaxError", message: string): Instr[] => {
+    emitWasiErrorConstructor(ctx, errorName, 1);
+    addStringConstantGlobal(ctx, message);
+    const ctorIdx = ctx.funcMap.get(`__new_${errorName}`)!;
+    const tagIdx = ensureExnTag(ctx);
+    return [
+      ...stringConstantExternrefInstrs(ctx, message),
+      { op: "call", funcIdx: ctorIdx },
+      { op: "throw", tagIdx } as Instr,
+    ];
   };
 
   // 3. __box_number(f64) -> externref
@@ -8178,6 +8211,15 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     { op: "extern.convert_any" },
   ]);
 
+  // #1644 Slice E1 — __box_bigint(i64) -> externref. In no-JS-host mode a
+  // bigint-branded i64 needs a WasmGC carrier so it cannot fall through to the
+  // number-box path and lose its BigInt identity at the externref frontier.
+  registerNative("__box_bigint", i64ToExternref, [
+    { op: "local.get", index: 0 },
+    { op: "struct.new", typeIdx: bigIntStructIdx },
+    { op: "extern.convert_any" },
+  ]);
+
   // 6. __unbox_boolean(externref) -> i32
   //    Returns the boxed value if it's a __box_boolean_struct, otherwise
   //    falls back to Boolean-coercion: null → false, any non-null ref
@@ -8215,6 +8257,141 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
       { op: "i32.const", value: 0 },
     ],
     [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+  );
+
+  // #1644 Slice E1 — __to_bigint(externref) -> i64. This is the native
+  // ToBigInt frontier for values already represented by the standalone
+  // BigInt struct, plus boolean -> 0n/1n. Boxed numbers throw TypeError per
+  // ECMA-262 §7.1.13; native string parsing is deferred to the constructor
+  // slice, so unsupported non-BigInt refs also throw instead of becoming 0.
+  registerNative(
+    "__to_bigint",
+    externrefToI64,
+    [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: throwNativeError("TypeError", "Cannot convert null or undefined to a BigInt"),
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: bigIntStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: bigIntStructIdx },
+          { op: "struct.get", typeIdx: bigIntStructIdx, fieldIdx: 0 },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxBoolStructIdx },
+          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+          { op: "i64.extend_i32_u" },
+          { op: "return" },
+        ],
+      },
+      ...throwNativeError("TypeError", "Cannot convert value to a BigInt"),
+    ],
+    [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+  );
+
+  // #1644 Slice E1/E2 bridge — minimal no-JS-host BigInt(value). Handles the
+  // standalone carriers that can be represented without a string parser:
+  // bigint identity, boolean -> 0n/1n, and integral finite boxed numbers.
+  registerNative(
+    "__bigint_ctor",
+    externrefToI64,
+    [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: throwNativeError("TypeError", "Cannot convert null or undefined to a BigInt"),
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: bigIntStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: bigIntStructIdx },
+          { op: "struct.get", typeIdx: bigIntStructIdx, fieldIdx: 0 },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxBoolStructIdx },
+          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+          { op: "i64.extend_i32_u" },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxNumStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxNumStructIdx },
+          { op: "struct.get", typeIdx: boxNumStructIdx, fieldIdx: 0 },
+          { op: "local.tee", index: 2 },
+          { op: "local.get", index: 2 },
+          { op: "f64.ne" },
+          { op: "local.get", index: 2 },
+          { op: "f64.floor" },
+          { op: "local.get", index: 2 },
+          { op: "f64.ne" },
+          { op: "i32.or" },
+          { op: "local.get", index: 2 },
+          { op: "f64.const", value: 2 ** 63 },
+          { op: "f64.ge" },
+          { op: "i32.or" },
+          { op: "local.get", index: 2 },
+          { op: "f64.const", value: -(2 ** 63) },
+          { op: "f64.lt" },
+          { op: "i32.or" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: throwNativeError(
+              "RangeError",
+              "The number cannot be converted to a BigInt because it is not an integer",
+            ),
+          },
+          { op: "local.get", index: 2 },
+          { op: "i64.trunc_sat_f64_s" },
+          { op: "return" },
+        ],
+      },
+      ...throwNativeError("SyntaxError", "Cannot convert string to a BigInt in standalone mode"),
+    ],
+    [
+      { name: "$any_temp", type: { kind: "anyref" } as ValType },
+      { name: "$num_temp", type: { kind: "f64" } },
+    ],
   );
 
   // 7. __is_truthy(externref) -> i32
@@ -8270,6 +8447,21 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
           { op: "return" },
         ],
       },
+      // boxed bigint? → value !== 0n
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: bigIntStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: bigIntStructIdx },
+          { op: "struct.get", typeIdx: bigIntStructIdx, fieldIdx: 0 },
+          { op: "i64.eqz" },
+          { op: "i32.eqz" },
+          { op: "return" },
+        ],
+      },
       // any other non-null ref → truthy
       { op: "i32.const", value: 1 },
     ],
@@ -8307,7 +8499,21 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     { op: "ref.test", typeIdx: boxBoolStructIdx },
   ]);
 
-  // 10. __typeof_string(externref) -> i32. Under nativeStrings (auto-on
+  // 10. __typeof_bigint(externref) -> i32 — `ref.test $BigInt`.
+  registerNative("__typeof_bigint", externrefToI32, [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: bigIntStructIdx },
+  ]);
+
+  // 11. __typeof_string(externref) -> i32. Under nativeStrings (auto-on
   //     for wasi) strings are NativeString structs at `ctx.anyStrTypeIdx`.
   //     If that type isn't registered, return 0 (no string in scope).
   if (ctx.anyStrTypeIdx >= 0) {
@@ -8328,11 +8534,11 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     registerNative("__typeof_string", externrefToI32, [{ op: "i32.const", value: 0 }]);
   }
 
-  // 11. __typeof_undefined(externref) -> i32 — `ref.is_null`.
+  // 12. __typeof_undefined(externref) -> i32 — `ref.is_null`.
   registerNative("__typeof_undefined", externrefToI32, [{ op: "local.get", index: 0 }, { op: "ref.is_null" }]);
 
-  // 12. __typeof_object(externref) -> i32 — non-null AND not number AND
-  //     not boolean AND not function. We approximate as "non-null and
+  // 13. __typeof_object(externref) -> i32 — non-null AND not number AND
+  //     not boolean AND not bigint AND not function. We approximate as "non-null and
   //     not a boxed primitive" — sufficient for the common typeof
   //     dispatch use cases. Returns 0 conservatively for boxed numbers
   //     and boxed booleans.
@@ -8363,17 +8569,24 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
         blockType: { kind: "empty" },
         then: [{ op: "i32.const", value: 0 }, { op: "return" }],
       },
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: bigIntStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
       // non-null, not a boxed primitive → object
       { op: "i32.const", value: 1 },
     ],
     [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
   );
 
-  // 13. __typeof_function(externref) -> i32 — wasi binaries don't expose
+  // 14. __typeof_function(externref) -> i32 — wasi binaries don't expose
   //     callable JS functions to the outside, so this is conservatively 0.
   registerNative("__typeof_function", externrefToI32, [{ op: "i32.const", value: 0 }]);
 
-  // 14. __typeof(externref) -> externref — returns null externref under
+  // 15. __typeof(externref) -> externref — returns null externref under
   //     wasi. Producing real type-tag strings would require a NativeString
   //     per tag; defer until a wasi caller needs the typeof RESULT as a
   //     string (today's callers compare against literal tags via the

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -1020,6 +1020,7 @@ export function compileTypeofComparison(
   if (stringLiteral === "number") helperName = "__typeof_number";
   else if (stringLiteral === "string") helperName = "__typeof_string";
   else if (stringLiteral === "boolean") helperName = "__typeof_boolean";
+  else if (stringLiteral === "bigint") helperName = "__typeof_bigint";
   else if (stringLiteral === "undefined") helperName = "__typeof_undefined";
   else if (stringLiteral === "object") helperName = "__typeof_object";
   else if (stringLiteral === "function") helperName = "__typeof_function";

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -96,6 +96,7 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   if (name === "__typeof_number") return { type: "typeof_check", targetType: "number" };
   if (name === "__typeof_string") return { type: "typeof_check", targetType: "string" };
   if (name === "__typeof_boolean") return { type: "typeof_check", targetType: "boolean" };
+  if (name === "__typeof_bigint") return { type: "typeof_check", targetType: "bigint" };
   if (name === "__typeof_undefined") return { type: "typeof_check", targetType: "undefined" };
   if (name === "__typeof_object") return { type: "typeof_check", targetType: "object" };
   if (name === "__typeof_function") return { type: "typeof_check", targetType: "function" };

--- a/tests/equivalence/helpers.ts
+++ b/tests/equivalence/helpers.ts
@@ -46,6 +46,7 @@ export function buildImports(result: CompileResult): WebAssembly.Imports {
     __typeof_number: (v: unknown) => (typeof v === "number" ? 1 : 0),
     __typeof_string: (v: unknown) => (typeof v === "string" ? 1 : 0),
     __typeof_boolean: (v: unknown) => (typeof v === "boolean" ? 1 : 0),
+    __typeof_bigint: (v: unknown) => (typeof v === "bigint" ? 1 : 0),
     __typeof: (v: unknown) => typeof v,
     __instanceof: (v: any, ctorName: string) => {
       try {

--- a/tests/issue-1644.test.ts
+++ b/tests/issue-1644.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
 import { compileToWasm } from "./equivalence/helpers.js";
+
+async function runWasiNumber(source: string): Promise<{ value: number; envImports: string[]; wat: string }> {
+  const result = await compile(source, { fileName: "issue-1644.ts", target: "wasi" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const envImports = result.imports.filter((i) => i.module === "env").map((i) => i.name);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  const test = instance.exports.test as () => number;
+  return { value: test(), envImports, wat: result.wat };
+}
 
 // #1644 Slice A — bigint-branded i64 boxing.
 //
@@ -75,5 +86,83 @@ describe("#1644 Slice A — bigint i64 brand boxing", () => {
     const v = exports.test();
     expect(typeof v).toBe("number");
     expect(v).toBe(8);
+  });
+});
+
+describe("#1644 Slice E1 — standalone bigint externref carrier", () => {
+  it("WASI bigint boxes and unboxes through an any-returning function without BigInt host imports", async () => {
+    const { value, envImports, wat } = await runWasiNumber(`
+      function asAny(x: bigint): any { return x; }
+      export function test(): number {
+        const round: bigint = asAny(10n);
+        return round === 10n ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+    expect(envImports).not.toContain("__box_bigint");
+    expect(envImports).not.toContain("__to_bigint");
+    expect(wat).toContain("$BigInt");
+  });
+
+  it('WASI dynamic typeof sees boxed bigint as "bigint", not "object"', async () => {
+    const { value, envImports } = await runWasiNumber(`
+      function asAny(x: bigint): any { return x; }
+      export function test(): number {
+        const x: any = asAny(5n);
+        return typeof x === "bigint" ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+    expect(envImports).not.toContain("__typeof_bigint");
+  });
+
+  it("WASI boxed 0n is falsy", async () => {
+    const { value } = await runWasiNumber(`
+      function asAny(x: bigint): any { return x; }
+      export function test(): number {
+        const x: any = asAny(0n);
+        return x ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(0);
+  });
+
+  it("WASI boxed bigint strict equality compares the i64 payload", async () => {
+    const { value } = await runWasiNumber(`
+      function asAny(x: bigint): any { return x; }
+      export function test(): number {
+        const a: any = asAny(1n);
+        const b: any = asAny(1n);
+        return a === b ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+  });
+
+  it("WASI BigInt(string-literal) folds decimal and prefixed numeric strings", async () => {
+    const { value, envImports } = await runWasiNumber(`
+      export function test(): number {
+        const a = BigInt("42");
+        const b = BigInt("0xff");
+        return a === 42n && b === 255n ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+    expect(envImports).not.toContain("__bigint_ctor");
+  });
+
+  it("WASI BigInt(number) uses the native integer gate", async () => {
+    const { value, envImports } = await runWasiNumber(`
+      export function test(): number {
+        try {
+          BigInt(1.5);
+          return 0;
+        } catch {
+          return 1;
+        }
+      }
+    `);
+    expect(value).toBe(1);
+    expect(envImports).not.toContain("__bigint_ctor");
   });
 });


### PR DESCRIPTION
## Summary
- Add a no-JS-host `$BigInt` WasmGC carrier plus native BigInt box/unbox/constructor/typeof helpers.
- Wire standalone `typeof`, truthiness, object exclusion, and dynamic strict equality to preserve BigInt identity across `externref`.
- Fold literal `BigInt("...")` decimal/prefixed numeric strings into branded `i64.const` values when they fit signed i64.

## Validation
- `npm test -- tests/issue-1644.test.ts tests/issue-1644-sliceb.test.ts tests/issue-1644-slice-d.test.ts`
- `pnpm run typecheck`
- Scoped standalone test262: `TEST262_TARGET=standalone TEST262_REPORTER=basic TEST262_LOCAL_SHARD_GLOB='tests/test262-local-shard[1-6].test.ts' TEST262_PATH_FILTER='built-ins/BigInt/constructor-from-hex-string.js|built-ins/BigInt/constructor-from-decimal-string.js|built-ins/BigInt/constructor-from-string-syntax-errors.js|built-ins/BigInt/non-integer-rangeerror.js|built-ins/BigInt/asIntN/bigint-tobigint.js|built-ins/BigInt/asUintN/bigint-tobigint.js' pnpm run test:262 -- --official-scope-only` -> report `2 pass / 6 total`; residual compile errors are the existing standalone `__get_builtin` gap (#1472) for `asIntN`/`asUintN` harness access and object-to-primitive conversion for decimal/hex constructor harness assertions.

Spec refs: ToBigInt §7.1.13 https://tc39.es/ecma262/2026/multipage/abstract-operations.html ; `typeof` §13.5.3 https://tc39.es/ecma262/2026/multipage/ecmascript-language-expressions.html