### PR TITLE
chore(#2093): issue->probe coverage CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,18 @@ jobs:
         # depends_on, or broken plan/issues/<id>-<slug>.md links in tracked *.md.
         run: pnpm run check:issues
 
+      - name: Issue→probe coverage gate (#2093)
+        # A bugfix issue (created on/after the cutoff) cannot flip to
+        # `status: done` without a permanent probe/test reference — either a
+        # tests/issue-<id>.test.ts file or a cited tests/…test… / test262/… path.
+        # WARNING-only at `ready`; HARD FAIL on the done-flip. Diffs the changed
+        # issue files against the PR base so only this PR's flips are gated.
+        # Skips cleanly when no diff base resolves (never blocks a build it can't
+        # reason about). Needs the base ref present for the diff.
+        run: |
+          git fetch --no-tags --depth=1 origin main 2>/dev/null || true
+          ISSUE_COVERAGE_BASE=origin/main pnpm run check:issue-spec-coverage
+
       - name: Host-import allowlist + strict-mode gate (#1524)
         env:
           # PRs that intentionally grow the allowlist must include

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "census:async": "node scripts/async-call-census.mjs",
     "check:codegen-fallbacks": "npx tsx scripts/check-codegen-fallbacks.ts",
     "check:any-box-sites": "node scripts/check-any-box-sites.mjs",
+    "check:issue-spec-coverage": "node scripts/check-issue-spec-coverage.mjs",
     "check:issues": "node scripts/update-issues.mjs --check",
     "test:diff": "npx tsx scripts/diff-test.ts",
     "test:diff:triage": "npx tsx scripts/diff-triage.ts",

--- a/plan/issues/2093-issue-probe-coverage-ci-rule.md
+++ b/plan/issues/2093-issue-probe-coverage-ci-rule.md
@@ -1,10 +1,12 @@
 ---
 id: 2093
 title: "issue→probe coverage CI rule: bugfix issues cannot flip to done without a permanent probe/test reference"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -45,3 +47,30 @@ retroactive noise).
 
 The fork's post-merge automation issue (2048 slug) covers status flipping,
 not test coverage. New (analysis program).
+
+## Resolution (2026-06-16, dev-b)
+
+- **`scripts/check-issue-spec-coverage.mjs`** — diffs the issue files CHANGED in
+  the PR (against `origin/main`, falling back to `HEAD^`) and, for those
+  `created >= 2026-06-15`:
+  - `status: done` with NO probe/test reference → **HARD FAIL** (exit 1)
+  - `status: ready` with NO probe/test reference → **WARNING** only
+  A probe reference is satisfied by either a `tests/issue-<id>.test.ts` file on
+  disk OR a cited `tests/…test…(.ts|.mjs|.js)` / `test262/…` path in the issue
+  body. Non-behavioural `task_type`s (infrastructure/tooling/docs/process) are
+  exempt — they have no runtime repro. Skips cleanly when no diff base resolves
+  (never blocks a build it can't reason about); `--all` scans every issue.
+- **`package.json`** — `check:issue-spec-coverage` script.
+- **`ci.yml` `quality` job** — new "Issue→probe coverage gate (#2093)" step
+  (fetches the base ref, runs with `ISSUE_COVERAGE_BASE=origin/main`).
+
+The cutoff keeps the gate off the pre-existing backlog (this issue itself is
+pre-cutoff + infra, so its own done-flip is exempt).
+
+Tests: `tests/issue-2093.test.ts` (6 cases — done-without-probe FAIL; done-with
+`tests/issue-<id>.test.ts` pass; done-with-test262-body-cite pass; pre-cutoff
+grandfathered; ready→WARNING-not-fail; infra task_type exempt). All pass.
+
+**Acceptance:**
+- [x] Gate live in `quality`; a done-flip without test reference fails CI
+- [x] Pre-cutoff issues unaffected (created < 2026-06-15 skipped)

--- a/scripts/check-issue-spec-coverage.mjs
+++ b/scripts/check-issue-spec-coverage.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// check-issue-spec-coverage.mjs — force a bugfix issue's repro into the
+// permanent test suite (#2093).
+//
+// PROBLEM: nothing made a bugfix issue carry its repro into a permanent test.
+// The June 2026 fix wave added `tests/issue-NNNN.test.ts` files by CONVENTION
+// only, so the next sweep's bugs would again ship with no armor.
+//
+// THIS GATE (wired into the required `quality` job): for issue files CHANGED in
+// the current PR/commit whose `created` date is on/after the cutoff:
+//   • flipping to `status: done` with NO probe/test reference → HARD FAIL
+//   • sitting at `status: ready` with NO probe/test reference → WARNING only
+// A "probe/test reference" is satisfied if EITHER:
+//   (a) a `tests/issue-<id>.test.ts` (or `-<id>-…`) file exists in the tree, OR
+//   (b) the issue body cites a `tests/…test…(.ts|.mjs|.js)` path or a
+//       `test262/…` path (a conformance repro is a permanent reference too).
+//
+// Cutoff (`created >= 2026-06-15`) keeps the gate off the pre-existing backlog —
+// no retroactive noise. Infra/tooling/docs issues are exempt (they have no
+// runtime repro); only behavioural task_types are gated.
+//
+// Usage:
+//   node scripts/check-issue-spec-coverage.mjs            # gate (CI)
+//   node scripts/check-issue-spec-coverage.mjs --all      # scan every issue, ignore diff
+//   node scripts/check-issue-spec-coverage.mjs --base REF # diff against REF (default: origin/main)
+//   node scripts/check-issue-spec-coverage.mjs --json
+//
+// Safe by construction: if the diff base can't be resolved it falls back to
+// scanning only files that differ from HEAD^ (push) or, failing that, exits 0
+// with a note — it never blocks a build it can't reason about.
+
+import { execSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const opt = (f, d) => {
+  const i = argv.indexOf(f);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : d;
+};
+const SCAN_ALL = has("--all");
+const JSON_OUT = has("--json");
+const BASE_REF = opt("--base", process.env.ISSUE_COVERAGE_BASE || "origin/main");
+
+const REPO = process.env.REPO_ROOT || process.cwd();
+const ISSUES_DIR = join(REPO, "plan", "issues");
+const TESTS_DIR = join(REPO, "tests");
+
+// Issues created on/after this date are gated; older ones are grandfathered.
+const CUTOFF = process.env.ISSUE_COVERAGE_CUTOFF || "2026-06-15";
+
+// task_types that describe a behavioural change with a runnable repro. Infra/
+// tooling/docs/process issues have no compiler repro, so they're exempt.
+const GATED_TASK_TYPES = new Set(["bug", "bugfix", "fix", "feature", "conformance", "codegen", "runtime"]);
+
+// A body reference that counts as a permanent test/probe anchor.
+const TEST_REF_RE = /tests\/[\w./-]*test[\w./-]*\.(?:ts|mjs|js)|test262\/[\w./-]+\.js/i;
+
+function log(s) {
+  if (!JSON_OUT) console.log(s);
+}
+
+function frontmatter(text) {
+  const out = {};
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = line.match(/^(\w+):\s*"?(.*?)"?\s*$/);
+    if (kv) out[kv[1]] = kv[2];
+  }
+  return out;
+}
+
+function issueIdFromFile(f) {
+  const m = f.match(/^(\d+[a-z]?)-.+\.md$/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// Does a permanent test/probe reference exist for this issue id?
+function hasProbe(id, body) {
+  // (a) a tests/issue-<id>*.test.ts file on disk
+  if (existsSync(TESTS_DIR)) {
+    const re = new RegExp(`^issue-${id}(?:[^0-9].*)?\\.test\\.(?:ts|mjs|js)$`, "i");
+    for (const f of readdirSync(TESTS_DIR)) {
+      if (re.test(f)) return true;
+    }
+  }
+  // (b) the issue body cites a test/probe path (any tests/*test* or test262/*).
+  return TEST_REF_RE.test(body || "");
+}
+
+// Which issue files changed vs the base? Returns null when we can't resolve a
+// diff (caller falls back to scanning HEAD^, then to a clean exit).
+function changedIssueFiles() {
+  if (SCAN_ALL) return null;
+  for (const ref of [BASE_REF, "HEAD^"]) {
+    try {
+      const out = execSync(`git diff --name-only --diff-filter=ACM ${ref}...HEAD -- plan/issues`, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        cwd: REPO,
+      });
+      const files = out
+        .split("\n")
+        .map((s) => s.trim())
+        .filter((s) => /^plan\/issues\/\d+[a-z]?-.+\.md$/i.test(s));
+      return files.map((f) => f.replace(/^plan\/issues\//, ""));
+    } catch {
+      // try next ref
+    }
+  }
+  return null;
+}
+
+function allIssueFiles() {
+  if (!existsSync(ISSUES_DIR)) return [];
+  return readdirSync(ISSUES_DIR).filter((f) => /^\d+[a-z]?-.+\.md$/i.test(f));
+}
+
+function main() {
+  if (!existsSync(ISSUES_DIR)) {
+    log("check-issue-spec-coverage: no plan/issues dir — nothing to check.");
+    if (JSON_OUT) console.log(JSON.stringify({ failures: [], warnings: [], skipped: "no issues dir" }));
+    process.exit(0);
+  }
+
+  let files = changedIssueFiles();
+  let scope;
+  if (files === null) {
+    if (SCAN_ALL) {
+      files = allIssueFiles();
+      scope = "all issues (--all)";
+    } else {
+      log("check-issue-spec-coverage: could not resolve a diff base — skipping (no build block).");
+      if (JSON_OUT) console.log(JSON.stringify({ failures: [], warnings: [], skipped: "no diff base" }));
+      process.exit(0);
+    }
+  } else {
+    scope = `${files.length} changed issue file(s) vs ${BASE_REF}`;
+  }
+
+  const failures = [];
+  const warnings = [];
+
+  for (const f of files) {
+    const id = issueIdFromFile(f);
+    if (!id) continue;
+    const path = join(ISSUES_DIR, f);
+    if (!existsSync(path)) continue; // deleted in the diff
+    const text = readFileSync(path, "utf8");
+    const fm = frontmatter(text);
+    const status = (fm.status || "").toLowerCase();
+    const created = fm.created || "";
+    const taskType = (fm.task_type || "").toLowerCase();
+
+    // Cutoff: only gate issues created on/after the cutoff date.
+    if (!created || created < CUTOFF) continue;
+    // Exempt non-behavioural task types (infra/tooling/docs/process).
+    if (taskType && !GATED_TASK_TYPES.has(taskType)) continue;
+
+    if (status !== "done" && status !== "ready") continue;
+    if (hasProbe(id, text)) continue;
+
+    const entry = { id, file: f, status, created, taskType: taskType || "(unset)" };
+    if (status === "done") failures.push(entry);
+    else warnings.push(entry);
+  }
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ scope, failures, warnings }, null, 2));
+  } else {
+    log(`check-issue-spec-coverage (#2093): ${scope}; cutoff created>=${CUTOFF}.`);
+    for (const w of warnings) {
+      log(`  ⚠ WARNING  #${w.id} [${w.status}] has no probe/test reference (created ${w.created}).`);
+    }
+    for (const e of failures) {
+      log(`  ✖ FAIL     #${e.id} flipped to done with NO probe/test reference (created ${e.created}).`);
+    }
+    if (failures.length) {
+      log(
+        `\nAdd a permanent repro before flipping to done: a tests/issue-${failures[0].id}.test.ts ` +
+          `(or cite a tests/…test… / test262/… path in the issue body). See #2093.`,
+      );
+    } else {
+      log(`  ✓ all gated done-flips carry a probe/test reference.`);
+    }
+  }
+
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+main();

--- a/tests/issue-2093.test.ts
+++ b/tests/issue-2093.test.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(fileURLToPath(import.meta.url), "..", "..", "scripts", "check-issue-spec-coverage.mjs");
+
+function issueFile(fm: Record<string, string>, body = "body"): string {
+  const lines = Object.entries(fm).map(([k, v]) => (k === "title" ? `${k}: "${v}"` : `${k}: ${v}`));
+  return `---\n${lines.join("\n")}\n---\n\n${body}\n`;
+}
+
+interface RunResult {
+  code: number;
+  json: { scope: string; failures: any[]; warnings: any[] };
+}
+
+describe("#2093 issue→probe coverage gate", () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  // Build a fixture repo and run the gate in --all mode (diff-independent).
+  function run(issues: Record<string, string>[], tests: string[] = []): RunResult {
+    dir = mkdtempSync(join(tmpdir(), "issue-2093-"));
+    const issuesDir = join(dir, "plan", "issues");
+    const testsDir = join(dir, "tests");
+    mkdirSync(issuesDir, { recursive: true });
+    mkdirSync(testsDir, { recursive: true });
+    for (const fm of issues) {
+      writeFileSync(join(issuesDir, `${fm.id}-slug.md`), issueFile(fm));
+    }
+    for (const t of tests) writeFileSync(join(testsDir, t), "test\n");
+
+    let code = 0;
+    let stdout = "";
+    try {
+      stdout = execFileSync("node", [SCRIPT, "--all", "--json"], {
+        encoding: "utf8",
+        env: { ...process.env, REPO_ROOT: dir },
+      });
+    } catch (e: any) {
+      code = e.status ?? 1;
+      stdout = e.stdout ?? "";
+    }
+    return { code, json: JSON.parse(stdout) };
+  }
+
+  it("HARD FAILs a post-cutoff bug flipped to done with no probe", () => {
+    const r = run([{ id: "3001", title: "bug", status: "done", created: "2026-06-16", task_type: "bug" }]);
+    expect(r.code).toBe(1);
+    expect(r.json.failures.map((f) => f.id)).toContain("3001");
+  });
+
+  it("passes a done bug that has a tests/issue-<id>.test.ts file", () => {
+    const r = run(
+      [{ id: "3002", title: "bug", status: "done", created: "2026-06-16", task_type: "bug" }],
+      ["issue-3002.test.ts"],
+    );
+    expect(r.code).toBe(0);
+    expect(r.json.failures).toEqual([]);
+  });
+
+  it("passes a done issue whose body cites a test262 repro path", () => {
+    dir = mkdtempSync(join(tmpdir(), "issue-2093-"));
+    const issuesDir = join(dir, "plan", "issues");
+    mkdirSync(issuesDir, { recursive: true });
+    writeFileSync(
+      join(issuesDir, "3006-conf.md"),
+      issueFile(
+        { id: "3006", title: "conf", status: "done", created: "2026-06-16", task_type: "conformance" },
+        "Repro: test262/test/built-ins/Foo/bar.js",
+      ),
+    );
+    let code = 0;
+    let stdout = "";
+    try {
+      stdout = execFileSync("node", [SCRIPT, "--all", "--json"], {
+        encoding: "utf8",
+        env: { ...process.env, REPO_ROOT: dir },
+      });
+    } catch (e: any) {
+      code = e.status ?? 1;
+      stdout = e.stdout ?? "";
+    }
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).failures).toEqual([]);
+  });
+
+  it("grandfathers pre-cutoff issues (no fail, no warn)", () => {
+    const r = run([{ id: "3003", title: "old", status: "done", created: "2026-06-01", task_type: "bug" }]);
+    expect(r.code).toBe(0);
+    expect(r.json.failures).toEqual([]);
+    expect(r.json.warnings).toEqual([]);
+  });
+
+  it("WARNs (does not fail) a ready issue with no probe", () => {
+    const r = run([{ id: "3004", title: "ready", status: "ready", created: "2026-06-16", task_type: "bug" }]);
+    expect(r.code).toBe(0);
+    expect(r.json.warnings.map((w) => w.id)).toContain("3004");
+    expect(r.json.failures).toEqual([]);
+  });
+
+  it("exempts non-behavioural task types (infra) even when done without a probe", () => {
+    const r = run([{ id: "3005", title: "infra", status: "done", created: "2026-06-16", task_type: "infrastructure" }]);
+    expect(r.code).toBe(0);
+    expect(r.json.failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## #2093 — nothing forces a repro into the permanent suite

The June 2026 fix wave added `tests/issue-NNNN.test.ts` files **by convention
only** — nothing made a bugfix issue carry its repro into a permanent test, so
the next sweep's bugs would again ship with no armor.

### What this does
- **`scripts/check-issue-spec-coverage.mjs`** — diffs the issue files CHANGED in
  the PR (vs `origin/main`, fallback `HEAD^`); for those created on/after the
  cutoff (`2026-06-15`):
  - `status: done` with **no** probe/test reference → **HARD FAIL** (exit 1)
  - `status: ready` with no probe/test reference → **WARNING** only
  A probe reference = a `tests/issue-<id>.test.ts` file on disk **or** a cited
  `tests/…test…(.ts|.mjs|.js)` / `test262/…` path in the issue body.
  Non-behavioural `task_type`s (infrastructure/tooling/docs/process) are exempt.
  Skips cleanly when no diff base resolves (never blocks a build it can't reason
  about); `--all` scans every issue.
- **`package.json`** — `check:issue-spec-coverage` script.
- **`ci.yml` `quality` job** — new "Issue→probe coverage gate (#2093)" step
  (fetches the base ref, `ISSUE_COVERAGE_BASE=origin/main`).

The cutoff keeps the gate off the pre-existing backlog — no retroactive noise.
(This issue itself is pre-cutoff + infra, so its own done-flip is exempt.)

### Acceptance criteria
- [x] Gate live in `quality`; a done-flip without a test reference fails CI
- [x] Pre-cutoff issues unaffected (created < 2026-06-15 skipped)

### Tests
`tests/issue-2093.test.ts` — 6 cases (done-without-probe FAIL; done-with
`tests/issue-<id>.test.ts` pass; done-with-test262-body-cite pass; pre-cutoff
grandfathered; ready→WARNING-not-fail; infra task_type exempt). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)