### PR TITLE
fix(#1712): if/else then-branch buffer escapes late global-index shift

### DIFF
--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -1,9 +1,9 @@
 ---
 id: 1712
 title: "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn"
-status: ready
+status: in-progress
 created: 2026-05-29
-updated: 2026-06-02
+updated: 2026-06-10
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -76,3 +76,65 @@ surfaces. The optimistic case — given the known blockers are cleared — is th
 - Status starts `backlog`; the tech lead flips it to `ready` once the blocking
   issues merge. Do NOT dispatch a dev to "make #1712 pass" directly — it is an
   integration gate, satisfied by fixing its dependencies.
+
+## Dogfood lap 2026-06-10 (fable-1712, main 6efc0d279)
+
+Prior attempt: **Codex PR #1293** (symphony/1712) implemented the full
+acceptance in one 1,700-line PR, but is CONFLICTING with main, stale since
+2026-06-08, and its own equivalence-gate found **24 new regressions** from its
+broad codegen edits (typeof-member, computed properties, shape-inference,
+refcast fallback, destructuring initializers) — violating acceptance #5.
+Treated as superseded; this lap re-fixes the blockers minimally off current
+main, one root cause per slice.
+
+### Blocker 1 — invalid Wasm: stale module-global index in `__closure_86` (FIXED, this PR)
+
+`pnpm run dogfood:acorn` on 6efc0d279: compile succeeds, binary INVALID —
+`f64.trunc[0] expected type f64, found global.get of type (ref null 1)`.
+
+**Root cause** (not the #1690/#1839 surface — a NEW orphan-buffer window):
+`compileIfStatement` (`src/codegen/statements/control-flow.ts`) finishes the
+then branch, then raw-swaps `fctx.body = []` for the else branch. The
+completed then-buffer survives only in the `thenInstrs` local — unreachable
+by `fixupModuleGlobalIndices` (and the func-idx shifters). When the else
+branch registers a brand-new string constant (acorn: a property null-throw
+TypeError message — codegen-generated, so not pre-collected by the module
+scan), the late `string_constants` import global shifts every module-global
+index +1, but the detached then-buffer's `global.get`s stay stale. In acorn,
+`return this.parseFunction(fNode, FUNC_STATEMENT | FUNC_NULLABLE_ID, …)`
+(dist line 1855) sits in exactly such a then branch; its stale reads landed
+on the neighbouring globals (one a `(ref null $array)`) → invalid Wasm.
+
+**Fix** (2 sites):
+1. `compileIfStatement` parks `thenInstrs` in `fctx.savedBodies` for the
+   else-compilation window (savedBodies is walked by every late-import
+   shifter), unparked LIFO before assembling the `if` instr.
+2. `fixupModuleGlobalIndices` (`src/codegen/registry/imports.ts`) now also
+   walks `ctx.liveBodies` — parity with `addStringImports`/`addUnionImports`
+   (#1384); the #779d destructuring branch buffers register there expecting
+   "every shift path" to walk them, but the *global*-index fixup never did.
+
+Regression pin: `tests/issue-1712-ifelse-global-shift.test.ts` (verified red
+on unfixed tree by reverse-applying the fix, green with it).
+
+Result: acorn binary now **validates** (835,680 bytes).
+
+### Blocker 2 — instantiation: `function.prototype` host bridge (NEXT)
+
+With the binary valid, instantiation fails in module-init:
+`Object.defineProperties called on non-object` (acorn dist 685:
+`Object.defineProperties(Parser.prototype, prototypeAccessors)`).
+`<fn>.prototype` on a function-style constructor compiles to
+`__extern_get(closureStruct→externref, "prototype")` which has no sidecar
+entry and no `__sget_prototype` export → undefined. This is the known
+function.prototype host-bridge gap (#1340 recon — escalated NEEDS-SPEC).
+25-line repro: `var P = function P(x){this.x=x}; P.prototype.m =
+function(){…}; Object.defineProperties(P.prototype, …); new P(1).m()` —
+all three flows fail (`m is not a function` / defineProperties non-object).
+
+Bridge sketch (JS-host lap-1 scope per the acceptance note): vivify a
+sidecar `prototype` object on closure structs in `__extern_get`; link
+functor instances → ctor closure at `new`-site codegen; `_wrapForHost` get
+trap falls back to the ctor's vivified proto and threads `this` via
+`__call_fn_method_N` (#1636-S1). Acorn's `var pp$N = Parser.prototype;
+pp$N.method = fn` aliasing is satisfied by the vivified object's identity.

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -212,6 +212,21 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
     shifted.add(ctx.pendingInitBody);
   }
 
+  // (#1712) Walk all live (allocated but not yet attached to mod.functions)
+  // FunctionContext bodies — same coverage the late FUNC-index shifters gained
+  // in #1384 (addStringImports/addUnionImports walk ctx.liveBodies). Without
+  // this, a lifted/callback closure body that is only reachable via
+  // liveBodies during its emission window keeps pre-shift module-global
+  // indices: compiling acorn left `FUNC_STATEMENT | FUNC_NULLABLE_ID` in
+  // __closure_86 reading the neighbouring global (ref-typed) and produced
+  // invalid Wasm (`f64.trunc[0] … found global.get of type (ref null 1)`).
+  for (const lb of ctx.liveBodies) {
+    if (!shifted.has(lb)) {
+      shiftGlobalIndices(lb);
+      shifted.add(lb);
+    }
+  }
+
   for (const g of ctx.mod.globals) {
     if (g.init) shiftGlobalIndices(g.init);
   }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -506,6 +506,19 @@ export function compileIfStatement(ctx: CodegenContext, fctx: FunctionContext, s
   let elseInstrs: Instr[] | undefined;
   let typeofNarrowResultElse: { originalLocalIdx: number; narrowedLocalIdx: number } | null = null;
   if (stmt.elseStatement) {
+    // (#1712) Park the completed then-branch buffer in savedBodies for the
+    // whole else-compilation window. The raw `fctx.body = []` swap below
+    // would otherwise leave `thenInstrs` reachable only through this local
+    // variable — invisible to every late-import index shifter
+    // (addStringImports / addUnionImports / fixupModuleGlobalIndices). A
+    // string constant first registered inside the else branch (e.g. a
+    // property null-throw message) then shifts all module-global indices
+    // while the then-branch's already-emitted `global.get`s stay stale by
+    // one. Compiling acorn hit exactly this: `FUNC_STATEMENT |
+    // FUNC_NULLABLE_ID` inside a then branch read the neighbouring
+    // (ref-typed) global and produced invalid Wasm. Mirrors the #779d fix
+    // for destructuring branch buffers.
+    fctx.savedBodies.push(thenInstrs);
     fctx.body = [];
 
     // Apply typeof narrowing for else branch
@@ -526,6 +539,9 @@ export function compileIfStatement(ctx: CodegenContext, fctx: FunctionContext, s
     if (typeofNarrowResultElse) {
       fctx.localMap.set(typeofNarrowing!.varName, typeofNarrowResultElse.originalLocalIdx);
     }
+
+    // (#1712) Unpark the then-branch buffer (LIFO — must precede popBody).
+    fctx.savedBodies.pop();
   }
 
   popBody(fctx, savedBody);

--- a/tests/issue-1712-ifelse-global-shift.test.ts
+++ b/tests/issue-1712-ifelse-global-shift.test.ts
@@ -1,0 +1,49 @@
+// #1712 (acorn dogfood) — compileIfStatement orphaned the completed
+// then-branch buffer while compiling the else branch: the raw
+// `fctx.body = []` swap left `thenInstrs` reachable only through a local
+// variable, invisible to fixupModuleGlobalIndices. A string constant first
+// registered inside the else branch (e.g. a property null-throw TypeError
+// message — NOT a source literal, which the module pre-scan would have
+// collected) inserts a late `string_constants` import global and shifts every
+// module-global index by one, while the then-branch's already-emitted
+// `global.get`s stay stale.
+//
+// Symptom (acorn 8.16.0, __closure_86): `FUNC_STATEMENT | FUNC_NULLABLE_ID`
+// read the neighbouring globals — one of them a (ref null $array) — and
+// produced invalid Wasm: `f64.trunc[0] expected type f64, found global.get of
+// type (ref null 1)`.
+//
+// The fix parks thenInstrs in fctx.savedBodies for the else window (walked by
+// every late-import shifter) and adds the missing ctx.liveBodies walk to
+// fixupModuleGlobalIndices (parity with addStringImports/addUnionImports,
+// #1384/#779d).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#1712 — then-branch module-global reads survive a late string-import shift from the else branch", () => {
+  it("module-global bitwise-or in the then branch still validates and computes after an else-branch null-throw string registers late", async () => {
+    const src = `
+      var FLAG_A = 1, FLAG_B = 2, FLAG_C = 4;
+
+      export function pick(x: number, obj: any): number {
+        if (x > 0) {
+          return FLAG_A | FLAG_C;
+        } else {
+          // Property access on \`any\` emits a null-throw TypeError message
+          // string unique to this property name — first registered HERE,
+          // inside the else branch, triggering the late global-index shift
+          // while thenInstrs is detached.
+          return obj.uniquePropNameZq77 + 0;
+        }
+      }
+    `;
+    const r = await compile(src, { fileName: "issue-1712.ts" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // Pre-fix this threw: "f64.trunc[0] expected type f64, found global.get of type externref"
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+    const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+    const pick = instance.exports.pick as (x: number, obj: unknown) => number;
+    expect(pick(1, null)).toBe(5); // FLAG_A | FLAG_C = 1 | 4
+  });
+});


### PR DESCRIPTION
## Summary
- `compileIfStatement` raw-swapped `fctx.body = []` for the else branch, orphaning the completed then-branch buffer in a local variable — invisible to every late-import index shifter. A string constant first registered inside the else branch (codegen-generated property null-throw message, not pre-collected by the module scan) inserts a late `string_constants` import global, shifting all module-global indices +1 while the detached then-buffer's `global.get`s stay stale.
- Compiling acorn 8.16.0 hit exactly this in `__closure_86` (`FUNC_STATEMENT | FUNC_NULLABLE_ID`, acorn dist line 1855): the stale reads landed on the neighbouring `(ref null $array)` global → invalid Wasm `f64.trunc[0] expected type f64, found global.get of type (ref null 1)`. This was the sole gate on the entire acorn dogfood surface (run+diff skipped).
- Fix 1: park `thenInstrs` in `fctx.savedBodies` for the else-compilation window (savedBodies is walked by every shifter), unpark LIFO before assembling the `if`.
- Fix 2: `fixupModuleGlobalIndices` now walks `ctx.liveBodies` — parity with the func-index shifters (#1384); the #779d destructuring branch buffers register there expecting "every shift path" to walk them, but the global-index fixup never did.

With this PR, compiled acorn **validates** (it was invalid on main 6efc0d279). Next blocker (instantiation: `function.prototype` host bridge) is documented in the issue file and is a separate slice.

This supersedes part of Codex PR #1293's scope; #1293 is CONFLICTING with main and its equivalence-gate found 24 new regressions, so this lap re-fixes blockers minimally off current main.

## Validation
- `tests/issue-1712-ifelse-global-shift.test.ts` — new regression pin, verified red by reverse-applying the fix, green with it
- `node node_modules/vitest/dist/cli.js run tests/issue-1712-ifelse-global-shift.test.ts tests/issue-1839.test.ts` — pass
- Related equivalence files (`global-index-shift-trycatch`, `logical-conditional-identity`, `iife-and-call-expressions`, `destructuring-initializer`, `typeof-member-expression`): 104 pass, 6 fail — all 6 are pre-existing entries in `scripts/equivalence-baseline.json`
- `tsc --noEmit` clean
- `pnpm run dogfood:acorn`: binary now validates (835,680 bytes); instantiation reaches the next, separately-tracked blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)