### PR TITLE
fix(#1992,#1991): instanceof Function recognises closures; 'in' sees Object.prototype

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1403,6 +1403,25 @@ const _wasmNonExtensibleObjs = new WeakSet<object>();
 const _userClassTags = new WeakMap<object, string>();
 const _userClassParents = new Map<string, string | null>();
 
+// (#1991) Object.prototype's own enumerable+non-enumerable data/accessor keys.
+// `key in obj` walks to Object.prototype (§13.10.1 → §7.3.12), so every object
+// value has these regardless of own properties — used by `__extern_has` to
+// answer e.g. `"toString" in ({} as any)` for opaque WasmGC-struct receivers.
+const _OBJECT_PROTO_KEYS: ReadonlySet<string> = new Set([
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+  "__proto__",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+]);
+
 /**
  * DataView subview metadata (#1064).
  *
@@ -6334,6 +6353,17 @@ assert._isSameValue = isSameValue;
               }
             }
           }
+          // (#1991) `in` walks the [[Prototype]] chain (§13.10.1 → §7.3.12), so
+          // EVERY object value inherits the Object.prototype members. A WasmGC
+          // struct (object literal / class instance / array) arrives here as an
+          // opaque externref whose `key in obj` above can't see Object.prototype,
+          // so `"toString" in ({} as any)` wrongly returned 0. Recognise the
+          // well-known Object.prototype keys explicitly for any non-null object.
+          // (Inherited *user-class* methods still need a method registry — not
+          // covered here.)
+          if (typeof key === "string" && (typeof obj === "object" || typeof obj === "function") && obj !== null) {
+            if (_OBJECT_PROTO_KEYS.has(key)) return 1;
+          }
           return 0;
         };
       if (name === "__extern_toString")
@@ -9709,6 +9739,24 @@ assert._isSameValue = isSameValue;
           // never reach this branch as wasm structs.
           if (ctorName === "Object" && v != null && _isWasmStruct(v)) {
             return 1;
+          }
+          // (#1992) `<fn> instanceof Function` — a compiled closure is a WasmGC
+          // struct, so V8's `v instanceof Function` above returns false for the
+          // opaque externref. Recognise it via `__is_closure` (the same callable
+          // discriminator `__typeof` uses to report "function"), so an
+          // `any`-typed callable answers `true` as the spec requires. Closures
+          // also have `Object` in their prototype chain — but only the explicit
+          // `Function` / `Object` RHS reaches here as a wasm struct.
+          if (ctorName === "Function" && v != null && typeof v === "object" && _isWasmStruct(v)) {
+            const exports = callbackState?.getExports();
+            const isClosureFn = exports?.__is_closure as ((x: any) => number) | undefined;
+            if (typeof isClosureFn === "function") {
+              try {
+                if (isClosureFn(v) === 1) return 1;
+              } catch {
+                /* fall through to false */
+              }
+            }
           }
           return 0;
         };

--- a/tests/issue-1991.test.ts
+++ b/tests/issue-1991.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1991 — the `in` operator never consulted the [[Prototype]] chain.
+//
+// `key in obj` (§13.10.1 → §7.3.12 HasProperty) walks the prototype chain, so
+// every object value inherits Object.prototype's members. A WasmGC-struct-backed
+// receiver (object literal / array / class instance) arrives at the host
+// `__extern_has` as an opaque externref whose `key in obj` can't see
+// Object.prototype, so `"toString" in ({} as any)` wrongly returned `false`.
+//
+// Fix: `__extern_has` recognises the well-known Object.prototype keys for any
+// non-null object receiver. Own-property and absent-key results are unchanged.
+//
+// SCOPE: inherited *user-class* methods (`"m" in (new C() as any)` where `m` is
+// on a base class) still return false — that needs a compiled class→method
+// registry the runtime can consult, and is left as the harder half of the task.
+
+import { describe, expect, it } from "vitest";
+
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function inTest(body: string): Promise<boolean> {
+  const exports = (await compileAndInstantiate(`export function test(): boolean { ${body} }`)) as { test(): number };
+  return Boolean(exports.test());
+}
+
+describe("#1991 `in` consults Object.prototype members", () => {
+  it("inherited Object.prototype members are found on an object literal", async () => {
+    expect(await inTest('const o: any = { a: 1 }; return "toString" in o;')).toBe(true);
+    expect(await inTest('const o: any = { a: 1 }; return "valueOf" in o;')).toBe(true);
+    expect(await inTest('const o: any = { a: 1 }; return "hasOwnProperty" in o;')).toBe(true);
+    expect(await inTest('const o: any = { a: 1 }; return "constructor" in o;')).toBe(true);
+  });
+
+  it("own data properties are still found", async () => {
+    expect(await inTest('const o: any = { a: 1 }; return "a" in o;')).toBe(true);
+  });
+
+  it("absent properties are still false", async () => {
+    expect(await inTest('const o: any = { a: 1 }; return "zzz" in o;')).toBe(false);
+  });
+
+  it("arrays see both indices/length and Object.prototype members", async () => {
+    expect(await inTest('const a: any = [10, 20]; return "0" in a;')).toBe(true);
+    expect(await inTest('const a: any = [10, 20]; return "length" in a;')).toBe(true);
+    expect(await inTest('const a: any = [10, 20]; return "toString" in a;')).toBe(true);
+  });
+});

--- a/tests/issue-1992.test.ts
+++ b/tests/issue-1992.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1992 — `<value> instanceof Function` was hard-coded false for a compiled
+// closure.
+//
+// A compiled closure is a WasmGC struct, so when `f instanceof Function`
+// reaches the host `__instanceof(v, "Function")` runtime handler, V8's
+// `v instanceof Function` is false for the opaque externref and the handler
+// returned 0. Fix: the handler recognises a callable closure struct via
+// `__is_closure` (the same discriminator `__typeof` uses to report
+// "function") for the `Function` RHS, so an `any`-typed callable answers
+// `true`. Non-callables (objects / strings / numbers) stay false; `instanceof
+// Object` and user-class `instanceof` are unchanged.
+
+import { describe, expect, it } from "vitest";
+
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function instanceofTest(body: string): Promise<boolean> {
+  const exports = (await compileAndInstantiate(`export function test(): boolean { ${body} }`)) as { test(): number };
+  // The exported boolean lowers to an i32 (1/0) at the JS boundary.
+  return Boolean(exports.test());
+}
+
+describe("#1992 instanceof Function recognises compiled closures", () => {
+  it("an arrow function is instanceof Function", async () => {
+    expect(await instanceofTest("const f: any = () => 1; return f instanceof Function;")).toBe(true);
+  });
+
+  it("a function declaration value is instanceof Function", async () => {
+    expect(await instanceofTest("function g() { return 1; } const f: any = g; return f instanceof Function;")).toBe(
+      true,
+    );
+  });
+
+  it("a closure is also instanceof Object (prototype chain)", async () => {
+    expect(await instanceofTest("const f: any = () => 1; return f instanceof Object;")).toBe(true);
+  });
+
+  it("a plain object is NOT instanceof Function", async () => {
+    expect(await instanceofTest("const o: any = { a: 1 }; return o instanceof Function;")).toBe(false);
+  });
+
+  it("primitives (number / string) are NOT instanceof Function", async () => {
+    expect(await instanceofTest("const n: any = 5; return n instanceof Function;")).toBe(false);
+    expect(await instanceofTest('const s: any = "x"; return s instanceof Function;')).toBe(false);
+  });
+
+  it("user-class instanceof is unchanged", async () => {
+    expect(await instanceofTest("class A {} const a: any = new A(); return a instanceof A;")).toBe(true);
+    expect(await instanceofTest("class A {} class B {} const a: any = new A(); return a instanceof B;")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problems

```ts
const f: any = () => 1;  f instanceof Function   // was false   node: true   (#1992)
const o: any = { a: 1 }; "toString" in o          // was false   node: true   (#1991)
```

## Root causes

**#1992** — a compiled closure is a WasmGC struct, so the host
`__instanceof(v, "Function")` handler's `v instanceof Function` is false for the
opaque externref → `f instanceof Function` always returned 0.

**#1991** — `key in obj` walks the [[Prototype]] chain (§13.10.1 → §7.3.12
HasProperty), so every object inherits Object.prototype's members. A WasmGC
struct receiver reaches `__extern_has` as an opaque externref whose `key in obj`
can't see Object.prototype, so `"toString" in ({} as any)` returned 0.

## Fixes (both in `src/runtime.ts`)

- **`__instanceof`**: recognise a callable closure struct via `__is_closure`
  (the discriminator `__typeof` uses to report `"function"`) for the `Function`
  RHS — mirrors the existing `Object` RHS special-case.
- **`__extern_has`**: recognise the well-known `Object.prototype` keys
  (`_OBJECT_PROTO_KEYS`) for any non-null object receiver.

## Scope (task split)

This delivers **#1992 in full** and **the Object.prototype half of #1991**.
**Inherited user-class methods** (`"m" in (new C() as any)` where `m` is on a
base class) still return false — that needs a compiled class→method registry
the runtime can consult, split out as the harder half (a struct instance only
exports `__sget___tag`, no method list). Filed for follow-up.

## Tests & non-regression

`tests/issue-1992.test.ts` (6) + `tests/issue-1991.test.ts` (6), all pass:
closures/objects/primitives `instanceof Function`, user-class `instanceof`,
Object.prototype members + own/absent keys + arrays for `in`. Verified the
pre-existing post-delete / rest-object `in` false-positives are **unchanged**
(identical on `main`, a separate own-key-tracking bug). `instanceof`/`in`
suites' pre-existing `string_constants`/`helpers.js` harness failures are
unaffected.

## Issue files

#1991/#1992 are part of an unmerged spec-conformance batch not yet on any
branch, so status notes live here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)