### PR TITLE
feat(regexp): standalone matcher Phase 2b — word boundaries, backrefs, class compat (#1912)

### DIFF
--- a/plan/issues/1912-standalone-regexp-phase-2b-boundaries-backrefs-classes.md
+++ b/plan/issues/1912-standalone-regexp-phase-2b-boundaries-backrefs-classes.md
@@ -1,11 +1,12 @@
 ---
 id: 1912
 title: "standalone RegExp Phase 2b: word boundaries, backrefs, and character-class compatibility"
-status: ready
+status: done
 sprint: 61
 model: fable
 created: 2026-06-07
-updated: 2026-06-07
+updated: 2026-06-10
+completed: 2026-06-10
 priority: critical
 feasibility: hard
 reasoning_effort: high
@@ -50,3 +51,53 @@ Representative signatures from the 2026-06-07 standalone JSONL:
   standalone mode or move to a more precise residual bucket.
 - Refusals remain compile-time diagnostics with no JS-host RegExp imports.
 - Focused tests cover both pattern parsing and Wasm execution.
+
+## Implementation Notes (fable-rx-engine, 2026-06-10)
+
+Landed in the pure-WasmGC matcher (no host imports, dual-implemented in the
+TS reference VM and the Wasm VM, mirrored opcode-for-opcode):
+
+- **Word boundaries `\b` / `\B`** — new `ReOp.WBOUND [negated, 0]`
+  (§22.2.2.6 IsWordChar, ASCII). The Wasm arm reuses the dispatch-head `CH`
+  ("after" unit) and guards the "before" read so out-of-bounds neighbours
+  never trap; `matched = boundary ^ negated`.
+- **Backreferences `\1`…`\99` + `\k<name>`** — new `ReOp.BACKREF
+[groupIdx, ci]` (§22.2.2.9). An unset group matches empty (forward refs
+  like `\1(a)` work). The `i` flag compares ASCII-folded units (operand b),
+  consistent with `CHARI`. A pre-scan pass counts groups + named-group table
+  before the descent parse, because DecimalEscape classification needs the
+  WHOLE pattern's capture count and `\k<name>` may forward-reference.
+- **Annex B decimal-escape fallback** — `\N` beyond the capture count is a
+  legacy octal escape (`\05`, `(a)\2` → `\x02`); `\8` `\9` are identity.
+  `\cX` control letters and class-internal octals also land.
+- **Negated shorthand in classes** (`[\D]` `[\W]` `[\S]`) — complemented to
+  plain ranges at compile time (`complementRanges` over [0, 0xFFFF]) since the
+  run-length class table is a union of ranges.
+- **Annex B class hyphen compatibility** — `[\d-z]` / `[a-\d]` treat the `-`
+  adjacent to a shorthand as a LITERAL `-` (never a range). This also fixes a
+  silent 2a mis-parse where `[\d-z]` became the range U+002D–U+007A.
+- **Runtime SyntaxError lowering (the "class range out of order" bucket)** —
+  the S15.10.1/S15.10.2.15 families construct INVALID patterns via
+  `new RegExp("[b-ac-e]")` and assert a _catchable runtime SyntaxError_.
+  `compileStandaloneRegExpConstructor` now consults the compile-time host
+  `RegExp` constructor as a spec-exact validity oracle: host-rejected
+  (pattern, flags) pairs lower to `__new_SyntaxError` + `throw` + `unreachable`
+  at the construction site (§22.2.3.2), instead of failing the compile. The
+  `unreachable` makes the post-throw stack polymorphic so the claimed
+  `$NativeRegExp` result type validates without materializing a struct.
+  Host-VALID patterns outside the matcher subset keep the compile-time
+  narrowed refusal. Regex _literals_ keep the compile diagnostic (early
+  error). Invalid flags (`"gg"`) ride the same path.
+- **Quantified assertions** (`\b*`, `^*`) are genuine SyntaxErrors (verified
+  against V8) and now refuse at parse instead of emitting a zero-progress
+  SPLIT loop that would spin to the step cap.
+
+Known residual (pre-existing 2a behavior, unchanged): a star/plus whose body
+can match empty (`/(a?)*/`, `/\1*/` with an unset group) backtracks to the
+1M step cap and reports no-match instead of matching empty — needs an
+empty-progress check instruction (left to a matcher-hardening follow-up).
+
+Validation: `tests/regex-bytecode.test.ts` (#1912 dual-run corpus, 23
+patterns vs native), `tests/issue-1912-regex-phase2b.test.ts` (end-to-end
+standalone Wasm with empty import object + runtime-SyntaxError probes),
+existing 1539/1474/682 regex suites all green.

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -262,6 +262,11 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   const SNAP = 20; // ref array<i32> — caps snapshot
   const TMPI = 21; // i32 scratch
   const NEWSTACK = 22; // ref $__ReFrameArr — grown stack
+  const GS = 23; // i32 backref group start (#1912)
+  const GE = 24; // i32 backref group end (#1912)
+  const BLEN = 25; // i32 backref length (#1912)
+  const JJ = 26; // i32 backref compare cursor (#1912)
+  const C1 = 27; // i32 backref left-hand unit (#1912)
 
   // Helper: read prog[pc*3 + k]
   const readProg = (k: number): Instr[] => [
@@ -482,8 +487,28 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                                 op: "if",
                                 blockType: { kind: "empty" },
                                 then: anchorArm(/*eol*/ true),
-                                // op == MATCH (the only remaining op): return 1
-                                else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                else: [
+                                  { op: "local.get", index: OP },
+                                  { op: "i32.const", value: ReOp.WBOUND },
+                                  { op: "i32.eq" },
+                                  {
+                                    op: "if",
+                                    blockType: { kind: "empty" },
+                                    then: wboundArm(),
+                                    else: [
+                                      { op: "local.get", index: OP },
+                                      { op: "i32.const", value: ReOp.BACKREF },
+                                      { op: "i32.eq" },
+                                      {
+                                        op: "if",
+                                        blockType: { kind: "empty" },
+                                        then: backrefArm(),
+                                        // op == MATCH (the only remaining op): return 1
+                                        else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                      },
+                                    ],
+                                  },
+                                ],
                               },
                             ],
                           },
@@ -697,6 +722,243 @@ export function ensureRegexRun(ctx: CodegenContext): number {
     ];
   }
 
+  /** Push i32 1/0: is the unit in `local` a word char (`[0-9A-Za-z_]`,
+   *  §22.2.2.6 IsWordChar)? An out-of-bounds sentinel (-1) is non-word. */
+  function isWordInstrs(local: number): Instr[] {
+    return [
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x30 },
+      { op: "i32.ge_s" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x39 },
+      { op: "i32.le_s" },
+      { op: "i32.and" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x41 },
+      { op: "i32.ge_s" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x5a },
+      { op: "i32.le_s" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x61 },
+      { op: "i32.ge_s" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x7a },
+      { op: "i32.le_s" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+      { op: "local.get", index: local },
+      { op: "i32.const", value: 0x5f },
+      { op: "i32.eq" },
+      { op: "i32.or" },
+    ];
+  }
+
+  /** WBOUND (#1912): operand a = negated (`\B`). Mirrors the WBOUND arm in
+   *  regex/vm.ts. CH already holds the "after" unit ((sp<slen) ? data[soff+sp]
+   *  : -1, computed at dispatch entry); the "before" unit is loaded into TMPI.
+   *  matched = (isWord(before) != isWord(after)) ^ negated. */
+  function wboundArm(): Instr[] {
+    return [
+      // TMPI = sp>0 ? data[soff+sp-1] : -1
+      { op: "local.get", index: SP },
+      { op: "i32.const", value: 0 },
+      { op: "i32.gt_s" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: SDATA },
+          { op: "local.get", index: SOFF },
+          { op: "local.get", index: SP },
+          { op: "i32.add" },
+          { op: "i32.const", value: 1 },
+          { op: "i32.sub" },
+          { op: "array.get_u", typeIdx: strDataIdx },
+        ],
+        else: [{ op: "i32.const", value: -1 }],
+      },
+      { op: "local.set", index: TMPI },
+      ...isWordInstrs(TMPI),
+      ...isWordInstrs(CH),
+      { op: "i32.ne" },
+      { op: "local.get", index: A },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ne" },
+      { op: "i32.xor" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: PC },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: PC },
+        ],
+        else: [
+          { op: "i32.const", value: 1 },
+          { op: "local.set", index: FAILED },
+        ],
+      },
+    ];
+  }
+
+  /** Conditionally ASCII-fold the i32 on the stack when the ci operand (local
+   *  B) is non-zero. `foldCh` re-stages through TMPI, so staging here first is
+   *  safe. Used by the BACKREF compare loop. */
+  function foldChIf(): Instr[] {
+    return [
+      { op: "local.set", index: TMPI },
+      { op: "local.get", index: B },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "local.get", index: TMPI }, ...foldCh()],
+        else: [{ op: "local.get", index: TMPI }],
+      },
+    ];
+  }
+
+  /** BACKREF (#1912): operand a = group index, b = case-insensitive. Mirrors
+   *  the BACKREF arm in regex/vm.ts: an unset group matches empty (§22.2.2.9
+   *  step 3); otherwise the captured span is compared unit-by-unit at sp.
+   *  FAILED doubles as the mismatch flag for the compare loop. */
+  function backrefArm(): Instr[] {
+    return [
+      // gs = caps[2a]; ge = caps[2a+1]
+      { op: "local.get", index: CAPS },
+      { op: "local.get", index: A },
+      { op: "i32.const", value: 2 },
+      { op: "i32.mul" },
+      { op: "array.get", typeIdx: i32Arr },
+      { op: "local.set", index: GS },
+      { op: "local.get", index: CAPS },
+      { op: "local.get", index: A },
+      { op: "i32.const", value: 2 },
+      { op: "i32.mul" },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "array.get", typeIdx: i32Arr },
+      { op: "local.set", index: GE },
+      // unset group (either slot -1) matches empty: pc++
+      { op: "local.get", index: GS },
+      { op: "i32.const", value: 0 },
+      { op: "i32.lt_s" },
+      { op: "local.get", index: GE },
+      { op: "i32.const", value: 0 },
+      { op: "i32.lt_s" },
+      { op: "i32.or" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: PC },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: PC },
+        ],
+        else: [
+          // blen = ge - gs
+          { op: "local.get", index: GE },
+          { op: "local.get", index: GS },
+          { op: "i32.sub" },
+          { op: "local.set", index: BLEN },
+          // if sp + blen > slen: fail
+          { op: "local.get", index: SP },
+          { op: "local.get", index: BLEN },
+          { op: "i32.add" },
+          { op: "local.get", index: SLEN },
+          { op: "i32.gt_s" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "i32.const", value: 1 },
+              { op: "local.set", index: FAILED },
+            ],
+            else: [
+              // j = 0; unit-by-unit compare
+              { op: "i32.const", value: 0 },
+              { op: "local.set", index: JJ },
+              {
+                op: "block",
+                blockType: { kind: "empty" },
+                body: [
+                  {
+                    op: "loop",
+                    blockType: { kind: "empty" },
+                    body: [
+                      // if j >= blen: break (all units matched)
+                      { op: "local.get", index: JJ },
+                      { op: "local.get", index: BLEN },
+                      { op: "i32.ge_s" },
+                      { op: "br_if", depth: 1 },
+                      // c1 = fold?(data[soff+gs+j])
+                      { op: "local.get", index: SDATA },
+                      { op: "local.get", index: SOFF },
+                      { op: "local.get", index: GS },
+                      { op: "i32.add" },
+                      { op: "local.get", index: JJ },
+                      { op: "i32.add" },
+                      { op: "array.get_u", typeIdx: strDataIdx },
+                      ...foldChIf(),
+                      { op: "local.set", index: C1 },
+                      // c2 = fold?(data[soff+sp+j]); mismatch → FAILED=1, break
+                      { op: "local.get", index: SDATA },
+                      { op: "local.get", index: SOFF },
+                      { op: "local.get", index: SP },
+                      { op: "i32.add" },
+                      { op: "local.get", index: JJ },
+                      { op: "i32.add" },
+                      { op: "array.get_u", typeIdx: strDataIdx },
+                      ...foldChIf(),
+                      { op: "local.get", index: C1 },
+                      { op: "i32.ne" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: [
+                          { op: "i32.const", value: 1 },
+                          { op: "local.set", index: FAILED },
+                          { op: "br", depth: 2 },
+                        ],
+                      },
+                      // j++
+                      { op: "local.get", index: JJ },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: JJ },
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              // matched: sp += blen; pc++
+              { op: "local.get", index: FAILED },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: SP },
+                  { op: "local.get", index: BLEN },
+                  { op: "i32.add" },
+                  { op: "local.set", index: SP },
+                  { op: "local.get", index: PC },
+                  { op: "i32.const", value: 1 },
+                  { op: "i32.add" },
+                  { op: "local.set", index: PC },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+  }
+
   // Grow STACK if TOP == CAP_USED: double capacity, array.copy old -> new.
   function growStackIfFull(): Instr[] {
     return [
@@ -831,6 +1093,11 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       { name: "snap", type: i32ArrRef },
       { name: "tmpi", type: { kind: "i32" } },
       { name: "newstack", type: frameArrRef },
+      { name: "gs", type: { kind: "i32" } },
+      { name: "ge", type: { kind: "i32" } },
+      { name: "blen", type: { kind: "i32" } },
+      { name: "jj", type: { kind: "i32" } },
+      { name: "c1", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/src/codegen/regex/bytecode.ts
+++ b/src/codegen/regex/bytecode.ts
@@ -37,6 +37,14 @@ export enum ReOp {
   EOL = 8,
   /** `[CHARI, foldedCodeUnit, 0]` — match one code unit, ASCII-case-insensitive. */
   CHARI = 9,
+  /** `[WBOUND, negated, 0]` — assert a word boundary (`\b`; `\B` when
+   *  `negated`=1). Word characters are `[0-9A-Za-z_]` (§22.2.2.6 IsWordChar,
+   *  ASCII — Unicode case folding lands with the `u` flag in 2d). #1912. */
+  WBOUND = 10,
+  /** `[BACKREF, groupIdx, caseInsensitive]` — match the text captured by group
+   *  `groupIdx` (§22.2.2.9 BackreferenceMatcher). An unset group matches the
+   *  empty string. `caseInsensitive`=1 compares ASCII-folded units. #1912. */
+  BACKREF = 11,
 }
 
 /** Slots per instruction in the flat program array. */

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -98,6 +98,14 @@ class Emitter {
         // line terminator, not only at the end of input.
         this.emit(ReOp.EOL, this.multiline ? 1 : 0);
         return;
+      case "wordBoundary":
+        // operand a = negated (`\B`). #1912.
+        this.emit(ReOp.WBOUND, node.negated ? 1 : 0);
+        return;
+      case "backref":
+        // operand a = group index, b = case-insensitive comparison. #1912.
+        this.emit(ReOp.BACKREF, node.index, this.caseInsensitive ? 1 : 0);
+        return;
       case "concat":
         for (const part of node.parts) this.compileNode(part);
         return;

--- a/src/codegen/regex/parse.ts
+++ b/src/codegen/regex/parse.ts
@@ -1,24 +1,37 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #1539 Phase 2a — Regex pattern parser (compile-time, pure TypeScript).
+ * #1539 Phase 2a/2b — Regex pattern parser (compile-time, pure TypeScript).
  *
- * Recursive-descent parser for the Phase-2a subset of ECMAScript regular
- * expressions (ES2024 §22.2.1). Produces a small AST consumed by
+ * Recursive-descent parser for the Phase-2a/2b subset of ECMAScript regular
+ * expressions (ES2024 §22.2.1 + Annex B.1.2). Produces a small AST consumed by
  * `compile.ts`. Anything outside the subset throws `RegexUnsupportedError`,
  * which the codegen entry points turn into a clean #1539-phased compile error
- * (the "narrowed refusal" the architect requires).
+ * (the "narrowed refusal" the architect requires). Genuinely *invalid* patterns
+ * (real ES SyntaxErrors, e.g. `[b-a]` or `a**`) also surface as
+ * `RegexUnsupportedError` here — the `new RegExp(...)` codegen entry point
+ * (#1912) consults the compile-time host `RegExp` constructor to tell the two
+ * apart and lowers real SyntaxErrors to a runtime `throw`.
  *
  * Supported in 2a:
  *   - literal code units, `.`
  *   - char classes `[...]` / `[^...]` with ranges and `\d \D \w \W \s \S`
- *   - escapes `\n \r \t \f \v \0`, `\xHH`, `\uHHHH`, escaped metacharacters
+ *   - escapes `\n \r \t \f \v`, `\xHH`, `\uHHHH`, escaped metacharacters
  *   - anchors `^` `$`
  *   - quantifiers `* + ?` and `{n}` `{n,}` `{n,m}`, optional lazy `?` suffix
  *   - alternation `|`
  *   - groups `(…)` capturing, `(?:…)` non-capturing, `(?<name>…)` named
  *
- * Refused in 2a (each cites the phase that adds it):
- *   - backreferences `\1` / `\k<name>`            → 2b
+ * Added in 2b (#1912):
+ *   - word boundaries `\b` / `\B`
+ *   - backreferences `\1`…`\99` and `\k<name>` (forward refs allowed; an
+ *     out-of-range decimal escape falls back to Annex B legacy octal)
+ *   - negated shorthands inside classes (`[\D]` `[\W]` `[\S]`) via compile-time
+ *     range complement
+ *   - Annex B class-range compatibility: a shorthand adjacent to `-` makes the
+ *     `-` literal (`[\d-z]` = `\d ∪ {-} ∪ {z}`), never a range
+ *   - Annex B legacy octal escapes (`\0`…`\377`) and `\cX` control escapes
+ *
+ * Still refused (each cites the phase that adds it):
  *   - lookahead/lookbehind `(?=) (?!) (?<=) (?<!)` → 2d
  *   - Unicode property escapes `\p{…}` / `\P{…}`   → 2d
  *   - the `u`/`v` flags' code-point semantics      → 2c/2d (parse still UTF-16)
@@ -31,6 +44,8 @@ export type ReNode =
   | { kind: "class"; ranges: Array<[number, number]>; negated: boolean }
   | { kind: "bol" }
   | { kind: "eol" }
+  | { kind: "wordBoundary"; negated: boolean }
+  | { kind: "backref"; index: number }
   | { kind: "concat"; parts: ReNode[] }
   | { kind: "alt"; options: ReNode[] }
   | { kind: "star"; node: ReNode; greedy: boolean }
@@ -54,7 +69,7 @@ const WORD: Array<[number, number]> = [
   [0x5f, 0x5f],
   [0x61, 0x7a],
 ];
-// \s per §22.2.2.1: \t \n \v \f \r space      -
+// \s per §22.2.2.1: \t \n \v \f \r space      -
 //
 const SPACE: Array<[number, number]> = [
   [0x09, 0x0d],
@@ -69,12 +84,88 @@ const SPACE: Array<[number, number]> = [
   [0xfeff, 0xfeff],
 ];
 
+/**
+ * Complement a range list over the full UTF-16 code-unit space [0, 0xFFFF].
+ * Used to lower negated shorthands *inside* a class (`[\D]`) to plain ranges,
+ * since a class is the union of its members and per-member negation cannot be
+ * expressed in the run-length class table. #1912.
+ */
+export function complementRanges(ranges: Array<[number, number]>): Array<[number, number]> {
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0]);
+  const out: Array<[number, number]> = [];
+  let next = 0;
+  for (const [lo, hi] of sorted) {
+    if (lo > next) out.push([next, lo - 1]);
+    next = Math.max(next, hi + 1);
+  }
+  if (next <= 0xffff) out.push([next, 0xffff]);
+  return out;
+}
+
+const NOT_DIGIT = complementRanges(DIGIT);
+const NOT_WORD = complementRanges(WORD);
+const NOT_SPACE = complementRanges(SPACE);
+
+/**
+ * Pre-scan the pattern for the total capture-group count and the named-group
+ * table. Both are needed *before* the descent parse: a decimal escape is a
+ * backreference only when its value does not exceed the total group count
+ * (§22.2.1 NcapturingParens — counted over the WHOLE pattern, so `\1(a)` is a
+ * legal forward reference), and `\k<name>` may reference a group declared
+ * later. Skips class bodies and escapes so `([(]` does not miscount.
+ */
+function scanGroups(src: string): { count: number; names: Map<string, number> } {
+  let i = 0;
+  let inClass = false;
+  let count = 0;
+  const names = new Map<string, number>();
+  while (i < src.length) {
+    const c = src[i]!;
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (inClass) {
+      if (c === "]") inClass = false;
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (c === "(") {
+      if (src[i + 1] === "?") {
+        if (src[i + 2] === "<" && src[i + 3] !== "=" && src[i + 3] !== "!") {
+          let j = i + 3;
+          let name = "";
+          while (j < src.length && src[j] !== ">") name += src[j++];
+          count++;
+          if (!names.has(name)) names.set(name, count);
+        }
+      } else {
+        count++;
+      }
+    }
+    i++;
+  }
+  return { count, names };
+}
+
 class Parser {
   private pos = 0;
   numCaptures = 0;
-  readonly groupNames = new Map<string, number>();
+  /** Total capture count over the whole pattern (pre-scanned). */
+  private readonly totalCaptures: number;
+  /** Name → group index over the whole pattern (pre-scanned, forward refs ok). */
+  readonly groupNames: Map<string, number>;
 
-  constructor(private readonly src: string) {}
+  constructor(private readonly src: string) {
+    const scan = scanGroups(src);
+    this.totalCaptures = scan.count;
+    this.groupNames = scan.names;
+  }
 
   private peek(): string | undefined {
     return this.src[this.pos];
@@ -119,6 +210,13 @@ class Parser {
   private parseQuantified(): ReNode {
     const atom = this.parseAtom();
     const c = this.peek();
+    const isAssertion = atom.kind === "bol" || atom.kind === "eol" || atom.kind === "wordBoundary";
+    if (isAssertion && (c === "*" || c === "+" || c === "?")) {
+      // Assertions are not quantifiable (§22.2.1 Term; Annex B only exempts
+      // lookahead). `/\b*/` is a real SyntaxError — refuse instead of emitting
+      // a zero-progress loop the VM would spin on until the step cap.
+      throw new RegexUnsupportedError(`nothing to repeat at index ${this.pos}`);
+    }
     if (c === "*" || c === "+" || c === "?") {
       this.next();
       const greedy = this.consumeLazy();
@@ -130,6 +228,9 @@ class Parser {
       const saved = this.pos;
       const bounds = this.tryParseBraceQuantifier();
       if (bounds) {
+        if (isAssertion) {
+          throw new RegexUnsupportedError(`nothing to repeat at index ${saved}`);
+        }
         const greedy = this.consumeLazy();
         return { kind: "repeat", node: atom, min: bounds[0], max: bounds[1], greedy };
       }
@@ -215,10 +316,13 @@ class Parser {
         if (this.peek() !== ">") throw new RegexUnsupportedError("unterminated group name");
         this.next();
         capIndex = ++this.numCaptures;
-        if (this.groupNames.has(name)) {
+        // The pre-scan kept the FIRST index for each name; a different index
+        // here means the pattern re-declares the name — ES2025 duplicate
+        // named groups stay outside the subset until the alternative-scoped
+        // semantics land.
+        if (this.groupNames.get(name) !== capIndex) {
           throw new RegexUnsupportedError(`duplicate capture group name '${name}'`);
         }
-        this.groupNames.set(name, capIndex);
       } else if (t === "=" || t === "!") {
         throw new RegexUnsupportedError("lookahead (?= / ?!) — #1539 Phase 2d");
       } else {
@@ -262,19 +366,72 @@ class Parser {
       this.next();
       return { kind: "class", ranges: SPACE, negated: true };
     }
-    if (e === "b" || e === "B") {
-      throw new RegexUnsupportedError(`word-boundary \\${e} — #1539 Phase 2b`);
+    if (e === "b") {
+      this.next();
+      return { kind: "wordBoundary", negated: false };
+    }
+    if (e === "B") {
+      this.next();
+      return { kind: "wordBoundary", negated: true };
     }
     if (e >= "1" && e <= "9") {
-      throw new RegexUnsupportedError(`backreference \\${e} — #1539 Phase 2b`);
+      // DecimalEscape (§22.2.1): a backreference when the decimal value does
+      // not exceed the pattern's total capture count (forward refs included);
+      // otherwise Annex B legacy octal (`\1`-`\7`…) or an identity escape
+      // (`\8` `\9`).
+      const saved = this.pos;
+      let digits = "";
+      while (this.peek() !== undefined && this.peek()! >= "0" && this.peek()! <= "9") digits += this.next();
+      const value = parseInt(digits, 10);
+      if (value >= 1 && value <= this.totalCaptures) {
+        return { kind: "backref", index: value };
+      }
+      this.pos = saved;
+      if (e >= "8") {
+        this.next();
+        return { kind: "char", code: e.charCodeAt(0) }; // \8 \9 — identity
+      }
+      return { kind: "char", code: this.parseLegacyOctal() };
     }
     if (e === "k") {
-      throw new RegexUnsupportedError("named backreference \\k — #1539 Phase 2b");
+      // \k<name> — named backreference. Annex B: when the pattern declares NO
+      // named groups, `\k` is an identity escape for `k`.
+      if (this.groupNames.size === 0) {
+        this.next();
+        return { kind: "char", code: 0x6b };
+      }
+      this.next();
+      if (this.peek() !== "<") throw new RegexUnsupportedError("\\k must be followed by <name>");
+      this.next();
+      let name = "";
+      while (this.peek() !== undefined && this.peek() !== ">") name += this.next();
+      if (this.peek() !== ">") throw new RegexUnsupportedError("unterminated \\k<name>");
+      this.next();
+      const idx = this.groupNames.get(name);
+      if (idx === undefined) {
+        throw new RegexUnsupportedError(`\\k<${name}> references an undeclared group`);
+      }
+      return { kind: "backref", index: idx };
     }
     if (e === "p" || e === "P") {
       throw new RegexUnsupportedError(`Unicode property escape \\${e}{…} — #1539 Phase 2d`);
     }
     return { kind: "char", code: this.parseEscapedCodeUnit() };
+  }
+
+  /** Annex B LegacyOctalEscapeSequence: 1-3 octal digits, value ≤ 0o377. The
+   *  cursor sits ON the first digit (the backslash is consumed). */
+  private parseLegacyOctal(): number {
+    let v = 0;
+    let n = 0;
+    while (n < 3 && this.peek() !== undefined && this.peek()! >= "0" && this.peek()! <= "7") {
+      const nv = v * 8 + (this.src[this.pos]!.charCodeAt(0) - 0x30);
+      if (nv > 0o377) break;
+      this.next();
+      v = nv;
+      n++;
+    }
+    return v;
   }
 
   /** Parse the code unit denoted by an escape, with the backslash already
@@ -294,7 +451,32 @@ class Parser {
       case "v":
         return 0x0b;
       case "0":
-        return 0x00;
+      case "1":
+      case "2":
+      case "3":
+      case "4":
+      case "5":
+      case "6":
+      case "7": {
+        // Annex B legacy octal (covers strict `\0` as the zero-digit case).
+        // Backref classification happened in parseEscapeAtom; inside a class a
+        // decimal escape is always octal/identity.
+        this.pos--;
+        return this.parseLegacyOctal();
+      }
+      case "8":
+      case "9":
+        return e.charCodeAt(0); // identity (Annex B)
+      case "c": {
+        // ControlLetter escape: \cA-\cZ \ca-\cz → code % 32. Anything else is
+        // host-invalid or a deeper Annex B identity case — refuse.
+        const l = this.peek();
+        if (l !== undefined && ((l >= "A" && l <= "Z") || (l >= "a" && l <= "z"))) {
+          this.next();
+          return l.charCodeAt(0) % 32;
+        }
+        throw new RegexUnsupportedError("\\c without a control letter");
+      }
       case "x": {
         const hex = this.next() + this.next();
         if (!/^[0-9a-fA-F]{2}$/.test(hex)) throw new RegexUnsupportedError(`bad \\x escape`);
@@ -325,6 +507,13 @@ class Parser {
       const member = this.parseClassMember();
       if (member.kind === "shorthand") {
         for (const r of member.ranges) ranges.push([r[0], r[1]]);
+        // Annex B NonemptyClassRanges: a `-` after a class escape is a literal
+        // `-` (unless it closes the class): `[\d-z]` = \d ∪ {-} ∪ {z}, never a
+        // range. Consume it here so the next member parses standalone. #1912.
+        if (this.peek() === "-" && this.src[this.pos + 1] !== "]" && this.src[this.pos + 1] !== undefined) {
+          this.next();
+          ranges.push([0x2d, 0x2d]);
+        }
         continue;
       }
       const lo = member.code;
@@ -333,7 +522,10 @@ class Parser {
         this.next(); // consume "-"
         const hiMember = this.parseClassMember();
         if (hiMember.kind === "shorthand") {
-          throw new RegexUnsupportedError("class shorthand as range endpoint");
+          // Annex B: shorthand as the upper bound → union {lo, '-', shorthand}.
+          ranges.push([lo, lo], [0x2d, 0x2d]);
+          for (const r of hiMember.ranges) ranges.push([r[0], r[1]]);
+          continue;
         }
         const hi = hiMember.code;
         if (hi < lo) throw new RegexUnsupportedError("class range out of order");
@@ -363,9 +555,20 @@ class Parser {
         this.next();
         return { kind: "shorthand", ranges: SPACE };
       }
-      // Negated shorthands inside a class need set complement — defer to 2b.
-      if (e === "D" || e === "W" || e === "S") {
-        throw new RegexUnsupportedError(`negated shorthand \\${e} inside [...] — #1539 Phase 2b`);
+      // Negated shorthands inside a class — lowered to their complement range
+      // list (the class is a union of members, so per-member negation must be
+      // materialized as ranges). #1912.
+      if (e === "D") {
+        this.next();
+        return { kind: "shorthand", ranges: NOT_DIGIT };
+      }
+      if (e === "W") {
+        this.next();
+        return { kind: "shorthand", ranges: NOT_WORD };
+      }
+      if (e === "S") {
+        this.next();
+        return { kind: "shorthand", ranges: NOT_SPACE };
       }
       if (e === "b") {
         this.next();

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -55,6 +55,11 @@ function isLineTerminator(c: number): boolean {
   return c === 0x0a || c === 0x0d || c === 0x2028 || c === 0x2029;
 }
 
+/** §22.2.2.6 IsWordChar (ASCII; Unicode case folding lands with `u` in 2d). */
+function isWordChar(c: number): boolean {
+  return (c >= 0x30 && c <= 0x39) || (c >= 0x41 && c <= 0x5a) || c === 0x5f || (c >= 0x61 && c <= 0x7a);
+}
+
 /**
  * Run `prog` against `input` starting at `startIdx`. Returns the filled
  * capture array on a match (anchored at `startIdx`), or null on no match /
@@ -147,6 +152,50 @@ export function runAt(
         // before a line terminator (§22.2.2.7).
         if (sp === len || (a !== 0 && isLineTerminator(input.charCodeAt(sp)))) pc++;
         else failed = true;
+        break;
+      }
+      case ReOp.WBOUND: {
+        // a = negated (`\B`). Word boundary: exactly one of the neighbouring
+        // code units is a word char (§22.2.2.6); out-of-bounds neighbours are
+        // non-word.
+        const before = sp > 0 ? isWordChar(input.charCodeAt(sp - 1)) : false;
+        const after = sp < len ? isWordChar(input.charCodeAt(sp)) : false;
+        const boundary = before !== after;
+        if (a !== 0 ? !boundary : boundary) pc++;
+        else failed = true;
+        break;
+      }
+      case ReOp.BACKREF: {
+        // a = group index, b = case-insensitive. An unset group matches the
+        // empty string (§22.2.2.9 BackreferenceMatcher step 3).
+        const gs = caps[2 * a]!;
+        const ge = caps[2 * a + 1]!;
+        if (gs < 0 || ge < 0) {
+          pc++;
+          break;
+        }
+        const blen = ge - gs;
+        if (sp + blen > len) {
+          failed = true;
+          break;
+        }
+        let ok = true;
+        for (let j = 0; j < blen; j++) {
+          let c1 = input.charCodeAt(gs + j);
+          let c2 = input.charCodeAt(sp + j);
+          if (b !== 0) {
+            c1 = asciiFold(c1);
+            c2 = asciiFold(c2);
+          }
+          if (c1 !== c2) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) {
+          sp += blen;
+          pc++;
+        } else failed = true;
         break;
       }
       case ReOp.MATCH: {

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -21,7 +21,9 @@ import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
-import { ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
+import { ensureNativeStringHelpers, nativeStringType, stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import {
   ensureRegexCaptureArray,
   ensureRegexReplace,
@@ -499,6 +501,46 @@ export function compileStandaloneRegExpLiteral(
   return compileStandaloneRegExpPattern(ctx, fctx, pattern, flags, node);
 }
 
+/**
+ * Genuine (pattern, flags) SyntaxErrors vs. engine limitations (#1912).
+ *
+ * The compiler runs on a JS host whose `RegExp` constructor is a spec-exact
+ * validity oracle: any pair the host rejects with a SyntaxError is invalid per
+ * §22.2.3.2 and must throw a *runtime* SyntaxError when the compiled
+ * `new RegExp(...)` evaluates — not fail the whole compile (test262's
+ * S15.10.1/S15.10.2.15 families catch exactly this). Host-VALID patterns our
+ * matcher can't handle stay compile-time narrowed refusals.
+ */
+function hostRegExpSyntaxErrorMessage(pattern: string, flags: string): string | null {
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(pattern, flags);
+    return null;
+  } catch (e) {
+    if (e instanceof SyntaxError) return e.message;
+    return e instanceof Error ? e.message : "Invalid regular expression";
+  }
+}
+
+/**
+ * Lower an invalid `new RegExp(...)` to a runtime `throw new SyntaxError(msg)`
+ * (#1912). The trailing `unreachable` makes the post-throw stack polymorphic,
+ * so the claimed `$NativeRegExp` result type validates without materializing a
+ * struct — downstream creation-site codegen (e.g. an `.exec` chained on the
+ * receiver) emits normally as dead code.
+ */
+function emitThrowRegExpSyntaxError(ctx: CodegenContext, fctx: FunctionContext, message: string): ValType {
+  emitWasiErrorConstructor(ctx, "SyntaxError", 1);
+  addStringConstantGlobal(ctx, message);
+  const ctorIdx = ctx.funcMap.get("__new_SyntaxError")!;
+  const tagIdx = ensureExnTag(ctx);
+  for (const instr of stringConstantExternrefInstrs(ctx, message)) fctx.body.push(instr);
+  fctx.body.push({ op: "call", funcIdx: ctorIdx });
+  fctx.body.push({ op: "throw", tagIdx } as Instr);
+  fctx.body.push({ op: "unreachable" } as Instr);
+  return { kind: "ref", typeIdx: ensureStandaloneRegExpStruct(ctx) };
+}
+
 export function compileStandaloneRegExpConstructor(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -518,6 +560,15 @@ export function compileStandaloneRegExpConstructor(
   if (flags === null) {
     reportStandaloneRegExpUnsupported(ctx, flagsArg, "dynamic constructor flags");
     return null;
+  }
+
+  // §22.2.3.2: an invalid static pattern/flags pair throws SyntaxError when
+  // the constructor call evaluates — emit the runtime throw, not a compile
+  // refusal (#1912). Regex *literals* keep the compile-time diagnostic since
+  // an invalid literal is an early error.
+  const syntaxMsg = hostRegExpSyntaxErrorMessage(pattern ?? "", flags ?? "");
+  if (syntaxMsg !== null && hasStandaloneRegExpEngine(ctx)) {
+    return emitThrowRegExpSyntaxError(ctx, fctx, syntaxMsg);
   }
 
   return compileStandaloneRegExpPattern(ctx, fctx, pattern ?? "", flags ?? "", node);

--- a/tests/issue-1539-standalone-regex.test.ts
+++ b/tests/issue-1539-standalone-regex.test.ts
@@ -332,10 +332,9 @@ describe("#1539 standalone narrowed refusals (Phase 2a)", () => {
   it("refuses dynamic new RegExp(var)", async () => {
     await expectRefused(`export function f(p: string): boolean { return new RegExp(p).test("x"); }`);
   });
-  it("refuses backreference", async () => {
-    // Single backslash in the emitted source: regex literal /(a)\1/.
-    await expectRefused(`export function f(s: string): boolean { return /(a)\\1/.test(s); }`);
-  });
+  // #1912 Phase 2b landed backreferences, word boundaries, and the class
+  // compatibility forms — they are no longer refused (see
+  // tests/issue-1912-regex-phase2b.test.ts for the dual-run coverage).
   it("refuses lookahead", async () => {
     await expectRefused(`export function f(s: string): boolean { return /a(?=b)/.test(s); }`);
   });

--- a/tests/issue-1912-regex-phase2b.test.ts
+++ b/tests/issue-1912-regex-phase2b.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1912 — standalone RegExp Phase 2b: word boundaries, backreferences, and
+ * character-class compatibility, plus runtime SyntaxError lowering for
+ * genuinely invalid `new RegExp(...)` patterns.
+ *
+ * Each case compiles under `--target standalone`, instantiates with an EMPTY
+ * import object (no JS host), and dual-runs against the native engine. The
+ * matcher itself is unit-tested in pure TS by tests/regex-bytecode.test.ts;
+ * this file validates the Wasm VM arms (WBOUND/BACKREF) and the codegen
+ * routing end-to-end.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function standaloneTest(pattern: string, flags: string, input: string): Promise<boolean> {
+  const inLit = JSON.stringify(input);
+  const src = `export function run(): boolean { return /${pattern}/${flags}.test(${inLit}); }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostRegex = WebAssembly.Module.imports(mod).filter((i) => /RegExp/.test(i.name));
+  expect(hostRegex, "no RegExp host import in standalone").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { run(): number }).run() !== 0;
+}
+
+// `p` holds the literal regex source; the same `p` drives the standalone
+// compile and the native `new RegExp(p, f)` reference.
+const CASES: Array<{ p: string; f: string; inputs: string[] }> = [
+  // Word boundaries \b / \B (§22.2.2.6).
+  { p: "\\bcat\\b", f: "", inputs: ["the cat sat", "concatenate", "cat", "a cat."] },
+  { p: "\\Bcat", f: "", inputs: ["concatenate", "the cat", "scat"] },
+  { p: "\\b\\w+\\b", f: "", inputs: ["hello world", " x ", ""] },
+  { p: "\\bok\\b", f: "i", inputs: ["OK then", "joke"] },
+  // Backreferences (§22.2.2.9): plain, alt-bound, unset-group-empty, named,
+  // forward reference, case-insensitive comparison.
+  { p: "(a+)\\1", f: "", inputs: ["aa", "aaaa", "a", "baab"] },
+  { p: "(ab|cd)e\\1", f: "", inputs: ["abeab", "cdecd", "abecd"] },
+  { p: "(a)?b\\1", f: "", inputs: ["b", "aba"] },
+  { p: "(?<x>\\d+)-\\k<x>", f: "", inputs: ["12-12", "12-13", "7-7"] },
+  { p: "\\1(a)", f: "", inputs: ["a"] },
+  { p: "(A)\\1", f: "i", inputs: ["aa", "aA", "Ab"] },
+  // `\/` so the pattern stays valid inside the generated regex literal.
+  { p: "<(\\w+)>.*<\\/\\1>", f: "", inputs: ["<b>hi</b>", "<b>hi</i>"] },
+  // Class compatibility: negated shorthands in classes, Annex B literal
+  // hyphen next to a shorthand, legacy octal, control escape, identity \8.
+  { p: "[\\D]+", f: "", inputs: ["abc123", "123"] },
+  { p: "[\\W]", f: "", inputs: ["a_b", "a b", "ab"] },
+  { p: "[\\S]+", f: "", inputs: ["  x  ", "   "] },
+  { p: "[^\\D]", f: "", inputs: ["abc1", "abc"] },
+  { p: "[\\d-z]+", f: "", inputs: ["a-9z", "qrs", "-", "/"] },
+  { p: "[a-\\d]+", f: "", inputs: ["a-9", "b", "5"] },
+  { p: "\\05", f: "", inputs: ["\x05", "5"] },
+  { p: "(a)\\2", f: "", inputs: ["a\x02", "aa"] },
+  { p: "\\cA", f: "", inputs: ["\x01", "cA"] },
+  { p: "\\8", f: "", inputs: ["8", "x"] },
+  { p: "[\\b]", f: "", inputs: ["\b", "b"] },
+];
+
+describe("#1912 standalone RegExp Phase 2b — dual-run vs native", () => {
+  for (const { p, f, inputs } of CASES) {
+    for (const input of inputs) {
+      it(`/${p}/${f} on ${JSON.stringify(input)}`, async () => {
+        const expected = new RegExp(p, f).test(input);
+        expect(await standaloneTest(p, f, input)).toBe(expected);
+      });
+    }
+  }
+
+  it("backref capture slots flow into exec result", async () => {
+    const src = `
+      export function matched(): boolean { const m = /(?<x>a+)b\\k<x>/.exec("xaabaay"); return m !== null; }
+      export function len(i: number): number { const m = /(?<x>a+)b\\k<x>/.exec("xaabaay")!; return m[i]!.length; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as { matched(): number; len(i: number): number };
+    expect(ex.matched()).toBe(1);
+    expect(ex.len(0)).toBe(5); // "aabaa"
+    expect(ex.len(1)).toBe(2); // "aa"
+  });
+});
+
+describe("#1912 runtime SyntaxError for invalid new RegExp(...)", () => {
+  // §22.2.3.2: an invalid static pattern throws SyntaxError when the
+  // constructor call EVALUATES — the compile must succeed and the throw must
+  // be catchable with the right brand (the S15.10.1 / S15.10.2.15 test262
+  // families). Regex literals keep the compile-time diagnostic (early error).
+  async function syntaxProbe(callExpr: string): Promise<number> {
+    const src = `
+      export function run(): number {
+        try {
+          ${callExpr};
+          return 0;
+        } catch (e) {
+          if (e instanceof SyntaxError) return 1;
+          return 2;
+        }
+      }`;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    const hostRegex = WebAssembly.Module.imports(mod).filter((i) => /RegExp/.test(i.name));
+    expect(hostRegex, "no RegExp host import in standalone").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as { run(): number }).run();
+  }
+
+  it("class range out of order: new RegExp('[b-ac-e]').exec(...)", async () => {
+    expect(await syntaxProbe(`new RegExp("[b-ac-e]").exec("a")`)).toBe(1);
+  });
+  it("nothing to repeat: new RegExp('a**')", async () => {
+    expect(await syntaxProbe(`new RegExp("a**").test("a")`)).toBe(1);
+  });
+  it("quantified anchor: new RegExp('^*')", async () => {
+    expect(await syntaxProbe(`new RegExp("^*").test("a")`)).toBe(1);
+  });
+  it("invalid flags: new RegExp('a', 'gg')", async () => {
+    expect(await syntaxProbe(`new RegExp("a", "gg").test("a")`)).toBe(1);
+  });
+  it("valid pattern does NOT throw", async () => {
+    expect(await syntaxProbe(`new RegExp("a+").test("ba")`)).toBe(0);
+  });
+
+  it("invalid regex literal stays a compile-time diagnostic (early error)", async () => {
+    const r = await compile(`export function f(s: string): boolean { return /a**/.test(s); }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/tests/regex-bytecode.test.ts
+++ b/tests/regex-bytecode.test.ts
@@ -102,21 +102,68 @@ describe("#1539 capture groups", () => {
   });
 });
 
-describe("#1539 narrowed refusals (Phase 2a)", () => {
+describe("#1539 narrowed refusals (Phase 2d residue after #1912)", () => {
   const refused = [
-    "\\1", // backref
-    "\\k<x>", // named backref
     "(?=ab)", // lookahead
     "(?!ab)", // neg lookahead
     "(?<=ab)", // lookbehind
     "\\p{L}", // unicode property
-    "\\bword", // word boundary
+    "\\b*", // quantified assertion — real SyntaxError, never a VM spin
+    "[b-a]", // class range out of order — real SyntaxError
+    "a**", // nothing to repeat — real SyntaxError
   ];
   for (const p of refused) {
     it(`refuses ${JSON.stringify(p)}`, () => {
       expect(() => compilePattern(p, 0)).toThrow(RegexUnsupportedError);
     });
   }
+});
+
+// #1912 Phase 2b — word boundaries, backrefs, class compatibility. Same
+// dual-run shape as the 2a corpus: our pipeline must agree with the native
+// engine on the first-match span.
+const CORPUS_2B: Array<{ p: string; f: string; inputs: string[] }> = [
+  { p: "\\bcat\\b", f: "", inputs: ["the cat sat", "concatenate", "cat", "a cat.", ""] },
+  { p: "\\Bcat", f: "", inputs: ["concatenate", "the cat", "scat"] },
+  { p: "\\b\\w+\\b", f: "", inputs: ["hello world", " x ", "", "_a1"] },
+  { p: "\\B\\B", f: "", inputs: ["ab", "a", ""] },
+  { p: "(a+)\\1", f: "", inputs: ["aa", "aaaa", "a", "baab"] },
+  { p: "(ab|cd)e\\1", f: "", inputs: ["abeab", "cdecd", "abecd"] },
+  { p: "(a)?b\\1", f: "", inputs: ["b", "ab a", "aba"] }, // unset group matches empty
+  { p: "(?<x>\\d+)-\\k<x>", f: "", inputs: ["12-12", "12-13", "7-7"] },
+  { p: "\\1(a)", f: "", inputs: ["a", "aa"] }, // forward ref: unset → empty
+  { p: "(A)\\1", f: "i", inputs: ["aa", "aA", "Ab"] }, // ci backref compare
+  { p: "(\\w+)\\s\\1", f: "", inputs: ["go go", "go stop", "aa aa"] },
+  { p: "[\\D]+", f: "", inputs: ["abc123", "123"] }, // negated shorthand in class
+  { p: "[\\W]", f: "", inputs: ["a_b", "a b", "ab"] },
+  { p: "[\\S]+", f: "", inputs: ["  x  ", "   "] },
+  { p: "[^\\D]", f: "", inputs: ["abc1", "abc"] }, // double negation = \d
+  { p: "[\\d-z]+", f: "", inputs: ["a-9z", "qrs", "-", "/"] }, // Annex B literal hyphen
+  { p: "[a-\\d]+", f: "", inputs: ["a-9", "b", "5", "c"] },
+  { p: "\\05", f: "", inputs: ["\x05", "5"] }, // legacy octal
+  { p: "(a)\\2", f: "", inputs: ["a\x02", "aa"] }, // out-of-range decimal → octal
+  { p: "\\cA", f: "", inputs: ["\x01", "cA"] }, // control escape
+  { p: "\\8", f: "", inputs: ["8", "x"] }, // identity escape
+  { p: "\\k<x>", f: "", inputs: ["k<x>", "kx"] }, // \k identity without named groups
+  { p: "[\\b]", f: "", inputs: ["\b", "b"] }, // backspace inside class
+];
+
+describe("#1912 Phase 2b pipeline vs native RegExp", () => {
+  for (const { p, f, inputs } of CORPUS_2B) {
+    for (const input of inputs) {
+      it(`/${p}/${f} on ${JSON.stringify(input)}`, () => {
+        expect(ourMatch(p, f, input)).toEqual(nativeMatch(p, f, input));
+      });
+    }
+  }
+
+  it("backref capture slots populate like native", () => {
+    const c = compilePattern("(?<x>a+)b\\k<x>", 0);
+    const m = search(c.prog, c.classTable, c.nGroups, "xaabaay", 0, false);
+    expect(m).not.toBeNull();
+    expect([m![0], m![1]]).toEqual([1, 6]); // aabaa
+    expect([m![2], m![3]]).toEqual([1, 3]); // aa
+  });
 });
 
 describe("#1539 flag parsing", () => {


### PR DESCRIPTION
## Summary

Implements `plan/issues/1912-standalone-regexp-phase-2b-boundaries-backrefs-classes.md` — the Phase 2b features of the pure-WasmGC standalone regex matcher (#1539 follow-up). All matcher changes are dual-implemented in the TS reference VM (`src/codegen/regex/vm.ts`) and the hand-authored Wasm VM (`src/codegen/native-regex.ts`), mirrored opcode-for-opcode.

- **Word boundaries `\b` / `\B`** — new `ReOp.WBOUND` (§22.2.2.6 IsWordChar, ASCII). Out-of-bounds neighbour reads are guarded and read as non-word; never traps.
- **Backreferences `\1`…`\99` + `\k<name>`** — new `ReOp.BACKREF` (§22.2.2.9). Unset groups match empty (forward refs work); the `i` flag compares ASCII-folded units. A pre-scan pass collects the whole-pattern capture count + named-group table, which DecimalEscape classification and `\k<name>` forward resolution require.
- **Annex B compatibility** — out-of-range decimal escapes → legacy octal (`\05`, `(a)\2` → `\x02`); `\8`/`\9` identity; `\cX` control letters; literal `-` adjacent to a class shorthand (`[\d-z]` = `\d ∪ {-} ∪ {z}` — also fixes a silent 2a mis-parse of that form into the range U+002D–U+007A).
- **Negated class shorthands** `[\D] [\W] [\S]` lower to complemented ranges at compile time.
- **Runtime SyntaxError lowering** — invalid `new RegExp(...)` pattern/flag pairs now compile to a catchable runtime `throw new SyntaxError(...)` (§22.2.3.2) instead of a compile refusal, using the compile-time host `RegExp` constructor as the spec-exact validity oracle. This is what the S15.10.1 / S15.10.2.15 test262 families ("class range out of order", "nothing to repeat") assert. Host-valid-but-unsupported patterns keep the narrowed refusal; regex literals keep the compile diagnostic (early error).
- **Quantified assertions** (`\b*`, `^*`) refuse at parse (genuine SyntaxErrors, verified against V8) instead of emitting a zero-progress SPLIT loop that would spin to the step cap.

Targets the `standalone-regexp-phase-2b` bucket (104 rows; the boundary/backref/class-compat + S15 SyntaxError families). The g/y `lastIndex` rows sharing the bucket belong to #1913/#1914 (fable-rx-surface).

## Validation

- `tests/regex-bytecode.test.ts` — new #1912 dual-run corpus (23 patterns vs native `RegExp`)
- `tests/issue-1912-regex-phase2b.test.ts` — end-to-end standalone Wasm: empty import object, no `RegExp` host imports, runtime-SyntaxError probes (`instanceof SyntaxError` works through the native error machinery)
- Existing `issue-1539-standalone-regex*`, `issue-1474-standalone-regex-refuse`, `issue-682-regexp-standalone-abi`, `regexp` suites: 481 tests green
- `tsc --noEmit`, biome lint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)