### PR TITLE
fix(#2021): array literal prefers annotation element type over first element

### DIFF
--- a/plan/issues/2021-array-literal-subclass-first-base-later-trap.md
+++ b/plan/issues/2021-array-literal-subclass-first-base-later-trap.md
@@ -1,10 +1,11 @@
 ---
 id: 2021
 title: "array literal [new Subclass(), new Base()] traps 'dereferencing a null pointer' — element type taken from first element, contextual annotation ignored"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-13
+completed: 2026-06-13
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -53,3 +54,30 @@ otherwise compute the least common ancestor of element ref types.
 
 #786/#1021 handled number+object and null mixes in this function; no issue
 for subclass/superclass unification. New.
+
+## Resolution (2026-06-13)
+
+Fixed in `compileArrayLiteral` (`src/codegen/literals.ts`, the real-first-
+element branch). After deriving `elemWasm` from the first element's type, when
+it resolves to a struct ref (`ref`/`ref_null`) and a contextual `Array<T>` /
+`ReadonlyArray<T>` annotation is present whose element type also resolves to a
+(different) struct ref, the literal now **prefers the annotation's element
+type** — the declared common supertype that holds every element. TS has already
+verified each element is assignable to `T`, so widening to it is sound. Base-
+first ordering was already correct (element 0 IS the supertype); this fixes the
+subclass-first ordering. Primitive/mixed/null/sibling-subclass paths are
+untouched (the new branch is gated on `elemWasm` being a struct ref AND a
+ref-typed contextual annotation differing from the first element's type).
+
+## Test Results
+
+`tests/issue-2021.test.ts` — 7/7 pass (`assertEquivalent`, wasm vs Node):
+- repro `[new Circle(), new Shape()]` → length 2 (was trap);
+- base-first ordering unchanged; polymorphic `for (const s of a) s.area()` → 12;
+- ancestor field read via base method; 3-level hierarchy subclass-first;
+- no-annotation sibling subclasses (unchanged); homogeneous `Circle[]` unchanged.
+
+Class/array/destructuring equivalence suites (`ir-slice4-classes`,
+`array-of-structs`, `anon-struct`, `self-referencing-struct`,
+`destructuring-initializer`) — 27 tests, all green. IR fallback budget gate OK.
+`biome lint`, `tsc --noEmit`, `prettier --check` clean.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -2695,6 +2695,35 @@ export function compileArrayLiteral(
   } else {
     const firstElemType = ctx.checker.getTypeAtLocation(firstElem);
     elemWasm = resolveWasmType(ctx, firstElemType);
+    // (#2021) The first element's class type can be a SUBTYPE of the array's
+    // declared element type — e.g. `const a: Shape[] = [new Circle(), new
+    // Shape()]` derives `(ref $Circle)` from element 0, but a later `new
+    // Shape()` cannot satisfy `(ref $Circle)` and ends up null → trap. When the
+    // first element resolves to a struct ref AND a contextual `Array<T>`
+    // annotation is present whose element type resolves to a (different) struct
+    // ref, prefer the annotation's element type: it is the declared common
+    // supertype that holds every element. TS has already verified each element
+    // is assignable to `T`, so widening to it is sound. (`[new Shape(), new
+    // Circle()]` — base first — already worked because element 0 IS the
+    // supertype; this fixes the subclass-first ordering.)
+    if (elemWasm.kind === "ref" || elemWasm.kind === "ref_null") {
+      const ctxType = ctx.checker.getContextualType(expr);
+      if (ctxType) {
+        const ctxSym = (ctxType as ts.TypeReference).symbol ?? ctxType.symbol;
+        if (ctxSym?.name === "Array" || ctxSym?.name === "ReadonlyArray") {
+          const ctxElemType = ctx.checker.getTypeArguments(ctxType as ts.TypeReference)[0];
+          if (ctxElemType) {
+            const ctxElemWasm = resolveWasmType(ctx, ctxElemType);
+            if (
+              (ctxElemWasm.kind === "ref" || ctxElemWasm.kind === "ref_null") &&
+              ctxElemWasm.typeIdx !== elemWasm.typeIdx
+            ) {
+              elemWasm = ctxElemWasm;
+            }
+          }
+        }
+      }
+    }
     // If the literal mixes a `null` literal with another kind (e.g. `[1, null]`),
     // fall back to externref so the null survives. Without this, null gets coerced
     // to f64 0 and destructuring defaults misbehave (#1021). We gate on `null`

--- a/tests/issue-2021.test.ts
+++ b/tests/issue-2021.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+/**
+ * #2021 — an array literal whose first element is a *subclass* must still be
+ * able to hold ancestor-class elements when the declared element type is the
+ * ancestor. The element kind was taken from the first element's type (`Circle`),
+ * so a later `new Shape()` could not satisfy `(ref $Circle)` and ended up null,
+ * trapping "dereferencing a null pointer". The literal now prefers the
+ * contextual `Array<T>` annotation's element type (the declared common
+ * supertype) when the first element resolves to a struct ref.
+ */
+describe("#2021 array literal element type from annotation, not first element", () => {
+  const decls = `
+    class Shape { area(): number { return 1; } }
+    class Circle extends Shape { r = 2; area(): number { return 3 * this.r * this.r; } }`;
+
+  it("subclass-first + ancestor-later (the repro)", async () => {
+    await assertEquivalent(
+      `${decls}
+       export function test(): number {
+         const a: Shape[] = [new Circle(), new Shape()];
+         return a.length;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("base-first ordering unchanged", async () => {
+    await assertEquivalent(
+      `${decls}
+       export function test(): number {
+         const a: Shape[] = [new Shape(), new Circle()];
+         return a.length;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("polymorphic dispatch over the mixed array", async () => {
+    await assertEquivalent(
+      `${decls}
+       export function test(): number {
+         const a: Shape[] = [new Circle(), new Shape()];
+         let s = 0;
+         for (const x of a) s += x.area();
+         return s;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("subclass-first, ancestor field read via base method", async () => {
+    await assertEquivalent(
+      `${decls}
+       export function test(): number {
+         const a: Shape[] = [new Circle(), new Shape(), new Circle()];
+         return a[1]!.area() + a[2]!.area();
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("three-level hierarchy, subclass-first", async () => {
+    await assertEquivalent(
+      `class A { tag(): number { return 1; } }
+       class B extends A { tag(): number { return 2; } }
+       class C extends B { tag(): number { return 3; } }
+       export function test(): number {
+         const a: A[] = [new C(), new B(), new A()];
+         let s = 0;
+         for (const x of a) s = s * 10 + x.tag();
+         return s;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("no annotation: sibling subclasses still work (unchanged)", async () => {
+    await assertEquivalent(
+      `class Base { v(): number { return 0; } }
+       class L extends Base { v(): number { return 1; } }
+       class R extends Base { v(): number { return 2; } }
+       export function test(): number {
+         const a = [new L(), new R()];
+         return a.length;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("homogeneous annotated array unchanged", async () => {
+    await assertEquivalent(
+      `${decls}
+       export function test(): number {
+         const a: Circle[] = [new Circle(), new Circle()];
+         return a[0]!.area();
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

```ts
class Shape { area(): number { return 0; } }
class Circle extends Shape { r = 2; area(): number { return 3 * this.r * this.r; } }
const a: Shape[] = [new Circle(), new Shape()];
a.length   // wasm: trap "dereferencing a null pointer"   node: 2
```

`compileArrayLiteral` derived the vec element kind from the **first** element's
type (`(ref $Circle)`), so a later `new Shape()` couldn't satisfy it and ended
up null → trap. Base-first ordering (`[new Shape(), new Circle()]`) already
worked because element 0 is the supertype; only **subclass-first +
ancestor-later** tripped.

## Fix

After resolving `elemWasm` from the first element, when it is a struct ref
(`ref`/`ref_null`) **and** a contextual `Array<T>` / `ReadonlyArray<T>`
annotation is present whose element type also resolves to a (different) struct
ref, prefer the annotation's element type — the declared common supertype that
holds every element. TS has already verified each element is assignable to `T`,
so widening is sound. Primitive/mixed/null/sibling-subclass paths are untouched
(the branch is gated on a struct-ref first element AND a differing ref-typed
contextual annotation).

## Tests

`tests/issue-2021.test.ts` — 7 equivalence cases (wasm vs Node), all pass:
repro, base-first unchanged, polymorphic `for (const s of a) s.area()`,
ancestor field read via base method, 3-level hierarchy subclass-first,
no-annotation sibling subclasses (unchanged), homogeneous `Circle[]` unchanged.

Class/array/destructuring equivalence suites (`ir-slice4-classes`,
`array-of-structs`, `anon-struct`, `self-referencing-struct`,
`destructuring-initializer` — 27 tests) green. IR fallback budget OK.
`biome lint`, `tsc --noEmit`, `prettier --check` clean.

Closes #2021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)