### PR TITLE
chore(hooks): cap agent spawns to hardware via a CPU load gate

### DIFF
--- a/.claude/hooks/pre-agent-spawn.sh
+++ b/.claude/hooks/pre-agent-spawn.sh
@@ -1,32 +1,61 @@
 #!/bin/bash
-# Pre-agent-spawn hook: check RAM, log event
-INPUT=$(cat)
-AVAIL_MB=$(free -m | awk '/Mem/{print $7}')
-AGENT_COUNT=$(ps aux | grep -c '[c]laude')
+# Pre-agent-spawn hook: cap concurrency to the box's hardware, then log.
+#
+# Why this exists: agents are cheap when idle (waiting on the API) but each
+# active one bursts a core during compile/test. With no CPU ceiling the box
+# oversubscribes (load hit 13 on 8 cores), which starves sshd and drops
+# interactive SSH sessions. We gate on the *load average* rather than a process
+# count because the harness keeps a warm pool of `claude.exe` helpers
+# (--bg-spare / --bg-pty-host) that makes process-counting a poor proxy for how
+# many agents are actually working.
+#
+# Hardware-matched limits (tunable via env):
+#   JS2WASM_MAX_LOAD    block new spawns when 1-min load >= this   (default: cores-2)
+#   JS2WASM_MIN_RAM_MB  block new spawns when avail RAM < this MB   (default: 1500)
+# The default leaves ~2 cores free for the lead, IDE, sshd and system so the box
+# stays interactive. Raise JS2WASM_MAX_LOAD to trade responsiveness for throughput.
 
-# Extract agent name/type from input
+INPUT=$(cat)
+
+CORES=$(nproc 2>/dev/null || echo 4)
+# Default ceiling = cores-2 (leave headroom), floor of 1.
+DEFAULT_MAX_LOAD=$(( CORES > 2 ? CORES - 2 : 1 ))
+MAX_LOAD=${JS2WASM_MAX_LOAD:-$DEFAULT_MAX_LOAD}
+MIN_RAM_MB=${JS2WASM_MIN_RAM_MB:-1500}
+
+AVAIL_MB=$(free -m | awk '/Mem/{print $7}')
+LOAD1=$(awk '{print $1}' /proc/loadavg 2>/dev/null)
+# Coarse footprint for observability only (NOT used for the hard gate — see header).
+CLAUDE_PROCS=$(pgrep -fc 'claude\.exe' 2>/dev/null || echo 0)
+
 AGENT_NAME=$(echo "$INPUT" | jq -r '.tool_input.name // "unknown"' 2>/dev/null)
 AGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // "general"' 2>/dev/null)
 
-# Log the spawn event
 source /workspace/.claude/hooks/event-log.sh
-log_event "agent_spawn" "agent=$AGENT_NAME" "type=$AGENT_TYPE" "ram_mb=$AVAIL_MB"
+log_event "agent_spawn" "agent=$AGENT_NAME" "type=$AGENT_TYPE" "ram_mb=$AVAIL_MB" "load1=$LOAD1" "cores=$CORES" "claude_procs=$CLAUDE_PROCS"
 
-# Prefer teammates over bare subagents for sprint work — warn but don't block
+# Prefer teammates over bare subagents for sprint work — warn but don't block.
 TEAM_NAME=$(echo "$INPUT" | jq -r '.tool_input.team_name // empty' 2>/dev/null)
 if [ -z "$TEAM_NAME" ]; then
   log_event "agent_spawn_no_team" "agent=$AGENT_NAME" "reason=no_team_name"
-  echo "NOTE: Agent spawned without team_name. For sprint dev agents use TeamCreate + team_name so they can coordinate. Bare subagents are fine for one-off research/fetches." >&2
+  echo "NOTE: Agent spawned without team_name. For sprint dev agents use a team_name so they coordinate; bare subagents are fine for one-off research/fetches." >&2
 fi
 
-if [ "$AVAIL_MB" -lt 1500 ]; then
+# --- Hardware-matched hard gates (exit 2 blocks the spawn) ---
+
+# 1) RAM floor — don't spawn into a nearly-full box.
+if [ "${AVAIL_MB:-0}" -lt "$MIN_RAM_MB" ]; then
   log_event "agent_spawn_blocked" "agent=$AGENT_NAME" "reason=low_ram" "ram_mb=$AVAIL_MB"
-  echo "BLOCKED: Only ${AVAIL_MB}MB available RAM with ${AGENT_COUNT} agents running." >&2
+  echo "BLOCKED: only ${AVAIL_MB}MB RAM available (< ${MIN_RAM_MB}MB floor). Wait for an agent to finish before spawning more." >&2
   exit 2
 fi
 
-if [ "$AGENT_COUNT" -gt 8 ]; then
-  echo "WARNING: ${AGENT_COUNT} Claude processes running. Available RAM: ${AVAIL_MB}MB." >&2
+# 2) CPU load — don't pile onto an already-saturated box. This is the cap that
+#    "matches the hardware": ~one core of active work per spawn, ~2 cores reserved.
+if [ -n "$LOAD1" ] && awk -v l="$LOAD1" -v m="$MAX_LOAD" 'BEGIN{exit !(l+0 >= m+0)}'; then
+  log_event "agent_spawn_blocked" "agent=$AGENT_NAME" "reason=high_load" "load1=$LOAD1" "max_load=$MAX_LOAD" "cores=$CORES"
+  echo "BLOCKED: 1-min load ${LOAD1} >= ${MAX_LOAD} on a ${CORES}-core box — already at the hardware-matched concurrency cap. Let active agents drain before spawning more (or raise JS2WASM_MAX_LOAD to trade SSH responsiveness for throughput)." >&2
+  exit 2
 fi
 
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,15 +187,17 @@ Default rule: if the agent's job is "produce one document and exit," it's a suba
 
 **IMPORTANT: Always use team name `"js2wasm"`** — this is the single permanent team. Never create ad-hoc team names (e.g. `"wasi-conflicts"`, `"s52-wave2"`). One team, one task queue, always.
 
-**Key numbers**: 16GB RAM + 16GB swap (container, set in `.devcontainer/devcontainer.json`). `free -m` may report ~20GB but Docker enforces 16GB hard limit. **Up to 8 dev teammates** (no local test262 — CI handles it). All agents use `bypassPermissions` mode + worktree isolation. Work driven by `plan/log/dependency-graph.md`.
+**Key numbers**: 16GB RAM + 16GB swap (container, set in `.devcontainer/devcontainer.json`), **8 cores**. `free -m` may report ~20GB but Docker enforces 16GB hard limit. **CPU is the binding constraint, not RAM** — keep concurrent *active* agents to ~`cores − 2` (≈6 here) so the box stays interactive; the `pre-agent-spawn.sh` load gate enforces this. All agents use `bypassPermissions` mode + worktree isolation. Work driven by `plan/log/dependency-graph.md`.
 
 **RAM monitoring**: Use `free -m` "available" column (not "free"). "free" excludes reclaimable disk cache. Hooks check "available" before allowing agent spawns.
+
+**CPU / concurrency cap (the binding limit)**: The real bottleneck on this box is CPU, not RAM — agents are cheap while idle (waiting on the API) but each *active* one bursts a core during compile/test. With no ceiling, load oversubscribes (it hit 13–16 on 8 cores), which starves sshd and drops interactive SSH sessions. `pre-agent-spawn.sh` therefore hard-blocks a new spawn when the **1-min load average ≥ `cores − 2`** (the `JS2WASM_MAX_LOAD` env var; default leaves ~2 cores for the lead/IDE/sshd/system). It gates on *load*, not a process count, because the harness keeps a warm `claude.exe` pool (`--bg-spare`/`--bg-pty-host`) that makes process-counting a poor proxy for active agents. Raise `JS2WASM_MAX_LOAD` to trade SSH responsiveness for throughput.
 
 **Memory budget** (measured peaks via `/proc/[pid]/status` VmHWM):
 - Fixed: Cursor ~1,400MB + system ~1,200MB + tech lead ~1,400MB = **~4,000MB**
 - Dev agent: ~700MB peak (no local test262)
 - Test262 (CI only): ~4,300MB peak per shard — runs in GitHub Actions, not locally
-- **Max 8 devs** (~9.6GB headroom). Check `free -m` available before spawning.
+- RAM allows ~8 devs (~9.6GB headroom), but **CPU is the tighter limit**: target ~`cores − 2` (≈6) concurrent *active* agents. The `pre-agent-spawn.sh` load gate (see "CPU / concurrency cap" above) enforces it; `free -m` available is still a secondary floor.
 
 ### Agent lifecycle — when to spawn, skill, or terminate
 


### PR DESCRIPTION
## Problem

The `pre-agent-spawn.sh` hook only **hard-blocked on RAM** (`< 1500 MB`) and merely *warned* above 8 "Claude processes". That count was meaningless: `ps aux | grep -c '[c]laude'` returns ~31 on this box — shell wrappers, the symphony channel, statusline scripts, and the harness's warm `--bg-spare`/`--bg-pty-host` pool, not real agents. So **nothing actually capped concurrency**, and the box oversubscribed: load hit **13–16 on 8 cores**, which starves `sshd` and drops interactive SSH sessions (this surfaced as "constant SSH disconnects" — *not* OOM: cgroup `oom_kill 0`, memory PSI `0.00`, ~9.5 GB free).

## Fix

Gate on the **1-min load average** instead of a process count. Agents are cheap while idle (waiting on the API) but each *active* one bursts a core during compile/test, so **load is the signal that matches the hardware**. The hook now hard-blocks a new spawn when:

- `load1 >= cores − 2` (default; leaves ~2 cores for the lead/IDE/sshd/system), or
- available RAM `< 1500 MB` (unchanged floor).

Both are env-tunable: `JS2WASM_MAX_LOAD`, `JS2WASM_MIN_RAM_MB`.

**Why load, not a count:** the harness keeps a warm `claude.exe` pool whose size doesn't track active-agent count (12 procs while solo, 11 during the load-13 burst), so process-counting is a poor proxy. Load-average gates on real CPU use — an idle agent costs ~0, a compiling one costs a core — which is exactly the resource that drops SSH when exhausted.

## Also

`CLAUDE.md` updated to state that **CPU is the binding constraint, not RAM** (the old "max 8 devs" was a RAM estimate; the practical cap is ~`cores − 2` *active* agents) and to document the gate + env knobs.

## Verification

- Blocks at high load (`load1 >= MAX_LOAD`) and low RAM; passes under headroom; still warns on missing `team_name`. Tested with `JS2WASM_MAX_LOAD` high/low and `JS2WASM_MIN_RAM_MB` high.
- Applied live on the affected box; at load 12 it correctly blocks new spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)