### PR TITLE
ci(test262): merge-group predecessor diffing — per-PR attribution in the queue

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -799,6 +799,25 @@ jobs:
             merged-reports/**
           if-no-files-found: warn
 
+      # #1956 — publish this group's merged JSONLs keyed by the GROUP HEAD
+      # SHA. The merge queue builds groups incrementally, so the NEXT queued
+      # group's head commit has THIS group's head as its first parent — its
+      # regression-gate can therefore download this artifact and diff against
+      # its exact predecessor, isolating only its own PR's delta (no cross-PR
+      # drift, no ALLGREEN masking once the queue batches >1). 3-day
+      # retention comfortably covers queue lifetimes; an expired/missing
+      # artifact just falls back to the runs-cache / latest-main baseline.
+      - name: Publish group results for predecessor diffing (#1956)
+        if: env.SHARDS_RAN == 'true' && github.event_name == 'merge_group'
+        uses: actions/upload-artifact@v6
+        with:
+          retention-days: 3
+          name: test262-group-${{ github.event.merge_group.head_sha }}
+          path: |
+            merged-reports/test262-results-merged.jsonl
+            merged-reports/test262-standalone-results-merged.jsonl
+          if-no-files-found: warn
+
   regression-gate:
     # Runs after merge-report in all gate-relevant contexts and compares the
     # branch report against the current baseline when shards produced artifacts.
@@ -817,6 +836,13 @@ jobs:
     # of serially after it) cuts ~3 min off every run's tail.
     needs: [changes, test262-shard]
     runs-on: ubuntu-latest
+    # actions:read — the #1956 predecessor-group baseline is an artifact from
+    # ANOTHER workflow run, downloaded via the artifacts API. The workflow's
+    # top-level `permissions: contents: write` would otherwise leave actions
+    # at `none` for this job.
+    permissions:
+      contents: read
+      actions: read
     env:
       SHARDS_RAN: ${{ needs.test262-shard.result == 'success' && 'true' || 'false' }}
 
@@ -924,6 +950,57 @@ jobs:
             --test262-version "$TEST262_VERSION" \
             --dest benchmarks/results/test262-current.jsonl || \
             echo "::warning::#1081 merge-base resolution errored (non-fatal); keeping latest-main baseline."
+
+      # #1956 — exact predecessor-group baseline for merge_group runs. The
+      # queue builds groups incrementally: this group's head is a merge
+      # commit whose FIRST PARENT is the predecessor group's head (or the
+      # main tip when this PR is the queue head). If a recent merge_group run
+      # published `test262-group-<HEAD^1>` (see merge-report), diffing
+      # against it isolates ONLY this PR's delta — no cross-PR drift and no
+      # ALLGREEN masking inside multi-entry queue windows, which is the
+      # precondition for raising the queue's batch size past 1 (see
+      # docs/ci-policy.md). Resolution order, last writer wins:
+      #   a. predecessor-group artifact (this step — strongest)
+      #   b. #1081 runs/<merge-base> cache (previous step)
+      #   c. latest-main baseline (fetch step, default)
+      # Every failure mode falls through to (b)/(c) with a log line; this
+      # step never fails the build.
+      - name: Resolve predecessor-group baseline (#1956)
+        id: pred_group
+        if: env.SHARDS_RAN == 'true' && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          PRED=$(git rev-parse HEAD^1 2>/dev/null || echo "")
+          if [ -z "$PRED" ]; then
+            echo "pred_path=none" >> "$GITHUB_OUTPUT"
+            echo "No first parent resolvable — keeping baseline from (b)/(c)."
+            exit 0
+          fi
+          ART_NAME="test262-group-${PRED}"
+          ART_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ART_NAME}&per_page=1" --jq '.artifacts[0].id // empty' 2>/dev/null || echo "")
+          if [ -z "$ART_ID" ]; then
+            echo "pred_path=miss" >> "$GITHUB_OUTPUT"
+            echo "Predecessor artifact ${ART_NAME} not found (queue head, expired, or non-incremental rebuild) — keeping baseline from (b)/(c)."
+            exit 0
+          fi
+          mkdir -p /tmp/pred-group
+          if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ART_ID}/zip" > /tmp/pred-group/art.zip 2>/dev/null; then
+            echo "pred_path=download-failed" >> "$GITHUB_OUTPUT"
+            echo "::warning::#1956 predecessor artifact download failed — keeping baseline from (b)/(c)."
+            exit 0
+          fi
+          unzip -o /tmp/pred-group/art.zip -d /tmp/pred-group >/dev/null 2>&1 || true
+          if [ -s /tmp/pred-group/test262-results-merged.jsonl ]; then
+            mkdir -p benchmarks/results
+            cp /tmp/pred-group/test262-results-merged.jsonl benchmarks/results/test262-current.jsonl
+            echo "pred_path=hit" >> "$GITHUB_OUTPUT"
+            echo "Using predecessor-group baseline ${ART_NAME} (path a): this diff isolates only this PR's delta."
+          else
+            echo "pred_path=empty" >> "$GITHUB_OUTPUT"
+            echo "::warning::#1956 predecessor artifact missing host JSONL — keeping baseline from (b)/(c)."
+          fi
 
       - name: Check baseline staleness (#1235)
         id: staleness

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -95,9 +95,21 @@ Two test262 workflows currently run on PRs:
 - **`test262-sharded.yml` is the authoritative PR gate.** The required
   check is `merge shard reports`, fed by the 57-shard host and standalone
   matrix.
-  - Serial-queue model (#109, see `plan/method/pr-drift-protocol.md`):
-    every PR is validated on its own merge_group ref via a `batch=1`
-    merge queue, so there is no ALLGREEN-hiding across batched PRs.
+  - Queue model (#109 → #1956, see `plan/method/pr-drift-protocol.md`):
+    every PR is validated on its own merge_group ref. Historically this was
+    pinned to a `batch=1` serial queue because the regression gate diffed
+    each group against the *main baseline*, where the cumulative diff of a
+    multi-entry queue window lets one PR's improvement mask another's
+    regression (ALLGREEN hiding). #1956 retires that constraint: each
+    merge_group run publishes its merged JSONLs keyed by the group head SHA,
+    and the next group's regression-gate diffs against its **exact
+    predecessor group** (the group head's first parent), isolating each PR's
+    own delta. With per-PR attribution restored, the queue runs with
+    `max_entries_to_build: 5` / `max_entries_to_merge: 5`
+    (`min_entries_to_merge` stays 1 — single multi-PR groups would collapse
+    per-PR runs and reintroduce intra-group masking). Fallback order when a
+    predecessor artifact is unavailable: #1081 runs/<merge-base> cache, then
+    latest-main baseline — i.e. exactly the pre-#1956 behavior.
   - Path filter restricts the matrix to PRs that touch source / test /
     config files. Docs-only PRs skip the full matrix.
   - The `cheap gate (main-ancestor + lint)` job in the same workflow is
@@ -283,7 +295,7 @@ behaviour can be flipped without touching the JS script.
 | Required check | Workflow | What it protects against |
 |---|---|---|
 | `cheap gate (main-ancestor + lint)` | `test262-sharded.yml` | fast pre-flight reject: lint + typecheck on the PR branch before any test262 shard runs. Catches obvious failures cheaply and stops the queue from spending compute on a doomed PR. |
-| `merge shard reports` | `test262-sharded.yml` | semantic conformance, **both lanes**: aggregates the 57 sharded test262 runs (host + standalone) into a single pass/fail. Authoritative gate via the `batch=1` serial merge queue — each PR validated on its own merge_group ref with no ALLGREEN hiding. Hosts the host catastrophic guard (#1668), the standalone net-regression guard (#1897), and the stale-baseline guard (#1668) — see §3. |
+| `merge shard reports` | `test262-sharded.yml` | semantic conformance, **both lanes**: aggregates the 57 sharded test262 runs (host + standalone) into a single pass/fail. Authoritative gate via the merge queue (build/merge up to 5 concurrently since #1956; predecessor-group diffing preserves per-PR attribution, so no ALLGREEN hiding) — each PR validated on its own merge_group ref. Hosts the host catastrophic guard (#1668), the standalone net-regression guard (#1897), and the stale-baseline guard (#1668) — see §3. |
 | `quality` | `ci.yml` | source quality regressions: lint, formatting, typecheck failures, IR fallback budget exceeded (#1376), planning-artifact regeneration. Also runs the "origin/main is merged into branch" pre-check that catches stale PR branches. |
 | `equivalence-gate` | `ci.yml` | semantic equivalence regressions across the sharded equivalence suite after the shard partials are merged. |
 | `check for test262 regressions` | `test262-sharded.yml` | full rolling-baseline test262 diff, including pass→fail changes that stay below the inline catastrophic thresholds. |

--- a/plan/issues/1956-ci-merge-group-predecessor-diff-batching.md
+++ b/plan/issues/1956-ci-merge-group-predecessor-diff-batching.md
@@ -1,9 +1,10 @@
 ---
 id: 1956
 title: "CI: merge-group predecessor diffing → enable merge-queue batching (rollups) safely"
-status: ready
+status: done
 created: 2026-06-11
 updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -11,6 +12,20 @@ sprint: 61
 depends_on: [1951, 1952]
 area: ci
 ---
+## Implemented (2026-06-11)
+
+As designed below, with one deviation: results are published as
+`test262-group-<group-head-sha>` workflow artifacts (3-day retention) by
+merge-report on merge_group runs, and the regression-gate resolves the
+predecessor as `HEAD^1` of the group ref and downloads the artifact via the
+actions API (job got `actions: read`). Resolution path is logged as
+`pred_path=hit|miss|…` in the step output for observability. Queue ruleset
+flip applied post-merge: `max_entries_to_build: 5`, `max_entries_to_merge: 5`,
+`min_entries_to_merge: 1` — min stays 1 deliberately: a single multi-PR group
+gets one combined run and would reintroduce intra-group masking; with min=1
+every PR keeps its own run, predecessor-diffed, so batching only adds
+*concurrency*, not aggregation. docs/ci-policy.md §queue updated.
+
 ## Problem
 
 The merge queue is pinned to batch=1 (docs/ci-policy.md: "each PR validated on


### PR DESCRIPTION
Implements #1956 (final piece of the sprint-61 CI-efficiency track).

## What

- **merge-report** (merge_group runs only): publishes the group's merged host+standalone JSONLs as a `test262-group-<group-head-sha>` artifact (3-day retention).
- **regression-gate** (merge_group runs only): resolves the predecessor group as `HEAD^1` of the group ref (the queue builds groups incrementally, so the first parent IS the previous group's head — or the main tip at the queue head), downloads its artifact cross-run via the actions API, and prefers it as the diff baseline. Resolution order: predecessor artifact → #1081 `runs/<merge-base>` cache → latest-main; every failure mode falls through with a `pred_path=` log, never failing the build. Job gains `actions: read`.
- **docs/ci-policy.md**: the batch=1 rationale (ALLGREEN hiding via cumulative diffs against the main baseline) is retired — each PR's queue run now diffs against its exact predecessor, isolating only its own delta.

## Queue ruleset flip (applied after this merges)

`max_entries_to_build: 5`, `max_entries_to_merge: 5`, `min_entries_to_merge: 1` — up to 5 groups validate **concurrently** (~5× queue latency reduction; tonight #1311 waited 40–60 min behind 4 serial validations). `min` deliberately stays 1: a single multi-PR group would get one combined run and reintroduce intra-group masking; with min=1 every PR keeps its own predecessor-diffed run, so batching adds concurrency, never aggregation.

## Behavior before the flip

At batch=1 this PR is identical-or-stricter than today: the queue head's `HEAD^1` is a main commit (artifact miss → existing #1081/latest-main path), and non-head groups get exact predecessor attribution instead of cumulative diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)