### PR TITLE
docs(#2100): deep-marshaling contract spec (single marshal() layer)

### DIFF
--- a/docs/architecture/marshaling-contract.md
+++ b/docs/architecture/marshaling-contract.md
@@ -1,0 +1,116 @@
+# Deep-marshaling contract (wasm ⇄ host boundary)
+
+> Status: **architecture spec** (#2100). Defines the single conversion contract
+> every wasm↔host bridge must route through. No implementation has landed yet;
+> this is the target the F4 member issues (#1996, #1969, #1998, #2028, #2015,
+> #2025) implement in phases. Verified against `origin/main` @ `516feec44`.
+
+## Why this exists
+
+Wasm↔host value conversion is currently decided **ad hoc per call site**. A
+WasmGC vec crosses opaque through some bridges and deep-converts in others; a
+closure is sometimes wrapped as a host callback and sometimes not; `this`
+routing diverges per bridge; identity/round-trip is undefined. The symptom
+issues are the visible faces of one missing abstraction: **there is no declared
+conversion layer.** This doc declares it.
+
+The fix is one entry point — `marshal(value, direction, depth, exports)` — with
+a fixed rule per (value-family × direction) cell. Every bridge calls `marshal`
+instead of its bespoke conversion.
+
+## The conversion matrix
+
+Directions: `OUT` = wasm → host, `IN` = host → wasm.
+
+| Value family | `OUT` (wasm → host) | `IN` (host → wasm) | Identity / round-trip |
+|---|---|---|---|
+| **vec ⇄ Array** | deep-convert to a JS Array, **recursively to `depth`**; inner vec refs unwrap (never pass opaque) | recognize a JS Array (or `IsConcatSpreadable`, §23.1.3.1.1) and rebuild the vec | object elements preserve identity (cached by ref); a round-tripped vec keeps its backing store where possible |
+| **closure ⇄ callback** | wrap the closure-struct as host-callable via `__fn_wrap` / `callback_maker` (`runtime.ts:8904`) | a host fn arriving as externref is invoked via `__call_extern_fn(fn, args)` — **never** `ref.cast` to a closure struct (the #2028 trap) | wasm closure wrapped OUT runs the original body when called from host; host fn passed IN dispatches to the host fn when called from wasm |
+| **struct ⇄ object** | `_wrapForHost` Proxy (live-mirror over sidecar + `__sget_*`); registered proto/class objects present method-only keys | `_unwrapForHost` to the raw struct ref before handing to a compiled function | Proxy is a distinct JS object (caveat, `runtime.ts:3863`); identity comparisons MUST `_unwrapForHost`. `_hostProxyCache`/`_hostProxyReverse` keep one stable Proxy per struct |
+| **primitive / boxed** | number→`__box_number`, string→host string, undefined→host undefined | ToNumber / ToString per the coercion plan (#1917) | value types; no identity concern |
+
+## `this`-binding rule
+
+One rule, applied by `marshal` at every method-dispatch bridge. The dispatch
+site already knows whether it resolved a compiled `${Class}_method` funcidx;
+that flag is the single gate.
+
+- **Compiled wasm method** via extern dispatch → pass the **raw struct ref** as
+  `this`, NOT the `_wrapForHost` mirror. (#2015: `calls.ts:7512` +
+  `runtime.ts:~6815` pass the mirror today; the body's `this.<field>` reads the
+  wrong object and traps.)
+- **Genuine host method** on a wrapped wasm struct → pass the mirror (the host
+  method only understands the Proxy surface).
+- **Extracted method** (`const f = a.m; f()`) with no receiver → trampoline
+  emits a **null-`this` prologue throwing a catchable `TypeError` exception
+  tag**, never a `ref.null` deref. (#2025: `closures.ts:3264-3269` traps
+  uncatchably today.)
+
+## Depth policy
+
+- **Enumeration / serialization sinks** (`JSON.stringify`, `Object.keys`,
+  spread) — `OUT` to **full depth** (`depth = ∞`).
+- **Structural splice** (`concat`) — `depth = 1`: recognize a vec arg as
+  `IsConcatSpreadable` and splice one level, do not deep-flatten (#1969).
+- **`flat(n)` / `flatMap`** — `OUT` inner vecs to the declared flatten depth
+  `n` (#1996: `_toJsArray` must recurse, bounded by `n`).
+
+## Identity policy
+
+- `marshal` caches `OUT` conversions of **reference** values: structs in
+  `_hostProxyCache`, vecs in a parallel vec→Array WeakMap, so the same wasm ref
+  marshals to the same JS object within a call (preserves e.g.
+  `arr.flat().includes(sameObjElem)`).
+- `IN` resolves identity via `_hostProxyReverse` / `_unwrapForHost`.
+- Primitives are never cached.
+
+## The single layer
+
+```ts
+// runtime.ts — the one bridge every host import routes through.
+// direction: "OUT" (wasm→host) | "IN" (host→wasm)
+function marshal(value: any, direction: "OUT" | "IN", depth: number, exports): any
+```
+
+- `OUT`: vec→Array (recurse to `depth`), struct→`_wrapForHost`, closure→
+  `__fn_wrap`, primitive→box. Identity-cached for reference values.
+- `IN`: Array→vec (or IsConcatSpreadable splice), object→`_unwrapForHost`,
+  host-fn→leave as externref tagged for `__call_extern_fn`, primitive→coerce.
+
+`HOST_CALLBACK_METHODS` (`closures.ts:1060`) remains the closure-vs-host-callback
+decision **input** (consumed by `isHostCallbackArgument`), feeding `marshal`'s
+closure cell — it is not a parallel conversion path and is not dead code.
+
+## Per-cell mode matrix (dual-mode, per CLAUDE.md)
+
+| Cell | JS-host mode | Standalone mode |
+|---|---|---|
+| vec ⇄ Array | `marshal` deep-convert | representable (WasmGC vec ↔ native array) |
+| primitive | `marshal` box/coerce | representable |
+| closure ⇄ callback | `__fn_wrap` / `__call_extern_fn` | representable (closure struct + `call_ref`); host-fn IN is host-only |
+| struct ⇄ object | `_wrapForHost` Proxy | **host-only** — standalone reads struct fields directly (the #2101/#2158 struct readers); no JS Proxy |
+
+The struct-mirror cell is the single place a standalone fallback is mandatory.
+M4 (below) audits and documents it.
+
+## Migration order
+
+Each phase routes a set of bridges through `marshal` and retires named member
+issues. Phases are independently mergeable; M0 lands first.
+
+| Phase | Scope | Bridges rewired | Retires |
+|---|---|---|---|
+| **M0** | Land this doc + `marshal` skeleton + identity caches; no rewires | (none) | — |
+| **M1** | vec ⇄ Array cell | `_toJsArray` (recursive, depth-bound), `__array_concat_any` (IsConcatSpreadable), `compileArrayJoin` elemToStr | **#1996, #1969, #1998** |
+| **M2** | `this`-binding + struct ⇄ object cell | `__extern_method_call` (raw struct ref for compiled methods), extraction trampoline (catchable-TypeError null-`this` prologue) | **#2015, #2025** |
+| **M3** | closure ⇄ callback (host-fn IN) | closure call path → `__call_extern_fn` fallback when callee is externref / cast fails | **#2028** (unblocks the host-fn-param family; same trap as #1950, inverse of #1382) |
+| **M4** | Sweep remaining bridges + standalone audit | every `_wrapForHost` / `extern.convert_any` call site routes through `marshal`; document per-cell mode matrix | — (hardening) |
+
+## Relationships
+
+- **#1917 (coercion engine)** owns the primitive cell; `marshal` delegates
+  primitives to it, does not duplicate ToNumber/ToString.
+- **#2101 (class object model)** — the struct-mirror cell consumes #2101's
+  `$ClassMeta` / struct readers for the standalone fallback.
+- **#1382 / #1950** — wasm-closure-as-JS-callable (the `OUT` closure cell) and
+  its trap family; M3's `IN` host-fn bridge is the inverse direction.

--- a/plan/issues/2100-arch-spec-deep-marshaling-contract.md
+++ b/plan/issues/2100-arch-spec-deep-marshaling-contract.md
@@ -4,7 +4,7 @@ title: "architect spec: deep-marshaling contract at the host boundary (vec ⇄ a
 status: ready
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-15
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -45,3 +45,137 @@ Feeds sprint 64 consumers.
 
 Member issues filed individually; no family owner exists. New (analysis
 program).
+
+---
+
+## Implementation Plan (architecture spec — 2026-06-15, arch1)
+
+> Verified against `origin/main` @ `516feec44`. Spec-only — **no
+> implementation** in this PR. Companion contract doc:
+> [`docs/architecture/marshaling-contract.md`](../../docs/architecture/marshaling-contract.md).
+> Feeds sprint-64 consumers; retires the F4 family member issues in phases.
+
+### Correction to the issue's premise
+
+`HOST_CALLBACK_METHODS` is **not dead code** — it is a live defensive
+allowlist in `closures.ts:1060`, consulted by `isHostCallbackArgument`
+(`closures.ts:1111`) to decide whether an arrow/function argument to a
+HOF/Promise/replace method is bridged as a host callback vs a wasm closure
+struct. The real defect the family shares is not "dead code" but **the absence
+of a single declared conversion layer**: each bridge re-derives, ad hoc, (a)
+whether to deep-convert a vec, (b) whether to wrap a closure, (c) which `this`
+to pass, and (d) identity/round-trip policy. The fix is to route every bridge
+through **one** `marshal(value, direction, depth)` layer with a declared matrix.
+
+### The conversion matrix (the contract)
+
+Two directions, four value families. Today each cell is decided per-call-site;
+the contract fixes one rule per cell.
+
+| Value family | wasm → host (`OUT`) | host → wasm (`IN`) | Identity / round-trip |
+|---|---|---|---|
+| **vec ⇄ Array** | deep-convert to a JS Array **recursively to `depth`** (default ∞ for enumeration sinks, bounded for `flat(n)`); inner vec refs unwrap, not pass opaque | recognize a JS Array (or `IsConcatSpreadable`) and rebuild the vec; spread per §23.1.3.1.1 | `OUT∘IN` must preserve element identity for object elements (cache by ref); a vec round-tripped through host stays the same backing store where possible |
+| **closure ⇄ callback** | wrap the closure-struct as a host-callable via the `__fn_wrap`/`callback_maker` bridge (`runtime.ts:8904`) | a host function arriving as externref is invoked via `__call_extern_fn(fn, args)` — **never** ref.cast to a closure struct (that is the #2028 trap) | a wasm closure wrapped OUT then called from host runs the original wasm body; a host fn passed IN then called from wasm dispatches to the host fn |
+| **struct ⇄ object** | `_wrapForHost` Proxy (live-mirror over sidecar + `__sget_*`); registered proto/class objects present method-only keys | `_unwrapForHost` back to the raw struct ref before handing to a compiled function | Proxy is a *different* JS object (documented caveat, `runtime.ts:3863`); callers that compare identity MUST `_unwrapForHost`. `_hostProxyCache`/`_hostProxyReverse` give a stable Proxy per struct |
+| **primitive / boxed** | number→`__box_number`, string→host string, undefined→host undefined, etc. (the coercion engine, #1917) | ToNumber/ToString per coercion plan | value types; no identity concern |
+
+### `this`-binding rules (the cell every bridge gets wrong differently)
+
+A single rule, applied by `marshal` at every method-dispatch bridge:
+
+- **Compiled wasm method** invoked via extern dispatch → pass the **raw struct
+  ref** as `this`, NOT the `_wrapForHost` mirror (#2015 root cause:
+  `calls.ts:7512` + `runtime.ts:~6815` pass the mirror; the body's
+  `this.<field>` then reads the wrong object and traps).
+- **Genuine host method** invoked on a wrapped wasm struct → pass the mirror
+  (the host method only understands the Proxy surface).
+- **Extracted method** (`const f = a.m; f()`) called with no receiver → the
+  trampoline must emit a **null-`this` check prologue throwing a catchable
+  `TypeError` exception tag**, never `ref.null` deref (the #2025 trap-vs-
+  catchable divergence at `closures.ts:3264-3269`).
+
+The discriminator "compiled wasm method vs host method" is already computable
+(the dispatch site knows whether it resolved a `${Class}_method` funcidx); the
+contract makes it the *single* gate for which `this` flows.
+
+### Depth / identity policy
+
+- **Depth.** Enumeration/serialization sinks (`JSON.stringify`, `Object.keys`,
+  spread) marshal `OUT` to **full depth**. Structural array ops carry their own
+  bound: `flat(n)`/`flatMap` marshal inner vecs to the declared flatten depth
+  (#1996 — `_toJsArray` recurses, bounded by `n`). `concat` does **not** deep-
+  flatten but MUST recognize a vec arg as `IsConcatSpreadable` and splice one
+  level (#1969). Default `depth = ∞` for `OUT` enumeration, `depth = 1` for
+  structural splice, explicit `n` for `flat`.
+- **Identity.** `marshal` caches `OUT` conversions of *reference* values in
+  `_hostProxyCache` (structs) and a parallel vec→Array WeakMap so the same wasm
+  ref marshals to the same JS object within a call (preserves
+  `arr.flat().includes(sameObjElem)`); `IN` uses `_hostProxyReverse` /
+  `_unwrapForHost`. Primitives are never cached.
+
+### The single layer
+
+One module-level entry point in `runtime.ts` (host side) plus its codegen-side
+emit helper:
+
+```ts
+// runtime.ts — the one bridge every host import routes through.
+// direction: "OUT" (wasm→host) | "IN" (host→wasm)
+function marshal(value: any, direction: "OUT" | "IN", depth: number, exports): any
+```
+
+- `OUT`: vec→Array (recurse to `depth`), struct→`_wrapForHost`, closure→
+  `__fn_wrap`, primitive→box. Identity-cached.
+- `IN`: Array→vec (or IsConcatSpreadable splice), object→`_unwrapForHost`,
+  host-fn→leave as externref tagged for `__call_extern_fn`, primitive→coerce.
+
+Every existing bridge (`__array_concat_any`, `_toJsArray`, `compileArrayJoin`'s
+elemToStr, `__extern_method_call`, `Promise_new`'s executor, the HOF callback
+bridges, `Object.assign`/spread) **calls `marshal` instead of its bespoke
+conversion**. `HOST_CALLBACK_METHODS` stays as the closure-vs-host-callback
+decision input but feeds `marshal`'s closure cell, not a parallel path.
+
+### Migration order (each phase retires named member issues)
+
+- **Phase M0 — land the contract doc + `marshal` skeleton (no rewires).**
+  Define `marshal`, the matrix, identity caches; leave existing bridges intact.
+  *Retires: none; establishes the layer.*
+- **Phase M1 — vec ⇄ Array cell.** Route `_toJsArray` (recursive, depth-bound),
+  `__array_concat_any` (IsConcatSpreadable), `compileArrayJoin` elemToStr
+  through `marshal`. *Retires: **#1996, #1969, #1998**.*
+- **Phase M2 — `this`-binding + struct ⇄ object cell.** `__extern_method_call`
+  passes the raw struct ref for compiled methods (mirror only for host methods);
+  extraction trampoline emits the catchable-TypeError null-`this` prologue.
+  *Retires: **#2015, #2025**.*
+- **Phase M3 — closure ⇄ callback cell (host-fn IN).** `__call_extern_fn`
+  fallback in the closure call path when the callee is externref / the cast
+  fails. *Retires: **#2028** (and unblocks the host-function-param family
+  broadly — same trap as #1950, inverse of #1382).*
+- **Phase M4 — sweep remaining bridges + standalone audit.** Audit every
+  `_wrapForHost`/`extern.convert_any` call site to route through `marshal`;
+  document which cells are host-only (the Proxy) vs standalone-representable
+  (vec/primitive), feeding the dual-mode requirement.
+
+### Standalone note (dual-mode, per CLAUDE.md)
+
+The struct ⇄ object cell's `_wrapForHost` Proxy is **host-only** — standalone
+mode has no JS Proxy. The contract must mark the struct-mirror cell as the one
+place a standalone fallback is required: standalone enumeration/method-dispatch
+reads struct fields directly (the same readers #2101/#2158 add for the class
+model). The vec, primitive, and closure cells are representable in both modes.
+M4 documents the per-cell mode matrix so #2158-style standalone work has a
+declared target.
+
+### What this spec does NOT do
+
+- No implementation (member-issue PRs implement each phase).
+- Does not change the coercion engine (#1917) — primitives delegate to it.
+- Does not decide the class model (#2101) — the struct-mirror cell consumes
+  #2101's `$ClassMeta` readers in standalone mode.
+
+### Deliverables
+
+1. This `## Implementation Plan`.
+2. `docs/architecture/marshaling-contract.md` — the full matrix, identity/
+   round-trip rules, depth policy, `marshal` signature, per-cell mode matrix,
+   and the M0–M4 migration table mapping each phase to retired member issues.


### PR DESCRIPTION
## #2100 — deep-marshaling contract at the host boundary (spec-only)

Declares the wasm↔host conversion contract the F4 family lacks. Today each
bridge re-derives vec deep-conversion, closure wrapping, `this`-routing, and
identity/round-trip **ad hoc per call site**. The fix routes every bridge
through one `marshal(value, direction, depth, exports)` layer with a fixed rule
per (value-family × direction) cell.

### The matrix
| Family | OUT (wasm→host) | IN (host→wasm) |
|---|---|---|
| vec ⇄ Array | deep-convert recursively to `depth` | rebuild vec / IsConcatSpreadable splice |
| closure ⇄ callback | `__fn_wrap` | `__call_extern_fn` (never `ref.cast` — the #2028 trap) |
| struct ⇄ object | `_wrapForHost` Proxy | `_unwrapForHost` |
| primitive | box/coerce (delegates to #1917) | ToNumber/ToString |

Plus the **`this`-binding rule** (raw struct ref for compiled methods, mirror
for host methods, catchable-TypeError null-`this` prologue for extraction) and
the depth/identity policy.

### Migration order (each phase retires named member issues)
- M0 — land doc + `marshal` skeleton (no rewires)
- M1 — vec ⇄ Array → **#1996, #1969, #1998**
- M2 — `this`-binding + struct ⇄ object → **#2015, #2025**
- M3 — closure ⇄ callback (host-fn IN) → **#2028**
- M4 — sweep + standalone audit

### Dual-mode
The struct-mirror Proxy cell is the one **host-only** cell; standalone reads
struct fields directly (consumes #2101/#2158). vec/primitive/closure cells are
representable in both modes.

### Correction
`HOST_CALLBACK_METHODS` is **not** dead code (the issue text said so) — it is
the live closure-vs-host-callback decision input (`closures.ts:1060`), feeding
`marshal`'s closure cell.

### Changes
- `plan/issues/2100-...md` — `## Implementation Plan`.
- `docs/architecture/marshaling-contract.md` — full contract doc + per-cell mode matrix.

Spec-only (no implementation); feeds sprint-64 consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)