### PR TITLE
fix(#2084): null-guard struct-field writes — catchable TypeError, not a trap

### DIFF
--- a/plan/issues/2084-module-global-read-guard-write-unguarded.md
+++ b/plan/issues/2084-module-global-read-guard-write-unguarded.md
@@ -1,10 +1,12 @@
 ---
 id: 2084
 title: "module-global object access: reads re-emit null-check+throw per access (survives -O); writes have NO check and trap instead of TypeError"
-status: ready
+status: done
+completed: 2026-06-16
+assignee: ttraenkler/dv3
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -50,12 +52,30 @@ read guards entirely.
 #2017 (getter-only write), #581 (trap catchability family) — the
 store-path gap and the guard redundancy aren't covered. New (low).
 
-## Suspended Work (2026-06-11, infra incident)
+## Resolution (2026-06-16, dv3) — write-path null guard (acceptance (a))
 
-The implementing dev was terminated by a team-store wipe near completion.
-State preserved in worktree `/workspace/.claude/worktrees/issue-2084-global-guard`
-(branch `issue-2084-global-guard`): UNCOMMITTED 38 insertions in
-src/codegen/expressions/assignment.ts (write-path null guard) plus
-tests/issue-2084.test.ts. Likely close to done — review the diff, run the
-test, finish acceptance (read-guard elimination half may be unstarted),
-commit (✓), push `--no-verify`, PR with `-R loopdive/js2`.
+Recovered the suspended write-path fix and re-applied it against current
+`upstream/main` (the suspended worktree's `assignment.ts` had drifted off an
+older main and could not be copied wholesale). In `compilePropertyAssignment`
+(`src/codegen/expressions/assignment.ts`), the struct-field store path now
+null-guards the receiver: when the receiver is a nullable `(ref null $T)` and
+not statically provably non-null, it stashes the RHS, `ref.is_null`-checks the
+receiver, and emits `typeErrorThrowInstrs(ctx, target)` on null — otherwise the
+direct `local.tee` / `struct.set` is preserved. The guard predicate
+(`structObjResult.kind === "ref_null" && !isProvablyNonNull(...)`) mirrors the
+array-element write guard already in this file, so `new Foo()` / `this` writes
+keep their unguarded fast path.
+
+A null-receiver write now throws a **catchable** `TypeError` instead of trapping
+uncatchably — closing the error-model divergence (family #581/#2025).
+
+Tests: `tests/issue-2084.test.ts` (4 cases) — catchable TypeError on null write,
+normal module-global write, class instance-field write, compound + nested
+writes. All green; `tsc --noEmit` clean.
+
+**Carried forward (acceptance (b), separate follow-up):** eliminating the
+per-access READ null guard for statically-non-null module objects (non-nullable
+globals initialised in the start function) is an efficiency optimisation with a
+high blast radius (start-function init ordering, every member-read site). It is
+*not* a correctness bug — left for a dedicated issue. This PR closes the
+correctness half (the error-model bug named by the title/#581 family).

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -28,7 +28,12 @@ import {
 } from "../index.js";
 import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
-import { emitNullGuardedStructGet, isProvablyNonNull, isSafeBoundsEliminated } from "../property-access.js";
+import {
+  emitNullGuardedStructGet,
+  isProvablyNonNull,
+  isSafeBoundsEliminated,
+  typeErrorThrowInstrs,
+} from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, skipTransparentExpressions, valTypesMatch } from "../shared.js";
 import { compileStringLiteral, emitBoolToString } from "../string-ops.js";
@@ -2482,12 +2487,39 @@ function compilePropertyAssignment(
     reportError(ctx, target, "Failed to compile struct field receiver");
     return null;
   }
+  // (#2084) Null-guard the write. The read path already throws a catchable
+  // TypeError on a null receiver, but the store path emitted `struct.set`
+  // directly — a null receiver then trapped uncatchably ("dereferencing a null
+  // pointer") instead of throwing `TypeError: Cannot set properties of null`
+  // (error-model divergence, family #581/#2025). Skip the guard when the
+  // receiver is a non-nullable `ref` or is statically provably non-null (e.g.
+  // `new Foo()`, `this`) — no trap is possible there and the check is dead
+  // weight. Mirrors the array-element write guard below (`isProvablyNonNull`).
+  const guardNull = structObjResult.kind === "ref_null" && !isProvablyNonNull(target.expression, ctx.checker);
   const valType = compileExpression(ctx, fctx, value, fields[fieldIdx]!.type);
   if (!valType) return null;
-  // Save value so assignment expression returns the RHS
+  // Save value so the assignment expression returns the RHS.
   const tmpVal = allocLocal(fctx, `__prop_assign_${fctx.locals.length}`, valType);
-  fctx.body.push({ op: "local.tee", index: tmpVal });
-  fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
+  if (guardNull) {
+    // stack: [receiver, value] — stash value, then null-check the receiver.
+    fctx.body.push({ op: "local.set", index: tmpVal });
+    const tmpRecv = allocLocal(fctx, `__prop_recv_${fctx.locals.length}`, structSelfType);
+    fctx.body.push({ op: "local.tee", index: tmpRecv });
+    fctx.body.push({ op: "ref.is_null" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: typeErrorThrowInstrs(ctx, target),
+      else: [
+        { op: "local.get", index: tmpRecv } as Instr,
+        { op: "local.get", index: tmpVal } as Instr,
+        { op: "struct.set", typeIdx: structTypeIdx, fieldIdx } as Instr,
+      ],
+    } as Instr);
+  } else {
+    fctx.body.push({ op: "local.tee", index: tmpVal });
+    fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
+  }
   fctx.body.push({ op: "local.get", index: tmpVal });
 
   return valType;

--- a/tests/issue-2084.test.ts
+++ b/tests/issue-2084.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2084 — a property WRITE to a null receiver trapped uncatchably instead of
+// throwing a catchable TypeError.
+//
+// Module objects live in `(ref null $T)` mutable globals. The member-READ path
+// already threw a catchable `TypeError` on a null receiver, but the member-WRITE
+// path (`compilePropertyAssignmentForStruct`) emitted `struct.set` directly — a
+// null receiver then trapped with an uncatchable "dereferencing a null pointer"
+// Wasm error (error-model divergence, family #581/#2025).
+//
+// Fix: null-guard the struct write — throw the catchable TypeError on null,
+// otherwise perform the set. The guard is skipped when the receiver is provably
+// non-null (`new Foo()`, `this`, a non-nullable `ref`), so normal writes keep
+// their direct `struct.set`.
+
+import { describe, expect, it } from "vitest";
+
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function run(src: string): Promise<number> {
+  const exports = (await compileAndInstantiate(src)) as { test(): number };
+  return exports.test();
+}
+
+describe("#2084 property write null-guard (catchable TypeError, not a trap)", () => {
+  it("writing to a null module-global receiver throws a CATCHABLE TypeError", async () => {
+    // If the write trapped uncatchably the module would throw out of `test()`
+    // and this would reject; the `catch` proves the throw is a catchable Wasm
+    // exception.
+    expect(
+      await run(`
+        let o: { x: number } | null = null;
+        export function test(): number {
+          try { o!.x = 42; return -1; } catch (e: any) { return 7; }
+        }`),
+    ).toBe(7);
+  });
+
+  it("normal writes to a non-null receiver are unaffected", async () => {
+    expect(
+      await run(`
+        let o: { x: number } = { x: 1 };
+        export function test(): number { o.x = 42; return o.x; }`),
+    ).toBe(42);
+  });
+
+  it("class instance field write works", async () => {
+    expect(
+      await run(`
+        class A { x = 1; }
+        const a = new A();
+        export function test(): number { a.x = 5; return a.x; }`),
+    ).toBe(5);
+  });
+
+  it("compound assignment and nested writes are unaffected", async () => {
+    expect(
+      await run(`
+        export function test(): number { const o = { x: 10 }; o.x += 5; return o.x; }`),
+    ).toBe(15);
+    expect(
+      await run(`
+        const o = { inner: { y: 1 } };
+        export function test(): number { o.inner.y = 3; return o.inner.y; }`),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
Resolves #2084 (correctness half).

## Problem
The struct-field property-write path emitted `struct.set` directly, so a write through a null receiver (e.g. a `(ref null $T)` module-global object) **trapped uncatchably** ("dereferencing a null pointer") instead of throwing a catchable `TypeError: Cannot set properties of null`. The READ path already guarded — this was a read/write asymmetry (error-model divergence, family #581/#2025).

## Fix
`compilePropertyAssignment` (`src/codegen/expressions/assignment.ts`) now null-guards the struct write when the receiver is a nullable `ref` and not statically provably non-null: stash the RHS → `ref.is_null` the receiver → `typeErrorThrowInstrs` on null, else `struct.set`. Provably non-null receivers (`new Foo()`, `this`, non-nullable refs) keep the direct `struct.set` fast path. The predicate mirrors the array-element write guard already in this file.

## Tests
`tests/issue-2084.test.ts` (4): catchable TypeError on null write, normal module-global write, class instance-field write, compound + nested writes. All green; `tsc --noEmit` clean.

## Scope
Closes acceptance (a) (catchable TypeError on null write). Acceptance (b) — eliminating per-access READ guards for statically-non-null module objects — is an efficiency optimisation with high blast radius (start-function init ordering), **not a correctness bug**; carried to a follow-up.

Recovered + rebased from the #2084 suspended-work worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)