### PR TITLE
feat(#2171): string-yield native generators in standalone (SF-4 of #2157)

### DIFF
--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -158,6 +158,14 @@ export interface NativeGeneratorInfo {
   yieldCount: number;
   /** Terminal state value. */
   doneState: number;
+  /**
+   * (#2171) ValType of the generator's yielded values. `{kind:"f64"}` for the
+   * numeric path (default); the native-string ref for a generator whose yields
+   * are all strings. The result struct's `value` field and the for-of / .next()
+   * extraction read this. Mixed / object yields are not yet supported (the plan
+   * bails before a generator with disagreeing yield types is registered).
+   */
+  elemValType: ValType;
 }
 
 export type NullishExclusion = "null" | "undefined" | "nullish";

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -26,12 +26,13 @@
  *     (try/finally without catch is, as in Phase 1).
  */
 import { ts } from "../ts-api.js";
-import { isBooleanType, isNumberType } from "../checker/type-mapper.js";
+import { isBooleanType, isNumberType, isStringType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
 import { allocLocal } from "./context/locals.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import type { CodegenContext, FunctionContext, NativeGeneratorInfo } from "./context/types.js";
 import { reportError } from "./context/errors.js";
+import { nativeStringType } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
 import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
 
@@ -84,6 +85,8 @@ interface NativeGeneratorState {
 interface NativeGeneratorPlan {
   states: NativeGeneratorState[];
   spills: string[];
+  /** (#2171) Uniform yield element ValType — f64 (numeric) or native string. */
+  elemValType: ValType;
 }
 
 function noJsHostTarget(ctx: CodegenContext): boolean {
@@ -98,6 +101,51 @@ function isNumericExpression(ctx: CodegenContext, expr: ts.Expression | undefine
   if (!expr) return true;
   const t = ctx.checker.getTypeAtLocation(expr);
   return isNumberType(t) || isBooleanType(t);
+}
+
+// (#2171) Native-string yield support. A yield expression qualifies for the
+// string-payload path when its static type is a string and the target lowers
+// strings to the native `$AnyString` ref (standalone / nativeStrings). The
+// generator-wide elem type is decided up-front (generatorElemValType): all
+// numeric → f64 (the default path), all string → the native string ref,
+// anything else / mixed → unsupported (bail to the #680 diagnostic).
+function isStringYieldExpression(ctx: CodegenContext, expr: ts.Expression | undefined): boolean {
+  if (!expr) return false;
+  if (!(ctx.nativeStrings && ctx.anyStrTypeIdx >= 0)) return false;
+  return isStringType(ctx.checker.getTypeAtLocation(expr));
+}
+
+/**
+ * Decide a generator's uniform yield element ValType, or null when the yields
+ * are mixed / unsupported (caller bails). Walks every `yield` in the body
+ * (not descending into nested functions). Returns `{kind:"f64"}` when there are
+ * no yields (degenerate; the plan rejects zero-yield generators separately).
+ */
+function generatorElemValType(ctx: CodegenContext, decl: ts.FunctionDeclaration): ValType | null {
+  let sawNumeric = false;
+  let sawString = false;
+  let unsupported = false;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
+      return; // a yield here belongs to an inner generator
+    }
+    if (ts.isYieldExpression(node) && !node.asteriskToken) {
+      if (isNumericExpression(ctx, node.expression)) sawNumeric = true;
+      else if (isStringYieldExpression(ctx, node.expression)) sawString = true;
+      else unsupported = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  if (decl.body) visit(decl.body);
+  if (unsupported) return null;
+  if (sawString && sawNumeric) return null; // mixed — deferred follow-up
+  if (sawString) return nativeStringType(ctx);
+  return { kind: "f64" };
 }
 
 function statementContainsYield(stmt: ts.Statement): boolean {
@@ -174,6 +222,17 @@ function nodeContainsYield(root: ts.Node): boolean {
  */
 function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclaration): NativeGeneratorPlan | null {
   if (!decl.body) return null;
+
+  // (#2171) Decide the uniform yield element type up-front. Numeric → f64 (the
+  // historical path); all-string → native string ref; mixed / unsupported →
+  // bail. `yieldValueOk` then gates each per-yield check on that decision so a
+  // string yield is accepted only in a string-typed generator (and a numeric
+  // yield only in a numeric one).
+  const elemValType = generatorElemValType(ctx, decl);
+  if (elemValType === null) return null;
+  const elemIsString = elemValType.kind === "ref" || elemValType.kind === "ref_null";
+  const yieldValueOk = (expr: ts.Expression | undefined): boolean =>
+    elemIsString ? isStringYieldExpression(ctx, expr) : isNumericExpression(ctx, expr);
 
   const states: NativeGeneratorState[] = [];
   const spills: string[] = [];
@@ -258,7 +317,9 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclarat
       // first so a bare `return expr;` is a completion terminator, not a raw
       // wasm `return` from compileStatement.)
       if (ts.isReturnStatement(stmt)) {
-        if (!isNumericExpression(ctx, stmt.expression)) return fail();
+        // (#2171) The return *value* must match the generator's yield element
+        // type (numeric or string); a bare `return;` (no expr) is allowed.
+        if (stmt.expression && !yieldValueOk(stmt.expression)) return fail();
         collectSpillsIn(stmt);
         finishState(curId, { kind: "return", expr: stmt.expression });
         // Unreachable tail — start a fresh (dead) state so the cursor stays
@@ -347,7 +408,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclarat
     bindSentTo: string | undefined,
     activeFinalizers: readonly ts.Statement[][],
   ): boolean {
-    if (yieldExpr.asteriskToken || !isNumericExpression(ctx, yieldExpr.expression)) return fail();
+    if (yieldExpr.asteriskToken || !yieldValueOk(yieldExpr.expression)) return fail();
     const next = startStateAfterYield(bindSentTo, activeFinalizers);
     // The state we were filling (curIdBefore) is finished by startStateAfterYield's
     // caller — handled inside helper to keep ids tidy.
@@ -604,7 +665,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclarat
   if (yieldCount === 0) return null;
   if (states.length > MAX_NATIVE_GENERATOR_STATES) return null;
 
-  return { states, spills };
+  return { states, spills, elemValType };
 }
 
 /** A `break`/`continue` inside a yield-loop body is not modeled in this slice. */
@@ -688,24 +749,38 @@ export function sourceNeedsGeneratorHostImports(ctx: CodegenContext, sourceFile:
   return found && needsHost;
 }
 
-export function ensureNativeGeneratorResultType(ctx: CodegenContext): number {
-  if (ctx.nativeGeneratorResultTypeIdx >= 0) return ctx.nativeGeneratorResultTypeIdx;
-  const existing = ctx.structMap.get("__NativeGeneratorResult_f64");
+/**
+ * Result struct (`{ value, done }`) for a generator whose yields have the given
+ * `elemValType`. The numeric (f64) variant is cached on
+ * `ctx.nativeGeneratorResultTypeIdx` (the historical singleton, kept so the many
+ * f64 callers are unchanged); any other elem type (e.g. the native string ref,
+ * #2171) gets its own `__NativeGeneratorResult_<kind>` struct, cached in
+ * `structMap` by name. Defaults to f64 when no elem type is supplied.
+ */
+export function ensureNativeGeneratorResultType(ctx: CodegenContext, elemValType?: ValType): number {
+  const elem: ValType = elemValType ?? { kind: "f64" };
+  const isF64 = elem.kind === "f64";
+  if (isF64 && ctx.nativeGeneratorResultTypeIdx >= 0) return ctx.nativeGeneratorResultTypeIdx;
+
+  const kindTag =
+    elem.kind === "ref" || elem.kind === "ref_null" ? `ref${(elem as { typeIdx: number }).typeIdx}` : elem.kind;
+  const structName = `__NativeGeneratorResult_${kindTag}`;
+  const existing = ctx.structMap.get(structName);
   if (existing !== undefined) {
-    ctx.nativeGeneratorResultTypeIdx = existing;
+    if (isF64) ctx.nativeGeneratorResultTypeIdx = existing;
     return existing;
   }
 
   const fields: FieldDef[] = [
-    { name: "value", type: { kind: "f64" }, mutable: false },
+    { name: "value", type: elem, mutable: false },
     { name: "done", type: { kind: "i32" }, mutable: false },
   ];
   const typeIdx = ctx.mod.types.length;
-  ctx.mod.types.push({ kind: "struct", name: "__NativeGeneratorResult_f64", fields });
-  ctx.structMap.set("__NativeGeneratorResult_f64", typeIdx);
-  ctx.typeIdxToStructName.set(typeIdx, "__NativeGeneratorResult_f64");
-  ctx.structFields.set("__NativeGeneratorResult_f64", fields);
-  ctx.nativeGeneratorResultTypeIdx = typeIdx;
+  ctx.mod.types.push({ kind: "struct", name: structName, fields });
+  ctx.structMap.set(structName, typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, structName);
+  ctx.structFields.set(structName, fields);
+  if (isF64) ctx.nativeGeneratorResultTypeIdx = typeIdx;
   return typeIdx;
 }
 
@@ -722,7 +797,20 @@ export function registerNativeGenerator(
   const plan = buildNativeGeneratorPlan(ctx, decl);
   if (!plan) return null;
 
-  const resultTypeIdx = ensureNativeGeneratorResultType(ctx);
+  const elemValType = plan.elemValType;
+  const elemIsString = elemValType.kind !== "f64";
+  // (#2171) Scope guard for the string slice: spilled locals are typed f64 in
+  // the state struct, so a string generator that needs to spill a live local
+  // across a suspension can't faithfully store it yet. Bail to the host/#680
+  // path for that shape (numeric generators are unaffected — they spill f64).
+  // This keeps the slice to the dominant `yield "a"; yield "b"` shape; spilled
+  // non-numeric locals are the documented follow-up.
+  const bodySpillsForGuard = plan.spills.filter(
+    (s) => !decl.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === s),
+  );
+  if (elemIsString && bodySpillsForGuard.length > 0) return null;
+
+  const resultTypeIdx = ensureNativeGeneratorResultType(ctx, elemValType);
   const paramNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
   const stateFields: FieldDef[] = [
     { name: "state", type: { kind: "i32" }, mutable: true },
@@ -773,13 +861,27 @@ export function registerNativeGenerator(
     spillFieldOffset,
     yieldCount,
     doneState: plan.states.length - 1, // the final `done` state id
+    elemValType,
   };
   ctx.nativeGenerators.set(functionName, info);
   return info;
 }
 
+// (#2171) The default `value` for a done/empty result: f64 0 for numeric
+// generators, a null ref for string (the consumer never reads value when
+// done=1, so the null is inert — it only satisfies struct.new's type).
+function defaultElemValueInstr(elemValType: ValType): Instr {
+  if (elemValType.kind === "f64") return { op: "f64.const", value: 0 };
+  if (elemValType.kind === "i32") return { op: "i32.const", value: 0 };
+  return { op: "ref.null", typeIdx: (elemValType as { typeIdx: number }).typeIdx } as Instr;
+}
+
 function emptyResult(info: NativeGeneratorInfo): Instr[] {
-  return emptyResultForType(info.resultTypeIdx);
+  return [
+    defaultElemValueInstr(info.elemValType),
+    { op: "i32.const", value: 1 },
+    { op: "struct.new", typeIdx: info.resultTypeIdx },
+  ];
 }
 
 function emptyResultForType(resultTypeIdx: number): Instr[] {
@@ -864,6 +966,37 @@ function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: t
     coerceType(ctx, fctx, resultType, { kind: "f64" });
   }
   const tmp = allocLocal(fctx, `__gen_value_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: tmp });
+  return tmp;
+}
+
+/**
+ * (#2171) Compile a yield/return value to the generator's element ValType and
+ * return a local holding it. For numeric generators this is exactly
+ * `emitExpressionAsF64` (unchanged path). For a string generator it compiles the
+ * expression to the native string ref and stores it; a missing expr (bare
+ * `return;`) yields the elem-type default (null ref).
+ */
+function emitYieldValueAsElem(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression | undefined,
+  info: NativeGeneratorInfo,
+): number {
+  if (info.elemValType.kind === "f64") return emitExpressionAsF64(ctx, fctx, expr);
+  const elem = info.elemValType;
+  const tmp = allocLocal(fctx, `__gen_value_${fctx.locals.length}`, elem);
+  if (!expr) {
+    fctx.body.push(defaultElemValueInstr(elem));
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
+  const t = compileExpression(ctx, fctx, expr, elem);
+  if (t === null) {
+    fctx.body.push(defaultElemValueInstr(elem));
+  } else if (!valTypesMatch(t, elem)) {
+    coerceType(ctx, fctx, t, elem);
+  }
   fctx.body.push({ op: "local.set", index: tmp });
   return tmp;
 }
@@ -1011,8 +1144,17 @@ function compileState(
     }
     abruptBody.push(...storeSpills(info, fctx, selfLocal));
     abruptBody.push(...setStateInstrs(info, selfLocal, info.doneState));
-    abruptBody.push({ op: "local.get", index: selfLocal });
-    abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
+    // (#2171) `.return(v)` value lives in the f64 `abrupt` field. For a numeric
+    // generator that f64 IS the completion value; for a string generator the
+    // result `value` is a string ref, and string `.return(v)` is not yet wired
+    // (the abrupt field stays f64) — complete with the elem-type default so the
+    // result struct typechecks. (String `.return(v)` is a documented follow-up.)
+    if (info.elemValType.kind === "f64") {
+      abruptBody.push({ op: "local.get", index: selfLocal });
+      abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
+    } else {
+      abruptBody.push(defaultElemValueInstr(info.elemValType));
+    }
     abruptBody.push({ op: "i32.const", value: 1 });
     abruptBody.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
     abruptBody.push({ op: "local.set", index: resultLocal });
@@ -1046,7 +1188,7 @@ function compileState(
   const term = state.terminator;
   switch (term.kind) {
     case "yield": {
-      const tmp = emitExpressionAsF64(ctx, fctx, term.expr);
+      const tmp = emitYieldValueAsElem(ctx, fctx, term.expr, info);
       body.push(...storeSpills(info, fctx, selfLocal));
       body.push(...setStateInstrs(info, selfLocal, term.next));
       body.push(...setModeInstrs(info, selfLocal, 0));
@@ -1058,7 +1200,7 @@ function compileState(
       break;
     }
     case "return": {
-      const tmp = emitExpressionAsF64(ctx, fctx, term.expr);
+      const tmp = emitYieldValueAsElem(ctx, fctx, term.expr, info);
       body.push(...storeSpills(info, fctx, selfLocal));
       body.push(...setStateInstrs(info, selfLocal, info.doneState));
       body.push(...setModeInstrs(info, selfLocal, 0));
@@ -1222,13 +1364,27 @@ function nativeInfoForStateType(ctx: CodegenContext, typeIdx: number): NativeGen
   return undefined;
 }
 
+// (#2171) Reverse-lookup a generator info by its result-struct typeIdx (used to
+// recover the element ValType of an `it.next()` result whose type is a per-elem
+// result struct, not the f64 singleton).
+function resultInfoForType(ctx: CodegenContext, typeIdx: number): NativeGeneratorInfo | undefined {
+  for (const info of ctx.nativeGenerators.values()) {
+    if (info.resultTypeIdx === typeIdx) return info;
+  }
+  return undefined;
+}
+
 function isNativeResultType(ctx: CodegenContext, type: ValType | null): boolean {
-  return (
-    !!type &&
-    (type.kind === "ref" || type.kind === "ref_null") &&
-    ctx.nativeGeneratorResultTypeIdx >= 0 &&
-    type.typeIdx === ctx.nativeGeneratorResultTypeIdx
-  );
+  if (!type || (type.kind !== "ref" && type.kind !== "ref_null")) return false;
+  const idx = type.typeIdx;
+  if (ctx.nativeGeneratorResultTypeIdx >= 0 && idx === ctx.nativeGeneratorResultTypeIdx) return true;
+  // (#2171) Result types are per-elem-kind (numeric f64 vs native string), so a
+  // string generator's result struct is a distinct typeIdx. Recognize any
+  // registered generator's result type.
+  for (const info of ctx.nativeGenerators.values()) {
+    if (info.resultTypeIdx === idx) return true;
+  }
+  return false;
 }
 
 function compileIgnoredArgs(ctx: CodegenContext, fctx: FunctionContext, args: readonly ts.Expression[]): void {
@@ -1461,17 +1617,25 @@ export function tryCompileNativeGeneratorResultProperty(
   propName: string,
 ): ValType | null | undefined {
   if (propName !== "value" && propName !== "done") return undefined;
-  if (ctx.nativeGeneratorResultTypeIdx < 0) return undefined;
+  // (#2171) Proceed if either the f64 singleton or any per-elem native
+  // generator result type exists (a string-only module never sets the singleton).
+  if (ctx.nativeGeneratorResultTypeIdx < 0 && ctx.nativeGenerators.size === 0) return undefined;
 
   const resultType = compileExpression(ctx, fctx, resultExpr);
   if (isNativeResultType(ctx, resultType)) {
+    // (#2171) The result type may be the f64 singleton OR a per-elem-kind result
+    // struct (e.g. native string). Read the value field at the matched result
+    // type's typeIdx and report its element ValType, not the f64 singleton.
+    const rtIdx = (resultType as { typeIdx: number }).typeIdx;
+    const matchInfo = resultInfoForType(ctx, rtIdx);
+    const valVT: ValType = matchInfo ? matchInfo.elemValType : { kind: "f64" };
     if (resultType?.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" });
     fctx.body.push({
       op: "struct.get",
-      typeIdx: ctx.nativeGeneratorResultTypeIdx,
+      typeIdx: rtIdx,
       fieldIdx: propName === "value" ? RESULT_VALUE_FIELD : RESULT_DONE_FIELD,
     });
-    return propName === "value" ? { kind: "f64" } : { kind: "i32" };
+    return propName === "value" ? valVT : { kind: "i32" };
   }
 
   if (resultType?.kind === "externref") {
@@ -1590,9 +1754,10 @@ export function tryCompileNativeGeneratorForOf(
 
   const resultLocal = allocLocal(fctx, `__nativegen_res_${fctx.locals.length}`, resultRef);
 
-  // Loop variable: f64 (the native result value type). const-ness recorded so
+  // Loop variable: the generator's element ValType (f64 numeric, or the native
+  // string ref for a string generator — #2171). const-ness recorded so
   // shadowing/TDZ logic downstream stays consistent.
-  const elemLocal = allocLocal(fctx, loopVarName, { kind: "f64" });
+  const elemLocal = allocLocal(fctx, loopVarName, info.elemValType);
   if (isConst) {
     if (!fctx.constBindings) fctx.constBindings = new Set();
     fctx.constBindings.add(loopVarName);

--- a/tests/issue-2171-string-yields.test.ts
+++ b/tests/issue-2171-string-yields.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2171 (SF-4 of #2157) — native generators with **string** yields in
+ * standalone.
+ *
+ * The Wasm-native generator (#1665/#2079) carried numeric-only payloads: the
+ * result struct's `value` field and the state spills were f64, so a string
+ * yield bailed to the #680 diagnostic. This slice keys the result struct (and
+ * the for-of loop variable) on a per-generator element ValType — f64 for the
+ * numeric path (unchanged) or the native `$AnyString` ref for a generator whose
+ * yields are all strings.
+ *
+ * Scope: uniformly-string-typed generators with straight-line / non-spilling
+ * bodies (`yield "a"; yield "b"`). Deferred (documented follow-ups): mixed-type
+ * yields (`yield 1; yield "a"`), string generators that spill a live local
+ * across a suspension (e.g. a `while`-loop induction var — bails cleanly),
+ * `.next(strValue)` / `.return(strValue)` (the sent/abrupt fields stay f64), and
+ * spread / Array.from of a string generator.
+ *
+ * Loop-var typing note: the generator carries the correct string value; reading
+ * it via `.length` / `===` / `+` requires the loop variable's static type to be
+ * `string`, so the examples annotate `Generator<string>` (matching idiomatic TS).
+ *
+ * Every case compiles standalone with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2171 native generator with string yields", () => {
+  it("for-of count over string yields", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "a"; yield "b"; }
+export function test(): number { let n = 0; for (const v of g()) n++; return n; }`),
+    ).toBe(2);
+  });
+
+  it("sum of yielded string lengths (value carried correctly)", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "ab"; yield "c"; }
+export function test(): number { let n = 0; for (const v of g()) n += v.length; return n; }`),
+    ).toBe(3); // 2 + 1
+  });
+
+  it("concatenation of yielded strings", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "ab"; yield "c"; }
+export function test(): number { let acc = ""; for (const v of g()) acc = acc + v; return acc.length; }`),
+    ).toBe(3); // "abc"
+  });
+
+  it("string equality on a yielded value", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "ab"; yield "c"; }
+export function test(): number { for (const v of g()) { const s: string = v; return s === "ab" ? 1 : 0; } return -1; }`),
+    ).toBe(1);
+  });
+
+  it("three string yields", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "x"; yield "yy"; yield "zzz"; }
+export function test(): number { let n = 0; for (const v of g()) n += v.length; return n; }`),
+    ).toBe(6); // 1 + 2 + 3
+  });
+});
+
+describe("#2171 regression — numeric generators unchanged", () => {
+  it("numeric for-of sums correctly", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield 1; yield 2; yield 3; }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6);
+  });
+  it("numeric while-loop generator (control flow + spill) unchanged", async () => {
+    expect(
+      await runStandalone(`function* g(){ let i = 0; while (i < 4) { yield i; i++; } }
+export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`),
+    ).toBe(6); // 0+1+2+3
+  });
+});


### PR DESCRIPTION
## Summary

SF-4 of the #2157 generator residual. Implements the **string-yield slice**: the Wasm-native generator (#1665/#2079) carried numeric-only payloads (f64 result `value` field + f64 spills), so a string yield bailed to the #680 diagnostic. Now the result struct and the for-of loop variable are keyed on a **per-generator element ValType** — f64 for the numeric path (unchanged) or the native `$AnyString` ref for an all-string generator.

Spec + scope detail lives in `plan/issues/2171-*.md` (landed via the companion #1495). This PR is the source + tests only (no issue-file edit, to avoid a conflict with #1495 which is in the queue).

## Changes (`generators-native.ts`)

- `NativeGeneratorInfo.elemValType`; `generatorElemValType` walks the yields → uniform type or null (mixed/unsupported → #680 bail).
- `ensureNativeGeneratorResultType(ctx, elemValType)` → per-elem-kind result struct; f64 variant stays the singleton.
- Plan yield-value checks gate on the generator elem type (`yieldValueOk`); loop/if **conditions** stay numeric.
- `emitYieldValueAsElem` for yield/return value writes; empty/abrupt completions use the elem-type default.
- `isNativeResultType` / `tryCompileNativeGeneratorResultProperty` recognize per-elem result types; the for-of loop var is typed `info.elemValType`.

## Tests

`tests/issue-2171-string-yields.test.ts` (7 cases, standalone, zero host imports): for-of count, sum-of-lengths, concat, `===`, three yields; numeric for-of + while-loop regressions. `issue-2079` (13/13) + `issue-1665` green.

## Scope / deferred (all bail cleanly — no crash)

Mixed-type yields (`yield 1; yield "a"`), string generators that **spill** a live local across a suspension (spill fields are f64 — guarded), `.next(str)` / `.return(str)` (sent/abrupt stay f64), and spread / Array.from of a string generator. #2171 stays open for these; the dominant `yield "a"; yield "b"` shape now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)