### PR TITLE
fix(#1976): linear string relationals compare content; string += is concat

### DIFF
--- a/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
+++ b/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
@@ -62,3 +62,35 @@ tracking for concat results in compound assignment and declarations.
 
 #1588 tracks UTF-8/WTF-16 strategy for the **GC** backend's dual storage; no
 issue on linear string compare/length. Unfiled.
+
+## Progress (2026-06-12) — relationals + concat-typing fixed; UTF-8 length follow-up
+
+**Done (this PR):**
+
+1. **String relationals** (`<`/`<=`/`>`/`>=`) now compare by content. Added a
+   `__str_cmp` runtime fn (lexicographic byte compare → -1/0/1) and route string
+   relationals through it before the `bothI32` pointer-comparison path. For
+   ASCII this matches JS UTF-16 ordering. (Multi-byte UTF-8 orders by byte, which
+   can differ for astral code points — folded into the length follow-up below.)
+2. **Concat type confusion → invalid module** fixed. `s += t` for a string `s`
+   now calls `__str_concat` and stores the i32 result (was `f64.add` → i32/f64
+   mismatch); `inferExprType` treats a string `a + b` as an i32 result so
+   `const x = "a" + b` declares an i32 local. Both compound-assign and
+   declaration paths produce valid modules now.
+
+Repro rows 1–2 (relationals) match Node; both invalid-module cases are gone.
+`tests/issue-1976.test.ts` (15 cases) + all 136 existing linear tests green.
+
+**Remaining (separate follow-up):** `.length` still returns the UTF-8 **byte**
+count, not UTF-16 code units (`"é世😀".length` → 9, Node → 4). Fixing this needs
+either WTF-16 storage (matching the GC nativeStrings i16 layout) or a code-unit
+count in `__str_len`, plus an audit of `charCodeAt`/`codePointAt`/slice on the
+same decision — a substantial string-subsystem change, larger than the compare
++ concat fixes here. ASCII lengths are correct. (Related to #1588's GC-side
+UTF-8/WTF-16 work.)
+
+### Files
+
+- `src/codegen-linear/runtime.ts` — new `__str_cmp` helper
+- `src/codegen-linear/index.ts` — route string relationals through `__str_cmp`;
+  string `+=` via `__str_concat`; `inferExprType` string-concat → i32

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -1967,6 +1967,31 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     }
   }
 
+  // #1976: string `+=` is concatenation, not numeric add. `s += t` for string
+  // `s` must call __str_concat (both operands are i32 pointers) and store the
+  // i32 result — the generic compound path below emits f64.add, which produces
+  // an invalid module (i32/f64 mismatch). Handle local and global string LHS.
+  if (op === ts.SyntaxKind.PlusEqualsToken && ts.isIdentifier(expr.left) && isStringExpr(ctx, fctx, expr.left)) {
+    const strConcatIdx = ctx.funcMap.get("__str_concat");
+    const localIdx = fctx.localMap.get(expr.left.text);
+    if (strConcatIdx !== undefined && localIdx !== undefined) {
+      fctx.body.push({ op: "local.get", index: localIdx });
+      compileExpression(ctx, fctx, expr.right);
+      fctx.body.push({ op: "call", funcIdx: strConcatIdx });
+      fctx.body.push({ op: "local.tee", index: localIdx });
+      return;
+    }
+    const gIdx = ctx.moduleGlobals.get(expr.left.text);
+    if (strConcatIdx !== undefined && gIdx !== undefined) {
+      fctx.body.push({ op: "global.get", index: gIdx });
+      compileExpression(ctx, fctx, expr.right);
+      fctx.body.push({ op: "call", funcIdx: strConcatIdx });
+      fctx.body.push({ op: "global.set", index: gIdx });
+      fctx.body.push({ op: "global.get", index: gIdx });
+      return;
+    }
+  }
+
   // Handle compound assignment (+=, -=, *=, /=, |=, &=, etc.)
   if (isCompoundAssignment(op) && ts.isIdentifier(expr.left)) {
     const idx = fctx.localMap.get(expr.left.text);
@@ -2099,6 +2124,37 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
       compileExpression(ctx, fctx, expr.right);
       const strConcatIdx = ctx.funcMap.get("__str_concat")!;
       fctx.body.push({ op: "call", funcIdx: strConcatIdx });
+      return;
+    }
+    // #1976: string relationals (`<`/`<=`/`>`/`>=`) must compare by content, not
+    // by pointer address. Route through __str_cmp (-1/0/1) then test the sign;
+    // the result is an f64 boolean to match the rest of the expression lowering.
+    if (
+      op === ts.SyntaxKind.LessThanToken ||
+      op === ts.SyntaxKind.LessThanEqualsToken ||
+      op === ts.SyntaxKind.GreaterThanToken ||
+      op === ts.SyntaxKind.GreaterThanEqualsToken
+    ) {
+      compileExpression(ctx, fctx, expr.left);
+      compileExpression(ctx, fctx, expr.right);
+      const strCmpIdx = ctx.funcMap.get("__str_cmp")!;
+      fctx.body.push({ op: "call", funcIdx: strCmpIdx });
+      fctx.body.push({ op: "i32.const", value: 0 });
+      switch (op) {
+        case ts.SyntaxKind.LessThanToken:
+          fctx.body.push({ op: "i32.lt_s" });
+          break;
+        case ts.SyntaxKind.LessThanEqualsToken:
+          fctx.body.push({ op: "i32.le_s" });
+          break;
+        case ts.SyntaxKind.GreaterThanToken:
+          fctx.body.push({ op: "i32.gt_s" });
+          break;
+        default: // GreaterThanEqualsToken
+          fctx.body.push({ op: "i32.ge_s" });
+          break;
+      }
+      fctx.body.push({ op: "f64.convert_i32_s" });
       return;
     }
   }
@@ -3808,6 +3864,15 @@ function inferExprType(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Exp
   // String literals and template expressions are i32 (pointers)
   if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr) || ts.isTemplateExpression(expr)) {
     return { kind: "i32" };
+  }
+
+  // #1976: string concatenation (`a + b` where either side is a string) yields
+  // a string POINTER (i32). Decide this explicitly before the numeric default
+  // so `const x = "a" + b` declares an i32 local matching __str_concat's result.
+  if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    if (isStringExpr(ctx, fctx, expr.left) || isStringExpr(ctx, fctx, expr.right)) {
+      return { kind: "i32" };
+    }
   }
 
   // `this` is always an i32 pointer

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -882,6 +882,106 @@ export function addStringRuntime(mod: WasmModule): void {
     2,
   );
 
+  // __str_cmp: lexicographic comparison → -1 / 0 / 1 (#1976).
+  // Compares byte-by-byte up to min(lenA, lenB); the first differing (unsigned)
+  // byte decides; if one is a prefix of the other, the shorter is "less". For
+  // ASCII this matches JS's UTF-16 code-unit ordering. (Multi-byte UTF-8 orders
+  // by byte, which can differ from UTF-16 order for astral/supplementary code
+  // points — tracked with the UTF-8↔UTF-16 storage decision in this issue.)
+  // locals: lenA(2), lenB(3), n(4 = min), i(5), ca(6), cb(7)
+  addRuntimeFunc(
+    mod,
+    "__str_cmp",
+    [{ kind: "i32" }, { kind: "i32" }],
+    [{ kind: "i32" }],
+    [],
+    (firstLocalIdx) => {
+      const lenA = firstLocalIdx;
+      const lenB = firstLocalIdx + 1;
+      const n = firstLocalIdx + 2;
+      const i = firstLocalIdx + 3;
+      const ca = firstLocalIdx + 4;
+      const cb = firstLocalIdx + 5;
+      return [
+        // lenA = a.len; lenB = b.len
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "local.set", index: lenA },
+        { op: "local.get", index: 1 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "local.set", index: lenB },
+        // n = min(lenA, lenB)
+        { op: "local.get", index: lenA },
+        { op: "local.get", index: lenB },
+        { op: "i32.lt_u" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [{ op: "local.get", index: lenA }],
+          else: [{ op: "local.get", index: lenB }],
+        },
+        { op: "local.set", index: n },
+        // i = 0
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: i },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                // break if i >= n
+                { op: "local.get", index: i },
+                { op: "local.get", index: n },
+                { op: "i32.ge_u" },
+                { op: "br_if", depth: 1 },
+                // ca = a.bytes[i]; cb = b.bytes[i]
+                { op: "local.get", index: 0 },
+                { op: "local.get", index: i },
+                { op: "i32.add" },
+                { op: "i32.load8_u", align: 0, offset: 12 },
+                { op: "local.set", index: ca },
+                { op: "local.get", index: 1 },
+                { op: "local.get", index: i },
+                { op: "i32.add" },
+                { op: "i32.load8_u", align: 0, offset: 12 },
+                { op: "local.set", index: cb },
+                // if ca < cb → return -1 ; if ca > cb → return 1
+                { op: "local.get", index: ca },
+                { op: "local.get", index: cb },
+                { op: "i32.lt_u" },
+                { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: -1 }, { op: "return" }] },
+                { op: "local.get", index: ca },
+                { op: "local.get", index: cb },
+                { op: "i32.gt_u" },
+                { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
+                // i++
+                { op: "local.get", index: i },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: i },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        // Common prefix equal: shorter string is "less".
+        { op: "local.get", index: lenA },
+        { op: "local.get", index: lenB },
+        { op: "i32.lt_u" },
+        { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: -1 }, { op: "return" }] },
+        { op: "local.get", index: lenA },
+        { op: "local.get", index: lenB },
+        { op: "i32.gt_u" },
+        { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
+        { op: "i32.const", value: 0 },
+      ];
+    },
+    6,
+  );
+
   // __str_hash: FNV-1a hash
   // FNV offset basis = 2166136261 (0x811c9dc5)
   // FNV prime = 16777619 (0x01000193)

--- a/tests/issue-1976.test.ts
+++ b/tests/issue-1976.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1976 — linear-backend string fixes:
+ *
+ *  1. Relational operators (`<` `<=` `>` `>=`) on strings compared the i32
+ *     POINTER addresses instead of the content. They now route through a new
+ *     `__str_cmp` runtime fn (lexicographic, -1/0/1).
+ *  2. `s += t` and `const x = "a" + b` for string operands produced an INVALID
+ *     module (the concat result is an i32 pointer but was typed/added as f64).
+ *     String `+=` now calls `__str_concat`, and `inferExprType` treats a string
+ *     `+` as an i32 result so the local/global gets the right type.
+ *
+ * (The UTF-8→UTF-16 `.length` divergence for non-ASCII is a separate, larger
+ * storage-strategy change tracked in the issue; ASCII lengths are correct.)
+ *
+ * Validated on `target: "linear"` against Node.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runLinear(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "linear" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#1976 linear backend string relationals and concat typing", () => {
+  describe("relational operators compare by content (not pointer address)", () => {
+    const cases: Array<[string, number]> = [
+      [`"zzz" < "aaa"`, 0],
+      [`"b" < "abc"`, 0],
+      [`"aaa" < "zzz"`, 1],
+      [`"abc" <= "abc"`, 1],
+      [`"abc" < "abd"`, 1],
+      [`"abc" > "abb"`, 1],
+      [`"ab" < "abc"`, 1], // prefix is "less"
+      [`"abc" >= "abc"`, 1],
+      [`"b" > "a"`, 1],
+      [`"A" < "a"`, 1], // 'A' (65) < 'a' (97)
+    ];
+    for (const [expr, want] of cases) {
+      it(`${expr} -> ${want}`, async () => {
+        expect(await runLinear(`return ${expr} ? 1 : 0;`)).toBe(want);
+      });
+    }
+  });
+
+  describe("string concatenation produces a valid module and correct result", () => {
+    it("compound assign: s += t", async () => {
+      expect(await runLinear(`let s = ""; s += "ab"; return s.length;`)).toBe(2);
+      expect(await runLinear(`let s = "x"; s += "yz"; return s.length;`)).toBe(3);
+    });
+
+    it("declaration: const a = x + y", async () => {
+      expect(await runLinear(`const a = "ab" + "c"; return a.length;`)).toBe(3);
+    });
+
+    it("repeated += in a loop builds up correctly", async () => {
+      expect(await runLinear(`let s = ""; for (let i = 0; i < 4; i++) s += "x"; return s.length;`)).toBe(4);
+    });
+
+    it("concatenated string still compares by content", async () => {
+      expect(await runLinear(`const a = "ab" + "c"; return a === "abc" ? 1 : 0;`)).toBe(1);
+      expect(await runLinear(`const a = "ab" + "c"; return a < "abd" ? 1 : 0;`)).toBe(1);
+    });
+  });
+
+  it("ASCII .length is unaffected", async () => {
+    expect(await runLinear(`return "hello".length;`)).toBe(5);
+  });
+});


### PR DESCRIPTION
## Problem (`target: "linear"`)

| probe | before | node |
|-------|--------|------|
| `"zzz" < "aaa"` | true (address order) | false |
| `"b" < "abc"` | true | false |
| `let s = ""; s += "ab"` | **invalid module** (f64.add on i32 ptrs) | — |
| `const a = "ab" + "c"` | **invalid module** (i32 result typed f64) | — |

## Fix

1. **Relationals** (`<`/`<=`/`>`/`>=`): added a `__str_cmp` runtime fn (lexicographic byte compare → -1/0/1) and route string relationals through it before the `bothI32` pointer-comparison path. For ASCII this matches JS UTF-16 ordering.
2. **Concat type confusion → invalid module**: `s += t` for a string `s` now calls `__str_concat` and stores the i32 result; `inferExprType` treats a string `a + b` as an i32 result so `const x = "a" + b` declares an i32 local. Both compound-assign and declaration paths produce valid modules.

## Remaining (documented in the issue — separate follow-up)

`.length` still returns the UTF-8 **byte** count, not UTF-16 code units (`"é世😀".length` → 9, Node → 4). Fixing this needs a WTF-16/code-unit storage decision across the string subsystem (`charCodeAt`/`codePointAt`/slice) — a much larger change than the compare + concat fixes here. ASCII lengths are correct. (Related to #1588's GC-side UTF-8/WTF-16 work.) The issue stays open for that part.

## Tests

- `tests/issue-1976.test.ts` (15 cases) — relationals by content (incl. prefix, case, equality boundary), `+=`/decl/loop concat validity + correctness, concatenated string still compares by content.
- All 136 existing linear-backend tests pass.

Refs #1976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)