### PR TITLE
fix(#2121): enforce TDZ for self/forward-referencing parameter defaults

### DIFF
--- a/plan/issues/2121-parameter-default-tdz-not-enforced.md
+++ b/plan/issues/2121-parameter-default-tdz-not-enforced.md
@@ -2,10 +2,11 @@
 id: 2121
 renumbered_from: 1954
 title: "parameter-default TDZ not enforced: f(a = a) yields NaN and f(a = b, b = 2) reads later params instead of throwing ReferenceError"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-11
+completed: 2026-06-11
 priority: low
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -43,6 +43,7 @@ import {
   emitParamDefaultArgMissingCheck,
   paramDefaultNeedsArgc,
 } from "./statements/nested-declarations.js";
+import { emitThrowReferenceError } from "./expressions/helpers.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import { isStrictFunction } from "./helpers/is-strict-function.js";
 import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-builder.js";
@@ -59,6 +60,62 @@ import { containsLinearU8Allocation, emitLinearU8ArenaMark, emitLinearU8ArenaRes
 
 /** Maximum number of instructions for a function body to be considered inlinable */
 export const INLINE_MAX_INSTRS = 10;
+
+/**
+ * (#2121) Per §10.2.11 FunctionDeclarationInstantiation, parameter bindings are
+ * initialized left-to-right, so a default value that reads its own parameter or
+ * a *later* one observes that binding in the TDZ and must throw ReferenceError.
+ * Scan the default initializer of the parameter at `paramIndex` for an
+ * identifier naming a parameter at index ≥ `paramIndex`. Returns that name when
+ * found (the default would throw if it fired), else undefined. References to
+ * strictly-earlier params (e.g. `f(a, b = a)`) are valid and ignored.
+ */
+function findTdzViolatingParamRef(decl: ts.FunctionLikeDeclarationBase, paramIndex: number): string | undefined {
+  // Names of params bound at or after this one (the TDZ window). Skip binding
+  // patterns and the `this` pseudo-param — only plain identifier params can be
+  // referenced by name and observed in the TDZ here.
+  const poisoned = new Set<string>();
+  for (let j = paramIndex; j < decl.parameters.length; j++) {
+    const p = decl.parameters[j]!;
+    if (ts.isIdentifier(p.name) && p.name.text !== "this") poisoned.add(p.name.text);
+  }
+  if (poisoned.size === 0) return undefined;
+
+  const init = decl.parameters[paramIndex]!.initializer;
+  if (!init) return undefined;
+  let found: string | undefined;
+  const walk = (node: ts.Node): void => {
+    if (found) return;
+    // Do not descend into nested functions/arrows: a reference to the param
+    // there is a closure capture resolved after instantiation, not a TDZ read.
+    if (
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node)
+    ) {
+      return;
+    }
+    if (ts.isIdentifier(node) && poisoned.has(node.text)) {
+      // Exclude identifiers in non-reference positions (property names, etc.).
+      const parent = node.parent;
+      if (
+        parent &&
+        ((ts.isPropertyAccessExpression(parent) && parent.name === node) ||
+          (ts.isPropertyAssignment(parent) && parent.name === node) ||
+          (ts.isBindingElement(parent) && parent.propertyName === node))
+      ) {
+        return;
+      }
+      found = node.text;
+      return;
+    }
+    forEachChild(node, walk);
+  };
+  walk(init);
+  return found;
+}
 
 /**
  * (#1042) Re-point a function to a func type with the same params but a new
@@ -751,9 +808,18 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       (ts.isObjectBindingPattern(param.name) || ts.isArrayBindingPattern(param.name)) &&
       isNullOrUndefinedLiteral(param.initializer);
 
+    // (#2121) TDZ: if this default reads its own parameter or a later one, the
+    // default — when it fires — observes that binding in the TDZ and must throw
+    // ReferenceError per §10.2.11, rather than reading the (still
+    // zero-/undefined-initialized) local. Emit the throw in the then-block.
+    const tdzViolatingName = findTdzViolatingParamRef(decl, i);
+
     // Build the "then" block: compile default expression, local.set
     const savedBody = pushBody(fctx);
-    if (dstrNullDefault) {
+    if (tdzViolatingName !== undefined) {
+      emitThrowReferenceError(ctx, fctx, `Cannot access '${tdzViolatingName}' before initialization`);
+      fctx.body.push({ op: "unreachable" } as Instr);
+    } else if (dstrNullDefault) {
       for (const ins of buildDestructureNullThrow(ctx, fctx)) fctx.body.push(ins);
     } else {
       // For destructuring patterns with externref param, force array literals in the

--- a/tests/issue-2121.test.ts
+++ b/tests/issue-2121.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2121 — parameter-default TDZ was not enforced.
+//
+// Per §10.2.11 FunctionDeclarationInstantiation, parameter bindings are
+// initialized left-to-right, so a default value that reads its own parameter or
+// a *later* one observes that binding in the TDZ and must throw ReferenceError.
+// The lowering read the (zero-/undefined-initialized) local directly, so
+// `f(a = a)` returned NaN and `f(a = b, b = 2)` read the later binding.
+//
+// Fix: when a parameter default references itself or a later parameter, emit a
+// ReferenceError throw in the "default fires" branch instead of the read.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+// Run a body that wraps the call in try/catch and reports whether a
+// ReferenceError was thrown — the compiled error model carries a real
+// ReferenceError instance, observable via the in-language `instanceof`.
+async function run(src: string, fn: string): Promise<number | string> {
+  const r = await compile(src, { fileName: "test.ts", skipDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  (io as { __setExports?: (e: WebAssembly.Exports) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => number | string>)[fn]!();
+}
+
+describe("#2121 parameter-default TDZ throws on self/forward reference", () => {
+  it("self-referencing default throws ReferenceError", async () => {
+    const src = `
+function f(a: number = a): number { return a; }
+export function test(): string {
+  try { f(); return "no-throw"; } catch (e) { return e instanceof ReferenceError ? "RE" : "other"; }
+}`;
+    expect(await run(src, "test")).toBe("RE");
+  });
+
+  it("forward-referencing default throws ReferenceError", async () => {
+    const src = `
+function f(a: any = b, b: any = 2): string { return "" + a + b; }
+export function test(): string {
+  try { f(); return "no-throw"; } catch (e) { return e instanceof ReferenceError ? "RE" : "other"; }
+}`;
+    expect(await run(src, "test")).toBe("RE");
+  });
+
+  it("string-typed self-referencing default throws", async () => {
+    const src = `
+function f(a: string = a): string { return a; }
+export function test(): string {
+  try { f(); return "no-throw"; } catch (e) { return e instanceof ReferenceError ? "RE" : "other"; }
+}`;
+    expect(await run(src, "test")).toBe("RE");
+  });
+
+  it("default does not fire when the argument is provided (no throw)", async () => {
+    const src = `
+function f(a: number = a): number { return a; }
+export function test(): number { return f(9); }`;
+    expect(await run(src, "test")).toBe(9);
+  });
+
+  it("referencing a strictly-earlier parameter stays valid", async () => {
+    const src = `
+function g(a: number, b: number = a): number { return a + b; }
+export function test(): number { return g(3); }`;
+    expect(await run(src, "test")).toBe(6);
+  });
+
+  it("chained left-to-right defaults stay valid", async () => {
+    const src = `
+function f(a: number = 1, b: number = a + 1): number { return a + b; }
+export function test(): number { return f(); }`;
+    expect(await run(src, "test")).toBe(3); // a=1, b=2
+  });
+});


### PR DESCRIPTION
## Problem

Per §10.2.11 FunctionDeclarationInstantiation, parameter bindings are initialized left-to-right, so a default value that reads its own parameter or a *later* one observes that binding in the TDZ and must throw ReferenceError. The lowering read the (zero-/undefined-initialized) local directly:

| probe | before | node |
|-------|--------|------|
| `function f(a: number = a) { return a; } f()` | `NaN` | ReferenceError |
| `function f(a = b, b = 2) { return ""+a+b; } f()` | `"22"` | ReferenceError |

## Fix

`findTdzViolatingParamRef` scans a parameter's default initializer for an identifier naming a parameter at index ≥ the current one, skipping:
- nested functions/classes (a reference there is a closure capture resolved after instantiation, not a TDZ read), and
- non-reference positions (property names, binding-element property keys).

When a violation is found, the param-default loop emits a ReferenceError throw in the "default fires" then-block instead of the read. The compiled error model carries a real `ReferenceError`, observable via in-language `catch (e) { e instanceof ReferenceError }`.

References to strictly-earlier params (`f(a, b = a)`) and left-to-right chains (`f(a = 1, b = a + 1)`) stay valid; a provided argument skips the default entirely (acceptance criterion).

## Results (tests/issue-2121.test.ts, 6 tests pass)

self-ref throw, forward-ref throw, string-typed self-ref throw, arg-provided no-throw (9), valid earlier-ref (6), chained left-to-right defaults (3). Existing default-param + TDZ suites (default-params, #1128 destructuring TDZ, #723) still pass — 23/23.

Sets issue #2121 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)