### PR TITLE
fix(#2012): track Object.freeze of inline literal bound to a variable

### DIFF
--- a/plan/issues/2012-object-freeze-not-enforced.md
+++ b/plan/issues/2012-object-freeze-not-enforced.md
@@ -1,10 +1,11 @@
 ---
 id: 2012
 title: "Object.freeze: no strict-mode TypeError on write, isFrozen false — tracking only fires for identifier args, struct receivers get no integrity bit"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-14
+completed: 2026-06-14
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -12,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: objects
 goal: core-semantics
-related: [797, 359]
+related: [797, 359, 2012]
 origin: "2026-06-10 spec-conformance sweep (objects agent): verified on main"
 ---
 
@@ -52,3 +53,46 @@ and in isFrozen.
 ## Dupe check
 
 #797d and #359 done; residual not listed in #1971. New.
+
+## Resolution — compile-time variable tracking (2026-06-14)
+
+The headline repro `const o = Object.freeze({a:1}); o.a = 2` was a no-op for
+struct receivers because the existing compile-time tracking only fired for an
+**identifier argument** (`Object.freeze(o)` → `ctx.frozenVars.add("o")`). An
+inline literal arg is not an identifier, so nothing was tracked: the strict
+write silently succeeded-as-noop and `isFrozen` returned false
+(`"false,1,false"` vs Node `"true,1,true"`).
+
+**Fix** (`src/codegen/expressions/calls.ts`, the freeze/seal/preventExtensions
+arm): when the `Object.<freeze|seal|preventExtensions>(<expr>)` CALL is the
+**initializer of a variable declaration**
+(`expr.parent` is a `VariableDeclaration` with an identifier name and
+`expr.parent.initializer === expr`), mark the **declared variable** in
+`ctx.frozenVars`/`sealedVars`/`nonExtensibleVars` instead of the
+(non-identifier) argument. The write-path (`assignment.ts:1763/2193`) and
+`isFrozen`/`isSealed` (`calls.ts`) already consult these sets keyed on the
+identifier name, so this single hook restores correct strict-throw, value-kept,
+and `isFrozen → true` for `const/let o = Object.freeze({...})`.
+
+Verified: `inline literal` → `"true,1,true"`; `let`-binding inline →
+`"true,true"`; identifier-arg unchanged; `Object.seal` inline → `isSealed true`;
+non-frozen control → `"false,1,false"` (no false positive).
+
+**Scope / follow-up (#22):** this is COMPILE-TIME variable tracking — it covers
+the common literal-to-variable binding but NOT aliased/dynamic cases
+(`const a = Object.freeze({}); const b = a; b.x = 1` does not throw, because the
+write target `b` was never marked). General runtime enforcement needs a runtime
+frozen bit on the object representation (host-mode WasmGC structs have no flags
+field like the standalone `$Object` does) — tracked as the
+`[SENIOR][follow-up]` #2012-runtime task. Standalone-mode freeze already works
+(verified in #2046 PR-B tests — the `$Object` runtime has real integrity flags).
+
+## Test Results (2026-06-14)
+
+- `tests/issue-2012.test.ts` (new) — 5/5: inline-literal const freeze
+  (strict-throw + value-kept + isFrozen true), `let`-binding inline,
+  identifier-arg (unchanged), inline `seal` → isSealed, non-frozen control.
+- Pre-existing unrelated failure (byte-identical to origin/main): the
+  `object-mutability.test.ts` "isFrozen/isSealed returns false (stub)" /
+  "isExtensible returns true (stub)" cases already fail on clean origin/main —
+  stale stub-behavior assertions superseded by a prior PR, not touched here.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4101,15 +4101,34 @@ function compileCallExpression(
       const method = propAccess.name.text;
       const arg0 = expr.arguments[0]!;
 
-      // Compile-time tracking: mark variable by freeze/seal/preventExtensions state
-      if (ts.isIdentifier(arg0)) {
-        ctx.nonExtensibleVars.add(arg0.text);
+      // Compile-time tracking: mark variable by freeze/seal/preventExtensions state.
+      // Two binding shapes carry the integrity to a variable the write-path /
+      // isFrozen consult (both keyed on the identifier name in ctx.frozenVars):
+      //   (a) `Object.freeze(o)` — the ARGUMENT is the identifier.
+      //   (b) `const o = Object.freeze({...})` (#2012) — the inline-literal arg
+      //       is not an identifier, but the CALL is the initializer of a
+      //       variable declaration, so mark the DECLARED variable instead.
+      //       Without this, an inline-literal freeze was a complete no-op for
+      //       struct receivers (no frozenVars entry → write never throws,
+      //       isFrozen → false).
+      const markIntegrity = (name: string): void => {
+        ctx.nonExtensibleVars.add(name);
         if (method === "freeze") {
-          ctx.frozenVars.add(arg0.text);
-          ctx.sealedVars.add(arg0.text); // frozen implies sealed
+          ctx.frozenVars.add(name);
+          ctx.sealedVars.add(name); // frozen implies sealed
         } else if (method === "seal") {
-          ctx.sealedVars.add(arg0.text);
+          ctx.sealedVars.add(name);
         }
+      };
+      if (ts.isIdentifier(arg0)) {
+        markIntegrity(arg0.text);
+      } else if (
+        // (#2012) `const/let o = Object.<freeze|seal|preventExtensions>(<expr>)`
+        ts.isVariableDeclaration(expr.parent) &&
+        ts.isIdentifier(expr.parent.name) &&
+        expr.parent.initializer === expr
+      ) {
+        markIntegrity(expr.parent.name.text);
       }
 
       // Compile the argument — returns the object itself (freeze/seal return their arg)

--- a/tests/issue-2012.test.ts
+++ b/tests/issue-2012.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2012 — Object.freeze of an inline literal was a no-op for struct receivers.
+//
+// `Object.freeze(o)` (identifier arg) marked `o` in ctx.frozenVars, so the
+// write-path threw and isFrozen reported true. But `const o = Object.freeze({a:1})`
+// passes an inline literal (not an identifier), so nothing was tracked: the
+// strict write silently succeeded-as-noop and isFrozen returned false
+// ("false,1,false" vs Node "true,1,true"). Fix: when the freeze/seal/
+// preventExtensions CALL is the initializer of a variable declaration, mark the
+// DECLARED variable instead of the (non-identifier) argument.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStr(source: string): Promise<string> {
+  const r = await compile(source, { fileName: "issue-2012.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imp = r.importObject;
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  (imp as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => string>).test();
+}
+
+describe("#2012 Object.freeze of inline literal (struct receiver)", () => {
+  it("const o = Object.freeze({a:1}): strict write throws, value kept, isFrozen true", async () => {
+    expect(
+      await runStr(`export function test(): string {
+        const o: any = Object.freeze({ a: 1 });
+        let threw = false;
+        try { o.a = 2; } catch { threw = true; }
+        return String(threw) + "," + String(o.a) + "," + String(Object.isFrozen(o));
+      }`),
+    ).toBe("true,1,true");
+  });
+
+  it("let o = Object.freeze({a:1}) is also tracked", async () => {
+    expect(
+      await runStr(`export function test(): string {
+        let o: any = Object.freeze({ a: 1 });
+        let threw = false;
+        try { o.a = 2; } catch { threw = true; }
+        return String(threw) + "," + String(Object.isFrozen(o));
+      }`),
+    ).toBe("true,true");
+  });
+
+  it("identifier-arg freeze still works (unchanged)", async () => {
+    expect(
+      await runStr(`export function test(): string {
+        const obj: any = { a: 1 };
+        Object.freeze(obj);
+        let threw = false;
+        try { obj.a = 2; } catch { threw = true; }
+        return String(threw) + "," + String(obj.a) + "," + String(Object.isFrozen(obj));
+      }`),
+    ).toBe("true,1,true");
+  });
+
+  it("const o = Object.seal({a:1}) marks the variable sealed", async () => {
+    expect(
+      await runStr(`export function test(): string {
+        const o: any = Object.seal({ a: 1 });
+        return String(Object.isSealed(o));
+      }`),
+    ).toBe("true");
+  });
+
+  it("a non-frozen object remains writable (no false positive)", async () => {
+    expect(
+      await runStr(`export function test(): string {
+        const o: any = { a: 1 };
+        let threw = false;
+        try { o.a = 2; } catch { threw = true; }
+        return String(threw) + "," + String(o.a) + "," + String(Object.isFrozen(o));
+      }`),
+    ).toBe("false,1,false");
+  });
+});


### PR DESCRIPTION
## #2012 — `const o = Object.freeze({a:1})` was a no-op for struct receivers

`Object.freeze(o)` (identifier arg) marked `o` in `ctx.frozenVars`, so the write-path threw and `isFrozen` reported true. But `const o = Object.freeze({a:1})` passes an **inline literal** (not an identifier), so nothing was tracked: the strict write silently succeeded-as-noop and `isFrozen` returned false — `"false,1,false"` vs Node `"true,1,true"`.

### Fix
`src/codegen/expressions/calls.ts` (freeze/seal/preventExtensions arm): when the `Object.<freeze|seal|preventExtensions>(<expr>)` **call is the initializer of a variable declaration**, mark the **declared variable** in `frozenVars`/`sealedVars`/`nonExtensibleVars` instead of the (non-identifier) argument. The write-path (`assignment.ts:1763/2193`) and `isFrozen`/`isSealed` already consult these sets keyed on the identifier name, so this one hook restores correct strict-throw, value-kept, and `isFrozen → true`.

### Scope / follow-up
This is **compile-time** variable tracking — it covers the common literal-to-variable binding but NOT aliased/dynamic cases (`const a = Object.freeze({}); const b = a; b.x = 1` — `b` was never marked). General runtime enforcement needs a runtime frozen bit on the object representation (host-mode WasmGC structs have no flags field) — tracked as the `[SENIOR][follow-up]` #2012-runtime task. Standalone-mode freeze already works (the `$Object` runtime has real integrity flags — verified in #2046 PR-B).

### Tests
- `tests/issue-2012.test.ts` (new) — 5/5: inline-literal `const` freeze (strict-throw + value-kept + isFrozen true), `let`-binding inline, identifier-arg (unchanged), inline `seal` → isSealed, non-frozen control (no false positive).

Spec: [§10.1.9 OrdinarySet](https://tc39.es/ecma262/#sec-ordinaryset) (read-only throw), [§10.1.10 OrdinaryDelete](https://tc39.es/ecma262/#sec-ordinarydelete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)