### PR TITLE
fix(#2107): standalone typeof conformance over canonical JsTag tags

### DIFF
--- a/plan/issues/2107-valuerep-p4-standalone-any-helper-conformance.md
+++ b/plan/issues/2107-valuerep-p4-standalone-any-helper-conformance.md
@@ -1,10 +1,12 @@
 ---
 id: 2107
 title: "value-rep P4: standalone any-helper conformance on canonical tags (__any_strict_eq, __any_unbox_bool, $__any_to_string, __any_typeof)"
-status: ready
+status: done
+completed: 2026-06-16
+assignee: ttraenkler/d3
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -49,3 +51,67 @@ canonical JsTag module (#2104). Coordinates with coercion-engine Step 3
 
 P0 issues (#2072/#2080) cover boxing only; helper conformance is the
 deferred consumer half. New (analysis program).
+
+## Resolution (2026-06-16, d3)
+
+The issue's premise was partly stale after #2104 landed:
+
+- **`__any_strict_eq` `0 === -0`** — already correct. #2104 added a
+  numeric-class arm that compares tags {2,3} via `__any_to_f64` + `f64.eq`,
+  and `f64.eq(0.0, -0.0)` is `true` (the right answer for `===`). No change
+  needed; verified by probe.
+- **`__any_unbox_bool` / `$__any_to_string`** — the string and box-recovery
+  arms were already present and correct after #2104/#2072 (empty-string
+  truthiness and the tag-5 externval / residual primitive-box arms verified
+  by probe). No change needed.
+
+The real, observable standalone defect was the **`typeof` operator over
+canonical tags**, which is what P4's "typeof correct for all 8 tags"
+acceptance criterion exercises:
+
+1. **`__typeof_object` (native, `src/codegen/index.ts`)** returned `1`
+   (object) for any non-null, non-boxed-primitive externref — *including a
+   native `$AnyString`*. So a string-typed `any` reported BOTH
+   `typeof === "string"` AND `typeof === "object"` as true. Added a
+   `ref.test $AnyString` guard (gated on `ctx.anyStrTypeIdx >= 0`) that
+   returns 0 (not object) for a native string, mirroring the #1896
+   closure-wrapper guard.
+2. **`compileTypeofComparison` `$AnyValue` fast-path
+   (`src/codegen/typeof-delete.ts`)** used pre-canonical tag maps
+   (`string -> [5,6]`, `object -> [0]`, no `function`). Corrected to canonical
+   JsTag: `string -> [5]`, `object -> [0,6]`, `function -> [7]`.
+3. **`__any_typeof` helper (`src/codegen/any-helpers.ts`)** collapsed tags
+   5/6/7 to `"object"`. Now emits `"string"` for tag 5, `"function"` for
+   tag 7, `"object"` for tag 6/other.
+4. **`compileTypeofExpression`** consulted `__any_typeof` only under
+   `ctx.fast`; the standalone path fell through to the `__typeof` native
+   *stub* (`ref.null.extern`), so bare `typeof v` returned null and every
+   `typeof v === "…"` compare failed. Re-gated on
+   `isAnyValue && nativeStrings && anyStrTypeIdx >= 0` so standalone uses the
+   real helper.
+
+Boolean (tag 4) producer routing is owned by #2105 (value-rep P2 boolean
+brand) and intentionally untouched here; the boolean typeof arm is correct
+at the helper level given a tag-4 input.
+
+## Test Results
+
+`tests/issue-2107.test.ts` — 10/10 pass (standalone + wasi), each via a
+runtime-selected union branch so the value flows through the runtime helper
+(not statically folded):
+
+| value (dynamic `any`) | `typeof ===` expected | result |
+|-----------------------|-----------------------|--------|
+| string                | "string" (not object) | pass   |
+| number                | "number"              | pass   |
+| object                | "object" (not string) | pass   |
+| function              | "function" (not obj)  | pass   |
+| undefined             | "undefined"           | pass   |
+
+Regression guards: `typeof-comparison`, `typeof-expression`,
+`issue-1896-typeof-closure`, `issue-1470-string-coercion-standalone`,
+`issue-1917-coercion-plan` all pass; host/GC typeof verified unchanged by
+probe (new helper path is no-op outside native-strings). Pre-existing
+`tests/typeof-member-expression.test.ts` / `comparison-coercion.test.ts`
+fail to load on a missing `./helpers.js` import — unrelated to this change.
+`tsc --noEmit` clean.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -1658,9 +1658,34 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
                       blockType: { kind: "val", type: anyStrRef },
                       then: nativeStrConstInstrs("boolean"),
                       else: [
-                        // tag == 5 (string/externref) or tag == 6 (gcref) — default to "object"
-                        // (In practice tag 5 would be "string" but we don't use it in fast mode)
-                        ...nativeStrConstInstrs("object"),
+                        // (#2107) Canonical JsTag (#2104) tag arms: 5 String,
+                        // 7 Function; everything else (6 Object, plus the null
+                        // tag-0 which already resolved to "object" above) →
+                        // "object". Before this, tag 5 wrongly returned
+                        // "object" in the standalone native-string path, so
+                        // `typeof (s: any-string)` mis-reported as "object".
+                        // tag == 5 (string) → "string"
+                        { op: "local.get", index: 1 },
+                        { op: "i32.const", value: 5 },
+                        { op: "i32.eq" },
+                        {
+                          op: "if",
+                          blockType: { kind: "val", type: anyStrRef },
+                          then: nativeStrConstInstrs("string"),
+                          else: [
+                            // tag == 7 (function) → "function"
+                            { op: "local.get", index: 1 },
+                            { op: "i32.const", value: 7 },
+                            { op: "i32.eq" },
+                            {
+                              op: "if",
+                              blockType: { kind: "val", type: anyStrRef },
+                              then: nativeStrConstInstrs("function"),
+                              // tag 6 (object) / unknown → "object"
+                              else: nativeStrConstInstrs("object"),
+                            },
+                          ],
+                        },
                       ],
                     },
                   ],

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9277,6 +9277,22 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
         blockType: { kind: "empty" },
         then: [{ op: "i32.const", value: 0 }, { op: "return" }],
       },
+      // (#2107) native string ($AnyString) → "string", NOT "object". Under
+      // nativeStrings/standalone a string value is a `$AnyString` GC struct
+      // carried as externref; without this guard `typeof (s: any) === "object"`
+      // wrongly held and `=== "string"` was the only true arm via the separate
+      // __typeof_string helper, so both string-tagged comparisons disagreed.
+      ...(ctx.anyStrTypeIdx >= 0
+        ? ([
+            { op: "local.get", index: 1 },
+            { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // non-null, not a boxed primitive → object
       { op: "i32.const", value: 1 },
     ],

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -865,9 +865,22 @@ export function compileTypeofExpression(
     return compileStringLiteral(ctx, fctx, staticResult);
   }
 
-  // Fast mode: any-typed operand -> runtime typeof via __any_typeof
+  // $AnyValue operand → runtime typeof via __any_typeof, which tag-dispatches
+  // and returns a native `ref $AnyString`. This fires for fast mode AND for
+  // standalone/WASI: the latter previously fell through to the `__typeof` host
+  // helper below, whose standalone native form is a `ref.null.extern` stub
+  // (index.ts registerNative), so `typeof (v: any)` returned null and every
+  // `typeof v === "…"` string compare failed (#2107). __any_typeof needs the
+  // native-string machinery (nativeStrings + a registered $AnyString type), so
+  // it's only consulted when those are present; otherwise we keep the legacy
+  // __typeof path so non-native-string builds stay byte-identical.
   const wasmType = resolveWasmType(ctx, tsType);
-  if (ctx.fast && (wasmType.kind === "ref" || wasmType.kind === "ref_null") && isAnyValue(wasmType, ctx)) {
+  if (
+    (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+    isAnyValue(wasmType, ctx) &&
+    ctx.nativeStrings &&
+    ctx.anyStrTypeIdx >= 0
+  ) {
     ensureAnyHelpers(ctx);
     const typeofIdx = ctx.funcMap.get("__any_typeof");
     if (typeofIdx !== undefined) {
@@ -995,15 +1008,23 @@ export function compileTypeofComparison(
   // on the $AnyValue struct. This avoids pulling in the full native string helpers.
   if (isAnyValue(resolveWasmType(ctx, tsType), ctx)) {
     ensureAnyHelpers(ctx);
-    // Map the string literal to tag check(s)
+    // Map the string literal to canonical JsTag (#2104) tag check(s):
+    //   0 Null · 1 Undefined · 2 NumberI32 · 3 NumberF64 · 4 Boolean ·
+    //   5 String · 6 Object · 7 Function.
+    // (#2107) Pre-canonical this used `string -> [5,6]` and `object -> [0]`,
+    // which conflated tag 6 (Object) with strings and dropped real objects
+    // from the `object` arm — so `typeof (s: any-string) === "object"` was
+    // true and `typeof (o: any-object) === "object"` was false. Corrected:
+    // string is tag 5 only; object is null (0) or Object (6); function is 7.
     let tagChecks: number[] | null = null;
     if (stringLiteral === "number")
       tagChecks = [2, 3]; // i32 or f64
     else if (stringLiteral === "boolean") tagChecks = [4];
-    else if (stringLiteral === "string")
-      tagChecks = [5, 6]; // externref string or gcref string
+    else if (stringLiteral === "string") tagChecks = [5];
     else if (stringLiteral === "undefined") tagChecks = [1];
-    else if (stringLiteral === "object") tagChecks = [0]; // null -> "object"
+    else if (stringLiteral === "object")
+      tagChecks = [0, 6]; // null -> "object", plain object ref
+    else if (stringLiteral === "function") tagChecks = [7];
 
     if (tagChecks !== null) {
       // Compile the operand

--- a/tests/issue-2107.test.ts
+++ b/tests/issue-2107.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2107 (value-rep P4) — standalone any-helper conformance for the `typeof`
+ * operator over canonical JsTag (#2104) tags.
+ *
+ * Two defects fixed here, both observable only on the standalone / WASI
+ * (native-strings, no JS host) path where an `any`/union value is carried as an
+ * externref and `typeof` routes through the native `__typeof_*` helpers (or, for
+ * a true `$AnyValue` operand, `__any_typeof`):
+ *
+ *   1. `__typeof_object` returned `1` (object) for ANY non-null, non-boxed
+ *      primitive externref — including a native `$AnyString` string. So a
+ *      string-typed `any` reported BOTH `typeof === "string"` and
+ *      `typeof === "object"` as true. Added a `ref.test $AnyString` guard that
+ *      classifies a native string as NOT an object.
+ *   2. `compileTypeofComparison`'s `$AnyValue` fast-path used pre-canonical tag
+ *      maps (`string -> [5,6]`, `object -> [0]`, no `function`). Corrected to
+ *      `string -> [5]`, `object -> [0,6]`, `function -> [7]`, and the
+ *      `__any_typeof` helper's tag arms now emit "string"/"function" for tags
+ *      5/7 instead of collapsing them to "object". `compileTypeofExpression`
+ *      now consults `__any_typeof` on the standalone path too (it was gated on
+ *      `ctx.fast`, leaving standalone on the null `__typeof` stub).
+ *
+ * Tests use the *dynamic* typeof path (a runtime-selected union branch) so the
+ * value flows through the runtime helper rather than being statically resolved.
+ */
+
+async function runStandalone(src: string, target: "standalone" | "wasi"): Promise<number> {
+  const r = await compile(src, { target });
+  expect(
+    r.success,
+    `compile failed (${target}):\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, { env: {} });
+  return (instance.exports as Record<string, (...a: unknown[]) => number>).test();
+}
+
+const TARGETS: Array<"standalone" | "wasi"> = ["standalone", "wasi"];
+
+describe("#2107 standalone typeof conformance over canonical tags", () => {
+  for (const target of TARGETS) {
+    describe(`target=${target}`, () => {
+      // A string held dynamically is `typeof === "string"` and NOT "object".
+      it("string-any reports typeof 'string', not 'object'", async () => {
+        const src = `
+          function pick(i: number): string | number { return i > 0 ? "hi" : 5; }
+          export function test(): number {
+            const x = pick(1); // runtime string
+            const isStr = (typeof x === "string") ? 1 : 0;
+            const isObj = (typeof x === "object") ? 1 : 0;
+            // expect string=1, object=0  → encode as isStr*10 + isObj
+            return isStr * 10 + isObj;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+
+      it("number-any reports typeof 'number'", async () => {
+        const src = `
+          function pick(i: number): string | number { return i > 0 ? "hi" : 5; }
+          export function test(): number {
+            const x = pick(0); // runtime number
+            const isNum = (typeof x === "number") ? 1 : 0;
+            const isStr = (typeof x === "string") ? 1 : 0;
+            return isNum * 10 + isStr;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+
+      it("object-any reports typeof 'object', not 'string'", async () => {
+        const src = `
+          function pick(i: number): { a: number } | number { return i > 0 ? { a: 1 } : 5; }
+          export function test(): number {
+            const x = pick(1); // runtime object
+            const isObj = (typeof x === "object") ? 1 : 0;
+            const isStr = (typeof x === "string") ? 1 : 0;
+            return isObj * 10 + isStr;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+
+      it("function-any reports typeof 'function', not 'object'", async () => {
+        const src = `
+          function pick(i: number): (() => number) | number { return i > 0 ? (() => 1) : 5; }
+          export function test(): number {
+            const x = pick(1); // runtime function
+            const isFn = (typeof x === "function") ? 1 : 0;
+            const isObj = (typeof x === "object") ? 1 : 0;
+            return isFn * 10 + isObj;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+
+      it("undefined-any reports typeof 'undefined'", async () => {
+        const src = `
+          function pick(i: number): string | undefined { return i > 0 ? "hi" : undefined; }
+          export function test(): number {
+            const x = pick(0); // runtime undefined
+            const isUndef = (typeof x === "undefined") ? 1 : 0;
+            const isStr = (typeof x === "string") ? 1 : 0;
+            return isUndef * 10 + isStr;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## #2107 — value-rep P4: standalone any-helper typeof conformance

The standalone/WASI `typeof` operator mis-classified `any`/union values carried
as externref. Four fixes against the canonical JsTag world (#2104):

1. **`__typeof_object`** (`src/codegen/index.ts`) — add a `ref.test $AnyString`
   guard (gated on `anyStrTypeIdx >= 0`) so a native string is NOT reported as
   `"object"`. Before, any non-null non-boxed-primitive externref returned
   "object", so a string-typed `any` was BOTH `typeof === "string"` and
   `typeof === "object"`.
2. **`compileTypeofComparison`** `$AnyValue` fast-path (`typeof-delete.ts`) —
   canonical tag maps: `string→[5]`, `object→[0,6]`, `function→[7]` (was
   `string→[5,6]`, `object→[0]`, no function).
3. **`__any_typeof`** (`any-helpers.ts`) — emit `"string"` for tag 5,
   `"function"` for tag 7 instead of collapsing 5/6/7 to `"object"`.
4. **`compileTypeofExpression`** — consult `__any_typeof` on the standalone
   path (was gated on `ctx.fast`, leaving standalone on the null `__typeof`
   stub, so bare `typeof v` returned null); re-gated on
   `isAnyValue && nativeStrings && anyStrTypeIdx >= 0`.

`__any_strict_eq` (`0 === -0`) and the `__any_unbox_bool` / `$__any_to_string`
string arms were already correct after #2104/#2072 (verified by probe, no
change). Boolean tag-4 producer routing stays with #2105.

## Tests
`tests/issue-2107.test.ts` — 10/10 (standalone + wasi), each via a
runtime-selected union branch so the value flows through the runtime helper:
string→"string"(not object), number→"number", object→"object"(not string),
function→"function"(not object), undefined→"undefined".

Regression guards green: `typeof-comparison`, `typeof-expression`,
`issue-1896-typeof-closure` (coexists with the closure-exclusion finalize
rewrite), `issue-1470-string-coercion-standalone`, `issue-1917-coercion-plan`.
Host/GC path unchanged (new helper path is no-op outside native-strings).
`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)