### PR TITLE
fix(codegen): forward implicit subclass constructor args

### DIFF
--- a/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
+++ b/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
@@ -1,15 +1,17 @@
 ---
 id: 1833
 title: "Implicit subclass constructor forwarder truncates multi-arg super(...)"
-status: ready
+status: in-progress
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-06
 priority: medium
 feasibility: medium
 task_type: bugfix
 area: codegen
 goal: correctness
 sprint: 60
+claimed_by: codex-developer
+claimed_at: 2026-06-06T18:07:20.508Z
 ---
 # #1833 — implicit derived constructor forwards only the first arg
 
@@ -29,3 +31,30 @@ An implicit derived constructor is `constructor(...args){ super(...args) }`.
 ## Fix
 Forward the full argument list (rest/vec) to the parent constructor.
 
+## Implementation Summary
+
+Implemented the implicit externref-backed subclass constructor as a parent-shaped
+externref forwarder instead of a single `__arg0` function. The synthetic
+constructor now registers enough externref slots for the built-in parent's
+known constructor arity, forwards all of those locals to `__new_<Parent>`, and
+still pads omitted caller arguments as JavaScript `undefined` so the runtime can
+trim them for optional parent constructor arguments.
+
+The explicit built-in `super(...)` path now uses the same parent arity so sibling
+classes cannot disagree on the `__new_<Parent>` import signature. Local class
+constructor calls also coerce emitted arguments to the callee signature, which is
+needed for numeric DataView offset/length arguments that are forwarded through
+externref synthetic parameters.
+
+Files changed:
+- `src/codegen/class-bodies.ts`
+- `src/codegen/expressions/new-super.ts`
+- `src/codegen/builtin-tags.ts`
+- `tests/issue-1833.test.ts`
+- `plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md`
+
+Validation:
+- `pnpm exec vitest run tests/issue-1833.test.ts` — pass
+- `pnpm exec vitest run tests/issue-1833.test.ts tests/issue-1515.test.ts` — pass
+- `pnpm exec tsc --noEmit --pretty false` — pass
+- `pnpm exec vitest run tests/issue-1833.test.ts tests/issue-1515.test.ts tests/arraybuffer-dataview.test.ts` — existing `arraybuffer-dataview.test.ts` runtime cases fail because their harness instantiates modules without a `string_constants` import object; `issue-1833` and `issue-1515` pass in the same run.

--- a/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
+++ b/plan/issues/1833-implicit-subclass-forwarder-truncates-super-args.md
@@ -1,7 +1,8 @@
 ---
 id: 1833
 title: "Implicit subclass constructor forwarder truncates multi-arg super(...)"
-status: in-progress
+status: in-review
+pr: 1255
 created: 2026-06-04
 updated: 2026-06-06
 priority: medium

--- a/src/codegen/builtin-tags.ts
+++ b/src/codegen/builtin-tags.ts
@@ -178,14 +178,9 @@ export function getBuiltinParent(name: string): BuiltinTypeName | undefined {
  *     impls automatically (since the instance IS a real Array/Map/etc.), but
  *     methods that return "a new instance of the same kind" return the
  *     parent type, not Sub.
- *   - Default constructor `class Sub extends Array {}` does not forward
- *     `new Sub(5)`'s `5` argument to `super(5)` (Sub has 0 declared params,
- *     so callers truncate args to match). Explicit `constructor(x){super(x)}`
- *     is the supported pattern.
- *   - Multi-arg `super(a, b)` only passes the first arg today (the existing
- *     #1366a `compileSuperCall` builtin branch is single-arg). DataView's
- *     3-arg and RegExp's 2-arg forms thus don't fully work; deferred to a
- *     follow-up that pre-scans super arities.
+ *   - Dynamic spread (`super(...args)` or `new Sub(...args)`) only forwards up
+ *     to the parent constructor's statically known import arity. Array-literal
+ *     spread is flattened, but arbitrary iterable spreading is still deferred.
  */
 export const BUILTIN_PARENTS_HOST_CONSTRUCTIBLE: ReadonlySet<BuiltinTypeName> = new Set<BuiltinTypeName>([
   // #1366a — Error family

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -21,6 +21,7 @@ import {
 import { emitThrowReferenceError } from "./expressions/helpers.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import { cacheStringLiterals, hasAbstractModifier, hasStaticModifier, resolveWasmType } from "./index.js";
+import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
@@ -72,6 +73,124 @@ function constructorBodyHasSuperCall(node: ts.Node): boolean {
   };
   ts.forEachChild(node, visit);
   return found;
+}
+
+function getBuiltinConstructorForwardArity(ctx: CodegenContext, builtinParent: string): number {
+  const declaredArity = ctx.externClasses.get(builtinParent)?.constructorParams.length ?? 0;
+  return Math.max(1, declaredArity);
+}
+
+function countStaticallyKnownArgs(
+  args: ts.NodeArray<ts.Expression> | readonly ts.Expression[] | undefined,
+): number | undefined {
+  if (!args) return 0;
+  let count = 0;
+  for (const arg of args) {
+    if (ts.isSpreadElement(arg)) {
+      if (!ts.isArrayLiteralExpression(arg.expression)) return undefined;
+      count += arg.expression.elements.length;
+    } else {
+      count++;
+    }
+  }
+  return count;
+}
+
+function flattenStaticallyKnownArgs(
+  args: ts.NodeArray<ts.Expression> | readonly ts.Expression[],
+): ts.Expression[] | null {
+  const result: ts.Expression[] = [];
+  for (const arg of args) {
+    if (ts.isSpreadElement(arg)) {
+      if (!ts.isArrayLiteralExpression(arg.expression)) return null;
+      for (const element of arg.expression.elements) {
+        result.push(element);
+      }
+    } else {
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
+function unwrapParenthesized(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (ts.isParenthesizedExpression(current)) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function newExpressionTargetsClass(
+  ctx: CodegenContext,
+  expr: ts.NewExpression,
+  decl: ts.ClassDeclaration | ts.ClassExpression,
+  className: string,
+): boolean {
+  const callee = unwrapParenthesized(expr.expression);
+  if (callee === decl) return true;
+  if (!ts.isIdentifier(callee)) return false;
+
+  const targetSymbol = ctx.checker.getSymbolAtLocation(callee);
+  const targetDecls = targetSymbol?.getDeclarations() ?? [];
+  if (targetDecls.some((d) => d === decl || (ts.isVariableDeclaration(d) && d.initializer === decl))) {
+    return true;
+  }
+  if (targetSymbol !== undefined) return false;
+
+  return (ctx.classExprNameMap.get(callee.text) ?? callee.text) === className;
+}
+
+function getObservedClassNewArity(
+  ctx: CodegenContext,
+  decl: ts.ClassDeclaration | ts.ClassExpression,
+  className: string,
+): number {
+  let maxArity = 0;
+  const visit = (node: ts.Node): void => {
+    if (ts.isNewExpression(node) && newExpressionTargetsClass(ctx, node, decl, className)) {
+      const argCount = countStaticallyKnownArgs(node.arguments);
+      if (argCount !== undefined) maxArity = Math.max(maxArity, argCount);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(decl.getSourceFile());
+  return maxArity;
+}
+
+function getImplicitExternrefForwarderArity(
+  ctx: CodegenContext,
+  decl: ts.ClassDeclaration | ts.ClassExpression,
+  className: string,
+  builtinParent: string,
+): number {
+  return Math.max(
+    getBuiltinConstructorForwardArity(ctx, builtinParent),
+    getObservedClassNewArity(ctx, decl, className),
+  );
+}
+
+function externrefParams(count: number): ValType[] {
+  return Array.from({ length: count }, () => ({ kind: "externref" }) as ValType);
+}
+
+function compileExternrefArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
+  const argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
+  if (argResult === null) {
+    emitUndefined(ctx, fctx);
+    return;
+  }
+  if (argResult.kind !== "externref") {
+    coerceType(ctx, fctx, argResult, { kind: "externref" });
+  }
+}
+
+function evaluateArgumentForSideEffects(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
+  const inner = ts.isSpreadElement(arg) ? arg.expression : arg;
+  const argResult = compileExpression(ctx, fctx, inner);
+  if (argResult !== null) {
+    fctx.body.push({ op: "drop" });
+  }
 }
 
 /**
@@ -342,15 +461,17 @@ export function collectClassDeclaration(
   // Register constructor function: takes ctor params, returns (ref $structTypeIdx)
   const ctorParams: ValType[] = [];
   const ctorName = `${className}_new`;
-  // (#1455) For externref-backed subclasses with no explicit constructor
+  // (#1833) For externref-backed subclasses with no explicit constructor
   // (`class Sub extends DataView {}`), synthesize the spec's implicit
-  // `constructor(...args) { super(...args); }` as a single-arg forwarder.
-  // The single externref param `__arg0` is forwarded to `__new_<Parent>`.
-  // Multi-arg forms (e.g. `new DataView(buf, 0, 16)`) only forward the first
-  // arg — multi-arg implicit forwarding is deferred (#1366c follow-up).
-  const isImplicitExternrefForwarder = !ctor && ctx.classBuiltinParentMap.has(className);
-  if (isImplicitExternrefForwarder) {
-    ctorParams.push({ kind: "externref" });
+  // `constructor(...args) { super(...args); }` as an externref forwarder whose
+  // arity matches the parent constructor shape. Missing caller args are padded
+  // as JS undefined and stripped by the runtime's `__new_<Parent>` resolver.
+  const implicitBuiltinParent = !ctor ? ctx.classBuiltinParentMap.get(className) : undefined;
+  const implicitForwarderArity = implicitBuiltinParent
+    ? getImplicitExternrefForwarderArity(ctx, decl, className, implicitBuiltinParent)
+    : 0;
+  if (implicitForwarderArity > 0) {
+    ctorParams.push(...externrefParams(implicitForwarderArity));
   }
   if (ctor) {
     for (let i = 0; i < ctor.parameters.length; i++) {
@@ -894,10 +1015,13 @@ function compileClassBodiesInner(
   if (ctorLocalIdx !== undefined) {
     const func = ctx.mod.functions[ctorLocalIdx]!;
     const params: { name: string; type: ValType }[] = [];
-    // (#1455) Match the synthetic forwarder param added during pre-registration.
-    const isImplicitForwarder = !ctor && ctx.classBuiltinParentMap.has(className);
-    if (isImplicitForwarder) {
-      params.push({ name: "__arg0", type: { kind: "externref" } });
+    // (#1833) Match the synthetic forwarder params added during pre-registration.
+    const implicitBuiltinParent = !ctor ? ctx.classBuiltinParentMap.get(className) : undefined;
+    const implicitForwarderArity = implicitBuiltinParent
+      ? getImplicitExternrefForwarderArity(ctx, decl, className, implicitBuiltinParent)
+      : 0;
+    for (let i = 0; i < implicitForwarderArity; i++) {
+      params.push({ name: `__arg${i}`, type: { kind: "externref" } });
     }
     if (ctor) {
       for (let pi = 0; pi < ctor.parameters.length; pi++) {
@@ -1095,33 +1219,30 @@ function compileClassBodiesInner(
       }
     }
 
-    // (#1366a) For externref-backed subclasses, the parent-chain field-walk
-    // path is irrelevant (no struct fields to copy). When there's no explicit
-    // ctor, emit an implicit `super(args[0])`-equivalent: forward the first
-    // declared parameter to `__new_<ParentBuiltin>(...)`. With no params, we
-    // call `__new_<Parent>(null)`.
+    // (#1366a / #1833) For externref-backed subclasses, the parent-chain
+    // field-walk path is irrelevant (no struct fields to copy). When there's no
+    // explicit ctor, emit the default derived constructor: forward the synthetic
+    // externref parameter list to `__new_<ParentBuiltin>(...)`.
     if (!ctor && isExternrefBacked) {
       const parentName = ctx.classBuiltinParentMap.get(className);
       if (parentName) {
         const importName = `__new_${parentName}`;
-        // (#1455) Implicit constructor: forward the synthetic `__arg0`
-        // externref param to `__new_<Parent>(__arg0)`. Callers that supply
-        // zero args have `pushDefaultValue` pad with `ref.null.extern`; the
-        // runtime strips trailing null/undefined so `new Sub()` correctly
-        // calls `new Builtin()`. Callers that supply 2+ args have the extras
-        // truncated — multi-arg forwarding is a follow-up.
-        if (params.length > 0 && params[0]!.type.kind === "externref") {
-          fctx.body.push({ op: "local.get", index: 0 });
-        } else {
-          fctx.body.push({ op: "ref.null.extern" });
-        }
-        const funcIdx = ensureLateImport(ctx, importName, [{ kind: "externref" }], [{ kind: "externref" }]);
+        const forwardParams = externrefParams(implicitForwarderArity);
+        const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
         flushLateImportShifts(ctx, fctx);
         if (funcIdx !== undefined) {
+          for (let i = 0; i < implicitForwarderArity; i++) {
+            fctx.body.push({ op: "local.get", index: i });
+          }
           fctx.body.push({ op: "call", funcIdx });
         } else {
-          // Standalone (no host import): the externref message is already on
-          // stack; treat that as the instance (best-effort fallback).
+          // Standalone (no host import): treat the first constructor argument
+          // as the instance, matching the previous single-arg fallback.
+          if (implicitForwarderArity > 0) {
+            fctx.body.push({ op: "local.get", index: 0 });
+          } else {
+            fctx.body.push({ op: "ref.null.extern" });
+          }
         }
         fctx.body.push({ op: "local.set", index: selfLocal });
         // (#1455) Set the instance's [[Prototype]] to `Sub.prototype` so
@@ -1889,43 +2010,52 @@ export function compileSuperCall(
   if (builtinParent) {
     const args = callExpr.arguments;
     const hasSpread = args.some((a) => ts.isSpreadElement(a));
-    if (hasSpread || args.length === 0) {
-      // (#1551) Even when we cannot forward spread args to the host
-      // constructor, evaluate them left-to-right for side effects so that
-      // abrupt completions (throws from arg expressions) propagate to the
-      // user's try/catch around `super(...)`. The host import receives null
-      // (best-effort; #1366b refines spread forwarding).
-      for (const a of args) {
-        const inner = ts.isSpreadElement(a) ? a.expression : a;
-        const argResult = compileExpression(ctx, fctx, inner);
-        if (argResult !== null) {
-          fctx.body.push({ op: "drop" });
-        }
-      }
-      fctx.body.push({ op: "ref.null.extern" });
-    } else {
-      // Single message arg coerced to externref, plus side-effect-only
-      // evaluation of any trailing args (§13.3.7.1 step 4 — #1551).
-      const argResult = compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
-      if (argResult && argResult.kind !== "externref") {
-        coerceType(ctx, fctx, argResult, { kind: "externref" });
-      }
-      for (let i = 1; i < args.length; i++) {
-        const extra = compileExpression(ctx, fctx, args[i]!);
-        if (extra !== null) {
-          fctx.body.push({ op: "drop" });
-        }
-      }
-    }
     const importName = `__new_${builtinParent}`;
-    const funcIdx = ensureLateImport(ctx, importName, [{ kind: "externref" }], [{ kind: "externref" }]);
+    const forwardArity = getBuiltinConstructorForwardArity(ctx, builtinParent);
+    const forwardParams = externrefParams(forwardArity);
+    const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
     flushLateImportShifts(ctx, fctx);
     if (funcIdx !== undefined) {
+      const flatArgs = hasSpread ? flattenStaticallyKnownArgs(args) : [...args];
+      if (flatArgs) {
+        for (let i = 0; i < forwardArity; i++) {
+          if (i < flatArgs.length) {
+            compileExternrefArgument(ctx, fctx, flatArgs[i]!);
+          } else {
+            emitUndefined(ctx, fctx);
+          }
+        }
+        for (let i = forwardArity; i < flatArgs.length; i++) {
+          evaluateArgumentForSideEffects(ctx, fctx, flatArgs[i]!);
+        }
+      } else {
+        // (#1551) Non-literal spread cannot be unpacked here yet. Evaluate
+        // operands left-to-right for side effects, then call the parent with an
+        // all-undefined argument list that the runtime trims to `super()`.
+        for (const arg of args) {
+          evaluateArgumentForSideEffects(ctx, fctx, arg);
+        }
+        for (let i = 0; i < forwardArity; i++) {
+          emitUndefined(ctx, fctx);
+        }
+      }
       fctx.body.push({ op: "call", funcIdx });
+    } else {
+      // If the import is unavailable (standalone/WASI), preserve the old
+      // best-effort fallback: evaluate arguments, then use the first value (or
+      // null) as the instance.
+      if (args.length > 0 && !ts.isSpreadElement(args[0]!)) {
+        compileExternrefArgument(ctx, fctx, args[0]!);
+        for (let i = 1; i < args.length; i++) {
+          evaluateArgumentForSideEffects(ctx, fctx, args[i]!);
+        }
+      } else {
+        for (const arg of args) {
+          evaluateArgumentForSideEffects(ctx, fctx, arg);
+        }
+        fctx.body.push({ op: "ref.null.extern" });
+      }
     }
-    // If the import is unavailable (standalone/WASI), the message externref
-    // is already on the stack; treating it as the instance is the documented
-    // standalone fallback (architect spec, risk #2).
     fctx.body.push({ op: "local.set", index: selfLocal });
     // (#1455) Adjust the instance's [[Prototype]] to `childClassName.prototype`
     // so `instance instanceof childClassName` returns true. Without this step

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -65,6 +65,32 @@ function resolveEnclosingClassName(fctx: FunctionContext): string | undefined {
   return undefined;
 }
 
+function valTypeMatches(a: ValType, b: ValType): boolean {
+  if (a.kind !== b.kind) return false;
+  if ((a.kind === "ref" || a.kind === "ref_null") && (b.kind === "ref" || b.kind === "ref_null")) {
+    return a.typeIdx === b.typeIdx;
+  }
+  return true;
+}
+
+function compileCtorArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression, expected?: ValType): void {
+  const result = compileExpression(ctx, fctx, arg, expected);
+  if (result === null) {
+    if (expected) pushDefaultValue(fctx, expected, ctx);
+    return;
+  }
+  if (expected && !valTypeMatches(result, expected)) {
+    coerceType(ctx, fctx, result, expected);
+  }
+}
+
+function evaluateCtorExtraArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
+  const result = compileExpression(ctx, fctx, arg);
+  if (result !== null) {
+    fctx.body.push({ op: "drop" });
+  }
+}
+
 /**
  * (#1732 S1) Decide whether a `new <id>` callee identifier resolves to a value
  * that is PROVABLY not a constructor — so the runtime `__construct` brand check
@@ -2928,7 +2954,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const flatCtorArgs = flattenCallArgs(args);
       if (flatCtorArgs) {
         for (let i = 0; i < flatCtorArgs.length && i < paramTypes.length; i++) {
-          compileExpression(ctx, fctx, flatCtorArgs[i]!, paramTypes[i]);
+          compileCtorArgument(ctx, fctx, flatCtorArgs[i]!, paramTypes[i]);
+        }
+        for (let i = paramTypes.length; i < flatCtorArgs.length; i++) {
+          evaluateCtorExtraArgument(ctx, fctx, flatCtorArgs[i]!);
         }
         // Pad missing args
         for (let i = flatCtorArgs.length; i < paramTypes.length; i++) {
@@ -2942,7 +2971,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // Calling a rest-param constructor: pack trailing args into a GC array
       for (let i = 0; i < ctorRestInfo.restIndex; i++) {
         if (i < args.length) {
-          compileExpression(ctx, fctx, args[i]!, paramTypes?.[i]);
+          compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i]);
         } else {
           pushDefaultValue(fctx, paramTypes?.[i] ?? { kind: "f64" }, ctx);
         }
@@ -2951,7 +2980,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const restArgCount = Math.max(0, args.length - ctorRestInfo.restIndex);
       fctx.body.push({ op: "i32.const", value: restArgCount });
       for (let i = ctorRestInfo.restIndex; i < args.length; i++) {
-        compileExpression(ctx, fctx, args[i]!, ctorRestInfo.elemType);
+        compileCtorArgument(ctx, fctx, args[i]!, ctorRestInfo.elemType);
       }
       fctx.body.push({
         op: "array.new_fixed",
@@ -2960,8 +2989,12 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       });
       fctx.body.push({ op: "struct.new", typeIdx: ctorRestInfo.vecTypeIdx });
     } else {
-      for (let i = 0; i < args.length; i++) {
-        compileExpression(ctx, fctx, args[i]!, paramTypes?.[i]);
+      const positionalParamCount = paramTypes?.length ?? args.length;
+      for (let i = 0; i < args.length && i < positionalParamCount; i++) {
+        compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i]);
+      }
+      for (let i = positionalParamCount; i < args.length; i++) {
+        evaluateCtorExtraArgument(ctx, fctx, args[i]!);
       }
       // Pad missing constructor arguments with defaults (arity mismatch)
       if (paramTypes) {

--- a/tests/issue-1833.test.ts
+++ b/tests/issue-1833.test.ts
@@ -1,0 +1,39 @@
+// #1833 — implicit externref-backed subclass constructors must forward every
+// observed constructor argument to the built-in parent.
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.ts";
+
+async function runNumber(source: string): Promise<number> {
+  const exports = await compileAndInstantiate(source);
+  return (exports.test as () => number)();
+}
+
+describe("#1833 implicit subclass constructor forwarding", () => {
+  it("forwards DataView byteOffset through the default derived constructor", async () => {
+    expect(
+      await runNumber(`
+        class Sub extends DataView {}
+
+        export function test(): number {
+          const buf = new ArrayBuffer(16);
+          const view = new Sub(buf, 4, 4);
+          return view.byteOffset;
+        }
+      `),
+    ).toBe(4);
+  });
+
+  it("forwards DataView byteLength through the default derived constructor", async () => {
+    expect(
+      await runNumber(`
+        class Sub extends DataView {}
+
+        export function test(): number {
+          const buf = new ArrayBuffer(16);
+          const view = new Sub(buf, 4, 4);
+          return view.byteLength;
+        }
+      `),
+    ).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- register implicit externref-backed subclass constructors with parent-shaped externref arity
- forward every synthetic argument to the built-in parent constructor
- coerce local class constructor arguments so numeric DataView offset/length survive externref forwarding

## Validation
- pnpm exec vitest run tests/issue-1833.test.ts
- pnpm exec vitest run tests/issue-1833.test.ts tests/issue-1515.test.ts
- pnpm exec tsc --noEmit --pretty false

## Note
- The broader arraybuffer-dataview test file still has existing runtime harness failures for missing string_constants imports; the new issue test and adjacent #1515 DataView tests pass.