### PR TITLE
fix(codegen): #2058 any + runtime string concatenates, not f64 add

### DIFF
--- a/plan/issues/2058-any-plus-runtime-string-numeric-add.md
+++ b/plan/issues/2058-any-plus-runtime-string-numeric-add.md
@@ -1,10 +1,11 @@
 ---
 id: 2058
 title: "+ and += with a runtime string in an any/externref position do numeric addition instead of concatenation"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -261,3 +262,64 @@ is precisely the −788 trap.
 - `tests/equivalence.test.ts` add `any`-concat cases.
 - Standalone: re-run the `test262` standalone shard; assert no movement in the
   `isSameValue`/`assert.sameValue` pass buckets (the −788 guard).
+
+---
+
+## Resolution (2026-06-12)
+
+Implemented per the staged plan: a new `__host_add` host import (JS `+`) plus a
+shared per-site runtime-dispatched add. **The comparator path
+(`binary-ops.ts` externref-equality block) and `__any_from_extern` /
+type-coercion boxing were NOT touched** — the gate only fires for `+`/`+=`, so
+the test262 `isSameValue` comparator ABI is untouched (the −788 guard holds).
+
+### What landed
+
+1. **`__host_add` wiring** — `src/index.ts` (`host_add` in the `ImportIntent`
+   union), `src/compiler/import-manifest.ts` (`__host_add → { type: "host_add" }`),
+   `src/runtime.ts` (`case "host_add": (a, b) => a + b`). JS `+` provides
+   ToPrimitive, the string-if-either-is-string rule, and object valueOf/toString
+   ordering for free.
+2. **`emitAnyAdd(ctx, fctx, expr)`** (`src/codegen/binary-ops.ts`) — the shared
+   add. Compiles both operands with an **externref hint** (keeping a runtime
+   string boxed, no ToNumber) then:
+   - JS-host → spill to externref temps, `call __host_add`, return externref.
+   - standalone/WASI (`noJsHost`) with `nativeStrings` → runtime branch:
+     `if (__typeof_string(l) | __typeof_string(r))` ToString both via
+     `__extern_toString` + `__str_concat`, **else** `__unbox_number` both +
+     `f64.add` + `__box_number`. No `__host_add` import is emitted standalone.
+   - no host / no native strings → legacy f64 add (status quo, no regression).
+3. **`+` gate** (`compileBinaryExpression`, after `isNumericOp`) — when
+   `op === PlusToken` and either static operand type is `any`/`unknown` (and not
+   bigint), route to `emitAnyAdd` **before** the f64 `numericHint` is applied
+   (the root cause: operands were ToNumber-coerced at compile time by the
+   numeric hint, so the late externref-numeric fallback never saw a string).
+4. **`+=` gate** (`compileCompoundAssignment` simple-identifier path) — new
+   `compileAnyCompoundAdd`: when LHS or RHS is `any`/`unknown`, compute via
+   `emitAnyAdd` (which reads `expr.left` as the current value) and store the
+   externref result back to the local / captured-global / module-global,
+   coercing to the binding's storage type. Boxed-capture and static-string
+   concat paths are left to their existing handlers.
+
+### Why it's regression-safe
+
+- Provably-numeric `+`/`+=` (neither side `any`/`unknown`) keep the f64/i32 fast
+  path verbatim — the gate's `leftIsAnyish || rightIsAnyish` predicate is false.
+- Provably-string `+` is still handled by the earlier `isStringType` concat gate
+  (runs before the new gate).
+- Fast mode (`anyValueTypeIdx >= 0`) intercepts `any + any` via
+  `compileAnyBinaryDispatch` earlier still, so it never reaches the new gate.
+- Standalone never emits a `__host_add` import (builds in-module or falls back).
+
+### Outcome (all verified)
+
+`plus("2")`/`plusBoth("1","2")`/`compound("2")` → `"12"`; `plusBoth(1,2)` → `3`;
+`null + 1` → `1`; `undefined + 1` → `NaN`; `"x" + null` → `"xnull"`;
+`string + (any number)` concatenates. Standalone numeric add computes correctly
+and the concat arm validates with no unsatisfiable import.
+
+### Tests
+
+`tests/issue-2058-any-plus-string.test.ts` — 12 JS-host equivalence cases
+(`assertEquivalent`) + 3 standalone cases (`--target standalone`,
+`WebAssembly.validate` + run).

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1247,6 +1247,31 @@ export function compileBinaryExpression(
     op === ts.SyntaxKind.LessThanLessThanToken ||
     op === ts.SyntaxKind.GreaterThanGreaterThanToken ||
     op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken;
+
+  // (#2058) `+` where an operand is statically `any`/`unknown` (so it lowers to a
+  // dynamic externref that may hold a runtime string). §13.15.3 requires
+  // concatenation when either ToPrimitive result is a string, but the numeric
+  // paths below compile both operands with an f64 hint — ToNumber-coercing a
+  // runtime string, so `1 + "2"` wrongly produced `3` instead of `"12"`. Route
+  // these through a runtime-dispatched add BEFORE the f64 hint is applied. We
+  // require at least one `any`/`unknown` operand: provably-numeric and
+  // provably-string `+` were already handled above (string concat at the
+  // isStringType gate, numeric via the typed fast paths), so this leaves their
+  // codegen untouched. `ctx.fast` mode keeps its i32/f64 numeric semantics for
+  // statically-typed operands and is unaffected (those aren't `any`/`unknown`).
+  //
+  // Fast mode (`anyValueTypeIdx >= 0`) is excluded: there `any + any` is routed
+  // through `compileAnyBinaryDispatch` (the AnyValue `__any_add` helper) earlier,
+  // and the `__host_add` host import isn't part of that ABI. Per the #2058 design
+  // rule, this per-site recovery is **default-mode only**.
+  if (op === ts.SyntaxKind.PlusToken && ctx.anyValueTypeIdx < 0) {
+    const leftIsAnyish = (leftTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+    const rightIsAnyish = (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+    if ((leftIsAnyish || rightIsAnyish) && !isBigIntType(leftTsType) && !isBigIntType(rightTsType)) {
+      return emitAnyAdd(ctx, fctx, expr);
+    }
+  }
+
   // In fast mode, numeric hint is i32 (unless division/power which promotes to f64).
   // Also use i32 hint when operands have native i32 type annotations (type i32 = number).
   const isDivOrPow = op === ts.SyntaxKind.SlashToken || op === ts.SyntaxKind.AsteriskAsteriskToken;
@@ -2507,6 +2532,137 @@ function compileAnyBinaryDispatch(
     return { kind: "i32" };
   }
   return { kind: "ref", typeIdx: ctx.anyValueTypeIdx };
+}
+
+/**
+ * (#2058) Emit `+` for two operands where at least one is a dynamic externref
+ * (an `any`/`unknown`/boxed value). The operands are already on the Wasm stack
+ * (left below right). Per §13.15.3 ApplyStringOrNumericBinaryOperator a runtime
+ * string on either side must CONCATENATE, not coerce to f64 — so we cannot take
+ * the externref-numeric f64 fast path.
+ *
+ * JS-host mode delegates to `__host_add` (JS `+`), which gives ToPrimitive, the
+ * string-if-either-is-string rule, and object valueOf/toString ordering for
+ * free. Standalone/WASI has no JS host, so we build the operation in-module from
+ * the union-native typeof/unbox probes + native string concat. If neither host
+ * nor native-string support is available we fall back to the legacy f64 add
+ * (status quo — no regression).
+ *
+ * Returns the value type left on the stack (`externref` for the host/native
+ * paths — a boxed number-or-string the caller stores into the `any` slot — or
+ * `f64` for the legacy numeric fallback).
+ */
+export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): ValType {
+  const noJsHost = ctx.standalone === true || ctx.wasi === true;
+
+  // Compile both operands to externref temps. Passing the externref hint keeps a
+  // runtime string boxed (no ToNumber coercion) so §13.15.3 can concatenate.
+  const lType = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
+  if (!lType) return { kind: "externref" };
+  if (lType.kind !== "externref") {
+    coerceType(ctx, fctx, lType, { kind: "externref" });
+  }
+  const lTmp = allocTempLocal(fctx, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: lTmp });
+  const rType = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
+  if (!rType) {
+    releaseTempLocal(fctx, lTmp);
+    return { kind: "externref" };
+  }
+  if (rType.kind !== "externref") {
+    coerceType(ctx, fctx, rType, { kind: "externref" });
+  }
+  const rTmp = allocTempLocal(fctx, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: rTmp });
+
+  // ── JS-host: JS `+` via __host_add ──
+  if (!noJsHost) {
+    fctx.body.push({ op: "local.get", index: lTmp });
+    fctx.body.push({ op: "local.get", index: rTmp });
+    releaseTempLocal(fctx, rTmp);
+    releaseTempLocal(fctx, lTmp);
+    const hostIdx = ensureLateImport(
+      ctx,
+      "__host_add",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalIdx = ctx.funcMap.get("__host_add") ?? hostIdx;
+    if (finalIdx === undefined) throw new Error("Missing import after ensureLateImport: __host_add");
+    fctx.body.push({ op: "call", funcIdx: finalIdx });
+    return { kind: "externref" };
+  }
+
+  // ── Standalone / WASI: build §13.15.3 in-module ──
+  // Requires native-string support for the concat arm; otherwise fall back.
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    ensureNativeStringHelpers(ctx);
+    addUnionImports(ctx);
+    const typeofStr = ctx.funcMap.get("__typeof_string");
+    const unboxNum = ctx.funcMap.get("__unbox_number");
+    const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
+    if (typeofStr !== undefined && unboxNum !== undefined && concatIdx !== undefined) {
+      // ToString(externref) → ref $AnyString, via the runtime walker (handles
+      // boxed strings, numbers, null/undefined, and struct valueOf/toString).
+      const externToStr = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      const finalToStr = ctx.funcMap.get("__extern_toString") ?? externToStr;
+
+      const emitToAnyString = (tmp: number): Instr[] => [
+        { op: "local.get", index: tmp },
+        { op: "call", funcIdx: finalToStr } as Instr,
+        { op: "any.convert_extern" } as Instr,
+        { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+      ];
+
+      // if (__typeof_string(l) | __typeof_string(r)) → concat both as strings
+      //                                      else      → f64.add(unbox, unbox)
+      const concatArm: Instr[] = [
+        ...emitToAnyString(lTmp),
+        ...emitToAnyString(rTmp),
+        { op: "call", funcIdx: concatIdx } as Instr,
+        { op: "extern.convert_any" } as Instr,
+      ];
+      const numericArm: Instr[] = [
+        { op: "local.get", index: lTmp },
+        { op: "call", funcIdx: unboxNum } as Instr,
+        { op: "local.get", index: rTmp },
+        { op: "call", funcIdx: unboxNum } as Instr,
+        { op: "f64.add" } as Instr,
+      ];
+      // Box the numeric arm's f64 result back to externref so both arms agree.
+      const boxNum = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      const finalBoxNum = ctx.funcMap.get("__box_number") ?? boxNum;
+      numericArm.push({ op: "call", funcIdx: finalBoxNum } as Instr);
+
+      fctx.body.push({ op: "local.get", index: lTmp });
+      fctx.body.push({ op: "call", funcIdx: typeofStr } as Instr);
+      fctx.body.push({ op: "local.get", index: rTmp });
+      fctx.body.push({ op: "call", funcIdx: typeofStr } as Instr);
+      fctx.body.push({ op: "i32.or" } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: concatArm,
+        else: numericArm,
+      } as Instr);
+      releaseTempLocal(fctx, rTmp);
+      releaseTempLocal(fctx, lTmp);
+      return { kind: "externref" };
+    }
+  }
+
+  // ── Fallback: no host, no native strings → legacy f64 add (status quo) ──
+  fctx.body.push({ op: "local.get", index: lTmp });
+  coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" }, "number");
+  fctx.body.push({ op: "local.get", index: rTmp });
+  coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" }, "number");
+  releaseTempLocal(fctx, rTmp);
+  releaseTempLocal(fctx, lTmp);
+  fctx.body.push({ op: "f64.add" });
+  return { kind: "f64" };
 }
 
 export function compileNumericBinaryOp(

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -7,7 +7,7 @@ import { isBooleanType, isExternalDeclaredClass, isStringType } from "../../chec
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet, resolveArrayInfo } from "../array-methods.js";
 import { tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
-import { emitModulo, emitToInt32 } from "../binary-ops.js";
+import { emitAnyAdd, emitModulo, emitToInt32 } from "../binary-ops.js";
 import { pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "../context/locals.js";
@@ -4098,6 +4098,59 @@ export function isCompoundAssignment(op: ts.SyntaxKind): boolean {
  * which corrupts every `call funcIdx=N` instruction whose index now points
  * at a host import instead of the intended native helper (#1175).
  */
+/**
+ * (#2058) `x += rhs` where the result may be a runtime string. Compute
+ * `x + rhs` via the shared runtime-dispatched add (`emitAnyAdd`: JS `+` host
+ * bridge, or a standalone tag-dispatch concat/add), then store the resulting
+ * externref back into the variable. Returns null (caller falls through to the
+ * numeric paths) only for storage classes this doesn't cover.
+ */
+function compileAnyCompoundAdd(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  name: string,
+): ValType | null {
+  const localIdx = fctx.localMap.get(name);
+  const capturedIdx = ctx.capturedGlobals.get(name);
+  const moduleIdx = ctx.moduleGlobals.get(name);
+  if (localIdx === undefined && capturedIdx === undefined && moduleIdx === undefined) {
+    return null; // unresolved binding — let the default paths handle it
+  }
+
+  // emitAnyAdd reads `expr.left` (the current value of `x`) and `expr.right`,
+  // leaving the §13.15.3 result on the stack as an externref.
+  const addResult = emitAnyAdd(ctx, fctx, expr);
+  if (addResult.kind !== "externref") {
+    // emitAnyAdd took the legacy f64 fallback (no host, no native strings).
+    // Coerce to externref so the store below is uniform.
+    coerceType(ctx, fctx, addResult, { kind: "externref" });
+  }
+
+  // Store back into the resolved binding (re-read global indices in case RHS
+  // compilation shifted them), coercing externref → the binding's storage type.
+  if (localIdx !== undefined) {
+    const localType = getLocalType(fctx, localIdx) ?? { kind: "externref" as const };
+    if (localType.kind !== "externref") coerceType(ctx, fctx, { kind: "externref" }, localType);
+    fctx.body.push({ op: "local.tee", index: localIdx });
+    return localType;
+  }
+  if (capturedIdx !== undefined) {
+    const capturedIdxPost = ctx.capturedGlobals.get(name)!;
+    const globalType: ValType = ctx.mod.globals[localGlobalIdx(ctx, capturedIdxPost)]?.type ?? { kind: "externref" };
+    if (globalType.kind !== "externref") coerceType(ctx, fctx, { kind: "externref" }, globalType);
+    fctx.body.push({ op: "global.set", index: capturedIdxPost });
+    fctx.body.push({ op: "global.get", index: capturedIdxPost });
+    return globalType;
+  }
+  const moduleIdxPost = ctx.moduleGlobals.get(name)!;
+  const globalType: ValType = ctx.mod.globals[localGlobalIdx(ctx, moduleIdxPost)]?.type ?? { kind: "externref" };
+  if (globalType.kind !== "externref") coerceType(ctx, fctx, { kind: "externref" }, globalType);
+  fctx.body.push({ op: "global.set", index: moduleIdxPost });
+  fctx.body.push({ op: "global.get", index: moduleIdxPost });
+  return globalType;
+}
+
 function compileStringCompoundAssignment(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -4608,6 +4661,33 @@ export function compileCompoundAssignment(
     }
     if (isStr) {
       return compileStringCompoundAssignment(ctx, fctx, expr, name);
+    }
+  }
+
+  // (#2058) `x += rhs` where the value may be a runtime string at `+` time —
+  // either the LHS is `any`/`unknown` (it could currently hold a string) or the
+  // RHS is `any`/`unknown` (it could evaluate to a string). The numeric `+=`
+  // paths below ToNumber-coerce both sides, so `let x: any = 1; x += "2"` wrongly
+  // produced `3` instead of `"12"`. The static-string concat gate above only
+  // catches LHS that are *statically* assigned a string; this catches the
+  // runtime case. Skip boxed captures (their own externref concat path handles
+  // them) and bigint. Provably-numeric `+=` keeps the f64 fast path (neither
+  // side is `any`/`unknown`).
+  //
+  // Fast mode (`anyValueTypeIdx >= 0`) is excluded: there the AnyValue
+  // infrastructure already round-trips `any += number` through the existing
+  // numeric path, and the `__host_add` host import isn't part of that ABI.
+  // Per the #2058 design rule, this per-site recovery is **default-mode only**.
+  if (op === ts.SyntaxKind.PlusEqualsToken && !fctx.boxedCaptures?.has(name) && ctx.anyValueTypeIdx < 0) {
+    const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
+    const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+    const leftIsAnyish = (leftTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+    const rightIsAnyish = (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+    const isBigInt =
+      (leftTsType.flags & ts.TypeFlags.BigIntLike) !== 0 || (rightTsType.flags & ts.TypeFlags.BigIntLike) !== 0;
+    if ((leftIsAnyish || rightIsAnyish) && !isBigInt) {
+      const r = compileAnyCompoundAdd(ctx, fctx, expr, name);
+      if (r !== null) return r;
     }
   }
 

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -128,6 +128,12 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   // Used for `any`-typed loose equality where null == undefined must be true. (#1134)
   if (name === "__host_loose_eq") return { type: "host_loose_eq" };
 
+  // Host `+` for two externref operands (§13.15.3 ApplyStringOrNumericBinaryOperator).
+  // Used for `any`/externref-typed `+`/`+=` where a runtime string must concatenate
+  // rather than coerce to f64 (`1 + "2"` → `"12"`, not `3`). ToPrimitive + the
+  // string-if-either-is-string rule come free from JS `+`. (#2058)
+  if (name === "__host_add") return { type: "host_add" };
+
   // SameValueZero comparison (§7.2.11) — like === except NaN equals NaN.
   // Used by Array.prototype.includes on array-like receivers (#1360).
   if (name === "__same_value_zero") return { type: "same_value_zero" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export type ImportIntent =
   | { type: "declared_global"; name: string }
   | { type: "host_eq" }
   | { type: "host_loose_eq" }
+  | { type: "host_add" }
   | { type: "same_value_zero" }
   | { type: "dynamic_import" }
   | { type: "proxy_create" }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10303,6 +10303,14 @@ assert._isSameValue = isSameValue;
       // Handles null == undefined → true and other JS coercion rules.
       // biome-ignore lint/suspicious/noDoubleEquals: §7.2.15 IsLooselyEqual requires == semantics (null == undefined, type coercion)
       return (a: any, b: any) => (a == b ? 1 : 0);
+    case "host_add":
+      // #2058 — `+` for two externref operands (§13.15.3
+      // ApplyStringOrNumericBinaryOperator). JS `+` gives us ToPrimitive on both
+      // operands, the "concatenate if either primitive is a string" rule, and
+      // object valueOf/toString ordering for free, so `1 + "2"` → `"12"` and
+      // `1 + 2` → `3`. Returns a boxed any (number or string) the caller stores
+      // back into the `any` slot.
+      return (a: any, b: any) => a + b;
     case "same_value_zero":
       // #1360 — SameValueZero comparison (§7.2.11).
       // Same as Strict Equality except NaN === NaN is true.

--- a/tests/issue-2058-any-plus-string.test.ts
+++ b/tests/issue-2058-any-plus-string.test.ts
@@ -1,0 +1,111 @@
+// #2058 — `+` / `+=` with a runtime string in an `any`/externref position must
+// CONCATENATE (§13.15.3 ApplyStringOrNumericBinaryOperator), not coerce to f64.
+// Before the fix `1 + (s: any = "2")` produced `3` instead of `"12"` because the
+// numeric paths unconditionally unboxed the externref operand to f64.
+//
+// JS-host mode delegates `+` to `__host_add` (JS `+`), which gives ToPrimitive,
+// the string-if-either-is-string rule, and object valueOf/toString ordering for
+// free. Standalone/WASI builds the operation in-module from the union-native
+// typeof/unbox probes + native string concat (no JS host import leak).
+import { describe, expect, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+import { compile } from "../src/index.js";
+
+describe("#2058 any + runtime string concatenation (JS-host / default mode)", () => {
+  it("1 + (any string) concatenates", async () => {
+    await assertEquivalent(`export function plus(s: any): any { return 1 + s; }`, [{ fn: "plus", args: ["2"] }]);
+  });
+
+  it("(any) + (any), both strings, concatenates", async () => {
+    await assertEquivalent(`export function plusBoth(a: any, b: any): any { return a + b; }`, [
+      { fn: "plusBoth", args: ["1", "2"] },
+    ]);
+  });
+
+  it("(any) + (any), both numbers, stays numeric", async () => {
+    await assertEquivalent(`export function plusBoth(a: any, b: any): any { return a + b; }`, [
+      { fn: "plusBoth", args: [40, 2] },
+    ]);
+  });
+
+  it("string + (any number) concatenates (ToString the number)", async () => {
+    await assertEquivalent(`export function f(s: string, n: any): any { return s + n; }`, [
+      { fn: "f", args: ["v", 2] },
+    ]);
+  });
+
+  it("(any) + literal string concatenates", async () => {
+    await assertEquivalent(`export function f(a: any): any { return "x" + a; }`, [{ fn: "f", args: [5] }]);
+  });
+
+  it("null + 1 → 1 (ToNumber null is 0)", async () => {
+    await assertEquivalent(`export function f(a: any): any { return a + 1; }`, [{ fn: "f", args: [null] }]);
+  });
+
+  it("undefined + 1 → NaN", async () => {
+    await assertEquivalent(`export function f(a: any): any { return a + 1; }`, [{ fn: "f", args: [undefined] }]);
+  });
+
+  it('"x" + null → "xnull"', async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [
+      { fn: "f", args: ["x", null] },
+    ]);
+  });
+
+  it("compound x += (any string) concatenates", async () => {
+    await assertEquivalent(`export function compound(s: any): any { let x: any = 1; x += s; return x; }`, [
+      { fn: "compound", args: ["2"] },
+    ]);
+  });
+
+  it("compound x += (any number) stays numeric", async () => {
+    await assertEquivalent(`export function compound(s: any): any { let x: any = 40; x += s; return x; }`, [
+      { fn: "compound", args: [2] },
+    ]);
+  });
+
+  it("regression: provably-numeric number + number unchanged", async () => {
+    await assertEquivalent(`export function f(a: number, b: number): number { return a + b; }`, [
+      { fn: "f", args: [3, 4] },
+    ]);
+  });
+
+  it("regression: provably-string string + string unchanged", async () => {
+    await assertEquivalent(`export function f(a: string, b: string): string { return a + b; }`, [
+      { fn: "f", args: ["ab", "cd"] },
+    ]);
+  });
+});
+
+// Standalone (pure-WasmGC) mode: the per-site add must build in-module with no
+// JS host and no unsatisfiable `env::__host_add` import. Numeric results are
+// JS-comparable; the concat arm is asserted only for validity (its native-string
+// result is not directly JS-comparable across the boundary).
+describe("#2058 any + runtime string concatenation (standalone / pure WasmGC)", () => {
+  async function compileStandalone(src: string) {
+    const result = await compile(src, { target: "standalone" });
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    return result;
+  }
+
+  it("any + any numeric: validates and computes the sum", async () => {
+    const result = await compileStandalone(
+      `export function f(): number { const a: any = 40; const b: any = 2; const r: any = a + b; return r; }`,
+    );
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.f as () => number)()).toBe(42);
+  });
+
+  it("any + runtime string: compiles + validates with no host import leak", async () => {
+    await compileStandalone(`export function f(s: any): any { return 1 + s; }`);
+  });
+
+  it("compound += any numeric: validates and runs", async () => {
+    const result = await compileStandalone(
+      `export function f(): number { let x: any = 1; const s: any = 2; x += s; return x; }`,
+    );
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.f as () => number)()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

`+`/`+=` with a runtime string in an `any`/externref position did **numeric** addition instead of concatenation (§13.15.3 ApplyStringOrNumericBinaryOperator). `1 + (s: any = "2")` produced `3` instead of `"12"`.

Root cause: the numeric paths compiled both operands with an f64 hint, ToNumber-coercing a runtime string before any string check could fire.

## Fix

- **`__host_add`** host import (JS `+`) — wired in `index.ts` / `import-manifest.ts` / `runtime.ts`. JS `+` gives ToPrimitive, the string-if-either-is-string rule, and object valueOf/toString ordering for free.
- **`emitAnyAdd`** (binary-ops.ts) — shared per-site add. Compiles operands with an **externref hint** (no ToNumber), then: JS-host → `__host_add`; standalone/WASI → in-module runtime branch (`__typeof_string` ⇒ `__extern_toString` + `__str_concat`, else `__unbox_number` + `f64.add` + `__box_number`) — **no host import leak**; no native strings → legacy f64 (status quo).
- **`+` gate** fires before the f64 hint when a static operand type is `any`/`unknown`.
- **`+=` gate** (`compileAnyCompoundAdd`) handles the compound case for local / captured-global / module-global storage.

## Regression safety (the −788 guard)

The gate fires **only** for `+`/`+=` with an `any`/`unknown` operand. The test262 `isSameValue` comparator (externref-equality block) and `__any_from_extern` / type-coercion boxing are **untouched**. Provably-numeric and provably-string `+` keep their existing fast paths; fast mode's `compileAnyBinaryDispatch` intercepts `any + any` earlier still.

## Tests

`tests/issue-2058-any-plus-string.test.ts` — 12 JS-host equivalence cases (incl. null/undefined operands, mixed string⇄number, regressions) + 3 standalone cases (validate + run).

Cluster: lands after #2063 (PR #1385, merged); unblocks #2059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)