### PR TITLE
docs(issue): record #1907 current-main validation

### DIFF
--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-review
+status: in-progress
 pr: 1287
 sprint: 61
 created: 2026-06-07
@@ -108,5 +108,11 @@ standalone refusal.
 - Codex verification on 2026-06-07T08:40+02:00 reran the issue-scoped
   validation on the current branch; all commands passed, PR #1287 was open,
   ready/non-draft, mergeable, and its remote-head checks were green.
-- The issue remains `in-review` with `pr: 1287` so the PR-status poller can
-  perform the normal post-merge status transition.
+- Final push of local verification commit `a110392e8` was rejected by GitHub
+  with GH006 because PR #1287 is already in the merge queue. The queue entry was
+  `QUEUED` at position 15, enqueued at `2026-06-07T06:26:03Z`; leave this issue
+  `in-progress` until the queued PR lands or the branch is intentionally
+  dequeued for another update.
+- The remote PR branch still has `pr: 1287` and was already queued, but this
+  local handoff leaves the issue `in-progress` because the final publish update
+  could not be pushed while the branch is queue-protected.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -90,16 +90,17 @@ standalone refusal.
 - Final codex-developer verification on this branch found no additional
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
-- `origin/main` was fetched and merged into `symphony/1907` through
-  `5b495ba47` before the final branch push. The merge brought in later sprint
-  issue/report updates without #1907 conflicts.
-- Scoped validation passed again after that final main merge: the focused
-  #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
-  targeted #1472 Reflect.ownKeys standalone route, and formatting.
+- `origin/main` was fetched at `d6957d5d` and merged into `symphony/1907` with
+  merge commit `9f350d0a`. The merge brought in later sprint issue/report
+  updates without #1907 conflicts.
+- Scoped validation passed again on 2026-06-07T09:13+02:00 after that final
+  main merge: the focused #1907/#1888 tests, typecheck, #1678 Array.isArray
+  regression tests, the targeted #1472 Reflect.ownKeys standalone route, and
+  formatting.
 - Redispatch verification on 2026-06-07T08:19+02:00 found the implementation
   already merged, branch synced with `origin/main`, PR #1287 opened
   ready/non-draft, and the same scoped validation still passing.
 - Codex verification on 2026-06-07T09:11+02:00 found PR #1287 still open,
   ready/non-draft, green on the remote head, and accepted in the merge queue at
-  position 11. This handoff keeps the issue `in-review` with `pr: 1287` while
-  syncing the local branch with current `origin/main`.
+  position 11 before the local main-sync publish. This handoff keeps the issue
+  `in-review` with `pr: 1287` for the PR-status poller.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -2,7 +2,7 @@
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
 status: in-review
-pr: 1267
+pr: 1287
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -85,8 +85,8 @@ standalone refusal.
 ## Final Findings
 
 - Implementation PR #1263 exists, was ready/non-draft, and is now merged into
-  `main` at `3827daa96`; follow-up PR #1267 tracks this final issue-status
-  verification update.
+  `main` at `3827daa96`; follow-up PR #1267 also merged, and PR #1287 tracks
+  this redispatch verification update.
 - Final codex-developer verification on this branch found no additional
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
@@ -97,7 +97,7 @@ standalone refusal.
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.
 - Redispatch verification on 2026-06-07T08:19+02:00 found the implementation
-  already merged, branch synced with `origin/main`, and the same scoped
-  validation still passing.
-- The issue remains `in-review` with `pr: 1267` so the PR-status poller can
+  already merged, branch synced with `origin/main`, PR #1287 opened
+  ready/non-draft, and the same scoped validation still passing.
+- The issue remains `in-review` with `pr: 1287` so the PR-status poller can
   perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:31:35.825Z
+claimed_at: 2026-06-07T06:38:34.913Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -105,5 +105,8 @@ standalone refusal.
 - Codex verification on 2026-06-07T08:34+02:00 reran the same scoped validation
   on the current branch; all commands passed, PR #1287 remained open and
   ready/non-draft, and `origin/main` was still an ancestor of `HEAD`.
+- Codex verification on 2026-06-07T08:40+02:00 reran the issue-scoped
+  validation on the current branch; all commands passed, PR #1287 was open,
+  ready/non-draft, mergeable, and its remote-head checks were green.
 - The issue remains `in-review` with `pr: 1287` so the PR-status poller can
   perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:15:24.162Z
+claimed_at: 2026-06-07T06:17:34.732Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -91,10 +91,13 @@ standalone refusal.
   implementation work outstanding; the scoped validation commands above passed
   again on 2026-06-07 after merging current `origin/main`.
 - `origin/main` was fetched and merged into `symphony/1907` through
-  `c871fe467` before the final branch push. The merge brought in later sprint
+  `5b495ba47` before the final branch push. The merge brought in later sprint
   issue/report updates without #1907 conflicts.
 - Scoped validation passed again after that final main merge: the focused
   #1907/#1888 tests, typecheck, #1678 Array.isArray regression tests, the
   targeted #1472 Reflect.ownKeys standalone route, and formatting.
+- Redispatch verification on 2026-06-07T08:19+02:00 found the implementation
+  already merged, branch synced with `origin/main`, and the same scoped
+  validation still passing.
 - The issue remains `in-review` with `pr: 1267` so the PR-status poller can
   perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: in-progress
+status: in-review
 pr: 1287
 sprint: 61
 created: 2026-06-07
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:50:35.215Z
+claimed_at: 2026-06-07T07:08:34.903Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -99,32 +99,7 @@ standalone refusal.
 - Redispatch verification on 2026-06-07T08:19+02:00 found the implementation
   already merged, branch synced with `origin/main`, PR #1287 opened
   ready/non-draft, and the same scoped validation still passing.
-- Codex verification on 2026-06-07T08:28+02:00 reran the issue-scoped
-  validation on `symphony/1907`; all commands passed, PR #1287 was still open
-  and ready/non-draft, and the branch remained current with `origin/main`.
-- Codex verification on 2026-06-07T08:34+02:00 reran the same scoped validation
-  on the current branch; all commands passed, PR #1287 remained open and
-  ready/non-draft, and `origin/main` was still an ancestor of `HEAD`.
-- Codex verification on 2026-06-07T08:40+02:00 reran the issue-scoped
-  validation on the current branch; all commands passed, PR #1287 was open,
-  ready/non-draft, mergeable, and its remote-head checks were green.
-- Final push of local verification commit `a110392e8` was rejected by GitHub
-  with GH006 because PR #1287 is already in the merge queue. The queue entry was
-  `QUEUED` at position 15, enqueued at `2026-06-07T06:26:03Z`; leave this issue
-  `in-progress` until the queued PR lands or the branch is intentionally
-  dequeued for another update.
-- The remote PR branch still has `pr: 1287` and was already queued, but this
-  local handoff leaves the issue `in-progress` because the final publish update
-  could not be pushed while the branch is queue-protected.
-- Codex verification on 2026-06-07T08:47+02:00 reran the same issue-scoped
-  validation on the current local branch; all commands passed, `origin/main`
-  remains an ancestor of `HEAD`, and PR #1287 is still open, ready/non-draft,
-  mergeable, green on the remote head, and queued at position 14. The local
-  branch still contains unpublished issue-doc verification commits because the
-  queued PR head is protected from further pushes.
-- Codex verification on 2026-06-07T08:54+02:00 reran the issue-scoped
-  validation again; all commands passed, `origin/main` remains an ancestor of
-  `HEAD`, and PR #1287 is still open, ready/non-draft, mergeable, green on the
-  remote head, and queued at position 14. The local branch still contains
-  unpublished issue-doc verification commits because the queued PR head is
-  protected from further pushes.
+- Codex verification on 2026-06-07T09:11+02:00 found PR #1287 still open,
+  ready/non-draft, green on the remote head, and accepted in the merge queue at
+  position 11. This handoff keeps the issue `in-review` with `pr: 1287` while
+  syncing the local branch with current `origin/main`.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:45:05.679Z
+claimed_at: 2026-06-07T06:50:35.215Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -122,3 +122,9 @@ standalone refusal.
   mergeable, green on the remote head, and queued at position 14. The local
   branch still contains unpublished issue-doc verification commits because the
   queued PR head is protected from further pushes.
+- Codex verification on 2026-06-07T08:54+02:00 reran the issue-scoped
+  validation again; all commands passed, `origin/main` remains an ancestor of
+  `HEAD`, and PR #1287 is still open, ready/non-draft, mergeable, green on the
+  remote head, and queued at position 14. The local branch still contains
+  unpublished issue-doc verification commits because the queued PR head is
+  protected from further pushes.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:25:34.963Z
+claimed_at: 2026-06-07T06:31:35.825Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -102,5 +102,8 @@ standalone refusal.
 - Codex verification on 2026-06-07T08:28+02:00 reran the issue-scoped
   validation on `symphony/1907`; all commands passed, PR #1287 was still open
   and ready/non-draft, and the branch remained current with `origin/main`.
+- Codex verification on 2026-06-07T08:34+02:00 reran the same scoped validation
+  on the current branch; all commands passed, PR #1287 remained open and
+  ready/non-draft, and `origin/main` was still an ancestor of `HEAD`.
 - The issue remains `in-review` with `pr: 1287` so the PR-status poller can
   perform the normal post-merge status transition.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:38:34.913Z
+claimed_at: 2026-06-07T06:45:05.679Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -116,3 +116,9 @@ standalone refusal.
 - The remote PR branch still has `pr: 1287` and was already queued, but this
   local handoff leaves the issue `in-progress` because the final publish update
   could not be pushed while the branch is queue-protected.
+- Codex verification on 2026-06-07T08:47+02:00 reran the same issue-scoped
+  validation on the current local branch; all commands passed, `origin/main`
+  remains an ancestor of `HEAD`, and PR #1287 is still open, ready/non-draft,
+  mergeable, green on the remote head, and queued at position 14. The local
+  branch still contains unpublished issue-doc verification commits because the
+  queued PR head is protected from further pushes.

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -18,7 +18,7 @@ related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:17:34.732Z
+claimed_at: 2026-06-07T06:25:34.963Z
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -99,5 +99,8 @@ standalone refusal.
 - Redispatch verification on 2026-06-07T08:19+02:00 found the implementation
   already merged, branch synced with `origin/main`, PR #1287 opened
   ready/non-draft, and the same scoped validation still passing.
+- Codex verification on 2026-06-07T08:28+02:00 reran the issue-scoped
+  validation on `symphony/1907`; all commands passed, PR #1287 was still open
+  and ready/non-draft, and the branch remained current with `origin/main`.
 - The issue remains `in-review` with `pr: 1287` so the PR-status poller can
   perform the normal post-merge status transition.


### PR DESCRIPTION
## Summary

I refreshed the #1907 issue record after redispatching the already-merged standalone built-in static method value-read work.

- records that the implementation is already merged and the branch is synced with current `origin/main`
- preserves `status: in-review` with the active PR pointer workflow
- adds the scoped validation rerun timestamp and result

## Validation

- `npm test -- tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts`
- `npm run typecheck -- --pretty false`
- `npm test -- tests/issue-1678.test.ts`
- `npm test -- tests/issue-1472.test.ts -t "Reflect.ownKeys routes"`
- `npx prettier --check src/codegen/property-access.ts src/codegen/expressions/calls.ts tests/issue-1907.test.ts tests/issue-1888-s6c.test.ts plan/issues/1907-standalone-builtin-static-method-value-reads.md`
- `npx prettier --check plan/issues/1907-standalone-builtin-static-method-value-reads.md`