### PR TITLE
docs(issue): refresh #1905 verification

### DIFF
--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:28:23.923Z
+claimed_at: 2026-06-07T01:36:53.662Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:22:23.562Z
+claimed_at: 2026-06-07T01:28:23.923Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:44:53.840Z
+claimed_at: 2026-06-07T02:58:54.084Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset
@@ -92,3 +92,5 @@ machinery and are out of scope here.
   `pnpm test tests/issue-1905.test.ts`,
   `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`, and
   `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`.
+- Final PR check: GitHub reports PR `#1261` as merged, so there is no
+  remaining merge-queue action for this issue.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:36:53.662Z
+claimed_at: 2026-06-07T02:44:53.840Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset
@@ -82,3 +82,13 @@ machinery and are out of scope here.
   pre-existing failures in Object prototype and open-any method-dispatch cases,
   so validation for this issue stayed scoped to the changed Reflect refusal
   regression.
+
+## Redispatch Verification
+
+- 2026-06-07: confirmed PR `#1261` is already merged and `origin/main`
+  contains the standalone Reflect object subset implementation and
+  `tests/issue-1905.test.ts`.
+- Reran scoped validation on this worktree:
+  `pnpm test tests/issue-1905.test.ts`,
+  `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`, and
+  `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T00:35:56.934Z
+claimed_at: 2026-06-07T01:22:23.562Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:58:54.084Z
+claimed_at: 2026-06-07T03:10:53.997Z
 pr: 1261
 ---
 # #1905 — Standalone native Reflect object subset
@@ -94,3 +94,6 @@ machinery and are out of scope here.
   `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`.
 - Final PR check: GitHub reports PR `#1261` as merged, so there is no
   remaining merge-queue action for this issue.
+- Current redispatch pass: fetched `origin/main`, reran the scoped validation
+  above successfully, and confirmed the only GitHub PR for `symphony/1905` is
+  ready/non-draft PR `#1261`, already merged on 2026-06-07.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
 claimed_at: 2026-06-07T03:10:53.997Z
-pr: 1261
+pr: 1266
 ---
 # #1905 — Standalone native Reflect object subset
 
@@ -95,5 +95,5 @@ machinery and are out of scope here.
 - Final PR check: GitHub reports PR `#1261` as merged, so there is no
   remaining merge-queue action for this issue.
 - Current redispatch pass: fetched `origin/main`, reran the scoped validation
-  above successfully, and confirmed the only GitHub PR for `symphony/1905` is
-  ready/non-draft PR `#1261`, already merged on 2026-06-07.
+  above successfully, confirmed implementation PR `#1261` is already merged,
+  and opened ready/non-draft follow-up PR `#1266` for this issue-file update.


### PR DESCRIPTION
## Summary

- record the redispatch verification for issue #1905
- keep the issue in review and note that implementation PR #1261 is already merged
- merge current origin/main into the issue branch before publishing

## Validation

- `pnpm test tests/issue-1905.test.ts`
- `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`
- `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`