### PR TITLE
fix(#2009) PR-2: spread-source value resolution + source-order override

### DIFF
--- a/plan/issues/2009-same-shape-struct-field-name-collision.md
+++ b/plan/issues/2009-same-shape-struct-field-name-collision.md
@@ -1,10 +1,10 @@
 ---
 id: 2009
 title: "structurally identical struct types share field names at the host boundary — Object.assign/spread/JSON.stringify mislabel keys, spread override order broken"
-status: ready
+status: in-progress
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-15
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -372,3 +372,52 @@ adds a non-colliding sanity case + the writeback case.
 R3 (spread source-order value resolution) remains — separate PR-2 (inline spread
 sources don't get struct types → resolveStructName undefined → values lost; needs
 the plan's lastWriter rewrite). Names + Object.assign values done here.
+
+## PR-2 landed (2026-06-15, sdev3) — R3 spread-source value resolution + source-order override
+
+Fixed R3 VALUES (`compileObjectLiteralForStruct`, `src/codegen/literals.ts`):
+
+1. **Inline spread-source value resolution.** An INLINE object-literal spread
+   source (`{ ...{x:1,y:2} }`) is never independently declared, so its anon
+   object type was never registered as a struct: `resolveStructName` returned
+   undefined, the source was dropped from `spreadSources`, and every
+   spread-sourced field fell through to the undefined-default branch
+   (`{ ...{x:1,y:2} }` → `{x:null,y:null}`, observed on main; WAT-confirmed even
+   a *single* inline spread lost all values, broader than the spec's recorded R3).
+   Fix: when `resolveStructName(srcType)` is undefined, call
+   `ensureStructForType(ctx, srcType)` then re-resolve — mirrors the
+   outer-literal registration at the `compileObjectLiteral` entry. NAMED sources
+   already worked (their declaration registered the struct), so this is a no-op
+   for them.
+
+2. **Source-order override (the plan's `lastWriter`).** The field-assembly loop
+   computed the winning writer (`lastMatch`) only from named/shorthand/method
+   props, ignoring spread position, so `{ x:1, ...{x:5} }` kept `x:1`. Fix:
+   record each spread's `propIndex` (position in `expr.properties`); per field,
+   if a spread that defines the key sits AFTER the last named writer, take the
+   spread's value. The overridden named prop's initializer is still evaluated +
+   dropped for §13.2.5.5 side effects (verified: `{ x: se(), ...{x:5} }` calls
+   `se()` once and yields 5).
+
+Test: `tests/issue-2009.test.ts` +10 cases (9 value/override on `toEqual`
+key-order-insensitive, 1 side-effect-order). Zero regressions —
+`json-stringify`/`json`/`object-literals`/`computed-props`/`destructuring`
+equiv suites identical to main (their incidental FAILs — `spread-rest`,
+`basic-destructuring` "no tests", a couple json cases — are all PRE-EXISTING on
+main, bisected). `tsc --noEmit` clean.
+
+### R3b STILL OPEN — spread-result key INSERTION ORDER (issue stays in-progress)
+`{ ...{x:1,y:2}, ...{y:3,z:4} }` now has correct VALUES but stringifies as
+`{"y":3,"z":4,"x":1}` instead of Node's `{"x":1,"y":3,"z":4}`. Root cause: the
+spread-result anon struct's `fields` array is ordered last-spread-first by the
+TypeChecker's `getProperties()` (WAT: `$__anon (struct $y $z $x)`); JSON /
+Object.keys read that order. **Pre-existing on main** — affects NAMED-source
+spreads too, independent of PR-2 (bisected against pre-#1462 and against current
+main with named sources). Plain (non-spread) literals already preserve source
+order, so the defect is specific to how the spread-result struct's fields are
+registered. Fix needs `ensureStructForType` (or a literal-aware registration
+pass) to order an anon object-literal type's fields by JS insertion order
+(first-occurrence position across spread evaluation) rather than checker order —
+higher blast radius (shared/canonical struct types, $shape, getters, dedup), so
+scoped OUT of PR-2. Tracked as `it.todo` in `tests/issue-2009.test.ts`. Keep
+#2009 in-progress until R3b lands.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1392,12 +1392,36 @@ export function compileObjectLiteralForStruct(
     return null;
   }
 
-  // Check if there are any spread assignments — if so, compile spread sources into locals
-  const spreadSources: { local: number; srcStructTypeIdx: number; srcFields: { name: string }[] }[] = [];
-  for (const prop of expr.properties) {
+  // Check if there are any spread assignments — if so, compile spread sources into locals.
+  // (#2009 R3) `propIndex` records each spread's position in `expr.properties` so the
+  // field-assembly loop can honour SOURCE ORDER between a named prop and a spread that
+  // both write the same key (later writer wins — `{ x:1, ...{x:5} }` → `x:5`).
+  const spreadSources: {
+    local: number;
+    srcStructTypeIdx: number;
+    srcFields: { name: string }[];
+    propIndex: number;
+  }[] = [];
+  for (let propIndex = 0; propIndex < expr.properties.length; propIndex++) {
+    const prop = expr.properties[propIndex]!;
     if (ts.isSpreadAssignment(prop)) {
       const srcType = ctx.checker.getTypeAtLocation(prop.expression);
-      const srcStructName = resolveStructName(ctx, srcType);
+      // (#2009 R3) An INLINE object-literal spread source (`{ ...{ x: 1 } }`)
+      // is never independently declared, so its anonymous object type was never
+      // registered as a struct — `resolveStructName` returns undefined, the
+      // source is dropped from `spreadSources`, and every spread-sourced field
+      // falls through to the undefined-default branch below (the observed
+      // `{ ...{x:1,y:2} }` → `{x:null,y:null}` bug). Register a struct for the
+      // source type first (mirroring the outer-literal registration at the
+      // `compileObjectLiteral` entry, lines ~921/938/950) so both
+      // `resolveStructName` AND the `compileExpression` below lower it to a real
+      // struct instance whose fields can be read. NAMED sources already work
+      // (their declaration registered the struct), so this is a no-op for them.
+      let srcStructName = resolveStructName(ctx, srcType);
+      if (!srcStructName) {
+        ensureStructForType(ctx, srcType);
+        srcStructName = resolveStructName(ctx, srcType);
+      }
       if (srcStructName) {
         const srcStructTypeIdx = ctx.structMap.get(srcStructName);
         const srcFields = ctx.structFields.get(srcStructName);
@@ -1407,7 +1431,7 @@ export function compileObjectLiteralForStruct(
           const spreadResult = compileExpression(ctx, fctx, prop.expression);
           if (!spreadResult) continue;
           fctx.body.push({ op: "local.set", index: srcLocal });
-          spreadSources.push({ local: srcLocal, srcStructTypeIdx, srcFields });
+          spreadSources.push({ local: srcLocal, srcStructTypeIdx, srcFields, propIndex });
         }
       }
     }
@@ -1651,6 +1675,40 @@ export function compileObjectLiteralForStruct(
         const dupType = compileExpression(ctx, fctx, dup.initializer);
         if (dupType) fctx.body.push({ op: "drop" });
       }
+    }
+    // (#2009 R3) Source-order override: when a spread appears AFTER the last
+    // named/shorthand/method writer of this key, the spread wins
+    // (`{ x:1, ...{x:5} }` → `x:5`). Find the position of the winning named
+    // writer and the LAST spread (by source position) that also defines this
+    // field; if that spread comes later, take its value instead of the named
+    // prop. When there is no named writer this is a no-op (the existing
+    // "fall through to spread" path below handles it). The named prop's
+    // initializer is still evaluated above for its observable side effects.
+    const lastMatchIndex = lastMatch ? expr.properties.indexOf(lastMatch) : -1;
+    let overridingSpread:
+      | { local: number; srcStructTypeIdx: number; srcFields: { name: string }[]; propIndex: number }
+      | undefined;
+    for (const src of spreadSources) {
+      if (src.propIndex <= lastMatchIndex) continue;
+      if (src.srcFields.some((f) => f.name === field.name)) {
+        if (!overridingSpread || src.propIndex > overridingSpread.propIndex) {
+          overridingSpread = src;
+        }
+      }
+    }
+    if (overridingSpread) {
+      // (§13.2.5.5) The overridden named prop is still evaluated for its
+      // observable side effects, then its value is dropped — only a
+      // PropertyAssignment has an initializer to run (shorthand/method have
+      // none). The earlier duplicates were already evaluated+dropped above.
+      if (lastMatch && ts.isPropertyAssignment(lastMatch)) {
+        const overriddenType = compileExpression(ctx, fctx, lastMatch.initializer);
+        if (overriddenType) fctx.body.push({ op: "drop" });
+      }
+      const fieldIdx = overridingSpread.srcFields.findIndex((f) => f.name === field.name);
+      fctx.body.push({ op: "local.get", index: overridingSpread.local });
+      fctx.body.push({ op: "struct.get", typeIdx: overridingSpread.srcStructTypeIdx, fieldIdx });
+      continue;
     }
     const prop =
       lastMatch && !ts.isShorthandPropertyAssignment(lastMatch) && !ts.isMethodDeclaration(lastMatch)

--- a/tests/issue-2009.test.ts
+++ b/tests/issue-2009.test.ts
@@ -132,3 +132,68 @@ describe("#2009 — per-instance struct field names (host boundary)", () => {
     ).toBe('{"a":1,"b":2}');
   });
 });
+
+/**
+ * #2009 R3 — spread-source VALUE resolution (PR-2).
+ *
+ * The struct-path object-literal lowering only read a spread source's field
+ * values when the source had a *registered* struct type. An INLINE
+ * object-literal spread source (`{ ...{ x: 1 } }`) is never independently
+ * declared, so its anonymous object type was never registered — the source was
+ * dropped from `spreadSources` and every spread-sourced field defaulted to the
+ * undefined sentinel (`{ ...{x:1,y:2} }` produced `{x:null,y:null}` instead of
+ * `{x:1,y:2}`). Fix: register a struct for the inline source type before
+ * compiling it (`ensureStructForType`), and honour SOURCE ORDER between a named
+ * prop and a spread that both write the same key (later writer wins).
+ *
+ * Asserted on VALUE equality (key insertion order for spread-result structs is
+ * a separate pre-existing defect — see the `it.todo` below — driven by the
+ * TypeChecker ordering the spread-result type's properties last-spread-first;
+ * it affects NAMED-source spreads on main too and is not introduced here).
+ */
+describe("#2009 R3 — spread-source value resolution + source-order override", () => {
+  const cases: { name: string; lit: string }[] = [
+    { name: "inline single spread", lit: `{ ...{ x: 1, y: 2 } }` },
+    { name: "inline two spreads value merge", lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } }` },
+    { name: "inline spreads + named override after", lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 }, x: 9 }` },
+    { name: "named prop before inline spread (spread wins)", lit: `{ x: 1, ...{ x: 5, y: 6 } }` },
+    { name: "named after spread (named wins)", lit: `{ ...{ x: 5, y: 6 }, x: 1 }` },
+    { name: "mixed named + inline source", lit: `{ x: 1, ...{ z: 3 } }` },
+    { name: "string values in spread", lit: `{ ...{ a: "hi", b: "bye" } }` },
+    { name: "three inline sources", lit: `{ ...{ a: 1 }, ...{ b: 2 }, ...{ c: 3 } }` },
+    { name: "named between two spreads (later spread overrides)", lit: `{ ...{ x: 1 }, y: 2, ...{ x: 9 } }` },
+  ];
+  for (const { name, lit } of cases) {
+    it(name, async () => {
+      const got = (await runWasm(
+        `export function test(): string { return JSON.stringify(${lit}); }`,
+      )) as string;
+      // eslint-disable-next-line no-eval
+      const expected = eval("(" + lit + ")") as Record<string, unknown>;
+      expect(JSON.parse(got)).toEqual(expected);
+    });
+  }
+
+  it("overridden named-prop initializer still runs for side effects (§13.2.5.5)", async () => {
+    // `x: se()` is overridden by a later `...{ x: 5 }`, but its side-effecting
+    // initializer must still evaluate exactly once.
+    expect(
+      await runWasm(`
+        let calls = 0;
+        function se(): number { calls = calls + 1; return 1; }
+        export function test(): string {
+          const o = { x: se(), ...{ x: 5 } };
+          return JSON.stringify(o.x) + "|" + String(calls);
+        }
+      `),
+    ).toBe("5|1");
+  });
+
+  // R3b (separate follow-up): key INSERTION ORDER for spread-result structs.
+  // `{ ...{x:1,y:2}, ...{y:3,z:4} }` should stringify as `{"x":1,"y":3,"z":4}`
+  // but the spread-result anon struct's fields are ordered last-spread-first
+  // (`y,z,x`) by the TypeChecker, so JSON/Object.keys report `{"y":3,"z":4,"x":1}`.
+  // Pre-existing on main (affects named-source spreads too); fixing it needs the
+  // spread-result struct's field registration to follow JS insertion order.
+  it.todo("spread-result keys follow JS insertion order (R3b — struct field-order)");
+});

--- a/tests/issue-2009.test.ts
+++ b/tests/issue-2009.test.ts
@@ -152,24 +152,38 @@ describe("#2009 — per-instance struct field names (host boundary)", () => {
  * it affects NAMED-source spreads on main too and is not introduced here).
  */
 describe("#2009 R3 — spread-source value resolution + source-order override", () => {
-  const cases: { name: string; lit: string }[] = [
-    { name: "inline single spread", lit: `{ ...{ x: 1, y: 2 } }` },
-    { name: "inline two spreads value merge", lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } }` },
-    { name: "inline spreads + named override after", lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 }, x: 9 }` },
-    { name: "named prop before inline spread (spread wins)", lit: `{ x: 1, ...{ x: 5, y: 6 } }` },
-    { name: "named after spread (named wins)", lit: `{ ...{ x: 5, y: 6 }, x: 1 }` },
-    { name: "mixed named + inline source", lit: `{ x: 1, ...{ z: 3 } }` },
-    { name: "string values in spread", lit: `{ ...{ a: "hi", b: "bye" } }` },
-    { name: "three inline sources", lit: `{ ...{ a: 1 }, ...{ b: 2 }, ...{ c: 3 } }` },
-    { name: "named between two spreads (later spread overrides)", lit: `{ ...{ x: 1 }, y: 2, ...{ x: 9 } }` },
+  // Each `lit` is the literal under test; `expected` is the Node-evaluated
+  // value (asserted key-order-insensitive via `toEqual` — key order is R3b).
+  const cases: { name: string; lit: string; expected: Record<string, unknown> }[] = [
+    { name: "inline single spread", lit: `{ ...{ x: 1, y: 2 } }`, expected: { x: 1, y: 2 } },
+    {
+      name: "inline two spreads value merge",
+      lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } }`,
+      expected: { x: 1, y: 3, z: 4 },
+    },
+    {
+      name: "inline spreads + named override after",
+      lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 }, x: 9 }`,
+      expected: { x: 9, y: 3, z: 4 },
+    },
+    {
+      name: "named prop before inline spread (spread wins)",
+      lit: `{ x: 1, ...{ x: 5, y: 6 } }`,
+      expected: { x: 5, y: 6 },
+    },
+    { name: "named after spread (named wins)", lit: `{ ...{ x: 5, y: 6 }, x: 1 }`, expected: { x: 1, y: 6 } },
+    { name: "mixed named + inline source", lit: `{ x: 1, ...{ z: 3 } }`, expected: { x: 1, z: 3 } },
+    { name: "string values in spread", lit: `{ ...{ a: "hi", b: "bye" } }`, expected: { a: "hi", b: "bye" } },
+    { name: "three inline sources", lit: `{ ...{ a: 1 }, ...{ b: 2 }, ...{ c: 3 } }`, expected: { a: 1, b: 2, c: 3 } },
+    {
+      name: "named between two spreads (later spread overrides)",
+      lit: `{ ...{ x: 1 }, y: 2, ...{ x: 9 } }`,
+      expected: { x: 9, y: 2 },
+    },
   ];
-  for (const { name, lit } of cases) {
+  for (const { name, lit, expected } of cases) {
     it(name, async () => {
-      const got = (await runWasm(
-        `export function test(): string { return JSON.stringify(${lit}); }`,
-      )) as string;
-      // eslint-disable-next-line no-eval
-      const expected = eval("(" + lit + ")") as Record<string, unknown>;
+      const got = (await runWasm(`export function test(): string { return JSON.stringify(${lit}); }`)) as string;
       expect(JSON.parse(got)).toEqual(expected);
     });
   }


### PR DESCRIPTION
## Summary
Fixes **R3** of #2009 — spread VALUE resolution (left after #1462 landed R1 names + R2 Object.assign values).

On main an inline object-literal spread source dropped all its values:
```ts
JSON.stringify({ ...{x:1, y:2} })   // main: {"x":null,"y":null}   node: {"x":1,"y":2}
JSON.stringify({ x:1, ...{x:5} })   // main: {"x":1}               node: {"x":5}
```

### Root cause + fix (`src/codegen/literals.ts`, `compileObjectLiteralForStruct`)
1. **Inline spread-source values.** An inline source (`{ ...{x:1} }`) is never independently declared, so its anon object type was never registered as a struct → `resolveStructName` returned undefined → the source was dropped from `spreadSources` → every spread-sourced field defaulted to the undefined sentinel. Fix: when `resolveStructName` is undefined, `ensureStructForType(srcType)` then re-resolve (mirrors the outer-literal registration at the `compileObjectLiteral` entry). Named sources already worked — no-op for them.
2. **Source-order override (`lastWriter`).** The field-assembly loop chose the winning writer only from named/shorthand/method props, ignoring spread position, so `{ x:1, ...{x:5} }` kept `x:1`. Fix: record each spread's source `propIndex`; per field, when a spread defining the key sits AFTER the last named writer, take the spread's value. The overridden named prop's initializer is still evaluated + dropped for §13.2.5.5 side effects.

### Scope — R3b deliberately NOT in this PR
`{ ...{x:1,y:2}, ...{y:3,z:4} }` now has correct VALUES but stringifies as `{"y":3,"z":4,"x":1}` (key order). The spread-result anon struct's `fields` are ordered last-spread-first by the TypeChecker — a **pre-existing** defect (affects named-source spreads on main too; bisected against pre-#1462 and current main). Fixing it needs anon-struct field registration to follow JS insertion order — higher blast radius (shared/canonical types, `$shape`, getters, dedup). Tracked as an `it.todo`; **#2009 stays `in-progress`** until R3b lands.

## Test
`tests/issue-2009.test.ts` +10 cases (9 value/override on key-order-insensitive `toEqual`, 1 §13.2.5.5 side-effect-order). All 18 pass, 1 todo.

## Regressions
None. `json-stringify` / `json` / `object-literals` / `computed-props` / `destructuring` equiv suites are identical to main (their incidental FAILs — `spread-rest`, `basic-destructuring` "no tests", a couple json cases — are all PRE-EXISTING on main, bisected). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)