### PR TITLE
fix(#2106): any[] array-element boolean tag recovery (value-rep P3 slice S0)

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -1,10 +1,11 @@
 ---
 id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev7
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-15
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -98,3 +99,35 @@ perf/size blast-radius measurement as the acceptance criteria require.
 
 Symptom issues filed; the representation phase is unfiled. New (analysis
 program).
+
+## Slice S0 — `any[]` array-element tag recovery (sdev7, 2026-06-16) — SHIPPED
+
+First slice of P3 (the multi-slice S0–S4 plan lives in the #1503/value-rep doc
+commits). **Independent of #1503** — it does not depend on `value-tags.ts`.
+
+**Bug (host)**: a boolean (or any non-string primitive) stored in an `any[]`
+ARRAY LITERAL lost its JS tag on read-back — `typeof [true][0]` → `"number"`,
+`"" + [true][0]` → `"1"` (value preserved: `[true][0] === true`). Root cause:
+`[true]` builds `__vec_i32` (booleans lower to i32 and the `any[]` contextual
+element type is dropped at the ref-only adoption guard `literals.ts:2886`), then
+the i32-vec→`any[]` externref vec coercion boxes by Wasm KIND
+(`f64.convert_i32_s; __box_number`) → a JS number.
+
+**Fix** (`src/codegen/literals.ts`, `compileArrayLiteral`, before
+`elemKind`/`vecTypeIdx`): when `!hasSpread && elemWasm.kind ∈ {i32,f64}` AND the
+literal's `getContextualType` is `Array<any>`/`ReadonlyArray<any>` (type-arg flags
+carry `ts.TypeFlags.Any`), widen `elemWasm` to externref. Each element is then
+boxed by its own static type via the existing `compileExpression(el, externref)`
+path (`__box_boolean` for bool, `__box_number` for number, native string for
+string) — the same already-correct route `a.push(true)` uses. No `boxToAny` call
+needed. Scoped strictly to `any[]` literals → number[]/string[]/struct[]
+byte-identical.
+
+**Validated**: `tests/issue-2106-any-array-element-tag.test.ts` (7/7 host); tsc
+clean. **Standalone/WASI unchanged**: `typeof [true][0]` was already `null` and
+`"" + [true][0]` already trapped on the base (the standalone `any`-boolean tag
+gap is pre-existing, owned by S1/S3) — neither fixed nor worsened here.
+
+Remaining slices S1 (standalone `$undefined`), S2 (sNaN carve-out), S3
+(number|undefined→externref), S4 (flag-gated collapse reversal) stay open under
+this issue.

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -260,3 +260,47 @@ carriers (S2 keeps the sentinel there).
   max-reasoning context.
 - `codePointAt(oob) ?? rhs` is already done (#2004, `logical-ops.ts:208`) —
   do NOT re-represent it. Optional-chain sites are #2051 — do NOT touch.
+
+## S3 producer map (sdev7, 2026-06-16) — exact sites, verified on main @ 24e520df8
+
+Confirmed the S3 host repros still fail and pinned the producers, so S3 is
+turnkey for its own focused (measure-first) PR:
+
+**Repros (host, all reproduce):**
+- `[1,2,3].find(x=>x>5) === undefined` → `0` (want `1`)
+- `typeof [1].find(x=>x>5)` → `"number"` (want `"undefined"`)
+- `function f(x?:number){return x ?? -1} f()` → `NaN` (want `-1`)
+- `function f(x?:number){return typeof x} f()` → `"number"` (want `"undefined"`)
+- `function f(x?:number){return x === undefined} f()` → `0` (want `1`)
+- Working (keep green): `f(5)`→5, `f(0) ?? -1`→0 (0 is not nullish), `find` HIT
+  cases, the generic externref-array `find` (already `ref.null.extern`).
+
+**Producer 1 — typed/numeric `find`/`findLast` fast-path.** The GENERIC array
+`find` (`array-methods.ts:856`) already returns `externref` with a
+`ref.null.extern` miss — but the numeric/typed fast-path returns an **f64 NaN
+sentinel**: `array-methods.ts:6522-6529` (`find`) and `:6712-6719` (`findLast`):
+`findResType = ctx.fast ? elemType : { kind: "f64" }`, miss = `f64.const 0;
+f64.const 0; f64.div` (NaN). For `number[]` the result local is f64
+(WAT-confirmed: `$__arr_find_res_9 f64`), so the miss is unobservable to
+`===`/`typeof`/`??`. Widen the **non-fast** branch's miss to `emitUndefined`
+(externref) and the result type to externref; the `ctx.fast` i32 branch is a
+separate (native-int) story — scope carefully.
+
+**Producer 2 — absent optional numeric parameter.** `f(x?: number)` called with
+no arg materializes `x` as an f64 NaN sentinel (param prologue /
+`destructuring-params.ts` default-fill), so `x ?? -1`→NaN, `typeof x`→"number",
+`x === undefined`→false. Widen the absent-optional-numeric-param carrier to
+externref + host `undefined` (standalone needs S1's `$undefined`).
+
+**Mechanism (per #2142 rule):** both producers emit `emitUndefined` (externref)
+for the absent case instead of `f64.const NaN`; result ValType becomes externref
+so the existing externref-aware `===`/`??`/`typeof` observers light up with zero
+new observer code (#2142 fact 1). Reuse #2051's widening helper
+(`variables.ts` `isNullablePrimitiveType`).
+
+**RISK / measure-first (why this is its own PR):** changing `find`/optional-param
+result type f64→externref means any **arithmetic** on the result needs an unbox
+(`arr.find(...) + 1`, `f() * 2`). Must measure the test262 delta before
+default-on; gate carefully and check the arithmetic-on-result paths. Standalone
+correctness depends on S1 (`$undefined` ≠ `null`). Recommend: land S1 first (or
+concurrently), then S3 with a CI-measured blast radius.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -2931,6 +2931,33 @@ export function compileArrayLiteral(
       }
     }
   }
+  // (#2106 S0) `any[]` element tag-recovery. When the contextual element type is
+  // `any`, the first-element heuristic above can pick a bare primitive ValType
+  // (e.g. `[true]` → i32, because `boolean` lowers to i32 and the contextual-type
+  // adoption at the ref branch never fires for a non-ref first element). The vec
+  // is then built as `__vec_i32` and later coerced to the `any[]` externref vec
+  // by Wasm KIND (`f64.convert_i32_s; __box_number`), so a boolean read back as
+  // `a[0]` reports `typeof === "number"` / `"" + a[0] === "1"` — the JS tag is
+  // lost. Booleans, mixed-primitive heterogeneity, and any non-string ref all
+  // need the per-element JS-type-aware boxing that `compileExpression(el,
+  // externref)` already performs (`__box_boolean` for bool, `__box_number` for
+  // number, native-string for string — the same path the `a.push(true)` route
+  // uses, which is already correct). Widen the element type to externref so each
+  // element is boxed by its own static type at construction, not by Wasm kind
+  // after the fact. Scoped strictly to `any` contextual elements: number[] /
+  // string[] / struct[] literals are untouched (byte-identical).
+  if (!hasSpread && (elemWasm.kind === "i32" || elemWasm.kind === "f64")) {
+    const ctxArrType = ctx.checker.getContextualType(expr);
+    if (ctxArrType) {
+      const ctxArrSym = (ctxArrType as ts.TypeReference).symbol ?? ctxArrType.symbol;
+      if (ctxArrSym?.name === "Array" || ctxArrSym?.name === "ReadonlyArray") {
+        const ctxElemType = ctx.checker.getTypeArguments(ctxArrType as ts.TypeReference)[0];
+        if (ctxElemType && (ctxElemType.flags & ts.TypeFlags.Any) !== 0) {
+          elemWasm = { kind: "externref" };
+        }
+      }
+    }
+  }
   elemKind = elemWasm.kind === "ref" || elemWasm.kind === "ref_null" ? `ref_${elemWasm.typeIdx}` : elemWasm.kind;
   const vecTypeIdx = getOrRegisterVecType(ctx, elemKind, elemWasm);
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);

--- a/tests/issue-2106-any-array-element-tag.test.ts
+++ b/tests/issue-2106-any-array-element-tag.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2106 value-rep P3 — slice S0: `any[]` array-element tag recovery (host mode).
+ *
+ * A boolean (or any non-string primitive) stored in an `any[]` ARRAY LITERAL lost
+ * its JS type tag on read-back: `[true]` built a `__vec_i32`, which was later
+ * coerced to the `any[]` externref vec by Wasm KIND (`f64.convert_i32_s;
+ * __box_number`) — so a boolean came back boxed as a JS *number*.
+ *   - `typeof [true][0]` → "number"  (should be "boolean")
+ *   - `"" + [true][0]`   → "1"       (should be "true")
+ * The VALUE survived (`[true][0] === true`); only the TAG was wrong.
+ *
+ * Fix (literals.ts, compileArrayLiteral): when the array literal's contextual
+ * element type is `any`, widen the element ValType to externref so each element
+ * is boxed by its own static type at construction (`compileExpression(el,
+ * externref)` already routes booleans → `__box_boolean`, numbers → `__box_number`,
+ * strings → native), instead of after-the-fact Wasm-kind coercion. This is the
+ * same path the (already-correct) `a.push(true)` route uses.
+ *
+ * Scoped strictly to `any[]` literals — number[]/string[]/struct[] are untouched.
+ * Standalone/WASI `any`-boolean tag recovery is a separate, pre-existing gap
+ * (S1/S3 of this issue), not covered here.
+ */
+
+async function runStr(src: string): Promise<string | number | undefined> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.binary).toBeTruthy();
+  const { instance } = await WebAssembly.instantiate(r.binary, (r.importObject ?? {}) as WebAssembly.Imports);
+  return (instance.exports.test as () => string | number | undefined)?.();
+}
+
+describe("#2106 S0 — any[] array-element tag recovery (host)", () => {
+  it("typeof of a boolean element is 'boolean', not 'number'", async () => {
+    expect(await runStr(`export function test(): string { const a: any[] = [true]; return typeof a[0]; }`)).toBe(
+      "boolean",
+    );
+  });
+
+  it("stringifying a boolean element gives 'true'/'false', not '1'/'0'", async () => {
+    expect(await runStr(`export function test(): string { const a: any[] = [true]; return "" + a[0]; }`)).toBe("true");
+    expect(await runStr(`export function test(): string { const a: any[] = [false]; return "" + a[0]; }`)).toBe(
+      "false",
+    );
+  });
+
+  it("the boolean VALUE is preserved (=== true)", async () => {
+    expect(await runStr(`export function test(): boolean { const a: any[] = [true]; return a[0] === true; }`)).toBe(1);
+  });
+
+  it("string and number elements keep their tags (controls)", async () => {
+    expect(await runStr(`export function test(): string { const a: any[] = ["x"]; return typeof a[0]; }`)).toBe(
+      "string",
+    );
+    expect(await runStr(`export function test(): string { const a: any[] = [42]; return typeof a[0]; }`)).toBe(
+      "number",
+    );
+  });
+
+  it("each element of a heterogeneous any[] literal is tagged by its own type", async () => {
+    const src = (i: number) =>
+      `export function test(): string { const a: any[] = [true, 1, "x"]; return typeof a[${i}]; }`;
+    expect(await runStr(src(0))).toBe("boolean");
+    expect(await runStr(src(1))).toBe("number");
+    expect(await runStr(src(2))).toBe("string");
+  });
+
+  it("numeric elements still round-trip their value through the any[] vec", async () => {
+    expect(await runStr(`export function test(): number { const a: any[] = [42]; return a[0]; }`)).toBe(42);
+    expect(await runStr(`export function test(): number { const a: any[] = [1.5]; return a[0]; }`)).toBe(1.5);
+  });
+
+  it("non-any number[] literals are unaffected (no behavior change)", async () => {
+    expect(
+      await runStr(`export function test(): number { const a: number[] = [1, 2, 3]; return a[0] + a[1] + a[2]; }`),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## #2106 value-rep P3 — slice S0: `any[]` array-element tag recovery

First (independently-mergeable) slice of P3. A boolean — or any non-string primitive — stored in an **`any[]` array literal** lost its JS type tag on read-back:

- `typeof [true][0]` → `"number"` (should be `"boolean"`)
- `"" + [true][0]` → `"1"` (should be `"true"`)

The *value* survived (`[true][0] === true`); only the **tag** was wrong.

### Root cause (WAT-confirmed)
`[true]` builds a `__vec_i32` (booleans lower to i32, and the `any[]` contextual element type is dropped at the ref-only adoption guard `literals.ts:2886`). The i32-vec → `any[]` externref-vec coercion then boxes each element by **Wasm kind** (`f64.convert_i32_s; __box_number`) — so a boolean comes back boxed as a JS *number*. `boolean[]` and `number[]` share `__vec_i32` (vecs are named by Wasm kind), so the tag is unrecoverable at the coercion site.

### Fix
`src/codegen/literals.ts`, `compileArrayLiteral`: when `!hasSpread && elemWasm.kind ∈ {i32,f64}` AND the literal's `getContextualType` is `Array<any>`/`ReadonlyArray<any>` (type-arg flags carry `ts.TypeFlags.Any`), widen `elemWasm` to **externref**. Each element is then boxed by its own static type via the existing `compileExpression(el, externref)` path — `__box_boolean` for bool, `__box_number` for number, native string for string. Same already-correct route `a.push(true)` uses; **no new `boxToAny` call**, so S0 is independent of #2104/#1503. Scoped strictly to `any[]` literals → `number[]`/`string[]`/`struct[]` byte-identical.

### Validation
- `tests/issue-2106-any-array-element-tag.test.ts` — 7/7 host: boolean typeof/stringify, value preserved, string/number control tags, **heterogeneous** `[true,1,"x"]` (each element tagged by its own type), numeric round-trip, non-any `number[]` unchanged.
- `tsc` clean; `check:any-box-sites` OK (no new box site); the 22 `array-methods.test.ts` failures are the pre-existing `{env:{}}` empty-importObject infra failures (identical count on main).

### Out of scope (pre-existing, owned by later slices)
**Standalone/WASI** `any`-boolean tag recovery is unchanged: `typeof [true][0]` already returned `null` and `"" + [true][0]` already trapped on the base. That standalone gap is S1/S3 territory; neither fixed nor worsened here.

S1–S4 of #2106 remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)