### PR TITLE
fix(#2067): remove silent 1M-iteration cap from for-of iterator loops

### DIFF
--- a/plan/issues/2067-forof-iterator-million-cap-silent-truncation.md
+++ b/plan/issues/2067-forof-iterator-million-cap-silent-truncation.md
@@ -1,10 +1,11 @@
 ---
 id: 2067
 title: "for-of iterator path silently breaks after 1,000,000 iterations (hard guard, counter not reset across re-entries)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -63,3 +64,34 @@ i32.const 1000000 / i32.gt_s / br_if 1`. Guard lives at
 `src/codegen/statements/loops.ts:4103-4111`, introduced by #662 against
 collection-mutation hangs. Should throw loudly (RangeError-style) or be
 removed/raised — silent wrong results are worse than a hang.
+
+## Resolution (2026-06-11)
+
+Removed the silent 1,000,000-iteration `br_if` guard from BOTH for-of iterator
+lowerings in `src/codegen/statements/loops.ts`: the `__iterator_next` host path
+(formerly :4103-4111) and the custom `next()`-method path (formerly the
+`__forit_guard` block). The loop now runs to the iterator's own `done`, so long
+iterations are not truncated and the per-statement counter (never reset across
+re-entries) no longer accumulates toward a cap. The guards were emitted
+instruction sequences only (counter local + increment + compare + break); their
+removal leaves the loop's block structure and break/continue depths unchanged.
+
+**Out of scope (separate mechanism):** the eager-generator evaluation buffer
+(`__EAGER_GEN_LIMIT` in `src/runtime.ts:9142`) caps a *generator's* buffered
+yields at 1M and throws a loud `RangeError` (not a silent truncation), so it is
+already spec-defensible. Raising/streaming that buffer is a distinct change
+(memory tradeoff) and not part of this fix.
+
+### Test Results
+
+`tests/issue-2067.test.ts` (2 cases, all PASS):
+
+| case | result |
+|------|--------|
+| single 200k generator for-of (no truncation) | 200000 ✓ |
+| 20× re-entry of a 100k loop (no cap accumulation) | 2000000 ✓ |
+
+`tsc --noEmit` clean; `tests/iterators.test.ts` + `tests/symbol-iterator-protocol.test.ts`
+green (10/10). Pre-existing failure in `tests/for-of-generator.test.ts`
+(imports a missing `./helpers.js`) is unrelated — a module-resolution error, not
+a test assertion, and independent of this change.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -3712,15 +3712,10 @@ function compileForOfDirectIterator(
   fctx.breakStack.push(1);
   fctx.continueStack.push(0);
 
-  // Safety guard
-  const iterCountLocal = allocLocal(fctx, `__forit_guard_${fctx.locals.length}`, { kind: "i32" });
-  fctx.body.push({ op: "local.get", index: iterCountLocal });
-  fctx.body.push({ op: "i32.const", value: 1 });
-  fctx.body.push({ op: "i32.add" });
-  fctx.body.push({ op: "local.tee", index: iterCountLocal });
-  fctx.body.push({ op: "i32.const", value: 1_000_000 });
-  fctx.body.push({ op: "i32.gt_s" });
-  fctx.body.push({ op: "br_if", depth: 1 });
+  // #2067: no iteration cap — see the matching note in the __iterator_next path.
+  // The former 1,000,000-iteration `br_if` guard silently truncated long
+  // custom-iterator loops and accumulated across re-entries; the loop now runs
+  // to the iterator's own `done`.
 
   // Call next(): result = iter.next()
   fctx.body.push({ op: "local.get", index: iterLocal });
@@ -4100,15 +4095,12 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   fctx.breakStack.push(1); // break = depth 1 (exit block, inside try wrapper)
   fctx.continueStack.push(0); // continue = depth 0 (restart loop)
 
-  // Safety guard: max iteration counter to prevent infinite loops from collection mutation
-  const iterCountLocal = allocLocal(fctx, `__forof_guard_${fctx.locals.length}`, { kind: "i32" });
-  fctx.body.push({ op: "local.get", index: iterCountLocal });
-  fctx.body.push({ op: "i32.const", value: 1 });
-  fctx.body.push({ op: "i32.add" });
-  fctx.body.push({ op: "local.tee", index: iterCountLocal });
-  fctx.body.push({ op: "i32.const", value: 1_000_000 });
-  fctx.body.push({ op: "i32.gt_s" });
-  fctx.body.push({ op: "br_if", depth: 1 }); // break if >1M iterations
+  // #2067: no iteration cap. A prior 1,000,000-iteration `br_if` guard (#662,
+  // against collection-mutation hangs) silently truncated legitimately long
+  // iterations — and its counter local was never reset across re-entries of the
+  // same compiled loop, so repeated executions accumulated toward the cap.
+  // Silent wrong results violate "compile away, don't emulate"; the loop now
+  // runs to the iterator's own `done`, matching JS.
 
   // Call __iterator_next(iter) → (i32 done, externref value) [multi-value].
   // Results are pushed left-to-right, so value (externref) is on top of the

--- a/tests/issue-2067.test.ts
+++ b/tests/issue-2067.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2067 — the generic for-of iterator lowering carried a hard `br_if` guard that
+// silently `break`ed after 1,000,000 iterations, and its counter local was never
+// reset across re-entries of the same compiled loop, so repeated executions
+// accumulated toward the cap. The guard is removed: the loop runs to the
+// iterator's own `done`. (The eager-generator buffer's separate `RangeError`
+// cap is out of scope here.)
+
+async function compileAndRun(source: string) {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+const GEN = `function* gen(n: number): Generator<number> { for (let i = 0; i < n; i++) yield 1; }`;
+
+describe("#2067 for-of iterator has no silent 1M-iteration cap", () => {
+  it("a single long iteration is not truncated", async () => {
+    const e = await compileAndRun(
+      GEN + `export function f(): number { let s = 0; for (const x of gen(200000)) { s += x; } return s; }`,
+    );
+    expect(e.f()).toBe(200000);
+  });
+
+  it("re-entering the same loop statement does not accumulate toward a cap", async () => {
+    // 20 runs of 100k each. With the old per-statement counter (never reset),
+    // the accumulated total would trip the 1M cap partway through.
+    const e = await compileAndRun(
+      GEN +
+        `export function f(): number {
+           let total = 0;
+           for (let k = 0; k < 20; k++) { let s = 0; for (const x of gen(100000)) { s += x; } total += s; }
+           return total;
+         }`,
+    );
+    expect(e.f()).toBe(2000000);
+  });
+});

--- a/tests/issue-2067.test.ts
+++ b/tests/issue-2067.test.ts
@@ -10,10 +10,9 @@ import { compile } from "../src/index.js";
 
 async function compileAndRun(source: string) {
   const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
   return instance.exports as Record<string, Function>;
 }


### PR DESCRIPTION
## Problem

The generic for-of iterator lowering carried a hard `br_if` guard that silently `break`ed out of the loop after 1,000,000 iterations (introduced by #662 against collection-mutation hangs). It truncated legitimately long iterations with zero diagnostics — a correctness-silent guard that violates "compile away, don't emulate". Worse, its counter local was never reset across re-entries of the same compiled loop, so repeated executions accumulated toward the cap.

## Fix

In `src/codegen/statements/loops.ts`, removed the guard from both for-of iterator paths: the `__iterator_next` host path (formerly :4103-4111) and the custom `next()`-method path (the `__forit_guard` block). The loop now runs to the iterator's own `done`. The guards were emitted instruction sequences only (counter local + increment + compare + break), so removal leaves the loop's block structure and break/continue depths unchanged.

**Out of scope:** the eager-generator buffer cap (`__EAGER_GEN_LIMIT`, `src/runtime.ts`) is a separate mechanism that already throws a loud `RangeError` (not a silent truncation), so it's spec-defensible; raising it is a distinct memory tradeoff.

## Tests

`tests/issue-2067.test.ts` — 2 cases, all pass:
- single 200k generator for-of → 200000 (no truncation)
- 20× re-entry of a 100k loop → 2000000 (no cap accumulation across re-entries)

`tsc --noEmit` clean; `tests/iterators.test.ts` + `tests/symbol-iterator-protocol.test.ts` green (10/10). Closes #2067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)