### PR TITLE
fix(#2105): boolean-brand rollout for Array.join/toString

### DIFF
--- a/plan/issues/2105-valuerep-p2-boolean-brand-rollout.md
+++ b/plan/issues/2105-valuerep-p2-boolean-brand-rollout.md
@@ -1,10 +1,12 @@
 ---
 id: 2105
 title: "value-rep P2: boolean brand rollout — ~20 producer + ~12 consumer sites onto {kind:'i32', boolean:true}"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/d2
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -46,3 +48,39 @@ lookups deleted.
 ## Dupe check
 
 Point fixes merged; the rollout phase is unfiled. New (analysis program).
+
+## Resolution (2026-06-16, d2)
+
+A producer/consumer audit against current main (after the value-rep P1
+landings #1503 / #2104) showed the brand rollout has largely happened: of
+10 representative boolean-producer → string-consumer probes (comparison via
+`any`, equality concat, `!x`, template literals, predicate-fn results,
+`Number.isInteger`, `Array.includes`, `typeof`, `startsWith`, …) **9 already
+render "true"/"false" correctly**. The one residual consumer gap was
+**`Array.prototype.join` / `Array.prototype.toString`**: a boolean array
+lowers to an i32 WasmGC element array, and the `{kind:"i32", boolean:true}`
+brand is structural-only — it does **not** survive into `arrDef.element`
+(arrays dedupe structurally). So the join element-stringify path rendered
+booleans numerically ("1"/"0").
+
+**Fix** (`src/codegen/array-methods.ts`): recover boolean-ness from the
+receiver's TS element type via a new `arrayElementIsBoolean(ctx, receiverExpr)`
+helper (`recvType.getNumberIndexType()` → `isBooleanType`). Both join paths
+honour it:
+- JS-host `compileArrayJoin` — select the "true"/"false" string-constant
+  global from the i32 element (externref form).
+- native-strings `compileArrayJoinNative` (standalone / WASI) — build the
+  native "true"/"false" string and `ref.cast` up to `$AnyString`.
+
+`toString` delegates to join (#1997), so it inherits the fix.
+
+## Test Results
+
+`tests/issue-2105.test.ts` — 8/8 pass (JS-host + standalone). Related
+families re-run green: #2016 + #2005 (17), join families #1997/#1998/#2074
+(37). tsc + biome lint clean.
+
+- boolean[] join → "true,false,true" (was "1,0,1")  ✓ JS-host + standalone
+- comparison-result booleans `[1<2, 2<1].join(",")` → "true,false"  ✓
+- default-separator join, Array.toString delegation  ✓
+- number[] / string[] join unchanged (no regression)  ✓

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -7,7 +7,7 @@
  * shared.ts (NOT expressions.ts) to avoid circular dependencies.
  */
 import { ts } from "../ts-api.js";
-import { isStringType } from "../checker/type-mapper.js";
+import { isBooleanType, isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, getLocalType } from "./context/locals.js";
@@ -32,6 +32,7 @@ import { ensureAnyHelpers, isAnyValue } from "./any-helpers.js";
 import {
   ensureNativeStringHelpers,
   nativeStringLiteralInstrs,
+  nativeStringType,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
@@ -204,6 +205,22 @@ function shouldReturnUndefinedCapableResult(
   if (parent && ts.isExpressionStatement(parent)) return false;
   if (expectedType && expectedType.kind !== "externref" && expectedType.kind !== "ref_extern") return false;
   return typeIncludesUndefined(ctx.checker.getTypeAtLocation(callExpr));
+}
+
+/**
+ * #2105 — value-rep P2 boolean-brand rollout for `Array.prototype.join` /
+ * `toString`. A boolean array lowers to an i32 WasmGC element array, but the
+ * `{ kind: "i32", boolean: true }` brand is structural-only and does not
+ * survive into `arrDef.element` (arrays dedupe by structure). So the join
+ * element-stringify path otherwise renders booleans numerically ("1"/"0").
+ * Recover the boolean-ness from the receiver's TS element type instead:
+ * `boolean[]`/`(true|false)[]` → number-index type is `boolean`.
+ */
+function arrayElementIsBoolean(ctx: CodegenContext, receiverExpr: ts.Expression): boolean {
+  const recvTsType = ctx.checker.getTypeAtLocation(receiverExpr);
+  if (!recvTsType) return false;
+  const elemTsType = recvTsType.getNumberIndexType();
+  return elemTsType ? isBooleanType(elemTsType) : false;
 }
 
 function arrayElementToExternrefInstrs(ctx: CodegenContext, fctx: FunctionContext, elemType: ValType): Instr[] {
@@ -4787,8 +4804,12 @@ function compileArrayJoinNative(
     return null;
   }
 
+  // #2105: a boolean element array stringifies as "true"/"false". The brand is
+  // lost in arrDef.element, so derive boolean-ness from the receiver TS type.
+  const elemIsBoolean = elemType.kind === "i32" && arrayElementIsBoolean(ctx, propAccess.expression);
   const isNumeric =
-    elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "i8" || elemType.kind === "i16";
+    !elemIsBoolean &&
+    (elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "i8" || elemType.kind === "i16");
   let numToStrIdx: number | undefined;
   if (isNumeric) {
     emitNativeNumberFormat(ctx, new Set(["number_toString"]));
@@ -4845,7 +4866,17 @@ function compileArrayJoinNative(
     { op: "local.get", index: iTmp } as Instr,
     { op: getOp, typeIdx: arrTypeIdx } as Instr,
   ];
-  if (isNumeric && numToStrIdx !== undefined) {
+  if (elemIsBoolean) {
+    // #2105: i32 element on the stack → native "true"/"false" string, then
+    // cast up to ref $AnyString for the concat loop (NativeString <: AnyString).
+    elemToStr.push({
+      op: "if",
+      blockType: { kind: "val", type: nativeStringType(ctx) },
+      then: nativeStringLiteralInstrs(ctx, "true"),
+      else: nativeStringLiteralInstrs(ctx, "false"),
+    } as Instr);
+    elemToStr.push({ op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr);
+  } else if (isNumeric && numToStrIdx !== undefined) {
     if (elemType.kind !== "f64") elemToStr.push({ op: "f64.convert_i32_s" } as Instr);
     elemToStr.push({ op: "call", funcIdx: numToStrIdx } as Instr);
     // number_toString returns the native string boxed as externref.
@@ -4935,6 +4966,9 @@ function compileArrayJoin(
   // externref at runtime is handled in compileArrayMethodCall via the
   // `receiverIsExternref` flag set by the probe. By the time we get here, the
   // receiver is known to be a vec struct.
+
+  // #2105: boolean[] joins/toStrings as "true"/"false", not "1"/"0".
+  const elemIsBoolean = elemType.kind === "i32" && arrayElementIsBoolean(ctx, propAccess.expression);
 
   // #1998: when the element type is externref/ref, each element must be
   // stringified via the `__extern_join_str` host import (undefined/null → "",
@@ -5063,6 +5097,20 @@ function compileArrayJoin(
         { op: "local.get", index: elemF64Tmp },
         { op: "call", funcIdx: toStrIdx },
       ],
+    } as Instr);
+  } else if (elemType.kind === "i32" && elemIsBoolean) {
+    // #2105: a boolean element array stringifies as "true"/"false", not the
+    // numeric "1"/"0" produced by number_toString. The boolean brand is lost
+    // in arrDef.element (structural array dedup), so derive boolean-ness from
+    // the receiver's TS element type. Select the "true"/"false" string-constant
+    // global from the i32 element on the stack (JS-host externref form).
+    addStringConstantGlobal(ctx, "true");
+    addStringConstantGlobal(ctx, "false");
+    elemToStr.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "global.get", index: ctx.stringGlobalMap.get("true")! } as Instr],
+      else: [{ op: "global.get", index: ctx.stringGlobalMap.get("false")! } as Instr],
     } as Instr);
   } else if (elemType.kind === "i32" && toStrIdx !== undefined) {
     elemToStr.push({ op: "f64.convert_i32_s" });

--- a/tests/issue-2105.test.ts
+++ b/tests/issue-2105.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+/**
+ * #2105 — value-rep P2 boolean-brand rollout for `Array.prototype.join` /
+ * `Array.prototype.toString`.
+ *
+ * A boolean array lowers to an i32 WasmGC element array, but the
+ * `{ kind: "i32", boolean: true }` ValType brand is structural-only and does
+ * not survive into `arrDef.element` (arrays dedupe by structure). The join
+ * element-stringify path therefore rendered booleans numerically ("1"/"0")
+ * instead of "true"/"false". The fix recovers boolean-ness from the receiver's
+ * TS element type (`boolean[]` → number-index type is `boolean`) in both the
+ * JS-host join path and the native-strings (standalone / WASI) join path.
+ */
+
+async function js(body: string): Promise<unknown> {
+  const e = await compileToWasm(body);
+  return (e as { test: () => unknown }).test();
+}
+
+describe("#2105 boolean-brand rollout — join (JS host)", () => {
+  it("join of a boolean[] renders true/false, not 1/0", async () => {
+    expect(
+      await js(`export function test(): string { const arr: boolean[] = [true, false, true]; return arr.join(","); }`),
+    ).toBe("true,false,true");
+  });
+
+  it("join of comparison-result booleans renders true/false", async () => {
+    expect(await js(`export function test(): string { const arr = [1 < 2, 2 < 1]; return arr.join(","); }`)).toBe(
+      "true,false",
+    );
+  });
+
+  it("default separator (no arg) renders true/false", async () => {
+    expect(
+      await js(`export function test(): string { const arr: boolean[] = [false, true]; return arr.join(); }`),
+    ).toBe("false,true");
+  });
+
+  it("Array.prototype.toString of a boolean[] delegates to join with true/false", async () => {
+    expect(
+      await js(`export function test(): string { const arr: boolean[] = [true, false]; return arr.toString(); }`),
+    ).toBe("true,false");
+  });
+
+  it("does not regress number[] join (stays numeric)", async () => {
+    expect(await js(`export function test(): string { const arr = [1, 0, 2]; return arr.join(","); }`)).toBe("1,0,2");
+  });
+
+  it("does not regress string[] join", async () => {
+    expect(await js(`export function test(): string { const arr = ["a", "b"]; return arr.join(","); }`)).toBe("a,b");
+  });
+});
+
+describe("#2105 boolean-brand rollout — join (standalone, no JS host)", () => {
+  async function standaloneLen(body: string): Promise<number> {
+    const r = await compile(body, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+    for (const re of [/^env::__extern_toString$/, /^wasm:js-string::/]) {
+      expect(
+        labels.filter((l) => re.test(l)),
+        `leaked ${re}`,
+      ).toEqual([]);
+    }
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  }
+
+  it("boolean[] join renders true/false (length proof: 'true,false,true' = 15)", async () => {
+    expect(
+      await standaloneLen(
+        `export function test(): number { const arr: boolean[] = [true, false, true]; return arr.join(",").length; }`,
+      ),
+    ).toBe(15);
+  });
+
+  it("number[] join stays numeric in standalone (length proof: '1,0,1' = 5)", async () => {
+    expect(
+      await standaloneLen(`export function test(): number { const arr = [1, 0, 1]; return arr.join(",").length; }`),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## #2105 — value-rep P2 boolean brand rollout (join/toString consumer)

A boolean array lowers to an i32 WasmGC element array, but the `{kind:'i32', boolean:true}` ValType brand is **structural-only** and is stripped from `arrDef.element` (arrays dedupe by structure). So `Array.prototype.join` / `toString` rendered booleans numerically (`1`/`0`) instead of `true`/`false`.

### Audit
Probing 10 representative boolean producer→string-consumer paths (comparison via `any`, equality concat, `!x`, template literals, predicate-fn results, `Number.isInteger`, `Array.includes`, `typeof`, `startsWith`) showed **9/10 already render correctly** after the value-rep P1 landings (#1503/#2104). The residual consumer gap was **join/toString**.

### Fix (`src/codegen/array-methods.ts`)
New `arrayElementIsBoolean(ctx, receiverExpr)` helper recovers boolean-ness from the receiver TS element type (`getNumberIndexType` → `isBooleanType`). Both join paths honour it:
- JS-host `compileArrayJoin`: select the `true`/`false` string-constant global from the i32 element.
- native-strings `compileArrayJoinNative` (standalone/WASI): build the native `true`/`false` string, cast up to `$AnyString`.

`toString` delegates to join (#1997) so it inherits the fix.

### Tests
`tests/issue-2105.test.ts` — 8/8 (JS-host + standalone, no-host import-leak assertion). No regression in #2016/#2005 (17) or join families #1997/#1998/#2074 (37). tsc + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)