### PR TITLE
fix(standalone): add native extern array predicate

### DIFF
--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -18,7 +18,7 @@ related: [1328, 1678, 1888]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:36:23.675Z
+claimed_at: 2026-06-07T01:43:24.047Z
 ---
 # #1904 — Native `__extern_is_array` for standalone
 
@@ -71,4 +71,4 @@ a native brand predicate.
 - `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
 - `npm run typecheck`
 
-Final Codex verification on 2026-06-07: all scoped validation passed.
+Final Codex verification on 2026-06-07: the scoped issue test, related regression set, and typecheck passed after refreshing the branch against current main.

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -71,4 +71,4 @@ a native brand predicate.
 - `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
 - `npm run typecheck`
 
-Final Codex verification on 2026-06-07: the scoped issue test, related regression set, and typecheck passed after refreshing the branch against current main.
+Final Codex verification on 2026-06-07: the scoped issue test, related regression set, and typecheck passed after refreshing the branch against current main. PR #1259's earlier test262 gate failure was on the stale published head and reported baseline drift; the branch was refreshed again against `origin/main` before republishing.

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -1,0 +1,71 @@
+---
+id: 1904
+title: "standalone: native __extern_is_array predicate for Array.isArray over Wasm carriers"
+status: in-progress
+sprint: 61
+created: 2026-06-07
+updated: 2026-06-07
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: codegen, runtime
+language_feature: arrays, objects
+goal: standalone-mode
+parent: 1472
+related: [1328, 1678, 1888]
+test262_bucket: standalone-dynamic-object-property
+test262_count: 8163
+claimed_by: codex-developer
+claimed_at: 2026-06-07T00:35:51.514Z
+---
+# #1904 — Native `__extern_is_array` for standalone
+
+## Problem
+
+The standalone dynamic object/property bucket still samples:
+
+```text
+Codegen error: '__extern_is_array' ... not yet supported in --target standalone
+```
+
+`Array.isArray` already has host-mode and compile-time paths, but any dynamic or
+externref-shaped value falls through to `__extern_is_array`, which the broad
+`__extern_*` standalone refusal catches. That blocks destructuring,
+Array/TypedArray construction guards, and test262 harness checks that only need
+a native brand predicate.
+
+## Scope
+
+- Add a standalone-native implementation for `__extern_is_array`.
+- Route it through `OBJECT_RUNTIME_HELPER_NAMES` or an equivalent standalone
+  native helper path before `STANDALONE_REFUSED_IMPORT`.
+- Recognize the Wasm carriers that this compiler uses for arrays/rest vectors
+  under standalone. Do not claim Proxy/exotic host arrays that cannot exist
+  without a JS host.
+
+## Acceptance Criteria
+
+- `Array.isArray` over a standalone-emitted array/rest/vector carrier returns
+  true where the JS semantics require an array result.
+- Non-array `$Object` and primitive values return false without trapping.
+- The regression test compiles and instantiates under `target: "standalone"`
+  with no `env::__extern_is_array` import.
+- JS-host/default behavior is unchanged.
+
+## Implementation Notes
+
+- Routed `__extern_is_array` through the standalone object-runtime native helper
+  path before the broad `__extern_*` refusal.
+- Reserved the helper with `ensureObjectRuntime`, then filled its body during
+  finalize after all Wasm array carriers are known.
+- The native predicate recognizes `$ObjVec`, `__vec_*`, and template vector
+  carriers; primitives, `$Object`, and other externrefs return false.
+- Proxy/host exotic recursion from ES §7.2.2 is intentionally out of scope for
+  standalone because those carriers cannot exist without a JS host.
+
+## Validation
+
+- `npm test -- tests/issue-1904.test.ts`
+- `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
+- `npm run typecheck`

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -18,7 +18,7 @@ related: [1328, 1678, 1888]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:29:54.017Z
+claimed_at: 2026-06-07T01:36:23.675Z
 ---
 # #1904 — Native `__extern_is_array` for standalone
 

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -18,7 +18,7 @@ related: [1328, 1678, 1888]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T00:35:51.514Z
+claimed_at: 2026-06-07T01:10:23.877Z
 ---
 # #1904 — Native `__extern_is_array` for standalone
 
@@ -70,3 +70,5 @@ a native brand predicate.
 - `npm test -- tests/issue-1904.test.ts`
 - `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
 - `npm run typecheck`
+
+Final Codex rerun on 2026-06-07: all scoped validation passed.

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -18,7 +18,7 @@ related: [1328, 1678, 1888]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:10:23.877Z
+claimed_at: 2026-06-07T01:29:54.017Z
 ---
 # #1904 — Native `__extern_is_array` for standalone
 
@@ -71,4 +71,4 @@ a native brand predicate.
 - `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
 - `npm run typecheck`
 
-Final Codex rerun on 2026-06-07: all scoped validation passed.
+Final Codex verification on 2026-06-07: all scoped validation passed.

--- a/plan/issues/1904-standalone-native-extern-is-array.md
+++ b/plan/issues/1904-standalone-native-extern-is-array.md
@@ -1,7 +1,8 @@
 ---
 id: 1904
 title: "standalone: native __extern_is_array predicate for Array.isArray over Wasm carriers"
-status: in-progress
+status: in-review
+pr: 1259
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -600,6 +600,13 @@ export interface CodegenContext {
    */
   applyClosureReserved?: boolean;
   /**
+   * (#1904) True once the standalone `__extern_is_array(externref) -> i32`
+   * helper placeholder has been emitted by the object runtime. Its body is
+   * filled in post-processing after all Wasm array carrier types (`__vec_*`
+   * plus `$ObjVec`) are known.
+   */
+  externIsArrayReserved?: boolean;
+  /**
    * Static property initializer expressions to compile into __module_init.
    * `className` (#1395) is the owning class name — used to set
    * `enclosingClassName` + `isStaticContext` on the initFctx so `this`

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -38,7 +38,7 @@ import { ensureNativeIteratorRuntime } from "./iterator-native.js";
 import { emitUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
 import { fillAccessorDrivers } from "./accessor-driver.js";
-import { fillApplyClosure } from "./object-runtime.js";
+import { fillApplyClosure, fillExternIsArray } from "./object-runtime.js";
 import {
   fixupExternConvertAny,
   fixupStructNewArgCounts,
@@ -1499,6 +1499,10 @@ export function generateModule(
     // `__call_fn_method_0..4` are registered. No-op when no standalone open-any
     // method-dispatch site reserved the bridge (`ctx.applyClosureReserved`).
     fillApplyClosure(ctx);
+
+    // (#1904) Fill the standalone native Array.isArray predicate after all
+    // module-local array carriers have been registered.
+    fillExternIsArray(ctx);
 
     // #1504: emit __is_closure(externref) -> i32 so the JS-side wrapExports
     // can discriminate a closure struct return from a vec/struct return

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -253,6 +253,21 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     return funcIdx;
   };
 
+  // ── __extern_is_array(externref v) -> i32 ────────────────────────────────
+  //
+  // Placeholder reserved with the object runtime and filled at FINALIZE by
+  // fillExternIsArray(), after all module-local array carrier types are known.
+  // This keeps Array.isArray over a helper compiled before a later array type
+  // from baking an incomplete ref.test list.
+  registerNative(
+    "__extern_is_array",
+    [{ kind: "externref" }],
+    [{ kind: "i32" }],
+    [{ name: "any", type: { kind: "anyref" } }],
+    [{ op: "i32.const", value: 0 } as Instr],
+  );
+  ctx.externIsArrayReserved = true;
+
   // Look up an already-emitted native string helper.
   const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
   const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals")!;
@@ -3794,6 +3809,62 @@ export function fillApplyClosure(ctx: CodegenContext): void {
   bridgeFn.locals = [{ name: "n", type: { kind: "i32" } }];
 }
 
+function collectStandaloneArrayCarrierTypeIdxs(ctx: CodegenContext): number[] {
+  const carriers = new Set<number>();
+  const objVecTypeIdx = ctx.objectRuntimeTypes?.objVecTypeIdx;
+  if (objVecTypeIdx !== undefined) carriers.add(objVecTypeIdx);
+  for (const typeIdx of ctx.vecTypeMap.values()) carriers.add(typeIdx);
+  for (let typeIdx = 0; typeIdx < ctx.mod.types.length; typeIdx++) {
+    const typeDef = ctx.mod.types[typeIdx];
+    if (typeDef?.kind !== "struct") continue;
+    const name = typeDef.name ?? "";
+    if (name.startsWith("__vec_") || name === "__template_vec_externref") carriers.add(typeIdx);
+  }
+  return Array.from(carriers).sort((a, b) => a - b);
+}
+
+/**
+ * (#1904) Fill the standalone native `__extern_is_array` predicate after all
+ * user functions and late runtime helpers have registered their WasmGC carrier
+ * types. Implements the non-Proxy subset of ES §7.2.2 IsArray that can exist in
+ * standalone: primitives/non-array objects return false, and compiler-emitted
+ * array carriers (`__vec_*`, template vectors, `$ObjVec`) return true.
+ */
+export function fillExternIsArray(ctx: CodegenContext): void {
+  if (!ctx.externIsArrayReserved) return;
+  const funcIdx = ctx.funcMap.get("__extern_is_array");
+  if (funcIdx === undefined) return;
+  const fn = ctx.mod.functions[funcIdx - ctx.numImportFuncs];
+  if (!fn) return;
+
+  const carrierTypeIdxs = collectStandaloneArrayCarrierTypeIdxs(ctx);
+  const anyLocal = 1;
+  const body: Instr[] = [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.set", index: anyLocal } as Instr,
+  ];
+
+  let chain: Instr[] = [{ op: "i32.const", value: 0 } as Instr];
+  for (let i = carrierTypeIdxs.length - 1; i >= 0; i--) {
+    const typeIdx = carrierTypeIdxs[i]!;
+    chain = [
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.test", typeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "i32.const", value: 1 } as Instr],
+        else: chain,
+      } as Instr,
+    ];
+  }
+  body.push(...chain);
+
+  fn.locals = [{ name: "any", type: { kind: "anyref" } }];
+  fn.body = body;
+}
+
 /**
  * Names of the object-runtime host imports that `ensureObjectRuntime` provides
  * Wasm-native implementations for. `ensureLateImport` routes these here under
@@ -3805,6 +3876,7 @@ export function fillApplyClosure(ctx: CodegenContext): void {
  */
 export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__new_plain_object",
+  "__extern_is_array",
   "__extern_get",
   "__extern_set",
   "__to_primitive",

--- a/tests/issue-1904.test.ts
+++ b/tests/issue-1904.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function envImportNames(bytes: Uint8Array): string[] {
+  const mod = new WebAssembly.Module(bytes);
+  return WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+async function compileStandaloneNumber(source: string): Promise<{ value: number; env: string[] }> {
+  const r = await compile(source, {
+    fileName: "issue-1904.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const env = envImportNames(r.binary);
+  expect(env, `leaked env imports: ${env.join(", ")}`).not.toContain("__extern_is_array");
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { value: (instance.exports.test as () => number)(), env };
+}
+
+describe("#1904 standalone native __extern_is_array", () => {
+  it("returns true for an any-typed compiled array without an env predicate import", async () => {
+    const { value, env } = await compileStandaloneNumber(`
+      let a: any;
+      a = [1, 2, 3];
+      export function test(): number {
+        return Array.isArray(a) ? 1 : 0;
+      }
+    `);
+
+    expect(value).toBe(1);
+    expect(env).toEqual([]);
+  });
+
+  it("returns false for standalone $Object and primitive carriers", async () => {
+    const { value, env } = await compileStandaloneNumber(`
+      export function test(): number {
+        const o: any = { a: 1 };
+        const n: any = 5;
+        const s: any = "x";
+        const z: any = null;
+        return (Array.isArray(o) ? 1 : 0)
+          + (Array.isArray(n) ? 2 : 0)
+          + (Array.isArray(s) ? 4 : 0)
+          + (Array.isArray(z) ? 8 : 0);
+      }
+    `);
+
+    expect(value).toBe(0);
+    expect(env).toEqual([]);
+  });
+
+  it("brands native $ObjVec enumeration results as arrays", async () => {
+    const { value, env } = await compileStandaloneNumber(`
+      export function test(): number {
+        const o: any = { a: 1, b: 2 };
+        const keys: any = Object.keys(o);
+        return Array.isArray(keys) ? 1 : 0;
+      }
+    `);
+
+    expect(value).toBe(1);
+    expect(env).toEqual([]);
+  });
+
+  it("fills the helper after arrays registered later in source order", async () => {
+    const { value, env } = await compileStandaloneNumber(`
+      function isArray(v: any): number {
+        return Array.isArray(v) ? 1 : 0;
+      }
+      export function test(): number {
+        const a: any = [1, 2, 3];
+        return isArray(a);
+      }
+    `);
+
+    expect(value).toBe(1);
+    expect(env).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Route `__extern_is_array` through the standalone native object-runtime helper path before the broad `__extern_*` refusal.
- Reserve the helper and fill it at finalize so it sees every registered Wasm array carrier, including `__vec_*`, template vectors, and `$ObjVec`.
- Add focused standalone tests for true array carriers, false `$Object`/primitive carriers, no `env::__extern_is_array` import, and late-registered vectors.

## Spec

Implements the standalone-applicable subset of ES §7.2.2 `IsArray`: non-objects return false, compiler-emitted array carriers return true, and Proxy/host exotic recursion remains out of scope because those carriers require a JS host.

## Validation

- `npm test -- tests/issue-1904.test.ts`
- `npm test -- tests/issue-1904.test.ts tests/issue-1678.test.ts tests/issue-1328.test.ts tests/issue-1866.test.ts`
- `npm run typecheck`
- pre-push hook: typecheck + lint, format check, issue integrity
