### PR TITLE
plan: #1971 triage object-literal cluster residuals — close container, file #2126-#2132

### DIFF
--- a/plan/issues/1971-object-literal-cluster-residual-revalidation.md
+++ b/plan/issues/1971-object-literal-cluster-residual-revalidation.md
@@ -1,10 +1,11 @@
 ---
 id: 1971
 title: "re-validate object-literal/property cluster: 6 reproducible-on-main behaviors whose covering issues are marked done (#140/#1239/#492/#1112/#1837/#1136)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -12,7 +13,7 @@ task_type: investigation
 area: codegen
 language_feature: object-literals
 goal: property-model
-related: [140, 1239, 492, 1112, 1837, 1136, 1821]
+related: [140, 1239, 492, 1112, 1837, 1136, 1821, 1994, 2017, 2032, 2126, 2127, 2128, 2129, 2130, 2131, 2132]
 origin: "2026-06-10 deep-audit sweep (objects + eval-order agents): verified on main; flagged as residuals/regressions of done issues rather than unknown bugs"
 ---
 
@@ -55,6 +56,39 @@ residual of #785 (done).
 - For each: either a scoped new issue (with `renumbered_from`-style provenance
   note pointing at the original) or a documented wont-fix rationale
 - The done-status originals annotated with the residual finding
+
+## Triage results (2026-06-12, PO re-validation vs main `c19a2e9c1`)
+
+Each probe compiled with `compile()` and run via `compileAndInstantiate()`
+(JS-host mode, default options); wasm vs node compared. Repros in
+`.tmp/triage.mts` / `.tmp/triage2.mts` on branch `po-1971-triage`.
+
+| # | Behavior (as filed) | Verdict | Probe result | Disposition |
+|---|---------------------|---------|--------------|-------------|
+| 1 | Dynamic computed keys dropped + key side-effects lost (#140/#1837) | **STILL-BROKEN** | static-resolvable key works (`{[k]:42}.dyn==42`); **truly-runtime key drops the property** (`{[ks[1]]:5}` → read `NaN`); **key-expr side effect never runs** (`{[key()]:1}` → `calls==0`) | **NEW #2126** (construction side; #2032 covers only the destructuring *read* side) |
+| 2 | Spread of accessor-bearing literal drops property, getter never fires (#492/#1112) | **STILL-BROKEN** | `{...{get a(){return 7}}}.a` → wasm `null`, node `7`. Data-prop spread is fine (`{...{a:7}}.a==7`) — accessor-only | **NEW #2127** |
+| 3 | Object-literal setters not invoked; accessor on module const traps (#1239) | **PARTIAL** | 3a setter on literal: `{set v(x){captured=x}}; o.v=9` → `captured==0` (**STILL-BROKEN**). 3b getter/setter on module-level const with `o.x+=3` → `13` (**FIXED**, no longer traps) | 3a → **NEW #2128**; 3b fixed. Getter-only *write* trap already tracked by #2017 |
+| 4 | Duplicate keys: first-wins instead of last-wins | **STILL-BROKEN** | `{a:1,a:2}.a` → wasm `1`, node `2`; `{a:1,b:9,a:3}.a` → wasm `1` | **NEW #2129** |
+| 5 | `delete o.a` leaves `"a" in o`; dynamic-key delete no-op; rest `in` (#1821) | **STILL-BROKEN** | `delete o.a; "a" in o` → wasm `true`; **worse: `o.a` still reads `1` after delete** (no-op on the struct, not just `in`). Dynamic-key `delete o[k]` and `{e,...rest}; "e" in rest` both → wasm `true`. `in` resolved at compile time against the source struct shape (`src/codegen/binary-ops.ts:486-583`) | **NEW #2130** (false-positive mirror of #1991's false-negative) |
+| 6 | JS-host enumeration ignores integer-keys-ascending | **STILL-BROKEN** | `{b:1,"2":2,a:3,"1":4}` → `Object.keys` wasm `"b,2,a,1"`, node `"1,2,b,a"` | **NEW #2131** (#1837 fixed standalone hash-bucket order; JS-host path still emits insertion order, never reorders integer keys) |
+| CE1 | `arr.flat()/flatMap()` on `number[][]` → "No default value" (#1136) | **FIXED** | `[[1,2],[3,4]].flat()[2]==3`; `[1,2,3].flatMap(x=>[x,x*2])[3]==4` — both match node | — |
+| CE2 | `reduceRight` on string arrays → "Illegal argument" | **STILL-BROKEN** | `["a","b","c"].reduceRight(...)` → "illegal cast"; also plain `reduce` on string[] traps | **already covered by open #1994** |
+| CE3 | `Object.entries(o)[0]` element access → "No default value" | **FIXED** | `Object.entries({x:1,y:2})[0][0]=="x"` matches node | — |
+| CE4 | `Map.forEach((v,k)=>...)` → invalid module | **FIXED** | `m.forEach((v,k)=>sum+=v)` → `3` matches node | — |
+| EO | Non-optional method call on null class receiver → uncatchable wasm trap instead of catchable TypeError (#785) | **STILL-BROKEN** | `const c:C\|null=null; try{(c as any).m()}catch{return 99}` → wasm `RuntimeError: dereferencing a null pointer` (uncatchable), node `99` | **NEW #2132** |
+
+### Summary
+
+- **FIXED since filing (3+1):** CE1 (flat/flatMap), CE3 (Object.entries elem),
+  CE4 (Map.forEach), plus item 3b (accessor on module const, compound assign).
+- **Already covered by open issues (1):** CE2 → #1994.
+- **STILL-BROKEN, new scoped issues filed (7):** #2126 (computed-key
+  construction), #2127 (spread accessor), #2128 (object-literal setter),
+  #2129 (duplicate-key last-wins), #2130 (delete/`in` against static struct),
+  #2131 (JS-host integer-key enum order), #2132 (null-receiver method call
+  uncatchable).
+- Close this container **done** once #2126–#2132 are filed; all 11 behaviors
+  are now individually tracked or fixed.
 
 ## Why one issue
 

--- a/plan/issues/2126-computed-key-construction-runtime-key-dropped.md
+++ b/plan/issues/2126-computed-key-construction-runtime-key-dropped.md
@@ -1,0 +1,71 @@
+---
+id: 2126
+title: "object-literal construction with a runtime computed key drops the property and never evaluates the key expression"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [140, 1837, 2032]
+renumbered_from: "residual of #140 (done) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2126 — computed-key object construction: runtime key dropped, key side-effect skipped
+
+## Problem
+
+Building an object literal whose `[key]` is not a statically-resolvable string
+literal drops the property entirely, and the key expression's side effects are
+never evaluated.
+
+```ts
+// runtime key not statically known → property dropped
+const ks = ["p", "q"];
+let k = ks[1];
+const o: any = { [k]: 5 };
+o.q                       // wasm: NaN      node: 5
+
+// key expression side effect never runs
+let calls = 0;
+const key = (): string => { calls++; return "x"; };
+const o2: any = { [key()]: 1 };
+calls                     // wasm: 0        node: 1
+```
+
+A statically-resolvable computed key DOES work today
+(`let k = "dyn"; ({ [k]: 42 }).dyn === 42`) — the compiler constant-folds `k`
+to `"dyn"` and lays out a static struct field. The bug is the fallback: when
+the key cannot be folded to a compile-time string, the property and the key
+expression are both silently discarded.
+
+This is the **construction** side. The destructuring **read** side
+(`const { [k]: v } = obj`) is tracked separately by #2032.
+
+## Root cause (pointer)
+
+Object-literal lowering lays out a static struct from compile-time-known
+property names. A `ComputedPropertyName` that doesn't fold to a literal has no
+static field slot, and there is no runtime `__define_prop` fallback emitted —
+so both the field write and the key-expression evaluation drop out. See
+object-literal construction in `src/codegen/object-ops.ts` and the
+ComputedPropertyName handling path (grep `ComputedPropertyName`).
+
+## Acceptance criteria
+
+- `const ks=["p","q"]; let k=ks[1]; const o:any={[k]:5}; o.q` → `5`
+- `let calls=0; const key=()=>{calls++;return "x"}; ({[key()]:1}); calls` → `1`
+- Statically-resolvable computed keys keep working (no regression on
+  `{[literalVar]: v}`)
+- An equivalence test under `tests/` covering both shapes
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts`
+(branch `po-1971-triage`). JS-host mode, default options.

--- a/plan/issues/2127-spread-accessor-object-drops-property.md
+++ b/plan/issues/2127-spread-accessor-object-drops-property.md
@@ -1,0 +1,61 @@
+---
+id: 2127
+title: "object spread of an accessor-bearing source drops the property — getter never fires, value is null"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [492, 1112, 1239]
+renumbered_from: "residual of #492/#1112 (done) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2127 — spread copies struct fields, skips accessor-defined own properties
+
+## Problem
+
+`{ ...src }` where `src` has a getter (or setter) drops that property: the
+getter is never invoked and the spread result has no value for it.
+
+```ts
+const src = { get a(): number { return 7; } };
+const o: any = { ...src };
+o.a                       // wasm: null     node: 7
+```
+
+Spread of a plain data-property source is correct:
+`{ ...{ a: 7 } }.a === 7`. The bug is accessor-defined own properties
+specifically — per spec, `CopyDataProperties` does a `[[Get]]` on each own
+enumerable key, which must invoke the getter and copy the resulting value as a
+plain data property on the target.
+
+## Root cause (pointer)
+
+Object spread lowering appears to copy the source struct's data fields by
+field index and never materialises accessor properties (which live in the
+accessor sidecar / `classAccessorGet` registry, not as struct fields). The
+getter call needs to be emitted at spread time and its result written as a
+data property on the target. See object-literal spread handling in
+`src/codegen/object-ops.ts` and accessor registration around
+`compileObjectDefineProperty` / `classAccessorGet`.
+
+## Acceptance criteria
+
+- `const src = { get a(){ return 7; } }; ({ ...src }).a` → `7`
+- Getter side effects fire exactly once during the spread
+- Setter-only source property: spread reads via `[[Get]]` → `undefined`
+  data property (matches node)
+- Data-property spread unchanged (no regression)
+- An equivalence test under `tests/`
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` (branch `po-1971-triage`).
+JS-host mode, default options.

--- a/plan/issues/2128-object-literal-setter-not-invoked-on-assignment.md
+++ b/plan/issues/2128-object-literal-setter-not-invoked-on-assignment.md
@@ -1,0 +1,63 @@
+---
+id: 2128
+title: "object-literal setter not invoked on property assignment — the write silently no-ops"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [1239, 2017]
+renumbered_from: "residual of #1239 (done) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2128 — assignment to an object-literal `set` accessor does not call the setter
+
+## Problem
+
+A `set` accessor defined inline on an object literal is not invoked when the
+property is assigned; the write silently does nothing.
+
+```ts
+let captured = 0;
+const o: any = { set v(x: number) { captured = x; } };
+o.v = 9;
+captured                  // wasm: 0    node: 9
+```
+
+## Scope / relationship to neighbours
+
+- **Getter/setter pair on a module-level const with compound assign**
+  (`o.x += 3`) now works — verified FIXED on main (`#1971` item 3b), so this
+  issue is narrowed to the **setter-invocation-on-write** path.
+- The **getter-only** write case (`o.x = 99` where `x` has only a getter)
+  trapping `illegal cast` instead of a strict-mode TypeError is already
+  tracked by **#2017** — distinct from this issue (here the setter *exists*
+  and just isn't called).
+
+## Root cause (pointer)
+
+The assignment-codegen path for `o.prop = v` treats `prop` as a plain struct
+field write and does not consult the accessor registry for an inline-literal
+`set` accessor (`classAccessorSet`). It needs the same setter-dispatch that
+class instance setters use. See member-assignment lowering in
+`src/codegen/expressions.ts` / `src/codegen/statements.ts` and accessor
+registration in `src/codegen/object-ops.ts`.
+
+## Acceptance criteria
+
+- `let c=0; const o:any={set v(x){c=x}}; o.v=9; c` → `9`
+- Getter+setter pair: `set` fires on write, `get` fires on read
+- No regression on plain data-property writes
+- An equivalence test under `tests/`
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` (branch `po-1971-triage`).
+JS-host mode, default options.

--- a/plan/issues/2129-duplicate-object-keys-first-wins.md
+++ b/plan/issues/2129-duplicate-object-keys-first-wins.md
@@ -1,0 +1,59 @@
+---
+id: 2129
+title: "duplicate object-literal keys resolve first-wins instead of last-wins"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: medium
+feasibility: low
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [140, 1239]
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2129 — duplicate object-literal keys: last property definition must win
+
+## Problem
+
+When an object literal repeats a key, the compiler keeps the first value; ES
+semantics require the **last** definition to win (each duplicate runs in source
+order and overwrites the previous, so the final value is observed).
+
+```ts
+({ a: 1, a: 2 }).a            // wasm: 1    node: 2
+({ a: 1, b: 9, a: 3 }).a      // wasm: 1    node: 3
+```
+
+## Root cause (pointer)
+
+Object-literal struct layout deduplicates property names but binds the field
+to the **first** initializer rather than the last. The fix is to let a later
+property with the same name override the earlier slot's initializer (while
+still evaluating all initializers in source order for their side effects). See
+object-literal field collection in `src/codegen/object-ops.ts`.
+
+## Spec
+
+ECMAScript §13.2.5.5 PropertyDefinitionEvaluation runs each
+PropertyDefinition in order; `PropertyDefinition : PropertyName : Assignment`
+calls `CreateDataPropertyOrThrow`, which a later same-key definition
+overwrites. Side effects of all initializers still occur.
+
+## Acceptance criteria
+
+- `({ a: 1, a: 2 }).a` → `2`
+- `({ a: 1, b: 9, a: 3 }).a` → `3`
+- All initializer side effects in a duplicate-key literal still run in order
+  (e.g. `{ a: sideEffect1(), a: sideEffect2() }` runs both)
+- An equivalence test under `tests/`
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts`
+(branch `po-1971-triage`). Likely XS-to-S — single layout fix plus
+side-effect ordering. JS-host mode, default options.

--- a/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
+++ b/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
@@ -1,0 +1,82 @@
+---
+id: 2130
+title: "delete o.prop is a no-op and `in` answers against the static struct shape — post-delete / dynamic-key / object-rest all wrong"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [1821, 492, 1112, 1991]
+renumbered_from: "residual of #1821 (done) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2130 — `delete` / `in` ignore runtime object shape (static-struct resolution)
+
+## Problem
+
+`in` is resolved at **compile time** against the source object's struct shape,
+and `delete` on a literal object is a no-op on the underlying struct. So any
+object whose runtime shape differs from its declared struct (post-delete
+objects, object-rest objects) answers `in` wrong, and the deleted value is
+still readable.
+
+```ts
+// delete is a no-op on the struct: value survives AND `in` stays true
+const o: any = { a: 1, b: 2 };
+delete o.a;
+o.a                      // wasm: 1      node: undefined
+"a" in o                 // wasm: true   node: false
+
+// dynamic-key delete also a no-op
+const k = "a";
+delete o[k];
+"a" in o                 // wasm: true   node: false
+
+// object-rest: rest has no `e`, but `in` answers from the SOURCE struct shape
+const { e, ...rest } = { e: 3, f: 4 };
+"e" in rest              // wasm: true   node: false
+// (rest CONTENTS are correct: rest.e === undefined, Object.keys(rest) === ["f"])
+```
+
+## Root cause
+
+`in` lowering resolves the key against the receiver type's struct fields at
+compile time and emits an `i32.const` (`src/codegen/binary-ops.ts:486-583`,
+the `InKeyword` path). It never consults the runtime `__delete_prop` /
+presence sidecar, so a property that was deleted at runtime — or never existed
+on a rest object whose declared type still carries the field — is reported
+present. The `delete` codegen for literal objects similarly doesn't clear the
+struct field or mark the sidecar (#1821 fixed only the literal-key
+`__delete_prop` sidecar for the *dynamic-key element-access* read path, not
+the struct-field case, and not `in`).
+
+This is the **false-positive** mirror of **#1991** (`in` never consults the
+prototype chain → false negatives for inherited members). A unified fix would
+route `in` through a runtime presence check that combines: own struct fields,
+the runtime presence/delete sidecar, and (per #1991) the prototype chain.
+
+## Acceptance criteria
+
+- `const o:any={a:1,b:2}; delete o.a; o.a` → `undefined`
+- `… "a" in o` after `delete o.a` → `false`
+- dynamic-key `delete o[k]` removes the property (`in` → `false`, read →
+  `undefined`)
+- `const {e,...rest}={e:3,f:4}; "e" in rest` → `false` while
+  `Object.keys(rest)` stays `["f"]`
+- No regression on `in` for present own properties or array index `in`
+- Equivalence tests under `tests/`
+
+## Notes
+
+`feasibility: hard` — touches the `in` lowering, `delete` lowering, and the
+runtime presence model; coordinate with #1991 so both directions land on one
+presence predicate rather than two divergent paths. Verified on main
+`c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts` (branch
+`po-1971-triage`). JS-host mode, default options.

--- a/plan/issues/2131-jshost-enum-order-ignores-integer-key-ascending.md
+++ b/plan/issues/2131-jshost-enum-order-ignores-integer-key-ascending.md
@@ -1,0 +1,65 @@
+---
+id: 2131
+title: "JS-host Object.keys/for-in enumeration ignores the integer-keys-ascending-first ordering rule"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [1837]
+renumbered_from: "residual of #1837 (done, standalone path only) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2131 — JS-host enumeration emits insertion order, never reorders integer keys
+
+## Problem
+
+Property enumeration in JS-host mode follows insertion order and does not move
+integer-index keys to the front in ascending numeric order, as
+`OrdinaryOwnPropertyKeys` (ES §10.1.11.1) requires.
+
+```ts
+const o: any = { b: 1, "2": 2, a: 3, "1": 4 };
+Object.keys(o).join(",")
+// wasm: "b,2,a,1"     node: "1,2,b,a"
+```
+
+Required order: array-index keys (canonical numeric strings) first, in
+ascending numeric order; then string keys in insertion order; then symbol keys
+in insertion order.
+
+## Scope
+
+#1837 fixed the **standalone** path (hash-bucket order → spec order). The
+**JS-host** enumeration path was not covered and still emits raw insertion
+order. This issue is the JS-host counterpart.
+
+## Root cause (pointer)
+
+The JS-host `Object.keys` / `for-in` key source preserves the struct field
+declaration order without partitioning integer-index keys. The fix mirrors
+#1837's standalone ordering: split keys into (ascending integer indices) ++
+(insertion-ordered string keys) ++ (symbol keys). See the enumeration / keys
+emission for JS-host mode (grep `Object.keys` / `for-in` key collection in
+`src/codegen/` and the host import wiring).
+
+## Acceptance criteria
+
+- `Object.keys({ b:1, "2":2, a:3, "1":4 })` → `["1","2","b","a"]`
+- `for (const k in o)` visits keys in the same order
+- Pure-string-key objects keep insertion order (no regression)
+- An equivalence test under `tests/` (assert both JS-host and, where it
+  already passes, standalone)
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` (branch `po-1971-triage`),
+default options (JS-host). Cross-check against #1837's standalone fix so both
+paths share one ordering helper if practical.

--- a/plan/issues/2132-null-receiver-method-call-uncatchable-trap.md
+++ b/plan/issues/2132-null-receiver-method-call-uncatchable-trap.md
@@ -1,0 +1,69 @@
+---
+id: 2132
+title: "method call on a null receiver is an uncatchable wasm trap instead of a catchable TypeError"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: exceptions
+goal: core-semantics
+related: [785, 2017]
+renumbered_from: "residual of #785 (done) — surfaced by #1971 eval-order re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2132 — non-optional method call on a null receiver: uncatchable trap
+
+## Problem
+
+Calling a method on a `null` receiver traps the wasm module
+(`dereferencing a null pointer`) instead of throwing a catchable `TypeError`,
+so user `try/catch` around the call cannot recover.
+
+```ts
+class C { m(): number { return 1; } }
+const c: C | null = null;
+try {
+  (c as any).m();
+  return 0;
+} catch (e) {
+  return 99;
+}
+// wasm: RuntimeError: dereferencing a null pointer (uncatchable)
+// node: returns 99
+```
+
+Node throws `TypeError: Cannot read properties of null (reading 'm')` which the
+`catch` handles. The compiled module instead executes a raw `ref.cast` / field
+access on the null reference, which the wasm engine turns into an untrappable
+host RuntimeError that bypasses the module's own exception tags.
+
+## Root cause (pointer)
+
+The method-call lowering for a possibly-null receiver does not emit a null
+guard that throws a JS `TypeError` (via the throw/`__throw` path) before the
+dispatch. Optional-call (`?.`) was handled separately; the **non-optional**
+call on a statically-nullable receiver needs a null check that raises a
+catchable TypeError. See call-expression / member-call lowering in
+`src/codegen/expressions.ts` and the throw-lowering helper (cf. #2102
+`__throw`/throwJsError shared lowering).
+
+## Acceptance criteria
+
+- `const c:C|null=null; try{(c as any).m();return 0}catch{return 99}` → `99`
+- The thrown value is a `TypeError` (message-compatible with node where the
+  harness checks it)
+- Non-null receivers dispatch with no added overhead on the hot path (guard
+  only where the type is nullable)
+- An equivalence test under `tests/` exercising the catch
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts`
+(branch `po-1971-triage`). JS-host mode, default options. Coordinate with the
+shared throw lowering (#2102) so this reuses one TypeError-emit helper.

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -258,6 +258,13 @@ All independent -- can run in parallel (different codegen paths).
 | 799 | Prototype chain (remaining: #802 for dynamic) | ~2,500 FAIL | **Ready** (CRITICAL) |
 | 802 | Dynamic prototype support (conditional __proto__) | property-model | **Ready** |
 | 678 | Dynamic prototype chain (reverted) | 625 FAIL | **Ready** |
+| 2126 | computed-key object construction: runtime key dropped, key side-effect skipped (#1971 residual of #140) | property-model | **Ready** |
+| 2127 | object spread of accessor source drops property (getter never fires) (#1971 residual of #492/#1112) | property-model | **Ready** |
+| 2128 | object-literal `set` accessor not invoked on assignment (#1971 residual of #1239) | property-model | **Ready** |
+| 2129 | duplicate object-literal keys: first-wins instead of last-wins (#1971) | property-model | **Ready** |
+| 2130 | `delete`/`in` resolved against static struct shape — post-delete/dynamic-key/rest wrong (#1971 residual of #1821; mirror of #1991) | property-model | **Ready** (hard) |
+| 2131 | JS-host enumeration ignores integer-keys-ascending (#1971 residual of #1837 standalone-only fix) | property-model | **Ready** |
+| 2132 | method call on null receiver = uncatchable trap, not catchable TypeError (#1971 residual of #785) | core-semantics | **Ready** |
 
 ---
 


### PR DESCRIPTION
## Summary

PO re-validation of #1971 — the object-literal/property cluster's 6+5 reported
residual behaviors, checked against current main \`c19a2e9c1\` (JS-host mode,
\`compileAndInstantiate\`, wasm vs node). Plan-only; no source changes.

### Outcome
- **FIXED since filing (3+1):** \`flat()/flatMap()\` (#1136), \`Object.entries(o)[0]\`
  element access, \`Map.forEach\`, and accessor-on-module-const compound assign
  (item 3b). Covered by the 27 PRs merged 2026-06-10/11.
- **Already covered by an open issue (1):** string \`reduce\`/\`reduceRight\`
  "illegal cast" → #1994.
- **STILL-BROKEN, filed 7 scoped issues:**
  - #2126 computed-key object construction drops a runtime key + skips the key
    expression's side effect
  - #2127 object spread of an accessor source drops the property (getter never fires)
  - #2128 object-literal \`set\` accessor not invoked on assignment
  - #2129 duplicate object-literal keys resolve first-wins (must be last-wins)
  - #2130 \`delete\`/\`in\` resolved against the static struct shape — post-delete,
    dynamic-key, and object-rest all answer wrong (false-positive mirror of #1991)
  - #2131 JS-host enumeration ignores integer-keys-ascending (#1837 fixed only
    the standalone path)
  - #2132 method call on a null receiver is an uncatchable wasm trap instead of a
    catchable TypeError (residual of #785)

#1971 closed as **done**; its triage table records every verdict + probe result.
Dependency graph Cluster E updated with #2126–#2132.

Repros: \`.tmp/triage.mts\` / \`.tmp/triage2.mts\` on this branch (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)