### PR TITLE
fix(#2081): native §7.2.15 loose-eq coercion for any/any in standalone

### DIFF
--- a/plan/issues/2081-standalone-any-any-loose-eq-ref-identity.md
+++ b/plan/issues/2081-standalone-any-any-loose-eq-ref-identity.md
@@ -1,10 +1,11 @@
 ---
 id: 2081
 title: "standalone: loose == between two any operands compares references, never coerces ('1' == 1 → false)"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-14
+completed: 2026-06-14
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -47,3 +48,56 @@ needs for mixed static types — implement together).
 
 #1986/#1987 (strict ===, host), #1990 (host loose eq), #1900/#1910
 (object ToPrimitive). Partially new — the primitive/primitive half. Filed.
+
+## Resolution (2026-06-14, sdev) — CORRECTED root cause + fix
+
+The architect spec (in the sprint-branch copy) routed the fix to extending
+`__any_eq`'s §7.2.15 coverage. **That was wrong for the live repro**: WAT-tracing
+`const a: any = "1"; const b: any = 1; a == b` under `--target wasi` showed it
+NEVER reaches `__any_eq` — `ctx.anyValueTypeIdx` stays `-1` (the module never
+boxes an `any` into `$AnyValue`), so the `compileAnyBinaryDispatch → __any_eq`
+gate (`binary-ops.ts:950`, `>= 0`) is skipped entirely. The `==` instead lowers
+through the **#1776 no-JS-host native equality cascade** (`binary-ops.ts:~1936`,
+gated `noJsHost && one-externref`): it handled number/number, bool/bool,
+bigint/bigint, then fell to **eqref `ref.eq` identity** — never the §7.2.15
+cross-type coercion. So `"1" == 1` compared two distinct externrefs by identity →
+`false`. (The original issue title — "compares references, never coerces" — was
+right; the spec's "already routes to __any_eq" correction was not.)
+
+### Fix — `src/codegen/binary-ops.ts` (#1776 native equality cascade)
+Added the missing §7.2.15 LOOSE arms (gated `!isStrict && (== | !=)` so strict
+`===` is unchanged — `"1" === 1` stays `false` by type):
+- **null/undefined (steps 2-3):** wrap the cascade in a both-nullish guard —
+  both `ref.is_null` ⇒ `true`; nullish-vs-non-nullish ⇒ `false` (never coerce —
+  `null == 0` stays false). (Under this rep null and undefined are both
+  `ref.null extern`, so one guard covers all three nullish pairings.)
+- **Number/Boolean (step 8):** broaden the numeric arm for loose eq to
+  number-OR-boolean, ToNumber each (`__unbox_boolean`+`f64.convert` for bool,
+  `__unbox_number` for number), `f64.eq` — so `true == 1`, `false == 0`.
+- **String⇄Number (steps 4-7):** when exactly one side is a native string ref
+  and the other is `typeof number`, ToNumber both — string via the §7.1.4.1
+  `__str_to_number` scanner (NaN unparseable, 0 empty, hex/inf; NOT `parseFloat`),
+  number via `__unbox_number` — `f64.eq`. Falls back to the existing
+  string==string `__str_equals` / eqref-identity arm otherwise.
+
+Also (defensive, for any module that DOES box to `$AnyValue`):
+- `src/codegen/any-helpers.ts` — added the String⇄Number arm to `__any_eq`
+  (the spec's intended change; correct but not the live path for this repro).
+- `src/codegen/binary-ops.ts` — the externref loose-eq host fallback now routes
+  through native `__any_eq(__any_from_extern(a), __any_from_extern(b))` in
+  standalone instead of leaking the unsatisfiable `__host_loose_eq` import.
+
+DEFERRED (out of scope, unchanged): object⇄primitive ToPrimitive (`[] == 0`)
+rides #1900; BigInt⇄String exact compare; the strict `null === undefined`
+representation collapse (separate — needs distinct undefined sentinel).
+
+### Verification
+- New `tests/issue-2081.test.ts` (11 cases, standalone): `"1"==1`/reversed,
+  `""==0`, `"abc"==0` (false), hex, `!=`, `true==1`/`false==0`/`true==2`(false),
+  `null==undefined`(true)/`null==0`(false), object identity (same==true,
+  distinct==false), strict `===` no-coerce, number/number. All pass; valid
+  module, zero host imports.
+- Equality regression suites green (82 tests across issue-1776/1986/1990/2063 +
+  equivalence equality/comparison/typeof/struct-null/boolean-relational).
+- Full `tests/equivalence/` sweep: identical failing-set vs origin/main
+  (verified by swapping the original binary-ops.ts/any-helpers.ts back in).

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -8,6 +8,7 @@
 import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { nativeStringType } from "./native-strings.js";
+import { emitNativeParseNumber } from "./parse-number-native.js";
 import { addFuncType } from "./registry/types.js";
 import { addStringImportsDelegate, registerEnsureAnyHelpers } from "./shared.js";
 
@@ -382,6 +383,22 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
 
   // String content comparison via wasm:js-string equals (tag 5)
   const strEqualsIdx = ctx.jsStringImports.get("equals") ?? -1;
+
+  // (#2081) StringToNumber scanner (§7.1.4.1) for the cross-tag String⇄Number
+  // loose-equality arm in `__any_eq`. Only the standalone/WASI native-string
+  // path has it (signature `(externref) -> f64`; converts the externref back to
+  // `ref $AnyString` internally — NaN for unparseable, 0 for empty, hex/inf
+  // handled). Host mode uses `__host_loose_eq`, so leave this -1 there and the
+  // arm stays a conservative `0` (no regression — host never reaches __any_eq).
+  // Mirrors the static-type lowering at binary-ops.ts:881-889; deliberately NOT
+  // `parseFloat` (Number("0xff")=255 but parseFloat("0xff")=NaN — §7.1.4.1).
+  let strToNumIdx = -1;
+  if ((ctx.standalone === true || ctx.wasi === true) && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    if (!ctx.funcMap.has("__str_to_number")) {
+      emitNativeParseNumber(ctx, new Set(["__str_to_number"]));
+    }
+    strToNumIdx = ctx.funcMap.get("__str_to_number") ?? -1;
+  }
 
   // Helper to register a helper function
   function addHelper(
@@ -1018,7 +1035,84 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
                       { op: "call", funcIdx: toF64Idx },
                       { op: "f64.eq" },
                     ],
-                    else: [{ op: "i32.const", value: 0 }],
+                    // (#2081) §7.2.15 steps 4-7: String(tag 5) ⇄ Number/Boolean
+                    // (tags 2,3,4) ⇒ compare ToNumber(both). Today this returned
+                    // a wrong `false` (`"1" == 1`). Gate on EXACTLY one side being
+                    // a string and the other numeric-coercible — never pull
+                    // null/undefined (tag<2) or object (tag 6) into coercion. Only
+                    // available with the native StringToNumber scanner (standalone
+                    // /WASI nativeStrings); else fall through to the prior `0`.
+                    else:
+                      strToNumIdx >= 0
+                        ? [
+                            // (tagA==5 && tagB in {2..4}) || (tagB==5 && tagA in {2..4})
+                            { op: "local.get", index: 2 },
+                            { op: "i32.const", value: 5 },
+                            { op: "i32.eq" },
+                            { op: "local.get", index: 3 },
+                            { op: "i32.const", value: 2 },
+                            { op: "i32.ge_s" },
+                            { op: "local.get", index: 3 },
+                            { op: "i32.const", value: 4 },
+                            { op: "i32.le_s" },
+                            { op: "i32.and" },
+                            { op: "i32.and" },
+                            { op: "local.get", index: 3 },
+                            { op: "i32.const", value: 5 },
+                            { op: "i32.eq" },
+                            { op: "local.get", index: 2 },
+                            { op: "i32.const", value: 2 },
+                            { op: "i32.ge_s" },
+                            { op: "local.get", index: 2 },
+                            { op: "i32.const", value: 4 },
+                            { op: "i32.le_s" },
+                            { op: "i32.and" },
+                            { op: "i32.and" },
+                            { op: "i32.or" },
+                            {
+                              op: "if",
+                              blockType: { kind: "val", type: { kind: "i32" } },
+                              then: [
+                                // ToNumber(a): tag5 → __str_to_number(externval), else __any_to_f64
+                                { op: "local.get", index: 2 },
+                                { op: "i32.const", value: 5 },
+                                { op: "i32.eq" },
+                                {
+                                  op: "if",
+                                  blockType: { kind: "val", type: { kind: "f64" } },
+                                  then: [
+                                    { op: "local.get", index: 0 },
+                                    { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                    { op: "call", funcIdx: strToNumIdx },
+                                  ],
+                                  else: [
+                                    { op: "local.get", index: 0 },
+                                    { op: "call", funcIdx: toF64Idx },
+                                  ],
+                                },
+                                // ToNumber(b)
+                                { op: "local.get", index: 3 },
+                                { op: "i32.const", value: 5 },
+                                { op: "i32.eq" },
+                                {
+                                  op: "if",
+                                  blockType: { kind: "val", type: { kind: "f64" } },
+                                  then: [
+                                    { op: "local.get", index: 1 },
+                                    { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                    { op: "call", funcIdx: strToNumIdx },
+                                  ],
+                                  else: [
+                                    { op: "local.get", index: 1 },
+                                    { op: "call", funcIdx: toF64Idx },
+                                  ],
+                                },
+                                { op: "f64.eq" },
+                              ],
+                              else: [{ op: "i32.const", value: 0 }],
+                            },
+                          ]
+                        : [{ op: "i32.const", value: 0 }],
                   },
                 ],
               },

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -15,7 +15,7 @@ import {
   isWrapperObjectType,
 } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
-import { isAnyValue } from "./any-helpers.js";
+import { ensureAnyFromExternHelper, isAnyValue } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -1956,23 +1956,63 @@ export function compileBinaryExpression(
       }
       fctx.body.push({ op: "local.set", index: lTmp });
 
-      const eqInstrs: Instr[] = [
-        // ── number? ──
+      // (#2081) LOOSE null/undefined arm (§7.2.15 steps 2-3): `null == undefined`
+      // (and null==null / undefined==undefined) ⇒ true; a nullish vs a
+      // non-nullish ⇒ false (never coerces — `null == 0` is false). Under this
+      // representation both null and undefined are `ref.null extern`, so a
+      // both-nullish test captures all three nullish pairings. LOOSE only — strict
+      // `null === undefined` is handled by the type-aware path and must stay
+      // false; gate on `!isStrict`. The numeric/bool/string/identity cascade
+      // below is the `else`.
+      const looseNullish =
+        !isStrict && (op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken);
+      // (#2081) ToNumber for the LOOSE numeric arm: a boxed boolean coerces to
+      // 0/1 (§7.2.15 step 8 / §7.1.4 ToNumber(Boolean)), a number unboxes. Used
+      // only when the arm has already established the operand is number-or-bool.
+      const looseToNum = (externLocal: number): Instr[] => [
+        { op: "local.get", index: externLocal },
+        { op: "call", funcIdx: typeofBool } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "f64" } },
+          then: [
+            { op: "local.get", index: externLocal },
+            { op: "call", funcIdx: unboxBool },
+            { op: "f64.convert_i32_s" },
+          ],
+          else: [
+            { op: "local.get", index: externLocal },
+            { op: "call", funcIdx: unboxNum },
+          ],
+        } as Instr,
+      ];
+      const coreEqInstrs: Instr[] = [
+        // ── number (loose: number-or-boolean — §7.2.15 step 8 Boolean→ToNumber,
+        //    so `true == 1`, `false == 0` compare numerically; strict keeps
+        //    number-only since `true === 1` is false by type)? ──
         { op: "local.get", index: lTmp },
         { op: "call", funcIdx: typeofNum } as Instr,
+        ...(looseNullish
+          ? ([{ op: "local.get", index: lTmp }, { op: "call", funcIdx: typeofBool }, { op: "i32.or" }] as Instr[])
+          : []),
         { op: "local.get", index: rTmp },
         { op: "call", funcIdx: typeofNum } as Instr,
+        ...(looseNullish
+          ? ([{ op: "local.get", index: rTmp }, { op: "call", funcIdx: typeofBool }, { op: "i32.or" }] as Instr[])
+          : []),
         { op: "i32.and" } as Instr,
         {
           op: "if",
           blockType: { kind: "val", type: { kind: "i32" } },
-          then: [
-            { op: "local.get", index: lTmp },
-            { op: "call", funcIdx: unboxNum },
-            { op: "local.get", index: rTmp },
-            { op: "call", funcIdx: unboxNum },
-            { op: "f64.eq" } as Instr,
-          ],
+          then: looseNullish
+            ? [...looseToNum(lTmp), ...looseToNum(rTmp), { op: "f64.eq" } as Instr]
+            : [
+                { op: "local.get", index: lTmp },
+                { op: "call", funcIdx: unboxNum },
+                { op: "local.get", index: rTmp },
+                { op: "call", funcIdx: unboxNum },
+                { op: "f64.eq" } as Instr,
+              ],
           else: [
             // ── boolean? ──
             { op: "local.get", index: lTmp },
@@ -2037,48 +2077,113 @@ export function compileBinaryExpression(
                           else: [{ op: "i32.const", value: 0 }],
                         } as Instr,
                       ];
+                      // ── string? ── (#1914) Native strings are VALUE-compared
+                      // (§7.2.16 "If x is a String"). Without this, `a === b` over
+                      // `any`-typed string operands (e.g. the test262 harness's
+                      // `isSameValue`) fell to ref.eq identity and returned false
+                      // for equal strings from distinct allocations. Falls back to
+                      // the eqref identity arm when not both strings.
+                      const stringAndIdentityArm = (): Instr[] => {
+                        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+                          ensureNativeStringHelpers(ctx);
+                          const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+                          const strEqIdx = ctx.nativeStrHelpers.get("__str_equals");
+                          if (flattenIdx !== undefined && strEqIdx !== undefined) {
+                            return [
+                              { op: "local.get", index: lAny },
+                              { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                              { op: "local.get", index: rAny },
+                              { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                              { op: "i32.and" } as Instr,
+                              {
+                                op: "if",
+                                blockType: { kind: "val", type: { kind: "i32" } },
+                                then: [
+                                  { op: "local.get", index: lAny },
+                                  { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                                  { op: "call", funcIdx: flattenIdx },
+                                  { op: "local.get", index: rAny },
+                                  { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                                  { op: "call", funcIdx: flattenIdx },
+                                  { op: "call", funcIdx: strEqIdx },
+                                ],
+                                else: identityArm,
+                              } as Instr,
+                            ];
+                          }
+                        }
+                        return identityArm;
+                      };
                       const seq: Instr[] = [
                         { op: "local.set", index: rAny },
                         { op: "local.set", index: lAny },
                       ];
-                      // ── string? ── (#1914) Native strings are VALUE-compared
-                      // (§7.2.16 step "If x is a String"). Without this arm,
-                      // every `a === b` over `any`-typed string operands — most
-                      // visibly the test262 harness's `isSameValue` — fell to
-                      // ref.eq identity and returned false for equal strings
-                      // from distinct allocations (literal vs literal included,
-                      // since each string literal materializes a fresh struct).
-                      let stringArmEmitted = false;
-                      if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
-                        ensureNativeStringHelpers(ctx);
-                        const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
-                        const strEqIdx = ctx.nativeStrHelpers.get("__str_equals");
-                        if (flattenIdx !== undefined && strEqIdx !== undefined) {
-                          stringArmEmitted = true;
+                      // ── (#2081) LOOSE String ⇄ Number arm (§7.2.15 steps 4-7) ──
+                      // For `==`/`!=` only (NOT strict — `"1" === 1` is false by
+                      // type), when EXACTLY one operand is a native string and the
+                      // other is a number, compare ToNumber(both): ToNumber(string)
+                      // via the §7.1.4.1 `__str_to_number` scanner (NaN for
+                      // unparseable, 0 for empty, hex/inf), `__unbox_number` for the
+                      // numeric side, then `f64.eq`. Without this, `"1" == 1` fell
+                      // through the string==string arm (right isn't a string) to
+                      // ref.eq identity → wrong `false`. The boolean side is already
+                      // covered by the typeof-boolean arm above (`true == 1`).
+                      // `parseFloat` is deliberately NOT used (Number("0xff")=255 vs
+                      // parseFloat("0xff")=NaN — §7.1.4.1).
+                      let looseStrNumEmitted = false;
+                      if (
+                        !isStrict &&
+                        ctx.nativeStrings &&
+                        ctx.anyStrTypeIdx >= 0 &&
+                        (op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken)
+                      ) {
+                        if (!ctx.funcMap.has("__str_to_number")) {
+                          emitNativeParseNumber(ctx, new Set(["__str_to_number"]));
+                        }
+                        const strToNumIdx = ctx.funcMap.get("__str_to_number");
+                        if (strToNumIdx !== undefined) {
+                          looseStrNumEmitted = true;
+                          // ToNumber(side): native string → __str_to_number(extern);
+                          // else (a boxed number) → __unbox_number.
+                          const toNumberOf = (anyLocal: number, externLocal: number): Instr[] => [
+                            { op: "local.get", index: anyLocal },
+                            { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                            {
+                              op: "if",
+                              blockType: { kind: "val", type: { kind: "f64" } },
+                              then: [
+                                { op: "local.get", index: externLocal },
+                                { op: "call", funcIdx: strToNumIdx },
+                              ],
+                              else: [
+                                { op: "local.get", index: externLocal },
+                                { op: "call", funcIdx: unboxNum },
+                              ],
+                            } as Instr,
+                          ];
+                          // (lIsStr && rIsNum) || (rIsStr && lIsNum)
                           seq.push(
                             { op: "local.get", index: lAny },
                             { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                            { op: "local.get", index: rTmp },
+                            { op: "call", funcIdx: typeofNum } as Instr,
+                            { op: "i32.and" } as Instr,
                             { op: "local.get", index: rAny },
                             { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                            { op: "local.get", index: lTmp },
+                            { op: "call", funcIdx: typeofNum } as Instr,
                             { op: "i32.and" } as Instr,
+                            { op: "i32.or" } as Instr,
                             {
                               op: "if",
                               blockType: { kind: "val", type: { kind: "i32" } },
-                              then: [
-                                { op: "local.get", index: lAny },
-                                { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
-                                { op: "call", funcIdx: flattenIdx },
-                                { op: "local.get", index: rAny },
-                                { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
-                                { op: "call", funcIdx: flattenIdx },
-                                { op: "call", funcIdx: strEqIdx },
-                              ],
-                              else: identityArm,
+                              then: [...toNumberOf(lAny, lTmp), ...toNumberOf(rAny, rTmp), { op: "f64.eq" } as Instr],
+                              else: stringAndIdentityArm(),
                             } as Instr,
                           );
                         }
                       }
-                      if (!stringArmEmitted) seq.push(...identityArm);
+                      if (!looseStrNumEmitted) seq.push(...stringAndIdentityArm());
                       releaseTempLocal(fctx, lAny);
                       releaseTempLocal(fctx, rAny);
                       return seq;
@@ -2090,6 +2195,31 @@ export function compileBinaryExpression(
           ],
         } as Instr,
       ];
+      // For loose equality, wrap the core cascade in the nullish guard
+      // (§7.2.15 steps 2-3): both nullish ⇒ true; nullish-vs-non-nullish ⇒ false.
+      const eqInstrs: Instr[] = looseNullish
+        ? [
+            { op: "local.get", index: lTmp },
+            { op: "ref.is_null" } as Instr,
+            { op: "local.get", index: rTmp },
+            { op: "ref.is_null" } as Instr,
+            // (lNull || rNull): if EITHER is nullish, the result is whether BOTH
+            // are nullish (true) or not (false) — never coerce against a nullish.
+            { op: "i32.or" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "i32" } },
+              then: [
+                { op: "local.get", index: lTmp },
+                { op: "ref.is_null" } as Instr,
+                { op: "local.get", index: rTmp },
+                { op: "ref.is_null" } as Instr,
+                { op: "i32.and" } as Instr,
+              ],
+              else: coreEqInstrs,
+            } as Instr,
+          ]
+        : coreEqInstrs;
       for (const ins of eqInstrs) fctx.body.push(ins);
       if (isNeqOp) fctx.body.push({ op: "i32.eqz" });
       releaseTempLocal(fctx, rTmp);
@@ -2402,6 +2532,37 @@ export function compileBinaryExpression(
               } as Instr,
             ] as Instr[];
           } else {
+            // Loose equality fallback for two externref `any` operands that are
+            // not eqref-identical.
+            //
+            // (#2081) STANDALONE/WASI has no JS host, so `__host_loose_eq` is an
+            // unsatisfiable import — it leaked into the module and made
+            // `("1" as any) == (1 as any)` either fail instantiation or return a
+            // wrong `false` (ref-identity never coerces string⇄number). Route
+            // through the NATIVE IsLooselyEqual instead: box both externrefs to
+            // `$AnyValue` (`__any_from_extern` → tag5 string / tag3 number / tag4
+            // bool / tag1 null) and call `__any_eq`, whose §7.2.15 arms
+            // (incl. the String⇄Number arm added in this PR) implement the spec
+            // coercion natively. Host mode keeps `__host_loose_eq` (JS `==`),
+            // unchanged.
+            const noJsHost = ctx.standalone === true || ctx.wasi === true;
+            if (noJsHost) {
+              ensureAnyHelpers(ctx);
+              const fromExternIdx = ensureAnyFromExternHelper(ctx);
+              const anyEqIdx = ctx.funcMap.get("__any_eq");
+              if (fromExternIdx !== undefined && anyEqIdx !== undefined) {
+                return [
+                  { op: "local.get", index: tmpLeft },
+                  { op: "call", funcIdx: fromExternIdx } as Instr,
+                  { op: "local.get", index: tmpRight },
+                  { op: "call", funcIdx: fromExternIdx } as Instr,
+                  { op: "call", funcIdx: anyEqIdx } as Instr,
+                  ...(isNeqOp ? [{ op: "i32.eqz" } as Instr] : []),
+                ] as Instr[];
+              }
+              // Helpers unavailable (should not happen) — fall through to the
+              // host import below rather than emit nothing.
+            }
             // Loose equality: __host_loose_eq (JS ==) handles all coercion
             // rules including null==undefined per §7.2.15. The result is
             // definitive — no numeric fallback needed. (#1134)

--- a/tests/issue-2081.test.ts
+++ b/tests/issue-2081.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2081 — standalone loose `==` between two `any` operands compared by reference
+// identity and never coerced, so `("1" as any) == (1 as any)` returned false.
+//
+// Root cause (corrected vs the architect spec): the headline repro does NOT
+// reach `__any_eq` (anyValueTypeIdx stays -1) — it lowers through the #1776
+// no-JS-host native equality cascade in binary-ops.ts, which handled
+// number/number, bool/bool, bigint/bigint, then fell to eqref ref-identity.
+// The cross-type loose coercion arms (§7.2.15) were missing. This adds, for
+// LOOSE `==`/`!=` only (strict is unchanged — `"1" === 1` is false by type):
+//   - null/undefined cross (steps 2-3) — both nullish ⇒ true,
+//   - Number/Boolean numeric coercion (step 8) — `true == 1`, `false == 0`,
+//   - String⇄Number (steps 4-7) — ToNumber(string) via the §7.1.4.1
+//     `__str_to_number` scanner (NOT parseFloat), then f64.eq.
+//
+// Verified standalone (`--target wasi`): valid module, no host imports.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function looseEq(src: string): Promise<boolean> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  // standalone: no host imports should leak for a pure equality module
+  expect((r.imports ?? []).filter((i) => i.module === "env" && i.name === "__host_loose_eq")).toHaveLength(0);
+  const io: any = r.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports);
+  return Boolean((instance.exports as { test(): unknown }).test());
+}
+
+describe("#2081 — standalone loose == coerces (any/any)", () => {
+  it('"1" == 1  → true (String⇄Number, the headline repro)', async () => {
+    expect(
+      await looseEq(`const a: any = "1"; const b: any = 1; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+  });
+
+  it('1 == "1"  → true (reversed)', async () => {
+    expect(
+      await looseEq(`const a: any = 1; const b: any = "1"; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+  });
+
+  it('"" == 0   → true (ToNumber("")=0)', async () => {
+    expect(
+      await looseEq(`const a: any = ""; const b: any = 0; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+  });
+
+  it('"abc" == 0 → false (ToNumber("abc")=NaN)', async () => {
+    expect(
+      await looseEq(`const a: any = "abc"; const b: any = 0; export function test(): boolean { return a == b; }`),
+    ).toBe(false);
+  });
+
+  it('"0x10" == 16 → true (ToNumber parses hex, NOT parseFloat)', async () => {
+    expect(
+      await looseEq(`const a: any = "0x10"; const b: any = 16; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+  });
+
+  it('"2" != 1  → true', async () => {
+    expect(
+      await looseEq(`const a: any = "2"; const b: any = 1; export function test(): boolean { return a != b; }`),
+    ).toBe(true);
+  });
+
+  it("true == 1, false == 0 → true (Boolean→ToNumber)", async () => {
+    expect(
+      await looseEq(`const a: any = true; const b: any = 1; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+    expect(
+      await looseEq(`const a: any = false; const b: any = 0; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+    expect(
+      await looseEq(`const a: any = true; const b: any = 2; export function test(): boolean { return a == b; }`),
+    ).toBe(false);
+  });
+
+  it("null == undefined → true; null == 0 → false (never coerces nullish)", async () => {
+    expect(
+      await looseEq(
+        `const a: any = null; const b: any = undefined; export function test(): boolean { return a == b; }`,
+      ),
+    ).toBe(true);
+    expect(
+      await looseEq(`const a: any = null; const b: any = 0; export function test(): boolean { return a == b; }`),
+    ).toBe(false);
+  });
+
+  it("object identity preserved: same ref == true, distinct == false", async () => {
+    expect(
+      await looseEq(
+        `const o: any = {}; const a: any = o; const b: any = o; export function test(): boolean { return a == b; }`,
+      ),
+    ).toBe(true);
+    expect(
+      await looseEq(`const a: any = {}; const b: any = {}; export function test(): boolean { return a == b; }`),
+    ).toBe(false);
+  });
+
+  it("strict === does NOT coerce: '1' === 1 → false, true === 1 → false", async () => {
+    expect(
+      await looseEq(`const a: any = "1"; const b: any = 1; export function test(): boolean { return a === b; }`),
+    ).toBe(false);
+    expect(
+      await looseEq(`const a: any = true; const b: any = 1; export function test(): boolean { return a === b; }`),
+    ).toBe(false);
+  });
+
+  it("number/number loose unchanged: 2 == 2 true, 2 == 3 false", async () => {
+    expect(
+      await looseEq(`const a: any = 2; const b: any = 2; export function test(): boolean { return a == b; }`),
+    ).toBe(true);
+    expect(
+      await looseEq(`const a: any = 2; const b: any = 3; export function test(): boolean { return a == b; }`),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

```ts
const a: any = "1"; const b: any = 1;
a == b   // standalone: false   node: true
```

Standalone loose `==` between two `any` operands compared by **reference identity** and never coerced.

## Root cause (corrected — the architect spec's diagnosis was unreachable)

The spec routed the fix to `__any_eq`'s §7.2.15 coverage. WAT-tracing the repro under `--target wasi` showed it **never reaches `__any_eq`**: `ctx.anyValueTypeIdx` stays `-1` (the module never boxes an `any` into `$AnyValue`), so the `compileAnyBinaryDispatch → __any_eq` gate (binary-ops.ts:950, `>= 0`) is skipped. `==` instead lowers through the **#1776 no-JS-host native equality cascade** (binary-ops.ts ~1936), which handled number/number, bool/bool, bigint/bigint, then fell to **eqref `ref.eq` identity** — missing every §7.2.15 cross-type coercion arm.

## Fix — `src/codegen/binary-ops.ts` (the #1776 cascade)

LOOSE only (gated `!isStrict && (== | !=)`; **strict `===` unchanged** — `"1" === 1` stays `false` by type):
- **null/undefined (steps 2-3):** both-nullish guard ⇒ `true`; nullish-vs-non-nullish ⇒ `false` (`null == 0` stays false).
- **Number/Boolean (step 8):** broaden the numeric arm to number-or-boolean, ToNumber each (`__unbox_boolean`+convert / `__unbox_number`), `f64.eq` → `true == 1`, `false == 0`.
- **String⇄Number (steps 4-7):** exactly-one-string vs number ⇒ ToNumber both — string via the §7.1.4.1 `__str_to_number` scanner (**NOT** `parseFloat`: `Number("0xff")=255`), `f64.eq`.

Also additive (for any module that DOES box to `$AnyValue`): `__any_eq` gets the String⇄Number arm, and the externref loose-eq host fallback routes through native `__any_eq(__any_from_extern,…)` in standalone instead of leaking the unsatisfiable `__host_loose_eq` import.

## Deferred (unchanged, out of scope)
object⇄primitive ToPrimitive (`[] == 0`) rides #1900; BigInt⇄String; the strict `null === undefined` representation collapse.

## Acceptance criteria
- [x] `"1" == 1` (+ reversed) → true; both repros match Node standalone (primitive/primitive half)
- [x] Reference identity preserved for object==object

## Tests
`tests/issue-2081.test.ts` (11 cases): String⇄Number, hex, `!=`, Boolean→Number, null/undefined, object identity (same/distinct), strict-no-coerce, number/number. All pass; valid module, zero host imports.

## Regression verification
Equality suites green (85 tests across #1776/#1986/#1990/#2063 + equivalence equality/comparison/typeof/struct-null/boolean-relational). **Full `tests/equivalence/` suite: identical 54/54 failing-set vs `origin/main`** (verified by swapping the original `binary-ops.ts`/`any-helpers.ts` back in — same per-test counts). Re-verified green after merging latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)