### PR TITLE
fix(#2029): guard -1 string-global sentinel in emitSetSubclassProto (standalone builtin-subclass emit crash)

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -1,10 +1,10 @@
 ---
 id: 2029
 title: "standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests)"
-status: ready
-sprint: Backlog
+status: in-progress
+sprint: 62
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-15
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -134,3 +134,39 @@ sentinel check — the Object.create / Iterator.prototype / DisposableStack
 clusters in this bucket are likely the same pattern. `grep -n
 "stringGlobalMap.get" src/codegen/` and check each use site emits
 `global.get` only for `idx >= 0`.
+
+## PR-1 landed (2026-06-15, sdev3) — builtin-subclass cluster
+
+Applied the prescribed fix shape to the confirmed producer. `emitSetSubclassProto`
+(`src/codegen/class-bodies.ts`) now skips the prototype-adjustment arm when
+either class-name string global is the `-1` sentinel (standalone/`nativeStrings`),
+in addition to the existing `=== undefined` guard. The arm exists only to feed
+the `__set_subclass_proto` HOST import (unavailable standalone anyway), and the
+WasmGC instance `__tag` already carries class identity for `instanceof`, so
+skipping is semantically correct standalone.
+
+**Fixed (compile-time emit crash gone):** `class X extends Error/TypeError/
+Uint8Array {}` and `extends`-builtin with own field / explicit `super()` /
+implicit ctor / 3-level hierarchy / class-expression — all the
+`language/{statements,expressions}/class` + `subclass-builtins/*` clusters
+(≈128 of the 497) now COMPILE under `--target standalone` instead of dying with
+`u32 out of range: -1`. Test: `tests/issue-2029-subclass-builtin-standalone-emit.test.ts`
+(8 compile-success cases). Zero host-mode regressions (the new branch only fires
+on the `-1` sentinel, which never occurs in gc/host mode where globals are real).
+
+**Audit of other `stringGlobalMap.get` consumers:** the remaining clusters in
+the bucket — `built-ins/Object/create` (74), `Iterator/prototype` (44),
+`DisposableStack`/`AsyncDisposableStack` (44), `for-await-of` (23) — all COMPILE
+in standalone on current main now (probed: no `-1`/`u32-out-of-range` emit), so
+they were either already resolved by later work or never shared this exact
+`emitSetSubclassProto` site. The other `stringGlobalMap.get` use sites that
+push `global.get` with a `!` non-null assertion (string-ops.ts, object-ops.ts,
+literals.ts) are reached only on the **legacy/host** string path (their callers
+gate on `!ctx.nativeStrings` or route through `compileNativeStringLiteral` /
+`stringConstantExternrefInstrs` in standalone), so they don't hit the sentinel.
+
+**Remaining (separate, NOT this PR):** runtime behaviour of `extends Error`
+standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/2187`)
+— a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
+the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
+runtime path is the residual. Reassess closing once that lands.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -328,8 +328,19 @@ function emitSetSubclassProto(
   addStringConstantGlobal(ctx, parentName);
   const subNameGlobal = ctx.stringGlobalMap.get(subName);
   const parentNameGlobal = ctx.stringGlobalMap.get(parentName);
-  if (subNameGlobal === undefined || parentNameGlobal === undefined) {
-    // String pool not available (very unusual) — skip silently.
+  // (#2029) In `--target standalone`/`nativeStrings`, `addStringConstantGlobal`
+  // stores the documented `-1` sentinel ("no host `string_constants` global —
+  // materialize the literal inline at use sites", see registry/imports.ts).
+  // The class-name strings here exist only to feed the `__set_subclass_proto`
+  // HOST import — which is itself unavailable standalone — so a `global.get -1`
+  // would be baked and crash binary emit (`u32 out of range: -1`). Guarding only
+  // `=== undefined` (a missing key) missed this in-pool `-1` value, the
+  // builtin-subclass cluster of the #2029 emit bucket. Skip the proto adjustment
+  // when either name resolves to the sentinel (or is absent): there is no host to
+  // call, and the WasmGC instance tag already carries class identity for
+  // `instanceof`.
+  if (subNameGlobal === undefined || parentNameGlobal === undefined || subNameGlobal < 0 || parentNameGlobal < 0) {
+    // String pool not available, or the standalone `-1` sentinel — skip silently.
     return;
   }
   // Skip when the instance is null (e.g. standalone `__new_<Parent>` fallback);

--- a/tests/issue-2029-subclass-builtin-standalone-emit.test.ts
+++ b/tests/issue-2029-subclass-builtin-standalone-emit.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2029 — builtin-subclass cluster of the standalone `u32 out of range: -1`
+ * emit bucket.
+ *
+ * `class X extends Error/TypeError/Uint8Array {}` died at EMIT time under
+ * `--target standalone` with `Binary emit error: u32 out of range: -1`
+ * (named by the #2043 always-on validator as
+ * `global index out of range — -1 ... at function 'X_new'`). The whole file
+ * was lost — a hard compile error, not a refusal.
+ *
+ * Root cause (per #2043 diagnosis): in standalone/`nativeStrings` mode,
+ * `addStringConstantGlobal` stores the documented `-1` sentinel in
+ * `ctx.stringGlobalMap` ("no host `string_constants` global — materialize the
+ * literal inline at use sites"). `emitSetSubclassProto` read the class-name
+ * globals and guarded only `=== undefined`, NOT the in-pool `-1` value, then
+ * baked `{ op: "global.get", index: -1 }` into the prototype-adjustment arm.
+ *
+ * Fix: `emitSetSubclassProto` now also skips when either name global is the
+ * `-1` sentinel. The prototype adjustment exists only to feed the
+ * `__set_subclass_proto` HOST import (unavailable standalone anyway), so
+ * skipping it is correct — the WasmGC instance tag still carries class
+ * identity for `instanceof`.
+ *
+ * These assert COMPILATION succeeds (the emit-crash is the bug). Runtime
+ * behaviour of `extends Error` standalone additionally depends on the
+ * `__new_<Builtin>` host-import retirement, tracked separately.
+ */
+describe("#2029 — builtin subclass compiles under --target standalone", () => {
+  async function compilesStandalone(src: string): Promise<void> {
+    const r = await compile(src, { fileName: "repro-2029.ts", target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  }
+
+  it("class extends Error with explicit super()", async () => {
+    await compilesStandalone(
+      `class E extends Error { constructor() { super("x"); } }
+       export function test(): number { new E(); return 1; }`,
+    );
+  });
+
+  it("class extends Error with an own field", async () => {
+    await compilesStandalone(
+      `class E extends Error { c: number = 9; constructor() { super("x"); } }
+       export function test(): number { return new E().c; }`,
+    );
+  });
+
+  it("class extends TypeError", async () => {
+    await compilesStandalone(
+      `class E extends TypeError { constructor() { super("y"); } }
+       export function test(): number { new E(); return 1; }`,
+    );
+  });
+
+  it("class extends Error with an implicit constructor", async () => {
+    await compilesStandalone(
+      `class E extends Error {}
+       export function test(): number { new E(); return 1; }`,
+    );
+  });
+
+  it("three-level extends Error hierarchy", async () => {
+    await compilesStandalone(
+      `class A extends Error {}
+       class B extends A {}
+       export function test(): number { new B(); return 1; }`,
+    );
+  });
+
+  it("class extends Uint8Array (the issue's minimal repro)", async () => {
+    await compilesStandalone(`class MyArr extends Uint8Array {} export function test(): number { return 1; }`);
+  });
+
+  it("class expression extends Error", async () => {
+    await compilesStandalone(`const E = class extends Error {}; export function test(): number { return 1; }`);
+  });
+
+  it("plain class still compiles (control — non-subclass path unaffected)", async () => {
+    await compilesStandalone(`class A { x: number = 5; } export function test(): number { return new A().x; }`);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the **builtin-subclass cluster** of #2029 — `class X extends Error/TypeError/Uint8Array {}` died at EMIT time under `--target standalone` with `Binary emit error: u32 out of range: -1` (the whole file lost as a hard compile error).

```ts
// before: repro.ts:1:1 - error: Binary emit error: u32 out of range: -1
class MyArr extends Uint8Array {}
```

### Root cause (per the #2043 always-on-validator diagnosis)
In standalone/`nativeStrings` mode, `addStringConstantGlobal` (`registry/imports.ts`) stores the documented **-1 sentinel** in `ctx.stringGlobalMap` ("no host `string_constants` global — materialize the literal inline at use sites"). `emitSetSubclassProto` (`class-bodies.ts`) read the class-name globals and guarded only `=== undefined`, **not** the in-pool `-1` value, then baked `{ op: "global.get", index: -1 }` into the prototype-adjustment arm → invalid Wasm.

### Fix
`emitSetSubclassProto` now also skips the proto-adjustment arm when either class-name string global is the `-1` sentinel (`subNameGlobal < 0 || parentNameGlobal < 0`), in addition to the existing `=== undefined` guard. That arm exists only to feed the `__set_subclass_proto` **host** import (unavailable standalone anyway), and the WasmGC instance `__tag` already carries class identity for `instanceof`, so skipping is semantically correct.

### Scope
Resolves the `language/{statements,expressions}/class` + `subclass-builtins/*` clusters (~128 of #2029's 497): they now **compile** under `--target standalone`. The other clusters (`Object.create`, `Iterator.prototype`, `DisposableStack`, `for-await-of`) already compile on current main (audited — no `-1`/`u32-out-of-range`). #2029 kept `in-progress`: the **emit crash** (the headline) is fixed; the separate `__new_<Builtin>` standalone runtime host-import leak is the residual.

## Test
`tests/issue-2029-subclass-builtin-standalone-emit.test.ts` — 8 standalone compile-success cases (extends Error/TypeError/Uint8Array, own field, explicit/implicit ctor, 3-level, class-expression, + a plain-class control). All pass.

## Regressions
None. The new branch only fires on the `-1` sentinel, which never occurs in gc/host mode (globals are real there). Class/inheritance equiv suites are identical to main (their incidental FAILs are pre-existing `{env:{}}`-harness "no string_constants import" failures, bisected). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)