### PR TITLE
fix(codegen): #2063 switch uses per-case StrictEquality, not one coercion domain

### DIFF
--- a/plan/issues/2063-switch-strict-equality-violation.md
+++ b/plan/issues/2063-switch-strict-equality-violation.md
@@ -1,10 +1,11 @@
 ---
 id: 2063
 title: "switch violates strict-equality matching across types: switch(true){case 1:} matches; \"1\" matches case 1; mixed cases crash"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -79,3 +80,194 @@ primitive type.
 Grepped `switch` + strict/coerc/mixed/discriminant: #162 (literal-narrowing,
 done), #198 (done — introduced the coercion), #245 (string cases, done). The
 strict-equality violation itself is unfiled.
+
+---
+
+## Implementation Plan (per-site delta — shared design in #2058)
+
+> **Read [#2058's `## Implementation Plan`](./2058-any-plus-runtime-string-numeric-add.md)
+> first** for the shared root cause (default mode lowers `any` to externref),
+> the −788 boxing-site trap, and the per-site tag-dispatch rule. This section
+> covers the switch deltas. **Land order: this is step 1 — land FIRST** (smallest
+> blast radius, no new host import; it validates that per-site tag dispatch
+> coexists with the test262 comparator).
+
+### Root cause (switch-specific)
+
+`compileSwitchStatement` (`control-flow.ts:567-696`) collapses the entire switch
+into **one** `wasmType` comparison domain (control-flow.ts:570-607):
+
+- If the discriminant **or any case** is string-typed → everything compares with
+  `__str_equals` / `wasm:js-string equals`, and a numeric discriminant/case gets
+  shoved through string-equals → host **"Illegal argument"** crash (`t2`,
+  `switch(1){case "1":}`).
+- Otherwise an externref discriminant is **unboxed to f64** (`:604-607`) →
+  ToNumber semantics: `true`→1.0, `"1"`→1.0, then `f64.eq` wrongly matches
+  `case 1` (`t3`, `s`).
+
+§14.12.2 CaseClauseIsSelected requires **per-case StrictEquality** — different
+types ⇒ no match, no coercion, no crash.
+
+### Changes
+
+**File: `src/codegen/statements/control-flow.ts`** — `compileSwitchStatement`
+
+1. **Add a homogeneity check.** After computing `switchIsString`
+   (control-flow.ts:575-586), compute whether the discriminant and **all** case
+   expression types are the *same* primitive class:
+   ```
+   const allNumeric = isNumberType(exprType) && every case isNumberType
+   const allString  = isStringType(exprType) && every case isStringType
+   const allBoolean = isBooleanType(exprType) && every case isBooleanType
+   const homogeneous = allNumeric || allString || allBoolean
+   ```
+   When `homogeneous`, keep the **existing fast path** verbatim (no test262 or
+   perf regression on the common case — acceptance criterion).
+
+2. **Non-homogeneous → strict-equals dispatch.** When `!homogeneous` (mixed
+   types, or discriminant is `any`/`unknown`/`externref` with concrete-typed
+   cases), do NOT pick a single `wasmType`. Instead:
+   - Keep the discriminant **boxed**: lower it to `ref_null $AnyValue` (box via
+     the existing `coerceType(..., {kind:"ref_null", typeIdx: anyValueTypeIdx})`
+     path after `ensureAnyValueType(ctx)` / `ensureAnyHelpers(ctx)`), stored in
+     `tmpLocalIdx` as the AnyValue box.
+   - In **Phase 1** (control-flow.ts:626-680), for each case: box the case
+     expression the same way, then compare with **`__any_strict_eq`**
+     (`any-helpers.ts:1131`) instead of `eqOp`/`strEqFuncIdx`. `__any_strict_eq`
+     already implements §7.2.16 StrictEquality with the right cross-tag rule
+     (different tags → 0, no coercion; numeric class 2/3 unified; string content
+     via `wasm:js-string equals`; ref identity via `ref.eq`).
+   - This makes `t3`/`s` return no-match (`true`/`"1"` have tags 4/5, `case 1`
+     tag 2 → `__any_strict_eq` returns 0) and `t2` match `case "1"` without
+     crashing (string content compare, no f64-into-string-equals trap).
+
+   **Default-mode (externref, `anyValueTypeIdx < 0`) variant:** if forcing
+   `ensureAnyValueType` for every mixed switch is undesirable, the alternative is
+   the externref tag-dispatch from #2058/#1776: spill discriminant + each case to
+   externref temps and compare with the **strict** form of the #1776 equality
+   block (typeof-number→f64.eq, typeof-bool→i32.eq, typeof-string→`__str_equals`,
+   else ref identity — **no** cross-type coercion). Prefer reusing
+   `__any_strict_eq` via boxing for code-share with the equality operator; fall
+   to the externref-spill form only if boxing the discriminant proves to pull in
+   too much fast-mode machinery in default mode. Either way the comparison is
+   **strict and per-case**.
+
+### The host-boxed-boolean tag-recovery defect (the crux of this issue)
+
+A prototype that routed non-homogeneous switches through `__any_strict_eq` was
+**correct except for host-boxed JS booleans**. `__any_from_extern`
+(`any-helpers.ts:170-265`) only recovers **bool tag 4** for **WasmGC-native**
+`nativeBoxBoolean` refs (the `ref.test $nativeBoxBoolean` arm at
+any-helpers.ts:236-251). A boolean that arrives as a **host-boxed** value
+(JS `true`/`false` crossing the externref boundary) is **not** a
+`$nativeBoxBoolean` struct, so it falls through to the **fallbackStringAny**
+(tag 5, any-helpers.ts:192-199, 252). Then `__any_strict_eq` sees tag 5 (string)
+vs tag 2 (number) and... that part is actually fine (different tags → 0). The
+**real** sibling defect the issue names — `(x:any=true) === 1` evaluating
+**true** — comes from the **numeric path**, not the switch: when the boolean is
+unboxed to f64 (`__any_to_f64` / the externref-numeric fallback) `true`→1.0 and
+`f64.eq(1.0, 1.0)` matches. So the fix has two parts:
+
+1. **Recover the boolean tag honestly in `__any_from_extern`** so a host-boxed
+   boolean becomes **tag 4**, not tag 5. Add a probe arm **before** the
+   `fallbackStringAny`: under JS-host mode use `__typeof_boolean` +
+   `__unbox_boolean` on the externref (manifest 98/104; union-native in
+   standalone) — if `__typeof_boolean(externval)` is 1, build a tag-4 AnyValue
+   with `i32val = __unbox_boolean(externval)`. Mirror the existing
+   `__typeof_number`/`__unbox_number` recovery you'd add for numbers (note the
+   #1888 comment forbids doing this re-tag at the *generic boxing* site, but
+   `__any_from_extern` is a **standalone-only helper** — `ensureAnyFromExternHelper`
+   bails unless `ctx.standalone || ctx.wasi`, any-helpers.ts:171 — and is NOT on
+   the comparator's hot path, so honest recovery here is safe).
+2. **Once tag 4 is honest, `__any_strict_eq(tag4, tag2)` correctly returns 0**
+   (`true === 1` is false) because the numeric-class arm (any-helpers.ts:1156-
+   1188) only unifies tags **2 and 3**, not 4 — a boolean is its own type under
+   StrictEquality. This kills the `(x:any=true) === 1 → true` sibling defect at
+   the **strict-equality** call site (switch and `===`) without touching the
+   numeric-context f64 unbox (which is correct for `+`/relational ToNumber).
+
+**Why this is safe vs −788:** the change is confined to `__any_from_extern`
+(standalone/WASI only) and `__any_strict_eq` selection at the switch site. The
+test262 comparator (`isSameValue`) uses the **externref-equality** block
+(binary-ops.ts:1833-2028), not `__any_from_extern` and not switch — so the
+comparator ABI is untouched. This is why #2063 lands **first**: it proves the
+per-site approach with zero comparator exposure.
+
+### Edge cases (#2063)
+
+- `switch(true){case 1:}` → no match (tag 4 vs tag 2). `default` runs.
+- `switch("1"){case 1:}` → no match (tag 5 vs tag 2).
+- `switch("1"){case 1: case "1":}` → matches `case "1"`, no crash (string
+  content compare; numeric case `1` simply doesn't match, no string-equals on a
+  number).
+- `switch(1){case "1":}` → no match, **no crash** (the f64-into-string-equals
+  trap is gone — strict-eq sees tag 2 vs tag 5 → 0).
+- `switch` on **booleans/null/undefined**: `switch(null){case undefined:}` → no
+  match (tags 0 vs 1, `__any_strict_eq` different-tag → 0); homogeneous boolean
+  switch keeps the i32 fast path.
+- Homogeneous numeric / string switch: **unchanged** — fast path, no `AnyValue`
+  boxing, no perf hit.
+- NaN discriminant: `switch(NaN){case NaN:}` → no match (`f64.eq(NaN,NaN)=0`
+  inside the tag-3 arm) — matches JS (`NaN !== NaN`).
+
+### Test files to verify (#2063)
+
+- This issue's three repros (`t3`→0, `s`→0, `t2`→50) + `switch(1){case "1":}`
+  no-match-no-crash.
+- `switch(true){case 1:}` no match; `(x:any=true) === 1` → false (the sibling
+  defect).
+- Standalone test262 shard: confirm **no** comparator-bucket movement (switch and
+  `__any_from_extern` are off the `isSameValue` path; this is the cleanest of the
+  three to land regression-free).
+
+---
+
+## Resolution (2026-06-12)
+
+Implemented entirely in `src/codegen/statements/control-flow.ts`
+(`compileSwitchStatement`) — **the comparator path (`binary-ops.ts`) and
+`__any_from_extern` were NOT touched**, so the −788 trap is structurally
+avoided (the test262 `isSameValue` comparator is off this path).
+
+Chose the spec's **per-site externref tag-dispatch** alternative over the
+`__any_strict_eq`-boxing route, which also sidesteps the host-boxed-boolean
+`__any_from_extern` tag-recovery defect the spec flagged (that helper is never
+invoked by switch now).
+
+### What landed
+
+1. `homogeneousSwitchClass(ctx, stmt)` — returns `"number"|"string"|"boolean"`
+   only when the discriminant **and every case** are provably that one primitive
+   class (flag-based `isNumberType`/`isStringType`/`isBooleanType`, which are all
+   false for `any`/`unknown`/unions/objects). Null ⇒ the switch needs per-case
+   strict equality.
+2. Homogeneous (`homogeneousClass !== null`): the legacy fast path runs
+   **verbatim** — no boxing, no behavior or perf change.
+3. Non-homogeneous (`strictPerCase`): the discriminant is kept boxed as
+   `externref` (the `else if … unbox-to-f64` is now gated on `!strictPerCase`),
+   `switchIsString` is forced false, and each case is compiled to `externref`
+   and compared via the new `emitSwitchStrictEq(ctx, fctx, discTmp, caseTmp)`.
+4. `emitSwitchStrictEq` mirrors the `===` operator's externref-equality lowering:
+   - JS-host mode → `__host_eq` (JS `===`, strict + cross-type-false), with the
+     #1383-gated both-numbers `__unbox_number` fallback to recover equal numbers
+     boxed in distinct externrefs.
+   - standalone/WASI (`noJsHost`) → the #1776 Wasm-native tag dispatch
+     (`__typeof_number`→f64.eq, `__typeof_boolean`→i32.eq, `__typeof_bigint`→
+     i64.eq, native-string value compare via `__str_equals`, else `ref.eq`
+     identity). No coercion across tags.
+
+### Outcome (all verified)
+
+- `t3` (`switch(true){case 1}`) → 0, `s` (`switch("1"){case 1}`) → 0,
+  `t2` (mixed `case 1`/`case "1"`) → 50, `switch(1){case "1"}` → 0 with **no
+  crash** — both JS-host and standalone modes.
+- `switch(true){case true}` → match; `switch(true){case false}` → no match.
+- Homogeneous numeric/string/boolean switches unchanged (fast path).
+- #198 (the switch-coercion suite that introduced the unification), #1776,
+  #1914, #1888 all stay green; `binary-ops.ts` untouched.
+
+### Tests
+
+`tests/issue-2063-switch-strict-equality.test.ts` — 13 cases (JS-host via
+`assertEquivalent`, plus a standalone block compiling `--target standalone` and
+asserting `WebAssembly.validate` + correct results).

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -3,18 +3,26 @@
  * Control flow statement lowering: return, if, switch, break, continue, labeled.
  */
 import { ts } from "../../ts-api.js";
-import { isStringType } from "../../checker/type-mapper.js";
+import { isBooleanType, isNumberType, isStringType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext, NullGuardFact, NullishExclusion } from "../context/types.js";
 import { emitThrowString } from "../expressions/helpers.js";
-import { addStringImports, ensureI32Condition, ensureNativeStringHelpers, resolveWasmType } from "../index.js";
+import {
+  addStringImports,
+  addUnionImports,
+  ensureI32Condition,
+  ensureNativeStringHelpers,
+  resolveWasmType,
+} from "../index.js";
 import {
   coerceType,
   compileExpression,
   compileStatement,
   ensureAnyHelpers,
+  ensureLateImport,
+  flushLateImportShifts,
   isAnyValue,
   valTypesMatch,
 } from "../shared.js";
@@ -564,10 +572,242 @@ export function compileIfStatement(ctx: CodegenContext, fctx: FunctionContext, s
   });
 }
 
+/**
+ * (#2063) Is the switch comparison domain a single, statically-known primitive
+ * class? Per §14.12.2 CaseClauseIsSelected the discriminant is matched against
+ * each case with **StrictEquality** (different types ⇒ no match, no coercion).
+ * The fast path (unify the whole switch into one f64/i32/string comparison) is
+ * only sound when the discriminant AND every case expression are provably the
+ * same primitive class — otherwise an `any`/mixed switch silently coerces
+ * (`switch(true){case 1}` matches; `switch("1"){case 1}` matches) or crashes
+ * (numeric value shoved through string-equals). Returns the homogeneous class,
+ * or null when the switch must use per-case strict equality.
+ */
+function homogeneousSwitchClass(ctx: CodegenContext, stmt: ts.SwitchStatement): "number" | "string" | "boolean" | null {
+  const discType = ctx.checker.getTypeAtLocation(stmt.expression);
+  let cls: "number" | "string" | "boolean" | null;
+  if (isNumberType(discType)) cls = "number";
+  else if (isStringType(discType)) cls = "string";
+  else if (isBooleanType(discType)) cls = "boolean";
+  else return null; // any / unknown / union / object discriminant → strict per-case
+  for (const clause of stmt.caseBlock.clauses) {
+    if (!ts.isCaseClause(clause)) continue; // default clause carries no value
+    const caseType = ctx.checker.getTypeAtLocation(clause.expression);
+    const caseCls = isNumberType(caseType)
+      ? "number"
+      : isStringType(caseType)
+        ? "string"
+        : isBooleanType(caseType)
+          ? "boolean"
+          : null;
+    if (caseCls !== cls) return null; // any cross-class case ⇒ strict per-case
+  }
+  return cls;
+}
+
+/**
+ * (#2063) Emit a §7.2.16 StrictEquality comparison of two externref operands
+ * already spilled to temps `lTmp` / `rTmp`, pushing an i32 (1 = equal).
+ *
+ * Mirrors the externref-equality lowering the `===` operator uses
+ * (binary-ops.ts): JS-host mode delegates to `__host_eq` (JS `===`, which is
+ * strict and cross-type-false by construction, with a both-numbers unbox
+ * fallback to recover equal numbers boxed in distinct externrefs); standalone /
+ * WASI mode uses the #1776 Wasm-native tag dispatch (number→f64.eq,
+ * boolean→i32.eq, bigint→i64.eq, native-string→value compare, else ref
+ * identity). No coercion across tags — different runtime types compare unequal,
+ * never crash.
+ */
+function emitSwitchStrictEq(ctx: CodegenContext, fctx: FunctionContext, lTmp: number, rTmp: number): void {
+  const noJsHost = ctx.standalone === true || ctx.wasi === true;
+  if (noJsHost) {
+    const EQ_HEAP = -19; // WasmGC `eq` abstract heap type
+    addUnionImports(ctx);
+    const typeofNum = ctx.funcMap.get("__typeof_number")!;
+    const typeofBool = ctx.funcMap.get("__typeof_boolean")!;
+    const typeofBigint = ctx.funcMap.get("__typeof_bigint")!;
+    const unboxNum = ctx.funcMap.get("__unbox_number")!;
+    const unboxBool = ctx.funcMap.get("__unbox_boolean")!;
+    const toBigint = ctx.funcMap.get("__to_bigint")!;
+
+    const lAny = allocLocal(fctx, `__sweq_l_${fctx.locals.length}`, { kind: "anyref" });
+    const rAny = allocLocal(fctx, `__sweq_r_${fctx.locals.length}`, { kind: "anyref" });
+    const identityArm: Instr[] = [
+      { op: "local.get", index: lAny },
+      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
+      { op: "local.get", index: rAny },
+      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
+      { op: "i32.and" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: lAny },
+          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+          { op: "local.get", index: rAny },
+          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+          { op: "ref.eq" } as Instr,
+        ],
+        else: [{ op: "i32.const", value: 0 }],
+      } as Instr,
+    ];
+    const refArm: Instr[] = [
+      { op: "local.get", index: lTmp },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: lAny },
+      { op: "local.get", index: rTmp },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: rAny },
+    ];
+    let stringArmEmitted = false;
+    if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+      ensureNativeStringHelpers(ctx);
+      const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+      const strEqIdx = ctx.nativeStrHelpers.get("__str_equals");
+      if (flattenIdx !== undefined && strEqIdx !== undefined) {
+        stringArmEmitted = true;
+        refArm.push(
+          { op: "local.get", index: lAny },
+          { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+          { op: "local.get", index: rAny },
+          { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+          { op: "i32.and" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: lAny },
+              { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+              { op: "call", funcIdx: flattenIdx },
+              { op: "local.get", index: rAny },
+              { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+              { op: "call", funcIdx: flattenIdx },
+              { op: "call", funcIdx: strEqIdx },
+            ],
+            else: identityArm,
+          } as Instr,
+        );
+      }
+    }
+    if (!stringArmEmitted) refArm.push(...identityArm);
+
+    fctx.body.push(
+      { op: "local.get", index: lTmp },
+      { op: "call", funcIdx: typeofNum } as Instr,
+      { op: "local.get", index: rTmp },
+      { op: "call", funcIdx: typeofNum } as Instr,
+      { op: "i32.and" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: lTmp },
+          { op: "call", funcIdx: unboxNum },
+          { op: "local.get", index: rTmp },
+          { op: "call", funcIdx: unboxNum },
+          { op: "f64.eq" } as Instr,
+        ],
+        else: [
+          { op: "local.get", index: lTmp },
+          { op: "call", funcIdx: typeofBool } as Instr,
+          { op: "local.get", index: rTmp },
+          { op: "call", funcIdx: typeofBool } as Instr,
+          { op: "i32.and" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: lTmp },
+              { op: "call", funcIdx: unboxBool },
+              { op: "local.get", index: rTmp },
+              { op: "call", funcIdx: unboxBool },
+              { op: "i32.eq" } as Instr,
+            ],
+            else: [
+              { op: "local.get", index: lTmp },
+              { op: "call", funcIdx: typeofBigint } as Instr,
+              { op: "local.get", index: rTmp },
+              { op: "call", funcIdx: typeofBigint } as Instr,
+              { op: "i32.and" } as Instr,
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "i32" } },
+                then: [
+                  { op: "local.get", index: lTmp },
+                  { op: "call", funcIdx: toBigint },
+                  { op: "local.get", index: rTmp },
+                  { op: "call", funcIdx: toBigint },
+                  { op: "i64.eq" } as Instr,
+                ],
+                else: refArm,
+              } as Instr,
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    );
+    return;
+  }
+
+  // JS-host mode: delegate to JS `===` via `__host_eq`, with a both-numbers
+  // unbox fallback to recover equal numbers boxed in distinct externrefs (the
+  // same #1383-gated fallback the `===` operator uses).
+  const hostEqIdx = ensureLateImport(
+    ctx,
+    "__host_eq",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const finalHostEqIdx = ctx.funcMap.get("__host_eq") ?? hostEqIdx;
+  const typeofNumIdx = ctx.funcMap.get("__typeof_number");
+  const unboxIdx = ctx.funcMap.get("__unbox_number");
+  fctx.body.push({ op: "local.get", index: lTmp }, { op: "local.get", index: rTmp }, {
+    op: "call",
+    funcIdx: finalHostEqIdx!,
+  } as Instr);
+  if (typeofNumIdx !== undefined && unboxIdx !== undefined) {
+    // Wrap: host_eq || (bothNumbers && unbox-eq).
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 1 }],
+      else: [
+        { op: "local.get", index: lTmp },
+        { op: "call", funcIdx: typeofNumIdx } as Instr,
+        { op: "local.get", index: rTmp },
+        { op: "call", funcIdx: typeofNumIdx } as Instr,
+        { op: "i32.and" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [
+            { op: "local.get", index: lTmp },
+            { op: "call", funcIdx: unboxIdx },
+            { op: "local.get", index: rTmp },
+            { op: "call", funcIdx: unboxIdx },
+            { op: "f64.eq" } as Instr,
+          ],
+          else: [{ op: "i32.const", value: 0 }],
+        } as Instr,
+      ],
+    } as Instr);
+  }
+}
+
 export function compileSwitchStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.SwitchStatement): void {
   // Evaluate the switch expression and save it to a temp local
   const exprType = ctx.checker.getTypeAtLocation(stmt.expression);
   let wasmType = resolveWasmType(ctx, exprType);
+
+  // (#2063) When the discriminant and every case are NOT provably the same
+  // primitive class, §14.12.2 requires per-case StrictEquality — the unified
+  // f64/string fast path below would coerce (`switch(true){case 1}` matches) or
+  // crash (numeric value through string-equals). Route those switches through a
+  // boxed, per-case strict-equality comparison instead. `homogeneousClass` is
+  // non-null exactly when the legacy fast path is sound.
+  const homogeneousClass = homogeneousSwitchClass(ctx, stmt);
+  const strictPerCase = homogeneousClass === null;
 
   // Detect if the switch discriminant or any case value involves strings (#245).
   // Check both the discriminant type and case expression types, since the
@@ -583,6 +823,13 @@ export function compileSwitchStatement(ctx: CodegenContext, fctx: FunctionContex
         }
       }
     }
+  }
+
+  // (#2063) Strict per-case path: keep the discriminant boxed as externref and
+  // compare each case with `emitSwitchStrictEq` (no coercion across types).
+  if (strictPerCase) {
+    wasmType = { kind: "externref" };
+    switchIsString = false; // suppress the string fast path; strict-eq handles strings
   }
 
   // For string switch: use the appropriate string type and comparison
@@ -601,8 +848,9 @@ export function compileSwitchStatement(ctx: CodegenContext, fctx: FunctionContex
       strEqFuncIdx = ctx.jsStringImports.get("equals");
       wasmType = { kind: "externref" };
     }
-  } else if (wasmType.kind === "externref") {
-    // Externref discriminant (non-string): unbox to f64 for numeric comparison
+  } else if (!strictPerCase && wasmType.kind === "externref") {
+    // Externref discriminant (non-string, homogeneous-numeric): unbox to f64 for
+    // numeric comparison. The strict per-case path (#2063) keeps it externref.
     wasmType = { kind: "f64" };
   }
 
@@ -639,20 +887,29 @@ export function compileSwitchStatement(ctx: CodegenContext, fctx: FunctionContex
     // fixups when new string-constant imports are added during case compilation.
     const savedCaseBody = pushBody(fctx);
 
-    fctx.body.push({ op: "local.get", index: tmpLocalIdx });
-    if (switchIsString && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
-      const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
-      fctx.body.push({ op: "call", funcIdx: flattenIdx });
-    }
-    compileExpression(ctx, fctx, caseClause.expression, wasmType);
-    if (switchIsString && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
-      const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
-      fctx.body.push({ op: "call", funcIdx: flattenIdx });
-    }
-    if (switchIsString && strEqFuncIdx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: strEqFuncIdx });
+    if (strictPerCase) {
+      // (#2063) Compile the case to externref and compare with the discriminant
+      // (already boxed in tmpLocalIdx) using §7.2.16 StrictEquality. Pushes i32.
+      const caseTmp = allocLocal(fctx, `__sw_case_${fctx.locals.length}`, { kind: "externref" });
+      compileExpression(ctx, fctx, caseClause.expression, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: caseTmp });
+      emitSwitchStrictEq(ctx, fctx, tmpLocalIdx, caseTmp);
     } else {
-      fctx.body.push({ op: eqOp });
+      fctx.body.push({ op: "local.get", index: tmpLocalIdx });
+      if (switchIsString && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+        const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+        fctx.body.push({ op: "call", funcIdx: flattenIdx });
+      }
+      compileExpression(ctx, fctx, caseClause.expression, wasmType);
+      if (switchIsString && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+        const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+        fctx.body.push({ op: "call", funcIdx: flattenIdx });
+      }
+      if (switchIsString && strEqFuncIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: strEqFuncIdx });
+      } else {
+        fctx.body.push({ op: eqOp });
+      }
     }
     // if (comparison result) { target = ci; }
     const setTarget: Instr[] = [

--- a/tests/issue-2063-switch-strict-equality.test.ts
+++ b/tests/issue-2063-switch-strict-equality.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2063 — switch must use per-case StrictEquality (§14.12.2 CaseClauseIsSelected),
+// not unify the whole statement into one f64/string comparison domain.
+//
+// Before the fix, a non-homogeneous switch coerced: `switch(true){case 1}`
+// matched (true→1.0→f64.eq), `switch("1"){case 1}` matched ("1"→1.0), and a
+// mixed numeric+string case set crashed (numeric value shoved through
+// wasm:js-string equals → host "Illegal argument"). The fix keeps the
+// discriminant boxed and compares each case with §7.2.16 StrictEquality
+// (JS-host `__host_eq`, or the standalone #1776 tag dispatch), so cross-type
+// cases never match and never crash. Homogeneous numeric/string/boolean
+// switches keep the fast path unchanged.
+//
+// `assertEquivalent` runs the source as JS and compares the wasm result (and
+// runs WebAssembly.validate on the binary).
+import { describe, expect, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+import { compile } from "../src/index.js";
+
+describe("#2063 switch StrictEquality (JS-host / default mode)", () => {
+  it("switch(true){case 1} -> default (true !== 1)", async () => {
+    await assertEquivalent(
+      `export function t3(): number { const x: any = true; switch (x) { case 1: return 100; default: return 0; } }`,
+      [{ fn: "t3", args: [] }],
+    );
+  });
+  it("switch('1'){case 1} -> default ('1' !== 1)", async () => {
+    await assertEquivalent(
+      `export function s(): number { const x: any = "1"; switch (x) { case 1: return 100; default: return 0; } }`,
+      [{ fn: "s", args: [] }],
+    );
+  });
+  it("switch('1'){case 1, case '1'} -> '1' (no crash on mixed cases)", async () => {
+    await assertEquivalent(
+      `export function t2(): number { const x: any = "1"; switch (x) { case 1: return 100; case "1": return 50; default: return 0; } }`,
+      [{ fn: "t2", args: [] }],
+    );
+  });
+  it("switch(1){case '1'} -> default (no crash, no match)", async () => {
+    await assertEquivalent(
+      `export function f(): number { const x: any = 1; switch (x) { case "1": return 50; default: return 0; } }`,
+      [{ fn: "f", args: [] }],
+    );
+  });
+  it("any-number discriminant matches a numeric case", async () => {
+    await assertEquivalent(
+      `export function f(): number { const x: any = 2; switch (x) { case 1: return 10; case 2: return 20; default: return 0; } }`,
+      [{ fn: "f", args: [] }],
+    );
+  });
+  it("any-string discriminant matches a string case", async () => {
+    await assertEquivalent(
+      `export function f(): number { const x: any = "b"; switch (x) { case "a": return 10; case "b": return 20; default: return 0; } }`,
+      [{ fn: "f", args: [] }],
+    );
+  });
+  it("mixed number|string discriminant picks the right typed case", async () => {
+    await assertEquivalent(
+      `export function f(x: number | string): number { switch (x) { case 1: return 10; case "1": return 50; case 2: return 20; default: return 0; } }`,
+      [
+        { fn: "f", args: [1] },
+        { fn: "f", args: [2] },
+      ],
+    );
+  });
+
+  // Homogeneous fast paths must stay unchanged (no coercion regression).
+  it("homogeneous numeric switch keeps the fast path", async () => {
+    await assertEquivalent(
+      `export function f(n: number): number { switch (n) { case 1: return 10; case 2: return 20; default: return 0; } }`,
+      [
+        { fn: "f", args: [1] },
+        { fn: "f", args: [2] },
+        { fn: "f", args: [3] },
+      ],
+    );
+  });
+  it("homogeneous string switch keeps the fast path", async () => {
+    await assertEquivalent(
+      `export function f(s: string): number { switch (s) { case "a": return 10; case "b": return 20; default: return 0; } }`,
+      [
+        { fn: "f", args: ["a"] },
+        { fn: "f", args: ["b"] },
+        { fn: "f", args: ["c"] },
+      ],
+    );
+  });
+});
+
+// Standalone (pure-WasmGC) mode: the strict-eq tag dispatch must also validate
+// and run with no JS host. Compiles with --target standalone and runs binary
+// with no imports.
+describe("#2063 switch StrictEquality (standalone / pure WasmGC)", () => {
+  async function runStandalone(src: string, fn: string, args: unknown[] = []) {
+    const result = await compile(src, { target: "standalone" });
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return (instance.exports[fn] as (...a: unknown[]) => unknown)(...args);
+  }
+
+  it("switch(true){case 1} -> 0", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { const x: any = true; switch (x) { case 1: return 100; default: return 0; } }`,
+        "f",
+      ),
+    ).toBe(0);
+  });
+  it("switch('1'){case 1, case '1'} -> 50", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { const x: any = "1"; switch (x) { case 1: return 100; case "1": return 50; default: return 0; } }`,
+        "f",
+      ),
+    ).toBe(50);
+  });
+  it("switch(true){case true} -> 7; switch(true){case false} -> 0", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { const x: any = true; switch (x) { case true: return 7; default: return 0; } }`,
+        "f",
+      ),
+    ).toBe(7);
+    expect(
+      await runStandalone(
+        `export function f(): number { const x: any = true; switch (x) { case false: return 7; default: return 0; } }`,
+        "f",
+      ),
+    ).toBe(0);
+  });
+  it("homogeneous numeric switch validates and runs standalone", async () => {
+    expect(
+      await runStandalone(
+        `export function f(n: number): number { switch (n) { case 1: return 10; case 2: return 20; default: return 0; } }`,
+        "f",
+        [2],
+      ),
+    ).toBe(20);
+  });
+});


### PR DESCRIPTION
## Problem (#2063)

`switch` matched the discriminant against each case with the wrong semantics. Per [§14.12.2 CaseClauseIsSelected](https://tc39.es/ecma262/#sec-runtime-semantics-caseclauseisselected) it must use **StrictEquality** (different types ⇒ no match, no coercion). `compileSwitchStatement` instead unified the whole switch into one comparison domain — an externref discriminant was unboxed to f64 (ToNumber):

| fn | before | node |
|----|--------|------|
| `switch(true){case 1}` | matches (`100`) | no match (`0`) |
| `switch("1"){case 1}` | matches (`100`) | no match (`0`) |
| `switch("1"){case 1, case "1"}` | `RuntimeError: Illegal argument` | `50` |
| `switch(1){case "1"}` | `RuntimeError: Illegal argument` | no match |

(The crash came from shoving a numeric value through `wasm:js-string equals`.)

## Fix

Confined to `src/codegen/statements/control-flow.ts` — **`binary-ops.ts` and `__any_from_extern` are untouched**, so the test262 `isSameValue` comparator is off this path and the −788 boxing-site regression trap is structurally avoided.

- `homogeneousSwitchClass()` keeps the existing fast path **verbatim** when the discriminant and every case are provably the same primitive class (all-number / all-string / all-boolean) — no perf or behavior change on the common case.
- Otherwise the discriminant stays boxed as `externref` and each case is compiled to `externref` and compared with `emitSwitchStrictEq`, which mirrors the `===` operator's externref-equality lowering:
  - **JS-host**: `__host_eq` (JS `===`) + the #1383-gated both-numbers `__unbox_number` fallback.
  - **standalone/WASI**: the #1776 Wasm-native tag dispatch (number→f64.eq, boolean→i32.eq, bigint→i64.eq, native-string value compare, else `ref.eq` identity).

No coercion across runtime types ⇒ cross-type cases never match and never crash.

## Tests

`tests/issue-2063-switch-strict-equality.test.ts` — 13 cases: all repros + homogeneous fast-path guards + mixed number|string discriminant, in JS-host mode (`assertEquivalent`) and a standalone block (`--target standalone`, asserting `WebAssembly.validate` + correct results). #198 (the switch suite that introduced the unification), #1776, #1914, #1888 all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)