### PR TITLE
fix(#2051): optional property access + typeof yield undefined on short-circuit

### DIFF
--- a/plan/issues/2051-optional-chain-undefined-representation.md
+++ b/plan/issues/2051-optional-chain-undefined-representation.md
@@ -1,10 +1,10 @@
 ---
 id: 2051
 title: "short-circuited ?. produces the type's default value (0 / \"null\") instead of undefined"
-status: ready
+status: in-progress
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-15
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -367,3 +367,44 @@ import (`__get_undefined`, `__box_number`, `__box_boolean` all already exist) an
 touches a disjoint code path (optional-chain sites only). It can land any time
 after #2050. Coordinate only the `compileElementAccess` optional-branch ownership
 with #2050 (see above).
+
+---
+
+## Resolution (2026-06-15, sdev5) — property access + typeof landed; call/element carried forward
+
+**Landed in this PR:**
+
+1. **`compileOptionalPropertyAccess`** (`property-access.ts`) — when the chain's
+   whole-expression static type is a nullable primitive
+   (`isNullablePrimitiveType(tsPropType)`, e.g. `number | undefined`), the result
+   widens to externref; the short-circuit (null) arm emits host `undefined`
+   (`emitUndefined`) and the non-null arm's existing `coerceType(elseResultType,
+   resultType)` boxes the primitive (`__box_number`/`__box_boolean`). Both the
+   non-reference-receiver short-circuit and the main `ref.is_null` arm updated.
+2. **`staticTypeofForType`** (`typeof-delete.ts`) — unions are now resolved
+   BEFORE the `resolveWasmType` collapse. `number | undefined` collapsed to f64
+   and mis-folded `typeof o?.v` to the constant "number"; per §13.5.3 it is only
+   statically known if every member agrees, so `number`+`undefined` (size 2) →
+   dynamic → reaches runtime `__typeof` → "undefined" for the nullish arm.
+
+Verified (default JS-host mode, `tests/issue-2051-optional-chain-undefined.test.ts`,
+8 cases): nullish `o?.v === undefined`, `typeof o?.v === "undefined"`,
+`"" + o?.v === "undefined"`, `o?.v ?? 5 === 5`; non-null `o?.v === 9`,
+`typeof === "number"`, the `v=0` distinguishing case, and nullish boolean
+`if (o?.flag)` falsy. No regression: `??` already routes externref through
+`__extern_is_undefined`, `issue-2049`/typeof suites green. Per the plan this
+boxes into a plain externref (not AnyValue), so the #1888 tag-5 comparator ABI is
+untouched.
+
+**Carried forward (still on #2051, status in-progress):** the optional **call**
+short-circuit (`o?.f()`, `calls-optional.ts`) and optional **element** access
+(`a?.[i]`, `compileOptionalElementAccess`). An initial calls-optional widening
+attempt regressed the non-nullish path (the call's VOID_RESULT handling +
+closure-field re-eval fallback + multiple `defaultValueInstrs` sites make the
+result-type widening interact badly — `o?.f(1)===2` started trapping). Reverted
+to keep this PR clean; those two arms need the same widen-to-externref +
+`emitUndefined` treatment but applied with care to the call's else-branch value
+coercion (the call arm must box its primitive return only when widening fires,
+and VOID_RESULT calls must never widen). The standalone caveat (host `undefined`
+falls back to `ref.null.extern`, indistinguishable from null) is unchanged and
+out of scope, per the plan.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -8,7 +8,12 @@
  */
 
 import { ts } from "../ts-api.js";
-import { isExternalDeclaredClass, isIteratorResultType, isStringType } from "../checker/type-mapper.js";
+import {
+  isExternalDeclaredClass,
+  isIteratorResultType,
+  isNullablePrimitiveType,
+  isStringType,
+} from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { popBody } from "./context/bodies.js";
@@ -24,7 +29,7 @@ import {
   noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
-import { patchStructNewForAddedField } from "./expressions/late-imports.js";
+import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
@@ -1192,6 +1197,24 @@ export function compileOptionalPropertyAccess(
   if (resultType.kind === "ref" || resultType.kind === "ref_null") {
     resultType = { kind: "externref" };
   }
+  // (#2051) A short-circuited `?.` must yield `undefined`, not the property
+  // type's default. When the whole-chain static type is a nullable primitive
+  // (`number | undefined` etc., which `resolveWasmType` collapses to a bare
+  // f64/i32 that cannot represent `undefined`), widen the result to externref so
+  // the null arm can carry host `undefined` (via `emitUndefined`) and the
+  // non-null arm boxes the primitive (`__box_number`/`__box_boolean`) — both
+  // arms then agree on externref. The rest of the pipeline already discriminates
+  // host undefined in this slot: `=== undefined` (`__extern_is_undefined`),
+  // `typeof` (`__typeof`), and ToString (`__extern_toString`). Gated on the
+  // nullable static type so non-nullable optional accesses (e.g. `s?.length`
+  // where `s: string`) keep their bare f64/i32 codegen — no boxing, no perf hit.
+  // This boxes into a plain externref, NOT the AnyValue struct, so the #1888
+  // tag-5 comparator ABI is untouched.
+  const widenToUndefinedExternref =
+    (resultType.kind === "f64" || resultType.kind === "i32") && isNullablePrimitiveType(tsPropType);
+  if (widenToUndefinedExternref) {
+    resultType = { kind: "externref" };
+  }
 
   // `?.` short-circuits on null/undefined. `ref.is_null` only validates on a
   // reference operand, but the receiver can lower to a non-reference value
@@ -1206,7 +1229,10 @@ export function compileOptionalPropertyAccess(
     } else if (resultType.kind === "i32") {
       fctx.body.push({ op: "i32.const", value: 0 });
     } else {
-      fctx.body.push({ op: "ref.null.extern" });
+      // (#2051) externref result (incl. the nullable-primitive widening above)
+      // → host `undefined`, so `=== undefined` / `typeof` / `+` read it as
+      // undefined rather than a bare null.
+      emitUndefined(ctx, fctx);
     }
     return resultType;
   }
@@ -1225,7 +1251,14 @@ export function compileOptionalPropertyAccess(
   } else if (resultType.kind === "i32") {
     thenInstrs = [{ op: "i32.const", value: 0 }];
   } else {
-    thenInstrs = [{ op: "ref.null.extern" }];
+    // (#2051) externref result (incl. the nullable-primitive widening above) →
+    // host `undefined`. Build via a body-swap because `emitUndefined` pushes to
+    // `fctx.body` and may flush late imports; do not hand-roll the instr array.
+    const savedForThen = fctx.body;
+    fctx.body = [];
+    emitUndefined(ctx, fctx);
+    thenInstrs = fctx.body;
+    fctx.body = savedForThen;
   }
 
   // else branch (non-null path): get the property from the temp

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -717,6 +717,23 @@ function staticTypeofForType(ctx: CodegenContext, tsType: ts.Type): string | nul
   if (tsType.flags & ts.TypeFlags.Undefined || tsType.flags & ts.TypeFlags.Void) return "undefined";
   if (tsType.flags & ts.TypeFlags.BigInt || tsType.flags & ts.TypeFlags.BigIntLiteral) return "bigint";
 
+  // (#2051) Resolve unions BEFORE the `resolveWasmType` collapse below. A
+  // nullable primitive like `number | undefined` (the static type of `o?.v`)
+  // collapses to a bare f64 under `resolveWasmType`, which would mis-fold
+  // `typeof o?.v` to the constant "number" — wrong when the chain short-circuits
+  // to `undefined`. Per §13.5.3 the union's typeof is only statically known if
+  // every member agrees; `number` + `undefined` disagree (size 2) → dynamic
+  // (`null`), so it reaches the runtime `__typeof` which reads host undefined.
+  if (tsType.isUnion?.()) {
+    const results = new Set<string>();
+    for (const member of (tsType as ts.UnionType).types) {
+      const r = staticTypeofForType(ctx, member);
+      if (r === null) return null;
+      results.add(r);
+    }
+    return results.size === 1 ? [...results][0]! : null;
+  }
+
   // Wrapper objects (new String/Number/Boolean) are "object" not their primitive type (#929)
   if (tsType.flags & ts.TypeFlags.Object) {
     const sym = tsType.getSymbol?.();
@@ -758,17 +775,7 @@ function staticTypeofForType(ctx: CodegenContext, tsType: ts.Type): string | nul
     if (tsType.flags & ts.TypeFlags.Object) return "object";
   }
 
-  // For union types, check if all members resolve to the same result
-  if (tsType.isUnion?.()) {
-    const results = new Set<string>();
-    for (const member of (tsType as ts.UnionType).types) {
-      const r = staticTypeofForType(ctx, member);
-      if (r === null) return null;
-      results.add(r);
-    }
-    if (results.size === 1) return [...results][0]!;
-  }
-
+  // (Unions are resolved up-front above, before the resolveWasmType collapse.)
   return null;
 }
 

--- a/tests/issue-2051-optional-chain-undefined.test.ts
+++ b/tests/issue-2051-optional-chain-undefined.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2051 — a short-circuited optional **property** access (`o?.v`) whose static
+ * type is a nullable primitive (`number | undefined`) must yield `undefined`,
+ * not the property type's default (`0`).
+ *
+ * Before this slice, `compileOptionalPropertyAccess` lowered the whole `?.`
+ * result to the property's bare value type (f64/i32) and the short-circuit arm
+ * fabricated a typed zero — so `o?.v === undefined`, `typeof o?.v`, `"" + o?.v`,
+ * and `o?.v ?? d` all went wrong for a nullish receiver.
+ *
+ * Fix: when the chain's static result type is a nullable primitive, the result
+ * is widened to externref; the null arm emits host `undefined` (`emitUndefined`)
+ * and the non-null arm boxes the primitive (`__box_number`/`__box_boolean`).
+ * `staticTypeofForType` was also corrected to resolve unions (e.g.
+ * `number | undefined`) BEFORE the `resolveWasmType` collapse, so `typeof o?.v`
+ * no longer const-folds to "number".
+ *
+ * Scope: property access (`o?.v`) + `typeof`. Optional **call** (`o?.f()`) and
+ * optional **element** access (`a?.[i]`) short-circuit arms are a separate
+ * follow-up under #2051 (calls-optional.ts / compileOptionalElementAccess) — not
+ * regressed here (their non-nullish path still returns the real value).
+ *
+ * Default (JS-host) mode: relies on host `undefined` (`__get_undefined`),
+ * `__typeof`, `__extern_toString`, `__extern_is_undefined` — all already present.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): number }).test();
+}
+
+const OBJ = `type Obj = { v: number };
+function getObj(b: boolean): Obj | null { return b ? { v: 9 } : null; }`;
+
+describe("#2051 optional property access yields undefined on short-circuit", () => {
+  it("nullish: o?.v === undefined", async () => {
+    expect(
+      await run(`${OBJ}\nexport function test(): boolean { const o = getObj(false); return (o?.v) === undefined; }`),
+    ).toBe(1);
+  });
+  it("nullish: typeof o?.v === 'undefined'", async () => {
+    expect(
+      await run(
+        `${OBJ}\nexport function test(): boolean { const o = getObj(false); return typeof (o?.v) === "undefined"; }`,
+      ),
+    ).toBe(1);
+  });
+  it('nullish: "" + o?.v === "undefined"', async () => {
+    expect(
+      await run(
+        `${OBJ}\nexport function test(): boolean { const o = getObj(false); return ("" + (o?.v)) === "undefined"; }`,
+      ),
+    ).toBe(1);
+  });
+  it("nullish: o?.v ?? 5 === 5", async () => {
+    expect(
+      await run(`${OBJ}\nexport function test(): boolean { const o = getObj(false); return ((o?.v) ?? 5) === 5; }`),
+    ).toBe(1);
+  });
+
+  it("non-null: o?.v === 9", async () => {
+    expect(await run(`${OBJ}\nexport function test(): boolean { const o = getObj(true); return (o?.v) === 9; }`)).toBe(
+      1,
+    );
+  });
+  it("non-null: typeof o?.v === 'number'", async () => {
+    expect(
+      await run(
+        `${OBJ}\nexport function test(): boolean { const o = getObj(true); return typeof (o?.v) === "number"; }`,
+      ),
+    ).toBe(1);
+  });
+  it("non-null v=0: o?.v === undefined is false (typed-zero rep can never get this right)", async () => {
+    expect(
+      await run(
+        `type O2 = { v: number }; function g2(b: boolean): O2 | null { return b ? { v: 0 } : null; }
+export function test(): boolean { const o = g2(true); return ((o?.v) === undefined) === false; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("nullish boolean: if (o?.flag) is falsy", async () => {
+    expect(
+      await run(
+        `type OF = { flag: boolean }; function gf(b: boolean): OF | null { return b ? { flag: true } : null; }
+export function test(): boolean { const o = gf(false); return (o?.flag) ? false : true; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Lane A value-rep critical-path item (unblocked by the #2142 spec). A short-circuited optional **property** access (`o?.v`) whose static type is a nullable primitive (`number | undefined`) fabricated the property type's default (`f64 0`) instead of `undefined` — so for a nullish receiver, `o?.v === undefined`, `typeof o?.v`, `"" + o?.v`, and `o?.v ?? d` all went wrong.

## Fix (per the architect plan in the issue)

- **`compileOptionalPropertyAccess`** (`property-access.ts`): when the chain's whole-expression static type is a nullable primitive (`isNullablePrimitiveType`), widen the result to externref; the null arm emits host `undefined` (`emitUndefined`) and the existing `coerceType(elseResultType, resultType)` boxes the non-null primitive (`__box_number`/`__box_boolean`). Both the non-reference-receiver short-circuit and the main `ref.is_null` arm. Gated on the nullable static type → non-nullable optional accesses keep bare f64/i32 codegen (no perf hit).
- **`staticTypeofForType`** (`typeof-delete.ts`): resolve unions **before** the `resolveWasmType` collapse. `number | undefined` collapsed to f64 and mis-folded `typeof o?.v` to the constant `"number"`; per §13.5.3 it's only statically known if every member agrees, so `number`+`undefined` → dynamic → runtime `__typeof` → `"undefined"`.

Boxes into a **plain externref** (not the AnyValue struct), so the #1888 tag-5 comparator ABI is untouched.

## Tests

`tests/issue-2051-optional-chain-undefined.test.ts` (8 cases, default JS-host): nullish `o?.v === undefined` / `typeof === "undefined"` / `"" + o?.v` / `?? 5`; non-null `o?.v === 9` / `typeof === "number"`; the `v=0` distinguishing case; nullish boolean `if (o?.flag)` falsy. `issue-2049` + typeof suites green; `??` already routes externref through `__extern_is_undefined` (no change needed).

## Scope / carried forward

Property access + `typeof` landed. The optional **call** (`o?.f()`, `calls-optional.ts`) and optional **element** access (`a?.[i]`, `compileOptionalElementAccess`) short-circuit arms are carried forward (#2051 stays `in-progress`) — they need the same widen + `emitUndefined` treatment, but applied with care to the call's else-branch coercion and `VOID_RESULT` handling (an initial attempt regressed the non-nullish call path via a late-import index shift, so it was reverted to keep this PR clean). Detailed in the issue's resolution note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)