### PR TITLE
fix(#1981): don't fold null-compare for class/object/closure IR types

### DIFF
--- a/plan/issues/1981-ir-null-compare-fold-class-types.md
+++ b/plan/issues/1981-ir-null-compare-fold-class-types.md
@@ -1,10 +1,11 @@
 ---
 id: 1981
 title: "IR: === null / !== null on class-typed values statically folded to false/true — null guards silently deleted"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -61,3 +62,39 @@ by `??` and optional chaining) instead of folding, for every ref-shaped kind.
 
 #1392 (ref.is_null primitive — done, didn't touch the fold), #1169a (documents
 the fold + boxed bail only), #1574 (class nominality note). Unfiled.
+
+## Resolution (2026-06-12)
+
+Took the minimal fix from the fix direction: extended `tryFoldNullCompare`'s
+bail-out list (`src/ir/from-ast.ts`) to cover the nullable WasmGC ref-shaped
+IrType kinds `class`, `object`, and `closure`. When the non-null operand has
+one of these kinds the fold returns `null`, so the caller falls through to the
+standard lowering, which (for a `NullKeyword` operand) throws and triggers the
+whole-function legacy fallback — and legacy emits the runtime `ref.is_null`
+check on the receiver. This is exactly the pattern the existing `boxed` and
+`extern` bails already use.
+
+Note: the issue title lists `vec` too, but `vec` is not a distinct `IrType`
+kind (vecs surface as `object`/`class` shapes or `val{ref_null}`, all already
+covered by this bail or the pre-existing `ref_null` bail), so no `vec` branch
+is needed.
+
+## Test Results
+
+`tests/issue-1981.test.ts` — 4/4 pass (`assertEquivalent`, wasm vs Node):
+- `class === null` guard fires when the arg is `null` (was: folded to false →
+  returned 0; now: returns -1).
+- `class !== null` guard protects a field access when `null` (was:
+  `RuntimeError: dereferencing a null pointer`; now: returns -1).
+- loose `== null` guard fires when `null`.
+- non-null class receiver still reads the field (no spurious guard).
+
+Pre-existing, unrelated failures confirmed identical on clean `origin/main`:
+`tests/null-deref-class.test.ts` (4/17) and `tests/null-dereference-guards.test.ts`
+(2 SpreadElement-IIFE cases) fail on main too — neither touched by this change.
+Several null/equality suites (`null-narrowing`, `coalesce-operator`,
+`equality-mixed-types`, `strict-equality-edge-cases`, `optional-chaining-call`)
+fail at import on main (broken `./helpers.js` import) — pre-existing.
+
+IR fallback budget gate (`check:ir-fallbacks`): OK, no unintended increases.
+`biome lint`, `tsc --noEmit`, `prettier --check`: all clean.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3984,6 +3984,18 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
   // `ref.is_null` check on the receiver. (TODO follow-up: emit
   // `ref.is_null` directly from the IR.)
   if (otherType.kind === "extern") return null;
+  // #1981: `class`, `object`, and `closure` IrTypes lower to nullable WasmGC
+  // ref shapes (`(ref null $Struct)`). A class/object/closure-typed value can
+  // be `null` at runtime (e.g. a host call passing `null` for a class-typed
+  // parameter), so the defensive `=== null` / `!== null` guard must NOT be
+  // folded to a constant — folding it deletes the guard, which either returns
+  // the wrong value (`=== null` → false) or dereferences null (`!== null` →
+  // true, then `p.v` traps). Bail so the caller falls back to legacy, which
+  // emits a runtime `ref.is_null` check. The slice-1 fold is only sound for
+  // statically non-nullable kinds.
+  if (otherType.kind === "class" || otherType.kind === "object" || otherType.kind === "closure") {
+    return null;
+  }
   // Slice 10 (#1169i): a `val { externref }` operand is similarly
   // nullable. Functions that compare externref-typed values against
   // null (e.g. through extern.call results assigned to a local) need

--- a/tests/issue-1981.test.ts
+++ b/tests/issue-1981.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+/**
+ * #1981 — the IR `tryFoldNullCompare` folded `=== null` / `!== null` to a
+ * constant for `class`/`object`/`closure`-typed operands, which lower to
+ * nullable WasmGC ref shapes. A class-typed value passed as `null` at runtime
+ * then bypassed its own defensive guard: `=== null` folded to `false` (wrong
+ * value) and `!== null` folded to `true` (then a null dereference trapped).
+ * The fold now bails for these ref-shaped kinds so a runtime `ref.is_null`
+ * check is emitted instead.
+ */
+describe("#1981 null-compare guards on ref-shaped values are not folded", () => {
+  it("class === null guard fires when the arg is null", async () => {
+    await assertEquivalent(
+      `class A { v: number = 7; }
+       export function f(p: A): number {
+         if (p === null) return -1;
+         return 0;
+       }`,
+      [{ fn: "f", args: [null] }],
+    );
+  });
+
+  it("class !== null guard protects a field access when null", async () => {
+    await assertEquivalent(
+      `class A { v: number = 7; }
+       export function g(p: A): number {
+         if (p !== null) return p.v;
+         return -1;
+       }`,
+      [{ fn: "g", args: [null] }],
+    );
+  });
+
+  it("loose == null guard fires when the arg is null", async () => {
+    await assertEquivalent(
+      `class A { v: number = 1; }
+       export function h(p: A): number {
+         if (p == null) return -1;
+         return p.v;
+       }`,
+      [{ fn: "h", args: [null] }],
+    );
+  });
+
+  it("non-null class receiver still returns the field (no spurious guard)", async () => {
+    await assertEquivalent(
+      `class A { v: number = 42; }
+       export function k(): number {
+         const a = new A();
+         if (a === null) return -1;
+         return a.v;
+       }`,
+      [{ fn: "k", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The IR `tryFoldNullCompare` deleted the defensive null-check idiom for
class-typed values:

```ts
class A { v: number = 7; }
export function f(p: A): number {
  if (p === null) return -1;   // folded to false → guard deleted
  return 0;
}
// host calls f(null) → wasm returned 0 (Node: -1)
// `return p.v` variant → RuntimeError: dereferencing a null pointer
```

`tryFoldNullCompare` folds `=== null` / `!== null` to a constant unless the
non-null operand is on its bail-out list. The list covered `boxed`, `extern`,
and `val{externref|ref_null}` but never `class`, `object`, or `closure` — all
of which lower to **nullable** WasmGC ref shapes (`(ref null $Struct)`). A
class/object/closure value that is actually `null` at runtime then bypassed
its own guard.

## Fix

Extend the bail-out to `class`, `object`, and `closure`. When the operand has
one of these kinds the fold returns `null`, so the caller falls through to the
standard lowering, which throws on the bare `NullKeyword` operand and triggers
the whole-function legacy fallback — and legacy emits a runtime `ref.is_null`
check. This mirrors the existing `boxed`/`extern` bails exactly.

(`vec` from the issue title is not a distinct `IrType` kind — vecs surface as
`object`/`class`/`val{ref_null}`, already covered.)

## Tests

`tests/issue-1981.test.ts` — 4 equivalence cases (wasm vs Node), all pass:
class `=== null` and `!== null` guards with a `null` arg, loose `== null`, and
a non-null class receiver (no spurious guard).

- IR fallback budget gate (`check:ir-fallbacks`): OK, no unintended increases.
- `biome lint`, `tsc --noEmit`, `prettier --check`: clean.
- Pre-existing, unrelated failures in `null-deref-class.test.ts` and
  `null-dereference-guards.test.ts` confirmed identical on clean `origin/main`.

Closes #1981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)