### PR TITLE
fix(codegen): #2061 retarget cloned finally branches for abrupt-site nesting depth

### DIFF
--- a/plan/issues/2061-finally-clone-branch-depth-mismatch.md
+++ b/plan/issues/2061-finally-clone-branch-depth-mismatch.md
@@ -1,10 +1,11 @@
 ---
 id: 2061
 title: "cloned finally branch depths not adjusted for nesting of the abrupt-completion site (return/break inside if inside try)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -95,3 +96,39 @@ Grepped `finally`, `cloneFinally`, `bumpOuterBranchDepths`: #1378 (completion
 override itself — works), #1858 C6 (the dual defect: branches inside the
 finally body, fixed), #1169h (IR port notes). The insertion-site-depth defect
 is unfiled.
+
+## Resolution (2026-06-11)
+
+Implemented the fix-direction approach. The key invariant that makes the delta
+cheap to compute: **every label-creating construct (`if`, `block`, `loop`,
+`switch`, `try`) bumps ALL pre-existing outer break/continue stack entries by
++1, uniformly** (verified in `compileIfStatement` :449, `compileSwitchStatement`
+:710/745, `compileTryStatement` :272, loops). So the extra nesting between an
+abrupt-completion site and the try frame at which the finally body was
+pre-compiled is a single scalar, readable from any outer entry as
+`current depth − try-entry-baseline depth`.
+
+Changes:
+- `FunctionContext.finallyStack` entries (`context/types.ts`) gained
+  `cloneFinallyAtDepth`, `breakDepthBaseline`, `continueDepthBaseline`. The
+  baselines are snapshots of `breakStack`/`continueStack` taken when the entry
+  is pushed (i.e. already at try-frame +1).
+- The three push sites set the new fields: `exceptions.ts` try-body (:281) and
+  catch-body (:379) entries forward the existing `cloneFinallyAtDepth`
+  (already used for the +2 catch_all sites) and snapshot the stacks;
+  `loops.ts` for-of iterator-close (:4098) uses the same closure for both clone
+  variants (its body has no outer-targeting `br`, so the delta is a no-op).
+- `control-flow.ts` gained `finallyInlineDelta(fctx, entry)` and routes all
+  three inline sites — `compileReturnStatement` (:196), `compileBreakStatement`
+  (:884), `compileContinueStatement` (:914) — through
+  `entry.cloneFinallyAtDepth(finallyInlineDelta(...))` instead of the raw
+  `entry.cloneFinally()`. When the site is at the try frame itself the delta is
+  0 and `cloneFinallyAtDepth(0)` is identical to `cloneFinally()`, so the prior
+  (correct) shallow-nesting behavior is preserved.
+
+Regression coverage: `tests/issue-2061-finally-clone-depth.test.ts` (6 cases)
+covers the two repros plus a depth-2 `return`, `continue`-in-finally nested in
+`if`, a labeled-break-from-finally three `if`s deep, and a `break`-in-finally
+where the abrupt site is inside a `switch` in the try. All match Node via
+`assertEquivalent` (which also runs `WebAssembly.validate`). The #1858 C6 suite
+(branches *inside* the finally body) stays green.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -333,6 +333,25 @@ export interface FunctionContext {
     cloneFinally: () => Instr[];
     breakStackLen: number;
     continueStackLen: number;
+    /**
+     * Clone the finally body and bump every `br`/`br_if`/`br_table` in it that
+     * targets a label OUTSIDE the finally body by `extraDepth`. The pre-compiled
+     * finally was lowered at the try-frame depth (+1); inlining it at an
+     * abrupt-completion site nested deeper than the try frame (inside an
+     * `if`/`switch`/inner-`try` within the try) requires bumping those
+     * outer-targeting branches by the extra nesting delta. (#2061)
+     */
+    cloneFinallyAtDepth: (extraDepth: number) => Instr[];
+    /**
+     * Snapshot of `breakStack` taken when this entry was pushed (i.e. at the
+     * try-frame depth). At an inline site the nesting delta is
+     * `current breakStack value − this snapshot value` for any outer label
+     * (every label op bumps all outer entries uniformly, so the delta is the
+     * same across entries). (#2061)
+     */
+    breakDepthBaseline: number[];
+    /** Snapshot of `continueStack` at push time — see `breakDepthBaseline`. (#2061) */
+    continueDepthBaseline: number[];
   }[];
   /**
    * Pending writeback instructions for mutable callback captures (#859).

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -21,6 +21,35 @@ import {
 import { emitLinearU8ArenaReset } from "../linear-uint8-arena.js";
 import { adjustRethrowDepth } from "./shared.js";
 
+/**
+ * (#2061) Compute the extra nesting depth between a finally-inline site and the
+ * try frame at which the finally body was pre-compiled.
+ *
+ * The finally body is lowered once with break/continue depths bumped by exactly
+ * +1 (the try frame). When a return/break/continue that triggers the inline is
+ * nested DEEPER than the try frame (inside an `if`/`switch`/inner-`try` within
+ * the try block), every label op descended since try entry has bumped all outer
+ * break/continue stack entries by +1, uniformly. So the delta is simply
+ * `current outer-label depth − baseline outer-label depth`, read from any outer
+ * entry. Returns 0 when the inline site is at the try frame itself, or when no
+ * outer label exists to measure against (e.g. a finally containing only
+ * `return`, whose clone has no outer-targeting branches to retarget).
+ */
+function finallyInlineDelta(
+  fctx: FunctionContext,
+  entry: { breakDepthBaseline: number[]; continueDepthBaseline: number[] },
+): number {
+  for (let i = entry.breakDepthBaseline.length - 1; i >= 0; i--) {
+    const cur = fctx.breakStack[i];
+    if (cur !== undefined) return cur - entry.breakDepthBaseline[i]!;
+  }
+  for (let i = entry.continueDepthBaseline.length - 1; i >= 0; i--) {
+    const cur = fctx.continueStack[i];
+    if (cur !== undefined) return cur - entry.continueDepthBaseline[i]!;
+  }
+  return 0;
+}
+
 function canTailCall(ctx: CodegenContext, fctx: FunctionContext, calleeIdx: number): boolean {
   let calleeTypeIdx: number | undefined;
   if (calleeIdx < ctx.numImportFuncs) {
@@ -191,9 +220,12 @@ export function compileReturnStatement(ctx: CodegenContext, fctx: FunctionContex
       retTmpIdx = allocLocal(fctx, `__finally_ret_${fctx.locals.length}`, fctx.returnType);
       fctx.body.push({ op: "local.set", index: retTmpIdx });
     }
-    // Inline ALL pending finally blocks from innermost to outermost
+    // Inline ALL pending finally blocks from innermost to outermost. Each
+    // clone's outer-targeting branches must be retargeted for the extra nesting
+    // between this return site and that try frame (#2061).
     for (let i = fctx.finallyStack!.length - 1; i >= 0; i--) {
-      fctx.body.push(...fctx.finallyStack![i]!.cloneFinally());
+      const entry = fctx.finallyStack![i]!;
+      fctx.body.push(...entry.cloneFinallyAtDepth(finallyInlineDelta(fctx, entry)));
     }
     emitLinearU8ArenaReset(ctx, fctx, fctx.linearU8ArenaMarkLocalIdx);
     // Restore return value and emit return
@@ -881,7 +913,9 @@ export function compileBreakStatement(_ctx: CodegenContext, fctx: FunctionContex
     for (let i = fctx.finallyStack.length - 1; i >= 0; i--) {
       const entry = fctx.finallyStack[i]!;
       if (breakIdx < entry.breakStackLen) {
-        fctx.body.push(...entry.cloneFinally());
+        // Retarget the clone's outer branches for the extra nesting between
+        // this break site and the try frame (#2061).
+        fctx.body.push(...entry.cloneFinallyAtDepth(finallyInlineDelta(fctx, entry)));
       }
     }
   }
@@ -911,7 +945,9 @@ export function compileContinueStatement(
     for (let i = fctx.finallyStack.length - 1; i >= 0; i--) {
       const entry = fctx.finallyStack[i]!;
       if (contIdx < entry.continueStackLen) {
-        fctx.body.push(...entry.cloneFinally());
+        // Retarget the clone's outer branches for the extra nesting between
+        // this continue site and the try frame (#2061).
+        fctx.body.push(...entry.cloneFinallyAtDepth(finallyInlineDelta(fctx, entry)));
       }
     }
   }

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -280,8 +280,11 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
     if (!fctx.finallyStack) fctx.finallyStack = [];
     fctx.finallyStack.push({
       cloneFinally,
+      cloneFinallyAtDepth,
       breakStackLen: fctx.breakStack.length,
       continueStackLen: fctx.continueStack.length,
+      breakDepthBaseline: fctx.breakStack.slice(),
+      continueDepthBaseline: fctx.continueStack.slice(),
     });
   }
 
@@ -375,8 +378,11 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
         if (!fctx.finallyStack) fctx.finallyStack = [];
         fctx.finallyStack.push({
           cloneFinally,
+          cloneFinallyAtDepth,
           breakStackLen: fctx.breakStack.length,
           continueStackLen: fctx.continueStack.length,
+          breakDepthBaseline: fctx.breakStack.slice(),
+          continueDepthBaseline: fctx.continueStack.slice(),
         });
       }
 

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -4076,24 +4076,32 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
     const capturedDoneFlag = doneFlag;
     const capturedIterLocal = iterLocal;
     const capturedReturnIdx = returnIdx;
+    // The iterator-close finally body contains no `br` to any outer label
+    // (only `local.get`/`call`/`if`), so the #2061 abrupt-site depth delta is a
+    // no-op here: `cloneFinallyAtDepth` ignores `extraDepth` and the baselines
+    // are unused. We still satisfy the finallyStack entry shape.
+    const cloneIterClose = (): Instr[] =>
+      structuredClone([
+        { op: "local.get", index: capturedDoneFlag } as Instr,
+        { op: "i32.eqz" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: capturedIterLocal } as Instr,
+            { op: "call", funcIdx: capturedReturnIdx } as Instr,
+          ],
+          else: [],
+        },
+      ]);
     if (!fctx.finallyStack) fctx.finallyStack = [];
     fctx.finallyStack.push({
-      cloneFinally: (): Instr[] =>
-        structuredClone([
-          { op: "local.get", index: capturedDoneFlag } as Instr,
-          { op: "i32.eqz" } as Instr,
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: capturedIterLocal } as Instr,
-              { op: "call", funcIdx: capturedReturnIdx } as Instr,
-            ],
-            else: [],
-          },
-        ]),
+      cloneFinally: cloneIterClose,
+      cloneFinallyAtDepth: cloneIterClose,
       breakStackLen: iterCloseBreakStackLen,
       continueStackLen: iterCloseContinueStackLen,
+      breakDepthBaseline: fctx.breakStack.slice(),
+      continueDepthBaseline: fctx.continueStack.slice(),
     });
   }
 

--- a/tests/issue-2061-finally-clone-depth.test.ts
+++ b/tests/issue-2061-finally-clone-depth.test.ts
@@ -98,7 +98,12 @@ describe("#2061 finally clone branch depth", () => {
         }
         return acc;
       }`,
-      [{ fn: "m", args: [0] }, { fn: "m", args: [1] }, { fn: "m", args: [3] }, { fn: "m", args: [9] }],
+      [
+        { fn: "m", args: [0] },
+        { fn: "m", args: [1] },
+        { fn: "m", args: [3] },
+        { fn: "m", args: [9] },
+      ],
     );
   });
 
@@ -119,7 +124,10 @@ describe("#2061 finally clone branch depth", () => {
         }
         return r;
       }`,
-      [{ fn: "sw", args: [1] }, { fn: "sw", args: [2] }],
+      [
+        { fn: "sw", args: [1] },
+        { fn: "sw", args: [2] },
+      ],
     );
   });
 });

--- a/tests/issue-2061-finally-clone-depth.test.ts
+++ b/tests/issue-2061-finally-clone-depth.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2061 — finally clone inlined at the wrong branch depth.
+//
+// The finally body is compiled once with break/continue depths bumped by +1
+// (the try frame) and CLONED into every abrupt-completion site
+// (return/break/continue inside the try). When the abrupt site sits DEEPER than
+// the try frame — inside an `if`/`switch`/inner-`try` within the try block —
+// any `br` in the clone that targets an OUTER label is short by the extra
+// nesting: a `break`/`continue` in the finally lands on the wrong block. The
+// fix records the break/continue depth baseline on each finallyStack entry and
+// routes every inline through `cloneFinallyAtDepth(delta)` with the
+// site-computed delta (control-flow.ts `finallyInlineDelta`).
+//
+// `assertEquivalent` runs the source as JS and compares the wasm result, and
+// also runs `WebAssembly.validate()` on the binary, so an out-of-range branch
+// depth fails loudly too.
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+describe("#2061 finally clone branch depth", () => {
+  it("return nested one level inside try, finally break (repro t1)", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function t1(): number {
+        let r = 0;
+        while (true) {
+          r = r + 1;
+          try { if (r === 1) { return 100; } } finally { break; }
+        }
+        return r;
+      }`,
+      [{ fn: "t1", args: [] }],
+    );
+  });
+
+  it("nested try + if, two finally levels (repro nestedFinallyBreak)", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function nestedFinallyBreak(): number {
+        let log = 0;
+        while (true) {
+          try { try { if (log === 0) { log = 1; return 100; } } finally { log = log*10 + 2; } }
+          finally { break; }
+        }
+        return log;
+      }`,
+      [{ fn: "nestedFinallyBreak", args: [] }],
+    );
+  });
+
+  it("return three ifs deep, finally labeled break outer", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function deepNest(): number {
+        let r = 0;
+        outer: while (true) {
+          r = r + 1;
+          try {
+            if (r > 0) { if (r > 0) { if (r === 1) { return 100; } } }
+          } finally { break outer; }
+        }
+        return r;
+      }`,
+      [{ fn: "deepNest", args: [] }],
+    );
+  });
+
+  it("continue in finally, abrupt site nested in if", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function contInFinally(): number {
+        let r = 0; let n = 0;
+        while (n < 3) {
+          n = n + 1;
+          try { if (n === 1) { continue; } r = r + 10; }
+          finally { if (n === 2) { continue; } r = r + 1; }
+        }
+        return r;
+      }`,
+      [{ fn: "contInFinally", args: [] }],
+    );
+  });
+
+  // Matrix: abrupt site at nesting depth 2 (two ifs) × finally containing
+  // continue outer × labeled for-loop.
+  it("matrix: return at depth 2 + finally continue outer", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function m(n: number): number {
+        let acc = 0;
+        outer: for (let i = 0; i < 4; i++) {
+          try {
+            if (i >= 0) {
+              if (i === n) { return acc * 100 + i; }
+            }
+            acc = acc + 1;
+          } finally {
+            if (i === 2) { continue outer; }
+            acc = acc + 10;
+          }
+          acc = acc + 1000;
+        }
+        return acc;
+      }`,
+      [{ fn: "m", args: [0] }, { fn: "m", args: [1] }, { fn: "m", args: [3] }, { fn: "m", args: [9] }],
+    );
+  });
+
+  // break inside a switch inside the try (switch adds a label level too).
+  it("break in finally, abrupt site inside switch in try", { timeout: 15000 }, async () => {
+    await assertEquivalent(
+      `export function sw(n: number): number {
+        let r = 0;
+        loop: while (true) {
+          r = r + 1;
+          try {
+            switch (n) {
+              case 1: { if (r === 1) { return 100; } break; }
+              default: { break; }
+            }
+            r = r + 1000;
+          } finally { break loop; }
+        }
+        return r;
+      }`,
+      [{ fn: "sw", args: [1] }, { fn: "sw", args: [2] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem (#2061)

When a `return`/`break`/`continue` sits **deeper than the try frame** (inside an `if`/`switch`/inner-`try` within the `try` block), the finally body cloned at that abrupt site has its outer-label branches off by the extra nesting: a `break` in the finally lands on the wrong block. Observable as a swallowed pending `return`, extra loop iterations, and double-executed inner finallys.

Repros (verified miscompiled on main, now matching Node):

| fn | before | node |
|----|--------|------|
| `t1` (return in `if`, finally `break`) | `2` | `1` |
| `nestedFinallyBreak` (nested try+if, two finallys) | `122` | `12` |

## Root cause

The finally body is pre-compiled once with break/continue depths bumped by exactly **+1** (the try frame), then cloned into each return/break/continue site (`control-flow.ts`). The compensation machinery (`cloneFinallyAtDepth`/`bumpOuterBranchDepths`) existed but was only wired to the two hardcoded `+2` catch_all insertion sites, never to the return/break/continue inline sites. So a clone inlined deeper than the try frame kept the `+1` branch depths.

## Fix

Every label-creating construct (`if`/`block`/`loop`/`switch`/`try`) bumps **all** outer break/continue stack entries by +1 uniformly, so the extra nesting between an inline site and the try frame is a single scalar: `current outer-label depth − try-entry-baseline`. 

- Snapshot that baseline on each `finallyStack` entry (`breakDepthBaseline`/`continueDepthBaseline`) and expose `cloneFinallyAtDepth`.
- `finallyInlineDelta()` computes the delta at each inline site; `compileReturnStatement`/`compileBreakStatement`/`compileContinueStatement` now route through `cloneFinallyAtDepth(delta)` instead of the raw `cloneFinally()`. Delta 0 (site at the try frame) reproduces the prior correct behavior.

## Tests

`tests/issue-2061-finally-clone-depth.test.ts` — both repros plus depth-2 return, continue-in-finally nested in `if`, labeled-break three `if`s deep, and break-in-finally inside a `switch` in the try. All match Node via `assertEquivalent` (which also runs `WebAssembly.validate`). The #1858 C6 suite (branches *inside* the finally body) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)