### PR TITLE
fix(#2057): isStaticNaN only folds NaN through const bindings

### DIFF
--- a/plan/issues/2057-isstaticnan-ignores-reassignment.md
+++ b/plan/issues/2057-isstaticnan-ignores-reassignment.md
@@ -1,10 +1,11 @@
 ---
 id: 2057
 title: "Math.min/max constant-fold a reassigned variable to NaN — isStaticNaN traces initializers without const/reassignment check"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: critical
 feasibility: easy
 reasoning_effort: medium

--- a/src/codegen/expressions/misc.ts
+++ b/src/codegen/expressions/misc.ts
@@ -524,12 +524,20 @@ function isStaticNaN(ctx: CodegenContext, expr: ts.Expression): boolean {
     Number(expr.right.text) === 0
   )
     return true;
-  // Variable initialized with NaN: trace to declaration
+  // Variable initialized with NaN: trace to declaration — but ONLY for `const`
+  // bindings (#2057). A `let`/`var` initialized to NaN can be reassigned to a
+  // finite value (`let x = NaN; x = 5; Math.min(x, 3)`), so tracing the
+  // initializer unconditionally folded the live value away to a compile-time
+  // NaN. The runtime NaN guard emitted for the general Math.min/max path makes
+  // this static fold a pure optimization, so restricting it to `const` is safe.
   if (ts.isIdentifier(expr)) {
     const sym = ctx.checker.getSymbolAtLocation(expr);
     const decl = sym?.valueDeclaration;
     if (decl && ts.isVariableDeclaration(decl) && decl.initializer) {
-      return isStaticNaN(ctx, decl.initializer);
+      const declList = decl.parent;
+      if (ts.isVariableDeclarationList(declList) && (declList.flags & ts.NodeFlags.Const) !== 0) {
+        return isStaticNaN(ctx, decl.initializer);
+      }
     }
   }
   return false;

--- a/tests/issue-2057.test.ts
+++ b/tests/issue-2057.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2057 — `Math.min`/`Math.max` constant-folded a reassigned NaN-initialized
+// variable to a compile-time NaN.
+//
+// `isStaticNaN` traced any identifier to its declaration initializer with no
+// const-ness check, so `let x = NaN; x = 5; Math.min(x, 3)` was deemed
+// "statically NaN" and folded to `f64.const NaN` — destroying the common
+// NaN-initialized accumulator pattern. Fix: only follow the initializer for
+// `const` declarations. The const fold (a sound optimization) is retained.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn: string, ...args: number[]): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as Record<string, (...a: number[]) => number>)[fn]!(...args);
+}
+
+describe("#2057 isStaticNaN only folds const NaN bindings", () => {
+  it("reassigned let: Math.min sees the live value", async () => {
+    const src = `export function t1(): number { let x = NaN; x = 5; return Math.min(x, 3); }`;
+    expect(await run(src, "t1")).toBe(3); // Math.min(5, 3)
+  });
+
+  it("conditionally-assigned let: Math.max sees the live value", async () => {
+    const src = `export function t2(b: boolean): number { let x = NaN; if (b) x = 10; return Math.max(x, 3); }`;
+    expect(await run(src, "t2", 1)).toBe(10); // Math.max(10, 3)
+  });
+
+  it("genuinely-NaN let still yields NaN at runtime", async () => {
+    // Never reassigned, so the runtime value really is NaN; Math.min(NaN, 3) === NaN.
+    const src = `export function t3(): number { let x = NaN; return Math.min(x, 3); }`;
+    expect(Number.isNaN(await run(src, "t3"))).toBe(true);
+  });
+
+  it("const NaN binding still folds (optimization retained)", async () => {
+    const src = `export function t4(): number { const x = NaN; return Math.min(x, 3); }`;
+    expect(Number.isNaN(await run(src, "t4"))).toBe(true);
+  });
+
+  it("literal NaN argument still folds", async () => {
+    const src = `export function t5(): number { return Math.max(NaN, 7); }`;
+    expect(Number.isNaN(await run(src, "t5"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`Math.min`/`Math.max` constant-folded a reassigned NaN-initialized variable to a compile-time NaN:

```ts
let x = NaN; x = 5; Math.min(x, 3);   // wasm: NaN, node: 3
let x = NaN; if (b) x = 10; Math.max(x, 3);  // wasm: NaN, node: 10
```

`isStaticNaN` (`src/codegen/expressions/misc.ts`) traced any identifier to its declaration initializer with **no const-ness check**, so a `let x = NaN` was deemed "statically NaN" and `Math.min/max` (builtins.ts) folded to `f64.const NaN`, evaluating the other args for side effects only. This silently destroyed the common NaN-initialized accumulator pattern.

## Fix

Restrict the initializer trace to `const` declarations, matching the existing const-guard idiom already used by `tryStaticToNumber` in the same file. The runtime NaN guard the general Math.min/max path already emits makes the static check a pure optimization, so it is safe to narrow:

- folded where sound: `const x = NaN` bindings and literal `NaN` args
- not folded where unsound: `let`/`var` that may be reassigned

The only `isStaticNaN` call sites are the two Math.min/max folds in `builtins.ts`; both consume the fixed predicate. No other unsound call sites (acceptance criterion).

## Results (tests/issue-2057.test.ts, 5 tests pass)

| case | before | after | node |
|------|--------|-------|------|
| `let x=NaN; x=5; Math.min(x,3)` | NaN | 3 | 3 |
| `let x=NaN; if(b) x=10; Math.max(x,3)` | NaN | 10 | 10 |
| `let x=NaN; Math.min(x,3)` (never reassigned) | NaN | NaN | NaN |
| `const x=NaN; Math.min(x,3)` (fold retained) | NaN | NaN | NaN |
| `Math.max(NaN,7)` (literal arg) | NaN | NaN | NaN |

Sets issue #2057 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)