### PR TITLE
fix(#2158): standalone class .constructor identity + empty-subclass AnyString canonicalization guard

### DIFF
--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -1,10 +1,11 @@
 ---
 id: 2158
 title: "Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sd1
 sprint: 62
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -45,3 +46,59 @@ descriptor object model — the second-largest catch-up bucket.
 
 Parent (done): #1591. Implements against spec #2101; depends on #1965.
 Part of sprint-62 standalone catch-up (rank 2 by gap impact).
+
+## Implementation notes — slice 1 (2026-06-16, sd1)
+
+This 1,388-test gap is a multi-PR epic (spec #2101 phases P0–P4). This slice
+lands the two highest-leverage, host-free defects, both diagnosed by WAT-tracing
+`--target standalone` repros. The remaining standalone reflection readers
+(`Object.getOwnPropertyNames`/`getOwnPropertyDescriptor`/`Object.keys` on class
+objects — still hard-errors `#1472 Phase B` in standalone) and `new.target`
+(#2023, P2) / dynamic `new K()` (#2026, P3) stay open for follow-up slices.
+
+### Defect 1 — `.constructor` identity returns false in standalone (spec #2101 P1)
+
+`new A().constructor` lowered to `ref.func ${A}_constructor` + `extern.convert_any`
+(`property-access.ts` instance `.constructor` arm) — a funcref-as-externref.
+But the class identifier `A` resolves to the `__class_<Name>` singleton struct
+(`emitLazyClassObjectGet`, via identifiers.ts). So `new A().constructor === A`
+compared two different externrefs → always false. **Fix:** route instance
+`.constructor` through the SAME `emitLazyClassObjectGet(typeName)` singleton, so
+both sides of the `===` are reference-identical. Host-free, so it fixes the
+identity in standalone AND host mode. Falls back to the constructor funcref only
+when no class-object global exists (externref-backed builtin subclasses).
+
+### Defect 2 — empty-subclass `===` / `typeof` crash with `illegal cast` (#2009)
+
+WAT-traced root cause: an EMPTY class root struct is exactly
+`(struct (field $__tag i32))`. The native-string supertype `$AnyString` is also
+a single-i32-field OPEN struct (`(struct (field $len i32))`). When the empty
+class is a hierarchy ROOT (it has subclasses → left non-final/open), WasmGC
+**iso-recursive canonicalization** (#2009's disease) merges the open class root
+with `$AnyString`; its `final` subclasses then become subtypes of `$AnyString`,
+so `ref.test $AnyString` on a subclass instance / class-object returns TRUE.
+That false positive drove the standalone `===` and `typeof === "string"` arms
+into `ref.cast $AnyString` + `__str_flatten` on a non-string struct →
+`RuntimeError: illegal cast`. This broke EVERY strict-equality and string-typeof
+over a subclass value in standalone (`B === B`, `new B() === x`,
+`B.prototype === p`, `typeof new B()`), a large slice of the gap. Lone empty
+classes escape it because `markLeafStructsFinal` makes them `final` (a final
+struct is not subtype-compatible with the non-final `$AnyString`).
+
+**Fix:** append a hidden immutable sentinel field (`__shape_brand` i32) to a
+class root struct whose only field would be `$__tag`, making it
+`(struct (field i32) (field i32))` — structurally distinct from the single-field
+`$AnyString`, breaking the canonical merge. Appended LAST so existing positional
+`fieldIdx` for real instance fields is unaffected; constructors and the lazy
+proto/class-object inits iterate the field list and default it automatically.
+Cost: +4 bytes only on empty-class instances (rare). Classes with ≥1 instance
+field are already structurally distinct and get no sentinel. This is the
+#2009-family canonicalization-collision fix applied to the class-vs-string
+boundary (distinct from #2009's anon-object-literal `$shape` work).
+
+Files: `src/codegen/property-access.ts` (instance `.constructor` → class-object
+singleton), `src/codegen/class-bodies.ts` (empty-root sentinel field). Test:
+`tests/issue-2158-class-identity-standalone.test.ts` (15 cases — constructor
+identity, empty-subclass identity/typeof, plus regression coverage for method
+dispatch, super()-inherited fields, getPrototypeOf, instanceof, string equality).
+tsc clean; standalone suite green.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -527,6 +527,35 @@ export function collectClassDeclaration(
   // struct type registered), since built-ins have no Wasm struct fields to inherit.
   if (!parentClassName || parentStructTypeIdx === undefined) {
     fields.unshift({ name: "__tag", type: { kind: "i32" }, mutable: false });
+
+    // (#2158 / #2009) Structural-collision guard. An empty class root struct
+    // is exactly `(struct (field $__tag i32))`. The native-string supertype
+    // `$AnyString` is also a single-i32-field open struct
+    // (`(struct (field $len i32))`). When such a class is a hierarchy ROOT
+    // (it has subclasses, so it is left non-final/open), WasmGC iso-recursive
+    // canonicalization merges it with `$AnyString` — both are structurally
+    // identical open singletons. The class's (final) subclasses then become
+    // subtypes of `$AnyString`, so `ref.test $AnyString` on a subclass
+    // instance (or class-object singleton) returns TRUE. That false positive
+    // drives the standalone `===` / `typeof` string arm to
+    // `ref.cast $AnyString` + `__str_flatten` on a non-string struct →
+    // `RuntimeError: illegal cast`, breaking every strict-equality and
+    // string-typeof over a subclass value in --target standalone (a large
+    // slice of the #2158 class/prototype residual). Lone empty classes do not
+    // hit this because `markLeafStructsFinal` makes them `final`, and a final
+    // struct is not subtype-compatible with the non-final `$AnyString`.
+    //
+    // Fix: append a hidden immutable sentinel i32 so the root struct is
+    // `(struct (field i32) (field i32))` — structurally distinct from the
+    // single-field `$AnyString`, breaking the canonical merge. Appended LAST
+    // so every existing positional `fieldIdx` for real instance fields is
+    // unaffected; constructors / lazy proto+class-object inits iterate the
+    // field list and default it to 0 automatically. Cost: +4 bytes only on
+    // empty class instances (the rare case). A class with any instance field
+    // is already structurally distinct and needs no sentinel.
+    if (fields.length === 1) {
+      fields.push({ name: "__shape_brand", type: { kind: "i32" }, mutable: false });
+    }
   }
 
   // Update the placeholder struct type with resolved fields

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -21,7 +21,7 @@ import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
-import { emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
+import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import {
   classifyPrivateMember,
   emitPrivateBrandPredicate,
@@ -3098,13 +3098,28 @@ export function compilePropertyAccess(
       }
     }
 
-    // Handle .constructor on class instances — return constructor function ref
+    // Handle .constructor on class instances — return the class VALUE.
+    //
+    // (#2158 P1) `new A().constructor` must be reference-identical to the
+    // class identifier `A` so that `new A().constructor === A` holds. The
+    // class identifier resolves to the `__class_<Name>` singleton via
+    // `emitLazyClassObjectGet` (identifiers.ts:620). Routing `.constructor`
+    // through the SAME singleton makes both sides of the `===` the same
+    // externref — host-free, so it fixes the identity in standalone mode
+    // too (the previous `ref.func` + `extern.convert_any` produced a
+    // funcref-as-externref that never compared equal to the class object).
     if (propName === "constructor" && ctx.classSet.has(typeName)) {
       // Compile and drop the object expression (for side effects)
       const objResult = compileExpression(ctx, fctx, expr.expression);
       if (objResult) {
         fctx.body.push({ op: "drop" });
       }
+      if (emitLazyClassObjectGet(ctx, fctx, typeName)) {
+        return { kind: "externref" };
+      }
+      // No class-object singleton (e.g. externref-backed builtin subclass):
+      // fall back to the constructor funcref so callable identity is at least
+      // stable across reads of the same class.
       const ctorName = `${typeName}_constructor`;
       const funcIdx = ctx.funcMap.get(ctorName);
       if (funcIdx !== undefined) {

--- a/tests/issue-2158-class-identity-standalone.test.ts
+++ b/tests/issue-2158-class-identity-standalone.test.ts
@@ -145,7 +145,9 @@ describe("#2158 no regression to existing class behaviour (standalone)", () => {
 
   it("native string equality is unaffected", async () => {
     expect(
-      await runStandalone(`export function test(): boolean { const a: any = "hello"; const b: any = "hel" + "lo"; return a === b; }`),
+      await runStandalone(
+        `export function test(): boolean { const a: any = "hello"; const b: any = "hel" + "lo"; return a === b; }`,
+      ),
     ).toBe(1);
   });
 });

--- a/tests/issue-2158-class-identity-standalone.test.ts
+++ b/tests/issue-2158-class-identity-standalone.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2158 — standalone class/prototype/descriptor conformance residual.
+//
+// Two host-free defects fixed here, both surfacing only in --target standalone
+// (no JS host Proxy / host-eq import):
+//
+//  1. `.constructor` identity. `new A().constructor === A` and
+//     `A.prototype.constructor`-shaped reads must be reference-identical to the
+//     class value `A`. Previously instance `.constructor` lowered to a
+//     `ref.func` + `extern.convert_any` (a funcref-as-externref) while the class
+//     identifier `A` resolves to the `__class_<Name>` singleton struct, so the
+//     two were never `===`. Both now resolve to the same `__class_<Name>`
+//     singleton. (Architecture spec #2101 P1.)
+//
+//  2. Subclass identity / typeof in standalone. An EMPTY class root struct is
+//     `(struct (field $__tag i32))`; the native-string supertype `$AnyString`
+//     is also a single-i32-field open struct. WasmGC iso-recursive
+//     canonicalization (#2009) merged the open class root with `$AnyString`,
+//     so its `final` subclasses became subtypes of `$AnyString` and
+//     `ref.test $AnyString` returned TRUE for a subclass instance. That false
+//     positive drove the standalone `===` / `typeof` string arm into
+//     `ref.cast $AnyString` + `__str_flatten` on a non-string struct →
+//     `RuntimeError: illegal cast`, breaking every strict equality and string
+//     typeof over a subclass value. A hidden sentinel field on empty class
+//     roots makes them structurally distinct from `$AnyString`.
+//
+// Spec references:
+// - ECMA-262 §10.2.4 (constructor [[Prototype]] / .constructor wiring)
+// - ECMA-262 §7.2.16 IsStrictlyEqual (object identity by reference)
+// - ECMA-262 §13.5.3 typeof
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#2158 standalone class constructor identity", () => {
+  it("new A().constructor === A (base class)", async () => {
+    expect(
+      await runStandalone(`class A { m(){ return 1; } }
+        export function test(): boolean { return new A().constructor === A; }`),
+    ).toBe(1);
+  });
+
+  it("new A().constructor === A (class with fields)", async () => {
+    expect(
+      await runStandalone(`class A { x: number; constructor(){ this.x = 7; } }
+        export function test(): boolean { return new A().constructor === A; }`),
+    ).toBe(1);
+  });
+
+  it("new B().constructor === B (subclass)", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { return new B().constructor === B; }`),
+    ).toBe(1);
+  });
+
+  it("new B().constructor !== A (subclass ctor is not the parent)", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { return new B().constructor === A; }`),
+    ).toBe(0);
+  });
+
+  it(".constructor is stable across reads", async () => {
+    expect(
+      await runStandalone(`class A {}
+        export function test(): boolean { const a = new A(); return a.constructor === a.constructor; }`),
+    ).toBe(1);
+  });
+});
+
+describe("#2158 standalone empty-subclass identity (AnyString canonicalization guard)", () => {
+  it("empty subclass class-value identity (B === B)", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { return B === B; }`),
+    ).toBe(1);
+  });
+
+  it("empty subclass instance self-identity", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { const x: any = new B(); return x === x; }`),
+    ).toBe(1);
+  });
+
+  it("distinct empty-subclass instances are not ===", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { const x: any = new B(); const y: any = new B(); return x === y; }`),
+    ).toBe(0);
+  });
+
+  it("empty subclass instance is not typeof string", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { const b: any = new B(); return typeof b === "string"; }`),
+    ).toBe(0);
+  });
+
+  it("empty subclass instance is typeof object", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { const b: any = new B(); return typeof b === "object"; }`),
+    ).toBe(1);
+  });
+});
+
+describe("#2158 no regression to existing class behaviour (standalone)", () => {
+  it("instance method dispatch still works", async () => {
+    expect(
+      await runStandalone(`class A { x: number; constructor(){ this.x = 42; } g(){ return this.x; } }
+        export function test(): number { return new A().g(); }`),
+    ).toBe(42);
+  });
+
+  it("subclass field + inherited field via super()", async () => {
+    expect(
+      await runStandalone(`class A { a: number; constructor(){ this.a = 1; } }
+        class B extends A { b: number; constructor(){ super(); this.b = 2; } g(){ return this.a + this.b; } }
+        export function test(): number { return new B().g(); }`),
+    ).toBe(3);
+  });
+
+  it("Object.getPrototypeOf(new A()) === A.prototype", async () => {
+    expect(
+      await runStandalone(`class A {}
+        export function test(): boolean { return Object.getPrototypeOf(new A()) === A.prototype; }`),
+    ).toBe(1);
+  });
+
+  it("instanceof across the empty hierarchy", async () => {
+    expect(
+      await runStandalone(`class A {} class B extends A {}
+        export function test(): boolean { const b: any = new B(); return (b instanceof B) && (b instanceof A); }`),
+    ).toBe(1);
+  });
+
+  it("native string equality is unaffected", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean { const a: any = "hello"; const b: any = "hel" + "lo"; return a === b; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2158 slice 1 — standalone class object-model conformance

Two host-free defects in the class object model, both WAT-traced on `--target standalone`. Part of the 1,388-test #2158 residual (spec #2101 phases P0–P4); this slice lands the two highest-leverage fixes.

### Defect 1 — `.constructor` identity returns false in standalone (spec #2101 P1)
Instance `.constructor` lowered to `ref.func ${A}_constructor` + `extern.convert_any` (a funcref-as-externref), while the class identifier `A` resolves to the `__class_<Name>` singleton struct. So `new A().constructor === A` compared two different externrefs → always false. **Fix:** route instance `.constructor` through the same `emitLazyClassObjectGet` singleton for reference identity (host-free; fixes host mode too). Funcref fallback retained for externref-backed builtin subclasses.

### Defect 2 — empty-subclass `===` / `typeof` crash with `illegal cast` (#2009 family)
An empty class root struct is `(struct (field $__tag i32))`; the native-string supertype `$AnyString` is also a single-i32-field **open** struct. WasmGC iso-recursive canonicalization (#2009's disease) merged the open class root with `$AnyString`, so its `final` subclasses became `$AnyString` subtypes → `ref.test $AnyString` false-positived on subclass instances/class-objects, driving the standalone `===` / `typeof === "string"` arm into `ref.cast $AnyString` + `__str_flatten` on a non-string struct → `RuntimeError: illegal cast`. This broke **every** strict equality and string-typeof over a subclass value in standalone. Lone empty classes escaped it because `markLeafStructsFinal` makes them `final`.

**Fix:** append a hidden immutable sentinel i32 (`__shape_brand`) to a class root struct whose only field would be `$__tag`, making it structurally distinct from `$AnyString` and breaking the canonical merge. Appended LAST so existing positional `fieldIdx` is unaffected; constructors and lazy proto/class-object inits default it automatically. Cost: +4 bytes only on empty-class instances.

### Validation
- `tests/issue-2158-class-identity-standalone.test.ts` — 15 cases (constructor identity base+subclass, empty-subclass identity/typeof, regression coverage: method dispatch, super()-inherited fields, getPrototypeOf, instanceof, string equality). All green.
- `tsc --noEmit` clean. GC-mode compile verified.

### Out of scope (follow-up slices)
- Standalone `Object.getOwnPropertyNames/getOwnPropertyDescriptor/Object.keys` on class objects (still `#1472 Phase B` hard-error in standalone).
- `new.target` (#2023, P2) and dynamic `new K()` (#2026, P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)