### PR TITLE
fix(#2022): `+` applies ToPrimitive(default), not the string hint

### DIFF
--- a/plan/issues/2022-add-default-hint-uses-tostring.md
+++ b/plan/issues/2022-add-default-hint-uses-tostring.md
@@ -1,10 +1,11 @@
 ---
 id: 2022
 title: "obj + '' applies string-hint ToPrimitive (toString) instead of default hint (valueOf first) when one operand is string-typed"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
+completed: 2026-06-12
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -53,3 +54,40 @@ correctness) and #1988 (any path).
 
 #1253/#1090 done; #1900 is standalone-native ToPrimitive phase 1 —
 host-mode `+` hint routing not covered. New.
+
+## Resolution (2026-06-12)
+
+`+` stringified object/`any` operands via the STRING hint
+(`__extern_toString` / `coerceType(..., "string")`, both toString-first).
+§13.15.3 requires the DEFAULT hint (valueOf-first) even when the other operand
+is a string.
+
+Fix kept entirely in `src/runtime.ts` + `src/codegen/string-ops.ts` (no
+`type-coercion.ts` edit — that region is #1989's; coordinated with dev-c):
+
+1. **`src/runtime.ts`** — new `__extern_to_string_default` host helper: mirrors
+   `__extern_toString` but calls `_toPrimitive(v, "default", …)` (valueOf before
+   toString), then `String(...)`. Throws on Symbol per spec.
+2. **`src/codegen/string-ops.ts`** — every `+`-concat object/`any`/struct
+   operand path now routes through `__extern_to_string_default` instead of the
+   string-hint helpers: the left/right externref + ref/struct branches in
+   `compileStringBinaryOp`, and the ref/struct branch of
+   `compileAndCoerceConcatOperand` (the batched `__concat_N` path; `__concat_N`
+   already used the default hint for raw structs, so its plain-externref operand
+   stays correct). Template literals / `String()` keep the string hint;
+   relational / `-` / `*` keep the number hint — all untouched.
+
+### Test Results
+
+New `tests/issue-2022.test.ts` — 7 cases, all match Node:
+`objWithValueOf + "" → "7"` (was "P!"), `"x" + obj → "x7"`, 3-op chain
+`"a"+obj+"b" → "a7b"`, only-toString obj still concats (`"Q!"`), template
+`${p}` keeps string hint (`"P!"`), `p > 5` keeps number hint (valueOf),
+`[Symbol.toPrimitive]` override honoured.
+
+Existing string/concat tests unregressed (`#1525` string-hint cases, `#2005`,
+`#2006`, `#1342` all pass). The two `#1525` *arithmetic* failures
+(`valueOf in arithmetic`, `hint number prefers valueOf`) pre-exist on clean
+`main` — that's the separate #1989 ref→f64 valueOf-collision bug, not this
+change. `tsc --noEmit`, `biome lint`, `prettier --check` clean;
+`check:ir-fallbacks` OK.

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -1233,14 +1233,25 @@ function compileAndCoerceConcatOperand(ctx: CodegenContext, fctx: FunctionContex
       });
     }
   } else if (valType.kind === "ref" || valType.kind === "ref_null") {
-    // #1525 — string concat is an explicit ToPrimitive("string") site, so
-    // walk @@toPrimitive("string") → toString() per §7.1.1.1. Routing through
-    // coerceType with an explicit hint reuses the dispatch table built in
-    // type-coercion.ts (ref → externref hint="string"). Without the hint,
-    // coerceType emits a bare `extern.convert_any`, and the wasm:js-string
-    // `concat` polyfill then calls V8 native String concat on the opaque
-    // struct, throwing "Cannot convert object to primitive value".
-    coerceType(ctx, fctx, valType, { kind: "externref" }, "string");
+    // #2022 — `+` applies ToPrimitive with the DEFAULT hint (valueOf-first),
+    // not the string hint. Convert the struct to externref and route through
+    // `__extern_to_string_default`. (Was `coerceType(..., "string")`, which
+    // walked @@toPrimitive("string")/toString — the wrong hint for `+`; e.g.
+    // `objWithValueOf + ""` must use valueOf.) The bare extern.convert_any
+    // alone would also let the wasm:js-string concat polyfill throw on the
+    // opaque struct, so the host stringify call is still required.
+    coerceType(ctx, fctx, valType, { kind: "externref" });
+    const toStrIdx = ensureLateImport(
+      ctx,
+      "__extern_to_string_default",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalIdx = ctx.funcMap.get("__extern_to_string_default") ?? toStrIdx;
+    if (finalIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: finalIdx });
+    }
   }
 }
 
@@ -1558,26 +1569,42 @@ export function compileStringBinaryOp(
         index: ctx.stringGlobalMap.get("undefined")!,
       });
     } else if (!isStringType(leftTsType)) {
-      // #1525 — string concat is a ToPrimitive("string") site (§7.1.1.1).
-      // For externref operands that aren't statically known to be strings
-      // (e.g. `const obj: any = {...}; obj + "x"`), route through
-      // `__extern_toString` so the runtime walks valueOf/toString on
-      // wasmGC structs before handing a value to `wasm:js-string concat`.
-      // Without this, the concat polyfill calls V8's native string concat
-      // on an opaque struct and throws "Cannot convert object to
-      // primitive value" before our spec-conformant walker runs.
-      const toStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+      // #2022 — `+` applies ToPrimitive with the DEFAULT hint (valueOf before
+      // toString), not the string hint, even when the other operand is a
+      // string. Route opaque externref operands through
+      // `__extern_to_string_default` so wasmGC structs run valueOf-first
+      // before `wasm:js-string concat`. (Previously `__extern_toString`'s
+      // string hint made `objWithValueOf + ""` use toString — wrong.)
+      const toStrIdx = ensureLateImport(
+        ctx,
+        "__extern_to_string_default",
+        [{ kind: "externref" }],
+        [{ kind: "externref" }],
+      );
       flushLateImportShifts(ctx, fctx);
-      if (toStrIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: toStrIdx });
+      const finalIdx = ctx.funcMap.get("__extern_to_string_default") ?? toStrIdx;
+      if (finalIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: finalIdx });
       }
     }
   } else if (op === ts.SyntaxKind.PlusToken && leftType && (leftType.kind === "ref" || leftType.kind === "ref_null")) {
-    // Struct ref → externref for concat. #1525 — route through coerceType
-    // with hint "string" so the dispatch table walks @@toPrimitive("string")
-    // / toString() rather than emitting a bare `extern.convert_any` that
-    // would let `wasm:js-string concat` throw on the opaque struct.
-    coerceType(ctx, fctx, leftType, { kind: "externref" }, "string");
+    // #2022 — `+` is a ToPrimitive(default) site. Convert the struct ref to an
+    // externref (bare extern.convert_any) and route it through
+    // `__extern_to_string_default`, which runs valueOf-first ToPrimitive on the
+    // wasmGC struct. (Was `coerceType(..., "string")`, which walks
+    // @@toPrimitive("string")/toString — the wrong hint for `+`.)
+    coerceType(ctx, fctx, leftType, { kind: "externref" });
+    const toStrIdx = ensureLateImport(
+      ctx,
+      "__extern_to_string_default",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalIdx = ctx.funcMap.get("__extern_to_string_default") ?? toStrIdx;
+    if (finalIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: finalIdx });
+    }
   }
   // For equality/inequality ops: String wrapper objects (new String("x")) are externrefs
   // but NOT wasm:js-string strings — the `equals` builtin would throw a WebAssembly trap.
@@ -1634,14 +1661,19 @@ export function compileStringBinaryOp(
         index: ctx.stringGlobalMap.get("undefined")!,
       });
     } else if (!isStringType(rightTsType)) {
-      // #1525 — see left-operand branch above. Route opaque externref
-      // operands through `__extern_toString` so wasmGC structs ride
-      // through the runtime ToPrimitive walker before reaching
-      // `wasm:js-string concat`.
-      const toStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+      // #2022 — see left-operand branch above. `+` uses ToPrimitive(default),
+      // so route opaque externref operands through `__extern_to_string_default`
+      // (valueOf-first) before `wasm:js-string concat`.
+      const toStrIdx = ensureLateImport(
+        ctx,
+        "__extern_to_string_default",
+        [{ kind: "externref" }],
+        [{ kind: "externref" }],
+      );
       flushLateImportShifts(ctx, fctx);
-      if (toStrIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: toStrIdx });
+      const finalIdx = ctx.funcMap.get("__extern_to_string_default") ?? toStrIdx;
+      if (finalIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: finalIdx });
       }
     }
   } else if (
@@ -1649,11 +1681,21 @@ export function compileStringBinaryOp(
     rightType &&
     (rightType.kind === "ref" || rightType.kind === "ref_null")
   ) {
-    // Struct ref → externref for concat. #1525 — route through coerceType
-    // with hint "string" so toString()/@@toPrimitive("string") run rather
-    // than emitting a raw `extern.convert_any` that crashes the concat
-    // polyfill on opaque wasmGC structs.
-    coerceType(ctx, fctx, rightType, { kind: "externref" }, "string");
+    // #2022 — `+` is a ToPrimitive(default) site. Convert the struct ref to an
+    // externref and route through `__extern_to_string_default` (valueOf-first)
+    // rather than `coerceType(..., "string")` (toString-first, wrong for `+`).
+    coerceType(ctx, fctx, rightType, { kind: "externref" });
+    const toStrIdx = ensureLateImport(
+      ctx,
+      "__extern_to_string_default",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalIdx = ctx.funcMap.get("__extern_to_string_default") ?? toStrIdx;
+    if (finalIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: finalIdx });
+    }
   }
   // Unwrap right-side String wrapper for equality/inequality (same as left above)
   const isRightStringWrapper =

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6412,6 +6412,41 @@ assert._isSameValue = isSameValue;
             return "[object Object]";
           }
         };
+      // (#2022) ToString of a `+`-concat operand. `+` applies ToPrimitive with
+      // the DEFAULT hint (valueOf before toString), even when the other operand
+      // is a string — unlike `String(x)` / template literals which use the
+      // string hint. So `({ toString:()=>"P!", valueOf:()=>7 }) + ""` is "7",
+      // not "P!". Mirrors `__extern_toString` but with the "default" hint.
+      if (name === "__extern_to_string_default")
+        return (v: any) => {
+          if (v == null) return String(v);
+          if (typeof v === "object" && _isWasmStruct(v)) {
+            const prim = _toPrimitive(v, "default", callbackState);
+            if (prim !== undefined) {
+              if (typeof prim === "symbol") throw new TypeError("Cannot convert a Symbol value to a string");
+              return String(prim);
+            }
+            try {
+              const prim2 = _hostToPrimitive(v, "default", callbackState);
+              if (typeof prim2 === "symbol") throw new TypeError("Cannot convert a Symbol value to a string");
+              return String(prim2);
+            } catch {
+              return "[object Object]";
+            }
+          }
+          if (typeof v === "object") {
+            const prim = _toPrimitive(v, "default", callbackState);
+            if (prim !== undefined) {
+              if (typeof prim === "symbol") throw new TypeError("Cannot convert a Symbol value to a string");
+              return String(prim);
+            }
+          }
+          try {
+            return String(v);
+          } catch {
+            return "[object Object]";
+          }
+        };
       // (#1638) Date.prototype string formatters. The Wasm side holds the
       // timestamp as an i64 and passes it here with a mode selector; we build
       // the spec-correct string from a UTC Date. The invalid-Date sentinel

--- a/tests/issue-2022.test.ts
+++ b/tests/issue-2022.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2022 — the `+` operator pre-committed to the STRING hint when one operand
+// was a string, so an object with both `valueOf` and `toString` stringified via
+// `toString`. Per §13.15.3, `+` applies ToPrimitive with the DEFAULT hint
+// (valueOf before toString) to both operands BEFORE deciding concat vs add —
+// even when the other operand is a string. So `objWithValueOf + ""` is "7"
+// (valueOf), not "P!" (toString).
+//
+// Fix: object/`any` operands of `+` route through a new
+// `__extern_to_string_default` host helper (ToPrimitive default hint) instead
+// of `__extern_toString` / `coerceType(..., "string")` (string hint). Template
+// literals and `String()` keep the string hint; relational/`-`/`*` keep the
+// number hint — all unchanged.
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function run(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  return (exports.test as () => unknown)();
+}
+
+const P = `class P { toString(): string { return "P!"; } valueOf(): number { return 7; } }`;
+const Q = `class Q { toString(): string { return "Q!"; } }`;
+
+describe("#2022 `+` uses ToPrimitive(default), not string hint", () => {
+  it('obj with valueOf + "" uses valueOf (not toString)', async () => {
+    expect(await run(`${P} export function test(): string { return (new P() as any) + ""; }`)).toBe("7"); // node: "7"
+  });
+
+  it("string + obj with valueOf uses valueOf", async () => {
+    expect(await run(`${P} export function test(): string { return "x" + (new P() as any); }`)).toBe("x7"); // node: "x7"
+  });
+
+  it("a 3-operand concat chain applies the default hint to the object", async () => {
+    expect(await run(`${P} export function test(): string { return "a" + (new P() as any) + "b"; }`)).toBe("a7b"); // node: "a7b"
+  });
+
+  it("obj with only toString still concats via toString", async () => {
+    expect(await run(`${Q} export function test(): string { return (new Q() as any) + ""; }`)).toBe("Q!"); // node: "Q!"
+  });
+
+  it("template literals keep the STRING hint (toString)", async () => {
+    expect(await run(`${P} export function test(): string { const p = new P(); return \`\${p}\`; }`)).toBe("P!"); // node: "P!"
+  });
+
+  it("relational comparison keeps the NUMBER hint (valueOf)", async () => {
+    expect(await run(`${P} export function test(): number { const p = new P(); return (p as any) > 5 ? 1 : 0; }`)).toBe(
+      1,
+    ); // node: 7 > 5 → true
+  });
+
+  it("Symbol.toPrimitive overrides the hint when present", async () => {
+    const src = `
+      class R {
+        [Symbol.toPrimitive](hint: string): any { return hint === "string" ? "STR" : 42; }
+      }
+      export function test(): string { return (new R() as any) + ""; }`;
+    expect(await run(src)).toBe("42"); // node: default hint → 42 → "42"
+  });
+});


### PR DESCRIPTION
## Problem (#2022)

The `+` operator stringified object/`any` operands via the STRING hint, so an
object with both `valueOf` and `toString` stringified via `toString`:

```ts
class P { toString() { return "P!"; } valueOf() { return 7; } }
(new P() as any) + ""   // wasm: "P!"   node: "7"
```

§13.15.3: `+` applies ToPrimitive with the **default** hint (valueOf before
toString) to both operands BEFORE deciding concat vs add — even when the other
operand is a string. Template `` `${p}` `` correctly used the string hint
("P!"); relational `p > 5` correctly used valueOf — only `+` was wrong.

## Fix

Kept entirely in `src/runtime.ts` + `src/codegen/string-ops.ts` — **no
`type-coercion.ts` edit** (that region belongs to #1989; coordinated with the
dev on it):

- **`src/runtime.ts`** — new `__extern_to_string_default` host helper: mirrors
  `__extern_toString` but uses `_toPrimitive(v, "default", …)` (valueOf-first),
  then `String(...)`. Throws on Symbol per spec.
- **`src/codegen/string-ops.ts`** — every `+`-concat object/`any`/struct operand
  path routes through `__extern_to_string_default` instead of the string-hint
  helpers (left/right externref + ref/struct branches in
  `compileStringBinaryOp`, and the ref/struct branch of
  `compileAndCoerceConcatOperand`). Template literals / `String()` keep the
  string hint; relational / `-` / `*` keep the number hint — all unchanged.

## Tests

`tests/issue-2022.test.ts` — 7 cases, all match Node: `obj+""→"7"`,
`"x"+obj→"x7"`, 3-op `"a"+obj+"b"→"a7b"`, only-toString obj → `"Q!"`, template
`${p}` keeps the string hint (`"P!"`), `p > 5` keeps the number hint,
`[Symbol.toPrimitive]` override honoured.

Existing string/concat tests unregressed (`#1525` string-hint cases, `#2005`,
`#2006`, `#1342`). The two `#1525` *arithmetic* failures pre-exist on clean
`main` (the separate #1989 ref→f64 valueOf-collision bug). `tsc --noEmit`,
`biome lint`, `prettier --check` clean; `check:ir-fallbacks` OK.

Closes #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)