### PR TITLE
fix(#1943): enforce ratio/bucket regression thresholds in CI

### DIFF
--- a/.claude/skills/dev-self-merge.md
+++ b/.claude/skills/dev-self-merge.md
@@ -33,13 +33,13 @@ done
 
 After the run exits:
 
-| Outcome | Action |
-|---|---|
-| **All required checks green** | Proceed to Step 0 (or directly to Step 1 if the CI feed JSON is present) |
+| Outcome                                                    | Action                                                                                                                                    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **All required checks green**                              | Proceed to Step 0 (or directly to Step 1 if the CI feed JSON is present)                                                                  |
 | **Drift** (mergeable_state becomes `BEHIND` while waiting) | `git fetch origin && git merge origin/main` in the worktree, resolve conflicts with full PR context, `git push`, loop back to wait-for-CI |
-| **CI failure** (any required check `FAILURE`) | Diagnose with full PR context — the agent KNOWS what it changed. Fix locally, `git push`, loop back to wait-for-CI |
-| **Long wait** (>10 min) | Emit a `TaskUpdate` noting the unusual wait but keep waiting |
-| **Very long wait** (>20 min) | Escalate to tech lead |
+| **CI failure** (any required check `FAILURE`)              | Diagnose with full PR context — the agent KNOWS what it changed. Fix locally, `git push`, loop back to wait-for-CI                        |
+| **Long wait** (>10 min)                                    | Emit a `TaskUpdate` noting the unusual wait but keep waiting                                                                              |
+| **Very long wait** (>20 min)                               | Escalate to tech lead                                                                                                                     |
 
 The CI feed `pr-<N>.json` still drives the merge gate below — fetch it once
 CI completes:
@@ -86,6 +86,7 @@ git show origin/main:.claude/ci-status/pr-<N>.json
 
 If `test262_skipped: true` in the JSON, this was a test-only / docs-only PR
 (no `src/**` changes). Skip Steps 3–4 entirely:
+
 - `conclusion == "success"` → **MERGE** (go to Step 5)
 - `conclusion != "success"` → **ESCALATE — basic CI failed on a non-src PR.**
 
@@ -180,14 +181,25 @@ If `head_sha` in the JSON ≠ `git rev-parse HEAD` output:
 
 Stop.
 
+> **#1943 — CI now ENFORCES criteria 2 and 3 as a hard gate.** The
+> regression-gate job (`scripts/diff-test262.ts`) fails the required check
+> when the 10% ratio or 50-per-bucket limit is exceeded, not just when
+> `net_per_test < 0`. The thresholds are exported constants
+> (`REGRESSION_RATIO_LIMIT` / `REGRESSION_BUCKET_LIMIT` /
+> `REGRESSION_BUCKET_PATH_DEPTH` in `scripts/diff-test262.ts`) — this table
+> is the documentation twin of those constants; they are byte-identical by
+> construction. So a branch-protected PR can no longer merge on `net ≥ 0`
+> alone; this skill's job below reduces to interpreting/explaining ESCALATE
+> cases the gate surfaces.
+
 ## Step 3 — criteria (in order, stop at first failure)
 
-| # | Criterion | Failure output |
-|---|-----------|----------------|
-| 1 | `net_per_test > 0` | **ESCALATE — net_per_test is not positive (value: N). PR caused more regressions than improvements.** |
-| 2 | `R == 0 OR R / improvements < 0.10`, where `R = regressions_wasm_change ?? regressions_real ?? regressions` | **ESCALATE — regression ratio is N% (R/improvements), exceeds 10% threshold.** |
-| 3 | No bucket > 50 regressions (see Step 4) | **ESCALATE — bucket "\<path\>" has N regressions, exceeds 50-test limit.** |
-| 4 | All above pass | **MERGE** |
+| #   | Criterion                                                                                                   | Failure output                                                                                        |
+| --- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1   | `net_per_test > 0`                                                                                          | **ESCALATE — net_per_test is not positive (value: N). PR caused more regressions than improvements.** |
+| 2   | `R == 0 OR R / improvements < 0.10`, where `R = regressions_wasm_change ?? regressions_real ?? regressions` | **ESCALATE — regression ratio is N% (R/improvements), exceeds 10% threshold.**                        |
+| 3   | No bucket > 50 regressions (see Step 4)                                                                     | **ESCALATE — bucket "\<path\>" has N regressions, exceeds 50-test limit.**                            |
+| 4   | All above pass                                                                                              | **MERGE**                                                                                             |
 
 `R` (criterion 2) prefers `regressions_wasm_change` if the feed has it
 (post-#1222 CI). This filters out byte-identical-binary pass→fail flips,
@@ -262,7 +274,7 @@ gh api graphql -f query='{ repository(owner:"loopdive",name:"js2"){ mergeQueue(b
 ```
 
 > **Why GraphQL `enqueuePullRequest`, NOT `gh pr merge <N> --auto`.** `--auto` only
-> *arms* auto-merge on a check-state **transition** — it fires when a PENDING
+> _arms_ auto-merge on a check-state **transition** — it fires when a PENDING
 > required check flips green. By the time `/dev-self-merge` runs (Steps 1–4 only
 > proceed on a **complete, green** CI run) the PR is already `CLEAN`, so there is no
 > transition left to fire on and `--auto` **silently no-ops — the PR is never
@@ -273,6 +285,7 @@ gh api graphql -f query='{ repository(owner:"loopdive",name:"js2"){ mergeQueue(b
 > direct bypass is tech-lead-only.)
 
 Once enqueued, GitHub will:
+
 1. Place the PR on a temp branch (`gh-readonly-queue/main/pr-<N>-...`)
 2. Re-run the required checks (`cheap gate`, `merge shard reports`, `quality`) against that merged state via the `merge_group` event
 3. Fast-forward main if checks pass — usually within minutes of CI completing
@@ -288,6 +301,7 @@ open the PR at `in-review` and plan a later flip — that is exactly what orphan
 issues at `in-review` (see #1602/#1603/#1606).
 
 **Once queued, your job is done.** Do not wait for the actual merge. Proceed immediately:
+
 1. (Status already `done` in the merged PR — no separate flip needed.)
 2. `TaskUpdate taskId=<your-task> status=completed`
 3. Remove your worktree: `git worktree remove /workspace/.claude/worktrees/<branch>`
@@ -300,12 +314,13 @@ issues at `in-review` (see #1602/#1603/#1606).
    it here too keeps the checkout fresh between monitor passes.)
 5. `TaskList` → claim next unowned task (or message tech lead if empty)
 
-> If the queue *rejects* the PR (rare — see below), the `status: done` you set
+> If the queue _rejects_ the PR (rare — see below), the `status: done` you set
 > has not yet landed on main, so nothing is orphaned; re-evaluate and re-queue.
 
 ### If the queue rejects your PR
 
 GitHub will comment on the PR if the final queue checks fail (rare — would mean something flipped between your CI run and the queue's re-run, likely main moved). In that case:
+
 - The auto-refresh workflow may have already pushed a merge of main into your branch — fetch and review
 - Re-evaluate /dev-self-merge against the new CI run
 - If still good, re-queue with the GraphQL `enqueuePullRequest` mutation above (NOT `gh pr merge --auto` — see why in Step 5)
@@ -313,6 +328,7 @@ GitHub will comment on the PR if the final queue checks fail (rare — would mea
 ### Admin direct-merge — only when
 
 Use `gh pr merge <N> --merge --admin` (bypassing the queue) only when:
+
 - The change is workflow-only / CI-only and the queue ruleset checks don't apply
 - Tech lead explicitly authorizes a hotfix bypass
 - The queue itself is broken and needs unblocking
@@ -322,6 +338,7 @@ Set `GATE_BYPASS=1` if the local pre-commit hook blocks because `pr-<N>.json` is
 ## What ESCALATE means
 
 Post to tech lead via SendMessage with:
+
 - Which criterion failed
 - The exact values from the CI JSON
 - The PR number

--- a/plan/issues/1943-enforce-ratio-bucket-thresholds-ci.md
+++ b/plan/issues/1943-enforce-ratio-bucket-thresholds-ci.md
@@ -1,10 +1,12 @@
 ---
 id: 1943
 title: "Enforce the documented regression thresholds (10% ratio, 50-per-bucket) in CI — today the hard gate is only net ≥ 0"
-status: ready
+status: done
+completed: 2026-06-16
+assignee: ttraenkler/dev-a
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -60,3 +62,44 @@ path-bucket > 50 regressions. But the **enforced** CI gate
 
 Compiler quality review 2026-06. Related: #1668, #1897, dev-self-merge
 skill, #1942.
+
+## Resolution (2026-06-16, dev-a)
+
+Moved the two thresholds into `scripts/diff-test262.ts`'s exit logic as the
+single source of truth:
+
+- Exported constants `REGRESSION_RATIO_LIMIT = 0.1`,
+  `REGRESSION_BUCKET_LIMIT = 50`, `REGRESSION_BUCKET_PATH_DEPTH = 5`.
+- `bucketRegressions(files)` groups regressed files by the first 5 path
+  segments — byte-identical to the skill's `'/'.join(f.split('/')[:5])`.
+- `evaluateRegressionThresholds({improvements, regressionsWasmChange,
+  regressedFiles})` (pure, no I/O) returns failure reasons: ratio gate fires
+  when `R > 0 && R/improvements >= 0.10`; bucket gate when any bucket > 50.
+- The script's exit logic now fails (exit 1) on net < 0 **or** any threshold
+  failure, printing a `GATE FAIL: …` line per reason. Operates on the same
+  `noiseFiltered` set the net gate uses, so `compile_timeout` flaps and
+  byte-identical (`wasm_sha`-unchanged) flips are already excluded — no double
+  counting, flake handling unchanged (proposed-approach step 2).
+
+**CI wiring:** the required "check for test262 regressions" job
+(`test262-sharded.yml`) already maps `diff-test262.ts` exit 1 → `regressions=true`
+→ "Fail on regressions" step fails the check. So the new ratio/bucket gates
+are enforced by branch protection with no workflow change. (The separate
+catastrophic/standalone guards in "merge shard reports" parse the text count
+and are unaffected — they tolerate exit 1 by design and do their own
+thresholding.)
+
+**Module-import safety:** the bottom `main()` call is now guarded to run only
+when `diff-test262.ts/.js` is the invoked script (`process.argv[1]`), so the
+unit test can import the exported helpers without triggering the CLI.
+
+**Skill sync (step 3):** `.claude/skills/dev-self-merge.md` Step 3 now notes CI
+enforces criteria 2 & 3 and points at the exported constants as the single
+source; the criteria table is the documentation twin.
+
+**Tests:** `tests/issue-1943.test.ts` (7 cases) — ratio 50% fails, 60-in-one-
+bucket fails (with ratio under 10%), clean passes, borderline 9% passes,
+zero-improvements-with-regressions fails (∞ ratio), plus constant + bucket
+grouping checks. Also validated end-to-end against synthetic fixture JSONLs
+via the real CLI (ratio-50% → exit 1 despite net +5; 60-bucket → exit 1
+despite net +640; clean and 9% → exit 0).

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -16,6 +16,69 @@
 import { createReadStream, readFileSync } from "fs";
 import { createInterface } from "readline";
 
+// #1943 — single source of truth for the documented merge thresholds, so the
+// CI regression-gate ENFORCES the same numbers the dev-self-merge skill
+// documents (previously the hard gate was only `net_per_test >= 0`; the 10%
+// ratio and 50-per-bucket limits lived solely in skill text an agent could
+// skip). `.claude/skills/dev-self-merge.md` references these constants.
+//
+// - REGRESSION_RATIO_LIMIT: fail when regressions / improvements >= 10%.
+// - REGRESSION_BUCKET_LIMIT: fail when any single path bucket has > 50
+//   regressions.
+// - REGRESSION_BUCKET_PATH_DEPTH: a "bucket" is the first N path segments of a
+//   test file (e.g. `test/built-ins/Array/prototype/every`), matching the
+//   skill's `'/'.join(f.split('/')[:5])`.
+export const REGRESSION_RATIO_LIMIT = 0.1;
+export const REGRESSION_BUCKET_LIMIT = 50;
+export const REGRESSION_BUCKET_PATH_DEPTH = 5;
+
+/**
+ * Group regressed test files into path buckets (first
+ * `REGRESSION_BUCKET_PATH_DEPTH` segments) and return them sorted by count
+ * descending. Mirrors the dev-self-merge skill's bucket grouping exactly so
+ * the documented and enforced definitions stay byte-identical (#1943).
+ */
+export function bucketRegressions(files: string[]): { bucket: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const file of files) {
+    const bucket = file.split("/").slice(0, REGRESSION_BUCKET_PATH_DEPTH).join("/");
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([bucket, count]) => ({ bucket, count })).sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Evaluate the documented merge thresholds against the wasm-hash-filtered
+ * counts. Returns the list of human-readable failure reasons (empty ⇒ pass).
+ * Pure (no I/O) so the unit test can drive it directly with fixture data
+ * (#1943 acceptance criteria). The ratio gate only fires when there is at
+ * least one regression — a clean PR (R == 0) always passes regardless of how
+ * few improvements it carries.
+ */
+export function evaluateRegressionThresholds(opts: {
+  improvements: number;
+  regressionsWasmChange: number;
+  regressedFiles: string[];
+}): string[] {
+  const failures: string[] = [];
+  const { improvements, regressionsWasmChange, regressedFiles } = opts;
+  if (regressionsWasmChange > 0) {
+    const ratio = improvements > 0 ? regressionsWasmChange / improvements : Infinity;
+    if (ratio >= REGRESSION_RATIO_LIMIT) {
+      const pct = improvements > 0 ? (ratio * 100).toFixed(1) + "%" : "∞ (0 improvements)";
+      failures.push(
+        `regression ratio ${pct} (${regressionsWasmChange}/${improvements}) meets/exceeds the ${(REGRESSION_RATIO_LIMIT * 100).toFixed(0)}% limit`,
+      );
+    }
+  }
+  for (const { bucket, count } of bucketRegressions(regressedFiles)) {
+    if (count > REGRESSION_BUCKET_LIMIT) {
+      failures.push(`bucket "${bucket}" has ${count} regressions, exceeds the ${REGRESSION_BUCKET_LIMIT}-test limit`);
+    }
+  }
+  return failures;
+}
+
 interface TestResult {
   file: string;
   status: string;
@@ -427,7 +490,29 @@ async function run(
   // Compile_timeout flaps (timing noise) and wasm-identical flips are excluded via
   // regressionsWasmChange. Gate: improvements.length - regressionsWasmChange < 0.
   const netPerTest = improvements.length - regressionsWasmChange;
+  let gateFailed = false;
   if (netPerTest < 0) {
+    console.log(
+      `=== GATE FAIL: net_per_test ${netPerTest} < 0 (${improvements.length} improvements − ${regressionsWasmChange} regressions) ===`,
+    );
+    gateFailed = true;
+  }
+
+  // #1943 — enforce the documented ratio (10%) and per-bucket (50) thresholds
+  // that previously lived only in the dev-self-merge skill text. Same
+  // wasm-hash-filtered count the net gate uses (`noiseFiltered`), so
+  // compile_timeout flaps and byte-identical flips never trip these either.
+  const thresholdFailures = evaluateRegressionThresholds({
+    improvements: improvements.length,
+    regressionsWasmChange,
+    regressedFiles: noiseFiltered.map((r) => r.file),
+  });
+  for (const reason of thresholdFailures) {
+    console.log(`=== GATE FAIL: ${reason} ===`);
+    gateFailed = true;
+  }
+
+  if (gateFailed) {
     process.exit(1);
   }
 }
@@ -437,4 +522,10 @@ function truncate(s: string, maxLen: number): string {
   return s.slice(0, maxLen - 3) + "...";
 }
 
-main();
+// Only run the CLI when invoked directly (not when imported by the unit test
+// for the exported threshold helpers — #1943). `process.argv[1]` is the
+// executed script path under tsx/node.
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.endsWith("diff-test262.ts") || invokedPath.endsWith("diff-test262.js")) {
+  main();
+}

--- a/tests/issue-1943.test.ts
+++ b/tests/issue-1943.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  REGRESSION_RATIO_LIMIT,
+  REGRESSION_BUCKET_LIMIT,
+  REGRESSION_BUCKET_PATH_DEPTH,
+  bucketRegressions,
+  evaluateRegressionThresholds,
+} from "../scripts/diff-test262.js";
+
+// #1943 — the documented merge thresholds (10% regression ratio, 50-per-bucket)
+// must be ENFORCED by the regression gate, not just documented in the
+// dev-self-merge skill text. These unit tests pin the pure gate logic so the
+// constants and the bucket grouping stay byte-identical to the skill.
+describe("#1943 — regression threshold enforcement", () => {
+  it("exposes the documented constants", () => {
+    expect(REGRESSION_RATIO_LIMIT).toBe(0.1);
+    expect(REGRESSION_BUCKET_LIMIT).toBe(50);
+    expect(REGRESSION_BUCKET_PATH_DEPTH).toBe(5);
+  });
+
+  it("buckets regressions by the first 5 path segments (skill-identical)", () => {
+    const buckets = bucketRegressions([
+      "test/built-ins/Array/prototype/every/a.js",
+      "test/built-ins/Array/prototype/every/b.js",
+      "test/built-ins/Array/prototype/some/c.js",
+    ]);
+    expect(buckets[0]).toEqual({ bucket: "test/built-ins/Array/prototype/every", count: 2 });
+    expect(buckets.find((b) => b.bucket === "test/built-ins/Array/prototype/some")?.count).toBe(1);
+  });
+
+  it("FAILS a 10-improvement / 5-regression diff (ratio 50%)", () => {
+    const failures = evaluateRegressionThresholds({
+      improvements: 10,
+      regressionsWasmChange: 5,
+      regressedFiles: Array.from({ length: 5 }, (_, i) => `test/built-ins/Reg${i}/x/y/t.js`),
+    });
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((f) => f.includes("ratio") && f.includes("50.0%"))).toBe(true);
+  });
+
+  it("FAILS a 60-in-one-bucket diff even when the ratio is under 10%", () => {
+    const failures = evaluateRegressionThresholds({
+      improvements: 700, // 60/700 = 8.6% < 10% → ratio OK
+      regressionsWasmChange: 60,
+      regressedFiles: Array.from({ length: 60 }, (_, i) => `test/built-ins/Array/prototype/every/case${i}.js`),
+    });
+    expect(failures.some((f) => f.includes("bucket") && f.includes("every") && f.includes("60"))).toBe(true);
+    expect(failures.some((f) => f.includes("ratio"))).toBe(false);
+  });
+
+  it("PASSES a clean diff (no regressions, few improvements)", () => {
+    expect(evaluateRegressionThresholds({ improvements: 2, regressionsWasmChange: 0, regressedFiles: [] })).toEqual([]);
+  });
+
+  it("PASSES a borderline 9% ratio (under the 10% limit)", () => {
+    expect(
+      evaluateRegressionThresholds({
+        improvements: 100,
+        regressionsWasmChange: 9,
+        regressedFiles: Array.from({ length: 9 }, (_, i) => `test/reg${i}/x/y/z/t.js`),
+      }),
+    ).toEqual([]);
+  });
+
+  it("FAILS when regressions exist but there are zero improvements (∞ ratio)", () => {
+    const failures = evaluateRegressionThresholds({
+      improvements: 0,
+      regressionsWasmChange: 3,
+      regressedFiles: ["test/a/b/c/d/e.js", "test/a/b/c/d/f.js", "test/g/h/i/j/k.js"],
+    });
+    expect(failures.some((f) => f.includes("ratio") && f.includes("∞"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## #1943 — enforce the documented regression thresholds in CI

The documented merge criteria (`dev-self-merge` skill) are `net_per_test > 0`, regression ratio < 10% of improvements, and no path bucket > 50 regressions — but the **enforced** CI gate (`scripts/diff-test262.ts`) only failed on `net < 0`. The finer thresholds lived solely as agent-followed skill text, so a PR with 60 improvements + 55 unrelated regressions (92% ratio) passed the required check.

### Change
Moved both thresholds into `scripts/diff-test262.ts` as the single source of truth:
- Exported constants `REGRESSION_RATIO_LIMIT = 0.1`, `REGRESSION_BUCKET_LIMIT = 50`, `REGRESSION_BUCKET_PATH_DEPTH = 5`.
- Pure `evaluateRegressionThresholds()` + `bucketRegressions()` (grouping mirrors the skill's `'/'.join(f.split('/')[:5])` byte-for-byte).
- Exit logic now fails (exit 1) on net < 0 **or** any threshold failure, printing a `GATE FAIL: …` line per reason. Operates on the same wasm-hash-filtered `noiseFiltered` set the net gate uses → `compile_timeout` flaps and byte-identical flips stay excluded (no double-counting).

### CI wiring
The required **check for test262 regressions** job already maps `diff-test262` exit 1 → `regressions=true` → fail, so the new gates are enforced by branch protection with **no workflow change**. The separate catastrophic/standalone guards tolerate exit 1 by design and are unaffected. The bottom `main()` call is now guarded (`process.argv[1]`) so the unit test imports the helpers without running the CLI.

### Docs
`.claude/skills/dev-self-merge.md` Step 3 now notes CI enforces criteria 2 & 3, pointing at the exported constants as the single source (the criteria table is the documentation twin).

### Tests
`tests/issue-1943.test.ts` (7 cases): ratio 50% fails; 60-in-one-bucket fails with ratio under 10%; clean passes; borderline 9% passes; zero-improvements-with-regressions fails (∞ ratio); constant + bucket-grouping checks. Also validated end-to-end through the real CLI against synthetic fixture JSONLs (ratio-50% → exit 1 despite net +5; 60-bucket → exit 1 despite net +640; clean & 9% → exit 0).

Closes #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)