### PR TITLE
docs(architecture): compiler quality & architecture review 2026-06 + issues #1916–#1950

### DIFF
--- a/docs/architecture/compiler-quality-review-2026-06.md
+++ b/docs/architecture/compiler-quality-review-2026-06.md
@@ -1,0 +1,348 @@
+# Compiler quality & architecture review — June 2026
+
+> Full-codebase review conducted 2026-06-10 by seven parallel subsystem
+> reviewers (Claude Fable 5, 1M context — each held its entire subsystem in
+> context), synthesized by the review lead. Every claim cites file:line
+> evidence; two findings were confirmed by live compilation probes. Companion
+> to [`structure-and-language-assessment.md`](structure-and-language-assessment.md)
+> (2026-06-04, structure/language) and [`codegen-axes.md`](codegen-axes.md)
+> (two-axis model). This review goes below the directory level into the code
+> itself.
+>
+> Improvement work items: **issues #1916–#1950** (`plan/issues/`), indexed at
+> the bottom of this document.
+
+## Grade sheet
+
+| Subsystem | Grade | One-line verdict |
+|---|---|---|
+| WasmGC codegen core (`src/codegen/`) | **C−** | Ships 71.6% test262, but correctness is validate-and-patch: lossy fixups silently substitute wrong values; absolute func-index baking has caused ≥7 regressions |
+| Typed IR (`src/ir/`) | **B−** | Excellent pass discipline (verify-between-every-stage, demote-not-miscompile) on a representation accreting debt; a live defect drops ordinary `while` loops off the IR path |
+| Front-end / types (`src/compiler*`, `src/checker/`) | **C+** | Works, but the pipeline exists in three divergent copies, diagnostics report wrong positions, and `ts.Type` leaks into ~400 codegen sites |
+| Runtime / host interop (`src/runtime*`) | **B** | Allowlist governance and the native regex engine are exemplary; the 10.4k-line host runtime has an unversioned 200-name ABI and multi-instance state bleed |
+| Linear backend + emit (`src/codegen-linear/`, `src/emit/`) | **C+** | Careful emitter and a self-hosting linker anchor a prototype-grade backend that silently miscompiles (`break`/`continue` never compiled) |
+| Testing & CI | **B+** | One of the most sophisticated conformance pipelines at this scale; but the enforced gate is weaker than the documented one and `--optimize` is conformance-untested |
+| Optimization / performance | **C+** | Real compile-away on the happy path; one step off it, closures pay 15-instruction dynamic dispatch that Binaryen provably cannot remove |
+
+**Overall: B−.** The split is stark: the *engineering process* (conformance
+pipeline, ratchets, issue-linked comments, honest self-documentation, dogfood
+lanes) operates at an A− level rare for a project this young, while the *core
+compiler architecture* is patch-layered C-range — velocity has been bought
+with silent-failure risk that test262 only partially observes. The strategic
+bets (typed IR, BackendEmitter trait, host-import allowlist) are the right
+ones; what's missing is one deliberate consolidation pass before the next
+adoption waves multiply the existing debt.
+
+---
+
+## Cross-cutting findings
+
+These five themes recur independently across subsystems. They matter more
+than any single-file fix, and they define the priority order below.
+
+### 1. The compiler prefers emitting *something* over refusing — silent degradation is systemic
+
+The single most consequential pattern. Independent instances:
+
+- **Stack-balance lossy fixups**: when a branch produces a wrongly-typed
+  value, `stack-balance.ts:709-755` patches it with `drop; f64.const 0` or
+  `drop; ref.null` — a compile-time bug becomes a silently wrong runtime
+  value. Fixup counts are computed and discarded (`index.ts:1571`). (#1918)
+- **The compile-failure gate is a string prefix**: `compiler.ts:731` fails the
+  build only for messages starting `"Codegen error:"`. ~118 "Unsupported …"
+  `reportError` sites compile the expression to `null`, the balancer patches
+  the hole, and `compile()` returns `success: true`. (#1921)
+- **Linear backend dispatchers have no default arm**: `break`/`continue` are
+  *never compiled* (`codegen-linear/index.ts:519-732` — the depth stacks are
+  pushed and never read), so `while (true) { if (x) break; }` is a silent
+  infinite loop; `typeof`/`await`/spread emit zero instructions. (#1937)
+- **`encodeInstr` has no default arm** (`emit/binary.ts:728-1678`): combined
+  with the 173 `as unknown as Instr` casts, an unmatched op string is
+  silently omitted from the binary. (#1939)
+- **WIT generator silently drops unmappable params**
+  (`wit-generator.ts:401-406`), emitting signatures whose arity disagrees
+  with the core function. (#1940)
+- **The runtime's `undefined`-as-sentinel protocol** (`runtime.ts:3869-3873`)
+  misinterprets user getters legitimately returning `undefined`. (#1935)
+
+The team demonstrably knows the standard — #1838/#1868 fixed exactly this
+class in two spots, and the standalone refusal layer
+(`late-imports.ts:46-86`) is a model — it just hasn't been applied uniformly.
+**Direction: make fail-loud the invariant, ratchet the remaining silent paths
+to zero** the same way IR fallbacks are ratcheted. Extends #1858.
+
+### 2. Single-sources-of-truth exist in 3–5 divergent copies — and divergence is already shipping bugs
+
+- **Four coercion matrices** (`type-coercion.ts:980`, `:2695`,
+  `stack-balance.ts:1179`, `:678`) that *disagree semantically*: externref→f64
+  unboxes in call-arg position but becomes `f64.const 0` in branch position.
+  (#1917)
+- **≥5 IR nested-buffer walkers** (verify/lower/DCE/const-fold/alloc) with
+  divergent coverage — confirmed live defect: DCE never walks `while.loop`
+  condition buffers, so every ordinary `while (i < limit)` demotes off the IR
+  path, invisibly to the ratchet (probe-verified). (#1922, #1923)
+- **Three pipeline drivers** (`compileSourceSync`/`compileMultiSource`/
+  `compileFilesSource`, ~450 lines each): multi-file compiles silently skip
+  ES early errors, hardened mode, IR, JSX, fs detection. (#1927)
+- **Three i32-safety matchers** (`array-element-typing.ts:30` admits
+  mirroring `function-body.ts` "intentionally narrower"), **three ToPrimitive
+  walkers**, **four property-lookup implementations** in the host runtime,
+  **≥4 instruction walkers** in codegen (peephole's misses `catchAll` —
+  bodies wrapped by async try/catch are never optimized; `walk-instructions.ts`
+  exists with 2 consumers). (#1948, #1934, #1920)
+
+**Direction: each of these is a mechanical consolidation with an existing
+"good twin" to consolidate onto.** They are the highest payoff-per-risk items
+in this review.
+
+### 3. Type information is gathered four times and then thrown away
+
+The TS checker knows the types; codegen mostly doesn't use them:
+
+- Four uncoordinated inference systems (TS checker, IR lattice
+  `propagate.ts`, `shape-inference.ts`, import-resolver's syntactic stubs)
+  with no shared representation; ~397 raw `getTypeAtLocation` sites leak
+  `ts.Type` deep into codegen — which also forecloses the planned TS7
+  migration (`ts-api.ts:114-131` throws under `--ts7`). (#1930)
+- A closure bound once to a known arrow is stored as **externref** and every
+  call does `ref.test`→`ref.cast`→`call_ref` (~15 instrs) — and the externref
+  laundering means **Binaryen -O3 provably cannot repair it** (verified by
+  disassembly diff). (#1946, #1947)
+- `strictNullChecks` non-nullness never reaches Wasm: every typed param is
+  `(ref null $T)` with four null-check-throw blocks in a 6-line function.
+- `i - 1` on a known-i32 loop var round-trips through f64
+  (`convert`→`sub`→`trunc_sat`, survives -O3). (#1948)
+
+**Direction: one type-query facade (TypeOracle) + one numeric lattice +
+end-to-end GC-ref typing.** This is also the precondition for the project's
+own "compile away, don't emulate" principle to hold off the happy path.
+
+### 4. The enforced gates are weaker than the documented ones
+
+- CI's hard test262 gate is **net ≥ 0** (`diff-test262.ts:336-340`); the
+  10%-ratio and 50-per-bucket rules exist only in skill text
+  (`dev-self-merge.md:187-189`) — agent convention, not branch protection. A
+  PR with 60 improvements and 55 unrelated regressions merges. (#1943)
+- **`pass → compile_timeout` is excluded from every gate** — a PR that
+  pathologically slows compilation is invisible; nothing tracks aggregate
+  compile time, though it's already recorded in the JSONL. (#1942)
+- **`--optimize` output is never executed in CI** — three reviewers
+  independently converged on this as the largest correctness hole. (#1941)
+- The test262 runner deliberately weakens its oracle (discards expected error
+  types in `assert.throws`, strips `assert.sameValue(x, undefined)`) — the
+  71.6% headline is an upper bound. (#1945)
+- The perf gate is 4 microbenchmarks at 50% tolerance, and one pass's header
+  literally names the benchmark it targets, while the honest internal suite
+  (string/split 4.9× slower than JS, csv-parse 2.9×) feeds no gate.
+  (#1949, #1950)
+
+### 5. Index- and ABI-fragility: identity by absolute number, compatibility by luck
+
+- **Absolute function-index baking** in WasmGC codegen forces three
+  coexisting shift/relocation regimes (`late-imports.ts:139-270`, `:355+`)
+  walking 13+ instruction roots; ≥7 numbered regressions (#618, #1109,
+  #1384, #1525b, #1666, #1677) trace to this one decision. The IR layer
+  already proved the fix (symbolic refs, `ir/nodes.ts:22-28`). (#1916)
+- **The ~200-name `env` ABI between compiled binaries and `runtime.ts` has no
+  version constant and no handshake** — skew fails as LinkError or silent
+  misbehavior. The team knows how: `STANDALONE_REGEXP_ABI_VERSION` exists
+  for the regex engine. (#1932)
+- Module-level mutable state in the host runtime (`_symbolCache`,
+  `_legacyRegExpState`, `_subclassCtors`) breaks two-instances-on-one-page
+  and retains whole instances forever in hot-reload scenarios. (#1933)
+
+---
+
+## Per-subsystem summaries
+
+### WasmGC codegen core — C−
+
+71.6% test262 from a direct AST→Wasm emitter is a serious achievement, the
+`context/` extraction shows active remediation, and known debt
+(#1095/#1098/#1172/#1530) is honestly tracked. But the architecture is
+patch-layered: the pipeline tail is repair passes
+(`eliminateDeadImports` → `repairStructTypeMismatches` → `peephole` →
+`stackBalance` → `fixupExternConvertAny`, index.ts:1559-1575 — three of six
+are fixups for invalid emission); `stack-balance.ts` (2,524 LOC) is a partial
+Wasm-validator reimplementation used to patch the emitter's own output, with
+176 lines of tests; `CodegenContext` is a ~150-field interface shaped partly
+by repair-pass reachability; 23 probe-compile-and-rollback sites truncate the
+body but leak locals/imports/types (#1847 fixed 8 of ~23); `compileCallExpression`
+is 8,800 lines with ~125 string-matched dispatch arms. New issues: #1916–#1921.
+
+### Typed IR — B−
+
+The process is excellent: verifier between every pass with
+demote-not-miscompile, reference-equality fixpoints, alloc-site provenance
+(ADR-0013), three-backend emitter-seam proof. The representation is the
+problem: two competing control-flow forms (a vestigial blockarg CFG under
+de-facto structured nested buffers — paying for both, benefiting from
+neither); 53 instruction kinds growing one-per-feature-per-strategy
+(`forof.vec/iter/string`); backend `ValType`/`typeIdx` inside `IrType`
+(blocks serialization/caching and linear adoption of unions); the verifier —
+the stated compensation for TS unsoundness — checks **no per-instruction
+operand types** (branch args: arity only; `resultType` trusted, never
+re-derived); hygiene passes never descend into loop bodies, so the IR's main
+optimization target is never optimized. Post-claim demotions are counted
+nowhere, so the #1530 ratchet has a blind side. New issues: #1922–#1926.
+
+### Front-end / type system — C+
+
+Smart lib caching, a clean TS-API shim, exemplary issue-linked comments, and
+a genuinely needed ES early-error pass. Structural debt: pipeline
+triplication with silently divergent semantics; the primary API path's
+"module system" string-rewrites imports into `any` stubs (destroying types
+and positions); pre-parse rewrites shift all line numbers with no offset
+mapping, so reported diagnostics are wrong whenever a rewrite fires;
+`CompileError` has no `file` field; ~300 lines of heuristics suppress the
+checker's own correct diagnostics because `number|null` lowers to bare `f64`
+— the fix belongs in type lowering, not diagnostic whack-a-mole;
+`detectEarlyErrors` is a single ~3,350-line function that runs only on the
+single-source path; the public `treeshake` option is dead code. New issues:
+#1927–#1931.
+
+### Runtime / host interop — B
+
+The host-import allowlist (40 entries, each with tracking issue + rationale,
+size-ratcheted in CI, enforced at codegen) is a model governance artifact;
+the native regex engine (compile-time bytecode + one backtracking VM,
+mirrored opcode-for-opcode by an executable reference VM, versioned ABI,
+shared step cap) is the template the rest of the codebase should follow;
+map/object runtimes are spec-cited. Held back by `runtime.ts` itself: one
+~5,000-line `resolveImport` with 188 name checks; seven WeakMap sidecars with
+four property-lookup implementations that must agree; three ToPrimitive
+walkers; the unversioned ABI; multi-instance state bleed; and the async
+landmine — CPS lowering is built but disabled (`ASYNC_CPS_ENABLED = false`)
+because legacy call sites consume async results synchronously, so shipped
+async semantics are spec-wrong by design until call sites learn to drive
+Promises. New issues: #1932–#1936.
+
+### Linear backend + emit — C+
+
+The periphery is the strong part: the binary emitter is careful and
+battle-hardened (rec-groups for forward refs, LEB range guards, valued-if
+patching); the linker is a self-hosting, isolation-checked gem (the linker
+compiles *itself* via the linear backend in tests); the Binaryen integration
+shows mature judgment (the custom-descriptors disable for wasmtime ≤44). The
+backend itself is prototype-grade behind a production flag: silent
+`break`/`continue` drop, `number[]` stored as i32 (`[1.5]` → `[1]`),
+element-assignment RHS evaluated twice, `throw` lowered to bare
+`unreachable`, diagnostics at `0:0`, `if (NaN)` truthy. The IR
+`BackendEmitter` seam is the right escape route but `LinearEmitter` is a
+206-line proof reachable only from tests. New issues: #1937–#1940.
+
+### Testing & CI — B+
+
+Dual-target 57×2-shard test262 with duration-weighted chunks, merge-base-exact
+baseline resolution, wasm-sha noise filtering, poison-fork recycling, a real
+V8 differential lane, an acorn dogfood lane (pinned tarball,
+compile→validate→run→AST-diff), zero snapshot tests, ratcheted baselines.
+Gaps: the gate/documentation mismatch and compile-time blindness (above);
+~100 equivalence failures permanently baselined with no burn-down ratchet;
+no fuzzing despite a harness that makes it cheap (#1855 exists);
+~120–170 wasted runner-minutes per run (per-shard installs ×114, run twice
+for PR + merge_group). New issues: #1941–#1945.
+
+### Optimization / performance — C+
+
+Real compile-away where types are explicit: interfaces → flat structs with
+direct `struct.get`, inlined `Math.*`, fully-inlined `push` growth, real Wasm
+Timsort. Off that path it emulates: the closure dispatch and i32/f64
+ping-pong findings (§3 above); default builds ship unoptimized (`-O` opt-in)
+while in-compiler peephole has 6 patterns; the gated benchmark set is 4
+overfitted micros while the honest suite shows JS winning most string/mixed
+workloads, ungated. New issues: #1946–#1950.
+
+---
+
+## Directions — what to do, in order
+
+**Now (small, high-leverage, mostly S-effort; the "stop the silent bleeding" wave):**
+
+1. Fail-loud defaults everywhere a dispatcher or encoder can fall through:
+   #1937 (linear break/continue + default arms), #1939 (encodeInstr default
+   throw + funcref validation in CI), #1921 (structured failure gate),
+   #1940 (WIT params).
+2. Make the gates match the documentation: #1941 (differential `--optimize`
+   lane — single biggest untested correctness surface), #1943 (ratio/bucket
+   in CI), #1942 (compile-time gate), #1923 (meter IR post-claim demotions).
+3. #1932 (version the env ABI) — one global, one check, removes a whole
+   failure mode for precompiled binaries.
+
+**Next (M-effort consolidations that delete recurring bug classes):**
+
+4. #1922 (shared IR traversal — fixes the live while-loop defect),
+   #1917 (one coercion engine), #1918 (stack-balance strict mode + fixup
+   ratchet), #1920 (one instruction walker), #1919 (transactional probes),
+   #1933 (runtime instance state), #1928/#1929 (diagnostics fidelity),
+   #1927 (one pipeline driver), #1924 (IR verifier type rules).
+
+**Strategic (L-effort, architect-spec first — these decide what the compiler becomes):**
+
+5. #1916 symbolic function references — removes the index-shift regime the
+   same way IR symbolic refs already did.
+6. #1930 TypeOracle boundary — prerequisite for TS7 and for every
+   type-driven optimization; #1946/#1947/#1948 (closure devirt, GC-ref
+   typing, numeric lattice) are the performance payoff that falls out.
+7. #1936 async contract migration (enable the already-built CPS path).
+8. #1925/#1926 IR representation consolidation (one control-flow form;
+   backend types out of IrType) — do this **before** the class-method/async
+   adoption waves (#1370/#1373) multiply every cost.
+9. Linear backend: drive `LinearEmitter` past the vec group rather than
+   patching `codegen-linear/index.ts` feature-by-feature (existing #1714
+   direction; #1938 is the interim correctness floor).
+
+**Explicit non-directions:** don't grow the IR node set one-node-per-feature
+(prefer resolver-deferred kinds like `string`/`object`); don't add host
+imports without standalone fallbacks (the allowlist ratchet is working);
+don't chase the 4 landing-page microbenchmarks (#1949 replaces the
+incentive).
+
+---
+
+## New issue index (#1916–#1950)
+
+| # | Title (short) | Area | Effort | Priority |
+|---|---|---|---|---|
+| 1916 | Symbolic function references in WasmGC codegen | codegen | L | high |
+| 1917 | Single coercion engine (4 divergent matrices) | codegen | M | high |
+| 1918 | Stack-balance strict mode + fixup ratchet | codegen | S→M | high |
+| 1919 | Transactional speculative-compile API | codegen | M | medium |
+| 1920 | One instruction walker; peephole catchAll bug | codegen | S | medium |
+| 1921 | Structured compile-failure gate (no string prefix) | compiler | S | high |
+| 1922 | Shared IR traversal; fix while-loop DCE demotion | ir | M | high |
+| 1923 | Meter IR post-claim demotions in ratchet | ir | S | high |
+| 1924 | Instruction-level type rules in IR verifier | ir | M | high |
+| 1925 | IR hygiene passes inside nested buffers / one CF form | ir | M→L | medium |
+| 1926 | Remove ValType/typeIdx from IrType | ir | M | medium |
+| 1927 | Single front-end pipeline driver | compiler | M | high |
+| 1928 | Source-position remapping for pre-parse rewrites | compiler | M | high |
+| 1929 | CompileError.file + flattened diagnostic chains | compiler | S | medium |
+| 1930 | TypeOracle: one type-query boundary | compiler | L | high |
+| 1931 | Decompose detectEarlyErrors; wire or delete treeshake | compiler | M | medium |
+| 1932 | Version the env ABI | runtime | S | high |
+| 1933 | Multi-instance isolation + retention leak | runtime | M | high |
+| 1934 | Decompose resolveImport into domain tables | runtime | L | medium |
+| 1935 | Retire the undefined-sentinel protocol | runtime | M | medium |
+| 1936 | Async contract migration (enable CPS) | runtime | L | high |
+| 1937 | Linear backend: fail loud; implement break/continue | codegen-linear | S | critical |
+| 1938 | Linear number[] i32 truncation + double-eval RHS | codegen-linear | M | high |
+| 1939 | encodeInstr default throw; funcref validation in CI | emit | S | high |
+| 1940 | WIT generator: never silently drop params | tooling | S | medium |
+| 1941 | Differential testing of --optimize output | testing | S | critical |
+| 1942 | Compile-time regression gate | testing | S | high |
+| 1943 | Enforce ratio/bucket thresholds in CI | testing | S | high |
+| 1944 | CI cost: bundle-once artifact + pnpm cache | testing | M | medium |
+| 1945 | Test262 oracle precision (error types, stripped asserts) | testing | M | medium |
+| 1946 | Closure devirtualization for singleton callees | codegen | M | high |
+| 1947 | End-to-end GC-ref typing (externref at boundary only) | codegen | L | high |
+| 1948 | Shared numeric i32 lattice | codegen | M | high |
+| 1949 | Representative, tighter perf gate | testing | S | medium |
+| 1950 | Default-on optimization pipeline | compiler | S | medium |
+
+Already-tracked overlaps deliberately *not* re-filed: god files (#1098/#1172),
+`as unknown as Instr` (#1095/#1526), IR fallback phase-out (#1530), verifier
+dominance hardening (#1850), backend value representation (#1852), cross-backend
+differential harness (#1854), TS fuzzer (#1855), naming symmetry (#1860),
+subdir READMEs (#1859), fail-loud audit umbrella (#1858 — issues #1918/#1921/
+#1937/#1939/#1940 are its concrete children).

--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -1,0 +1,75 @@
+---
+id: 1916
+title: "Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+---
+# #1916 — Symbolic function references in WasmGC codegen
+
+## Problem
+
+The WasmGC backend bakes **absolute function indices** into instruction
+streams as it compiles. Any import added after bodies exist shifts every
+defined-function index, so compensation machinery must find and patch every
+instruction array in flight:
+
+- `shiftLateImportIndices` (`src/codegen/late-imports.ts:139-270`) walks 13+
+  roots: `mod.functions`, `fctx.body`, `savedBodies`, `currentFunc`,
+  `funcStack`, `parentBodiesStack`, `liveBodies`, `pendingInitBody`,
+  `funcMap`, `nativeStrHelpers`, `pendingMethodTrampolines`, exports, elem
+  segments, `declaredFuncRefs`.
+- A **second** shift regime (`reconcileNativeStrFinalizeShift`,
+  `late-imports.ts:355+`, #1677) exists because raw `addImport` deliberately
+  doesn't shift (the #618 revert).
+- Context fields exist *only* to make bodies reachable for the shifter
+  (`liveBodies`, `context/types.ts:940-946`, citing #1384) — the context
+  schema is shaped by repair-pass reachability.
+- `generateModule`'s prologue (`index.ts:954-1103`) is a 150-line ordering
+  ballet of which emission must precede which import registration.
+
+At least 7 numbered regressions trace to this one design decision: #618,
+#1109, #1384, #1525b, #1666, #1677, plus the #172-era class trampoline bug.
+The IR layer already proved the alternative works: symbolic refs instead of
+raw indices (`src/ir/nodes.ts:22-28`), which is exactly why IR integration
+doesn't need `shiftLateImportIndices` (`ir/integration.ts:20-23`).
+
+## Proposed approach
+
+1. Introduce `FuncHandle` — one shared mutable `{ index: number }` (or
+   name-keyed) object per function/import, interned in the codegen context.
+2. Emit call/ref instructions as `{ op: "call", target: FuncHandle }`;
+   resolve handles to concrete indices **once**, at binary-encoding time
+   (`src/emit/binary.ts`), the same place type indices are already final.
+3. `addImport`/`ensureLateImport` then renumber by mutating handles — no
+   instruction walking, no body registry, no ordering constraints.
+4. Delete `shiftLateImportIndices`, `reconcileNativeStrFinalizeShift`,
+   `liveBodies`, `pendingLateImportShift`, and the prologue ordering
+   comments as they become dead.
+5. Migrate incrementally: accept `number | FuncHandle` in the `Instr` union
+   during transition; ratchet raw-number call sites to zero (same pattern as
+   the #1095 cast budget).
+
+## Acceptance criteria
+
+- No instruction-walking shift pass remains; `git grep shiftLateImportIndices` is empty.
+- Equivalence suite + test262 sharded CI green (net ≥ 0, no bucket regressions).
+- `liveBodies` / `parentBodiesStack` bookkeeping removed from `CodegenContext`.
+- A regression test that adds a late import after N bodies are compiled and
+  validates the binary.
+
+## Source
+
+Compiler quality review 2026-06
+(`docs/architecture/compiler-quality-review-2026-06.md`), WasmGC codegen
+section. Related: #1677 (unified two shift regimes; this removes the regime),
+#1899 (funcIdx authority contract). Needs an architect spec before dev
+dispatch (`/architect-spec`).

--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -1,0 +1,63 @@
+---
+id: 1917
+title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: correctness
+---
+# #1917 — One coercion engine
+
+## Problem
+
+Four independently-maintained type-coercion matrices coexist in the WasmGC
+backend, and they **disagree semantically**:
+
+- `coerceType` (`src/codegen/type-coercion.ts:980`, ~1,100 lines for one function)
+- `coercionInstrs` (`type-coercion.ts:2695-2903`)
+- `callArgCoercionInstrs` (`src/codegen/stack-balance.ts:1179-1310`)
+- `fixBranchType` (`stack-balance.ts:678-764`), plus `fixLocalSetCoercion`
+
+Observed divergence:
+- externref→f64: `callArgCoercionInstrs` calls `__unbox_number` (correct);
+  `fixBranchType` emits lossy `drop; f64.const 0` (`stack-balance.ts:724-728`).
+- ref→f64: `coercionInstrs` pushes `f64.const NaN` (line 2786);
+  `fixBranchType` pushes `0` (lines 737-742).
+
+So the runtime value a coercion produces depends on *which syntactic context
+triggered it* — call argument vs branch result vs local.set. Additionally,
+the guarded-ref-cast idiom (tee tmp → ref.test → if/then cast / else null) is
+copy-pasted ≥6 times within type-coercion.ts alone (1026-1048, 1067-1089,
+2820-2834, 2843-2857, 2865-2878, 2885-2898).
+
+## Proposed approach
+
+1. Extract a single `coercionPlan(from: ValType, to: ValType, ctx) →
+   { instrs: Instr[] } | { needsTemp: ... } | { lossy: true, instrs }` table
+   in `type-coercion.ts`.
+2. Consume it from all four call sites; delete the local matrices.
+3. `lossy` arms emit a located diagnostic (ties into #1918's strict mode) —
+   a lossy coercion in a branch fixup is an emitter bug being masked, and
+   should be visible.
+4. Extract one `guardedRefCast(toTypeIdx)` helper for the 6+ copies.
+5. Add table-driven unit tests: for every (from, to) pair, all consumers
+   produce identical instruction sequences.
+
+## Acceptance criteria
+
+- One coercion table; `callArgCoercionInstrs`/`fixBranchType` delegate to it.
+- The externref→f64 and ref→f64 divergences are gone (branch context unboxes
+  / NaNs identically to call-arg context), with a regression test for each.
+- Equivalence + test262 CI green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1918 (fixup ratchet), #1858
+(fail-loud umbrella).

--- a/plan/issues/1918-stack-balance-strict-mode-fixup-ratchet.md
+++ b/plan/issues/1918-stack-balance-strict-mode-fixup-ratchet.md
@@ -1,0 +1,62 @@
+---
+id: 1918
+title: "Stack-balance strict mode + fixup ratchet — stop silently patching emitter bugs into wrong runtime values"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: codegen
+language_feature: compiler-internals
+goal: correctness
+---
+# #1918 — Stack-balance strict mode + fixup ratchet
+
+## Problem
+
+`src/codegen/stack-balance.ts` (2,524 LOC) is a partial reimplementation of
+the Wasm validator used to **repair** the emitter's own output. Every repair
+it applies is a masked emitter bug, and some repairs are *silently lossy*:
+
+- Wrong-typed branch values are patched with `drop; f64.const 0` or
+  `drop; ref.null` (`stack-balance.ts:709-755`) — a compile-time bug becomes
+  a silently wrong runtime value.
+- `fixBranch` appends drops/defaults for arity mismatches (`:773+`).
+- Heuristic inference: `fixCallArgTypesInBody` admits it "only handles the
+  common case where the argument-producing instruction is directly before
+  the call" (`:1306-1310`); interleaved control flow defeats it silently.
+- The pass **returns fixup counts that are computed and then discarded**
+  (`src/codegen/index.ts:1571`). Nothing reports, gates, or ratchets them.
+- Test coverage of the safety net itself: 176 lines / 10 e2e tests for a
+  2,524-line pass; 36 issue files reference stack-balance — it is a
+  recurring defect locus.
+
+## Proposed approach
+
+Phase 1 (S — instrumentation):
+1. Thread fixup events out of `stackBalance` with location info (function
+   name, op offset, fixup kind, from→to types).
+2. `JS2WASM_STRICT_BALANCE=1` promotes each fixup to a located warning;
+   `=error` makes it fail the compile (for CI experiments / new code).
+3. Record per-corpus fixup totals (playground examples — same corpus as
+   `check:ir-fallbacks`) into a baseline JSON.
+
+Phase 2 (M — burn-down):
+4. CI gate: fail when any fixup bucket **grows** (same ratchet mechanics as
+   `scripts/check-ir-fallbacks.ts`, `--update-on-decrease` mode).
+5. Fix the top buckets at the emitter; when a fixup kind hits zero, its
+   repair arm becomes `throw` (strict by construction).
+
+## Acceptance criteria
+
+- Fixup counts visible per compile (debug) and per corpus (CI artifact).
+- `scripts/stack-balance-baseline.json` ratchet wired into ci.yml quality job.
+- At least the lossy `drop; const-default` branch arms are warning-visible.
+
+## Source
+
+Compiler quality review 2026-06. Direct child of #1858 (fail-loud audit).
+Related: #1917 (the lossy arms it instruments), #1921.

--- a/plan/issues/1919-transactional-speculative-compile.md
+++ b/plan/issues/1919-transactional-speculative-compile.md
@@ -1,0 +1,55 @@
+---
+id: 1919
+title: "Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: correctness
+---
+# #1919 — Transactional speculative-compile API
+
+## Problem
+
+The probe-compile-and-rollback idiom — speculatively `compileExpression`,
+inspect the result type, then truncate `fctx.body.length` to undo — appears
+at **23 sites** (`src/codegen/array-methods.ts:2489-2492`,
+`property-access.ts:2491`, `string-builder.ts:771-780`,
+`statements/loops.ts` ×10, …). Rollback restores **only the body**: locals
+allocated during the probe, late imports registered, closure counters,
+registered struct types, and `ctx.errors` mutations all leak.
+
+#1847 added `snapshotLocals`/`restoreLocals` (`src/codegen/context/locals.ts:201`)
+for exactly this bug class, but only `loops.ts` adopted it (8 call sites);
+the other ~15 truncation sites are unguarded. This is a heisenbug factory:
+a probe that registers a late import perturbs function indices for the rest
+of the module (interacts with #1916).
+
+## Proposed approach
+
+1. Add `withSpeculativeCompile(ctx, fctx, fn)` to `src/codegen/context/`:
+   snapshots body length + locals (existing `snapshotLocals`) + `ctx.errors`
+   length, and **defers `ensureLateImport` registration** until commit
+   (queue-and-flush); rollback discards the queue.
+2. Migrate all 23 truncation sites; lint/grep guard (`fctx.body.length =`
+   outside the helper fails CI quality job).
+3. Where the probe only needs a type, prefer adding a pure
+   `inferExpressionWasmType(node)` that never emits — several sites
+   (method-dispatch routers) need only that.
+
+## Acceptance criteria
+
+- Zero raw `body.length =` rollbacks outside the helper.
+- Late imports registered during a rolled-back probe do not appear in the
+  module (regression test).
+- Equivalence + test262 CI green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1847 (snapshotLocals), #1916.

--- a/plan/issues/1920-unify-instruction-walkers-peephole-catchall.md
+++ b/plan/issues/1920-unify-instruction-walkers-peephole-catchall.md
@@ -1,0 +1,60 @@
+---
+id: 1920
+title: "One instruction walker — peephole misses catchAll bodies; ≥4 divergent recursive walkers"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: compiler-internals
+goal: correctness
+---
+# #1920 — Unify instruction walkers; fix peephole catchAll gap
+
+## Problem
+
+≥4 hand-rolled recursive instruction walkers exist in the WasmGC backend with
+**divergent child coverage**:
+
+- `peephole.ts:76-95` — handles `catches` but **not `catchAll`**, so bodies
+  built by e.g. `wrapAsyncCallInTryCatch` (`expressions.ts:336+`) are never
+  peephole-optimized. (Bug, not just smell.)
+- `stack-balance.ts:54-96` (`eliminateDeadCode`) — handles catchAll correctly;
+  the two walkers diverged.
+- `late-imports.ts:151-171`, `context/locals.ts:192-201` — their own copies.
+- `src/codegen/walk-instructions.ts` exists **precisely for this** and has
+  only 2 consumers.
+
+Also cheap peephole wins identified while reviewing:
+- ~23 sites materialize NaN as `f64.const 0; f64.const 0; f64.div`
+  (`array-methods.ts:5801-5803`) when `{op:"f64.const", value: NaN}` is
+  directly encodable and already used at `type-coercion.ts:2786` — 3→1
+  instructions; the peephole can also normalize existing occurrences.
+- No `local.set N; local.get N → local.tee N` fusion.
+
+## Proposed approach
+
+1. Make `walkInstructions`/`walkChildren` (`walk-instructions.ts`) the single
+   traversal: enumerate child-buffer fields (`then`/`else`/`body`/`catches`/
+   `catchAll`/`tryBody`…) in ONE place with an exhaustiveness check against
+   the `Instr` union.
+2. Port peephole, stack-balance DCE, late-imports, and locals scanning onto it.
+3. Fix the catchAll gap (regression test: async call wrapped in try/catch,
+   assert `ref.cast`+`ref.as_non_null` pair is collapsed inside the handler).
+4. Add the NaN-const normalization and set/get→tee fusion patterns; replace
+   the 23 div-NaN emission sites with the direct const.
+
+## Acceptance criteria
+
+- One walker; the four local recursions are gone.
+- catchAll regression test passes; binary-size spot-check shows the NaN and
+  tee savings on a closure-heavy example.
+- Equivalence + test262 CI green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #957 (peephole corpus), #1530.

--- a/plan/issues/1921-structured-compile-failure-gate.md
+++ b/plan/issues/1921-structured-compile-failure-gate.md
@@ -1,0 +1,63 @@
+---
+id: 1921
+title: "Replace the 'Codegen error:' string-prefix compile-failure gate with structured severity"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: compiler
+language_feature: compiler-internals
+goal: correctness
+---
+# #1921 — Structured compile-failure gate
+
+## Problem
+
+Whether a codegen diagnostic **fails the build** is decided by a string
+prefix: `compiler.ts:731` bails only when a message
+`startsWith("Codegen error:")`. The consequences:
+
+- A plain `reportError(..., "Unsupported expression: X")`
+  (`src/codegen/expressions.ts:1274`) pushes a severity-`"error"`
+  diagnostic, the expression compiles to `null`, the stack balancer patches
+  the hole with a default value (#1918), and `compileCore` still returns
+  **`success: true`** (`compiler.ts:877`) with the wrong value baked in.
+- 177 `reportError` sites; ~118 "Unsupported …" messages are on the soft
+  path. Failing vs silently degrading depends on whether the author
+  remembered the magic prefix.
+- `generateModule` wraps the whole pipeline in one try/catch that flattens
+  any exception into a single locationless "Codegen error"
+  (`index.ts:1576-1578`).
+
+`CodegenError` already has a `severity?` field (`context/errors.ts:29-36`) —
+the gate just doesn't use it.
+
+## Proposed approach
+
+1. Gate on severity, not message text: any `severity: "error"` diagnostic ⇒
+   `success: false`. Introduce `severity: "degrade"` for the (few,
+   deliberate) cases where compile-with-fallback-value is intended, each with
+   a tracking-issue reference (mirror the host-import allowlist discipline).
+2. Sweep the 177 `reportError` sites: classify each as error vs degrade.
+   Expect most "Unsupported …" sites to become hard errors; run test262
+   sharded CI to quantify the conformance delta and whitelist deliberate
+   degrades.
+3. Preserve the exception catch-all but attach `lastKnownNode` position
+   instead of locationless line 1.
+
+## Acceptance criteria
+
+- `git grep 'startsWith("Codegen error'` is empty; gate reads severity.
+- An "Unsupported expression" input returns `success: false` (regression
+  test) unless explicitly degrade-listed.
+- test262 net impact reviewed and accepted in the PR (some currently-"passing"
+  tests may legitimately flip to compile errors — that is the honest result).
+
+## Source
+
+Compiler quality review 2026-06. Direct child of #1858. Related: #1918,
+#1853 (hard-error stability bucket).

--- a/plan/issues/1922-shared-ir-traversal-while-loop-dce-defect.md
+++ b/plan/issues/1922-shared-ir-traversal-while-loop-dce-defect.md
@@ -1,0 +1,80 @@
+---
+id: 1922
+title: "Shared IR traversal/use-collection module — fixes live defect: ordinary while loops demote off the IR path"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: ir
+language_feature: compiler-internals
+goal: correctness
+---
+# #1922 — Shared IR traversal; fix while-loop DCE demotion
+
+## Problem
+
+At least **five hand-rolled copies** of "walk nested instruction buffers /
+collect uses" exist in `src/ir/`, each with its own buffer coverage, kept in
+sync only by comments ("if a new buffer-bearing instr kind is added, extend
+both", `verify.ts:33-34`):
+
+- `verify.ts:459` + `nestedBuffers` (`verify.ts:35`)
+- `lower.ts:2255` + `collectForOfBodyUses` (`lower.ts:2409`)
+- `passes/dead-code.ts:285` with per-case inline walkers
+- `passes/constant-fold.ts` const-map seeding
+- alloc-discipline's walker
+
+**Confirmed live defect** (probe-verified during the 2026-06 review):
+
+```ts
+export function f(n: number): number {
+  const limit = n * 2; let i = 0;
+  while (i < limit) { i = i + 1; }
+  return i;
+}
+```
+
+with `experimentalIR: true` emits `warning IR path failed for f:
+post-hygiene verify: use of SSA value 2 before def in block 0 [IR-FALLBACK]`.
+Root cause: DCE's `collectInstrUses` returns only `[condValue]` for
+`while.loop`/`for.loop`, with a comment claiming the buffers "are already
+walked separately by the dead-code analysis walker"
+(`passes/dead-code.ts:489-494`) — **false**; no such walk exists in
+`computeLiveValues` (`dead-code.ts:138-173`). DCE strips `limit` (its only
+use is inside the condition buffer it never walks), the post-stage verifier
+catches the dangling ref, and the function silently demotes to legacy. The
+most ordinary loop shape in the language never compiles through the IR — and
+because this is a post-claim demotion, no ratchet counts it (#1923).
+`while.loop`/`for.loop` (#1280) updated some walker copies and not others —
+exactly the failure mode the duplication invites.
+
+## Proposed approach
+
+1. Add to `src/ir/nodes.ts`: `forEachNestedBuffer(instr, fn)` and
+   `collectUses(instr, { deep?: boolean })`, the single authority on which
+   instr kinds carry buffers (`if`, `forof.vec/iter/string`, `while.loop`,
+   `for.loop`, `try`, generator kinds…).
+2. Port verify / lower / dead-code / constant-fold / alloc-discipline onto
+   them; delete local copies (~600 lines).
+3. Exhaustiveness test: for every `IrInstr` kind that has an `Instr[]`/
+   nested-IR field (derive by construction in the test), assert
+   `forEachNestedBuffer` visits it.
+4. Regression test: the `while (i < limit)` function above compiles through
+   the IR path with **zero** fallback warnings.
+
+## Acceptance criteria
+
+- The probe program (and a `for (let i = 0; i < limit; i++)` variant) stays
+  on the IR path.
+- One traversal module, five consumers; the false comment at
+  `dead-code.ts:489-494` is gone.
+- `check:ir-fallbacks` corpus shows the while-loop demotions disappear.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1280 (introduced the loop kinds),
+#1923 (would have made this visible), #1530.

--- a/plan/issues/1923-meter-ir-post-claim-demotions.md
+++ b/plan/issues/1923-meter-ir-post-claim-demotions.md
@@ -1,0 +1,62 @@
+---
+id: 1923
+title: "Meter IR post-claim demotions in the fallback ratchet — build/verify/lower failures are invisible to CI"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: ir
+language_feature: compiler-internals
+goal: correctness
+---
+# #1923 — Meter IR post-claim demotions in the ratchet
+
+## Problem
+
+The IR fallback ratchet (`pnpm run check:ir-fallbacks`,
+`scripts/ir-fallback-baseline.json`) counts **only selector-level rejection
+reasons** (`IrFallbackReason`). Functions that the selector *claims* and that
+then fail during build/verify/lower demote to legacy through the warning
+channel (`src/codegen/index.ts:889-896`) and are **counted nowhere**:
+
+- `from-ast.ts` has 174 `throw new Error` sites that land as `kind: "build"`
+  errors in `IrIntegrationReport` (`ir/integration.ts:238-240`, `:84`).
+- `STRICT_IR_BUILD_ERRORS` exists but is empty (`codegen/index.ts:906`).
+- Selector/lowerer disagreement is institutionalized: the selector
+  deliberately accepts shapes the lowerer is known to reject (class
+  receivers `select.ts:44-48`; array literals accepted purely to protect the
+  call-graph closure with a guaranteed lowerer throw, `from-ast.ts:1221-1230`).
+
+Consequence: a regression that makes claimed functions fail **after**
+claiming bypasses CI entirely. The #1922 while-loop defect is a live example
+— ordinary loops fell off the IR path and no gate noticed. The #1530
+phase-out of the warning channel cannot be trusted while its main leak is
+unmetered.
+
+## Proposed approach
+
+1. Aggregate `IrIntegrationReport.errors` by `kind` (build/verify/lower) and
+   a normalized message class (first line, identifiers stripped) over the
+   same `playground/examples/` corpus the ratchet already walks.
+2. Add these as a second bucket family in `ir-fallback-baseline.json`
+   (`postClaim: { build: {...}, verify: {...}, lower: {...} }`).
+3. Same gate semantics: growth fails CI; `--update-on-decrease` banks
+   improvements; `--verbose` prints per-file breakdown.
+4. As buckets hit zero, promote the message class into
+   `STRICT_IR_BUILD_ERRORS` so regressions become hard compile errors.
+
+## Acceptance criteria
+
+- `check:ir-fallbacks` output shows selector buckets AND post-claim buckets.
+- A deliberate injected `from-ast` throw on a claimed shape fails the gate
+  (test).
+- Baseline committed; ci.yml quality job unchanged otherwise.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1376 (ratchet), #1530 (phase-out),
+#1922 (the defect this would have caught).

--- a/plan/issues/1924-ir-verifier-instruction-type-rules.md
+++ b/plan/issues/1924-ir-verifier-instruction-type-rules.md
@@ -1,0 +1,65 @@
+---
+id: 1924
+title: "Instruction-level type rules in the IR verifier — operands, branch-arg types, and resultType validation"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: ir
+language_feature: compiler-internals
+goal: correctness
+---
+# #1924 — IR verifier: instruction-level type rules
+
+## Problem
+
+The IR verifier is positioned as the project's compensation for TypeScript's
+unsound type system (`docs/architecture/structure-and-language-assessment.md:107-110`),
+and #1850 hardened SSA/dominance/legality. But it still checks **no
+per-instruction operand typing at all**:
+
+- `f64.add` over two i32 values, `string.concat` over f64s, `object.get` of
+  a missing field, `closure.call` arity/type mismatch — all pass verification.
+  The only type rules are the union trio (`verify.ts:375-410`) and
+  conservative return assignability (#1798, `verify.ts:264-285`).
+- Branch args: **arity checked, types not** — `checkBranchArity`
+  (`verify.ts:681-704`) compares lengths only; `blockArgTypes` are never
+  matched against passed values' types.
+- `resultType` is denormalized onto every instr "for verifier speed"
+  (`nodes.ts:438`) and **trusted, never re-derived** — yet it directly
+  becomes Wasm local types at lowering (`lower.ts:523-533`). A pass that
+  writes a wrong resultType is invisible until the engine rejects the binary
+  (or worse, accepts it with wrong semantics).
+- Slot discipline unchecked: `slot.read/write` indices never validated
+  against `func.slots` bounds or declared types.
+- Perf note: `operandIrType` re-scans the whole function per query
+  (`verify.ts:629-641`) — quadratic; build a def-map once (the dominance
+  check already builds one).
+
+## Proposed approach
+
+1. Table-driven rule per `IrInstr` kind: expected operand IrType kinds →
+   derived result kind. Start permissive (kind-level: scalar/ref/string/
+   object) and tighten; reuse the def map from #1850's dominance pass.
+2. Validate `resultType` against the derived kind; mismatch ⇒ verify error
+   (demotes safely via the existing channel, metered by #1923).
+3. Branch-arg type matching against `blockArgTypes`.
+4. Slot read/write bounds + declared-type checks.
+5. Keep total verify cost O(n): one def-map, one pass.
+
+## Acceptance criteria
+
+- Injected wrong-resultType and i32-into-f64.add IR (unit tests via
+  IrFunctionBuilder) are rejected.
+- No new post-claim demotions on the playground corpus (or each one
+  investigated — they are real latent bugs by definition).
+- Verify wall-time on the corpus within 1.5× of current.
+
+## Source
+
+Compiler quality review 2026-06. Extends #1850 (in-review). Related: #1923,
+#1857 (attributes vs operands).

--- a/plan/issues/1925-ir-hygiene-passes-nested-buffers.md
+++ b/plan/issues/1925-ir-hygiene-passes-nested-buffers.md
@@ -1,0 +1,71 @@
+---
+id: 1925
+title: "Run IR hygiene passes inside nested buffers — or commit to one control-flow representation"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: ir
+language_feature: compiler-internals
+goal: performance
+---
+# #1925 — IR optimization inside nested buffers / one CF representation
+
+## Problem
+
+The IR carries **two competing control-flow representations** and pays for
+both while benefiting from neither:
+
+- A blockarg CFG with phis exists (`nodes.ts:1837-1886`) and #1850 built
+  dominance analysis over it — but `simplify-cfg.ts:37-40` states that
+  "from-ast.ts and CF never introduce block args": the CFG layer is largely
+  vestigial.
+- Nearly all real control flow lives in **nested instruction buffers** on
+  statement-level instrs: `if` (`nodes.ts:613-620`), `forof.*`,
+  `while.loop`/`for.loop` (`nodes.ts:1649-1692`), `try` (`nodes.ts:1723-1739`).
+  Loop-carried state escapes SSA into mutable `slot.read`/`slot.write` Wasm
+  locals (`nodes.ts:1045-1060`).
+
+Consequences:
+- **Constant folding never descends into buffers** (`constant-fold.ts:50-57`
+  seeds only top-level `block.instrs`; `tryFoldInstr:110-120` punts on `if`
+  arms). Loop bodies — the only code where folding pays — are never folded.
+- Every pass must special-case ~10 buffer-bearing kinds (see #1922).
+- MIR/SIL-style loop reasoning (LICM, induction variables) is impossible.
+
+## Proposed approach
+
+Decide explicitly, then execute (architect spec first):
+
+**Option A (M)** — accept the structured-IR direction (Binaryen-style):
+make hygiene passes (constant-fold, DCE, simplify) apply recursively inside
+buffers with scoped def maps, using #1922's shared traversal; delete the
+unused blockarg machinery (or freeze it behind the CFG-only paths that use
+it). Cheapest path to the IR delivering optimization value.
+
+**Option B (L)** — commit to the CFG: lower loops/ifs into blocks + branch
+args at build time, make slots into SSA values with phis, drop nested
+buffers. Stronger analyses, much bigger migration; touches every pass and
+the emitter trait.
+
+The review's recommendation: **A now, keep B as the long-term question** —
+but either way, stop maintaining both halves. Do this **before** the
+class-method/async adoption waves (#1370/#1373) multiply the per-pass
+special-casing.
+
+## Acceptance criteria
+
+- A constant expression inside a `while` body is folded (unit test).
+- DCE removes a dead value defined and used only inside a loop body.
+- ADR documenting the chosen representation; `docs/adr/0012` marked
+  superseded-in-practice (the high-level-IR + lowered-IR split it accepted
+  was never built).
+
+## Source
+
+Compiler quality review 2026-06. Depends on #1922 (shared traversal).
+Related: #1850, #1851, #1370, #1373.

--- a/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
+++ b/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
@@ -1,0 +1,58 @@
+---
+id: 1926
+title: "Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir
+language_feature: compiler-internals
+goal: maintainability
+---
+# #1926 — Remove ValType/typeIdx from IrType
+
+## Problem
+
+The IR's type system embeds backend Wasm types, contradicting the
+symbolic-ref premise that makes the IR backend-agnostic:
+
+- `union.members: ValType[]` and `boxed.inner: ValType`
+  (`src/ir/nodes.ts:211-216`) — and `ValType` includes
+  `ref { typeIdx: number }`, a **module-relative concrete type index**,
+  which `irTypeEquals` happily compares (`nodes.ts:335-341`). An IrType can
+  smuggle exactly the raw indices the symbolic-ref design
+  (`nodes.ts:22-28`) exists to eliminate.
+- This pins the IR to one module instance and one backend: it blocks IR
+  serialization/caching, and blocks the linear backend from adopting
+  IR-driven unions (the `BackendEmitter` aggregate group, #1851/#1852).
+- The resolver-deferred kinds (`string`, `object`, `closure`, `class`,
+  `extern` — `nodes.ts:88-114`) already demonstrate the right pattern:
+  structural shape in the IR, concrete layout decided at lowering.
+
+## Proposed approach
+
+1. `union.members: IrType[]`; `boxed.inner: IrType`.
+2. Where a concrete reference is genuinely needed pre-lowering, introduce a
+   symbolic `IrTypeRef` (interned shape key), resolved to `ValType` by the
+   backend resolver at lowering — same mechanism the string/object kinds use.
+3. Mechanical migration of `irTypeEquals`, propagate.ts's
+   `lowerTypeToIrType`, the union passes (`passes/tagged-union-types.ts`),
+   and lowering sites; behavior-identical for WasmGC (assert byte-identical
+   output on the playground corpus, the #1713 method).
+4. Follow-up unlocked (not in scope): aligning `propagate.ts`'s separate
+   `LatticeType` with IrType so the two type systems stop diverging.
+
+## Acceptance criteria
+
+- `git grep 'typeIdx' src/ir/nodes.ts` shows no IrType-reachable concrete
+  indices; `IrType` is serializable (JSON round-trip test).
+- WasmGC output byte-identical on the corpus; equivalence + test262 green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1851 (legalization boundary),
+#1852 (per-backend value representation), #1714.

--- a/plan/issues/1927-single-pipeline-driver.md
+++ b/plan/issues/1927-single-pipeline-driver.md
@@ -1,0 +1,62 @@
+---
+id: 1927
+title: "One front-end pipeline driver — compileSourceSync/compileMultiSource/compileFilesSource are divergent clones"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: compiler
+language_feature: compiler-internals
+goal: correctness
+---
+# #1927 — Single front-end pipeline driver
+
+## Problem
+
+The compile pipeline exists as three ~450-line near-clones with **divergent
+feature sets** (`src/compiler.ts:467` `compileSourceSync`, `:894`
+`compileMultiSource`, `:1195` `compileFilesSource`):
+
+- `detectEarlyErrors`, `rewriteEvalSuperCall`, hardened mode,
+  `preprocessImports`, the JS-mode retry, and the timer shim run **only** on
+  the single-source path. Multi-file compiles silently skip ES early errors
+  entirely.
+- `compileFilesSource` also skips define substitution and the CJS rewrite.
+- `generateMultiModule` is not passed `experimentalIR`, `nodeBuiltins`,
+  `wasiNodeFsFuncs`, `allowFs`, or `jsxRuntime` (`compiler.ts:1013-1022` vs
+  `:701-720`) — multi-file users silently get a weaker, different compiler.
+- The ~25-line error-return object is copy-pasted **14 times** across the file.
+- Doc drift: `index.ts:213-216` says `experimentalIR` "Defaults to off";
+  `compiler.ts:714` defaults it on.
+
+Every new option or phase must be added in three places; missing one is
+silent.
+
+## Proposed approach
+
+1. Extract `runPipeline(ast: TypedAST | MultiTypedAST, opts)` with an
+   explicit ordered phase list (rewrites → parse/check → diagnostic triage →
+   early errors → safe/hardened validation → codegen → post passes → emit).
+2. Entry points differ only in how they build the AST(s); everything below
+   the parse is shared.
+3. One `failResult(errors)` helper replaces the 14 copies.
+4. Phase applicability (e.g. CJS rewrite per-file in multi mode) is data on
+   the phase, not a fork of the driver.
+5. Fix the `experimentalIR` doc/default mismatch while there.
+
+## Acceptance criteria
+
+- Multi-file compile reports ES early errors (regression test: duplicate
+  `let` in a second file).
+- Option-plumbing parity test: the options object reaching codegen is
+  identical for equivalent single/multi invocations.
+- `compiler.ts` shrinks by ≥800 lines; equivalence + test262 green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1931 (early-error decomposition
+rides on this), #1929.

--- a/plan/issues/1928-source-position-remapping-preparse-rewrites.md
+++ b/plan/issues/1928-source-position-remapping-preparse-rewrites.md
@@ -1,0 +1,56 @@
+---
+id: 1928
+title: "Source-position remapping for pre-parse rewrites — diagnostics report wrong line numbers"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: compiler
+language_feature: compiler-internals
+goal: correctness
+---
+# #1928 — Source-position remapping for pre-parse rewrites
+
+## Problem
+
+Diagnostics are computed against the **rewritten** source, not the user's:
+`compiler.ts:554` calls `diag.file.getLineAndCharacterOfPosition` on
+`processedSource`, after:
+
+- the timer shim is **prepended** (`import-resolver.ts:697`) — every line
+  shifts down for any source using `setTimeout`;
+- imports are replaced by multi-line `declare namespace` stubs
+  (`import-resolver.ts:546-589`) — everything below shifts;
+- CJS/define rewrites change text lengths.
+
+No offset mapping exists, so reported line numbers are wrong whenever any
+pre-parse rewrite fires — which on the primary single-source path is most
+nontrivial inputs. Additionally, codegen crashes are anchored to the first
+statement (`compiler/validation.ts:17-24`), reporting line 1.
+
+## Proposed approach
+
+1. The rewriters already build replacement lists — record per-rewrite deltas
+   `(origStart, origEnd, newLength)` while applying them.
+2. A small `PositionMap` translates processed→original offsets; apply it at
+   the single point where `CompileError`s are materialized (`compiler.ts:554`
+   and the multi-source equivalents — or once in the unified driver, #1927).
+3. Prepends (timer shim) become a constant line offset; same-length padding
+   is an acceptable stopgap for line-preserving rewrites if any resist
+   mapping.
+4. Test: a source with an import stub + timer shim + a type error on a known
+   line asserts the reported line equals the original.
+
+## Acceptance criteria
+
+- Diagnostic positions match the user's source under each rewrite (import
+  replacement, timer shim, CJS, define) — one regression test each.
+- No position changes for sources where no rewrite fires.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1929, #1927.

--- a/plan/issues/1929-compileerror-file-flatten-chains.md
+++ b/plan/issues/1929-compileerror-file-flatten-chains.md
@@ -1,0 +1,46 @@
+---
+id: 1929
+title: "CompileError: add file attribution and stop truncating TS diagnostic message chains"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: compiler
+language_feature: compiler-internals
+goal: contributor-readiness
+---
+# #1929 — CompileError.file + flattened diagnostic chains
+
+## Problem
+
+- `CompileError` has no `file` field (`src/index.ts:124-131`). Multi-file
+  compiles report `line/column` with no way to tell **which file** — a hard
+  usability gap for the multi-source/files APIs.
+- Message chains are truncated: `diag.messageText.messageText`
+  (`compiler.ts:560`) keeps only the head of a `DiagnosticMessageChain`,
+  dropping TS's "Type X is not assignable… because…" elaboration.
+  `ts.flattenDiagnosticMessageText` exists for exactly this.
+
+## Proposed approach
+
+1. Add optional `file?: string` to `CompileError`; populate from
+   `diag.file.fileName` at every materialization site (3 today; 1 after
+   #1927).
+2. Replace manual `.messageText` digging with
+   `ts.flattenDiagnosticMessageText(diag.messageText, "\n")`.
+3. Include `file` in CLI error formatting when present.
+
+## Acceptance criteria
+
+- A multi-file compile with an error in the second file reports that file's
+  name (test).
+- A nested assignability error includes the "because" elaboration (test).
+- Public API change is additive only.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1928, #1927.

--- a/plan/issues/1930-typeoracle-type-query-boundary.md
+++ b/plan/issues/1930-typeoracle-type-query-boundary.md
@@ -1,0 +1,66 @@
+---
+id: 1930
+title: "TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: compiler
+language_feature: compiler-internals
+goal: maintainability
+---
+# #1930 — TypeOracle: one type-query boundary
+
+## Problem
+
+There is no abstraction between the TypeScript checker and codegen:
+
+- **~397 `getTypeAtLocation` call sites** across 20+ codegen files thread a
+  live `ts.TypeChecker` and raw `ts.Type` objects everywhere. The only
+  firewalls are the small `ValType` mapper (`checker/type-mapper.ts:38`) and
+  the partial IR `TypeMap`.
+- This **forecloses the project's own TS7 plan**: typescript-native-preview
+  has no JS-API TypeChecker; the shim already throws under `--ts7`
+  (`src/ts-api.ts:114-131`, #1029). Migration today would be a rewrite.
+- Type knowledge is fragmented across **four** uncoordinated mechanisms: the
+  TS checker, the IR lattice (`ir/propagate.ts:220`), `shape-inference.ts`,
+  and import-resolver's syntactic `any` stubs.
+- The `number|null` → bare `f64` lowering spawned ~300 lines of heuristics
+  (`compiler.ts:98-391`) that *suppress the checker's own correct
+  diagnostics*, recognizing only direct `!== null` if-guards — suppression
+  is inconsistent, and `compiler.ts:387-390` reaches into the unsupported
+  internal `isTypeAssignableTo` API.
+
+## Proposed approach
+
+Architect spec first; then mechanical migration:
+
+1. Define `TypeOracle` — the closed set of queries codegen actually needs
+   (survey the 397 sites; expect ~15 query kinds: valTypeOf(node),
+   isNullable, callSignatureOf, elementTypeOf, propertyTypeOf, …) returning
+   **compiler-owned types** (ValType/IrType-level), never `ts.Type`.
+2. Implement `TsCheckerOracle` (today's behavior) behind it; migrate codegen
+   sites file-by-file with a grep ratchet on `getTypeAtLocation`
+   (same mechanics as the #1095 cast budget).
+3. Fold nullable-primitive handling into the lowering (branded externref or
+   (i32-flag, f64) pair — coordinate with #1852's per-backend value
+   representation), then delete the suppression heuristics in
+   `compiler.ts:98-391`.
+4. Later backends: TS7 LSP-based oracle; IR TypeMap as a refinement layer.
+
+## Acceptance criteria
+
+- Ratchet file counts direct checker access in `src/codegen/`; CI fails on
+  growth; trend to zero.
+- The suppression-heuristic block is deleted; `number|null` programs compile
+  with correct semantics (tests).
+- A `--ts7` smoke path can construct the oracle without `createProgram`.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1029 (TS7), #1852, #1948 (numeric
+lattice consumes the oracle). Needs `/architect-spec`.

--- a/plan/issues/1931-decompose-detect-early-errors-treeshake.md
+++ b/plan/issues/1931-decompose-detect-early-errors-treeshake.md
@@ -1,0 +1,60 @@
+---
+id: 1931
+title: "Decompose detectEarlyErrors (3,350-line function) and run it on every path; wire or delete the dead treeshake option"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: refactor
+area: compiler
+language_feature: compiler-internals
+goal: conformance
+---
+# #1931 — Decompose detectEarlyErrors; wire or delete treeshake
+
+## Problem
+
+- `detectEarlyErrors` (`src/compiler/validation.ts:171-3527`) is a **single
+  ~3,350-line function** containing 55+ nested closures reimplementing
+  ECMA-262 early errors (strict-mode rules, TDZ, duplicate lexical
+  declarations, labels, assignment targets, private names…). The purpose is
+  right — TS doesn't enforce ES early errors and test262 `negative.phase:
+  parse` demands them — but nested closures are individually untestable, and
+  per-node dispatch is one giant `visit` re-checking dozens of patterns.
+- It runs **only on the single-source path** — `compileMultiSource` /
+  `compileFilesSource` skip ES early errors entirely.
+- Stale comment at `validation.ts:215-217` claims "we add export {}
+  synthetically" — no code does.
+- Separately: the public `CompileOptions.treeshake` (`src/index.ts:194`) is
+  **dead code** — never read by any compile path; `treeshake()` is only
+  re-exported (`index.ts:443`). A documented option that does nothing.
+
+## Proposed approach
+
+1. Split into per-concern rule modules under `src/compiler/early-errors/`
+   (`strict-mode.ts`, `tdz.ts`, `duplicates.ts`, `labels.ts`,
+   `assignment-targets.ts`, `private-names.ts`, …) sharing **one** AST walk
+   via a rule registry; each rule unit-testable with small fixtures.
+2. Call from the unified pipeline driver (#1927) so all entry points get ES
+   early errors; until #1927 lands, add the call to both multi paths.
+3. Delete the stale comment; keep behavior identical (test262 parse-negative
+   results must not regress — that's the acceptance oracle).
+4. `treeshake`: either invoke `treeshake()` when the option is set (with a
+   test showing a dropped unused export) or remove the option from the
+   public API and docs. Decide with the PO; the review recommends wiring it,
+   since the implementation exists.
+
+## Acceptance criteria
+
+- No function in validation.ts exceeds ~300 lines; rules have direct unit
+  tests.
+- Multi-source compile rejects a duplicate-`let` early error (test).
+- test262 parse-negative bucket unchanged or improved.
+- `treeshake` option either functional (test) or gone.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1927.

--- a/plan/issues/1932-version-env-abi.md
+++ b/plan/issues/1932-version-env-abi.md
@@ -1,0 +1,58 @@
+---
+id: 1932
+title: "Version the env ABI — no compatibility handshake between compiled binaries and runtime.ts"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: feature
+area: runtime
+language_feature: compiler-internals
+goal: correctness
+---
+# #1932 — Version the env ABI
+
+## Problem
+
+The `env` ABI between compiled binaries and the JS host runtime — ~200
+distinct import names, NaN-as-missing-arg sentinels
+(`number_toPrecision`'s isNaN check, `runtime.ts:5092-5096`; the `split`
+NaN-limit hack, `:4684-4689`), `__call_fn_N` arity exports, `__sget_*`
+naming — has **no version constant and no handshake**. A precompiled `.wasm`
+paired with a newer/older `runtime.js` fails only at runtime, by
+missing-import LinkError or silent misbehavior.
+
+The team already knows how to do this: `STANDALONE_REGEXP_ABI_VERSION = 1`
+exists for the regex engine (`src/codegen/regexp-standalone.ts:51`). It just
+isn't applied to the main surface.
+
+## Proposed approach
+
+1. Define `ENV_ABI_VERSION` in one shared module imported by both codegen
+   and runtime.
+2. Codegen emits it (an exported immutable global `__abi_version`, plus a
+   custom section for offline inspection).
+3. `buildImports`/instantiation (`runtime.ts:10018`,
+   `runtime-instantiate.ts`) reads the export post-instantiation (or the
+   custom section pre-instantiation) and throws a clear, actionable error on
+   mismatch: expected vs found, with the compiler version that produced the
+   binary.
+4. Bump policy documented in the allowlist header: any change to an import
+   name/signature/sentinel bumps the constant (review checklist line).
+5. Tolerate absence (binaries older than this feature) with a one-time
+   console warning, for one release window.
+
+## Acceptance criteria
+
+- Mismatched binary/runtime pair produces the structured error (test with a
+  doctored global).
+- Old binary without the global still instantiates with a warning.
+- Docs: `docs/` note on ABI stability for precompiled binaries.
+
+## Source
+
+Compiler quality review 2026-06. Related: host-import allowlist
+(`src/codegen/host-import-allowlist.ts`), #1858.

--- a/plan/issues/1933-runtime-multi-instance-isolation-leak.md
+++ b/plan/issues/1933-runtime-multi-instance-isolation-leak.md
@@ -1,0 +1,58 @@
+---
+id: 1933
+title: "Runtime multi-instance isolation — module-level mutable state bleeds across instances and retains them forever"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: compiler-internals
+goal: correctness
+---
+# #1933 — Runtime multi-instance isolation + retention leak
+
+## Problem
+
+`src/runtime.ts` keeps **module-level mutable state** that is shared by all
+instances on a page:
+
+1. `buildImports` *resets* `_symbolCache = undefined;
+   _symbolDescRegistry.clear()` (`runtime.ts:10053-10054`) — two concurrently
+   live instances clobber each other's symbol-id↔description mapping.
+2. `_legacyRegExpState` (`runtime.ts:3146`) is a single shared register —
+   RegExp static state (`RegExp.$1` style) crosses instances.
+3. **Retention leak**: `_subclassCtors: Map<string, Function[]>`
+   (`runtime.ts:3634`) and `_userClassParents` (`:1320`) are string-keyed,
+   module-level, never cleared; registered ctors close over their instance's
+   exports — in hot-reload/test-runner scenarios, **whole instances are
+   retained forever**.
+4. Minor: `lastCaughtException` (`:10048`) pins the most recent exception
+   graph until the next throw.
+
+## Proposed approach
+
+1. Move all four into the existing per-build `InstanceState`
+   (`runtime.ts:10064`) / `callbackState`; thread through the closures that
+   read them (mechanical but wide — the helpers already receive state in
+   most paths).
+2. `_subclassCtors` keyed per instance also fixes the leak.
+3. Test: instantiate two modules in one realm; (a) symbols registered in A
+   keep their descriptions after B instantiates; (b) after dropping all refs
+   to A and a forced GC (`--expose-gc` is already in vitest config), a
+   `WeakRef` to A's exports is collected despite B having registered
+   subclasses.
+
+## Acceptance criteria
+
+- No module-level mutable `let`/`Map` in runtime.ts that holds per-instance
+  data (grep-able allowlist for true constants).
+- Two-instance test green; WeakRef collection test green.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1934 (decomposition makes this
+easier — coordinate ordering).

--- a/plan/issues/1934-decompose-resolveimport-domain-tables.md
+++ b/plan/issues/1934-decompose-resolveimport-domain-tables.md
@@ -1,0 +1,61 @@
+---
+id: 1934
+title: "Decompose runtime.ts resolveImport — 5,000-line function, 188 name checks, into per-domain handler tables"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: runtime
+language_feature: compiler-internals
+goal: maintainability
+---
+# #1934 — Decompose resolveImport into domain tables
+
+## Problem
+
+`resolveImport` (`src/runtime.ts:4600-9610`) is a single **~5,000-line
+function**; its `"builtin"` case alone is ~4,190 lines carrying **188
+distinct `if (name === ...)` checks**, with Promise combinators, JSON, Date,
+Object.*, Reflect.* interleaved in one switch arm. Linear if-chains give
+O(n) dispatch; review and merge-conflict cost is the real tax (runtime.ts is
+a top-churn file).
+
+Compounding issues found during review:
+- A **test262 harness shim** (`Test262Error`, `assert_*`, `verifyProperty`
+  stubs) is embedded as a template string inside the production eval handler
+  (`runtime.ts:5250-5320`) — test infrastructure shipped in the production
+  runtime.
+- Three coexisting ToPrimitive walkers (`_toPrimitive` :2092,
+  `_toPrimitiveSync` :2280, `_hostToPrimitive` :2347) with #1716 comments
+  papering over divergence; a full JS-side JSON.stringify reimplementation
+  (:2719-3100) beside the host fast path.
+
+## Proposed approach
+
+1. Split the `"builtin"` arm into per-domain modules under `src/runtime/`
+   (`promise.ts`, `json.ts`, `date.ts`, `object-reflect.ts`, `string.ts`,
+   `math.ts`, …), each exporting
+   `Record<string, (ctx: InstanceState) => Function>`; `resolveImport` does
+   one map lookup. `src/runtime/builtins.ts` already seeds this pattern.
+2. Move the test262 shim behind a build/option flag (`runtimeTest262Shim`),
+   excluded from production bundles.
+3. Unify the three ToPrimitive walkers into one (parameterized by
+   sync/host), as its own PR within this issue.
+4. Keep behavior identical: the equivalence suite + test262 js-host lane are
+   the oracle; do the move in mechanical, per-domain PRs.
+
+## Acceptance criteria
+
+- No function in runtime.ts over ~300 lines; dispatch is table lookup.
+- Production bundle excludes the test262 shim (size check in test).
+- One ToPrimitive implementation; #1716 divergence comments resolved.
+- Equivalence + test262 green per PR.
+
+## Source
+
+Compiler quality review 2026-06. Coordinate with #1933 (instance state) —
+doing #1934 first makes #1933 mechanical.

--- a/plan/issues/1935-retire-undefined-sentinel-protocol.md
+++ b/plan/issues/1935-retire-undefined-sentinel-protocol.md
@@ -1,0 +1,58 @@
+---
+id: 1935
+title: "Retire the undefined-as-sentinel protocol in runtime.ts — getters returning undefined are misread as absent"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: compiler-internals
+goal: correctness
+---
+# #1935 — Retire the undefined-sentinel protocol
+
+## Problem
+
+The host runtime pervasively uses `undefined` as an in-band "absent" signal,
+which misinterprets user code that legitimately returns `undefined`:
+
+- `safeGetField` treats a getter returning `undefined` as "getter absent"
+  and falls through to sidecar/struct fields (`runtime.ts:3869-3873`:
+  `const v = invokeGetter(getter); if (v !== undefined) return v;`). A user
+  getter returning `undefined` silently yields the underlying field value
+  instead.
+- Same pattern in ToPrimitive paths (`prim !== undefined`, e.g.
+  `runtime.ts:4658`, `:5046`) — a `valueOf` returning `undefined` is treated
+  as "no valueOf".
+- The file already demonstrates the correct pattern: `_PRIM_ABSENT` unique
+  symbol (`runtime.ts:2079`) — it just isn't applied uniformly.
+
+Property-lookup precedence is additionally re-derived in four places
+(`_safeGet` :3307, `_wrapForHost` :3843-4133, `_readOwnDescriptor` :3685,
+`_liveGet` :2790) that must all agree — fixing the sentinel must fix all
+four consistently.
+
+## Proposed approach
+
+1. One exported `const MISS: unique symbol`; `invokeGetter`, sidecar
+   lookups, and ToPrimitive step functions return `MISS` for absence.
+2. Sweep the `!== undefined` fallthrough sites (grep
+   `invokeGetter|_PRIM_ABSENT|!== undefined` in runtime.ts) and convert.
+3. Differential tests (equivalence suite): getter returning `undefined`
+   shadows a field; `valueOf` returning `undefined` falls through to
+   `toString` per spec ToPrimitive (it should — but via the spec path, not
+   the absent path); `Object.assign`/spread over such objects.
+
+## Acceptance criteria
+
+- The getter-returns-undefined test matches V8 in the equivalence harness.
+- One absence sentinel; `_PRIM_ABSENT` either renamed/unified or removed.
+- test262 js-host lane net non-negative.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1934 (the four lookup paths).

--- a/plan/issues/1936-async-contract-migration-enable-cps.md
+++ b/plan/issues/1936-async-contract-migration-enable-cps.md
@@ -1,0 +1,67 @@
+---
+id: 1936
+title: "Async contract migration — teach call sites to drive Promises, then enable the built-but-disabled CPS lowering"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+language_feature: async-await
+goal: conformance
+---
+# #1936 — Async contract migration (enable CPS)
+
+## Problem
+
+The sound async lowering exists and is switched off. `src/codegen/async-cps.ts`
+splits bodies at awaits, computes live-local capture sets
+(`analyzeAsyncBody`), and chains continuations via `Promise.then` — but
+`ASYNC_CPS_ENABLED = false` (`async-cps.ts:60`), with the reason documented
+at `async-cps.ts:38-58`: legacy call sites consume async results
+**synchronously** (`asyncFn() as any as number` returns an unwrapped value).
+The gate is per-definition but the contract is per-call-site, so a global
+flip can't preserve both.
+
+Consequences: shipped async semantics are spec-wrong by design (async
+functions don't return Promises synchronously); the CPS path bit-rots; and
+the standalone scheduler (`async-scheduler.ts` — clean native `$Promise` +
+microtask queue, drained after `_start`) is underused. This is the single
+biggest semantic landmine in the runtime layer and a major test262 bucket.
+
+## Proposed approach
+
+Architect spec first (this is the review's #1 architect-level item):
+
+1. **Call-site census**: classify every consumer of an async call result
+   (await in async context / `.then` / synchronous consumption) over the
+   playground + tests corpora; the sync-consumption set is the migration
+   surface.
+2. **Compile-time await-elision** for the statically-resolvable chains
+   (fits the "compile away" principle): where an async function's awaited
+   values are all synchronously-resolved (no real suspension), compile it as
+   a sync function returning a resolved `$Promise` — this preserves most
+   current sync-consumption behavior *soundly*.
+3. Per-module (or per-function-strongly-connected-component) flip:
+   `ASYNC_CPS_ENABLED` becomes a per-function decision driven by the census,
+   ratcheted like IR adoption.
+4. Wire the standalone scheduler as the CPS path's substrate in
+   standalone/WASI mode; js-host mode uses host Promises.
+5. Track conformance: built-ins/promise and async-function test262 buckets
+   are the oracle.
+
+## Acceptance criteria
+
+- `asyncFn()` returns a then-able in both modes (spec shape).
+- No equivalence regressions in the sync-consumption corpus (elision covers
+  them, or they're flagged as deliberate breaks with migration notes).
+- `ASYNC_CPS_ENABLED` constant removed in favor of the per-function decision.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1373 (IR async adoption — align
+so IR adopts the CPS form, not the legacy form), async-scheduler phases.
+Needs `/architect-spec`.

--- a/plan/issues/1937-linear-backend-fail-loud-break-continue.md
+++ b/plan/issues/1937-linear-backend-fail-loud-break-continue.md
@@ -1,0 +1,68 @@
+---
+id: 1937
+title: "Linear backend: break/continue are never compiled (silent infinite loops); dispatchers need default-arm diagnostics"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: critical
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen-linear
+language_feature: compiler-internals
+goal: correctness
+---
+# #1937 — Linear backend: fail loud; implement break/continue
+
+## Problem
+
+Despite #1868 (surfacing `ctx.errors` to `compiler.ts`), the linear
+backend's dispatchers still **fall through silently** on constructs they
+don't handle, because neither has a default arm:
+
+- `compileStatement` (`src/codegen-linear/index.ts:519-732`) ends at
+  `isThrowStatement` with no else. **`break` and `continue` are never
+  compiled** — there is no `ts.isBreakStatement` anywhere in the file, even
+  though `breakStack`/`continueStack` are pushed/popped
+  (`index.ts:603-611`) and never read. `while (true) { if (x) break; }`
+  compiles to an **infinite loop with zero diagnostics**. No `break` test
+  exists in `tests/linear-controlflow.test.ts`.
+- `compileExpression` (`index.ts:1230-1475`) ends at
+  `isObjectLiteralExpression` with no else: `typeof`, `await`, spread,
+  tagged templates, regex literals compile to **zero instructions** — a
+  stack-arity hole surfacing (at best) as an opaque validator error.
+- `throw` lowers to bare `unreachable` (`index.ts:728-731`) — exception
+  semantics silently replaced by a trap (contrast try/catch, which #1838
+  correctly made a hard error).
+- Truthiness is `f64.ne 0` (`index.ts:2158-2166`): `if (NaN)` is truthy.
+- Diagnostics that do exist mostly carry `line: 0, column: 0`
+  (`index.ts:2355, 2453, 2811`).
+- Switch fall-through from a non-empty case body is silently dropped
+  (`index.ts:1122-1228`).
+
+## Proposed approach
+
+1. **Implement break/continue** — the depth stacks already exist; emit
+   `br $breakDepth` / `br $continueDepth`. Add loop tests incl. labeled-less
+   nested loops.
+2. Add `else` arms to both dispatchers: push a located `ctx.errors` entry
+   ("Unsupported in linear backend: <SyntaxKind>") AND keep the stack
+   balanced (or rely on the #1868 success gate — but the diagnostic must
+   exist). Same for `throw` (named diagnostic, not silent trap, until real
+   exceptions land).
+3. Fix truthiness for NaN (`f64.eq self` test) and document the string case.
+4. Thread real positions (`getLineAndCharacterOfPosition`) into linear
+   diagnostics — the helper exists in the GC backend.
+5. Switch: hard error on non-empty-body fall-through until implemented.
+
+## Acceptance criteria
+
+- `break`/`continue` loop tests pass in `tests/linear-controlflow.test.ts`.
+- Every unsupported construct yields `success: false` with a located message
+  (table-driven test over a list of unsupported snippets).
+- `if (NaN)` takes the else branch (test).
+
+## Source
+
+Compiler quality review 2026-06. Direct child of #1858; extends #1868/#1838.

--- a/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
+++ b/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
@@ -1,0 +1,57 @@
+---
+id: 1938
+title: "Linear backend: number[] stores i32 elements ([1.5] → [1]) and element-assignment evaluates RHS twice"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen-linear
+language_feature: arrays
+goal: correctness
+---
+# #1938 — Linear number[] i32 truncation + double-eval RHS
+
+## Problem
+
+Two silent miscompiles in the linear backend's array path:
+
+1. **`number[]` arrays store i32 elements** (`codegen-linear/runtime.ts:484`:
+   "elements: i32×cap"). Reads convert back (`__arr_get` → i32 →
+   `f64.convert_i32_s`, `index.ts:2734-2736`); writes truncate via
+   `compileExprToI32` (`index.ts:2796-2798`). `[1.5]` silently becomes
+   `[1]`. Map keys/values are likewise i32 (`index.ts:1021-1033`). Nothing
+   documents or diagnoses this.
+2. **Element-assignment-as-expression evaluates the RHS twice** — once for
+   the store, again for the expression result (`index.ts:2797-2800`,
+   `:2806-2809`, and the Float64Array path `:2772-2774`). `arr[i] = f()`
+   calls `f()` twice; observable with any side-effecting RHS.
+
+## Proposed approach
+
+1. RHS double-eval (S, do first): compile RHS once into a scratch local;
+   store from the local; leave the local as the expression value. Test with
+   a counter-incrementing function as RHS.
+2. Element type (M): switch `number[]` element storage to f64 (stride 8) in
+   `runtime.ts` array helpers + `layout.ts`; keep an i32 fast path only
+   where the element type is provably integral (explicit `i32`-typed
+   annotation — mirroring the GC backend's `array-element-typing.ts`
+   contract). Map keys: f64 (or document+diagnose integer-only until then —
+   silent truncation is the bug, not the representation).
+3. Add linear equivalence tests for fractional elements, NaN elements, and
+   Map with fractional keys.
+
+## Acceptance criteria
+
+- `[1.5][0]` returns 1.5 under `--target linear` (test).
+- `arr[i] = f()` calls `f()` exactly once (test).
+- Existing linear tests green; benchmark suite (`benchmarks/run.ts` linear
+  strategies) shows no crash.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1937 (fail-loud companion),
+#1854 (cross-backend differential harness would have caught both).

--- a/plan/issues/1939-encodeinstr-default-throw-funcref-validation.md
+++ b/plan/issues/1939-encodeinstr-default-throw-funcref-validation.md
@@ -1,0 +1,58 @@
+---
+id: 1939
+title: "Binary emitter: encodeInstr silently drops unknown ops — add default throw, un-gate validateFuncRefs, add round-trip test"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: compiler-internals
+goal: correctness
+---
+# #1939 — encodeInstr default throw + funcref validation + round-trip test
+
+## Problem
+
+- **`encodeInstr` has no `default:` arm** (`src/emit/binary.ts:728-1678`).
+  Combined with the **173 `as unknown as Instr` casts** (#1095) that bypass
+  the type union, an op string that misses its case is **silently omitted
+  from the binary** — the exact failure shape the casts invite. The fix is
+  one line plus an exhaustiveness check.
+- `encodeValType` silently encodes i8/i16 as i32 with a "this shouldn't
+  happen" comment (`binary.ts:599-607`) — should throw.
+- `validateFuncRefs` (`binary.ts:105-157`) guards the recurring
+  stale-funcIdx bug class (#1891, #1899) but is **env-gated off by default**
+  (`binary.ts:190`).
+- **No round-trip test exists** for the emitter, even though
+  `src/link/reader.ts` is a full Wasm decoder that could verify it.
+
+## Proposed approach
+
+1. `default: throw new Error(\`encodeInstr: unknown op ${(instr as any).op}\`)`
+   plus a `satisfies never` exhaustiveness check where the union allows it.
+   Run equivalence + test262 sharded to flush any op currently being
+   silently dropped (each hit is a live bug found).
+2. `encodeValType` i8/i16 outside array-element context: throw.
+3. Enable `validateFuncRefs` whenever `process.env.NODE_ENV !== "production"`
+   and always in vitest/CI (cost is per-emit linear scan; measure, expect
+   negligible).
+4. Round-trip test: emit a representative module (the playground corpus
+   compiled small), decode with `link/reader.ts`, re-encode, assert
+   byte-identical; plus property: every `Instr` op in the union encodes to
+   ≥1 byte.
+
+## Acceptance criteria
+
+- Unknown-op and i8/i16-leak paths throw (unit tests).
+- funcref validation active in CI; round-trip test in `tests/`.
+- Any ops flushed out by the default-throw are fixed or added to the
+  encoder in the same PR.
+
+## Source
+
+Compiler quality review 2026-06. Direct child of #1858. Related: #1095/#1526
+(cast budget), #1899 (funcIdx authority), #1916.

--- a/plan/issues/1940-wit-generator-silent-param-drop.md
+++ b/plan/issues/1940-wit-generator-silent-param-drop.md
@@ -1,0 +1,55 @@
+---
+id: 1940
+title: "WIT generator: unmappable params are silently dropped — emitted WIT arity disagrees with the core function"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: tooling
+language_feature: compiler-internals
+goal: correctness
+---
+# #1940 — WIT generator: never silently drop params
+
+## Problem
+
+`functionToWit` skips any parameter whose type can't be mapped to WIT
+(`src/wit-generator.ts:401-406`), emitting a WIT signature whose **arity
+disagrees with the core function** — a consumer binding against the WIT
+will mis-call the export. Related silent mappings:
+
+- `any` maps to `string` (`wit-generator.ts:177-179`).
+- Unions of more than one non-null type return null and the member vanishes
+  (`wit-generator.ts:235`).
+
+The generator is honestly scoped ("first step toward Component Model",
+`wit-generator.ts:6` — no canonical-ABI adapters, no component binary), but
+within that scope the output must be either correct or refused.
+
+## Proposed approach
+
+1. Unmappable param/return ⇒ **skip the whole function** with a comment in
+   the WIT output (`// skipped foo: parameter 'x' has unmappable type T`)
+   and a compiler diagnostic — never emit a wrong-arity signature.
+2. `any` ⇒ skip-with-diagnostic too (mapping to `string` is a silent lie);
+   or gate behind an explicit `--wit-any=string` opt-in.
+3. Multi-member unions ⇒ WIT `variant` where members are mappable, else
+   skip-with-diagnostic.
+4. Tests: arity-mismatch regression (function with one unmappable param),
+   variant emission, and a golden-file check that every emitted function's
+   param count matches the export's signature (cross-check against the
+   compiled module's types).
+
+## Acceptance criteria
+
+- No emitted WIT function has an arity differing from its core export
+  (programmatic test, not golden text).
+- Diagnostics name the function and offending type.
+
+## Source
+
+Compiler quality review 2026-06. Child of #1858 (fail-loud).

--- a/plan/issues/1941-differential-testing-optimize-output.md
+++ b/plan/issues/1941-differential-testing-optimize-output.md
@@ -1,0 +1,60 @@
+---
+id: 1941
+title: "Differential testing of --optimize output — wasm-opt miscompiles currently ship invisibly"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: critical
+feasibility: easy
+reasoning_effort: medium
+task_type: test
+area: testing
+language_feature: compiler-internals
+goal: correctness
+---
+# #1941 — Differential testing of --optimize output
+
+## Problem
+
+Three independent reviewers in the 2026-06 quality review converged on this
+as the single largest untested correctness surface: **optimized output is
+never executed by any gate.**
+
+- The equivalence harness compiles with defaults only
+  (`tests/equivalence/helpers.ts:234` — no optimize flag).
+- The only optimize coverage is `tests/wasm-opt-optimize.test.ts` — 6 tests
+  that check compilation *succeeds* (magic bytes, `WebAssembly.validate`),
+  never that optimized output **behaves identically**.
+- The differential corpus lane (`scripts/diff-test.ts`) also uses default
+  compile options.
+- js2wasm emits unusual WasmGC patterns (externref laundering, guarded
+  casts, rec-groups) — exactly the territory where wasm-opt GC passes have
+  historically had bugs. The `--disable-custom-descriptors` workaround in
+  `optimize.ts:393-400` proves the team is already living on this edge. A
+  wasm-opt-induced miscompile today is discovered only by user bug reports.
+
+## Proposed approach
+
+1. Add `JS2WASM_EQUIV_OPTIMIZE=1` to `compileToWasm` in
+   `tests/equivalence/helpers.ts` (pass `{ optimize: true }`).
+2. Run **one of the 8 equivalence CI shards** in optimize mode (cheapest
+   slot: extend the ci.yml matrix with a 9th entry `shard: 1, optimize: 1`),
+   gated against its own known-failure baseline.
+3. Add an optimize lane to `scripts/diff-test.ts` (the V8-oracle corpus —
+   104 programs, fast) and gate deltas like the existing lane.
+4. Optionally: one test262 chunk with `optimize: true` weekly
+   (workflow_dispatch first to size the cost).
+5. Any failures found are *real shipped bugs* — file individually.
+
+## Acceptance criteria
+
+- CI executes optimized binaries and compares behavior against the JS
+  oracle on every PR (at least the equivalence shard + diff-test lane).
+- Baseline file for optimize-mode known failures, ratcheted.
+
+## Source
+
+Compiler quality review 2026-06 (testing, optimization, and linear/emit
+reviews all flagged it). Related: #1855 (fuzzer would also run this lane),
+optimize.ts custom-descriptors note.

--- a/plan/issues/1942-compile-time-regression-gate.md
+++ b/plan/issues/1942-compile-time-regression-gate.md
@@ -1,0 +1,58 @@
+---
+id: 1942
+title: "Compile-time regression gate — pass→compile_timeout is excluded from every gate, so compile-perf regressions are invisible"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: testing
+language_feature: compiler-internals
+goal: correctness
+---
+# #1942 — Compile-time regression gate
+
+## Problem
+
+`pass → compile_timeout` transitions are categorically excluded from gating
+(`scripts/diff-test262.ts:233`: `!r.wasmUnchanged && r.to !==
+"compile_timeout"`), and the standalone guard excludes them too (#1897,
+test262-sharded.yml). The exclusion is right for *runner-load flake*
+(documented in `feedback_regression_analysis`), but it creates a structural
+blind spot: **a PR that pathologically slows compilation** (exponential type
+inference, accidental O(n²) pass) converts passes to timeouts and is
+invisible to the host gate, the standalone gate, and the catastrophic guard.
+Nothing tracks aggregate compile time, although per-test `compileMs` is
+already recorded in the JSONL (`tests/test262-shared.ts:782`).
+
+## Proposed approach
+
+Two cheap signals, both computed in the existing regression-gate job from
+data already present:
+
+1. **Count gate**: fail (or ESCALATE) when `pass→compile_timeout` count
+   exceeds a threshold calibrated above observed flake (start N=25; the
+   canary's flip data can calibrate — `test262-canary.yml` separates
+   non-determinism).
+2. **Aggregate-time gate**: sum `compileMs` over the shared
+   (baseline ∩ current, both-compiled) test set; fail when total rises >20%
+   vs the merge-base baseline. Immune to single-test flake; catches the
+   exponential-blowup case directly.
+3. Surface both numbers in the PR report comment + `.claude/ci-status` JSON
+   so dev self-merge sees them.
+
+## Acceptance criteria
+
+- A synthetic slow-compiler commit (sleep injected behind an env flag in a
+  test branch) trips the gate in a dry run.
+- Flake calibration documented (threshold vs canary flip rates).
+- Normal PRs unaffected (validate on 3 recent green PRs' artifacts).
+
+## Source
+
+Compiler quality review 2026-06. Related: #1897, #1668,
+`feedback_regression_analysis` (flake reclassification stays — this gates
+the aggregate, not the per-test noise).

--- a/plan/issues/1943-enforce-ratio-bucket-thresholds-ci.md
+++ b/plan/issues/1943-enforce-ratio-bucket-thresholds-ci.md
@@ -1,0 +1,62 @@
+---
+id: 1943
+title: "Enforce the documented regression thresholds (10% ratio, 50-per-bucket) in CI — today the hard gate is only net ≥ 0"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: easy
+reasoning_effort: low
+task_type: infrastructure
+area: testing
+language_feature: compiler-internals
+goal: correctness
+---
+# #1943 — Enforce ratio/bucket thresholds in CI
+
+## Problem
+
+The documented merge criteria (`.claude/skills/dev-self-merge.md:187-189`)
+are: `net_per_test > 0`, regression ratio < 10% of improvements, and no
+path-bucket > 50 regressions. But the **enforced** CI gate
+(`scripts/diff-test262.ts:336-340`) exits 1 only when
+`improvements − regressions_wasm_change < 0`:
+
+- A PR with 60 improvements and 55 unrelated real regressions **passes the
+  required check** (ratio 92%, far beyond the documented 10%).
+- The catastrophic guard fires only above 200 (`test262-sharded.yml`,
+  `CATASTROPHIC_REGRESSION_THRESHOLD: "200"`); the standalone tolerance is
+  ±15. A 150-test host regression that nets positive sails through.
+- The finer thresholds exist only as **agent-followed skill text**; the
+  auto-enqueue backstop (`scripts/enqueue-green-prs.mjs`) checks only
+  check-greenness. An agent that skips the skill merges on net ≥ 0 alone —
+  the documented quality bar depends on agent discipline, not branch
+  protection.
+
+## Proposed approach
+
+1. Move the two checks into `diff-test262.ts`'s exit logic (the data is
+   already computed there): fail when `R > 0 && R/improvements >= 0.10`, or
+   when any 5-level path bucket > 50 — same definitions as the skill
+   (`dev-self-merge.md:241` bucket logic already exists in the script's
+   report path).
+2. Keep flake reclassification (wasm_sha, compile_timeout) exactly as-is —
+   these gates consume the already-filtered counts.
+3. Update dev-self-merge.md to note CI now enforces; the skill's job
+   reduces to interpreting ESCALATE cases.
+4. Dry-run against the last ~20 merged PRs' artifacts to confirm no
+   historical green PR would have been blocked incorrectly (if any would:
+   examine — they were policy violations that merged).
+
+## Acceptance criteria
+
+- regression-gate job fails on a synthetic 10-improvement/5-regression diff
+  (ratio 50%) and on a 60-in-one-bucket diff (tests using fixture JSONLs).
+- Documented and enforced thresholds are byte-identical (single source:
+  constants exported from diff-test262.ts, referenced by the skill doc).
+
+## Source
+
+Compiler quality review 2026-06. Related: #1668, #1897, dev-self-merge
+skill, #1942.

--- a/plan/issues/1944-ci-cost-bundle-once-pnpm-cache.md
+++ b/plan/issues/1944-ci-cost-bundle-once-pnpm-cache.md
@@ -1,0 +1,58 @@
+---
+id: 1944
+title: "CI cost: build the compiler bundle once per run and cache pnpm — ~120-170 wasted runner-minutes per test262 run"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: maintainability
+---
+# #1944 — CI cost: bundle-once artifact + pnpm cache
+
+## Problem
+
+Every one of the **114 test262 shard jobs** (57 chunks × 2 targets,
+`test262-sharded.yml:294-365`) independently runs `actions/setup-node`
+(without `cache: pnpm`), `pnpm install --frozen-lockfile`, and a compiler
+bundle build (`test262-sharded.yml:417-421`). At ~60-90s of setup each,
+that's **~120-170 runner-minutes of pure overhead per run** — and the full
+matrix runs both at PR time and again in merge_group
+(`test262-sharded.yml:4`), roughly doubling it. The 8 equivalence shards
+(ci.yml:144-195) repeat the same pattern at smaller scale.
+
+## Proposed approach
+
+1. **Bundle once**: the cheap-gate job (already runs first,
+   `test262-sharded.yml:282-285`) builds the compiler bundle and uploads it
+   as an artifact; shard jobs download instead of building. (Bundle is
+   deterministic per commit — also enables cross-job byte-identity checks.)
+2. **pnpm store cache**: add `cache: pnpm` to `actions/setup-node` (or
+   `actions/cache` on the pnpm store keyed by lockfile hash) in all
+   workflows; measure — typical savings 30-60s/job.
+3. Evaluate (separate decision with the user/PO, not bundled in this PR):
+   PR-time = reduced smoke matrix (e.g. 8 representative shards), full
+   114-job matrix in merge_group only — the bot-refresh skip
+   (`test262-sharded.yml:479`) shows the conditional-matrix pattern already
+   exists. The merge queue remains the hard gate, so coverage at merge is
+   unchanged.
+4. Also: delete or revive the vestigial `.test262-cache` actions/cache step
+   (`test262-sharded.yml:396-414`) — the runner disabled result caching
+   ("stale cache entries caused false baselines", `test262-shared.ts:763`),
+   so 114 jobs save/restore mostly-dead state every run.
+
+## Acceptance criteria
+
+- Shard job setup time (pre-test) drops below ~30s p50 (compare run
+  timings before/after).
+- Bundle byte-identity asserted across ≥2 shards in one run.
+- Vestigial cache step removed or re-justified in a comment.
+
+## Source
+
+Compiler quality review 2026-06.

--- a/plan/issues/1945-test262-oracle-precision.md
+++ b/plan/issues/1945-test262-oracle-precision.md
@@ -1,0 +1,65 @@
+---
+id: 1945
+title: "Test262 oracle precision — runner discards expected error types and strips undefined-asserts, inflating the headline number"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: test
+area: testing
+language_feature: compiler-internals
+goal: conformance
+---
+# #1945 — Test262 oracle precision
+
+## Problem
+
+The test262 runner deliberately weakens its oracle in three ways
+(`tests/test262-runner.ts`), so the 71.6% headline is an upper bound and
+whole bug classes are structurally untestable:
+
+1. `assert.throws(ErrorType, fn)` is rewritten to `assert_throws(fn)` —
+   **the expected error type is discarded** (`test262-runner.ts:643-652`).
+   Throwing *any* error passes; wrong-error-type bugs (TypeError vs
+   RangeError) are invisible. (Parse/early-phase negatives DO check
+   `expectedErrorType` — runtime throws are the gap.)
+2. `assert.sameValue(x, undefined)` calls are **stripped entirely**
+   (`test262-runner.ts:835-923`, "stripped undefined assert").
+3. `throw new Error(...)` is regex-replaced with `return 0;`
+   (`test262-runner.ts:631-639`).
+
+These were pragmatic bootstrapping rewrites; the compiler has outgrown some
+of them (error classes, `undefined` returns, and exceptions all work today
+in many configurations).
+
+## Proposed approach
+
+Incremental, measured re-tightening — each step quantified on a full
+dashboard run before promotion (expect the pass count to DROP; that drop is
+honesty, not regression — coordinate messaging with the PO):
+
+1. `assert_throws` with constructor check where the expected type is a known
+   global error class (`TypeError`, `RangeError`, …): compare
+   `e instanceof X` host-side (js-host lane) or via the error-tag payload
+   (standalone). Land behind `TEST262_STRICT_THROWS=1`; flip default once
+   the delta is triaged into real bug buckets.
+2. Stop stripping `sameValue(x, undefined)` where the compiled module can
+   represent undefined returns (probe-classify, like other runner rewrites).
+3. Re-audit the `throw new Error → return 0` rewrite list — narrow to the
+   specific harness patterns that still need it.
+4. Track the deltas as new failure buckets so the PO can mint issues from
+   them (`/harvest-errors`).
+
+## Acceptance criteria
+
+- Strict-throws mode exists and a dashboard run quantifies the delta.
+- Runner rewrites are each gated/classified rather than unconditional.
+- A "oracle strictness" note on the dashboard explains the number's basis.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1853 (stability bucket), PO
+coordination required (headline number will move).

--- a/plan/issues/1946-closure-devirtualization-singleton-callees.md
+++ b/plan/issues/1946-closure-devirtualization-singleton-callees.md
@@ -1,0 +1,68 @@
+---
+id: 1946
+title: "Closure devirtualization — statically-known callees pay ~15-instruction dynamic dispatch that Binaryen cannot remove"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: closures
+goal: performance
+---
+# #1946 — Closure devirtualization for singleton callees
+
+## Problem
+
+A closure bound once to a known function is compiled as fully dynamic
+dispatch (verified by compiling and disassembling a probe during the
+2026-06 review):
+
+- `const inc = () => counter++` stores the closure as **externref**
+  (`extern.convert_any` at creation, `src/codegen/closures.ts:3673`).
+- Every call does `any.convert_extern` → `ref.test` → guarded `ref.cast` →
+  two null-check/throw blocks → `struct.get` funcref → second `ref.test` →
+  `call_ref`, plus writes to `__argc`/`__extras_argv` globals
+  (`src/codegen/expressions/calls-closures.ts:56-81, 132-152`) — **~15
+  instructions of dynamic dispatch to a callee that is a statically-known
+  arrow in the same function**.
+- **Binaryen -O3 provably cannot repair it**: the externref round-trip
+  launders the type, and the `__call_fn_*` exports pin escape — the
+  optimized binary still does per-iteration `ref.test` + `call_ref` +
+  throws.
+
+This poisons every callback-style API: `map`/`filter`/`forEach` lowering,
+scheduler-style code — the exact workloads where the honest benchmark suite
+shows JS winning.
+
+## Proposed approach
+
+1. **Singleton-callee analysis per binding**: a closure-typed binding whose
+   value set is one known function literal (single assignment, no
+   reassignment, not passed somewhere that loses identity) compiles calls
+   as direct `call $__closure_N_impl(env, args…)`.
+2. Keep the local typed `(ref $__closure_N_struct)` instead of externref for
+   closure values that don't cross a host/`any` boundary; box to externref
+   only at true escape points (depends on / overlaps #1947's boundary
+   discipline — this issue can land for the strictly-local case first).
+3. Mutable-capture refcells: when the cell is assigned `struct.new` in the
+   same scope and provably non-null, skip the per-access null-or-NaN branch
+   (`sample` probe showed null checks on a cell created two instructions
+   earlier).
+4. Measure on the callback-shaped benchmarks (`array/map`-style + the
+   react-scheduler bench), not the landing-page micros.
+
+## Acceptance criteria
+
+- Probe loop calling a same-function arrow shows direct `call` (no
+  `ref.test`) in WAT (pattern test).
+- Equivalence suite green incl. reassigned-closure and escaping-closure
+  cases (must keep dynamic path).
+- Benchmark delta reported on ≥2 callback-heavy workloads.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1947 (ref typing), #1948.

--- a/plan/issues/1947-end-to-end-gc-ref-typing.md
+++ b/plan/issues/1947-end-to-end-gc-ref-typing.md
@@ -1,0 +1,66 @@
+---
+id: 1947
+title: "End-to-end GC-ref typing — stop externref laundering inside the module; convert at the host boundary only"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: performance
+area: codegen
+language_feature: compiler-internals
+goal: performance
+---
+# #1947 — End-to-end GC-ref typing (externref at the boundary only)
+
+## Problem
+
+The WasmGC backend round-trips its own GC references through externref as a
+matter of course (`extern.convert_any` → externref local →
+`any.convert_extern` → `ref.test`/`ref.cast`), even for values that never
+cross the host boundary. Evidence from the 2026-06 review probes:
+
+- Closure values stored as externref locals (`closures.ts:3673`; see #1946).
+- 286 `ref.test` / 275 `any.convert_extern` sites backend-wide.
+- The pipeline even has a dedicated repair pass for the pattern:
+  `fixupExternConvertAny` runs last because earlier passes "can introduce
+  invalid coercions" (`src/codegen/index.ts:1573-1575`).
+- Consequence verified by -O3 disassembly: the type laundering blocks
+  Binaryen's GC passes (cast removal, devirtualization, const-field
+  propagation) — the strongest free optimizations available on WasmGC are
+  forfeited before emission.
+- Also discarded: `strictNullChecks` non-nullness — every typed param is
+  `(ref null $T)` with per-access null-check-throw blocks; a 6-line
+  function carried four.
+
+## Proposed approach
+
+Architect spec first (this is a representation decision):
+
+1. **Boundary discipline**: define where externref is *required* (host
+   imports/exports, `any`-typed storage, mixed-type containers) and keep
+   concrete `(ref $T)` / `(ref null $T)` local/param/field types everywhere
+   else. The IR encoding analysis (`ir/analysis/`, encoding classification
+   unboxed/boxed/ref) is the natural home for the decision; direct codegen
+   consumes it.
+2. **Non-null params**: under strictNullChecks, non-optional reference
+   params lower to `(ref $T)`; callers guarantee, callees drop the null
+   blocks. (Coordinate with #1852's per-backend value representation.)
+3. Ratchet `extern.convert_any` count on the playground corpus (the #1095
+   mechanics) — each removal is measurable.
+4. Re-measure Binaryen -O3 effect after: expect cast removal + devirt to
+   start firing (compare instruction counts on the review's probe corpus).
+
+## Acceptance criteria
+
+- Probe corpus shows GC refs staying typed across locals/calls within the
+  module; externref only at allowlisted boundary ops.
+- `fixupExternConvertAny` shrinks toward no-op on the corpus (counted).
+- Equivalence + test262 green; benchmark delta reported.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1946, #1852, #1916. Needs
+`/architect-spec`.

--- a/plan/issues/1948-shared-numeric-i32-lattice.md
+++ b/plan/issues/1948-shared-numeric-i32-lattice.md
@@ -1,0 +1,63 @@
+---
+id: 1948
+title: "Shared numeric lattice — replace three duplicated syntactic i32-safety matchers; stop i32↔f64 ping-pong"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: compiler-internals
+goal: performance
+---
+# #1948 — Shared numeric i32 lattice
+
+## Problem
+
+i32-ness is decided by at least three **duplicated syntactic pattern
+matchers**, each intentionally narrower than the next:
+
+- `isI32SafeExprForArray` "mirrors `isI32SafeExpr` in function-body.ts but
+  is intentionally narrower" (`src/codegen/array-element-typing.ts:30-31`).
+- `function-body.ts:387` (`isI32SafeExpr`) — loop-var promotion.
+- The linear-uint8 / string-builder / reduce-fusion passes each re-implement
+  their own capture/escape + integer-safety scans.
+
+Consequence, verified by -O3 disassembly during the 2026-06 review: one step
+off the recognized patterns falls to the generic f64 path — `pts[i - 1]`
+with a known-i32 `i` compiles as `f64.convert_i32_s` → `f64.sub 1` →
+`i32.trunc_sat_f64_s` and **survives Binaryen -O3** (value-range recovery
+needs semantics Binaryen doesn't have); `i < n` re-truncates the
+loop-invariant `n` every iteration. This pattern is endemic in numeric code
+— precisely the workloads a Wasm compiler should win.
+
+## Proposed approach
+
+1. One `numericFacts(node): { kind: i32|u32|f64, range?: [lo,hi] }` module —
+   a small forward lattice over expressions (literals, annotated vars,
+   loop-var promotion results, array lengths, index arithmetic ±k, bitwise
+   ops), consulted via the type facade (#1930) or directly pre-facade.
+2. Replace the three matchers with calls into it; their current behaviors
+   become test fixtures (no regression in what's already recognized).
+3. Extend index-expression lowering (`property-access.ts` element access)
+   to consume facts: `arr[i - 1]` with i32 `i` and known-nonnegative range
+   emits `i32.sub` directly.
+4. Loop-invariant comparisons: hoist the `i32.trunc`/convert of invariant
+   bounds out of the loop (cheap local-caching at emission; full LICM is
+   #1925's territory).
+5. Measure: the review probe (`pts[i-1]` loop) plus `benchmarks` numeric
+   suite.
+
+## Acceptance criteria
+
+- Probe shows pure-i32 index arithmetic in WAT (pattern test).
+- The two "mirror" matchers are deleted; one module, ≥3 consumers.
+- Equivalence + test262 green; numeric benchmark delta reported.
+
+## Source
+
+Compiler quality review 2026-06. Related: #1930 (TypeOracle), #1126
+(signedness), #1925.

--- a/plan/issues/1949-representative-perf-gate.md
+++ b/plan/issues/1949-representative-perf-gate.md
@@ -1,0 +1,58 @@
+---
+id: 1949
+title: "Representative perf gate — 4 overfitted micros at 50% tolerance gate nothing; the honest suite is ungated"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: performance
+---
+# #1949 — Representative, tighter perf gate
+
+## Problem
+
+- The gated benchmark set is the **4 landing-page micros**
+  (fib/loop/string/array, `playground-benchmark-sidebar.json`) at
+  `--max-relative-regression 0.50 --max-wasm-slowdown 0.40`
+  (`.github/workflows/benchmark-refresh.yml:84-86`) — a 49% slowdown
+  merges silently.
+- The set is overfitted: `array-reduce-fusion.ts:8` literally says "Targets
+  the 'array-sum' benchmark pattern"; `bench_loop` is exactly the peephole
+  #1197 shape. Optimization work is incentivized toward 4 shapes.
+- The **honest internal suite is ungated**: `benchmarks/results/latest.md`
+  shows string/split 4.9× slower than JS (gc-native), csv-parse 2.9×,
+  case-convert 115×; app-shaped benches (pako, react-scheduler,
+  threejs-math) exist but feed nothing.
+- On push to main the gate is informational-only and the auto-commit is
+  disabled, so the baseline can drift indefinitely.
+
+## Proposed approach
+
+1. Add to the gated set: pako, react-scheduler, threejs-math + 2-3
+   string-heavy workloads (split/csv-parse) from the existing internal
+   suite — they already run under `benchmarks/run.ts`; this is wiring, not
+   new benchmarks.
+2. Tighten thresholds to ~15% relative regression (calibrate against
+   run-to-run variance first — record 5 runs' spread, set threshold ≥3σ).
+3. Track gc-native and host-call strategies separately (their regressions
+   have different causes).
+4. Decide the baseline-refresh story for main (the #491 merge-queue
+   auto-commit problem): refresh via the same promote-on-push pattern
+   test262 uses (push to the baselines repo or a [skip ci] commit), so
+   drift is bounded.
+
+## Acceptance criteria
+
+- ≥8 gated workloads including ≥2 string-heavy and ≥2 app-shaped.
+- Threshold justified by measured variance in the PR description.
+- A synthetic 20% string-path regression trips the gate (dry run).
+
+## Source
+
+Compiler quality review 2026-06. Related: #1216, #1863, #1895.

--- a/plan/issues/1950-default-on-optimization-pipeline.md
+++ b/plan/issues/1950-default-on-optimization-pipeline.md
@@ -1,0 +1,60 @@
+---
+id: 1950
+title: "Default-on optimization — default builds ship unoptimized; add -O default where Binaryen is present plus tiny always-on cleanups"
+status: backlog
+sprint: Backlog
+created: 2026-06-10
+updated: 2026-06-10
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: performance
+area: compiler
+language_feature: n/a
+goal: performance
+---
+# #1950 — Default-on optimization pipeline
+
+## Problem
+
+- `optimize` defaults to **off** (`src/cli.ts:102`, `compiler.ts:447`), so
+  every consumer who doesn't pass `-O` — including the playground and most
+  doc examples — ships unoptimized output. The 2026-06 review's probe
+  showed Binaryen -O3 doing materially valuable, safe work the in-compiler
+  passes don't: inlining small functions, tracking `array.len` into locals,
+  null-check cleanup post-inline, and eliminating a dead
+  `f64.convert; drop` pair the peephole misses.
+- The always-on in-compiler tail has only 6 peephole patterns and no
+  constant folding; 3 of its 6 passes are fixups, not optimizations
+  (`src/codegen/index.ts:1559-1575`).
+
+## Proposed approach
+
+1. **Flip the default where Binaryen is available**: CLI and playground
+   paths run `optimize: 1` by default with `--no-optimize` opt-out; keep
+   `optimize: false` for the test-suite default (tests assert on raw
+   patterns) and for programmatic API (no surprise behavior change for
+   library users — document the recommendation instead). Decide exact
+   surface with the user/PO in the PR.
+2. Keep graceful degradation when neither npm binaryen nor system wasm-opt
+   exists (already handled, `optimize.ts:411-424`) — default-on must not
+   turn absence into failure, just a one-line note.
+3. Add two cheap always-on cleanups to the in-compiler tail (orthogonal to
+   Binaryen, helps the no-binaryen path): per-function const folding of
+   `f64.const/i32.const` arithmetic, and dead `convert/drop` pair removal
+   (the patterns the probe caught).
+4. **Hard dependency: #1941 must land first** — making `-O` the default
+   without differential coverage of optimized output widens the blast
+   radius of any wasm-opt miscompile.
+
+## Acceptance criteria
+
+- `js2 build foo.ts` output is wasm-opt-processed when binaryen is present;
+  `--no-optimize` restores current behavior.
+- Playground binary sizes/perf sidebar reflect the change (expect
+  improvement); benchmark gate green.
+- Blocked-by relationship to #1941 recorded and respected.
+
+## Source
+
+Compiler quality review 2026-06. Depends on #1941. Related: #1949.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -264,3 +264,61 @@ test262 doesn't cover: ESM, Web/WASI/Node/Deno APIs, Hono/React/Express):
 ### Fable-team findings (2026-06-10)
 
 - [#1915](../1915-gc-host-string-spread-empty-array.md) — gc JS-host mode: `[...str]` / `Array.from(str)` returns an empty array (externref-spread gap; pre-existing, verified independent of #1470's standalone fix) — medium, medium, **backlog**
+
+### Compiler quality & architecture review (2026-06-10)
+
+From [`docs/architecture/compiler-quality-review-2026-06.md`](../../../docs/architecture/compiler-quality-review-2026-06.md)
+(seven-subsystem graded review; every finding file:line-evidenced, two
+probe-verified). Grades: WasmGC codegen C−, IR B−, front-end C+, runtime B,
+linear+emit C+, test/CI B+, optimization C+ — overall **B−**. Already-tracked
+overlaps (#1098/#1172/#1095/#1530/#1850/#1852/#1854/#1855/#1858–#1860) were
+not re-filed; the issues below are net-new.
+
+**Fail-loud / correctness (children of #1858):**
+- [#1937](../1937-linear-backend-fail-loud-break-continue.md) — linear backend: `break`/`continue` never compiled (silent infinite loops); dispatchers need default-arm diagnostics — **critical**, easy, **backlog**
+- [#1941](../1941-differential-testing-optimize-output.md) — differential testing of `--optimize` output (wasm-opt miscompiles currently invisible; 3 reviewers converged) — **critical**, easy, **backlog**
+- [#1939](../1939-encodeinstr-default-throw-funcref-validation.md) — emit: `encodeInstr` silently drops unknown ops; default-throw + un-gate `validateFuncRefs` + round-trip test — high, easy, **backlog**
+- [#1921](../1921-structured-compile-failure-gate.md) — replace the `"Codegen error:"` string-prefix failure gate with structured severity — high, easy, **backlog**
+- [#1938](../1938-linear-number-array-i32-truncation-double-eval.md) — linear: `number[]` i32 truncation (`[1.5]`→`[1]`) + element-assignment RHS double-eval — high, medium, **backlog**
+- [#1918](../1918-stack-balance-strict-mode-fixup-ratchet.md) — stack-balance strict mode + fixup ratchet (lossy `drop; const 0` repairs mask emitter bugs) — high, medium, **backlog**
+- [#1940](../1940-wit-generator-silent-param-drop.md) — WIT generator silently drops unmappable params (arity mismatch) — medium, easy, **backlog**
+
+**Consolidation (divergent copies already shipping bugs):**
+- [#1922](../1922-shared-ir-traversal-while-loop-dce-defect.md) — shared IR traversal module; fixes probe-verified live defect (ordinary `while` loops demote off the IR path) — high, medium, **backlog**
+- [#1917](../1917-single-coercion-engine.md) — one coercion engine (4 matrices disagree: externref→f64 unboxes vs `f64.const 0` by context) — high, medium, **backlog**
+- [#1927](../1927-single-pipeline-driver.md) — one front-end pipeline driver (3 divergent clones; multi-file silently skips early errors/hardened/IR/JSX) — high, medium, **backlog**
+- [#1920](../1920-unify-instruction-walkers-peephole-catchall.md) — one instruction walker; peephole misses `catchAll` bodies (bug); NaN-const + tee fusion — medium, easy, **backlog**
+- [#1919](../1919-transactional-speculative-compile.md) — transactional speculative-compile API (23 probe/rollback sites leak locals/imports/types) — medium, medium, **backlog**
+- [#1934](../1934-decompose-resolveimport-domain-tables.md) — decompose `resolveImport` (5,000-line fn, 188 name checks) into domain tables; unify 3 ToPrimitive walkers; unbundle test262 shim — medium, hard, **backlog**
+- [#1931](../1931-decompose-detect-early-errors-treeshake.md) — decompose `detectEarlyErrors` (3,350-line fn), run on every path; wire or delete dead `treeshake` option — medium, medium, **backlog**
+
+**Gates that don't match documentation:**
+- [#1943](../1943-enforce-ratio-bucket-thresholds-ci.md) — enforce the documented 10%-ratio / 50-per-bucket thresholds in CI (today only net ≥ 0 is enforced) — high, easy, **backlog**
+- [#1942](../1942-compile-time-regression-gate.md) — compile-time regression gate (`pass→compile_timeout` excluded from every gate today) — high, easy, **backlog**
+- [#1923](../1923-meter-ir-post-claim-demotions.md) — meter IR post-claim demotions in the fallback ratchet (build/verify/lower failures invisible to CI) — high, easy, **backlog**
+- [#1945](../1945-test262-oracle-precision.md) — test262 oracle precision (expected error types discarded; undefined-asserts stripped; 71.6% is an upper bound) — medium, medium, **backlog**
+- [#1949](../1949-representative-perf-gate.md) — representative perf gate (4 overfitted micros at 50% tolerance; honest suite ungated) — medium, easy, **backlog**
+- [#1944](../1944-ci-cost-bundle-once-pnpm-cache.md) — CI cost: bundle-once artifact + pnpm cache (~120–170 wasted runner-min/run) — medium, medium, **backlog**
+
+**Type information & performance:**
+- [#1946](../1946-closure-devirtualization-singleton-callees.md) — closure devirtualization for singleton callees (~15-instr dynamic dispatch Binaryen provably can't remove) — high, medium, **backlog**
+- [#1948](../1948-shared-numeric-i32-lattice.md) — shared numeric i32 lattice (3 duplicated matchers; `i-1` f64 round-trip survives -O3) — high, medium, **backlog**
+- [#1947](../1947-end-to-end-gc-ref-typing.md) — end-to-end GC-ref typing; externref at host boundary only (unlocks Binaryen GC passes) — high, hard, **backlog**, needs `/architect-spec`
+- [#1924](../1924-ir-verifier-instruction-type-rules.md) — instruction-level type rules in the IR verifier (operands/branch-arg types/resultType unchecked; extends #1850) — high, medium, **backlog**
+- [#1950](../1950-default-on-optimization-pipeline.md) — default-on optimization (CLI/playground `-O` default; tiny always-on cleanups; **blocked by #1941**) — medium, easy, **backlog**
+
+**Diagnostics & API quality:**
+- [#1928](../1928-source-position-remapping-preparse-rewrites.md) — source-position remapping for pre-parse rewrites (diagnostics report wrong lines whenever a rewrite fires) — high, medium, **backlog**
+- [#1929](../1929-compileerror-file-flatten-chains.md) — `CompileError.file` + flattened TS diagnostic chains — medium, easy, **backlog**
+
+**Runtime hygiene:**
+- [#1932](../1932-version-env-abi.md) — version the env ABI (~200 names, no handshake; regex engine already shows the pattern) — high, easy, **backlog**
+- [#1933](../1933-runtime-multi-instance-isolation-leak.md) — multi-instance isolation (symbol/RegExp state bleed) + `_subclassCtors` instance-retention leak — high, medium, **backlog**
+- [#1935](../1935-retire-undefined-sentinel-protocol.md) — retire the undefined-as-sentinel protocol (`MISS` symbol; getters returning `undefined` misread as absent) — medium, medium, **backlog**
+
+**Strategic (architect-spec first):**
+- [#1916](../1916-symbolic-function-references-codegen.md) — symbolic function references in WasmGC codegen; retire the late-import index-shift machinery (≥7 regressions trace to it) — high, hard, **backlog**, needs `/architect-spec`
+- [#1930](../1930-typeoracle-type-query-boundary.md) — TypeOracle: one type-query boundary (~397 raw checker sites; unblocks TS7; kills suppression heuristics) — high, hard, **backlog**, needs `/architect-spec`
+- [#1936](../1936-async-contract-migration-enable-cps.md) — async contract migration: enable the built-but-disabled CPS lowering via call-site census + await-elision — high, hard, **backlog**, needs `/architect-spec`
+- [#1925](../1925-ir-hygiene-passes-nested-buffers.md) — run IR hygiene passes inside nested buffers, or commit to one control-flow representation (do before #1370/#1373 waves) — medium, hard, **backlog**
+- [#1926](../1926-remove-valtype-typeidx-from-irtype.md) — remove backend `ValType`/`typeIdx` from `IrType` (blocks IR serialization + linear union adoption) — medium, medium, **backlog**


### PR DESCRIPTION
## Summary

Full-codebase quality & architecture review (2026-06-10): seven parallel subsystem reviewers, every finding cited to file:line, two findings verified by live compile probes.

- **Report**: `docs/architecture/compiler-quality-review-2026-06.md` — grades per subsystem (WasmGC codegen C−, IR B−, front-end C+, runtime B, linear+emit C+, test/CI B+, optimization C+; overall **B−**), five cross-cutting themes, prioritized direction list.
- **35 net-new issues** `#1916–#1950` in `plan/issues/` (schema-compliant, `update-issues.mjs --check` green), deduplicated against the existing #1850–#1860 / #1095 / #1098 / #1172 / #1530 tracks.
- `plan/issues/backlog/backlog.md` indexes the new issues by theme.

Highlights worth immediate attention:
- **#1937 (critical)**: linear backend never compiles `break`/`continue` — silent infinite loops.
- **#1941 (critical)**: `--optimize` output is never behaviorally tested — wasm-opt miscompiles would ship invisibly.
- **#1922**: probe-verified live defect — ordinary `while` loops silently demote off the IR path (DCE never walks loop condition buffers).

Docs/plan-only change — no compiler source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)