### PR TITLE
fix(#2129): duplicate object-literal keys — last definition wins, all initializers run

### DIFF
--- a/plan/issues/2129-duplicate-object-keys-first-wins.md
+++ b/plan/issues/2129-duplicate-object-keys-first-wins.md
@@ -1,0 +1,86 @@
+---
+id: 2129
+title: "duplicate object-literal keys resolve first-wins instead of last-wins"
+status: done
+sprint: 61
+created: 2026-06-12
+updated: 2026-06-12
+completed: 2026-06-12
+priority: medium
+feasibility: low
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [140, 1239]
+origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
+---
+
+# #2129 — duplicate object-literal keys: last property definition must win
+
+## Problem
+
+When an object literal repeats a key, the compiler keeps the first value; ES
+semantics require the **last** definition to win (each duplicate runs in source
+order and overwrites the previous, so the final value is observed).
+
+```ts
+({ a: 1, a: 2 }).a            // wasm: 1    node: 2
+({ a: 1, b: 9, a: 3 }).a      // wasm: 1    node: 3
+```
+
+## Root cause (pointer)
+
+Object-literal struct layout deduplicates property names but binds the field
+to the **first** initializer rather than the last. The fix is to let a later
+property with the same name override the earlier slot's initializer (while
+still evaluating all initializers in source order for their side effects). See
+object-literal field collection in `src/codegen/object-ops.ts`.
+
+## Spec
+
+ECMAScript §13.2.5.5 PropertyDefinitionEvaluation runs each
+PropertyDefinition in order; `PropertyDefinition : PropertyName : Assignment`
+calls `CreateDataPropertyOrThrow`, which a later same-key definition
+overwrites. Side effects of all initializers still occur.
+
+## Acceptance criteria
+
+- `({ a: 1, a: 2 }).a` → `2`
+- `({ a: 1, b: 9, a: 3 }).a` → `3`
+- All initializer side effects in a duplicate-key literal still run in order
+  (e.g. `{ a: sideEffect1(), a: sideEffect2() }` runs both)
+- An equivalence test under `tests/`
+
+## Notes
+
+Verified on main `c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts`
+(branch `po-1971-triage`). Likely XS-to-S — single layout fix plus
+side-effect ordering. JS-host mode, default options.
+
+## Resolution (2026-06-12)
+
+`compileObjectLiteralForStruct` (src/codegen/literals.ts) bound each struct
+field via `expr.properties.find(...)` — the FIRST matching property. The
+field loop now collects ALL matching properties (data, shorthand, method —
+the three matcher kinds previously checked in fixed precedence), binds the
+field to the LAST one per §13.2.5.5, and evaluates-then-drops the earlier
+duplicates' PropertyAssignment initializers so their side effects still run
+(shorthands/methods have none).
+
+Known caveat (documented in code): duplicates are evaluated adjacent to the
+winning one, so cross-key side-effect ORDER can deviate from strict source
+order in mixed duplicate literals — the same field-order evaluation the
+struct path already uses for non-duplicates.
+
+## Test Results
+
+- `tests/issue-2129.test.ts` — 7/7: both issue repros (2, 39), both side
+  effects run (12200), shorthand-after-data and data-after-shorthand
+  last-wins, non-duplicate and method-shorthand literals unregressed.
+- Method/shorthand matcher suites (`issue-1557`, `issue-1602` ×2,
+  `issue-1671`, `issue-1118`, `object-methods`): 41/41 pass.
+- Object-literal suites (`computed-props`, `issue-computed-props`,
+  `empty-object-widening`, `issue-786`, `computed-property-class`): 19/20 —
+  the 1 failure identical on main.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1414,35 +1414,48 @@ export function compileObjectLiteralForStruct(
   }
 
   for (const field of fields) {
-    // First check for an explicit property assignment (identifier, string literal, or computed key).
-    // #2010: resolvePropertyNameText now also matches shorthands; exclude them here so
-    // the dedicated shorthand branch below (which compiles `prop.name` as the value)
-    // keeps handling them — the property-assignment branch can't read a shorthand.
-    const prop = expr.properties.find(
-      (p) => !ts.isShorthandPropertyAssignment(p) && resolvePropertyNameText(ctx, p) === field.name,
-    );
-    // Also check for shorthand property assignment ({ x, y } where x/y are identifiers)
-    const shorthandProp = !prop
-      ? expr.properties.find((p) => ts.isShorthandPropertyAssignment(p) && p.name.text === field.name)
-      : undefined;
-    // #1118: Method shorthand `{ m() {…} }` — `resolvePropertyNameText`
-    // returns undefined for MethodDeclaration, so the search above misses
-    // it. Look it up explicitly by name. The pre-pass in
-    // `ensureStructForType` already registered the method's funcMap entry;
-    // emit a closure-struct ref to it and convert to the field type.
-    // Without this, the field defaults to `undefined` and dynamic dispatch
-    // through `any` (the test262 wrapper pattern) returns null.
-    const methodProp =
-      !prop && !shorthandProp
-        ? expr.properties.find(
-            (p): p is ts.MethodDeclaration =>
-              ts.isMethodDeclaration(p) &&
-              !!p.name &&
-              ((ts.isIdentifier(p.name) && p.name.text === field.name) ||
-                (ts.isStringLiteral(p.name) && p.name.text === field.name) ||
-                (ts.isNumericLiteral(p.name) && p.name.text === field.name)),
-          )
+    // (#2129) Collect EVERY property that defines this field, in source
+    // order. Per §13.2.5.5 PropertyDefinitionEvaluation, each duplicate runs
+    // (its initializer's side effects are observable) and the LAST definition
+    // provides the field's value — not the first.
+    //
+    // #2010: resolvePropertyNameText also matches shorthands; classify them
+    // separately so the dedicated shorthand branch below (which compiles
+    // `prop.name` as the value) keeps handling them.
+    // #1118: method shorthand `{ m() {…} }` — resolvePropertyNameText returns
+    // undefined for MethodDeclaration, so match those by name explicitly.
+    const matchingProps = expr.properties.filter((p) => {
+      if (ts.isShorthandPropertyAssignment(p)) return p.name.text === field.name;
+      if (ts.isMethodDeclaration(p)) {
+        return (
+          !!p.name &&
+          ((ts.isIdentifier(p.name) && p.name.text === field.name) ||
+            (ts.isStringLiteral(p.name) && p.name.text === field.name) ||
+            (ts.isNumericLiteral(p.name) && p.name.text === field.name))
+        );
+      }
+      return resolvePropertyNameText(ctx, p) === field.name;
+    });
+    const lastMatch = matchingProps[matchingProps.length - 1];
+    // (#2129) Evaluate earlier duplicates' initializers for their side
+    // effects and drop the values. (Shorthands/methods have no side effects
+    // to run.) Note: duplicates are evaluated adjacent to the winning one,
+    // so cross-key side-effect ORDER may deviate from strict source order in
+    // mixed duplicate literals — the same field-order evaluation the struct
+    // path already uses.
+    for (let di = 0; di < matchingProps.length - 1; di++) {
+      const dup = matchingProps[di]!;
+      if (ts.isPropertyAssignment(dup)) {
+        const dupType = compileExpression(ctx, fctx, dup.initializer);
+        if (dupType) fctx.body.push({ op: "drop" });
+      }
+    }
+    const prop =
+      lastMatch && !ts.isShorthandPropertyAssignment(lastMatch) && !ts.isMethodDeclaration(lastMatch)
+        ? lastMatch
         : undefined;
+    const shorthandProp = lastMatch && ts.isShorthandPropertyAssignment(lastMatch) ? lastMatch : undefined;
+    const methodProp = lastMatch && ts.isMethodDeclaration(lastMatch) ? lastMatch : undefined;
     if (methodProp) {
       const methodFullName = `${typeName}_${field.name}`;
       // (#1557) Prefer the per-literal funcIdx if we detected a sig mismatch

--- a/tests/issue-2129.test.ts
+++ b/tests/issue-2129.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2129 — duplicate object-literal keys resolved first-wins and silently
+// skipped the later initializer. Per ES §13.2.5.5 every PropertyDefinition
+// runs in order and a later same-key definition overwrites the earlier one:
+// the LAST value wins, and all initializer side effects occur. The struct
+// literal path now binds each field to the last matching property and
+// evaluates (then drops) the earlier duplicates' initializers.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const r = await compile(source);
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "<unknown>"}`);
+  }
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as any)[fn]();
+}
+
+describe("#2129 — duplicate object-literal keys: last definition wins", () => {
+  it("({ a: 1, a: 2 }).a is 2", async () => {
+    const out = await run(`
+      export function test(): number {
+        const o = { a: 1, a: 2 } as any;
+        return o.a;
+      }
+    `);
+    expect(out).toBe(2);
+  });
+
+  it("({ a: 1, b: 9, a: 3 }) — a is 3, b untouched", async () => {
+    const out = await run(`
+      export function test(): number {
+        const o = { a: 1, b: 9, a: 3 } as any;
+        return o.a * 10 + o.b;
+      }
+    `);
+    expect(out).toBe(39);
+  });
+
+  it("all duplicate initializers run for their side effects", async () => {
+    const out = await run(`
+      let log = 0;
+      const f1 = (): number => { log = log * 10 + 1; return 100; };
+      const f2 = (): number => { log = log * 10 + 2; return 200; };
+      export function test(): number {
+        const o = { a: f1(), a: f2() } as any;
+        return log * 1000 + o.a;
+      }
+    `);
+    expect(out).toBe(12200);
+  });
+
+  it("shorthand after data property wins", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = 7;
+        const o = { a: 1, a } as any;
+        return o.a;
+      }
+    `);
+    expect(out).toBe(7);
+  });
+
+  it("data property after shorthand wins", async () => {
+    const out = await run(`
+      export function test(): number {
+        const a = 7;
+        const o = { a, a: 1 } as any;
+        return o.a;
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("non-duplicate literals are unregressed", async () => {
+    const out = await run(`
+      export function test(): number {
+        const o = { x: 4, y: 5, z: 6 };
+        return o.x + o.y + o.z;
+      }
+    `);
+    expect(out).toBe(15);
+  });
+
+  it("method shorthand literals are unregressed", async () => {
+    const out = await run(`
+      export function test(): number {
+        const o = { m(): number { return 8; }, v: 1 } as any;
+        return o.m() + o.v;
+      }
+    `);
+    expect(out).toBe(9);
+  });
+});


### PR DESCRIPTION
Fixes #2129 (plan/issues/2129-duplicate-object-keys-first-wins.md) — sprint 61, object-literal cluster.

## Problem

`({ a: 1, a: 2 }).a` returned 1 (first-wins) and the second initializer never evaluated. ES §13.2.5.5 runs every PropertyDefinition in source order; a later same-key definition overwrites — last wins, all side effects occur.

## Fix (src/codegen/literals.ts)

`compileObjectLiteralForStruct` bound each struct field via `expr.properties.find(...)` — the FIRST match (with data/shorthand/method checked in fixed precedence). The field loop now collects ALL matching properties, binds the field to the LAST one (whatever its kind), and evaluates-then-drops earlier duplicates' PropertyAssignment initializers so their side effects still run. Known caveat (documented in code + issue): duplicates evaluate adjacent to the winner, so cross-key side-effect order in mixed duplicate literals follows the struct path's existing field-order evaluation rather than strict source order.

## Tests

`tests/issue-2129.test.ts` — 7 tests: both issue repros, side-effect execution, shorthand↔data last-wins both directions, non-duplicate and method-shorthand literals unregressed. Matcher-adjacent suites (`issue-1557`, `issue-1602` ×2, `issue-1671`, `issue-1118`, `object-methods`): 41/41. Object-literal suites: 19/20, the 1 failure identical on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)