### PR TITLE
fix(#2038): standalone native {next()} iterator carrier (PATH A)

### DIFF
--- a/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
+++ b/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
@@ -281,3 +281,53 @@ gotchas confirmed while starting:
    for-of/typed-struct paths must stay byte-identical (run the generator/for-of
    suites) BEFORE adding the USER arm — that isolates a struct-arity regression
    from a USER-arm bug.
+
+## Implementation attempt (2026-06-14, sdev) — USER carrier WIP + PREREQUISITE BLOCKER
+
+Implemented the USER_ITER carrier on this branch (committed WIP):
+- `$IterRec` extended with `userIter` (field 3, externref); the vec-path
+  `__iterator` `struct.new` updated to push the 4th operand. **Vec/array path is
+  byte-identical and fully intact** (array for-of host+wasi → 6; `issue-1320-
+  standalone-iter` 5/5; closure tests green — zero regression).
+- `__iterator` now branches `ref.test $vecExtern`: vec → VEC carrier; else →
+  USER carrier: `userIter = __extern_method_call(obj, "@@iterator", emptyVec)`
+  (falls back to `obj` itself if no `@@iterator`), builds `$IterRec{USER, null,
+  0, userIter}`. The module compiles VALID with ZERO leaked env imports.
+- `__iterator_next` branches on `rec.kind`: USER →
+  `res = __extern_method_call(userIter, "next", emptyVec)`,
+  `done = __is_truthy(__extern_get(res, "done"))`,
+  `value = __extern_get(res, "value")`.
+- Deps set up before bodies: `ensureObjectRuntime`, force-register the
+  `@@iterator`/`next`/`value`/`done` string constants, capture
+  `__extern_method_call`/`__extern_get`/`__is_truthy` funcMap indices. All three
+  are NATIVE funcs in standalone (not imports). tsc clean, module valid.
+
+### BLOCKER (root cause for the runtime hang)
+The USER runtime path HANGS (infinite loop in `__iterator_next` — `done` never
+becomes truthy). Traced to a PREREQUISITE GAP, not a bug in this code:
+**standalone any-receiver method dispatch is broken.** Direct repro on current
+main: `const o: any = { next() { return 7; } }; o.next()` → **standalone returns
+0** (should be 7) and does NOT even emit `__extern_method_call` — it takes a
+different, broken path. So `__extern_method_call(userIter, "next", …)` never
+actually invokes the iterator's `next()`; it returns null → `__extern_get(null,
+"done")` → null → `__is_truthy` 0 → never done → infinite loop.
+
+Root: `__extern_method_call` only handles an OPEN `$Object` receiver
+(object-runtime.ts:~4188 — non-`$Object` brands return undefined); a standalone
+object-literal method is a CLOSED WasmGC struct, and the any-receiver call path
+doesn't route closed-struct method calls through a working dispatcher. This is
+the STANDALONE analog of #2015 (which fixed the JS-host any-receiver `this`
+path). The USER carrier is correct in shape but cannot function until standalone
+any-receiver object-literal/iterator method dispatch works.
+
+### Recommendation
+Prerequisite needed: **native standalone any-receiver method dispatch**
+(`o.method()` on an `any`/externref object-literal receiver → call the
+closed-struct's compiled method, or a `__extern_method_call` that handles closed
+structs). File as a SENIOR prerequisite blocking #2038's USER arm. The
+USER-carrier scaffolding (struct + `__iterator`/`__iterator_next` branches) is
+committed and ready to light up once the dispatch prereq lands — then the sync
+custom-iterable repro (`for (const x of {[Symbol.iterator](){return
+{next(){…}}}})` → 0+1+2) should pass, and `ensureAsyncIterator` returning native
+`__iterator` in standalone extends it to sync-backed `for await`. Keep
+async-gen/yield* + Promise deferred.

--- a/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
+++ b/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
@@ -243,3 +243,41 @@ status stays `ready`/in-progress; implementation in worktree
   FINALIZE — ensure the native iterator bodies reference them by funcMap name
   (resolved at finalize), not by eager funcIdx. Watch late-import index shifting
   when registering the new string constants / forcing `__sget_*`.
+
+### Implementation-start learnings (2026-06-14, sdev — partial attempt, reverted)
+Started the carrier on freshest main (branch is merged-current with main), then
+reverted to keep the branch clean (blueprint-only) because the full USER carrier
+is a sizable, finalize-ordering-sensitive runtime change that warrants a
+fresh-context focused pass rather than a rushed one at deep context. Concrete
+gotchas confirmed while starting:
+1. **Struct arity is load-bearing.** Adding `userIter` as `$__IterRec` field 3
+   means the EXISTING vec-path `__iterator` body (`struct.new $__IterRec` with
+   3 operands: kind, vec, idx) becomes INVALID — it must push a 4th operand
+   (`ref.null.extern` for userIter). Update BOTH the `__iterator` vec arm AND
+   any other `struct.new $__IterRec` site in lockstep with the field add, or the
+   module fails validation. (I extracted the body into a `buildIteratorBody`
+   helper to branch vec-vs-user; do the same and keep the vec arm's 4-field
+   struct.new.)
+2. **Dependency setup order in `ensureNativeIteratorRuntime`:** call
+   `ensureObjectRuntime(ctx)` (registers/reserves `__extern_method_call`,
+   `__extern_get`, `__obj_find`) and force-register `__sget_value`/`__sget_done`
+   + the `@@iterator`/`next`/`value`/`done` string constants
+   (`addStringConstantGlobal` then `stringConstantExternrefInstrs(ctx, …)`)
+   BEFORE building the `__iterator`/`__iterator_next` bodies, so their funcIdx /
+   string-global refs are stable. The native bodies are passed EAGERLY to
+   `registerNative`, so capture `ctx.funcMap.get("__extern_method_call")` etc.
+   after `ensureObjectRuntime` — referencing the reserved index is fine
+   (finalize fills the body, not the index).
+3. **`stringConstantExternrefInstrs(ctx, value)`** (native-strings.ts:169) is the
+   right way to push a string-const externref from the fctx-less native body
+   (call `addStringConstantGlobal(ctx, value)` first). Use it for the
+   `@@iterator` / `next` name args to `__extern_method_call`.
+4. **USER `__iterator_next`:** `r = __extern_method_call(userIter, "next", emptyVec)`;
+   `done = truthy(__sget_done(r))` (reuse buildTruthyCheck), `value = __sget_value(r)`;
+   non-object `r` ⇒ TypeError via the standalone throw helper (#1888), never a
+   trap. Build the empty-args vec the same way the for-of consumer builds arg
+   vecs (or pass a null/empty externref the host bridge tolerates).
+5. **Validate incrementally:** after the struct+vec-arm change alone, the array
+   for-of/typed-struct paths must stay byte-identical (run the generator/for-of
+   suites) BEFORE adding the USER arm — that isolates a struct-arity regression
+   from a USER-arm bug.

--- a/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
+++ b/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
@@ -1,10 +1,10 @@
 ---
 id: 2038
 title: "standalone: `illegal cast` in __iterator_next / async destructuring & yield* paths (~470 tests)"
-status: ready
-sprint: Backlog
+status: in-progress
+sprint: 62
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -73,3 +73,173 @@ the microtask/CPS scheduler (#1326/#1326c).
   baseline; overall bucket ≤ 50 (remaining rows reassigned to owners).
 - Wasm traps are not used for spec-reachable error paths in the iterator
   protocol (TypeError surfaces as catchable JS error).
+
+## Investigation (2026-06-14, sdev) — PR-A as scoped is ALREADY satisfied; the
+## remaining bucket needs the DEFERRED sub-bucket B + PR-C, not PR-A
+
+Re-traced on current main (d1aba0601 — 76+ commits past the architect spec's
+936d1ac51 base). The spec's "## Implementation Plan" is on a not-yet-merged
+branch; I read it from the /workspace copy. Findings against live HEAD:
+
+1. **Array-literal-backed for-await already works standalone** — the loop is
+   inlined/unrolled over the literal, bypassing the iterator protocol. All
+   compile valid, leak ZERO env imports, run correctly:
+   `for await (const x of [1,2,3])` → 6; `for await (var {} of [{a:1}])` (the
+   spec's "simplest passing case") → ok; `for await (const {a} of [{a:1},{a:2}])`
+   → 3; `for await (const [x,y] of [[1,2],[3,4]])` → 10. So PR-A's sync-backed
+   array acceptance shapes **pass on current main with no change.**
+
+2. **The spec's premise "sync is healthy" is INACCURATE for custom iterables.**
+   BOTH sync `for-of` AND async `for await` over a user
+   `{ [Symbol.iterator](){ return {next(){…}} } }` trap `illegal cast` in
+   standalone — the native iterator runtime (`iterator-native.ts`
+   `__iterator`/`__iterator_next`) only supports the canonical externref **vec**
+   carrier (`ref.cast $vecExtern`), NOT the general user `{next()}` protocol.
+   This is a broad native-iterator gap, not an async-only carrier mismatch.
+
+3. **The named PR-A smoke file is actually a sub-bucket-B case.**
+   `async-func-dstr-var-async-obj-ptrn-empty.js` =
+   `var asyncIter = (async function*(){ yield* [obj]; })(); for await (var {} of asyncIter)`
+   — an **async generator** with **`yield*`**. It compiles standalone to an
+   INVALID module leaking 7 host imports (`__create_async_generator`,
+   `__gen_yield_star`, `__async_iterator`, `__make_getter_callback`,
+   `__gen_create_buffer`, `__get_caught_exception`, `__extern_is_undefined`).
+   Native-async-generators + standalone-Promise territory — the spec's own
+   **deferred** sub-bucket B / PR-C.
+
+### Conclusion / recommendation
+No clean in-scope PR-A change remains: the sync-backed array for-await shapes PR-A
+targets already pass; every remaining 470-bucket row needs either (a) extending
+the native iterator runtime to the general `{next()}` protocol (affects sync
+for-of too — a separate broad effort) or (b) native async generators + standalone
+Promise/Await (deferred sub-bucket B / PR-C). Recommend re-scoping #2038 around a
+**native `{next()}`-protocol iterator runtime** (the real shared root cause for
+sync+async custom iterables) and keeping async-generator/Promise as the
+explicitly-deferred follow-ups. Surfaced to tech lead for a scope decision rather
+than shipping a no-op PR-A or silently expanding into the deferred work.
+
+## Re-scope APPROVED (tech-lead, 2026-06-14) + implementation design (sdev)
+
+Scope: add a **USER_ITER carrier** to `src/codegen/iterator-native.ts` so the
+standalone native iterator runtime drives the general `{next()}` protocol, not
+just the canonical externref vec. Fixes BOTH sync `for-of` and (sync-backed)
+async `for await` over a user
+`{ [Symbol.iterator]() { return { next(){…} } } }`. DEFERRED (separate
+follow-ups): native async generators + `yield*` (sub-bucket B), standalone
+Promise runtime (PR-C).
+
+### Precise trap (confirmed via WAT)
+For-of consumer emits `call $__iterator(subject)` → `$IterRec` → loop
+`call $__iterator_next(iter)`. Native `__iterator` (iterator-native.ts:106)
+unconditionally `ref.cast`s `subject` to `$vecExtern`; a custom-iterable object
+struct is not a vec ⇒ `illegal cast`. (For arrays the loop is inlined upstream,
+so only custom iterables reach here.)
+
+### Design — USER_ITER carrier (kind=1)
+Extend `$IterRec` to carry a user iterator object as an externref alongside the
+vec. Two new fields (keep vec path byte-identical):
+`(struct $__IterRec (field kind i32) (field vec (ref null $vecExtern))
+  (field idx (mut i32)) (field userIter (mut externref)))`.
+
+- **`__iterator(subject)`**: `ref.test (ref $vecExtern)` on
+  `any.convert_extern(subject)`.
+  - vec ⇒ existing kind=VEC path (unchanged).
+  - else ⇒ obtain the user iterator: call `subject[@@iterator]()` and store the
+    result in `userIter`, build `$IterRec{kind:USER, vec:null, idx:0, userIter}`.
+    Resolving `@@iterator` on an arbitrary externref needs the standalone
+    method-by-name dispatch — reuse the same mechanism `compileForOfDirectIterator`
+    uses for typed structs, lifted to a name-keyed call (`@@iterator` field +
+    `__call_fn_method_*`). If `subject` is ALREADY an iterator (has `next` but no
+    `@@iterator` — the result of a manual `obj[Symbol.iterator]()`), pass through.
+- **`__iterator_next(rec)`**: branch on `rec.kind`.
+  - VEC ⇒ existing path.
+  - USER ⇒ call `userIter.next()` via the closure dispatcher → result externref
+    → `done = truthy(__sget_done(result))`, `value = __sget_value(result)`.
+    Return `(done, value)` in ABI order. A non-object `next()` result ⇒ TypeError
+    via the standalone throw helper (#1888 invariant), never a trap.
+- **`__iterator_return(rec)`**: USER ⇒ if `userIter.return` exists, call it; else
+  no-op (sync-backed close is a no-op for the common shape).
+
+### Building blocks (already present)
+- `__sget_value` / `__sget_done` per-field getters (index.ts:1856) — emitted when
+  `.value`/`.done` are accessed; ensure they exist (force-register for USER path).
+- closure dispatch `__call_fn_method_*` for calling `next`/`@@iterator` closures.
+- `@@iterator` reserved field name (literals.ts:1162/1246).
+- truthiness helper for `done` (boxed-bool / number) — reuse buildTruthyCheck.
+
+### Async (for-await) reuse
+`ensureAsyncIterator` (destructuring.ts:377) in standalone should NOT add the
+host import; instead return the native `__iterator` (CreateAsyncFromSyncIterator
+= identity carrier for sync-backed), so the async consumer drives the SAME
+USER_ITER carrier. Per-element Await reduces to identity for already-settled
+(sync-backed) values — no `Promise_resolve` leak. Genuinely-pending Promises
+remain deferred to PR-C (refuse-loud, no host leak).
+
+### Smoke tests
+- sync: `for (const x of {[Symbol.iterator](){let i=0;return{next(){return i<3?{value:i++,done:false}:{value:undefined,done:true}}}}}) …` → 0+1+2
+- async sync-backed: same subject under `for await` → identical.
+- both standalone (`--target wasi`): valid module, ZERO env imports, correct sum.
+- regression: array for-of/for-await (inlined) + typed-struct @@iterator
+  (compileForOfDirectIterator) byte-identical.
+
+### Status
+status stays `ready`/in-progress; implementation in worktree
+`/workspace/.claude/worktrees/issue-2038-async-iter-carrier`
+(branch `issue-2038-async-iter-carrier`).
+
+### Confirmed building blocks (all already in standalone)
+- **`__extern_method_call(recv, name, args)`** — native, `object-runtime.ts:4141`
+  (filled at finalize via `fillApplyClosure` → `__call_fn_method_0..4`). Use it
+  to call `subject["@@iterator"]()` and `userIter["next"]()` from the
+  fctx-less native iterator bodies. Pass an empty args vec.
+- **`__obj_find(obj, key)`** / `__sget_value` / `__sget_done` — native property
+  read on the `{value,done}` result. `__sget_*` getters are emitted only when
+  the field name is referenced; FORCE-register `__sget_value`/`__sget_done` (and
+  the `@@iterator`/`next`/`done`/`value` string constants) when the USER_ITER
+  path is enabled so they exist at runtime.
+- **truthiness** for `done` — reuse `buildTruthyCheck` (boxed-bool / number).
+- **`@@iterator`** reserved field name — `literals.ts:1162/1246`.
+
+## Suspended Work (2026-06-14, sdev) — full blueprint ready, NOT yet coded
+
+- **Worktree**: `/workspace/.claude/worktrees/issue-2038-async-iter-carrier`
+  (branch `issue-2038-async-iter-carrier`). Only this issue doc is modified;
+  NO source changed yet (analysis + design only).
+- **Why suspended**: re-scope approved late in a long session; the USER_ITER
+  carrier is a sizable, careful `iterator-native.ts` runtime change (extend
+  `$IterRec`, branch `__iterator`/`__iterator_next` on kind, wire
+  `__extern_method_call` + `__sget_value`/`__sget_done` + truthiness + TypeError
+  on non-object next-result + late-import/funcIdx ordering). Best done as a
+  focused pass on the freshest main (after PRs #1450/#1452 land), not rushed at
+  session tail.
+- **Resume steps**:
+  1. Extend `getOrRegisterIterRecType` (iterator-native.ts:43) with a mutable
+     `userIter` externref field (4th field). Keep field order so existing
+     `fieldIdx` refs (kind=0, vec=1, idx=2) are unchanged; userIter=3.
+  2. Add `ITER_KIND_USER = 1`. In `__iterator` (`:106`): `ref.test (ref
+     $vecExtern)` on `any.convert_extern(subject)` — vec ⇒ existing path; else ⇒
+     `__extern_method_call(subject, "@@iterator", emptyVec)` (if it returns
+     non-null use it as userIter; if subject already has `next` and no
+     `@@iterator`, treat subject itself as userIter), build
+     `$IterRec{kind:USER, vec:null, idx:0, userIter}`.
+  3. In `__iterator_next` (`buildIteratorNextBody`, `:183`): branch on
+     `struct.get kind`. USER ⇒ `r = __extern_method_call(userIter, "next",
+     emptyVec)`; non-object `r` ⇒ TypeError via `__new_TypeError`+exn tag (#1888);
+     `done = truthy(__sget_done(r))`, `value = __sget_value(r)`; return (done,value).
+  4. `__iterator_return` USER ⇒ call `userIter["return"]()` if present, else no-op.
+  5. Async reuse: in `ensureAsyncIterator` (destructuring.ts:377), when
+     `ctx.standalone || ctx.wasi` do NOT addImport — return native `__iterator`
+     (identity CreateAsyncFromSyncIterator for sync-backed); mirror its
+     `shiftLateImportIndices`. Per-element Await = identity for already-settled.
+  6. Force-register `__sget_value`/`__sget_done` + string constants
+     `@@iterator`/`next`/`return`/`value`/`done` when the USER path is enabled.
+  7. Validate (`.tmp` probes already written): sync `for (const x of
+     {[Symbol.iterator](){…}})` → 0+1+2; async `for await` same → identical;
+     both `--target wasi` valid + ZERO env imports; arrays + typed-struct
+     `@@iterator` (compileForOfDirectIterator) byte-identical; full equivalence
+     suite identical failing-set vs origin/main.
+  8. New `tests/issue-2038.test.ts` per the smoke list above. PR + self-merge.
+- **Pitfalls**: `__extern_method_call`/`__call_fn_method_*` are filled at
+  FINALIZE — ensure the native iterator bodies reference them by funcMap name
+  (resolved at finalize), not by eager funcIdx. Watch late-import index shifting
+  when registering the new string constants / forcing `__sget_*`.

--- a/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
+++ b/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
@@ -1,10 +1,11 @@
 ---
 id: 2038
 title: "standalone: `illegal cast` in __iterator_next / async destructuring & yield* paths (~470 tests)"
-status: in-progress
+status: done
 sprint: 62
 created: 2026-06-10
 updated: 2026-06-14
+completed: 2026-06-14
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -416,3 +417,53 @@ two dispatch calls swapped to `__call_@@iterator`/`__call_next` + `__sget_*`
 plus the reserve-then-fill ordering. Clean repros for both paths:
 `const o:any={next(){return 7}};o.next()` (→ should 7) and
 `for (const x of {[Symbol.iterator](){let i=0;return{next(){return i<3?{value:i++,done:false}:{value:undefined,done:true}}}}}) sum+=x` (→ 3).
+
+## PATH A LANDED (2026-06-14, sdev4) — USER carrier wired to closed-struct dispatchers
+
+Implemented PATH A exactly as sdev3 specced. `status: done`.
+
+**What changed**
+- `src/codegen/iterator-native.ts` — the `$IterRec` USER arm now dispatches
+  through the closed-struct helpers, NOT the `$Object`-only
+  `__extern_method_call`/`__extern_get` (which returned null → infinite loop):
+  - `__iterator` USER arm: `userIter = __call_@@iterator(obj)` (fallback to `obj`
+    if null = obj is itself a bare-`next` iterator).
+  - `__iterator_next` USER arm: `res = __call_next(userIter)`;
+    `done = __is_truthy(__sget_done(res))`; `value = done ? undefined :
+    __sget_value(res)`.
+  - **Reserve-then-fill (#1719):** the carrier `__iterator`/`__iterator_next` are
+    emitted **vec-only** in `ensureNativeIteratorRuntime` (byte-identical to the
+    pre-#2038 runtime) with `ctx.nativeIteratorUserArmPending`. The new
+    `fillNativeIteratorUserArms(ctx)` rebuilds both bodies with the USER arm at
+    FINALIZE, after `emitStructFieldGetters` + `emitIteratorMethodExport` have run
+    (so the `__sget_*` / `__call_*` funcIdx resolve). If a module has no custom
+    iterable, the dispatchers are absent → the fill is a no-op → vec-only carrier
+    (byte-identical, verified).
+- `src/codegen/index.ts` — (1) `emitIteratorMethodExport` + `emitStructFieldGetters`
+  now register their emitted funcs (`__call_@@iterator`/`__call_next`/`__sget_*`)
+  in `ctx.funcMap` (they previously only pushed to `mod.functions`/`mod.exports`,
+  so the fill couldn't find them — the actual blocker); (2) finalize calls
+  `fillNativeIteratorUserArms` after the two emitters, force-registering
+  `__is_truthy` via `addUnionImports` only in the rare bucket that didn't box.
+- `src/codegen/statements/destructuring.ts` — `ensureAsyncIterator` in
+  standalone/wasi returns the native `__iterator` (CreateAsyncFromSyncIterator =
+  identity for sync-backed) instead of the `env.__async_iterator` host import, so
+  sync-backed `for await` drives the SAME USER carrier (no host leak, no
+  `illegal cast`). Host mode unchanged.
+
+**Validation (all green)**
+- sync `for (const x of {[Symbol.iterator](){return {next(){…}}}})` → 3,
+  array-backed custom iterable → 60 — standalone, ZERO env imports.
+- async sync-backed `for await (const x of customIterable)` → 3 — standalone,
+  ZERO env imports. (Was `illegal cast` before.)
+- array for-of / for-await / spread / destructuring / generator standalone
+  binaries **byte-identical** (sha256) to origin/main — no regression.
+- new `tests/issue-2038.test.ts` (6 cases) passes; iterator/generator equiv
+  suites show the SAME pre-existing failure set as origin/main (3 unrelated:
+  one #681 case, two `symbol-async-iterator` test-harness instantiate errors —
+  both fail identically on main, not caused here).
+
+**Still deferred (NOT in this PR):** async-generator `yield*` (sub-bucket B,
+`generators-native.ts` sequential-restriction lift) and the standalone
+Promise/microtask runtime for genuinely-pending for-await (PR-C). The general
+closed-struct any-method dispatch is the separate #25 epic (PATH B).

--- a/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
+++ b/plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md
@@ -331,3 +331,88 @@ custom-iterable repro (`for (const x of {[Symbol.iterator](){return
 {next(){…}}}})` → 0+1+2) should pass, and `ensureAsyncIterator` returning native
 `__iterator` in standalone extends it to sync-backed `for await`. Keep
 async-gen/yield* + Promise deferred.
+
+## Deep re-analysis (2026-06-14, sdev3) — precise dispatch mechanism + two fix paths
+
+Independently re-confirmed the whole chain on current main (branch
+`issue-2038-async-iter-carrier` @ `8ca988f34`). The USER carrier is correct and
+regression-free (vec/array path byte-identical, module valid, zero leaked `env`
+imports). #2038 is genuinely blocked by **#25**. Two new precise facts beyond
+the prior write-up:
+
+### Fact 1 — `__extern_method_call`/`__extern_get` are `$Object`-ONLY; object literals are CLOSED structs
+The native `__extern_method_call` (object-runtime.ts ~`:4188`) body is:
+`if ref.test (ref $Object) → __apply_closure(__extern_get(recv,name), recv,
+args) else → ref.null.extern`. A standalone object literal `{ next(){…} }`
+compiles to a **closed nominal WasmGC struct** with a named funcref field
+(`$next`), NOT the open `$Object` open-hash-map. So `ref.test $Object` is FALSE
+→ else arm → `ref.null.extern`. `__extern_get` (`:~ same family`) has the same
+`$Object`-only gate, so reading `.value`/`.done` off the (also closed) result
+struct returns null too. Net: the USER `__iterator_next` gets `next()`→null,
+`done`→null→falsy→never done→**infinite loop** (clean repro:
+`const o:any={next(){return 7}}; o.next()` → **0 in BOTH `--target wasi` AND
+`--target standalone`**; under wasi it additionally can't even instantiate
+because the any-method arg-array path requests refused `env.__js_array_new`).
+
+### Fact 2 — closed-struct dispatchers ALREADY EXIST and work on these structs
+`emitIteratorMethodExport` (index.ts `:2190`, via `emitMethodDispatch`
+`:2198`) emits, at finalize, **type-switch** dispatchers over every registered
+closed struct:
+- `__call_@@iterator(externref)->externref` — `ref.test/ref.cast/call
+  <Struct>_@@iterator` per struct.
+- `__call_next(externref)->externref` — same for `<Struct>_next`.
+
+and `emitStructFieldGetters` (index.ts `:1737`) emits `__sget_value` /
+`__sget_done` — type-switch field getters over closed structs (the #1320
+`{value,done}` host-read path). **Verified at runtime**: on the sync
+custom-iterable module, `exports.__call_@@iterator(obj)` returns the closed
+`{next}` struct (non-null) and `exports.__call_next(it)` returns the `{value,
+done}` struct — i.e. these dispatch closed structs correctly. (Could not read
+the boxed value from JS, but dispatch fires; the all-`$Object` path returns
+null.)
+
+### Two fix paths
+
+**PATH A — targeted carrier rewrite (unblocks #2038 alone, does NOT need #25):**
+In `iterator-native.ts`, the USER arms should call the closed-struct
+dispatchers, NOT the `$Object`-only helpers:
+- `__iterator` USER arm: `userIter = __call_@@iterator(obj)` (fallback to `obj`
+  if null), instead of `__extern_method_call(obj,"@@iterator",emptyVec)`.
+- `__iterator_next` USER arm: `res = __call_next(userIter)`;
+  `done = __is_truthy(__sget_done(res))`; `value = __sget_done(res)?undef:__sget_value(res)`,
+  instead of `__extern_method_call`/`__extern_get`.
+- **Ordering hazard (the reason this is senior work):** `__call_@@iterator` /
+  `__call_next` / `__sget_*` are emitted at FINALIZE (after user structs are
+  known), but the carrier bodies are built EARLY in `ensureNativeIteratorRuntime`.
+  So their funcIdx are forward references → use the established
+  **reserve-then-fill** pattern (`reserveProtoIteratorDriver` /
+  `fillProtoIteratorDriver`, #1719) — reserve the carrier `__iterator`/
+  `__iterator_next` funcIdx with placeholder bodies, and fill them at finalize
+  AFTER `emitIteratorMethodExport` + `emitStructFieldGetters` have run, so the
+  `call` targets resolve. Alternatively, late-bind the dispatcher funcIdx the
+  same way `fillApplyClosure` does. Validate the vec arm stays byte-identical.
+- Spec edge (§7.4.4): a non-object `next()` result ⇒ TypeError via the #1888
+  standalone throw helper, never a trap (covered once the USER arm dispatches).
+- This path is self-contained to `iterator-native.ts` + finalize ordering and
+  does not regress the general any-method path.
+
+**PATH B — general #25 fix (broader, helps every standalone object-literal
+method call):** Give `__extern_method_call`/`__extern_get` a closed-struct
+fallback. Because they are name-dynamic and fctx-less, a per-name `ref.test`
+switch can't live inside one generic body — instead route the call SITE
+(calls.ts any-receiver fallback `:7966`, and `emitWrapperDynamicMethodCall`
+`:1137`) to: (a) for `ctx.wasi`, take the **ObjVec-builder** branch too (the
+`if (ctx.standalone)` at `:8068` / `:1147` must be `ctx.standalone || ctx.wasi`,
+else wasi requests refused `__js_array_new`); and (b) when the receiver is a
+known closed struct, emit a `ref.test/ref.cast/call <Struct>_<method>`
+type-switch (generalize `emitMethodDispatch` to arbitrary method names + args).
+Larger surface; needs its own regression pass over all standalone method calls.
+
+### Recommendation (sdev3)
+Do **PATH A** to unblock #2038 now (contained, finalize-ordering-sensitive →
+keep on senior); pursue **PATH B** as the standalone #25 epic in parallel since
+it fixes the whole class. The committed USER-carrier scaffolding only needs its
+two dispatch calls swapped to `__call_@@iterator`/`__call_next` + `__sget_*`
+plus the reserve-then-fill ordering. Clean repros for both paths:
+`const o:any={next(){return 7}};o.next()` (→ should 7) and
+`for (const x of {[Symbol.iterator](){let i=0;return{next(){return i<3?{value:i++,done:false}:{value:undefined,done:true}}}}}) sum+=x` (→ 3).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -660,6 +660,23 @@ export interface CodegenContext {
    */
   externIsArrayReserved?: boolean;
   /**
+   * (#2038) True once the native iterator runtime (`ensureNativeIteratorRuntime`,
+   * iterator-native.ts) has emitted `__iterator` / `__iterator_next` with a
+   * vec-only body and is awaiting its USER-iterator arm. The USER arm dispatches
+   * a custom `{[Symbol.iterator]()}` / `{next()}` object through the closed-struct
+   * method dispatchers `__call_@@iterator` / `__call_next` and the field getters
+   * `__sget_value` / `__sget_done`, all of which are emitted at FINALIZE (after
+   * every user struct is known — `emitIteratorMethodExport` /
+   * `emitStructFieldGetters`). So the carrier bodies are rebuilt with the USER arm
+   * by `fillNativeIteratorUserArms` in post-processing — same reserve-then-fill
+   * funcIdx-authority discipline as `protoIteratorDriverReserved` (#1719). The
+   * eager body is a valid vec-only carrier (byte-identical to the pre-#2038
+   * runtime), so if the fill is ever skipped (e.g. multi-module) custom iterables
+   * keep trapping as before rather than shipping a broken module. Only set under
+   * `--target standalone` / `wasi`.
+   */
+  nativeIteratorUserArmPending?: boolean;
+  /**
    * Static property initializer expressions to compile into __module_init.
    * `className` (#1395) is the owning class name — used to set
    * `enclosingClassName` + `isStaticContext` on the initFctx so `this`

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -35,7 +35,7 @@ import type {
 import type { NodeBuiltinImport } from "../import-resolver.js";
 import { eliminateDeadImports } from "./dead-elimination.js";
 import { ensureMapRuntimeTypes } from "./map-runtime.js";
-import { ensureNativeIteratorRuntime } from "./iterator-native.js";
+import { ensureNativeIteratorRuntime, fillNativeIteratorUserArms } from "./iterator-native.js";
 import { emitUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
 import { fillAccessorDrivers } from "./accessor-driver.js";
@@ -1455,6 +1455,30 @@ export function generateModule(
     // Emit __call_@@iterator export for runtime Symbol.iterator dispatch on WasmGC structs
     emitIteratorMethodExport(ctx);
 
+    // (#2038, reserve-then-fill #1719) Rebuild the native `__iterator` /
+    // `__iterator_next` carrier bodies with the USER `{next()}`-protocol arm now
+    // that the closed-struct dispatchers exist: `__sget_value`/`__sget_done`
+    // (emitStructFieldGetters, above) and `__call_@@iterator`/`__call_next`
+    // (emitIteratorMethodExport, just above). No-op unless the standalone native
+    // iterator runtime was registered AND a custom iterable produced those
+    // dispatchers — otherwise the carrier stays vec-only and byte-identical.
+    if (
+      ctx.nativeIteratorUserArmPending &&
+      ctx.funcMap.has("__call_@@iterator") &&
+      ctx.funcMap.has("__call_next") &&
+      ctx.funcMap.has("__sget_value") &&
+      ctx.funcMap.has("__sget_done") &&
+      !ctx.funcMap.has("__is_truthy")
+    ) {
+      // The USER `done` flag needs `__is_truthy` (ToBoolean on the boxed bool).
+      // `emitStructFieldGetters` usually registers it via `addUnionImports` when a
+      // `{value,done}` bucket boxes, but force it here for the rare bucket shape
+      // that does not, so the fill never silently degrades to vec-only.
+      // Native in standalone/WASI (appends funcs, no funcIdx shift).
+      addUnionImports(ctx);
+    }
+    fillNativeIteratorUserArms(ctx);
+
     // (#1716) Emit __call_@@toPrimitive(self, hint) for runtime ToPrimitive
     // dispatch of a class's [Symbol.toPrimitive] *method* on opaque structs.
     emitToPrimitiveMethodExport(ctx);
@@ -1871,6 +1895,12 @@ function _emitStructFieldGettersInner(ctx: CodegenContext): void {
       name: funcName,
       desc: { kind: "func", index: funcIdx },
     });
+
+    // (#2038) Register in funcMap so the native iterator carrier's USER arm can
+    // resolve `__sget_value` / `__sget_done` at finalize-fill time
+    // (`fillNativeIteratorUserArms`). No other code looks `__sget_*` up by funcMap
+    // key, so this is inert for every other path.
+    ctx.funcMap.set(funcName, funcIdx);
   }
 
   // Emit __struct_field_names(externref) -> externref
@@ -2282,6 +2312,12 @@ function emitIteratorMethodExport(ctx: CodegenContext): void {
       name: exportName,
       desc: { kind: "func", index: funcIdx },
     });
+
+    // (#2038) Register in funcMap so the native iterator carrier's USER arm can
+    // resolve `__call_@@iterator` / `__call_next` at finalize-fill time
+    // (`fillNativeIteratorUserArms`). Harmless for the host/GC path — no other
+    // code looks these up by funcMap key.
+    ctx.funcMap.set(exportName, funcIdx);
   };
 
   emitMethodDispatch("@@iterator", "__call_@@iterator");

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -30,10 +30,24 @@
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 
 /** Slice-1 IterRec kind tag for a canonical externref `$Vec`. */
 const ITER_KIND_VEC = 3;
+
+/**
+ * (#2038) IterRec kind tag for a USER iterator: a general `{next()}`-protocol
+ * object obtained from a custom iterable's `[Symbol.iterator]()`. The `vec`
+ * field is null; the iterator object is held in `userIter` (field 3, externref)
+ * and each `__iterator_next` step calls `userIter.next()` via
+ * `__extern_method_call` and reads `.value`/`.done`. This covers BOTH sync
+ * `for-of` and (sync-backed) async `for await` over a user iterable, which
+ * previously trapped `illegal cast` in the vec-only native runtime.
+ */
+const ITER_KIND_USER = 1;
 
 /**
  * Lazily register (or fetch) the `$__IterRec` GC struct type. Mirrors
@@ -47,10 +61,14 @@ export function getOrRegisterIterRecType(ctx: CodegenContext): number {
   // The canonical externref vec the record cursors over.
   const vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
 
+  // Field order is load-bearing: fieldIdx kind=0, vec=1, idx=2 (the vec path).
+  // (#2038) userIter=3 — a mutable externref holding the user `{next()}`
+  // iterator object for the USER carrier (null on the vec path).
   const fields = [
     { name: "kind", type: { kind: "i32" as const }, mutable: false },
     { name: "vec", type: { kind: "ref_null" as const, typeIdx: vecTypeIdx }, mutable: false },
     { name: "idx", type: { kind: "i32" as const }, mutable: true },
+    { name: "userIter", type: { kind: "externref" as const }, mutable: true },
   ];
   const typeIdx = ctx.mod.types.length;
   ctx.mod.types.push({ kind: "struct", name: "__IterRec", fields });
@@ -85,6 +103,29 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   const iterRecRef: ValType = { kind: "ref", typeIdx: iterRecTypeIdx };
   const vecRefNull: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
 
+  // (#2038) USER `{next()}`-protocol carrier dependencies. Set up BEFORE building
+  // the native bodies so funcMap indices / string-const globals are stable when
+  // captured. `__extern_method_call` (+ `__extern_get`/`__apply_closure`) is
+  // filled at FINALIZE — referencing its reserved funcIdx is fine (finalize
+  // fills the body, not the index). Force-register the method-name string
+  // constants so `stringConstantExternrefInstrs` materializes them.
+  ensureObjectRuntime(ctx);
+  for (const s of ["@@iterator", "next", "value", "done"]) addStringConstantGlobal(ctx, s);
+  const externMethodCallIdx = ctx.funcMap.get("__extern_method_call");
+  // Per-field getters for the {value, done} next()-result. They are emitted on
+  // demand when a `.value`/`.done` access is compiled; on the USER iterator path
+  // the result object is host/$Object-shaped, so use the generic host get via
+  // `__extern_get` (resolves own + prototype) keyed by the field-name string,
+  // which is always available once ensureObjectRuntime ran.
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  // `__is_truthy(externref) -> i32` for the §7.2.15 `done` flag (ToBoolean).
+  // Emitted natively in standalone; resolved by funcMap name.
+  const isTruthyIdx = ctx.funcMap.get("__is_truthy");
+  // USER carrier is only wired when the host-dispatch helpers exist (they do in
+  // standalone after ensureObjectRuntime). If absent (shouldn't happen), the
+  // vec-only path is preserved and a non-vec subject keeps trapping as before.
+  const userCarrierWired = externMethodCallIdx !== undefined && externGetIdx !== undefined && isTruthyIdx !== undefined;
+
   const registerNative = (
     name: string,
     paramTypes: ValType[],
@@ -100,24 +141,88 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   };
 
   // --- __iterator(obj: externref) -> externref (the $IterRec, as externref) ---
-  // GetIterator §7.4.1. Slice 1: `obj` is an externref-wrapped canonical
-  // externref `$Vec`. Unwrap → build $IterRec{kind:3, vec, idx:0} → rewrap.
-  // local 0 = obj (param, externref)
+  // GetIterator §7.4.1.
+  //   - obj is a canonical externref `$Vec` (the common array path)  → build
+  //     $IterRec{kind:VEC, vec, idx:0, userIter:null}.
+  //   - (#2038) otherwise obj is a USER iterable (custom `{[Symbol.iterator]()
+  //     {…}}`) → obtain its iterator object via `obj[@@iterator]()` and build
+  //     $IterRec{kind:USER, vec:null, idx:0, userIter}. If `@@iterator` resolves
+  //     to nothing (obj is ALREADY an iterator with a bare `next`), fall back to
+  //     using obj itself as the iterator object.
+  // local 0 = obj (param, externref); local 1 = objAny (anyref); local 2 = userIter (externref)
+  const emptyArgsVec: Instr[] = [
+    // $vecExtern{ length: 0, data: null } → externref
+    { op: "i32.const", value: 0 },
+    { op: "ref.null", typeIdx: arrTypeIdx } as Instr,
+    { op: "struct.new", typeIdx: vecTypeIdx },
+    { op: "extern.convert_any" } as Instr,
+  ];
+  const iteratorBody: Instr[] = [
+    // objAny = any.convert_extern(obj)
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: 1 },
+    { op: "ref.test", typeIdx: vecTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [
+        // VEC carrier: $IterRec{VEC, vec, 0, userIter:null}
+        { op: "i32.const", value: ITER_KIND_VEC },
+        { op: "local.get", index: 1 },
+        { op: "ref.cast", typeIdx: vecTypeIdx },
+        { op: "i32.const", value: 0 },
+        { op: "ref.null.extern" } as Instr,
+        { op: "struct.new", typeIdx: iterRecTypeIdx },
+        { op: "extern.convert_any" } as Instr,
+      ],
+      else: userCarrierWired
+        ? [
+            // userIter = obj[@@iterator]()  (null if obj has no @@iterator)
+            { op: "local.get", index: 0 },
+            ...stringConstantExternrefInstrs(ctx, "@@iterator"),
+            ...emptyArgsVec,
+            { op: "call", funcIdx: externMethodCallIdx! },
+            { op: "local.tee", index: 2 },
+            { op: "ref.is_null" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "externref" } },
+              // No @@iterator → obj is itself the iterator (has `next`).
+              then: [{ op: "local.get", index: 0 }],
+              else: [{ op: "local.get", index: 2 }],
+            } as unknown as Instr,
+            { op: "local.set", index: 2 },
+            // $IterRec{USER, vec:null, idx:0, userIter}
+            { op: "i32.const", value: ITER_KIND_USER },
+            { op: "ref.null", typeIdx: vecTypeIdx } as Instr,
+            { op: "i32.const", value: 0 },
+            { op: "local.get", index: 2 },
+            { op: "struct.new", typeIdx: iterRecTypeIdx },
+            { op: "extern.convert_any" } as Instr,
+          ]
+        : [
+            // USER carrier unavailable — preserve the legacy hard cast so the
+            // failure mode is unchanged (loud trap) rather than silently wrong.
+            { op: "i32.const", value: ITER_KIND_VEC },
+            { op: "local.get", index: 1 },
+            { op: "ref.cast", typeIdx: vecTypeIdx },
+            { op: "i32.const", value: 0 },
+            { op: "ref.null.extern" } as Instr,
+            { op: "struct.new", typeIdx: iterRecTypeIdx },
+            { op: "extern.convert_any" } as Instr,
+          ],
+    } as unknown as Instr,
+  ];
   registerNative(
     "__iterator",
     [{ kind: "externref" }],
     [{ kind: "externref" }],
-    [],
     [
-      { op: "i32.const", value: ITER_KIND_VEC },
-      // vec = ref.cast<$vecExtern>(any.convert_extern(obj))
-      { op: "local.get", index: 0 },
-      { op: "any.convert_extern" } as Instr,
-      { op: "ref.cast", typeIdx: vecTypeIdx },
-      { op: "i32.const", value: 0 },
-      { op: "struct.new", typeIdx: iterRecTypeIdx },
-      { op: "extern.convert_any" } as Instr,
+      { name: "objAny", type: { kind: "anyref" } },
+      { name: "userIter", type: { kind: "externref" } },
     ],
+    iteratorBody,
   );
 
   // --- __iterator_next(recExt: externref) -> (i32 done, externref value) ---
@@ -131,6 +236,7 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   //   local 3 = i      (i32 cursor)
   //   local 4 = done   (i32)
   //   local 5 = value  (externref)
+  //   local 6 = res    (externref — USER next() result, #2038)
   registerNative(
     "__iterator_next",
     [{ kind: "externref" }],
@@ -141,8 +247,15 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
       { name: "i", type: { kind: "i32" } },
       { name: "done", type: { kind: "i32" } },
       { name: "value", type: { kind: "externref" } },
+      { name: "res", type: { kind: "externref" } },
     ],
-    buildIteratorNextBody(iterRecTypeIdx, vecTypeIdx, arrTypeIdx),
+    buildIteratorNextBody(ctx, iterRecTypeIdx, vecTypeIdx, arrTypeIdx, {
+      userCarrierWired,
+      externMethodCallIdx,
+      externGetIdx,
+      isTruthyIdx,
+      emptyArgsVec,
+    }),
   );
 
   // --- __iterator_return(recExt: externref) -> ()  (IteratorClose §7.4.8) ---
@@ -178,16 +291,27 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
 /**
  * Build the `__iterator_next` body with explicit done/value computation so the
  * multi-value `(i32 done, externref value)` results are emitted in ABI order.
- * Locals: 0=recExt(param), 1=rec, 2=vec, 3=i, 4=done(i32), 5=value(externref).
+ * Locals: 0=recExt(param), 1=rec, 2=vec, 3=i, 4=done(i32), 5=value(externref),
+ * 6=res(externref, USER next() result).
  */
-function buildIteratorNextBody(iterRecTypeIdx: number, vecTypeIdx: number, arrTypeIdx: number): Instr[] {
-  return [
-    // rec = cast(any.convert_extern(recExt))
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" } as Instr,
-    { op: "ref.cast", typeIdx: iterRecTypeIdx },
-    { op: "local.tee", index: 1 },
+interface UserNextDeps {
+  userCarrierWired: boolean;
+  externMethodCallIdx: number | undefined;
+  externGetIdx: number | undefined;
+  isTruthyIdx: number | undefined;
+  emptyArgsVec: Instr[];
+}
+function buildIteratorNextBody(
+  ctx: CodegenContext,
+  iterRecTypeIdx: number,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  deps: UserNextDeps,
+): Instr[] {
+  // The vec-carrier step (existing behavior), computing done(4)/value(5).
+  const vecStep: Instr[] = [
     // vec = rec.vec
+    { op: "local.get", index: 1 },
     { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 1 },
     { op: "local.set", index: 2 },
     // i = rec.idx
@@ -214,14 +338,12 @@ function buildIteratorNextBody(iterRecTypeIdx: number, vecTypeIdx: number, arrTy
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        // value = vec.data[i]
         { op: "local.get", index: 2 },
         { op: "ref.as_non_null" } as Instr,
         { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
         { op: "local.get", index: 3 },
         { op: "array.get", typeIdx: arrTypeIdx },
         { op: "local.set", index: 5 },
-        // rec.idx = i + 1
         { op: "local.get", index: 1 },
         { op: "local.get", index: 3 },
         { op: "i32.const", value: 1 },
@@ -229,6 +351,67 @@ function buildIteratorNextBody(iterRecTypeIdx: number, vecTypeIdx: number, arrTy
         { op: "struct.set", typeIdx: iterRecTypeIdx, fieldIdx: 2 } as Instr,
       ],
       else: [],
+    } as unknown as Instr,
+  ];
+
+  // (#2038) The USER-carrier step (§7.4.4 IteratorNext + §7.4.6 IteratorValue):
+  //   res = userIter.next();  done = ToBoolean(res.done);  value = res.value
+  // Result-not-an-object is left to the host get returning undefined (the common
+  // user-iterator shapes always return an object); a hard TypeError on a
+  // non-object result is a follow-up refinement.
+  const userStep: Instr[] = deps.userCarrierWired
+    ? [
+        // res = __extern_method_call(rec.userIter, "next", emptyArgs)
+        { op: "local.get", index: 1 },
+        { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 },
+        ...stringConstantExternrefInstrs(ctx, "next"),
+        ...deps.emptyArgsVec,
+        { op: "call", funcIdx: deps.externMethodCallIdx! },
+        { op: "local.set", index: 6 },
+        // done = ToBoolean(__extern_get(res, "done"))
+        { op: "local.get", index: 6 },
+        ...stringConstantExternrefInstrs(ctx, "done"),
+        { op: "call", funcIdx: deps.externGetIdx! },
+        { op: "call", funcIdx: deps.isTruthyIdx! },
+        { op: "local.set", index: 4 },
+        // value = done ? undefined : __extern_get(res, "value")
+        { op: "local.get", index: 4 },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [{ op: "ref.null.extern" } as Instr],
+          else: [
+            { op: "local.get", index: 6 },
+            ...stringConstantExternrefInstrs(ctx, "value"),
+            { op: "call", funcIdx: deps.externGetIdx! },
+          ],
+        } as unknown as Instr,
+        { op: "local.set", index: 5 },
+      ]
+    : // USER carrier not wired — never reached (kind is never USER without it).
+      [
+        { op: "i32.const", value: 1 },
+        { op: "local.set", index: 4 },
+        { op: "ref.null.extern" } as Instr,
+        { op: "local.set", index: 5 },
+      ];
+
+  return [
+    // rec = cast(any.convert_extern(recExt))
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: iterRecTypeIdx },
+    { op: "local.set", index: 1 },
+    // if (rec.kind == USER) { userStep } else { vecStep }
+    { op: "local.get", index: 1 },
+    { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
+    { op: "i32.const", value: ITER_KIND_USER },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: userStep,
+      else: vecStep,
     } as unknown as Instr,
     // results in ABI order: (done, value)
     { op: "local.get", index: 4 },

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -19,21 +19,34 @@
  * an externref vec. That keeps the fctx-less native bodies trivial: no
  * per-elemKind `ref.test`/box switch and no `coerceType` (which needs an fctx).
  *
+ * **(#2038) USER `{next()}`-protocol carrier.** Beyond the canonical vec, the
+ * native runtime now also drives a custom iterable
+ * `{ [Symbol.iterator]() { return { next() {…} } } }`. Such an object compiles to
+ * a *closed nominal WasmGC struct* (a named funcref field per method), NOT the
+ * open `$Object` hash-map — so the generic `__extern_method_call` / `__extern_get`
+ * helpers (which gate on `ref.test $Object`) return null for it, which previously
+ * made `__iterator_next` spin forever (PATH A blocker, #25). Instead the USER arm
+ * dispatches through the closed-struct **type-switch** helpers that the finalize
+ * pass emits over every registered struct: `__call_@@iterator` / `__call_next`
+ * (`emitIteratorMethodExport`) and `__sget_value` / `__sget_done`
+ * (`emitStructFieldGetters`). Those are only known at finalize, so the carrier
+ * bodies are emitted vec-only eagerly and *rebuilt with the USER arm* by
+ * `fillNativeIteratorUserArms` after the dispatchers exist — the reserve-then-fill
+ * funcIdx-authority discipline of #1719 (`fillProtoIteratorDriver`).
+ *
  * The native iterator-record:
- *   (struct $__IterRec (field $kind i32)                  ;; reserved (Slice 1b+)
+ *   (struct $__IterRec (field $kind i32)                  ;; VEC=3 / USER=1
  *                       (field $vec  (ref null $vecExtern));; canonical externref vec
- *                       (field $idx  (mut i32)))           ;; cursor
- *   $kind is currently always 3 ($Vec); reserved for kind=1 native-gen (Slice 1b).
+ *                       (field $idx  (mut i32))            ;; cursor
+ *                       (field $userIter (mut externref))) ;; USER iterator object
  *
  * Spec: ECMA-262 §7.4 (GetIterator / IteratorStep / IteratorValue /
- * IteratorClose). See plan/issues/1320-array-from-externref-iterator-bridge.md.
+ * IteratorClose). See plan/issues/2038-standalone-iterator-next-illegal-cast-async-dstr.md.
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { stringConstantExternrefInstrs } from "./native-strings.js";
-import { ensureObjectRuntime } from "./object-runtime.js";
-import { addStringConstantGlobal } from "./registry/imports.js";
-import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { addFuncType } from "./registry/types.js";
 
 /** Slice-1 IterRec kind tag for a canonical externref `$Vec`. */
 const ITER_KIND_VEC = 3;
@@ -42,12 +55,30 @@ const ITER_KIND_VEC = 3;
  * (#2038) IterRec kind tag for a USER iterator: a general `{next()}`-protocol
  * object obtained from a custom iterable's `[Symbol.iterator]()`. The `vec`
  * field is null; the iterator object is held in `userIter` (field 3, externref)
- * and each `__iterator_next` step calls `userIter.next()` via
- * `__extern_method_call` and reads `.value`/`.done`. This covers BOTH sync
- * `for-of` and (sync-backed) async `for await` over a user iterable, which
- * previously trapped `illegal cast` in the vec-only native runtime.
+ * and each `__iterator_next` step calls `userIter.next()` through the
+ * closed-struct dispatcher `__call_next` and reads `.value`/`.done` via
+ * `__sget_value` / `__sget_done`. Covers BOTH sync `for-of` and (sync-backed)
+ * async `for await` over a user iterable, which previously trapped/hung in the
+ * vec-only native runtime.
  */
 const ITER_KIND_USER = 1;
+
+/**
+ * Resolved funcIdx of the closed-struct dispatchers the USER arm calls. All four
+ * are emitted at FINALIZE; `fillNativeIteratorUserArms` looks them up then.
+ */
+interface UserCarrierDeps {
+  /** `__call_@@iterator(externref) -> externref` (emitIteratorMethodExport). */
+  callIteratorIdx: number;
+  /** `__call_next(externref) -> externref` (emitIteratorMethodExport). */
+  callNextIdx: number;
+  /** `__sget_value(externref) -> externref` (emitStructFieldGetters). */
+  sgetValueIdx: number;
+  /** `__sget_done(externref) -> externref` (emitStructFieldGetters). */
+  sgetDoneIdx: number;
+  /** `__is_truthy(externref) -> i32` (ToBoolean on the boxed `done` flag). */
+  isTruthyIdx: number;
+}
 
 /**
  * Lazily register (or fetch) the `$__IterRec` GC struct type. Mirrors
@@ -78,6 +109,20 @@ export function getOrRegisterIterRecType(ctx: CodegenContext): number {
   return typeIdx;
 }
 
+/** Cached per-module geometry the body builders + the finalize fill both need. */
+interface IterRuntimeTypes {
+  iterRecTypeIdx: number;
+  vecTypeIdx: number;
+  arrTypeIdx: number;
+}
+
+function iterRuntimeTypes(ctx: CodegenContext): IterRuntimeTypes {
+  const iterRecTypeIdx = getOrRegisterIterRecType(ctx);
+  const vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  return { iterRecTypeIdx, vecTypeIdx, arrTypeIdx };
+}
+
 /**
  * #1320 Slice 1 — register the four iteration-protocol operations as native
  * Wasm functions (standalone/WASI). Idempotent: guards on `funcMap.has`.
@@ -92,39 +137,22 @@ export function getOrRegisterIterRecType(ctx: CodegenContext): number {
  * The argument to `__iterator` is, in Slice 1, an externref-wrapped canonical
  * externref `$Vec` (the caller box-builds it). `__iterator` wraps it in an
  * `$IterRec`; `__iterator_next` walks the vec by index.
+ *
+ * (#2038) The `__iterator` / `__iterator_next` bodies are emitted **vec-only**
+ * here — byte-identical to the pre-USER runtime — and `nativeIteratorUserArmPending`
+ * is set so `fillNativeIteratorUserArms` (finalize) rebuilds them with the USER
+ * arm once the closed-struct dispatchers exist. A non-vec subject keeps trapping
+ * (the legacy hard cast) until that fill runs, so a module where the fill is
+ * skipped (e.g. multi-module) never ships a broken iterator.
  */
 export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   if (ctx.funcMap.has("__iterator")) return;
 
-  const iterRecTypeIdx = getOrRegisterIterRecType(ctx);
-  const vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
-  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  const types = iterRuntimeTypes(ctx);
+  const { iterRecTypeIdx, vecTypeIdx, arrTypeIdx } = types;
 
   const iterRecRef: ValType = { kind: "ref", typeIdx: iterRecTypeIdx };
   const vecRefNull: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
-
-  // (#2038) USER `{next()}`-protocol carrier dependencies. Set up BEFORE building
-  // the native bodies so funcMap indices / string-const globals are stable when
-  // captured. `__extern_method_call` (+ `__extern_get`/`__apply_closure`) is
-  // filled at FINALIZE — referencing its reserved funcIdx is fine (finalize
-  // fills the body, not the index). Force-register the method-name string
-  // constants so `stringConstantExternrefInstrs` materializes them.
-  ensureObjectRuntime(ctx);
-  for (const s of ["@@iterator", "next", "value", "done"]) addStringConstantGlobal(ctx, s);
-  const externMethodCallIdx = ctx.funcMap.get("__extern_method_call");
-  // Per-field getters for the {value, done} next()-result. They are emitted on
-  // demand when a `.value`/`.done` access is compiled; on the USER iterator path
-  // the result object is host/$Object-shaped, so use the generic host get via
-  // `__extern_get` (resolves own + prototype) keyed by the field-name string,
-  // which is always available once ensureObjectRuntime ran.
-  const externGetIdx = ctx.funcMap.get("__extern_get");
-  // `__is_truthy(externref) -> i32` for the §7.2.15 `done` flag (ToBoolean).
-  // Emitted natively in standalone; resolved by funcMap name.
-  const isTruthyIdx = ctx.funcMap.get("__is_truthy");
-  // USER carrier is only wired when the host-dispatch helpers exist (they do in
-  // standalone after ensureObjectRuntime). If absent (shouldn't happen), the
-  // vec-only path is preserved and a non-vec subject keeps trapping as before.
-  const userCarrierWired = externMethodCallIdx !== undefined && externGetIdx !== undefined && isTruthyIdx !== undefined;
 
   const registerNative = (
     name: string,
@@ -141,79 +169,8 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   };
 
   // --- __iterator(obj: externref) -> externref (the $IterRec, as externref) ---
-  // GetIterator §7.4.1.
-  //   - obj is a canonical externref `$Vec` (the common array path)  → build
-  //     $IterRec{kind:VEC, vec, idx:0, userIter:null}.
-  //   - (#2038) otherwise obj is a USER iterable (custom `{[Symbol.iterator]()
-  //     {…}}`) → obtain its iterator object via `obj[@@iterator]()` and build
-  //     $IterRec{kind:USER, vec:null, idx:0, userIter}. If `@@iterator` resolves
-  //     to nothing (obj is ALREADY an iterator with a bare `next`), fall back to
-  //     using obj itself as the iterator object.
+  // GetIterator §7.4.1. Vec-only at emit time; the USER arm is filled later.
   // local 0 = obj (param, externref); local 1 = objAny (anyref); local 2 = userIter (externref)
-  const emptyArgsVec: Instr[] = [
-    // $vecExtern{ length: 0, data: null } → externref
-    { op: "i32.const", value: 0 },
-    { op: "ref.null", typeIdx: arrTypeIdx } as Instr,
-    { op: "struct.new", typeIdx: vecTypeIdx },
-    { op: "extern.convert_any" } as Instr,
-  ];
-  const iteratorBody: Instr[] = [
-    // objAny = any.convert_extern(obj)
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" } as Instr,
-    { op: "local.tee", index: 1 },
-    { op: "ref.test", typeIdx: vecTypeIdx },
-    {
-      op: "if",
-      blockType: { kind: "val", type: { kind: "externref" } },
-      then: [
-        // VEC carrier: $IterRec{VEC, vec, 0, userIter:null}
-        { op: "i32.const", value: ITER_KIND_VEC },
-        { op: "local.get", index: 1 },
-        { op: "ref.cast", typeIdx: vecTypeIdx },
-        { op: "i32.const", value: 0 },
-        { op: "ref.null.extern" } as Instr,
-        { op: "struct.new", typeIdx: iterRecTypeIdx },
-        { op: "extern.convert_any" } as Instr,
-      ],
-      else: userCarrierWired
-        ? [
-            // userIter = obj[@@iterator]()  (null if obj has no @@iterator)
-            { op: "local.get", index: 0 },
-            ...stringConstantExternrefInstrs(ctx, "@@iterator"),
-            ...emptyArgsVec,
-            { op: "call", funcIdx: externMethodCallIdx! },
-            { op: "local.tee", index: 2 },
-            { op: "ref.is_null" } as Instr,
-            {
-              op: "if",
-              blockType: { kind: "val", type: { kind: "externref" } },
-              // No @@iterator → obj is itself the iterator (has `next`).
-              then: [{ op: "local.get", index: 0 }],
-              else: [{ op: "local.get", index: 2 }],
-            } as unknown as Instr,
-            { op: "local.set", index: 2 },
-            // $IterRec{USER, vec:null, idx:0, userIter}
-            { op: "i32.const", value: ITER_KIND_USER },
-            { op: "ref.null", typeIdx: vecTypeIdx } as Instr,
-            { op: "i32.const", value: 0 },
-            { op: "local.get", index: 2 },
-            { op: "struct.new", typeIdx: iterRecTypeIdx },
-            { op: "extern.convert_any" } as Instr,
-          ]
-        : [
-            // USER carrier unavailable — preserve the legacy hard cast so the
-            // failure mode is unchanged (loud trap) rather than silently wrong.
-            { op: "i32.const", value: ITER_KIND_VEC },
-            { op: "local.get", index: 1 },
-            { op: "ref.cast", typeIdx: vecTypeIdx },
-            { op: "i32.const", value: 0 },
-            { op: "ref.null.extern" } as Instr,
-            { op: "struct.new", typeIdx: iterRecTypeIdx },
-            { op: "extern.convert_any" } as Instr,
-          ],
-    } as unknown as Instr,
-  ];
   registerNative(
     "__iterator",
     [{ kind: "externref" }],
@@ -222,14 +179,12 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
       { name: "objAny", type: { kind: "anyref" } },
       { name: "userIter", type: { kind: "externref" } },
     ],
-    iteratorBody,
+    buildIteratorBody(types, undefined),
   );
 
   // --- __iterator_next(recExt: externref) -> (i32 done, externref value) ---
-  // IteratorStep + IteratorValue §7.4.5/§7.4.6. Read the canonical externref
-  // vec at the cursor; advance on a live element, else report done. Body built
-  // with explicit done/value locals so the multi-value results are emitted in
-  // ABI order (done, value).
+  // IteratorStep + IteratorValue §7.4.5/§7.4.6. Vec-only at emit time; the USER
+  // arm is filled later. Locals sized for both arms (USER uses local 6 = res).
   //   local 0 = recExt (param, externref)
   //   local 1 = rec    ($IterRec)
   //   local 2 = vec    (ref null $vecExtern)
@@ -249,17 +204,12 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
       { name: "value", type: { kind: "externref" } },
       { name: "res", type: { kind: "externref" } },
     ],
-    buildIteratorNextBody(ctx, iterRecTypeIdx, vecTypeIdx, arrTypeIdx, {
-      userCarrierWired,
-      externMethodCallIdx,
-      externGetIdx,
-      isTruthyIdx,
-      emptyArgsVec,
-    }),
+    buildIteratorNextBody(types, undefined),
   );
 
   // --- __iterator_return(recExt: externref) -> ()  (IteratorClose §7.4.8) ---
-  // Slice 1: canonical-vec iterators have no user `.return` → no-op.
+  // Slice 1: canonical-vec iterators have no user `.return` → no-op. (USER-arm
+  // close of a sync-backed iterator is also a no-op for the common shape.)
   registerNative("__iterator_return", [{ kind: "externref" }], [], [], []);
 
   // --- __iterator_rest(recExt: externref) -> externref  ([...rest] drain) ---
@@ -286,28 +236,141 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
     ],
     buildIteratorRestBody(iterRecTypeIdx, vecTypeIdx, arrTypeIdx),
   );
+
+  // (#2038) Defer the USER arm to finalize (closed-struct dispatchers not yet
+  // emitted). The eager bodies above are a valid vec-only carrier.
+  ctx.nativeIteratorUserArmPending = true;
 }
 
 /**
- * Build the `__iterator_next` body with explicit done/value computation so the
- * multi-value `(i32 done, externref value)` results are emitted in ABI order.
- * Locals: 0=recExt(param), 1=rec, 2=vec, 3=i, 4=done(i32), 5=value(externref),
- * 6=res(externref, USER next() result).
+ * (#2038, reserve-then-fill #1719) Rebuild the `__iterator` / `__iterator_next`
+ * bodies with the USER `{next()}`-protocol arm, now that the closed-struct
+ * dispatchers (`__call_@@iterator`, `__call_next`, `__sget_value`, `__sget_done`)
+ * and `__is_truthy` have been emitted at finalize. No-op when:
+ *   - the native runtime was never registered (`!nativeIteratorUserArmPending`),
+ *   - any dispatcher is absent (e.g. no custom iterable / `{value,done}` struct in
+ *     the module) — the carrier stays vec-only and byte-identical.
+ *
+ * MUST be called AFTER `emitStructFieldGetters` + `emitIteratorMethodExport` in
+ * the finalize sequence. Storing the carrier funcIdx in `funcMap` (and looking it
+ * up post-shift here) keeps it in lockstep with any late-import index shift.
  */
-interface UserNextDeps {
-  userCarrierWired: boolean;
-  externMethodCallIdx: number | undefined;
-  externGetIdx: number | undefined;
-  isTruthyIdx: number | undefined;
-  emptyArgsVec: Instr[];
+export function fillNativeIteratorUserArms(ctx: CodegenContext): void {
+  if (!ctx.nativeIteratorUserArmPending) return;
+
+  const callIteratorIdx = ctx.funcMap.get("__call_@@iterator");
+  const callNextIdx = ctx.funcMap.get("__call_next");
+  const sgetValueIdx = ctx.funcMap.get("__sget_value");
+  const sgetDoneIdx = ctx.funcMap.get("__sget_done");
+  const isTruthyIdx = ctx.funcMap.get("__is_truthy");
+  if (
+    callIteratorIdx === undefined ||
+    callNextIdx === undefined ||
+    sgetValueIdx === undefined ||
+    sgetDoneIdx === undefined ||
+    isTruthyIdx === undefined
+  ) {
+    // No closed-struct iterable in this module (or no truthiness helper) → the
+    // vec-only carrier is correct as-is. Custom iterables, if any, keep trapping
+    // exactly as on the pre-#2038 runtime rather than shipping a broken arm.
+    return;
+  }
+  const deps: UserCarrierDeps = { callIteratorIdx, callNextIdx, sgetValueIdx, sgetDoneIdx, isTruthyIdx };
+
+  const types = iterRuntimeTypes(ctx);
+
+  const iteratorIdx = ctx.funcMap.get("__iterator");
+  const iteratorNextIdx = ctx.funcMap.get("__iterator_next");
+  if (iteratorIdx === undefined || iteratorNextIdx === undefined) return;
+
+  const iteratorFn = ctx.mod.functions[iteratorIdx - ctx.numImportFuncs];
+  const iteratorNextFn = ctx.mod.functions[iteratorNextIdx - ctx.numImportFuncs];
+  if (iteratorFn) iteratorFn.body = buildIteratorBody(types, deps);
+  if (iteratorNextFn) iteratorNextFn.body = buildIteratorNextBody(types, deps);
 }
-function buildIteratorNextBody(
-  ctx: CodegenContext,
-  iterRecTypeIdx: number,
-  vecTypeIdx: number,
-  arrTypeIdx: number,
-  deps: UserNextDeps,
-): Instr[] {
+
+/**
+ * Build the `__iterator(obj) -> externref` body. With `deps === undefined` this
+ * is the vec-only carrier (a non-vec subject hard-casts → `illegal cast`, the
+ * legacy failure mode). With `deps` it adds the USER arm:
+ *   - obj is a canonical externref `$Vec` → $IterRec{kind:VEC, vec, 0, null}.
+ *   - (#2038) otherwise → obtain the iterator object via `__call_@@iterator(obj)`
+ *     and build $IterRec{kind:USER, vec:null, 0, userIter}. If the dispatcher
+ *     returns null (obj is ALREADY an iterator with a bare `next` and no
+ *     `@@iterator`), fall back to using obj itself as the iterator object.
+ * Locals: 0=obj(param), 1=objAny(anyref), 2=userIter(externref).
+ */
+function buildIteratorBody(types: IterRuntimeTypes, deps: UserCarrierDeps | undefined): Instr[] {
+  const { iterRecTypeIdx, vecTypeIdx } = types;
+  // VEC arm: $IterRec{VEC, vec, 0, userIter:null}. Field order/arity is
+  // load-bearing — struct.new pushes all 4 fields (userIter = ref.null.extern).
+  const vecArm: Instr[] = [
+    { op: "i32.const", value: ITER_KIND_VEC },
+    { op: "local.get", index: 1 },
+    { op: "ref.cast", typeIdx: vecTypeIdx },
+    { op: "i32.const", value: 0 },
+    { op: "ref.null.extern" } as Instr,
+    { op: "struct.new", typeIdx: iterRecTypeIdx },
+    { op: "extern.convert_any" } as Instr,
+  ];
+
+  const elseArm: Instr[] = deps
+    ? [
+        // userIter = __call_@@iterator(obj)  (null if obj has no @@iterator)
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: deps.callIteratorIdx } as Instr,
+        { op: "local.tee", index: 2 },
+        { op: "ref.is_null" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          // No @@iterator → obj is itself the iterator (has `next`).
+          then: [{ op: "local.get", index: 0 }],
+          else: [{ op: "local.get", index: 2 }],
+        } as unknown as Instr,
+        { op: "local.set", index: 2 },
+        // $IterRec{USER, vec:null, idx:0, userIter}
+        { op: "i32.const", value: ITER_KIND_USER },
+        { op: "ref.null", typeIdx: vecTypeIdx } as Instr,
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: 2 },
+        { op: "struct.new", typeIdx: iterRecTypeIdx },
+        { op: "extern.convert_any" } as Instr,
+      ]
+    : // USER carrier not filled — preserve the legacy hard cast so the failure
+      // mode is unchanged (loud trap) rather than silently wrong.
+      vecArm;
+
+  return [
+    // objAny = any.convert_extern(obj)
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: 1 },
+    { op: "ref.test", typeIdx: vecTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: vecArm,
+      else: elseArm,
+    } as unknown as Instr,
+  ];
+}
+
+/**
+ * Build the `__iterator_next(recExt) -> (i32 done, externref value)` body. With
+ * `deps === undefined` only the vec arm is reachable (USER kind is never produced
+ * without the fill). With `deps` the USER arm dispatches (§7.4.4 IteratorNext +
+ * §7.4.6 IteratorValue):
+ *   res = __call_next(userIter);  done = ToBoolean(__sget_done(res));
+ *   value = done ? undefined : __sget_value(res)
+ * (a non-object `res` ⇒ the field getters return null ⇒ done falsy/value null;
+ *  the §7.4.4 "next result not an Object ⇒ TypeError" refinement is a follow-up).
+ * Locals: 0=recExt(param), 1=rec, 2=vec, 3=i, 4=done(i32), 5=value(externref),
+ * 6=res(externref).
+ */
+function buildIteratorNextBody(types: IterRuntimeTypes, deps: UserCarrierDeps | undefined): Instr[] {
+  const { iterRecTypeIdx, vecTypeIdx, arrTypeIdx } = types;
+
   // The vec-carrier step (existing behavior), computing done(4)/value(5).
   const vecStep: Instr[] = [
     // vec = rec.vec
@@ -354,47 +417,44 @@ function buildIteratorNextBody(
     } as unknown as Instr,
   ];
 
-  // (#2038) The USER-carrier step (§7.4.4 IteratorNext + §7.4.6 IteratorValue):
-  //   res = userIter.next();  done = ToBoolean(res.done);  value = res.value
-  // Result-not-an-object is left to the host get returning undefined (the common
-  // user-iterator shapes always return an object); a hard TypeError on a
-  // non-object result is a follow-up refinement.
-  const userStep: Instr[] = deps.userCarrierWired
-    ? [
-        // res = __extern_method_call(rec.userIter, "next", emptyArgs)
-        { op: "local.get", index: 1 },
-        { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 },
-        ...stringConstantExternrefInstrs(ctx, "next"),
-        ...deps.emptyArgsVec,
-        { op: "call", funcIdx: deps.externMethodCallIdx! },
-        { op: "local.set", index: 6 },
-        // done = ToBoolean(__extern_get(res, "done"))
-        { op: "local.get", index: 6 },
-        ...stringConstantExternrefInstrs(ctx, "done"),
-        { op: "call", funcIdx: deps.externGetIdx! },
-        { op: "call", funcIdx: deps.isTruthyIdx! },
-        { op: "local.set", index: 4 },
-        // value = done ? undefined : __extern_get(res, "value")
-        { op: "local.get", index: 4 },
-        {
-          op: "if",
-          blockType: { kind: "val", type: { kind: "externref" } },
-          then: [{ op: "ref.null.extern" } as Instr],
-          else: [
-            { op: "local.get", index: 6 },
-            ...stringConstantExternrefInstrs(ctx, "value"),
-            { op: "call", funcIdx: deps.externGetIdx! },
-          ],
-        } as unknown as Instr,
-        { op: "local.set", index: 5 },
-      ]
-    : // USER carrier not wired — never reached (kind is never USER without it).
-      [
-        { op: "i32.const", value: 1 },
-        { op: "local.set", index: 4 },
-        { op: "ref.null.extern" } as Instr,
-        { op: "local.set", index: 5 },
-      ];
+  if (!deps) {
+    // Vec-only carrier: kind is always VEC, so emit the vec step directly with no
+    // kind branch — byte-identical to the pre-#2038 runtime.
+    return [
+      // rec = cast(any.convert_extern(recExt))
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.cast", typeIdx: iterRecTypeIdx },
+      { op: "local.set", index: 1 },
+      ...vecStep,
+      // results in ABI order: (done, value)
+      { op: "local.get", index: 4 },
+      { op: "local.get", index: 5 },
+    ];
+  }
+
+  // (#2038) The USER-carrier step: dispatch through the closed-struct helpers.
+  const userStep: Instr[] = [
+    // res = __call_next(rec.userIter)
+    { op: "local.get", index: 1 },
+    { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 },
+    { op: "call", funcIdx: deps.callNextIdx } as Instr,
+    { op: "local.set", index: 6 },
+    // done = ToBoolean(__sget_done(res))
+    { op: "local.get", index: 6 },
+    { op: "call", funcIdx: deps.sgetDoneIdx } as Instr,
+    { op: "call", funcIdx: deps.isTruthyIdx } as Instr,
+    { op: "local.set", index: 4 },
+    // value = done ? undefined : __sget_value(res)
+    { op: "local.get", index: 4 },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "ref.null.extern" } as Instr],
+      else: [{ op: "local.get", index: 6 }, { op: "call", funcIdx: deps.sgetValueIdx } as Instr],
+    } as unknown as Instr,
+    { op: "local.set", index: 5 },
+  ];
 
   return [
     // rec = cast(any.convert_extern(recExt))

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -40,6 +40,7 @@ import {
 import { collectInstrs } from "./shared.js";
 import { emitLocalTdzInit, emitTdzInitForBindingPattern } from "./tdz.js";
 import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "../expressions/proto-override.js";
+import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 
 /**
  * (#1719 S1) Gate predicate for the array object-value representation track.
@@ -370,11 +371,30 @@ export function emitNullGuard(
 }
 
 /**
- * Ensure __async_iterator import is available.
- * Returns the function index, or undefined if registration failed.
- * JS impl: (obj) => obj[Symbol.asyncIterator]?.() ?? obj[Symbol.iterator]()
+ * Ensure __async_iterator is available; return its function index.
+ *
+ * JS-host mode: register `env.__async_iterator`
+ *   (obj) => obj[Symbol.asyncIterator]?.() ?? obj[Symbol.iterator]()
+ *
+ * (#2038) Standalone / WASI: there is no JS host to satisfy that import, and
+ * feeding the host carrier to the native `__iterator_next` traps `illegal cast`.
+ * Per §7.4.3 GetIterator(async) + §27.1.4.1 CreateAsyncFromSyncIterator, for a
+ * **sync-backed** async iterable (the dominant test262 shape — `for await (x of
+ * [literals])` and `for await (x of syncIterable)`) the async iterator is the
+ * sync iterator with each value `Await`-ed; for an already-settled value
+ * `Await(v) = v`, so the async wrapper degenerates to the *identity* native
+ * iterator. So in standalone we return the SAME native `__iterator` the sync
+ * for-of consumer uses (now USER-`{next()}`-carrier aware). The per-element
+ * `Await` is layered by the for-await CPS lowering around the loop body and is a
+ * no-op for settled values — no `env.__async_iterator` / `env.Promise_resolve`
+ * leak. Genuinely-pending-Promise async iterables stay deferred to the standalone
+ * Promise runtime (PR-C).
  */
 export function ensureAsyncIterator(ctx: CodegenContext, fctx: FunctionContext): number | undefined {
+  if (ctx.standalone || ctx.wasi) {
+    ensureNativeIteratorRuntime(ctx);
+    return ctx.funcMap.get("__iterator");
+  }
   const idx = ctx.funcMap.get("__async_iterator");
   if (idx !== undefined) return idx;
   const importsBefore = ctx.numImportFuncs;

--- a/tests/issue-2038.test.ts
+++ b/tests/issue-2038.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #2038 (PATH A) — standalone native `{next()}`-protocol iterator carrier.
+ *
+ * A custom iterable `{ [Symbol.iterator]() { return { next() {…} } } }` compiles
+ * to a *closed nominal WasmGC struct*, not the open `$Object` hash-map. The
+ * vec-only native iterator runtime `ref.cast`s its arg to the externref vec, so a
+ * custom-iterable subject trapped `illegal cast` (sync for-of), and the
+ * `__extern_method_call`/`__extern_get` dispatch helpers (which gate on
+ * `ref.test $Object`) returned null for it, hanging `__iterator_next` forever.
+ *
+ * PATH A wires the native carrier's USER arm through the closed-struct
+ * dispatchers the finalize pass already emits — `__call_@@iterator` / `__call_next`
+ * (`emitIteratorMethodExport`) and `__sget_value` / `__sget_done`
+ * (`emitStructFieldGetters`) — via the #1719 reserve-then-fill discipline. This
+ * fixes BOTH sync `for-of` and (sync-backed) async `for await` over a custom
+ * iterable in standalone, with zero `env` imports. (Async generators + `yield*`
+ * and genuinely-pending-Promise for-await stay deferred — sub-bucket B / PR-C.)
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** env imports leaked by the compiled module (must be empty in standalone). */
+function envImports(result: Awaited<ReturnType<typeof compile>>): string[] {
+  return result.imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+/** Compile standalone (wasi), assert zero env imports + valid module, run `test`. */
+async function runStandalone(src: string): Promise<unknown> {
+  const result = await compile(src, { fileName: "t.ts", target: "wasi" });
+  expect(result.success, `compile failed: ${result.errors?.map((e) => e.message).join("; ")}`).toBe(true);
+  expect(envImports(result), "standalone module must leak no env imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  const ret = (instance.exports as Record<string, () => unknown>).test?.();
+  return ret;
+}
+
+/** Compile JS-host mode and run `test` (parity check). */
+async function runHost(src: string): Promise<unknown> {
+  const result = await compile(src, { fileName: "t.ts" });
+  expect(result.success, `host compile failed: ${result.errors?.map((e) => e.message).join("; ")}`).toBe(true);
+  const importObject = (result as unknown as { importObject: WebAssembly.Imports }).importObject;
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  (importObject as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  const ret = (instance.exports as Record<string, () => unknown>).test?.();
+  return ret;
+}
+
+const SYNC_CUSTOM_ITERABLE = `
+  export function test(): number {
+    const it = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return { next() { return i < 3 ? { value: i++, done: false } : { value: undefined, done: true }; } };
+      }
+    };
+    let sum = 0;
+    for (const x of it) sum += x;
+    return sum;
+  }
+`;
+
+const SYNC_CUSTOM_ITERABLE_ARR = `
+  export function test(): number {
+    const arr = [10, 20, 30];
+    const it = {
+      [Symbol.iterator]() {
+        let n = 0;
+        return { next() { return n < arr.length ? { value: arr[n++], done: false } : { value: 0, done: true }; } };
+      }
+    };
+    let sum = 0;
+    for (const x of it) sum += x;
+    return sum;
+  }
+`;
+
+const ASYNC_FOR_AWAIT_SYNC_BACKED = `
+  export async function test(): Promise<number> {
+    const it = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return { next() { return i < 3 ? { value: i++, done: false } : { value: undefined, done: true }; } };
+      }
+    };
+    let sum = 0;
+    for await (const x of it) sum += x;
+    return sum;
+  }
+`;
+
+describe("#2038 — standalone native {next()} iterator carrier", () => {
+  it("sync for-of over a custom {next()} iterable sums correctly (standalone)", async () => {
+    expect(await runStandalone(SYNC_CUSTOM_ITERABLE)).toBe(3);
+  });
+
+  it("sync for-of over a custom iterable backed by an array (standalone)", async () => {
+    expect(await runStandalone(SYNC_CUSTOM_ITERABLE_ARR)).toBe(60);
+  });
+
+  it("async for await over a sync-backed custom iterable (standalone, no env imports)", async () => {
+    expect(await runStandalone(ASYNC_FOR_AWAIT_SYNC_BACKED)).toBe(3);
+  });
+
+  it("matches JS-host mode for the custom-iterable for-of", async () => {
+    expect(await runHost(SYNC_CUSTOM_ITERABLE)).toBe(3);
+    expect(await runHost(SYNC_CUSTOM_ITERABLE_ARR)).toBe(60);
+  });
+
+  it("array for-of stays standalone-clean (no regression)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { let s = 0; for (const x of [1, 2, 3, 4]) s += x; return s; }`,
+      ),
+    ).toBe(10);
+  });
+
+  it("array for await stays standalone-clean (no regression)", async () => {
+    expect(
+      await runStandalone(
+        `export async function test(): Promise<number> { let s = 0; for await (const x of [1, 2, 3]) s += x; return s; }`,
+      ),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## #2038 PATH A — standalone native `{next()}`-protocol iterator carrier

Unblocks the dominant #2038 `illegal cast` bucket: a custom iterable
`{ [Symbol.iterator]() { return { next() {…} } } }` compiles to a **closed
nominal WasmGC struct**, not the open `$Object` hash-map. The vec-only native
iterator runtime `ref.cast`s its arg to the externref vec → `illegal cast` (sync
for-of); and the `$Object`-gated `__extern_method_call`/`__extern_get` helpers
the prior WIP used return null for a closed struct → `__iterator_next` spun
forever. Self-contained — does **not** need the #25 general-dispatch epic.

### What changed
- **`iterator-native.ts`** — the `$IterRec` USER arm now dispatches through the
  closed-struct helpers the finalize pass already emits:
  - `__iterator` USER arm: `userIter = __call_@@iterator(obj)` (fallback to `obj`
    when null = obj is itself a bare-`next` iterator).
  - `__iterator_next` USER arm: `res = __call_next(userIter)`;
    `done = __is_truthy(__sget_done(res))`; `value = done ? undefined :
    __sget_value(res)`.
  - **Reserve-then-fill (#1719):** `__iterator`/`__iterator_next` are emitted
    **vec-only** eagerly (byte-identical to the pre-#2038 runtime) and rebuilt
    with the USER arm by `fillNativeIteratorUserArms` at FINALIZE, after
    `emitStructFieldGetters` + `emitIteratorMethodExport` register the
    dispatchers. No custom iterable in the module ⇒ dispatchers absent ⇒ fill is
    a no-op ⇒ vec-only carrier (byte-identical).
- **`index.ts`** — `emitIteratorMethodExport` + `emitStructFieldGetters` now
  register their emitted funcs (`__call_@@iterator`/`__call_next`/`__sget_*`) in
  `ctx.funcMap` so the fill can resolve them (the actual blocker — they
  previously only pushed to `mod.functions`/`mod.exports`). Finalize invokes the
  fill after both emitters.
- **`destructuring.ts`** — `ensureAsyncIterator` in standalone/wasi returns the
  native `__iterator` (CreateAsyncFromSyncIterator = identity for sync-backed,
  §27.1.4.1) instead of the `env.__async_iterator` host import, so sync-backed
  `for await` drives the SAME USER carrier — no host leak, no `illegal cast`.
  Host mode unchanged.

### Validation
- sync `for (const x of {[Symbol.iterator](){return {next(){…}}}})` → 3;
  array-backed custom iterable → 60 — standalone, **zero env imports**.
- async sync-backed `for await (const x of customIterable)` → 3 — standalone,
  **zero env imports** (was `illegal cast`).
- array for-of / for-await / spread / destructuring / generator standalone
  binaries **byte-identical (sha256)** to `origin/main` — no regression.
- new `tests/issue-2038.test.ts` (6 cases) green; iterator/generator equiv
  suites show the **same pre-existing failure set** as main (one #681 case, two
  `symbol-async-iterator` + two `for-of-*` test-harness `helpers.js`/import
  errors — all fail identically on main, not caused here).

### Deferred (NOT in this PR)
Async-generator `yield*` (sub-bucket B, `generators-native.ts`) and the
standalone Promise/microtask runtime for genuinely-pending `for await` (PR-C).
General closed-struct any-method dispatch is the separate #25 epic (PATH B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)