### PR TITLE
docs(#1983): root-cause + scope analysis for class-method funcMap name collision

### DIFF
--- a/plan/issues/1983-class-method-funcmap-name-collision.md
+++ b/plan/issues/1983-class-method-funcmap-name-collision.md
@@ -53,3 +53,47 @@ statics, closure wrappers) for the same convention.
 ## Dupe check
 
 #1370 (class-method IR adoption — keying origin). No collision issue on file.
+
+
+## Root-cause confirmation + scope (2026-06-15, sdev5)
+
+Repro confirmed on main (`39a63edf0`): `class A { m(){return 10} }` +
+`function A_m(){return 2}` → both compile to a wasm func literally NAMED `A_m`
+(WAT shows two `(func $A_m …)` — wasm permits duplicate names). The defect is in
+the **funcMap key**, not the emitted name: both register under the key `A_m`, so
+`funcMap.get("A_m")` returns whichever registered LAST, and the other call site
+(`new A().m()` vs `A_m()`) baked the wrong funcIdx → null-ref trap (legacy) /
+arg-type CompileError (IR). Getter variant (`B.get v` vs `function B_get_v`) and
+ctor (`A_new`) collide the same way.
+
+**Why this is bigger than "medium" / NOT a clean isolated PR right now:**
+
+- The `${className}_${method}` key convention is computed at **~103 call sites
+  across ~20 files** (grep `\${[A-Za-z]*[Nn]ame}_\${`): both the *producer*
+  (class-bodies.ts registration) and every *consumer* (property-access.ts,
+  calls.ts, closures.ts, accessor-driver.ts, struct-accessor-closure.ts,
+  object-ops.ts, fixups.ts, …) independently recompute the same string. A
+  collision-free key (e.g. a separator invalid in TS identifiers, or
+  uniquify-on-collision with a redirect map) must be threaded through ALL of
+  them consistently, or producer/consumer disagree and EVERY class method call
+  breaks.
+- **Active-lane conflict:** sdev3's #2158 (standalone class/prototype/descriptor
+  residual, in_progress) is editing `class-bodies.ts` — the producer file. A
+  103-site naming refactor landed underneath an in-flight #2158 PR is a
+  guaranteed merge conflict and a destabilization risk to the larger class work.
+
+**Recommended approach (for whoever takes it, AFTER #2158 lands):**
+
+Introduce one helper `classSyntheticKey(className, kind, name)` (kind =
+`method`/`get`/`set`/`new`/`init`/`static`) returning a key with a
+**reserved-prefix or invalid-identifier separator** (e.g. `\x00C\x00m` or
+`#cls#A#m`) that can never collide with a user identifier, and route BOTH the
+class-bodies producers and all consumers through it. Audit the emitted-name vs
+funcMap-key split: keep a readable emitted wasm name (debugging) but key funcMap
+by the mangled key. Acceptance: repro returns 12, getter variant 8, no mangled
+key leaks to exports/WIT. This is a focused 1-day refactor once the file is
+quiescent — should be **sequenced after sdev3's #2158**, not landed concurrently.
+
+Releasing the task back to the queue with this scope note (verified, not
+abandoned) so the lead can sequence it after #2158. Repro file:
+tests-style cases above all reproduce on main.


### PR DESCRIPTION
## Summary

Investigated #1983 (synthetic `${ClassName}_${method}` funcMap keys collide with user functions). Confirmed the repro on main and documented the root cause + a scoping finding — **no code change** (the fix should be sequenced; see below).

## Findings

- Repro on main: `class A { m() }` + `function A_m()` both register under the funcMap **key** `A_m` (wasm permits duplicate emitted names — the bug is the shared key) → last-write-wins, the other call site baked the wrong funcIdx → trap. Getter (`B_get_v`) and ctor (`A_new`) collide identically.
- **Scope**: the `${className}_${method}` key is recomputed at **~103 sites across ~20 files** (producer in `class-bodies.ts` + every consumer). A collision-free key must thread through all of them consistently. **sdev3's #2158 is actively editing `class-bodies.ts`** — a 103-site naming refactor landed concurrently is a guaranteed conflict + destabilization risk.

## Recommendation

Sequence the fix **after #2158 lands**: one `classSyntheticKey(className, kind, name)` helper with an invalid-identifier separator, routed through the producer + all consumers; keep readable emitted names, mangle only the funcMap key; ensure no mangled key leaks to exports/WIT. ~1-day focused refactor once the file is quiescent.

Releasing the task to the queue with this verified scope note. #1983 stays `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)