### PR TITLE
docs(issue): refresh RegExp residual PR state

### DIFF
--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -186,3 +186,16 @@ state confirms PR #1260 is `MERGED`, ready/non-draft, with merge commit
 The implementation remains complete and present on `origin/main`; this branch is
 now carrying only the #1909 issue-state refresh so the plan metadata stays in
 sync with the merged PR state.
+
+Follow-up validation after merging current `origin/main`:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+The rebuilt report still classifies `30,733 / 30,733` standalone non-pass
+non-skip rows. The RegExp split is unchanged: `833` Phase 2d rows, `104` Phase
+2b rows, `452` string-protocol rows, `546` native-engine rows, and `62`
+fallback rows.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:08:24.842Z
+claimed_at: 2026-06-07T03:14:54.632Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -141,3 +141,27 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until the queued
 PR merges or is dequeued so the current main-sync metadata can be pushed.
+
+## 2026-06-07 queue refresh after reassignment
+
+Scoped validation was rerun in this worktree after the reassignment:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts tests/issue-1910.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts tests/issue-1910.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. PR #1260 remains open and ready, with remote head
+`a3fe42c32`. GitHub has accepted it into the merge queue again:
+
+- Queue ref:
+  `refs/heads/gh-readonly-queue/main/pr-1260-f4dd784d4f1960a8c759b51f0cff23e8f4ed4f34`
+- Merge-group run:
+  `https://github.com/loopdive/js2/actions/runs/27081078870`
+- Current merge-group status at refresh time: `in_progress`
+
+The local branch still contains post-sync metadata commits that cannot be pushed
+while GitHub keeps the PR branch in the merge queue. This issue remains
+`in-progress` locally until either the queued PR merges or the branch is
+dequeued for another push.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -107,3 +107,21 @@ The final rebuilt report keeps `30,733 / 30,733` standalone non-pass/non-skip
 rows classified with `0` unclassified. The RegExp residual remains split into
 `833` Phase 2d rows, `104` Phase 2b rows, `452` string-protocol rows, `546`
 native-engine rows, and `62` fallback rows.
+
+## 2026-06-07 publish blocker
+
+PR #1260 exists and is ready, but GitHub rejected the latest branch push because
+the PR is already in the merge queue:
+
+- Remote PR head: `a3fe42c32`
+- Local attempted head: `09402eef4`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until the queued
+PR merges or the PR is dequeued and the local metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -15,7 +15,7 @@ goal: standalone-mode
 related: [682, 1474, 1539]
 test262_bucket: standalone-regexp
 test262_count: 1997
-pr: 1260
+pr: 1289
 claimed_by: codex-developer
 claimed_at: 2026-06-07T06:34:35.205Z
 ---
@@ -199,3 +199,5 @@ The rebuilt report still classifies `30,733 / 30,733` standalone non-pass
 non-skip rows. The RegExp split is unchanged: `833` Phase 2d rows, `104` Phase
 2b rows, `452` string-protocol rows, `546` native-engine rows, and `62`
 fallback rows.
+
+Opened ready follow-up PR #1289 for this issue-state refresh.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:39:53.975Z
+claimed_at: 2026-06-07T02:55:54.288Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -119,5 +119,6 @@ queue refs, but the remote PR head `a3fe42c32` now shows a failed
 - summary: `62` pass-to-other transitions, `27` improvements, net `-35` pass
 - baseline note in the failed log: baseline age `1h 20m` at commit `99b58e6`
 
-Before the final push, this branch is being resynced with current `origin/main`
-so the PR reruns against the latest committed baseline.
+The branch has since been resynced with current `origin/main`, and the scoped
+local validation listed above passed again. The next push will rerun the PR
+checks against the latest committed baseline.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:00:54.182Z
+claimed_at: 2026-06-07T03:08:24.842Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -108,20 +108,16 @@ rows classified with `0` unclassified. The RegExp residual remains split into
 `833` Phase 2d rows, `104` Phase 2b rows, `452` string-protocol rows, `546`
 native-engine rows, and `62` fallback rows.
 
-## 2026-06-07 publish blocker
+## 2026-06-07 PR status refresh
 
-PR #1260 exists and is ready, but GitHub rejected the latest branch push because
-the PR is already in the merge queue:
+PR #1260 is open, ready for review, and still points at this issue branch. The
+previous queue push blocker cleared after GitHub dropped the temporary merge
+queue refs, but the remote PR head `a3fe42c32` now shows a failed
+`check for test262 regressions` job:
 
-- Remote PR head: `a3fe42c32`
-- Local attempted head: `09402eef4`
-- Push result:
+- run: `https://github.com/loopdive/js2/actions/runs/27080559423/job/79926321031`
+- summary: `62` pass-to-other transitions, `27` improvements, net `-35` pass
+- baseline note in the failed log: baseline age `1h 20m` at commit `99b58e6`
 
-```text
-GH006: Protected branch update failed ...
-A pull request for this branch has been added to a merge queue.
-Branches that are queued for merging cannot be updated.
-```
-
-Per the publish rule, this issue is left `in-progress` locally until the queued
-PR merges or the PR is dequeued and the local metadata refresh can be pushed.
+Before the final push, this branch is being resynced with current `origin/main`
+so the PR reruns against the latest committed baseline.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -152,8 +152,9 @@ Scoped validation was rerun in this worktree after the reassignment:
 - `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts tests/issue-1910.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
 - `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
 
-All scoped checks passed. PR #1260 remains open and ready, with remote head
-`a3fe42c32`. GitHub has accepted it into the merge queue again:
+All scoped checks passed. At refresh time, PR #1260 remained open and ready,
+with remote head `a3fe42c32`. GitHub had accepted it into the merge queue
+again:
 
 - Queue ref:
   `refs/heads/gh-readonly-queue/main/pr-1260-f4dd784d4f1960a8c759b51f0cff23e8f4ed4f34`
@@ -161,7 +162,17 @@ All scoped checks passed. PR #1260 remains open and ready, with remote head
   `https://github.com/loopdive/js2/actions/runs/27081078870`
 - Current merge-group status at refresh time: `in_progress`
 
-The local branch still contains post-sync metadata commits that cannot be pushed
-while GitHub keeps the PR branch in the merge queue. This issue remains
-`in-progress` locally until either the queued PR merges or the branch is
-dequeued for another push.
+At that point the local branch still contained post-sync metadata commits that
+could not be pushed while GitHub kept the PR branch in the merge queue.
+
+## 2026-06-07 merged PR state
+
+PR #1260 merged via the GitHub merge queue at `2026-06-07T03:16:41Z`:
+
+- Merge commit: `d4492156fbb45e50954700f8c1f3ca6b6e3970ef`
+- PR URL: `https://github.com/loopdive/js2/pull/1260`
+- Final PR head included in the merge: `a3fe42c32`
+
+After the merge, this branch was merged with current `origin/main` so the local
+issue metadata is based on the merged PR state. The issue remains `in-review`
+with `pr: 1260`; the PR-status poller owns the eventual `done` transition.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:32:23.806Z
+claimed_at: 2026-06-07T02:39:53.975Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:27:54.492Z
+claimed_at: 2026-06-07T05:01:30.049Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T03:14:54.632Z
+claimed_at: 2026-06-07T03:27:54.492Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -119,6 +119,25 @@ queue refs, but the remote PR head `a3fe42c32` now shows a failed
 - summary: `62` pass-to-other transitions, `27` improvements, net `-35` pass
 - baseline note in the failed log: baseline age `1h 20m` at commit `99b58e6`
 
-The branch has since been resynced with current `origin/main`, and the scoped
-local validation listed above passed again. The next push will rerun the PR
-checks against the latest committed baseline.
+The branch was then resynced with current `origin/main`, and the scoped local
+validation listed above passed again.
+
+## 2026-06-07 publish blocker after main sync
+
+The final branch push was rejected because PR #1260 is back in GitHub's merge
+queue:
+
+- Remote PR head: `a3fe42c32`
+- Local attempted head: `0808e70fc`
+- Queue ref observed:
+  `refs/heads/gh-readonly-queue/main/pr-1260-f4dd784d4f1960a8c759b51f0cff23e8f4ed4f34`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until the queued
+PR merges or is dequeued so the current main-sync metadata can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T02:55:54.288Z
+claimed_at: 2026-06-07T03:00:54.182Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1260
 claimed_by: codex-developer
-claimed_at: 2026-06-07T05:01:30.049Z
+claimed_at: 2026-06-07T06:34:35.205Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -176,3 +176,13 @@ PR #1260 merged via the GitHub merge queue at `2026-06-07T03:16:41Z`:
 After the merge, this branch was merged with current `origin/main` so the local
 issue metadata is based on the merged PR state. The issue remains `in-review`
 with `pr: 1260`; the PR-status poller owns the eventual `done` transition.
+
+## 2026-06-07 follow-up metadata refresh
+
+This issue was reassigned after PR #1260 had already merged. Current GitHub
+state confirms PR #1260 is `MERGED`, ready/non-draft, with merge commit
+`d4492156fbb45e50954700f8c1f3ca6b6e3970ef`.
+
+The implementation remains complete and present on `origin/main`; this branch is
+now carrying only the #1909 issue-state refresh so the plan metadata stays in
+sync with the merged PR state.


### PR DESCRIPTION
## Summary

- record that #1909 implementation PR #1260 has merged
- preserve the current scoped validation and RegExp residual split counts in the issue file
- keep the issue in review for the PR-status poller rather than marking it done locally

## Validation

- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
- `node --check scripts/build-test262-report.mjs`
- `node scripts/check-issue-ids.mjs`
- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`