### PR TITLE
fix(#2008): make tagged-template object readable (param type + String.raw)

### DIFF
--- a/plan/issues/2008-tagged-template-object-broken.md
+++ b/plan/issues/2008-tagged-template-object-broken.md
@@ -1,10 +1,11 @@
 ---
 id: 2008
 title: "tagged templates broken: cooked elements read as undefined, .raw access traps, String.raw throws (template object unusable)"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -56,3 +57,50 @@ recognize the template struct. Cover host marshaling for String.raw.
 
 #109/#141/#363 done; #1445 (in-review) covers String.raw *argument
 coercion*, not total breakage. New.
+
+## Resolution (2026-06-12)
+
+Root cause was a missing parameter-type mapping: `resolveWasmType`
+(`src/codegen/index.ts`) had no case for `TemplateStringsArray`, so the tag
+function's `strings` parameter resolved to a plain `externref`. Indexed
+element access / `.length` / `.raw` / spread then operated on an opaque
+externref instead of the template vec struct that
+`compileTaggedTemplateExpression` actually builds.
+
+Two changes:
+
+1. **`src/codegen/index.ts`** — `resolveWasmType` now maps a
+   `TemplateStringsArray`-symboled type to
+   `{ kind: "ref_null", typeIdx: templateVecTypeIdx }` (the
+   `{ length, data, raw }` struct), checked *before* the `Array`/`ReadonlyArray`
+   branch (it extends `ReadonlyArray<string>`). Element access reads `data`
+   (field 1), `.length` field 0, `.raw` field 2 — all via the existing vec /
+   template-vec paths. The call-site coercion to externref no longer fires
+   because `paramType0` is now the struct ref.
+
+2. **`src/codegen/string-ops.ts`** — `String.raw` is detected
+   (`isStringRawTag`) and lowered in-module (`compileStringRaw`) from the
+   compile-time-known raw parts interleaved with stringified substitutions,
+   instead of routing the WasmGC template struct through the `__tagged_template`
+   host bridge (which can't index a struct from JS → the
+   "Cannot convert undefined or null to object" trap). This "compiles away" and
+   works without a JS runtime.
+
+### Test Results
+
+New `tests/issue-2008.test.ts` — 7 cases, all pass: `strings[0]`/`strings[1]`,
+`strings.length`, `strings.raw[i]`, substitution values, `String.raw` with /
+without substitutions, and raw backslash-escape preservation — all match Node.
+
+Existing tagged-template tests unregressed (`tests/issue-836.test.ts` 5/5,
+`tests/issue-927-safe.test.ts` 8/8, `tests/issue-1473.test.ts`). `tsc --noEmit`,
+`biome lint`, `prettier --check` clean; `check:ir-fallbacks` OK.
+
+### Residual (out of scope, pre-existing)
+
+In `--nativeStrings`/WASI mode the template object *construction* itself fails
+validation (`array.new_fixed expected externref, found struct.new of type
+(ref ...)`) because the data array is declared with externref elements while
+native strings are `ref $AnyString`. Confirmed identical on clean `main` — a
+separate nativeStrings template-construction bug, not this issue (which is the
+JS-host read path). Filing/fixing that is follow-up work.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -8912,6 +8912,17 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
   // in the lib as `declare var Array: ArrayConstructor` which would match externref
   if (tsType.flags & ts.TypeFlags.Object) {
     const sym = (tsType as ts.TypeReference).symbol ?? (tsType as ts.Type).symbol;
+    // `TemplateStringsArray` (the first parameter of a tag function) is the
+    // template object built by `compileTaggedTemplateExpression` — a vec struct
+    // `{ length, data, raw }` (the template vec type). It extends
+    // `ReadonlyArray<string>`, so it MUST be matched before the Array branch
+    // below, otherwise it would lower to a plain string vec without the `raw`
+    // field and indexed/`.raw` reads would mismatch the runtime struct (#2008).
+    if (sym?.name === "TemplateStringsArray") {
+      const templateVecTypeIdx = getOrRegisterTemplateVecType(ctx);
+      return { kind: "ref_null", typeIdx: templateVecTypeIdx };
+    }
+
     // `readonly T[]` / `ReadonlyArray<T>` lower identically to `T[]` — `readonly`
     // is a TS-only modifier with no runtime representation. Without this, a
     // ReadonlyArray-typed struct field falls through to the anonymous-struct /

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -552,6 +552,97 @@ export function compileNativeTemplateExpression(
 
 // ── Tagged template expressions ──────────────────────────────────────
 
+/** Is `tag` syntactically the builtin `String.raw`? (#2008) */
+function isStringRawTag(tag: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(tag) &&
+    ts.isIdentifier(tag.expression) &&
+    tag.expression.text === "String" &&
+    tag.name.text === "raw"
+  );
+}
+
+/**
+ * Lower `String.raw`tmpl`` to the RAW parts interleaved with the stringified
+ * substitutions, as a plain in-module string concat (#2008). The raw parts are
+ * compile-time string literals, so no template struct read or host bridge is
+ * needed — this works in both JS-host and standalone/native-strings modes.
+ */
+function compileStringRaw(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.TaggedTemplateExpression,
+  rawParts: readonly string[],
+  substitutions: readonly ts.Expression[],
+): ValType | null {
+  addStringImports(ctx);
+  const concatIdx = ctx.jsStringImports.get("concat") ?? ctx.nativeStrHelpers.get("__str_concat");
+  if (concatIdx === undefined) {
+    reportError(ctx, expr, "String.raw: string concat helper unavailable");
+    return null;
+  }
+  const toStrIdx = ctx.funcMap.get("number_toString");
+
+  // rawParts has length substitutions.length + 1: raw0 sub0 raw1 sub1 ... rawN.
+  // Start the accumulator with raw0.
+  compileStringLiteral(ctx, fctx, rawParts[0] ?? "", expr);
+
+  for (let i = 0; i < substitutions.length; i++) {
+    const sub = substitutions[i]!;
+    const subTsType = ctx.checker.getTypeAtLocation(sub);
+    const subIsUndef = (subTsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0;
+    const subIsNull = (subTsType.flags & ts.TypeFlags.Null) !== 0;
+    const subType = compileExpression(ctx, fctx, sub);
+
+    if ((subIsUndef || subIsNull) && subType && subType.kind !== "externref") {
+      fctx.body.push({ op: "drop" });
+      const word = subIsNull ? "null" : "undefined";
+      addStringConstantGlobal(ctx, word);
+      fctx.body.push({ op: "global.get", index: ctx.stringGlobalMap.get(word)! });
+    } else if (subType && subType.kind === "i32" && isBooleanType(subTsType)) {
+      emitBoolToString(ctx, fctx);
+    } else if (subType && subType.kind === "f64" && toStrIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: toStrIdx });
+    } else if (subType && subType.kind === "i32" && toStrIdx !== undefined) {
+      fctx.body.push({ op: "f64.convert_i32_s" });
+      fctx.body.push({ op: "call", funcIdx: toStrIdx });
+    } else if (subType && subType.kind === "i64" && toStrIdx !== undefined) {
+      fctx.body.push({ op: "f64.convert_i64_s" });
+      fctx.body.push({ op: "call", funcIdx: toStrIdx });
+    } else if (subType && subType.kind === "externref") {
+      if (subIsNull) {
+        fctx.body.push({ op: "drop" });
+        addStringConstantGlobal(ctx, "null");
+        fctx.body.push({ op: "global.get", index: ctx.stringGlobalMap.get("null")! });
+      } else if (subIsUndef) {
+        fctx.body.push({ op: "drop" });
+        addStringConstantGlobal(ctx, "undefined");
+        fctx.body.push({ op: "global.get", index: ctx.stringGlobalMap.get("undefined")! });
+      } else if (!isStringType(subTsType)) {
+        const externToStrIdx = ensureLateImport(
+          ctx,
+          "__extern_toString",
+          [{ kind: "externref" }],
+          [{ kind: "externref" }],
+        );
+        flushLateImportShifts(ctx, fctx);
+        const finalIdx = ctx.funcMap.get("__extern_toString") ?? externToStrIdx;
+        if (finalIdx !== undefined) fctx.body.push({ op: "call", funcIdx: finalIdx });
+      }
+    } else if (subType && (subType.kind === "ref" || subType.kind === "ref_null")) {
+      coerceType(ctx, fctx, subType, { kind: "externref" }, "string");
+    }
+    // Accumulator + stringified substitution.
+    fctx.body.push({ op: "call", funcIdx: concatIdx });
+
+    // Append the following raw part.
+    compileStringLiteral(ctx, fctx, rawParts[i + 1] ?? "", expr);
+    fctx.body.push({ op: "call", funcIdx: concatIdx });
+  }
+
+  return { kind: "externref" };
+}
+
 /**
  * Compile a tagged template expression: tag`hello ${x} world`
  * Desugars to: tag(["hello ", " world"], x)
@@ -687,6 +778,15 @@ export function compileTaggedTemplateExpression(
   // Load cached template object into the local
   fctx.body.push({ op: "global.get", index: cacheGlobalIdx });
   fctx.body.push({ op: "local.set", index: stringsLocal });
+
+  // `String.raw` is a builtin whose result is the RAW (uncooked) parts
+  // interleaved with the stringified substitutions. Lower it in-module rather
+  // than routing the template struct through the `__tagged_template` host
+  // bridge, which can't index a WasmGC struct from JS (#2008). The raw parts
+  // are known at compile time, so this "compiles away" to a plain concat.
+  if (isStringRawTag(expr.tag)) {
+    return compileStringRaw(ctx, fctx, expr, rawParts, substitutions);
+  }
 
   // Now compile the call to the tag function.
   // The tag function receives (stringsArray, ...substitutions).

--- a/tests/issue-2008.test.ts
+++ b/tests/issue-2008.test.ts
@@ -1,0 +1,76 @@
+// #2008 — the tagged-template object (a WasmGC vec struct { length, data, raw })
+// was unreadable: the tag function's `strings: TemplateStringsArray` parameter
+// resolved to a plain `externref`, so `strings[0]` / `.raw[i]` read the wrong
+// representation (undefined / illegal cast) and `String.raw` traps in the host
+// bridge ("Cannot convert undefined or null to object").
+//
+// Fix: (1) resolveWasmType maps `TemplateStringsArray` to the template vec
+// struct type so indexed/`.length`/`.raw` reads hit the right fields; (2)
+// `String.raw` lowers in-module from the (compile-time-known) raw parts instead
+// of routing the opaque struct through the `__tagged_template` host bridge.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors.map((e) => `L${e.line}: ${e.message}`).join("; ")}`);
+  }
+  const importObj = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(result.binary, importObj as never);
+  if (typeof importObj.setExports === "function") {
+    (importObj.setExports as (e: unknown) => void)(instance.exports);
+  }
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2008 tagged-template object reads", () => {
+  it("indexes the cooked strings array", async () => {
+    const got = await run(`
+      function tag(strings: TemplateStringsArray, ...vals: any[]): string {
+        return "s0=" + strings[0] + ",s1=" + strings[1];
+      }
+      export function test(): string { return tag\`a\${1}b\`; }`);
+    expect(got).toBe("s0=a,s1=b"); // node: "s0=a,s1=b" (was "s0=undefined,s1=undefined")
+  });
+
+  it("reports the correct strings.length", async () => {
+    const got = await run(`
+      function tag(strings: TemplateStringsArray, ...vals: any[]): number { return strings.length; }
+      export function test(): number { return tag\`a\${1}b\${2}c\`; }`);
+    expect(got).toBe(3); // node: 3
+  });
+
+  it("reads the raw strings via strings.raw[i]", async () => {
+    const got = await run(`
+      function tag(strings: TemplateStringsArray, ...vals: any[]): string {
+        return strings.raw[0] + "|" + strings.raw[1];
+      }
+      export function test(): string { return tag\`a\${1}b\`; }`);
+    expect(got).toBe("a|b"); // node: "a|b" (was illegal cast)
+  });
+
+  it("still passes substitution values to the tag function", async () => {
+    const got = await run(`
+      function tag(strings: TemplateStringsArray, ...vals: any[]): number { return vals[0] + vals[1]; }
+      export function test(): number { return tag\`x\${10}y\${32}z\`; }`);
+    expect(got).toBe(42); // node: 42
+  });
+
+  it("String.raw interleaves raw parts with substitutions", async () => {
+    const got = await run(`export function test(): string { return String.raw\`a\${1}b\${2}c\`; }`);
+    expect(got).toBe("a1b2c"); // node: "a1b2c" (was host-bridge TypeError)
+  });
+
+  it("String.raw with no substitution returns the raw head", async () => {
+    const got = await run(`export function test(): string { return String.raw\`hello\`; }`);
+    expect(got).toBe("hello"); // node: "hello"
+  });
+
+  it("String.raw preserves backslash escapes literally", async () => {
+    // The cooked text would collapse \\n to a newline; raw keeps "\\n".
+    const got = await run(`export function test(): string { return String.raw\`x\${2}\\ny\`; }`);
+    expect(got).toBe("x2\\ny"); // node: String.raw`x${2}\ny` === "x2\\ny"
+  });
+});


### PR DESCRIPTION
## Problem (#2008)

The tagged-template object (a WasmGC vec struct `{ length, data, raw }`) was
unreadable inside a tag function:

```ts
function tag2(strings: TemplateStringsArray, ...vals: any[]): string {
  return "s0=" + strings[0] + ",s1=" + strings[1];
}
tag2`a${1}b`        // wasm: "s0=undefined,s1=undefined"   node: "s0=a,s1=b"
String.raw`a${1}b`  // wasm: TypeError: Cannot convert undefined or null to object
```

`strings.length` was correct (2) but `strings[0]`/`strings.raw[0]` read
undefined / illegal-cast, and `String.raw` trapped.

## Root cause

`resolveWasmType` had no case for `TemplateStringsArray`, so the `strings`
parameter resolved to a plain `externref` — indexed/`.raw`/spread reads then
operated on an opaque externref instead of the template vec struct that
`compileTaggedTemplateExpression` actually builds.

## Fix

- **`src/codegen/index.ts`** — `resolveWasmType` maps a `TemplateStringsArray`
  type to `{ kind: "ref_null", typeIdx: templateVecTypeIdx }`, checked *before*
  the `Array`/`ReadonlyArray` branch (it extends `ReadonlyArray<string>`).
  Element access reads `data` (field 1), `.length` field 0, `.raw` field 2.
- **`src/codegen/string-ops.ts`** — `String.raw` is detected and lowered
  in-module from the compile-time-known raw parts interleaved with stringified
  substitutions, instead of routing the WasmGC struct through the
  `__tagged_template` host bridge (which can't index a struct from JS). Works
  standalone — no host import.

## Tests

`tests/issue-2008.test.ts` — 7 cases, all green: `strings[i]`, `.length`,
`.raw[i]`, substitution values, `String.raw` with/without substitutions, raw
backslash-escape preservation — all match Node.

Existing tagged-template tests unregressed (`#836` 5/5, `#927` 8/8, `#1473`).
`tsc --noEmit`, `biome lint`, `prettier --check` clean; `check:ir-fallbacks` OK.

**Residual (pre-existing, confirmed on main, out of scope):** `--nativeStrings`
mode fails template *construction* (`array.new_fixed externref vs ref
$AnyString`) — a separate nativeStrings bug, not this JS-host read-path issue.

Closes #2008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)