### PR TITLE
docs(arch): presence-predicate addendum for #2130/#1991 — verified corrections

### DIFF
--- a/plan/issues/1991-in-operator-no-prototype-chain.md
+++ b/plan/issues/1991-in-operator-no-prototype-chain.md
@@ -4,7 +4,7 @@ title: "in operator never consults the prototype chain — inherited class metho
 status: ready
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -275,3 +275,76 @@ Add `tests/issue-1991-in-prototype-chain.test.ts`:
 test262: `language/expressions/in/*`,
 `built-ins/Object/prototype/hasOwnProperty/*` (must stay green — the Stage A
 extraction touches `__hasOwnProperty`).
+
+## Addendum — verified corrections to the plan (2026-06-12, second architect pass)
+
+See also the addendum in #2130's file (A1-A8); the items below are
+#1991-specific. **Dev: treat these as authoritative where they conflict with
+the text above.**
+
+### B1. Option (b)'s plain `ref.test` chain has a wrong-answer mode — dispatch on the `__tag` value instead
+
+The recommended `__instance_proto_methods(externref) -> externref` export is
+right, but a chain of `ref.test <classStructTypeIdx>` cannot distinguish
+classes whose structs have **identical field layouts**: WasmGC types are
+canonicalized **iso-recursively** (this is exactly #2009's collision), so
+`class A { m() {} }` and `class B { n() {} }` — both lowering to
+`(i32 __tag)` plus the same field kinds — share one heap type, and the chain
+returns the *first* class's method CSV for instances of both. Result:
+`"n" in new A()` → true. Field-name dispatch (`__struct_field_names`) lives
+with this today, but for the method registry there is a collision-free
+discriminator already in every class instance: the `__tag` field (field 0),
+whose **values** are globally unique per class (`ctx.classTagMap`) — it is
+per-instance data, immune to type canonicalization. Emit the export the way
+`compileInstanceOf`'s externref arm already reads tags
+(`src/codegen/typeof-delete.ts:531-585`):
+
+```wasm
+;; __instance_proto_methods(externref) -> externref
+local.get 0
+any.convert_extern
+local.tee $any
+ref.test $RootStruct_1          ;; per root-class hierarchy; gates the cast
+if
+  local.get $any
+  ref.cast $RootStruct_1
+  struct.get $RootStruct_1 0    ;; __tag
+  ;; if-chain (or br_table) over ALL class tag values → global.get <csv>
+end
+;; ... next root hierarchy ...
+ref.null.extern                 ;; not a class instance
+```
+
+Per-class transitive CSV = own `ctx.classMethodNames` ∪ ancestors via
+`ctx.classParentMap` (child names shadow parent — dedupe keeps one entry;
+membership is what matters here). Register CSVs with
+`addStringConstantGlobal`; skip emission in `ctx.nativeStrings` mode for the
+same reason as `emitStructFieldNamesExport` (`index.ts:2097`). Note the
+`ref.test $RootStruct` gate is only a safe-cast guard — two unrelated root
+hierarchies may canonicalize together and both pass the same test, which is
+fine because the tag if-chain spans all classes and disambiguates.
+
+### B2. Tombstone ordering for `delete instance.m` — simpler than the edge-case text suggests
+
+The "method deleted via `delete instance.m`" bullet hedges. The clean rule,
+already implied by the predicate shape: **the tombstone gates the OWN tier
+only** — when tombstoned, skip own checks but still evaluate
+`_wasmStructHasInherited`. That yields spec behavior with no special cases:
+`delete c.m` (m inherited, not own) per §13.5.1 removes nothing, and
+`"m" in c` stays true because the inherited tier answers after the
+tombstone-suppressed own tier. Do NOT make the tombstone short-circuit the
+whole predicate to false.
+
+### B3. Confirmations (probed/read on `c19a2e9c1`, no action needed)
+
+- Inherited accessors are covered: `class-bodies.ts:890-903` collects
+  get/set accessor names into `ctx.classMethodNames` alongside methods.
+- `"toString" in c` already true via `_OBJECT_PROTO_KEYS` (PR #1352);
+  `"m" in c` / `"missing" in c` probe `false`/`false` today — only the
+  registry tier is missing.
+- Statically-typed receivers (`const c: C = …; "m" in c`) already fold to
+  `true`: the TS type of `C` carries `m`, and `binary-ops.ts:588-614`
+  (`getProperty` + apparent-type check) answers before any struct-field
+  test. The optional static-path improvement in the plan is therefore
+  already-implemented behavior — verify with a test, but expect no code
+  change.

--- a/plan/issues/1991-in-operator-no-prototype-chain.md
+++ b/plan/issues/1991-in-operator-no-prototype-chain.md
@@ -60,3 +60,218 @@ PR loopdive#1352 (merged) fixed the Object.prototype-members half
 of #1992. REMAINING for this issue: inherited user-class methods
 (`"m" in subclassInstance`) need the per-class method-name registry —
 scoped in the sprint-62/63 proposal (analysis program 08-new-issues list).
+
+---
+
+## Implementation Plan (joint with #2130 — shared presence predicate)
+
+> **This is the canonical design block for the joint presence-predicate
+> work.** #2130 carries the same shared design plus its own deltas. Read
+> both. Land in the staged order below; #1991 is **Stage C** and depends on
+> Stage A landing first.
+
+### Root cause (both issues are one defect)
+
+Objects lowered to static WasmGC structs have **no runtime property-presence
+notion**. The `in` operator has two lowering paths in
+`src/codegen/binary-ops.ts` (the `InKeyword` arm, ~line 487-799):
+
+1. **Static struct path** (staticKey known + receiver resolves to a named
+   struct via `resolveWasmType`): emits a compile-time `i32.const` from the
+   struct's *declared field set* — `binary-ops.ts:654-702`. This ignores
+   runtime deletes (#2130 own-field false-positive) and inherited members
+   (#1991 false-negative).
+2. **Runtime path** (`externref`/`anyref` receiver — which is what an `any`,
+   `unknown`, or cast receiver becomes): routes to the `__extern_has` host
+   import — `binary-ops.ts:663-688` and `745-772`. `__extern_has`
+   (`src/runtime.ts`, the `name === "__extern_has"` arm ~line 6343-6386) is a
+   **thinner, divergent** presence predicate than `__hasOwnProperty`
+   (~line 8781-8818): it never consults the delete **tombstone**
+   (`_wasmStructDeletedKeys`), never consults `_getStructFieldNames` as a
+   value-independent own check, and never walks the prototype chain for
+   inherited user-class methods.
+
+So today (verified on `c19a2e9c1`, JS-host mode, via probes in this PR's
+branch):
+
+| Case | wasm | node | path |
+|------|------|------|------|
+| `const o:any={a:1,b:2}; "b" in o` | `true` | `true` | runtime ok |
+| `delete o.a; "a" in o` | **`true`** | `false` | tombstone ignored (#2130) |
+| `delete o.a; o.a` | **`1`** | `undefined` | struct field uncleared (#2130) |
+| `delete o[k]; "a" in o` | **`true`** | `false` | dynamic-key (#2130) |
+| `const {e,...rest}=…; "e" in rest` | **`true`** | `false` | rest source shape (#2130) |
+| `"m" in subclassInstance` | **`false`** | `true` | no proto walk (#1991) |
+| `"toString" in c` | `true` | `true` | `_OBJECT_PROTO_KEYS` ok (#1352) |
+| `"zzz" in c` | `false` | `false` | ok |
+
+The two issues are the **false-positive** (#2130) and **false-negative**
+(#1991) faces of the same missing runtime presence predicate. Fix them with
+**one** predicate, not two divergent host imports.
+
+### The unified predicate
+
+`__hasOwnProperty` (`runtime.ts` ~8781-8818) is already the most complete
+**own**-presence predicate: it checks, in order, tombstone →
+sidecar (`_wasmStructProps`) → descriptor map (`_wasmPropDescs`) →
+prototype/static method registries (`_prototypeMethodNames` /
+`_staticMethodNames`, only when `obj` *is* a registered proto/class object) →
+struct field names (`_getStructFieldNames`). `in` differs from
+`hasOwnProperty` only by **also walking `[[Prototype]]`**.
+
+**Design: one own-presence helper, one inherited-presence helper, both
+consumed by every presence site.**
+
+#### 1. `_wasmStructHasOwn(obj, key, exports): boolean` — new helper in `runtime.ts`
+
+Factor the body of `__hasOwnProperty`'s WasmGC-struct branch (everything
+after the `_isWasmStruct(obj)` guard, lines ~8791-8817) into a named
+function. It returns true iff `key` is an **own** property of the struct
+`obj` right now: tombstone-absent AND (sidecar-has OR descriptor-has OR
+struct-field-has). Re-point `__hasOwnProperty` at it (no behavior change —
+pure extraction, keeps the existing #1334 tombstone + #929 descriptor
+semantics). This becomes the single source of own-presence truth.
+
+#### 2. `_wasmStructHasInherited(obj, key, exports): boolean` — new helper
+
+For the prototype-chain half that `in` needs but `hasOwnProperty` does not:
+
+- `_OBJECT_PROTO_KEYS.has(key)` → true (already done inline in `__extern_has`;
+  move it here so all `in` callers share it).
+- **Inherited user-class methods (#1991 core):** the struct instance has no
+  JS `[[Prototype]]` edge to its class's registered prototype object, so the
+  runtime cannot reach `_prototypeMethodNames` from the instance. **Codegen
+  must register an instance→method-name-set mapping** (see Stage C codegen
+  work below). The helper consults that new registry:
+  `_wasmInstanceProtoMethods.get(obj)?.includes(key)`.
+
+#### 3. Rewrite `__extern_has` (the `in` runtime) as: own ∨ inherited
+
+```
+__extern_has(obj, key):
+  if obj == null: return 0          // matches current; in on non-object → caller-guarded
+  key = ToPrimitive(key) if wasm-struct key   // keep existing #1716 coercion
+  if !_isWasmStruct(obj):
+    try { if key in obj: return 1 } catch {}    // host object — native in walks its proto
+    if _sidecarGet(obj,key) !== undefined: return 1
+    return 0
+  // WasmGC struct: own first (incl. tombstone), then inherited
+  if _wasmStructHasOwn(obj, key, exports): return 1
+  if _wasmStructHasInherited(obj, key, exports): return 1
+  return 0
+```
+
+This single change fixes #2130's `in` false-positives (tombstone now
+consulted via `_wasmStructHasOwn`) **and** #1991's inherited-method
+false-negatives (via `_wasmStructHasInherited`) for the runtime path. Keep
+the `__sget_<key>` getter probe folded into `_wasmStructHasOwn` (it already
+lives there as the struct-field check).
+
+### Staged landing order
+
+The stages are independently testable and independently mergeable. **Land A
+before B and C** (A is the shared refactor + tombstone fix that both depend
+on). B and C are parallel after A.
+
+- **Stage A (#2130 core, blocks B & C):** extract `_wasmStructHasOwn`;
+  re-point `__hasOwnProperty`; rewrite `__extern_has` to call it (own half +
+  tombstone). Fixes `delete o.a → "a" in o === false` and object-rest. This
+  is the minimal change that closes the #2130 `in` false-positive.
+- **Stage B (#2130 remainder):** dynamic-key delete actually removing the
+  property, and the struct-field-clear-on-delete read fix. See #2130 deltas.
+- **Stage C (#1991, this issue):** add `_wasmInstanceProtoMethods` registry +
+  codegen registration; add `_wasmStructHasInherited`; route `__extern_has`
+  through it. Fixes `"m" in subclassInstance`.
+
+### #1991-specific work (Stage C)
+
+**File: `src/codegen/class-bodies.ts`** — `ctx.classMethodNames` (set at
+line ~905) already holds each class's **own** prototype method names, and
+`ctx.classParentMap` (line ~408) gives the parent chain. Compute the
+**transitive** inherited method-name set per class (own ∪ all ancestors'),
+deduped, and emit a registration call so the runtime can map a constructed
+instance to that set.
+
+Two registration options — **prefer (a)**:
+
+- **(a) Per-instance registration at construction.** In the class
+  constructor codegen (where the instance struct is allocated — see
+  `compileNewExpression` / the ctor body emit in `class-bodies.ts`), after
+  the instance is created, emit a call to a new host import
+  `__register_instance_methods(externref instance, externref csv)` where
+  `csv` is the comma-joined transitive method-name string (a string constant
+  global, same mechanism as `__struct_field_names` uses —
+  `addStringConstantGlobal` / `stringGlobalMap`). Runtime stores
+  `_wasmInstanceProtoMethods.set(instance, names)`. Zero overhead for classes
+  whose instances never hit an `in`-miss is **not** achievable per-instance,
+  but the cost is one host call + one WeakMap set per `new` of a class that
+  has methods — acceptable and bounded. Guard with `nativeStrings` skip
+  (standalone has no host; see Stage C standalone note).
+- **(b) Per-struct-type lookup.** Emit a `__instance_proto_methods(externref)
+  -> externref` export mirroring `emitStructFieldNamesExport`
+  (`index.ts:2086`): a `ref.test typeIdx` chain returning the class's
+  transitive method CSV. Runtime's `_wasmStructHasInherited` calls it
+  (via `getExports()`), no per-`new` cost. **This is lower-overhead and
+  preferred IF the instance struct typeIdx ↔ class-name mapping is available
+  at export-emit time** (it is — `ctx.structMap` keyed by class name). Use
+  (b) if the `ref.test` chain is clean; fall back to (a) only if instance
+  structs can't be distinguished by typeIdx from the class.
+
+> **Architect recommendation: implement (b).** It mirrors an existing,
+> proven export (`__struct_field_names`), has zero per-`new` cost, and the
+> typeIdx→methods map is trivially built from `ctx.structMap` +
+> `ctx.classMethodNames` + `ctx.classParentMap`. (a) is the fallback only if
+> a class's instances share a typeIdx with something else.
+
+**File: `src/runtime.ts`** — add `_wasmStructHasInherited`; if using (b), add
+a `_getInstanceProtoMethods(obj, exports)` reading the new export (mirror
+`_getStructFieldNames`, `runtime.ts:2782`). Fold `_OBJECT_PROTO_KEYS` into
+the inherited check.
+
+**Also (optional, low-risk) static-path improvement:** in
+`binary-ops.ts:654-702`, when the receiver resolves to a known class struct
+(`ctx.classSet.has(typeName)`) and `staticKey` is known, also consult the
+transitive `ctx.classMethodNames` + ancestors so a *statically-typed* (non-
+`any`) `"m" in instance` folds to `i32.const 1` at compile time without a
+runtime call. Not required for correctness (the runtime path covers `any`
+receivers) but removes a host call on the common typed path. Verify
+`_OBJECT_PROTO_KEYS` membership is also accepted here.
+
+### Edge cases (#1991)
+
+- `"m" in subclassInstance` where `m` is declared on the grandparent → must
+  be true (transitive walk, not just immediate parent).
+- Inherited **accessor** (`get x()`): `resolveClassMemberName` already
+  collects get/set accessors into `classMethodNames`
+  (`class-bodies.ts:895-902`), so they're included — confirm.
+- A method **deleted** via `delete instance.m` → `_isDeletedClassProp` /
+  tombstone must win over the inherited-method registry (own tombstone is
+  checked first in the predicate order, so `delete` of an *inherited* method
+  on the instance shadows it as a tombstone — matches spec, the own delete
+  records absence; but note deleting an inherited method via the instance is
+  a no-op in real JS since it's not own — keep `in` true unless the tombstone
+  semantics already cover it; do NOT regress `__for_in_has`).
+- `"constructor" in instance` → true (it's on the proto chain). Add
+  `"constructor"` handling if not in `_OBJECT_PROTO_KEYS`.
+- Static-side: `"m" in C` (the class object, not an instance) routes through
+  `_staticMethodNames` already — do not break it.
+
+### Test plan (#1991)
+
+Add `tests/issue-1991-in-prototype-chain.test.ts`:
+
+- `class P{m(){return 1}} class C extends P{own=1} const c:any=new C();`
+  → `"m" in c === true`, `"own" in c === true`, `"toString" in c === true`,
+  `"zzz" in c === false`.
+- Three-level inheritance: method on grandparent visible via `in` on a
+  grandchild instance.
+- Inherited accessor `get g(){…}` → `"g" in instance === true`.
+- `"m" in C` (class object) unchanged.
+- Statically-typed receiver (`const c: C = new C(); "m" in c`) → true
+  (exercises the optional static-path improvement if implemented).
+- No regression: array-index `in`, own-data-property `in`, `#priv in obj`
+  brand check (`binary-ops.ts:503-521`).
+
+test262: `language/expressions/in/*`,
+`built-ins/Object/prototype/hasOwnProperty/*` (must stay green — the Stage A
+extraction touches `__hasOwnProperty`).

--- a/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
+++ b/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
@@ -1,0 +1,246 @@
+---
+id: 2130
+title: "delete o.prop is a no-op and `in` answers against the static struct shape — post-delete / dynamic-key / object-rest all wrong"
+status: ready
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [1821, 492, 1112, 1991]
+renumbered_from: "residual of #1821 (done) — surfaced by #1971 re-validation"
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2130 — `delete` / `in` ignore runtime object shape (static-struct resolution)
+
+## Problem
+
+`in` is resolved at **compile time** against the source object's struct shape,
+and `delete` on a literal object is a no-op on the underlying struct. So any
+object whose runtime shape differs from its declared struct (post-delete
+objects, object-rest objects) answers `in` wrong, and the deleted value is
+still readable.
+
+```ts
+// delete is a no-op on the struct: value survives AND `in` stays true
+const o: any = { a: 1, b: 2 };
+delete o.a;
+o.a                      // wasm: 1      node: undefined
+"a" in o                 // wasm: true   node: false
+
+// dynamic-key delete also a no-op
+const k = "a";
+delete o[k];
+"a" in o                 // wasm: true   node: false
+
+// object-rest: rest has no `e`, but `in` answers from the SOURCE struct shape
+const { e, ...rest } = { e: 3, f: 4 };
+"e" in rest              // wasm: true   node: false
+// (rest CONTENTS are correct: rest.e === undefined, Object.keys(rest) === ["f"])
+```
+
+## Root cause
+
+`in` lowering resolves the key against the receiver type's struct fields at
+compile time and emits an `i32.const` (`src/codegen/binary-ops.ts:486-583`,
+the `InKeyword` path). It never consults the runtime `__delete_prop` /
+presence sidecar, so a property that was deleted at runtime — or never existed
+on a rest object whose declared type still carries the field — is reported
+present. The `delete` codegen for literal objects similarly doesn't clear the
+struct field or mark the sidecar (#1821 fixed only the literal-key
+`__delete_prop` sidecar for the *dynamic-key element-access* read path, not
+the struct-field case, and not `in`).
+
+This is the **false-positive** mirror of **#1991** (`in` never consults the
+prototype chain → false negatives for inherited members). A unified fix would
+route `in` through a runtime presence check that combines: own struct fields,
+the runtime presence/delete sidecar, and (per #1991) the prototype chain.
+
+## Acceptance criteria
+
+- `const o:any={a:1,b:2}; delete o.a; o.a` → `undefined`
+- `… "a" in o` after `delete o.a` → `false`
+- dynamic-key `delete o[k]` removes the property (`in` → `false`, read →
+  `undefined`)
+- `const {e,...rest}={e:3,f:4}; "e" in rest` → `false` while
+  `Object.keys(rest)` stays `["f"]`
+- No regression on `in` for present own properties or array index `in`
+- Equivalence tests under `tests/`
+
+## Notes
+
+`feasibility: hard` — touches the `in` lowering, `delete` lowering, and the
+runtime presence model; coordinate with #1991 so both directions land on one
+presence predicate rather than two divergent paths. Verified on main
+`c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts` (branch
+`po-1971-triage`). JS-host mode, default options.
+
+---
+
+## Implementation Plan (joint with #1991 — shared presence predicate)
+
+> **The canonical shared design lives in `#1991`'s `## Implementation Plan`.**
+> Read it first. This issue is **Stage A + Stage B** of the staged landing
+> order defined there; #1991 is Stage C. Stage A is the shared refactor that
+> #1991 also depends on, so land A before C.
+
+### Root cause (recap — full version in #1991)
+
+Two faces of one defect. The `in` operator and `delete` operate against the
+**static struct shape**, never the runtime presence/delete sidecar:
+
+- `in` on an `any`/cast receiver routes to `__extern_has`
+  (`src/runtime.ts`, ~line 6343), which — unlike `__hasOwnProperty`
+  (~line 8781) — **never consults the delete tombstone**
+  `_wasmStructDeletedKeys`. So `delete o.a; "a" in o` stays `true`.
+- `delete o.a` on a struct **field** sets a NaN/ref-null sentinel
+  (`typeof-delete.ts:32` `emitDeleteSentinel`) only on the **static
+  struct-field arm** (`typeof-delete.ts:115-196`). For an `any`/cast
+  receiver that arm is skipped and delete falls to the `__delete_property`
+  runtime arm (`typeof-delete.ts:267-342`), which records the tombstone but
+  **cannot clear the struct field** — so the subsequent read `o.a` reads the
+  unchanged field via `__sget_a` and returns the stale value (`1`).
+
+Ground truth (this PR's branch, `c19a2e9c1`, JS-host, `setExports` wired):
+
+```
+const o:any={a:1,b:2}; delete o.a;
+  o.a        → 1      (want undefined)   ← field uncleared
+  "a" in o   → true   (want false)       ← tombstone ignored
+  "b" in o   → true   (correct)
+const k="a"; delete o[k]; "a" in o → true (want false)   ← dyn-key no-op
+const {e,...rest}={e:3,f:4}; "e" in rest → true (want false)
+```
+
+### Stage A — the `in` false-positive fix (shared; blocks #1991 Stage C)
+
+Implement the shared predicate refactor from #1991's plan:
+
+**File: `src/runtime.ts`**
+- Extract `_wasmStructHasOwn(obj, key, exports)` from `__hasOwnProperty`'s
+  WasmGC branch (~line 8791-8817) — tombstone-absent AND (sidecar OR
+  descriptor OR struct-field). Re-point `__hasOwnProperty` at it (pure
+  extraction, no behavior change).
+- Rewrite the `__extern_has` arm (~line 6343-6386) so its WasmGC-struct
+  branch is `_wasmStructHasOwn(...) || _wasmStructHasInherited(...)` (the
+  inherited half is #1991 Stage C; for Stage A landing alone, call
+  `_wasmStructHasOwn` and keep the existing inline `_OBJECT_PROTO_KEYS`
+  check). The key Stage-A effect: the tombstone is now consulted, so
+  `"a" in o` after `delete o.a` returns `false`, and object-rest `"e" in
+  rest` returns `false` (the rest struct never had `e` written, and if the
+  source struct's typeIdx leaks the field, the tombstone/own-check on the
+  *rest* object — which has its own struct shape — answers correctly; verify
+  the rest object is a distinct struct, see Stage B object-rest note).
+
+This alone fixes acceptance criteria #2 and the object-rest criterion.
+
+### Stage B — delete actually removes the property (read + dynamic-key)
+
+**(B1) Clear the struct field on the runtime delete path.**
+
+**File: `src/codegen/typeof-delete.ts`** — the `__delete_property` runtime
+arm (`267-342`) records the tombstone but leaves the struct field holding
+its old value, so reads return stale data. Two options:
+
+- **Preferred:** when the receiver *can* be resolved to a struct type even
+  through an `any`/cast (consult `ctx.widenedVarStructMap.get(ident.text)`
+  the same way the static arm does at `typeof-delete.ts:118-119`), take the
+  static field arm (sentinel `struct.set` + `__delete_property`) instead of
+  the pure-runtime arm. The static arm at lines 115-196 already does exactly
+  the right thing — extend its **guard** so it fires for widened-`any`
+  identifiers, not only for receivers whose TS type resolves to a struct.
+  This makes `delete (o as any).a` clear the field AND set the tombstone.
+- **Fallback (covers truly opaque receivers):** make the read side
+  tombstone-aware. The `__sget_<key>` getter path in property reads should
+  return `undefined` when `_wasmStructDeletedKeys.get(obj)?.has(key)`. This
+  is a runtime-only guard but adds a tombstone check to every dynamic struct
+  read — heavier. Prefer the codegen-side field clear (B1 preferred) and use
+  this only for receivers with no resolvable struct type.
+
+**(B2) Dynamic-key delete `delete o[k]`.**
+
+The element-access runtime arm (`typeof-delete.ts:304-324`) compiles the key
+as externref and calls `__delete_property`, which DOES set the tombstone
+keyed by `String(k)`. So after Stage A, `"a" in o` post `delete o[k]`
+already returns `false` (tombstone consulted). The remaining gap is the
+**read** `o.a` returning stale — same fix as B1 (the field isn't cleared
+because a dynamic key can't be resolved to a static field index). For the
+dynamic-key case the read-side tombstone guard (B1 fallback) is the only
+option, since the field index isn't known at compile time. Scope: add the
+tombstone guard to the dynamic element-read runtime helper
+(`__extern_get` / `__sget` dispatch) so a tombstoned key reads `undefined`.
+
+**(B3) `__for_in_keys` tombstone filter.**
+
+**File: `src/runtime.ts`** — `__for_in_keys` (~line 8834) collects struct
+field names (line ~8861) **without** filtering the tombstone. The per-visit
+`__for_in_has` (#2066, line ~8924) currently masks this for for-in
+enumeration, but `Object.keys` / `Object.entries` (which call
+`__getOwnPropertyNames`-style helpers) may not. Filter
+`_wasmStructDeletedKeys.get(current)` out of the collected `fieldNames` in
+`__for_in_keys` and in `__getOwnPropertyNames` (~line 8814 region) so
+`Object.keys(o)` after `delete o.a` omits `a`. **Cross-check the
+`Object.keys(rest)` acceptance criterion stays `["f"]`** (it currently
+passes — do not regress).
+
+### Object-rest specifics
+
+`const {e,...rest}={e:3,f:4}` — confirm the compiler lowers `rest` to a
+**distinct struct** containing only `f` (not an alias of the source struct
+with `e` still present). If `rest` shares the source struct shape, `"e" in
+rest` resolves `e` as an own field and Stage A's own-check returns true
+incorrectly. Check the object-rest lowering (grep `ObjectBindingPattern` /
+rest-element in `src/codegen/declarations.ts` / `destructuring`); if `rest`
+carries the source typeIdx, either (i) build a fresh struct type for the rest
+object omitting the bound keys, or (ii) record the omitted keys as tombstones
+on the rest object at construction. Prefer (i) — a correct shape is cheaper
+than a tombstone the runtime must always consult. The acceptance note says
+`rest` CONTENTS are already correct (`rest.e===undefined`,
+`Object.keys(rest)===["f"]`), which suggests the rest object's *field set* is
+right and only `in`'s static/own resolution is consulting the wrong shape —
+verify which, as it decides between (i) and "Stage A already fixes it".
+
+### Edge cases (#2130)
+
+- **delete then re-add:** `delete o.a; o.a=5; "a" in o` → `true`, `o.a` → `5`.
+  `_sidecarSet` already clears the tombstone (`runtime.ts:2250-2253`); confirm
+  the re-add path (struct.set or sidecar) reaches it.
+- **delete non-configurable** (`Object.defineProperty(o,"a",{configurable:
+  false})` then `delete o.a`): `__delete_property` returns `0` and keeps the
+  property — `"a" in o` must stay `true`. Stage A's own-check via descriptor
+  map must still see it.
+- **integer keys** (`delete o[0]`, `0 in o`): mirror #1837's integer-key
+  helper; tombstone keys are stringified (`String(0)==="0"`) consistently on
+  both delete and `in`. Coordinate with #2131 (integer-key enumeration).
+- **Symbol keys:** `delete o[sym]; sym in o` — tombstone stores the raw
+  symbol (`runtime.ts:8777`); `_wasmStructHasOwn` must compare symbol keys by
+  identity, not `String(key)`.
+- **null receiver:** `delete (null as any).x` → `__delete_property` returns
+  vacuously true (`runtime.ts:8729`); `"x" in null` is a TypeError in real JS
+  — but that's #2132's domain, do not change here.
+
+### Test plan (#2130)
+
+Add `tests/issue-2130-delete-in-presence.test.ts` (JS-host; mirror the
+`setExports`-wired harness in `tests/fast-arrays.test.ts`):
+
+- `const o:any={a:1,b:2}; delete o.a;` → `o.a===undefined`, `!("a" in o)`,
+  `"b" in o`.
+- dynamic key: `const k="a"; delete o[k];` → `!("a" in o)`,
+  `o.a===undefined`.
+- object-rest: `const {e,...rest}={e:3,f:4};` → `!("e" in rest)`,
+  `"f" in rest`, `Object.keys(rest)` deep-equals `["f"]`.
+- delete-then-re-add round-trips `in` and read.
+- non-configurable delete keeps `in` true and returns `false` from `delete`.
+- `Object.keys(o)` / `for (const k in o)` omit the deleted key.
+
+test262: `language/expressions/delete/*`,
+`language/statements/for-in/*`, `built-ins/Object/keys/*`,
+`built-ins/Object/prototype/hasOwnProperty/*` — Stage A touches
+`__hasOwnProperty`, must stay green.

--- a/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
+++ b/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
@@ -244,3 +244,124 @@ test262: `language/expressions/delete/*`,
 `language/statements/for-in/*`, `built-ins/Object/keys/*`,
 `built-ins/Object/prototype/hasOwnProperty/*` — Stage A touches
 `__hasOwnProperty`, must stay green.
+
+## Addendum — verified corrections to the plan (2026-06-12, second architect pass)
+
+Independent re-derivation against main `c19a2e9c1` with fresh probes
+(equivalence harness, JS-host). The plan above is architecturally right; the
+items below correct or pin down points where it is vague or where the probe
+results contradict its assumptions. **Dev: treat these as authoritative where
+they conflict with the text above.**
+
+### A1. The `__sget_<key>` probe must be DELETED, not "kept folded in"
+
+Stage A's closing line ("Keep the `__sget_<key>` getter probe folded into
+`_wasmStructHasOwn`") is wrong and is the single most likely way this fix
+fails review. The probe (`runtime.ts:6359-6373`) is the actual root cause of
+the `in` false positives: `__sget_<key>` getters **never throw** —
+`buildNestedIfElse` (`src/codegen/index.ts:4047`, default branch) falls
+through to `ref.null.extern`/`i32.const 0` for receivers matching no struct
+type. So "the getter returned without throwing" (the #1589A heuristic) is
+true for *every* receiver whenever *any* struct type in the module has a
+field of that name — a module-global check, not a per-receiver one. The
+per-receiver shape oracle is `_getStructFieldNames(obj, exports)`
+(`runtime.ts:2782`, backed by the `__struct_field_names` ref.test dispatch,
+`index.ts:2086-2181`) — already what `__hasOwnProperty` uses at
+`runtime.ts:8816`, and what `_wasmStructHasOwn` inherits via the extraction.
+Delete the probe lines; do not port them.
+
+### A2. Object-rest needs NO codegen work — close that open question
+
+The "Object-rest specifics" section asks the dev to verify how `rest` is
+lowered and sketches building a fresh struct type. Verified: `rest` is built
+by the `__extern_rest_object` host import (`runtime.ts:6988-7030`), which
+returns a **plain JS object** containing only the non-excluded keys. The
+false positive comes entirely from A1: the plain-JS branch of `__extern_has`
+misses (`"e" in rest` → false natively), then falls through to the
+module-global `__sget_e` probe (the source struct `{e,f}` makes it exist) →
+wrongly returns 1. The Stage A rewrite (own/inherited tiers for wasm structs;
+native `key in obj` + sidecar for plain JS, with no `__sget_` fallthrough)
+fixes rest with zero codegen changes. Drop options (i)/(ii); skip the
+fresh-struct work.
+
+### A3. delete-then-re-add is broken TODAY — promote from "confirm" to a fix item
+
+Probe: `const o:any={a:1}; delete o.a; o.a = 5;` then `o.a` reads **1** (the
+original value — the re-added `5` is lost). So the edge-case bullet
+("confirm the re-add path reaches `_sidecarSet`") understates it: the write
+path does NOT clear the tombstone and does not even surface the new value.
+`_sidecarSet` clears tombstones (`runtime.ts:2245-2253`) but `_safeSet`
+prefers the `__sset_<name>` struct setter (`emitStructFieldSetters`,
+`index.ts:1898`), which writes the real struct field and bypasses
+`_sidecarSet` entirely. Fix: clear `_wasmStructDeletedKeys` in **`_safeSet`
+itself** (single choke point covering both the sidecar and `__sset_` arms),
+and add `delete o.a; o.a=5; o.a===5 && ("a" in o)` to the tests — it guards
+two distinct regressions.
+
+### A4. `Object.keys` consistency: the real import is `__object_keys`, and it needs the sidecar union too
+
+B3 points at `__for_in_keys`/`__getOwnPropertyNames`, but `Object.keys(o)`
+on an `any` receiver routes to `__object_keys` (`runtime.ts:6684`; `values`
+6702, `entries` 6725 — chosen in `compileObjectKeysOrValues`,
+`src/codegen/object-ops.ts:3046-3063`). Probe confirms: after `delete o.a`,
+`Object.keys(o)` is still `["a","b"]`. All three helpers enumerate
+`_getStructFieldNames` + the `_SC_ENUMERABLE` filter only. Add (a) the
+tombstone filter, and (b) the union of enumerable **sidecar** keys not in the
+shape (mirror `__for_in_keys`'s sidecar block, `runtime.ts:8868-8882`) —
+without (b), a deleted-then-re-added key (which now lives in the sidecar per
+A3) vanishes from `Object.keys` forever. Shape order first, sidecar insertion
+order after, matching `__for_in_keys`.
+
+### A5. Read-path tombstone gate: both `__extern_get` AND `_safeGet`
+
+B1/B2's read fix should be pinned to two exact spots: the wasm-struct
+fallback region of `__extern_get` (`runtime.ts:6170-6179`, before the
+`__sget_<key>` call) and the top of `_safeGet`'s `_isWasmStruct` branch
+(`runtime.ts:3539`). Rule: **every path that treats `__sget_<key>` or struct
+shape as own-property evidence must first consult
+`_wasmStructDeletedKeys`.** With this in place, B1's "preferred"
+widened-struct-arm extension becomes optional hardening, not a correctness
+requirement — the generic arm + read gate already satisfy the acceptance
+criteria (the sentinel `struct.set` only matters for statically-typed
+`struct.get` reads, which remain number-typed NaN by design).
+
+### A6. Two residual `in` gaps to document in the PR (not blockers)
+
+- **Statically-typed receivers**: `const o={a:1}; delete (o as any).a;
+  "a" in o` still folds to `i32.const 1` at compile time
+  (`binary-ops.ts:654-702`). Acceptance criteria only cover `any` receivers,
+  so this is out of Stage A/B scope. If wanted later: add a
+  `sourceContainsDelete(sourceFile)` pre-scan (pattern:
+  `sourceContainsClass`, `index.ts:208-220`; count only delete of
+  property/element access) as `ctx.moduleUsesDelete`, and when true route
+  struct-ref receivers through `__extern_has` instead of folding — preserves
+  byte-identical output for delete-free modules.
+- **Dynamic-key `in` on typed structs** (`k in typedStruct`,
+  `binary-ops.ts:705-733`): an inline `__str_eq` loop over compile-time field
+  names — a third divergent presence implementation that misses tombstones,
+  sidecar props, and the proto tiers. Recommended: delete the path and route
+  through `__extern_has` unconditionally (the shape is rare; one predicate,
+  not three).
+
+### A7. Standalone mode (Stage D — file as a follow-up issue, do not do here)
+
+Static structs in standalone have no WeakMap sidecar; the native
+`__extern_has` / `__delete_property`
+(`src/codegen/object-runtime.ts:1468` / `:1199`) only understand the dynamic
+`$Object` representation, which already has spec-correct tombstones
+(`FLAG_TOMBSTONE`), proto-walk `in`, and #1837 insertion-order enumeration.
+Do NOT build a wasm-side global (obj, key) tombstone registry — WasmGC has no
+weak refs, so it would strongly retain every deleted-from object. The
+dual-mode answer is **representation steering**: reuse the A6 pre-scan to
+find object-literal struct types targeted by `delete`, and in standalone mode
+lower those literals to `$Object`. Zero overhead for untouched objects, full
+fidelity for delete-touched ones. PO: open the follow-up referencing this
+section.
+
+### A8. One-line predicate hygiene
+
+In the `__extern_has` rewrite, the plain-JS sidecar check must be key-based
+(`const sc = _wasmStructProps.get(obj); sc && key in sc`), not the current
+value-based `_sidecarGet(obj, key) !== undefined` (`runtime.ts:6357`) —
+HasProperty (§7.3.12) is value-independent, so `o.x = undefined; "x" in o`
+must be true.


### PR DESCRIPTION
Plan-only PR (no src/ changes). The original joint spec commit (338c8e410) on this branch is already in main; the effective diff is the second-architect-pass **addendum** (b26320d88), written after fresh probes against main c19a2e9c1, appended to both issue files.

The landed design (one HasProperty predicate, own ∨ inherited tiers, `_wasmStructHasOwn` extraction) stands. The addendum corrects the points where the spec was vague or contradicted by probe results:

**#2130 (A1-A8):**
- **A1 (load-bearing):** the `__sget_<key>` probe in `__extern_has` must be deleted, not kept — getters never throw (`buildNestedIfElse` falls through to null), so the #1589A heuristic is module-global and is the actual root cause of every `in` false positive.
- **A2:** object-rest needs zero codegen work — `__extern_rest_object` already returns a plain JS object; A1 fixes the rest case. Closes the spec's open (i)/(ii) question.
- **A3:** `delete o.a; o.a = 5` loses the 5 today (probed) — tombstone clear belongs in `_safeSet`, not only `_sidecarSet`.
- **A4:** the real `Object.keys` import is `__object_keys` (runtime.ts:6684); needs tombstone filter + sidecar-key union.
- **A5-A8:** exact read-path gate spots, residual typed/dynamic-key `in` gaps to document, standalone representation-steering follow-up (Stage D), key-based sidecar check.

**#1991 (B1-B3):**
- **B1 (design flaw fix):** the recommended bare `ref.test` chain for the method-name registry export gives wrong answers for same-layout sibling classes under iso-recursive canonicalization (#2009) — dispatch on the `__tag` field VALUE instead (the `compileInstanceOf` pattern), which is collision-free.
- **B2:** tombstone gates the own tier only — gives spec-correct `delete c.m` (inherited) behavior for free.
- **B3:** probe-verified confirmations (accessors covered; typed receivers already fold correctly).

Merge note: if a drift-merge ever conflicts with PR #1392 (po-1971-triage) in these files, keep this branch's addendum sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)