### PR TITLE
fix(#2130): `in`/hasOwnProperty consult delete tombstone, not static struct shape

### DIFF
--- a/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
+++ b/plan/issues/2130-delete-and-in-resolved-against-static-struct-shape.md
@@ -1,10 +1,12 @@
 ---
 id: 2130
 title: "delete o.prop is a no-op and `in` answers against the static struct shape — post-delete / dynamic-key / object-rest all wrong"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/d1
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -12,12 +14,37 @@ task_type: bugfix
 area: codegen
 language_feature: object-literals
 goal: property-model
-related: [1821, 492, 1112, 1991]
+related: [1821, 492, 1112, 1991, 2179]
 renumbered_from: "residual of #1821 (done) — surfaced by #1971 re-validation"
 origin: "2026-06-12 #1971 PO re-validation vs main c19a2e9c1"
 ---
 
 # #2130 — `delete` / `in` ignore runtime object shape (static-struct resolution)
+
+## Resolution (2026-06-16, Stage A — the titled `in`/hasOwnProperty defect)
+
+**Done:** `in` and `Object.prototype.hasOwnProperty` now consult the runtime
+presence model (delete tombstone + sidecar) via a single shared predicate
+`_wasmStructHasOwn` (`src/runtime.ts`), instead of the static struct shape.
+`__hasOwnProperty` and `__extern_has` (the `in` operator) both route through
+it. The buggy module-global `__sget_<key>` existence probe in `__extern_has`
+(which reported any field-name present in *any* struct type as present on
+*every* receiver, and never consulted the tombstone — architect addendum A1)
+was deleted. `_safeGet` is tombstone-gated and `_safeSet` clears the tombstone
+on re-add (A3/A5). Tests: `tests/issue-2130-delete-in-presence.test.ts` (7
+cases, all green). Verified `delete o.a; "a" in o` → false; object-rest
+`"e" in rest` → false; `o.x = undefined; "x" in o` → true; delete-then-re-add
+restores `in`.
+
+**Deferred to #2179 (architect addenda A6/A7 — never in #2130's deliverable):**
+the post-delete struct **read** path for statically-resolvable receivers
+(`const o:any={a:1,b:2}; delete o.a; o.a === undefined`). The `any` read
+compiles to an inline `ref.test`+`struct.get` fast-path that reads the live
+f64 field (bypassing the runtime tombstone), and `=== undefined` is
+constant-folded on the f64 field type. Fixing it requires routing such reads
+through `__extern_get` for delete-using modules — which breaks standalone/WASI
+(no `__extern_get` host import) and needs representation-steering. Tracked as a
+separate `feasibility: hard` codegen concern in #2179.
 
 ## Problem
 
@@ -365,3 +392,55 @@ In the `__extern_has` rewrite, the plain-JS sidecar check must be key-based
 value-based `_sidecarGet(obj, key) !== undefined` (`runtime.ts:6357`) —
 HasProperty (§7.3.12) is value-independent, so `o.x = undefined; "x" in o`
 must be true.
+
+---
+
+## Implementation status (2026-06-16, d1)
+
+### Landed — Stage A: tombstone-aware presence predicate (the `in` half)
+
+The headline defect — `in` / `hasOwnProperty` answering against the static
+struct shape and ignoring runtime deletes — is fixed. `src/runtime.ts`:
+
+- Extracted **`_wasmStructHasOwn(obj, key, exports)`** — the single own-property
+  predicate (tombstone → sidecar (key-based, A8) → descriptor → class
+  proto/static methods → struct-field shape). `__hasOwnProperty` now delegates
+  to it (pure extraction).
+- Rewrote **`__extern_has`** (the `in` operator): WasmGC-struct receivers route
+  through `_wasmStructHasOwn` + the `_OBJECT_PROTO_KEYS` inherited tier, and the
+  buggy **module-global `__sget_<key>` existence probe is deleted** (addendum
+  A1 — it reported every receiver as having any field name present in any struct
+  type and never consulted the tombstone). Plain-JS receivers use native
+  HasProperty + a key-based sidecar check (A8).
+- **`_safeGet`**: tombstone gate at the top of the WasmGC branch — a deleted key
+  reads `undefined` via the generic (`__extern_get`) read path.
+- **`_safeSet`**: clears the tombstone on (re-)assignment (A3) — single choke
+  point covering the sidecar / `__sset_` / symbol arms.
+
+Acceptance criteria met by Stage A:
+- `delete o.a; "a" in o` → `false` ✓
+- sibling `"b" in o` stays `true` ✓
+- dynamic-key `delete o[k]; "a" in o` → `false` ✓
+- object-rest `"e" in rest` → `false`, `"f" in rest` → `true` ✓
+- `delete o.a; o.a = 5; "a" in o` → `true` ✓
+- value-independent HasProperty: `o.x = undefined; "x" in o` → `true` ✓
+- No regressions across in-operator / hasOwnProperty / delete-operator /
+  #1821 / #1991 / #1364b suites.
+
+Tests: `tests/issue-2130-delete-in-presence.test.ts` (7 cases, all green).
+
+### Deferred — the read half (`delete o.a; o.a === undefined`)
+
+For a **statically-resolvable struct receiver** (e.g. `const o:any={a:1,b:2}`),
+`o.a` after delete still reads the stale field value. Root cause: that read
+compiles to an inline `ref.test`+`struct.get` fast-path
+(`emitExternrefToStructGet`, `src/codegen/property-access.ts`) that reads the
+live f64 field and bypasses the runtime tombstone, and `o.a === undefined` is
+constant-folded because the field's static type is `f64` (never `undefined`).
+
+This is the architect's explicitly-deferred **A6/A7** work: the only sound fix
+is to steer delete-touched object literals away from the inline struct.get
+fast-path (route reads through tombstone-aware `__extern_get` in JS-host mode,
+and use `$Object` representation steering in standalone mode — a wasm-side
+`(obj,key)` tombstone registry is rejected by A7 because WasmGC has no weak
+refs). Tracked as the read-path follow-up to this issue.

--- a/plan/issues/2179-delete-post-read-struct-fastpath-tombstone.md
+++ b/plan/issues/2179-delete-post-read-struct-fastpath-tombstone.md
@@ -1,0 +1,107 @@
+---
+id: 2179
+title: "post-delete struct READ returns stale value — inline struct.get fast-path bypasses the runtime tombstone"
+status: ready
+sprint: 63
+created: 2026-06-16
+updated: 2026-06-16
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [2130]
+origin: "2026-06-16 deferred read-path half of #2130 (Stage A landed in-fix; architect addenda A6/A7)"
+---
+
+# #2179 — post-delete struct read is a no-op for statically-resolvable receivers
+
+## Problem
+
+The `in` / `hasOwnProperty` half of #2130 landed (Stage A): both now consult
+the runtime delete tombstone. But the **read** of a deleted property still
+returns the stale value when the receiver resolves to a static struct shape:
+
+```ts
+const o: any = { a: 1, b: 2 };
+delete o.a;
+o.a              // wasm: 1          node: undefined
+o.a === undefined // wasm: false (folded)  node: true
+
+const o2: any = { a: 1 };
+delete o2.a;
+o2.a = 5;
+o2.a             // wasm: 1 (original, re-add lost on the field) node: 5
+```
+
+(`"a" in o`, `o.hasOwnProperty("a")`, object-rest `"e" in rest`, and the
+re-added key's `in` result are all CORRECT after #2130 Stage A — only the
+struct-field READ value is wrong.)
+
+## Root cause (verified on main `8c74365b4`, JS-host)
+
+A property read on an `any`-typed identifier whose initializer gives it a
+resolvable anon struct type compiles to an inline fast-path
+(`emitExternrefToStructGet`, `src/codegen/property-access.ts:1029`):
+
+```
+any.convert_extern
+ref.test (ref <structTypeIdx>)
+(if (then  ref.cast (ref <T>)  struct.get <T> <fieldIdx> )   ;; <-- reads the LIVE field
+   (else  ... __extern_get fallback ... ))
+```
+
+Two compile-time issues compound:
+
+1. The `then` arm reads the WasmGC struct field directly via `struct.get`,
+   which has no knowledge of the runtime `_wasmStructDeletedKeys` tombstone or
+   the sidecar. `delete o.a` (an `any` receiver) takes the runtime
+   `__delete_property` arm, which sets the tombstone but cannot clear the
+   struct field — so the field still holds `1`.
+2. `o.a === undefined` is **constant-folded to `false`** because `o.a`'s
+   static type is `f64` (`src/codegen/binary-ops.ts`, the null/undefined
+   comparison path only emits `__extern_is_undefined` for an **externref**
+   operand; an f64 operand can never be `undefined`, so it folds).
+
+The runtime tombstone gate added to `_safeGet`/`__extern_get` in #2130 is
+therefore bypassed for this receiver class (the read never reaches those
+helpers).
+
+## Why it is deferred (architect addenda A6/A7 on #2130)
+
+- **A6**: the fix is to route delete-touched struct-ref reads through
+  `__extern_get` (tombstone-aware, returns externref → real `undefined`, so
+  `=== undefined` is no longer folded). Gate it on a `ctx.moduleUsesDelete`
+  pre-scan (pattern: `sourceContainsClass`, `src/codegen/index.ts:209`) so
+  delete-free modules keep byte-identical output and incur zero overhead.
+- **A7 (standalone)**: `__extern_get` is a JS host import — unavailable under
+  `--target wasi` / standalone. WasmGC has no weak refs, so a wasm-side
+  `(obj,key)` tombstone registry would strongly retain every deleted-from
+  object. The dual-mode answer is **representation steering**: reuse the A6
+  pre-scan to find object-literal struct types targeted by `delete`, and in
+  standalone mode lower those literals to the dynamic `$Object` representation
+  (which already has spec-correct `FLAG_TOMBSTONE` tombstones, proto-walk
+  `in`, and insertion-order enumeration — `src/codegen/object-runtime.ts`).
+  Zero overhead for untouched objects, full fidelity for delete-touched ones.
+
+## Acceptance criteria
+
+- `const o:any={a:1,b:2}; delete o.a; o.a` → `undefined` (JS-host AND
+  standalone).
+- `o.a === undefined` after delete → `true` (not constant-folded).
+- `delete o.a; o.a = 5; o.a` → `5` and `"a" in o` → `true` (re-add round-trip).
+- `Object.keys(o)` / `for (const k in o)` omit the deleted key (verify #2130's
+  `__object_keys`/`__for_in_keys` tombstone+sidecar union still holds — addenda
+  A4).
+- Delete-free modules emit byte-identical wasm (gate proves zero regression).
+- No standalone regression; standalone path uses `$Object` steering, not a
+  wasm tombstone registry.
+
+## Notes
+
+Split from #2130 (Stage A `in`/hasOwnProperty fix is `done`). This is the
+codegen + representation-steering remainder. Coordinate the `moduleUsesDelete`
+pre-scan with any other delete-aware lowering. See #2130's `## Resolution`
+note and the architect addenda A6/A7 in #2130's Implementation Plan.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2822,6 +2822,49 @@ function _getStructFieldNames(obj: any, exports: Record<string, Function> | unde
 }
 
 /**
+ * (#2130) Shared own-property presence predicate for a WasmGC struct receiver.
+ * This is the single source of truth for "does `obj` have its OWN property
+ * `key`", combining — in spec order — the runtime delete tombstone, the sidecar
+ * store, the descriptor table (accessor-only properties), registered class
+ * proto/static method names, and finally the static struct field shape. It is
+ * the WasmGC branch of `__hasOwnProperty` extracted verbatim so that
+ * `__extern_has` (the `in` operator) and `__hasOwnProperty` answer identically
+ * and BOTH consult the tombstone (`delete o.a; "a" in o` → false).
+ *
+ * The caller must have already established `_isWasmStruct(obj)` is true.
+ * `key` may be a string or a symbol; tombstone/sidecar comparisons preserve
+ * symbol identity (a symbol key is never stringified).
+ */
+function _wasmStructHasOwn(obj: any, key: any, exports: Record<string, Function> | undefined): boolean {
+  // (#1334) Property explicitly deleted — treat as absent regardless of the
+  // struct shape having the field name.
+  const tomb = _wasmStructDeletedKeys.get(obj);
+  if (tomb && tomb.has(typeof key === "symbol" ? key : String(key))) return false;
+  // Sidecar properties (user-assigned dynamic props). Key-based — HasProperty
+  // (§7.3.12) is value-independent, so `o.x = undefined; "x" in o` is true (A8).
+  const sc = _wasmStructProps.get(obj);
+  if (sc && key in sc) return true;
+  // Descriptor map (accessor properties set via Object.defineProperty, #929).
+  const descs = _wasmPropDescs.get(obj);
+  if (descs && descs.has(String(key))) return true;
+  // (#1047) registered class prototype — only allowlisted methods qualify.
+  const protoMethods = _prototypeMethodNames.get(obj);
+  if (protoMethods !== undefined) {
+    const prop = String(key);
+    return protoMethods.includes(prop) && !_isDeletedClassProp(obj, prop);
+  }
+  const staticMethods = _staticMethodNames.get(obj);
+  if (staticMethods !== undefined) {
+    const prop = String(key);
+    return staticMethods.includes(prop) && !_isDeletedClassProp(obj, prop);
+  }
+  // Static struct field shape (the per-receiver oracle, A1 — NOT a module-global
+  // `__sget_<key>` existence probe).
+  const fieldNames = _getStructFieldNames(obj, exports) ?? [];
+  return fieldNames.includes(String(key));
+}
+
+/**
  * Convert a WasmGC struct to a plain JS object using exported getters.
  * Returns undefined if the struct type is not recognized.
  */
@@ -3661,6 +3704,13 @@ function _safeGet(obj: any, key: any, callbackState?: { getExports: () => Record
     }
   }
   if (_isWasmStruct(obj)) {
+    // (#2130) A deleted property reads as `undefined` even when the static
+    // struct shape still carries the field (the `__sget_<key>` getter would
+    // otherwise return the stale field value). The tombstone is cleared by
+    // `_safeSet` on re-add, so a re-added key never reaches here as tombstoned.
+    // Symbol keys preserve identity; everything else compares stringified.
+    const tomb = _wasmStructDeletedKeys.get(obj);
+    if (tomb && tomb.has(typeof key === "symbol" ? key : String(key))) return undefined;
     // For WasmGC structs, user-assigned properties live in the sidecar.
     // Check sidecar FIRST — native JS property access on WasmGC structs can return
     // built-in artifacts (e.g. `obj.constructor` returns the Wasm struct constructor),
@@ -3736,6 +3786,16 @@ function _safeSet(
     const cbState = callbackState ?? (exports ? { getExports: () => exports } : undefined);
     const prim = _toPrimitiveSync(key, "string", cbState);
     if (prim != null && typeof prim !== "object") key = prim;
+  }
+  // (#2130) Re-adding a previously-deleted property clears its tombstone, so
+  // `delete o.a; o.a = 5; o.a` reads `5` and `"a" in o` is `true` again. This
+  // is the single choke point for every WasmGC write arm (sidecar setter,
+  // descriptor write, symbol-id, struct field) — placing the clear here rather
+  // than only in `_sidecarSet` covers the `__sset_<name>`/native-write paths
+  // that bypass the sidecar (A3).
+  if (_isWasmStruct(obj)) {
+    const tomb = _wasmStructDeletedKeys.get(obj);
+    if (tomb) tomb.delete(typeof key === "symbol" ? key : String(key));
   }
   // Well-known symbol ID (i32 from compiler): store under both real Symbol and "@@name".
   // ONLY apply this remapping to WasmGC structs — for regular JS objects/arrays,
@@ -6573,37 +6633,32 @@ assert._isSameValue = isSameValue;
             const prim = _toPrimitiveSync(key, "string", callbackState);
             if (prim != null && typeof prim !== "object") key = prim;
           }
+          // (#2130) WasmGC struct receivers route through the shared own-property
+          // predicate (tombstone-aware, per-receiver shape oracle) — NOT a
+          // module-global `__sget_<key>` existence probe, which reported every
+          // receiver as having any field name present in any struct type and
+          // never consulted the delete tombstone. So `delete o.a; "a" in o` is
+          // now `false`, and object-rest `"e" in rest` is `false` (rest's plain
+          // object never has `e`; the source struct's shape no longer leaks).
+          if (typeof obj === "object" && _isWasmStruct(obj)) {
+            if (_wasmStructHasOwn(obj, key, callbackState?.getExports())) return 1;
+            // (#1991) `in` walks the [[Prototype]] chain (§13.10.1 → §7.3.12):
+            // every object inherits the Object.prototype members.
+            if (typeof key === "string" && _OBJECT_PROTO_KEYS.has(key)) return 1;
+            return 0;
+          }
+          // Plain JS object (or host-supplied object) — native HasProperty walks
+          // its own prototype chain. HasProperty is value-independent (§7.3.12),
+          // so the sidecar fallback is key-based, not value-based (A8): a
+          // user-assigned `o.x = undefined` must still report present.
           try {
             if (key in obj) return 1;
           } catch {
             /* opaque struct or non-object obj */
           }
-          // Fall back to sidecar (user-assigned properties on host objects)
-          if (_sidecarGet(obj, key) !== undefined) return 1;
-          // Wasm struct getter (defineProperty accessor)
-          if (typeof key === "string") {
-            const exports = callbackState?.getExports();
-            if (typeof exports?.[`__sget_${key}`] === "function") {
-              try {
-                // (#1589A) Mirror __extern_has_idx: a getter that returns at
-                // all (even null/undefined) proves the field exists on this
-                // struct shape — HasProperty (§7.3.12) is value-independent.
-                // Only a throw signals "field not defined on this variant".
-                exports[`__sget_${key}`](obj);
-                return 1;
-              } catch {
-                /* getter not defined for this struct variant — fall through */
-              }
-            }
-          }
-          // (#1991) `in` walks the [[Prototype]] chain (§13.10.1 → §7.3.12), so
-          // EVERY object value inherits the Object.prototype members. A WasmGC
-          // struct (object literal / class instance / array) arrives here as an
-          // opaque externref whose `key in obj` above can't see Object.prototype,
-          // so `"toString" in ({} as any)` wrongly returned 0. Recognise the
-          // well-known Object.prototype keys explicitly for any non-null object.
-          // (Inherited *user-class* methods still need a method registry — not
-          // covered here.)
+          const sc = _wasmStructProps.get(obj);
+          if (sc && key in sc) return 1;
+          // Inherited Object.prototype members for any non-null object value.
           if (typeof key === "string" && (typeof obj === "object" || typeof obj === "function") && obj !== null) {
             if (_OBJECT_PROTO_KEYS.has(key)) return 1;
           }
@@ -9151,33 +9206,9 @@ assert._isSameValue = isSameValue;
               return 0;
             }
           }
-          // (#1334) Property explicitly deleted — treat as absent regardless
-          // of the struct shape having the field name.
-          const tomb = _wasmStructDeletedKeys.get(obj);
-          if (tomb && tomb.has(typeof key === "symbol" ? key : String(key))) return 0;
-          // WasmGC struct: check sidecar properties
-          const sc = _wasmStructProps.get(obj);
-          if (sc && key in sc) return 1;
-          // Check descriptor map (for accessor properties set via Object.defineProperty)
-          // __defineProperty_accessor stores flags in _wasmPropDescs so that
-          // hasOwnProperty returns true for accessor-only properties. (#929)
-          const descs = _wasmPropDescs.get(obj);
-          if (descs && descs.has(String(key))) return 1;
-          // #1047 — registered class prototype: only allowlisted methods qualify
-          const protoMethods = _prototypeMethodNames.get(obj);
-          if (protoMethods !== undefined) {
-            const prop = String(key);
-            return protoMethods.includes(prop) && !_isDeletedClassProp(obj, prop) ? 1 : 0;
-          }
-          const staticMethods = _staticMethodNames.get(obj);
-          if (staticMethods !== undefined) {
-            const prop = String(key);
-            return staticMethods.includes(prop) && !_isDeletedClassProp(obj, prop) ? 1 : 0;
-          }
-          // Check struct field names via exported helpers
-          const exports = callbackState?.getExports();
-          const fieldNames = _getStructFieldNames(obj, exports) ?? [];
-          return fieldNames.includes(String(key)) ? 1 : 0;
+          // (#2130) Single shared own-property predicate — tombstone, sidecar,
+          // descriptor, class methods, struct shape.
+          return _wasmStructHasOwn(obj, key, callbackState?.getExports()) ? 1 : 0;
         };
       // propertyIsEnumerable runtime check for externref/any receivers
       if (name === "__propertyIsEnumerable")

--- a/tests/issue-2130-delete-in-presence.test.ts
+++ b/tests/issue-2130-delete-in-presence.test.ts
@@ -108,7 +108,7 @@ describe("#2130 — `in` / hasOwnProperty consult the delete tombstone", () => {
     ).toBe(1);
   });
 
-  it("HasProperty is value-independent: `o.x = undefined; \"x\" in o` is true", async () => {
+  it('HasProperty is value-independent: `o.x = undefined; "x" in o` is true', async () => {
     expect(
       await run(
         `export function test(): number {

--- a/tests/issue-2130-delete-in-presence.test.ts
+++ b/tests/issue-2130-delete-in-presence.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2130 — `in` / `hasOwnProperty` must consult the runtime delete tombstone, not
+// just the static struct shape. Stage A (this PR) fixes the presence-predicate
+// half: `in` and `Object.prototype.hasOwnProperty` now route through a single
+// tombstone-aware own-property predicate (`_wasmStructHasOwn`), and the buggy
+// module-global `__sget_<key>` existence probe in `__extern_has` is removed.
+//
+// The read half (`delete o.a; o.a === undefined` for a statically-resolvable
+// struct receiver) is the architect's deferred A6/A7 follow-up — that read uses
+// an inline `struct.get` fast-path which bypasses the tombstone, and the fix
+// requires representation steering to stay sound in standalone mode.
+
+async function run(source: string, fn: string): Promise<unknown> {
+  const result = await compile(source, {});
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as any)[fn]();
+}
+
+describe("#2130 — `in` / hasOwnProperty consult the delete tombstone", () => {
+  it("`in` returns false after delete o.prop", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = { a: 1, b: 2 };
+          delete o.a;
+          return ("a" in o) ? 0 : 1;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("`in` stays true for a sibling property after delete", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = { a: 1, b: 2 };
+          delete o.a;
+          return ("b" in o) ? 1 : 0;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("dynamic-key `in` returns false after delete o[k]", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = { a: 1, b: 2 };
+          const k = "a";
+          delete o[k];
+          return ("a" in o) ? 0 : 1;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("object-rest: `in` answers against the rest object's own shape, not the source", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const { e, ...rest } = { e: 3, f: 4 };
+          const r = rest as any;
+          const hasE = ("e" in r) ? 1 : 0;
+          const hasF = ("f" in r) ? 1 : 0;
+          return (hasE === 0 && hasF === 1) ? 1 : 0;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("hasOwnProperty returns false after delete (shares the predicate with `in`)", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = { a: 1, b: 2 };
+          delete o.a;
+          const oo = o as any;
+          return oo.hasOwnProperty("a") ? 0 : 1;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("delete then re-add makes `in` true again", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = { a: 1 };
+          delete o.a;
+          o.a = 5;
+          return ("a" in o) ? 1 : 0;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+
+  it("HasProperty is value-independent: `o.x = undefined; \"x\" in o` is true", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = {};
+          o.x = undefined;
+          return ("x" in o) ? 1 : 0;
+        }`,
+        "test",
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2130 — `in` / `hasOwnProperty` answered against the static struct shape

Closes the **titled defect** of #2130: `in` and `Object.prototype.hasOwnProperty` resolved against the compile-time struct shape and ignored the runtime delete tombstone, so `delete o.a; "a" in o` stayed `true`, and object-rest `"e" in rest` was wrongly `true`.

### Fix
- Extract a single shared own-property predicate `_wasmStructHasOwn(obj, key, exports)` (`src/runtime.ts`) — consults, in spec order: the delete tombstone (`_wasmStructDeletedKeys`), the sidecar, the descriptor table, registered class proto/static methods, then the static struct field shape.
- Re-point `__hasOwnProperty` at it (pure extraction) and rewrite `__extern_has` (the `in` operator) to use it.
- **Delete the buggy module-global `__sget_<key>` existence probe** in `__extern_has` (architect addendum A1): it returned `1` for any receiver whenever any struct type in the module had that field name, and never consulted the tombstone.
- Tombstone-gate `_safeGet` and clear the tombstone in `_safeSet` on re-add (A3/A5).

### Tests — `tests/issue-2130-delete-in-presence.test.ts` (7, all green)
`delete o.a; "a" in o`→false (sibling stays true) · dynamic-key `delete o[k]` · object-rest `"e" in rest`→false · hasOwnProperty agrees with `in` · delete-then-re-add restores `in` · value-independent `o.x=undefined; "x" in o`→true.
No regressions across in-operator / hasOwnProperty / delete-operator / #1821 / #1991 / #1364b suites.

### Deferred to #2179 (architect A6/A7 — never in #2130's deliverable)
The post-delete struct **read** path for statically-resolvable receivers (`const o:any={a:1,b:2}; delete o.a; o.a === undefined`): the `any` read compiles to an inline `ref.test`+`struct.get` fast-path that reads the live f64 field (bypassing the tombstone), and `=== undefined` constant-folds on the f64 field type. Fixing it needs read routing through `__extern_get` for delete-using modules + standalone representation-steering — a separately-scoped codegen concern, filed as #2179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)