### PR TITLE
docs(issue): record #1910 final validation

### DIFF
--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -149,3 +149,7 @@ validation after syncing the assigned branch with current `origin/main`.
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
   - `npx prettier --check` on the issue file (passed).
+- After merging current `origin/main` (`c871fe467`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).
+  - `npx prettier --check` on the issue file (passed).

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
 claimed_at: 2026-06-07T03:17:54.225Z
-pr: 1265
+pr: 1268
 ---
 
 # #1910 — Standalone ToPrimitive residual bucket
@@ -121,8 +121,10 @@ follow-up buckets:
 No contained compiler semantics residual was obvious from this pass; this PR
 is the classifier/reporting split requested by the issue.
 
-Implementation landed in PR #1258; PR #1265 publishes the final issue-record
-validation after syncing the assigned branch with current `origin/main`.
+Implementation landed in PR #1258. PR #1265 published the first issue-record
+validation update, then merged before the final branch updates were pushed.
+PR #1268 publishes the active issue-record validation after syncing the assigned
+branch with current `origin/main`.
 
 ## Validation - 2026-06-07
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:59:53.891Z
+claimed_at: 2026-06-07T03:13:23.989Z
 pr: 1265
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -16,7 +16,7 @@ related: [1806, 1900, 1525, 1525b, 1759]
 test262_bucket: object-to-primitive
 test262_count: 784
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:13:23.989Z
+claimed_at: 2026-06-07T03:17:54.225Z
 pr: 1265
 ---
 

--- a/plan/issues/1910-standalone-toprimitive-residual-bucket.md
+++ b/plan/issues/1910-standalone-toprimitive-residual-bucket.md
@@ -145,3 +145,7 @@ validation after syncing the assigned branch with current `origin/main`.
   - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
     (8 tests passed).
   - `npx prettier --check` on the issue file (passed).
+- After merging current `origin/main` (`d4492156f`):
+  - `npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts`
+    (8 tests passed).
+  - `npx prettier --check` on the issue file (passed).


### PR DESCRIPTION
## Summary
- record the latest scoped #1910 validation after syncing the assigned branch with current origin/main at c871fe467
- keep the issue in review with the ToPrimitive classifier findings preserved
- replace the already-merged #1265 as the active follow-up for final issue-record publication

## Validation
- npm test -- tests/issue-1910.test.ts tests/build-test262-report.test.ts
- npx prettier --check plan/issues/1910-standalone-toprimitive-residual-bucket.md

Note: the classifier/reporting implementation itself landed in #1258; #1265 merged before the final branch updates were published.