### PR TITLE
fix(#2125): native String.prototype.split honours the limit argument

### DIFF
--- a/plan/issues/2125-native-split-ignores-limit.md
+++ b/plan/issues/2125-native-split-ignores-limit.md
@@ -2,10 +2,11 @@
 id: 2125
 renumbered_from: 1958
 title: "nativeStrings split() ignores the limit argument; split(undefined) emits an invalid Wasm module"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -61,3 +62,40 @@ array containing the whole string).
 #1369 (done) fixed limit on the **host** path; #1913 (ready) covers
 **RegExp**-separator split limit in standalone. The native string-separator
 helper untracked; no hit for the invalid-wasm shape.
+
+## Resolution (2026-06-12)
+
+Salvaged + completed dev-2's WIP (it died uncommitted on an old base). Added an
+i32 `limit` param to `__str_split`:
+
+- `__str_split(s, sep, limit) -> vec` — `limit === 0` returns the empty array;
+  callers pass `0xFFFFFFFF` (`-1` as i32) for "no limit" (unsigned compares).
+- Both push loops (string-separator and empty-separator per-char) stop once
+  `limit` pieces are collected.
+- The call site (`string-ops.ts` native split branch) compiles `arguments[1]`
+  via `compileStringIntegerArg` (ToUint32) — so its side effects run exactly
+  once — or pushes `-1` when absent.
+
+### Repro rows
+
+- `"a,b,c".split(",", 2).length === 2` ✓
+- `"a,b".split(",", 0).length === 0` ✓
+- `"a,b".split(undefined as any)` — **the invalid-wasm module is gone**: it now
+  surfaces a clean #1474 narrowed refusal (a non-string-typed separator falls
+  out of the native branch). Returning the spec's 1-element whole-string array
+  for a literal `undefined`/no-arg separator is left as a small follow-up (it
+  needs a no-arg native-split path); the binary is no longer broken, which was
+  the reported hazard.
+
+### Files
+
+- `src/codegen/native-strings.ts` — `__str_split` limit param + loop guards
+- `src/codegen/string-ops.ts` — limit arg compiled at the call site
+
+### Test Results
+
+`tests/issue-2125.test.ts` (7 cases) green — all limit rows, limit-0 empty,
+side-effect-once, per-char-split limit, leading-piece contents. Pre-existing
+unrelated failures on clean main: `issue-682.test.ts` two "refuses …" tests
+(standalone RegExp features now supported but refusal tests not updated) fail
+identically without this change.

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -3937,8 +3937,10 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     });
   }
 
-  // --- $__str_split(s: ref $NativeString, sep: ref $NativeString) -> ref $vec_nstr ---
-  // Splits s by sep, returns a native array of native strings.
+  // --- $__str_split(s: ref $NativeString, sep: ref $NativeString, limit: i32) -> ref $vec_nstr ---
+  // Splits s by sep, returns a native array of native strings. `limit` caps the
+  // number of pieces (ECMA-262 §22.1.3.23): callers pass 0xFFFFFFFF (= -1 as i32)
+  // for "no limit"; `limit === 0` yields the empty array (#2125).
   {
     // Register native string array type: (array (mut (ref null $AnyString)))
     // Use ref_null so array.new_default can initialize with null.
@@ -3949,29 +3951,47 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
     const nstrVecTypeIdx = getOrRegisterVecType(ctx, nstrElemKey, nstrElemType);
     const nstrVecRef: ValType = { kind: "ref", typeIdx: nstrVecTypeIdx };
 
-    const typeIdx = addFuncType(ctx, [strRef, strRef], [nstrVecRef]);
+    const typeIdx = addFuncType(ctx, [strRef, strRef, { kind: "i32" }], [nstrVecRef]);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.nativeStrHelpers.set("__str_split", funcIdx);
 
     const indexOfIdx = ctx.nativeStrHelpers.get("__str_indexOf")!;
     const substringIdx = ctx.nativeStrHelpers.get("__str_substring")!;
 
-    // params: s(0), sep(1)
-    // locals: sLen(2), sepLen(3), pos(4), idx(5), part(6-nullable),
-    //         resultArr(7-nullable), resultLen(8), resultCap(9), newArr(10-nullable)
+    // params: s(0), sep(1), limit(2)
+    // locals: sLen(3), sepLen(4), pos(5), idx(6), part(7-nullable),
+    //         resultArr(8-nullable), resultLen(9), resultCap(10), newArr(11-nullable)
     const S = 0,
-      SEP = 1;
-    const SLEN = 2,
-      SEPLEN = 3,
-      POS = 4,
-      IDX = 5,
-      PART = 6;
-    const RARR = 7,
-      RLEN = 8,
-      RCAP = 9,
-      NEWARR = 10;
+      SEP = 1,
+      LIMIT = 2;
+    const SLEN = 3,
+      SEPLEN = 4,
+      POS = 5,
+      IDX = 6,
+      PART = 7;
+    const RARR = 8,
+      RLEN = 9,
+      RCAP = 10,
+      NEWARR = 11;
 
     const body: Instr[] = [
+      // #2125: limit === 0 → return empty array (ECMA-262 §22.1.3.23 step 14).
+      // The vec struct is { length: i32, data: ref $arr }, so push length 0
+      // then a 0-capacity backing array.
+      { op: "local.get", index: LIMIT },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "i32.const", value: 0 }, // vec length
+          { op: "i32.const", value: 0 }, // backing array size
+          { op: "array.new_default", typeIdx: nstrArrTypeIdx },
+          { op: "struct.new", typeIdx: nstrVecTypeIdx },
+          { op: "return" },
+        ] as Instr[],
+      },
+
       // sLen = s.len
       { op: "local.get", index: S },
       { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
@@ -4022,9 +4042,14 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
                 op: "loop",
                 blockType: { kind: "empty" },
                 body: [
+                  // stop at sLen OR when we've emitted `limit` pieces (#2125)
                   { op: "local.get", index: POS },
                   { op: "local.get", index: SLEN },
                   { op: "i32.ge_s" },
+                  { op: "local.get", index: POS },
+                  { op: "local.get", index: LIMIT },
+                  { op: "i32.ge_u" },
+                  { op: "i32.or" },
                   { op: "br_if", depth: 1 },
 
                   // part = substring(s, pos, pos+1)
@@ -4052,8 +4077,9 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
             ] as Instr[],
           },
 
-          // return struct.new(sLen, resultArr)
-          { op: "local.get", index: SLEN },
+          // return struct.new(pos, resultArr) — `pos` is the number of chars
+          // actually emitted, which equals min(sLen, limit) (#2125).
+          { op: "local.get", index: POS },
           { op: "local.get", index: RARR },
           { op: "ref.as_non_null" },
           { op: "struct.new", typeIdx: nstrVecTypeIdx },
@@ -4070,6 +4096,13 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
             op: "loop",
             blockType: { kind: "empty" },
             body: [
+              // #2125: stop once `limit` pieces have been collected. From the
+              // loop body (not inside an `if`), depth 1 exits the wrapping block.
+              { op: "local.get", index: RLEN },
+              { op: "local.get", index: LIMIT },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 }, // break outer block
+
               // idx = indexOf(s, sep, pos)
               { op: "local.get", index: S },
               { op: "local.get", index: SEP },

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2344,6 +2344,13 @@ export function compileNativeStringMethodCall(
       });
       fctx.body.push({ op: "struct.new", typeIdx: ctx.nativeStrTypeIdx });
     }
+    // #2125: limit arg → i32 (ToUint32). Default (absent/undefined) is no limit,
+    // encoded as 0xFFFFFFFF (= -1 as i32) which the helper treats as unbounded.
+    if (expr.arguments.length > 1) {
+      compileStringIntegerArg(ctx, fctx, expr.arguments[1]!);
+    } else {
+      fctx.body.push({ op: "i32.const", value: -1 });
+    }
     const splitIdx = ctx.nativeStrHelpers.get("__str_split")!;
     fctx.body.push({ op: "call", funcIdx: splitIdx });
     // Return type is ref $vec_nstr — use same key as resolveWasmType for string[]

--- a/tests/issue-2125.test.ts
+++ b/tests/issue-2125.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2125 — native (standalone) `String.prototype.split(sep, limit)` ignored the
+ * `limit` argument (§22.1.3.23): it was never compiled, so the result was never
+ * capped, and `split(undefined)` produced an invalid Wasm module.
+ *
+ * `__str_split` now takes an i32 `limit` param (0xFFFFFFFF = no limit; 0 → []),
+ * and the call site compiles `arguments[1]` (ToUint32) or passes -1. Validated
+ * against Node on the pure-WasmGC standalone backend.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2125 native String.prototype.split honours the limit argument", () => {
+  it('"a,b,c".split(",", 2).length === 2', async () => {
+    expect(await runNum(`return "a,b,c".split(",", 2).length;`)).toBe(2);
+  });
+
+  it('"a,b".split(",", 0).length === 0 (empty array)', async () => {
+    expect(await runNum(`return "a,b".split(",", 0).length;`)).toBe(0);
+  });
+
+  it("split with no limit returns all pieces", async () => {
+    expect(await runNum(`return "a,b,c".split(",").length;`)).toBe(3);
+  });
+
+  it("limit caps but keeps the leading pieces' contents", async () => {
+    // "a,b,c".split(",", 2) === ["a", "b"]
+    expect(await runNum(`const a = "a,b,c".split(",", 2); return a[0].charCodeAt(0) * 10 + a[1].charCodeAt(0);`)).toBe(
+      97 * 10 + 98,
+    );
+  });
+
+  it("empty-separator split (per-char) respects the limit", async () => {
+    expect(await runNum(`return "abcd".split("", 2).length;`)).toBe(2);
+    expect(await runNum(`return "abc".split("").length;`)).toBe(3);
+  });
+
+  it("limit 1 yields a single piece", async () => {
+    expect(await runNum(`return "a,b,c".split(",", 1).length;`)).toBe(1);
+  });
+
+  it("the limit expression's side effects run exactly once", async () => {
+    expect(await runNum(`let n = 0; const lim = () => { n++; return 2; }; "a,b,c".split(",", lim()); return n;`)).toBe(
+      1,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The standalone `__str_split` never compiled the `limit` argument (§22.1.3.23):

| case | before | node |
|------|--------|------|
| `"a,b,c".split(",", 2).length` | 3 | 2 |
| `"a,b".split(",", 0).length` | 2 | 0 |
| `"a,b".split(undefined as any)` | **broken binary** (stack-shape mismatch) | 1 |

## Fix

- `__str_split(s, sep, limit) -> vec` gains an i32 `limit` param: `limit === 0` returns the empty array; callers pass `0xFFFFFFFF` (`-1` as i32) for "no limit" (unsigned compares). Both push loops (string-separator and empty-separator per-char) stop once `limit` pieces are collected.
- The native split call site compiles `arguments[1]` via `compileStringIntegerArg` (ToUint32, so its side effects run exactly once), or pushes `-1` when absent.
- `split(undefined)` **no longer emits a broken binary** — a non-string-typed separator now falls out of the native branch into the clean #1474 narrowed refusal. (Returning the spec's 1-element whole-string array for a literal `undefined`/no-arg separator is a small follow-up needing a no-arg native-split path; the reported hazard — the invalid module — is gone.)

Salvaged + completed dev-2's uncommitted WIP (it died on an old base; rebased onto current main).

## Tests

- `tests/issue-2125.test.ts` (7 cases) green — all limit rows, limit-0 → empty, side-effect-once, per-char-split limit, leading-piece contents.
- Pre-existing **unrelated** failures on clean main: `issue-682.test.ts` two "refuses …" tests (standalone RegExp features now supported but those refusal tests weren't updated) fail identically without this change.

Closes #2125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)