### PR TITLE
feat(standalone): native OrdinaryToPrimitive for open objects

### DIFF
--- a/plan/issues/1900-standalone-native-toprimitive-phase1.md
+++ b/plan/issues/1900-standalone-native-toprimitive-phase1.md
@@ -1,9 +1,9 @@
 ---
 id: 1900
 title: "standalone native ToPrimitive (Phase 1): Wasm-native OrdinaryToPrimitive over $Object (~2,136 ceiling)"
-status: ready
+status: in-progress
 created: 2026-06-05
-updated: 2026-06-05
+updated: 2026-06-06
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -15,6 +15,8 @@ sprint: 60
 parent: 1806
 related: [1806, 1525b, 1472, 850, 1253, 1716]
 needs_arch_spec: true
+claimed_by: codex-developer
+claimed_at: 2026-06-06T09:10:05.166Z
 ---
 # #1900 — Standalone native ToPrimitive (Phase 1)
 
@@ -125,3 +127,35 @@ Before dev dispatch the architect must pin down:
 3. **Primitive-test predicate** — the exact `$Object` discriminants for
    "is primitive" in standalone (number/string/boolean/bigint/symbol/undefined
    /null) without a host roundtrip.
+
+## Implementation Notes
+
+- Implemented Slice 1 as native `__to_primitive(externref, hint)` over the
+  standalone `$Object` runtime, following fetched ECMA-262 §7.1.1 and
+  §7.1.1.1 text: non-objects return unchanged, `"string"` hint tries
+  `toString` then `valueOf`, and `"number"`/`"default"` try `valueOf` then
+  `toString`.
+- Method dispatch reuses the existing zero-arg accessor/closure driver after a
+  `__typeof_function` guard, so non-callable properties are skipped instead of
+  being treated as successful undefined returns.
+- Primitive results are accepted for null/undefined sentinel, boxed number,
+  boxed boolean, and native strings. Unknown non-null refs are treated as
+  objects for this slice.
+- The no-primitive path constructs and throws native `TypeError`, so
+  `e instanceof TypeError` works in standalone catches.
+- Added native `__extern_toString` routing for `String(obj)` and native-string
+  template substitutions over dynamic `$Object` values.
+- Extended standalone `__unbox_number` to parse native string primitives through
+  the existing `__str_to_number` scanner, so `valueOf` object then `toString`
+  string fallback feeds ToNumber correctly.
+- Slice 2 remains deferred: dynamic `Symbol.toPrimitive` still hits the
+  existing `#1472` `__get_builtin` standalone refusal because symbol-keyed
+  lookup in the `$Object` property map is not available yet.
+
+## Validation
+
+- `pnpm exec vitest run tests/issue-1900.test.ts`
+- `pnpm exec vitest run tests/issue-1900.test.ts tests/issue-1806.test.ts tests/issue-1806-string-hint.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm exec vitest run tests/issue-1472.test.ts --testNamePattern "Phase B: dynamic property add/read|Phase B: property update"`
+- `pnpm exec prettier --check src/codegen/binary-ops.ts src/codegen/expressions/calls.ts src/codegen/index.ts src/codegen/object-runtime.ts src/codegen/string-ops.ts src/codegen/type-coercion.ts tests/issue-1806.test.ts tests/issue-1900.test.ts`

--- a/plan/issues/1900-standalone-native-toprimitive-phase1.md
+++ b/plan/issues/1900-standalone-native-toprimitive-phase1.md
@@ -1,7 +1,7 @@
 ---
 id: 1900
 title: "standalone native ToPrimitive (Phase 1): Wasm-native OrdinaryToPrimitive over $Object (~2,136 ceiling)"
-status: in-progress
+status: in-review
 created: 2026-06-05
 updated: 2026-06-06
 priority: high
@@ -17,6 +17,7 @@ related: [1806, 1525b, 1472, 850, 1253, 1716]
 needs_arch_spec: true
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:10:05.166Z
+pr: 1251
 ---
 # #1900 — Standalone native ToPrimitive (Phase 1)
 

--- a/plan/issues/1900-standalone-native-toprimitive-phase1.md
+++ b/plan/issues/1900-standalone-native-toprimitive-phase1.md
@@ -16,7 +16,7 @@ parent: 1806
 related: [1806, 1525b, 1472, 850, 1253, 1716]
 needs_arch_spec: true
 claimed_by: codex-developer
-claimed_at: 2026-06-06T09:10:05.166Z
+claimed_at: 2026-06-06T09:46:21.649Z
 pr: 1251
 ---
 # #1900 — Standalone native ToPrimitive (Phase 1)

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -295,9 +295,7 @@ export function compileBinaryExpression(
       if (pfIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx: pfIdx });
       } else {
-        addUnionImports(ctx);
-        const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-        fctx.body.push({ op: "call", funcIdx: unboxIdx });
+        coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
       }
       emitToInt32(fctx);
       return { kind: "i32" };
@@ -1069,9 +1067,7 @@ export function compileBinaryExpression(
           if (pfIdx !== undefined) {
             fctx.body.push({ op: "call", funcIdx: pfIdx });
           } else {
-            addUnionImports(ctx);
-            const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-            fctx.body.push({ op: "call", funcIdx: unboxIdx });
+            coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
           }
         } else if (leftType.kind === "i32") {
           fctx.body.push({ op: "f64.convert_i32_s" });
@@ -1092,9 +1088,7 @@ export function compileBinaryExpression(
           if (pfIdx !== undefined) {
             fctx.body.push({ op: "call", funcIdx: pfIdx });
           } else {
-            addUnionImports(ctx);
-            const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-            fctx.body.push({ op: "call", funcIdx: unboxIdx });
+            coerceType(ctx, fctx, rightType, { kind: "f64" }, "number");
           }
         } else if (rightType.kind === "i32") {
           fctx.body.push({ op: "f64.convert_i32_s" });
@@ -1720,15 +1714,13 @@ export function compileBinaryExpression(
 
   // Externref in numeric context: unbox externref operands to f64
   if ((leftType.kind === "externref" || rightType.kind === "externref") && isNumericOp) {
-    addUnionImports(ctx);
-    const unboxIdx = ctx.funcMap.get("__unbox_number")!;
     if (rightType.kind === "externref") {
-      fctx.body.push({ op: "call", funcIdx: unboxIdx });
+      coerceType(ctx, fctx, rightType, { kind: "f64" }, "number");
     }
     if (leftType.kind === "externref") {
       const tmpR = allocTempLocal(fctx, { kind: "f64" });
       fctx.body.push({ op: "local.set", index: tmpR });
-      fctx.body.push({ op: "call", funcIdx: unboxIdx });
+      coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
       fctx.body.push({ op: "local.get", index: tmpR });
       releaseTempLocal(fctx, tmpR);
     }
@@ -2195,9 +2187,7 @@ export function compileBinaryExpression(
   if (isNumericOp) {
     // Coerce right operand (top of stack) to f64
     if (rightType.kind === "externref") {
-      addUnionImports(ctx);
-      const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-      fctx.body.push({ op: "call", funcIdx: unboxIdx });
+      coerceType(ctx, fctx, rightType, { kind: "f64" }, "number");
     } else if (rightType.kind === "i32") {
       fctx.body.push({ op: "f64.convert_i32_s" });
     } else if (rightType.kind === "i64") {
@@ -2216,9 +2206,7 @@ export function compileBinaryExpression(
       const tmpR = allocTempLocal(fctx, { kind: "f64" });
       fctx.body.push({ op: "local.set", index: tmpR });
       if (leftType.kind === "externref") {
-        addUnionImports(ctx);
-        const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-        fctx.body.push({ op: "call", funcIdx: unboxIdx });
+        coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
       } else if (leftType.kind === "i32") {
         fctx.body.push({ op: "f64.convert_i32_s" });
       } else if (leftType.kind === "i64") {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7796,6 +7796,10 @@ function compileCallExpression(
         return { kind: "f64" };
       }
       if (argType?.kind === "externref") {
+        if (ctx.standalone) {
+          coerceType(ctx, fctx, argType, { kind: "f64" }, "number");
+          return { kind: "f64" };
+        }
         // Number(x) uses ToNumber semantics — __unbox_number calls Number(v) in JS.
         // parseFloat is wrong here: Number(null)=0 but parseFloat(null)=NaN,
         // Number("")=0 but parseFloat("")=NaN, Number("0x1F")=31 but parseFloat gives 0.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -60,6 +60,7 @@ import {
 import { exportDrainMicrotasksIfRegistered, getDrainFuncIdxForWasiStart } from "./async-scheduler.js";
 import { registerAddStringImports, registerAddUnionImports } from "./shared.js";
 import { stackBalance } from "./stack-balance.js";
+import { emitNativeParseNumber } from "./parse-number-native.js";
 
 // ── Extracted sub-modules ──────────────────────────────────────────────────
 import {
@@ -8110,6 +8111,11 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   const i32ToExternref = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "externref" }]);
   const externrefToExternref = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
 
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && !ctx.funcMap.has("__str_to_number")) {
+    emitNativeParseNumber(ctx, new Set(["__str_to_number"]));
+  }
+  const strToNumberIdx = ctx.funcMap.get("__str_to_number");
+
   /**
    * Synthesize a native helper function. The funcIdx is allocated as
    * `numImportFuncs + mod.functions.length` to match how every other
@@ -8165,6 +8171,20 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
           { op: "return" },
         ],
       },
+      ...(strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0
+        ? ([
+            // StringToNumber (§7.1.4.1): object ToPrimitive can yield a native
+            // string; parse it with the existing pure-Wasm scanner before the
+            // opaque-ref NaN fallback.
+            { op: "local.get", index: 1 },
+            { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: strToNumberIdx }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // not a recognized boxed number → NaN (matches Number(opaque))
       { op: "f64.const", value: NaN },
     ],

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -58,7 +58,14 @@
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { ensureNativeStringHelpers, nativeStringLiteralInstrs } from "./native-strings.js";
+import {
+  ensureAnyToStringHelper,
+  ensureNativeStringHelpers,
+  nativeStringLiteralInstrs,
+  stringConstantExternrefInstrs,
+} from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry } from "./shared.js";
 import { reserveAccessorGetDriver, reserveAccessorSetDriver } from "./accessor-driver.js";
@@ -1375,6 +1382,218 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       ],
       body,
     );
+  }
+
+  // ── __to_primitive(externref input, externref hint) -> externref ─────────
+  //
+  // #1900 Phase 1 — Wasm-native OrdinaryToPrimitive over the standalone
+  // `$Object` runtime. Implements ECMA-262 §7.1.1.1 method ordering:
+  //   string hint: toString → valueOf
+  //   number/default hint: valueOf → toString
+  //
+  // The standalone runtime does not yet materialize Object.prototype as a real
+  // prototype object, so a modeled object with no `toString` property would
+  // otherwise throw. When `__extern_has(obj, "toString")` is false, the helper
+  // supplies the ordinary default Object.prototype.toString result
+  // `"[object Object]"`. A present non-callable or object-returning `toString`
+  // still shadows that default and can produce the required TypeError.
+  {
+    addUnionImportsViaRegistry(ctx);
+    const externGetIdx = ctx.funcMap.get("__extern_get")!;
+    const externHasIdx = ctx.funcMap.get("__extern_has")!;
+    const callMethod0Idx = reserveAccessorGetDriver(ctx);
+    const typeofNumberIdx = ctx.funcMap.get("__typeof_number")!;
+    const typeofStringIdx = ctx.funcMap.get("__typeof_string")!;
+    const typeofBooleanIdx = ctx.funcMap.get("__typeof_boolean")!;
+    const typeofFunctionIdx = ctx.funcMap.get("__typeof_function")!;
+
+    const typeErrorMessage = "Cannot convert object to primitive value";
+    addStringConstantGlobal(ctx, typeErrorMessage);
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+    const typeErrorCtorIdx = ctx.funcMap.get("__new_TypeError")!;
+    const exnTagIdx = ensureExnTag(ctx);
+
+    const stringExtern = (value: string): Instr[] => {
+      addStringConstantGlobal(ctx, value);
+      return stringConstantExternrefInstrs(ctx, value);
+    };
+
+    const L_ANY = 2;
+    const L_METHOD = 3;
+    const L_RESULT = 4;
+
+    const returnIfPrimitive = (localIdx: number): Instr[] => [
+      { op: "local.get", index: localIdx },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: localIdx }, { op: "return" }],
+      },
+      { op: "local.get", index: localIdx },
+      { op: "call", funcIdx: typeofNumberIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: localIdx }, { op: "return" }],
+      },
+      { op: "local.get", index: localIdx },
+      { op: "call", funcIdx: typeofBooleanIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: localIdx }, { op: "return" }],
+      },
+      { op: "local.get", index: localIdx },
+      { op: "call", funcIdx: typeofStringIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: localIdx }, { op: "return" }],
+      },
+    ];
+
+    const throwTypeError = (): Instr[] => [
+      ...stringExtern(typeErrorMessage),
+      { op: "call", funcIdx: typeErrorCtorIdx },
+      { op: "throw", tagIdx: exnTagIdx } as Instr,
+    ];
+
+    const isStringHint: Instr[] = [
+      { op: "local.get", index: 1 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "i32.const", value: 0 }],
+        else: [
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: typeofStringIdx },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: 1 },
+              { op: "any.convert_extern" },
+              { op: "ref.cast", typeIdx: anyStrTypeIdx },
+              { op: "call", funcIdx: strFlattenIdx },
+              ...nativeStringLiteralInstrs(ctx, "string"),
+              { op: "call", funcIdx: strFlattenIdx },
+              { op: "call", funcIdx: strEqualsIdx },
+            ],
+            else: [{ op: "i32.const", value: 0 }],
+          } as Instr,
+        ],
+      } as Instr,
+    ];
+
+    const tryOrdinaryMethod = (name: "valueOf" | "toString", defaultObjectToStringOnMissing: boolean): Instr[] => [
+      { op: "local.get", index: 0 },
+      ...stringExtern(name),
+      { op: "call", funcIdx: externGetIdx },
+      { op: "local.tee", index: L_METHOD },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: defaultObjectToStringOnMissing
+          ? [
+              { op: "local.get", index: 0 },
+              ...stringExtern(name),
+              { op: "call", funcIdx: externHasIdx },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [...stringExtern("[object Object]"), { op: "return" }],
+              } as Instr,
+            ]
+          : [],
+        else: [
+          { op: "local.get", index: L_METHOD },
+          { op: "call", funcIdx: typeofFunctionIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: L_METHOD },
+              { op: "call", funcIdx: callMethod0Idx },
+              { op: "local.set", index: L_RESULT },
+              ...returnIfPrimitive(L_RESULT),
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ];
+
+    const body: Instr[] = [
+      // Non-objects return unchanged (ToPrimitive step 1).
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: L_ANY },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      },
+      ...isStringHint,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [...tryOrdinaryMethod("toString", true), ...tryOrdinaryMethod("valueOf", false)],
+        else: [...tryOrdinaryMethod("valueOf", false), ...tryOrdinaryMethod("toString", true)],
+      },
+      ...throwTypeError(),
+    ];
+
+    registerNative(
+      "__to_primitive",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "method", type: { kind: "externref" } },
+        { name: "result", type: { kind: "externref" } },
+      ],
+      body,
+    );
+
+    const toPrimitiveIdx = ctx.funcMap.get("__to_primitive")!;
+    const anyToStringIdx = ensureAnyToStringHelper(ctx);
+    const toStringBody: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: [{ op: "ref.null.extern" }],
+        else: [
+          { op: "local.get", index: 0 },
+          { op: "any.convert_extern" },
+          { op: "ref.test", typeIdx: objectTypeIdx },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [{ op: "local.get", index: 0 }, ...stringExtern("string"), { op: "call", funcIdx: toPrimitiveIdx }],
+            else: [{ op: "local.get", index: 0 }],
+          } as Instr,
+        ],
+      } as Instr,
+      { op: "any.convert_extern" },
+      { op: "call", funcIdx: anyToStringIdx },
+      { op: "extern.convert_any" },
+    ];
+    registerNative("__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }], [], toStringBody);
   }
 
   // ── Prototype-chain ops (#1472 Phase C) ──────────────────────────────────
@@ -3588,6 +3807,8 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__new_plain_object",
   "__extern_get",
   "__extern_set",
+  "__to_primitive",
+  "__extern_toString",
   "__delete_property",
   // #1472 Phase B Blocker B — native $ObjVec-backed enumeration + indexed read.
   "__object_keys",

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -132,11 +132,15 @@ function compileNativeConcatOperand(ctx: CodegenContext, fctx: FunctionContext, 
       compileStringLiteral(ctx, fctx, "undefined", operand);
       return true;
     }
-    // Dynamic externref (boxed string / any) → bridge to anyref, then the
-    // in-module ToString dispatcher.
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-    const anyToStrIdx = ensureAnyToStringHelper(ctx);
-    fctx.body.push({ op: "call", funcIdx: anyToStrIdx });
+    // Dynamic externref (boxed string / any / $Object) → runtime ToString.
+    // For standalone $Object values this routes through native
+    // OrdinaryToPrimitive("string") before the native-string concat helper.
+    const toStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+    flushLateImportShifts(ctx, fctx);
+    if (toStrIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: toStrIdx });
+    }
+    emitNativeStringRefFromExternref(ctx, fctx);
     return true;
   }
 
@@ -392,9 +396,12 @@ export function compileNativeTemplateExpression(
           fctx.body.push({ op: "drop" });
           compileStringLiteral(ctx, fctx, "undefined", span.expression);
         } else {
-          fctx.body.push({ op: "any.convert_extern" } as Instr);
-          const anyToStrIdx = ensureAnyToStringHelper(ctx);
-          fctx.body.push({ op: "call", funcIdx: anyToStrIdx });
+          const toStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+          flushLateImportShifts(ctx, fctx);
+          if (toStrIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx: toStrIdx });
+          }
+          emitNativeStringRefFromExternref(ctx, fctx);
         }
       } else {
         coerceType(ctx, fctx, spanType, { kind: "externref" }, "string");

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -10,7 +10,7 @@ import type { ArrayTypeDef, Instr, StructTypeDef, TypeDef, ValType } from "../ir
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
 import { addUnionImports, ensureAnyHelpers, isAnyValue } from "./index.js";
-import { ensureAnyToStringHelper } from "./native-strings.js";
+import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { getArrTypeIdxFromVec } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts, registerCoerceType } from "./shared.js";
@@ -79,10 +79,7 @@ export type CompileStringLiteralFn = (ctx: CodegenContext, fctx: FunctionContext
  */
 function pushStringHint(ctx: CodegenContext, fctx: FunctionContext, hint: string): void {
   addStringConstantGlobal(ctx, hint);
-  const globalIdx = ctx.stringGlobalMap.get(hint);
-  if (globalIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: globalIdx });
-  }
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, hint));
 }
 
 /**
@@ -1351,6 +1348,29 @@ export function coerceType(
   }
   // externref → f64 (unbox number)
   if (from.kind === "externref" && to.kind === "f64") {
+    if (ctx.standalone) {
+      const hint = toPrimitiveHint ?? "number";
+      pushStringHint(ctx, fctx, hint);
+      const toPrimIdx = ensureLateImport(
+        ctx,
+        "__to_primitive",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      flushLateImportShifts(ctx, fctx);
+      if (toPrimIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: toPrimIdx });
+      }
+      addUnionImports(ctx);
+      const funcIdx = ctx.funcMap.get("__unbox_number");
+      if (funcIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx });
+        return;
+      }
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "f64.const", value: NaN });
+      return;
+    }
     addUnionImports(ctx);
     const funcIdx = ctx.funcMap.get("__unbox_number");
     if (funcIdx !== undefined) {

--- a/tests/issue-1806.test.ts
+++ b/tests/issue-1806.test.ts
@@ -2,7 +2,8 @@
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 
-// #1806 Phase 0 — standalone ToPrimitive refusal.
+// #1806 Phase 0 — standalone ToPrimitive refusal, superseded by #1900 native
+// OrdinaryToPrimitive coverage.
 //
 // In `--target standalone` there is no JS host to satisfy the `env::__to_primitive`
 // import that the ToPrimitive (§7.1.1) lowering dispatches to for objects whose
@@ -12,51 +13,45 @@ import { compile } from "../src/index.js";
 // JS-host runtime which threw the bare "Cannot convert object to primitive value"
 // with no tracking issue — the 2,136-test #1806 failure cluster.
 //
-// Phase 0 converts every such case into a compile error that cites #1806, making
-// the cluster trackable. The Wasm-native ToPrimitive over the $Object struct is
-// Phase 1 (#1806).
+// Phase 0 converted every such case into a compile error that cited #1806,
+// making the cluster trackable. #1900 replaces that broad refusal with native
+// standalone ToPrimitive coverage, so this file now guards the old failure
+// shapes against regressing back to leaked host imports.
 
-const HOST_TOPRIM_REFUSED: Array<{ label: string; src: string }> = [
+const HOST_TOPRIM_REFUSED: Array<{ label: string; src: string; expected: number | "NaN" }> = [
   {
     label: "plain object coerced to number (host ToPrimitive dispatch)",
-    src: `function test(): number { const o = { a: 1, b: 2 }; return (o as any) - 0; }`,
+    src: `export function test(): number { const o = { a: 1, b: 2 }; return (o as any) - 0; }`,
+    expected: "NaN",
   },
   {
     label: "plain object in multiply (numeric hint)",
-    src: `function test(): number { const o = { x: 3 }; return (o as any) * 2; }`,
+    src: `export function test(): number { const o = { x: 3 }; return (o as any) * 2; }`,
+    expected: "NaN",
   },
   {
     label: "object in bitwise-and (ToNumeric → ToPrimitive)",
-    src: `function test(): number { const o = { p: 1 }; return (o as any) & 3; }`,
+    src: `export function test(): number { const o = { p: 1 }; return (o as any) & 3; }`,
+    expected: 0,
   },
 ];
 
-describe("#1806 Phase 0 — standalone ToPrimitive refusal", () => {
-  for (const { label, src } of HOST_TOPRIM_REFUSED) {
-    it(`refuses with a #1806 compile error: ${label}`, async () => {
+describe("#1806/#1900 — standalone ToPrimitive no longer leaks host imports", () => {
+  for (const { label, src, expected } of HOST_TOPRIM_REFUSED) {
+    it(`compiles host-free after #1900: ${label}`, async () => {
       const r = await compile(src, {
         fileName: "issue-1806.ts",
         target: "standalone",
         skipSemanticDiagnostics: true,
       });
 
-      // The compile must FAIL (no half-working module with a leaked host import).
-      expect(r.success).toBe(false);
-
-      // Every error in the cluster must cite the tracking issue #1806 so the
-      // failure is attributable, and must name the ToPrimitive operation.
-      const messages = r.errors.map((e) => e.message);
-      expect(messages.some((m) => m.includes("#1806"))).toBe(true);
-      expect(messages.some((m) => /toPrimitive/i.test(m))).toBe(true);
-
-      // The message must NOT begin with "Cannot " / "Invalid " — those prefixes
-      // make the test262 classifier bucket it as a stray runtime_error instead
-      // of a trackable compile_error.
-      const toPrimMsg = messages.find((m) => m.includes("#1806"))!;
-      expect(/^Cannot |^Invalid /.test(toPrimMsg)).toBe(false);
-
-      // No `__to_primitive` host import may leak into the standalone module.
+      expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
       expect((r.imports ?? []).some((i) => i.name === "__to_primitive")).toBe(false);
+      expect(WebAssembly.validate(r.binary)).toBe(true);
+      const { instance } = await WebAssembly.instantiate(r.binary, {});
+      const actual = (instance.exports.test as () => number)();
+      if (expected === "NaN") expect(actual).toBeNaN();
+      else expect(actual).toBe(expected);
     });
   }
 

--- a/tests/issue-1900.test.ts
+++ b/tests/issue-1900.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileAndRunNumber(source: string): Promise<number> {
+  const r = await compile(source, {
+    fileName: "issue-1900.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(r.imports.filter((i) => i.module === "env" && i.name === "__to_primitive")).toEqual([]);
+  expect(r.imports.filter((i) => i.module === "env" && i.name === "__extern_toString")).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#1900 — standalone native OrdinaryToPrimitive over $Object", () => {
+  it("numeric hint calls dynamic valueOf on an open $Object", async () => {
+    expect(
+      await compileAndRunNumber(`
+        export function test(): number {
+          const o: any = {};
+          const key: any = "valueOf";
+          o[key] = function() { return 42; };
+          return o - 0;
+        }
+      `),
+    ).toBe(42);
+  });
+
+  it("string hint prefers toString for template substitutions", async () => {
+    expect(
+      await compileAndRunNumber(`
+        export function test(): number {
+          const o: any = {};
+          const valueOfKey: any = "valueOf";
+          const toStringKey: any = "toString";
+          o[valueOfKey] = function() { return 1; };
+          o[toStringKey] = function() { return "X"; };
+          return \`\${o}!\` === "X!" ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("falls back from object-returning valueOf to primitive toString", async () => {
+    expect(
+      await compileAndRunNumber(`
+        export function test(): number {
+          const o: any = {};
+          const valueOfKey: any = "valueOf";
+          const toStringKey: any = "toString";
+          o[valueOfKey] = function() { return ({} as any); };
+          o[toStringKey] = function() { return "17"; };
+          return o - 0;
+        }
+      `),
+    ).toBe(17);
+  });
+
+  it("throws a real TypeError when both ordinary methods return objects", async () => {
+    expect(
+      await compileAndRunNumber(`
+        export function test(): number {
+          const o: any = {};
+          const valueOfKey: any = "valueOf";
+          const toStringKey: any = "toString";
+          o[valueOfKey] = function() { return ({} as any); };
+          o[toStringKey] = function() { return ({} as any); };
+          try {
+            o - 0;
+            return 0;
+          } catch (e) {
+            return e instanceof TypeError ? 1 : 2;
+          }
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps Symbol.toPrimitive deferred until symbol-keyed $Object lookup exists", async () => {
+    const r = await compile(
+      `
+        export function test(): number {
+          const o: any = {};
+          o[Symbol.toPrimitive] = function(_hint: string) { return 99; };
+          return o - 0;
+        }
+      `,
+      { fileName: "issue-1900-symbol.ts", target: "standalone", skipSemanticDiagnostics: true },
+    );
+
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toContain("#1472");
+    expect(r.imports.filter((i) => i.module === "env" && i.name === "__to_primitive")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add native standalone __to_primitive and __extern_toString over the $Object runtime
- route standalone externref numeric/string coercions through the native helper
- parse native string primitives through the existing StringToNumber scanner
- add issue-1900 coverage for numeric hint, string hint, fallback, TypeError, and deferred Symbol.toPrimitive

## Validation
- pnpm exec vitest run tests/issue-1900.test.ts
- pnpm exec vitest run tests/issue-1900.test.ts tests/issue-1806.test.ts tests/issue-1806-string-hint.test.ts
- pnpm exec vitest run tests/issue-1472.test.ts --testNamePattern "Phase B: dynamic property add/read|Phase B: property update"
- pnpm exec tsc --noEmit --pretty false
- pnpm exec prettier --check src/codegen/binary-ops.ts src/codegen/expressions/calls.ts src/codegen/index.ts src/codegen/object-runtime.ts src/codegen/string-ops.ts src/codegen/type-coercion.ts tests/issue-1806.test.ts tests/issue-1900.test.ts

Spec: ECMA-262 §7.1.1 and §7.1.1.1.