### PR TITLE
fix(#1151): object-pattern param RequireObjectCoercible (Gap B residual)

### DIFF
--- a/plan/issues/1151-async-function-synchronous-throws-bypass.md
+++ b/plan/issues/1151-async-function-synchronous-throws-bypass.md
@@ -1,9 +1,11 @@
 ---
 id: 1151
 title: "Async function synchronous throws bypass Promise.reject wrapping"
-status: ready
+status: done
+assignee: ttraenkler/dv1
+completed: 2026-06-16
 created: 2026-04-21
-updated: 2026-04-21
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -506,3 +508,36 @@ the `await asyncCall()` fast-path were NOT touched, per the critical rules.
 **Not in scope / deferred:** Gap A2 (body-wrap safety net) — open only if a
 residual sync-throw cluster remains after CI measures A1. Gap C (`src/ir/lower.ts`
 `IrInstrAsyncThrow`) — bundled with the #1373b gate flip (senior-dev).
+
+## Gap B residual closed (dv1, 2026-06-16) — object-pattern param RequireObjectCoercible
+
+Gap B (binding-pattern param coercion) was marked DONE, but a residual remained:
+the coercion forces `wasmType = externref` for binding-pattern params, yet the
+`compileFunctionExpression` arrow/function-expression path
+(`closures.ts` → object-pattern arm) routes an externref object pattern to
+**`destructureParamObjectExternref`**, which — unlike the array param helper
+(`destructureParamArray`, guards at destructuring-params.ts:922) and the
+function-DECLARATION path (`destructureParamObject`, guards at :584) — did **not**
+emit the spec-mandated RequireObjectCoercible null/undefined guard
+(ECMA-262 §8.6.2 step 1).
+
+Symptom (verified on current main, host + standalone):
+- `(({a}) => a)(null)` / `(undefined)` → silently returned `undefined`
+  instead of throwing a synchronous TypeError.
+- `(({}) => 0)(null)` → same (empty pattern must throw too).
+- Array-pattern arrows (`([a]) => a`) and `function f({a}){}` declarations
+  already threw correctly — asymmetric.
+
+**Fix:** emit `emitExternrefDestructureGuard(ctx, fctx, paramIdx)` at the top of
+`destructureParamObjectExternref` (`src/codegen/destructuring-params.ts`). The
+guard only throws on null/undefined; valid objects and the two
+`destructureParamObject` delegation sites (which already guard first) pass
+through unchanged — a second guard on a non-null value is a no-op. +12 LOC.
+
+**Tests:** `tests/issue-1151.test.ts` (8 cases) — arrow object pattern throws on
+null/undefined, empty pattern throws on null, nested array pattern regression
+watch, and four valid-argument cases (field read, nested read-through, default
+key, rest) confirming no false-positive throws. tsc clean; biome clean. The
+pre-existing `tests/basic-destructuring.test.ts` etc. failures are a broken
+`./helpers.js` harness import (missing in tree, fails identically on main), not
+a regression from this change.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -337,6 +337,18 @@ export function destructureParamObjectExternref(
   if (shouldEnsureLetConstFlags(opts)) {
     ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
   }
+  // (#1151) RequireObjectCoercible — destructuring a binding pattern against
+  // null/undefined must throw a synchronous TypeError (ECMA-262 §8.6.2 step 1,
+  // BindingPattern : ObjectBindingPattern). The array param helper and
+  // `destructureParamObject`'s own externref arm already emit this guard, but
+  // the `compileFunctionExpression` arrow / function-expression path
+  // (closures.ts) calls THIS helper directly for an `any`/externref object
+  // pattern with no struct to ref.test against, so without the guard
+  // `(({a}) => a)(null)` silently returned undefined. The guard only fires for
+  // null/undefined; valid objects (and `destructureParamObject` callers that
+  // already guarded) pass through unchanged (a second guard on a non-null value
+  // is a no-op).
+  emitExternrefDestructureGuard(ctx, fctx, paramIdx);
   // Ensure __extern_get is available (#1866: ensureLateImport routes to the
   // native object-runtime impl under --target standalone — no leaked
   // `env::__extern_get` host import — and to the host import in JS-host mode).

--- a/tests/issue-1151.test.ts
+++ b/tests/issue-1151.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1151 — destructuring an OBJECT binding-pattern parameter of a function /
+// arrow EXPRESSION against null/undefined silently returned undefined instead
+// of throwing a synchronous TypeError (RequireObjectCoercible, ECMA-262 §8.6.2
+// step 1). The array-pattern arm and the function-DECLARATION path already
+// guarded, but `compileFunctionExpression`'s object-pattern arm calls
+// `destructureParamObjectExternref` directly — which lacked the
+// null/undefined guard. Fix: emit `emitExternrefDestructureGuard` at the top
+// of that helper.
+//
+// These exercise the host/gc lowering (the bug manifests identically there);
+// each compiles and runs `test()`, asserting it returns 1 when the expected
+// TypeError was thrown and caught, else 0.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function run(source: string): Promise<unknown> {
+  const r = await compile(source);
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "<unknown>"}`);
+  }
+  const imports = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#1151 — object-pattern param RequireObjectCoercible", () => {
+  it("arrow object pattern throws on null", async () => {
+    const out = await run(`
+      const f = ({a}: any): number => (a as number);
+      export function test(): number {
+        try { f(null); return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("arrow object pattern throws on undefined", async () => {
+    const out = await run(`
+      const f = ({a}: any): number => (a as number);
+      export function test(): number {
+        try { f(undefined as any); return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("empty object pattern still throws on null (RequireObjectCoercible runs first)", async () => {
+    const out = await run(`
+      const f = ({}: any): number => 0;
+      export function test(): number {
+        try { f(null); return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("nested array pattern param throws on inner null (pre-existing, regression watch)", async () => {
+    const out = await run(`
+      function f([[x]]: any): number { return x as number; }
+      export function test(): number {
+        try { f([null]); return 0; } catch (e) { return 1; }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("valid object argument is unaffected — fields are read", async () => {
+    const out = await run(`
+      const f = ({a}: any): number => (a as number);
+      export function test(): number { return f({a: 5}); }
+    `);
+    expect(out).toBe(5);
+  });
+
+  it("nested object pattern reads through on a valid argument", async () => {
+    const out = await run(`
+      const f = ({a: {b}}: any): number => (b as number);
+      export function test(): number { return f({a: {b: 7}}); }
+    `);
+    expect(out).toBe(7);
+  });
+
+  it("object-pattern default applies for a missing key on a valid object", async () => {
+    const out = await run(`
+      const f = ({a = 9}: any): number => (a as number);
+      export function test(): number { return f({}); }
+    `);
+    expect(out).toBe(9);
+  });
+
+  it("rest in object pattern works on a valid object", async () => {
+    const out = await run(`
+      const f = ({a, ...r}: any): number => (a as number);
+      export function test(): number { return f({a: 1, b: 2, c: 3}); }
+    `);
+    expect(out).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1151 Gap B residual — object-pattern param destructure skipped RequireObjectCoercible

Gap B (binding-pattern param coercion to externref) was previously landed, but a residual remained.

### Root cause
The Gap B coercion forces `wasmType = externref` for binding-pattern params. But the `compileFunctionExpression` arrow / function-expression path routes an externref **object** pattern to `destructureParamObjectExternref` (`src/codegen/destructuring-params.ts`), which — unlike:
- the array param helper `destructureParamArray` (guards at :922), and
- the function-**declaration** path `destructureParamObject` (guards at :584)

— never emitted the spec-mandated **RequireObjectCoercible** null/undefined guard (ECMA-262 §8.6.2 BindingPattern : ObjectBindingPattern, step 1).

Symptom (host + standalone): `(({a}) => a)(null)` / `(undefined)` silently returned `undefined` instead of throwing a synchronous `TypeError`; `(({}) => 0)(null)` likewise. Array-pattern arrows and `function f({a}){}` declarations already threw — asymmetric.

### Fix
Emit `emitExternrefDestructureGuard(ctx, fctx, paramIdx)` at the top of `destructureParamObjectExternref`. The guard only throws on null/undefined; valid objects and the two `destructureParamObject` delegation sites (which already guard first) pass through unchanged — a second guard on a non-null value is a no-op. +12 LOC, one file.

### Tests
`tests/issue-1151.test.ts` — 8 cases:
- arrow object pattern throws on `null` / `undefined`
- empty `{}` pattern throws on `null` (RequireObjectCoercible runs before the empty body)
- nested array pattern param regression watch (`f([null])` throws)
- valid argument cases: field read, nested read-through, default key, rest — all unaffected (no false-positive throws)

`tsc --noEmit` clean; biome clean on changed files. (Pre-existing `tests/basic-destructuring.test.ts` etc. failures are a broken `./helpers.js` harness import missing in tree — identical on main, not a regression here.)

Does NOT touch `effectiveRetType`, `wrapAsyncCallInTryCatch`, or the `await asyncCall()` fast-path (per the issue's critical rules). Option 1 (body-wrap) remains declined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)