### PR TITLE
fix(#2065): for-of observes mid-iteration array mutation (live length/data)

### DIFF
--- a/plan/issues/2065-forof-array-mutation-not-observed.md
+++ b/plan/issues/2065-forof-array-mutation-not-observed.md
@@ -1,10 +1,11 @@
 ---
 id: 2065
 title: "for-of over an array hoists length and data once — mutation during iteration not observed (push invisible, pop over-iterates)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -74,3 +75,33 @@ bounds-check elimination and can gate this.
 Grepped `mutat` + `for-of`, `stale length`, `collection mutation`: #365 (done —
 only removed runner skip filters), #1130 (getter-observing array methods,
 different). Not covered.
+
+## Resolution (2026-06-11)
+
+Fixed in `src/codegen/statements/loops.ts` (`compileForOfArray`). Added a
+`reReadLive` gate: when the iterable is a plain identifier and the existing
+`loopBodyMutatesIndexOrArray` analysis (reused with an empty index name) reports
+the body may mutate that array, the loop now re-reads `length` (struct field 0)
+and `data` (field 1) from the vec local at the top of every iteration — in both
+the `i >= length` break test and the `data[i]` element read — instead of using
+the hoisted `lenLocal`/`dataLocal`. The vec ref itself is still captured once, so
+reassigning the *binding* mid-loop correctly keeps iterating the original array
+(matches JS: the iterator is bound to the original object). Non-mutating loops
+keep the hoisted fast path (no perf regression).
+
+### Test Results
+
+`tests/issue-2065.test.ts` (6 cases, all PASS), expected values cross-checked
+against Node:
+
+| case | result |
+|------|--------|
+| push during iteration visited | 1234 ✓ |
+| pop stops early | 12 ✓ |
+| growth past capacity (reallocation) | 6 ✓ |
+| `arr.length = 2` shrink | 12 ✓ |
+| binding reassignment iterates original | 123 ✓ |
+| non-mutating loop (unregressed) | 18 ✓ |
+
+`tsc --noEmit` clean; `tests/iterators.test.ts` + `tests/symbol-iterator-protocol.test.ts`
+green (10/10, incl. the for-of array regression check).

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -2770,6 +2770,17 @@ function compileForOfArray(
   const vecLocal = allocLocal(fctx, `__forof_vec_${fctx.locals.length}`, vecType);
   fctx.body.push({ op: "local.set", index: vecLocal });
 
+  // #2065: Array iterators re-read the live length each step (§23.1.5.1), so a
+  // body that mutates the array (push/pop/splice/length=…/reassignment, or a
+  // closure that captures it) must observe the change. Hoisting `length`/`data`
+  // once before the loop misses pushes and over-iterates after pops (and a
+  // reallocated backing array leaves `data` stale). When the iterable is a plain
+  // identifier and the body may mutate it, re-read both fields from the vec local
+  // at the top of every iteration. Non-mutating loops keep the hoisted fast path.
+  const iterableSource = iterableOverride ?? stmt.expression;
+  const reReadLive =
+    ts.isIdentifier(iterableSource) && loopBodyMutatesIndexOrArray(stmt.statement, "", iterableSource.text);
+
   // Mark position for null guard wrapping (struct.get on null ref traps)
   const nullGuardStart = fctx.body.length;
 
@@ -2850,14 +2861,28 @@ function compileForOfArray(
   fctx.breakStack.push(2); // break = depth 2 (exit outer block)
   fctx.continueStack.push(0); // continue = depth 0 (exit body block, then increment)
 
-  // Condition: i >= length → break
+  // Condition: i >= length → break. When the array may be mutated mid-loop
+  // (#2065), read the live length from the vec each iteration rather than the
+  // hoisted `lenLocal`.
   fctx.body.push({ op: "local.get", index: iLocal });
-  fctx.body.push({ op: "local.get", index: lenLocal });
+  if (reReadLive) {
+    fctx.body.push({ op: "local.get", index: vecLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  } else {
+    fctx.body.push({ op: "local.get", index: lenLocal });
+  }
   fctx.body.push({ op: "i32.ge_s" });
   fctx.body.push({ op: "br_if", depth: 1 }); // break
 
-  // Get element: x = data[i]
-  fctx.body.push({ op: "local.get", index: dataLocal });
+  // Get element: x = data[i]. Re-read the live data array when mutating (#2065):
+  // a growth that reallocated the backing array leaves the hoisted `dataLocal`
+  // stale.
+  if (reReadLive) {
+    fctx.body.push({ op: "local.get", index: vecLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+  } else {
+    fctx.body.push({ op: "local.get", index: dataLocal });
+  }
   fctx.body.push({ op: "local.get", index: iLocal });
   fctx.body.push({ op: "array.get", typeIdx: arrTypeIdx });
   // Coerce from Wasm array element type to the local's declared type

--- a/tests/issue-2065.test.ts
+++ b/tests/issue-2065.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2065 — the for-of array fast path hoisted the vec's `length` and `data` into
+// locals once before the loop, so elements pushed during iteration were never
+// visited and popped elements were still visited (and a reallocated backing
+// array left `data` stale). When the iterable is a plain identifier whose array
+// the body may mutate, the loop now re-reads length/data from the vec each
+// iteration. Non-mutating loops keep the hoisted fast path.
+
+async function compileAndRun(source: string) {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2065 for-of observes mid-iteration array mutation", () => {
+  it("push during iteration is visited", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         const arr: number[] = [1, 2, 3];
+         let log = 0;
+         for (const x of arr) { log = log * 10 + x; if (x === 1) arr.push(4); }
+         return log;
+       }`,
+    );
+    expect(e.f()).toBe(1234);
+  });
+
+  it("pop during iteration stops early", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         const arr: number[] = [1, 2, 3, 4];
+         let log = 0;
+         for (const x of arr) { log = log * 10 + x; arr.pop(); }
+         return log;
+       }`,
+    );
+    expect(e.f()).toBe(12);
+  });
+
+  it("growth past capacity (reallocation) is observed", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         const arr: number[] = [1, 2, 3];
+         let count = 0;
+         for (const x of arr) { count++; if (count <= 3) arr.push(x + 10); }
+         return count;
+       }`,
+    );
+    expect(e.f()).toBe(6);
+  });
+
+  it("arr.length = n shrink is observed", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         const arr: number[] = [1, 2, 3, 4];
+         let log = 0;
+         for (const x of arr) { log = log * 10 + x; arr.length = 2; }
+         return log;
+       }`,
+    );
+    expect(e.f()).toBe(12);
+  });
+
+  it("reassigning the binding does not change the iterated array", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         let arr: number[] = [1, 2, 3];
+         let log = 0;
+         for (const x of arr) { log = log * 10 + x; arr = [9, 9, 9, 9]; }
+         return log;
+       }`,
+    );
+    expect(e.f()).toBe(123);
+  });
+
+  it("non-mutating loop keeps the hoisted fast path (unregressed)", async () => {
+    const e = await compileAndRun(
+      `export function f(): number {
+         const arr: number[] = [5, 6, 7];
+         let s = 0;
+         for (const x of arr) { s += x; }
+         return s;
+       }`,
+    );
+    expect(e.f()).toBe(18);
+  });
+});

--- a/tests/issue-2065.test.ts
+++ b/tests/issue-2065.test.ts
@@ -10,10 +10,9 @@ import { compile } from "../src/index.js";
 
 async function compileAndRun(source: string) {
   const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
   return instance.exports as Record<string, Function>;
 }


### PR DESCRIPTION
## Problem

The for-of array fast path hoisted the vec's `length` and `data` into locals once before the loop. Array iterators re-read the live length each step ([§23.1.5.1](https://tc39.es/ecma262/#sec-createarrayiterator)), so:
- elements pushed during iteration were never visited (`grow` → 123 not 1234)
- popped elements were still visited (`shrink` → 1234 not 12)
- growth past capacity reallocated the backing array, leaving `data` stale

## Fix

In `src/codegen/statements/loops.ts` (`compileForOfArray`), added a `reReadLive` gate: when the iterable is a plain identifier and the existing `loopBodyMutatesIndexOrArray` analysis reports the body may mutate that array (push/pop/splice/`length=`/reassignment/closure capture), re-read `length` (struct field 0) and `data` (field 1) from the vec local at the top of each iteration — in both the `i >= length` break test and the `data[i]` element read. The vec ref itself is captured once, so reassigning the *binding* mid-loop correctly keeps iterating the original array (matches JS). Non-mutating loops keep the hoisted fast path.

## Tests

`tests/issue-2065.test.ts` — 6 cases, all pass (expected values cross-checked against Node):
- push visited → 1234; pop stops early → 12; growth-past-capacity → 6; `arr.length=2` → 12
- binding reassignment iterates original → 123; non-mutating loop (unregressed) → 18

`tsc --noEmit` clean; `tests/iterators.test.ts` + `tests/symbol-iterator-protocol.test.ts` green (10/10). Closes #2065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)