### PR TITLE
fix(#2133): regression-gate staleness warning reads fresh baseline metadata

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -955,12 +955,24 @@ jobs:
           # clone take ~100s; materializing just the host baseline JSONL takes
           # ~2-5s. The #1081 merge-base step below sparse-checkout-adds its
           # runs/<sha> entry on demand from the same clone.
+          # #49 — also materialize the baselines-repo report JSON so the
+          # regression diff can read FRESH baseline metadata (baseline_sha /
+          # baseline_generated_at) from the SAME source as the JSONL it diffs.
+          # The committed benchmarks/results/test262-current.json on main is
+          # deliberately frozen by promote-baseline (it skips the main commit
+          # when only baseline_sha/timestamp changed), so reading age/SHA from
+          # it reports a stale "8h old (commit 3903ea6)" even though the JSONL
+          # being diffed is current.
           { git clone --depth=2 --filter=blob:none --no-checkout https://github.com/loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines \
-            && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone /test262-current.jsonl \
+            && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone /test262-current.jsonl /test262-current.json \
             && git -C /tmp/js2wasm-baselines checkout main; } 2>/dev/null || true
           if [ -f /tmp/js2wasm-baselines/test262-current.jsonl ]; then
             mkdir -p benchmarks/results
             cp /tmp/js2wasm-baselines/test262-current.jsonl benchmarks/results/test262-current.jsonl
+            # Fresh metadata for the staleness warning (#49). Kept at a distinct
+            # path so it never overwrites the committed file the rest of the
+            # tree reads, and is only used for --baseline-meta below.
+            cp /tmp/js2wasm-baselines/test262-current.json /tmp/baseline-meta-fresh.json 2>/dev/null || true
             echo "Baseline fetched from js2wasm-baselines repo."
             # #1235 — capture baseline commit timestamp + sha for the staleness
             # check below. The PR gate will warn if the baseline is older than
@@ -999,6 +1011,10 @@ jobs:
           MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || echo "")
           TEST262_VERSION=$(git submodule status test262 2>/dev/null | awk '{print $1}' | tr -d '+-' || echo "")
           echo "Merge-base: ${MERGE_BASE:-<unknown>}; test262 version: ${TEST262_VERSION:-<unknown>}"
+          # Expose merge-base so the regression-diff step can read fresh metadata
+          # from runs/<merge-base>.json when the cache hit (#49). The .json is
+          # sparse-checked-out below alongside the .jsonl.
+          echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
           # The clone above is sparse + blob-filtered; materialize only this
           # merge-base's run-cache entry. A pattern that matches nothing in
           # the tree is a silent no-op, and the resolver then reports a miss.
@@ -1123,14 +1139,31 @@ jobs:
             echo "Missing baseline JSONL: $BASELINE"
             exit 2
           fi
-          # Prefer the committed baseline JSON (test262-current.json) for age/SHA
-          # metadata; fall back to test262-report.json if the first doesn't exist.
+          # Age/SHA metadata for the staleness warning. Prefer the FRESH
+          # baselines-repo report JSON (#49) — it carries the baseline_sha /
+          # baseline_generated_at of the JSONL we actually diff against. The
+          # committed benchmarks/results/test262-current.json is deliberately
+          # frozen by promote-baseline (it skips the main commit when only
+          # baseline_sha/timestamp changed), so using it reports a stale
+          # "Nh old (commit <old-sha>)" even when the diffed baseline is current.
+          # Order: fresh baselines JSON → merge-base cache JSON (#1081, if the
+          # diff used it) → committed JSON → committed report.json.
           BASELINE_META=""
-          if [ -f "benchmarks/results/test262-current.json" ]; then
+          MERGE_BASE_JSON=""
+          if [ "${{ steps.merge_base_cache.outputs.cache }}" = "hit" ]; then
+            MB="${{ steps.merge_base_cache.outputs.merge_base }}"
+            [ -n "$MB" ] && [ -f "/tmp/js2wasm-baselines/runs/${MB}.json" ] && MERGE_BASE_JSON="/tmp/js2wasm-baselines/runs/${MB}.json"
+          fi
+          if [ -n "$MERGE_BASE_JSON" ]; then
+            BASELINE_META="$MERGE_BASE_JSON"
+          elif [ -f "/tmp/baseline-meta-fresh.json" ]; then
+            BASELINE_META="/tmp/baseline-meta-fresh.json"
+          elif [ -f "benchmarks/results/test262-current.json" ]; then
             BASELINE_META="benchmarks/results/test262-current.json"
           elif [ -f "benchmarks/results/test262-report.json" ]; then
             BASELINE_META="benchmarks/results/test262-report.json"
           fi
+          echo "Using baseline metadata for staleness warning: ${BASELINE_META:-<none>}"
           META_ARGS=""
           if [ -n "$BASELINE_META" ]; then
             META_ARGS="--baseline-meta $BASELINE_META"

--- a/plan/issues/2133-baseline-sha-stale-in-staleness-warning.md
+++ b/plan/issues/2133-baseline-sha-stale-in-staleness-warning.md
@@ -1,0 +1,69 @@
+---
+id: 2133
+title: "test262 regression-gate staleness warning reads frozen committed baseline_sha (reports '8h old, commit 3903ea6')"
+status: done
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+completed: 2026-06-12
+priority: high
+feasibility: medium
+reasoning_effort: medium
+---
+
+## Problem
+
+PR #1376's regression check, re-run 3× across 2026-06-12 01:00–02:30, kept
+reporting `⚠️ baseline is 8h+ old (commit 3903ea6)` even though the
+js2wasm-baselines repo received fresh commits (pass 31050→31075) in that window.
+
+## Root cause
+
+Two separate baseline artifacts, and the staleness warning reads the wrong one:
+
+1. **The diffed JSONL** comes from the baselines repo
+   (`/tmp/js2wasm-baselines/test262-current.jsonl`) or the #1081 merge-base
+   cache — both **fresh** (baselines HEAD carried advancing main SHAs:
+   `682e22d7`, `68beba90`, `3d352c38`…).
+2. **The staleness warning** in `diff-test262.ts` reads `baseline_sha` +
+   `baseline_generated_at` from `--baseline-meta`, which the workflow pointed at
+   the **committed** `benchmarks/results/test262-current.json`. That committed
+   file is deliberately frozen: `promote-baseline` **skips the main commit when
+   only `baseline_sha`/`timestamp` changed** (`compare-test262-artifact.mjs`
+   excludes those keys, lines ~1529-1538 of test262-sharded.yml). So whenever
+   test262 pass/fail counts are unchanged but main advances, the committed
+   `baseline_sha` stays frozen — it was stuck at `3903ea64` / 17:40 / pass=31050
+   while the real baseline was `682e22d7` / 03:00 / pass=31075.
+
+The warning is **informational only** — it does NOT affect the regression
+gate's exit code (`netPerTest < 0`), so it was never the actual blocker for
+PR #1376 (that was a real `-2 wasm-hash-change` diff against the merge-base).
+But the misleading "8h old" message made every regression report look
+undecidable and eroded trust in the gate.
+
+## Fix
+
+In `test262-sharded.yml`, point `--baseline-meta` at the **same source as the
+diffed JSONL**, newest-first:
+1. the #1081 merge-base cache report (`runs/<merge-base>.json`) when that cache
+   hit (the diff used that exact baseline) — added a `merge_base` step output
+   and sparse-checkout of the `.json`;
+2. else the fresh baselines-repo report (`/tmp/baseline-meta-fresh.json`,
+   copied during the fetch step alongside the JSONL);
+3. else the committed `test262-current.json` / `test262-report.json` (prior
+   behaviour, last resort).
+
+This makes the age/SHA in the warning reflect the baseline actually being
+diffed, so a current baseline never reports as 8h-stale.
+
+Note: the committed `test262-current.json` staying frozen is by design (avoids
+a churn commit on every identical-result push). The hard stale-baseline guard
+(#1668) already reads the advancing main-SHA from the baselines-repo commit
+**subject**, not this committed file, so it was unaffected.
+
+## Validation
+- `test262-sharded.yml` parses as valid YAML.
+- Confirmed the baselines-repo `test262-current.json` carries fresh metadata
+  (`baseline_sha=682e22d7`, `2026-06-12T03:00`, pass=31075) vs the committed
+  file's frozen `3903ea64` / 17:40 / pass=31050 — the exact divergence the fix
+  closes.


### PR DESCRIPTION
## Problem
PR #1376's regression check kept reporting `⚠️ baseline is 8h+ old (commit 3903ea6)` across 3 re-runs even though the js2wasm-baselines repo advanced (pass 31050→31075) in that window.

## Root cause
The staleness warning in `diff-test262.ts` reads `baseline_sha` + `baseline_generated_at` from `--baseline-meta`, which the workflow pointed at the **committed** `benchmarks/results/test262-current.json`. That file is deliberately frozen by `promote-baseline` — it skips the main commit when only `baseline_sha`/`timestamp` changed (so identical-result pushes don't churn main). Meanwhile the actually-diffed JSONL comes fresh from the baselines repo / #1081 merge-base cache. Result: the warning showed `3903ea6` / 17:40 / pass=31050 while the real baseline was `682e22d7` / 03:00 / pass=31075.

The warning is **informational** (doesn't affect the gate's exit code), so it was never the real blocker for #1376 — but it made every regression report look undecidable.

## Fix
Point `--baseline-meta` at the **same source as the diffed JSONL**, newest-first:
1. #1081 merge-base cache report (`runs/<merge-base>.json`) when that cache hit — added a `merge_base` step output;
2. else the fresh baselines-repo report (`/tmp/baseline-meta-fresh.json`, copied during fetch alongside the JSONL);
3. else the committed file (prior behaviour, last resort).

The hard stale-baseline guard (#1668) reads the advancing main-sha from the baselines commit **subject**, not this committed file, so it was unaffected.

## Validation
`test262-sharded.yml` parses as valid YAML. Confirmed the baselines-repo `test262-current.json` carries fresh metadata (sha `682e22d7`, 03:00, pass 31075) vs the committed file's frozen `3903ea64` / 17:40 / 31050 — the exact divergence this closes.

Closes #2133. Related #1235, #1668, #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)