### PR TITLE
fix(plan): resolve duplicate issue id 2155 blocking the merge queue

### DIFF
--- a/.claude/skills/claim-issue.md
+++ b/.claude/skills/claim-issue.md
@@ -3,7 +3,7 @@ name: claim-issue
 description: Atomically claim an issue for a developer (human or agent) via the cross-developer lock ref, so two devs never pick up the same task. Syncs with origin first, refuses if already claimed or already done on main, and pushes the claim immediately without touching main or triggering CI.
 ---
 
-# /claim-issue — atomic cross-developer issue claim (#2155)
+# /claim-issue — atomic cross-developer issue claim (#2168)
 
 With several developers (humans + agents, possibly across forks) on the project,
 the in-memory TaskList is invisible to other devs. Before starting work on an

--- a/plan/issues/2168-multi-dev-issue-assignment-lock.md
+++ b/plan/issues/2168-multi-dev-issue-assignment-lock.md
@@ -1,5 +1,5 @@
 ---
-id: 2155
+id: 2168
 title: "Cross-developer issue-assignment lock (humans + agents, no CI churn)"
 status: in-progress
 sprint: Backlog

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// scripts/claim-issue.mjs (#2155)
+// scripts/claim-issue.mjs (#2168)
 //
 // Cross-developer atomic issue-claim lock for multi-dev work (humans + agents,
 // possibly across forks). The live lock lives on a dedicated orphan ref —


### PR DESCRIPTION
**Hotfix.** main has two issue files with `id: 2155` — `2155-wasm-treemap-component-model.md` (#1471) and `2155-multi-dev-issue-assignment-lock.md` (#1473). The #1616 issue-integrity gate fails with '1 duplicate IDs', which fails the required `quality` check in **every merge group**, so all queued PRs get evicted without merging and main is effectively blocked.

Treemap 2155/2156 is a coupled pair (2156 references 2155 6×), so this renumbers the single assignment-lock issue to **2168** and updates its two cosmetic code references. `check-issue-ids` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)