### PR TITLE
fix(#2062): throw e after catch-param reassignment rethrows the original

### DIFF
--- a/plan/issues/2062-rethrow-ignores-catch-param-reassignment.md
+++ b/plan/issues/2062-rethrow-ignores-catch-param-reassignment.md
@@ -1,10 +1,11 @@
 ---
 id: 2062
 title: "throw e after reassigning the catch parameter rethrows the ORIGINAL exception (rethrow optimization ignores writes)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -66,3 +67,32 @@ the moment an assignment to that name is compiled.
 
 Grepped `rethrow`, `catchRethrowStack`, `reassign` — hits are IR-port plumbing
 notes (#1124, #1131, #1169h) and unrelated async issues. Not covered.
+
+## Resolution (2026-06-11)
+
+Fixed in `src/codegen/statements/exceptions.ts`. Added `catchVarIsReassigned`,
+which walks the catch block AST (including nested functions/arrows) for any
+write to the catch parameter: plain/compound assignment, `++`/`--`, and
+identifiers appearing in array/object destructuring assignment targets. The
+`catchRethrowStack` entry is now pushed only when the parameter is NOT
+reassigned, so `throw e` after a write compiles `throw` of the local's current
+value (`compileExpression` + `throw $tag`) instead of Wasm `rethrow`. The pop is
+gated on the same condition. Plain `catch (e) { throw e; }` keeps the `rethrow`
+fast path (preserving exception identity for foreign/host exceptions).
+
+### Test Results
+
+`tests/issue-2062.test.ts` (6 cases, all PASS):
+
+| case | result |
+|------|--------|
+| `e = 2; throw e` | 20 ✓ |
+| `e = e + 7; throw e` (compound) | 10 ✓ |
+| closure mutation `()=>{e=2}; throw e` | 20 ✓ |
+| reassign then rethrow from nested `if` | 99 ✓ |
+| plain `throw e` (unregressed) | 42 ✓ |
+| plain rethrow from nested `if` (unregressed) | 8 ✓ |
+
+`tsc --noEmit` clean; `tests/try-catch.test.ts` green. Pre-existing failures in
+`tests/finally-block.test.ts` (minimal import object missing `string_constants`)
+are unrelated — they fail identically on baseline with this change reverted.

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -430,8 +430,7 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
       // #2062: skip the rethrow fast path when the catch parameter is reassigned
       // anywhere in the body (including via a capturing closure) — `throw e` must
       // then propagate the local's current value, not the originally-caught one.
-      const rethrowEligible =
-        catchVarName !== undefined && !catchVarIsReassigned(stmt.catchClause.block, catchVarName);
+      const rethrowEligible = catchVarName !== undefined && !catchVarIsReassigned(stmt.catchClause.block, catchVarName);
       if (catchVarName && rethrowEligible) {
         if (!fctx.catchRethrowStack) fctx.catchRethrowStack = [];
         fctx.catchRethrowStack.push({ varName: catchVarName, depth: 0 });

--- a/src/codegen/statements/exceptions.ts
+++ b/src/codegen/statements/exceptions.ts
@@ -139,6 +139,73 @@ function compileExternrefCatchDestructure(
   fctx.body.push({ op: "drop" });
 }
 
+/**
+ * #2062: Does `name` get reassigned anywhere inside `node`?
+ *
+ * The `throw e` → Wasm `rethrow` fast path re-raises the *originally-caught*
+ * exception, not the catch local's current value. That is only correct when the
+ * catch parameter is never written between catch entry and the throw. We detect
+ * any write to the binding name — plain/compound assignment, `++`/`--`, and
+ * destructuring assignment targets — including writes performed inside nested
+ * functions/arrows that capture the variable (`const f = () => { e = x }; f()`).
+ * If any is found, the rethrow optimization is disabled for that catch clause so
+ * `throw e` compiles the local's current value instead.
+ */
+function catchVarIsReassigned(node: ts.Node, name: string): boolean {
+  let found = false;
+  const visit = (n: ts.Node): void => {
+    if (found) return;
+    // `e = ...`, `e += ...`, etc. — assignment where the LHS is the identifier.
+    if (ts.isBinaryExpression(n) && isAssignmentOperator(n.operatorToken.kind)) {
+      if (assignmentTargetWritesName(n.left, name)) {
+        found = true;
+        return;
+      }
+    }
+    // `e++` / `++e` / `e--` / `--e`
+    if (
+      (ts.isPostfixUnaryExpression(n) || ts.isPrefixUnaryExpression(n)) &&
+      (n.operator === ts.SyntaxKind.PlusPlusToken || n.operator === ts.SyntaxKind.MinusMinusToken) &&
+      ts.isIdentifier(n.operand) &&
+      n.operand.text === name
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+/**
+ * Whether an assignment target (LHS of `=`/`+=`/… ) writes `name`. Covers the
+ * bare identifier and identifiers appearing as elements of array/object
+ * destructuring assignment targets (`[e] = ...`, `({x: e} = ...)`).
+ */
+function assignmentTargetWritesName(target: ts.Expression, name: string): boolean {
+  if (ts.isIdentifier(target)) return target.text === name;
+  if (ts.isArrayLiteralExpression(target)) {
+    return target.elements.some((el) => {
+      const inner = ts.isSpreadElement(el) ? el.expression : el;
+      return assignmentTargetWritesName(inner, name);
+    });
+  }
+  if (ts.isObjectLiteralExpression(target)) {
+    return target.properties.some((p) => {
+      if (ts.isShorthandPropertyAssignment(p)) return p.name.text === name;
+      if (ts.isPropertyAssignment(p)) return assignmentTargetWritesName(p.initializer, name);
+      if (ts.isSpreadAssignment(p)) return assignmentTargetWritesName(p.expression, name);
+      return false;
+    });
+  }
+  return false;
+}
+
 export function compileThrowStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ThrowStatement): void {
   // Check if this is a rethrow: `throw e` where `e` is the catch variable
   // of an enclosing catch block. If so, emit `rethrow` to preserve the
@@ -359,8 +426,13 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
       fctx.savedBodies.push(tryBody);
       fctx.body = [];
 
-      // Push rethrow info: depth starts at 0 (directly inside catch)
-      if (catchVarName) {
+      // Push rethrow info: depth starts at 0 (directly inside catch).
+      // #2062: skip the rethrow fast path when the catch parameter is reassigned
+      // anywhere in the body (including via a capturing closure) — `throw e` must
+      // then propagate the local's current value, not the originally-caught one.
+      const rethrowEligible =
+        catchVarName !== undefined && !catchVarIsReassigned(stmt.catchClause.block, catchVarName);
+      if (catchVarName && rethrowEligible) {
         if (!fctx.catchRethrowStack) fctx.catchRethrowStack = [];
         fctx.catchRethrowStack.push({ varName: catchVarName, depth: 0 });
       }
@@ -407,8 +479,8 @@ export function compileTryStatement(ctx: CodegenContext, fctx: FunctionContext, 
         adjustRethrowDepth(fctx, -1);
       }
 
-      // Pop rethrow info
-      if (catchVarName) {
+      // Pop rethrow info (only if we pushed it above)
+      if (catchVarName && rethrowEligible) {
         fctx.catchRethrowStack!.pop();
       }
 

--- a/tests/issue-2062.test.ts
+++ b/tests/issue-2062.test.ts
@@ -9,10 +9,9 @@ import { compile } from "../src/index.js";
 
 async function compileAndRun(source: string) {
   const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
   return instance.exports as Record<string, Function>;
 }

--- a/tests/issue-2062.test.ts
+++ b/tests/issue-2062.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2062 — `catch (e) { e = ...; throw e; }` used to emit Wasm `rethrow`, which
+// re-raises the ORIGINALLY-caught exception, ignoring the reassignment. The
+// rethrow fast path is now disabled whenever the catch parameter is written
+// anywhere in the block (assignment, compound, ++/--, or via a capturing
+// closure); plain `catch (e) { throw e; }` keeps the fast path.
+
+async function compileAndRun(source: string) {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2062 throw e after catch-param reassignment", () => {
+  it("reassign then throw propagates the new value", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 1; } catch (e) { e = 2; throw e; } }
+         catch (e2) { return (e2 as number) * 10; }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(20);
+  });
+
+  it("compound assignment to catch param", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 3; } catch (e) { e = (e as number) + 7; throw e; } }
+         catch (e2) { return (e2 as number); }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(10);
+  });
+
+  it("reassignment inside a capturing closure", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 1; } catch (e) { const g = () => { e = 2; }; g(); throw e; } }
+         catch (e2) { return (e2 as number) * 10; }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(20);
+  });
+
+  it("reassign then rethrow from a nested block", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 8; } catch (e) { e = 99; if (true) { throw e; } } }
+         catch (e2) { return (e2 as number); }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(99);
+  });
+
+  it("plain rethrow keeps the fast path (unregressed)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 42; } catch (e) { throw e; } }
+         catch (e2) { return (e2 as number); }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(42);
+  });
+
+  it("plain rethrow from a nested block keeps the fast path", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         try { try { throw 8; } catch (e) { if (true) { throw e; } } }
+         catch (e2) { return (e2 as number); }
+         return -1;
+       }`,
+    );
+    expect(e.f()).toBe(8);
+  });
+});


### PR DESCRIPTION
## Problem

`throw <catchVar>` was compiled unconditionally to Wasm `rethrow` by name match against `catchRethrowStack`, ignoring writes to the binding. `rethrow` re-raises the *originally-caught* exception, so the common error-normalization pattern `catch (e) { e = wrap(e); throw e; }` propagated the **original** value, not the reassigned one.

```ts
try { try { throw 1; } catch (e) { e = 2; throw e; } }
catch (e2) { return (e2 as number) * 10; }  // wasm: 10 (caught original 1) — node: 20
```

## Fix

In `src/codegen/statements/exceptions.ts`, added `catchVarIsReassigned` which walks the catch block AST (including nested functions/arrows that capture the variable) for any write to the catch parameter: plain/compound assignment, `++`/`--`, and identifiers in array/object destructuring assignment targets. The `catchRethrowStack` entry is pushed (and popped) only when the parameter is NOT reassigned, so `throw e` after a write compiles `throw` of the local's current value instead of `rethrow`. Plain `catch (e) { throw e; }` keeps the rethrow fast path (preserves exception identity for foreign/host exceptions).

## Tests

`tests/issue-2062.test.ts` — 6 cases, all pass:
- `e = 2; throw e` → 20; compound `e = e + 7` → 10; closure mutation → 20; reassign then rethrow from nested `if` → 99
- plain `throw e` → 42 (unregressed); plain rethrow from nested `if` → 8 (unregressed)

`tsc --noEmit` clean; `tests/try-catch.test.ts` green. Closes #2062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)