### PR TITLE
refactor(#2086): single source for implicit-derived-ctor param prefix + cross-lane guard

### DIFF
--- a/plan/issues/2086-single-implicit-derived-ctor-synthesis.md
+++ b/plan/issues/2086-single-implicit-derived-ctor-synthesis.md
@@ -1,10 +1,12 @@
 ---
 id: 2086
 title: "single implicit-derived-ctor synthesis shared by all three representation paths (externref / WasmGC struct / standalone)"
-status: ready
+status: done
+completed: 2026-06-16
+assignee: ttraenkler/dv3
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -48,3 +50,44 @@ plan/log/analysis-2026-06/05-structure-review.md §2a.
 #1833 (externref fix, merged), #2082 (struct fix, merged), #2078
 (standalone, suspended) are the point fixes; no issue owns the
 consolidation. New (analysis program).
+
+## Resolution (2026-06-16, dv3)
+
+**Consolidated the synthesized parameter-prefix rule onto one source.** The
+externref-forwarder (#1833) and forwarded-ancestor-ctor-param (#2082) prefixes
+were computed twice — once in the func-type registration phase
+(`class-bodies.ts` ~612) and again in the `FunctionContext`-build phase
+(~1280) — and the two copies were the exact drift pair the issue describes.
+Both phases now call a single helper
+`computeImplicitDerivedCtorPrefix(ctx, decl, className, ctor)` that returns
+`{ implicitBuiltinParent, implicitForwarderArity, implicitStructCtorParams,
+prefixParams }`; the type phase maps `prefixParams.map(p => p.type)` and the
+fctx phase spreads `prefixParams` directly. The two lanes can no longer
+disagree about arity, names, or `ref→ref_null` widening.
+
+**Cross-lane regression guard (acceptance (2)).** `tests/issue-2086.test.ts`
+runs the *same* implicit-derived-ctor forwarding scenario through all three
+representation lanes in one file — Lane A (WasmGC-struct, host), Lane B
+(externref-backed `DataView`), Lane C (standalone, asserting no `env::` leak).
+Verified it has teeth: deleting the synthesized prefix from the fctx-build
+phase fails **all three** Lane A/B/C cases (Dog_init arity mismatch, Sub_new
+local-index error, standalone numeric-forward). #1833/#2082/#2078 suites all
+stay green (21 tests across the 4 files); `tsc --noEmit` clean.
+
+**Finding (informs the follow-up below).** Injecting the same bug into the
+*func-type-registration* prefix alone did NOT break forwarding, because the
+fctx-build phase re-registers the ctor/init func types via `addFuncType`
+(~1324), which overrides the earlier registration. So the fctx-build prefix is
+the authoritative one; the type-registration prefix is effectively belt-and-
+braces. Folding both onto the shared helper removes the chance they diverge,
+which is the point — but it confirms the body-emission phase is where the real
+behaviour lives.
+
+**Carried forward (follow-up, not done here).** The deeper unification — a
+single `synthesizeImplicitDerivedCtor(repr)` that also owns the *body-emission*
+divergence (struct-default fill vs externref host-alloc vs standalone zeroed
+base fields, ~1340–1530) — is a high-blast-radius refactor of the most fragile
+class-construction code and was scoped out to avoid a class-ctor regression
+mid-sprint. The param-prefix consolidation + the cross-lane guard close the
+named drift pair and lock the three lanes; the body-emit unification can land
+later against the guard now in place.

--- a/plan/issues/2086-single-implicit-derived-ctor-synthesis.md
+++ b/plan/issues/2086-single-implicit-derived-ctor-synthesis.md
@@ -83,11 +83,13 @@ braces. Folding both onto the shared helper removes the chance they diverge,
 which is the point — but it confirms the body-emission phase is where the real
 behaviour lives.
 
-**Carried forward (follow-up, not done here).** The deeper unification — a
-single `synthesizeImplicitDerivedCtor(repr)` that also owns the *body-emission*
-divergence (struct-default fill vs externref host-alloc vs standalone zeroed
-base fields, ~1340–1530) — is a high-blast-radius refactor of the most fragile
-class-construction code and was scoped out to avoid a class-ctor regression
-mid-sprint. The param-prefix consolidation + the cross-lane guard close the
+**Carried forward → #2181 (follow-up, sprint 63, senior-dev).** The deeper
+unification — a single `synthesizeImplicitDerivedCtorBody(repr)` that also owns
+the *body-emission* divergence (struct-default fill vs externref host-alloc vs
+standalone zeroed base fields, ~1340–1530) — is a high-blast-radius refactor of
+the most fragile class-construction code and was scoped out to avoid a class-ctor
+regression mid-sprint. It is filed as **#2181** (feasibility:hard, routed to
+senior-dev), protected by the #2086 cross-lane guard. The param-prefix
+consolidation + the cross-lane guard close the
 named drift pair and lock the three lanes; the body-emit unification can land
 later against the guard now in place.

--- a/plan/issues/2181-implicit-derived-ctor-body-emit-unification.md
+++ b/plan/issues/2181-implicit-derived-ctor-body-emit-unification.md
@@ -1,0 +1,74 @@
+---
+id: 2181
+title: "unify implicit-derived-ctor BODY emission across the three representation lanes (struct-fill / externref-alloc / standalone-zeroed)"
+status: ready
+sprint: 63
+created: 2026-06-16
+updated: 2026-06-16
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: classes
+goal: core-semantics
+related: [2086, 1833, 2082, 2078]
+origin: "2026-06-16 follow-up carved out of #2086 (param-prefix consolidation landed; body-emit unification deferred)"
+---
+
+# #2181 — one body-emission rule for the implicit derived constructor
+
+## Problem
+
+#2086 consolidated the **parameter-prefix** half of implicit-derived-ctor
+synthesis onto a single helper (`computeImplicitDerivedCtorPrefix`), used by
+both the func-type-registration and `FunctionContext`-build phases. The
+**body-emission** half is still realized three times, one per representation
+lane:
+
+- **WasmGC-struct** (`class-bodies.ts` ~1340–1400): pushes per-field default
+  values then `struct.new`, replays parent field initializers + ctor-body
+  `this.x = …` assignments, calls the parent `_init` (#2082).
+- **externref-backed** (~1347–1352, ~1500–1520): `__self` is a null externref
+  set by the host-import `super(...)`; no `struct.new`; forwards `__arg{i}`
+  externrefs to the built-in parent (#1833).
+- **standalone** (the #2078 lane): zeroed base fields + replayed base ctor body
+  with no `env::` host imports.
+
+These are the same drift surface that bred #1833/#2082/#2078 — a forwarding or
+field-replay fix in one lane can still miss the others, even though the
+param-prefix can no longer diverge.
+
+## Fix direction
+
+Extract a single `synthesizeImplicitDerivedCtorBody(ctx, fctx, repr, …)`
+parameterized by representation (`struct` | `externref` | `standalone`), so
+the three current inline blocks become thin wrappers selecting `repr`. The
+cross-lane regression guard from #2086 (`tests/issue-2086.test.ts`) already
+exercises all three lanes with the same forwarding scenario and is proven to
+fail every lane on an injected bug — use it as the safety net for the
+extraction.
+
+## Why deferred from #2086
+
+This is a **high-blast-radius refactor of the most fragile class-construction
+code** (struct allocation, `_init` splitting #1965, externref host-alloc,
+standalone field zeroing). #2086 is a `medium` issue and all three lanes
+already pass; doing the body-emit extraction inside it risked a >10-test
+class-ctor regression mid-sprint. The param-prefix consolidation + the
+cross-lane guard landed in #2086; this issue carries the remaining body-emit
+unification with the guard already in place to protect it.
+
+## Acceptance criteria
+
+- The three representation lanes emit the implicit-derived-ctor body from ONE
+  `synthesizeImplicitDerivedCtorBody` (or equivalent single source).
+- `tests/issue-2086.test.ts` + #1833/#2082/#2078 suites stay green; a
+  deliberately-injected body-emit bug fails all three lanes via the #2086 guard.
+- No test262 regression (CI gate).
+
+## Notes
+
+Route to **senior-developer** — same architectural-consolidation flavor as the
+class-object-model work (#2101/#2158). `tsc --noEmit` + the #2086 guard are the
+local checks; CI validates conformance.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -272,6 +272,60 @@ function findNearestAncestorCtorParams(
   return undefined;
 }
 
+/**
+ * #2086: single source of truth for the parameter prefix synthesized for an
+ * implicit derived constructor (`constructor(...args){ super(...args) }`,
+ * §15.7.14). The rule was previously realized twice — once for func-type
+ * registration and once for the `FunctionContext` build — and the two copies
+ * drifted (each point fix #1833/#2082/#2078 landed in one phase or one
+ * representation lane). Both phases now derive the prefix from this function.
+ *
+ * `implicitForwarderArity` (the externref-backed built-in lane, #1833) and
+ * `implicitStructCtorParams` (the WasmGC-struct lane, #2082) are mutually
+ * exclusive by construction (`implicitStructCtorParams` is only computed for a
+ * non-builtin parent), so the returned list has at most one of the two shapes.
+ * `ctor` (the explicit-constructor case) is handled by the callers, not here —
+ * this helper covers only the *implicit* (no own ctor) synthesis.
+ */
+function computeImplicitDerivedCtorPrefix(
+  ctx: CodegenContext,
+  decl: ts.ClassDeclaration | ts.ClassExpression,
+  className: string,
+  ctor: ts.ConstructorDeclaration | undefined,
+): {
+  implicitBuiltinParent: string | undefined;
+  implicitForwarderArity: number;
+  implicitStructCtorParams: ts.NodeArray<ts.ParameterDeclaration> | undefined;
+  prefixParams: { name: string; type: ValType }[];
+} {
+  const implicitBuiltinParent = !ctor ? ctx.classBuiltinParentMap.get(className) : undefined;
+  const implicitForwarderArity = implicitBuiltinParent
+    ? getImplicitExternrefForwarderArity(ctx, decl, className, implicitBuiltinParent)
+    : 0;
+  const implicitStructCtorParams =
+    !ctor && !implicitBuiltinParent ? findNearestAncestorCtorParams(ctx, className) : undefined;
+
+  const prefixParams: { name: string; type: ValType }[] = [];
+  for (let i = 0; i < implicitForwarderArity; i++) {
+    prefixParams.push({ name: `__arg${i}`, type: { kind: "externref" } });
+  }
+  if (implicitStructCtorParams) {
+    for (let pi = 0; pi < implicitStructCtorParams.length; pi++) {
+      const param = implicitStructCtorParams[pi]!;
+      const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${pi}`;
+      const paramType = ctx.checker.getTypeAtLocation(param);
+      let wasmType = resolveWasmType(ctx, paramType);
+      // Widen ref→ref_null for params with defaults (caller passes ref.null as
+      // the omitted-arg sentinel). Must match the explicit-ctor widening below.
+      if (param.initializer && wasmType.kind === "ref") {
+        wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
+      }
+      prefixParams.push({ name: paramName, type: wasmType });
+    }
+  }
+  return { implicitBuiltinParent, implicitForwarderArity, implicitStructCtorParams, prefixParams };
+}
+
 function compileExternrefArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
   const argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
   if (argResult === null) {
@@ -609,29 +663,16 @@ export function collectClassDeclaration(
   // `constructor(...args) { super(...args); }` as an externref forwarder whose
   // arity matches the parent constructor shape. Missing caller args are padded
   // as JS undefined and stripped by the runtime's `__new_<Parent>` resolver.
-  const implicitBuiltinParent = !ctor ? ctx.classBuiltinParentMap.get(className) : undefined;
-  const implicitForwarderArity = implicitBuiltinParent
-    ? getImplicitExternrefForwarderArity(ctx, decl, className, implicitBuiltinParent)
-    : 0;
-  if (implicitForwarderArity > 0) {
-    ctorParams.push(...externrefParams(implicitForwarderArity));
-  }
-  // #2082: implicit ctor of a WasmGC-struct-backed derived class (no explicit
-  // ctor, non-builtin parent) — forward the nearest ancestor ctor's params so
-  // `new Dog("rex")` actually passes "rex" through to the replayed
-  // `this.name = name` (spec §15.7.14 `constructor(...args){ super(...args) }`).
-  const implicitStructCtorParams =
-    !ctor && !implicitBuiltinParent ? findNearestAncestorCtorParams(ctx, className) : undefined;
-  if (implicitStructCtorParams) {
-    for (const param of implicitStructCtorParams) {
-      const paramType = ctx.checker.getTypeAtLocation(param);
-      let wasmType = resolveWasmType(ctx, paramType);
-      if (param.initializer && wasmType.kind === "ref") {
-        wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
-      }
-      ctorParams.push(wasmType);
-    }
-  }
+  // (#2086) Synthesize the implicit derived-ctor parameter prefix from the one
+  // shared rule. `implicitForwarderArity` (#1833, externref-backed built-in
+  // parent) and `implicitStructCtorParams` (#2082, WasmGC-struct parent) are
+  // the two lanes; the fctx-build phase below reuses the same helper.
+  const {
+    implicitForwarderArity,
+    implicitStructCtorParams,
+    prefixParams: implicitPrefixParams,
+  } = computeImplicitDerivedCtorPrefix(ctx, decl, className, ctor);
+  ctorParams.push(...implicitPrefixParams.map((p) => p.type));
   if (ctor) {
     for (let i = 0; i < ctor.parameters.length; i++) {
       const param = ctor.parameters[i]!;
@@ -1236,31 +1277,17 @@ function compileClassBodiesInner(
   if (ctorLocalIdx !== undefined) {
     const func = ctx.mod.functions[ctorLocalIdx]!;
     const params: { name: string; type: ValType }[] = [];
-    // (#1833) Match the synthetic forwarder params added during pre-registration.
-    const implicitBuiltinParent = !ctor ? ctx.classBuiltinParentMap.get(className) : undefined;
-    const implicitForwarderArity = implicitBuiltinParent
-      ? getImplicitExternrefForwarderArity(ctx, decl, className, implicitBuiltinParent)
-      : 0;
-    for (let i = 0; i < implicitForwarderArity; i++) {
-      params.push({ name: `__arg${i}`, type: { kind: "externref" } });
-    }
-    // #2082: bind the forwarded ancestor-ctor params as named locals so the
-    // replayed parent `this.x = name` assignments below resolve `name`. Must
-    // mirror the func-type registration (the implicitStructCtorParams block).
-    const implicitStructCtorParams =
-      !ctor && !implicitBuiltinParent ? findNearestAncestorCtorParams(ctx, className) : undefined;
-    if (implicitStructCtorParams) {
-      for (let pi = 0; pi < implicitStructCtorParams.length; pi++) {
-        const param = implicitStructCtorParams[pi]!;
-        const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${pi}`;
-        const paramType = ctx.checker.getTypeAtLocation(param);
-        let wasmType = resolveWasmType(ctx, paramType);
-        if (param.initializer && wasmType.kind === "ref") {
-          wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
-        }
-        params.push({ name: paramName, type: wasmType });
-      }
-    }
+    // (#2086) Match the synthetic forwarder params added during pre-registration
+    // from the SAME shared rule — `__arg{i}` externref forwarders (#1833) and/or
+    // the bound ancestor-ctor params (#2082) so the replayed parent
+    // `this.x = name` assignments below resolve `name`. `implicitForwarderArity`
+    // / `implicitStructCtorParams` are reused later in the body-emission phase.
+    const {
+      implicitForwarderArity,
+      implicitStructCtorParams,
+      prefixParams: implicitPrefixParams,
+    } = computeImplicitDerivedCtorPrefix(ctx, decl, className, ctor);
+    params.push(...implicitPrefixParams);
     if (ctor) {
       for (let pi = 0; pi < ctor.parameters.length; pi++) {
         const param = ctor.parameters[pi]!;

--- a/tests/issue-2086.test.ts
+++ b/tests/issue-2086.test.ts
@@ -1,0 +1,94 @@
+// #2086 — cross-lane regression guard for implicit-derived-ctor synthesis.
+//
+// The rule "an implicit derived constructor forwards all args to super"
+// (spec §15.7.14 — `constructor(...args) { super(...args); }`) is realized in
+// THREE representation lanes that historically drifted apart: each point fix
+// (#1833 externref-backed, #2082 WasmGC-struct, #2078 standalone) landed in one
+// lane while the others stayed broken. This file pins the SAME forwarding
+// behavior across all three lanes so a future change that breaks one lane fails
+// here immediately, regardless of which lane the author was thinking about.
+//
+// Lane A — WasmGC-struct parent, JS-host mode (the #2082 lane)
+// Lane B — externref-backed built-in parent (the #1833 lane)
+// Lane C — standalone target, no `env` host imports (the #2078 lane)
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, compileAndInstantiate } from "../src/runtime.js";
+
+// Lane A: default WasmGC-struct path under JS host.
+async function runHost(source: string): Promise<unknown> {
+  const exports = await compileAndInstantiate(source);
+  return (exports as { test: () => unknown }).test();
+}
+
+// Lane C: standalone — additionally assert NO `env::` host imports leaked, the
+// invariant #2078 guards. A drift that re-routes the synthesized ctor through a
+// host import would surface here.
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const env = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(env, `standalone leaked env imports: ${env.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+describe("#2086 implicit derived ctor forwards args — all three repr lanes", () => {
+  // --- Lane A: WasmGC-struct parent, single forwarded arg (#2082 repro) ---
+  it("Lane A (host struct): forwards a constructor arg through the implicit ctor", async () => {
+    expect(
+      await runHost(
+        `class Animal { name: string; constructor(name: string){ this.name = name; } }
+         class Dog extends Animal {}
+         export function test(): string { return new Dog("rex").name; }`,
+      ),
+    ).toBe("rex");
+  });
+
+  it("Lane A (host struct): replays the parent ctor BODY assignment through the implicit ctor", async () => {
+    expect(
+      await runHost(
+        `class Base { x: number; constructor(){ this.x = 7; } }
+         class Sub extends Base {}
+         export function test(): number { return new Sub().x; }`,
+      ),
+    ).toBe(7);
+  });
+
+  // --- Lane B: externref-backed built-in parent (#1833 repro) ---
+  it("Lane B (externref built-in): forwards every arg to the built-in parent", async () => {
+    expect(
+      await runHost(
+        `class Sub extends DataView {}
+         export function test(): number {
+           const buf = new ArrayBuffer(16);
+           const view = new Sub(buf, 4, 4);
+           return view.byteOffset;
+         }`,
+      ),
+    ).toBe(4);
+  });
+
+  // --- Lane C: standalone target (#2078 repro), env-import-free ---
+  it("Lane C (standalone): replays the parent ctor body assignment, no env leak", async () => {
+    expect(
+      await runStandalone(
+        `class Base { x: number; constructor(){ this.x = 7; } }
+         class Sub extends Base {}
+         export function test(): number { return new Sub().x; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("Lane C (standalone): forwards a numeric ctor arg through the implicit ctor, no env leak", async () => {
+    expect(
+      await runStandalone(
+        `class Base { v: number; constructor(v: number){ this.v = v; } }
+         class Sub extends Base {}
+         export function test(): number { return new Sub(42).v; }`,
+      ),
+    ).toBe(42);
+  });
+});


### PR DESCRIPTION
Resolves #2086.

## What
The synthesized parameter prefix for an implicit derived constructor (`constructor(...args){ super(...args) }`, §15.7.14) was computed **twice** in `class-bodies.ts` — once for func-type registration (~612), once for the `FunctionContext` build (~1280) — and the two copies were exactly the drift pair the issue names (#1833 externref-forwarder lane, #2082 struct-param lane). Each point fix landed in one copy/lane while the other stayed broken.

Both phases now derive the prefix from one helper, `computeImplicitDerivedCtorPrefix(ctx, decl, className, ctor)`, returning the externref-forwarder arity, the forwarded ancestor-ctor params, and the unified `{name,type}[]` prefix (matching `ref→ref_null` widening). The lanes can no longer disagree.

## Cross-lane guard (acceptance (2))
`tests/issue-2086.test.ts` runs the **same** forwarding scenario through Lane A (WasmGC-struct/host), Lane B (externref-backed `DataView`), Lane C (standalone, asserting no `env::` leak). Verified it has teeth: deleting the synthesized prefix fails **all three** lanes (Dog_init arity, Sub_new local-index, standalone numeric forward).

## Validation
- #1833 (2) + #2082 (6) + #2078 (8) + #2086 (5) = **21 tests green**
- `tsc --noEmit` clean

## Scope
Closes acceptance (1) param-prefix consolidation + (2) cross-lane guard. The deeper *body-emission* unification (struct-fill vs externref-alloc vs standalone-zeroed, high blast radius) is carried to a documented follow-up — the guard now in place protects it. See the issue Resolution for the finding that the fctx-build prefix is authoritative (func-type registration is overridden by `addFuncType` re-registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)