### PR TITLE
fix(#2053): spread followed by trailing positional args miscompiles to NaN

### DIFF
--- a/plan/issues/2053-spread-with-trailing-positional-arg-nan.md
+++ b/plan/issues/2053-spread-with-trailing-positional-arg-nan.md
@@ -1,10 +1,11 @@
 ---
 id: 2053
 title: "f(...arr, x) — trailing positional arg after spread silently miscompiles to NaN"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -74,3 +75,32 @@ currently also silently read OOB) rather than callee arity.
 Grepped spread issues: #18, #177, #213, #382, #409, #536, #761, #987, #1519,
 #1609, #1749 — all done; cover new-expression spread, destructuring rest, object
 spread, iterator override. None cover trailing-arg-after-spread in direct calls.
+
+## Resolution (2026-06-11)
+
+Fixed in `compileSpreadCallArgs` (non-rest target path) at
+`src/codegen/expressions/extern.ts`. Before expanding a spread, the code now
+precomputes `trailingPositionalAfter[argPos]` (count of non-spread args that
+follow each arg index) and reserves those param slots:
+`remainingParams = max(0, paramTypes.length - paramIdx - reservedForTrailing)`.
+The spread now expands only into the parameters it actually covers; trailing
+positional args fill the reserved slots instead of being left as surplus stack
+values, and the spread no longer reads past its array (OOB → NaN).
+
+### Test Results
+
+`tests/issue-2053.test.ts` (7 cases, all PASS):
+
+| case | result |
+|------|--------|
+| `sum3(...arr, 3)` (arr=[1,2]) | 123 ✓ |
+| `sum3(1, ...arr)` (arr=[2,3], unregressed) | 123 ✓ |
+| `sum3(...arr)` exact arity (unregressed) | 123 ✓ |
+| `sum3(1, ...arr, 3)` (arr=[2]) | 123 ✓ |
+| `sum4(...arr, 3, 4)` (arr=[1,2]) | 1234 ✓ |
+| `sum4(1, ...arr, 4)` (arr=[2,3]) | 1234 ✓ |
+| `sum3(...arr, 2, 3)` (arr=[1]) | 123 ✓ |
+
+`tsc --noEmit` clean. Pre-existing failures in `tests/spread-rest.test.ts`
+(missing `string_constants` import object) are unrelated — present on baseline
+with this change reverted.

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -480,8 +480,7 @@ function compileSpreadCallArgs(
   const trailingPositionalAfter: number[] = new Array(args.length).fill(0);
   for (let i = args.length - 2; i >= 0; i--) {
     const next = args[i + 1]!;
-    trailingPositionalAfter[i] =
-      trailingPositionalAfter[i + 1]! + (ts.isSpreadElement(next) ? 0 : 1);
+    trailingPositionalAfter[i] = trailingPositionalAfter[i + 1]! + (ts.isSpreadElement(next) ? 0 : 1);
   }
 
   // Collect all arguments, resolving spreads

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -471,9 +471,23 @@ function compileSpreadCallArgs(
   // Strategy: for each spread arg, store the vec in a local, extract data array, then extract elements by index
   if (!paramTypes) return;
 
+  // Count non-spread (positional) args that follow each argument index, so a
+  // spread that precedes trailing positional args reserves their param slots
+  // instead of greedily consuming every remaining parameter (#2053). Without
+  // this, `f(...arr, x)` reads one element too many out of the spread vec
+  // (OOB → NaN) and compiles `x` as a surplus stack value.
+  const args = expr.arguments;
+  const trailingPositionalAfter: number[] = new Array(args.length).fill(0);
+  for (let i = args.length - 2; i >= 0; i--) {
+    const next = args[i + 1]!;
+    trailingPositionalAfter[i] =
+      trailingPositionalAfter[i + 1]! + (ts.isSpreadElement(next) ? 0 : 1);
+  }
+
   // Collect all arguments, resolving spreads
   let paramIdx = 0;
-  for (const arg of expr.arguments) {
+  for (let argPos = 0; argPos < args.length; argPos++) {
+    const arg = args[argPos]!;
     if (ts.isSpreadElement(arg)) {
       // Compile the spread source (vec struct)
       const vecType = compileExpression(ctx, fctx, arg.expression);
@@ -504,7 +518,10 @@ function compileSpreadCallArgs(
       const arrDefSpread = ctx.mod.types[arrTypeIdx];
       const spreadElemType =
         arrDefSpread && arrDefSpread.kind === "array" ? arrDefSpread.element : { kind: "f64" as const };
-      const remainingParams = paramTypes.length - paramIdx;
+      // Reserve param slots for trailing positional args after this spread so
+      // the spread only expands into the parameters it actually covers (#2053).
+      const reservedForTrailing = trailingPositionalAfter[argPos] ?? 0;
+      const remainingParams = Math.max(0, paramTypes.length - paramIdx - reservedForTrailing);
       for (let i = 0; i < remainingParams; i++) {
         fctx.body.push({ op: "local.get", index: dataLocal });
         fctx.body.push({ op: "i32.const", value: i });

--- a/tests/issue-2053.test.ts
+++ b/tests/issue-2053.test.ts
@@ -8,10 +8,9 @@ import { compile } from "../src/index.js";
 
 async function compileAndRun(source: string) {
   const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
   return instance.exports as Record<string, Function>;
 }

--- a/tests/issue-2053.test.ts
+++ b/tests/issue-2053.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2053 — a spread followed by trailing positional args used to greedily
+// consume every remaining parameter, reading past the spread array (OOB → NaN)
+// and leaving the trailing args as surplus stack values. The fix reserves the
+// trailing positional param slots so the spread only fills the params it covers.
+
+async function compileAndRun(source: string) {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+const SUM3 = `function sum3(a: number, b: number, c: number): number { return a * 100 + b * 10 + c; }`;
+const SUM4 = `function sum4(a: number, b: number, c: number, d: number): number { return a * 1000 + b * 100 + c * 10 + d; }`;
+
+describe("#2053 spread followed by trailing positional args", () => {
+  it("spread then one trailing positional", async () => {
+    const e = await compileAndRun(
+      SUM3 + `export function f(): number { const arr: number[] = [1, 2]; return sum3(...arr, 3); }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+
+  it("leading positional then spread (unregressed)", async () => {
+    const e = await compileAndRun(
+      SUM3 + `export function f(): number { const arr: number[] = [2, 3]; return sum3(1, ...arr); }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+
+  it("spread fills exact arity (unregressed)", async () => {
+    const e = await compileAndRun(
+      SUM3 + `export function f(): number { const arr: number[] = [1, 2, 3]; return sum3(...arr); }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+
+  it("spread in the middle with trailing positional", async () => {
+    const e = await compileAndRun(
+      SUM3 + `export function f(): number { const arr: number[] = [2]; return sum3(1, ...arr, 3); }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+
+  it("spread then two trailing positionals", async () => {
+    const e = await compileAndRun(
+      SUM4 + `export function f(): number { const arr: number[] = [1, 2]; return sum4(...arr, 3, 4); }`,
+    );
+    expect(e.f()).toBe(1234);
+  });
+
+  it("middle spread covering one element", async () => {
+    const e = await compileAndRun(
+      SUM4 + `export function f(): number { const arr: number[] = [2, 3]; return sum4(1, ...arr, 4); }`,
+    );
+    expect(e.f()).toBe(1234);
+  });
+
+  it("short spread plus two trailing positionals", async () => {
+    const e = await compileAndRun(
+      SUM3 + `export function f(): number { const arr: number[] = [1]; return sum3(...arr, 2, 3); }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+});


### PR DESCRIPTION
## Problem

A call mixing a spread with a **trailing** positional argument compiled cleanly but produced `NaN`: `sum3(...arr, 3)` returned NaN instead of 123. `compileSpreadCallArgs` (non-rest target path) expanded the spread into *every* remaining parameter, reading one element past the spread array (OOB → NaN) and leaving the trailing `3` as a surplus stack value. No diagnostic was emitted.

## Fix

In `src/codegen/expressions/extern.ts`, precompute `trailingPositionalAfter[argPos]` (count of non-spread args after each arg index) and reserve those param slots:

```
remainingParams = max(0, paramTypes.length - paramIdx - reservedForTrailing)
```

The spread now expands only into the parameters it actually covers; trailing positional args fill the reserved slots. Handles spread-in-the-middle (`f(1, ...arr, 4)`) and multiple trailing args (`f(...arr, 3, 4)`).

## Tests

`tests/issue-2053.test.ts` — 7 cases, all pass:
- `sum3(...arr, 3)` → 123
- `sum3(1, ...arr)`, `sum3(...arr)` exact arity — unregressed
- `sum3(1, ...arr, 3)`, `sum4(...arr, 3, 4)`, `sum4(1, ...arr, 4)`, `sum3(...arr, 2, 3)`

`tsc --noEmit` clean. Closes #2053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)