### PR TITLE
fix(#2090): stack-balance refuses to invent unrecoverable-type values

### DIFF
--- a/plan/issues/2090-stack-balance-self-repair-hard-error.md
+++ b/plan/issues/2090-stack-balance-self-repair-hard-error.md
@@ -1,10 +1,12 @@
 ---
 id: 2090
 title: "stack-balance self-repair must not invent values — null patch becomes a hard compile error"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/dev-b
 priority: high
 feasibility: easy
 reasoning_effort: low
@@ -44,3 +46,31 @@ standalone.
 ## Dupe check
 
 No issue covers the repair pass. New (analysis program).
+
+## Resolution (2026-06-16, dev-b)
+
+`src/codegen/stack-balance.ts` `fixBranch` had two arms that patched a missing
+stack slot of **unrecoverable** type with an invented `ref.null.extern` "safe
+default" (the `default:` case for an unknown valtype kind, and the
+type-indexed/multi-value `else`). Those masked the producing codegen bug as a
+silent null. The **typed-zero** arms (i32/i64/f64/f32/externref/ref → push that
+type's zero) are legitimate and untouched — they fill a *known*-type slot.
+
+- A module-scoped `inventedValueSites` collector + `currentDiagFunc` (set per
+  function in `stackBalance`'s loop) records any hit on the two unknown-type
+  arms with the function name + detail. `stackBalance` drains it into
+  `mod.codegenErrors` as a structured hard compile error ("refuses to invent a
+  value … would mask a producing codegen bug"), which `compiler.ts` surfaces as
+  a failed compile (#1868 channel). A placeholder is still pushed so the pass
+  finishes its walk; the recorded error fails the compile regardless.
+
+**Acceptance:**
+- [x] The unknown-type null-patch arms now produce a structured CE
+- [x] Playground examples all compile clean (`pnpm run check:ir-fallbacks` OK —
+  no #2090 trigger), proving no legitimate trigger on the example corpus; the
+  full equivalence suite runs green in CI (sharded). The legitimate typed-zero
+  arms are unaffected.
+
+Tests: `tests/issue-2090.test.ts` — drives the type-indexed unknown arm via a
+hand-built module (asserts the #2090 structured error) and confirms the
+known-type (i32) arm does NOT error.

--- a/src/codegen/stack-balance.ts
+++ b/src/codegen/stack-balance.ts
@@ -31,6 +31,18 @@ import type { BlockType, FuncTypeDef, Instr, TypeDef, ValType, WasmFunction, Was
 /** Sentinel: the instruction sequence is unreachable (after return/br/throw/unreachable). */
 const UNREACHABLE = -999;
 
+// #2090 — the stack-repair pass exists to fix *known* count/type mismatches by
+// adding `drop`s or typed zero-defaults. But two arms below patched an
+// UNKNOWN-typed missing slot with an invented `ref.null.extern` "safe default".
+// That masks the producing codegen bug twice (once at the producer, once in the
+// pass that should have flagged it) and ships a silent null. Report 04 §2a/§5
+// concluded there is no legitimate trigger. We now record any such site and
+// `stackBalance` converts it into a structured hard compile error instead of
+// inventing a value. The collector is module-scoped (the recursive fix* helpers
+// don't thread `mod`); `stackBalance` resets it per run and drains it at the end.
+let inventedValueSites: { func: string; detail: string }[] = [];
+let currentDiagFunc = "<unknown>";
+
 /**
  * Check if an instruction is a terminator (makes subsequent code unreachable).
  */
@@ -799,13 +811,26 @@ function fixBranch(
             body.push({ op: "ref.null", typeIdx: t.typeIdx });
             break;
           default:
-            // Unknown type -- push ref.null.extern as safe default
+            // #2090 — unknown value type: we cannot pick a correct default, so
+            // inventing one would mask a real producer bug. Record the site;
+            // stackBalance turns it into a hard compile error. Still push a
+            // placeholder so the rest of the pass can finish walking (the
+            // compile fails via the recorded error regardless).
+            inventedValueSites.push({
+              func: currentDiagFunc,
+              detail: `missing value of unknown valtype kind "${(t as { kind?: string }).kind ?? "?"}" in a val-typed block`,
+            });
             body.push({ op: "ref.null.extern" } as Instr);
             break;
         }
       } else {
-        // For type-indexed block types, we can't easily determine individual value types.
-        // Push ref.null.extern as a safe default (avoids runtime trap).
+        // #2090 — type-indexed block type: individual value types aren't
+        // recoverable here, so a default is necessarily a guess. Record it as a
+        // hard error rather than inventing a ref.null.extern (see above).
+        inventedValueSites.push({
+          func: currentDiagFunc,
+          detail: "missing value in a type-indexed (multi-value) block whose element types are not recoverable",
+        });
         body.push({ op: "ref.null.extern" } as Instr);
       }
       fixups++;
@@ -2216,6 +2241,9 @@ export function stackBalance(mod: WasmModule): number {
   const tags = mod.tags || [];
   let totalFixups = 0;
 
+  // #2090 — reset the invented-value collector for this run.
+  inventedValueSites = [];
+
   // Count import functions and find __box_number/__unbox_number indices
   let numImports = 0;
   let boxNumberIdx: number | null = null;
@@ -2241,6 +2269,8 @@ export function stackBalance(mod: WasmModule): number {
 
   for (let fi = 0; fi < mod.functions.length; fi++) {
     const func = mod.functions[fi]!;
+    // #2090 — attribute any invented-value site to this function in diagnostics.
+    currentDiagFunc = func.name || `func#${numImports + fi}`;
     // Build local types array (params + locals)
     const ft = resolveFuncType(mod.types, func.typeIdx);
     const localTypes: ValType[] = [];
@@ -2318,6 +2348,29 @@ export function stackBalance(mod: WasmModule): number {
       );
     }
   }
+
+  // #2090 — drain the invented-value collector into structured compile errors.
+  // Any entry means the repair pass hit a missing slot of unrecoverable type:
+  // a real producing-codegen bug that must NOT ship as a silent null. We fail
+  // the compile here instead. Report 04 §5 Phase 1 concluded there is no
+  // legitimate trigger, so in practice this list is empty for every module the
+  // equivalence suite + playground examples compile.
+  if (inventedValueSites.length > 0) {
+    if (!mod.codegenErrors) mod.codegenErrors = [];
+    for (const site of inventedValueSites) {
+      mod.codegenErrors.push({
+        message:
+          `stack-balance (#2090): cannot supply a missing stack value in function "${site.func}" — ` +
+          `${site.detail}. The repair pass refuses to invent a value here because doing so would ` +
+          `mask a producing codegen bug as a silent null. This is a compiler defect at the value ` +
+          `producer; report the failing input.`,
+        line: 0,
+        column: 0,
+      });
+    }
+    inventedValueSites = [];
+  }
+
   return totalFixups;
 }
 

--- a/tests/issue-2090.test.ts
+++ b/tests/issue-2090.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2090 — the stack-repair pass must not invent a value for a missing slot of
+ * unrecoverable type. Previously it pushed a "safe default" `ref.null.extern`,
+ * masking the producing codegen bug as a silent null. It now records the site
+ * and `stackBalance` converts it into a structured hard compile error
+ * (surfaced via `mod.codegenErrors`).
+ *
+ * Report 04 §5 Phase 1 concluded there is no legitimate trigger from real TS
+ * input, so we drive the arm directly with a hand-built module: a `block` whose
+ * type-indexed (multi-value) block type expects more results than its body
+ * produces. That forces the type-indexed missing-slot path the old code patched
+ * with an invented null.
+ */
+import { describe, expect, it } from "vitest";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import type { WasmModule } from "../src/ir/types.js";
+
+function emptyModule(): WasmModule {
+  return {
+    types: [],
+    imports: [],
+    functions: [],
+    globals: [],
+    exports: [],
+    memories: [],
+    tables: [],
+    elements: [],
+    dataSegments: [],
+    tags: [],
+  } as unknown as WasmModule;
+}
+
+describe("#2090 stack-balance refuses to invent a value", () => {
+  it("records a structured compile error for a missing slot of unrecoverable (type-indexed) type", () => {
+    const mod = emptyModule();
+    // type 0: the function signature () -> i32
+    // type 1: a multi-value block type (i32, i32) used as a `block` result type
+    //         whose body produces nothing → forces the type-indexed missing arm.
+    mod.types.push({ kind: "func", name: "$f", params: [], results: [{ kind: "i32" }] });
+    mod.types.push({ kind: "func", name: "$mv", params: [], results: [{ kind: "i32" }, { kind: "i32" }] });
+
+    mod.functions.push({
+      name: "victim",
+      typeIdx: 0,
+      locals: [],
+      // A block typed to produce TWO values (type idx 1) but whose body pushes
+      // none. fixBranch sees expected=2, actual=0, blockType.kind==="type" →
+      // the #2090 arm. Then the function still needs an i32 to satisfy its own
+      // result; the recorded error fails the compile regardless.
+      body: [
+        { op: "block", blockType: { kind: "type", typeIdx: 1 }, body: [] },
+        { op: "drop" },
+      ],
+      exported: false,
+    } as never);
+
+    stackBalance(mod);
+
+    const errs = (mod as { codegenErrors?: { message: string }[] }).codegenErrors ?? [];
+    const hit = errs.find((e) => /#2090/.test(e.message) && /victim/.test(e.message));
+    expect(hit, `expected a #2090 structured error, got: ${JSON.stringify(errs)}`).toBeTruthy();
+    expect(hit!.message).toMatch(/refuses to invent a value|mask a producing codegen bug/i);
+  });
+
+  it("does NOT record an error for a legitimate known-type missing slot (typed zero default)", () => {
+    const mod = emptyModule();
+    mod.types.push({ kind: "func", name: "$f", params: [], results: [{ kind: "i32" }] });
+    // A val-typed (i32) block whose body produces nothing — this is the
+    // LEGITIMATE arm: the repair pass fills it with `i32.const 0`, no error.
+    mod.functions.push({
+      name: "ok",
+      typeIdx: 0,
+      locals: [],
+      body: [{ op: "block", blockType: { kind: "val", type: { kind: "i32" } }, body: [] }],
+      exported: false,
+    } as never);
+
+    stackBalance(mod);
+
+    const errs = (mod as { codegenErrors?: { message: string }[] }).codegenErrors ?? [];
+    expect(errs.filter((e) => /#2090/.test(e.message))).toEqual([]);
+  });
+});

--- a/tests/issue-2090.test.ts
+++ b/tests/issue-2090.test.ts
@@ -48,10 +48,7 @@ describe("#2090 stack-balance refuses to invent a value", () => {
       // none. fixBranch sees expected=2, actual=0, blockType.kind==="type" →
       // the #2090 arm. Then the function still needs an i32 to satisfy its own
       // result; the recorded error fails the compile regardless.
-      body: [
-        { op: "block", blockType: { kind: "type", typeIdx: 1 }, body: [] },
-        { op: "drop" },
-      ],
+      body: [{ op: "block", blockType: { kind: "type", typeIdx: 1 }, body: [] }, { op: "drop" }],
       exported: false,
     } as never);
 


### PR DESCRIPTION
## #2090 — the repair pass masks the bugs it exists to catch

`src/codegen/stack-balance.ts` `fixBranch` patched a missing stack slot of
**unrecoverable** type with an invented `ref.null.extern` "safe default" — in
the unknown-valtype `default:` case and the type-indexed/multi-value `else`.
That masked the producing codegen bug as a silent null (once at the producer,
once in the pass that should have flagged it). Report 04 §5 concluded there is
no legitimate trigger.

### Fix
- The **typed-zero** arms (i32/i64/f64/f32/externref/ref → push that type's
  zero) are legitimate (the slot's type is known) and are **untouched**.
- The two **unknown-type** arms now record the site (module-scoped collector +
  `currentDiagFunc`, set per function in `stackBalance`'s loop) instead of
  inventing a value. `stackBalance` drains the collector into
  `mod.codegenErrors` as a **structured hard compile error**, which
  `compiler.ts` surfaces as a failed compile (#1868 channel). A placeholder is
  still pushed so the pass finishes its walk; the recorded error fails the
  compile regardless.

### Acceptance criteria
- [x] The null-patch arms now produce a structured CE
- [x] Full equivalence suite + playground examples still compile (no legitimate
  trigger): `node scripts/equivalence-gate.mjs` exits **0** over the full
  corpus; `pnpm run check:ir-fallbacks` (all playground examples) is **OK** —
  neither trips the #2090 error. Legitimate typed-zero arms unaffected.

### Tests
`tests/issue-2090.test.ts` — drives the type-indexed unknown arm via a
hand-built module (asserts the `#2090` structured error names the function) and
confirms the known-type (i32) arm does **not** error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)