### PR TITLE
fix(#1973): build optimize feature mask from named keys, not Features.All

### DIFF
--- a/plan/issues/1973-binaryen-module-exact-heap-types-residual.md
+++ b/plan/issues/1973-binaryen-module-exact-heap-types-residual.md
@@ -1,10 +1,11 @@
 ---
 id: 1973
 title: "optimize:true via binaryen npm module re-introduces exact heap types — optimized binaries rejected by stock V8 and JSC (#1580 masking silently no-ops)"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -65,3 +66,44 @@ instantiation in tests so this class of breakage fails CI.
 
 #1173 (done) fixed the system-CLI path; #1580 (done) claims the npm-module
 masking — this is its silent failure, untracked.
+
+## Resolution (2026-06-12)
+
+`optimizeWithBinaryenModule` now builds the feature mask by **OR-ing only the
+NAMED `Features` enum keys**, instead of starting from `Features.All`. On
+binaryen 125 `All` = 0x3FFFFF but the OR of every named key = 0x1FFFFF — the
+extra bit 0x200000 is the unnamed custom-descriptors flag, and
+`Features.CustomDescriptors` is `undefined` so the old
+`CustomDescriptors !== undefined` guard no-opped. OR-ing named keys excludes the
+bit structurally; the guard is kept (defensively) for a future binaryen that
+names the flag.
+
+The named superset is the same one the non-`All` fallback branch already used,
+extended with the other named keys binaryen 125 exposes (GCNNLocals, RelaxedSIMD,
+ExtendedConst, SIMD128, Atomics, MultiMemory, CallIndirectOverlong) so nothing
+js2wasm emits is disabled. Verified the optimizer still shrinks output (e.g. the
+closure repro 2050 → 1300 bytes) and produces identical runtime results.
+
+### Note on current reproducibility
+
+On binaryen 125 the *symptom* (exact types in the output) no longer manifested
+for the repro programs even before this change — binaryen's GC passes only
+emit `(ref (exact $T))` under conditions that didn't trigger here — but the
+**latent hazard** the issue describes was real: the mask still carried the
+unnamed custom-descriptors bit, one binaryen-pass change away from re-emitting
+exact types. This makes the mask correct by construction and adds the
+post-optimize validation gate the issue asked for.
+
+### Files
+
+- `src/optimize.ts` — `optimizeWithBinaryenModule` feature mask
+- `tests/issue-1973.test.ts` — for closures/arrays/classes: optimized binary
+  passes `WebAssembly.validate`, contains no `exact` ref types (re-parsed via
+  binaryen), and round-trips to the same observable output as unoptimized.
+
+## Test Results
+
+`tests/issue-1973.test.ts` (3 cases) green. Existing optimize suites
+(`optimize-differential`, `wasm-opt-optimize`, `issue-1580`) green.
+(`tail-call-optimization.test.ts` has a pre-existing `string_constants` import
+failure on clean main, unrelated to this change.)

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -322,26 +322,36 @@ function optimizeWithBinaryenModule(
     // simply read as 0 and are no-ops. The "All" feature mask covers
     // everything binaryen knows about — equivalent to the CLI
     // `--all-features`.
+    // #1973: build the mask by OR-ing the NAMED feature keys, never starting
+    // from `Features.All`. binaryen 125's `All` (0x3FFFFF) includes an *unnamed*
+    // custom-descriptors bit (0x200000) that its JS Features enum does not
+    // expose as a key, so the `CustomDescriptors !== undefined` guard below
+    // silently no-ops and `mod.optimize()` can rewrite `(ref $T)` → `(ref (exact
+    // $T))` — a type stock V8/JSC and wasmtime ≤ 44 reject. OR-ing only the
+    // named keys covers everything js2wasm emits (the explicit list below is the
+    // same superset as the non-`All` branch) without that latent bit.
     let features = 0;
-    if (featureFlags.All !== undefined) {
-      features = featureFlags.All;
-    } else {
-      if (gc) features |= featureFlags.GC | featureFlags.ReferenceTypes;
-      if (referenceTypes) features |= featureFlags.ReferenceTypes;
-      if (exceptionHandling) features |= featureFlags.ExceptionHandling;
-      features |= featureFlags.BulkMemory ?? 0;
-      features |= featureFlags.MutableGlobals ?? 0;
-      features |= featureFlags.SignExt ?? 0;
-      features |= featureFlags.TruncSat ?? 0;
-      features |= featureFlags.TailCall ?? 0;
-      features |= featureFlags.Multivalue ?? 0;
-      features |= featureFlags.TypedFunctionReferences ?? 0;
-      features |= featureFlags.Strings ?? 0;
-    }
-    // Mirror the CLI's `--disable-custom-descriptors`: clear the
-    // CustomDescriptors bit if `All` set it, so wasm-opt's GC passes don't
-    // introduce `(ref (exact $T))` types that wasmtime ≤ 44 can't parse.
-    // See the matching comment in `optimizeWithSystemBinary`.
+    if (gc) features |= (featureFlags.GC ?? 0) | (featureFlags.ReferenceTypes ?? 0);
+    if (referenceTypes) features |= featureFlags.ReferenceTypes ?? 0;
+    if (exceptionHandling) features |= featureFlags.ExceptionHandling ?? 0;
+    features |= featureFlags.BulkMemory ?? 0;
+    features |= featureFlags.MutableGlobals ?? 0;
+    features |= featureFlags.SignExt ?? 0;
+    features |= featureFlags.TruncSat ?? 0;
+    features |= featureFlags.TailCall ?? 0;
+    features |= featureFlags.Multivalue ?? 0;
+    features |= featureFlags.TypedFunctionReferences ?? 0;
+    features |= featureFlags.Strings ?? 0;
+    features |= featureFlags.GCNNLocals ?? 0;
+    features |= featureFlags.RelaxedSIMD ?? 0;
+    features |= featureFlags.ExtendedConst ?? 0;
+    features |= featureFlags.SIMD128 ?? 0;
+    features |= featureFlags.Atomics ?? 0;
+    features |= featureFlags.MultiMemory ?? 0;
+    features |= featureFlags.CallIndirectOverlong ?? 0;
+    // Defensive: if a future binaryen DOES name the CustomDescriptors bit, still
+    // clear it (its GC passes introduce the unparseable exact types). On 125 the
+    // key is undefined, so OR-ing named keys above already excludes the bit.
     if (featureFlags.CustomDescriptors !== undefined) {
       features &= ~featureFlags.CustomDescriptors;
     }

--- a/tests/issue-1973.test.ts
+++ b/tests/issue-1973.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1973 — `optimize` via the binaryen npm module re-introduced exact heap types.
+//
+// binaryen 125's `Features.All` (0x3FFFFF) includes an *unnamed* custom-
+// descriptors bit (0x200000) that its JS Features enum does not expose as a
+// key, so the `CustomDescriptors !== undefined` guard in optimize.ts silently
+// no-opped and `mod.optimize()` could rewrite `(ref $T)` → `(ref (exact $T))` —
+// a type stock V8/JSC reject ("invalid heap type 'exact'") and wasmtime ≤ 44
+// can't parse. optimize.ts now builds the feature mask by OR-ing only the NAMED
+// enum keys, so the unnamed bit is never set.
+//
+// Two properties (mirroring the issue's acceptance criteria):
+//   1. `optimize: 3` output validates (V8 acceptance) and contains no `exact`
+//      reference types, for closures/arrays/classes.
+//   2. Optimized output produces identical observable results to unoptimized.
+
+import { describe, expect, it } from "vitest";
+import binaryen from "binaryen";
+import { compile } from "../src/index.js";
+import { buildImports } from "./equivalence/helpers.js";
+
+/** Does the (re-parsed) optimized binary contain any `exact` heap type? */
+function hasExactRefTypes(binary: Uint8Array): boolean {
+  const mod = binaryen.readBinary(binary);
+  try {
+    return /\bexact\b/.test(mod.emitText());
+  } finally {
+    mod.dispose();
+  }
+}
+
+const PROGRAMS: Array<[string, string]> = [
+  // The exact issue repro — a closure that mutates a captured local in a loop.
+  [
+    "closure",
+    `export function main(): void {
+       let acc = 0; const add = (x: number) => { acc += x; };
+       for (let i = 0; i < 5; i++) add(i);
+       console.log(acc);
+     }`,
+  ],
+  [
+    "array",
+    `export function main(): void { const a = [1, 2, 3, 4]; let s = 0; for (const x of a) s += x; console.log(s); }`,
+  ],
+  [
+    "class",
+    `class P { x: number; constructor(x: number) { this.x = x; } g(): number { return this.x * 2; } }
+     export function main(): void { console.log(new P(7).g()); }`,
+  ],
+];
+
+async function runProgram(source: string, optimize: boolean): Promise<string[]> {
+  const result = await compile(source, optimize ? { optimize: 3 } : {});
+  expect(result.success, `compile failed: ${result.errors.map((e) => e.message).join("; ")}`).toBe(true);
+
+  if (optimize) {
+    // Property 1: must validate on a stock engine, and carry no exact types.
+    expect(WebAssembly.validate(result.binary), "optimized binary failed WebAssembly.validate").toBe(true);
+    expect(hasExactRefTypes(result.binary), "optimized binary contains exact ref types (#1973)").toBe(false);
+  }
+
+  const output: string[] = [];
+  const imports = buildImports(result);
+  const env = imports.env as Record<string, (...a: unknown[]) => unknown>;
+  env.console_log_number = (v: unknown) => void output.push(String(v));
+  env.console_log_string = (v: unknown) => void output.push(String(v));
+  env.console_log_bool = (v: unknown) => void output.push(String(!!v));
+  env.console_log_externref = (v: unknown) => void output.push(String(v));
+
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const main = (instance.exports as Record<string, unknown>).main;
+  if (typeof main === "function") (main as () => void)();
+  return output;
+}
+
+describe("#1973 optimize output has no exact heap types and round-trips", () => {
+  for (const [label, source] of PROGRAMS) {
+    it(`${label}: optimized binary validates, no exact types, matches unoptimized`, async () => {
+      const unopt = await runProgram(source, false);
+      const opt = await runProgram(source, true);
+      expect(opt).toEqual(unopt);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

`optimize` via the binaryen npm module could re-introduce exact heap types. binaryen 125's `Features.All` (0x3FFFFF) includes an **unnamed** custom-descriptors bit (0x200000) that its JS `Features` enum doesn't expose as a key, so the `CustomDescriptors !== undefined` guard in `optimize.ts` silently no-opped — leaving `mod.optimize()` free to rewrite `(ref $T)` → `(ref (exact $T))`, a type stock V8/JSC reject ("invalid heap type 'exact'") and wasmtime ≤ 44 can't parse. #1580 claimed this masking fixed; the fix silently failed because the named-feature key it relied on doesn't exist on 125.

## Fix

Build the feature mask by **OR-ing only the NAMED `Features` enum keys** instead of starting from `Features.All`. On 125 that yields 0x1FFFFF (vs `All` 0x3FFFFF) — the unnamed 0x200000 bit is excluded by construction. The named superset is the same one the non-`All` fallback branch already used, extended with the other keys 125 exposes (GCNNLocals, RelaxedSIMD, ExtendedConst, SIMD128, Atomics, MultiMemory, CallIndirectOverlong) so nothing js2wasm emits is disabled. The `CustomDescriptors !== undefined` guard is kept defensively for a future binaryen that names the flag.

Verified the optimizer still shrinks output (closure repro 2050 → 1300 bytes) and round-trips to identical results.

## Note on reproducibility

On binaryen 125 the *symptom* (exact types in the emitted binary) didn't manifest for the repro programs even before this change — binaryen's GC passes only emit exact types under conditions that didn't trigger here. But the **latent hazard** is real: the mask still carried the unnamed bit, one pass-change away from re-emitting exact types. This makes the mask correct by construction and adds the post-optimize validation gate the issue asked for.

## Tests

- `tests/issue-1973.test.ts` (3 cases) — for closures/arrays/classes: optimized binary passes `WebAssembly.validate`, contains no `exact` ref types (re-parsed via binaryen), and round-trips to the same observable output as unoptimized.
- Existing optimize suites (`optimize-differential`, `wasm-opt-optimize`, `issue-1580`) green. (`tail-call-optimization.test.ts` has a pre-existing `string_constants` import failure on clean main, unrelated.)

Closes #1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)