### PR TITLE
fix(standalone): route Reflect object subset natively

### DIFF
--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -1,0 +1,83 @@
+---
+id: 1905
+title: "standalone: native Reflect.get/set/has/deleteProperty over $Object"
+status: in-progress
+sprint: 61
+created: 2026-06-07
+updated: 2026-06-07
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: codegen, runtime
+language_feature: reflection, objects
+goal: standalone-mode
+parent: 1472
+related: [1472, 1466, 1629, 1888]
+test262_bucket: standalone-reflect-refusal
+test262_count: 309
+claimed_by: codex-developer
+claimed_at: 2026-06-07T00:35:56.934Z
+---
+# #1905 — Standalone native Reflect object subset
+
+## Problem
+
+The standalone report still has `309` failures in
+`standalone-reflect-refusal`. `#1472` deliberately routed only
+`Reflect.ownKeys` to native `__object_keys` and refused the rest to avoid
+leaking `env::__reflect_*` imports.
+
+The obvious `$Object` subset is now implementable:
+
+- `Reflect.get(target, key[, receiver])`
+- `Reflect.set(target, key, value[, receiver])`
+- `Reflect.has(target, key)`
+- `Reflect.deleteProperty(target, key)`
+
+`Reflect.apply` and `Reflect.construct` remain separate call/constructor
+machinery and are out of scope here.
+
+## Scope
+
+- Implement the object-runtime-backed subset for standalone only.
+- Reuse existing `__extern_get`, `__extern_set`, `__extern_has`/keyed has, and
+  `__delete_property` helpers where semantics line up.
+- Preserve boolean return semantics for `Reflect.set`, `Reflect.has`, and
+  `Reflect.deleteProperty`.
+- Keep descriptor/prototype/integrity methods refused unless they are proven
+  correct in this slice.
+
+## Acceptance Criteria
+
+- Focused tests in `tests/issue-1905.test.ts` cover get/set/has/deleteProperty
+  on open `$Object` values under `target: "standalone"`.
+- No `env::__reflect_*` imports leak under standalone.
+- Unsupported Reflect methods still refuse loud with a tracked issue cite.
+- Default/gc mode still uses the host Reflect bridge.
+
+## Implementation Notes
+
+- Added standalone lowering for `Reflect.get`, `Reflect.set`, `Reflect.has`,
+  and `Reflect.deleteProperty` before the existing Reflect refusal path.
+- `Reflect.get`, `Reflect.has`, and `Reflect.deleteProperty` route to the
+  existing native `$Object` helpers: `__extern_get`, `__extern_has`, and
+  `__delete_property`.
+- Added native `__reflect_set` as a boolean-returning wrapper around
+  `__extern_set` so ordinary assignments keep their void ABI while
+  `Reflect.set` reports false for the object-runtime write refusals it can
+  prove: frozen data writes, non-extensible new keys, non-writable own data
+  properties, getter-only accessors, and non-`$Object` receivers.
+- Descriptor/prototype/integrity methods, `Reflect.apply`, and
+  `Reflect.construct` remain on the standalone refusal path with the existing
+  `#1472 Phase C` cite.
+
+## Validation
+
+- `pnpm test tests/issue-1905.test.ts`
+- `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`
+- `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`
+- Also tried the full `tests/issue-1472.test.ts`; it still has unrelated
+  pre-existing failures in Object prototype and open-any method-dispatch cases,
+  so validation for this issue stayed scoped to the changed Reflect refusal
+  regression.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -1,7 +1,7 @@
 ---
 id: 1905
 title: "standalone: native Reflect.get/set/has/deleteProperty over $Object"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -18,6 +18,7 @@ test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
 claimed_at: 2026-06-07T00:35:56.934Z
+pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5064,19 +5064,84 @@ function compileCallExpression(
       // a native helper through it, and refuse the rest with a clear compile
       // error rather than emitting a half-working module.
       //
+      // - Reflect.get/has/deleteProperty(target, key) → native keyed $Object
+      //   helpers, which already perform the same own/prototype walk or delete
+      //   operation used by dynamic property access.
+      // - Reflect.set(target, key, value) → native __reflect_set, a boolean
+      //   wrapper around the supported __extern_set data-write subset.
       // - Reflect.ownKeys(target) → native __object_keys (string own keys of
       //   the $Object hash-map, insertion order). The native runtime tracks
       //   only string keys; Symbol/non-enumerable keys are out of scope for the
       //   standalone object runtime (consistent approximation across #1472
       //   Phase B). __object_keys is in OBJECT_RUNTIME_HELPER_NAMES, so
       //   ensureLateImport auto-routes it to the in-module native func.
-      // - Reflect.has needs a *keyed* HasProperty over the hash-map; the native
-      //   __extern_has_idx is an *indexed* (array-like) helper, so it cannot
-      //   stand in here without being semantically wrong — refuse instead.
-      //   Reflect.apply/construct require host call machinery with no native
-      //   analog — refuse. The descriptor/prototype/integrity methods all rely
-      //   on the JS descriptor sidecar — refuse.
+      // - Reflect.apply/construct require call/constructor machinery with no
+      //   native analog in this slice. Descriptor/prototype/integrity methods
+      //   stay refused until their native invariants are proven end-to-end.
       if (ctx.standalone) {
+        const emitAndDropOptionalArg = (index: number): void => {
+          const arg = expr.arguments[index];
+          if (arg === undefined) return;
+          const argTy = compileExpression(ctx, fctx, arg, externRef);
+          if (argTy && argTy.kind !== "externref") {
+            coerceType(ctx, fctx, argTy, externRef);
+          } else if (argTy === null) {
+            fctx.body.push({ op: "ref.null.extern" });
+          }
+          fctx.body.push({ op: "drop" });
+        };
+
+        if (reflectMethod === "get" && expr.arguments.length >= 2) {
+          emitReflectArgs(2);
+          // Evaluate the optional receiver for call argument side effects. The
+          // existing native __extern_get helper has no separate receiver slot,
+          // so this slice supports the data-property/default-receiver subset.
+          emitAndDropOptionalArg(2);
+          const funcIdx = ensureLateImport(ctx, "__extern_get", [externRef, externRef], [externRef]);
+          flushLateImportShifts(ctx, fctx);
+          if (funcIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx });
+            return { kind: "externref" };
+          }
+          return fallbackReturn(2, "extern-null");
+        }
+
+        if (reflectMethod === "set" && expr.arguments.length >= 2) {
+          emitReflectArgs(3);
+          // Evaluate the optional receiver for side effects. __extern_set writes
+          // the supported open-object data-property subset on target itself.
+          emitAndDropOptionalArg(3);
+          const funcIdx = ensureLateImport(ctx, "__reflect_set", [externRef, externRef, externRef], [i32Ty]);
+          flushLateImportShifts(ctx, fctx);
+          if (funcIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx });
+            return { kind: "i32" };
+          }
+          return fallbackReturn(3, "i32-true");
+        }
+
+        if (reflectMethod === "has" && expr.arguments.length >= 2) {
+          emitReflectArgs(2);
+          const funcIdx = ensureLateImport(ctx, "__extern_has", [externRef, externRef], [i32Ty]);
+          flushLateImportShifts(ctx, fctx);
+          if (funcIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx });
+            return { kind: "i32" };
+          }
+          return fallbackReturn(2, "i32-true");
+        }
+
+        if (reflectMethod === "deleteProperty" && expr.arguments.length >= 2) {
+          emitReflectArgs(2);
+          const funcIdx = ensureLateImport(ctx, "__delete_property", [externRef, externRef], [i32Ty]);
+          flushLateImportShifts(ctx, fctx);
+          if (funcIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx });
+            return { kind: "i32" };
+          }
+          return fallbackReturn(2, "i32-true");
+        }
+
         if (reflectMethod === "ownKeys" && expr.arguments.length >= 1) {
           emitReflectArgs(1);
           const funcIdx = ensureLateImport(ctx, "__object_keys", [externRef], [externRef]);

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1038,6 +1038,137 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __reflect_set(externref obj, externref key, externref value) -> i32 ──
+  //
+  // Reflect.set's supported standalone subset shares the existing __extern_set
+  // data-write machinery, but it must return the [[Set]] boolean instead of
+  // void. Keep __extern_set's ABI stable for ordinary assignment call sites and
+  // preflight the object-runtime refusal cases here:
+  //   - non-$Object receiver → false (standalone has no host TypeError bridge)
+  //   - own accessor with no setter → false
+  //   - own data property with !writable → false
+  //   - frozen object data write → false
+  //   - missing own property on a non-extensible object → false
+  // Otherwise delegate to __extern_set and return true.
+  {
+    const reflectSetExternSetIdx = ctx.funcMap.get("__extern_set")!;
+    const body: Instr[] = [
+      // any = any.convert_extern(obj); if !ref.test $Object → false
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 3 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      // o = cast<$Object>(any); e = __obj_find(o, key)
+      { op: "local.get", index: 3 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 4 },
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: 5 },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // Own accessor: true iff a setter exists; __extern_set invokes it.
+          { op: "local.get", index: 5 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+          { op: "i32.const", value: FLAG_ACCESSOR },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 5 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 5 },
+              { op: "extern.convert_any" },
+              { op: "ref.is_null" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+              },
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: 1 },
+              { op: "local.get", index: 2 },
+              { op: "call", funcIdx: reflectSetExternSetIdx },
+              { op: "i32.const", value: 1 },
+              { op: "return" },
+            ],
+          },
+          // Own data: false if non-writable.
+          { op: "local.get", index: 5 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+          { op: "i32.const", value: FLAG_WRITABLE },
+          { op: "i32.and" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+          },
+          // Frozen data write: false. __extern_set would no-op; Reflect.set
+          // exposes that refusal as its boolean result.
+          { op: "local.get", index: 4 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+          { op: "i32.const", value: OBJ_FLAG_FROZEN },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+          },
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 2 },
+          { op: "call", funcIdx: reflectSetExternSetIdx },
+          { op: "i32.const", value: 1 },
+          { op: "return" },
+        ],
+      },
+      // Missing own property: non-extensible objects refuse the new key.
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+      { op: "i32.const", value: OBJ_FLAG_NONEXTENSIBLE },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      { op: "call", funcIdx: reflectSetExternSetIdx },
+      { op: "i32.const", value: 1 },
+    ];
+    registerNative(
+      "__reflect_set",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "o", type: objRefNull },
+        { name: "e", type: entryRefNull },
+      ],
+      body,
+    );
+  }
+
   // ── __delete_property(externref obj, externref key) -> i32 ───────────────
   //
   // ES §13.5.1 delete operator on an own data property. Finds the live entry;
@@ -3807,6 +3938,7 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__new_plain_object",
   "__extern_get",
   "__extern_set",
+  "__reflect_set",
   "__to_primitive",
   "__extern_toString",
   "__delete_property",

--- a/tests/issue-1472.test.ts
+++ b/tests/issue-1472.test.ts
@@ -748,15 +748,11 @@ describe("#1472 — --target standalone object/Proxy host-import refusal", () =>
   });
 
   it("Phase C: unsupported Reflect.* methods refuse in standalone without leaking __reflect_* imports", async () => {
-    // The descriptor/prototype/integrity/has/apply/construct family has no
-    // native analog yet; each must fail at compile time with the Phase C
-    // message instead of leaking an env::__reflect_* import that traps at
-    // instantiation.
+    // The descriptor/prototype/integrity/apply/construct family has no native
+    // analog yet; each must fail at compile time with the Phase C message
+    // instead of leaking an env::__reflect_* import that traps at instantiation.
+    // Reflect.get/set/has/deleteProperty are covered by #1905.
     const cases: ReadonlyArray<[string, string]> = [
-      ["get", `export function f(o: any): any { return Reflect.get(o, "k"); }`],
-      ["set", `export function f(o: any): boolean { return Reflect.set(o, "k", 1); }`],
-      ["has", `export function f(o: any): boolean { return Reflect.has(o, "k"); }`],
-      ["deleteProperty", `export function f(o: any): boolean { return Reflect.deleteProperty(o, "k"); }`],
       ["defineProperty", `export function f(o: any): boolean { return Reflect.defineProperty(o, "k", {}); }`],
       [
         "getOwnPropertyDescriptor",

--- a/tests/issue-1905.test.ts
+++ b/tests/issue-1905.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function envImportNames(bytes: Uint8Array): string[] {
+  const mod = new WebAssembly.Module(bytes);
+  return WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+function assertNoReflectHostImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const hits = imports.filter((i) => i.module === "env" && i.name.startsWith("__reflect_"));
+  expect(
+    hits.map((i) => `${i.module}::${i.name}`),
+    "standalone Reflect object subset must not leak env::__reflect_*",
+  ).toEqual([]);
+}
+
+async function runStandaloneNumber(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoReflectHostImports(r.imports);
+  expect(envImportNames(r.binary).filter((name) => name.startsWith("__reflect_"))).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#1905 standalone native Reflect object subset", () => {
+  it("Reflect.get/set/has/deleteProperty operate on open $Object values", async () => {
+    expect(
+      await runStandaloneNumber(`
+        export function run(): number {
+          const o: any = {};
+          const setX = Reflect.set(o, "x", 40);
+          const setY = Reflect.set(o, "y", (Reflect.get(o, "x") as number) + 2);
+          const hadX = Reflect.has(o, "x") ? 4 : 0;
+          const hadMissing = Reflect.has(o, "missing") ? 100 : 0;
+          const deletedX = Reflect.deleteProperty(o, "x") ? 8 : 0;
+          const hasDeletedX = Reflect.has(o, "x") ? 1000 : 0;
+          return (setX ? 1 : 0) + (setY ? 2 : 0) + hadX + deletedX
+            + (Reflect.get(o, "y") as number) + hadMissing + hasDeletedX;
+        }
+      `),
+    ).toBe(57);
+  });
+
+  it("Reflect.set returns false when the native $Object write gate refuses", async () => {
+    expect(
+      await runStandaloneNumber(`
+        export function run(): number {
+          const frozen: any = {};
+          Reflect.set(frozen, "x", 1);
+          Object.freeze(frozen);
+          const frozenOk = Reflect.set(frozen, "x", 2);
+
+          const fixed: any = {};
+          Object.preventExtensions(fixed);
+          const fixedOk = Reflect.set(fixed, "newKey", 3);
+
+          return (frozenOk ? 100 : 0)
+            + (fixedOk ? 1000 : 0)
+            + (Reflect.get(frozen, "x") as number)
+            + (Reflect.has(fixed, "newKey") ? 10 : 0);
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("unsupported standalone Reflect methods still refuse without __reflect_* imports", async () => {
+    const cases: ReadonlyArray<[string, string]> = [
+      ["defineProperty", `export function f(o: any): boolean { return Reflect.defineProperty(o, "k", {}); }`],
+      ["getPrototypeOf", `export function f(o: any): any { return Reflect.getPrototypeOf(o); }`],
+      ["apply", `export function f(fn: any, t: any, a: any): any { return Reflect.apply(fn, t, a); }`],
+      ["construct", `export function f(c: any, a: any): any { return Reflect.construct(c, a); }`],
+    ];
+
+    for (const [method, source] of cases) {
+      const r = await compile(source, { target: "standalone" });
+      expect(r.success, `Reflect.${method} should refuse in standalone`).toBe(false);
+      const joined = r.errors.map((e) => e.message).join("\n");
+      expect(joined).toMatch(new RegExp(`Reflect\\.${method} not supported in standalone mode`));
+      expect(joined).toMatch(/#1472 Phase C/);
+      assertNoReflectHostImports(r.imports);
+    }
+  });
+
+  it("default target still uses the host Reflect bridge", async () => {
+    const r = await compile(
+      `
+        export function f(o: any): number {
+          Reflect.set(o, "x", 7);
+          const v: any = Reflect.get(o, "x");
+          const ok = Reflect.has(o, "x") && Reflect.deleteProperty(o, "x");
+          return ok ? v : 0;
+        }
+      `,
+      {},
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const names = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+    expect(names).toContain("__reflect_get");
+    expect(names).toContain("__reflect_set");
+    expect(names).toContain("__reflect_has");
+    expect(names).toContain("__reflect_deleteProperty");
+  });
+});


### PR DESCRIPTION
## Summary

- Route standalone `Reflect.get`, `Reflect.has`, and `Reflect.deleteProperty` over open `$Object` values to the existing native object-runtime helpers.
- Add native `__reflect_set` as a boolean-returning wrapper around `__extern_set`, preserving the ordinary assignment ABI while reporting false for native write refusals such as frozen data writes and non-extensible new keys.
- Keep descriptor/prototype/integrity Reflect methods plus `apply`/`construct` on the existing standalone refusal path, and keep gc/default mode on the host `__reflect_*` bridge.

Spec reference: ECMA-262 §§28.1.4, 28.1.5, 28.1.8, and 28.1.12.

## Validation

- `pnpm test tests/issue-1905.test.ts`
- `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`
- `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`

Note: a full run of `tests/issue-1472.test.ts` still has unrelated pre-existing failures in Object prototype and open-any method-dispatch cases, so this PR uses scoped validation for the changed Reflect path.