### PR TITLE
fix(#1963): native trim recognises full Unicode whitespace set

### DIFF
--- a/plan/issues/1963-native-trim-whitespace-set-incomplete.md
+++ b/plan/issues/1963-native-trim-whitespace-set-incomplete.md
@@ -1,10 +1,11 @@
 ---
 id: 1963
 title: "nativeStrings trim/trimStart/trimEnd whitespace set incomplete (U+1680, U+2000-200A, U+2028/29, U+202F, U+205F, U+3000 not trimmed)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -38,6 +39,23 @@ Copy the `SPACE` range list from regex/parse.ts into `__str_isWhitespace`
 
 - All three repros trim to length 1 in native mode
 - ASCII fast path unchanged
+
+## Resolution
+
+Extended `__str_isWhitespace` in `src/codegen/native-strings.ts` to the full
+§22.1.3.32 WhiteSpace + LineTerminator set: added `0x1680`, `0x2000-0x200A`,
+`0x2028`, `0x2029`, `0x202F`, `0x205F`, `0x3000` to the existing
+`0x09-0x0D / 0x20 / 0xA0 / 0xFEFF`. The membership test is built from small
+`eq()`/`range()` helpers OR-ed together (ASCII forms first so the common case
+folds cheaply). `__str_trim`/`trimStart`/`trimEnd` all share this helper, so the
+fix covers all three. ASCII fast path is unchanged.
+
+## Test Results
+
+`tests/issue-1963.test.ts` — 16 fast-mode cases (one per added whitespace code
+unit + a mixed run + non-whitespace controls + trimStart/trimEnd), all trim to
+the expected length matching Node. `tests/native-strings.test.ts`: 86/86 still
+pass.
 
 ## Dupe check
 

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -2685,33 +2685,50 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
   }
 
   // --- $__str_isWhitespace(codeUnit: i32) -> i32 (helper, not exported) ---
-  // Checks if a WTF-16 code unit is whitespace: 0x09-0x0D, 0x20, 0xA0, 0xFEFF
+  // §22.1.3.32 TrimString trims WhiteSpace + LineTerminator. The full set
+  // (#1963) mirrors the regex `\s` SPACE table in src/codegen/regex/parse.ts:
+  //   0x09-0x0D, 0x20, 0xA0, 0x1680, 0x2000-0x200A, 0x2028, 0x2029, 0x202F,
+  //   0x205F, 0x3000, 0xFEFF (BOM/ZWNBSP).
   {
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "i32" }]);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.nativeStrHelpers.set("__str_isWhitespace", funcIdx);
 
-    const body: Instr[] = [
-      // Check ranges: 0x09 <= c <= 0x0D || c == 0x20 || c == 0xA0 || c == 0xFEFF
-      // Use a chain of comparisons
+    // Membership test as an OR-chain. `eq(v)` / `range(lo,hi)` each push one i32
+    // truthy value; all are OR-ed together. The two ASCII forms (0x20 and
+    // 0x09-0x0D) stay first so the common case folds cheaply.
+    const eq = (v: number): Instr[] => [{ op: "local.get", index: 0 }, { op: "i32.const", value: v }, { op: "i32.eq" }];
+    const range = (lo: number, hi: number): Instr[] => [
       { op: "local.get", index: 0 },
-      { op: "i32.const", value: 0x20 },
-      { op: "i32.eq" },
-      { op: "local.get", index: 0 },
-      { op: "i32.const", value: 0x09 },
+      { op: "i32.const", value: lo },
       { op: "i32.ge_u" },
       { op: "local.get", index: 0 },
-      { op: "i32.const", value: 0x0d },
+      { op: "i32.const", value: hi },
       { op: "i32.le_u" },
       { op: "i32.and" },
+    ];
+
+    const body: Instr[] = [
+      ...eq(0x20),
+      ...range(0x09, 0x0d),
       { op: "i32.or" },
-      { op: "local.get", index: 0 },
-      { op: "i32.const", value: 0xa0 },
-      { op: "i32.eq" },
+      ...eq(0xa0),
       { op: "i32.or" },
-      { op: "local.get", index: 0 },
-      { op: "i32.const", value: 0xfeff },
-      { op: "i32.eq" },
+      ...eq(0x1680),
+      { op: "i32.or" },
+      ...range(0x2000, 0x200a),
+      { op: "i32.or" },
+      ...eq(0x2028),
+      { op: "i32.or" },
+      ...eq(0x2029),
+      { op: "i32.or" },
+      ...eq(0x202f),
+      { op: "i32.or" },
+      ...eq(0x205f),
+      { op: "i32.or" },
+      ...eq(0x3000),
+      { op: "i32.or" },
+      ...eq(0xfeff),
       { op: "i32.or" },
     ];
 

--- a/tests/issue-1963.test.ts
+++ b/tests/issue-1963.test.ts
@@ -1,0 +1,69 @@
+// #1963 — native `__str_isWhitespace` (used by trim/trimStart/trimEnd) only
+// recognised 0x09-0x0D, 0x20, 0xA0, 0xFEFF and missed most Unicode whitespace
+// (U+1680, U+2000-200A, U+2028/29, U+202F, U+205F, U+3000), so e.g.
+// "　x".trim() kept length 2 in native mode (node: 1). The set now mirrors
+// the regex `\s` SPACE table = §22.1.3.32 TrimString's WhiteSpace+LineTerminator.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runFast(source: string, exportName = "test"): Promise<number> {
+  const result = await compile(source, { fast: true });
+  if (!result.success) {
+    throw new Error(result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n"));
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  if (imports.setExports) {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  return (instance.exports[exportName] as Function)() as number;
+}
+
+/** `length` of `("<ws>x<ws>").trim()` in native mode — must equal Node's. */
+async function trimLen(jsStringLiteralBody: string): Promise<number> {
+  return runFast(`export function test(): number { return ${jsStringLiteralBody}.trim().length; }`);
+}
+
+describe("#1963 native trim covers the full Unicode whitespace set", () => {
+  // Each: a literal wrapping a single 'x' in the named whitespace code unit.
+  // `.trim()` must reduce it to length 1, matching Node.
+  const cases: Array<[string, string]> = [
+    ["U+0020 SPACE", '" x "'],
+    ["U+0009 TAB / U+000A LF / U+000D CR", '"\\t\\nx\\r"'],
+    ["U+00A0 NBSP", '"\\u00A0x\\u00A0"'],
+    ["U+1680 OGHAM SPACE MARK", '"\\u1680x\\u1680"'],
+    ["U+2000 EN QUAD", '"\\u2000x\\u2000"'],
+    ["U+2003 EM SPACE", '"\\u2003x\\u2003"'],
+    ["U+200A HAIR SPACE", '"\\u200Ax\\u200A"'],
+    ["U+2028 LINE SEPARATOR", '"\\u2028x\\u2028"'],
+    ["U+2029 PARAGRAPH SEPARATOR", '"\\u2029x\\u2029"'],
+    ["U+202F NARROW NBSP", '"\\u202Fx\\u202F"'],
+    ["U+205F MEDIUM MATH SPACE", '"\\u205Fx\\u205F"'],
+    ["U+3000 IDEOGRAPHIC SPACE", '"\\u3000x\\u3000"'],
+    ["U+FEFF ZWNBSP / BOM", '"\\uFEFFx\\uFEFF"'],
+    ["mixed run", '"\\u3000\\u00A0\\t x \\u2003\\uFEFF"'],
+  ];
+
+  for (const [name, literal] of cases) {
+    it(`trims ${name} → length 1`, async () => {
+      // Each literal is a single 'x' wrapped in the named whitespace, so the
+      // native (Node) trim is length 1 by construction; the assertion below
+      // checks the compiled native-strings path produces the same.
+      expect(await trimLen(literal)).toBe(1);
+    });
+  }
+
+  it("does NOT trim non-whitespace (ASCII fast path unchanged)", async () => {
+    // 'y' and 'z' are not whitespace — only the surrounding spaces go.
+    expect(await trimLen('"  yz  "')).toBe(2);
+    // A bare non-whitespace string is unchanged.
+    expect(await runFast(`export function test(): number { return "abc".trim().length; }`)).toBe(3);
+  });
+
+  it("trimStart / trimEnd honour the extended set too", async () => {
+    // Shared __str_isWhitespace, so both directions get the fix.
+    expect(await runFast(`export function test(): number { return "\\u3000\\u2003x".trimStart().length; }`)).toBe(1);
+    expect(await runFast(`export function test(): number { return "x\\u202F\\uFEFF".trimEnd().length; }`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`__str_isWhitespace` (used by native-strings `trim`/`trimStart`/`trimEnd`) only matched `0x09-0x0D, 0x20, 0xA0, 0xFEFF`, so e.g. `"　x".trim()` kept length 2 in native/fast/WASI mode (node + jsHost: 1). Missing: U+1680, U+2000-200A, U+2028/29, U+202F, U+205F, U+3000.

## Fix

Extended the membership test in `src/codegen/native-strings.ts` to the full §22.1.3.32 WhiteSpace + LineTerminator set (mirrors the regex `\s` SPACE table in `src/codegen/regex/parse.ts`). Built from small `eq()`/`range()` helpers OR-ed together, ASCII forms first. `trim`/`trimStart`/`trimEnd` share the helper, so all three are fixed; ASCII fast path unchanged.

## Tests

`tests/issue-1963.test.ts` — 16 fast-mode cases: one per added whitespace code unit, a mixed run, non-whitespace controls (ASCII fast path), and trimStart/trimEnd. All trim to the Node-expected length. `tests/native-strings.test.ts`: 86/86 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)