### PR TITLE
fix(#2060): scale Math.hypot to avoid overflow/underflow

### DIFF
--- a/plan/issues/2060-math-hypot-no-scaling.md
+++ b/plan/issues/2060-math-hypot-no-scaling.md
@@ -1,10 +1,11 @@
 ---
 id: 2060
 title: "Math.hypot overflows/underflows: inlined sqrt(a*a+b*b) without scaling"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: medium
 feasibility: easy
 reasoning_effort: medium

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -2177,18 +2177,54 @@ function compileMathCall(
         fctx.body.push({ op: "i32.or" } as Instr);
       }
     }
-    // if any is Inf, return +Infinity, else sqrt(sum of squares)
+    // if any is Inf, return +Infinity, else the scaled sum-of-squares (#2060).
     const thenBlock: Instr[] = [{ op: "f64.const", value: Infinity }];
+
+    // Naive `sqrt(Σ aᵢ²)` overflows above ~1e154 and underflows below ~1e-162
+    // because each square leaves the f64 range. Scale by the largest magnitude
+    // `m = max(|aᵢ|)`: result = m * sqrt(Σ (aᵢ/m)²). Each ratio is in [0,1], so
+    // its square is representable, and the single multiply by `m` at the end
+    // restores the true magnitude. When `m == 0` every arg is ±0, so the result
+    // is 0 (and we must avoid the 0/0 = NaN the scaling would otherwise yield).
+    const mLocal = allocLocal(fctx, `__hypot_m_${fctx.locals.length}`, { kind: "f64" });
     const elseBlock: Instr[] = [];
+    // m = max(|a0|, |a1|, ...) via f64.max over the absolute values.
+    elseBlock.push({ op: "local.get", index: hypotLocals[0]! } as Instr);
+    elseBlock.push({ op: "f64.abs" } as Instr);
+    for (let i = 1; i < hypotLocals.length; i++) {
+      elseBlock.push({ op: "local.get", index: hypotLocals[i]! } as Instr);
+      elseBlock.push({ op: "f64.abs" } as Instr);
+      elseBlock.push({ op: "f64.max" } as unknown as Instr);
+    }
+    elseBlock.push({ op: "local.set", index: mLocal } as Instr);
+
+    // Guard m == 0 → 0; else m * sqrt(Σ (aᵢ/m)²).
+    elseBlock.push({ op: "local.get", index: mLocal } as Instr);
+    elseBlock.push({ op: "f64.const", value: 0 });
+    elseBlock.push({ op: "f64.eq" } as Instr);
+    const scaledBlock: Instr[] = [];
     for (let i = 0; i < hypotLocals.length; i++) {
-      elseBlock.push({ op: "local.get", index: hypotLocals[i]! } as Instr);
-      elseBlock.push({ op: "local.get", index: hypotLocals[i]! } as Instr);
-      elseBlock.push({ op: "f64.mul" } as Instr);
+      scaledBlock.push({ op: "local.get", index: hypotLocals[i]! } as Instr);
+      scaledBlock.push({ op: "local.get", index: mLocal } as Instr);
+      scaledBlock.push({ op: "f64.div" } as Instr);
+      scaledBlock.push({ op: "local.get", index: hypotLocals[i]! } as Instr);
+      scaledBlock.push({ op: "local.get", index: mLocal } as Instr);
+      scaledBlock.push({ op: "f64.div" } as Instr);
+      scaledBlock.push({ op: "f64.mul" } as Instr);
     }
     for (let i = 1; i < hypotLocals.length; i++) {
-      elseBlock.push({ op: "f64.add" } as Instr);
+      scaledBlock.push({ op: "f64.add" } as Instr);
     }
-    elseBlock.push({ op: "f64.sqrt" } as Instr);
+    scaledBlock.push({ op: "f64.sqrt" } as Instr);
+    scaledBlock.push({ op: "local.get", index: mLocal } as Instr);
+    scaledBlock.push({ op: "f64.mul" } as Instr);
+    elseBlock.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: 0 }],
+      else: scaledBlock,
+    } as Instr);
+
     fctx.body.push({
       op: "if",
       blockType: { kind: "val", type: { kind: "f64" } },

--- a/tests/issue-2060.test.ts
+++ b/tests/issue-2060.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2060 — `Math.hypot` was inlined as `sqrt(Σ aᵢ²)` with no scaling, so the
+// squares overflowed to Infinity above ~1e154 and underflowed to 0 below
+// ~1e-162, while JS engines compute hypot with scaling.
+//
+// Fix: scale by the largest magnitude m = max(|aᵢ|) and compute
+// m * sqrt(Σ (aᵢ/m)²), guarding m == 0 → 0. Infinity/NaN propagation is
+// preserved (Infinity short-circuit first; NaN flows through f64.max + the
+// scaled arithmetic).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function hypot(args: number[]): Promise<number> {
+  const params = args.map((_, i) => `a${i}: number`).join(", ");
+  const call = args.map((_, i) => `a${i}`).join(", ");
+  const src = `export function h(${params}): number { return Math.hypot(${call}); }`;
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as { h(...a: number[]): number }).h(...args);
+}
+
+function expectClose(got: number, exp: number): void {
+  if (Number.isNaN(exp)) {
+    expect(Number.isNaN(got)).toBe(true);
+    return;
+  }
+  if (!Number.isFinite(exp)) {
+    expect(got).toBe(exp);
+    return;
+  }
+  // Within a few ULP — hypot exactness is implementation-approximated per spec.
+  expect(Math.abs(got - exp)).toBeLessThanOrEqual(Math.abs(exp) * 1e-15);
+}
+
+describe("#2060 Math.hypot scales to avoid overflow/underflow", () => {
+  it("no overflow at the top of the f64 range", async () => {
+    expectClose(await hypot([1e200, 1e200]), Math.hypot(1e200, 1e200));
+    expectClose(await hypot([1e200, 1e200, 1e200]), Math.hypot(1e200, 1e200, 1e200));
+  });
+
+  it("no underflow at the bottom of the f64 range", async () => {
+    expectClose(await hypot([3e-200, 4e-200]), Math.hypot(3e-200, 4e-200));
+  });
+
+  it("ordinary magnitudes still exact", async () => {
+    expectClose(await hypot([3, 4]), 5);
+    expectClose(await hypot([-3, -4]), 5);
+    expectClose(await hypot([2, 3, 6]), 7);
+  });
+
+  it("all-zero args return 0 (no 0/0 NaN from scaling)", async () => {
+    expect(await hypot([0, 0])).toBe(0);
+    expect(await hypot([0, 0, 0])).toBe(0);
+  });
+
+  it("Infinity and NaN propagation unchanged", async () => {
+    expect(await hypot([Infinity, 1])).toBe(Infinity);
+    expect(await hypot([NaN, Infinity])).toBe(Infinity); // Infinity wins per spec
+    expect(Number.isNaN(await hypot([NaN, 1]))).toBe(true);
+  });
+
+  it("1-arg form returns the magnitude", async () => {
+    expect(await hypot([-5])).toBe(5);
+  });
+});


### PR DESCRIPTION
## Problem

`Math.hypot` was inlined as `sqrt(Σ aᵢ²)` with no scaling, so the squares left the f64 range:

| call | before | node |
|------|--------|------|
| `Math.hypot(1e200, 1e200)` | `Infinity` | `1.414213562373095e+200` |
| `Math.hypot(3e-200, 4e-200)` | `0` | `5e-200` |

## Fix

Scale by the largest magnitude `m = max(|aᵢ|)` and compute `m * sqrt(Σ (aᵢ/m)²)` (`src/codegen/expressions/builtins.ts`). Each ratio is in `[0,1]`, so its square stays representable; the single multiply by `m` restores the true magnitude. `m == 0` is guarded → `0` to avoid the `0/0 = NaN` the scaling would otherwise yield for all-zero args.

- The `Infinity` short-circuit (any `|aᵢ| == Inf` → `+Infinity`) runs first, unchanged.
- NaN flows through `f64.max` and the scaled arithmetic to NaN, so propagation is preserved (`hypot(NaN,1) = NaN`, `hypot(NaN,Infinity) = Infinity`).

## Results (tests/issue-2060.test.ts, 6 tests pass)

Overflow/underflow now match V8 within ~1 ULP; ordinary magnitudes exact (`hypot(3,4)=5`, `hypot(2,3,6)=7`); all-zero → 0; Infinity/NaN propagation unchanged; variadic (2/3-arg) and 1-arg forms covered.

Sets issue #2060 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)