### PR TITLE
fix(#1712): fnctor two-shape unification — instance types resolve to externref, member calls go dynamic

### DIFF
--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -364,3 +364,22 @@ never becomes true. Suggested approach: instrument the host bridge with an
 invocation counter per method name (env-gated) and run one fixture to see
 which method spins; or precompile acorn once to .tmp and drive
 `parse` with a 1-char input under a watchdog.
+
+**Tokenizer-loop root cause pinned (`.tmp/dbg28.mts`, host-bridge call
+counter under a 200k watchdog):** for input `var x = 1;`, `parseStatement`
+executes 9,090 times — each iteration COMPLETES (its statement is pushed:
+`push` 9,090, `parseExpressionStatement` 9,089), but `parseTopLevel`'s
+guard `this.type !== types$1.eof` never becomes false. This is a token-
+object IDENTITY failure across dynamic reads: TokenType objects are
+compared with `!==` by reference, and the two operands (`this.type` via
+the instance read path; `types$1.eof` via module-global + property read)
+evidently don't resolve to the SAME reference — one side likely a
+`_wrapForHost` proxy / boxed copy and the other the raw struct (the
+`_hostProxyCache` makes proxies identity-stable per struct, so the bug is
+a path that returns the RAW value while the other returns the proxy, or
+vice versa). Also suspicious: every statement parses as an
+ExpressionStatement (`isLet` truthiness / keyword-token recognition may
+have the same identity/equality defect). Next slice: make all dynamic
+read paths return ONE canonical representation per struct (always raw, or
+always cached proxy) before values re-enter Wasm, and check the strict-
+equality lowering for externref operands unwraps proxies on both sides.

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -316,3 +316,38 @@ the member call takes the STATIC vec path which UNGUARDED-casts the
 externref field value to the checker-inferred vec type → "illegal cast".
 Needs the same guarded-cast + dynamic-fallback treatment in the
 property-access lowering that feeds compileArrayPush.
+
+### Two-shape slice 2026-06-11 (fable-1712c, branch issue-1712-two-shape, stacked on issue-1712-vec-mutators)
+
+The original Blocker-2 two-shape trap is FIXED — three coordinated changes
+(the "steer member-call split together with the type change" the failed
+attempt called for, but resolved to EXTERNREF instead of the ctor struct):
+
+1. `resolveWasmType` (src/codegen/index.ts, before the named-struct arm):
+   fnctor instance types resolve to EXTERNREF — the checker shape is never
+   synthesized. Gated to instance shapes only (`getCallSignatures().length
+   === 0` keeps the function VALUE on its closure-wrapper resolution),
+   JS-host only. This makes fnctor instances flow dynamically end-to-end.
+2. `compileCallablePropertyCall` (calls-closures.ts): when the receiver is
+   an fnctor instance, route the member call through
+   `emitWrapperDynamicMethodCall` (host bridge) instead of the
+   checker-shape field-read path (which trapped struct.get-on-null).
+3. `emitWrapperDynamicMethodCall` (calls.ts, exported now): grew args
+   support (__js_array_push packing, JS-host).
+4. Runtime `_wrapForHost.safeGetField`: a nullish `__sget_<name>` result is
+   a MISS, not a hit — the per-shape dispatcher returns undefined for
+   shapes that don't carry the field, which short-circuited the vivified-
+   prototype fallback (every prototype method was unreachable whenever the
+   checker shape had synthesized a same-named __sget export).
+
+Verified: `.tmp/dbg16/25/26` (E4/M-series) green, G/H probes unchanged,
+tests/issue-1712-dynamic-dispatch.test.ts extended (8 green), targeted
+suites 0 new fails (19 pre-existing env fails).
+
+**acorn status: parse() now EXECUTES into the tokenizer and LOOPS FOREVER
+(dogfood times out after compile+validate).** Next root-cause: likely
+instance field WRITES through dynamic dispatch (`this.pos = ...` /
+`+= `) not writing back to the struct (so the scan position never
+advances), or a loop-condition coercion. Probe direction: minimal
+`Parser.prototype.step = function(){ this.pos = this.pos + 1 }` write-back
+check, then bisect acorn's nextToken loop.

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -279,3 +279,40 @@ existing `__vec_len`/`__vec_get`/`__vec_set_byte` precedent,
 chains (grow = alloc new $arr + struct.set, fields are mutable), then route
 array methods on vec receivers there from `__extern_method_call`. The
 two-shape struct issue (previous section) remains relevant after that.
+
+### Vec-mutator slice 2026-06-11 (fable-1712c, branch issue-1712-vec-mutators, stacked on issue-1712-dyn-dispatch)
+
+Fixes the `push is not a function` blocker (acorn `enterScope`:
+`this.scopeStack.push(new Scope(flags))`) — THREE stacked defects:
+
+1. **No host-side vec mutation**: new Wasm-side exports in
+   `_emitVecAccessExportsInner` (`src/codegen/index.ts`): `__is_vec`,
+   `__vec_mut_supported`, `__vec_push`, `__vec_pop` — per-vec-type ref.test
+   dispatch, grow = compileArrayPush discipline (newCap = max((len+1)*2,4),
+   array.new_default + array.copy + struct.set). Elem coverage: externref
+   always; f64/i32 when __box_number/__unbox_number imported; others return
+   the -1/0 sentinel (runtime falls through to its fail-loud TypeError).
+2. **closureBridge wrapped DATA fields**: `_wrapForHost`'s get trap bridged
+   ANY struct field into a callable (`closureBridge`, #1090) — acorn's
+   `this.scopeStack` read returned a JS function. Vetoed via `__is_vec`
+   (positive discriminator; `__is_closure` can FALSE-POSITIVE on vecs whose
+   canonicalized layout collides with a closure capture struct).
+3. **Routing**: `__extern_method_call`'s not-a-function arm routes push/pop
+   on vec receivers through the new exports (raw args, not host proxies, so
+   Wasm-side element reads see structs; receiver unwrapped through both the
+   proxy map and `_wasmClosureWrapperTargets`).
+
+acorn now executes enterScope/exitScope; the chain stops at the NEXT
+blocker — a null-deref in `__closure_340` (the static `Parser.parse` body)
+right after `__fnctor_Parser_new` returns: this is the documented TWO-SHAPE
+instance trap (`new this(…).parse()` member call guard-casts the ctor-shape
+instance against the checker shape → null → struct.get). See the
+"fnctor instances have TWO irreconcilable struct shapes" analysis above —
+that is now the live front of the onion.
+
+Also KNOWN, pre-existing, NOT fixed here (`.tmp/dbg23.mts` L1/L2): when the
+TS checker CAN type the instance array field (TS-typed input, not acorn),
+the member call takes the STATIC vec path which UNGUARDED-casts the
+externref field value to the checker-inferred vec type → "illegal cast".
+Needs the same guarded-cast + dynamic-fallback treatment in the
+property-access lowering that feeds compileArrayPush.

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -351,3 +351,16 @@ instance field WRITES through dynamic dispatch (`this.pos = ...` /
 advances), or a loop-condition coercion. Probe direction: minimal
 `Parser.prototype.step = function(){ this.pos = this.pos + 1 }` write-back
 check, then bisect acorn's nextToken loop.
+
+**Correction (same session): the field-write-back hypothesis is DISPROVEN.**
+`.tmp/dbg27.mts` N-probes all pass: `this.pos = this.pos + 1` through a
+prototype method writes back (N1=2), a bounded `while (this.pos <
+this.input.length)` terminates correctly (N2), and compound `this.pos += n`
+works (N3). The acorn tokenizer infinite loop must be bisected INSIDE the
+loop instead — likely candidates: `charCodeAt`/`fullCharCodeAtPos` results
+through the dynamic path (NaN making no scanner branch match so `pos` never
+moves), `skipSpace` semantics, or a context/type-token comparison that
+never becomes true. Suggested approach: instrument the host bridge with an
+invocation counter per method name (env-gated) and run one fixture to see
+which method spins; or precompile acorn once to .tmp and drive
+`parse` with a 1-char input under a watchdog.

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -225,3 +225,57 @@ Open items for the next session:
     proto-method closure values to be reachable as globals at ctor time).
 - Probes live in `.tmp/repro2.mts` / `.tmp/dbg1.mts`–`.tmp/dbg15.mts`
   (dbg4–15 are the #1712b dispatch-bisection series).
+
+### Dynamic-dispatch slice 2026-06-11 (fable-1712c, branch issue-1712-dyn-dispatch)
+
+After the merge with main (#1320 closure-bridge reconcile), the live blocker
+chain shifted: all 5 fixtures failed `parse is not a function` BEFORE reaching
+the two-shape trap. Bisection (`.tmp/dbg17.mts`–`.tmp/dbg22.mts`) pinned and
+fixed FOUR stacked root causes (regression pin:
+`tests/issue-1712-dynamic-dispatch.test.ts`):
+
+1. **Static methods on fnctors unreachable** (`src/runtime.ts`,
+   `__extern_method_call`): a CALLABLE closure-struct receiver is wrapped by
+   `_wrapWasmClosureUnknownArity` into a bare JS function bridge with no view
+   of sidecar statics, so `Parser.parse(input)` threw. Fix: not-a-function arm
+   resolves through `_safeGet` on the RAW struct (sidecar → accessors →
+   vivified prototype) and applies with the raw closure struct as receiver —
+   which also makes `new this(…)` inside the static body see the ctor.
+2. **Non-closure-shaped callee trapped** (`src/codegen/expressions/calls.ts`,
+   `__callable_param_` dispatch ~8447): externref callee guard-cast against
+   ONE wrapper-struct shape; non-null mismatch (acorn's `var hasOwn =
+   Object.hasOwn || fn` → host builtin in a JS var) fell into `struct.get`
+   of null → "dereferencing a null pointer" inside `getOptions`. Fix: a
+   host-callable fallback arm — `if (cast-null && raw-non-null)` route
+   through `__call_function(callee, undefined, argsArray)` (JS-host only,
+   i64/v128 params bail). Buffers parked in `fctx.savedBodies` while
+   detached (blocker-1 shifter discipline).
+3. **`__call_function` arg marshaling** (`src/runtime.ts`): passed raw WasmGC
+   structs to host callees (`Object.hasOwn(struct, "a")` → false) and wrapped
+   closure callees at arity 0 (dropped args). Fix: `__extern_method_call`-style
+   wrapHostValue marshaling + `_maybeWrapCallableUnknownArity` + return
+   `_unwrapForHost`.
+4. **In-ctor prototype calls on `this`** (`src/codegen/expressions/new-super.ts`):
+   `__register_fnctor_instance` was emitted at the END of the synthesized
+   ctor, so acorn's `this.context = this.initialContext()` (inside the ctor)
+   missed the vivified prototype. Fix: moved to the ctor PROLOGUE (buffer-reach
+   note in the code comment).
+
+Verified: acorn's compiled `parse` now executes `getOptions` →
+`new this(…)` → `initialContext` correctly. Targeted suites
+(fn-constructor, prototype-chain, bind-call, illegal-cast-closures, …):
+identical pass/fail with and without the changes (19 pre-existing fails on
+the branch tip, 0 new).
+
+**NEXT blocker (root-caused, not fixed): host-side vec mutation.** The chain
+now stops at acorn's `enterScope`: `this.scopeStack.push(new Scope(flags))` →
+`push is not a function`. `this.scopeStack = []` compiles to a WasmGC vec
+struct stored in the ctor-shape field; dynamic dispatch hands the vec struct
+to `__extern_method_call`, but `_wrapForHost` has NO array facade and the
+host cannot grow a WasmGC array. Recommended fix direction (mirrors the
+existing `__vec_len`/`__vec_get`/`__vec_set_byte` precedent,
+`src/codegen/index.ts:3530+`): emit generic Wasm-side mutator exports
+(`__vec_push`, `__vec_pop`, `__vec_set`) with per-vec-type ref.test dispatch
+chains (grow = alloc new $arr + struct.set, fields are mutable), then route
+array methods on vec receivers there from `__extern_method_call`. The
+two-shape struct issue (previous section) remains relevant after that.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -20,7 +20,7 @@ import { coerceType, compileExpression, VOID_RESULT } from "../shared.js";
 import { emitGuardedFuncRefCast, emitGuardedRefCast, pushDefaultValue } from "../type-coercion.js";
 import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
-import { emitClosureCallArgcExtras, emitResetArgcExtras } from "./calls.js";
+import { emitClosureCallArgcExtras, emitResetArgcExtras, emitWrapperDynamicMethodCall } from "./calls.js";
 
 /** Compile a call to a closure variable: closureVar(args...) */
 export function compileClosureCall(
@@ -456,6 +456,36 @@ export function compileCallablePropertyCall(
   const methodName = ts.isPrivateIdentifier(propAccess.name)
     ? "__priv_" + propAccess.name.text.slice(1)
     : propAccess.name.text;
+
+  // (#1712) Function-style-constructor instances NEVER carry their prototype
+  // methods as struct fields: compileFnctorNew synthesizes the runtime
+  // instance struct from ctor `this.*` writes only, while the TS checker's
+  // shape (className here) models prototype-assigned methods as instance
+  // members. The guarded receiver cast below can therefore never match (the
+  // two shapes have no subtype relation) — the cast nulls out and the
+  // `struct.get` traps "dereferencing a null pointer" (acorn:
+  // `new this(options, input).parse()` in the static `Parser.parse`). Route
+  // the call through the dynamic host bridge instead, which resolves the
+  // method on the closure's vivified prototype (__register_fnctor_instance
+  // + _fnctorProtoLookup). JS-host mode only; the funcConstructorMap check
+  // covers already-compiled fnctors and the declaration check covers
+  // compile-order races (member call compiled before the first `new`).
+  if (!ctx.standalone && !ctx.wasi && !ts.isPrivateIdentifier(propAccess.name)) {
+    const recvTsType = ctx.checker.getTypeAtLocation(propAccess.expression);
+    const recvSym = recvTsType?.symbol;
+    const decl = recvSym?.valueDeclaration;
+    const isFnCtorInstance =
+      ctx.funcConstructorMap.has(className) ||
+      (recvSym?.name !== undefined && ctx.funcConstructorMap.has(recvSym.name)) ||
+      (!!decl &&
+        (ts.isFunctionDeclaration(decl) ||
+          ts.isFunctionExpression(decl) ||
+          (ts.isVariableDeclaration(decl) && !!decl.initializer && ts.isFunctionExpression(decl.initializer))));
+    if (isFnCtorInstance) {
+      const dyn = emitWrapperDynamicMethodCall(ctx, fctx, propAccess.expression, methodName, expr);
+      if (dyn !== null) return dyn;
+    }
+  }
 
   // Check if this property name is a struct field
   const structTypeIdx = ctx.structMap.get(className);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1074,11 +1074,12 @@ function sourceHasMethodReassignment(ctx: CodegenContext, anchor: ts.Node, metho
  * runtime imports cannot be registered (caller falls through to the
  * static path as a best-effort fallback).
  */
-function emitWrapperDynamicMethodCall(
+export function emitWrapperDynamicMethodCall(
   ctx: CodegenContext,
   fctx: FunctionContext,
   recvExpr: ts.Expression,
   methodName: string,
+  callExpr?: ts.CallExpression,
 ): ValType | null {
   // (#1888 Slice 2) Standalone routes __extern_method_call native, which reads
   // its args over a $ObjVec — build the (empty) args list with the native
@@ -1086,6 +1087,13 @@ function emitWrapperDynamicMethodCall(
   const arrNewIdx = ctx.standalone
     ? ensureObjVecBuilders(ctx).newIdx
     : ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+  // (#1712) Args support: when a call expression with arguments is supplied,
+  // pack them into the args array via __js_array_push. JS-host only — the
+  // standalone $ObjVec path stays empty-args until it grows a native push.
+  const wantArgs = callExpr !== undefined && callExpr.arguments.length > 0 && !ctx.standalone && !ctx.wasi;
+  const arrPushIdx = wantArgs
+    ? ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], [])
+    : undefined;
   const methodCallIdx = ensureLateImport(
     ctx,
     "__extern_method_call",
@@ -1094,6 +1102,7 @@ function emitWrapperDynamicMethodCall(
   );
   flushLateImportShifts(ctx, fctx);
   if (arrNewIdx === undefined || methodCallIdx === undefined) return null;
+  if (wantArgs && arrPushIdx === undefined) return null;
 
   // Compile receiver as externref.
   const recvType = compileExpression(ctx, fctx, recvExpr, { kind: "externref" });
@@ -1108,8 +1117,23 @@ function emitWrapperDynamicMethodCall(
   addStringConstantGlobal(ctx, methodName);
   fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
 
-  // Empty args array: __js_array_new() → externref.
-  fctx.body.push({ op: "call", funcIdx: arrNewIdx });
+  // Args array: __js_array_new() → externref (+ per-arg __js_array_push).
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__js_array_new") ?? arrNewIdx });
+  if (wantArgs) {
+    const argsArrLocal = allocLocal(fctx, `__dynm_args_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: argsArrLocal });
+    for (const argExpr of callExpr!.arguments) {
+      fctx.body.push({ op: "local.get", index: argsArrLocal });
+      const t = compileExpression(ctx, fctx, argExpr, { kind: "externref" });
+      if (t === null) {
+        fctx.body.push({ op: "ref.null.extern" });
+      } else if (t.kind !== "externref") {
+        coerceType(ctx, fctx, t, { kind: "externref" });
+      }
+      fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__js_array_push") ?? arrPushIdx! });
+    }
+    fctx.body.push({ op: "local.get", index: argsArrLocal });
+  }
 
   // Re-lookup methodCallIdx in case args compilation triggered shifts.
   const finalMcIdx = ctx.funcMap.get("__extern_method_call") ?? methodCallIdx;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8445,12 +8445,20 @@ function compileCallExpression(
 
           // Save closure ref to a local
           let closureLocal: number;
+          let rawCalleeLocal: number | undefined;
           if (innerResultType?.kind === "externref") {
             const closureRefType: ValType = {
               kind: "ref_null",
               typeIdx: matchedStructTypeIdx,
             };
             closureLocal = allocLocal(fctx, `__callable_param_${fctx.locals.length}`, closureRefType);
+            // (#1712) Keep the raw externref callee around for the host-callable
+            // fallback below. When the guarded struct cast nulls out (the callee
+            // is a host builtin like `Object.hasOwn`, a bound function, or a
+            // closure of a foreign struct shape), the call must dispatch through
+            // `__call_function` instead of trapping on `struct.get` of null.
+            rawCalleeLocal = allocLocal(fctx, `__callable_raw_${fctx.locals.length}`, { kind: "externref" });
+            fctx.body.push({ op: "local.tee", index: rawCalleeLocal });
             fctx.body.push({ op: "any.convert_extern" });
             emitGuardedRefCast(fctx, matchedStructTypeIdx);
             fctx.body.push({ op: "local.set", index: closureLocal });
@@ -8523,6 +8531,97 @@ function compileCallExpression(
             const argLocal = allocLocal(fctx, `__carg_${fctx.locals.length}`, padType);
             fctx.body.push({ op: "local.set", index: argLocal });
             argLocals.push(argLocal);
+          }
+
+          // (#1712) Host-callable fallback: when the callee arrived as externref
+          // and the guarded cast to the wrapper struct failed (closureLocal is
+          // null) while the raw value is non-null, the callee is callable but
+          // not a closure of the matched shape — a host builtin held in a JS
+          // variable (acorn's `var hasOwn = Object.hasOwn || function(…){…}`),
+          // a bound function, or a closure with a foreign struct layout. The
+          // struct.get below would trap "dereferencing a null pointer". Route
+          // that case through `__call_function(callee, undefined, argsArray)`
+          // instead. JS-host mode only — standalone/WASI keeps the existing
+          // (trapping) path since __call_function has no host there.
+          // Eligibility excludes i64/v128-typed params/returns (no boxing rule).
+          const boxableKind = (t: ValType | null): boolean =>
+            t === null ||
+            t.kind === "externref" ||
+            t.kind === "f64" ||
+            t.kind === "i32" ||
+            t.kind === "ref" ||
+            t.kind === "ref_null";
+          const hostCallFallback =
+            rawCalleeLocal !== undefined &&
+            !ctx.standalone &&
+            !ctx.wasi &&
+            boxableKind(expectedReturn) &&
+            matchedClosureInfo.paramTypes.every((t) => boxableKind(t));
+
+          let fallbackInstrs: Instr[] | null = null;
+          let dispatchOuterBody: Instr[] | null = null;
+          if (hostCallFallback) {
+            // Ensure all fallback imports BEFORE detaching buffers so the index
+            // shifts land while every buffer is reachable by the shifters.
+            const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+            const arrPushIdx = ensureLateImport(
+              ctx,
+              "__js_array_push",
+              [{ kind: "externref" }, { kind: "externref" }],
+              [],
+            );
+            const callFnIdx = ensureLateImport(
+              ctx,
+              "__call_function",
+              [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+              [{ kind: "externref" }],
+            );
+            flushLateImportShifts(ctx, fctx);
+            const arrNew = ctx.funcMap.get("__js_array_new") ?? arrNewIdx;
+            const arrPush = ctx.funcMap.get("__js_array_push") ?? arrPushIdx;
+            const callFn = ctx.funcMap.get("__call_function") ?? callFnIdx;
+            if (arrNew !== undefined && arrPush !== undefined && callFn !== undefined) {
+              // Build the fallback arm in a detached buffer parked in savedBodies
+              // (late-import/global shifters walk savedBodies — #1712 blocker 1).
+              const mainBuf = fctx.body;
+              fctx.savedBodies.push(mainBuf);
+              fctx.body = [];
+              fctx.body.push({ op: "call", funcIdx: arrNew });
+              const argsArrLocal = allocLocal(fctx, `__callable_hargs_${fctx.locals.length}`, { kind: "externref" });
+              fctx.body.push({ op: "local.set", index: argsArrLocal });
+              for (let ai = 0; ai < argLocals.length; ai++) {
+                // Only pass the call-site arg count — padded defaults must stay
+                // invisible to the host callee (fn.length / arguments.length).
+                if (ai >= expr.arguments.length) break;
+                fctx.body.push({ op: "local.get", index: argsArrLocal });
+                fctx.body.push({ op: "local.get", index: argLocals[ai]! });
+                const at = matchedClosureInfo.paramTypes[ai]!;
+                if (at.kind !== "externref") {
+                  coerceType(ctx, fctx, at, { kind: "externref" });
+                }
+                fctx.body.push({ op: "call", funcIdx: arrPush });
+              }
+              for (const exLocal of cpExtrasLocals) {
+                fctx.body.push({ op: "local.get", index: argsArrLocal });
+                fctx.body.push({ op: "local.get", index: exLocal });
+                fctx.body.push({ op: "call", funcIdx: arrPush });
+              }
+              fctx.body.push({ op: "local.get", index: rawCalleeLocal! });
+              fctx.body.push({ op: "ref.null.extern" });
+              fctx.body.push({ op: "local.get", index: argsArrLocal });
+              fctx.body.push({ op: "call", funcIdx: callFn });
+              if (expectedReturn === null) {
+                fctx.body.push({ op: "drop" });
+              } else if (expectedReturn.kind !== "externref") {
+                coerceType(ctx, fctx, { kind: "externref" }, expectedReturn);
+              }
+              fallbackInstrs = fctx.body;
+              // Redirect the existing dispatch emission below into a second
+              // detached buffer; both stay parked until the if-assembly.
+              fctx.savedBodies.push(fallbackInstrs);
+              fctx.body = [];
+              dispatchOuterBody = mainBuf;
+            }
           }
 
           // Extract funcref from the closure struct (field 0) — null-check → TypeError (#728)
@@ -8650,6 +8749,31 @@ function compileCallExpression(
             }
 
             fctx.body.push(...funcDispatch);
+          }
+
+          // (#1712) Assemble the host-callable fallback split: the funcref
+          // dispatch emitted above went into a detached buffer; wrap both arms
+          // in an `if` on "cast failed but raw callee non-null".
+          if (hostCallFallback && fallbackInstrs && dispatchOuterBody) {
+            const dispatchInstrs = fctx.body;
+            fctx.body = dispatchOuterBody;
+            fctx.savedBodies.pop(); // fallbackInstrs
+            fctx.savedBodies.pop(); // mainBuf (now fctx.body again)
+            fctx.body.push({ op: "local.get", index: closureLocal });
+            fctx.body.push({ op: "ref.is_null" });
+            fctx.body.push({ op: "local.get", index: rawCalleeLocal! });
+            fctx.body.push({ op: "ref.is_null" });
+            fctx.body.push({ op: "i32.eqz" });
+            fctx.body.push({ op: "i32.and" });
+            fctx.body.push({
+              op: "if",
+              blockType:
+                expectedReturn === null
+                  ? ({ kind: "empty" } as const)
+                  : ({ kind: "val", type: expectedReturn } as const),
+              then: fallbackInstrs,
+              else: dispatchInstrs,
+            });
           }
 
           return expectedReturn ?? VOID_RESULT;

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1014,31 +1014,20 @@ function compileNewFunctionDeclaration(
   // Bind `this` to the struct
   ctorFctx.localMap.set("this", selfLocal);
 
-  // Compile the function body
-  const savedFunc = ctx.currentFunc;
-  if (savedFunc) ctx.parentBodiesStack.push(savedFunc.body);
-  if (savedFunc) ctx.funcStack.push(savedFunc);
-  ctx.currentFunc = ctorFctx;
-  for (const stmt of body.statements) {
-    compileStatement(ctx, ctorFctx, stmt);
-  }
-  if (savedFunc) ctx.funcStack.pop();
-  if (savedFunc) ctx.parentBodiesStack.pop();
-  ctx.currentFunc = savedFunc;
-
-  // Attach the live body array to the registered function FIRST: the
-  // late-import registration below can shift function indices, and the shift
-  // walkers reach this body only through ctx.mod.functions (#1712 — same
-  // orphan-buffer class as the compileIfStatement then-branch fix).
-  ctorFunc.locals = ctorFctx.locals;
-  ctorFunc.body = ctorFctx.body;
-
   // (#1712) Register the instance → constructor-closure link with the JS
   // host so instance property misses resolve through the closure's vivified
   // `.prototype` object (acorn's `Parser.prototype.m = fn; new Parser().m()`
-  // pattern). JS-host mode only — standalone/WASI construction stays pure
-  // Wasm; the native equivalent rides on the #1888 open-object runtime in a
-  // later dogfood lap.
+  // pattern). Emitted in the ctor PROLOGUE — before the user body compiles —
+  // because acorn-style ctors call prototype methods on `this` inside the
+  // ctor itself (`this.context = this.initialContext()`); an end-of-ctor
+  // registration left those in-ctor dispatches unresolvable. JS-host mode
+  // only — standalone/WASI construction stays pure Wasm; the native
+  // equivalent rides on the #1888 open-object runtime in a later dogfood lap.
+  // Buffer-reach note: the flush below walks ctx.currentFunc (still the
+  // OUTER call-site fctx here) plus ctorFctx.body explicitly; once the body
+  // compile switches ctx.currentFunc to ctorFctx, later shifts reach these
+  // prologue instrs through currentFunc.body, and after attachment through
+  // ctx.mod.functions.
   if (!ctx.standalone && !ctx.wasi) {
     const ctorGlobalIdx = ctx.moduleGlobals.get(funcName) ?? ctx.funcClosureGlobals.get(funcName);
     if (ctorGlobalIdx !== undefined) {
@@ -1060,6 +1049,31 @@ function compileNewFunctionDeclaration(
       }
     }
   }
+
+  // Compile the function body
+  const savedFunc = ctx.currentFunc;
+  if (savedFunc) ctx.parentBodiesStack.push(savedFunc.body);
+  if (savedFunc) ctx.funcStack.push(savedFunc);
+  ctx.currentFunc = ctorFctx;
+  for (const stmt of body.statements) {
+    compileStatement(ctx, ctorFctx, stmt);
+  }
+  if (savedFunc) ctx.funcStack.pop();
+  if (savedFunc) ctx.parentBodiesStack.pop();
+  ctx.currentFunc = savedFunc;
+
+  // Attach the live body array to the registered function FIRST: the
+  // late-import registration below can shift function indices, and the shift
+  // walkers reach this body only through ctx.mod.functions (#1712 — same
+  // orphan-buffer class as the compileIfStatement then-branch fix).
+  ctorFunc.locals = ctorFctx.locals;
+  ctorFunc.body = ctorFctx.body;
+
+  // (#1712) The instance → constructor-closure registration
+  // (__register_fnctor_instance) is emitted in the ctor PROLOGUE above —
+  // before the user body — so in-ctor prototype-method calls on `this`
+  // (`this.context = this.initialContext()`) already resolve through the
+  // vivified prototype.
 
   // Return the struct instance
   ctorFctx.body.push({ op: "local.get", index: selfLocal });

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9051,6 +9051,36 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
     // Check externref AFTER Array check — Array is declared in lib but should use wasm GC arrays
     if (isExternalDeclaredClass(tsType, ctx.checker)) return { kind: "externref" };
 
+    // (#1712) Function-style-constructor instance types resolve to EXTERNREF,
+    // never to a synthesized checker-shape struct. The runtime instance struct
+    // (compileFnctorNew, `__fnctor_<name>`) is built from ctor `this.*` writes
+    // only, while the checker's shape adds prototype-assigned methods as
+    // members — the two shapes have no subtype relation, so any value typed
+    // with the checker shape guard-casts to null and downstream struct.get /
+    // ref.as_non_null traps (acorn `Parser.prototype.parse = function () {
+    // return new Parser(...); }`). Externref makes fnctor instances flow
+    // dynamically end to end: member calls take the host-bridge path (which
+    // resolves through the vivified prototype) and field reads go through
+    // __extern_get/_safeGet. NOTE: resolving to the CTOR struct here instead
+    // was tried and regressed (.tmp/dbg15.mts G4/G5) — the member-call
+    // static/dynamic split keys off this type, so only the always-dynamic
+    // externref resolution is safe. JS-host mode only.
+    if (!ctx.standalone && !ctx.wasi) {
+      const fnDecl = sym?.valueDeclaration;
+      const isFnCtorType =
+        (sym?.name !== undefined && ctx.funcConstructorMap.has(sym.name)) ||
+        (!!fnDecl &&
+          (ts.isFunctionDeclaration(fnDecl) ||
+            ts.isFunctionExpression(fnDecl) ||
+            (ts.isVariableDeclaration(fnDecl) && !!fnDecl.initializer && ts.isFunctionExpression(fnDecl.initializer))));
+      // Only when the type is an INSTANCE shape (has properties but is not
+      // itself callable) — the function VALUE type (callable) must keep its
+      // closure-wrapper resolution.
+      if (isFnCtorType && tsType.getCallSignatures().length === 0) {
+        return { kind: "externref" };
+      }
+    }
+
     let name = sym?.name;
     // Map class expression symbol names to their synthetic names
     if (name && !ctx.structMap.has(name)) {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3658,6 +3658,319 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       desc: { kind: "func", index: getFuncIdx },
     });
   }
+
+  // (#1712) Generic host-side vec MUTATORS. Compiled acorn mutates instance
+  // array fields through dynamic `this` dispatch (`this.scopeStack.push(
+  // new Scope(flags))` in enterScope): the receiver reaches the host's
+  // __extern_method_call as an opaque vec struct, and the host cannot grow a
+  // WasmGC array itself. These exports mirror the __vec_len/__vec_get
+  // per-vec-type ref.test dispatch and perform the mutation on the Wasm side
+  // (same grow discipline as compileArrayPush: newCap = max((len+1)*2, 4),
+  // array.new_default + array.copy + struct.set). Element-kind coverage is
+  // externref always, f64/i32 when __unbox_number/__box_number are imported;
+  // unsupported kinds return the -1 / 0 sentinel so the runtime falls
+  // through to its fail-loud TypeError instead of silently no-oping.
+  const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+  const boxNumIdx2 = ctx.funcMap.get("__box_number");
+  const mutEntries = vecEntries.filter(([elemKey]) => {
+    if (elemKey === "externref") return true;
+    if (elemKey === "f64" || elemKey === "i32") return unboxNumIdx !== undefined && boxNumIdx2 !== undefined;
+    return false;
+  });
+
+  // __is_vec(externref) -> i32 — POSITIVE vec discriminator over ALL
+  // registered vec types. `__vec_len` cannot serve this role (its not-a-vec
+  // default of 0 is indistinguishable from an empty vec), and `__is_closure`
+  // can FALSE-POSITIVE on a vec whose canonicalized layout collides with a
+  // closure capture struct — the runtime's callable-wrapping paths consult
+  // this export to veto bridging a vec into a JS function.
+  {
+    const isVecTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__is_vec_type");
+    const isVecFuncIdx = ctx.numImportFuncs + mod.functions.length;
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 1 } as Instr,
+    ];
+    let current: Instr[] = [{ op: "i32.const", value: 0 } as Instr, { op: "return" } as Instr];
+    for (let i = vecEntries.length - 1; i >= 0; i--) {
+      const [, vecTypeIdx] = vecEntries[i]!;
+      current = [
+        { op: "local.get", index: 1 } as Instr,
+        { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "i32.const", value: 1 } as Instr, { op: "return" } as Instr],
+          else: current,
+        } as Instr,
+      ];
+    }
+    body.push(...current);
+    mod.functions.push({
+      name: "__is_vec",
+      typeIdx: isVecTypeIdx,
+      locals: [{ name: "__any", type: { kind: "anyref" } }],
+      body,
+      exported: true,
+    } as any);
+    mod.exports.push({ name: "__is_vec", desc: { kind: "func", index: isVecFuncIdx } });
+  }
+
+  // __vec_mut_supported(externref) -> i32 (1 = push/pop cover this vec's elem kind)
+  {
+    const supTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__vec_mut_supported_type");
+    const supFuncIdx = ctx.numImportFuncs + mod.functions.length;
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 1 } as Instr,
+    ];
+    let current: Instr[] = [{ op: "i32.const", value: 0 } as Instr, { op: "return" } as Instr];
+    for (let i = mutEntries.length - 1; i >= 0; i--) {
+      const [, vecTypeIdx] = mutEntries[i]!;
+      current = [
+        { op: "local.get", index: 1 } as Instr,
+        { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "i32.const", value: 1 } as Instr, { op: "return" } as Instr],
+          else: current,
+        } as Instr,
+      ];
+    }
+    body.push(...current);
+    mod.functions.push({
+      name: "__vec_mut_supported",
+      typeIdx: supTypeIdx,
+      locals: [{ name: "__any", type: { kind: "anyref" } }],
+      body,
+      exported: true,
+    } as any);
+    mod.exports.push({ name: "__vec_mut_supported", desc: { kind: "func", index: supFuncIdx } });
+  }
+
+  // __vec_push(externref vec, externref value) -> i32 (new length, or -1 unsupported)
+  {
+    const pushTypeIdx = addFuncType(
+      ctx,
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      "$__vec_push_type",
+    );
+    const pushFuncIdx = ctx.numImportFuncs + mod.functions.length;
+    // locals: 2 = anyref converted; per-arm typed locals appended below
+    const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 2 } as Instr,
+    ];
+    let current: Instr[] = [{ op: "i32.const", value: -1 } as Instr, { op: "return" } as Instr];
+    for (let i = mutEntries.length - 1; i >= 0; i--) {
+      const [elemKey, vecTypeIdx] = mutEntries[i]!;
+      const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+      if (arrTypeIdx < 0) continue;
+      const base = 2 + locals.length; // 2 params + locals so far
+      const vecL = base;
+      const dataL = base + 1;
+      const lenL = base + 2;
+      const ncapL = base + 3;
+      const ndataL = base + 4;
+      locals.push(
+        { name: `__vp_vec_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: vecTypeIdx } },
+        { name: `__vp_data_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+        { name: `__vp_len_${vecTypeIdx}`, type: { kind: "i32" } },
+        { name: `__vp_ncap_${vecTypeIdx}`, type: { kind: "i32" } },
+        { name: `__vp_ndata_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+      );
+      // value unboxing per element kind (value param is local 1)
+      const valueInstrs: Instr[] =
+        elemKey === "externref"
+          ? [{ op: "local.get", index: 1 } as Instr]
+          : elemKey === "f64"
+            ? [{ op: "local.get", index: 1 } as Instr, { op: "call", funcIdx: unboxNumIdx! } as Instr]
+            : [
+                { op: "local.get", index: 1 } as Instr,
+                { op: "call", funcIdx: unboxNumIdx! } as Instr,
+                { op: "i32.trunc_sat_f64_s" } as Instr,
+              ];
+      const thenBranch: Instr[] = [
+        { op: "local.get", index: 2 } as Instr,
+        { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
+        { op: "local.set", index: vecL } as Instr,
+        // len
+        { op: "local.get", index: vecL } as Instr,
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "local.set", index: lenL } as Instr,
+        // data + capacity check: cap < len+1 ?
+        { op: "local.get", index: vecL } as Instr,
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "local.tee", index: dataL } as Instr,
+        { op: "array.len" } as Instr,
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "i32.lt_s" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // ncap = max((len+1)*2, 4)
+            { op: "local.get", index: lenL } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.shl" } as Instr,
+            { op: "i32.const", value: 4 } as Instr,
+            { op: "local.get", index: lenL } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.shl" } as Instr,
+            { op: "i32.const", value: 4 } as Instr,
+            { op: "i32.gt_s" } as Instr,
+            { op: "select" } as Instr,
+            { op: "local.set", index: ncapL } as Instr,
+            // ndata = array.new_default(ncap); copy old; vec.data = ndata
+            { op: "local.get", index: ncapL } as Instr,
+            { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+            { op: "local.set", index: ndataL } as Instr,
+            { op: "local.get", index: ndataL } as Instr,
+            { op: "i32.const", value: 0 } as Instr,
+            { op: "local.get", index: dataL } as Instr,
+            { op: "i32.const", value: 0 } as Instr,
+            { op: "local.get", index: lenL } as Instr,
+            { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+            { op: "local.get", index: vecL } as Instr,
+            { op: "local.get", index: ndataL } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+            { op: "local.get", index: ndataL } as Instr,
+            { op: "local.set", index: dataL } as Instr,
+          ],
+        } as Instr,
+        // data[len] = value
+        { op: "local.get", index: dataL } as Instr,
+        { op: "local.get", index: lenL } as Instr,
+        ...valueInstrs,
+        { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+        // vec.length = len + 1
+        { op: "local.get", index: vecL } as Instr,
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        // return len + 1
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "return" } as Instr,
+      ];
+      current = [
+        { op: "local.get", index: 2 } as Instr,
+        { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: thenBranch,
+          else: current,
+        } as Instr,
+      ];
+    }
+    body.push(...current);
+    mod.functions.push({
+      name: "__vec_push",
+      typeIdx: pushTypeIdx,
+      locals,
+      body,
+      exported: true,
+    } as any);
+    mod.exports.push({ name: "__vec_push", desc: { kind: "func", index: pushFuncIdx } });
+  }
+
+  // __vec_pop(externref) -> externref (boxed last element; null.extern when
+  // empty or unsupported — callers gate on __vec_mut_supported to tell apart)
+  {
+    const popTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$__vec_pop_type");
+    const popFuncIdx = ctx.numImportFuncs + mod.functions.length;
+    const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
+    const body: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 1 } as Instr,
+    ];
+    let current: Instr[] = [{ op: "ref.null.extern" } as Instr, { op: "return" } as Instr];
+    for (let i = mutEntries.length - 1; i >= 0; i--) {
+      const [elemKey, vecTypeIdx] = mutEntries[i]!;
+      const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+      if (arrTypeIdx < 0) continue;
+      const base = 1 + locals.length; // 1 param + locals so far
+      const vecL = base;
+      const lenL = base + 1;
+      locals.push(
+        { name: `__vpop_vec_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: vecTypeIdx } },
+        { name: `__vpop_len_${vecTypeIdx}`, type: { kind: "i32" } },
+      );
+      const boxInstrs: Instr[] =
+        elemKey === "externref"
+          ? []
+          : elemKey === "f64"
+            ? [{ op: "call", funcIdx: boxNumIdx2! } as Instr]
+            : [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx2! } as Instr];
+      const thenBranch: Instr[] = [
+        { op: "local.get", index: 1 } as Instr,
+        { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
+        { op: "local.set", index: vecL } as Instr,
+        { op: "local.get", index: vecL } as Instr,
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "local.set", index: lenL } as Instr,
+        // empty → undefined
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.eqz" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "ref.null.extern" } as Instr, { op: "return" } as Instr],
+        } as Instr,
+        // value = data[len-1] (boxed)
+        { op: "local.get", index: vecL } as Instr,
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+        ...boxInstrs,
+        // vec.length = len - 1 (value stays beneath on the stack)
+        { op: "local.get", index: vecL } as Instr,
+        { op: "local.get", index: lenL } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.sub" } as Instr,
+        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "return" } as Instr,
+      ];
+      current = [
+        { op: "local.get", index: 1 } as Instr,
+        { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: thenBranch,
+          else: current,
+        } as Instr,
+      ];
+    }
+    body.push(...current);
+    mod.functions.push({
+      name: "__vec_pop",
+      typeIdx: popTypeIdx,
+      locals,
+      body,
+      exported: true,
+    } as any);
+    mod.exports.push({ name: "__vec_pop", desc: { kind: "func", index: popFuncIdx } });
+  }
 }
 
 /**

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7047,6 +7047,23 @@ assert._isSameValue = isSameValue;
             return ret === wrappedObj ? obj : _unwrapForHost(ret);
           }
           if (typeof fn !== "function") {
+            // (#1712) Static method on a callable closure struct (function-style
+            // constructor): `wrapHostValue` wrapped the receiver into a bare JS
+            // function bridge (`_wrapWasmClosureUnknownArity`), which has no view
+            // of sidecar statics — `Parser.parse = function …` lands in the
+            // struct's sidecar via __extern_set. Resolve the method through
+            // `_safeGet` on the RAW struct (sidecar → accessors → vivified
+            // fnctor prototype) and dispatch with the raw closure struct as the
+            // receiver so `this` inside the static body (acorn's
+            // `Parser.parse = function(i,o){ return new this(o,i).parse() }`)
+            // observes the constructor closure.
+            if (typeof wrappedObj === "function" && _isWasmStruct(obj)) {
+              const resolved = _maybeWrapCallableUnknownArity(_safeGet(obj, method, callbackState), callbackState);
+              if (typeof resolved === "function") {
+                const ret = resolved.apply(obj, wrappedArgs);
+                return ret === obj || ret === wrappedObj ? obj : _unwrapForHost(ret);
+              }
+            }
             // (#837) Map/WeakMap upsert proposal polyfill — Node 25 / V8
             // currently don't ship `getOrInsert` / `getOrInsertComputed`
             // (TC39 Stage 3). Implement the spec algorithm here so the
@@ -7645,17 +7662,32 @@ assert._isSameValue = isSameValue;
       if (name === "__call_function")
         return (fn: any, thisArg: any, argsArray: any): any => {
           if (typeof fn !== "function") {
-            // Unwrap a wasm-struct closure if one slipped through.
+            // Wrap a wasm-struct closure if one slipped through. Arity-aware
+            // (#1712): the previous arity-0 wrap dropped every argument.
             if (_isWasmStruct(fn)) {
-              const wrapped = _wrapWasmClosure(fn, 0, callbackState);
-              if (wrapped) fn = wrapped;
+              const wrapped = _maybeWrapCallableUnknownArity(fn, callbackState);
+              if (typeof wrapped === "function") fn = wrapped;
             }
           }
           if (typeof fn !== "function") {
             throw new TypeError(String(fn) + " is not a function");
           }
           const args: any[] = Array.isArray(argsArray) ? argsArray : [];
-          return Reflect.apply(fn, thisArg, args);
+          // (#1712) Host-marshal wasmGC struct args the same way
+          // __extern_method_call does: callable closures become JS functions
+          // (so host higher-order callees can invoke them), plain structs get
+          // the live-mirror proxy (so `Object.hasOwn(o, "a")`-style builtins
+          // observe struct fields as real properties).
+          const exports = callbackState?.getExports();
+          const wrapHostValue = (v: any): any => {
+            if (!_isWasmStruct(v)) return v;
+            const callable = _maybeWrapCallableUnknownArity(v, callbackState);
+            return callable !== v ? callable : _wrapForHost(v, exports);
+          };
+          const wrappedThis = wrapHostValue(thisArg);
+          const wrappedArgs = args.map(wrapHostValue);
+          const ret = Reflect.apply(fn, wrappedThis, wrappedArgs);
+          return _unwrapForHost(ret);
         };
       if (name === "__reflect_construct")
         return (ctor: any, args: any, newTarget: any): any => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4071,7 +4071,16 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       const getter = exports[`__sget_${String(key)}`];
       if (typeof getter === "function") {
         try {
-          return getter(obj);
+          // (#1712) Treat a nullish result as a MISS, not a hit: the
+          // __sget_<name> per-shape dispatcher yields null/undefined when the
+          // receiver's struct shape doesn't carry the field at all (fnctor
+          // ctor-shape instances vs the wider checker shape that generated
+          // the export). Returning it unconditionally short-circuited the
+          // vivified-prototype fallback below and made every prototype
+          // method on a fnctor instance unreachable whenever the checker
+          // shape had synthesized a same-named field.
+          const v = getter(obj);
+          if (v !== undefined && v !== null) return v;
         } catch {
           /* not a field of this struct type */
         }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4164,6 +4164,19 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       // can invoke it. Without this, JS sees `typeof val === "object"` and
       // ToPrimitive fails with "Cannot convert object to primitive value".
       if (val != null && typeof val === "object" && _isWasmStruct(val) && exports) {
+        // (#1712) Vec structs are DATA, never callables — wrapping one in the
+        // closureBridge below made acorn's `this.scopeStack` field read return
+        // a JS function, so `scopeStack.push(…)` threw "push is not a
+        // function". `__is_vec` is the positive discriminator (`__is_closure`
+        // can false-positive on layout-canonicalization collisions).
+        try {
+          const isVecFn = exports.__is_vec as ((v: any) => number) | undefined;
+          if (typeof isVecFn === "function" && isVecFn(val) === 1) {
+            return _wrapForHost(val, exports);
+          }
+        } catch {
+          // fall through to the closure-bridge heuristics
+        }
         // Resolve the export key — for string keys use directly, for well-known
         // symbols use the @@name form (e.g. Symbol.toPrimitive → "@@toPrimitive") (#1090)
         const exportKey = typeof key === "string" ? key : typeof key === "symbol" ? _symbolToWasm.get(key) : undefined;
@@ -7062,6 +7075,56 @@ assert._isSameValue = isSameValue;
               if (typeof resolved === "function") {
                 const ret = resolved.apply(obj, wrappedArgs);
                 return ret === obj || ret === wrappedObj ? obj : _unwrapForHost(ret);
+              }
+            }
+            // (#1712) Array mutators on WasmGC vec structs. acorn mutates
+            // instance array fields through dynamic `this` dispatch
+            // (`this.scopeStack.push(new Scope(flags))`); the receiver is an
+            // opaque vec struct the host cannot grow. Route push/pop through
+            // the Wasm-side __vec_push/__vec_pop exports (per-vec-type
+            // dispatch, grow on the Wasm side). __vec_mut_supported is the
+            // discriminator — __vec_len's not-a-vec default is 0 and can't
+            // tell an empty vec from a non-vec. Push the RAW args (not host
+            // proxies) so Wasm-side reads of the elements see the structs.
+            {
+              // The receiver may be a _wrapForHost proxy (the field read that
+              // produced it wrapped the struct for host visibility) — unwrap
+              // to the raw vec struct before the export round-trip.
+              let rawVec = _unwrapForHost(obj);
+              // A vec struct whose canonicalized layout collides with a
+              // closure capture struct false-positives __is_closure, so
+              // wrapHostValue wrapped it into a callable bridge — reverse
+              // that through the wrapper→closure map.
+              if (typeof rawVec === "function") {
+                const wrapperTarget = _wasmClosureWrapperTargets.get(rawVec);
+                if (wrapperTarget) rawVec = wrapperTarget;
+              }
+              if (_isWasmStruct(rawVec) && exports) {
+                const mutSupFn = exports.__vec_mut_supported as ((v: any) => number) | undefined;
+                let vecSupported = false;
+                try {
+                  vecSupported = typeof mutSupFn === "function" && mutSupFn(rawVec) === 1;
+                } catch {
+                  vecSupported = false;
+                }
+                if (vecSupported) {
+                  if (method === "push" && typeof exports.__vec_push === "function") {
+                    const pushFn = exports.__vec_push as (v: any, x: any) => number;
+                    const rawArgs = args ?? [];
+                    let newLen = (exports.__vec_len as (v: any) => number)(rawVec);
+                    let ok = true;
+                    for (const a of rawArgs) {
+                      newLen = pushFn(rawVec, _unwrapForHost(a));
+                      if (newLen < 0) {
+                        ok = false;
+                        break;
+                      }
+                    }
+                    if (ok) return newLen;
+                  } else if (method === "pop" && typeof exports.__vec_pop === "function") {
+                    return (exports.__vec_pop as (v: any) => any)(rawVec);
+                  }
+                }
               }
             }
             // (#837) Map/WeakMap upsert proposal polyfill — Node 25 / V8

--- a/tests/issue-1712-dynamic-dispatch.test.ts
+++ b/tests/issue-1712-dynamic-dispatch.test.ts
@@ -97,3 +97,26 @@ describe("#1712 — in-ctor prototype-method calls on this", () => {
     expect(exp.parse("x")).toBe("CTX-x");
   });
 });
+
+describe("#1712 — fnctor two-shape unification (checker shape never synthesized)", () => {
+  it("prototype method RETURNING an instance of the same fnctor (was: null-deref trap)", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.parse = function parse() { return new Parser("inner"); };
+      export function parse(input) { return new Parser(input).parse(); }
+    `);
+    expect(exp.parse("x")).toEqual({ input: "inner" });
+  });
+
+  it("checker-typed member call routes through the dynamic prototype path", async () => {
+    const exp = await run(`
+      var Node = function Node(t) { this.type = t; };
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.startNode = function startNode() { return new Node("Program"); };
+      Parser.prototype.finishNode = function finishNode(node) { node.end = 1; return node; };
+      Parser.prototype.parse = function parse() { var n = this.startNode(); return this.finishNode(n).type; };
+      export function parse(input) { return new Parser(input).parse(); }
+    `);
+    expect(exp.parse("x")).toBe("Program");
+  });
+});

--- a/tests/issue-1712-dynamic-dispatch.test.ts
+++ b/tests/issue-1712-dynamic-dispatch.test.ts
@@ -1,0 +1,99 @@
+// #1712 — dynamic dispatch fixes that unblock compiled acorn's parse() chain
+// (exports.parse → static Parser.parse → new this(…) → getOptions → in-ctor
+// prototype-method calls). Four pinned root causes:
+//
+// 1. Static method on a function-style constructor (`Parser.parse = fn;
+//    Parser.parse(input)`): __extern_method_call wrapped the callable closure
+//    receiver into a bare JS function bridge, which has no view of sidecar
+//    statics — every static call threw "X is not a function". Fixed by a
+//    _safeGet sidecar/prototype fallback that dispatches with the RAW closure
+//    struct as receiver, so `new this(…)` inside the static body works.
+//
+// 2. Externref callee whose guarded wrapper-struct cast fails but is non-null
+//    (acorn's `var hasOwn = Object.hasOwn || function(){…}` — a host builtin
+//    in a JS variable): the dispatch did `struct.get` on the null cast result
+//    and trapped "dereferencing a null pointer". Fixed by a host-callable
+//    fallback arm routing through __call_function (JS-host mode only).
+//
+// 3. __call_function passed raw WasmGC struct args to the host callee, so
+//    `Object.hasOwn(structArg, "a")` observed no properties; closure args were
+//    wrapped at arity 0 (all args dropped). Fixed by __extern_method_call-style
+//    host marshaling + arity-aware closure wrapping.
+//
+// 4. __register_fnctor_instance was emitted at the END of the synthesized
+//    fnctor ctor, so prototype-method calls on `this` INSIDE the ctor
+//    (acorn's `this.context = this.initialContext()`) could not resolve
+//    through the vivified prototype. Fixed by emitting it in the ctor
+//    prologue.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "acorn.mjs" });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#1712 — static methods on function-style constructors", () => {
+  it("plain static method call (was: 'parse is not a function')", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.parse = function parse(input) { return "STATIC-" + input; };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    expect(exp.parse("x")).toBe("STATIC-x");
+  });
+
+  it("acorn shape: static method does new this(…).method()", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.parse = function parse() { return this.input; };
+      Parser.parse = function parse(input) { return new this(input).parse(); };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    expect(exp.parse("x")).toBe("x");
+  });
+
+  it("static data property read-back still works", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.version = "8.16.0";
+      export function parse(input) { var p = new Parser(input); return Parser.version + ":" + p.input; }
+    `);
+    expect(exp.parse("x")).toBe("8.16.0:x");
+  });
+});
+
+describe("#1712 — host-callable fallback for non-closure-shaped callees", () => {
+  it("builtin || closure module var is callable (was: null-deref trap)", async () => {
+    const exp = await run(`
+      var hasOwn = Object.hasOwn || function (obj, propName) { return Object.prototype.hasOwnProperty.call(obj, propName); };
+      export function parse(input) { var o = { a: 1 }; return hasOwn(o, "a") ? "HAS" : "MISSING"; }
+    `);
+    expect(exp.parse("x")).toBe("HAS");
+  });
+
+  it("builtin callee with numeric return feeds arithmetic", async () => {
+    const exp = await run(`
+      var max = Math.max || function (a, b) { return a > b ? a : b; };
+      export function parse(input) { return max(2, 5) + 1; }
+    `);
+    expect(exp.parse("x")).toBe(6);
+  });
+});
+
+describe("#1712 — in-ctor prototype-method calls on this", () => {
+  it("ctor calls own prototype method (acorn initialContext pattern)", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); this.ctx = this.initialContext(); };
+      Parser.prototype.initialContext = function initialContext() { return "CTX-" + this.input; };
+      Parser.prototype.parse = function parse() { return this.ctx; };
+      export function parse(input) { return new Parser(input).parse(); }
+    `);
+    expect(exp.parse("x")).toBe("CTX-x");
+  });
+});


### PR DESCRIPTION
## Summary

**Stacked on #1335 → #1327 → #1307** — draft until the stack lands below it; the diff then collapses to this slice's single commit.

Fixes the original #1712 Blocker-2 **two-shape trap**: `compileFnctorNew` builds the runtime instance struct from ctor `this.*` writes only, while the TS checker's shape adds prototype-assigned methods as instance members. The two shapes have no subtype relation, so any checker-typed fnctor instance guard-cast to null and downstream `struct.get` / `ref.as_non_null` trapped "dereferencing a null pointer" (acorn: `new this(options, input).parse()` in the static `Parser.parse`).

Four coordinated changes — the "steer the member-call split together with the type change" approach the issue file's documented FAILED attempt (ctor-struct resolution, regressed G4/G5) called for, but resolved to **externref** instead so fnctor instances always flow dynamically:

1. `resolveWasmType` (`src/codegen/index.ts`): fnctor instance types resolve to externref — the checker shape is never synthesized. Gated to instance shapes only (`getCallSignatures().length === 0` keeps function VALUES on their closure-wrapper resolution); JS-host mode only.
2. `compileCallablePropertyCall` (`src/codegen/expressions/calls-closures.ts`): fnctor-instance receivers route through the dynamic host bridge instead of the checker-shape field-read path.
3. `emitWrapperDynamicMethodCall` (`src/codegen/expressions/calls.ts`): exported + call-argument support (`__js_array_push` packing, JS-host).
4. Runtime `_wrapForHost.safeGetField`: a nullish `__sget_<name>` result is a MISS, not a hit — the per-shape dispatcher returns undefined for shapes that don't carry the field, which short-circuited the vivified-prototype fallback and made every prototype method unreachable whenever the checker shape had synthesized a same-named field export.

## Validation

- `tests/issue-1712-dynamic-dispatch.test.ts` extended with the two-shape pins (8 tests green).
- Probe series E4/M green; G/H series unchanged; targeted suites (fn-constructor, prototype-chain, bind-call, illegal-cast-closures, wrapper-constructors, …): 0 new failures (19 pre-existing env fails identical with/without the change).
- **acorn milestone**: compiled `parse()` now executes past ALL dispatch traps into the tokenizer loop. Next blocker (root-cause direction documented in the issue file): infinite loop, likely instance-field write-back through dynamic dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)