### PR TITLE
fix(#2097): absolute standalone pass-count high-water floor

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -604,6 +604,20 @@ jobs:
             --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}
 
+      # #2097 — ABSOLUTE standalone pass-count floor (high-water-mark backstop).
+      # The #1897 standalone gate is a MOVING floor (re-seeded from the new
+      # baseline every push to main), so a run of small net-negative PRs each
+      # within tolerance can compound undetected. This guard asserts the merged
+      # standalone pass count stays within `tolerance` of the committed
+      # high-water mark (benchmarks/results/test262-standalone-highwater.json),
+      # which only ever ratchets UP. It lives inside the required
+      # "merge shard reports" check so a breach blocks the merge queue.
+      - name: Standalone pass-count high-water floor (#2097)
+        if: env.SHARDS_RAN == 'true'
+        run: |
+          node scripts/check-standalone-highwater.mjs \
+            --report merged-reports/test262-standalone-report-merged.json
+
       # #1668 — HARD catastrophic-regression guard. Lives INSIDE the REQUIRED
       # "merge shard reports" check so it blocks the merge queue. The
       # fine-grained `regression-gate` job below also blocks the merge queue
@@ -1278,6 +1292,15 @@ jobs:
           cp shard-artifacts/test262-results-merged.jsonl public/benchmarks/results/test262-results.jsonl
           cp shard-artifacts/test262-standalone-report-merged.json public/benchmarks/results/test262-standalone-report.json
 
+      # #2097 — ratchet the absolute standalone high-water mark UP when this
+      # push improved standalone conformance. Only ever raises (never lowers);
+      # the raised file is staged into the same atomic main-repo commit below.
+      - name: Raise standalone pass-count high-water mark (#2097)
+        run: |
+          node scripts/check-standalone-highwater.mjs \
+            --report benchmarks/results/test262-standalone-current.json \
+            --update --sha "${{ github.sha }}" || true
+
       - name: Regenerate edition buckets
         run: node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
 
@@ -1541,6 +1564,10 @@ jobs:
               benchmarks/results/test262-report.json \
               public/benchmarks/results/test262-report.json \
               public/benchmarks/results/test262-standalone-report.json
+            # #2097 — the standalone high-water mark (raised just above when
+            # conformance improved). Staged so the new floor lands atomically
+            # with the refreshed summary.
+            git add -f benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true
             # editions JSON is regenerated into website/public/ (the vite
             # publicDir, served by the landing page) by the earlier step. #1656
             # moved the public dir under website/; staging the old public/ path

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ benchmarks/results/*.json
 !benchmarks/results/playground-benchmark-sidebar-no-jit.json
 !benchmarks/results/size-benchmarks.json
 !benchmarks/results/loadtime-benchmarks.json
+!benchmarks/results/test262-standalone-highwater.json
 benchmarks/results/*.md
 benchmarks/results/*.txt
 # #1528 — the ~15 MB test262 baseline JSONL lives in loopdive/js2wasm-baselines.

--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,0 +1,7 @@
+{
+  "pass": 21184,
+  "sha": "b74ddfda6c70dc8707419de55cafd72a544b3083",
+  "generated_at": "2026-06-16T00:00:00Z",
+  "tolerance": 50,
+  "_comment": "#2097 absolute standalone pass-count high-water mark. Floor = pass - tolerance. Auto-raised on improvement by check-standalone-highwater.mjs --update in the promote-baseline job; only ever moves UP. Seeded from test262-standalone-current.jsonl (loopdive/js2wasm-baselines)."
+}

--- a/plan/issues/2097-standalone-pass-count-highwater-floor.md
+++ b/plan/issues/2097-standalone-pass-count-highwater-floor.md
@@ -1,10 +1,12 @@
 ---
 id: 2097
 title: "absolute standalone pass-count floor — high-water-mark backstop against compounding small regressions"
-status: ready
+status: done
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dv2
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -44,3 +46,47 @@ the mark auto-raised on improvement.
 
 #1897 (merged) is the per-PR rolling gate; the absolute backstop is
 unfiled. New (analysis program).
+
+## Resolution (2026-06-16, dv2)
+
+**Committed high-water mark.** `benchmarks/results/test262-standalone-highwater.json`
+holds the absolute standalone pass-count floor reference
+(`{ pass, sha, generated_at, tolerance }`), seeded at the current published
+standalone baseline (`pass: 21184`, full corpus). It only ever ratchets UP.
+
+**Check script.** `scripts/check-standalone-highwater.mjs`:
+- reads the merged standalone report's `full_summary.pass` (matching the
+  standalone JSONL row count),
+- asserts `pass ≥ mark.pass − tolerance` (default 50) — on breach it fails
+  loudly with the slide magnitude, the mark's commit/timestamp (the trend
+  window), and a re-seed pointer; exit 1,
+- with `--update`, RAISES the committed mark when pass improved (never lowers).
+
+**CI wiring** (`.github/workflows/test262-sharded.yml`):
+- A `Standalone pass-count high-water floor (#2097)` step inside the **required**
+  `merge shard reports` job (right after the standalone report build) runs the
+  assert, so a compounding slide below `mark − tolerance` blocks the merge
+  queue — independent of the moving #1897 per-PR floor.
+- In `promote-baseline` (push:main), a `Raise standalone pass-count high-water
+  mark (#2097)` step runs `--update`, and the raised file is staged into the
+  same atomic main-repo summary commit (`stage_files`). So the mark auto-rises
+  with conformance and is never silently lowered.
+
+### Acceptance criteria — met
+- ✅ High-water file committed and auto-raised (promote-baseline `--update`;
+  ratchet verified: raises on improvement, refuses to lower).
+- ✅ Breach fails loudly with the trend window (commit + timestamp + slide
+  magnitude) in the message; gated inside the required `merge shard reports`
+  check.
+
+### Files
+- `benchmarks/results/test262-standalone-highwater.json` — committed mark.
+- `scripts/check-standalone-highwater.mjs` — assert + ratchet.
+- `.github/workflows/test262-sharded.yml` — required-check assert step +
+  promote-baseline auto-raise + stage.
+- `tests/issue-2097-standalone-highwater.test.ts` — decision-logic unit tests.
+
+### Test Results
+- `tests/issue-2097-standalone-highwater.test.ts` — 7/7 pass.
+- Script smoke (within-tolerance pass, breach exit 1, ratchet raise/refuse) —
+  all correct.

--- a/scripts/check-standalone-highwater.mjs
+++ b/scripts/check-standalone-highwater.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2097 — absolute standalone pass-count floor (high-water-mark backstop).
+//
+// Why this exists:
+//   The #1897 standalone regression gate is a MOVING floor — `promote-baseline`
+//   re-seeds it from the new baseline on every push to main. So a sequence of
+//   small net-negative PRs, each within the per-PR tolerance (−15), compounds
+//   without any single gate catching the downward trend. This script adds an
+//   ABSOLUTE reference: a committed high-water mark that the standalone pass
+//   count must stay within `TOLERANCE` of, regardless of how the rolling
+//   baseline drifts. The mark only ever moves UP (auto-raised on improvement),
+//   so it ratchets conformance and fails loudly on a compounding slide.
+//
+// Usage:
+//   node scripts/check-standalone-highwater.mjs --report <merged-report.json>
+//       Assert pass >= highwater.pass - TOLERANCE. Exit 1 on breach.
+//   node scripts/check-standalone-highwater.mjs --report <r.json> --update
+//       Same assert, then RAISE the committed mark if pass improved on it.
+//       (Intended for the post-merge promote-baseline job.)
+//   node scripts/check-standalone-highwater.mjs --pass <N> [...]
+//       Take the pass count directly instead of reading a report.
+//
+// Inputs:
+//   The report is the merged standalone report produced by
+//   `scripts/build-test262-report.mjs --target standalone`. We read
+//   `full_summary.pass` (the full corpus: standard + annex_b + proposals),
+//   matching the row count in `test262-standalone-current.jsonl`.
+//
+// High-water file: benchmarks/results/test262-standalone-highwater.json
+//   { "pass": <int>, "sha": "<commit>", "generated_at": "<iso>", "tolerance": 50 }
+//
+// Exit codes:
+//   0 — pass within tolerance of the mark (and, with --update, mark refreshed)
+//   1 — pass is below high-water − tolerance (compounding regression)
+//   2 — internal error (missing/garbled files, bad args)
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+export const HIGHWATER_PATH = resolve(REPO_ROOT, "benchmarks/results/test262-standalone-highwater.json");
+
+// Default slack below the mark — matches the #1897 per-PR tolerance order of
+// magnitude (a single PR's legitimate churn / runner flake) but is absolute,
+// not relative to a moving baseline. Override with --tolerance N.
+const DEFAULT_TOLERANCE = 50;
+
+/**
+ * Read the standalone pass count from a merged report JSON. Prefers
+ * `full_summary.pass` (full corpus), falling back to `summary.pass` for older
+ * report shapes.
+ *
+ * @param {string} reportPath
+ * @returns {number}
+ */
+export function passFromReport(reportPath) {
+  const raw = readFileSync(reportPath, "utf-8");
+  const report = JSON.parse(raw);
+  const pass = report?.full_summary?.pass ?? report?.summary?.pass ?? report?.summary?.by_category?.full?.pass;
+  if (typeof pass !== "number") {
+    throw new Error(`could not read full_summary.pass from ${reportPath}`);
+  }
+  return pass;
+}
+
+/** Load the committed high-water mark, or null if it does not exist yet. */
+export function loadHighwater() {
+  if (!existsSync(HIGHWATER_PATH)) return null;
+  return JSON.parse(readFileSync(HIGHWATER_PATH, "utf-8"));
+}
+
+/**
+ * Evaluate the current pass count against the committed mark.
+ *
+ * @param {number} pass current standalone pass count
+ * @param {{pass:number, tolerance?:number}|null} mark committed high-water
+ * @param {number} tolerance slack below the mark
+ * @returns {{ ok: boolean, floor: number, delta: number, mark: number }}
+ */
+export function evaluate(pass, mark, tolerance) {
+  // No mark yet → nothing to breach; treat as a pass (the --update path seeds it).
+  if (!mark) return { ok: true, floor: 0, delta: pass, mark: 0 };
+  const tol = mark.tolerance ?? tolerance;
+  const floor = mark.pass - tol;
+  return { ok: pass >= floor, floor, delta: pass - mark.pass, mark: mark.pass };
+}
+
+function parseArgs(argv) {
+  const args = {
+    report: undefined,
+    pass: undefined,
+    update: false,
+    tolerance: DEFAULT_TOLERANCE,
+    sha: process.env.GITHUB_SHA,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--report") args.report = argv[++i];
+    else if (a === "--pass") args.pass = Number(argv[++i]);
+    else if (a === "--update") args.update = true;
+    else if (a === "--tolerance") args.tolerance = Number(argv[++i]);
+    else if (a === "--sha") args.sha = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node scripts/check-standalone-highwater.mjs --report <r.json> [--update] [--tolerance N] [--sha <commit>]",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  let pass;
+  try {
+    if (typeof args.pass === "number" && !Number.isNaN(args.pass)) {
+      pass = args.pass;
+    } else if (args.report) {
+      pass = passFromReport(resolve(args.report));
+    } else {
+      console.error("fatal: pass either --report <merged-report.json> or --pass <N>.");
+      process.exit(2);
+    }
+  } catch (e) {
+    console.error(`fatal: ${e instanceof Error ? e.message : e}`);
+    process.exit(2);
+  }
+
+  const mark = loadHighwater();
+  const { ok, floor, delta, mark: markPass } = evaluate(pass, mark, args.tolerance);
+  const tol = mark?.tolerance ?? args.tolerance;
+
+  if (!mark) {
+    console.log(`[standalone-highwater] no committed mark yet; current standalone pass=${pass}.`);
+  } else {
+    console.log(
+      `[standalone-highwater] current pass=${pass}, mark=${markPass} (floor=${floor}, tolerance=${tol}, delta=${delta >= 0 ? "+" : ""}${delta}).`,
+    );
+  }
+
+  if (!ok) {
+    console.error("");
+    console.error(
+      `::error::STANDALONE pass-count floor breached: ${pass} < high-water ${markPass} − ${tol} = ${floor}. ` +
+        `The standalone lane has slid ${-delta} below the committed high-water mark (a compounding regression the ` +
+        `moving #1897 per-PR gate can miss). High-water set at commit ${mark.sha ?? "?"} (${mark.generated_at ?? "?"}). ` +
+        `If this drop is intentional, re-seed the mark with --update on a known-good main run. See #2097.`,
+    );
+    process.exit(1);
+  }
+
+  if (args.update) {
+    // Ratchet UP only: never lower the committed mark here (that is the job of
+    // an explicit re-seed). A net improvement raises the floor so future
+    // slides are caught against the new, higher reference.
+    if (!mark || pass > mark.pass) {
+      const next = {
+        pass,
+        sha: args.sha ?? mark?.sha ?? "unknown",
+        generated_at: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+        tolerance: mark?.tolerance ?? args.tolerance,
+      };
+      writeFileSync(HIGHWATER_PATH, `${JSON.stringify(next, null, 2)}\n`);
+      console.log(`[standalone-highwater] raised mark ${mark?.pass ?? 0} → ${pass} (commit ${next.sha}).`);
+    } else {
+      console.log(`[standalone-highwater] mark unchanged (current ${pass} ≤ mark ${mark.pass}); within tolerance.`);
+    }
+  }
+
+  process.exit(0);
+}
+
+// Only run as a script, not when imported by tests.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/issue-2097-standalone-highwater.test.ts
+++ b/tests/issue-2097-standalone-highwater.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2097 — absolute standalone pass-count high-water floor.
+ *
+ * The #1897 standalone regression gate is a MOVING floor (re-seeded from the
+ * new baseline on every push to main), so a sequence of small net-negative PRs
+ * — each within the per-PR tolerance — compounds undetected. The high-water
+ * mark is an ABSOLUTE reference that only ever ratchets UP, so a compounding
+ * slide eventually breaches `mark − tolerance` and fails loudly.
+ *
+ * This pins the pure decision logic of `scripts/check-standalone-highwater.mjs`
+ * (the CI step is exercised by the workflow itself) plus the committed mark's
+ * shape.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluate, passFromReport, loadHighwater, HIGHWATER_PATH } from "../scripts/check-standalone-highwater.mjs";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+
+describe("#2097 — high-water evaluate()", () => {
+  const mark = { pass: 21184, tolerance: 50 };
+
+  it("passes when current pass is at the mark", () => {
+    const r = evaluate(21184, mark, 50);
+    expect(r.ok).toBe(true);
+    expect(r.floor).toBe(21134);
+    expect(r.delta).toBe(0);
+  });
+
+  it("passes when within tolerance below the mark", () => {
+    expect(evaluate(21140, mark, 50).ok).toBe(true); // 21140 >= 21134
+    expect(evaluate(21134, mark, 50).ok).toBe(true); // exactly the floor
+  });
+
+  it("fails when below mark − tolerance (a compounding slide)", () => {
+    const r = evaluate(21133, mark, 50);
+    expect(r.ok).toBe(false);
+    expect(r.delta).toBe(-51);
+  });
+
+  it("passes (no breach) when no committed mark exists yet — the --update path seeds it", () => {
+    expect(evaluate(12345, null, 50).ok).toBe(true);
+  });
+
+  it("honors a per-mark tolerance over the CLI default", () => {
+    // mark carries tolerance:10 → floor is 21174, so 21150 breaches even though
+    // it would pass under the default-50 floor (21134).
+    expect(evaluate(21150, { pass: 21184, tolerance: 10 }, 50).ok).toBe(false);
+  });
+});
+
+describe("#2097 — passFromReport() reads full_summary.pass", () => {
+  it("prefers full_summary.pass", () => {
+    const tmp = resolve(ROOT, ".test262-cache/issue-2097-probe-report.json");
+    // Reuse the cache dir (gitignored). Write a minimal report shape.
+    const { mkdirSync, writeFileSync } = require("node:fs") as typeof import("node:fs");
+    mkdirSync(dirname(tmp), { recursive: true });
+    writeFileSync(tmp, JSON.stringify({ full_summary: { pass: 4242 }, summary: { pass: 1 } }));
+    expect(passFromReport(tmp)).toBe(4242);
+  });
+});
+
+describe("#2097 — committed high-water file is well-formed", () => {
+  it("has an integer pass count and a numeric tolerance", () => {
+    const raw = readFileSync(HIGHWATER_PATH, "utf-8");
+    const mark = JSON.parse(raw);
+    expect(Number.isInteger(mark.pass)).toBe(true);
+    expect(mark.pass).toBeGreaterThan(1000); // never a corrupt/empty seed
+    expect(typeof mark.tolerance).toBe("number");
+    // loadHighwater() returns the same object.
+    expect(loadHighwater()?.pass).toBe(mark.pass);
+  });
+});


### PR DESCRIPTION
## #2097 — a moving floor ratchets nothing

The #1897 standalone regression gate is a MOVING floor (re-seeded from the new
baseline on every push to main), so a sequence of small net-negative PRs — each
within the per-PR tolerance — compounds without any single gate catching the
downward trend.

## Fix

An ABSOLUTE high-water backstop that only ever ratchets UP:

- **`benchmarks/results/test262-standalone-highwater.json`** — committed mark
  (`pass`/`sha`/`generated_at`/`tolerance`), seeded at the current published
  standalone pass count (21184, full corpus).
- **`scripts/check-standalone-highwater.mjs`** — reads the merged standalone
  report's `full_summary.pass`; asserts `pass ≥ mark − tolerance` (default 50),
  failing loudly with the slide magnitude + the mark's commit/timestamp (the
  trend window) on breach; `--update` raises the mark on improvement (never
  lowers).
- **`test262-sharded.yml`**:
  - assert step inside the **required** `merge shard reports` job (right after
    the standalone report build) — a compounding slide below `mark − tolerance`
    blocks the merge queue, independent of the moving #1897 per-PR floor;
  - `promote-baseline` (push:main) `--update` step auto-raises the mark and
    stages it into the atomic main-repo summary commit.
- **`.gitignore`** — un-ignore the committed high-water file.

## Acceptance criteria — met

- ✅ High-water file committed and auto-raised; ratchet verified (raises on
  improvement, refuses to lower).
- ✅ Breach fails loudly with the trend window in the message; gated inside the
  required `merge shard reports` check.

## Tests

- `tests/issue-2097-standalone-highwater.test.ts` — 7/7 (evaluate floor/tolerance,
  no-mark seed path, report parse, committed-file shape).
- Script smoke (within-tolerance, breach exit 1, ratchet raise/refuse) — correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)