### PR TITLE
fix(#2017): getter-only accessor write throws catchable TypeError

### DIFF
--- a/plan/issues/2017-getter-only-assignment-trap-not-typeerror.md
+++ b/plan/issues/2017-getter-only-assignment-trap-not-typeerror.md
@@ -1,10 +1,12 @@
 ---
 id: 2017
 title: "assignment to a getter-only object-literal property traps 'illegal cast' instead of throwing strict-mode TypeError"
-status: ready
+status: done
+completed: 2026-06-16
+assignee: ttraenkler/dev-a
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -47,3 +49,30 @@ instead of the struct write.
 
 #1092 done; #1932 is accessor double-get (different). New (borderline
 low/wont-fix severity — filed for completeness).
+
+## Resolution (2026-06-16, dev-a)
+
+The "illegal cast" trap was already gone by the time of this verify-wave
+(s62 accessor work). The residual divergence was that `o.x = 99` on a
+getter-only accessor **silently no-op'd** instead of throwing a catchable
+strict-mode TypeError (node: "Cannot set property x … which has only a
+getter"). Root cause: object literals `{ get x(){…} }` install a real host
+accessor on a `__new_plain_object` JS object; `o.x = …` lowers to
+`__extern_set` → `_safeSet`, whose strict `obj[key] = val` correctly threw
+V8's getter-only TypeError — but `_safeSet`'s catch swallowed it and
+diverted to the sidecar.
+
+Fix (`src/runtime.ts`): in `_safeSet`'s write catch, detect a getter-only
+accessor via the new `_isGetterOnlyAccessor(obj, key)` helper (walks the
+proto chain; data property anywhere shadows it) and re-throw a
+spec-worded TypeError instead of falling through to the sidecar. Mirrors
+the existing `_isRevokedProxyError` rethrow (#2180). get/set pairs and
+plain dynamic writes are unaffected.
+
+Regression net: `tests/issue-2017.test.ts` (4 cases). The pre-existing
+`accessor-side-effects.test.ts` 3 failures are unchanged by this fix
+(confirmed failing on unmodified main). **Out of scope, noted:** data
+property in an `any`-typed object literal that is later overwritten
+(`const o:any={a:1}; o.a=42` reads back `1`) is a separate pre-existing
+bug in the literal/sidecar write path, unrelated to the getter-only
+accessor semantics fixed here.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3901,6 +3901,19 @@ function _safeSet(
     // #2180 — writing to a revoked proxy throws TypeError; propagate it
     // instead of silently diverting to the sidecar.
     if (_isRevokedProxyError(e)) throw e;
+    // #2017 — assignment to a getter-only accessor property must throw a
+    // catchable strict-mode TypeError (§13.15.2 → §10.1.9 [[Set]] failure),
+    // not silently fall through to the sidecar. The strict `obj[key] = val`
+    // above already throws V8's "Cannot set property … which has only a
+    // getter"; rethrow it (re-worded to the spec phrasing) when the own/
+    // inherited descriptor is an accessor with a getter and no setter, so
+    // the compiled program observes a real TypeError instead of a no-op.
+    // (TS modules compile in strict mode, so this is the conformant path.)
+    if (e instanceof TypeError && _isGetterOnlyAccessor(obj, key)) {
+      throw new TypeError(
+        `Cannot set property ${String(key)} of #<Object> which has only a getter`,
+      );
+    }
     // For non-WasmGC objects (frozen/sealed JS objects),
     // fall through to sidecar set — preserves original behavior for non-strict callers.
     _sidecarSet(obj, key, val);
@@ -4715,6 +4728,35 @@ function _isObjectLike(v: any): boolean {
  */
 function _isRevokedProxyError(e: any): boolean {
   return e instanceof TypeError && typeof e.message === "string" && e.message.includes("proxy that has been revoked");
+}
+
+/**
+ * #2017 — true when `key` resolves (own or inherited) to an accessor property
+ * descriptor that has a getter but no setter. Writing to such a property is a
+ * [[Set]] failure that must throw a TypeError in strict mode rather than be
+ * silently swallowed by `_safeSet`'s sidecar fallback. Walks the prototype
+ * chain because a getter-only accessor inherited from a prototype also makes
+ * the write fail (§10.1.9.2 OrdinarySetWithOwnDescriptor). Defensive: any host
+ * error during the descriptor lookup means "not a known getter-only accessor".
+ */
+function _isGetterOnlyAccessor(obj: any, key: any): boolean {
+  if (obj == null || (typeof obj !== "object" && typeof obj !== "function")) return false;
+  if (typeof key === "object") return false;
+  try {
+    let cur: any = obj;
+    while (cur != null) {
+      const desc = Object.getOwnPropertyDescriptor(cur, key);
+      if (desc) {
+        // Data property anywhere on the chain shadows accessor semantics.
+        if ("value" in desc || "writable" in desc) return false;
+        return typeof desc.get === "function" && typeof desc.set !== "function";
+      }
+      cur = Object.getPrototypeOf(cur);
+    }
+  } catch {
+    return false;
+  }
+  return false;
 }
 
 /**

--- a/tests/issue-2017.test.ts
+++ b/tests/issue-2017.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2017 — assignment to a getter-only object-literal property must throw a
+// catchable strict-mode TypeError (§13.15.2 → §10.1.9 [[Set]] failure), not
+// silently no-op. Previously the write trapped with an uncatchable "illegal
+// cast"; after the s62 accessor work it silently fell through to the sidecar.
+// The fix re-throws the strict-mode TypeError from `_safeSet`.
+async function run(source: string, fn = "test", args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+    );
+  }
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!(...args);
+}
+
+describe("#2017 — assignment to getter-only accessor throws TypeError", () => {
+  it("throws a catchable TypeError (not illegal cast, not silent)", async () => {
+    const r = await run(`
+      export function test(): string {
+        const o: any = { get x() { return 1; } };
+        try { o.x = 99; return "NO-THROW"; }
+        catch (e: any) { return e instanceof TypeError ? "TypeError" : "other"; }
+      }
+    `);
+    expect(r).toBe("TypeError");
+  });
+
+  it("leaves the getter value unchanged after the rejected write", async () => {
+    const r = await run(`
+      const o: any = { get x() { return 1; } };
+      try { o.x = 99; } catch (e) { /* swallow */ }
+      export function test(): number { return o.x; }
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("get/set accessor pairs still accept writes (no over-broad rejection)", async () => {
+    const r = await run(`
+      let backing = 100;
+      const o: any = { get x() { return backing; }, set x(v: number){ backing = v; } };
+      o.x = 105;
+      export function test(): string { return o.x + "," + backing; }
+    `);
+    expect(r).toBe("105,105");
+  });
+
+  it("adding a brand-new dynamic property still works", async () => {
+    const r = await run(`
+      const o: any = {};
+      o.z = 7;
+      export function test(): number { return o.z; }
+    `);
+    expect(r).toBe(7);
+  });
+});


### PR DESCRIPTION
## #2017 — assignment to getter-only accessor must throw strict-mode TypeError

```ts
const o: any = { get x() { return 1; } };
o.x = 99;  // was: silent no-op   node: TypeError (only a getter)
```

### Root cause
The "illegal cast" trap was already gone (s62 accessor work). Residual: `o.x = 99` on a getter-only accessor **silently no-op'd** instead of throwing. Object literals `{ get x(){…} }` install a real host accessor on a `__new_plain_object` JS object; `o.x = …` lowers to `__extern_set` → `_safeSet`, whose strict `obj[key] = val` correctly threw V8's getter-only TypeError — but `_safeSet`'s catch swallowed it and diverted to the sidecar.

### Fix
In `_safeSet`'s write catch (`src/runtime.ts`), detect a getter-only accessor via the new `_isGetterOnlyAccessor(obj, key)` helper (walks the proto chain; a data property anywhere shadows it) and re-throw a spec-worded TypeError instead of falling through to the sidecar. Mirrors the existing `_isRevokedProxyError` rethrow (#2180). get/set pairs and plain dynamic writes are unaffected.

### Tests
`tests/issue-2017.test.ts` — 4 cases: throws catchable TypeError; getter value unchanged; get/set pairs still accept writes; new dynamic property still works.

The 3 pre-existing `accessor-side-effects.test.ts` failures are unchanged by this fix (confirmed failing on unmodified main).

Closes #2017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)