### PR TITLE
fix(#2149): object emit — don't relocate abstract heap-type typeIdx (u32 out of range: -19)

### DIFF
--- a/plan/issues/2149-objemit-abstract-heaptype-reloc.md
+++ b/plan/issues/2149-objemit-abstract-heaptype-reloc.md
@@ -1,0 +1,84 @@
+---
+id: 2149
+title: "standalone object emit: `Object emit error: u32 out of range: -19` — abstract heap-type typeIdx emitted as a relocation symbolIndex"
+status: done
+sprint: Backlog
+created: 2026-06-14
+updated: 2026-06-14
+completed: 2026-06-14
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, emit
+language_feature: any, equality
+goal: standalone-mode
+related: [2029, 2081, 1842]
+origin: "Surfaced by dev-c during #2081 standalone loose-eq work: a function with any-typed params (`function eq(a:any,b:any){return a==b}`) fails relocatable-object compilation (`compileToObject`, --target standalone) with `Object emit error: u32 out of range: -19`, blocking #2081 reproduction."
+---
+
+# #2149 — object emit: abstract heap-type typeIdx serialized as a reloc symbolIndex
+
+## Problem
+
+`compileToObject(src, { target: "standalone" })` (the relocatable `.o`
+emitter) throws `Object emit error: u32 out of range: -19` for any function
+that uses any/any equality, e.g.:
+
+```ts
+export function eq(a: any, b: any): boolean { return a == b; }
+```
+
+`compile()` (the `emitBinary` path) compiles the same source fine — only the
+**object emitter** (`src/emit/object.ts`) fails. `a:any == 1` (one numeric
+operand) does NOT fail; the trigger is the **any/any** equality dispatch.
+
+## Root cause
+
+The any-equality / AnyValue path emits `ref.test` / `ref.cast` / `ref.null`
+instructions whose `typeIdx` is a **negative abstract heap-type sentinel**.
+`eq` is encoded as `-19` — `EQ_HEAP_TYPE = -19` in
+`src/codegen/any-helpers.ts` (the signed-LEB heap-type byte `0x6d`). Abstract
+heap types (`eq`, `any`, `func`, `i31`, …) are encoded INLINE as a single
+signed-LEB byte; they are not concrete module type indices.
+
+`emitBinary` encodes them correctly via `enc.i32(typeIdx)`. But the object
+emitter (`encodeInstrWithReloc` in `object.ts`) **unconditionally** pushed a
+type-index relocation for `ref.test` / `ref.cast` / `ref.cast_null`:
+
+```ts
+relocs.push({ type: RELOC.R_WASM_TYPE_INDEX_LEB, offset: enc.position, symbolIndex: instr.typeIdx });
+enc.i32(instr.typeIdx);
+```
+
+When `instr.typeIdx` is `-19`, the inline `enc.i32` is fine, but the reloc
+entry carries `symbolIndex: -19`. Serializing the `reloc.CODE` section then does
+`s.u32(-19)` → `RangeError: u32 out of range: -19` (object.ts:294, the
+`reloc.CODE` symbolIndex write). `ref.null` already (correctly) emitted no
+reloc, which is why only the `ref.test`/`ref.cast` arms tripped.
+
+## Fix
+
+In `src/emit/object.ts`, skip the `R_WASM_TYPE_INDEX_LEB` relocation for
+`ref.test` / `ref.cast` / `ref.cast_null` when `instr.typeIdx < 0` — a negative
+typeIdx is an abstract heap type encoded inline, not a relocatable concrete
+module type. `enc.i32(typeIdx)` still writes the correct signed-LEB byte.
+`struct.*` / `array.*` ops (which use `enc.u32` and always take concrete types)
+are unaffected.
+
+## Acceptance criteria
+
+- `compileToObject(`any/any `==`/`===`/`!=`, { target: "standalone" })` succeeds
+  (no `u32 out of range: -19`).
+- Concrete-type relocations (object literal / class / array `struct.new`,
+  `ref.cast` to a defined struct) still emit their `R_WASM_TYPE_INDEX_LEB`
+  relocs — verified by the existing `tests/object-file.test.ts` (12 passing) +
+  the regression case in the new test.
+- `emitBinary` output unchanged.
+- Unblocks #2081 standalone loose-eq reproduction.
+
+## Test
+
+`tests/issue-objemit-abstract-heaptype.test.ts` — 5 cases: any/any
+loose/strict/inequality object emit; any param compared then called; and the
+concrete-type-reloc regression guard.

--- a/src/emit/object.ts
+++ b/src/emit/object.ts
@@ -705,23 +705,32 @@ function encodeInstrWithReloc(
     case "ref.cast": {
       enc.byte(GC.prefix);
       enc.byte(GC.ref_cast);
-      // Type index relocation
-      relocs.push({
-        type: RELOC.R_WASM_TYPE_INDEX_LEB,
-        offset: enc.position,
-        symbolIndex: instr.typeIdx,
-      });
+      // #15 — only relocate CONCRETE (>= 0) type indices. A negative typeIdx is
+      // an ABSTRACT heap type (eq=-19, any=-18, func=-16, …) that `enc.i32`
+      // encodes directly as a signed-LEB heap type; it is not a relocatable
+      // module type, and pushing it as a reloc `symbolIndex` makes the reloc
+      // section's `s.u32(symbolIndex)` throw `u32 out of range: -19`.
+      if (instr.typeIdx >= 0) {
+        relocs.push({
+          type: RELOC.R_WASM_TYPE_INDEX_LEB,
+          offset: enc.position,
+          symbolIndex: instr.typeIdx,
+        });
+      }
       enc.i32(instr.typeIdx);
       break;
     }
     case "ref.cast_null": {
       enc.byte(GC.prefix);
       enc.byte(GC.ref_cast_null);
-      relocs.push({
-        type: RELOC.R_WASM_TYPE_INDEX_LEB,
-        offset: enc.position,
-        symbolIndex: instr.typeIdx,
-      });
+      // #15 — concrete types only (see ref.cast above).
+      if (instr.typeIdx >= 0) {
+        relocs.push({
+          type: RELOC.R_WASM_TYPE_INDEX_LEB,
+          offset: enc.position,
+          symbolIndex: instr.typeIdx,
+        });
+      }
       enc.i32(instr.typeIdx);
       break;
     }
@@ -736,11 +745,14 @@ function encodeInstrWithReloc(
     case "ref.test": {
       enc.byte(GC.prefix);
       enc.byte(GC.ref_test);
-      relocs.push({
-        type: RELOC.R_WASM_TYPE_INDEX_LEB,
-        offset: enc.position,
-        symbolIndex: instr.typeIdx,
-      });
+      // #15 — concrete types only (see ref.cast above).
+      if (instr.typeIdx >= 0) {
+        relocs.push({
+          type: RELOC.R_WASM_TYPE_INDEX_LEB,
+          offset: enc.position,
+          symbolIndex: instr.typeIdx,
+        });
+      }
       enc.i32(instr.typeIdx);
       break;
     }

--- a/tests/issue-objemit-abstract-heaptype.test.ts
+++ b/tests/issue-objemit-abstract-heaptype.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compileToObject } from "../src/index.js";
+
+// Standalone object emitter (`compileToObject`, the relocatable `.o` output)
+// threw `Object emit error: u32 out of range: -19` when a function used any/any
+// loose/strict equality (e.g. `function eq(a:any,b:any){return a==b}`).
+//
+// Root cause: the any-equality / AnyValue path emits `ref.test` / `ref.cast` /
+// `ref.null` instructions whose `typeIdx` is a NEGATIVE *abstract heap type*
+// sentinel — `eq` is `-19` (`EQ_HEAP_TYPE` in any-helpers.ts, the signed-LEB
+// heap-type encoding). `emitBinary` encodes that inline as a signed-LEB heap
+// type, but the object emitter UNCONDITIONALLY pushed a type-index relocation
+// (`R_WASM_TYPE_INDEX_LEB`) with `symbolIndex: instr.typeIdx`. The reloc section
+// then serialized `s.u32(-19)` → RangeError. Abstract heap types are not
+// relocatable concrete module types; the fix skips the relocation when
+// `typeIdx < 0` (object.ts ref.test/ref.cast/ref.cast_null).
+//
+// This unblocked reproduction of the #2081 standalone loose-eq work.
+
+function compileObjectOk(src: string): number {
+  const r = compileToObject(src, { fileName: "test.ts", target: "standalone" }) as {
+    success: boolean;
+    object?: Uint8Array;
+    errors?: { message: string }[];
+  };
+  if (!r.success) {
+    throw new Error(`compileToObject failed: ${r.errors?.map((e) => e.message).join("; ")}`);
+  }
+  return r.object!.length;
+}
+
+describe("object emitter — abstract heap-type typeIdx must not be relocated", () => {
+  it("any/any loose equality compiles to an object file", () => {
+    // Before the fix: `Object emit error: u32 out of range: -19`.
+    expect(compileObjectOk(`export function eq(a: any, b: any): boolean { return a == b; }`)).toBeGreaterThan(0);
+  });
+
+  it("any/any strict equality compiles to an object file", () => {
+    expect(compileObjectOk(`export function eq(a: any, b: any): boolean { return a === b; }`)).toBeGreaterThan(0);
+  });
+
+  it("any/any inequality compiles to an object file", () => {
+    expect(compileObjectOk(`export function ne(a: any, b: any): boolean { return a != b; }`)).toBeGreaterThan(0);
+  });
+
+  it("any param compared then called still compiles", () => {
+    expect(
+      compileObjectOk(
+        `function eq(a: any, b: any): boolean { return a == b; }
+         export function test(): number { return eq(1, 1) ? 1 : 0; }`,
+      ),
+    ).toBeGreaterThan(0);
+  });
+
+  it("concrete-type relocations still work (object literal / class / array)", () => {
+    // Regression guard: the fix only skips relocs for NEGATIVE typeIdx; concrete
+    // (>= 0) type indices must still emit their R_WASM_TYPE_INDEX_LEB relocs.
+    expect(compileObjectOk(`export function f(): number { const o: any = { x: 5 }; return o.x; }`)).toBeGreaterThan(0);
+    expect(
+      compileObjectOk(`class C { x: number = 3; } export function f(): number { const c = new C(); return c.x; }`),
+    ).toBeGreaterThan(0);
+    expect(compileObjectOk(`export function f(): number { const a = [1, 2, 3]; return a[1]; }`)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## #2149 — object emit `u32 out of range: -19` on any/any equality

### Problem
`compileToObject(src, { target: "standalone" })` (the relocatable `.o` emitter)
threw `Object emit error: u32 out of range: -19` for any function using any/any
equality:

```ts
export function eq(a: any, b: any): boolean { return a == b; }
```

`compile()` (`emitBinary`) compiled the same source fine — only the object
emitter failed. `a:any == 1` (one numeric operand) did NOT fail; the trigger is
the **any/any** equality dispatch. This was TaskList item #15 and blocked #2081
standalone loose-eq reproduction. It only repros via `compileToObject` (the
"Object emit error" prefix = `src/emit/object.ts`), which is why plain
`compile()`/`emitBinary` smoke tests at HEAD never surfaced it.

### Root cause
The any-equality / AnyValue path emits `ref.test` / `ref.cast` / `ref.null`
whose `typeIdx` is a **negative abstract heap-type sentinel** — `eq` is `-19`
(`EQ_HEAP_TYPE` in `src/codegen/any-helpers.ts`, the signed-LEB heap-type byte).
Abstract heap types are encoded INLINE; they are not concrete module type
indices. `emitBinary` does this correctly. The object emitter
(`encodeInstrWithReloc`) **unconditionally** pushed an `R_WASM_TYPE_INDEX_LEB`
relocation with `symbolIndex: instr.typeIdx` for `ref.test`/`ref.cast`/
`ref.cast_null`; serializing the `reloc.CODE` section then did `s.u32(-19)` →
RangeError. (`ref.null` already emitted no reloc, so only the test/cast arms
tripped.)

### Fix
Skip the type-index relocation when `instr.typeIdx < 0` for
`ref.test`/`ref.cast`/`ref.cast_null` — a negative typeIdx is an abstract heap
type encoded inline by `enc.i32`, not a relocatable concrete type. `struct.*` /
`array.*` (which use `enc.u32` and always take concrete types) are unaffected.

### Verification
- New `tests/issue-objemit-abstract-heaptype.test.ts` (5 passing): any/any
  loose/strict/inequality object emit; any param compared then called; plus a
  concrete-type-reloc regression guard (object literal / class / array).
- Existing `tests/object-file.test.ts` (12) + `linker-e2e` / `c-abi` object-emit
  consumers still pass — concrete-type relocs unchanged.
- `emitBinary` output unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)