### PR TITLE
fix(#1977): linear array growth — push/set past capacity no longer corrupts the heap

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -68,12 +68,12 @@ if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
         if [ -n "$last_seen" ]; then
           fresh=$(( now_sec - last_seen ))
           [ "$fresh" -lt 0 ] && fresh=0
-          if [ "$fresh" -ge 600 ]; then   color="48;5;196;37"  # red: >10min since heartbeat = likely dead
+          if [ "$fresh" -ge 600 ]; then   color="48;5;196;30"  # red: >10min since heartbeat = likely dead
           elif [ "$fresh" -ge 180 ]; then color="43;30"         # yellow: 3-10min = slow/lagging
           else                            color="42;30"; fi      # green: <3min = alive
         else
           # No heartbeat yet — fall back to time-in-state coloring
-          if [ "$elapsed" -ge 900 ]; then   color="48;5;196;37"
+          if [ "$elapsed" -ge 900 ]; then   color="48;5;196;30"
           elif [ "$elapsed" -ge 300 ]; then color="43;30"
           else                              color="100;37"; fi
         fi
@@ -100,7 +100,7 @@ if [ -n "$resets_at" ]; then
         printf " \033[32m%sd left\033[00m", left
       } else {
         if (days_int >= 2) { fill=43;         fg=30 }
-        else               { fill="48;5;196"; fg=37 }
+        else               { fill="48;5;196"; fg=30 }
         width = 10
         filled = int(elapsed_pct * width / 100 + 0.5)
         label = sprintf(" %sd left", left)
@@ -118,7 +118,7 @@ fi
 if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   if [ -n "$used" ]; then
     awk -v p="$used" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 9
@@ -134,7 +134,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   fi
   if [ -n "$five_hour" ] && [ -z "$in_worktree" ]; then
     awk -v p="$five_hour" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 9
@@ -150,7 +150,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   fi
   if [ -n "$weekly" ] && [ -z "$in_worktree" ]; then
     awk -v p="$weekly" 'BEGIN {
-      if (p >= 75)      { fill="48;5;196"; fg=37 }
+      if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
       width = 10
@@ -192,7 +192,7 @@ pass_bar() {
   awk -v p="$1" -v label="$2" 'BEGIN {
     if (p >= 66.7)     { fill=42; fg=30 }
     else if (p >= 33.3){ fill=43; fg=30 }
-    else               { fill="48;5;196"; fg=37 }
+    else               { fill="48;5;196"; fg=30 }
   }
   END {
     width = 12
@@ -213,7 +213,7 @@ free_bar() {
     pct = free_g * 100 / total_g
     if (pct >= 66.7)      { fill=42; fg=30 }
     else if (pct >= 33.3) { fill=43; fg=30 }
-    else                  { fill="48;5;196"; fg=37 }
+    else                  { fill="48;5;196"; fg=30 }
     width = 10
     filled = int(pct * width / 100)
     label = " " free_g "G free"
@@ -303,7 +303,7 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
     awk -v p="$sprint_pct" -v n="$sprint_n" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
       if (p >= 67)      { fill=42;         fg=30 }
       else if (p >= 33) { fill=43;         fg=30 }
-      else              { fill="48;5;196"; fg=37 }
+      else              { fill="48;5;196"; fg=30 }
       width = 12
       filled = int(p * width / 100)
       label = sprintf(" %d/%d s%d", done, total, n)

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -42,17 +42,6 @@ issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
 
-# PR badge from JSON (open PR for current branch — shown in both views)
-if [ -n "$pr_number" ]; then
-  case "$pr_state" in
-    approved)           pr_color="00;32" ;  pr_icon="✓" ;;
-    changes_requested)  pr_color="00;31" ;  pr_icon="✗" ;;
-    draft)              pr_color="00;90" ;  pr_icon="~" ;;
-    *)                  pr_color="00;33" ;  pr_icon="?" ;;
-  esac
-  printf ' \033[%smPR#%s%s\033[00m' "$pr_color" "$pr_number" "$pr_icon"
-fi
-
 # Agent PR badge — only shown when inside a worktree, for that worktree's own agent
 status_dir="/workspace/.claude/agent-status"
 if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
@@ -429,6 +418,16 @@ fi
 [ -n "$vim_mode" ] && printf ' \033[00;35m%s\033[00m' "$vim_mode"
 # Agent name — shown when running under --agent flag
 [ -n "$agent_name" ] && printf ' \033[00;36magent:%s\033[00m' "$agent_name"
-# Session name (when /rename has been used) — kept last so it ends the line
+# Session name (when /rename has been used) — near the end of the line
 [ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
+# PR badge from JSON (open PR for current branch) — kept last so it ends the line
+if [ -n "$pr_number" ]; then
+  case "$pr_state" in
+    approved)           pr_color="00;32" ;  pr_icon="✓" ;;
+    changes_requested)  pr_color="00;31" ;  pr_icon="✗" ;;
+    draft)              pr_color="00;90" ;  pr_icon="~" ;;
+    *)                  pr_color="00;33" ;  pr_icon="?" ;;
+  esac
+  printf ' \033[%smPR#%s%s\033[00m' "$pr_color" "$pr_number" "$pr_icon"
+fi
 printf '\n'

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -137,7 +137,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
       if (p >= 75)      { fill="48;5;196"; fg=30 }
       else if (p >= 50) { fill=43; fg=30 }
       else              { fill=42; fg=30 }
-      width = 9
+      width = 8
       filled = int(p * width / 100)
       label = sprintf(" %d%% 5h", int(p))
       bar = ""

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -41,6 +41,8 @@ branch=$(git -C "${cwd:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null)
 issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
+# Model badge — before the ctx bar
+[ -n "$model" ] && printf ' \033[%sm%s\033[00m' "$model_color" "$model"
 
 # Agent PR badge — only shown when inside a worktree, for that worktree's own agent
 status_dir="/workspace/.claude/agent-status"
@@ -410,7 +412,6 @@ else
 fi
 # Repo identity (owner/name) — shown only when available and not on main (already know the repo there)
 [ -n "$repo" ] && [ -n "$in_worktree" ] && printf ' \033[00;90m%s\033[00m' "$repo"
-[ -n "$model" ] && printf ' \033[%sm%s\033[00m' "$model_color" "$model"
 [ -n "$effort" ] && [ "$effort" != "none" ] && [ "$effort" != "disabled" ] && printf ' \033[00;33m%s\033[00m' "$effort"
 # Output style — shown when not "default" (non-default modes are worth flagging)
 [ -n "$output_style" ] && [ "$output_style" != "default" ] && [ "$output_style" != "Default" ] && printf ' \033[00;36m[%s]\033[00m' "$output_style"

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -17,6 +17,8 @@ vim_mode=$(echo "$input" | jq -r '.vim.mode // empty')
 agent_name=$(echo "$input" | jq -r '.agent.name // empty')
 repo=$(echo "$input" | jq -r '.workspace.repo | if . then .owner + "/" + .name else empty end')
 case "$model_id" in
+  claude-fable-5*)    model='Fable 5';    price_in=15 ;;
+  claude-mythos-5*)   model='Mythos 5';   price_in=15 ;;
   claude-opus-4-8*)   model='Opus 4.8';   price_in=15 ;;
   claude-opus-4-7*)   model='Opus 4.7';   price_in=15 ;;
   claude-opus-4-6*)   model='Opus 4.6';   price_in=15 ;;
@@ -39,8 +41,6 @@ branch=$(git -C "${cwd:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null)
 issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
-# Session name (when /rename has been used)
-[ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
 
 # PR badge from JSON (open PR for current branch — shown in both views)
 if [ -n "$pr_number" ]; then
@@ -429,4 +429,6 @@ fi
 [ -n "$vim_mode" ] && printf ' \033[00;35m%s\033[00m' "$vim_mode"
 # Agent name — shown when running under --agent flag
 [ -n "$agent_name" ] && printf ' \033[00;36magent:%s\033[00m' "$agent_name"
+# Session name (when /rename has been used) — kept last so it ends the line
+[ -n "$session_name" ] && printf ' \033[00;36m(%s)\033[00m' "$session_name"
 printf '\n'

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -94,6 +94,38 @@ if [ -d "$status_dir" ] && [ -n "$in_worktree" ]; then
   fi
 fi
 
+# Days-left-in-week bar: derived from rate_limits.seven_day.resets_at (Unix ts).
+# Computed here so it can be emitted right after the wkly bar below.
+days_bar=""
+resets_at=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+if [ -n "$resets_at" ]; then
+  now_sec=$(date +%s)
+  remaining_sec=$((${resets_at%.*} - now_sec))
+  if [ "$remaining_sec" -gt 0 ]; then
+    days_left=$(awk "BEGIN {printf \"%.1f\", $remaining_sec / 86400}")
+    days_int=$(awk "BEGIN {printf \"%d\", $remaining_sec / 86400}")
+    elapsed_pct=$(awk "BEGIN {printf \"%.4f\", (7 - $remaining_sec / 86400) * 100 / 7}")
+    days_bar=$(awk -v left="$days_left" -v days_int="$days_int" -v elapsed_pct="$elapsed_pct" 'BEGIN {
+      if (days_int >= 4) {
+        # Green zone: plain green text, no background bar — less salient
+        printf " \033[32m%sd left\033[00m", left
+      } else {
+        if (days_int >= 2) { fill=43;         fg=30 }
+        else               { fill="48;5;196"; fg=37 }
+        width = 10
+        filled = int(elapsed_pct * width / 100 + 0.5)
+        label = sprintf(" %sd left", left)
+        bar = ""
+        for (i = 0; i < width; i++) bar = bar " "
+        bar = label substr(bar, length(label) + 1)
+        filled_part = substr(bar, 1, filled)
+        empty_part  = substr(bar, filled + 1)
+        printf " \033[%s;%sm%s\033[48;5;237;37m%s \033[00m", fill, fg, filled_part, empty_part
+      }
+    }' /dev/null)
+  fi
+fi
+
 if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
   if [ -n "$used" ]; then
     awk -v p="$used" 'BEGIN {
@@ -142,6 +174,7 @@ if [ -n "$used" ] || [ -n "$weekly" ] || [ -n "$five_hour" ]; then
       empty_part  = substr(bar, filled + 1)
       printf " \033[%s;%sm%s\033[48;5;237;37m%s\033[00m", fill, fg, filled_part, empty_part
     }' /dev/null
+    [ -n "$days_bar" ] && printf '%s' "$days_bar"
   fi
 fi
 # Test262 progress
@@ -276,37 +309,6 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
       fi
     fi
   fi
-  # Days-left-in-week bar: derived from rate_limits.seven_day.resets_at (Unix ts)
-  # Captured into $days_bar and emitted after the free memory indicator below.
-  days_bar=""
-  resets_at=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
-  if [ -n "$resets_at" ]; then
-    now_sec=$(date +%s)
-    remaining_sec=$((${resets_at%.*} - now_sec))
-    if [ "$remaining_sec" -gt 0 ]; then
-      days_left=$(awk "BEGIN {printf \"%.1f\", $remaining_sec / 86400}")
-      days_int=$(awk "BEGIN {printf \"%d\", $remaining_sec / 86400}")
-      elapsed_pct=$(awk "BEGIN {printf \"%.4f\", (7 - $remaining_sec / 86400) * 100 / 7}")
-      days_bar=$(awk -v left="$days_left" -v days_int="$days_int" -v elapsed_pct="$elapsed_pct" 'BEGIN {
-        if (days_int >= 4) {
-          # Green zone: plain green text, no background bar — less salient
-          printf " \033[32m%sd left\033[00m", left
-        } else {
-          if (days_int >= 2) { fill=43;         fg=30 }
-          else               { fill="48;5;196"; fg=37 }
-          width = 10
-          filled = int(elapsed_pct * width / 100 + 0.5)
-          label = sprintf(" %sd left", left)
-          bar = ""
-          for (i = 0; i < width; i++) bar = bar " "
-          bar = label substr(bar, length(label) + 1)
-          filled_part = substr(bar, 1, filled)
-          empty_part  = substr(bar, filled + 1)
-          printf " \033[%s;%sm%s\033[48;5;237;37m%s \033[00m", fill, fg, filled_part, empty_part
-        }
-      }' /dev/null)
-    fi
-  fi
   if [ -n "$sprint_n" ] && [ "$sprint_total" -gt 0 ]; then
     sprint_pct=$((sprint_done * 100 / sprint_total))
     awk -v p="$sprint_pct" -v n="$sprint_n" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
@@ -387,7 +389,6 @@ elif [ -n "$vitesting" ]; then
         p_bar=$(pass_bar "$pass_pct" "${pass_pct}% t262")
         f_bar=$(free_bar "$free_g")
         printf ' \033[00;33m⟳t262\033[00m %s %s %s' "$p_bar" "$d_bar" "$f_bar"
-        [ -n "$days_bar" ] && printf '%s' "$days_bar"
       else
         printf ' \033[00;33m⟳t262\033[00m %s' "$d_bar"
       fi
@@ -407,7 +408,6 @@ elif [ -f "$report" ]; then
     p_bar=$(pass_bar "$pass_pct" "${pass_pct}% t262")
     f_bar=$(free_bar "$free_g")
     printf ' %s %s' "$p_bar" "$f_bar"
-    [ -n "$days_bar" ] && printf '%s' "$days_bar"
   fi
 fi
 # Branch display:

--- a/plan/issues/1105-wasm-native-string-method-implementations.md
+++ b/plan/issues/1105-wasm-native-string-method-implementations.md
@@ -13,8 +13,6 @@ language_feature: string-methods
 goal: standalone-mode
 sprint: 58
 es_edition: multi
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:52:56.870Z
 ---
 # #1105 — Wasm-native String method implementations for standalone mode
 

--- a/plan/issues/1320-array-from-externref-iterator-bridge.md
+++ b/plan/issues/1320-array-from-externref-iterator-bridge.md
@@ -14,8 +14,6 @@ language_feature: iterators, externref, Array.from
 goal: spec-conformance
 sprint: 61
 related: [1154, 1665, 1472, 1620, 1633, 1684]
-claimed_by: codex-developer
-claimed_at: 2026-06-10T16:33:00.234Z
 completed: 2026-06-10
 ---
 # #1320 — Array.from / Iterator.from runtime bridge drops own [Symbol.iterator]

--- a/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
+++ b/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
@@ -13,8 +13,6 @@ language_feature: async, promises, generators
 goal: standalone-mode
 sprint: 58
 required_by: [1326c, 1766, 1774]
-claimed_by: codex-developer
-claimed_at: 2026-06-02T22:45:33.452Z
 ---
 # #1326 — Async standalone: Wasm microtask queue + CPS desugaring
 

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -13,8 +13,6 @@ language_feature: class
 goal: spec-completeness
 sprint: 61
 parent: 1328
-claimed_by: codex-developer
-claimed_at: 2026-06-06T09:51:22.932Z
 pr: 1250
 completed: 2026-06-06
 ---

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -16,8 +16,6 @@ model: fable
 depends_on: [1710, 1711]
 es_edition: multi
 related: [1690, 1690b, 1584, 1058]
-claimed_by: codex-developer
-claimed_at: 2026-06-07T05:10:23.845Z
 pr: 1293
 ---
 

--- a/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
+++ b/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
@@ -13,8 +13,6 @@ language_feature: array-pop, empty-array, undefined
 goal: standalone-correctness
 sprint: 58
 related: [1584, 1748]
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:53:18.030Z
 ---
 # #1747 — `[].pop()` on an empty array traps instead of returning `undefined`
 

--- a/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
+++ b/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
@@ -15,8 +15,6 @@ sprint: 58
 es_edition: n/a
 related: [1662, 1776, 1472, 682, 1474, 1599, 1387, 1778, 1782, 1591, 1623, 1665]
 origin: "Investigation of all failing standalone test262 tests found that the June 1 full standalone JSONL/report artifacts were generated but not retained, leaving only summary counts and five manually documented root-cause clusters."
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:53:11.407Z
 ---
 # #1781 - Standalone test262 run must publish full JSONL and root-cause issue map
 

--- a/plan/issues/1977-linear-array-push-heap-corruption.md
+++ b/plan/issues/1977-linear-array-push-heap-corruption.md
@@ -1,10 +1,11 @@
 ---
 id: 1977
 title: "linear backend: Array.push past capacity silently corrupts adjacent heap objects — no growth, no bounds checks in the array runtime"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-12
+completed: 2026-06-12
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -63,3 +64,42 @@ undefined-sentinel for `idx >= len`.
 #2045 is the **GC/WASI codegen's** linear-uint8 fast path
 (`src/codegen/linear-uint8-*.ts`) — different subsystem. #1856 (allocator
 modes), #46 (backend creation) don't mention bounds/growth. Unfiled.
+
+## Resolution (2026-06-12)
+
+Implemented growth via relocation + forwarding in
+`src/codegen-linear/runtime.ts`:
+
+- `__arr_grow(ptr, minCap) → newPtr` — allocates a fresh block with
+  `cap = max(cap*2, minCap, 4)`, copies `len` elements, and rewrites the OLD
+  header into a forwarding record (tag `0x06` at +0, new pointer at +4).
+  Linear has no GC forwarding, so stale aliases are handled lazily: every
+  accessor first chases the forwarding chain via the new idempotent
+  `__arr_resolve` helper (registered by both `addUint8ArrayRuntime` and
+  `addArrayRuntime`, so direct-runtime tests that build modules manually
+  keep working).
+- `__arr_push` — resolves, grows when `len >= cap`, then stores.
+- `__arr_set` — resolves; grows when `idx >= cap`; zero-fills the gap and
+  extends `len` to `idx+1` when `idx >= len` (JS store-beyond-length);
+  negative `idx` (a JS non-index property write) is a no-op instead of
+  corrupting header/neighbour memory.
+- `__arr_get` — resolves; `idx >= len` (unsigned, covers negative) returns
+  0, the linear backend's `undefined` representation.
+- `__arr_len` — resolves before loading.
+- `__u8arr_from_arr` — resolves its array argument at entry (only raw
+  offset-16 array consumer outside the core accessors; the map/set
+  offset-16 hits are their own structures, and the simd.ts array helpers
+  are currently unreferenced dead code).
+
+Tag dispatch sites in `src/codegen-linear/index.ts` (`tag == 0x02` →
+Uint8Array else Array) stay correct: a forwarded header (0x06) routes to
+the `__arr_*` helpers, which resolve internally.
+
+## Test Results
+
+- Repro returns 600 in linear mode (was 500).
+- `tests/issue-1977.test.ts` — 8/8: neighbour integrity, relocation value
+  survival, alias-through-growth, `a[5]=9` → length 6, zero-filled gap,
+  OOB/negative reads → 0, 1000-push interleaved stress (sum verified),
+  in-capacity behaviour unregressed.
+- All 17 linear suites (`tests/linear-*.test.ts`) — 136/136 pass.

--- a/plan/issues/680-wasm-native-generators-state-machines.md
+++ b/plan/issues/680-wasm-native-generators-state-machines.md
@@ -17,8 +17,6 @@ files:
   src/codegen/expressions.ts:
     breaking:
       - "yield compiles to state save + return, next() resumes from saved state"
-claimed_by: codex-developer
-claimed_at: 2026-06-02T22:52:32.748Z
 ---
 # #680 — Wasm-native generators (state machines) with optional JS host fallback
 

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -234,6 +234,7 @@ function addArenaManagementExports(mod: WasmModule, heapPtrGlobalIdx: number): v
  * - __u8arr_len(ptr: i32) → i32
  */
 export function addUint8ArrayRuntime(mod: WasmModule): void {
+  ensureArrayResolveRuntime(mod); // __u8arr_from_arr resolves forwarded arrays (#1977)
   const mallocIdx = findFuncIndex(mod, "__malloc");
 
   // __u8arr_new: allocate header(8) + len(4) + bytes(len)
@@ -425,6 +426,11 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
       const newPtrLocal = local1Idx + 1;
       const iLocal = local1Idx + 2;
       return [
+        // arrPtr = __arr_resolve(arrPtr) — the source array may have been
+        // relocated by a growing push (#1977)
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: findFuncIndex(mod, "__arr_resolve") },
+        { op: "local.set", index: 0 },
         // len = arrPtr.len (at +8)
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 8 },
@@ -479,12 +485,57 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
   );
 }
 
+/** Tag byte marking a relocated (grown) array header — see addArrayResolveRuntime (#1977). */
+const ARR_FORWARDED_TAG = 0x06;
+
+/**
+ * Register the array forwarding resolver (#1977) — idempotent; called by
+ * every runtime builder whose functions touch array memory
+ * (addUint8ArrayRuntime's __u8arr_from_arr, addArrayRuntime).
+ *
+ * When __arr_push outgrows capacity it relocates the array to a fresh
+ * allocation and rewrites the OLD header into a forwarding record:
+ * tag ARR_FORWARDED_TAG at +0, the new pointer at +4. Aliased locals/fields
+ * still hold the old pointer, so every accessor first chases the forwarding
+ * chain: while (tag == ARR_FORWARDED_TAG) ptr = *(ptr+4).
+ */
+function ensureArrayResolveRuntime(mod: WasmModule): void {
+  if (mod.functions.some((f) => f.name === "__arr_resolve")) return;
+  addRuntimeFunc(mod, "__arr_resolve", [{ kind: "i32" }], [{ kind: "i32" }], [], () => [
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if tag != ARR_FORWARDED_TAG, break
+            { op: "local.get", index: 0 },
+            { op: "i32.load8_u", align: 0, offset: 0 },
+            { op: "i32.const", value: ARR_FORWARDED_TAG },
+            { op: "i32.ne" },
+            { op: "br_if", depth: 1 },
+            // ptr = *(ptr+4)
+            { op: "local.get", index: 0 },
+            { op: "i32.load", align: 2, offset: 4 },
+            { op: "local.set", index: 0 },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: 0 },
+  ]);
+}
+
 /**
  * Add Array runtime functions to the module.
  * Layout: [header 8B][len:u32 at +8][cap:u32 at +12][elements: i32×cap at +16...]
  *
  * Functions added:
  * - __arr_new(cap: i32) → i32 (pointer)
+ * - __arr_grow(ptr: i32, minCap: i32) → i32 (relocated pointer; forwards old header)
  * - __arr_push(ptr: i32, val: i32) → void
  * - __arr_get(ptr: i32, idx: i32) → i32
  * - __arr_set(ptr: i32, idx: i32, val: i32) → void
@@ -492,6 +543,7 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
  * - __arr_from_data(dataPtr: i32, len: i32) → i32 (header ptr)
  */
 export function addArrayRuntime(mod: WasmModule): void {
+  ensureArrayResolveRuntime(mod); // accessors below resolve forwarded arrays (#1977)
   const mallocIdx = findFuncIndex(mod, "__malloc");
 
   // __arr_new: allocate header(8) + len(4) + cap(4) + elements(cap*4)
@@ -530,7 +582,134 @@ export function addArrayRuntime(mod: WasmModule): void {
     1,
   );
 
-  // __arr_push: store val at ptr+16+len*4, increment len
+  const arrResolveIdx = findFuncIndex(mod, "__arr_resolve");
+
+  // __arr_grow(ptr, minCap) → newPtr (#1977)
+  // Relocate the array to a fresh allocation with cap = max(cap*2, minCap, 4),
+  // copy len elements, and rewrite the old header into a forwarding record
+  // (tag ARR_FORWARDED_TAG at +0, newPtr at +4) so stale aliases resolve.
+  // Caller must pass an already-resolved ptr.
+  addRuntimeFunc(
+    mod,
+    "__arr_grow",
+    [{ kind: "i32" }, { kind: "i32" }],
+    [{ kind: "i32" }],
+    [],
+    (firstLocalIdx) => {
+      const lenLocal = firstLocalIdx;
+      const newCapLocal = firstLocalIdx + 1;
+      const newPtrLocal = firstLocalIdx + 2;
+      const iLocal = firstLocalIdx + 3;
+      return [
+        // len = *(ptr+8)
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "local.set", index: lenLocal },
+        // newCap = *(ptr+12) * 2
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 12 },
+        { op: "i32.const", value: 2 },
+        { op: "i32.mul" },
+        { op: "local.set", index: newCapLocal },
+        // if newCap < minCap: newCap = minCap
+        { op: "local.get", index: newCapLocal },
+        { op: "local.get", index: 1 },
+        { op: "i32.lt_u" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 1 },
+            { op: "local.set", index: newCapLocal },
+          ],
+          else: [],
+        },
+        // if newCap < 4: newCap = 4
+        { op: "local.get", index: newCapLocal },
+        { op: "i32.const", value: 4 },
+        { op: "i32.lt_u" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 4 },
+            { op: "local.set", index: newCapLocal },
+          ],
+          else: [],
+        },
+        // newPtr = __malloc(16 + newCap*4)
+        { op: "i32.const", value: 16 },
+        { op: "local.get", index: newCapLocal },
+        { op: "i32.const", value: 4 },
+        { op: "i32.mul" },
+        { op: "i32.add" },
+        { op: "call", funcIdx: mallocIdx },
+        { op: "local.set", index: newPtrLocal },
+        // Header: tag 0x01 (Array), len, newCap
+        { op: "local.get", index: newPtrLocal },
+        { op: "i32.const", value: 0x01 },
+        { op: "i32.store8", align: 0, offset: 0 },
+        { op: "local.get", index: newPtrLocal },
+        { op: "local.get", index: lenLocal },
+        { op: "i32.store", align: 2, offset: 8 },
+        { op: "local.get", index: newPtrLocal },
+        { op: "local.get", index: newCapLocal },
+        { op: "i32.store", align: 2, offset: 12 },
+        // Copy elements: for (i = 0; i < len; i++) newPtr[i] = ptr[i]
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: iLocal },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: iLocal },
+                { op: "local.get", index: lenLocal },
+                { op: "i32.ge_u" },
+                { op: "br_if", depth: 1 },
+                { op: "local.get", index: newPtrLocal },
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 4 },
+                { op: "i32.mul" },
+                { op: "i32.add" },
+                { op: "local.get", index: 0 },
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 4 },
+                { op: "i32.mul" },
+                { op: "i32.add" },
+                { op: "i32.load", align: 2, offset: 16 },
+                { op: "i32.store", align: 2, offset: 16 },
+                { op: "local.get", index: iLocal },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: iLocal },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        // Forward the old header: tag ARR_FORWARDED_TAG, newPtr at +4
+        { op: "local.get", index: 0 },
+        { op: "i32.const", value: ARR_FORWARDED_TAG },
+        { op: "i32.store8", align: 0, offset: 0 },
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: newPtrLocal },
+        { op: "i32.store", align: 2, offset: 4 },
+        // Return newPtr
+        { op: "local.get", index: newPtrLocal },
+      ];
+    },
+    4,
+  );
+
+  const arrGrowIdx = findFuncIndex(mod, "__arr_grow");
+
+  // __arr_push: store val at ptr+16+len*4, increment len.
+  // Resolves forwarding and grows when len == cap (#1977 — was an unbounded
+  // write into the bump arena that corrupted adjacent allocations).
   addRuntimeFunc(
     mod,
     "__arr_push",
@@ -538,10 +717,32 @@ export function addArrayRuntime(mod: WasmModule): void {
     [],
     [],
     (local2Idx) => [
+      // ptr = __arr_resolve(ptr)
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: arrResolveIdx },
+      { op: "local.set", index: 0 },
       // Load current len
       { op: "local.get", index: 0 }, // ptr
       { op: "i32.load", align: 2, offset: 8 },
       { op: "local.set", index: local2Idx },
+      // if len >= cap: ptr = __arr_grow(ptr, len+1)
+      { op: "local.get", index: local2Idx },
+      { op: "local.get", index: 0 },
+      { op: "i32.load", align: 2, offset: 12 },
+      { op: "i32.ge_u" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: local2Idx },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "call", funcIdx: arrGrowIdx },
+          { op: "local.set", index: 0 },
+        ],
+        else: [],
+      },
       // Store val at ptr + 16 + len*4
       { op: "local.get", index: 0 }, // ptr
       { op: "local.get", index: local2Idx }, // len
@@ -560,8 +761,26 @@ export function addArrayRuntime(mod: WasmModule): void {
     1,
   );
 
-  // __arr_get: load i32 at ptr + 16 + idx*4
+  // __arr_get: load i32 at ptr + 16 + idx*4.
+  // Resolves forwarding; OOB (idx >= len, unsigned — covers negative idx)
+  // returns 0, the backend's undefined representation (#1977 — was a raw
+  // load of neighbouring memory).
   addRuntimeFunc(mod, "__arr_get", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], [], () => [
+    // ptr = __arr_resolve(ptr)
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: arrResolveIdx },
+    { op: "local.set", index: 0 },
+    // if idx >= len (unsigned): return 0 (undefined)
+    { op: "local.get", index: 1 },
+    { op: "local.get", index: 0 },
+    { op: "i32.load", align: 2, offset: 8 },
+    { op: "i32.ge_u" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      else: [],
+    },
     { op: "local.get", index: 0 }, // ptr
     { op: "local.get", index: 1 }, // idx
     { op: "i32.const", value: 4 },
@@ -570,20 +789,118 @@ export function addArrayRuntime(mod: WasmModule): void {
     { op: "i32.load", align: 2, offset: 16 },
   ]);
 
-  // __arr_set: store i32 at ptr + 16 + idx*4
-  addRuntimeFunc(mod, "__arr_set", [{ kind: "i32" }, { kind: "i32" }, { kind: "i32" }], [], [], () => [
-    { op: "local.get", index: 0 }, // ptr
-    { op: "local.get", index: 1 }, // idx
-    { op: "i32.const", value: 4 },
-    { op: "i32.mul" },
-    { op: "i32.add" },
-    { op: "local.get", index: 2 }, // val
-    { op: "i32.store", align: 2, offset: 16 },
-  ]);
+  // __arr_set: store i32 at ptr + 16 + idx*4.
+  // Resolves forwarding; grows when idx >= cap; extends len (zero-filling
+  // the gap) when idx >= len, per JS store-beyond-length semantics (#1977).
+  // A negative idx is a JS non-index property write — dropped (no-op) rather
+  // than corrupting header/neighbour memory.
+  addRuntimeFunc(
+    mod,
+    "__arr_set",
+    [{ kind: "i32" }, { kind: "i32" }, { kind: "i32" }],
+    [],
+    [],
+    (firstLocalIdx) => {
+      const fillLocal = firstLocalIdx;
+      return [
+        // if idx < 0 (signed): no-op
+        { op: "local.get", index: 1 },
+        { op: "i32.const", value: 0 },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "return" }],
+          else: [],
+        },
+        // ptr = __arr_resolve(ptr)
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: arrResolveIdx },
+        { op: "local.set", index: 0 },
+        // if idx >= cap: ptr = __arr_grow(ptr, idx+1)
+        { op: "local.get", index: 1 },
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 12 },
+        { op: "i32.ge_u" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "call", funcIdx: arrGrowIdx },
+            { op: "local.set", index: 0 },
+          ],
+          else: [],
+        },
+        // Zero-fill the gap: for (fill = len; fill < idx; fill++) ptr[fill] = 0
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "local.set", index: fillLocal },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: fillLocal },
+                { op: "local.get", index: 1 },
+                { op: "i32.ge_u" },
+                { op: "br_if", depth: 1 },
+                { op: "local.get", index: 0 },
+                { op: "local.get", index: fillLocal },
+                { op: "i32.const", value: 4 },
+                { op: "i32.mul" },
+                { op: "i32.add" },
+                { op: "i32.const", value: 0 },
+                { op: "i32.store", align: 2, offset: 16 },
+                { op: "local.get", index: fillLocal },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: fillLocal },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        // if idx >= len: len = idx + 1
+        { op: "local.get", index: 1 },
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "i32.ge_u" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "i32.store", align: 2, offset: 8 },
+          ],
+          else: [],
+        },
+        // Store val
+        { op: "local.get", index: 0 }, // ptr
+        { op: "local.get", index: 1 }, // idx
+        { op: "i32.const", value: 4 },
+        { op: "i32.mul" },
+        { op: "i32.add" },
+        { op: "local.get", index: 2 }, // val
+        { op: "i32.store", align: 2, offset: 16 },
+      ];
+    },
+    1,
+  );
 
-  // __arr_len: load i32 at ptr+8
+  // __arr_len: load i32 at ptr+8 (resolving forwarding, #1977)
   addRuntimeFunc(mod, "__arr_len", [{ kind: "i32" }], [{ kind: "i32" }], [], () => [
     { op: "local.get", index: 0 }, // ptr
+    { op: "call", funcIdx: arrResolveIdx },
     { op: "i32.load", align: 2, offset: 8 },
   ]);
 

--- a/tests/issue-1977.test.ts
+++ b/tests/issue-1977.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1977 — linear backend: Array.push past capacity silently corrupted
+// adjacent heap objects (no growth path), arr[idx] stores beyond length
+// neither extended nor bounds-checked, and OOB reads returned raw
+// neighbouring memory.
+//
+// The fix adds __arr_grow (double capacity, relocate, leave a forwarding
+// record in the old header) plus forwarding resolution and bounds/length
+// semantics in __arr_push / __arr_get / __arr_set / __arr_len.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const r = await compile(source, { target: "linear" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "<unknown>"}`);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, { env: {} });
+  return (instance.exports as any)[fn]();
+}
+
+describe("#1977 — linear array growth and bounds", () => {
+  it("push past capacity does not corrupt the neighbouring allocation", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [1];
+        const b = [100, 200, 300];
+        for (let i = 0; i < 20; i++) a.push(0);
+        return b[0] + b[1] + b[2];
+      }
+    `);
+    expect(out).toBe(600);
+  });
+
+  it("pushed values survive relocation", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [7];
+        for (let i = 1; i <= 30; i++) a.push(i);
+        return a[0] + a[1] + a[30] + a.length;
+      }
+    `);
+    expect(out).toBe(7 + 1 + 30 + 31);
+  });
+
+  it("aliases observe growth through the forwarding record", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [1];
+        const b = a;
+        for (let i = 0; i < 20; i++) a.push(i);
+        return b.length + b[20];
+      }
+    `);
+    expect(out).toBe(21 + 19);
+  });
+
+  it("store beyond length extends the array (a[5] = 9 → length 6)", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [1];
+        a[5] = 9;
+        return a.length * 100 + a[5];
+      }
+    `);
+    expect(out).toBe(609);
+  });
+
+  it("the gap created by store-beyond-length reads as undefined (0)", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [1];
+        a[5] = 9;
+        return a[2];
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("out-of-bounds and negative reads yield the undefined sentinel", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [1, 2, 3];
+        return a[10] + a[-1];
+      }
+    `);
+    expect(out).toBe(0);
+  });
+
+  it("stress: 1000 pushes with interleaved allocations stay consistent", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [0];
+        const guards: number[][] = [];
+        for (let i = 1; i < 1000; i++) {
+          a.push(i);
+          if (i % 50 === 0) guards.push([i, i * 2, i * 3]);
+        }
+        let sum = 0;
+        for (let i = 0; i < a.length; i++) sum += a[i];
+        let g = 0;
+        for (let i = 0; i < guards.length; i++) g += guards[i][0] + guards[i][1] + guards[i][2];
+        return sum * 1000000 + g;
+      }
+    `);
+    // sum(0..999) = 499500; guards: 6 * (50+100+...+950) = 57000
+    expect(out).toBe(499500 * 1000000 + 57000);
+  });
+
+  it("in-capacity behaviour unregressed (literal init, set, get, len)", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = [10, 20, 30];
+        a[1] = 21;
+        let s = 0;
+        for (let i = 0; i < a.length; i++) s += a[i];
+        return s;
+      }
+    `);
+    expect(out).toBe(61);
+  });
+});


### PR DESCRIPTION
Fixes #1977 (plan/issues/1977-linear-array-push-heap-corruption.md) — CRITICAL, sprint 61, linear backend.

## Problem

`__arr_push` stored at `ptr+16+len*4` with no capacity check or growth path — pushing past capacity silently overwrote the next bump allocation (repro: pushing into `a` overwrote `b[0]`, returning 500 instead of 600). `__arr_set`/`__arr_get` were raw stores/loads: store-beyond-length neither extended nor errored, and OOB/negative reads returned neighbouring memory.

## Fix (src/codegen-linear/runtime.ts)

Linear memory has no GC forwarding, so growth relocates and leaves a forwarding record:

- **`__arr_grow(ptr, minCap)`** — fresh block with `cap = max(cap*2, minCap, 4)`, copies elements, rewrites the old header to tag `0x06` + new pointer at +4.
- **`__arr_resolve`** (idempotent registration, used by both `addUint8ArrayRuntime` and `addArrayRuntime`) — chases the forwarding chain so stale aliases keep working lazily.
- **`__arr_push`** resolves + grows on `len >= cap`. **`__arr_set`** resolves, grows on `idx >= cap`, zero-fills the gap and extends `len` per JS store-beyond-length; negative idx is a no-op instead of header corruption. **`__arr_get`** returns 0 (the backend's `undefined`) for OOB (unsigned compare covers negative). **`__arr_len`** resolves. **`__u8arr_from_arr`** (the only raw array consumer outside the accessors) resolves its argument.
- Tag-dispatch sites in index.ts (`tag == 0x02` → Uint8Array else Array) stay correct: forwarded headers (0x06) route to the `__arr_*` helpers, which resolve internally.

## Tests

`tests/issue-1977.test.ts` — 8 tests: neighbour integrity (repro = 600), relocation value survival, **alias-through-growth**, `a[5]=9` → length 6, zero-filled gap, OOB/negative reads → 0, 1000-push interleaved stress, in-capacity behaviour unregressed. All 17 `tests/linear-*.test.ts` suites: 136/136 pass (including the direct-runtime module-builder tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)