### PR TITLE
fix(#2076): standalone Object.assign builds literal args as native $Objects

### DIFF
--- a/plan/issues/2076-standalone-object-assign-drops-sources.md
+++ b/plan/issues/2076-standalone-object-assign-drops-sources.md
@@ -1,10 +1,12 @@
 ---
 id: 2076
 title: "standalone: Object.assign drops later sources entirely — native __object_assign never iterates the sources vec"
-status: ready
+status: done
+assignee: ttraenkler/dv1
+completed: 2026-06-16
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -72,3 +74,48 @@ touches. **Recommend holding #2076 until #2009 PR-1 lands**, then re-evaluating
 whether `__object_assign`'s writeback works against the new $shape.
 
 (The paired #2077 `.name` half also intersects #2072 boxing per the task note.)
+
+## Resolution (2026-06-16, dv1)
+
+The earlier "writeback never lands" diagnosis was a misread — `__extern_set`
+and `__object_assign` are both correct. The real fault is upstream, at the
+`Object.assign` CALL SITE (`src/codegen/expressions/calls.ts`): the target and
+source object-literal ARGUMENTS were compiled with an `externref` contextual
+type, which routes them through `compileObjectLiteral`'s **closed-struct** path
+(their TS contextual type, inferred from `Object.assign`'s generic lib
+signature, is a concrete object type — not `any` — so the open-`$Object`
+diversion at `literals.ts:864` never fires). `__object_assign` then reads each
+operand via `ref.test $Object` + a `$PropEntry` walk, which a closed struct
+fails — so the sources are skipped entirely AND the target's own keys are
+invisible to `Object.keys` (`__obj_ordered` sizes its output by `$Object.count`,
+which a closed struct doesn't have).
+
+This is why a probe like `Object.assign({a:1}, {a:3}).a` returned 1 (the read
+`.a` hit a struct field) while `Object.keys` returned 0 (no `$Object` to
+enumerate) — two facets of the same closed-struct routing, NOT a writeback bug.
+
+**Fix**: a `compileObjectAssignArg` helper (calls.ts) that, in standalone mode,
+builds a plain data-property / spread object-literal argument directly as a
+native `$Object` via the now-exported `compileObjectLiteralAsExternref`, so
+`__object_assign` recognises both target and sources. Identifiers, calls and
+accessor-bearing literals keep the ordinary `compileExpression` path. Host / gc
+/ wasi modes are untouched (the `__object_assign` JS import owns those).
+
+Independent of #2009 — no struct-shape change was needed.
+
+## Test Results (2026-06-16, standalone, host-import-free)
+
+`tests/issue-2076.test.ts` — 8/8 pass:
+
+| case | before | after |
+|---|---|---|
+| `Object.assign({a:1},{b:2,a:3})` → `a*10+b` | 10 | 32 |
+| `Object.keys(Object.assign({a:1},{b:2})).length` | 0 | 2 |
+| 3 sources, last wins (`{a:1},{a:2},{a:3}`) | 1 | 3 |
+| target mutated in place (`src.b`) | 0 | 2 |
+| non-literal source variable | (skipped) | 32 |
+| spread inside source literal | (skipped) | 32 |
+| empty source `{}` keeps target keys | 0 | 1 |
+| no source returns target | 2 | 2 |
+
+No regressions in `issue-2127.test.ts` / `issue-1901.test.ts` (13/13).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -56,7 +56,13 @@ import {
   nativeStringType,
   resolveWasmType,
 } from "../index.js";
-import { compileArrayConstructorCall, compileSymbolCall, resolveComputedKeyExpression } from "../literals.js";
+import {
+  compileArrayConstructorCall,
+  compileObjectLiteralAsExternref,
+  compileSymbolCall,
+  resolveComputedKeyExpression,
+  resolvePropertyNameText,
+} from "../literals.js";
 import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
 import { emitJsonParsePrimitive, emitJsonQuoteString } from "../json-runtime.js";
 import {
@@ -203,6 +209,46 @@ const BUILTIN_CLASS_NAMES = new Set([
  * literal to `false`. Returns `undefined` when the value isn't statically
  * resolvable (caller should fall back to the runtime path).
  */
+/**
+ * (#2076) Compile an `Object.assign(target, ...sources)` argument, pushing an
+ * externref onto the stack. Under `--target standalone`, the native
+ * `__object_assign` reads each operand by `ref.test $Object` and iterates its
+ * `$PropEntry` table; a *closed-struct* literal fails that test, so its
+ * properties are silently dropped and `Object.keys` on the result sees nothing
+ * (the bug). The struct path is what `compileObjectLiteral` picks for a literal
+ * argument whose TS contextual type — here `Object.assign`'s generic signature
+ * resolves it to a CONCRETE object type, not `any` — so the open-`$Object`
+ * diversion (literals.ts) never fires.
+ *
+ * Fix: when the argument is a *plain data-property / spread* object literal
+ * (no accessors, methods, or computed/symbol keys — the same shapes the
+ * `$Object` builder accepts at literals.ts:870-874), build it directly as a
+ * native `$Object` via `compileObjectLiteralAsExternref` so `__object_assign`
+ * recognises it. Any other argument (identifiers, calls, accessor-bearing
+ * literals) keeps the ordinary `compileExpression` path. Standalone-only — host
+ * / WASI mode owns the `__object_assign` JS import and is untouched.
+ */
+function compileObjectAssignArg(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
+  if (
+    ctx.standalone &&
+    ts.isObjectLiteralExpression(arg) &&
+    arg.properties.length > 0 &&
+    arg.properties.every(
+      (p) => ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p) || ts.isSpreadAssignment(p),
+    ) &&
+    arg.properties.every((p) => ts.isSpreadAssignment(p) || resolvePropertyNameText(ctx, p) !== undefined)
+  ) {
+    const objResult = compileObjectLiteralAsExternref(ctx, fctx, arg);
+    if (objResult) {
+      if (objResult.kind !== "externref") coerceType(ctx, fctx, objResult, { kind: "externref" });
+      return;
+    }
+    // fall through to the ordinary path if the $Object builder declined.
+  }
+  const t = compileExpression(ctx, fctx, arg, { kind: "externref" });
+  if (t && t.kind !== "externref") coerceType(ctx, fctx, t, { kind: "externref" });
+}
+
 function staticToBoolean(expr: ts.Expression): boolean | undefined {
   while (
     ts.isAsExpression(expr) ||
@@ -5161,8 +5207,9 @@ function compileCallExpression(
       expr.arguments.length >= 1
     ) {
       const targetArg = expr.arguments[0]!;
-      const targetType = compileExpression(ctx, fctx, targetArg, { kind: "externref" });
-      if (targetType && targetType.kind !== "externref") coerceType(ctx, fctx, targetType, { kind: "externref" });
+      // (#2076) Object-literal operands must build as native $Objects in
+      // standalone so __object_assign's `ref.test $Object` recognises them.
+      compileObjectAssignArg(ctx, fctx, targetArg);
       // Build the variadic `...sources` list. Under --target standalone there is
       // no JS array, so the native __object_assign iterates a $ObjVec built by
       // the native $ObjVec builders (__objvec_new / __objvec_push) instead of the
@@ -5195,8 +5242,7 @@ function compileCallExpression(
         fctx.body.push({ op: "local.set", index: sourcesLocal });
         for (let i = 1; i < expr.arguments.length; i++) {
           fctx.body.push({ op: "local.get", index: sourcesLocal });
-          const srcType = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "externref" });
-          if (srcType && srcType.kind !== "externref") coerceType(ctx, fctx, srcType, { kind: "externref" });
+          compileObjectAssignArg(ctx, fctx, expr.arguments[i]!);
           fctx.body.push({ op: "call", funcIdx: arrPushIdx });
         }
         fctx.body.push({ op: "local.get", index: targetLocal });

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -170,7 +170,7 @@ export function ensureComputedPropertyFields(
  *
  * Returns externref, or null if the host import is unavailable.
  */
-function compileObjectLiteralAsExternref(
+export function compileObjectLiteralAsExternref(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.ObjectLiteralExpression,

--- a/tests/issue-2076.test.ts
+++ b/tests/issue-2076.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2076 — standalone Object.assign drops every source (and the target's own
+// keys vanished from Object.keys). Root cause: the call site compiled the
+// target / source object-literal arguments with an externref contextual type,
+// which routed them to the CLOSED-STRUCT path (their TS contextual type from
+// Object.assign's generic signature resolves to a concrete object type, not
+// `any`). The native __object_assign reads each operand via `ref.test $Object`
+// + a $PropEntry walk, which a closed struct fails — so nothing copied and
+// Object.keys saw zero keys.
+//
+// Fix (expressions/calls.ts): in standalone mode build plain data-property /
+// spread object-literal arguments directly as native $Objects via
+// compileObjectLiteralAsExternref, so __object_assign recognises them.
+//
+// Each test compiles with `target: "standalone"`, asserts ZERO host imports
+// (pure Wasm), and runs against the WASI polyfill.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<{ value: number; hostImports: number }> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const module = await WebAssembly.compile(result.binary);
+  // Standalone must be host-import-free: only the WASI snapshot module is allowed.
+  const hostImports = WebAssembly.Module.imports(module).filter((i) => i.module !== "wasi_snapshot_preview1").length;
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, hostImports };
+}
+
+describe("#2076 — standalone Object.assign copies sources", () => {
+  it("the repro: later source overrides + new key both land", async () => {
+    const { value, hostImports } = await runStandalone(
+      `export function test(): number {
+         const t: any = Object.assign({a:1}, {b:2, a:3});
+         return (t.a as number) * 10 + (t.b as number);
+       }`,
+    );
+    expect(hostImports).toBe(0);
+    expect(value).toBe(32); // a=3, b=2
+  });
+
+  it("Object.keys of the result reflects all merged keys", async () => {
+    const { value, hostImports } = await runStandalone(
+      `export function test(): number {
+         const o: any = Object.assign({a:1}, {b:2});
+         return Object.keys(o).length;
+       }`,
+    );
+    expect(hostImports).toBe(0);
+    expect(value).toBe(2);
+  });
+
+  it("multiple sources apply in order — last wins", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const o: any = Object.assign({a:1}, {a:2}, {a:3});
+         return o.a as number;
+       }`,
+    );
+    expect(value).toBe(3);
+  });
+
+  it("mutates the target in place", async () => {
+    // The source's properties land on the ORIGINAL target object (read back
+    // through the target binding, not the return value). Object identity of the
+    // return value (`r === src`) depends on a separate standalone `===`
+    // limitation and is intentionally out of scope here.
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const src: any = {a:1};
+         Object.assign(src, {b:2});
+         return src.b as number;
+       }`,
+    );
+    expect(value).toBe(2);
+  });
+
+  it("a non-literal source variable still copies", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const s: any = {b:2, a:3};
+         const t: any = Object.assign({a:1}, s);
+         return (t.a as number) * 10 + (t.b as number);
+       }`,
+    );
+    expect(value).toBe(32);
+  });
+
+  it("a spread inside the source literal is honored", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const base: any = {b:2};
+         const t: any = Object.assign({a:1}, {...base, a:3});
+         return (t.a as number) * 10 + (t.b as number);
+       }`,
+    );
+    expect(value).toBe(32);
+  });
+
+  it("empty source leaves the target's own keys intact", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const o: any = Object.assign({a:1}, {});
+         return Object.keys(o).length;
+       }`,
+    );
+    expect(value).toBe(1);
+  });
+
+  it("no source at all returns the target unchanged", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number {
+         const o: any = Object.assign({a:1, b:2});
+         return Object.keys(o).length;
+       }`,
+    );
+    expect(value).toBe(2);
+  });
+});


### PR DESCRIPTION
## #2076 — standalone `Object.assign` dropped every source (and the target's own keys)

### Root cause
The `Object.assign(target, ...sources)` call site (`src/codegen/expressions/calls.ts`) compiled the target and source object-literal **arguments** with an `externref` contextual type. That routes them through `compileObjectLiteral`'s **closed-struct** path: their TS contextual type — inferred from `Object.assign`'s generic lib signature — is a concrete object type, not `any`, so the open-`$Object` diversion at `literals.ts:864` never fires.

The native `__object_assign` reads each operand via `ref.test $Object` + a `$PropEntry` walk. A closed struct fails that test, so:
- every source was skipped → no properties copied;
- the target's own keys were invisible to `Object.keys` (`__obj_ordered` sizes its output by `$Object.count`, which a closed struct doesn't carry).

This explains the earlier confusing probe (`Object.assign({a:1},{a:3}).a` → 1 but `Object.keys` → 0): the `.a` read hit a struct field while enumeration found no `$Object`. It was NOT a writeback bug, and is independent of #2009 (no struct-shape change needed).

### Fix
`compileObjectAssignArg` (calls.ts): in standalone mode, build a plain data-property / spread object-literal argument directly as a native `$Object` via the now-exported `compileObjectLiteralAsExternref`. Identifiers, calls, and accessor-bearing literals keep the ordinary `compileExpression` path. Host / gc / wasi modes are untouched (the `__object_assign` JS import owns those).

### Tests
`tests/issue-2076.test.ts` — 8 standalone, host-import-free cases:

| case | before | after |
|---|---|---|
| `Object.assign({a:1},{b:2,a:3})` → `a*10+b` | 10 | 32 |
| `Object.keys(Object.assign({a:1},{b:2})).length` | 0 | 2 |
| 3 sources, last wins | 1 | 3 |
| target mutated in place | 0 | 2 |
| non-literal source variable | — | 32 |
| spread inside source literal | — | 32 |
| empty source `{}` keeps target keys | 0 | 1 |
| no source returns target | 2 | 2 |

No regressions in `issue-2127` / `issue-1901` (13/13). `tsc --noEmit` clean; biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)