### PR TITLE
docs(issue): refresh #1905 PR state

### DIFF
--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:58:59.062Z
+claimed_at: 2026-06-07T11:05:59.366Z
 pr: 1290
 ---
 
@@ -173,3 +173,12 @@ machinery and are out of scope here.
   ancestor of `symphony/1905`, reran the scoped validation above successfully,
   and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and queued
   in the merge queue at position 19 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully
+  including the focused Prettier check, and confirmed ready PR `#1290` is
+  open/non-draft, clean, mergeable, and queued in the merge queue at position 18
+  before publishing this issue-state refresh.
+- Final Codex publish pass: dequeued PR `#1290`, pushed this refreshed issue
+  state to `symphony/1905`, and re-enabled GitHub auto-merge for the refreshed
+  head while required checks are pending so GitHub can queue it after checks
+  pass.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T13:05:29.413Z
+claimed_at: 2026-06-07T13:13:30.221Z
 pr: 1290
 ---
 
@@ -261,6 +261,12 @@ machinery and are out of scope here.
   and re-enabled GitHub auto-merge for the refreshed head while required checks
   are pending so GitHub can queue it after checks pass.
 - Current Codex pass (2026-06-07T15:08+02:00): fetched current `origin/main`
+  (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
+  scoped validation above successfully including the focused Prettier check, and
+  confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
+  queued in the merge queue at position 12 before publishing this issue-state
+  refresh.
+- Current Codex pass (2026-06-07T15:15+02:00): fetched current `origin/main`
   (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
   scoped validation above successfully including the focused Prettier check, and
   confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:54:59.920Z
+claimed_at: 2026-06-07T13:05:29.413Z
 pr: 1290
 ---
 
@@ -260,3 +260,9 @@ machinery and are out of scope here.
   allow the branch update, pushed the refreshed issue state to `symphony/1905`,
   and re-enabled GitHub auto-merge for the refreshed head while required checks
   are pending so GitHub can queue it after checks pass.
+- Current Codex pass (2026-06-07T15:08+02:00): fetched current `origin/main`
+  (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
+  scoped validation above successfully including the focused Prettier check, and
+  confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
+  queued in the merge queue at position 12 before publishing this issue-state
+  refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:11:35.413Z
+claimed_at: 2026-06-07T10:34:59.352Z
 pr: 1290
 ---
 
@@ -157,3 +157,7 @@ machinery and are out of scope here.
   current main (`28c668ab4`), reran the scoped validation above successfully,
   and confirmed the previously tracked ready PR `#1284` is already merged.
 - Opened ready follow-up PR `#1290` for the Attempt 30 issue-state refresh.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully,
+  and confirmed ready PR `#1290` is open, non-draft, mergeable, and green before
+  publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:09:29.226Z
+claimed_at: 2026-06-07T12:16:29.270Z
 pr: 1290
 ---
 
@@ -226,3 +226,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, and queued in the merge queue at
   position 17 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 18 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:48:00.247Z
+claimed_at: 2026-06-07T12:54:59.920Z
 pr: 1290
 ---
 
@@ -251,3 +251,8 @@ machinery and are out of scope here.
   confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
   queued in the merge queue at position 16 before publishing this issue-state
   refresh.
+- Current Codex pass (2026-06-07T14:57+02:00): fetched current `origin/main`
+  (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
+  scoped validation above successfully including the focused Prettier check, and
+  confirmed ready PR `#1290` is open/non-draft, mergeable, and queued in the
+  merge queue at position 13 while the final equivalence gate is still queued.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:40:59.252Z
+claimed_at: 2026-06-07T11:48:29.305Z
 pr: 1290
 ---
 
@@ -206,3 +206,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 17 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 15 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:55:30.508Z
+claimed_at: 2026-06-07T12:01:59.296Z
 pr: 1290
 ---
 
@@ -216,3 +216,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 16 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft and mergeable with required checks still completing
+  before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:27:59.472Z
+claimed_at: 2026-06-07T11:34:29.249Z
 pr: 1290
 ---
 
@@ -196,3 +196,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 17 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 18 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:16:29.270Z
+claimed_at: 2026-06-07T12:22:59.813Z
 pr: 1290
 ---
 
@@ -231,3 +231,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 18 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft and mergeable with required checks still completing
+  before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T13:13:30.221Z
+claimed_at: 2026-06-07T13:19:59.758Z
 pr: 1290
 ---
 
@@ -272,3 +272,13 @@ machinery and are out of scope here.
   confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
   queued in the merge queue at position 12 before publishing this issue-state
   refresh.
+- Current Codex pass (2026-06-07T15:22+02:00): fetched current `origin/main`
+  (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
+  scoped validation above successfully including the focused Prettier check, and
+  confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
+  queued in the merge queue at position 12 before publishing this issue-state
+  refresh.
+- Final Codex publish pass (2026-06-07T15:23+02:00): dequeued PR `#1290`, pushed
+  this refreshed issue state to `symphony/1905`, and re-enabled GitHub
+  auto-merge for the refreshed head while required checks are pending so GitHub
+  can queue it after checks pass.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:34:29.249Z
+claimed_at: 2026-06-07T11:40:59.252Z
 pr: 1290
 ---
 
@@ -201,3 +201,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 18 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 17 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:20:58.960Z
+claimed_at: 2026-06-07T11:27:59.472Z
 pr: 1290
 ---
 
@@ -191,3 +191,8 @@ machinery and are out of scope here.
   and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
   queued in the merge queue at position 19 before publishing this issue-state
   refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 17 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:13:29.182Z
+claimed_at: 2026-06-07T11:20:58.960Z
 pr: 1290
 ---
 
@@ -186,3 +186,8 @@ machinery and are out of scope here.
   ancestor of `symphony/1905`, reran the scoped validation above successfully,
   and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and green
   before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully,
+  and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
+  queued in the merge queue at position 19 before publishing this issue-state
+  refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -256,3 +256,7 @@ machinery and are out of scope here.
   scoped validation above successfully including the focused Prettier check, and
   confirmed ready PR `#1290` is open/non-draft, mergeable, and queued in the
   merge queue at position 13 while the final equivalence gate is still queued.
+- Final Codex publish pass (2026-06-07T15:01+02:00): dequeued PR `#1290` to
+  allow the branch update, pushed the refreshed issue state to `symphony/1905`,
+  and re-enabled GitHub auto-merge for the refreshed head while required checks
+  are pending so GitHub can queue it after checks pass.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:51:59.647Z
+claimed_at: 2026-06-07T10:58:59.062Z
 pr: 1290
 ---
 
@@ -169,3 +169,7 @@ machinery and are out of scope here.
   ancestor of `symphony/1905`, reran the scoped validation above successfully,
   and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and queued
   in the merge queue at position 17 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully,
+  and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and queued
+  in the merge queue at position 19 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:05:59.366Z
+claimed_at: 2026-06-07T11:13:29.182Z
 pr: 1290
 ---
 
@@ -182,3 +182,7 @@ machinery and are out of scope here.
   state to `symphony/1905`, and re-enabled GitHub auto-merge for the refreshed
   head while required checks are pending so GitHub can queue it after checks
   pass.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully,
+  and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and green
+  before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:34:59.352Z
+claimed_at: 2026-06-07T10:43:59.334Z
 pr: 1290
 ---
 
@@ -161,3 +161,7 @@ machinery and are out of scope here.
   ancestor of `symphony/1905`, reran the scoped validation above successfully,
   and confirmed ready PR `#1290` is open, non-draft, mergeable, and green before
   publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main`, confirmed `symphony/1905`
+  remains based on it, reran the scoped validation above successfully, and
+  confirmed ready PR `#1290` is open/non-draft and mergeable with required
+  checks still completing before this issue-state refresh is published.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:43:59.334Z
+claimed_at: 2026-06-07T10:51:59.647Z
 pr: 1290
 ---
 
@@ -165,3 +165,7 @@ machinery and are out of scope here.
   remains based on it, reran the scoped validation above successfully, and
   confirmed ready PR `#1290` is open/non-draft and mergeable with required
   checks still completing before this issue-state refresh is published.
+- Current Codex pass: fetched current `origin/main`, confirmed it remains an
+  ancestor of `symphony/1905`, reran the scoped validation above successfully,
+  and confirmed ready PR `#1290` is open/non-draft, clean, mergeable, and queued
+  in the merge queue at position 17 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:40:00.034Z
+claimed_at: 2026-06-07T12:48:00.247Z
 pr: 1290
 ---
 
@@ -245,8 +245,9 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 15 before publishing this issue-state refresh.
-- Current Codex pass: fetched current `origin/main` (`767e64754`), confirmed it
-  remains an ancestor of `symphony/1905`, reran the scoped validation above
-  successfully including the focused Prettier check, and confirmed ready PR
-  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
-  queue at position 16 before publishing this issue-state refresh.
+- Current Codex pass (2026-06-07T14:50+02:00): fetched current `origin/main`
+  (`767e64754`), confirmed it remains an ancestor of `symphony/1905`, reran the
+  scoped validation above successfully including the focused Prettier check, and
+  confirmed ready PR `#1290` is open/non-draft, clean, mergeable, green, and
+  queued in the merge queue at position 16 before publishing this issue-state
+  refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:48:29.305Z
+claimed_at: 2026-06-07T11:55:30.508Z
 pr: 1290
 ---
 
@@ -211,3 +211,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 15 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 16 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -1,7 +1,7 @@
 ---
 id: 1905
 title: "standalone: native Reflect.get/set/has/deleteProperty over $Object"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:41:35.010Z
+claimed_at: 2026-06-07T10:11:35.413Z
 pr: 1284
 ---
 
@@ -153,3 +153,6 @@ machinery and are out of scope here.
 - Final Codex publish pass: dequeued PR `#1284`, pushed the refreshed issue
   state to `symphony/1905`, and re-enabled GitHub auto-merge for the refreshed
   head while required checks are pending.
+- Attempt 30: fetched current `origin/main`, fast-forwarded `symphony/1905` to
+  current main (`28c668ab4`), reran the scoped validation above successfully,
+  and confirmed the previously tracked ready PR `#1284` is already merged.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:01:59.296Z
+claimed_at: 2026-06-07T12:09:29.226Z
 pr: 1290
 ---
 
@@ -221,3 +221,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft and mergeable with required checks still completing
   before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`28c668ab4`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, and queued in the merge queue at
+  position 17 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -1,7 +1,7 @@
 ---
 id: 1905
 title: "standalone: native Reflect.get/set/has/deleteProperty over $Object"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -19,7 +19,7 @@ test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
 claimed_at: 2026-06-07T10:11:35.413Z
-pr: 1284
+pr: 1290
 ---
 
 # #1905 — Standalone native Reflect object subset
@@ -156,3 +156,4 @@ machinery and are out of scope here.
 - Attempt 30: fetched current `origin/main`, fast-forwarded `symphony/1905` to
   current main (`28c668ab4`), reran the scoped validation above successfully,
   and confirmed the previously tracked ready PR `#1284` is already merged.
+- Opened ready follow-up PR `#1290` for the Attempt 30 issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:22:59.813Z
+claimed_at: 2026-06-07T12:32:59.692Z
 pr: 1290
 ---
 
@@ -240,3 +240,8 @@ machinery and are out of scope here.
   `symphony/1905`, reran the scoped validation above successfully including the
   focused Prettier check, and kept ready PR `#1290` as the tracked in-review PR
   before publishing this refreshed branch.
+- Current Codex pass: fetched current `origin/main` (`767e64754`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 15 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -18,7 +18,7 @@ related: [1472, 1466, 1629, 1888]
 test262_bucket: standalone-reflect-refusal
 test262_count: 309
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:32:59.692Z
+claimed_at: 2026-06-07T12:40:00.034Z
 pr: 1290
 ---
 
@@ -245,3 +245,8 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
   queue at position 15 before publishing this issue-state refresh.
+- Current Codex pass: fetched current `origin/main` (`767e64754`), confirmed it
+  remains an ancestor of `symphony/1905`, reran the scoped validation above
+  successfully including the focused Prettier check, and confirmed ready PR
+  `#1290` is open/non-draft, clean, mergeable, green, and queued in the merge
+  queue at position 16 before publishing this issue-state refresh.

--- a/plan/issues/1905-standalone-native-reflect-object-subset.md
+++ b/plan/issues/1905-standalone-native-reflect-object-subset.md
@@ -236,3 +236,7 @@ machinery and are out of scope here.
   successfully including the focused Prettier check, and confirmed ready PR
   `#1290` is open/non-draft and mergeable with required checks still completing
   before publishing this issue-state refresh.
+- Post-merge Codex pass: merged current `origin/main` (`767e64754`) into
+  `symphony/1905`, reran the scoped validation above successfully including the
+  focused Prettier check, and kept ready PR `#1290` as the tracked in-review PR
+  before publishing this refreshed branch.


### PR DESCRIPTION
## Summary

- record the current #1905 scoped validation and PR #1290 state
- keep the issue in review for the PR-status poller
- preserve the standalone Reflect implementation that is already on main

## Validation

- `pnpm test tests/issue-1905.test.ts`
- `pnpm test tests/issue-1472.test.ts -t "unsupported Reflect"`
- `pnpm exec prettier --check src/codegen/object-runtime.ts src/codegen/expressions/calls.ts tests/issue-1472.test.ts tests/issue-1905.test.ts`
