### PR TITLE
fix(#1961): nativeStrings string|undefined === compares by content, not ref

### DIFF
--- a/plan/issues/1961-native-string-undefined-union-ref-equality.md
+++ b/plan/issues/1961-native-string-undefined-union-ref-equality.md
@@ -1,10 +1,11 @@
 ---
 id: 1961
 title: "nativeStrings: === on a string|undefined value compares by reference, not content (\"hello\".at(1) === \"e\" → false)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -6,6 +6,7 @@
  */
 import { ts } from "../ts-api.js";
 import {
+  getNullablePrimitiveInfo,
   isBigIntType,
   isBooleanType,
   isNumberType,
@@ -981,6 +982,30 @@ export function compileBinaryExpression(
   const leftIsWrapperObj = isWrapperObjectType(leftTsType);
   const rightIsWrapperObj = isWrapperObjectType(rightTsType);
   const wrapperEquality = isEqualityOp && (leftIsWrapperObj || rightIsWrapperObj);
+
+  // (#1961) In nativeStrings mode a `string | undefined` / `string | null`
+  // operand (e.g. `"x".at(i)`, optional chains/params) lowers to a NULLABLE
+  // `$AnyString` ref. `isStringType` returns false for the union, so an equality
+  // like `"hello".at(1) === "e"` fell through to generic struct ref-equality
+  // (always false for equal content). Treat a nullable-string operand as a
+  // string operand for equality so it routes to `__str_equals` (content compare,
+  // null-tolerant). Only for equality ops — relational/`+` on nullable strings
+  // keep their existing handling.
+  const isStringOrNullableString = (t: ts.Type): boolean =>
+    isStringType(t) || getNullablePrimitiveInfo(t)?.primitiveKind === "string";
+  if (
+    ctx.nativeStrings &&
+    ctx.nativeStrTypeIdx >= 0 &&
+    isEqualityOp &&
+    !wrapperEquality &&
+    isStringOrNullableString(leftTsType) &&
+    isStringOrNullableString(rightTsType) &&
+    // At least one side is the union form (else the plain-string path below handles it)
+    (!isStringType(leftTsType) || !isStringType(rightTsType))
+  ) {
+    return compileStringBinaryOp(ctx, fctx, expr, op);
+  }
+
   if (
     !wrapperEquality &&
     isStringType(leftTsType) &&

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -1200,6 +1200,61 @@ function coerceCompiledValueToNumber(ctx: CodegenContext, fctx: FunctionContext,
   coerceType(ctx, fctx, valueType, { kind: "f64" }, "number");
 }
 
+/**
+ * (#1961) Null-tolerant native string content equality. A `string | undefined`
+ * operand lowers to a NULLABLE `$AnyString` ref where a null ref IS the
+ * `undefined` value. `__str_flatten`/`__str_equals` deref their operands and
+ * trap on null, so guard first: both-null → equal (1), exactly-one-null →
+ * unequal (0), else flatten both and compare content. Leaves an i32 (1/0) on
+ * the stack representing `left == right` (the caller negates for `!=`/`!==`).
+ */
+function emitNullableStringEquals(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  flattenIdx: number,
+  equalsIdx: number,
+): void {
+  const nullableStr = nativeStringTypeNullable(ctx);
+  const leftLocal = allocLocal(fctx, `__streq_l_${fctx.locals.length}`, nullableStr);
+  const rightLocal = allocLocal(fctx, `__streq_r_${fctx.locals.length}`, nullableStr);
+  compileExpression(ctx, fctx, expr.left, nullableStr);
+  fctx.body.push({ op: "local.set", index: leftLocal });
+  compileExpression(ctx, fctx, expr.right, nullableStr);
+  fctx.body.push({ op: "local.set", index: rightLocal });
+
+  // if (left is null) { result = right is null ? 1 : 0 }
+  // else if (right is null) { result = 0 }
+  // else { result = __str_equals(flatten(left), flatten(right)) }
+  const compareBody: Instr[] = [
+    { op: "local.get", index: leftLocal },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+    { op: "call", funcIdx: flattenIdx },
+    { op: "local.get", index: rightLocal },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+    { op: "call", funcIdx: flattenIdx },
+    { op: "call", funcIdx: equalsIdx },
+  ];
+  const rightNullCheck: Instr[] = [
+    { op: "local.get", index: rightLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 0 } as Instr],
+      else: compareBody,
+    } as Instr,
+  ];
+  fctx.body.push({ op: "local.get", index: leftLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "local.get", index: rightLocal } as Instr, { op: "ref.is_null" } as Instr],
+    else: rightNullCheck,
+  } as Instr);
+}
+
 export function compileStringBinaryOp(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1259,27 +1314,18 @@ export function compileStringBinaryOp(
       }
       case ts.SyntaxKind.EqualsEqualsEqualsToken:
       case ts.SyntaxKind.EqualsEqualsToken: {
-        // equals needs flat strings — flatten both operands
-        compileExpression(ctx, fctx, expr.left);
-        fctx.body.push({ op: "call", funcIdx: strFlattenIdx });
-        compileExpression(ctx, fctx, expr.right);
-        fctx.body.push({ op: "call", funcIdx: strFlattenIdx });
         const funcIdx = ctx.nativeStrHelpers.get("__str_equals");
         if (funcIdx !== undefined) {
-          fctx.body.push({ op: "call", funcIdx });
+          emitNullableStringEquals(ctx, fctx, expr, strFlattenIdx, funcIdx);
           return { kind: "i32" };
         }
         break;
       }
       case ts.SyntaxKind.ExclamationEqualsEqualsToken:
       case ts.SyntaxKind.ExclamationEqualsToken: {
-        compileExpression(ctx, fctx, expr.left);
-        fctx.body.push({ op: "call", funcIdx: strFlattenIdx });
-        compileExpression(ctx, fctx, expr.right);
-        fctx.body.push({ op: "call", funcIdx: strFlattenIdx });
         const funcIdx = ctx.nativeStrHelpers.get("__str_equals");
         if (funcIdx !== undefined) {
-          fctx.body.push({ op: "call", funcIdx });
+          emitNullableStringEquals(ctx, fctx, expr, strFlattenIdx, funcIdx);
           fctx.body.push({ op: "i32.eqz" });
           return { kind: "i32" };
         }

--- a/tests/issue-1961.test.ts
+++ b/tests/issue-1961.test.ts
@@ -26,7 +26,7 @@ async function run(src: string, fn: string): Promise<number> {
 }
 
 describe("#1961 nativeStrings: string|undefined === compares by content", () => {
-  it("the repro: \"hello\".at(1) === \"e\" is true", async () => {
+  it('the repro: "hello".at(1) === "e" is true', async () => {
     expect(await run(`export function t(): number { return "hello".at(1) === "e" ? 1 : 0; }`, "t")).toBe(1);
   });
 

--- a/tests/issue-1961.test.ts
+++ b/tests/issue-1961.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1961 — in nativeStrings mode, `===` on a `string | undefined` value compared
+// by reference (struct identity) instead of by content.
+//
+// Any API producing `string | undefined` (`.at()`, optional chains, optional
+// params) lowers to a NULLABLE `$AnyString` ref. `isStringType` returns false
+// for the union, so the comparison fell through to generic struct ref-equality
+// — always false for equal content.
+//
+// Fix: route an equality with a nullable-string operand to the native string
+// content comparison (`emitNullableStringEquals`), which null-guards first
+// (both-null → equal, one-null → unequal) then compares via `__str_equals`.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(src: string, fn: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", nativeStrings: true, skipDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  (io as { __setExports?: (e: WebAssembly.Exports) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => number>)[fn]!();
+}
+
+describe("#1961 nativeStrings: string|undefined === compares by content", () => {
+  it("the repro: \"hello\".at(1) === \"e\" is true", async () => {
+    expect(await run(`export function t(): number { return "hello".at(1) === "e" ? 1 : 0; }`, "t")).toBe(1);
+  });
+
+  it("!== negates correctly", async () => {
+    expect(await run(`export function t(): number { return "hello".at(1) !== "e" ? 1 : 0; }`, "t")).toBe(0);
+  });
+
+  it("loose == and != also compare by content", async () => {
+    expect(await run(`export function t(): number { return "hello".at(1) == "e" ? 1 : 0; }`, "t")).toBe(1);
+    expect(await run(`export function t(): number { return "hello".at(1) != "e" ? 1 : 0; }`, "t")).toBe(0);
+  });
+
+  it("unequal content is false", async () => {
+    expect(await run(`export function t(): number { return "hello".at(1) === "z" ? 1 : 0; }`, "t")).toBe(0);
+  });
+
+  it("x === undefined for an out-of-range .at() is true (both operand orders)", async () => {
+    expect(await run(`export function t(): number { return "hello".at(99) === undefined ? 1 : 0; }`, "t")).toBe(1);
+    expect(await run(`export function t(): number { return undefined === "hello".at(99) ? 1 : 0; }`, "t")).toBe(1);
+  });
+
+  it("an undefined (null) value compared to a string does not trap and is false", async () => {
+    expect(await run(`export function t(): number { return "hello".at(99) === "e" ? 1 : 0; }`, "t")).toBe(0);
+  });
+
+  it("two union-typed values with equal content compare equal", async () => {
+    const src = `export function t(): number { const a = "ab".at(0); const b = "ab".at(0); return a === b ? 1 : 0; }`;
+    expect(await run(src, "t")).toBe(1);
+  });
+
+  it("plain string === string (control) still works", async () => {
+    expect(await run(`export function t(): number { return "hello".charAt(1) === "e" ? 1 : 0; }`, "t")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

In nativeStrings mode any `string | undefined` value (`"x".at(i)`, optional chains/params) lowers to a NULLABLE `$AnyString` ref. `isStringType` returns false for the union, so an equality fell through to generic struct ref-equality — always false for equal content:

```ts
"hello".at(1) === "e"   // native: false, node: true
```

## Fix

- **binary-ops.ts**: route an equality op to the native string content comparison when either operand is a nullable-string (`string | null/undefined`) and the other is string-or-nullable-string. Gated to nativeStrings + equality ops, so relational / `+` keep their existing handling.
- **string-ops.ts**: `emitNullableStringEquals` null-guards before `__str_equals` — both-null → equal, exactly-one-null → unequal, else flatten + content compare. This also stops the null (undefined) operand from trapping `__str_flatten` (`"hello".at(99) === "e"` no longer derefs a null pointer).

Covers `===`, `!==`, `==`, `!=`; both operand orders for `x === undefined`; two union-typed values; and keeps plain `string === string` correct (acceptance criteria).

## Results (tests/issue-1961.test.ts, 8 tests pass)

Repro true, negations correct, unequal content false, `x === undefined` both orders, null-vs-string no-trap-and-false, two union values equal, plain-string control. Existing native-string suites (native-strings, #1105, roundtrip, standalone) pass — 112 tests, no regression.

Sets issue #1961 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)