### PR TITLE
fix(#1983): collision-free class-member funcMap keys (class A.m vs function A_m)

### DIFF
--- a/plan/issues/1983-class-method-funcmap-name-collision.md
+++ b/plan/issues/1983-class-method-funcmap-name-collision.md
@@ -1,10 +1,11 @@
 ---
 id: 1983
 title: "synthetic class-method names collide with user functions: class A { m() {} } + function A_m() breaks both paths"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -106,20 +107,35 @@ collision-free; method-dispatch reads them by the same legacy name).
 - The dispatch site **bakes the right compile-time funcIdx** (instrumented:
   `new A().m()` bakes `call <method funcIdx>`, fnName=`__cm$A_m`).
 
-### REMAINING (blocks acceptance — needs dedicated sequencing)
+### SOLVED (2026-06-16, sdev5) — the real last consumer was the IR front-end
 
-`test()` still returns `4` not `12`: in a function that calls BOTH `new A().m()`
-and `A_m()`, the **DCE finalize funcIdx remap** (`dead-elimination.ts` Phase 4
-`fR` table) mis-maps the relocated method's compile-time index — the
-`new A().m()` `call` lands on the user fn's *final* slot (idx 5) instead of the
-method's (idx 4), even though the pre-DCE baked index and both bodies are
-correct. The remap/reachability needs to be relocation-aware (order-dependent).
+The earlier "DCE remap" hypothesis was WRONG. Root cause of the residual
+`test() === 4`: the **IR front-end recompiles eligible top-level functions**
+(`compileIrPathFunctions`, index.ts), and the IR backend has its **own**
+class-member dispatch resolution that bypassed `classMemberFuncKey`:
 
-This touches the funcIdx **reservation + DCE remap pipeline** — the compiler's
-highest-regression-risk machinery — and is order-dependent. Recommend it land as
-a **dedicated change with architect input on the reservation pipeline, NOT raced
-against the active #2158** (which edits class-bodies.ts concurrently). The
-branch + commit 26f099222 carry the complete scaffolding; resume by making the
-DCE Phase-4 remap consistent with the relocated keys (and re-run the equivalence
-+ class suites — the safe-by-construction property means a green suite proves the
-non-colliding path is unchanged).
+- `src/ir/integration.ts` `ClassRegistry` — `methodFuncName` / `constructorFuncName`
+  built the legacy `${className}_${member}` name, which the IR
+  `class.call` lowering (`src/ir/lower.ts:1358`) resolved via `resolveFunc` →
+  `funcMap`. For a colliding class that key resolved to the **user function's**
+  funcIdx. Fixed: both route through `classMemberFuncKey(ctx, …)`.
+- `src/codegen/property-access.ts` — the getter-read / method-reference paths
+  resolve `${className}_get_${prop}` / `${className}_${method}` funcMap keys
+  (~14 sites: `getterName` / `setterName` / `methodFullName` / `fullName`).
+  All routed through `classMemberFuncKey`.
+
+With those two, the fix is COMPLETE. `tests/issue-1983-funcmap-collision.test.ts`
+(5 cases, standalone + empty importObject) all pass:
+
+- method `A.m` vs `function A_m()` → `test()` = **12** ✓
+- ctor `A_new` vs `function A_new()` → **10** ✓
+- getter `B.v` vs `function B_get_v()` → **8** ✓ (acceptance criterion)
+- non-colliding class → **15** ✓ (byte-identical / unchanged — safe-by-construction)
+- user `A_m()` reachable on its own → **42** ✓
+
+The existing class suites' `string_constants` instantiate failures are a
+**pre-existing harness artifact** (`{ env: {} }` importObject), identical on
+origin/main — verified by running `tests/inheritance.test.ts` on a base worktree
+(7/7 fail there too). Not a regression: the module *compiles* successfully.
+
+Status: implementation done; awaiting CI on the PR.

--- a/plan/issues/1983-class-method-funcmap-name-collision.md
+++ b/plan/issues/1983-class-method-funcmap-name-collision.md
@@ -53,3 +53,73 @@ statics, closure wrappers) for the same convention.
 ## Dupe check
 
 #1370 (class-method IR adoption — keying origin). No collision issue on file.
+
+## Full root-cause + WIP status (2026-06-15, sdev5)
+
+Repro confirmed on main `39a63edf0` (both wasm + standalone CompileError
+`call[0] expected (ref null 6), found f64`). The defect is a **shared flat
+funcMap namespace**: a class member `A.m` registers funcMap key `A_m`; the
+user-function reservation (`ensureSiblingFunctionsRegistered`,
+declarations.ts:3660) then **silently skips** `function A_m()` because
+`funcMap.has("A_m")` is already true, so `A_m()` call sites resolve to the
+class method's funcIdx (wrong signature → trap).
+
+### The collision spans FOUR distinct name-spaces, not one
+
+Pinned by exhaustive tracing. Any fix must keep all four consistent:
+
+1. **`ctx.funcMap` funcIdx key** — `${className}_${member}` (the trap source).
+2. **wasm display name** (`mod.functions[i].name`) — because the body-fill
+   `funcByName` map (compileDeclarations) is built from display names; a
+   collision there mis-fills bodies.
+3. **`funcByName` body-fill lookups** in class-bodies.ts (ctor/init/method/
+   getter/setter) AND the struct-method pre-registration in `ensureStructForType`
+   (index.ts:10120) — three separate reservation sites.
+4. **The DCE finalize funcIdx remap** (`dead-elimination.ts` Phase 4) — see
+   "Remaining" below.
+
+### Approach implemented (branch `issue-1983-funcmap-key`, commit 26f099222)
+
+`classMemberFuncKey(ctx, fullName)` (new leaf module `class-member-keys.ts`):
+returns the **byte-identical** legacy key for every non-colliding program, and
+only on a real collision relocates the *class member's* funcMap key + display
+name to `__cm$<name>` (a prefix no `${className}_${member}` join can emit). The
+user function keeps the bare `A_m` key (it is no longer skipped, because the
+class member vacated `A_m`), so its many bare-call / export / ref.func consumers
+are untouched. `topLevelFunctionNames` is pre-scanned at `generateModule` start
+(MUST precede all class registration — producers query it).
+
+Routed through: producers (class-bodies.ts ctor/init/method/getter/setter +
+inheritance copy; index.ts `ensureStructForType`; new-super.ts ctor) and the
+class-method-dispatch consumers (calls.ts main + static + inheritance/override
+scans; new-super.ts; closures.ts). Membership sets (`classMethodSet` etc.) and
+per-name metadata (`funcOptionalParams`/`funcRestParams`/`funcUsesArguments`)
+intentionally stay on legacy `fullName` (they answer "is this a class member",
+collision-free; method-dispatch reads them by the same legacy name).
+
+### Verified correct so far
+
+- Typechecks clean. Both function **bodies** are now emitted correctly:
+  `$__cm$A_m` = `(param (ref null 6))(result f64)` body `f64.const 10` (method,
+  takes self); `$A_m` = `()→f64` body `f64.const 2` (user fn). They are now
+  **separate** functions (was a single clobbered slot).
+- The dispatch site **bakes the right compile-time funcIdx** (instrumented:
+  `new A().m()` bakes `call <method funcIdx>`, fnName=`__cm$A_m`).
+
+### REMAINING (blocks acceptance — needs dedicated sequencing)
+
+`test()` still returns `4` not `12`: in a function that calls BOTH `new A().m()`
+and `A_m()`, the **DCE finalize funcIdx remap** (`dead-elimination.ts` Phase 4
+`fR` table) mis-maps the relocated method's compile-time index — the
+`new A().m()` `call` lands on the user fn's *final* slot (idx 5) instead of the
+method's (idx 4), even though the pre-DCE baked index and both bodies are
+correct. The remap/reachability needs to be relocation-aware (order-dependent).
+
+This touches the funcIdx **reservation + DCE remap pipeline** — the compiler's
+highest-regression-risk machinery — and is order-dependent. Recommend it land as
+a **dedicated change with architect input on the reservation pipeline, NOT raced
+against the active #2158** (which edits class-bodies.ts concurrently). The
+branch + commit 26f099222 carry the complete scaffolding; resume by making the
+DCE Phase-4 remap consistent with the relocated keys (and re-run the equivalence
++ class suites — the safe-by-construction property means a green suite proves the
+non-colliding path is unchanged).

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -8,6 +8,7 @@ import { ts } from "../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType } from "../ir/types.js";
 import { isHostConstructibleBuiltin } from "./builtin-tags.js";
+import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, deduplicateLocals } from "./context/locals.js";
@@ -362,6 +363,11 @@ export function resolveClassMemberName(ctx: CodegenContext, name: ts.PropertyNam
   return undefined;
 }
 
+// (#1983) `classMemberFuncKey` lives in the leaf module `class-member-keys.ts`
+// (imported above) so consumer files can use it without an import cycle; it is
+// re-exported here for callers that already import from `class-bodies.js`.
+export { classMemberFuncKey } from "./class-member-keys.js";
+
 /** Collect all function declarations and interfaces */
 /** Collect a class declaration or class expression: register struct type, constructor, and methods */
 export function collectClassDeclaration(
@@ -635,10 +641,13 @@ export function collectClassDeclaration(
   }
   const ctorTypeIdx = addFuncType(ctx, ctorParams, ctorResults, `${className}_new_type`);
   const ctorFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.funcMap.set(ctorName, ctorFuncIdx);
+  // (#1983) collision-free key — also the wasm display name so the funcByName
+  // body-fill lookup doesn't collide with a user `function ClassName_new()`.
+  const ctorKey = classMemberFuncKey(ctx, ctorName);
+  ctx.funcMap.set(ctorKey, ctorFuncIdx);
 
   ctx.mod.functions.push({
-    name: ctorName,
+    name: ctorKey,
     typeIdx: ctorTypeIdx,
     locals: [],
     body: [],
@@ -662,9 +671,10 @@ export function collectClassDeclaration(
     const initParams: ValType[] = [...ctorParams, { kind: "ref", typeIdx: structTypeIdx }];
     const initTypeIdx = addFuncType(ctx, initParams, [{ kind: "ref", typeIdx: structTypeIdx }], `${initName}_type`);
     const initFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.funcMap.set(initName, initFuncIdx);
+    const initKey = classMemberFuncKey(ctx, initName); // (#1983) collision-free key + display name
+    ctx.funcMap.set(initKey, initFuncIdx);
     ctx.mod.functions.push({
-      name: initName,
+      name: initKey,
       typeIdx: initTypeIdx,
       locals: [],
       body: [],
@@ -714,7 +724,9 @@ export function collectClassDeclaration(
       // Skip if a function with this name is already registered (e.g., when
       // both a static and instance method share the same name, they produce
       // the same function name — avoid creating duplicate placeholders).
-      if (ctx.funcMap.has(fullName)) continue;
+      // (#1983) check the relocated key so a user `function ClassName_m()` does
+      // not look like an already-registered method and suppress the real one.
+      if (ctx.funcMap.has(classMemberFuncKey(ctx, fullName))) continue;
 
       // Static methods have no self parameter; instance methods get self: (ref $structTypeIdx)
       const methodParams: ValType[] = isStatic ? [] : [{ kind: "ref", typeIdx: structTypeIdx }];
@@ -760,10 +772,14 @@ export function collectClassDeclaration(
 
       const methodTypeIdx = addFuncType(ctx, methodParams, methodResults, `${fullName}_type`);
       const methodFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-      ctx.funcMap.set(fullName, methodFuncIdx);
+      // (#1983) Use the collision-free key for the funcMap entry AND the wasm
+      // display name, so the `funcByName` body-fill lookup (which keys on the
+      // display name) does not collide with a user `function ClassName_m()`.
+      const methodKey = classMemberFuncKey(ctx, fullName);
+      ctx.funcMap.set(methodKey, methodFuncIdx);
 
       ctx.mod.functions.push({
-        name: fullName,
+        name: methodKey,
         typeIdx: methodTypeIdx,
         locals: [],
         body: [],
@@ -800,7 +816,7 @@ export function collectClassDeclaration(
       // both a static and instance getter share the same computed property name,
       // they produce the same function name — avoid creating duplicates that
       // leave empty-body placeholders causing "stack fallthru" validation errors).
-      if (ctx.funcMap.has(getterName)) continue;
+      if (ctx.funcMap.has(classMemberFuncKey(ctx, getterName))) continue; // (#1983)
       // Getter takes self, returns the accessor return type
       const getterParams: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }];
       const sig = ctx.checker.getSignatureFromDeclaration(member);
@@ -814,10 +830,11 @@ export function collectClassDeclaration(
 
       const getterTypeIdx = addFuncType(ctx, getterParams, getterResults, `${getterName}_type`);
       const getterFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-      ctx.funcMap.set(getterName, getterFuncIdx);
+      const getterKey = classMemberFuncKey(ctx, getterName); // (#1983) key + display name
+      ctx.funcMap.set(getterKey, getterFuncIdx);
 
       ctx.mod.functions.push({
-        name: getterName,
+        name: getterKey,
         typeIdx: getterTypeIdx,
         locals: [],
         body: [],
@@ -836,7 +853,7 @@ export function collectClassDeclaration(
 
       const setterName = `${className}_set_${propName}`;
       // Skip if already registered (same collision guard as getter above)
-      if (ctx.funcMap.has(setterName)) continue;
+      if (ctx.funcMap.has(classMemberFuncKey(ctx, setterName))) continue; // (#1983)
       // Setter takes self + value, returns void
       const setterParams: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }];
       for (const param of member.parameters) {
@@ -847,10 +864,11 @@ export function collectClassDeclaration(
 
       const setterTypeIdx = addFuncType(ctx, setterParams, [], `${setterName}_type`);
       const setterFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-      ctx.funcMap.set(setterName, setterFuncIdx);
+      const setterKey = classMemberFuncKey(ctx, setterName); // (#1983) key + display name
+      ctx.funcMap.set(setterKey, setterFuncIdx);
 
       ctx.mod.functions.push({
-        name: setterName,
+        name: setterKey,
         typeIdx: setterTypeIdx,
         locals: [],
         body: [],
@@ -879,8 +897,13 @@ export function collectClassDeclaration(
       visitedAncestors.add(ancestor);
       // Inherit methods
       for (const [key, funcIdx] of ctx.funcMap) {
-        if (key.startsWith(`${ancestor}_`) && !key.endsWith("_new") && !key.endsWith("_type")) {
-          const suffix = key.substring(ancestor.length + 1);
+        // (#1983) A parent member whose legacy `${ancestor}_${member}` key
+        // collided with a user function is registered under the relocated
+        // `__cm$${ancestor}_${member}` key. Recover the legacy form first so the
+        // prefix-scan below sees inherited members regardless of relocation.
+        const legacyKey = key.startsWith("__cm$") ? key.slice("__cm$".length) : key;
+        if (legacyKey.startsWith(`${ancestor}_`) && !legacyKey.endsWith("_new") && !legacyKey.endsWith("_type")) {
+          const suffix = legacyKey.substring(ancestor.length + 1);
           // Skip constructor-related entries
           if (suffix === "new" || suffix.startsWith("new_")) continue;
           // Check if this is a getter/setter (get_X or set_X)
@@ -891,8 +914,9 @@ export function collectClassDeclaration(
             const accPropName = (getMatch || setMatch)![1]!;
             if (!ownAccessorNames.has(accPropName)) {
               const childFullName = `${className}_${suffix}`;
-              if (!ctx.funcMap.has(childFullName)) {
-                ctx.funcMap.set(childFullName, funcIdx);
+              const childKey = classMemberFuncKey(ctx, childFullName); // (#1983)
+              if (!ctx.funcMap.has(childKey)) {
+                ctx.funcMap.set(childKey, funcIdx);
               }
               // Also inherit accessor set entry
               const parentAccessorKey = `${ancestor}_${accPropName}`;
@@ -905,8 +929,9 @@ export function collectClassDeclaration(
             // Regular method — inherit from parent (works for all method names,
             // including those with underscores like my_method) (#799 WI6)
             const childFullName = `${className}_${suffix}`;
-            if (!ownMethodNames.has(suffix) && !ctx.funcMap.has(childFullName)) {
-              ctx.funcMap.set(childFullName, funcIdx);
+            const childKey = classMemberFuncKey(ctx, childFullName); // (#1983)
+            if (!ownMethodNames.has(suffix) && !ctx.funcMap.has(childKey)) {
+              ctx.funcMap.set(childKey, funcIdx);
               ctx.classMethodSet.add(childFullName);
             }
           }
@@ -1167,7 +1192,7 @@ function compileClassBodiesInner(
   // Compile constructor
   const ctor = decl.members.find(ts.isConstructorDeclaration) as ts.ConstructorDeclaration | undefined;
   const ctorName = `${className}_new`;
-  const ctorLocalIdx = funcByName.get(ctorName);
+  const ctorLocalIdx = funcByName.get(classMemberFuncKey(ctx, ctorName)); // (#1983)
   if (ctorLocalIdx !== undefined) {
     const func = ctx.mod.functions[ctorLocalIdx]!;
     const params: { name: string; type: ValType }[] = [];
@@ -1222,7 +1247,7 @@ function compileClassBodiesInner(
     // calls the parent's init on the derived instance, so the parent ctor
     // body actually executes. Externref-backed classes keep the legacy
     // single-function shape (their instance comes from a host import).
-    const initLocalIdx = isExternrefBacked ? undefined : funcByName.get(`${className}_init`);
+    const initLocalIdx = isExternrefBacked ? undefined : funcByName.get(classMemberFuncKey(ctx, `${className}_init`)); // (#1983)
     const initFunc = initLocalIdx !== undefined ? ctx.mod.functions[initLocalIdx] : undefined;
     const splitInit = !isExternrefBacked && initFunc !== undefined;
 
@@ -1230,6 +1255,8 @@ function compileClassBodiesInner(
       ? [...params, { name: "__self", type: { kind: "ref", typeIdx: structTypeIdx } as ValType }]
       : params;
     const fctx: FunctionContext = {
+      // display name only — cosmetic; the relocated funcMap/funcByName keys
+      // above carry the actual identity (#1983).
       name: splitInit ? `${className}_init` : ctorName,
       params: fctxParams,
       locals: [],
@@ -1326,7 +1353,9 @@ function compileClassBodiesInner(
     // effects would run twice, and the raw args + untouched `__argc` global
     // flow through to the parent's own check).
     const implicitParentInitIdx =
-      splitInit && !ctor ? ctx.funcMap.get(`${ctx.classParentMap.get(className) ?? ""}_init`) : undefined;
+      splitInit && !ctor
+        ? ctx.funcMap.get(classMemberFuncKey(ctx, `${ctx.classParentMap.get(className) ?? ""}_init`)) // (#1983)
+        : undefined;
 
     // Emit default-value initialization for constructor parameters with initializers.
     // For primitive params, __argc distinguishes an omitted argument from a
@@ -1638,7 +1667,7 @@ function compileClassBodiesInner(
         newBody.push({ op: "local.get", index: i });
       }
       newBody.push({ op: "local.get", index: newSelfLocal });
-      const initIdxNow = ctx.funcMap.get(`${className}_init`);
+      const initIdxNow = ctx.funcMap.get(classMemberFuncKey(ctx, `${className}_init`)); // (#1983)
       newBody.push({ op: "return_call", funcIdx: initIdxNow! } as Instr);
       func.locals = [{ name: "__self", type: { kind: "ref", typeIdx: structTypeIdx } }];
       func.body = newBody;
@@ -1661,7 +1690,7 @@ function compileClassBodiesInner(
       if (compiledMethods.has(fullName)) continue; // already compiled
       compiledMethods.add(fullName);
       const isStatic = ctx.staticMethodSet.has(fullName);
-      const methodLocalIdx = funcByName.get(fullName);
+      const methodLocalIdx = funcByName.get(classMemberFuncKey(ctx, fullName)); // (#1983)
       if (methodLocalIdx === undefined) continue;
 
       const func = ctx.mod.functions[methodLocalIdx]!;
@@ -1929,7 +1958,7 @@ function compileClassBodiesInner(
       const getterName = `${className}_get_${propName}`;
       if (compiledAccessors.has(getterName)) continue; // already compiled
       compiledAccessors.add(getterName);
-      const getterLocalIdx = funcByName.get(getterName);
+      const getterLocalIdx = funcByName.get(classMemberFuncKey(ctx, getterName)); // (#1983)
       if (getterLocalIdx === undefined) continue;
 
       const func = ctx.mod.functions[getterLocalIdx]!;
@@ -2017,7 +2046,7 @@ function compileClassBodiesInner(
       const setterName = `${className}_set_${propName}`;
       if (compiledAccessors.has(setterName)) continue; // already compiled
       compiledAccessors.add(setterName);
-      const setterLocalIdx = funcByName.get(setterName);
+      const setterLocalIdx = funcByName.get(classMemberFuncKey(ctx, setterName)); // (#1983)
       if (setterLocalIdx === undefined) continue;
 
       const func = ctx.mod.functions[setterLocalIdx]!;

--- a/src/codegen/class-member-keys.ts
+++ b/src/codegen/class-member-keys.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * (#1983) Collision-free funcMap key for class-member synthetic names.
+ *
+ * Leaf module (depends only on the CodegenContext type) so every codegen file
+ * — producers in `class-bodies.ts` / `new-super.ts` / `literals.ts` /
+ * `object-ops.ts` and consumers in `expressions/calls.ts` / `closures.ts` /
+ * `index.ts` — can import it without risking an import cycle.
+ */
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * Class members register in `ctx.funcMap` under `${className}_${member}` keys
+ * (`A_m` for `A.m`, `A_new` for the ctor, `A_get_v` for a getter, …). A
+ * top-level user `function A_m() {}` would claim the same flat string key, and
+ * `ensureSiblingFunctionsRegistered` then *silently skips* registering the user
+ * function because `funcMap.has("A_m")` is already true — so `A_m()` call sites
+ * resolve to the class member's funcIdx (wrong signature → validation trap).
+ *
+ * The fix keeps the funcMap key **byte-identical** (`A_m`) in the overwhelming
+ * common case (no user function of that name), and only when a real collision
+ * exists relocates the *class member's* funcMap key to a form a user identifier
+ * cannot produce (`__cm$A_m`). The user function keeps the bare `A_m` key (it
+ * is no longer skipped, because the class member vacated `A_m`), so its many
+ * bare-call / export / ref.func consumers are untouched.
+ *
+ * IMPORTANT: this relocates ONLY the `funcMap` funcIdx key. The parallel
+ * membership sets (`classMethodSet`, `staticMethodSet`, `classAccessorSet`,
+ * `staticProps`, …) and the per-name metadata maps (`funcOptionalParams`,
+ * `funcRestParams`, `funcUsesArguments`, …) keep the legacy
+ * `${className}_${member}` string — the sets answer "is this name a class
+ * member?" (collision-free), and the method-dispatch consumer reads the
+ * metadata by the same legacy `fullName`, so producer and consumer agree.
+ * Producers and consumers of the funcMap **funcIdx** must both route the legacy
+ * name through this helper so they agree on the relocated key.
+ *
+ * Known residual (out of scope, does NOT trap): if a program declares BOTH a
+ * class member `A.m` *and* a user `function A_m()` *and both* carry optional /
+ * rest params, the two share the legacy `funcOptionalParams[A_m]` slot. This
+ * affects only optional-arg backfill for that pathological name clash; the
+ * funcIdx (the trap cause) is correctly separated.
+ */
+export function classMemberFuncKey(ctx: CodegenContext, fullName: string): string {
+  // Only relocate when the legacy key would actually collide with a top-level
+  // user function. Keeps output identical for every non-colliding program.
+  if (!ctx.topLevelFunctionNames.has(fullName)) return fullName;
+  // Relocate to a prefixed key. The `__cm$` prefix never appears in a
+  // `${className}_${member}` join, so it cannot collide with another class
+  // member's legacy key. Guard the pathological case where a user also wrote
+  // `function __cm$A_m() {}` by appending disambiguators until free.
+  let key = `__cm$${fullName}`;
+  let n = 0;
+  while (ctx.topLevelFunctionNames.has(key)) key = `__cm$${fullName}$${n++}`;
+  return key;
+}

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -17,6 +17,7 @@
 import { ts, forEachChild } from "../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
+import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
@@ -1204,7 +1205,7 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
     // Check if the constructor is a user-defined class — if so, NOT a host callback
     if (ts.isIdentifier(parent.expression)) {
       const ctorName = parent.expression.text;
-      const newFuncIdx = ctx.funcMap.get(`${ctorName}_new`);
+      const newFuncIdx = ctx.funcMap.get(classMemberFuncKey(ctx, `${ctorName}_new`)); // (#1983)
       if (newFuncIdx !== undefined && newFuncIdx >= ctx.numImportFuncs) {
         return false;
       }

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -68,6 +68,7 @@ export function createCodegenContext(
     capturedGlobalsWidened: new Set(),
     classSet: new Set(),
     classThrowsOnEval: new Set(),
+    topLevelFunctionNames: new Set(), // (#1983) for class-member funcMap key collision detection
     classMethodSet: new Set(),
     deferredClassBodies: new Set(),
     classAccessorSet: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -565,6 +565,15 @@ export interface CodegenContext {
   classSet: Set<string>;
   /** Classes that must throw TypeError at evaluation time */
   classThrowsOnEval: Set<string>;
+  /**
+   * (#1983) Names of top-level user `function` declarations in the source. Used
+   * by `classMemberFuncKey` to detect when a synthetic class-member key
+   * (`${className}_${member}`) would collide with a user function of the same
+   * name (e.g. `class A { m() {} }` + `function A_m() {}`), so the class
+   * member's **funcMap** entry can take a collision-free key. Populated in
+   * `collectDeclarations` (runs before any class body compiles).
+   */
+  topLevelFunctionNames: Set<string>;
   /** Map from "ClassName_methodName" → method info for local classes */
   classMethodSet: Set<string>;
   /** Classes inside function bodies whose body compilation is deferred */

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2730,6 +2730,11 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       const name = stmt.name ? stmt.name.text : "default";
       // Register the function's .name value for ES-spec compliance
       ctx.functionNameMap.set(name, name);
+      // (#1983) Record the top-level user-function name so class-member funcMap
+      // keys (`${className}_${member}`) that would collide with it can relocate.
+      // Only real `function` declarations participate — class names are tracked
+      // separately and must NOT poison the collision set.
+      if (stmt.name) ctx.topLevelFunctionNames.add(name);
       // #1463 — capture source text for Function.prototype.toString() so that
       // `someFn.toString()` returns the original declaration text instead of
       // the `function () { [native code] }` placeholder. Only top-level

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -19,6 +19,7 @@ import {
 } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } from "../array-methods.js";
+import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { reserveClosedMethodDispatch } from "../closed-method-dispatch.js";
 import { ensureObjVecBuilders, ensureObjectRuntime } from "../object-runtime.js";
 import {
@@ -6231,7 +6232,7 @@ function compileCallExpression(
       const methodName = propAccess.name.text;
       const fullName = `${clsName}_${methodName}`;
       if (ctx.staticMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)); // (#1983)
         if (funcIdx !== undefined) {
           // No self parameter for static methods
           const paramTypes = getFuncParamTypes(ctx, funcIdx);
@@ -6261,7 +6262,7 @@ function compileCallExpression(
           // Set __argc before the call so the callee knows the actual arg count
           maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, staticParamCount);
           // Re-lookup funcIdx: argument compilation may trigger addUnionImports
-          const finalStaticIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+          const finalStaticIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? funcIdx; // (#1983)
           fctx.body.push({ op: "call", funcIdx: finalStaticIdx });
 
           const sig = ctx.checker.getResolvedSignature(expr);
@@ -6691,13 +6692,13 @@ function compileCallExpression(
         ? "__priv_" + propAccess.name.text.slice(1)
         : propAccess.name.text;
       let fullName = `${receiverClassName}_${methodName}`;
-      let funcIdx = ctx.funcMap.get(fullName);
+      let funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)); // (#1983)
       // Walk inheritance chain to find the method in a parent class
       if (funcIdx === undefined) {
         let ancestor = ctx.classParentMap.get(receiverClassName);
         while (ancestor && funcIdx === undefined) {
           fullName = `${ancestor}_${methodName}`;
-          funcIdx = ctx.funcMap.get(fullName);
+          funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)); // (#1983)
           ancestor = ctx.classParentMap.get(ancestor);
         }
       }
@@ -6713,7 +6714,7 @@ function compileCallExpression(
         for (const [childClass, parentClass] of ctx.classParentMap) {
           if (parentClass === receiverClassName || parentClass === baseClass) {
             const childFullName = `${childClass}_${methodName}`;
-            const childFuncIdx = ctx.funcMap.get(childFullName);
+            const childFuncIdx = ctx.funcMap.get(classMemberFuncKey(ctx, childFullName)); // (#1983)
             const childTag = ctx.classTagMap.get(childClass);
             if (childFuncIdx !== undefined && childTag !== undefined) {
               candidates.push({ className: childClass, funcIdx: childFuncIdx, classTag: childTag });
@@ -6744,7 +6745,7 @@ function compileCallExpression(
           }
           if (cur === receiverClassName && childClass !== receiverClassName) {
             const childFullName = `${childClass}_${methodName}`;
-            const childFuncIdx = ctx.funcMap.get(childFullName);
+            const childFuncIdx = ctx.funcMap.get(classMemberFuncKey(ctx, childFullName)); // (#1983)
             const childTag = ctx.classTagMap.get(childClass);
             if (
               childFuncIdx !== undefined &&
@@ -6783,7 +6784,7 @@ function compileCallExpression(
       // We call the getter first, then invoke the returned callable.
       if (funcIdx === undefined) {
         const getterName = `${receiverClassName}_get_${methodName}`;
-        const getterIdx = ctx.funcMap.get(getterName);
+        const getterIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName)); // (#1983)
         if (getterIdx !== undefined) {
           const getterCallResult = compileGetterCallable(ctx, fctx, expr, propAccess, receiverClassName, getterIdx);
           if (getterCallResult !== undefined) return getterCallResult;
@@ -6813,7 +6814,7 @@ function compileCallExpression(
           }
           // Re-resolve funcIdx after receiver compilation — emitUndefined (for `this` in static
           // context) triggers addUnionImports which shifts all function indices (#998)
-          const resolvedStaticIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+          const resolvedStaticIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? funcIdx; // (#1983)
           const paramTypes = getFuncParamTypes(ctx, resolvedStaticIdx);
           const paramCount = paramTypes ? paramTypes.length : expr.arguments.length;
           const calleeReadsArgsStatic = ctx.funcUsesArguments.has(fullName);
@@ -6839,7 +6840,7 @@ function compileCallExpression(
           }
           // Set __argc before the call so the callee knows the actual arg count
           maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, paramCount);
-          const finalMethodIdx = ctx.funcMap.get(fullName) ?? resolvedStaticIdx;
+          const finalMethodIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? resolvedStaticIdx; // (#1983)
           fctx.body.push({ op: "call", funcIdx: finalMethodIdx });
           const sig = ctx.checker.getResolvedSignature(expr);
           if (sig) {
@@ -6970,7 +6971,7 @@ function compileCallExpression(
           }
           // Set __argc before the call so the callee knows the actual arg count
           maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, ngParamCount);
-          const finalMethodIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+          const finalMethodIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? funcIdx; // (#1983)
           fctx.body.push({ op: "call", funcIdx: finalMethodIdx });
           const elseInstrs = fctx.body;
           fctx.body = savedBody;
@@ -7034,7 +7035,7 @@ function compileCallExpression(
         // Set __argc before the call so the callee knows the actual arg count
         maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, methodParamCount);
         // Re-lookup funcIdx: argument compilation may trigger addUnionImports
-        const finalMethodIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+        const finalMethodIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? funcIdx; // (#1983)
         fctx.body.push({ op: "call", funcIdx: finalMethodIdx });
 
         // Determine return type

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -25,6 +25,7 @@ import {
   resolveWasmType,
 } from "../index.js";
 import { ensureMapHelpers } from "../map-runtime.js";
+import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { resolveComputedKeyExpression } from "../literals.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import {
@@ -933,7 +934,7 @@ function compileNewFunctionDeclaration(
   const ctorResults: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }];
   const ctorTypeIdx = addFuncType(ctx, ctorParams, ctorResults, `${ctorName}_type`);
   const ctorFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.funcMap.set(ctorName, ctorFuncIdx);
+  ctx.funcMap.set(classMemberFuncKey(ctx, ctorName), ctorFuncIdx); // (#1983) collision-free key
 
   const ctorFunc = {
     name: ctorName,
@@ -1097,7 +1098,7 @@ function compileNewFunctionDeclaration(
     }
   }
   // Re-lookup funcIdx in case addUnionImports shifted indices
-  const finalCtorIdx = ctx.funcMap.get(ctorName) ?? ctorFuncIdx;
+  const finalCtorIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)) ?? ctorFuncIdx; // (#1983)
   maybeSetArgcForKnownCall(ctx, fctx, ctorName, args.length, paramTypes?.length ?? args.length);
   fctx.body.push({ op: "call", funcIdx: finalCtorIdx });
   return { kind: "ref", typeIdx: structTypeIdx };
@@ -1565,7 +1566,7 @@ function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr
 
   if (syntheticName) {
     const ctorName = `${syntheticName}_new`;
-    const funcIdx = ctx.funcMap.get(ctorName);
+    const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)); // (#1983)
     if (funcIdx !== undefined) {
       return emitClassCtorValue(ctx, fctx, ctorName, funcIdx);
     }
@@ -1576,7 +1577,7 @@ function compileClassExpression(ctx: CodegenContext, fctx: FunctionContext, expr
     const className = expr.name.text;
     if (ctx.classSet.has(className)) {
       const ctorName = `${className}_new`;
-      const funcIdx = ctx.funcMap.get(ctorName);
+      const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)); // (#1983)
       if (funcIdx !== undefined) {
         return emitClassCtorValue(ctx, fctx, ctorName, funcIdx);
       }
@@ -1685,7 +1686,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const syntheticName = ctx.anonClassExprNames.get(unwrappedExpr);
       if (syntheticName) {
         const ctorName = `${syntheticName}_new`;
-        const funcIdx = ctx.funcMap.get(ctorName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)); // (#1983)
         if (funcIdx === undefined) {
           reportError(ctx, expr, `Missing constructor for anonymous class`);
           return null;
@@ -3000,7 +3001,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // Handle local class constructors
   if (ctx.classSet.has(className)) {
     const ctorName = `${className}_new`;
-    const funcIdx = ctx.funcMap.get(ctorName);
+    const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)); // (#1983)
     if (funcIdx === undefined) {
       reportError(ctx, expr, `Missing constructor for class: ${className}`);
       return null;
@@ -3072,7 +3073,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
     // Re-lookup funcIdx: argument compilation may trigger addUnionImports
     // which shifts defined-function indices, making the earlier lookup stale.
-    const finalCtorIdx = ctx.funcMap.get(ctorName) ?? funcIdx;
+    const finalCtorIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)) ?? funcIdx; // (#1983)
     maybeSetArgcForKnownCall(ctx, fctx, ctorName, ctorActualArgCount, paramTypes?.length ?? ctorActualArgCount);
     fctx.body.push({ op: "call", funcIdx: finalCtorIdx });
     // (#1366a) Externref-backed subclass instances (extends Error / TypeError

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -89,6 +89,7 @@ import {
   collectDeclaredFuncRefs,
   compileClassBodies,
 } from "./class-bodies.js";
+import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983)
 import {
   applyShapeInference,
   collectDeclarations,
@@ -957,6 +958,16 @@ export function generateModule(
 } {
   const mod = createEmptyModule();
   const ctx = createCodegenContext(mod, ast.checker, options);
+  // (#1983) Pre-scan top-level user `function` declaration names BEFORE any
+  // class member registers a funcMap key, so `classMemberFuncKey` can detect a
+  // `${className}_${member}` ↔ user-function collision (e.g. `class A { m() {} }`
+  // + `function A_m() {}`) and relocate the class member's key. Must run here —
+  // ahead of class collection/compile — because the producers query this set.
+  for (const stmt of ast.sourceFile.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body && !hasDeclareModifier(stmt)) {
+      ctx.topLevelFunctionNames.add(stmt.name.text);
+    }
+  }
   try {
     // WASI target: register linear memory, bump pointer global, and WASI imports
     if (ctx.wasi) {
@@ -2662,7 +2673,7 @@ function emitToPrimitiveMethodExport(ctx: CodegenContext): void {
     )
       continue;
 
-    const funcIdx = ctx.funcMap.get(`${structName}_${methodSuffix}`);
+    const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, `${structName}_${methodSuffix}`)); // (#1983)
     if (funcIdx === undefined) continue;
 
     const funcDef = mod.functions[funcIdx - ctx.numImportFuncs];
@@ -10108,7 +10119,8 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
     if (declSourceFile && declSourceFile.isDeclarationFile) continue;
 
     const fullName = `${structName}_${prop.name}`;
-    if (ctx.funcMap.has(fullName)) continue; // already registered
+    const methodKey = classMemberFuncKey(ctx, fullName); // (#1983) collision-free key + display name
+    if (ctx.funcMap.has(methodKey)) continue; // already registered
 
     const sig = callSigs[0]!;
     // Build parameter types: self (ref $structTypeIdx) + declared params.
@@ -10154,10 +10166,10 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
 
     const methodTypeIdx = addFuncType(ctx, methodParams, methodResults, `${fullName}_type`);
     const methodFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.funcMap.set(fullName, methodFuncIdx);
+    ctx.funcMap.set(methodKey, methodFuncIdx); // (#1983) relocated key
 
     const methodFunc: WasmFunction = {
-      name: fullName,
+      name: methodKey, // (#1983) display name matches relocated funcMap key for body-fill
       typeIdx: methodTypeIdx,
       locals: [],
       body: [],

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -11,6 +11,7 @@ import { ts } from "../ts-api.js";
 import { isExternalDeclaredClass, isIteratorResultType, isStringType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { emitBoundsCheckedArrayGet } from "./array-methods.js";
+import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { popBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -1261,7 +1262,7 @@ export function compileOptionalPropertyAccess(
         // Check for accessor first
         const accessorKey = `${structName}_${propName}`;
         const getterName = `${structName}_get_${propName}`;
-        const getterIdx = ctx.funcMap.get(getterName);
+        const getterIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
         const closureAccGet =
           S5C_STRUCT_ACCESSOR_CLOSURE && ctx.standalone
             ? ctx.structAccessorClosure.get(accessorKey)?.getGlobal
@@ -1739,7 +1740,8 @@ export function compilePropertyAccess(
     ) {
       const structTypeIdx = ctx.structMap.get(cls.className);
       const getterName = `${cls.className}_get_${cls.fieldName}`;
-      const canEmit = structTypeIdx !== undefined && (cls.kind === "method" || ctx.funcMap.has(getterName));
+      const canEmit =
+        structTypeIdx !== undefined && (cls.kind === "method" || ctx.funcMap.has(classMemberFuncKey(ctx, getterName)));
       if (canEmit) {
         const objResult = compileExpression(ctx, fctx, expr.expression);
         const tmpAny = allocTempLocal(fctx, { kind: "anyref" });
@@ -1777,7 +1779,7 @@ export function compilePropertyAccess(
           resultKind = { kind: "externref" };
         } else {
           // Resolve the getter funcIdx AFTER the throw branch settled imports.
-          const getterIdx = ctx.funcMap.get(getterName)!;
+          const getterIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName))!;
           successInstrs.push({ op: "call", funcIdx: getterIdx });
           const funcDef = ctx.mod.functions[getterIdx - ctx.numImportFuncs];
           const typeDef = funcDef ? ctx.mod.types[funcDef.typeIdx] : undefined;
@@ -2057,7 +2059,7 @@ export function compilePropertyAccess(
       const accessorKey = `${enclosingClass}_${propName}`;
       if (ctx.staticAccessorSet.has(accessorKey)) {
         const getterName = `${enclosingClass}_get_${propName}`;
-        const funcIdx = ctx.funcMap.get(getterName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
         if (funcIdx !== undefined) {
           const retType = emitGetterCallWithDummy(ctx, fctx, enclosingClass, getterName, funcIdx);
           if (retType) return retType;
@@ -2068,7 +2070,7 @@ export function compilePropertyAccess(
       // (same as ClassName.method path at line 992) — avoids generic
       // fallthrough cast of undefined.
       if (ctx.staticMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
         if (funcIdx !== undefined) {
           fctx.body.push({ op: "ref.null.extern" });
           return { kind: "externref" };
@@ -2162,7 +2164,7 @@ export function compilePropertyAccess(
       // unblocking 273 test262 cases for class async-generator yield-star
       // tests that follow this exact extraction pattern.
       if (ctx.staticMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
         if (funcIdx !== undefined) {
           const closureRef = emitFuncRefAsClosure(ctx, fctx, fullName, funcIdx);
           if (closureRef) {
@@ -2177,7 +2179,7 @@ export function compilePropertyAccess(
       // Instance method accessed as `ClassName.method` (without prototype) —
       // unusual; keep the legacy null placeholder to preserve existing behavior.
       if (ctx.classMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
         if (funcIdx !== undefined) {
           fctx.body.push({ op: "ref.null.extern" });
           return { kind: "externref" };
@@ -2187,7 +2189,7 @@ export function compilePropertyAccess(
       const accessorKey = `${resolvedClass}_${propName}`;
       if (ctx.classAccessorSet.has(accessorKey)) {
         const getterName = `${resolvedClass}_get_${propName}`;
-        const funcIdx = ctx.funcMap.get(getterName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
         if (funcIdx !== undefined) {
           const retType = emitGetterCallWithDummy(ctx, fctx, resolvedClass, getterName, funcIdx);
           return retType ?? { kind: "externref" };
@@ -2217,7 +2219,7 @@ export function compilePropertyAccess(
       // (they live on the constructor, not the prototype) and
       // accessors (handled by the existing accessor path below).
       if (ctx.classMethodSet.has(fullName) && !ctx.staticMethodSet.has(fullName)) {
-        const funcIdx = ctx.funcMap.get(fullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
         const structTypeIdx = ctx.structMap.get(className);
         if (funcIdx !== undefined && structTypeIdx !== undefined) {
           if (emitCachedMethodClosureAccess(ctx, fctx, fullName, funcIdx, structTypeIdx)) {
@@ -2935,7 +2937,7 @@ export function compilePropertyAccess(
     }
     if (ctx.classAccessorSet.has(accessorKey)) {
       const getterName = `${typeName}_get_${propName}`;
-      const funcIdx = ctx.funcMap.get(getterName);
+      const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
       if (funcIdx !== undefined) {
         compileExpression(ctx, fctx, expr.expression);
         fctx.body.push({ op: "call", funcIdx });
@@ -3003,7 +3005,7 @@ export function compilePropertyAccess(
       const owner = ownerNameForChain(typeName);
       const methodFullName = `${owner}_${propName}`;
       if (ctx.classMethodSet.has(methodFullName) || ctx.staticMethodSet.has(methodFullName)) {
-        const funcIdx = ctx.funcMap.get(methodFullName);
+        const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, methodFullName));
         if (funcIdx !== undefined) {
           // #1118: Object literal — read the struct field which holds the closure.
           // Detected by: typeName is a registered struct AND the struct has a
@@ -3991,7 +3993,7 @@ export function compileElementAccess(
         const accessorKey = `${resolvedClass}_${key}`;
         if (ctx.classAccessorSet.has(accessorKey)) {
           const getterName = `${resolvedClass}_get_${key}`;
-          const funcIdx = ctx.funcMap.get(getterName);
+          const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
           if (funcIdx !== undefined) {
             const retType = emitGetterCallWithDummy(ctx, fctx, resolvedClass, getterName, funcIdx);
             return retType ?? { kind: "externref" };
@@ -4010,7 +4012,7 @@ export function compileElementAccess(
         // externref instead of the legacy `ref.null.extern` so that
         // `const f = C['method']; f()` actually invokes the method.
         if (ctx.staticMethodSet.has(fullName)) {
-          const funcIdx = ctx.funcMap.get(fullName);
+          const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
           if (funcIdx !== undefined) {
             const closureRef = emitFuncRefAsClosure(ctx, fctx, fullName, funcIdx);
             if (closureRef) {
@@ -4022,7 +4024,7 @@ export function compileElementAccess(
           }
         }
         if (ctx.classMethodSet.has(fullName)) {
-          const funcIdx = ctx.funcMap.get(fullName);
+          const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
           if (funcIdx !== undefined) {
             fctx.body.push({ op: "ref.null.extern" });
             return { kind: "externref" };
@@ -4048,7 +4050,7 @@ export function compileElementAccess(
         const accessorKey = `${className}_${key}`;
         if (ctx.classAccessorSet.has(accessorKey) && !ctx.staticAccessorSet.has(accessorKey)) {
           const getterName = `${className}_get_${key}`;
-          const funcIdx = ctx.funcMap.get(getterName);
+          const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
           if (funcIdx !== undefined) {
             const retType = emitGetterCallWithDummy(ctx, fctx, className, getterName, funcIdx);
             return retType ?? { kind: "externref" };
@@ -4060,7 +4062,7 @@ export function compileElementAccess(
         // dot-access path at property-access.ts:1361–1383.
         const methodFullName = `${className}_${key}`;
         if (ctx.classMethodSet.has(methodFullName) && !ctx.staticMethodSet.has(methodFullName)) {
-          const funcIdx = ctx.funcMap.get(methodFullName);
+          const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, methodFullName));
           const structTypeIdx = ctx.structMap.get(className);
           if (funcIdx !== undefined && structTypeIdx !== undefined) {
             if (emitCachedMethodClosureAccess(ctx, fctx, methodFullName, funcIdx, structTypeIdx)) {
@@ -4269,7 +4271,7 @@ export function compileElementAccessBody(
           const accessorKey = `${sName}_${fieldName}`;
           if (ctx.classAccessorSet.has(accessorKey)) {
             const getterName = `${sName}_get_${fieldName}`;
-            const funcIdx = ctx.funcMap.get(getterName);
+            const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
             if (funcIdx !== undefined) {
               fctx.body.push({ op: "call", funcIdx });
               // Use actual Wasm return type of the getter

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -26,6 +26,7 @@ import { ts } from "../ts-api.js";
 
 import { getOrRegisterPromiseType } from "../codegen/async-scheduler.js";
 import { addGeneratorImports, addIteratorImports, addStringImports } from "../codegen/index.js";
+import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import {
   ensureNativeStringHelpers,
   nativeStringLiteralInstrs,
@@ -1692,7 +1693,14 @@ class ClassRegistry {
       fieldIdxByName.set(legacyFields[i]!.name, i);
     }
 
-    const constructorFuncName = `${shape.className}_new`;
+    // (#1983) Route synthetic class-member names through `classMemberFuncKey`
+    // so the IR backend resolves the SAME (possibly relocated) funcMap key the
+    // legacy pass registered. Without this, a class whose `${className}_new` /
+    // `${className}_${method}` key collided with a user function resolves to the
+    // user function's funcIdx (wrong signature → validation trap). Identical to
+    // the legacy name for every non-colliding class.
+    const ctx = this.ctx;
+    const constructorFuncName = classMemberFuncKey(ctx, `${shape.className}_new`);
 
     const lowering: IrClassLowering = {
       structTypeIdx,
@@ -1707,8 +1715,8 @@ class ClassRegistry {
       methodFuncName: (name: string): string => {
         // Returns a NAME — the resolver's `resolveFunc` maps it to the
         // funcIdx via `ctx.funcMap`, which the legacy collection pass
-        // populated with stable indices.
-        return `${shape.className}_${name}`;
+        // populated with stable indices. (#1983) collision-free key.
+        return classMemberFuncKey(ctx, `${shape.className}_${name}`);
       },
     };
     this.cache.set(shape.className, lowering);

--- a/tests/issue-1983-funcmap-collision.test.ts
+++ b/tests/issue-1983-funcmap-collision.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1983 — `${ClassName}_${member}` funcMap keys must not collide with user
+ * functions.
+ *
+ * A class member `A.m` registers the synthetic funcMap key `A_m`; a top-level
+ * `function A_m()` would claim the same flat key, and the user-function
+ * reservation then SILENTLY SKIPS it (`funcMap.has("A_m")` already true) — so
+ * `A_m()` call sites resolved to the class method's funcIdx (wrong signature →
+ * validation trap) and `new A().m()` resolved to the user function.
+ *
+ * Fix: `classMemberFuncKey` relocates the class member's funcMap key + wasm
+ * display name to `__cm$<name>` ONLY on a real collision (byte-identical
+ * otherwise). Routed through producers + every consumer that resolves a
+ * class-member funcIdx — legacy dispatch (calls.ts / new-super.ts), the IR
+ * backend's ClassRegistry (`methodFuncName` / `constructorFuncName`), and the
+ * property-access getter/method-reference paths.
+ *
+ * Standalone + empty importObject (proves no JS host; instantiate with `{}`).
+ */
+async function standaloneExports(source: string) {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, (...a: unknown[]) => number>;
+}
+
+describe("#1983 — class-member funcMap key collision with user functions", () => {
+  it("method A.m vs function A_m — both callable, correct dispatch", async () => {
+    const ex = await standaloneExports(`
+      class A { m(): number { return 10; } }
+      function A_m(): number { return 2; }
+      export function test(): number { return new A().m() + A_m(); }
+    `);
+    expect(ex.test()).toBe(12);
+  });
+
+  it("constructor A_new vs function A_new", async () => {
+    const ex = await standaloneExports(`
+      class A { x: number = 7; }
+      function A_new(): number { return 3; }
+      export function test(): number { return new A().x + A_new(); }
+    `);
+    expect(ex.test()).toBe(10);
+  });
+
+  it("getter B.v vs function B_get_v", async () => {
+    const ex = await standaloneExports(`
+      class B { get v(): number { return 5; } }
+      function B_get_v(): number { return 3; }
+      export function test(): number { const b = new B(); return b.v + B_get_v(); }
+    `);
+    expect(ex.test()).toBe(8);
+  });
+
+  it("non-colliding class is byte-identical / unchanged (safe-by-construction)", async () => {
+    const ex = await standaloneExports(`
+      class C { m(): number { return 10; } }
+      export function test(): number { return new C().m() + 5; }
+    `);
+    expect(ex.test()).toBe(15);
+  });
+
+  it("user function reachable on its own when it shadows a method name", async () => {
+    const ex = await standaloneExports(`
+      class A { m(): number { return 10; } }
+      function A_m(): number { return 42; }
+      export function onlyUser(): number { return A_m(); }
+    `);
+    expect(ex.onlyUser()).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

A class member `A.m` registers the synthetic funcMap key `A_m`; a top-level `function A_m()` claims the same flat key, the user-fn reservation then **silently skips** it (`funcMap.has("A_m")` already true), so `A_m()` resolved to the method's funcIdx (wrong signature → validation trap) and `new A().m()` resolved to the user function. Same for ctor (`A_new`) and getters (`A_get_v`).

## Approach — byte-identical for non-colliding code (approved by lead; sdev3 reached the same "option B" independently)
New leaf helper `classMemberFuncKey(ctx, name)` (`src/codegen/class-member-keys.ts`): returns the **identical** legacy key for every non-colliding program, and only on a real collision relocates the *class member's* funcMap key + wasm display name to `__cm$<name>` (a prefix no `${className}_${member}` join emits). The user function keeps the bare key (no longer skipped). `topLevelFunctionNames` is pre-scanned at `generateModule` start so producers see it.

Routed through producers (class-bodies.ts ctor/init/method/getter/setter + inheritance copy; index.ts `ensureStructForType`; new-super.ts ctor) AND every consumer that resolves a class-member funcIdx:
- legacy dispatch — calls.ts (main/static/inheritance/override), new-super.ts, closures.ts;
- **the IR backend** — `ir/integration.ts` ClassRegistry `methodFuncName`/`constructorFuncName` (the IR front-end recompiles eligible functions and has its own dispatch — this was the subtle last consumer);
- property-access.ts getter-read / method-reference paths.

Membership sets (`classMethodSet` etc.) + per-name metadata stay on the legacy name (collision-free by purpose).

## Tests
`tests/issue-1983-funcmap-collision.test.ts` — 5 standalone + empty-importObject cases: method (12), ctor (10), getter (8), non-colliding control (15, byte-identical), user fn reachable (42). All green. Existing class suites' `string_constants` instantiate failures are a pre-existing `{env:{}}` harness artifact (identical on origin/main; module compiles fine).

Feeds #2158 (the #2101 spec names "post-#1983 collision-free funcMap names" as a contract). Object-literal `typeName`/`structName` keys use anon `__anon_*` names that can't collide — left untouched per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)