### PR TITLE
fix(iterator): advance array iterator loops on continue

### DIFF
--- a/plan/issues/681-pure-wasm-iterator-protocol-eliminate.md
+++ b/plan/issues/681-pure-wasm-iterator-protocol-eliminate.md
@@ -1,7 +1,7 @@
 ---
 id: 681
 title: "Pure Wasm iterator protocol (eliminate 5 host imports)"
-status: in-progress
+status: in-review
 created: 2026-03-20
 updated: 2026-06-06
 priority: high
@@ -20,6 +20,7 @@ files:
       - "for-of uses struct-based iterators instead of host imports"
 claimed_by: codex-developer
 claimed_at: 2026-06-06T18:07:10.511Z
+pr: 1256
 ---
 # #681 — Pure Wasm iterator protocol (eliminate 5 host imports)
 

--- a/plan/issues/681-pure-wasm-iterator-protocol-eliminate.md
+++ b/plan/issues/681-pure-wasm-iterator-protocol-eliminate.md
@@ -3,7 +3,7 @@ id: 681
 title: "Pure Wasm iterator protocol (eliminate 5 host imports)"
 status: in-progress
 created: 2026-03-20
-updated: 2026-06-03
+updated: 2026-06-06
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -18,6 +18,8 @@ files:
   src/codegen/expressions.ts:
     breaking:
       - "for-of uses struct-based iterators instead of host imports"
+claimed_by: codex-developer
+claimed_at: 2026-06-06T18:07:10.511Z
 ---
 # #681 — Pure Wasm iterator protocol (eliminate 5 host imports)
 
@@ -28,7 +30,7 @@ files:
 - [§7.4.7 IteratorClose](https://tc39.es/ecma262/#sec-iteratorclose) — calls .return() if it exists
 
 
-## Status: open
+## Status: in-progress
 
 Iterator protocol uses 5 host imports (__iterator, __iterator_next, __iterator_done, __iterator_value, __iterator_return). Should be pure Wasm.
 
@@ -149,3 +151,28 @@ Generic for-of over an opaque externref `any` (a runtime `GetIterator` →
 standalone — the genuinely-hard residual called out in the 2026-06-03 profile.
 Non-destructured `for (pair of arr.entries())` (needs a materialized 2-tuple)
 is also a deliberate fall-through, not yet native.
+
+## 2026-06-06 codex slice: continue-safe native Array iterator loops
+
+Fixed the direct pure-Wasm array iterator loops so `continue` advances the
+native index before re-entering the loop. The previous `block { loop { ... } }`
+shape bound `continue` to the loop header while the increment sat after the
+user body, so `for (... of arr.entries()) { if (...) continue; }` could repeat
+the same `[index, value]` pair forever.
+
+The array value loop used by direct array for-of and `arr.values()` now wraps
+the user body in an inner block and places `i += 1` after that block. The
+`.keys()` / `.entries()` projection loop uses the same structure. `break`
+still exits the outer block, while `continue` exits only the inner body block
+and falls through to the increment. No iterator or array-iterator host imports
+are introduced.
+
+Scoped validation:
+
+- `pnpm vitest run tests/issue-681.test.ts tests/issue-681-standalone-iterators.test.ts tests/issue-1320-standalone.test.ts --reporter verbose` — 21 passing.
+- `pnpm vitest run tests/issue-1665-standalone-generator-forof.test.ts --reporter verbose` — 3 passing.
+- `pnpm exec prettier --check src/codegen/statements/loops.ts tests/issue-681.test.ts` — passing.
+
+Remaining #681 gap stays open: fully generic for-of over an opaque externref
+`any` in standalone/WASI still refuses at the IR gate unless the iterable is a
+known native shape handled by earlier slices.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -2731,14 +2731,15 @@ function compileForOfArray(
   // Build loop body
   const savedBody = pushBody(fctx);
 
-  // Adjust existing break/continue depths: block+loop adds 2 nesting levels
-  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 2;
-  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 2;
-  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 2;
-  adjustRethrowDepth(fctx, 2);
+  // Structure: block { loop { guard/bind; block { body }; i++; br loop } }.
+  // `continue` exits the inner body block so the increment still runs.
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 3;
+  adjustRethrowDepth(fctx, 3);
 
-  fctx.breakStack.push(1); // break = depth 1 (exit block)
-  fctx.continueStack.push(0); // continue = depth 0 (restart loop)
+  fctx.breakStack.push(2); // break = depth 2 (exit outer block)
+  fctx.continueStack.push(0); // continue = depth 0 (exit body block, then increment)
 
   // Condition: i >= length → break
   fctx.body.push({ op: "local.get", index: iLocal });
@@ -2766,6 +2767,8 @@ function compileForOfArray(
     compileForOfAssignDestructuring(ctx, fctx, assignDestructExpr, elemLocal, elemType, vecTypeIdx, arrTypeIdx, stmt);
   }
 
+  const savedLoopBody = pushBody(fctx);
+
   // Compile body — save/restore block-scoped shadows for let/const (#817).
   if (ts.isBlock(stmt.statement)) {
     const savedScope = saveBlockScopedShadows(fctx, stmt.statement);
@@ -2776,6 +2779,14 @@ function compileForOfArray(
   } else {
     compileStatement(ctx, fctx, stmt.statement);
   }
+  const bodyInstrs = fctx.body;
+  popBody(fctx, savedLoopBody);
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: bodyInstrs,
+  });
 
   // Increment i
   fctx.body.push({ op: "local.get", index: iLocal });
@@ -2790,10 +2801,10 @@ function compileForOfArray(
   fctx.continueStack.pop();
 
   // Restore existing break/continue depths
-  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 2;
-  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 2;
-  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 2;
-  adjustRethrowDepth(fctx, -2);
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 3;
+  adjustRethrowDepth(fctx, -3);
 
   popBody(fctx, savedBody);
 
@@ -3065,14 +3076,16 @@ function emitArrayKeysEntriesLoop(
   // Build loop body
   const savedBody = pushBody(fctx);
 
-  // block+loop adds 2 nesting levels
-  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 2;
-  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 2;
-  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 2;
-  adjustRethrowDepth(fctx, 2);
+  // block+loop+body-block adds 3 nesting levels. The inner body block makes
+  // `continue` fall through to the index increment instead of re-reading the
+  // same element forever.
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 3;
+  adjustRethrowDepth(fctx, 3);
 
-  fctx.breakStack.push(1); // break = exit block
-  fctx.continueStack.push(0); // continue = restart loop
+  fctx.breakStack.push(2); // break = exit outer block
+  fctx.continueStack.push(0); // continue = exit body block, then increment
 
   // i >= len → break
   fctx.body.push({ op: "local.get", index: iLocal });
@@ -3082,6 +3095,8 @@ function emitArrayKeysEntriesLoop(
 
   // Project the per-iteration binding(s).
   bindIteration(lenLocal, iLocal, dataLocal, arrTypeIdx);
+
+  const savedLoopBody = pushBody(fctx);
 
   // Compile body — save/restore block-scoped shadows for let/const (#817).
   if (ts.isBlock(stmt.statement)) {
@@ -3093,6 +3108,14 @@ function emitArrayKeysEntriesLoop(
   } else {
     compileStatement(ctx, fctx, stmt.statement);
   }
+  const bodyInstrs = fctx.body;
+  popBody(fctx, savedLoopBody);
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: bodyInstrs,
+  });
 
   // i += 1
   fctx.body.push({ op: "local.get", index: iLocal });
@@ -3106,10 +3129,10 @@ function emitArrayKeysEntriesLoop(
   fctx.breakStack.pop();
   fctx.continueStack.pop();
 
-  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 2;
-  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 2;
-  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 2;
-  adjustRethrowDepth(fctx, -2);
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 3;
+  adjustRethrowDepth(fctx, -3);
 
   popBody(fctx, savedBody);
 

--- a/tests/issue-681.test.ts
+++ b/tests/issue-681.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const ITER_HOST_IMPORT_RE = /__(?:async_)?iterator|__array_(?:entries|keys|values)/;
+
+function expectNoIteratorHostImports(result: Awaited<ReturnType<typeof compile>>) {
+  const names = result.imports.map((i) => `${i.module}::${i.name}`);
+  expect(names.filter((name) => ITER_HOST_IMPORT_RE.test(name))).toEqual([]);
+}
+
+async function runF(src: string, target: "standalone" | "wasi" = "standalone"): Promise<number> {
+  const result = await compile(src, { target });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expectNoIteratorHostImports(result);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#681 pure-Wasm array iterator for-of", () => {
+  it("continues Array.prototype.values() without repeating the skipped element", async () => {
+    expect(
+      await runF(`
+        export function f(): number {
+          let sum: number = 0;
+          for (const value of [1, 2, 3, 4].values()) {
+            if (value === 2) continue;
+            sum = sum + value;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(1 + 3 + 4);
+  });
+
+  it("continues Array.prototype.keys() without repeating the skipped index", async () => {
+    expect(
+      await runF(`
+        export function f(): number {
+          let sum: number = 0;
+          for (const index of [9, 9, 9, 9].keys()) {
+            if (index === 1) continue;
+            sum = sum + index;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(0 + 2 + 3);
+  });
+
+  it("continues Array.prototype.entries() under WASI without repeating the skipped pair", async () => {
+    expect(
+      await runF(
+        `
+          export function f(): number {
+            let sum: number = 0;
+            for (const [index, value] of [5, 6, 7].entries()) {
+              if (index === 1) continue;
+              sum = sum + value;
+            }
+            return sum;
+          }
+        `,
+        "wasi",
+      ),
+    ).toBe(5 + 7);
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap direct pure-Wasm array for-of bodies in an inner block so `continue` falls through to `i += 1`.
- Apply the same continue-safe loop shape to native `Array.prototype.keys()` / `.entries()` projection loops.
- Add focused #681 coverage for `.values()`, `.keys()`, and `.entries()` continue paths with no iterator host imports.

## Validation
- `pnpm vitest run tests/issue-681.test.ts tests/issue-681-standalone-iterators.test.ts tests/issue-1320-standalone.test.ts --reporter verbose`
- `pnpm vitest run tests/issue-1665-standalone-generator-forof.test.ts --reporter verbose`
- `pnpm exec prettier --check src/codegen/statements/loops.ts tests/issue-681.test.ts`
- pre-push hook: typecheck, lint, Prettier format check, issue integrity

Co-authored-by: Codex <codex@openai.com>
