### PR TITLE
fix(#2155): --no-verify on claim-issue assignment-ref push (unblocks team claims)

### DIFF
--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -146,7 +146,11 @@ function commitAndPush(baseSha, id, content, message) {
     const commitArgs = ["commit-tree", tree, "-m", message];
     if (baseSha) commitArgs.push("-p", baseSha);
     const commit = git(commitArgs);
-    const push = gitTry(["push", REMOTE, `${commit}:refs/heads/${ASSIGN_REF}`]);
+    // --no-verify: the assignment ref only ever carries a single <id>.json (never
+    // labs/ content), and the pre-push integrity gate (pnpm install + typecheck +
+    // lint, ~120s+) makes every claim hang/exit 124. CLAUDE.md sanctions
+    // --no-verify for these non-main, no-CI claim pushes.
+    const push = gitTry(["push", "--no-verify", REMOTE, `${commit}:refs/heads/${ASSIGN_REF}`]);
     return push.ok;
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
The pre-push integrity gate (pnpm install + typecheck + lint, ~120s+) runs on every `git push`, so `claim-issue.mjs`'s assignment-ref push hangs/exits 124 — breaking the cross-developer upstream lock for **every** dev. Surfaced by a teammate during sprint 62 dispatch.

The assignment ref (`refs/heads/issue-assignments`) only ever carries a single `<id>.json` (never `labs/` content), so bypassing the hook is safe, and CLAUDE.md already sanctions `--no-verify` for these non-main, no-CI claim pushes.

Interim workaround in use by devs: manual `git push --no-verify upstream <commit>:refs/heads/issue-assignments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)