### PR TITLE
fix(#2036): standalone Array.prototype generics over array-like refuse loud (stage 1)

### DIFF
--- a/plan/issues/2036-standalone-array-generics-arraylike-invalid-wasm.md
+++ b/plan/issues/2036-standalone-array-generics-arraylike-invalid-wasm.md
@@ -1,10 +1,10 @@
 ---
 id: 2036
 title: "standalone: Array.prototype generics over array-like receivers emit invalid Wasm / null-deref / wrong results instead of refusing loud (~500+ tests)"
-status: ready
+status: in-progress
 sprint: Backlog
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-13
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -101,3 +101,38 @@ null deref or `-1`.
 - No `local.set expected f64, found externref` rows remain in the standalone
   baseline for `built-ins/Array/prototype`.
 - Host mode unchanged.
+
+## Stage 1 landed (2026-06-13) — stop the bleeding
+
+Implemented the issue's "stop the bleeding first (small PR)" step in
+`src/codegen/array-methods.ts` `compileArrayPrototypeCall`: in standalone /
+WASI mode, when the borrowed receiver is NOT a genuine native-array vec
+(`resolveArrayInfo` returns null — i.e. an open `$Object`, `arguments`, or
+`any`), the function now returns `undefined` so the borrowed-method dispatch in
+`expressions/calls.ts` emits the loud `#1888 Slice 3/4` refusal — exactly like
+`map`/`reduce`/`lastIndexOf` already do. This is the correct move because the
+typed shape-inferred fast paths emit f64/i32 element loads on an externref
+(invalid Wasm) and `compileArrayLikePrototypeCall` depends on the
+`__extern_length`/`__extern_get_idx` JS-host `env` imports that don't exist
+standalone.
+
+Effect: standalone `Array.prototype.indexOf/filter/forEach/…call(arrayLike)`
+moves from `compile_error`(invalid Wasm) / null-deref / silently-wrong `-1` to
+an honest `Codegen error:` refusal — converting the ~430 broken rows into honest
+refusals and protecting conformance from silent wrongness. Genuine native-array
+receivers still take the fast path; **host mode is byte-for-byte unchanged**
+(the gate is `ctx.standalone || ctx.wasi` only).
+
+`tests/issue-2036.test.ts` (5 cases): standalone indexOf/filter/forEach.call on
+an array-like → loud refusal; standalone `indexOf.call([10,20,30], 20)` → `1`;
+host array-like call still compiles. `tsc`/`biome`/`prettier` clean; all
+pre-existing array-call test failures (#1461 concat-spreadable, #1131 fib,
+#1888 wasi-roundtrip) confirmed identical on clean main.
+
+## Stage 2 still open (follow-up)
+
+The generic `$Object` arm (read `length` via `__extern_get`, elements via keyed
+get, externref/anyref comparison per §23.1.3.17) is NOT in this PR — that's the
+larger Slice-4 implementation. This issue stays `in-progress` until stage 2
+lands; the host-mode array-like wrong-results (`-1`/`0`) are a separate,
+pre-existing concern outside this standalone issue's scope.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -1757,23 +1757,6 @@ export function compileArrayPrototypeCall(
   // Check if the method is a known array method
   if (!ARRAY_METHODS.has(methodName)) return undefined;
 
-  // (#2036) Standalone / WASI: `Array.prototype.<m>.call(arrayLike, …)` over a
-  // NON-array receiver (an open `$Object`, `arguments`, `any`) cannot use the
-  // typed shape-inferred fast paths (they emit f64/i32 element loads on an
-  // externref → invalid Wasm / null-deref / silently-wrong `-1`), nor the
-  // `compileArrayLikePrototypeCall` host-import path (`__extern_length` /
-  // `__extern_get_idx` are JS-host `env` imports that don't exist standalone).
-  // Per the #1888 dual-mode invariant ("any uncertainty ⇒ fail loud, never
-  // invalid Wasm"), bail to `undefined` so the borrowed-method dispatch in
-  // calls.ts emits the loud `#1888 Slice 3/4` refusal — exactly like
-  // `map`/`reduce` already do. A genuine native-array receiver (resolveArrayInfo
-  // truthy) still takes the fast path below. Host mode is unaffected.
-  if (ctx.standalone || ctx.wasi) {
-    const recvTsType = ctx.checker.getTypeAtLocation(receiverArg);
-    const recvArrInfo = recvTsType ? resolveArrayInfo(ctx, recvTsType) : null;
-    if (!recvArrInfo) return undefined;
-  }
-
   // Resolve array info from shape map or TypeScript type
   let receiverTsType: ts.Type | undefined;
   if (ts.isIdentifier(receiverArg)) {
@@ -1805,6 +1788,17 @@ export function compileArrayPrototypeCall(
   if (!receiverTsType) return undefined;
   const arrInfo = resolveArrayInfo(ctx, receiverTsType);
   if (!arrInfo) {
+    // (#2036) Standalone / WASI: the array-like fallback
+    // (`compileArrayLikePrototypeCall`) iterates via the `__extern_length` /
+    // `__extern_get_idx` JS-host `env` imports, which DON'T exist standalone —
+    // the receiver is an open `$Object`/`any`, not a genuine vec. Emitting it
+    // there produced invalid Wasm / null-deref / silently-wrong `-1`. Per the
+    // #1888 dual-mode invariant ("any uncertainty ⇒ fail loud"), bail to
+    // `undefined` so the borrowed-method dispatch in calls.ts emits the loud
+    // `#1888 Slice 3/4` refusal — like `map`/`reduce` already do. The
+    // shape-inferred genuine-array path above and the `arrInfo` typed path
+    // below still work standalone; host mode is unaffected (it has the imports).
+    if (ctx.standalone || ctx.wasi) return undefined;
     // For any-typed receivers, use the array-like implementation that iterates
     // using __extern_length/__extern_get_idx and calls the callback directly in Wasm.
     return compileArrayLikePrototypeCall(ctx, fctx, callExpr, methodName, receiverArg as ts.Expression);

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -1757,6 +1757,23 @@ export function compileArrayPrototypeCall(
   // Check if the method is a known array method
   if (!ARRAY_METHODS.has(methodName)) return undefined;
 
+  // (#2036) Standalone / WASI: `Array.prototype.<m>.call(arrayLike, …)` over a
+  // NON-array receiver (an open `$Object`, `arguments`, `any`) cannot use the
+  // typed shape-inferred fast paths (they emit f64/i32 element loads on an
+  // externref → invalid Wasm / null-deref / silently-wrong `-1`), nor the
+  // `compileArrayLikePrototypeCall` host-import path (`__extern_length` /
+  // `__extern_get_idx` are JS-host `env` imports that don't exist standalone).
+  // Per the #1888 dual-mode invariant ("any uncertainty ⇒ fail loud, never
+  // invalid Wasm"), bail to `undefined` so the borrowed-method dispatch in
+  // calls.ts emits the loud `#1888 Slice 3/4` refusal — exactly like
+  // `map`/`reduce` already do. A genuine native-array receiver (resolveArrayInfo
+  // truthy) still takes the fast path below. Host mode is unaffected.
+  if (ctx.standalone || ctx.wasi) {
+    const recvTsType = ctx.checker.getTypeAtLocation(receiverArg);
+    const recvArrInfo = recvTsType ? resolveArrayInfo(ctx, recvTsType) : null;
+    if (!recvArrInfo) return undefined;
+  }
+
   // Resolve array info from shape map or TypeScript type
   let receiverTsType: ts.Type | undefined;
   if (ts.isIdentifier(receiverArg)) {

--- a/tests/issue-2036.test.ts
+++ b/tests/issue-2036.test.ts
@@ -1,0 +1,79 @@
+// #2036 — standalone: `Array.prototype.<m>.call(arrayLike, …)` over a NON-array
+// receiver (open `$Object`, `arguments`, `any`) used to emit invalid Wasm
+// (`local.set expected f64, found externref`), a null-deref, or a silently
+// wrong result (`indexOf` → -1) — violating the #1888 dual-mode invariant
+// ("any uncertainty ⇒ fail loud, never invalid Wasm").
+//
+// Stage-1 fix (compileArrayPrototypeCall): in standalone/WASI mode, bail to the
+// loud `#1888 Slice 3/4` refusal for non-array receivers (the typed fast paths
+// and the `__extern_length`/`__extern_get_idx` host-import path can't handle
+// them standalone), exactly like `map`/`reduce` already do. Genuine native
+// arrays still compile; host mode is unchanged.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string) {
+  return compile(source, { target: "standalone", fileName: "test.ts" });
+}
+
+const REFUSAL = /not yet.*supported in --target standalone.*#1888|#1888 Slice/;
+
+describe("#2036 standalone Array.prototype generics over array-like receivers", () => {
+  it("refuses indexOf.call on an array-like object loudly (was invalid Wasm)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        const obj: any = { 0: 5, 5: "length", length: 6 };
+        return Array.prototype.indexOf.call(obj, "length");
+      }`);
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => REFUSAL.test(e.message))).toBe(true);
+  });
+
+  it("refuses filter.call on an array-like object loudly (was invalid Wasm)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        const obj: any = { 0: 1, 1: 2, length: 2 };
+        const out = Array.prototype.filter.call(obj, (x: any) => true);
+        return out.length;
+      }`);
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => REFUSAL.test(e.message))).toBe(true);
+  });
+
+  it("refuses forEach.call on an array-like object loudly (was silently wrong: 0)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        const obj: any = { 0: 1, 1: 2, length: 2 };
+        let s = 0;
+        Array.prototype.forEach.call(obj, (x: any) => { s += 1; });
+        return s;
+      }`);
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => REFUSAL.test(e.message))).toBe(true);
+  });
+
+  it("still compiles + runs indexOf.call on a GENUINE standalone array", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        const a: number[] = [10, 20, 30];
+        return Array.prototype.indexOf.call(a, 20);
+      }`);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test(): number }).test()).toBe(1); // node: [10,20,30].indexOf(20) === 1
+  });
+
+  it("host mode is unchanged — the array-like call still compiles (no refusal)", async () => {
+    // The host path keeps its existing (separately-tracked) behaviour; the only
+    // requirement here is that the standalone refusal did NOT leak into host mode.
+    const r = await compile(
+      `export function test(): number {
+        const obj: any = { 0: 5, 5: "length", length: 6 };
+        return Array.prototype.indexOf.call(obj, "length");
+      }`,
+      { fileName: "test.ts" },
+    );
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (#2036)

In **standalone/WASI** mode, `Array.prototype.<m>.call(arrayLike, …)` over a
NON-array receiver (open `$Object`, `arguments`, `any`) produced three broken
outcomes — two of which violate the #1888 dual-mode invariant ("any uncertainty
⇒ fail loud, never invalid Wasm"):

1. **Invalid Wasm** — `local.set expected f64, found externref` (indexOf), `call
   expected externref, found f64.convert_i32_s` (filter)
2. **Null deref** at runtime
3. **Silently wrong** — `Array.prototype.indexOf.call({0:5,5:'length',length:6}, 'length')` → `-1`

Meanwhile `map`/`reduce`/`lastIndexOf` already refuse such receivers loudly — so
the refusal gate exists, but `indexOf`/`filter`/`forEach`/… had arms slipping
past it into broken codegen.

## Fix — stage 1 ("stop the bleeding")

Per the issue's own staged plan. In `src/codegen/array-methods.ts`
`compileArrayPrototypeCall`: when `ctx.standalone || ctx.wasi` AND the receiver
is not a genuine native-array vec (`resolveArrayInfo` returns null), return
`undefined` so the borrowed-method dispatch in `expressions/calls.ts` emits the
loud `#1888 Slice 3/4` refusal — exactly like `map`/`reduce`.

Why: the typed shape-inferred fast paths emit f64/i32 element loads on an
externref (invalid Wasm), and `compileArrayLikePrototypeCall` depends on the
`__extern_length`/`__extern_get_idx` JS-host `env` imports that **don't exist
standalone**. Genuine native-array receivers still take the fast path. The gate
is `standalone/wasi` only, so **host mode is byte-for-byte unchanged**.

This converts the ~430 invalid-Wasm/null-deref/wrong-result standalone rows into
honest refusals, protecting conformance from silent wrongness.

## Tests

`tests/issue-2036.test.ts` (5): standalone indexOf/filter/forEach.call on an
array-like → loud refusal; standalone `indexOf.call([10,20,30], 20)` → `1`; host
array-like call still compiles (refusal didn't leak into host mode).

Pre-existing failures in `#1461` (concat-spreadable), `#1131` (fib), `#1888`
(wasi-roundtrip) confirmed **identical on clean main** — not caused by this
change. `tsc --noEmit`, `biome lint`, `prettier --check` clean.

## Stage 2 (follow-up, NOT in this PR)

The generic `$Object` arm (read `length` via `__extern_get`, keyed element get,
externref comparison per §23.1.3.17) is the larger Slice-4 work. Issue stays
`in-progress`. The host-mode array-like wrong-results are a separate, pre-existing
concern outside this standalone issue's scope.

Refs #2036 (stage 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)