### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding configuration — shows the "Sponsor" button on the repo.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: [loopdive]


### PR DESCRIPTION
## What

Adds `.github/FUNDING.yml` pointing the repo's **Sponsor** button at the `loopdive` organization.

```yaml
github: [loopdive]
```

## Notes

- The Sponsor button only appears once this lands on `main` (the default branch).
- The button links to `github.com/sponsors/loopdive`, so the org must complete GitHub Sponsors enrollment (identity verification, Stripe bank account, tax form, sponsorship tiers) for the link to resolve. The file can merge before that; the link just won't be useful until the org's Sponsors profile is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)