### PR TITLE
fix(#2095): baseline validator samples both lanes and both row classes

### DIFF
--- a/plan/issues/2095-baseline-validator-standalone-fail-rows.md
+++ b/plan/issues/2095-baseline-validator-standalone-fail-rows.md
@@ -1,10 +1,12 @@
 ---
 id: 2095
 title: "baseline validator: sample the standalone lane and fail rows, not just 50 host pass rows"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dv2
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -45,3 +47,52 @@ the #1897 status reconciliation (merged but stale `in-review`).
 
 #1218 built the pass-row sampler; lane/class coverage unfiled. New
 (analysis program).
+
+## Resolution (2026-06-16, dv2)
+
+The validator (`scripts/validate-test262-baseline.ts`) now exercises **both
+lanes and both row classes**:
+
+- **Lanes**: HOST (gc) + STANDALONE. The standalone-lane baseline JSONL
+  (`test262-standalone-current.jsonl`) is fetched via two new exports on
+  `scripts/fetch-baseline-jsonl.mjs` — `ensureStandaloneBaselineJsonl()` /
+  `STANDALONE_BASELINE_CACHE_PATH` / `STANDALONE_BASELINE_REMOTE_URL` (the
+  fetch+cache core was refactored into a shared lane-parameterised helper;
+  `--standalone` CLI flag added). If the standalone baseline is unavailable
+  (fresh seed), the validator degrades to host-only with a warning rather than
+  failing.
+- **Row classes**: N `pass` rows per lane (must STILL pass — the #1218 floor
+  check) + M `fail` rows per lane (must STILL fail — a `fail` row that now
+  PASSES is flagged as stale-baseline drift that inflates the regression-gate
+  `improvements` count and can mask a real regression). Defaults
+  `SAMPLE_SIZE=50`, `FAIL_SAMPLE_SIZE=25`; one deterministic PRNG consumed in a
+  fixed lane/class order keeps the sample reproducible from the seed.
+- Standalone rows compile+run in the standalone lane via a new optional
+  `target` parameter threaded into `runTest262File` (`tests/test262-runner.ts`);
+  the instantiation path is mode-agnostic (`buildImports` yields an empty
+  import object for a standalone binary), so only the `compile()` target
+  changed.
+
+### Acceptance criteria — met
+- ✅ Validator exercises both lanes and both row classes (verified end-to-end:
+  host 32,734 pass / 14,072 fail; standalone 21,184 pass / 11,551 fail sampled
+  cleanly).
+- ✅ CI-time increase bounded: ~0.76 s/row measured; default ~150 rows
+  (50+25 × 2 lanes) ≈ under 2 min total, roughly +1 min over the host-only
+  pass-row run.
+
+### Files
+- `scripts/fetch-baseline-jsonl.mjs` — standalone lane fetch (URL/path exports,
+  `ensureStandaloneBaselineJsonl`, shared `ensureLaneBaselineJsonl` core,
+  `--standalone` CLI).
+- `scripts/validate-test262-baseline.ts` — dual-lane, dual-row-class sampler
+  (`validateLane` / `validateRowClass`).
+- `tests/test262-runner.ts` — optional `target` param on `runTest262File`.
+- `tests/issue-2095-baseline-validator-lanes.test.ts` — pins the standalone
+  fetch exports + the standalone runner target.
+
+### Test Results
+- `tests/issue-2095-baseline-validator-lanes.test.ts` — 2/2 pass.
+- End-to-end validator smoke (SAMPLE_SIZE=4 FAIL_SAMPLE_SIZE=2, both lanes) —
+  12 rows, 0 discrepancies, exit 0.
+- `tsc --noEmit` — clean for changed files.

--- a/scripts/fetch-baseline-jsonl.mjs
+++ b/scripts/fetch-baseline-jsonl.mjs
@@ -49,8 +49,16 @@ const REPO_ROOT = resolve(__dirname, "..");
 export const BASELINE_REMOTE_URL =
   "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.jsonl";
 
+// (#2095) The STANDALONE lane has its own baseline JSONL in the same baselines
+// repo, refreshed by the `promote-baseline` job alongside the host JSONL. The
+// validator (#2095) samples it so a rotted standalone baseline can't silently
+// weaken the #1897 standalone regression floor.
+export const STANDALONE_BASELINE_REMOTE_URL =
+  "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.jsonl";
+
 export const BASELINE_CACHE_DIR = resolve(REPO_ROOT, ".test262-cache");
 export const BASELINE_CACHE_PATH = resolve(BASELINE_CACHE_DIR, "test262-current.jsonl");
+export const STANDALONE_BASELINE_CACHE_PATH = resolve(BASELINE_CACHE_DIR, "test262-standalone-current.jsonl");
 
 // Sanity-check thresholds — a healthy baseline has ~43k entries and is ~15 MB.
 // Smaller than this almost certainly means a partial download or a corrupted
@@ -66,21 +74,20 @@ const MIN_REASONABLE_LINES = 5_000; // ~43k entries today
  * @param {string} targetPath absolute path to write to
  * @returns {Promise<{ bytes: number; lines: number }>}
  */
-async function downloadTo(targetPath) {
-  const res = await fetch(BASELINE_REMOTE_URL, {
+async function downloadTo(targetPath, url = BASELINE_REMOTE_URL) {
+  const res = await fetch(url, {
     redirect: "follow",
     headers: { "User-Agent": "js2wasm-baseline-fetcher/1.0" },
   });
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status} ${res.statusText} fetching ${BASELINE_REMOTE_URL}`);
+    throw new Error(`HTTP ${res.status} ${res.statusText} fetching ${url}`);
   }
   const text = await res.text();
   const lines = text.split("\n").filter((l) => l.trim().length > 0).length;
   const bytes = Buffer.byteLength(text, "utf-8");
   if (bytes < MIN_REASONABLE_BYTES || lines < MIN_REASONABLE_LINES) {
     throw new Error(
-      `Downloaded baseline looks truncated (bytes=${bytes}, lines=${lines}). ` +
-        `Refusing to write. Source: ${BASELINE_REMOTE_URL}`,
+      `Downloaded baseline looks truncated (bytes=${bytes}, lines=${lines}). ` + `Refusing to write. Source: ${url}`,
     );
   }
   mkdirSync(dirname(targetPath), { recursive: true });
@@ -100,39 +107,72 @@ async function downloadTo(targetPath) {
  * @returns {Promise<string>} absolute path to a JSONL file ready to read
  */
 export async function ensureBaselineJsonl(opts = {}) {
+  return ensureLaneBaselineJsonl(BASELINE_REMOTE_URL, BASELINE_CACHE_PATH, "test262-current", opts);
+}
+
+/**
+ * (#2095) Standalone-lane analog of {@link ensureBaselineJsonl}. Fetches
+ * `test262-standalone-current.jsonl` from the baselines repo to
+ * `STANDALONE_BASELINE_CACHE_PATH`. Same idempotent + graceful-fallback
+ * semantics as the host fetch.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.force]
+ * @param {boolean} [opts.noCache]
+ * @returns {Promise<string>} absolute path to a standalone JSONL ready to read
+ */
+export async function ensureStandaloneBaselineJsonl(opts = {}) {
+  return ensureLaneBaselineJsonl(
+    STANDALONE_BASELINE_REMOTE_URL,
+    STANDALONE_BASELINE_CACHE_PATH,
+    "test262-standalone-current",
+    opts,
+  );
+}
+
+/**
+ * Shared fetch+cache core for a single lane's baseline JSONL.
+ *
+ * @param {string} remoteUrl   raw.githubusercontent URL of the lane's JSONL
+ * @param {string} cachePath   absolute local cache path for the lane
+ * @param {string} stem        cache-file stem, used for the --no-cache tmp name
+ * @param {{force?: boolean, noCache?: boolean}} [opts]
+ * @returns {Promise<string>}
+ */
+async function ensureLaneBaselineJsonl(remoteUrl, cachePath, stem, opts = {}) {
   const { force = false, noCache = false } = opts;
 
   if (noCache) {
-    const tmpPath = resolve(BASELINE_CACHE_DIR, `test262-current.${process.pid}.tmp.jsonl`);
-    await downloadTo(tmpPath);
+    const tmpPath = resolve(BASELINE_CACHE_DIR, `${stem}.${process.pid}.tmp.jsonl`);
+    await downloadTo(tmpPath, remoteUrl);
     return tmpPath;
   }
 
-  if (!force && existsSync(BASELINE_CACHE_PATH)) {
-    const sz = statSync(BASELINE_CACHE_PATH).size;
+  if (!force && existsSync(cachePath)) {
+    const sz = statSync(cachePath).size;
     if (sz >= MIN_REASONABLE_BYTES) {
-      return BASELINE_CACHE_PATH;
+      return cachePath;
     }
     // Cached file exists but looks suspicious — fall through and re-download.
     console.warn(`[fetch-baseline-jsonl] cached file is suspiciously small (${sz} bytes); re-downloading.`);
   }
 
   try {
-    const { bytes, lines } = await downloadTo(BASELINE_CACHE_PATH);
+    const { bytes, lines } = await downloadTo(cachePath, remoteUrl);
     console.log(
-      `[fetch-baseline-jsonl] downloaded ${BASELINE_REMOTE_URL} -> ${BASELINE_CACHE_PATH} ` +
+      `[fetch-baseline-jsonl] downloaded ${remoteUrl} -> ${cachePath} ` +
         `(${bytes.toLocaleString()} bytes, ${lines.toLocaleString()} entries).`,
     );
-    return BASELINE_CACHE_PATH;
+    return cachePath;
   } catch (e) {
     // If we already have a cached copy, fall back to it — better stale than
     // nothing. Callers that need fresh data should pass `force: true`.
-    if (existsSync(BASELINE_CACHE_PATH)) {
+    if (existsSync(cachePath)) {
       console.warn(
         `[fetch-baseline-jsonl] download failed (${e instanceof Error ? e.message : e}); ` +
-          `using existing cache at ${BASELINE_CACHE_PATH}.`,
+          `using existing cache at ${cachePath}.`,
       );
-      return BASELINE_CACHE_PATH;
+      return cachePath;
     }
     throw e;
   }
@@ -144,20 +184,25 @@ if (process.argv[1] && resolve(process.argv[1]) === __filename) {
   const force = args.includes("--force");
   const noCache = args.includes("--no-cache");
   const printPath = args.includes("--print-path");
+  const standalone = args.includes("--standalone"); // (#2095) fetch the standalone lane JSONL
+
+  const cachePath = standalone ? STANDALONE_BASELINE_CACHE_PATH : BASELINE_CACHE_PATH;
+  const ensure = standalone ? ensureStandaloneBaselineJsonl : ensureBaselineJsonl;
+  const remoteUrl = standalone ? STANDALONE_BASELINE_REMOTE_URL : BASELINE_REMOTE_URL;
 
   if (printPath) {
-    process.stdout.write(`${BASELINE_CACHE_PATH}\n`);
+    process.stdout.write(`${cachePath}\n`);
     process.exit(0);
   }
 
-  ensureBaselineJsonl({ force, noCache })
+  ensure({ force, noCache })
     .then((path) => {
       if (force || noCache) process.stdout.write(`${path}\n`);
       process.exit(0);
     })
     .catch((e) => {
       console.error(`[fetch-baseline-jsonl] fatal: ${e instanceof Error ? e.message : e}`);
-      console.error(`[fetch-baseline-jsonl] upstream: ${BASELINE_REMOTE_URL}`);
+      console.error(`[fetch-baseline-jsonl] upstream: ${remoteUrl}`);
       console.error(`[fetch-baseline-jsonl] if the upstream URL has changed, update scripts/fetch-baseline-jsonl.mjs.`);
       process.exit(1);
     });

--- a/scripts/validate-test262-baseline.ts
+++ b/scripts/validate-test262-baseline.ts
@@ -1,49 +1,64 @@
 #!/usr/bin/env -S npx tsx
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
-// #1218 — Auto-validate the test262 baseline by spot-checking 50 random
-// "pass" entries against the current `main` HEAD compiler.
+// #1218 / #2095 — Auto-validate the test262 baselines by spot-checking random
+// rows against the current `main` HEAD compiler.
 //
 // Why: the baseline JSONL is what `dev-self-merge` Step 4 reads for
-// bucket-by-path regression analysis. If the baseline gets corrupted
-// (mass-rewritten by a malformed merge, desynced by a workflow bug), the
-// bucket analysis silently produces wrong answers and the merge gate
-// becomes unreliable.
+// bucket-by-path regression analysis, and what the #1897 standalone floor
+// gates against. If a baseline rots (mass-rewritten by a malformed merge,
+// desynced by a workflow bug), the bucket analysis silently produces wrong
+// answers and the merge gate becomes unreliable.
 //
-// As of #1528 the baseline JSONL is no longer committed to the main repo
-// — it lives in `loopdive/js2wasm-baselines` and is fetched on demand to
-// `.test262-cache/test262-current.jsonl` via
-// `scripts/fetch-baseline-jsonl.mjs`.
+// As of #1528 the baselines are not committed to the main repo — they live in
+// `loopdive/js2wasm-baselines` and are fetched on demand to `.test262-cache/`
+// via `scripts/fetch-baseline-jsonl.mjs` (host + standalone lanes).
 //
-// This script picks 50 random "pass" entries from the JSONL, runs
-// `runTest262File` against each, and FAILS if any of them no longer pass.
-// It's a smoke test, not a full validator — 50/43000 is 0.1% sampling, but
-// any single-test miss strongly suggests broader corruption.
+// #2095 — the validator now covers BOTH lanes and BOTH row classes:
+//   - HOST lane (gc)         pass rows (must still pass) + fail rows
+//   - STANDALONE lane        pass rows (must still pass) + fail rows
+// A sampled `pass` row that no longer passes means the baseline floor rotted
+// too low (#1218). A sampled `fail` row that now PASSES means the baseline is
+// stale — it inflates the regression-gate `improvements` count and can mask
+// one real regression per PR diff (#2095). Standalone rows compile+run with
+// `--target standalone`. It's a smoke test, not a full validator, but a single
+// miss in either lane/class strongly suggests broader baseline corruption.
 //
 // Usage:
 //   npx tsx scripts/validate-test262-baseline.ts                    # default seed
-//   SAMPLE_SIZE=50 SEED=12345 npx tsx scripts/validate-test262-baseline.ts
+//   SAMPLE_SIZE=50 FAIL_SAMPLE_SIZE=25 SEED=12345 npx tsx scripts/validate-test262-baseline.ts
 //   PR_NUMBER=109 npx tsx scripts/validate-test262-baseline.ts       # CI mode
 //
 // Exit codes:
-//   0 — all sampled tests still pass; baseline is honest
-//   1 — at least one sampled "pass" entry no longer passes; baseline corruption suspected
+//   0 — every sampled row matches its baseline status; baselines are honest
+//   1 — at least one sampled row diverged (pass→non-pass, or fail→pass); drift suspected
 //   2 — internal error (missing files, etc.)
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { findTestFiles, runTest262File, TEST_CATEGORIES } from "../tests/test262-runner.ts";
+import { runTest262File, TEST_CATEGORIES } from "../tests/test262-runner.ts";
 // #1528 — fetch baseline JSONL on demand from `loopdive/js2wasm-baselines`
 // instead of reading a committed copy. The helper handles caching and
 // graceful fallback if upstream is unreachable.
-import { BASELINE_CACHE_PATH, ensureBaselineJsonl } from "./fetch-baseline-jsonl.mjs";
+// #2095 — the standalone lane has its own baseline JSONL fetched the same way.
+import {
+  BASELINE_CACHE_PATH,
+  STANDALONE_BASELINE_CACHE_PATH,
+  ensureBaselineJsonl,
+  ensureStandaloneBaselineJsonl,
+} from "./fetch-baseline-jsonl.mjs";
 
 const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
-const BASELINE_PATH = BASELINE_CACHE_PATH;
 
+// (#2095) Per-lane `pass`-row sample size (the historical SAMPLE_SIZE knob) and
+// a separate, smaller `fail`-row sample. Fail rows assert STILL-failing: a fail
+// row that now passes inflates the regression-gate `improvements` count and can
+// mask one real regression per PR diff, so we sample them too. M defaults lower
+// than N because fail rows are cheaper signal-per-row and the corpus is huge.
 const SAMPLE_SIZE = Number(process.env.SAMPLE_SIZE ?? "50");
+const FAIL_SAMPLE_SIZE = Number(process.env.FAIL_SAMPLE_SIZE ?? "25");
 
 /** Resolve a deterministic seed from env. PR number > explicit SEED > Date.now(). */
 function resolveSeed(): number {
@@ -87,12 +102,12 @@ interface BaselineEntry {
   category?: string;
 }
 
-function loadBaseline(): BaselineEntry[] {
+function loadBaseline(baselinePath: string): BaselineEntry[] {
   let raw: string;
   try {
-    raw = readFileSync(BASELINE_PATH, "utf-8");
+    raw = readFileSync(baselinePath, "utf-8");
   } catch (e: unknown) {
-    console.error(`fatal: cannot read ${BASELINE_PATH}: ${(e as Error).message}`);
+    console.error(`fatal: cannot read ${baselinePath}: ${(e as Error).message}`);
     process.exit(2);
   }
   const out: BaselineEntry[] = [];
@@ -141,142 +156,227 @@ process.on("unhandledRejection", (reason) => {
   process.stderr.write(`[unhandledRejection swallowed] ${msg.slice(0, 200)}\n`);
 });
 
-async function main(): Promise<void> {
-  // #1528 — fetch the baseline JSONL on demand from the baselines repo and
-  // cache it locally. ensureBaselineJsonl is idempotent: it's a no-op if the
-  // cache file already exists and looks healthy.
-  try {
-    await ensureBaselineJsonl();
-  } catch (e: unknown) {
-    console.error(`fatal: could not fetch baseline JSONL: ${(e as Error).message}`);
-    console.error(
-      `       source: https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.jsonl`,
-    );
-    console.error(`       cache:  ${BASELINE_PATH}`);
-    process.exit(2);
+// Snapshot global built-in prototype methods that test262 tests may clobber.
+// Some tests mutate globalThis.Set.prototype, Array.prototype, etc. in ways
+// that survive test isolation (especially when runTest262File is invoked in
+// the same process rather than a worker). Restore after each test so
+// subsequent runner preprocessing (which uses `new Set()` etc.) still works.
+const _savedGlobals: Array<[object, PropertyKey, PropertyDescriptor | undefined]> = [
+  [Set.prototype, "add", Object.getOwnPropertyDescriptor(Set.prototype, "add")],
+  [Set.prototype, "has", Object.getOwnPropertyDescriptor(Set.prototype, "has")],
+  [Set.prototype, "delete", Object.getOwnPropertyDescriptor(Set.prototype, "delete")],
+  [Set.prototype, "clear", Object.getOwnPropertyDescriptor(Set.prototype, "clear")],
+  [Map.prototype, "set", Object.getOwnPropertyDescriptor(Map.prototype, "set")],
+  [Map.prototype, "get", Object.getOwnPropertyDescriptor(Map.prototype, "get")],
+  [Map.prototype, "has", Object.getOwnPropertyDescriptor(Map.prototype, "has")],
+  [Array.prototype, "push", Object.getOwnPropertyDescriptor(Array.prototype, "push")],
+  [Array.prototype, "pop", Object.getOwnPropertyDescriptor(Array.prototype, "pop")],
+  [Object.prototype, "hasOwnProperty", Object.getOwnPropertyDescriptor(Object.prototype, "hasOwnProperty")],
+];
+function restoreGlobals(): void {
+  for (const [obj, key, desc] of _savedGlobals) {
+    if (desc) Object.defineProperty(obj, key, desc);
   }
-
-  const baseline = loadBaseline();
-  const passes = baseline.filter((e) => e.status === "pass");
-  console.log(`Baseline: ${baseline.length} entries, ${passes.length} pass.`);
-
-  if (passes.length === 0) {
-    console.error("fatal: no `pass` entries in baseline — file appears empty or corrupt.");
-    process.exit(2);
-  }
-
-  const seed = resolveSeed();
-  const rng = makePRNG(seed);
-  const sample = shuffle(passes, rng).slice(0, Math.min(SAMPLE_SIZE, passes.length));
-  console.log(`Sampling ${sample.length} entries (seed=${seed}).`);
-
-  // We need actual filesystem paths; resolve via findTestFiles by category, then look up.
-  // Cheaper alternative: build path from baseline entry directly. Test262 root is `${ROOT}/test262`.
-  const TEST262_ROOT = resolve(ROOT, "test262");
-
-  const startMs = Date.now();
-  const failures: { file: string; expected: string; observed: string; reason?: string }[] = [];
-
-  // Snapshot global built-in prototype methods that test262 tests may clobber.
-  // Some tests mutate globalThis.Set.prototype, Array.prototype, etc. in ways
-  // that survive test isolation (especially when runTest262File is invoked in
-  // the same process rather than a worker). Restore after each test so
-  // subsequent runner preprocessing (which uses `new Set()` etc.) still works.
-  const _savedGlobals: Array<[object, PropertyKey, PropertyDescriptor | undefined]> = [
-    [Set.prototype, "add", Object.getOwnPropertyDescriptor(Set.prototype, "add")],
-    [Set.prototype, "has", Object.getOwnPropertyDescriptor(Set.prototype, "has")],
-    [Set.prototype, "delete", Object.getOwnPropertyDescriptor(Set.prototype, "delete")],
-    [Set.prototype, "clear", Object.getOwnPropertyDescriptor(Set.prototype, "clear")],
-    [Map.prototype, "set", Object.getOwnPropertyDescriptor(Map.prototype, "set")],
-    [Map.prototype, "get", Object.getOwnPropertyDescriptor(Map.prototype, "get")],
-    [Map.prototype, "has", Object.getOwnPropertyDescriptor(Map.prototype, "has")],
-    [Array.prototype, "push", Object.getOwnPropertyDescriptor(Array.prototype, "push")],
-    [Array.prototype, "pop", Object.getOwnPropertyDescriptor(Array.prototype, "pop")],
-    [Object.prototype, "hasOwnProperty", Object.getOwnPropertyDescriptor(Object.prototype, "hasOwnProperty")],
-  ];
-  function restoreGlobals(): void {
-    for (const [obj, key, desc] of _savedGlobals) {
-      if (desc) Object.defineProperty(obj, key, desc);
-    }
-    // Remove any numeric-index getter/accessor properties that a test may have
-    // installed on Array.prototype in-process (e.g. Object.defineProperty(
-    // Array.prototype, "1", {get: fn})). These survive test isolation and cause
-    // "Cannot set property N of [object Array] which has only a getter" on the
-    // next array index-write inside the validator itself.
-    for (const key of Object.getOwnPropertyNames(Array.prototype)) {
-      if (/^\d+$/.test(key)) {
-        try {
-          delete (Array.prototype as Record<string, unknown>)[key];
-        } catch {}
-      }
+  // Remove any numeric-index getter/accessor properties that a test may have
+  // installed on Array.prototype in-process (e.g. Object.defineProperty(
+  // Array.prototype, "1", {get: fn})). These survive test isolation and cause
+  // "Cannot set property N of [object Array] which has only a getter" on the
+  // next array index-write inside the validator itself.
+  for (const key of Object.getOwnPropertyNames(Array.prototype)) {
+    if (/^\d+$/.test(key)) {
+      try {
+        delete (Array.prototype as Record<string, unknown>)[key];
+      } catch {}
     }
   }
+}
+
+const TEST262_ROOT = resolve(ROOT, "test262");
+
+interface SampleFailure {
+  file: string;
+  expected: string;
+  observed: string;
+  reason?: string;
+}
+
+interface LaneResult {
+  lane: string;
+  passSampled: number;
+  failSampled: number;
+  failures: SampleFailure[];
+}
+
+/**
+ * (#2095) Validate a single lane (host or standalone) and a single row class.
+ *
+ * For `expected: "pass"` rows we FAIL when the row no longer passes (the
+ * historical #1218 check) — a `pass` row that regressed signals a rotted
+ * baseline whose floor is now too low.
+ *
+ * For `expected: "fail"` rows we FAIL when the row now PASSES — a stale `fail`
+ * row inflates the regression-gate `improvements` count and can mask one real
+ * regression per PR diff (#2095). (A `fail` row that still fails — for any
+ * reason — is healthy; we only flag the pass flip.)
+ */
+async function validateRowClass(
+  lane: string,
+  target: "standalone" | undefined,
+  rows: BaselineEntry[],
+  expected: "pass" | "fail",
+  sampleSize: number,
+  rng: () => number,
+): Promise<SampleFailure[]> {
+  const failures: SampleFailure[] = [];
+  if (rows.length === 0) return failures;
+  const sample = shuffle(rows, rng).slice(0, Math.min(sampleSize, rows.length));
+  console.log(`  [${lane}] sampling ${sample.length} "${expected}" rows.`);
 
   for (let i = 0; i < sample.length; i++) {
     const entry = sample[i]!;
     const cat = categoryFor(entry.file);
     const fullPath = resolve(TEST262_ROOT, entry.file);
-
     try {
-      const result = await runTest262File(fullPath, cat);
-      // The runner returns `pass`, `fail`, `skip`, or `compile_error`. We treat
-      // `skip` as a pass-equivalent (the sampled test is filtered out by current
-      // skip rules; that's a config drift, not a baseline-corruption signal we
-      // care about here).
-      if (result.status !== "pass" && result.status !== "skip") {
+      const result = await runTest262File(fullPath, cat, undefined, target);
+      // `skip` is pass-equivalent for our purposes — the sampled test is
+      // filtered by current skip rules; that's config drift, not corruption.
+      const nowPasses = result.status === "pass" || result.status === "skip";
+      if (expected === "pass" && !nowPasses) {
         failures.push({
           file: entry.file,
           expected: "pass",
           observed: result.status,
           reason: result.error?.slice(0, 160) ?? result.reason,
         });
+      } else if (expected === "fail" && result.status === "pass") {
+        // A baseline `fail` row that now passes — stale baseline; inflates
+        // improvements and can mask a regression. Treat as corruption.
+        failures.push({
+          file: entry.file,
+          expected: "fail",
+          observed: "pass",
+          reason: "baseline 'fail' row now passes — baseline is stale (inflates improvements, masks regressions)",
+        });
       }
     } catch (e: unknown) {
-      // An exception from the runner itself is also a failure signal.
-      failures.push({
-        file: entry.file,
-        expected: "pass",
-        observed: "runner_error",
-        reason: (e as Error).message?.slice(0, 160) ?? String(e),
-      });
+      // A runner exception only matters for `pass` rows — a `fail` row that
+      // throws in the runner is still not passing, which is the healthy state.
+      if (expected === "pass") {
+        failures.push({
+          file: entry.file,
+          expected,
+          observed: "runner_error",
+          reason: (e as Error).message?.slice(0, 160) ?? String(e),
+        });
+      }
     } finally {
-      // Restore globals in case the test polluted prototype chains in this
-      // process (the sandbox vm-realm guards the *sandbox* built-ins, but
-      // a test could still reach the real globalThis via leaked imports).
       restoreGlobals();
     }
-    if ((i + 1) % 10 === 0) {
-      const pct = Math.round(((i + 1) / sample.length) * 100);
-      console.log(`  ... ${i + 1}/${sample.length} (${pct}%) — failures so far: ${failures.length}`);
-    }
+  }
+  return failures;
+}
+
+/** Validate one lane across both row classes. */
+async function validateLane(
+  lane: string,
+  target: "standalone" | undefined,
+  baselinePath: string,
+  rng: () => number,
+): Promise<LaneResult> {
+  const baseline = loadBaseline(baselinePath);
+  const passes = baseline.filter((e) => e.status === "pass");
+  const fails = baseline.filter((e) => e.status === "fail");
+  console.log(`[${lane}] baseline: ${baseline.length} entries — ${passes.length} pass, ${fails.length} fail.`);
+  if (passes.length === 0) {
+    console.error(`fatal: no \`pass\` entries in the ${lane} baseline — file appears empty or corrupt.`);
+    process.exit(2);
+  }
+
+  const passFailures = await validateRowClass(lane, target, passes, "pass", SAMPLE_SIZE, rng);
+  const failFailures = await validateRowClass(lane, target, fails, "fail", FAIL_SAMPLE_SIZE, rng);
+
+  return {
+    lane,
+    passSampled: Math.min(SAMPLE_SIZE, passes.length),
+    failSampled: Math.min(FAIL_SAMPLE_SIZE, fails.length),
+    failures: [...passFailures, ...failFailures],
+  };
+}
+
+async function main(): Promise<void> {
+  // #1528 / #2095 — fetch BOTH lane baselines on demand from the baselines
+  // repo and cache them locally. Both are idempotent (no-op when cached).
+  let standaloneAvailable = true;
+  try {
+    await ensureBaselineJsonl();
+  } catch (e: unknown) {
+    console.error(`fatal: could not fetch host baseline JSONL: ${(e as Error).message}`);
+    console.error(
+      `       source: https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.jsonl`,
+    );
+    console.error(`       cache:  ${BASELINE_CACHE_PATH}`);
+    process.exit(2);
+  }
+  try {
+    await ensureStandaloneBaselineJsonl();
+  } catch (e: unknown) {
+    // The standalone baseline may not exist yet on a fresh seed; degrade to
+    // host-only rather than failing the whole validator (#2095 / #1897 note).
+    console.warn(
+      `warning: standalone baseline JSONL unavailable (${(e as Error).message}); validating host lane only.`,
+    );
+    standaloneAvailable = false;
+  }
+
+  const seed = resolveSeed();
+  console.log(`Seed=${seed}. Per-lane sample: ${SAMPLE_SIZE} pass rows + ${FAIL_SAMPLE_SIZE} fail rows.`);
+
+  // One PRNG, consumed in a fixed order (host pass, host fail, standalone pass,
+  // standalone fail) so the sample is deterministic given the seed.
+  const rng = makePRNG(seed);
+  const startMs = Date.now();
+
+  const laneResults: LaneResult[] = [];
+  laneResults.push(await validateLane("host", undefined, BASELINE_CACHE_PATH, rng));
+  if (standaloneAvailable) {
+    laneResults.push(await validateLane("standalone", "standalone", STANDALONE_BASELINE_CACHE_PATH, rng));
   }
 
   const durationS = (Date.now() - startMs) / 1000;
-  console.log(`\nValidated ${sample.length} entries in ${durationS.toFixed(1)}s. Failures: ${failures.length}.`);
+  const allFailures = laneResults.flatMap((r) => r.failures);
+  const totalSampled = laneResults.reduce((n, r) => n + r.passSampled + r.failSampled, 0);
+  console.log(`\nValidated ${totalSampled} rows across ${laneResults.length} lane(s) in ${durationS.toFixed(1)}s.`);
+  for (const r of laneResults) {
+    const n = r.failures.length;
+    console.log(
+      `  [${r.lane}] ${r.passSampled} pass + ${r.failSampled} fail sampled — ${n} discrepanc${n === 1 ? "y" : "ies"}.`,
+    );
+  }
 
-  if (failures.length === 0) {
-    console.log("✅ Baseline is honest — all sampled `pass` entries still pass.");
+  if (allFailures.length === 0) {
+    console.log("✅ Baseline is honest — both lanes, both row classes verified.");
     process.exit(0);
   }
 
   console.error("");
   console.error(
-    `❌ Baseline corruption detected: ${failures.length} of ${sample.length} sampled "pass" entries no longer pass on main HEAD.`,
+    `❌ Baseline drift detected: ${allFailures.length} of ${totalSampled} sampled rows no longer match the baseline on main HEAD.`,
   );
   console.error("");
-  console.error(`Most-affected (top ${Math.min(5, failures.length)}):`);
-  for (const f of failures.slice(0, 5)) {
+  console.error(`Most-affected (top ${Math.min(5, allFailures.length)}):`);
+  for (const f of allFailures.slice(0, 5)) {
     const reason = f.reason ? ` — ${f.reason}` : "";
     console.error(`  - ${f.file}  (expected: ${f.expected}, observed: ${f.observed})${reason}`);
   }
-  if (failures.length > 5) console.error(`  ... ${failures.length - 5} more`);
+  if (allFailures.length > 5) console.error(`  ... ${allFailures.length - 5} more`);
   console.error("");
-  console.error(`The baseline JSONL is published to loopdive/js2wasm-baselines by`);
+  console.error(`The baseline JSONLs are published to loopdive/js2wasm-baselines by`);
   console.error(`test262-sharded.yml's promote-baseline job after every push to main.`);
   console.error(`Force a fresh fetch with:  node scripts/fetch-baseline-jsonl.mjs --force`);
+  console.error(`                           node scripts/fetch-baseline-jsonl.mjs --standalone --force`);
   console.error("");
   console.error(
-    `Reproduce locally with:  PR_NUMBER=${process.env.PR_NUMBER ?? "<n>"} SAMPLE_SIZE=${SAMPLE_SIZE} npx tsx scripts/validate-test262-baseline.ts`,
+    `Reproduce locally with:  PR_NUMBER=${process.env.PR_NUMBER ?? "<n>"} SAMPLE_SIZE=${SAMPLE_SIZE} FAIL_SAMPLE_SIZE=${FAIL_SAMPLE_SIZE} npx tsx scripts/validate-test262-baseline.ts`,
   );
   process.exit(1);
 }

--- a/tests/issue-2095-baseline-validator-lanes.test.ts
+++ b/tests/issue-2095-baseline-validator-lanes.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2095 — baseline validator samples both lanes and both row classes.
+ *
+ * The `test262-baseline-validate` smoke test historically spot-checked only 50
+ * HOST `pass` rows. A rotted STANDALONE baseline silently weakened the #1897
+ * regression floor, and a stale `fail` row that now passes inflated
+ * `improvements` (masking a real regression per PR diff). #2095 extends the
+ * validator to:
+ *   - fetch the standalone-lane baseline JSONL (new fetch-helper export), and
+ *   - run sampled rows in the standalone lane via a new `target` parameter on
+ *     `runTest262File`.
+ *
+ * This file pins the two load-bearing pieces the runtime validator depends on,
+ * without the network/full-corpus cost of the validator itself:
+ *   1. the fetch helper exposes distinct standalone URL + cache path, and
+ *   2. `runTest262File(..., "standalone")` compiles+runs in the standalone lane
+ *      (a host-import-free test passes; the parameter is actually threaded).
+ */
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import {
+  BASELINE_REMOTE_URL,
+  BASELINE_CACHE_PATH,
+  STANDALONE_BASELINE_REMOTE_URL,
+  STANDALONE_BASELINE_CACHE_PATH,
+} from "../scripts/fetch-baseline-jsonl.mjs";
+import { runTest262File } from "../tests/test262-runner.ts";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const TEST262_ROOT = resolve(ROOT, "test262");
+
+describe("#2095 — fetch helper exposes a distinct standalone lane", () => {
+  it("standalone URL + cache path differ from the host lane and point at the standalone JSONL", () => {
+    expect(STANDALONE_BASELINE_REMOTE_URL).not.toBe(BASELINE_REMOTE_URL);
+    expect(STANDALONE_BASELINE_REMOTE_URL).toContain("test262-standalone-current.jsonl");
+    expect(STANDALONE_BASELINE_CACHE_PATH).not.toBe(BASELINE_CACHE_PATH);
+    expect(STANDALONE_BASELINE_CACHE_PATH).toContain("test262-standalone-current.jsonl");
+  });
+});
+
+describe("#2095 — runTest262File honors the standalone target", () => {
+  // A stable, host-import-free arithmetic conformance test that is a `pass`
+  // row in BOTH lane baselines. If the `target` parameter were ignored (or
+  // standalone codegen broke for this shape) the standalone run would diverge
+  // from the host control.
+  const REL = "test/language/expressions/addition/S11.6.1_A4_T3.js";
+  const CATEGORY = "language/expressions/addition";
+
+  it("passes a host-import-free assert in the standalone lane (matches the host control)", async () => {
+    const path = resolve(TEST262_ROOT, REL);
+    if (!existsSync(path)) {
+      // test262 submodule not checked out in this environment — skip rather
+      // than fail (the runtime validator exercises this lane in CI).
+      return;
+    }
+    const hostResult = await runTest262File(path, CATEGORY);
+    const stdResult = await runTest262File(path, CATEGORY, undefined, "standalone");
+    expect(["pass", "skip"]).toContain(hostResult.status);
+    // The load-bearing assertion: the standalone lane was actually exercised
+    // (the target threaded into compile()) and agrees with the host control.
+    expect(stdResult.status).toBe(hostResult.status);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2554,6 +2554,7 @@ export async function handleNegativeTest(
       const result = await compile(minimalWrapped, {
         fileName: "test.ts",
         emitWat: false,
+        ...(target ? { target } : {}),
       });
       compileMs = performance.now() - compileStart;
       const totalMs = performance.now() - totalStart;
@@ -2877,6 +2878,12 @@ export async function runTest262File(
   filePath: string,
   category: string,
   timeoutMs = TEST_TIMEOUT_MS,
+  // (#2095) Optional compile target so the baseline validator can exercise the
+  // STANDALONE lane, not just the default JS-host (gc) lane. `undefined` keeps
+  // the historical host-mode behaviour. The instantiation path below is
+  // mode-agnostic — `buildImports` produces an empty import object for a
+  // standalone binary — so only the `compile()` target needs to change.
+  target?: "standalone",
 ): Promise<TestResult> {
   const totalStart = performance.now();
   const relPath = relative(TEST262_ROOT, filePath);
@@ -2973,6 +2980,8 @@ export async function runTest262File(
       fileName: "test.ts",
       sourceMap: true,
       emitWat: false,
+      // (#2095) standalone lane for the baseline validator (default host/gc).
+      ...(target ? { target } : {}),
       // #1251: align with the sharded runner — both `scripts/compiler-fork-worker.mjs`
       // (the production path that records the committed JSONL) and `tests/test262-vitest.test.ts`
       // FIXTURE multi-compile pass `skipSemanticDiagnostics: true`. Without this flag,


### PR DESCRIPTION
## #2095 — one lane, one row class

`test262-baseline-validate` spot-checked only **50 HOST `pass` rows**. A rotted
STANDALONE baseline silently weakened the #1897 regression floor, and a stale
`fail` row that now passes inflated the regression-gate `improvements` count
(masking one real regression per PR diff).

## Fix

The validator now covers **both lanes and both row classes**:

- **Lanes**: HOST (gc) + STANDALONE. `scripts/fetch-baseline-jsonl.mjs` gains the
  standalone-lane fetch — `ensureStandaloneBaselineJsonl()`,
  `STANDALONE_BASELINE_{REMOTE_URL,CACHE_PATH}`, a shared lane-parameterised
  fetch core, and a `--standalone` CLI flag. Missing standalone baseline degrades
  to host-only with a warning (fresh-seed safe).
- **Row classes**: N `pass` rows per lane (must still pass — #1218 floor) + M
  `fail` rows per lane (must still fail; a `fail`→`pass` flip is flagged as stale
  drift). Defaults `SAMPLE_SIZE=50`, `FAIL_SAMPLE_SIZE=25`; one deterministic
  PRNG in a fixed lane/class order keeps sampling reproducible.
- Standalone rows compile+run via a new optional `target` param on
  `runTest262File` (`tests/test262-runner.ts`); the instantiation path is
  mode-agnostic so only the `compile()` target changed.

## Acceptance criteria — met

- ✅ Validator exercises both lanes and both row classes (verified end-to-end:
  host 32,734 pass / 14,072 fail; standalone 21,184 pass / 11,551 fail).
- ✅ CI-time increase bounded: ~0.76 s/row; default ~150 rows ≈ under 2 min
  (~+1 min over the host-only pass-row run).

## Tests

- `tests/issue-2095-baseline-validator-lanes.test.ts` — 2/2 (standalone fetch
  exports + standalone runner target).
- End-to-end validator smoke (both lanes, small samples) — 12 rows, 0
  discrepancies, exit 0.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)