### PR TITLE
feat(#1539): add standalone regex exec/match captures

### DIFF
--- a/plan/issues/1539-wasm-native-regex-engine-regress.md
+++ b/plan/issues/1539-wasm-native-regex-engine-regress.md
@@ -1,7 +1,7 @@
 ---
 id: 1539
 title: "Standalone Wasm RegExp engine via regress (Phase 2 of #1474)"
-status: in-review
+status: in-progress
 created: 2026-05-20
 updated: 2026-06-06
 priority: high
@@ -15,7 +15,7 @@ sprint: 60
 depends_on: [1474]
 related: [1474, 682, 1535]
 claimed_by: codex-developer
-claimed_at: 2026-06-06T09:09:50.202Z
+claimed_at: 2026-06-06T09:31:52.475Z
 pr: 1247
 ---
 # #1539 — Standalone Wasm RegExp engine via regress (Phase 2 of #1474)
@@ -571,3 +571,39 @@ imports.
 Still open for #1539: capture-array materialization for `.exec`/`.match` and
 capture-interleaved `split`, `$`/function replacement semantics, `matchAll`, and
 the `d`/`u`/`v` plus lookaround/backreference/property-escape work.
+
+## Implementation Notes (codex-developer, 2026-06-06) — Phase 2b `.exec` + non-global `.match`
+
+Landed standalone capture-array materialization for non-global/non-sticky
+`RegExp.prototype.exec(str)` and `String.prototype.match(/re/)` on the existing
+pure-WasmGC regex VM. Matches now return a nullable native string vec:
+`null` for no match, otherwise `[fullMatch, cap1, cap2, ...]`, with unmatched
+captures represented as null native strings so indexed reads observe
+`undefined` without any JS host array bridge.
+
+- Added `__regex_capture_array`, which consumes the populated `caps` slot array
+  from `__regex_search` and slices the flattened subject via native string
+  helpers. This keeps `.exec`/`.match` fully standalone and avoids
+  `env.RegExp_new`, `env.string_match`, `env.__make_iterable`, and
+  `env.__extern_get`.
+- Routed static backend-created regex values through `.exec` and non-global
+  `.match`; global/sticky paths remain narrowed refusals because observable
+  `lastIndex` and all-match semantics need the next slice.
+- Added local/global type inference for variables initialized from static
+  `.exec`/non-global `.match` calls, including non-null assertions, so indexed
+  result reads stay on the native vec path instead of coercing through
+  `externref`.
+- Tests: extended `tests/issue-1539-standalone-regex.test.ts` with dual-run
+  capture cases for full matches, optional captures, alternation captures,
+  `i`/`m` flags, no-match results, var-bound regexes, and `new RegExp(...)`;
+  updated `tests/issue-1474-standalone-regex-refuse.test.ts` so non-global
+  `.match` compiles while global `.match` remains refused.
+
+Validation: `npm test -- tests/issue-1539-standalone-regex.test.ts
+tests/issue-1474-standalone-regex-refuse.test.ts
+tests/issue-1539-standalone-regex-replace.test.ts` passed
+(3 files, 208 tests).
+
+Still open for #1539: capture-interleaved `split`, `$`/function replacement
+semantics, `matchAll`, named groups / `groups`, and the `d`/`u`/`v` plus
+lookaround/backreference/property-escape work.

--- a/plan/issues/1539-wasm-native-regex-engine-regress.md
+++ b/plan/issues/1539-wasm-native-regex-engine-regress.md
@@ -1,7 +1,7 @@
 ---
 id: 1539
 title: "Standalone Wasm RegExp engine via regress (Phase 2 of #1474)"
-status: in-progress
+status: in-review
 created: 2026-05-20
 updated: 2026-06-06
 priority: high
@@ -16,7 +16,7 @@ depends_on: [1474]
 related: [1474, 682, 1535]
 claimed_by: codex-developer
 claimed_at: 2026-06-06T09:31:52.475Z
-pr: 1247
+pr: 1252
 ---
 # #1539 — Standalone Wasm RegExp engine via regress (Phase 2 of #1474)
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -98,6 +98,7 @@ import { compileExternMethodCall, compileSpreadCallArgs, emitLazyProtoGet } from
 import {
   compileStandaloneRegExpConstructor,
   isGlobalRegExpIdentifier,
+  tryCompileStandaloneRegExpExec,
   tryCompileStandaloneRegExpTest,
 } from "../regexp-standalone.js";
 import {
@@ -2429,6 +2430,9 @@ function compileCallExpression(
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const propAccess = expr.expression;
 
+    const standaloneRegExpExec = tryCompileStandaloneRegExpExec(ctx, fctx, expr, propAccess);
+    if (standaloneRegExpExec !== undefined) return standaloneRegExpExec;
+
     const standaloneRegExpTest = tryCompileStandaloneRegExpTest(ctx, fctx, expr, propAccess);
     if (standaloneRegExpTest !== undefined) return standaloneRegExpTest;
 
@@ -2836,9 +2840,9 @@ function compileCallExpression(
           const typeName = objExpr.expression.text;
           const isBuiltinRegExpPrototype = typeName === "RegExp" && isGlobalRegExpIdentifier(ctx, objExpr.expression);
           if (ctx.standalone && isBuiltinRegExpPrototype) {
-            if (methodName === "test") {
+            if (methodName === "test" || methodName === "exec") {
               const receiverArg = expr.arguments[0]!;
-              const syntheticProp = ts.factory.createPropertyAccessExpression(receiverArg, "test");
+              const syntheticProp = ts.factory.createPropertyAccessExpression(receiverArg, methodName);
               ts.setTextRange(syntheticProp, innerExpr);
               const syntheticCall = ts.factory.createCallExpression(
                 syntheticProp,
@@ -2847,14 +2851,17 @@ function compileCallExpression(
               );
               ts.setTextRange(syntheticCall, expr);
               (syntheticCall as any).parent = expr.parent;
-              const standaloneRegExpTest = tryCompileStandaloneRegExpTest(ctx, fctx, syntheticCall, syntheticProp);
-              if (standaloneRegExpTest !== undefined) return standaloneRegExpTest;
+              const standaloneRegExpMethod =
+                methodName === "exec"
+                  ? tryCompileStandaloneRegExpExec(ctx, fctx, syntheticCall, syntheticProp)
+                  : tryCompileStandaloneRegExpTest(ctx, fctx, syntheticCall, syntheticProp);
+              if (standaloneRegExpMethod !== undefined) return standaloneRegExpMethod;
             }
             reportError(
               ctx,
               expr,
               `Codegen error: standalone RegExp literal-substring backend does not support ` +
-                `RegExp.prototype.${methodName}.call(...) (#682/#1474). Use RegExp.prototype.test ` +
+                `RegExp.prototype.${methodName}.call(...) (#682/#1474). Use RegExp.prototype.test/exec ` +
                 `with a plain static pattern and no flags, or recompile without --target standalone.`,
             );
             return null;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -54,6 +54,7 @@ import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } fro
 import {
   addFuncType,
   getArrTypeIdxFromVec,
+  getOrRegisterArrayType,
   getOrRegisterTemplateVecType,
   getOrRegisterVecType,
 } from "./registry/types.js";
@@ -10183,6 +10184,8 @@ function collectUsedExternImports(ctx: CodegenContext, sourceFile: ts.SourceFile
       // Skip when element access is the callee of a call expression (e.g. obj['method']())
       // — the call handler compiles this as a direct method call, not a property read
       const isCallCallee = node.parent && ts.isCallExpression(node.parent) && node.parent.expression === node;
+      const isNativeStandaloneRegExpMatchArray =
+        ctx.standalone && isStandaloneRegExpMatchArrayValue(ctx, node.expression);
       const objType = ctx.checker.getTypeAtLocation(node.expression);
       const sym = objType.getSymbol();
       // Skip Array and tuple types — those use Wasm GC struct/array ops, not host import
@@ -10190,6 +10193,7 @@ function collectUsedExternImports(ctx: CodegenContext, sourceFile: ts.SourceFile
       const isWidenedVar = ts.isIdentifier(node.expression) && ctx.widenedVarStructMap.has(node.expression.text);
       if (
         !isCallCallee &&
+        !isNativeStandaloneRegExpMatchArray &&
         sym?.name !== "Array" &&
         sym?.name !== "__type" &&
         sym?.name !== "__object" &&
@@ -11057,18 +11061,113 @@ function isVecStructType(ctx: CodegenContext, type: ValType | undefined): type i
   return def?.kind === "struct" && def.fields[0]?.name === "length" && def.fields[1]?.name === "data";
 }
 
+function stripRegExpInferenceWrapper(expr: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isTypeAssertionExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = (
+      expr as
+        | ts.ParenthesizedExpression
+        | ts.AsExpression
+        | ts.TypeAssertion
+        | ts.SatisfiesExpression
+        | ts.NonNullExpression
+    ).expression;
+  }
+  return expr;
+}
+
+function isStaticRegExpExpressionForInference(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const unwrapped = stripRegExpInferenceWrapper(expr);
+  if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) return true;
+  if (ts.isNewExpression(unwrapped) || (ts.isCallExpression(unwrapped) && !unwrapped.questionDotToken)) {
+    const callee = stripRegExpInferenceWrapper(unwrapped.expression);
+    return ts.isIdentifier(callee) && callee.text === "RegExp";
+  }
+  if (ts.isIdentifier(unwrapped)) {
+    const sym = ctx.checker.getSymbolAtLocation(unwrapped);
+    const decl = sym?.getDeclarations()?.find((d) => ts.isVariableDeclaration(d)) as ts.VariableDeclaration | undefined;
+    return decl?.initializer !== undefined && isStaticRegExpExpressionForInference(ctx, decl.initializer);
+  }
+  return false;
+}
+
+function nativeStringVecTypeForStandaloneRegExp(ctx: CodegenContext): ValType | null {
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return null;
+  const elemKey = `ref_${ctx.anyStrTypeIdx}`;
+  const elemType: ValType = { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+  getOrRegisterArrayType(ctx, elemKey, elemType);
+  const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
+  return { kind: "ref_null", typeIdx: vecTypeIdx };
+}
+
+function inferStandaloneRegExpMatchArrayType(
+  ctx: CodegenContext,
+  initializer: ts.Expression | undefined,
+): ValType | null {
+  if (!ctx.standalone || !initializer) return null;
+  const unwrapped = stripRegExpInferenceWrapper(initializer);
+  if (!ts.isCallExpression(unwrapped)) return null;
+  if (!ts.isPropertyAccessExpression(unwrapped.expression)) return null;
+  const method = unwrapped.expression.name.text;
+  if (method === "exec") {
+    return isStaticRegExpExpressionForInference(ctx, unwrapped.expression.expression)
+      ? nativeStringVecTypeForStandaloneRegExp(ctx)
+      : null;
+  }
+  if (method === "match" && unwrapped.arguments.length === 1) {
+    return isStaticRegExpExpressionForInference(ctx, unwrapped.arguments[0]!)
+      ? nativeStringVecTypeForStandaloneRegExp(ctx)
+      : null;
+  }
+  return null;
+}
+
+function isStaticRegExpMatchArrayCallForImportScan(ctx: CodegenContext, call: ts.CallExpression): boolean {
+  const callee = stripRegExpInferenceWrapper(call.expression);
+  if (!ts.isPropertyAccessExpression(callee)) return false;
+  const method = callee.name.text;
+  if (method === "exec") return isStaticRegExpExpressionForInference(ctx, callee.expression);
+  if (method === "match" && call.arguments.length === 1) {
+    return isStaticRegExpExpressionForInference(ctx, call.arguments[0]!);
+  }
+  return false;
+}
+
+function isStandaloneRegExpMatchArrayValue(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const unwrapped = stripRegExpInferenceWrapper(expr);
+  if (ts.isCallExpression(unwrapped)) return isStaticRegExpMatchArrayCallForImportScan(ctx, unwrapped);
+  if (!ts.isIdentifier(unwrapped)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(unwrapped);
+  const decl = sym?.getDeclarations()?.find((d) => ts.isVariableDeclaration(d)) as ts.VariableDeclaration | undefined;
+  const initializer = decl?.initializer ? stripRegExpInferenceWrapper(decl.initializer) : undefined;
+  return initializer !== undefined && ts.isCallExpression(initializer)
+    ? isStaticRegExpMatchArrayCallForImportScan(ctx, initializer)
+    : false;
+}
+
 function inferLetConstInitializerWasmType(
   ctx: CodegenContext,
   fctx: FunctionContext,
   initializer: ts.Expression | undefined,
 ): ValType | null {
-  if (!initializer || !ts.isCallExpression(initializer) || !ts.isPropertyAccessExpression(initializer.expression)) {
+  if (!initializer) return null;
+  const standaloneRegExpMatchArrayType = inferStandaloneRegExpMatchArrayType(ctx, initializer);
+  if (standaloneRegExpMatchArrayType !== null) return standaloneRegExpMatchArrayType;
+
+  const unwrapped = stripRegExpInferenceWrapper(initializer);
+  if (!ts.isCallExpression(unwrapped) || !ts.isPropertyAccessExpression(unwrapped.expression)) {
     return null;
   }
-  const methodName = initializer.expression.name.text;
+
+  const methodName = unwrapped.expression.name.text;
   if (methodName !== "subarray" && methodName !== "slice") return null;
 
-  const receiver = initializer.expression.expression;
+  const receiver = unwrapped.expression.expression;
   let receiverType: ValType | undefined;
   if (ts.isIdentifier(receiver)) {
     const localIdx = fctx.localMap.get(receiver.text);

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -1156,6 +1156,141 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
 }
 
 /**
+ * Emit `__regex_capture_array(nGroups, subject, caps) -> ref $vec_nstr`
+ * (#1539 Phase 2b).
+ *
+ * Materializes capture slots from a populated caps array as a native string
+ * vec: element 0 is the full match, element N is capture N, and unmatched
+ * captures are null `(ref null $AnyString)`, which the standalone compiler
+ * already treats as `undefined` for native-string values.
+ */
+export function ensureRegexCaptureArray(ctx: CodegenContext): number {
+  const existing = ctx.nativeRegexHelpers.get("__regex_capture_array");
+  if (existing !== undefined) return existing;
+
+  const i32Arr = regexI32ArrayType(ctx);
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  const i32ArrRef: ValType = { kind: "ref", typeIdx: i32Arr };
+
+  const nstrElemKey = `ref_${anyStrTypeIdx}`;
+  const nstrElemType: ValType = { kind: "ref_null", typeIdx: anyStrTypeIdx };
+  const nstrArrTypeIdx = getOrRegisterArrayType(ctx, nstrElemKey, nstrElemType);
+  const nstrVecTypeIdx = getOrRegisterVecType(ctx, nstrElemKey, nstrElemType);
+  const nstrVecRef: ValType = { kind: "ref", typeIdx: nstrVecTypeIdx };
+
+  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
+  if (substringIdx === undefined) {
+    throw new Error("__regex_capture_array requires __str_substring (#682 native string helpers)");
+  }
+
+  const typeIdx = addFuncType(
+    ctx,
+    [
+      { kind: "i32" }, // nGroups
+      strRef, // subject (flattened)
+      i32ArrRef, // caps
+    ],
+    [nstrVecRef],
+  );
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.nativeRegexHelpers.set("__regex_capture_array", funcIdx);
+
+  // params
+  const NGROUPS = 0,
+    SUBJ = 1,
+    CAPS = 2;
+  // locals
+  const RARR = 3;
+  const I = 4;
+  const CSTART = 5;
+  const CEND = 6;
+
+  const body: Instr[] = [
+    // result array length is nGroups (group 0 + captures).
+    { op: "local.get", index: NGROUPS },
+    { op: "array.new_default", typeIdx: nstrArrTypeIdx },
+    { op: "local.set", index: RARR },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: I },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: I },
+            { op: "local.get", index: NGROUPS },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            // cstart = caps[2*i]; cend = caps[2*i+1]
+            { op: "local.get", index: CAPS },
+            { op: "local.get", index: I },
+            { op: "i32.const", value: 2 },
+            { op: "i32.mul" },
+            { op: "array.get", typeIdx: i32Arr },
+            { op: "local.set", index: CSTART },
+            { op: "local.get", index: CAPS },
+            { op: "local.get", index: I },
+            { op: "i32.const", value: 2 },
+            { op: "i32.mul" },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "array.get", typeIdx: i32Arr },
+            { op: "local.set", index: CEND },
+            // result[i] = cstart < 0 ? undefined : substring(subject, cstart, cend)
+            { op: "local.get", index: RARR },
+            { op: "local.get", index: I },
+            { op: "local.get", index: CSTART },
+            { op: "i32.const", value: 0 },
+            { op: "i32.lt_s" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: nstrElemType },
+              then: [{ op: "ref.null", typeIdx: anyStrTypeIdx } as Instr],
+              else: [
+                { op: "local.get", index: SUBJ },
+                { op: "ref.cast", typeIdx: strTypeIdx } as Instr,
+                { op: "local.get", index: CSTART },
+                { op: "local.get", index: CEND },
+                { op: "call", funcIdx: substringIdx },
+              ],
+            },
+            { op: "array.set", typeIdx: nstrArrTypeIdx },
+            { op: "local.get", index: I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: NGROUPS },
+    { op: "local.get", index: RARR },
+    { op: "ref.as_non_null" },
+    { op: "struct.new", typeIdx: nstrVecTypeIdx },
+  ];
+
+  ctx.mod.functions.push({
+    name: "__regex_capture_array",
+    typeIdx,
+    locals: [
+      { name: "resultArr", type: { kind: "ref_null", typeIdx: nstrArrTypeIdx } },
+      { name: "i", type: { kind: "i32" } },
+      { name: "cstart", type: { kind: "i32" } },
+      { name: "cend", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
  * Emit `__regex_split(prog, classTable, nGroups, strData, strOff, strLen,
  * subject) -> ref $vec_nstr` (#1539 Phase 2c).
  *

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -10,10 +10,11 @@
  * degenerate path of the VM. See the issue's "Implementation Notes (sd-1539)".
  *
  * Current slice: `RegExp` literals / `new RegExp(staticPattern, staticFlags)`,
- * `RegExp.prototype.test`, `String.prototype.search`, literal-string
+ * `RegExp.prototype.test`/non-global `.exec`, non-global
+ * `String.prototype.match`, `String.prototype.search`, literal-string
  * `replace`/`replaceAll`, and non-capturing regex `split`. Dynamic patterns,
- * `.exec`/`.match`/`matchAll`, capture-materializing string methods, and fancy
- * features stay narrowed refusals citing the later phase.
+ * global/sticky capture-array methods, `matchAll`, replacement substitutions,
+ * and fancy features stay narrowed refusals citing the later phase.
  */
 import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
@@ -22,6 +23,7 @@ import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
 import { ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
 import {
+  ensureRegexCaptureArray,
   ensureRegexReplace,
   ensureRegexSearch,
   ensureRegexSplit,
@@ -536,6 +538,8 @@ function isStandaloneRegExpValue(
 interface RegexSearchEmission {
   /** Local holding the (non-null) `$NativeRegExp` struct ref. */
   regexpLocal: number;
+  /** Local holding the flattened subject string. */
+  inputLocal: number;
   /** Local holding the populated caps array (length `2 * nGroups`). */
   capsLocal: number;
   /** The `$NativeRegExp` struct type index (== `ctx.structMap` entry). */
@@ -667,7 +671,7 @@ function emitRegexSearchCall(
   fctx.body.push({ op: "local.get", index: stickyLocal });
   fctx.body.push({ op: "local.get", index: capsLocal });
   fctx.body.push({ op: "call", funcIdx: searchIdx });
-  return { regexpLocal, capsLocal, structTypeIdx };
+  return { regexpLocal, inputLocal, capsLocal, structTypeIdx };
 }
 
 /** True when `argExpr`'s static type is string-like (or a String wrapper). */
@@ -709,6 +713,95 @@ export function tryCompileStandaloneRegExpTest(
   const emitted = emitRegexSearchCall(ctx, fctx, propAccess.expression, expr.arguments[0]!);
   if (emitted === null) return null;
   return { kind: "i32" };
+}
+
+function flagsHaveGlobalOrSticky(flags: string): boolean {
+  return flags.includes("g") || flags.includes("y");
+}
+
+/**
+ * Emit a call to `__regex_exec_array`, returning a nullable native string vec:
+ * `null` on no match, otherwise `[fullMatch, cap1, cap2, ...]` with unmatched
+ * captures represented as null native strings (the compiler's `undefined` for
+ * nullable native string slots).
+ */
+function emitRegexExecArrayCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  regexpExpr: ts.Expression,
+  inputExpr: ts.Expression,
+): ValType | null {
+  const emitted = emitRegexSearchCall(ctx, fctx, regexpExpr, inputExpr);
+  if (emitted === null) return null;
+
+  const captureArrayIdx = ensureRegexCaptureArray(ctx);
+  const nstrVecTypeIdx = ctx.vecTypeMap.get(`ref_${ctx.anyStrTypeIdx}`);
+  if (nstrVecTypeIdx === undefined) {
+    reportError(ctx, regexpExpr, "Codegen error: standalone RegExp exec missing native string vec type (#1539).");
+    return null;
+  }
+
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "ref_null", typeIdx: nstrVecTypeIdx } },
+    then: [
+      { op: "local.get", index: emitted.regexpLocal } as Instr,
+      { op: "struct.get", typeIdx: emitted.structTypeIdx, fieldIdx: RE_FIELD_NGROUPS } as Instr,
+      { op: "local.get", index: emitted.inputLocal } as Instr,
+      { op: "local.get", index: emitted.capsLocal } as Instr,
+      { op: "call", funcIdx: captureArrayIdx } as Instr,
+    ],
+    else: [{ op: "ref.null", typeIdx: nstrVecTypeIdx } as Instr],
+  } as Instr);
+  return { kind: "ref_null", typeIdx: nstrVecTypeIdx };
+}
+
+/**
+ * `RegExp.prototype.exec(str)` in standalone mode (#1539 Phase 2b).
+ *
+ * This slice materializes the capture array for backend-created static RegExp
+ * values with non-global/non-sticky flags. `g`/`y` require observable
+ * `lastIndex` mutation and stay refused until the dedicated lastIndex slice.
+ */
+export function tryCompileStandaloneRegExpExec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): InnerResult | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "exec") return undefined;
+
+  const receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
+  if (!isGlobalRegExpType(receiverType)) return undefined;
+
+  if (!hasStandaloneRegExpEngine(ctx)) {
+    reportStandaloneRegExpUnsupported(ctx, expr, "RegExp.prototype.exec without an enabled standalone engine");
+    return null;
+  }
+  if (expr.arguments.length !== 1) {
+    reportStandaloneRegExpUnsupported(ctx, expr, "RegExp.prototype.exec arities other than one string argument");
+    return null;
+  }
+  if (!isStringLikeArg(ctx, expr.arguments[0]!)) {
+    reportStandaloneRegExpUnsupported(ctx, expr.arguments[0]!, "RegExp.prototype.exec argument coercion");
+    return null;
+  }
+
+  const flags = staticRegExpFlags(ctx, propAccess.expression);
+  if (flags === null) {
+    reportStandaloneRegExpUnsupported(ctx, propAccess.expression, "RegExp.prototype.exec with dynamic flags");
+    return null;
+  }
+  if (flagsHaveGlobalOrSticky(flags)) {
+    reportStandaloneRegExpUnsupported(
+      ctx,
+      propAccess.expression,
+      "RegExp.prototype.exec with g/y lastIndex semantics (#1539 Phase 2b)",
+    );
+    return null;
+  }
+
+  return emitRegexExecArrayCall(ctx, fctx, propAccess.expression, expr.arguments[0]!);
 }
 
 /**
@@ -778,6 +871,51 @@ export function tryCompileStandaloneStringSearch(
  */
 function staticRegExpFlags(ctx: CodegenContext, expr: ts.Expression): string | null {
   return staticRegExpPatternFlags(ctx, expr)?.flags ?? null;
+}
+
+/**
+ * `String.prototype.match(regexp)` in standalone mode (#1539 Phase 2b).
+ *
+ * Non-global static RegExp arguments share the same result shape as `.exec`.
+ * Global `match` returns an all-matches array and sticky/global lastIndex
+ * details are intentionally left to the next capture-array slice.
+ */
+export function tryCompileStandaloneStringMatch(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "match") return undefined;
+
+  if (!isStringLikeArg(ctx, propAccess.expression)) return undefined;
+  if (expr.arguments.length !== 1) return undefined;
+  const argExpr = expr.arguments[0]!;
+  const argType = ctx.checker.getTypeAtLocation(argExpr);
+  if (!isGlobalRegExpType(argType) && !isKnownBackendCreatedRegExpReceiver(ctx, argExpr)) {
+    return undefined;
+  }
+
+  const flags = staticRegExpFlags(ctx, argExpr);
+  if (flags === null) {
+    reportStandaloneRegExpUnsupported(ctx, argExpr, "String.prototype.match with dynamic RegExp flags");
+    return null;
+  }
+  if (flagsHaveGlobalOrSticky(flags)) {
+    reportStandaloneRegExpUnsupported(
+      ctx,
+      argExpr,
+      "String.prototype.match with g/y all-match or lastIndex semantics (#1539 Phase 2b/2c)",
+    );
+    return null;
+  }
+
+  if (!hasStandaloneRegExpEngine(ctx)) {
+    reportStandaloneRegExpUnsupported(ctx, expr, "String.prototype.match without an enabled standalone engine");
+    return null;
+  }
+
+  return emitRegexExecArrayCall(ctx, fctx, argExpr, propAccess.expression);
 }
 
 /**

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -13,7 +13,7 @@ import { emitUndefined } from "../expressions/late-imports.js";
 import { needsTdzFlag, resolveWasmType } from "../index.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { localGlobalIdx } from "../registry/imports.js";
-import { getOrRegisterVecType } from "../registry/types.js";
+import { getOrRegisterArrayType, getOrRegisterVecType } from "../registry/types.js";
 import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
 import { emitGuardedRefCast } from "../type-coercion.js";
 import { compileArrayDestructuring, compileObjectDestructuring } from "./destructuring.js";
@@ -99,6 +99,68 @@ const HOST_ARRAY_STRING_METHODS = new Set(["split"]);
 
 function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type): ValType {
   return isNullablePrimitiveType(type) ? { kind: "externref" } : resolveWasmType(ctx, type);
+}
+
+function stripInferenceWrapper(expr: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isTypeAssertionExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = (
+      expr as
+        | ts.ParenthesizedExpression
+        | ts.AsExpression
+        | ts.TypeAssertion
+        | ts.SatisfiesExpression
+        | ts.NonNullExpression
+    ).expression;
+  }
+  return expr;
+}
+
+function isStaticRegExpExpression(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const unwrapped = stripInferenceWrapper(expr);
+  if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) return true;
+  if (ts.isNewExpression(unwrapped) || (ts.isCallExpression(unwrapped) && !unwrapped.questionDotToken)) {
+    const callee = stripInferenceWrapper(unwrapped.expression);
+    return ts.isIdentifier(callee) && callee.text === "RegExp";
+  }
+  if (ts.isIdentifier(unwrapped)) {
+    const sym = ctx.checker.getSymbolAtLocation(unwrapped);
+    const decl = sym?.getDeclarations()?.find((d) => ts.isVariableDeclaration(d)) as ts.VariableDeclaration | undefined;
+    return decl?.initializer !== undefined && isStaticRegExpExpression(ctx, decl.initializer);
+  }
+  return false;
+}
+
+function nativeStringVecType(ctx: CodegenContext): ValType | null {
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return null;
+  const elemKey = `ref_${ctx.anyStrTypeIdx}`;
+  const elemType: ValType = { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+  getOrRegisterArrayType(ctx, elemKey, elemType);
+  const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
+  return { kind: "ref_null", typeIdx: vecTypeIdx };
+}
+
+function inferStandaloneRegExpMatchArrayType(
+  ctx: CodegenContext,
+  initializer: ts.Expression | undefined,
+): ValType | null {
+  if (!ctx.standalone || !initializer) return null;
+  const unwrapped = stripInferenceWrapper(initializer);
+  if (!ts.isCallExpression(unwrapped)) return null;
+  if (!ts.isPropertyAccessExpression(unwrapped.expression)) return null;
+  const method = unwrapped.expression.name.text;
+  if (method === "exec") {
+    return isStaticRegExpExpression(ctx, unwrapped.expression.expression) ? nativeStringVecType(ctx) : null;
+  }
+  if (method === "match" && unwrapped.arguments.length === 1) {
+    return isStaticRegExpExpression(ctx, unwrapped.arguments[0]!) ? nativeStringVecType(ctx) : null;
+  }
+  return null;
 }
 
 function nullishLiteralKind(expr: ts.Expression): "null" | "undefined" | null {
@@ -525,6 +587,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       ctx.externrefAccessorVars.add(name);
     }
 
+    const standaloneRegExpMatchArrayType = inferStandaloneRegExpMatchArrayType(ctx, decl.initializer);
     const wasmType: ValType = initIsAccessorLiteral
       ? { kind: "externref" as const }
       : isI32CoercedLocal
@@ -534,6 +597,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           : widenedTypeIdx !== undefined
             ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
             : (inferredVecType ??
+              standaloneRegExpMatchArrayType ??
               (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
                 ? { kind: "externref" as const }
                 : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
@@ -624,6 +688,8 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         // is the same "undefined" sentinel a hoisted externref would carry
         // before its first assignment).
         if (initIsAccessorLiteral && existingIsRef && wasmType.kind === "externref") {
+          localSlot.type = wasmType;
+        } else if (standaloneRegExpMatchArrayType !== null && existingIsExternref && newIsRef) {
           localSlot.type = wasmType;
         } else if (!(existingIsRef && newIsPrimitive) && !(existingIsExternref && newIsRef)) {
           localSlot.type = wasmType;

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -22,6 +22,7 @@ import {
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
 import {
+  tryCompileStandaloneStringMatch,
   tryCompileStandaloneStringReplace,
   tryCompileStandaloneStringSearch,
   tryCompileStandaloneStringSplit,
@@ -2453,6 +2454,14 @@ export function compileNativeStringMethodCall(
   //   - replace / replaceAll / split: only when the first argument needs
   //     RegExp/symbol-protocol dispatch (string-arg forms use the native helpers
   //     above and never reach this fall-through).
+  // #1539 Phase 2b — `String.prototype.match(/re/)` for non-global
+  // backend-created static RegExp materializes the same native capture vec as
+  // `.exec`. Global/all-match semantics stay refused below.
+  if (ctx.standalone && method === "match") {
+    const matchResult = tryCompileStandaloneStringMatch(ctx, fctx, expr, propAccess);
+    if (matchResult !== undefined) return matchResult;
+  }
+
   // #1539 Phase 2b — `String.prototype.search(/re/)` against a backend-created
   // static RegExp routes to the pure-WasmGC matcher (returns the match index or
   // -1) instead of the host regex engine. The string-coercion form (string

--- a/tests/issue-1474-standalone-regex-refuse.test.ts
+++ b/tests/issue-1474-standalone-regex-refuse.test.ts
@@ -42,8 +42,17 @@ describe("#1474/#1539 --target standalone still refuses (narrowed)", () => {
     await expectRefused(`export function f(p: string): boolean { const r = RegExp(p); return r.test("x"); }`);
   });
 
-  it("rejects s.match(regexLiteral) — String method (Phase 2c)", async () => {
-    await expectRefused(`export function f(s: string): boolean { return s.match(/\\d+/) !== null; }`);
+  it("compiles non-global s.match(regexLiteral) — capture-array Phase 2b slice", async () => {
+    const r = await compile(`export function f(s: string): boolean { return s.match(/\\d+/) !== null; }`, {
+      target: "standalone",
+    });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  });
+
+  it("rejects global s.match(regexLiteral) — all-match semantics (Phase 2c)", async () => {
+    await expectRefused(
+      `export function f(s: string): number { const m = s.match(/\\d+/g); return m === null ? -1 : m.length; }`,
+    );
   });
 
   it("rejects s.matchAll(regexLiteral) — Phase 2c", async () => {

--- a/tests/issue-1539-standalone-regex.test.ts
+++ b/tests/issue-1539-standalone-regex.test.ts
@@ -133,6 +133,132 @@ describe("#1539 standalone String.prototype.search — no JS host, matches nativ
   });
 });
 
+async function readStandaloneStringSlots(src: string): Promise<Array<string | undefined> | null> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostRegex = WebAssembly.Module.imports(mod).filter((i) =>
+    /RegExp|string_match|__make_iterable|__extern_get/.test(i.name),
+  );
+  expect(hostRegex, "no RegExp/string_match/iterable/extern_get host import in standalone").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as {
+    matched(): number;
+    count(): number;
+    isUndef(i: number): number;
+    len(i: number): number;
+    at(i: number, j: number): number;
+  };
+  if (ex.matched() === 0) return null;
+  const out: Array<string | undefined> = [];
+  for (let i = 0; i < ex.count(); i++) {
+    if (ex.isUndef(i) !== 0) {
+      out.push(undefined);
+      continue;
+    }
+    let part = "";
+    for (let j = 0; j < ex.len(i); j++) part += String.fromCharCode(ex.at(i, j));
+    out.push(part);
+  }
+  return out;
+}
+
+async function standaloneExecSlots(
+  pattern: string,
+  flags: string,
+  input: string,
+): Promise<Array<string | undefined> | null> {
+  const inLit = JSON.stringify(input);
+  return readStandaloneStringSlots(`
+    export function matched(): boolean { const m = /${pattern}/${flags}.exec(${inLit}); return m !== null; }
+    export function count(): number { const m = /${pattern}/${flags}.exec(${inLit}); return m === null ? -1 : m.length; }
+    export function isUndef(i: number): boolean {
+      const m = /${pattern}/${flags}.exec(${inLit})!;
+      return m[i] === undefined;
+    }
+    export function len(i: number): number {
+      const m = /${pattern}/${flags}.exec(${inLit})!;
+      return m[i] === undefined ? -1 : m[i]!.length;
+    }
+    export function at(i: number, j: number): number {
+      const m = /${pattern}/${flags}.exec(${inLit})!;
+      return m[i]!.charCodeAt(j);
+    }
+  `);
+}
+
+async function standaloneMatchSlots(
+  pattern: string,
+  flags: string,
+  input: string,
+): Promise<Array<string | undefined> | null> {
+  const inLit = JSON.stringify(input);
+  return readStandaloneStringSlots(`
+    export function matched(): boolean { const m = ${inLit}.match(/${pattern}/${flags}); return m !== null; }
+    export function count(): number { const m = ${inLit}.match(/${pattern}/${flags}); return m === null ? -1 : m.length; }
+    export function isUndef(i: number): boolean {
+      const m = ${inLit}.match(/${pattern}/${flags})!;
+      return m[i] === undefined;
+    }
+    export function len(i: number): number {
+      const m = ${inLit}.match(/${pattern}/${flags})!;
+      return m[i] === undefined ? -1 : m[i]!.length;
+    }
+    export function at(i: number, j: number): number {
+      const m = ${inLit}.match(/${pattern}/${flags})!;
+      return m[i]!.charCodeAt(j);
+    }
+  `);
+}
+
+function nativeExecSlots(pattern: string, flags: string, input: string): Array<string | undefined> | null {
+  const m = new RegExp(pattern, flags).exec(input);
+  return m === null ? null : Array.from(m, (s) => s);
+}
+
+describe("#1539 standalone RegExp.exec/String.match — capture vec, no JS host", () => {
+  const captureCases: Array<{ p: string; f: string; input: string }> = [
+    { p: "(ab)(\\d+)", f: "", input: "xxab123yy" },
+    { p: "(a)?b", f: "", input: "b" },
+    { p: "([a-z]+)|(\\d+)", f: "", input: "42" },
+    { p: "([a-z]+)", f: "i", input: "ABC" },
+    { p: "^([a-z]+)$", f: "m", input: "x\nabc\ny" },
+    { p: "z+", f: "", input: "abc" },
+  ];
+
+  for (const { p, f, input } of captureCases) {
+    it(`/${p}/${f}.exec(${JSON.stringify(input)})`, async () => {
+      expect(await standaloneExecSlots(p, f, input)).toEqual(nativeExecSlots(p, f, input));
+    });
+    it(`${JSON.stringify(input)}.match(/${p}/${f})`, async () => {
+      expect(await standaloneMatchSlots(p, f, input)).toEqual(nativeExecSlots(p, f, input));
+    });
+  }
+
+  it("var-bound RegExp.exec argument", async () => {
+    const out = await readStandaloneStringSlots(`
+      const re = /(x+)(y)/;
+      export function matched(): boolean { const m = re.exec("axxy"); return m !== null; }
+      export function count(): number { const m = re.exec("axxy"); return m === null ? -1 : m.length; }
+      export function isUndef(i: number): boolean { const m = re.exec("axxy")!; return m[i] === undefined; }
+      export function len(i: number): number { const m = re.exec("axxy")!; return m[i]!.length; }
+      export function at(i: number, j: number): number { const m = re.exec("axxy")!; return m[i]!.charCodeAt(j); }
+    `);
+    expect(out).toEqual(["xxy", "xx", "y"]);
+  });
+
+  it("new RegExp(...).exec argument", async () => {
+    const out = await readStandaloneStringSlots(`
+      export function matched(): boolean { const m = new RegExp("(a+)(b)").exec("aaab"); return m !== null; }
+      export function count(): number { const m = new RegExp("(a+)(b)").exec("aaab"); return m === null ? -1 : m.length; }
+      export function isUndef(i: number): boolean { const m = new RegExp("(a+)(b)").exec("aaab")!; return m[i] === undefined; }
+      export function len(i: number): number { const m = new RegExp("(a+)(b)").exec("aaab")!; return m[i]!.length; }
+      export function at(i: number, j: number): number { const m = new RegExp("(a+)(b)").exec("aaab")!; return m[i]!.charCodeAt(j); }
+    `);
+    expect(out).toEqual(["aaab", "aaa", "b"]);
+  });
+});
+
 async function standaloneSplit(pattern: string, flags: string, input: string): Promise<string[]> {
   const inLit = JSON.stringify(input);
   const src = `
@@ -221,6 +347,16 @@ describe("#1539 standalone narrowed refusals (Phase 2a)", () => {
   });
   it("refuses indices flag (d, Phase 2d)", async () => {
     await expectRefused(`export function f(s: string): boolean { return /^a/d.test(s); }`);
+  });
+  it("refuses RegExp.exec with global lastIndex semantics", async () => {
+    await expectRefused(
+      `export function f(s: string): number { const m = /a/g.exec(s); return m === null ? -1 : m.length; }`,
+    );
+  });
+  it("refuses String.match with global all-match semantics", async () => {
+    await expectRefused(
+      `export function f(s: string): number { const m = s.match(/a/g); return m === null ? -1 : m.length; }`,
+    );
   });
   it("refuses regex split with capturing groups", async () => {
     await expectRefused(`export function f(s: string): number { return s.split(/(,)/).length; }`);


### PR DESCRIPTION
## Summary
- add pure-WasmGC capture-array materialization for standalone non-global `RegExp.prototype.exec` and `String.prototype.match`
- keep static exec/match result variables on the native nullable string vec path, including non-null assertions
- preserve narrowed refusals for global/sticky capture-array semantics and update issue #1539 notes

## Validation
- `npm test -- tests/issue-1539-standalone-regex.test.ts tests/issue-1474-standalone-regex-refuse.test.ts tests/issue-1539-standalone-regex-replace.test.ts`
- pre-push hook: typecheck + lint, prettier format:check, issue integrity
