### PR TITLE
test(#2059): lock in standalone §7.2.13 relational runtime behavior

### DIFF
--- a/plan/issues/2059-any-relational-no-string-comparison.md
+++ b/plan/issues/2059-any-relational-no-string-comparison.md
@@ -1,10 +1,11 @@
 ---
 id: 2059
 title: "relational operators on two any/externref operands never perform string comparison (\"a\" < \"b\" → false)"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-15
+completed: 2026-06-15
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -192,3 +193,41 @@ exercises in default mode.
 - Standalone test262 shard: confirm no movement in comparator buckets (the −788
   guard from #2058 — relational gate is disjoint from equality, so the
   `isSameValue` path is untouched).
+
+---
+
+## Resolution (2026-06-15)
+
+Both the JS-host AND standalone paths of this fix already landed via **PR #1420**
+(`fix(codegen): #2059 any relational does §7.2.13 string compare, not f64`,
+merged 2026-06-12). The implementation lives in `emitAnyRelational`
+(`src/codegen/binary-ops.ts`), gated at the relational call-site by the
+`isRelational && ctx.anyValueTypeIdx < 0 && (leftIsAnyish || rightIsAnyish)`
+check. The standalone arm (`noJsHost && ctx.nativeStrings && ctx.anyStrTypeIdx
+>= 0`) builds §7.2.13 in-module: both-string → native `__str_compare` after
+`__str_flatten`; else ToNumber both via `__unbox_number` + f64 sign derivation,
+with the `2`-sentinel making all four operators yield `false` for an
+incomparable (NaN/undefined) operand. No `env::__host_compare` import leaks.
+
+Verified on `origin/main` (sha 516feec44): with native `$AnyString` values
+flowing entirely within wasm (the only standalone scenario — there is no JS host
+to inject raw JS strings), all repro cases produce the correct §7.2.13 result at
+runtime in pure-WasmGC standalone mode:
+
+| case | standalone result | expected |
+|------|-------------------|----------|
+| `"a" < "b"` | `1` | `true` (lexicographic) |
+| `"10" < "9"` | `1` | `true` (`"1" < "9"`, NOT numeric `10<9`) |
+| `"10" < 9` | `0` | `false` (mixed → numeric) |
+| `"b" > "a"` | `1` | `true` |
+| `"a" <= "a"` | `1` | `true` |
+| `"abc" >= "abd"` | `0` | `false` |
+| `1 < 2` (any) | `1` | `true` |
+
+This task closes as a **test-hardening** change only: the standalone section of
+`tests/issue-2059-any-relational.test.ts` previously asserted numeric runtime +
+string *compile-validate* only, so a regression in the in-module `__str_compare`
+dispatch would have stayed invisible (the exact "closed at first impl, not at
+standalone conformance" trap this sprint targets). Added two runtime tests that
+lock in the lexicographic/numeric §7.2.13 results for both `any`-local and
+`any`-parameter (native-string-via-caller) forms.

--- a/tests/issue-2059-any-relational.test.ts
+++ b/tests/issue-2059-any-relational.test.ts
@@ -103,4 +103,47 @@ describe("#2059 any/any relational comparisons (standalone / pure WasmGC)", () =
   it("any string < validates (no host import leak)", async () => {
     await compileStandalone(`export function f(a: any, b: any): number { return (a < b) ? 1 : 0; }`);
   });
+
+  // The in-module §7.2.13 path must produce the SAME lexicographic/numeric
+  // results at runtime as JS-host mode — not just validate. These run on native
+  // `$AnyString` values flowing entirely within wasm (no JS host strings), which
+  // is how standalone/WASI builds actually exercise the helper. Earlier the
+  // standalone section only checked numeric runtime + string compile-validate, so
+  // a regression in `__str_compare` dispatch would have stayed invisible.
+  it("any string/numeric relationals match §7.2.13 at runtime (native strings)", async () => {
+    const r = await compileStandalone(`
+      export function lt_ab(): number { const a: any = "a"; const b: any = "b"; return (a < b) ? 1 : 0; }
+      export function lt_10_9(): number { const a: any = "10"; const b: any = "9"; return (a < b) ? 1 : 0; }
+      export function lt_mixed(): number { const a: any = "10"; const b: any = 9; return (a < b) ? 1 : 0; }
+      export function gt_ba(): number { const a: any = "b"; const b: any = "a"; return (a > b) ? 1 : 0; }
+      export function le_aa(): number { const a: any = "a"; const b: any = "a"; return (a <= b) ? 1 : 0; }
+      export function ge_abc_abd(): number { const a: any = "abc"; const b: any = "abd"; return (a >= b) ? 1 : 0; }
+    `);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const exp = instance.exports as Record<string, () => number>;
+    expect(exp.lt_ab(), 'lt("a","b")').toBe(1); // lexicographic
+    expect(exp.lt_10_9(), 'lt("10","9")').toBe(1); // "1" < "9" — NOT numeric 10<9
+    expect(exp.lt_mixed(), 'lt("10",9)').toBe(0); // mixed → numeric 10<9 → false
+    expect(exp.gt_ba(), 'gt("b","a")').toBe(1);
+    expect(exp.le_aa(), 'le("a","a")').toBe(1);
+    expect(exp.ge_abc_abd(), 'ge("abc","abd")').toBe(0);
+  });
+
+  // `any` PARAMETERS (not const locals) carrying native strings must also dispatch
+  // through the in-module compare. Pass values via an exported caller so the
+  // strings stay native (host-injected JS strings are not a standalone scenario).
+  it("any-PARAMETER relationals dispatch correctly (native strings via caller)", async () => {
+    const r = await compileStandalone(`
+      function cmp_lt(a: any, b: any): number { return (a < b) ? 1 : 0; }
+      function cmp_ge(a: any, b: any): number { return (a >= b) ? 1 : 0; }
+      export function lt_ab(): number { const a: any = "a"; const b: any = "b"; return cmp_lt(a, b); }
+      export function lt_nums(): number { const a: any = 1; const b: any = 2; return cmp_lt(a, b); }
+      export function ge_abc_abd(): number { const a: any = "abc"; const b: any = "abd"; return cmp_ge(a, b); }
+    `);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const exp = instance.exports as Record<string, () => number>;
+    expect(exp.lt_ab(), "cmp_lt(any,any) string").toBe(1);
+    expect(exp.lt_nums(), "cmp_lt(any,any) numeric").toBe(1);
+    expect(exp.ge_abc_abd(), "cmp_ge(any,any) string").toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2059. The #2059 fix (both JS-host and standalone paths) already landed via **PR #1420** (merged 2026-06-12) — `emitAnyRelational` in `src/codegen/binary-ops.ts` builds §7.2.13 in-module for standalone (`noJsHost && nativeStrings && anyStrTypeIdx >= 0`): both-string → native `__str_compare`, else ToNumber + f64 with a `2`-sentinel for incomparable operands. No `env::__host_compare` import leaks.

But the standalone test section only asserted **numeric runtime + string compile-validate** — a regression in the in-module `__str_compare` dispatch would have stayed invisible. This is exactly the 'closed at first impl, not at standalone conformance' trap sprint 62 targets.

## Change

Test-hardening only (no codegen change). Added two runtime tests to `tests/issue-2059-any-relational.test.ts` that lock in the lexicographic/numeric §7.2.13 results in pure-WasmGC standalone mode:
- `any`-local form: `"a"<"b"`→true, `"10"<"9"`→true (lexicographic), `"10"<9`→false (mixed→numeric), `>`/`<=`/`>=` variants.
- `any`-parameter form (native strings via an exported caller — the only standalone scenario, no host-injected JS strings).

Verified against `origin/main` (516feec44): all 7 tests pass.

## Test plan
```
npx vitest run tests/issue-2059-any-relational.test.ts  # 7 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)