### PR TITLE
fix(#2166): standalone JSON.stringify of a boolean-typed value

### DIFF
--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -38,3 +38,39 @@ parse/stringify residuals — currently **untracked**.
 
 Parent (done): #1599. Part of sprint-62 standalone catch-up (rank 12 by gap
 impact). Likely benefits from the coercion engine (#1917) number/string path.
+
+---
+
+## Progress (2026-06-15, dev3) — boolean-typed `JSON.stringify` slice
+
+**Status stays `ready`** — this is one slice of the 76-test bucket, not the
+whole residual.
+
+Investigation against `origin/main` @ `516feec44` found the standalone
+`JSON.stringify` primitive/static-fold slices (#1324 / #1599) are in much
+better shape than the gap suggests; verified working in standalone (compared
+INTERNALLY, since standalone native strings don't marshal across the JS export
+boundary):
+
+- `JSON.stringify` of **static** object/array/number/string/nested literals →
+  correct (folded by `tryEmitJsonStringifyStatic`).
+- `JSON.stringify` of a **dynamic** number / string → correct.
+- `JSON.parse` of a runtime number/`true`/`false`/`null` string → correct.
+
+**One concrete bug fixed (this PR):** `JSON.stringify` of a **`boolean`-typed**
+value (`const b: boolean = …`) refused to compile in standalone. TypeScript
+models `boolean` as the union `true | false`, so the value carries the `Union`
+type flag and was wrongly rejected by the ambiguous-shape early-return in
+`tryEmitJsonStringifyPrimitive` (`src/codegen/expressions/calls.ts`) before
+reaching the boolean stringify branch. The fix recognizes the `boolean` union
+(`Boolean` flag + `intrinsicName === "boolean"`) ahead of the mask. Static
+`true`/`false` literals were unaffected and keep working; a genuinely mixed
+union (`boolean | number`) still falls through to the host import (intrinsicName
+guard). Regression test: `tests/issue-2166.test.ts` (8 cases, host + standalone).
+
+**Still open (the bulk of the 76):** `JSON.stringify` / `JSON.parse` of
+**dynamic object graphs** (runtime-built objects, runtime JSON text →
+object/array) still refuse with the #1599 Phase-2 compile error — they need the
+pure-Wasm JSON codec + a dynamic value representation. That is the #1599 Phase 2
+architect-spec follow-up (large; benefits from the #1917 coercion engine and the
+value-rep work), not a point fix.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -365,8 +365,22 @@ function tryEmitJsonStringifyPrimitive(
   }
   const flags = argType.flags;
 
+  // (#2166) TypeScript models the `boolean` primitive as the union
+  // `true | false`, so a `boolean`-typed value (e.g. `const b: boolean = x`)
+  // carries the `Union` flag and was wrongly skipped by the ambiguous-mask
+  // early-return below — so `JSON.stringify(b)` refused in standalone instead
+  // of serializing to "true"/"false". A `BooleanLike` type (the boolean union
+  // or a boolean literal) is unambiguously serializable, so recognize it before
+  // the mask. Guard on `intrinsicName === "boolean"` for the union so we don't
+  // misfire on a mixed union that merely contains a boolean member.
+  const isBooleanType =
+    (flags & ts.TypeFlags.BooleanLiteral) !== 0 ||
+    ((flags & ts.TypeFlags.Boolean) !== 0 &&
+      (argType as ts.Type & { intrinsicName?: string }).intrinsicName === "boolean");
+
   // Skip ambiguous shapes (any/unknown/union/object/intersection) — let
-  // the caller fall through to the host import which handles them.
+  // the caller fall through to the host import which handles them. The
+  // `boolean` union is the documented exception (see above).
   const ambiguousMask =
     ts.TypeFlags.Any |
     ts.TypeFlags.Unknown |
@@ -375,7 +389,7 @@ function tryEmitJsonStringifyPrimitive(
     ts.TypeFlags.Object |
     ts.TypeFlags.NonPrimitive |
     ts.TypeFlags.TypeParameter;
-  if (flags & ambiguousMask) return undefined;
+  if (!isBooleanType && flags & ambiguousMask) return undefined;
 
   // null literal
   if (flags & ts.TypeFlags.Null) {

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2166 — standalone JSON conformance residual.
+//
+// The standalone `JSON.stringify` primitive slice (#1324) handled the static
+// `true`/`false` keyword literals but skipped a `boolean`-TYPED value: TypeScript
+// models the `boolean` primitive as the union `true | false`, so a `boolean`-typed
+// variable carries the `Union` type flag and was wrongly rejected by the
+// ambiguous-shape early-return in `tryEmitJsonStringifyPrimitive`
+// (src/codegen/expressions/calls.ts). `JSON.stringify(b)` then refused to compile
+// in standalone instead of serializing to "true"/"false".
+//
+// Fix: recognize the `boolean` union (`Boolean` flag + `intrinsicName === "boolean"`)
+// before the ambiguous-mask return, so the existing boolean stringify branch fires.
+//
+// Standalone native strings don't auto-marshal across the export boundary to JS,
+// so these assertions compare the JSON string INTERNALLY (the §25.5 result vs an
+// in-module literal) and return a boolean — matching how test262 exercises this.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Mode = { label: string; opts: Record<string, unknown> };
+const MODES: Mode[] = [
+  { label: "host", opts: {} },
+  { label: "standalone", opts: { target: "standalone" } },
+];
+
+async function runBool(src: string, opts: Record<string, unknown>): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts", ...opts });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2166 — standalone JSON.stringify of a boolean-typed value", () => {
+  for (const { label, opts } of MODES) {
+    describe(`[${label}]`, () => {
+      it('dynamic boolean true → "true"', async () => {
+        expect(
+          await runBool(
+            `export function test(): boolean { const b: boolean = 1 > 0; return JSON.stringify(b) === "true"; }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+
+      it('dynamic boolean false → "false"', async () => {
+        expect(
+          await runBool(
+            `export function test(): boolean { const b: boolean = 1 < 0; return JSON.stringify(b) === "false"; }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+
+      it("boolean parameter serializes both ways", async () => {
+        expect(
+          await runBool(
+            `function s(b: boolean): boolean { return JSON.stringify(b) === (b ? "true" : "false"); }
+             export function test(): boolean { return s(true) && s(false); }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+
+      it("static true/false literals still serialize (regression guard)", async () => {
+        expect(
+          await runBool(
+            `export function test(): boolean { return JSON.stringify(true) === "true" && JSON.stringify(false) === "false"; }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

One slice of the **#2166** standalone JSON conformance residual (76 tests).

TypeScript models the `boolean` primitive as the union `true | false`, so a
`boolean`-typed value (`const b: boolean = …`) carries the `Union` type flag and
was wrongly rejected by the ambiguous-shape early-return in
`tryEmitJsonStringifyPrimitive` (`src/codegen/expressions/calls.ts`) **before**
reaching the boolean stringify branch. In standalone there is no `JSON_stringify`
host import, so `JSON.stringify(b)` then hit the #1599 refusal compile error
instead of serializing to `"true"`/`"false"`.

**Fix:** recognize the `boolean` union (`Boolean` flag + `intrinsicName ===
"boolean"`) ahead of the ambiguous-mask return so the existing boolean branch
fires. Static `true`/`false` literals already worked and are unaffected; a
genuinely mixed union (`boolean | number`) still falls through to the host
import (intrinsicName guard, so no behavior change there).

## Verified (host + standalone)

Standalone native strings don't marshal across the JS export boundary, so these
compare the result INTERNALLY (`=== "true"` in-module) — how test262 exercises
it.

| program | result |
|---|---|
| `const b: boolean = 1>0; JSON.stringify(b) === "true"` | true |
| `const b: boolean = 1<0; JSON.stringify(b) === "false"` | true |
| boolean param serializes both ways | true |
| `JSON.stringify(true)/(false)` static literals | true (unchanged) |

`tests/issue-2166.test.ts` — 8 cases (4 × {host, standalone}), all green.
`tsc --noEmit` clean.

## Scope

Issue **stays `ready`**: investigation found the static-fold + primitive slices
(#1324/#1599) already cover static objects/arrays/numbers/strings and runtime
number/string stringify + primitive `JSON.parse`. The remaining bulk of the 76
is `JSON.stringify`/`JSON.parse` of **dynamic object graphs**, which still refuse
with the #1599 Phase-2 compile error and need the pure-Wasm JSON codec + dynamic
value representation (the #1599 Phase 2 architect follow-up, not a point fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)