### PR TITLE
fix(#1960): clear capture groups between RegExp quantifier iterations

### DIFF
--- a/plan/issues/1960-regex-vm-captures-not-reset-per-iteration.md
+++ b/plan/issues/1960-regex-vm-captures-not-reset-per-iteration.md
@@ -1,10 +1,11 @@
 ---
 id: 1960
 title: "native RegExp VM: capture groups not reset between quantifier iterations"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -64,3 +65,41 @@ backtrack-aware (restore on backtrack like SAVE).
 
 #1539's Phase 2b `.exec` capture work has no reset note; no grep hit for
 "capture reset"/RepeatMatcher in plan/issues.
+
+## Resolution (2026-06-12)
+
+Added a `CLEAR loSlot,hiSlot` opcode (`ReOp.CLEAR = 14`) that resets capture
+slots `[loSlot..hiSlot]` to -1. The compiler emits it at the head of every
+star/plus body (`emitClearForBody`), using a new `captureSpan` helper to find
+the body's group-index span `[lo, hi]` → slot range `[2*lo, 2*hi+1]`. Bodies
+with no capture groups emit no CLEAR (common case unchanged). CLEAR runs once
+per iteration (the loop back-edge re-enters at the body head), so a group that
+doesn't participate in the final iteration reads as unset.
+
+CLEAR mutates the caps array in place (like SAVE); the enclosing SPLIT's caps
+snapshot restores it on backtrack, so the reset is correctly undone when an
+iteration is abandoned. Implemented in both the reference VM (`vm.ts`) and the
+hand-authored Wasm VM (`native-regex.ts` `clearArm()`).
+
+This builds on the #1959 PROGRESS work (same loop lowering); the branch is
+stacked on #1959 (PR #1395).
+
+### Files
+
+- `src/codegen/regex/bytecode.ts` — `ReOp.CLEAR`
+- `src/codegen/regex/compile.ts` — `captureSpan`, `emitClearForBody`, CLEAR at
+  star/plus body heads
+- `src/codegen/regex/vm.ts` — reference VM `CLEAR` dispatch
+- `src/codegen/native-regex.ts` — Wasm VM `clearArm()` dispatch
+
+## Test Results
+
+All match Node `RegExp` on the standalone backend:
+
+- `/(?:(a)|(b))+/.exec("ab")` → group 1 `undefined`, group 2 `"b"` (was group 1
+  stale `"a"`) — `test()` returns 18, matching Node
+- `/(?:(a)|(b))+/.exec("ba")` → group 1 `"a"`, group 2 `undefined`
+- `/((a)|(b))*/.exec("abab")`, `/(?:a(b)?)+/.exec("aa")` correct
+- `tests/issue-1960.test.ts` (5 cases) green
+- `regex-bytecode.test.ts` (277), replace (17), phase2b (#1912), #1914 — all
+  green, no capture regression

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -525,8 +525,18 @@ export function ensureRegexRun(ctx: CodegenContext): number {
                                                 op: "if",
                                                 blockType: { kind: "empty" },
                                                 then: progressArm(),
-                                                // op == MATCH (the only remaining op): return 1
-                                                else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                                else: [
+                                                  { op: "local.get", index: OP },
+                                                  { op: "i32.const", value: ReOp.CLEAR },
+                                                  { op: "i32.eq" },
+                                                  {
+                                                    op: "if",
+                                                    blockType: { kind: "empty" },
+                                                    then: clearArm(),
+                                                    // op == MATCH (the only remaining op): return 1
+                                                    else: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                                                  },
+                                                ],
                                               },
                                             ],
                                           },
@@ -704,6 +714,50 @@ export function ensureRegexRun(ctx: CodegenContext): number {
           { op: "local.set", index: PC },
         ],
       },
+    ];
+  }
+
+  function clearArm(): Instr[] {
+    // Reset capture slots a..b (inclusive) to -1 (§22.2.2.3.1, #1960). TMPI is
+    // the loop cursor (general i32 scratch — does not overlap backref state).
+    // Mirrors the CLEAR case in regex/vm.ts; backtrack restore is handled by
+    // the enclosing SPLIT's caps snapshot.
+    return [
+      { op: "local.get", index: A },
+      { op: "local.set", index: TMPI },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if (TMPI > B) break
+              { op: "local.get", index: TMPI },
+              { op: "local.get", index: B },
+              { op: "i32.gt_s" },
+              { op: "br_if", depth: 1 },
+              // caps[TMPI] = -1
+              { op: "local.get", index: CAPS },
+              { op: "local.get", index: TMPI },
+              { op: "i32.const", value: -1 },
+              { op: "array.set", typeIdx: i32Arr },
+              // TMPI++
+              { op: "local.get", index: TMPI },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: TMPI },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // pc++
+      { op: "local.get", index: PC },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "local.set", index: PC },
     ];
   }
 

--- a/src/codegen/regex/bytecode.ts
+++ b/src/codegen/regex/bytecode.ts
@@ -62,6 +62,14 @@ export enum ReOp {
    *  iteration (backtracking to the quantifier's exit arm). Only emitted for
    *  star/plus whose body can match the empty string. #1959. */
   PROGRESS = 13,
+  /** `[CLEAR, loSlot, hiSlot]` — reset capture slots `loSlot..hiSlot`
+   *  (inclusive) to -1. §22.2.2.3.1 RepeatMatcher clears the quantified
+   *  subtree's capture set on each repetition entry, so only the final
+   *  iteration's participation is observable. Emitted at the head of every
+   *  star/plus/repeat body that contains capture groups; the slot range is the
+   *  group span `[2*lo, 2*hi+1]`. Backtrack-aware via the usual caps snapshot
+   *  (CLEAR mutates `caps`, which SPLIT snapshots). #1960. */
+  CLEAR = 14,
 }
 
 /** Slots per instruction in the flat program array. */

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -106,6 +106,19 @@ class Emitter {
     return this.scratchBase + this.scratchCount++;
   }
 
+  /**
+   * Emit a `CLEAR` at a quantifier-iteration head that resets the body's
+   * capture-group slots to -1 (§22.2.2.3.1 RepeatMatcher, #1960). No-op when the
+   * body has no capture groups. The slot range is `[2*lo, 2*hi+1]` for the
+   * group-index span `[lo, hi]`. Lookbehind bodies (reversed) store group spans
+   * the same way, so the same range applies.
+   */
+  private emitClearForBody(body: ReNode): void {
+    const span = captureSpan(body);
+    if (span === null) return;
+    this.emit(ReOp.CLEAR, 2 * span[0], 2 * span[1] + 1);
+  }
+
   /** Add a class to the class table, return its start offset. */
   private addClass(ranges: Array<[number, number]>): number {
     const offset = this.classTable.length;
@@ -212,14 +225,17 @@ class Emitter {
         return;
       }
       case "star": {
-        // Greedy: SAVE? sp ; L1: SPLIT body,exit ; body ; PROGRESS? ; JMP L1 ; exit
+        // Greedy: SAVE? sp ; L1: SPLIT body,exit ; CLEAR? ; body ; PROGRESS? ; JMP L1 ; exit
         // A nullable body needs the empty-iteration guard (§22.2.2.3.1): record
         // sp before SPLIT, and after the body PROGRESS fails the iteration when
         // sp is unchanged, so the loop can't spin on a zero-width match (#1959).
+        // CLEAR resets the subtree's capture slots on each iteration entry so a
+        // group that doesn't participate this time reads as unset (#1960).
         const guard = canMatchEmpty(node.node) ? this.allocScratch() : -1;
         if (guard >= 0) this.emit(ReOp.SAVE, guard);
         const l1 = this.emit(ReOp.SPLIT, 0, 0);
         const bodyStart = this.here();
+        this.emitClearForBody(node.node);
         this.compileNode(node.node);
         if (guard >= 0) this.emit(ReOp.PROGRESS, guard);
         this.emit(ReOp.JMP, guard >= 0 ? l1 - 1 : l1);
@@ -243,7 +259,11 @@ class Emitter {
         //   body ; SAVE g ; L2: SPLIT body2,exit ; body2 ; PROGRESS g ; JMP L2 ; exit
         const guard = canMatchEmpty(node.node) ? this.allocScratch() : -1;
         if (guard < 0) {
+          // L1: CLEAR? ; body ; SPLIT L1,exit ; exit — CLEAR runs each iteration
+          // (the SPLIT back-edge re-enters at L1), resetting the subtree's
+          // captures so only the final iteration participates (#1960).
           const l1 = this.here();
+          this.emitClearForBody(node.node);
           this.compileNode(node.node);
           const split = this.emit(ReOp.SPLIT, 0, 0);
           const exit = this.here();
@@ -256,7 +276,9 @@ class Emitter {
           }
           return;
         }
-        // Nullable body: mandatory first match, then a guarded star.
+        // Nullable body: mandatory first match (cleared), then a guarded star
+        // (which clears on every iteration of the remaining repetitions).
+        this.emitClearForBody(node.node);
         this.compileNode(node.node);
         this.compileNode({ kind: "star", node: node.node, greedy: node.greedy });
         return;
@@ -387,6 +409,49 @@ export function canMatchEmpty(node: ReNode): boolean {
     case "alt":
       return node.options.some(canMatchEmpty);
   }
+}
+
+/**
+ * Capture-group index span of a subtree (#1960): `[min, max]` of every group's
+ * `capIndex` reachable inside `node`, or null when it contains no captures.
+ * Used to emit a `CLEAR` at each quantifier-iteration head so stale captures
+ * from an earlier iteration don't leak (§22.2.2.3.1 RepeatMatcher). Lookaround
+ * bodies are NOT descended into — their captures live in separate sub-programs
+ * governed by the lookaround's own atomic attempt, not the outer loop.
+ */
+export function captureSpan(node: ReNode): [number, number] | null {
+  let lo = Infinity;
+  let hi = -Infinity;
+  const visit = (n: ReNode): void => {
+    switch (n.kind) {
+      case "group":
+        if (n.capIndex >= 0) {
+          if (n.capIndex < lo) lo = n.capIndex;
+          if (n.capIndex > hi) hi = n.capIndex;
+        }
+        visit(n.node);
+        return;
+      case "concat":
+        for (const p of n.parts) visit(p);
+        return;
+      case "alt":
+        for (const o of n.options) visit(o);
+        return;
+      case "star":
+      case "plus":
+      case "opt":
+      case "modGroup":
+      case "repeat":
+        visit(n.node);
+        return;
+      // lookaround: separate sub-program — do not descend. char/any/udot/class/
+      // bol/eol/wordBoundary/backref define no groups.
+      default:
+        return;
+    }
+  };
+  visit(node);
+  return hi >= lo ? [lo, hi] : null;
 }
 
 /** Thrown when `{n,m}` expansion would blow past the size cap. */

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -247,6 +247,16 @@ export function runAt(
         else pc++;
         break;
       }
+      case ReOp.CLEAR: {
+        // Reset capture slots a..b (inclusive) to -1 at a quantifier-iteration
+        // head (§22.2.2.3.1, #1960) so a group that doesn't participate this
+        // iteration reads as unset. Copy-on-write like SAVE; the snapshot taken
+        // by the enclosing SPLIT restores it on backtrack.
+        caps = caps.slice();
+        for (let i = a; i <= b; i++) caps[i] = -1;
+        pc++;
+        break;
+      }
       case ReOp.MATCH: {
         return caps;
       }

--- a/tests/issue-1960.test.ts
+++ b/tests/issue-1960.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1960 — native RegExp VM must clear a quantified subtree's capture groups at
+ * each repetition entry (§22.2.2.3.1 RepeatMatcher). Previously SAVE slots from
+ * an earlier iteration persisted, so a group that did NOT participate in the
+ * final iteration still read as set — e.g. `/(?:(a)|(b))+/.exec("ab")` left
+ * group 1 holding `"a"` instead of `undefined`.
+ *
+ * The compiler now emits a CLEAR opcode at every star/plus body head. Validated
+ * on the pure-WasmGC standalone backend against Node `RegExp`.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#1960 capture groups reset between quantifier iterations", () => {
+  it("alternation under + — non-participating group reads undefined (issue repro)", async () => {
+    // /(?:(a)|(b))+/.exec("ab"): last iteration matched "b", so group 1 is
+    // undefined and group 2 is "b". Node returns 18 (10 + 'b'%10 = 10 + 8).
+    const got = await runNum(`
+      const m = /(?:(a)|(b))+/.exec("ab");
+      if (m === null) return -1;
+      let r = 0;
+      if (m[1] !== undefined) r += 100;
+      if (m[2] !== undefined) { r += 10; r += m[2].charCodeAt(0) % 10; }
+      return r;
+    `);
+    expect(got).toBe(18);
+  });
+
+  it("reverse order — group 1 participates last", async () => {
+    // /(?:(a)|(b))+/.exec("ba"): last iteration matched "a", so group 1 is "a"
+    // and group 2 is undefined.
+    const got = await runNum(`
+      const m = /(?:(a)|(b))+/.exec("ba");
+      if (m === null) return -1;
+      let r = 0;
+      if (m[1] !== undefined) r += 100;
+      if (m[2] !== undefined) r += 10;
+      return r;
+    `);
+    expect(got).toBe(100);
+  });
+
+  it("capturing star — stale group cleared when final iteration omits it", async () => {
+    // /((a)|(b))*/.exec("abab"): last iteration matched "b"; group 2 ('a')
+    // undefined, group 3 ('b') = "b".
+    const got = await runNum(`
+      const m = /((a)|(b))*/.exec("abab");
+      if (m === null) return -1;
+      let r = 0;
+      if (m[2] !== undefined) r += 100; // 'a' branch — should be cleared
+      if (m[3] !== undefined) r += 10; // 'b' branch — participated last
+      return r;
+    `);
+    expect(got).toBe(10);
+  });
+
+  it("single match group still captured (control)", async () => {
+    // /(a)(b)/.exec("ab"): both groups participate.
+    const got = await runNum(`
+      const m = /(a)(b)/.exec("ab");
+      if (m === null) return -1;
+      let r = 0;
+      if (m[1] !== undefined) r += 10;
+      if (m[2] !== undefined) r += 1;
+      return r;
+    `);
+    expect(got).toBe(11);
+  });
+
+  it("optional group inside + that never matches is undefined", async () => {
+    // /(?:a(b)?)+/.exec("aa"): the (b) never matches, must be undefined.
+    const got = await runNum(`
+      const m = /(?:a(b)?)+/.exec("aa");
+      if (m === null) return -1;
+      return m[1] === undefined ? 1 : 0;
+    `);
+    expect(got).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Native RegExp VM (standalone backend): §22.2.2.3.1 RepeatMatcher clears a quantified subtree's captures on each repetition entry, so only the **final** iteration's participation is observable. The VM kept stale SAVE slots from earlier iterations.

```ts
/(?:(a)|(b))+/.exec("ab")
```

wasm left group 1 holding `"a"` from iteration 1; Node returns group 1 `undefined`, group 2 `"b"`.

## Fix

Adds a `CLEAR loSlot,hiSlot` opcode (`ReOp.CLEAR = 14`):

- Emitted at every star/plus body head via `captureSpan` (the body's group-index span `[lo,hi]` → slot range `[2*lo, 2*hi+1]`) + `emitClearForBody`.
- CLEAR resets the body's capture slots to -1 once per iteration (the loop back-edge re-enters the body head), so a group that doesn't participate in the final iteration reads as unset.
- Mutates the caps array in place (like SAVE); the enclosing SPLIT's caps snapshot restores it on backtrack — the reset is correctly undone for abandoned iterations.
- Implemented in both the reference VM (`vm.ts`) and the hand-authored Wasm VM (`native-regex.ts` `clearArm()`).
- **Bodies with no capture groups emit no CLEAR** — common case byte-for-byte unchanged.

## Stacking

This branch is **stacked on #1959 (PR #1395)** — they share the star/plus loop lowering. The diff here is just the #1960 commit on top; once #1395 lands, this becomes a clean single-commit diff. (If the queue lands them out of order, merging main resolves cleanly — the changes are adjacent, not conflicting.)

## Tests

- `tests/issue-1960.test.ts` — 5 cases, all match Node `RegExp` on the standalone backend (issue repro + reverse order + capturing star + optional-group-in-plus + a both-participate control).
- `regex-bytecode.test.ts` (277), `issue-1539-standalone-regex-replace.test.ts` (17), `issue-1912-regex-phase2b.test.ts`, `issue-1914.test.ts` — all green, no capture regression.

Closes #1960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)