### PR TITLE
fix(#2059): any < any performs §7.2.13 string comparison

### DIFF
--- a/plan/issues/2059-any-relational-no-string-comparison.md
+++ b/plan/issues/2059-any-relational-no-string-comparison.md
@@ -1,10 +1,11 @@
 ---
 id: 2059
 title: "relational operators on two any/externref operands never perform string comparison (\"a\" < \"b\" → false)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -66,3 +67,35 @@ policy). Likely shares plumbing with #2058.
 Grepped `relational`, `string comparison`, `__any_lt` — #117 (harness string
 compare, done), #295 (comparison ops, bigint-focused, done), #1563/#1577
 (broad spec audits, item absent). Not covered.
+
+## Resolution (2026-06-11)
+
+The root-cause note about `__any_lt` was a red herring for the **default**
+(JS-host) compile path: there `ctx.anyValueTypeIdx` is `-1`, so the AnyValue
+helpers are never registered and `any` operands compile to **externref**, not
+`$AnyValue`. The numeric fast path then coerces both externrefs to f64
+(`__unbox_number` → `Number("a") = NaN`), so every string relational was false.
+
+Fix (JS-host path, dual-mode safe):
+- Added a `__host_relational` host import + `host_relational` intent
+  (`src/compiler/import-manifest.ts`, `src/index.ts`, `src/runtime.ts`). It
+  takes `(externref, externref, i32 opcode)` where opcode 0/1/2/3 =
+  `<`/`<=`/`>`/`>=` and delegates to the native JS operator, which already
+  implements §7.2.13 (ToPrimitive + lexicographic string compare).
+- In `compileBinaryExpression` (`src/codegen/binary-ops.ts`), before the numeric
+  coercion, when the op is relational, a JS host is available, **and neither
+  operand is statically typed as a primitive we already handle numerically**
+  (number / boolean / bigint / string), compile both operands as externref and
+  call `__host_relational`. The "both non-primitive" guard keeps the
+  provably-numeric and provably-string fast paths untouched (no perf
+  regression). Standalone/WASI (`ctx.standalone`/`ctx.wasi`) falls through to
+  the existing numeric path — no new unsatisfiable host import is emitted.
+
+### Test Results
+
+New `tests/equivalence/any-relational-string.test.ts` — 16 cases covering
+string lexicographic (`"a"<"b"`, `"10"<"9"`, `"abc"<"abd"`, `"abc"<"ab"`),
+mixed string/number (numeric), pure numeric, NaN, and null/undefined, across
+all four operators. All pass. No regressions in string-relational-operators /
+comparison-coercion / boolean-relational-comparison / i32-loop-compare /
+string-arithmetic-coercion / logical-operators (48 tests green).

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -818,6 +818,70 @@ export function compileBinaryExpression(
   const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
   const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
 
+  // ── Relational (< <= > >=) on two `any`/externref operands (#2059) ──
+  // §7.2.13 IsLessThan compares strings lexicographically when both ToPrimitive
+  // results are strings. The numeric fast path below unboxes both externref
+  // operands to f64 (`Number("a")` → NaN), so every string relational wrongly
+  // yields false. When neither operand is statically typed as a primitive that
+  // we already handle numerically (number / boolean / bigint / string), and a
+  // JS host is available, delegate to `__host_relational` which runs the real
+  // JS operator. Standalone/WASI falls through to the numeric path (no host).
+  {
+    const relOpcode =
+      op === ts.SyntaxKind.LessThanToken
+        ? 0
+        : op === ts.SyntaxKind.LessThanEqualsToken
+          ? 1
+          : op === ts.SyntaxKind.GreaterThanToken
+            ? 2
+            : op === ts.SyntaxKind.GreaterThanEqualsToken
+              ? 3
+              : -1;
+    const noJsHost = ctx.standalone === true || ctx.wasi === true;
+    const isPrimNumericish = (t: ts.Type): boolean =>
+      isNumberType(t) || isBooleanType(t) || isBigIntType(t) || isStringType(t);
+    // Apply only when BOTH sides are non-primitive (any / unknown / object /
+    // union with externref) — a statically-string or statically-numeric side
+    // is already handled correctly by the dedicated paths below. This keeps the
+    // provably-numeric fast path untouched (no perf regression).
+    if (relOpcode >= 0 && !noJsHost && !isPrimNumericish(leftTsType) && !isPrimNumericish(rightTsType)) {
+      const leftResult = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
+      if (leftResult) {
+        if (leftResult.kind !== "externref") coerceType(ctx, fctx, leftResult, { kind: "externref" });
+        const tmpL = allocTempLocal(fctx, { kind: "externref" });
+        fctx.body.push({ op: "local.set", index: tmpL });
+        const rightResult = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
+        if (rightResult) {
+          if (rightResult.kind !== "externref") coerceType(ctx, fctx, rightResult, { kind: "externref" });
+          const tmpR = allocTempLocal(fctx, { kind: "externref" });
+          fctx.body.push({ op: "local.set", index: tmpR });
+          const hostIdx = ensureLateImport(
+            ctx,
+            "__host_relational",
+            [{ kind: "externref" }, { kind: "externref" }, { kind: "i32" }],
+            [{ kind: "i32" }],
+          );
+          flushLateImportShifts(ctx, fctx);
+          const finalIdx = ctx.funcMap.get("__host_relational") ?? hostIdx;
+          if (finalIdx !== undefined) {
+            fctx.body.push({ op: "local.get", index: tmpL });
+            fctx.body.push({ op: "local.get", index: tmpR });
+            fctx.body.push({ op: "i32.const", value: relOpcode });
+            fctx.body.push({ op: "call", funcIdx: finalIdx });
+            releaseTempLocal(fctx, tmpR);
+            releaseTempLocal(fctx, tmpL);
+            return { kind: "i32" };
+          }
+          releaseTempLocal(fctx, tmpR);
+        }
+        releaseTempLocal(fctx, tmpL);
+        // If we bailed after compiling operands, we cannot cleanly recover the
+        // stack — but ensureLateImport for a host import effectively never
+        // returns undefined in JS-host mode, so this path is not reached.
+      }
+    }
+  }
+
   // ── Loose equality (== / !=) with mixed types ──
   // JS loose equality coerces types before comparing. Handle common cases:
   //   number == boolean / boolean == number → coerce boolean to number

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -128,6 +128,12 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   // Used for `any`-typed loose equality where null == undefined must be true. (#1134)
   if (name === "__host_loose_eq") return { type: "host_loose_eq" };
 
+  // Host relational comparison for two externref operands (§7.2.13 IsLessThan).
+  // The third arg is an opcode: 0=`<`, 1=`<=`, 2=`>`, 3=`>=`. Implements the
+  // string-vs-number ToPrimitive dispatch (lexicographic for two strings) that
+  // the f64 fast path gets wrong for `any < any`. (#2059)
+  if (name === "__host_relational") return { type: "host_relational" };
+
   // SameValueZero comparison (§7.2.11) — like === except NaN equals NaN.
   // Used by Array.prototype.includes on array-like receivers (#1360).
   if (name === "__same_value_zero") return { type: "same_value_zero" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export type ImportIntent =
   | { type: "declared_global"; name: string }
   | { type: "host_eq" }
   | { type: "host_loose_eq" }
+  | { type: "host_relational" }
   | { type: "same_value_zero" }
   | { type: "dynamic_import" }
   | { type: "proxy_create" }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10271,6 +10271,23 @@ assert._isSameValue = isSameValue;
       // Handles null == undefined → true and other JS coercion rules.
       // biome-ignore lint/suspicious/noDoubleEquals: §7.2.15 IsLooselyEqual requires == semantics (null == undefined, type coercion)
       return (a: any, b: any) => (a == b ? 1 : 0);
+    case "host_relational":
+      // #2059 — relational comparison for two externref operands (§7.2.13
+      // IsLessThan). The native JS `<`/`<=`/`>`/`>=` operators already implement
+      // ToPrimitive + the string-vs-number dispatch (lexicographic when both
+      // sides are strings), so we delegate to them. opcode: 0=`<`,1=`<=`,2=`>`,3=`>=`.
+      return (a: any, b: any, opcode: number) => {
+        switch (opcode) {
+          case 0:
+            return a < b ? 1 : 0;
+          case 1:
+            return a <= b ? 1 : 0;
+          case 2:
+            return a > b ? 1 : 0;
+          default:
+            return a >= b ? 1 : 0;
+        }
+      };
     case "same_value_zero":
       // #1360 — SameValueZero comparison (§7.2.11).
       // Same as Strict Equality except NaN === NaN is true.

--- a/tests/equivalence/any-relational-string.test.ts
+++ b/tests/equivalence/any-relational-string.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm, evaluateAsJs } from "./helpers.js";
+
+// §7.2.13 IsLessThan: relational operators on two `any` operands must compare
+// strings lexicographically, not coerce both to f64 (→ NaN → always false). (#2059)
+describe("relational operators on any/any operands (#2059)", () => {
+  const src = `
+    export function lt(a: any, b: any): boolean { return a < b; }
+    export function le(a: any, b: any): boolean { return a <= b; }
+    export function gt(a: any, b: any): boolean { return a > b; }
+    export function ge(a: any, b: any): boolean { return a >= b; }
+  `;
+
+  const cases: { fn: string; a: unknown; b: unknown }[] = [
+    // string lexicographic
+    { fn: "lt", a: "a", b: "b" },
+    { fn: "lt", a: "b", b: "a" },
+    { fn: "lt", a: "10", b: "9" }, // lexicographic: "1" < "9" → true (NOT numeric 10<9)
+    { fn: "lt", a: "abc", b: "abd" },
+    { fn: "lt", a: "abc", b: "ab" },
+    { fn: "gt", a: "b", b: "a" },
+    { fn: "le", a: "a", b: "a" },
+    { fn: "ge", a: "b", b: "a" },
+    // mixed string/number → numeric per §7.2.13
+    { fn: "lt", a: "10", b: 9 },
+    { fn: "lt", a: 5, b: "9" },
+    // pure numeric
+    { fn: "lt", a: 5, b: 3 },
+    { fn: "gt", a: 7, b: 2 },
+    // NaN operand → all relationals false
+    { fn: "lt", a: NaN, b: 1 },
+    { fn: "gt", a: NaN, b: 1 },
+    // null / undefined coercion
+    { fn: "lt", a: null, b: 1 },
+    { fn: "le", a: null, b: 0 },
+  ];
+
+  it("matches Node for any/any relational comparisons", async () => {
+    const wasm = await compileToWasm(src);
+    const js = evaluateAsJs(src);
+    for (const { fn, a, b } of cases) {
+      const w = wasm[fn]!(a, b);
+      const j = js[fn]!(a, b);
+      // wasm returns i32 (0/1); js returns boolean — normalize.
+      expect(!!w, `${fn}(${JSON.stringify(a)}, ${JSON.stringify(b)})`).toBe(!!j);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Relational operators (`<`/`<=`/`>`/`>=`) on two `any` operands always returned `false` for strings:

```ts
function lt(a: any, b: any): boolean { return a < b; }
lt("a", "b");   // wasm: false — node: true
lt("10", "9");  // wasm: false — node: true (lexicographic)
```

## Root cause

In the default JS-host path `any` compiles to **externref** (`ctx.anyValueTypeIdx` is `-1`, so the `__any_lt` machinery the issue pointed at never registers). The numeric fast path then unboxes both externrefs to f64 (`Number("a") = NaN`), so `f64.lt(NaN, NaN)` is false for every string relational.

## Fix

- New `__host_relational` host import + `host_relational` intent (`import-manifest.ts`, `index.ts`, `runtime.ts`): `(externref, externref, i32 opcode)` where opcode 0/1/2/3 = `<`/`<=`/`>`/`>=`, delegating to the native JS operator which already implements §7.2.13 (ToPrimitive + lexicographic string compare).
- In `compileBinaryExpression` (`binary-ops.ts`), before the numeric coercion, route relationals through `__host_relational` when a JS host is available **and neither operand is statically a primitive we already handle numerically** (number / boolean / bigint / string). That guard leaves the provably-numeric and provably-string fast paths untouched (no perf regression). Standalone/WASI falls through to the numeric path — no unsatisfiable host import.

## Tests

New `tests/equivalence/any-relational-string.test.ts` (16 cases: string lexicographic, mixed string/number, pure numeric, NaN, null/undefined, all four operators). All pass. No regressions in string-relational-operators / comparison-coercion / boolean-relational-comparison / i32-loop-compare / string-arithmetic-coercion / logical-operators (48 tests green).

Closes #2059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)