### PR TITLE
fix(#1959): empty-iteration progress guard for nullable RegExp quantifiers

### DIFF
--- a/plan/issues/1959-regex-vm-empty-quantifier-no-progress-guard.md
+++ b/plan/issues/1959-regex-vm-empty-quantifier-no-progress-guard.md
@@ -1,10 +1,11 @@
 ---
 id: 1959
 title: "native RegExp VM: empty-body quantifier loops burn the 1M-step cap and silently report no-match (/(?:a?)*/ fails)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -64,3 +65,50 @@ exhaustion a thrown error rather than a silent no-match.
 #1909/#1911/#1912/#1914 catalog refusals/unsupported features; #1539 covers
 empty-match lastIndex advance and split separators — nothing about the
 quantifier-empty-body loop in the VM.
+
+## Resolution (2026-06-12)
+
+Added a `PROGRESS` opcode (`ReOp.PROGRESS = 13`) implementing the RepeatMatcher
+empty-iteration guard. The compiler allocates one **scratch capture slot** per
+nullable star/plus, appended after the real capture slots (`nScratch` on
+`CompiledRegex` / the `$NativeRegExp` struct). The loop records `sp` at each
+iteration's entry via `SAVE scratch`; after the body, `PROGRESS scratch` fails
+the iteration when `sp` is unchanged (empty match), so backtracking takes the
+quantifier's exit arm instead of re-entering forever.
+
+- **Nullability** decided at compile time by `canMatchEmpty` (over-approximating
+  — unknown shapes default to nullable, only adding a cheap guard). Non-nullable
+  quantifiers allocate no scratch slot and emit the original tight encoding, so
+  the common case is byte-for-byte unchanged.
+- **Plus** keeps its mandatory first match unguarded (min=1) and lowers the
+  remaining repetitions as a guarded star, so an empty first match (e.g.
+  `(a?)+` on `"b"`) still succeeds.
+- Threaded `nScratch` through the caps-array sizing at every VM entry point:
+  the search/exec path plus the `__regex_replace` / `__regex_split` /
+  `__regex_match_all` helpers (caps array is now `2*nGroups + nScratch`).
+
+### Files
+
+- `src/codegen/regex/bytecode.ts` — `ReOp.PROGRESS`, `CompiledRegex.nScratch`
+- `src/codegen/regex/compile.ts` — `canMatchEmpty`, scratch allocation, guarded
+  star/plus lowering
+- `src/codegen/regex/vm.ts` — reference VM `PROGRESS` dispatch + `nScratch` slot
+- `src/codegen/native-regex.ts` — Wasm VM `progressArm()` dispatch; `nScratch`
+  param on replace/split/match_all
+- `src/codegen/regexp-standalone.ts` — `nScratch` struct field + `pushNSlots`
+
+## Test Results
+
+All match Node `RegExp` semantics on the standalone backend:
+
+- `/(?:a?)*/.test("b")` → empty match at 0, <1 ms (was ~3 s "no match")
+- `/(a?)*x/.test("bbbbbbbbbbbbbbbbbbbb")` → false, <1 ms (was step-cap burn)
+- `/(?:a?)*/` on `"aab"` → `[0,2]`; `/(a*)*/` on `"aaa"` → `[0,3]`;
+  `/(a*)+/` on `""` → `[0,0]`
+- Non-nullable controls (`a*`, `a+`, `(ab)+`, `[0-9]+`) unregressed
+- `tests/issue-1959.test.ts` (15 cases) green; `regex-bytecode.test.ts` (277),
+  `issue-1539-standalone-regex-replace.test.ts` (17) green
+
+(Pre-existing unrelated failure: `issue-1539-standalone-regex.test.ts` "refuses
+unicode flag (u)" fails on clean main too — the `u` flag is no longer refused
+but that refusal test wasn't updated; not touched here.)

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -517,8 +517,18 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                                             op: "if",
                                             blockType: { kind: "empty" },
                                             then: lookaroundArm(),
-                                            // op == MATCH (the only remaining op): return 1
-                                            else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                            else: [
+                                              { op: "local.get", index: OP },
+                                              { op: "i32.const", value: ReOp.PROGRESS },
+                                              { op: "i32.eq" },
+                                              {
+                                                op: "if",
+                                                blockType: { kind: "empty" },
+                                                then: progressArm(),
+                                                // op == MATCH (the only remaining op): return 1
+                                                else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                              },
+                                            ],
                                           },
                                         ],
                                       },
@@ -666,6 +676,34 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       { op: "i32.const", value: 1 },
       { op: "i32.add" },
       { op: "local.set", index: PC },
+    ];
+  }
+
+  function progressArm(): Instr[] {
+    // Empty-iteration guard (§22.2.2.3.1, #1959): if sp == caps[a] (the loop
+    // entry recorded by a preceding SAVE), the body matched empty — fail the
+    // iteration so backtracking takes the quantifier's exit arm. Otherwise
+    // pc++. Mirrors the PROGRESS case in regex/vm.ts.
+    return [
+      { op: "local.get", index: SP },
+      { op: "local.get", index: CAPS },
+      { op: "local.get", index: A },
+      { op: "array.get", typeIdx: i32Arr },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "i32.const", value: 1 },
+          { op: "local.set", index: FAILED },
+        ],
+        else: [
+          { op: "local.get", index: PC },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: PC },
+        ],
+      },
     ];
   }
 
@@ -1381,6 +1419,7 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
       strRef, // subject (flattened)
       strRef, // replacement (flattened)
       { kind: "i32" }, // global flag
+      { kind: "i32" }, // nScratch (#1959 — PROGRESS guard slots)
     ],
     [strRef],
   );
@@ -1396,21 +1435,24 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     SLEN = 5,
     SUBJ = 6,
     REPL = 7,
-    GLOBAL = 8;
+    GLOBAL = 8,
+    NSCRATCH = 9;
   // locals
-  const NSLOTS = 9; // 2 * nGroups
-  const CAPS = 10; // ref array<i32> capture slots
-  const POS = 11; // current search start
-  const LASTEND = 12; // end of last replaced match (start of next kept slice)
-  const RESULT = 13; // ref $NativeString accumulator
-  const MSTART = 14;
-  const MEND = 15;
+  const NSLOTS = 10; // 2 * nGroups + nScratch
+  const CAPS = 11; // ref array<i32> capture slots
+  const POS = 12; // current search start
+  const LASTEND = 13; // end of last replaced match (start of next kept slice)
+  const RESULT = 14; // ref $NativeString accumulator
+  const MSTART = 15;
+  const MEND = 16;
 
   const body: Instr[] = [
-    // nSlots = 2 * nGroups
+    // nSlots = 2 * nGroups + nScratch (#1959 scratch slots ride in caps)
     { op: "local.get", index: NGROUPS },
     { op: "i32.const", value: 2 },
     { op: "i32.mul" },
+    { op: "local.get", index: NSCRATCH },
+    { op: "i32.add" },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },
@@ -1779,6 +1821,7 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
       { kind: "i32" }, // strLen
       strRef, // subject (flattened)
       { kind: "i32" }, // lim (u32; -1 = no limit)
+      { kind: "i32" }, // nScratch (#1959 — PROGRESS guard slots)
     ],
     [nstrVecRef],
   );
@@ -1793,22 +1836,23 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
     SOFF = 4,
     SLEN = 5,
     SUBJ = 6,
-    LIM = 7;
+    LIM = 7,
+    NSCRATCH = 8;
   // locals
-  const NSLOTS = 8;
-  const CAPS = 9;
-  const P = 10; // last split point (spec p)
-  const Q = 11; // scan cursor (spec q)
-  const RARR = 12;
-  const RLEN = 13;
-  const RCAP = 14;
-  const NEWARR = 15;
-  const PART = 16;
-  const MSTART = 17;
-  const MEND = 18;
-  const GI = 19; // capture interleave index
-  const CS = 20;
-  const CE = 21;
+  const NSLOTS = 9;
+  const CAPS = 10;
+  const P = 11; // last split point (spec p)
+  const Q = 12; // scan cursor (spec q)
+  const RARR = 13;
+  const RLEN = 14;
+  const RCAP = 15;
+  const NEWARR = 16;
+  const PART = 17;
+  const MSTART = 18;
+  const MEND = 19;
+  const GI = 20; // capture interleave index
+  const CS = 21;
+  const CE = 22;
 
   const appendPart = (): Instr[] => [
     // Grow result if needed.
@@ -1887,10 +1931,12 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
   ];
 
   const body: Instr[] = [
-    // nSlots = 2 * nGroups; caps = array.new_default(nSlots)
+    // nSlots = 2 * nGroups + nScratch; caps = array.new_default(nSlots) (#1959)
     { op: "local.get", index: NGROUPS },
     { op: "i32.const", value: 2 },
     { op: "i32.mul" },
+    { op: "local.get", index: NSCRATCH },
+    { op: "i32.add" },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },
@@ -2140,6 +2186,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
       { kind: "i32" }, // strOff
       { kind: "i32" }, // strLen
       strRef, // subject (flattened)
+      { kind: "i32" }, // nScratch (#1959 — PROGRESS guard slots)
     ],
     [{ kind: "ref_null", typeIdx: matchVecTypeIdx }],
   );
@@ -2153,23 +2200,27 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
     SDATA = 3,
     SOFF = 4,
     SLEN = 5,
-    SUBJ = 6;
+    SUBJ = 6,
+    NSCRATCH = 7;
   // locals
-  const NSLOTS = 7;
-  const CAPS = 8;
-  const POS = 9;
-  const RARR = 10;
-  const RLEN = 11;
-  const RCAP = 12;
-  const NEWARR = 13;
-  const MSTART = 14;
-  const MEND = 15;
-  const FIRSTMS = 16;
+  const NSLOTS = 8;
+  const CAPS = 9;
+  const POS = 10;
+  const RARR = 11;
+  const RLEN = 12;
+  const RCAP = 13;
+  const NEWARR = 14;
+  const MSTART = 15;
+  const MEND = 16;
+  const FIRSTMS = 17;
 
   const body: Instr[] = [
+    // nSlots = 2 * nGroups + nScratch (#1959 scratch slots ride in caps)
     { op: "local.get", index: NGROUPS },
     { op: "i32.const", value: 2 },
     { op: "i32.mul" },
+    { op: "local.get", index: NSCRATCH },
+    { op: "i32.add" },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },

--- a/src/codegen/regex/bytecode.ts
+++ b/src/codegen/regex/bytecode.ts
@@ -54,6 +54,14 @@ export enum ReOp {
    *  successful positive lookaround persist; everything else restores the
    *  pre-assertion capture state. #1911. */
   LOOKAROUND = 12,
+  /** `[PROGRESS, slot, 0]` — empty-iteration guard for nullable quantifiers
+   *  (§22.2.2.3.1 RepeatMatcher: a min=0 iteration that consumes nothing
+   *  fails, ending the loop). `slot` is a scratch capture slot into which the
+   *  loop entry recorded `sp` via a preceding SAVE; if the current `sp` equals
+   *  that recorded value the body matched empty, so this op FAILS the
+   *  iteration (backtracking to the quantifier's exit arm). Only emitted for
+   *  star/plus whose body can match the empty string. #1959. */
+  PROGRESS = 13,
 }
 
 /** Slots per instruction in the flat program array. */
@@ -90,6 +98,11 @@ export interface CompiledRegex {
   classTable: number[];
   /** Number of capture groups including group 0 (the whole match). */
   nGroups: number;
+  /** Extra scratch slots appended after the `2*nGroups` capture slots, one per
+   *  nullable star/plus, used by `ReOp.PROGRESS` to detect empty iterations
+   *  (#1959). The VM allocates `2*nGroups + nScratch` slots; scratch slots are
+   *  never reported as captures. */
+  nScratch: number;
   /** Flags bitfield: g=1 i=2 m=4 s=8 u=16 y=32 d=64 v=128. */
   flags: number;
 }

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -62,6 +62,14 @@ class Emitter {
   private reversed = false;
   /** Lookaround bodies pending sub-program emission (drained by compileParsed). */
   private readonly pendingSubs: PendingSub[] = [];
+  /** Count of scratch capture slots allocated for `ReOp.PROGRESS` empty-loop
+   *  guards (#1959). Each nullable star/plus claims one slot, appended after
+   *  the real capture slots so it is never reported as a capture. Seeded by
+   *  compileParsed once the capture count is known. */
+  scratchCount = 0;
+  /** Base slot index for the next scratch slot = `2 * nGroups + scratchCount`.
+   *  Set by compileParsed before compileNode runs. */
+  private scratchBase = 0;
 
   constructor(caseInsensitive: boolean, dotAll: boolean, multiline: boolean) {
     this.caseInsensitive = caseInsensitive;
@@ -86,6 +94,16 @@ class Emitter {
 
   private here(): number {
     return this.instrs.length;
+  }
+
+  /** Set the base index for scratch slots (called once nGroups is known). */
+  setScratchBase(base: number): void {
+    this.scratchBase = base;
+  }
+
+  /** Claim the next scratch capture slot for a PROGRESS guard (#1959). */
+  private allocScratch(): number {
+    return this.scratchBase + this.scratchCount++;
   }
 
   /** Add a class to the class table, return its start offset. */
@@ -194,11 +212,17 @@ class Emitter {
         return;
       }
       case "star": {
-        // L1: SPLIT body,exit ; body ; JMP L1 ; exit:   (greedy: body first)
+        // Greedy: SAVE? sp ; L1: SPLIT body,exit ; body ; PROGRESS? ; JMP L1 ; exit
+        // A nullable body needs the empty-iteration guard (§22.2.2.3.1): record
+        // sp before SPLIT, and after the body PROGRESS fails the iteration when
+        // sp is unchanged, so the loop can't spin on a zero-width match (#1959).
+        const guard = canMatchEmpty(node.node) ? this.allocScratch() : -1;
+        if (guard >= 0) this.emit(ReOp.SAVE, guard);
         const l1 = this.emit(ReOp.SPLIT, 0, 0);
         const bodyStart = this.here();
         this.compileNode(node.node);
-        this.emit(ReOp.JMP, l1);
+        if (guard >= 0) this.emit(ReOp.PROGRESS, guard);
+        this.emit(ReOp.JMP, guard >= 0 ? l1 - 1 : l1);
         const exit = this.here();
         if (node.greedy) {
           this.patchA(l1, bodyStart);
@@ -210,18 +234,31 @@ class Emitter {
         return;
       }
       case "plus": {
-        // L1: body ; SPLIT L1,exit ; exit:   (greedy: loop first)
-        const l1 = this.here();
-        this.compileNode(node.node);
-        const split = this.emit(ReOp.SPLIT, 0, 0);
-        const exit = this.here();
-        if (node.greedy) {
-          this.patchA(split, l1);
-          this.patchB(split, exit);
-        } else {
-          this.patchA(split, exit);
-          this.patchB(split, l1);
+        // The first repetition is mandatory (min=1), so it is NOT guarded — an
+        // empty first match is a legitimate one-repetition match. Only the loop
+        // back-edge (the min=0 repetitions) needs the empty-iteration guard.
+        // Non-nullable body keeps the tight original encoding:
+        //   L1: body ; SPLIT L1,exit ; exit
+        // Nullable body lowers to one body + a guarded star for the rest:
+        //   body ; SAVE g ; L2: SPLIT body2,exit ; body2 ; PROGRESS g ; JMP L2 ; exit
+        const guard = canMatchEmpty(node.node) ? this.allocScratch() : -1;
+        if (guard < 0) {
+          const l1 = this.here();
+          this.compileNode(node.node);
+          const split = this.emit(ReOp.SPLIT, 0, 0);
+          const exit = this.here();
+          if (node.greedy) {
+            this.patchA(split, l1);
+            this.patchB(split, exit);
+          } else {
+            this.patchA(split, exit);
+            this.patchB(split, l1);
+          }
+          return;
         }
+        // Nullable body: mandatory first match, then a guarded star.
+        this.compileNode(node.node);
+        this.compileNode({ kind: "star", node: node.node, greedy: node.greedy });
         return;
       }
       case "opt": {
@@ -312,6 +349,46 @@ class Emitter {
   }
 }
 
+/**
+ * Conservative nullability test (#1959): can `node` match the empty string?
+ * Used to decide whether a star/plus loop needs the empty-iteration PROGRESS
+ * guard. Over-approximating (returning true when unsure) only adds a cheap
+ * guard; under-approximating would risk the silent-no-match bug, so unknown
+ * shapes default to nullable. Zero-width assertions (`^`, `$`, `\b`,
+ * lookaround) are nullable; consuming atoms (char/class/any) are not.
+ */
+export function canMatchEmpty(node: ReNode): boolean {
+  switch (node.kind) {
+    case "char":
+    case "any":
+    case "udot":
+    case "class":
+    case "backref":
+      // backref to an unset group matches empty, but a set group may consume;
+      // treat as consuming — the guard is only skipped when DEFINITELY non-empty.
+      return false;
+    case "bol":
+    case "eol":
+    case "wordBoundary":
+    case "lookaround":
+      return true;
+    case "star":
+    case "opt":
+      return true;
+    case "plus":
+      return canMatchEmpty(node.node);
+    case "repeat":
+      return node.min === 0 || canMatchEmpty(node.node);
+    case "group":
+    case "modGroup":
+      return canMatchEmpty(node.node);
+    case "concat":
+      return node.parts.every(canMatchEmpty);
+    case "alt":
+      return node.options.some(canMatchEmpty);
+  }
+}
+
 /** Thrown when `{n,m}` expansion would blow past the size cap. */
 export class RepeatTooLargeError extends Error {
   constructor(detail: string) {
@@ -390,7 +467,11 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
   const caseInsensitive = (flags & RE_FLAG_I) !== 0;
   const dotAll = (flags & RE_FLAG_S) !== 0;
   const multiline = (flags & RE_FLAG_M) !== 0;
+  const nGroups = parsed.numCaptures + 1;
   const em = new Emitter(caseInsensitive, dotAll, multiline);
+  // Scratch slots for PROGRESS guards (#1959) live after the 2*nGroups capture
+  // slots, so the emitter must know the capture-slot count before lowering.
+  em.setScratchBase(2 * nGroups);
   // SAVE 0 (match start)
   em.emit(ReOp.SAVE, 0);
   em.compileNode(parsed.root);
@@ -404,7 +485,8 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
   return {
     prog,
     classTable: em.classTable,
-    nGroups: parsed.numCaptures + 1,
+    nGroups,
+    nScratch: em.scratchCount,
     flags,
   };
 }

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -85,8 +85,12 @@ export function runAt(
   entryPc = 0,
   dir = 1,
   capsIn?: Int32Array,
+  nScratch = 0,
 ): Int32Array | null {
-  const nSlots = 2 * nGroups;
+  // Capture slots (2*nGroups) plus scratch slots for PROGRESS empty-loop guards
+  // (#1959). Scratch slots travel with the capture array (snapshotted on SPLIT,
+  // seeded into recursive lookaround attempts) and are sliced off by callers.
+  const nSlots = 2 * nGroups + nScratch;
   const initCaps = capsIn !== undefined ? capsIn.slice() : new Int32Array(nSlots).fill(-1);
   const stack: Frame[] = [];
   let pc = entryPc;
@@ -226,12 +230,21 @@ export function runAt(
         // the sub ran copy-on-write and never mutated ours (§22.2.2.4).
         const negated = (b & 1) !== 0;
         const behind = (b & 2) !== 0;
-        const sub = runAt(prog, classTable, nGroups, input, sp, a, behind ? -1 : 1, caps);
+        const sub = runAt(prog, classTable, nGroups, input, sp, a, behind ? -1 : 1, caps, nScratch);
         const ok = sub !== null;
         if (negated ? !ok : ok) {
           if (!negated && sub !== null) caps = sub;
           pc++;
         } else failed = true;
+        break;
+      }
+      case ReOp.PROGRESS: {
+        // Empty-iteration guard (§22.2.2.3.1, #1959): `a` is a scratch slot
+        // holding sp at this loop iteration's entry. If sp is unchanged the
+        // body matched empty, so fail the iteration — backtracking takes the
+        // quantifier's exit arm (the SPLIT alternative pushed at loop entry).
+        if (sp === caps[a]) failed = true;
+        else pc++;
         break;
       }
       case ReOp.MATCH: {
@@ -263,10 +276,11 @@ export function search(
   input: string,
   startIdx: number,
   sticky: boolean,
+  nScratch = 0,
 ): Int32Array | null {
   const len = input.length;
   for (let i = Math.max(0, startIdx); i <= len; i++) {
-    const m = runAt(prog, classTable, nGroups, input, i);
+    const m = runAt(prog, classTable, nGroups, input, i, 0, 1, undefined, nScratch);
     if (m) return m;
     if (sticky) return null;
   }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -435,7 +435,24 @@ const RE_FIELD_NGROUPS = 1;
 const RE_FIELD_PROG = 2;
 const RE_FIELD_CLASS_TABLE = 3;
 const RE_FIELD_SOURCE = 4;
-const RE_FIELD_LASTINDEX = 5;
+const RE_FIELD_NSCRATCH = 5; // #1959 — scratch slots for PROGRESS guards
+const RE_FIELD_LASTINDEX = 6;
+
+/**
+ * Push `2 * nGroups + nScratch` (the VM caps-array length) onto the stack,
+ * reading both fields from a `$NativeRegExp` struct local (#1959). The caps
+ * array carries the real capture slots plus the scratch slots that back
+ * PROGRESS empty-loop guards.
+ */
+function pushNSlots(fctx: FunctionContext, regexpLocal: number, structTypeIdx: number): void {
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
+  fctx.body.push({ op: "i32.const", value: 2 });
+  fctx.body.push({ op: "i32.mul" });
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH });
+  fctx.body.push({ op: "i32.add" });
+}
 
 /**
  * EscapeRegExpPattern (ECMA-262 §22.2.6.13.1), computed at compile time —
@@ -497,6 +514,10 @@ function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
     { name: "prog", type: i32ArrRef, mutable: false },
     { name: "classTable", type: i32ArrRef, mutable: false },
     { name: "source", type: nativeStringType(ctx), mutable: false },
+    // Scratch capture-slot count for PROGRESS empty-loop guards (#1959). The VM
+    // caps array is sized `2*nGroups + nScratch`; scratch slots are never
+    // reported as captures. Field added after source to keep lastIndex last.
+    { name: "nScratch", type: { kind: "i32" } as ValType, mutable: false },
     // [[LastIndex]] (§22.2.7.1) — a plain writable number property on the
     // RegExp object. Stored as f64; exec applies ToLength at use time. Only
     // g/y exec mutates it (#1913); reads/writes route through the #1914
@@ -542,7 +563,9 @@ function emitStandaloneRegExpStruct(
   // EscapeRegExpPattern) so the `.source` getter is a plain field read.
   const srcType = compileStringLiteral(ctx, fctx, escapeRegExpPattern(pattern), node);
   if (!srcType) return null;
-  // field 5: lastIndex — fresh RegExp objects start at 0 (§22.2.3.3).
+  // field 5: nScratch — PROGRESS empty-loop guard slots (#1959).
+  fctx.body.push({ op: "i32.const", value: compiled.nScratch });
+  // field 6: lastIndex — fresh RegExp objects start at 0 (§22.2.3.3).
   fctx.body.push({ op: "f64.const", value: 0 });
   fctx.body.push({ op: "struct.new", typeIdx });
   return { kind: "ref", typeIdx };
@@ -770,12 +793,10 @@ function emitRegexSearchCall(
   });
   fctx.body.push({ op: "local.set", index: inputLocal });
 
-  // caps = array.new_default(2 * nGroups)
+  // caps = array.new_default(2 * nGroups + nScratch) — scratch slots back the
+  // PROGRESS empty-loop guards (#1959); they ride along in the caps array.
   const capsLocal = allocLocal(fctx, `__re_caps_${fctx.locals.length}`, { kind: "ref", typeIdx: i32Arr });
-  fctx.body.push({ op: "local.get", index: regexpLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
-  fctx.body.push({ op: "i32.const", value: 2 });
-  fctx.body.push({ op: "i32.mul" });
+  pushNSlots(fctx, regexpLocal, structTypeIdx);
   fctx.body.push({ op: "array.new_default", typeIdx: i32Arr } as Instr);
   fctx.body.push({ op: "local.set", index: capsLocal });
 
@@ -794,11 +815,8 @@ function emitRegexSearchCall(
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG });
   fctx.body.push({ op: "local.get", index: regexpLocal });
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_CLASS_TABLE });
-  // nSlots = 2 * nGroups
-  fctx.body.push({ op: "local.get", index: regexpLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
-  fctx.body.push({ op: "i32.const", value: 2 });
-  fctx.body.push({ op: "i32.mul" });
+  // nSlots = 2 * nGroups + nScratch
+  pushNSlots(fctx, regexpLocal, structTypeIdx);
   // input data / off / len
   fctx.body.push({ op: "local.get", index: inputLocal });
   fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }); // data
@@ -1120,6 +1138,9 @@ export function tryCompileStandaloneStringMatch(
     fctx.body.push({ op: "local.get", index: subjLocal });
     fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }); // len
     fctx.body.push({ op: "local.get", index: subjLocal });
+    // nScratch (#1959) — PROGRESS empty-loop guard slots, last arg.
+    fctx.body.push({ op: "local.get", index: regexpLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH });
     fctx.body.push({ op: "call", funcIdx: matchAllIdx });
     // lastIndex = 0 (net effect of the spec's exec loop on a global regex).
     fctx.body.push({ op: "local.get", index: regexpLocal });
@@ -1245,6 +1266,9 @@ export function tryCompileStandaloneStringReplace(
   fctx.body.push({ op: "local.get", index: subjLocal });
   fctx.body.push({ op: "local.get", index: replLocal });
   fctx.body.push({ op: "i32.const", value: globalReplace ? 1 : 0 });
+  // nScratch (#1959) — PROGRESS empty-loop guard slots, last arg.
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH });
   fctx.body.push({ op: "call", funcIdx: replaceIdx });
   return nativeStringType(ctx);
 }
@@ -1343,6 +1367,9 @@ export function tryCompileStandaloneStringSplit(
       return null;
     }
   }
+  // nScratch (#1959) — PROGRESS empty-loop guard slots, last arg.
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH });
   fctx.body.push({ op: "call", funcIdx: splitIdx });
 
   const nstrVecTypeIdx = ctx.vecTypeMap.get(`ref_${ctx.anyStrTypeIdx}`);

--- a/tests/issue-1959.test.ts
+++ b/tests/issue-1959.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1959 — native RegExp VM empty-iteration progress guard (§22.2.2.3.1
+ * RepeatMatcher). A nullable quantifier body (`(?:a?)*`, `(a*)*`, …) used to
+ * loop pushing backtrack frames until the 1,000,000-step cap, which was then
+ * reported as "no match" — a silent wrong answer plus a multi-second perf
+ * cliff at every scan position. The compiler now emits a PROGRESS opcode that
+ * fails any iteration consuming nothing, so the loop exits per spec.
+ *
+ * Validation is on the pure-WasmGC standalone backend (the affected VM). We
+ * compare against Node's `RegExp` via `String.prototype.search` (returns the
+ * match index, or -1). The TS reference VM is covered in regex-bytecode.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function search(pattern: string, input: string): Promise<number> {
+  const src = `export function run(): number { return ${JSON.stringify(input)}.search(/${pattern}/); }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { run(): number }).run();
+}
+
+describe("#1959 native RegExp empty-iteration progress guard", () => {
+  // The exact repros from the issue file — nullable quantifier bodies.
+  const nullableCases: Array<[string, string]> = [
+    ["(?:a?)*", "b"], // empty match at 0 — was a 3s "no match"
+    ["(?:a?)*", "aab"], // consumes "aa" then exits
+    ["(a?)*x", "bbb"], // no match, must be fast (no cap burn)
+    ["(a*)*", "aaa"], // nested nullable stars
+    ["(a*)*", ""], // empty input
+    ["(?:)*", "abc"], // empty body star
+    ["(a*)+", ""], // nullable plus on empty input
+    ["(a*)+", "aaab"], // nullable plus consuming
+    ["(?:x*)*y", "xxxy"], // nullable inner consumed by outer
+  ];
+
+  for (const [pattern, input] of nullableCases) {
+    it(`/${pattern}/ on ${JSON.stringify(input)} matches native`, async () => {
+      const expected = input.search(new RegExp(pattern));
+      expect(await search(pattern, input)).toBe(expected);
+    });
+  }
+
+  it("pathological pattern no longer burns the step cap (fast no-match)", async () => {
+    const src = `export function run(): boolean { return /(a?)*x/.test("bbbbbbbbbbbbbbbbbbbb"); }`;
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const t0 = Date.now();
+    // boolean export marshals as i32 (0/1), not a JS boolean.
+    const ret = (instance.exports as { run(): number }).run();
+    const dt = Date.now() - t0;
+    expect(ret).toBe(0);
+    expect(dt).toBeLessThan(500); // was multiple seconds before the guard
+  });
+
+  // Non-nullable quantifiers (no scratch slot allocated) must be unaffected.
+  const controlCases: Array<[string, string]> = [
+    ["a*", "aaab"],
+    ["a+", "aaab"],
+    ["a+b", "xxb"],
+    ["(ab)+", "ababab"],
+    ["[0-9]+", "ab123"],
+  ];
+
+  for (const [pattern, input] of controlCases) {
+    it(`control /${pattern}/ on ${JSON.stringify(input)} unregressed`, async () => {
+      const expected = input.search(new RegExp(pattern));
+      expect(await search(pattern, input)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Native RegExp VM (standalone backend): a nullable quantifier body (`/(?:a?)*/`, `/(a*)*/`, …) loops pushing backtrack frames until the 1,000,000-step cap. Cap exhaustion is reported as **"no match"** — a silent wrong answer plus a multi-second perf cliff at every scan position.

`/(?:a?)*/.test("b")` returned `false` in ~3 s; Node returns `true` (empty match at 0).

## Fix

Implements the §22.2.2.3.1 RepeatMatcher empty-iteration guard via a new `PROGRESS` opcode (`ReOp.PROGRESS = 13`):

- The compiler allocates one **scratch capture slot** per nullable star/plus (`nScratch` on `CompiledRegex` / the `$NativeRegExp` struct), appended after the real capture slots.
- The loop records `sp` at each iteration's entry (`SAVE scratch`); after the body, `PROGRESS scratch` fails the iteration when `sp` is unchanged (empty match), so backtracking takes the quantifier's exit arm.
- `canMatchEmpty` decides nullability at compile time (over-approximating). **Non-nullable quantifiers allocate no scratch slot and emit the original tight encoding** — the common case is byte-for-byte unchanged.
- `plus` keeps its mandatory first match unguarded (min=1), lowering the rest as a guarded star, so `(a?)+` on `"b"` still matches empty.
- `nScratch` threaded through caps-array sizing at every VM entry (search/exec + `__regex_replace` / `__regex_split` / `__regex_match_all`).

## Tests

- `tests/issue-1959.test.ts` — 15 cases, all match Node `RegExp` on the standalone backend (nullable repros + non-nullable controls + a fast-no-match stress test).
- `regex-bytecode.test.ts` (277) and `issue-1539-standalone-regex-replace.test.ts` (17) green — no regression to existing regex paths.

(Unrelated pre-existing failure noted in the issue file: `issue-1539-standalone-regex.test.ts` "refuses unicode flag (u)" fails on clean main too; not touched here.)

Closes #1959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)