### PR TITLE
fix(#1975): linear backend ToBoolean — empty string is falsy

### DIFF
--- a/plan/issues/1975-linear-truthiness-nan-empty-string.md
+++ b/plan/issues/1975-linear-truthiness-nan-empty-string.md
@@ -55,3 +55,28 @@ dispatching on the inferred expression kind (string → length check). Fix
 ## Dupe check
 
 No linear truthiness issue exists. Unfiled.
+
+## Progress (2026-06-12) — ToBoolean fixed; &&/|| operand-value follow-up
+
+**Done (this PR):** `emitTruthyCoercion` now takes the source expression and,
+for a string-typed value, replaces the i32 pointer on the stack with
+`__str_len(ptr) != 0` — so `""` is falsy and a non-empty string truthy. The
+NaN case (`f64.abs(x) > 0`) was already correct (#1937). The coercion feeds
+`if`/`while`/`for`/ternary and the `&&`/`||` left operand, so both problem-table
+rows now match Node, and string truthiness drives `&&`/`||` short-circuit
+correctly in boolean contexts (`"" && x`, `"" || x`, `"a" && x`). All 136
+existing linear tests pass; `tests/issue-1975.test.ts` (8 cases) added.
+
+**Remaining (separate follow-up):** the `&&`/`||` lowering still coerces its
+result to f64 and yields `0`/`1` constants on the short-circuit arm instead of
+the *operand value* — so `("" || "x")` used as a string doesn't yield `"x"`.
+Fixing this needs result-type unification in the linear backend (the f64-only
+`if` result type can't carry a string operand), which is a larger change than
+the ToBoolean fix and is left for a dedicated issue. The boolean-context use
+(the common case, and what the problem table exercises) is correct now.
+
+### Files
+
+- `src/codegen-linear/index.ts` — `emitTruthyCoercion` string branch + threaded
+  the source expression through all call sites (`if`/`while`/`for`/ternary/
+  unary-`!`/`&&`/`||`).

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -573,7 +573,7 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
   } else if (ts.isIfStatement(stmt)) {
     compileExpression(ctx, fctx, stmt.expression);
     // Convert f64 condition to i32 (0.0 = false, else true)
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression), { ctx, expr: stmt.expression });
 
     const thenBody: Instr[] = [];
     const savedBody = fctx.body;
@@ -613,7 +613,7 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
     // Compile condition (break out if false)
     fctx.body = loopBody;
     compileExpression(ctx, fctx, stmt.expression);
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression), { ctx, expr: stmt.expression });
     fctx.body.push({ op: "i32.eqz" });
     fctx.body.push({ op: "br_if", depth: 1 }); // break to outer block
 
@@ -660,7 +660,7 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
     // Condition
     if (stmt.condition) {
       compileExpression(ctx, fctx, stmt.condition);
-      emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.condition));
+      emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.condition), { ctx, expr: stmt.condition });
       fctx.body.push({ op: "i32.eqz" });
       fctx.body.push({ op: "br_if", depth: 1 }); // break to outer block
     }
@@ -1193,7 +1193,7 @@ function compileDoWhileStatement(ctx: LinearContext, fctx: LinearFuncContext, st
 
   // Compile condition
   compileExpression(ctx, fctx, stmt.expression);
-  emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression));
+  emitTruthyCoercion(fctx, inferExprType(ctx, fctx, stmt.expression), { ctx, expr: stmt.expression });
   // If condition is true, continue looping (br to loop)
   fctx.body.push({ op: "br_if", depth: 0 });
 
@@ -1448,7 +1448,7 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
       // unary plus is a no-op for numbers
     } else if (expr.operator === ts.SyntaxKind.ExclamationToken) {
       compileExpression(ctx, fctx, expr.operand);
-      emitTruthyCoercion(fctx, inferExprType(ctx, fctx, expr.operand));
+      emitTruthyCoercion(fctx, inferExprType(ctx, fctx, expr.operand), { ctx, expr: expr.operand });
       fctx.body.push({ op: "i32.eqz" });
       // Result is i32 (0 or 1), convert back to f64
       fctx.body.push({ op: "f64.convert_i32_s" });
@@ -1617,7 +1617,7 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
   } else if (ts.isConditionalExpression(expr)) {
     // ternary: cond ? then : else
     compileExpression(ctx, fctx, expr.condition);
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, expr.condition));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, expr.condition), { ctx, expr: expr.condition });
 
     const resultType = inferExprType(ctx, fctx, expr.whenTrue);
 
@@ -2107,7 +2107,7 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
   if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
     compileExpression(ctx, fctx, expr.left);
     const leftType = inferExprType(ctx, fctx, expr.left);
-    emitTruthyCoercion(fctx, leftType);
+    emitTruthyCoercion(fctx, leftType, { ctx, expr: expr.left });
     const thenBody: Instr[] = [];
     const elseBody: Instr[] = [];
     const savedBody = fctx.body;
@@ -2352,18 +2352,33 @@ function compoundAssignmentOp(op: ts.SyntaxKind): Instr {
 }
 
 /** Convert a value to i32 truthiness (for conditions) */
-function emitTruthyCoercion(fctx: LinearFuncContext, type: ValType): void {
+function emitTruthyCoercion(
+  fctx: LinearFuncContext,
+  type: ValType,
+  opts?: { ctx: LinearContext; expr: ts.Expression },
+): void {
   if (type.kind === "f64") {
     // f64 → i32: abs(value) > 0.0. The previous `value != 0` test made NaN
     // truthy (NaN != 0 is true); JS ToBoolean(NaN) is false (#1937).
     // abs folds -0 to 0 and NaN > 0 is false, so this covers 0, -0 and NaN.
-    // Note: strings are i32 pointers here, so JS "" falsiness does not apply —
-    // a string pointer is always nonzero (see the string layout in runtime.ts).
     fctx.body.push({ op: "f64.abs" });
     fctx.body.push({ op: "f64.const", value: 0 });
     fctx.body.push({ op: "f64.gt" });
   } else if (type.kind === "i32") {
-    // Already i32, no conversion needed
+    // #1975: a string value is an i32 POINTER (always nonzero), so raw i32
+    // truthiness would make every string — including "" — truthy. JS
+    // ToBoolean(string) is `length !== 0`, so for a string-typed expression
+    // replace the pointer on the stack with `__str_len(ptr) != 0`. Non-string
+    // i32 values (numbers-as-i32, booleans) keep raw i32 truthiness.
+    if (opts !== undefined && isStringExpr(opts.ctx, fctx, opts.expr)) {
+      const strLenIdx = opts.ctx.funcMap.get("__str_len");
+      if (strLenIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: strLenIdx });
+        fctx.body.push({ op: "i32.const", value: 0 });
+        fctx.body.push({ op: "i32.ne" });
+      }
+    }
+    // else: already i32, no conversion needed
   }
 }
 
@@ -3361,7 +3376,7 @@ function compileArrayHOF(
   if (method === "filter") {
     // if (callback(elem)) __arr_push(result, elem)
     compileExpression(ctx, fctx, bodyExpr);
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr), { ctx, expr: bodyExpr });
     const pushBody: Instr[] = [];
     const savedBody2 = fctx.body;
     fctx.body = pushBody;
@@ -3386,7 +3401,7 @@ function compileArrayHOF(
   } else if (method === "some") {
     // if (callback(elem)) { result = 1.0; break; }
     compileExpression(ctx, fctx, bodyExpr);
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr), { ctx, expr: bodyExpr });
     const foundBody: Instr[] = [];
     const savedBody2 = fctx.body;
     fctx.body = foundBody;
@@ -3398,7 +3413,7 @@ function compileArrayHOF(
   } else if (method === "find") {
     // if (callback(elem)) { result = elem; break; }
     compileExpression(ctx, fctx, bodyExpr);
-    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr));
+    emitTruthyCoercion(fctx, inferExprType(ctx, fctx, bodyExpr), { ctx, expr: bodyExpr });
     const foundBody: Instr[] = [];
     const savedBody2 = fctx.body;
     fctx.body = foundBody;

--- a/tests/issue-1975.test.ts
+++ b/tests/issue-1975.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1975 — linear-backend ToBoolean was wrong for strings. A string value is an
+ * i32 POINTER (always nonzero), so `emitTruthyCoercion`'s i32 branch left it
+ * unchanged and every string — including `""` — was truthy. JS
+ * ToBoolean(string) is `length !== 0`, so `""` must be falsy.
+ *
+ * (The NaN case — `f64.abs(x) > 0` — was already fixed by #1937; this guards it
+ * too.) The coercion feeds `if`/`while`/`for`/ternary and the left operand of
+ * `&&`/`||`, so a string condition now branches correctly in every position.
+ *
+ * Validated on `target: "linear"` against Node ToBoolean semantics.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runLinear(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "linear" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#1975 linear backend ToBoolean for strings and NaN", () => {
+  it("empty string is falsy in an `if`", async () => {
+    expect(await runLinear(`const s = ""; if (s) return 1; return 0;`)).toBe(0);
+  });
+
+  it("a non-empty string is truthy", async () => {
+    expect(await runLinear(`const s = "a"; if (s) return 1; return 0;`)).toBe(1);
+  });
+
+  it("NaN is falsy (regression guard for #1937)", async () => {
+    expect(await runLinear(`const x = 0 / 0; if (x) return 1; return 0;`)).toBe(0);
+  });
+
+  it("0 and -0 are falsy, nonzero numbers truthy", async () => {
+    expect(await runLinear(`const x = 0; if (x) return 1; return 0;`)).toBe(0);
+    expect(await runLinear(`const x = -0; if (x) return 1; return 0;`)).toBe(0);
+    expect(await runLinear(`const x = 5; if (x) return 1; return 0;`)).toBe(1);
+  });
+
+  it("empty string is falsy as a `while` condition", async () => {
+    expect(await runLinear(`let s = ""; let n = 0; while (s) { n++; break; } return n;`)).toBe(0);
+  });
+
+  it("empty string is falsy in a ternary", async () => {
+    expect(await runLinear(`const s = ""; return s ? 1 : 0;`)).toBe(0);
+  });
+
+  it("string truthiness drives && / || short-circuit (boolean context)", async () => {
+    // "" is falsy, so `"" && 1` short-circuits to falsy; `"" || 1` takes the RHS.
+    expect(await runLinear(`const s = ""; if (s && 1) return 1; return 0;`)).toBe(0);
+    expect(await runLinear(`const s = ""; if (s || 1) return 1; return 0;`)).toBe(1);
+    // "a" is truthy, so `"a" && 1` proceeds to the RHS.
+    expect(await runLinear(`const s = "a"; if (s && 1) return 1; return 0;`)).toBe(1);
+  });
+
+  it("string .length still works (coercion does not disturb length reads)", async () => {
+    expect(await runLinear(`const s = "abc"; return s.length;`)).toBe(3);
+    expect(await runLinear(`const s = ""; return s.length;`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem (`target: "linear"`)

| probe | before | node |
|-------|--------|------|
| `const x = 0/0; if (x) return 1; return 0;` | (fixed by #1937) | 0 |
| `const s = ""; if (s) return 1; return 0;` | **1** | 0 |

A string value is an i32 **pointer** (always nonzero), so `emitTruthyCoercion`'s i32 branch left it unchanged and every string — including `""` — was truthy. JS ToBoolean(string) is `length !== 0`.

## Fix

`emitTruthyCoercion` now takes the source expression and, for a string-typed value, replaces the pointer on the stack with `__str_len(ptr) != 0`. The source expression is threaded through every call site (`if`/`while`/`for`/ternary/unary-`!`/`&&`/`||` left operand). The NaN case (`f64.abs(x) > 0`) was already correct (#1937).

Both problem-table rows now match Node, and string truthiness drives `&&`/`||` short-circuit correctly in boolean contexts (`"" && x`, `"" || x`, `"a" && x`).

## Remaining (documented in the issue — separate follow-up)

The `&&`/`||` lowering still coerces its result to f64 and yields `0`/`1` constants on the short-circuit arm instead of the *operand value*, so `("" || "x")` used as a string doesn't yield `"x"`. Fixing this needs result-type unification in the linear backend (its f64-only `if` result type can't carry a string operand) — a larger change than this ToBoolean fix. The boolean-context use (the common case, what the problem table exercises) is correct now. The issue stays open for that follow-up.

## Tests

- `tests/issue-1975.test.ts` (8 cases) — string/NaN/0/-0 truthiness across `if`/`while`/ternary, `&&`/`||` short-circuit, and `.length` unaffected.
- All 136 existing linear-backend tests pass.

Refs #1975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)