### PR TITLE
fix(#2078): replay base-ctor body field assignments on explicit super()

### DIFF
--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -2079,6 +2079,72 @@ export function compileSuperCall(
       compileExpression(ctx, fctx, member.initializer, childFields[fieldIdx]!.type);
       fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
     }
+    // #2078 — also replay the ancestor constructor BODY's `this.<field> = <expr>`
+    // assignments. Field declarations only cover initialized members (`x = 5`);
+    // a base ctor that sets `this.x = 1` in its body would otherwise leave the
+    // child's `x` slot at its zero default after an explicit `super()` (the
+    // implicit-super path already does this; compileSuperCall did not). Mirrors
+    // the implicit-super replay above. super()/argument-positional fields are
+    // handled separately below, so skip nested super() statements here.
+    const ancestorCtor = ancestorDecl.members.find(ts.isConstructorDeclaration) as
+      | ts.ConstructorDeclaration
+      | undefined;
+    if (ancestorCtor?.body) {
+      // Parent-ctor parameter names: assignments whose RHS reads a parameter
+      // (`constructor(v){ this.x = v*2 }`) are NOT replayed here — `v` is not
+      // bound in the child's super() frame, and the positional super(args)→field
+      // mapping below already drives those fields. We only replay
+      // parameter-independent body assignments (`this.x = 1`, `this.w = this.x + 3`).
+      const paramNames = new Set<string>();
+      for (const p of ancestorCtor.parameters) {
+        if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
+      }
+      const rhsReadsParam = (expr: ts.Expression): boolean => {
+        let found = false;
+        const visit = (n: ts.Node): void => {
+          if (found) return;
+          // A bare identifier that names a parameter (but not a `this.<param>`
+          // property access — that's a field, fine to replay).
+          if (ts.isIdentifier(n) && paramNames.has(n.text)) {
+            const parent = n.parent;
+            const isPropName = parent && ts.isPropertyAccessExpression(parent) && parent.name === n;
+            if (!isPropName) found = true;
+            return;
+          }
+          ts.forEachChild(n, visit);
+        };
+        visit(expr);
+        return found;
+      };
+      for (const stmt of ancestorCtor.body.statements) {
+        if (
+          ts.isExpressionStatement(stmt) &&
+          ts.isCallExpression(stmt.expression) &&
+          stmt.expression.expression.kind === ts.SyntaxKind.SuperKeyword
+        ) {
+          continue; // handled by ancestor chain order
+        }
+        if (
+          ts.isExpressionStatement(stmt) &&
+          ts.isBinaryExpression(stmt.expression) &&
+          stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+          ts.isPropertyAccessExpression(stmt.expression.left) &&
+          stmt.expression.left.expression.kind === ts.SyntaxKind.ThisKeyword
+        ) {
+          if (rhsReadsParam(stmt.expression.right)) continue;
+          const rawName = stmt.expression.left.name.text;
+          const bodyFieldName = ts.isPrivateIdentifier(stmt.expression.left.name)
+            ? "__priv_" + rawName.slice(1)
+            : rawName;
+          const bodyFieldIdx = childFields.findIndex((f) => f.name === bodyFieldName);
+          if (bodyFieldIdx !== -1) {
+            fctx.body.push({ op: "local.get", index: selfLocal });
+            compileExpression(ctx, fctx, stmt.expression.right, childFields[bodyFieldIdx]!.type);
+            fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx: bodyFieldIdx });
+          }
+        }
+      }
+    }
   }
 
   // Evaluate super(args) and assign to parent fields on the child struct.

--- a/tests/issue-2078.test.ts
+++ b/tests/issue-2078.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2078 — a derived class's explicit `super()` must replay the base
+// constructor BODY's `this.<field> = <expr>` assignments. Previously only field
+// initializers + positional super(args) were applied, so `class A { x;
+// constructor(){ this.x = 1; } }` left `this.x` at 0 in the subclass.
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const env = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(env, `standalone leaked env imports: ${env.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+async function runHost(source: string): Promise<number> {
+  const r = await compile(source);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const POST_SUPER = `
+class A { x: number; constructor(){ this.x = 1; } }
+class B extends A { y: number; constructor(){ super(); this.y = this.x + 1; } }
+export function run(): number { return new B().y; }`; // 2
+
+const BASE_FIELD = `
+class A { x: number; constructor(){ this.x = 1; } }
+class B extends A { y: number; constructor(){ super(); this.y = 99; } }
+export function run(): number { return new B().x; }`; // 1
+
+const METHOD_READ = `
+class A { x: number; constructor(){ this.x = 1; } }
+class B extends A { y: number; constructor(){ super(); this.y = 5; } getSum(): number { return this.x + this.y; } }
+export function run(): number { return new B().getSum(); }`; // 6
+
+const MULTILEVEL = `
+class A { x: number; constructor(){ this.x = 1; } }
+class B extends A { y: number; constructor(){ super(); this.y = this.x + 1; } }
+class C extends B { z: number; constructor(){ super(); this.z = this.x + this.y + 1; } }
+export function run(): number { const c = new C(); return c.x * 100 + c.y * 10 + c.z; }`; // 124
+
+const MIXED = `
+class A { x: number = 7; w: number; constructor(){ this.w = this.x + 3; } }
+class B extends A { y: number; constructor(){ super(); this.y = this.w; } }
+export function run(): number { const b = new B(); return b.x * 100 + b.w * 10 + b.y; }`; // 810
+
+describe("#2078 — explicit super() replays base ctor body assignments (standalone)", () => {
+  it("post-super this.x read returns 2", async () => expect(await runStandalone(POST_SUPER)).toBe(2));
+  it("direct base-field read returns 1", async () => expect(await runStandalone(BASE_FIELD)).toBe(1));
+  it("method read of base field returns 6", async () => expect(await runStandalone(METHOD_READ)).toBe(6));
+  it("multi-level A->B->C chain returns 124", async () => expect(await runStandalone(MULTILEVEL)).toBe(124));
+  it("mixed field-initializer + body assignment returns 810", async () => expect(await runStandalone(MIXED)).toBe(810));
+});
+
+describe("#2078 — host mode unchanged", () => {
+  it("post-super this.x read returns 2", async () => expect(await runHost(POST_SUPER)).toBe(2));
+  it("multi-level A->B->C chain returns 124", async () => expect(await runHost(MULTILEVEL)).toBe(124));
+  it("mixed field-initializer + body assignment returns 810", async () => expect(await runHost(MIXED)).toBe(810));
+});


### PR DESCRIPTION
## Summary

```ts
class A { x: number; constructor(){ this.x = 1; } }
class B extends A { y: number; constructor(){ super(); this.y = this.x + 1; } }
new B().y   // standalone: 1 (this.x read 0)   node: 2
new B().x   // standalone: 0                   node: 1
```

The base constructor's `this.x = 1` was never replayed for the derived class. `compileSuperCall` (the explicit-`super()` path) only replayed ancestor **field initializers** (`x = 5` property declarations) and mapped `super(args)` positionally to parent fields — it never ran the parent constructor **body**'s `this.<field> = <expr>` assignments. So `this.x` stayed at its zero default. (The implicit-super path — auto-generated `super()` for default constructors — already did this; this ports the same replay to `compileSuperCall`.)

### Fix
After the field-initializer replay in `compileSuperCall`, also replay each ancestor constructor body's `this.<field> = <expr>` assignment onto the child struct (skipping nested `super()` statements). Parameter-dependent assignments (`constructor(v){ this.x = v*2 }`) are **skipped** — `v` isn't bound in the child's `super()` frame, and the existing positional `super(args)→field` mapping already drives those fields (its handling of computed param assignments is a separate, pre-existing limitation, left unchanged → no regression). Parameter-independent assignments (`this.x = 1`, `this.w = this.x + 3`) are replayed.

## Testing
- `tests/issue-2078.test.ts` — 8 cases: post-super `this.x` read (→2), direct base-field read (→1), method read (→6), multi-level A→B→C (→124), mixed field-init + body assignment (→810); host + standalone (zero env imports). All green.
- `tsc --noEmit` clean; IR fallback gate OK.
- Note: the existing `classes.test.ts`/`class-method-struct-new.test.ts` failures are pre-existing on upstream/main (those test harnesses don't wire `string_constants`) — confirmed unchanged by this PR.

Issue file is on PR #1315's branch, so status is noted here rather than flipped in-tree: #2078 is **done** with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)