### PR TITLE
plan(s63): architect impl specs for async/Proxy epic chain-heads

### DIFF
--- a/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
+++ b/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
@@ -69,11 +69,30 @@ prove the target isn't a Proxy; for typed locals where we know the type, skip th
 
 Cascade-blocks Reflect.* invariant tests (#1346). Until landed, Proxy stays at host-mode only.
 
-## Implementation Plan (architect, 2026-06-16)
+## Implementation Plan (architect, 2026-06-16; sequencing re-confirmed arch1 2026-06-16)
 
 (Standalone/pure-Wasm. Builds on #1100 Phase 1. Adds the remaining 10 trap
 dispatchers + full §10.5 invariant enforcement; drives standalone
 `built-ins/Proxy` from ~21% to ≥75%. Host-mode companion is #2180.)
+
+### BLOCKED — hard dependency on #1100 (verified against upstream/main 319d43460)
+The standalone substrate this plan extends **does not exist on main yet**:
+`grep` for `$Proxy` / `$ProxyTraps` / `registerProxyType` / `__proxy_*_dispatch`
+in `src/codegen/object-runtime.ts` and `src/codegen/registry/proxy.ts` returns
+nothing — `src/codegen/registry/proxy.ts` is not created, and the only `__proxy`
+references are the **host-mode** path in `runtime.ts`/`calls.ts`. #1100
+(`status: ready`, senior-dev WIP on a branch per s63 task #21) lands
+`$Proxy` + `$ProxyTraps` + get/set/has/apply + revocable. **Do NOT dispatch
+#1355 until #1100 has merged to main** — every section below presumes
+`$ProxyTraps` (the 4 base trap fields) and the standalone Proxy struct exist.
+When #1100 lands, re-grep to confirm the field layout of `$ProxyTraps` and the
+`$Proxy` struct before extending — coordinate the 9 added funcref fields with
+whatever #1100 shipped (append, do not renumber the base 4).
+
+Also note `$PropEntry` exists (`object-runtime.ts:16`) but the
+descriptor-attribute bits (configurable/writable/enumerable) needed for §10.5
+invariant enforcement may not be present — verify and extend per the Invariant
+section below, coordinating with #797/#1460/#1462.
 
 ### Root cause / gap
 

--- a/plan/issues/1373b-ir-async-cps-lowering.md
+++ b/plan/issues/1373b-ir-async-cps-lowering.md
@@ -144,13 +144,50 @@ Each sub-slice is independently shippable.
 
 ---
 
+## Refresh (arch1, 2026-06-16 — against upstream/main 319d43460): UNBLOCKED, line numbers re-anchored
+
+**Dependency #1326c is DONE** (se1, completed 2026-06-16). The Phase 1C-B
+substrate the S53 plan below blocks on is now live in
+`src/codegen/async-scheduler.ts`:
+- `emitStandalonePromiseThen` — **line 1132** (the gating helper; no longer a
+  throwing stub).
+- `emitStandalonePromiseResolve` (1089) / `emitStandalonePromiseReject` (1103).
+- `__microtask_enqueue` registration (~326), `__drain_microtasks` (~341),
+  `getOrRegisterPromiseType` (144).
+
+So **Slice 2 and Slice 1b can begin now.** Slice 3 (gate flip) follows.
+
+**Line-number corrections (the S53 plan below cites pre-drift values — use these):**
+
+| S53 plan says | Current (319d43460) | Symbol |
+|---|---|---|
+| `select.ts:163` / `:190` / `:194` | `select.ts:190-200` | `isAsyncIrReady` (body is 6 lines; the `return false;` to flip in Slice 3 is **line 200**, after the `if (!options?.supportsAsyncIr) return false;` short-circuit at 191) |
+| `lower.ts:1819` | `lower.ts:2107` | `case "async.return"` |
+| (—) | `lower.ts:2125` | `case "async.throw"` |
+| `lower.ts:1850` | `lower.ts:2143` | `case "await"` |
+| `create-context.ts:130` | `create-context.ts:198` | `supportsAsyncIr: false` default |
+| `types.ts:588` | `types.ts:1202` | `CodegenContext.supportsAsyncIr` |
+| `integration.ts:582` | `integration.ts:577` | `readyForLower.some(... funcKind === "generator")` — the analogous async-state split hook goes adjacent to this generator check |
+| `integration.ts:92` | `integration.ts:109` | `planIrCompilation(... { experimentalIR: true })` — add `supportsAsyncIr: ctx.supportsAsyncIr` here for Slice 3 |
+| `integration.ts:178` | `compileIrPathFunctions` body (start `integration.ts:102`) | Phase-1 build loop where `splitAsyncIntoStates` is invoked |
+
+Everything else in the S53 plan (the frame-struct strategy, uniform-arity
+`(externref, externref) -> void` continuations, liveness sweep, per-state
+emission, entry rewrite, slice sequencing) is **still correct** — re-read it as
+written below; only the line anchors above have moved. The `select.ts`
+`isAsyncIrReady` body currently has the Slice-2 TODO marker inline (lines
+192-199) and still `return false`s — confirming Slice 1b/2/3 are all still open.
+
+---
+
 ## Implementation Plan (S53 architect — joint spec for #1042 / #1373 / #1373b)
 
 This plan covers the remaining slices (2, 1b, 3) on top of the Slice 1
 scaffolding that landed in PR #441 (commit `3ea48c20c`). It is the
 single source of truth for the async-model cluster — see #1042 and
 #1373 for the upstream framing; this file is where devs read the IR
-patterns and file:line targets.
+patterns and file:line targets. **NOTE: file:line targets below are
+pre-drift — see the Refresh table above for current anchors.**
 
 ### Slice 1 recap (already on main as of `3ea48c20c`)
 

--- a/plan/issues/1796-async-cps-sync-model-migration.md
+++ b/plan/issues/1796-async-cps-sync-model-migration.md
@@ -88,35 +88,92 @@ as one coordinated change with the test corpus.
   (`1792-node-url-builtin-impl.md`); the lead's dispatch said "1792" but that
   collides — using the next free id.
 
-## Implementation Plan
+## Implementation Plan (refreshed 2026-06-16, arch1 — against upstream/main 319d43460)
+
+### What landed since the prior spec (verified on current main)
+- **#1936 DONE** (se1, completed 2026-06-16). `analyzeAsyncBody`,
+  `awaitIsStaticallyResolved`, `asyncFnNeedsCps(fn, plan)`, `AsyncConsumerKind`,
+  and `classifyAsyncConsumer(checker, expr)` all exist in
+  `src/codegen/async-cps.ts` (lines 60, 104, 182, 256, 279, 297). The call-site
+  classifier IS wired: `asyncResultConsumedAsValue` (`expressions.ts:259-266`)
+  now delegates to `classifyAsyncConsumer(...) !== "thenable"` — a
+  behaviour-preserving refactor (parity note at async-cps.ts:292).
+- **`ASYNC_CPS_ENABLED` is STILL `false`** (`async-cps.ts:60`) and
+  `asyncFnNeedsCps` short-circuits on it (line 257). The global flip has NOT
+  happened.
+- **The activation gates have NOT yet been migrated to `asyncFnNeedsCps`.**
+  Both `function-body.ts:1117-1132` and the `collectAsyncCpsImports` prepass at
+  `declarations.ts:652-665` still use the *inline* duplicated shape check
+  (`ASYNC_CPS_ENABLED && … && plan.awaitPoints.length === 1 &&
+  !plan.hasTryAcrossAwait && splitBodyAtAwait(...) !== null`). This issue is
+  what migrates them onto the single predicate.
+- **#1326c DONE** — standalone microtask queue + chained `.then` landed; the
+  standalone Promise substrate referenced below is live.
 
 ### Root cause
-Execution of the #1936 census: flip `ASYNC_CPS_ENABLED` (`async-cps.ts:59`) on,
-route every async fn through `asyncFnNeedsCps` (#1936), and migrate the test
-corpus + remaining synchronous-consumption call sites off the raw-value contract
-onto the real-Promise contract. Machinery is present and verified-when-run
+Execution of the #1936 census: flip `ASYNC_CPS_ENABLED` (`async-cps.ts:60`) on,
+route both activation gates through the now-existing `asyncFnNeedsCps` predicate
+(replacing the two inline duplicated shape checks), and migrate the test corpus +
+remaining synchronous-consumption (`value`-bucket) call sites off the raw-value
+contract onto the real-Promise contract. Machinery is present and verified-when-run
 (`tests/issue-1042.test.ts` Slice-2A); the work is contract migration, not new
 lowering.
+
+### Sequencing dependency note (read before flipping)
+The interaction with **#2028** (Promise executor body never dispatches) and the
+**#1042 staleness note** (`await Promise.resolve(41)` yields NaN today — issue
+file lines 63-68) means the *host-mode Promise substrate itself is partially
+broken right now*. Confirm #2028's `__make_callback`/`Promise_new` dispatch fix
+has landed (or that the executor path is not on the critical path for the 5
+canonical #1042 cases) BEFORE flipping — otherwise the migrated equivalence
+tests will fail on a substrate bug, not a migration bug, and the net-delta
+signal is unreadable. Recommend: land #2028 first, then this flip.
 
 ### Sequencing
 Gated on #1936 (census + `asyncFnNeedsCps` + elision) and #1373b (CPS/IR
 adoption). Do NOT flip before #1936's census report exists.
 
-### Changes
-- `async-cps.ts`: `ASYNC_CPS_ENABLED` → true (59), then REMOVE the constant;
-  `function-body.ts:1117` + `declarations.ts:636` consult `asyncFnNeedsCps`
-  (removal is acceptance criterion 3).
-- `function-body.ts:1116-1132`: replace the `ASYNC_CPS_ENABLED && … &&
-  splitBodyAtAwait!==null` gate with `asyncFnNeedsCps(ctx,decl)`; drop the
-  `!wasi && !standalone` exclusion only once the standalone substrate is wired.
-- `declarations.ts:630-648`: mirror the gate in `collectAsyncCpsImports` prepass
-  so Promise_resolve/__make_callback/Promise_then2 get stable funcMap indices
-  (the #1384 late-import-shift hazard).
-- `expressions.ts`: `asyncResultConsumedAsValue` (252) stops taking the raw-value
-  elision for CPS callees (they now return real Promises); keep elision only for
-  statically-resolved callees. await arm (1207-1225): non-tail await under an
-  active state machine still `reportError`s (PR1 limit) — widen per step 6 or keep
-  the explicit error, never silent mis-lowering.
+### Changes (file:line verified on upstream/main 319d43460)
+- **`async-cps.ts:60`**: `ASYNC_CPS_ENABLED` → `true`. Step 2 (after green):
+  REMOVE the constant and the `if (!ASYNC_CPS_ENABLED) return false;` line at
+  `async-cps.ts:257` (removal is acceptance criterion 3).
+- **`function-body.ts:1117-1132`**: replace the inline duplicated shape check
+  ```ts
+  if (ASYNC_CPS_ENABLED && isAsync && !ctx.wasi && !ctx.standalone && ts.isFunctionDeclaration(decl) && decl.body) {
+    const asyncPlan = analyzeAsyncBody(ctx, decl);
+    if (asyncPlan.awaitPoints.length === 1 && !asyncPlan.hasTryAcrossAwait && splitBodyAtAwait(decl, asyncPlan) !== null) { … }
+  }
+  ```
+  with the single predicate:
+  ```ts
+  if (isAsync && !ctx.wasi && !ctx.standalone && ts.isFunctionDeclaration(decl) && decl.body) {
+    const asyncPlan = analyzeAsyncBody(ctx, decl);
+    if (asyncFnNeedsCps(decl, asyncPlan)) { … }
+  }
+  ```
+  `asyncFnNeedsCps` already folds in `awaitPoints.length > 0`, the
+  any-real-suspension check, AND `splitBodyAtAwait !== null` — so this is
+  strictly equal-or-narrower (it ALSO elides fully-static-await bodies, which is
+  the intended #1936 behaviour). Keep the `!ctx.wasi && !ctx.standalone`
+  exclusion until the standalone substrate (#1326c) is wired into this gate;
+  drop it in a follow-up.
+- **`declarations.ts:652-665`** (`collectAsyncCpsImports` prepass): mirror the
+  exact same migration — replace the inline `plan.awaitPoints.length === 1 &&
+  !plan.hasTryAcrossAwait && splitBodyAtAwait(...) !== null` with
+  `asyncFnNeedsCps(node, plan)`. The two gates MUST stay byte-identical in their
+  decision or the prepass under/over-registers `Promise_resolve` /
+  `__make_callback` / `Promise_then2` imports → the #1384 late-import-shift
+  hazard or a missing-import `reportError` at `async-cps.ts:373-379`. Using one
+  predicate in both places is the durable fix for that duplication.
+- **`expressions.ts:259-266`** (`asyncResultConsumedAsValue`): already routes
+  through `classifyAsyncConsumer`. After the flip, the `"value"` bucket
+  (`f() as any as number`) is the set that BREAKS — those callees now return a
+  real Promise and the cast yields NaN. Migrate those sites per the Migration
+  surface below; the `"thenable"` and `"await"` buckets are already correct.
+  Keep raw-value elision ONLY for statically-resolved callees (await-elided
+  sync fns). The non-tail await arm (`expressions.ts` await handling under an
+  active state machine) must keep its explicit `reportError` (PR1 limit) — widen
+  per scope step 6 or keep erroring; **never silently mis-lower**.
 
 ### Migration surface (from #1936 census)
 1. `value`-bucket sites (`f() as any as number`): rewrite to `await f()` /

--- a/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
+++ b/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
@@ -112,3 +112,104 @@ whose target name≠expected once the by-name authority exists.
 
 ## Resilience
 Full context also in `plan/agent-context/sd-1472c-329.md`.
+
+---
+
+## Ratification (arch1, 2026-06-16 — against upstream/main 319d43460)
+
+### Live-repro check: NO LIVE REPRO post-#1225
+I compiled the exact #1899 repro and three sibling forms in `--target standalone`
+on current main and **all compile AND validate cleanly**:
+
+| Case | Result |
+|---|---|
+| `let g:any; g = function(){return 42;}; export function test(){ return g(); }` (the #1899 repro) | compile-ok, **VALIDATE OK** |
+| `const f:any = function(){return 1;}; …` | compile-ok, VALIDATE OK |
+| closure-assign + native-string `.slice` in the same fn | compile-ok, VALIDATE OK |
+| native-string-helper-heavy (`+`, `.slice`, `.repeat`) | compile-ok, VALIDATE OK |
+
+The `__str_flatten ... call[0] expected (ref null 5), found i32.const` validation
+failure the issue documents **no longer reproduces**. PR #1225's
+`ensureGetUndefined` fix (under `ctx.nativeStrings`, return the native
+`ref.null.extern` sentinel instead of importing `env::__get_undefined`) removed
+the *specific* late finalize-import that triggered the extra 3rd
+`reconcileNativeStrFinalizeShift` firing. With that trigger gone, the
+incremental-monotonic reconcile no longer disagrees with the final import count
+for the cited repro.
+
+### Contract questions — ratified answers
+
+**Q1 — Who OWNS finalize-emitted helper call-target resolution?**
+RATIFIED: a **final, post-all-churn, by-name authority pass** is the single
+source of truth. `reconcileNativeStrFinalizeShift` (incremental shift) and
+`eliminateDeadImports` (remap) remain index-bookkeeping, but for *finalize-emitted
+helper sibling-calls* the final pass overrides them by re-pointing each such
+`call` to `nativeStrHelpers.get(<name>)` / `funcMap.get(<name>)`. Rationale: the
+recurring class is precisely that two independent bookkeeping mechanisms
+(incremental add vs. churn-aware remove) cannot agree on an index; a single
+name-anchored authority that runs *after both settle* is the only design that
+cannot drift. Option (A) (compute-shift-once) is correctly rejected in the issue
+— it fights the load-bearing mid-stream incremental requirement.
+
+**Q2 — Scope: native-string helpers only, or all finalize-emitted defined funcs?**
+RATIFIED: **all finalize-emitted defined funcs**, not just native-string helpers.
+The same class blocks #1888 S2 (`__apply_closure`→`__call_fn_method_N`) and
+#1888 Slice 5 (accessor `__call_fn_method_N`). A native-string-only authority
+would leave those two to recur. The final pass keys off a registry of
+`(emittedFuncName → funcIdx)` covering every finalize-time-defined helper, so one
+mechanism kills all three workstreams' exposure.
+
+**Q3 — B1 (tag at emit) vs B2 (central reverse map)?**
+RATIFIED: **B2 — central reverse map**, snapshotted at each helper registration.
+B1 touches ~35 emit sites (high diff surface, easy to miss a site, and each new
+helper must remember to tag — the same forgot-a-site failure mode that produced
+5 recurrences). B2 is one central map maintained where helpers are *registered*
+(a single chokepoint), so a newly-added helper is covered automatically with no
+per-emit-site discipline. The reverse map is `Map<staleFuncIdxAtBake, helperName>`
+populated when a helper sibling-call is baked; the final pass walks every
+finalize-emitted body and, for each `{op:"call", funcIdx}` whose `funcIdx` is in
+the reverse map, re-points it to the authoritative current index for that name.
+(Edge: a helper may be baked at several stale indices over the run — the map
+value is the *name*, which is stable, so collisions resolve correctly.)
+
+**Q4 — Interaction with `flushLateImportShifts` (compilation-phase path)?**
+RATIFIED constraint: the final by-name pass must operate **only on
+finalize-emitted helper bodies** (the native-string helpers + the enumerated
+finalize-time defined funcs), identified by membership in the central registry —
+NOT on compilation-phase bodies that `flushLateImportShifts` already correctly
+shifted. Double-shifting is avoided because the final pass *overwrites by name*
+(idempotent: re-pointing an already-correct call to the same authoritative index
+is a no-op) rather than applying a delta. The implementer must assert the final
+pass never touches a `call` whose funcIdx is not in the reverse map, so
+compilation-phase calls are untouched even if they happen to alias a stale index
+numerically.
+
+### Disposition: RATIFIED design, recommend **defer (not wont-fix), de-prioritise**
+
+- There is **no live failing repro** on current main, so this is **not
+  dispatchable as a bugfix right now** — a senior-dev implementing (B2) would be
+  refactoring against a class with no reproducing case, which violates the s63
+  "verify-still-repros-then-fix" discipline and risks a high-blast-radius (35
+  bake sites / every standalone string program) change with no failing test to
+  anchor correctness.
+- **Recommend: keep at `status: ready` but DROP from the s63 dispatch queue.**
+  Re-activate (and dispatch (B2) to a senior-dev) the moment EITHER:
+  (a) #1888 S2 or Slice 5 surfaces a concrete `expected (ref null N), found
+  i32.const`-class validation failure during their own implementation (the
+  issue's keystone claim — those are the live consumers), OR
+  (b) any new finalize-import addition re-triggers the reconcile/dead-elim
+  mismatch with a reproducing case.
+- When re-activated, the implementer has a fully-ratified blueprint above:
+  final by-name authority pass (Q1), all-finalize-funcs scope (Q2), central
+  reverse map B2 (Q3), registry-membership-gated to avoid double-shift (Q4).
+- **Detection hardening (cheap, dispatchable now if desired):** extend #1209's
+  `validateFuncRefs` (`src/emit/binary.ts`, env-gated) to flag a finalize-emitted
+  helper sibling-`call` whose target *name* ≠ the expected helper name, once a
+  name-anchored registry exists. This converts the silent in-range-wrong-target
+  failure into a loud one and is the lowest-cost first step — but it presupposes
+  the B2 reverse map, so it lands *with* (B2), not before.
+
+This satisfies the task directive: 4 questions resolved, no live repro confirmed,
+disposition = defer-with-ratified-blueprint (not wont-fix — the class can recur
+via #1888; the design is locked in so the next occurrence is a mechanical
+implementation, not a re-investigation).

--- a/plan/issues/2028-promise-executor-resolve-reject-trap.md
+++ b/plan/issues/2028-promise-executor-resolve-reject-trap.md
@@ -180,3 +180,166 @@ unrelated to the closure-call `struct.get` trap the spec targeted.
   fresh `## Implementation Plan` against current main before re-dispatch.
 - Acceptance criteria (resolve "ok" / reject reason / resolve-twice ignored)
   remain UNMET; left at `ready` with this updated analysis.
+
+## Re-spec (arch1, 2026-06-16 — against upstream/main 319d43460, with live WAT repro)
+
+**Both prior analyses are partly wrong. Live repro corrects them.** I compiled
+`new Promise<string>((resolve) => { resolve("ok"); })` with `compileToWat` on
+current main and inspected `$__cb_0`:
+
+- The executor lowers to an exported synthetic callback `$__cb_0` with signature
+  `(param externref externref)` = `(captures, resolve)`. It **IS exported**
+  (`(export "__cb_0" (func 5))`) and **the host wrapper DOES invoke it** — so the
+  se1 "executor body never runs" conclusion is an artifact of the test only
+  observing a side-effect that is itself skipped by the trap (see below). The
+  body runs.
+- Inside `$__cb_0`, the call `resolve("ok")` is compiled through the **WasmGC
+  closure-struct dispatch**, NOT a host call:
+  ```wat
+  local.get 1            ;; the `resolve` param (externref host fn)
+  any.convert_extern
+  local.tee 4
+  ref.test (ref 14)      ;; is it a $closure struct? NO — it's a host JS fn
+  (if (result (ref null 14))
+    (then ... ref.cast null (ref null 14))
+    (else ref.null 14))  ;; cast fails → null
+  local.set 2            ;; $__callable_param_0 = null
+  ...
+  local.get 2
+  ref.is_null
+  (if (then local.get 4 ref.is_null (if (then global.get 4 throw 0))))  ;; THROWS $__exn
+  local.get 6
+  struct.get 14 0        ;; (or traps null-deref here on the non-throw path)
+  ```
+  The `resolve` param holds a real host JS function. `ref.test (ref 14)` (the
+  `$closure` struct test) fails, the guarded cast yields null, and the body
+  **throws `$__exn` (the #1536 wasm exception) at the null-guard** — which the
+  host wrapper propagates as a thrown JS value into native `new Promise`'s
+  executor invocation. Native Promise catches it and **rejects the promise with
+  that wasm RuntimeError**; `resolve("ok")` is never reached, so the promise
+  never fulfils and any post-`resolve` side-effect is skipped. That is precisely
+  why se1 saw `log === 0` (the `throw` aborts the body before the second
+  assignment) and why the `.then`/`.catch` fulfil path never fires.
+
+### Root cause (definitive)
+The **original spec's root cause was correct**: `resolve`/`reject` arrive into
+`$__cb_0` as plain externref host functions and the in-body call site dispatches
+them through the closure-struct `ref.test`/`ref.cast`/`struct.get`/`call_ref`
+path, which fails on a foreign callable. The **fix location** the original spec
+named (`calleeMayBeHostCallable`) is also correct, but the gate widening it
+prescribed was **not actually implemented in a way that fires for this case** —
+`calleeMayBeHostCallable` (`expressions/calls.ts:975-1007`) requires the callee
+to be a **`VariableDeclaration` with an initializer referencing a host builtin**
+(line 979: `!ts.isVariableDeclaration(decl) || !decl.initializer → return
+false`). The executor's `resolve`/`reject` are **`ParameterDeclaration`s**, so
+the gate returns `false`, no `__call_function` arm is emitted, and the call
+traps. se1's "implemented then reverted as inert" was because the widening they
+tried did not cover the parameter case (or covered it but the test's observation
+masked the now-correct behaviour).
+
+### Fix (definitive)
+Widen `calleeMayBeHostCallable` (`src/codegen/expressions/calls.ts:975`) to ALSO
+return `true` when the callee identifier resolves to a **function parameter**
+(`decl` is a `ts.ParameterDeclaration`) whose **lowered wasm local type is
+`externref`** (NOT a `ref $closure` — a closure-struct param keeps the fast
+`call_ref` path) and whose **declared TS type has a call signature**
+(`checker.getTypeAtLocation(expr).getCallSignatures().length > 0`). Be
+conservative — the externref-typed restriction is what preserves the #1941
+dual-mode guarantee (pure local-closure programs whose params are wrapped as
+closure structs must NOT pull `__js_array_new`/`__call_function` host imports).
+
+With the gate widened, the existing dispatch arm at
+`expressions/calls.ts:9227-9300` (the #1712 `hostCallFallback` block) emits BOTH
+arms automatically: the guarded `ref.test (ref 14)` succeeds → `call_ref` fast
+path; the cast nulls (host fn) → `__call_function(resolve, undefined, ["ok"])`.
+The arm is already gated `!ctx.standalone && !ctx.wasi` (line 9247-9248), so
+standalone stays on the native `$Promise` path (#1326) — no change there. **No
+new host import**: `__call_function` / `__js_array_new` / `__js_array_push` are
+all already wired.
+
+### Why this is sufficient now (vs se1's doubt)
+se1 doubted the fix because they believed the body never ran. The WAT proves it
+does — the ONLY thing wrong is the in-body `resolve`/`reject` dispatch. Widening
+the gate so those two calls take the `__call_function` arm makes `resolve("ok")`
+actually invoke the host resolve function, settling the promise. No
+`__make_callback`/`Promise_new` bridge change is needed — that bridge already
+correctly hands the executor wrapper to native `new Promise`, and native Promise
+already passes real host `resolve`/`reject` into `$__cb_0`. The defect is purely
+the closure-struct mis-dispatch of those two externref params.
+
+### Changes (file:line, verified on 319d43460)
+- **`src/codegen/expressions/calls.ts:975-1007`** (`calleeMayBeHostCallable`):
+  after the existing `VariableDeclaration` clause, add:
+  ```ts
+  // (#2028) A function parameter typed as an externref callable (e.g. the
+  // `resolve`/`reject` params of a `new Promise(executor)` — host JS fns
+  // arriving as plain externref) must take the __call_function arm, not the
+  // closure-struct call_ref path which traps on a foreign callable.
+  if (decl && ts.isParameter(decl)) {
+    const localIdx = /* resolve via fctx.localMap or symbol */;
+    // Only externref-typed params (NOT ref $closure) — preserves #1941.
+    const wasmType = /* the param's lowered ValType */;
+    if (wasmType?.kind === "externref") {
+      const t = ctx.checker.getTypeAtLocation(expr);
+      if ((t?.getCallSignatures?.()?.length ?? 0) > 0) return true;
+    }
+  }
+  ```
+  NOTE: `calleeMayBeHostCallable` currently takes only `(ctx, expr)` and has no
+  `fctx`; the param's lowered wasm type must be obtained from the call site that
+  invokes it (the dispatch block at 9227 has `fctx` + `matchedClosureInfo`).
+  Implementer choice: either thread `fctx` into `calleeMayBeHostCallable`, or
+  add the parameter-callable check inline at the `hostCallFallback` computation
+  (line 9245-9257) where `fctx` and the matched closure shape are already in
+  scope (this is the lower-risk option — keeps `calleeMayBeHostCallable` pure).
+- **`src/codegen/expressions/calls.ts:9245-9257`** (`hostCallFallback`
+  computation): this is the recommended single edit point — replace the
+  `calleeMayBeHostCallable(ctx, expr.expression)` conjunct with
+  `(calleeMayBeHostCallable(ctx, expr.expression) || calleeIsExternrefCallableParam(ctx, fctx, expr.expression))`
+  where the new helper does the parameter-typed-externref + call-signature check
+  using `fctx.localMap` / `fctx.params` for the lowered type.
+- **`src/codegen/expressions/new-super.ts:1848-1867`**: no change to the bridge;
+  add a comment cross-referencing this fix.
+- **`src/runtime.ts`** `__call_function`: confirm it tolerates a host fn (it
+  already does `typeof fn === "function"` direct-call). No change expected.
+
+### Edge cases
+- sync `resolve("ok")` → promise fulfils "ok"; `.then` fires.
+- `reject(reason)` → `.catch` receives `reason`, not a RuntimeError.
+- resolve-twice / reject-after-resolve → ignored. Native `new Promise` enforces
+  `[[AlreadyResolved]]` (§27.2.1.3) once the call reaches the host resolve fn —
+  no wasm guard needed.
+- sync `throw` in executor → with `resolve`/`reject` now dispatching correctly,
+  a genuine `throw` in the executor body still surfaces as `$__exn`; the host
+  wrapper propagates it and native `new Promise` rejects per §27.2.3.1 step 9.
+  Verify the wasm exception crosses `exports.__cb_0(...)` as a thrown JS value
+  (it does — #1536 maps `$__exn` to a thrown JS value at the export boundary).
+- non-callable executor → native `new Promise` throws TypeError (host-enforced).
+- **#1941 dual-mode guard**: a pure local-closure program (`const f = (cb) =>
+  cb(); f((x) => x)`) must NOT pull `__call_function` — the externref-only param
+  restriction ensures the closure-struct param keeps the `call_ref` path.
+  Regression-assert no `__js_array_new` import for such programs.
+- **standalone**: the arm is gated `!ctx.standalone && !ctx.wasi`; standalone
+  `new Promise` is the native-`$Promise` path (#1326) — confirm the widened
+  clause does not fire there.
+
+### Test-gate plan
+`tests/issue-2028.test.ts`:
+`new Promise<string>((resolve) => resolve("ok"))` → "ok";
+`new Promise((_,reject) => reject(new Error("x")))` → `.catch` gets the Error;
+resolve-twice → first wins; throw-in-executor → rejects.
+test262: `built-ins/Promise/executor-*.js`, `resolve-function-*`,
+`reject-function-*`, `create-resolving-functions-resolve.js`/`-reject.js`,
+`exception-after-resolve-in-executor.js`.
+Regression: `tests/equivalence/*closure*` — assert NO new `__js_array_new` /
+`__call_function` imports for pure local-closure cases.
+
+### Spec citations
+Promise constructor + resolving functions §27.2.3.1 steps 8-10;
+CreateResolvingFunctions `[[AlreadyResolved]]` §27.2.1.3;
+resolve/reject §27.2.1.3.2 / §27.2.1.3.1.
+
+### Disposition
+**Dispatchable to senior-dev.** Single, well-isolated codegen change with a
+verified WAT-level root cause. Lower risk than the prior analyses suggested —
+no `__make_callback` bridge surgery required.


### PR DESCRIPTION
Architect specs for the s63 Proxy/Promise/async-to-100% epic. Doc-only (`plan/issues/*.md`).

## What changed

- **#1796** (CPS flip): refreshed against current main. #1936's `asyncFnNeedsCps`/`classifyAsyncConsumer` have landed; both activation gates (`function-body.ts:1117`, `declarations.ts:652`) still use the inline duplicated shape check, so migrating them onto the single predicate IS the work. `ASYNC_CPS_ENABLED` still false. Sequencing note added: land #2028 first (host Promise substrate is partially broken today).
- **#1373b** (IR async CPS lowering): UNBLOCKED — #1326c done, `emitStandalonePromiseThen` live at async-scheduler.ts:1132. Re-anchored all S53-plan line numbers (select.ts/lower.ts/integration.ts/create-context.ts drifted). Slices 1b/2/3 still open.
- **#2028** (Promise executor): definitive re-spec with a **live WAT repro**. Both prior analyses partly wrong — the executor body DOES run; `resolve("ok")` traps because the externref host-fn param is dispatched through the closure-struct `call_ref` path. Fix: widen `calleeMayBeHostCallable` (calls.ts:975) for externref callable params so the existing `__call_function` arm fires. Dispatchable to senior-dev.
- **#1355** (Proxy traps to 100%): confirmed hard block on #1100 — `$Proxy`/`$ProxyTraps` not on main yet; do not dispatch until #1100 merges.
- **#1899** (finalize-funcidx authority): RATIFIED the 4 contract questions (final by-name authority pass; all finalize-emitted funcs; B2 central reverse map; registry-gated to avoid double-shift). **No live repro post-#1225** (verified 4 standalone cases compile + validate). Disposition: defer-with-blueprint, drop from s63 dispatch queue, re-activate when #1888 S2/Slice 5 surfaces a concrete failure.

## Dispatchability

- **#2028** → senior-dev now (single isolated codegen change, WAT-verified root cause)
- **#1373b** → senior-dev now (dependency satisfied)
- **#1796** → after #2028 lands
- **#1355** → blocked on #1100 merge
- **#1899** → defer (no live repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)