### PR TITLE
fix(#2123): nativeStrings slice() must not swap start/end

### DIFF
--- a/plan/issues/2123-native-slice-swaps-bounds.md
+++ b/plan/issues/2123-native-slice-swaps-bounds.md
@@ -2,10 +2,11 @@
 id: 2123
 renumbered_from: 1956
 title: "nativeStrings slice() swaps start/end like substring — \"hello\".slice(3,1) returns \"el\" instead of \"\""
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -55,3 +56,20 @@ instead of delegating to the swapping substring helper.
 
 #1381 (done) lists "substring-vs-slice swap" and fixed the **host** path only.
 No open issue mentions the native-side swap.
+
+## Resolution (2026-06-12)
+
+In `__str_slice` (`src/codegen/native-strings.ts`), after resolving negatives
+and clamping start/end to ≥0, added a guard before delegating to
+`__str_substring`: `if (start >= end) return ""` (a fresh empty `$NativeString`),
+else delegate. This stops the swap that `__str_substring` performs (correct for
+substring, wrong for slice per §22.1.3.21). The substring helper itself is
+untouched, so `substring` semantics are preserved.
+
+### Test Results
+
+5 new cases in `tests/native-strings.test.ts`: `slice(3,1)` → `""`,
+`slice(2,2)` → `""`, `slice(1,3)` → 2 (no swap), `slice(-2,-1)` → 1,
+`slice(-100,2)` → 2. All pass (91 tests in the file green, including the
+existing substring/slice tests). No regressions in native-strings-roundtrip /
+native-strings-standalone / equivalence/string-methods (59 tests green).

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -2122,11 +2122,32 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
         ],
       },
 
-      // Delegate to __str_substring (which handles clamping to len and swapping)
-      { op: "local.get", index: 0 },
-      { op: "local.get", index: 1 },
-      { op: "local.get", index: 2 },
-      { op: "call", funcIdx: substringIdx },
+      // §22.1.3.21 String.prototype.slice: unlike substring, slice does NOT
+      // swap when start > end — it returns the empty string. __str_substring
+      // swaps, so guard here: if (start >= end) return "" instead of
+      // delegating. (#2123)
+      { op: "local.get", index: 1 }, // start
+      { op: "local.get", index: 2 }, // end
+      { op: "i32.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: strRef },
+        then: [
+          // empty string: len=0, off=0, empty backing array
+          { op: "i32.const", value: 0 },
+          { op: "i32.const", value: 0 },
+          { op: "i32.const", value: 0 },
+          { op: "array.new_default", typeIdx: strDataTypeIdx },
+          { op: "struct.new", typeIdx: strTypeIdx },
+        ],
+        else: [
+          // start < end: __str_substring clamps to len; no swap occurs.
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 2 },
+          { op: "call", funcIdx: substringIdx },
+        ],
+      } as Instr,
     ];
 
     ctx.mod.functions.push({

--- a/tests/native-strings.test.ts
+++ b/tests/native-strings.test.ts
@@ -202,6 +202,33 @@ describe("fast mode: native strings", () => {
     expect(await runFast(src)).toBe(3);
   });
 
+  // §22.1.3.21: slice does NOT swap when start > end (returns "") — unlike
+  // substring. (#2123)
+  it("slice(3, 1) returns empty string (no swap)", async () => {
+    const src = `export function test(): number { return "hello".slice(3, 1).length; }`;
+    expect(await runFast(src)).toBe(0);
+  });
+
+  it("slice(2, 2) with equal bounds returns empty", async () => {
+    const src = `export function test(): number { return "hello".slice(2, 2).length; }`;
+    expect(await runFast(src)).toBe(0);
+  });
+
+  it("slice(1, 3) keeps order (does not swap)", async () => {
+    const src = `export function test(): number { return "hello".slice(1, 3).length; }`;
+    expect(await runFast(src)).toBe(2);
+  });
+
+  it("slice(-2, -1) negative bounds", async () => {
+    const src = `export function test(): number { return "hello".slice(-2, -1).length; }`;
+    expect(await runFast(src)).toBe(1);
+  });
+
+  it("slice(-100, 2) clamps start to 0", async () => {
+    const src = `export function test(): number { return "hello".slice(-100, 2).length; }`;
+    expect(await runFast(src)).toBe(2);
+  });
+
   // ── String as function parameter and return ──────────────────────
 
   it("string parameter and return", async () => {


### PR DESCRIPTION
## Problem

In native-strings mode, `String.prototype.slice` swapped start/end like `substring`. Per §22.1.3.21, slice does NOT swap — when start > end it returns `""`.

```ts
"hello".slice(3, 1).length  // native wasm: 2 ("el") — node: 0 ("")
```

(`slice(1, undefined)` likewise corrupted to "h".)

## Root cause

`__str_slice` (`src/codegen/native-strings.ts`) resolved negative indices, clamped to ≥0, then delegated to `__str_substring` "which handles clamping to len **and swapping**". The swap is correct for substring, wrong for slice. #1381 fixed the host path; the native helper was missed.

## Fix

After clamping, guard before delegating: `if (start >= end) return ""` (a fresh empty `$NativeString`), else delegate. The substring helper is untouched, so its spec-correct swap behaviour is preserved.

## Tests

5 new cases in `tests/native-strings.test.ts`: `slice(3,1)`→"", `slice(2,2)`→"", `slice(1,3)`→2 (no swap), `slice(-2,-1)`→1, `slice(-100,2)`→2. All 91 in the file pass; no regressions in native-strings-roundtrip / native-strings-standalone / equivalence/string-methods.

Closes #2123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)