### PR TITLE
feat(#2151): N-ary any-receiver method dispatch on closed structs (Slice 2)

### DIFF
--- a/plan/issues/2151-standalone-any-receiver-method-dispatch.md
+++ b/plan/issues/2151-standalone-any-receiver-method-dispatch.md
@@ -161,3 +161,36 @@ standalone object-literal method calls.
 
 Status: ready to PR; held pending tech-lead go (#25 was marked DEFERRED epic —
 sdev3 found the 0-arg slice is contained + green and recommends landing it).
+
+## Slice 2 RESULT (2026-06-15, sdev5) — N-ary methods IMPLEMENTED & GREEN
+
+Branch `issue-2151-nary-method`. Generalizes the Slice 1 dispatcher to methods
+**with arguments**:
+- `closed-method-dispatch.ts`: the dispatcher is now arity-specialized
+  `__call_m_<name>_<arity>(recv, arg0..arg{arity-1})` (all externref). The fill
+  side matches each candidate struct's `<Struct>_<name>` by `1 + arity` params,
+  coerces each externref arg to the method's declared param type inline
+  (`__unbox_number` for f64, `__unbox_boolean`/`__unbox_number`+trunc for i32,
+  `any.convert_extern`+`ref.cast` for refs), threads the struct as `this`, calls,
+  and box-coerces the result. The open-`$Object` fallback arm builds an `$ObjVec`
+  of the args (`__objvec_new`/`__objvec_push`) for `__extern_method_call`.
+- `calls.ts`: the any-receiver routing no longer gates on `arguments.length===0`
+  — it reserves `__call_m_<name>_<arity>`, compiles the receiver + each arg to
+  externref, and calls. Spread args still fall through to the generic path.
+
+Verified standalone AND wasi, ZERO host imports: 1-arg `f(n)→n+4`=9, 2-arg
+`g(a,b)→a*b+2`=14, 3-arg `h(a,b,c)`=6, `this`+arg `plus(n)→this.base+n`=25, and
+the Slice 1 0-arg path (`next()`=7) intact. Test: `tests/issue-2151-nary.test.ts`
+(6 cases). No regression: `issue-2151` 11/11, `object-methods` 13/13,
+`object-literals` 21/21. Host mode unchanged (gated `standalone||wasi`).
+
+**Still deferred (pre-existing, NOT this slice):**
+- **Built-in-method-name collision**: `o.add(5)` / `o.push(x)` on an object
+  literal route to the built-in `Set_add` / array fast-path BEFORE the
+  any-receiver fallback (verified identical on main). Needs the static
+  builtin-method fast-path to defer to the closed-struct dispatcher for `any`
+  receivers — a separate precedence fix.
+- **Host mode** any-method on a closed object literal (`o.f(5)` → "f is not a
+  function") — pre-existing host limitation (verified on main), out of scope
+  (this fix is gated on standalone/wasi).
+- Spread-arg method calls (`o.m(...xs)`).

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -43,21 +43,30 @@ import { ensureObjVecBuilders } from "./object-runtime.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 
-/** Mangle a method name into the reserved dispatcher export/funcMap name. */
-function dispatcherName(methodName: string): string {
-  return `__call_m_${methodName}`;
+/**
+ * Mangle a method name + arg count into the reserved dispatcher export/funcMap
+ * name. (#2151 Slice 2) The arity is part of the key so `o.m()` and `o.m(a,b)`
+ * get distinct dispatchers with the right number of externref arg params.
+ */
+function dispatcherName(methodName: string, arity: number): string {
+  return `__call_m_${methodName}_${arity}`;
 }
 
 /**
- * Reserve (or fetch) the closed-struct dispatcher `__call_m_<name>` funcIdx with
- * a placeholder body. The real body is built by {@link fillClosedMethodDispatch}
- * at finalize. Idempotent; records the method name in
- * `ctx.closedMethodDispatchNames`. Returns the reserved funcIdx.
+ * Reserve (or fetch) the closed-struct dispatcher `__call_m_<name>_<arity>`
+ * funcIdx with a placeholder body. The real body is built by
+ * {@link fillClosedMethodDispatch} at finalize. Idempotent; records the
+ * (method name, arity) pair in `ctx.closedMethodDispatchNames` (encoded as
+ * `<name>/<arity>`). Returns the reserved funcIdx.
+ *
+ * The dispatcher signature is `(recv: externref, arg0..arg{arity-1}: externref)
+ * -> externref`; the call site coerces each argument to externref before the
+ * call, and the fill side coerces each back to the method's declared param type.
  *
  * Only meaningful under `ctx.standalone || ctx.wasi` — callers gate on that.
  */
-export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: string): number {
-  const name = dispatcherName(methodName);
+export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: string, arity = 0): number {
+  const name = dispatcherName(methodName, arity);
   const existing = ctx.funcMap.get(name);
   if (existing !== undefined) return existing;
 
@@ -66,12 +75,15 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
   // would shift baked call/global indices (the addUnionImports hazard the
   // reserve-then-fill pattern exists to avoid). `fillClosedMethodDispatch` then
   // only READS funcMap. `ensureObjVecBuilders` pulls in the object runtime +
-  // `__objvec_new`/`__extern_method_call`; the method-name string constant is
-  // materialized for the fallback `__extern_method_call(recv, "<name>", [])`.
+  // `__objvec_new`/`__objvec_push`/`__extern_method_call`; the method-name
+  // string constant is materialized for the fallback
+  // `__extern_method_call(recv, "<name>", [args…])`.
   ensureObjVecBuilders(ctx);
   addStringConstantGlobal(ctx, methodName);
 
-  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$closed_method_dispatch_type");
+  // Signature: (recv, arg0..arg{arity-1}) all externref → externref.
+  const params: ValType[] = Array.from({ length: arity + 1 }, () => ({ kind: "externref" }) as ValType);
+  const typeIdx = addFuncType(ctx, params, [{ kind: "externref" }], `$closed_method_dispatch_type_${arity}`);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   ctx.mod.functions.push({
     name,
@@ -83,7 +95,7 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
     exported: false,
   });
   ctx.funcMap.set(name, funcIdx);
-  (ctx.closedMethodDispatchNames ??= new Set<string>()).add(methodName);
+  (ctx.closedMethodDispatchNames ??= new Set<string>()).add(`${methodName}/${arity}`);
   return funcIdx;
 }
 
@@ -101,16 +113,30 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
 
   const mod = ctx.mod;
   const boxNumIdx = ctx.funcMap.get("__box_number");
+  // (#2151 Slice 2) externref→primitive unbox helpers for arg coercion (read
+  // only; registered at reserve time via addUnionImports).
+  const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+  const unboxBoolIdx = ctx.funcMap.get("__unbox_boolean");
 
-  for (const methodName of names) {
-    const dispIdx = ctx.funcMap.get(dispatcherName(methodName));
+  for (const key of names) {
+    // key is `<methodName>/<arity>` (#2151 Slice 2). Split from the LAST `/` so
+    // method names containing `/` (none in practice) wouldn't corrupt the arity.
+    const slash = key.lastIndexOf("/");
+    const methodName = slash >= 0 ? key.slice(0, slash) : key;
+    const arity = slash >= 0 ? Number.parseInt(key.slice(slash + 1), 10) || 0 : 0;
+    const dispIdx = ctx.funcMap.get(dispatcherName(methodName, arity));
     if (dispIdx === undefined) continue;
     const dispFn = mod.functions[dispIdx - ctx.numImportFuncs];
     if (!dispFn) continue;
 
-    // Collect every closed struct with a `<Struct>_<methodName>` 1-param method
-    // (param 0 = the receiver struct). Skip wrapper/internal carriers.
-    const entries: { typeIdx: number; funcIdx: number; resultType: ValType }[] = [];
+    // Param layout of the dispatcher: local 0 = recv (externref), locals
+    // 1..arity = the externref args, local (arity+1) = the `any` temp (anyref).
+    const anyLocalIdx = arity + 1;
+
+    // Collect every closed struct with a `<Struct>_<methodName>` method whose
+    // signature is `(this, arg0..arg{arity-1})` — i.e. `1 + arity` params (param
+    // 0 = the receiver struct). Skip wrapper/internal carriers.
+    const entries: { typeIdx: number; funcIdx: number; paramTypes: ValType[]; resultType: ValType }[] = [];
     for (const [structName] of ctx.structFields) {
       const typeIdx = ctx.structMap.get(structName);
       if (typeIdx === undefined) continue;
@@ -130,26 +156,41 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
       const funcDef = mod.functions[funcIdx - ctx.numImportFuncs];
       const funcType = funcDef ? mod.types[funcDef.typeIdx] : undefined;
       if (!funcType || funcType.kind !== "func") continue;
-      // Slice 1: zero-arg-after-`this` only (the method takes just the receiver).
-      if (funcType.params.length !== 1) continue;
+      // Must be `this` + exactly `arity` declared params.
+      if (funcType.params.length !== 1 + arity) continue;
       const resultType: ValType = funcType.results.length > 0 ? funcType.results[0]! : { kind: "externref" };
-      entries.push({ typeIdx, funcIdx, resultType });
+      // Declared param types of the args (skip param 0 = `this`).
+      const paramTypes = funcType.params.slice(1);
+      entries.push({ typeIdx, funcIdx, paramTypes, resultType });
     }
 
-    // Bottom arm: open-$Object fallback via __extern_method_call(recv, name, []).
-    // Only available when the object runtime + ObjVec builders are present
-    // (they are in standalone/wasi after ensureObjectRuntime). If absent, return
-    // undefined so the dispatcher stays valid.
-    // Both registered at reserve time (reserveClosedMethodDispatch) — read only.
+    // Bottom arm: open-$Object fallback via
+    // __extern_method_call(recv, name, [arg0..arg{arity-1}]). The args are pushed
+    // onto a fresh $ObjVec so the open-object runtime reads them by index.
     const methodCallIdx = ctx.funcMap.get("__extern_method_call");
     const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+    const objVecPushIdx = ctx.funcMap.get("__objvec_push");
     let current: Instr[];
-    if (methodCallIdx !== undefined && objVecNewIdx !== undefined) {
-      // __extern_method_call(recv, "<name>", __objvec_new())  — open-$Object arm.
+    if (methodCallIdx !== undefined && objVecNewIdx !== undefined && (arity === 0 || objVecPushIdx !== undefined)) {
+      const argVec: Instr[] = [];
+      if (arity > 0 && objVecPushIdx !== undefined) {
+        // vec = __objvec_new(); for each arg: __objvec_push(vec, argi); then vec.
+        const vecTmp = anyLocalIdx + 1; // an extra local for the arg vec
+        argVec.push({ op: "call", funcIdx: objVecNewIdx } as Instr);
+        argVec.push({ op: "local.set", index: vecTmp } as Instr);
+        for (let a = 0; a < arity; a++) {
+          argVec.push({ op: "local.get", index: vecTmp } as Instr);
+          argVec.push({ op: "local.get", index: 1 + a } as Instr);
+          argVec.push({ op: "call", funcIdx: objVecPushIdx } as Instr);
+        }
+        argVec.push({ op: "local.get", index: vecTmp } as Instr);
+      } else {
+        argVec.push({ op: "call", funcIdx: objVecNewIdx } as Instr);
+      }
       current = [
         { op: "local.get", index: 0 } as Instr,
         ...stringConstantExternrefInstrs(ctx, methodName),
-        { op: "call", funcIdx: objVecNewIdx } as Instr,
+        ...argVec,
         { op: "call", funcIdx: methodCallIdx } as Instr,
       ];
     } else {
@@ -157,13 +198,41 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
     }
 
     // Build the type-switch from the bottom up: nest each struct arm.
-    // local 0 = recv (param externref); local 1 = any (anyref).
     for (const entry of entries) {
       const callAndCoerce: Instr[] = [
-        { op: "local.get", index: 1 } as Instr,
-        { op: "ref.cast", typeIdx: entry.typeIdx } as Instr,
-        { op: "call", funcIdx: entry.funcIdx } as Instr,
+        { op: "local.get", index: anyLocalIdx } as Instr,
+        { op: "ref.cast", typeIdx: entry.typeIdx } as Instr, // `this`
       ];
+      // Push each arg coerced from externref to the method's declared param type.
+      // Args arrive as externref (the call site boxes them); the method wants
+      // its declared types. Inline the unbox (we're building a raw Instr[], not
+      // via fctx, so we can't call coerceType): f64 ← __unbox_number, i32-boolean
+      // ← __unbox_boolean, i32 ← __unbox_number + trunc, ref ← any.convert_extern
+      // + guarded cast. The unbox helpers are registered at reserve time.
+      for (let a = 0; a < arity; a++) {
+        const want = entry.paramTypes[a] ?? { kind: "externref" };
+        callAndCoerce.push({ op: "local.get", index: 1 + a } as Instr);
+        if (want.kind === "f64") {
+          if (unboxNumIdx !== undefined) callAndCoerce.push({ op: "call", funcIdx: unboxNumIdx } as Instr);
+          else callAndCoerce.push({ op: "drop" } as Instr, { op: "f64.const", value: 0 } as Instr);
+        } else if (want.kind === "i32") {
+          if ((want as { boolean?: true }).boolean && unboxBoolIdx !== undefined) {
+            callAndCoerce.push({ op: "call", funcIdx: unboxBoolIdx } as Instr);
+          } else if (unboxNumIdx !== undefined) {
+            callAndCoerce.push({ op: "call", funcIdx: unboxNumIdx } as Instr);
+            callAndCoerce.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+          } else {
+            callAndCoerce.push({ op: "drop" } as Instr, { op: "i32.const", value: 0 } as Instr);
+          }
+        } else if (want.kind === "ref" || want.kind === "ref_null") {
+          // externref → GC ref: any.convert_extern then guarded ref.cast.
+          callAndCoerce.push({ op: "any.convert_extern" } as Instr);
+          callAndCoerce.push({ op: "ref.cast", typeIdx: (want as { typeIdx: number }).typeIdx } as Instr);
+        }
+        // externref param: arg is already externref — no coercion.
+      }
+      callAndCoerce.push({ op: "call", funcIdx: entry.funcIdx } as Instr);
+      // Box-coerce the result back to externref.
       if (entry.resultType.kind === "ref" || entry.resultType.kind === "ref_null") {
         callAndCoerce.push({ op: "extern.convert_any" } as Instr);
       } else if (entry.resultType.kind === "f64") {
@@ -177,7 +246,7 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
       // externref result: no coercion.
 
       current = [
-        { op: "local.get", index: 1 } as Instr,
+        { op: "local.get", index: anyLocalIdx } as Instr,
         { op: "ref.test", typeIdx: entry.typeIdx } as Instr,
         {
           op: "if",
@@ -191,11 +260,16 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
     const body: Instr[] = [
       { op: "local.get", index: 0 } as Instr,
       { op: "any.convert_extern" } as Instr,
-      { op: "local.set", index: 1 } as Instr,
+      { op: "local.set", index: anyLocalIdx } as Instr,
       ...current,
     ];
 
-    dispFn.locals = [{ name: "__any", type: { kind: "anyref" } }];
+    const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
+    // The open-$Object fallback for arity>0 needs an extra arg-vec local.
+    if (arity > 0 && objVecNewIdx !== undefined && objVecPushIdx !== undefined) {
+      locals.push({ name: "__argvec", type: { kind: "externref" } });
+    }
+    dispFn.locals = locals;
     dispFn.body = body;
     void (dispFn as WasmFunction);
   }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8111,14 +8111,28 @@ function compileCallExpression(
         // with arguments keep the existing generic path below.
         const recvIsBuiltinClass =
           ts.isIdentifier(propAccess.expression) && BUILTIN_CLASS_NAMES.has(propAccess.expression.text);
-        if ((ctx.standalone || ctx.wasi) && expr.arguments.length === 0 && !recvIsBuiltinClass) {
-          const dispatchIdx = reserveClosedMethodDispatch(ctx, methodName);
+        // (#2151 Slice 2) N-ary: the dispatcher is arity-specialized
+        // `__call_m_<name>_<arity>(recv, arg0..arg{arity-1})` (all externref).
+        // Spread args fall through to the generic path (the dispatcher has a
+        // fixed arity).
+        const hasSpreadArg = expr.arguments.some((a) => ts.isSpreadElement(a));
+        if ((ctx.standalone || ctx.wasi) && !hasSpreadArg && !recvIsBuiltinClass) {
+          const arity = expr.arguments.length;
+          const dispatchIdx = reserveClosedMethodDispatch(ctx, methodName, arity);
           flushLateImportShifts(ctx, fctx);
+          // Receiver as externref.
           const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
           if (recvType && recvType.kind !== "externref") {
             fctx.body.push({ op: "extern.convert_any" });
           } else if (recvType === null) {
             fctx.body.push({ op: "ref.null.extern" });
+          }
+          // Each argument compiled and boxed to externref (the dispatcher unboxes
+          // to the method's declared param type per candidate struct).
+          for (const arg of expr.arguments) {
+            const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
+            if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+            else if (at === null) fctx.body.push({ op: "ref.null.extern" });
           }
           fctx.body.push({ op: "call", funcIdx: dispatchIdx });
           return { kind: "externref" };

--- a/tests/issue-2151-nary.test.ts
+++ b/tests/issue-2151-nary.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2151 Slice 2 — N-ary any-receiver method dispatch on closed object-literal
+ * structs in standalone / WASI.
+ *
+ * Slice 1 (#1463, merged) handled 0-arg any-receiver method calls via the
+ * `__call_m_<name>` closed-struct dispatcher. Methods invoked WITH arguments
+ * (`o.add(5)`, `o.sum(2,3)`) fell through to the host path → wrong value / NaN
+ * standalone. This slice arity-specializes the dispatcher
+ * (`__call_m_<name>_<arity>(recv, arg0..argK)`, all externref): the call site
+ * boxes each argument to externref, the dispatcher unboxes each back to the
+ * method's declared param type per candidate struct (`__unbox_number` /
+ * `__unbox_boolean` / cast), threads the struct as `this`, and box-coerces the
+ * result.
+ *
+ * Every case compiles standalone with ZERO host imports.
+ *
+ * NOTE: method names that collide with a built-in (`add` → Set.prototype.add,
+ * `push`, etc.) still route to the builtin fast-path *before* the any-receiver
+ * fallback — a pre-existing builtin-method-name precedence issue, NOT part of
+ * this slice. The tests use non-colliding names.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, target: "standalone" | "wasi" = "standalone"): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  if (target === "standalone") {
+    const mod = await WebAssembly.compile(r.binary);
+    const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+    expect(imports, "standalone module must have zero host imports").toEqual([]);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2151 Slice 2 — N-ary any-receiver method dispatch (standalone)", () => {
+  it("1-arg method", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { f(n: number) { return n + 4; } }; return o.f(5); }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("2-arg method", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { g(a: number, b: number) { return a * b + 2; } }; return o.g(3, 4); }`,
+      ),
+    ).toBe(14);
+  });
+
+  it("3-arg method", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { h(a: number, b: number, c: number) { return a + b + c; } }; return o.h(1, 2, 3); }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("method using this + arg", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { base: 20, plus(n: number) { return this.base + n; } }; return o.plus(5); }`,
+      ),
+    ).toBe(25);
+  });
+
+  it("0-arg path still works (Slice 1 regression)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { next() { return 7; } }; return o.next(); }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("wasi: 1-arg method", async () => {
+    const r = await compile(
+      `export function test(): number { const o: any = { f(n: number) { return n + 4; } }; return o.f(5); }`,
+      { target: "wasi" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test(): number }).test()).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of #2151. Slice 1 (#1463, merged) made **0-arg** any-receiver method calls on closed object-literal structs work standalone/wasi via the `__call_m_<name>` dispatcher. Methods called **with arguments** (`o.sum(2,3)`, `o.plus(5)`) still fell through to the host path → wrong value / NaN standalone. This generalizes the dispatcher to **N-ary**.

## Changes

- **`closed-method-dispatch.ts`**: the dispatcher is arity-specialized — `__call_m_<name>_<arity>(recv, arg0..arg{arity-1})` (all externref). The fill side matches each candidate struct's `<Struct>_<name>` by `1 + arity` params, unboxes each externref arg to the method's declared param type inline (`__unbox_number` for f64, `__unbox_boolean`/`__unbox_number`+trunc for i32, `any.convert_extern`+`ref.cast` for refs), threads the struct as `this`, calls, and box-coerces the result. The open-`$Object` fallback builds an `$ObjVec` of the args.
- **`calls.ts`**: the any-receiver routing no longer gates on `arguments.length === 0` — it reserves `__call_m_<name>_<arity>`, compiles the receiver + each arg to externref, and calls. Spread args fall through to the generic path.

## Tests

`tests/issue-2151-nary.test.ts` (6, standalone + wasi, zero host imports): 1/2/3-arg methods, `this`+arg, the Slice 1 0-arg regression. No regression: `issue-2151` 11/11, `object-methods` 13/13, `object-literals` 21/21. Host mode unchanged (gated `standalone||wasi`).

## Deferred (pre-existing, verified identical on main)

- **Built-in-method-name collision**: `o.add(5)` routes to the built-in `Set_add` fast-path *before* the any-receiver fallback — a separate precedence fix.
- **Host mode** any-method on a closed object literal (`o.f(5)` → "f is not a function").
- Spread-arg method calls.

#2151 stays `in-progress` for the precedence fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)