### PR TITLE
fix(#1968): empty-array join returns "" not "null"

### DIFF
--- a/plan/issues/1968-empty-array-join-returns-null.md
+++ b/plan/issues/1968-empty-array-join-returns-null.md
@@ -1,10 +1,11 @@
 ---
 id: 1968
 title: "[].join(...) returns \"null\" instead of \"\" (resultTmp initialized to ref.null extern)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -54,3 +55,25 @@ the externref-element path concats raw nulls.
 
 Greps `join empty`, `join null` → only #1286 (externref-receiver join routing,
 done) and #1215 (number_toString registration, done). Unfiled.
+
+## Resolution (2026-06-12)
+
+`compileArrayJoin` (`src/codegen/array-methods.ts`) initialised `resultTmp`
+(externref) with `ref.null.extern`; for `len == 0` the element loop never ran,
+so the function returned a null externref that every downstream string consumer
+stringifies as `"null"`. Now `resultTmp` starts as `""` via
+`compileStringLiteral(ctx, fctx, "")`; a non-empty array still overwrites it on
+iteration 0, so non-empty joins are byte-identical. The `""` constant is
+registered with `addStringConstantGlobal(ctx, "")` at the top of the function —
+before any body instruction — so the module-global index fixup can't desync an
+already-emitted `global.get`.
+
+Verified (`tests/equivalence/empty-array-join.test.ts`, 6 green): `[].join(",")`,
+filter-to-empty `.join`, `string[]` empty join, and non-empty number/string/
+single-element joins unregressed. Native-strings path (`compileArrayJoinNative`)
+and #2074 join suite unaffected (108 native-string tests green).
+
+Out of scope: the spec's null/undefined-*element* → `""` rule
+([§23.1.3.18](https://tc39.es/ecma262/#sec-array.prototype.join)) — TS array
+element types don't admit `null`/`undefined` for the WasmGC vec path, so it's a
+separate element-stringification concern, not this resultTmp init bug.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -14,6 +14,7 @@ import { allocLocal, getLocalType } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
+import { compileStringLiteral } from "./shared.js";
 import { getArrTypeIdxFromVec, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
@@ -4863,6 +4864,12 @@ function compileArrayJoin(
     return null;
   }
 
+  // #1968 — the empty-join result must be "" not a null externref (which every
+  // downstream string consumer stringifies as "null"). Pre-register the ""
+  // string constant *before* any body instructions so the eventual fixup of
+  // module-global indices can't desync already-emitted global.gets.
+  addStringConstantGlobal(ctx, "");
+
   const vecTmp = allocLocal(fctx, `__arr_join_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_join_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const lenTmp = allocLocal(fctx, `__arr_join_len_${fctx.locals.length}`, { kind: "i32" });
@@ -4898,8 +4905,9 @@ function compileArrayJoin(
   }
   fctx.body.push({ op: "local.set", index: sepTmp });
 
-  // result starts as null (empty)
-  fctx.body.push({ op: "ref.null.extern" });
+  // result starts as "" (the empty-array join result, #1968) — not null, which
+  // would stringify as "null". A non-empty array overwrites this on iteration 0.
+  compileStringLiteral(ctx, fctx, "");
   fctx.body.push({ op: "local.set", index: resultTmp });
 
   fctx.body.push({ op: "i32.const", value: 0 });

--- a/tests/equivalence/empty-array-join.test.ts
+++ b/tests/equivalence/empty-array-join.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// #1968 — [].join(...) must return "" not "null" (resultTmp was init'd to a null
+// externref, which downstream string consumers stringify as "null").
+describe("empty array join (#1968)", () => {
+  it("[].join(',') is empty, not 'null'", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a: number[] = [];
+         return "<" + a.join(",") + ">";
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("filter-to-empty then join", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a = [1, 2, 3];
+         return "<" + a.filter((x) => x > 10).join(",") + ">";
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("string[] empty join", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a: string[] = [];
+         return "<" + a.join("-") + ">";
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("non-empty number join unregressed", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         return [1, 2, 3].join(",");
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("single-element join unregressed", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         return [42].join(",");
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("non-empty string join unregressed", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         return ["a", "b", "c"].join("-");
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`compileArrayJoin` initialised `resultTmp` (externref) with `ref.null.extern`. For `len == 0` the element loop never assigns it, so the function returns a null externref that every downstream string consumer stringifies as `"null"`.

```ts
const a: number[] = [];
"<" + a.join(",") + ">"; // node: "<>", wasm (before): "<null>"
```

Also reachable dynamically via `[1,2,3].filter(x => x > 10).join(",")`.

## Fix

`resultTmp` now starts as `""` via `compileStringLiteral`. A non-empty array overwrites it on iteration 0, so non-empty joins are byte-identical. The `""` constant is registered (`addStringConstantGlobal`) at the top of the function — before any body instruction — so the module-global index fixup can't desync an already-emitted `global.get`.

## Tests

`tests/equivalence/empty-array-join.test.ts` (6, all match Node): empty number/string/filter-to-empty joins, and non-empty/single-element joins unregressed. Native-strings join path + #2074 suite unaffected (108 native-string tests green).

Out of scope: the null/undefined-*element* → `""` rule (§23.1.3.18) — TS array element types don't admit null/undefined for the WasmGC vec path, so it's a separate element-stringification concern, not this resultTmp init bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)