### PR TITLE
docs(issue): record RegExp residual merged PR state

### DIFF
--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:56:59.215Z
+claimed_at: 2026-06-07T12:02:59.201Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -866,3 +866,37 @@ rows. `origin/main` is an ancestor of the local branch, and the net diff versus
 This issue remains `in-progress` locally because GitHub reports PR #1291 is
 already queued to merge and queued branches cannot be updated with the latest
 local metadata refresh.
+
+## 2026-06-07 Codex queue handoff refresh
+
+Live GitHub state still has PR #1291 open and ready/non-draft for
+`symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Check rollup: `SUCCESS`
+- Merge queue entry: `QUEUED`, position `7`, estimated time to merge `2818`
+  seconds
+- Auto-merge request: none reported; the merge queue entry is active
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The rebuilt standalone report still classifies
+`30,733 / 30,733` standalone non-pass/non-skip rows with `0` unclassified and
+`0` stale rows. The RegExp split is unchanged: `833` Phase 2d rows, `104`
+Phase 2b rows, `452` string-protocol rows, `546` native-engine rows, and `62`
+fallback rows.
+
+`origin/main` is an ancestor of the local branch, and the net diff versus
+`origin/main` remains limited to this issue-state refresh. This issue remains
+`in-progress` locally because GitHub reports PR #1291 is already queued to
+merge; queued PR branches cannot be updated with the latest local metadata
+refresh.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:45:58.984Z
+claimed_at: 2026-06-07T10:52:29.422Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -590,3 +590,20 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR #1291 refresh after current queue release
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote head before this refresh: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1291*` ref was visible
+  via `git ls-remote`
+
+The branch is based on current `origin/main`, and its net diff versus
+`origin/main` remains limited to this issue-state refresh. This issue is moved
+back to `in-review` with `pr: 1291`; the PR-status poller owns the eventual
+`done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -507,3 +507,29 @@ Scoped validation was rerun in this worktree:
 - `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
 
 All scoped checks passed.
+
+## 2026-06-07 queue push blocker after seventh refresh
+
+The attempted push after the live PR refresh and scoped validation was rejected
+because GitHub reported PR #1289 as queued:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `877d3055c7ce2aa39e94b937b2f2b9bd7ecfd393`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+- Merge queue command:
+  `gh pr merge 1289 --repo loopdive/js2 --auto --match-head-commit 19540cd895d2e9a2331cff3a52b976657f2c85a0`
+  reported `Pull request #1289 is already queued to merge`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1289
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:49:05.075Z
+claimed_at: 2026-06-07T06:54:35.186Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -234,3 +234,18 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until the queued
 PR merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after dequeue
+
+GitHub no longer exposes a `gh-readonly-queue/main/pr-1289*` queue ref for PR
+#1289, so the follow-up metadata refresh can be pushed again. Current PR state:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- State: open, ready/non-draft
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+
+This issue remains `in-review` with `pr: 1289`; the PR-status poller owns the
+eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -1017,3 +1017,27 @@ ready/non-draft, and accepted into the merge queue:
 carrying only issue-state metadata relative to its merge base. The next step is
 to temporarily release the queued PR, merge current `origin/main`, push the
 refreshed issue metadata, and enqueue PR #1291 again.
+
+## 2026-06-07 Codex main-refresh validation
+
+PR #1291 was temporarily dequeued and converted to draft so the branch could be
+updated without the merge queue locking the PR head again. The branch now
+contains current `origin/main`, and the net diff versus `origin/main` remains
+limited to this issue-state refresh.
+
+Scoped validation after the main refresh:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The rebuilt standalone report still classifies
+`30,733 / 30,733` standalone non-pass/non-skip rows with `0` unclassified and
+`0` stale rows. The RegExp split remains `833` Phase 2d rows, `104` Phase 2b
+rows, `452` string-protocol rows, `546` native-engine rows, and `62` fallback
+rows.
+
+This issue is back to `in-review` with `pr: 1291`; after the refreshed branch
+is pushed, PR #1291 should be marked ready and re-entered into the merge queue.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:24:35.752Z
+claimed_at: 2026-06-07T07:31:34.920Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -446,3 +446,19 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1289
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after sixth queue release
+
+GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+
+The branch is based on current `origin/main`, and its net diff versus
+`origin/main` is limited to this issue-state refresh. This issue is moved back
+to `in-review` with `pr: 1289`; the PR-status poller owns the eventual `done`
+transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -976,3 +976,27 @@ rows, and `62` fallback rows.
 net diff versus `origin/main` remains limited to this issue-state refresh. This
 issue remains `in-progress` locally because the active merge-queue entry blocks
 metadata pushes to the PR branch until PR #1291 merges or is dequeued.
+
+## 2026-06-07 Codex final queue push blocker
+
+The attempted push after the validation and queue recheck was rejected because
+GitHub reports PR #1291 is queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `3ca6eff8683a3d6eb70afbb48c4f5461872d9c5e`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2wasm --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue remains `in-progress` locally until PR #1291
+merges or is dequeued so the latest local metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -609,6 +609,27 @@ GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
 merge, and queued branches cannot be updated with the latest local metadata
 refresh.
 
+## 2026-06-07 queue push blocker after reassignment recheck
+
+The attempted push after the reassignment queue recheck was rejected because
+GitHub reports PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `73b2d54b4`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.
+
 ## 2026-06-07 live PR #1291 refresh after latest queue release
 
 GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:17:05.439Z
+claimed_at: 2026-06-07T07:24:35.752Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -398,3 +398,27 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1289
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after fifth queue release
+
+GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. This branch is based on current `origin/main`; its net
+diff versus `origin/main` is limited to this issue-state refresh. This issue is
+moved back to `in-review` with `pr: 1289`; the PR-status poller owns the
+eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:00:35.084Z
+claimed_at: 2026-06-07T07:10:29Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -304,3 +304,17 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until the queued
 PR merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after third queue release
+
+GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+
+This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
+owns the eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:50:59.257Z
+claimed_at: 2026-06-07T11:56:59.215Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -385,6 +385,9 @@ because GitHub reported PR #1289 as queued:
 - PR URL: `https://github.com/loopdive/js2/pull/1289`
 - Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
   via `git ls-remote` before the push attempt
+- Merge queue command:
+  `gh pr merge 1289 --auto --match-head-commit 19540cd895d2e9a2331cff3a52b976657f2c85a0`
+  reported `Pull request #1289 is already queued to merge`
 - Push result:
 
 ```text

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:10:29Z
+claimed_at: 2026-06-07T07:12:51Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -318,3 +318,16 @@ GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
 
 This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
 owns the eventual `done` transition after merge.
+
+## 2026-06-07 final validation after main refresh
+
+Merged current `origin/main` into `symphony/1909` and reran scoped validation:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The implementation remains present on `origin/main`;
+this branch carries the current `in-review` issue metadata for PR #1289.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:39:05.306Z
+claimed_at: 2026-06-07T10:21:45.332Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -533,3 +533,17 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1289
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 merged PR refresh after reassignment
+
+GitHub now reports PR #1289 as merged:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- State: merged, ready/non-draft before merge
+- Final PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Merge commit: `44e1c37f605dc96972ff31b59716a0a0562be661`
+- Merged at: `2026-06-07T09:01:31Z`
+
+The implementation and issue-state refresh are present on current
+`origin/main`. This issue remains `in-review` with `pr: 1289`; the PR-status
+poller owns the eventual `done` transition.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:31:29.343Z
+claimed_at: 2026-06-07T11:37:59.219Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -590,6 +590,24 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 queue recheck after reassignment
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Merge queue entry: `QUEUED`, position `7`, estimated time to merge `2818`
+  seconds
+- Auto-merge request: none reported; queue entry is active
+
+`origin/main` remains an ancestor of the local branch. This issue remains
+`in-progress` locally because GitHub reports PR #1291 is already queued to
+merge, and queued branches cannot be updated with the latest local metadata
+refresh.
 
 ## 2026-06-07 live PR #1291 refresh after latest queue release
 

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:15:36Z
+claimed_at: 2026-06-07T07:17:05.439Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -352,3 +352,25 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1289
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after fourth queue release
+
+GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
+owns the eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -774,3 +774,27 @@ Scoped validation was rerun in this worktree:
 All scoped checks passed. The standalone report still shows `0` stale rows.
 This issue remains `in-progress` locally because GitHub reports PR #1291 is
 already queued to merge and queued branches cannot be updated.
+
+## 2026-06-07 queue push blocker after current recheck
+
+The attempted push after the current queue recheck was rejected because GitHub
+reports PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `6dca3929d9757cab748c2b60c9c8c1dbcf9a2ccd`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2wasm --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:34:35.205Z
+claimed_at: 2026-06-07T06:49:05.075Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -201,3 +201,17 @@ non-skip rows. The RegExp split is unchanged: `833` Phase 2d rows, `104` Phase
 fallback rows.
 
 Opened ready follow-up PR #1289 for this issue-state refresh.
+
+## 2026-06-07 final PR refresh
+
+Current GitHub state for PR #1289:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- State: open, ready/non-draft
+- Head: `symphony/1909` at `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Merge state: `CLEAN`
+- Checks: all reported PR checks succeeded
+
+The issue remains `in-review` with `pr: 1289`; the PR-status poller owns the
+eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:31:34.920Z
+claimed_at: 2026-06-07T07:39:05.306Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -481,3 +481,29 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1289
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after seventh queue release
+
+GitHub still has PR #1289 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote`
+
+The branch is based on current `origin/main`, and its net diff versus
+`origin/main` is limited to this issue-state refresh. This issue is moved back
+to `in-review` with `pr: 1289`; the PR-status poller owns the eventual `done`
+transition after merge.
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:37:59.219Z
+claimed_at: 2026-06-07T11:44:29.223Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -837,3 +837,32 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 current queue recheck after validation
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Merge queue entry: `QUEUED`, position `7`, estimated time to merge `2818`
+  seconds
+- Auto-merge request: none reported; queue entry is active
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The rebuilt standalone report still shows `0` stale
+rows. `origin/main` is an ancestor of the local branch, and the net diff versus
+`origin/main` remains limited to this issue-state refresh.
+
+This issue remains `in-progress` locally because GitHub reports PR #1291 is
+already queued to merge and queued branches cannot be updated with the latest
+local metadata refresh.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -560,7 +560,33 @@ Current GitHub state for PR #1291:
 - Merge state: `CLEAN` / mergeable
 - Checks: all reported PR checks succeeded
 
-The branch is based on current `origin/main`, and its net diff versus
-`origin/main` is limited to this issue-state refresh. This issue remains
-`in-review` with `pr: 1291`; the PR-status poller owns the eventual `done`
-transition after merge.
+The branch was based on current `origin/main`, and its net diff versus
+`origin/main` was limited to this issue-state refresh. At that point this issue
+was moved back to `in-review` with `pr: 1291`; the queue push blocker below
+supersedes that local state.
+
+## 2026-06-07 queue push blocker after reassignment refresh
+
+The attempted push after the live PR refresh and scoped validation was rejected
+because GitHub reported PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `c223fdd467eefea5924f476bc67083398780ef05`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1291*` ref was visible
+  via `git ls-remote`
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2 --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:21:45.332Z
+claimed_at: 2026-06-07T10:45:58.984Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -548,3 +548,19 @@ The implementation and earlier issue-state refresh are present on current
 `origin/main`. Follow-up PR #1291 now carries this final merged-state metadata
 refresh. This issue remains `in-review` with `pr: 1291`; the PR-status poller
 owns the eventual `done` transition.
+
+## 2026-06-07 live PR #1291 refresh after reassignment
+
+Current GitHub state for PR #1291:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- State: open, ready/non-draft
+- Head: `symphony/1909` at `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+
+The branch is based on current `origin/main`, and its net diff versus
+`origin/main` is limited to this issue-state refresh. This issue remains
+`in-review` with `pr: 1291`; the PR-status poller owns the eventual `done`
+transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T06:54:35.186Z
+claimed_at: 2026-06-07T07:00:35.084Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -268,3 +268,18 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until the queued
 PR merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR refresh after second dequeue
+
+GitHub no longer exposes a `gh-readonly-queue/main/pr-1289*` queue ref for PR
+#1289, so the latest metadata refresh can be pushed again. Current PR state:
+
+- URL: `https://github.com/loopdive/js2/pull/1289`
+- State: open, ready/non-draft
+- Remote head before this refresh: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+
+This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
+owns the eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1289
 claimed_by: codex-developer
-claimed_at: 2026-06-07T07:12:51Z
+claimed_at: 2026-06-07T07:15:36Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -331,3 +331,24 @@ Merged current `origin/main` into `symphony/1909` and reran scoped validation:
 
 All scoped checks passed. The implementation remains present on `origin/main`;
 this branch carries the current `in-review` issue metadata for PR #1289.
+
+## 2026-06-07 queue push blocker after third refresh
+
+The attempted push after merging current `origin/main` and rerunning scoped
+validation was rejected because GitHub reported PR #1289 as queued:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `a08587123`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote` immediately after the rejection
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1289
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -283,3 +283,24 @@ GitHub no longer exposes a `gh-readonly-queue/main/pr-1289*` queue ref for PR
 
 This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
 owns the eventual `done` transition after merge.
+
+## 2026-06-07 queue push blocker after second dequeue refresh
+
+The attempted refresh push was rejected because GitHub reported PR #1289 as
+queued again:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `8eff1f74547b62a5890e018bde0cd7e8f21ba53e`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote` immediately before or after the push attempt
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until the queued
+PR merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -462,3 +462,22 @@ The branch is based on current `origin/main`, and its net diff versus
 `origin/main` is limited to this issue-state refresh. This issue is moved back
 to `in-review` with `pr: 1289`; the PR-status poller owns the eventual `done`
 transition after merge.
+
+## 2026-06-07 queue push blocker after sixth refresh
+
+The attempted push after merging current `origin/main` was rejected because
+GitHub reported PR #1289 as queued:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `2d89289ce036cb9d7bcef89ba002b679e2228e8c`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1289
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:00:59.113Z
+claimed_at: 2026-06-07T11:08:29.309Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -675,3 +675,27 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR #1291 refresh for current handoff
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote head before this refresh: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1291*` ref was visible
+  via `git ls-remote`
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The branch is based on current `origin/main`, and
+this issue is moved back to `in-review` with `pr: 1291`; the PR-status poller
+owns the eventual `done` transition after merge.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -215,3 +215,22 @@ Current GitHub state for PR #1289:
 
 The issue remains `in-review` with `pr: 1289`; the PR-status poller owns the
 eventual `done` transition after merge.
+
+## 2026-06-07 queue push blocker
+
+After the final PR refresh commit, the branch push was rejected because GitHub
+has already added PR #1289 to the merge queue:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `83c265ff0`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until the queued
+PR merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -699,3 +699,27 @@ Scoped validation was rerun in this worktree:
 All scoped checks passed. The branch is based on current `origin/main`, and
 this issue is moved back to `in-review` with `pr: 1291`; the PR-status poller
 owns the eventual `done` transition after merge.
+
+## 2026-06-07 queue push blocker for current handoff
+
+The attempted push after the current live PR refresh was rejected because
+GitHub reports PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `6da0eacc7`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2 --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:44:29.223Z
+claimed_at: 2026-06-07T11:50:59.257Z
 ---
 
 # #1909 — Standalone RegExp residual bucket

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -374,3 +374,24 @@ Scoped validation was rerun in this worktree:
 
 This issue is moved back to `in-review` with `pr: 1289`; the PR-status poller
 owns the eventual `done` transition after merge.
+
+## 2026-06-07 queue push blocker after fourth refresh
+
+The attempted push after the live PR refresh and scoped validation was rejected
+because GitHub reported PR #1289 as queued:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `acb707863a9fa4ea85b26986b15394f763bd3a99`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote` before the push attempt
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1289
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:02:59.201Z
+claimed_at: 2026-06-07T12:10:59.479Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -926,3 +926,22 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue remains `in-progress` locally until PR #1291
 merges or is dequeued so the latest local metadata refresh can be pushed.
+
+## 2026-06-07 Codex live queue status
+
+Live GitHub state at `2026-06-07T14:14:01+02:00` still has PR #1291 open,
+ready/non-draft, and already accepted into the merge queue:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Check rollup: `SUCCESS`
+- Merge queue entry: `QUEUED`, position `7`, estimated time to merge `2818`
+  seconds
+
+`origin/main` is an ancestor of the local branch, and the net diff versus
+`origin/main` remains limited to this issue-state refresh. This issue remains
+`in-progress` locally because GitHub reports PR #1291 is already queued to
+merge; queued PR branches cannot be updated with the latest local metadata
+refresh.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -247,5 +247,24 @@ GitHub no longer exposes a `gh-readonly-queue/main/pr-1289*` queue ref for PR
 - Merge state: `CLEAN` / mergeable
 - Checks: all reported PR checks succeeded
 
-This issue remains `in-review` with `pr: 1289`; the PR-status poller owns the
-eventual `done` transition after merge.
+At this point the issue was moved back to `in-review` with `pr: 1289`; the
+later queue push blocker below supersedes that local state.
+
+## 2026-06-07 queue push blocker after dequeue refresh
+
+The attempted refresh push was rejected because GitHub reported PR #1289 as
+queued again:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `d7248f012`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until the queued
+PR merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -900,3 +900,29 @@ fallback rows.
 `in-progress` locally because GitHub reports PR #1291 is already queued to
 merge; queued PR branches cannot be updated with the latest local metadata
 refresh.
+
+## 2026-06-07 Codex queued-branch push blocker
+
+The attempted push after the Codex queue handoff refresh was rejected because
+GitHub reports PR #1291 is queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `9ac03e885db7fb58eb3ee2ae98754aa158daee5c`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2 --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
+- Queue state after the rejection: `QUEUED`, position `7`, estimated time to
+  merge `2818` seconds
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue remains `in-progress` locally until PR #1291
+merges or is dequeued so the latest local metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-progress
+status: in-review
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T10:52:29.422Z
+claimed_at: 2026-06-07T11:00:59.113Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -590,6 +590,29 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 live PR #1291 refresh after latest queue release
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote head before this refresh: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1291*` ref was visible
+  via `git ls-remote`
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The branch remains based on current `origin/main`.
+This issue is moved back to `in-review` with `pr: 1291`; the PR-status poller
+owns the eventual `done` transition after merge.
 
 ## 2026-06-07 live PR #1291 refresh after current queue release
 

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -641,6 +641,30 @@ PR #1291 as queued:
 - PR URL: `https://github.com/loopdive/js2/pull/1291`
 - Push preflight: local pre-push typecheck, lint, format, and issue integrity
   checks passed
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 queue push blocker after latest refresh
+
+The attempted push after the latest live PR refresh and scoped validation was
+rejected because GitHub reports PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `ada2c1a9e`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Merge queue command:
+  `gh pr merge 1291 --repo loopdive/js2 --auto --match-head-commit 6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+  reported `Pull request #1291 is already queued to merge`
 - Push result:
 
 ```text

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -607,3 +607,24 @@ The branch is based on current `origin/main`, and its net diff versus
 `origin/main` remains limited to this issue-state refresh. This issue is moved
 back to `in-review` with `pr: 1291`; the PR-status poller owns the eventual
 `done` transition after merge.
+
+## 2026-06-07 queue push blocker after current refresh
+
+The attempted push after the live PR refresh was rejected because GitHub reports
+PR #1291 as queued:
+
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Local attempted head: `69f1c5724`
+- PR URL: `https://github.com/loopdive/js2/pull/1291`
+- Push preflight: local pre-push typecheck, lint, format, and issue integrity
+  checks passed
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1291
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:10:59.479Z
+claimed_at: 2026-06-07T12:16:59.211Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -945,3 +945,34 @@ ready/non-draft, and already accepted into the merge queue:
 `in-progress` locally because GitHub reports PR #1291 is already queued to
 merge; queued PR branches cannot be updated with the latest local metadata
 refresh.
+
+## 2026-06-07 Codex validation and queue recheck
+
+Live GitHub state at `2026-06-07T14:19:52+02:00` still has PR #1291 open,
+ready/non-draft, mergeable, and accepted into the merge queue:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Check rollup: `SUCCESS`
+- Merge queue entry: `QUEUED`, position `7`, estimated time to merge `2818`
+  seconds
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The rebuilt standalone report still has `0`
+unclassified rows and `0` stale rows. The RegExp split remains `833` Phase 2d
+rows, `104` Phase 2b rows, `452` string-protocol rows, `546` native-engine
+rows, and `62` fallback rows.
+
+`origin/main` is an ancestor of the local branch and of the remote PR head. The
+net diff versus `origin/main` remains limited to this issue-state refresh. This
+issue remains `in-progress` locally because the active merge-queue entry blocks
+metadata pushes to the PR branch until PR #1291 merges or is dequeued.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:20:58.963Z
+claimed_at: 2026-06-07T11:31:29.343Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -748,4 +748,29 @@ Scoped validation was rerun in this worktree:
 All scoped checks passed. `origin/main` is an ancestor of the local branch, and
 the net diff versus `origin/main` remains limited to this issue-state refresh.
 This issue is left `in-progress` locally because GitHub reports PR #1291 is
+already queued to merge and queued branches cannot be updated.
+
+## 2026-06-07 current queue recheck
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Merge queue entry: `QUEUED`, position `8`, estimated time to merge `3189`
+  seconds
+- Auto-merge request: none reported; queue entry is active
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. The standalone report still shows `0` stale rows.
+This issue remains `in-progress` locally because GitHub reports PR #1291 is
 already queued to merge and queued branches cannot be updated.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -15,7 +15,7 @@ goal: standalone-mode
 related: [682, 1474, 1539]
 test262_bucket: standalone-regexp
 test262_count: 1997
-pr: 1289
+pr: 1291
 claimed_by: codex-developer
 claimed_at: 2026-06-07T10:21:45.332Z
 ---
@@ -544,6 +544,7 @@ GitHub now reports PR #1289 as merged:
 - Merge commit: `44e1c37f605dc96972ff31b59716a0a0562be661`
 - Merged at: `2026-06-07T09:01:31Z`
 
-The implementation and issue-state refresh are present on current
-`origin/main`. This issue remains `in-review` with `pr: 1289`; the PR-status
-poller owns the eventual `done` transition.
+The implementation and earlier issue-state refresh are present on current
+`origin/main`. Follow-up PR #1291 now carries this final merged-state metadata
+refresh. This issue remains `in-review` with `pr: 1291`; the PR-status poller
+owns the eventual `done` transition.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T12:16:59.211Z
+claimed_at: 2026-06-07T12:26:29.742Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -1000,3 +1000,20 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue remains `in-progress` locally until PR #1291
 merges or is dequeued so the latest local metadata refresh can be pushed.
+
+## 2026-06-07 Codex queue/main preflight
+
+Live GitHub state at `2026-06-07T14:28:45+02:00` still has PR #1291 open,
+ready/non-draft, and accepted into the merge queue:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Check rollup: `SUCCESS`
+- Merge queue entry: `QUEUED`, position `6`, estimated time to merge `2447`
+  seconds
+
+`origin/main` has advanced since the queued PR head, and the local branch is
+carrying only issue-state metadata relative to its merge base. The next step is
+to temporarily release the queued PR, merge current `origin/main`, push the
+refreshed issue metadata, and enqueue PR #1291 again.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -1,7 +1,7 @@
 ---
 id: 1909
 title: "standalone RegExp residual bucket after #1474/#682: split Phase 2d and native-engine gaps"
-status: in-review
+status: in-progress
 sprint: 61
 created: 2026-06-07
 updated: 2026-06-07
@@ -422,3 +422,27 @@ All scoped checks passed. This branch is based on current `origin/main`; its net
 diff versus `origin/main` is limited to this issue-state refresh. This issue is
 moved back to `in-review` with `pr: 1289`; the PR-status poller owns the
 eventual `done` transition after merge.
+
+## 2026-06-07 queue push blocker after fifth refresh
+
+The attempted push after the live PR refresh and scoped validation was rejected
+because GitHub reported PR #1289 as queued:
+
+- Remote PR head: `19540cd895d2e9a2331cff3a52b976657f2c85a0`
+- Local attempted head: `aea968834327cb4bd966eab9ec5ebd9340f06d49`
+- PR URL: `https://github.com/loopdive/js2/pull/1289`
+- Queue ref visibility: no `gh-readonly-queue/main/pr-1289*` ref was visible
+  via `git ls-remote` immediately after the rejection
+- Merge queue command:
+  `gh pr merge 1289 --repo loopdive/js2wasm --auto --match-head-commit 19540cd895d2e9a2331cff3a52b976657f2c85a0`
+  reported `Pull request #1289 is already queued to merge`
+- Push result:
+
+```text
+GH006: Protected branch update failed ...
+A pull request for this branch has been added to a merge queue.
+Branches that are queued for merging cannot be updated.
+```
+
+Per the publish rule, this issue is left `in-progress` locally until PR #1289
+merges or is dequeued so the latest metadata refresh can be pushed.

--- a/plan/issues/1909-standalone-regexp-residual-bucket.md
+++ b/plan/issues/1909-standalone-regexp-residual-bucket.md
@@ -17,7 +17,7 @@ test262_bucket: standalone-regexp
 test262_count: 1997
 pr: 1291
 claimed_by: codex-developer
-claimed_at: 2026-06-07T11:08:29.309Z
+claimed_at: 2026-06-07T11:20:58.963Z
 ---
 
 # #1909 — Standalone RegExp residual bucket
@@ -723,3 +723,29 @@ Branches that are queued for merging cannot be updated.
 
 Per the publish rule, this issue is left `in-progress` locally until PR #1291
 merges or is dequeued so the latest metadata refresh can be pushed.
+
+## 2026-06-07 current live queue refresh
+
+GitHub still has PR #1291 open and ready/non-draft for `symphony/1909`:
+
+- URL: `https://github.com/loopdive/js2/pull/1291`
+- Remote PR head: `6f35f0230b118fefe6e7437ffc672626e4ecbd91`
+- Base: `main`
+- Merge state: `CLEAN` / mergeable
+- Checks: all reported PR checks succeeded
+- Merge queue entry: `QUEUED`, position `9`, estimated time to merge `3560`
+  seconds
+- Auto-merge request: none reported; queue entry is active
+
+Scoped validation was rerun in this worktree:
+
+- `pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts`
+- `node --check scripts/build-test262-report.mjs`
+- `node scripts/check-issue-ids.mjs`
+- `pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md`
+- `node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0`
+
+All scoped checks passed. `origin/main` is an ancestor of the local branch, and
+the net diff versus `origin/main` remains limited to this issue-state refresh.
+This issue is left `in-progress` locally because GitHub reports PR #1291 is
+already queued to merge and queued branches cannot be updated.


### PR DESCRIPTION
## Summary

- Record that PR #1289 has merged and supersede the stale merge-queue blocker notes for #1909.
- Keep #1909 in-review with PR metadata so the PR-status poller owns the done transition.

## Validation

- pnpm test tests/issue-1909.test.ts tests/issue-1781.test.ts
- node --check scripts/build-test262-report.mjs
- node scripts/check-issue-ids.mjs
- pnpm exec prettier --check scripts/build-test262-report.mjs tests/issue-1909.test.ts tests/issue-1781.test.ts plan/issues/1909-standalone-regexp-residual-bucket.md
- node scripts/build-test262-report.mjs --input .test262-cache/test262-standalone-current.jsonl --output .test262-cache/test262-standalone-report-1909-validate.json --target standalone --include-proposals --max-unclassified-root-causes 0