### PR TITLE
feat(async): flip ASYNC_CPS_ENABLED on via per-function asyncFnNeedsCps (#1796)

### DIFF
--- a/plan/issues/1796-async-cps-sync-model-migration.md
+++ b/plan/issues/1796-async-cps-sync-model-migration.md
@@ -1,7 +1,9 @@
 ---
 id: 1796
 title: "Migrate synchronous-async contract to CPS Promise model (flip ASYNC_CPS_ENABLED)"
-status: ready
+status: done
+assignee: ttraenkler/sen-b
+completed: 2026-06-16
 created: 2026-06-03
 priority: top
 feasibility: hard
@@ -10,7 +12,7 @@ task_type: feature
 area: codegen
 language_feature: async, promises
 goal: spec-completeness
-sprint: 62
+sprint: 63
 related: [1042, 1326, 1373, 1373b]
 note: "2026-06-15: elevated to TOP priority by stakeholder (Proxy/Promise/async-to-100% epic). Host-mode Promise/async completion linchpin. Needs architect spec + senior-dev; sequenced after #1936 census, gated on #1373b CPS lowering."
 ---
@@ -156,3 +158,75 @@ net delta ≥ 0 (criterion 3). Run `/analyze-regression` on async buckets.
 ### Spec citations
 Await §27.7.5.3/§27.7.5.1; AsyncFunctionStart/rejection §27.7.5.2/§27.7.5.4;
 microtask FIFO PerformPromiseThen §27.2.5.4.1, Jobs §9.5.
+
+---
+
+## Implementation (sen-b, 2026-06-16) — gate flipped ON
+
+Branch `issue-1796-async-cps-flip` off upstream/main `319d43460`. PR routes the
+flip through the #1936 census predicate exactly as the plan above specified.
+
+### What landed
+1. **`ASYNC_CPS_ENABLED = true`** (`src/codegen/async-cps.ts`). The
+   synchronous-consumption regression that kept it off is resolved structurally
+   by **`asyncFnNeedsCps`**: an async fn is CPS-lowered (returns a real Promise)
+   ONLY when it *genuinely suspends* — at least one await operand is not
+   statically resolved. Fully await-elidable bodies
+   (`return await Promise.resolve(42)`) stay on the legacy synchronous path and
+   keep returning the unwrapped value, so the `asyncFn() as any as number`
+   "compile away" idiom (#1313/#1727) is preserved for those.
+2. **Both activation gates now consult `asyncFnNeedsCps`** — the function-body
+   hook (`function-body.ts:~1117`) and the `collectAsyncCpsImports` prepass
+   (`declarations.ts:~652`). Keeping them identical preserves the stable-funcMap
+   pre-registration that removes the #1384 late-import-shift hazard.
+3. **Promise-combinator awaits excluded from CPS** (`awaitedExprIsPromiseCombinator`
+   in async-cps.ts). `await Promise.all/race/any/allSettled(...)` already yields
+   a real Promise, so the legacy `await`-identity path produces a correct result
+   Promise with no CPS benefit; routing them through CPS would also surface the
+   host-`declare`-class-method argument-marshaling gap that **#2028** owns
+   (`Promise.all(src.getPromises())`). This keeps those on the legacy path.
+
+### Root-cause finding — the "design wall" was the per-call-site contract
+The blocker recorded across #1042's notes was: the gate is per-definition but
+the consumption contract is per-call-site, so a global flip cannot serve both a
+`value` consumer (wants unwrapped T) and a `thenable` consumer (wants a Promise)
+of the same fn. The resolution is that `asyncFnNeedsCps` makes the *flip itself*
+per-function and conditioned on genuine suspension: a fn that truly suspends
+*cannot* synchronously produce its value, so a `value`-consumer of it was already
+semantically broken under the legacy fakery (the cast yielded a value only
+because the runtime had nothing to suspend on). Those few tests are migrated to
+the Promise model (`await exports.main()`); everything that stays synchronous
+(await-elidable) is untouched.
+
+### Test migration (corpus → Promise model, plan criterion 2)
+Migrated the cases that consumed a genuinely-suspending async fn as a raw value
+to `await … resolves`:
+- `tests/equivalence/async-function.test.ts` — "await … identity (pass-through)"
+- `tests/equivalence/promise-chains.test.ts` — "await … passes through value",
+  "nested async calls"
+- `tests/async-await.test.ts` — "await on an internal async value"
+- `tests/async-census.test.ts` — gate-on assertions + true/false shape coverage
+- `tests/issue-1042.test.ts` — gate-on assertion; the 8 Slice-2A CPS
+  resolved-value cases (previously `skipIf` skipped) now run and pass.
+
+### Regression posture (verified locally)
+- Full async suite green except for failures that **pre-exist on upstream/main**
+  (verified by running the same files on the `/workspace` main checkout):
+  `tests/promise-combinators.test.ts` ×2 (host `declare`-class method marshaling,
+  #2028 — fails identically with the gate off) and
+  `tests/symbol-async-iterator.test.ts` ×2 (for-await-of, pre-existing). The
+  stale duplicate root files `tests/async-function.test.ts` /
+  `tests/for-await-of.test.ts` fail to load `./helpers.js` on main too (broken
+  import path, not async-related).
+- `tests/equivalence/` full directory: see PR CI (run locally pre-push).
+- Net new regressions from this PR: **0**.
+
+### Deferred / follow-up
+- Multi-await sequencing, awaits in branches/loops, try-across-await (#1373c),
+  async arrows/methods, standalone/WASI CPS — all remain on the legacy path via
+  `splitBodyAtAwait → null` (plan step 6). They are not regressed; they are
+  simply not yet CPS-lowered.
+- **#2028** (host `declare`-class-method marshaling) unblocks the
+  `await Promise.combinator(hostMethod())` shape; once it lands, drop the
+  `awaitedExprIsPromiseCombinator` exclusion so those combinators can CPS-lower
+  too (and re-evaluate the 2 pre-existing combinator test failures).

--- a/plan/issues/2028-promise-executor-resolve-reject-trap.md
+++ b/plan/issues/2028-promise-executor-resolve-reject-trap.md
@@ -180,3 +180,19 @@ unrelated to the closure-call `struct.get` trap the spec targeted.
   fresh `## Implementation Plan` against current main before re-dispatch.
 - Acceptance criteria (resolve "ok" / reject reason / resolve-twice ignored)
   remain UNMET; left at `ready` with this updated analysis.
+
+### Blocks dropping the #1796 combinator exclusion (sen-b, 2026-06-16)
+
+#1796 (flip `ASYNC_CPS_ENABLED` on) shipped with `await Promise.all/race/any/allSettled(...)`
+**excluded from CPS** (`awaitedExprIsPromiseCombinator` in `async-cps.ts`) because
+routing those through the CPS state machine surfaces a host-method
+argument-marshaling gap: `await Promise.all(src.getPromises())` mis-marshals the
+`declare`-class method `getPromises()` (it compiles to `__get_undefined`, so
+`Promise.all` receives `undefined` → "undefined is not iterable"). The same
+defect already fails `tests/promise-combinators.test.ts` ×2 on main today
+(verified gate-off), independent of #1796 — so these are #2028's failures, not a
+#1796 regression. **Once #2028 lands, drop the `awaitedExprIsPromiseCombinator`
+exclusion** so combinator awaits CPS-lower too, and the 2 combinator tests should
+go green. This is the concrete consumer that re-spec should keep in scope:
+host-`declare`-class-method values flowing as arguments into a wasm-side
+combinator/host call, not only the executor `resolve`/`reject` callable-param case.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -40,24 +40,24 @@ import { isPromiseType } from "../checker/type-mapper.js";
  * Master gate for the AST-side async CPS lowering.
  *
  * Slice 2A (#1042) built the linear single-tail-await state machine and made it
- * *correct when it runs* (verified end-to-end in `tests/issue-1042.test.ts` with
- * the gate forced on locally): the three canonical shapes resolve to the right
- * value through `Promise_resolve` → `Promise_then2` → continuation, captures and
- * the `return await` identity tail are handled, and the late-import shift hazard
- * is removed by the `collectAsyncCpsImports` prepass.
+ * *correct when it runs*: the canonical shapes resolve to the right value
+ * through `Promise_resolve` → `Promise_then2` → continuation, captures and the
+ * `return await` identity tail are handled, and the late-import shift hazard is
+ * removed by the `collectAsyncCpsImports` prepass.
  *
- * It stays **OFF** because flipping it globally regresses the *synchronous
- * consumption* contract: a single-await async fn consumed as a raw value
- * (`asyncFn() as any as number`, the #1313/#1727 "compile away" pattern) relies
- * on the legacy path returning the unwrapped value synchronously. With CPS on,
- * that fn returns a real Promise and the cast yields NaN — see the 3 regressed
- * `tests/equivalence/{async-function,promise-chains}.test.ts` cases. The gate is
- * per-definition but the contract is per-call-site, so a global flip cannot
- * preserve both. Turning CPS on for real needs the synchronous-consumption call
- * sites taught to drive the Promise (architect-level; risk #1/#6 in the spec).
- * See the "Slice 2A — gate-flip regression" finding in the #1042 issue file.
+ * Flipped **ON** in #1796. The synchronous-consumption regression that kept it
+ * off is resolved by the per-function {@link asyncFnNeedsCps} predicate (#1936):
+ * an async fn is CPS-lowered (returns a real Promise) ONLY when it *genuinely
+ * suspends* — at least one await operand is not statically resolved. Fully
+ * await-elidable bodies (`return await Promise.resolve(42)`, `await 41; ...`)
+ * stay on the legacy synchronous path and keep returning the unwrapped value, so
+ * the `asyncFn() as any as number` "compile away" idiom (#1313/#1727) is
+ * preserved for those. Functions that truly suspend now return a real Promise;
+ * call sites that consume such a result as a raw value cannot be served
+ * synchronously by construction and were already semantically broken under the
+ * legacy fakery — those test cases are migrated to the Promise model in #1796.
  */
-export const ASYNC_CPS_ENABLED = false;
+export const ASYNC_CPS_ENABLED = true;
 
 /**
  * Result of analysing an async function body for the CPS transform.
@@ -235,6 +235,38 @@ export function awaitIsStaticallyResolved(operand: ts.Expression): boolean {
   return false;
 }
 
+/** Promise static combinators whose call result is already a real Promise. */
+const PROMISE_COMBINATOR_NAMES = new Set(["all", "race", "any", "allSettled"]);
+
+/**
+ * Is `operand` a `Promise.<combinator>(...)` call (`Promise.all`, `Promise.race`,
+ * `Promise.any`, `Promise.allSettled`)? Such an operand is *already* a real
+ * Promise, so `await` over it gains nothing from the CPS state machine: the
+ * legacy path (`await`-is-identity over a combinator that returns a real
+ * Promise) already produces a correct result Promise. Keeping these on the
+ * legacy path also sidesteps the host `declare`-class-method argument marshaling
+ * gap (e.g. `Promise.all(src.getPromises())`) that #2028 owns — the CPS awaited
+ * expression would otherwise mis-marshal the host-method argument. (#1796)
+ */
+function awaitedExprIsPromiseCombinator(operand: ts.Expression): boolean {
+  let expr: ts.Expression = operand;
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isTypeAssertionExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = expr.expression;
+  }
+  return (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    ts.isIdentifier(expr.expression.expression) &&
+    expr.expression.expression.text === "Promise" &&
+    PROMISE_COMBINATOR_NAMES.has(expr.expression.name.text)
+  );
+}
+
 /**
  * The per-function CPS decision (#1936) — replaces the global
  * {@link ASYNC_CPS_ENABLED} kill-switch with a per-function predicate. Returns
@@ -247,18 +279,25 @@ export function awaitIsStaticallyResolved(operand: ts.Expression): boolean {
  *      a fulfilled Promise), and
  *   3. {@link splitBodyAtAwait} accepts the body shape (single top-level await in
  *      a canonical position; richer control flow stays on the legacy path with a
- *      `cps-unsupported-shape` census bucket).
+ *      `cps-unsupported-shape` census bucket), and
+ *   4. the single awaited operand is not a `Promise.<combinator>(...)` call —
+ *      those already return a real Promise that the legacy `await`-identity path
+ *      resolves correctly, and routing them through CPS regresses host-method
+ *      argument marshaling pending #2028 (see {@link awaitedExprIsPromiseCombinator}).
  *
  * `ASYNC_CPS_ENABLED` is retained as a transitional master kill-switch routed
- * through this predicate so the global flip stays inert until #1796; when it is
- * `false` the predicate always returns `false` (current shipped behaviour).
+ * through this predicate; when it is `false` the predicate always returns
+ * `false` (the pre-#1796 shipped behaviour).
  */
 export function asyncFnNeedsCps(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
   if (plan.awaitPoints.length === 0) return false;
   const anyRealSuspension = plan.awaitPoints.some((a) => plan.awaitedStaticallyResolved.get(a) !== true);
   if (!anyRealSuspension) return false; // fully await-elidable → sync + resolved Promise
-  return splitBodyAtAwait(fn, plan) !== null;
+  const split = splitBodyAtAwait(fn, plan);
+  if (split === null) return false;
+  if (awaitedExprIsPromiseCombinator(split.awaitedExpr)) return false; // already a real Promise
+  return true;
 }
 
 /**

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -19,7 +19,7 @@ import {
 import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction } from "../ir/types.js";
 import { collectShapes } from "../shape-inference.js";
 import { ensureWrapperTypes } from "./any-helpers.js";
-import { ASYNC_CPS_ENABLED, analyzeAsyncBody, splitBodyAtAwait } from "./async-cps.js";
+import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps } from "./async-cps.js";
 import { collectClassDeclaration, compileClassBodies } from "./class-bodies.js";
 import { collectFunctionOwnLocals, collectReferencedIdentifiers } from "./closures.js";
 import { reportError } from "./context/errors.js";
@@ -659,7 +659,12 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
     hasAsyncModifier(node)
   ) {
     const plan = analyzeAsyncBody(ctx, node);
-    if (plan.awaitPoints.length === 1 && !plan.hasTryAcrossAwait && splitBodyAtAwait(node, plan) !== null) {
+    // Mirror the function-body.ts activation gate EXACTLY (#1936
+    // `asyncFnNeedsCps`): genuine suspension + single canonical tail-await
+    // shape. Pre-registering imports for a fn that won't actually be CPS-lowered
+    // would add unused imports (harmless) but a mismatch the other way would
+    // re-introduce the late-import shift hazard, so keep the predicates identical.
+    if (asyncFnNeedsCps(node, plan)) {
       state.asyncCpsFound = true;
     }
   }

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -51,7 +51,7 @@ import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-bu
 import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
 import { compileNativeGeneratorFunction } from "./generators-native.js";
-import { ASYNC_CPS_ENABLED, analyzeAsyncBody, splitBodyAtAwait, emitAsyncStateMachine } from "./async-cps.js";
+import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps, emitAsyncStateMachine } from "./async-cps.js";
 import {
   functionHasLinearU8Params,
   getLinearU8ParamIndicesForDeclaration,
@@ -1107,20 +1107,21 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       // to be available before their textual position in the enclosing scope.
       hoistFunctionDeclarations(ctx, fctx, bodyStatements);
 
-      // (#1042) Async/await CPS state-machine activation hook. Gated behind
-      // ASYNC_CPS_ENABLED (off by default → byte-identical legacy codegen).
-      // Eligible only for a JS-host async function whose body matches a single
-      // tail-await canonical shape with no try-across-await / nested await. On
-      // a match we rewrite the result type to externref (the fn returns a
-      // Promise object), drive emitAsyncStateMachine, and skip the normal loop.
+      // (#1042/#1796) Async/await CPS state-machine activation hook. Gated by
+      // the per-function `asyncFnNeedsCps` predicate (#1936): a JS-host async
+      // function is CPS-lowered ONLY when it *genuinely suspends* — at least one
+      // await operand is not statically resolved AND the body matches a single
+      // tail-await canonical shape (no try-across-await / nested await). Fully
+      // await-elidable bodies (`return await Promise.resolve(42)`) fall through
+      // to the legacy synchronous path and keep returning the unwrapped value,
+      // preserving the `asyncFn() as any as number` "compile away" idiom
+      // (#1313/#1727). On a match we rewrite the result type to externref (the
+      // fn now returns a real Promise object), drive emitAsyncStateMachine, and
+      // skip the normal statement loop.
       let asyncCpsHandled = false;
       if (ASYNC_CPS_ENABLED && isAsync && !ctx.wasi && !ctx.standalone && ts.isFunctionDeclaration(decl) && decl.body) {
         const asyncPlan = analyzeAsyncBody(ctx, decl);
-        if (
-          asyncPlan.awaitPoints.length === 1 &&
-          !asyncPlan.hasTryAcrossAwait &&
-          splitBodyAtAwait(decl, asyncPlan) !== null
-        ) {
+        if (asyncFnNeedsCps(decl, asyncPlan)) {
           // The async function returns a Promise object (externref), not the
           // unwrapped value. Rewrite the registered signature's result + fctx.
           rewriteFuncResultType(ctx, func, { kind: "externref" });

--- a/tests/async-await.test.ts
+++ b/tests/async-await.test.ts
@@ -38,7 +38,10 @@ describe("async/await support", () => {
     expect(exports.getNum()).toBe(42);
   });
 
-  it("await on an internal async value", async () => {
+  it("await on an internal async value (#1796 — genuine suspension returns a real Promise)", async () => {
+    // `getValue` awaits `fetchValue()` (a non-static async call) so it
+    // genuinely suspends and is CPS-lowered to return a real Promise — no
+    // longer the legacy synchronous fakery. Await it through a microtask tick.
     const exports = await instantiate(`
       async function fetchValue(): Promise<number> { return 99; }
       export async function getValue(): Promise<number> {
@@ -46,7 +49,7 @@ describe("async/await support", () => {
         return val;
       }
     `);
-    expect(exports.getValue()).toBe(99);
+    await expect(exports.getValue()).resolves.toBe(99);
   });
 
   it("async function with multiple sequential awaits", async () => {

--- a/tests/async-census.test.ts
+++ b/tests/async-census.test.ts
@@ -126,15 +126,24 @@ describe("#1936 — awaitIsStaticallyResolved", () => {
 });
 
 describe("#1936 — asyncFnNeedsCps (gated through ASYNC_CPS_ENABLED)", () => {
-  it("the master gate stays OFF until #1796", () => {
-    expect(ASYNC_CPS_ENABLED).toBe(false);
+  it("the master gate is ON (#1796 flipped it)", () => {
+    expect(ASYNC_CPS_ENABLED).toBe(true);
   });
 
-  it("returns false for every shape while the gate is off (current shipped behaviour)", () => {
+  it("returns true for a genuinely-suspending single-tail-await body, false otherwise (#1796)", () => {
+    // `const x = await g(); return x` — `g()` is a non-static call ⇒ real
+    // suspension ⇒ canonical single-tail-await shape ⇒ CPS-lowered.
     const a = firstFn(`async function f() { const x = await g(); return x; }`);
-    expect(asyncFnNeedsCps(a.fn, a.plan)).toBe(false);
+    expect(asyncFnNeedsCps(a.fn, a.plan)).toBe(true);
+    // No await ⇒ await-elidable / sync ⇒ legacy path.
     const b = firstFn(`async function f() { return 1; }`);
     expect(asyncFnNeedsCps(b.fn, b.plan)).toBe(false);
+    // Await present but fully statically resolved ⇒ await-elidable ⇒ legacy path.
+    const c = firstFn(`async function f() { const x = await 1; return x; }`);
+    expect(asyncFnNeedsCps(c.fn, c.plan)).toBe(false);
+    // Two awaits ⇒ outside the single-tail-await shape ⇒ legacy path.
+    const d = firstFn(`async function f() { const x = await g(); const y = await h(); return x + y; }`);
+    expect(asyncFnNeedsCps(d.fn, d.plan)).toBe(false);
   });
 
   it("populates awaitedStaticallyResolved per await point", () => {

--- a/tests/equivalence/async-function.test.ts
+++ b/tests/equivalence/async-function.test.ts
@@ -27,7 +27,13 @@ describe("Async function support (synchronous compilation)", () => {
     expect(exports.main()).toBe(42);
   });
 
-  it("await expression is identity (pass-through)", async () => {
+  it("await of a genuinely-suspending call resolves through a real Promise (#1796 CPS)", async () => {
+    // `test` awaits another async call (`getValue()`), which is NOT statically
+    // resolved — so `asyncFnNeedsCps` is true and `test` is CPS-lowered to
+    // return a REAL Promise (no longer the legacy synchronous fakery). `main`
+    // is async too and returns that Promise; the test awaits it through a real
+    // microtask tick. (Was "await expression is identity (pass-through)",
+    // asserting the now-removed sync-consumption contract.)
     const src = `
       async function getValue(): Promise<number> {
         return 100;
@@ -36,12 +42,12 @@ describe("Async function support (synchronous compilation)", () => {
         const v = await getValue();
         return v;
       }
-      export function main(): number {
-        return test() as any as number;
+      export async function main(): Promise<number> {
+        return await test();
       }
     `;
     const exports = await compileToWasm(src);
-    expect(exports.main()).toBe(100);
+    await expect(exports.main()).resolves.toBe(100);
   });
 
   it("async function with computation", async () => {

--- a/tests/equivalence/promise-chains.test.ts
+++ b/tests/equivalence/promise-chains.test.ts
@@ -39,19 +39,23 @@ describe("Promise / async equivalence", () => {
     expect(wasm.main()).toBe(42);
   });
 
-  it("await expression passes through value", async () => {
+  it("await of a suspending call resolves through a real Promise (#1796 CPS)", async () => {
+    // `test` awaits `getVal()` (a non-static async call) so it genuinely
+    // suspends and is CPS-lowered to return a real Promise. `main` awaits it;
+    // the result resolves through a microtask tick. (Was "await expression
+    // passes through value" under the legacy synchronous-async fakery.)
     const src = `
       async function getVal(): Promise<number> { return 100; }
       async function test(): Promise<number> {
         const v = await getVal();
         return v;
       }
-      export function main(): number {
-        return test() as any as number;
+      export async function main(): Promise<number> {
+        return await test();
       }
     `;
     const wasm = await compileToWasm(src);
-    expect(wasm.main()).toBe(100);
+    await expect(wasm.main()).resolves.toBe(100);
   });
 
   it("multiple sequential awaits", async () => {
@@ -101,19 +105,24 @@ describe("Promise / async equivalence", () => {
     expect(wasm.main()).toBe(42);
   });
 
-  it("nested async calls", async () => {
+  it("nested async calls resolve through a real Promise (#1796 CPS)", async () => {
+    // `outer` awaits `inner(x)` (a non-static async call) so it genuinely
+    // suspends, then computes `squared + 1` in its continuation — exercising
+    // a captured prefix local across the suspension. CPS-lowered to a real
+    // Promise; awaited through a microtask tick. (Was "nested async calls"
+    // under the legacy synchronous-async fakery.)
     const src = `
       async function inner(x: number): Promise<number> { return x * x; }
       async function outer(x: number): Promise<number> {
         const squared = await inner(x);
         return squared + 1;
       }
-      export function main(): number {
-        return outer(5) as any as number;
+      export async function main(): Promise<number> {
+        return await outer(5);
       }
     `;
     const wasm = await compileToWasm(src);
-    expect(wasm.main()).toBe(26);
+    await expect(wasm.main()).resolves.toBe(26);
   });
 
   it("async function with loop", async () => {

--- a/tests/issue-1042.test.ts
+++ b/tests/issue-1042.test.ts
@@ -22,8 +22,8 @@ function analyze(src: string): AsyncCpsPlan {
 }
 
 describe("#1042 PR1 — async CPS analysis surface", () => {
-  it("the gate is OFF (synchronous-consumption contract regresses on a global flip — see async-cps.ts)", () => {
-    expect(ASYNC_CPS_ENABLED).toBe(false);
+  it("the gate is ON (#1796 — per-function asyncFnNeedsCps resolves the sync-consumption contract)", () => {
+    expect(ASYNC_CPS_ENABLED).toBe(true);
   });
 
   it("no await ⇒ zero await points (function-body hook keeps legacy path)", () => {
@@ -138,14 +138,13 @@ describe("#1042 PR1 — async CPS analysis surface", () => {
 // ---------------------------------------------------------------------------
 // Slice 2A — end-to-end resolved-value tests.
 //
-// These validate the state machine when ASYNC_CPS_ENABLED is on: a JS-host
-// async fn matching one of the three canonical single-tail-await shapes returns
-// a real Promise that resolves to the right value through
-// `Promise_resolve` → `Promise_then2` → continuation. They are gated on the
-// flag because it ships OFF (a global flip regresses the synchronous-consumption
-// contract — see async-cps.ts and the #1042 issue file); flip the flag locally
-// to exercise them. They pinned the machinery as correct-when-run during Slice
-// 2A development.
+// These validate the state machine with ASYNC_CPS_ENABLED on (#1796): a JS-host
+// async fn that genuinely suspends and matches one of the canonical
+// single-tail-await shapes returns a real Promise that resolves to the right
+// value through `Promise_resolve` → `Promise_then2` → continuation. The
+// `skipIf` is retained as a guard so the block self-disables if the gate is
+// ever turned back off; with the gate on (the shipped state since #1796) the
+// block always runs.
 //
 // Awaited sources are INTERNAL compiled async functions and literals — these
 // marshal a real number across the await boundary. (Host `declare function` /


### PR DESCRIPTION
## Summary

Turns ON the async/await CPS state-machine lowering built in #1042 (which has shipped inert behind `ASYNC_CPS_ENABLED = false`). The flip is routed through the #1936 census predicate `asyncFnNeedsCps`, which resolves the per-call-site consumption-contract conflict that previously kept the gate off.

A JS-host `async function` is now CPS-lowered (returns a **real Promise**) only when it **genuinely suspends** — at least one await operand is not statically resolved — and matches the canonical single-tail-await shape. Fully await-elidable bodies (`return await Promise.resolve(42)`) stay on the legacy synchronous path and keep returning the unwrapped value, so the `asyncFn() as any as number` "compile away" idiom (#1313/#1727) is preserved.

## Root cause / design wall resolution

The blocker recorded in #1042/#1796 was that the gate is *per-definition* but the consumption contract is *per-call-site*: a global flip could not serve both a `value` consumer (wants unwrapped T) and a `thenable` consumer (wants a Promise) of the same fn. `asyncFnNeedsCps` makes the flip per-function and conditioned on genuine suspension — a fn that truly suspends cannot synchronously produce its value, so a `value`-consumer of it was already semantically broken under the legacy fakery. Those few tests are migrated to the Promise model; everything await-elidable is untouched.

## Changes

- `ASYNC_CPS_ENABLED = true` (`src/codegen/async-cps.ts`).
- Both activation gates — function-body hook + `collectAsyncCpsImports` prepass — now consult `asyncFnNeedsCps` (kept identical so the stable-funcMap pre-registration that removes the #1384 late-import-shift hazard stays correct).
- Exclude `await Promise.all/race/any/allSettled(...)` from CPS: they already return a real Promise (legacy `await`-identity is correct), and routing them through CPS would surface the host `declare`-class-method argument-marshaling gap owned by **#2028**.
- Test corpus migrated to the Promise model where a genuinely-suspending async fn was consumed as a raw value; the 8 previously-skipped Slice-2A CPS resolved-value cases in `tests/issue-1042.test.ts` now run and pass.

## Validation

- `tsc` clean; IR fallback budget unchanged; full `tests/equivalence/` green (exit 0).
- **Net new regressions: 0.** Remaining async-suite failures (`promise-combinators` x2 — host method marshaling #2028; `symbol-async-iterator` x2; stale duplicate root `async-function`/`for-await-of` helper-import errors) all **pre-exist on upstream/main**, verified identical with the gate off.

## Follow-ups

- Multi-await sequencing, awaits in branches/loops, try-across-await (#1373c), async arrows/methods, standalone/WASI CPS remain on the legacy path (not regressed; not yet CPS-lowered).
- Once #2028 lands, drop the `awaitedExprIsPromiseCombinator` exclusion so combinator awaits can CPS-lower too.

Closes #1796. Advances #1042 acceptance (criteria 1-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)