### PR TITLE
fix(#1989): per-instance valueOf/toString dispatch for same-shape object literals

### DIFF
--- a/plan/issues/1989-valueof-dispatch-per-shape-last-literal-wins.md
+++ b/plan/issues/1989-valueof-dispatch-per-shape-last-literal-wins.md
@@ -1,10 +1,11 @@
 ---
 id: 1989
 title: "ToPrimitive valueOf dispatch keyed by struct type name, not object identity — last same-shape literal's valueOf wins for ALL coercions"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-14
+completed: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -177,3 +178,76 @@ building new dispatch. PR-1 is small and high-leverage. Developer-claimable
 struct construction in literals.ts (different concerns — field NAMES vs field
 TYPE for valueOf — low conflict risk, but sequence #2009 PR-1 and #1989 PR-1 to
 avoid overlapping edits at literals.ts:9314/9348).
+
+## Resolution (2026-06-14, sdev2) — status: done
+
+Fixed by per-instance method-func dispatch for same-shape ToPrimitive literals.
+All acceptance criteria pass; both headline repros + the cross-method and
+mixed-hint variants match Node. PR: `issue-1989-per-instance-valueof`.
+
+### What landed (the WHY behind each change)
+
+The root cause was deeper than the spec's PR-1 sketch — verified by source
+tracing. Three stacked defects, all addressed:
+
+1. **Collapse (literals.ts).** Same-shape literals deduped to one struct type AND
+   one name-keyed method func `${typeName}_valueOf`. The #1557 per-literal fork
+   only triggered on a *signature* mismatch, so same-signature siblings (the
+   exact repro) collapsed onto the last-compiled body. Fix: fork a per-literal
+   method func for the **2nd+** same-shape `valueOf`/`toString`/`@@toPrimitive`
+   literal even when the signature matches, and mark the struct in
+   `ctx.toPrimitiveForkedStructs`. The **first** literal stays entirely on the
+   base path (keeps the shared `${typeName}_valueOf`) — forking it would record a
+   STALE funcIdx, because `emitObjectMethodAsClosure` for an earlier field pushes
+   a trampoline during construction and shifts later method funcs (a
+   valueOf+toString literal hit exactly this: toString's body landed in the
+   pre-pass index while `funcMap` advanced, leaving the dispatched func empty).
+   This sidesteps the architect's "TIMING blocker" rather than fighting it.
+
+2. **`any`-operand `+` never reached in-module dispatch (runtime.ts).** The
+   headline `a + 1` (an `any`/externref operand) routes to the host `__host_add`,
+   which ran native JS `a + b` — V8 cannot reach a WasmGC struct's compiled
+   valueOf, so it threw "Cannot convert object to primitive value". Fix: run
+   `_toPrimitiveSync` on **un-proxied** WasmGC struct operands inside `host_add`
+   (mirrors `host_loose_eq`), which dispatches the per-instance compiled method
+   in-module. Proxied structs and primitives still take native `+` (preserving
+   the existing TypeError-propagation path).
+
+3. **Host ToPrimitive exports were name-keyed (index.ts) + a latent re-entrancy
+   bug (type-coercion.ts).** `__call_valueOf`/`__call_toString` (consulted by the
+   runtime ToPrimitive proxy, hence by `host_add` / `String()` / loose-eq) read
+   the name-keyed standalone func. Fix: for **forked** structs only, dispatch
+   through the per-instance struct field — added a `closure-extern` mode for the
+   `any`-object externref-field case (`extern.convert_any` → `ref.cast
+   closureType` → field-0 funcref → `call_ref`). Also restored the `cleanup()`
+   re-entrancy-guard reset in the eqref valueOf coercion path so coercing the
+   first of two struct operands (`a < b`) doesn't leave the second yielding NaN.
+
+### Deliberate scoping (avoids regressions)
+
+Single-literal structs stay on the well-tested name-keyed standalone path. This
+preserves the §7.1.1.1 step-6 TypeError walk (both valueOf+toString return
+objects → TypeError) and avoids the same-shape-closure `ref.test` ambiguity the
+spec warned about. Only the genuine same-shape COLLISION opts into per-instance
+dispatch.
+
+### Verified
+
+- `tests/issue-1989.test.ts` (new, 8 cases): all three property forms,
+  cross-method, mixed-hint, 3-object, two-toString, and the step-6 TypeError.
+- Zero regressions across issue-1525/1525b/866/1253/1319/1990/2058 + the
+  object-to-primitive / comparison-coercion / string-arithmetic equivalence
+  suites (these went from 5 pre-existing failures → 0). Merged clean over #1988
+  (`__any_add`) and #2015; typecheck clean.
+
+### Known residual (NOT in this issue's acceptance criteria)
+
+Two same-shape **typed-nominal** struct literals (`type O = {valueOf():number}`,
+not `any`) still collapse in the **in-module numeric coercion** path, because for
+a nominal struct the first literal's method func is not pre-registered at
+construction time, so its per-instance closure field is never stored (the
+architect's timing blocker). The `any`-typed repros — which are what this issue
+filed — all work. The nominal-typed collision is a narrower follow-up; it shares
+the same per-literal-funcref mechanism but needs the construction-time func
+reservation problem solved without the index-shift hazard (track in #2009's
+orbit).

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -88,6 +88,8 @@ export function createCodegenContext(
     argcGlobalIdx: -1,
     currentThisGlobalIdx: -1,
     valueOfClosureTypes: new Map(),
+    toPrimitiveSharedClaimed: new Set(),
+    toPrimitiveForkedStructs: new Set(),
     exnTagIdx: -1,
     hasUnionImports: false,
     asyncFunctions: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -701,6 +701,30 @@ export interface CodegenContext {
   currentThisGlobalIdx: number;
   /** Map from struct name → set of closure type indices used for valueOf fields */
   valueOfClosureTypes: Map<string, number[]>;
+  /**
+   * (#1989) Set of `${structName}_${valueOf|toString|@@toPrimitive}` method full
+   * names whose SHARED func body has already been claimed by the first object
+   * literal of a deduped anon-struct type. Same-shape literals share a struct
+   * type, so the first literal compiled keeps the shared `${name}_valueOf` func
+   * (referenced by the host `__call_*`/`__sget_*` exports and name-keyed coercion
+   * fallbacks); every LATER same-shape literal forks its own per-literal method
+   * func and stores its own funcref in the struct field, so per-instance
+   * `call_ref` dispatch resolves to the correct method body per object.
+   */
+  toPrimitiveSharedClaimed: Set<string>;
+  /**
+   * (#1989) Set of anon-struct type names that have MORE THAN ONE object literal
+   * sharing the deduped struct type and carrying a `valueOf`/`toString`/
+   * `@@toPrimitive` method — i.e. the same-shape collision case where each
+   * literal stores its own method funcref. Only these structs route the host
+   * `__call_*` ToPrimitive dispatch through the per-instance struct-field closure
+   * (instead of the name-keyed standalone func, which is the first literal's body
+   * and is correct + simpler for the single-literal case). This keeps the
+   * single-literal path — including the §7.1.1.1 step-6 TypeError walk — on the
+   * well-tested standalone arm, and only opts the genuine collision case into
+   * per-instance dispatch.
+   */
+  toPrimitiveForkedStructs: Set<string>;
   /** Tag index for the exception tag (-1 if not yet registered) */
   exnTagIdx: number;
   /** Whether union type helper imports have been registered */

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3392,7 +3392,6 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
             ? funcType.results[0]!
             : { kind: "externref" };
         entries.push({ structName, typeIdx, mode: "standalone", funcIdx, resultType });
-        continue;
       }
     }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3292,6 +3292,21 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
           fieldIdx: number;
           closureTypeIdx: number;
           closureInfo: ClosureInfo;
+        }
+      | {
+          // (#1989) externref field holding a closure (the `any`-typed
+          // object-literal method case — the field stores
+          // `extern.convert_any(closureStruct)`). Recover the closure per
+          // instance: `struct.get` (externref) → `any.convert_extern` →
+          // `ref.cast closureTypeIdx` → field-0 funcref → `call_ref`. This makes
+          // `__call_valueOf`/`__call_toString` per-object even when same-shape
+          // literals share a struct type but store distinct method funcrefs.
+          structName: string;
+          typeIdx: number;
+          mode: "closure-extern";
+          fieldIdx: number;
+          closureTypeIdx: number;
+          closureInfo: ClosureInfo;
         };
 
     const entries: DispatchEntry[] = [];
@@ -3307,8 +3322,67 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
       )
         continue;
 
-      // 1. Check for standalone method: StructName_toString
       const methodFullName = `${structName}_${methodName}`;
+      const fieldIdx = fields.findIndex((f) => f.name === methodName);
+      const field = fieldIdx >= 0 ? fields[fieldIdx]! : undefined;
+
+      // (#1989) 1. Per-instance closure FIELD takes precedence over the
+      // name-keyed standalone method — but ONLY for structs with the genuine
+      // same-shape collision (`toPrimitiveForkedStructs`): two+ object literals
+      // share the deduped struct type, each storing its OWN method closure in
+      // the field, so reading the field + `call_ref` resolves to the right body
+      // per object. The standalone `${structName}_${methodName}` func is only the
+      // first literal's body and would collapse all instances onto it.
+      //
+      // Single-literal structs intentionally STAY on the name-keyed standalone
+      // arm below: it is the one literal's correct body, is simpler, and
+      // (critically) preserves the §7.1.1.1 step-6 object-return TypeError walk
+      // in `_hostToPrimitive`. Same-shape valueOf/toString closures are
+      // `ref.test`-indistinguishable, so routing a single-literal struct through
+      // the per-instance arm could mis-select the closure type for `toString`.
+      const preferClosure = ctx.toPrimitiveForkedStructs.has(structName);
+      let pushedClosure = false;
+      if (field && preferClosure) {
+        // Closure ref field (eagerly-typed closure ref).
+        if (field.type.kind === "ref" || field.type.kind === "ref_null") {
+          const closureTypeIdx = (field.type as { typeIdx: number }).typeIdx;
+          const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
+          if (closureInfo && closureInfo.paramTypes.length === 0) {
+            entries.push({ structName, typeIdx, mode: "closure", fieldIdx, closureTypeIdx, closureInfo });
+            pushedClosure = true;
+          }
+        }
+        // eqref field — try tracked closure types (typed object-literal methods).
+        if (!pushedClosure && field.type.kind === "eqref") {
+          const trackedTypes = ctx.valueOfClosureTypes.get(structName) ?? [];
+          for (const closureTypeIdx of trackedTypes) {
+            const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
+            if (closureInfo && closureInfo.paramTypes.length === 0) {
+              entries.push({ structName, typeIdx, mode: "closure", fieldIdx, closureTypeIdx, closureInfo });
+              pushedClosure = true;
+              break;
+            }
+          }
+        }
+        // (#1989) externref field holding a closure — the `any`-typed
+        // object-literal method case. The field stores
+        // `extern.convert_any(closureStruct)`; recover it per instance.
+        if (!pushedClosure && field.type.kind === "externref") {
+          const trackedTypes = ctx.valueOfClosureTypes.get(structName) ?? [];
+          for (const closureTypeIdx of trackedTypes) {
+            const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
+            if (closureInfo && closureInfo.paramTypes.length === 0) {
+              entries.push({ structName, typeIdx, mode: "closure-extern", fieldIdx, closureTypeIdx, closureInfo });
+              pushedClosure = true;
+              break;
+            }
+          }
+        }
+      }
+      if (pushedClosure) continue;
+
+      // 2. Fallback: name-keyed standalone method `StructName_toString`. Used by
+      // nominal class methods and structs whose method has no stored closure.
       const funcIdx = ctx.funcMap.get(methodFullName);
       if (funcIdx !== undefined) {
         const funcDef = mod.functions[funcIdx - ctx.numImportFuncs];
@@ -3319,33 +3393,6 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
             : { kind: "externref" };
         entries.push({ structName, typeIdx, mode: "standalone", funcIdx, resultType });
         continue;
-      }
-
-      // 2. Check for closure field
-      const fieldIdx = fields.findIndex((f) => f.name === methodName);
-      if (fieldIdx < 0) continue;
-      const field = fields[fieldIdx]!;
-
-      // Closure ref field
-      if (field.type.kind === "ref" || field.type.kind === "ref_null") {
-        const closureTypeIdx = (field.type as { typeIdx: number }).typeIdx;
-        const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
-        if (closureInfo && closureInfo.paramTypes.length === 0) {
-          entries.push({ structName, typeIdx, mode: "closure", fieldIdx, closureTypeIdx, closureInfo });
-          continue;
-        }
-      }
-
-      // eqref field — try tracked closure types
-      if (field.type.kind === "eqref") {
-        const trackedTypes = ctx.valueOfClosureTypes.get(structName) ?? [];
-        for (const closureTypeIdx of trackedTypes) {
-          const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
-          if (closureInfo && closureInfo.paramTypes.length === 0) {
-            entries.push({ structName, typeIdx, mode: "closure", fieldIdx, closureTypeIdx, closureInfo });
-            break;
-          }
-        }
       }
     }
 
@@ -3395,6 +3442,34 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
           funcIdx: entry.funcIdx,
         } as Instr);
         boxResult(entry.resultType, thenInstrs);
+      } else if (entry.mode === "closure-extern") {
+        // (#1989) externref field holding `extern.convert_any(closureStruct)`.
+        // Recover the per-instance closure: struct.get (externref) →
+        // any.convert_extern → ref.cast closureType → field-0 funcref → call_ref.
+        const ci = entry.closureInfo;
+        const closureLocal = 2; // eqref scratch local
+        thenInstrs.push(
+          { op: "local.get", index: anyLocal } as Instr,
+          { op: "ref.cast", typeIdx: entry.typeIdx },
+          { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: entry.fieldIdx } as Instr,
+          // externref field → anyref → eqref scratch
+          { op: "any.convert_extern" } as Instr,
+          { op: "local.set", index: closureLocal } as Instr,
+          // self-param: the closure struct
+          { op: "local.get", index: closureLocal } as Instr,
+          { op: "ref.cast", typeIdx: entry.closureTypeIdx },
+          // funcref from closure field 0
+          { op: "local.get", index: closureLocal } as Instr,
+          { op: "ref.cast", typeIdx: entry.closureTypeIdx },
+          { op: "struct.get", typeIdx: entry.closureTypeIdx, fieldIdx: 0 } as Instr,
+          { op: "ref.cast", typeIdx: ci.funcTypeIdx },
+          { op: "call_ref", typeIdx: ci.funcTypeIdx } as Instr,
+        );
+        if (!ci.returnType) {
+          thenInstrs.push({ op: "ref.null.extern" } as Instr);
+        } else {
+          boxResult(ci.returnType, thenInstrs);
+        }
       } else {
         // Closure field: extract closure, get funcref, call_ref
         const ci = entry.closureInfo;
@@ -3439,7 +3514,7 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
     };
 
     // Determine locals: param 0 (externref), local 1 (anyref), local 2 (eqref for closure)
-    const hasClosureEntry = entries.some((e) => e.mode === "closure");
+    const hasClosureEntry = entries.some((e) => e.mode === "closure" || e.mode === "closure-extern");
     const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
     if (hasClosureEntry) {
       locals.push({ name: "__closure", type: { kind: "eqref" } });

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1442,7 +1442,59 @@ export function compileObjectLiteralForStruct(
     if (methodName === undefined) continue;
     const fullName = `${typeName}_${methodName}`;
     const existingFuncIdx = ctx.funcMap.get(fullName);
-    if (existingFuncIdx === undefined) continue;
+
+    // (#1989) ToPrimitive-relevant methods (`valueOf`/`toString`/
+    // `@@toPrimitive`) MUST be per-instance when two same-shape object literals
+    // deduplicate to the same struct type. Otherwise the shared
+    // `${typeName}_valueOf` method (used both as the ToPrimitive fallback AND as
+    // the body referenced by the first literal's stored closure) collapses
+    // distinct literals onto the LAST-compiled method body — so
+    // `{valueOf(){return 7}}` and `{valueOf(){return 100}}` both coerce via
+    // `()=>100`. The generic #1557 fork below only fires on a *signature*
+    // mismatch; same-signature siblings (the exact #1989 repro) slip past it.
+    //
+    // We fix this with a per-struct "claim" of the shared method func:
+    //   - The FIRST same-shape literal claims the shared `${typeName}_valueOf`
+    //     func (binding it in `literalMethodFuncIdx` so its OWN closure points at
+    //     it and its body lands in it). The shared func keeps a real body, so the
+    //     host `__call_*`/`__sget_*` exports and name-keyed coercion fallbacks
+    //     still work.
+    //   - Every LATER same-shape literal FORKS a fresh per-literal func (below),
+    //     stores its own funcref in the struct field, and the per-instance
+    //     `call_ref` dispatch resolves to the right body per object.
+    // This claim is independent of WHEN the method func happens to be pre-
+    // registered in `funcMap` (it is for `any`-typed structs via the widening
+    // pre-pass, but not for nominal struct types) — `existingFuncIdx` is an
+    // unreliable "is this the first literal?" signal, so we track the claim
+    // explicitly in `ctx.toPrimitiveSharedClaimed`.
+    const isToPrimitiveMethod =
+      methodName === "valueOf" || methodName === "toString" || methodName === "@@toPrimitive";
+    let forkToPrimitive = false;
+    if (isToPrimitiveMethod) {
+      if (!ctx.toPrimitiveSharedClaimed.has(fullName)) {
+        // First same-shape literal: claim the shared func but leave it ENTIRELY
+        // on the base path — do NOT add a `literalMethodFuncIdx` override. The
+        // shared `${typeName}_valueOf` func is maintained by `funcMap` and the
+        // body loop the same way it is on main; capturing the funcIdx HERE
+        // (pre-construction) would record a STALE index, because
+        // `emitObjectMethodAsClosure` for an earlier field pushes a trampoline
+        // func during construction and shifts later method funcs (a
+        // valueOf+toString literal hit exactly this: toString's body landed in
+        // the pre-pass index while `funcMap` advanced to a fresh one, leaving the
+        // dispatched func empty). The first literal's per-instance closure is
+        // stored at construction via `funcMap.get(methodFullName)` for `any`
+        // structs (pre-registered) just as on main; nominal single-literal
+        // structs keep the name-keyed standalone path. Only LATER same-shape
+        // literals need a per-literal fork.
+        ctx.toPrimitiveSharedClaimed.add(fullName);
+        continue;
+      }
+      // 2nd+ same-shape literal: always fork a fresh per-literal func so its
+      // stored closure carries its own body (the #1989 collision fix).
+      forkToPrimitive = true;
+    }
+
+    if (existingFuncIdx === undefined && !forkToPrimitive) continue;
 
     // Compute the signature this method would compile to. This MUST mirror the
     // body-compile param-type derivation below (search "methodParams") exactly,
@@ -1483,36 +1535,48 @@ export function compileObjectLiteralForStruct(
     // method-as-closure trampoline built for the first literal forwards args in
     // the wrong order, emitting an invalid `call`. Treat any per-position type
     // divergence as a mismatch too, so each literal gets its own funcIdx.
-    const localIdx = existingFuncIdx - ctx.numImportFuncs;
-    const existingFunc = ctx.mod.functions[localIdx];
-    if (!existingFunc) continue;
-    const existingType = ctx.mod.types[existingFunc.typeIdx];
-    if (!existingType || existingType.kind !== "func") continue;
-    const sameArity = existingType.params.length === newParams.length;
-    // (#1602 regression fix) Compare param types nullability-insensitively for
-    // ref/ref_null of the SAME struct typeIdx. The pre-pass builds the self
-    // param as a non-null `ref structTypeIdx`, but the actual compiled method
-    // uses `ref null structTypeIdx` for self (and `ref null T` for any
-    // default-initialised ref param). A strict `valTypesMatch` flags this as a
-    // mismatch and forks a per-literal funcIdx — but that orphans the original
-    // shared funcMap entry (left with an empty body), so a *direct* call like
-    // `obj.method()` (which dispatches via funcMap, not the per-literal map)
-    // lands on the empty func and traps. Real divergence we still want to
-    // catch (e.g. sibling literals with [f64, externref] vs [externref, f64])
-    // differs in `kind` or `typeIdx`, which `refTypesMatch` still rejects.
-    const refTypesMatch = (p: ValType, q: ValType): boolean => {
-      const pRef = p.kind === "ref" || p.kind === "ref_null";
-      const qRef = q.kind === "ref" || q.kind === "ref_null";
-      if (pRef && qRef) {
-        return (p as { typeIdx: number }).typeIdx === (q as { typeIdx: number }).typeIdx;
-      }
-      return valTypesMatch(p, q);
-    };
-    const sameParamTypes = sameArity && existingType.params.every((p, i) => refTypesMatch(p, newParams[i]!));
-    if (sameArity && sameParamTypes) continue;
+    // (#1989) A 2nd+ ToPrimitive-method literal (`forkToPrimitive`) skips the
+    // same-signature short-circuit entirely: it must ALWAYS fork a per-literal
+    // funcIdx so its stored closure carries its own body, even when its
+    // signature matches the first literal's (the exact #1989 same-shape repro).
+    // Other methods keep the #1557 behaviour: fork only on a real signature
+    // mismatch.
+    if (!forkToPrimitive) {
+      // Reaching here with `!forkToPrimitive` guarantees `existingFuncIdx` is
+      // defined (the `existingFuncIdx === undefined && !forkToPrimitive`
+      // short-circuit above already `continue`d), but TS can't narrow it.
+      if (existingFuncIdx === undefined) continue;
+      const localIdx = existingFuncIdx - ctx.numImportFuncs;
+      const existingFunc = ctx.mod.functions[localIdx];
+      if (!existingFunc) continue;
+      const existingType = ctx.mod.types[existingFunc.typeIdx];
+      if (!existingType || existingType.kind !== "func") continue;
+      const sameArity = existingType.params.length === newParams.length;
+      // (#1602 regression fix) Compare param types nullability-insensitively for
+      // ref/ref_null of the SAME struct typeIdx. The pre-pass builds the self
+      // param as a non-null `ref structTypeIdx`, but the actual compiled method
+      // uses `ref null structTypeIdx` for self (and `ref null T` for any
+      // default-initialised ref param). A strict `valTypesMatch` flags this as a
+      // mismatch and forks a per-literal funcIdx — but that orphans the original
+      // shared funcMap entry (left with an empty body), so a *direct* call like
+      // `obj.method()` (which dispatches via funcMap, not the per-literal map)
+      // lands on the empty func and traps. Real divergence we still want to
+      // catch (e.g. sibling literals with [f64, externref] vs [externref, f64])
+      // differs in `kind` or `typeIdx`, which `refTypesMatch` still rejects.
+      const refTypesMatch = (p: ValType, q: ValType): boolean => {
+        const pRef = p.kind === "ref" || p.kind === "ref_null";
+        const qRef = q.kind === "ref" || q.kind === "ref_null";
+        if (pRef && qRef) {
+          return (p as { typeIdx: number }).typeIdx === (q as { typeIdx: number }).typeIdx;
+        }
+        return valTypesMatch(p, q);
+      };
+      const sameParamTypes = sameArity && existingType.params.every((p, i) => refTypesMatch(p, newParams[i]!));
+      if (sameArity && sameParamTypes) continue;
+    }
 
-    // Mismatch — allocate a fresh funcIdx for this literal's method without
-    // touching the shared funcMap entry.
+    // Mismatch (or a forced-per-instance ToPrimitive method) — allocate a fresh
+    // funcIdx for this literal's method without touching the shared funcMap entry.
     //
     // (#1602) Seed the fresh func with a type built from THIS literal's actual
     // params (`newParams`) and result, not the colliding sibling's type. A
@@ -1541,6 +1605,15 @@ export function compileObjectLiteralForStruct(
       exported: false,
     });
     literalMethodFuncIdx.set(methodName, freshFuncIdx);
+
+    if (forkToPrimitive) {
+      // (#1989) This is a 2nd+ same-shape literal of a ToPrimitive method — the
+      // genuine same-shape collision. Mark the struct so the host `__call_*`
+      // dispatch (and the in-module coercion sites) opt into per-instance
+      // struct-field closure dispatch. The single-literal case stays on the
+      // name-keyed standalone arm, preserving the §7.1.1.1 step-6 TypeError walk.
+      ctx.toPrimitiveForkedStructs.add(typeName);
+    }
   }
 
   for (const field of fields) {
@@ -1595,6 +1668,26 @@ export function compileObjectLiteralForStruct(
       if (methodFuncIdx !== undefined) {
         const closureType = emitObjectMethodAsClosure(ctx, fctx, methodFullName, methodFuncIdx, structTypeIdx);
         if (closureType) {
+          // (#1989) Method-shorthand `valueOf`/`toString` now store a
+          // per-instance closure in the eqref field (each literal owns a
+          // distinct funcIdx via the per-literal fork above). Register the
+          // closure type so ToPrimitive coercion takes the per-instance
+          // eqref-closure dispatch (type-coercion.ts) — `struct.get` the
+          // closure field of THIS instance and `call_ref` its own funcref —
+          // instead of the name-keyed `${typeName}_valueOf` standalone
+          // fallback that collapses same-shape literals onto one body.
+          if (
+            (field.name === "valueOf" || field.name === "toString") &&
+            field.type.kind === "eqref" &&
+            (closureType.kind === "ref" || closureType.kind === "ref_null")
+          ) {
+            const closureTypeIdx = (closureType as { typeIdx: number }).typeIdx;
+            const existing = ctx.valueOfClosureTypes.get(typeName) ?? [];
+            if (!existing.includes(closureTypeIdx)) {
+              existing.push(closureTypeIdx);
+              ctx.valueOfClosureTypes.set(typeName, existing);
+            }
+          }
           // Coerce closure-struct ref → field type. The common case is
           // externref (un-typed obj literal), which needs extern.convert_any.
           // For a concretely-typed struct field of the same closure type,

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1467,8 +1467,7 @@ export function compileObjectLiteralForStruct(
     // pre-pass, but not for nominal struct types) — `existingFuncIdx` is an
     // unreliable "is this the first literal?" signal, so we track the claim
     // explicitly in `ctx.toPrimitiveSharedClaimed`.
-    const isToPrimitiveMethod =
-      methodName === "valueOf" || methodName === "toString" || methodName === "@@toPrimitive";
+    const isToPrimitiveMethod = methodName === "valueOf" || methodName === "toString" || methodName === "@@toPrimitive";
     let forkToPrimitive = false;
     if (isToPrimitiveMethod) {
       if (!ctx.toPrimitiveSharedClaimed.has(fullName)) {

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2046,6 +2046,13 @@ export function coerceType(
             for (const instr of buildDispatch(0)) {
               fctx.body.push(instr);
             }
+            // (#1989) Restore the re-entrancy guard before returning. Without
+            // this, coercing the FIRST of two struct operands (e.g. `a < b`)
+            // leaves `__insideValueOfCoercion` set, so the SECOND operand's
+            // coercion takes the recursion-guard early-return and silently
+            // yields NaN. (Latent since this eqref-closure path was rarely
+            // reached for method-shorthand before per-instance dispatch.)
+            cleanup();
             return;
           }
           // No closure types found — check for a standalone ClassName_valueOf function (#433)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10697,8 +10697,10 @@ assert._isSameValue = isSameValue;
       // `host_loose_eq` uses) so the per-instance compiled valueOf/toString is
       // dispatched in-module; a no-method struct resolves to "[object Object]".
       return (a: any, b: any) => {
-        const av = a != null && typeof a === "object" && _isWasmStruct(a) ? _toPrimitiveSync(a, "default", callbackState) : a;
-        const bv = b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, "default", callbackState) : b;
+        const av =
+          a != null && typeof a === "object" && _isWasmStruct(a) ? _toPrimitiveSync(a, "default", callbackState) : a;
+        const bv =
+          b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, "default", callbackState) : b;
         return av + bv;
       };
     case "same_value_zero":

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10651,12 +10651,23 @@ assert._isSameValue = isSameValue;
       };
     case "host_add":
       // #2058 — `+` for two externref operands (§13.15.3
-      // ApplyStringOrNumericBinaryOperator). JS `+` gives us ToPrimitive on both
-      // operands, the "concatenate if either primitive is a string" rule, and
-      // object valueOf/toString ordering for free, so `1 + "2"` → `"12"` and
-      // `1 + 2` → `3`. Returns a boxed any (number or string) the caller stores
-      // back into the `any` slot.
-      return (a: any, b: any) => a + b;
+      // ApplyStringOrNumericBinaryOperator). JS `+` gives us the "concatenate if
+      // either primitive is a string" rule and primitive valueOf/toString
+      // ordering for free, so `1 + "2"` → `"12"` and `1 + 2` → `3`. Returns a
+      // boxed any (number or string) the caller stores back into the `any` slot.
+      //
+      // #1989/#1988 — but a WasmGC struct operand carrying a COMPILED
+      // valueOf/toString (the funcref field isn't a JS-callable method) makes
+      // native JS `a + b` throw "Cannot convert object to primitive value". Per
+      // §13.15.3 step 1, `+` runs ToPrimitive(operand, "default") on each side
+      // FIRST. Route struct operands through `_toPrimitiveSync` (the same proxy
+      // `host_loose_eq` uses) so the per-instance compiled valueOf/toString is
+      // dispatched in-module; a no-method struct resolves to "[object Object]".
+      return (a: any, b: any) => {
+        const av = a != null && typeof a === "object" && _isWasmStruct(a) ? _toPrimitiveSync(a, "default", callbackState) : a;
+        const bv = b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, "default", callbackState) : b;
+        return av + bv;
+      };
     case "same_value_zero":
       // #1360 — SameValueZero comparison (§7.2.11).
       // Same as Strict Equality except NaN === NaN is true.

--- a/tests/issue-1989.test.ts
+++ b/tests/issue-1989.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #1989 — ToPrimitive valueOf/toString dispatch must be PER-INSTANCE.
+ *
+ * Two object literals that share a Wasm struct SHAPE (e.g.
+ * `{ valueOf() { return 7; } }` and `{ valueOf() { return 100; } }`) dedup to
+ * one anonymous struct type. Before this fix, every same-shape literal's method
+ * was compiled to a single name-keyed standalone function `${typeName}_valueOf`,
+ * so the LAST-compiled literal's method body won for ALL coercions:
+ *
+ *   const a: any = { valueOf() { return 7; } };
+ *   const b: any = { valueOf() { return 100; } };
+ *   String(a + 1) + "," + String(b + 1)
+ *   // wasm (buggy): "101,101"   node: "8,101"
+ *
+ * Three stacked defects had to be addressed (see the issue file):
+ *   (D1) same-shape literals collapsed onto one method func — fixed by forking a
+ *        per-literal method func for 2nd+ same-shape ToPrimitive-method literals
+ *        and storing each literal's OWN funcref in its struct field
+ *        (literals.ts, `toPrimitiveForkedStructs`).
+ *   (D2) the headline `a + 1` (an `any`/externref operand) routes to the host
+ *        `__host_add` which ran native JS `a + b` — V8 cannot reach a WasmGC
+ *        struct's compiled valueOf. Fixed by running `_toPrimitiveSync` on
+ *        un-proxied struct operands inside `host_add` (runtime.ts), which
+ *        dispatches the per-instance compiled method in-module.
+ *   (D3) the host `__call_valueOf`/`__call_toString` ToPrimitive exports + the
+ *        in-module eqref dispatch read the per-instance struct field (not the
+ *        name-keyed func) for forked structs (index.ts, type-coercion.ts).
+ *
+ * The §7.1.1.1 step-6 TypeError walk (both valueOf+toString return objects) is
+ * preserved: single-literal structs stay on the well-tested name-keyed standalone
+ * path; only the genuine same-shape collision opts into per-instance dispatch.
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function runWasm(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  const fn = exports.test as () => unknown;
+  return fn();
+}
+
+describe("#1989 — per-instance valueOf/toString dispatch", () => {
+  it("method-shorthand: same-shape valueOf literals coerce per-instance (the repro)", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf() { return 7; } };
+          const b: any = { valueOf() { return 100; } };
+          return String(a + 1) + "," + String(b + 1);
+        }
+      `),
+    ).toBe("8,101");
+  });
+
+  it("arrow-property: same-shape valueOf literals coerce per-instance", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf: () => 7 };
+          const b: any = { valueOf: () => 100 };
+          return String(a + 1) + "," + String(b + 1);
+        }
+      `),
+    ).toBe("8,101");
+  });
+
+  it("function-expression property: same-shape valueOf literals coerce per-instance", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf: function () { return 7; } };
+          const b: any = { valueOf: function () { return 100; } };
+          return String(a + 1) + "," + String(b + 1);
+        }
+      `),
+    ).toBe("8,101");
+  });
+
+  it("cross-method variant: valueOf and toString objects each pick their own method", async () => {
+    // a/b carry valueOf (number hint via `+`); c carries toString (String()).
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf() { return 2; } };
+          const b: any = { valueOf() { return 100; } };
+          const c: any = { toString() { return "T"; } };
+          return String(a + 1) + "," + String(b + 1) + "," + String(c);
+        }
+      `),
+    ).toBe("3,101,T");
+  });
+
+  it("mixed-hint: one object's string vs number hint pick the right method", async () => {
+    // `${a}` is a string hint → toString → "S"; `a + 0` is number hint → valueOf → 5.
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf() { return 5; }, toString() { return "S"; } };
+          return \`\${a}\` + "," + String(a + 0);
+        }
+      `),
+    ).toBe("S,5");
+  });
+
+  it("three same-shape valueOf objects all coerce via their own method", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { valueOf() { return 1; } };
+          const b: any = { valueOf() { return 2; } };
+          const c: any = { valueOf() { return 3; } };
+          return String(a + 0) + String(b + 0) + String(c + 0);
+        }
+      `),
+    ).toBe("123");
+  });
+
+  it("two same-shape toString objects stringify per-instance", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const a: any = { toString() { return "A"; } };
+          const b: any = { toString() { return "B"; } };
+          return String(a) + "," + String(b);
+        }
+      `),
+    ).toBe("A,B");
+  });
+
+  it("preserves §7.1.1.1 step-6 TypeError when both valueOf and toString return objects", async () => {
+    // Single literal: stays on the name-keyed standalone ToPrimitive walk, which
+    // throws TypeError when neither method yields a primitive.
+    expect(
+      await runWasm(`
+        export function test(): any {
+          const obj: any = {
+            valueOf() { return ({} as any); },
+            toString() { return ({} as any); },
+          };
+          try { return obj + 1; } catch (e) { return "TYPEERR"; }
+        }
+      `),
+    ).toBe("TYPEERR");
+  });
+});


### PR DESCRIPTION
## #1989 — last same-shape literal's valueOf wins for ALL coercions

Two object literals sharing a Wasm struct shape deduped to one anon struct type
AND one name-keyed `${typeName}_valueOf` method, so the last-compiled body won
for every coercion:

```ts
const a: any = { valueOf() { return 7; } };
const b: any = { valueOf() { return 100; } };
String(a + 1) + "," + String(b + 1)   // wasm: "101,101"  node: "8,101"
```

### Root cause — three stacked defects (all fixed)

1. **Collapse (`literals.ts`)** — the #1557 per-literal fork only fired on a
   *signature* mismatch, so same-signature siblings (the repro) shared one method
   func. Now the **2nd+** same-shape `valueOf`/`toString`/`@@toPrimitive` literal
   forks its own method func (even on sig match) and stores its own funcref in its
   struct field; the struct is marked in `ctx.toPrimitiveForkedStructs`. The
   **first** literal stays on the base path (keeps the shared func) — forking it
   recorded a stale funcIdx because `emitObjectMethodAsClosure` shifts later
   method funcs during construction (the architect's "timing blocker").

2. **`any`-operand `+` never reached in-module dispatch (`runtime.ts`)** — the
   headline `a + 1` routes to host `__host_add` which ran native JS `a + b`; V8
   can't reach a WasmGC struct's compiled valueOf. Now `host_add` runs
   `_toPrimitiveSync` on un-proxied struct operands (mirrors `host_loose_eq`),
   dispatching the per-instance compiled method in-module.

3. **Host ToPrimitive exports were name-keyed (`index.ts`) + a re-entrancy bug
   (`type-coercion.ts`)** — `__call_valueOf`/`__call_toString` (used by the
   runtime ToPrimitive proxy → `host_add`/`String()`/loose-eq) now dispatch
   through the per-instance struct field for forked structs (new `closure-extern`
   mode for the `any`-object externref field). Also restored the `cleanup()`
   re-entrancy-guard reset so coercing the first of two struct operands doesn't
   leave the second yielding NaN.

### Scope / safety

Single-literal structs stay on the name-keyed standalone path — this preserves
the §7.1.1.1 step-6 TypeError walk (both valueOf+toString return objects) and
avoids the same-shape-closure `ref.test` ambiguity. Only the genuine same-shape
collision opts into per-instance dispatch.

### Tests

- `tests/issue-1989.test.ts` (8 cases): all three property forms (method
  shorthand / arrow / function expression), cross-method + mixed-hint variants,
  3-object, two-toString, and the step-6 TypeError.
- Zero regressions across issue-1525/1525b/866/1253/1319/1990/2058/2007 + the
  object-to-primitive / comparison-coercion / string-arithmetic equivalence
  suites (5 pre-existing failures in these files → 0). Typecheck clean; merged
  clean over #1988/#2015/#2007.

### Known residual (not in this issue's acceptance criteria)

Two same-shape **typed-nominal** struct literals (not `any`) still collapse in
the in-module numeric coercion path, because a nominal struct's first method func
isn't pre-registered at construction time. The `any`-typed repros this issue
filed all work; the nominal variant is a narrower follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)