### PR TITLE
test(#1962): regression guard for array-literal string spread (code points)

### DIFF
--- a/plan/issues/1962-native-string-spread-empty-array.md
+++ b/plan/issues/1962-native-string-spread-empty-array.md
@@ -1,10 +1,11 @@
 ---
 id: 1962
 title: "nativeStrings: spreading a string ([...\"ab\"]) silently produces an empty array"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -63,3 +64,26 @@ empty fill (same hazard class as #2054).
 
 #1514 fixed externref-iterable spread (same symptom, host mode); native-string
 source not covered. No other hit.
+
+## Resolution (2026-06-12)
+
+**Already fixed on main** by the time this was re-picked up — the array-literal
+spread path now handles a native/standalone string source correctly. Verified
+against every acceptance criterion on `target: "standalone"`:
+
+- `[..."ab"].length === 2`; elements `"a"` (97), `"b"` (98)
+- `[...""].length === 0`
+- non-BMP: `[..."a😀"].length === 2` (code points, not surrogate halves)
+- `[..."ab", ..."cde"].length === 5`; `["x", ..."ab", "y"].length === 4`
+
+The fix landed via the string-iterator/spread work merged after this issue was
+filed (2026-06-10) — likely the same path that fixed the related element-access
+and shorthand-with-spread bugs (#2014/#2010, commit a11e03905). No further code
+change was needed.
+
+Added `tests/issue-1962.test.ts` (6 cases) as a regression guard so the
+spread → code-point behaviour can't silently regress.
+
+(The issue also suggested making an unknown spread-source a compile error rather
+than a silent empty fill — that hardening is a separate concern from the
+now-correct string-spread path and is not in scope here.)

--- a/tests/issue-1962.test.ts
+++ b/tests/issue-1962.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1962 — spreading a string in an array literal (`[..."ab"]`) must iterate the
+ * string's CODE POINTS, not silently yield an empty array, on the pure-WasmGC
+ * standalone backend (§13.2.5.5 ArrayAccumulation → string iterator).
+ *
+ * The miscompile (empty array) was resolved on main before this regression
+ * guard landed; these cases lock in the spread → code-point behaviour so it
+ * can't silently regress. Validated against Node semantics via length / element
+ * code-unit reads.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#1962 array-literal string spread iterates code points (standalone)", () => {
+  it('[..."ab"].length === 2', async () => {
+    expect(await runNum(`return [..."ab"].length;`)).toBe(2);
+  });
+
+  it("spread elements are the individual characters", async () => {
+    expect(await runNum(`return [..."ab"][0].charCodeAt(0);`)).toBe(97); // 'a'
+    expect(await runNum(`return [..."ab"][1].charCodeAt(0);`)).toBe(98); // 'b'
+  });
+
+  it("empty string spreads to an empty array", async () => {
+    expect(await runNum(`return [...""].length;`)).toBe(0);
+  });
+
+  it("non-BMP code point counts as one element (not two surrogates)", async () => {
+    expect(await runNum(`return [..."a😀"].length;`)).toBe(2);
+  });
+
+  it("multiple spreads concatenate", async () => {
+    expect(await runNum(`return [..."ab", ..."cde"].length;`)).toBe(5);
+  });
+
+  it("spread mixed with literal elements", async () => {
+    expect(await runNum(`return ["x", ..."ab", "y"].length;`)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

#1962 reported that `[...ab]` silently produced an empty array in native/standalone mode (should iterate the string's code points per §13.2.5.5).

**Already fixed on main** by the time this was re-picked up — the array-literal spread path now handles a native/standalone string source correctly, via the string-iterator/spread work merged since the issue was filed (2026-06-10; the same path that fixed the related #2014/#2010 element-access bugs).

Verified every acceptance criterion on `target: "standalone"`:

| case | result |
|------|--------|
| `[...ab].length` | 2 |
| elements | `a` (97), `b` (98) |
| `[...].length` | 0 |
| non-BMP `[...a😀].length` | 2 (code points) |
| `[...ab, ...cde].length` | 5 |
| `[x, ...ab, y].length` | 4 |

## Change

No compiler change needed. Adds `tests/issue-1962.test.ts` (6 cases) as a regression guard so the spread → code-point behaviour can't silently regress, and marks the issue `done`.

(The issue's secondary suggestion — make an unknown spread source a compile error instead of a silent empty fill — is a separate hardening, out of scope here.)

Closes #1962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)