### PR TITLE
chore(#1326): confirm async Phase 1 landed — flip #1326 + #1326c to done

### DIFF
--- a/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
+++ b/plan/issues/1326-async-microtask-queue-wasm-scheduler.md
@@ -1,9 +1,11 @@
 ---
 id: 1326
 title: "Async standalone: implement microtask queue + CPS scheduler in Wasm for Promise/async without JS host"
-status: in-review
+status: done
 created: 2026-05-07
-updated: 2026-06-03
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/se1
 priority: low
 feasibility: hard
 reasoning_effort: max
@@ -329,3 +331,39 @@ flip to `done` is defensible. Not flipped here only because the issue body
 still carries a "~70% done" implementation note and this is a hard,
 multi-phase issue — confirm the Phase-1 test passes on current main, then
 flip to `done` (or split Phase 2+ into a follow-up and flip this).
+
+## Phase 1 confirmation + flip to done (2026-06-16, se1, sprint 62)
+
+CONFIRM-THEN-FLIP **executed**. The async keystone (Phase 1A/1B/1C-A/1C-B/1D)
+has fully landed on `main` — confirmed by running the suite on current
+`main` HEAD (`e424a7d3a`):
+
+- `pnpm exec vitest run tests/issue-1326.test.ts` → **14/14 pass**, covering
+  every Phase 1 acceptance criterion:
+  - **1B** — `Promise.resolve(42)` / `Promise.reject('err')` compile to the
+    Wasm-native `$Promise` struct in WASI mode (no `Promise_resolve` /
+    `Promise_reject` host import).
+  - **1C** — microtask queue: a fulfilled `.then` callback runs only after
+    `__drain_microtasks`; chained `.then` callbacks drain in microtask order;
+    rejected promises route through the `onRejected` continuation.
+  - **1D** — `__drain_microtasks` export + WASI `_start` auto-drain wiring.
+- `src/codegen/async-scheduler.ts` (1,170 LoC on main) carries **no throwing
+  stubs** — `emitMicrotaskEnqueue` / `emitDrainMicrotasks` /
+  `emitStandalonePromiseResolve` / `emitStandalonePromiseReject` /
+  `emitStandalonePromiseThen` all have real Wasm bodies.
+- `.then` standalone dispatch (incl. two-arg `onRejected`) is wired at
+  `src/codegen/expressions/calls.ts:6513`, gated on
+  `isStandalonePromiseActive(ctx)`.
+
+The "~70% done" note in §Problem predates the landed work and is stale.
+
+**Phase 2+ remains scoped to existing follow-up issues** (no work lost by
+flipping this):
+- **#1936** — async contract migration / enable the built-but-disabled CPS
+  lowering (host chain head; precedes #1796).
+- **#1373b** — IR async CPS lowering.
+- **#2165** — standalone Promise/async conformance residual (~223 tests).
+- **#2028** — `new Promise(executor)` standalone (resolve/reject capture).
+- Promise combinators (`all`/`race`/`allSettled`/`any`) standalone and async
+  generators remain explicitly out-of-scope here, tracked under the
+  standalone-mode goal.

--- a/plan/issues/1326c-microtask-queue-and-promise-then-standalone.md
+++ b/plan/issues/1326c-microtask-queue-and-promise-then-standalone.md
@@ -1,9 +1,11 @@
 ---
 id: 1326c
 title: "Async standalone Phase 1C: microtask queue + Promise.then chained-resolution (follow-up to #1326 Phase 1B)"
-status: in-progress
+status: done
 created: 2026-05-08
-updated: 2026-05-20
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/se1
 priority: medium
 feasibility: hard
 reasoning_effort: max
@@ -986,7 +988,25 @@ unchanged.
   passthrough still works after .then plumbing
 
 
-## Suspended Work
+## Completion (2026-06-16, se1, sprint 62)
+
+Both Phase 1C-A (queue infra) and Phase 1C-B (`emitStandalonePromiseThen`
+chained resolution + rejection routing) have **landed on `main`** (PRs
+#405 + follow-ups). Confirmed on current `main` HEAD (`e424a7d3a`):
+
+- `pnpm exec vitest run tests/issue-1326.test.ts` → **14/14 pass**, including
+  the Phase 1C-B acceptance cases: "drains chained `.then` callbacks in
+  microtask order" and "routes rejected promises through the `onRejected`
+  continuation".
+- `src/codegen/async-scheduler.ts` has a real `emitStandalonePromiseThen`
+  body (no throwing stub); `.then` standalone dispatch incl. two-arg
+  `onRejected` is wired at `src/codegen/expressions/calls.ts:6513`.
+
+The Suspended Work below (PR #405, "Phase 1C-B remaining") is historical —
+that follow-up work has since merged. Flipped `in-progress` → `done`.
+`#1373b` (the `required_by` dependent) is now unblocked.
+
+## Suspended Work (historical — completed; see Completion note above)
 
 - **PR**: https://github.com/loopdive/js2/pull/405
 - **Branch**: `issue-1326c-microtask-standalone`

--- a/plan/issues/1373b-ir-async-cps-lowering.md
+++ b/plan/issues/1373b-ir-async-cps-lowering.md
@@ -1,9 +1,9 @@
 ---
 id: 1373b
 title: "IR async Phase C: CPS lowering for await + async-return + async-throw"
-status: blocked
+status: ready
 created: 2026-05-09
-updated: 2026-05-21
+updated: 2026-06-16
 priority: top
 feasibility: hard
 reasoning_effort: max
@@ -13,7 +13,7 @@ language_feature: async
 goal: ir-full-coverage
 sprint: 62
 depends_on: [1326c]
-note: "Verified 2026-05-21: src/codegen/async-scheduler.ts exists; src/codegen/async-cps.ts does NOT exist yet (still pending #1042 introducing it). async-cluster-architect-spec.md exists."
+note: "Verified 2026-05-21: src/codegen/async-scheduler.ts exists; src/codegen/async-cps.ts does NOT exist yet (still pending #1042 introducing it). async-cluster-architect-spec.md exists. Unblocked 2026-06-16 (se1): sole dependency #1326c flipped done — Phase 1C microtask queue + chained .then landed on main."
 ---
 # #1373b — IR async Phase C: CPS lowering
 


### PR DESCRIPTION
## Summary

The async standalone **keystone** (#1326 — microtask queue + CPS scheduler, Phase 1A/1B/1C-A/1C-B/1D) has **fully landed on `main`**. This is the CONFIRM-THEN-FLIP the #2147 board-hygiene triage flagged: confirm Phase 1 passes on current main, then flip `#1326` (and its Phase 1C follow-up `#1326c`) from `in-review`/`in-progress` to `done`.

Doc/issue-status only — **no source changes**.

## Confirmation

On current `main` HEAD (`e424a7d3a`), `pnpm exec vitest run tests/issue-1326.test.ts` → **14/14 pass**, covering every Phase 1 acceptance criterion:

- **1B** — `Promise.resolve(42)` / `Promise.reject('err')` compile to the Wasm-native `$Promise` struct in WASI mode (no `Promise_resolve`/`Promise_reject` host import).
- **1C** — microtask queue: a fulfilled `.then` callback runs only after `__drain_microtasks`; chained `.then` callbacks drain in microtask order; rejected promises route through the `onRejected` continuation.
- **1D** — `__drain_microtasks` export + WASI `_start` auto-drain wiring.

`src/codegen/async-scheduler.ts` carries no throwing stubs; `.then` standalone dispatch (incl. two-arg `onRejected`) is wired at `src/codegen/expressions/calls.ts:6513`, gated on `isStandalonePromiseActive(ctx)`.

## Scope preserved

Phase 2+ (async/await CPS desugaring, Promise combinators, async generators) remains scoped to existing follow-ups — **no work lost**:
- #1936 — async contract migration / enable built-but-disabled CPS lowering
- #1373b — IR async CPS lowering (**unblocked** here: sole dep #1326c now done → flipped `blocked`→`ready`)
- #2165 — standalone Promise/async conformance residual (~223 tests)
- #2028 — `new Promise(executor)` standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)