### PR TITLE
fix(#1939): encodeInstr fail-loud default + encodeValType i8/i16 throw + un-gate validateFuncRefs

### DIFF
--- a/plan/issues/1939-encodeinstr-default-throw-funcref-validation.md
+++ b/plan/issues/1939-encodeinstr-default-throw-funcref-validation.md
@@ -1,10 +1,11 @@
 ---
 id: 1939
 title: "Binary emitter: encodeInstr silently drops unknown ops — add default throw, un-gate validateFuncRefs, add round-trip test"
-status: backlog
-sprint: Backlog
+status: done
+sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -13,6 +14,7 @@ area: codegen
 language_feature: compiler-internals
 goal: correctness
 ---
+
 # #1939 — encodeInstr default throw + funcref validation + round-trip test
 
 ## Problem
@@ -32,8 +34,7 @@ goal: correctness
 
 ## Proposed approach
 
-1. `default: throw new Error(\`encodeInstr: unknown op ${(instr as any).op}\`)`
-   plus a `satisfies never` exhaustiveness check where the union allows it.
+1. `default: throw new Error(\`encodeInstr: unknown op ${(instr as any).op}\`)`plus a`satisfies never` exhaustiveness check where the union allows it.
    Run equivalence + test262 sharded to flush any op currently being
    silently dropped (each hit is a live bug found).
 2. `encodeValType` i8/i16 outside array-element context: throw.
@@ -51,6 +52,49 @@ goal: correctness
 - funcref validation active in CI; round-trip test in `tests/`.
 - Any ops flushed out by the default-throw are fixed or added to the
   encoder in the same PR.
+
+## Implementation notes (resolved 2026-06-11)
+
+All in `src/emit/binary.ts` (+ one opcode in `src/emit/opcodes.ts`).
+
+**`encodeInstr` default arm + exhaustiveness.** Added a `default` arm that
+binds `const unknown: never = instr` (compile-time exhaustiveness over the
+real `Instr` union) and throws `encodeInstr: unknown op "<op>"` at runtime
+(catches cast-injected strings the union can't see).
+
+**Three latent silent-drops flushed by the `never` check** — all were `Instr`
+union members with **no encoder case** (would be silently omitted from the
+binary the instant any path emitted one; none does today, so no live
+miscompile, but a removed footgun):
+
+- `i32.trunc_f64_u` — real op, given a proper case (opcode `0xab`, added to
+  `opcodes.ts` next to its signed sibling `0xaa`).
+- `end` — structured-block terminator (`0x0b`); block/loop/if normally emit
+  their own trailing `end`, but a standalone `end` instr is valid.
+- `br_table` — declared as `{ op: "br_table" }` with **no payload** (no target
+  label vector / default). There is no correct encoding, so its case _throws_
+  with a clear message rather than emit a truncated branch. Wiring it requires
+  the union to carry `targets: number[]` + `default: number` first.
+
+**`encodeValType` i8/i16 leak → throw.** Packed storage types are valid only
+in struct fields / array elements (a dedicated path handles those). Reaching
+them in a value position (param/result/local/global) used to silently encode
+i32, producing a binary whose declared type disagreed with its values. Now
+throws.
+
+**`validateFuncRefs` un-gated.** Was `if (process.env.JS2WASM_VALIDATE_FUNCREFS)`
+(off by default). Now runs whenever `VITEST`/`CI` is set or `NODE_ENV !==
+"production"` (env override still force-enables; a production build opts out
+for byte-identical output). It is a pure in-range scan — cannot reject a valid
+module, only turns the recurring stale-funcIdx class (#1891/#1899) into a named
+emit-time error. Validated as a no-op across the equivalence suite (0 fires).
+
+**Tests** — `tests/emit-encodeinstr-failloud.test.ts`: unknown-op throws,
+br_table throws, the three flushed ops encode (or throw, for br_table),
+a no-silent-drop spot-check over representative simple ops, and i8/i16
+value-position leak throws. Full equivalence suite green with the default-throw
+
+- funcref validation active (no op dropped, no funcref false-fire).
 
 ## Source
 

--- a/src/emit/binary.ts
+++ b/src/emit/binary.ts
@@ -187,7 +187,19 @@ export function emitBinaryWithSourceMap(mod: WasmModule): EmitResult {
   // accepted, so it cannot reject a valid module; it only converts the two
   // already-broken outcomes above into an actionable message. Validated as a
   // no-op across the issue-16xx/17xx/18xx + WASI corpus (0 fires).
-  if (process.env.JS2WASM_VALIDATE_FUNCREFS) {
+  // #1939 — run the funcref range-check by default everywhere except a
+  // production build. It is a pure in-range check (cannot reject a valid
+  // module; only turns the recurring stale-funcIdx bug class — #1891/#1899 —
+  // into a named emit-time error instead of an opaque wasmtime type mismatch),
+  // and it is a per-emit linear scan (negligible). Explicitly forced on in
+  // vitest/CI; `JS2WASM_VALIDATE_FUNCREFS` still force-enables, and a
+  // production build (`NODE_ENV=production`) opts out for byte-identical output.
+  const validateFuncRefsEnabled =
+    !!process.env.JS2WASM_VALIDATE_FUNCREFS ||
+    !!process.env.VITEST ||
+    !!process.env.CI ||
+    process.env.NODE_ENV !== "production";
+  if (validateFuncRefsEnabled) {
     validateFuncRefs(mod, numImportFuncs);
   }
 
@@ -597,14 +609,18 @@ export function encodeValType(t: ValType, enc: WasmEncoder): void {
       enc.byte(TYPE.any);
       break;
     case "i8":
-      // i8 is only valid as a packed storage type — encode as i32 fallback
-      enc.byte(TYPE.i32);
-      break;
     case "i16":
-      // i16 is only valid as a packed storage type in struct fields/array elements,
-      // but if it appears in encodeValType, encode it as i32 (this shouldn't happen)
-      enc.byte(TYPE.i32);
-      break;
+      // #1939 — i8/i16 are *packed storage* types, valid only inside struct
+      // fields and array elements (encoded by the dedicated path at the top of
+      // this function / the field encoder). Reaching them here means a packed
+      // type leaked into a value position (param/result/local/global) where
+      // Wasm has no such type; silently encoding it as i32 produced a binary
+      // whose declared type disagreed with the values flowing through it — a
+      // downstream validation error far from the leak. Fail loud instead.
+      throw new Error(
+        `encodeValType: packed storage type "${t.kind}" is not valid in a value position ` +
+          `(only struct fields / array elements) — a packed type leaked into a param/result/local/global`,
+      );
   }
 }
 
@@ -1038,6 +1054,11 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
       break;
     case "i32.trunc_f64_s":
       enc.byte(OP.i32_trunc_f64_s);
+      break;
+    case "i32.trunc_f64_u":
+      // #1939 — was a union member with no encoder case (silently dropped if
+      // ever emitted). Unsigned f64→i32 truncation, opcode 0xab.
+      enc.byte(OP.i32_trunc_f64_u);
       break;
     case "f64.convert_i32_s":
       enc.byte(OP.f64_convert_i32_s);
@@ -1674,6 +1695,35 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
       enc.u32(instr.align);
       enc.u32(instr.offset);
       break;
+    case "end":
+      // #1939 — the explicit structured-block terminator (0x0b). Block/loop/if
+      // bodies normally emit their own trailing `end` in the structured
+      // encoders, but a standalone `end` instr is a valid union member and was
+      // previously a silent drop.
+      enc.byte(OP.end);
+      break;
+    case "br_table":
+      // #1939 — `br_table` is declared in the Instr union as `{ op: "br_table" }`
+      // with NO payload (target label vector + default), so there is no correct
+      // encoding for it: emitting opcode 0x0e without its operands would corrupt
+      // every following instruction. No codegen path produces it today. Fail
+      // loud rather than emit a malformed branch; wiring it needs the union to
+      // carry `targets: number[]` + `default: number` first.
+      throw new Error(
+        "encodeInstr: 'br_table' has no payload in the Instr union (needs targets[] + default) — " +
+          "cannot be encoded; no codegen path should emit it yet (#1939)",
+      );
+    // #1939 — fail loud on an op with no encoding case. The ~170
+    // `as unknown as Instr` casts (#1095) bypass the type union, so a
+    // mistyped/missing op string would otherwise be silently omitted from the
+    // binary — the worst failure shape, surfacing far downstream as an opaque
+    // wasm validation error (stack/type mismatch) with no link to the source
+    // op. The `never` binding is a compile-time exhaustiveness check over the
+    // real union; the throw also catches cast-injected strings at runtime.
+    default: {
+      const unknown: never = instr;
+      throw new Error(`encodeInstr: unknown op "${(unknown as { op?: string }).op ?? "<no op>"}"`);
+    }
   }
 }
 

--- a/src/emit/opcodes.ts
+++ b/src/emit/opcodes.ts
@@ -91,6 +91,7 @@ export const OP = {
   f64_copysign: 0xa6,
   i32_wrap_i64: 0xa7,
   i32_trunc_f64_s: 0xaa,
+  i32_trunc_f64_u: 0xab,
   f32_demote_f64: 0xb6,
   f64_promote_f32: 0xbb,
   // i64 comparison

--- a/tests/emit-encodeinstr-failloud.test.ts
+++ b/tests/emit-encodeinstr-failloud.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1939 — the binary emitter's `encodeInstr` had NO default arm, so an op
+// string with no matching case (the failure shape the ~170 `as unknown as
+// Instr` casts invite) was **silently omitted from the binary** — surfacing,
+// at best, as an opaque wasm validation error far downstream. `encodeValType`
+// likewise silently encoded packed i8/i16 as i32 in a value position. This
+// suite locks in the fail-loud behaviour and the no-silent-drop property that
+// flushed three latent union members (`i32.trunc_f64_u`, `br_table`, `end`).
+import { describe, it, expect } from "vitest";
+import { WasmEncoder } from "../src/emit/encoder.js";
+import { encodeInstr, encodeValType } from "../src/emit/binary.js";
+import type { Instr, ValType } from "../src/ir/types.js";
+
+function encodeOne(instr: Instr): Uint8Array {
+  const enc = new WasmEncoder();
+  encodeInstr(instr, enc);
+  return enc.finish();
+}
+
+describe("encodeInstr fail-loud (#1939)", () => {
+  it("throws on an unknown op instead of silently emitting nothing", () => {
+    // The cast escape hatch that the union forbids: an op string with no case.
+    const bogus = { op: "totally.not.a.real.op" } as unknown as Instr;
+    expect(() => encodeOne(bogus)).toThrow(/unknown op/i);
+  });
+
+  it("throws on br_table (declared in the union but has no encodable payload)", () => {
+    // `{ op: "br_table" }` carries no target table, so there is no correct
+    // encoding — must fail loud rather than emit a truncated branch.
+    expect(() => encodeOne({ op: "br_table" } as Instr)).toThrow(/br_table/);
+  });
+
+  it("encodes the three previously-dropped simple ops to ≥1 byte", () => {
+    // These were union members with no encoder case (silent drops if emitted).
+    expect(encodeOne({ op: "i32.trunc_f64_u" } as Instr)).toEqual(new Uint8Array([0xab]));
+    expect(encodeOne({ op: "end" } as Instr)).toEqual(new Uint8Array([0x0b]));
+  });
+
+  it("no-silent-drop property: representative simple ops each encode to ≥1 byte", () => {
+    // A spot-check that the common nullary numeric/ref/stack ops all produce
+    // output. The exhaustiveness `never` check in encodeInstr already enforces
+    // this at compile time for the whole union; this is the runtime backstop.
+    const simpleOps: Instr[] = [
+      { op: "i32.add" },
+      { op: "i32.sub" },
+      { op: "i32.eqz" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+      { op: "f64.add" },
+      { op: "f64.ne" },
+      { op: "f64.eq" },
+      { op: "f64.neg" },
+      { op: "i32.trunc_f64_s" },
+      { op: "i32.trunc_f64_u" },
+      { op: "f64.convert_i32_s" },
+      { op: "i32.wrap_i64" },
+      { op: "drop" },
+      { op: "return" },
+      { op: "end" },
+      { op: "unreachable" },
+      { op: "nop" },
+    ];
+    for (const op of simpleOps) {
+      const bytes = encodeOne(op);
+      expect(bytes.length, `op "${op.op}" must encode to ≥1 byte`).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe("encodeValType fail-loud on packed types in value position (#1939)", () => {
+  it("throws when i8 leaks into a value position", () => {
+    const enc = new WasmEncoder();
+    expect(() => encodeValType({ kind: "i8" } as ValType, enc)).toThrow(/packed storage type/i);
+  });
+
+  it("throws when i16 leaks into a value position", () => {
+    const enc = new WasmEncoder();
+    expect(() => encodeValType({ kind: "i16" } as ValType, enc)).toThrow(/packed storage type/i);
+  });
+
+  it("still encodes ordinary value types (i32/f64) without throwing", () => {
+    const enc = new WasmEncoder();
+    expect(() => encodeValType({ kind: "i32" }, enc)).not.toThrow();
+    expect(() => encodeValType({ kind: "f64" }, enc)).not.toThrow();
+    expect(enc.finish().length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Fixes #1939 (from the 2026-06 architecture review #1310).

## Problem
The binary emitter (`src/emit/binary.ts`) silently dropped unknown ops:
- **`encodeInstr` had no `default` arm.** Combined with the ~170 `as unknown as Instr` casts (#1095) that bypass the type union, an op string with no matching case was **omitted from the binary** — the worst failure shape, surfacing far downstream as an opaque wasm validation error (stack/type mismatch) with no link to the source op.
- **`encodeValType`** silently encoded packed `i8`/`i16` as `i32` in a value position.
- **`validateFuncRefs`** (the guard for the recurring stale-funcIdx class #1891/#1899) was env-gated off by default.

## Fix
- `default: throw` in `encodeInstr` with a `const _: never = instr` compile-time exhaustiveness check. **This flushed three `Instr` union members with no encoder case** (latent silent-drops — none emitted in practice today, footgun removed): `i32.trunc_f64_u` (now encoded, opcode `0xab`), `end` (`0x0b`), and `br_table` (declared with **no payload** — its case throws, since there is no correct encoding without `targets[]`/`default`).
- `encodeValType`: throw on packed i8/i16 in a value position (param/result/local/global) instead of silently mis-encoding as i32.
- Un-gate `validateFuncRefs`: runs by default in VITEST/CI and when `NODE_ENV !== "production"` (env override still force-enables; production opts out for byte-identical output). Pure in-range scan — cannot reject a valid module, only names the stale-funcIdx bug at emit time.

## Validation
- **Full equivalence suite green** with the default-throw + funcref validation active — **no op dropped in any real codegen path, no funcref false-fire** (the three flushed ops are genuinely unreached today).
- New `tests/emit-encodeinstr-failloud.test.ts`: unknown-op throw, br_table throw, the flushed ops encode, a no-silent-drop spot-check over representative simple ops, and i8/i16 value-position leak throw. `tests/binary.test.ts` still green.
- Typecheck clean (the `never` binding is the compile-time half of the no-silent-drop guarantee).

Scoped to `src/emit/` + one test. No behaviour change on the default compile path beyond the now-active funcref range-check (validated no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)