### PR TITLE
fix(ci #2149): refresh-baseline.yml pushes main audit commit via MAIN_DEPLOY_KEY, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -199,6 +199,14 @@ jobs:
     name: merge shards and promote baseline
     needs: test262-shard
     runs-on: ubuntu-latest
+    # (#3) The main-repo audit-commit push uses the MAIN_DEPLOY_KEY SSH deploy
+    # key (the only auth path in the ruleset's bypass_actors — DeployKey:always),
+    # because the GITHUB_TOKEN origin push is rejected by ruleset GH013. The key
+    # is gated behind the `baseline-promote` Environment (deployment branch
+    # restricted to `main`), exactly like test262-sharded.yml's promote-baseline
+    # and baseline-summary-sync.yml. Declaring the environment is what makes the
+    # ENVIRONMENT-scoped secret resolvable here.
+    environment: baseline-promote
 
     steps:
       - name: Checkout
@@ -335,8 +343,26 @@ jobs:
             git push
           fi
 
+      # (#3) Push the audit commit to main over the SSH deploy-key remote — that
+      # auth path is in the ruleset's bypass_actors (DeployKey: always), so it is
+      # NOT rejected by GH013 the way the GITHUB_TOKEN `origin` push is. The
+      # previous `git pull --rebase origin main && git push` here authenticated
+      # with the checkout's GITHUB_TOKEN and was BLOCKED by GH013, freezing the
+      # committed baseline even on this emergency-recovery workflow (the exact
+      # drift-deadlock this step is supposed to BREAK). Mirrors the proven
+      # Option-A re-anchor loop (#1861) in test262-sharded.yml's promote-baseline
+      # and baseline-summary-sync.yml: snapshot the small promote JSON files,
+      # hard-checkout a CLEAN tip of main on each attempt, re-apply, commit
+      # [skip ci], push via the deploy key, retry on the merge-queue race.
       - name: Commit FORCED baseline refresh (audit trail)
+        env:
+          MAIN_DEPLOY_KEY: ${{ secrets.MAIN_DEPLOY_KEY }}
         run: |
+          set -uo pipefail
+          if [ -z "${MAIN_DEPLOY_KEY:-}" ]; then
+            echo "::error::MAIN_DEPLOY_KEY secret is empty/unset (environment baseline-promote). The main-repo baseline push needs the private half of the loopdive/js2 'MAIN_DEPLOY_KEY' deploy key — GITHUB_TOKEN is blocked by ruleset GH013."
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Stage only the small JSON files and generated edition buckets (JSONL lives in baselines repo, not main).
@@ -353,25 +379,64 @@ jobs:
           PASS=${{ steps.sanity.outputs.pass }}
           TOTAL=${{ steps.sanity.outputs.total }}
           ACTOR="${{ github.actor }}"
-          git commit -m "chore(test262): FORCED baseline refresh by ${ACTOR} — ${PASS}/${TOTAL} pass [skip ci]"
-          if ! git pull --rebase origin main; then
-            git rebase --abort 2>/dev/null || true
-            git fetch origin main
-            git reset --hard origin/main
-            cp merged-reports/test262-results-merged.jsonl benchmarks/results/test262-current.jsonl
-            cp merged-reports/test262-report-merged.json benchmarks/results/test262-current.json
-            cp merged-reports/test262-report-merged.json benchmarks/results/test262-report.json
-            cp merged-reports/test262-report-merged.json public/benchmarks/results/test262-report.json
-            node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
-            git add -f benchmarks/results/test262-current.json \
-              benchmarks/results/test262-report.json \
-              public/benchmarks/results/test262-report.json \
-              website/public/benchmarks/results/test262-editions.json \
-              website/public/benchmarks/results/test262-category-editions.json
-            git diff --cached --quiet && exit 0
+
+          # --- Set up the SSH deploy key (mirrors the baselines-repo push step
+          # above and the promote-baseline / summary-sync main pushes). ---
+          eval "$(ssh-agent -s)"
+          echo "$MAIN_DEPLOY_KEY" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git remote remove deploykey 2>/dev/null || true
+          git remote add deploykey "git@github.com:${GITHUB_REPOSITORY}.git"
+          # The shard run can leave the test262 submodule dirty — keep it from
+          # blocking the clean re-anchor checkout below.
+          git config submodule.test262.ignore all || true
+          git config diff.ignoreSubmodules dirty || true
+
+          # Option A re-anchor loop (#1861): snapshot the staged promote files,
+          # hard-checkout a clean tip of main on every attempt, re-apply, commit
+          # [skip ci] (prevents self-retrigger), push via the deploy key, retry
+          # on the merge-queue advance race.
+          PROMOTE_FILES=$(git diff --cached --name-only)
+          echo "Promote files staged for main:"; echo "$PROMOTE_FILES" | sed 's/^/  /'
+          PROMOTE_SNAPSHOT="$(mktemp -d)"
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            mkdir -p "$PROMOTE_SNAPSHOT/$(dirname "$f")"
+            cp "$f" "$PROMOTE_SNAPSHOT/$f"
+          done <<< "$PROMOTE_FILES"
+          PUSHED=0
+          for attempt in 1 2 3 4 5; do
+            git fetch deploykey main
+            git checkout -f -B _emergency_promote_tmp deploykey/main || {
+              echo "checkout of deploykey/main failed (attempt ${attempt}) — retrying"
+              sleep $((attempt * 5))
+              continue
+            }
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              mkdir -p "$(dirname "$f")"
+              cp "$PROMOTE_SNAPSHOT/$f" "$f"
+              git add -f "$f"
+            done <<< "$PROMOTE_FILES"
+            if git diff --cached --quiet; then
+              echo "Baseline already current on main after re-anchor — nothing to push."
+              PUSHED=1
+              break
+            fi
             git commit -m "chore(test262): FORCED baseline refresh by ${ACTOR} — ${PASS}/${TOTAL} pass [skip ci]"
+            if git push deploykey HEAD:main; then
+              echo "Pushed FORCED baseline refresh to main via deploy key (${PASS}/${TOTAL} pass, attempt ${attempt})."
+              PUSHED=1
+              break
+            fi
+            echo "push race lost (attempt ${attempt}) — re-anchoring on latest main and retrying"
+            sleep $((attempt * 5))
+          done
+          if [ "$PUSHED" != "1" ]; then
+            echo "::error::Failed to push refreshed baseline to main after 5 attempts (persistent, not a transient race)."
+            exit 1
           fi
-          git push
 
       - name: Trigger Pages deploy
         if: success()

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -119,6 +119,22 @@ Two test262 workflows currently run on PRs:
     summary) and the `js2wasm-baselines` repo's `test262-current.jsonl`
     (history feed for the trend chart). The `refresh-committed-baseline.yml`
     workflow consumes the sharded artifact to sync the committed JSONL.
+  - **Baseline pushes to `main` MUST authenticate with the `MAIN_DEPLOY_KEY`
+    SSH deploy key, never `GITHUB_TOKEN`.** The deploy key is the only auth
+    path in this ruleset's `bypass_actors` (DeployKey: `always`); a
+    `GITHUB_TOKEN`-authenticated push to `main` is rejected by ruleset GH013
+    ("Changes must be made through a pull request") and silently FREEZES the
+    committed baseline while the `js2wasm-baselines` repo moves on — the
+    drift deadlock (regression gates go blind; phantom ~500-test regression
+    in `git status` / fresh clones). All three baseline-promoting jobs use
+    the deploy key + the `baseline-promote` Environment (deployment branch
+    restricted to `main`): `promote-baseline` (test262-sharded.yml), the
+    scheduled `sync` (baseline-summary-sync.yml), and the manual emergency
+    `merge-and-promote` (refresh-baseline.yml). PR #725/#896 and #3 each
+    regressed one of these back onto `GITHUB_TOKEN`; do NOT swap any of them
+    back. If GH013 recurs, first confirm the ruleset still lists the
+    `DeployKey: always` bypass actor
+    (`gh api /repos/loopdive/js2/rulesets/16700772 --jq .bypass_actors`).
   - The `check for test262 regressions` job is also required. It compares
     the merged PR report against the baseline and catches full pass→fail
     regressions even when the inline hard guards inside `merge shard reports`

--- a/plan/issues/2149-ci-refresh-baseline-github-token-gh013-deadlock.md
+++ b/plan/issues/2149-ci-refresh-baseline-github-token-gh013-deadlock.md
@@ -1,0 +1,95 @@
+---
+id: 2149
+title: "emergency refresh-baseline.yml pushes the main audit commit with GITHUB_TOKEN → GH013-blocked → drift deadlock"
+status: done
+sprint: 62
+created: 2026-06-14
+updated: 2026-06-14
+completed: 2026-06-14
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: ci-infra
+area: ci
+related: [1078, 1080, 1668, 1861, 1951]
+origin: "2026-06-13 drift deadlock — baseline froze; resolved manually via refresh + admin-merges"
+---
+
+# #2149 — refresh-baseline.yml main push uses GITHUB_TOKEN (GH013-blocked)
+
+## Problem
+
+On 2026-06-13 the regression baseline froze: the test262 promote pipeline's
+push to `main` failed with **GH013** ("Changes must be made through a pull
+request"), so the committed `benchmarks/results/test262-current.json` stopped
+advancing while the `js2wasm-baselines` repo moved on. That blinds the
+regression gates (stale-baseline guard trips) — the drift deadlock. It was
+unstuck manually (forced refresh + admin merges).
+
+## Root cause
+
+The `merge-and-promote` job in `.github/workflows/refresh-baseline.yml` (the
+ONE-CLICK EMERGENCY RECOVERY workflow) committed the main-repo audit refresh
+and pushed it with:
+
+```yaml
+- name: Checkout
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+...
+- name: Commit FORCED baseline refresh (audit trail)
+  run: |
+    ...
+    git pull --rebase origin main
+    git push          # ← GITHUB_TOKEN origin push → GH013 BLOCKED
+```
+
+The ruleset on `main` only bypasses GH013 for **DeployKey (always)** actors.
+A `GITHUB_TOKEN`-authenticated push to a protected branch is rejected. So the
+emergency recovery tool itself could not land its baseline — exactly the
+deadlock it exists to break.
+
+`test262-sharded.yml`'s `promote-baseline` and `baseline-summary-sync.yml`'s
+`sync` already push via the `MAIN_DEPLOY_KEY` SSH deploy key (deploy-key
+bypass + the `baseline-promote` Environment). Only `refresh-baseline.yml` had
+the GITHUB_TOKEN gap — a partial regression of the same kind #725/#896 (PR
+a8f72e6cf) introduced and #490 first fixed.
+
+## Fix (this PR)
+
+- `.github/workflows/refresh-baseline.yml`:
+  - Added `environment: baseline-promote` to `merge-and-promote` so the
+    ENVIRONMENT-scoped `MAIN_DEPLOY_KEY` secret resolves.
+  - Replaced the GITHUB_TOKEN `git pull --rebase origin main && git push` with
+    the proven `MAIN_DEPLOY_KEY` SSH deploy-key push + Option-A re-anchor loop
+    (#1861): snapshot the small promote JSON files, hard-checkout a clean tip
+    of `main` per attempt, re-apply, commit `[skip ci]`, `git push deploykey
+    HEAD:main`, retry on the merge-queue advance race. Fails loudly if the
+    secret is missing.
+- `docs/ci-policy.md`: documented the hard invariant — **baseline pushes to
+  `main` MUST use `MAIN_DEPLOY_KEY`, never `GITHUB_TOKEN`** (GH013) — with the
+  list of all three baseline-promoting jobs and a `gh api … bypass_actors`
+  recovery check.
+
+## Why not "route promotion through the merge queue" (the task's Option A)
+
+The #1951 design DEFERS even `[skip ci]` main pushes while the merge queue is
+non-empty, because any push to `main` makes GitHub rebuild EVERY queued merge
+group (114-job validation × N PRs + ~10 min latency). Routing the baseline
+THROUGH the queue as a PR would re-introduce exactly that full-validation cost
+per promotion — fighting the existing architecture. The deploy-key bypass is
+the intended, low-cost path; the only bug was one job not using it. Fixed at
+the root rather than re-architecting around it.
+
+## Verification
+
+- YAML parses (js-yaml). `environment: baseline-promote` present on the job.
+- No `GITHUB_TOKEN`-authenticated push to `main` remains in the workflow (the
+  one remaining `git push` is the baselines-repo push under
+  `/tmp/js2wasm-baselines`, which uses `BASELINE_DEPLOY_KEY`).
+- The current ruleset still lists `DeployKey: always` in `bypass_actors`
+  (verified via `gh api /repos/loopdive/js2/rulesets/16700772`), so the
+  deploy-key path is unblocked.
+- Full end-to-end exercise requires a `workflow_dispatch` run with the
+  MAIN_DEPLOY_KEY environment secret — to be validated by the tech lead on the
+  next emergency refresh (or a dry dispatch).


### PR DESCRIPTION
## Problem

On 2026-06-13 the regression baseline froze: the test262 promote pipeline's push to `main` hit **GH013** ("Changes must be made through a pull request"), so the committed `benchmarks/results/test262-current.json` stopped advancing while `js2wasm-baselines` moved on — the **drift deadlock** (regression gates go blind). Unstuck manually (forced refresh + admin merges).

## Root cause

The `merge-and-promote` job in **`.github/workflows/refresh-baseline.yml`** — the one-click *emergency recovery* workflow — committed the main-repo audit refresh and pushed it with the checkout's `GITHUB_TOKEN`:

```yaml
- name: Checkout
  with: { token: ${{ secrets.GITHUB_TOKEN }} }
...
  git pull --rebase origin main && git push   # ← GITHUB_TOKEN → GH013 BLOCKED
```

The `main` ruleset only bypasses GH013 for **DeployKey (always)**. So the recovery tool itself couldn't land its baseline — exactly the deadlock it exists to break. `test262-sharded.yml`'s `promote-baseline` and `baseline-summary-sync.yml`'s `sync` already push via the `MAIN_DEPLOY_KEY` SSH deploy key; only `refresh-baseline.yml` had the gap (a partial regression of the same `GITHUB_TOKEN` mistake #725/#896 made and #490 first fixed).

## Fix

- **`refresh-baseline.yml`**: add `environment: baseline-promote` to `merge-and-promote` (so the env-scoped `MAIN_DEPLOY_KEY` resolves); replace the `GITHUB_TOKEN` `git pull --rebase origin main && git push` with the proven `MAIN_DEPLOY_KEY` SSH deploy-key push + Option-A re-anchor loop (#1861) used by the other two promoters. Fails loudly if the secret is unset.
- **`docs/ci-policy.md`**: document the hard invariant — baseline pushes to `main` MUST use `MAIN_DEPLOY_KEY`, never `GITHUB_TOKEN` (GH013) — listing all three promoting jobs + a `bypass_actors` recovery check.

## Why NOT route promotion through the merge queue (the task's Option A)

The #1951 design **defers even `[skip ci]` main pushes while the queue is non-empty**, because any push to `main` rebuilds EVERY queued merge group (114-job validation × N PRs + ~10 min latency). Routing the baseline THROUGH the queue as a PR would re-introduce exactly that full-validation cost per promotion — fighting the existing architecture. The deploy-key bypass is the intended low-cost path; the only bug was one job not using it. Fixed at the root.

## Verification

- YAML parses (js-yaml); `environment: baseline-promote` present on the job.
- No `GITHUB_TOKEN` push to `main` remains (the one remaining `git push` is the baselines-repo push under `/tmp/js2wasm-baselines` via `BASELINE_DEPLOY_KEY`).
- The ruleset still lists `DeployKey: always` in `bypass_actors` (`gh api /repos/loopdive/js2/rulesets/16700772`), so the deploy-key path is unblocked.
- End-to-end exercise needs a `workflow_dispatch` run with the `MAIN_DEPLOY_KEY` environment secret — to validate on the next emergency refresh or a dry dispatch.

Closes the recurrence vector for the 2026-06-13 deadlock (#2149; related #1078/#1080/#1668/#1861/#1951).

🤖 Generated with [Claude Code](https://claude.com/claude-code)