### PR TITLE
docs(#2142): reconcile undefined-rep ownership (externref widening vs sNaN sentinel)

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -4,7 +4,7 @@ title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-coll
 status: ready
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-15
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -46,6 +46,53 @@ Erasure stays for pure ToNumber/ToBoolean sinks (proven sound).
 - `codePointAt(oob) ?? -1`, `=== undefined`, typeof, and stringification
   observe undefined in both modes; null vs undefined distinct standalone
 - Flag-gated collapse reversal lands with perf/size measurements
+
+## Ownership reconcile (#2142, 2026-06-15) — READ BEFORE DISPATCH
+
+#2142 reconciled the two-document conflict (this issue's `UNDEF_F64` sentinel
+vs #2051's externref widening). Authoritative decision in
+[`2142-undefined-rep-owner-reconcile.md`](2142-undefined-rep-owner-reconcile.md#decision-authoritative--2026-06-15-arch1).
+Net effect on this issue's scope:
+
+**Decision rule:** widen to **externref + host `undefined`** when the value
+must be observable to `===`/`!==`/`typeof`/ToString/`??`; use the **sNaN
+sentinel** only inside hot f64 carriers whose sole consumer is
+`emitDefaultValueCheck` (destructuring/default-parameter reads, array/tuple
+holes).
+
+**Producer list — #2051's sites are REMOVED from this issue.** The
+optional-chain short-circuit sites (`a?.b` / `a?.[i]` / `a?.m()`) are owned by
+**#2051** (externref widening, per its own `## Implementation Plan`). Do **not**
+apply the `UNDEF_F64` sentinel to optional-chain sites — that channel cannot
+reach `===`/`typeof`/ToString (verified: `=== undefined` on an f64 is
+unconditionally `false`, `binary-ops.ts:479-482`; the sNaN sentinel is observed
+*only* by `emitDefaultValueCheck`, `shared.ts:418`).
+
+**This issue's remaining scope after the reconcile is three disjoint pieces:**
+
+1. **General `number|undefined` observability → externref.** For
+   `number|undefined` carriers consumed by `===`/`!==`/`typeof`/ToString/`??`
+   (NOT optional-chain — those are #2051), widen to externref + host
+   `undefined`, composing with the #2072/#2104 value-rep boxing. This is the
+   same mechanism #2051 uses, applied to the non-optional-chain producers.
+2. **Codify the sNaN sentinel carve-out (erasure stays).** The existing
+   `0x7FF00000DEADC0DE` sentinel for default-check / hole carriers
+   (`type-coercion.ts:2672`, `emitDefaultValueCheck`) is **kept** — erasure is
+   proven sound for pure ToNumber/ToBoolean and default-initializer sinks. Do
+   not widen these to externref (hot path, zero observability gain).
+3. **Standalone `$undefined` singleton.** Add the standalone tag-1 `$undefined`
+   global so `undefined` is distinct from `null` in standalone mode
+   (`late-imports.ts:553-571` currently falls both back to `ref.null extern`).
+   This is orthogonal to the host-vs-sentinel choice and aligns with #2104's
+   JsTag module.
+
+**Do NOT re-claim `codePointAt(oob) ?? rhs`** — already shipped via the
+`??`-site NaN special-case (`logical-ops.ts:208-216`, `isCodePointAtCall`);
+#2004 is `done`. Neither this issue nor #2051 touches it.
+
+The flag-gated union-collapse reversal (index.ts:9108-9117 /
+type-mapper.ts:79-99) stays in this issue's scope and lands with the
+perf/size blast-radius measurement as the acceptance criteria require.
 
 ## Dupe check
 

--- a/plan/issues/2142-undefined-rep-owner-reconcile.md
+++ b/plan/issues/2142-undefined-rep-owner-reconcile.md
@@ -42,3 +42,97 @@ consumers and needs zero observer changes).
 ## Notes
 
 Doc-only, S-size. Do before dispatching #2051 or #2106.
+
+---
+
+## Decision (authoritative — 2026-06-15, arch1)
+
+> Verified against `origin/main` @ `516feec44`. Code anchors below are from
+> that HEAD; re-grep the function names if they have drifted.
+
+### The actual state on main (the three mechanisms already exist)
+
+There are **three** distinct undefined-in-a-primitive-carrier mechanisms in
+the tree today, not two. The conflict #2142 names is real, but the resolution
+is grounded in which consumers each mechanism's value can actually reach:
+
+1. **externref + host `undefined`** (`emitUndefined` → `__get_undefined`).
+   Observed by `===`/`!==` (`binary-ops.ts:411-422` routes
+   `x === undefined` through `__extern_is_undefined`), by `typeof` (runtime
+   `__typeof`, `typeof-delete.ts`), by ToString (`__extern_toString`,
+   `string-ops.ts`), and by `??` (`logical-ops.ts:226-236` —
+   `ref.is_null || __extern_is_undefined`). This is **the only channel all of
+   `===`/`typeof`/ToString/`??` already discriminate.**
+2. **sNaN sentinel `0x7FF00000DEADC0DE`** (`type-coercion.ts:2672`,
+   `emitDefaultValueCheck` family). Observed by **exactly one** consumer:
+   `emitDefaultValueCheck` (`shared.ts:418`), wired into
+   destructuring/default-parameter checks (`destructuring-params.ts:830`) and
+   array/tuple hole materialization (`literals.ts:1759,2317,2886`). It is
+   **NOT** observed by `===`, `typeof`, ToString, or `??`. `=== undefined` on
+   an f64 is unconditionally `false` (`binary-ops.ts:479-482`); the f64 channel
+   cannot be told apart from a *real* `NaN`-valued property.
+3. **codePointAt `??`-site NaN special-case** (`logical-ops.ts:208-216`,
+   `isCodePointAtCall`). `codePointAt`'s result type is **still `f64`**
+   (`index.ts:6936`) and out-of-range still emits `f64.const NaN`
+   (`string-ops.ts:2635`). The *only* place this NaN is read as "undefined" is
+   a hard-coded branch in `compileNullishCoalescing` that detects an
+   `isCodePointAtCall` LHS and tests `f64.ne` (isNaN). `=== undefined` /
+   `typeof` over `codePointAt(oob)` do **not** observe undefined today.
+
+### The decision rule
+
+**Widen to externref + host `undefined` when the value must be observable to
+the general nullish/identity/stringify consumer set (`===`, `!==`, `typeof`,
+ToString, `??`). Use the sNaN sentinel ONLY inside the hot f64 carriers whose
+sole consumer is `emitDefaultValueCheck` (destructuring/default-parameter
+reads, array/tuple holes). Do not introduce a third claim on `codePointAt` —
+it already has its own `??`-site mechanism; leave it.**
+
+Why widen, not sentinel, for the general case: facts 1–2 above mean the
+sentinel value can never reach `===`/`typeof`/ToString — those consumers would
+need new per-operator sentinel-detection code at every site (and the sNaN bit
+pattern collides with a genuine `NaN` property value, which is unfixable). The
+externref channel already routes through all four consumers with zero new
+observer code. #2051's own implementation plan confirms its binding slots are
+*already* externref (`variables.ts:100-102` widens `isNullablePrimitiveType`),
+so widening removes a lie at the source rather than adding a representation.
+
+Why sentinel, not widen, for the default-check carriers: those f64 values are
+consumed *only* by `emitDefaultValueCheck` (which already compares against the
+sentinel), they are hot (destructuring/param init on every call), and widening
+them to externref would force a `__box_number` on every defaulted read for zero
+observability gain — the value is never compared with `===`/`typeof`/ToString,
+only "is this the absent sentinel? then run the default initializer."
+
+### Per-site ownership (one owner mechanism per site)
+
+| Site | Owner mechanism | Owning issue | Rationale |
+|---|---|---|---|
+| Optional-chain short-circuit (`a?.b`, `a?.[i]`, `a?.m()`) where non-nullish result is primitive | **externref + host `undefined`** | **#2051** | result feeds `===`/`typeof`/ToString/`??`; binding slot already externref |
+| `number\|undefined` carriers consumed by `===`/`!==`/`typeof`/ToString/`??` (general value-rep observability) | **externref + host `undefined`** | **#2106** (P3 observability), composing with #2072/#2104 value-rep | same consumer set; the sentinel can't reach these consumers |
+| Destructuring / default-parameter f64 reads; array/tuple holes | **sNaN sentinel** (existing) | **#2106** (P3) — codifies the existing `emitDefaultValueCheck` carve-out; **erasure stays** | sole consumer is `emitDefaultValueCheck`; hot path; no observability needed |
+| `codePointAt(oob) ?? rhs` | **codePointAt `??`-site NaN special-case** (existing, `logical-ops.ts:208`) | **neither #2051 nor #2106** — already shipped, leave as-is | already works for `??`; do not re-represent |
+| Standalone `undefined` vs `null` distinctness (`$undefined` singleton) | **standalone tag-1 `$undefined` global** | **#2106** (P3 standalone), aligned with #2104 JsTag | orthogonal to the host-vs-sentinel choice; standalone-only gap |
+
+### Amendments applied
+
+- **#2106**: producer list amended — #2051's optional-chain sites **removed**
+  (they are #2051-owned, externref-widened). #2106's remaining producer scope
+  is (a) the general `number|undefined` observability widening to externref and
+  (b) codifying the existing sNaN sentinel carve-out for default-check carriers,
+  plus (c) the standalone `$undefined` singleton. The decision rule above is
+  recorded in #2106's "Root cause"/"Fix direction".
+- **#2051**: unchanged — lands per its own `## Implementation Plan` (externref
+  widening at the three optional-chain sites). It composes with all four
+  existing consumers and needs zero observer changes.
+- **#2004** (`codePointAt ?? -1`): already `done` (PR #1329 / #1475-era). Its
+  one mechanism is the `logical-ops.ts:208` `??`-site NaN special-case. Neither
+  #2051 nor #2106 touches it.
+
+### Acceptance criteria — met
+
+- ✔ Both documents name exactly one owner mechanism per site (table above).
+- ✔ #2051's `t4`/`t6` cases → externref widening (#2051).
+- ✔ #2004's `codePointAt ?? -1` → the existing codePointAt `??`-site NaN
+  special-case (neither doc re-claims it).
+- ✔ Default-check / hole carriers → sNaN sentinel, erasure preserved (#2106).


### PR DESCRIPTION
## #2142 — undefined-representation ownership reconcile (doc-only)

Resolves the double-claim where the **#2051 spec** (externref widening + host
`undefined`) and **#2106** (`UNDEF_F64` sNaN sentinel) both prescribed a
representation for the same undefined-in-a-primitive-carrier sites. A dev
dispatched on either would have contradicted the other.

### Authoritative decision (in `2142-...md`)

Verified against `origin/main` @ `516feec44`. There are **three** distinct
mechanisms in the tree, and the decision is grounded in which consumers each
value can actually reach:

| Site | Owner mechanism | Owning issue |
|---|---|---|
| Optional-chain short-circuit (`a?.b` / `a?.[i]` / `a?.m()`), primitive result | externref + host `undefined` | **#2051** |
| `number\|undefined` carriers consumed by `===`/`!==`/`typeof`/ToString/`??` | externref + host `undefined` | **#2106** |
| Destructuring/default-param f64 reads; array/tuple holes | sNaN sentinel `0x7FF00000DEADC0DE` (existing, **erasure stays**) | **#2106** |
| `codePointAt(oob) ?? rhs` | existing `??`-site NaN special-case (`logical-ops.ts:208`) | neither (already `done`, #2004) |
| Standalone `undefined` vs `null` distinctness | tag-1 `$undefined` singleton | **#2106** |

**Decision rule:** widen to externref when the value must be observable to
`===`/`!==`/`typeof`/ToString/`??` (the only channel all four already
discriminate — the sNaN sentinel is observed *only* by `emitDefaultValueCheck`,
`shared.ts:418`; `=== undefined` on an f64 is unconditionally `false`,
`binary-ops.ts:480-483`). Use the sentinel only inside hot f64 default-check
carriers.

### Changes
- `plan/issues/2142-...md` — adds the authoritative `## Decision` section.
- `plan/issues/2106-...md` — amends the producer list (removes #2051's
  optional-chain sites), records the decision rule and post-reconcile scope.

### Acceptance criteria — met
- Both documents name exactly one owner mechanism per site.
- #2051's `t4`/`t6` and #2004's `codePointAt ?? -1` each cite exactly one mechanism.

Unblocks dispatch of #2051 and #2106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)