### PR TITLE
fix(#1979): only apply IR early-return-if rewrite to terminating then-arms

### DIFF
--- a/plan/issues/1979-ir-void-early-if-skips-rest.md
+++ b/plan/issues/1979-ir-void-early-if-skips-rest.md
@@ -1,10 +1,11 @@
 ---
 id: 1979
 title: "IR: mid-body `if (cond) stmt;` in a void function silently skips ALL subsequent statements when cond is true"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -70,3 +71,36 @@ non-terminating then-arms as a plain side-effect `if` followed by the rest.
 
 #1228 (introduced the relaxation; tests only cover early-*return*),
 #1131/#1850/#1858 umbrellas — none mention this.
+
+## Resolution (2026-06-12)
+
+Fixed in `src/ir/from-ast.ts` `lowerStatementList`, in lowering (the selector
+still claims the shape, so IR fallback counts are unchanged):
+
+1. Added `thenArmTerminates(stmt)` — true for `return`/`throw`, a block ending
+   in a terminating tail, or an `if/else` where both arms terminate.
+2. The mid-body `if (cond) <then>; <rest>` branch now splits on it:
+   - **Terminating then-arm** → the original early-return rewrite
+     (`if (cond) <tail> else { <rest> }`) — unchanged.
+   - **Non-terminating then-arm** → a converging guard: `br_if cond → then /
+     cont`; the then-block lowers the side effect and `br`s to `cont`; the
+     false branch targets `cont`; `cont` holds `<rest>` (or the implicit void
+     return when `<rest>` is empty). Both paths run the rest.
+   - The compile-time constant-fold branch (`evaluateConstantCondition`) got
+     the same split — a true-but-non-terminating then-arm now lowers its side
+     effect and falls through instead of synthesizing a return.
+
+### Test Results
+
+New `tests/issue-1979.test.ts` — 6 cases, all pass:
+- `if (a>0) g(b); h(b);` → `f(b,1)=101` (was `100`, h skipped), `f(b,0)=1`.
+- Non-terminating guard at end of fn → runs (`101`/`1`).
+- True/false early-RETURN guard → still short-circuits / falls through
+  (`0`/`1`) — unregressed.
+- Non-void early-return recursion `fact(5)=120` — unregressed.
+
+`tests/issue-1228.test.ts` (9/9), `tests/issue-1280.test.ts`,
+`tests/ir/issue-1373*.test.ts`, `tests/ir/issue-1392.test.ts` all pass.
+`pnpm run check:ir-fallbacks` OK (no unintended increases). `tsc --noEmit`,
+`biome lint`, `prettier --check` clean. Pre-existing `tests/ir/passes.test.ts`
+/ `inline-small.test.ts` failures are unrelated (confirmed on clean main).

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -395,6 +395,31 @@ export function lowerFunctionAstToIr(
   return { main: builder.finish(), lifted };
 }
 
+/**
+ * Does `stmt` unconditionally terminate its control flow (return / throw, or a
+ * block / if-else whose every path does)? Used by the mid-body `if (cond)
+ * <then>; <rest>` rewrite: the "early-return" structural reinterpretation
+ * (`if (cond) <then> else { <rest> }`) is only sound when the then-arm
+ * terminates — otherwise `<rest>` must still run after a true-branch
+ * side effect. (#1979)
+ */
+function thenArmTerminates(stmt: ts.Statement): boolean {
+  if (ts.isReturnStatement(stmt) || ts.isThrowStatement(stmt)) {
+    return true;
+  }
+  if (ts.isBlock(stmt)) {
+    const last = stmt.statements[stmt.statements.length - 1];
+    return last !== undefined && thenArmTerminates(last);
+  }
+  if (ts.isIfStatement(stmt)) {
+    // An `if` terminates only when it has an else and BOTH arms terminate.
+    return (
+      stmt.elseStatement !== undefined && thenArmTerminates(stmt.thenStatement) && thenArmTerminates(stmt.elseStatement)
+    );
+  }
+  return false;
+}
+
 function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void {
   if (stmts.length < 1) {
     throw new Error(`ir/from-ast: empty statement list in ${cx.funcName}`);
@@ -479,16 +504,27 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
     // (lowerTail enforces that); the else-arm opens a reserved block and
     // recursively lowers the remaining statements.
     if (ts.isIfStatement(s) && !s.elseStatement) {
+      // Whether the then-arm unconditionally terminates decides the shape:
+      // a terminating then-arm permits the early-return rewrite
+      // (`if (cond) <tail> else { <rest> }`); a non-terminating one is just a
+      // side-effecting guard and `<rest>` must run afterwards either way. (#1979)
+      const terminates = thenArmTerminates(s.thenStatement);
+
       // #1043: compile-time constant fold. After --define substitution of
       // process.env.NODE_ENV (etc.), the condition may be a literal-vs-literal
       // comparison. Skip the dead arm so dev-only code never reaches codegen.
       const constResult = evaluateConstantCondition(s.expression);
       if (constResult !== undefined) {
         if (constResult) {
-          // Then-arm taken: it must be a tail (returns), so the rest is
-          // unreachable and we stop here.
-          lowerTail(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
-          return;
+          if (terminates) {
+            // Then-arm taken and terminating: the rest is unreachable, stop.
+            lowerTail(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
+            return;
+          }
+          // Then-arm taken but non-terminating: run its side effects, then
+          // fall through to the rest in the same block / scope.
+          lowerStmt(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
+          continue;
         }
         // Then-arm dead: skip it and continue with the remaining statements
         // in the same block / scope.
@@ -499,21 +535,50 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
       if (asVal(condType)?.kind !== "i32") {
         throw new Error(`ir/from-ast: if condition must be bool in ${cx.funcName}`);
       }
+      const rest = stmts.slice(i + 1);
+
+      if (terminates) {
+        // Early-return rewrite: `if (cond) <tail> else { <rest> }`.
+        const thenId = cx.builder.reserveBlockId();
+        const elseId = cx.builder.reserveBlockId();
+        cx.builder.terminate({
+          kind: "br_if",
+          condition: cond,
+          ifTrue: { target: thenId, args: [] },
+          ifFalse: { target: elseId, args: [] },
+        });
+
+        cx.builder.openReservedBlock(thenId);
+        lowerTail(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
+
+        cx.builder.openReservedBlock(elseId);
+        lowerStatementList(rest, { ...cx, scope: new Map(cx.scope) });
+        return;
+      }
+
+      // Non-terminating then-arm: emit a converging guard. Both the then-block
+      // (after its side effect) and the false branch fall through to a shared
+      // continuation block holding `<rest>`. (#1979)
       const thenId = cx.builder.reserveBlockId();
-      const elseId = cx.builder.reserveBlockId();
+      const contId = cx.builder.reserveBlockId();
       cx.builder.terminate({
         kind: "br_if",
         condition: cond,
         ifTrue: { target: thenId, args: [] },
-        ifFalse: { target: elseId, args: [] },
+        ifFalse: { target: contId, args: [] },
       });
 
       cx.builder.openReservedBlock(thenId);
-      lowerTail(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
+      lowerStmt(s.thenStatement, { ...cx, scope: new Map(cx.scope) });
+      cx.builder.terminate({ kind: "br", branch: { target: contId, args: [] } });
 
-      cx.builder.openReservedBlock(elseId);
-      const rest = stmts.slice(i + 1);
-      lowerStatementList(rest, { ...cx, scope: new Map(cx.scope) });
+      cx.builder.openReservedBlock(contId);
+      if (rest.length === 0) {
+        // No trailing statements — the function's implicit void return.
+        cx.builder.terminate({ kind: "return", values: [] });
+      } else {
+        lowerStatementList(rest, { ...cx, scope: new Map(cx.scope) });
+      }
       return;
     }
     throw new Error(`ir/from-ast: unexpected statement before tail (got ${ts.SyntaxKind[s.kind]} in ${cx.funcName})`);

--- a/tests/issue-1979.test.ts
+++ b/tests/issue-1979.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1979 — the IR Phase-2 "early-return if" rewrite turned `if (cond) <then>;
+// <rest>` into `if (cond) <then> else { <rest> }`, sound only when the then-arm
+// terminates. Slice 14 (#1228) made a non-terminating ExpressionStatement a
+// valid void "tail", so `if (a > 0) g(b); h(b);` lowered the then-arm to a
+// synthesized `return` — the true branch returned after `g(b)` and `h(b)` never
+// ran (b.v = 100 instead of 101).
+//
+// Fix (src/ir/from-ast.ts): only apply the early-return rewrite when the
+// then-arm unconditionally terminates (`thenArmTerminates`). A non-terminating
+// then-arm now lowers as a converging guard — both the then-block (after its
+// side effect) and the false branch fall through to a continuation block that
+// holds `<rest>`.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: Function }).setExports === "function") {
+    (imps as { setExports: Function }).setExports(instance.exports);
+  }
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+const helpers = `
+class Box { v: number = 0; }
+function g(b: Box): number { b.v = b.v + 100; return b.v; }
+function h(b: Box): number { b.v = b.v + 1; return b.v; }
+`;
+
+describe("#1979 non-terminating early-if in a void function", () => {
+  it("runs the statements after a true-but-non-terminating `if` guard", async () => {
+    const got = await run(
+      `${helpers}
+      function f(b: Box, a: number): void { if (a > 0) g(b); h(b); }
+      export function test(): number { const b = new Box(); f(b, 1); return b.v; }`,
+    );
+    expect(got).toBe(101); // node: g adds 100, h adds 1 → 101 (was 100)
+  });
+
+  it("skips the guarded statement but still runs the rest when the cond is false", async () => {
+    const got = await run(
+      `${helpers}
+      function f(b: Box, a: number): void { if (a > 0) g(b); h(b); }
+      export function test(): number { const b = new Box(); f(b, 0); return b.v; }`,
+    );
+    expect(got).toBe(1); // node: only h runs → 1
+  });
+
+  it("a non-terminating guard at the end of the function still runs", async () => {
+    const got = await run(
+      `${helpers}
+      function f(b: Box, a: number): void { h(b); if (a > 0) g(b); }
+      export function test(): number { const b = new Box(); f(b, 1); return b.v; }`,
+    );
+    expect(got).toBe(101); // node: h then g → 101
+  });
+
+  it("a true early-RETURN guard still short-circuits the rest (unregressed)", async () => {
+    const got = await run(
+      `${helpers}
+      function f(b: Box, a: number): void { if (a > 0) return; h(b); }
+      export function test(): number { const b = new Box(); f(b, 1); return b.v; }`,
+    );
+    expect(got).toBe(0); // node: returns before h → 0
+  });
+
+  it("a false early-RETURN guard falls through to the rest (unregressed)", async () => {
+    const got = await run(
+      `${helpers}
+      function f(b: Box, a: number): void { if (a > 0) return; h(b); }
+      export function test(): number { const b = new Box(); f(b, 0); return b.v; }`,
+    );
+    expect(got).toBe(1); // node: h runs → 1
+  });
+
+  it("non-void early-return recursion is unregressed (classic fact)", async () => {
+    const got = await run(
+      `function fact(n: number): number { if (n <= 1) return 1; return n * fact(n - 1); }
+      export function test(): number { return fact(5); }`,
+    );
+    expect(got).toBe(120); // node: 120
+  });
+});


### PR DESCRIPTION
## Problem (#1979)

The IR Phase-2 "early-return if" rewrite turned `if (cond) <then>; <rest>` into
`if (cond) <then> else { <rest> }` — sound only when the then-arm terminates.
Slice 14 (#1228) made a non-terminating `ExpressionStatement` a valid void
"tail", so the then-arm lowered to a synthesized `return` and the true branch
returned, skipping the rest of the void function.

```ts
class Box { v: number = 0; }
function g(b: Box): number { b.v = b.v + 100; return b.v; }
function h(b: Box): number { b.v = b.v + 1; return b.v; }
function f(b: Box, a: number): void {
  if (a > 0) g(b);   // non-terminating then-arm
  h(b);              // must run regardless
}
// f(b, 1): IR gave b.v = 100 (h skipped);  legacy/node: 101
```

## Fix

In lowering (`src/ir/from-ast.ts` `lowerStatementList`) — the selector still
claims the shape, so IR fallback counts are unchanged:

- `thenArmTerminates(stmt)` — true for `return`/`throw`, a block ending in a
  terminating tail, or an `if/else` where both arms terminate.
- **Terminating** then-arm → the original early-return rewrite, unchanged.
- **Non-terminating** then-arm → a converging guard: `br_if cond → then / cont`;
  the then-block runs the side effect and `br`s to `cont`; the false branch
  targets `cont`; `cont` holds `<rest>` (or the implicit void return when
  empty). Both paths run the rest.
- The compile-time constant-fold branch got the same split.

## Tests

`tests/issue-1979.test.ts` — 6 cases, all green: `f(b,1)=101` (was `100`),
false-cond → rest runs, end-of-fn guard runs, true/false early-RETURN still
short-circuits/falls through, non-void `fact(5)=120` unregressed.

`tests/issue-1228.test.ts` (9/9), `tests/issue-1280.test.ts`,
`tests/ir/issue-1373*.test.ts`, `tests/ir/issue-1392.test.ts` pass.
`pnpm run check:ir-fallbacks` OK (no unintended increases). `tsc --noEmit`,
`biome lint`, `prettier --check` clean. Pre-existing `tests/ir/passes.test.ts`
/ `inline-small.test.ts` failures are unrelated (confirmed on clean main).

Closes #1979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)