### PR TITLE
fix(#1999): route captured string += through ref cell, not bare local

### DIFF
--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -4568,8 +4568,14 @@ export function compileCompoundAssignment(
     return { kind: "f64" };
   }
 
-  // String += : concat instead of numeric add
-  if (op === ts.SyntaxKind.PlusEqualsToken) {
+  // String += : concat instead of numeric add.
+  // Skip when the binding is a boxed mutable capture (ref cell): the boxed
+  // path below (assignment.ts boxedCaptures branch) loads/stores through the
+  // ref-cell struct and has its own externref string-concat handling (#795).
+  // compileStringCompoundAssignment uses bare local.get/local.tee, which would
+  // pass the `(struct (mut externref))` ref cell straight into js-string concat
+  // (→ illegal cast / invalid wasm). #1999.
+  if (op === ts.SyntaxKind.PlusEqualsToken && !fctx.boxedCaptures?.has(name)) {
     const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
     let isStr = isStringType(leftTsType);
     if (!isStr && (leftTsType.flags & ts.TypeFlags.Any) !== 0) {
@@ -4692,9 +4698,13 @@ export function compileCompoundAssignment(
     if (boxed.valType.kind === "externref" && op === ts.SyntaxKind.PlusEqualsToken) {
       const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
       const rhsIsString = isStringType(rightTsType);
+      // A statically string-typed LHS (`let acc = ""` / `let acc: string`) must
+      // concat even when the RHS is numeric (`acc += x`) — JS coerces x to
+      // string. #1999.
+      const lhsIsString = isStringType(ctx.checker.getTypeAtLocation(expr.left));
       // Also check if the variable was assigned a string in any enclosing scope
       const varHasStringAssign = hasStringAssignment(name, expr) || hasStringAssignmentInParentScopes(name, expr);
-      if (rhsIsString || varHasStringAssign) {
+      if (rhsIsString || lhsIsString || varHasStringAssign) {
         // String concat path: current value (externref) is on stack
         addStringImports(ctx);
         const concatIdx = ctx.jsStringImports.get("concat");

--- a/tests/issue-1999.test.ts
+++ b/tests/issue-1999.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function run(source: string) {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile error: " + r.errors[0]?.message);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if ((instance.exports as any).__module_init) (instance.exports as any).__module_init();
+  return (instance.exports as any).test();
+}
+
+// #1999 — compileStringCompoundAssignment ignored boxedCaptures, so string `+=`
+// on a closure-captured variable passed the `(struct (mut externref))` ref cell
+// straight into js-string concat → "illegal cast" at runtime, or invalid wasm
+// (call expected externref, found ref-null) when an i32 index was concatenated.
+describe("#1999 string += on a closure-captured variable", () => {
+  it("numeric += inside an array HOF callback concatenates as string", async () => {
+    expect(
+      await run(`export function test(): string {
+        let acc = "";
+        [1, 2, 3].forEach((x: number) => { acc += x; });
+        return acc;
+      }`),
+    ).toBe("123");
+  });
+
+  it("the i32-index CE variant emits valid wasm and concatenates", async () => {
+    expect(
+      await run(`export function test(): string {
+        let s = "";
+        const a = [10, 20];
+        a.forEach((v: number, i: number) => { s += i + ":" + v; });
+        return s;
+      }`),
+    ).toBe("0:101:20");
+  });
+
+  it("string += inside a captured inner function appends", async () => {
+    expect(
+      await run(`export function test(): string {
+        let log = "x";
+        function inner(): void { log += "a"; }
+        inner();
+        return log;
+      }`),
+    ).toBe("xa");
+  });
+
+  it("string += in the outer scope after capture still appends", async () => {
+    expect(
+      await run(`export function test(): string {
+        let acc = "";
+        const f = (x: number): void => { acc += x; };
+        f(1);
+        acc += "Z";
+        f(2);
+        return acc;
+      }`),
+    ).toBe("1Z2");
+  });
+
+  it("captured string += inside an async function appends", async () => {
+    const src = `export async function test(): Promise<string> {
+      let log = "";
+      async function step(s: string): Promise<void> { log += s; }
+      await step("a");
+      await step("b");
+      return log;
+    }`;
+    const r = await compile(src, { fileName: "test.ts" });
+    if (!r.success) throw new Error("compile error: " + r.errors[0]?.message);
+    const imports = buildImports(r.imports, undefined, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, imports);
+    expect(await (instance.exports as any).test()).toBe("ab");
+  });
+
+  // Controls — these worked before the fix and must keep working.
+  it("control: acc = acc + x inside the same closure", async () => {
+    expect(
+      await run(`export function test(): string {
+        let acc = "";
+        [1, 2, 3].forEach((x: number) => { acc = acc + x; });
+        return acc;
+      }`),
+    ).toBe("123");
+  });
+
+  it("control: numeric captured += is unchanged", async () => {
+    expect(
+      await run(`export function test(): number {
+        let n = 0;
+        [1, 2, 3].forEach((x: number) => { n += x; });
+        return n;
+      }`),
+    ).toBe(6);
+  });
+
+  it("control: uncaptured string += is unchanged", async () => {
+    expect(
+      await run(`export function test(): string {
+        let acc = "";
+        acc += "a";
+        acc += "b";
+        return acc;
+      }`),
+    ).toBe("ab");
+  });
+});


### PR DESCRIPTION
## #1999 — string `+=` on a closure-captured variable traps "illegal cast" / emits invalid wasm

`compileCompoundAssignment` routed string `+=` to
`compileStringCompoundAssignment` **before** the `boxedCaptures` check, and
that function loads/stores the variable with bare `local.get`/`local.tee`.
For a closure-captured string the local holds a `(struct (mut externref))`
ref cell, so the cell itself flowed straight into js-string `concat`:

- `let acc=""; [1,2,3].forEach((x:number)=>{acc+=x;})` → `RuntimeError: illegal cast`
- `s += i + ":" + v` (i32 index) → invalid wasm (`call[0] expected externref, found local.get of (ref null N)`)

### Fix

`src/codegen/expressions/assignment.ts` — skip the string-compound branch
when the binding is a boxed capture (`fctx.boxedCaptures.has(name)`), so it
falls through to the existing boxed externref path, which reads/writes
through the ref cell (`struct.get`/`struct.set`) and already handles string
concat (#795). Also detect a statically string-typed LHS in that path so
`acc += x` with a numeric RHS concatenates instead of doing `f64.add`.

### Verification

`tests/issue-1999.test.ts` (8 cases, all green) covers both repro shapes
plus captured inner-fn, async log-append, and outer-scope `+=` after
capture — all match Node. Controls (`acc = acc + x`, numeric captured `+=`,
uncaptured string `+=`) are unchanged. Related compound-assignment/closure
suites show no new failures (the 7 `__get_caught_exception` LinkErrors in
`illegal-cast-closures-585` etc. pre-exist on clean main — a test-harness
stub gap, not a regression).

### Issue status

The issue file `plan/issues/1999-*.md` is not yet on `main` (it lands via
the spec-sweep PR loopdive/js2#1315), so this PR does not flip its
frontmatter. Lead reconciles `status: done` when that file merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)