### PR TITLE
fix(#1995,#1996): flat() default depth 1 + deep-unwrap nested wasm vecs in flat/flatMap

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4448,6 +4448,51 @@ function _toJsArray(arr: any, exports: Record<string, Function> | undefined): an
   return [arr]; // Fallback: wrap single value
 }
 
+/**
+ * (#1996) Recursion cap for `_toJsArrayDeep`. Generous enough for any
+ * realistic nesting while preventing unbounded recursion on a pathological
+ * input. Vec refs are acyclic, so this is a safety ceiling, not a semantic
+ * limit.
+ */
+const VEC_UNWRAP_MAX_DEPTH = 64;
+
+/**
+ * (#1996) Recursively materialize a WasmGC vec into a JS array, unwrapping
+ * any nested vec-ref elements into real JS arrays so native `Array.prototype`
+ * methods (`flat`, `flatMap`, `JSON.stringify`) recognize them via
+ * `Array.isArray`. Without this, `_toJsArray` converts only the outer vec and
+ * leaves inner elements as opaque WasmGC refs, which `flat()` cannot flatten
+ * and `JSON.stringify` renders as `null`.
+ *
+ * `maxDepth` bounds the recursion so already-flat scalar elements aren't probed
+ * past the depth the caller cares about (flat's depth argument). A non-vec
+ * value passes through unchanged.
+ */
+function _toJsArrayDeep(arr: any, exports: Record<string, Function> | undefined, maxDepth: number): any {
+  if (arr == null) return arr;
+  if (Array.isArray(arr)) {
+    if (maxDepth <= 0) return arr;
+    return arr.map((el) => _toJsArrayDeep(el, exports, maxDepth - 1));
+  }
+  // Only probe opaque WasmGC structs as candidate vecs — scalars (numbers,
+  // strings, booleans) and JS objects pass straight through.
+  if (maxDepth <= 0 || !_isWasmStruct(arr) || !exports) return arr;
+  const vecLen = exports.__vec_len;
+  const vecGet = exports.__vec_get;
+  if (typeof vecLen !== "function" || typeof vecGet !== "function") return arr;
+  try {
+    const len = vecLen(arr) as number;
+    if (typeof len !== "number" || len < 0) return arr;
+    const result: any[] = new Array(len);
+    for (let i = 0; i < len; i++) {
+      result[i] = _toJsArrayDeep(vecGet(arr, i), exports, maxDepth - 1);
+    }
+    return result;
+  } catch {
+    return arr; // Not a vec — pass through
+  }
+}
+
 /** Per-instance state shared across imports inside one `buildImports()`
  *  call. Currently used by the `web_storage` intent so localStorage /
  *  sessionStorage resolve to a stable per-instance polyfill in standalone
@@ -9421,15 +9466,23 @@ assert._isSameValue = isSameValue;
       if (name === "__array_flat")
         return (arr: any, depth: any) => {
           const exports = callbackState?.getExports();
-          const jsArr = _toJsArray(arr, exports);
-          return jsArr.flat(depth === undefined ? undefined : depth);
+          // (#1996) Deeply unwrap nested vec refs so native flat() can flatten
+          // them and JSON.stringify renders them as arrays, not null.
+          const jsArr = _toJsArrayDeep(arr, exports, VEC_UNWRAP_MAX_DEPTH) as any[];
+          // (#1995) An omitted depth arrives as JS null (ref.null.extern), not
+          // undefined. `null` would coerce to depth 0 via ToIntegerOrInfinity,
+          // so treat both null and undefined as "use the spec default of 1".
+          return depth == null ? jsArr.flat() : jsArr.flat(depth);
         };
       // Array.prototype.flatMap(callback, thisArg?) — map then flatten (#1136)
       if (name === "__array_flatMap")
         return (arr: any, fn: Function, thisArg: any) => {
           const exports = callbackState?.getExports();
           const jsArr = _toJsArray(arr, exports);
-          return thisArg !== undefined ? jsArr.flatMap(fn as any, thisArg) : jsArr.flatMap(fn as any);
+          // (#1996) The callback may return a WasmGC vec; unwrap its result so
+          // flatMap's single-level flatten recognizes it as an array.
+          const wrapped = (...args: any[]): any => _toJsArrayDeep((fn as any)(...args), exports, VEC_UNWRAP_MAX_DEPTH);
+          return thisArg !== undefined ? jsArr.flatMap(wrapped, thisArg) : jsArr.flatMap(wrapped);
         };
       // Callback bridges for functional array methods
       if (name === "__call_1_f64") return (fn: Function, a: number) => fn(a);

--- a/tests/issue-1995.test.ts
+++ b/tests/issue-1995.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+// #1995 — `arr.flat()` with no argument flattened depth 0 instead of the spec
+//   default of 1: the omitted depth was emitted as `ref.null.extern`, arriving
+//   in the host shim as JS `null`. The shim checked `depth === undefined`
+//   (false for null), so it called `jsArr.flat(null)` →
+//   ToIntegerOrInfinity(null) = 0 → a no-op copy. Fixed by treating both
+//   `null` and `undefined` as "use the default of 1".
+//
+// #1996 — `_toJsArray` materialized only the OUTER vec; nested elements stayed
+//   opaque WasmGC vec refs. `flat()`/`flatMap` couldn't recognize them
+//   (Array.isArray false) and JSON.stringify rendered them as `null`. Fixed by
+//   deeply unwrapping nested vec refs (and flatMap callback results) into real
+//   JS arrays before the native flatten runs.
+async function runStr(src: string): Promise<string> {
+  const exports = (await compileAndInstantiate(src)) as { f: () => string };
+  return exports.f();
+}
+
+describe("#1995 flat() omitted depth defaults to 1", () => {
+  it("flat() with no argument flattens one level (not zero)", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: any[] = [1, [2, 3], [4, [5]]];
+          return JSON.stringify(a.flat());
+        }
+      `),
+    ).toBe(JSON.stringify([1, [2, 3], [4, [5]]].flat()));
+  });
+
+  it("flat() ≡ flat(1)", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: any[] = [1, [2, 3], [4, [5]]];
+          return JSON.stringify(a.flat(1));
+        }
+      `),
+    ).toBe(JSON.stringify([1, [2, 3], [4, [5]]].flat(1)));
+  });
+
+  it("flat(0) stays a no-op copy", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: any[] = [1, [2, 3]];
+          return JSON.stringify(a.flat(0));
+        }
+      `),
+    ).toBe(JSON.stringify([1, [2, 3]].flat(0)));
+  });
+});
+
+describe("#1996 flat/flatMap unwrap nested WasmGC vecs", () => {
+  it("[[1,2],[3,4]].flat() yields the numbers, not [null,null]", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: number[][] = [[1, 2], [3, 4]];
+          return JSON.stringify(a.flat());
+        }
+      `),
+    ).toBe(
+      JSON.stringify(
+        (
+          [
+            [1, 2],
+            [3, 4],
+          ] as number[][]
+        ).flat(),
+      ),
+    );
+  });
+
+  it("flatMap unwraps callback-returned arrays", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: number[] = [1, 2, 3];
+          return JSON.stringify(a.flatMap((x: number) => [x, x * 2]));
+        }
+      `),
+    ).toBe(JSON.stringify([1, 2, 3].flatMap((x) => [x, x * 2])));
+  });
+
+  it("flat(2) on a 3-deep vec-of-vec flattens two levels", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: any[] = [1, [2, [3, [4]]]];
+          return JSON.stringify(a.flat(2));
+        }
+      `),
+    ).toBe(JSON.stringify([1, [2, [3, [4]]]].flat(2)));
+  });
+
+  it("flat(Infinity) fully flattens nested vecs", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: any[] = [1, [2, [3, [4, [5]]]]];
+          return JSON.stringify(a.flat(Infinity));
+        }
+      `),
+    ).toBe(JSON.stringify([1, [2, [3, [4, [5]]]]].flat(Infinity)));
+  });
+
+  it("flatMap returning nested arrays flattens exactly one level", async () => {
+    expect(
+      await runStr(`
+        export function f(): string {
+          const a: number[] = [1, 2];
+          return JSON.stringify(a.flatMap((x: number) => [[x]]));
+        }
+      `),
+    ).toBe(JSON.stringify([1, 2].flatMap((x) => [[x]])));
+  });
+});


### PR DESCRIPTION
## #1995 — `flat()` omitted depth flattened depth 0 instead of 1

`[1,[2,3],[4,[5]]].flat()` was a no-op copy (Node flattens one level). The
omitted depth is emitted as `ref.null.extern`, arriving in the `__array_flat`
host shim as JS `null`. The shim checked `depth === undefined` (false for
null), so it called `jsArr.flat(null)` → `ToIntegerOrInfinity(null) = 0` →
depth 0. Now both `null` and `undefined` map to the spec default of 1;
`flat(0)` still a no-op.

## #1996 — flat/flatMap left nested WasmGC vecs opaque → `[null,null]`

`([[1,2],[3,4]] as number[][]).flat()` returned `[null,null]` and
`[1,2,3].flatMap(x => [x, x*2])` returned `[null,null,null]`. `_toJsArray`
converted only the OUTER vec; inner elements (and callback-returned vecs)
stayed opaque WasmGC refs, so native `flat`/`flatMap` couldn't recognize them
(`Array.isArray` false) and `JSON.stringify` rendered them `null`.

Added `_toJsArrayDeep`, a depth-bounded recursive vec→array unwrapper (only
probes opaque WasmGC structs as candidate vecs; scalars/JS objects pass
through), and routed `__array_flat` and the `__array_flatMap` callback results
through it.

## Tests

`tests/issue-1995.test.ts` (8 cases, all matching Node): flat() default depth,
flat(0) no-op, flat(1)/flat(2)/flat(Infinity), vec-of-vec flatten, flatMap
callback-result unwrapping, flatMap single-level flatten. `tsc --noEmit` clean.

## Issue status

Issue files `plan/issues/1995-*.md` and `1996-*.md` are not yet on `main`
(they land via PR loopdive/js2#1315 / `spec-sweep-issues-1986-2035`), so this
PR can't flip their frontmatter. Both are **done** — please reconcile when the
sweep branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)