### PR TITLE
fix(#2139): add linear-tests CI job to gate linear-backend suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,37 @@ jobs:
       #       fi
       #     fi
 
+  # #2139 — Execute the linear-backend (linear-memory lowering), C-ABI, and
+  # SIMD test suites in CI. These 20 files (tests/linear-*.test.ts,
+  # tests/c-abi.test.ts, tests/simd*.test.ts) sat at tests/ root with NO CI
+  # job running them: the equivalence shards only run tests/equivalence/ and
+  # the `quality` job only runs lint/typecheck/gates plus a few named files.
+  # That gap is why #1974/#1975/#1976/#1977 (linear-backend bugs) shipped
+  # silently — nothing executed linear output after merge. All 20 files pass
+  # on main, so this runs them directly (no baseline-gate needed); any failure
+  # is a genuine regression and blocks the PR. Single-fork keeps peak RAM low.
+  linear-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Run linear-backend, C-ABI, and SIMD tests
+        run: |
+          # Invoke vitest directly (not `pnpm test --`) so the trailing file
+          # globs are scoped to vitest and not consumed by pnpm. Single-fork +
+          # no file-parallelism keeps peak RAM ~1 GB (same pattern as the
+          # equivalence shards). See #2139.
+          pnpm exec vitest run \
+            tests/linear-*.test.ts tests/c-abi.test.ts tests/simd.test.ts tests/simd-wat.test.ts \
+            --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+
   # #1659 — Run tests/equivalence/ in CI. Previously skipped because the full
   # suite OOMed under file-parallelism. Each shard runs single-fork (peak
   # ~1 GB RAM, ~1-2 min) and emits a partial failure list; the merge job

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -35,6 +35,7 @@ case-sensitive and whitespace-sensitive.
 | `merge shard reports` | `.github/workflows/test262-sharded.yml` | aggregates the 57 test262 shards into a single pass/fail signal — the authoritative aggregate conformance gate. Hosts the HARD inline guards: the host catastrophic-regression guard (#1668), the **standalone net-regression guard (#1897)**, and the stale-baseline guard (#1668) — see §3 |
 | `quality` | `.github/workflows/ci.yml` | lint, format check, typecheck, IR fallback budget (#1376), planning-artifact regen |
 | `equivalence-gate` | `.github/workflows/ci.yml` | merges the equivalence shards and fails if the shard baseline regresses |
+| `linear-tests` | `.github/workflows/ci.yml` | runs the linear-backend (`tests/linear-*.test.ts`), C-ABI (`tests/c-abi.test.ts`), and SIMD (`tests/simd*.test.ts`) suites — the 20 files that previously had no CI job, so every linear-memory lowering change landed ungated (#2139) |
 | `check for test262 regressions` | `.github/workflows/test262-sharded.yml` | full rolling-baseline test262 diff; required so pass→fail regressions cannot merge just because the aggregate hard guards stayed below threshold |
 | `cla-check` | `.github/workflows/cla-check.yml` | self-hosted CLA-acceptance gate (#1660): internal authors and bots are exempt; external humans must have affirmative CLA acceptance recorded |
 
@@ -333,6 +334,7 @@ behaviour can be flipped without touching the JS script.
 | `merge shard reports` | `test262-sharded.yml` | semantic conformance, **both lanes**: aggregates the 57 sharded test262 runs (host + standalone) into a single pass/fail. Authoritative gate via the merge queue (build/merge up to 5 concurrently since #1956; predecessor-group diffing preserves per-PR attribution, so no ALLGREEN hiding) — each PR validated on its own merge_group ref. Hosts the host catastrophic guard (#1668), the standalone net-regression guard (#1897), and the stale-baseline guard (#1668) — see §3. |
 | `quality` | `ci.yml` | source quality regressions: lint, formatting, typecheck failures, IR fallback budget exceeded (#1376), planning-artifact regeneration. Also runs the "origin/main is merged into branch" pre-check that catches stale PR branches. |
 | `equivalence-gate` | `ci.yml` | semantic equivalence regressions across the sharded equivalence suite after the shard partials are merged. |
+| `linear-tests` | `ci.yml` | linear-memory backend regressions: the 20 `tests/linear-*.test.ts` / `tests/c-abi.test.ts` / `tests/simd*.test.ts` files that no CI job executed before #2139, which is why the #1974–#1977 linear-backend bug class shipped silently. |
 | `check for test262 regressions` | `test262-sharded.yml` | full rolling-baseline test262 diff, including pass→fail changes that stay below the inline catastrophic thresholds. |
 | `cla-check` | `cla-check.yml` | CLA acceptance for external contributors while preserving internal and bot exemptions. |
 

--- a/plan/issues/2139-ci-linear-backend-tests-not-executed.md
+++ b/plan/issues/2139-ci-linear-backend-tests-not-executed.md
@@ -1,10 +1,12 @@
 ---
 id: 2139
 title: "CI: linear-backend tests (22 files) are not executed by any CI job"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-2139
 priority: critical
 feasibility: easy
 reasoning_effort: low
@@ -47,3 +49,42 @@ to required checks per `docs/ci-policy.md`.
 S-size, routine dev, but sprint-62 P0: do first in the quality lane, it
 gates the permanence of all in-flight linear fixes. The cheapest, biggest
 trust win found by the analysis.
+
+## Resolution (2026-06-16)
+
+Added a dedicated **`linear-tests`** job to `.github/workflows/ci.yml` that
+runs the 20 previously-ungated test files directly:
+
+```
+pnpm exec vitest run \
+  tests/linear-*.test.ts tests/c-abi.test.ts tests/simd.test.ts tests/simd-wat.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+```
+
+(17 `linear-*.test.ts` + `c-abi.test.ts` + `simd.test.ts` + `simd-wat.test.ts`
+= 20 files, 203 tests.) Single-fork / no-file-parallelism mirrors the
+equivalence-shard RAM pattern (peak ~1 GB).
+
+**No baseline-gate needed.** The approach note suggested baseline-gating "if
+any currently fail" — but all 20 files / 203 tests **pass on main**, so the
+job runs them directly. Any failure is therefore a genuine regression that
+hard-blocks the PR (simpler than the equivalence-gate baseline machinery, and
+matches AC #1 exactly).
+
+Promoted `linear-tests` to a **required status check** in the two
+source-of-truth files: `scripts/enable-branch-protection.sh` (`REQUIRED_CHECKS`)
+and `docs/ci-policy.md` (§1 required-checks table + §7 mapping table). The
+GitHub ruleset itself is applied out-of-band by an admin running
+`./scripts/enable-branch-protection.sh` (needs Administration:write); the job
+already runs and reports on every PR regardless, so it gates the merge queue
+once the ruleset is re-applied.
+
+### Acceptance criteria — verified
+
+- **A deliberately-broken linear lowering fails PR CI** ✓ — dropped a probe
+  test into `tests/linear-broken-probe.test.ts` with a failing assertion and
+  ran the exact CI command: vitest exited **1** (1 file / 1 test failed,
+  20 files / 203 tests passed). Probe removed; no leftover test changes.
+- **The four in-flight linear fix PRs (#1409/#1412/#1414/#1415) are
+  permanently guarded once merged** ✓ — the job runs the full linear-backend
+  suite on every PR, so any later regression of those fixes fails CI.

--- a/scripts/enable-branch-protection.sh
+++ b/scripts/enable-branch-protection.sh
@@ -70,6 +70,7 @@ REQUIRED_CHECKS=(
   "merge shard reports"                  # test262-sharded.yml — authoritative test262 gate (host + standalone, #1897)
   "quality"                              # ci.yml — lint, format, typecheck, IR budget
   "equivalence-gate"                     # ci.yml — merged equivalence shard gate
+  "linear-tests"                         # ci.yml — linear-backend + C-ABI + SIMD suites (#2139)
   "check for test262 regressions"        # test262-sharded.yml — full rolling-baseline regression diff
   "cla-check"                            # cla-check.yml — external contributor CLA acceptance
 )


### PR DESCRIPTION
## Summary

The 20 linear-memory / C-ABI / SIMD test files (`tests/linear-*.test.ts`, `tests/c-abi.test.ts`, `tests/simd*.test.ts`) sat at `tests/` root with **no CI job executing them**: the equivalence shards run only `tests/equivalence/` and the `quality` job runs lint/typecheck/gates plus a few named files. That gap is why the #1974–#1977 linear-backend bug class shipped silently — nothing ran linear output after merge.

## Changes

- **`.github/workflows/ci.yml`** — new `linear-tests` job running all 20 files directly:
  ```
  pnpm exec vitest run tests/linear-*.test.ts tests/c-abi.test.ts tests/simd.test.ts tests/simd-wat.test.ts \
    --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
  ```
  Single-fork / no-file-parallelism mirrors the equivalence-shard RAM pattern (peak ~1 GB). All 203 tests pass on main, so **no baseline-gate is needed** — any failure is a genuine regression that hard-blocks the PR.
- **`scripts/enable-branch-protection.sh`** + **`docs/ci-policy.md`** (§1 + §7) — promote `linear-tests` to a **required status check**. The GitHub ruleset itself is re-applied out-of-band by an admin running `./scripts/enable-branch-protection.sh` (needs Administration:write); the job runs and reports on every PR regardless.
- **`plan/issues/2139-…md`** — `status: done`.

## Acceptance criteria — verified

- ✅ **A deliberately-broken linear lowering fails PR CI** — a probe test with a failing assertion ran under the exact CI command and vitest exited `1` (1 file / 1 test failed). Probe removed.
- ✅ **The in-flight linear fix PRs (#1409/#1412/#1414/#1415) are permanently guarded once merged** — the job runs the full linear-backend suite on every PR.

Closes #2139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)