### PR TITLE
fix(#1994): derive reduce/reduceRight accumulator type (string[] no longer traps)

### DIFF
--- a/plan/issues/1994-reduce-string-accumulator-illegal-cast.md
+++ b/plan/issues/1994-reduce-string-accumulator-illegal-cast.md
@@ -1,10 +1,11 @@
 ---
 id: 1994
 title: "reduce/reduceRight on string[] trap 'illegal cast' — accumulator local hard-coded to numeric kind"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -51,3 +52,43 @@ elements.
 
 #1967 covers struct(`ref`)-element gates returning garbage; string elements
 are externref, pass that gate, and hit this distinct bug. New.
+
+## Resolution (2026-06-12)
+
+Fixed per the fix direction in `src/codegen/array-methods.ts`. Added a
+`resolveReduceAccType(setup, numKind)` helper that derives the accumulator
+ValType from the callback's resolved return type (falling back to the
+accumulator parameter type, then the numeric kind). Threaded the resulting
+`accType` through both `compileArrayReduce` and `compileArrayReduceRight`:
+
+- `accTmp` local is allocated as `accType` (was always `numKind`).
+- The initial-value expression is compiled to `accType`.
+- The no-initial-value seed element (`data[0]` / `data[length-1]`) is coerced
+  `elemType → accType` before `local.set accTmp`.
+- The accumulator→param0 coercion (`accCoerce`) and the callback-return→`accType`
+  coercion use `accType` instead of `numKind`.
+- The function returns `accType`.
+
+The host-bridge fallback path (no `closureInfo`) keeps a numeric accumulator —
+`resolveReduceAccType` returns `numKind` when there is no closure, so that path
+is unchanged. Numeric reduce/reduceRight (closure with `f64`/`i32` return) also
+resolve to `numKind` and are byte-for-byte unchanged.
+
+## Test Results
+
+`tests/issue-1994.test.ts` — 10/10 pass (`assertEquivalent`, wasm vs Node):
+- reduce / reduceRight on `string[]` with and without an initial value →
+  matches Node (was `RuntimeError: illegal cast` / `null`/`NaN`).
+- reduce on `string[]` with 5 entries + separator → matches Node.
+- mixed-type accumulator: `string[].reduce((acc:number,s)=>acc+s.length, 0)` and
+  the index-parameter form → match Node.
+- numeric reduce / reduceRight (no-init, with-init) → unchanged, match Node.
+
+Pre-existing, unrelated failures confirmed identical on clean `origin/main`:
+`tests/functional-array-methods.test.ts` (23/24) and `tests/array-methods.test.ts`
+(22/22) fail on main too — their bespoke minimal import harness omits
+`__box_number`/string constants and the test sources have a strict-typecheck
+error (`number | undefined`), neither touched by this change.
+
+Quality gate: `biome lint`, `tsc --noEmit`, and `prettier --check` all clean on
+the changed files.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -5794,6 +5794,33 @@ function compileArrayMap(
 }
 
 /**
+ * Resolve the accumulator ValType for reduce/reduceRight.
+ *
+ * The accumulator holds whatever the callback returns between iterations, so
+ * the callback's resolved return type is the most accurate source. We fall
+ * back to the accumulator parameter type, then to the numeric kind. This
+ * lets non-numeric accumulators (e.g. `string[].reduce((x,y)=>x+y)`) use an
+ * `externref` local instead of being forced through a numeric unbox that
+ * traps with "illegal cast" (#1994).
+ */
+function resolveReduceAccType(setup: ArrayCallbackSetup, numKind: "i32" | "f64"): ValType {
+  const ci = setup.closureInfo;
+  if (ci) {
+    // A void-returning callback (returnType === null) yields `undefined`; keep
+    // the numeric kind so the default-value path stays valid.
+    if (ci.returnType && ci.returnType.kind !== numKind) {
+      return ci.returnType;
+    }
+    if (ci.returnType) return ci.returnType;
+    const accParam = ci.paramTypes[0];
+    if (accParam && accParam.kind !== numKind) {
+      return accParam;
+    }
+  }
+  return { kind: numKind };
+}
+
+/**
  * arr.reduce(cb, initial) -> iterate elements, accumulate result via callback.
  * Reduce has a 2-arg callback (acc, elem) so it uses custom call logic.
  */
@@ -5817,12 +5844,16 @@ function compileArrayReduce(
   const setup = setupArrayCallback(ctx, fctx, callExpr, "reduce", "red", bridgeName);
   if (!setup) return null;
 
+  // The accumulator local must match the actual accumulator type, not always
+  // the numeric kind — string/object accumulators are externref (#1994).
+  const accType = resolveReduceAccType(setup, numKind);
+
   const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "red");
-  const accTmp = allocLocal(fctx, `__arr_red_acc_${fctx.locals.length}`, { kind: numKind as any });
+  const accTmp = allocLocal(fctx, `__arr_red_acc_${fctx.locals.length}`, accType);
 
   // Compile initial value or use arr[0] as default
   if (callExpr.arguments.length >= 2) {
-    compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: numKind as any });
+    compileExpression(ctx, fctx, callExpr.arguments[1]!, accType);
     fctx.body.push({ op: "local.set", index: accTmp });
     // i already = 0 from setupArrayLoop
   } else {
@@ -5840,6 +5871,9 @@ function compileArrayReduce(
       op: elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get",
       typeIdx: arrTypeIdx,
     });
+    // Coerce the seed element to the accumulator type (e.g. element externref
+    // string → accumulator externref, or i32 element → f64 accumulator).
+    coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
     fctx.body.push({ op: "local.set", index: accTmp });
     fctx.body.push({ op: "i32.const", value: 1 });
     fctx.body.push({ op: "local.set", index: loop.iTmp });
@@ -5850,7 +5884,7 @@ function compileArrayReduce(
   if (setup.closureInfo && setup.closureTypeIdx !== undefined && setup.closureTmp !== undefined) {
     const ci = setup.closureInfo;
     const numParams = ci.paramTypes.length;
-    const accCoerce = ci.paramTypes[0] ? coercionInstrs(ctx, { kind: numKind as any }, ci.paramTypes[0], fctx) : [];
+    const accCoerce = ci.paramTypes[0] ? coercionInstrs(ctx, accType, ci.paramTypes[0], fctx) : [];
     const elemCoerce = ci.paramTypes[1] ? coercionInstrs(ctx, elemType, ci.paramTypes[1], fctx) : [];
     callInstrs = [
       { op: "local.get", index: setup.closureTmp } as Instr,
@@ -5892,13 +5926,16 @@ function compileArrayReduce(
       // validates. JS: cb returns `undefined` → acc becomes undefined →
       // for numeric kind that's NaN (f64) / 0 (i32). (#1522 Cluster 2)
       ...(ci.returnType === null
-        ? defaultValueInstrs({ kind: numKind as any })
-        : ci.returnType.kind !== numKind
-          ? coercionInstrs(ctx, ci.returnType, { kind: numKind as any }, fctx)
+        ? defaultValueInstrs(accType)
+        : ci.returnType.kind !== accType.kind
+          ? coercionInstrs(ctx, ci.returnType, accType, fctx)
           : []),
       { op: "local.set", index: accTmp } as Instr,
     ];
   } else {
+    // Host-bridge fallback path: the bridge takes/returns the numeric kind, so
+    // the accumulator must be numeric here. resolveReduceAccType returns the
+    // numeric kind when there is no closureInfo, so accTmp is numeric too.
     callInstrs = [
       { op: "local.get", index: setup.cbTmp! } as Instr,
       { op: "local.get", index: accTmp } as Instr,
@@ -5916,7 +5953,7 @@ function compileArrayReduce(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: accTmp });
-  return { kind: numKind as any };
+  return accType;
 }
 
 /**
@@ -5942,6 +5979,10 @@ function compileArrayReduceRight(
   const setup = setupArrayCallback(ctx, fctx, callExpr, "reduceRight", "rr", bridgeName);
   if (!setup) return null;
 
+  // The accumulator local must match the actual accumulator type, not always
+  // the numeric kind — string/object accumulators are externref (#1994).
+  const accType = resolveReduceAccType(setup, numKind);
+
   // Set up receiver: vec/data/len
   const vecTmp = allocLocal(fctx, `__arr_rr_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_rr_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
@@ -5958,11 +5999,11 @@ function compileArrayReduceRight(
   fctx.body.push({ op: "local.set", index: dataTmp });
 
   const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
-  const accTmp = allocLocal(fctx, `__arr_rr_acc_${fctx.locals.length}`, { kind: numKind as any });
+  const accTmp = allocLocal(fctx, `__arr_rr_acc_${fctx.locals.length}`, accType);
 
   // Compile initial value or use arr[length-1] as default
   if (callExpr.arguments.length >= 2) {
-    compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: numKind as any });
+    compileExpression(ctx, fctx, callExpr.arguments[1]!, accType);
     fctx.body.push({ op: "local.set", index: accTmp });
     // Start from length - 1
     fctx.body.push({ op: "local.get", index: lenTmp });
@@ -5983,6 +6024,9 @@ function compileArrayReduceRight(
     fctx.body.push({ op: "i32.const", value: 1 });
     fctx.body.push({ op: "i32.sub" });
     fctx.body.push({ op: getOp, typeIdx: arrTypeIdx });
+    // Coerce the seed element to the accumulator type (e.g. element externref
+    // string → accumulator externref, or i32 element → f64 accumulator).
+    coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
     fctx.body.push({ op: "local.set", index: accTmp });
     fctx.body.push({ op: "local.get", index: lenTmp });
     fctx.body.push({ op: "i32.const", value: 2 });
@@ -6004,7 +6048,7 @@ function compileArrayReduceRight(
   if (setup.closureInfo && setup.closureTypeIdx !== undefined && setup.closureTmp !== undefined) {
     const ci = setup.closureInfo;
     const numParams = ci.paramTypes.length;
-    const accCoerce = ci.paramTypes[0] ? coercionInstrs(ctx, { kind: numKind as any }, ci.paramTypes[0], fctx) : [];
+    const accCoerce = ci.paramTypes[0] ? coercionInstrs(ctx, accType, ci.paramTypes[0], fctx) : [];
     const elemCoerce = ci.paramTypes[1] ? coercionInstrs(ctx, elemType, ci.paramTypes[1], fctx) : [];
     callInstrs = [
       { op: "local.get", index: setup.closureTmp } as Instr,
@@ -6044,13 +6088,14 @@ function compileArrayReduceRight(
       // validates. JS: cb returns `undefined` → acc becomes undefined →
       // for numeric kind that's NaN (f64) / 0 (i32). (#1522 Cluster 2)
       ...(ci.returnType === null
-        ? defaultValueInstrs({ kind: numKind as any })
-        : ci.returnType.kind !== numKind
-          ? coercionInstrs(ctx, ci.returnType, { kind: numKind as any }, fctx)
+        ? defaultValueInstrs(accType)
+        : ci.returnType.kind !== accType.kind
+          ? coercionInstrs(ctx, ci.returnType, accType, fctx)
           : []),
       { op: "local.set", index: accTmp } as Instr,
     ];
   } else {
+    // Host-bridge fallback path: numeric accumulator (see compileArrayReduce).
     callInstrs = [
       { op: "local.get", index: setup.cbTmp! } as Instr,
       { op: "local.get", index: accTmp } as Instr,
@@ -6083,7 +6128,7 @@ function compileArrayReduceRight(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: accTmp });
-  return { kind: numKind as any };
+  return accType;
 }
 
 /**

--- a/tests/issue-1994.test.ts
+++ b/tests/issue-1994.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+/**
+ * #1994 — reduce/reduceRight on string[] trapped "illegal cast" because the
+ * accumulator local was hard-coded to the numeric kind (i32/f64). String
+ * (and any externref) accumulators were forced through a numeric unbox that
+ * trapped or produced NaN. The accumulator local now derives its ValType from
+ * the callback's resolved return type, so non-numeric accumulators use an
+ * externref local. Numeric reduce/reduceRight are unchanged.
+ */
+describe("#1994 reduce/reduceRight string accumulator", () => {
+  it("reduce on string[] without initial value", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["a", "b", "c"];
+        return a.reduce((x: string, y: string) => x + y);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reduce on string[] with initial value", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["a", "b", "c"];
+        return a.reduce((x: string, y: string) => x + y, "z");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reduceRight on string[] without initial value", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["a", "b", "c"];
+        return a.reduceRight((x: string, y: string) => x + y);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reduceRight on string[] with initial value", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["a", "b", "c"];
+        return a.reduceRight((x: string, y: string) => x + y, "z");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reduce on string[] with 5+ entries (separator)", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["x", "y", "z", "p", "q"];
+        return a.reduce((acc: string, cur: string) => acc + "-" + cur);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("string[] reduces to a numeric accumulator (sum of lengths)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a = ["ab", "cde", "f"];
+        return a.reduce((acc: number, s: string) => acc + s.length, 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reduce on string[] using the index parameter", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a = ["a", "b"];
+        return a.reduce((acc: string, v: string, i: number) => acc + v + i, "");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("numeric reduce is unchanged (no initial value)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a = [1, 2, 3, 4];
+        return a.reduce((x: number, y: number) => x + y);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("numeric reduce is unchanged (with initial value)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a = [1, 2, 3, 4];
+        return a.reduce((x: number, y: number) => x + y, 100);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("numeric reduceRight is unchanged", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        const a = [10, 20, 30];
+        return a.reduceRight((x: number, y: number) => x - y);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`Array.prototype.reduce` / `reduceRight` on a `string[]` trapped with
`RuntimeError: illegal cast` (or produced `null`/`NaN`):

```ts
["a","b","c"].reduce((x: string, y: string) => x + y) // wasm trapped; node "abc"
["a","b","c"].reduceRight((x,y)=>x+y, "z")             // wasm null;    node "zcba"
```

The accumulator local was allocated as the numeric kind (`i32`/`f64`)
unconditionally, so a string (or any externref) accumulator was forced
through a numeric unbox. Numeric reduce was unaffected.

## Fix

Add `resolveReduceAccType(setup, numKind)` which derives the accumulator
`ValType` from the callback's resolved return type (falling back to the
accumulator parameter type, then the numeric kind), mirroring how `map`
derives its result element type. Thread the resulting `accType` through both
`compileArrayReduce` and `compileArrayReduceRight`:

- `accTmp` local allocated as `accType` (was `numKind`)
- initial value compiled to `accType`
- no-init seed element (`data[0]` / `data[length-1]`) coerced `elemType → accType`
- accumulator→param0 and callback-return→`accType` coercions use `accType`
- both functions return `accType`

The host-bridge fallback path (no `closureInfo`) is unchanged — the helper
returns `numKind` when there is no closure, keeping a numeric accumulator.
Numeric reduce/reduceRight (closure returning `f64`/`i32`) also resolve to
`numKind` and are byte-for-byte unchanged.

## Tests

`tests/issue-1994.test.ts` — 10 equivalence cases (wasm vs Node), all pass:
string reduce/reduceRight with and without an initial value, a 5-element
case, a mixed-type (string element → numeric accumulator) case, the
index-parameter form, and numeric reduce/reduceRight.

Pre-existing, unrelated suite failures (`functional-array-methods.test.ts`,
`array-methods.test.ts`) were confirmed identical on clean `origin/main` —
their minimal harness omits `__box_number`/string constants and the sources
have a strict-typecheck error; neither is touched by this change.

Closes #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)