### PR TITLE
fix(#2066): for-in skips properties deleted during enumeration

### DIFF
--- a/plan/issues/2066-forin-visits-deleted-properties.md
+++ b/plan/issues/2066-forin-visits-deleted-properties.md
@@ -1,10 +1,11 @@
 ---
 id: 2066
 title: "for-in visits properties deleted during enumeration (eager key snapshot, no per-visit liveness check)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: medium
 feasibility: easy
 reasoning_effort: medium

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -8722,6 +8722,11 @@ export function addForInImports(ctx: CodegenContext): void {
   // __for_in_get: (externref, i32) -> externref — returns keys[i]
   const extI32ToExt = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [{ kind: "externref" }]);
   addImport(ctx, "env", "__for_in_get", { kind: "func", typeIdx: extI32ToExt });
+
+  // __for_in_has: (externref obj, externref key) -> i32 — per-visit liveness
+  // check so a property deleted mid-enumeration is skipped (#2066).
+  const extExtToI32 = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+  addImport(ctx, "env", "__for_in_has", { kind: "func", typeIdx: extExtToI32 });
 }
 
 /**

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -4361,6 +4361,7 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   const keysIdx = ctx.funcMap.get("__for_in_keys");
   const lenIdx = ctx.funcMap.get("__for_in_len");
   const getIdx = ctx.funcMap.get("__for_in_get");
+  const hasIdx = ctx.funcMap.get("__for_in_has");
 
   if (keysIdx === undefined || lenIdx === undefined || getIdx === undefined) {
     // Fallback: static unrolling when host imports are not available (standalone mode)
@@ -4377,11 +4378,17 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     return;
   }
 
-  // Compile the object expression and coerce to externref for the host import
+  // Compile the object expression and coerce to externref for the host import.
+  // Retain the object ref in a local so the per-visit liveness check (#2066) can
+  // re-query whether a key deleted during the loop body should be skipped.
+  const objLocal = allocLocal(fctx, `__forin_obj_${fctx.locals.length}`, {
+    kind: "externref",
+  });
   const exprType = compileExpression(ctx, fctx, stmt.expression);
   if (exprType && exprType.kind !== "externref") {
     coerceType(ctx, fctx, exprType, { kind: "externref" });
   }
+  fctx.body.push({ op: "local.tee", index: objLocal });
   fctx.body.push({ op: "call", funcIdx: keysIdx }); // __for_in_keys(obj) -> keys array
 
   // Store keys array in a local
@@ -4479,11 +4486,34 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   loopBody.push({ op: "call", funcIdx: getIdx }); // __for_in_get(keys, i) -> externref
   loopBody.push({ op: "local.set", index: keyLocal });
 
+  // Per-visit liveness guard (#2066): if the key was deleted earlier in this
+  // enumeration, skip it. Emitted at the START of the $continue block so the
+  // `br 0` lands on the increment (same path as a user `continue`), never
+  // re-running the loop without advancing. Only when the host check is
+  // available (it always is when the snapshot imports are).
+  const guardedBody: Instr[] = userBody;
+  if (hasIdx !== undefined) {
+    // The guard sits inside `block $continue { … }`. From inside the `if`'s
+    // `then`, the enclosing labels are: if(0) → $continue(1). Skipping a deleted
+    // key means exiting $continue (which falls through to the increment), so the
+    // br target is depth 1, not 0 (br 0 would only exit the `if` and fall into
+    // the user body — re-visiting the deleted key).
+    guardedBody.unshift({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "br", depth: 1 } as Instr],
+    } as Instr);
+    guardedBody.unshift({ op: "i32.eqz" } as Instr);
+    guardedBody.unshift({ op: "call", funcIdx: hasIdx } as Instr);
+    guardedBody.unshift({ op: "local.get", index: keyLocal } as Instr);
+    guardedBody.unshift({ op: "local.get", index: objLocal } as Instr);
+  }
+
   // Wrap user body in block $continue so `continue` exits here
   loopBody.push({
     op: "block",
     blockType: { kind: "empty" },
-    body: userBody,
+    body: guardedBody,
   });
 
   // Increment counter (reached after user body OR after continue)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8907,6 +8907,30 @@ assert._isSameValue = isSameValue;
           if (keys == null || !Array.isArray(keys)) return undefined;
           return keys[i];
         };
+      // Per-visit liveness check for for-in (#2066). The key set is snapshotted
+      // up front (spec-permitted), but §14.7.5.10 requires that a property
+      // deleted before it is visited is skipped. This re-tests, at visit time,
+      // whether `key` still exists on the (own-or-inherited) live object — the
+      // `in`-operator semantics that match for-in's enumeration set. Returns 1
+      // if still present, 0 if it has since been deleted.
+      if (name === "__for_in_has")
+        return (obj: any, key: any): number => {
+          if (obj == null) return 0;
+          const k = typeof key === "symbol" ? key : String(key);
+          if (!_isWasmStruct(obj)) {
+            try {
+              return k in (obj as object) ? 1 : 0;
+            } catch {
+              return 0;
+            }
+          }
+          // WasmGC struct: an explicit delete records a tombstone — honor it.
+          const tomb = _wasmStructDeletedKeys.get(obj);
+          if (tomb && tomb.has(k)) return 0;
+          // Otherwise the key was enumerated from the live shape and has not been
+          // deleted, so it is still present.
+          return 1;
+        };
       // Promise combinators and constructors
       // Helper: convert WasmGC vec struct to JS array (vec structs are opaque
       // from JS; Promise.all/race/etc. need an iterable).

--- a/tests/issue-2066.test.ts
+++ b/tests/issue-2066.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2066 — for-in visited properties deleted during enumeration.
+//
+// EnumerateObjectProperties (§14.7.5.10) requires that a property deleted
+// before it is visited is not visited. The compiler snapshotted all keys up
+// front (spec-permitted) but then indexed through the snapshot with no
+// per-visit liveness re-check.
+//
+// Fix: retain the live object ref, register a `__for_in_has(obj, key)` host
+// import (honors the WasmGC delete tombstone / `key in obj` for plain objects),
+// and emit a per-visit guard at the start of the $continue block that skips
+// (br to the increment) when the key has since been deleted.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn: string): Promise<string> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  // Wire the exports hook so the host runtime can read struct field names
+  // (the for-in key enumeration + liveness check depend on it).
+  (io as { __setExports?: (e: WebAssembly.Exports) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => string>)[fn]!();
+}
+
+describe("#2066 for-in skips properties deleted during enumeration", () => {
+  it("a property deleted before it is visited is not visited", async () => {
+    const src = `
+export function test(): string {
+  const obj: any = { a: 1, b: 2, c: 3 };
+  let s = "";
+  for (const k in obj) { s = s + k; if (k === "a") { delete obj.c; } }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("ab"); // c deleted before its turn
+  });
+
+  it("deleting the current key as it is visited still visits the others up to that point", async () => {
+    // delete obj[k] then read k: k is already the live binding, deletion only
+    // affects later keys (which are all deleted by the time they'd be visited).
+    const src = `
+export function test(): string {
+  const obj: any = { a: 1, b: 2, c: 3 };
+  let s = "";
+  for (const k in obj) { delete obj[k]; s = s + k; }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("abc");
+  });
+
+  it("plain enumeration (no deletion) visits every own key in order", async () => {
+    const src = `
+export function test(): string {
+  const obj: any = { x: 1, y: 2, z: 3 };
+  let s = "";
+  for (const k in obj) { s = s + k; }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("xyz");
+  });
+
+  it("deleting an already-visited key does not affect the remaining enumeration", async () => {
+    const src = `
+export function test(): string {
+  const obj: any = { a: 1, b: 2, c: 3 };
+  let s = "";
+  for (const k in obj) { s = s + k; if (k === "b") { delete obj.a; } }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("abc");
+  });
+
+  it("user continue and the deletion guard coexist", async () => {
+    const src = `
+export function test(): string {
+  const obj: any = { a: 1, b: 2, c: 3 };
+  let s = "";
+  for (const k in obj) { if (k === "a") { delete obj.c; continue; } s = s + k; }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("b"); // a continued, c deleted → only b
+  });
+
+  it("break still exits the loop", async () => {
+    const src = `
+export function test(): string {
+  const obj: any = { a: 1, b: 2, c: 3 };
+  let s = "";
+  for (const k in obj) { if (k === "b") break; s = s + k; }
+  return s;
+}`;
+    expect(await run(src, "test")).toBe("a");
+  });
+});


### PR DESCRIPTION
## Problem

EnumerateObjectProperties (§14.7.5.10) requires that a property deleted before it is visited is not visited. `compileForInStatement` snapshotted all keys up front (spec-permitted) but indexed through the snapshot with no per-visit liveness re-check:

```ts
const obj: any = { a: 1, b: 2, c: 3 };
let s = "";
for (const k in obj) { s = s + k; if (k === "a") { delete obj.c; } }
return s;   // wasm: "abc", node: "ab"
```

## Fix

- **runtime.ts**: add `__for_in_has(obj, key) -> i32` — honors the WasmGC delete tombstone (`_wasmStructDeletedKeys`) for structs and `key in obj` for plain objects, returning 0 once a key has been deleted.
- **index.ts**: register the `__for_in_has` host import (auto-allowlisted by the existing `__for_in_` prefix gate; standalone for-in already falls back to static unrolling, where runtime deletion can't occur).
- **loops.ts**: retain the live object ref in a local, then emit a per-visit guard at the START of the `$continue` block — `if (!__for_in_has(obj, key)) br 1`. Depth 1 exits `$continue` and falls through to the increment, exactly the path a user `continue` takes; `br 0` would only exit the guard's own `if` and re-visit the deleted key.

## Results (tests/issue-2066.test.ts, 6 tests pass)

delete-before-visit (the repro → "ab"), delete-current-key ("abc"), plain enumeration ("xyz"), delete-already-visited ("abc"), continue+delete coexist ("b"), break ("a") — all match Node. Existing for-in suites (issue-forin, #1243) still pass, 26/26.

Standalone-mode note: the host `__for_in_has` is only used on the host-backed for-in path; the standalone path statically unrolls known struct fields where mid-loop deletion isn't expressible, so no new unsatisfiable import is introduced.

Sets issue #2066 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)