### PR TITLE
fix(#2163): don't leak __symbol_register_desc on standalone Symbol()

### DIFF
--- a/plan/issues/2163-standalone-symbol-residual.md
+++ b/plan/issues/2163-standalone-symbol-residual.md
@@ -1,10 +1,10 @@
 ---
 id: 2163
 title: "Standalone Symbol conformance residual (~240 tests)"
-status: ready
+status: in-progress
 sprint: 62
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -40,3 +40,36 @@ standalone**, attributed to Symbol semantics — currently **untracked**.
 
 Parent (done): #483. Part of sprint-62 standalone catch-up (rank 9 by gap
 impact).
+
+---
+
+## Slice 1 (2026-06-16) — `Symbol()` creation no longer leaks a host import
+
+**Landed.** Triage showed the dominant Symbol standalone failure was the
+**foundational one**: every `Symbol()` / `Symbol(desc)` call failed to
+instantiate standalone. `compileSymbolCall` (`src/codegen/literals.ts`) lowers a
+symbol to a unique i32 counter id, and (#1467) also called
+`env::__symbol_register_desc` to register the description with the JS host —
+**unconditionally**, so standalone/wasi modules carried an unsatisfiable import
+and `Symbol()` was a hard runtime failure.
+
+**Fix:** the description registration is a pure JS-host fast path (the symbol
+value is just the i32 id, which is all `typeof s === "symbol"` and symbol
+identity/distinctness need). Gate the host registration on JS-host mode; in
+`noJsHost` mode only evaluate the description argument for side effects. Host
+mode unchanged (the 2 pre-existing `symbol-basic` well-known-constant failures
+on main are orthogonal). Test: `tests/issue-2163.test.ts` (creation, typeof,
+distinctness, identity, side-effecting desc arg, well-known iterator — 6/6).
+
+### Remaining slices (issue stays open) — triage 2026-06-16
+
+- **`.description` standalone** leaks `__symbol_description` + `__box_symbol`.
+  Standalone the symbol is a bare i32 id with no stored description — supporting
+  `.description` needs **native description storage** (a Wasm-native id→string
+  map paralleling the host registry). Medium slice.
+- **`Symbol.for` / `Symbol.keyFor` registry** leaks `__symbol_for` /
+  `__symbol_keyFor` — needs a native id↔key registry (same native-storage
+  infra as `.description`). Medium slice; pairs naturally with description
+  storage.
+- **`Symbol#toString()`** hits a late-import index-shift CE (#2043 class) —
+  separate codegen bug, independent of the above.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1209,7 +1209,19 @@ export function compileSymbolCall(ctx: CodegenContext, fctx: FunctionContext, ar
   // Standalone-mode fallback: if the host import isn't available, the symbol
   // is still constructed (with the legacy `wasm_<id>` description); only the
   // `.description` accessor in JS-host mode benefits.
-  const regIdx = ensureLateImport(ctx, "__symbol_register_desc", [{ kind: "i32" }, { kind: "externref" }], []);
+  //
+  // (#2163) In no-JS-host mode (`--target standalone` / `--target wasi`) there
+  // is no host to register the description with, so emitting the
+  // `env::__symbol_register_desc` import leaves it unsatisfiable and the module
+  // fails to instantiate — making EVERY `Symbol()` call a runtime failure
+  // standalone. The symbol value itself is just the i32 counter id (which is
+  // all `typeof s === "symbol"` and symbol identity/distinctness need), so the
+  // host registration is a pure JS-host fast path. Skip it standalone and only
+  // evaluate the description argument for side effects.
+  const noJsHost = ctx.standalone === true || ctx.wasi === true;
+  const regIdx = noJsHost
+    ? undefined
+    : ensureLateImport(ctx, "__symbol_register_desc", [{ kind: "i32" }, { kind: "externref" }], []);
   if (regIdx !== undefined) {
     fctx.body.push({ op: "global.get", index: counterIdx });
     if (args.length > 0) {

--- a/tests/issue-2163.test.ts
+++ b/tests/issue-2163.test.ts
@@ -1,0 +1,83 @@
+// #2163 — standalone Symbol() creation leaked a host import.
+//
+// `Symbol()` / `Symbol(desc)` lowers to a unique i32 counter id, and (#1467) it
+// also called `env::__symbol_register_desc` to register the description with the
+// JS host so a later `__box_symbol(id)` could reconstruct `Symbol(desc)`. That
+// host call was emitted UNCONDITIONALLY, so under `--target standalone` /
+// `--target wasi` the module carried an unsatisfiable `env::__symbol_register_desc`
+// import and failed to instantiate — making EVERY `Symbol()` call a runtime
+// failure standalone (the foundational slice of the Symbol standalone gap).
+//
+// Fix (src/codegen/literals.ts compileSymbolCall): the description registration
+// is a pure JS-host fast path — the symbol value itself is just the i32 id,
+// which is all `typeof s === "symbol"` and symbol identity/distinctness need.
+// Gate the host registration on JS-host mode; standalone only evaluates the
+// description argument for side effects.
+//
+// (Out of this slice: `.description`, `Symbol.for`/`keyFor` registry, and
+// `Symbol#toString` still need native description storage — separate slices.)
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No host-import leak for the Symbol-creation path.
+  const leaked = (r.imports ?? []).filter((i) => /__symbol_register_desc|__box_symbol/.test(i.name));
+  expect(
+    leaked.map((i) => i.name),
+    "no symbol host-import leak",
+  ).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#2163 standalone Symbol() creation (no host-import leak)", () => {
+  it("Symbol() constructs and typeof is 'symbol'", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const s = Symbol(); return typeof s === "symbol" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Symbol(desc) constructs (description arg evaluated for side effects)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const s = Symbol("hi"); return typeof s === "symbol" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("two Symbols are distinct values", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a = Symbol("z"); const b = Symbol("z"); return a === b ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("a Symbol equals itself", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a = Symbol("z"); const b = a; return a === b ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Symbol() with a side-effecting description arg still evaluates it", async () => {
+    // The description expression must still run (spec: ToString(description)).
+    expect(
+      await runStandalone(
+        `export function run(): number { let n = 0; const f = (): string => { n = 7; return "d"; }; const s = Symbol(f()); return typeof s === "symbol" ? n : -1; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("well-known Symbol.iterator is a symbol", async () => {
+    expect(
+      await runStandalone(`export function run(): number { return typeof Symbol.iterator === "symbol" ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

First standalone slice of #2163 (Symbol residual, 240-test gap). Triage found the **foundational** failure: every `Symbol()` / `Symbol(desc)` call failed to instantiate standalone.

`compileSymbolCall` (`src/codegen/literals.ts`) lowers a symbol to a unique i32 counter id, and (#1467) also called `env::__symbol_register_desc` to register the description with the JS host — **unconditionally**. Under `--target standalone`/`--target wasi` that left an unsatisfiable `env::__symbol_register_desc` import, so `Symbol()` was a hard runtime failure (the root of the standalone Symbol gap).

## Fix

The description registration is a pure JS-host fast path — the symbol value itself is just the i32 id, which is all `typeof s === "symbol"` and symbol identity/distinctness need. Gate the host registration on JS-host mode; standalone only evaluates the description argument for side effects. **Host mode unchanged** (the 2 pre-existing `symbol-basic` well-known-constant failures on main are orthogonal — verified they fail identically on clean main).

## Test plan

`tests/issue-2163.test.ts` (standalone, empty import object, asserts no `__symbol_register_desc`/`__box_symbol` leak): creation, `typeof === 'symbol'`, distinctness, identity, side-effecting description arg, well-known `Symbol.iterator` — **6/6 pass**.

```
npx vitest run tests/issue-2163.test.ts   # 6 passed
```

#2163 stays open (`in-progress`) — `.description` + `Symbol.for`/`keyFor` registry (need native id↔string/key storage) and `Symbol#toString` (late-import CE) are the next slices, triaged in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)