### PR TITLE
fix(#2034): Number.is* predicates must not coerce their argument

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1883,6 +1883,68 @@ function compileStandalonePromiseThenCallback(
   }
 }
 
+/**
+ * #2034: compile a `Number.is*` predicate argument as an f64, honouring the
+ * spec rule that these predicates do NOT coerce (ES §21.1.2.x): a non-Number
+ * argument must yield `false` without ToNumber. (The *global* `isNaN`/`isFinite`
+ * DO coerce — they are handled elsewhere and unaffected.)
+ *
+ * Emits one of two shapes and returns i32 (0/1):
+ *   - static number arg → `predicate(arg)` (unchanged fast path).
+ *   - any-typed arg → `__typeof_number(box) ? predicate(__unbox_number(box)) : 0`.
+ *     The typeof guard runs first, so a string/object/null box short-circuits to
+ *     0 (false) and never reaches the numeric test.
+ *
+ * `emitPredicate` receives the local holding the f64 value and pushes the
+ * boolean (i32) test for that value.
+ */
+function compileNumberIsPredicate(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  emitPredicate: (valLocal: number) => Instr[],
+): ValType {
+  const argTsType = ctx.checker.getTypeAtLocation(arg);
+  const argWasm = resolveWasmType(ctx, argTsType);
+  const isStaticNumber = isNumberType(argTsType) || argWasm.kind === "f64" || argWasm.kind === "i32";
+
+  if (isStaticNumber) {
+    // Fast path: the argument is statically a number — apply the test directly.
+    compileExpression(ctx, fctx, arg, { kind: "f64" });
+    const valTmp = allocLocal(fctx, `__numpred_${fctx.locals.length}`, { kind: "f64" });
+    fctx.body.push({ op: "local.set", index: valTmp });
+    for (const instr of emitPredicate(valTmp)) fctx.body.push(instr);
+    return { kind: "i32" };
+  }
+
+  // Any-typed argument: inspect the box's runtime type. Non-numbers are `false`
+  // (no coercion); numbers unbox to f64 and run the test.
+  addUnionImports(ctx);
+  const typeofNumIdx = ctx.funcMap.get("__typeof_number")!;
+  const unboxIdx = ctx.funcMap.get("__unbox_number")!;
+
+  compileExpression(ctx, fctx, arg, { kind: "externref" });
+  const boxTmp = allocLocal(fctx, `__numpred_box_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: boxTmp });
+
+  const valTmp = allocLocal(fctx, `__numpred_${fctx.locals.length}`, { kind: "f64" });
+
+  fctx.body.push({ op: "local.get", index: boxTmp });
+  fctx.body.push({ op: "call", funcIdx: typeofNumIdx });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [
+      { op: "local.get", index: boxTmp } as Instr,
+      { op: "call", funcIdx: unboxIdx } as Instr,
+      { op: "local.set", index: valTmp } as Instr,
+      ...emitPredicate(valTmp),
+    ],
+    else: [{ op: "i32.const", value: 0 } as Instr],
+  } as Instr);
+  return { kind: "i32" };
+}
+
 function compileCallExpression(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3369,73 +3431,65 @@ function compileCallExpression(
     // Handle Number.isNaN(n) and Number.isInteger(n)
     if (ts.isIdentifier(propAccess.expression) && propAccess.expression.text === "Number") {
       const method = propAccess.name.text;
+      // #2034: `Number.is*` predicates must NOT coerce their argument — a
+      // non-Number value is `false` (ES §21.1.2.x). compileNumberIsPredicate
+      // guards an any-typed argument with `__typeof_number` before applying the
+      // numeric test; a static number keeps the direct f64 fast path.
       if (method === "isNaN" && expr.arguments.length >= 1) {
-        // NaN !== NaN is true; for any other value it's false
-        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
-        const tmp = allocLocal(fctx, `__isnan_${fctx.locals.length}`, {
-          kind: "f64",
-        });
-        fctx.body.push({ op: "local.tee", index: tmp });
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.ne" } as Instr);
-        return { kind: "i32" };
+        // NaN !== NaN is true; for any other number it's false.
+        return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.ne" } as Instr,
+        ]);
       }
       if (method === "isInteger" && expr.arguments.length >= 1) {
-        // n === Math.trunc(n) && isFinite(n)
-        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
-        const tmp = allocLocal(fctx, `__isint_${fctx.locals.length}`, {
-          kind: "f64",
-        });
-        fctx.body.push({ op: "local.tee", index: tmp });
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.trunc" } as Instr);
-        fctx.body.push({ op: "f64.eq" } as Instr);
-        // Also check finite: n - n === 0 (Infinity - Infinity = NaN, NaN !== 0)
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.sub" } as Instr);
-        fctx.body.push({ op: "f64.const", value: 0 });
-        fctx.body.push({ op: "f64.eq" } as Instr);
-        fctx.body.push({ op: "i32.and" } as Instr);
-        return { kind: "i32" };
+        // n === trunc(n) && isFinite(n)
+        return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.trunc" } as Instr,
+          { op: "f64.eq" } as Instr,
+          // finite: n - n === 0 (Infinity - Infinity = NaN, NaN !== 0)
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.sub" } as Instr,
+          { op: "f64.const", value: 0 },
+          { op: "f64.eq" } as Instr,
+          { op: "i32.and" } as Instr,
+        ]);
       }
       if (method === "isFinite" && expr.arguments.length >= 1) {
         // isFinite(n) → n - n === 0.0
-        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
-        const tmp = allocLocal(fctx, `__isfin_${fctx.locals.length}`, {
-          kind: "f64",
-        });
-        fctx.body.push({ op: "local.tee", index: tmp });
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.sub" } as Instr);
-        fctx.body.push({ op: "f64.const", value: 0 });
-        fctx.body.push({ op: "f64.eq" } as Instr);
-        return { kind: "i32" };
+        return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.sub" } as Instr,
+          { op: "f64.const", value: 0 },
+          { op: "f64.eq" } as Instr,
+        ]);
       }
       if (method === "isSafeInteger" && expr.arguments.length >= 1) {
         // isSafeInteger(n) = isInteger(n) && abs(n) <= MAX_SAFE_INTEGER
-        compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
-        const tmp = allocLocal(fctx, `__issafe_${fctx.locals.length}`, {
-          kind: "f64",
-        });
-        fctx.body.push({ op: "local.tee", index: tmp });
-        // isInteger: n === trunc(n) && isFinite(n)
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.trunc" } as Instr);
-        fctx.body.push({ op: "f64.eq" } as Instr);
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.sub" } as Instr);
-        fctx.body.push({ op: "f64.const", value: 0 });
-        fctx.body.push({ op: "f64.eq" } as Instr);
-        fctx.body.push({ op: "i32.and" } as Instr);
-        // abs(n) <= MAX_SAFE_INTEGER
-        fctx.body.push({ op: "local.get", index: tmp });
-        fctx.body.push({ op: "f64.abs" } as Instr);
-        fctx.body.push({ op: "f64.const", value: Number.MAX_SAFE_INTEGER });
-        fctx.body.push({ op: "f64.le" } as Instr);
-        fctx.body.push({ op: "i32.and" } as Instr);
-        return { kind: "i32" };
+        return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
+          // isInteger: n === trunc(n) && isFinite(n)
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.trunc" } as Instr,
+          { op: "f64.eq" } as Instr,
+          { op: "local.get", index: v },
+          { op: "local.get", index: v },
+          { op: "f64.sub" } as Instr,
+          { op: "f64.const", value: 0 },
+          { op: "f64.eq" } as Instr,
+          { op: "i32.and" } as Instr,
+          // abs(n) <= MAX_SAFE_INTEGER
+          { op: "local.get", index: v },
+          { op: "f64.abs" } as Instr,
+          { op: "f64.const", value: Number.MAX_SAFE_INTEGER },
+          { op: "f64.le" } as Instr,
+          { op: "i32.and" } as Instr,
+        ]);
       }
       if ((method === "parseFloat" || method === "parseInt") && expr.arguments.length >= 1) {
         // Delegate to the global parseInt / parseFloat host import

--- a/tests/issue-2034.test.ts
+++ b/tests/issue-2034.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2034: Number.isNaN / isInteger / isFinite / isSafeInteger must NOT coerce
+// their argument (ES §21.1.2.x). A non-Number value is `false` without ToNumber
+// — `Number.isNaN("foo")` is `false`, not `true`. The *global* `isNaN` /
+// `isFinite` DO coerce (`isNaN("foo") === true`) and must keep doing so.
+
+async function evalBool(body: string): Promise<boolean> {
+  const exports = await compileToWasm(body);
+  return !!(exports as { test: () => unknown }).test();
+}
+
+describe("#2034 Number.is* predicates do not coerce", () => {
+  it("Number.isNaN of a non-number is false", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isNaN("foo" as any); }`)).toBe(false);
+    expect(await evalBool(`export function test(): boolean { const x: any = {}; return Number.isNaN(x); }`)).toBe(
+      false,
+    );
+    expect(await evalBool(`export function test(): boolean { const x: any = true; return Number.isNaN(x); }`)).toBe(
+      false,
+    );
+  });
+
+  it("Number.isNaN of a real NaN is true (number arg unaffected)", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isNaN(NaN); }`)).toBe(true);
+    expect(await evalBool(`export function test(): boolean { const x: any = NaN; return Number.isNaN(x); }`)).toBe(
+      true,
+    );
+    expect(await evalBool(`export function test(): boolean { return Number.isNaN(1); }`)).toBe(false);
+  });
+
+  it("Number.isInteger of a non-number is false", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isInteger("5" as any); }`)).toBe(false);
+    expect(
+      await evalBool(`export function test(): boolean { const x: any = undefined; return Number.isInteger(x); }`),
+    ).toBe(false);
+  });
+
+  it("Number.isInteger of a number is correct", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isInteger(5); }`)).toBe(true);
+    expect(await evalBool(`export function test(): boolean { return Number.isInteger(5.5); }`)).toBe(false);
+    expect(await evalBool(`export function test(): boolean { const x: any = 5; return Number.isInteger(x); }`)).toBe(
+      true,
+    );
+  });
+
+  it("Number.isFinite of a non-number is false", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isFinite("1" as any); }`)).toBe(false);
+    expect(await evalBool(`export function test(): boolean { const x: any = null; return Number.isFinite(x); }`)).toBe(
+      false,
+    );
+  });
+
+  it("Number.isFinite of a number is correct", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isFinite(1); }`)).toBe(true);
+    expect(await evalBool(`export function test(): boolean { return Number.isFinite(Infinity); }`)).toBe(false);
+  });
+
+  it("Number.isSafeInteger of a non-number is false", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isSafeInteger("5" as any); }`)).toBe(false);
+  });
+
+  it("Number.isSafeInteger of a number is correct", async () => {
+    expect(await evalBool(`export function test(): boolean { return Number.isSafeInteger(5); }`)).toBe(true);
+    expect(await evalBool(`export function test(): boolean { return Number.isSafeInteger(2 ** 53); }`)).toBe(false);
+  });
+
+  it("the GLOBAL isNaN / isFinite still coerce (must not regress)", async () => {
+    expect(await evalBool(`export function test(): boolean { return isNaN("foo" as any); }`)).toBe(true);
+    expect(await evalBool(`export function test(): boolean { return isFinite("1" as any); }`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`Number.isNaN` / `isInteger` / `isFinite` / `isSafeInteger` compiled their
argument with a `{kind: "f64"}` hint, forcing ToNumber, so
`Number.isNaN("foo" as any)` returned `true` (Node: `false`). Per ES §21.1.2.x
these predicates return `false` for any non-Number **without coercion** — unlike
the *global* `isNaN`/`isFinite`, which DO coerce (and are unaffected here).

Added `compileNumberIsPredicate`: a statically-numeric argument keeps the direct
f64 fast path; an any-typed argument is guarded by `__typeof_number` first —
non-numbers short-circuit to `0` (false), numbers unbox via `__unbox_number` and
run the numeric test. All four predicates share the helper (`isSafeInteger` had
the same bug).

## Repros (all now match Node)

| Expression | Before | After |
|---|---|---|
| `Number.isNaN("foo" as any)` | `true` | `false` |
| `Number.isInteger("5" as any)` | `true` | `false` |
| `Number.isFinite("1" as any)` | `true` | `false` |
| `Number.isSafeInteger("5" as any)` | `true` | `false` |
| `Number.isNaN(NaN)` | `true` | `true` |
| `isNaN("foo")` (global) | `true` | `true` (unchanged) |

## Tests

`tests/issue-2034.test.ts` — 9 equivalence cases: non-number args (string,
object, boolean, null, undefined) are false; number / any-boxed-number args
correct; `isSafeInteger` boundary; global `isNaN`/`isFinite` still coerce
(non-regression). Related suites green (number-statics, #1023, #1322,
ir-frontend-widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)