### PR TITLE
fix(#1920): peephole recurses into try.catchAll

### DIFF
--- a/plan/issues/1920-unify-instruction-walkers-peephole-catchall.md
+++ b/plan/issues/1920-unify-instruction-walkers-peephole-catchall.md
@@ -58,3 +58,23 @@ Also cheap peephole wins identified while reviewing:
 ## Source
 
 Compiler quality review 2026-06. Related: #957 (peephole corpus), #1530.
+
+## Resolution (2026-06-16, dev-b) — catchAll gap fixed (item 3)
+
+The load-bearing **bug** — `peephole.ts` `optimizeBody` recursed into
+`try.body` and `try.catches` but NOT `try.catchAll`, so bodies built by e.g.
+`wrapAsyncCallInTryCatch` never got peephole-optimized — is fixed: the `try`
+arm now also recurses into `instr.catchAll`.
+
+Scope note: items 1 (single `walkInstructions`), 2 (port the 4 walkers onto
+it), and 4 (NaN-const / set-get→tee patterns) are a larger refactor and remain
+open as follow-up — this PR lands the actual defect (item 3) with a focused,
+low-risk change. The remaining unification stays tracked here.
+
+Tests: `tests/issue-1920.test.ts` drives `peepholeOptimize` on a hand-built
+module with the redundant `ref.cast; ref.as_non_null` pair inside a `catchAll`
+body and asserts it's collapsed (it was NOT before); plus catch-body and
+no-pattern cases. All pass. (The pre-existing `ref-cast-peephole.test.ts`
+closure failures are an unrelated test-harness import-shape issue —
+`string_constants` import missing from the test's `{ env: {} }` — present on
+main before this change.)

--- a/src/codegen/peephole.ts
+++ b/src/codegen/peephole.ts
@@ -90,6 +90,12 @@ function optimizeBody(body: Instr[], localTypes?: ValType[]): number {
             if (c.body) removed += optimizeBody(c.body, localTypes);
           }
         }
+        // #1920 — the `catchAll` body was previously skipped, so instruction
+        // bodies built by e.g. wrapAsyncCallInTryCatch (expressions.ts) never
+        // got peephole-optimized (redundant ref.as_non_null after ref.cast left
+        // in). stack-balance's eliminateDeadCode walker handles catchAll; the
+        // two walkers had diverged. Recurse into it too.
+        if (instr.catchAll) removed += optimizeBody(instr.catchAll, localTypes);
         break;
     }
   }

--- a/tests/issue-1920.test.ts
+++ b/tests/issue-1920.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1920 — the WasmGC peephole walker recursed into `try.body` and `try.catches`
+ * but NOT `try.catchAll`, so bodies built by e.g. wrapAsyncCallInTryCatch were
+ * never peephole-optimized (the redundant `ref.as_non_null` after `ref.cast`
+ * was left in). This drives `peepholeOptimize` directly with a hand-built
+ * module so the catchAll path is exercised in isolation.
+ */
+import { describe, expect, it } from "vitest";
+import { peepholeOptimize } from "../src/codegen/peephole.js";
+import type { Instr, WasmModule } from "../src/ir/types.js";
+
+function moduleWithTry(opts: { catchAll?: Instr[]; catchBody?: Instr[]; outerBody?: Instr[] }): WasmModule {
+  const tryInstr: Instr = {
+    op: "try",
+    blockType: { kind: "empty" },
+    body: opts.outerBody ?? [],
+    catches: opts.catchBody ? [{ tagIdx: 0, body: opts.catchBody }] : [],
+    ...(opts.catchAll ? { catchAll: opts.catchAll } : {}),
+  } as Instr;
+  return {
+    types: [{ kind: "func", name: "$f", params: [], results: [] }],
+    imports: [],
+    functions: [{ name: "f", typeIdx: 0, locals: [], body: [tryInstr], exported: false }],
+    globals: [],
+    exports: [],
+    memories: [],
+    tables: [],
+    elements: [],
+    dataSegments: [],
+    tags: [{ typeIdx: 0 }],
+  } as unknown as WasmModule;
+}
+
+// The redundant pair the peephole removes: ref.cast then ref.as_non_null.
+const redundantPair = (): Instr[] => [{ op: "ref.cast", typeIdx: 0 } as Instr, { op: "ref.as_non_null" } as Instr];
+
+describe("#1920 peephole recurses into try.catchAll", () => {
+  it("removes the redundant ref.as_non_null inside a catchAll body", () => {
+    const mod = moduleWithTry({ catchAll: redundantPair() });
+    const removed = peepholeOptimize(mod);
+    expect(removed).toBe(1);
+    const tryInstr = mod.functions[0]!.body[0] as Extract<Instr, { op: "try" }>;
+    expect(tryInstr.catchAll).toEqual([{ op: "ref.cast", typeIdx: 0 }]);
+  });
+
+  it("still removes the pattern inside a named catch body (no regression)", () => {
+    const mod = moduleWithTry({ catchBody: redundantPair() });
+    const removed = peepholeOptimize(mod);
+    expect(removed).toBe(1);
+  });
+
+  it("removes the pattern in both catch and catchAll bodies in one pass", () => {
+    const mod = moduleWithTry({ catchBody: redundantPair(), catchAll: redundantPair() });
+    const removed = peepholeOptimize(mod);
+    expect(removed).toBe(2);
+  });
+
+  it("leaves a catchAll body without the pattern unchanged", () => {
+    const mod = moduleWithTry({ catchAll: [{ op: "nop" } as Instr] });
+    const removed = peepholeOptimize(mod);
+    expect(removed).toBe(0);
+    const tryInstr = mod.functions[0]!.body[0] as Extract<Instr, { op: "try" }>;
+    expect(tryInstr.catchAll).toEqual([{ op: "nop" }]);
+  });
+});


### PR DESCRIPTION
## #1920 (item 3) — peephole misses catchAll bodies

`peephole.ts` `optimizeBody` recursed into `try.body` and `try.catches` but
**not** `try.catchAll`, so instruction bodies built by e.g.
`wrapAsyncCallInTryCatch` never got peephole-optimized (the redundant
`ref.as_non_null` after `ref.cast` was left in). `stack-balance`'s
`eliminateDeadCode` walker handled catchAll — the two walkers had diverged.

### Fix
The `try` arm now also recurses into `instr.catchAll`.

**Scope**: this PR lands the actual defect (issue item 3). The broader
walker-unification (item 1 single `walkInstructions`, item 2 port the 4
walkers, item 4 NaN-const / set-get→tee patterns) is a larger refactor and
**remains tracked on #1920** as follow-up.

### Tests
`tests/issue-1920.test.ts` drives `peepholeOptimize` on a hand-built module
with the redundant `ref.cast; ref.as_non_null` pair inside a `catchAll` body
and asserts it's collapsed (it was **not** before this change), plus
catch-body and no-pattern control cases. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)