### PR TITLE
fix(#2124): default explicit-undefined string-index args per method (both backends)

### DIFF
--- a/plan/issues/2124-explicit-undefined-string-index-args.md
+++ b/plan/issues/2124-explicit-undefined-string-index-args.md
@@ -2,10 +2,11 @@
 id: 2124
 renumbered_from: 1957
 title: "explicit undefined as optional string-index arg coerced to NaN/0 instead of per-method default (substring/slice/lastIndexOf/endsWith/repeat, both backends)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7399,9 +7399,33 @@ function compileCallExpression(
         // start and end to 0 → host called `s.substring(0, 0)` → "" instead of
         // the whole string. The pad loop's `pi === 2` branch supplies s.length
         // for the missing end; the missing start (pi === 1) correctly pads to 0.
+        // (#2124) An explicit `undefined` end arg is spec-equivalent to absent:
+        // substring/slice default `end` to `s.length`. Without this, the f64
+        // slot coerces `undefined` → NaN and the host runs `substring(1, NaN)`
+        // → wrong length. Detect a statically-undefined end so the same
+        // length-default path that handles a missing end fires.
+        const isStaticUndefinedExpr = (a: ts.Expression | undefined): boolean => {
+          if (a === undefined) return false;
+          let cur: ts.Expression = a;
+          while (
+            ts.isParenthesizedExpression(cur) ||
+            ts.isAsExpression(cur) ||
+            ts.isNonNullExpression(cur) ||
+            ts.isTypeAssertionExpression(cur)
+          ) {
+            cur = (cur as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression | ts.TypeAssertion)
+              .expression;
+          }
+          return (
+            (ts.isIdentifier(cur) && cur.text === "undefined") ||
+            (ts.isVoidExpression(cur) && ts.isNumericLiteral(cur.expression))
+          );
+        };
+        const substringEndUndefined =
+          (method === "substring" || method === "slice") && args.length === 2 && isStaticUndefinedExpr(args[1]);
         const needsLengthDefault =
           (method === "substring" || method === "slice") &&
-          args.length <= 1 &&
+          (args.length <= 1 || substringEndUndefined) &&
           paramTypes !== undefined &&
           paramTypes.length === 3;
         let savedReceiverLocal: number | undefined;
@@ -7418,6 +7442,19 @@ function compileCallExpression(
         // Cap at declared param count (excluding self) to avoid pushing extra values
         const userParamCount = paramTypes ? paramTypes.length - 1 : args.length;
         for (let ai = 0; ai < args.length; ai++) {
+          if (substringEndUndefined && ai === 1 && savedReceiverLocal !== undefined) {
+            // Explicit `undefined` end → s.length (#2124). Skip compiling the
+            // undefined arg; emit the receiver's length for the f64 end slot.
+            const lenIdx = ctx.jsStringImports.get("length");
+            if (lenIdx !== undefined) {
+              fctx.body.push({ op: "local.get", index: savedReceiverLocal });
+              fctx.body.push({ op: "call", funcIdx: lenIdx });
+              fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+            } else {
+              fctx.body.push({ op: "f64.const", value: 0x7fffffff });
+            }
+            continue;
+          }
           if (ai < userParamCount) {
             const expectedArgType = paramTypes?.[ai + 1]; // +1 for self param
             const argResult = compileExpression(ctx, fctx, args[ai]!, expectedArgType);

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -38,6 +38,31 @@ import {
   tryStructToString,
 } from "./type-coercion.js";
 
+/**
+ * (#2124) An explicit `undefined` (or `void 0`) passed for an optional string
+ * index arg is spec-equivalent to omitting it — the method applies its own
+ * default (substring/slice/endsWith end → length, lastIndexOf from → length).
+ * But compiling it through the i32 arg path coerces NaN/undefined → 0, which is
+ * wrong. Detect the statically-undefined forms so callers can treat the arg as
+ * absent. Unwraps paren/as/!-assertion wrappers.
+ */
+function isStaticUndefinedArg(arg: ts.Expression | undefined): boolean {
+  if (arg === undefined) return false;
+  let cur: ts.Expression = arg;
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isNonNullExpression(cur) ||
+    ts.isTypeAssertionExpression(cur)
+  ) {
+    cur = (cur as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression | ts.TypeAssertion).expression;
+  }
+  return (
+    (ts.isIdentifier(cur) && cur.text === "undefined") ||
+    (ts.isVoidExpression(cur) && ts.isNumericLiteral(cur.expression))
+  );
+}
+
 // ── Guarded funcref cast (ref.test before ref.cast to avoid illegal cast traps) ──
 function emitGuardedFuncRefCast(fctx: FunctionContext, funcTypeIdx: number): void {
   const tmpFunc = allocLocal(fctx, `__gfc_${fctx.locals.length}`, {
@@ -1738,7 +1763,9 @@ export function compileNativeStringMethodCall(
     const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, {
       kind: "i32",
     });
-    if (value) {
+    // Explicit `undefined` is spec-equivalent to an absent arg → use the
+    // method's default sentinel rather than coercing undefined → 0 (#2124).
+    if (value && !isStaticUndefinedArg(value)) {
       compileStringIntegerArg(ctx, fctx, value);
     } else {
       fctx.body.push({ op: "i32.const", value: fallback });
@@ -1901,8 +1928,8 @@ export function compileNativeStringMethodCall(
     } else {
       fctx.body.push({ op: "i32.const", value: 0 });
     }
-    // end
-    if (expr.arguments.length > 1) {
+    // end — explicit `undefined` defaults to length (§22.1.3.24), same as absent (#2124)
+    if (expr.arguments.length > 1 && !isStaticUndefinedArg(expr.arguments[1])) {
       compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
     } else {
       // Default end = string length
@@ -1926,8 +1953,8 @@ export function compileNativeStringMethodCall(
     } else {
       fctx.body.push({ op: "i32.const", value: 0 });
     }
-    // end
-    if (expr.arguments.length > 1) {
+    // end — explicit `undefined` defaults to length (§22.1.3.22), same as absent (#2124)
+    if (expr.arguments.length > 1 && !isStaticUndefinedArg(expr.arguments[1])) {
       compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
     } else {
       fctx.body.push({ op: "i32.const", value: 0x7fffffff });
@@ -1954,7 +1981,13 @@ export function compileNativeStringMethodCall(
   if (method === "lastIndexOf") {
     const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_lastIndexOf_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_lastIndexOf_search");
-    const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0x7fffffff, "__str_lastIndexOf_from");
+    // §22.1.3.9 step 5: ToIntegerOrInfinity(position) with NaN → +∞, so an
+    // explicit `NaN` (or `undefined`) position searches from the end — the same
+    // 0x7fffffff sentinel as an absent arg. `compileIntegerValueToLocal` already
+    // maps explicit `undefined`; map explicit `NaN` here too (#2124).
+    const fromArg = expr.arguments[1];
+    const fromIsNaN = fromArg !== undefined && ts.isIdentifier(fromArg) && fromArg.text === "NaN";
+    const fromLocal = compileIntegerValueToLocal(fromIsNaN ? undefined : fromArg, 0x7fffffff, "__str_lastIndexOf_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_lastIndexOf")!;
     fctx.body.push({ op: "local.get", index: receiverLocal });
     fctx.body.push({ op: "local.get", index: searchLocal });
@@ -2027,11 +2060,18 @@ export function compileNativeStringMethodCall(
       const argType = compileExpression(ctx, fctx, expr.arguments[0]!, {
         kind: "f64",
       });
-      // RangeError: count must be non-negative, finite, and not too large
+      // RangeError: count must be non-negative, finite, and not too large.
+      // §22.1.3.18: n = ToIntegerOrInfinity(count) (truncates toward zero),
+      // THEN throw if n < 0 or n is +∞. The `< 0` test must run on the
+      // truncated value, else `repeat(-0.5)` — whose ToIntegerOrInfinity is
+      // `-0`, NOT negative — wrongly throws (#2124). `f64.trunc(-0.5) = -0.0`,
+      // and `-0.0 < 0` is false, so truncating first gives the spec result.
+      // The +∞ check stays on the raw f64 (trunc_sat would clamp it).
       if (argType && argType.kind === "f64") {
         const countLocal = allocLocal(fctx, `__repeat_count_${fctx.locals.length}`, { kind: "f64" });
         fctx.body.push({ op: "local.tee", index: countLocal });
-        // Check count < 0
+        // Check ToIntegerOrInfinity(count) < 0 — truncate toward zero first.
+        fctx.body.push({ op: "f64.trunc" } as Instr);
         fctx.body.push({ op: "f64.const", value: 0 });
         fctx.body.push({ op: "f64.lt" });
         // Check count is Infinity (count != count is NaN, but we also need +Inf)

--- a/tests/issue-2124.test.ts
+++ b/tests/issue-2124.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2124 — explicit `undefined` (and explicit `NaN` for lastIndexOf) passed for
+// an optional string-index arg was coerced to NaN/0 instead of the per-method
+// default, on both the JS-host string-import path and the native string path.
+//
+// Spec: an explicit `undefined` index arg is equivalent to an absent one
+// (substring/slice end → length; lastIndexOf from → +∞ i.e. search from the
+// end; endsWith end → length), and `repeat` truncates ToIntegerOrInfinity
+// BEFORE the range check (so `repeat(-0.5)` is `repeat(-0)` → "", not a throw).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn: string, native: boolean): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", nativeStrings: native, skipDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  (io as { __setExports?: (e: WebAssembly.Exports) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => number>)[fn]!();
+}
+
+// Each case asserts on BOTH backends (jsHost + nativeStrings).
+function bothBackends(name: string, src: string, fn: string, expected: number): void {
+  it(`${name} (jsHost)`, async () => {
+    expect(await run(src, fn, false)).toBe(expected);
+  });
+  it(`${name} (native)`, async () => {
+    expect(await run(src, fn, true)).toBe(expected);
+  });
+}
+
+describe("#2124 explicit undefined for optional string-index args defaults correctly", () => {
+  bothBackends(
+    "substring(1, undefined) → to end",
+    `export function t(): number { return "hello".substring(1, undefined).length; }`,
+    "t",
+    4,
+  );
+  bothBackends(
+    "slice(1, undefined) → to end",
+    `export function t(): number { return "hello".slice(1, undefined).length; }`,
+    "t",
+    4,
+  );
+  bothBackends(
+    'lastIndexOf("a", NaN) → search from end',
+    `export function t(): number { return "aba".lastIndexOf("a", NaN); }`,
+    "t",
+    2,
+  );
+  bothBackends(
+    'lastIndexOf("a", undefined) → search from end',
+    `export function t(): number { return "aba".lastIndexOf("a", undefined); }`,
+    "t",
+    2,
+  );
+  bothBackends(
+    'endsWith("lo", undefined) → end defaults to length',
+    `export function t(): number { return "hello".endsWith("lo", undefined) ? 1 : 0; }`,
+    "t",
+    1,
+  );
+  bothBackends(
+    "repeat(-0.5) → ToInteger is -0, no RangeError",
+    `export function t(): number { return "a".repeat(-0.5).length; }`,
+    "t",
+    0,
+  );
+
+  // Regression guards: absent-arg and normal-arg behavior must be unchanged.
+  bothBackends(
+    "substring(1) absent end still goes to length",
+    `export function t(): number { return "hello".substring(1).length; }`,
+    "t",
+    4,
+  );
+  bothBackends(
+    "substring(1, 3) explicit end still honored",
+    `export function t(): number { return "hello".substring(1, 3).length; }`,
+    "t",
+    2,
+  );
+  bothBackends(
+    "repeat(3) normal count still works",
+    `export function t(): number { return "ab".repeat(3).length; }`,
+    "t",
+    6,
+  );
+});


### PR DESCRIPTION
## Problem

An explicit `undefined` (and explicit `NaN` for lastIndexOf) passed for an optional string index arg was coerced to NaN/0 instead of the per-method default, on **both** the JS-host string-import path and the native string path:

| case | node | before (host / native) |
|------|------|------------------------|
| `"hello".substring(1, undefined).length` | 4 | 1 / 1 |
| `"hello".slice(1, undefined).length` | 4 | 0 / 1 |
| `"aba".lastIndexOf("a", NaN)` | 2 | 2 / 0 |
| `"aba".lastIndexOf("a", undefined)` | 2 | 2 / 0 |
| `"hello".endsWith("lo", undefined)` | true | true / false |
| `"a".repeat(-0.5)` | `""` | `""` / throws RangeError |

## Fix

**Native (`string-ops.ts`):**
- `isStaticUndefinedArg` detects explicit `undefined`/`void 0`; `compileIntegerValueToLocal` and substring/slice's end-arg treat it as absent → the method's default sentinel.
- `lastIndexOf` also maps explicit `NaN` to the search-from-end sentinel (§22.1.3.9 step 5: ToIntegerOrInfinity(NaN) → +∞).
- `repeat` truncates ToIntegerOrInfinity (`f64.trunc`) **before** the `< 0` range check, so `repeat(-0.5)` is `repeat(-0)` → `""` (was throwing on the raw -0.5); the +∞ check stays on the raw f64.

**Host (`calls.ts`):**
- substring/slice with an explicit-undefined end now take the same length-default path as a missing end — emit `s.length` for the f64 end slot instead of coercing `undefined` → NaN.

## Results (tests/issue-2124.test.ts, 18 tests pass)

All six issue rows on **both** backends, plus absent-arg / normal-arg regression guards. Existing string-method suites (#1248, #1381, #1445, substring-noarg) pass — 29 tests, no regression.

Out of scope: `endsWith` with an explicit *numeric* end position on the host path is a separate pre-existing bug (confirmed on clean main), not the explicit-undefined case this issue targets.

Sets issue #2124 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)