### PR TITLE
plan(#2058,#2059,#2063): architect spec — AnyValue host-bridge tag recovery

### DIFF
--- a/plan/issues/2058-any-plus-runtime-string-numeric-add.md
+++ b/plan/issues/2058-any-plus-runtime-string-numeric-add.md
@@ -76,3 +76,188 @@ when the checker proves both operands numeric.
 Grepped `compileAnyBinaryDispatch`, `concat` + `any`, `addition` + `externref` —
 #79 (AnyValue infra, done, fast-mode only), #308 (static string/number
 addition, done), #1175 (concat type mismatch, different). Not covered.
+
+---
+
+## Implementation Plan (shared design for #2058 / #2059 / #2063)
+
+> This is the **anchor spec** for the AnyValue host-bridge tag-recovery cluster.
+> #2059 (relational) and #2063 (switch) reference this section for the shared
+> tag-dispatch mechanism and carry only their per-site deltas. Read this first.
+
+### Root cause (one sentence)
+
+In default (JS-host, non-`nativeStrings`) mode `any`/`unknown` parameters lower
+to a **plain `externref`** and `ctx.anyValueTypeIdx` stays `-1`
+(`create-context.ts:141`; set lazily only by `ensureAnyValueType`), so every
+operator site that needs runtime number-vs-string tag awareness instead takes a
+**type-blind fast path** that unconditionally treats the externref as a number:
+`+`/`+=` unbox both sides to f64 and `f64.add` (binary-ops.ts:1815-1828,
+assignment.ts:4587-4619), relationals do the same (#2059), and `switch` unifies
+the whole statement into one f64-or-string comparison domain (#2063). The
+honest tag lives in the host value (or, in standalone, in the WasmGC heap type)
+but is never probed.
+
+### Why honest recovery at the *boxing* site regressed −788 (do NOT touch it)
+
+`type-coercion.ts:1207-1219` boxes **every** `externref → AnyValue` as **tag 5**
+(`__any_box_string`, externval = the raw externref) on purpose. The comment
+there (and the mirror in `any-helpers.ts:694-705`) records the #1888 finding:
+routing that generic boxing through `__any_from_extern` (which probes
+`ref.test $BoxedNumber` / `$BoxedBoolean` and assigns honest tags 3/4) flipped
+**~794 standalone test262 passes red**. The dependency is the **test262
+standalone harness comparator**: `isSameValue(a: any, b: any)` /
+`assert.sameValue` compile their `any` params to `externref`, and their
+`a === b` / `a !== a` bodies reach the externref-equality path
+(binary-ops.ts:1833-2028). That path was already hardened (#1776 numeric/bool
+tag dispatch, #1914 string value-compare) to be **bit-compatible with the
+current tag-5 box-the-externref ABI**. Re-tagging at the boxing site shifts the
+representation those comparators were tuned against and desyncs the harness.
+
+**Design rule that falls out of this:** do **NOT** change the
+`externref → AnyValue` boxing in type-coercion.ts, and do **NOT** flip
+`anyValueTypeIdx` on for default mode. Honest tag recovery must happen
+**per-operator-site, on the externref operands directly**, exactly mirroring the
+#1776/#1914 equality blocks that already coexist with the comparator without
+regressing it. Each site is opt-in, so the baseline can only move per landed
+site and any regression is attributable and revertible.
+
+### The one shared mechanism: per-site externref tag dispatch
+
+All three issues get the same primitive — a helper that, given two `externref`
+operands already spilled to temps `$l` / `$r`, branches on runtime type and
+performs the spec-correct primitive operation. This is **the #1776 pattern
+generalized** from equality to `+`, relational, and `switch` case-compare.
+
+**Dual-mode probes (CLAUDE.md dual-mode principle — no new host import without a
+standalone fallback):**
+
+| Concern | JS-host fast path (import) | Standalone / WASI Wasm-native fallback |
+|---|---|---|
+| is operand a string? | `__typeof_string` (manifest 97) | same name — in `UNION_NATIVE_HELPER_NAMES` (late-imports.ts:32), `addUnionImports` emits an in-module func |
+| is operand a number? | `__typeof_number` (96) | union-native (late-imports.ts:30) |
+| is operand a boolean? | `__typeof_boolean` (98) | union-native (late-imports.ts:31) |
+| number value | `__unbox_number` (103) | union-native (late-imports.ts:26) |
+| boolean value | `__unbox_boolean` (104) | union-native (late-imports.ts:28) |
+| string→number (ToNumber) | `__unbox_number` (host ToNumber, manifest 103) | `__str_to_number` native scanner (§7.1.4.1), emitted via `emitNativeParseNumber(ctx, new Set(["__str_to_number"]))` — see binary-ops.ts:884-887 |
+| string content op (concat / compare / equals) | wasm:js-string `concat`/`equals` + a new host `__host_*` for ordering, OR native helpers when `nativeStrings` | `__str_concat` / `__str_compare` / `__str_equals` via `any.convert_extern` + `ref.test $AnyString` + `ref.cast` (the #1914 pattern at binary-ops.ts:1982-2009) |
+
+**Two new host imports** (each WITH a standalone story, so the dual-mode rule
+holds):
+
+1. **`__host_add(a: externref, b: externref) -> externref`** — §13.15.3
+   ApplyStringOrNumericBinaryOperator for `+`. Host body (runtime.ts, new
+   `case "host_add"` next to `host_loose_eq` at 10293): `(a, b) => a + b`. This
+   gets ToPrimitive + the string-if-either-is-string rule + object valueOf/
+   toString ordering **for free** from JS `+`. Manifest: add
+   `if (name === "__host_add") return { type: "host_add" };` near line 129.
+2. **`__host_compare(a: externref, b: externref) -> i32`** — §7.2.13 IsLessThan
+   core for relationals (used by #2059). Host body: return `-1` / `0` / `1` /
+   `2`(=undefined/NaN incomparable): e.g.
+   `(a,b) => { if (a < b) return -1; if (a > b) return 1; if (a === b ... ) ...; return 2 /*NaN*/ }`.
+   Returning a 4-way result lets the call-site map each relational operator
+   (`<`,`<=`,`>`,`>=`) without 4 separate imports, and the `2` sentinel makes
+   every comparison involving a NaN/undefined operand yield `false` per spec.
+   Manifest + runtime `case "host_compare"` likewise. (Detailed in #2059.)
+
+**Standalone substitution** for these two: there is no JS host, so the call-site
+must NOT emit `__host_add`/`__host_compare`. Instead, under
+`ctx.standalone || ctx.wasi`, build the operation inline from the union-native
+probes + `__str_*` helpers, exactly as binary-ops.ts:879-908 already does for
+mixed string⇄number `==` (the `noJsHost && ctx.nativeStrings` branch). Gate with
+`const noJsHost = ctx.standalone === true || ctx.wasi === true;` and require
+`ctx.nativeStrings && ctx.anyStrTypeIdx >= 0` for the string arms (auto-true for
+`--target standalone`/`wasi`). If neither host nor native-string support is
+available, fall through to the existing f64 path (status-quo, no regression).
+
+### #2058-specific changes — `+` and `+=`
+
+**File: `src/codegen/binary-ops.ts`**
+
+- **New gate, placed BEFORE the externref-numeric fallback at line 1815**
+  (so it intercepts `+` before the unconditional f64 unbox). Condition:
+  `op === ts.SyntaxKind.PlusToken && (leftType.kind === "externref" || rightType.kind === "externref")`.
+  (Use the lowered `leftType`/`rightType`, the Wasm types already computed
+  above — `any` lowers to externref, so this catches the issue's `any + any`,
+  `1 + any`, `any + "2"` cases. Do **not** rely on `leftIsAny && rightIsAny` —
+  one side is often a concrete `number`/`string` literal.)
+- Spill both operands to externref temps (`coerceType(..., {kind:"externref"})`
+  for any non-externref side), mirroring the spill at binary-ops.ts:1877-1887.
+- **JS-host path:** `ensureLateImport(ctx, "__host_add", [externref, externref],
+  [externref])`, `flushLateImportShifts(ctx, fctx)`, `call __host_add`. Result
+  is `externref` (a boxed any) — return `{ kind: "externref" }` so the caller
+  boxes it back into the `any` slot via the existing externref→AnyValue path.
+- **Standalone path** (`noJsHost`): inline §13.15.3 — if `__typeof_string(l) ||
+  __typeof_string(r)` then ToString both and `__str_concat`; else ToNumber both
+  (string via `__str_to_number`, number via `__unbox_number`) and `f64.add` then
+  box. Reuse `emitConcatOperand`-style ToString from string-ops.ts:68-72 for the
+  non-string side's `ToString`. If a clean standalone ToString for arbitrary
+  externref isn't reachable, scope the standalone string-concat arm to operands
+  `__typeof_string`-positive on at least one side and fall through to f64 add for
+  the all-numeric case (covers `lt`-style numeric `any+any`; pure object
+  ToPrimitive in standalone is out of scope and already unsupported).
+- **Fast path preserved:** when the checker proves both operands `number`
+  (`isNumberType(leftTsType) && isNumberType(rightTsType)`), skip this gate and
+  let the existing numeric path run — no host call, no perf change.
+
+**File: `src/codegen/expressions/assignment.ts`**
+
+- Function `compileCompoundAssignment` (the `PlusEqualsToken` arm, line
+  ~4587-4619). Today it forces the RHS to f64 and `f64.add`s. When the LHS
+  variable's static type is `any`/`unknown` (not provably numeric — extend the
+  existing `hasStringAssignment` heuristic at 4452/4595 to also fire for `any`),
+  route through the **same `__host_add` / standalone-inline helper**: load LHS as
+  externref, compile RHS to externref, call the shared add, store back. Keep the
+  f64 fast path when LHS is provably numeric.
+- Factor the add-dispatch into a small shared emitter (e.g.
+  `emitAnyAdd(ctx, fctx)` in binary-ops.ts exported for assignment.ts) so `+`
+  and `+=` share one implementation and one host import.
+
+### Edge cases (apply to all three sites)
+
+- **NaN**: ToNumber("x") → NaN; `f64.add`/`f64.eq`/comparisons propagate NaN
+  correctly. The `__host_compare` `2` sentinel makes NaN relationals `false`.
+- **-0**: `f64.add(-0, ...)`/`f64.eq` already match JS; do not special-case.
+- **null / undefined operands** (tags 0/1 in the AnyValue scheme; `null` /
+  `undefined` host values): `null + 1 === 1`, `undefined + 1 === NaN`,
+  `"x" + null === "xnull"`. JS-host `__host_add` gets these free. Standalone:
+  `__typeof_number(null)` is 0 and `__unbox_number(null/undefined)` →
+  `0`/`NaN` per the host ToNumber funnel (runtime.ts:10181-10206) / union-native
+  equivalent — verify the union-native `__unbox_number` returns NaN for
+  undefined and 0 for null (it must, to match the f64-unbox table at
+  type-coercion.ts:1270-1284).
+- **Subclassed primitives / wrapper objects** (`new String("a")`): these are
+  `typeof === "object"`, so `__typeof_string` is 0 and they take the ToPrimitive
+  path — JS-host `+`/`<` handle valueOf/toString ordering. Standalone wrapper
+  ToPrimitive is out of scope (already refused for open objects, late-imports.ts
+  §1472); fall through is acceptable.
+- **bigint**: not in scope for `+`/relational here — `any + bigint` keeps the
+  existing bigint routing (binary-ops.ts:998+) which runs before this gate for
+  statically-typed operands; for runtime bigint in an externref, `__host_add`
+  throws `TypeError` (string+bigint) or concatenates (correct), matching JS.
+
+### Staged landing order (regression-safe)
+
+1. **Land #2063 switch strict-eq first** (smallest blast radius, no new host
+   import — reuses `__any_strict_eq` + the host-boxed-boolean tag-4 fix). It is
+   the cleanest validation that per-site tag dispatch coexists with the harness.
+2. **Land #2058 `+`/`+=`** — adds `__host_add` (+ standalone inline). Run the
+   standalone test262 shard locally/CI and confirm the comparator buckets
+   (`isSameValue`, `sameValue`) do **not** move; the gate only fires for `+`, so
+   equality is untouched.
+3. **Land #2059 relational** — adds `__host_compare` (+ standalone inline),
+   depends on the spill/dispatch scaffolding from #2058. Re-check the same
+   buckets.
+
+Each step is independently revertible and touches a disjoint operator set, so a
+−N regression localizes to exactly one PR. **Do not** combine them into one PR
+and **do not** "simplify" by flipping `anyValueTypeIdx` on in default mode — that
+is precisely the −788 trap.
+
+### Test files to verify (#2058)
+
+- The three repros in this issue (`plus("2")`, `plusBoth("1","2")`,
+  `compound("2")`) → `"12"`; `plusBoth(1,2)` → `3`.
+- `tests/equivalence.test.ts` add `any`-concat cases.
+- Standalone: re-run the `test262` standalone shard; assert no movement in the
+  `isSameValue`/`assert.sameValue` pass buckets (the −788 guard).

--- a/plan/issues/2059-any-relational-no-string-comparison.md
+++ b/plan/issues/2059-any-relational-no-string-comparison.md
@@ -152,17 +152,38 @@ closes the gap in both lowerings. Gate it behind the same staged landing.
 - NaN operand → all relationals `false` (the `cmp == 2` sentinel / f64 NaN rule).
 - `null < 1` → `0 < 1 = true`; `undefined < 1` → `NaN < 1 = false` (ToNumber).
 
-### Coordination note (dev-4)
+### Coordination note (dev-4) — interim fix must be forward-compatible
 
 As of this spec, the local `issue-2059-any-relational-string` branch has **0
 commits ahead of main** and is **not pushed to origin** — no implementation
-exists to conflict with. This design slots the relational gate **next to** the
-#2058 `+` gate and **reuses** the same spill scaffolding and the new
-`__host_compare` host import, so dev-4 should implement #2059 **after** #2058
-lands (or coordinate to share the spill/dispatch helper). If dev-4 has already
-chosen a divergent approach (e.g. routing through `__any_lt` only), reconcile
-toward the externref-site gate here, since that is the path the repro exercises
-in default mode.
+exists to conflict with. Dev-4 was told to either **scope #2059 to
+provably-string operands** or **release the issue**.
+
+**Any scoped interim fix MUST be compatible with the general mechanism here**:
+
+- A provably-string-only interim (both operands statically `string`, route to
+  `__str_compare` / `wasm:js-string` ordering) is an **acceptable subset** of
+  this design — it is exactly the "both `__typeof_string`" arm, just resolved at
+  compile time instead of at runtime. Land it as the **statically-typed fast
+  path** that sits *in front of* the externref runtime gate, not as a competing
+  mechanism. Do **not** introduce a separate helper or a separate boxing scheme
+  that the full externref gate would later have to unwind.
+- Do **not** implement the interim by flipping `anyValueTypeIdx` on in default
+  mode or by re-tagging at the `externref→AnyValue` boxing site — that is the
+  −788 trap (see #2058's shared plan). The interim must stay **per-site on the
+  operands**, same as the full fix.
+- The general fix here **supersedes and absorbs** any such interim: when this
+  lands, the runtime externref gate handles the `any < any` repro and the
+  provably-string fast path remains a pure compile-time shortcut. No rework of
+  the interim is required if it followed the two rules above.
+
+This design slots the relational gate **next to** the #2058 `+` gate and
+**reuses** the same spill scaffolding and the new `__host_compare` host import,
+so dev-4 should implement the full #2059 **after** #2058 lands (or coordinate to
+share the spill/dispatch helper). If dev-4 has already chosen a divergent
+approach (e.g. routing through `__any_lt` only, or a bespoke boxing path),
+reconcile toward the externref-site gate here, since that is the path the repro
+exercises in default mode.
 
 ### Test files to verify (#2059)
 

--- a/plan/issues/2059-any-relational-no-string-comparison.md
+++ b/plan/issues/2059-any-relational-no-string-comparison.md
@@ -66,3 +66,108 @@ policy). Likely shares plumbing with #2058.
 Grepped `relational`, `string comparison`, `__any_lt` — #117 (harness string
 compare, done), #295 (comparison ops, bigint-focused, done), #1563/#1577
 (broad spec audits, item absent). Not covered.
+
+---
+
+## Implementation Plan (per-site delta — shared design in #2058)
+
+> **Read [#2058's `## Implementation Plan`](./2058-any-plus-runtime-string-numeric-add.md)
+> first** for the shared root cause, the −788 boxing-site trap, the dual-mode
+> probe table, and the per-site tag-dispatch mechanism. This section covers only
+> the relational deltas. **Land order: this is step 3 — after #2058.**
+
+### Root cause (relational-specific)
+
+Two converging gates blind relationals to strings:
+
+1. **Dispatch gate** (`binary-ops.ts:958-962`): `compileAnyBinaryDispatch` is
+   only entered for `isPlusOp || isEqualityOp` — relationals are deliberately
+   excluded, so `any < any` never reaches the AnyValue helpers even when
+   `anyValueTypeIdx >= 0`.
+2. **`__any_lt` is numeric-only** anyway (`any-helpers.ts:1305-1323`): all four
+   comparison helpers do `__any_to_f64(a) f64op __any_to_f64(b)`, so
+   `"a" < "b"` becomes `NaN < NaN = false`.
+3. In default mode `anyValueTypeIdx < 0`, both externref operands hit the
+   **externref-numeric fallback** (`binary-ops.ts:1815-1828`) → `f64.lt(NaN,NaN)`.
+
+### Changes
+
+**File: `src/codegen/binary-ops.ts`**
+
+- **New gate, placed alongside the #2058 `+` gate, BEFORE the
+  externref-numeric fallback at line 1815.** Condition:
+  `isRelational && (leftType.kind === "externref" || rightType.kind === "externref")`
+  where `isRelational` is already computed at line 968-972 (move/duplicate that
+  flag above the gate).
+- Spill both operands to externref temps (the #1776 spill at 1877-1887).
+- **JS-host path:** emit the new shared `__host_compare(externref, externref)
+  -> i32` (spec'd in #2058), then map its 4-way result to the operator:
+
+  | op | predicate on `cmp = __host_compare(l, r)` |
+  |----|--------------------------------------------|
+  | `<`  | `cmp == -1` (i32.const -1; i32.eq) |
+  | `>`  | `cmp == 1` |
+  | `<=` | `cmp == -1 OR cmp == 0` → `(cmp \| 0x?) ` — simplest: `cmp <= 0 AND cmp != 2` ; or test `cmp == -1 \|\| cmp == 0` |
+  | `>=` | `cmp == 1 \|\| cmp == 0` |
+
+  The `cmp == 2` (NaN/undefined incomparable) sentinel makes **all four**
+  operators yield `0` (false) for any NaN/undefined operand, matching §7.2.13
+  (IsLessThan returns `undefined` → the relational expression is `false`). Build
+  each predicate so that `cmp == 2` can never satisfy it (for `<=`/`>=`, test the
+  two concrete values explicitly rather than `cmp <= 0` / `cmp >= 0`, since `2`
+  would wrongly pass `>= 0`).
+- **Standalone path** (`noJsHost && ctx.nativeStrings && ctx.anyStrTypeIdx >=
+  0`): inline §7.2.13 dispatch on the externref temps, mirroring
+  binary-ops.ts:879-908 + the #1914 string arm:
+  - if **both** `__typeof_string` → `any.convert_extern` + `ref.cast
+    $AnyString` + `__str_flatten` both, `__str_compare` → returns -1/0/1
+    (native-strings.ts:1656-1657 — already the exact convention), map to op.
+  - else ToNumber both (string→`__str_to_number`, number→`__unbox_number`,
+    bool→`f64.convert_i32_s` after `__unbox_boolean`) and `f64.lt/le/gt/ge`.
+    NaN propagates → `false` automatically (f64 comparisons with NaN are false).
+  - §7.2.13 subtlety: string-vs-string is **lexicographic**, but
+    string-vs-number is **numeric** (ToNumber the string). So the "both strings"
+    test must be `AND`, not `OR` — a mixed `"10" < 9` goes numeric
+    (`10 < 9 = false`), matching the issue's acceptance criterion
+    `lt("10", 9)` numeric.
+- **Fast path preserved:** when the checker proves both operands numeric, skip
+  the gate (the existing numeric relational path at 1815 runs). No perf change
+  on provably-numeric compares (acceptance criterion).
+
+### Optional: also fix `__any_lt` for the `anyValueTypeIdx >= 0` (fast) mode
+
+If a module already has `anyValueTypeIdx >= 0` (fast mode with boxed any), the
+cleanest secondary fix is to (a) extend the dispatch gate at line 958 to include
+relationals, and (b) make `addComparisonHelper` (`any-helpers.ts:1305`)
+tag-aware: when both tags are 5 (string), compare via `wasm:js-string`/`__str_*`
+content ordering; else fall to the existing `__any_to_f64` numeric path. This is
+**lower priority** than the externref-site fix because default mode (externref,
+`anyValueTypeIdx < 0`) is where the issue's repro actually lives — but doing both
+closes the gap in both lowerings. Gate it behind the same staged landing.
+
+### Edge cases (relational-specific; see #2058 for the shared list)
+
+- `lt("a","b")` → `true`, `lt("10","9")` → `true` (lexicographic: "1" < "9").
+- `lt("10", 9)` → numeric `10 < 9` → `false` (mixed → ToNumber).
+- NaN operand → all relationals `false` (the `cmp == 2` sentinel / f64 NaN rule).
+- `null < 1` → `0 < 1 = true`; `undefined < 1` → `NaN < 1 = false` (ToNumber).
+
+### Coordination note (dev-4)
+
+As of this spec, the local `issue-2059-any-relational-string` branch has **0
+commits ahead of main** and is **not pushed to origin** — no implementation
+exists to conflict with. This design slots the relational gate **next to** the
+#2058 `+` gate and **reuses** the same spill scaffolding and the new
+`__host_compare` host import, so dev-4 should implement #2059 **after** #2058
+lands (or coordinate to share the spill/dispatch helper). If dev-4 has already
+chosen a divergent approach (e.g. routing through `__any_lt` only), reconcile
+toward the externref-site gate here, since that is the path the repro exercises
+in default mode.
+
+### Test files to verify (#2059)
+
+- This issue's repros: `lt("a","b")`, `lt("10","9")` → `true`; `lt("10",9)` →
+  `false`; provably-numeric `lt(1,2)` unchanged.
+- Standalone test262 shard: confirm no movement in comparator buckets (the −788
+  guard from #2058 — relational gate is disjoint from equality, so the
+  `isSameValue` path is untouched).

--- a/plan/issues/2063-switch-strict-equality-violation.md
+++ b/plan/issues/2063-switch-strict-equality-violation.md
@@ -79,3 +79,142 @@ primitive type.
 Grepped `switch` + strict/coerc/mixed/discriminant: #162 (literal-narrowing,
 done), #198 (done — introduced the coercion), #245 (string cases, done). The
 strict-equality violation itself is unfiled.
+
+---
+
+## Implementation Plan (per-site delta — shared design in #2058)
+
+> **Read [#2058's `## Implementation Plan`](./2058-any-plus-runtime-string-numeric-add.md)
+> first** for the shared root cause (default mode lowers `any` to externref),
+> the −788 boxing-site trap, and the per-site tag-dispatch rule. This section
+> covers the switch deltas. **Land order: this is step 1 — land FIRST** (smallest
+> blast radius, no new host import; it validates that per-site tag dispatch
+> coexists with the test262 comparator).
+
+### Root cause (switch-specific)
+
+`compileSwitchStatement` (`control-flow.ts:567-696`) collapses the entire switch
+into **one** `wasmType` comparison domain (control-flow.ts:570-607):
+
+- If the discriminant **or any case** is string-typed → everything compares with
+  `__str_equals` / `wasm:js-string equals`, and a numeric discriminant/case gets
+  shoved through string-equals → host **"Illegal argument"** crash (`t2`,
+  `switch(1){case "1":}`).
+- Otherwise an externref discriminant is **unboxed to f64** (`:604-607`) →
+  ToNumber semantics: `true`→1.0, `"1"`→1.0, then `f64.eq` wrongly matches
+  `case 1` (`t3`, `s`).
+
+§14.12.2 CaseClauseIsSelected requires **per-case StrictEquality** — different
+types ⇒ no match, no coercion, no crash.
+
+### Changes
+
+**File: `src/codegen/statements/control-flow.ts`** — `compileSwitchStatement`
+
+1. **Add a homogeneity check.** After computing `switchIsString`
+   (control-flow.ts:575-586), compute whether the discriminant and **all** case
+   expression types are the *same* primitive class:
+   ```
+   const allNumeric = isNumberType(exprType) && every case isNumberType
+   const allString  = isStringType(exprType) && every case isStringType
+   const allBoolean = isBooleanType(exprType) && every case isBooleanType
+   const homogeneous = allNumeric || allString || allBoolean
+   ```
+   When `homogeneous`, keep the **existing fast path** verbatim (no test262 or
+   perf regression on the common case — acceptance criterion).
+
+2. **Non-homogeneous → strict-equals dispatch.** When `!homogeneous` (mixed
+   types, or discriminant is `any`/`unknown`/`externref` with concrete-typed
+   cases), do NOT pick a single `wasmType`. Instead:
+   - Keep the discriminant **boxed**: lower it to `ref_null $AnyValue` (box via
+     the existing `coerceType(..., {kind:"ref_null", typeIdx: anyValueTypeIdx})`
+     path after `ensureAnyValueType(ctx)` / `ensureAnyHelpers(ctx)`), stored in
+     `tmpLocalIdx` as the AnyValue box.
+   - In **Phase 1** (control-flow.ts:626-680), for each case: box the case
+     expression the same way, then compare with **`__any_strict_eq`**
+     (`any-helpers.ts:1131`) instead of `eqOp`/`strEqFuncIdx`. `__any_strict_eq`
+     already implements §7.2.16 StrictEquality with the right cross-tag rule
+     (different tags → 0, no coercion; numeric class 2/3 unified; string content
+     via `wasm:js-string equals`; ref identity via `ref.eq`).
+   - This makes `t3`/`s` return no-match (`true`/`"1"` have tags 4/5, `case 1`
+     tag 2 → `__any_strict_eq` returns 0) and `t2` match `case "1"` without
+     crashing (string content compare, no f64-into-string-equals trap).
+
+   **Default-mode (externref, `anyValueTypeIdx < 0`) variant:** if forcing
+   `ensureAnyValueType` for every mixed switch is undesirable, the alternative is
+   the externref tag-dispatch from #2058/#1776: spill discriminant + each case to
+   externref temps and compare with the **strict** form of the #1776 equality
+   block (typeof-number→f64.eq, typeof-bool→i32.eq, typeof-string→`__str_equals`,
+   else ref identity — **no** cross-type coercion). Prefer reusing
+   `__any_strict_eq` via boxing for code-share with the equality operator; fall
+   to the externref-spill form only if boxing the discriminant proves to pull in
+   too much fast-mode machinery in default mode. Either way the comparison is
+   **strict and per-case**.
+
+### The host-boxed-boolean tag-recovery defect (the crux of this issue)
+
+A prototype that routed non-homogeneous switches through `__any_strict_eq` was
+**correct except for host-boxed JS booleans**. `__any_from_extern`
+(`any-helpers.ts:170-265`) only recovers **bool tag 4** for **WasmGC-native**
+`nativeBoxBoolean` refs (the `ref.test $nativeBoxBoolean` arm at
+any-helpers.ts:236-251). A boolean that arrives as a **host-boxed** value
+(JS `true`/`false` crossing the externref boundary) is **not** a
+`$nativeBoxBoolean` struct, so it falls through to the **fallbackStringAny**
+(tag 5, any-helpers.ts:192-199, 252). Then `__any_strict_eq` sees tag 5 (string)
+vs tag 2 (number) and... that part is actually fine (different tags → 0). The
+**real** sibling defect the issue names — `(x:any=true) === 1` evaluating
+**true** — comes from the **numeric path**, not the switch: when the boolean is
+unboxed to f64 (`__any_to_f64` / the externref-numeric fallback) `true`→1.0 and
+`f64.eq(1.0, 1.0)` matches. So the fix has two parts:
+
+1. **Recover the boolean tag honestly in `__any_from_extern`** so a host-boxed
+   boolean becomes **tag 4**, not tag 5. Add a probe arm **before** the
+   `fallbackStringAny`: under JS-host mode use `__typeof_boolean` +
+   `__unbox_boolean` on the externref (manifest 98/104; union-native in
+   standalone) — if `__typeof_boolean(externval)` is 1, build a tag-4 AnyValue
+   with `i32val = __unbox_boolean(externval)`. Mirror the existing
+   `__typeof_number`/`__unbox_number` recovery you'd add for numbers (note the
+   #1888 comment forbids doing this re-tag at the *generic boxing* site, but
+   `__any_from_extern` is a **standalone-only helper** — `ensureAnyFromExternHelper`
+   bails unless `ctx.standalone || ctx.wasi`, any-helpers.ts:171 — and is NOT on
+   the comparator's hot path, so honest recovery here is safe).
+2. **Once tag 4 is honest, `__any_strict_eq(tag4, tag2)` correctly returns 0**
+   (`true === 1` is false) because the numeric-class arm (any-helpers.ts:1156-
+   1188) only unifies tags **2 and 3**, not 4 — a boolean is its own type under
+   StrictEquality. This kills the `(x:any=true) === 1 → true` sibling defect at
+   the **strict-equality** call site (switch and `===`) without touching the
+   numeric-context f64 unbox (which is correct for `+`/relational ToNumber).
+
+**Why this is safe vs −788:** the change is confined to `__any_from_extern`
+(standalone/WASI only) and `__any_strict_eq` selection at the switch site. The
+test262 comparator (`isSameValue`) uses the **externref-equality** block
+(binary-ops.ts:1833-2028), not `__any_from_extern` and not switch — so the
+comparator ABI is untouched. This is why #2063 lands **first**: it proves the
+per-site approach with zero comparator exposure.
+
+### Edge cases (#2063)
+
+- `switch(true){case 1:}` → no match (tag 4 vs tag 2). `default` runs.
+- `switch("1"){case 1:}` → no match (tag 5 vs tag 2).
+- `switch("1"){case 1: case "1":}` → matches `case "1"`, no crash (string
+  content compare; numeric case `1` simply doesn't match, no string-equals on a
+  number).
+- `switch(1){case "1":}` → no match, **no crash** (the f64-into-string-equals
+  trap is gone — strict-eq sees tag 2 vs tag 5 → 0).
+- `switch` on **booleans/null/undefined**: `switch(null){case undefined:}` → no
+  match (tags 0 vs 1, `__any_strict_eq` different-tag → 0); homogeneous boolean
+  switch keeps the i32 fast path.
+- Homogeneous numeric / string switch: **unchanged** — fast path, no `AnyValue`
+  boxing, no perf hit.
+- NaN discriminant: `switch(NaN){case NaN:}` → no match (`f64.eq(NaN,NaN)=0`
+  inside the tag-3 arm) — matches JS (`NaN !== NaN`).
+
+### Test files to verify (#2063)
+
+- This issue's three repros (`t3`→0, `s`→0, `t2`→50) + `switch(1){case "1":}`
+  no-match-no-crash.
+- `switch(true){case 1:}` no match; `(x:any=true) === 1` → false (the sibling
+  defect).
+- Standalone test262 shard: confirm **no** comparator-bucket movement (switch and
+  `__any_from_extern` are off the `isSameValue` path; this is the cleanest of the
+  three to land regression-free).


### PR DESCRIPTION
Architect spec for the sprint-61 AnyValue host-bridge tag-recovery cluster — three issues that share one root cause and now share one coherent design. **Plan-only: no `src/` changes.**

## What

Appends an `## Implementation Plan` to each of the three issue files:
- **#2058** (`plan/issues/2058-any-plus-runtime-string-numeric-add.md`) — the **anchor spec** (shared design + `+`/`+=` deltas)
- **#2059** (`plan/issues/2059-any-relational-no-string-comparison.md`) — relational deltas, cross-refs #2058
- **#2063** (`plan/issues/2063-switch-strict-equality-violation.md`) — switch deltas + the host-boxed-boolean tag-recovery fix, cross-refs #2058

## Root cause (shared)

In default (JS-host, non-`nativeStrings`) mode, `any` lowers to a plain `externref` and `ctx.anyValueTypeIdx` stays `-1`, so every operator site that needs runtime number-vs-string awareness takes a type-blind fast path that treats the externref as a number. `+`/`+=` and relationals unbox both sides to f64; `switch` unifies the whole statement into one f64-or-string comparison domain (and crashes when a numeric value hits `wasm:js-string equals`).

## Chosen design: one mechanism

**Per-operator-site externref tag dispatch** — the #1776 (numeric/bool equality) and #1914 (string value-compare) pattern, generalized to `+`, relational, and `switch`. Dual-mode:
- **JS-host fast path:** existing `__typeof_*`/`__unbox_*` probes + two new host imports `__host_add` (§13.15.3, `(a,b)=>a+b`) and `__host_compare` (§7.2.13, 4-way -1/0/1/2-NaN result).
- **Standalone/WASI fallback (dual-mode rule):** union-native `__typeof_*`/`__unbox_*` + `__str_concat`/`__str_compare`/`__str_to_number` via `any.convert_extern` + `ref.test $AnyString`. No new host import lacks a standalone story.

## The -788 mitigation (load-bearing)

Honest tag recovery stays **per-site, on the externref operands** — never at the `externref->AnyValue` boxing site (type-coercion.ts:1207-1219) and never by flipping `anyValueTypeIdx` on in default mode. That boxing site deliberately tags every externref as tag-5; the test262 standalone harness comparator (`isSameValue`/`assert.sameValue`) depends on that ABI, and re-tagging there is exactly what flipped ~794 baseline passes red in #1888. Each operator gate is opt-in and disjoint from the equality path the comparator uses.

## Staged landing order (regression-safe)

1. **#2063 switch first** — no new host import, off the comparator path; cleanest proof that per-site dispatch coexists with the harness.
2. **#2058 `+`/`+=`** — adds `__host_add` (+ standalone inline).
3. **#2059 relational** — adds `__host_compare` (+ standalone inline); reuses #2058's spill/dispatch scaffolding.

Each step touches a disjoint operator set, so any -N regression localizes to one PR and is revertible.

## Coordination note

The local `issue-2059-any-relational-string` branch has **0 commits ahead of main** and is not on origin — no #2059 implementation exists yet to conflict with. The spec slots the relational gate next to the #2058 `+` gate; dev-4 should implement #2059 after #2058 lands or share the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)