### PR TITLE
fix(codegen): dispatch new Promise(executor) resolve/reject via __call_function (#2028)

### DIFF
--- a/plan/issues/2028-promise-executor-resolve-reject-trap.md
+++ b/plan/issues/2028-promise-executor-resolve-reject-trap.md
@@ -1,10 +1,12 @@
 ---
 id: 2028
 title: "new Promise(executor): invoking the host-provided resolve/reject from wasm traps null deref — executor pattern fully broken in JS-host mode"
-status: ready
-sprint: 62
+status: done
+assignee: ttraenkler/sen-b
+completed: 2026-06-16
+sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -359,3 +361,61 @@ resolve/reject §27.2.1.3.2 / §27.2.1.3.1.
 **Dispatchable to senior-dev.** Single, well-isolated codegen change with a
 verified WAT-level root cause. Lower risk than the prior analyses suggested —
 no `__make_callback` bridge surgery required.
+
+---
+
+## Implementation (sen-b, 2026-06-16) — DONE
+
+Implemented arch1's fix in `src/codegen/expressions/calls.ts`. Repro confirmed
+on main first (`new Promise((resolve)=>resolve("ok"))` → "dereferencing a null
+pointer" when awaited), then fixed.
+
+### What landed
+- New helper `calleeIsPromiseExecutorParam(ctx, expr)` next to
+  `calleeMayBeHostCallable`. Returns true when the callee identifier resolves to
+  a parameter of a **Promise executor** — an arrow/function-expression that is a
+  direct argument of `new Promise(...)`. Those params (`resolve`/`reject`) are
+  host-supplied JS functions arriving as externref.
+- Wired into the `hostCallFallback` gate (`calls.ts` ~9257) as
+  `calleeMayBeHostCallable(...) || calleeIsPromiseExecutorParam(...)`. The
+  existing `#1712` dispatch block then emits both arms: the closure-struct
+  `ref.test` fast path AND the `__call_function(fn, undefined, args)` arm taken
+  when the cast nulls (the host-fn case). Arm stays gated `!standalone && !wasi`.
+- `tests/issue-2028.test.ts`: resolve→"ok", reject→reason, resolve-twice→first
+  wins, resolve+await→derived value, and the #1941 dual-mode guard.
+
+### Critical refinement vs the spec (arch1's externref-type gate was too broad)
+arch1's spec proposed gating on "param whose lowered wasm type is externref +
+has a call signature". **That is NOT a safe discriminator** — I verified that an
+*ordinary* callable param (`cb` in `function apply(cb, v){ return cb(v); }`) is
+ALSO lowered as `externref` (the closure struct is recovered dynamically at the
+call site via `ref.test (ref $closure)`). Gating on externref-typed-callable
+re-emitted the `__call_function`/`__js_array_new` arm for pure local-closure
+programs — the exact **#1941 dual-mode regression** the spec warned against
+(confirmed: the imports reappeared). The precise, safe discriminator is that the
+param's *declaring function is a Promise executor* (direct `new Promise` arg),
+whose params are genuinely host-bound. The final helper gates on that.
+
+### Scope finding — the 2 `promise-combinators.test.ts` failures are NOT in scope
+The lead/spec expected this fix to recover `tests/promise-combinators.test.ts`
+×2 (`Promise.all(src.getPromises())`). It does **not**, and they are a *separate*
+defect: `src.getPromises()` is a `declare class` **instance-method** call whose
+return value compiles to `__get_undefined` (no host import is even emitted for
+the method — verified in WAT). That is host-`declare`-class-method-return
+marshaling, unrelated to the executor `resolve`/`reject` *parameter* dispatch
+fixed here. Those 2 tests pre-exist red on main and remain red — they need a
+distinct fix. **Consequence: the #1796 `awaitedExprIsPromiseCombinator`
+exclusion must STAY** until that separate host-method-return marshaling gap is
+fixed; #2028 does not enable dropping it. Recommend filing the combinator-arg
+marshaling as its own issue.
+
+### Edge cases verified
+- resolve → fulfils; reject(Error) → `.catch`/rejects with the Error; resolve
+  twice → first wins (native `[[AlreadyResolved]]`).
+- sync `throw` in executor → promise rejects (correct), but the rejection reason
+  is the bare `WebAssembly.Exception` (message undefined), identical to main —
+  a pre-existing #1536 exception-boundary fidelity detail, out of #2028 scope.
+- #1941 dual-mode: pure local-closure program pulls NO
+  `__call_function`/`__js_array_new` imports (asserted in the test).
+- tsc clean; no regressions across async-await / promise-chains / async-function
+  / issue-1042 suites (43 passed).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -9299,8 +9299,7 @@ function compileCallExpression(
             // (which traps on the null cast). Narrowly gated to Promise-executor
             // params so the #1941 dual-mode guarantee for ordinary callable
             // params is preserved.
-            (calleeMayBeHostCallable(ctx, expr.expression) ||
-              calleeIsPromiseExecutorParam(ctx, expr.expression));
+            (calleeMayBeHostCallable(ctx, expr.expression) || calleeIsPromiseExecutorParam(ctx, expr.expression));
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1007,6 +1007,45 @@ function calleeMayBeHostCallable(ctx: CodegenContext, expr: ts.Expression): bool
 }
 
 /**
+ * (#2028) Is `expr` an identifier resolving to a parameter of a **Promise
+ * executor** — the `(resolve, reject) => {…}` arrow/function-expression passed
+ * directly to `new Promise(...)`?
+ *
+ * Those params are bound by the host (native `new Promise` calls the executor
+ * with real JS `resolve`/`reject` functions), so they arrive as plain externref
+ * JS callables, NOT wasm closure structs. Calling them through the closure-struct
+ * `ref.test`/`ref.cast`/`struct.get`/`call_ref` dispatch path nulls the cast and
+ * traps on the null deref — they must take the `__call_function` arm instead.
+ *
+ * This is intentionally narrow. An ordinary callable parameter (`cb` in
+ * `function apply(cb, v) { return cb(v); }`) is ALSO lowered with an `externref`
+ * wasm type — the closure struct is recovered dynamically at the call site via
+ * `ref.test (ref $closure)`. So "externref-typed callable param" alone is NOT a
+ * safe discriminator: gating on it would re-emit the `__call_function` arm for
+ * pure local-closure programs and regress the #1941 dual-mode guarantee. The
+ * precise signal is that the param's *declaring function is a Promise executor*
+ * (an arrow/function-expression that is the direct argument of `new Promise`),
+ * whose param values are genuinely host-supplied.
+ */
+function calleeIsPromiseExecutorParam(ctx: CodegenContext, expr: ts.Expression): boolean {
+  if (!ts.isIdentifier(expr)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(expr);
+  const decl = sym?.valueDeclaration;
+  if (!decl || !ts.isParameter(decl)) return false;
+  // The parameter's declaring function must be the executor of `new Promise(...)`:
+  // an arrow / function expression that is a direct argument of a `new Promise`.
+  const fn = decl.parent;
+  if (!fn || (!ts.isArrowFunction(fn) && !ts.isFunctionExpression(fn))) return false;
+  const argParent = fn.parent;
+  if (!argParent || !ts.isNewExpression(argParent)) return false;
+  const ctor = argParent.expression;
+  if (!ts.isIdentifier(ctor) || ctor.text !== "Promise") return false;
+  // Confirm the executor is actually in the argument list (not, e.g., a type arg).
+  const fnNode: ts.Node = fn;
+  return (argParent.arguments ?? []).some((a) => a === fnNode);
+}
+
+/**
  * (#1337) Emit a call to a host bound-function externref via the
  * `__call_function(fn, thisArg, argsArray)` host helper. The bound function
  * already carries [[BoundThis]] and [[BoundArguments]], so `thisArg` is passed
@@ -9254,7 +9293,14 @@ function compileCallExpression(
             // function params are always wrapped into the closure struct, so the
             // arm would be dead code and only serve to pull host imports
             // (__js_array_new/…) into otherwise self-contained modules.
-            calleeMayBeHostCallable(ctx, expr.expression);
+            // (#2028) ALSO emit it for a Promise-executor `resolve`/`reject`
+            // parameter — those arrive as host JS functions and must dispatch
+            // through __call_function, not the closure-struct call_ref path
+            // (which traps on the null cast). Narrowly gated to Promise-executor
+            // params so the #1941 dual-mode guarantee for ordinary callable
+            // params is preserved.
+            (calleeMayBeHostCallable(ctx, expr.expression) ||
+              calleeIsPromiseExecutorParam(ctx, expr.expression));
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/tests/issue-2028.test.ts
+++ b/tests/issue-2028.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2028 — new Promise(executor): the host-provided resolve/reject arrive into
+// the executor as plain externref JS functions. Before the fix, calling them
+// from wasm dispatched through the closure-struct call_ref path, nulled the
+// cast, and trapped on a null deref ("dereferencing a null pointer"). The fix
+// routes a Promise-executor resolve/reject param through __call_function.
+//
+// JS-host mode only (the __call_function arm is gated !standalone && !wasi).
+
+async function instantiate(src: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
+  const result = await compile(src);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if (imports.setExports) imports.setExports(exports as Record<string, Function>);
+  return exports;
+}
+
+describe("#2028 — new Promise(executor) host resolve/reject dispatch", () => {
+  it("synchronous resolve(value) settles the promise to that value", async () => {
+    const ex = await instantiate(`
+      export function f(): any {
+        return new Promise<string>((resolve) => { resolve("ok"); });
+      }
+    `);
+    await expect(ex.f() as Promise<unknown>).resolves.toBe("ok");
+  });
+
+  it("synchronous reject(reason) rejects the promise with that reason", async () => {
+    const ex = await instantiate(`
+      export function f(): any {
+        return new Promise<number>((_resolve, reject) => { reject(new Error("nope")); });
+      }
+    `);
+    await expect(ex.f() as Promise<unknown>).rejects.toThrow("nope");
+  });
+
+  it("resolve-twice: first settlement wins (host [[AlreadyResolved]])", async () => {
+    const ex = await instantiate(`
+      export function f(): any {
+        return new Promise<number>((resolve) => { resolve(1); resolve(2); });
+      }
+    `);
+    await expect(ex.f() as Promise<unknown>).resolves.toBe(1);
+  });
+
+  it("resolve then await chains a derived value", async () => {
+    const ex = await instantiate(`
+      export async function f(): Promise<number> {
+        const p = new Promise<number>((resolve) => { resolve(41); });
+        const v = await p;
+        return v + 1;
+      }
+    `);
+    await expect(ex.f() as Promise<unknown>).resolves.toBe(42);
+  });
+
+  it("#1941 dual-mode guard: a pure local-closure callable param does NOT pull host imports", async () => {
+    // `cb` is an ordinary callable parameter — lowered as externref but the
+    // closure struct is recovered dynamically at the call site. It must keep the
+    // closure-struct call_ref path and NOT pull __call_function/__js_array_new.
+    const result = await compile(`
+      function apply(cb: (x: number) => number, v: number): number { return cb(v); }
+      export function f(): number { return apply((x) => x + 1, 10); }
+    `);
+    expect(result.success).toBe(true);
+    const wat = result.wat ?? "";
+    expect(wat).not.toMatch(/import "env" "__call_function"/);
+    expect(wat).not.toMatch(/import "env" "__js_array_new"/);
+  });
+});

--- a/tests/issue-2028.test.ts
+++ b/tests/issue-2028.test.ts
@@ -12,10 +12,9 @@ import { buildImports } from "../src/runtime.js";
 
 async function instantiate(src: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
   const result = await compile(src);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const imports = buildImports(result.imports, {}, result.stringPool);
   const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
   const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;


### PR DESCRIPTION
## Summary

Fixes #2028 — `new Promise(executor)` was fully broken in JS-host mode: the executor's `resolve`/`reject` arrive as host JS functions (externref), but were dispatched through the closure-struct `ref.test`/`ref.cast`/`struct.get`/`call_ref` path, which nulled the cast and trapped **"dereferencing a null pointer"** the moment `resolve(...)`/`reject(...)` was called.

Implements arch1's re-spec (the authoritative plan, confirmed by live WAT repro: the executor body DOES run; only the in-body `resolve`/`reject` dispatch traps).

## Fix

New `calleeIsPromiseExecutorParam(ctx, expr)` gate, OR'd into the existing #1712 `hostCallFallback` condition in `src/codegen/expressions/calls.ts`. When the callee is a `resolve`/`reject` parameter of a Promise executor, the dispatch takes the `__call_function(fn, undefined, args)` arm. The existing #1712 block already emits both arms — the closure-struct fast path AND the host-call arm taken when the cast nulls — so no new dispatch machinery is needed. Gated `!standalone && !wasi`; no new host imports.

## Refinement over the spec (important)

arch1's spec proposed gating on *"param whose lowered wasm type is externref + has a call signature."* I verified that is **unsafe**: an ordinary callable param (`cb` in `function apply(cb, v) { return cb(v); }`) is **also** lowered as `externref` (the closure struct is recovered dynamically at the call site). Gating on that re-emitted the `__call_function`/`__js_array_new` arm for pure local-closure programs — the exact **#1941 dual-mode regression** the spec warned against (confirmed reproduced). The precise, safe discriminator is that the param's *declaring function is a Promise executor* (a direct `new Promise(...)` argument), whose params are genuinely host-bound. The final helper gates on that.

## Validation

`tests/issue-2028.test.ts`: resolve→"ok", reject→reason, resolve-twice→first wins, resolve+await→derived value, and a **#1941 dual-mode guard** asserting a pure local-closure program pulls NO `__call_function`/`__js_array_new` imports. tsc clean; no regressions across async-await / promise-chains / async-function / issue-1042 (43 passed).

## Scope note

The 2 `promise-combinators.test.ts` failures (`Promise.all(src.getPromises())`) are **NOT** fixed here and are a **separate defect**: `src.getPromises()` is a `declare class` instance-method call whose return compiles to `__get_undefined` (no host import emitted) — host-`declare`-class-method-return marshaling, unrelated to the executor *parameter* dispatch. They pre-exist red on main and remain red. Consequently the #1796 `awaitedExprIsPromiseCombinator` exclusion must stay until that distinct gap is fixed (recommend a follow-up issue).

Closes #2028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)