### PR TITLE
fix(#1990): route struct operands through ToPrimitive in host_loose_eq

### DIFF
--- a/plan/issues/1990-host-loose-eq-struct-toprimitive-typeerror.md
+++ b/plan/issues/1990-host-loose-eq-struct-toprimitive-typeerror.md
@@ -1,10 +1,11 @@
 ---
 id: 1990
 title: "loose == between any object carrying toString/valueOf and a string throws TypeError: host_loose_eq lacks _toPrimitiveSync routing"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -53,3 +54,32 @@ before applying `==`.
 
 #1134 introduced host_loose_eq (done); #1090/#1253/#1319/#983 done. No
 open issue. New.
+
+## Resolution (2026-06-12)
+
+Fixed in `host_loose_eq` (`src/runtime.ts`, the `case "host_loose_eq"` intent
+handler — line ~10346, not the :9044 cited above which drifted). Per
+§7.2.15 IsLooselyEqual steps 8-9, `object == primitive` coerces the object via
+ToPrimitive. When a WasmGC-struct operand is compared against a **primitive**,
+the handler now runs it through `_toPrimitiveSync(v, "default", callbackState)`
+— the same callbackState-aware walker `__extern_has` uses — before applying
+`==`. A no-method struct still resolves to `"[object Object]"`, so
+`{} == "[object Object]"` is preserved, and `object == object` stays reference
+identity (no coercion when both sides are objects).
+
+## Test Results
+
+`tests/issue-1990.test.ts` — 5/5 pass (`assertEquivalent`, wasm vs Node):
+object `toString` == string, object `valueOf` == number (match + non-match),
+`{}` == `"[object Object]"`, and `object == object` reference identity (`a==b`
+false, `a==a` true). Pre-existing coercion/equality suites green:
+`tests/equivalence/{object-to-primitive,tostring-valueof,loose-equality,
+equality-mixed-types,comparison-coercion}.test.ts` 40/40. `biome lint`,
+`tsc --noEmit`, `prettier --check` clean.
+
+### Known follow-up (out of scope, not fixed here)
+The **symmetric** `"T" == o` (string LITERAL on the LHS) is lowered through a
+different codegen path than `host_loose_eq` and still mis-compares (returns
+`false`). #1990 is scoped to the `object == primitive` host_loose_eq path; the
+string-literal-LHS path is a separate codegen routing gap worth a follow-up
+issue.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10346,8 +10346,29 @@ assert._isSameValue = isSameValue;
     case "host_loose_eq":
       // #1134 — loose equality for two externref operands (§7.2.15).
       // Handles null == undefined → true and other JS coercion rules.
-      // biome-ignore lint/suspicious/noDoubleEquals: §7.2.15 IsLooselyEqual requires == semantics (null == undefined, type coercion)
-      return (a: any, b: any) => (a == b ? 1 : 0);
+      return (a: any, b: any) => {
+        // #1990 — IsLooselyEqual §7.2.15 steps 8-9: `object == primitive`
+        // coerces the object via ToPrimitive (no hint → "default"). For a
+        // WasmGC struct carrying a compiled valueOf/toString, host `==` would
+        // throw "Cannot convert object to primitive value" because the funcref
+        // field isn't a JS-callable method. Route struct operands through
+        // `_toPrimitiveSync` first — the same fix `__extern_has` already uses —
+        // BUT only when the other operand is a primitive (object == object is
+        // reference identity per steps 1-2, no coercion). A no-method struct
+        // resolves to "[object Object]", preserving `{} == "[object Object]"`.
+        const aStruct = a != null && typeof a === "object" && _isWasmStruct(a);
+        const bStruct = b != null && typeof b === "object" && _isWasmStruct(b);
+        let av = a;
+        let bv = b;
+        if (aStruct && !bStruct && (b == null || typeof b !== "object")) {
+          av = _toPrimitiveSync(a, "default", callbackState);
+        }
+        if (bStruct && !aStruct && (a == null || typeof a !== "object")) {
+          bv = _toPrimitiveSync(b, "default", callbackState);
+        }
+        // biome-ignore lint/suspicious/noDoubleEquals: §7.2.15 IsLooselyEqual requires == semantics (null == undefined, type coercion)
+        return av == bv ? 1 : 0;
+      };
     case "host_add":
       // #2058 — `+` for two externref operands (§13.15.3
       // ApplyStringOrNumericBinaryOperator). JS `+` gives us ToPrimitive on both

--- a/tests/issue-1990.test.ts
+++ b/tests/issue-1990.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+/**
+ * #1990 — loose `==` between a WasmGC-struct object carrying a compiled
+ * `toString`/`valueOf` and a primitive threw "Cannot convert object to
+ * primitive value" because `host_loose_eq` applied JS `==` directly and the
+ * struct's funcref field is not a host-callable method. `host_loose_eq` now
+ * routes a struct operand through `_toPrimitiveSync` (hint "default") when the
+ * other operand is a primitive — mirroring `__extern_has`.
+ */
+describe("#1990 loose == ToPrimitive on struct operands", () => {
+  it("object toString == string", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const o: any = { toString() { return "T"; } };
+        return String(o == "T");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  // NOTE: the symmetric `"T" == o` (string literal on the LHS) is lowered
+  // through a DIFFERENT codegen path than `host_loose_eq` and is NOT covered by
+  // this runtime fix (it still mis-compares). That is a separate codegen issue
+  // — #1990 is scoped to the `object == primitive` host_loose_eq path.
+
+  it("object valueOf == number", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const o: any = { valueOf() { return 5; } };
+        return String(o == 5);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("object valueOf != non-matching number", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const o: any = { valueOf() { return 5; } };
+        return String(o == 6);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("empty object == [object Object] still works", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const o: any = {};
+        return String(o == "[object Object]");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("object == object is reference identity (not coerced)", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        const a: any = { valueOf() { return 1; } };
+        const b: any = { valueOf() { return 1; } };
+        return String(a == b) + "," + String(a == a);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Loose `==` between a WasmGC-struct object carrying a compiled `toString`/`valueOf`
and a primitive threw:

```ts
const o: any = { toString() { return "T"; } };
String(o == "T")   // wasm: throws "Cannot convert object to primitive value"; node: "true"
```

`host_loose_eq` applied JS `==` directly, and the struct's funcref field isn't a
host-callable method, so host-side ToPrimitive on the opaque struct threw. Plain
`{}` operands survived (they coerce to `"[object Object]"`).

## Fix

Per §7.2.15 IsLooselyEqual steps 8-9 (`object == primitive` coerces the object
via ToPrimitive), `host_loose_eq` now runs a WasmGC-struct operand through
`_toPrimitiveSync(v, "default", callbackState)` — the same callbackState-aware
walker `__extern_has` already uses — before applying `==`, **only when the other
operand is a primitive**. A no-method struct still resolves to `"[object
Object]"` (preserving `{} == "[object Object]"`), and `object == object` stays
reference identity (no coercion).

## Tests

`tests/issue-1990.test.ts` — 5 equivalence cases (wasm vs Node), all pass:
object `toString` == string, object `valueOf` == number (match + non-match),
`{}` == `"[object Object]"`, and `object == object` reference identity.
Coercion/equality equivalence suites unchanged (40/40):
`tests/equivalence/{object-to-primitive,tostring-valueof,loose-equality,
equality-mixed-types,comparison-coercion}.test.ts`. `biome lint`, `tsc
--noEmit`, `prettier --check` clean.

## Known follow-up (out of scope)

The symmetric `"T" == o` (string LITERAL on the LHS) is lowered through a
different codegen path than `host_loose_eq` and still mis-compares — a separate
routing gap worth its own issue. #1990 is scoped to the `object == primitive`
host_loose_eq path.

Closes #1990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)