### PR TITLE
chore(#2096): oracle_version stamp + cross-version diff guard

### DIFF
--- a/plan/issues/2096-oracle-version-stamp-diff-guard.md
+++ b/plan/issues/2096-oracle-version-stamp-diff-guard.md
@@ -1,10 +1,12 @@
 ---
 id: 2096
 title: "oracle_version stamping + cross-version diff guard (prerequisite for the #1945 oracle flip)"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -46,3 +48,31 @@ even if #1945's steps split.
 
 #1945 (upstream slug, oracle precision) covers the oracle change itself;
 the versioning protocol is unfiled. New (analysis program).
+
+## Resolution (2026-06-16, dev-b)
+
+Implemented the version-stamp protocol:
+
+- **Single source of truth**: `tests/test262-oracle-version.ts` exports
+  `ORACLE_VERSION` (opaque monotonic integer, currently `1`) plus an
+  append-only `ORACLE_VERSION_HISTORY`. A "HOW TO BUMP" doc-comment ties the
+  bump to the `ORACLE_REBASE=1` flip PR — this is the owner the issue asked for.
+- **Row stamp**: `recordResult` (`tests/test262-shared.ts`) writes
+  `oracle_version` on every JSONL row.
+- **Report stamp**: `scripts/build-test262-report.mjs` carries
+  `oracle_version` on the merged report and sets `oracle_version_mixed: true`
+  when shards disagree (a mixed report must never be promoted).
+- **Diff guard**: `scripts/diff-test262.ts` reads the oracle version from both
+  JSONLs and **refuses a cross-version diff with exit 2** unless
+  `ORACLE_REBASE=1`. A MIXED file is a hard error (exit 2) regardless of the
+  flag. Unstamped (pre-#2096) files fall back to legacy same-oracle behaviour
+  with an informational note. Exit 2 slots into the existing
+  `test262-sharded.yml` contract, which already treats `diff_exit > 1` as a
+  hard CI failure — so the gate halts on oracle skew instead of reading it as
+  regressions.
+- **Re-seed path**: `promote-baseline` needs no change — on the flip PR's
+  merge it promotes main's JSONL, which already carries the bumped version.
+
+Tests: `tests/issue-2096.test.ts` (7 cases) — same-version diff, cross-version
+refuse, `ORACLE_REBASE=1` allow, mixed hard-refuse, unstamped legacy, and
+report stamping/mixed-flag. All pass.

--- a/scripts/build-test262-report.mjs
+++ b/scripts/build-test262-report.mjs
@@ -766,6 +766,12 @@ async function main() {
     ["proposal", createCounts()],
   ]);
   const rootCauseRecords = [];
+  // #2096: capture the oracle_version stamped on the result rows so the
+  // merged report carries the same identity. If rows disagree (a merge of
+  // shards produced under different oracles) we keep the LOWEST seen and flag
+  // it as mixed — a mixed report should never be promoted to a baseline.
+  let oracleVersion;
+  let oracleVersionMixed = false;
 
   const rl = createInterface({
     input: createReadStream(args.input),
@@ -775,6 +781,14 @@ async function main() {
   for await (const line of rl) {
     if (!line.trim()) continue;
     const record = JSON.parse(line);
+    if (typeof record.oracle_version === "number") {
+      if (oracleVersion === undefined) {
+        oracleVersion = record.oracle_version;
+      } else if (oracleVersion !== record.oracle_version) {
+        oracleVersionMixed = true;
+        oracleVersion = Math.min(oracleVersion, record.oracle_version);
+      }
+    }
     const status = record.status;
     const scope = record.scope ?? "standard";
     const scopeOfficial = record.scope_official ?? scope !== "proposal";
@@ -831,6 +845,12 @@ async function main() {
     timestamp: new Date().toISOString(),
     baseline_generated_at: args.baselineGeneratedAt || new Date().toISOString(),
     baseline_sha: args.baselineSha || "",
+    // #2096: oracle identity for the merged report. Carried so diff-test262
+    // can refuse cross-version comparisons. `oracle_version_mixed` flags a
+    // report assembled from shards run under different oracles — never promote
+    // such a report to a baseline.
+    oracle_version: oracleVersion ?? null,
+    ...(oracleVersionMixed ? { oracle_version_mixed: true } : {}),
     mode: {
       target,
       include_proposals: args.includeProposals ? 1 : 0,

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -274,11 +274,7 @@ async function run(
   // unstamped (pre-#2096) file as comparable to anything — there is no
   // recorded oracle to conflict with, so we fall back to the legacy behaviour
   // and only emit an informational note.
-  if (
-    baseOracle !== undefined &&
-    newOracle !== undefined &&
-    baseOracle !== newOracle
-  ) {
+  if (baseOracle !== undefined && newOracle !== undefined && baseOracle !== newOracle) {
     if (!oracleRebase) {
       console.error(
         `\n✖ Oracle-version guard (#2096): cross-version diff refused.\n` +

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -37,17 +37,42 @@ interface TestResult {
    * per-test `compile_timeout` exclusion otherwise hides.
    */
   compile_ms?: number;
+  /**
+   * #2096: opaque monotonic integer identifying the conformance oracle (the
+   * verdict logic: error classification + negative-expectation matching +
+   * required error precision). Stamped on every row by `recordResult`. Two
+   * runs with the same `oracle_version` apply identical verdict logic, so
+   * their rows are directly comparable; differing versions are not, and the
+   * diff is refused unless `ORACLE_REBASE=1`. Defined in
+   * tests/test262-oracle-version.ts.
+   */
+  oracle_version?: number;
 }
 
 type StatusMap = Map<string, TestResult>;
 
-async function loadJsonl(path: string): Promise<StatusMap> {
+interface LoadedJsonl {
+  map: StatusMap;
+  /**
+   * The oracle_version observed in the file. `undefined` if no row carried
+   * one (a pre-#2096 file). `"mixed"` if rows disagreed — a file assembled
+   * from shards run under different oracles, which must never be compared.
+   */
+  oracleVersion: number | "mixed" | undefined;
+}
+
+async function loadJsonl(path: string): Promise<LoadedJsonl> {
   const map: StatusMap = new Map();
+  let oracleVersion: number | "mixed" | undefined;
   const rl = createInterface({ input: createReadStream(path) });
   for await (const line of rl) {
     if (!line.trim()) continue;
     try {
       const entry = JSON.parse(line) as TestResult;
+      if (typeof entry.oracle_version === "number" && oracleVersion !== "mixed") {
+        if (oracleVersion === undefined) oracleVersion = entry.oracle_version;
+        else if (oracleVersion !== entry.oracle_version) oracleVersion = "mixed";
+      }
       if (entry.file) {
         map.set(entry.file, entry);
       }
@@ -55,7 +80,7 @@ async function loadJsonl(path: string): Promise<StatusMap> {
       // skip malformed lines
     }
   }
-  return map;
+  return { map, oracleVersion };
 }
 
 // Reads baseline metadata (baseline_generated_at, baseline_sha) from a report.json.
@@ -93,6 +118,14 @@ Options:
   --all                         Show all transitions (no limit)
   --quiet, -q                   Only show summary counts
   --baseline-meta <report.json> Read baseline_generated_at + baseline_sha to warn on stale baseline
+
+Environment:
+  ORACLE_REBASE=1               Allow a cross-oracle-version diff (#2096). By default a diff
+                                between two JSONL files whose rows carry different oracle_version
+                                stamps is refused (exit 2), because the verdict logic differed and
+                                the diff would read oracle skew as regressions. Set this only on the
+                                oracle-flip PR (e.g. #1945) to intentionally re-seed the baseline at
+                                the new oracle version.
   --path-filter <patterns>      Restrict the diff to tests whose path contains any of the
                                 pipe-separated substrings (same semantics as TEST262_PATH_FILTER).
                                 Used by #1954 scoped PR-time runs: the candidate JSONL only covers
@@ -144,7 +177,67 @@ async function run(
   baselineMetaPath?: string,
   pathFilter: string[] = [],
 ) {
-  let [baseline, newer] = await Promise.all([loadJsonl(baselinePath), loadJsonl(newPath)]);
+  const [baselineLoaded, newerLoaded] = await Promise.all([loadJsonl(baselinePath), loadJsonl(newPath)]);
+  let baseline = baselineLoaded.map;
+  let newer = newerLoaded.map;
+
+  // #2096: cross-version oracle guard. The oracle (verdict logic) decides
+  // pass/fail/CE; when it tightens (e.g. the #1945 trap-vs-TypeError upgrade)
+  // rows flip for the SAME compiler output. Diffing a baseline against a
+  // candidate produced under a DIFFERENT oracle reads that skew as regressions
+  // and trips the gate on oracle change, not code change. Refuse such a diff
+  // unless ORACLE_REBASE=1 — which is how the oracle-flip PR re-seeds the
+  // baseline at the new version (promote-baseline picks it up on merge).
+  const oracleRebase = process.env.ORACLE_REBASE === "1";
+  const baseOracle = baselineLoaded.oracleVersion;
+  const newOracle = newerLoaded.oracleVersion;
+  const fmtOracle = (v: number | "mixed" | undefined) =>
+    v === undefined ? "unstamped (pre-#2096)" : v === "mixed" ? "mixed (multiple versions)" : `v${v}`;
+
+  // A "mixed" file is never comparable: it was assembled from shards run under
+  // different oracles, so even a same-version peer can't be trusted. This is a
+  // hard error regardless of ORACLE_REBASE.
+  if (baseOracle === "mixed" || newOracle === "mixed") {
+    console.error(
+      `\n✖ Oracle-version guard (#2096): one side carries MIXED oracle versions ` +
+        `(baseline=${fmtOracle(baseOracle)}, new=${fmtOracle(newOracle)}).\n` +
+        `  A result file assembled from shards run under different oracles cannot be diffed.\n` +
+        `  Re-run all shards under a single oracle version, then diff again.\n`,
+    );
+    process.exit(2);
+  }
+
+  // Differing single versions: refuse unless explicitly rebasing. Treat an
+  // unstamped (pre-#2096) file as comparable to anything — there is no
+  // recorded oracle to conflict with, so we fall back to the legacy behaviour
+  // and only emit an informational note.
+  if (
+    baseOracle !== undefined &&
+    newOracle !== undefined &&
+    baseOracle !== newOracle
+  ) {
+    if (!oracleRebase) {
+      console.error(
+        `\n✖ Oracle-version guard (#2096): cross-version diff refused.\n` +
+          `  baseline oracle = ${fmtOracle(baseOracle)}, new oracle = ${fmtOracle(newOracle)}.\n` +
+          `  These rows were produced by different verdict logic, so the diff would read\n` +
+          `  oracle skew as regressions. To intentionally re-seed the baseline at the new\n` +
+          `  oracle version (e.g. the #1945 flip PR), re-run with ORACLE_REBASE=1.\n`,
+      );
+      process.exit(2);
+    }
+    console.log(
+      `ORACLE_REBASE=1 — comparing across oracle versions ` +
+        `(baseline ${fmtOracle(baseOracle)} → new ${fmtOracle(newOracle)}). ` +
+        `Regression numbers below mix oracle skew with code changes; use only to re-seed.`,
+    );
+  } else if (baseOracle === undefined || newOracle === undefined) {
+    console.log(
+      `Oracle-version note (#2096): ${fmtOracle(baseOracle)} (baseline) vs ${fmtOracle(newOracle)} (new) — ` +
+        `at least one side is unstamped, comparing as legacy same-oracle.`,
+    );
+  }
+
   if (pathFilter.length > 0) {
     const before = baseline.size;
     baseline = applyPathFilter(baseline, pathFilter);

--- a/tests/issue-2096.test.ts
+++ b/tests/issue-2096.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ORACLE_VERSION, ORACLE_VERSION_HISTORY } from "./test262-oracle-version.js";
+
+function writeJsonl(path: string, records: Record<string, unknown>[]) {
+  writeFileSync(path, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+}
+
+/**
+ * Run scripts/diff-test262.ts on two JSONL files and capture exit code + output,
+ * so the oracle-version guard can be asserted without throwing on non-zero exit.
+ */
+function runDiff(
+  baseline: string,
+  candidate: string,
+  env: Record<string, string> = {},
+): { code: number; out: string } {
+  try {
+    const out = execFileSync("npx", ["tsx", "scripts/diff-test262.ts", baseline, candidate, "--quiet"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ...env },
+    });
+    return { code: 0, out };
+  } catch (err: any) {
+    return { code: err.status ?? 1, out: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+  }
+}
+
+describe("#2096 oracle_version stamping + cross-version diff guard", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  function paths() {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-2096-"));
+    return {
+      base: join(tmpDir, "base.jsonl"),
+      cand: join(tmpDir, "cand.jsonl"),
+      report: join(tmpDir, "report.json"),
+    };
+  }
+
+  it("ORACLE_VERSION is a positive integer with a matching history entry", () => {
+    expect(Number.isInteger(ORACLE_VERSION)).toBe(true);
+    expect(ORACLE_VERSION).toBeGreaterThan(0);
+    const latest = ORACLE_VERSION_HISTORY[ORACLE_VERSION_HISTORY.length - 1];
+    expect(latest?.version).toBe(ORACLE_VERSION);
+  });
+
+  it("diffs same-version files normally (net-positive → exit 0)", () => {
+    const p = paths();
+    writeJsonl(p.base, [
+      { oracle_version: 1, file: "a.js", status: "fail" },
+      { oracle_version: 1, file: "b.js", status: "pass" },
+    ]);
+    writeJsonl(p.cand, [
+      { oracle_version: 1, file: "a.js", status: "pass" },
+      { oracle_version: 1, file: "b.js", status: "pass" },
+    ]);
+    const { code } = runDiff(p.base, p.cand);
+    expect(code).toBe(0);
+  });
+
+  it("refuses a cross-version diff (exit 2) without ORACLE_REBASE", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ oracle_version: 1, file: "a.js", status: "pass" }]);
+    writeJsonl(p.cand, [{ oracle_version: 2, file: "a.js", status: "pass" }]);
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(2);
+    expect(out).toMatch(/cross-version diff refused/i);
+  });
+
+  it("allows a cross-version diff with ORACLE_REBASE=1", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ oracle_version: 1, file: "a.js", status: "pass" }]);
+    writeJsonl(p.cand, [{ oracle_version: 2, file: "a.js", status: "pass" }]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    // net-zero (a.js stays pass) → exit 0; the guard must NOT block.
+    expect(code).toBe(0);
+    expect(out).toMatch(/ORACLE_REBASE=1/);
+  });
+
+  it("hard-refuses a MIXED-version file (exit 2) even with ORACLE_REBASE=1", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ oracle_version: 1, file: "a.js", status: "pass" }]);
+    writeJsonl(p.cand, [
+      { oracle_version: 1, file: "a.js", status: "pass" },
+      { oracle_version: 2, file: "b.js", status: "pass" },
+    ]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    expect(code).toBe(2);
+    expect(out).toMatch(/MIXED oracle versions/i);
+  });
+
+  it("treats an unstamped (pre-#2096) file as legacy-comparable", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ file: "a.js", status: "pass" }]);
+    writeJsonl(p.cand, [{ oracle_version: 1, file: "a.js", status: "pass" }]);
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(0);
+    expect(out).toMatch(/unstamped/i);
+  });
+
+  it("stamps oracle_version onto the merged report and flags mixed reports", () => {
+    const p = paths();
+    writeJsonl(p.base, [
+      { oracle_version: 1, file: "a.js", category: "x", status: "pass", scope: "standard", scope_official: true },
+    ]);
+    execFileSync("node", ["scripts/build-test262-report.mjs", "--input", p.base, "--output", p.report], {
+      stdio: "ignore",
+    });
+    const report = JSON.parse(readFileSync(p.report, "utf8"));
+    expect(report.oracle_version).toBe(1);
+    expect(report.oracle_version_mixed).toBeUndefined();
+
+    const mixed = join(tmpDir!, "mixed.jsonl");
+    const mixedReport = join(tmpDir!, "mixed-report.json");
+    writeJsonl(mixed, [
+      { oracle_version: 1, file: "a.js", category: "x", status: "pass", scope: "standard", scope_official: true },
+      { oracle_version: 2, file: "b.js", category: "x", status: "fail", scope: "standard", scope_official: true },
+    ]);
+    execFileSync("node", ["scripts/build-test262-report.mjs", "--input", mixed, "--output", mixedReport], {
+      stdio: "ignore",
+    });
+    const mr = JSON.parse(readFileSync(mixedReport, "utf8"));
+    expect(mr.oracle_version).toBe(1); // lowest seen
+    expect(mr.oracle_version_mixed).toBe(true);
+  });
+});

--- a/tests/issue-2096.test.ts
+++ b/tests/issue-2096.test.ts
@@ -13,11 +13,7 @@ function writeJsonl(path: string, records: Record<string, unknown>[]) {
  * Run scripts/diff-test262.ts on two JSONL files and capture exit code + output,
  * so the oracle-version guard can be asserted without throwing on non-zero exit.
  */
-function runDiff(
-  baseline: string,
-  candidate: string,
-  env: Record<string, string> = {},
-): { code: number; out: string } {
+function runDiff(baseline: string, candidate: string, env: Record<string, string> = {}): { code: number; out: string } {
   try {
     const out = execFileSync("npx", ["tsx", "scripts/diff-test262.ts", baseline, candidate, "--quiet"], {
       encoding: "utf8",

--- a/tests/test262-oracle-version.ts
+++ b/tests/test262-oracle-version.ts
@@ -1,0 +1,46 @@
+/**
+ * test262-oracle-version.ts — single source of truth for the conformance
+ * ORACLE VERSION (#2096).
+ *
+ * The "oracle" is the verdict logic that decides pass/fail/CE for a test262
+ * row: error classification (`classifyError`), negative-test expectation
+ * matching, and the error-type precision the runner demands (e.g. the #1945
+ * trap-vs-TypeError upgrade). When that logic tightens, rows that used to
+ * read `pass` flip to `fail`/`compile_error` for the SAME compiler output.
+ * Those flips are oracle skew, not code regressions.
+ *
+ * Every result row (`recordResult`) and every merged report/baseline JSON
+ * is stamped with this version. `scripts/diff-test262.ts` refuses to diff a
+ * baseline against a candidate whose oracle_version differs (the comparison
+ * would be apples-to-oranges and the regression gate would fire on skew),
+ * unless `ORACLE_REBASE=1` is set — which is how the #1945 flip PR (and any
+ * future oracle change) re-seeds the baseline at the new version.
+ *
+ * ── HOW TO BUMP ──────────────────────────────────────────────────────────
+ * When you tighten the oracle (change classifyError / negative-expectation
+ * matching / required error precision in a way that flips existing rows):
+ *   1. Bump ORACLE_VERSION below (increment the integer).
+ *   2. Note the change in ORACLE_VERSION_HISTORY.
+ *   3. Land the change as a single PR run with ORACLE_REBASE=1 so the diff
+ *      gate accepts the cross-version comparison and promote-baseline
+ *      re-seeds the committed baseline at the new version.
+ * After that PR merges, every post-flip PR diffs same-version → same-version
+ * and the gate measures only code changes again.
+ *
+ * The version is an opaque monotonic integer — it is NOT the compiler
+ * version or a date. Two runs with the same ORACLE_VERSION are guaranteed to
+ * apply identical verdict logic, so their rows are directly comparable.
+ */
+export const ORACLE_VERSION = 1;
+
+/**
+ * Append-only log of what each oracle version means. Newest last.
+ */
+export const ORACLE_VERSION_HISTORY: ReadonlyArray<{ version: number; note: string }> = [
+  {
+    version: 1,
+    note:
+      "Baseline oracle as of #2096. Error classification per classifyError + " +
+      "negative-test expectation matching as shipped before the #1945 error-type upgrade.",
+  },
+];

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -17,6 +17,7 @@ import { availableParallelism } from "os";
 import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
 import { isPoisonCompileError } from "../scripts/test262-poison-error.mjs";
 import { findNthAssert } from "./test262-assert-locator.js";
+import { ORACLE_VERSION } from "./test262-oracle-version.js";
 import {
   buildNegativeCompileSource,
   classifyError,
@@ -325,6 +326,11 @@ function recordResult(
 
   const entry = JSON.stringify({
     timestamp: new Date().toLocaleString("de-DE", { timeZone: "Europe/Berlin" }),
+    // #2096: oracle identity. Every row carries the version of the verdict
+    // logic that produced its status so diff-test262 can refuse cross-version
+    // comparisons (which would read oracle skew as regressions). Bump in
+    // tests/test262-oracle-version.ts when the oracle tightens (e.g. #1945).
+    oracle_version: ORACLE_VERSION,
     file,
     category,
     status,


### PR DESCRIPTION
## #2096 — oracle upgrades must not read as regressions

Prerequisite for the #1945 oracle precision flip. Tightening the test262
oracle flips `pass` rows to `fail` for the **same** compiler output; without a
version stamp the regression gate fires on oracle skew, not code changes.

### What this does
- **`tests/test262-oracle-version.ts`** — single source of truth:
  `ORACLE_VERSION` (opaque monotonic int, `1`) + append-only history +
  HOW-TO-BUMP doc tying the bump to the `ORACLE_REBASE=1` flip PR.
- **`recordResult`** stamps `oracle_version` on every JSONL result row.
- **`build-test262-report.mjs`** carries `oracle_version` on the merged report
  and sets `oracle_version_mixed: true` when shards disagree (never promote a
  mixed report).
- **`diff-test262.ts`** refuses a cross-version diff (**exit 2**) unless
  `ORACLE_REBASE=1`; a MIXED file is a hard error regardless of the flag;
  unstamped (pre-#2096) files fall back to legacy same-oracle behaviour.
  Exit 2 plugs into `test262-sharded.yml`'s existing `diff_exit > 1`
  hard-fail, so the gate halts on skew instead of mislabelling it regressions.
- **`promote-baseline`** needs no change — on the flip PR's merge it promotes
  main's already-bumped JSONL, re-seeding the baseline at the new version.

### Acceptance criteria
- [x] Cross-version diff refused with a clear message (exit 2)
- [x] Flip PR can re-seed via `ORACLE_REBASE=1`; post-flip PRs diff clean
- [x] Mixed-oracle reports flagged and never promotable

### Tests
`tests/issue-2096.test.ts` — 7 cases (same-version diff, cross-version refuse,
`ORACLE_REBASE=1` allow, mixed hard-refuse, unstamped legacy, report
stamping/mixed-flag). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)