### PR TITLE
fix(#2180): host-mode Proxy completion — trap discovery, construction TypeErrors, revocation

### DIFF
--- a/plan/issues/2180-host-mode-proxy-completion-to-100.md
+++ b/plan/issues/2180-host-mode-proxy-completion-to-100.md
@@ -1,9 +1,11 @@
 ---
 id: 2180
 title: "Host-mode Proxy: close remaining test262 failures toward 100% (invariant checks, Wasm-typed targets, revocation lifecycle)"
-status: ready
+status: done
+assignee: se2
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-06-16
+completed: 2026-06-16
 priority: top
 feasibility: hard
 reasoning_effort: high
@@ -150,3 +152,76 @@ non-skipped `built-ins/Proxy`.
 File overlap with #1100/#1355 in `new-super.ts`/`calls.ts`/`runtime.ts` — land #2180
 first (small additive runtime fixes); standalone tracks branch on `ctx.standalone`.
 Adding `Proxy` to `NAMESPACE_NON_CALLABLE` must not shadow `new Proxy`.
+
+## Implementation Notes (se2, 2026-06-16)
+
+Host-mode `built-ins/Proxy` went **71 → 112 pass / 311** (+41; 23 % → 36 %),
+no `built-ins/Reflect` regression (119/153 ≈ 78 %, well above the ≥72 % gate).
+The architect plan's first-order diagnosis (construction TypeErrors + wrap
+Wasm-struct targets) was correct but **incomplete** — empirical triage found the
+dominant defect was trap **discovery**, not target wrapping. Root causes and
+fixes:
+
+1. **Trap discovery was the real blocker (largest win).** A compiled object
+   literal handler is an opaque WasmGC struct; `handler[trapName]` returns
+   `undefined` for every trap, so the host's native `Proxy` fired **no traps**
+   and silently fell through to the target. The architect plan's `_wrapForHost`
+   route does **not** work here: `_wrapForHost(handler).get` runs the closure
+   value back through `_wrapForHost` (because the closure-field detector only
+   matched `_isWasmStruct(val)` *after* the mirror had already wrapped it),
+   yielding a non-callable object. Fix: read each trap closure **directly off
+   the raw struct** via the per-shape `__sget_<name>` getter (+ sidecar
+   fallback) in `_structFieldRaw`, then wrap with
+   `_maybeWrapCallableUnknownArity`. The result is a plain-object *bridge
+   handler* the host can read; each bridge method forwards to the closure with
+   `this` = the **raw** handler struct so trap-receiver identity
+   (`assert.sameValue(this, handler)`) holds. `new-super.ts`/`calls.ts` are
+   unchanged on the wrapping side — all of this is in `runtime.ts`.
+
+2. **Construction TypeErrors** (§28.2.1.1 step 1/2): `_hostProxyConstruct` /
+   `_hostProxyConstructRevocable` throw `TypeError` when target/handler is not
+   object-like, replacing the old swallow-and-return-target behaviour. The raw
+   struct stays as `[[ProxyTarget]]` so `t === target` holds in traps.
+
+3. **`Proxy(t,h)` without `new`** → added `"Proxy"` to `NAMESPACE_NON_CALLABLE`
+   in `calls.ts` (bare-identifier call guard only; `new Proxy` and
+   `Proxy.revocable(...)` reach other branches, so no shadowing).
+
+4. **Proxy-over-struct misclassified as a struct.** `_isWasmStruct` probes by
+   "null proto + set throws"; a Proxy whose target is a WasmGC struct inherits
+   the null proto and forwards the probe-set to the opaque target (which
+   throws), so the heuristic flagged the Proxy itself as a struct — routing
+   `delete`/`in`/`getPrototypeOf` to the sidecar instead of the host trap.
+   Fixed with a `_userProxies` WeakSet that `_isWasmStruct` short-circuits
+   (+9 pass).
+
+5. **Revoked-proxy errors were swallowed.** `__extern_get`/`__extern_has`/
+   `_safeSet`/`__delete_property` wrap their host read in a try/catch that
+   falls through to a struct-getter path; a revoked-proxy `TypeError` was
+   eaten there. Added `_isRevokedProxyError` and re-throw it in each.
+
+### Out of scope (separate front-end codegen issues, not host-proxy plumbing)
+Empirically confirmed via probes that these remaining buckets fail **before**
+the runtime proxy path:
+- `construct/**` — proxy target is a `class`; the extern-class machinery
+  ("No dependency provided for extern class …") is unrelated.
+- `with`-statement tests (#1387).
+- A function that returns a complex object literal (`allowProxyTraps` helper)
+  compiles to `return null`, so handlers built through it arrive as `null` —
+  many `*/call-parameters-prototype.js` and several `null-handler` revocation
+  tests depend on it.
+- `delete p.x` / `Reflect.deleteProperty` on an `any`-typed proxy receiver: the
+  bare `delete` statement never emits `__delete_property` (the front-end
+  resolves/elides it), so the trap can't fire regardless of runtime. The
+  `_userProxies` + revoked-rethrow fixes are in place for when that path is
+  fixed.
+
+### Files changed
+- `src/runtime.ts` — `_hostProxyConstruct`, `_hostProxyConstructRevocable`,
+  `_buildProxyBridgeHandler`, `_structFieldRaw`, `_isObjectLike`,
+  `_isRevokedProxyError`, `_userProxies`; rewired `proxy_create` intent +
+  `__proxy_revocable` host import; revoked-rethrow in the four boundary helpers.
+- `src/codegen/expressions/calls.ts` — `"Proxy"` in `NAMESPACE_NON_CALLABLE`.
+- `src/codegen/expressions/new-super.ts` — no-arg `new Proxy()` now routes
+  through `__proxy_create(null, null)` so the runtime raises the TypeError.
+- `tests/issue-2180.test.ts` — construction-throws + trap-dispatch coverage.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2113,7 +2113,12 @@ function compileCallExpression(
             : (unwrapped as ts.TypeAssertion).expression;
     }
     if (ts.isIdentifier(unwrapped)) {
-      const NAMESPACE_NON_CALLABLE = new Set(["Math", "JSON", "Reflect", "Atomics"]);
+      // #2180 — `Proxy(t,h)` without `new` must throw TypeError: the Proxy
+      // exotic has [[Construct]] but no [[Call]]. The `new Proxy` form is
+      // handled separately in new-super.ts; member calls like
+      // `Proxy.revocable(...)` reach a different branch (this guard only fires
+      // for a bare-identifier callee), so listing it here is safe.
+      const NAMESPACE_NON_CALLABLE = new Set(["Math", "JSON", "Reflect", "Atomics", "Proxy"]);
       if (NAMESPACE_NON_CALLABLE.has(unwrapped.text)) {
         // Evaluate arguments for their side effects (spec: argument list is
         // evaluated before the [[Call]] check would normally run), then throw.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2158,8 +2158,23 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
       return { kind: "externref" };
     }
-    // No arguments — null proxy
-    fctx.body.push({ op: "ref.null.extern" });
+    // No arguments — `new Proxy()`. Per §28.2.1.1 the missing target/handler
+    // are `undefined`, which are not objects, so construction throws TypeError.
+    // Route through __proxy_create(null, null) so the runtime raises it (#2180).
+    {
+      fctx.body.push({ op: "ref.null.extern" });
+      fctx.body.push({ op: "ref.null.extern" });
+      const proxyIdx = ensureLateImport(
+        ctx,
+        "__proxy_create",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      flushLateImportShifts(ctx, fctx);
+      if (proxyIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: proxyIdx });
+      }
+    }
     return { kind: "externref" };
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1666,8 +1666,18 @@ function _toPropertyDescriptorValidate(
 }
 
 /** Return true when `obj` is a WasmGC struct (opaque to JS). */
+// #2180 — user `new Proxy` / `Proxy.revocable` objects we construct. A Proxy
+// over a WasmGC-struct target otherwise trips `_isWasmStruct`'s probe: it has a
+// null prototype (inherited from the struct target) and a property set on it
+// forwards to the opaque struct and throws "opaque" — so the heuristic
+// misclassifies the Proxy AS a struct, routing `delete`/`in`/etc. to the
+// sidecar instead of letting the host fire the user trap. Excluding registered
+// user proxies keeps them on the host MOP path.
+const _userProxies = new WeakSet<object>();
+
 function _isWasmStruct(obj: any): boolean {
   if (obj == null || typeof obj !== "object") return false;
+  if (_userProxies.has(obj)) return false;
   // WasmGC structs have a null prototype and no own keys — quick heuristic
   // that avoids try/catch on normal objects.
   try {
@@ -3888,6 +3898,9 @@ function _safeSet(
   try {
     obj[key] = val;
   } catch (e) {
+    // #2180 — writing to a revoked proxy throws TypeError; propagate it
+    // instead of silently diverting to the sidecar.
+    if (_isRevokedProxyError(e)) throw e;
     // For non-WasmGC objects (frozen/sealed JS objects),
     // fall through to sidecar set — preserves original behavior for non-strict callers.
     _sidecarSet(obj, key, val);
@@ -4645,6 +4658,174 @@ function _unwrapForHost(v: any): any {
   if (v == null || typeof v !== "object") return v;
   const orig = _hostProxyReverse.get(v);
   return orig ?? v;
+}
+
+// ── #2180 — host-mode user `new Proxy` / `Proxy.revocable` construction ──────
+//
+// A compiled `new Proxy(target, handler)` reaches the host with `target` and
+// `handler` as raw WasmGC structs (object literals compile to opaque structs).
+// Two problems must be solved for the host's native Proxy MOP to behave per
+// §10.5 / §28.2:
+//
+//  1. **Trap discovery.** The host reads `handler[trapName]` to find each trap.
+//     On a raw struct every read returns `undefined` (opaque), so NO trap ever
+//     fires and every operation silently falls through to the target. We build
+//     a plain-object *bridge handler* whose trap methods forward to the Wasm
+//     closures stored on the struct, invoked via `_wrapForHost`'s closure
+//     bridge (which threads `this` = the original handler struct).
+//
+//  2. **Identity.** Spec trap signatures hand the user `target`/`handler`
+//     identities (`get(t, p, recv)` with `t === target`, `this === handler`).
+//     The user's source holds the *raw* structs, so the values the trap sees
+//     must compare equal to those raw structs. We therefore use the raw struct
+//     as the host `[[ProxyTarget]]` (preserving `t === target`) and re-thread
+//     `this`/the target arg back to the raw handler/target inside each bridge.
+//
+// Construction also enforces the §28.2.1.1 step-1/2 `TypeError`s: both target
+// and handler must be objects (a WasmGC struct counts as an object).
+const _PROXY_TRAP_NAMES = [
+  "apply",
+  "construct",
+  "defineProperty",
+  "deleteProperty",
+  "get",
+  "getOwnPropertyDescriptor",
+  "getPrototypeOf",
+  "has",
+  "isExtensible",
+  "ownKeys",
+  "preventExtensions",
+  "set",
+  "setPrototypeOf",
+] as const;
+
+function _isObjectLike(v: any): boolean {
+  if (v === null || v === undefined) return false;
+  const t = typeof v;
+  return t === "object" || t === "function";
+}
+
+/**
+ * #2180 — a revoked Proxy throws a `TypeError` from EVERY internal method
+ * ("Cannot perform 'get' on a proxy that has been revoked"). The boundary
+ * helpers (`__extern_get` etc.) wrap their host reads in a try/catch that
+ * silently falls through to a struct-getter path — which would swallow this
+ * spec-mandated TypeError and return `undefined` instead. Detect it so callers
+ * can re-throw, letting the user program's `assert.throws(TypeError, …)` see it.
+ */
+function _isRevokedProxyError(e: any): boolean {
+  return (
+    e instanceof TypeError &&
+    typeof e.message === "string" &&
+    e.message.includes("proxy that has been revoked")
+  );
+}
+
+/**
+ * #2180 — build a real host Proxy from a user `new Proxy(target, handler)`.
+ * `ctor` is "Proxy" or "Proxy.revocable" for the spec-mandated TypeError text.
+ * Returns the constructed Proxy (revocable=false) — callers that need the
+ * `{proxy, revoke}` pair call `_hostProxyConstructRevocable`.
+ */
+function _hostProxyConstruct(
+  target: any,
+  handler: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+  ctor: string,
+): any {
+  if (!_isObjectLike(target)) {
+    throw new TypeError(`Cannot create ${ctor} with a non-object as target`);
+  }
+  if (!_isObjectLike(handler)) {
+    throw new TypeError(`Cannot create ${ctor} with a non-object as handler`);
+  }
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState);
+  // Use the raw target as [[ProxyTarget]] so `t === target` holds in traps and
+  // `proxy`-vs-`target` identity probes resolve. WasmGC structs are valid
+  // exotic targets for the host engine; the bridge handler routes every MOP
+  // operation through the user trap (or, when a trap is absent, the host's
+  // default which reads the struct via the same boundary helpers).
+  const proxy = new Proxy(target, bridgeHandler);
+  _userProxies.add(proxy);
+  return proxy;
+}
+
+/** #2180 — `Proxy.revocable(target, handler)` → `{ proxy, revoke }`. */
+function _hostProxyConstructRevocable(
+  target: any,
+  handler: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+): any {
+  if (!_isObjectLike(target)) {
+    throw new TypeError("Cannot create proxy with a non-object as target");
+  }
+  if (!_isObjectLike(handler)) {
+    throw new TypeError("Cannot create proxy with a non-object as handler");
+  }
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState);
+  const rv = Proxy.revocable(target, bridgeHandler);
+  if (rv && typeof rv.proxy === "object" && rv.proxy !== null) _userProxies.add(rv.proxy);
+  return rv;
+}
+
+/**
+ * #2180 — read a (possibly closure-valued) field off a WasmGC struct WITHOUT
+ * routing through `_wrapForHost` (whose mirror double-wraps a closure field
+ * into a non-callable object — the very bug that left every user trap
+ * undiscovered). Prefers the per-shape `__sget_<name>` field getter, then the
+ * sidecar store. Returns `undefined` when the field is absent.
+ */
+function _structFieldRaw(obj: any, name: string, exports: Record<string, Function> | undefined): any {
+  if (exports) {
+    const getter = exports[`__sget_${name}`];
+    if (typeof getter === "function") {
+      try {
+        const v = getter(obj);
+        if (v !== undefined && v !== null) return v;
+      } catch {
+        /* field not present on this struct shape */
+      }
+    }
+  }
+  return _sidecarGet(obj, name);
+}
+
+/**
+ * #2180 — translate a (possibly WasmGC-struct) user handler into a plain-object
+ * handler the host engine can read trap functions from. Each present trap is
+ * read directly off the struct and wrapped into a JS callable that dispatches
+ * the underlying Wasm closure with `this` = the raw handler struct (so the
+ * user-observable `this` inside the trap is identity-equal to the `handler`
+ * value the compiled program holds). A trap the user did not define is omitted,
+ * so the host falls back to its default (ordinary) behavior for that operation
+ * — matching the spec, where a missing trap means "use the target's internal
+ * method".
+ */
+function _buildProxyBridgeHandler(
+  handler: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+): any {
+  // Plain JS handler (created host-side, not a WasmGC struct) already exposes
+  // its traps directly — use it verbatim so identity/`this` are untouched.
+  if (!_isWasmStruct(handler)) return handler;
+
+  const exports = callbackState?.getExports();
+  const bridge: Record<string, any> = {};
+  for (const name of _PROXY_TRAP_NAMES) {
+    const rawTrap = _structFieldRaw(handler, name, exports);
+    if (rawTrap == null) continue;
+    const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
+    if (typeof callable !== "function") continue;
+    // Forward to the user trap with `this` = the raw handler struct. The
+    // closure bridge installs that struct as `__current_this`, so the trap
+    // body's `this` is the same value the program sees as `handler` and
+    // `assert.sameValue(this, handler)` passes. Spec-correct args (raw target,
+    // property key, receiver = our user Proxy) flow through unchanged.
+    bridge[name] = function (this: any, ...args: any[]): any {
+      return (callable as Function).apply(handler, args);
+    };
+  }
+  return bridge;
 }
 
 // ── #1234 — sparse-aware Array.prototype fast paths ─────────────────────────
@@ -6431,8 +6612,11 @@ assert._isSameValue = isSameValue;
           if (obj != null && typeof obj === "object") {
             try {
               if (Object.getPrototypeOf(obj) !== null && key in Object(obj)) return obj[key];
-            } catch {
-              /* fall through to the generic path */
+            } catch (e) {
+              // #2180 — a revoked-proxy TypeError must propagate, not be
+              // swallowed by the struct-getter fallback below.
+              if (_isRevokedProxyError(e)) throw e;
+              /* otherwise fall through to the generic path */
             }
           }
           const val = _safeGet(obj, key, callbackState);
@@ -6653,7 +6837,9 @@ assert._isSameValue = isSameValue;
           // user-assigned `o.x = undefined` must still report present.
           try {
             if (key in obj) return 1;
-          } catch {
+          } catch (e) {
+            // #2180 — `key in revokedProxy` throws TypeError; propagate it.
+            if (_isRevokedProxyError(e)) throw e;
             /* opaque struct or non-object obj */
           }
           const sc = _wasmStructProps.get(obj);
@@ -8486,7 +8672,15 @@ assert._isSameValue = isSameValue;
         return (iterable: any, keyFn: any): any =>
           (Object as any).groupBy(iterable, _maybeWrapCallable(keyFn, 2, callbackState));
       // Proxy.revocable(target, handler) — creates a revocable Proxy (#965)
-      if (name === "__proxy_revocable") return (target: any, handler: any): any => Proxy.revocable(target, handler);
+      if (name === "__proxy_revocable")
+        return (target: any, handler: any): any => {
+          // #2180 — same construction path as `new Proxy`: validate the
+          // target/handler are objects (else TypeError), bridge a WasmGC-struct
+          // handler so the host can read its traps, and keep the raw target as
+          // [[ProxyTarget]] for identity. Host enforces revoked-throws +
+          // revoke idempotence on the returned pair.
+          return _hostProxyConstructRevocable(target, handler, callbackState);
+        };
       // ── Reflect.* host dispatch (#1466) ─────────────────────────────────
       // Each handler delegates to the host's Reflect.X so Proxy targets see
       // their traps fire and boolean returns are preserved. Wasm structs
@@ -9150,7 +9344,9 @@ assert._isSameValue = isSameValue;
             try {
               const k = typeof key === "symbol" ? key : String(key);
               return delete obj[k] ? 1 : 0;
-            } catch {
+            } catch (e) {
+              // #2180 — deleting from a revoked proxy throws TypeError; propagate it.
+              if (_isRevokedProxyError(e)) throw e;
               // Non-configurable in strict mode throws TypeError; report failure.
               return 0;
             }
@@ -11104,20 +11300,7 @@ assert._isSameValue = isSameValue;
       });
     }
     case "proxy_create":
-      return (target: any, handler: any) => {
-        // Wrap the Wasm struct target in a real JS Proxy with the given handler.
-        // If handler is null/undefined, use an empty handler (transparent proxy).
-        // If target is null/undefined, fall back to an empty object as target.
-        const t = target ?? {};
-        const h = handler ?? {};
-        try {
-          return new Proxy(t, h);
-        } catch {
-          // If Proxy construction fails (e.g. handler is not an object),
-          // return target as-is (standalone fallback behavior).
-          return t;
-        }
-      };
+      return (target: any, handler: any) => _hostProxyConstruct(target, handler, callbackState, "Proxy");
     default:
       // #1858 C9a: fail loud instead of silently binding an unhandled import
       // intent to a no-op. A no-op `() => {}` returns `undefined` for every

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4714,11 +4714,7 @@ function _isObjectLike(v: any): boolean {
  * can re-throw, letting the user program's `assert.throws(TypeError, …)` see it.
  */
 function _isRevokedProxyError(e: any): boolean {
-  return (
-    e instanceof TypeError &&
-    typeof e.message === "string" &&
-    e.message.includes("proxy that has been revoked")
-  );
+  return e instanceof TypeError && typeof e.message === "string" && e.message.includes("proxy that has been revoked");
 }
 
 /**

--- a/tests/issue-2180.test.ts
+++ b/tests/issue-2180.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { runTest262File } from "./test262-runner.js";
+
+/**
+ * #2180 — Host-mode `Proxy` completion.
+ *
+ * In JS-host mode a compiled `new Proxy(target, handler)` reaches the runtime
+ * with `target`/`handler` as opaque WasmGC structs. Three defects kept
+ * `built-ins/Proxy` conformance stuck at ~23 % after #1466:
+ *
+ *  1. Construction never threw the §28.2.1.1 `TypeError`s for a non-object
+ *     target/handler (`proxy_create` swallowed the native throw and returned
+ *     the target).
+ *  2. The host could not discover ANY trap on the struct handler — every
+ *     `handler[trapName]` read on an opaque struct returns `undefined`, so no
+ *     trap ever fired and operations silently fell through to the target.
+ *     `proxy_create` now bridges each trap closure off the raw struct (via the
+ *     `__sget_<name>` field getter + the closure-wrap helper) into a
+ *     plain-object handler the host can read, with `this` re-threaded to the
+ *     raw handler struct for trap-receiver identity.
+ *  3. `Proxy(t,h)` without `new` did not throw (`Proxy` was missing from
+ *     `NAMESPACE_NON_CALLABLE`).
+ *
+ * The boundary helpers (`__extern_get`/`__extern_has`/`__extern_set`/
+ * `__delete_property`) also re-throw a revoked-proxy `TypeError` instead of
+ * swallowing it in their struct-getter fallback.
+ *
+ * These tests assert the buckets that flipped to `pass`. Cases that depend on
+ * unrelated codegen (extern-class proxy targets, `with`, object-literal
+ * function returns) remain out of scope and are not asserted here.
+ */
+
+const TEST262 = "/workspace/test262";
+const ROOT = `${TEST262}/test/built-ins/Proxy`;
+
+// Construction TypeErrors (§28.2.1.1 step 1/2) — target/handler must be objects.
+const constructionThrows = [
+  "create-target-not-object-throw-number.js",
+  "create-target-not-object-throw-string.js",
+  "create-target-not-object-throw-boolean.js",
+  "create-target-not-object-throw-null.js",
+  "create-target-not-object-throw-undefined.js",
+  "create-target-not-object-throw-symbol.js",
+  "create-handler-not-object-throw-number.js",
+  "create-handler-not-object-throw-string.js",
+  "create-handler-not-object-throw-boolean.js",
+  "create-handler-not-object-throw-null.js",
+  "create-handler-not-object-throw-undefined.js",
+  "create-handler-not-object-throw-symbol.js",
+];
+
+// Trap dispatch + receiver/argument fidelity — the host now finds the struct
+// handler's traps and fires them with spec-correct arguments.
+const trapDispatch = [
+  "get/call-parameters.js",
+  "set/call-parameters.js",
+  "getPrototypeOf/call-parameters.js",
+];
+
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+maybe("#2180 host-mode Proxy", () => {
+  describe("construction throws TypeError for non-object target/handler", () => {
+    for (const rel of constructionThrows) {
+      it(rel, async () => {
+        const r = await runTest262File(`${ROOT}/${rel}`, "built-ins/Proxy");
+        expect(r.status, `error: ${(r as any).error ?? ""}`).toBe("pass");
+      });
+    }
+  });
+
+  describe("trap dispatch + receiver/argument fidelity", () => {
+    for (const rel of trapDispatch) {
+      it(rel, async () => {
+        const r = await runTest262File(`${ROOT}/${rel}`, "built-ins/Proxy");
+        expect(r.status, `error: ${(r as any).error ?? ""}`).toBe("pass");
+      });
+    }
+  });
+});

--- a/tests/issue-2180.test.ts
+++ b/tests/issue-2180.test.ts
@@ -52,11 +52,7 @@ const constructionThrows = [
 
 // Trap dispatch + receiver/argument fidelity — the host now finds the struct
 // handler's traps and fires them with spec-correct arguments.
-const trapDispatch = [
-  "get/call-parameters.js",
-  "set/call-parameters.js",
-  "getPrototypeOf/call-parameters.js",
-];
+const trapDispatch = ["get/call-parameters.js", "set/call-parameters.js", "getPrototypeOf/call-parameters.js"];
 
 const maybe = existsSync(TEST262) ? describe : describe.skip;
 


### PR DESCRIPTION
## #2180 — Host-mode Proxy completion

In JS-host mode a compiled `new Proxy(target, handler)` reaches the runtime with
both operands as opaque WasmGC structs. The host's native `Proxy` then found **no
traps** on the struct handler (every `handler[trapName]` read on an opaque struct
returns `undefined`), so it silently fell through to the target — leaving
`built-ins/Proxy` stuck at ~23%.

### Root cause and fixes (all in `src/runtime.ts` unless noted)
1. **Trap discovery (the dominant defect).** `proxy_create` / `__proxy_revocable`
   now build a plain-object *bridge handler* whose trap methods are read
   **directly off the raw struct** (`__sget_<name>` + sidecar) and wrapped into
   JS callables, with `this` re-threaded to the raw handler struct so
   trap-receiver identity (`assert.sameValue(this, handler)`) holds. The
   architect-suggested `_wrapForHost` route double-wrapped the closure field into
   a non-callable object, which is why no trap fired.
2. **Construction TypeErrors** (§28.2.1.1 step 1/2): a non-object target/handler
   now throws `TypeError` instead of being swallowed.
3. **`Proxy(t,h)` without `new`** throws (added to `NAMESPACE_NON_CALLABLE` in
   `calls.ts`); no-arg `new Proxy()` routes through `__proxy_create(null,null)`
   (`new-super.ts`).
4. **Proxy-over-struct misclassification**: a `_userProxies` WeakSet excludes user
   proxies from `_isWasmStruct` (a proxy over a struct target was flagged as a
   struct, routing `delete`/`in` to the sidecar).
5. **Revoked-proxy errors** are re-thrown in `__extern_get`/`__extern_has`/
   `_safeSet`/`__delete_property` instead of being eaten by the struct-getter
   fallback.

### Results
- Host `built-ins/Proxy`: **71 → 112 / 311** pass (+41; 23% → 36%).
- No `built-ins/Reflect` regression (119/153 ≈ 78%, well above the ≥72% gate).
- No regression in `proxy-passthrough` / `struct-proxy-wrappers` (4 pre-existing
  failures identical on clean main).
- New coverage: `tests/issue-2180.test.ts` (construction-throws + trap-dispatch).

Out of scope (separate front-end issues, documented in the issue file): extern-class
proxy targets, `with`, object-literal-returning helpers compiling to `return null`,
and bare `delete p.x` on `any`-typed proxies being elided before `__delete_property`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)