### PR TITLE
fix(#2024): get-only accessor override throws on write, doesn't drop it

### DIFF
--- a/plan/issues/2024-accessor-override-partial-pair-wrong-semantics.md
+++ b/plan/issues/2024-accessor-override-partial-pair-wrong-semantics.md
@@ -1,10 +1,11 @@
 ---
 id: 2024
 title: "class accessor override with partial pair: get-only override silently drops writes (should TypeError); set-only override reads NaN (should undefined)"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-13
+completed: 2026-06-13
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -56,3 +57,42 @@ undefined.
 
 #1456 covers private readonly accessor TypeError; #1364 is descriptor
 shape. New. Object-literal sibling: #2017.
+
+## Resolution (2026-06-13)
+
+Fixed the **get-only override drops writes** half in
+`compileAssignmentToAccessor` (`src/codegen/expressions/assignment.ts`, the
+`classAccessorSet.has(accessorKey)` block). Root cause confirmed: class-bodies
+adds the accessor key to `classAccessorSet` for BOTH getters and setters, so a
+get-only override (`class B extends A { get v() {…} }` over a parent with
+`set v`) entered the accessor-write block, found no `<type>_set_<field>`
+function, and fell through to the struct-field path which silently dropped the
+write. Added: when the setter funcIdx is undefined AND the class has an own
+getter (`funcMap.has(`<type>_get_<field>`)`), evaluate+drop the RHS (spec:
+GetValue before [[Set]]) and `emitThrowTypeError` — the own get-only accessor
+SHADOWS the inherited setter (§10.1.5.3), so the parent setter must NOT run.
+
+Set-only-read mirror (`b.v` on a set-only override → `undefined`) already
+behaves correctly on current main (verified — `typeof` returns "undefined"); no
+change needed there.
+
+## Test Results
+
+`tests/issue-2024.test.ts` — 5/5 pass (`assertEquivalent`, wasm vs Node):
+- subclass get-only override write throws (returns -1, was silently 1);
+- the parent setter side effect never fires (threw=1, `_v` unchanged);
+- single-class get-only write throws;
+- full accessor-pair override still writes (unchanged);
+- inherited setter (subclass adds no accessor) still writes (unchanged).
+
+Note: the get-only write cases use `// @ts-ignore` since TS rejects assigning to
+a read-only accessor — the assignment is valid (throwing) JS, which is what
+test262 exercises; the compiler infers `new B()` as `B`, so the write takes the
+typed struct-accessor path fixed here.
+
+Class/accessor equivalence suites (`accessor-side-effects`,
+`computed-setter-class`, `super-property-access`, `private-class-members`,
+`ir-slice4-classes` — 23 tests) unchanged. The one `object-literal-getters-
+setters > setter stores value` failure is **pre-existing on clean origin/main**
+(unrelated). IR fallback gate OK; `biome lint`, `tsc --noEmit`,
+`prettier --check` clean.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -2388,6 +2388,28 @@ function compilePropertyAssignment(
   if (ctx.classAccessorSet.has(accessorKey)) {
     const setterName = `${typeName}_set_${fieldName}`;
     const funcIdx = ctx.funcMap.get(setterName);
+    // (#2024) `classAccessorSet` records a class that declares EITHER a getter
+    // or a setter for this prop (class-bodies.ts adds the key for both). A
+    // get-only accessor — `class B extends A { get v() {…} }` over a parent
+    // with `set v` — therefore lands here with NO `${type}_set_${field}`
+    // function. Per §10.1.5.3 OrdinarySetWithOwnDescriptor, the own get-only
+    // accessor SHADOWS the inherited setter: strict-mode writes throw TypeError
+    // and the parent's setter must NOT run. Without this, control fell through
+    // to the struct-field path, which found no field named `<field>` and
+    // silently dropped the write. Emit the spec TypeError instead.
+    if (funcIdx === undefined && ctx.funcMap.has(`${typeName}_get_${fieldName}`)) {
+      // Evaluate the RHS for its side effects (spec: GetValue(rhs) is performed
+      // before the [[Set]]), drop its value, then throw. `emitThrowTypeError`
+      // emits an `unreachable`, so the assignment expression's stack effect is
+      // satisfied by divergence — we report the RHS type so any wrapping
+      // expression type-checks consistently.
+      const rhsResult = compileExpression(ctx, fctx, value);
+      if (rhsResult !== null) {
+        fctx.body.push({ op: "drop" });
+      }
+      emitThrowTypeError(ctx, fctx, `Cannot assign to read only property '${fieldName}' of object`);
+      return rhsResult ?? { kind: "f64" };
+    }
     if (funcIdx !== undefined) {
       // `C.prototype.<setter> = v` and `C.<static setter> = v` both write
       // through a receiver that is an externref (the prototype singleton or the

--- a/tests/issue-2024.test.ts
+++ b/tests/issue-2024.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+/**
+ * #2024 — a class whose OWN accessor is get-only must shadow an inherited
+ * setter (§10.1.5.3 OrdinarySetWithOwnDescriptor): a strict-mode write throws
+ * TypeError and the parent's setter must NOT run. The compiler tracks "this
+ * class declares an accessor for this prop" with a single set used for both
+ * getters and setters, so a get-only override entered the accessor-write block,
+ * found no `<type>_set_<field>` function, fell through to the struct-field path,
+ * and silently dropped the write. The write now throws TypeError.
+ *
+ * The get-only writes use `// @ts-ignore` because TS rejects assigning to a
+ * read-only accessor — but the assignment is valid (throwing) JavaScript, which
+ * is exactly what test262 exercises.
+ */
+describe("#2024 get-only accessor override shadows inherited setter", () => {
+  it("subclass get-only override: write throws, parent setter does not run", async () => {
+    await assertEquivalent(
+      `class A { _v = 1; get v(): number { return this._v; } set v(x: number) { this._v = x * 2; } }
+       class B extends A { get v(): number { return this._v + 100; } }
+       export function test(): number {
+         const b = new B();
+         try {
+           // @ts-ignore — assigning to a read-only accessor is valid (throwing) JS
+           b.v = 7;
+         } catch (e) {
+           return -1;
+         }
+         return b._v;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("single-class get-only accessor: write throws", async () => {
+    await assertEquivalent(
+      `class A { _v = 5; get v(): number { return this._v; } }
+       export function test(): number {
+         const a = new A();
+         try {
+           // @ts-ignore
+           a.v = 7;
+         } catch (e) {
+           return -1;
+         }
+         return a._v;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("get-only override: the parent setter side effect never fires", async () => {
+    // If the parent setter wrongly ran, `_v` would become 14 (7*2); the write
+    // must throw and leave `_v` at its constructed value.
+    await assertEquivalent(
+      `class A { _v = 3; get v(): number { return this._v; } set v(x: number) { this._v = x * 2; } }
+       class B extends A { get v(): number { return this._v; } }
+       export function test(): number {
+         const b = new B();
+         let threw = 0;
+         try {
+           // @ts-ignore
+           b.v = 7;
+         } catch (e) {
+           threw = 1;
+         }
+         return threw * 1000 + b._v;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("full accessor pair override still writes (unchanged)", async () => {
+    await assertEquivalent(
+      `class A { _v = 1; get v(): number { return this._v; } set v(x: number) { this._v = x * 2; } }
+       class B extends A { get v(): number { return this._v + 100; } set v(x: number) { this._v = x + 5; } }
+       export function test(): number {
+         const b = new B();
+         b.v = 7;
+         return b._v;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("inherited setter (subclass adds no accessor) still writes (unchanged)", async () => {
+    await assertEquivalent(
+      `class A { _v = 1; get v(): number { return this._v; } set v(x: number) { this._v = x * 3; } }
+       class B extends A {}
+       export function test(): number {
+         const b = new B();
+         b.v = 7;
+         return b._v;
+       }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

```ts
class A { _v = 1; get v(): number { return this._v; } set v(x: number) { this._v = x * 2; } }
class B extends A { get v(): number { return this._v + 100; } }
const b = new B();
try { b.v = 7; } catch (e) { return -1; }
return b._v;
// wasm: 1 (write silently dropped)   node: -1 (TypeError)
```

`classAccessorSet` records the accessor key for **both** getters and setters,
so a get-only override entered the accessor-write block, found no `B_set_v`
function, and fell through to the struct-field path — which found no field `v`
and silently dropped the write.

## Fix

Per §10.1.5.3 OrdinarySetWithOwnDescriptor the own get-only accessor **shadows**
the inherited setter: a strict-mode write throws TypeError and the parent setter
must NOT run. In `compileAssignmentToAccessor`, when the setter funcIdx is
undefined **and** the class has an own getter (`funcMap.has(<type>_get_<field>)`),
evaluate + drop the RHS (GetValue happens before [[Set]]) and `emitThrowTypeError`.

The set-only-read mirror (`b.v` on a set-only override → `undefined`) already
behaves correctly on main, so no change there.

## Tests

`tests/issue-2024.test.ts` — 5 equivalence cases (wasm vs Node), all pass:
get-only override write throws, **parent-setter side effect never fires**,
single-class get-only, full accessor-pair override unchanged, inherited setter
unchanged. (Get-only writes use `// @ts-ignore` — assigning to a read-only
accessor is valid *throwing* JS, which is what test262 exercises; the compiler
infers `new B()` as `B`, so the write takes the typed struct-accessor path.)

Class/accessor equivalence suites (`accessor-side-effects`,
`computed-setter-class`, `super-property-access`, `private-class-members`,
`ir-slice4-classes` — 23 tests) unchanged. The one `object-literal-getters-
setters > setter stores value` failure is **pre-existing on clean origin/main**.
IR fallback gate OK; `biome lint`, `tsc --noEmit`, `prettier --check` clean.

Closes #2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)