### PR TITLE
fix(#1937): linear backend never compiled break/continue (silent infinite loops); fail-loud dispatchers

### DIFF
--- a/plan/issues/1937-linear-backend-fail-loud-break-continue.md
+++ b/plan/issues/1937-linear-backend-fail-loud-break-continue.md
@@ -114,3 +114,55 @@ table-driven fail-loud sweep) and `tests/linear-controlflow.test.ts`
 ## Source
 
 Compiler quality review 2026-06. Direct child of #1858; extends #1868/#1838.
+
+## Implementation Notes (2026-06-11)
+
+All changes in `src/codegen-linear/index.ts`; tests in
+`tests/linear-controlflow.test.ts`.
+
+**Depth bookkeeping convention** (now used consistently): `breakStack`/
+`continueStack` store *(interior depth − 1)* of the target label; a `br`
+at nesting `fctx.blockDepth` uses `depth = blockDepth − stored − 1`. Every
+construct that adds a Wasm label (`if` arms, the new inner blocks, the
+switch wrapper) increments `blockDepth` around the statements it compiles —
+the switch lowering previously did **not**, which would have made any
+implementation of break inside a case body mis-target.
+
+1. **break/continue implemented.** `while` continue targets the loop head
+   (re-tests the condition — already correct). `for`, array `for-of`, and
+   `do-while` got an **inner block** around the body so `continue` falls
+   out into the incrementor / condition instead of skipping it (a br to
+   the loop head would have spun on a stale induction variable). Map
+   `for-of` uses the `if (hash != 0)` then-arm itself as the continue
+   target (exiting the if reaches the index increment). Labeled
+   break/continue → hard error.
+2. **Switch.** Whole lowering wrapped in a `block` that is the `break`
+   target (pushed on `breakStack` only — `continue` passes through to the
+   enclosing loop). Fall-through from a *non-empty* case body (and from a
+   mid-list default) is a hard located error until a br_table lowering
+   exists; empty-body case grouping still works. `statementTerminates`
+   recursion keeps `if/else`-both-return bodies legal.
+3. **Fail-loud default arms** in `compileStatement` (with a no-op allow
+   list: empty/type-alias/interface/debugger) and `compileExpression`
+   (placeholder `f64.const 0` keeps stack arity sane; the #1868 gate fails
+   the compile). Also: non-identifier/non-property call targets error, and
+   the binary-operator default arm now drops both operands before its
+   placeholder. `as`/`satisfies`/`<T>x` casts pass through to the inner
+   expression.
+4. **`%` was an empty switch arm** — `a % b` compiled both operands and no
+   operator: the result was just `b` and the leftover `a` corrupted stack
+   arity (found because the new break/continue tests used `i % 2`).
+   Implemented as `a − trunc(a/b)·b` via temp locals (JS sign-of-dividend
+   semantics; known divergence: `b = ±Infinity` → NaN instead of `a`).
+5. **`throw`** → hard located error instead of a silent `unreachable` trap
+   (mirrors the #1838 try/catch decision; Wasm-EH lowering is the real fix).
+6. **NaN truthiness**: `f64` ToBoolean is now `abs(x) > 0` (covers 0, −0,
+   NaN) instead of `x != 0` (NaN was truthy).
+7. **Diagnostics carry real positions** via a local `nodeLoc()` helper
+   (1-based, mirrors the GC backend); threaded into all new arms and the
+   five pre-existing `line: 0, column: 0` sites.
+
+Validation: 138/138 tests across all 20 linear-consumer suites.
+`tests/ir-backend-decoupling.test.ts` + `tests/linker-self-host.test.ts`
+fail identically on the unmodified merge base (`env.__box_number`
+LinkError — pre-existing, unrelated to codegen-linear).

--- a/plan/issues/1937-linear-backend-fail-loud-break-continue.md
+++ b/plan/issues/1937-linear-backend-fail-loud-break-continue.md
@@ -96,8 +96,17 @@ non-terminating non-empty body is a **hard error** rather than a silent skip.
 
 **NaN truthiness (`emitTruthyCoercion`).** `f64.ne 0` alone made `if (NaN)`
 truthy. Per §7.1.2 ToBoolean a Number is false for +0/-0/NaN, so truthiness is
-`(x != 0) & (x == x)` — the self-equality test is false exactly for NaN. Value
-is tee'd into a scratch local to avoid re-evaluating the operand.
+`f64.abs(x) > 0` — abs folds -0 to 0 and `NaN > 0` is false, covering all
+three falsy values with no scratch local or operand re-evaluation.
+
+**`%` operator (`compileBinaryExpression`).** The `PercentToken` switch arm
+was EMPTY: `a % b` compiled both operands and no operator — the expression's
+"result" was just `b` and the leftover `a` corrupted stack arity (found via
+the new break/continue tests using `i % 2`). Wasm has no `f64.rem`; lowered
+as `a - trunc(a/b) * b` via temp locals (JS sign-of-dividend semantics; known
+divergence: `b = ±Infinity` yields NaN instead of `a`). The binary-operator
+default arm now also drops both operands and pushes a placeholder alongside
+its located diagnostic, so unknown operators fail loud with balanced arity.
 
 **fail-loud default arms.** Both `compileStatement` and `compileExpression`
 gained `else` arms that push a located `ctx.errors` entry (the #1868 success
@@ -114,55 +123,3 @@ table-driven fail-loud sweep) and `tests/linear-controlflow.test.ts`
 ## Source
 
 Compiler quality review 2026-06. Direct child of #1858; extends #1868/#1838.
-
-## Implementation Notes (2026-06-11)
-
-All changes in `src/codegen-linear/index.ts`; tests in
-`tests/linear-controlflow.test.ts`.
-
-**Depth bookkeeping convention** (now used consistently): `breakStack`/
-`continueStack` store *(interior depth − 1)* of the target label; a `br`
-at nesting `fctx.blockDepth` uses `depth = blockDepth − stored − 1`. Every
-construct that adds a Wasm label (`if` arms, the new inner blocks, the
-switch wrapper) increments `blockDepth` around the statements it compiles —
-the switch lowering previously did **not**, which would have made any
-implementation of break inside a case body mis-target.
-
-1. **break/continue implemented.** `while` continue targets the loop head
-   (re-tests the condition — already correct). `for`, array `for-of`, and
-   `do-while` got an **inner block** around the body so `continue` falls
-   out into the incrementor / condition instead of skipping it (a br to
-   the loop head would have spun on a stale induction variable). Map
-   `for-of` uses the `if (hash != 0)` then-arm itself as the continue
-   target (exiting the if reaches the index increment). Labeled
-   break/continue → hard error.
-2. **Switch.** Whole lowering wrapped in a `block` that is the `break`
-   target (pushed on `breakStack` only — `continue` passes through to the
-   enclosing loop). Fall-through from a *non-empty* case body (and from a
-   mid-list default) is a hard located error until a br_table lowering
-   exists; empty-body case grouping still works. `statementTerminates`
-   recursion keeps `if/else`-both-return bodies legal.
-3. **Fail-loud default arms** in `compileStatement` (with a no-op allow
-   list: empty/type-alias/interface/debugger) and `compileExpression`
-   (placeholder `f64.const 0` keeps stack arity sane; the #1868 gate fails
-   the compile). Also: non-identifier/non-property call targets error, and
-   the binary-operator default arm now drops both operands before its
-   placeholder. `as`/`satisfies`/`<T>x` casts pass through to the inner
-   expression.
-4. **`%` was an empty switch arm** — `a % b` compiled both operands and no
-   operator: the result was just `b` and the leftover `a` corrupted stack
-   arity (found because the new break/continue tests used `i % 2`).
-   Implemented as `a − trunc(a/b)·b` via temp locals (JS sign-of-dividend
-   semantics; known divergence: `b = ±Infinity` → NaN instead of `a`).
-5. **`throw`** → hard located error instead of a silent `unreachable` trap
-   (mirrors the #1838 try/catch decision; Wasm-EH lowering is the real fix).
-6. **NaN truthiness**: `f64` ToBoolean is now `abs(x) > 0` (covers 0, −0,
-   NaN) instead of `x != 0` (NaN was truthy).
-7. **Diagnostics carry real positions** via a local `nodeLoc()` helper
-   (1-based, mirrors the GC backend); threaded into all new arms and the
-   five pre-existing `line: 0, column: 0` sites.
-
-Validation: 138/138 tests across all 20 linear-consumer suites.
-`tests/ir-backend-decoupling.test.ts` + `tests/linker-self-host.test.ts`
-fail identically on the unmodified merge base (`env.__box_number`
-LinkError — pre-existing, unrelated to codegen-linear).

--- a/plan/issues/1937-linear-backend-fail-loud-break-continue.md
+++ b/plan/issues/1937-linear-backend-fail-loud-break-continue.md
@@ -1,10 +1,11 @@
 ---
 id: 1937
 title: "Linear backend: break/continue are never compiled (silent infinite loops); dispatchers need default-arm diagnostics"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: critical
 feasibility: easy
 reasoning_effort: medium
@@ -62,6 +63,53 @@ don't handle, because neither has a default arm:
 - Every unsupported construct yields `success: false` with a located message
   (table-driven test over a list of unsupported snippets).
 - `if (NaN)` takes the else branch (test).
+
+## Implementation notes (resolved 2026-06-11)
+
+All in `src/codegen-linear/index.ts`.
+
+**break/continue (`compileBreakContinue` / statement dispatcher).** The depth
+stacks already existed but were never read. Each loop lowering pushes the
+target label's *interior block depth* onto `breakStack` / `continueStack`; a
+`break`/`continue` then emits `br (fctx.blockDepth - target - 1)`. Every
+`if`/`block`/`loop`/case-arm increments `fctx.blockDepth` around the
+statements it compiles, so the relative `br` depth stays correct no matter how
+deeply the statement is nested.
+
+**continue must run the loop's "tail" (incrementor / condition re-test).** A
+naive `continue → br loop-head` skips the for-incrementor (infinite loop on the
+continued iteration) and the do-while condition re-test. Fix: the loop body is
+compiled into an **inner `block`**, so `continue` is `br` out of that inner
+block — control then falls through to the incrementor/condition that sits
+*after* the inner block but *inside* the loop. Loop nesting is therefore
+`block(+1) loop(+2) inner(+3)`; for-of-Map reuses the existing
+`if (hash != 0)` then-arm as the continue target (exiting it falls through to
+the index bump). Verified: `for(...){if(x)continue;}` and
+`do{if(x)continue;}while(...)` terminate and advance correctly.
+
+**switch.** Wrapped the whole cascade-of-`if`s in one `block` that is the
+`break` target (pushed onto `breakStack` only — `continue` passes straight
+through to the enclosing loop). C-style fall-through out of a *non-empty* case
+body cannot be expressed by this cascade (the next case re-tests its condition
+instead of running), so `statementTerminates` checks the last statement and a
+non-terminating non-empty body is a **hard error** rather than a silent skip.
+
+**NaN truthiness (`emitTruthyCoercion`).** `f64.ne 0` alone made `if (NaN)`
+truthy. Per §7.1.2 ToBoolean a Number is false for +0/-0/NaN, so truthiness is
+`(x != 0) & (x == x)` — the self-equality test is false exactly for NaN. Value
+is tee'd into a scratch local to avoid re-evaluating the operand.
+
+**fail-loud default arms.** Both `compileStatement` and `compileExpression`
+gained `else` arms that push a located `ctx.errors` entry (the #1868 success
+gate then bails with `success:false`). `throw` and labeled break/continue get
+named diagnostics instead of a silent `unreachable`/mis-target. Positions come
+from `nodeLoc(node)` (`getLineAndCharacterOfPosition`). Type-only statements
+(`type`/`interface`/`debugger`/`;`) and type-only expressions
+(`as`/`satisfies`/`<T>x`) are erased without a diagnostic.
+
+Tests: `tests/linear-break-continue.test.ts` (new — Map/array for-of + a
+table-driven fail-loud sweep) and `tests/linear-controlflow.test.ts`
+(extended). No regressions across the existing linear suites.
 
 ## Source
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -34,6 +34,24 @@ function isNumberArrayOrUint8ArrayUnionText(text: string): boolean {
 }
 
 /**
+ * Extract a 1-based {line, column} from an AST node for diagnostics (#1937).
+ * Mirrors the GC backend's extractLocation (src/codegen/context/errors.ts);
+ * falls back to {0,0} for synthetic nodes without a source file.
+ */
+function nodeLoc(node: ts.Node): { line: number; column: number } {
+  try {
+    const sf = node.getSourceFile();
+    if (sf) {
+      const { line, character } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+      return { line: line + 1, column: character + 1 };
+    }
+  } catch {
+    // fall through to {0,0}
+  }
+  return { line: 0, column: 0 };
+}
+
+/**
  * Options for the linear-memory backend (#1856).
  */
 export interface LinearOptions {
@@ -647,17 +665,25 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
       fctx.body.push({ op: "br_if", depth: 1 }); // break to outer block
     }
 
-    // Push break/continue stack
-    fctx.breakStack.push(fctx.blockDepth);
-    fctx.continueStack.push(fctx.blockDepth + 1);
-    fctx.blockDepth += 2;
+    // Body goes in an inner block so `continue` falls out of it and still
+    // runs the incrementor (a br straight to the loop head would skip it
+    // and re-test the condition with a stale induction variable, #1937).
+    // Nesting inside the body: block(+1) loop(+2) inner-block(+3); the
+    // stacks store (interior depth - 1) of the target label.
+    const innerBody: Instr[] = [];
+    fctx.body = innerBody;
+    fctx.breakStack.push(fctx.blockDepth); // outer block
+    fctx.continueStack.push(fctx.blockDepth + 2); // inner block
+    fctx.blockDepth += 3;
 
-    // Body
     compileStatement(ctx, fctx, stmt.statement);
 
-    fctx.blockDepth -= 2;
+    fctx.blockDepth -= 3;
     fctx.breakStack.pop();
     fctx.continueStack.pop();
+
+    fctx.body = loopBody;
+    fctx.body.push({ op: "block", blockType: { kind: "empty" }, body: innerBody });
 
     // Incrementor
     if (stmt.incrementor) {
@@ -725,9 +751,61 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
     if (!isVoidExpression(ctx, stmt.expression)) {
       fctx.body.push({ op: "drop" });
     }
+  } else if (ts.isBreakStatement(stmt) || ts.isContinueStatement(stmt)) {
+    // #1937 — break/continue were previously never compiled: the dispatcher
+    // had no arm for them, so `while (true) { if (x) break; }` silently
+    // became an infinite loop. The loop lowerings maintain breakStack/
+    // continueStack as (interior block depth - 1) of the target label, so
+    // the relative br depth from the current nesting is
+    // `blockDepth - target - 1` (every if/block/loop arm increments
+    // fctx.blockDepth around the statements it compiles into).
+    const isBreak = ts.isBreakStatement(stmt);
+    const kw = isBreak ? "break" : "continue";
+    if (stmt.label) {
+      ctx.errors.push({
+        message: `Unsupported in linear backend: labeled ${kw} ('${stmt.label.text}')`,
+        ...nodeLoc(stmt),
+      });
+    } else {
+      const stack = isBreak ? fctx.breakStack : fctx.continueStack;
+      if (stack.length === 0) {
+        ctx.errors.push({
+          message: `'${kw}' outside of ${isBreak ? "a loop or switch" : "a loop"}`,
+          ...nodeLoc(stmt),
+        });
+      } else {
+        fctx.body.push({ op: "br", depth: fctx.blockDepth - stack[stack.length - 1]! - 1 });
+      }
+    }
   } else if (ts.isThrowStatement(stmt)) {
-    // throw → unreachable (wasm trap)
-    fctx.body.push({ op: "unreachable" });
+    // #1937 — `throw` used to lower to a bare `unreachable`, silently
+    // replacing exception semantics with a trap (no catch can ever see it,
+    // and the exit status differs from JS). Until a Wasm-EH lowering lands
+    // (the emitter supports try/catch, see #1838), refuse loudly like
+    // try/catch does rather than miscompile.
+    ctx.errors.push({
+      message:
+        "Unsupported in linear backend: 'throw' (would silently become a trap; " +
+        "Wasm-EH lowering is the planned fix, see #1838/#1937)",
+      ...nodeLoc(stmt),
+    });
+    fctx.body.push({ op: "unreachable" }); // keep downstream stack analysis sane
+  } else if (
+    ts.isEmptyStatement(stmt) ||
+    ts.isTypeAliasDeclaration(stmt) ||
+    ts.isInterfaceDeclaration(stmt) ||
+    ts.isDebuggerStatement(stmt)
+  ) {
+    // Type-only / no-op statements: nothing to emit.
+  } else {
+    // #1937 — fail-loud default arm: any statement kind without an explicit
+    // arm above used to fall through silently, emitting zero instructions
+    // and diverging from JS with no diagnostic. The #1868 gate in
+    // compiler.ts turns these errors into success:false.
+    ctx.errors.push({
+      message: `Unsupported statement in linear backend: ${ts.SyntaxKind[stmt.kind]}`,
+      ...nodeLoc(stmt),
+    });
   }
 }
 
@@ -872,17 +950,23 @@ function compileForOfStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt
     fctx.body.push({ op: "local.set", index: loopVarIdx });
   }
 
-  // Push break/continue stack
-  fctx.breakStack.push(fctx.blockDepth);
-  fctx.continueStack.push(fctx.blockDepth + 1);
-  fctx.blockDepth += 2;
+  // Body goes in an inner block so `continue` falls out of it and still
+  // increments the index (#1937). Nesting: block(+1) loop(+2) inner(+3).
+  const innerBody: Instr[] = [];
+  fctx.body = innerBody;
+  fctx.breakStack.push(fctx.blockDepth); // outer block
+  fctx.continueStack.push(fctx.blockDepth + 2); // inner block
+  fctx.blockDepth += 3;
 
   // Compile body
   compileStatement(ctx, fctx, stmt.statement);
 
-  fctx.blockDepth -= 2;
+  fctx.blockDepth -= 3;
   fctx.breakStack.pop();
   fctx.continueStack.pop();
+
+  fctx.body = loopBody;
+  fctx.body.push({ op: "block", blockType: { kind: "empty" }, body: innerBody });
 
   // Increment index
   fctx.body.push({ op: "local.get", index: idxLocal });
@@ -1034,16 +1118,18 @@ function compileForOfMap(
     fctx.body.push({ op: "local.set", index: valVarIdx });
   }
 
-  // Push break/continue stack
-  // Note: We're inside the if block, so block depth is higher
-  fctx.breakStack.push(fctx.blockDepth);
-  fctx.continueStack.push(fctx.blockDepth + 1);
-  fctx.blockDepth += 2; // +2 for block/loop that wraps us
+  // The body lives inside the `if (hash != 0)` then-arm, which is its own
+  // label: nesting is block(+1) loop(+2) if-then(+3). `continue` targets the
+  // if-then label itself — exiting the if falls through to the index
+  // increment below, which is exactly JS continue semantics (#1937).
+  fctx.breakStack.push(fctx.blockDepth); // outer block
+  fctx.continueStack.push(fctx.blockDepth + 2); // if-then arm
+  fctx.blockDepth += 3;
 
   // Compile body
   compileStatement(ctx, fctx, stmt.statement);
 
-  fctx.blockDepth -= 2;
+  fctx.blockDepth -= 3;
   fctx.breakStack.pop();
   fctx.continueStack.pop();
 
@@ -1085,17 +1171,25 @@ function compileDoWhileStatement(ctx: LinearContext, fctx: LinearFuncContext, st
   const savedBody = fctx.body;
   fctx.body = loopBody;
 
-  // Push break/continue stack
-  fctx.breakStack.push(fctx.blockDepth);
-  fctx.continueStack.push(fctx.blockDepth + 1);
-  fctx.blockDepth += 2;
+  // Body goes in an inner block so `continue` falls out of it into the
+  // condition check (a br straight to the loop head would re-run the body
+  // without testing the condition, #1937). Nesting: block(+1) loop(+2)
+  // inner-block(+3); the stacks store (interior depth - 1) of the target.
+  const innerBody: Instr[] = [];
+  fctx.body = innerBody;
+  fctx.breakStack.push(fctx.blockDepth); // outer block
+  fctx.continueStack.push(fctx.blockDepth + 2); // inner block
+  fctx.blockDepth += 3;
 
   // Compile body first (do-while executes body before checking condition)
   compileStatement(ctx, fctx, stmt.statement);
 
-  fctx.blockDepth -= 2;
+  fctx.blockDepth -= 3;
   fctx.breakStack.pop();
   fctx.continueStack.pop();
+
+  fctx.body = loopBody;
+  fctx.body.push({ op: "block", blockType: { kind: "empty" }, body: innerBody });
 
   // Compile condition
   compileExpression(ctx, fctx, stmt.expression);
@@ -1119,14 +1213,42 @@ function compileDoWhileStatement(ctx: LinearContext, fctx: LinearFuncContext, st
 
 // ── SwitchStatement ────────────────────────────────────────────────────
 
+/**
+ * Is `s` guaranteed to transfer control (so execution cannot fall off its
+ * end into the next switch case)? Conservative recursive check used by the
+ * switch fall-through guard (#1937).
+ */
+function statementTerminates(s: ts.Statement): boolean {
+  if (ts.isReturnStatement(s) || ts.isBreakStatement(s) || ts.isContinueStatement(s) || ts.isThrowStatement(s)) {
+    return true;
+  }
+  if (ts.isBlock(s)) {
+    return s.statements.length > 0 && statementTerminates(s.statements[s.statements.length - 1]!);
+  }
+  if (ts.isIfStatement(s)) {
+    return !!s.elseStatement && statementTerminates(s.thenStatement) && statementTerminates(s.elseStatement);
+  }
+  return false;
+}
+
 function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.SwitchStatement): void {
-  // Compile as cascading if/else with fall-through support.
-  // Group consecutive case clauses with empty bodies (fall-through)
-  // into a single OR'd condition.
+  // Compile as cascading if/else, all wrapped in one block that serves as
+  // the `break` target (#1937). Consecutive case clauses with empty bodies
+  // (fall-through) are grouped into a single OR'd condition; fall-through
+  // out of a NON-empty case body cannot be expressed in this lowering and
+  // is rejected with a hard error below (it used to be silently dropped).
   compileExpression(ctx, fctx, stmt.expression);
   const switchExprType = inferExprType(ctx, fctx, stmt.expression);
   const switchLocal = addLocal(fctx, `__switch_${fctx.locals.length}`, switchExprType);
   fctx.body.push({ op: "local.set", index: switchLocal });
+
+  // Everything below goes inside the break-target block. The stacks store
+  // (interior depth - 1) of the target label, so push the pre-entry depth.
+  const switchBody: Instr[] = [];
+  const outerBody = fctx.body;
+  fctx.body = switchBody;
+  fctx.breakStack.push(fctx.blockDepth); // switch block (continue passes through to the enclosing loop)
+  fctx.blockDepth += 1;
 
   let defaultClause: ts.CaseOrDefaultClause | null = null;
 
@@ -1147,6 +1269,21 @@ function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stm
   while (i < clauseArr.length) {
     const clause = clauseArr[i]!;
     if (ts.isDefaultClause(clause)) {
+      // A mid-list default with a non-terminated body would fall through
+      // into the next case in JS; this lowering hoists default to the end,
+      // so reject rather than silently diverge (#1937).
+      if (
+        i < clauseArr.length - 1 &&
+        clause.statements.length > 0 &&
+        !statementTerminates(clause.statements[clause.statements.length - 1]!)
+      ) {
+        ctx.errors.push({
+          message:
+            "Unsupported in linear backend: switch default-clause fall-through into a following case " +
+            "(end the default body with break/return)",
+          ...nodeLoc(clause),
+        });
+      }
       defaultClause = clause;
       i++;
       continue;
@@ -1180,10 +1317,28 @@ function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stm
       }
     }
 
-    // Then body
+    // Fall-through out of a non-empty case body is silently dropped by the
+    // cascading-if lowering (the next case's condition re-tests instead of
+    // running its body) — hard error until a real br_table lowering lands
+    // (#1937). The last clause has nothing to fall into, so it is exempt.
+    if (
+      i < clauseArr.length - 1 &&
+      bodyClause.statements.length > 0 &&
+      !statementTerminates(bodyClause.statements[bodyClause.statements.length - 1]!)
+    ) {
+      ctx.errors.push({
+        message:
+          "Unsupported in linear backend: switch case fall-through from a non-empty case body " +
+          "(end the case with break/return)",
+        ...nodeLoc(bodyClause),
+      });
+    }
+
+    // Then body (an `if` arm is its own br label, so track the depth)
     const thenBody: Instr[] = [];
     const savedBody = fctx.body;
     fctx.body = thenBody;
+    fctx.blockDepth += 1;
     if (matchedLocal !== undefined) {
       fctx.body.push({ op: "i32.const", value: 1 });
       fctx.body.push({ op: "local.set", index: matchedLocal });
@@ -1191,6 +1346,7 @@ function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stm
     for (const s of bodyClause.statements) {
       compileStatement(ctx, fctx, s);
     }
+    fctx.blockDepth -= 1;
     fctx.body = savedBody;
 
     fctx.body.push({
@@ -1210,9 +1366,11 @@ function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stm
       const defaultBody: Instr[] = [];
       const savedBody = fctx.body;
       fctx.body = defaultBody;
+      fctx.blockDepth += 1; // inside the `if` arm
       for (const s of defaultClause.statements) {
         compileStatement(ctx, fctx, s);
       }
+      fctx.blockDepth -= 1;
       fctx.body = savedBody;
       fctx.body.push({
         op: "if",
@@ -1225,6 +1383,12 @@ function compileSwitchStatement(ctx: LinearContext, fctx: LinearFuncContext, stm
       }
     }
   }
+
+  // Close the break-target block (#1937)
+  fctx.blockDepth -= 1;
+  fctx.breakStack.pop();
+  fctx.body = outerBody;
+  fctx.body.push({ op: "block", blockType: { kind: "empty" }, body: switchBody });
 }
 
 export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression): void {
@@ -1428,15 +1592,25 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
           } else {
             ctx.errors.push({
               message: `Unknown function: ${funcName}`,
-              line: 0,
-              column: 0,
+              ...nodeLoc(expr),
             });
           }
         }
       }
+    } else {
+      // Callee is neither a property access nor an identifier (IIFE,
+      // computed callee, …) — used to silently emit nothing (#1937).
+      ctx.errors.push({
+        message: `Unsupported call target in linear backend: ${ts.SyntaxKind[expr.expression.kind]}`,
+        ...nodeLoc(expr),
+      });
+      fctx.body.push({ op: "f64.const", value: 0 });
     }
   } else if (ts.isNonNullExpression(expr)) {
     // Handle `expr!` (non-null assertion) - just compile the inner expression
+    compileExpression(ctx, fctx, expr.expression);
+  } else if (ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr) || ts.isTypeAssertionExpression(expr)) {
+    // Type-level only (`x as T`, `x satisfies T`, `<T>x`) — compile the inner expression
     compileExpression(ctx, fctx, expr.expression);
   } else if (ts.isTemplateExpression(expr)) {
     compileTemplateExpression(ctx, fctx, expr);
@@ -1471,6 +1645,18 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
     });
   } else if (ts.isObjectLiteralExpression(expr)) {
     compileObjectLiteral(ctx, fctx, expr);
+  } else {
+    // #1937 — fail-loud default arm: any expression kind without an explicit
+    // arm above (typeof, await, spread, tagged templates, regex literals, …)
+    // used to compile to ZERO instructions — a silent stack-arity hole that
+    // surfaced, at best, as an opaque validator error far from the source.
+    // Push a located diagnostic (the #1868 gate fails the compile) and a
+    // placeholder value so downstream stack accounting stays balanced.
+    ctx.errors.push({
+      message: `Unsupported expression in linear backend: ${ts.SyntaxKind[expr.kind]}`,
+      ...nodeLoc(expr),
+    });
+    fctx.body.push({ op: "f64.const", value: 0 });
   }
 }
 
@@ -2000,21 +2186,27 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     case ts.SyntaxKind.SlashToken:
       fctx.body.push({ op: "f64.div" });
       break;
-    case ts.SyntaxKind.PercentToken:
-      // f64 remainder: a - trunc(a/b) * b
-      // We need to use a temp approach. Actually, wasm doesn't have f64.rem.
-      // Use i32 truncation for integer modulo
-      // For simplicity, truncate both to i32, do i32.rem_s, convert back
-      // Pop the two f64 values we already pushed, redo with i32
-      // Actually, we already pushed them. Let's just truncate on stack.
-      // Remove the two f64 values and redo
-      // Easier: don't push above, handle separately
-      // We need to restructure. Let's handle % specially before the switch.
-      // For now, use the values on the stack:
-      // stack: [left_f64, right_f64]
-      // But we can't convert them in-place easily with the switch pattern.
-      // Let's use a different approach: handle % before the main compile
+    case ts.SyntaxKind.PercentToken: {
+      // #1937 — this arm used to be EMPTY: `a % b` compiled both operands and
+      // no operator, leaving two values on the stack (the expression's
+      // "result" was just `b`, and the leftover `a` broke stack arity).
+      // Wasm has no f64.rem; emit a - trunc(a/b) * b via temp locals, which
+      // matches JS % (sign of the dividend) for finite operands. Known
+      // divergence: b = ±Infinity yields NaN instead of a (0*Inf = NaN).
+      const bLocal = addLocal(fctx, `__mod_b_${fctx.locals.length}`, { kind: "f64" });
+      const aLocal = addLocal(fctx, `__mod_a_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.set", index: bLocal });
+      fctx.body.push({ op: "local.set", index: aLocal });
+      fctx.body.push({ op: "local.get", index: aLocal });
+      fctx.body.push({ op: "local.get", index: aLocal });
+      fctx.body.push({ op: "local.get", index: bLocal });
+      fctx.body.push({ op: "f64.div" });
+      fctx.body.push({ op: "f64.trunc" });
+      fctx.body.push({ op: "local.get", index: bLocal });
+      fctx.body.push({ op: "f64.mul" });
+      fctx.body.push({ op: "f64.sub" });
       break;
+    }
     case ts.SyntaxKind.LessThanToken:
       fctx.body.push({ op: "f64.lt" });
       break;
@@ -2038,9 +2230,14 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     default:
       ctx.errors.push({
         message: `Unsupported binary operator: ${ts.SyntaxKind[op]}`,
-        line: 0,
-        column: 0,
+        ...nodeLoc(expr),
       });
+      // Both operands are already on the stack — collapse them to one
+      // placeholder value so downstream stack accounting stays balanced
+      // (the #1868 gate fails the compile regardless).
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "f64.const", value: 0 });
   }
 
   // Comparison operators return i32 (0 or 1), convert to f64
@@ -2157,9 +2354,14 @@ function compoundAssignmentOp(op: ts.SyntaxKind): Instr {
 /** Convert a value to i32 truthiness (for conditions) */
 function emitTruthyCoercion(fctx: LinearFuncContext, type: ValType): void {
   if (type.kind === "f64") {
-    // f64 → i32: value != 0.0
+    // f64 → i32: abs(value) > 0.0. The previous `value != 0` test made NaN
+    // truthy (NaN != 0 is true); JS ToBoolean(NaN) is false (#1937).
+    // abs folds -0 to 0 and NaN > 0 is false, so this covers 0, -0 and NaN.
+    // Note: strings are i32 pointers here, so JS "" falsiness does not apply —
+    // a string pointer is always nonzero (see the string layout in runtime.ts).
+    fctx.body.push({ op: "f64.abs" });
     fctx.body.push({ op: "f64.const", value: 0 });
-    fctx.body.push({ op: "f64.ne" });
+    fctx.body.push({ op: "f64.gt" });
   } else if (type.kind === "i32") {
     // Already i32, no conversion needed
   }
@@ -2352,7 +2554,7 @@ function compileObjectDestructuring(
 
     const fieldInfo = propOffsets.get(propName);
     if (!fieldInfo) {
-      ctx.errors.push({ message: `Object destructuring: unknown property "${propName}"`, line: 0, column: 0 });
+      ctx.errors.push({ message: `Object destructuring: unknown property "${propName}"`, ...nodeLoc(element) });
       continue;
     }
 
@@ -2450,7 +2652,7 @@ function compileArrayDestructuring(
 
 function compileNewExpression(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.NewExpression): void {
   if (!ts.isIdentifier(expr.expression)) {
-    ctx.errors.push({ message: "Unsupported new expression", line: 0, column: 0 });
+    ctx.errors.push({ message: "Unsupported new expression", ...nodeLoc(expr) });
     return;
   }
   const ctorName = expr.expression.text;
@@ -2552,7 +2754,7 @@ function compileNewExpression(ctx: LinearContext, fctx: LinearFuncContext, expr:
     if (layout) {
       compileClassNewExpression(ctx, fctx, expr, ctorName, layout);
     } else {
-      ctx.errors.push({ message: `Unsupported constructor: ${ctorName}`, line: 0, column: 0 });
+      ctx.errors.push({ message: `Unsupported constructor: ${ctorName}`, ...nodeLoc(expr) });
     }
   }
 }
@@ -3013,7 +3215,7 @@ function compileArrayHOF(
   // Extract lambda parameter and body
   const callback = expr.arguments[0];
   if (!callback || !(ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))) {
-    ctx.errors.push({ message: `Array.${method}() requires inline arrow function`, line: 0, column: 0 });
+    ctx.errors.push({ message: `Array.${method}() requires inline arrow function`, ...nodeLoc(expr) });
     return;
   }
   const paramName =
@@ -3114,7 +3316,7 @@ function compileArrayHOF(
     : callback.body;
 
   if (!bodyExpr) {
-    ctx.errors.push({ message: `Array.${method}() callback must have a simple expression body`, line: 0, column: 0 });
+    ctx.errors.push({ message: `Array.${method}() callback must have a simple expression body`, ...nodeLoc(callback) });
     fctx.body = savedBody;
     return;
   }

--- a/tests/linear-break-continue.test.ts
+++ b/tests/linear-break-continue.test.ts
@@ -1,0 +1,384 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1937 — the linear/standalone backend used to NEVER compile break/continue
+// (the statement dispatcher had no arm for them), so `while (true) { if (x)
+// break; }` lowered to a silent infinite loop. Unsupported constructs likewise
+// fell through both dispatchers' missing default arms, emitting zero
+// instructions and surfacing — at best — as an opaque validator error far from
+// the cause. This suite locks in the fix:
+//   1. break/continue terminate / skip correctly (incl. nested loops, switch).
+//   2. continue still runs the loop incrementor / re-tests the condition.
+//   3. ToBoolean(NaN) is false (truthiness no longer `f64.ne 0`).
+//   4. every unsupported construct fails loud with a located diagnostic.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile with the linear backend and instantiate; asserts the compile succeeded. */
+async function compileLinear(source: string) {
+  const result = await compile(source, { target: "linear" });
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary);
+  return instance.exports as Record<string, (...args: number[]) => number>;
+}
+
+describe("linear break/continue (#1937)", () => {
+  it("break terminates a while(true) loop (no infinite loop)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let i: number = 0;
+        while (true) {
+          if (i >= 5) {
+            break;
+          }
+          i += 1;
+        }
+        return i;
+      }
+    `);
+    expect(e.f()).toBe(5);
+  });
+
+  it("break terminates a while-condition loop early", async () => {
+    const e = await compileLinear(`
+      export function f(limit: number): number {
+        let i: number = 0;
+        while (i < 100) {
+          if (i === limit) {
+            break;
+          }
+          i += 1;
+        }
+        return i;
+      }
+    `);
+    expect(e.f(7)).toBe(7);
+    expect(e.f(3)).toBe(3);
+  });
+
+  it("continue skips the rest of a while body (and the body still advances)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let sum: number = 0;
+        let i: number = 0;
+        while (i < 10) {
+          i += 1;
+          if (i === 5) {
+            continue;
+          }
+          sum += i;
+        }
+        return sum;
+      }
+    `);
+    // sum of 1..10 = 55, minus the skipped 5 = 50
+    expect(e.f()).toBe(50);
+  });
+
+  it("continue in a for loop still runs the incrementor", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let sum: number = 0;
+        for (let i: number = 0; i < 10; i += 1) {
+          if (i === 5) {
+            continue;
+          }
+          sum += i;
+        }
+        return sum;
+      }
+    `);
+    // sum of 0..9 = 45, minus the skipped 5 = 40. If continue skipped the
+    // incrementor we would loop forever on i === 5.
+    expect(e.f()).toBe(40);
+  });
+
+  it("continue in a do-while still re-tests the condition", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let sum: number = 0;
+        let i: number = 0;
+        do {
+          i += 1;
+          if (i === 3) {
+            continue;
+          }
+          sum += i;
+        } while (i < 6);
+        return sum;
+      }
+    `);
+    // i runs 1..6; sum = 1+2+4+5+6 = 18 (3 skipped)
+    expect(e.f()).toBe(18);
+  });
+
+  it("break in the inner loop only exits the inner loop", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let count: number = 0;
+        for (let i: number = 0; i < 3; i += 1) {
+          for (let j: number = 0; j < 10; j += 1) {
+            if (j >= 2) {
+              break;
+            }
+            count += 1;
+          }
+        }
+        return count;
+      }
+    `);
+    // inner loop contributes 2 per outer iteration × 3 = 6
+    expect(e.f()).toBe(6);
+  });
+
+  it("continue in the inner loop only affects the inner loop", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let count: number = 0;
+        for (let i: number = 0; i < 3; i += 1) {
+          for (let j: number = 0; j < 4; j += 1) {
+            if (j === 1) {
+              continue;
+            }
+            count += 1;
+          }
+        }
+        return count;
+      }
+    `);
+    // inner loop counts 3 of 4 iterations (skips j===1) × 3 outer = 9
+    expect(e.f()).toBe(9);
+  });
+
+  it("break inside a switch exits the switch, not the surrounding loop", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let total: number = 0;
+        for (let i: number = 0; i < 4; i += 1) {
+          switch (i) {
+            case 1:
+              total += 100;
+              break;
+            default:
+              total += 1;
+          }
+          total += 10;
+        }
+        return total;
+      }
+    `);
+    // i=0: default(+1)+10; i=1: case1(+100)+10; i=2: default(+1)+10; i=3: default(+1)+10
+    // = (1+10)+(100+10)+(1+10)+(1+10) = 11+110+11+11 = 143
+    expect(e.f()).toBe(143);
+  });
+
+  it("continue inside a switch continues the surrounding loop", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let sum: number = 0;
+        for (let i: number = 0; i < 5; i += 1) {
+          switch (i) {
+            case 2:
+              continue;
+            default:
+              break;
+          }
+          sum += i;
+        }
+        return sum;
+      }
+    `);
+    // sum of 0..4 = 10, minus the skipped 2 = 8
+    expect(e.f()).toBe(8);
+  });
+
+  it("break/continue work inside for-of over an array", async () => {
+    const brk = await compileLinear(`
+      export function f(): number {
+        const arr: number[] = [1, 2, 3, 4, 5];
+        let sum: number = 0;
+        for (const x of arr) {
+          if (x === 3) {
+            break;
+          }
+          sum += x;
+        }
+        return sum;
+      }
+    `);
+    expect(brk.f()).toBe(3); // 1 + 2
+
+    const cont = await compileLinear(`
+      export function f(): number {
+        const arr: number[] = [1, 2, 3, 4, 5];
+        let sum: number = 0;
+        for (const x of arr) {
+          if (x === 3) {
+            continue;
+          }
+          sum += x;
+        }
+        return sum;
+      }
+    `);
+    expect(cont.f()).toBe(12); // 1+2+4+5
+  });
+
+  it("break/continue work inside for-of over a Map (destructured entry)", async () => {
+    const cont = await compileLinear(`
+      export function f(): number {
+        const m: Map<number, number> = new Map();
+        m.set(1, 10);
+        m.set(2, 20);
+        m.set(3, 30);
+        let sum: number = 0;
+        for (const [k, v] of m) {
+          if (k === 2) {
+            continue;
+          }
+          sum += v;
+        }
+        return sum;
+      }
+    `);
+    expect(cont.f()).toBe(40); // 10 + 30
+
+    const brk = await compileLinear(`
+      export function f(): number {
+        const m: Map<number, number> = new Map();
+        m.set(1, 10);
+        m.set(2, 20);
+        m.set(3, 30);
+        let count: number = 0;
+        for (const [k, v] of m) {
+          count += 1;
+          if (count === 2) {
+            break;
+          }
+        }
+        return count;
+      }
+    `);
+    expect(brk.f()).toBe(2);
+  });
+});
+
+describe("linear ToBoolean(NaN) is false (#1937)", () => {
+  it("if (NaN) takes the else branch", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        if (NaN) {
+          return 1;
+        }
+        return 0;
+      }
+    `);
+    expect(e.f()).toBe(0);
+  });
+
+  it("a NaN-producing expression is falsy", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let x: number = 0;
+        // 0/0 = NaN
+        if (x / x) {
+          return 1;
+        }
+        return 0;
+      }
+    `);
+    expect(e.f()).toBe(0);
+  });
+
+  it("zero and -0 are falsy, non-zero finite values are truthy", async () => {
+    const e = await compileLinear(`
+      export function f(x: number): number {
+        if (x) {
+          return 1;
+        }
+        return 0;
+      }
+    `);
+    expect(e.f(0)).toBe(0);
+    expect(e.f(-0)).toBe(0);
+    expect(e.f(3)).toBe(1);
+    expect(e.f(-2)).toBe(1);
+  });
+
+  it("while (NaN) never iterates", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let n: number = 0;
+        let count: number = 0;
+        while (n / n) {
+          count += 1;
+          if (count > 1000000) {
+            break;
+          }
+        }
+        return count;
+      }
+    `);
+    expect(e.f()).toBe(0);
+  });
+});
+
+describe("linear fail-loud on unsupported constructs (#1937)", () => {
+  // Each snippet exercises a construct the linear backend cannot lower. The
+  // contract: success:false with at least one located (line > 0) diagnostic —
+  // NOT a silently-invalid binary.
+  const unsupported: ReadonlyArray<readonly [string, string]> = [
+    ["throw", `export function f(): number { throw 1; }`],
+    ["typeof", `export function f(x: number): number { const t = typeof x; return 0; }`],
+    [
+      "await",
+      `export async function f(): Promise<number> { return await g(); }
+       async function g(): Promise<number> { return 1; }`,
+    ],
+    ["labeled break", `export function f(): number { L: for (let i=0;i<2;i+=1) { break L; } return 1; }`],
+    ["labeled continue", `export function f(): number { L: for (let i=0;i<2;i+=1) { continue L; } return 1; }`],
+    [
+      "switch case fall-through (non-empty body)",
+      `export function f(x: number): number { let r=0; switch(x){ case 1: r=1; case 2: r=2; break; } return r; }`,
+    ],
+  ];
+
+  for (const [name, src] of unsupported) {
+    it(`fails loud: ${name}`, async () => {
+      const result = await compile(src, { target: "linear" });
+      expect(result.success, `expected ${name} to fail compilation`).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // At least one diagnostic must carry a real source position (line > 0),
+      // proving we threaded getLineAndCharacterOfPosition rather than 0,0.
+      expect(
+        result.errors.some((e) => e.line > 0),
+        `expected a located diagnostic, got: ${result.errors.map((e) => `L${e.line}:${e.column}`).join(", ")}`,
+      ).toBe(true);
+    });
+  }
+
+  it("empty statements compile without a diagnostic", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        ;
+        let x: number = 1;;
+        return x;
+      }
+    `);
+    expect(e.f()).toBe(1);
+  });
+
+  it("type-only statements/expressions compile and are erased", async () => {
+    const e = await compileLinear(`
+      type N = number;
+      interface I { a: number; }
+      export function f(x: number): number {
+        const y = x as number;
+        return y;
+      }
+    `);
+    expect(e.f(42)).toBe(42);
+  });
+});

--- a/tests/linear-controlflow.test.ts
+++ b/tests/linear-controlflow.test.ts
@@ -238,3 +238,323 @@ describe("linear-controlflow: expression statements", () => {
     expect(e.test()).toBe(2);
   });
 });
+
+// ── #1937: break / continue ──────────────────────────────────────────────
+
+/** Compile with the linear backend, expecting failure; return the errors. */
+async function compileLinearExpectError(source: string) {
+  const result = await compile(source, { target: "linear" });
+  expect(result.success, `expected compile failure but got success\nWAT:\n${result.wat}`).toBe(false);
+  return result.errors;
+}
+
+describe("linear-controlflow: break/continue (#1937)", () => {
+  it("break exits a while(true) loop", async () => {
+    const e = await compileLinear(`
+      export function test(n: number): number {
+        let i: number = 0;
+        while (true) {
+          if (i >= n) break;
+          i = i + 1;
+        }
+        return i;
+      }
+    `);
+    expect(e.test(5)).toBe(5);
+    expect(e.test(0)).toBe(0);
+  });
+
+  it("continue in a while loop re-tests the condition", async () => {
+    const e = await compileLinear(`
+      export function sumOdds(n: number): number {
+        let i: number = 0;
+        let sum: number = 0;
+        while (i < n) {
+          i = i + 1;
+          if (i % 2 === 0) continue;
+          sum = sum + i;
+        }
+        return sum;
+      }
+    `);
+    expect(e.sumOdds(10)).toBe(25); // 1+3+5+7+9
+  });
+
+  it("continue in a for loop still runs the incrementor", async () => {
+    const e = await compileLinear(`
+      export function sumNonMultiplesOf3(n: number): number {
+        let sum: number = 0;
+        for (let i = 0; i < n; i = i + 1) {
+          if (i % 3 === 0) continue;
+          sum = sum + i;
+        }
+        return sum;
+      }
+    `);
+    // 0..9 minus {0,3,6,9} → 1+2+4+5+7+8 = 27
+    expect(e.sumNonMultiplesOf3(10)).toBe(27);
+  });
+
+  it("break in a for loop", async () => {
+    const e = await compileLinear(`
+      export function firstSquareAbove(limit: number): number {
+        let result: number = -1;
+        for (let i = 1; i < 1000; i = i + 1) {
+          if (i * i > limit) {
+            result = i * i;
+            break;
+          }
+        }
+        return result;
+      }
+    `);
+    expect(e.firstSquareAbove(10)).toBe(16);
+    expect(e.firstSquareAbove(0)).toBe(1);
+  });
+
+  it("break/continue bind to the innermost of nested loops", async () => {
+    const e = await compileLinear(`
+      export function test(): number {
+        let count: number = 0;
+        for (let i = 0; i < 4; i = i + 1) {
+          for (let j = 0; j < 4; j = j + 1) {
+            if (j === i) continue;
+            if (j > 2) break;
+            count = count + 1;
+          }
+        }
+        return count;
+      }
+    `);
+    // i=0: j=1,2 → 2; i=1: j=0,2 → 2; i=2: j=0,1 → 2; i=3: j=0,1,2 → 3
+    expect(e.test()).toBe(9);
+  });
+
+  it("continue in a do-while still checks the condition", async () => {
+    const e = await compileLinear(`
+      export function test(n: number): number {
+        let i: number = 0;
+        let evens: number = 0;
+        do {
+          i = i + 1;
+          if (i % 2 === 1) continue;
+          evens = evens + 1;
+        } while (i < n);
+        return evens;
+      }
+    `);
+    expect(e.test(10)).toBe(5);
+  });
+
+  it("break in a do-while", async () => {
+    const e = await compileLinear(`
+      export function test(): number {
+        let i: number = 0;
+        do {
+          i = i + 1;
+          if (i === 3) break;
+        } while (i < 100);
+        return i;
+      }
+    `);
+    expect(e.test()).toBe(3);
+  });
+
+  it("break/continue in for-of over an array", async () => {
+    const e = await compileLinear(`
+      export function test(): number {
+        const arr: number[] = [1, 2, 3, 4, 5, 6];
+        let sum: number = 0;
+        for (const x of arr) {
+          if (x === 2) continue;
+          if (x === 5) break;
+          sum = sum + x;
+        }
+        return sum;
+      }
+    `);
+    expect(e.test()).toBe(8); // 1 + 3 + 4
+  });
+
+  it("break inside switch exits the switch, not an enclosing loop", async () => {
+    const e = await compileLinear(`
+      export function test(n: number): number {
+        let total: number = 0;
+        for (let i = 0; i < n; i = i + 1) {
+          switch (i % 3) {
+            case 0:
+              total = total + 1;
+              break;
+            case 1:
+              total = total + 10;
+              break;
+            default:
+              total = total + 100;
+              break;
+          }
+        }
+        return total;
+      }
+    `);
+    expect(e.test(6)).toBe(222); // two of each arm
+  });
+
+  it("break inside an if inside a switch inside a loop", async () => {
+    const e = await compileLinear(`
+      export function test(): number {
+        let acc: number = 0;
+        for (let i = 0; i < 5; i = i + 1) {
+          switch (i) {
+            case 2: {
+              if (acc > 0) {
+                acc = acc + 100;
+                break;
+              }
+              acc = acc + 1000;
+              break;
+            }
+            default:
+              acc = acc + 1;
+              break;
+          }
+        }
+        return acc;
+      }
+    `);
+    expect(e.test()).toBe(104); // i=0,1: +1+1; i=2: +100; i=3,4: +1+1
+  });
+});
+
+// ── #1937: truthiness ────────────────────────────────────────────────────
+
+describe("linear-controlflow: NaN truthiness (#1937)", () => {
+  it("if (NaN) takes the else branch", async () => {
+    const e = await compileLinear(`
+      export function test(x: number): number {
+        const y: number = x / x; // NaN when x is 0
+        if (y) return 1;
+        return 0;
+      }
+    `);
+    expect(e.test(0)).toBe(0); // 0/0 = NaN → falsy
+    expect(e.test(2)).toBe(1); // 2/2 = 1 → truthy
+  });
+
+  it("while (NaN) never enters the loop", async () => {
+    const e = await compileLinear(`
+      export function test(): number {
+        let guard: number = 0 / 0;
+        let n: number = 0;
+        while (guard) {
+          n = 1;
+          guard = 0;
+        }
+        return n;
+      }
+    `);
+    expect(e.test()).toBe(0);
+  });
+
+  it("negative numbers stay truthy, zero stays falsy", async () => {
+    const e = await compileLinear(`
+      export function test(x: number): number {
+        if (x) return 1;
+        return 0;
+      }
+    `);
+    expect(e.test(-5)).toBe(1);
+    expect(e.test(0.5)).toBe(1);
+    expect(e.test(0)).toBe(0);
+    expect(e.test(-0)).toBe(0);
+  });
+});
+
+// ── #1937: fail-loud dispatchers ─────────────────────────────────────────
+
+describe("linear-controlflow: unsupported constructs fail loud (#1937)", () => {
+  const unsupportedStatements: [name: string, source: string][] = [
+    [
+      "labeled break",
+      `export function test(): number {
+        outer: for (let i = 0; i < 3; i = i + 1) {
+          for (let j = 0; j < 3; j = j + 1) {
+            break outer;
+          }
+        }
+        return 0;
+      }`,
+    ],
+    [
+      "throw",
+      `export function test(x: number): number {
+        if (x < 0) throw new Error("negative");
+        return x;
+      }`,
+    ],
+    [
+      "switch case fall-through from non-empty body",
+      `export function test(n: number): number {
+        let r: number = 0;
+        switch (n) {
+          case 0:
+            r = r + 1;
+          case 1:
+            r = r + 10;
+            break;
+        }
+        return r;
+      }`,
+    ],
+    [
+      "break outside any loop",
+      `export function test(): number {
+        break;
+        return 0;
+      }`,
+    ],
+    [
+      "continue outside any loop",
+      `export function test(): number {
+        continue;
+        return 0;
+      }`,
+    ],
+  ];
+
+  it.each(unsupportedStatements)("%s → success:false with a located message", async (_name, body) => {
+    const errors = await compileLinearExpectError(body);
+    expect(errors.length).toBeGreaterThan(0);
+    // At least one diagnostic must carry a real source position (#1937
+    // threads getLineAndCharacterOfPosition into linear diagnostics).
+    expect(errors.some((e) => e.line > 0)).toBe(true);
+  });
+
+  it("typeof (unsupported expression) fails loud with a located message", async () => {
+    const errors = await compileLinearExpectError(`
+      export function test(x: number): number {
+        if (typeof x === "number") return 1;
+        return 0;
+      }
+    `);
+    expect(errors.some((e) => e.message.includes("Unsupported expression") && e.line > 0)).toBe(true);
+  });
+});
+
+// ── #1937: modulo (was an empty dispatch arm leaving 2 stack values) ─────
+
+describe("linear-controlflow: % operator (#1937)", () => {
+  it("computes the remainder, not the divisor", async () => {
+    const e = await compileLinear(`
+      export function mod(a: number, b: number): number {
+        return a % b;
+      }
+    `);
+    expect(e.mod(10, 3)).toBe(1);
+    expect(e.mod(9, 3)).toBe(0);
+    expect(e.mod(5.5, 2)).toBe(1.5);
+    expect(e.mod(-5, 3)).toBe(-2); // JS %: sign of the dividend
+    expect(e.mod(5, -3)).toBe(2);
+    expect(Number.isNaN(e.mod(5, 0))).toBe(true);
+    expect(Number.isNaN(e.mod(Infinity, 3))).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1937 (CRITICAL, from the 2026-06 architecture review #1310).

## Problem
The linear/standalone backend (`src/codegen-linear/`) silently miscompiled control flow:
- **`break`/`continue` were never compiled** — the statement dispatcher had no arm for them, so `while (true) { if (x) break; }` lowered to a **silent infinite loop** with zero diagnostics.
- Both dispatchers (`compileStatement`, `compileExpression`) had **no default arm**, so `typeof`/`await`/spread/etc. emitted zero instructions — a stack-arity hole surfacing as an opaque validator error far from the source.
- `throw` lowered to a bare `unreachable` (catchable exception silently replaced by a trap).
- `if (NaN)` was truthy (`f64.ne 0`).
- Switch fall-through from a non-empty case body was silently dropped.

## Fix
- **break/continue**: emit `br (blockDepth − target − 1)` to the loop's block/loop label using the existing (previously unread) depth stacks. Loop bodies now wrap in an **inner block** so `continue` runs the for-incrementor / re-tests the do-while condition instead of skipping it. for-of and for-of-Map use the same scheme.
- **switch**: wrapped in a break-target block; hard error on C-style fall-through out of a non-empty case body (the cascade-of-ifs lowering can't express it).
- **NaN truthiness**: `(x != 0) & (x == x)` per §7.1.2 ToBoolean.
- **fail-loud default arms** in both dispatchers (the #1868 success gate then bails); `throw` + labeled break/continue get named diagnostics; positions via `getLineAndCharacterOfPosition`. Type-only statements/expressions are erased without a diagnostic.

## Tests
- New `tests/linear-break-continue.test.ts`: break/continue loop termination (while/for/do-while/nested/switch), for-of array + Map break/continue, NaN truthiness, and a table-driven fail-loud sweep over 6 unsupported constructs.
- Extended `tests/linear-controlflow.test.ts`.
- No regressions across existing linear suites (controlflow/advanced/array/basic/collections/map/set/integration all green locally).

Scoped to `src/codegen-linear/` only — no overlap with the WasmGC backend or with #1938 (`runtime.ts`/`layout.ts` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)