### PR TITLE
chore(#2147): reconciler flags ready issues fixed by a merged PR

### DIFF
--- a/plan/issues/2147-reconcile-script-merged-pr-ready-issues.md
+++ b/plan/issues/2147-reconcile-script-merged-pr-ready-issues.md
@@ -1,10 +1,12 @@
 ---
 id: 2147
 title: "reconcile-tasklist.mjs: flag ready issues whose number appears in a merged PR title"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -43,3 +45,34 @@ output (report-only; flipping stays manual/PO).
 ## Notes
 
 Routine dev, S-size, sprint 63. PO owns the flips.
+
+## Resolution (2026-06-16, dev-b)
+
+Extended `scripts/reconcile-tasklist.mjs` with a second drift check:
+
+- New helpers `listIssues()`, `mergedPrIssueRefs()`, `mergedPrStaleIssues()`.
+  Fetches merged PR titles via `gh pr list --state merged -L 200 --json title`,
+  extracts every `#NNNN` reference, and reports issues still at
+  `ready`/`in-progress` whose number is cited by a merged **code** PR.
+- **Plan/docs exclusion** — `PLAN_DOCS_TITLE_RE` drops `plan:`/`docs:`/
+  `chore(plan)`/`chore(docs)` (and scoped variants) titles so a planning commit
+  that merely *mentions* an issue can't false-flag it (acceptance: zero false
+  flags on plan-only PRs).
+- **At-risk filter** — only `ready`/`in-progress` issues are flagged
+  (`done`/`wont-fix`/`in-review`/`blocked`/`backlog` aren't claimable, so a
+  stale reference can't poison dispatch).
+- Wired into all three output modes (human report, `--quiet` one-liner,
+  `--json`). Report-only — does NOT write frontmatter (PO owns the flips).
+- Resilient: skips silently with a reason when `gh` is unavailable/
+  unauthenticated (CI) or `--no-merged-prs` is passed; never fails the
+  SessionStart hook.
+
+Tests: `tests/issue-2147.test.ts` (4 cases — code PR flags a ready issue;
+plan/docs PR does NOT flag; `done` issue never flagged; in-progress flagged +
+`--no-merged-prs` skip path) all pass via a fixture issues dir and a shimmed
+`gh` on PATH.
+
+**Acceptance:**
+- [x] Running the script after a merge citing #NNNN flags the issue within one
+  session (it runs in the SessionStart hook).
+- [x] Zero false flags on plan-only PRs (plan:/docs: titles excluded).

--- a/scripts/reconcile-tasklist.mjs
+++ b/scripts/reconcile-tasklist.mjs
@@ -298,7 +298,9 @@ if (JSON_OUT) {
       : ` | ${mergedPr.flagged.length} merged-but-ready: ${mergedPr.flagged.map((s) => "#" + s.id).join(",")}`;
   console.log(staleLine + prLine);
 } else {
-  out(`\nreconcile-tasklist: ${tasks.length} tasks, ${open.length} open, ${stale.length} STALE (done-but-not-completed)\n`);
+  out(
+    `\nreconcile-tasklist: ${tasks.length} tasks, ${open.length} open, ${stale.length} STALE (done-but-not-completed)\n`,
+  );
   for (const s of stale) {
     out(`  #${s.id}  [${s.reason}]  ${s.subject}`);
   }

--- a/scripts/reconcile-tasklist.mjs
+++ b/scripts/reconcile-tasklist.mjs
@@ -29,9 +29,21 @@
 //   node scripts/reconcile-tasklist.mjs --quiet    # one line: "N stale: id,id" (for hooks)
 //   node scripts/reconcile-tasklist.mjs --json      # machine-readable
 //   node scripts/reconcile-tasklist.mjs --apply     # best-effort: rewrite stale task JSON status=completed
+//   node scripts/reconcile-tasklist.mjs --no-merged-prs  # skip the merged-PR cross-check (offline)
 //
 // Safe everywhere: if no task store is present (e.g. CI runners), it exits 0
 // with "no task store" and never fails a build.
+//
+// SECOND DRIFT SOURCE (#2147): the task<->frontmatter reconciler above never
+// checks issue frontmatter against MERGED PRs. The sprint-62 triage found 11
+// sprint-61 issues still `ready` whose fixes had already merged — a dev WILL
+// claim already-fixed work. So we additionally fetch merged PR titles
+// (`gh pr list --state merged`), extract their `#NNNN` references, and report
+// every issue still at `ready`/`in-progress` whose number is cited by a merged
+// CODE PR. Plan/docs PRs (`plan:`/`docs:`/`chore(plan)` titles) are excluded so
+// a planning commit that merely *mentions* an issue can't false-flag it.
+// Report-only — the PO owns the actual frontmatter flips. The check is skipped
+// silently when `gh` is unavailable/unauthenticated (CI) or `--no-merged-prs`.
 
 import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -42,6 +54,7 @@ const args = new Set(process.argv.slice(2));
 const QUIET = args.has("--quiet");
 const JSON_OUT = args.has("--json");
 const APPLY = args.has("--apply");
+const NO_MERGED_PRS = args.has("--no-merged-prs");
 
 const CLAUDE_HOME = process.env.CLAUDE_HOME || join(homedir(), ".claude");
 const TASKS_ROOT = join(CLAUDE_HOME, "tasks");
@@ -140,6 +153,99 @@ function subjectSaysDone(task) {
   return /\b(CLOSED|SUPERSEDED|STALE|\[DONE\])\b/.test(task.subject || "");
 }
 
+// ── #2147: cross-check ready/in-progress issues against merged PR titles ──────
+
+// PR titles that are planning/docs-only — a `#NNNN` in one of these is a
+// mention, not a fix, so it must NOT flag the issue. Matches the repo's
+// conventional-commit prefixes (`plan:`, `docs:`, `chore(plan): …`, etc.).
+const PLAN_DOCS_TITLE_RE = /^\s*(?:plan|docs|chore\(plan\)|chore\(docs\)|plan\([^)]*\)|docs\([^)]*\))\b/i;
+
+// Issues actively claimable by a dev — these are the ones a stale merged-PR
+// reference actually poisons (a dev would pick them up). `done`/`wont-fix`/
+// `in-review`/`blocked`/`backlog` are not at risk of a wrong claim.
+const AT_RISK_ISSUE_STATUSES = new Set(["ready", "in-progress"]);
+
+// List every issue file with its id, status, and title.
+function listIssues() {
+  const issues = [];
+  if (!existsSync(ISSUES_DIR)) return issues;
+  for (const f of readdirSync(ISSUES_DIR)) {
+    const m = f.match(/^(\d+[a-z]?)-.+\.md$/i);
+    if (!m) continue;
+    let text;
+    try {
+      text = readFileSync(join(ISSUES_DIR, f), "utf8");
+    } catch {
+      continue;
+    }
+    const status = (text.match(/^status:\s*(\S+)/m)?.[1] || "").toLowerCase() || null;
+    const title = text.match(/^title:\s*"?(.+?)"?\s*$/m)?.[1] || "";
+    issues.push({ id: m[1].toLowerCase(), file: f, status, title });
+  }
+  return issues;
+}
+
+// Fetch merged PR titles via `gh` and return the set of issue ids cited by a
+// non-plan/docs (i.e. code) PR. Returns null if `gh` is unavailable so the
+// caller can skip the check cleanly (CI, offline). The `#NNNN` reference is
+// taken from the whole title — for code PRs every cited issue is a candidate
+// (a fix PR commonly cites the primary issue plus the ones it also closes).
+function mergedPrIssueRefs() {
+  let raw;
+  try {
+    // -L caps the lookback; merged PRs older than the current sprint window are
+    // irrelevant (their issues were reconciled long ago). JSON keeps parsing robust.
+    raw = execSync("gh pr list --state merged -L 200 --json title", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 20000,
+    });
+  } catch {
+    return null; // gh missing / unauthenticated / network — skip silently
+  }
+  let prs;
+  try {
+    prs = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const refs = new Map(); // issueId -> sample PR title that cited it
+  for (const pr of prs) {
+    const title = pr.title || "";
+    if (PLAN_DOCS_TITLE_RE.test(title)) continue; // mention-only, not a fix
+    const seen = new Set();
+    for (const m of title.matchAll(/#(\d+[a-z]?)/gi)) {
+      const id = m[1].toLowerCase();
+      if (seen.has(id)) continue;
+      seen.add(id);
+      if (!refs.has(id)) refs.set(id, title);
+    }
+  }
+  return refs;
+}
+
+// Build the list of at-risk issues cited by a merged code PR.
+function mergedPrStaleIssues() {
+  if (NO_MERGED_PRS) return { skipped: true, reason: "--no-merged-prs", flagged: [] };
+  const refs = mergedPrIssueRefs();
+  if (refs === null) return { skipped: true, reason: "gh unavailable", flagged: [] };
+  const flagged = [];
+  for (const issue of listIssues()) {
+    if (!issue.status || !AT_RISK_ISSUE_STATUSES.has(issue.status)) continue;
+    const prTitle = refs.get(issue.id);
+    if (prTitle) {
+      flagged.push({
+        id: issue.id,
+        issueStatus: issue.status,
+        prTitle: prTitle.slice(0, 90),
+        title: issue.title.slice(0, 70),
+      });
+    }
+  }
+  flagged.sort((a, b) => Number(parseInt(a.id, 10)) - Number(parseInt(b.id, 10)));
+  return { skipped: false, flagged };
+}
+
 const tasks = loadTasks();
 if (tasks.length === 0) {
   out("reconcile-tasklist: no task store found (ok on CI) — nothing to do.");
@@ -167,10 +273,30 @@ for (const t of open) {
   }
 }
 
+// #2147: ready/in-progress issues already fixed by a merged PR.
+const mergedPr = mergedPrStaleIssues();
+
 if (JSON_OUT) {
-  console.log(JSON.stringify({ total: tasks.length, open: open.length, stale }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        total: tasks.length,
+        open: open.length,
+        stale,
+        mergedPrFixed: mergedPr.flagged,
+        mergedPrCheckSkipped: mergedPr.skipped ? mergedPr.reason : false,
+      },
+      null,
+      2,
+    ),
+  );
 } else if (QUIET) {
-  console.log(stale.length === 0 ? "0 stale" : `${stale.length} stale: ${stale.map((s) => s.id).join(",")}`);
+  const staleLine = stale.length === 0 ? "0 stale" : `${stale.length} stale: ${stale.map((s) => s.id).join(",")}`;
+  const prLine =
+    mergedPr.flagged.length === 0
+      ? ""
+      : ` | ${mergedPr.flagged.length} merged-but-ready: ${mergedPr.flagged.map((s) => "#" + s.id).join(",")}`;
+  console.log(staleLine + prLine);
 } else {
   out(`\nreconcile-tasklist: ${tasks.length} tasks, ${open.length} open, ${stale.length} STALE (done-but-not-completed)\n`);
   for (const s of stale) {
@@ -180,6 +306,22 @@ if (JSON_OUT) {
     out(`\nApply (authoritative — run as the team lead):`);
     for (const s of stale) out(`  TaskUpdate taskId=${s.id} status=completed`);
     out(`\nOr best-effort direct rewrite: node scripts/reconcile-tasklist.mjs --apply`);
+  }
+
+  // #2147 merged-PR cross-check report.
+  if (mergedPr.skipped) {
+    out(`\nmerged-PR cross-check (#2147): skipped (${mergedPr.reason}).`);
+  } else {
+    out(
+      `\nmerged-PR cross-check (#2147): ${mergedPr.flagged.length} ready/in-progress issue(s) cited by a merged code PR:`,
+    );
+    for (const s of mergedPr.flagged) {
+      out(`  #${s.id}  [${s.issueStatus}]  fixed by merged PR "${s.prTitle}"`);
+    }
+    if (mergedPr.flagged.length) {
+      out(`\n  → these fixes have merged but the issue frontmatter still reads ready/in-progress.`);
+      out(`    The PO should flip status: done (report-only — this script does not write frontmatter).`);
+    }
   }
 }
 

--- a/tests/issue-2147.test.ts
+++ b/tests/issue-2147.test.ts
@@ -81,10 +81,7 @@ describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () 
   }
 
   it("flags a ready issue cited by a merged code PR", () => {
-    const f = setup(
-      [["2002", "ready", "some bug"]],
-      ["fix(#2002): correct the thing", "feat(#9999): unrelated"],
-    );
+    const f = setup([["2002", "ready", "some bug"]], ["fix(#2002): correct the thing", "feat(#9999): unrelated"]);
     const { json } = run(f);
     expect(json.mergedPrCheckSkipped).toBe(false);
     expect(json.mergedPrFixed.map((x) => x.id)).toContain("2002");
@@ -100,10 +97,7 @@ describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () 
   });
 
   it("does NOT flag an issue already marked done", () => {
-    const f = setup(
-      [["2004", "done", "fixed bug"]],
-      ["fix(#2004): correct the other thing"],
-    );
+    const f = setup([["2004", "done", "fixed bug"]], ["fix(#2004): correct the other thing"]);
     const { json } = run(f);
     expect(json.mergedPrFixed.map((x) => x.id)).not.toContain("2004");
   });

--- a/tests/issue-2147.test.ts
+++ b/tests/issue-2147.test.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(fileURLToPath(import.meta.url), "..", "..", "scripts", "reconcile-tasklist.mjs");
+
+interface Fixture {
+  dir: string;
+  issuesDir: string;
+  binDir: string;
+}
+
+function issue(id: string, status: string, title: string): string {
+  return `---\nid: ${id}\ntitle: "${title}"\nstatus: ${status}\nsprint: 63\n---\n\n# #${id}\n`;
+}
+
+/** Write a fake `gh` on PATH that returns the given merged-PR JSON for `pr list`. */
+function fakeGh(binDir: string, prTitles: string[]): void {
+  const json = JSON.stringify(prTitles.map((t) => ({ title: t })));
+  const script = `#!/usr/bin/env node
+const a = process.argv.slice(2).join(" ");
+if (a.includes("pr list")) { process.stdout.write(${JSON.stringify(json)}); process.exit(0); }
+process.exit(0);
+`;
+  writeFileSync(join(binDir, "gh"), script);
+  chmodSync(join(binDir, "gh"), 0o755);
+}
+
+function run(fx: Fixture): { stdout: string; json: any } {
+  // --no-merged-prs is NOT passed; we want the gh-backed path. The team task
+  // store is unlikely to exist in CI, but the merged-PR section runs regardless.
+  const stdout = execFileSync("node", [SCRIPT, "--json"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      REPO_ROOT: fx.dir,
+      PATH: `${fx.binDir}:${process.env.PATH}`,
+      // Point the task store somewhere empty so the task section is a no-op.
+      CLAUDE_HOME: join(fx.dir, "empty-claude-home"),
+    },
+  });
+  // --json prints one JSON object; if no task store, the early-exit prints a
+  // different shape, so guard.
+  return { stdout, json: JSON.parse(stdout) };
+}
+
+describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () => {
+  let fx: Fixture | undefined;
+
+  afterEach(() => {
+    if (fx) rmSync(fx.dir, { recursive: true, force: true });
+    fx = undefined;
+  });
+
+  function setup(issues: string[][], prTitles: string[]): Fixture {
+    const dir = mkdtempSync(join(tmpdir(), "issue-2147-"));
+    const issuesDir = join(dir, "plan", "issues");
+    mkdirSync(issuesDir, { recursive: true });
+    // Seed a non-empty task store so the script reaches the merged-PR section
+    // (it early-exits when zero tasks are found).
+    const taskDir = join(dir, "empty-claude-home", "tasks", "js2wasm");
+    mkdirSync(taskDir, { recursive: true });
+    writeFileSync(join(taskDir, "1.json"), JSON.stringify({ id: "1", status: "completed", subject: "noop" }));
+    for (const [id, status, title] of issues) {
+      writeFileSync(join(issuesDir, `${id}-slug.md`), issue(id, status, title));
+    }
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    fakeGh(binDir, prTitles);
+    fx = { dir, issuesDir, binDir };
+    return fx;
+  }
+
+  it("flags a ready issue cited by a merged code PR", () => {
+    const f = setup(
+      [["2002", "ready", "some bug"]],
+      ["fix(#2002): correct the thing", "feat(#9999): unrelated"],
+    );
+    const { json } = run(f);
+    expect(json.mergedPrCheckSkipped).toBe(false);
+    expect(json.mergedPrFixed.map((x: any) => x.id)).toContain("2002");
+  });
+
+  it("does NOT flag an issue only mentioned by a plan/docs PR", () => {
+    const f = setup(
+      [["2003", "ready", "another bug"]],
+      ["plan(s63): triage #2003 into the sprint", "docs: note #2003 in the changelog"],
+    );
+    const { json } = run(f);
+    expect(json.mergedPrFixed.map((x: any) => x.id)).not.toContain("2003");
+  });
+
+  it("does NOT flag an issue already marked done", () => {
+    const f = setup(
+      [["2004", "done", "fixed bug"]],
+      ["fix(#2004): correct the other thing"],
+    );
+    const { json } = run(f);
+    expect(json.mergedPrFixed.map((x: any) => x.id)).not.toContain("2004");
+  });
+
+  it("flags in-progress issues too, and reports skipped when --no-merged-prs", () => {
+    const f = setup([["2005", "in-progress", "wip bug"]], ["fix(#2005): land it"]);
+    const { json } = run(f);
+    expect(json.mergedPrFixed.map((x: any) => x.id)).toContain("2005");
+
+    // --no-merged-prs path
+    const stdout = execFileSync("node", [SCRIPT, "--json", "--no-merged-prs"], {
+      encoding: "utf8",
+      env: { ...process.env, REPO_ROOT: f.dir, CLAUDE_HOME: join(f.dir, "empty-claude-home") },
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.mergedPrCheckSkipped).toBe("--no-merged-prs");
+    expect(parsed.mergedPrFixed).toEqual([]);
+  });
+});

--- a/tests/issue-2147.test.ts
+++ b/tests/issue-2147.test.ts
@@ -29,7 +29,13 @@ process.exit(0);
   chmodSync(join(binDir, "gh"), 0o755);
 }
 
-function run(fx: Fixture): { stdout: string; json: any } {
+interface ReconcileJson {
+  mergedPrCheckSkipped: boolean | string;
+  mergedPrFixed: Array<{ id: string; issueStatus: string; prTitle: string; title: string }>;
+  stale: unknown[];
+}
+
+function run(fx: Fixture): { stdout: string; json: ReconcileJson } {
   // --no-merged-prs is NOT passed; we want the gh-backed path. The team task
   // store is unlikely to exist in CI, but the merged-PR section runs regardless.
   const stdout = execFileSync("node", [SCRIPT, "--json"], {
@@ -81,7 +87,7 @@ describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () 
     );
     const { json } = run(f);
     expect(json.mergedPrCheckSkipped).toBe(false);
-    expect(json.mergedPrFixed.map((x: any) => x.id)).toContain("2002");
+    expect(json.mergedPrFixed.map((x) => x.id)).toContain("2002");
   });
 
   it("does NOT flag an issue only mentioned by a plan/docs PR", () => {
@@ -90,7 +96,7 @@ describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () 
       ["plan(s63): triage #2003 into the sprint", "docs: note #2003 in the changelog"],
     );
     const { json } = run(f);
-    expect(json.mergedPrFixed.map((x: any) => x.id)).not.toContain("2003");
+    expect(json.mergedPrFixed.map((x) => x.id)).not.toContain("2003");
   });
 
   it("does NOT flag an issue already marked done", () => {
@@ -99,20 +105,20 @@ describe("#2147 reconcile-tasklist flags ready issues fixed by a merged PR", () 
       ["fix(#2004): correct the other thing"],
     );
     const { json } = run(f);
-    expect(json.mergedPrFixed.map((x: any) => x.id)).not.toContain("2004");
+    expect(json.mergedPrFixed.map((x) => x.id)).not.toContain("2004");
   });
 
   it("flags in-progress issues too, and reports skipped when --no-merged-prs", () => {
     const f = setup([["2005", "in-progress", "wip bug"]], ["fix(#2005): land it"]);
     const { json } = run(f);
-    expect(json.mergedPrFixed.map((x: any) => x.id)).toContain("2005");
+    expect(json.mergedPrFixed.map((x) => x.id)).toContain("2005");
 
     // --no-merged-prs path
     const stdout = execFileSync("node", [SCRIPT, "--json", "--no-merged-prs"], {
       encoding: "utf8",
       env: { ...process.env, REPO_ROOT: f.dir, CLAUDE_HOME: join(f.dir, "empty-claude-home") },
     });
-    const parsed = JSON.parse(stdout);
+    const parsed = JSON.parse(stdout) as ReconcileJson;
     expect(parsed.mergedPrCheckSkipped).toBe("--no-merged-prs");
     expect(parsed.mergedPrFixed).toEqual([]);
   });


### PR DESCRIPTION
## #2147 — stale `ready` frontmatter poisons dispatch

The task↔frontmatter reconciler never cross-checked issue frontmatter against
**merged PRs**, so issues sat at `ready` after their fix merged and a dev would
claim already-fixed work — the sprint-62 triage found 11 such sprint-61 issues.

### What this does
Extends `scripts/reconcile-tasklist.mjs` with a second drift check
(`listIssues()`, `mergedPrIssueRefs()`, `mergedPrStaleIssues()`):
- fetches merged PR titles (`gh pr list --state merged -L 200 --json title`),
  extracts every `#NNNN` reference, and reports issues still at
  `ready`/`in-progress` cited by a merged **code** PR
- **`PLAN_DOCS_TITLE_RE`** excludes `plan:`/`docs:`/`chore(plan)`/`chore(docs)`
  (and scoped variants) titles so a planning commit that merely *mentions* an
  issue can't false-flag it
- only `ready`/`in-progress` issues are flagged (others aren't claimable)
- wired into all three output modes (human report, `--quiet`, `--json`)
- **report-only** — does NOT write frontmatter (the PO owns the flips)
- resilient: skips silently with a reason when `gh` is unavailable/
  unauthenticated (CI) or `--no-merged-prs` is passed; never fails the
  SessionStart hook

### Acceptance criteria
- [x] Running the script after a merge citing #NNNN flags the issue within one
  session (runs in the SessionStart hook)
- [x] Zero false flags on plan-only PRs (`plan:`/`docs:` titles excluded)

### Tests
`tests/issue-2147.test.ts` — 4 cases (code PR flags a ready issue; plan/docs PR
does NOT flag; `done` issue never flagged; in-progress flagged + `--no-merged-prs`
skip path) via a fixture issues dir and a shimmed `gh` on PATH. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)