### PR TITLE
fix(#2014,#2010-residual): numeric-key element access + shorthand-with-spread

### DIFF
--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -979,6 +979,12 @@ export function resolveConstantExpression(ctx: CodegenContext, expr: ts.Expressi
  * Returns undefined if the name cannot be statically resolved.
  */
 export function resolvePropertyNameText(ctx: CodegenContext, prop: ts.ObjectLiteralElementLike): string | undefined {
+  // #2010: a shorthand `{ x }` carries its key as `prop.name` (an Identifier).
+  // Treat it like `{ x: x }` so the open-$Object construction path
+  // (compileObjectLiteralAsExternref) does not skip it — previously this returned
+  // undefined for shorthands, so a literal mixing a shorthand with a spread
+  // (`{ x, ...null }`) dropped the shorthand binding entirely.
+  if (ts.isShorthandPropertyAssignment(prop)) return prop.name.text;
   if (!ts.isPropertyAssignment(prop)) return undefined;
   const name = prop.name;
 
@@ -1408,8 +1414,13 @@ export function compileObjectLiteralForStruct(
   }
 
   for (const field of fields) {
-    // First check for an explicit property assignment (identifier, string literal, or computed key)
-    const prop = expr.properties.find((p) => resolvePropertyNameText(ctx, p) === field.name);
+    // First check for an explicit property assignment (identifier, string literal, or computed key).
+    // #2010: resolvePropertyNameText now also matches shorthands; exclude them here so
+    // the dedicated shorthand branch below (which compiles `prop.name` as the value)
+    // keeps handling them — the property-assignment branch can't read a shorthand.
+    const prop = expr.properties.find(
+      (p) => !ts.isShorthandPropertyAssignment(p) && resolvePropertyNameText(ctx, p) === field.name,
+    );
     // Also check for shorthand property assignment ({ x, y } where x/y are identifiers)
     const shorthandProp = !prop
       ? expr.properties.find((p) => ts.isShorthandPropertyAssignment(p) && p.name.text === field.name)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3495,6 +3495,16 @@ function _safeGet(obj: any, key: any, callbackState?: { getExports: () => Record
   // (e.g. getOwnPropertyNames conversion loop uses __extern_get with integer indices).
   // #1830 — the range must cover every id in `_symbolIdToKeys` (1-15, 15 =
   // @@matchAll); `<= 14` silently dropped Symbol.matchAll on WasmGC structs.
+  // #2014: a small integer key (1-15) collides with the well-known-symbol ID
+  // range below. A genuine numeric data property (`o[2]` on `{ 2: "two" }`) is
+  // stored under the string field name "2" and exposed as `__sget_2`, so try
+  // that real-property getter BEFORE interpreting the key as a symbol ID —
+  // otherwise `o[2]` is mis-resolved as Symbol(2) and returns undefined.
+  if (_isWasmStruct(obj) && typeof key === "number" && Number.isInteger(key) && key >= 0) {
+    const exports = callbackState?.getExports();
+    const getter = exports?.[`__sget_${String(key)}`];
+    if (typeof getter === "function") return getter(obj);
+  }
   if (_isWasmStruct(obj) && typeof key === "number" && key >= 1 && key <= 15) {
     const symKeys = _symbolIdToKeys.get(key);
     if (symKeys) {

--- a/tests/issue-2014.test.ts
+++ b/tests/issue-2014.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2014 — numeric-key element access on a struct/any receiver.
+// `o[2]` / `o[i]` on `{ 2: "two" }` returned undefined while `o["2"]` worked:
+// a small integer key (1-15) collided with the well-known-symbol ID range in
+// `_safeGet`, so the numeric key was mis-resolved as Symbol(n) before the real
+// `__sget_<n>` property getter was tried.
+//
+// #2010 residual — a shorthand property mixed with a spread (`{ x, ...null }`)
+// dropped the shorthand binding: `resolvePropertyNameText` returned undefined
+// for shorthands, so the open-$Object construction path skipped them entirely.
+
+async function evalNum(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+async function evalStr(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+
+describe("#2014 numeric-key element access", () => {
+  it("reads a numeric-literal key", async () => {
+    expect(await evalStr(`export function test(): string { const o: any = { 2: "two" }; return o[2]; }`)).toBe("two");
+  });
+
+  it("reads a string-literal key (was already working)", async () => {
+    expect(await evalStr(`export function test(): string { const o: any = { 2: "two" }; return o["2"]; }`)).toBe("two");
+  });
+
+  it("reads a dynamic numeric-variable key", async () => {
+    expect(
+      await evalStr(`export function test(): string { const o: any = { 2: "two" }; const i = 2; return o[i]; }`),
+    ).toBe("two");
+  });
+
+  it("does not regress array indexing", async () => {
+    expect(await evalNum(`export function test(): number { const a = [10, 20, 30]; return a[1]; }`)).toBe(20);
+    expect(await evalNum(`export function test(): number { const a = [10, 20, 30]; const i = 2; return a[i]; }`)).toBe(
+      30,
+    );
+  });
+});
+
+describe("#2010 residual: shorthand + spread", () => {
+  it("keeps a leading shorthand alongside an error-typed spread", async () => {
+    expect(
+      await evalNum(
+        `export function test(): number { const x = 5; const o = { x, ...null, y: 6 }; return (o as any).x; }`,
+      ),
+    ).toBe(5);
+    expect(
+      await evalNum(
+        `export function test(): number { const x = 5; const o = { x, ...null, y: 6 }; return (o as any).y; }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("keeps a shorthand after a spread", async () => {
+    expect(
+      await evalNum(`export function test(): number { const x = 5; const o = { ...null, x }; return (o as any).x; }`),
+    ).toBe(5);
+  });
+
+  it("does not regress a shorthand without a spread", async () => {
+    expect(
+      await evalNum(`export function test(): number { const x = 5; const o = { x, y: 6 }; return (o as any).x; }`),
+    ).toBe(5);
+  });
+
+  it("does not regress a non-leading named property with a spread", async () => {
+    expect(
+      await evalNum(`export function test(): number { const o = { a: 5, ...null, b: 6 }; return (o as any).a; }`),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

**#2014** — `o[2]` / `o[i]` on `{ 2: "two" }` returned `undefined` while `o["2"]`
worked. A small integer key (1-15) collided with the well-known-symbol ID range
in `_safeGet`: the numeric key was interpreted as `Symbol(n)` and returned
`undefined` before the real `__sget_<n>` property getter was ever tried. Now try
the `__sget_${String(key)}` getter for any non-negative integer key FIRST
(matching ES OrdinaryGet's ToPropertyKey — `o[2]` and `o["2"]` name the same
property), then fall through to the symbol-ID interpretation. Array indexing is
unaffected (arrays are vec structs, not `$Object`s, and never reach this branch).

**#2010 residual** — a shorthand property mixed with a spread (`{ x, ...null }`,
`{ ...null, x }`) dropped the shorthand binding. `resolvePropertyNameText`
returned `undefined` for shorthands, so the open-`$Object` construction path
(`compileObjectLiteralAsExternref`) skipped them (`keyText === undefined →
continue`). It now returns the shorthand's name; the closed-struct path's
property find is adjusted to keep routing shorthands through its dedicated
shorthand branch (which reads `prop.name` as the value).

## Repros (now match Node)

| Expression | Before | After |
|---|---|---|
| `o[2]` on `{ 2: "two" }` | `undefined` | `"two"` |
| `o[i]` (i=2) | `undefined` | `"two"` |
| `o["2"]` | `"two"` | `"two"` (unchanged) |
| `{ x, ...null, y: 6 }.x` | `null` | `5` |
| `{ ...null, x }.x` | `null` | `5` |
| `[10,20,30][1]` | `20` | `20` (unchanged) |

## Tests

`tests/issue-2014.test.ts` — 8 equivalence cases (numeric-literal / string-literal
/ dynamic-variable keys; array-indexing non-regression; leading & trailing
shorthand with a spread; shorthand-without-spread and named-prop-with-spread
non-regression). Related suites green (numeric-key-object, object-literals,
object-methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)