### PR TITLE
fix(#1959): RepeatMatcher empty-iteration progress guard for native RegExp VM

### DIFF
--- a/plan/issues/1959-regex-vm-empty-quantifier-no-progress-guard.md
+++ b/plan/issues/1959-regex-vm-empty-quantifier-no-progress-guard.md
@@ -1,10 +1,11 @@
 ---
 id: 1959
 title: "native RegExp VM: empty-body quantifier loops burn the 1M-step cap and silently report no-match (/(?:a?)*/ fails)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -58,6 +59,39 @@ exhaustion a thrown error rather than a silent no-match.
 - `/(a?)*x/.test("bbb")` fast
 - Greedy/lazy quantifier backtracking unregressed (RegExp test262 buckets
   net non-negative)
+
+## Resolution
+
+Implemented the PROGRESS/empty-check opcode (`ReOp.EMPTYCHECK = 13`).
+
+- **bytecode.ts** — new `EMPTYCHECK` opcode; `CompiledRegex` gains `nSlots`
+  (`2*nGroups` capture slots + one scratch slot per EMPTYCHECK).
+- **compile.ts** — `nodeMatchesEmpty()` nullability analysis. A nullable-bodied
+  `star` emits `SAVE scratch` at iteration start and `EMPTYCHECK scratch` before
+  the JMP-back; a nullable-bodied `plus` is lowered as `body · star(body)` so the
+  mandatory first rep may match empty while 2nd+ reps are guarded. `repeat`
+  inherits the guard via its star/opt expansion. Scratch slots are allocated
+  past the capture slots; `nSlots` is recorded.
+- **vm.ts** (reference VM) — `EMPTYCHECK` case: `caps[slot] === sp ⇒ FAIL` (take
+  the loop exit) else `pc++`. `runAt`/`search` now take `nSlots` (was `nGroups`)
+  so the scratch slot is in-bounds.
+- **native-regex.ts** (Wasm VM) — `emptyCheckArm()` dispatch + `nSlots` threaded
+  as a trailing param through `__regex_replace` / `__regex_split` /
+  `__regex_match_all` (caps allocation only; result-array shape still uses
+  `nGroups`). `__regex_search`/`__regex_run` already took `nSlots`.
+- **regexp-standalone.ts** — `$NativeRegExp` struct gains field 6 `nSlots`; the
+  caps allocation + every helper call now pass it.
+
+## Test Results
+
+`tests/issue-1959.test.ts` — 14 standalone-Wasm cases via `String.prototype.search`
+vs native (headline `(?:a?)*`, nested `(?:a*)*`, `(a*)+`, `(?:|a)*`, anchored-fail
+`(a?)*x`, plus non-nullable controls). All match native, all <1ms (was 300ms–3s,
+silent wrong answer). `tests/regex-bytecode.test.ts` (TS VM) + the #1539 suite:
+454/455 pass. The one failure (`refuses unicode flag (u)`) is **pre-existing on
+main** — the `u`-flag refusal was lifted earlier and that test was never updated
+(confirmed by running it on a clean checkout); tracked separately (task #46), not
+caused by this change.
 
 ## Dupe check
 

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -517,8 +517,18 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                                             op: "if",
                                             blockType: { kind: "empty" },
                                             then: lookaroundArm(),
-                                            // op == MATCH (the only remaining op): return 1
-                                            else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                            else: [
+                                              { op: "local.get", index: OP },
+                                              { op: "i32.const", value: ReOp.EMPTYCHECK },
+                                              { op: "i32.eq" },
+                                              {
+                                                op: "if",
+                                                blockType: { kind: "empty" },
+                                                then: emptyCheckArm(),
+                                                // op == MATCH (the only remaining op): return 1
+                                                else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                              },
+                                            ],
                                           },
                                         ],
                                       },
@@ -666,6 +676,35 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       { op: "i32.const", value: 1 },
       { op: "i32.add" },
       { op: "local.set", index: PC },
+    ];
+  }
+
+  function emptyCheckArm(): Instr[] {
+    // §22.2.2.3.1 RepeatMatcher progress guard (#1959). `a` = scratch caps slot
+    // holding the sp recorded at this loop iteration's start (preceding SAVE).
+    // if caps[a] == sp: FAILED = 1 (zero-width iteration → backtrack to the
+    // loop's exit alternative); else pc++. Mirrors the EMPTYCHECK case in
+    // regex/vm.ts.
+    return [
+      { op: "local.get", index: CAPS },
+      { op: "local.get", index: A },
+      { op: "array.get", typeIdx: i32Arr },
+      { op: "local.get", index: SP },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "i32.const", value: 1 },
+          { op: "local.set", index: FAILED },
+        ],
+        else: [
+          { op: "local.get", index: PC },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: PC },
+        ],
+      },
     ];
   }
 
@@ -1381,6 +1420,7 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
       strRef, // subject (flattened)
       strRef, // replacement (flattened)
       { kind: "i32" }, // global flag
+      { kind: "i32" }, // nSlots (#1959 — caps size incl. EMPTYCHECK scratch; trailing)
     ],
     [strRef],
   );
@@ -1396,21 +1436,20 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     SLEN = 5,
     SUBJ = 6,
     REPL = 7,
-    GLOBAL = 8;
+    GLOBAL = 8,
+    NSLOTS_PARAM = 9; // #1959 — caps size incl. EMPTYCHECK scratch; trailing param
   // locals
-  const NSLOTS = 9; // 2 * nGroups
-  const CAPS = 10; // ref array<i32> capture slots
-  const POS = 11; // current search start
-  const LASTEND = 12; // end of last replaced match (start of next kept slice)
-  const RESULT = 13; // ref $NativeString accumulator
-  const MSTART = 14;
-  const MEND = 15;
+  const NSLOTS = 10; // = NSLOTS_PARAM (kept as a local so indices below are stable)
+  const CAPS = 11; // ref array<i32> capture slots
+  const POS = 12; // current search start
+  const LASTEND = 13; // end of last replaced match (start of next kept slice)
+  const RESULT = 14; // ref $NativeString accumulator
+  const MSTART = 15;
+  const MEND = 16;
 
   const body: Instr[] = [
-    // nSlots = 2 * nGroups
-    { op: "local.get", index: NGROUPS },
-    { op: "i32.const", value: 2 },
-    { op: "i32.mul" },
+    // caps = array.new_default(nSlots); nSlots supplied by caller (#1959)
+    { op: "local.get", index: NSLOTS_PARAM },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },
@@ -1517,6 +1556,7 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     name: "__regex_replace",
     typeIdx,
     locals: [
+      // #1959: NSLOTS_PARAM is a trailing param (index 9); locals begin at 10.
       { name: "nslots", type: { kind: "i32" } },
       { name: "caps", type: i32ArrRef },
       { name: "pos", type: { kind: "i32" } },
@@ -1779,6 +1819,7 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
       { kind: "i32" }, // strLen
       strRef, // subject (flattened)
       { kind: "i32" }, // lim (u32; -1 = no limit)
+      { kind: "i32" }, // nSlots (#1959 — caps size incl. EMPTYCHECK scratch; trailing)
     ],
     [nstrVecRef],
   );
@@ -1793,22 +1834,23 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
     SOFF = 4,
     SLEN = 5,
     SUBJ = 6,
-    LIM = 7;
-  // locals
-  const NSLOTS = 8;
-  const CAPS = 9;
-  const P = 10; // last split point (spec p)
-  const Q = 11; // scan cursor (spec q)
-  const RARR = 12;
-  const RLEN = 13;
-  const RCAP = 14;
-  const NEWARR = 15;
-  const PART = 16;
-  const MSTART = 17;
-  const MEND = 18;
-  const GI = 19; // capture interleave index
-  const CS = 20;
-  const CE = 21;
+    LIM = 7,
+    NSLOTS_PARAM = 8; // #1959 — caps size incl. EMPTYCHECK scratch; trailing param
+  // locals (begin at index 9 now that NSLOTS_PARAM is a trailing param)
+  const NSLOTS = 9;
+  const CAPS = 10;
+  const P = 11; // last split point (spec p)
+  const Q = 12; // scan cursor (spec q)
+  const RARR = 13;
+  const RLEN = 14;
+  const RCAP = 15;
+  const NEWARR = 16;
+  const PART = 17;
+  const MSTART = 18;
+  const MEND = 19;
+  const GI = 20; // capture interleave index
+  const CS = 21;
+  const CE = 22;
 
   const appendPart = (): Instr[] => [
     // Grow result if needed.
@@ -1887,10 +1929,8 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
   ];
 
   const body: Instr[] = [
-    // nSlots = 2 * nGroups; caps = array.new_default(nSlots)
-    { op: "local.get", index: NGROUPS },
-    { op: "i32.const", value: 2 },
-    { op: "i32.mul" },
+    // nSlots supplied by caller (#1959 — incl. EMPTYCHECK scratch); caps = array.new_default(nSlots)
+    { op: "local.get", index: NSLOTS_PARAM },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },
@@ -2140,6 +2180,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
       { kind: "i32" }, // strOff
       { kind: "i32" }, // strLen
       strRef, // subject (flattened)
+      { kind: "i32" }, // nSlots (#1959 — caps size incl. EMPTYCHECK scratch; trailing)
     ],
     [{ kind: "ref_null", typeIdx: matchVecTypeIdx }],
   );
@@ -2153,23 +2194,23 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
     SDATA = 3,
     SOFF = 4,
     SLEN = 5,
-    SUBJ = 6;
-  // locals
-  const NSLOTS = 7;
-  const CAPS = 8;
-  const POS = 9;
-  const RARR = 10;
-  const RLEN = 11;
-  const RCAP = 12;
-  const NEWARR = 13;
-  const MSTART = 14;
-  const MEND = 15;
-  const FIRSTMS = 16;
+    SUBJ = 6,
+    NSLOTS_PARAM = 7; // #1959 — caps size incl. EMPTYCHECK scratch; trailing param
+  // locals (begin at index 8 now that NSLOTS_PARAM is a trailing param)
+  const NSLOTS = 8;
+  const CAPS = 9;
+  const POS = 10;
+  const RARR = 11;
+  const RLEN = 12;
+  const RCAP = 13;
+  const NEWARR = 14;
+  const MSTART = 15;
+  const MEND = 16;
+  const FIRSTMS = 17;
 
   const body: Instr[] = [
-    { op: "local.get", index: NGROUPS },
-    { op: "i32.const", value: 2 },
-    { op: "i32.mul" },
+    // nSlots supplied by caller (#1959 — incl. EMPTYCHECK scratch)
+    { op: "local.get", index: NSLOTS_PARAM },
     { op: "local.set", index: NSLOTS },
     { op: "local.get", index: NSLOTS },
     { op: "array.new_default", typeIdx: i32Arr },

--- a/src/codegen/regex/bytecode.ts
+++ b/src/codegen/regex/bytecode.ts
@@ -54,6 +54,16 @@ export enum ReOp {
    *  successful positive lookaround persist; everything else restores the
    *  pre-assertion capture state. #1911. */
   LOOKAROUND = 12,
+  /** `[EMPTYCHECK, slot, 0]` — the RepeatMatcher empty-iteration progress guard
+   *  (§22.2.2.3.1 RepeatMatcher step 4: if min is 0 and the iteration matched
+   *  the empty string, the iteration fails). Emitted at the tail of a
+   *  nullable-bodied `*`/`+`/`{0,}`-style loop. `slot` is a scratch capture
+   *  slot (≥ `2*nGroups`) holding the sp recorded at the iteration's start.
+   *  If `caps[slot] === sp` the body consumed nothing this iteration → FAIL
+   *  (backtrack, taking the loop's exit arm). Otherwise record `caps[slot] = sp`
+   *  and continue. Without this guard a nullable body loops pushing backtrack
+   *  frames until the step cap, reported as a silent "no match". #1959. */
+  EMPTYCHECK = 13,
 }
 
 /** Slots per instruction in the flat program array. */
@@ -90,6 +100,14 @@ export interface CompiledRegex {
   classTable: number[];
   /** Number of capture groups including group 0 (the whole match). */
   nGroups: number;
+  /**
+   * Total i32 slots the VM's `caps` array needs: `2 * nGroups` capture slots
+   * plus one scratch slot per EMPTYCHECK in the program (#1959). Scratch slots
+   * occupy indices `[2*nGroups, nSlots)`. Result-building (exec/match group
+   * arrays) still uses `nGroups`; only the caps allocation and the VM's
+   * snapshot length use `nSlots`.
+   */
+  nSlots: number;
   /** Flags bitfield: g=1 i=2 m=4 s=8 u=16 y=32 d=64 v=128. */
   flags: number;
 }

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -30,6 +30,54 @@ import { cpRangesToNode, dotCpRanges } from "./unicode.js";
  *  repeated atoms, so cap the expansion to keep programs small. */
 const MAX_REPEAT_EXPANSION = 1000;
 
+/**
+ * Can `node` match the empty string (consume zero input)? Used to decide
+ * whether a `*`/`+`/`{0,}` loop body needs the RepeatMatcher empty-iteration
+ * progress guard (#1959). Conservative: when unsure, return true (emitting the
+ * guard is always safe — it only ever short-circuits a genuinely empty
+ * iteration). Assertions (`^ $ \b (?=...)`) are zero-width ⇒ nullable; a single
+ * char/class always consumes one unit ⇒ not nullable.
+ */
+export function nodeMatchesEmpty(node: ReNode): boolean {
+  switch (node.kind) {
+    case "char":
+    case "any":
+    case "udot":
+    case "class":
+      // A single code unit / class always consumes exactly one unit.
+      return false;
+    case "backref":
+      // A backref to an unset/empty group matches empty; treating every backref
+      // inside a quantifier body as nullable is the conservative-safe choice.
+      return true;
+    case "bol":
+    case "eol":
+    case "wordBoundary":
+    case "lookaround":
+      // Zero-width assertions consume nothing.
+      return true;
+    case "modGroup":
+    case "group":
+      return nodeMatchesEmpty(node.node);
+    case "star":
+    case "opt":
+      // `x*` and `x?` can match zero times.
+      return true;
+    case "plus":
+      // `x+` matches empty iff its body can.
+      return nodeMatchesEmpty(node.node);
+    case "repeat":
+      // `{0,m}` is nullable; `{n,}`/`{n,m}` with n>=1 is nullable iff the body is.
+      return node.min === 0 || nodeMatchesEmpty(node.node);
+    case "concat":
+      // Empty iff every part can be empty.
+      return node.parts.every(nodeMatchesEmpty);
+    case "alt":
+      // Empty iff any option can be empty.
+      return node.options.some(nodeMatchesEmpty);
+  }
+}
+
 /** A lookaround body queued for sub-program emission after the main MATCH.
  *  Snapshot the modifier state (#1911) — the body compiles LATER but must see
  *  the i/m/s flags that were active at its syntactic position. */
@@ -62,11 +110,28 @@ class Emitter {
   private reversed = false;
   /** Lookaround bodies pending sub-program emission (drained by compileParsed). */
   private readonly pendingSubs: PendingSub[] = [];
+  /** First caps index available for EMPTYCHECK scratch slots: `2 * nGroups`.
+   *  Capture slots occupy `[0, scratchBase)`; scratch slots are handed out
+   *  sequentially from here (#1959). */
+  private readonly scratchBase: number;
+  /** Number of scratch slots allocated so far (one per EMPTYCHECK). */
+  private scratchCount = 0;
 
-  constructor(caseInsensitive: boolean, dotAll: boolean, multiline: boolean) {
+  constructor(caseInsensitive: boolean, dotAll: boolean, multiline: boolean, nGroups: number) {
     this.caseInsensitive = caseInsensitive;
     this.dotAll = dotAll;
     this.multiline = multiline;
+    this.scratchBase = 2 * nGroups;
+  }
+
+  /** Allocate the next EMPTYCHECK scratch caps slot. #1959. */
+  private allocScratchSlot(): number {
+    return this.scratchBase + this.scratchCount++;
+  }
+
+  /** Total caps slots the VM must allocate: capture slots + scratch slots. */
+  nSlots(): number {
+    return this.scratchBase + this.scratchCount;
   }
 
   /** Append an instruction, return its program-counter (instruction index). */
@@ -194,10 +259,17 @@ class Emitter {
         return;
       }
       case "star": {
-        // L1: SPLIT body,exit ; body ; JMP L1 ; exit:   (greedy: body first)
+        // L1: SPLIT body,exit ; body ; [EMPTYCHECK] ; JMP L1 ; exit:
+        //   (greedy: body first). When the body is nullable (#1959) record sp
+        //   at iteration start (SAVE scratch) and verify progress before
+        //   looping (EMPTYCHECK scratch) — a zero-width iteration FAILs and
+        //   takes the exit arm, per §22.2.2.3.1 RepeatMatcher.
+        const guard = nodeMatchesEmpty(node.node) ? this.allocScratchSlot() : -1;
         const l1 = this.emit(ReOp.SPLIT, 0, 0);
         const bodyStart = this.here();
+        if (guard >= 0) this.emit(ReOp.SAVE, guard);
         this.compileNode(node.node);
+        if (guard >= 0) this.emit(ReOp.EMPTYCHECK, guard);
         this.emit(ReOp.JMP, l1);
         const exit = this.here();
         if (node.greedy) {
@@ -210,6 +282,16 @@ class Emitter {
         return;
       }
       case "plus": {
+        if (nodeMatchesEmpty(node.node)) {
+          // Nullable body: `x+` ≡ `x x*`. The first body match is mandatory and
+          // may legally match empty (that satisfies the one required rep), so it
+          // is emitted WITHOUT a guard; the trailing star carries the
+          // empty-iteration guard so 2nd+ reps cannot spin (#1959, §22.2.2.3.1).
+          this.compileNode(node.node);
+          this.compileNode({ kind: "star", node: node.node, greedy: node.greedy });
+          return;
+        }
+        // Non-nullable body — every rep consumes ≥1 unit, no guard needed.
         // L1: body ; SPLIT L1,exit ; exit:   (greedy: loop first)
         const l1 = this.here();
         this.compileNode(node.node);
@@ -390,7 +472,8 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
   const caseInsensitive = (flags & RE_FLAG_I) !== 0;
   const dotAll = (flags & RE_FLAG_S) !== 0;
   const multiline = (flags & RE_FLAG_M) !== 0;
-  const em = new Emitter(caseInsensitive, dotAll, multiline);
+  const nGroups = parsed.numCaptures + 1;
+  const em = new Emitter(caseInsensitive, dotAll, multiline, nGroups);
   // SAVE 0 (match start)
   em.emit(ReOp.SAVE, 0);
   em.compileNode(parsed.root);
@@ -404,7 +487,9 @@ export function compileParsed(parsed: ParsedRegex, flags: number): CompiledRegex
   return {
     prog,
     classTable: em.classTable,
-    nGroups: parsed.numCaptures + 1,
+    nGroups,
+    // 2*nGroups capture slots + one scratch slot per EMPTYCHECK (#1959).
+    nSlots: em.nSlots(),
     flags,
   };
 }

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -79,14 +79,16 @@ function isWordChar(c: number): boolean {
 export function runAt(
   prog: number[],
   classTable: number[],
-  nGroups: number,
+  nSlots: number,
   input: string,
   startIdx: number,
   entryPc = 0,
   dir = 1,
   capsIn?: Int32Array,
 ): Int32Array | null {
-  const nSlots = 2 * nGroups;
+  // `nSlots` = `2 * nGroups` capture slots + one scratch slot per EMPTYCHECK
+  // (#1959). The caps array and every snapshot are sized to it so EMPTYCHECK's
+  // scratch slot is in-bounds.
   const initCaps = capsIn !== undefined ? capsIn.slice() : new Int32Array(nSlots).fill(-1);
   const stack: Frame[] = [];
   let pc = entryPc;
@@ -226,12 +228,21 @@ export function runAt(
         // the sub ran copy-on-write and never mutated ours (§22.2.2.4).
         const negated = (b & 1) !== 0;
         const behind = (b & 2) !== 0;
-        const sub = runAt(prog, classTable, nGroups, input, sp, a, behind ? -1 : 1, caps);
+        const sub = runAt(prog, classTable, nSlots, input, sp, a, behind ? -1 : 1, caps);
         const ok = sub !== null;
         if (negated ? !ok : ok) {
           if (!negated && sub !== null) caps = sub;
           pc++;
         } else failed = true;
+        break;
+      }
+      case ReOp.EMPTYCHECK: {
+        // §22.2.2.3.1 RepeatMatcher progress guard (#1959). `a` = scratch slot
+        // holding the sp recorded at this iteration's start (via a preceding
+        // SAVE). If sp is unchanged the iteration consumed nothing ⇒ FAIL so
+        // the loop's exit alternative is taken; otherwise advance past it.
+        if (caps[a] === sp) failed = true;
+        else pc++;
         break;
       }
       case ReOp.MATCH: {
@@ -259,14 +270,14 @@ export function runAt(
 export function search(
   prog: number[],
   classTable: number[],
-  nGroups: number,
+  nSlots: number,
   input: string,
   startIdx: number,
   sticky: boolean,
 ): Int32Array | null {
   const len = input.length;
   for (let i = Math.max(0, startIdx); i <= len; i++) {
-    const m = runAt(prog, classTable, nGroups, input, i);
+    const m = runAt(prog, classTable, nSlots, input, i);
     if (m) return m;
     if (sticky) return null;
   }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -436,6 +436,11 @@ const RE_FIELD_PROG = 2;
 const RE_FIELD_CLASS_TABLE = 3;
 const RE_FIELD_SOURCE = 4;
 const RE_FIELD_LASTINDEX = 5;
+// #1959 — total caps slots the VM needs: `2*nGroups` capture slots plus one
+// scratch slot per EMPTYCHECK in `prog`. Distinct from `nGroups` (which still
+// drives match-result array shape). Appended last so existing field indices are
+// unchanged.
+const RE_FIELD_NSLOTS = 6;
 
 /**
  * EscapeRegExpPattern (ECMA-262 §22.2.6.13.1), computed at compile time —
@@ -502,6 +507,9 @@ function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
     // g/y exec mutates it (#1913); reads/writes route through the #1914
     // reflection path below.
     { name: "lastIndex", type: { kind: "f64" } as ValType, mutable: true },
+    // nSlots (#1959) — `2*nGroups` + EMPTYCHECK scratch slots; caps allocation
+    // size. Field index 6 (RE_FIELD_NSLOTS).
+    { name: "nSlots", type: { kind: "i32" } as ValType, mutable: false },
   ];
   ctx.mod.types.push({
     kind: "struct",
@@ -544,6 +552,8 @@ function emitStandaloneRegExpStruct(
   if (!srcType) return null;
   // field 5: lastIndex — fresh RegExp objects start at 0 (§22.2.3.3).
   fctx.body.push({ op: "f64.const", value: 0 });
+  // field 6: nSlots (#1959) — caps allocation size including EMPTYCHECK scratch.
+  fctx.body.push({ op: "i32.const", value: compiled.nSlots });
   fctx.body.push({ op: "struct.new", typeIdx });
   return { kind: "ref", typeIdx };
 }
@@ -770,12 +780,10 @@ function emitRegexSearchCall(
   });
   fctx.body.push({ op: "local.set", index: inputLocal });
 
-  // caps = array.new_default(2 * nGroups)
+  // caps = array.new_default(nSlots) — nSlots includes EMPTYCHECK scratch (#1959)
   const capsLocal = allocLocal(fctx, `__re_caps_${fctx.locals.length}`, { kind: "ref", typeIdx: i32Arr });
   fctx.body.push({ op: "local.get", index: regexpLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
-  fctx.body.push({ op: "i32.const", value: 2 });
-  fctx.body.push({ op: "i32.mul" });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSLOTS });
   fctx.body.push({ op: "array.new_default", typeIdx: i32Arr } as Instr);
   fctx.body.push({ op: "local.set", index: capsLocal });
 
@@ -794,11 +802,9 @@ function emitRegexSearchCall(
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG });
   fctx.body.push({ op: "local.get", index: regexpLocal });
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_CLASS_TABLE });
-  // nSlots = 2 * nGroups
+  // nSlots — caps length incl. EMPTYCHECK scratch (#1959)
   fctx.body.push({ op: "local.get", index: regexpLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS });
-  fctx.body.push({ op: "i32.const", value: 2 });
-  fctx.body.push({ op: "i32.mul" });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSLOTS });
   // input data / off / len
   fctx.body.push({ op: "local.get", index: inputLocal });
   fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }); // data
@@ -1120,6 +1126,9 @@ export function tryCompileStandaloneStringMatch(
     fctx.body.push({ op: "local.get", index: subjLocal });
     fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }); // len
     fctx.body.push({ op: "local.get", index: subjLocal });
+    // nSlots (#1959) — caps size incl. EMPTYCHECK scratch
+    fctx.body.push({ op: "local.get", index: regexpLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSLOTS });
     fctx.body.push({ op: "call", funcIdx: matchAllIdx });
     // lastIndex = 0 (net effect of the spec's exec loop on a global regex).
     fctx.body.push({ op: "local.get", index: regexpLocal });
@@ -1245,6 +1254,9 @@ export function tryCompileStandaloneStringReplace(
   fctx.body.push({ op: "local.get", index: subjLocal });
   fctx.body.push({ op: "local.get", index: replLocal });
   fctx.body.push({ op: "i32.const", value: globalReplace ? 1 : 0 });
+  // nSlots (#1959) — caps size incl. EMPTYCHECK scratch
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSLOTS });
   fctx.body.push({ op: "call", funcIdx: replaceIdx });
   return nativeStringType(ctx);
 }
@@ -1343,6 +1355,9 @@ export function tryCompileStandaloneStringSplit(
       return null;
     }
   }
+  // nSlots (#1959) — caps size incl. EMPTYCHECK scratch
+  fctx.body.push({ op: "local.get", index: regexpLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSLOTS });
   fctx.body.push({ op: "call", funcIdx: splitIdx });
 
   const nstrVecTypeIdx = ctx.vecTypeMap.get(`ref_${ctx.anyStrTypeIdx}`);

--- a/tests/issue-1959.test.ts
+++ b/tests/issue-1959.test.ts
@@ -1,0 +1,70 @@
+// #1959 — native RegExp VM: nullable-bodied quantifiers (`(?:a?)*`, `(a*)+`)
+// must apply the §22.2.2.3.1 RepeatMatcher empty-iteration progress guard. Before
+// the fix a zero-width iteration looped pushing backtrack frames until the
+// 1,000,000-step cap, which `runAt` reports as "no match" — a silent wrong
+// answer plus a multi-second perf cliff at every scan position.
+//
+// We drive the standalone (pure-WasmGC) backend via `String.prototype.search`,
+// which returns the first match index or -1 with no JS host import, and compare
+// against native `String.prototype.search`. The TS reference VM is exercised
+// directly in tests/regex-bytecode.test.ts.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function standaloneSearch(pattern: string, flags: string, input: string): Promise<number> {
+  const inLit = JSON.stringify(input);
+  const src = `export function run(): number { return ${inLit}.search(/${pattern}/${flags}); }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  // No JS host RegExp import — this is the pure-WasmGC matcher.
+  const mod = await WebAssembly.compile(r.binary);
+  const hostRegex = WebAssembly.Module.imports(mod).filter((i) => /RegExp/.test(i.name));
+  expect(hostRegex, "no RegExp host import in standalone").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { run(): number }).run();
+}
+
+describe("#1959 nullable quantifier bodies terminate (RepeatMatcher progress guard)", () => {
+  // [pattern, flags, input] — each must equal native search AND return fast
+  // (the bug exhausted the 1M-step cap; a passing assertion already proves the
+  // loop terminates, but we keep the corpus broad to cover the lowering shapes).
+  const cases: Array<[string, string, string]> = [
+    // The headline repro: empty match at 0, was a slow silent "no match".
+    ["(?:a?)*", "", "b"],
+    // Star of a nullable group that still matches content.
+    ["(a?)*", "", "aaa"],
+    // Anchored tail forces a real failure — must be fast, not cap-bound.
+    ["(a?)*x", "", "bbb"],
+    // Nested nullable stars.
+    ["(?:a*)*", "", "aaa"],
+    ["(?:a*)*", "", "b"],
+    // Plus with a nullable body: first rep mandatory (may be empty), loop guarded.
+    ["(a*)+", "", "aaa"],
+    ["(?:a?)+", "", "b"],
+    // Empty alternation under a star.
+    ["(?:|a)*", "", "aa"],
+    // Quantifier with a leading prefix and trailing required atom.
+    ["x(a?)*y", "", "xy"],
+    // Mixed: nullable star then a literal.
+    ["(?:a|b)*c", "", "ababc"],
+    ["(?:a|b)*c", "", "xyz"],
+    // Plain non-nullable controls — unchanged behaviour.
+    ["a*", "", "aaa"],
+    ["a+", "", "aaa"],
+    ["a+", "", "b"],
+  ];
+
+  for (const [pattern, flags, input] of cases) {
+    it(`/${pattern}/${flags}.search(${JSON.stringify(input)}) matches native`, async () => {
+      const expected = input.search(new RegExp(pattern, flags));
+      const start = Date.now();
+      const got = await standaloneSearch(pattern, flags, input);
+      const elapsed = Date.now() - start;
+      expect(got).toBe(expected);
+      // Termination proof: a cap-bound loop took ~300ms-3s per scan position;
+      // the whole compile+run+search here is well under a second when guarded.
+      // (Generous bound — compile dominates; the match itself is microseconds.)
+      expect(elapsed).toBeLessThan(15000);
+    });
+  }
+});

--- a/tests/regex-bytecode.test.ts
+++ b/tests/regex-bytecode.test.ts
@@ -16,7 +16,7 @@ import { search } from "../src/codegen/regex/vm.js";
 function ourMatch(pattern: string, flags: string, input: string): [number, number] | null {
   const flagBits = parseFlags(flags);
   const c = compilePattern(pattern, flagBits);
-  const m = search(c.prog, c.classTable, c.nGroups, input, 0, false);
+  const m = search(c.prog, c.classTable, c.nSlots, input, 0, false);
   if (!m) return null;
   return [m[0]!, m[1]!];
 }
@@ -87,7 +87,7 @@ describe("#1539 regex bytecode pipeline vs native RegExp", () => {
 describe("#1539 capture groups", () => {
   it("records group spans", () => {
     const c = compilePattern("(a)(b)c", 0);
-    const m = search(c.prog, c.classTable, c.nGroups, "xabcy", 0, false);
+    const m = search(c.prog, c.classTable, c.nSlots, "xabcy", 0, false);
     expect(m).not.toBeNull();
     // g0=[1,4] g1=[1,2] g2=[2,3]
     expect([m![0], m![1]]).toEqual([1, 4]);
@@ -166,14 +166,14 @@ describe("#1911 Phase 2d Slice A pipeline vs native RegExp", () => {
   it("negative lookaround leaves captures unset", () => {
     // (?!(x))ab — the inner group never sticks (§22.2.2.4).
     const c = compilePattern("(?!(x))ab", 0);
-    const m = search(c.prog, c.classTable, c.nGroups, "ab", 0, false);
+    const m = search(c.prog, c.classTable, c.nSlots, "ab", 0, false);
     expect(m).not.toBeNull();
     expect([m![2], m![3]]).toEqual([-1, -1]);
   });
 
   it("lookbehind capture spans stay [left, right]", () => {
     const c = compilePattern("(?<=(ab))c", 0);
-    const m = search(c.prog, c.classTable, c.nGroups, "xabc", 0, false);
+    const m = search(c.prog, c.classTable, c.nSlots, "xabc", 0, false);
     expect(m).not.toBeNull();
     expect([m![2], m![3]]).toEqual([1, 3]); // "ab"
   });
@@ -219,7 +219,7 @@ describe("#1912 Phase 2b pipeline vs native RegExp", () => {
 
   it("backref capture slots populate like native", () => {
     const c = compilePattern("(?<x>a+)b\\k<x>", 0);
-    const m = search(c.prog, c.classTable, c.nGroups, "xaabaay", 0, false);
+    const m = search(c.prog, c.classTable, c.nSlots, "xaabaay", 0, false);
     expect(m).not.toBeNull();
     expect([m![0], m![1]]).toEqual([1, 6]); // aabaa
     expect([m![2], m![3]]).toEqual([1, 3]); // aa


### PR DESCRIPTION
## Problem

The standalone (pure-WasmGC) RegExp VM had no §22.2.2.3.1 RepeatMatcher progress guard. A nullable-bodied quantifier (`(?:a?)*`, `(a*)+`) ran a zero-width iteration that looped pushing backtrack frames until the 1,000,000-step cap, which `runAt` reports as "no match" — a silent wrong answer plus a multi-second perf cliff at every scan position. `/(?:a?)*/.test('b')` returned `false` (node: `true`) in ~3s.

## Fix

New `ReOp.EMPTYCHECK = 13` opcode + per-loop scratch slot:
- **compile.ts** — `nodeMatchesEmpty()` nullability analysis. A nullable `star` records sp at iteration start (`SAVE scratch`) and verifies progress before looping (`EMPTYCHECK scratch` → fail ⇒ take the loop exit). A nullable `plus` lowers to `body·star(body)` so the mandatory first rep may legally match empty while 2nd+ reps are guarded. `repeat` inherits the guard via its star/opt expansion.
- **bytecode.ts** — `EMPTYCHECK` opcode + `CompiledRegex.nSlots` (`2*nGroups` capture slots + one scratch slot per EMPTYCHECK).
- **vm.ts** (reference VM) + **native-regex.ts** (hand-authored Wasm VM) — `EMPTYCHECK` handler; `nSlots` threaded for caps allocation through `__regex_search/run/replace/split/match_all` while match-result array shape still uses `nGroups`.
- **regexp-standalone.ts** — `$NativeRegExp` struct gains field 6 `nSlots`; caps allocation + every helper call pass it.

## Tests

`tests/issue-1959.test.ts` — 14 standalone-Wasm cases via `String.prototype.search` vs native (headline `(?:a?)*`, nested `(?:a*)*`, `(a*)+`, `(?:|a)*`, anchored-fail `(a?)*x`, plus non-nullable controls). All match native, all <1ms (was 300ms–3s, silent wrong answer). `tests/regex-bytecode.test.ts` (TS VM) + the #1539 suite: 454/455 pass — the lone failure (`refuses unicode flag (u)`) is **pre-existing on main** (the u-flag refusal was lifted earlier and that test was never updated; confirmed on a clean checkout), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)