### PR TITLE
fix(#2047): unify standalone Array.isArray onto finalize-filled native helper

### DIFF
--- a/plan/issues/2047-unify-standalone-isarray-predicate.md
+++ b/plan/issues/2047-unify-standalone-isarray-predicate.md
@@ -1,10 +1,11 @@
 ---
 id: 2047
 title: "unify standalone Array.isArray: inline snapshot predicate diverges from direct calls; #1904's native __extern_is_array is dead code; both over-claim non-array carriers"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
+completed: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -85,3 +86,46 @@ and merged without integrating:
   shipping in modules (or it is the only implementation).
 - No host-mode changes; equivalence + issue-1904/1907 tests green with the
   new coexistence cases.
+
+## Resolution (2026-06-14)
+
+Unified the standalone `Array.isArray` predicate onto the finalize-filled
+native helper and filtered the exclusively-non-array byte carriers.
+
+**Changes**
+- `src/codegen/property-access.ts` — `emitArrayIsArrayExternrefPredicate` now
+  routes the `ctx.standalone` arm to the in-module native `__extern_is_array`
+  helper (which is *filled at finalize* by `fillExternIsArray` with the complete
+  carrier list), deleting the inline `vecTypeMap` `ref.test` snapshot chain for
+  standalone. Host **and** WASI keep the existing inline chain (host ORs the JS
+  `__extern_is_array` predicate for foreign JS arrays — #1328/#1678 unchanged;
+  WASI's `__extern_is_array` does not resolve to the native object-runtime func,
+  so it stays on the inline chain). Both standalone dispatch sites (the direct
+  `Array.isArray(x)` call in `calls.ts` and the value-read closure) already share
+  this one function, so fixing it covers both.
+- `src/codegen/object-runtime.ts` — `collectStandaloneArrayCarrierTypeIdxs` now
+  excludes the `i32_byte` (ArrayBuffer/DataView) and `i8_byte` (native
+  Uint8Array) byte carriers per ES §7.2.2 IsArray.
+
+**Known residual** (documented in `object-runtime.ts`): other TypedArrays
+(Float64Array, Int32Array, …) share the generic `__vec_f64` carrier with
+`number[]` and cannot be distinguished by a struct-level `ref.test` without a
+brand bit. `__vec_f64` is kept in the carrier list, so
+`Array.isArray(new Float64Array(1))` remains a false-positive pending a
+brand-bit follow-up. Only the cleanly-non-array `_byte` carriers are filtered.
+
+## Test Results (2026-06-14)
+
+- `tests/issue-2047.test.ts` (new) — 8/8 pass: value-read↔direct-call agreement
+  for boolean[]/number[]/string[], capture-before-decl snapshot case,
+  ArrayBuffer/DataView/Uint8Array ⇒ false, byte carrier false beside a real
+  array carrier, primitives/objects ⇒ false, `$ObjVec` (Object.keys) ⇒ true,
+  host-mode parity (unchanged output).
+- `tests/issue-1904.test.ts`, `tests/issue-1907.test.ts` — green (the rival
+  inline impl's tests survive its deletion).
+- Pre-existing, unrelated failures (byte-identical to origin/main, not touched
+  by this change): `tests/array-methods.test.ts` /
+  `tests/arraybuffer-dataview.test.ts` instantiate with a partial import object
+  (missing `string_constants`); `tests/sparse-array-spread.test.ts` imports the
+  broken `tests/helpers.js`; `tests/issue-1767.test.ts` 64 MiB memory-cap stream
+  test is environmental.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4370,15 +4370,48 @@ export function fillApplyClosure(ctx: CodegenContext): void {
   bridgeFn.locals = [{ name: "n", type: { kind: "i32" } }];
 }
 
+/**
+ * (#2047) Byte-backed vec carriers that are NEVER JS arrays and must report
+ * `Array.isArray === false` per ES §7.2.2:
+ *   - `i32_byte` — ArrayBuffer / DataView backing store.
+ *   - `i8_byte`  — native (standalone/WASI) `Uint8Array` packed-byte storage.
+ * The codebase already excludes `i32_byte` vecs from array treatment elsewhere
+ * (`type-coercion.ts` — the `__make_iterable` shim skips it), so this filter is
+ * consistent precedent. NOTE: other TypedArrays (Float64Array, Int32Array, …)
+ * share the generic `f64` vec carrier with `number[]`, so a struct-level
+ * `ref.test` cannot distinguish them without a brand bit — `__vec_f64` is kept
+ * IN the carrier list and `Array.isArray(new Float64Array(1))` remains a known
+ * residual false-positive tracked for a brand-bit follow-up. Only the
+ * exclusively-non-array `_byte` carriers can be filtered cleanly.
+ */
+const NON_ARRAY_BYTE_VEC_ELEM_KINDS: ReadonlySet<string> = new Set(["i32_byte", "i8_byte"]);
+
+function isNonArrayByteVecName(name: string): boolean {
+  // Matches `__vec_i32_byte` / `__vec_i8_byte`. Only `__vec_*` structs reach
+  // this check (the caller already restricts to vec struct names).
+  for (const elemKind of NON_ARRAY_BYTE_VEC_ELEM_KINDS) {
+    if (name === `__vec_${elemKind}`) return true;
+  }
+  return false;
+}
+
 function collectStandaloneArrayCarrierTypeIdxs(ctx: CodegenContext): number[] {
   const carriers = new Set<number>();
   const objVecTypeIdx = ctx.objectRuntimeTypes?.objVecTypeIdx;
   if (objVecTypeIdx !== undefined) carriers.add(objVecTypeIdx);
-  for (const typeIdx of ctx.vecTypeMap.values()) carriers.add(typeIdx);
+
+  // (#2047) Drop the exclusively-non-array byte carriers from vecTypeMap by key
+  // so ArrayBuffer/DataView (`i32_byte`) and native Uint8Array (`i8_byte`) are
+  // never claimed as arrays.
+  for (const [elemKind, typeIdx] of ctx.vecTypeMap.entries()) {
+    if (NON_ARRAY_BYTE_VEC_ELEM_KINDS.has(elemKind)) continue;
+    carriers.add(typeIdx);
+  }
   for (let typeIdx = 0; typeIdx < ctx.mod.types.length; typeIdx++) {
     const typeDef = ctx.mod.types[typeIdx];
     if (typeDef?.kind !== "struct") continue;
     const name = typeDef.name ?? "";
+    if (isNonArrayByteVecName(name)) continue; // (#2047) §7.2.2 — never an array
     if (name.startsWith("__vec_") || name === "__template_vec_externref") carriers.add(typeIdx);
   }
   return Array.from(carriers).sort((a, b) => a - b);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -278,12 +278,46 @@ function emitRuntimeDescriptorGet(
 /**
  * Consume an externref value and push the Array.isArray boolean result.
  *
- * Spec basis: ECMA-262 §23.1.2.3 delegates to IsArray (§7.2.2). In no-host
- * targets we can only decide compiled WasmGC array values, so the predicate is
- * a ref.test over every registered vec type; host mode ORs that with the real
- * JS Array.isArray predicate for foreign JS arrays.
+ * Spec basis: ECMA-262 §23.1.2.3 delegates to IsArray (§7.2.2).
+ *
+ * Two regimes (#2047 — unified):
+ *
+ * - **`--target standalone`**: route through the in-module native
+ *   `__extern_is_array` helper. That helper is reserved with the object runtime
+ *   and *filled at finalize* (`fillExternIsArray`) with the COMPLETE, filtered
+ *   array-carrier list, so a value-read of `Array.isArray` taken before a later
+ *   array type (e.g. `boolean[]` → `__vec_i32`) is registered no longer bakes an
+ *   incomplete `ref.test` chain. This both fixes the first-emission snapshot bug
+ *   (`const f = Array.isArray; f(boolean[])` ⇒ `false`) and excludes the
+ *   exclusively-non-array byte carriers (`i32_byte` ArrayBuffer/DataView,
+ *   `i8_byte` Uint8Array) per §7.2.2.
+ * - **Host / WASI**: keep the inline `ref.test` chain over every registered vec
+ *   type (it detects compiled WasmGC array values materialised into an externref
+ *   slot — #1678), ORed in host mode with the real JS `Array.isArray` host
+ *   predicate for foreign JS arrays (#1328). Host output is unchanged.
  */
 export function emitArrayIsArrayExternrefPredicate(ctx: CodegenContext, fctx: FunctionContext): void {
+  // (#2047) Standalone: defer entirely to the finalize-filled native helper.
+  // It owns the complete, byte-carrier-filtered carrier list (late binding),
+  // so neither declaration order nor lazy vec registration can produce a wrong
+  // answer here. WASI is intentionally NOT routed here: its
+  // `__extern_is_array` does not resolve to the native object-runtime func
+  // (OBJECT_RUNTIME_HELPER_NAMES routing is `ctx.standalone`-only), so it stays
+  // on the inline chain below.
+  if (ctx.standalone) {
+    const nativeIdx = ensureLateImport(ctx, "__extern_is_array", [{ kind: "externref" }], [{ kind: "i32" }]);
+    if (nativeIdx !== undefined) {
+      flushLateImportShifts(ctx, fctx);
+      fctx.body.push({ op: "call", funcIdx: nativeIdx });
+      return;
+    }
+    // Defensive fallback (should not happen — the object runtime always reserves
+    // the helper under standalone): nothing is an array.
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return;
+  }
+
   const vecTypeIdxs = Array.from(new Set(ctx.vecTypeMap.values()));
   const isArrIdx =
     !noJsHost(ctx) && !ctx.strictNoHostImports

--- a/tests/issue-2047.test.ts
+++ b/tests/issue-2047.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2047 — Unify the standalone Array.isArray predicate.
+//
+// Two sprint-61 PRs shipped competing standalone `Array.isArray` paths:
+//   - a live inline `ref.test` chain that bakes an INCOMPLETE carrier list at
+//     first emission (snapshot bug — a value-read of `Array.isArray` taken
+//     before a later array type, e.g. `boolean[]` → `__vec_i32`, is registered
+//     answered `false` while a direct call answered `true`); and
+//   - a dead-code native helper (`__extern_is_array`, finalize-filled with the
+//     complete carrier list) that standalone never called.
+//
+// This routes the standalone path through the finalize-filled native helper so
+// a value-read and a direct call always agree, and filters the exclusively-
+// non-array byte carriers (`i32_byte` ArrayBuffer/DataView, `i8_byte`
+// Uint8Array) so they report `false` per ES §7.2.2 IsArray.
+//
+// Known residual (documented in object-runtime.ts): other TypedArrays
+// (Float64Array, Int32Array, …) share the generic `__vec_f64` carrier with
+// `number[]` and cannot be distinguished by a struct-level `ref.test` without a
+// brand bit, so they remain a false-positive pending that follow-up. Only the
+// `_byte` carriers are filtered here.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+function envImportNames(bytes: Uint8Array): string[] {
+  const mod = new WebAssembly.Module(bytes);
+  return WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, {
+    fileName: "issue-2047.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  // Standalone must not leak the host array predicate import — the unified path
+  // resolves to the in-module native helper, never an env import.
+  const env = envImportNames(r.binary);
+  expect(env, `leaked __extern_is_array env import: ${env.join(", ")}`).not.toContain("__extern_is_array");
+  // Any other env import (e.g. the DataView view-register helper, unrelated to
+  // #2047) is satisfied with a permissive stub so the module instantiates.
+  const stub = new Proxy({}, { get: () => () => 0 });
+  const imp = { env: stub } as unknown as WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  return (instance.exports.test as () => number)();
+}
+
+async function runHost(source: string): Promise<number> {
+  const r = await compile(source, { fileName: "issue-2047.ts", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imp = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  (imp as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2047 unify standalone Array.isArray", () => {
+  it("value-read agrees with direct call for boolean[] in one module", async () => {
+    // The value-read `f` and the direct `Array.isArray` must produce identical
+    // answers. Before the fix the value-read snapshot chain disagreed.
+    const value = await runStandalone(`
+      export function test(): number {
+        const f = Array.isArray;
+        const b: boolean[] = [true, false];
+        const viaValue = f(b as any) ? 1 : 0;
+        const viaDirect = Array.isArray(b as any) ? 2 : 0;
+        return viaValue + viaDirect; // expect 3 (both true)
+      }
+    `);
+    expect(value).toBe(3);
+  });
+
+  it("value-read captured before a boolean[] type exists still answers true", async () => {
+    // The snapshot bug, isolated: `f` is captured at module top level (before
+    // any `boolean[]` / `__vec_i32` carrier is registered), then applied to a
+    // boolean[]. The finalize-filled native helper sees ALL carriers regardless
+    // of capture order.
+    const value = await runStandalone(`
+      let f = Array.isArray;
+      export function test(): number {
+        const b: boolean[] = [true];
+        return f(b as any) ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+  });
+
+  it("value-read and direct call agree across carrier kinds", async () => {
+    const value = await runStandalone(`
+      export function test(): number {
+        const f = Array.isArray;
+        const nums: number[] = [1, 2];
+        const bools: boolean[] = [true];
+        const strs: string[] = ["a"];
+        let acc = 0;
+        if (f(nums as any) === Array.isArray(nums as any) && Array.isArray(nums as any)) acc += 1;
+        if (f(bools as any) === Array.isArray(bools as any) && Array.isArray(bools as any)) acc += 2;
+        if (f(strs as any) === Array.isArray(strs as any) && Array.isArray(strs as any)) acc += 4;
+        return acc; // expect 7
+      }
+    `);
+    expect(value).toBe(7);
+  });
+
+  it("returns false for ArrayBuffer / DataView / Uint8Array carriers (§7.2.2)", async () => {
+    const value = await runStandalone(`
+      export function test(): number {
+        const ab: any = new ArrayBuffer(8);
+        const dv: any = new DataView(new ArrayBuffer(8));
+        const u8: any = new Uint8Array(2);
+        return (Array.isArray(ab) ? 1 : 0)
+          + (Array.isArray(dv) ? 2 : 0)
+          + (Array.isArray(u8) ? 4 : 0);
+      }
+    `);
+    expect(value).toBe(0);
+  });
+
+  it("byte carriers are false even when a real array carrier coexists", async () => {
+    // Regression guard: filtering must not be defeated by another `__vec_f64`
+    // (number[]) carrier being present in the same module.
+    const value = await runStandalone(`
+      export function test(): number {
+        const nums: number[] = [1, 2, 3];
+        const u8: any = new Uint8Array(2);
+        const arrTrue = Array.isArray(nums as any) ? 1 : 0;
+        const u8False = Array.isArray(u8) ? 0 : 2;
+        return arrTrue + u8False; // expect 3
+      }
+    `);
+    expect(value).toBe(3);
+  });
+
+  it("returns false for primitives and plain objects", async () => {
+    const value = await runStandalone(`
+      export function test(): number {
+        const o: any = { a: 1 };
+        const n: any = 5;
+        const s: any = "x";
+        return (Array.isArray(o) ? 1 : 0) + (Array.isArray(n) ? 2 : 0) + (Array.isArray(s) ? 4 : 0);
+      }
+    `);
+    expect(value).toBe(0);
+  });
+
+  it("brands native $ObjVec enumeration results as arrays", async () => {
+    const value = await runStandalone(`
+      export function test(): number {
+        const o: any = { a: 1, b: 2 };
+        const keys: any = Object.keys(o);
+        return Array.isArray(keys) ? 1 : 0;
+      }
+    `);
+    expect(value).toBe(1);
+  });
+
+  it("host mode is unchanged: value-read and direct call both detect compiled arrays", async () => {
+    // The host path keeps the inline ref.test chain ORed with the JS host
+    // predicate. This guards against the standalone unification leaking into
+    // host output.
+    const value = await runHost(`
+      export function test(): number {
+        const f = Array.isArray;
+        const nums: number[] = [1, 2];
+        const viaValue = f(nums as any) ? 1 : 0;
+        const viaDirect = Array.isArray(nums as any) ? 2 : 0;
+        const notArr = Array.isArray(5 as any) ? 4 : 0;
+        return viaValue + viaDirect + notArr; // expect 3
+      }
+    `);
+    expect(value).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2047 — Unify the standalone `Array.isArray` predicate

Two sprint-61 PRs (#1904, #1907) shipped competing standalone `Array.isArray` paths and merged without integrating:

- **Live inline path had a snapshot bug** — `emitArrayIsArrayExternrefPredicate` baked a `ctx.vecTypeMap` `ref.test` chain **at first emission** for the standalone arm. Only externref/f64 vecs register eagerly; `boolean[]` (`__vec_i32`), typed-array, and struct-element vecs register lazily, so a value-read of `Array.isArray` captured before those types exist snapshotted an incomplete chain. `const f = Array.isArray; f(boolean[])` → `false` while a later direct `Array.isArray(boolean[])` → `true`. Silent wrong value.
- **The correct fix was dead code** — the native `__extern_is_array` helper is *filled at finalize* (`fillExternIsArray`) with the COMPLETE carrier list (the late-binding answer to the snapshot bug), but its only caller was gated `!noJsHost`, so standalone never reached it.
- **Both over-claimed carriers** — they swept every `__vec_*` struct including the exclusively-non-array byte carriers (`i32_byte` ArrayBuffer/DataView, `i8_byte` native Uint8Array), which ES §7.2.2 IsArray requires be `false`.

## Fix

- **`src/codegen/property-access.ts`** — route the `ctx.standalone` arm of `emitArrayIsArrayExternrefPredicate` through the in-module native `__extern_is_array` helper, deleting the inline snapshot chain for standalone. Because the helper is finalize-filled, capture order no longer matters. **Host and WASI are unchanged**: host keeps the inline `ref.test` chain ORed with the JS `Array.isArray` predicate (foreign JS arrays — #1328/#1678); WASI's `__extern_is_array` does not resolve to the native object-runtime func (`OBJECT_RUNTIME_HELPER_NAMES` routing is `ctx.standalone`-only), so it stays on the inline chain. Both standalone dispatch sites (the direct `Array.isArray(x)` call in `calls.ts` and the value-read closure) already share this one function.
- **`src/codegen/object-runtime.ts`** — `collectStandaloneArrayCarrierTypeIdxs` now excludes the `i32_byte` / `i8_byte` byte carriers per §7.2.2.

### Known residual (documented)
Other TypedArrays (Float64Array, Int32Array, …) share the generic `__vec_f64` carrier with `number[]` and cannot be distinguished by a struct-level `ref.test` without a brand bit, so `Array.isArray(new Float64Array(1))` remains a false-positive pending a brand-bit follow-up. Only the cleanly-non-array `_byte` carriers are filtered here.

## Tests
- `tests/issue-2047.test.ts` (new) — 8/8: value-read↔direct-call agreement (boolean[]/number[]/string[]), capture-before-decl snapshot case, ArrayBuffer/DataView/Uint8Array ⇒ false, byte carrier false beside a real array carrier, primitives/objects ⇒ false, `$ObjVec` (Object.keys) ⇒ true, host-mode parity.
- `tests/issue-1904.test.ts` / `tests/issue-1907.test.ts` — green (the rival inline impl's tests survive its deletion).

Spec: [ECMA-262 §7.2.2 IsArray](https://tc39.es/ecma262/#sec-isarray).

🤖 Generated with [Claude Code](https://claude.com/claude-code)