### PR TITLE
plan(ci): #1955 pool=4 verdict (keep 3), #1958 merge_group event-drop watchdog issue

### DIFF
--- a/plan/issues/1955-test262-pool-4-experiment.md
+++ b/plan/issues/1955-test262-pool-4-experiment.md
@@ -1,9 +1,10 @@
 ---
 id: 1955
 title: "test262: evaluate COMPILER_POOL_SIZE=4 on the 4-vCPU shard runners"
-status: ready
+status: done
 created: 2026-06-11
 updated: 2026-06-11
+completed: 2026-06-11
 priority: low
 feasibility: easy
 reasoning_effort: low
@@ -11,6 +12,24 @@ sprint: 61
 depends_on: [1953]
 area: ci
 ---
+## Result (2026-06-11): measured — KEEPING pool=3
+
+Dispatch run 27324333289 (`compiler_pool_size=4`, main, pre-#1342 maps, so
+directly comparable to the pool=3 run 27309868379):
+
+| | pool=3 | pool=4 | Δ |
+|---|---|---|---|
+| shard p50 | 110s | 107s | −3s |
+| shard p90 | 126s | 121s | −5s |
+| shard max | 141–153s | 141s | ~−12s |
+| corpus `compile_timeout` | 64 | **79** | **+23 %** |
+
+The wall win (−12s max) fails the decision rule's second condition: the
+timeout-flake count rose markedly under 4 forks + vitest main on 4 vCPUs.
+Those timeouts are excluded from regression gating but pollute the baseline
+and every dev-self-merge analysis. Verdict: the default stays **3**; the
+dispatch input remains available for re-testing if runners grow.
+
 ## Problem / opportunity
 
 #1311 bumped the shard compiler pool from 2 → 3 forks (4-vCPU public-repo

--- a/plan/issues/1958-merge-group-checks-requested-event-drops.md
+++ b/plan/issues/1958-merge-group-checks-requested-event-drops.md
@@ -1,0 +1,68 @@
+---
+id: 1958
+title: "CI: merge_group checks_requested events intermittently dropped — queue wedges with AWAITING_CHECKS groups that have no check suites"
+status: ready
+created: 2026-06-11
+updated: 2026-06-11
+priority: high
+feasibility: medium
+reasoning_effort: medium
+sprint: 61
+area: ci
+---
+## Problem (observed 2026-06-11, twice)
+
+GitHub intermittently fails to deliver `merge_group checks_requested` events
+for this repo. The queue then sits with entries in AWAITING_CHECKS whose
+group head commits have **no github-actions check suite at all** (only the
+third-party app suites: cloudflare/cursor/claude, all `queued runs:0`), and
+no workflow runs are ever created for the group refs.
+
+Evidence:
+
+- Window 1: last merge_group run 23:33Z; head entry #1283 stuck >5h;
+  recycling the head (dequeue+enqueue, fresh group ref `aabcaa7f…` built)
+  produced a group but again no check suite after 20+ min. Unstuck by
+  admin-merging two validated PRs at 03:25Z — the main advance rebuilt all
+  groups and fresh events were delivered (runs resumed 03:44Z).
+- Window 2: after #1343 merged at 04:40Z, no merge_group runs were created
+  again; by 05:30Z five concurrent groups (post-#1956 `build=5`) all sat
+  AWAITING_CHECKS with no suites.
+- Same night, a `pull_request` event was also dropped once (PR #1314's
+  initial push produced no workflow runs; an empty-commit `synchronize`
+  fixed it) — so this is a delivery-layer problem, not merge_group-specific
+  config. githubstatus.com reported all systems operational throughout.
+
+## Current mitigations (already live)
+
+- `check_response_timeout_minutes` lowered 240 → 60 (#1956 ruleset flip):
+  a no-show group fails out of the queue after 1h instead of 4h.
+- `auto-enqueue.yml` re-enqueues open green PRs every 10 min, so timed-out
+  entries re-enter automatically → wedges self-heal on a ~1h carousel
+  instead of permanently.
+- Main advances (any push) rebuild all groups and re-fire events — observed
+  to recover delivery.
+
+## Proposed fix: queue watchdog in merge-group-sweeper.yml (#1952)
+
+The sweeper already runs on a 15-min schedule with an API token. Extend it:
+
+1. Query the merge queue (GraphQL `mergeQueue.entries` with state +
+   `headCommit`/position).
+2. For each AWAITING_CHECKS entry older than ~10 min, check the group head
+   commit's check-suites for a `github-actions` suite
+   (`/commits/<sha>/check-suites`).
+3. If absent → the event was dropped: `dequeuePullRequest` +
+   `enqueuePullRequest` (a fresh group re-rolls delivery). Cap at 1
+   recycle/entry/sweep and log loudly. Needs `pull-requests: write` and the
+   GraphQL mutations to work with GITHUB_TOKEN (verify; else a PAT/app token).
+4. If recycling twice doesn't produce a suite, emit a `::error::` for
+   human triage (likely a GitHub support ticket — collect group SHAs and
+   delivery timestamps from this issue as evidence).
+
+## Acceptance criteria
+
+- A dropped-event wedge clears within one sweeper cycle (≤15 min) without
+  human intervention.
+- No recycle ever happens for a group that HAS a github-actions suite
+  (in-progress validations are untouched).

--- a/plan/issues/sprints/61.md
+++ b/plan/issues/sprints/61.md
@@ -62,6 +62,7 @@ queue-rebuild churn, shard imbalance, PR-time volume, queue serialization):
 - [#1955](../1955-test262-pool-4-experiment.md) — COMPILER_POOL_SIZE=4 experiment
 - [#1956](../1956-ci-merge-group-predecessor-diff-batching.md) — merge-group predecessor diffing → queue batching (rollups)
 - [#1957](../1957-test262-fork-realm-isolation.md) — realm-contamination canary (root fix for order-dependent flips; unblocked #1953)
+- [#1958](../1958-merge-group-checks-requested-event-drops.md) — merge_group event drops: queue watchdog in the sweeper
 
 ## Definition of done
 


### PR DESCRIPTION
Closes out the sprint-61 CI-efficiency track bookkeeping:

- **#1955 → done**: pool=4 dispatch measured (run 27324333289, comparable corpus to the pool=3 run): shard max −12s but corpus `compile_timeout` 64 → 79 (+23 %). Fails the issue's decision rule; **default stays 3**, dispatch input remains for re-testing.
- **#1958 → ready (new)**: twice tonight GitHub dropped `merge_group checks_requested` events — queue entries sat AWAITING_CHECKS with **no github-actions check suite** on their group heads (evidence + timeline in the issue; a `pull_request` event was also dropped once, so it's delivery-layer). Live mitigations: `check_response_timeout` 240→60 min (#1956 flip) + the auto-enqueue carousel make wedges self-heal in ~1h. The issue specs a sweeper watchdog (#1952 extension) that detects suite-less AWAITING_CHECKS entries and recycles them within ≤15 min.
- Sprint-61 doc: #1958 added to the CI track list.

Plan-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)