### PR TITLE
fix: restore WASI stdout module-init for user main (#1411 regression)

### DIFF
--- a/plan/issues/2154-wasi-start-skips-user-main-1411-regression.md
+++ b/plan/issues/2154-wasi-start-skips-user-main-1411-regression.md
@@ -1,0 +1,111 @@
+---
+id: 2154
+title: "WASI _start wraps only __module_init, never calls a user main() — #1411/#1978 regression (native-messaging smoke red)"
+status: done
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+completed: 2026-06-15
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: modules
+goal: core-semantics
+related: [900, 907, 1122, 1789, 1978]
+origin: "2026-06-15 native-messaging-smoke.yml red on main since PR #1411 (commit 657c6524); bisected last-good 65bea37e"
+---
+
+# #2154 — WASI `_start` skips a user `main()` (regression from #1411/#1978)
+
+## Symptom
+
+The `native-messaging smoke (real wasmtime)` check
+(`.github/workflows/native-messaging-smoke.yml`, job `smoke`) went green→red on
+`main` exactly at the merge of **PR #1411** (`fix(#1978): stop splicing
+module-init into a user function named main`, commit `657c6524`; last good
+`65bea37e`). It failed with `FAIL: stdout frame mismatch`: the compiled Native
+Messaging host (`examples/native-messaging/nm_js2wasm.ts`, which has an
+`export function main()`) produced **empty stdout** under real wasmtime.
+
+A red non-required `smoke` makes every PR `UNSTABLE`, which disabled
+auto-enqueue and stalled the merge pipeline — so this was high-leverage.
+
+## Root cause
+
+`addWasiStartExport` (`src/codegen/index.ts`) builds the WASI `_start` entry by
+choosing ONE target function to wrap. Before #1978, a user `main` had the
+module-init body spliced into it and no standalone `__module_init` existed, so
+`_start` fell back to wrapping `main` — running init-then-body. The program
+worked.
+
+#1978 correctly removed that splice (module-init must run **once** at load, not
+on every `main()` call), moving init into a standalone `__module_init`. But it
+left `addWasiStartExport` **preferring `__module_init` unconditionally**:
+
+```
+// old addWasiStartExport target selection
+let targetIdx;
+for (…) if (fn.name === "__module_init") targetIdx = …;   // always wins
+if (targetIdx === undefined) { …fall back to main… }      // never reached
+```
+
+So for a program WITH a user `main`, `_start` wrapped only `__module_init` —
+top-level globals were initialised but `main()` was **never called**. Verified
+in the emitted WAT: `(func $_start (call 47))` where funcIdx 47 = `$__module_init`
+(globals-only), and zero `call 44` (= `$main`) anywhere in the module. Under
+wasmtime the host read no stdin and wrote no stdout.
+
+## Fix (this PR — re-greens the smoke check)
+
+Restructured `addWasiStartExport` so it runs `applyModuleInitGuard` (#1789)
+**first** — that prepends `call __module_init` to every exported function,
+including a user `main` — and then **prefers an EXPORTED, no-arg, no-result
+`main`** as the `_start` entry:
+
+- `_start → main`. Because `main` (exported) now begins with the guard's
+  `call __module_init`, module init runs **exactly once** (idempotent
+  `__init_done` guard) and **then** main's body runs. This restores the
+  pre-#1978 program entry **without** re-introducing the splice — #1978 stays
+  fixed (init is not in `main`'s body, does not re-run per call).
+- Only when there is **no callable exported `main`** does `_start` fall back to
+  wrapping `__module_init` directly. This covers (a) pure top-level / init-only
+  programs, and (b) the `main()`-calls-itself convention where a **non-exported**
+  `main` is reached through the top-level call captured inside `__module_init`
+  (a non-exported `main` carries no guard prefix, so wrapping it would skip
+  init — it must NOT be the target).
+
+The `func.exported` check is the load-bearing distinction between an
+extension-entry `export function main()` (the target) and the convention
+`function main(){…} main();` (not the target). Non-WASI codegen is untouched —
+both `addWasiStartExport` call sites are `if (ctx.wasi)`-gated; non-WASI init
+still runs via the Wasm `(start)` section set in `declarations.ts`.
+
+## Acceptance
+
+- `examples/native-messaging/smoke-test.sh` passes byte-for-byte under real
+  wasmtime 44.0.0 (stdout = exact 17-byte frame; stderr = clean debug line).
+- The emitted `_start` calls `$main`, and `$main`'s body begins with
+  `call $__module_init`.
+- #1978 stays fixed: top-level state persists across `main()` calls (init runs
+  once), and the init body is not spliced into `main`.
+- A non-exported `main()` (convention) and a no-`main` module still wrap
+  `__module_init` in `_start`.
+
+## Test Results
+
+- `examples/native-messaging/smoke-test.sh`: **PASS** under real wasmtime
+  (before: `FAIL: stdout frame mismatch`, empty stdout).
+- `tests/issue-1411-wasi-main-start.test.ts` (new, 4 cases): exported-`main`
+  entry + init-first, #1978 once-only init, non-exported-`main` →
+  `__module_init`, no-`main` → `__module_init`. All pass.
+- `tests/issue-1978.test.ts` (5 cases): all pass — no #1978 regression.
+- `tests/wasi.test.ts` (24), `tests/wasi-target.test.ts`,
+  `tests/issue-1618-1651-wasi-stdout.test.ts`,
+  `tests/issue-1789-standalone-module-init.test.ts`: green.
+- Pre-existing failures NOT caused by this change (verified identical on
+  unpatched `origin/main`): `tests/issue-907.test.ts` "WASI target keeps _start
+  … does NOT use start section" (stale assertion vs #1789's `__init_done`);
+  `tests/issue-1653-*.test.ts` "ArrayBuffer-backed Uint8Array at a non-zero
+  offset"; `tests/issue-1326c.test.ts` "exports the async-scheduler API surface".

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1683,36 +1683,13 @@ function applyModuleInitGuard(ctx: CodegenContext): void {
   ctx.moduleInitGuardApplied = true;
 }
 
-/** Add a _start export for WASI — wraps __module_init or a no-arg main() (#1122).
+/** Add a _start export for WASI — wraps a user `main()` (running module init
+ *  first via the #1789 guard) or, when there is no callable `main`, the bare
+ *  `__module_init` (#1122).
  *  When the async microtask queue was registered (#1326c Phase 1C-A), append a
  *  call to `__drain_microtasks` after the entry function so any scheduled
  *  microtasks fire before WASI process exit. */
 function addWasiStartExport(ctx: CodegenContext): void {
-  // Prefer __module_init — it's always () -> void and handles all top-level code
-  let targetIdx: number | undefined;
-  for (let i = 0; i < ctx.mod.functions.length; i++) {
-    if (ctx.mod.functions[i]!.name === "__module_init") {
-      targetIdx = ctx.numImportFuncs + i;
-      break;
-    }
-  }
-
-  // Fall back to main only if __module_init doesn't exist AND main is () -> void
-  if (targetIdx === undefined) {
-    const mainIdx = ctx.funcMap.get("main");
-    if (mainIdx !== undefined) {
-      // Check that the function takes no parameters and returns no values
-      const funcArrayIdx = mainIdx - ctx.numImportFuncs;
-      if (funcArrayIdx >= 0 && funcArrayIdx < ctx.mod.functions.length) {
-        const func = ctx.mod.functions[funcArrayIdx]!;
-        const funcType = ctx.mod.types[func.typeIdx];
-        if (funcType && funcType.kind === "func" && funcType.params.length === 0 && funcType.results.length === 0) {
-          targetIdx = mainIdx;
-        }
-      }
-    }
-  }
-
   // (#1789) Make module init run before ANY exported function, not just
   // `_start`. The test262 standalone harness calls exports (e.g. `test()`)
   // directly without invoking `_start`, so a module-level `const`/`let`
@@ -1724,8 +1701,70 @@ function addWasiStartExport(ctx: CodegenContext): void {
   // no-op. Observable top-level side effects (console.log/stdout) therefore
   // still fire on whichever entry runs first (for WASI hosts that's `_start`,
   // preserving existing stdout behaviour) and never run twice.
+  //
+  // This MUST run BEFORE we pick the `_start` target below: the guard prepends
+  // `call __module_init` to every exported function (including a user `main`),
+  // which is exactly what lets `_start → main` run module init before main's
+  // body without splicing the init body into `main` (see the #1411/#1978 note
+  // on target selection).
   if (ctx.wasi) {
     applyModuleInitGuard(ctx);
+  }
+
+  // Choose the WASI program entry that `_start` wraps.
+  //
+  // #1411 regression: #1978 correctly stopped splicing the module-init body
+  // INTO a user `main` (init must run once at module load, not on every
+  // `main()` call), moving init to a standalone `__module_init`. But that left
+  // this function preferring `__module_init` unconditionally, so for a program
+  // WITH a user `main` (e.g. the Native Messaging host) `_start` wrapped ONLY
+  // `__module_init` — top-level globals were initialised but the user `main()`
+  // never ran, so the program produced no stdout under wasmtime.
+  //
+  // Fix: prefer an EXPORTED, no-arg, no-result `main` as the entry. Because
+  // applyModuleInitGuard (above) has already prepended `call __module_init` to
+  // every exported function, wrapping `main` runs module init exactly once (the
+  // idempotent guard) and THEN main's body — restoring the pre-#1978 behaviour
+  // WITHOUT re-introducing the splice. Only when there is no callable exported
+  // `main` do we fall back to wrapping `__module_init` directly: that covers
+  // pure top-level / init-only programs, and the `main()`-calls-itself
+  // convention where a NON-exported `main` is already invoked from top-level
+  // code captured in `__module_init`.
+  let targetIdx: number | undefined;
+
+  const mainIdx = ctx.funcMap.get("main");
+  if (mainIdx !== undefined) {
+    const funcArrayIdx = mainIdx - ctx.numImportFuncs;
+    if (funcArrayIdx >= 0 && funcArrayIdx < ctx.mod.functions.length) {
+      const func = ctx.mod.functions[funcArrayIdx]!;
+      const funcType = ctx.mod.types[func.typeIdx];
+      // Only an EXPORTED, no-arg, no-result `main` is a valid `_start` entry.
+      // A non-exported `main` (the `main()`-calls-itself convention) is reached
+      // through the top-level call already captured in `__module_init`, so it
+      // must NOT be the target — and, being non-exported, it does NOT carry the
+      // guard's `call __module_init` prefix, so wrapping it would skip module
+      // init entirely.
+      if (
+        func.exported &&
+        funcType &&
+        funcType.kind === "func" &&
+        funcType.params.length === 0 &&
+        funcType.results.length === 0
+      ) {
+        targetIdx = mainIdx;
+      }
+    }
+  }
+
+  // No callable exported `main` → wrap `__module_init`, which carries all
+  // top-level code (including any top-level call to a non-exported `main`).
+  if (targetIdx === undefined) {
+    for (let i = 0; i < ctx.mod.functions.length; i++) {
+      if (ctx.mod.functions[i]!.name === "__module_init") {
+        targetIdx = ctx.numImportFuncs + i;
+        break;
+      }
+    }
   }
 
   if (targetIdx !== undefined) {

--- a/tests/issue-1411-wasi-main-start.test.ts
+++ b/tests/issue-1411-wasi-main-start.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1411 — WASI `_start` must call a user `main()`, not just `__module_init`.
+ *
+ * #1978 correctly stopped splicing the module-init body INTO a user function
+ * named `main` (init must run once at module load, not on every `main()`
+ * call), moving init into a standalone `__module_init`. But `addWasiStartExport`
+ * was left preferring `__module_init` unconditionally as the `_start` target,
+ * so a `--target wasi` program WITH a user `main` (e.g. the Native Messaging
+ * host, examples/native-messaging/nm_js2wasm.ts) wrapped ONLY `__module_init`
+ * in `_start`: top-level globals were initialised but the user `main()` never
+ * ran. Under real wasmtime the program produced no stdout — the
+ * native-messaging smoke check went red (FAIL: stdout frame mismatch).
+ *
+ * Fix: `addWasiStartExport` runs `applyModuleInitGuard` first (which prepends
+ * `call __module_init` to every exported function, including `main`), then
+ * prefers an EXPORTED, no-arg, no-result `main` as the `_start` entry. So
+ * `_start → main` runs module init exactly once (idempotent guard) and THEN
+ * main's body — restoring the program entry without re-introducing the
+ * #1978 splice. A NON-exported `main` (the `main()`-calls-itself convention)
+ * is reached through the top-level call captured in `__module_init`, so
+ * `_start` still wraps `__module_init` there.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Return the funcIdx that `(func $_start ...)` calls (its first `call N`). */
+function startCallTarget(wat: string): number | undefined {
+  // Isolate the $_start function body.
+  const m = wat.match(/\(func \$_start [\s\S]*?\n {2}\)/);
+  if (!m) return undefined;
+  const call = m[0].match(/\bcall (\d+)/);
+  return call ? Number(call[1]) : undefined;
+}
+
+/** Map a defined-function name ($main, $__module_init, …) to its module funcIdx
+ *  (import funcs occupy the low indices, then defined funcs in textual order). */
+function funcIdxByName(wat: string, name: string): number | undefined {
+  const numImportFuncs = (wat.match(/\(import [^\n]*\(func /g) || []).length;
+  let idx = numImportFuncs;
+  for (const line of wat.split("\n")) {
+    const dm = line.match(/^ {2}\(func (\$[A-Za-z0-9_$]+)/);
+    if (dm) {
+      if (dm[1] === name) return idx;
+      idx++;
+    }
+  }
+  return undefined;
+}
+
+describe("#1411 WASI _start wraps a user main() (not just __module_init)", () => {
+  it("an exported main() is the _start entry, with module init run first via the #1789 guard", async () => {
+    // Top-level state + an exported `main` that uses it. The fix must wire
+    // `_start → main`, and `main` must begin with `call __module_init`.
+    const src = `
+      let counter = 0;
+      counter = 41;
+      export function main(): void { counter = counter + 1; }
+      export function get(): number { return counter; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const wat = r.wat!;
+
+    // _start must call the user `main`, NOT `__module_init` directly.
+    const mainIdx = funcIdxByName(wat, "$main");
+    const initIdx = funcIdxByName(wat, "$__module_init");
+    expect(mainIdx).toBeDefined();
+    expect(initIdx).toBeDefined();
+    expect(startCallTarget(wat)).toBe(mainIdx);
+
+    // And the init body is NOT spliced into main (#1978 must stay fixed):
+    // module init lives in its own function, reached via the guard prefix.
+    expect(wat).toContain("__module_init");
+    expect(wat).toMatch(/\(export "_start"/);
+
+    // Functional: instantiate standalone (empty imports). Calling `_start`
+    // runs module init (counter = 41) then main's body (counter = 42).
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as { _start(): void; get(): number };
+    ex._start();
+    expect(ex.get()).toBe(42);
+  });
+
+  it("#1978 stays fixed: top-level init runs once, not on every main() call", async () => {
+    // If init were spliced into (or re-run on) `main`, counter would reset to
+    // its initial top-level value every call → 42,42,42 instead of 42,43,44.
+    const src = `
+      let counter = 0;
+      counter = 41;
+      export function main(): void { counter = counter + 1; }
+      export function get(): number { return counter; }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as { main(): void; get(): number };
+    ex.main();
+    ex.main();
+    ex.main();
+    expect(ex.get()).toBe(44); // 41 (init, once) + 3 increments
+  });
+
+  it("a NON-exported main() (main()-calls-itself convention) keeps _start → __module_init", async () => {
+    // Here `main` is invoked from top-level code, which lives in
+    // `__module_init`. `_start` must wrap `__module_init` (so the top-level
+    // call to `main` runs) — NOT `main` directly (which would skip init and,
+    // being non-exported, carries no guard prefix).
+    const src = `function main(): void { /* entry */ } main();`;
+    const r = await compile(src, { fileName: "test.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const wat = r.wat!;
+    const initIdx = funcIdxByName(wat, "$__module_init");
+    expect(initIdx).toBeDefined();
+    expect(startCallTarget(wat)).toBe(initIdx);
+    expect(wat).toMatch(/\(export "_start"/);
+  });
+
+  it("a module with NO main is unregressed: _start → __module_init", async () => {
+    const src = `console.log("hi");`;
+    const r = await compile(src, { fileName: "test.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    const wat = r.wat!;
+    const initIdx = funcIdxByName(wat, "$__module_init");
+    expect(initIdx).toBeDefined();
+    expect(startCallTarget(wat)).toBe(initIdx);
+  });
+});


### PR DESCRIPTION
## Summary

The `native-messaging smoke (real wasmtime)` check (`.github/workflows/native-messaging-smoke.yml`, job `smoke`) went **green→red on main** at the merge of **PR #1411** (`fix(#1978): stop splicing module-init into a user function named main`, commit `657c6524`; last good `65bea37e`). It failed with `FAIL: stdout frame mismatch` — the compiled Native Messaging host produced **empty stdout** under real wasmtime. A red non-required `smoke` makes every PR `UNSTABLE` and disabled auto-enqueue, stalling the merge pipeline.

## Root cause

`addWasiStartExport` (`src/codegen/index.ts`) picks ONE function for the WASI `_start` to wrap. #1978 correctly stopped splicing the module-init body **into** a user `main` (init must run once at module load, not on every `main()` call) and moved init to a standalone `__module_init` — but it left `addWasiStartExport` **preferring `__module_init` unconditionally**. So for a program WITH a user `main` (the Native Messaging host has `export function main()`), `_start` wrapped only `__module_init`: top-level globals were initialised but **`main()` was never called**.

Confirmed in the emitted WAT: `(func $_start (call 47))` where funcIdx 47 = `$__module_init` (globals-only), and **zero** calls to `$main` anywhere.

## Fix

Restructured `addWasiStartExport` so it runs `applyModuleInitGuard` (#1789) **first** — that prepends `call __module_init` to every exported function, including `main` — and then **prefers an EXPORTED, no-arg, no-result `main`** as the `_start` entry:

- `_start → main`: because `main` (exported) now begins with the guard's `call __module_init`, module init runs **exactly once** (idempotent `__init_done` guard) and **then** main's body runs. Restores the pre-#1978 program entry **without** re-introducing the splice — **#1978 stays fixed**.
- Falls back to wrapping `__module_init` only when there is **no callable exported `main`**: pure top-level / init-only programs, and the `main()`-calls-itself convention where a **non-exported** `main` is reached via the top-level call inside `__module_init` (a non-exported `main` carries no guard prefix, so it must NOT be the target).

The `func.exported` check is the load-bearing distinction between an extension-entry `export function main()` (the target) and the convention `function main(){…} main();` (not the target). **Non-WASI codegen is untouched** — both call sites are `if (ctx.wasi)`-gated.

## Verification (real wasmtime 44.0.0)

- **Before:** `examples/native-messaging/smoke-test.sh` → `FAIL: stdout frame mismatch`, empty stdout.
- **After:** `OK: stdout is the exact 17-byte frame`; `OK: stderr is the clean debug line`; `PASS`.
- New `tests/issue-1411-wasi-main-start.test.ts` (4 cases): exported-`main` entry + init-first; #1978 once-only init (counter 41→44 across 3 calls, not 42,42,42); non-exported-`main` → `__module_init`; no-`main` → `__module_init`. All pass.
- `tests/issue-1978.test.ts` (5 cases) green — no #1978 regression.

**Re-greens** `native-messaging-smoke.yml` (`smoke`). After merge, `smoke` can be promoted to a required check.

New issue: `plan/issues/2154-wasi-start-skips-user-main-1411-regression.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)