### PR TITLE
fix(#2073): standalone mixed-primitive == is pure Wasm, no __host_loose_eq

### DIFF
--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -32,6 +32,7 @@ import {
 import { ensureExternIsUndefinedImport, ensureLateImport } from "./expressions/late-imports.js";
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
+import { emitNativeParseNumber } from "./parse-number-native.js";
 import { addStringImports, addUnionImports, resolveNativeTypeAnnotation, resolveWasmType } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
@@ -864,6 +865,47 @@ export function compileBinaryExpression(
       (leftIsStr && rightIsBool) ||
       (leftIsBool && rightIsStr)
     ) {
+      // (#2073) Standalone / WASI has no JS host, so the `__host_loose_eq`
+      // delegation below leaks an unsatisfiable `env::__host_loose_eq` import
+      // and the module fails to instantiate. Compile these mixed string⇄number
+      // and string⇄boolean `==` comparisons to a pure-Wasm numeric compare:
+      // per §7.2.15 IsLooselyEqual, a string-vs-Number/Boolean comparison
+      // applies ToNumber to BOTH sides (Number→Number, Boolean→ToNumber, and
+      // §7.2.15 step 4/6 ToNumber the string), then compares numerically. The
+      // native `__str_to_number` scanner is §7.1.4.1 StringToNumber (NaN for a
+      // non-numeric string, 0 for empty), and `f64.eq` reproduces +0===-0 and
+      // NaN≠NaN — so `"1"==1`, `0==""`, `false==""`, `"x"==1` all match Node.
+      const noJsHost = ctx.standalone === true || ctx.wasi === true;
+      if (noJsHost && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+        // Ensure the native StringToNumber scanner exists. Its signature is
+        // `(externref) -> f64`; it converts the externref back to ref $AnyString
+        // internally (any.convert_extern + ref.cast).
+        if (!ctx.funcMap.has("__str_to_number")) {
+          emitNativeParseNumber(ctx, new Set(["__str_to_number"]));
+        }
+        const strToNumIdx = ctx.funcMap.get("__str_to_number");
+        if (strToNumIdx !== undefined) {
+          // Emit ToNumber(operand) as f64 for a string / number / boolean side.
+          const emitToNumber = (operand: ts.Expression, isStr: boolean, isBool: boolean): void => {
+            if (isStr) {
+              // native string ref → externref → __str_to_number → f64
+              compileExpression(ctx, fctx, operand);
+              fctx.body.push({ op: "extern.convert_any" } as Instr);
+              fctx.body.push({ op: "call", funcIdx: strToNumIdx });
+            } else if (isBool) {
+              compileExpression(ctx, fctx, operand);
+              fctx.body.push({ op: "f64.convert_i32_s" });
+            } else {
+              compileExpression(ctx, fctx, operand, { kind: "f64" });
+            }
+          };
+          emitToNumber(expr.left, leftIsStr, leftIsBool);
+          emitToNumber(expr.right, rightIsStr, rightIsBool);
+          fctx.body.push({ op: isLooseEq ? "f64.eq" : "f64.ne" });
+          return { kind: "i32" };
+        }
+      }
+
       compileExpression(ctx, fctx, expr.left);
       if (!leftIsStr) {
         coerceType(ctx, fctx, leftIsBool ? { kind: "i32" } : { kind: "f64" }, { kind: "externref" });

--- a/tests/issue-2073.test.ts
+++ b/tests/issue-2073.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2073 — standalone `==` between a string and a number/boolean leaked an
+// `env::__host_loose_eq` import.
+//
+// `compileBinaryExpression`'s mixed-primitive loose-equality branch routed
+// `"1" == 1`, `0 == ""`, `false == ""`, etc. through the JS-host
+// `__host_loose_eq` import unconditionally. Under `--target standalone` (and
+// WASI) there is no JS host, so the module carried an unsatisfiable
+// `env::__host_loose_eq` import and failed `WebAssembly.instantiate` with no
+// env object.
+//
+// Fix: in standalone / WASI, compile these comparisons to a pure-Wasm numeric
+// compare per §7.2.15 IsLooselyEqual — ToNumber both sides (the native
+// `__str_to_number` §7.1.4.1 scanner for the string, `f64.convert_i32_s` for
+// the boolean) then `f64.eq` / `f64.ne`. JS-host mode is unchanged.
+//
+// (The any/any half of the original task — #2081 — is tracked separately; it
+// depends on type-aware AnyValue boxing, #2072/#2080.)
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+// Compile `return <expr>;` under --target standalone, assert ZERO env imports
+// (the leak this fixes), instantiate with no host object, and read the boolean.
+async function standaloneEq(expr: string): Promise<boolean> {
+  const r = await compile(`export function test(): boolean { return ${expr}; }`, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(envImports, `standalone leaked env imports: ${envImports.join(", ")}`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return Boolean((instance.exports as { test(): number }).test());
+}
+
+describe("#2073 standalone mixed-primitive == is pure Wasm (no __host_loose_eq)", () => {
+  it("string == number coerces the string via ToNumber", async () => {
+    expect(await standaloneEq(`("1" as string) == (1 as number)`)).toBe(true);
+    expect(await standaloneEq(`(1 as number) == ("1" as string)`)).toBe(true);
+    expect(await standaloneEq(`("1.5" as string) == (1.5 as number)`)).toBe(true);
+    expect(await standaloneEq(`("-3" as string) == (-3 as number)`)).toBe(true);
+  });
+
+  it("StringToNumber semantics: empty/whitespace → 0, hex prefix, non-numeric → NaN", async () => {
+    expect(await standaloneEq(`(0 as number) == ("" as string)`)).toBe(true); // Number("") === 0
+    expect(await standaloneEq(`(5 as number) == ("  5  " as string)`)).toBe(true); // trimmed
+    expect(await standaloneEq(`("0x10" as string) == (16 as number)`)).toBe(true); // hex
+    expect(await standaloneEq(`("x" as string) == (1 as number)`)).toBe(false); // NaN != 1
+    expect(await standaloneEq(`("NaN" as string) == (0 as number)`)).toBe(false);
+  });
+
+  it("string == boolean coerces both via ToNumber", async () => {
+    expect(await standaloneEq(`(false as boolean) == ("" as string)`)).toBe(true); // 0 == 0
+    expect(await standaloneEq(`("" as string) == (false as boolean)`)).toBe(true);
+    expect(await standaloneEq(`("1" as string) == (true as boolean)`)).toBe(true); // 1 == 1
+    expect(await standaloneEq(`("2" as string) == (true as boolean)`)).toBe(false); // 2 != 1
+  });
+
+  it("!= negates correctly", async () => {
+    expect(await standaloneEq(`("1" as string) != (1 as number)`)).toBe(false);
+    expect(await standaloneEq(`("abc" as string) != (1 as number)`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Under `--target standalone` (and WASI), a loose `==` between a string and a
number/boolean leaked an unsatisfiable `env::__host_loose_eq` import, so the
module failed `WebAssembly.instantiate` with no env object:

```ts
("1" as string) == (1 as number)   // standalone: Import "env" is not an object
```

## Root cause

`compileBinaryExpression`'s mixed-primitive loose-equality branch
(`src/codegen/binary-ops.ts:861`) routed `string == number`,
`number == string`, `string == boolean`, and `boolean == string` through the
JS-host `__host_loose_eq` import **unconditionally** — no standalone fallback.

## Fix

In standalone / WASI, compile these comparisons to a pure-Wasm numeric compare
per §7.2.15 IsLooselyEqual: ToNumber **both** sides — the native
`__str_to_number` (§7.1.4.1 StringToNumber) scanner for the string,
`f64.convert_i32_s` for the boolean — then `f64.eq` / `f64.ne`.

StringToNumber gives `NaN` for a non-numeric string and `0` for empty/
whitespace, and `f64.eq` reproduces `+0 === -0` and `NaN ≠ NaN`, so `"1"==1`,
`0==""`, `false==""`, `"  5  "==5`, `"0x10"==16`, `"1.5"==1.5`, `"x"==1` all
match Node with **zero env imports**. JS-host mode keeps the `__host_loose_eq`
delegation unchanged.

## Scope (task split)

This is the **typed-primitive half** of the original #2073/#2081 task. The
`any`/`any` half (**#2081** — `const a:any="1"; const b:any=1; a==b`) depends on
type-aware AnyValue boxing (#2072/#2080, routed to senior-dev) and is tracked
separately; this PR does not touch it.

## Tests

`tests/issue-2073.test.ts` (4 tests): string⇄number, string⇄boolean,
StringToNumber edge cases (empty / whitespace / hex / non-numeric / `"NaN"`),
and `!=` negation — each asserting **zero `env` imports** and a no-host
instantiation. `#1134` (host loose-eq) and `#1776` (standalone equality) suites
still pass; JS-host mode verified unchanged.

## Issue files

Issue #2073 is part of an unmerged spec-conformance batch not yet on any branch,
so its `status: done` flip is noted here rather than committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)