### PR TITLE
test(#1964): regression guard for string for-of code-point iteration

### DIFF
--- a/plan/issues/1964-native-string-forof-code-units.md
+++ b/plan/issues/1964-native-string-forof-code-units.md
@@ -1,10 +1,11 @@
 ---
 id: 1964
 title: "nativeStrings: for-of over a string iterates code units, not code points (4 iterations for \"a😀b\")"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -48,3 +49,21 @@ advancing by 2. Share the surrogate-pair walk with the string-spread fix
 
 #1183 explicitly deferred with a follow-up request; no follow-up issue
 existed. jsHost path is correct (host iterator).
+
+## Resolution (2026-06-12)
+
+**Already fixed on main** by the time this was re-picked up — the native string
+for-of lowering is now surrogate-pair aware. Verified every acceptance criterion
+on `target: "standalone"`:
+
+- `for (const c of "a😀b")` → 3 iterations (was 4); middle chunk `.length === 2`
+- the emoji chunk leads with its high surrogate (U+D83D)
+- `"😀😁"` → 2 iterations; `""` → 0
+- lone high surrogate (`"\uD83D"`) → 1 iteration (single unit, per spec)
+- BMP-only strings keep the one-iteration-per-char fast path
+
+This landed via the same string-iterator work that resolved the related string
+spread (#1962) after the issue was filed (2026-06-10). No further code change
+was needed.
+
+Added `tests/issue-1964.test.ts` (7 cases) as a regression guard.

--- a/tests/issue-1964.test.ts
+++ b/tests/issue-1964.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1964 — for-of over a string must iterate CODE POINTS, not code units
+ * (§22.1.5 String Iterator). `for (const c of "a😀b")` should run 3 iterations
+ * with the emoji delivered as a 2-unit surrogate pair, not 4 iterations of lone
+ * surrogates.
+ *
+ * The native for-of lowering became surrogate-pair aware on main before this
+ * regression guard landed (the same string-iterator work that fixed #1962
+ * spread). These cases lock the code-point behaviour in. Validated on the
+ * pure-WasmGC standalone backend.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#1964 for-of over a string iterates code points (standalone)", () => {
+  it('"a😀b" runs 3 iterations (not 4)', async () => {
+    expect(await runNum(`let n = 0; for (const c of "a😀b") { n++; } return n;`)).toBe(3);
+  });
+
+  it("the astral code point arrives as a 2-unit chunk", async () => {
+    // i===1 is the emoji; its .length is 2 (high + low surrogate).
+    expect(
+      await runNum(`let r = 0; let i = 0; for (const c of "a😀b") { if (i === 1) r = c.length; i++; } return r;`),
+    ).toBe(2);
+  });
+
+  it("the emoji chunk leads with its high surrogate (U+D83D)", async () => {
+    expect(await runNum(`let r = 0; for (const c of "😀") { r = c.charCodeAt(0); } return r;`)).toBe(0xd83d);
+  });
+
+  it("a string of only astral chars runs one iteration per code point", async () => {
+    expect(await runNum(`let n = 0; for (const c of "😀😁") { n++; } return n;`)).toBe(2);
+  });
+
+  it("a lone high surrogate is still yielded as a single unit (spec)", async () => {
+    expect(await runNum(`let n = 0; for (const c of "\\uD83D") { n++; } return n;`)).toBe(1);
+  });
+
+  it("BMP-only strings keep the fast path (one iteration per char)", async () => {
+    expect(await runNum(`let n = 0; for (const c of "hello") { n++; } return n;`)).toBe(5);
+    expect(await runNum(`let s = 0; for (const c of "abc") { s += c.charCodeAt(0); } return s;`)).toBe(97 + 98 + 99);
+  });
+
+  it("empty string runs zero iterations", async () => {
+    expect(await runNum(`let n = 0; for (const c of "") { n++; } return n;`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

#1964 reported that `for (const c of "a😀b")` iterated code UNITS (4 iterations, emoji as two lone surrogates) instead of code points per §22.1.5.

**Already fixed on main** — the native string for-of lowering became surrogate-pair aware via the same string-iterator work that resolved the related string spread (#1962), merged after this issue was filed (2026-06-10).

Verified every acceptance criterion on `target: "standalone"`:

| case | result |
|------|--------|
| `for (const c of "a😀b")` iterations | 3 (was 4) |
| emoji chunk `.length` | 2 (surrogate pair) |
| emoji chunk leading code unit | U+D83D |
| `"😀😁"` iterations | 2 |
| lone high surrogate `"\uD83D"` | 1 (single unit, per spec) |
| BMP-only fast path | one iteration per char |

## Change

No compiler change needed. Adds `tests/issue-1964.test.ts` (7 cases) as a regression guard and marks the issue `done`.

Closes #1964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)