### PR TITLE
fix(#2015): thread receiver as this for any-typed object-literal method calls

### DIFF
--- a/plan/issues/2015-any-receiver-method-this-throws.md
+++ b/plan/issues/2015-any-receiver-method-this-throws.md
@@ -1,7 +1,7 @@
 ---
 id: 2015
 title: "method call using `this` on an any-typed object-literal receiver throws bare WebAssembly.Exception (__extern_method_call this-routing)"
-status: ready
+status: suspended
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-12
@@ -52,3 +52,59 @@ objects.
 
 #1017/#1022/#1038 older done-era; #1971's method finding is null class
 receivers. New.
+
+## Suspended Work (2026-06-13, dev-c) — CORRECTED root cause
+
+- **Worktree**: `/workspace/.claude/worktrees/issue-2015-any-receiver-this`
+  (branch `issue-2015-any-receiver-this`, NO code committed — analysis only;
+  one wrong-path runtime attempt was reverted).
+
+### The issue's cited root cause is WRONG — this is NOT an `__extern_method_call` bug
+WAT-traced `o.getx()` on the repro (`const o: any = { x: 21, getx() { return
+this.x; } }; o.getx()`): the compiled `$test` uses **`__call_fn_0` + `call_ref`
++ a `getx_`-named function** and does **NOT** emit `__extern_method_call` /
+`__proto_method_call` / `__extern_get` at all. So despite the `any` annotation,
+the compiler statically resolves the object-literal's shape and calls the
+`getx` closure **directly** — it just fails to thread the receiver struct as the
+method's `this`. The runtime `__extern_method_call` / `_wrapForHost` path
+(cited at calls.ts:7512 / runtime.ts:~6815) is never reached.
+
+A runtime fix attempt (unwrap the host-proxy `this` via `_hostProxyReverse` in
+`_wrapWasmClosureUnknownArity`'s `__call_fn_method_N` bridge, runtime.ts:~1812)
+had **no effect** — confirming the dispatch doesn't go through that bridge.
+
+### Where the real fix is
+`src/codegen/expressions/calls.ts` — the **static closure-call path** for a
+method access on an any/externref receiver (the `__call_fn_0`/`call_ref` arm,
+near the closure-call helpers at ~1345-1360 and the method-call resolution that
+picks `closureInfoByTypeIdx`/`closureMap`). When the callee is an object-literal
+**method** closure (not a free function), the receiver struct must be threaded
+as `this` — either as the method's `__self`/first param, or via the
+`__current_this` global (the mechanism class methods already use; grep
+`__current_this`, set #1636-S1). Today the closure is called with only its
+captured args, so `this.<field>` (a `struct.get` on a null/absent `this`) traps.
+
+### Resume steps
+1. In calls.ts, find the arm that compiles `recv.method()` where `recv` is
+   any/externref and `method` resolves to an object-literal closure field
+   (produces `__call_fn_0`/`call_ref`). Confirm via WAT that the repro hits it.
+2. Compare with the CLASS method path (typed receiver works — `o.getx()` on a
+   non-`any` receiver returns 21) to see how `this` is threaded there
+   (`emitClosureCall*`, the `__current_this` set, or a self param), and mirror it.
+3. Thread the receiver struct as `this` for the object-literal-method closure
+   call. Guard: free-function closure calls (no receiver) must stay unchanged;
+   the no-`this` method control (`{ getx() { return 5; } }`) already works.
+4. Equivalence test: any-receiver method using `this.x` → 21; typed-receiver
+   unchanged; no-`this` method unchanged; method mutating `this.x` then reading;
+   nested `this` in a method calling another method.
+
+### Repro (verified on main)
+`const o: any = { x: 21, getx() { return this.x; } }; o.getx()` → wasm throws
+bare WebAssembly.Exception; node 21. Typed receiver (`const o = {...}`) → 21.
+no-`this` method (`{ getx() { return 5; } }`) → 5 (works).
+
+### Why suspended
+`reasoning_effort: high`; the issue's diagnosis was wrong (runtime vs codegen),
+so the real fix is a codegen this-threading change with regression risk across
+the closure-call paths. Warrants a focused pass / senior-dev with the corrected
+analysis above rather than a rushed change at session tail.

--- a/plan/issues/2015-any-receiver-method-this-throws.md
+++ b/plan/issues/2015-any-receiver-method-this-throws.md
@@ -1,10 +1,11 @@
 ---
 id: 2015
 title: "method call using `this` on an any-typed object-literal receiver throws bare WebAssembly.Exception (__extern_method_call this-routing)"
-status: suspended
+status: done
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-14
+completed: 2026-06-14
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -108,3 +109,61 @@ no-`this` method (`{ getx() { return 5; } }`) → 5 (works).
 so the real fix is a codegen this-threading change with regression risk across
 the closure-call paths. Warrants a focused pass / senior-dev with the corrected
 analysis above rather than a rushed change at session tail.
+
+## Resolution (2026-06-14, sdev) — FINAL root cause + fix
+
+Both the issue's original diagnosis (`__extern_method_call` this-routing) AND
+dev-c's corrected diagnosis (static `__call_fn_0`/`call_ref`, never reaching the
+runtime) were inaccurate against current main (76 commits had landed since the
+suspension). WAT-tracing the repro on the merged HEAD showed `o.getx()` DOES
+route through the JS host — but the real mechanism is a THREE-layer this-loss:
+
+1. **Runtime — `_wrapForHost` proxy `get` trap, generic `closureBridge`
+   fallback** (`src/runtime.ts` ~4250). Reading the `getx` closure field off
+   the host-mirror proxy returned a bridge that invoked the closure via the
+   PLAIN `__call_fn_N` dispatcher (`callFn0(val)`), discarding `this` entirely.
+   `__call_fn_N` never installs `__current_this`, so the receiver was lost
+   before the method body ran. (The `_wrapWasmClosureUnknownArity` dynamic
+   bridge had the same gap — it installed `this` but without unwrapping the
+   host-mirror proxy to the raw struct.)
+2. **Codegen — object-method trampoline** (`src/codegen/closures.ts`,
+   `emitObjectMethodAsClosure` / `emitCachedMethodClosureAccess` /
+   `finalizeMethodTrampolines`). The trampoline that bridges the closure ABI
+   `(closure_self, …args)` to the method ABI `(this_struct, …args)` HARDCODED
+   `ref.null <objStruct>` for the method's `this` slot. So even once
+   `__current_this` was installed, the method body (which reads `this` from its
+   struct param, not the global) got null → `this.<field>` = `struct.get` on
+   null → bare `WebAssembly.Exception`.
+
+### Fix (two files)
+- **`src/runtime.ts`**: the generic `closureBridge` fallback and the
+  `_wrapWasmClosureUnknownArity` dynamic bridge now dispatch through
+  `__call_fn_method_N` (unwrapping the `_wrapForHost` proxy to the raw struct
+  via `_unwrapForHost`, gated on `_isWasmStruct`) when invoked with a real
+  receiver. A bare/undefined/globalThis `this` (extraction call `const f = o.m;
+  f()`) keeps the plain `__call_fn_N` path, preserving spec-mandated unbound-
+  `this` semantics unchanged.
+- **`src/codegen/closures.ts`**: new `buildTrampolineThisSlot` helper — the
+  object-method trampoline reads `__current_this`, `ref.test`s it as the object
+  struct, casts and uses it as `this` when it matches, else falls back to
+  `ref.null` (so plain `__call_fn_N` dispatch still yields unbound `this`).
+  Mirrors the null-guarded `__current_this` read lifted closure bodies already
+  use for `ThisKeyword` (#1702). Applied to BOTH the per-call-site
+  (`emitObjectMethodAsClosure`) and the cached class/proto
+  (`emitCachedMethodClosureAccess`) trampolines, plus the `finalizeMethodTrampolines`
+  rebuild — the rebuild replaces (not appends) the func's locals so the
+  pre-seeded `__this_any` anyref scratch stays in lockstep with the rebuilt
+  body's local indices.
+
+### Verification
+- Repro `o.getx()` → 21; typed receiver → 21; no-`this` method → 5.
+- New `tests/issue-2015.test.ts` (7 cases): 0/1/2-arg this-threading, `this.x`
+  mutation across calls, nested method-to-method `this`. All pass.
+- Regression sweep: `issue-1636s1-this-regression`, `issue-1636-s1-tojson-this`,
+  `issue-1702-strict-this`, `issue-1742-this-receiver-guard`,
+  `issue-1712-capture-closure-dispatch`, `issue-1669-trampoline-externref-coercion`
+  all green (25 tests). Full `tests/equivalence/` sweep run; every failure that
+  surfaced was confirmed PRE-EXISTING on `origin/main` (verified by swapping the
+  original `closures.ts`/`runtime.ts` back in — identical per-file counts). The
+  stale `*-calls`/`externref` unit tests that instantiate with `{env:{}}` fail on
+  main too (they predate the lazy-importObject ABI), not caused by this change.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -19,7 +19,7 @@ import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
 import { pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
-import { allocLocal, getLocalType } from "./context/locals.js";
+import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import {
   addFuncType,
@@ -61,6 +61,7 @@ import {
   emitF64ParamSentinelCheck,
   emitArgumentsVecBody,
   emitParamDefaultArgMissingCheck,
+  ensureCurrentThisGlobal,
   paramDefaultNeedsArgc,
 } from "./statements/nested-declarations.js";
 import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-builder.js";
@@ -3359,6 +3360,50 @@ export function emitFuncRefAsClosure(
 }
 
 /**
+ * (#2015) Build the `this`-slot prologue for an object-method trampoline.
+ *
+ * Object-literal / cached method trampolines bridge the closure-value ABI
+ * `(closure_self, …userParams)` to the method ABI `(this_struct, …userParams)`.
+ * Historically they hardcoded `ref.null <objStruct>` for the method's `this`
+ * slot, implementing the unbound-`this` method-extraction case (`var f = o.m;
+ * f()` → `this === undefined`). But the SAME trampoline is reached when the
+ * closure is dispatched as a METHOD via `__call_fn_method_N`, which installs
+ * the receiver into the `__current_this` module global before the inner
+ * `call_ref` (#1636-S1). In that case the hardcoded null made `this.<field>`
+ * trap (the issue's bare `WebAssembly.Exception`).
+ *
+ * Read `__current_this` instead and use it as `this` when it `ref.test`s as the
+ * method's object struct; otherwise fall back to `ref.null` (preserving the
+ * unbound-extraction semantics, since plain `__call_fn_N` dispatch leaves the
+ * global null). This mirrors the null-guarded `__current_this` read that lifted
+ * closure bodies already use for `ThisKeyword` (`expressions.ts`, #1702).
+ *
+ * `anyTempLocalIdx` must reference a spare `anyref` local appended to the
+ * trampoline. Emits a sequence leaving exactly one `(ref null objStructTypeIdx)`
+ * on the stack.
+ */
+function buildTrampolineThisSlot(ctx: CodegenContext, objStructTypeIdx: number, anyTempLocalIdx: number): Instr[] {
+  const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
+  const nullThis: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx } as Instr];
+  if (currentThisGlobalIdx < 0) return nullThis;
+  return [
+    { op: "global.get", index: currentThisGlobalIdx } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: anyTempLocalIdx } as Instr,
+    { op: "ref.test", typeIdx: objStructTypeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref_null", typeIdx: objStructTypeIdx } },
+      then: [
+        { op: "local.get", index: anyTempLocalIdx } as Instr,
+        { op: "ref.cast", typeIdx: objStructTypeIdx } as Instr,
+      ],
+      else: nullThis,
+    } as unknown as Instr,
+  ];
+}
+
+/**
  * #1118: Emit an object-literal method as a first-class closure value.
  *
  * Object-literal methods are compiled as Wasm functions with signature
@@ -3404,10 +3449,13 @@ export function emitObjectMethodAsClosure(
 
   // Create the trampoline. Signature matches the wrapper's lifted func
   // type: (closure_self, ...userParams) → ret. We ignore closure_self,
-  // push ref.null <objStruct> for the method's self_obj, then forward
-  // the user params.
+  // resolve the method's self_obj from `__current_this` (#2015 — falls back
+  // to `ref.null` for the unbound method-extraction case), then forward the
+  // user params.
   const trampolineName = `__obj_meth_tramp_${methodName}_${ctx.closureCounter++}`;
-  const trampolineBody: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx } as Instr];
+  // anyref temp at the first slot past the params (closure_self + userParams).
+  const anyTempLocalIdx = 1 + userParams.length;
+  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
   for (let i = 0; i < userParams.length; i++) {
     // Skip closure_self at param 0; user params start at index 1
     trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
@@ -3418,7 +3466,7 @@ export function emitObjectMethodAsClosure(
   ctx.mod.functions.push({
     name: trampolineName,
     typeIdx: liftedFuncTypeIdx,
-    locals: [],
+    locals: [{ name: "__this_any", type: { kind: "anyref" } }],
     body: trampolineBody,
     exported: false,
   });
@@ -3559,9 +3607,18 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
     };
 
     // (#1340) Function-decl trampolines have no `this` prologue; method
-    // trampolines emit `ref.null <objStruct>` as the receiver before
-    // forwarding user params.
-    const newBody: Instr[] = t.noThisParam ? [] : [{ op: "ref.null", typeIdx: t.objStructTypeIdx } as Instr];
+    // trampolines resolve the receiver from `__current_this` (#2015, falling
+    // back to `ref.null` for the unbound method-extraction case) before
+    // forwarding user params. The anyref scratch local is allocated through
+    // `tFctx` so it lands in `localDefs` (attached to the registered function
+    // below) and any later coercion temps allocate after it.
+    let newBody: Instr[];
+    if (t.noThisParam) {
+      newBody = [];
+    } else {
+      const anyTempLocalIdx = allocTempLocal(tFctx, { kind: "anyref" });
+      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx);
+    }
     for (let i = 0; i < methodUserParams.length; i++) {
       newBody.push({ op: "local.get", index: i + 1 } as Instr);
       const from = wrapperUserParams[i];
@@ -3633,9 +3690,17 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
     // coercion allocated for this trampoline. The function is located by body
     // identity (not by `trampolineFuncIdx`, which may have shifted): the
     // registered trampoline holds the SAME `t.trampolineBody` array reference.
-    if (localDefs.length > 0) {
+    //
+    // (#2015) The rebuilt body's local indices are computed against `tFctx`,
+    // whose `locals` (`localDefs`) start empty — so the `__current_this` anyref
+    // scratch lands at the first slot past the wrapper params and any coercion
+    // temps after it. The initial emit pre-seeded the function with a single
+    // `__this_any` anyref local at that SAME index, so REPLACE the function's
+    // locals with `localDefs` (rather than append) to keep the persisted layout
+    // in lockstep with the rebuilt body; an append would shift every temp by one.
+    if (!t.noThisParam || localDefs.length > 0) {
       const func = ctx.mod.functions.find((f) => f.body === t.trampolineBody);
-      if (func) func.locals.push(...localDefs);
+      if (func) func.locals = localDefs;
     }
     t.trampolineBody.length = 0;
     t.trampolineBody.push(...newBody);
@@ -3687,14 +3752,14 @@ export function emitCachedMethodClosureAccess(
   const trampolineName = `__obj_meth_tramp_${methodName}_cached`;
   let trampolineFuncIdx = ctx.funcMap.get(trampolineName);
   if (trampolineFuncIdx === undefined) {
-    // Trampoline body: drop the closure-self arg (param 0), push
-    // `ref.null <objStruct>` for the method's `this` (matches the
-    // per-call-site emitObjectMethodAsClosure semantics — JS strict
-    // mode `var fn = c.m; fn();` calls with `this = undefined`, so a
-    // null receiver propagates the spec-mandated TypeError on
-    // `this.field` access), then forward user params, then call the
-    // method.
-    const trampolineBody: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx } as Instr];
+    // Trampoline body: drop the closure-self arg (param 0), resolve the
+    // method's `this` from `__current_this` (#2015 — falls back to
+    // `ref.null` for the unbound method-extraction case `var fn = c.m;
+    // fn();` where JS strict mode calls with `this = undefined`, so the
+    // null receiver propagates the spec-mandated TypeError on `this.field`
+    // access), then forward user params, then call the method.
+    const anyTempLocalIdx = 1 + userParams.length;
+    const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
     for (let i = 0; i < userParams.length; i++) {
       trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
     }
@@ -3703,7 +3768,7 @@ export function emitCachedMethodClosureAccess(
     ctx.mod.functions.push({
       name: trampolineName,
       typeIdx: liftedFuncTypeIdx,
-      locals: [],
+      locals: [{ name: "__this_any", type: { kind: "anyref" } }],
       body: trampolineBody,
       exported: false,
     });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1810,7 +1810,15 @@ function _wrapWasmClosureUnknownArity(
     for (let i = 0; i < arity; i++) padded.push(args[i]);
     const methodCallFn = exports[`__call_fn_method_${arity}`];
     if (typeof methodCallFn === "function" && this !== undefined && this !== globalThis) {
-      return methodCallFn(this, closure, ...padded);
+      // (#2015) Unwrap a `_wrapForHost` proxy receiver back to its raw WasmGC
+      // struct before installing it as `__current_this`. `__extern_method_call`
+      // dispatches `fn.apply(wrappedObj, …)` with `wrappedObj` being the host
+      // proxy, so without this unwrap `__call_fn_method_N` would install the
+      // opaque Proxy as `__current_this`; the object-literal method trampoline's
+      // `ref.test (ref objStruct)` then fails and the body's `this.<field>` traps.
+      // Mirrors the known-arity bridge in `_wrapWasmClosure` (#1712 / #1320).
+      const rawThis = this !== null && typeof this === "object" ? _unwrapForHost(this) : this;
+      return methodCallFn(_isWasmStruct(rawThis) ? rawThis : this, closure, ...padded);
     }
     return callFn(closure, ...padded);
   };
@@ -4238,7 +4246,32 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
         const callFn1 = exports["__call_fn_1"];
         const callFn2 = exports["__call_fn_2"];
         if (typeof callFn0 === "function" || typeof callFn1 === "function" || typeof callFn2 === "function") {
+          // (#2015) Method-`this` threading. When this closure field is invoked
+          // as a METHOD (`o.m()` on an any/externref receiver routes through
+          // `__extern_method_call` → `fn.apply(wrappedObj, …)`), the bridge's
+          // `this` is the host-mirror proxy for the receiver struct. Dispatch
+          // through `__call_fn_method_N` so the compiled method body's
+          // `this.<field>` observes the receiver via the `__current_this` global
+          // (#1636-S1) / the object-method trampoline's receiver slot. Unwrap
+          // the proxy to the raw struct first (mirrors `_wrapWasmClosure`).
+          // A bare/undefined/globalThis `this` (extraction call `const f = o.m;
+          // f()`) keeps the plain `__call_fn_N` path so the spec-mandated
+          // unbound-`this` semantics are preserved unchanged.
+          const mcall0 = exports["__call_fn_method_0"];
+          const mcall1 = exports["__call_fn_method_1"];
+          const mcall2 = exports["__call_fn_method_2"];
           return function closureBridge(this: any, ...args: any[]) {
+            const hasRecv = this !== undefined && this !== null && this !== globalThis;
+            const rawThis = hasRecv && typeof this === "object" ? _unwrapForHost(this) : this;
+            const recv = _isWasmStruct(rawThis) ? rawThis : undefined;
+            if (recv !== undefined) {
+              if (args.length === 0 && typeof mcall0 === "function") return mcall0(recv, val);
+              if (args.length === 1 && typeof mcall1 === "function") return mcall1(recv, val, args[0]);
+              if (args.length >= 2 && typeof mcall2 === "function") return mcall2(recv, val, args[0], args[1]);
+              if (typeof mcall1 === "function") return mcall1(recv, val, args[0]);
+              if (typeof mcall0 === "function") return mcall0(recv, val);
+              if (typeof mcall2 === "function") return mcall2(recv, val, args[0], args[1]);
+            }
             if (args.length === 0 && typeof callFn0 === "function") return callFn0(val);
             if (args.length === 1 && typeof callFn1 === "function") return callFn1(val, args[0]);
             if (args.length >= 2 && typeof callFn2 === "function") return callFn2(val, args[0], args[1]);

--- a/tests/issue-2015.test.ts
+++ b/tests/issue-2015.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2015 — a method call using `this` on an any-typed object-literal receiver
+// threw a bare WebAssembly.Exception.
+//
+// `const o: any = { x: 21, getx() { return this.x; } }; o.getx()` dispatches
+// through the JS host (`__extern_method_call` for a 0-arg call, or the
+// `_wrapForHost` proxy `get` trap's generic closureBridge fallback for the
+// callable-field read). That bridge invoked the compiled method via the plain
+// `__call_fn_N` dispatcher, which never installs `__current_this`; the
+// object-literal method trampoline then forwarded a NULL receiver struct, so
+// `this.<field>` (a `struct.get` on null) trapped.
+//
+// Two coordinated fixes:
+//   - runtime: the closureBridge / dynamic-bridge dispatch through
+//     `__call_fn_method_N` (unwrapping the host-mirror proxy to the raw
+//     struct) when invoked with a real receiver, preserving the plain path
+//     for unbound extraction calls (`const f = o.m; f()`).
+//   - codegen: the object-method trampoline reads `__current_this` for its
+//     `this` slot (cast to the object struct, null fallback) instead of a
+//     hardcoded `ref.null`.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2015 — any-receiver object-literal method this-threading", () => {
+  it("reads this.<field> on an any-typed receiver (the repro)", async () => {
+    expect(
+      await run(`const o: any = { x: 21, getx() { return this.x; } };
+        export function test(): number { return o.getx(); }`),
+    ).toBe(21);
+  });
+
+  it("typed-receiver method call is unchanged", async () => {
+    expect(
+      await run(`const o = { x: 21, getx() { return this.x; } };
+        export function test(): number { return o.getx(); }`),
+    ).toBe(21);
+  });
+
+  it("a method that does not read this is unchanged", async () => {
+    expect(
+      await run(`const o: any = { getx() { return 5; } };
+        export function test(): number { return o.getx(); }`),
+    ).toBe(5);
+  });
+
+  it("threads this through a one-argument method (this.x + n)", async () => {
+    expect(
+      await run(`const o: any = { x: 21, addNum(n: number) { return this.x + n; } };
+        export function test(): number { return o.addNum(4); }`),
+    ).toBe(25);
+  });
+
+  it("threads this through a two-argument method", async () => {
+    expect(
+      await run(`const o: any = { base: 10, combine(a: number, b: number) { return this.base + a + b; } };
+        export function test(): number { return o.combine(2, 3); }`),
+    ).toBe(15);
+  });
+
+  it("mutates this.<field> across successive method calls", async () => {
+    expect(
+      await run(`const o: any = { x: 21, inc() { this.x = this.x + 1; return this.x; } };
+        export function test(): number { o.inc(); return o.inc(); }`),
+    ).toBe(23);
+  });
+
+  it("threads this through a nested method-to-method call", async () => {
+    expect(
+      await run(`const o: any = {
+          x: 10,
+          getx() { return this.x; },
+          both() { return this.getx() + this.x; }
+        };
+        export function test(): number { return o.both(); }`),
+    ).toBe(20);
+  });
+});


### PR DESCRIPTION
## Problem

```ts
const o: any = { x: 21, getx() { return this.x; } };
o.getx()   // wasm: bare WebAssembly.Exception   node: 21
```

A method call using `this` on an **any-typed** object-literal receiver threw a bare `WebAssembly.Exception`. A typed receiver (`const o = {...}`) worked.

## Root cause (corrected — verified by WAT-tracing on current main)

Both the issue's original diagnosis (`__extern_method_call` routing) and the suspended-work corrected diagnosis (static `__call_fn_0`/`call_ref`) were inaccurate against current HEAD. The receiver was lost across the JS-host closure dispatch on **three layers**:

1. **Runtime** — the `_wrapForHost` proxy `get`-trap generic `closureBridge` fallback (and the `_wrapWasmClosureUnknownArity` dynamic bridge) invoked the closure via the plain `__call_fn_N` dispatcher, which never installs `__current_this`, so `this` was discarded before the method body ran.
2. **Codegen** — the object-method trampoline that bridges the closure ABI `(closure_self, …args)` to the method ABI `(this_struct, …args)` **hardcoded `ref.null`** for the method's `this` slot. So `this.<field>` = `struct.get` on null → trap.

## Fix

- **`src/runtime.ts`**: the `closureBridge` fallback + dynamic bridge now dispatch through `__call_fn_method_N` (unwrapping the host-mirror proxy to the raw struct via `_unwrapForHost`, gated on `_isWasmStruct`) when a real receiver is present. Bare/undefined/globalThis `this` (unbound extraction `const f = o.m; f()`) keeps the plain `__call_fn_N` path — spec-mandated unbound-`this` semantics unchanged.
- **`src/codegen/closures.ts`**: new `buildTrampolineThisSlot` helper — the trampoline reads `__current_this`, `ref.test`s it as the object struct, casts when it matches, else `ref.null`. Mirrors the null-guarded `__current_this` read lifted closure bodies already use for `ThisKeyword` (#1702). Applied to the per-call-site, cached class/proto, and `finalizeMethodTrampolines` rebuild paths.

## Acceptance criteria

- [x] Repro returns 21; typed-receiver calls unchanged
- [x] no-`this` method unchanged

## Tests

`tests/issue-2015.test.ts` (7 cases): 0/1/2-arg this-threading, `this.x` mutation across calls, nested method-to-method `this`. All pass.

## Regression verification

Full `tests/equivalence/` suite: **identical 55/55 failing-test set vs `origin/main`** (verified by swapping the original `closures.ts`/`runtime.ts` back in — same per-file and per-test counts). WASI/standalone object- and class-method modules validate. This/closure regression suites (`#1636-S1`, `#1702`, `#1712`, `#1742`, `#1669`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)