### PR TITLE
test(#1988): regression guard for any + ref ToPrimitive (already fixed)

### DIFF
--- a/plan/issues/1988-any-add-object-array-no-toprimitive.md
+++ b/plan/issues/1988-any-add-object-array-no-toprimitive.md
@@ -1,10 +1,11 @@
 ---
 id: 1988
 title: "__any_add on object/array operands skips ToPrimitive entirely — 1 + {} → NaN, [] + [] → 0"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-14
+completed: 2026-06-14
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -59,3 +60,32 @@ is a string. Sibling of #1938 which covers runtime *strings* in `__any_add`
 
 #1938 covers the same mechanism for runtime strings only; objects/arrays
 needing ToPrimitive not mentioned there. Filed as sibling with `related`.
+
+## Resolution — already fixed (2026-06-14)
+
+Smoke-tested all three headline repros on current `main` (origin/main
+`d1aba0601`, host/gc mode) — **all match Node**, so the `__any_add`
+ToPrimitive gap was closed by the recent #1938/#1900/#2073 type-coercion wave.
+No new code change needed; added a regression test to lock the behavior in.
+
+| expr | wasm (now) | node | status |
+|------|-----------|------|--------|
+| `1 + {}` | `"1[object Object]"` | `"1[object Object]"` | ✓ |
+| `[] + []` | `""` | `""` | ✓ |
+| `[1,2] + 1` | `"1,21"` | `"1,21"` | ✓ |
+| `{} + "x"` | `"[object Object]x"` | `"[object Object]x"` | ✓ |
+| `[3,4] + ",5"` | `"3,4,5"` | `"3,4,5"` | ✓ |
+| `{} + {}` | `"[object Object][object Object]"` | (same) | ✓ |
+
+**Residuals (out of scope, tracked elsewhere):**
+- The acceptance line `{valueOf(){return 2}} + 1 → 3` still throws "Cannot
+  convert object to primitive value" — that is the user-defined-`valueOf`
+  dispatch covered by **#1989** (in progress, task #9), not the object/array
+  ToPrimitive this issue is about.
+- Standalone (`--target standalone`) `String(...)` of the concat result returns
+  `undefined` / derefs null — a separate standalone `String()` / string-result
+  bug, NOT the `__any_add` defect. The `__any_add` ToPrimitive path itself is
+  correct; only the standalone `String()` wrapper misbehaves (file separately if
+  not already tracked).
+
+Regression test: `tests/issue-1988.test.ts` (host/gc mode, 6 cases).

--- a/tests/issue-1988.test.ts
+++ b/tests/issue-1988.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1988 — `any + ref` ToPrimitive regression guard.
+//
+// `__any_add` once skipped ToPrimitive on object/array operands, so `1 + {}`
+// returned NaN and `[] + []` returned 0 instead of string-concatenating the
+// ToPrimitive(default) results (§13.15.3 ApplyStringOrNumericBinaryOperator).
+// The recent #1938/#1900/#2073 type-coercion wave fixed it; this locks the
+// host/gc-mode behavior in so it cannot silently regress.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStr(source: string): Promise<string> {
+  const r = await compile(source, { fileName: "issue-1988.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imp = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  (imp as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => string>).test();
+}
+
+describe("#1988 any + ref ToPrimitive", () => {
+  it("1 + {} → \"1[object Object]\"", async () => {
+    expect(await runStr(`export function test(): string { const o: any = {}; return String(1 + o); }`)).toBe(
+      "1[object Object]",
+    );
+  });
+
+  it("[] + [] → \"\"", async () => {
+    expect(await runStr(`export function test(): string { const a: any = []; return String(a + a); }`)).toBe("");
+  });
+
+  it("[1,2] + 1 → \"1,21\"", async () => {
+    expect(await runStr(`export function test(): string { const a: any = [1, 2]; return String(a + 1); }`)).toBe("1,21");
+  });
+
+  it("{} + \"x\" → \"[object Object]x\"", async () => {
+    expect(await runStr(`export function test(): string { const o: any = {}; return o + "x"; }`)).toBe(
+      "[object Object]x",
+    );
+  });
+
+  it("[3,4] + \",5\" → \"3,4,5\"", async () => {
+    expect(await runStr(`export function test(): string { const a: any = [3, 4]; return a + ",5"; }`)).toBe("3,4,5");
+  });
+
+  it("{} + {} → \"[object Object][object Object]\"", async () => {
+    expect(await runStr(`export function test(): string { const o: any = {}; return o + o; }`)).toBe(
+      "[object Object][object Object]",
+    );
+  });
+});

--- a/tests/issue-1988.test.ts
+++ b/tests/issue-1988.test.ts
@@ -20,31 +20,33 @@ async function runStr(source: string): Promise<string> {
 }
 
 describe("#1988 any + ref ToPrimitive", () => {
-  it("1 + {} → \"1[object Object]\"", async () => {
+  it('1 + {} → "1[object Object]"', async () => {
     expect(await runStr(`export function test(): string { const o: any = {}; return String(1 + o); }`)).toBe(
       "1[object Object]",
     );
   });
 
-  it("[] + [] → \"\"", async () => {
+  it('[] + [] → ""', async () => {
     expect(await runStr(`export function test(): string { const a: any = []; return String(a + a); }`)).toBe("");
   });
 
-  it("[1,2] + 1 → \"1,21\"", async () => {
-    expect(await runStr(`export function test(): string { const a: any = [1, 2]; return String(a + 1); }`)).toBe("1,21");
+  it('[1,2] + 1 → "1,21"', async () => {
+    expect(await runStr(`export function test(): string { const a: any = [1, 2]; return String(a + 1); }`)).toBe(
+      "1,21",
+    );
   });
 
-  it("{} + \"x\" → \"[object Object]x\"", async () => {
+  it('{} + "x" → "[object Object]x"', async () => {
     expect(await runStr(`export function test(): string { const o: any = {}; return o + "x"; }`)).toBe(
       "[object Object]x",
     );
   });
 
-  it("[3,4] + \",5\" → \"3,4,5\"", async () => {
+  it('[3,4] + ",5" → "3,4,5"', async () => {
     expect(await runStr(`export function test(): string { const a: any = [3, 4]; return a + ",5"; }`)).toBe("3,4,5");
   });
 
-  it("{} + {} → \"[object Object][object Object]\"", async () => {
+  it('{} + {} → "[object Object][object Object]"', async () => {
     expect(await runStr(`export function test(): string { const o: any = {}; return o + o; }`)).toBe(
       "[object Object][object Object]",
     );


### PR DESCRIPTION
## #1988 — `any + ref` ToPrimitive: already fixed, regression-guarded

Smoke-tested all three #1988 headline repros on current `main` (host/gc mode) — **all match Node**, so the `__any_add` ToPrimitive gap (`1 + {}` → NaN, `[] + []` → 0) was closed by the recent #1938/#1900/#2073 type-coercion wave. No new code change needed; this PR adds a regression test and flips the issue to `done`.

| expr | wasm (now) | node |
|------|-----------|------|
| `1 + {}` | `"1[object Object]"` | `"1[object Object]"` |
| `[] + []` | `""` | `""` |
| `[1,2] + 1` | `"1,21"` | `"1,21"` |
| `{} + "x"` | `"[object Object]x"` | `"[object Object]x"` |
| `[3,4] + ",5"` | `"3,4,5"` | `"3,4,5"` |
| `{} + {}` | `"[object Object][object Object]"` | (same) |

### Residuals (out of scope, tracked elsewhere)
- `{valueOf(){return 2}} + 1 → 3` still throws "Cannot convert object to primitive value" — that is user-defined-`valueOf` dispatch, covered by **#1989** (in progress), not the object/array ToPrimitive this issue is about.
- Standalone (`--target standalone`) `String(...)` of the concat result returns `undefined` / derefs null — a separate standalone `String()`/string-result bug, NOT the `__any_add` defect.

### Tests
- `tests/issue-1988.test.ts` (new) — 6/6 (host/gc mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)