### PR TITLE
fix(statusline): correct sprints.json path (website/dashboard, not dashboard)

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -270,7 +270,7 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
   sprint_n=""
   sprint_done=0
   sprint_total=0
-  sprints_json="/workspace/dashboard/data/sprints.json"
+  sprints_json="/workspace/website/dashboard/data/sprints.json"
   if [ -f "$sprints_json" ]; then
     # Read from pre-built sprints.json (deduplicated, wont-fix counted as done)
     sprint_data=$(jq -r '


### PR DESCRIPTION
## What

`.claude/statusline-command.sh:273` hardcoded the sprint-data path as `/workspace/dashboard/data/sprints.json`, but `build-data.js` writes to `website/dashboard/data/sprints.json` (`OUT = join(import.meta.dirname, "data")`, and the script lives in `website/dashboard/`). That path doesn't exist, so the primary `jq` read silently failed on **every** render and fell back to shelling out to `statusline-sprint.mjs`.

## Fix

One-line: point line 273 at the real path. The badge now resolves from the pre-built JSON directly; the `statusline-sprint.mjs` fallback stays in place as backup (it already used the correct path, which is why the badge still rendered).

No behavior change to what's displayed — just removes a wasted failed read + subprocess per render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)