### PR TITLE
chore(#2099): heal poison-classified rows before baseline promotion

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1268,6 +1268,42 @@ jobs:
           pattern: test262-merged-report
           merge-multiple: true
 
+      # #2099 — heal poison-classified rows BEFORE promotion. A phantom
+      # "Binary emit error" (etc.) row from a contaminated sharded worker would
+      # otherwise be copied verbatim into the baseline and carried forward by
+      # every later promotion. Re-run just those rows serially in a clean
+      # in-process compiler; a row that now passes (or fails for a non-poison
+      # reason) replaces the phantom, a row that still trips the poison
+      # signature is left as-is (genuine resource limit, not contamination).
+      # Bounded cost: the poison count is small (acceptance: < 2 min).
+      # Needs pnpm + deps + the test262 submodule (checkout already pulls
+      # submodules recursively above).
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Heal poison-classified rows (#2099)
+        run: |
+          npx tsx scripts/heal-poison-rows.ts \
+            --in  shard-artifacts/test262-results-merged.jsonl \
+            --out shard-artifacts/test262-results-merged.jsonl
+          npx tsx scripts/heal-poison-rows.ts \
+            --target standalone \
+            --in  shard-artifacts/test262-standalone-results-merged.jsonl \
+            --out shard-artifacts/test262-standalone-results-merged.jsonl
+          # Rebuild the merged report JSONs so their summary counts reflect any
+          # healed rows (the report build derives status counts from the JSONL).
+          node scripts/build-test262-report.mjs \
+            --input  shard-artifacts/test262-results-merged.jsonl \
+            --output shard-artifacts/test262-report-merged.json \
+            --baseline-sha "${{ github.sha }}"
+          node scripts/build-test262-report.mjs \
+            --input  shard-artifacts/test262-standalone-results-merged.jsonl \
+            --output shard-artifacts/test262-standalone-report-merged.json \
+            --baseline-sha "${{ github.sha }}"
+
       - name: Promote merged artifacts to stable baseline
         run: |
           mkdir -p benchmarks/results

--- a/plan/issues/2099-promote-baseline-rerun-poison-rows.md
+++ b/plan/issues/2099-promote-baseline-rerun-poison-rows.md
@@ -1,10 +1,12 @@
 ---
 id: 2099
 title: "promote-baseline must re-run (not carry forward) poison-classified rows"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -48,3 +50,38 @@ before starting.
 #1862 (in-review) covers the residual burst analysis; the promotion-time
 re-run is its unimplemented item 3 — filed so it isn't lost if #1862
 closes. New (analysis program).
+
+## Resolution (2026-06-16, dev-b)
+
+Implemented #1862 item 3 as a standalone, unit-testable script wired into the
+promote-baseline job:
+
+- **`scripts/heal-poison-rows.ts`** — reads a merged JSONL, collects rows whose
+  error matches the shared `POISON_ERROR_RE` (`scripts/test262-poison-error.mjs`)
+  and re-runs JUST those tests serially in a clean in-process compiler via
+  `runTest262File`. A re-run that now passes/skips (or fails for a NON-poison
+  reason) replaces the phantom row (status/error rewritten, stale
+  error_category/signature dropped, `poison_healed: true` breadcrumb added); a
+  re-run that STILL trips the poison signature is left as-is (genuine resource
+  limit, not contamination). `pass`/`skip` rows are never poison candidates.
+  Supports `--target standalone`, `--max-heal N`, `--quiet`; `--in`/`--out` may
+  be the same path.
+- **`test262-sharded.yml` promote-baseline job** — new step (after artifact
+  download, before promotion) sets up pnpm + deps and heals both the host and
+  standalone merged JSONLs, then rebuilds the merged report JSONs so the
+  promoted summary counts reflect the healed rows. The job already checks out
+  the test262 submodule recursively.
+
+Serial + in-process is intentional: poison counts are small, so the wall-clock
+cost is bounded (acceptance: < 2 min) and a single clean process is the
+cleanest possible worker.
+
+Tests: `tests/issue-2099.test.ts` (4 cases — phantom Binary-emit-error healed
+to true verdict via a real passing test262 file; non-poison rows passed
+through byte-for-byte; nothing-to-heal report; pass row with stray poison-text
+error not treated as poison). All pass.
+
+**Acceptance:**
+- [x] A synthetic poisoned row is healed by the next promotion
+- [x] Promotion wall-clock increase bounded — re-run is serial over the small
+  poison set only; single-row heal measured at ~0.7s locally.

--- a/scripts/heal-poison-rows.ts
+++ b/scripts/heal-poison-rows.ts
@@ -171,14 +171,22 @@ async function main(): Promise<void> {
       continue;
     }
 
-    // Heal: replace status/error, drop the stale error_category/signature so
-    // the report build re-derives them. Preserve all other fields.
-    const after: Row = { ...before, status: newStatus };
+    // Heal: replace status/error, drop the stale error/error_category/
+    // error_signature so the report build re-derives them. Build the row by
+    // omitting those keys (no `delete` — biome noDelete) and re-adding error
+    // only when the re-run produced one. JSON.stringify drops undefined keys,
+    // so an absent `error` serializes the same as a deleted one.
+    const {
+      error: _staleError,
+      error_category: _staleCategory,
+      error_signature: _staleSignature,
+      ...rest
+    } = before as Row & { error_category?: unknown; error_signature?: unknown };
+    void _staleError;
+    void _staleCategory;
+    void _staleSignature;
+    const after: Row = { ...rest, status: newStatus, poison_healed: true };
     if (newError) after.error = newError;
-    else delete after.error;
-    delete after.error_category;
-    delete after.error_signature;
-    after.poison_healed = true; // breadcrumb for audit (#2099)
     lines[idx] = JSON.stringify(after);
     healed += 1;
     if (!args.quiet) console.log(`  • ${file}: ${before.status} → ${newStatus} (healed).`);

--- a/scripts/heal-poison-rows.ts
+++ b/scripts/heal-poison-rows.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env npx tsx
+/**
+ * heal-poison-rows.ts — re-run poison-classified test262 rows in a clean
+ * in-process compiler before a baseline promotion (#2099).
+ *
+ * ── Why ──────────────────────────────────────────────────────────────────
+ * Emit/allocation-class failures ("Binary emit error", "out of memory",
+ * "Array buffer allocation failed", …) can leave a sharded compiler worker (or
+ * its incremental compiler) in a contaminated state, so the verdict written to
+ * the JSONL is a phantom — the test would pass in a fresh process. The runner
+ * already recycles + retries within a shard (#1862), but a poison row that
+ * still slips through and enters the baseline is then carried forward by EVERY
+ * later promotion: `promote-baseline` copies the merged JSONL verbatim, so the
+ * phantom failure becomes permanent drift (#1862 investigation item 3).
+ *
+ * This is that unimplemented item: at PROMOTION time, collect rows whose error
+ * matches the shared poison signature (`POISON_ERROR_RE`) and re-run JUST those
+ * tests serially in a clean in-process compiler. A re-run that now passes
+ * (or skips, or fails for a NON-poison reason) replaces the phantom row; a
+ * re-run that STILL trips the poison signature is left as-is (it is a genuine
+ * resource limit for that test, not contamination) and reported.
+ *
+ * Serial + in-process is deliberate: the poison count is small (single/low
+ * double digits), so the wall-clock cost is bounded (< 2 min, acceptance
+ * criterion), and a single clean process is the cleanest possible worker.
+ *
+ * ── Usage ──────────────────────────────────────────────────────────────────
+ *   npx tsx scripts/heal-poison-rows.ts \
+ *     --in  shard-artifacts/test262-results-merged.jsonl \
+ *     --out shard-artifacts/test262-results-merged.jsonl \
+ *     [--target standalone] [--max-heal N] [--quiet]
+ *
+ * `--in` and `--out` may be the same path (the file is read fully before any
+ * write). Non-poison rows are passed through byte-for-byte. Exit code is always
+ * 0 unless an argument is malformed or the input is unreadable — a row that
+ * can't be healed is a reported no-op, not a failure (the promotion must not be
+ * blocked by a genuinely resource-bound test).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runTest262File, TEST_CATEGORIES } from "../tests/test262-runner.ts";
+import { isPoisonCompileError } from "./test262-poison-error.mjs";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const TEST262_ROOT = resolve(ROOT, "test262");
+
+interface Row {
+  file?: string;
+  status?: string;
+  error?: string;
+  [k: string]: unknown;
+}
+
+interface Args {
+  in: string;
+  out: string;
+  target?: "standalone";
+  maxHeal: number;
+  quiet: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const inPath = get("--in");
+  if (!inPath) {
+    console.error("heal-poison-rows: --in <merged.jsonl> is required.");
+    process.exit(64);
+  }
+  const target = get("--target");
+  if (target !== undefined && target !== "standalone") {
+    console.error(`heal-poison-rows: --target must be "standalone" if given (got "${target}").`);
+    process.exit(64);
+  }
+  const maxHealRaw = get("--max-heal");
+  return {
+    in: inPath,
+    out: get("--out") ?? inPath,
+    target: target as "standalone" | undefined,
+    maxHeal: maxHealRaw && /^\d+$/.test(maxHealRaw) ? Number(maxHealRaw) : Infinity,
+    quiet: argv.includes("--quiet"),
+  };
+}
+
+/** Map a test path back to a TEST_CATEGORIES entry so runTest262File wraps correctly. */
+function categoryFor(file: string): string {
+  const trimmed = file.startsWith("test/") ? file.slice(5) : file;
+  let best = "";
+  for (const cat of TEST_CATEGORIES) {
+    if (trimmed.startsWith(cat + "/") && cat.length > best.length) best = cat;
+  }
+  if (!best) {
+    const i = trimmed.indexOf("/");
+    return i > 0 ? trimmed.slice(0, i) : trimmed;
+  }
+  return best;
+}
+
+function isPoisonRow(row: Row): boolean {
+  // Only failing rows can be phantoms; a `pass`/`skip` row is never poison.
+  if (row.status === "pass" || row.status === "skip") return false;
+  return isPoisonCompileError(typeof row.error === "string" ? row.error : "");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Read every line first (the in/out paths may be identical).
+  const raw = readFileSync(args.in, "utf8");
+  const lines = raw.split("\n");
+
+  const poisonIdx: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    let row: Row;
+    try {
+      row = JSON.parse(line) as Row;
+    } catch {
+      continue; // pass malformed lines through untouched
+    }
+    if (row.file && isPoisonRow(row)) poisonIdx.push(i);
+  }
+
+  const laneLabel = args.target ?? "host";
+  if (poisonIdx.length === 0) {
+    if (!args.quiet) console.log(`heal-poison-rows [${laneLabel}]: no poison-classified rows — nothing to heal.`);
+    // Still write the output (no-op copy) so the caller can use a single path.
+    if (args.out !== args.in) writeFileSync(args.out, raw);
+    return;
+  }
+
+  const toHeal = poisonIdx.slice(0, args.maxHeal);
+  console.log(
+    `heal-poison-rows [${laneLabel}]: ${poisonIdx.length} poison row(s) found; re-running ${toHeal.length} serially in a clean process.`,
+  );
+
+  let healed = 0;
+  let stillPoison = 0;
+  const startMs = Date.now();
+
+  for (const idx of toHeal) {
+    const before = JSON.parse(lines[idx]!) as Row;
+    const file = before.file!;
+    const cat = categoryFor(file);
+    const fullPath = resolve(TEST262_ROOT, file);
+
+    let newStatus: string;
+    let newError: string | undefined;
+    try {
+      const result = await runTest262File(fullPath, cat, undefined, args.target);
+      newStatus = result.status;
+      newError = (result as { error?: string; reason?: string }).error ?? (result as { reason?: string }).reason;
+    } catch (e) {
+      // A thrown runner error on re-run is itself a verdict; record it so the
+      // row reflects the clean-process reality rather than the phantom.
+      newStatus = "runtime";
+      newError = (e as Error)?.message?.slice(0, 200) ?? String(e);
+    }
+
+    // If the re-run STILL trips the poison signature, this is a genuine
+    // resource limit for the test, not worker contamination — leave the row
+    // unchanged so we don't mask a real failure.
+    if (newStatus !== "pass" && newStatus !== "skip" && isPoisonCompileError(newError ?? "")) {
+      stillPoison += 1;
+      if (!args.quiet) console.log(`  • ${file}: still poison on clean re-run (${newStatus}) — left as-is.`);
+      continue;
+    }
+
+    // Heal: replace status/error, drop the stale error_category/signature so
+    // the report build re-derives them. Preserve all other fields.
+    const after: Row = { ...before, status: newStatus };
+    if (newError) after.error = newError;
+    else delete after.error;
+    delete after.error_category;
+    delete after.error_signature;
+    after.poison_healed = true; // breadcrumb for audit (#2099)
+    lines[idx] = JSON.stringify(after);
+    healed += 1;
+    if (!args.quiet) console.log(`  • ${file}: ${before.status} → ${newStatus} (healed).`);
+  }
+
+  const elapsedS = ((Date.now() - startMs) / 1000).toFixed(1);
+  console.log(
+    `heal-poison-rows [${laneLabel}]: healed ${healed}, still-poison ${stillPoison}, ` +
+      `skipped ${poisonIdx.length - toHeal.length} (over --max-heal). ${elapsedS}s.`,
+  );
+
+  writeFileSync(args.out, lines.join("\n"));
+}
+
+main().catch((e) => {
+  console.error("heal-poison-rows: fatal:", e);
+  process.exit(1);
+});

--- a/tests/issue-2099.test.ts
+++ b/tests/issue-2099.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+function writeJsonl(path: string, records: Record<string, unknown>[]) {
+  writeFileSync(path, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+}
+
+function readJsonl(path: string): Record<string, unknown>[] {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+function runHeal(inPath: string, outPath: string): string {
+  return execFileSync("npx", ["tsx", "scripts/heal-poison-rows.ts", "--in", inPath, "--out", outPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+// Real test262 files that compile + pass under the current compiler — used so
+// the clean-process re-run produces a real `pass` verdict for the healed row.
+const PASSING_TEST = "test/language/types/boolean/S8.3_A1_T1.js";
+
+describe("#2099 promote-baseline heals poison-classified rows", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  function paths() {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-2099-"));
+    return { in: join(tmpDir, "merged.jsonl"), out: join(tmpDir, "healed.jsonl") };
+  }
+
+  it("re-runs a phantom Binary-emit-error row and heals it to its true verdict", () => {
+    const p = paths();
+    writeJsonl(p.in, [
+      {
+        file: PASSING_TEST,
+        category: "language",
+        status: "compile_error",
+        error: "Binary emit error: offset is out of bounds",
+        oracle_version: 1,
+      },
+    ]);
+    runHeal(p.in, p.out);
+    const rows = readJsonl(p.out);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("pass");
+    expect(rows[0]!.error).toBeUndefined();
+    expect(rows[0]!.poison_healed).toBe(true);
+  });
+
+  it("passes non-poison rows through byte-for-byte", () => {
+    const p = paths();
+    const passRow = { file: "test/a.js", category: "language", status: "pass", oracle_version: 1 };
+    const realFail = {
+      file: "test/b.js",
+      category: "language",
+      status: "fail",
+      error: "assertion failed: expected 1 got 2",
+      oracle_version: 1,
+    };
+    writeJsonl(p.in, [passRow, realFail]);
+    runHeal(p.in, p.out);
+    const rows = readJsonl(p.out);
+    expect(rows).toEqual([passRow, realFail]);
+  });
+
+  it("reports nothing-to-heal when no poison rows are present", () => {
+    const p = paths();
+    writeJsonl(p.in, [{ file: "test/a.js", category: "language", status: "pass", oracle_version: 1 }]);
+    const out = runHeal(p.in, p.out);
+    expect(out).toMatch(/no poison-classified rows/i);
+    expect(readJsonl(p.out)).toHaveLength(1);
+  });
+
+  it("does not treat a pass/skip row as poison even if its error text matches", () => {
+    // Defensive: a pass row should never carry a poison error, but if a stray
+    // field exists the row must not be re-run / mutated.
+    const p = paths();
+    const row = {
+      file: PASSING_TEST,
+      category: "language",
+      status: "pass",
+      error: "Binary emit error (stale field)",
+      oracle_version: 1,
+    };
+    writeJsonl(p.in, [row]);
+    const out = runHeal(p.in, p.out);
+    expect(out).toMatch(/no poison-classified rows/i);
+    expect(readJsonl(p.out)).toEqual([row]);
+  });
+});


### PR DESCRIPTION
## #2099 — phantom failures persist across promotions

Implements the unimplemented **item 3** of the #1862 investigation. Phantom
emit/allocation-class rows (`Binary emit error`, `out of memory`, `Array
buffer allocation failed`, …) from a contaminated sharded compiler worker were
copied **verbatim** into the baseline by `promote-baseline` and then carried
forward by every later promotion — the historical drift class.

### What this does
- **`scripts/heal-poison-rows.ts`** — reads a merged JSONL, collects rows whose
  error matches the shared `POISON_ERROR_RE`
  (`scripts/test262-poison-error.mjs`) and **re-runs just those tests serially
  in a clean in-process compiler** via `runTest262File`:
  - re-run now passes/skips (or fails for a **non-poison** reason) → replace the
    phantom row (rewrite status/error, drop stale `error_category`/
    `error_signature`, add a `poison_healed: true` breadcrumb)
  - re-run **still** trips the poison signature → leave as-is (genuine resource
    limit for that test, not contamination — don't mask a real failure)
  - `pass`/`skip` rows are never poison candidates
  - flags: `--target standalone`, `--max-heal N`, `--quiet`; `--in`/`--out` may
    be the same path
- **`test262-sharded.yml` promote-baseline job** — new step after artifact
  download / before promotion: sets up pnpm + deps, heals the host and
  standalone merged JSONLs, then rebuilds the merged report JSONs so the
  promoted summary counts reflect the healed rows. (The job already checks out
  the test262 submodule recursively.)

Serial + in-process is intentional: poison counts are small, so the wall-clock
cost is bounded and a single clean process is the cleanest possible worker.

### Acceptance criteria
- [x] A synthetic poisoned row is healed by the next promotion
- [x] Promotion wall-clock increase bounded (< 2 min) — serial over the small
  poison set only; single-row heal ~0.7s locally

### Tests
`tests/issue-2099.test.ts` — 4 cases (phantom Binary-emit-error healed to true
verdict via a real passing test262 file; non-poison rows passed through
byte-for-byte; nothing-to-heal report; pass row with stray poison-text error
not treated as poison). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)