### PR TITLE
feat(#1942): compile-time regression gate — count + aggregate compile_ms signals

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -696,6 +696,63 @@ jobs:
             exit 1
           fi
 
+      # #1942 — compile-time regression guard. `pass → compile_timeout` is
+      # excluded from every regression gate above (it's runner-load flake —
+      # see #1192), which leaves compile-perf regressions invisible: a PR that
+      # pathologically slows compilation (exponential type inference, O(n²)
+      # pass) converts passes to timeouts and trips no gate. Two cheap signals
+      # — both already EMITTED by diff-test262.ts (#1942) into the catastrophic
+      # guard's /tmp/cat-diff.txt — gate that surface:
+      #   1. count: pass→compile_timeout above COMPILE_TIMEOUT_THRESHOLD
+      #      (N=25, calibrated above the observed contention-flake floor; the
+      #      #1589 serial retry already absorbs most CT flake, and the
+      #      test262-canary separates non-determinism).
+      #   2. aggregate: sum(compile_ms) over the shared both-compiled set, fail
+      #      when it rises > AGG_COMPILE_TIME_PCT_THRESHOLD (20%). Immune to
+      #      single-test flake and set churn — it measures the same population
+      #      on both sides, so a 20% jump is a real systemic slowdown.
+      # Reuses /tmp/cat-diff.txt from the catastrophic guard (same job, same
+      # merged report) so this adds no extra diff run.
+      - name: Compile-time regression guard (#1942)
+        if: env.SHARDS_RAN == 'true'
+        env:
+          COMPILE_TIMEOUT_THRESHOLD: "25"
+          AGG_COMPILE_TIME_PCT_THRESHOLD: "20"
+        run: |
+          if [ ! -f /tmp/cat-diff.txt ]; then
+            echo "::warning::No /tmp/cat-diff.txt (catastrophic guard skipped — first seed?) — skipping compile-time guard."
+            exit 0
+          fi
+          # pass→compile_timeout count (already split out by diff-test262.ts).
+          CT=$(grep -oE 'Compile timeouts \(pass → compile_timeout\): [0-9]+' /tmp/cat-diff.txt | grep -oE '[0-9]+' | head -1)
+          CT="${CT:-0}"
+          # Aggregate compile-time delta percentage (signed, one decimal).
+          # Line shape: "=== Aggregate compile time (shared N tests): baseline Xms → current Yms (Δ +Z.Z%) ==="
+          AGG_LINE=$(grep -F 'Aggregate compile time (shared' /tmp/cat-diff.txt | head -1)
+          AGG_PCT=$(echo "$AGG_LINE" | grep -oE 'Δ [+-]?[0-9]+\.[0-9]+%' | grep -oE '[-]?[0-9]+\.[0-9]+' | head -1)
+          AGG_PCT="${AGG_PCT:-0.0}"
+          echo "Compile-time guard: pass→compile_timeout=${CT} (threshold ${COMPILE_TIMEOUT_THRESHOLD}); aggregate compile-time Δ=${AGG_PCT}% (threshold +${AGG_COMPILE_TIME_PCT_THRESHOLD}%)."
+          echo "  ${AGG_LINE}"
+          fail=0
+          if [ "$CT" -gt "$COMPILE_TIMEOUT_THRESHOLD" ]; then
+            echo "::error::COMPILE-TIME regression: ${CT} tests went pass→compile_timeout, exceeding the ${COMPILE_TIMEOUT_THRESHOLD} flake threshold. A spike this large is a real compile-perf regression (compilation got slow enough to cross the 30s per-test timeout), not runner-load noise. See #1942."
+            fail=1
+          fi
+          # Integer-compare the percentage (floor): strip the fractional part
+          # for the shell -gt comparison, so +20.x stays under a 20% threshold
+          # and only +21%+ trips.
+          AGG_INT=$(echo "$AGG_PCT" | grep -oE '^-?[0-9]+')
+          AGG_INT="${AGG_INT:-0}"
+          if [ "$AGG_INT" -gt "$AGG_COMPILE_TIME_PCT_THRESHOLD" ]; then
+            echo "::error::COMPILE-TIME regression: aggregate compile time rose ${AGG_PCT}% over the shared both-compiled test set, exceeding the +${AGG_COMPILE_TIME_PCT_THRESHOLD}% threshold. This is a systemic compilation slowdown (the same tests take materially longer to compile). See #1942."
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "----- compile-time signals (from /tmp/cat-diff.txt) -----"
+            grep -E 'Compile timeouts|Aggregate compile time' /tmp/cat-diff.txt || true
+            exit 1
+          fi
+
       # #1668 — HARD stale-baseline guard. The catastrophic guard above (and the
       # full regression gate) are only as trustworthy as the baseline they
       # diff against. The baseline is refreshed per-merge by the promote-baseline

--- a/plan/issues/1942-compile-time-regression-gate.md
+++ b/plan/issues/1942-compile-time-regression-gate.md
@@ -1,10 +1,11 @@
 ---
 id: 1942
 title: "Compile-time regression gate — pass→compile_timeout is excluded from every gate, so compile-perf regressions are invisible"
-status: backlog
-sprint: Backlog
+status: done
+sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -56,3 +57,54 @@ data already present:
 Compiler quality review 2026-06. Related: #1897, #1668,
 `feedback_regression_analysis` (flake reclassification stays — this gates
 the aggregate, not the per-test noise).
+
+## Implementation notes (sd-optimize, 2026-06-11)
+
+Both signals are computed from data already in the JSONL (`compile_ms`,
+recorded per-test in `tests/test262-shared.ts`) and **emitted by
+`scripts/diff-test262.ts`** as grep-able summary lines; the workflow guard
+(`test262-sharded.yml`, "Compile-time regression guard (#1942)") reads them
+and applies the thresholds in YAML — mirroring the #1897 standalone guard's
+"explicit threshold in YAML" style so the gate logic is auditable without
+reading the diff script.
+
+- **Count gate** — reuses the existing `=== Compile timeouts (pass →
+  compile_timeout): N ===` line; fails when `N > 25`.
+- **Aggregate gate** — new `=== Aggregate compile time (shared N tests):
+  baseline Xms → current Yms (Δ ±Z.Z%) ===` line, computed over the
+  **intersection** of files present *and compiled* (`compile_ms` present on
+  both sides) in baseline and current. Restricting to the shared
+  both-compiled set makes the sum immune to set-membership churn and to
+  single-test timeout flake (a timeout has no `compile_ms`, so it can't
+  pollute the aggregate — it's caught by the count gate instead). Fails when
+  the rise exceeds **+20%** (integer floor, so +20.x stays under; +21%+
+  trips).
+- The guard **reuses `/tmp/cat-diff.txt`** produced by the catastrophic
+  guard (same job, same merged report) — no extra diff run.
+
+### Flake calibration
+- **Count threshold N=25.** The #1589 serial retry (10/shard) already absorbs
+  most `compile_timeout` contention flake before it reaches the JSONL, and
+  `test262-canary.yml` separates non-determinism. 25 sits comfortably above
+  the residual per-run CT flake floor (the standalone guard already prints
+  the CT count for visibility and it has run in low single digits). A real
+  exponential-compile regression converts *hundreds* of near-boundary tests,
+  so it clears 25 by a wide margin while ordinary load jitter does not.
+- **Aggregate threshold +20%.** The aggregate is over thousands of shared
+  tests, so per-test scheduling jitter averages out to well under a percent;
+  20% is a deliberate, large margin that only a systemic O(n²)/exponential
+  slowdown reaches. The aggregate is the primary signal (immune to single
+  flaky tests); the count gate is the backstop for the boundary-crossing
+  case.
+
+### Validation (dry-run, synthetic JSONL — equivalent to the AC slow-commit)
+- +28.6% aggregate (350ms→450ms over 3 shared tests) ⇒ aggregate gate
+  **trips** (AGG_INT=28 > 20). Identical compile_ms ⇒ `Δ +0.0%`, **no trip**.
+- 30 `pass→compile_timeout` ⇒ count gate **trips** (30 > 25); timed-out
+  tests correctly excluded from the aggregate (only the both-compiled test
+  contributes).
+- The workflow's `grep -oE`/integer-floor extraction was exercised against
+  the real `diff-test262.ts --quiet` output and parses the values
+  deterministically.
+- Normal PRs: the aggregate Δ on an unchanged compiler is ~0% and CT is in
+  the low single digits, both far below threshold — no false positives.

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -29,6 +29,14 @@ interface TestResult {
    * that are pure CI runner noise.
    */
   wasm_sha?: string | null;
+  /**
+   * Wall-clock compile time in ms (rounded), recorded per-test in the JSONL
+   * (`tests/test262-shared.ts` `recordResult`). Present only when a binary was
+   * actually produced (pass / fail / runtime). #1942 sums this over the shared
+   * both-compiled set to gate aggregate compile-time regressions, which the
+   * per-test `compile_timeout` exclusion otherwise hides.
+   */
+  compile_ms?: number;
 }
 
 type StatusMap = Map<string, TestResult>;
@@ -231,6 +239,40 @@ async function run(baselinePath: string, newPath: string, maxShow: number, quiet
   const regressionsReal = regressions.length - regressionsCT;
   console.log(`=== Compile timeouts (pass → compile_timeout): ${regressionsCT} ===`);
   console.log(`=== Regressions excluding compile_timeout: ${regressionsReal} ===`);
+
+  // #1942: compile-time regression signals. `pass → compile_timeout` is
+  // excluded from every regression gate (it's runner-load flake — see the
+  // #1192 split above), which leaves a blind spot: a PR that pathologically
+  // slows compilation (exponential type inference, accidental O(n²) pass)
+  // converts passes to timeouts invisibly. Two cheap signals, both from data
+  // already in the JSONL (`compile_ms`), gate that surface. We only EMIT them
+  // here (grep-able lines); the workflow guard (#1942, test262-sharded.yml)
+  // reads these lines and applies the thresholds, mirroring the #1897
+  // standalone guard's "explicit threshold in YAML" style.
+  //
+  // (1) Aggregate compile time over the SHARED both-compiled set: files
+  //     present in BOTH baseline and current whose status carries a binary
+  //     (`compile_ms` present on both). Restricting to the intersection makes
+  //     the sum immune to set-membership churn (added/removed tests, skips)
+  //     and to single-test timeout flake — it measures the same population on
+  //     both sides, so a >X% rise is a real systemic slowdown.
+  let aggBaseMs = 0;
+  let aggCurMs = 0;
+  let aggShared = 0;
+  for (const [file, base] of baseline) {
+    const cur = newer.get(file);
+    if (!cur) continue;
+    if (typeof base.compile_ms !== "number" || typeof cur.compile_ms !== "number") continue;
+    aggBaseMs += base.compile_ms;
+    aggCurMs += cur.compile_ms;
+    aggShared += 1;
+  }
+  const aggPct = aggBaseMs > 0 ? ((aggCurMs - aggBaseMs) / aggBaseMs) * 100 : 0;
+  // Round to whole ms for the sums and one decimal for the percentage so the
+  // workflow's `grep -oE '[0-9.-]+'` parses deterministically.
+  console.log(
+    `=== Aggregate compile time (shared ${aggShared} tests): baseline ${Math.round(aggBaseMs)}ms → current ${Math.round(aggCurMs)}ms (Δ ${aggPct >= 0 ? "+" : ""}${aggPct.toFixed(1)}%) ===`,
+  );
 
   // #1222: filter regressions where the compiled Wasm binary is byte-identical
   // on both base and PR. A test that compiles to the same bytes cannot have


### PR DESCRIPTION
## Summary

`pass → compile_timeout` is excluded from every test262 regression gate (the #1192 split, the #1897 standalone guard, the #1668 catastrophic guard all skip it). That exclusion is correct for **runner-load flake** — but it leaves a structural blind spot: a PR that pathologically slows compilation (exponential type inference, accidental O(n²) pass) converts passes to timeouts and trips **no gate**. Nothing tracked aggregate compile time, though per-test `compile_ms` is already in the JSONL.

This adds two cheap signals from data already present, then gates on them.

### `scripts/diff-test262.ts`
- Add `compile_ms` to `TestResult`.
- Emit a new grep-able summary line: **aggregate compile time over the SHARED both-compiled set** — files present *and compiled* (`compile_ms` present) on both baseline and current. Restricting to the intersection makes the sum immune to set-membership churn and to single-test timeout flake (a timeout has no `compile_ms`, so it can't pollute the aggregate — the count gate catches that case instead).
- The existing `=== Compile timeouts (pass → compile_timeout): N ===` line is reused for the count signal.

### `.github/workflows/test262-sharded.yml`
- New **"Compile-time regression guard (#1942)"** step, mirroring the #1897 standalone guard's "explicit threshold in YAML" style. It reads both signal lines out of the catastrophic guard's `/tmp/cat-diff.txt` (same job, same merged report — **no extra diff run**) and fails when:
  - `pass→compile_timeout > 25` (count gate), OR
  - aggregate compile time rose `> 20%` (integer floor).

### Flake calibration (documented in the issue file)
- **N=25 count threshold**: the #1589 serial retry absorbs most CT contention flake; the canary separates non-determinism; a real exponential-compile regression converts hundreds of near-boundary tests, clearing 25 by a wide margin.
- **+20% aggregate threshold**: the aggregate is over thousands of shared tests so per-test jitter averages to <1%; 20% only a systemic slowdown reaches. The aggregate is the primary signal; the count is the boundary-crossing backstop.

### Validation (synthetic dry-run — equivalent to the AC slow-commit)
- +28.6% aggregate (350ms→450ms over 3 shared) ⇒ aggregate gate **trips** (28 > 20); identical `compile_ms` ⇒ `Δ +0.0%`, no trip.
- 30 `pass→compile_timeout` ⇒ count gate **trips** (30 > 25); timed-out tests correctly excluded from the aggregate.
- The workflow's `grep -oE` / integer-floor extraction was exercised against the real `diff-test262.ts --quiet` output and parses deterministically.
- typecheck / lint / format / workflow-YAML all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)