### PR TITLE
fix(#1966): implement native Array.prototype.unshift (was a silent no-op)

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -2385,6 +2385,7 @@ const ARRAY_METHODS = new Set([
   "push",
   "pop",
   "shift",
+  "unshift",
   "indexOf",
   "includes",
   "slice",
@@ -2536,7 +2537,22 @@ export function compileArrayMethodCall(
   // getReceiverLocalIdx succeeds and mutating methods can write back.
   let moduleGlobalIdx: number | undefined;
   let savedLocal: number | undefined;
-  const MUTATING = new Set(["push", "pop", "shift", "reverse", "splice", "fill", "copyWithin", "sort", "set"]);
+  // #1966: `unshift` mutates in place (prepends + shifts), so its mutated vec
+  // must be written back to the receiver — include it here. The `to*`
+  // variants (toSorted/toReversed/toSpliced/with) and slice/concat/map/filter
+  // are NON-mutating (they return a new array) and are deliberately excluded.
+  const MUTATING = new Set([
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "reverse",
+    "splice",
+    "fill",
+    "copyWithin",
+    "sort",
+    "set",
+  ]);
   if (ts.isIdentifier(propAccess.expression)) {
     const name = propAccess.expression.text;
     const gIdx = ctx.moduleGlobals.get(name);
@@ -2571,6 +2587,9 @@ export function compileArrayMethodCall(
       break;
     case "shift":
       result = compileArrayShift(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType, expectedType);
+      break;
+    case "unshift":
+      result = compileArrayUnshift(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "slice":
       result = compileArraySlice(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
@@ -4147,6 +4166,150 @@ function compileArrayShift(
   // Return result (default value if empty, shifted value if non-empty)
   fctx.body.push({ op: "local.get", index: resultTmp });
   return resultType;
+}
+
+/**
+ * arr.unshift(...items) -> O(n) in-place: grow if needed, shift existing
+ * elements right by argCount, write items into [0..argCount), bump length.
+ * Returns the new length. The mirror of shift; §23.1.3.34.
+ *
+ * #1966: previously `unshift` was not in ARRAY_METHODS at all, so it fell
+ * through to the host-import generic path which never wrote the mutation back
+ * to the WasmGC vec — a silent no-op (host) / corruption (standalone). This is
+ * the native lowering.
+ */
+function compileArrayUnshift(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  // 0-arg unshift: no-op, return current length.
+  if (callExpr.arguments.length === 0) {
+    const vecTmp0 = allocLocal(fctx, `__arr_unsft_vec_${fctx.locals.length}`, {
+      kind: "ref_null",
+      typeIdx: vecTypeIdx,
+    });
+    compileExpression(ctx, fctx, propAccess.expression);
+    fctx.body.push({ op: "local.tee", index: vecTmp0 });
+    emitReceiverNullGuard(ctx, fctx, vecTmp0, propAccess.expression);
+    fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+    if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+    return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  }
+
+  const argCount = callExpr.arguments.length;
+  const vecTmp = allocLocal(fctx, `__arr_unsft_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  const dataTmp = allocLocal(fctx, `__arr_unsft_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
+  const lenTmp = allocLocal(fctx, `__arr_unsft_len_${fctx.locals.length}`, { kind: "i32" });
+  const newCapTmp = allocLocal(fctx, `__arr_unsft_ncap_${fctx.locals.length}`, { kind: "i32" });
+  const newDataTmp = allocLocal(fctx, `__arr_unsft_ndata_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: arrTypeIdx,
+  });
+
+  // Compile receiver -> vec ref
+  compileExpression(ctx, fctx, propAccess.expression);
+  fctx.body.push({ op: "local.tee", index: vecTmp });
+  emitReceiverNullGuard(ctx, fctx, vecTmp, propAccess.expression);
+
+  // Get length
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.set", index: lenTmp });
+
+  // Get data array
+  fctx.body.push({ op: "local.get", index: vecTmp });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+  fctx.body.push({ op: "local.set", index: dataTmp });
+
+  // Capacity check: len + argCount > capacity? If so, allocate a new buffer and
+  // copy the existing elements directly into their shifted destination
+  // (data[0..len] -> newData[argCount..argCount+len]); otherwise array.copy
+  // in place (overlapping copy is memmove-correct).
+  fctx.body.push({ op: "local.get", index: dataTmp });
+  fctx.body.push({ op: "array.len" });
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "i32.const", value: argCount });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "i32.lt_s" }); // capacity < len + argCount
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      // newCap = max((len + argCount) * 2, 4)
+      { op: "local.get", index: lenTmp } as Instr,
+      { op: "i32.const", value: argCount } as Instr,
+      { op: "i32.add" } as Instr,
+      { op: "i32.const", value: 1 } as Instr,
+      { op: "i32.shl" } as Instr,
+      { op: "i32.const", value: 4 } as Instr,
+      { op: "local.get", index: lenTmp } as Instr,
+      { op: "i32.const", value: argCount } as Instr,
+      { op: "i32.add" } as Instr,
+      { op: "i32.const", value: 1 } as Instr,
+      { op: "i32.shl" } as Instr,
+      { op: "i32.const", value: 4 } as Instr,
+      { op: "i32.gt_s" } as Instr,
+      { op: "select" } as Instr,
+      { op: "local.set", index: newCapTmp } as Instr,
+
+      // newData = array.new_default(newCap)
+      { op: "local.get", index: newCapTmp } as Instr,
+      { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+      { op: "local.set", index: newDataTmp } as Instr,
+
+      // newData[argCount .. argCount+len] = data[0..len]
+      { op: "local.get", index: newDataTmp } as Instr,
+      { op: "i32.const", value: argCount } as Instr,
+      { op: "local.get", index: dataTmp } as Instr,
+      { op: "i32.const", value: 0 } as Instr,
+      { op: "local.get", index: lenTmp } as Instr,
+      { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+
+      // Update vec struct data field + local pointer
+      { op: "local.get", index: vecTmp } as Instr,
+      { op: "local.get", index: newDataTmp } as Instr,
+      { op: "ref.as_non_null" } as Instr,
+      { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+      { op: "local.get", index: newDataTmp } as Instr,
+      { op: "local.set", index: dataTmp } as Instr,
+    ],
+    else: [
+      // In-place right shift: data[argCount .. argCount+len] = data[0..len].
+      // array.copy is memmove-safe for overlapping ranges.
+      { op: "local.get", index: dataTmp } as Instr,
+      { op: "i32.const", value: argCount } as Instr,
+      { op: "local.get", index: dataTmp } as Instr,
+      { op: "i32.const", value: 0 } as Instr,
+      { op: "local.get", index: lenTmp } as Instr,
+      { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+    ],
+  } as Instr);
+
+  // Write the new elements into data[0..argCount) (compile-time unrolled).
+  for (let i = 0; i < argCount; i++) {
+    fctx.body.push({ op: "local.get", index: dataTmp });
+    fctx.body.push({ op: "i32.const", value: i });
+    compileExpression(ctx, fctx, callExpr.arguments[i]!, elemType);
+    fctx.body.push({ op: "array.set", typeIdx: arrTypeIdx });
+  }
+
+  // Update length: vec.length = len + argCount
+  fctx.body.push({ op: "local.get", index: vecTmp });
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "i32.const", value: argCount });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+
+  // Return new length (i32 in fast mode, f64 otherwise).
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "i32.const", value: argCount });
+  fctx.body.push({ op: "i32.add" });
+  if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+  return ctx.fast ? { kind: "i32" } : { kind: "f64" };
 }
 
 /**

--- a/tests/issue-1966.test.ts
+++ b/tests/issue-1966.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #1966: Array.prototype.unshift mutates the array in place (§23.1.3.34) —
+// prepend the items, shift the rest right, return the new length. It was never
+// registered in ARRAY_METHODS, so it fell through to the host-import generic
+// path that does not write the mutation back to the WasmGC vec: a silent no-op
+// (host mode) / corruption (standalone). This adds the native lowering and
+// includes unshift in the MUTATING write-back set.
+
+async function evalNum(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+
+describe("#1966 Array.prototype.unshift", () => {
+  it("prepends a single element and grows the array", async () => {
+    expect(await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); return a.length; }`)).toBe(
+      3,
+    );
+    expect(await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); return a[0]; }`)).toBe(1);
+    expect(await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); return a[1]; }`)).toBe(2);
+    expect(await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); return a[2]; }`)).toBe(3);
+  });
+
+  it("returns the new length", async () => {
+    expect(await evalNum(`export function test(): number { const a = [2, 3]; return a.unshift(1); }`)).toBe(3);
+  });
+
+  it("interacts correctly with shift (the original repro)", async () => {
+    // [2,3] -> unshift(1) -> [1,2,3] -> shift() returns 1, leaving [2,3]
+    expect(
+      await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); return a.shift() as number; }`),
+    ).toBe(1);
+    expect(
+      await evalNum(`export function test(): number { const a = [2, 3]; a.unshift(1); a.shift(); return a[0]; }`),
+    ).toBe(2);
+  });
+
+  it("prepends multiple elements in order", async () => {
+    expect(await evalNum(`export function test(): number { const a = [3]; a.unshift(1, 2); return a.length; }`)).toBe(
+      3,
+    );
+    expect(await evalNum(`export function test(): number { const a = [3]; a.unshift(1, 2); return a[0]; }`)).toBe(1);
+    expect(await evalNum(`export function test(): number { const a = [3]; a.unshift(1, 2); return a[1]; }`)).toBe(2);
+    expect(await evalNum(`export function test(): number { const a = [3]; a.unshift(1, 2); return a[2]; }`)).toBe(3);
+  });
+
+  it("unshifts into an empty array", async () => {
+    expect(await evalNum(`export function test(): number { const a: number[] = []; a.unshift(5); return a[0]; }`)).toBe(
+      5,
+    );
+    expect(
+      await evalNum(`export function test(): number { const a: number[] = []; a.unshift(5); return a.length; }`),
+    ).toBe(1);
+  });
+
+  it("no-arg unshift is a no-op returning the current length", async () => {
+    expect(await evalNum(`export function test(): number { const a = [1, 2, 3]; return a.unshift(); }`)).toBe(3);
+    expect(await evalNum(`export function test(): number { const a: number[] = []; return a.unshift(); }`)).toBe(0);
+  });
+
+  it("repeated unshifts keep order across reallocation", async () => {
+    expect(
+      await evalNum(
+        `export function test(): number { const a = [5]; a.unshift(1); a.unshift(2); a.unshift(3); return a[0] * 100 + a[3]; }`,
+      ),
+    ).toBe(305); // [3,2,1,5] -> 3*100 + 5
+  });
+
+  it("mutates a module-global array (write-back path)", async () => {
+    expect(await evalNum(`const g = [2, 3]; export function test(): number { g.unshift(1); return g.length; }`)).toBe(
+      3,
+    );
+    expect(await evalNum(`const g = [2, 3]; export function test(): number { g.unshift(1); return g[0]; }`)).toBe(1);
+    expect(await evalNum(`const g = [2, 3]; export function test(): number { g.unshift(1); return g[2]; }`)).toBe(3);
+  });
+
+  it("does not regress push / pop / shift on the same array", async () => {
+    expect(
+      await evalNum(
+        `export function test(): number { const a = [1]; a.push(2); a.unshift(0); a.shift(); a.pop(); return a[0]; }`,
+      ),
+    ).toBe(1); // [1]->[1,2]->[0,1,2]->[1,2]->[1]
+  });
+});


### PR DESCRIPTION
## Summary

`Array.prototype.unshift` was not registered in `ARRAY_METHODS`, so it never
reached the WasmGC-native dispatch — it fell through to the host-import generic
path, which operates on a JS-array view and never wrote the mutation back to the
underlying vec. Result: `a.unshift(1)` was a **silent no-op** (host mode) / left
the array **corrupt** (standalone, where a subsequent `a.shift()` returned
`"[object Object]"`).

Added `compileArrayUnshift` (§23.1.3.34):

- grow the buffer if `len + argCount` exceeds capacity (copying existing
  elements straight into their shifted destination),
- otherwise right-shift in place via memmove-safe `array.copy`,
- write the new items into `[0..argCount)`, bump length, return the new length.

It's the mirror of `compileArrayShift`, modelled on `compileArrayPush`'s growth
path. Registered `"unshift"` in `ARRAY_METHODS` (enables both `a.unshift(...)`
and the `Array.prototype.unshift.call(a, ...)` shape) and in the `MUTATING`
write-back set (so a module-global receiver's proxied temp is stored back).
Audited `MUTATING` while here — the `to*` variants and slice/concat/map/filter
are non-mutating and correctly excluded.

## Repro (now matches Node in both modes)

`const a = [2,3]; a.unshift(1); a.shift();`

| | Before | After |
|---|---|---|
| host: `a.unshift(1)` | no-op, length stays 2 | `[1,2,3]`, length 3 |
| standalone: after `shift()` | array `[3,3]`, shift → `"[object Object]"` | shift → `1`, array `[2,3]` |

## Tests

`tests/issue-1966.test.ts` — 9 equivalence cases (single/multi prepend, return
value, shift interplay, empty array, no-arg no-op, reallocation order, global
write-back, push/pop/shift non-regression). Verified in host and standalone
(WASI) modes with numeric and string elements. Related suites green
(array-push-pop, array-prototype-methods, global-index-shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)