### PR TITLE
docs(issue): record #1907 final verification

### DIFF
--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:42:54.148Z
+claimed_at: 2026-06-07T02:56:54.160Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -87,6 +87,8 @@ standalone refusal.
 - PR #1263 exists, was ready/non-draft, and is now merged into `main` at
   `3827daa96`; merge-queue/auto-merge entry is no longer applicable because the
   PR is already merged.
+- Redispatch verification on this branch found no additional implementation
+  work outstanding; the scoped validation commands below passed again.
 - `origin/main` was fetched and merged into `symphony/1907` before the final
   branch push. The merge brought in later main changes without #1907 conflicts.
 - Scoped validation passed again after the final main merge: the focused

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -86,7 +86,7 @@ standalone refusal.
 
 - PR #1263 exists and remains the review vehicle for this issue.
 - `origin/main` was fetched and merged before publishing; this handoff pulled in
-  the latest `main` changes, including #1905, without conflicts.
+  the latest `main` changes, including #1905 and #1910, without conflicts.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -2,7 +2,7 @@
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
 status: in-review
-pr: 1263
+pr: 1267
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -84,9 +84,9 @@ standalone refusal.
 
 ## Final Findings
 
-- PR #1263 exists, was ready/non-draft, and is now merged into `main` at
-  `3827daa96`; merge-queue/auto-merge entry is no longer applicable because the
-  PR is already merged.
+- Implementation PR #1263 exists, was ready/non-draft, and is now merged into
+  `main` at `3827daa96`; follow-up PR #1267 tracks this final issue-status
+  verification update.
 - Final codex-developer verification on this branch found no additional
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
@@ -96,5 +96,5 @@ standalone refusal.
 - Scoped validation passed again after that final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.
-- The issue remains `in-review` with `pr: 1263` so the PR-status poller can
+- The issue remains `in-review` with `pr: 1267` so the PR-status poller can
   perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:56:54.160Z
+claimed_at: 2026-06-07T03:02:54.204Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -91,8 +91,8 @@ standalone refusal.
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
 - `origin/main` was fetched and merged into `symphony/1907` through
-  `f4dd784d4` before the final branch push. The merge brought in a later
-  test262 baseline refresh without #1907 conflicts.
+  `d4492156f` before the final branch push. The merge brought in later sprint
+  issue/report updates without #1907 conflicts.
 - Scoped validation passed again after that final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-review
+status: in-progress
 pr: 1263
 sprint: 61
 created: 2026-06-07
@@ -90,3 +90,6 @@ standalone refusal.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.
+- Publishing the local sync commits is blocked because GitHub already has PR
+  #1263 in the merge queue; queued branches cannot be updated without
+  dequeuing the PR.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-progress
+status: in-review
 pr: 1263
 sprint: 61
 created: 2026-06-07
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:57:23.827Z
+claimed_at: 2026-06-07T02:13:24.006Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -84,15 +84,12 @@ standalone refusal.
 
 ## Final Findings
 
-- PR #1263 exists, is ready/non-draft, and remains the review vehicle for this
-  issue.
-- `origin/main` was fetched and merged before publishing; the branch includes
-  current `main` through `5bef49a5a` without conflicts.
-- Scoped validation passed again after the merge: the focused #1907/#1888 tests,
-  typecheck, #1678 Array.isArray regression tests, the targeted #1472
-  Reflect.ownKeys standalone route, and formatting.
-- Publishing the local main-sync and issue-update commits is blocked because
-  GitHub reports PR #1263 is already in the merge queue (`isInMergeQueue:
-  true`); queued branches cannot be updated without dequeuing the PR.
-- Required checks on the queued PR are passing, so the remote PR can still land
-  from the existing queued branch head.
+- PR #1263 exists, was ready/non-draft, and is now merged into `main` at
+  `3827daa96`.
+- `origin/main` was fetched before this handoff validation; it includes the
+  #1907 merge commit and the prior main sync.
+- Scoped validation passed again after confirming the PR merge: the focused
+  #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
+  targeted #1472 Reflect.ownKeys standalone route, and formatting.
+- The issue remains `in-review` with `pr: 1263` so the PR-status poller can
+  perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -91,7 +91,7 @@ standalone refusal.
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
 - `origin/main` was fetched and merged into `symphony/1907` through
-  `d4492156f` before the final branch push. The merge brought in later sprint
+  `c871fe467` before the final branch push. The merge brought in later sprint
   issue/report updates without #1907 conflicts.
 - Scoped validation passed again after that final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:13:24.006Z
+claimed_at: 2026-06-07T02:42:54.148Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-progress
+status: in-review
 pr: 1263
 sprint: 61
 created: 2026-06-07
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:48:23.687Z
+claimed_at: 2026-06-07T01:57:23.827Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -84,12 +84,11 @@ standalone refusal.
 
 ## Final Findings
 
-- PR #1263 exists and remains the review vehicle for this issue.
-- `origin/main` was fetched and merged before publishing; this handoff pulled in
-  the latest `main` changes through `5bef49a5a` without conflicts.
+- PR #1263 exists, is ready/non-draft, and is the review vehicle for this issue.
+- `origin/main` was fetched and merged before publishing; the branch includes
+  current `main` through `5bef49a5a` without conflicts.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.
-- Publishing the local sync commits is blocked because GitHub already has PR
-  #1263 in the merge queue; queued branches cannot be updated without
-  dequeuing the PR.
+- GitHub reports PR #1263 is in the merge queue (`isInMergeQueue: true`) with
+  required checks passing.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-review
+status: in-progress
 pr: 1263
 sprint: 61
 created: 2026-06-07
@@ -84,11 +84,15 @@ standalone refusal.
 
 ## Final Findings
 
-- PR #1263 exists, is ready/non-draft, and is the review vehicle for this issue.
+- PR #1263 exists, is ready/non-draft, and remains the review vehicle for this
+  issue.
 - `origin/main` was fetched and merged before publishing; the branch includes
   current `main` through `5bef49a5a` without conflicts.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.
-- GitHub reports PR #1263 is in the merge queue (`isInMergeQueue: true`) with
-  required checks passing.
+- Publishing the local main-sync and issue-update commits is blocked because
+  GitHub reports PR #1263 is already in the merge queue (`isInMergeQueue:
+  true`); queued branches cannot be updated without dequeuing the PR.
+- Required checks on the queued PR are passing, so the remote PR can still land
+  from the existing queued branch head.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -85,10 +85,11 @@ standalone refusal.
 ## Final Findings
 
 - PR #1263 exists, was ready/non-draft, and is now merged into `main` at
-  `3827daa96`.
-- `origin/main` was fetched before this handoff validation; it includes the
-  #1907 merge commit and the prior main sync.
-- Scoped validation passed again after confirming the PR merge: the focused
+  `3827daa96`; merge-queue/auto-merge entry is no longer applicable because the
+  PR is already merged.
+- `origin/main` was fetched and merged into `symphony/1907` before the final
+  branch push. The merge brought in later main changes without #1907 conflicts.
+- Scoped validation passed again after the final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.
 - The issue remains `in-review` with `pr: 1263` so the PR-status poller can

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:02:54.204Z
+claimed_at: 2026-06-07T03:15:24.162Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -87,9 +87,9 @@ standalone refusal.
 - PR #1263 exists, was ready/non-draft, and is now merged into `main` at
   `3827daa96`; merge-queue/auto-merge entry is no longer applicable because the
   PR is already merged.
-- Redispatch verification on this branch found no additional implementation
-  work outstanding; the scoped validation commands below passed again on
-  2026-06-07 after merging current `origin/main`.
+- Final codex-developer verification on this branch found no additional
+  implementation work outstanding; the scoped validation commands above passed
+  again on 2026-06-07 after merging current `origin/main`.
 - `origin/main` was fetched and merged into `symphony/1907` through
   `f4dd784d4` before the final branch push. The merge brought in a later
   test262 baseline refresh without #1907 conflicts.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -88,10 +88,12 @@ standalone refusal.
   `3827daa96`; merge-queue/auto-merge entry is no longer applicable because the
   PR is already merged.
 - Redispatch verification on this branch found no additional implementation
-  work outstanding; the scoped validation commands below passed again.
-- `origin/main` was fetched and merged into `symphony/1907` before the final
-  branch push. The merge brought in later main changes without #1907 conflicts.
-- Scoped validation passed again after the final main merge: the focused
+  work outstanding; the scoped validation commands below passed again on
+  2026-06-07 after merging current `origin/main`.
+- `origin/main` was fetched and merged into `symphony/1907` through
+  `f4dd784d4` before the final branch push. The merge brought in a later
+  test262 baseline refresh without #1907 conflicts.
+- Scoped validation passed again after that final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.
 - The issue remains `in-review` with `pr: 1263` so the PR-status poller can

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -86,7 +86,7 @@ standalone refusal.
 
 - PR #1263 exists and remains the review vehicle for this issue.
 - `origin/main` was fetched and merged before publishing; this handoff pulled in
-  the latest `main` changes, including #1905 and #1910, without conflicts.
+  the latest `main` changes through `5bef49a5a` without conflicts.
 - Scoped validation passed again after the merge: the focused #1907/#1888 tests,
   typecheck, #1678 Array.isArray regression tests, the targeted #1472
   Reflect.ownKeys standalone route, and formatting.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T01:34:54.097Z
+claimed_at: 2026-06-07T01:48:23.687Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`


### PR DESCRIPTION
## Summary

I recorded the final #1907 redispatch verification and kept the issue in review while noting that implementation PR #1263 is already merged.

## Validation

I reran the scoped validation after merging current `origin/main`:

- `npm test -- tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts`
- `npm run typecheck -- --pretty false`
- `npm test -- tests/issue-1678.test.ts`
- `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`
- `npx prettier --check src/codegen/property-access.ts src/codegen/expressions/calls.ts tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts plan/issues/1907-standalone-builtin-static-method-value-reads.md`
