### PR TITLE
fix(#1998): Array(n) sparse array renders holes as empty in join/toString

### DIFF
--- a/plan/issues/1997-array-tostring-object-array.md
+++ b/plan/issues/1997-array-tostring-object-array.md
@@ -1,10 +1,11 @@
 ---
 id: 1997
 title: "Array.prototype.toString() returns '[object Array]' instead of join() (method call only; String(a) works)"
-status: ready
+status: done
+completed: 2026-06-15
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-15
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -49,3 +50,21 @@ default separator.
 
 #1215 (done) registered `number_toString` for array `.toString()`; current
 behavior is a residual. New.
+
+---
+
+## Resolution (2026-06-15, dev3)
+
+**Done.** Verified on `origin/main` @ `516feec44`: `"toString"` is already in
+`ARRAY_METHODS` (`src/codegen/array-methods.ts`), so `[1,2,3].toString()` →
+`"1,2,3"` and the nested `[[1,2],[3]].toString()` → `"1,2,3"` (the host
+`__extern_join_str` recurses into nested vecs via `__vec_len`/`__vec_get`) —
+**provided the host instantiation calls
+`result.importObject.__setExports(instance.exports)`** so the recursion can
+reach the exported vec accessors. Without `__setExports` the recursion can't
+find the vec accessors and falls back to `"[object Object]"`; that is a
+harness requirement, not a compiler bug.
+
+Closed alongside #1998 (same `tests/issue-1997.test.ts` regression gate, which
+covers both flat and nested `toString`). The only residual array-stringify bug
+found was the `Array(n)` sparse-hole rendering, fixed in #1998.

--- a/plan/issues/1998-join-externref-elements-illegal-cast.md
+++ b/plan/issues/1998-join-externref-elements-illegal-cast.md
@@ -1,10 +1,11 @@
 ---
 id: 1998
 title: "join() traps 'illegal cast' on externref-element arrays — any[] numbers, undefined/null elements, holes, Array(n) results"
-status: ready
+status: done
+completed: 2026-06-15
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-15
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -51,3 +52,46 @@ host ToString before concat.
 
 #1968 covers only the empty-array `resultTmp` null init (different lines,
 different symptom); #1215 (done) covered typed `number[]`. New.
+
+---
+
+## Resolution (2026-06-15, dev3)
+
+**Done.** Verified on `origin/main` @ `516feec44`. By the time this was picked
+up, four of the five repros (`[10,9]` any-numbers, `[1,undefined,2]`,
+`[1,null,2]`, `[1,,3]`) already passed in JS-host mode — `join`'s
+`__extern_join_str` path (`src/codegen/array-methods.ts`,
+`src/runtime.ts:6684`) handles externref/undefined/null/hole elements and even
+recurses into nested vecs (so #1997's `[[1,2],[3]].toString()` works) **as long
+as the host instantiation calls `result.importObject.__setExports(instance.exports)`**.
+
+The one genuine residual was **`Array(3).join(",")` → `"0,0,0"`** (should be
+`",,"`). Root cause: the non-`new` `Array(n)` constructor
+(`compileArrayConstructorCall` in `src/codegen/literals.ts`) defaulted an
+**untyped** sparse array's element storage to **f64**, whose `array.new_default`
+fills holes with `0`. The `new Array(n)` path (`new-super.ts`) already backs
+untyped sparse arrays with **externref** (default `ref.null` → `join` renders
+`""`). Fix: in `compileArrayConstructorCall`, the single-arg `Array(n)` length
+form with an untyped element type now also resolves to externref, mirroring
+`new Array(n)`. Dense `Array()`/`Array(a,b,c)` and typed `Array<T>(n)` keep f64.
+
+### Verified (JS-host)
+
+| program | before | after |
+|---|---|---|
+| `Array(3).join(",")` | `"0,0,0"` | `",,"` ✓ |
+| `Array(0).join(",")` | `""` | `""` ✓ |
+| `Array(5).length` | `5` | `5` ✓ |
+| `Array(1,2,3).join(",")` | `"1,2,3"` | `"1,2,3"` ✓ (dense, unchanged) |
+| `Array<number>(3)` + index assign + join | `"1,2,3"` | `"1,2,3"` ✓ (typed, unchanged) |
+| `[10,9]`/`[1,undefined,2]`/`[1,null,2]`/`[1,,3]` join | pass | pass ✓ |
+
+Regression test: `tests/issue-1997.test.ts` (11 cases, host mode), all green.
+
+### Out-of-scope standalone residual
+
+Under `target: standalone` the array-element/join path emits a compile error
+(`local.set[0] expected type (ref null 5)`) for several of these shapes — this
+pre-existed this change (same error on `origin/main`) and is part of the
+broader standalone array residual (Lane B #2159 / value-rep undefined
+observability), not the `Array(n)` constructor fix here.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3226,10 +3226,19 @@ export function compileArrayConstructorCall(
   let elemWasm: ValType;
   const rawTypeArgs = ctx.checker.getTypeArguments(exprType as ts.TypeReference);
   const elemTsType = rawTypeArgs?.[0];
-  if (elemTsType && !(elemTsType.flags & ts.TypeFlags.Any)) {
-    elemWasm = resolveWasmType(ctx, elemTsType);
+  const untypedElem = !elemTsType || (elemTsType.flags & ts.TypeFlags.Any) !== 0;
+  if (!untypedElem) {
+    elemWasm = resolveWasmType(ctx, elemTsType!);
+  } else if (args.length === 1 && !ts.isSpreadElement(args[0]!)) {
+    // #1998: `Array(n)` with an untyped element type is a *sparse* array of `n`
+    // holes (§23.1.1.1 step 4) — every slot is `undefined`. An f64 backing
+    // (`array.new_default`) defaults those holes to `0`, so `Array(3).join(",")`
+    // wrongly rendered "0,0,0". Mirror the `new Array(n)` path (new-super.ts):
+    // back untyped sparse arrays with externref, whose default is `ref.null`,
+    // which `join`/`toString` render as "" (§23.1.3.18 step 7.c/d) → ",,".
+    elemWasm = { kind: "externref" };
   } else {
-    // Default to f64 for untyped arrays
+    // Default to f64 for untyped dense arrays (`Array()`, `Array(a, b, c)`).
     elemWasm = { kind: "f64" };
   }
 

--- a/tests/issue-1997.test.ts
+++ b/tests/issue-1997.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1997 — Array.prototype.toString() (§23.1.3.36) delegates to join(",").
+// #1998 — join's elemToStr must handle externref/ref elements (boxed numbers,
+//   undefined, null, holes) and the `Array(n)` sparse-array hole case.
+//
+// Both were spec-conformance residuals of #1215. The `Array(n)` sub-case
+// (#1998) miscompiled because the non-`new` `Array(n)` constructor
+// (compileArrayConstructorCall in src/codegen/literals.ts) defaulted untyped
+// element storage to f64, whose `array.new_default` fills holes with `0`, so
+// `Array(3).join(",")` rendered "0,0,0". This pins the externref-backed
+// sparse-array fix (matching the `new Array(n)` path), so holes render as ""
+// (§23.1.3.18 step 7.c/d) → ",,".
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStr(src: string): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#1997/#1998 — Array toString/join element stringification", () => {
+  describe("#1997 Array.prototype.toString delegates to join", () => {
+    it("flat numeric array toString", async () => {
+      expect(await runStr(`export function test(): string { return [1, 2, 3].toString(); }`)).toBe("1,2,3");
+    });
+
+    it("nested array toString stringifies recursively via join", async () => {
+      expect(
+        await runStr(`export function test(): string { const a: any[] = [[1, 2], [3]]; return a.toString(); }`),
+      ).toBe("1,2,3");
+    });
+  });
+
+  describe("#1998 join handles externref / hole elements", () => {
+    it("any[] of numbers joins", async () => {
+      expect(await runStr(`export function test(): string { const a: any[] = [10, 9]; return a.join(","); }`)).toBe(
+        "10,9",
+      );
+    });
+
+    it("undefined element renders empty", async () => {
+      expect(await runStr(`export function test(): string { return [1, undefined, 2].join("-"); }`)).toBe("1--2");
+    });
+
+    it("null element renders empty", async () => {
+      expect(await runStr(`export function test(): string { return [1, null, 2].join("-"); }`)).toBe("1--2");
+    });
+
+    it("literal hole renders empty", async () => {
+      expect(await runStr(`export function test(): string { return [1, , 3].join(","); }`)).toBe("1,,3");
+    });
+
+    it("Array(n) sparse array renders holes as empty (the #1998 fix)", async () => {
+      expect(await runStr(`export function test(): string { return Array(3).join(","); }`)).toBe(",,");
+    });
+
+    it("Array(n) sparse array reports length n", async () => {
+      expect(await runStr(`export function test(): number { const a = Array(5); return a.length; }`)).toBe(5);
+    });
+
+    it("Array(0) joins to empty string", async () => {
+      expect(await runStr(`export function test(): string { return Array(0).join(","); }`)).toBe("");
+    });
+  });
+
+  describe("regression guards — untyped dense + typed Array(n) unchanged", () => {
+    it("Array(a, b, c) builds a dense numeric array", async () => {
+      expect(await runStr(`export function test(): string { return Array(1, 2, 3).join(","); }`)).toBe("1,2,3");
+    });
+
+    it("typed number[] via Array(n) then assignment joins numerically", async () => {
+      expect(
+        await runStr(
+          `export function test(): string { const a: number[] = Array(3); a[0] = 1; a[1] = 2; a[2] = 3; return a.join(","); }`,
+        ),
+      ).toBe("1,2,3");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **#1998** — `Array(3).join(",")` rendered `"0,0,0"` instead of `",,"`. The
  non-`new` `Array(n)` constructor (`compileArrayConstructorCall` in
  `src/codegen/literals.ts`) defaulted an **untyped** sparse array's element
  storage to **f64**, whose `array.new_default` fills holes with `0`. The
  `new Array(n)` path already backs untyped sparse arrays with **externref**
  (default `ref.null` → `join` renders `""` per §23.1.3.18 step 7.c/d). This
  mirrors that for the single-arg `Array(n)` length form. Dense
  `Array()`/`Array(a,b,c)` and typed `Array<T>(n)` keep f64.
- **#1997** (Array.prototype.toString → join) — already resolved on `main`
  (`"toString"` is in `ARRAY_METHODS`; nested `toString` recurses via the host
  `__extern_join_str` → `__vec_len`/`__vec_get` when the host instantiation
  calls `importObject.__setExports`). Closed alongside #1998 with the shared
  regression gate.

## Verified (JS-host)

| program | before | after |
|---|---|---|
| `Array(3).join(",")` | `"0,0,0"` | `",,"` |
| `Array(0).join(",")` | `""` | `""` |
| `Array(5).length` | `5` | `5` |
| `Array(1,2,3).join(",")` | `"1,2,3"` | `"1,2,3"` (dense, unchanged) |
| `Array<number>(3)` + index assign + join | `"1,2,3"` | `"1,2,3"` (typed, unchanged) |
| `[1,2,3].toString()` / `[[1,2],[3]].toString()` | pass | pass |
| `[10,9]`/`[1,undefined,2]`/`[1,null,2]`/`[1,,3]` join | pass | pass |

Regression test: `tests/issue-1997.test.ts` — 11 host-mode cases (both issues +
dense/typed regression guards), all green. `tsc --noEmit` clean.

## Notes

- The pre-existing `array-methods.test.ts` / `array-capacity.test.ts` failures
  (hand-rolled importObject missing `__unbox_number` / `string_constants`) are
  unrelated infra rot — same failures on `origin/main`, and those tests use
  array literals / typed `number[]`, not `Array(n)`. CI's equivalence shards
  are the authoritative array gate.
- Under `target: standalone` the array/join path emits a compile error
  (`local.set[0] expected type (ref null 5)`) for several of these shapes;
  this pre-existed this change and belongs to the broader standalone array
  residual (Lane B #2159 / value-rep), not the `Array(n)` constructor fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)