### PR TITLE
feat(#2172): no-capture nested function* lowers to native generator (SF-1 of #2157)

### DIFF
--- a/plan/issues/2172-standalone-nested-generator-native-lowering.md
+++ b/plan/issues/2172-standalone-nested-generator-native-lowering.md
@@ -1,0 +1,81 @@
+---
+id: 2172
+title: "standalone: nested `function*` declarations take the JS-host path (funcindex CE) — native lowering only wired for top-level generators"
+status: done
+completed: 2026-06-15
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-15
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: iterators-generators
+goal: standalone-mode
+parent: 2157
+depends_on: [2079]
+---
+
+# #2172 — nested generator native lowering (SF-1 of #2157)
+
+> Renumbered from #2168 (which was already assigned to the multi-dev
+> issue-assignment-lock issue).
+
+## Problem
+
+A `function*` declared INSIDE a function body always took the JS-host
+generator path (`__create_generator` etc.), so standalone leaks env imports /
+hits the late-import funcindex CE. The same generator hoisted to top-level
+works (native lowering, #2079).
+
+```ts
+export function test(): number {
+  function* g(){ yield 1; yield 2; yield 3; }   // nested
+  let s=0; for (const v of g()) s+=v; return s;  // was: funcindex CE; exp 6
+}
+```
+
+## Root cause
+
+`statements/nested-declarations.ts:207-209` hard-coded a nested generator's
+return type to `externref` and never called `registerNativeGenerator` /
+`compileNativeGeneratorFunction`. The native path
+(`collectDeclarations` → `registerNativeGenerator`) was only wired for
+top-level `sourceFile.statements` + `registerBodylessFunctionDeclaration`.
+
+## Resolution (2026-06-15, sdev5) — no-capture native lowering landed
+
+`compileNestedFunctionDeclaration` now, for a **no-capture** native-generator
+candidate (`isGenerator && captures.length === 0 && isNativeGeneratorCandidate`),
+registers it via `registerNativeGenerator` (so the factory returns the
+state-struct ref) and emits the factory body via `compileNativeGeneratorFunction`
+— exactly the top-level path. A no-capture nested generator is semantically a
+module-level function, so it slots straight into the existing native machinery.
+The funcindex hazard is already handled: the no-capture branch reserves the
+function's module slot with a placeholder before its body emits (#2068/#2079).
+
+Verified standalone, zero host imports: sequential / while / for(param) yields,
+manual `next()`, and multiple distinct nested generators in one function.
+Top-level generators unchanged; default (JS-host) mode unchanged (the native
+path is gated on `noJsHostTarget` inside `isNativeGeneratorCandidate`).
+Test: `tests/issue-2172-nested-native-generator.test.ts`.
+
+## Deliberately deferred — capturing nested generators
+
+A nested generator that **captures** an enclosing local still falls through to
+the host path (which fails standalone) — the resume function runs detached from
+the enclosing frame, so captured cells would have to spill into the state
+struct. That's a separate, larger change (`reasoning_effort: max`). Tracked as
+the SF-1 capture follow-up under #2157. The capture case bails cleanly (no
+crash, no wrong answer) exactly as before.
+
+## Acceptance criteria
+
+- No-capture nested generators compile + run standalone with zero host imports.
+- Capturing nested generators bail cleanly (unchanged).
+- Top-level + JS-host generator paths unchanged.
+
+## Source
+
+Triage of #2157 (2026-06-15, sdev5), SF-1 — largest single lever in the gap.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -20,6 +20,11 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext, OptionalParamInfo } from "../context/types.js";
+import {
+  compileNativeGeneratorFunction,
+  isNativeGeneratorCandidate,
+  registerNativeGenerator,
+} from "../generators-native.js";
 import { emitThrowReferenceError, emitThrowString, emitThrowTypeError } from "../expressions/helpers.js";
 import {
   collectClassDeclaration,
@@ -319,6 +324,31 @@ export function compileNestedFunctionDeclaration(
     captures.push({ name, type, localIdx, mutable: isMutable, hasTdzFlag, tdzFlagIdx });
   }
 
+  // (#2172 / SF-1 of #2157) Wasm-native lowering for a NESTED `function*` in
+  // standalone/WASI. Previously a nested generator always took the JS-host
+  // buffer path (`__create_generator` etc.), which in standalone leaks env
+  // imports / hits the late-import funcindex CE — the same regression #2079
+  // fixed for top-level generators, but never wired for nested declarations.
+  //
+  // Scope: NO captures only. A capturing nested generator would need its
+  // captured cells spilled into the state struct (the resume function runs
+  // detached from the enclosing frame) — that's a separate, larger change
+  // (`reasoning_effort: max`), so a capturing native candidate falls through to
+  // the host path unchanged. A no-capture nested generator is semantically a
+  // module-level function, so it slots straight into the existing top-level
+  // native machinery (`registerNativeGenerator` → state struct return →
+  // `compileNativeGeneratorFunction`). The funcindex hazard is already handled:
+  // both the no-capture and has-captures branches reserve the function's module
+  // slot with a placeholder BEFORE the body emits (#2068 / #2079).
+  const nativeGenInfo =
+    isGenerator && captures.length === 0 && isNativeGeneratorCandidate(ctx, stmt)
+      ? registerNativeGenerator(ctx, stmt, funcName, paramTypes)
+      : undefined;
+  if (nativeGenInfo) {
+    // The generator factory returns the state struct, not a JS Generator object.
+    returnType = { kind: "ref", typeIdx: nativeGenInfo.stateTypeIdx };
+  }
+
   const results: ValType[] = returnType ? [returnType] : [];
 
   // Register optional/default parameters so call sites can supply defaults
@@ -458,7 +488,12 @@ export function compileNestedFunctionDeclaration(
       emitArgumentsObject(ctx, liftedFctx, paramTypes, 0, isStrictFunction(stmt));
     }
 
-    if (isGenerator) {
+    if (nativeGenInfo) {
+      // (#2172) No-capture nested `function*` in standalone/WASI — emit the
+      // Wasm-native generator factory (builds + returns the state struct), the
+      // same body the top-level path emits. No host imports, no JS buffer.
+      compileNativeGeneratorFunction(ctx, liftedFctx, stmt, nativeGenInfo);
+    } else if (isGenerator) {
       // Generator function: eagerly evaluate body, collect yields into a JS array,
       // then wrap it with __create_generator to return a Generator-like object.
       // The body is wrapped in try/catch so that exceptions thrown before any yields

--- a/tests/issue-2172-nested-native-generator.test.ts
+++ b/tests/issue-2172-nested-native-generator.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2172 (SF-1 of #2157) — no-capture nested `function*` lowers to the
+ * Wasm-native generator in standalone / WASI.
+ *
+ * Before this slice, a generator declared INSIDE a function body always took
+ * the JS-host buffer path (`__create_generator` etc.) — the native lowering
+ * was only wired for top-level declarations (`collectDeclarations` /
+ * `registerBodylessFunctionDeclaration`). So a nested generator in standalone
+ * either leaked env imports or hit the late-import funcindex CE (#2079's class,
+ * but for nested decls). The hoisted-to-top-level form of the SAME generator
+ * worked.
+ *
+ * `compileNestedFunctionDeclaration` now, for a NO-CAPTURE native-generator
+ * candidate, registers it via `registerNativeGenerator` (state-struct return)
+ * and emits the factory via `compileNativeGeneratorFunction` — exactly the
+ * top-level path. A *capturing* nested generator still falls through to the
+ * host path (its captured cells would need to spill into the state struct — a
+ * separate, larger change; tracked as the SF-1 capture follow-up).
+ *
+ * Every case must compile standalone with ZERO host imports and run correctly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2172 no-capture nested native generator", () => {
+  it("sequential yields, nested in a function body", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        function* g(){ yield 1; yield 2; yield 3; }
+        let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6);
+  });
+
+  it("while-loop yield, nested", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        function* g(){ let i = 0; while (i < 4) { yield i; i++; } }
+        let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6); // 0+1+2+3
+  });
+
+  it("for-loop yield with a param bound, nested", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        function* g(n: number){ for (let i = 0; i < n; i++) yield i * 2; }
+        let s = 0; for (const v of g(4)) s += v; return s; }`),
+    ).toBe(12); // 0+2+4+6
+  });
+
+  it("manual next().value, nested", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        function* g(){ yield 7; yield 8; }
+        const it = g(); return it.next().value as number; }`),
+    ).toBe(7);
+  });
+
+  it("two distinct nested generators in one function", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        function* a(){ yield 1; yield 2; }
+        function* b(){ yield 3; yield 3; }
+        let s = 0; for (const v of a()) s += v; for (const v of b()) s += v; return s; }`),
+    ).toBe(9); // (1+2) + (3+3)
+  });
+});
+
+describe("#2172 regression — top-level native generators unchanged", () => {
+  it("top-level sequential for-of", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 1; yield 2; yield 3; }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6);
+  });
+
+  it("top-level while-loop yield", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (i < 4) { yield i; i++; } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

SF-1 of the #2157 iterator/generator residual — the **largest single lever** in the 2,172-test gap. A `function*` declared inside a function body always took the JS-host buffer path (`__create_generator` etc.), so standalone leaked env imports / hit the late-import funcindex CE (#2079's class, but for nested decls). The hoisted-to-top-level form of the same generator worked; the nested form did not.

## Fix

`compileNestedFunctionDeclaration` now, for a **no-capture** native-generator candidate (`isGenerator && captures.length === 0 && isNativeGeneratorCandidate`), registers it via `registerNativeGenerator` (so the factory returns the state-struct ref) and emits the factory via `compileNativeGeneratorFunction` — the same path the top-level machinery uses. A no-capture nested generator is semantically a module-level function, so it slots straight in. The funcindex hazard is already covered: the no-capture branch reserves the function's module slot with a placeholder before its body emits (#2068/#2079).

## Scope

**No captures only.** A *capturing* nested generator (its cells would have to spill into the detached resume function's state struct) still falls through to the host path, bailing cleanly — tracked as the SF-1 capture follow-up under #2157. Default (JS-host) mode is unchanged: the native path is gated on `noJsHostTarget` inside `isNativeGeneratorCandidate`.

## Tests

`tests/issue-2172-nested-native-generator.test.ts` — standalone, zero host imports: sequential / while / for(param) yields nested in a body, manual `next()`, two distinct nested generators in one function; plus top-level regression guards. Existing generator/closure suites green (`issue-2079`, `issue-1665`, `issue-995-996`, `issue-1712`).

> Pre-existing failures unrelated to this PR (reproduce on main HEAD): `generator-nested.test.ts` (missing `./helpers.js` infra gotcha), default-mode *capturing* nested generator (separate known limitation, deferred above).

## Notes

- Issue renumbered from **#2168** (taken by the multi-dev issue-assignment-lock). The companion #1490 (triage PR) carries the matching rename.
- Composes with #2169 (PR #1491, enqueued): once both land, nested generator + spread (`[...g()]`) work together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)