### PR TITLE
fix(#2045): close linear Uint8Array silent-corruption routes (A.1, A.2)

### DIFF
--- a/plan/issues/2045-linear-uint8-soundness-holes.md
+++ b/plan/issues/2045-linear-uint8-soundness-holes.md
@@ -1,7 +1,7 @@
 ---
 id: 2045
 title: "linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up)"
-status: ready
+status: in-progress
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
@@ -91,3 +91,59 @@ corruption routes must be fixed before the linear path widens further
   compile errors on valid programs, no signature mismatches.
 - `real-world-wasi.test.ts` and `tests/issue-1886*.test.ts` stay green;
   new regression tests for findings 1, 2, 3, 4, 8.
+
+## Partial resolution (2026-06-12) — silent-corruption routes A.1 + A.2 landed
+
+The two **silent-corruption** routes (Part A, "fix first") are fixed. The
+escape-analysis demotion gaps (Part B) and the smaller correctness items
+(Part C) remain — the issue stays **in-progress**.
+
+### A.1 — scope-blind buffer registry → symbol-keyed
+
+`fctx.linearU8Buffers` was keyed by identifier **text**
+(`linear-uint8-signatures.ts`), so a linear param `buf` plus an inner-block
+`const buf = new Uint8Array(...)` (distinct symbol, same name) collided — the
+inner registration overwrote the param's `(ptr,len)` entry, and element access
+addressed the wrong buffer in **both** shadowing directions (verified: the
+param's trailing `write(buf)` emitted the inner buffer's bytes).
+
+Fix: key the registry by the binding's `ts.Symbol`. `registerLinearU8Buffer`
+now takes a symbol; `getLinearU8Buffer(ctx, fctx, node)` resolves the symbol
+via `ctx.checker.getSymbolAtLocation(node)`. Param registration
+(`function-body.ts`) and `new Uint8Array(...)` registration
+(`linear-uint8-codegen.ts`) both pass the symbol; a binding with no resolvable
+symbol simply isn't registered (falls to the GC path — sound).
+
+### A.2 — no bounds check on linear element access → trap like GC
+
+`b[i]` / `b[i] = v` lowered to a raw `i32.load8_u`/`i32.store8` at
+`ptr + trunc(i)` with no bounds check; an OOB index silently read/wrote
+arbitrary linear memory (iovec scratch at 0..11, string-literal data, and —
+under Slice C — a caller's buffer). The GC array path traps.
+
+Fix: `emitLinearU8BoundsCheck` emits `idx (u32) >= len → unreachable` before
+every linear element get/set, matching the GC trap. The index is compared
+unsigned so a negative (huge-u32) index also traps. The store path checks
+**before** evaluating the value, matching the GC `array.set` trap order. Index
+exprs are stored once so a side-effecting index runs once. The guard is
+unconditional (one compare + branch per access); eliding it for provably
+in-range constant indices is a possible later perf tweak, not a soundness need.
+
+Covered (`tests/issue-2045-linear-u8-soundness.test.ts`, 6 green): OOB read
+traps, OOB write traps, negative-index traps, in-bounds access unchanged
+(read-back), inner-block same-name shadow (param not corrupted), outer local
+keeps its buffer after a same-name inner const. Regression-clean across
+`tests/issue-1886*.test.ts` (16 green), `linear-*` (22 green), and the WASI
+I/O suites; tsc + biome + prettier clean. (`real-world-wasi.test.ts` and the
+`issue-1886-slice-b` escaping test have two pre-existing host-import-allowlist
+failures unrelated to this change — verified identical on main.)
+
+### Remaining (issue stays open)
+
+- **B.3 / B.4** escape-analysis demotion gaps (untracked call-site args;
+  function-value escapes of rewritten helpers) — these are fail-closed
+  `reportError`s on otherwise-valid WASI programs, a larger interprocedural
+  change split out from the corruption fixes.
+- **C.5–C.8** loop-arena rewind ordering, the all-target while-loop
+  restructure gate, `process.stdin.read` offset clamp + errno, and compound
+  element writes (`b[i] += 1`).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -434,16 +434,22 @@ export interface FunctionContext {
     }
   >;
   /**
-   * #1886 Slice B — live linear-backed `Uint8Array` buffers in this function,
-   * keyed by binding name. A buffer proven linear-safe by the #1886 analysis
+   * #1886 Slice B — live linear-backed `Uint8Array` buffers in this function. A
+   * buffer proven linear-safe by the #1886 analysis
    * (`ctx.linearUint8.safeBindings`) is represented as a `(ptr, len)` pair of
    * i32 locals instead of a GC vec, so `buf[i]`, `buf.length`, and
    * `process.std*.{read,write}(buf)` operate on linear memory with zero
    * GC↔linear copies. Absent entry ⇒ the binding uses the existing GC-vec path
    * unchanged.
+   *
+   * #2045: keyed by the binding's `ts.Symbol`, NOT by identifier text. A
+   * name-keyed registry was scope-blind — a linear param `buf` plus an
+   * inner-block `const buf = new Uint8Array(...)` (a distinct symbol with the
+   * same name) collided, so element access addressed the wrong buffer in both
+   * shadowing directions (silent corruption). Symbol identity is scope-correct.
    */
   linearU8Buffers?: Map<
-    string,
+    ts.Symbol,
     {
       ptrLocalIdx: number; // i32 — base byte offset into the page-4 linear arena
       lenLocalIdx: number; // i32 — element length (== byte length for Uint8Array)

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -9480,7 +9480,7 @@ function compileCallExpression(
       for (let i = 0; i < Math.min(expr.arguments.length, paramCount); i++) {
         if (hasLinearParamsForCall && linearParamsForCall.has(i)) {
           const arg = expr.arguments[i]!;
-          const buf = getLinearU8Buffer(fctx, arg);
+          const buf = getLinearU8Buffer(ctx, fctx, arg);
           if (!buf) {
             reportError(
               ctx,

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -661,7 +661,9 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   const restInfo = ctx.funcRestParams.get(func.name);
   const params: { name: string; type: ValType }[] = [];
   const linearParams = getLinearU8ParamIndicesForDeclaration(ctx, decl);
-  const linearParamBuffers: { name: string; ptrLocalIdx: number; lenLocalIdx: number }[] = [];
+  // #2045: carry the param's ts.Symbol so the buffer registry is keyed by
+  // symbol (scope-correct) rather than identifier text (shadow-blind).
+  const linearParamBuffers: { sym: ts.Symbol | undefined; ptrLocalIdx: number; lenLocalIdx: number }[] = [];
   const funcType = ctx.mod.types[func.typeIdx];
   const sigParamTypes = funcType?.kind === "func" ? funcType.params : undefined;
   let wasmParamCursor = 0;
@@ -681,7 +683,8 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
           type: sigParamTypes?.[lenLocalIdx] ?? { kind: "i32" },
         },
       );
-      linearParamBuffers.push({ name: paramName, ptrLocalIdx, lenLocalIdx });
+      const paramSym = ts.isIdentifier(param.name) ? ctx.checker.getSymbolAtLocation(param.name) : undefined;
+      linearParamBuffers.push({ sym: paramSym, ptrLocalIdx, lenLocalIdx });
     } else if (restInfo && i === restInfo.restIndex) {
       // Rest parameter — use the vec struct ref type from the function signature
       params.push({
@@ -751,7 +754,9 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
     fctx.localMap.set(params[i]!.name, i);
   }
   for (const buf of linearParamBuffers) {
-    registerLinearU8Buffer(fctx, buf.name, buf.ptrLocalIdx, buf.lenLocalIdx);
+    // A param with no resolvable symbol can't be looked up by element access
+    // either, so skipping registration is sound — it falls to the GC path.
+    if (buf.sym) registerLinearU8Buffer(fctx, buf.sym, buf.ptrLocalIdx, buf.lenLocalIdx);
   }
 
   ctx.currentFunc = fctx;

--- a/src/codegen/linear-uint8-codegen.ts
+++ b/src/codegen/linear-uint8-codegen.ts
@@ -111,7 +111,7 @@ export function tryEmitLinearU8New(
       fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
       fctx.body.push({ op: "i32.store8", align: 0, offset: 0 } as Instr);
     });
-    registerBuffer(fctx, nameNode.text, ptrLocal, lenLocal);
+    registerBuffer(ctx, fctx, nameNode, ptrLocal, lenLocal);
     return true;
   }
 
@@ -127,12 +127,26 @@ export function tryEmitLinearU8New(
   fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
   fctx.body.push({ op: "call", funcIdx: allocIdx } as Instr);
   fctx.body.push({ op: "local.set", index: ptrLocal } as Instr);
-  registerBuffer(fctx, nameNode.text, ptrLocal, lenLocal);
+  registerBuffer(ctx, fctx, nameNode, ptrLocal, lenLocal);
   return true;
 }
 
-function registerBuffer(fctx: FunctionContext, name: string, ptrLocalIdx: number, lenLocalIdx: number): void {
-  registerLinearU8Buffer(fctx, name, ptrLocalIdx, lenLocalIdx);
+/**
+ * Register a linear-backed buffer under the binding's `ts.Symbol` (#2045).
+ * Falls back to a no-op when the identifier has no resolvable symbol — codegen
+ * then leaves the binding on the GC path, which is sound (never silent
+ * corruption).
+ */
+function registerBuffer(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  nameNode: ts.Identifier,
+  ptrLocalIdx: number,
+  lenLocalIdx: number,
+): void {
+  const sym = ctx.checker.getSymbolAtLocation(nameNode);
+  if (!sym) return;
+  registerLinearU8Buffer(fctx, sym, ptrLocalIdx, lenLocalIdx);
 }
 
 /**
@@ -145,16 +159,47 @@ export function tryEmitLinearU8ElementGet(
   fctx: FunctionContext,
   expr: ts.ElementAccessExpression,
 ): ValType | null {
-  const buf = lookupLinearU8Buffer(fctx, expr.expression);
+  const buf = lookupLinearU8Buffer(ctx, fctx, expr.expression);
   if (!buf) return null;
-  // address = ptr + trunc(index)
-  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  // idx = trunc(index), stored once so the bounds check and the address
+  // computation observe the same value (and side-effecting index exprs run once).
+  const idxLocal = allocLocal(fctx, `__linu8_gidx_${fctx.locals.length}`, { kind: "i32" });
   compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
   fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
+  // #2045 A.2: bounds-check like the GC path. An unchecked OOB read silently
+  // returned arbitrary linear memory (iovec scratch, string data, a caller's
+  // buffer under Slice C); trap instead.
+  emitLinearU8BoundsCheck(fctx, idxLocal, buf.lenLocalIdx);
+  // address = ptr + idx
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
   fctx.body.push({ op: "i32.load8_u", align: 0, offset: 0 } as Instr);
   fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
   return { kind: "f64" };
+}
+
+/**
+ * #2045 A.2 — emit a `idx (u32) >= len → unreachable` guard before a linear
+ * element access, matching the WasmGC array path which traps on OOB. The index
+ * is compared as unsigned so a negative (huge-u32) index also traps.
+ *
+ * `idxLocal` holds the truncated i32 index; `lenLocalIdx` the buffer length.
+ * On out-of-range the module traps (`unreachable`) — the same observable
+ * outcome as the GC `array.get`/`array.set` bounds trap. A provably in-range
+ * constant index could elide this, but I keep it unconditional for soundness;
+ * the cost is one compare + branch per element access.
+ */
+function emitLinearU8BoundsCheck(fctx: FunctionContext, idxLocal: number, lenLocalIdx: number): void {
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocalIdx } as Instr);
+  fctx.body.push({ op: "i32.ge_u" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "unreachable" } as Instr],
+  } as Instr);
 }
 
 /**
@@ -181,20 +226,28 @@ export function tryEmitLinearU8ElementSet(
   target: ts.ElementAccessExpression,
   valueExpr: ts.Expression,
 ): InnerResult {
-  const buf = lookupLinearU8Buffer(fctx, target.expression);
+  const buf = lookupLinearU8Buffer(ctx, fctx, target.expression);
   if (!buf) return null;
   // Allocate the result/addr temps up-front so their slot indices are fixed
   // before the nested index/value sub-expressions compile (those allocate their
   // own temps as they go). Each sub-expression is fully evaluated into a temp
   // before the next is compiled, so no stash ever interleaves with another
   // expression's temp usage on the value stack (#1886).
+  const idxLocal = allocLocal(fctx, `__linu8_sidx_${fctx.locals.length}`, { kind: "i32" });
   const addrLocal = allocLocal(fctx, `__linu8_addr_${fctx.locals.length}`, { kind: "i32" });
   const valLocal = allocLocal(fctx, `__linu8_val_${fctx.locals.length}`, { kind: "f64" });
 
-  // addr = ptr + trunc(index)  (index evaluated first, per JS + the GC path)
-  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  // idx = trunc(index)  (index evaluated first, per JS + the GC path)
   compileExpression(ctx, fctx, target.argumentExpression, { kind: "f64" });
   fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
+  // #2045 A.2: bounds-check BEFORE evaluating the value, so an OOB write traps
+  // (like the GC path) rather than scribbling into a caller's linear memory.
+  // The check precedes value evaluation to match the GC array.set trap order.
+  emitLinearU8BoundsCheck(fctx, idxLocal, buf.lenLocalIdx);
+  // addr = ptr + idx
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
   fctx.body.push({ op: "local.set", index: addrLocal } as Instr);
   // val = v (kept as f64 for the assignment-expression result)
@@ -219,9 +272,13 @@ export function tryEmitLinearU8ElementSet(
 }
 
 /** `b.length` for a linear-backed buffer → `len` widened to f64. */
-export function tryEmitLinearU8Length(fctx: FunctionContext, expr: ts.PropertyAccessExpression): ValType | null {
+export function tryEmitLinearU8Length(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+): ValType | null {
   if (expr.name.text !== "length") return null;
-  const buf = lookupLinearU8Buffer(fctx, expr.expression);
+  const buf = lookupLinearU8Buffer(ctx, fctx, expr.expression);
   if (!buf) return null;
   fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
   fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
@@ -230,10 +287,11 @@ export function tryEmitLinearU8Length(fctx: FunctionContext, expr: ts.PropertyAc
 
 /** Accessor used by the WASI I/O intrinsics to get a buffer's (ptr, len) locals. */
 export function getLinearU8Buffer(
+  ctx: CodegenContext,
   fctx: FunctionContext,
   node: ts.Node,
 ): { ptrLocalIdx: number; lenLocalIdx: number } | undefined {
-  return lookupLinearU8Buffer(fctx, node);
+  return lookupLinearU8Buffer(ctx, fctx, node);
 }
 
 /**
@@ -251,7 +309,7 @@ export function tryEmitLinearU8StdinRead(
   expr: ts.CallExpression,
   fdReadIdx: number,
 ): ValType | null {
-  const buf = getLinearU8Buffer(fctx, expr.arguments[0]!);
+  const buf = getLinearU8Buffer(ctx, fctx, expr.arguments[0]!);
   if (!buf) return null;
 
   // off = arg1 (trunc) or 0
@@ -298,12 +356,13 @@ export function tryEmitLinearU8StdinRead(
  * stack, matching the GC write path), `null` if `buf` is not linear-backed.
  */
 export function tryEmitLinearU8StdWrite(
+  ctx: CodegenContext,
   fctx: FunctionContext,
   bufArg: ts.Expression,
   fdWriteIdx: number,
   useStderr: boolean,
 ): boolean {
-  const buf = getLinearU8Buffer(fctx, bufArg);
+  const buf = getLinearU8Buffer(ctx, fctx, bufArg);
   if (!buf) return false;
   const fd = useStderr ? 2 : 1;
   // iovec.buf = ptr (memory[0])

--- a/src/codegen/linear-uint8-signatures.ts
+++ b/src/codegen/linear-uint8-signatures.ts
@@ -105,20 +105,30 @@ export function sourceParamCountFromExpanded(
   return wasmParamCount - leadingParams - (linearParams?.size ?? 0);
 }
 
+/**
+ * #2045: look up a linear-backed buffer by the binding's `ts.Symbol`, resolved
+ * from the identifier `node`. Symbol identity is scope-correct, so a param
+ * `buf` and an inner-block `const buf` (distinct symbols, same text) no longer
+ * collide — the previous name-keyed map addressed whichever was registered last
+ * in both shadowing directions (silent corruption).
+ */
 export function getLinearU8Buffer(
+  ctx: CodegenContext,
   fctx: FunctionContext,
   node: ts.Node,
 ): { ptrLocalIdx: number; lenLocalIdx: number } | undefined {
   if (!fctx.linearU8Buffers || !ts.isIdentifier(node)) return undefined;
-  return fctx.linearU8Buffers.get(node.text);
+  const sym = ctx.checker.getSymbolAtLocation(node);
+  if (!sym) return undefined;
+  return fctx.linearU8Buffers.get(sym);
 }
 
 export function registerLinearU8Buffer(
   fctx: FunctionContext,
-  name: string,
+  sym: ts.Symbol,
   ptrLocalIdx: number,
   lenLocalIdx: number,
 ): void {
   if (!fctx.linearU8Buffers) fctx.linearU8Buffers = new Map();
-  fctx.linearU8Buffers.set(name, { ptrLocalIdx, lenLocalIdx });
+  fctx.linearU8Buffers.set(sym, { ptrLocalIdx, lenLocalIdx });
 }

--- a/src/codegen/node-process-api.ts
+++ b/src/codegen/node-process-api.ts
@@ -56,7 +56,7 @@ export function tryCompileNodeProcessCall(
   // Uint8Array — fd_write reads straight from `ptr` for `len` bytes (no
   // GC→linear staging copy). Only fires for a registered linear-safe buffer.
   if (ctx.wasiFdWriteIdx !== undefined && ctx.wasiFdWriteIdx >= 0) {
-    if (tryEmitLinearU8StdWrite(fctx, argExpr, ctx.wasiFdWriteIdx, useStderr)) {
+    if (tryEmitLinearU8StdWrite(ctx, fctx, argExpr, ctx.wasiFdWriteIdx, useStderr)) {
       // Match the GC Uint8Array write path's contract: push `1` (write
       // succeeded) and return i32, so the expression-statement wrapper drops it
       // exactly like the GC path. (#1886)

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1355,7 +1355,7 @@ export function compilePropertyAccess(
   // #1886 Slice B: linear-backed Uint8Array `buf.length` → the len i32 local
   // (widened to f64). Only fires for a registered linear-safe buffer; any other
   // receiver falls through to the GC property-access path unchanged.
-  const linU8Len = tryEmitLinearU8Length(fctx, expr);
+  const linU8Len = tryEmitLinearU8Length(ctx, fctx, expr);
   if (linU8Len !== null) return linU8Len;
 
   const objType = ctx.checker.getTypeAtLocation(expr.expression);

--- a/tests/issue-2045-linear-u8-soundness.test.ts
+++ b/tests/issue-2045-linear-u8-soundness.test.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2045 — linear-backed `Uint8Array` (WASI) soundness holes, the two
+ * silent-corruption routes found reviewing the #1886 Slice C merge:
+ *
+ *   A.1  Name-keyed buffer registry was scope-blind. A linear param `buf` plus
+ *        an inner-block `const buf = new Uint8Array(...)` (a distinct symbol
+ *        with the same text) collided in `fctx.linearU8Buffers`, so element
+ *        access addressed the wrong buffer in both shadowing directions. The
+ *        registry is now keyed by `ts.Symbol`.
+ *
+ *   A.2  `b[i]` / `b[i] = v` lowered to a raw `i32.load8_u`/`i32.store8` at
+ *        `ptr + trunc(i)` with NO bounds check, so an OOB index silently
+ *        read/wrote arbitrary linear memory (iovec scratch, string data, a
+ *        caller's buffer under Slice C). The GC array path traps; the linear
+ *        path now traps too (`idx (u32) >= len → unreachable`).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const STDIN_DECL = `declare const process: {
+  stdin: { read(b: Uint8Array, off?: number): number };
+  stdout: { write(b: Uint8Array): void };
+};`;
+
+async function compileWasi(source: string): Promise<Uint8Array> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.map((e) => e.message).join("; ") ?? "unknown"}`);
+  }
+  return result.binary;
+}
+
+/** Run a WASI module's `main`/`_start`, capturing fd_write bytes. */
+async function runWasiMain(binary: Uint8Array): Promise<number[]> {
+  const module = await WebAssembly.compile(binary);
+  const memRef: { value?: WebAssembly.Memory } = {};
+  const out: number[] = [];
+  const view = () => new DataView(memRef.value!.buffer);
+  const memU8 = () => new Uint8Array(memRef.value!.buffer);
+  const wasi = {
+    fd_read: () => 0,
+    fd_write(_fd: number, iovsPtr: number, iovsLen: number, nwrittenPtr: number): number {
+      const dv = view();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const base = iovsPtr + i * 8;
+        const p = dv.getUint32(base, true);
+        const l = dv.getUint32(base + 4, true);
+        for (const b of memU8().subarray(p, p + l)) out.push(b);
+        total += l;
+      }
+      dv.setUint32(nwrittenPtr, total, true);
+      return 0;
+    },
+    proc_exit: () => {
+      throw new Error("__proc_exit");
+    },
+  };
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  memRef.value = exports.memory as WebAssembly.Memory;
+  const entry = (exports.main ?? exports._start) as undefined | (() => void);
+  if (!entry) throw new Error("no main/_start export");
+  entry();
+  return out;
+}
+
+describe("#2045 linear Uint8Array soundness", () => {
+  // A.2 — out-of-bounds read traps instead of returning arbitrary memory.
+  it("A.2: OOB read traps like the GC path", async () => {
+    const src = `${STDIN_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        const x = buf[100];   // OOB — must trap
+        const out = new Uint8Array(1);
+        out[0] = x;
+        process.stdout.write(out);
+      }`;
+    const bin = await compileWasi(src);
+    await expect(runWasiMain(bin)).rejects.toThrow();
+  });
+
+  // A.2 — out-of-bounds write traps instead of scribbling into linear memory.
+  it("A.2: OOB write traps like the GC path", async () => {
+    const src = `${STDIN_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        buf[100] = 7;         // OOB — must trap
+        process.stdout.write(buf);
+      }`;
+    const bin = await compileWasi(src);
+    await expect(runWasiMain(bin)).rejects.toThrow();
+  });
+
+  // A.2 — a negative index is a huge u32 and must trap too.
+  it("A.2: negative index traps", async () => {
+    const src = `${STDIN_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(4);
+        const i = -1;
+        buf[i] = 9;           // negative → huge u32 — must trap
+        process.stdout.write(buf);
+      }`;
+    const bin = await compileWasi(src);
+    await expect(runWasiMain(bin)).rejects.toThrow();
+  });
+
+  // A.2 — the in-bounds happy path is unaffected (read-back through the bounds
+  // check still returns the stored bytes).
+  it("A.2: in-bounds access is unchanged", async () => {
+    const src = `${STDIN_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(3);
+        buf[0] = 10;
+        buf[1] = 20;
+        buf[2] = buf[0] + buf[1];   // 30, last index in range
+        process.stdout.write(buf);
+      }`;
+    const out = await runWasiMain(await compileWasi(src));
+    expect(out).toEqual([10, 20, 30]);
+  });
+
+  // A.1 — a linear param `buf` and an inner-block `const buf` (same text,
+  // distinct symbols) must address their own buffers. Before the fix the inner
+  // registration overwrote the param's entry, so the trailing write to the
+  // param's `buf` scribbled the inner buffer instead.
+  it("A.1: inner-block shadow does not corrupt the param buffer", async () => {
+    const src = `${STDIN_DECL}
+      function fill(buf: Uint8Array): void {
+        buf[0] = 1;
+        buf[1] = 2;
+        buf[2] = 3;
+        {
+          const buf = new Uint8Array(2);
+          buf[0] = 9;
+          buf[1] = 8;
+          process.stdout.write(buf);   // inner → [9, 8]
+        }
+        process.stdout.write(buf);     // param → [1, 2, 3], NOT [9, 8]
+      }
+      export function main(): void {
+        const outer = new Uint8Array(3);
+        fill(outer);
+      }`;
+    const out = await runWasiMain(await compileWasi(src));
+    expect(out).toEqual([9, 8, 1, 2, 3]);
+  });
+
+  // A.1 — the reverse shadow: a local `buf` declared before a same-name inner
+  // const must keep addressing its own buffer after the inner block ends.
+  it("A.1: outer local keeps its buffer after a same-name inner const", async () => {
+    const src = `${STDIN_DECL}
+      export function main(): void {
+        const buf = new Uint8Array(2);
+        buf[0] = 4;
+        buf[1] = 5;
+        {
+          const buf = new Uint8Array(1);
+          buf[0] = 99;
+          process.stdout.write(buf);   // inner → [99]
+        }
+        process.stdout.write(buf);     // outer → [4, 5]
+      }`;
+    const out = await runWasiMain(await compileWasi(src));
+    expect(out).toEqual([99, 4, 5]);
+  });
+});


### PR DESCRIPTION
## Problem

Two **silent-corruption** holes in the #1886 Slice-C linear-backed `Uint8Array` (WASI) path, found reviewing merged PR #1288. Both produce wrong results with no error.

**A.1 — scope-blind buffer registry.** `fctx.linearU8Buffers` was keyed by identifier *text*, so a linear param `buf` plus an inner-block `const buf = new Uint8Array(...)` (a distinct symbol with the same name) collided — the inner registration overwrote the param's `(ptr,len)` entry, and element access addressed the wrong buffer in **both** shadowing directions.

**A.2 — no bounds check.** `b[i]` / `b[i] = v` lowered to a raw `i32.load8_u`/`i32.store8` at `ptr + trunc(i)` with no bounds check. An OOB index silently read/wrote arbitrary linear memory (iovec scratch at 0..11, string-literal data, and — under Slice C — a *caller's* buffer). The GC array path traps.

## Fix

**A.1** — key the registry by the binding's `ts.Symbol`. `registerLinearU8Buffer` takes a symbol; `getLinearU8Buffer(ctx, fctx, node)` resolves it via `ctx.checker.getSymbolAtLocation`. Param registration (`function-body.ts`) and `new Uint8Array(...)` registration both pass the symbol; an unresolvable binding simply isn't registered (falls to the GC path — sound).

**A.2** — `emitLinearU8BoundsCheck` emits `idx (u32) >= len → unreachable` before every linear element get/set, matching the GC trap. Unsigned compare so a negative (huge-u32) index also traps; the store checks **before** evaluating the value (GC `array.set` order); the index is stored once so a side-effecting index runs once.

## Tests

`tests/issue-2045-linear-u8-soundness.test.ts` (6): OOB read traps, OOB write traps, negative-index traps, in-bounds access unchanged (read-back), inner-block same-name shadow (param not corrupted), outer local keeps its buffer after a same-name inner const. Regression-clean across `tests/issue-1886*.test.ts` (16), `linear-*` (22), and the WASI I/O suites; tsc + biome + prettier clean. (`real-world-wasi.test.ts` and the `issue-1886-slice-b` escaping test have two pre-existing host-import-allowlist failures unrelated to this change — verified identical on main.)

## Scope

Lands the two silent-corruption routes the issue flags **fix first** (Part A). The escape-analysis demotion gaps (B.3/B.4) and smaller correctness items (C.5–8) remain — **#2045 stays `in-progress`**, documented in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)