### PR TITLE
fix(#2165): standalone .catch lowering — close __make_callback host-import leak

### DIFF
--- a/plan/issues/2165-standalone-promise-async-residual.md
+++ b/plan/issues/2165-standalone-promise-async-residual.md
@@ -1,10 +1,12 @@
 ---
 id: 2165
 title: "Standalone Promise/async conformance residual (~223 tests)"
-status: ready
+status: done
+assignee: ttraenkler/se1
+completed: 2026-06-16
 sprint: 62
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-06-16
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -43,3 +45,64 @@ fail standalone**, attributed to Promise/async semantics.
 
 Parent (done): #1116. Depends on the standalone microtask scheduler (#1326)
 landing. Part of sprint-62 standalone catch-up (rank 11 by gap impact).
+
+## Implementation Notes (se1, 2026-06-16, sprint 62)
+
+### Gap census (standalone/WASI, current main)
+
+Probed the representative Promise/async constructs in `--target wasi` for
+`Promise_*` / `__make_callback` host-import leaks:
+
+| construct | standalone |
+|-----------|-----------|
+| `Promise.resolve` / `.reject` | clean |
+| `.then(f)` / `.then(f,g)` | clean |
+| `async fn` / `await Promise.resolve` | clean |
+| `Promise.all` / `Promise.race` | clean |
+| **`.catch(f)`** | **LEAK: `__make_callback`** ← fixed here |
+| `.finally(f)` | LEAK: `__make_callback` (residual) |
+| `new Promise(executor)` | LEAK: `Promise_new` + `__make_callback` (residual, see #2028) |
+
+So most of the originally-reported ~223-test gap had already closed via
+#1326/#1326c; the live leaks at this point are `.catch`, `.finally`, and the
+`new Promise` executor.
+
+### This slice — standalone `.catch`
+
+`.catch(onRejected)` ≡ `.then(undefined, onRejected)` (§27.2.5.1). Lowered it
+through the existing native-`$Promise` then-machinery instead of the host
+import:
+
+- `src/codegen/expressions/calls.ts`: added a standalone `.catch` branch
+  alongside the standalone `.then` branch — `emitStandalonePromiseThen(promise,
+  null /*onFulfilled*/, onRejected)`. The chained promise propagates a
+  fulfilled receiver unchanged (identity-fulfill wrapper) and routes a
+  rejection through the user's `onRejected`.
+- `src/codegen/expressions.ts`: extended the `isAsyncCallExpression` standalone
+  guard to exclude `.catch` (it already excluded `.then`). Without this the
+  `.catch` result — already a `$Promise` — was double-wrapped by
+  `wrapAsyncReturn`, producing a Promise-of-Promise that yielded `illegal cast`
+  / `NaN` when the chained result was consumed.
+
+Result: `.catch` (standalone) no longer emits `Promise_catch` /
+`__make_callback`. Inline `Promise.resolve(x).catch(f).then(g)` and rejection
+routing both verified at runtime; brought to parity with `.then`.
+
+### Validation
+
+- `tests/issue-1326.test.ts` — 16/16 pass, including 2 new WASI `.catch` cases
+  (rejection routing → reason+3; fulfilled promise skips `.catch`, value flows).
+- `tsc --noEmit` clean; prettier clean; host-mode async suites
+  (`async-await`, `issue-1042`) unchanged/pass.
+
+### Remaining residual (NOT in this PR)
+
+- **`.finally(f)`** — still leaks `__make_callback`. Needs synthesized
+  pass-through wrappers (`(v)=>{f();return v}` / `(e)=>{f();throw e}`) that the
+  current `emitStandalonePromiseThen` user-closure callback path doesn't express
+  directly. Follow-up.
+- **`new Promise(executor)`** — leaks `Promise_new` + `__make_callback` and the
+  executor body never runs (separate root cause, see #2028 re-analysis / PR
+  #1543).
+- **Native `$Promise` stored in a `const`/var then re-consumed** — throws
+  `illegal cast` (pre-existing; affects `.then` too, not introduced here).

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -167,7 +167,13 @@ function isAsyncCallExpression(ctx: CodegenContext, expr: ts.CallExpression): bo
   if (
     isStandalonePromiseActive(ctx) &&
     ts.isPropertyAccessExpression(expr.expression) &&
-    expr.expression.name.text === "then"
+    (expr.expression.name.text === "then" ||
+      // (#2165) `.catch` lowers to the same native `$Promise` then-machinery
+      // in standalone mode (`.catch(f)` ≡ `.then(undefined, f)`); it already
+      // returns a `$Promise`, so it must NOT be re-wrapped by `wrapAsyncReturn`
+      // (double-wrapping yields a Promise-of-Promise → illegal cast / NaN when
+      // the chained result is consumed).
+      expr.expression.name.text === "catch")
   ) {
     const receiverType = ctx.checker.getTypeAtLocation(expr.expression.expression);
     const receiverSym = receiverType.getSymbol()?.name;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6569,6 +6569,24 @@ function compileCallExpression(
             return { kind: "externref" };
           }
 
+          // (#2165) Standalone `.catch(onRejected)` ≡ `.then(undefined, onRejected)`
+          // per §27.2.5.1. Reuse the native `$Promise` then-machinery so WASI
+          // mode doesn't leak the `Promise_catch` / `__make_callback` host
+          // imports. The chained promise still propagates a fulfilled receiver
+          // unchanged (onFulfilled = null) and routes a rejection through the
+          // user's onRejected continuation.
+          if (isStandalonePromiseActive(ctx) && method === "catch") {
+            const liveBuffers: Instr[][] = [];
+            try {
+              const promiseInstrs = compilePromiseThenReceiverBuffer(ctx, fctx, propAccess.expression, liveBuffers);
+              const onRejected = compileStandalonePromiseThenCallback(ctx, fctx, expr.arguments[0], liveBuffers);
+              emitStandalonePromiseThen(ctx, fctx, promiseInstrs, null, onRejected);
+            } finally {
+              for (const b of liveBuffers) ctx.liveBodies.delete(b);
+            }
+            return { kind: "externref" };
+          }
+
           // Determine import name: use Promise_then2 for .then(cb1, cb2)
           const useThen2 = method === "then" && expr.arguments.length >= 2;
           const importName = useThen2 ? "Promise_then2" : `Promise_${method}`;

--- a/tests/issue-1326.test.ts
+++ b/tests/issue-1326.test.ts
@@ -224,4 +224,49 @@ describe("#1326 Phase 1C-B — WASI microtask queue + Promise.then", () => {
     (exports.__drain_microtasks as () => void)();
     expect((exports.value as () => number)()).toBe(7);
   });
+
+  // (#2165) Standalone `.catch(onRejected)` ≡ `.then(undefined, onRejected)`.
+  // Removes the `Promise_catch` / `__make_callback` host-import leak in WASI
+  // mode (the `instantiateWasi` helper asserts no `Promise_then` import, which
+  // also covers the catch lowering since it routes through the same native
+  // then-machinery).
+  it("routes a rejected promise through .catch in WASI mode", async () => {
+    const exports = await instantiateWasi(`
+      let out = 0;
+      export function schedule(): number {
+        Promise.reject(5).catch((reason: number) => {
+          out = reason + 3;
+          return out;
+        });
+        return out;
+      }
+      export function value(): number { return out; }
+    `);
+
+    expect((exports.schedule as () => number)()).toBe(0);
+    (exports.__drain_microtasks as () => void)();
+    expect((exports.value as () => number)()).toBe(8);
+  });
+
+  it("a fulfilled promise skips its .catch handler in WASI mode", async () => {
+    const exports = await instantiateWasi(`
+      let out = 0;
+      export function schedule(): number {
+        Promise.resolve(10).catch((_reason: number) => {
+          out = 999;
+          return out;
+        }).then((v: number) => {
+          out = v;
+          return out;
+        });
+        return out;
+      }
+      export function value(): number { return out; }
+    `);
+
+    expect((exports.schedule as () => number)()).toBe(0);
+    (exports.__drain_microtasks as () => void)();
+    // catch is skipped (no rejection); the fulfilled value (10) flows through.
+    expect((exports.value as () => number)()).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the standalone `.catch` slice of the #2165 Promise/async residual.

A fresh standalone/WASI gap census shows most of the originally-reported ~223-test gap had already closed via #1326/#1326c. The live host-import leaks at this point were `.catch`, `.finally`, and `new Promise(executor)`. **This PR closes `.catch`.**

`.catch(onRejected)` ≡ `.then(undefined, onRejected)` (ECMA-262 §27.2.5.1). Lowered through the existing native-`$Promise` then-machinery instead of the `Promise_catch` / `__make_callback` host imports.

## Changes

- `src/codegen/expressions/calls.ts`: standalone `.catch` branch alongside the standalone `.then` branch — `emitStandalonePromiseThen(promise, null, onRejected)`. Fulfilled receiver propagates unchanged (identity-fulfill wrapper); rejection routes through the user `onRejected`.
- `src/codegen/expressions.ts`: extended the `isAsyncCallExpression` standalone guard to also exclude `.catch` (it already excluded `.then`). Without this the `.catch` result — already a `$Promise` — was double-wrapped by `wrapAsyncReturn`, yielding a Promise-of-Promise that threw `illegal cast` / `NaN` when the chained result was consumed.

Result: standalone `.catch` no longer emits `Promise_catch` / `__make_callback`; inline `Promise.resolve(x).catch(f).then(g)` and rejection routing both verified at runtime, at parity with `.then`.

## Validation

- `tests/issue-1326.test.ts` — 16/16 pass (2 new WASI `.catch` cases: rejection routing; fulfilled promise skips `.catch`, value flows through).
- `tsc --noEmit` clean; prettier clean; host-mode `async-await` + `issue-1042` unchanged/pass.

## Residual (follow-ups, documented in the issue)

- `.finally(f)` — needs synthesized pass-through wrappers.
- `new Promise(executor)` — #2028 (executor body never runs; see PR #1543 re-analysis).
- Native `$Promise` stored in a `const`/var then re-consumed → `illegal cast` (pre-existing; affects `.then` too, not introduced here).

Spec: ECMA-262 §27.2.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)