### PR TITLE
fix(class): enforce private brands and super field order

### DIFF
--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -14,7 +14,7 @@ goal: spec-completeness
 sprint: 60
 parent: 1328
 claimed_by: codex-developer
-claimed_at: 2026-06-06T09:09:45.155Z
+claimed_at: 2026-06-06T09:42:52.777Z
 pr: 1250
 ---
 # #1348 — Class: static block order, private field exotics, super-class field shadow
@@ -256,6 +256,8 @@ Validation:
   tests/issue-1643.test.ts tests/issue-846h.test.ts tests/issue-1682.test.ts
   tests/class-static-private-this.test.ts` — pass (29 tests).
 - `pnpm exec tsc --noEmit --pretty false` — pass.
+- Rechecked before PR handoff on 2026-06-06 with the same scoped vitest set
+  and `pnpm exec tsc --noEmit --pretty false` — pass.
 
 Notes:
 

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -14,7 +14,7 @@ goal: spec-completeness
 sprint: 60
 parent: 1328
 claimed_by: codex-developer
-claimed_at: 2026-06-06T09:42:52.777Z
+claimed_at: 2026-06-06T09:51:22.932Z
 pr: 1250
 ---
 # #1348 — Class: static block order, private field exotics, super-class field shadow

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -256,8 +256,8 @@ Validation:
   tests/issue-1643.test.ts tests/issue-846h.test.ts tests/issue-1682.test.ts
   tests/class-static-private-this.test.ts` — pass (29 tests).
 - `pnpm exec tsc --noEmit --pretty false` — pass.
-- Rechecked before PR handoff on 2026-06-06 with the same scoped vitest set
-  and `pnpm exec tsc --noEmit --pretty false` — pass.
+- Rechecked after merging `origin/main` on 2026-06-06 with the same scoped
+  vitest set and `pnpm exec tsc --noEmit --pretty false` — pass.
 
 Notes:
 

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -1,9 +1,9 @@
 ---
 id: 1348
 title: "spec gap: class static initialization order + private field semantics (significant share of 1500+ class fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
-updated: 2026-05-24
+updated: 2026-06-06
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -13,6 +13,8 @@ language_feature: class
 goal: spec-completeness
 sprint: 60
 parent: 1328
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:09:45.155Z
 ---
 # #1348 — Class: static block order, private field exotics, super-class field shadow
 
@@ -218,3 +220,47 @@ field order/identity.
   `language/statements/class/elements/static-*` as the guard.
 - No new host imports — codegen ordering + `ref.test` brand checks + native
   throws (#1473, standalone-safe). Dual-mode clean. ✓
+
+## Codex implementation notes (2026-06-06)
+
+Implemented the residual class/private semantics that still reproduced locally:
+
+- Private brand checks now combine the existing `ref.test` with the hidden class
+  tag and descendant-tag ancestry. This rejects unrelated classes that declare
+  the same private name and compile to an equivalent WasmGC struct shape, while
+  preserving subclass instances as valid receivers for ancestor private names.
+  The shared predicate is used by both `#x in obj` and `obj.#x` reads.
+- Explicit derived constructors now defer their own instance field initializers
+  until the handled `super()` call returns. `compileSuperCall` also replays
+  superclass field declaration initializers before child initializers, so
+  same-named child fields overwrite after parent side effects run.
+- Static field/static-block source order was already mostly implemented on this
+  branch; added focused regression coverage for public static fields/blocks and
+  static blocks reading earlier private static fields.
+
+Spec references checked before implementation:
+
+- ECMA-262 §15.7.14 ClassDefinitionEvaluation: class elements are evaluated and
+  static field/block records execute during class evaluation.
+- ECMA-262 §13.3.7.1 SuperCall: after constructing the super constructor,
+  `InitializeInstanceElements(result, funcObj)` runs for the derived constructor.
+- ECMA-262 §7.3.26 PrivateElementFind / §7.3.30 PrivateGet: private membership
+  is keyed by the declaring private name, not by structural field shape.
+
+Validation:
+
+- `node node_modules/vitest/dist/cli.js run tests/issue-1348.test.ts` — pass
+  (10 tests).
+- `node node_modules/vitest/dist/cli.js run tests/issue-1348.test.ts
+  tests/issue-1643.test.ts tests/issue-846h.test.ts tests/issue-1682.test.ts
+  tests/class-static-private-this.test.ts` — pass (29 tests).
+- `pnpm exec tsc --noEmit --pretty false` — pass.
+
+Notes:
+
+- The local `test262/` checkout is absent in this worktree, so no local
+  test262 path-filter run was possible.
+- An accidental broad `pnpm test -- tests/issue-1348.test.ts` invocation expanded
+  into a partial full-suite run, surfaced unrelated existing failures, and ended
+  with a vitest worker OOM. Scoped direct vitest runs above are the validation
+  used for this issue.

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -1,7 +1,7 @@
 ---
 id: 1348
 title: "spec gap: class static initialization order + private field semantics (significant share of 1500+ class fails)"
-status: in-progress
+status: in-review
 created: 2026-05-08
 updated: 2026-06-06
 priority: high
@@ -15,6 +15,7 @@ sprint: 60
 parent: 1328
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:09:45.155Z
+pr: 1250
 ---
 # #1348 — Class: static block order, private field exotics, super-class field shadow
 

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -24,7 +24,11 @@ import {
   compileLogicalAssignment,
   isCompoundAssignment,
 } from "./expressions/assignment.js";
-import { emitThrowTypeError, resolveDeclaringClassForPrivateName } from "./expressions/helpers.js";
+import {
+  emitPrivateBrandPredicate,
+  emitThrowTypeError,
+  resolveDeclaringClassForPrivateName,
+} from "./expressions/helpers.js";
 import { ensureExternIsUndefinedImport, ensureLateImport } from "./expressions/late-imports.js";
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
@@ -498,16 +502,17 @@ export function compileBinaryExpression(
     if (ts.isPrivateIdentifier(expr.left)) {
       const declared = resolveDeclaringClassForPrivateName(ctx, expr.left);
       if (declared) {
-        // Compile the receiver. Coerce externref → anyref so ref.test sees
-        // a concrete heap-typed value. Class refs are already eqref-rooted.
+        // Compile the receiver. Coerce externref → anyref and save it so
+        // the brand predicate can combine structural ref.test with class-tag
+        // ancestry.
         const objResult = compileExpression(ctx, fctx, expr.right);
         if (objResult?.kind === "externref") {
           fctx.body.push({ op: "any.convert_extern" } as Instr);
         }
-        // Note: ref.test against the struct typeIdx returns 0 even for
-        // null refs (per Wasm GC spec), matching the spec's "no throw,
-        // returns false" behavior.
-        fctx.body.push({ op: "ref.test", typeIdx: declared.structTypeIdx } as Instr);
+        const tmpAny = allocTempLocal(fctx, { kind: "anyref" });
+        fctx.body.push({ op: "local.set", index: tmpAny });
+        emitPrivateBrandPredicate(ctx, fctx, tmpAny, declared.className, declared.structTypeIdx);
+        releaseTempLocal(fctx, tmpAny);
         return { kind: "i32" };
       }
       // No declaring class found — fall through to the legacy compile-time

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -1197,11 +1197,16 @@ function compileClassBodiesInner(
       }
     }
 
-    // Compile field initializers from property declarations (e.g., x: number = 42, #x: number = 42)
-    // (#1366a) Skip for externref-backed classes — they have no WasmGC struct
-    // fields; user `prop = ...` declarations inside `class Sub extends Error`
-    // would need to be installed via host setters, which is out of scope.
-    if (!isExternrefBacked) {
+    const isDerivedClass = ctx.classParentMap.has(className) || ctx.classBuiltinParentMap.has(className);
+    let ownFieldInitializersEmitted = false;
+    const emitOwnInstanceFieldInitializers = (): void => {
+      // Compile field initializers from property declarations
+      // (e.g., x: number = 42, #x: number = 42). (#1366a) Skip for
+      // externref-backed classes — they have no WasmGC struct fields; user
+      // `prop = ...` declarations inside `class Sub extends Error` would need
+      // to be installed via host setters, which is out of scope.
+      if (isExternrefBacked || ownFieldInitializersEmitted) return;
+      ownFieldInitializersEmitted = true;
       for (const member of decl.members) {
         if (ts.isPropertyDeclaration(member) && member.name && member.initializer && !hasStaticModifier(member)) {
           const fieldName = resolveClassMemberName(ctx, member.name);
@@ -1214,6 +1219,13 @@ function compileClassBodiesInner(
           }
         }
       }
+    };
+
+    // Base classes and implicit derived constructors run own fields at the
+    // original constructor-initialization point. Explicit derived constructors
+    // must wait until `super()` returns (§13.3.7.1).
+    if (!isDerivedClass || !ctor) {
+      emitOwnInstanceFieldInitializers();
     }
 
     // (#846h) A derived class with an explicit constructor that never calls
@@ -1223,7 +1235,6 @@ function compileClassBodiesInner(
     // case (no lexical `super()` anywhere in the constructor body) and emit an
     // unconditional throw at the constructor entry, skipping the (now dead)
     // body compilation.
-    const isDerivedClass = ctx.classParentMap.has(className) || ctx.classBuiltinParentMap.has(className);
     const ctorMissingSuper = isDerivedClass && ctor?.body !== undefined && !constructorBodyHasSuperCall(ctor.body);
 
     if (ctorMissingSuper) {
@@ -1245,6 +1256,9 @@ function compileClassBodiesInner(
           stmt.expression.expression.kind === ts.SyntaxKind.SuperKeyword
         ) {
           compileSuperCall(ctx, fctx, className, selfLocal, stmt.expression, fields);
+          if (isDerivedClass) {
+            emitOwnInstanceFieldInitializers();
+          }
           continue;
         }
         compileStatement(ctx, fctx, stmt);
@@ -1922,6 +1936,36 @@ export function compileSuperCall(
 
   const parentFields = ctx.structFields.get(parentClassName) ?? [];
   const structTypeIdx = ctx.structMap.get(childClassName)!;
+
+  // ECMA-262 §13.3.7.1 SuperCall constructs the superclass first. That
+  // construction initializes superclass fields before the derived class runs
+  // its own fields, so parent field initializer side effects must occur even
+  // when the child declares the same public/private field name.
+  const ancestors: string[] = [];
+  const visitedAncestors = new Set<string>();
+  let ancestor: string | undefined = parentClassName;
+  while (ancestor && !visitedAncestors.has(ancestor)) {
+    visitedAncestors.add(ancestor);
+    ancestors.unshift(ancestor);
+    ancestor = ctx.classParentMap.get(ancestor);
+  }
+  const childFields = ctx.structFields.get(childClassName) ?? [];
+  for (const ancestorName of ancestors) {
+    const ancestorDecl = ctx.classDeclarationMap.get(ancestorName);
+    if (!ancestorDecl) continue;
+    for (const member of ancestorDecl.members) {
+      if (!ts.isPropertyDeclaration(member) || !member.name || !member.initializer || hasStaticModifier(member)) {
+        continue;
+      }
+      const fieldName = resolveClassMemberName(ctx, member.name);
+      if (fieldName === undefined) continue;
+      const fieldIdx = childFields.findIndex((f) => f.name === fieldName);
+      if (fieldIdx < 0) continue;
+      fctx.body.push({ op: "local.get", index: selfLocal });
+      compileExpression(ctx, fctx, member.initializer, childFields[fieldIdx]!.type);
+      fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
+    }
+  }
 
   // Evaluate super(args) and assign to parent fields on the child struct.
   // Skip __tag (immutable, already set by struct.new) and map arguments to

--- a/src/codegen/expressions/helpers.ts
+++ b/src/codegen/expressions/helpers.ts
@@ -88,6 +88,72 @@ export function resolveDeclaringClassForPrivateName(
   return undefined;
 }
 
+function collectClassAndDescendantTags(ctx: CodegenContext, className: string): number[] {
+  const tags: number[] = [];
+  const ownTag = ctx.classTagMap.get(className);
+  if (ownTag !== undefined) tags.push(ownTag);
+
+  const queue = [className];
+  const seen = new Set(queue);
+  while (queue.length > 0) {
+    const parent = queue.shift()!;
+    for (const [child, childParent] of ctx.classParentMap) {
+      if (childParent !== parent || seen.has(child)) continue;
+      seen.add(child);
+      queue.push(child);
+      const tag = ctx.classTagMap.get(child);
+      if (tag !== undefined) tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Emit the runtime private-brand predicate for a receiver saved as anyref.
+ *
+ * `ref.test $DeclaringClass` alone is not a full brand check in this compiler:
+ * unrelated classes with identical private-field layout may canonicalize to the
+ * same WasmGC shape. The hidden class tag distinguishes declarations, while
+ * descendant tags remain valid for private names initialized by an ancestor.
+ */
+export function emitPrivateBrandPredicate(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverLocal: number,
+  className: string,
+  structTypeIdx: number,
+): void {
+  const fields = ctx.structFields.get(className);
+  const tagFieldIdx = fields?.findIndex((f) => f.name === "__tag") ?? -1;
+  const allowedTags = collectClassAndDescendantTags(ctx, className);
+
+  fctx.body.push({ op: "local.get", index: receiverLocal });
+  fctx.body.push({ op: "ref.test", typeIdx: structTypeIdx } as Instr);
+
+  if (tagFieldIdx < 0 || allowedTags.length === 0) {
+    return;
+  }
+
+  const tagChecks: Instr[] = [];
+  for (let i = 0; i < allowedTags.length; i++) {
+    tagChecks.push({ op: "local.get", index: receiverLocal } as Instr);
+    tagChecks.push({ op: "ref.cast", typeIdx: structTypeIdx } as Instr);
+    tagChecks.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: tagFieldIdx } as Instr);
+    tagChecks.push({ op: "i32.const", value: allowedTags[i]! } as Instr);
+    tagChecks.push({ op: "i32.eq" } as Instr);
+    if (i > 0) {
+      tagChecks.push({ op: "i32.or" } as Instr);
+    }
+  }
+
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: tagChecks,
+    else: [{ op: "i32.const", value: 0 } as Instr],
+  } as Instr);
+}
+
 /**
  * #1365 — Emit a Wasm throw of a real TypeError INSTANCE (not a bare string).
  *

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -19,6 +19,7 @@ import { emitCachedMethodClosureAccess, emitFuncRefAsClosure } from "./closures.
 import { emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import {
   classifyPrivateMember,
+  emitPrivateBrandPredicate,
   emitThrowTypeError,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
@@ -1239,9 +1240,7 @@ export function compilePropertyAccess(
           fctx.body.push({ op: "any.convert_extern" } as Instr);
         }
         fctx.body.push({ op: "local.set", index: tmpAny });
-        // Brand check: ref.test against the declaring class's struct.
-        fctx.body.push({ op: "local.get", index: tmpAny });
-        fctx.body.push({ op: "ref.test", typeIdx: declared.structTypeIdx } as Instr);
+        emitPrivateBrandPredicate(ctx, fctx, tmpAny, declared.className, declared.structTypeIdx);
         // result-type block: on success, return the field value; on
         // failure, throw TypeError (which doesn't return).
         const successInstrs: Instr[] = [
@@ -1301,8 +1300,7 @@ export function compilePropertyAccess(
           fctx.body.push({ op: "any.convert_extern" } as Instr);
         }
         fctx.body.push({ op: "local.set", index: tmpAny });
-        fctx.body.push({ op: "local.get", index: tmpAny });
-        fctx.body.push({ op: "ref.test", typeIdx: structTypeIdx! } as Instr);
+        emitPrivateBrandPredicate(ctx, fctx, tmpAny, cls.className, structTypeIdx!);
 
         // Build the failure (throw) branch FIRST. emitThrowTypeError may
         // register late imports, which shift every funcMap index (the

--- a/tests/issue-1348.test.ts
+++ b/tests/issue-1348.test.ts
@@ -20,9 +20,10 @@
  *
  * Fix lives in `src/codegen/expressions/calls.ts` (void-IIFE inlining).
  */
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { compileToWasm } from "./equivalence/helpers.js";
 
 async function runWasm(src: string): Promise<unknown> {
   const r = await compile(src, { fileName: "test.ts", allowJs: true });
@@ -127,8 +128,109 @@ describe("#1348 — void IIFE return", () => {
         return x;
       }
     `;
-    // Inner return after first iteration → x === 1, post-arrow code in outer
+    // Inner return after first iteration -> x === 1, post-arrow code in outer
     // function runs normally (no-op here since the return is the last statement).
     expect(await runWasm(src)).toBe(1);
+  });
+});
+
+// #1348 — class static initialization order and private-field semantics.
+//
+// These cases mirror the residual test262 clusters called out in the issue.
+// Spec anchors:
+// - ECMA-262 §15.7.14 ClassDefinitionEvaluation collects static fields/blocks
+//   in class-body order and executes those records during class evaluation.
+// - ECMA-262 §13.3.7.1 SuperCall performs InitializeInstanceElements on the
+//   derived constructor after the super constructor returns.
+// - ECMA-262 §7.3.26 PrivateElementFind underpins `#x in obj` brand checks.
+describe("#1348 class static initialization and private fields", () => {
+  it("runs static fields and static blocks in source order", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        static n: number = 0;
+        static a: number = C.n + 1;
+        static { C.n = C.a + 1; }
+        static b: number = C.n + 1;
+        static { C.n = C.b + 1; }
+      }
+      export function test(): number { return C.n * 100 + C.a * 10 + C.b; }
+    `);
+    expect(ex.test()).toBe(413);
+  });
+
+  it("static block can read earlier private static field", async () => {
+    const ex = await compileToWasm(`
+      class C {
+        static #x: number = 41;
+        static y: number = 0;
+        static { C.y = this.#x + 1; }
+      }
+      export function test(): number { return C.y; }
+    `);
+    expect(ex.test()).toBe(42);
+  });
+
+  it("private in is a brand check and does not throw on wrong receiver", async () => {
+    const ex = await compileToWasm(`
+      class A {
+        #x: number = 1;
+        has(o: any): boolean { return #x in o; }
+      }
+      class B {
+        #x: number = 2;
+      }
+      export function test(): number {
+        const a = new A();
+        const b = new B();
+        return (a.has(a) ? 1 : 0) + (a.has(b) ? 10 : 0) + (a.has(null) ? 100 : 0);
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("private field read rejects unrelated class with the same private name", async () => {
+    const ex = await compileToWasm(`
+      class A {
+        #x: number = 1;
+        read(o: any): number { return o.#x; }
+      }
+      class B {
+        #x: number = 2;
+      }
+      export function test(): number {
+        const a = new A();
+        const b = new B();
+        if (a.read(a) !== 1) return 0;
+        try {
+          a.read(b);
+          return 0;
+        } catch (e: any) {
+          return e instanceof TypeError ? 1 : 2;
+        }
+      }
+    `);
+    expect(ex.test()).toBe(1);
+  });
+
+  it("super() runs parent field initializer before child shadow field", async () => {
+    const ex = await compileToWasm(`
+      let log: number = 0;
+      function mark(n: number): number {
+        log = log * 10 + n;
+        return n;
+      }
+      class Parent {
+        x: number = mark(1);
+      }
+      class Child extends Parent {
+        x: number = mark(2);
+        constructor() { super(); }
+      }
+      export function test(): number {
+        const c = new Child();
+        return log * 10 + c.x;
+      }
+    `);
+    expect(ex.test()).toBe(122);
   });
 });


### PR DESCRIPTION
## Summary
- add a shared private-brand predicate that combines Wasm struct checks with class-tag ancestry, so unrelated same-shaped private classes fail while subclasses remain valid
- use that predicate for both `#x in obj` and `obj.#x` private reads
- defer explicit derived-class own field initializers until after handled `super()`, and replay parent field initializers during `super()` so child shadow fields overwrite after parent side effects
- extend `tests/issue-1348.test.ts` while preserving the existing void-IIFE coverage

## Spec references
- ECMA-262 §15.7.14 ClassDefinitionEvaluation
- ECMA-262 §13.3.7.1 SuperCall
- ECMA-262 §7.3.26 PrivateElementFind / §7.3.30 PrivateGet

## Validation
- `node node_modules/vitest/dist/cli.js run tests/issue-1348.test.ts tests/issue-1643.test.ts tests/issue-846h.test.ts tests/issue-1682.test.ts tests/class-static-private-this.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- push hook: typecheck, lint, format:check, issue integrity

Local `test262/` checkout is absent in this worktree, so no local test262 path-filter run was possible. An accidental broad vitest invocation expanded into a partial full-suite run, surfaced unrelated existing failures, and ended with a worker OOM; scoped direct runs above are the validation for this PR.