### PR TITLE
fix(#1938 part 1): linear element assignment evaluated RHS twice

### DIFF
--- a/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
+++ b/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
@@ -1,10 +1,10 @@
 ---
 id: 1938
 title: "Linear backend: number[] stores i32 elements ([1.5] → [1]) and element-assignment evaluates RHS twice"
-status: ready
+status: in-progress
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -50,6 +50,53 @@ Two silent miscompiles in the linear backend's array path:
 - `arr[i] = f()` calls `f()` exactly once (test).
 - Existing linear tests green; benchmark suite (`benchmarks/run.ts` linear
   strategies) shows no crash.
+
+## Implementation notes (2026-06-11)
+
+Split into two independent parts. **Part 1 (RHS double-eval) is done**; part 2
+(f64 element storage) is carved out below because it requires a layout decision.
+
+### Part 1 — element-assignment RHS double-eval — DONE
+
+`compileElementAccessAssignment` (`src/codegen-linear/index.ts`) compiled the
+RHS *twice*: once to feed the store, once to leave the value on the operand
+stack as the expression result. So `arr[i] = f()` ran `f()` twice — observable
+with any side-effecting RHS, across all four arms (array, Uint8Array,
+Float64Array, Float32Array). Fix: compile the RHS once into a scratch local,
+store from the local, leave the local as the expression value.
+
+A subtlety surfaced while fixing it: for a numeric `arr[i] = v` the expression
+result must be the **f64** value (an assignment-as-expression flows into an f64
+context like `let x: number = (arr[i] = v)`), even though the store currently
+truncates to i32. The scratch is therefore typed by `inferExprType(right)`
+(f64 for numeric, i32 for reference elements); the store truncates from the f64
+scratch, and the f64 scratch is returned. Tests:
+`tests/linear-element-assign.test.ts` (RHS-once for array + Uint8Array,
+assignment-expression value, truncated read-back).
+
+### Part 2 — `number[]` stores i32 elements (`[1.5][0]` → 1) — CARVED OUT (needs layout decision)
+
+Not a localized change. The linear array runtime (`runtime.ts` `__arr_new`/
+`__arr_push`/`__arr_get`/`__arr_set`/`__arr_from_data` + ~20 inline
+load/store sites across every Array.prototype method) uses a **single
+type-agnostic i32×4 element layout shared by ALL array kinds** — `number[]`,
+`boolean[]`, `string[]`, and object arrays all store an i32 (a value for
+numbers/bools, a pointer for strings/objects). `number[]` reads convert i32→f64
+on the way out (`index.ts:2734`), which is exactly the truncation.
+
+Storing f64 elements requires either:
+- **(a) a separate `__f64arr_*` runtime (stride 8)** selected by element type at
+  every array call site (new/push/get/set/length/for-of/method dispatch/spread/
+  Array.isArray), keeping the i32 runtime for reference arrays; or
+- **(b) widening all array slots to 8 bytes** and boxing reference values,
+  which wastes space for the common ref-array case and complicates the C-ABI
+  (`__arr_from_data`, #1835, hands the runtime a contiguous i32 block).
+
+Both ripple through the entire array-method suite and the for-of/Map iteration
+paths; (a) additionally needs element-type routing the backend does not yet
+thread to those sites. This is an architecture decision (which representation),
+not a dev slice — recommend an architect spec before implementation. Acceptance
+criterion `[1.5][0] === 1.5` is deferred to that follow-up.
 
 ## Source
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -2758,31 +2758,48 @@ function compileElementAccessAssignment(
   left: ts.ElementAccessExpression,
   right: ts.Expression,
 ): void {
+  // #1938 — an element assignment used as an expression (`arr[i] = f()`) must
+  // evaluate the RHS exactly once. The previous code compiled `right` twice
+  // (once to store, once to leave as the expression value), so any
+  // side-effecting RHS ran twice. Fix: compile the RHS into a scratch local,
+  // store from the local, and leave the local on the stack as the result.
+  const addScratch = (type: ValType): number => {
+    const idx = fctx.params.length + fctx.locals.length;
+    fctx.locals.push({ name: `__elemassign_${idx}`, type });
+    return idx;
+  };
+
   // Handle typed array views: new Float64Array(buf)[i] = v, new Float32Array(buf)[i] = v
   if (ts.isNewExpression(left.expression) && ts.isIdentifier(left.expression.expression)) {
     const typeName = left.expression.expression.text;
     if (typeName === "Float64Array" && left.expression.arguments?.length) {
       // new Float64Array(buf)[i] = value → buf + i*8, f64.store(value)
+      const valLocal = addScratch({ kind: "f64" });
+      compileExpression(ctx, fctx, right); // value (f64) — evaluated once
+      fctx.body.push({ op: "local.set", index: valLocal });
       compileExpression(ctx, fctx, left.expression.arguments[0]); // buf ptr
       compileExprToI32(ctx, fctx, left.argumentExpression); // index
       fctx.body.push({ op: "i32.const", value: 3 }); // *8 = <<3
       fctx.body.push({ op: "i32.shl" });
       fctx.body.push({ op: "i32.add" }); // buf + index*8
-      compileExpression(ctx, fctx, right); // value (f64)
+      fctx.body.push({ op: "local.get", index: valLocal });
       fctx.body.push({ op: "f64.store", align: 3, offset: 0 });
-      compileExpression(ctx, fctx, right); // return value for expression result
+      fctx.body.push({ op: "local.get", index: valLocal }); // expression result
       return;
     }
     if (typeName === "Float32Array" && left.expression.arguments?.length) {
+      const valLocal = addScratch({ kind: "f64" });
+      compileExpression(ctx, fctx, right); // value (f64) — evaluated once
+      fctx.body.push({ op: "local.set", index: valLocal });
       compileExpression(ctx, fctx, left.expression.arguments[0]);
       compileExprToI32(ctx, fctx, left.argumentExpression);
       fctx.body.push({ op: "i32.const", value: 2 }); // *4 = <<2
       fctx.body.push({ op: "i32.shl" });
       fctx.body.push({ op: "i32.add" });
-      compileExpression(ctx, fctx, right); // value (f64)
+      fctx.body.push({ op: "local.get", index: valLocal });
       fctx.body.push({ op: "f32.demote_f64" });
       fctx.body.push({ op: "f32.store", align: 2, offset: 0 });
-      compileExpression(ctx, fctx, right);
+      fctx.body.push({ op: "local.get", index: valLocal }); // expression result
       return;
     }
   }
@@ -2790,23 +2807,43 @@ function compileElementAccessAssignment(
   const objKind = getExprCollectionKind(ctx, fctx, left.expression);
 
   if (objKind === "Array") {
-    // arr[i] = v → __arr_set(arr, i, v)
+    // arr[i] = v → __arr_set(arr, i, v); leave v as the expression result.
+    //
+    // For a numeric element the value is an f64; element storage is currently
+    // i32 (the truncation half of #1938 is a separate change), so we keep the
+    // f64 in a scratch local as the expression result (an assignment used as a
+    // value must yield the assigned value, not the i32-truncated form — and a
+    // numeric `arr[i] = v` flows into an f64 context) and truncate only for the
+    // store. Non-numeric (string/object) element arrays already produce an i32
+    // value; for those `compileExprToI32` is the identity and the scratch is i32.
     const setIdx = ctx.funcMap.get("__arr_set")!;
+    // A numeric RHS compiles to f64; a reference (string/object) RHS to i32.
+    const rightIsNumeric = inferExprType(ctx, fctx, right).kind === "f64";
+    const valLocal = addScratch({ kind: rightIsNumeric ? "f64" : "i32" });
+    compileExpression(ctx, fctx, right); // value — evaluated once
+    fctx.body.push({ op: "local.set", index: valLocal });
     compileExpression(ctx, fctx, left.expression); // arr ptr (i32)
     compileExprToI32(ctx, fctx, left.argumentExpression); // index → i32
-    compileExprToI32(ctx, fctx, right); // value → i32
+    fctx.body.push({ op: "local.get", index: valLocal });
+    if (rightIsNumeric) {
+      fctx.body.push({ op: "i32.trunc_f64_s" }); // store i32 element (#1938 part 2 will store f64)
+    }
     fctx.body.push({ op: "call", funcIdx: setIdx });
-    // Assignment expressions should return the assigned value
-    compileExpression(ctx, fctx, right);
+    fctx.body.push({ op: "local.get", index: valLocal }); // assigned value (f64 for numeric)
   } else if (objKind === "Uint8Array") {
-    // u8[i] = v → __u8arr_set(u8, i, v)
+    // u8[i] = v → __u8arr_set(u8, i, v); leave v as the expression result.
+    // Uint8Array elements are always numeric; store the byte (i32) and return
+    // the original f64 value as the expression result.
     const setIdx = ctx.funcMap.get("__u8arr_set")!;
+    const valLocal = addScratch({ kind: "f64" });
+    compileExpression(ctx, fctx, right); // value (f64) — evaluated once
+    fctx.body.push({ op: "local.set", index: valLocal });
     compileExpression(ctx, fctx, left.expression);
     compileExprToI32(ctx, fctx, left.argumentExpression); // index → i32
-    compileExprToI32(ctx, fctx, right); // value → i32
+    fctx.body.push({ op: "local.get", index: valLocal });
+    fctx.body.push({ op: "i32.trunc_f64_s" }); // byte value
     fctx.body.push({ op: "call", funcIdx: setIdx });
-    // Push the assigned value as the expression result
-    compileExpression(ctx, fctx, right);
+    fctx.body.push({ op: "local.get", index: valLocal }); // assigned value (f64)
   } else {
     ctx.errors.push({
       message: "Unsupported element access assignment",

--- a/tests/linear-element-assign.test.ts
+++ b/tests/linear-element-assign.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1938 (part 1) — an element assignment used as an expression evaluated the
+// RHS twice: once to store, once to leave the value on the stack as the
+// expression result. So `arr[i] = f()` called `f()` twice, observable with any
+// side-effecting RHS. The fix compiles the RHS into a scratch local, stores
+// from the local, and leaves the local as the expression value (one eval).
+//
+// (Part 2 — `number[]` storing i32 elements so `[1.5][0]` → 1 — is a separate
+// representation change tracked in the issue; not covered here.)
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileLinear(source: string) {
+  const result = await compile(source, { target: "linear" });
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary);
+  return instance.exports as Record<string, (...args: number[]) => number>;
+}
+
+describe("linear element-assignment evaluates RHS once (#1938)", () => {
+  it("number[] element assignment calls a side-effecting RHS exactly once", async () => {
+    const e = await compileLinear(`
+      let calls: number = 0;
+      function side(): number {
+        calls += 1;
+        return calls;
+      }
+      export function f(): number {
+        let arr: number[] = [0, 0, 0];
+        arr[0] = side();
+        return calls;
+      }
+    `);
+    expect(e.f()).toBe(1);
+  });
+
+  it("number[] element assignment stores the value once and returns it", async () => {
+    const e = await compileLinear(`
+      let calls: number = 0;
+      function side(): number {
+        calls += 1;
+        return 99;
+      }
+      export function f(): number {
+        let arr: number[] = [0, 0, 0];
+        // assignment-as-expression: value flows into x, RHS must run once
+        let x: number = (arr[1] = side());
+        // x (99) + calls (1) = 100
+        return x + calls;
+      }
+    `);
+    expect(e.f()).toBe(100);
+  });
+
+  it("number[] element assignment used purely as a statement runs RHS once", async () => {
+    const e = await compileLinear(`
+      let calls: number = 0;
+      function side(): number {
+        calls += 1;
+        return 5;
+      }
+      export function f(): number {
+        let arr: number[] = [0, 0];
+        arr[0] = side();
+        arr[1] = side();
+        return calls;
+      }
+    `);
+    expect(e.f()).toBe(2);
+  });
+
+  it("Uint8Array element assignment calls a side-effecting RHS exactly once", async () => {
+    const e = await compileLinear(`
+      let calls: number = 0;
+      function side(): number {
+        calls += 1;
+        return 7;
+      }
+      export function f(): number {
+        let u: Uint8Array = new Uint8Array(3);
+        u[0] = side();
+        return calls;
+      }
+    `);
+    expect(e.f()).toBe(1);
+  });
+
+  it("Uint8Array element assignment returns the assigned (untruncated) value", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let u: Uint8Array = new Uint8Array(3);
+        // The store truncates to a byte (300 & 0xff = 44) but the assignment
+        // expression yields the original 300 — verify the expression value.
+        let v: number = (u[0] = 300);
+        return v;
+      }
+    `);
+    expect(e.f()).toBe(300);
+  });
+
+  it("the stored Uint8Array byte is the truncated value (read-back)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        let u: Uint8Array = new Uint8Array(3);
+        u[0] = 300;
+        return u[0];
+      }
+    `);
+    // 300 & 0xff = 44
+    expect(e.f()).toBe(44);
+  });
+});


### PR DESCRIPTION
Addresses **part 1** of #1938 (from the 2026-06 architecture review #1310).

## Problem
In the linear/standalone backend, an element assignment used as an expression
compiled the RHS **twice** — once to feed the store, once to leave the value on
the operand stack as the assignment-expression result. So `arr[i] = f()` called
`f()` twice; observable with any side-effecting RHS. All four arms were affected
(Array, Uint8Array, Float64Array, Float32Array).

## Fix
Compile the RHS once into a scratch local, store from the local, and leave the
local as the expression value. For a numeric element the scratch is typed f64
(via `inferExprType`) so `let x: number = (arr[i] = v)` gets the f64 value it
expects, while the store still truncates to the current i32 slot; reference
(string/object) elements keep an i32 scratch.

## Tests
`tests/linear-element-assign.test.ts`: RHS-evaluated-once for array + Uint8Array,
assignment-expression value, and truncated byte read-back. Existing linear
suites green (52/52 across the linear-* files I ran locally).

## Scope / out of scope
- Touches only `compileElementAccessAssignment` in `src/codegen-linear/index.ts`.
- **Part 2** of #1938 — `number[]` storing i32 elements (`[1.5][0]` → 1) — is
  **carved out** (documented in the issue file). It needs an array-element-storage
  layout decision: the linear array runtime uses a single type-agnostic i32×4
  layout shared by every array kind (`number[]`/`boolean[]`/`string[]`/object),
  so f64 elements require either a separate stride-8 `__f64arr_*` runtime selected
  by element type at every call site, or widening all slots to 8 bytes (boxing
  refs, complicating the C-ABI `__arr_from_data`). Recommend an architect spec.
  Issue left `status: in-progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)