### PR TITLE
plan(s62): reschedule to standalone catch-up; track Fable disablement (#2167)

### DIFF
--- a/plan/issues/1095-eliminate-as-unknown-as-instr.md
+++ b/plan/issues/1095-eliminate-as-unknown-as-instr.md
@@ -10,7 +10,7 @@ reasoning_effort: high
 task_type: refactor
 language_feature: compiler-internals
 goal: maintainability
-sprint: 62
+sprint: 63
 es_edition: n/a
 ---
 # #1095 — Eliminate `as unknown as Instr` casts (273 sites)

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -12,7 +12,7 @@ area: test-infrastructure, codegen
 language_feature: multi
 goal: self-hosting-dogfood
 sprint: 64
-model: fable
+model: opus
 depends_on: [1710, 1711]
 es_edition: multi
 related: [1690, 1690b, 1584, 1058]

--- a/plan/issues/1804-ir-vec-new-fixed-array-literal.md
+++ b/plan/issues/1804-ir-vec-new-fixed-array-literal.md
@@ -2,7 +2,7 @@
 id: 1804
 title: "feat(IR): vec.new_fixed — lower fixed-length array literals through the IR path"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-03
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1853-conformance-hard-error-stability-bucket.md
+++ b/plan/issues/1853-conformance-hard-error-stability-bucket.md
@@ -2,7 +2,7 @@
 id: 1853
 title: "Track a separate hard-error (compiler-crash / malformed-Wasm) stability bucket on the conformance dashboard, distinct from unsupported-feature"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-04
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1854-cross-backend-differential-testing.md
+++ b/plan/issues/1854-cross-backend-differential-testing.md
@@ -2,7 +2,7 @@
 id: 1854
 title: "Cross-backend differential testing harness — same TS to WasmGC / linear / bytecode-VM must produce identical observable output"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-04
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1855-ub-free-ts-fuzzer-and-minimization.md
+++ b/plan/issues/1855-ub-free-ts-fuzzer-and-minimization.md
@@ -2,7 +2,7 @@
 id: 1855
 title: "UB-free TypeScript program generator + automated validity-preserving test-case minimization for equivalence failures"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-04
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -1,7 +1,8 @@
 ---
 id: 1916
 title: "Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 model: fable
 created: 2026-06-10

--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -3,7 +3,7 @@ id: 1917
 title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
 status: ready
 sprint: 62
-model: fable
+model: opus
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1918-stack-balance-strict-mode-fixup-ratchet.md
+++ b/plan/issues/1918-stack-balance-strict-mode-fixup-ratchet.md
@@ -2,7 +2,7 @@
 id: 1918
 title: "Stack-balance strict mode + fixup ratchet — stop silently patching emitter bugs into wrong runtime values"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1919-transactional-speculative-compile.md
+++ b/plan/issues/1919-transactional-speculative-compile.md
@@ -2,7 +2,7 @@
 id: 1919
 title: "Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1921-structured-compile-failure-gate.md
+++ b/plan/issues/1921-structured-compile-failure-gate.md
@@ -2,7 +2,7 @@
 id: 1921
 title: "Replace the 'Codegen error:' string-prefix compile-failure gate with structured severity"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1922-shared-ir-traversal-while-loop-dce-defect.md
+++ b/plan/issues/1922-shared-ir-traversal-while-loop-dce-defect.md
@@ -2,7 +2,7 @@
 id: 1922
 title: "Shared IR traversal/use-collection module — fixes live defect: ordinary while loops demote off the IR path"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1923-meter-ir-post-claim-demotions.md
+++ b/plan/issues/1923-meter-ir-post-claim-demotions.md
@@ -2,7 +2,7 @@
 id: 1923
 title: "Meter IR post-claim demotions in the fallback ratchet — build/verify/lower failures are invisible to CI"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1924-ir-verifier-instruction-type-rules.md
+++ b/plan/issues/1924-ir-verifier-instruction-type-rules.md
@@ -2,7 +2,7 @@
 id: 1924
 title: "Instruction-level type rules in the IR verifier — operands, branch-arg types, and resultType validation"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1925-ir-hygiene-passes-nested-buffers.md
+++ b/plan/issues/1925-ir-hygiene-passes-nested-buffers.md
@@ -2,7 +2,7 @@
 id: 1925
 title: "Run IR hygiene passes inside nested buffers — or commit to one control-flow representation"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
+++ b/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
@@ -2,7 +2,7 @@
 id: 1926
 title: "Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1927-single-pipeline-driver.md
+++ b/plan/issues/1927-single-pipeline-driver.md
@@ -2,7 +2,7 @@
 id: 1927
 title: "One front-end pipeline driver — compileSourceSync/compileMultiSource/compileFilesSource are divergent clones"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1930-typeoracle-type-query-boundary.md
+++ b/plan/issues/1930-typeoracle-type-query-boundary.md
@@ -1,7 +1,8 @@
 ---
 id: 1930
 title: "TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 model: fable
 created: 2026-06-10

--- a/plan/issues/1931-decompose-detect-early-errors-treeshake.md
+++ b/plan/issues/1931-decompose-detect-early-errors-treeshake.md
@@ -2,7 +2,7 @@
 id: 1931
 title: "Decompose detectEarlyErrors (3,350-line function) and run it on every path; wire or delete the dead treeshake option"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
+++ b/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
@@ -2,7 +2,7 @@
 id: 1938
 title: "Linear backend: number[] stores i32 elements ([1.5] → [1]) and element-assignment evaluates RHS twice"
 status: in-progress
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-11
 priority: high

--- a/plan/issues/1950-default-on-optimization-pipeline.md
+++ b/plan/issues/1950-default-on-optimization-pipeline.md
@@ -2,7 +2,7 @@
 id: 1950
 title: "Default-on optimization — default builds ship unoptimized; add -O default where Binaryen is present plus tiny always-on cleanups"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1975-linear-truthiness-nan-empty-string.md
+++ b/plan/issues/1975-linear-truthiness-nan-empty-string.md
@@ -2,7 +2,7 @@
 id: 1975
 title: "linear backend: NaN and \"\" are truthy (f64.ne 0 / raw i32 pointer truthiness); &&/|| return 0/1 instead of operand values"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-10
 priority: high

--- a/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
+++ b/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
@@ -2,7 +2,7 @@
 id: 1976
 title: "linear backend: string relationals compare memory addresses; .length returns UTF-8 byte count; string concat in compound-assign emits invalid module"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-10
 priority: high

--- a/plan/issues/1984-index-space-freeze-point.md
+++ b/plan/issues/1984-index-space-freeze-point.md
@@ -2,7 +2,7 @@
 id: 1984
 title: "freeze-point discipline: indexSpaceFrozen flag — late addImport/ensureLateImport after final flush throws at the producer (#2043 Option 3)"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1985-stale-proof-index-cells.md
+++ b/plan/issues/1985-stale-proof-index-cells.md
@@ -1,7 +1,8 @@
 ---
 id: 1985
 title: "stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-10
 updated: 2026-06-12

--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -8,7 +8,7 @@ updated: 2026-06-10
 priority: critical
 feasibility: medium
 reasoning_effort: high
-model: fable
+model: opus
 task_type: bugfix
 area: codegen, emit
 language_feature: classes, explicit-resource-management, objects

--- a/plan/issues/2039-standalone-invalid-wasm-residual-bucket.md
+++ b/plan/issues/2039-standalone-invalid-wasm-residual-bucket.md
@@ -1,7 +1,8 @@
 ---
 id: 2039
 title: "standalone invalid-Wasm residual bucket after #1623/#1666/#1677: async-gen i64 ABI, __obj_find externref key, __str_flatten, arguments arity (~1,135 tests)"
-status: in-progress
+status: blocked
+blocked_by: [2167]
 sprint: Backlog
 created: 2026-06-10
 updated: 2026-06-10

--- a/plan/issues/2044-bigint-i64-brand-valtype-decision.md
+++ b/plan/issues/2044-bigint-i64-brand-valtype-decision.md
@@ -1,7 +1,8 @@
 ---
 id: 2044
 title: "architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-10
 updated: 2026-06-12

--- a/plan/issues/2045-linear-uint8-soundness-holes.md
+++ b/plan/issues/2045-linear-uint8-soundness-holes.md
@@ -2,7 +2,7 @@
 id: 2045
 title: "linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up)"
 status: in-progress
-sprint: 62
+sprint: 63
 created: 2026-06-10
 updated: 2026-06-12
 priority: critical

--- a/plan/issues/2084-module-global-read-guard-write-unguarded.md
+++ b/plan/issues/2084-module-global-read-guard-write-unguarded.md
@@ -2,7 +2,7 @@
 id: 2084
 title: "module-global object access: reads re-emit null-check+throw per access (survives -O); writes have NO check and trap instead of TypeError"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-11
 updated: 2026-06-12
 priority: low

--- a/plan/issues/2090-stack-balance-self-repair-hard-error.md
+++ b/plan/issues/2090-stack-balance-self-repair-hard-error.md
@@ -2,7 +2,7 @@
 id: 2090
 title: "stack-balance self-repair must not invent values — null patch becomes a hard compile error"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-11
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2134-ir-effect-model-ordered-emission.md
+++ b/plan/issues/2134-ir-effect-model-ordered-emission.md
@@ -1,7 +1,8 @@
 ---
 id: 2134
 title: "IR effect model: classify instruction kinds, enforce program-order emission for effectful ops"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-12
 updated: 2026-06-12

--- a/plan/issues/2135-ir-capability-predicate-single-source.md
+++ b/plan/issues/2135-ir-capability-predicate-single-source.md
@@ -1,7 +1,8 @@
 ---
 id: 2135
 title: "Single IR capability predicate shared by selector and builder (retire select.ts/from-ast.ts drift)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-12
 updated: 2026-06-12

--- a/plan/issues/2136-ir-loop-cond-toboolean.md
+++ b/plan/issues/2136-ir-loop-cond-toboolean.md
@@ -2,7 +2,7 @@
 id: 2136
 title: "IR loop conditions: lower non-i32 conds through ToBoolean instead of bailing to legacy"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-12
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2137-irpath-report-structured-channel.md
+++ b/plan/issues/2137-irpath-report-structured-channel.md
@@ -2,7 +2,7 @@
 id: 2137
 title: "IrPathReport channel: stop laundering IR fallbacks through ctx.errors warnings"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-12
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -1,7 +1,8 @@
 ---
 id: 2138
 title: "IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-12
 updated: 2026-06-12

--- a/plan/issues/2139-ci-linear-backend-tests-not-executed.md
+++ b/plan/issues/2139-ci-linear-backend-tests-not-executed.md
@@ -2,7 +2,7 @@
 id: 2139
 title: "CI: linear-backend tests (22 files) are not executed by any CI job"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-12
 updated: 2026-06-12
 priority: critical

--- a/plan/issues/2140-fixbranchtype-coerce-or-throw.md
+++ b/plan/issues/2140-fixbranchtype-coerce-or-throw.md
@@ -1,7 +1,8 @@
 ---
 id: 2140
 title: "stack-balance fixBranchType: coerce-where-possible, throw on impossible (split of #1858-C1)"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-12
 updated: 2026-06-12

--- a/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
+++ b/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
@@ -1,7 +1,8 @@
 ---
 id: 2141
 title: "Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing"
-status: ready
+status: blocked
+blocked_by: [2167]
 sprint: 64
 created: 2026-06-12
 updated: 2026-06-12

--- a/plan/issues/2143-validate-unoptimized-output-lane.md
+++ b/plan/issues/2143-validate-unoptimized-output-lane.md
@@ -2,7 +2,7 @@
 id: 2143
 title: "WebAssembly.validate lane for unoptimized pipeline output (split of #1858-C5)"
 status: ready
-sprint: 62
+sprint: 63
 created: 2026-06-12
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2157-standalone-iterator-generator-conformance-residual.md
+++ b/plan/issues/2157-standalone-iterator-generator-conformance-residual.md
@@ -1,0 +1,55 @@
+---
+id: 2157
+title: "Standalone iterator/generator conformance residual (~1,200 tests beyond #2079)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: critical
+feasibility: hard
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: iterators-generators
+goal: standalone-mode
+parent: 1665
+depends_on: [2079, 1899]
+---
+
+# Standalone iterator/generator conformance residual
+
+## Problem
+
+The pure-Wasm iterator protocol and native generators landed across #680,
+#1665, #681, #1718 (all `done`, sprints 58–61). But a host-vs-standalone
+test262 baseline diff (`loopdive/js2wasm-baselines`, sha `31fa7e099`,
+generated 2026-06-15) shows the **single largest catch-up bucket**: **2,172
+tests pass in JS-host mode but fail standalone**, attributed to iterator /
+generator machinery.
+
+`#2079` (standalone generators funcindex CE) accounts for ~960 of these via
+the late-import index-shift compile error. **This issue tracks the remaining
+~1,200** — runtime/iterator-protocol divergences not explained by the
+funcindex CE.
+
+## Evidence
+
+- Audit leak classes in the gap: `iterator_protocol` 2,057, plus generator
+  host imports (`__gen_next`, `__gen_create_buffer`, `__create_generator`,
+  `__create_async_generator`, `__gen_yield_star`, `__array_from_iter_n`).
+- Mechanism split: heavy on `compile_error` (funcindex, captured by #2079)
+  plus runtime `fail` (spread/for-of/destructuring over user iterators
+  returning wrong values).
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/Iterator`, `built-ins/GeneratorPrototype`,
+  and generator/spread/for-of language tests rises toward host parity.
+- No `iterator_protocol` host-import leak remains in standalone mode for the
+  covered cases.
+- Repros from the gap diff added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1665. Sequenced after #2079 + #1899 (funcidx authority).
+Part of sprint-62 standalone catch-up (rank 1 by gap impact).

--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -1,0 +1,47 @@
+---
+id: 2158
+title: "Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: classes
+goal: standalone-mode
+parent: 1591
+depends_on: [2101, 1965]
+---
+
+# Standalone class/prototype/descriptor conformance residual
+
+## Problem
+
+Class elements, private fields, brand checks, and descriptor fidelity landed
+in #1591, #1365, #1364 (all `done`, sprints 51–61). The host-vs-standalone
+baseline diff (sha `31fa7e099`, 2026-06-15) shows **1,388 tests pass in host
+mode but fail standalone**, attributed to the class/prototype/private-name/
+descriptor object model — the second-largest catch-up bucket.
+
+## Evidence
+
+- Concentrated in `built-ins/Object` (compile-error heavy) and class
+  language tests; `dynamic_object_property` leaks plus `(none)`-leak compile
+  errors in the object model.
+- Implementation should consume the #2101 class object-model architecture
+  spec and the #1965 base-constructor execution fix.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/Object` + class language tests rises
+  toward host parity.
+- Descriptor/private-name/brand-check semantics match host mode standalone.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1591. Implements against spec #2101; depends on #1965.
+Part of sprint-62 standalone catch-up (rank 2 by gap impact).

--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -1,0 +1,47 @@
+---
+id: 2159
+title: "Standalone TypedArray/DataView/ArrayBuffer conformance residual (~1,308 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 1461
+---
+
+# Standalone TypedArray/DataView/buffer conformance residual
+
+## Problem
+
+TypedArray callback methods, generic array-like receivers, and DataView/
+ArrayBuffer support landed in #1358, #1461, #1654 (all `done`, sprints
+51–58). The host-vs-standalone baseline diff (sha `31fa7e099`, 2026-06-15)
+shows **1,308 tests pass in host mode but fail standalone**, attributed to
+TypedArray/DataView/buffer semantics — the third-largest catch-up bucket
+and currently **untracked/unscheduled**.
+
+## Evidence
+
+- Gap categories: `built-ins/TypedArray` (565), `built-ins/TypedArrayConstructors`
+  (321), `built-ins/DataView` (336), `built-ins/ArrayBuffer` (78),
+  `built-ins/Atomics` (132).
+- Mostly `(none)`-leak `compile_error` (525 TypedArray + 287 ctor +
+  135 DataView) — standalone codegen gaps, not host-import shims.
+
+## Acceptance criteria
+
+- Standalone pass count for the TypedArray/DataView/ArrayBuffer/Atomics
+  categories rises toward host parity.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1461. Part of sprint-62 standalone catch-up (rank 3 by gap
+impact). Compile-error-heavy — likely shares root cause with the #2079
+late-import index-shift class for some constructors.

--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -1,0 +1,46 @@
+---
+id: 2160
+title: "Standalone String/Number method & coercion conformance residual (~635 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: string-number
+goal: standalone-mode
+parent: 1470
+depends_on: [1917, 2104]
+---
+
+# Standalone String/Number method & coercion conformance residual
+
+## Problem
+
+Wasm-native string methods and standalone number formatting landed in #1470,
+#1335, #1105 (all `done`, sprints 58–61). The host-vs-standalone baseline
+diff (sha `31fa7e099`, 2026-06-15) shows **635 tests pass in host mode but
+fail standalone**, attributed to String/Number method and coercion residuals.
+
+## Evidence
+
+- Gap categories: `built-ins/String` (643), `built-ins/Number` (159),
+  plus String/Number coercion in `language/expressions`.
+- Partly overlaps the coercion engine (#1917) and value-rep boxing
+  (#2072/#2104) work — `__new_String`/`__new_Number` wrapper boxing leaks.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/String` + `built-ins/Number` rises
+  toward host parity.
+- No `__new_String`/`__new_Number` host-import leak for the covered cases.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1470. Sequenced after the coercion engine (#1917) and
+value-rep P1 (#2104). Part of sprint-62 standalone catch-up (rank 4 by gap
+impact).

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -1,0 +1,44 @@
+---
+id: 2161
+title: "Standalone RegExp engine conformance residual (~579 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: regexp
+goal: standalone-mode
+parent: 1909
+---
+
+# Standalone RegExp engine conformance residual
+
+## Problem
+
+The standalone native RegExp engine landed in #682 and the #1909–#1914 phase
+bucket (all `done`, sprint 61, mostly `critical`). The host-vs-standalone
+baseline diff (sha `31fa7e099`, 2026-06-15) shows **579 tests still pass in
+host mode but fail standalone**, attributed to the RegExp engine — currently
+**untracked/unscheduled**.
+
+## Evidence
+
+- Gap category: `built-ins/RegExp` 554, of which 425 are `(none)`-leak
+  `compile_error` and ~51 runtime `fail`.
+- Residual phases the #1909–#1914 buckets did not fully close: source/flags
+  reflection, `lastIndex` for global/sticky, `split`/`replace`/`matchAll`,
+  and u/v/d-flag Unicode/lookaround edge cases.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/RegExp` rises toward host parity.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1909. Part of sprint-62 standalone catch-up (rank 5 by gap
+impact).

--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -1,0 +1,42 @@
+---
+id: 2162
+title: "Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: collections
+goal: standalone-mode
+parent: 1103
+---
+
+# Standalone Map/Set/Weak collections conformance residual
+
+## Problem
+
+Wasm-native Map/Set/WeakMap collections landed in #1103 (`done`, sprint 58).
+The host-vs-standalone baseline diff (sha `31fa7e099`, 2026-06-15) shows
+**532 tests pass in host mode but fail standalone**, attributed to the
+collection types — currently **untracked/unscheduled**.
+
+## Evidence
+
+- Gap categories: `built-ins/Set` 286, `built-ins/Map` 148,
+  `built-ins/WeakMap` 101, plus WeakSet/WeakRef/FinalizationRegistry tails.
+- `Set_new` and related host-import leaks plus `(none)`-leak compile errors.
+
+## Acceptance criteria
+
+- Standalone pass count for Map/Set/WeakMap/WeakSet rises toward host parity.
+- No collection host-import leak (e.g. `Set_new`) for the covered cases.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1103. Part of sprint-62 standalone catch-up (rank 7 by gap
+impact).

--- a/plan/issues/2163-standalone-symbol-residual.md
+++ b/plan/issues/2163-standalone-symbol-residual.md
@@ -1,0 +1,42 @@
+---
+id: 2163
+title: "Standalone Symbol conformance residual (~240 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: symbol
+goal: standalone-mode
+parent: 483
+---
+
+# Standalone Symbol conformance residual
+
+## Problem
+
+Symbol constructor / `typeof symbol` and `toNumeric` Symbol TypeError landed
+in #483, #1564 (`done`). The host-vs-standalone baseline diff (sha
+`31fa7e099`, 2026-06-15) shows **240 tests pass in host mode but fail
+standalone**, attributed to Symbol semantics — currently **untracked**.
+
+## Evidence
+
+- `__symbol_register_desc` (368) and `__box_symbol` (325) host-import leaks
+  in the gap; well-known symbols, registry (`Symbol.for`/`keyFor`), and
+  argument validation.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/Symbol` rises toward host parity.
+- No `__symbol_*` / `__box_symbol` host-import leak for the covered cases.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #483. Part of sprint-62 standalone catch-up (rank 9 by gap
+impact).

--- a/plan/issues/2164-standalone-date-residual.md
+++ b/plan/issues/2164-standalone-date-residual.md
@@ -1,0 +1,40 @@
+---
+id: 2164
+title: "Standalone Date conformance residual (~234 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: date
+goal: standalone-mode
+parent: 1343
+---
+
+# Standalone Date conformance residual
+
+## Problem
+
+Date prototype formatters landed in #1343 (`done`, sprint 50). The
+host-vs-standalone baseline diff (sha `31fa7e099`, 2026-06-15) shows **234
+tests pass in host mode but fail standalone**, attributed to Date semantics
+— currently **untracked**.
+
+## Evidence
+
+- Gap category: `built-ins/Date` 235; `(none)`-leak compile errors (219)
+  dominate — standalone codegen gaps in Date construction/formatting/coercion.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/Date` rises toward host parity.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1343. Part of sprint-62 standalone catch-up (rank 10 by gap
+impact).

--- a/plan/issues/2165-standalone-promise-async-residual.md
+++ b/plan/issues/2165-standalone-promise-async-residual.md
@@ -1,0 +1,45 @@
+---
+id: 2165
+title: "Standalone Promise/async conformance residual (~223 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: promise-async
+goal: standalone-mode
+parent: 1116
+depends_on: [1326]
+---
+
+# Standalone Promise/async conformance residual
+
+## Problem
+
+Promise resolution and async error handling landed in #1116 (`done`, sprint
+55); the standalone microtask scheduler #1326 is `in-review` and Promise
+subclass capability #1694 is in `backlog`. The host-vs-standalone baseline
+diff (sha `31fa7e099`, 2026-06-15) shows **223 tests pass in host mode but
+fail standalone**, attributed to Promise/async semantics.
+
+## Evidence
+
+- Gap category: `built-ins/Promise` 180 plus async language tests;
+  `Promise_resolve`/`Promise_reject`/`Promise_then`/`__create_async_generator`/
+  `__make_callback` host-import leaks.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/Promise` + async language tests rises
+  toward host parity.
+- No `Promise_*` / `__make_callback` host-import leak for the covered cases.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1116. Depends on the standalone microtask scheduler (#1326)
+landing. Part of sprint-62 standalone catch-up (rank 11 by gap impact).

--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -1,0 +1,40 @@
+---
+id: 2166
+title: "Standalone JSON conformance residual (~76 tests)"
+status: ready
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: json
+goal: standalone-mode
+parent: 1599
+---
+
+# Standalone JSON conformance residual
+
+## Problem
+
+The standalone JSON parser/stringifier landed in #1599 (`done`, sprint 58).
+The host-vs-standalone baseline diff (sha `31fa7e099`, 2026-06-15) shows
+**76 tests pass in host mode but fail standalone**, attributed to JSON
+parse/stringify residuals — currently **untracked**.
+
+## Evidence
+
+- Gap category: `built-ins/JSON` 76; mix of runtime `fail` (reviver/replacer
+  behavior, number formatting) and a few compile errors.
+
+## Acceptance criteria
+
+- Standalone pass count for `built-ins/JSON` rises toward host parity.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1599. Part of sprint-62 standalone catch-up (rank 12 by gap
+impact). Likely benefits from the coercion engine (#1917) number/string path.

--- a/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
+++ b/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
@@ -1,0 +1,62 @@
+---
+id: 2167
+title: "Fable model disabled — frontier-reasoning work blocked"
+status: in-progress
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: external
+reasoning_effort: low
+task_type: infra
+area: process
+goal: process
+---
+
+# Fable model disabled — frontier-reasoning work blocked
+
+## Problem
+
+**As of 2026-06-15 the Fable model is no longer available.** Sprint 62 was
+originally planned as the "last Fable sprint," front-loading frontier-grade
+reasoning work (architecture specs, value-representation migrations, identity
+doctrines, keystone silent-wrong-answer mechanisms). With Fable gone, that
+plan is void (see `plan/issues/sprints/62.md`, rescheduled to standalone
+catch-up).
+
+Most former `model: fable` issues fall back to **Opus** cleanly and proceed.
+But a subset is flagged `reasoning_effort: max` + `feasibility: hard` —
+representation migrations and cross-cutting identity/effect/ABI work where a
+wrong call is silently wrong-code and hard to detect. For these, **Opus is
+judged to have no realistic chance of doing the work properly**, so they are
+**blocked on this issue** rather than dispatched and botched.
+
+## Blocked issues (depend on this)
+
+`reasoning_effort: max`, Fable-only — kept `model: fable`, `status: blocked`,
+`blocked_by: 2167`:
+
+- #1916 — symbolic function references in WasmGC codegen (identity migration)
+- #1930 — TypeOracle single type-query boundary
+- #1985 — stale-proof index cells (shift-walker `{idx}` handles)
+- #2044 — BigInt i64-brand ValType architect decision
+- #2134 — IR effect model (classify/enforce ordered emission)
+- #2135 — single IR capability predicate (selector ⇄ builder)
+- #2138 — IR-first compile-once inversion
+- #2140 — stack-balance fixBranchType coerce-or-throw keystone
+- #2141 — retire tag-5 box-the-externref ABI
+- #2039 — standalone invalid-Wasm residual bucket
+
+Issues judged **Opus-doable** and intentionally NOT blocked: #1712, #1917
+(coercion engine — the sprint-62 catch-up engine lane), #2029.
+
+## Resolution
+
+Close (`done`) when Fable access is restored; at that point the dependent
+issues unblock (`blocked_by` cleared, `status` → `ready`) and route back to
+`model: fable` dispatch. Until then they stay parked — no Opus attempt.
+
+## Notes
+
+Recorded by stakeholder direction 2026-06-15. Process/tracking issue, not a
+code change.

--- a/plan/issues/sprints/62.md
+++ b/plan/issues/sprints/62.md
@@ -3,206 +3,135 @@ sprint: 62
 status: active
 ---
 
-# Sprint 62 — "Fable architecture sprint": clean, maintainable, trustworthy, consistent
+# Sprint 62 — Standalone conformance catch-up
 
-> Planned 2026-06-12. **This is (probably) the last sprint with access to the
-> Fable model.** That constraint reorders everything: work that needs
-> frontier-grade reasoning — architecture specs, representation migrations,
-> measured-rollout judgment calls — is pulled INTO this sprint; routine
-> point-fixes and mechanism scripts are pushed OUT to sprint 63, where
-> default-model devs handle them fine.
+> **Rescheduled 2026-06-15.** The original "Fable architecture sprint" premise
+> is void: **Fable is no longer available — all `model: fable` work falls back
+> to Opus.** With the model deadline gone, the organizing principle changes
+> from "do all frontier-reasoning architecture/specs now" to **closing the
+> standalone-mode test262 gap**, the goal that actually moves the headline.
 >
-> Inputs: the 2026-06 analysis program (`plan/log/analysis-2026-06/00–08`),
-> its sprint proposal (07), and five fresh deep-analysis reports run against
-> main @ 682e22d76 on 2026-06-12 (pipeline, WasmGC codegen/coercion, IR,
-> value representation, backend symmetry/quality). Where this document
-> conflicts with `07-sprint-62-63-64-proposal.md`, **this document wins** —
-> 07 assumed normal sprint cadence; the Fable deadline changes the
-> sequencing, not the program. The program's content (value-rep phases,
-> coercion engine steps, fail-loud phases) is unchanged; what moves is
-> *which sprint* each piece lands in and *who* (which model) does it.
+> Pure-architecture, IR-adoption, pipeline-unification, linear-backend, and
+> trust-infra work that does **not** directly raise the standalone pass count
+> this sprint has moved to **sprint 63** (see "Moved to sprint 63" below). The
+> coercion-engine and value-representation work **stays** — it is the engine
+> that closes the largest slice of the gap.
 
-## Goal
+## The gap this sprint closes
 
-One sprint that makes the compiler architecture **clean** (one pipeline
-driver, one coercion engine, one capability predicate), **maintainable**
-(structured channels instead of string-matching, tables instead of clone
-sites), **trustworthy** (every backend gated in CI, verifier rules that
-catch wrong-code before merge, measured rollouts), and **consistent** (one
-value representation doctrine with named owners per site).
+Host-vs-standalone test262 baseline diff (`loopdive/js2wasm-baselines`, sha
+`31fa7e099`, generated 2026-06-15):
 
-## Model routing (REQUIRED reading for the dispatching lead)
+| | tests |
+|---|---|
+| JS-host mode pass | 31,271 (72.5%) |
+| Standalone pass | 19,953 (46.3%) |
+| **Pass in host but NOT standalone (catch-up gap)** | **11,960** |
 
-- Issues with `model: fable` in frontmatter (and every architect spec in
-  this sprint) MUST be dispatched to `senior-developer`/`architect` agents
-  spawned with **`model: "fable"`** explicitly — agent-def defaults are
-  Opus and will silently downgrade the work.
-- Issues marked *routine* below run on default dev agents; do NOT burn
-  Fable capacity on them.
-- When the queue forces a choice, a Fable-marked issue ALWAYS outranks a
-  routine one — unfinished routine work moves to 63 for free; unfinished
-  Fable work loses its model.
+The audit attributes the gap to ~13 features. The catch-up debt was previously
+**invisible**: nearly every feature issue was closed `done` when its *first*
+implementation landed, not when standalone *conformance* was reached. Issues
+**#2157–#2166** (new, 2026-06-15) re-open that debt as sized, trackable work.
 
-## Stakeholder decisions (recorded 2026-06-12)
+## Model routing
 
-- **Flat test262 headline accepted for this sprint.** Sprint 62 produces
-  specs, engines, verifiers, and CI gates; the conformance payoff arrives
-  in 63 when routine devs mass-close symptom bugs as engine rows. No
-  visible-wins lane is required.
-- **Sprint 62 starts immediately**; sprint 61's in-flight PRs drain
-  through the merge queue concurrently.
-- **Fable capacity**: specs-before-impls when capacity is tight —
-  implementations consciously slip to 63 on default models rather than
-  displacing spec work.
-- Parked product fronts (#639, #743, npm front #1791–#1795, #1132 npm
-  publish, perf #1946–#1949) **stay parked** through 62–63.
+- **Fable is unavailable** (tracked in **#2167**). Every issue formerly
+  marked `model: fable` and every architect spec runs on **Opus**
+  (`senior-developer` / `architect` agent defaults). #1917 frontmatter
+  updated `model: opus`.
+- **Exception — frontier-only work is blocked, not downgraded.** Ten
+  `reasoning_effort: max` issues where Opus has no realistic chance of doing
+  it properly (representation/identity/effect/ABI migrations) keep
+  `model: fable`, are set `status: blocked` with `blocked_by: [2167]`, and
+  stay parked until Fable returns: #1916 #1930 #1985 #2044 #2134 #2135 #2138
+  #2140 #2141 #2039. All are sprint-64/backlog — they do not gate sprint 62.
+- `reasoning_effort: high` / `feasibility: hard` issues route to
+  `senior-developer`; routine point-fixes to `developer`.
+- The sprint is ordered by **gap impact** (test count), not by tier.
 
-## Tier 0 — day 1 (trust repairs + gates; mostly routine)
+## Lane A — coercion engine + value representation (cross-cutting, highest leverage)
 
-| Item | What | Lane |
-|---|---|---|
-| PR sweep | Merge/enqueue in-flight plan + fix PRs that define frozen regions: #1393 (#2051 spec), #1392 (PO triage), #1394 (presence-predicate), #1417 (plan sync), #1405 (#1982 IR emission fix — green, just enqueue), #1340/#1399/#1361 | lead/PO |
-| #1979 #1980 #1981 | IR wrong-code fixes (verified repros, unclaimed). The IR cannot be "trustworthy" with these open | dev |
-| #2139 | linear-backend tests into CI — **P0**, gates permanence of in-flight linear PRs #1409/#1412/#1414/#1415 | dev (routine) |
-| #1921 | structured compile-failure gate (replaces `"Codegen error:"` string-prefix) — every later consolidation fails loud | dev (routine) |
-| #2142 | undefined-rep ownership reconcile (#2051-spec vs #2106) — BEFORE dispatching either | architect (doc) |
-| #1923 | meter IR post-claim demotions — observability before the IR wave changes anything | dev (routine) |
-| #2148 | status-orphan reconciliation: smoke-test the 60 PR-less `in-review` issues + 17 reset dead `in-progress`; resolve #680's true state first (gates #735/#762/#1687/#1691/#2040) | PO |
-
-## Tier 1 — senior/Fable keystone lane
+This lane closes the **~3,460 "unattributed" residual** (runtime `fail` +
+object-model compile errors with no host-import leak) **plus** the 576-test
+boxing bucket and much of String/Number coercion — together the single
+biggest slice of the gap. Sequencing: A1 spec → #1917 Step 0 → Steps 1–3 →
+value-rep P0 → P1 → P2/P3 → P4.
 
 | Item | What | Notes |
 |---|---|---|
-| #2072 + #2080 | **Type-aware AnyValue boxing (value-rep P0)** — the program's first mover; freezes `type-coercion.ts:1178-1228`, `native-strings.ts:5417-5586`, `any-helpers.ts:384-443` | `model: fable`, senior. Everything in coercion steps + value-rep P1+ rebases on its API |
-| #2009 | Resume suspended `issue-2009-shape-id` worktree ($shape PR-1) | senior; unblocks #1989 eqref half |
-| #1965 | Base-ctor body execution (`super(args)` stops being a positional field copy) | senior, max; feeds #2101 class-model spec |
-| #2051 | Optional-chain undefined representation per the PR-#1393 spec | senior, max |
-| #2079 | Standalone generators funcindex CE | senior; feeds the A2 identity spec with fresh index-shift reality |
-| #2140 | fixBranchType coerce-or-throw (#1858-C1 split) — the keystone silent-wrong-answer mechanism | `model: fable`; AFTER #1917 Step 0 lands |
-| #2090 | stack-balance `:812` null-patch → hard error | easy; rides the #2140 lane |
-| #1918 | stack-balance strict-mode fixup ratchet — same machinery as #2090/#2140, makes the fixup count a one-way gate | dev; rides the #2140 lane |
-| #2045 | linear-uint8 soundness holes (critical) — pairs with the #2139/#1854 linear trust lane | senior, `model: fable` |
-| #2044 | BigInt i64-brand ValType **decision** — the architect call gating #1349/#1644; decisions are what the Fable deadline makes urgent | architect, `model: fable` |
+| #1917 | Single coercion engine: `coercionPlan` table → `emitToString`/`emitToPrimitive`/`emitStrictEq`/`emitLooseEq` | `model: opus`, senior. Symptom issues #1988 #1990 #2022 #2059 #2081 #2015 #2085 close as engine rows |
+| #2072 #2080 | Value-rep P0: type-aware AnyValue boxing | senior; everything below rebases on its API |
+| #2104 | Value-rep P1: canonical JsTag module | dev, after P0 |
+| #2105 #2106 | P2 boolean brand, P3 undefined observability | parallel after P1; #2106 amended by #2142 |
+| #2107 | P4 standalone helper conformance | high |
+| #2051 #2059 | Optional-chain undefined rep; any-relational string compare | senior/dev |
+| #2130 #1991 | Presence predicate (`in`/`delete` vs static struct shape) | dev |
+| #1989 #2009 #1997 #1998 #1988 | valueOf dispatch; $shape collision; array-toString; join-externref; any-add | dev |
+| #2151 | Standalone any-receiver method dispatch | in-progress |
+| #2092 | Spec-conformance probe suite (guards every engine step) | dev |
+| #2142 | undefined-rep ownership reconcile (BEFORE #2051/#2106 dispatch) | architect doc |
 
-## Tier 1 — coercion engine + value representation (pulled forward from 63)
+## Lane B — feature residual buckets (ordered by gap impact)
 
-Sequencing: A1 amendment → Step 0 → (S2 merges) → Steps 1–3 → P1–P3.
+Each issue is a newly-sized standalone conformance residual against a
+closed parent feature.
 
-| Item | What | Notes |
+| Rank | Gap | Issue | Feature | Priority |
+|---|---:|---|---|---|
+| 1 | 2,172 | **#2157** (+#2079, #2038) | Iterator / generators | critical |
+| 2 | 1,388 | **#2158** (+#1965, spec #2101) | Class / prototype / private / descriptor | high |
+| 3 | 1,308 | **#2159** | TypedArray / DataView / ArrayBuffer | high |
+| 4 | 635 | **#2160** | String / Number methods & coercion | high |
+| 5 | 579 | **#2161** | RegExp standalone engine | high |
+| 6 | 532 | **#2162** | Map / Set / Weak collections | high |
+| 7 | 240 | **#2163** | Symbol | medium |
+| 8 | 234 | **#2164** | Date | medium |
+| 9 | 223 | **#2165** (dep #1326) | Promise / async | medium |
+| 10 | 76 | **#2166** | JSON | low |
+
+(Boxing 576 and dynamic-object/Reflect 496 are covered by Lane A —
+#2072/#2104–2107 and #2130/#1991 respectively.)
+
+## Lane C — enabling fixes & specs (unblock Lanes A/B)
+
+| Item | What | Feeds |
 |---|---|---|
-| A1 spec | #1917 amendment: `(fromWasmType, toWasmType, staticJsType?)` signature + thin TypeOracle slice definition (#1930 first increment) | architect, `model: fable` |
-| #1917 Step 0 | `coercionPlan` ValType table unifying `coercionInstrs`/`callArgCoercionInstrs`/`fixBranchType` + `guardedRefCast` dedup | dev; dependency-safe NOW; kills the verified lossy `drop; f64.const 0` divergence |
-| #1917 Steps 1–3 | `coercion-engine.ts`: `emitToString` → `emitToPrimitive` → `emitStrictEq`/`emitLooseEq` | `model: fable` devs; gated on S2 + PRs #1340/#1399 landing. Symptom issues #1988 #1990 #2022 #2059 #2081 #2015 #2085 close as engine rows with their repros as the test gate |
-| #1930 | Thin TypeOracle slice impl (one ctx field, 3–4 queries) | dev, after A1 |
-| #2104 | Value-rep P1: canonical JsTag module | dev; MUST follow S2 (consolidates its hint plumbing) |
-| #2105 #2106 | P2 boolean brand, P3 undefined observability (as amended by #2142) | dev, parallel after P1; P3's union-collapse flag needs senior review |
-| #2107 | P4 standalone helper conformance | stretch → 63 if capacity runs out |
-| #2141 | Tag-5 ABI untangle: characterization + consumer-migration spec | architect, `model: fable`; impl is 63's keystone — the spec is what needs Fable |
-| #1989 | valueOf per-instance dispatch: typed-ref half now; eqref half after #2009 merges | dev |
-| #2092 | Spec-conformance probe suite (T-tables) — the guardrail for everything above | dev (routine but scheduled HERE: it guards S2 and every engine step) |
-| #1991 + #2130 | Joint presence-predicate work (`in`/`delete` vs runtime presence) — spec complete via PRs #1392/#1394; Stage A→B (#2130) then C (#1991) | dev (routine) |
-| #2089 | Fallback-telemetry ratchet phase 0 (counts only) | dev (routine) |
+| #2079 | Standalone generators funcindex CE (~960 tests) — highest single ROI, pure compiler bug | #2157 |
+| #1899 | Scoped finalize-authority pass (funcidx identity) | #2079, #2157 generator family |
+| #1965 | Base-constructor body execution (`super(args)`) | #2158 |
+| #1983 | class-method funcMap name collision | #2158 |
+| #2101 | Class object-model spec — now feeds **this sprint's** #2158 impl (was 63/64) | #2158 |
+| #2100 | Deep-marshaling contract spec | host-import retirement |
+| #2089 | Fallback-telemetry ratchet (standalone observability) | gap tracking |
+| #2148 #2149 #2154 #2152 #1978 | status reconciliation, CI/baseline fixes, WASI user-main regression | housekeeping/trust |
 
-## Tier 1 — IR workstream
+## Moved to sprint 63 (pure architecture / linear / IR-adoption / trust-infra)
 
-Sequencing: #1923 → #1922 → #1924/#2134 → #1804 → ratchet flips → stretch.
+Rescheduled out of 62 on 2026-06-15 because they don't directly raise the
+standalone pass count this sprint:
 
-| Item | What | Notes |
-|---|---|---|
-| #1922 | Shared IR traversal + while-loop DCE defect | dev; unblocks the most common loop shape |
-| #1924 | Verifier instruction type rules (fold #1857's attributes/operands checklist into the rule table) — would have caught #1980/#1982 | `model: fable` |
-| #2134 | IR effect model (pure/read/write/control table; ordered emission for effectful ops) | `model: fable`; plugs into #1924's framework |
-| #1804 | `vec.new_fixed` array literals — highest single adoption lever: retires ~21 of 31 `body-shape-rejected` + most `call-graph-closure` | dev (impl plan exists) |
-| Ratchet flips | After #1804: zero `param-type-not-resolvable`, then `call-graph-closure` → add to `STRICT_IR_REASONS` (first-ever use of the #1530 ratchet hook) | dev, with lead sign-off |
-| #2135 | Single capability predicate (select.ts/from-ast.ts) — spec this sprint, staged impl | architect `model: fable`, then dev |
-| #2136 | Loop-cond ToBoolean through IR (claims `while (k)` instead of demoting) | dev (routine), after #1980 |
-| #2137 | IrPathReport structured channel | dev (routine) |
-| class-method residual | Adopt get/set accessors or formally reclassify to deferred (zeroes the bucket honestly) | dev, small |
-| #1925 | Hygiene passes descend nested buffers (Option A), spec then impl | stretch; `model: fable` spec |
-| #1926 | Remove ValType/typeIdx from IrType (byte-identity method, behind the verifier net) | stretch → 63 if tight |
-| #1936 | Async contract census/spec ONLY (#1373b stays blocked on #1326c) | architect; do not dispatch impl |
+- **Pipeline / identity**: #1927 (single driver), #1921 (compile-failure
+  gate), #1931 (early-errors decomposition), #1984 (index-space freeze).
+- **IR workstream**: #1922 #1924 #1925 #1926 #1804 #1923 #2136 #2137.
+- **Linear backend** (orthogonal axis, not standalone WasmGC): #2139 #2045
+  #1938 #1975 #1976 #1854.
+- **Trust / backend infra**: #1853 #2143 #1950 #1855 #1918 #2090 #2084.
+- **Cleanup**: #1095 (instr-cast ratchet), #1919 (speculative compile).
 
-## Tier 1 — pipeline workstream
-
-| Item | What | Notes |
-|---|---|---|
-| A2 spec | **One identity doctrine**: #1916 amendment (collision-free declaration-site FuncIds, names = debug metadata) + #1899's finalize-helper by-name authority pass ratified as #1916 phase 0 | architect, `model: fable` — prevents two specs answering the same question divergently |
-| #1899 | Scoped finalize-authority pass impl per A2 | senior; unblocks the funcidx bug class (#1983, #2079's family) |
-| #1984 #1985 | Index-space freeze point + stale-proof `{idx}` cells — incremental identity hardening the 07-proposal wanted "before the #1916 train" | dev, after A2 |
-| #1983 | class-method funcMap name collision — falls out of A2/#1899; verify + close with regression test | dev |
-| #1927 | **Single pipeline driver** — collapse the 4 driver clones (3 in compiler.ts + generateMultiModule); amended AC: multi-module paths get IR/early-errors/hardened parity, 14× `failResult` copies deduped | `model: fable`, M/L — the structural keystone of the sprint |
-| #1931 step 1 | Wire `detectEarlyErrors` into both multi paths (~10 lines + tests) — closes a silent conformance hole NOW; decomposition rides on #1927 | dev (routine) |
-| #1919 | Transactional speculative compile (26 unguarded `fctx.body.length =` truncation sites; adopt `snapshotLocals` beyond loops.ts) | senior; parallel lane, BEFORE #1916 impl |
-| #1916 phase 1 | `FuncHandle` + binary-encode-time resolution + `number\|FuncHandle` ratchet | **stretch**; only if Fable capacity remains after the above — otherwise 63 inherits the A2 spec |
-| #2138 | IR-first compile-once inversion (flag-gated investigation + measured run) | `model: fable`, sprint tail; findings shape 63/64 sequencing |
-| #1095 | Instr-cast ratchet (re-scoped: `scripts/check-instr-casts.mjs` + baseline in `quality`; count is 175, was 273) | dev (routine); full union extension → 63 |
-
-## Tier 1 — trust & backend symmetry
-
-| Item | What | Notes |
-|---|---|---|
-| #1854 | Cross-backend differential lane: `DIFF_TEST_TARGET=linear` against the V8 oracle, per-lane baseline (most corpus programs won't compile on linear yet — baseline the gap, gate the delta) | short architect note, then dev |
-| #1853 + #2143 | Hard-error stability bucket + `WebAssembly.validate` on unoptimized output (the 2 known invalid corpus programs become bucketed hard errors) | dev (routine) |
-| #1950 | Default-on optimize pipeline (unblocked: #1941 done) | dev; PO decides surface in-PR |
-| #1855 | UB-free TS fuzzer — **architect spec only** (generator soundness is the Fable-worthy part); impl 63 | architect, `model: fable` |
-| #2100 #2101 | Arch specs: deep-marshaling contract; class object-model (consumes #1965's findings) | architect, `model: fable`; consumed by 63/64 |
-
-## Explicitly NOT in sprint 62 (and where it went)
-
-- **Routine point-fix wave** → sprint 63: #1994 #2001 #2007 #2008 #2011
-  #2012 #2013 #2017 #2021 #2023 #2024 #2025 #2026 #2028 #2033 #2035 #2076
-  #2077 #2083 #2118 #2119 (moved from 61), plus #2086 #2087 #2088 #2093
-  #2094 #2095 #2096 #2097 #2098 #2099 #2102 #2103 #2108 #2144 #2145 #2146
-  #2147 (from backlog/new). Note: #2086/#2087 are senior-grade — pull
-  forward ONLY if the Fable senior lane drains early.
-- **In-flight PR issues stay in 61** and land via the queue: #1960 #1961
-  #1962 #1963 #1964 #1969 #1970 #1972 #1973 #1974 #1975 #1976 #1977 #1978
-  #1982 #1986 #1987 #1997 #1998 #2031 #2032 #2058 #2064 #2068 #2120 #2122
-  #2125 (+#1971 closes via PO PR #1392).
-- **Duplicates closed**: #2110–#2117 ≡ #2118–#2125 (high series canonical —
-  merged/open PRs reference it).
-- **Stale-ready flipped to done**: #1991 #2002 #2003 #2004 #2005 #2006
-  #2018 #2019 #2020 #2027 #2078 (fix PRs merged; see #2147 for the
-  structural fix).
-- **#1624** closed as superseded by #2104–#2107 + #2141.
-- **#1934** (runtime resolveImport decomposition), #1848 (dead-code sweep,
-  now including the `codegen-linear/simd.ts` wire-or-delete decision),
-  #1860 (backend naming — resolve as `src/codegen/{gc,linear}/`, AFTER
-  linear PRs land), #1859 (READMEs, after #1860) → 63, all routine.
-- **#1947 #1166 #1741** — valid, orthogonal, not this sprint.
-- **Oracle default flip, #2108 drift gate, #1373b** — 63 (need soak /
-  sealed vocabulary / #1326c respectively).
-
-## Dependency spine
-
-```
-A1 spec ──► #1917 Step0 ──► Steps 1–3 ──► symptom closures (#1988 #1990 #2022 #2059 #2081 #2015 #2085)
-#2072/#2080 (S2/P0) ──► #2104 P1 ──► #2105/#2106 (P2/P3) ──► #2107 (P4, stretch)
-#2142 reconcile ──► #2051 dispatch ∥ #2106 dispatch
-#2009 ($shape) ──► #1989 eqref half
-A2 spec (#1916+#1899) ──► #1899 impl ──► #1983 close ──► [stretch] #1916 phase 1 ──► 63: #2146
-#1923 ──► #1922 ──► #1924 + #2134 ──► #1804 ──► STRICT ratchet flips ──► [stretch] #1925/#1926
-#1921 ──► #1927 (driver) ──► 63: #1931 decomposition
-#1917 Step0 ──► #2140 (fixBranchType C1)
-#2139 (linear CI) ──► #1854 (linear diff lane) ──► 63: #2144 (fmod parity)
-#2141 spec ──► 63: tag-5 ABI impl ──► host-import retirement endgame
-```
+Plus the routine point-fix wave already slated for 63 (unchanged from the
+prior plan): #1994 #2001 #2007 #2008 #2011 #2012 #2013 #2017 #2021 #2023–#2028
+#2033 #2035 #2076 #2077 #2083 #2086–#2103 #2108 #2118 #2119 #2144–#2147.
 
 ## Exit criteria
 
-1. Value-rep P0 (#2072/#2080) merged with T-string/T-typeof probes green in
-   both lanes; P1 merged; P2/P3 merged or in review.
-2. Coercion engine exists (`coercion-engine.ts`) with Steps 0–3 landed and
-   ≥5 symptom issues closed as engine rows.
-3. IR: zero verified wrong-code bugs open; verifier has instruction-level
-   type rules + effect table; `vec.new_fixed` landed; ≥1 STRICT_IR_REASONS
-   entry promoted (first ratchet flip ever).
-4. Pipeline: one driver (#1927) merged; identity doctrine ratified (A2) and
-   the #1899 pass landed.
-5. Trust: linear tests + linear differential lane + unoptimized-validate
-   in CI; a deliberately-broken linear lowering fails PR CI.
-6. Every Fable-marked spec (A1, A2, #2141, #1855, #2100, #2101, #2135)
-   written and committed — specs survive the model deadline even where
-   impls slip to 63.
-7. Sprint 63 queue is dispatch-ready: routine point-fix wave + mechanisms,
-   no Fable dependencies.
+1. **Lane A**: coercion engine (`coercion-engine.ts`) Steps 0–3 landed, ≥5
+   symptom issues closed as engine rows; value-rep P0 + P1 merged, P2/P3
+   merged or in review.
+2. **Lane B**: #2079 merged (the ~960-test funcindex ROI); standalone pass
+   count rises by **≥2,500** toward host parity; each of #2157–#2166 either
+   merged or carrying a concrete dispatched plan with repros as test gates.
+3. **Lane C**: #1899 + #1965 landed; #2101 spec written and #2158 impl
+   dispatched against it.
+4. Standalone headline tracked in `test262-standalone-current.json` shows a
+   measurable rise from the 46.3% baseline; sprint 63 inherits the moved
+   architecture work dispatch-ready.


### PR DESCRIPTION
## Summary

Fable is no longer available (2026-06-15) — fall back to Opus. This reschedules **sprint 62** from the (now void) "last Fable sprint" into a **standalone test262 catch-up** sprint, ordered by host-vs-standalone gap impact, and records the Fable disablement as a tracked blocker.

Derived from a host-vs-standalone baseline diff (`loopdive/js2wasm-baselines`, sha `31fa7e099`, 2026-06-15): standalone 19,953 vs host 31,271 → **11,960-test catch-up gap**.

## Changes (plan-only, 52 files)

- **New #2157–#2166** — sized standalone conformance residuals for closed-but-failing buckets: iterator/gen 2,172 · class/descriptor 1,388 · TypedArray 1,308 · String/Number 635 · RegExp 579 · Map/Set 532 · Symbol 240 · Date 234 · Promise 223 · JSON 76.
- **New #2167** — Fable disabled. Blocks the 10 `reasoning_effort: max` frontier issues Opus cannot do properly (#1916 #1930 #1985 #2044 #2134 #2135 #2138 #2140 #2141 #2039): kept `model: fable`, `status: blocked`, `blocked_by: [2167]` (all sprint-64/backlog, do not gate s62).
- **Moved 27** orthogonal architecture/IR/linear/trust-infra issues to **sprint 63**.
- Flipped remaining non-done `model: fable` → `opus`.
- Rewrote `plan/issues/sprints/62.md`.

No code changes — issue frontmatter + sprint doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)