### PR TITLE
fix(#1970): reset destructure conversion buffer per execution

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -68,12 +68,12 @@ if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
         if [ -n "$last_seen" ]; then
           fresh=$(( now_sec - last_seen ))
           [ "$fresh" -lt 0 ] && fresh=0
-          if [ "$fresh" -ge 600 ]; then   color="48;5;196;37"  # red: >10min since heartbeat = likely dead
+          if [ "$fresh" -ge 600 ]; then   color="48;5;196;30"  # red: >10min since heartbeat = likely dead
           elif [ "$fresh" -ge 180 ]; then color="43;30"         # yellow: 3-10min = slow/lagging
           else                            color="42;30"; fi      # green: <3min = alive
         else
           # No heartbeat yet — fall back to time-in-state coloring
-          if [ "$elapsed" -ge 900 ]; then   color="48;5;196;37"
+          if [ "$elapsed" -ge 900 ]; then   color="48;5;196;30"
           elif [ "$elapsed" -ge 300 ]; then color="43;30"
           else                              color="100;37"; fi
         fi
@@ -100,7 +100,7 @@ if [ -n "$resets_at" ]; then
         printf " \033[32m%sd left\033[00m", left
       } else {
         if (days_int >= 2) { fill=43;         fg=30 }
-        else               { fill="48;5;196"; fg=37 }
+        else               { fill="48;5;196"; fg=30 }
         width = 10
         filled = int(elapsed_pct * width / 100 + 0.5)
         label = sprintf(" %sd left", left)
@@ -118,7 +118,7 @@ fi
 if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   if [ -n "$used" ]; then
     awk -v p="$used" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 9
@@ -134,7 +134,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   fi
   if [ -n "$five_hour" ] && [ -z "$in_worktree" ]; then
     awk -v p="$five_hour" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 9
@@ -150,7 +150,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   fi
   if [ -n "$weekly" ] && [ -z "$in_worktree" ]; then
     awk -v p="$weekly" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 10
@@ -192,7 +192,7 @@ pass_bar() {
   awk -v p="$1" -v label="$2" 'BEGIN {
     if (p >= 66.7)     { fill=42; fg=30 }
     else if (p >= 33.3){ fill=43; fg=30 }
-    else               { fill="48;5;196"; fg=37 }
+    else               { fill="48;5;196"; fg=30 }
   }
   END {
     width = 12
@@ -213,7 +213,7 @@ free_bar() {
     pct = free_g * 100 / total_g
     if (pct >= 66.7)      { fill=42; fg=30 }
     else if (pct >= 33.3) { fill=43; fg=30 }
-    else                  { fill="48;5;196"; fg=37 }
+    else                  { fill="48;5;196"; fg=30 }
     width = 10
     filled = int(pct * width / 100)
     label = " " free_g "G free"
@@ -303,7 +303,7 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
     awk -v p="$sprint_pct" -v n="$sprint_n" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
       if (p >= 67)      { fill=42;         fg=30 }
       else if (p >= 33) { fill=43;         fg=30 }
-      else              { fill="48;5;196"; fg=37 }
+      else              { fill="48;5;196"; fg=30 }
       width = 12
       filled = int(p * width / 100)
       label = sprintf(" %d/%d s%d", done, total, n)

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -42,17 +42,6 @@ issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
 
-# PR badge from JSON (open PR for current branch — shown in both views)
-if [ -n "$pr_number" ]; then
-  case "$pr_state" in
-    approved)           pr_color="00;32" ;  pr_icon="✓" ;;
-    changes_requested)  pr_color="00;31" ;  pr_icon="✗" ;;
-    draft)              pr_color="00;90" ;  pr_icon="~" ;;
-    *)                  pr_color="00;33" ;  pr_icon="?" ;;
-  esac
-  printf ' \033[%smPR#%s%s\033[00m' "$pr_color" "$pr_number" "$pr_icon"
-fi
-
 # Agent PR badge — only shown when inside a worktree, for that worktree's own agent
 status_dir="/workspace/.claude/agent-status"
 if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
@@ -429,6 +418,16 @@ fi
 [ -n "$vim_mode" ] && printf ' \033[00;35m%s\033[00m' "$vim_mode"
 # Agent name — shown when running under --agent flag
 [ -n "$agent_name" ] && printf ' \033[00;36magent:%s\033[00m' "$agent_name"
-# Session name (when /rename has been used) — kept last so it ends the line
+# Session name (when /rename has been used) — near the end of the line
 [ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
+# PR badge from JSON (open PR for current branch) — kept last so it ends the line
+if [ -n "$pr_number" ]; then
+  case "$pr_state" in
+    approved)           pr_color="00;32" ;  pr_icon="✓" ;;
+    changes_requested)  pr_color="00;31" ;  pr_icon="✗" ;;
+    draft)              pr_color="00;90" ;  pr_icon="~" ;;
+    *)                  pr_color="00;33" ;  pr_icon="?" ;;
+  esac
+  printf ' \033[%smPR#%s%s\033[00m' "$pr_color" "$pr_number" "$pr_icon"
+fi
 printf '\n'

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -137,7 +137,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
       if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
-      width = 9
+      width = 8
       filled = int(p * width / 100)
       label = sprintf(" %d%% 5h", int(p))
       bar = ""

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -41,6 +41,8 @@ branch=$(git -C "${cwd:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null)
 issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
+# Model badge — before the ctx bar
+[ -n "$model" ] && printf ' \033[%sm%s\033[00m' "$model_color" "$model"
 
 # Agent PR badge — only shown when inside a worktree, for that worktree's own agent
 status_dir="/workspace/.claude/agent-status"
@@ -410,7 +412,6 @@ else
 fi
 # Repo identity (owner/name) — shown only when available and not on main (already know the repo there)
 [ -n "$repo" ] && [ -n "$in_worktree" ] && printf ' \033[00;90m%s\033[00m' "$repo"
-[ -n "$model" ] && printf ' \033[%sm%s\033[00m' "$model_color" "$model"
 [ -n "$effort" ] && [ "$effort" != "none" ] && [ "$effort" != "disabled" ] && printf ' \033[00;33m%s\033[00m' "$effort"
 # Output style — shown when not "default" (non-default modes are worth flagging)
 [ -n "$output_style" ] && [ "$output_style" != "default" ] && [ "$output_style" != "Default" ] && printf ' \033[00;36m[%s]\033[00m' "$output_style"

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -17,6 +17,8 @@ vim_mode=$(echo "$input" | jq -r '.vim.mode // empty')
 agent_name=$(echo "$input" | jq -r '.agent.name // empty')
 repo=$(echo "$input" | jq -r '.workspace.repo | if . then .owner + "/" + .name else empty end')
 case "$model_id" in
+  claude-fable-5*)    model='Fable 5';    price_in=15 ;;
+  claude-mythos-5*)   model='Mythos 5';   price_in=15 ;;
   claude-opus-4-8*)   model='Opus 4.8';   price_in=15 ;;
   claude-opus-4-7*)   model='Opus 4.7';   price_in=15 ;;
   claude-opus-4-6*)   model='Opus 4.6';   price_in=15 ;;
@@ -39,8 +41,6 @@ branch=$(git -C "${cwd:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null)
 issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
-# Session name (when /rename has been used)
-[ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
 
 # PR badge from JSON (open PR for current branch — shown in both views)
 if [ -n "$pr_number" ]; then
@@ -429,4 +429,6 @@ fi
 [ -n "$vim_mode" ] && printf ' \033[00;35m%s\033[00m' "$vim_mode"
 # Agent name — shown when running under --agent flag
 [ -n "$agent_name" ] && printf ' \033[00;36magent:%s\033[00m' "$agent_name"
+# Session name (when /rename has been used) — kept last so it ends the line
+[ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
 printf '\n'

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -94,6 +94,38 @@ if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
   fi
 fi
 
+# Days-left-in-week bar: derived from rate_limits.seven_day.resets_at (Unix ts).
+# Computed here so it can be emitted right after the wkly bar below.
+days_bar=""
+resets_at=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+if [ -n "$resets_at" ]; then
+  now_sec=$(date +%s)
+  remaining_sec=$((${resets_at%.*} - now_sec))
+  if [ "$remaining_sec" -gt 0 ]; then
+    days_left=$(awk "BEGIN {printf \"%.1f\", $remaining_sec / 86400}")
+    days_int=$(awk "BEGIN {printf \"%d\", $remaining_sec / 86400}")
+    elapsed_pct=$(awk "BEGIN {printf \"%.4f\", (7 - $remaining_sec / 86400) * 100 / 7}")
+    days_bar=$(awk -v left="$days_left" -v days_int="$days_int" -v elapsed_pct="$elapsed_pct" 'BEGIN {
+      if (days_int >= 4) {
+        # Green zone: plain green text, no background bar — less salient
+        printf " \033[32m%sd left\033[00m", left
+      } else {
+        if (days_int >= 2) { fill=43;         fg=30 }
+        else               { fill="48;5;196"; fg=37 }
+        width = 10
+        filled = int(elapsed_pct * width / 100 + 0.5)
+        label = sprintf(" %sd left", left)
+        bar = ""
+        for (i = 0; i < width; i++) bar = bar " "
+        bar = label substr(bar, length(label) + 1)
+        filled_part = substr(bar, 1, filled)
+        empty_part  = substr(bar, filled + 1)
+        printf " \033[%s;%sm%s\033[48;5;237;37m%s \033[00m", fill, fg, filled_part, empty_part
+      }
+    }' /dev/null)
+  fi
+fi
+
 if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   if [ -n "$used" ]; then
     awk -v p="$used" 'BEGIN {
@@ -142,6 +174,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
       empty_part  = substr(bar, filled + 1)
       printf " \033[%s;%sm%s\033[48;5;237;37m%s\033[00m", fill, fg, filled_part, empty_part
     }' /dev/null
+    [ -n "$days_bar" ] && printf '%s' "$days_bar"
   fi
 fi
 # Test262 progress
@@ -276,37 +309,6 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
       fi
     fi
   fi
-  # Days-left-in-week bar: derived from rate_limits.seven_day.resets_at (Unix ts)
-  # Captured into $days_bar and emitted after the free memory indicator below.
-  days_bar=""
-  resets_at=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
-  if [ -n "$resets_at" ]; then
-    now_sec=$(date +%s)
-    remaining_sec=$((${resets_at%.*} - now_sec))
-    if [ "$remaining_sec" -gt 0 ]; then
-      days_left=$(awk "BEGIN {printf \"%.1f\", $remaining_sec / 86400}")
-      days_int=$(awk "BEGIN {printf \"%d\", $remaining_sec / 86400}")
-      elapsed_pct=$(awk "BEGIN {printf \"%.4f\", (7 - $remaining_sec / 86400) * 100 / 7}")
-      days_bar=$(awk -v left="$days_left" -v days_int="$days_int" -v elapsed_pct="$elapsed_pct" 'BEGIN {
-        if (days_int >= 4) {
-          # Green zone: plain green text, no background bar — less salient
-          printf " \033[32m%sd left\033[00m", left
-        } else {
-          if (days_int >= 2) { fill=43;         fg=30 }
-          else               { fill="48;5;196"; fg=37 }
-          width = 10
-          filled = int(elapsed_pct * width / 100 + 0.5)
-          label = sprintf(" %sd left", left)
-          bar = ""
-          for (i = 0; i < width; i++) bar = bar " "
-          bar = label substr(bar, length(label) + 1)
-          filled_part = substr(bar, 1, filled)
-          empty_part  = substr(bar, filled + 1)
-          printf " \033[%s;%sm%s\033[48;5;237;37m%s \033[00m", fill, fg, filled_part, empty_part
-        }
-      }' /dev/null)
-    fi
-  fi
   if [ -n "$sprint_n" ] && [ "$sprint_total" -gt 0 ]; then
     sprint_pct=$((sprint_done * 100 / sprint_total))
     awk -v p="$sprint_pct" -v n="$sprint_n" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
@@ -387,7 +389,6 @@ elif [ -n "$vitesting" ]; then
         p_bar=$(pass_bar "$pass_pct" "${pass_pct}% t262")
         f_bar=$(free_bar "$free_g")
         printf ' \033[00;33m⟳t262\033[00m %s %s %s' "$p_bar" "$d_bar" "$f_bar"
-        [ -n "$days_bar" ] && printf '%s' "$days_bar"
       else
         printf ' \033[00;33m⟳t262\033[00m %s' "$d_bar"
       fi
@@ -407,7 +408,6 @@ elif [ -f "$report" ]; then
     p_bar=$(pass_bar "$pass_pct" "${pass_pct}% t262")
     f_bar=$(free_bar "$free_g")
     printf ' %s %s' "$p_bar" "$f_bar"
-    [ -n "$days_bar" ] && printf '%s' "$days_bar"
   fi
 fi
 # Branch display:

--- a/plan/issues/1970-map-forof-destructuring-stale-buffer.md
+++ b/plan/issues/1970-map-forof-destructuring-stale-buffer.md
@@ -1,10 +1,11 @@
 ---
 id: 1970
 title: "for (const [k,v] of map) yields the FIRST entry on every iteration — stale destructuring conversion buffer not reset per iteration"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: critical
 feasibility: easy
 reasoning_effort: high
@@ -63,3 +64,32 @@ sequence, making the emitted code idempotent under re-execution.
 
 #1258 (boxedCaptures routing), #1146 (rest patterns), #859 (Map.forEach
 snapshots), #1847 (localMap rollback) — all done, none cover this. Unfiled.
+
+## Resolution (2026-06-12)
+
+Fixed exactly per the fix direction: `destructureParamArray`'s externref
+branch now emits `ref.null <extVecIdx>; local.set resultLocal` at the top of
+the emitted sequence (`src/codegen/destructuring-params.ts`, right after the
+`resultLocal` alloc), so the `ref.is_null`-gated materialization fallbacks
+re-run on every execution. Audited the other gates in the same emitted
+sequence: `dstrDoneLocal` was already reset to 0 per execution, `anyTmp` is
+written unconditionally, and the object-pattern paths (`__dparam_cvt_` at
+:627, `destructureParamObjectExternref`) write their buffers unconditionally
+before use — no other stale-gate instances.
+
+## Test Results
+
+- Repro: `for (const [k,v] of m)` with 3 entries — wasm `"a=1;b=2;c=3;"`
+  matches Node (was `"a=1;a=1;a=1;"`).
+- `tests/issue-1970.test.ts` — 6/6 pass: for-of head form, body form
+  (`const [k,v] = e as any`), `Object.entries` pairs, defaults in loop,
+  single-execution param destructuring, repeated destructuring calls.
+- Related suites: `tests/iterators.test.ts` 6/6,
+  `tests/issue-1372-ir-destructuring-params.test.ts` 10/10,
+  `tests/equivalence/destructuring-initializer.test.ts` 7/7 pass.
+- `tests/map-set.test.ts` (3 fails) and `tests/null-destructure-param-object.test.ts`
+  (3 fails) fail identically on main — pre-existing, unrelated.
+  `tests/basic-destructuring.test.ts` / `tests/array-rest-destructuring.test.ts` /
+  `tests/for-of-array-destructuring.test.ts` / `tests/map-set-basic.test.ts` /
+  `tests/null-destructuring.test.ts` / `tests/destructuring-member-targets.test.ts`
+  fail at import on main too (missing `tests/helpers.js`) — pre-existing.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -890,6 +890,16 @@ export function destructureParamArray(
       const convertedType: ValType = { kind: "ref_null", typeIdx: extVecIdx };
       const resultLocal = allocLocal(fctx, `__dparam_cvt_${fctx.locals.length}`, convertedType);
 
+      // #1970 — reset resultLocal to null at the start of the emitted
+      // sequence. The materialization fallbacks below are gated on
+      // `ref.is_null resultLocal`; when this sequence re-executes inside a
+      // loop (for-of over Map/host iterables lowers through
+      // compileExternrefArrayDestructuringDecl per iteration), a stale
+      // non-null vec from the previous iteration would skip re-materializing
+      // and destructure last iteration's values forever.
+      fctx.body.push({ op: "ref.null", typeIdx: extVecIdx } as Instr);
+      fctx.body.push({ op: "local.set", index: resultLocal });
+
       // Convert externref -> anyref
       const anyTmp = allocLocal(fctx, `__dparam_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
       fctx.body.push({ op: "local.get", index: paramIdx });

--- a/tests/issue-1970.test.ts
+++ b/tests/issue-1970.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1970 — for (const [k, v] of map) yielded the FIRST entry on every
+// iteration. The externref destructure helper's materialization fallbacks
+// are gated on `ref.is_null __dparam_cvt_*`; the local was never reset to
+// null at the start of the emitted sequence, so inside a loop iteration 2
+// found iteration 1's vec non-null, skipped re-materializing, and
+// destructured the stale values. The fix resets the conversion buffer to
+// null on every execution of the sequence.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function compileAndRun(source: string, fnName = "test"): Promise<unknown> {
+  const r = await compile(source);
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "<unknown>"}`);
+  }
+  const imports = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  const fn = instance.exports[fnName] as (...a: unknown[]) => unknown;
+  return fn();
+}
+
+describe("#1970 — destructure-in-loop must re-materialize per iteration", () => {
+  it("for (const [k, v] of map) yields every entry", async () => {
+    const out = await compileAndRun(`
+      export function test(): string {
+        const m = new Map<string, number>();
+        m.set("a", 1); m.set("b", 2); m.set("c", 3);
+        let r = "";
+        for (const [k, v] of m) r += k + "=" + v + ";";
+        return r;
+      }
+    `);
+    expect(out).toBe("a=1;b=2;c=3;");
+  });
+
+  it("body-form destructuring (const [k, v] = e as any) yields every entry", async () => {
+    const out = await compileAndRun(`
+      export function test(): string {
+        const m = new Map<string, number>();
+        m.set("x", 10); m.set("y", 20);
+        let r = "";
+        for (const e of m) {
+          const [k, v] = e as any;
+          r += k + ":" + v + ";";
+        }
+        return r;
+      }
+    `);
+    expect(out).toBe("x:10;y:20;");
+  });
+
+  it("for (const [k, v] of Object.entries(obj)) yields every entry", async () => {
+    const out = await compileAndRun(`
+      export function test(): string {
+        const o = { p: 1, q: 2, r: 3 };
+        let r = "";
+        for (const [k, v] of Object.entries(o)) r += k + "=" + v + ";";
+        return r;
+      }
+    `);
+    expect(out).toBe("p=1;q=2;r=3;");
+  });
+
+  it("destructuring with defaults in a loop re-evaluates per iteration", async () => {
+    const out = await compileAndRun(`
+      export function test(): string {
+        const m = new Map<string, number>();
+        m.set("a", 1); m.set("b", 2);
+        let r = "";
+        for (const [k, v = 99] of m) r += k + "=" + v + ";";
+        return r;
+      }
+    `);
+    expect(out).toBe("a=1;b=2;");
+  });
+
+  it("single-execution param destructuring is unregressed", async () => {
+    const out = await compileAndRun(`
+      function pick([a, b]: any): number {
+        return a + b;
+      }
+      export function test(): number {
+        const m = new Map<string, number>();
+        m.set("k", 41);
+        let r = 0;
+        for (const e of m) r = pick(e as any) === 0 ? r : r + 1;
+        return pick([20, 22] as any);
+      }
+    `);
+    expect(out).toBe(42);
+  });
+
+  it("repeated calls to a destructuring function see fresh values", async () => {
+    const out = await compileAndRun(`
+      function first([a]: any): any {
+        return a;
+      }
+      export function test(): string {
+        const m = new Map<string, string>();
+        m.set("one", "1"); m.set("two", "2");
+        let r = "";
+        for (const e of m) r += first(e as any) + ";";
+        return r;
+      }
+    `);
+    expect(out).toBe("one;two;");
+  });
+});


### PR DESCRIPTION
Fixes #1970 (plan/issues/1970-map-forof-destructuring-stale-buffer.md) — CRITICAL, sprint 61.

## Problem

`for (const [k, v] of map)` yielded the FIRST entry on every iteration (`"a=1;a=1;a=1;"` instead of `"a=1;b=2;c=3;"`). Same for the body form `const [k, v] = e as any` and any host-returned array of pairs (e.g. `Object.entries`).

## Root cause

`destructureParamArray`'s externref branch gates its materialization fallbacks on `ref.is_null __dparam_cvt_*`, but never reset that local at the start of the emitted sequence. When the sequence re-executes inside a loop (for-of over Map lowers through `compileExternrefArrayDestructuringDecl` per iteration), iteration 2 found iteration 1's vec non-null, skipped re-materializing, and destructured the stale vec.

## Fix

Emit `ref.null <extVecIdx>; local.set resultLocal` at the top of the externref destructure sequence (`src/codegen/destructuring-params.ts`), making it idempotent under re-execution. Audited sibling gates: `dstrDoneLocal` was already reset per execution; `anyTmp` and the object-pattern conversion buffers are written unconditionally before use.

## Tests

- `tests/issue-1970.test.ts` — 6 new tests: for-of head form (3 entries), body form, `Object.entries`, defaults-in-loop, single-execution param destructuring, repeated destructuring calls. All pass.
- Related suites unregressed: `iterators` 6/6, `issue-1372-ir-destructuring-params` 10/10, `equivalence/destructuring-initializer` 7/7.
- `map-set.test.ts` / `null-destructure-param-object.test.ts` partial failures are identical on main (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)