### PR TITLE
fix(#2144): linear % uses __fmod helper for cross-backend parity

### DIFF
--- a/plan/issues/2144-linear-fmod-parity.md
+++ b/plan/issues/2144-linear-fmod-parity.md
@@ -1,10 +1,12 @@
 ---
 id: 2144
 title: "linear %: replace naive trunc-formula with the #2056 fmod helper (cross-backend parity)"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -40,3 +42,32 @@ Emit `fmod.ts`'s long-division remainder as a linear runtime func
 
 Routine dev, sprint 63 (after the in-flight linear PRs land). Shows up in
 the #1854 differential lane once that exists.
+
+## Resolution (2026-06-16, dev-b)
+
+- **`src/codegen-linear/runtime.ts`** — new `addFmodRuntime(mod)` + `FMOD_FN`
+  export. Pushes a `__fmod` runtime func `(f64 a, f64 b) -> f64` implementing
+  the exact binary long-division remainder (same algorithm as the WasmGC
+  `src/codegen/fmod.ts`, #2056): special-cases b==0/|a|==Inf/NaN/|b|==Inf, then
+  `t=y·2^k` alignment + subtract-down loop, `copysign(x, a)` for the dividend
+  sign. All intermediates stay ≤ |a| so nothing overflows and every step is an
+  exact f64 op (zero ULP drift).
+- **`src/codegen-linear/index.ts`** — `addFmodRuntime(mod)` wired into both
+  `generateLinearModule` and `generateLinearMultiModule` (after the other
+  `add*Runtime` calls); the `PercentToken` arm now emits a single
+  `call __fmod` (operands already on the stack in `(a,b)` order) instead of the
+  naive `a - trunc(a/b)*b`. `fixupFuncIndices` patches the call like any other
+  runtime-func call.
+
+Verified vs Node on the linear backend (runtime operands, no constant folding):
+`1e308 % 1e-308` → `3.498…e-309` ✓ (was `-Infinity`), `7 % Infinity` → `7` ✓
+(was `NaN`), `1e16 % 0.0001` and `123456789.123 % 0.001` ✓ (no longer collapse),
+plus the sign/zero/NaN edge set — 18/18 match.
+
+Tests: extended `tests/issue-1974.test.ts` with a `#2144 __fmod parity` block
+(extreme ratio, Infinity divisor, round-collapse, sign-of-dividend, `x % 0`
+→ NaN). 19/19 pass.
+
+**Acceptance:**
+- [x] `1e308 % 1e-308` and `7 % Infinity` match Node on the linear backend
+- [x] #1974's regression guard extended to cover these cases

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -9,6 +9,7 @@ import type { ClassLayout } from "./layout.js";
 import { computeClassLayout } from "./layout.js";
 import {
   addArrayRuntime,
+  addFmodRuntime,
   addMapRuntime,
   addNumericMapRuntime,
   addNumericSetRuntime,
@@ -16,6 +17,7 @@ import {
   addSetRuntime,
   addStringRuntime,
   addUint8ArrayRuntime,
+  FMOD_FN,
 } from "./runtime.js";
 
 /** Type tag for class instances in linear memory */
@@ -81,6 +83,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   addSetRuntime(mod);
   addNumericMapRuntime(mod);
   addNumericSetRuntime(mod);
+  addFmodRuntime(mod); // #2144 — exact f64 remainder for the `%` arm
 
   // Add __closure_env global (mutable i32, init 0) for closure support
   const closureEnvGlobalIdx = mod.globals.length;
@@ -215,6 +218,7 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
   addSetRuntime(mod);
   addNumericMapRuntime(mod);
   addNumericSetRuntime(mod);
+  addFmodRuntime(mod); // #2144 — exact f64 remainder for the `%` arm
 
   // Add __closure_env global for closure support
   const closureEnvGlobalIdx = mod.globals.length;
@@ -2243,24 +2247,16 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
       fctx.body.push({ op: "f64.div" });
       break;
     case ts.SyntaxKind.PercentToken: {
-      // #1937 — this arm used to be EMPTY: `a % b` compiled both operands and
-      // no operator, leaving two values on the stack (the expression's
-      // "result" was just `b`, and the leftover `a` broke stack arity).
-      // Wasm has no f64.rem; emit a - trunc(a/b) * b via temp locals, which
-      // matches JS % (sign of the dividend) for finite operands. Known
-      // divergence: b = ±Infinity yields NaN instead of a (0*Inf = NaN).
-      const bLocal = addLocal(fctx, `__mod_b_${fctx.locals.length}`, { kind: "f64" });
-      const aLocal = addLocal(fctx, `__mod_a_${fctx.locals.length}`, { kind: "f64" });
-      fctx.body.push({ op: "local.set", index: bLocal });
-      fctx.body.push({ op: "local.set", index: aLocal });
-      fctx.body.push({ op: "local.get", index: aLocal });
-      fctx.body.push({ op: "local.get", index: aLocal });
-      fctx.body.push({ op: "local.get", index: bLocal });
-      fctx.body.push({ op: "f64.div" });
-      fctx.body.push({ op: "f64.trunc" });
-      fctx.body.push({ op: "local.get", index: bLocal });
-      fctx.body.push({ op: "f64.mul" });
-      fctx.body.push({ op: "f64.sub" });
+      // #2144 — call the `__fmod` runtime helper (exact IEEE-754 remainder,
+      // shared algorithm with the WasmGC backend's #2056 work). The previous
+      // inline `a - trunc(a/b)*b` formula (#1937) diverged from JS / the GC
+      // backend: it produced `±Infinity` for extreme ratios (ratio ≳ 1e308,
+      // e.g. `1e308 % 1e-308`), `NaN` for `x % Infinity` (0*Inf), and drifted
+      // by ULPs / collapsed to 0 when the intermediate rounded. `__fmod`
+      // handles all those cases exactly. Operands are already on the stack in
+      // (a, b) order — the helper's signature is `(f64 a, f64 b) -> f64`.
+      const fmodIdx = ctx.funcMap.get(FMOD_FN)!;
+      fctx.body.push({ op: "call", funcIdx: fmodIdx });
       break;
     }
     case ts.SyntaxKind.LessThanToken:

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -3313,3 +3313,175 @@ function addRuntimeFunc(
     exported: false,
   });
 }
+
+/** Reserved name for the linear-backend f64 remainder helper (#2144). */
+export const FMOD_FN = "__fmod";
+
+/**
+ * (#2144) Add the Wasm-native IEEE-754 remainder (`fmod`) helper to the linear
+ * backend, mirroring the WasmGC `src/codegen/fmod.ts` work (#2056).
+ *
+ * The linear `%` arm previously emitted the naive `a - trunc(a/b)*b` formula
+ * that the GC backend explicitly retired: it drifts by ULPs, collapses to 0
+ * when `trunc(a/b)*b` rounds back to `a`, and produces `±Infinity` when `a/b`
+ * overflows f64 (ratio ≳ 1e308). This is the textbook cross-backend divergence
+ * flagged in docs/architecture/codegen-axes.md — both backends must agree on
+ * `%`.
+ *
+ * Algorithm (exact, no host import — dual-mode standalone): classic binary
+ * long-division remainder operating purely in f64. All intermediates stay
+ * ≤ |a|, so nothing overflows, and every step is an exact f64 op, so there is
+ * zero rounding drift. See fmod.ts for the full derivation and the verified
+ * edge-case set (`x % Inf`, `-0 % x`, `Inf % x`, `x % 0`, `NaN % x`, …).
+ *
+ * Signature: `(f64 a, f64 b) -> f64`. Idempotent — a second call is a no-op.
+ */
+export function addFmodRuntime(mod: WasmModule): void {
+  if (mod.functions.some((f) => f.name === FMOD_FN)) return;
+
+  const typeIdx = mod.types.length;
+  mod.types.push({
+    kind: "func",
+    name: "$type___fmod",
+    params: [{ kind: "f64" }, { kind: "f64" }],
+    results: [{ kind: "f64" }],
+  });
+
+  // Locals: 0=a, 1=b (params); 2=x (|a|, running remainder), 3=y (|b|), 4=t.
+  const A = 0;
+  const B = 1;
+  const X = 2;
+  const Y = 3;
+  const T = 4;
+  const INF = Infinity;
+
+  const body: Instr[] = [
+    // if (b == 0) return NaN
+    { op: "local.get", index: B },
+    { op: "f64.const", value: 0 },
+    { op: "f64.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "f64.const", value: NaN }, { op: "return" }] },
+    // if (|a| == Inf) return NaN  (Inf % x)
+    { op: "local.get", index: A },
+    { op: "f64.abs" },
+    { op: "f64.const", value: INF },
+    { op: "f64.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "f64.const", value: NaN }, { op: "return" }] },
+    // if (a != a) return NaN  (NaN dividend)
+    { op: "local.get", index: A },
+    { op: "local.get", index: A },
+    { op: "f64.ne" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "f64.const", value: NaN }, { op: "return" }] },
+    // if (b != b) return NaN  (NaN divisor)
+    { op: "local.get", index: B },
+    { op: "local.get", index: B },
+    { op: "f64.ne" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "f64.const", value: NaN }, { op: "return" }] },
+    // if (|b| == Inf) return a  (a finite → remainder is a itself)
+    { op: "local.get", index: B },
+    { op: "f64.abs" },
+    { op: "f64.const", value: INF },
+    { op: "f64.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "local.get", index: A }, { op: "return" }] },
+
+    // x = |a|; y = |b|
+    { op: "local.get", index: A },
+    { op: "f64.abs" },
+    { op: "local.set", index: X },
+    { op: "local.get", index: B },
+    { op: "f64.abs" },
+    { op: "local.set", index: Y },
+
+    // if (x < y) return copysign(x, a)  (covers x == 0 → ±0)
+    { op: "local.get", index: X },
+    { op: "local.get", index: Y },
+    { op: "f64.lt" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: X }, { op: "local.get", index: A }, { op: "f64.copysign" }, { op: "return" }],
+    },
+
+    // t = y; while (t * 2 <= x) t *= 2
+    { op: "local.get", index: Y },
+    { op: "local.set", index: T },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 2 },
+            { op: "f64.mul" },
+            { op: "local.get", index: X },
+            { op: "f64.le" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 2 },
+            { op: "f64.mul" },
+            { op: "local.set", index: T },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // while (t >= y) { if (x >= t) x -= t; t *= 0.5 }
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: T },
+            { op: "local.get", index: Y },
+            { op: "f64.ge" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: X },
+            { op: "local.get", index: T },
+            { op: "f64.ge" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: X },
+                { op: "local.get", index: T },
+                { op: "f64.sub" },
+                { op: "local.set", index: X },
+              ],
+            },
+            { op: "local.get", index: T },
+            { op: "f64.const", value: 0.5 },
+            { op: "f64.mul" },
+            { op: "local.set", index: T },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // return copysign(x, a)
+    { op: "local.get", index: X },
+    { op: "local.get", index: A },
+    { op: "f64.copysign" },
+  ];
+
+  mod.functions.push({
+    name: FMOD_FN,
+    typeIdx,
+    locals: [
+      { name: "$x", type: { kind: "f64" } }, // X
+      { name: "$y", type: { kind: "f64" } }, // Y
+      { name: "$t", type: { kind: "f64" } }, // T
+    ],
+    body,
+    exported: false,
+  });
+}

--- a/tests/issue-1974.test.ts
+++ b/tests/issue-1974.test.ts
@@ -2,12 +2,14 @@
 /**
  * #1974 — the linear backend's `%` (PercentToken) arm used to be empty, so a
  * remainder expression left both operands on the stack and silently evaluated
- * to the divisor (`7 % 2` → `2`). The arm now spills to locals and emits
- * `a - trunc(a/b)*b` (sign of the dividend, matching JS for finite operands).
+ * to the divisor (`7 % 2` → `2`). #1937 filled the arm with `a - trunc(a/b)*b`.
  *
- * Resolved on main (the #1937 fill of the empty arm); these cases lock the
- * behaviour in for `target: "linear"` and guard stack discipline in non-return
- * positions.
+ * #2144 — that naive formula diverged from JS / the WasmGC backend on extreme
+ * inputs (it produced `±Infinity` for ratios ≳ 1e308, `NaN` for `x % Infinity`,
+ * and drifted/collapsed when the intermediate rounded). The arm now calls the
+ * `__fmod` runtime helper (exact IEEE-754 remainder, shared algorithm with the
+ * GC backend's #2056 work). The cases below lock both the basic behaviour
+ * (#1974) and the extreme-input parity (#2144) for `target: "linear"`.
  */
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
@@ -47,5 +49,47 @@ describe("#1974 linear backend modulo (%) is correct", () => {
     expect(await runLinear(`let s = 0; for (let i = 0; i < 10; i++) { if (i % 3 === 0) s += i; } return s;`)).toBe(
       0 + 3 + 6 + 9,
     );
+  });
+
+  // #2144 — extreme-input parity with JS / the WasmGC backend. The naive
+  // `a - trunc(a/b)*b` formula failed all of these (Inf / NaN / round-collapse);
+  // `__fmod` returns the exact IEEE-754 remainder.
+  describe("#2144 __fmod parity on extreme inputs", () => {
+    // Runtime operands so the values aren't constant-folded before codegen.
+    async function runMod(a: number, b: number): Promise<number> {
+      const src = `export function test(a: number, b: number): number { return a % b; }`;
+      const r = await compile(src, { fileName: "test.ts", target: "linear" });
+      expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+      const { instance } = await WebAssembly.instantiate(r.binary, {});
+      return (instance.exports as { test(a: number, b: number): number }).test(a, b);
+    }
+
+    const parity: Array<[number, number]> = [
+      [1e308, 1e-308], // overflowed to ±Infinity under the naive formula
+      [7, Infinity], // produced NaN (0*Inf) under the naive formula
+      [1e16, 0.0001], // collapsed to 0 when trunc(a/b)*b rounded back to a
+      [123456789.123, 0.001], // ULP drift / collapse
+      [-7, 3], // sign of the dividend
+      [7, -3],
+      [5.5, 2],
+      [10, 10],
+    ];
+
+    for (const [a, b] of parity) {
+      it(`${a} % ${b} matches Node`, async () => {
+        const got = await runMod(a, b);
+        const want = a % b;
+        if (Number.isNaN(want)) expect(Number.isNaN(got)).toBe(true);
+        else expect(got).toBe(want);
+      });
+    }
+
+    it("x % Infinity returns x (not NaN)", async () => {
+      expect(await runMod(7, Infinity)).toBe(7);
+    });
+
+    it("x % 0 is NaN", async () => {
+      expect(Number.isNaN(await runMod(5, 0))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## #2144 — backends diverge on `%` for extreme ratios

The linear backend's `%` arm used the naive `a - trunc(a/b)*b` formula (#1937)
that the WasmGC backend explicitly retired in #2056. It diverged from JS and
the GC backend on extreme inputs:
- `1e308 % 1e-308` → `-Infinity` (ratio overflows f64) — should be `3.498…e-309`
- `7 % Infinity` → `NaN` (`0*Inf`) — should be `7`
- `1e16 % 0.0001`, `123456789.123 % 0.001` → collapse to 0 / ULP drift

Textbook cross-backend divergence per `docs/architecture/codegen-axes.md`.

### Fix
- **`src/codegen-linear/runtime.ts`** — `addFmodRuntime(mod)` + `FMOD_FN` push a
  `__fmod (f64 a, f64 b) -> f64` runtime func implementing the **exact** binary
  long-division remainder (same algorithm as the GC `src/codegen/fmod.ts`,
  #2056): all intermediates stay ≤ |a| so nothing overflows and every step is
  an exact f64 op — zero rounding drift.
- **`src/codegen-linear/index.ts`** — wire `addFmodRuntime` into both linear
  generators; the `PercentToken` arm now emits a single `call __fmod` (operands
  already on the stack in `(a,b)` order). `fixupFuncIndices` patches the call
  like any other runtime-func call.

### Acceptance criteria
- [x] `1e308 % 1e-308` and `7 % Infinity` match Node on the linear backend
- [x] #1974's regression guard extended to cover these cases

### Verification
Runtime operands (no constant folding) vs Node: 18/18 edge cases match —
extreme ratio, Infinity divisor, round-collapse, sign-of-dividend, `x % 0`→NaN.
Tests: extended `tests/issue-1974.test.ts` with a `#2144 __fmod parity` block;
19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)