### PR TITLE
fix(#2055): relational i32 hint truncates fractional f64 operand (i < 2.5 wrong)

### DIFF
--- a/plan/issues/2055-relational-i32-hint-truncates-f64-operand.md
+++ b/plan/issues/2055-relational-i32-hint-truncates-f64-operand.md
@@ -1,10 +1,11 @@
 ---
 id: 2055
 title: "relational comparison against an i32-promoted local silently truncates the other f64 operand (i < 2.5 wrong)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -81,3 +82,37 @@ the hinted operand comes back f64, promote rather than truncate.
 Grepped `hasI32LocalOperand`, `fractional`, `i32-promoted`, `detectI32LoopVar`,
 `truncat` — closest are #1236 (i32 accumulator saturation, done) and #595/#1166
 (i32 loop inference). None cover relational truncation.
+
+## Resolution (2026-06-11)
+
+Fixed in `src/codegen/binary-ops.ts`. `hasI32LocalOperand` previously fired the
+i32 numeric hint for a relational whenever *either* operand was an i32 local,
+truncating a fractional/derived f64 operand via `i32.trunc_sat_f64_s` before the
+compare. The flag now also requires **both** operands to satisfy `isI32PureExpr`
+(which already treats an i32 local as a pure leaf), so it only fires when both
+sides are provably integral. The flag was changed to a `let` and assigned after
+`isI32PureExpr` is in scope. When the guard fails, the operands stay f64 (the
+existing i32↔f64 promotion at binary-ops.ts:1520 converts the i32 local with
+`f64.convert_i32_s` — cheap and exact) and an f64 compare is emitted. The
+for-header fast path (`i < 10000`, integer bound) and two-i32-local compares
+still take the i32 path.
+
+### Test Results
+
+`tests/issue-2055.test.ts` (8 cases, all PASS):
+
+| case | result |
+|------|--------|
+| `if (i < 2.5)` | 3 ✓ |
+| `if (i < n/2)` (n=5) | 3 ✓ |
+| `if (2.5 > i)` (literal left) | 3 ✓ |
+| `<=`, `>`, `>=` with 2.5 | 3 / 2 / 2 ✓ |
+| `while (i < x/2)` + ternary | 3 / 3 ✓ |
+| `if (i < 3)` integer fast path (unregressed) | 3 ✓ |
+| two i32 locals `i < j` (unregressed) | 3 ✓ |
+| `for (i<10000)` perf path intact | 10000 ✓ |
+
+`tsc --noEmit` clean. Pre-existing failures in `tests/i32-loop-inference.test.ts`,
+`tests/native-i32-type.test.ts`, etc. are unrelated — those harnesses call
+`compile()` without `await` or use a minimal import object missing
+`string_constants`; they fail identically on baseline with this change reverted.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1266,7 +1266,13 @@ export function compileBinaryExpression(
         : (entry as ValType | undefined);
     return type?.kind === "i32";
   };
-  const hasI32LocalOperand = isRelational && !isDivOrPow && (isI32LocalRef(expr.left) || isI32LocalRef(expr.right));
+  // Whether a relational op may use the i32 fast path. Computed below, once
+  // `isI32PureExpr` is in scope: it is only safe when BOTH operands are
+  // provably i32-pure. If only one side is an i32 local and the other is a
+  // fractional / non-integral f64 (e.g. `i < 2.5`, `i < n/2`), forcing the i32
+  // hint truncates that operand via i32.trunc_sat_f64_s before the compare,
+  // silently producing the wrong result (#2055).
+  let hasI32LocalOperand = false;
   // #1120: when an arithmetic expression is the operand of `expr | 0`
   // (ToInt32 coercion), AND both operands are already i32 locals, hint
   // i32 so we emit native i32 arithmetic. The i32-overflow wrap is
@@ -1405,6 +1411,19 @@ export function compileBinaryExpression(
     }
     return false;
   };
+  // #2055: a relational op only takes the i32 fast path when BOTH operands are
+  // provably i32-pure (the for-header fast path `i < N` with integer literal N,
+  // or two i32 locals). When one side is a fractional/derived f64 the i32 hint
+  // would truncate it before the compare, so we fall back to f64 comparison
+  // (promoting the i32 local via f64.convert_i32_s, which is cheap and exact).
+  // `isI32PureExpr` already treats an i32 local as a pure leaf, so this still
+  // covers the original `i < 10000` loop-condition optimisation.
+  hasI32LocalOperand =
+    isRelational &&
+    !isDivOrPow &&
+    (isI32LocalRef(expr.left) || isI32LocalRef(expr.right)) &&
+    isI32PureExpr(expr.left) &&
+    isI32PureExpr(expr.right);
   // #1746: emit a *proven-i32-pure* expression directly as an i32 instruction
   // chain, leaving the result as i32 on the stack. The caller MUST have verified
   // `isI32PureExpr(e)` first — this mirrors that predicate's structure exactly.

--- a/tests/issue-2055.test.ts
+++ b/tests/issue-2055.test.ts
@@ -9,10 +9,9 @@ import { compile } from "../src/index.js";
 
 async function compileAndRun(source: string) {
   const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
   return instance.exports as Record<string, Function>;
 }

--- a/tests/issue-2055.test.ts
+++ b/tests/issue-2055.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2055 — a relational comparison where one operand is an i32-promoted loop var
+// used to force the i32 numeric hint onto the *other* operand, truncating a
+// fractional f64 (e.g. `i < 2.5` became `i < 2`) via i32.trunc_sat_f64_s. The
+// fix only takes the i32 fast path when BOTH operands are provably i32-pure;
+// otherwise the i32 local is promoted to f64 and an f64 compare is emitted.
+
+async function compileAndRun(source: string) {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2055 relational i32 hint must not truncate a fractional f64 operand", () => {
+  it("if (i < 2.5) with i32 loop var", async () => {
+    const e = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (i < 2.5) c++; } return c; }`,
+    );
+    expect(e.f()).toBe(3);
+  });
+
+  it("if (i < n / 2) — derived f64 operand", async () => {
+    const e = await compileAndRun(
+      `export function f(n: number): number { let c = 0; for (let i = 0; i < 5; i++) { if (i < n / 2) c++; } return c; }`,
+    );
+    expect(e.f(5)).toBe(3);
+  });
+
+  it("fractional literal on the left (2.5 > i)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (2.5 > i) c++; } return c; }`,
+    );
+    expect(e.f()).toBe(3);
+  });
+
+  it("all four relational ops with a fractional bound", async () => {
+    const lt = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (i <= 2.5) c++; } return c; }`,
+    );
+    expect(lt.f()).toBe(3);
+    const gt = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (i > 2.5) c++; } return c; }`,
+    );
+    expect(gt.f()).toBe(2);
+    const ge = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (i >= 2.5) c++; } return c; }`,
+    );
+    expect(ge.f()).toBe(2);
+  });
+
+  it("while-body and ternary contexts", async () => {
+    const w = await compileAndRun(
+      `export function f(x: number): number { let c = 0; let i = 0; while (i < x / 2) { c++; i++; } return c; }`,
+    );
+    expect(w.f(5)).toBe(3);
+    const t = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { c += (i < 2.5) ? 1 : 0; } return c; }`,
+    );
+    expect(t.f()).toBe(3);
+  });
+
+  it("integer comparisons still take the i32 fast path (unregressed)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { if (i < 3) c++; } return c; }`,
+    );
+    expect(e.f()).toBe(3);
+  });
+
+  it("two i32 loop vars compared directly (unregressed)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 5; i++) { let j = 3; if (i < j) c++; } return c; }`,
+    );
+    expect(e.f()).toBe(3);
+  });
+
+  it("large-bound for-header loop runs the full count (perf path intact)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number { let c = 0; for (let i = 0; i < 10000; i++) { c++; } return c; }`,
+    );
+    expect(e.f()).toBe(10000);
+  });
+});


### PR DESCRIPTION
## Problem

A relational comparison where one operand is an i32-promoted loop var (from `detectI32LoopVar`) forced the i32 numeric hint onto the *other* operand, truncating a fractional/derived f64 via `i32.trunc_sat_f64_s` before the compare. `if (i < 2.5)` became `if (i < 2)` — silent wrong branch counts in idiomatic loop code. Affected if/ternary/while-body relationals (the for-header condition itself compiled correctly).

## Fix

In `src/codegen/binary-ops.ts`, `hasI32LocalOperand` now additionally requires **both** operands to satisfy `isI32PureExpr` (which already treats an i32 local as a pure leaf), so the i32 fast path only fires when both sides are provably integral. The flag became a `let` assigned after `isI32PureExpr` is in scope. When the guard fails, the existing i32↔f64 promotion (binary-ops.ts:1520) converts the i32 local with `f64.convert_i32_s` (cheap, exact) and an f64 compare is emitted.

For-header fast path (`i < 10000`, integer bound) and two-i32-local compares are unaffected.

## Tests

`tests/issue-2055.test.ts` — 8 cases, all pass:
- `if (i < 2.5)`, `if (i < n/2)`, `2.5 > i` → 3
- `<=` / `>` / `>=` with 2.5 → 3 / 2 / 2
- while-body + ternary → 3
- integer `i < 3` fast path (unregressed), two-i32-local `i < j` (unregressed)
- `for (i<10000)` perf path → 10000

`tsc --noEmit` clean. Closes #2055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)