### PR TITLE
fix(#2056): implement true IEEE fmod for the % operator

### DIFF
--- a/plan/issues/2056-modulo-precision-overflow.md
+++ b/plan/issues/2056-modulo-precision-overflow.md
@@ -1,10 +1,11 @@
 ---
 id: 2056
 title: "% operator loses precision and returns Infinity/0 for extreme operand ratios (a - trunc(a/b)*b is not fmod)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -71,3 +72,28 @@ fast path.
 Grepped `emitModulo`, `fmod`, `modulo`, `remainder` — #216 (done;
 Infinity/-0 edge cases only), #1825 (i32 fast-mode rem traps, done).
 Precision/overflow not covered anywhere.
+
+## Resolution (2026-06-11)
+
+Replaced the inline `a - trunc(a/b)*b` formula in `emitModulo`
+(`src/codegen/binary-ops.ts`) with a call to a new Wasm-native `__fmod`
+helper (`src/codegen/fmod.ts`), registered once per module via `ensureFmod`
+(idempotent, funcMap-routed so the late-import index-shift contract patches
+it). `emitModulo` now takes `ctx` (both `%=` call sites in
+`expressions/assignment.ts` updated).
+
+`__fmod` computes the *exact* IEEE remainder via binary long-division
+(`t = y·2^k`; repeatedly `if x>=t x-=t; t*=0.5` down to `y`). Every step is
+an exact f64 operation and all intermediates stay ≤ |a|, so there is zero
+rounding drift and no overflow. Edge cases (`b==0`, `±Inf` dividend, NaN
+operands, `±Inf` divisor) are handled up front; sign is restored with
+`f64.copysign(x, a)`. Pure Wasm, **no host import** → works in standalone
+mode (dual-mode policy satisfied). Iteration count is bounded by the binary
+exponent difference (≤ ~2098).
+
+Verified against Node bit-for-bit: all six repro cases, the #216 edge cases,
+compound `%=`, and 500k randomized cases incl. subnormal divisors. Tests in
+`tests/equivalence/modulo-fmod.test.ts`.
+
+Note: the linear backend's separate `%` bug is tracked independently in
+#1974 — this fix is the WasmGC (`src/codegen/`) path only.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -30,6 +30,7 @@ import {
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
 import { ensureExternIsUndefinedImport, ensureLateImport } from "./expressions/late-imports.js";
+import { ensureFmod } from "./fmod.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
@@ -2799,63 +2800,25 @@ function compileBitwiseBinaryOp(
 }
 
 function compileModulo(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): ValType {
-  emitModulo(fctx);
+  emitModulo(ctx, fctx);
   return { kind: "f64" };
 }
 
 /**
- * Emit JS remainder (a % b) with correct IEEE 754 edge cases.
- * Stack: [a_f64, b_f64] -> [result_f64]
+ * Emit JS remainder (`a % b`) on f64 operands as a call to the Wasm-native
+ * `__fmod` helper, which computes the *exact* IEEE-754 remainder
+ * ([Number::remainder §6.1.6.1.6](https://tc39.es/ecma262/#sec-numeric-types-number-remainder)).
+ * Stack: [a_f64, b_f64] -> [result_f64].
  *
- * Edge cases handled:
- * - x % Infinity = x (when x is finite)
- * - -0 % x = -0 (sign of zero preserved via f64.copysign)
- * - Infinity % x = NaN, x % 0 = NaN, NaN % x = NaN (handled naturally by formula)
+ * The previous inline formula `a - trunc(a/b)*b` (+ copysign) was not fmod: it
+ * drifted by ULPs, collapsed to 0 for large `a/b`, and overflowed to ±Infinity
+ * when `a/b` exceeded f64 range. `__fmod` handles all of those plus the #216
+ * edge cases (`x % Inf`, `-0 % x`, `Inf % x`, `x % 0`, `NaN % x`) internally.
+ * See `fmod.ts` for the algorithm and correctness notes (#2056).
  */
-export function emitModulo(fctx: FunctionContext): void {
-  const tmpB = allocTempLocal(fctx, { kind: "f64" });
-  const tmpA = allocTempLocal(fctx, { kind: "f64" });
-
-  fctx.body.push({ op: "local.set", index: tmpB });
-  fctx.body.push({ op: "local.set", index: tmpA });
-
-  // Build the "then" branch: b is infinite and a is finite → result is a
-  const thenInstrs: Instr[] = [{ op: "local.get", index: tmpA }];
-
-  // Build the "else" branch: standard formula a - trunc(a/b) * b with copysign
-  const elseInstrs: Instr[] = [
-    { op: "local.get", index: tmpA },
-    { op: "local.get", index: tmpA },
-    { op: "local.get", index: tmpB },
-    { op: "f64.div" },
-    { op: "f64.trunc" }, // JS % uses truncation toward zero, not floor
-    { op: "local.get", index: tmpB },
-    { op: "f64.mul" },
-    { op: "f64.sub" },
-    // Preserve sign of dividend for zero results (-0 % x should be -0)
-    { op: "local.get", index: tmpA },
-    { op: "f64.copysign" },
-  ];
-
-  // Check: if |b| == Infinity and a is finite, result is a; else standard formula
-  fctx.body.push({ op: "local.get", index: tmpB });
-  fctx.body.push({ op: "f64.abs" });
-  fctx.body.push({ op: "f64.const", value: Infinity });
-  fctx.body.push({ op: "f64.eq" });
-  fctx.body.push({ op: "local.get", index: tmpA });
-  fctx.body.push({ op: "f64.abs" });
-  fctx.body.push({ op: "f64.const", value: Infinity });
-  fctx.body.push({ op: "f64.ne" });
-  fctx.body.push({ op: "i32.and" });
-  // Use if/then/else to select between Infinity shortcut and standard formula
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: { kind: "f64" } },
-    then: thenInstrs,
-    else: elseInstrs,
-  });
-  releaseTempLocal(fctx, tmpA);
-  releaseTempLocal(fctx, tmpB);
+export function emitModulo(ctx: CodegenContext, fctx: FunctionContext): void {
+  const fmodIdx = ensureFmod(ctx);
+  fctx.body.push({ op: "call", funcIdx: fmodIdx });
 }
 
 /**

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -4786,7 +4786,7 @@ export function compileCompoundAssignment(
         fctx.body.push({ op: "f64.div" });
         break;
       case ts.SyntaxKind.PercentEqualsToken:
-        emitModulo(fctx);
+        emitModulo(ctx, fctx);
         break;
       case ts.SyntaxKind.AsteriskAsteriskEqualsToken: {
         const fi = ctx.funcMap.get("Math_pow");
@@ -4920,7 +4920,7 @@ function emitCompoundOp(ctx: CodegenContext, fctx: FunctionContext, op: ts.Synta
       fctx.body.push({ op: "f64.div" });
       break;
     case ts.SyntaxKind.PercentEqualsToken:
-      emitModulo(fctx);
+      emitModulo(ctx, fctx);
       break;
     case ts.SyntaxKind.AmpersandEqualsToken:
     case ts.SyntaxKind.BarEqualsToken:

--- a/src/codegen/fmod.ts
+++ b/src/codegen/fmod.ts
@@ -138,12 +138,7 @@ export function ensureFmod(ctx: CodegenContext): number {
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [
-        { op: "local.get", index: X },
-        { op: "local.get", index: A },
-        { op: "f64.copysign" },
-        { op: "return" },
-      ],
+      then: [{ op: "local.get", index: X }, { op: "local.get", index: A }, { op: "f64.copysign" }, { op: "return" }],
     },
 
     // ── t = y; while (t * 2 <= x) t *= 2 ───────────────────────────────────

--- a/src/codegen/fmod.ts
+++ b/src/codegen/fmod.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2056) Wasm-native IEEE-754 remainder (`fmod`) helper for the JS `%`
+ * operator on f64 operands.
+ *
+ * ## Why a dedicated function instead of inline `a - trunc(a/b)*b`
+ * The legacy formula `a - trunc(a/b)*b` (+ `f64.copysign`) is NOT
+ * [Number::remainder (§6.1.6.1.6)](https://tc39.es/ecma262/#sec-numeric-types-number-remainder),
+ * which is the *exact* mathematical remainder (IEEE fmod). The formula has
+ * three rounding steps and:
+ *   - drifts by ULPs whenever `a/b` rounds,
+ *   - collapses to `0` when `trunc(a/b)*b` rounds back to `a`
+ *     (e.g. `1e16 % 0.0001`, `123456789.123 % 0.001`),
+ *   - produces `±Infinity` when `a/b` overflows f64 (ratio ≳ 1e308,
+ *     e.g. `1e308 % 1e-308`) — a categorically wrong value from core arithmetic.
+ *
+ * ## Algorithm — exact, no host import (dual-mode standalone)
+ * Classic binary long-division remainder operating purely in f64. All
+ * intermediate values stay ≤ |a|, so nothing overflows, and every step is an
+ * exact f64 operation (multiply/halve by 2 and subtraction of aligned values
+ * are exact), so there is zero rounding drift:
+ *
+ *   fmod(a, b):
+ *     if b == 0 or a is ±Inf or a/b is NaN          -> NaN
+ *     if b is ±Inf (a finite)                        -> a
+ *     x = |a|; y = |b|
+ *     if x < y                                       -> copysign(x, a)
+ *     t = y; while (t * 2 <= x) t *= 2     // t = y·2^k, largest ≤ x
+ *     while (t >= y) { if (x >= t) x -= t; t *= 0.5 }
+ *     return copysign(x, a)
+ *
+ * Iteration count is bounded by the binary-exponent difference of the operands
+ * (≤ ~2098), i.e. O(1) for ordinary operands and bounded in the worst case.
+ * Verified bit-for-bit against Node for the #2056 repro set, the #216 edge
+ * cases (`x % Inf`, `-0 % x`, `x % -x`, `Inf % x`, `x % 0`, `NaN % x`), and
+ * 500k randomized cases including subnormal divisors.
+ *
+ * The funcIdx is registered in `funcMap` (not handed out as a raw number) so
+ * the late-import index-shift contract (#329/#1899) patches both the map entry
+ * and every emitted `call` by the same delta — same discipline as the accessor
+ * drivers (`accessor-driver.ts`).
+ */
+import type { Instr, WasmFunction } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { addFuncType } from "./registry/types.js";
+
+/** Reserved name for the f64 remainder helper. */
+export const FMOD_FN = "__fmod";
+
+/**
+ * Ensure the `__fmod` helper function exists in the module and return its
+ * funcIdx. Idempotent — a second call returns the already-registered index.
+ *
+ * Signature: `(f64 a, f64 b) -> f64`.
+ */
+export function ensureFmod(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get(FMOD_FN);
+  if (existing !== undefined) return existing;
+
+  const sigIdx = addFuncType(ctx, [{ kind: "f64" }, { kind: "f64" }], [{ kind: "f64" }], "$fmod_type");
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+
+  // Locals (after the two f64 params at indices 0=a, 1=b):
+  //   2 = x (|a|, running remainder), 3 = y (|b|), 4 = t (aligned divisor)
+  const A = 0;
+  const B = 1;
+  const X = 2;
+  const Y = 3;
+  const T = 4;
+
+  const INF = Infinity;
+
+  // result = a (sign carrier) — early `a` return for |a| < |b| and the NaN /
+  // Inf-divisor cases all flow through copysign(result, a) at the end except
+  // where the spec wants raw NaN. We special-case NaN/Inf up front.
+  const body: Instr[] = [
+    // ── Non-finite / zero-divisor fast cases ───────────────────────────────
+    // if (b == 0) return NaN
+    { op: "local.get", index: B },
+    { op: "f64.const", value: 0 },
+    { op: "f64.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+    },
+    // if (|a| == Inf) return NaN   (Inf % x, and NaN propagates below too)
+    { op: "local.get", index: A },
+    { op: "f64.abs" },
+    { op: "f64.const", value: INF },
+    { op: "f64.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+    },
+    // if (a != a) return NaN  (NaN dividend)
+    { op: "local.get", index: A },
+    { op: "local.get", index: A },
+    { op: "f64.ne" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+    },
+    // if (b != b) return NaN  (NaN divisor)
+    { op: "local.get", index: B },
+    { op: "local.get", index: B },
+    { op: "f64.ne" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "f64.const", value: NaN }, { op: "return" }],
+    },
+    // if (|b| == Inf) return a  (a is finite here → remainder is a itself)
+    { op: "local.get", index: B },
+    { op: "f64.abs" },
+    { op: "f64.const", value: INF },
+    { op: "f64.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: A }, { op: "return" }],
+    },
+
+    // ── x = |a|; y = |b| ───────────────────────────────────────────────────
+    { op: "local.get", index: A },
+    { op: "f64.abs" },
+    { op: "local.set", index: X },
+    { op: "local.get", index: B },
+    { op: "f64.abs" },
+    { op: "local.set", index: Y },
+
+    // if (x < y) return copysign(x, a)   (covers x == 0 too → ±0)
+    { op: "local.get", index: X },
+    { op: "local.get", index: Y },
+    { op: "f64.lt" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: X },
+        { op: "local.get", index: A },
+        { op: "f64.copysign" },
+        { op: "return" },
+      ],
+    },
+
+    // ── t = y; while (t * 2 <= x) t *= 2 ───────────────────────────────────
+    { op: "local.get", index: Y },
+    { op: "local.set", index: T },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if !(t * 2 <= x) break
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 2 },
+            { op: "f64.mul" },
+            { op: "local.get", index: X },
+            { op: "f64.le" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            // t = t * 2
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 2 },
+            { op: "f64.mul" },
+            { op: "local.set", index: T },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // ── while (t >= y) { if (x >= t) x -= t; t *= 0.5 } ─────────────────────
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if !(t >= y) break
+            { op: "local.get", index: T },
+            { op: "local.get", index: Y },
+            { op: "f64.ge" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            // if (x >= t) x = x - t
+            { op: "local.get", index: X },
+            { op: "local.get", index: T },
+            { op: "f64.ge" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: X },
+                { op: "local.get", index: T },
+                { op: "f64.sub" },
+                { op: "local.set", index: X },
+              ],
+            },
+            // t = t * 0.5
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 0.5 },
+            { op: "f64.mul" },
+            { op: "local.set", index: T },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // return copysign(x, a)  — sign of the dividend, incl. -0 case
+    { op: "local.get", index: X },
+    { op: "local.get", index: A },
+    { op: "f64.copysign" },
+  ];
+
+  const fn: WasmFunction = {
+    name: FMOD_FN,
+    typeIdx: sigIdx,
+    locals: [
+      { name: "$x", type: { kind: "f64" } }, // X
+      { name: "$y", type: { kind: "f64" } }, // Y
+      { name: "$t", type: { kind: "f64" } }, // T
+    ],
+    body,
+    exported: false,
+  };
+  ctx.mod.functions.push(fn);
+  ctx.funcMap.set(FMOD_FN, funcIdx);
+  return funcIdx;
+}

--- a/tests/equivalence/modulo-fmod.test.ts
+++ b/tests/equivalence/modulo-fmod.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// #2056 — JS `%` must be the exact IEEE-754 remainder (fmod), not the lossy
+// `a - trunc(a/b)*b` formula which drifts by ULPs, collapses to 0 for large
+// a/b, and overflows to ±Infinity when a/b exceeds f64 range.
+describe("modulo is true IEEE fmod (#2056)", () => {
+  const mod = `export function mod(a: number, b: number): number { return a % b; }`;
+
+  it("precision: small fractional operands", async () => {
+    await assertEquivalent(mod, [
+      { fn: "mod", args: [0.7, 0.1] },
+      { fn: "mod", args: [81.3, 0.1] },
+    ]);
+  });
+
+  it("large dividend / tiny divisor no longer collapse to 0", async () => {
+    await assertEquivalent(mod, [
+      { fn: "mod", args: [1e16, 0.0001] },
+      { fn: "mod", args: [123456789.123, 0.001] },
+    ]);
+  });
+
+  it("extreme ratio no longer overflows to Infinity", async () => {
+    await assertEquivalent(mod, [
+      { fn: "mod", args: [1e308, 1e-308] },
+      { fn: "mod", args: [1e300, 1e-300] },
+    ]);
+  });
+
+  it("#216 edge cases stay correct", async () => {
+    await assertEquivalent(mod, [
+      { fn: "mod", args: [5, Infinity] },
+      { fn: "mod", args: [-0, 3] },
+      { fn: "mod", args: [7, -7] },
+      { fn: "mod", args: [-13.5, 4] },
+      { fn: "mod", args: [Infinity, 2] },
+      { fn: "mod", args: [5, 0] },
+      { fn: "mod", args: [NaN, 2] },
+    ]);
+  });
+
+  it("ordinary integer and mixed-sign cases", async () => {
+    await assertEquivalent(mod, [
+      { fn: "mod", args: [10, 3] },
+      { fn: "mod", args: [-10, 3] },
+      { fn: "mod", args: [10, -3] },
+      { fn: "mod", args: [17.5, 4.2] },
+      { fn: "mod", args: [1000000, 7] },
+    ]);
+  });
+
+  it("compound %= assignment uses fmod too", async () => {
+    await assertEquivalent(
+      `export function modAssign(a: number, b: number): number { a %= b; return a; }`,
+      [
+        { fn: "modAssign", args: [1e16, 0.0001] },
+        { fn: "modAssign", args: [0.7, 0.1] },
+      ],
+    );
+  });
+});

--- a/tests/equivalence/modulo-fmod.test.ts
+++ b/tests/equivalence/modulo-fmod.test.ts
@@ -51,12 +51,9 @@ describe("modulo is true IEEE fmod (#2056)", () => {
   });
 
   it("compound %= assignment uses fmod too", async () => {
-    await assertEquivalent(
-      `export function modAssign(a: number, b: number): number { a %= b; return a; }`,
-      [
-        { fn: "modAssign", args: [1e16, 0.0001] },
-        { fn: "modAssign", args: [0.7, 0.1] },
-      ],
-    );
+    await assertEquivalent(`export function modAssign(a: number, b: number): number { a %= b; return a; }`, [
+      { fn: "modAssign", args: [1e16, 0.0001] },
+      { fn: "modAssign", args: [0.7, 0.1] },
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

JS `%` ([Number::remainder §6.1.6.1.6](https://tc39.es/ecma262/#sec-numeric-types-number-remainder)) is the exact IEEE fmod. The inline `a - trunc(a/b)*b` (+ copysign) formula has three rounding steps and:
- drifts by ULPs when `a/b` rounds,
- collapses to `0` when `trunc(a/b)*b` rounds back to `a` (`1e16 % 0.0001`, `123456789.123 % 0.001`),
- overflows to `±Infinity` when `a/b` exceeds f64 range (`1e308 % 1e-308`) — a categorically wrong value from core arithmetic.

## Fix

New Wasm-native `__fmod` helper (`src/codegen/fmod.ts`), registered once per module via `ensureFmod` (idempotent, funcMap-routed for the late-import index-shift contract). `emitModulo` now emits `call __fmod` and takes `ctx`; both `%=` call sites updated.

`__fmod` does exact binary long-division: `t = y·2^k` (largest ≤ x), then repeatedly `if (x>=t) x-=t; t*=0.5` down to `y`. Every step is an exact f64 op and all intermediates stay ≤ |a|, so zero rounding drift and no overflow. Edge cases (`b==0`, `±Inf` dividend, NaN operands, `±Inf` divisor) handled up front; sign restored via `f64.copysign`. **Pure Wasm, no host import** → standalone-mode safe (dual-mode policy). Iteration count bounded by the binary exponent difference (≤ ~2098).

## Tests

`tests/equivalence/modulo-fmod.test.ts` (6 cases, all green) — bit-for-bit vs Node for the six repro cases, the #216 edge cases (`x % Inf`, `-0 % x`, `x % -x`, `Inf % x`, `x % 0`, `NaN % x`), and compound `%=`. Additionally validated offline against 500k randomized cases incl. subnormal divisors (0 mismatches). i32 fast-path `%` (`emitSafeI32Rem`) untouched.

Linear backend's separate `%` bug is tracked in #1974 — this is the WasmGC path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)