### PR TITLE
fix(strings): standalone string iteration + localeCompare residual sweep (#1470)

### DIFF
--- a/plan/issues/1470-no-js-host-string-ops.md
+++ b/plan/issues/1470-no-js-host-string-ops.md
@@ -530,3 +530,71 @@ standalone + WASI + gc-default regression + explicit nativeStrings).
 `native-strings`, `native-strings-standalone`,
 `issue-1470-standalone-string-imports` (14) all green; default `gc` JS-host
 path unchanged.
+
+### 2026-06-10 — residual sweep: string iteration + localeCompare + toLocale case
+
+Behavioral probe of all string surfaces under `--target standalone` (45-case
+battery, compared against real JS evaluation) found the remaining defects were
+not import *leaks* — the import section was already clean for every probed op
+— but silently-wrong or invalid lowerings on the **String-iteration** and
+**string_method-fall-through** paths:
+
+1. **`[...str]` produced an empty array** (`[..."abc"].length === 0`,
+   elements null). Root cause: `compileArrayLiteralWithSpread`
+   (`src/codegen/literals.ts`) pushed the native-string struct into the
+   generic vec-spread branch; `getArrTypeIdxFromVec` fails for the string
+   type and the branch silently `continue`d — the spread contributed
+   nothing while the result vec's `len` stayed 0.
+2. **`Array.from(str)` emitted an INVALID module** under standalone: the
+   string argument fell to the `__array_from` JS-host fallback (#965),
+   which both leaks `env::__array_from` and corrupted `__str_flatten`'s
+   body through the late-import shift ("call[0] expected (ref null 5),
+   found i32.const").
+3. **for-of / IR `forof.string` iterated code UNITS** — §22.1.5.1 String
+   iteration yields code POINTS (a surrogate pair is one 2-unit element).
+   Both the legacy `compileForOfString` (loops.ts) and the IR lowering
+   (`src/ir/lower.ts` `forof.string`) advanced by a fixed +1.
+4. **`localeCompare` always returned 0** — fell through to "Unknown string
+   method", demoted to a `f64.const 0` stub. Violates §22.1.3.12's
+   consistency requirement (everything compared "equal").
+5. **`toLocaleLowerCase`/`toLocaleUpperCase`** hit the same numeric-zero
+   stub.
+
+**Fixes (pure Wasm, no new imports):**
+- New `$__str_to_char_vec(s: ref $AnyString) -> ref $vec_nstr` helper
+  (`src/codegen/native-strings.ts`, `ensureStrToCharVecHelper`) — the
+  §22.1.5.1 materializer; reuses `__str_split`'s `ref_<anyStr>` vec
+  registration so the result IS the `string[]` shape. Wired into the
+  array-literal spread path and a new `Array.from(string)` fast path
+  (`src/codegen/expressions/calls.ts`, tentative-compile + rollback per the
+  #1610 pattern). Spread element-type inference now maps a string spread
+  source to the nstr element type.
+- New `$__str_charAt_cp(s, idx)` helper (registered with the main suite,
+  right after `__str_charAt`) — code-point charAt returning the whole pair.
+  The IR `forof.string` lowering calls it and advances the cursor by the
+  element's `len` (no new slots needed). The legacy `compileForOfString`
+  flattens once up front and does the surrogate check inline on the raw
+  code units (also removes the per-iteration re-flatten).
+- `localeCompare` lowers to the native `__str_compare` (-1/0/1, UTF-16
+  code-unit order — a valid §22.1.3.12 implementation-defined consistent
+  total order absent ECMA-402); locales/options args evaluated + dropped.
+- `toLocale{Lower,Upper}Case` alias the default case-fold arm.
+
+**Verified:** `[..."a😀b"].length === 3` (middle element len 2),
+`Array.from("abc")` native vec (no env imports, empty-import instantiate),
+for-of yields pairs as one element in BOTH IR and legacy paths, lone
+surrogates stay separate, localeCompare total order matches `<`. Tests:
+`tests/issue-1470-string-iteration-standalone.test.ts` (8 cases:
+standalone + WASI parity + gc-host regression guard).
+
+**Known remaining (documented, deferred):**
+- Non-ASCII case folding (`"À".toLowerCase()` is identity) and
+  `normalize()` composition (identity) need Unicode tables — the issue's
+  `--full-unicode` follow-up (#640-family). Both are *silent-identity*, not
+  import leaks.
+- gc / JS-host mode `[..."abc"]` returns an empty array on main too
+  (pre-existing host-mode gap in the externref spread branch's
+  `__extern_length` on a JS string) — out of #1470's standalone scope,
+  needs its own issue.
+- Standalone `Array.from(<non-string non-array iterable>)` still falls to
+  the `__array_from` host fallback — owned by the #1320 iterator bridge.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -121,6 +121,7 @@ import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-sup
 import { tryCompileNativeGeneratorMethodCall } from "../generators-native.js";
 import {
   ensureNativeStringExternBridge,
+  ensureStrToCharVecHelper,
   ensureTextEncodingHelpers,
   stringConstantExternrefInstrs,
 } from "../native-strings.js";
@@ -3678,6 +3679,31 @@ function compileCallExpression(
       // `_wrapWasmClosure`. The fast path's `array.copy` would silently
       // drop the mapFn.
       const hasMapFn = expr.arguments.length >= 2;
+      // (#1470) Array.from(string) without a mapFn — the string iterable
+      // yields code points (§23.1.2.1 via §22.1.5.1). In native-strings mode
+      // materialize the char vec in pure Wasm. Without this the string fell
+      // into the host `__array_from` fallback below, which both leaks a JS
+      // host import and (post late-import shift) emitted an invalid module
+      // under --target standalone. Tentatively compile and only commit when
+      // the argument genuinely lowers to a native string ref (#1610 pattern).
+      if (!hasMapFn && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && isStringType(argTsType)) {
+        const bodyLenBefore = fctx.body.length;
+        const t = compileExpression(ctx, fctx, expr.arguments[0]!);
+        if (
+          t &&
+          (t.kind === "ref" || t.kind === "ref_null") &&
+          (t.typeIdx === ctx.anyStrTypeIdx || t.typeIdx === ctx.nativeStrTypeIdx)
+        ) {
+          if (t.kind === "ref_null") {
+            fctx.body.push({ op: "ref.as_non_null" } as Instr);
+          }
+          const { funcIdx: toCharVecIdx, vecTypeIdx: nstrVecTypeIdx } = ensureStrToCharVecHelper(ctx);
+          fctx.body.push({ op: "call", funcIdx: toCharVecIdx });
+          return { kind: "ref", typeIdx: nstrVecTypeIdx };
+        }
+        // Didn't lower as a native string — roll back and use the paths below.
+        fctx.body.length = bodyLenBefore;
+      }
       // Only handle array arguments — create a shallow copy
       if (!hasMapFn && (argWasmType.kind === "ref" || argWasmType.kind === "ref_null")) {
         const arrInfo = resolveArrayInfo(ctx, argTsType);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -14,7 +14,7 @@
  */
 
 import ts from "typescript";
-import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
+import { isStringType, isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction } from "../ir/types.js";
 import {
   compileArrowAsCallback,
@@ -24,7 +24,7 @@ import {
   promoteAccessorCapturesToGlobals,
 } from "./closures.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
-import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureStrToCharVecHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -2405,9 +2405,16 @@ export function compileArrayLiteral(
   const firstElem = firstSignificantElem ?? expr.elements[0]!;
   if (ts.isSpreadElement(firstElem)) {
     const spreadType = ctx.checker.getTypeAtLocation(firstElem.expression);
-    const typeArgs = ctx.checker.getTypeArguments(spreadType as ts.TypeReference);
-    const innerType = typeArgs[0];
-    elemWasm = innerType ? resolveWasmType(ctx, innerType) : { kind: "f64" };
+    if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && isStringType(spreadType)) {
+      // (#1470) String spread iterates code points (§22.1.5.1) — each
+      // element is a single-code-point string. Must match the element type
+      // `__str_to_char_vec` produces (same key as `__str_split`'s string[]).
+      elemWasm = { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+    } else {
+      const typeArgs = ctx.checker.getTypeArguments(spreadType as ts.TypeReference);
+      const innerType = typeArgs[0];
+      elemWasm = innerType ? resolveWasmType(ctx, innerType) : { kind: "f64" };
+    }
   } else if (ts.isOmittedExpression(firstElem) || _isUndefinedLike(firstElem)) {
     // All elements are omitted or undefined-like — consult the contextual type
     // to choose an element kind so destructuring defaults fire correctly (#1553e).
@@ -2508,6 +2515,40 @@ export function compileArrayLiteral(
     if (ts.isSpreadElement(el)) {
       const srcType = compileExpression(ctx, fctx, el.expression);
       if (!srcType) continue;
+      if (
+        (srcType.kind === "ref" || srcType.kind === "ref_null") &&
+        ctx.nativeStrings &&
+        ctx.anyStrTypeIdx >= 0 &&
+        (srcType.typeIdx === ctx.anyStrTypeIdx || srcType.typeIdx === ctx.nativeStrTypeIdx)
+      ) {
+        // (#1470) Spread of a native string — previously this fell into the
+        // generic vec-struct branch below, whose getArrTypeIdxFromVec lookup
+        // fails for the string struct and silently contributed NOTHING (the
+        // result array stayed empty). Materialize the §22.1.5.1 code-point
+        // vec in pure Wasm instead.
+        const { funcIdx: toCharVecIdx, vecTypeIdx: nstrVecTypeIdx } = ensureStrToCharVecHelper(ctx);
+        if (vecTypeIdx !== nstrVecTypeIdx) {
+          // Result element type is not string (mixed literal like
+          // `[1, ..."ab"]` whose first-element heuristic picked f64) —
+          // copying string refs into that array would be invalid Wasm.
+          // Preserve the pre-existing skip behavior for this rare shape.
+          fctx.body.push({ op: "drop" });
+          continue;
+        }
+        if (srcType.kind === "ref_null") {
+          fctx.body.push({ op: "ref.as_non_null" } as Instr);
+        }
+        fctx.body.push({ op: "call", funcIdx: toCharVecIdx });
+        const srcLocal = allocLocal(fctx, `__spread_str_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: nstrVecTypeIdx,
+        });
+        fctx.body.push({ op: "local.tee", index: srcLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: nstrVecTypeIdx, fieldIdx: 0 });
+        fctx.body.push({ op: "i32.add" });
+        spreadLocals.push({ local: srcLocal, elemIdx: i, srcVecTypeIdx: nstrVecTypeIdx });
+        continue;
+      }
       if (srcType.kind === "externref") {
         // #1514 — Spread of a JS iterable (Set, Map, generator, Array, etc.)
         // arriving as externref. Materialize into a wasm vec matching the

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -1949,6 +1949,104 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     });
   }
 
+  // --- $__str_charAt_cp(s: ref $NativeString, idx: i32) -> ref $NativeString ---
+  // (#1470) Code-POINT charAt: like __str_charAt but when the code unit at
+  // `idx` is a high surrogate followed by a low surrogate, returns the whole
+  // 2-code-unit pair (§22.1.5.1 String iteration / §11.1.4 CodePointAt).
+  // Lone surrogates and BMP scalars return the single unit. Used by the
+  // for-of / spread / Array.from string-iteration lowerings; callers advance
+  // their cursor by the returned string's `len`.
+  {
+    const typeIdx = addFuncType(ctx, [strRef, { kind: "i32" }], [strRef]);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.nativeStrHelpers.set("__str_charAt_cp", funcIdx);
+    const substringIdx = ctx.nativeStrHelpers.get("__str_substring")!;
+
+    const body: Instr[] = [
+      // Bounds check: if idx < 0 || idx >= s.len, return empty string
+      { op: "local.get", index: 1 },
+      { op: "i32.const", value: 0 },
+      { op: "i32.lt_s" },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
+      { op: "i32.ge_s" },
+      { op: "i32.or" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: strRef },
+        then: [
+          // empty string: len=0, off=0, empty array
+          { op: "i32.const", value: 0 },
+          { op: "i32.const", value: 0 },
+          { op: "i32.const", value: 0 },
+          { op: "array.new_default", typeIdx: strDataTypeIdx },
+          { op: "struct.new", typeIdx: strTypeIdx },
+        ],
+        else: [
+          // __str_substring(s, idx, idx + 1 + isPair)
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 1 },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          // isPair = (data[off+idx] & 0xFC00) == 0xD800 && idx + 1 < len
+          //          && (data[off+idx+1] & 0xFC00) == 0xDC00
+          { op: "local.get", index: 0 },
+          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // .data
+          { op: "local.get", index: 0 },
+          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // .off
+          { op: "local.get", index: 1 },
+          { op: "i32.add" },
+          { op: "array.get_u", typeIdx: strDataTypeIdx },
+          { op: "i32.const", value: 0xfc00 },
+          { op: "i32.and" },
+          { op: "i32.const", value: 0xd800 },
+          { op: "i32.eq" },
+          { op: "local.get", index: 1 },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.get", index: 0 },
+          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // .len
+          { op: "i32.lt_s" },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              // The low-surrogate read is guarded: only reached when
+              // idx + 1 < len, so data[off+idx+1] is in bounds.
+              { op: "local.get", index: 0 },
+              { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // .data
+              { op: "local.get", index: 0 },
+              { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // .off
+              { op: "local.get", index: 1 },
+              { op: "i32.add" },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "array.get_u", typeIdx: strDataTypeIdx },
+              { op: "i32.const", value: 0xfc00 },
+              { op: "i32.and" },
+              { op: "i32.const", value: 0xdc00 },
+              { op: "i32.eq" },
+            ],
+            else: [{ op: "i32.const", value: 0 }],
+          } as Instr,
+          { op: "i32.add" }, // end = idx + 1 + isPair
+          { op: "call", funcIdx: substringIdx },
+        ],
+      },
+    ];
+
+    ctx.mod.functions.push({
+      name: "__str_charAt_cp",
+      typeIdx,
+      locals: [],
+      body: wrapBodyWithFlatten(body, [0]),
+      exported: false,
+    });
+  }
+
   // --- $__str_slice(s: ref $NativeString, start: i32, end: i32) -> ref $NativeString ---
   // Like substring but handles negative indices
   {
@@ -5494,6 +5592,201 @@ export function ensureAnyToStringHelper(ctx: CodegenContext): number {
     exported: false,
   });
   return funcIdx;
+}
+
+/**
+ * #1470 — Emit `$__str_to_char_vec(s: ref $AnyString) -> ref $vec_nstr`: the
+ * pure-Wasm String-iterator materializer. Splits the string into single
+ * **code point** strings per §22.1.5.1 (the String Iteration protocol that
+ * `[...s]`, `Array.from(s)` and for-of observe): a well-formed surrogate
+ * pair yields one 2-code-unit string; everything else (BMP scalars and lone
+ * surrogates) yields a 1-code-unit string.
+ *
+ * The result reuses the `ref_<anyStr>` vec registration that `__str_split`
+ * established, so callers get the exact vec shape `string[]` lowers to
+ * (`.length`, indexing, spreads compose without conversion). The backing
+ * array is sized `len` (the code-unit count — an upper bound on the code
+ * point count); the vec's `len` field carries the actual element count, so
+ * trailing unused slots are never observed.
+ *
+ * Returns both the helper funcIdx (current at call time — late-import shifts
+ * keep `nativeStrHelpers` patched, #1839) and the nstr vec type index.
+ */
+export function ensureStrToCharVecHelper(ctx: CodegenContext): { funcIdx: number; vecTypeIdx: number } {
+  ensureNativeStringHelpers(ctx);
+
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+
+  // Same registration key/type as `__str_split` so the vec matches string[].
+  const nstrElemKey = `ref_${anyStrTypeIdx}`;
+  const nstrElemType: ValType = { kind: "ref_null", typeIdx: anyStrTypeIdx };
+  const nstrArrTypeIdx = getOrRegisterArrayType(ctx, nstrElemKey, nstrElemType);
+  const nstrVecTypeIdx = getOrRegisterVecType(ctx, nstrElemKey, nstrElemType);
+
+  const existing = ctx.nativeStrHelpers.get("__str_to_char_vec");
+  if (existing !== undefined) return { funcIdx: existing, vecTypeIdx: nstrVecTypeIdx };
+
+  const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  const flattenIdx = ctx.funcMap.get("__str_flatten") ?? ctx.nativeStrHelpers.get("__str_flatten")!;
+  const substringIdx = ctx.nativeStrHelpers.get("__str_substring")!;
+
+  // param: s(0); locals: flat(1), len(2), off(3), data(4), out(5), n(6),
+  // i(7), cu(8), take(9)
+  const S = 0;
+  const FLAT = 1;
+  const LEN = 2;
+  const OFF = 3;
+  const DATA = 4;
+  const OUT = 5;
+  const N = 6;
+  const I = 7;
+  const CU = 8;
+  const TAKE = 9;
+
+  const body: Instr[] = [
+    // flat = __str_flatten(s); cache len/off/data
+    { op: "local.get", index: S },
+    { op: "call", funcIdx: flattenIdx },
+    { op: "local.set", index: FLAT },
+    { op: "local.get", index: FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: LEN },
+    { op: "local.get", index: FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: OFF },
+    { op: "local.get", index: FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+    { op: "local.set", index: DATA },
+
+    // out = new (ref null $AnyString)[len] — len is an upper bound on the
+    // code-point count; the vec's len field below carries the real count.
+    { op: "local.get", index: LEN },
+    { op: "array.new_default", typeIdx: nstrArrTypeIdx },
+    { op: "local.set", index: OUT },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: N },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: I },
+
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: I },
+            { op: "local.get", index: LEN },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+
+            // cu = data[off + i]; take = 1
+            { op: "local.get", index: DATA },
+            { op: "local.get", index: OFF },
+            { op: "local.get", index: I },
+            { op: "i32.add" },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.set", index: CU },
+            { op: "i32.const", value: 1 },
+            { op: "local.set", index: TAKE },
+
+            // High surrogate with a following low surrogate → take = 2
+            // (cu & 0xFC00) == 0xD800 && i + 1 < len
+            { op: "local.get", index: CU },
+            { op: "i32.const", value: 0xfc00 },
+            { op: "i32.and" },
+            { op: "i32.const", value: 0xd800 },
+            { op: "i32.eq" },
+            { op: "local.get", index: I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.get", index: LEN },
+            { op: "i32.lt_s" },
+            { op: "i32.and" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                // (data[off + i + 1] & 0xFC00) == 0xDC00 → take = 2
+                { op: "local.get", index: DATA },
+                { op: "local.get", index: OFF },
+                { op: "local.get", index: I },
+                { op: "i32.add" },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "array.get_u", typeIdx: strDataTypeIdx },
+                { op: "i32.const", value: 0xfc00 },
+                { op: "i32.and" },
+                { op: "i32.const", value: 0xdc00 },
+                { op: "i32.eq" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    { op: "i32.const", value: 2 },
+                    { op: "local.set", index: TAKE },
+                  ],
+                } as Instr,
+              ],
+            } as Instr,
+
+            // out[n] = __str_substring(flat, i, i + take); n++; i += take
+            { op: "local.get", index: OUT },
+            { op: "local.get", index: N },
+            { op: "local.get", index: FLAT },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: I },
+            { op: "local.get", index: I },
+            { op: "local.get", index: TAKE },
+            { op: "i32.add" },
+            { op: "call", funcIdx: substringIdx },
+            { op: "array.set", typeIdx: nstrArrTypeIdx },
+            { op: "local.get", index: N },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: N },
+            { op: "local.get", index: I },
+            { op: "local.get", index: TAKE },
+            { op: "i32.add" },
+            { op: "local.set", index: I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // return { len: n, data: out }
+    { op: "local.get", index: N },
+    { op: "local.get", index: OUT },
+    { op: "ref.as_non_null" } as Instr,
+    { op: "struct.new", typeIdx: nstrVecTypeIdx },
+  ];
+
+  const typeIdx = addFuncType(ctx, [strRef], [{ kind: "ref", typeIdx: nstrVecTypeIdx }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.nativeStrHelpers.set("__str_to_char_vec", funcIdx);
+  ctx.funcMap.set("__str_to_char_vec", funcIdx);
+  ctx.mod.functions.push({
+    name: "__str_to_char_vec",
+    typeIdx,
+    locals: [
+      { name: "flat", type: { kind: "ref_null", typeIdx: strTypeIdx } },
+      { name: "len", type: { kind: "i32" } },
+      { name: "off", type: { kind: "i32" } },
+      { name: "data", type: { kind: "ref_null", typeIdx: strDataTypeIdx } },
+      { name: "out", type: { kind: "ref_null", typeIdx: nstrArrTypeIdx } },
+      { name: "n", type: { kind: "i32" } },
+      { name: "i", type: { kind: "i32" } },
+      { name: "cu", type: { kind: "i32" } },
+      { name: "take", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+  return { funcIdx, vecTypeIdx: nstrVecTypeIdx };
 }
 
 export function ensureNativeStringExternBridge(ctx: CodegenContext): void {

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -2461,20 +2461,20 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   // The IR path (#1183) sidesteps this by walking
   // `ctx.mod.functions[i].name` at lowering time. Mirroring that here
   // for the legacy path:
-  let charAtIdx: number | undefined;
+  let flattenIdx: number | undefined;
+  let substringIdx: number | undefined;
   for (let i = 0; i < ctx.mod.functions.length; i++) {
-    if (ctx.mod.functions[i]!.name === "__str_charAt") {
-      charAtIdx = ctx.numImportFuncs + i;
-      break;
-    }
+    const name = ctx.mod.functions[i]!.name;
+    if (name === "__str_flatten") flattenIdx = ctx.numImportFuncs + i;
+    else if (name === "__str_substring") substringIdx = ctx.numImportFuncs + i;
+    if (flattenIdx !== undefined && substringIdx !== undefined) break;
   }
-  if (charAtIdx === undefined) {
-    reportError(ctx, stmt, "for-of on string: __str_charAt helper not available");
+  if (flattenIdx === undefined || substringIdx === undefined) {
+    reportError(ctx, stmt, "for-of on string: __str_flatten/__str_substring helpers not available");
     return;
   }
 
   const strType = nativeStringType(ctx);
-  const anyStrTypeIdx = ctx.anyStrTypeIdx;
 
   // Compile the iterable expression (string ref)
   const bodyLenBefore = fctx.body.length;
@@ -2492,13 +2492,42 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   // Mark position for null guard wrapping
   const strNullGuardStart = fctx.body.length;
 
-  // Extract length from string (field 0 of AnyString struct)
+  // (#1470) Flatten ONCE up front and cache len/off/data: the loop reads raw
+  // code units to detect surrogate pairs (§22.1.5.1 — the String iterator
+  // yields code points, so a well-formed pair is one 2-code-unit element).
+  const flatLocal = allocLocal(fctx, `__forof_flat_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: ctx.nativeStrTypeIdx,
+  });
+  fctx.body.push({ op: "local.get", index: strLocal });
+  fctx.body.push({ op: "call", funcIdx: flattenIdx });
+  fctx.body.push({ op: "local.set", index: flatLocal });
+
   const lenLocal = allocLocal(fctx, `__forof_len_${fctx.locals.length}`, {
     kind: "i32",
   });
-  fctx.body.push({ op: "local.get", index: strLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: lenLocal });
+
+  const offLocal = allocLocal(fctx, `__forof_off_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 1 });
+  fctx.body.push({ op: "local.set", index: offLocal });
+
+  const dataLocal = allocLocal(fctx, `__forof_data_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: ctx.nativeStrDataTypeIdx,
+  });
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 2 });
+  fctx.body.push({ op: "local.set", index: dataLocal });
+
+  const takeLocal = allocLocal(fctx, `__forof_take_${fctx.locals.length}`, {
+    kind: "i32",
+  });
 
   // Allocate counter local (i32)
   const iLocal = allocLocal(fctx, `__forof_i_${fctx.locals.length}`, {
@@ -2547,10 +2576,61 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   fctx.body.push({ op: "i32.ge_s" });
   fctx.body.push({ op: "br_if", depth: 1 }); // break
 
-  // Get character: c = charAt(str, i)
-  fctx.body.push({ op: "local.get", index: strLocal });
+  // take = 1; if data[off+i] is a high surrogate followed by a low surrogate,
+  // take = 2 (the pair is one code point — §22.1.5.1).
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "local.set", index: takeLocal });
+  // (data[off + i] & 0xFC00) == 0xD800 && i + 1 < len
+  fctx.body.push({ op: "local.get", index: dataLocal });
+  fctx.body.push({ op: "local.get", index: offLocal });
   fctx.body.push({ op: "local.get", index: iLocal });
-  fctx.body.push({ op: "call", funcIdx: charAtIdx });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx });
+  fctx.body.push({ op: "i32.const", value: 0xfc00 });
+  fctx.body.push({ op: "i32.and" });
+  fctx.body.push({ op: "i32.const", value: 0xd800 });
+  fctx.body.push({ op: "i32.eq" });
+  fctx.body.push({ op: "local.get", index: iLocal });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "local.get", index: lenLocal });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "i32.and" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      // (data[off + i + 1] & 0xFC00) == 0xDC00 → take = 2
+      { op: "local.get", index: dataLocal },
+      { op: "local.get", index: offLocal },
+      { op: "local.get", index: iLocal },
+      { op: "i32.add" },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
+      { op: "i32.const", value: 0xfc00 },
+      { op: "i32.and" },
+      { op: "i32.const", value: 0xdc00 },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "i32.const", value: 2 },
+          { op: "local.set", index: takeLocal },
+        ],
+      } as Instr,
+    ],
+  } as Instr);
+
+  // Get element: c = __str_substring(flat, i, i + take)
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  fctx.body.push({ op: "local.get", index: iLocal });
+  fctx.body.push({ op: "local.get", index: iLocal });
+  fctx.body.push({ op: "local.get", index: takeLocal });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "call", funcIdx: substringIdx });
   fctx.body.push({ op: "local.set", index: elemLocal });
 
   // Compile body — save/restore block-scoped shadows for let/const (#817).
@@ -2564,9 +2644,9 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
     compileStatement(ctx, fctx, stmt.statement);
   }
 
-  // Increment i
+  // Advance by the consumed code-unit count (1, or 2 for a surrogate pair)
   fctx.body.push({ op: "local.get", index: iLocal });
-  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "local.get", index: takeLocal });
   fctx.body.push({ op: "i32.add" });
   fctx.body.push({ op: "local.set", index: iLocal });
 

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2188,13 +2188,49 @@ export function compileNativeStringMethodCall(
   }
 
   // toLowerCase, toUpperCase: native helpers
-  if (method === "toLowerCase" || method === "toUpperCase") {
+  if (
+    method === "toLowerCase" ||
+    method === "toUpperCase" ||
+    method === "toLocaleLowerCase" ||
+    method === "toLocaleUpperCase"
+  ) {
+    // (#1470) toLocale{Lower,Upper}Case without ECMA-402 falls back to the
+    // default case conversion (§22.1.3.27/§22.1.3.29 note this is the same as
+    // toLowerCase/toUpperCase except for locale-sensitive mappings, which a
+    // standalone module has no ICU tables for). Previously these fell through
+    // to "Unknown string method" and got demoted to a numeric-zero stub.
     compileExpression(ctx, fctx, propAccess.expression);
     emitFlatten();
-    const helperName = `__str_${method}`;
+    // Locale arguments are still evaluated, in order, for side effects.
+    for (const arg of expr.arguments) {
+      const argType = compileExpression(ctx, fctx, arg);
+      if (argType) fctx.body.push({ op: "drop" });
+    }
+    const helperName = `__str_${method.replace("Locale", "")}`;
     const funcIdx = ctx.nativeStrHelpers.get(helperName)!;
     fctx.body.push({ op: "call", funcIdx });
     return nativeStringType(ctx);
+  }
+
+  // (#1470) localeCompare — §22.1.3.12 only requires an implementation-
+  // defined CONSISTENT total order when ECMA-402 is absent; we use UTF-16
+  // code-unit order via the native __str_compare helper (the same order the
+  // relational operators use). Previously this fell through to "Unknown
+  // string method" and got demoted to an always-0 stub, which violates the
+  // consistency requirement (every pair compared "equal"). The locales /
+  // options arguments are evaluated for side effects and ignored.
+  if (method === "localeCompare") {
+    compileExpression(ctx, fctx, propAccess.expression);
+    const thatLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__lc_that");
+    for (let ai = 1; ai < expr.arguments.length; ai++) {
+      const argType = compileExpression(ctx, fctx, expr.arguments[ai]!);
+      if (argType) fctx.body.push({ op: "drop" });
+    }
+    fctx.body.push({ op: "local.get", index: thatLocal });
+    const funcIdx = ctx.nativeStrHelpers.get("__str_compare")!;
+    fctx.body.push({ op: "call", funcIdx });
+    fctx.body.push({ op: "f64.convert_i32_s" });
+    return { kind: "f64" };
   }
 
   // For replace/replaceAll/split with non-string args (RegExp or custom objects

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1725,9 +1725,13 @@ export function lowerIrFunctionBody<S>(
       // ensures this case only runs in native-strings mode (host-strings
       // mode falls through to forof.iter).
       case "forof.string": {
+        // (#1470) __str_charAt_cp — the code-POINT charAt. §22.1.5.1 String
+        // iteration yields code points: a well-formed surrogate pair is ONE
+        // 2-code-unit element. The cursor advances by the element's `len`
+        // (1, or 2 for a pair) below instead of a fixed +1.
         const charAtIdx = resolver.resolveFunc({
           kind: "func",
-          name: "__str_charAt",
+          name: "__str_charAt_cp",
         });
         // The AnyString struct's `len` field is at index 0 (matches
         // `nativeStringType` in src/codegen/native-strings.ts).
@@ -1779,7 +1783,7 @@ export function lowerIrFunctionBody<S>(
         // #1584 (a3): control-flow ops route through the trait.
         emitter.emitBrIf(1, loopBody as unknown as S);
 
-        // element = __str_charAt(str, counter)
+        // element = __str_charAt_cp(str, counter)
         loopBody.push({ op: "local.get", index: slotWasmIdx(instr.strSlot) });
         loopBody.push({
           op: "local.get",
@@ -1805,12 +1809,18 @@ export function lowerIrFunctionBody<S>(
           }
         }
 
-        // counter = counter + 1
+        // counter = counter + element.len — the element is the whole code
+        // point (1 code unit, or 2 for a surrogate pair), and it is never
+        // empty inside the bounds-checked loop, so this always advances.
         loopBody.push({
           op: "local.get",
           index: slotWasmIdx(instr.counterSlot),
         });
-        loopBody.push({ op: "i32.const", value: 1 });
+        loopBody.push({
+          op: "local.get",
+          index: slotWasmIdx(instr.elementSlot),
+        });
+        loopBody.push({ op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 });
         loopBody.push({ op: "i32.add" });
         loopBody.push({
           op: "local.set",

--- a/tests/issue-1470-string-iteration-standalone.test.ts
+++ b/tests/issue-1470-string-iteration-standalone.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1470 residual sweep — string iteration + comparison must be pure Wasm and
+ * spec-correct under `--target standalone`:
+ *
+ * 1. `[...str]` previously fell into the generic vec-spread branch, whose
+ *    array-type lookup fails for the string struct and silently contributed
+ *    NOTHING (`[..."abc"].length === 0`, elements null).
+ * 2. `Array.from(str)` fell into the `__array_from` JS-host fallback — an
+ *    env:: import leak AND (post late-import shift) an invalid module.
+ * 3. `for (const c of str)` iterated code UNITS; §22.1.5.1 String iteration
+ *    yields code POINTS (a well-formed surrogate pair is one element).
+ * 4. `a.localeCompare(b)` fell through to "Unknown string method" and was
+ *    demoted to an always-0 stub — violating §22.1.3.12's consistency
+ *    requirement. Now lowers to UTF-16 code-unit order via __str_compare.
+ * 5. `toLocaleLowerCase`/`toLocaleUpperCase` hit the same always-0 stub; they
+ *    now alias the default case conversion (no ECMA-402 tables).
+ *
+ * Each case instantiates with an EMPTY import object — proving no JS host.
+ */
+
+async function instantiate(source: string, target: "standalone" | "wasi" = "standalone") {
+  const r = await compile(source, { target });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envLeaks = r.imports.filter((i) => i.module === "env" || i.module.startsWith("wasm:js-string"));
+  expect(
+    envLeaks.map((i) => `${i.module}::${i.name}`),
+    "JS-host imports leaked",
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, (...args: number[]) => number>;
+}
+
+describe("#1470 string spread — standalone", () => {
+  it("[...str] yields one element per code point", async () => {
+    const ex = await instantiate(`
+      export function len(): number { return [..."abc"].length; }
+      export function elem1(): number { const a = [..."abc"]; return a[1].charCodeAt(0); }
+      export function astralLen(): number { return [..."a\\u{1F600}b"].length; }
+      export function astralMidLen(): number { const a = [..."a\\u{1F600}b"]; return a[1].length; }
+      export function loneSurrogate(): number { return [..."a\\uD800b"].length; }
+      export function empty(): number { return [...""].length; }
+      export function consSpread(a: string, b: string): number { const s = a + b; return [...s].length; }
+    `);
+    expect(ex.len!()).toBe(3);
+    expect(ex.elem1!()).toBe(98); // "b"
+    expect(ex.astralLen!()).toBe(3); // §22.1.5.1: pair is ONE element
+    expect(ex.astralMidLen!()).toBe(2); // ...of TWO code units
+    expect(ex.loneSurrogate!()).toBe(3); // lone surrogate stays its own element
+    expect(ex.empty!()).toBe(0);
+  });
+
+  it("mixed prefix element + string spread composes", async () => {
+    const ex = await instantiate(`
+      export function f(): number {
+        const a = ["x", ..."yz"];
+        return a.length * 1000 + a[2].charCodeAt(0);
+      }
+    `);
+    expect(ex.f!()).toBe(3122); // len 3, "z" = 122
+  });
+});
+
+describe("#1470 Array.from(string) — standalone", () => {
+  it("materializes the code-point vec natively (no __array_from)", async () => {
+    const ex = await instantiate(`
+      export function len(): number { return Array.from("abc").length; }
+      export function elem(): number { return Array.from("abc")[2].charCodeAt(0); }
+      export function astral(): number { return Array.from("\\u{1F600}").length; }
+    `);
+    expect(ex.len!()).toBe(3);
+    expect(ex.elem!()).toBe(99); // "c"
+    expect(ex.astral!()).toBe(1);
+  });
+});
+
+describe("#1470 for-of over strings — code points (standalone)", () => {
+  it("yields surrogate pairs as one 2-unit element", async () => {
+    const ex = await instantiate(`
+      export function count(): number { let c = 0; for (const ch of "a\\u{1F600}b") c++; return c; }
+      export function pairLen(): number { for (const ch of "\\u{1F600}") return ch.length; return -1; }
+      export function sumAscii(): number { let c = 0; for (const ch of "abc") c += ch.charCodeAt(0); return c; }
+      export function loneCount(): number { let c = 0; for (const ch of "\\uD800\\uD800") c++; return c; }
+    `);
+    expect(ex.count!()).toBe(3);
+    expect(ex.pairLen!()).toBe(2);
+    expect(ex.sumAscii!()).toBe(294);
+    expect(ex.loneCount!()).toBe(2); // unpaired highs stay separate elements
+  });
+});
+
+describe("#1470 localeCompare / toLocale case — standalone", () => {
+  it("localeCompare is a consistent total order (code-unit)", async () => {
+    const ex = await instantiate(`
+      export function lt(): number { return "a".localeCompare("b"); }
+      export function gt(): number { return "b".localeCompare("a"); }
+      export function eq(): number { return "ab".localeCompare("a" + "b"); }
+      export function prefix(): number { return "a".localeCompare("ab"); }
+    `);
+    expect(ex.lt!()).toBe(-1);
+    expect(ex.gt!()).toBe(1);
+    expect(ex.eq!()).toBe(0);
+    expect(ex.prefix!()).toBe(-1);
+  });
+
+  it("toLocaleLowerCase/toLocaleUpperCase fall back to default case fold", async () => {
+    const ex = await instantiate(`
+      export function lower(): number { return "AbC".toLocaleLowerCase().charCodeAt(0); }
+      export function upper(): number { return "aBc".toLocaleUpperCase().charCodeAt(0); }
+      export function lowerLen(): number { return "AbC".toLocaleLowerCase("en-US").length; }
+    `);
+    expect(ex.lower!()).toBe(97); // "a"
+    expect(ex.upper!()).toBe(65); // "A"
+    expect(ex.lowerLen!()).toBe(3);
+  });
+});
+
+describe("#1470 string iteration — WASI parity", () => {
+  it("the same iteration semantics hold under --target wasi", async () => {
+    const ex = await instantiate(
+      `
+      export function spreadLen(): number { return [..."a\\u{1F600}b"].length; }
+      export function forofCount(): number { let c = 0; for (const ch of "a\\u{1F600}b") c++; return c; }
+      export function lc(): number { return "a".localeCompare("b"); }
+    `,
+      "wasi",
+    );
+    expect(ex.spreadLen!()).toBe(3);
+    expect(ex.forofCount!()).toBe(3);
+    expect(ex.lc!()).toBe(-1);
+  });
+});
+
+describe("#1470 default (gc / JS-host) mode regression guard", () => {
+  it("keeps for-of/localeCompare behavior in JS-host mode", async () => {
+    // NOTE: gc-mode `[..."abc"]` is a PRE-EXISTING host-mode gap (the
+    // externref spread branch's __extern_length on a JS string yields 0) —
+    // verified broken on main before this change; tracked separately. This
+    // guard pins the paths this PR could plausibly affect.
+    const r = await compile(
+      `
+      export function forofCount(): number { let c = 0; for (const ch of "abc") c++; return c; }
+      export function lc(): number { return "a".localeCompare("b"); }
+    `,
+      {},
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // #1667 — compile() returns a ready-to-pass importObject for JS-host mode.
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject!);
+    const ex = instance.exports as Record<string, () => number>;
+    expect(ex.forofCount!()).toBe(3);
+    expect(ex.lc!()).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary

Residual sweep for #1470, deliberately **non-overlapping with Codex PR #1283** (which owns the WASI fd_write UTF-8 encoder in `ensureWasiWriteAnyStringHelper` + `tests/issue-1470.test.ts` — neither file is touched here).

A 45-case behavioral probe of `--target standalone` string ops against real JS evaluation showed the remaining defects are not import leaks (the import section was already clean) but silently-wrong or invalid lowerings on the String-iteration and `string_method` fall-through paths:

- **`[...str]` contributed nothing** (`[..."abc"].length === 0`, null elements): the native string struct fell into the generic vec-spread branch, whose `getArrTypeIdxFromVec` lookup fails and silently `continue`s. Now materializes a §22.1.5.1 code-point vec via a new pure-Wasm `$__str_to_char_vec` helper (reuses `__str_split`'s `ref_<anyStr>` vec shape, so the result IS `string[]`).
- **`Array.from(str)` emitted an invalid module**: the string fell to the `env::__array_from` host fallback, which leaks the import AND corrupted `__str_flatten` through the late-import shift. New native fast path through the same helper (tentative-compile + rollback, #1610 pattern). Non-string standalone iterables stay with the #1320 iterator bridge.
- **for-of over strings iterated code units**, splitting surrogate pairs (§22.1.5.1 yields code points). Fixed in **both** front-ends: legacy `compileForOfString` (flatten once, inline pair check, advance by take) and the IR `forof.string` lowering (new `$__str_charAt_cp` helper; cursor advances by the element's `len`, no new IR slots).
- **`localeCompare` always returned 0** (demoted "Unknown string method" stub — violates §22.1.3.12 consistency). Now lowers to native `__str_compare` (UTF-16 code-unit total order, a valid implementation-defined order absent ECMA-402). `toLocaleLowerCase`/`toLocaleUpperCase` alias the default case-fold arm instead of the numeric-zero stub.

Deferred + documented in the issue file: non-ASCII case fold / `normalize` composition (Unicode tables, #640-family), and the **pre-existing** gc-host-mode string-spread gap (broken on main before this PR; needs its own issue).

## Validation

- `tests/issue-1470-string-iteration-standalone.test.ts` (new, 8 cases: standalone + WASI parity + gc-host regression guard, all instantiated with an empty import object)
- `native-strings` (86), `native-strings-standalone`, `issue-1470-standalone-string-imports` (14), `issue-1470-string-coercion-standalone`, `issue-1183` (IR string for-of), `issue-1759`, `issue-1618-1651-wasi-stdout` — all green
- `node scripts/equivalence-gate.mjs` — no new regressions; newly FIXES "for await...of with string iteration"
- `pnpm run check:ir-fallbacks` — OK, `tsc --noEmit`, prettier, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)