### PR TITLE
plan: release stale codex-developer claims; memory: cla-check rerun lesson

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -78,6 +78,7 @@
 - [feedback_never_delete_test_data.md](feedback_never_delete_test_data.md) — Never delete test data/cache/runs without asking
 - [feedback_ask_before_killing_tests.md](feedback_ask_before_killing_tests.md) — Never kill running tests without asking
 - [feedback_baseline_drift_cross_check.md](feedback_baseline_drift_cross_check.md) — Cross-check CI regressions against other open PRs; sample locally — identical clusters across unrelated PRs are drift
+- [feedback_cla_check_rerun_after_merge_commit.md](feedback_cla_check_rerun_after_merge_commit.md) — Fork PR enqueue fails "cla-check expected" after a merge-main commit; gh run rerun the cla-check workflow to repost on the new head
 - [reference_error_analysis.md](reference_error_analysis.md) — Test262 error analysis procedure
 
 ### Development methodology

--- a/.claude/memory/feedback_cla_check_rerun_after_merge_commit.md
+++ b/.claude/memory/feedback_cla_check_rerun_after_merge_commit.md
@@ -1,0 +1,14 @@
+---
+name: feedback_cla_check_rerun_after_merge_commit
+description: "Fork PR enqueue fails with \"cla-check expected\" after a merge-main commit; re-run the cla-check workflow to repost the status on the new head"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 64a72f6d-c076-4dff-8bd4-7e7d93e3852c
+---
+
+When the merge queue (or a drift-update) adds a `Merge branch 'main'` commit on top of a fork PR branch, the **new head SHA has no `cla-check` commit status**, so `enqueuePullRequest` fails with `Required status check "cla-check" is expected` even though the CLA workflow already passed on the *prior* head. The `auto-enqueue.yml` backstop hits the same wall.
+
+**Why:** `.github/workflows/cla-check.yml` runs on `pull_request_target` and posts `cla-check` to `pr.head.sha` via the statuses API. It does NOT re-run automatically when a merge commit changes the head, so the status lands on the old SHA only.
+
+**How to apply:** `gh run rerun <cla-check-run-id> -R loopdive/js2` — the `pull_request_target` re-run re-resolves `pr.head.sha` to the current head and reposts `cla-check: success` there. Find the run with `gh run list -R loopdive/js2 --workflow cla-check.yml --branch <branch> --limit 1`. Wait ~45s, confirm via `gh api repos/loopdive/js2/commits/<head-sha>/status --jq '.statuses[]|select(.context=="cla-check")'`, then re-enqueue. (Hit on #2061 / PR #1365, 2026-06-11.) Related: [[feedback_cla_gate]].

--- a/plan/issues/1105-wasm-native-string-method-implementations.md
+++ b/plan/issues/1105-wasm-native-string-method-implementations.md
@@ -13,8 +13,6 @@ language_feature: string-methods
 goal: standalone-mode
 sprint: 58
 es_edition: multi
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:52:56.870Z
 ---
 # #1105 — Wasm-native String method implementations for standalone mode
 

--- a/plan/issues/1320-array-from-externref-iterator-bridge.md
+++ b/plan/issues/1320-array-from-externref-iterator-bridge.md
@@ -14,8 +14,6 @@ language_feature: iterators, externref, Array.from
 goal: spec-conformance
 sprint: 61
 related: [1154, 1665, 1472, 1620, 1633, 1684]
-claimed_by: codex-developer
-claimed_at: 2026-06-10T16:33:00.234Z
 completed: 2026-06-10
 ---
 # #1320 — Array.from / Iterator.from runtime bridge drops own [Symbol.iterator]

--- a/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
+++ b/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
@@ -13,8 +13,6 @@ language_feature: async, promises, generators
 goal: standalone-mode
 sprint: 58
 required_by: [1326c, 1766, 1774]
-claimed_by: codex-developer
-claimed_at: 2026-06-02T22:45:33.452Z
 ---
 # #1326 — Async standalone: Wasm microtask queue + CPS desugaring
 

--- a/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
+++ b/plan/issues/1348-spec-gap-class-static-init-and-private-fields.md
@@ -13,8 +13,6 @@ language_feature: class
 goal: spec-completeness
 sprint: 61
 parent: 1328
-claimed_by: codex-developer
-claimed_at: 2026-06-06T09:51:22.932Z
 pr: 1250
 completed: 2026-06-06
 ---

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -16,8 +16,6 @@ model: fable
 depends_on: [1710, 1711]
 es_edition: multi
 related: [1690, 1690b, 1584, 1058]
-claimed_by: codex-developer
-claimed_at: 2026-06-07T05:10:23.845Z
 pr: 1293
 ---
 

--- a/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
+++ b/plan/issues/1747-empty-array-pop-traps-instead-of-undefined.md
@@ -13,8 +13,6 @@ language_feature: array-pop, empty-array, undefined
 goal: standalone-correctness
 sprint: 58
 related: [1584, 1748]
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:53:18.030Z
 ---
 # #1747 — `[].pop()` on an empty array traps instead of returning `undefined`
 

--- a/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
+++ b/plan/issues/1781-standalone-test262-artifact-root-cause-map.md
@@ -15,8 +15,6 @@ sprint: 58
 es_edition: n/a
 related: [1662, 1776, 1472, 682, 1474, 1599, 1387, 1778, 1782, 1591, 1623, 1665]
 origin: "Investigation of all failing standalone test262 tests found that the June 1 full standalone JSONL/report artifacts were generated but not retained, leaving only summary counts and five manually documented root-cause clusters."
-claimed_by: codex-developer
-claimed_at: 2026-06-02T20:53:11.407Z
 ---
 # #1781 - Standalone test262 run must publish full JSONL and root-cause issue map
 

--- a/plan/issues/680-wasm-native-generators-state-machines.md
+++ b/plan/issues/680-wasm-native-generators-state-machines.md
@@ -17,8 +17,6 @@ files:
   src/codegen/expressions.ts:
     breaking:
       - "yield compiles to state save + return, next() resumes from saved state"
-claimed_by: codex-developer
-claimed_at: 2026-06-02T22:52:32.748Z
 ---
 # #680 — Wasm-native generators (state machines) with optional JS host fallback
 


### PR DESCRIPTION
Carries two local plan commits (codex-developer claim releases on #680/#1105/#1320/#1326/#1348/#1712/#1747/#1781 — Symphony suspended) plus a memory lesson (cla-check rerun after merge-main commit), rescued off the local main checkout during fork↔upstream sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)