### PR TITLE
fix(#2079): standalone native generators — yields in control flow (#680 Phase 2)

### DIFF
--- a/plan/issues/2079-standalone-generators-funcindex-ce.md
+++ b/plan/issues/2079-standalone-generators-funcindex-ce.md
@@ -1,10 +1,11 @@
 ---
 id: 2079
 title: "standalone: function* CEs with 'function index out of range' (late-import shift guard) — wasm-native generator lowering regressed; manual protocol leaks env import"
-status: ready
+status: done
+completed: 2026-06-15
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-15
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -55,3 +56,87 @@ Make the #1665 native generator lowering the standalone path end-to-end
 #1665 (done — regressed/residual standalone), #2043 (guard correct),
 #2040 (destructuring semantics, different). Filed as the concrete
 standalone-generator residual.
+
+## Implementation (sdev1, 2026-06-15)
+
+### Re-diagnosis — the simple funcindex CE was already fixed
+
+On current main the original repro (`function* g(){ yield 1; yield 2; return 3; }`
++ for-of, and the manual `it.next()` protocol) compiles **standalone with zero
+imports and runs correctly**. The late-import funcindex CE described in the
+title no longer reproduces for sequential numeric yields — #1665's Phase-1
+state machine handles them.
+
+The ACTUAL residual blocking the ~960-test ROI is the **"sequential numeric
+yields" hard CE** in `buildNativeGeneratorPlan`: it bailed (→ the scoped
+`#680` compile diagnostic in standalone) on **any `while`/`for`/`do-while` loop
+or `if`/`else` that contains a `yield`**. Loops/conditionals are the dominant
+generator shape (`while(i<n){yield i; i++}`, `for(...)`), so this was the bulk
+of the gap. This is exactly #680 "Phase 2" (architect estimate: "covers 85%").
+
+### Fix — state-graph + trampoline (`src/codegen/generators-native.ts`)
+
+Replaced the linear-segment plan with a **state-graph** plan. Each state has a
+straight-line, yield-free prelude plus an explicit terminator:
+`yield(next)` · `return(expr)` · `done` · `jump(next)` · `branch(cond, then,
+else)`. Structured control flow lowers to states with explicit successor ids:
+
+- `while`/`do-while`/`for` → a header state (`branch` on cond → body / exit)
+  and a body whose tail `jump`s back to the header (the loop back-edge). The
+  induction variable and all body-declared numeric locals **spill** to the
+  state struct so they survive each suspension.
+- `if`/`else` → a `branch` state into then/else entry states that `jump` to a
+  shared join state.
+- nested combinations recurse, producing more states.
+
+The resume function (`__gen_resume_*`) is now a **trampoline**:
+`block $exit { loop $dispatch { if(state==0){…} else if(state==1){…} … else
+{done} } } local.get $__result`. A `yield`/`return` writes `$__result` and
+`br`s out of the block (return to caller); a `jump`/`branch` sets the `state`
+field and `br`s back to the dispatch `loop` to re-enter at the new state within
+the **same** `next()` call. This models user loops as state self-transitions in
+the trampoline (no wasm `loop` is emitted for the user loop), so each state body
+stays straight-line and reuses `compileStatement`/`compileExpression` verbatim.
+
+A `return` nested inside control flow (e.g. `if (i===3) return 99;`) is routed
+through the structural lowering (not `compileStatement`) so it becomes a proper
+`{value, done:true}` completion terminator instead of a raw wasm `return` (which
+mis-coerced the value to the result-ref type → null deref).
+
+### Late-import funcindex hardening (the #1899 class, real this time)
+
+Phase-2 bodies compile arbitrary numeric expressions that **lazily register
+helper functions** (`%` → f64-modulo, etc.) while the resume body is being
+emitted. The old code computed `info.resumeFuncIdx = numImportFuncs +
+functions.length` up front, then pushed the resume function **last** — so a
+helper registered mid-body shifted the resume function past its captured index,
+and every baked `call resumeFuncIdx` (the for-of driver, `.next()` dispatch) hit
+the **helper** instead. Caught by the `if (i % 2 === 0) yield i` repro:
+`call 52` resolved to the modulo helper ("not enough arguments on the stack").
+
+Fix: **reserve the resume function's slot with a placeholder BEFORE emitting the
+body** (same idiom as the accessor drivers in `accessor-driver.ts`), then fill
+the placeholder in place. `funcIdx` stays stable while helpers append after it.
+This also hardens the Phase-1 path against the same class.
+
+### Scope kept conservative (clean bail, never wrong/invalid)
+
+Unsupported shapes still return `null` → the scoped `#680` diagnostic (no
+crash, no wrong answer, no invalid Wasm — verified): `yield*`, `for-of`/`for-in`
+yielding, `break`/`continue` targeting a yield-loop, `switch`/labeled
+statements with yields, `try/catch` with yields, and non-numeric yields/spills.
+These are follow-ups under #2157.
+
+### Validation
+
+- `tests/issue-2079-standalone-generator-control-flow.test.ts` — 13 cases
+  (while/for/do-while, if-else, nested loops, yields around loops, if-in-loop
+  funcindex guard, return-in-loop, manual next(), `.next(value)` send,
+  `.return()` early completion, infinite-generator partial consume, sequential
+  regression). All pass, all zero-import standalone.
+- No regression: `issue-680`, `issue-1665`, `issue-1665-standalone-generator-forof`,
+  `generators`, async-iteration / async-function equivalence — all green.
+  (`tests/*helpers.js`-importing suites fail to load on main too — untracked
+  `tests/helpers.js`, pre-existing infra gotcha — and
+  `arguments-nested-and-loops.test.ts:181` fails identically on unmodified main.)
+- `tsc --noEmit` clean; `check:ir-fallbacks` OK (no unintended increases).

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -2,10 +2,28 @@
 /**
  * Wasm-native generator lowering (#680).
  *
- * This is the Phase 1 state-machine path for no-JS-host targets. It handles
- * simple, top-level sequential `function*` declarations with numeric yields and
- * an optional numeric `return`. More complex generator shapes keep using the
- * legacy JS-host buffer path when a JS host is available.
+ * No-JS-host state-machine path for `function*` declarations. The body is
+ * decomposed into a flat list of **states**; each `yield` is a suspension
+ * checkpoint that spills live locals into a WasmGC state struct and returns a
+ * `{value, done}` result. `next()` re-enters a generated resume function at the
+ * saved state.
+ *
+ * Phase 1 (#1665) handled a linear sequence of sequential numeric yields with
+ * an optional numeric `return`.
+ *
+ * Phase 2 (#2079) adds yields inside structured control flow — `while` / `for`
+ * / `do-while` loops and `if` / `else` — by lowering each construct to states
+ * with explicit successor-state transitions and driving them with a trampoline:
+ * the resume function wraps the state dispatch in a `loop`, a yield/return
+ * `br`s out producing the result, and a non-yielding transition (loop back-edge,
+ * if-join, sequential boundary) sets the state field and `br`s back to the
+ * dispatch top to re-enter at the new state within the same `next()` call.
+ *
+ * Constraints kept for this slice (bail to the scoped diagnostic / host path):
+ *   - yielded expressions and spilled locals are numeric (f64);
+ *   - `yield*`, `break`/`continue` targeting a yield-loop, `switch`/labeled
+ *     statements with yields, and `try/catch` with yields are not modeled
+ *     (try/finally without catch is, as in Phase 1).
  */
 import { ts } from "../ts-api.js";
 import { isBooleanType, isNumberType } from "../checker/type-mapper.js";
@@ -26,18 +44,45 @@ const RESULT_DONE_FIELD = 1;
 const PARAM_FIELD_OFFSET = 4;
 const MAX_NATIVE_GENERATOR_STATES = 256;
 
-interface NativeGeneratorSegment {
-  resumeBindings: string[];
-  abruptResume?: {
-    finalizers: readonly ts.Statement[][];
-  };
+/**
+ * Terminator of a generator state — what happens after the state's straight-line
+ * prelude statements run.
+ *
+ *  - `yield`   suspend: emit the yielded value as `{value, done:0}`, set the
+ *              state to `next` and return to the caller.
+ *  - `return`  complete with a value: `{value, done:1}`.
+ *  - `done`    complete with no value: `{undefined, done:1}`.
+ *  - `jump`    transfer control to state `next` WITHOUT suspending (loop
+ *              back-edge / if-join / sequential boundary) — re-enters the
+ *              trampoline in the same `next()` call.
+ *  - `branch`  evaluate a numeric condition; if truthy jump to `thenState`,
+ *              else jump to `elseState`. No suspension.
+ */
+type StateTerminator =
+  | { kind: "yield"; expr: ts.Expression | undefined; next: number }
+  | { kind: "return"; expr: ts.Expression | undefined }
+  | { kind: "done" }
+  | { kind: "jump"; next: number }
+  | { kind: "branch"; cond: ts.Expression; negate: boolean; thenState: number; elseState: number };
+
+interface NativeGeneratorState {
+  /** Straight-line, yield-free statements to run on entering this state. */
   statements: ts.Statement[];
-  yieldExpr?: ts.YieldExpression;
-  returnStmt?: ts.ReturnStatement;
+  /**
+   * Local names bound from the `.next(value)` argument on resume into this
+   * state (the suspended `let x = yield …` target).
+   */
+  resumeBindings: string[];
+  /**
+   * Active `finally` blocks (innermost last) whose statements run on a
+   * `GeneratorResumeAbrupt` (`.return()`) hitting the yield that leads here.
+   */
+  abruptResume?: { finalizers: readonly ts.Statement[][] };
+  terminator: StateTerminator;
 }
 
 interface NativeGeneratorPlan {
-  segments: NativeGeneratorSegment[];
+  states: NativeGeneratorState[];
   spills: string[];
 }
 
@@ -56,11 +101,30 @@ function isNumericExpression(ctx: CodegenContext, expr: ts.Expression | undefine
 }
 
 function statementContainsYield(stmt: ts.Statement): boolean {
+  return nodeContainsYield(stmt);
+}
+
+/**
+ * A `return` anywhere in this statement (not descending into nested functions).
+ * Used to route `if`/loops that contain a `return` through the structural
+ * lowering even when they have no yield — a `return` inside a generator must
+ * produce `{value, done:true}`, NOT a raw wasm `return` (which `compileStatement`
+ * would emit, mis-coercing the value to the resume function's result-ref type).
+ */
+function statementContainsReturn(stmt: ts.Statement): boolean {
   let found = false;
   function visit(node: ts.Node): void {
     if (found) return;
-    if (ts.isYieldExpression(node)) {
+    if (ts.isReturnStatement(node)) {
       found = true;
+      return;
+    }
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
       return;
     }
     ts.forEachChild(node, visit);
@@ -69,52 +133,100 @@ function statementContainsYield(stmt: ts.Statement): boolean {
   return found;
 }
 
+/** Statement needs structural state-graph lowering (vs straight-line prelude). */
+function statementNeedsStructuralLowering(stmt: ts.Statement): boolean {
+  if (statementContainsYield(stmt)) return true;
+  // A bare/top-level `return` is handled by the caller's `return` terminator;
+  // but a `return` nested inside control flow needs structural lowering so it
+  // still maps to a generator-completion terminator.
+  if (!ts.isReturnStatement(stmt) && statementContainsReturn(stmt)) return true;
+  return false;
+}
+
+function nodeContainsYield(root: ts.Node): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (ts.isYieldExpression(node)) {
+      found = true;
+      return;
+    }
+    // Do not descend into nested function bodies — a `yield` there belongs to
+    // a different (inner) generator and must not split this one.
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(root, visit);
+  return found;
+}
+
+/**
+ * Plan builder. Walks the generator body producing a state graph. Returns
+ * `null` when any shape is outside the supported subset, so callers fall back
+ * to the host path (or the scoped diagnostic in standalone).
+ */
 function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclaration): NativeGeneratorPlan | null {
   if (!decl.body) return null;
-  const segments: NativeGeneratorSegment[] = [];
+
+  const states: NativeGeneratorState[] = [];
   const spills: string[] = [];
   const spillSet = new Set<string>();
-  let current: ts.Statement[] = [];
-  let pendingResumeBindings: string[] = [];
-  let pendingAbruptResume: NativeGeneratorSegment["abruptResume"] | undefined;
-
   const addSpill = (name: string): void => {
     if (spillSet.has(name)) return;
     spillSet.add(name);
     spills.push(name);
   };
 
-  const pushSegment = (yieldExpr: ts.YieldExpression | undefined, returnStmt: ts.ReturnStatement | undefined): void => {
-    segments.push({
-      resumeBindings: pendingResumeBindings,
-      abruptResume: pendingAbruptResume,
-      statements: current,
-      yieldExpr,
-      returnStmt,
-    });
-    pendingResumeBindings = [];
-    pendingAbruptResume = undefined;
-    current = [];
-  };
+  // Builder is structured as a recursive lowering over the statement list with
+  // an explicit "current state being filled" cursor. Because Wasm has no goto,
+  // we model control flow with state ids resolved up-front: we reserve a state
+  // id, then fill it.
+  let ok = true;
 
-  const emitYieldSegment = (
-    yieldExpr: ts.YieldExpression,
-    bindSentTo: string | undefined,
-    activeFinalizers: readonly ts.Statement[][],
-  ): boolean => {
-    if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return false;
-    pushSegment(yieldExpr, undefined);
-    pendingAbruptResume = {
-      // GeneratorResumeAbrupt resumes at the suspended yield with a return
-      // completion. Any enclosing finally blocks run nearest-first.
-      finalizers: [...activeFinalizers].reverse(),
+  // The state currently being constructed: its prelude statements + pending
+  // resume bindings / abrupt-resume context.
+  let curStatements: ts.Statement[] = [];
+  let curResumeBindings: string[] = [];
+  let curAbrupt: NativeGeneratorState["abruptResume"] | undefined;
+  let curUsed = false; // becomes the id below once we know it
+
+  // Reserve the state id for the in-progress state.
+  let curId = reserveState();
+
+  function reserveState(): number {
+    const id = states.length;
+    // Placeholder; filled by finishState. Marked with a sentinel terminator.
+    states.push({
+      statements: [],
+      resumeBindings: [],
+      terminator: { kind: "done" },
+    });
+    return id;
+  }
+
+  function startState(): number {
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    curUsed = false;
+    return reserveState();
+  }
+
+  function finishState(id: number, terminator: StateTerminator): void {
+    states[id] = {
+      statements: curStatements,
+      resumeBindings: curResumeBindings,
+      abruptResume: curAbrupt,
+      terminator,
     };
-    if (bindSentTo) {
-      addSpill(bindSentTo);
-      pendingResumeBindings = [bindSentTo];
-    }
-    return true;
-  };
+  }
 
   const tryYieldDeclaration = (stmt: ts.Statement): { name: string; yieldExpr: ts.YieldExpression } | null => {
     if (!ts.isVariableStatement(stmt)) return null;
@@ -128,69 +240,413 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclarat
   const statementsAreYieldFree = (statements: readonly ts.Statement[]): boolean =>
     statements.every((stmt) => !statementContainsYield(stmt));
 
-  const visitStatements = (
-    statements: readonly ts.Statement[],
-    activeFinalizers: readonly ts.Statement[][],
-  ): boolean => {
+  /**
+   * Lower a list of statements into the state graph, threading the "current
+   * state" cursor. Each `yield` closes the current state with a yield
+   * terminator pointing at a freshly-reserved successor and continues filling
+   * that successor. Loops/ifs containing yields reserve their header / branch
+   * states and wire jumps. Returns false (sets ok=false) on unsupported shapes.
+   *
+   * `activeFinalizers` carries enclosing try/finally bodies for abrupt-resume.
+   */
+  function lowerStatements(statements: readonly ts.Statement[], activeFinalizers: readonly ts.Statement[][]): boolean {
     for (const stmt of statements) {
+      if (!ok) return false;
       if (stmt.kind === ts.SyntaxKind.EmptyStatement) continue;
 
+      // A top-level `return` always terminates the current state. (Routed here
+      // first so a bare `return expr;` is a completion terminator, not a raw
+      // wasm `return` from compileStatement.)
+      if (ts.isReturnStatement(stmt)) {
+        if (!isNumericExpression(ctx, stmt.expression)) return fail();
+        collectSpillsIn(stmt);
+        finishState(curId, { kind: "return", expr: stmt.expression });
+        // Unreachable tail — start a fresh (dead) state so the cursor stays
+        // valid; it will simply never be entered.
+        curId = startState();
+        // Statements after an unconditional return are dead.
+        return true;
+      }
+
+      // Straight-line statement (no yield, no nested return): append to the
+      // current state's prelude and let compileStatement emit it verbatim.
+      if (!statementNeedsStructuralLowering(stmt)) {
+        collectSpillsIn(stmt);
+        curStatements.push(stmt);
+        continue;
+      }
+
+      // Statement that CONTAINS a yield somewhere — must be modeled.
+      // 1) `yield expr;` as an expression statement.
       if (ts.isExpressionStatement(stmt) && ts.isYieldExpression(stmt.expression)) {
-        if (!emitYieldSegment(stmt.expression, undefined, activeFinalizers)) return false;
+        if (!emitYield(stmt.expression, undefined, activeFinalizers)) return false;
         continue;
       }
 
-      const yieldedDeclaration = tryYieldDeclaration(stmt);
-      if (yieldedDeclaration) {
-        if (!emitYieldSegment(yieldedDeclaration.yieldExpr, yieldedDeclaration.name, activeFinalizers)) return false;
+      // 2) `let x = yield expr;`
+      const yd = tryYieldDeclaration(stmt);
+      if (yd) {
+        if (!emitYield(yd.yieldExpr, yd.name, activeFinalizers)) return false;
         continue;
       }
 
+      // 3) try/finally (no catch) wrapping yields.
       if (ts.isTryStatement(stmt)) {
-        if (stmt.catchClause || !stmt.finallyBlock) return false;
-        if (!statementsAreYieldFree(stmt.finallyBlock.statements)) return false;
-        if (!visitStatements(stmt.tryBlock.statements, [...activeFinalizers, [...stmt.finallyBlock.statements]])) {
+        if (stmt.catchClause || !stmt.finallyBlock) return fail();
+        if (!statementsAreYieldFree(stmt.finallyBlock.statements)) return fail();
+        if (!lowerStatements(stmt.tryBlock.statements, [...activeFinalizers, [...stmt.finallyBlock.statements]])) {
           return false;
         }
-        current.push(...stmt.finallyBlock.statements);
+        // finally runs on the normal path too.
+        for (const f of stmt.finallyBlock.statements) {
+          collectSpillsIn(f);
+          curStatements.push(f);
+        }
         continue;
       }
 
-      if (ts.isReturnStatement(stmt)) {
-        if (statementContainsYield(stmt) || !isNumericExpression(ctx, stmt.expression)) return false;
-        pushSegment(undefined, stmt);
-        current = [];
-        break;
-      }
-
-      // Phase 1 allows ordinary expression statements in a segment so side
-      // effects before a yield stay lazy. Declarations/control flow need spill
-      // analysis and are left to follow-up phases.
-      if (ts.isExpressionStatement(stmt) && !statementContainsYield(stmt)) {
-        current.push(stmt);
+      // 4) if / else with yields in a branch.
+      if (ts.isIfStatement(stmt)) {
+        if (!lowerIf(stmt, activeFinalizers)) return false;
         continue;
       }
 
-      return false;
+      // 5) while / do-while / for loops with yields in the body.
+      if (ts.isWhileStatement(stmt)) {
+        if (!lowerWhile(stmt, activeFinalizers)) return false;
+        continue;
+      }
+      if (ts.isDoStatement(stmt)) {
+        if (!lowerDoWhile(stmt, activeFinalizers)) return false;
+        continue;
+      }
+      if (ts.isForStatement(stmt)) {
+        if (!lowerFor(stmt, activeFinalizers)) return false;
+        continue;
+      }
+
+      // 6) A bare block with yields — flatten it (no new scope modeling).
+      if (ts.isBlock(stmt)) {
+        if (!lowerStatements(stmt.statements, activeFinalizers)) return false;
+        continue;
+      }
+
+      return fail();
     }
-    return true;
-  };
-
-  if (!visitStatements(decl.body.statements, [])) return null;
-
-  if (
-    current.length > 0 ||
-    pendingResumeBindings.length > 0 ||
-    pendingAbruptResume !== undefined ||
-    segments.length === 0 ||
-    segments.at(-1)?.returnStmt === undefined
-  ) {
-    pushSegment(undefined, undefined);
+    return ok;
   }
 
-  const yieldCount = segments.filter((s) => s.yieldExpr !== undefined).length;
-  if (yieldCount > MAX_NATIVE_GENERATOR_STATES) return null;
-  return { segments, spills };
+  function fail(): boolean {
+    ok = false;
+    return false;
+  }
+
+  /** Close the current state at a yield and continue in a fresh successor. */
+  function emitYield(
+    yieldExpr: ts.YieldExpression,
+    bindSentTo: string | undefined,
+    activeFinalizers: readonly ts.Statement[][],
+  ): boolean {
+    if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return fail();
+    const next = startStateAfterYield(bindSentTo, activeFinalizers);
+    // The state we were filling (curIdBefore) is finished by startStateAfterYield's
+    // caller — handled inside helper to keep ids tidy.
+    finishCurrentAsYield(yieldExpr.expression, next, activeFinalizers, bindSentTo);
+    return ok;
+  }
+
+  // Reserve the successor of a yield and set up its resume binding/abrupt
+  // context, returning its id.
+  let pendingResumeBindings: string[] = [];
+  let pendingAbrupt: NativeGeneratorState["abruptResume"] | undefined;
+  function startStateAfterYield(
+    bindSentTo: string | undefined,
+    activeFinalizers: readonly ts.Statement[][],
+  ): number {
+    pendingResumeBindings = bindSentTo ? [bindSentTo] : [];
+    pendingAbrupt = { finalizers: [...activeFinalizers].reverse() };
+    if (bindSentTo) addSpill(bindSentTo);
+    return states.length; // successor id (reserved inside finishCurrentAsYield)
+  }
+
+  function finishCurrentAsYield(
+    expr: ts.Expression | undefined,
+    nextId: number,
+    _activeFinalizers: readonly ts.Statement[][],
+    _bindSentTo: string | undefined,
+  ): void {
+    finishState(curId, { kind: "yield", expr, next: nextId });
+    // Now actually create the successor and make it current.
+    curId = reserveState();
+    curStatements = [];
+    curResumeBindings = pendingResumeBindings;
+    curAbrupt = pendingAbrupt;
+    pendingResumeBindings = [];
+    pendingAbrupt = undefined;
+  }
+
+  /** if (cond) thenBlock [else elseBlock] — at least one branch yields. */
+  function lowerIf(stmt: ts.IfStatement, activeFinalizers: readonly ts.Statement[][]): boolean {
+    if (!isNumericExpression(ctx, stmt.expression)) return fail();
+    collectSpillsIn(stmt.expression);
+    // Close current state with a branch terminator. Reserve the join state and
+    // the branch entry states.
+    const branchHostId = curId;
+
+    // Reserve then-entry, else-entry, join.
+    const thenEntry = reserveState();
+    const hasElse = !!stmt.elseStatement;
+    const elseEntry = hasElse ? reserveState() : -1;
+    const joinId = reserveState();
+
+    finishState(branchHostId, {
+      kind: "branch",
+      cond: stmt.expression,
+      negate: false,
+      thenState: thenEntry,
+      elseState: hasElse ? elseEntry : joinId,
+    });
+
+    // Lower then-branch starting at thenEntry.
+    curId = thenEntry;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    if (!lowerStatements(thenBody(stmt.thenStatement), activeFinalizers)) return false;
+    finishState(curId, { kind: "jump", next: joinId });
+
+    if (hasElse) {
+      curId = elseEntry;
+      curStatements = [];
+      curResumeBindings = [];
+      curAbrupt = undefined;
+      if (!lowerStatements(thenBody(stmt.elseStatement!), activeFinalizers)) return false;
+      finishState(curId, { kind: "jump", next: joinId });
+    }
+
+    // Continue in the join state.
+    curId = joinId;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    return ok;
+  }
+
+  /** while (cond) body — body yields. */
+  function lowerWhile(stmt: ts.WhileStatement, activeFinalizers: readonly ts.Statement[][]): boolean {
+    if (!isNumericExpression(ctx, stmt.expression)) return fail();
+    if (loopBodyHasUnsupportedJump(stmt.statement)) return fail();
+    collectSpillsIn(stmt.expression);
+
+    // Current state jumps to the header.
+    const headerId = reserveState();
+    finishState(curId, { kind: "jump", next: headerId });
+
+    // header: branch on cond → bodyEntry / exit
+    const bodyEntry = reserveState();
+    const exitId = reserveState();
+    states[headerId] = {
+      statements: [],
+      resumeBindings: [],
+      terminator: { kind: "branch", cond: stmt.expression, negate: false, thenState: bodyEntry, elseState: exitId },
+    };
+
+    // body: lower, then jump back to header.
+    curId = bodyEntry;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    if (!lowerStatements(thenBody(stmt.statement), activeFinalizers)) return false;
+    finishState(curId, { kind: "jump", next: headerId });
+
+    // continue at exit.
+    curId = exitId;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    return ok;
+  }
+
+  /** do body while (cond) — body runs at least once, then header. */
+  function lowerDoWhile(stmt: ts.DoStatement, activeFinalizers: readonly ts.Statement[][]): boolean {
+    if (!isNumericExpression(ctx, stmt.expression)) return fail();
+    if (loopBodyHasUnsupportedJump(stmt.statement)) return fail();
+    collectSpillsIn(stmt.expression);
+
+    const bodyEntry = reserveState();
+    finishState(curId, { kind: "jump", next: bodyEntry });
+
+    const headerId = reserveState();
+    const exitId = reserveState();
+
+    // body → header
+    curId = bodyEntry;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    if (!lowerStatements(thenBody(stmt.statement), activeFinalizers)) return false;
+    finishState(curId, { kind: "jump", next: headerId });
+
+    // header: cond ? bodyEntry : exit
+    states[headerId] = {
+      statements: [],
+      resumeBindings: [],
+      terminator: { kind: "branch", cond: stmt.expression, negate: false, thenState: bodyEntry, elseState: exitId },
+    };
+
+    curId = exitId;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    return ok;
+  }
+
+  /** for (init; cond; update) body — body yields. */
+  function lowerFor(stmt: ts.ForStatement, activeFinalizers: readonly ts.Statement[][]): boolean {
+    if (loopBodyHasUnsupportedJump(stmt.statement)) return fail();
+    // init: a yield-free var-decl list or expression; append to current state.
+    if (stmt.initializer) {
+      if (ts.isVariableDeclarationList(stmt.initializer)) {
+        // Only numeric simple declarations.
+        for (const d of stmt.initializer.declarations) {
+          if (!ts.isIdentifier(d.name)) return fail();
+          if (d.initializer && statementContainsYield(d.initializer as unknown as ts.Statement)) return fail();
+          addSpill(d.name.text);
+        }
+        // Wrap into a synthetic VariableStatement so compileStatement handles it.
+        const vs = ts.factory.createVariableStatement(undefined, stmt.initializer);
+        curStatements.push(vs);
+      } else {
+        if (nodeContainsYield(stmt.initializer)) return fail();
+        curStatements.push(ts.factory.createExpressionStatement(stmt.initializer));
+      }
+    }
+
+    const cond = stmt.condition;
+    if (cond && !isNumericExpression(ctx, cond)) return fail();
+    if (cond) collectSpillsIn(cond);
+
+    const headerId = reserveState();
+    finishState(curId, { kind: "jump", next: headerId });
+
+    const bodyEntry = reserveState();
+    const updateId = reserveState();
+    const exitId = reserveState();
+
+    states[headerId] = {
+      statements: [],
+      resumeBindings: [],
+      terminator: cond
+        ? { kind: "branch", cond, negate: false, thenState: bodyEntry, elseState: exitId }
+        : { kind: "jump", next: bodyEntry },
+    };
+
+    // body → update
+    curId = bodyEntry;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    if (!lowerStatements(thenBody(stmt.statement), activeFinalizers)) return false;
+    finishState(curId, { kind: "jump", next: updateId });
+
+    // update → header
+    if (stmt.incrementor) {
+      if (nodeContainsYield(stmt.incrementor)) return fail();
+      collectSpillsIn(stmt.incrementor);
+    }
+    states[updateId] = {
+      statements: stmt.incrementor ? [ts.factory.createExpressionStatement(stmt.incrementor)] : [],
+      resumeBindings: [],
+      terminator: { kind: "jump", next: headerId },
+    };
+
+    curId = exitId;
+    curStatements = [];
+    curResumeBindings = [];
+    curAbrupt = undefined;
+    return ok;
+  }
+
+  // Conservatively spill every simple numeric local declared / assigned in the
+  // generator body, since loops re-enter states across suspensions and the live
+  // local set is hard to compute precisely. Identifiers that are params are
+  // already in the state struct.
+  function collectSpillsIn(node: ts.Node): void {
+    function visit(n: ts.Node): void {
+      if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name)) {
+        addSpill(n.name.text);
+      }
+      if (
+        ts.isFunctionDeclaration(n) ||
+        ts.isFunctionExpression(n) ||
+        ts.isArrowFunction(n) ||
+        ts.isMethodDeclaration(n)
+      ) {
+        return;
+      }
+      ts.forEachChild(n, visit);
+    }
+    visit(node);
+  }
+
+  // Pre-scan the whole body so every loop-carried / yield-crossing local is a
+  // spill field BEFORE states are emitted (a state entered on resume reads all
+  // spills from the struct, so any local mutated across a suspension must be a
+  // spill regardless of which state declared it).
+  collectSpillsIn(decl.body);
+
+  if (!lowerStatements(decl.body.statements, [])) return null;
+  if (!ok) return null;
+
+  // Final fallthrough state completes the generator.
+  finishState(curId, { kind: "done" });
+
+  // Reject if there is no actual yield (then it's not a generator worth the
+  // native path) or the state count is too large.
+  const yieldCount = states.filter((s) => s.terminator.kind === "yield").length;
+  if (yieldCount === 0) return null;
+  if (states.length > MAX_NATIVE_GENERATOR_STATES) return null;
+
+  return { states, spills };
+}
+
+/** A `break`/`continue` inside a yield-loop body is not modeled in this slice. */
+function loopBodyHasUnsupportedJump(body: ts.Statement): boolean {
+  let bad = false;
+  function visit(node: ts.Node): void {
+    if (bad) return;
+    if (ts.isBreakStatement(node) || ts.isContinueStatement(node)) {
+      bad = true;
+      return;
+    }
+    // Don't descend into nested loops/switches — their break/continue bind
+    // there, not to the loop we're checking. (A break in a nested yield-free
+    // loop is fine; a break in THIS loop that crosses a yield is the problem.
+    // Conservatively reject any break/continue at this level when the body
+    // yields — caller only invokes this for yielding bodies.)
+    if (
+      ts.isForStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isWhileStatement(node) ||
+      ts.isDoStatement(node) ||
+      ts.isSwitchStatement(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(body, visit);
+  return bad;
+}
+
+function thenBody(stmt: ts.Statement): readonly ts.Statement[] {
+  if (ts.isBlock(stmt)) return stmt.statements;
+  return [stmt];
 }
 
 export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.FunctionDeclaration): boolean {
@@ -204,7 +660,7 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.Functio
     if (param.dotDotDotToken || !ts.isIdentifier(param.name)) return false;
   }
   const plan = buildNativeGeneratorPlan(ctx, decl);
-  return plan !== null && plan.segments.some((s) => s.yieldExpr !== undefined);
+  return plan !== null && plan.states.some((s) => s.terminator.kind === "yield");
 }
 
 export function sourceNeedsGeneratorHostImports(ctx: CodegenContext, sourceFile: ts.SourceFile): boolean {
@@ -285,7 +741,11 @@ export function registerNativeGenerator(
     });
   }
   const spillFieldOffset = PARAM_FIELD_OFFSET + paramTypes.length;
-  for (const spill of plan.spills) {
+  // Params that are also reassigned in the body need a mutable spill slot too;
+  // but params already live in the struct. Spills cover body-declared locals.
+  const paramNameSet = new Set(paramNames);
+  const bodySpills = plan.spills.filter((s) => !paramNameSet.has(s));
+  for (const spill of bodySpills) {
     stateFields.push({
       name: `spill_${spill}`,
       type: { kind: "f64" },
@@ -300,7 +760,7 @@ export function registerNativeGenerator(
   ctx.typeIdxToStructName.set(stateTypeIdx, stateName);
   ctx.structFields.set(stateName, stateFields);
 
-  const yieldCount = plan.segments.filter((s) => s.yieldExpr !== undefined).length;
+  const yieldCount = plan.states.filter((s) => s.terminator.kind === "yield").length;
   const info: NativeGeneratorInfo = {
     functionName,
     decl,
@@ -312,10 +772,10 @@ export function registerNativeGenerator(
     sentFieldIdx: SENT_FIELD,
     modeFieldIdx: MODE_FIELD,
     abruptFieldIdx: ABRUPT_FIELD,
-    spillNames: plan.spills,
+    spillNames: bodySpills,
     spillFieldOffset,
     yieldCount,
-    doneState: yieldCount + 1,
+    doneState: plan.states.length - 1, // the final `done` state id
   };
   ctx.nativeGenerators.set(functionName, info);
   return info;
@@ -333,17 +793,17 @@ function emptyResultForType(resultTypeIdx: number): Instr[] {
   ];
 }
 
-function setState(info: NativeGeneratorInfo, state: number): Instr[] {
+function setStateInstrs(info: NativeGeneratorInfo, selfLocal: number, state: number): Instr[] {
   return [
-    { op: "local.get", index: 0 },
+    { op: "local.get", index: selfLocal },
     { op: "i32.const", value: state },
     { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
   ];
 }
 
-function setMode(info: NativeGeneratorInfo, mode: number): Instr[] {
+function setModeInstrs(info: NativeGeneratorInfo, selfLocal: number, mode: number): Instr[] {
   return [
-    { op: "local.get", index: 0 },
+    { op: "local.get", index: selfLocal },
     { op: "i32.const", value: mode },
     { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
   ];
@@ -378,26 +838,16 @@ function nativeReturnResultFromLocal(info: NativeGeneratorInfo, valueLocal: numb
   ];
 }
 
-function storeSpills(info: NativeGeneratorInfo, fctx: FunctionContext): Instr[] {
+function storeSpills(info: NativeGeneratorInfo, fctx: FunctionContext, selfLocal: number): Instr[] {
   const body: Instr[] = [];
   for (let i = 0; i < info.spillNames.length; i++) {
     const localIdx = fctx.localMap.get(info.spillNames[i]!);
     if (localIdx === undefined) continue;
-    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: selfLocal });
     body.push({ op: "local.get", index: localIdx });
     body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
   }
   return body;
-}
-
-function returnAbruptResult(info: NativeGeneratorInfo): Instr[] {
-  return [
-    ...setState(info, info.doneState),
-    { op: "local.get", index: 0 },
-    { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
-    { op: "i32.const", value: 1 },
-    { op: "struct.new", typeIdx: info.resultTypeIdx },
-  ];
 }
 
 function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression | undefined): number {
@@ -421,104 +871,234 @@ function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: t
   return tmp;
 }
 
-function compileSegment(
+/**
+ * Compile a numeric condition to an i32 truthiness on the stack. Booleans are
+ * already i32; numbers compile to f64, so reduce with `f64.ne 0` (NaN → 0,
+ * matching JS ToBoolean for numbers).
+ */
+function emitConditionAsI32(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): void {
+  const t = compileExpression(ctx, fctx, expr);
+  if (t === null) {
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return;
+  }
+  if (t.kind === "i32") return;
+  if (t.kind === "f64") {
+    fctx.body.push({ op: "f64.const", value: 0 });
+    fctx.body.push({ op: "f64.ne" });
+    return;
+  }
+  // Fallback: coerce to f64 then truthiness.
+  coerceType(ctx, fctx, t, { kind: "f64" });
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "f64.ne" });
+}
+
+/**
+ * Emit the trampoline resume body into `fctx.body`. `selfLocal` is the state
+ * struct ref. The shape is:
+ *
+ *   block $exit (result <empty, $__result holds the value>)
+ *     loop $dispatch
+ *       if (state==0) { …state 0… }
+ *       else if (state==1) { …state 1… }
+ *       …
+ *       else { done }
+ *     end
+ *   end
+ *   local.get $__result
+ *
+ * Each state's terminator emits:
+ *   - yield/return  → set $__result, `br $exit`
+ *   - jump/branch   → set state, `br $dispatch`
+ *   - done          → set $__result (=undefined,done:1); fall out of loop
+ */
+function emitTrampoline(
   ctx: CodegenContext,
   fctx: FunctionContext,
   info: NativeGeneratorInfo,
-  segment: NativeGeneratorSegment,
-  yieldIndex: number,
+  plan: NativeGeneratorPlan,
+  selfLocal: number,
+  resultLocal: number,
+): Instr[] {
+  const states = plan.states;
+
+  // Recursively build the nested-if chain. `level` is the recursion depth
+  // (0-based) — used to compute branch depths: from inside the arm at `level`,
+  // the enclosing `loop` is at depth `level+1` and the wrapping `block` at
+  // `level+2`.
+  function buildArm(stateId: number, level: number): Instr[] {
+    if (stateId >= states.length) {
+      // Past the last state: complete (defensive; should be the `done` state).
+      return [
+        ...setStateInstrs(info, selfLocal, info.doneState),
+        ...emptyResult(info),
+        { op: "local.set", index: resultLocal },
+      ];
+    }
+    const loopDepth = level + 1; // br to re-enter dispatch
+    const exitDepth = level + 2; // br to leave block (return to caller)
+
+    const thenBody = compileState(ctx, fctx, info, states[stateId]!, stateId, loopDepth, exitDepth, selfLocal, resultLocal);
+    const elseBody = buildArm(stateId + 1, level + 1);
+    return [
+      { op: "local.get", index: selfLocal },
+      { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+      { op: "i32.const", value: stateId },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: thenBody,
+        else: elseBody,
+      },
+    ];
+  }
+
+  const chain = buildArm(0, 0);
+
+  return [
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: chain,
+        } as Instr,
+      ],
+    } as Instr,
+    { op: "local.get", index: resultLocal },
+  ];
+}
+
+/**
+ * Compile one state's prelude + terminator into an Instr[] for its dispatch
+ * arm. Branch depths are passed in (the arm sits `level` ifs deep inside the
+ * trampoline loop).
+ */
+function compileState(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: NativeGeneratorInfo,
+  state: NativeGeneratorState,
+  stateId: number,
+  loopDepth: number,
+  exitDepth: number,
+  selfLocal: number,
+  resultLocal: number,
 ): Instr[] {
   const saved = fctx.body;
   const body: Instr[] = [];
   fctx.body = body;
 
-  if (segment.abruptResume) {
+  // Abrupt-resume (.return()) handling: if we resumed into this state in mode 1
+  // (return), run finalizers, store spills, and complete with the abrupt value.
+  if (state.abruptResume) {
     const abruptBody: Instr[] = [];
-    const savedAbruptBody = fctx.body;
+    const savedAbrupt = fctx.body;
     fctx.body = abruptBody;
-    for (const finalizer of segment.abruptResume.finalizers) {
-      for (const stmt of finalizer) {
-        compileStatement(ctx, fctx, stmt);
-      }
+    for (const finalizer of state.abruptResume.finalizers) {
+      for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
     }
-    abruptBody.push(...storeSpills(info, fctx));
-    abruptBody.push(...returnAbruptResult(info));
-    abruptBody.push({ op: "return" });
-    fctx.body = savedAbruptBody;
+    abruptBody.push(...storeSpills(info, fctx, selfLocal));
+    abruptBody.push(...setStateInstrs(info, selfLocal, info.doneState));
+    abruptBody.push({ op: "local.get", index: selfLocal });
+    abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
+    abruptBody.push({ op: "i32.const", value: 1 });
+    abruptBody.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+    abruptBody.push({ op: "local.set", index: resultLocal });
+    abruptBody.push({ op: "br", depth: exitDepth + 1 }); // +1: inside the `if`
+    fctx.body = savedAbrupt;
 
-    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: selfLocal });
     body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx });
     body.push({ op: "i32.const", value: 1 });
     body.push({ op: "i32.eq" });
-    body.push({
-      op: "if",
-      blockType: { kind: "empty" },
-      then: abruptBody,
-      else: [],
-    });
+    body.push({ op: "if", blockType: { kind: "empty" }, then: abruptBody, else: [] });
   }
 
-  for (const name of segment.resumeBindings) {
+  // Resume bindings: copy the `.next(value)` sent value into the bound local
+  // and its spill field.
+  for (const name of state.resumeBindings) {
     const localIdx = fctx.localMap.get(name);
     const spillIdx = info.spillNames.indexOf(name);
     if (localIdx === undefined || spillIdx < 0) continue;
-    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: selfLocal });
     body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.sentFieldIdx });
     body.push({ op: "local.set", index: localIdx });
-    body.push({ op: "local.get", index: 0 });
+    body.push({ op: "local.get", index: selfLocal });
     body.push({ op: "local.get", index: localIdx });
     body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + spillIdx });
   }
 
-  for (const stmt of segment.statements) {
-    compileStatement(ctx, fctx, stmt);
-  }
+  // Prelude statements (straight-line, yield-free).
+  for (const stmt of state.statements) compileStatement(ctx, fctx, stmt);
 
-  if (segment.yieldExpr) {
-    const tmp = emitExpressionAsF64(ctx, fctx, segment.yieldExpr.expression);
-    body.push(...storeSpills(info, fctx));
-    body.push(...setState(info, yieldIndex + 1));
-    body.push(...setMode(info, 0));
-    body.push({ op: "local.get", index: tmp });
-    body.push({ op: "i32.const", value: 0 });
-    body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
-  } else if (segment.returnStmt) {
-    const tmp = emitExpressionAsF64(ctx, fctx, segment.returnStmt.expression);
-    body.push(...storeSpills(info, fctx));
-    body.push(...setState(info, info.doneState));
-    body.push(...setMode(info, 0));
-    body.push({ op: "local.get", index: tmp });
-    body.push({ op: "i32.const", value: 1 });
-    body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
-  } else {
-    body.push(...storeSpills(info, fctx));
-    body.push(...setState(info, info.doneState));
-    body.push(...setMode(info, 0));
-    body.push(...emptyResult(info));
+  const term = state.terminator;
+  switch (term.kind) {
+    case "yield": {
+      const tmp = emitExpressionAsF64(ctx, fctx, term.expr);
+      body.push(...storeSpills(info, fctx, selfLocal));
+      body.push(...setStateInstrs(info, selfLocal, term.next));
+      body.push(...setModeInstrs(info, selfLocal, 0));
+      body.push({ op: "local.get", index: tmp });
+      body.push({ op: "i32.const", value: 0 });
+      body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+      body.push({ op: "local.set", index: resultLocal });
+      body.push({ op: "br", depth: exitDepth }); // leave trampoline → return result
+      break;
+    }
+    case "return": {
+      const tmp = emitExpressionAsF64(ctx, fctx, term.expr);
+      body.push(...storeSpills(info, fctx, selfLocal));
+      body.push(...setStateInstrs(info, selfLocal, info.doneState));
+      body.push(...setModeInstrs(info, selfLocal, 0));
+      body.push({ op: "local.get", index: tmp });
+      body.push({ op: "i32.const", value: 1 });
+      body.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+      body.push({ op: "local.set", index: resultLocal });
+      body.push({ op: "br", depth: exitDepth });
+      break;
+    }
+    case "jump": {
+      body.push(...storeSpills(info, fctx, selfLocal));
+      body.push(...setStateInstrs(info, selfLocal, term.next));
+      body.push({ op: "br", depth: loopDepth }); // re-enter dispatch at new state
+      break;
+    }
+    case "branch": {
+      body.push(...storeSpills(info, fctx, selfLocal));
+      emitConditionAsI32(ctx, fctx, term.cond);
+      if (term.negate) body.push({ op: "i32.eqz" });
+      body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...setStateInstrs(info, selfLocal, term.thenState),
+          { op: "br", depth: loopDepth + 1 }, // +1 for the inner branch `if`
+        ],
+        else: [
+          ...setStateInstrs(info, selfLocal, term.elseState),
+          { op: "br", depth: loopDepth + 1 },
+        ],
+      });
+      break;
+    }
+    case "done": {
+      body.push(...storeSpills(info, fctx, selfLocal));
+      body.push(...setStateInstrs(info, selfLocal, info.doneState));
+      body.push(...emptyResult(info));
+      body.push({ op: "local.set", index: resultLocal });
+      // No br: fall out of the trampoline loop (loop only repeats on explicit
+      // br), then `block $exit` ends and the caller reads $__result.
+      break;
+    }
   }
 
   fctx.body = saved;
   return body;
-}
-
-function buildDispatch(info: NativeGeneratorInfo, cases: Instr[][], defaultBody: Instr[]): Instr[] {
-  function caseAt(index: number): Instr[] {
-    if (index >= cases.length) return defaultBody;
-    const elseBody = caseAt(index + 1);
-    return [
-      { op: "local.get", index: 0 },
-      { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
-      { op: "i32.const", value: index },
-      { op: "i32.eq" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "ref", typeIdx: info.resultTypeIdx } },
-        then: cases[index]!,
-        else: elseBody,
-      },
-    ];
-  }
-  return caseAt(0);
 }
 
 export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: NativeGeneratorInfo): number {
@@ -538,6 +1118,24 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
   info.resumeFuncIdx = funcIdx;
   ctx.funcMap.set(fnName, funcIdx);
 
+  // #2079: reserve this function's slot with a placeholder BEFORE emitting the
+  // body. The Phase-2 body can lazily register helper functions (numeric
+  // operators like `%`/`**`, coercions, …) which append to `ctx.mod.functions`
+  // and would otherwise push the real resume function past `funcIdx` — a stale
+  // capture: every baked `call funcIdx` (the for-of driver, `.next()` dispatch)
+  // would hit the helper instead of resume. Reserving the slot now keeps
+  // `funcIdx` stable; we fill the placeholder body in place at the end. (Same
+  // late-shift class as #1677/#1809/#1899; same fix idiom as the accessor
+  // drivers.)
+  const placeholder: WasmFunction = {
+    name: fnName,
+    typeIdx,
+    locals: [],
+    body: [{ op: "unreachable" } as Instr],
+    exported: false,
+  };
+  ctx.mod.functions.push(placeholder);
+
   const resumeFctx: FunctionContext = {
     name: fnName,
     params: [{ name: "__gen_self", type: selfType }],
@@ -552,6 +1150,7 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     savedBodies: [],
   };
 
+  // Copy params into locals.
   for (let i = 0; i < info.paramTypes.length; i++) {
     const localIdx = allocLocal(resumeFctx, info.paramNames[i]!, info.paramTypes[i]!);
     resumeFctx.body.push({ op: "local.get", index: 0 });
@@ -559,12 +1158,16 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     resumeFctx.body.push({ op: "local.set", index: localIdx });
   }
 
+  // Load spills into locals.
   for (let i = 0; i < info.spillNames.length; i++) {
     const localIdx = allocLocal(resumeFctx, info.spillNames[i]!, { kind: "f64" });
     resumeFctx.body.push({ op: "local.get", index: 0 });
     resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
     resumeFctx.body.push({ op: "local.set", index: localIdx });
   }
+
+  // Result holding local (the trampoline writes it; the tail reads it).
+  const resultLocal = allocLocal(resumeFctx, "__gen_result", { kind: "ref", typeIdx: info.resultTypeIdx });
 
   const plan = buildNativeGeneratorPlan(ctx, info.decl);
   if (!plan) {
@@ -574,27 +1177,16 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     const savedFunc = ctx.currentFunc;
     ctx.currentFunc = resumeFctx;
     try {
-      let yieldIndex = 0;
-      const cases = plan.segments.map((segment) => {
-        const caseBody = compileSegment(ctx, resumeFctx, info, segment, yieldIndex);
-        if (segment.yieldExpr) yieldIndex++;
-        return caseBody;
-      });
-      const defaultBody = [...setState(info, info.doneState), ...emptyResult(info)];
-      resumeFctx.body.push(...buildDispatch(info, cases, defaultBody));
+      resumeFctx.body.push(...emitTrampoline(ctx, resumeFctx, info, plan, 0, resultLocal));
     } finally {
       ctx.currentFunc = savedFunc;
     }
   }
 
-  const fn: WasmFunction = {
-    name: fnName,
-    typeIdx,
-    locals: resumeFctx.locals,
-    body: resumeFctx.body,
-    exported: false,
-  };
-  ctx.mod.functions.push(fn);
+  // Fill the reserved placeholder in place — its index (funcIdx) stayed stable
+  // while body compilation appended any helper functions after it.
+  placeholder.locals = resumeFctx.locals;
+  placeholder.body = resumeFctx.body;
   return funcIdx;
 }
 
@@ -605,6 +1197,7 @@ export function compileNativeGeneratorFunction(
   info: NativeGeneratorInfo,
 ): void {
   ensureNativeGeneratorResumeFunction(ctx, info);
+  // Construct the state struct: state=0, sent=NaN, mode=0, abrupt=NaN, params…, spills(NaN)…
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "f64.const", value: NaN });
   fctx.body.push({ op: "i32.const", value: 0 });

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -359,10 +359,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclarat
   // context, returning its id.
   let pendingResumeBindings: string[] = [];
   let pendingAbrupt: NativeGeneratorState["abruptResume"] | undefined;
-  function startStateAfterYield(
-    bindSentTo: string | undefined,
-    activeFinalizers: readonly ts.Statement[][],
-  ): number {
+  function startStateAfterYield(bindSentTo: string | undefined, activeFinalizers: readonly ts.Statement[][]): number {
     pendingResumeBindings = bindSentTo ? [bindSentTo] : [];
     pendingAbrupt = { finalizers: [...activeFinalizers].reverse() };
     if (bindSentTo) addSpill(bindSentTo);
@@ -939,7 +936,17 @@ function emitTrampoline(
     const loopDepth = level + 1; // br to re-enter dispatch
     const exitDepth = level + 2; // br to leave block (return to caller)
 
-    const thenBody = compileState(ctx, fctx, info, states[stateId]!, stateId, loopDepth, exitDepth, selfLocal, resultLocal);
+    const thenBody = compileState(
+      ctx,
+      fctx,
+      info,
+      states[stateId]!,
+      stateId,
+      loopDepth,
+      exitDepth,
+      selfLocal,
+      resultLocal,
+    );
     const elseBody = buildArm(stateId + 1, level + 1);
     return [
       { op: "local.get", index: selfLocal },
@@ -1079,10 +1086,7 @@ function compileState(
           ...setStateInstrs(info, selfLocal, term.thenState),
           { op: "br", depth: loopDepth + 1 }, // +1 for the inner branch `if`
         ],
-        else: [
-          ...setStateInstrs(info, selfLocal, term.elseState),
-          { op: "br", depth: loopDepth + 1 },
-        ],
+        else: [...setStateInstrs(info, selfLocal, term.elseState), { op: "br", depth: loopDepth + 1 }],
       });
       break;
     }

--- a/tests/issue-2079-standalone-generator-control-flow.test.ts
+++ b/tests/issue-2079-standalone-generator-control-flow.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2079 — standalone native generators with yields inside control flow
+ * (#680 "Phase 2").
+ *
+ * Before this slice, the Wasm-native generator lowering
+ * (`src/codegen/generators-native.ts`) only modeled a LINEAR sequence of
+ * sequential numeric yields: any `while`/`for`/`do-while` loop or `if`/`else`
+ * containing a `yield` fell into `buildNativeGeneratorPlan` returning `null`,
+ * which in standalone/WASI mode is a hard compile error ("native generator
+ * lowering currently supports only sequential numeric yields"). Loops and
+ * conditionals are the dominant generator shape, so this blocked a large slice
+ * of the standalone iterator/generator conformance gap (#2157).
+ *
+ * Phase 2 lowers structured control flow to a state graph driven by a
+ * trampoline in the generated resume function: a yield/return `br`s out with
+ * the result; a loop back-edge / if-join / sequential boundary sets the state
+ * field and re-enters the dispatch. Loop-carried locals spill to the state
+ * struct so they survive each suspension.
+ *
+ * It also hardens the late-import funcindex hazard (#1899 class): the resume
+ * function reserves its module slot with a placeholder BEFORE its body emits
+ * (Phase-2 bodies can lazily register numeric-operator helpers like `%`, which
+ * would otherwise shift the resume function past its captured funcIdx and make
+ * every baked `call` — the for-of driver, `.next()` — hit the helper instead).
+ *
+ * Every case must compile standalone with ZERO host imports and run correctly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2079 standalone native generators — yields in control flow", () => {
+  it("while loop with a yield", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (i < 3) { yield i; i++; } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(3); // 0+1+2
+  });
+
+  it("for loop with a yield and a param bound", async () => {
+    expect(
+      await runStandalone(`function* g(n: number){ for (let i = 0; i < n; i++) { yield i * 2; } }
+export function test(): number { let s = 0; for (const v of g(4)) s += v; return s; }`),
+    ).toBe(12); // 0+2+4+6
+  });
+
+  it("do-while loop with a yield", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; do { yield i; i++; } while (i < 3); }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(3);
+  });
+
+  it("if/else with yields in both branches", async () => {
+    const src = (n: number) => `function* g(n: number){ if (n > 0) { yield 1; yield 2; } else { yield 9; } }
+export function test(): number { let s = 0; for (const v of g(${n})) s += v; return s; }`;
+    expect(await runStandalone(src(1))).toBe(3);
+    expect(await runStandalone(src(0))).toBe(9);
+  });
+
+  it("yields before and after a loop", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 10; let i = 0; while (i < 2) { yield i; i++; } yield 20; }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(31); // 10 + 0 + 1 + 20
+  });
+
+  it("nested loops with a yield (loop-carried spills round-trip)", async () => {
+    expect(
+      await runStandalone(`function* g(){ for (let i = 0; i < 2; i++) { for (let j = 0; j < 2; j++) { yield i*10 + j; } } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(22); // 0,1,10,11
+  });
+
+  it("if (no else) with a yield inside a loop — exercises the funcindex placeholder", async () => {
+    // `i % 2` lazily registers the f64-modulo helper while the resume body is
+    // being emitted; without the reserved-slot fix the for-of driver's baked
+    // `call` would target the modulo helper instead of the resume function.
+    expect(
+      await runStandalone(`function* g(){ for (let i = 0; i < 5; i++) { if (i % 2 === 0) yield i; } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6); // 0 + 2 + 4
+  });
+
+  it("return inside a loop completes the generator", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (true) { if (i === 3) return 99; yield i; i++; } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(3); // yields 0,1,2 then returns (return value not part of for-of sum)
+  });
+
+  it("manual .next() over a while-loop generator", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (i < 3) { yield i; i++; } }
+export function test(): number {
+  const it = g(); let s = 0; let r = it.next();
+  while (!r.done) { s += r.value as number; r = it.next(); }
+  return s;
+}`),
+    ).toBe(3);
+  });
+
+  it(".next(value) sent into a loop binds across suspension", async () => {
+    expect(
+      await runStandalone(`function* g(){ let total = 0; while (true) { const x = yield total; total += x; } }
+export function test(): number {
+  const it = g();
+  it.next();
+  it.next(10);
+  const r = it.next(5);
+  return (r.value as number);
+}`),
+    ).toBe(15);
+  });
+
+  it(".return() early-completes an infinite loop generator", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<number, number, unknown> {
+  let i = 0; while (i < 100) { yield i; i++; } return 0;
+}
+export function test(): number {
+  const it = g();
+  it.next(); it.next();
+  const r = it.return(42);
+  return (r.done ? 1 : 0) * 1000 + (r.value as number);
+}`),
+    ).toBe(1042);
+  });
+
+  it("infinite generator consumed partially via .next()", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (true) { yield i; i++; } }
+export function test(): number {
+  const it = g(); let s = 0;
+  for (let k = 0; k < 5; k++) { s += it.next().value as number; }
+  return s;
+}`),
+    ).toBe(10); // 0+1+2+3+4
+  });
+
+  it("regression: a purely-sequential generator still lowers natively", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 1; yield 2; return 3; }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2079 — standalone generators with yields inside control flow

### Re-diagnosis
On current main the original funcindex CE no longer reproduces for sequential numeric yields — #1665's Phase-1 state machine handles `function* g(){ yield 1; yield 2; }` + for-of and manual `it.next()` standalone with zero imports. The **actual** residual blocking the ~960-test ROI is the `"sequential numeric yields"` hard CE: `buildNativeGeneratorPlan` bailed on **any `while`/`for`/`do-while` loop or `if`/`else` containing a `yield`** — the dominant generator shape. This is #680 "Phase 2" (architect estimate: "covers 85%").

### Fix (`src/codegen/generators-native.ts`)
- **State-graph plan**: each state has a straight-line prelude + an explicit terminator (`yield(next)` / `return` / `done` / `jump(next)` / `branch(cond, then, else)`). Loops → header `branch` + body that `jump`s back (back-edge); `if/else` → `branch` into then/else entries that `jump` to a join. Loop-carried numeric locals spill to the state struct.
- **Trampoline resume fn**: `block { loop { if(state==0){…} else if(state==1){…} … else {done} } } local.get $__result`. yield/return `br` out with the result; jump/branch set the `state` field and `br` back to the dispatch loop to re-enter in the same `next()` call. User loops become state self-transitions (no wasm `loop` emitted for them), so each state body stays straight-line and reuses `compileStatement`.
- **`return` nested in control flow** lowers to a `{value, done:true}` completion terminator, not a raw wasm `return` (which mis-coerced the value → null deref).
- **Late-import funcindex hardening (#1899 class)**: Phase-2 bodies lazily register numeric-operator helpers (`%` → f64 modulo) mid-emit, shifting the resume function past its captured funcIdx → baked `call`s (for-of driver, `.next()`) hit the helper. Fix: reserve the resume fn slot with a placeholder before emitting its body (accessor-driver idiom), fill in place so funcIdx stays stable. Hardens Phase-1 too.

### Scope (clean bail — never wrong/invalid)
Unsupported shapes still return the scoped #680 diagnostic (verified: no crash / wrong answer / invalid Wasm): `yield*`, `for-of`/`for-in` yielding, `break`/`continue` targeting a yield-loop, `switch`/labeled with yields, `try/catch` with yields, non-numeric yields/spills. Follow-ups under #2157.

### Validation
- `tests/issue-2079-standalone-generator-control-flow.test.ts` — 13 zero-import standalone cases (while/for/do-while, if-else, nested loops, yields around loops, if-in-loop funcindex guard, return-in-loop, manual next(), `.next(value)` send, `.return()` early completion, infinite-gen partial consume, sequential regression). All pass.
- No regression: `issue-680`, `issue-1665`, `issue-1665-standalone-generator-forof`, `generators`, async-iteration / async-function equivalence — all green.
- `tsc --noEmit` clean; `check:ir-fallbacks` OK.

Closes #2079. Feeds #2157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)