### PR TITLE
fix(#1988): standalone any + object/array applies §13.15.3 ToPrimitive

### DIFF
--- a/plan/issues/1988-any-add-object-array-no-toprimitive.md
+++ b/plan/issues/1988-any-add-object-array-no-toprimitive.md
@@ -1,10 +1,11 @@
 ---
 id: 1988
 title: "__any_add on object/array operands skips ToPrimitive entirely — 1 + {} → NaN, [] + [] → 0"
-status: ready
+status: done
+completed: 2026-06-15
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-15
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -12,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: type-coercion
 goal: core-semantics
-related: [1938]
+related: [1938, 1997, 1998]
 origin: "2026-06-10 spec-conformance sweep (equality agent): verified on main"
 ---
 
@@ -59,3 +60,52 @@ is a string. Sibling of #1938 which covers runtime *strings* in `__any_add`
 
 #1938 covers the same mechanism for runtime strings only; objects/arrays
 needing ToPrimitive not mentioned there. Filed as sibling with `related`.
+
+## Resolution (2026-06-15)
+
+Host/gc mode was already correct (routes `+` through `__host_add`). The defect
+was the standalone / pure-WasmGC path. Two `+` lowerings exist depending on the
+operand representation:
+
+- **`emitAnyAdd`** (`src/codegen/binary-ops.ts`) — externref operands (the path
+  actually taken for `f(a: any, b: any)` in standalone). It decided
+  string-concat-vs-numeric by testing `__typeof_string` on the **raw** operands,
+  so an object/array operand (not a string) wrongly took the numeric arm → NaN.
+  Fixed by first reducing both operands through the native `__to_primitive`
+  (default hint) and testing stringness on the **primitives** — an object/array
+  reduces to its `toString` string, forcing §13.15.3 concatenation.
+- **`__any_add`** (`src/codegen/any-helpers.ts`) — the tagged-union `$AnyValue`
+  helper (built only in standalone/fast mode). Added a §13.15.3 string-concat
+  arm: when either operand tag ∈ {5 string, 6 object/array ref}, ToString both
+  (via `__extern_toString` / the `__any_to_string` tag dispatcher) and
+  `__str_concat`, boxing the result as tag 5; otherwise the original i32/f64
+  numeric arm.
+
+Two supporting fixes made the result observable in standalone:
+
+- `__any_to_string` (`src/codegen/native-strings.ts`) now recognises a
+  `__box_number_struct` externref (how a standalone `any` number is carried) and
+  formats it via `number_toString`, instead of falling to "[object Object]".
+- The `$AnyValue` → native-string unbox (`src/codegen/type-coercion.ts`) read
+  `refval` (field 3) for every GC-ref target; a tag-5 string lives in
+  `externval` (field 4), so the read deref'd null. It now reads `externval` for
+  native-string targets.
+
+### Verified (tests/issue-1988.test.ts, 10/10)
+
+- Host: `1 + {}`, `{} + 1`, `{} + {}`, `[] + []`, `[1,2] + 1`, numeric — all
+  match Node.
+- Standalone: `1 + {}` → length 16, `{} + {}` → length 30, string+string any →
+  length 2, and `f(a,b)=a+b` emits **zero host imports**.
+
+### Out of scope / residual
+
+- **Standalone array-element joins** (`[1,2] + 1` → "1,21") still resolve the
+  array operand's `toString` via the Phase-1 "[object Object]" fallback rather
+  than `join`. That is the array-toString-via-join path owned by **#1997/#1998**
+  (now done); once their join lands for the `any`-receiver path the standalone
+  array concat follows automatically. Host mode already matches Node.
+- `any === stringLiteral` content comparison is a separate open gap and is
+  intentionally not used by these tests.
+- `{valueOf(){return 2}} + 1` → 3 still depends on user-defined `valueOf`
+  dispatch (**#1989**).

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -7,7 +7,8 @@
  */
 import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { nativeStringType } from "./native-strings.js";
+import { ensureAnyToStringHelper, ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
 import { addFuncType } from "./registry/types.js";
 import { addStringImportsDelegate, registerEnsureAnyHelpers } from "./shared.js";
@@ -400,6 +401,31 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     strToNumIdx = ctx.funcMap.get("__str_to_number") ?? -1;
   }
 
+  // (#1988) Standalone/WASI `+` string-concat support for the `__any_add`
+  // helper. §13.15.3 ApplyStringOrNumericBinaryOperator: a string operand — or
+  // an object/array operand, whose ToPrimitive(default)→toString yields a
+  // string — forces string CONCATENATION, not numeric addition. The base
+  // `__any_add` only had i32/f64 arms, so `{} + {}`, `[] + []`, `1 + {}`
+  // wrongly hit the f64 arm → NaN. The concat arm below needs four native
+  // helpers; register them FIRST (idempotent) so their funcIdx values are
+  // stable when `__any_add`'s body bakes them in — mirroring how `strToNumIdx`
+  // above is captured for `__any_eq`. Host mode never builds `__any_add` (it
+  // routes `+` through the `__host_add` import), so this is standalone-only and
+  // cannot regress the host path.
+  let externToStringIdx = -1;
+  let anyToStringIdx = -1;
+  let strConcatIdx = -1;
+  if ((ctx.standalone === true || ctx.wasi === true) && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    ensureNativeStringHelpers(ctx);
+    ensureObjectRuntime(ctx); // registers native __extern_toString + __to_primitive
+    anyToStringIdx = ensureAnyToStringHelper(ctx); // (anyref AnyValue) → ref $AnyString, tag-dispatched
+    externToStringIdx = ctx.funcMap.get("__extern_toString") ?? -1;
+    strConcatIdx = ctx.nativeStrHelpers.get("__str_concat") ?? -1;
+  }
+  // True when the standalone concat arm can be built (all pieces present).
+  const anyAddCanConcat =
+    anyToStringIdx >= 0 && externToStringIdx >= 0 && strConcatIdx >= 0 && ctx.anyStrTypeIdx >= 0;
+
   // Helper to register a helper function
   function addHelper(
     name: string,
@@ -776,10 +802,103 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
   const boxF64Idx = ctx.funcMap.get("__any_box_f64")!;
 
   // __any_add(a: ref $AnyValue, b: ref $AnyValue) -> ref $AnyValue
-  // If both are i32 (tag==2): i32.add, box as i32
-  // If both are numeric (tag 2 or 3): convert to f64, f64.add, box as f64
-  // Otherwise: trap (string concat via any not supported yet for simplicity)
+  //
+  // §13.15.3 ApplyStringOrNumericBinaryOperator for `+`:
+  //   1. lprim = ToPrimitive(a); rprim = ToPrimitive(b)
+  //   2. if lprim or rprim is a String → string concatenation
+  //   3. else → numeric addition
+  // Tag 5 (string) is already a string. Tag 6 (object/array ref) reduces under
+  // ToPrimitive(default)→toString to a string ("[object Object]" / joined array
+  // elements), so it also forces concatenation. All other tags (0/1 null/undef,
+  // 2 i32, 3 f64, 4 bool) ToPrimitive to non-strings → numeric arm.
+  //
+  // The numeric arm is the original behaviour: both tag==2 → i32.add+box i32;
+  // otherwise __any_to_f64 both + f64.add + box f64.
+  //
+  // The concat arm only exists in standalone/WASI native-string builds
+  // (`anyAddCanConcat`). Host mode never builds `__any_add` (it routes `+`
+  // through the `__host_add` import), so this whole helper is standalone-only.
+  // When native concat helpers are unavailable the helper degrades to the prior
+  // numeric-only behaviour — no regression, just the unimplemented edge.
+  //
   // params: a(0), b(1)  locals: tagA(2), tagB(3)
+  const numericArm: Instr[] = [
+    // if tagA == 2 && tagB == 2 → i32 add
+    { op: "local.get", index: 2 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.eq" },
+    { op: "local.get", index: 3 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.eq" },
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: anyRef },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
+        { op: "local.get", index: 1 },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
+        { op: "i32.add" },
+        { op: "call", funcIdx: boxI32Idx },
+      ],
+      else: [
+        // f64 path: convert both to f64, add, box as f64
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: toF64Idx },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: toF64Idx },
+        { op: "f64.add" },
+        { op: "call", funcIdx: boxF64Idx },
+      ],
+    } as Instr,
+  ];
+
+  // ToString(operand: ref $AnyValue) → ref $AnyString, dispatched on the tag:
+  //   - tag 6 (object/array ref): pull the actual ref out of `refval`, wrap to
+  //     externref and run the §7.1.17 object walker `__extern_toString` (plain
+  //     objects → "[object Object]"; arrays / custom toString via the $Object
+  //     runtime), casting the string externref back to ref $AnyString.
+  //   - all other tags (0/1 null/undef, 2/3 number, 4 bool, 5 string): the
+  //     `__any_to_string` tag-dispatcher already returns the right ref
+  //     $AnyString directly from the box — and crucially handles number→decimal
+  //     and string→identity without the __box_number round-trip that confuses
+  //     __extern_toString's tag detection.
+  const opToAnyString = (paramIdx: number): Instr[] => [
+    { op: "local.get", index: paramIdx },
+    { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 0 }, // tag
+    { op: "i32.const", value: 6 },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref", typeIdx: ctx.anyStrTypeIdx } },
+      then: [
+        { op: "local.get", index: paramIdx },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 3 }, // refval (eqref)
+        { op: "extern.convert_any" } as Instr,
+        { op: "call", funcIdx: externToStringIdx } as Instr,
+        { op: "any.convert_extern" } as Instr,
+        { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+      ],
+      else: [{ op: "local.get", index: paramIdx }, { op: "call", funcIdx: anyToStringIdx } as Instr],
+    } as Instr,
+  ];
+
+  const concatArm: Instr[] = anyAddCanConcat
+    ? [
+        // box a tag-5 $AnyValue around __str_concat(ToString(a), ToString(b))
+        { op: "i32.const", value: 5 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: 0 },
+        { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+        ...opToAnyString(0),
+        ...opToAnyString(1),
+        { op: "call", funcIdx: strConcatIdx } as Instr,
+        { op: "extern.convert_any" } as Instr,
+        { op: "struct.new", typeIdx: anyTypeIdx },
+      ]
+    : numericArm;
+
   addHelper(
     "__any_add",
     [anyRefNull, anyRefNull],
@@ -793,35 +912,31 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
       { op: "local.get", index: 1 },
       { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 0 },
       { op: "local.set", index: 3 },
-      // if tagA == 2 && tagB == 2 → i32 add
+      // stringy = (tagA==5 || tagA==6 || tagB==5 || tagB==6)
       { op: "local.get", index: 2 },
-      { op: "i32.const", value: 2 },
+      { op: "i32.const", value: 5 },
       { op: "i32.eq" },
+      { op: "local.get", index: 2 },
+      { op: "i32.const", value: 6 },
+      { op: "i32.eq" },
+      { op: "i32.or" },
       { op: "local.get", index: 3 },
-      { op: "i32.const", value: 2 },
+      { op: "i32.const", value: 5 },
       { op: "i32.eq" },
-      { op: "i32.and" },
+      { op: "i32.or" },
+      { op: "local.get", index: 3 },
+      { op: "i32.const", value: 6 },
+      { op: "i32.eq" },
+      { op: "i32.or" },
       {
         op: "if",
         blockType: { kind: "val", type: anyRef },
-        then: [
-          { op: "local.get", index: 0 },
-          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
-          { op: "local.get", index: 1 },
-          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
-          { op: "i32.add" },
-          { op: "call", funcIdx: boxI32Idx },
-        ],
-        else: [
-          // f64 path: convert both to f64, add, box as f64
-          { op: "local.get", index: 0 },
-          { op: "call", funcIdx: toF64Idx },
-          { op: "local.get", index: 1 },
-          { op: "call", funcIdx: toF64Idx },
-          { op: "f64.add" },
-          { op: "call", funcIdx: boxF64Idx },
-        ],
-      },
+        // string concatenation (§13.15.3 step 2) when either operand is a
+        // string or an object/array (whose ToPrimitive→toString is a string).
+        then: concatArm,
+        // numeric addition (§13.15.3 step 3).
+        else: numericArm,
+      } as Instr,
     ],
     [
       { name: "tagA", type: { kind: "i32" } },

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -423,8 +423,7 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     strConcatIdx = ctx.nativeStrHelpers.get("__str_concat") ?? -1;
   }
   // True when the standalone concat arm can be built (all pieces present).
-  const anyAddCanConcat =
-    anyToStringIdx >= 0 && externToStringIdx >= 0 && strConcatIdx >= 0 && ctx.anyStrTypeIdx >= 0;
+  const anyAddCanConcat = anyToStringIdx >= 0 && externToStringIdx >= 0 && strConcatIdx >= 0 && ctx.anyStrTypeIdx >= 0;
 
   // Helper to register a helper function
   function addHelper(
@@ -822,37 +821,8 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
   // numeric-only behaviour — no regression, just the unimplemented edge.
   //
   // params: a(0), b(1)  locals: tagA(2), tagB(3)
-  const numericArm: Instr[] = [
-    // if tagA == 2 && tagB == 2 → i32 add
-    { op: "local.get", index: 2 },
-    { op: "i32.const", value: 2 },
-    { op: "i32.eq" },
-    { op: "local.get", index: 3 },
-    { op: "i32.const", value: 2 },
-    { op: "i32.eq" },
-    { op: "i32.and" },
-    {
-      op: "if",
-      blockType: { kind: "val", type: anyRef },
-      then: [
-        { op: "local.get", index: 0 },
-        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
-        { op: "local.get", index: 1 },
-        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
-        { op: "i32.add" },
-        { op: "call", funcIdx: boxI32Idx },
-      ],
-      else: [
-        // f64 path: convert both to f64, add, box as f64
-        { op: "local.get", index: 0 },
-        { op: "call", funcIdx: toF64Idx },
-        { op: "local.get", index: 1 },
-        { op: "call", funcIdx: toF64Idx },
-        { op: "f64.add" },
-        { op: "call", funcIdx: boxF64Idx },
-      ],
-    } as Instr,
-  ];
+  // (numeric arm built lazily via `buildNumericArm()` below — see the note there
+  //  on why each `if` arm must be a distinct array.)
 
   // ToString(operand: ref $AnyValue) → ref $AnyString, dispatched on the tag:
   //   - tag 6 (object/array ref): pull the actual ref out of `refval`, wrap to
@@ -884,6 +854,50 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     } as Instr,
   ];
 
+  // Build a fresh copy of the numeric instructions every time this is called.
+  // CRITICAL: the `then`/`else` arms of an `if` must be DISTINCT array objects
+  // (and contain distinct instruction objects). Several post-codegen passes
+  // mutate instruction nodes in place — most notably `shiftFuncIndices` in
+  // index.ts, which does `instr.funcIdx += delta` on every `call`. If the same
+  // array (or the same `call` instruction object) is reachable from two tree
+  // positions, those passes can visit it twice and double-shift the funcIdx,
+  // corrupting `__any_box_i32`/`__any_box_f64` call targets. (Before this fix,
+  // the non-concat fallback aliased `concatArm` to `numericArm`, then the outer
+  // `if` used `then: concatArm, else: numericArm` — the SAME array in both arms
+  // — which produced exactly that corruption: "expected (ref null N), got i32"
+  // / "call[0] expected type (ref null 5), found i32.add" in fast mode.)
+  const buildNumericArm = (): Instr[] => [
+    // if tagA == 2 && tagB == 2 → i32 add
+    { op: "local.get", index: 2 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.eq" },
+    { op: "local.get", index: 3 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.eq" },
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: anyRef },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
+        { op: "local.get", index: 1 },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 1 },
+        { op: "i32.add" },
+        { op: "call", funcIdx: boxI32Idx },
+      ],
+      else: [
+        // f64 path: convert both to f64, add, box as f64
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: toF64Idx },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: toF64Idx },
+        { op: "f64.add" },
+        { op: "call", funcIdx: boxF64Idx },
+      ],
+    } as Instr,
+  ];
+
   const concatArm: Instr[] = anyAddCanConcat
     ? [
         // box a tag-5 $AnyValue around __str_concat(ToString(a), ToString(b))
@@ -897,7 +911,11 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
         { op: "extern.convert_any" } as Instr,
         { op: "struct.new", typeIdx: anyTypeIdx },
       ]
-    : numericArm;
+    : // No concat support (e.g. fast mode): the stringy `then` arm can never be
+      // reached at runtime (no tag-5/6 operands without native strings), but it
+      // must still be a SEPARATE, well-typed instruction array from the `else`
+      // numeric arm so the two arms don't alias. Use a fresh numeric copy.
+      buildNumericArm();
 
   addHelper(
     "__any_add",
@@ -934,8 +952,11 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
         // string concatenation (§13.15.3 step 2) when either operand is a
         // string or an object/array (whose ToPrimitive→toString is a string).
         then: concatArm,
-        // numeric addition (§13.15.3 step 3).
-        else: numericArm,
+        // numeric addition (§13.15.3 step 3). A FRESH numeric arm (distinct
+        // array + distinct instruction objects) so it never aliases `concatArm`
+        // — see the `buildNumericArm` note above on why in-place index-shift
+        // passes corrupt shared `if` arms.
+        else: buildNumericArm(),
       } as Instr,
     ],
     [

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -36,6 +36,7 @@ import { ensureNativeStringHelpers } from "./native-strings.js";
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringImports, addUnionImports, resolveNativeTypeAnnotation, resolveWasmType } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
@@ -2806,6 +2807,19 @@ function compileAnyBinaryDispatch(
 export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): ValType {
   const noJsHost = ctx.standalone === true || ctx.wasi === true;
 
+  // #1988: in standalone/WASI the §13.15.3 string-vs-numeric decision must be
+  // made on the ToPrimitive(default) results, not the raw operands — an object
+  // or array reduces (valueOf→toString) to a STRING, which forces string
+  // concatenation. The native `__to_primitive` helper that performs that
+  // reduction is registered by `ensureObjectRuntime`. Run it here, BEFORE the
+  // operands are compiled into `fctx.body`, so any one-time funcIdx setup it
+  // does cannot desync the current function body. It registers only defined
+  // funcs (no import shift) and is idempotent, so this is a no-op when the
+  // object runtime is already present.
+  if (noJsHost && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    ensureObjectRuntime(ctx);
+  }
+
   // Compile both operands to externref temps. Passing the externref hint keeps a
   // runtime string boxed (no ToNumber coercion) so §13.15.3 can concatenate.
   const lType = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
@@ -2853,12 +2867,45 @@ export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.
     const typeofStr = ctx.funcMap.get("__typeof_string");
     const unboxNum = ctx.funcMap.get("__unbox_number");
     const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
+    // #1988: the native ToPrimitive helper registered by `ensureObjectRuntime`
+    // (called at the top of this function). Reducing the operands to primitives
+    // BEFORE the string-vs-numeric test is what §13.15.3 requires — an object /
+    // array operand becomes its toString string, forcing concatenation. When it
+    // is unavailable (older minimal standalone path) we degrade to the previous
+    // raw-operand dispatch rather than failing.
+    const toPrimIdx = ctx.funcMap.get("__to_primitive");
     if (typeofStr !== undefined && unboxNum !== undefined && concatIdx !== undefined) {
       // ToString(externref) → ref $AnyString, via the runtime walker (handles
       // boxed strings, numbers, null/undefined, and struct valueOf/toString).
       const externToStr = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);
       const finalToStr = ctx.funcMap.get("__extern_toString") ?? externToStr;
+
+      // §13.15.3 step 1-2: lprim = ToPrimitive(left, default); rprim =
+      // ToPrimitive(right, default). The "default" hint maps to valueOf→toString
+      // ordering; `__to_primitive` treats a null hint as default. Plain objects
+      // and arrays (no exotic valueOf) reduce to their toString string, so the
+      // string test below then forces concatenation. Reduce into fresh temps so
+      // both the typeof test and the two arms operate on the SAME primitives
+      // (no double-evaluation of valueOf/toString).
+      const lPrim = allocTempLocal(fctx, { kind: "externref" });
+      const rPrim = allocTempLocal(fctx, { kind: "externref" });
+      if (toPrimIdx !== undefined) {
+        fctx.body.push({ op: "local.get", index: lTmp });
+        fctx.body.push({ op: "ref.null.extern" } as Instr); // default hint
+        fctx.body.push({ op: "call", funcIdx: toPrimIdx } as Instr);
+        fctx.body.push({ op: "local.set", index: lPrim });
+        fctx.body.push({ op: "local.get", index: rTmp });
+        fctx.body.push({ op: "ref.null.extern" } as Instr);
+        fctx.body.push({ op: "call", funcIdx: toPrimIdx } as Instr);
+        fctx.body.push({ op: "local.set", index: rPrim });
+      } else {
+        // Degrade: no ToPrimitive available — carry the raw operands through.
+        fctx.body.push({ op: "local.get", index: lTmp });
+        fctx.body.push({ op: "local.set", index: lPrim });
+        fctx.body.push({ op: "local.get", index: rTmp });
+        fctx.body.push({ op: "local.set", index: rPrim });
+      }
 
       const emitToAnyString = (tmp: number): Instr[] => [
         { op: "local.get", index: tmp },
@@ -2867,18 +2914,19 @@ export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.
         { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
       ];
 
-      // if (__typeof_string(l) | __typeof_string(r)) → concat both as strings
-      //                                      else      → f64.add(unbox, unbox)
+      // if (__typeof_string(lprim) | __typeof_string(rprim)) → concat both as
+      //                                            strings
+      //                                      else            → f64.add(unbox, unbox)
       const concatArm: Instr[] = [
-        ...emitToAnyString(lTmp),
-        ...emitToAnyString(rTmp),
+        ...emitToAnyString(lPrim),
+        ...emitToAnyString(rPrim),
         { op: "call", funcIdx: concatIdx } as Instr,
         { op: "extern.convert_any" } as Instr,
       ];
       const numericArm: Instr[] = [
-        { op: "local.get", index: lTmp },
+        { op: "local.get", index: lPrim },
         { op: "call", funcIdx: unboxNum } as Instr,
-        { op: "local.get", index: rTmp },
+        { op: "local.get", index: rPrim },
         { op: "call", funcIdx: unboxNum } as Instr,
         { op: "f64.add" } as Instr,
       ];
@@ -2888,9 +2936,9 @@ export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.
       const finalBoxNum = ctx.funcMap.get("__box_number") ?? boxNum;
       numericArm.push({ op: "call", funcIdx: finalBoxNum } as Instr);
 
-      fctx.body.push({ op: "local.get", index: lTmp });
+      fctx.body.push({ op: "local.get", index: lPrim });
       fctx.body.push({ op: "call", funcIdx: typeofStr } as Instr);
-      fctx.body.push({ op: "local.get", index: rTmp });
+      fctx.body.push({ op: "local.get", index: rPrim });
       fctx.body.push({ op: "call", funcIdx: typeofStr } as Instr);
       fctx.body.push({ op: "i32.or" } as Instr);
       fctx.body.push({
@@ -2899,6 +2947,8 @@ export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.
         then: concatArm,
         else: numericArm,
       } as Instr);
+      releaseTempLocal(fctx, rPrim);
+      releaseTempLocal(fctx, lPrim);
       releaseTempLocal(fctx, rTmp);
       releaseTempLocal(fctx, lTmp);
       return { kind: "externref" };

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -5630,6 +5630,34 @@ export function ensureAnyToStringHelper(ctx: CodegenContext): number {
     } as Instr,
   ];
 
+  // (#1988) A standalone `any` number flows as a `__box_number_struct`
+  // externref (see `__box_number` / type-coercion i32→AnyValue boxing), NOT a
+  // $AnyValue tag-3 box. ToString of one — e.g. the `1` in `1 + {}` after
+  // ToPrimitive — must yield its decimal, not the "[object Object]" fallback.
+  // Add a recognition arm when both the box type and the formatter are present.
+  const boxNumIdx = ctx.nativeBoxNumberTypeIdx;
+  const boxNumberArm: Instr[] =
+    boxNumIdx >= 0 && numToStrIdx !== undefined
+      ? [
+          { op: "local.get", index: L_V },
+          { op: "ref.test", typeIdx: boxNumIdx } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: strRef },
+            then: [
+              { op: "local.get", index: L_V },
+              { op: "ref.cast", typeIdx: boxNumIdx } as Instr,
+              { op: "struct.get", typeIdx: boxNumIdx, fieldIdx: 0 },
+              { op: "call", funcIdx: numToStrIdx },
+              { op: "any.convert_extern" } as Instr,
+              { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
+            ],
+            // else (null ref, plain object, vec, …) → "[object Object]"
+            else: litStr("[object Object]"),
+          } as Instr,
+        ]
+      : litStr("[object Object]");
+
   const body: Instr[] = [
     // if (v is a $AnyString) return it directly
     { op: "local.get", index: L_V },
@@ -5651,8 +5679,9 @@ export function ensureAnyToStringHelper(ctx: CodegenContext): number {
             { op: "local.set", index: L_BOX },
             ...boxDispatch,
           ],
-          // else (null ref, plain object, vec, …) → "[object Object]"
-          else: litStr("[object Object]"),
+          // else: a boxed-number externref → decimal; everything else →
+          // "[object Object]" (Phase-1 fallback).
+          else: boxNumberArm,
         } as Instr,
       ],
     } as Instr,

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -1132,6 +1132,35 @@ export function coerceType(
     if (isAnyValue(from, ctx) && !isAnyValue(to, ctx)) {
       ensureAnyHelpers(ctx);
       const toIdx = (to as { typeIdx: number }).typeIdx;
+      // (#1988) A native string is boxed into $AnyValue tag 5 with its payload
+      // in `externval` (field 4, externref-wrapped $AnyString) — NOT `refval`
+      // (field 3, eqref). The generic unbox below reads field 3, so a tag-5
+      // string box (e.g. the result of the `__any_add` concat arm) deref'd null.
+      // When the target is a native-string type, pull the string out of
+      // externval and cast it; fall through to the field-3 eqref path for every
+      // other GC ref target (objects/arrays/tag 6).
+      const isNativeStrTarget =
+        ctx.nativeStrings &&
+        (toIdx === ctx.anyStrTypeIdx || (ctx.nativeStrTypeIdx >= 0 && toIdx === ctx.nativeStrTypeIdx));
+      if (isNativeStrTarget) {
+        const tmpStr = allocTempLocal(fctx, { kind: "anyref" } as ValType);
+        fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 4 }); // externval
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+        fctx.body.push({ op: "local.tee", index: tmpStr });
+        fctx.body.push({ op: "ref.test", typeIdx: toIdx });
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
+          then: [
+            { op: "local.get", index: tmpStr },
+            { op: "ref.cast_null", typeIdx: toIdx },
+          ],
+          else: [{ op: "ref.null", typeIdx: toIdx }],
+        });
+        fctx.body.push({ op: "ref.as_non_null" } as Instr);
+        releaseTempLocal(fctx, tmpStr);
+        return;
+      }
       fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 3 });
       // Guarded cast: eqref → ref $X
       const tmpUnbox = allocTempLocal(fctx, { kind: "eqref" } as ValType);

--- a/tests/issue-1988.test.ts
+++ b/tests/issue-1988.test.ts
@@ -34,7 +34,7 @@ describe("#1988 any + ref operand applies ToPrimitive (JS-host / default mode)",
     await assertEquivalent(`export function f(o: any): any { return o + 1; }`, [{ fn: "f", args: [{}] }]);
   });
 
-  it("{} + {} → \"[object Object][object Object]\"", async () => {
+  it('{} + {} → "[object Object][object Object]"', async () => {
     await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [{}, {}] }]);
   });
 
@@ -42,8 +42,10 @@ describe("#1988 any + ref operand applies ToPrimitive (JS-host / default mode)",
     await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [[], []] }]);
   });
 
-  it("[1,2] + 1 → \"1,21\"", async () => {
-    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [[1, 2], 1] }]);
+  it('[1,2] + 1 → "1,21"', async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [
+      { fn: "f", args: [[1, 2], 1] },
+    ]);
   });
 
   it("both numbers stay numeric (no false concat)", async () => {
@@ -71,11 +73,11 @@ describe("#1988 any + ref operand applies ToPrimitive (standalone / pure WasmGC)
     return (instance.exports as Record<string, () => number>).test();
   }
 
-  it("1 + {} length is 16 (\"1[object Object]\")", async () => {
+  it('1 + {} length is 16 ("1[object Object]")', async () => {
     expect(await concatLen(`const o: any = {}; return f(1, o).length;`)).toBe(16);
   });
 
-  it("{} + {} length is 30 (two \"[object Object]\")", async () => {
+  it('{} + {} length is 30 (two "[object Object]")', async () => {
     expect(await concatLen(`const o: any = {}; return f(o, o).length;`)).toBe(30);
   });
 

--- a/tests/issue-1988.test.ts
+++ b/tests/issue-1988.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1988 — `any + any` (and `any + number`) with an object/array operand must
+// apply §13.15.3 ApplyStringOrNumericBinaryOperator: ToPrimitive(default) on
+// both operands, then if either is a String → string CONCATENATION, else
+// numeric add. A plain object's ToPrimitive→toString is "[object Object]", so
+// `1 + {}` is "1[object Object]", not NaN.
+//
+// JS-host mode delegates `+` to `__host_add` (JS `+`) and was already correct.
+// The regression lived in the standalone / pure-WasmGC path: `__any_add`
+// (tagged-union helper) and `emitAnyAdd` (externref helper) only had i32/f64
+// arms, so a tag-5 (string) or tag-6 (object/array ref) operand wrongly hit the
+// numeric arm → NaN. The fix routes ToPrimitive-string operands through native
+// string concatenation (`__extern_toString` + `__str_concat`).
+//
+// Standalone assertions read the concat result back through a `string`-typed
+// return (`(a + b) as string`) and check `.length`, which exercises the native
+// `$AnyValue` tag-5 → `$AnyString` unbox (also fixed here: it read `refval`
+// instead of `externval`). Comparing the `any` result directly against a string
+// literal is intentionally avoided — `any === stringLiteral` content comparison
+// is a separate, still-open gap (tracked elsewhere) and would confound this
+// test. Array-element joins (`[1,2] + 1` → "1,21") in standalone depend on the
+// array-toString-via-join path (#1997/#1998) and are out of scope here.
+import { describe, expect, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+import { compile } from "../src/index.js";
+
+describe("#1988 any + ref operand applies ToPrimitive (JS-host / default mode)", () => {
+  it("1 + {} → ToString concatenation", async () => {
+    await assertEquivalent(`export function f(o: any): any { return 1 + o; }`, [{ fn: "f", args: [{}] }]);
+  });
+
+  it("{} + 1 → ToString concatenation", async () => {
+    await assertEquivalent(`export function f(o: any): any { return o + 1; }`, [{ fn: "f", args: [{}] }]);
+  });
+
+  it("{} + {} → \"[object Object][object Object]\"", async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [{}, {}] }]);
+  });
+
+  it("[] + [] → empty string", async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [[], []] }]);
+  });
+
+  it("[1,2] + 1 → \"1,21\"", async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [[1, 2], 1] }]);
+  });
+
+  it("both numbers stay numeric (no false concat)", async () => {
+    await assertEquivalent(`export function f(a: any, b: any): any { return a + b; }`, [{ fn: "f", args: [40, 2] }]);
+  });
+});
+
+describe("#1988 any + ref operand applies ToPrimitive (standalone / pure WasmGC)", () => {
+  async function compileStandalone(s: string) {
+    const r = await compile(s, { target: "standalone" });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    return r;
+  }
+
+  // The `+` result is read as a native string; `.length` confirms the concat
+  // produced the right characters without depending on the (separately-broken)
+  // any-vs-literal string comparison.
+  async function concatLen(body: string): Promise<number> {
+    const src = `export function f(a: any, b: any): string { return (a + b) as string; }
+                 export function test(): number { ${body} }`;
+    const r = await compileStandalone(src);
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+    (r.importObject as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+    return (instance.exports as Record<string, () => number>).test();
+  }
+
+  it("1 + {} length is 16 (\"1[object Object]\")", async () => {
+    expect(await concatLen(`const o: any = {}; return f(1, o).length;`)).toBe(16);
+  });
+
+  it("{} + {} length is 30 (two \"[object Object]\")", async () => {
+    expect(await concatLen(`const o: any = {}; return f(o, o).length;`)).toBe(30);
+  });
+
+  it("string + string any concatenates (length 2)", async () => {
+    expect(await concatLen(`const a: any = "a"; const b: any = "b"; return f(a, b).length;`)).toBe(2);
+  });
+
+  it("does not leak a JS host import", async () => {
+    const r = await compileStandalone(`export function f(a: any, b: any): any { return a + b; }`);
+    expect(r.imports.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Standalone / pure-WasmGC `any + any` (and `any + number`) with an object or array operand produced NaN instead of applying §13.15.3 ApplyStringOrNumericBinaryOperator. `1 + {}` → NaN (should be `"1[object Object]"`), `[] + []` → 0 (should be `""`). Host/gc mode was already correct (routes `+` through `__host_add`).

## Root cause

Both standalone `+` lowerings decided string-concat-vs-numeric on the **raw** operand types instead of the ToPrimitive results. Per §13.15.3, an object/array reduces (valueOf→toString) to a string, which forces string concatenation — but a raw object/array isn't a string, so they fell into the f64 numeric arm → NaN.

## Fix

- **`emitAnyAdd`** (`binary-ops.ts`, the externref path actually taken for `f(a: any, b: any)` in standalone): reduce both operands through the native `__to_primitive` (default hint) first, then test stringness on the **primitives**.
- **`__any_add`** (`any-helpers.ts`, the `$AnyValue` tagged-union helper): add a §13.15.3 string-concat arm for tag-5 (string) / tag-6 (object/array ref) operands via `__extern_toString` + `__str_concat`, boxing the result as tag 5; numeric arm otherwise.
- **`__any_to_string`** (`native-strings.ts`): recognise a `__box_number_struct` externref (how a standalone `any` number is carried) and format it via `number_toString` instead of "[object Object]".
- **`$AnyValue`→native-string unbox** (`type-coercion.ts`): read `externval` (field 4) for a tag-5 string, not `refval` (field 3) — the latter deref'd null on a concat result.

No host import is added in standalone (verified). Host/gc mode is byte-unchanged.

## Tests

`tests/issue-1988.test.ts` (new) — 10/10: host equivalence (`1+{}`, `{}+1`, `{}+{}`, `[]+[]`, `[1,2]+1`, numeric) + standalone `.length` checks (`1+{}`→16, `{}+{}`→30, string+string→2, zero host imports).

## Out of scope / residual

- Standalone **array-element joins** (`[1,2] + 1` → `"1,21"`) resolve the array operand's toString via the Phase-1 "[object Object]" fallback; that join path is owned by #1997/#1998 (done). Host matches Node.
- `any === stringLiteral` content comparison is a separate open gap.

Closes #1988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)