### PR TITLE
fix(#2042): ToPropertyKey defineProperty key in standalone (PR-A)

### DIFF
--- a/plan/issues/2042-standalone-defineproperty-descriptor-semantics.md
+++ b/plan/issues/2042-standalone-defineproperty-descriptor-semantics.md
@@ -1,10 +1,10 @@
 ---
 id: 2042
 title: "standalone: Object.defineProperty/defineProperties residual — __obj_insert illegal cast + descriptor semantics over $Object (~340 tests)"
-status: ready
+status: in-progress
 sprint: Backlog
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -73,3 +73,36 @@ slice and re-measure.
 - TypeError thrown (catchable) on invalid redefinitions — no traps.
 - Host mode unchanged; equivalence test for numeric + symbol keys through
   `Object.defineProperty` in standalone.
+
+## Progress
+
+### PR-A — key cast fix (2026-06-14, dev-b) — DONE
+
+ToPropertyKey the `Object.defineProperty` key at the call site so a numeric /
+boxed key reaches the string-keyed `$Object` runtime as a `$AnyString`,
+eliminating the `illegal cast` trap (class A, 37+ rows).
+
+- New helper `emitStandaloneDefinePropertyKeyToString` in
+  `src/codegen/object-ops.ts` routes the compiled key externref through
+  `__extern_toString` (host import in JS mode; native runtime helper in
+  standalone), gated on `ctx.standalone` so host output stays byte-identical
+  (the host `__defineProperty_value` JS import ToPropertyKeys the key itself and
+  would alias a pre-stringified Symbol).
+- Applied symmetrically in both the value path
+  (`emitExternDefinePropertyValue`) and the accessor path
+  (`emitExternDefinePropertyNoValue`).
+- Verified: `Object.defineProperty(o, 0, {value:5})` no longer traps in
+  standalone (was `illegal cast`); string-key define round-trips unchanged
+  (`o.foo`); host mode untouched. Tests in `tests/issue-2042.test.ts`.
+- Symbol keys: out of scope for Part A (the string-keyed runtime cannot
+  represent them); the `15.2.3.6-4-*` illegal-cast rows are numeric, not symbol.
+
+### Remaining (PR-B — senior follow-up)
+
+- ValidateAndApplyPropertyDescriptor / CompletePropertyDescriptor over the
+  `$PropEntry` flag word (class B, ~300 rows): attribute defaults, redefinition
+  rules, catchable TypeError. Out of scope for this PR.
+- Standalone defineProperty value readback via numeric/computed member access
+  (`o[0]`) and enumeration (`Object.keys` / `getOwnPropertyNames`) over
+  defineProperty'd keys are separate pre-existing gaps (the latter is refused
+  loud under #1472 Phase B) — not introduced by PR-A.

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -1853,6 +1853,38 @@ function emitRuntimeFlagsF64(
 }
 
 /**
+ * #2042 PR-A — ToPropertyKey the `Object.defineProperty` key in standalone mode.
+ *
+ * The standalone `$Object` runtime is string-keyed: `__obj_insert` /
+ * `__defineProperty_value` / `__defineProperty_accessor` all `ref.cast
+ * $AnyString` the incoming key. The defineProperty call sites compile the key
+ * with the `{ externref }` hint, which boxes a *number* literal
+ * (`Object.defineProperty(o, 0, …)`) as a boxed-number externref rather than a
+ * string — that boxed number then traps `illegal cast` in `__obj_insert`.
+ *
+ * `__extern_toString` (host import in JS mode, native runtime helper in
+ * standalone) maps any externref through ToString — numeric keys become their
+ * canonical decimal ("0", "1.5"), matching how `{0:x}` / `obj[0]=x` store the
+ * key. It is idempotent on strings, so string keys pass through unchanged.
+ *
+ * Expects the key externref on top of the stack; leaves a $AnyString externref.
+ * Gated on `ctx.standalone`: in host mode `__defineProperty_value` is a JS
+ * import that ToPropertyKeys the key itself (and correctly preserves Symbol
+ * keys, which a pre-emptive ToString would alias) — so host output stays
+ * byte-identical. Symbol keys in standalone are out of scope for Part A; the
+ * string-keyed runtime cannot represent them, and ToString-ing one would alias
+ * `Symbol("x")` to `"Symbol(x)"` — but the `15.2.3.6-4-*` illegal-cast rows are
+ * numeric, not symbol, so the bulk is fixed here.
+ */
+function emitStandaloneDefinePropertyKeyToString(ctx: CodegenContext, fctx: FunctionContext): void {
+  if (!ctx.standalone) return;
+  const toStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  const finalIdx = ctx.funcMap.get("__extern_toString") ?? toStrIdx;
+  if (finalIdx !== undefined) fctx.body.push({ op: "call", funcIdx: finalIdx });
+}
+
+/**
  * Emit __defineProperty_value(obj, prop, value, flags) for the externref value path.
  */
 function emitExternDefinePropertyValue(
@@ -1895,6 +1927,14 @@ function emitExternDefinePropertyValue(
   if (propType.kind !== "externref") {
     coerceType(ctx, fctx, propType, { kind: "externref" });
   }
+  // #2042 PR-A: in standalone mode the `$Object` table is string-keyed and
+  // `__obj_insert` does `ref.cast $AnyString` on the key. A non-string key —
+  // `Object.defineProperty(o, 0, …)` boxes `0` as a number externref — traps
+  // `illegal cast`. ToPropertyKey (ToString for everything but Symbols) it here
+  // so the value handed to `__defineProperty_value` is always a $AnyString. In
+  // host mode `__defineProperty_value` is a JS import that ToPropertyKeys
+  // itself (and would mishandle a pre-stringified Symbol), so gate on standalone.
+  emitStandaloneDefinePropertyKeyToString(ctx, fctx);
   const propLocal = allocLocal(fctx, `__defprop_key_${fctx.locals.length}`, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: propLocal });
 
@@ -2060,6 +2100,11 @@ function emitExternDefinePropertyNoValue(
     if (propType.kind !== "externref") {
       coerceType(ctx, fctx, propType, { kind: "externref" });
     }
+    // #2042 PR-A: symmetric with the value path — stringify the key in
+    // standalone so the string-keyed `$Object` runtime (__obj_insert /
+    // __defineProperty_accessor) never `ref.cast $AnyString`-traps on a
+    // numeric/boxed key.
+    emitStandaloneDefinePropertyKeyToString(ctx, fctx);
     propLocal = allocLocal(fctx, `__defprop_key_${fctx.locals.length}`, { kind: "externref" });
     fctx.body.push({ op: "local.set", index: propLocal });
   }

--- a/tests/issue-2042.test.ts
+++ b/tests/issue-2042.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2042 PR-A — standalone `Object.defineProperty` with a non-string (numeric)
+// key must not trap `illegal cast`.
+//
+// The standalone `$Object` runtime is string-keyed: `__obj_insert` does
+// `ref.cast $AnyString` on the incoming key. The defineProperty call sites
+// compile the key with the `{ externref }` hint, which boxes a *number* literal
+// (`Object.defineProperty(o, 0, …)`) as a boxed-number externref rather than a
+// string — that boxed number then traps `illegal cast` in `__obj_insert`.
+//
+// PR-A ToPropertyKeys the key (ToString for everything but Symbols) at the call
+// site so a numeric key reaches `__obj_insert` as its canonical decimal string
+// ("0", "5"). PR-B (ValidateAndApply / descriptor-default semantics, value
+// readback, enumeration) is a separate senior follow-up — this test asserts
+// only that the define no longer traps and that the string-key path is
+// unregressed. (Standalone enumeration / `getOwnPropertyNames` over a
+// defineProperty'd key is itself not yet supported — #1472 Phase B / PR-B — so
+// it is intentionally NOT exercised here.)
+
+async function runStandalone(body: string): Promise<unknown> {
+  const r = await compile(body, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error(`Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#2042 standalone Object.defineProperty key cast", () => {
+  it("numeric key define does not trap illegal cast", async () => {
+    // Before PR-A this threw `illegal cast` at runtime inside __obj_insert.
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, 0, { value: 5 });
+          return 1;
+        }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a larger numeric key define does not trap", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, 5, { value: 9, enumerable: true, writable: true, configurable: true });
+          return 1;
+        }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("numeric key define with an accessor descriptor does not trap", async () => {
+    // The accessor branch (emitExternDefinePropertyNoValue) gets the same
+    // key-stringification; a numeric key there must not trap either.
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, 0, { get() { return 5; } });
+          return 1;
+        }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("string key define still round-trips (regression guard)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "foo", { value: 7 });
+          const v: any = o.foo;
+          return (v === 7) ? 1 : 0;
+        }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a string numeric-looking key does not trap", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "0", { value: 5 });
+          return 1;
+        }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2042 PR-A — standalone `Object.defineProperty` numeric-key `illegal cast`

### Problem
In `--target standalone`, `Object.defineProperty(o, 0, { value: 5 })` traps
`illegal cast` at runtime. The `$Object` runtime is string-keyed —
`__obj_insert` does `ref.cast $AnyString` on the incoming key — but the
defineProperty call sites compile the key with the `{ externref }` hint, which
boxes a *number* literal as a boxed-number externref rather than a string. That
boxed number then fails the cast in `__obj_insert`.

### Fix (Part A only)
ToPropertyKey the key at the call site (ToString for everything but Symbols)
via the new `emitStandaloneDefinePropertyKeyToString` helper in
`src/codegen/object-ops.ts`, which routes the compiled key externref through
`__extern_toString`. Numeric keys become their canonical decimal string
("0", "5"), matching how `{0:x}` / `obj[0]=x` store the key. Applied
symmetrically to:
- the value path (`emitExternDefinePropertyValue`), and
- the accessor path (`emitExternDefinePropertyNoValue`).

Gated on `ctx.standalone`: in host mode `__defineProperty_value` is a JS import
that ToPropertyKeys the key itself (and correctly preserves Symbol keys, which a
pre-emptive ToString would alias), so **host output stays byte-identical**.

### Scope
- **In scope:** kill the `illegal cast` trap (class A, the `15.2.3.6-4-*`
  numeric-key rows).
- **Out of scope:** Symbol keys (the string-keyed runtime cannot represent
  them; the illegal-cast rows are numeric), and PR-B — ValidateAndApply /
  CompletePropertyDescriptor semantics (~300 class-B rows), a separate senior
  follow-up. Standalone enumeration / value-readback over defineProperty'd keys
  are separate pre-existing gaps, not introduced here.

### Verification
- `Object.defineProperty(o, 0, {value:5})` no longer traps in standalone (was
  `illegal cast`); confirmed the `/workspace` checkout without this change still
  traps.
- String-key define round-trips unchanged (`o.foo`).
- Host mode untouched (gate on `ctx.standalone`).
- New `tests/issue-2042.test.ts` (5 tests, all pass). Pre-existing
  defineProperty test failures (`object-define-property*.test.ts` broken
  `./helpers.js` import; `issue-929` accessor) are unchanged by this PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)