### PR TITLE
fix(#2069): thread thisArg into explicit this-param on .call/.apply

### DIFF
--- a/plan/issues/2069-call-apply-discard-thisarg.md
+++ b/plan/issues/2069-call-apply-discard-thisarg.md
@@ -1,10 +1,11 @@
 ---
 id: 2069
 title: "fn.call(thisArg, …) / fn.apply(thisArg, […]) silently discard thisArg for functions that use this"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2004,6 +2004,28 @@ function compileNumberIsPredicate(
   return { kind: "i32" };
 }
 
+/**
+ * (#2069) Detect whether a named callee was declared with an explicit
+ * TypeScript `this` parameter (`function f(this: T, …)`). Such a function
+ * materializes a leading `externref` `this` slot in its Wasm signature, so a
+ * `.call`/`.apply` lowering must thread the user's thisArg into that slot
+ * rather than dropping it. Returns the function's first ParameterDeclaration
+ * when it is the `this` pseudo-parameter, else undefined.
+ */
+function getExplicitThisParam(ctx: CodegenContext, callee: ts.Expression): ts.ParameterDeclaration | undefined {
+  const sym = ctx.checker.getSymbolAtLocation(callee);
+  const decl = sym?.valueDeclaration ?? sym?.declarations?.[0];
+  if (
+    decl &&
+    (ts.isFunctionDeclaration(decl) || ts.isFunctionExpression(decl) || ts.isArrowFunction(decl)) &&
+    decl.parameters.length > 0
+  ) {
+    const p0 = decl.parameters[0]!;
+    if (ts.isIdentifier(p0.name) && p0.name.text === "this") return p0;
+  }
+  return undefined;
+}
+
 function compileCallExpression(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2684,6 +2706,44 @@ function compileCallExpression(
         ts.setTextRange(reshapedCall, expr);
         (reshapedCall as any).parent = expr.parent;
         return compileCallExpression(ctx, fctx, reshapedCall as ts.CallExpression);
+      }
+
+      // (#2069) `.call`/`.apply` on a callee declared with an explicit
+      // TypeScript `this` parameter (`function f(this: T, …)`). Such a function
+      // has a leading `externref` `this` slot in its Wasm signature, so the
+      // legacy "evaluate thisArg, drop it" lowering passed `undefined` for
+      // `this` AND shifted every user argument into the wrong slot. Rewrite to a
+      // direct call that supplies the thisArg as the first positional argument —
+      // it lands in param 0 (the `this` slot, boxed to externref by the regular
+      // arg coercion) and the remaining args fill the declared params in order.
+      // Only fires when the thisArg can be threaded soundly: a named callee with
+      // a static this-param, and (for `.apply`) a statically-flattenable args
+      // array. Anything else falls through to the legacy paths below.
+      if (getExplicitThisParam(ctx, innerExpr) !== undefined && expr.arguments.length > 0) {
+        const thisArg = expr.arguments[0]!;
+        let directArgs: ts.Expression[] | undefined;
+        if (isCall) {
+          directArgs = [thisArg, ...expr.arguments.slice(1)];
+        } else if (expr.arguments.length === 1) {
+          // .apply(thisArg) — no args array
+          directArgs = [thisArg];
+        } else {
+          const argsExpr = expr.arguments[1]!;
+          if (ts.isArrayLiteralExpression(argsExpr)) {
+            const flattened = flattenStaticArrayElements(argsExpr);
+            if (flattened !== undefined) directArgs = [thisArg, ...flattened];
+          }
+        }
+        if (directArgs !== undefined) {
+          const directCall = ts.factory.createCallExpression(
+            innerExpr as ts.LeftHandSideExpression,
+            undefined,
+            directArgs,
+          );
+          ts.setTextRange(directCall, expr);
+          (directCall as { parent?: ts.Node }).parent = expr.parent;
+          return compileCallExpression(ctx, fctx, directCall as ts.CallExpression);
+        }
       }
 
       // Case 0: (function(){}).call/apply(...) and (() => {}).call/apply(...).

--- a/tests/issue-2069.test.ts
+++ b/tests/issue-2069.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2069 — `fn.call(thisArg, …)` / `fn.apply(thisArg, [...])` silently discarded
+// thisArg for functions declared with an explicit TypeScript `this` parameter.
+//
+// Such a function materializes a leading `externref` `this` slot in its Wasm
+// signature. The legacy `.call`/`.apply` lowering evaluated the thisArg, dropped
+// it, and passed `undefined` for `this` — and, because it then fed the user args
+// starting at param 0, it also shifted every argument into the wrong slot.
+//
+// Fix: when the named callee has an explicit `this` param, rewrite the
+// `.call`/`.apply` to a direct call that supplies the thisArg as the first
+// positional argument (which lands in the `this` slot, boxed to externref),
+// with the remaining args filling the declared params in order.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn: string): Promise<number | string> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  (io as { __setExports?: (e: WebAssembly.Exports) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => number | string>)[fn]!();
+}
+
+describe("#2069 .call/.apply thread the thisArg into an explicit this-param", () => {
+  it("the repro: .call and .apply both bind this and pass args in order", async () => {
+    const src = `
+function getV(this: any, a: number, b: number): number { return this.v + a + b; }
+export function test(): string {
+  const o = { v: 100 };
+  return "" + getV.call(o, 1, 2) + "," + getV.apply(o, [3, 4]);
+}`;
+    expect(await run(src, "test")).toBe("103,107");
+  });
+
+  it(".call on a this-only function returns this.v", async () => {
+    const src = `
+function getThisV(this: any): number { return this.v; }
+export function test(): number { const o = { v: 77 }; return getThisV.call(o); }`;
+    expect(await run(src, "test")).toBe(77);
+  });
+
+  it(".apply with a literal args array binds this and spreads args", async () => {
+    const src = `
+function getV(this: any, a: number, b: number): number { return this.v + a + b; }
+export function test(): number { const o = { v: 10 }; return getV.apply(o, [1, 2]); }`;
+    expect(await run(src, "test")).toBe(13);
+  });
+
+  it(".apply with no args array still binds this", async () => {
+    const src = `
+function getThisV(this: any): number { return this.v; }
+export function test(): number { const o = { v: 88 }; return getThisV.apply(o); }`;
+    expect(await run(src, "test")).toBe(88);
+  });
+
+  it("functions WITHOUT an explicit this param are unchanged (thisArg ignored)", async () => {
+    const src = `
+function noThis(a: number, b: number): number { return a + b; }
+export function c(): number { return noThis.call(null, 3, 4); }
+export function a(): number { return noThis.apply(null, [5, 6]); }`;
+    expect(await run(src, "c")).toBe(7);
+    expect(await run(src, "a")).toBe(11);
+  });
+
+  it("a side-effecting thisArg is evaluated exactly once and bound", async () => {
+    const src = `
+let log = 0;
+function mark(): { v: number } { log = log + 1; return { v: 5 }; }
+function getV(this: any, a: number): number { return this.v + a; }
+export function test(): number { const r = getV.call(mark(), 2); return r * 10 + log; }`;
+    // getV.call(mark(), 2) = 5 + 2 = 7; mark ran once → 7*10 + 1 = 71
+    expect(await run(src, "test")).toBe(71);
+  });
+});


### PR DESCRIPTION
## Problem

A function declared with an explicit TypeScript `this` parameter (`function f(this: T, …)`) materializes a leading `externref` `this` slot in its Wasm signature. The `.call`/`.apply` lowering evaluated the thisArg, **dropped** it, passed `undefined` for `this`, and — because it then fed the user args starting at param 0 — also shifted every argument into the wrong slot:

```ts
function getV(this: any, a: number, b: number): number { return this.v + a + b; }
const o = { v: 100 };
getV.call(o, 1, 2);    // wasm: NaN (this=box(1), a=2, b=0), node: 103
getV.apply(o, [3, 4]); // wasm: NaN, node: 107
```

## Fix

When the named callee has an explicit `this` param (detected via the callee symbol's declaration, `parameters[0].name === "this"`), rewrite the `.call`/`.apply` to a **direct call that supplies the thisArg as the first positional argument**. It lands in param 0 (the `this` slot, boxed to externref by the regular arg coercion) and the remaining args fill the declared params in order. `.apply` statically flattens its literal args array (reusing `flattenStaticArrayElements`).

Functions **without** an explicit this-param are untouched — they fall through to the existing drop-thisArg paths, so there's no extra boxing and no behavior change (acceptance criterion).

## Results (tests/issue-2069.test.ts, 6 tests pass)

The repro (`.call` + `.apply` → "103,107"), this-only function (77), `.apply` with a literal array (13), `.apply` with no array (88), no-this functions unchanged (7 / 11), and a side-effecting thisArg evaluated exactly once (71). Existing call/apply suites with no `helpers.js` dependency still pass.

Sets issue #2069 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)