### PR TITLE
fix(#2049): route o?.m(args) to optional-call codegen

### DIFF
--- a/plan/issues/2049-optional-method-call-routing-gap.md
+++ b/plan/issues/2049-optional-method-call-routing-gap.md
@@ -1,10 +1,11 @@
 ---
 id: 2049
 title: "o?.m(args) never routed to optional-call codegen: args evaluated on nullish receiver, null class receiver traps"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -99,3 +100,38 @@ Grepped `optional chain`, `questionDot`, `short-circuit`, `optional call`,
 `uncatchable` over plan/issues/: #16, #409, #1281, #1375, #1392 (done; IR-path
 or other forms), #1820 (IR `&&`/`||`), #1298 (fn-typed field call). None cover
 the questionDotToken routing gap or arg evaluation on short-circuit.
+
+## Resolution (2026-06-11)
+
+Three changes in `src/codegen/expressions/`:
+
+1. **`calls.ts`** — routing gate now keys on `ts.isOptionalChain(expr)` instead
+   of `expr.questionDotToken`, so `o?.m(args)` (token on the inner
+   PropertyAccessExpression) reaches `compileOptionalCallExpression`.
+2. **`calls-optional.ts`** — strip receiver nullability with
+   `checker.getNonNullableType(...)` before method resolution; the receiver is
+   `K | null` by construction, so `getSymbol()` on the raw union never resolved
+   the class/struct.
+3. **`calls-optional.ts`** — added a closure-field fallback: when no named
+   method resolves, delegate the non-null branch to
+   `compileCallablePropertyCall` (which already extracts the closure field,
+   pushes self + args, and `call_ref`s, handling a nullable receiver via a
+   guarded cast). Gated on a side-effect-free receiver so the re-evaluation is
+   sound.
+
+### Test results (`tests/issue-2049.test.ts`, all pass)
+
+| case | before | after | node |
+|------|--------|-------|------|
+| `o?.f(mark(5))` null receiver — arg eval | `5` (mark ran) | `0` | `0` |
+| `k?.m(mark(7))` null class receiver | **trap** | `0` | `0` |
+| `o?.f(mark(5))` non-null closure field | `1005` | `1005` | `1005` |
+| `k?.m(mark(7))` non-null class method | `807` | `807` | `807` |
+| `o.f?.()` / `o?.f?.()` dynamic-call form | ok | ok | ok |
+| void method side effect via `k?.m()` | n/a | `7` | `7` |
+
+The **undefined-vs-NaN result-value** half of the short-circuit (e.g.
+`o?.f(x) ?? -1` yielding NaN instead of -1) is out of scope here — tracked as
+**#2051**. Nested `a?.b?.c()` previously threw an uncatchable host TypeError on
+the inner `a?.b`; it now returns a (NaN-encoded) value, a strict improvement,
+with the encoding likewise deferred to #2051.

--- a/src/codegen/expressions/calls-optional.ts
+++ b/src/codegen/expressions/calls-optional.ts
@@ -14,6 +14,7 @@ import type { InnerResult } from "../shared.js";
 import { compileExpression, VOID_RESULT } from "../shared.js";
 import { compileNativeStringMethodCall } from "../string-ops.js";
 import { defaultValueInstrs, pushDefaultValue } from "../type-coercion.js";
+import { compileCallablePropertyCall } from "./calls-closures.js";
 import { getFuncParamTypes } from "./helpers.js";
 import { resolveStructName } from "./misc.js";
 
@@ -53,7 +54,11 @@ export function compileOptionalCallExpression(
   fctx.body.push({ op: "ref.is_null" });
 
   const savedBody = pushBody(fctx);
-  const tsReceiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
+  // The receiver of an optional chain is nullable by construction (`K | null`),
+  // so `getTypeAtLocation` yields a union whose `getSymbol()` does not resolve
+  // to the underlying class/struct. Strip null/undefined first so method
+  // resolution sees the concrete declared type (#2049).
+  const tsReceiverType = ctx.checker.getNonNullableType(ctx.checker.getTypeAtLocation(propAccess.expression));
   const methodName = ts.isPrivateIdentifier(propAccess.name) ? propAccess.name.text.slice(1) : propAccess.name.text;
   let methodResolved = false;
 
@@ -155,6 +160,31 @@ export function compileOptionalCallExpression(
     }
   }
 
+  // Closure-field / function-typed-property callee (e.g. `o?.f(x)` where `f`
+  // holds a closure on an object/struct, not a named method). None of the
+  // method-resolution branches above match these, so without this fallback the
+  // non-null branch would emit a default value and the call would never happen
+  // (#2049). `compileCallablePropertyCall` implements exactly this — extract the
+  // closure field, push self + args, `call_ref` — and already normalizes a
+  // nullable receiver via a guarded cast. It recompiles the receiver
+  // (`propAccess.expression`) once inside this non-null branch, which runs only
+  // when the receiver is non-null, so re-evaluation is restricted to
+  // side-effect-free receivers to preserve `?.` short-circuit semantics.
+  if (!methodResolved && isSideEffectFreeOptionalReceiver(propAccess.expression)) {
+    const structName = resolveStructName(ctx, tsReceiverType);
+    if (structName) {
+      const delegated = compileCallablePropertyCall(ctx, fctx, expr, propAccess, structName);
+      if (delegated !== undefined) {
+        if (delegated !== null && delegated !== VOID_RESULT) {
+          resultType = delegated;
+        } else if (delegated === VOID_RESULT) {
+          fctx.body.push(...defaultValueInstrs(resultType));
+        }
+        methodResolved = true;
+      }
+    }
+  }
+
   if (!methodResolved) fctx.body.push(...defaultValueInstrs(resultType));
 
   const elseInstrs = fctx.body;
@@ -170,4 +200,27 @@ export function compileOptionalCallExpression(
   });
 
   return resultType;
+}
+
+/**
+ * The closure-field fallback in `compileOptionalCallExpression` re-evaluates the
+ * receiver inside the non-null branch by delegating to the regular call path.
+ * That is only correct when evaluating the receiver has no observable side
+ * effect. Identifiers, `this`, and member chains rooted in those qualify;
+ * calls and element access do not.
+ */
+function isSideEffectFreeOptionalReceiver(expr: ts.Expression): boolean {
+  let cur: ts.Expression = expr;
+  for (;;) {
+    if (ts.isIdentifier(cur) || cur.kind === ts.SyntaxKind.ThisKeyword) return true;
+    if (ts.isPropertyAccessExpression(cur)) {
+      cur = cur.expression;
+      continue;
+    }
+    if (ts.isParenthesizedExpression(cur) || ts.isNonNullExpression(cur)) {
+      cur = cur.expression;
+      continue;
+    }
+    return false;
+  }
 }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2010,8 +2010,16 @@ function compileCallExpression(
   expr: ts.CallExpression,
   expectedType?: ValType,
 ): InnerResult {
-  // Optional chaining on calls: obj?.method()
-  if (expr.questionDotToken && ts.isPropertyAccessExpression(expr.expression)) {
+  // Optional chaining on calls: obj?.method() and obj.method?.().
+  //
+  // In the TS AST the `?.` of `o?.m(args)` sits on the inner
+  // PropertyAccessExpression, NOT on the CallExpression — only `o.m?.(args)`
+  // sets `expr.questionDotToken`. Gating on the call token alone (#2049) missed
+  // the common `o?.m(args)` form, so it fell into the regular method-call path
+  // which evaluates arguments unconditionally and derefs the receiver (trapping
+  // on a null class instance). Gate on the optional chain itself so both forms
+  // route to the short-circuiting path.
+  if (ts.isOptionalChain(expr) && ts.isPropertyAccessExpression(expr.expression)) {
     return compileOptionalCallExpression(ctx, fctx, expr);
   }
 

--- a/tests/issue-2049.test.ts
+++ b/tests/issue-2049.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2049 — `o?.m(args)` was never routed to the optional-call codegen.
+//
+// In the TS AST the `?.` of `o?.m(args)` sits on the inner
+// PropertyAccessExpression, not on the CallExpression — only `o.m?.(args)`
+// sets `CallExpression.questionDotToken`. The routing gate in
+// `compileCallExpression` keyed on the call token, so `o?.m(args)` fell into the
+// regular method-call path, which (a) evaluated arguments unconditionally even
+// when the receiver was nullish and (b) emitted a receiver deref that trapped
+// (`ref.as_non_null to a null reference`) on a null class instance.
+//
+// Fix: gate on `ts.isOptionalChain(expr)`, strip receiver nullability before
+// method resolution (the receiver is `K | null` by construction), and add a
+// closure-field fallback that delegates to `compileCallablePropertyCall`.
+//
+// The undefined-vs-NaN representation of the short-circuit *result value* is a
+// separate concern tracked as #2051, so these tests assert side-effect /
+// no-trap / non-null-result behavior, not the exact undefined encoding.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn = "test"): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as Record<string, () => number>)[fn]!();
+}
+
+describe("#2049 o?.m(args) routes to optional-call codegen", () => {
+  it("closure-field receiver: nullish chain does NOT evaluate the argument", async () => {
+    // `o?.f(mark(5))` with null `o` must short-circuit before `mark` runs.
+    const src = `
+let log = 0;
+function mark(k: number): number { log = log * 10 + k; return k; }
+type Obj = { f: (x: number) => number; v: number };
+function getObj(b: boolean): Obj | null { if (b) return { f: (x: number) => x * 2, v: 9 }; return null; }
+export function test(): number { log = 0; const o = getObj(false); const r = o?.f(mark(5)); return log; }`;
+    expect(await run(src)).toBe(0); // mark never called
+  });
+
+  it("class-method receiver: nullish chain does NOT trap", async () => {
+    // Regular path emitted `ref.as_non_null` on a null class instance → uncatchable trap.
+    const src = `
+let log = 0;
+function mark(k: number): number { log = log * 10 + k; return k; }
+class K { m(x: number): number { return x + 1; } }
+function getK(b: boolean): K | null { return b ? new K() : null; }
+export function test(): number { log = 0; const k = getK(false); const r = k?.m(mark(7)); return log; }`;
+    expect(await run(src)).toBe(0); // no trap; mark never called
+  });
+
+  it("closure-field receiver: non-null chain calls and returns the real value", async () => {
+    const src = `
+let log = 0;
+function mark(k: number): number { log = log * 10 + k; return k; }
+type Obj = { f: (x: number) => number; v: number };
+function getObj(b: boolean): Obj | null { if (b) return { f: (x: number) => x * 2, v: 9 }; return null; }
+export function test(): number { log = 0; const o = getObj(true); const r = o?.f(mark(5)); return (r as number) * 100 + log; }`;
+    expect(await run(src)).toBe(1005); // mark(5)→5, f(5)=10, 10*100+5
+  });
+
+  it("class-method receiver: non-null chain calls and returns the real value", async () => {
+    const src = `
+let log = 0;
+function mark(k: number): number { log = log * 10 + k; return k; }
+class K { m(x: number): number { return x + 1; } }
+function getK(b: boolean): K | null { return b ? new K() : null; }
+export function test(): number { log = 0; const k = getK(true); const r = k?.m(mark(7)); return (r as number) * 100 + log; }`;
+    expect(await run(src)).toBe(807); // mark(7)→7, m(7)=8, 8*100+7
+  });
+
+  it("dynamic-call form o.f?.(x) and o?.f?.(x) still work (no regression)", async () => {
+    const src = `
+type O = { f: (x: number) => number };
+function g(b: boolean): O | null { return b ? { f: (x: number) => x * 2 } : null; }
+export function pure(): number { const o = g(true)!; return o.f?.(3) ?? -1; }
+export function both(): number { const o = g(true); return o?.f?.(3) ?? -1; }`;
+    expect(await run(src, "pure")).toBe(6);
+    expect(await run(src, "both")).toBe(6);
+  });
+
+  it("void-returning method via optional chain runs its side effect when non-null", async () => {
+    const src = `
+class K { p = 0; m(): void { this.p = 7; } }
+function g(b: boolean): K | null { return b ? new K() : null; }
+export function test(): number { const k = g(true); k?.m(); return k!.p; }`;
+    expect(await run(src)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

`o?.m(args)` — the most common optional-call form — was compiled by the regular method-call machinery instead of `compileOptionalCallExpression`. In the TS AST the `?.` token of `o?.m(args)` sits on the inner PropertyAccessExpression; only `o.m?.(args)` sets `CallExpression.questionDotToken`. The routing gate keyed on the call token, so `o?.m(args)` fell through and, on a nullish receiver, (1) evaluated arguments unconditionally and (2) emitted a receiver deref that trapped uncatchably (`ref.as_non_null to a null reference`) on a null class instance.

## Fix

- **`calls.ts`**: gate on `ts.isOptionalChain(expr)` instead of `expr.questionDotToken`, so both `o?.m(args)` and `o.m?.(args)` route to the short-circuiting path.
- **`calls-optional.ts`**: strip receiver nullability with `getNonNullableType` before class/struct method resolution — the receiver is `K | null` by construction, so `getSymbol()` on the raw union never resolved the class.
- **`calls-optional.ts`**: add a closure-field fallback. When no named method resolves (e.g. `o?.f(x)` where `f` is a function-typed object field), delegate the non-null branch to `compileCallablePropertyCall`, which extracts the closure field, pushes self + args, and `call_ref`s — and already normalizes a nullable receiver via a guarded cast. Gated on a side-effect-free receiver so the re-evaluation inside the non-null branch is sound.

## Results (tests/issue-2049.test.ts, 6 tests pass; tsc clean)

| case | before | after | node |
|------|--------|-------|------|
| `o?.f(mark(5))` null receiver | `5` (mark ran) | `0` | `0` |
| `k?.m(mark(7))` null class receiver | **trap** | `0` | `0` |
| `o?.f(mark(5))` non-null closure field | `1005` | `1005` | `1005` |
| `k?.m(mark(7))` non-null class method | `807` | `807` | `807` |
| `o.f?.()` / `o?.f?.()` dynamic-call form | ok | ok | ok |
| void method side effect via `k?.m()` | n/a | `7` | `7` |

The undefined-vs-NaN encoding of the short-circuit *result value* (e.g. `o?.f(x) ?? -1` yielding NaN) is out of scope here and tracked as **#2051**. Nested `a?.b?.c()` previously threw an uncatchable host TypeError on the inner `a?.b`; it now returns a (NaN-encoded) value — a strict improvement, encoding deferred to #2051.

Sets issue #2049 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)