### PR TITLE
feat(regexp): standalone matcher Phase 2d Slice A — lookaround, modifiers, d flag (#1911)

### DIFF
--- a/plan/issues/1911-standalone-regexp-phase-2d-unicode-lookaround.md
+++ b/plan/issues/1911-standalone-regexp-phase-2d-unicode-lookaround.md
@@ -1,11 +1,11 @@
 ---
 id: 1911
 title: "standalone RegExp Phase 2d: u/v/d flags, Unicode escapes, lookaround, modifiers"
-status: ready
+status: in-progress
 sprint: 61
 model: fable
 created: 2026-06-07
-updated: 2026-06-07
+updated: 2026-06-10
 priority: critical
 feasibility: hard
 reasoning_effort: high
@@ -48,3 +48,50 @@ Representative signatures from the 2026-06-07 standalone JSONL:
   test262 rows leave the `standalone-regexp-phase-2d` bucket.
 - Any remaining refusals cite the specific follow-up phase or issue.
 - Focused standalone tests prove no `env.RegExp_*` host import is emitted.
+
+## Implementation Notes — Slice A (fable-rx-engine, 2026-06-10)
+
+Landed (stacked on #1912 / PR #1300):
+
+- **Lookahead `(?=) (?!)` + lookbehind `(?<=) (?<!)`** — new
+  `ReOp.LOOKAROUND [subPc, bit0 negated | bit1 behind]`. Bodies compile to
+  SUB-PROGRAMS appended after the main MATCH; the VM runs them as a fresh
+  anchored attempt via a _recursive_ `__regex_run` call (new `entryPc` + `dir`
+  params), which is what makes assertions atomic — no backtrack entries leak
+  into the outer attempt. Lookbehind bodies are compiled REVERSED (concat
+  order flipped, capture SAVE slots swapped so spans stay [left, right]) and
+  run with direction -1, reading the unit at sp-1 — the Irregexp approach.
+  Backrefs inside lookbehind match right-to-left. Captures from a successful
+  positive lookaround persist; all other outcomes restore the pre-assertion
+  capture snapshot (§22.2.2.4).
+- **Direction-aware Wasm VM** — the dispatch head computes a per-step
+  `inb`/unit pair from `dir`; CHAR/CHARI/ANY/CLASS/BACKREF advance `sp += dir`.
+  (Found and fixed during this slice: the CHAR/CHARI arms had their own inline
+  `sp+1` advance separate from `advance1()` — multi-unit lookbehind walked the
+  wrong way until they were unified.)
+- **Inline modifier groups `(?ims-ims:…)`** (regexp-modifiers proposal) —
+  pure compile-time flag scoping: the bytecode emitter's i/m/s state nests
+  with the group; lookaround bodies snapshot the modifier state at their
+  syntactic position since they compile later. Invalid modifier syntax
+  (`(?I:`, duplicates, both-sides, empty) refuses at parse and lowers to a
+  runtime SyntaxError at `new RegExp(...)` sites via the #1912 host oracle.
+- **Quantified lookarounds** (Annex B QuantifiableAssertion) rewrite to their
+  zero-width-idempotent equivalent at parse (`X*` → `X?`, `X+` → `X`,
+  `X{0,0}` → ε) — correct because a lookaround is deterministic at a fixed
+  position, and it avoids a zero-progress SPLIT loop.
+- **`d` flag accepted** — no matching-semantics change; the `.indices` result
+  surface belongs to #1914 (fable-rx-surface).
+
+## Remaining — Slice B (u/v code-point semantics)
+
+- `u` flag: `\u{…}` escapes, astral code points via surrogate-pair
+  desugaring (regexpu-style alternation), code-point `.`, Unicode case
+  folding for `i`.
+- `\p{…}`/`\P{…}` property escapes — planned approach: expand to plain
+  range lists at COMPILE TIME by enumerating code points against the host
+  `RegExp` (the compiler runs on Node; no runtime tables, no host imports),
+  then astral-desugar. Cache per (class, flags).
+- `v` flag (UnicodeSets): same host-enumeration approach for char-class
+  semantics; `\q{…}` string disjunctions stay refused.
+- Negative u/v syntax tests already pass via the #1912 host-oracle runtime
+  SyntaxError lowering at `new RegExp(...)` sites.

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -201,12 +201,19 @@ function emitClassMatch(ctx: CodegenContext): number {
  * Signature:
  *   __regex_run(prog: ref array<i32>, classTable: ref array<i32>,
  *               nSlots: i32, strData: ref array<i16>, strOff: i32, strLen: i32,
- *               startIdx: i32, caps: ref array<i32>) -> i32
+ *               startIdx: i32, caps: ref array<i32>,
+ *               entryPc: i32, dir: i32) -> i32
  *
  * `caps` is caller-allocated, length `nSlots`, pre-filled with -1. On a match
  * (1 returned) the slots hold `[g0s,g0e,g1s,g1e,…]`; -1 = unset. This is one
  * anchored attempt at `startIdx`; the start-position scan lives in the
  * higher-level helpers (`__regex_search`).
+ *
+ * #1911: `entryPc` selects the (sub-)program, `dir` the scan direction (+1
+ * forward, -1 for lookbehind sub-programs — consuming ops read the unit at
+ * sp-1 and decrement). LOOKAROUND recursively calls this function on its
+ * sub-program at the current position; the recursion is what makes
+ * lookarounds atomic (no backtrack entries leak into the outer attempt).
  */
 export function ensureRegexRun(ctx: CodegenContext): number {
   const existing = ctx.nativeRegexHelpers.get("__regex_run");
@@ -231,6 +238,8 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       { kind: "i32" }, // strLen
       { kind: "i32" }, // startIdx
       i32ArrRef, // caps
+      { kind: "i32" }, // entryPc (#1911 — 0 for the main program)
+      { kind: "i32" }, // dir (#1911 — +1 forward, -1 lookbehind)
     ],
     [{ kind: "i32" }],
   );
@@ -245,28 +254,31 @@ export function ensureRegexRun(ctx: CodegenContext): number {
     SOFF = 4,
     SLEN = 5,
     START = 6,
-    CAPS = 7;
+    CAPS = 7,
+    ENTRYPC = 8,
+    DIR = 9;
   // locals
-  const PC = 8; // i32 program counter (instruction index)
-  const SP = 9; // i32 string position
-  const STEPS = 10; // i32 step counter
-  const STACK = 11; // ref $__ReFrameArr — backtrack stack
-  const TOP = 12; // i32 stack top (count of live frames)
-  const CAP_USED = 13; // i32 stack capacity
-  const OP = 14; // i32 current opcode
-  const A = 15; // i32 operand a
-  const B = 16; // i32 operand b
-  const FAILED = 17; // i32 fail flag
-  const CH = 18; // i32 current code unit
-  const FRAME = 19; // ref null $__ReFrame — popped/pushed frame
-  const SNAP = 20; // ref array<i32> — caps snapshot
-  const TMPI = 21; // i32 scratch
-  const NEWSTACK = 22; // ref $__ReFrameArr — grown stack
-  const GS = 23; // i32 backref group start (#1912)
-  const GE = 24; // i32 backref group end (#1912)
-  const BLEN = 25; // i32 backref length (#1912)
-  const JJ = 26; // i32 backref compare cursor (#1912)
-  const C1 = 27; // i32 backref left-hand unit (#1912)
+  const PC = 10; // i32 program counter (instruction index)
+  const SP = 11; // i32 string position
+  const STEPS = 12; // i32 step counter
+  const STACK = 13; // ref $__ReFrameArr — backtrack stack
+  const TOP = 14; // i32 stack top (count of live frames)
+  const CAP_USED = 15; // i32 stack capacity
+  const OP = 16; // i32 current opcode
+  const A = 17; // i32 operand a
+  const B = 18; // i32 operand b
+  const FAILED = 19; // i32 fail flag
+  const CH = 20; // i32 current code unit
+  const FRAME = 21; // ref null $__ReFrame — popped/pushed frame
+  const SNAP = 22; // ref array<i32> — caps snapshot
+  const TMPI = 23; // i32 scratch
+  const NEWSTACK = 24; // ref $__ReFrameArr — grown stack
+  const GS = 25; // i32 backref group start (#1912)
+  const GE = 26; // i32 backref group end (#1912)
+  const BLEN = 27; // i32 backref length (#1912)
+  const JJ = 28; // i32 backref compare cursor (#1912)
+  const C1 = 29; // i32 backref left-hand unit (#1912)
+  const INB = 30; // i32 direction-aware in-bounds flag (#1911)
 
   // Helper: read prog[pc*3 + k]
   const readProg = (k: number): Instr[] => [
@@ -306,11 +318,21 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   // The dispatch switch over OP. We emit an if/else chain (op === k) … .
   // Each arm sets PC/SP/CAPS or FAILED. MATCH returns 1 directly.
   const dispatch: Instr[] = [
-    // CHAR / CHARI: compare a code unit.
-    // ch = (sp < slen) ? strData[soff+sp] : -1
-    { op: "local.get", index: SP },
-    { op: "local.get", index: SLEN },
-    { op: "i32.lt_s" },
+    // Direction-aware bounds + unit read (#1911):
+    // inb = dir>0 ? sp<slen : sp>0
+    { op: "local.get", index: DIR },
+    { op: "i32.const", value: 0 },
+    { op: "i32.gt_s" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "local.get", index: SP }, { op: "local.get", index: SLEN }, { op: "i32.lt_s" }],
+      else: [{ op: "local.get", index: SP }, { op: "i32.const", value: 0 }, { op: "i32.gt_s" }],
+    },
+    { op: "local.set", index: INB },
+    // ch = inb ? strData[soff + sp + (dir>0 ? 0 : -1)] : -1
+    // The offset term is (dir-1)>>1: +1 → 0, -1 → -1.
+    { op: "local.get", index: INB },
     {
       op: "if",
       blockType: { kind: "val", type: { kind: "i32" } },
@@ -318,6 +340,12 @@ export function ensureRegexRun(ctx: CodegenContext): number {
         { op: "local.get", index: SDATA },
         { op: "local.get", index: SOFF },
         { op: "local.get", index: SP },
+        { op: "i32.add" },
+        { op: "local.get", index: DIR },
+        { op: "i32.const", value: 1 },
+        { op: "i32.sub" },
+        { op: "i32.const", value: 1 },
+        { op: "i32.shr_s" },
         { op: "i32.add" },
         { op: "array.get_u", typeIdx: strDataIdx },
       ],
@@ -333,10 +361,8 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        // matched = sp<slen && ch==a
-        { op: "local.get", index: SP },
-        { op: "local.get", index: SLEN },
-        { op: "i32.lt_s" },
+        // matched = inb && ch==a
+        { op: "local.get", index: INB },
         { op: "local.get", index: CH },
         { op: "local.get", index: A },
         { op: "i32.eq" },
@@ -344,16 +370,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: [
-            { op: "local.get", index: SP },
-            { op: "i32.const", value: 1 },
-            { op: "i32.add" },
-            { op: "local.set", index: SP },
-            { op: "local.get", index: PC },
-            { op: "i32.const", value: 1 },
-            { op: "i32.add" },
-            { op: "local.set", index: PC },
-          ],
+          then: advance1(),
           else: [
             { op: "i32.const", value: 1 },
             { op: "local.set", index: FAILED },
@@ -370,9 +387,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
           blockType: { kind: "empty" },
           then: [
             // fold ch (A-Z -> a-z) then compare to a
-            { op: "local.get", index: SP },
-            { op: "local.get", index: SLEN },
-            { op: "i32.lt_s" },
+            { op: "local.get", index: INB },
             { op: "local.get", index: CH },
             ...foldCh(),
             { op: "local.get", index: A },
@@ -381,16 +396,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
             {
               op: "if",
               blockType: { kind: "empty" },
-              then: [
-                { op: "local.get", index: SP },
-                { op: "i32.const", value: 1 },
-                { op: "i32.add" },
-                { op: "local.set", index: SP },
-                { op: "local.get", index: PC },
-                { op: "i32.const", value: 1 },
-                { op: "i32.add" },
-                { op: "local.set", index: PC },
-              ],
+              then: advance1(),
               else: [
                 { op: "i32.const", value: 1 },
                 { op: "local.set", index: FAILED },
@@ -503,8 +509,18 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                                         op: "if",
                                         blockType: { kind: "empty" },
                                         then: backrefArm(),
-                                        // op == MATCH (the only remaining op): return 1
-                                        else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                        else: [
+                                          { op: "local.get", index: OP },
+                                          { op: "i32.const", value: ReOp.LOOKAROUND },
+                                          { op: "i32.eq" },
+                                          {
+                                            op: "if",
+                                            blockType: { kind: "empty" },
+                                            then: lookaroundArm(),
+                                            // op == MATCH (the only remaining op): return 1
+                                            else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                          },
+                                        ],
                                       },
                                     ],
                                   },
@@ -526,11 +542,9 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   }
 
   function anyArm(): Instr[] {
-    // matched = sp<slen && (a!=0 || !isLineTerminator(ch))
+    // matched = inb && (a!=0 || !isLineTerminator(ch))
     return [
-      { op: "local.get", index: SP },
-      { op: "local.get", index: SLEN },
-      { op: "i32.lt_s" },
+      { op: "local.get", index: INB },
       // (a != 0) | (!isLineTerm(ch))
       { op: "local.get", index: A },
       { op: "i32.const", value: 0 },
@@ -552,11 +566,9 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   }
 
   function classArm(): Instr[] {
-    // matched = sp<slen && class_match(ctab, a, ch, b)
+    // matched = inb && class_match(ctab, a, ch, b)
     return [
-      { op: "local.get", index: SP },
-      { op: "local.get", index: SLEN },
-      { op: "i32.lt_s" },
+      { op: "local.get", index: INB },
       {
         op: "if",
         blockType: { kind: "val", type: { kind: "i32" } },
@@ -582,9 +594,10 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   }
 
   function advance1(): Instr[] {
+    // sp += dir (#1911 — backwards in lookbehind sub-programs); pc++
     return [
       { op: "local.get", index: SP },
-      { op: "i32.const", value: 1 },
+      { op: "local.get", index: DIR },
       { op: "i32.add" },
       { op: "local.set", index: SP },
       { op: "local.get", index: PC },
@@ -865,12 +878,28 @@ export function ensureRegexRun(ctx: CodegenContext): number {
           { op: "local.get", index: GS },
           { op: "i32.sub" },
           { op: "local.set", index: BLEN },
-          // if sp + blen > slen: fail
-          { op: "local.get", index: SP },
-          { op: "local.get", index: BLEN },
-          { op: "i32.add" },
-          { op: "local.get", index: SLEN },
+          // out of room? dir>0: sp+blen > slen ; dir<0: sp-blen < 0 (#1911)
+          { op: "local.get", index: DIR },
+          { op: "i32.const", value: 0 },
           { op: "i32.gt_s" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: SP },
+              { op: "local.get", index: BLEN },
+              { op: "i32.add" },
+              { op: "local.get", index: SLEN },
+              { op: "i32.gt_s" },
+            ],
+            else: [
+              { op: "local.get", index: SP },
+              { op: "local.get", index: BLEN },
+              { op: "i32.sub" },
+              { op: "i32.const", value: 0 },
+              { op: "i32.lt_s" },
+            ],
+          },
           {
             op: "if",
             blockType: { kind: "empty" },
@@ -905,10 +934,21 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                       { op: "array.get_u", typeIdx: strDataIdx },
                       ...foldChIf(),
                       { op: "local.set", index: C1 },
-                      // c2 = fold?(data[soff+sp+j]); mismatch → FAILED=1, break
+                      // c2 = fold?(data[soff+base+j]); mismatch → FAILED=1, break.
+                      // base = sp + ((dir-1)>>1)*blen — sp forward, sp-blen
+                      // backwards (#1911): the captured span is matched against
+                      // the units ENDING at sp, compared left-to-right.
                       { op: "local.get", index: SDATA },
                       { op: "local.get", index: SOFF },
                       { op: "local.get", index: SP },
+                      { op: "i32.add" },
+                      { op: "local.get", index: DIR },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.sub" },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.shr_s" },
+                      { op: "local.get", index: BLEN },
+                      { op: "i32.mul" },
                       { op: "i32.add" },
                       { op: "local.get", index: JJ },
                       { op: "i32.add" },
@@ -935,7 +975,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                   },
                 ],
               },
-              // matched: sp += blen; pc++
+              // matched: sp += dir*blen; pc++
               { op: "local.get", index: FAILED },
               { op: "i32.eqz" },
               {
@@ -944,6 +984,8 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                 then: [
                   { op: "local.get", index: SP },
                   { op: "local.get", index: BLEN },
+                  { op: "local.get", index: DIR },
+                  { op: "i32.mul" },
                   { op: "i32.add" },
                   { op: "local.set", index: SP },
                   { op: "local.get", index: PC },
@@ -955,6 +997,62 @@ export function ensureRegexRun(ctx: CodegenContext): number {
             ],
           },
         ],
+      },
+    ];
+  }
+
+  /** LOOKAROUND (#1911): operand a = sub-program entry pc, b = bit0 negated |
+   *  bit1 behind. Mirrors the LOOKAROUND arm in regex/vm.ts: snapshot caps,
+   *  recursively run the sub-program at sp (dir = behind ? -1 : +1, same caps
+   *  array — the Wasm VM mutates in place), then keep the sub's captures only
+   *  on a positive success; every other outcome restores the snapshot. The
+   *  recursion is what makes the assertion atomic. */
+  function lookaroundArm(): Instr[] {
+    return [
+      ...snapshotCaps(SNAP),
+      // ok = __regex_run(prog, ctab, nslots, sdata, soff, slen, sp, caps,
+      //                  subPc=a, dir = (b&2) ? -1 : 1)
+      { op: "local.get", index: PROG },
+      { op: "local.get", index: CTAB },
+      { op: "local.get", index: NSLOTS },
+      { op: "local.get", index: SDATA },
+      { op: "local.get", index: SOFF },
+      { op: "local.get", index: SLEN },
+      { op: "local.get", index: SP },
+      { op: "local.get", index: CAPS },
+      { op: "local.get", index: A },
+      { op: "local.get", index: B },
+      { op: "i32.const", value: 2 },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "i32.const", value: -1 }],
+        else: [{ op: "i32.const", value: 1 }],
+      },
+      { op: "call", funcIdx },
+      { op: "local.set", index: TMPI },
+      // matched = ok ^ negated
+      { op: "local.get", index: TMPI },
+      { op: "local.get", index: B },
+      { op: "i32.const", value: 1 },
+      { op: "i32.and" },
+      { op: "i32.xor" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // negated success never keeps sub-captures (§22.2.2.4).
+          { op: "local.get", index: B },
+          { op: "i32.const", value: 1 },
+          { op: "i32.and" },
+          { op: "if", blockType: { kind: "empty" }, then: restoreCaps(SNAP) },
+          { op: "local.get", index: PC },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: PC },
+        ],
+        else: [...restoreCaps(SNAP), { op: "i32.const", value: 1 }, { op: "local.set", index: FAILED }],
       },
     ];
   }
@@ -993,8 +1091,8 @@ export function ensureRegexRun(ctx: CodegenContext): number {
   }
 
   const body: Instr[] = [
-    // pc = 0; sp = start; steps = 0
-    { op: "i32.const", value: 0 },
+    // pc = entryPc (#1911 — 0 for the main program); sp = start; steps = 0
+    { op: "local.get", index: ENTRYPC },
     { op: "local.set", index: PC },
     { op: "local.get", index: START },
     { op: "local.set", index: SP },
@@ -1098,6 +1196,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       { name: "blen", type: { kind: "i32" } },
       { name: "jj", type: { kind: "i32" } },
       { name: "c1", type: { kind: "i32" } },
+      { name: "inb", type: { kind: "i32" } },
     ],
     body,
     exported: false,
@@ -1189,7 +1288,7 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
             { op: "i32.const", value: -1 },
             { op: "local.get", index: NSLOTS },
             { op: "array.fill", typeIdx: i32Arr },
-            // if __regex_run(...) at i: return 1
+            // if __regex_run(... entryPc=0, dir=+1) at i: return 1
             { op: "local.get", index: PROG },
             { op: "local.get", index: CTAB },
             { op: "local.get", index: NSLOTS },
@@ -1198,6 +1297,8 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
             { op: "local.get", index: SLEN },
             { op: "local.get", index: I },
             { op: "local.get", index: CAPS },
+            { op: "i32.const", value: 0 },
+            { op: "i32.const", value: 1 },
             { op: "call", funcIdx: runIdx },
             { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
             // if sticky: break (only the start position is tried)

--- a/src/codegen/regex/bytecode.ts
+++ b/src/codegen/regex/bytecode.ts
@@ -45,6 +45,15 @@ export enum ReOp {
    *  `groupIdx` (§22.2.2.9 BackreferenceMatcher). An unset group matches the
    *  empty string. `caseInsensitive`=1 compares ASCII-folded units. #1912. */
   BACKREF = 11,
+  /** `[LOOKAROUND, subPc, flags]` — zero-width assertion (§22.2.2.4 Assertion
+   *  `(?=) (?!) (?<=) (?<!)`). Runs the sub-program starting at instruction
+   *  `subPc` as a fresh anchored attempt at the current position via a
+   *  recursive `__regex_run` call (atomic — no backtrack entries leak out).
+   *  `flags` bit 0 = negated, bit 1 = lookbehind (sub-program is compiled
+   *  REVERSED and executed with direction -1). Captures written by a
+   *  successful positive lookaround persist; everything else restores the
+   *  pre-assertion capture state. #1911. */
+  LOOKAROUND = 12,
 }
 
 /** Slots per instruction in the flat program array. */

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -13,6 +13,14 @@
  * (Russ Cox, "Regular Expression Matching: the Virtual Machine Approach").
  * Greedy `x*` is `L1: SPLIT body, L2 ; body ; JMP L1 ; L2:` — body tried first.
  * Lazy `x*?` swaps the SPLIT targets so the exit is tried first.
+ *
+ * #1911 — lookarounds compile to SUB-PROGRAMS appended after the main
+ * program's MATCH: `LOOKAROUND [subPc, flags]` runs the sub-program as a
+ * fresh anchored attempt via a recursive `__regex_run` call. Lookbehind
+ * bodies are compiled REVERSED (concat order flipped, capture SAVE slots
+ * swapped) and executed with direction -1 — the Irregexp approach. Inline
+ * modifier groups `(?ims-ims:…)` are a pure compile-time flag-scope: the
+ * emitter's i/m/s state nests with the group.
  */
 import { INSTR_WIDTH, ReOp, RE_FLAG_I, RE_FLAG_M, RE_FLAG_S, type CompiledRegex } from "./bytecode.js";
 import { parsePattern, type ParsedRegex, type ReNode } from "./parse.js";
@@ -21,16 +29,38 @@ import { parsePattern, type ParsedRegex, type ReNode } from "./parse.js";
  *  repeated atoms, so cap the expansion to keep programs small. */
 const MAX_REPEAT_EXPANSION = 1000;
 
+/** A lookaround body queued for sub-program emission after the main MATCH.
+ *  Snapshot the modifier state (#1911) — the body compiles LATER but must see
+ *  the i/m/s flags that were active at its syntactic position. */
+interface PendingSub {
+  /** Body AST (already reversed for lookbehind). */
+  node: ReNode;
+  /** pc of the LOOKAROUND instruction whose operand `a` needs the sub start. */
+  patchPc: number;
+  /** Lookbehind bodies emit reversed capture SAVE order. */
+  reversed: boolean;
+  caseInsensitive: boolean;
+  dotAll: boolean;
+  multiline: boolean;
+}
+
 class Emitter {
   /** Instruction records, each `[op,a,b]`, flattened on finish. */
   private readonly instrs: Array<[number, number, number]> = [];
   /** Flat class table; class offset = index of its rangeCount cell. */
   readonly classTable: number[] = [];
-  private readonly caseInsensitive: boolean;
+  // Mutable since #1911: inline modifier groups `(?ims-ims:…)` scope these
+  // per-subtree; lookaround sub-programs restore the snapshot they captured.
+  private caseInsensitive: boolean;
   /** dotAll (`s` flag): `.` matches line terminators too. */
-  private readonly dotAll: boolean;
+  private dotAll: boolean;
   /** multiline (`m` flag): `^`/`$` match at line boundaries, not just BOS/EOS. */
-  private readonly multiline: boolean;
+  private multiline: boolean;
+  /** Lookbehind bodies emit group SAVE slots swapped (end first) so capture
+   *  spans stay [left, right] while matching right-to-left. #1911. */
+  private reversed = false;
+  /** Lookaround bodies pending sub-program emission (drained by compileParsed). */
+  private readonly pendingSubs: PendingSub[] = [];
 
   constructor(caseInsensitive: boolean, dotAll: boolean, multiline: boolean) {
     this.caseInsensitive = caseInsensitive;
@@ -39,7 +69,7 @@ class Emitter {
   }
 
   /** Append an instruction, return its program-counter (instruction index). */
-  private emit(op: number, a = 0, b = 0): number {
+  emit(op: number, a = 0, b = 0): number {
     const pc = this.instrs.length;
     this.instrs.push([op, a, b]);
     return pc;
@@ -106,6 +136,35 @@ class Emitter {
         // operand a = group index, b = case-insensitive comparison. #1912.
         this.emit(ReOp.BACKREF, node.index, this.caseInsensitive ? 1 : 0);
         return;
+      case "lookaround": {
+        // operand a = sub-program start (patched when the queue drains),
+        // b = bit0 negated | bit1 behind. The body is queued — sub-programs
+        // live after the main MATCH so the linear flow never falls into them.
+        const flags = (node.negated ? 1 : 0) | (node.behind ? 2 : 0);
+        const pc = this.emit(ReOp.LOOKAROUND, 0, flags);
+        this.pendingSubs.push({
+          node: node.behind ? reverseNode(node.node) : node.node,
+          patchPc: pc,
+          reversed: node.behind,
+          caseInsensitive: this.caseInsensitive,
+          dotAll: this.dotAll,
+          multiline: this.multiline,
+        });
+        return;
+      }
+      case "modGroup": {
+        // `(?ims-ims:…)` — scope the emitter flags over the subtree. #1911.
+        const saved: [boolean, boolean, boolean] = [this.caseInsensitive, this.dotAll, this.multiline];
+        if (node.add & RE_FLAG_I) this.caseInsensitive = true;
+        if (node.remove & RE_FLAG_I) this.caseInsensitive = false;
+        if (node.add & RE_FLAG_S) this.dotAll = true;
+        if (node.remove & RE_FLAG_S) this.dotAll = false;
+        if (node.add & RE_FLAG_M) this.multiline = true;
+        if (node.remove & RE_FLAG_M) this.multiline = false;
+        this.compileNode(node.node);
+        [this.caseInsensitive, this.dotAll, this.multiline] = saved;
+        return;
+      }
       case "concat":
         for (const part of node.parts) this.compileNode(part);
         return;
@@ -183,9 +242,13 @@ class Emitter {
           this.compileNode(node.node);
           return;
         }
-        this.emit(ReOp.SAVE, 2 * node.capIndex);
+        // In a reversed (lookbehind) sub-program sp moves right-to-left, so
+        // the END slot is recorded first — capture spans stay [left, right].
+        const first = this.reversed ? 2 * node.capIndex + 1 : 2 * node.capIndex;
+        const second = this.reversed ? 2 * node.capIndex : 2 * node.capIndex + 1;
+        this.emit(ReOp.SAVE, first);
         this.compileNode(node.node);
-        this.emit(ReOp.SAVE, 2 * node.capIndex + 1);
+        this.emit(ReOp.SAVE, second);
         return;
       }
     }
@@ -207,6 +270,31 @@ class Emitter {
       for (let i = min; i < max; i++) {
         this.compileNode({ kind: "opt", node: node.node, greedy });
       }
+    }
+  }
+
+  /**
+   * Emit all queued lookaround sub-programs (each body + MATCH), patching the
+   * owning LOOKAROUND's `a` operand. Bodies may queue further lookarounds —
+   * the queue keeps draining. #1911.
+   */
+  drainPendingSubs(): void {
+    while (this.pendingSubs.length > 0) {
+      const sub = this.pendingSubs.shift()!;
+      this.patchA(sub.patchPc, this.here());
+      const saved: [boolean, boolean, boolean, boolean] = [
+        this.caseInsensitive,
+        this.dotAll,
+        this.multiline,
+        this.reversed,
+      ];
+      this.caseInsensitive = sub.caseInsensitive;
+      this.dotAll = sub.dotAll;
+      this.multiline = sub.multiline;
+      this.reversed = sub.reversed;
+      this.compileNode(sub.node);
+      this.emit(ReOp.MATCH);
+      [this.caseInsensitive, this.dotAll, this.multiline, this.reversed] = saved;
     }
   }
 
@@ -256,8 +344,41 @@ export function foldClassRangesAscii(ranges: Array<[number, number]>): Array<[nu
 }
 
 /**
+ * Structurally reverse an AST for lookbehind compilation (#1911): concat order
+ * flips recursively so the body matches right-to-left when the VM runs with
+ * direction -1. Alternative ORDER is preserved (only each option's contents
+ * reverse). Lookaround nodes are leaves — their bodies are separate
+ * sub-programs compiled in their own direction.
+ */
+export function reverseNode(node: ReNode): ReNode {
+  switch (node.kind) {
+    case "concat":
+      return { kind: "concat", parts: [...node.parts].reverse().map(reverseNode) };
+    case "alt":
+      return { kind: "alt", options: node.options.map(reverseNode) };
+    case "star":
+      return { kind: "star", node: reverseNode(node.node), greedy: node.greedy };
+    case "plus":
+      return { kind: "plus", node: reverseNode(node.node), greedy: node.greedy };
+    case "opt":
+      return { kind: "opt", node: reverseNode(node.node), greedy: node.greedy };
+    case "repeat":
+      return { kind: "repeat", node: reverseNode(node.node), min: node.min, max: node.max, greedy: node.greedy };
+    case "group":
+      return { kind: "group", node: reverseNode(node.node), capIndex: node.capIndex, name: node.name };
+    case "modGroup":
+      return { kind: "modGroup", add: node.add, remove: node.remove, node: reverseNode(node.node) };
+    default:
+      // char / any / class / bol / eol / wordBoundary / backref / lookaround —
+      // single units or position assertions; nothing to reverse internally.
+      return node;
+  }
+}
+
+/**
  * Compile a parsed pattern + flag bits into a runnable program. Wraps the body
- * in SAVE 0 … SAVE 1 (whole match) and a trailing MATCH.
+ * in SAVE 0 … SAVE 1 (whole match) and a trailing MATCH, then appends the
+ * queued lookaround sub-programs.
  */
 export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex {
   const caseInsensitive = (flags & RE_FLAG_I) !== 0;
@@ -265,11 +386,13 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
   const multiline = (flags & RE_FLAG_M) !== 0;
   const em = new Emitter(caseInsensitive, dotAll, multiline);
   // SAVE 0 (match start)
-  emitRaw(em, ReOp.SAVE, 0);
+  em.emit(ReOp.SAVE, 0);
   em.compileNode(parsed.root);
   // SAVE 1 (match end), MATCH
-  emitRaw(em, ReOp.SAVE, 1);
-  emitRaw(em, ReOp.MATCH);
+  em.emit(ReOp.SAVE, 1);
+  em.emit(ReOp.MATCH);
+  // Lookaround sub-programs live after the main MATCH (#1911).
+  em.drainPendingSubs();
   const prog = em.finish();
   void INSTR_WIDTH; // width is enforced by the [op,a,b] tuple shape.
   return {
@@ -278,13 +401,6 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
     nGroups: parsed.numCaptures + 1,
     flags,
   };
-}
-
-// Emitter.emit is private; this thin shim lets compileParsed add the wrapper
-// SAVE/MATCH without exposing emit on the public surface.
-function emitRaw(em: Emitter, op: number, a = 0, b = 0): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (em as any).emit(op, a, b);
 }
 
 /** Convenience: parse + compile in one step. Throws RegexUnsupportedError /

--- a/src/codegen/regex/parse.ts
+++ b/src/codegen/regex/parse.ts
@@ -31,12 +31,17 @@
  *     `-` literal (`[\d-z]` = `\d ∪ {-} ∪ {z}`), never a range
  *   - Annex B legacy octal escapes (`\0`…`\377`) and `\cX` control escapes
  *
- * Still refused (each cites the phase that adds it):
- *   - lookahead/lookbehind `(?=) (?!) (?<=) (?<!)` → 2d
- *   - Unicode property escapes `\p{…}` / `\P{…}`   → 2d
- *   - the `u`/`v` flags' code-point semantics      → 2c/2d (parse still UTF-16)
+ * Added in 2d Slice A (#1911):
+ *   - lookahead/lookbehind `(?=) (?!) (?<=) (?<!)` — compiled to recursive
+ *     sub-programs; quantified lookarounds (Annex B QuantifiableAssertion)
+ *     rewrite to their zero-width-idempotent equivalent
+ *   - inline modifier groups `(?ims-ims:…)` (regexp-modifiers proposal)
+ *
+ * Still refused (each cites the phase/slice that adds it):
+ *   - Unicode property escapes `\p{…}` / `\P{…}`   → 2d Slice B
+ *   - the `u`/`v` flags' code-point semantics      → 2d Slice B (parse stays UTF-16)
  */
-import { RegexUnsupportedError } from "./bytecode.js";
+import { RE_FLAG_I, RE_FLAG_M, RE_FLAG_S, RegexUnsupportedError } from "./bytecode.js";
 
 export type ReNode =
   | { kind: "char"; code: number }
@@ -46,6 +51,9 @@ export type ReNode =
   | { kind: "eol" }
   | { kind: "wordBoundary"; negated: boolean }
   | { kind: "backref"; index: number }
+  | { kind: "lookaround"; node: ReNode; negated: boolean; behind: boolean }
+  // Inline modifier group `(?ims-ims:…)`: add/remove are RE_FLAG_I|M|S masks.
+  | { kind: "modGroup"; add: number; remove: number; node: ReNode }
   | { kind: "concat"; parts: ReNode[] }
   | { kind: "alt"; options: ReNode[] }
   | { kind: "star"; node: ReNode; greedy: boolean }
@@ -220,6 +228,14 @@ class Parser {
     if (c === "*" || c === "+" || c === "?") {
       this.next();
       const greedy = this.consumeLazy();
+      // Annex B QuantifiableAssertion: a quantified lookaround is legal in
+      // non-u mode. A lookaround is zero-width and deterministic at a fixed
+      // position, so `X*`/`X{n,m}` collapse to `X?` (or `X` when min ≥ 1) —
+      // rewriting avoids a zero-progress SPLIT loop in the VM. #1911.
+      if (atom.kind === "lookaround") {
+        if (c === "+") return atom;
+        return { kind: "opt", node: atom, greedy };
+      }
       if (c === "*") return { kind: "star", node: atom, greedy };
       if (c === "+") return { kind: "plus", node: atom, greedy };
       return { kind: "opt", node: atom, greedy };
@@ -232,6 +248,12 @@ class Parser {
           throw new RegexUnsupportedError(`nothing to repeat at index ${saved}`);
         }
         const greedy = this.consumeLazy();
+        if (atom.kind === "lookaround") {
+          // Zero-width idempotence (see above): {0,0} → ε, {0,…} → opt,
+          // {n≥1,…} → atom.
+          if (bounds[1] === 0) return { kind: "concat", parts: [] };
+          return bounds[0] >= 1 ? atom : { kind: "opt", node: atom, greedy };
+        }
         return { kind: "repeat", node: atom, min: bounds[0], max: bounds[1], greedy };
       }
       // Not a valid quantifier — treat `{` as a literal (Annex B). Rewind.
@@ -299,6 +321,8 @@ class Parser {
     this.next(); // consume "("
     let capIndex = -1;
     let name: string | null = null;
+    let lookaround: { negated: boolean; behind: boolean } | null = null;
+    let modifiers: { add: number; remove: number } | null = null;
     if (this.peek() === "?") {
       this.next();
       const t = this.peek();
@@ -308,23 +332,33 @@ class Parser {
         this.next();
         const after = this.peek();
         if (after === "=" || after === "!") {
-          throw new RegexUnsupportedError("lookbehind (?<= / ?<!) — #1539 Phase 2d");
-        }
-        // named capture (?<name>…)
-        name = "";
-        while (this.peek() !== ">" && !this.eof()) name += this.next();
-        if (this.peek() !== ">") throw new RegexUnsupportedError("unterminated group name");
-        this.next();
-        capIndex = ++this.numCaptures;
-        // The pre-scan kept the FIRST index for each name; a different index
-        // here means the pattern re-declares the name — ES2025 duplicate
-        // named groups stay outside the subset until the alternative-scoped
-        // semantics land.
-        if (this.groupNames.get(name) !== capIndex) {
-          throw new RegexUnsupportedError(`duplicate capture group name '${name}'`);
+          // lookbehind (?<= / ?<! — #1911
+          this.next();
+          lookaround = { negated: after === "!", behind: true };
+        } else {
+          // named capture (?<name>…)
+          name = "";
+          while (this.peek() !== ">" && !this.eof()) name += this.next();
+          if (this.peek() !== ">") throw new RegexUnsupportedError("unterminated group name");
+          this.next();
+          capIndex = ++this.numCaptures;
+          // The pre-scan kept the FIRST index for each name; a different index
+          // here means the pattern re-declares the name — ES2025 duplicate
+          // named groups stay outside the subset until the alternative-scoped
+          // semantics land.
+          if (this.groupNames.get(name) !== capIndex) {
+            throw new RegexUnsupportedError(`duplicate capture group name '${name}'`);
+          }
         }
       } else if (t === "=" || t === "!") {
-        throw new RegexUnsupportedError("lookahead (?= / ?!) — #1539 Phase 2d");
+        // lookahead (?= / ?! — #1911
+        this.next();
+        lookaround = { negated: t === "!", behind: false };
+      } else if (t !== undefined && (t === "-" || t === "i" || t === "m" || t === "s")) {
+        // Inline modifier group `(?ims-ims:…)` (regexp-modifiers). Only i/m/s
+        // are valid; duplicates, letters on both sides, and an empty modifier
+        // pair are real SyntaxErrors (the `new RegExp` host oracle confirms).
+        modifiers = this.parseModifiers();
       } else {
         throw new RegexUnsupportedError(`unsupported group form '(?${t ?? ""}' — #1539 Phase 2d`);
       }
@@ -334,7 +368,44 @@ class Parser {
     const inner = this.parseAlternation();
     if (this.peek() !== ")") throw new RegexUnsupportedError("unterminated group");
     this.next();
+    if (lookaround !== null) {
+      return { kind: "lookaround", node: inner, negated: lookaround.negated, behind: lookaround.behind };
+    }
+    if (modifiers !== null) {
+      return { kind: "modGroup", add: modifiers.add, remove: modifiers.remove, node: inner };
+    }
     return { kind: "group", node: inner, capIndex, name };
+  }
+
+  /** Parse `ims-ims:` after `(?` (regexp-modifiers proposal). The cursor sits
+   *  on the first modifier letter or `-`. Returns add/remove flag masks; the
+   *  trailing `:` is consumed. */
+  private parseModifiers(): { add: number; remove: number } {
+    const flagBit = (ch: string): number => {
+      if (ch === "i") return RE_FLAG_I;
+      if (ch === "m") return RE_FLAG_M;
+      if (ch === "s") return RE_FLAG_S;
+      throw new RegexUnsupportedError(`invalid regexp modifier '${ch}'`);
+    };
+    let add = 0;
+    let remove = 0;
+    while (this.peek() !== undefined && this.peek() !== "-" && this.peek() !== ":") {
+      const bit = flagBit(this.next());
+      if ((add & bit) !== 0) throw new RegexUnsupportedError("duplicate regexp modifier");
+      add |= bit;
+    }
+    if (this.peek() === "-") {
+      this.next();
+      while (this.peek() !== undefined && this.peek() !== ":") {
+        const bit = flagBit(this.next());
+        if (((add | remove) & bit) !== 0) throw new RegexUnsupportedError("duplicate regexp modifier");
+        remove |= bit;
+      }
+    }
+    if (this.peek() !== ":") throw new RegexUnsupportedError("unterminated regexp modifier group");
+    this.next();
+    if (add === 0 && remove === 0) throw new RegexUnsupportedError("empty regexp modifier group");
+    return { add, remove };
   }
 
   private parseEscapeAtom(): ReNode {

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -12,6 +12,11 @@
  * entry is `(pc, sp, capsSnapshotMarker)`. To keep captures cheap we snapshot
  * the whole capture array on SPLIT (Phase 2a; a trail-based undo is a 2b
  * optimisation). A bounded step counter guards catastrophic backtracking.
+ *
+ * #1911 — direction support: lookbehind sub-programs run with `dir = -1`,
+ * reading the unit at `sp-1` and decrementing. LOOKAROUND recursively invokes
+ * `runAt` on the sub-program at the current position (atomic — no backtrack
+ * entries leak into the outer attempt).
  */
 import { ReOp } from "./bytecode.js";
 
@@ -65,6 +70,11 @@ function isWordChar(c: number): boolean {
  * capture array on a match (anchored at `startIdx`), or null on no match /
  * step-cap exceeded. This is a single anchored attempt — callers (test/exec/
  * match) drive the start position scan.
+ *
+ * #1911: `entryPc` selects the (sub-)program to run, `dir` the scan direction
+ * (-1 for lookbehind bodies), and `capsIn` seeds the capture state for
+ * recursive lookaround attempts (copy-on-write — the caller's array is never
+ * mutated; adopt the RETURNED array to observe sub-captures).
  */
 export function runAt(
   prog: number[],
@@ -72,11 +82,14 @@ export function runAt(
   nGroups: number,
   input: string,
   startIdx: number,
+  entryPc = 0,
+  dir = 1,
+  capsIn?: Int32Array,
 ): Int32Array | null {
   const nSlots = 2 * nGroups;
-  const initCaps = new Int32Array(nSlots).fill(-1);
+  const initCaps = capsIn !== undefined ? capsIn.slice() : new Int32Array(nSlots).fill(-1);
   const stack: Frame[] = [];
-  let pc = 0;
+  let pc = entryPc;
   let sp = startIdx;
   // Explicit `Int32Array` (not the narrower `Int32Array<ArrayBuffer>` the
   // compiler infers from `new Int32Array(...)`) so reassignment from
@@ -85,6 +98,10 @@ export function runAt(
   let caps: Int32Array = initCaps;
   let steps = 0;
   const len = input.length;
+
+  // Direction-aware unit access: forward reads at sp, backward at sp-1.
+  const inBounds = (): boolean => (dir > 0 ? sp < len : sp > 0);
+  const unit = (): number => input.charCodeAt(dir > 0 ? sp : sp - 1);
 
   for (;;) {
     if (++steps > REGEX_STEP_CAP) return null;
@@ -95,29 +112,29 @@ export function runAt(
 
     switch (op) {
       case ReOp.CHAR: {
-        if (sp < len && input.charCodeAt(sp) === a) {
-          sp++;
+        if (inBounds() && unit() === a) {
+          sp += dir;
           pc++;
         } else failed = true;
         break;
       }
       case ReOp.CHARI: {
-        if (sp < len && asciiFold(input.charCodeAt(sp)) === a) {
-          sp++;
+        if (inBounds() && asciiFold(unit()) === a) {
+          sp += dir;
           pc++;
         } else failed = true;
         break;
       }
       case ReOp.ANY: {
-        if (sp < len && (a !== 0 || !isLineTerminator(input.charCodeAt(sp)))) {
-          sp++;
+        if (inBounds() && (a !== 0 || !isLineTerminator(unit()))) {
+          sp += dir;
           pc++;
         } else failed = true;
         break;
       }
       case ReOp.CLASS: {
-        if (sp < len && classMatch(classTable, a, input.charCodeAt(sp), b !== 0)) {
-          sp++;
+        if (inBounds() && classMatch(classTable, a, unit(), b !== 0)) {
+          sp += dir;
           pc++;
         } else failed = true;
         break;
@@ -157,7 +174,7 @@ export function runAt(
       case ReOp.WBOUND: {
         // a = negated (`\B`). Word boundary: exactly one of the neighbouring
         // code units is a word char (§22.2.2.6); out-of-bounds neighbours are
-        // non-word.
+        // non-word. Position-based — direction-independent.
         const before = sp > 0 ? isWordChar(input.charCodeAt(sp - 1)) : false;
         const after = sp < len ? isWordChar(input.charCodeAt(sp)) : false;
         const boundary = before !== after;
@@ -167,7 +184,9 @@ export function runAt(
       }
       case ReOp.BACKREF: {
         // a = group index, b = case-insensitive. An unset group matches the
-        // empty string (§22.2.2.9 BackreferenceMatcher step 3).
+        // empty string (§22.2.2.9 BackreferenceMatcher step 3). Backwards
+        // (dir=-1) the captured span is matched against the units ENDING at
+        // sp — same left-to-right unit comparison from base = sp - blen.
         const gs = caps[2 * a]!;
         const ge = caps[2 * a + 1]!;
         if (gs < 0 || ge < 0) {
@@ -175,14 +194,15 @@ export function runAt(
           break;
         }
         const blen = ge - gs;
-        if (sp + blen > len) {
+        if (dir > 0 ? sp + blen > len : sp - blen < 0) {
           failed = true;
           break;
         }
+        const base = dir > 0 ? sp : sp - blen;
         let ok = true;
         for (let j = 0; j < blen; j++) {
           let c1 = input.charCodeAt(gs + j);
-          let c2 = input.charCodeAt(sp + j);
+          let c2 = input.charCodeAt(base + j);
           if (b !== 0) {
             c1 = asciiFold(c1);
             c2 = asciiFold(c2);
@@ -193,7 +213,23 @@ export function runAt(
           }
         }
         if (ok) {
-          sp += blen;
+          sp += dir * blen;
+          pc++;
+        } else failed = true;
+        break;
+      }
+      case ReOp.LOOKAROUND: {
+        // a = sub-program entry pc, b = bit0 negated | bit1 behind. A fresh
+        // anchored recursive attempt at sp — atomic, so no backtrack entries
+        // leak. Captures from a successful POSITIVE lookaround persist (adopt
+        // the sub's caps); all other outcomes keep the pre-assertion caps —
+        // the sub ran copy-on-write and never mutated ours (§22.2.2.4).
+        const negated = (b & 1) !== 0;
+        const behind = (b & 2) !== 0;
+        const sub = runAt(prog, classTable, nGroups, input, sp, a, behind ? -1 : 1, caps);
+        const ok = sub !== null;
+        if (negated ? !ok : ok) {
+          if (!negated && sub !== null) caps = sub;
           pc++;
         } else failed = true;
         break;

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -36,6 +36,7 @@ import {
   type CompiledRegex,
   parseFlags,
   RegexUnsupportedError,
+  RE_FLAG_D,
   RE_FLAG_G,
   RE_FLAG_I,
   RE_FLAG_M,
@@ -136,9 +137,10 @@ export function hasStandaloneRegExpEngine(state: StandaloneRegExpEngineState): b
 }
 
 const STANDALONE_REGEXP_STRUCT_NAME = "__StandaloneRegExp";
-// Supported standalone flags for the current pure-WasmGC VM slice: g/i/y from
-// Phase 2a plus m/s from Phase 2c. u/v/d remain code-point/indices follow-ups.
-const SUPPORTED_STANDALONE_FLAGS = RE_FLAG_G | RE_FLAG_I | RE_FLAG_Y | RE_FLAG_M | RE_FLAG_S;
+// g/i/y from Phase 2a, m/s from 2c, d from 2d Slice A (#1911 — `d` does not
+// change MATCHING semantics; the `.indices` result surface is #1914's lane).
+// u/v stay code-point follow-ups (2d Slice B).
+const SUPPORTED_STANDALONE_FLAGS = RE_FLAG_G | RE_FLAG_I | RE_FLAG_Y | RE_FLAG_M | RE_FLAG_S | RE_FLAG_D;
 
 function reportStandaloneRegExpUnsupported(ctx: CodegenContext, node: ts.Node, detail: string): void {
   reportError(

--- a/tests/issue-1539-standalone-regex.test.ts
+++ b/tests/issue-1539-standalone-regex.test.ts
@@ -333,19 +333,13 @@ describe("#1539 standalone narrowed refusals (Phase 2a)", () => {
     await expectRefused(`export function f(p: string): boolean { return new RegExp(p).test("x"); }`);
   });
   // #1912 Phase 2b landed backreferences, word boundaries, and the class
-  // compatibility forms — they are no longer refused (see
-  // tests/issue-1912-regex-phase2b.test.ts for the dual-run coverage).
-  it("refuses lookahead", async () => {
-    await expectRefused(`export function f(s: string): boolean { return /a(?=b)/.test(s); }`);
-  });
-  // #1539 Phase 2c landed the `m` (multiline) and `s` (dotAll) flags — they are
-  // no longer refused (see the dual-run CASES above). The `u`/`v` (code-point)
-  // and `d` (indices) flags remain deferred to Phase 2d.
-  it("refuses unicode flag (u, Phase 2d)", async () => {
+  // compatibility forms; #1911 Phase 2d Slice A landed lookarounds, inline
+  // modifiers, and the `d` flag — none are refused anymore (see
+  // tests/issue-1912-regex-phase2b.test.ts and
+  // tests/issue-1911-regex-phase2d.test.ts for the dual-run coverage). The
+  // `u`/`v` (code-point) flags remain deferred to 2d Slice B.
+  it("refuses unicode flag (u, Phase 2d Slice B)", async () => {
     await expectRefused(`export function f(s: string): boolean { return /^a/u.test(s); }`);
-  });
-  it("refuses indices flag (d, Phase 2d)", async () => {
-    await expectRefused(`export function f(s: string): boolean { return /^a/d.test(s); }`);
   });
   it("refuses RegExp.exec with global lastIndex semantics", async () => {
     await expectRefused(

--- a/tests/issue-1911-regex-phase2d.test.ts
+++ b/tests/issue-1911-regex-phase2d.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1911 — standalone RegExp Phase 2d Slice A: lookahead/lookbehind, inline
+ * modifier groups `(?ims-ims:…)`, and the `d` flag.
+ *
+ * Each case compiles under `--target standalone`, instantiates with an EMPTY
+ * import object (no JS host), and dual-runs against the native engine.
+ * Lookarounds execute as recursive `__regex_run` sub-program calls (lookbehind
+ * bodies compiled reversed, direction -1); the matcher is unit-tested in pure
+ * TS by tests/regex-bytecode.test.ts — this validates the Wasm VM end-to-end.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function standaloneTest(pattern: string, flags: string, input: string): Promise<boolean> {
+  const inLit = JSON.stringify(input);
+  const src = `export function run(): boolean { return /${pattern}/${flags}.test(${inLit}); }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostRegex = WebAssembly.Module.imports(mod).filter((i) => /RegExp/.test(i.name));
+  expect(hostRegex, "no RegExp host import in standalone").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { run(): number }).run() !== 0;
+}
+
+const CASES: Array<{ p: string; f: string; inputs: string[] }> = [
+  // Lookahead (?= / ?! — §22.2.2.4
+  { p: "a(?=b)", f: "", inputs: ["ab", "ac", "a"] },
+  { p: "a(?!b)", f: "", inputs: ["ab", "ac", "a"] },
+  { p: "foo(?!bar)", f: "", inputs: ["foobar", "foobaz", "foo"] },
+  { p: "x(?=y(?=z))", f: "", inputs: ["xyz", "xy"] },
+  { p: "\\d+(?= dollars)", f: "", inputs: ["100 dollars", "100 euros"] },
+  // Lookbehind (?<= / ?<! — variable length, alternation, anchors, backrefs
+  { p: "(?<=a)b", f: "", inputs: ["ab", "cb", "b"] },
+  { p: "(?<!a)b", f: "", inputs: ["ab", "cb", "b"] },
+  { p: "(?<=ab|c)d", f: "", inputs: ["abd", "cd", "xd"] },
+  { p: "(?<=(a+))b", f: "", inputs: ["aab", "b"] },
+  { p: "(?<=^abc)d", f: "", inputs: ["abcd", "xabcd"] },
+  { p: "(?<=\\d{2})x", f: "", inputs: ["12x", "1x"] },
+  { p: "(?<=(a)\\1)b", f: "", inputs: ["aab", "ab"] },
+  // Quantified lookahead (Annex B QuantifiableAssertion)
+  { p: "(?=a)*a", f: "", inputs: ["a", "b"] },
+  // Inline modifiers (regexp-modifiers proposal)
+  { p: "(?i:abc)", f: "", inputs: ["ABC", "abc", "xyz"] },
+  { p: "a(?-i:b)c", f: "i", inputs: ["ABC", "AbC", "aBc"] },
+  { p: "(?s:.)", f: "", inputs: ["\n", "x"] },
+  { p: "(?m:^b)", f: "", inputs: ["a\nb", "ba"] },
+  { p: "(?im-s:a.b)", f: "s", inputs: ["A\nB", "AxB"] },
+  { p: "(?i:(?-i:a)b)", f: "", inputs: ["aB", "Ab", "ab"] },
+  // `d` flag — accepted; matching semantics unchanged (indices surface: #1914)
+  { p: "^a$", f: "d", inputs: ["a", "b"] },
+  { p: "(a)(b)?", f: "d", inputs: ["ab", "a"] },
+];
+
+describe("#1911 standalone RegExp Phase 2d Slice A — dual-run vs native", () => {
+  for (const { p, f, inputs } of CASES) {
+    for (const input of inputs) {
+      it(`/${p}/${f} on ${JSON.stringify(input)}`, async () => {
+        const expected = new RegExp(p, f).test(input);
+        expect(await standaloneTest(p, f, input)).toBe(expected);
+      });
+    }
+  }
+
+  it("positive lookahead captures flow into exec result", async () => {
+    const src = `
+      export function matched(): boolean { const m = /(?=(\\d+))\\w+/.exec("12ab"); return m !== null; }
+      export function len(i: number): number { const m = /(?=(\\d+))\\w+/.exec("12ab")!; return m[i]!.length; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as { matched(): number; len(i: number): number };
+    expect(ex.matched()).toBe(1);
+    expect(ex.len(0)).toBe(4); // "12ab"
+    expect(ex.len(1)).toBe(2); // "12"
+  });
+
+  it("negative lookahead leaves its captures unset", async () => {
+    const src = `
+      export function run(): boolean { const m = /(?!(x))ab/.exec("ab")!; return m[1] === undefined; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { run(): number }).run()).toBe(1);
+  });
+
+  it("invalid modifier group throws a runtime SyntaxError via new RegExp", async () => {
+    const src = `
+      export function run(): number {
+        try { new RegExp("(?I:a)").test("a"); return 0; }
+        catch (e) { return e instanceof SyntaxError ? 1 : 2; }
+      }`;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { run(): number }).run()).toBe(1);
+  });
+
+  it("u flag stays a narrowed refusal (2d Slice B)", async () => {
+    const r = await compile(`export function f(s: string): boolean { return /^a/u.test(s); }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => /#1539|#1474/.test(e.message))).toBe(true);
+  });
+});

--- a/tests/regex-bytecode.test.ts
+++ b/tests/regex-bytecode.test.ts
@@ -102,21 +102,81 @@ describe("#1539 capture groups", () => {
   });
 });
 
-describe("#1539 narrowed refusals (Phase 2d residue after #1912)", () => {
+describe("#1539 narrowed refusals (2d Slice B residue after #1911)", () => {
   const refused = [
-    "(?=ab)", // lookahead
-    "(?!ab)", // neg lookahead
-    "(?<=ab)", // lookbehind
-    "\\p{L}", // unicode property
-    "\\b*", // quantified assertion — real SyntaxError, never a VM spin
+    "\\p{L}", // unicode property — 2d Slice B
+    "\\b*", // quantified non-lookaround assertion — real SyntaxError, never a VM spin
     "[b-a]", // class range out of order — real SyntaxError
     "a**", // nothing to repeat — real SyntaxError
+    "(?I:a)", // invalid modifier letter — real SyntaxError
+    "(?ii:a)", // duplicate modifier — real SyntaxError
+    "(?i-i:a)", // modifier on both sides — real SyntaxError
+    "(?-:a)", // empty modifier group — real SyntaxError
   ];
   for (const p of refused) {
     it(`refuses ${JSON.stringify(p)}`, () => {
       expect(() => compilePattern(p, 0)).toThrow(RegexUnsupportedError);
     });
   }
+});
+
+// #1911 Phase 2d Slice A — lookarounds + inline modifiers. Dual-run vs native.
+const CORPUS_2D: Array<{ p: string; f: string; inputs: string[] }> = [
+  // lookahead
+  { p: "a(?=b)", f: "", inputs: ["ab", "ac", "a"] },
+  { p: "a(?!b)", f: "", inputs: ["ab", "ac", "a"] },
+  { p: "foo(?!bar)", f: "", inputs: ["foobar", "foobaz", "foo"] },
+  { p: "x(?=y(?=z))", f: "", inputs: ["xyz", "xy", "xz"] }, // nested
+  { p: "(?=(\\d+))\\w+", f: "", inputs: ["12ab", "ab12", "99"] }, // capture persists
+  { p: "(?=a)|b", f: "", inputs: ["a", "b", "c"] },
+  { p: "\\d+(?= dollars)", f: "", inputs: ["100 dollars", "100 euros"] },
+  // lookbehind (variable length, alternation, captures, backrefs)
+  { p: "(?<=a)b", f: "", inputs: ["ab", "cb", "b"] },
+  { p: "(?<!a)b", f: "", inputs: ["ab", "cb", "b"] },
+  { p: "(?<=ab|c)d", f: "", inputs: ["abd", "cd", "xd"] },
+  { p: "(?<=(a+))b", f: "", inputs: ["aab", "b", "xab"] },
+  { p: "(?<=^abc)d", f: "", inputs: ["abcd", "xabcd"] },
+  { p: "(?<=\\d{2})x", f: "", inputs: ["12x", "1x", "x"] },
+  { p: "(?<=(a)\\1)b", f: "", inputs: ["aab", "ab"] }, // backref runs backwards
+  { p: "(?<=\\bword\\b )next", f: "", inputs: ["word next", "sword next"] },
+  // quantified lookarounds (Annex B QuantifiableAssertion → idempotent rewrite)
+  { p: "(?=a)*a", f: "", inputs: ["a", "b"] },
+  { p: "(?=(a))?b", f: "", inputs: ["ab", "b"] },
+  { p: "(?=a)+a", f: "", inputs: ["a", "b"] },
+  // inline modifiers (regexp-modifiers)
+  { p: "(?i:abc)", f: "", inputs: ["ABC", "abc", "xyz"] },
+  { p: "(?i:a)b", f: "", inputs: ["Ab", "AB", "ab"] },
+  { p: "a(?-i:b)c", f: "i", inputs: ["ABC", "AbC", "aBc"] },
+  { p: "(?s:.)", f: "", inputs: ["\n", "x"] },
+  { p: "(?m:^b)", f: "", inputs: ["a\nb", "ba"] },
+  { p: "(?im-s:a.b)", f: "s", inputs: ["A\nB", "AxB"] },
+  { p: "(?i:(?-i:a)b)", f: "", inputs: ["aB", "Ab", "ab"] }, // nested scopes
+  { p: "(?i:[a-c])x", f: "", inputs: ["Bx", "dx"] }, // class folding under modifier
+];
+
+describe("#1911 Phase 2d Slice A pipeline vs native RegExp", () => {
+  for (const { p, f, inputs } of CORPUS_2D) {
+    for (const input of inputs) {
+      it(`/${p}/${f} on ${JSON.stringify(input)}`, () => {
+        expect(ourMatch(p, f, input)).toEqual(nativeMatch(p, f, input));
+      });
+    }
+  }
+
+  it("negative lookaround leaves captures unset", () => {
+    // (?!(x))ab — the inner group never sticks (§22.2.2.4).
+    const c = compilePattern("(?!(x))ab", 0);
+    const m = search(c.prog, c.classTable, c.nGroups, "ab", 0, false);
+    expect(m).not.toBeNull();
+    expect([m![2], m![3]]).toEqual([-1, -1]);
+  });
+
+  it("lookbehind capture spans stay [left, right]", () => {
+    const c = compilePattern("(?<=(ab))c", 0);
+    const m = search(c.prog, c.classTable, c.nGroups, "xabc", 0, false);
+    expect(m).not.toBeNull();
+    expect([m![2], m![3]]).toEqual([1, 3]); // "ab"
+  });
 });
 
 // #1912 Phase 2b — word boundaries, backrefs, class compatibility. Same


### PR DESCRIPTION
## Summary

Phase 2d Slice A of `plan/issues/1911-standalone-regexp-phase-2d-unicode-lookaround.md`, building directly on #1912 (PR #1300). All matcher changes are dual-implemented in the TS reference VM (`src/codegen/regex/vm.ts`) and the hand-authored Wasm VM (`src/codegen/native-regex.ts`).

- **Lookahead `(?=) (?!)` + lookbehind `(?<=) (?<!)`** (§22.2.2.4) — new `ReOp.LOOKAROUND`. Assertion bodies compile to sub-programs appended after the main `MATCH` and run as fresh anchored attempts via a *recursive* `__regex_run` call (new `entryPc`/`dir` params) — the recursion is what makes assertions atomic (no backtrack entries leak into the outer attempt). Lookbehind bodies compile **reversed** (concat order flipped, capture SAVE slots swapped so spans stay `[left, right]`) and execute with direction −1, the Irregexp approach; backrefs inside lookbehind match right-to-left. Captures from a successful positive lookaround persist; every other outcome restores the pre-assertion snapshot.
- **Direction-aware Wasm VM** — the dispatch head computes a per-step in-bounds/unit pair from `dir`; all consuming ops advance `sp += dir`. This also unifies the CHAR/CHARI arms onto the shared `advance1()` (they carried a separate inline `sp+1` that walked multi-unit lookbehinds forward — caught by the dual-run probes).
- **Inline modifier groups `(?ims-ims:…)`** (regexp-modifiers proposal) — pure compile-time flag scoping in the bytecode emitter; lookaround bodies snapshot the modifier state at their syntactic position (they compile later). Invalid modifier syntax refuses at parse and lowers to a runtime `SyntaxError` at `new RegExp(...)` sites via the #1912 host oracle.
- **Quantified lookarounds** (Annex B QuantifiableAssertion) rewrite to the zero-width-idempotent equivalent at parse (`X*` → `X?`, `X+` → `X`, `X{0,0}` → ε) — correct since lookarounds are deterministic at a fixed position, and it eliminates zero-progress SPLIT loops.
- **`d` flag accepted** — no matching-semantics change; the `.indices` result surface is #1914 (fable-rx-surface). `u`/`v` stay narrowed refusals — 2d Slice B (host-enumerated property-escape ranges + astral desugaring) is planned in the issue file.

Targets the lookaround (~57 rows) and regexp-modifiers (~128 rows incl. invalid-modifier SyntaxError tests via the host oracle) families of the `standalone-regexp-phase-2d` bucket; the `u`/`v` property-escape mass (~565 rows) is Slice B.

Coordination: fable-rx-surface (#1913/#1914) was notified of the `__regex_run` signature change (two trailing i32 params; `ensureRegexSearch` unchanged) and will merge main before opening their PR.

## Validation

- `tests/regex-bytecode.test.ts` — new #1911 dual-run corpus (26 patterns vs native), negative-lookaround capture-reset and lookbehind capture-span unit pins
- `tests/issue-1911-regex-phase2d.test.ts` — end-to-end standalone Wasm: empty import object, no `RegExp` host imports, lookahead-capture exec flow, runtime-SyntaxError probe, u-flag still-refused pin
- Full scoped regex suite (8 files, 614 tests) green after merging current `origin/main`
- `tsc --noEmit`, biome lint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)