### PR TITLE
plan(#1538): JSON codec recon + sliced A1/A2/Phase-B roadmap

### DIFF
--- a/plan/issues/1538-wasm-native-json-parse-stringify.md
+++ b/plan/issues/1538-wasm-native-json-parse-stringify.md
@@ -1,9 +1,10 @@
 ---
 id: 1538
 title: "Wasm-native JSON.parse and JSON.stringify (standalone, no host)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dv3
 created: 2026-05-20
-updated: 2026-05-20
+updated: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -85,3 +86,82 @@ All gated `ctx.wasi || ctx.standalone`; JS-host keeps imports. **Depends on #153
 
 ### test262 gate & phasing
 `built-ins/JSON/parse/` (~80), `built-ins/JSON/stringify/` (~120) standalone; reviver/replacer/toJSON tests gated to Phase B if deferred. `tests/issue-1538.test.ts` `{target:"standalone",testRuntime:true}`: round-trip deep-equal, circular→throws, escapes, indent `=== JSON.stringify(x,null,2)`. Est. +150-300 passes. **Phase A** = parse(objects/arrays/strings/escapes, no reviver) + stringify(value types, indent, cycle detection); **Phase B** = reviver/replacer/toJSON. Ship A first.
+
+## Recon (2026-06-16, dv3) — current standalone behavior + slicing
+
+Verified the standalone gap on current main (`--target standalone`, no `env`
+imports leak — the host imports are already DCE'd, they're just non-functional):
+
+| input | standalone result | want |
+| --- | --- | --- |
+| `JSON.stringify({a:1,b:2})` | `undefined` (no object walk) | `{"a":1,"b":2}` |
+| `JSON.stringify([1,2,3])` | `undefined` | `[1,2,3]` |
+| `JSON.parse('{"a":5}').a` | TRAP `unreachable` | `5` |
+
+Primitive stringify (`null`/bool/number/string) already works standalone via
+`tryEmitJsonStringifyPrimitive` (`calls.ts:406`) + `__json_quote_string`
+(`json-runtime.ts:66`). Primitive parse works via `__json_parse_primitive`
+(`json-runtime.ts:422`). The gap is purely the **runtime object/array codec**.
+
+Building blocks confirmed in-tree to build on (do NOT reinvent):
+- `$AnyValue` tagged union (`any-helpers.ts:23` `ensureAnyValueType`): 0=null
+  1=undefined 2=i32 3=f64 4=bool 5=string 6=object/ref.
+- `object-runtime.ts` (`ensureObjectRuntime`): `$Object` with **insertion-
+  ordered** keys (#1837 seq field), `__new_plain_object`, `__obj_insert`,
+  `__obj_find` — the stringify key-order + parse object-build primitives.
+- `__json_quote_string` (string→quoted), `__json_parse_primitive`.
+
+**Slicing (independently-shippable PRs, new file `src/codegen/json-codec.ts`):**
+- **A1** — `JSON.stringify(object|array)`: recursive `$AnyValue`-tag dispatch,
+  `$Object` insertion-order walk, array vs object via `ref.test`, numeric/string
+  `space` indent, cycle detection (`seen` eq-set → `throw TypeError` via #1536),
+  NaN/Inf→`null`. Reuses existing number→string (full Ryū edge-numbers are the
+  #1537 dependency; interim is acceptable per architect).
+- **A2** — `JSON.parse(object|array|string|escapes)`: recursive-descent over
+  flattened `$NativeString` with an i32 cursor ref-cell; object→`__new_plain_object`
+  +`__obj_insert`, array→standalone array, string-unescape, number→§21 scanner,
+  malformed→`throw SyntaxError`.
+- **Phase B** — reviver/replacer/toJSON (separate follow-up; gate to host in the
+  interim).
+
+Wiring points: `calls.ts` `tryEmitJsonParsePrimitive`(~565) + JSON.stringify
+dispatch(~6028); `index.ts` needStringify/needParse(~8087) emit native codec
+under `ctx.wasi||ctx.standalone` instead of `addImport`. All gated standalone;
+JS-host keeps host imports unchanged.
+
+## Suspended Work (2026-06-16, dv3)
+
+Worktree `/workspace/.claude/worktrees/issue-1538-host-native-json`
+(branch `issue-1538-host-native-json`, from upstream/main @0275de164).
+No code committed yet — only the **Recon** section above (verified gaps,
+building-block map, struct layouts, sliced A1/A2/Phase-B plan).
+
+**Resume steps for slice A1 (`JSON.stringify(object|array)`):**
+1. New file `src/codegen/json-codec.ts`, `emitJsonStringify(ctx)` gated
+   `ctx.wasi||ctx.standalone`; idempotent in `ctx.funcMap` like
+   `emitJsonQuoteString`. Call `ensureObjectRuntime(ctx)` (gives
+   `$Object`@objectTypeIdx, `$PropEntry`@propEntryTypeIdx {key:0,value:1,
+   flags:2,seq:3}, `$PropMap`@propMapTypeIdx) + `ensureAnyValueType` +
+   `ensureNativeStringHelpers` (`__str_concat`).
+2. Recursive `__json_stringify_value(ref $AnyValue, i32 depth) -> ref $AnyString`
+   dispatching on `$AnyValue` tag (0 null→"null", 1 undefined→omit, 2/3
+   number→`number_toString` (NaN/Inf→"null"), 4 bool, 5 string→
+   `__json_quote_string`, 6 ref). Tag-6: `ref.test` array-vec vs `$Object`.
+   **Known sharp edge:** standalone arrays are closed-shape `__vec_<elem>` types
+   (per element type), so array detection needs the registered vec type idx(s),
+   not one canonical array type — resolve via `ctx.shapeMap`/vecTypeIdx. Object:
+   walk `$PropMap` entries, sort by `seq` (insertion order), skip tombstones
+   (null entries) + undefined/function values, emit `"key":value` joined by ",".
+3. `space` indent (numeric 1-10 / string) → `\n`+indent*depth, `": "` after keys.
+4. Cycle detection: `seen` `(array (mut (ref null eq)))`, `ref.eq` check,
+   push on descent/pop on ascent; re-entry → `throw TypeError` via `$Error_struct`
+   + `throw $tag` (#1536 machinery).
+5. Wire `calls.ts` JSON.stringify dispatch (~6028, after
+   `tryEmitJsonStringifyPrimitive` returns undefined for object/array under
+   standalone) to call `__json_stringify_value`; `index.ts` needStringify (~8087)
+   emit `emitJsonStringify(ctx)` instead of `addImport(JSON_stringify)` under
+   standalone.
+6. `tests/issue-1538.test.ts` `{target:"standalone",testRuntime:true}`: object
+   round-trip, array, nested, indent `=== JSON.stringify(x,null,2)`, circular→throws.
+
+Slice A2 (parse) and Phase B (reviver/replacer/toJSON) per the Recon plan.


### PR DESCRIPTION
Groundwork for #1538 (host-native JSON.parse/stringify). **Docs-only** — no code yet; lands a verified, resumable plan so the implementation can proceed in reviewable slices.

## What this adds to the issue
- **Recon**: verified standalone gaps on current main — `JSON.stringify({...})`→`undefined`, `JSON.stringify([...])`→`undefined`, `JSON.parse('{...}')`→`unreachable` trap. No `env::` import leak (host imports already DCE'd, just non-functional). Primitive stringify/parse already work (`tryEmitJsonStringifyPrimitive`, `__json_quote_string`, `__json_parse_primitive`).
- **Building-block map + exact struct layouts**: `$AnyValue` tags, object-runtime `$Object`/`$PropEntry`(key/value/flags/seq)/`$PropMap` insertion-ordered, `__str_concat`.
- **Sliced roadmap**: A1 `stringify(object|array)`, A2 `parse(object|array|string|escapes)`, Phase B reviver/replacer/toJSON — each an independently-shippable PR.
- **Suspended-work note** with concrete A1 resume steps (incl. the sharp edge: standalone arrays are per-element closed-shape `__vec_*` types, so array-vs-object detection needs the registered vec idx, not one canonical array type).

Issue set `in-progress`. Implementation slices follow as separate code PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)