### PR TITLE
fix(#2082): implicit derived ctor forwards args on the WasmGC-struct path

### DIFF
--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -244,6 +244,31 @@ function externrefParams(count: number): ValType[] {
   return Array.from({ length: count }, () => ({ kind: "externref" }) as ValType);
 }
 
+/**
+ * #2082: for a derived class with NO explicit constructor and a WasmGC-struct
+ * parent, the spec synthesizes `constructor(...args) { super(...args); }`
+ * (§15.7.14). Walk the parent chain to the nearest ancestor that declares an
+ * explicit constructor and return its parameter list, so the implicit ctor is
+ * synthesized with the same parameters (bound as locals) and the replayed
+ * parent `this.x = param` assignments can resolve `param`. Returns undefined
+ * when no ancestor has an explicit constructor (no args to forward).
+ */
+function findNearestAncestorCtorParams(
+  ctx: CodegenContext,
+  className: string,
+): ts.NodeArray<ts.ParameterDeclaration> | undefined {
+  const seen = new Set<string>([className]);
+  let anc = ctx.classParentMap.get(className);
+  while (anc && !seen.has(anc)) {
+    seen.add(anc);
+    const ancDecl = ctx.classDeclarationMap.get(anc);
+    const ancCtor = ancDecl?.members.find(ts.isConstructorDeclaration) as ts.ConstructorDeclaration | undefined;
+    if (ancCtor) return ancCtor.parameters;
+    anc = ctx.classParentMap.get(anc);
+  }
+  return undefined;
+}
+
 function compileExternrefArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
   const argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
   if (argResult === null) {
@@ -543,6 +568,22 @@ export function collectClassDeclaration(
   if (implicitForwarderArity > 0) {
     ctorParams.push(...externrefParams(implicitForwarderArity));
   }
+  // #2082: implicit ctor of a WasmGC-struct-backed derived class (no explicit
+  // ctor, non-builtin parent) — forward the nearest ancestor ctor's params so
+  // `new Dog("rex")` actually passes "rex" through to the replayed
+  // `this.name = name` (spec §15.7.14 `constructor(...args){ super(...args) }`).
+  const implicitStructCtorParams =
+    !ctor && !implicitBuiltinParent ? findNearestAncestorCtorParams(ctx, className) : undefined;
+  if (implicitStructCtorParams) {
+    for (const param of implicitStructCtorParams) {
+      const paramType = ctx.checker.getTypeAtLocation(param);
+      let wasmType = resolveWasmType(ctx, paramType);
+      if (param.initializer && wasmType.kind === "ref") {
+        wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
+      }
+      ctorParams.push(wasmType);
+    }
+  }
   if (ctor) {
     for (let i = 0; i < ctor.parameters.length; i++) {
       const param = ctor.parameters[i]!;
@@ -585,6 +626,10 @@ export function collectClassDeclaration(
     : [{ kind: "ref", typeIdx: structTypeIdx }];
   if (ctor) {
     registerClassOptionalParams(ctx, ctorName, ctor.parameters, ctorParams);
+  } else if (implicitStructCtorParams) {
+    // #2082: the implicit ctor inherits the forwarded parent params' optionality
+    // so the call site sets `__argc` and the default-value checks fire.
+    registerClassOptionalParams(ctx, ctorName, implicitStructCtorParams, ctorParams, implicitForwarderArity);
   }
   const ctorTypeIdx = addFuncType(ctx, ctorParams, ctorResults, `${className}_new_type`);
   const ctorFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -1098,6 +1143,23 @@ function compileClassBodiesInner(
     for (let i = 0; i < implicitForwarderArity; i++) {
       params.push({ name: `__arg${i}`, type: { kind: "externref" } });
     }
+    // #2082: bind the forwarded ancestor-ctor params as named locals so the
+    // replayed parent `this.x = name` assignments below resolve `name`. Must
+    // mirror the func-type registration (the implicitStructCtorParams block).
+    const implicitStructCtorParams =
+      !ctor && !implicitBuiltinParent ? findNearestAncestorCtorParams(ctx, className) : undefined;
+    if (implicitStructCtorParams) {
+      for (let pi = 0; pi < implicitStructCtorParams.length; pi++) {
+        const param = implicitStructCtorParams[pi]!;
+        const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${pi}`;
+        const paramType = ctx.checker.getTypeAtLocation(param);
+        let wasmType = resolveWasmType(ctx, paramType);
+        if (param.initializer && wasmType.kind === "ref") {
+          wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
+        }
+        params.push({ name: paramName, type: wasmType });
+      }
+    }
     if (ctor) {
       for (let pi = 0; pi < ctor.parameters.length; pi++) {
         const param = ctor.parameters[pi]!;
@@ -1202,19 +1264,27 @@ function compileClassBodiesInner(
     // Emit default-value initialization for constructor parameters with initializers.
     // For primitive params, __argc distinguishes an omitted argument from a
     // legitimate falsy value. Ref/externref params keep their value checks.
-    if (ctor) {
-      const defaultArgcLocal = ctor.parameters.some((param, i) => {
+    // #2082: the implicit ctor must also honour the FORWARDED parent params'
+    // defaults (`class A { constructor(v = 7){...} }; class B extends A {}` →
+    // `new B()` must see v = 7). Those params occupy indices
+    // [implicitForwarderArity, implicitForwarderArity + len) — 0-based here
+    // since a WasmGC-struct implicit ctor has no externref forwarder prefix.
+    const defaultInitParams: ts.NodeArray<ts.ParameterDeclaration> | undefined =
+      ctor?.parameters ?? implicitStructCtorParams;
+    const defaultInitBase = ctor ? 0 : implicitForwarderArity;
+    if (defaultInitParams) {
+      const defaultArgcLocal = defaultInitParams.some((param, i) => {
         if (!param.initializer) return false;
-        return paramDefaultNeedsArgc(params[i]?.type);
+        return paramDefaultNeedsArgc(params[defaultInitBase + i]?.type);
       })
         ? cacheParamDefaultArgc(ctx, fctx)
         : undefined;
-      for (let i = 0; i < ctor.parameters.length; i++) {
-        const param = ctor.parameters[i]!;
+      for (let i = 0; i < defaultInitParams.length; i++) {
+        const param = defaultInitParams[i]!;
         if (!param.initializer) continue;
 
-        const paramIdx = i;
-        const paramType = params[i]!.type;
+        const paramIdx = defaultInitBase + i;
+        const paramType = params[paramIdx]!.type;
 
         // Pre-ensure `__extern_is_undefined` before compiling the initializer so
         // any late-import funcIdx shift happens while `fctx.body` is authoritative.

--- a/tests/issue-2082.test.ts
+++ b/tests/issue-2082.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2082: a derived class with NO explicit constructor and a WasmGC-struct parent
+// must forward its arguments to the parent (spec §15.7.14
+// `constructor(...args) { super(...args); }`). The implicit ctor was synthesized
+// with zero parameters, so `new Dog("rex")` evaluated the argument and DROPPED
+// it — the replayed parent `this.name = name` saw `name` unresolved (ref.null /
+// f64 0). The fix forwards the nearest-ancestor ctor's parameter list.
+
+async function evalStr(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+async function evalNum(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+
+describe("#2082 implicit derived constructor forwards args", () => {
+  it("forwards a single string arg to the parent (the original repro)", async () => {
+    expect(
+      await evalStr(
+        `class Animal { name: string; constructor(name: string){ this.name = name; } speak(){ return this.name + " barks"; } } class Dog extends Animal {} export function test(): string { return new Dog("rex").speak(); }`,
+      ),
+    ).toBe("rex barks");
+    expect(
+      await evalStr(
+        `class Animal { name: string; constructor(name: string){ this.name = name; } } class Dog extends Animal {} export function test(): string { return new Dog("rex").name; }`,
+      ),
+    ).toBe("rex");
+  });
+
+  it("forwards multiple args", async () => {
+    expect(
+      await evalNum(
+        `class P { a: number; b: number; constructor(a: number, b: number){ this.a=a; this.b=b; } } class C extends P {} export function test(): number { const c = new C(3, 4); return c.a * 10 + c.b; }`,
+      ),
+    ).toBe(34);
+  });
+
+  it("forwards through multi-level implicit chains", async () => {
+    expect(
+      await evalStr(
+        `class A { x: string; constructor(x: string){ this.x = x; } } class B extends A {} class D extends B {} export function test(): string { return new D("hi").x; }`,
+      ),
+    ).toBe("hi");
+    expect(
+      await evalNum(
+        `class A { a: number; b: number; constructor(a: number, b: number){ this.a=a; this.b=b; } } class B extends A {} class C extends B {} export function test(): number { const c = new C(5, 6); return c.a - c.b; }`,
+      ),
+    ).toBe(-1);
+  });
+
+  it("honours forwarded parent default parameters", async () => {
+    expect(
+      await evalNum(
+        `class A { v: number; constructor(v: number = 7){ this.v = v; } } class B extends A {} export function test(): number { return new B().v; }`,
+      ),
+    ).toBe(7);
+    expect(
+      await evalNum(
+        `class A { v: number; constructor(v: number = 7){ this.v = v; } } class B extends A {} export function test(): number { return new B(3).v; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("runs parent field initializers alongside forwarded ctor args", async () => {
+    expect(
+      await evalStr(
+        `class A { tag = "A"; name: string; constructor(n: string){ this.name = n; } } class B extends A {} export function test(): string { const b = new B("x"); return b.tag + b.name; }`,
+      ),
+    ).toBe("Ax");
+  });
+
+  it("does not regress an explicit derived constructor", async () => {
+    expect(
+      await evalStr(
+        `class Animal { name: string; constructor(name: string){ this.name = name; } } class Dog extends Animal { constructor(n: string){ super(n); } } export function test(): string { return new Dog("rex").name; }`,
+      ),
+    ).toBe("rex");
+  });
+});


### PR DESCRIPTION
## Summary

A derived class with **no explicit constructor** and a WasmGC-struct parent was
synthesized with a zero-parameter `$Sub_new`. `new Dog("rex")` evaluated the
argument and **dropped** it (the call site forwards by the ctor's param types,
and there were none), so the replayed parent `this.name = name` saw `name`
unresolved → `ref.null` / f64 0, giving `name === null`.

Per spec §15.7.14 the implicit ctor is `constructor(...args){ super(...args) }`.
The externref-backed path (#1833) already forwarded a synthetic param list; this
mirrors that for the WasmGC-struct path:

- `findNearestAncestorCtorParams` walks `classParentMap` to the nearest ancestor
  with an explicit constructor and returns its parameters.
- both ctor-registration sites (func-type + FunctionContext) append those params
  (named locals), so the replayed parent assignments resolve them and the call
  site forwards the args.
- forwarded params also register their optionality and run their default-value
  initialization, so `class A { constructor(v = 7){…} }; class B extends A {};
  new B()` sees `v = 7`.

## Repro (now matches Node)

| Expression | Before | After |
|---|---|---|
| `new Dog("rex").speak()` (Dog extends Animal{}) | `"null barks"` | `"rex barks"` |
| `new Dog("rex").name` | `null` | `"rex"` |
| `new C(3,4)` multi-arg | `0` | fields 3, 4 |
| `new D("hi").x` (3-level chain) | `null` | `"hi"` |
| `new B().v` (parent `v = 7`) | `0` | `7` |

## Tests

`tests/issue-2082.test.ts` — 6 equivalence cases (single/multi-arg forward,
multi-level chain, forwarded parent default params, parent field initializers +
forwarded args, explicit-ctor non-regression). Verified in host and standalone
(WASI) — arg forwarding works in both (numeric-field standalone confirms; the
standalone string-RETURN marshalling error is a separate pre-existing harness
limitation, reproducible on a single non-derived class). #1833's externref-path
tests are unchanged (issue-1833.test.ts green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)