### PR TITLE
fix(#2122): String.fromCharCode/fromCodePoint must keep all arguments

### DIFF
--- a/plan/issues/2122-fromcharcode-drops-extra-arguments.md
+++ b/plan/issues/2122-fromcharcode-drops-extra-arguments.md
@@ -2,10 +2,11 @@
 id: 2122
 renumbered_from: 1955
 title: "String.fromCharCode/fromCodePoint silently drop all arguments after the first (host backend; native fromCodePoint too)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -64,3 +65,33 @@ add variadic host imports taking a vec.
 #1598 (`fromCharCode` standalone, in-review) covers the standalone/native
 helper only; host-mode dropping untracked. Greps for
 `fromCharCode`/`fromCodePoint` found no argument-dropping issue.
+
+## Resolution (2026-06-12)
+
+Fixed in `src/codegen/expressions/calls.ts`. The native `fromCharCode` branch
+already looped over the args and joined via `__str_concat`; the other three
+paths compiled only `arguments[0]`. Added the same per-argument loop to:
+1. **host `fromCharCode`** — call the 1-arg `String_fromCharCode` import per
+   argument and join with the js-string `concat` import;
+2. **native `fromCodePoint`** — call `__str_fromCodePoint` per argument and join
+   with `__str_concat`;
+3. **host `fromCodePoint`** — same shape as (1) with `String_fromCodePoint`.
+
+Arguments are still compiled left-to-right exactly once. The native marshal /
+return-type handling is unchanged.
+
+### Test Results
+
+`tests/issue-2122.test.ts` (5 cases, all PASS):
+
+| case | result |
+|------|--------|
+| host `fromCharCode(104,105,33)` | "hi!" ✓ |
+| host `fromCodePoint(97, 0x1F600)` | "a😀" ✓ |
+| host fromCharCode side-effect count (eval once, in order) | 3 ✓ |
+| native fromCharCode multi-arg length/charCodeAt | 3 / 33 ✓ |
+| native fromCodePoint multi-arg + surrogate pair | length 3, cc0 97, cc1 0xD83D ✓ |
+
+`tsc --noEmit` clean; `tests/issue-1598.test.ts` green (9/9). Pre-existing
+failure in `tests/string-methods.test.ts` (imports a missing `./helpers.js`) is
+unrelated — a module-resolution error independent of this change.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3683,6 +3683,24 @@ function compileCallExpression(
           fctx.body.push({ op: "f64.convert_i32_s" });
         }
         fctx.body.push({ op: "call", funcIdx });
+        // #2122: fromCharCode is variadic — each subsequent code unit produces a
+        // 1-char string that must be concatenated (ES §22.1.2.1). The host import
+        // is 1-arg, so call it per-argument and join via the js-string `concat`
+        // import. (Args are still evaluated left-to-right exactly once.)
+        if (expr.arguments.length > 1) {
+          addStringImports(ctx);
+          const concatIdx = ctx.jsStringImports.get("concat");
+          if (concatIdx !== undefined) {
+            for (let i = 1; i < expr.arguments.length; i++) {
+              const ai = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "f64" });
+              if (ai && ai.kind === "i32") {
+                fctx.body.push({ op: "f64.convert_i32_s" });
+              }
+              fctx.body.push({ op: "call", funcIdx });
+              fctx.body.push({ op: "call", funcIdx: concatIdx });
+            }
+          }
+        }
         // In fast mode, marshal externref string to native string
         if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
           ensureNativeStringExternBridge(ctx);
@@ -3707,12 +3725,24 @@ function compileCallExpression(
       // Native strings mode: use pure-Wasm __str_fromCodePoint (no host import)
       if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
         const helperIdx = ctx.nativeStrHelpers.get("__str_fromCodePoint");
+        const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
         if (helperIdx !== undefined) {
           const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
           if (argType && argType.kind !== "i32") {
             fctx.body.push({ op: "i32.trunc_sat_f64_s" });
           }
           fctx.body.push({ op: "call", funcIdx: helperIdx });
+          // #2122: variadic — concat each subsequent code point's string.
+          if (expr.arguments.length > 1 && concatIdx !== undefined) {
+            for (let i = 1; i < expr.arguments.length; i++) {
+              const ai = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "f64" });
+              if (ai && ai.kind !== "i32") {
+                fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+              }
+              fctx.body.push({ op: "call", funcIdx: helperIdx });
+              fctx.body.push({ op: "call", funcIdx: concatIdx });
+            }
+          }
           return nativeStringType(ctx);
         }
       }
@@ -3724,6 +3754,22 @@ function compileCallExpression(
           fctx.body.push({ op: "f64.convert_i32_s" });
         }
         fctx.body.push({ op: "call", funcIdx });
+        // #2122: variadic — concat each subsequent code point's string via the
+        // 1-arg host import joined with the js-string `concat` import.
+        if (expr.arguments.length > 1) {
+          addStringImports(ctx);
+          const concatIdx = ctx.jsStringImports.get("concat");
+          if (concatIdx !== undefined) {
+            for (let i = 1; i < expr.arguments.length; i++) {
+              const ai = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "f64" });
+              if (ai && ai.kind === "i32") {
+                fctx.body.push({ op: "f64.convert_i32_s" });
+              }
+              fctx.body.push({ op: "call", funcIdx });
+              fctx.body.push({ op: "call", funcIdx: concatIdx });
+            }
+          }
+        }
         return { kind: "externref" };
       }
     }

--- a/tests/issue-2122.test.ts
+++ b/tests/issue-2122.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+
+// #2122 — String.fromCharCode / fromCodePoint silently dropped every argument
+// after the first. Three of the four backend paths compiled only argument[0];
+// only native fromCharCode looped. All paths now join the per-argument results,
+// evaluating later args exactly once in order.
+
+// Host (JS-string) backend: the export returns a JS string directly.
+async function runHost(source: string): Promise<any> {
+  const r = await compile(source, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject!);
+  return (instance.exports.test as Function)();
+}
+
+// Native-strings (fast mode) backend: the export returns an opaque native-string
+// ref, so probe its length / charCodeAt to read the contents.
+async function runFast(source: string): Promise<any> {
+  const r = await compile(source, { fast: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await instantiateWasm(r.binary, imports.env, imports.string_constants);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports.test as Function)();
+}
+
+describe("#2122 fromCharCode/fromCodePoint keep all arguments", () => {
+  it("host fromCharCode(104,105,33) === 'hi!'", async () => {
+    expect(await runHost(`export function test(): string { return String.fromCharCode(104, 105, 33); }`)).toBe("hi!");
+  });
+
+  it("host fromCodePoint(97, 0x1F600) === 'a😀'", async () => {
+    expect(await runHost(`export function test(): string { return String.fromCodePoint(97, 0x1F600); }`)).toBe("a😀");
+  });
+
+  it("host fromCharCode evaluates each argument exactly once, in order", async () => {
+    expect(
+      await runHost(
+        `let n = 0; function c(x: number): number { n++; return x; }
+         export function test(): number { String.fromCharCode(c(72), c(105), c(33)); return n; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("native fromCharCode multi-arg length / content", async () => {
+    expect(await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).length; }`)).toBe(3);
+    expect(await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).charCodeAt(2); }`)).toBe(
+      33,
+    );
+  });
+
+  it("native fromCodePoint multi-arg concatenates with surrogate pairs", async () => {
+    // "a😀" — 'a' (1) + U+1F600 surrogate pair (2) = length 3
+    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).length; }`)).toBe(3);
+    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(0); }`)).toBe(
+      97,
+    );
+    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(1); }`)).toBe(
+      0xd83d,
+    );
+  });
+});

--- a/tests/issue-2122.test.ts
+++ b/tests/issue-2122.test.ts
@@ -44,20 +44,24 @@ describe("#2122 fromCharCode/fromCodePoint keep all arguments", () => {
   });
 
   it("native fromCharCode multi-arg length / content", async () => {
-    expect(await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).length; }`)).toBe(3);
-    expect(await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).charCodeAt(2); }`)).toBe(
-      33,
+    expect(await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).length; }`)).toBe(
+      3,
     );
+    expect(
+      await runFast(`export function test(): number { return String.fromCharCode(104, 105, 33).charCodeAt(2); }`),
+    ).toBe(33);
   });
 
   it("native fromCodePoint multi-arg concatenates with surrogate pairs", async () => {
     // "a😀" — 'a' (1) + U+1F600 surrogate pair (2) = length 3
-    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).length; }`)).toBe(3);
-    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(0); }`)).toBe(
-      97,
+    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).length; }`)).toBe(
+      3,
     );
-    expect(await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(1); }`)).toBe(
-      0xd83d,
-    );
+    expect(
+      await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(0); }`),
+    ).toBe(97);
+    expect(
+      await runFast(`export function test(): number { return String.fromCodePoint(97, 0x1F600).charCodeAt(1); }`),
+    ).toBe(0xd83d);
   });
 });


### PR DESCRIPTION
## Problem

`String.fromCharCode(104, 105, 33)` returned `"h"` and `String.fromCodePoint(97, 0x1F600)` returned `"a"` — every argument after the first was silently dropped (and not even evaluated for side effects). Three of the four backend paths compiled only `arguments[0]`; only the native `fromCharCode` branch looped.

## Fix

In `src/codegen/expressions/calls.ts`, added the same per-argument concat loop the native `fromCharCode` path already used to the three broken paths:
1. **host `fromCharCode`** — call the 1-arg `String_fromCharCode` import per argument, join with the js-string `concat` import;
2. **native `fromCodePoint`** — `__str_fromCodePoint` per argument + `__str_concat`;
3. **host `fromCodePoint`** — same shape as (1) with `String_fromCodePoint`.

Arguments compile left-to-right exactly once; surrogate-pair emission for non-BMP code points is preserved. Return-type / native-marshal handling is unchanged.

## Tests

`tests/issue-2122.test.ts` — 5 cases, all pass:
- host `fromCharCode(104,105,33)` → "hi!"; host `fromCodePoint(97,0x1F600)` → "a😀"
- host side-effect count → 3 (each arg evaluated once, in order)
- native `fromCharCode` multi-arg length/charCodeAt; native `fromCodePoint` multi-arg + surrogate pair (length 3, cc0 97, cc1 0xD83D)

`tsc --noEmit` clean; `tests/issue-1598.test.ts` green (9/9). Closes #2122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)