### PR TITLE
fix(#1980): apply i32-bool check to IR while/for loop conditions

### DIFF
--- a/plan/issues/1980-ir-numeric-loop-cond-invalid-wasm.md
+++ b/plan/issues/1980-ir-numeric-loop-cond-invalid-wasm.md
@@ -1,10 +1,11 @@
 ---
 id: 1980
 title: "IR: while/for with a numeric-truthiness condition emits invalid Wasm and bricks the entire module (no fallback, verifier silent)"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -63,3 +64,37 @@ only uses `i < N` conditions — add truthiness-cond cases.
 
 #1280 (introduced while/for claims — no mention), #1850 (verifier umbrella,
 in-progress — lists dominance/buffer recursion, not cond typing).
+
+## Resolution (2026-06-12)
+
+Two source changes, both following the fix direction:
+
+1. **`src/ir/from-ast.ts`** — `lowerWhileStatement` and `lowerForStatement`
+   now capture the value id `lowerExpr` returns (instead of the fragile
+   `condInstrs[last].result`) and throw the same `if`/ternary-style fallback
+   (`"while/for condition must be bool"`) when `asVal(typeOf(condValue))` isn't
+   i32. The IR demotes the function to the legacy path, which already does
+   ToBoolean lowering for numeric-truthiness loops — restoring `f(3)=6`,
+   `f(0)=0` for both the `while` and `for` repros.
+
+2. **`src/ir/verify.ts`** — `while.loop`/`for.loop` now type-check `condValue`
+   after walking the cond buffer: a non-i32 condValue pushes a
+   `"condValue must be i32"` error. This is the structural backstop for the
+   #1850 gap (the lowerer throw in (1) fires first, but the verifier should
+   never wave a non-i32 loop cond through to the unconditional `i32.eqz`).
+
+### Test Results
+
+New `tests/issue-1980.test.ts` — 5 cases, all pass:
+- `while (k)` / `for (; k; )` with an f64 counter → `f(3)=6`, `f(5)=15`,
+  `f(0)=0` (were: `i32.eqz expected i32, found f64` invalid-Wasm, whole module
+  failed to instantiate).
+- i32-comparison `for (i < n)` and `while (i < n)` loops → unchanged, still
+  compile via the IR path (`f(4)=6`).
+
+`tests/issue-1280.test.ts` (9/9) and `tests/issue-1844.test.ts` pass — #1280's
+claimed loop shapes unregressed. Pre-existing failures in
+`tests/ir/passes.test.ts` / `tests/ir/inline-small.test.ts` (8 total) are
+confirmed identical on clean `origin/main` — unrelated to this change (they
+exercise `if`/`return`/inline, not loops). `tsc --noEmit`, `biome lint`,
+`prettier --check` all clean on the changed files.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2933,12 +2933,23 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
  * through `slot.read` / `slot.write` and survive the loop.
  */
 function lowerWhileStatement(stmt: ts.WhileStatement, cx: LowerCtx): void {
+  // Capture the value id `lowerExpr` returns rather than the cond buffer's
+  // last instruction result — the latter is fragile (e.g. a trailing store
+  // produces no value). (#1980)
+  let condResult: number | null = null;
   const condInstrs = cx.builder.collectBodyInstrs(() => {
-    lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
+    condResult = lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
   });
-  const condResult = condInstrs[condInstrs.length - 1]?.result;
   if (condResult === null || condResult === undefined) {
     throw new Error(`ir/from-ast: while cond produced no SSA value (${cx.funcName})`);
+  }
+  // `if`/ternary throw a clean fallback when the condition isn't already an
+  // i32 bool; loops skipped that check and the lowerer's unconditional
+  // `i32.eqz` then emitted invalid Wasm (e.g. a numeric-truthiness `while (k)`
+  // with an f64 `k`). Throw the same fallback so the legacy path handles
+  // ToBoolean lowering until the IR grows its own. (#1980)
+  if (asVal(cx.builder.typeOf(condResult))?.kind !== "i32") {
+    throw new Error(`ir/from-ast: while condition must be bool in ${cx.funcName}`);
   }
   const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
   const bodyInstrs = cx.builder.collectBodyInstrs(() => {
@@ -2982,12 +2993,20 @@ function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
   }
 
   // 2. Cond — collect its IR into a buffer.
+  // Capture the value id `lowerExpr` returns rather than the buffer's last
+  // instruction result (fragile — see #1980).
+  let condResult: number | null = null;
   const condInstrs = innerCx.builder.collectBodyInstrs(() => {
-    lowerExpr(stmt.condition!, innerCx, irVal({ kind: "i32" }));
+    condResult = lowerExpr(stmt.condition!, innerCx, irVal({ kind: "i32" }));
   });
-  const condResult = condInstrs[condInstrs.length - 1]?.result;
   if (condResult === null || condResult === undefined) {
     throw new Error(`ir/from-ast: for cond produced no SSA value (${cx.funcName})`);
+  }
+  // Same i32-bool fallback as `if`/ternary — a numeric-truthiness `for` cond
+  // (e.g. `for (...; k; ...)` with f64 `k`) otherwise reaches the lowerer's
+  // unconditional `i32.eqz` and emits invalid Wasm. (#1980)
+  if (asVal(innerCx.builder.typeOf(condResult))?.kind !== "i32") {
+    throw new Error(`ir/from-ast: for condition must be bool in ${cx.funcName}`);
   }
 
   // 3. Body — collect into a buffer.

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -361,6 +361,19 @@ function verifyBlock(
       // would spuriously read as use-before-def. (#1844)
       if (instr.kind === "while.loop" || instr.kind === "for.loop") {
         walkBuffer(instr.cond);
+        // The lowerer emits an unconditional `i32.eqz` on `condValue`, so a
+        // non-i32 cond produces invalid Wasm that bricks the whole module.
+        // Reject it here (the lowerer's #1980 fix throws a fallback before
+        // reaching this, but the verifier is the structural backstop — the
+        // #1850 gap that let this through silently). (#1980)
+        const condT = operandIrType(func, block, instr.condValue, localDefs);
+        if (condT && asVal(condT)?.kind !== "i32") {
+          errors.push({
+            message: `${instr.kind} condValue must be i32, got ${asVal(condT)?.kind ?? condT.kind}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
       }
 
       // Use-before-def check (params + block args always count). Nested-body

--- a/tests/issue-1980.test.ts
+++ b/tests/issue-1980.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1980 — IR `while`/`for` lowering skipped the i32-bool check that `if` and
+// ternary apply, so a numeric-truthiness loop condition (`while (k)` with an
+// f64 `k`) reached the lowerer's unconditional `i32.eqz` and emitted invalid
+// Wasm — `i32.eqz expected type i32, found local.get of type f64` — which
+// bricked the *entire module* (no fallback, verifier silent).
+//
+// Fix: `lowerWhileStatement` / `lowerForStatement` now (a) capture the value id
+// `lowerExpr` returns instead of the cond buffer's last instruction result, and
+// (b) throw the same "condition must be bool" fallback as `if`/ternary when the
+// cond isn't already i32 — restoring the legacy path for numeric-truthiness
+// loops. The IR verifier also gained an i32 check on `while.loop`/`for.loop`
+// condValue as the structural backstop (#1850 gap).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string, arg: number): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: Function }).setExports === "function") {
+    (imps as { setExports: Function }).setExports(instance.exports);
+  }
+  return (instance.exports as { f: (n: number) => unknown }).f(arg);
+}
+
+const whileTruthy = `export function f(n: number): number {
+  let s = 0; let k = n;
+  while (k) { s = s + k; k = k - 1; }
+  return s;
+}`;
+
+const forTruthy = `export function f(n: number): number {
+  let s = 0;
+  for (let k = n; k; k = k - 1) { s = s + k; }
+  return s;
+}`;
+
+describe("#1980 numeric-truthiness loop condition", () => {
+  it("while (k) with an f64 counter sums n..1 (was: invalid Wasm)", async () => {
+    expect(await run(whileTruthy, 3)).toBe(6); // node: 3+2+1
+    expect(await run(whileTruthy, 5)).toBe(15); // node: 5+4+3+2+1
+  });
+
+  it("while (k) terminates immediately when n is 0", async () => {
+    expect(await run(whileTruthy, 0)).toBe(0); // node: 0
+  });
+
+  it("for (; k; ) with an f64 counter sums n..1", async () => {
+    expect(await run(forTruthy, 3)).toBe(6); // node: 3+2+1
+    expect(await run(forTruthy, 0)).toBe(0); // node: 0
+  });
+
+  it("does not regress an i32-comparison for loop (IR path)", async () => {
+    const src = `export function f(n: number): number {
+      let s = 0;
+      for (let i = 0; i < n; i = i + 1) { s = s + i; }
+      return s;
+    }`;
+    expect(await run(src, 4)).toBe(6); // node: 0+1+2+3
+  });
+
+  it("does not regress an i32-comparison while loop (IR path)", async () => {
+    const src = `export function f(n: number): number {
+      let s = 0; let i = 0;
+      while (i < n) { s = s + i; i = i + 1; }
+      return s;
+    }`;
+    expect(await run(src, 4)).toBe(6); // node: 0+1+2+3
+  });
+});


### PR DESCRIPTION
## Problem (#1980)

IR lowering of `while`/`for` skipped the i32-truthiness check that `if` and
ternary apply. A numeric-truthiness loop condition — `while (k)` where `k` is an
f64 — reached the lowerer's unconditional `i32.eqz` and emitted invalid Wasm:

```
i32.eqz expected type i32, found local.get of type f64
```

This bricked the **entire module** (every export failed to instantiate), with no
IR fallback and the verifier silent.

```ts
export function f(n: number): number {
  let s = 0; let k = n;
  while (k) { s = s + k; k = k - 1; }  // f64-typed JS-truthiness cond
  return s;
}
// before: module fails to instantiate;  node: f(3)=6, f(0)=0
```

## Fix

- **`src/ir/from-ast.ts`** — `lowerWhileStatement` / `lowerForStatement` now
  capture the value id `lowerExpr` returns (instead of the fragile
  `condInstrs[last].result`) and throw the same `if`/ternary-style fallback when
  `asVal(typeOf(condValue))` isn't i32. The function demotes to the legacy path,
  which already does ToBoolean lowering for numeric-truthiness loops.
- **`src/ir/verify.ts`** — `while.loop`/`for.loop` now type-check `condValue` is
  i32 after walking the cond buffer — the structural backstop for the #1850
  verifier gap (the lowerer throw fires first, but the verifier should never
  pass a non-i32 loop cond to the unconditional `i32.eqz`).

Proper IR-native ToBoolean lowering for loops can come later; this restores the
correct legacy behavior and closes the invalid-Wasm hole.

## Tests

`tests/issue-1980.test.ts` — 5 cases, all green: f64-counter `while`/`for` loops
return `6`/`15`/`0` (were invalid Wasm); i32-comparison `for (i < n)` /
`while (i < n)` loops unchanged via the IR path.

`tests/issue-1280.test.ts` (9/9) and `tests/issue-1844.test.ts` unregressed.
Pre-existing failures in `tests/ir/passes.test.ts` / `inline-small.test.ts`
(8 total, `if`/`return`/inline — not loops) confirmed identical on clean
`origin/main`. `tsc --noEmit`, `biome lint`, `prettier --check` clean.

Closes #1980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)