### PR TITLE
feat(#2169): array spread of a native generator drives next() (SF-2 of #2157)

### DIFF
--- a/plan/issues/2169-standalone-spread-arrayfrom-destructure-native-generator.md
+++ b/plan/issues/2169-standalone-spread-arrayfrom-destructure-native-generator.md
@@ -1,0 +1,83 @@
+---
+id: 2169
+title: "standalone: spread / Array.from / array-destructure don't drive a native generator (treat the state struct as a __vec)"
+status: in-progress
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: iterators-generators
+goal: standalone-mode
+parent: 2157
+depends_on: [2079]
+---
+
+# #2169 — native-generator consumers (SF-2 of #2157)
+
+## Problem
+
+A top-level `function*` lowers (since #2079) to a native state struct
+(`$__gen_state_*`) consumed correctly by `for-of` via
+`tryCompileNativeGeneratorForOf`. But three OTHER consumers don't recognize the
+state struct as an iterator — they treat it as a `__vec`:
+
+```ts
+function* g(){ yield 1; yield 2; yield 3; }
+[...g()]            // standalone: wrong-length array of NaN (exp [1,2,3])
+Array.from(g())     // standalone: env-import leak + zero-import instantiate fail
+const [a,b]=g();    // standalone: env-import leak (exp a=1,b=2)
+```
+
+## Root cause
+
+The spread / `Array.from` / array-destructuring lowerings read
+`struct.get <gen> 0` expecting a `$length` field, but field 0 of the generator
+state struct is `state`. They build a garbage-length array of defaults and
+never call `next()`.
+
+## Fix direction
+
+At each consumer, detect the native-generator subject
+(`nativeGeneratorInfoForForOfSubject` / the `$__gen_state_*` type family) and
+drive it with the same `next()`-until-`done` loop `tryCompileNativeGeneratorForOf`
+already emits, collecting `value`s into the target array / binding list. Reuse,
+don't duplicate, the driver.
+
+## Acceptance criteria
+
+- The three repros in `tests/issue-2157-*.test.ts` (SF-2 `it.todo`s) pass,
+  zero host imports.
+- `for-of` / array / string spread regression guards stay green.
+
+## Source
+
+Triage of #2157 (2026-06-15, sdev5), SF-2.
+
+## Resolution (2026-06-15, sdev5) — array spread landed; Array.from/destructure carried forward
+
+Landed the **array-spread** consumer (`[...g()]`). Added a reusable
+`emitNativeGeneratorToVec(ctx, fctx, info, subjectType, vecTypeIdx, arrTypeIdx)`
+in `generators-native.ts`: it drains the native generator via the same
+`resume()`-until-`done` loop the for-of driver uses, accumulating yields into a
+growable f64 backing array, and leaves a freshly-built `ref $vec_f64` on the
+stack. The array-literal spread site (`literals.ts compileArrayLiteral`) now
+detects a native-generator subject via `nativeGeneratorInfoForForOfSubject` and
+materializes through that helper, then reuses the existing materialized-vec
+spread machinery (same shape as the externref `buildVecFromExternref` path).
+
+Verified standalone, zero host imports: `[...g()]` length/values, >4-yield grow
+path, control-flow generators, mixed `[head, ...g()]`; array/string spread
+regressions unchanged. Test: `tests/issue-2169-spread-native-generator.test.ts`
++ the SF-2 spread gate in `tests/issue-2157-*.test.ts` (un-todo'd).
+
+**Carried forward (still on this issue):** `Array.from(g())` and
+array-destructuring `[a,b]=g()` are separate consumer call sites
+(`destructuring-params.ts` and the Array.from builtin) — the
+`emitNativeGeneratorToVec` helper is ready to wire into both, but they're a
+distinct, independently-testable change left as a follow-up to keep this PR
+focused. Their `it.todo` gates in `tests/issue-2157-*.test.ts` stay todo.
+Status kept `in-progress` until those two land.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -1667,3 +1667,128 @@ export function tryCompileNativeGeneratorForOf(
   });
   return true;
 }
+
+/**
+ * #2169 — materialize a Wasm-native generator into a `__vec` of f64 by driving
+ * its resume function to completion, WITHOUT the JS-host iterator protocol.
+ *
+ * The non-`for-of` iterator consumers (array spread `[...g()]`, `Array.from(g())`,
+ * array-destructuring `[a,b]=g()`) previously treated the generator's state
+ * struct as if it were a `__vec` (reading field 0 as a `$length`), producing a
+ * garbage-length array of defaults / leaking host imports. This helper gives
+ * them the same `next()`-until-`done` drain the for-of driver uses, but
+ * collects the values into a growable backing array and leaves a freshly
+ * constructed `ref $vec_f64` on the stack (so the caller can treat it as a
+ * normal materialized vec).
+ *
+ * Contract: the generator state ref (`subjectType`, a ref/ref_null to the
+ * `info.stateTypeIdx` struct) MUST already be on the stack. On return the stack
+ * top is `(ref <vecTypeIdx>)` of element type f64. Numeric yields only (native
+ * generators are numeric today; non-numeric is #2171 / SF-4).
+ *
+ * The vec struct layout matches `getVecInfo`: field 0 = `$length` (i32),
+ * field 1 = `$data` (ref $arr). `vecTypeIdx`/`arrTypeIdx` are supplied by the
+ * caller (an f64 vec from `getOrRegisterVecType`).
+ */
+export function emitNativeGeneratorToVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: NativeGeneratorInfo,
+  subjectType: ValType,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+): void {
+  const resumeIdx = ensureNativeGeneratorResumeFunction(ctx, info);
+  const resultRef: ValType = { kind: "ref", typeIdx: info.resultTypeIdx };
+
+  // Stash the generator state ref (currently on stack) into a local typed as
+  // the exact state struct.
+  const iterLocal = allocLocal(fctx, `__gen2vec_iter_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: info.stateTypeIdx,
+  } as ValType);
+  if (subjectType.kind === "ref_null") {
+    fctx.body.push({ op: "ref.as_non_null" });
+  }
+  if ((subjectType as { typeIdx?: number }).typeIdx !== info.stateTypeIdx) {
+    fctx.body.push({ op: "ref.cast", typeIdx: info.stateTypeIdx });
+  }
+  fctx.body.push({ op: "local.set", index: iterLocal });
+
+  const resultLocal = allocLocal(fctx, `__gen2vec_res_${fctx.locals.length}`, resultRef);
+  const capLocal = allocLocal(fctx, `__gen2vec_cap_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__gen2vec_len_${fctx.locals.length}`, { kind: "i32" });
+  const dataLocal = allocLocal(fctx, `__gen2vec_data_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const growLocal = allocLocal(fctx, `__gen2vec_grow_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+
+  // cap = 4; data = new f64[cap]; len = 0.
+  fctx.body.push({ op: "i32.const", value: 4 });
+  fctx.body.push({ op: "local.set", index: capLocal });
+  fctx.body.push({ op: "local.get", index: capLocal });
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.set", index: dataLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: lenLocal });
+
+  // Grow when len == cap: cap *= 2; grow = new f64[cap];
+  // array.copy grow[0..len] = data[0..len]; data = grow.
+  const growInstrs: Instr[] = [
+    { op: "local.get", index: capLocal },
+    { op: "i32.const", value: 2 },
+    { op: "i32.mul" },
+    { op: "local.set", index: capLocal },
+    { op: "local.get", index: capLocal },
+    { op: "array.new_default", typeIdx: arrTypeIdx },
+    { op: "local.set", index: growLocal },
+    { op: "local.get", index: growLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: dataLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: lenLocal },
+    { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+    { op: "local.get", index: growLocal },
+    { op: "local.set", index: dataLocal },
+  ];
+
+  // block { loop {
+  //   res = resume(iter); if (res.done) br block;
+  //   if (len == cap) grow; data[len] = res.value; len++; br loop;
+  // } }
+  const loopBody: Instr[] = [
+    { op: "local.get", index: iterLocal },
+    { op: "call", funcIdx: resumeIdx },
+    { op: "local.set", index: resultLocal },
+    { op: "local.get", index: resultLocal },
+    { op: "struct.get", typeIdx: info.resultTypeIdx, fieldIdx: RESULT_DONE_FIELD },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "br", depth: 2 } as Instr], else: [] },
+    // grow if full
+    { op: "local.get", index: lenLocal },
+    { op: "local.get", index: capLocal },
+    { op: "i32.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: growInstrs, else: [] },
+    // data[len] = res.value
+    { op: "local.get", index: dataLocal },
+    { op: "local.get", index: lenLocal },
+    { op: "local.get", index: resultLocal },
+    { op: "struct.get", typeIdx: info.resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD },
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    // len++
+    { op: "local.get", index: lenLocal },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: lenLocal },
+    { op: "br", depth: 0 },
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  });
+
+  // Construct ref $vec { length: len, data }. Note: the backing array may be
+  // larger than len (capacity); the vec's $length field is the authoritative
+  // element count, matching every other materialized vec in the codebase.
+  fctx.body.push({ op: "local.get", index: lenLocal });
+  fctx.body.push({ op: "local.get", index: dataLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
+}

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -49,6 +49,7 @@ import {
   resolveWasmType,
 } from "./index.js";
 import { ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
+import { emitNativeGeneratorToVec, nativeGeneratorInfoForForOfSubject } from "./generators-native.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
   coerceType,
@@ -2974,6 +2975,36 @@ export function compileArrayLiteral(
     if (ts.isSpreadElement(el)) {
       const srcType = compileExpression(ctx, fctx, el.expression);
       if (!srcType) continue;
+      // (#2169) Spread of a Wasm-native generator (`[...g()]`). The subject is a
+      // ref to the generator state struct, NOT a __vec — without this it fell
+      // into the generic vec branch below (struct.get field 0 read as $length →
+      // garbage-length array of defaults / host-import leak). Drain the
+      // generator into an f64 vec via the native resume loop, then treat it as a
+      // normal materialized vec spread (same shape as the externref path).
+      const genInfo = nativeGeneratorInfoForForOfSubject(ctx, srcType);
+      if (genInfo) {
+        const genVecTypeIdx = getOrRegisterVecType(ctx, "f64");
+        const genArrTypeIdx = getArrTypeIdxFromVec(ctx, genVecTypeIdx);
+        if (vecTypeIdx !== genVecTypeIdx) {
+          // Result element type isn't f64 (mixed literal whose first-element
+          // heuristic picked another type) — copying f64s into that array would
+          // be invalid Wasm. Preserve the conservative skip for this rare shape.
+          fctx.body.push({ op: "drop" });
+          continue;
+        }
+        // Stack: [running-length(i32), genState]. emitNativeGeneratorToVec
+        // consumes genState and leaves (ref $vec_f64).
+        emitNativeGeneratorToVec(ctx, fctx, genInfo, srcType, genVecTypeIdx, genArrTypeIdx);
+        const srcLocal = allocLocal(fctx, `__spread_gen_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: genVecTypeIdx,
+        });
+        fctx.body.push({ op: "local.tee", index: srcLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: genVecTypeIdx, fieldIdx: 0 });
+        fctx.body.push({ op: "i32.add" });
+        spreadLocals.push({ local: srcLocal, elemIdx: i, srcVecTypeIdx: genVecTypeIdx });
+        continue;
+      }
       if (
         (srcType.kind === "ref" || srcType.kind === "ref_null") &&
         ctx.nativeStrings &&

--- a/tests/issue-2169-spread-native-generator.test.ts
+++ b/tests/issue-2169-spread-native-generator.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2169 (SF-2 of #2157) — array spread of a Wasm-native generator.
+ *
+ * A top-level `function*` lowers (since #2079) to a native state struct
+ * consumed correctly by `for-of`. But `[...g()]` treated that state struct as a
+ * `__vec` (reading field 0 — actually `state` — as a `$length`), building a
+ * garbage-length array of defaults and never calling `next()`. This slice
+ * drains the generator via the native resume loop into an f64 vec
+ * (`emitNativeGeneratorToVec`), then reuses the normal materialized-vec spread.
+ *
+ * Scope: array spread only. `Array.from(gen)` and array-destructuring
+ * (`[a,b]=gen()`) are separate consumer call sites carried forward under #2169
+ * (see the issue's "remaining" note); their `it.todo` gates live in
+ * tests/issue-2157-iterator-generator-residual.test.ts.
+ *
+ * Every case must compile standalone with ZERO host imports and run correctly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2169 array spread of a native generator", () => {
+  it("spread length", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 1; yield 2; yield 3; }
+export function test(): number { const a=[...g()]; return a.length; }`),
+    ).toBe(3);
+  });
+
+  it("spread values", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 1; yield 2; yield 3; }
+export function test(): number { const a=[...g()]; return a[0]*100 + a[1]*10 + a[2]; }`),
+    ).toBe(123);
+  });
+
+  it("spread more than initial capacity (>4 yields exercises grow)", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 0; yield 1; yield 2; yield 3; yield 4; yield 5; }
+export function test(): number { const a=[...g()]; let s=0; for (let i=0;i<a.length;i++) s+=a[i]; return s*1000 + a.length; }`),
+    ).toBe(15006); // sum 0..5 = 15, length 6
+  });
+
+  it("spread of a control-flow generator", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i=0; while(i<4){ if (i!==1) yield i; i++; } }
+export function test(): number { const a=[...g()]; let s=0; for (let i=0;i<a.length;i++) s+=a[i]; return s*100 + a.length; }`),
+    ).toBe(503); // values 0,2,3 → sum 5, length 3
+  });
+
+  it("mixed literal [head, ...gen]", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 3; yield 4; }
+export function test(): number { const a=[0, ...g()]; return a.length*1000 + a[0]*100 + a[1]*10 + a[2]; }`),
+    ).toBe(3034); // length 3, [0,3,4]
+  });
+
+  // Regression guards — non-generator spread paths must stay byte-identical.
+  it("regression: array spread", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a=[1,2,3]; const b=[...a]; return b[0]+b[1]+b[2]; }`),
+    ).toBe(6);
+  });
+  it("regression: string spread", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[..."abcd"]; return a.length; }`)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

SF-2 of the #2157 iterator/generator residual triage. A top-level `function*` lowers (since #2079) to a native state struct consumed correctly by `for-of`, but `[...g()]` treated that state struct as a `__vec` (reading field 0 — actually `state` — as a `$length`), building a garbage-length array of defaults and never calling `next()`. Standalone `[...g()]` returned a wrong-length array of `NaN`.

## Fix — recover the generator at the spread read site

- **New reusable helper** `emitNativeGeneratorToVec` in `generators-native.ts`: drains the generator via the same `resume()`-until-`done` loop the for-of driver uses, accumulating yields into a growable f64 backing array, leaving a freshly built `ref $vec_f64` on the stack.
- **`literals.ts compileArrayLiteral`** detects a native-generator spread subject via `nativeGeneratorInfoForForOfSubject` and materializes through that helper, then reuses the existing materialized-vec spread machinery (same shape as the externref `buildVecFromExternref` path).

Type indices only (the only func index is the `resume` call the helper already reserves) → no late-import shift hazard. Numeric yields only (native generators are numeric today; non-numeric is #2171).

## Tests

`tests/issue-2169-spread-native-generator.test.ts` — standalone, zero host imports: `[...g()]` length/values, >4-yield grow path, control-flow generators, mixed `[head, ...g()]`, plus array/string spread regression guards. Existing generator/iterator suites (`#2079`, `#1665`, `#681`) unchanged.

> Pre-existing failures unrelated to this PR (reproduce identically on main HEAD): `spread-rest.test.ts` (instantiates host-mode modules with an empty import object → `string_constants` import error — the known `{env:{}}` test-harness gotcha) and `#681` typed-array-WASI.

## Scope / carried forward

Array **spread** lands here. `Array.from(g())` and array-destructuring `[a,b]=g()` are separate consumer call sites — the `emitNativeGeneratorToVec` helper is ready to wire into both; left as a focused follow-up under #2169 (kept `in-progress`). Their `it.todo` gates are in `tests/issue-2157-*.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)