### PR TITLE
fix(#1982): IR lazy emission no longer reorders memory reads past writes

### DIFF
--- a/plan/issues/1982-ir-lazy-emission-reorders-reads-past-writes.md
+++ b/plan/issues/1982-ir-lazy-emission-reorders-reads-past-writes.md
@@ -1,10 +1,11 @@
 ---
 id: 1982
 title: "IR: lazy use-site emission reorders memory reads past writes — slot/class-field reads observe future mutations"
-status: ready
+status: done
+completed: 2026-06-12
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -95,3 +96,65 @@ read/write order per memory class.
 #1850/#1844 (verifier SSA/dominance — orthogonal, IR is valid here), #1858
 (no emission-ordering item), #1945 (legacy for-of hoist — different
 mechanism), #1131/#1574. Unfiled.
+
+## Implementation notes (2026-06-12, senior-fable)
+
+Implemented as an **emission-point resolution pass** in `src/ir/lower.ts`,
+inserted between the crossBlock computation and local allocation, plus a
+one-line hook in `emitBlockBody` (anchored values take the existing
+crossBlock emit+`local.set` branch).
+
+**Why not the issue's "materialize eagerly unless the use is the
+immediately-next instruction" first cut:** that rule anchors every member
+chain (`a.b.c.d`) and every nested call (`f(g(x))`) — both extremely common
+and both safe — so the code-size criterion fails. Instead the pass resolves,
+bottom-up per block, where each instr's tree is actually emitted:
+
+- in-place instrs (void result, crossBlock, eager side-effect drop) emit at
+  their own index; lazy values at their first consumer's *resolved* emission
+  point (multi-use tees execute the tree once, at first use); dead pure
+  values never.
+- a non-pure lazy candidate anchors at its def iff some instr between def
+  and emission point **executes before the candidate's tree** and
+  **conflicts** with it.
+
+Two load-bearing subtleties found during design:
+
+1. **Same emission point ≠ safe.** Two values collapsing into the same
+   consumer tree execute in tree order, which matches def order only when
+   one transitively consumes the other (SSA: operand defs precede
+   consumers, operands emit before their op). Unrelated siblings can swap —
+   `select` emits its condition *last*, and values defined by earlier
+   statements are referenced in arbitrary operand positions (`const c = g();
+   const t = b.v + 1; return t + c` emits the read before the call). So
+   same-point pairs are conflict-checked unless data-dependent. This is
+   what keeps `f(g(x))` lazy (g flows into f) while fixing the sibling case.
+2. **Slot precision matters and is free.** Slots are Wasm locals: only
+   `slot.write` and loop headers (forof slot fields) touch them — a call can
+   never write another function's locals (mutable captures go through
+   refcells). So `slot.read` anchors only against writes of the *same*
+   slot index, not against every call, which keeps anchoring (and the
+   extra locals) limited to genuinely conflicting windows. Heap reads
+   (class.get/object.get/vec.*/refcell.get/global.get) conservatively
+   conflict with any heap write or call.
+
+Effect summaries (`SchedFx`) recurse into loop/if/try buffers; unknown
+future instr kinds default to a full barrier (exhaustiveness-checked).
+Buffer-internal values were already safe: their uses are recorded against
+the synthetic `-1` block, so every used buffer value is crossBlock and
+materializes at def.
+
+**Scope:** the lowerer runs only under `experimentalIR` (and linear-IR
+tests) — default-path codegen is byte-identical, so test262 cannot move.
+
+**Validation:** 4 repro variants fixed (probe + `tests/issue-1982-ir-emission-order.test.ts`,
+9 cases incl. sibling call/read both operand orders, multi-use tee across
+loop, disjoint-slot non-anchoring); IR suites — identical pass/fail set to
+main (the 8 failures in `tests/ir/{inline-small,passes}.test.ts` and the
+ir-*-equivalence env breakage pre-date this change); 600-program seeded
+statement fuzz (IR vs legacy vs Node, 4 seed bases) clean — the harness
+verifiably catches the bug on unfixed main (IR-only divergence at seed
+198200037), after two generator fixes: block-scoped name tracking, and
+box/helper moved inside `f` (module-level state body-shape-rejects the
+function, silently fuzzing legacy-vs-legacy); `check:ir-fallbacks`
+unchanged; 600-statement single-block compile time on par with main.

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -509,6 +509,126 @@ export function lowerIrFunctionBody<S>(
     }
   }
 
+  // --- #1982: effects-aware emission scheduling ---------------------------
+  //
+  // Lazy use-site emission re-emits a value's defining tree at its consumer,
+  // which silently moves order-sensitive READS (slot.read, class.get, …) and
+  // EFFECTS (calls) past instructions that execute in between. Repro:
+  // `const t = b.v + 0; b.v = b.v * 10; return t + b.v` — the `b.v` read
+  // inside `t` was emitted after both `class.set`s.
+  //
+  // Resolve, bottom-up per block, where each instr's tree will actually be
+  // EMITTED ("emission point"): in-place instrs (void result, crossBlock,
+  // eager side-effect drop) emit at their own index; lazy values at their
+  // first consumer's emission point (multi-use tees at first use, later uses
+  // are local.gets and re-execute nothing); dead pure values never. A
+  // non-pure lazy candidate is then ANCHORED at its def position (emit +
+  // local.set, exactly like the crossBlock path) when some instr between its
+  // def and its emission point executes before the candidate's tree AND
+  // conflicts with it (read-vs-write / write-vs-anything / same slot).
+  //
+  // Two values collapsing into the SAME emission point execute in tree
+  // order. That matches def order only when one transitively consumes the
+  // other (operands emit before their consumer, and SSA guarantees the
+  // operand's def comes first). Unrelated siblings are conservatively
+  // conflict-checked: consumer operand order need not match def order
+  // (`select` emits its condition last; values defined by earlier
+  // statements are referenced in arbitrary operand positions).
+  //
+  // Buffer-internal values (loop bodies, if arms, try) are exempt: their
+  // uses are recorded against the synthetic -1 block, so any used value is
+  // already crossBlock-materialized at its def position. The IR itself is in
+  // program order — this is purely an emission-scheduling fix.
+  const anchorEager = new Set<IrValueId>();
+  {
+    const fxCache = new Map<IrInstr, SchedFx>();
+    const NEVER = Number.POSITIVE_INFINITY;
+    for (const block of func.blocks) {
+      const instrs = block.instrs;
+      const n = instrs.length;
+      if (n === 0) continue;
+
+      // Block-level consumers of each SSA value (terminator = index n).
+      // Buffer-internal uses are intentionally absent (crossBlock covers them).
+      const consumersOf = new Map<IrValueId, number[]>();
+      const addConsumer = (v: IrValueId, i: number): void => {
+        const list = consumersOf.get(v);
+        if (list) list.push(i);
+        else consumersOf.set(v, [i]);
+      };
+      instrs.forEach((instr, i) => {
+        for (const u of collectIrUses(instr)) addConsumer(u, i);
+      });
+      for (const u of collectTerminatorUses(block)) addConsumer(u, n);
+
+      const defIdxOf = new Map<IrValueId, number>();
+      instrs.forEach((instr, i) => {
+        if (instr.result !== null) defIdxOf.set(instr.result, i);
+      });
+
+      const emissionIdx: number[] = new Array(n).fill(NEVER);
+      const isLazyAt: boolean[] = new Array(n).fill(false);
+
+      // Does `instrs[k]`'s lazily-emitted tree transitively consume `target`?
+      // Walks only same-block lazy defs — anchored / in-place operands are
+      // local.gets at the use site and execute nothing. Defs at indices below
+      // `target`'s def cannot reach it (SSA def-before-use), so the default
+      // false for not-yet-processed entries only prunes irrelevant paths.
+      const treeConsumes = (k: number, target: IrValueId): boolean => {
+        const seen = new Set<number>();
+        const stack = [k];
+        while (stack.length > 0) {
+          const cur = stack.pop()!;
+          if (seen.has(cur)) continue;
+          seen.add(cur);
+          for (const u of collectIrUses(instrs[cur])) {
+            if (u === target) return true;
+            const d = defIdxOf.get(u);
+            if (d !== undefined && isLazyAt[d]) stack.push(d);
+          }
+        }
+        return false;
+      };
+
+      for (let i = n - 1; i >= 0; i--) {
+        const instr = instrs[i];
+        const r = instr.result;
+        const uses = r === null ? 0 : (totalUses.get(r) ?? 0);
+        if (r === null || crossBlock.has(r) || (uses === 0 && isSideEffecting(instr))) {
+          emissionIdx[i] = i; // emitted in place by emitBlockBody
+          continue;
+        }
+        if (uses === 0) continue; // dead pure value — never emitted
+        const consumers = consumersOf.get(r);
+        if (!consumers || consumers.length === 0) continue; // defensive: buffer-only uses are crossBlock
+        let e = NEVER;
+        for (const c of consumers) e = Math.min(e, c === n ? n : emissionIdx[c]);
+        if (e === NEVER) continue; // consumed only by dead chains — never emitted
+        const fx = schedFxOf(instr, fxCache);
+        let anchored = false;
+        if (!schedFxIsPure(fx)) {
+          for (let k = i + 1; k < e && k < n; k++) {
+            const ek = emissionIdx[k];
+            if (ek === NEVER || ek > e) continue; // executes after our tree (or never) — def order preserved
+            if (ek === e && treeConsumes(k, r)) continue; // same tree, operands emit before consumers
+            if (schedFxConflicts(fx, schedFxOf(instrs[k], fxCache))) {
+              anchored = true;
+              break;
+            }
+          }
+        }
+        if (anchored) {
+          anchorEager.add(r);
+          needsLocal.add(r);
+          emissionIdx[i] = i;
+        } else {
+          emissionIdx[i] = e;
+          isLazyAt[i] = true;
+        }
+      }
+    }
+  }
+
   // --- local allocation ---------------------------------------------------
   // Stable order: scan blocks then instrs. Every `needsLocal` value gets one
   // Wasm local slot, placed after the function's parameter slots. The slot's
@@ -2135,10 +2255,12 @@ export function lowerIrFunctionBody<S>(
         emitInstrTree(instr, out);
         continue;
       }
-      if (crossBlock.has(instr.result)) {
-        // Pre-materialize for successor blocks. `local.set` is a trait
-        // primitive (emitLocalSet) — byte-identical on WasmGC, OP.STORE on
-        // bytecode.
+      if (crossBlock.has(instr.result) || anchorEager.has(instr.result)) {
+        // Pre-materialize for successor blocks (crossBlock) or because the
+        // value's tree observes mutable state that a later instruction in
+        // this block writes before the use site (#1982 anchorEager).
+        // `local.set` is a trait primitive (emitLocalSet) — byte-identical
+        // on WasmGC, OP.STORE on bytecode.
         emitInstrTree(instr, out);
         emitter.emitLocalSet(localIdx.get(instr.result)!, out);
         materialized.add(instr.result);
@@ -2250,6 +2372,210 @@ export function lowerIrFunctionBody<S>(
     typeIdx,
     exported: func.exported,
   };
+}
+
+// --- #1982: emission-scheduling effect summaries ----------------------------
+//
+// `emitBlockBody`'s lazy use-site emission re-orders instruction trees
+// relative to program order. That is sound only for values that commute with
+// everything in between. These summaries classify what each instruction reads
+// and writes so the scheduler can anchor order-sensitive values at their def
+// position instead.
+//
+// Slots are Wasm locals of the current function: nothing but `slot.write`
+// (and the loop headers that own dedicated slot indices) can modify them —
+// calls cannot reach another function's locals, and mutable closure captures
+// go through refcells. That keeps slot conflicts precise per index, which
+// matters because `slot.read` is by far the most common deferred read.
+
+interface SchedFx {
+  /** Reads mutable heap state (struct fields, globals, vec elements, host objects). */
+  readsHeap: boolean;
+  /** Writes heap state or has arbitrary effects (calls, iterator advance, throw). */
+  writesHeap: boolean;
+  /** Touches statically-unknown slots (raw.wasm may local.set; gen.* use func-level slots). */
+  allSlots: boolean;
+  readSlots: Set<number>;
+  writeSlots: Set<number>;
+}
+
+function schedFxOf(instr: IrInstr, cache: Map<IrInstr, SchedFx>): SchedFx {
+  const hit = cache.get(instr);
+  if (hit) return hit;
+  const fx: SchedFx = {
+    readsHeap: false,
+    writesHeap: false,
+    allSlots: false,
+    readSlots: new Set(),
+    writeSlots: new Set(),
+  };
+  // Memoize BEFORE recursing — buffers cannot be cyclic, but this keeps the
+  // walk linear in total instr count.
+  cache.set(instr, fx);
+  const mergeBuffer = (body: readonly IrInstr[]): void => {
+    for (const sub of body) {
+      const s = schedFxOf(sub, cache);
+      fx.readsHeap ||= s.readsHeap;
+      fx.writesHeap ||= s.writesHeap;
+      fx.allSlots ||= s.allSlots;
+      for (const x of s.readSlots) fx.readSlots.add(x);
+      for (const x of s.writeSlots) fx.writeSlots.add(x);
+    }
+  };
+  switch (instr.kind) {
+    // Pure: constants, arithmetic, allocation of fresh objects, immutable
+    // string content ops. Re-ordering these is unobservable.
+    case "const":
+    case "string.const":
+    case "binary":
+    case "unary":
+    case "select":
+    case "box":
+    case "unbox":
+    case "tag.test":
+    case "coerce.to_externref":
+    case "string.concat":
+    case "string.eq":
+    case "string.len":
+    case "object.new":
+    case "refcell.new":
+    case "closure.new":
+    case "extern.regex":
+      break;
+    // Reads of mutable heap state.
+    case "global.get":
+    case "object.get":
+    case "class.get":
+    case "vec.get":
+    case "vec.len":
+    case "refcell.get":
+    case "closure.cap":
+      fx.readsHeap = true;
+      break;
+    // Writes of heap state (void-result, so only ever hazards).
+    case "global.set":
+    case "object.set":
+    case "class.set":
+    case "refcell.set":
+      fx.writesHeap = true;
+      break;
+    // Call-like: may read AND write arbitrary heap state. `extern.prop` can
+    // trigger a host getter; iterator ops advance host iterator state; throw
+    // is a control effect treated as a full heap barrier.
+    case "call":
+    case "class.call":
+    case "closure.call":
+    case "extern.call":
+    case "class.new":
+    case "extern.new":
+    case "extern.prop":
+    case "extern.propSet":
+    case "iter.new":
+    case "iter.next":
+    case "iter.done":
+    case "iter.value":
+    case "iter.return":
+    case "throw":
+    case "await":
+    case "async.return":
+    case "async.throw":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      break;
+    // Generator ops read/write the function-level buffer/pendingThrow slots
+    // (slot indices live on IrFunction, not on the instr) plus the heap.
+    case "gen.push":
+    case "gen.epilogue":
+    case "gen.yieldStar":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.allSlots = true;
+      break;
+    // Raw embedded Wasm may contain arbitrary ops including local.set.
+    case "raw.wasm":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.allSlots = true;
+      break;
+    case "slot.read":
+      fx.readSlots.add(instr.slotIndex);
+      break;
+    case "slot.write":
+      fx.writeSlots.add(instr.slotIndex);
+      break;
+    // Loop headers write their pre-allocated state slots every iteration;
+    // body/cond/update effects merge in recursively.
+    case "forof.vec":
+      fx.readsHeap = true;
+      for (const s of [instr.counterSlot, instr.lengthSlot, instr.vecSlot, instr.dataSlot, instr.elementSlot]) {
+        fx.writeSlots.add(s);
+      }
+      mergeBuffer(instr.body);
+      break;
+    case "forof.iter":
+      fx.readsHeap = true;
+      fx.writesHeap = true; // iterator protocol host calls
+      for (const s of [instr.iterSlot, instr.resultSlot, instr.elementSlot]) fx.writeSlots.add(s);
+      mergeBuffer(instr.body);
+      break;
+    case "forof.string":
+      fx.readsHeap = true;
+      for (const s of [instr.counterSlot, instr.lengthSlot, instr.strSlot, instr.elementSlot]) {
+        fx.writeSlots.add(s);
+      }
+      mergeBuffer(instr.body);
+      break;
+    case "while.loop":
+      mergeBuffer(instr.cond);
+      mergeBuffer(instr.body);
+      break;
+    case "for.loop":
+      mergeBuffer(instr.cond);
+      mergeBuffer(instr.body);
+      mergeBuffer(instr.update);
+      break;
+    case "try":
+      mergeBuffer(instr.body);
+      if (instr.catchClause) mergeBuffer(instr.catchClause.body);
+      if (instr.finallyBody) mergeBuffer(instr.finallyBody);
+      break;
+    case "if":
+      mergeBuffer(instr.then);
+      mergeBuffer(instr.else);
+      break;
+    default: {
+      // Future instruction kinds default to a full barrier so a new kind can
+      // never silently become re-orderable.
+      const _exhaustive: never = instr;
+      void _exhaustive;
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.allSlots = true;
+      break;
+    }
+  }
+  return fx;
+}
+
+function schedFxIsPure(fx: SchedFx): boolean {
+  return !fx.readsHeap && !fx.writesHeap && !fx.allSlots && fx.readSlots.size === 0 && fx.writeSlots.size === 0;
+}
+
+/** May re-ordering `a` across `b` change observable behavior? */
+function schedFxConflicts(a: SchedFx, b: SchedFx): boolean {
+  if (a.writesHeap && (b.readsHeap || b.writesHeap)) return true;
+  if (b.writesHeap && a.readsHeap) return true;
+  const aTouchesSlots = a.allSlots || a.readSlots.size > 0 || a.writeSlots.size > 0;
+  const bTouchesSlots = b.allSlots || b.readSlots.size > 0 || b.writeSlots.size > 0;
+  if (a.allSlots && bTouchesSlots) return true;
+  if (b.allSlots && aTouchesSlots) return true;
+  for (const s of a.writeSlots) {
+    if (b.readSlots.has(s) || b.writeSlots.has(s)) return true;
+  }
+  for (const s of b.writeSlots) {
+    if (a.readSlots.has(s)) return true;
+  }
+  return false;
 }
 
 function collectIrUses(instr: IrInstr): readonly IrValueId[] {

--- a/tests/issue-1982-ir-emission-order.test.ts
+++ b/tests/issue-1982-ir-emission-order.test.ts
@@ -1,0 +1,171 @@
+// #1982 — IR lazy use-site emission must not reorder memory reads past writes.
+//
+// The lowerer defers result-bearing instruction trees to their use site
+// (single-use inline, multi-use tee-at-first-use). A deferred tree containing
+// an order-sensitive read (slot.read, class.get, …) or an effect (call) must
+// be anchored at its def position when an instruction with a conflicting
+// write effect executes between def and use — otherwise the read observes
+// future mutations (e.g. `const t = b.v + 0; b.v *= 10; return t + b.v`
+// returned 20·a instead of 11·a).
+//
+// Each case compiles legacy and IR and asserts both match the expected
+// JS-semantics value.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runOne(source: string, experimentalIR: boolean, args: number[]): Promise<unknown> {
+  const result = await compile(source, { nativeStrings: true, experimentalIR });
+  if (!result.success) {
+    throw new Error(`compile failed (ir=${experimentalIR}):\n${result.errors.map((e) => e.message).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env);
+  return (instance.exports.f as (...a: number[]) => unknown)(...args);
+}
+
+async function expectBoth(source: string, args: number[], expected: unknown): Promise<void> {
+  expect(await runOne(source, false, args), "legacy").toBe(expected);
+  expect(await runOne(source, true, args), "ir").toBe(expected);
+}
+
+describe("#1982 — IR emission scheduling preserves read/write order", () => {
+  it("class-field read before straight-line writes (repro A)", async () => {
+    await expectBoth(
+      `class Box { v: number = 1; }
+export function f(a: number): number {
+  const b = new Box();
+  b.v = a;
+  const t = b.v + 0;
+  b.v = b.v * 10;
+  return t + b.v;
+}`,
+      [1],
+      11,
+    );
+  });
+
+  it("slot read snapshot across a while loop (repro B)", async () => {
+    await expectBoth(
+      `export function f(a: number): number {
+  let x0 = a;
+  const x1 = x0 + 5;
+  let i = 0;
+  while (i < 2) { x0 = x0 * 10; i = i + 1; }
+  return x1;
+}`,
+      [1],
+      6,
+    );
+  });
+
+  it("slot read snapshot across a for loop", async () => {
+    await expectBoth(
+      `export function f(a: number): number {
+  let x0 = a;
+  const x1 = x0 + 5;
+  for (let i = 0; i < 2; i = i + 1) { x0 = x0 * 10; }
+  return x1;
+}`,
+      [1],
+      6,
+    );
+  });
+
+  it("class-field read snapshot across a loop that mutates the field", async () => {
+    await expectBoth(
+      `class Box { v: number = 1; }
+export function f(a: number): number {
+  const b = new Box();
+  b.v = a;
+  const t = b.v + 0;
+  let i = 0;
+  while (i < 2) { b.v = b.v * 10; i = i + 1; }
+  return t + b.v;
+}`,
+      [1],
+      101,
+    );
+  });
+
+  it("call result defined before a later field read keeps call-then-read order", async () => {
+    // c = g() runs FIRST (mutating the field), then t reads. The return
+    // expression references them in the opposite operand order (t + c), so a
+    // lazily-collapsed tree would emit the read before the call.
+    await expectBoth(
+      `class Box { v: number = 1; }
+function g(b: Box): number { b.v = b.v + 100; return 7; }
+export function f(a: number): number {
+  const b = new Box();
+  b.v = a;
+  const c = g(b);
+  const t = b.v + 1;
+  return t + c;
+}`,
+      [1],
+      109,
+    );
+  });
+
+  it("field read before an intervening call used in read-then-call operand order", async () => {
+    // Operand order matches def order here — the in-order lazy collapse is
+    // correct and must stay correct.
+    await expectBoth(
+      `class Box { v: number = 1; }
+function g(b: Box): number { b.v = b.v + 100; return 7; }
+export function f(a: number): number {
+  const b = new Box();
+  b.v = a;
+  const t = b.v + 1;
+  const c = g(b);
+  return t + c;
+}`,
+      [1],
+      9,
+    );
+  });
+
+  it("nested pure-ish calls stay correct (lazy chain preserved)", async () => {
+    await expectBoth(
+      `function g(x: number): number { return x + 1; }
+function h(x: number): number { return x * 2; }
+export function f(a: number): number {
+  return h(g(a));
+}`,
+      [3],
+      8,
+    );
+  });
+
+  it("multi-use snapshot across a loop (tee path)", async () => {
+    await expectBoth(
+      `export function f(a: number): number {
+  let x0 = a;
+  const x1 = x0 + 5;
+  let i = 0;
+  while (i < 2) { x0 = x0 + x1; i = i + 1; }
+  return x1 + x1 + x0;
+}`,
+      [1],
+      // x1 = 6; loop: x0 = 1+6=7, then 7+6=13; return 6+6+13
+      25,
+    );
+  });
+
+  it("read of one slot is not perturbed by writes to a different slot", async () => {
+    await expectBoth(
+      `export function f(a: number): number {
+  let x0 = a;
+  let y = 0;
+  const x1 = x0 + 5;
+  let i = 0;
+  while (i < 2) { y = y + 1; i = i + 1; }
+  return x1 + y;
+}`,
+      [1],
+      8,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The IR lowerer (`src/ir/lower.ts`) defers result-bearing instruction trees to their use site (single-use inline, multi-use tee at first use). Order-sensitive reads and effects were treated as freely movable pure values, so a read defined before an intervening write or loop in the same block was re-emitted after it and observed future mutations:

```ts
const b = new Box(); b.v = a;
const t = b.v + 0;     // must read a
b.v = b.v * 10;
return t + b.v;        // IR: 20a — node/legacy: 11a
```

Same class: slot snapshots across while/for loops (`105` vs `6`), class-field reads across loops (`200` vs `101`). WAT-proofed in the issue: the read subtree was emitted after both `struct.set`s.

## Fix

An emission-point resolution pass between the crossBlock computation and local allocation. Bottom-up per block it resolves where each instr's tree is actually **emitted** — in place (void result / crossBlock / eager side-effect drop), at its first consumer's resolved emission point (lazy), or never (dead pure) — then **anchors** a non-pure lazy candidate at its def position (emit + `local.set`, the existing crossBlock branch) when an instr between its def and emission point executes before the candidate's tree and conflicts with it (heap read-vs-write, write-vs-anything, same-slot).

Two scheduling subtleties (documented in the issue's implementation notes):

- **Same emission point is only safe for data-dependent pairs** (operands emit before consumers; SSA puts the operand def first). Unrelated siblings can swap — `select` emits its condition last, and consts from earlier statements are referenced in arbitrary operand positions — so they're conflict-checked. This keeps `f(g(x))` and member chains lazy (byte-identical) while fixing sibling call/read order.
- **Slot precision is free**: slots are Wasm locals, only `slot.write`/loop-header slots touch them (calls can't reach another function's locals; mutable captures go through refcells). Slot reads anchor only against same-index writes — extra locals appear only where a genuine conflict exists.

Buffer-internal values (loop bodies, if arms, try) were already safe — their uses are recorded against the synthetic `-1` block, making them crossBlock-materialized at def.

**Scope**: the lowerer runs only under `experimentalIR` (plus linear-IR tests) — the default compile path is byte-identical, so test262 cannot move.

## Validation

- 4 repro variants fixed; `tests/issue-1982-ir-emission-order.test.ts` (9 cases: both sibling call/read operand orders, multi-use tee across loop, disjoint-slot non-anchoring, nested-call laziness)
- IR suites: pass/fail set identical to main (the 8 failures in `tests/ir/{inline-small,passes}.test.ts` and the ir-*-equivalence minimal-ENV breakage pre-date this PR)
- 600-program seeded statement fuzz (IR vs legacy vs Node, 4 seed bases): clean; the harness verifiably catches the bug on unfixed main (IR-only divergence at seed 198200037)
- `check:ir-fallbacks`: unchanged
- 600-statement single-block compile time on par with main

Closes #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)