### PR TITLE
docs(issue): refresh #1905 attempt 21 state

### DIFF
--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -17,7 +17,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:26:24.844Z
+claimed_at: 2026-06-07T05:02:59.247Z
 pr: 1269
 ---
 
@@ -103,3 +103,6 @@ machinery and are out of scope here.
   merge-queue action remains for that tracked PR.
 - Opened ready follow-up PR `#1269` for this current validation and issue-state
   refresh.
+- Attempt 21: reran the scoped validation above successfully, confirmed GitHub
+  reports ready PR `#1269` as merged with successful checks, and left the issue
+  in review for the PR-status poller.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
 claimed_at: 2026-06-07T05:02:59.247Z
-pr: 1269
+pr: 1270
 ---
 
 # #1905 — Standalone native Reflect object subset
@@ -106,3 +106,4 @@ machinery and are out of scope here.
 - Attempt 21: reran the scoped validation above successfully, confirmed GitHub
   reports ready PR `#1269` as merged with successful checks, and left the issue
   in review for the PR-status poller.
+- Opened ready follow-up PR `#1270` for the Attempt 21 issue-state refresh.


### PR DESCRIPTION
## Summary

- record the Attempt 21 validation pass for #1905
- keep the issue in `in-review` while the PR-status poller handles merged PR state

## Validation

- `pnpm test tests/issue-1905.test.ts`
- `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`
- `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`
- pre-push hook: typecheck, lint, format check, issue integrity

The standalone Reflect object subset implementation itself was already merged via PR #1261, and the previous issue-state PR #1269 is merged with successful checks.