### PR TITLE
fix(standalone): emit built-in static method value closures

### DIFF
--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -86,7 +86,7 @@ standalone refusal.
 
 - PR #1263 exists and remains the review vehicle for this issue.
 - `origin/main` was fetched and merged before publishing; this handoff pulled in
-  the latest `main` changes, including #1905, without conflicts.
+  the latest `main` changes, including #1905 and #1910, without conflicts.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,8 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-progress
+status: in-review
+pr: 1263
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:04:23.850Z
+claimed_at: 2026-06-07T01:10:23.881Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -80,3 +80,10 @@ standalone refusal.
 - `npm run typecheck -- --pretty false`
 - `npm test -- tests/issue-1678.test.ts`
 - `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`
+
+## Final Findings
+
+- PR #1263 exists and remains the review vehicle for this issue.
+- Scoped validation passed on the implementation branch after re-checking the
+  focused #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests,
+  and the targeted #1472 Reflect.ownKeys standalone route.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:19:24.010Z
+claimed_at: 2026-06-07T01:34:54.097Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,0 +1,81 @@
+---
+id: 1907
+title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
+status: in-progress
+sprint: 61
+created: 2026-06-07
+updated: 2026-06-07
+priority: critical
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: codegen, runtime
+language_feature: built-ins, objects
+goal: standalone-mode
+parent: 1888
+related: [1888, 1902, 1472]
+test262_bucket: standalone-dynamic-object-property
+test262_count: 8163
+claimed_by: codex-developer
+claimed_at: 2026-06-07T00:36:07.285Z
+---
+
+# #1907 — Built-in static method value reads without `__get_builtin`
+
+## Problem
+
+`#1902` fixed the constant-only `Math.PI` / `Number.MAX_SAFE_INTEGER` slice by
+letting existing native constant emitters run under standalone. The real
+`#1888` Slice 6-b gap remains: reading a built-in static method as a value still
+routes through `__get_builtin` and is refused.
+
+Examples:
+
+```ts
+const isArray = Array.isArray;
+const keys = Object.keys;
+const stringify = JSON.stringify;
+```
+
+These should lower to native callable values or fail loud for the specific
+unsupported built-in/property pair, not to the generic `__get_builtin`
+standalone refusal.
+
+## Scope
+
+- Implement the first demand-driven built-in static method value reads needed
+  by the standalone bucket.
+- Start with `Array.isArray`, `Object.keys`, and `Object.defineProperty` or
+  `Object.getOwnPropertyDescriptor` if their native helper signatures are
+  already usable as closures.
+- Reuse the `#1888` built-ins-as-static-globals design. Keep binary size
+  proportional to referenced built-ins.
+
+## Acceptance Criteria
+
+- Focused tests show at least two built-in static method values can be read and
+  called under `target: "standalone"` with no `env::__get_builtin` import.
+- Unsupported `Builtin.prop` pairs fail loud with `#1907` or `#1888 S6-b`
+  cited.
+- `Math`/`Number` constant tests from `#1902` remain green.
+- Default/gc behavior is unchanged.
+
+## Implementation Notes
+
+- Added standalone built-in static method closure emission for `Array.isArray`,
+  `Object.keys`, and `Object.getOwnPropertyDescriptor`.
+- `Array.isArray` method values share the direct-call externref predicate:
+  WasmGC vec `ref.test` under no-host targets, with the JS host predicate only
+  in host mode.
+- `Object.keys` method values preserve the standalone object-runtime `$ObjVec`
+  `externref` return contract so `__extern_length` / `__extern_get_idx`
+  consumers remain host-free.
+- Unsupported standalone `Builtin.prop` value reads now fail with a
+  `#1907 / #1888 S6-b` diagnostic instead of falling into `__get_builtin`.
+
+## Validation
+
+- `npm test -- tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts`
+- `npm run typecheck -- --pretty false`
+- `npm test -- tests/issue-1678.test.ts`
+- `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:10:23.881Z
+claimed_at: 2026-06-07T01:19:24.010Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -80,10 +80,11 @@ standalone refusal.
 - `npm run typecheck -- --pretty false`
 - `npm test -- tests/issue-1678.test.ts`
 - `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`
+- `npx prettier --check src/codegen/property-access.ts src/codegen/expressions/calls.ts tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts plan/issues/1907-standalone-builtin-static-method-value-reads.md`
 
 ## Final Findings
 
 - PR #1263 exists and remains the review vehicle for this issue.
-- Scoped validation passed on the implementation branch after re-checking the
+- Scoped validation passed again on the implementation branch after re-checking the
   focused #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests,
-  and the targeted #1472 Reflect.ownKeys standalone route.
+  the targeted #1472 Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -85,6 +85,8 @@ standalone refusal.
 ## Final Findings
 
 - PR #1263 exists and remains the review vehicle for this issue.
+- `origin/main` was fetched and merged before publishing; the branch was already
+  up to date with current `origin/main`.
 - Scoped validation passed again on the implementation branch after re-checking the
   focused #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests,
   the targeted #1472 Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -85,8 +85,8 @@ standalone refusal.
 ## Final Findings
 
 - PR #1263 exists and remains the review vehicle for this issue.
-- `origin/main` was fetched and merged before publishing; the branch was already
-  up to date with current `origin/main`.
-- Scoped validation passed again on the implementation branch after re-checking the
-  focused #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests,
-  the targeted #1472 Reflect.ownKeys standalone route, and formatting.
+- `origin/main` was fetched and merged before publishing; this handoff pulled in
+  the latest `main` changes, including #1905, without conflicts.
+- Scoped validation passed again after the merge: the focused #1907/#1888 tests,
+  typecheck, #1678 Array.isArray regression tests, the targeted #1472
+  Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T00:36:07.285Z
+claimed_at: 2026-06-07T01:04:23.850Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -63,7 +63,7 @@ import {
   compileObjectKeysOrValues,
   compilePropertyIntrospection,
 } from "../object-ops.js";
-import { emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
+import { emitArrayIsArrayExternrefPredicate, emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
@@ -3452,45 +3452,7 @@ function compileCallExpression(
           fctx.body.push({ op: "i32.const", value: 0 });
           return { kind: "i32" };
         }
-        const vecTypeIdxs = Array.from(new Set(ctx.vecTypeMap.values()));
-        const isArrIdx = ensureLateImport(ctx, "__extern_is_array", [{ kind: "externref" }], [{ kind: "i32" }]);
-        if (vecTypeIdxs.length === 0 && isArrIdx === undefined) {
-          // No WasmGC array types registered and no host predicate available
-          // (e.g. standalone with no arrays in the module) — never an array.
-          fctx.body.push({ op: "drop" });
-          fctx.body.push({ op: "i32.const", value: 0 });
-          return { kind: "i32" };
-        }
-        // Keep the externref value live in a temp; both the ref.test scan
-        // (needs an anyref) and the host predicate (needs the externref)
-        // consume it, so we can't leave it on the stack.
-        const externTmp = allocLocal(fctx, `__isarr_ext_${fctx.locals.length}`, { kind: "externref" } as ValType);
-        fctx.body.push({ op: "local.set", index: externTmp });
-        let emittedTerm = false;
-        if (vecTypeIdxs.length > 0) {
-          const anyTmp = allocLocal(fctx, `__isarr_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
-          fctx.body.push({ op: "local.get", index: externTmp } as Instr);
-          fctx.body.push({ op: "any.convert_extern" } as Instr);
-          fctx.body.push({ op: "local.set", index: anyTmp });
-          // result = ref.test(t0) | ref.test(t1) | ...
-          for (let vi = 0; vi < vecTypeIdxs.length; vi++) {
-            fctx.body.push({ op: "local.get", index: anyTmp } as Instr);
-            fctx.body.push({ op: "ref.test", typeIdx: vecTypeIdxs[vi]! } as Instr);
-            if (vi > 0) fctx.body.push({ op: "i32.or" } as Instr);
-          }
-          emittedTerm = true;
-        }
-        if (isArrIdx !== undefined) {
-          flushLateImportShifts(ctx, fctx);
-          fctx.body.push({ op: "local.get", index: externTmp } as Instr);
-          fctx.body.push({ op: "call", funcIdx: isArrIdx });
-          if (emittedTerm) fctx.body.push({ op: "i32.or" } as Instr);
-          emittedTerm = true;
-        }
-        if (!emittedTerm) {
-          // Should be unreachable given the guard above, but stay safe.
-          fctx.body.push({ op: "i32.const", value: 0 });
-        }
+        emitArrayIsArrayExternrefPredicate(ctx, fctx);
         return { kind: "i32" };
       }
       // If the wasm type is a ref to a vec struct (array), return true; otherwise false

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -15,12 +15,13 @@ import { popBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { emitCachedMethodClosureAccess, emitFuncRefAsClosure } from "./closures.js";
+import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import {
   classifyPrivateMember,
   emitPrivateBrandPredicate,
   emitThrowTypeError,
+  noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
 import { patchStructNewForAddedField } from "./expressions/late-imports.js";
@@ -51,6 +52,54 @@ import { coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
 import { tryEmitJsonParseElementAccess, tryEmitJsonParsePropertyAccess } from "./json-standalone.js";
 import { reserveAccessorGetDriver } from "./accessor-driver.js";
 import { S5C_STRUCT_ACCESSOR_CLOSURE } from "./struct-accessor-closure.js";
+
+const BUILTIN_CTOR_NAMES = new Set([
+  "Object",
+  "Array",
+  "Function",
+  "Symbol",
+  "Proxy",
+  "Reflect",
+  "Math",
+  "BigInt",
+  "JSON",
+  "Date",
+  "RegExp",
+  "ArrayBuffer",
+  "SharedArrayBuffer",
+  "DataView",
+  "Promise",
+  "WeakMap",
+  "WeakSet",
+  "WeakRef",
+  "FinalizationRegistry",
+  "Atomics",
+  "Iterator",
+  "Map",
+  "Set",
+  "Error",
+  "TypeError",
+  "RangeError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "ReferenceError",
+  "String",
+  "Number",
+  "Boolean",
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+]);
+
 // Well-known Symbol IDs (inlined from literals.ts to avoid circular deps)
 const WELL_KNOWN_SYMBOLS: Record<string, number> = {
   iterator: 1,
@@ -131,6 +180,172 @@ function hasNativeBuiltinConstantHandler(builtinName: string, propName: string):
   if (builtinName === "Math") return MATH_CONSTANT_PROPS.has(propName);
   if (builtinName === "Number") return NUMBER_CONSTANT_PROPS.has(propName);
   return false;
+}
+
+/**
+ * Consume an externref value and push the Array.isArray boolean result.
+ *
+ * Spec basis: ECMA-262 §23.1.2.3 delegates to IsArray (§7.2.2). In no-host
+ * targets we can only decide compiled WasmGC array values, so the predicate is
+ * a ref.test over every registered vec type; host mode ORs that with the real
+ * JS Array.isArray predicate for foreign JS arrays.
+ */
+export function emitArrayIsArrayExternrefPredicate(ctx: CodegenContext, fctx: FunctionContext): void {
+  const vecTypeIdxs = Array.from(new Set(ctx.vecTypeMap.values()));
+  const isArrIdx =
+    !noJsHost(ctx) && !ctx.strictNoHostImports
+      ? ensureLateImport(ctx, "__extern_is_array", [{ kind: "externref" }], [{ kind: "i32" }])
+      : undefined;
+
+  if (vecTypeIdxs.length === 0 && isArrIdx === undefined) {
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return;
+  }
+
+  const externTmp = allocLocal(fctx, `__isarr_ext_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: externTmp });
+  let emittedTerm = false;
+
+  if (vecTypeIdxs.length > 0) {
+    const anyTmp = allocLocal(fctx, `__isarr_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+    fctx.body.push({ op: "local.get", index: externTmp } as Instr);
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: anyTmp });
+    for (let vi = 0; vi < vecTypeIdxs.length; vi++) {
+      fctx.body.push({ op: "local.get", index: anyTmp } as Instr);
+      fctx.body.push({ op: "ref.test", typeIdx: vecTypeIdxs[vi]! } as Instr);
+      if (vi > 0) fctx.body.push({ op: "i32.or" } as Instr);
+    }
+    emittedTerm = true;
+  }
+
+  if (isArrIdx !== undefined) {
+    flushLateImportShifts(ctx, fctx);
+    fctx.body.push({ op: "local.get", index: externTmp } as Instr);
+    fctx.body.push({ op: "call", funcIdx: isArrIdx });
+    if (emittedTerm) fctx.body.push({ op: "i32.or" } as Instr);
+    emittedTerm = true;
+  }
+
+  if (!emittedTerm) {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  }
+}
+
+function reportUnsupportedStandaloneBuiltinValueRead(ctx: CodegenContext, builtinName: string, propName: string): void {
+  if (!ctx.standaloneRefusedImports) ctx.standaloneRefusedImports = new Set<string>();
+  const key = `#1907:${builtinName}.${propName}`;
+  if (ctx.standaloneRefusedImports.has(key)) return;
+  ctx.standaloneRefusedImports.add(key);
+  reportErrorNoNode(
+    ctx,
+    `Codegen error: ${builtinName}.${propName} built-in static property value read is not supported ` +
+      `in --target standalone (#1907 / #1888 S6-b). Add a native built-in method closure for this pair.`,
+  );
+}
+
+function makeBuiltinClosureFctx(
+  name: string,
+  selfType: ValType,
+  paramTypes: ValType[],
+  returnType: ValType | null,
+): FunctionContext {
+  const fctx: FunctionContext = {
+    name,
+    params: [{ name: "__self", type: selfType }, ...paramTypes.map((type, i) => ({ name: `arg${i}`, type }))],
+    locals: [],
+    localMap: new Map(),
+    returnType,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+  for (let i = 0; i < fctx.params.length; i++) {
+    fctx.localMap.set(fctx.params[i]!.name, i);
+  }
+  return fctx;
+}
+
+function ensureStandaloneBuiltinStaticMethodClosure(
+  ctx: CodegenContext,
+  builtinName: string,
+  propName: string,
+  _expr: ts.PropertyAccessExpression,
+): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
+  const key = `${builtinName}.${propName}`;
+  let paramTypes: ValType[];
+  let returnType: ValType | null;
+
+  switch (key) {
+    case "Array.isArray":
+      paramTypes = [{ kind: "externref" }];
+      returnType = { kind: "i32" };
+      break;
+    case "Object.keys":
+      paramTypes = [{ kind: "externref" }];
+      // Standalone Object.keys returns the object-runtime `$ObjVec` as an
+      // externref; consumers read it back through native __extern_length /
+      // __extern_get_idx. Preserve that contract for method values.
+      returnType = { kind: "externref" };
+      break;
+    case "Object.getOwnPropertyDescriptor":
+      paramTypes = [{ kind: "externref" }, { kind: "externref" }];
+      returnType = { kind: "externref" };
+      break;
+    default:
+      return null;
+  }
+
+  const resultTypes = returnType ? [returnType] : [];
+  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, paramTypes, resultTypes);
+  if (!wrapperTypes) return null;
+
+  const funcName = `__builtin_static_${builtinName}_${propName}`;
+  let funcIdx = ctx.funcMap.get(funcName);
+  if (funcIdx === undefined) {
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const closureFctx = makeBuiltinClosureFctx(funcName, selfType, paramTypes, returnType);
+
+    if (key === "Array.isArray") {
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      emitArrayIsArrayExternrefPredicate(ctx, closureFctx);
+    } else if (key === "Object.keys") {
+      const keysIdx = ensureLateImport(ctx, "__object_keys", [{ kind: "externref" }], [{ kind: "externref" }]);
+      if (keysIdx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "call", funcIdx: keysIdx });
+      if (returnType && !valTypesMatch({ kind: "externref" }, returnType)) {
+        coerceType(ctx, closureFctx, { kind: "externref" }, returnType);
+      }
+    } else if (key === "Object.getOwnPropertyDescriptor") {
+      const gopdIdx = ensureLateImport(
+        ctx,
+        "__getOwnPropertyDescriptor",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      if (gopdIdx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "local.get", index: 2 });
+      closureFctx.body.push({ op: "call", funcIdx: gopdIdx });
+    }
+
+    funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.mod.functions.push({
+      name: funcName,
+      typeIdx: wrapperTypes.liftedFuncTypeIdx,
+      locals: closureFctx.locals,
+      body: closureFctx.body,
+      exported: false,
+    });
+    ctx.funcMap.set(funcName, funcIdx);
+  }
+
+  return { type: { kind: "ref", typeIdx: wrapperTypes.structTypeIdx }, funcIdx };
 }
 
 /**
@@ -1472,52 +1687,6 @@ export function compilePropertyAccess(
   // Skip if the name is shadowed by a local variable.
   if (ts.isIdentifier(expr.expression)) {
     const builtinName = expr.expression.text;
-    const BUILTIN_CTOR_NAMES = new Set([
-      "Object",
-      "Array",
-      "Function",
-      "Symbol",
-      "Proxy",
-      "Reflect",
-      "Math",
-      "BigInt",
-      "JSON",
-      "Date",
-      "RegExp",
-      "ArrayBuffer",
-      "SharedArrayBuffer",
-      "DataView",
-      "Promise",
-      "WeakMap",
-      "WeakSet",
-      "WeakRef",
-      "FinalizationRegistry",
-      "Atomics",
-      "Iterator",
-      "Map",
-      "Set",
-      "Error",
-      "TypeError",
-      "RangeError",
-      "SyntaxError",
-      "URIError",
-      "EvalError",
-      "ReferenceError",
-      "String",
-      "Number",
-      "Boolean",
-      "Int8Array",
-      "Uint8Array",
-      "Uint8ClampedArray",
-      "Int16Array",
-      "Uint16Array",
-      "Int32Array",
-      "Uint32Array",
-      "Float32Array",
-      "Float64Array",
-      "BigInt64Array",
-      "BigUint64Array",
-    ]);
     const isShadowed = fctx.localMap.has(builtinName) || (fctx.boxedCaptures?.has(builtinName) ?? false);
     // (#1888 S6-c) Under --target standalone, `__get_builtin` refuses-loud (the
     // open-object runtime does not expose it). For builtin constant reads that
@@ -1529,6 +1698,17 @@ export function compilePropertyAccess(
     // (`__get_builtin` is a real host import there and the early shortcut +
     // the later constant handler are observationally identical for these reads).
     const deferToNativeConstant = ctx.standalone && hasNativeBuiltinConstantHandler(builtinName, propName);
+    if (ctx.standalone && BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed && !deferToNativeConstant) {
+      const closure = ensureStandaloneBuiltinStaticMethodClosure(ctx, builtinName, propName, expr);
+      if (closure) {
+        fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx });
+        fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx });
+        return closure.type;
+      }
+      reportUnsupportedStandaloneBuiltinValueRead(ctx, builtinName, propName);
+      fctx.body.push({ op: "ref.null.extern" });
+      return { kind: "externref" };
+    }
     if (BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed && !deferToNativeConstant) {
       const getBuiltinIdx = ensureLateImport(ctx, "__get_builtin", [{ kind: "externref" }], [{ kind: "externref" }]);
       const getIdx = ensureLateImport(

--- a/tests/issue-1888-s6c.test.ts
+++ b/tests/issue-1888-s6c.test.ts
@@ -69,12 +69,13 @@ describe("#1888 S6-c — Math/Number constants reach native f64.const under stan
     );
   });
 
-  it("guardrail: genuine Builtin.method value-read (Array.isArray) still refuses-loud (S6-b lever, not S6-c)", async () => {
-    const r = await compile(`export function run(): number { const f: any = Array.isArray; return f([1]) ? 1 : 0; }`, {
+  it("guardrail: unsupported Builtin.method value-read still refuses-loud (S6-b lever)", async () => {
+    const r = await compile(`export function run(): number { const f: any = Math.max; return f(1, 2); }`, {
       target: "standalone",
     });
-    // S6-c must NOT accidentally widen to non-constant builtin reads; those stay
-    // refused until S6-b lands. (A clean compile error, not invalid Wasm.)
+    // #1907 only enables selected static method values; unsupported pairs still
+    // refuse cleanly instead of routing through __get_builtin or invalid Wasm.
     expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/#1907|#1888 S6-b/);
   });
 });

--- a/tests/issue-1907.test.ts
+++ b/tests/issue-1907.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1907 / #1888 S6-b — standalone reads of selected built-in static methods as
+ * values lower to Wasm closure structs instead of `__get_builtin`.
+ *
+ * Spec basis:
+ * - ECMA-262 §23.1.2.3 Array.isArray delegates to IsArray.
+ * - ECMA-262 §20.1.2.19 Object.keys performs ToObject, EnumerableOwnProperties
+ *   with kind=key, then CreateArrayFromList.
+ */
+
+const BANNED = [/^env::__get_builtin$/, /^env::__extern_is_array$/, /^env::__object_keys$/];
+
+function assertNoBannedImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of BANNED) {
+    const hits = labels.filter((label) => re.test(label));
+    expect(hits, `standalone leaked ${re}: ${hits.join(", ")}`).toEqual([]);
+  }
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, { target: "standalone" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoBannedImports(result.imports);
+  expect(WebAssembly.validate(result.binary), "module must validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { run: () => number }).run();
+}
+
+describe("#1907 standalone built-in static method value reads", () => {
+  it("reads Array.isArray as a callable value without __get_builtin", async () => {
+    const value = await runStandalone(`
+      export function run(): number {
+        const isArray = Array.isArray;
+        return isArray([1, 2, 3]) ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+  });
+
+  it("Array.isArray method value returns false for non-arrays", async () => {
+    const value = await runStandalone(`
+      export function run(): number {
+        const isArray = Array.isArray;
+        const obj: any = { a: 1 };
+        return isArray(obj) ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(0);
+  });
+
+  it("reads Object.keys as a callable value without __get_builtin", async () => {
+    const value = await runStandalone(`
+      export function run(): number {
+        const keys: any = Object.keys;
+        const obj: any = {};
+        const ka = "a";
+        const kb = "b";
+        obj[ka] = 1;
+        obj[kb] = 2;
+        const ks: any = keys(obj);
+        return ks.length;
+      }
+    `);
+    expect(value).toBe(2);
+  });
+
+  it("unsupported built-in static method value reads fail loud with #1907", async () => {
+    const result = await compile(`export function run(): number { const max = Math.max; return max(1, 2); }`, {
+      target: "standalone",
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((e) => e.message).join("\n")).toMatch(/#1907|#1888 S6-b/);
+    assertNoBannedImports(result.imports);
+  });
+});


### PR DESCRIPTION
## Summary

- Emit standalone closures for supported built-in static method value reads: `Array.isArray`, `Object.keys`, and `Object.getOwnPropertyDescriptor`.
- Share the `Array.isArray` externref predicate with the direct-call path so standalone builds avoid `__get_builtin` and host-only array predicates where possible.
- Report unsupported `Builtin.prop` static method value reads with the #1907 / #1888 S6-b diagnostic.

## Validation

- `npm test -- tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts`
- `npm run typecheck -- --pretty false`
- `npm test -- tests/issue-1678.test.ts`
- `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`
- `npx prettier --check src/codegen/property-access.ts src/codegen/expressions/calls.ts tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts plan/issues/1907-standalone-builtin-static-method-value-reads.md`