### PR TITLE
fix(#1958): PR-pipeline rot prevention — 4 mechanisms

### DIFF
--- a/.github/workflows/approve-fork-runs.yml
+++ b/.github/workflows/approve-fork-runs.yml
@@ -1,0 +1,53 @@
+name: Approve trusted-fork runs
+
+# WHY (#1958c): PRs from the team's fork (ttraenkler/js2) land their CI runs in
+# `action_required` until a maintainer approves them (GitHub's fork-PR gate).
+# Our dev agents all push to that fork, so every run stalls until approved; on
+# 2026-06-12 ~90 runs stranded until a tech-lead session swept them by hand, and
+# that manual sweep dies with the session. This workflow approves the backlog
+# automatically — but ONLY for the trusted fork ttraenkler/js2. Arbitrary forks
+# are never auto-approved (that would run untrusted code with repo secrets); a
+# drive-by contributor's run stays in action_required for a human.
+#
+# TOKEN: the approve endpoint is NOT accessible to the default GITHUB_TOKEN
+# (github-actions[bot] → 403). It needs the AUTO_ENQUEUE_TOKEN PAT (repo write +
+# actions:write) that auto-enqueue.yml / queue-unstick.yml already use. If that
+# secret is unset the job runs and logs a clear pointer, but every approve 403s.
+
+on:
+  # Responsive: when any run completes/changes state, sweep for fork runs that
+  # just landed in action_required.
+  workflow_run:
+    workflows: ["Test262 Sharded", "CI", "Differential test"]
+    types: [requested, completed]
+  # Backstop: catch runs the workflow_run trigger missed.
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write # approve action_required runs
+  contents: read
+
+concurrency:
+  group: approve-fork-runs
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/approve-fork-runs.mjs
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Approve trusted-fork action_required runs
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_ENQUEUE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/approve-fork-runs.mjs

--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -44,6 +44,8 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  actions: write # rerun cla-check when its status is stale on the head (#1958a)
+  issues: write # comment + stale-draft label on aging green drafts (#1958d)
 
 concurrency:
   group: auto-enqueue

--- a/plan/issues/1958-pr-pipeline-rot-prevention.md
+++ b/plan/issues/1958-pr-pipeline-rot-prevention.md
@@ -1,0 +1,88 @@
+---
+id: 1958
+title: "PR-pipeline rot prevention — 4 mechanisms observed live 2026-06-12"
+status: done
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+completed: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+---
+
+## Problem
+
+Four distinct mechanisms that silently rot the PR pipeline were observed live
+on 2026-06-12. Each strands green PRs and (today) needs a human to clear it.
+
+### (a) CLA-CHECK SHA STRANDING
+When the merge queue or a drift-update adds a `Merge branch 'main'` commit on
+top of a PR branch, the new head SHA has no `cla-check` commit status —
+`cla-check.yml` runs on `pull_request_target` and posts the status to the PR
+head SHA only; it does not re-fire when a merge commit changes the head. So
+`enqueuePullRequest` fails with `Required status check "cla-check" is expected`
+even though CLA was already accepted on the prior head. (Incident: senior-1 on
+PR #1365 / #2061.)
+
+### (b) QUEUE WEDGE DETECTION GAP
+`queue-unstick.yml` / `unstick-merge-queue.mjs` exist for the #1958 wedge
+(entry AWAITING_CHECKS, no merge_group runs), but the 01:36Z run reported
+success while PR #1364 was wedged 00:44→02:10.
+
+### (c) FORK-PR action_required GATING
+Fork PRs land their CI runs in `action_required` until a maintainer approves
+them. The team's dev agents all push to `ttraenkler/js2`, so every run stalls;
+~90 runs stranded on 2026-06-12 until a tech-lead session swept them, and that
+sweep dies with the session.
+
+### (d) DRAFT ROT
+Green drafts are invisible to auto-enqueue by design, but nothing flags them;
+PRs #1345 / #1335 (the acorn dogfood blocker) rotted ~1 day as drafts.
+
+## Fix (this PR)
+
+### (a) — `scripts/enqueue-green-prs.mjs`
+When `enqueuePullRequest` fails and the only blocker is a stale/missing
+`cla-check` status on the head (we already verified every visible check is
+pass/skipping), rerun the PR's latest `cla-check` run. The
+`pull_request_target` re-run re-resolves `pr.head.sha` and reposts
+`cla-check=success` on the current head, so the next sweep enqueues cleanly.
+Added `actions: write` to `auto-enqueue.yml`.
+
+### (b) — `scripts/unstick-merge-queue.mjs`
+Root cause: each merge group spawns ~4-5 workflow runs, so the old
+`per_page=50` single-page fetch covered only ~10 PRs of history — and that
+fetch ENOBUFS-crashed on the ~1 MB/page payload. Fixes:
+- raise `execFileSync` `maxBuffer` to 64 MB (the fetch was crashing);
+- project the runs API server-side with `-q` (id/head_branch/created_at only)
+  and paginate (`RUN_PAGES`×100, default 4) so the window covers the whole
+  recent queue;
+- de-alias stale prior-enqueue runs (only runs created at/after the entry's
+  current `enqueuedAt` count as healthy) and log matched/stale run IDs so a
+  future missed-wedge is debuggable from the cycle log;
+- fix the `REPO` default from the dead `loopdive/js2wasm` to `loopdive/js2`
+  (a hand-run without `GH_REPO` was querying the wrong repo).
+
+### (c) — new `scripts/approve-fork-runs.mjs` + `.github/workflows/approve-fork-runs.yml`
+Scheduled (10 min) + `workflow_run`-triggered job that approves
+`action_required` runs whose `head_repository.full_name == ttraenkler/js2`
+ONLY (trusted fork; arbitrary forks are never auto-approved). Uses the
+`AUTO_ENQUEUE_TOKEN` PAT — the default `GITHUB_TOKEN` cannot approve fork runs
+(403); the script logs a clear pointer if the secret is unset.
+
+### (d) — `scripts/enqueue-green-prs.mjs`
+After the enqueue sweep, list green drafts older than `DRAFT_AGE_HOURS`
+(default 6) and, once per PR (idempotent on a comment marker + `stale-draft`
+label), nudge the author to mark it ready. Never un-drafts or enqueues — that
+stays a human decision. Added `issues: write` to `auto-enqueue.yml`.
+
+## Validation
+- Both scripts pass `node --check`.
+- `unstick-merge-queue.mjs` dry-run against the live queue now fetches 400
+  merge_group runs (was ENOBUFS-crashing) and correctly detects the live
+  AWAITING_CHECKS heads.
+- `approve-fork-runs.mjs` dry-run confirms the trusted-fork projection
+  (`head_repository.full_name`) resolves and the trusted-fork filter is applied.
+- `enqueue-green-prs.mjs` dry-run exercises the back-off guard; the (a)/(d)
+  paths are guarded behind it and parse-clean.

--- a/scripts/approve-fork-runs.mjs
+++ b/scripts/approve-fork-runs.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// approve-fork-runs.mjs — auto-approve `action_required` workflow runs from the
+// TRUSTED fork only.
+//
+// WHY THIS EXISTS (#1958c): workflow runs triggered by PRs from a fork need a
+// maintainer to click "Approve and run" the first time (GitHub's fork-PR
+// safety gate). Our dev agents all push to the `ttraenkler/js2` fork and open
+// PRs against `loopdive/js2`, so EVERY one of their CI runs lands in
+// `action_required` until a human approves it. On 2026-06-12 ~90 runs stranded
+// this way until a tech-lead session swept them by hand — and that manual sweep
+// dies with the session. This script approves the backlog automatically on a
+// schedule + on each workflow_run event.
+//
+// SECURITY — TRUSTED FORK ONLY. We approve a run ONLY when its
+// head_repository.full_name is exactly `ttraenkler/js2` (the team's own fork,
+// configurable via TRUSTED_FORK). Arbitrary forks are NEVER auto-approved —
+// approving them would run untrusted PR code with repo secrets. A drive-by
+// contributor's run stays in action_required for a human to review, exactly as
+// GitHub intends.
+//
+// TOKEN: the approve endpoint (POST .../actions/runs/{id}/approve) requires a
+// token with `actions:write` AND repo write access acting as a USER or a PAT —
+// the default GITHUB_TOKEN (github-actions[bot]) is NOT permitted to approve
+// fork runs (GitHub returns 403 "Resource not accessible by integration"). So
+// the workflow passes secrets.AUTO_ENQUEUE_TOKEN (the same PAT the auto-enqueue
+// / queue-unstick workflows already use). If that secret is unset the script
+// still runs but every approve 403s; it prints a clear pointer to this note.
+//
+// Runs in GitHub Actions (.github/workflows/approve-fork-runs.yml) on a 10-min
+// cron + workflow_run, and by hand: `node scripts/approve-fork-runs.mjs`.
+// DRY RUN: `DRY_RUN=1 node scripts/approve-fork-runs.mjs` lists what it would
+// approve without mutating anything.
+
+import { execFileSync } from "node:child_process";
+
+const DRY = process.env.DRY_RUN === "1" || process.argv.includes("--dry-run");
+const REPO = process.env.GH_REPO || "loopdive/js2";
+const TRUSTED_FORK = process.env.TRUSTED_FORK || "ttraenkler/js2";
+const MAX_APPROVE = Number(process.env.MAX_APPROVE || 100);
+
+function gh(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+function ghMaybe(args) {
+  try {
+    return { ok: true, stdout: gh(args), stderr: "" };
+  } catch (e) {
+    return { ok: false, stdout: String(e.stdout || ""), stderr: String(e.stderr || e.message || e) };
+  }
+}
+function log(msg) {
+  console.log(`[approve-fork-runs ${new Date().toISOString()}] ${msg}`);
+}
+
+// List action_required runs. Project to just the fields we need (the full
+// payload is ~10 KB/run and ENOBUFS-prone at scale).
+const out = gh([
+  "api",
+  `repos/${REPO}/actions/runs?status=action_required&per_page=100`,
+  "-q",
+  ".workflow_runs[] | {id, name, head_branch, fork: .head_repository.full_name}",
+]).trim();
+const runs = out ? out.split("\n").map((l) => JSON.parse(l)) : [];
+
+if (runs.length === 0) {
+  log("no action_required runs — nothing to do");
+  process.exit(0);
+}
+
+let approved = 0;
+let skipped = 0;
+let failed = 0;
+for (const run of runs) {
+  if (run.fork !== TRUSTED_FORK) {
+    log(`skip run ${run.id} (${run.name}) — head_repository=${run.fork} is not the trusted fork ${TRUSTED_FORK}`);
+    skipped++;
+    continue;
+  }
+  if (approved >= MAX_APPROVE) {
+    log(`approve cap (${MAX_APPROVE}) reached — leaving the rest for the next cycle`);
+    break;
+  }
+  if (DRY) {
+    log(`would approve run ${run.id} (${run.name}) on ${run.head_branch} from ${run.fork}`);
+    approved++;
+    continue;
+  }
+  const res = ghMaybe(["api", "--method", "POST", `repos/${REPO}/actions/runs/${run.id}/approve`]);
+  if (res.ok) {
+    log(`approved run ${run.id} (${run.name}) on ${run.head_branch}`);
+    approved++;
+  } else {
+    const msg = (res.stderr || "").split("\n")[0].slice(0, 160);
+    failed++;
+    if (/not accessible by integration|Resource not accessible/i.test(msg)) {
+      log(
+        `FAILED run ${run.id}: ${msg} — the GITHUB_TOKEN cannot approve fork runs. ` +
+          `Set the AUTO_ENQUEUE_TOKEN PAT secret (repo write + actions:write) on this workflow.`,
+      );
+    } else {
+      log(`FAILED run ${run.id}: ${msg}`);
+    }
+  }
+}
+
+log(
+  `cycle done: ${runs.length} action_required, ${approved} ${DRY ? "would be " : ""}approved, ${skipped} non-trusted skipped, ${failed} failed`,
+);
+process.exit(0);

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -120,7 +120,7 @@ function openPrs() {
       "--limit",
       "100",
       "--json",
-      "number,mergeStateStatus,isDraft,labels,id,title",
+      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,createdAt",
     ]),
   );
 }
@@ -177,6 +177,49 @@ function visibleCheckState(prNumber) {
   if (parsed === 0) return { failed: [], pending: [], error: "no parseable checks" };
 
   return { failed, pending, error: null };
+}
+
+// CLA-CHECK SHA STRANDING (#1958a). When the merge queue or a drift-update adds
+// a `Merge branch 'main'` commit on top of a PR branch, the NEW head SHA has no
+// `cla-check` commit status — cla-check.yml runs on pull_request_target and
+// posts the status to the PR head SHA only, and does not re-fire when a merge
+// commit changes the head. So `enqueuePullRequest` fails with
+//   Required status check "cla-check" is expected
+// even though CLA was already accepted on the prior head. The fix: rerun the
+// PR's latest cla-check workflow run; the pull_request_target re-run re-resolves
+// pr.head.sha and reposts cla-check=success on the current head, so the NEXT
+// sweep enqueues cleanly. Returns true if a rerun was kicked off.
+function isClaExpectedError(msg) {
+  return /cla-check.*is expected/i.test(msg) || /required status check.*cla-check/i.test(msg);
+}
+function rerunClaCheck(prNumber, branch) {
+  // Find the most recent cla-check run for this PR's branch and rerun it.
+  // `--branch` matches the PR head branch (fork PRs show the source branch).
+  const res = ghMaybe([
+    "run",
+    "list",
+    "--repo",
+    REPO,
+    "--workflow",
+    "cla-check.yml",
+    "--branch",
+    branch,
+    "--limit",
+    "1",
+    "--json",
+    "databaseId",
+    "-q",
+    ".[0].databaseId",
+  ]);
+  const runId = res.ok ? res.stdout.trim() : "";
+  if (!runId) {
+    return { ok: false, why: `no cla-check run found for branch ${branch}` };
+  }
+  const rerun = ghMaybe(["run", "rerun", runId, "--repo", REPO]);
+  if (!rerun.ok) {
+    return { ok: false, why: `rerun ${runId} failed: ${(rerun.stderr || "").split("\n")[0].slice(0, 80)}` };
+  }
+  return { ok: true, why: `reran cla-check run ${runId}` };
 }
 
 const { queued: inQueue, forming } = mergeQueueSnapshot();
@@ -312,13 +355,71 @@ for (const pr of prs) {
     const msg = String(e.stderr || e.message || e)
       .split("\n")[0]
       .slice(0, 120);
-    skipped.push([pr.number, `enqueue-failed: ${msg}`]);
+    // CLA-CHECK SHA STRANDING (#1958a): if the ONLY blocker is a missing
+    // cla-check status on the current head (typical after a merge-main commit),
+    // rerun cla-check so the next sweep enqueues cleanly. We already verified
+    // above that every VISIBLE check is pass/skipping, so cla-check-expected
+    // here means the status is on a stale SHA, not a genuine CLA rejection.
+    if (isClaExpectedError(msg)) {
+      const r = DRY ? { ok: true, why: "would rerun cla-check" } : rerunClaCheck(pr.number, pr.headRefName);
+      skipped.push([pr.number, `cla-check stale on head — ${r.why}; retry next sweep`]);
+    } else {
+      skipped.push([pr.number, `enqueue-failed: ${msg}`]);
+    }
   }
+}
+
+// DRAFT ROT (#1958d). Green drafts are invisible to auto-enqueue BY DESIGN —
+// but nothing flags them, so a finished draft can rot for ~a day (PRs
+// #1345/#1335 — the acorn dogfood blocker — sat green as drafts). This pass
+// lists drafts older than DRAFT_AGE_HOURS whose visible checks are all green
+// and, ONCE per PR (idempotent on the comment marker + label), nudges the
+// author to mark it ready. It never un-drafts or enqueues — that stays a human
+// decision.
+const DRAFT_AGE_HOURS = Number(process.env.DRAFT_AGE_HOURS ?? "6");
+const DRAFT_AGE_MS = DRAFT_AGE_HOURS * 60 * 60 * 1000;
+const STALE_DRAFT_LABEL = "stale-draft";
+const DRAFT_MARKER = "<!-- enqueue-bot:stale-draft -->";
+const draftFlagged = [];
+for (const pr of prs) {
+  if (!pr.isDraft) continue;
+  const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
+  if (labels.some((l) => HOLD_LABELS.has(l))) continue; // wip/hold drafts are intentional
+  if (labels.includes(STALE_DRAFT_LABEL)) {
+    draftFlagged.push([pr.number, "already-flagged"]);
+    continue; // idempotent — flagged on a prior sweep
+  }
+  const ageMs = Date.now() - Date.parse(pr.createdAt);
+  if (!Number.isFinite(ageMs) || ageMs < DRAFT_AGE_MS) continue; // too fresh
+  const checks = visibleCheckState(pr.number);
+  if (checks.error || checks.failed.length > 0 || checks.pending.length > 0) continue; // not green
+  const ageH = (ageMs / 3_600_000).toFixed(1);
+  if (DRY) {
+    draftFlagged.push([pr.number, `would-flag (green draft ${ageH}h old)`]);
+    continue;
+  }
+  // Post one comment + add the label. Both are guarded so re-running is a no-op.
+  const comment = ghMaybe([
+    "pr",
+    "comment",
+    String(pr.number),
+    "--repo",
+    REPO,
+    "--body",
+    `${DRAFT_MARKER}\nThis PR has been a green draft for ${ageH}h. If it is ready, mark it **Ready for review** so auto-enqueue can pick it up; otherwise add a \`wip\`/\`hold\` label so it stops showing up here.`,
+  ]);
+  const label = ghMaybe(["pr", "edit", String(pr.number), "--repo", REPO, "--add-label", STALE_DRAFT_LABEL]);
+  const why =
+    comment.ok && label.ok
+      ? `flagged (green draft ${ageH}h)`
+      : `flag-partial (comment=${comment.ok} label=${label.ok})`;
+  draftFlagged.push([pr.number, why]);
 }
 
 console.log(
   `enqueue-green-prs: ${prs.length} open, ${inQueue.size} already queued, grace=${GRACE_MINUTES}m${DRY ? " (DRY RUN)" : ""}`,
 );
+for (const [n, why] of draftFlagged) console.log(`  ! #${n} draft ${why}`);
 for (const [n, why] of updated) console.log(`  ~ #${n} ${why}`);
 for (const [n, why] of enqueued) console.log(`  + #${n} ${why}`);
 for (const [n, why] of skipped) console.log(`  - #${n} skip (${why})`);

--- a/scripts/unstick-merge-queue.mjs
+++ b/scripts/unstick-merge-queue.mjs
@@ -43,7 +43,13 @@ import { execFileSync } from "node:child_process";
 
 const DRY_RUN = process.env.DRY_RUN === "1" || process.argv.includes("--dry-run");
 const STALL_MINUTES = Number(process.env.STALL_MINUTES || 12);
-const REPO = process.env.GH_REPO || "loopdive/js2wasm";
+// Default to the real upstream slug. The old default `loopdive/js2wasm` was a
+// dead repo name — a hand-run (`node scripts/unstick-merge-queue.mjs` without
+// GH_REPO) queried the wrong repo and silently saw an empty queue. CI passes
+// GH_REPO=${{ github.repository }} so this only bit manual invocations, but a
+// wrong default on a queue-rescue script is exactly the tool you reach for when
+// the queue is wedged and you cannot afford a misfire. (#1958b)
+const REPO = process.env.GH_REPO || "loopdive/js2";
 const [OWNER, NAME] = REPO.split("/");
 
 function gh(args, input) {
@@ -51,6 +57,10 @@ function gh(args, input) {
     encoding: "utf8",
     input,
     stdio: ["pipe", "pipe", "pipe"],
+    // The actions/runs API returns ~1 MB/page (each run carries full repo +
+    // actor objects). The default 1 MB stdio buffer ENOBUFS-crashes the script
+    // on a single page, let alone paginating. Give it generous headroom. (#1958b)
+    maxBuffer: 64 * 1024 * 1024,
   });
 }
 
@@ -81,8 +91,33 @@ if (entries.length === 0) {
 //    (or vice versa). A head-only check cleared one entry and left four
 //    others silently stalled — each needed its own nudge. So: check EVERY
 //    entry, nudge every stalled one (oldest first), capped per cycle.
-const runs = JSON.parse(gh(["api", `repos/${REPO}/actions/runs?event=merge_group&per_page=50`]));
-const allRuns = runs.workflow_runs ?? [];
+//
+//    WINDOW-SIZE GAP (#1958b — the 01:36Z-reported-success-during-#1364-wedge
+//    incident): each merge group spawns ~4-5 workflow runs (CI, CLA Check,
+//    Differential test, Test262 Sharded). A single `per_page=50` page therefore
+//    covers only ~10 PRs of merge_group history. During a busy stretch the
+//    wedged head's group runs (or, worse, a STALE prior-enqueue run that aliases
+//    it) can sit outside or skew that window, so detection silently misreads the
+//    state. We page back far enough to cover the whole queue's recent history
+//    (PAGES × 100) and de-alias by created_at below.
+const RUN_PAGES = Number(process.env.RUN_PAGES || 4); // 4 × 100 = up to ~80 PRs of merge_group history
+const allRuns = [];
+for (let page = 1; page <= RUN_PAGES; page++) {
+  // Project server-side to just the fields we use (id, head_branch, created_at)
+  // so we transfer ~60 B/run instead of ~10 KB/run — the full payload is what
+  // ENOBUFS'd the old per_page=50 fetch. `-q` emits one compact JSON object per
+  // line (jq default), which we parse line-by-line.
+  const out = gh([
+    "api",
+    `repos/${REPO}/actions/runs?event=merge_group&per_page=100&page=${page}`,
+    "-q",
+    ".workflow_runs[] | {id, head_branch, created_at}",
+  ]).trim();
+  const pageRuns = out ? out.split("\n").map((l) => JSON.parse(l)) : [];
+  allRuns.push(...pageRuns);
+  if (pageRuns.length < 100) break; // last page
+}
+log(`fetched ${allRuns.length} merge_group runs across up to ${RUN_PAGES} page(s)`);
 
 const MAX_NUDGES = Number(process.env.MAX_NUDGES || 5);
 let nudged = 0;
@@ -103,13 +138,31 @@ for (const entry of byPosition) {
     log(`#${prNum} pos=${entry.position} enqueued ${ageMin.toFixed(1)} min ago (< ${STALL_MINUTES}) — too fresh`);
     continue;
   }
-  const groupRuns = allRuns.filter(
-    (r) => r.head_branch?.includes(`/pr-${prNum}-`) && new Date(r.created_at) >= enqueuedAt,
-  );
+  // Match this entry's merge_group runs. The synthetic branch is
+  // `gh-readonly-queue/main/pr-<N>-<sha>`; anchor on `/pr-<N>-` so #136 never
+  // aliases #1364. DE-ALIAS (#1958b): only runs created AT OR AFTER this
+  // entry's current enqueuedAt count. A re-enqueue resets enqueuedAt, so a
+  // completed run from a PRIOR enqueue of the same PR has an older created_at
+  // and is correctly excluded — that stale-run aliasing is what let a wedged,
+  // re-enqueued head read "healthy" and the cycle report success.
+  const prefix = `/pr-${prNum}-`;
+  const groupRuns = allRuns.filter((r) => r.head_branch?.includes(prefix) && new Date(r.created_at) >= enqueuedAt);
   if (groupRuns.length > 0) {
     healthy++;
-    log(`#${prNum} pos=${entry.position} has ${groupRuns.length} merge_group run(s) — healthy`);
+    const ids = groupRuns
+      .slice(0, 4)
+      .map((r) => `${r.id}@${r.created_at}`)
+      .join(", ");
+    log(`#${prNum} pos=${entry.position} has ${groupRuns.length} merge_group run(s) — healthy [${ids}]`);
     continue;
+  }
+  // No matching runs after enqueuedAt. Surface whether ANY (stale) runs exist
+  // for this PR so a future "missed wedge" is debuggable from the cycle log.
+  const staleRuns = allRuns.filter((r) => r.head_branch?.includes(prefix));
+  if (staleRuns.length > 0) {
+    log(
+      `#${prNum} pos=${entry.position}: ${staleRuns.length} merge_group run(s) exist but ALL predate enqueuedAt=${entry.enqueuedAt} (stale prior-enqueue) — treating as wedged`,
+    );
   }
 
   // WEDGED entry.


### PR DESCRIPTION
Hardens the PR pipeline against four rot mechanisms observed live 2026-06-12. CI/scripts only — no codegen.

## (a) CLA-CHECK SHA STRANDING
`enqueue-green-prs.mjs`: when `enqueuePullRequest` fails and the only blocker is a stale/missing `cla-check` status on the head (every visible check already pass/skipping — typical after a merge-main commit), rerun the PR's latest `cla-check` run so the next sweep enqueues cleanly. Added `actions: write` to auto-enqueue.yml. (Incident: PR #1365/#2061.)

## (b) QUEUE-WEDGE DETECTION GAP
`unstick-merge-queue.mjs` was **ENOBUFS-crashing** on the ~1 MB/page `actions/runs` payload, and a single `per_page=50` page only covered ~10 PRs of merge_group history (each group spawns ~4-5 runs). Fixes: raise `maxBuffer` to 64 MB; project the runs API server-side with `-q` + paginate (`RUN_PAGES`×100); de-alias stale prior-enqueue runs (only runs created ≥ current `enqueuedAt` count as healthy) and log matched/stale run IDs; fix `REPO` default `loopdive/js2wasm`→`loopdive/js2`. Dry-run now fetches 400 runs and correctly detects live wedged heads.

## (c) FORK-PR action_required GATING
New `scripts/approve-fork-runs.mjs` + `.github/workflows/approve-fork-runs.yml` (10-min cron + workflow_run) approve `action_required` runs whose `head_repository.full_name == ttraenkler/js2` **only** — arbitrary forks are never auto-approved. Uses `AUTO_ENQUEUE_TOKEN` (default GITHUB_TOKEN can't approve fork runs → 403; script logs a clear pointer if unset). (Incident: ~90 stranded runs swept by hand.)

## (d) DRAFT ROT
`enqueue-green-prs.mjs`: after the sweep, flag green drafts older than 6h once each (idempotent comment marker + `stale-draft` label) nudging the author to mark ready. Never un-drafts or enqueues. Added `issues: write`. (Incident: #1345/#1335 rotted ~1 day.)

## Validation
All three scripts pass `node --check`, `biome lint scripts`, and prettier. Dry-runs against the live repo confirm: unstick fetches 400 merge_group runs (was crashing) and detects the live AWAITING_CHECKS heads; approve-fork-runs' trusted-fork projection resolves; enqueue exercises the back-off guard with (a)/(d) parse-clean behind it.

Closes #1958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)