### PR TITLE
fix(#2106): find/findLast miss observable through ?? (value-rep P3 slice S3.1)

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -1,10 +1,11 @@
 ---
 id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev7
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-15
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -259,3 +260,42 @@ carriers (S2 keeps the sentinel there).
   max-reasoning context.
 - `codePointAt(oob) ?? rhs` is already done (#2004, `logical-ops.ts:208`) —
   do NOT re-represent it. Optional-chain sites are #2051 — do NOT touch.
+
+## S3 increment 1 — find/findLast miss observability through `??` (sdev7, 2026-06-16) — SHIPPED
+
+First bounded increment of S3, zero arithmetic blast radius (keeps the f64
+result type). Reproduced + fixed `[1,2,3].find(x=>x>5) ?? -1` → `NaN` (should be
+`-1`): a numeric-array `find`/`findLast` miss is lowered to f64, and `??` treats
+any f64 as never-nullish.
+
+**Fix** (two spots, composing with #2104's `value-tags.ts`):
+1. `array-methods.ts` (find `:6526`, findLast `:6717`): the f64 miss now uses
+   `pushUndefF64` (the DISTINGUISHED `UNDEF_F64` sentinel `0x7FF00000DEADC0DE`)
+   instead of a plain `0/0` NaN — so a genuine NaN ELEMENT
+   (`[NaN].find(Number.isNaN)` is a real hit, never nullish) stays distinct from
+   a miss.
+2. `expressions/logical-ops.ts` `compileNullishCoalescing`: added
+   `isFindFamilyCall` (mirrors the existing `isCodePointAtCall` #2004 case); for
+   an f64 find/findLast LHS, branch on `emitIsUndefF64` (the exact sentinel, NOT
+   plain NaN) so `find(miss) ?? rhs` yields `rhs`.
+
+**Scope / honest limits:**
+- Covers the **inline** `find(...) ?? rhs` form (syntactic recognition, like
+  #2004). The **bound-variable** form (`const v = find(...); v ?? rhs`) is NOT
+  covered — the `??` LHS is an identifier, not the call. Unchanged from before
+  (still f64-never-nullish → NaN); needs the f64→externref result-type widening
+  (S3 increment 2).
+- `=== undefined` / `typeof` on a numeric find result still need the externref
+  widening too (an f64 can never be `=== undefined`). Increment 2.
+- No regression: the sentinel is still a NaN bit pattern, so `Number.isNaN`,
+  truthiness, and arithmetic propagation on a miss are byte-identical to the old
+  plain-NaN behavior; only inline `??` improved.
+
+**Validated**: `tests/issue-2106-find-nullish.test.ts` (7/7); `tsc`,
+`ir-nullish-coalesce` (4/4), `issue-1136-findlast` (6/6), `check:any-box-sites`
+all clean.
+
+**S3 increment 2 (next)**: f64→externref widening for find/optional-param so the
+bound-variable `??`, `=== undefined`, and `typeof` cases light up — measure-first
+(arithmetic-on-result needs unbox; test262 blast radius). Optional-param producer
+also still open (absent `x?: number` → f64 sentinel; `f() ?? -1` → NaN).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -14,6 +14,7 @@ import { allocLocal, getLocalType } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
+import { pushUndefF64 } from "./value-tags.js";
 import { compileStringLiteral } from "./shared.js";
 import { getArrTypeIdxFromVec, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
@@ -6518,15 +6519,18 @@ function compileArrayFind(
     "truthy",
   );
 
-  // Result local -- NaN (not found) or element value
+  // Result local -- undefined-sentinel (not found) or element value.
+  // (#2106 S3) The miss case is a JS `undefined`. For the f64 carrier, use the
+  // DISTINGUISHED UNDEF_F64 sentinel (0x7FF00000DEADC0DE) rather than a plain
+  // `0/0` NaN, so observers (`?? rhs`) can tell a genuine NaN ELEMENT
+  // (`[NaN].find(isNaN)` → a real NaN hit, not nullish) apart from a miss. Plain
+  // NaN would conflate the two.
   const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_find_res_${fctx.locals.length}`, findResType);
   if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
   } else {
-    fctx.body.push({ op: "f64.const", value: 0 });
-    fctx.body.push({ op: "f64.const", value: 0 });
-    fctx.body.push({ op: "f64.div" }); // NaN
+    pushUndefF64(fctx.body);
   }
   fctx.body.push({ op: "local.set", index: findResTmp });
 
@@ -6709,14 +6713,13 @@ function compileArrayFindLast(
     "truthy",
   );
 
+  // (#2106 S3) Miss → distinguished UNDEF_F64 sentinel (see find above).
   const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_findLast_res_${fctx.locals.length}`, findResType);
   if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
   } else {
-    fctx.body.push({ op: "f64.const", value: 0 });
-    fctx.body.push({ op: "f64.const", value: 0 });
-    fctx.body.push({ op: "f64.div" }); // NaN (undefined sentinel)
+    pushUndefF64(fctx.body);
   }
   fctx.body.push({ op: "local.set", index: findResTmp });
 

--- a/src/codegen/expressions/logical-ops.ts
+++ b/src/codegen/expressions/logical-ops.ts
@@ -12,6 +12,7 @@ import { ensureI32Condition } from "../index.js";
 import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
 import { defaultValueInstrs } from "../type-coercion.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+import { emitIsUndefF64 } from "../value-tags.js";
 
 export function compileLogicalAnd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): ValType {
   // JS semantics: a && b → if a is falsy, return a; else return b
@@ -190,6 +191,27 @@ function isCodePointAtCall(expr: ts.Expression): boolean {
   );
 }
 
+/**
+ * #2106 S3 — `Array.prototype.find` / `findLast` return `undefined` on a miss
+ * (§23.1.3.8). Over a numeric array js2wasm lowers the result to f64, encoding
+ * the miss as the DISTINGUISHED `UNDEF_F64` sentinel (0x7FF00000DEADC0DE; see
+ * array-methods.ts). For `arr.find(...) ?? rhs`, recognise the LHS and branch on
+ * that exact sentinel via `emitIsUndefF64` — NOT on plain NaN, so a genuine NaN
+ * element (`[NaN].find(Number.isNaN)` is a real hit, never nullish) is preserved.
+ * Without this, an f64 LHS is treated as never-nullish and `?? rhs` never fires.
+ */
+function isFindFamilyCall(expr: ts.Expression): boolean {
+  let inner: ts.Expression = expr;
+  while (ts.isParenthesizedExpression(inner) || ts.isAsExpression(inner) || ts.isNonNullExpression(inner)) {
+    inner = inner.expression;
+  }
+  return (
+    ts.isCallExpression(inner) &&
+    ts.isPropertyAccessExpression(inner.expression) &&
+    (inner.expression.name.text === "find" || inner.expression.name.text === "findLast")
+  );
+}
+
 export function compileNullishCoalescing(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -212,6 +234,15 @@ export function compileNullishCoalescing(
     // isNaN(lhs): a value is NaN iff it is not equal to itself.
     fctx.body.push({ op: "local.get", index: tmp });
     fctx.body.push({ op: "f64.ne" });
+    return finishNullishBranch(ctx, fctx, expr, resultKind, tmp);
+  }
+
+  // #2106 S3 — `arr.find(...) ?? rhs` / `findLast`. The f64 miss carries the
+  // distinguished UNDEF_F64 sentinel; branch on it (not plain NaN) so a genuine
+  // NaN element survives `??` while a true miss yields `rhs`.
+  if (resultKind.kind === "f64" && isFindFamilyCall(expr.left)) {
+    fctx.body.push({ op: "local.get", index: tmp });
+    emitIsUndefF64(fctx.body);
     return finishNullishBranch(ctx, fctx, expr, resultKind, tmp);
   }
 

--- a/tests/issue-2106-find-nullish.test.ts
+++ b/tests/issue-2106-find-nullish.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2106 value-rep P3 — slice S3 (first increment): `Array.prototype.find` /
+ * `findLast` miss observability through `??`.
+ *
+ * `find`/`findLast` return `undefined` on a miss (§23.1.3.8). Over a numeric
+ * array js2wasm lowers the result to f64; previously the miss was a plain `0/0`
+ * NaN, which `??` treats as never-nullish — so `[1,2,3].find(x=>x>5) ?? -1`
+ * wrongly yielded `NaN` instead of `-1`.
+ *
+ * Fix: the miss now carries the DISTINGUISHED `UNDEF_F64` sentinel
+ * (0x7FF00000DEADC0DE), and `compileNullishCoalescing` recognises a
+ * `find`/`findLast` f64 LHS and branches on that exact sentinel (via
+ * `emitIsUndefF64`) rather than plain NaN. This disambiguates a true miss from a
+ * genuine NaN ELEMENT (`[NaN].find(Number.isNaN)` is a real hit, never nullish).
+ *
+ * Scope: the `??` observability only. `=== undefined` / `typeof` on a numeric
+ * find result still need the f64→externref widening (a later S3 increment) — an
+ * f64 can never be `=== undefined`.
+ */
+
+async function runNum(src: string): Promise<number | undefined> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.binary).toBeTruthy();
+  const { instance } = await WebAssembly.instantiate(r.binary, (r.importObject ?? {}) as WebAssembly.Imports);
+  return (instance.exports.test as () => number | undefined)?.();
+}
+
+async function runBool(src: string): Promise<number | undefined> {
+  return runNum(src);
+}
+
+describe("#2106 S3 — find/findLast miss observability through ??", () => {
+  it("find miss ?? rhs yields rhs (not NaN)", async () => {
+    expect(await runNum(`export function test(): number { return [1,2,3].find(x=>x>5) ?? -1; }`)).toBe(-1);
+  });
+
+  it("find hit ?? rhs yields the hit", async () => {
+    expect(await runNum(`export function test(): number { return [1,2,3].find(x=>x>1) ?? -1; }`)).toBe(2);
+  });
+
+  it("findLast miss ?? rhs yields rhs", async () => {
+    expect(await runNum(`export function test(): number { return [1,2,3].findLast(x=>x>5) ?? -1; }`)).toBe(-1);
+  });
+
+  it("findLast hit ?? rhs yields the last hit", async () => {
+    expect(await runNum(`export function test(): number { return [1,2,3].findLast(x=>x<3) ?? -1; }`)).toBe(2);
+  });
+
+  it("a genuine NaN element is a HIT, not a miss (NaN is not nullish)", async () => {
+    // [NaN].find(isNaN) returns the real NaN; `?? -1` must keep NaN, not coalesce.
+    expect(
+      await runBool(`export function test(): boolean { return Number.isNaN([NaN].find(x=>Number.isNaN(x)) ?? 0); }`),
+    ).toBe(1);
+  });
+
+  it("find hit of 0 is not coalesced (0 is not nullish)", async () => {
+    expect(await runNum(`export function test(): number { return [0,1,2].find(x=>x===0) ?? -1; }`)).toBe(0);
+  });
+
+  it("arithmetic on an inline coalesced miss uses the default", async () => {
+    // The `??` recognizer is syntactic (like the #2004 codePointAt case): it fires
+    // for an inline `find(...) ?? rhs`. Binding the result to a local first
+    // (`const v = find(...); v ?? rhs`) is NOT yet covered — that needs the
+    // f64→externref result-type widening, a later S3 increment.
+    expect(await runNum(`export function test(): number { return ([1,2,3].find(x=>x>9) ?? 0) + 5; }`)).toBe(5);
+  });
+});


### PR DESCRIPTION
## #2106 value-rep P3 — slice S3.1: `find`/`findLast` miss observable through `??`

First bounded increment of S3 (zero arithmetic blast radius — keeps the f64 result type).

`[1,2,3].find(x=>x>5) ?? -1` returned **`NaN`** instead of `-1`: a numeric-array `find`/`findLast` miss is lowered to f64, and `??` treats any f64 as never-nullish, so `?? rhs` never fired.

### Fix (two spots, composing with #2104's `value-tags.ts`)
1. **`array-methods.ts`** (find, findLast): the f64 miss now carries the **distinguished `UNDEF_F64` sentinel** (`0x7FF00000DEADC0DE` via `pushUndefF64`) instead of a plain `0/0` NaN — so a genuine NaN **element** (`[NaN].find(Number.isNaN)` is a real hit, never nullish) stays distinct from a miss.
2. **`expressions/logical-ops.ts`** `compileNullishCoalescing`: added `isFindFamilyCall` (mirrors the existing #2004 `isCodePointAtCall` case); for an f64 find/findLast LHS, branch on `emitIsUndefF64` (the exact sentinel, NOT plain NaN) so `find(miss) ?? rhs` yields `rhs`.

### Scope / honest limits
- Covers the **inline** `find(...) ?? rhs` form (syntactic recognition, exactly like the merged #2004 codePointAt approach).
- The **bound-variable** form (`const v = find(...); v ?? rhs`), `=== undefined`, and `typeof` are **not** covered — an f64 can never be `=== undefined`; those need the f64→externref result-type widening (**S3 increment 2**, measure-first). Bound-variable `??` is unchanged from before (still NaN), so no regression.
- **No regression**: the sentinel is still a NaN bit pattern, so `Number.isNaN`, truthiness, and arithmetic propagation on a miss are byte-identical to the old plain-NaN behavior; only inline `??` improved.

### Validation
- `tests/issue-2106-find-nullish.test.ts` — 7/7 (find/findLast miss→rhs, hit, genuine-NaN-element-is-a-hit, `0` not coalesced, inline arithmetic).
- `tsc`, `ir-nullish-coalesce` (4/4), `issue-1136-findlast` (6/6), `check:any-box-sites` all clean.

S1/S2/S4 + S3 increment 2 (optional-param + externref widening) remain open under #2106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)