### PR TITLE
fix(#2046): standalone Reflect PR-A (fail-loud) + PR-B (delete configurability)

### DIFF
--- a/plan/issues/2046-standalone-reflect-spec-gaps.md
+++ b/plan/issues/2046-standalone-reflect-spec-gaps.md
@@ -1,10 +1,10 @@
 ---
 id: 2046
 title: "standalone Reflect: receiver arg silently dropped, deleteProperty ignores freeze/configurable, no ToPropertyKey (#1905 follow-up)"
-status: ready
+status: in-progress
 sprint: Backlog
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -86,3 +86,58 @@ non-string-key cases; the `fallbackReturn(n, "i32-true")` dead branch at
 - tests/issue-1905.test.ts extended with proto-chain, frozen-delete,
   numeric-key, and receiver cases; standalone test262
   `built-ins/Reflect/{get,set,has,deleteProperty}` rows improve.
+
+## Resolution — PR-A + PR-B (2026-06-14)
+
+PR-A (defects 1 + 3a) and PR-B (defect 2) landed; PR-C (real receiver) is
+senior/deferred and PR-D (ToPropertyKey) rides #2042 — both remain, so this
+issue stays `in-progress`.
+
+**PR-A — restore fail-loud** (`src/codegen/expressions/calls.ts`, all inside
+`if (ctx.standalone)`):
+- **Defect 1 (receiver mis-bind):** `Reflect.get`/`Reflect.set` now refuse
+  loudly (`reportError`) when an explicit receiver is present
+  (`arguments.length > 2` / `> 3`) instead of evaluating-then-dropping it (which
+  silently bound `this = target` for accessors, §28.1.5/§28.1.12 →
+  §10.1.8/§10.1.9). Removed the now-dead `emitAndDropOptionalArg`.
+- **Defect 3a (non-object deleteProperty):** added a CALL-SITE `ref.test $Object`
+  guard on the target; a non-`$Object` target throws a catchable TypeError
+  (`emitThrowTypeError`, §28.1.4). The SHARED `__delete_property` helper is
+  untouched (sloppy `delete primitive[k]` stays a no-op success).
+- Cleanup: the boolean-Reflect `fallbackReturn` dead branches now return
+  `i32-false` (registration-failure default), not a phantom `true`.
+
+**PR-B — delete configurability/integrity preflight**
+(`src/codegen/object-runtime.ts`, `__delete_property`):
+- After finding a live entry, refuse (return 0, keep the prop) when the object
+  is sealed/frozen **OR** the entry is non-configurable
+  (`FLAG_CONFIGURABLE` cleared), per §10.1.10 OrdinaryDelete.
+- **Verified subtlety:** `__object_freeze`/`__object_seal` set only the
+  object-level `$Object.flags` `OBJ_FLAG_SEALED` bit and do NOT clear each
+  entry's `FLAG_CONFIGURABLE`, so the preflight checks BOTH the object
+  `OBJ_FLAG_SEALED` bit and the per-entry `FLAG_CONFIGURABLE` bit.
+  `Object.preventExtensions` (NONEXTENSIBLE only, not SEALED) does NOT block
+  delete — confirmed. Correct for both `Reflect.deleteProperty` and sloppy
+  `delete` (§13.5.1.2 — both refuse a non-configurable own prop).
+
+**Remaining (out of this PR):**
+- **PR-C (real receiver plumbing)** — senior/deferred, coordinates with #1888
+  Slice 5 accessor-invocation machinery.
+- **PR-D (ToPropertyKey)** — `Reflect.get(o, 1)` still traps ("illegal cast" on
+  `ref.cast $AnyString` in `__obj_hash`). This is the SAME numeric-key fix as
+  #2042 PR-A; reuse #2042's shared key-coercion helper once it lands rather than
+  duplicating. Coordinated with dev-b.
+
+## Test Results (2026-06-14)
+
+- `tests/issue-2046.test.ts` (new) — 10/10: explicit-receiver refusal (get+set),
+  no-receiver get/set work, non-object deleteProperty throws TypeError,
+  object deleteProperty deletes, frozen/sealed deleteProperty → false + kept,
+  preventExtensions delete still succeeds, sloppy delete honors freeze, sloppy
+  delete normal succeeds.
+- `tests/issue-1905.test.ts` — green (4/4, no regression).
+- Pre-existing unrelated failures (byte-identical to origin/main, untouched by
+  this change): `tests/object-define-property.test.ts` /
+  `tests/delete-operator.test.ts` import the broken `tests/helpers.js`;
+  `tests/equivalence/reflect-api.test.ts` "Reflect.construct creates a new
+  instance" fails identically on clean origin/main (host-mode, not standalone).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -19,7 +19,7 @@ import {
 } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } from "../array-methods.js";
-import { ensureObjVecBuilders } from "../object-runtime.js";
+import { ensureObjVecBuilders, ensureObjectRuntime } from "../object-runtime.js";
 import {
   emitStandalonePromiseReject,
   emitStandalonePromiseResolve,
@@ -5348,10 +5348,13 @@ function compileCallExpression(
       };
 
       // Helper — drop N pushed args and return a fallback constant when the import is unavailable.
-      const fallbackReturn = (n: number, ret: "i32-true" | "extern-null"): InnerResult => {
+      // (#2046 cleanup) `i32-false` is the safer default for boolean-returning
+      // Reflect methods on a registration failure (the module is already marked
+      // failed by reportError; false is the less-wrong observable value).
+      const fallbackReturn = (n: number, ret: "i32-true" | "i32-false" | "extern-null"): InnerResult => {
         for (let i = 0; i < n; i++) fctx.body.push({ op: "drop" });
-        if (ret === "i32-true") {
-          fctx.body.push({ op: "i32.const", value: 1 });
+        if (ret === "i32-true" || ret === "i32-false") {
+          fctx.body.push({ op: "i32.const", value: ret === "i32-true" ? 1 : 0 });
           return { kind: "i32" };
         }
         fctx.body.push({ op: "ref.null.extern" });
@@ -5385,24 +5388,25 @@ function compileCallExpression(
       //   native analog in this slice. Descriptor/prototype/integrity methods
       //   stay refused until their native invariants are proven end-to-end.
       if (ctx.standalone) {
-        const emitAndDropOptionalArg = (index: number): void => {
-          const arg = expr.arguments[index];
-          if (arg === undefined) return;
-          const argTy = compileExpression(ctx, fctx, arg, externRef);
-          if (argTy && argTy.kind !== "externref") {
-            coerceType(ctx, fctx, argTy, externRef);
-          } else if (argTy === null) {
-            fctx.body.push({ op: "ref.null.extern" });
-          }
-          fctx.body.push({ op: "drop" });
-        };
-
         if (reflectMethod === "get" && expr.arguments.length >= 2) {
+          // (#2046 PR-A defect 1) The native __extern_get has no separate
+          // receiver slot — an explicit receiver was previously evaluated and
+          // SILENTLY DROPPED, so accessor getters (live since #1888 S5b) ran
+          // with `this = target` instead of `receiver` (§28.1.5 → §10.1.8).
+          // Until real receiver plumbing (PR-C, senior/deferred), refuse loudly
+          // rather than mis-bind `this` — restores the #1888 fail-loud invariant.
+          if (expr.arguments.length > 2) {
+            reportError(
+              ctx,
+              expr,
+              "Codegen error: Reflect.get with an explicit receiver argument is not yet supported " +
+                "in --target standalone (#2046); the receiver would be silently dropped and accessor " +
+                "getters would bind `this` to the target instead of the receiver.",
+            );
+            fctx.body.push({ op: "ref.null.extern" });
+            return { kind: "externref" };
+          }
           emitReflectArgs(2);
-          // Evaluate the optional receiver for call argument side effects. The
-          // existing native __extern_get helper has no separate receiver slot,
-          // so this slice supports the data-property/default-receiver subset.
-          emitAndDropOptionalArg(2);
           const funcIdx = ensureLateImport(ctx, "__extern_get", [externRef, externRef], [externRef]);
           flushLateImportShifts(ctx, fctx);
           if (funcIdx !== undefined) {
@@ -5413,17 +5417,30 @@ function compileCallExpression(
         }
 
         if (reflectMethod === "set" && expr.arguments.length >= 2) {
+          // (#2046 PR-A defect 1) Same as Reflect.get: __reflect_set writes the
+          // data-property subset on `target` itself and has no receiver slot, so
+          // an explicit receiver was evaluated then dropped — writing to the
+          // wrong object for accessor setters (§28.1.12 → §10.1.9). Refuse
+          // loudly with an explicit receiver until PR-C lands.
+          if (expr.arguments.length > 3) {
+            reportError(
+              ctx,
+              expr,
+              "Codegen error: Reflect.set with an explicit receiver argument is not yet supported " +
+                "in --target standalone (#2046); the receiver would be silently dropped and accessor " +
+                "setters would write to the target instead of the receiver.",
+            );
+            fctx.body.push({ op: "i32.const", value: 0 });
+            return { kind: "i32" };
+          }
           emitReflectArgs(3);
-          // Evaluate the optional receiver for side effects. __extern_set writes
-          // the supported open-object data-property subset on target itself.
-          emitAndDropOptionalArg(3);
           const funcIdx = ensureLateImport(ctx, "__reflect_set", [externRef, externRef, externRef], [i32Ty]);
           flushLateImportShifts(ctx, fctx);
           if (funcIdx !== undefined) {
             fctx.body.push({ op: "call", funcIdx });
             return { kind: "i32" };
           }
-          return fallbackReturn(3, "i32-true");
+          return fallbackReturn(3, "i32-false");
         }
 
         if (reflectMethod === "has" && expr.arguments.length >= 2) {
@@ -5434,18 +5451,72 @@ function compileCallExpression(
             fctx.body.push({ op: "call", funcIdx });
             return { kind: "i32" };
           }
-          return fallbackReturn(2, "i32-true");
+          // (#2046 cleanup) i32-false: a registration failure should not report
+          // a phantom `true` for `Reflect.has`.
+          return fallbackReturn(2, "i32-false");
         }
 
         if (reflectMethod === "deleteProperty" && expr.arguments.length >= 2) {
-          emitReflectArgs(2);
+          // (#2046 PR-A defect 3a) Reflect.deleteProperty(primitive, k) must
+          // throw a TypeError (§28.1.4 — Reflect requires an Object target),
+          // NOT return true. The shared __delete_property helper returns 1 for
+          // non-$Object targets because sloppy `delete primitive[k]` is a no-op
+          // SUCCESS — correct there, wrong for Reflect. So gate at the CALL SITE
+          // (do NOT touch the shared helper): ref.test the target against
+          // $Object; if it is not an open object, throw a catchable TypeError.
+          const ort = ensureObjectRuntime(ctx);
+          const targetLocal = allocTempLocal(fctx, externRef);
+          // Evaluate the target once, save it for both the guard and the call.
+          {
+            const tArg = expr.arguments[0];
+            if (tArg !== undefined) {
+              const tTy = compileExpression(ctx, fctx, tArg, externRef);
+              if (tTy && tTy.kind !== "externref") coerceType(ctx, fctx, tTy, externRef);
+              else if (tTy === null) fctx.body.push({ op: "ref.null.extern" });
+            } else {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+          }
+          fctx.body.push({ op: "local.set", index: targetLocal });
+          // Pre-register the TypeError constructor + any late import the throw
+          // needs BEFORE entering the `if`, so capturing the throw instrs by
+          // splice below cannot interleave a late-import index shift into the
+          // nested block (the registration happens against the flat body here).
+          const throwInstrs: Instr[] = (() => {
+            const before = fctx.body.length;
+            emitThrowTypeError(ctx, fctx, "Reflect.deleteProperty called on non-object");
+            return fctx.body.splice(before);
+          })();
+          // if !ref.test $Object(target) → throw TypeError
+          fctx.body.push({ op: "local.get", index: targetLocal });
+          fctx.body.push({ op: "any.convert_extern" } as Instr);
+          fctx.body.push({ op: "ref.test", typeIdx: ort.objectTypeIdx } as Instr);
+          fctx.body.push({ op: "i32.eqz" });
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: throwInstrs,
+          } as Instr);
+          // target is an $Object — push [target, key] and delete.
+          fctx.body.push({ op: "local.get", index: targetLocal });
+          releaseTempLocal(fctx, targetLocal);
+          {
+            const kArg = expr.arguments[1];
+            if (kArg !== undefined) {
+              const kTy = compileExpression(ctx, fctx, kArg, externRef);
+              if (kTy && kTy.kind !== "externref") coerceType(ctx, fctx, kTy, externRef);
+              else if (kTy === null) fctx.body.push({ op: "ref.null.extern" });
+            } else {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+          }
           const funcIdx = ensureLateImport(ctx, "__delete_property", [externRef, externRef], [i32Ty]);
           flushLateImportShifts(ctx, fctx);
           if (funcIdx !== undefined) {
             fctx.body.push({ op: "call", funcIdx });
             return { kind: "i32" };
           }
-          return fallbackReturn(2, "i32-true");
+          return fallbackReturn(0, "i32-false");
         }
 
         if (reflectMethod === "ownKeys" && expr.arguments.length >= 1) {

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1198,13 +1198,16 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
 
   // ── __delete_property(externref obj, externref key) -> i32 ───────────────
   //
-  // ES §13.5.1 delete operator on an own data property. Finds the live entry;
-  // if present, marks it tombstoned (FLAG_TOMBSTONE), nulls its value (drop the
-  // reference for GC), decrements count, increments tombstones, returns 1. A
-  // configurable check could refuse non-configurable props, but data props
-  // created via __extern_set are always configurable (FLAG_DEFAULT), so delete
-  // always succeeds — returns 1 even when the key is absent (matches the host
-  // import, which returns true for missing own props per spec step 5).
+  // ES §13.5.1 delete operator / §28.1.4 Reflect.deleteProperty on an own data
+  // property. Finds the live entry; if present AND configurable (§10.1.10
+  // OrdinaryDelete), marks it tombstoned (FLAG_TOMBSTONE), nulls its value (drop
+  // the reference for GC), decrements count, increments tombstones, returns 1.
+  // (#2046 PR-B) A configurability preflight refuses non-configurable props
+  // (return 0): props on a sealed/frozen object, or data props defined
+  // non-configurable via __defineProperty_value (#1629) — the prior "always
+  // configurable" assumption was stale once #1629 landed. Returns 1 when the key
+  // is absent (delete of a missing own prop succeeds, §10.1.10 step 2 / host
+  // import parity).
   //
   // params: 0=obj(externref) 1=key(externref)
   // locals: 2=any(anyref) 3=o(ref null $Object) 4=e(ref null $PropEntry)
@@ -1234,6 +1237,39 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         op: "if",
         blockType: { kind: "empty" },
         then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+      },
+      // (#2046 PR-B) Configurability preflight — §10.1.10 OrdinaryDelete step 3-4:
+      // a non-configurable own property is NOT deletable. Return 0 (false, keep)
+      // when either:
+      //   (a) the OBJECT is sealed/frozen — `__object_seal`/`__object_freeze`
+      //       set the object-level OBJ_FLAG_SEALED bit but do NOT clear each
+      //       entry's FLAG_CONFIGURABLE, so the per-entry check below is NOT
+      //       sufficient on its own; sealed ⇒ every own prop is non-configurable
+      //       (frozen ⊃ sealed), so test the object bit too; OR
+      //   (b) the individual entry was defined non-configurable
+      //       (FLAG_CONFIGURABLE cleared) via __defineProperty_value (#1629).
+      // This is correct for BOTH callers of __delete_property: Reflect (returns
+      // false) and sloppy `delete obj[k]` (also returns false for a
+      // non-configurable own prop, §13.5.1.2).
+      // (a) object sealed/frozen?
+      { op: "local.get", index: 3 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+      { op: "i32.const", value: OBJ_FLAG_SEALED },
+      { op: "i32.and" },
+      // (b) entry non-configurable? ((e.flags & FLAG_CONFIGURABLE) == 0)
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+      { op: "i32.const", value: FLAG_CONFIGURABLE },
+      { op: "i32.and" },
+      { op: "i32.eqz" },
+      // refuse-delete = (sealed) | (entry not configurable)
+      { op: "i32.or" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
       },
       // e.flags |= TOMBSTONE
       { op: "local.get", index: 4 },

--- a/tests/issue-2046.test.ts
+++ b/tests/issue-2046.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2046 — Standalone Reflect spec gaps (#1905 follow-up).
+//
+// PR-A (restore fail-loud):
+//   - Reflect.get/set with an explicit receiver were evaluated then SILENTLY
+//     DROPPED (no receiver slot in __extern_get/__reflect_set), so accessor
+//     get/set ran with `this = target` instead of `receiver`. Until real
+//     receiver plumbing (PR-C, deferred), refuse loudly at compile time.
+//   - Reflect.deleteProperty(primitive, k) returned true; §28.1.4 requires a
+//     TypeError. Guarded at the call site (ref.test $Object) so the SHARED
+//     __delete_property (also backing sloppy `delete`, a no-op success on
+//     primitives) is untouched.
+// PR-B (delete integrity/configurability preflight):
+//   - __delete_property ignored sealed/frozen objects and per-entry
+//     FLAG_CONFIGURABLE. Object.freeze/seal set only the object-level flag and
+//     do NOT clear each entry's FLAG_CONFIGURABLE, so the preflight checks BOTH
+//     the object OBJ_FLAG_SEALED bit and the per-entry FLAG_CONFIGURABLE bit.
+//     Correct for both Reflect.deleteProperty and sloppy `delete`.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  // Permissive stub for any unrelated env helper (none expected for these).
+  const stub = new Proxy({}, { get: () => () => 0 });
+  const { instance } = await WebAssembly.instantiate(r.binary, { env: stub } as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+async function expectCompileRefusal(source: string, needle: string): Promise<void> {
+  const r = await compile(source, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, "expected a compile refusal but the module compiled").toBe(false);
+  const joined = r.errors.map((e) => e.message).join("\n");
+  expect(joined).toContain(needle);
+}
+
+async function expectThrows(source: string): Promise<void> {
+  const r = await compile(source, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const stub = new Proxy({}, { get: () => () => 0 });
+  const { instance } = await WebAssembly.instantiate(r.binary, { env: stub } as unknown as WebAssembly.Imports);
+  expect(() => (instance.exports as Record<string, () => number>).test()).toThrow();
+}
+
+describe("#2046 standalone Reflect spec gaps", () => {
+  // ── PR-A defect 1: explicit-receiver refusal ──────────────────────────────
+  it("Reflect.get with an explicit receiver is refused at compile time", async () => {
+    await expectCompileRefusal(
+      `export function test(): number {
+        const o: any = { x: 1 };
+        const recv: any = {};
+        return Reflect.get(o, "x", recv) as number;
+      }`,
+      "Reflect.get with an explicit receiver",
+    );
+  });
+
+  it("Reflect.set with an explicit receiver is refused at compile time", async () => {
+    await expectCompileRefusal(
+      `export function test(): boolean {
+        const o: any = { x: 1 };
+        const recv: any = {};
+        return Reflect.set(o, "x", 2, recv);
+      }`,
+      "Reflect.set with an explicit receiver",
+    );
+  });
+
+  it("Reflect.get/set WITHOUT a receiver still compile and work", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        Reflect.set(o, "x", 41);
+        return (Reflect.get(o, "x") as number) + 1;
+      }`),
+    ).toBe(42);
+  });
+
+  // ── PR-A defect 3a: non-object deleteProperty → TypeError ─────────────────
+  it("Reflect.deleteProperty on a primitive throws a TypeError", async () => {
+    await expectThrows(`export function test(): boolean {
+      const n: any = 5;
+      return Reflect.deleteProperty(n, "x");
+    }`);
+  });
+
+  it("Reflect.deleteProperty on an object still returns true and deletes", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 1 };
+        const deleted = Reflect.deleteProperty(o, "x") ? 1 : 0;
+        const gone = Reflect.has(o, "x") ? 0 : 2;
+        return deleted + gone; // expect 3
+      }`),
+    ).toBe(3);
+  });
+
+  // ── PR-B: configurability / integrity preflight ───────────────────────────
+  it("Reflect.deleteProperty on a frozen object returns false and keeps the property", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 1 };
+        Object.freeze(o);
+        const refused = Reflect.deleteProperty(o, "x") ? 0 : 1;
+        const kept = (Reflect.get(o, "x") as number) === 1 ? 2 : 0;
+        return refused + kept; // expect 3
+      }`),
+    ).toBe(3);
+  });
+
+  it("Reflect.deleteProperty on a sealed object returns false and keeps the property", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 1 };
+        Object.seal(o);
+        const refused = Reflect.deleteProperty(o, "x") ? 0 : 1;
+        const kept = (Reflect.get(o, "x") as number) === 1 ? 2 : 0;
+        return refused + kept; // expect 3
+      }`),
+    ).toBe(3);
+  });
+
+  it("preventExtensions does NOT make existing props non-configurable — delete still succeeds", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const o: any = { x: 1 };
+        Object.preventExtensions(o);
+        return Reflect.deleteProperty(o, "x");
+      }`),
+    ).toBe(1);
+  });
+
+  it("sloppy delete also honors freeze (shared __delete_property)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 1 };
+        Object.freeze(o);
+        const refused = (delete o.x) ? 0 : 1;
+        const kept = o.x === 1 ? 2 : 0;
+        return refused + kept; // expect 3
+      }`),
+    ).toBe(3);
+  });
+
+  it("sloppy delete on a normal object still succeeds", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const o: any = { x: 1 };
+        return delete o.x;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2046 — Standalone Reflect spec gaps (#1905 follow-up)

Two of the four #1905 standalone `Reflect` gaps produced **silently wrong values**. This PR lands the two developer-claimable fixes (PR-A + PR-B). PR-C (real receiver) is senior/deferred; PR-D (ToPropertyKey) rides #2042 — both remain, so the issue stays `in-progress`.

### PR-A — restore fail-loud (`src/codegen/expressions/calls.ts`, all inside `if (ctx.standalone)`)
- **Defect 1 (receiver mis-bind):** `Reflect.get`/`Reflect.set` evaluated then **silently dropped** an explicit receiver (no receiver slot in `__extern_get`/`__reflect_set`), so accessor get/set ran with `this = target` instead of `receiver` (§28.1.5/§28.1.12 → §10.1.8/§10.1.9). Now **refuse loudly** at compile time when an explicit receiver is present (`arguments.length > 2` / `> 3`). Removed the now-dead `emitAndDropOptionalArg`.
- **Defect 3a (non-object deleteProperty):** `Reflect.deleteProperty(primitive, k)` returned `true`; §28.1.4 requires a TypeError. Added a **call-site** `ref.test $Object` guard that throws a catchable TypeError (`emitThrowTypeError`). The **shared** `__delete_property` helper is untouched, so sloppy `delete primitive[k]` stays a no-op success.
- **Cleanup:** the boolean-Reflect `fallbackReturn` dead branches now return `i32-false` (registration-failure default) instead of a phantom `true`.

### PR-B — delete configurability/integrity preflight (`src/codegen/object-runtime.ts`, `__delete_property`)
- Refuse (return `0`, keep the prop) for a non-configurable own property per §10.1.10 OrdinaryDelete.
- **Verified subtlety:** `__object_freeze`/`__object_seal` set only the object-level `$Object.flags` `OBJ_FLAG_SEALED` bit and do **NOT** clear each entry's `FLAG_CONFIGURABLE`, so the preflight checks **both** the object `OBJ_FLAG_SEALED` bit **and** the per-entry `FLAG_CONFIGURABLE` bit. `Object.preventExtensions` (NONEXTENSIBLE only) does not block delete. Correct for **both** `Reflect.deleteProperty` and sloppy `delete` (§13.5.1.2).

### Remaining (out of this PR, tracked)
- **PR-C (real receiver plumbing)** — senior/deferred, coordinates with #1888 Slice 5 accessor invocation.
- **PR-D (ToPropertyKey)** — `Reflect.get(o, 1)` still traps (`illegal cast` on `ref.cast $AnyString` in `__obj_hash`). Same numeric-key fix as #2042 PR-A; reuse #2042's shared key-coercion helper once it lands (coordinated with dev-b).

### Tests
- `tests/issue-2046.test.ts` (new) — 10/10: explicit-receiver refusal (get+set), no-receiver get/set work, non-object deleteProperty throws TypeError, object deleteProperty deletes, frozen/sealed deleteProperty → false + kept, preventExtensions delete still succeeds, sloppy delete honors freeze, sloppy delete normal succeeds.
- `tests/issue-1905.test.ts` — green (4/4, no regression).

Spec: [§28.1.4](https://tc39.es/ecma262/#sec-reflect.deleteproperty), [§28.1.5](https://tc39.es/ecma262/#sec-reflect.get), [§10.1.10 OrdinaryDelete](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p).

🤖 Generated with [Claude Code](https://claude.com/claude-code)