### PR TITLE
fix(host-interop): dispatch Promise-executor resolve/reject through __call_function (#2028)

### DIFF
--- a/plan/issues/2028-promise-executor-resolve-reject-trap.md
+++ b/plan/issues/2028-promise-executor-resolve-reject-trap.md
@@ -1,10 +1,12 @@
 ---
 id: 2028
 title: "new Promise(executor): invoking the host-provided resolve/reject from wasm traps null deref — executor pattern fully broken in JS-host mode"
-status: ready
-sprint: 62
+status: done
+assignee: ttraenkler/sen-b
+completed: 2026-06-16
+sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -359,3 +361,56 @@ resolve/reject §27.2.1.3.2 / §27.2.1.3.1.
 **Dispatchable to senior-dev.** Single, well-isolated codegen change with a
 verified WAT-level root cause. Lower risk than the prior analyses suggested —
 no `__make_callback` bridge surgery required.
+
+---
+
+## Implementation (sen-b, 2026-06-16) — DONE
+
+Confirmed arch1's WAT diagnosis with a live repro on main (gate now ON post-#1796):
+`new Promise<string>((resolve) => resolve("ok"))` rejected with
+`RuntimeError: dereferencing a null pointer` at `$__cb_0` — the host `resolve`
+param went down the closure-struct `ref.test`/`ref.cast`/`struct.get`/`call_ref`
+path, the cast nulled on the foreign callable, and `struct.get` trapped.
+
+### Fix (one helper + one disjunct, `src/codegen/expressions/calls.ts`)
+Rather than widen `calleeMayBeHostCallable` (which is `(ctx, expr)` only and
+keyed on `VariableDeclaration`), I added a sibling predicate
+**`calleeIsPromiseExecutorParam(ctx, expr)`** and OR'd it into the existing
+`hostCallFallback` computation. It returns `true` only when the callee is a
+parameter of the arrow/function-expression passed **directly as arg 0 to
+`new Promise(...)`** and whose declared type is callable. On a match the call
+takes the already-wired `__call_function(fn, undefined, argsArray)` host arm
+(JS-host only — gated `!ctx.standalone && !ctx.wasi` at the dispatch site).
+
+### Scope decision — why executor-param, not "any externref callable param"
+arch1's spec suggested "any externref-typed callable param." I implemented that
+first and it **regressed the #1941 dual-mode guarantee**: an ordinary
+local-closure callback (`function apply(cb,v){return cb(v)}`) ALSO lowers its
+`cb` param to a bare `externref` local (verified in WAT: `$apply (param externref
+f64)`), so the broad predicate fired on it and pulled `__call_function` /
+`__js_array_new` into a self-contained module. The discriminator is not the
+lowered type — it's provenance: `apply`'s `cb` receives a **wasm closure** at the
+call site (so `ref.test $closure` succeeds, fast path taken; the host arm is dead
+code that only leaks imports), whereas a Promise executor's `resolve`/`reject`
+receive **host functions** from native `new Promise`. Scoping the predicate to
+the executor-param shape keeps the host arm exactly where a foreign callable can
+arrive and restores the #1941 guard (verified: no `__call_function`/`__js_array_new`
+for the local-closure case, `main()` still returns 11).
+
+### Verified
+- `tests/issue-2028.test.ts` (6 cases): sync resolve → "ok"; reject → reason;
+  resolve-twice → first wins; resolve(number); `.then` chain → 11; **#1941
+  dual-mode guard** (no host imports for a pure local-closure callback param).
+- tsc clean; IR fallback budget unchanged (the #1941 guard holds).
+- Net new regressions: 0. Pre-existing-on-main failures unaffected
+  (`promise-combinators` ×2, `optional-direct-closure-call` ×2,
+  `accessor-side-effects` ×3 — all verified identical on the `/workspace` main
+  checkout).
+
+### Out of scope (separate follow-up)
+The `promise-combinators` ×2 failures (`await Promise.all(src.getPromises())`)
+are a **different** defect: the host `declare`-class **method** `getPromises()`
+returns `__get_undefined`, unrelated to the resolve/reject param dispatch this
+issue fixes. That host-method-return marshaling gap is what blocks dropping the
+`awaitedExprIsPromiseCombinator` exclusion in #1796 — it remains a separate
+follow-up (host-method value marshaling), not addressed here.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1007,6 +1007,45 @@ function calleeMayBeHostCallable(ctx: CodegenContext, expr: ts.Expression): bool
 }
 
 /**
+ * (#2028) Is `expr` a call to a `resolve`/`reject` **parameter of a Promise
+ * executor** — i.e. a parameter of the arrow/function-expression passed directly
+ * as the sole argument to `new Promise(...)`? At runtime native `new Promise`
+ * invokes the compiled executor body with **real host functions** for those
+ * params, so the in-body call `resolve("ok")` must dispatch through the host
+ * `__call_function` arm. Without this it goes down the closure-struct
+ * `ref.test`/`ref.cast`/`struct.get`/`call_ref` path, the cast nulls on the
+ * foreign callable, and `struct.get` traps "dereferencing a null pointer" — the
+ * promise rejects with a RuntimeError instead of fulfilling.
+ *
+ * Scoped narrowly to the executor-parameter case ON PURPOSE: an ordinary
+ * closure-callback param (e.g. `apply(cb, v) { return cb(v); }`) also lowers to
+ * an `externref` local, but it receives a **wasm closure** at the call site, so
+ * `ref.test $closure` succeeds and the fast `call_ref` path is taken. Emitting
+ * the host arm for those would be dead code that needlessly pulls
+ * `__call_function` / `__js_array_new` host imports into otherwise self-contained
+ * modules — the #1941 dual-mode regression. Restricting to executor params keeps
+ * the host arm exactly where a foreign callable can actually arrive.
+ */
+function calleeIsPromiseExecutorParam(ctx: CodegenContext, expr: ts.Expression): boolean {
+  if (!ts.isIdentifier(expr)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(expr);
+  const decl = sym?.valueDeclaration;
+  if (!decl || !ts.isParameter(decl)) return false;
+  // The parameter's declared type must be callable (resolve/reject are fns).
+  const t = ctx.checker.getTypeAtLocation(expr);
+  if ((t?.getCallSignatures?.()?.length ?? 0) === 0) return false;
+  // The owning function must be the executor passed directly to `new Promise(...)`:
+  //   new Promise((resolve, reject) => { ... })  /  new Promise(function (resolve) { ... })
+  const owner = decl.parent;
+  if (!owner || !(ts.isArrowFunction(owner) || ts.isFunctionExpression(owner))) return false;
+  const callOrNew = owner.parent;
+  if (!callOrNew || !ts.isNewExpression(callOrNew)) return false;
+  if (callOrNew.arguments?.[0] !== owner) return false; // executor must be arg 0
+  const ctor = callOrNew.expression;
+  return ts.isIdentifier(ctor) && ctor.text === "Promise";
+}
+
+/**
  * (#1337) Emit a call to a host bound-function externref via the
  * `__call_function(fn, thisArg, argsArray)` host helper. The bound function
  * already carries [[BoundThis]] and [[BoundArguments]], so `thisArg` is passed
@@ -9254,7 +9293,15 @@ function compileCallExpression(
             // function params are always wrapped into the closure struct, so the
             // arm would be dead code and only serve to pull host imports
             // (__js_array_new/…) into otherwise self-contained modules.
-            calleeMayBeHostCallable(ctx, expr.expression);
+            //
+            // (#2028) ALSO emit it for a `resolve`/`reject` parameter of a
+            // `new Promise(executor)` — those arrive as foreign host functions,
+            // and calling them must take the `__call_function` arm rather than
+            // trap on the closure-struct `call_ref` path. Scoped to the executor
+            // params (not all callable externref params) to preserve the #1941
+            // dual-mode guarantee — see the helper's doc.
+            (calleeMayBeHostCallable(ctx, expr.expression) ||
+              calleeIsPromiseExecutorParam(ctx, expr.expression));
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -9300,8 +9300,7 @@ function compileCallExpression(
             // trap on the closure-struct `call_ref` path. Scoped to the executor
             // params (not all callable externref params) to preserve the #1941
             // dual-mode guarantee — see the helper's doc.
-            (calleeMayBeHostCallable(ctx, expr.expression) ||
-              calleeIsPromiseExecutorParam(ctx, expr.expression));
+            (calleeMayBeHostCallable(ctx, expr.expression) || calleeIsPromiseExecutorParam(ctx, expr.expression));
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/tests/issue-2028.test.ts
+++ b/tests/issue-2028.test.ts
@@ -47,7 +47,9 @@ describe("#2028 — Promise executor resolve/reject dispatch", () => {
   });
 
   it("resolve with a number value fulfils to that number", async () => {
-    const ex = await instantiate(`export function f(): any { return new Promise<number>((resolve) => { resolve(42); }); }`);
+    const ex = await instantiate(
+      `export function f(): any { return new Promise<number>((resolve) => { resolve(42); }); }`,
+    );
     await expect(ex.f() as Promise<unknown>).resolves.toBe(42);
   });
 

--- a/tests/issue-2028.test.ts
+++ b/tests/issue-2028.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2028 — `new Promise(executor)`: the `resolve`/`reject` parameters arrive as
+// real host functions when native `new Promise` invokes the compiled executor
+// body. Before the fix, the in-body call `resolve("ok")` was dispatched through
+// the closure-struct `ref.test`/`ref.cast`/`struct.get`/`call_ref` path, which
+// fails on a foreign callable (the cast nulls, then `struct.get` traps
+// "dereferencing a null pointer"), so the promise rejected with a RuntimeError
+// instead of fulfilling. The fix (calls.ts `calleeIsPromiseExecutorParam`)
+// routes executor-param calls through the `__call_function` host arm.
+
+async function instantiate(src: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
+  const result = await compile(src);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+  ).toBe(true);
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if (imports.setExports) imports.setExports(exports as Record<string, Function>);
+  return exports;
+}
+
+describe("#2028 — Promise executor resolve/reject dispatch", () => {
+  it("sync resolve fulfils the promise (§27.2.3.1)", async () => {
+    const ex = await instantiate(
+      `export function f(): any { return new Promise<string>((resolve) => { resolve("ok"); }); }`,
+    );
+    await expect(ex.f() as Promise<unknown>).resolves.toBe("ok");
+  });
+
+  it("sync reject rejects with the reason", async () => {
+    const ex = await instantiate(
+      `export function f(): any { return new Promise((_resolve, reject) => { reject(new Error("boom")); }); }`,
+    );
+    await expect(ex.f() as Promise<unknown>).rejects.toThrow("boom");
+  });
+
+  it("resolve-twice: first call wins, second is ignored ([[AlreadyResolved]] §27.2.1.3)", async () => {
+    const ex = await instantiate(
+      `export function f(): any { return new Promise<number>((resolve) => { resolve(1); resolve(2); }); }`,
+    );
+    await expect(ex.f() as Promise<unknown>).resolves.toBe(1);
+  });
+
+  it("resolve with a number value fulfils to that number", async () => {
+    const ex = await instantiate(`export function f(): any { return new Promise<number>((resolve) => { resolve(42); }); }`);
+    await expect(ex.f() as Promise<unknown>).resolves.toBe(42);
+  });
+
+  it("a .then chained off the resolved promise observes the value", async () => {
+    const ex = await instantiate(
+      `export function f(): any {
+         const p = new Promise<number>((resolve) => { resolve(10); });
+         return p.then((v: number) => v + 1);
+       }`,
+    );
+    await expect(ex.f() as Promise<unknown>).resolves.toBe(11);
+  });
+
+  it("#1941 dual-mode guard: a pure local-closure callback param does NOT pull host imports", async () => {
+    // `apply`'s `cb` param also lowers to an externref local, but it receives a
+    // wasm closure at the call site (so `ref.test $closure` succeeds and the fast
+    // `call_ref` path runs). The #2028 fix is scoped to Promise-executor params,
+    // so this case must stay free of `__call_function` / `__js_array_new`.
+    const result = await compile(
+      `function apply(cb: (x: number) => number, v: number): number { return cb(v); }
+       export function main(): number { return apply((x) => x + 1, 10); }`,
+    );
+    expect(result.success).toBe(true);
+    expect(result.wat?.includes("__call_function")).toBe(false);
+    expect(result.wat?.includes("__js_array_new")).toBe(false);
+    const imports = buildImports(result.imports, {}, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+    const exports = instance.exports as Record<string, () => number>;
+    if (imports.setExports) imports.setExports(exports as Record<string, Function>);
+    expect(exports.main()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

`new Promise(executor)` invokes the compiled executor body with **real host functions** for the `resolve`/`reject` params. The in-body call `resolve("ok")` was dispatched down the closure-struct `ref.test`/`ref.cast`/`struct.get`/`call_ref` path, which fails on a foreign callable: the cast nulls and `struct.get` traps `"dereferencing a null pointer"`, so the promise **rejected with a RuntimeError instead of fulfilling**. (Verified with a live repro now that the async CPS gate is ON post-#1796.)

## Fix

New predicate **`calleeIsPromiseExecutorParam(ctx, expr)`** (`src/codegen/expressions/calls.ts`), OR'd into the existing `hostCallFallback` gate. It fires only when the callee is a parameter of the arrow/function-expression passed **directly as arg 0 to `new Promise(...)`** and the param type is callable, routing the call through the already-wired `__call_function(fn, undefined, argsArray)` host arm (JS-host only — gated `!ctx.standalone && !ctx.wasi`). No `__make_callback` bridge surgery, no new host import.

## Scope decision (why executor-param, not "any externref callable param")

arch1's spec suggested "any externref-typed callable param." I implemented that first and it **regressed the #1941 dual-mode guarantee**: an ordinary local-closure callback (`apply(cb,v){return cb(v)}`) ALSO lowers its `cb` param to a bare `externref` local, so the broad predicate fired on it and pulled `__call_function`/`__js_array_new` into a self-contained module. The discriminator isn't the lowered type — it's **provenance**: executor params receive host fns; closure callbacks receive wasm closures (`ref.test $closure` succeeds, fast path taken). Scoping to the executor-param shape restores the #1941 guard.

## Validation

- `tests/issue-2028.test.ts` (6 cases): sync resolve → "ok"; reject → reason; resolve-twice → first wins; resolve(number); `.then` chain → 11; **#1941 dual-mode guard** (no host imports for a pure local-closure callback param).
- tsc clean; IR fallback budget unchanged.
- **Net new regressions: 0** — pre-existing-on-main failures unaffected (`promise-combinators` ×2, `optional-direct-closure-call` ×2, `accessor-side-effects` ×3, all verified identical on the main checkout).

## Out of scope

The `promise-combinators` ×2 failures (`await Promise.all(src.getPromises())`) are a **separate** defect — the host `declare`-class **method** `getPromises()` returns `__get_undefined`, unrelated to the resolve/reject dispatch. That host-method-return marshaling gap is what blocks dropping the `awaitedExprIsPromiseCombinator` exclusion in #1796; it remains a follow-up.

Closes #2028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)