### PR TITLE
fix(#2132): null-receiver method call throws a catchable TypeError, not a trap

### DIFF
--- a/plan/issues/2132-null-receiver-method-call-uncatchable-trap.md
+++ b/plan/issues/2132-null-receiver-method-call-uncatchable-trap.md
@@ -1,10 +1,11 @@
 ---
 id: 2132
 title: "method call on a null receiver is an uncatchable wasm trap instead of a catchable TypeError"
-status: ready
+status: done
 sprint: 61
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-13
+completed: 2026-06-13
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -67,3 +68,30 @@ catchable TypeError. See call-expression / member-call lowering in
 Verified on main `c19a2e9c1` via `.tmp/triage.mts` / `.tmp/triage2.mts`
 (branch `po-1971-triage`). JS-host mode, default options. Coordinate with the
 shared throw lowering (#2102) so this reuses one TypeError-emit helper.
+
+## Resolution (2026-06-13)
+
+Fixed in `src/codegen/expressions/calls.ts` (typed-class method dispatch). Root
+cause: for a statically-nullable receiver the dispatch compiled the receiver
+with the method's non-null `ref` param-0 hint, so `coerceType` emitted a bare
+`ref.as_non_null` that trapped on null BEFORE any guard — and `as any` laundered
+the `null` out of the receiver's static type so the existing nullability check
+never fired.
+
+Two changes:
+1. Detect nullability by **peeling** `as` / `!` / parenthesized / type-assertion
+   wrappers (`(c as any)` / `c!`) and checking the inner expression's static
+   type for `Null|Undefined|Void`.
+2. When the receiver may be null, compile it with a **nullable** param-0 hint
+   (`ref` → `ref_null`) so the value stays nullable on the stack; the existing
+   `ref_null` null-guard then tees it, null-checks, throws a CATCHABLE TypeError
+   on the null branch, and re-asserts non-null only on the non-null branch.
+
+### Test Results
+
+`tests/issue-2132.test.ts` (5): `(c as any).m()` / `c!.m()` / undefined receiver
+on null → catch returns 99 (was uncatchable `dereferencing a null pointer`
+trap); non-null receiver dispatches (`m()`=7, `add(3,4)`=7). Node parity
+confirmed. `#789` null-guard tests (5/5), optional-chaining, and
+array-prototype-methods unregressed; the `classes.test.ts` failures pre-exist on
+clean main (unrelated harness issue). `tsc`/`biome`/`prettier` clean.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6710,11 +6710,61 @@ function compileCallExpression(
         }
         // Push self (the receiver) as first argument, with type hint from method's first param
         const methodParamTypes0 = getFuncParamTypes(ctx, funcIdx);
-        let recvType = compileExpression(ctx, fctx, propAccess.expression, methodParamTypes0?.[0]);
+        // (#2132) A method call on a statically-nullable receiver (`C | null`,
+        // incl. when laundered through `as any`) must throw a CATCHABLE
+        // TypeError on null, not a bare `ref.as_non_null` trap (Wasm null-deref
+        // traps bypass the module's exception tags and abort uncatchably).
+        // Detect nullability from the static type here, because the param-0 type
+        // hint passed to compileExpression below can coerce the value to a
+        // non-null `ref` and hide it from the `recvType.kind === "ref_null"`
+        // guard further down.
+        const NULL_OR_UNDEF = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
+        const typeIsMaybeNull = (t: ts.Type): boolean =>
+          (t.flags & NULL_OR_UNDEF) !== 0 ||
+          (t.isUnion?.() === true && t.types.some((u) => (u.flags & NULL_OR_UNDEF) !== 0));
+        // Peel `as`/`!`/parens so `(c as any)` / `c!` reveal the underlying
+        // declared nullability — `as any` launders Null out of the static type,
+        // so checking only the cast expression's own type would miss it (#2132).
+        let receiverInner: ts.Expression = propAccess.expression;
+        while (
+          ts.isAsExpression(receiverInner) ||
+          ts.isNonNullExpression(receiverInner) ||
+          ts.isParenthesizedExpression(receiverInner) ||
+          ts.isTypeAssertionExpression(receiverInner)
+        ) {
+          receiverInner = (
+            receiverInner as ts.AsExpression | ts.NonNullExpression | ts.ParenthesizedExpression | ts.TypeAssertion
+          ).expression;
+        }
+        const receiverMaybeNull =
+          typeIsMaybeNull(ctx.checker.getTypeAtLocation(propAccess.expression)) ||
+          typeIsMaybeNull(ctx.checker.getTypeAtLocation(receiverInner));
+        // (#2132) When the receiver may be null, pass a NULLABLE param-0 hint (or
+        // none) so compileExpression keeps the value nullable on the stack — a
+        // non-null `ref` hint makes coerceType emit `ref.as_non_null`, which
+        // would trap on null BEFORE the guard below can throw a catchable
+        // TypeError. The `ref_null` guard further down re-asserts non-null only
+        // on the non-null branch.
+        const recvHint0: ValType | undefined =
+          receiverMaybeNull && methodParamTypes0?.[0]?.kind === "ref"
+            ? { kind: "ref_null", typeIdx: (methodParamTypes0[0] as { typeIdx: number }).typeIdx }
+            : methodParamTypes0?.[0];
+        let recvType = compileExpression(ctx, fctx, propAccess.expression, recvHint0);
         // Track whether receiver went through emitGuardedRefCast — if so, null
         // means "wrong struct type" (not genuinely null), so we should NOT throw
         // TypeError on null after cast.
         let receiverWasCast = false;
+        // (#2132) If the receiver is statically nullable but compiled to a
+        // non-null `ref` (e.g. via `as any`), force `ref_null` so the null-guard
+        // below fires and throws a catchable TypeError instead of trapping.
+        if (
+          receiverMaybeNull &&
+          recvType &&
+          recvType.kind === "ref" &&
+          (recvType as { typeIdx?: number }).typeIdx !== undefined
+        ) {
+          recvType = { kind: "ref_null", typeIdx: (recvType as { typeIdx: number }).typeIdx };
+        }
         // If receiver is externref but the method expects a struct ref, coerce
         if (recvType && recvType.kind === "externref") {
           const structTypeIdx = ctx.structMap.get(receiverClassName);

--- a/tests/issue-2132.test.ts
+++ b/tests/issue-2132.test.ts
@@ -1,0 +1,79 @@
+// #2132 — a non-optional method call on a statically-nullable receiver
+// (`C | null`, incl. laundered through `as any` / `!`) must throw a CATCHABLE
+// `TypeError` on null, not a bare `ref.as_non_null` Wasm trap. A Wasm null-deref
+// trap bypasses the module's own exception tags and aborts uncatchably, so a
+// user `try/catch` around the call could not recover.
+//
+// Fix (src/codegen/expressions/calls.ts): detect receiver nullability from the
+// static type (peeling `as`/`!`/parens so `as any` doesn't hide it), compile the
+// receiver with a NULLABLE param-0 hint so it stays nullable on the stack, then
+// the existing `ref_null` null-guard throws a catchable TypeError. Non-null
+// receivers dispatch unchanged.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile error: ${result.errors.map((e) => e.message).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as never);
+  if (typeof imports.setExports === "function") {
+    (imports.setExports as (e: unknown) => void)(instance.exports);
+  }
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2132 method call on a null receiver throws a catchable TypeError", () => {
+  it("catches the TypeError from `(c as any).m()` on a null receiver", async () => {
+    const got = await run(`
+      class C { m(): number { return 1; } }
+      export function test(): number {
+        const c: C | null = null;
+        try { (c as any).m(); return 0; } catch (e) { return 99; }
+      }`);
+    expect(got).toBe(99); // node: TypeError caught → 99 (was: uncatchable trap)
+  });
+
+  it("catches the TypeError from `c!.m()` on a null receiver", async () => {
+    const got = await run(`
+      class C { m(): number { return 1; } }
+      export function test(): number {
+        const c: C | null = null;
+        try { c!.m(); return 0; } catch (e) { return 99; }
+      }`);
+    expect(got).toBe(99); // node: 99
+  });
+
+  it("catches the TypeError on an `undefined` receiver too", async () => {
+    const got = await run(`
+      class C { m(): number { return 1; } }
+      export function test(): number {
+        const c: C | undefined = undefined;
+        try { (c as any).m(); return 0; } catch (e) { return 99; }
+      }`);
+    expect(got).toBe(99); // node: 99
+  });
+
+  it("a non-null receiver dispatches normally (no added trap)", async () => {
+    const got = await run(`
+      class C { m(): number { return 7; } }
+      export function test(): number {
+        const c: C | null = new C();
+        return (c as any).m();
+      }`);
+    expect(got).toBe(7); // node: 7
+  });
+
+  it("a method with arguments on a non-null nullable-typed receiver works", async () => {
+    const got = await run(`
+      class C { add(a: number, b: number): number { return a + b; } }
+      export function test(): number {
+        const c: C | null = new C();
+        return c!.add(3, 4);
+      }`);
+    expect(got).toBe(7); // node: 7
+  });
+});


### PR DESCRIPTION
## Problem (#2132)

A non-optional method call on a statically-nullable receiver traps the module
uncatchably instead of throwing a catchable `TypeError`:

```ts
class C { m(): number { return 1; } }
const c: C | null = null;
try { (c as any).m(); return 0; } catch (e) { return 99; }
// wasm: RuntimeError: dereferencing a null pointer (uncatchable)
// node: returns 99 (TypeError caught)
```

A Wasm null-deref trap bypasses the module's own exception tags, so the user
`try/catch` can't recover.

## Root cause

In the typed-class method dispatch (`src/codegen/expressions/calls.ts`), the
receiver was compiled with the method's **non-null `ref`** param-0 hint, so
`coerceType` emitted a bare `ref.as_non_null` that traps on null BEFORE any
guard. And `as any` launders `null` out of the receiver's static type, so the
existing nullability check never fired.

## Fix

- Detect nullability by **peeling** `as` / `!` / parens / type-assertion
  wrappers and checking the inner expression's static type for
  `Null|Undefined|Void`.
- When the receiver may be null, compile it with a **nullable** param-0 hint
  (`ref` → `ref_null`) so it stays nullable on the stack; the existing
  `ref_null` null-guard then tees it, null-checks, throws a catchable `TypeError`
  on the null branch, and re-asserts non-null only on the non-null branch.

Non-null receivers dispatch unchanged (guard only fires where the type is
nullable).

## Tests

`tests/issue-2132.test.ts` (5): `(c as any).m()` / `c!.m()` / undefined receiver
on null → catch returns `99` (was uncatchable trap); non-null receiver
dispatches (`m()`=7, `add(3,4)`=7). Node parity confirmed.

`#789` null-guard tests (5/5), optional-chaining, and array-prototype-methods
unregressed. The `classes.test.ts` failures pre-exist on clean `main` (unrelated
harness issue). `tsc --noEmit`, `biome lint`, `prettier --check` clean.

Closes #2132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)