### PR TITLE
fix(#2164): don't leak __date_now on standalone Date.now()/new Date()

### DIFF
--- a/plan/issues/2164-standalone-date-residual.md
+++ b/plan/issues/2164-standalone-date-residual.md
@@ -1,10 +1,10 @@
 ---
 id: 2164
 title: "Standalone Date conformance residual (~234 tests)"
-status: ready
+status: in-progress
 sprint: 62
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -38,3 +38,32 @@ tests pass in host mode but fail standalone**, attributed to Date semantics
 
 Parent (done): #1343. Part of sprint-62 standalone catch-up (rank 10 by gap
 impact).
+
+---
+
+## Slice 1 (2026-06-16) — `Date.now()` / `new Date()` no-arg host-import leak
+
+**Landed.** Triage showed most Date functionality already works standalone
+(explicit-timestamp ctor, getTime, UTC components, setters, toISOString,
+multi-arg ctor, NaN, Date.UTC). The dominant *foundational* failure: `Date.now()`
+and `new Date()` (no args) emitted the `env::__date_now` host import
+**unconditionally** in non-WASI mode — under `--target standalone` (no JS host,
+no WASI clock) that import is unsatisfiable, so every module calling `Date.now()`
+or `new Date()` (commonly in test setup) failed to instantiate, taking unrelated
+Date assertions down with it.
+
+**Fix** (`expressions/calls.ts` Date.now/performance.now; `expressions/new-super.ts`
+`new Date()`): pure standalone has no wall-clock source, so emit the Unix epoch
+(`f64.const 0` / `i64.const 0`) directly — deterministic, no import leak, module
+instantiates. WASI still uses its clock; host mode unchanged (gated on
+`ctx.standalone === true`). Test: `tests/issue-2164.test.ts` — Date.now()/new
+Date()/performance.now() instantiate, mixed setup+explicit-timestamp works,
+explicit dates unaffected (5/5). Host date-basic equiv unchanged (12/12).
+
+### Remaining slices (issue stays open)
+
+- **`Date.parse(str)`** returns 0 standalone (`Date.parse("2000-01-01")` → 0)
+  — the date-string parser isn't wired standalone. Medium slice.
+- Real current-time semantics standalone are intentionally NOT provided (no
+  clock source); only the instantiate-blocking leak is fixed here. Tests
+  asserting a non-zero *current* time stay failing by design.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6091,6 +6091,20 @@ function compileCallExpression(
           fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__wasi_date_now")! } as Instr);
           return { kind: "f64" };
         }
+        // (#2164) Pure standalone (--target standalone, no JS host AND no WASI
+        // clock) has no wall-clock source, so the env::__date_now host import is
+        // unsatisfiable — every module that calls Date.now() (or new Date() with
+        // no args) failed to instantiate standalone, breaking unrelated Date
+        // tests that only touch Date.now() in setup. Emit the Unix epoch (0)
+        // directly: deterministic, no import leak, module instantiates. Tests
+        // that construct explicit timestamps (the bulk of the gap) then work;
+        // only tests asserting a *real* current time (which standalone WasmGC
+        // cannot provide) stay failing — and those need a clock source, not a
+        // host import.
+        if (ctx.standalone === true) {
+          fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+          return { kind: "f64" };
+        }
         const dateNowIdx = ensureLateImport(ctx, "__date_now", [], [{ kind: "f64" }]);
         if (dateNowIdx !== undefined) {
           flushLateImportShifts(ctx, fctx);

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2158,6 +2158,16 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         fctx.body.push({ op: "struct.new", typeIdx: dateTypeIdx } as Instr);
         return { kind: "ref", typeIdx: dateTypeIdx };
       }
+      // (#2164) Pure standalone has no wall clock — emit the Unix epoch (0)
+      // directly instead of leaking the unsatisfiable env::__date_now host
+      // import (which made `new Date()` a hard instantiate failure standalone,
+      // breaking unrelated Date tests). See the matching Date.now() fallback in
+      // expressions/calls.ts.
+      if (ctx.standalone === true) {
+        fctx.body.push({ op: "i64.const", value: 0n });
+        fctx.body.push({ op: "struct.new", typeIdx: dateTypeIdx } as Instr);
+        return { kind: "ref", typeIdx: dateTypeIdx };
+      }
       const dateNowIdx = ensureLateImport(ctx, "__date_now", [], [{ kind: "f64" }]);
       if (dateNowIdx !== undefined) {
         flushLateImportShifts(ctx, fctx);

--- a/tests/issue-2164.test.ts
+++ b/tests/issue-2164.test.ts
@@ -1,0 +1,63 @@
+// #2164 — standalone Date.now() / new Date() leaked an unsatisfiable host import.
+//
+// `Date.now()` and `new Date()` (no args) read the current wall-clock time. In
+// JS-host mode that's the `env::__date_now` import; under `--target wasi` it's
+// the WASI clock (`__wasi_date_now`). But under `--target standalone` (no JS
+// host AND no WASI clock) the compiler still emitted the `env::__date_now`
+// import — leaving it unsatisfiable, so EVERY module that calls `Date.now()` or
+// `new Date()` failed to instantiate standalone. That broke unrelated Date
+// tests that only touch `Date.now()` in their setup (a large slice of the Date
+// standalone gap).
+//
+// Fix (expressions/calls.ts Date.now / performance.now, expressions/new-super.ts
+// `new Date()`): pure standalone has no wall-clock source, so emit the Unix epoch
+// (0) directly — deterministic, no import leak, module instantiates. Tests that
+// construct explicit timestamps (the bulk of the gap) then work; only tests
+// asserting a *real* current time stay failing (they need a clock, not an import).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No __date_now host-import leak.
+  const leaked = (r.imports ?? []).filter((i) => /__date_now/.test(i.name));
+  expect(
+    leaked.map((i) => i.name),
+    "no __date_now leak",
+  ).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#2164 standalone Date.now() / new Date() (no host-import leak)", () => {
+  it("Date.now() instantiates and returns the epoch (0)", async () => {
+    expect(await runStandalone(`export function run(): number { return Date.now() === 0 ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("new Date() (no args) instantiates with epoch time", async () => {
+    expect(
+      await runStandalone(`export function run(): number { const d = new Date(); return d.getTime() === 0 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("performance.now() instantiates standalone", async () => {
+    expect(await runStandalone(`export function run(): number { return performance.now() >= 0 ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("Date.now() in a module that also uses explicit timestamps", async () => {
+    // The previously-fatal pattern: Date.now() in setup alongside real date math.
+    expect(
+      await runStandalone(
+        `export function run(): number { const start = Date.now(); const d = new Date(5000); return d.getTime() - start; }`,
+      ),
+    ).toBe(5000);
+  });
+
+  it("explicit-timestamp Date construction is unaffected", async () => {
+    expect(
+      await runStandalone(`export function run(): number { const d = new Date(86400000); return d.getUTCFullYear(); }`),
+    ).toBe(1970);
+  });
+});


### PR DESCRIPTION
## Summary

First standalone slice of #2164 (Date residual, 234-test gap). Triage showed most Date functionality already works standalone (explicit-timestamp ctor, getTime, UTC components, setters, toISOString, multi-arg ctor, NaN, Date.UTC). The **foundational** failure: `Date.now()` and `new Date()` (no args) emitted `env::__date_now` **unconditionally** in non-WASI mode — under `--target standalone` (no JS host, no WASI clock) that import is unsatisfiable, so every module calling `Date.now()` or `new Date()` (commonly in test setup) failed to instantiate, taking unrelated Date assertions down with it.

## Fix

Pure standalone has no wall-clock source, so emit the Unix epoch (`f64.const 0` / `i64.const 0`) directly — deterministic, no import leak, module instantiates. WASI keeps its clock; **host mode unchanged** (gated on `ctx.standalone === true`). Covers `Date.now`/`performance.now` (`expressions/calls.ts`) and `new Date()` no-args (`expressions/new-super.ts`).

## Test plan

`tests/issue-2164.test.ts` (standalone, empty import object, asserts no `__date_now` leak): Date.now()/new Date()/performance.now() instantiate, mixed setup+explicit-timestamp works, explicit dates unaffected — **5/5**. Host `date-basic` equivalence unchanged — **12/12**.

```
npx vitest run tests/issue-2164.test.ts                    # 5 passed
npx vitest run tests/equivalence/date-basic.test.ts        # 12 passed
```

#2164 stays open (`in-progress`) — `Date.parse(str)` standalone (returns 0) is the next slice. Real current-time semantics standalone are intentionally not provided (no clock source); only the instantiate-blocking leak is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)