### PR TITLE
fix(#1967): widen sort gate to string/struct element arrays

### DIFF
--- a/plan/issues/1967-sort-map-nonnumeric-element-gates.md
+++ b/plan/issues/1967-sort-map-nonnumeric-element-gates.md
@@ -1,10 +1,10 @@
 ---
 id: 1967
 title: "sort is a silent no-op on string/object-element arrays (even with comparator); map/filter/reduce on struct-element arrays return empty garbage"
-status: ready
+status: in-progress
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -64,3 +64,33 @@ loop). At minimum, make the fallthrough loud (shared fix with #1966).
 #1361/#1816 (done) — #1816 carves out only the numeric-default-ToString-order
 follow-up. "Non-numeric element arrays never sort at all, comparator included"
 and "map on struct-element arrays returns length 0" are unfiled.
+
+## Partial resolution (2026-06-12) — `sort` landed
+
+The outer dispatch gate in `compileArrayMethodCall`
+(`src/codegen/array-methods.ts`, `case "sort"`) only passed `f64`/`i32`
+element kinds, so externref (string, JS-host mode) and ref (struct) element
+arrays fell into the generic no-op fallback. But `compileArraySort` *already*
+routes non-numeric elements correctly — comparator via
+`tryCompileComparatorSort` (#1816) and the default ToString order via
+`compileArrayDefaultToStringSort` (#1993). The gate was the only blocker.
+
+Widened the `sort` gate to also accept `externref`/`ref`/`ref_null`. No change
+to `compileArraySort`'s body. Covered (match Node —
+`tests/equivalence/sort-nonnumeric.test.ts`, 4 green):
+- `["b","a","c"].sort()` (string default)
+- `[{k:2},{k:1},{k:3}].sort((x,y)=>x.k-y.k)` (struct comparator)
+- string comparator sort by length
+- numeric comparator sort unregressed
+
+Regression-clean across #1361/#1816/#1966/#1993/#1589 + array-prototype-methods
+(72 tests green); tsc clean.
+
+### Remaining (issue stays open)
+
+- **map/filter/reduce/find\* on struct (`ref`) element arrays** still return
+  empty/garbage (`[{v:"a"}].map(o=>o.v)` → `null|0`). The HOF gates already
+  accept `externref` but not `ref`; widening them needs `compileArrayMap` (and
+  siblings) to box each `ref` element to externref before invoking the callback
+  (the convert-loop pattern in `destructureParamArray`). Larger, separate change
+  — split out from the safe sort gate fix.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -2627,8 +2627,18 @@ export function compileArrayMethodCall(
       result = compileArrayLastIndexOf(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "sort":
+      // #1967 — the gate previously excluded externref (string, JS-host mode)
+      // and ref (struct) element arrays, so `["b","a"].sort()` and
+      // `objs.sort((x,y)=>…)` silently no-op'd via the generic fallback. The
+      // internal compileArraySort ALREADY routes non-numeric elements through
+      // tryCompileComparatorSort (comparator) and compileArrayDefaultToStringSort
+      // (default ToString order, #1993) — only this gate kept it unreachable.
       result =
-        elemType.kind === "f64" || elemType.kind === "i32"
+        elemType.kind === "f64" ||
+        elemType.kind === "i32" ||
+        elemType.kind === "externref" ||
+        elemType.kind === "ref" ||
+        elemType.kind === "ref_null"
           ? compileArraySort(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
           : undefined;
       break;

--- a/tests/equivalence/sort-nonnumeric.test.ts
+++ b/tests/equivalence/sort-nonnumeric.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// #1967 — sort on string (externref) and struct (ref) element arrays silently
+// no-op'd because the outer gate excluded non-numeric elements, even though
+// compileArraySort internally handles them (comparator + default ToString sort).
+describe("sort on non-numeric element arrays (#1967)", () => {
+  it("string array default sort", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a = ["b", "a", "c"];
+         a.sort();
+         return a[0] + a[1] + a[2];
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("object array comparator sort", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a = [{ k: 2 }, { k: 1 }, { k: 3 }];
+         a.sort((x, y) => x.k - y.k);
+         return a[0].k + "," + a[1].k + "," + a[2].k;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("string array comparator sort (by length)", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a = ["ccc", "a", "bb"];
+         a.sort((x, y) => x.length - y.length);
+         return a[0] + "," + a[1] + "," + a[2];
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("numeric sort still works (unregressed)", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+         const a = [3, 1, 2];
+         a.sort((x, y) => x - y);
+         return a[0] + "," + a[1] + "," + a[2];
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The outer dispatch gate in `compileArrayMethodCall` (`case "sort"`) only passed `f64`/`i32` element kinds, so externref (string, JS-host mode) and ref (struct) element arrays fell into the generic no-op fallback. `["b","a","c"].sort()` and `objs.sort((x,y)=>…)` silently did nothing — comparator included.

```ts
["b","a","c"].sort();          // wasm (before): no-op "bac", node: "abc"
[{k:2},{k:1}].sort((x,y)=>x.k-y.k); // wasm (before): no-op, node: sorted
```

## Fix

`compileArraySort` **already** handles non-numeric elements: comparator via `tryCompileComparatorSort` (#1816) and default ToString order via `compileArrayDefaultToStringSort` (#1993). The gate was the only thing keeping that code unreachable. Widen it to accept `externref`/`ref`/`ref_null`; no change to the sort body.

## Tests

`tests/equivalence/sort-nonnumeric.test.ts` (4, match Node): string default sort, struct comparator sort, string comparator sort, numeric unregressed. Regression-clean across #1361/#1816/#1966/#1993/#1589 + array-prototype-methods (72 tests); tsc clean.

## Scope

Issue stays **in-progress**: `map`/`filter`/`reduce`/`find*` on struct (`ref`) element arrays still return empty (`[{v:"a"}].map(o=>o.v)` → `null|0`). Those HOF gates already accept externref but not ref; widening them needs `compileArrayMap` (+siblings) to box each ref element to externref before the callback — a larger separate change, split out from this safe sort gate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)