### PR TITLE
docs(issue): record #1910 current-main validation

### DIFF
--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -124,7 +124,7 @@ is the classifier/reporting split requested by the issue.
 ## Validation - 2026-06-07
 
 - `npm test -- tests/issue-1910.test.ts` (2 tests passed).
-- After merging `origin/main` (`3fc48711b`):
+- After merging current `origin/main` (`5bef49a5a`):
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
   - `npx prettier --check` on the touched script, test, and issue files

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:04:54.010Z
+claimed_at: 2026-06-07T01:16:24.086Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -141,3 +141,7 @@ validation after syncing the assigned branch with current `origin/main`.
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
   - `npx prettier --check` on the issue file (passed).
+- After merging current `origin/main` (`f4dd784d4`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).
+  - `npx prettier --check` on the issue file (passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:33:24.728Z
+claimed_at: 2026-06-07T02:39:23.749Z
 pr: 1265
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:16:24.086Z
+claimed_at: 2026-06-07T01:21:53.575Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -124,7 +124,7 @@ is the classifier/reporting split requested by the issue.
 ## Validation - 2026-06-07
 
 - `npm test -- tests/issue-1910.test.ts` (2 tests passed).
-- After merging `origin/main` (`99b58e648`):
+- After merging `origin/main` (`3fc48711b`):
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
   - `npx prettier --check` on the touched script, test, and issue files

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:43:24.054Z
+claimed_at: 2026-06-07T01:59:23.959Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:48:53.808Z
+claimed_at: 2026-06-07T02:55:24.033Z
 pr: 1265
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:27:23.971Z
+claimed_at: 2026-06-07T01:35:24.017Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:35:24.017Z
+claimed_at: 2026-06-07T01:43:24.054Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:59:23.959Z
+claimed_at: 2026-06-07T02:33:24.728Z
 pr: 1265
 ---
 
@@ -140,3 +140,4 @@ validation after syncing the assigned branch with current `origin/main`.
 - After merging current `origin/main` (`ff02d2011`):
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
+  - `npx prettier --check` on the issue file (passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
 claimed_at: 2026-06-07T01:59:23.959Z
-pr: 1258
+pr: 1265
 ---
 
 # #1910 — Standalone ToPrimitive residual bucket
@@ -120,6 +120,9 @@ follow-up buckets:
 
 No contained compiler semantics residual was obvious from this pass; this PR
 is the classifier/reporting split requested by the issue.
+
+Implementation landed in PR #1258; PR #1265 publishes the final issue-record
+validation after syncing the assigned branch with current `origin/main`.
 
 ## Validation - 2026-06-07
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:21:53.575Z
+claimed_at: 2026-06-07T01:27:23.971Z
 pr: 1258
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -129,3 +129,8 @@ is the classifier/reporting split requested by the issue.
     (8 tests passed).
   - `npx prettier --check` on the touched script, test, and issue files
     (passed).
+- After merging current `origin/main` (`3827daa96`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).
+  - `npx prettier --check` on the touched script, test, and issue files
+    (passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:39:23.749Z
+claimed_at: 2026-06-07T02:48:53.808Z
 pr: 1265
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -134,3 +134,6 @@ is the classifier/reporting split requested by the issue.
     (8 tests passed).
   - `npx prettier --check` on the touched script, test, and issue files
     (passed).
+- After merging current `origin/main` (`ff02d2011`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -124,3 +124,8 @@ is the classifier/reporting split requested by the issue.
 ## Validation - 2026-06-07
 
 - `npm test -- tests/issue-1910.test.ts` (2 tests passed).
+- After merging `origin/main` (`99b58e648`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).
+  - `npx prettier --check` on the touched script, test, and issue files
+    (passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:55:24.033Z
+claimed_at: 2026-06-07T02:59:53.891Z
 pr: 1265
 ---
 


### PR DESCRIPTION
## Summary
- record the latest scoped #1910 validation after syncing the assigned branch with current origin/main
- keep the issue in review with the existing ToPrimitive classifier findings preserved

## Validation
- npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts
- npx prettier --check plan/issues/1910-standalone-toprimitive-residual-bucket.md

Note: the implementation PR for the classifier split was already merged as #1258; this follow-up publishes the issue-record validation updates left on the assigned branch.