### PR TITLE
fix(#2025): extracted-method null-this throws catchable TypeError, not a trap

### DIFF
--- a/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
+++ b/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
@@ -1,10 +1,12 @@
 ---
 id: 2025
 title: "calling an extracted method (const f = a.m; f()) traps uncatchably instead of throwing catchable TypeError"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-2108
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -52,3 +54,53 @@ instead of trapping.
 
 #1949 (call/apply thisArg) adjacent but distinct; #581 is the general
 family. New.
+
+## Implementation (2026-06-16)
+
+The method-extraction trampoline lives in `buildTrampolineThisSlot`
+(`src/codegen/closures.ts`), shared by the object-literal (`emitObjectMethodAsClosure`),
+cached class-method (`emitCachedMethodClosureAccess`), and per-call-site paths
+(all rebuilt by `finalizeMethodTrampolines`). It resolved `this` from
+`__current_this` (#2015) and, on the unbound-extraction null arm, forwarded
+`ref.null`. When the method body then did `this.x` (`local.get 0; struct.get`),
+the `struct.get` on a null ref **trapped uncatchably**, escaping the user's
+try/catch.
+
+Fix:
+- `buildTypeErrorThrow(ctx, msg, fctx?)` — generalised `buildDestructureNullThrow`
+  in `src/codegen/destructuring-params.ts` into a message-parameterised, JS-host
+  + standalone (`__new_TypeError` / `__throw_type_error`) catchable-TypeError
+  throw returned as `Instr[]`.
+- `buildTrampolineThisSlot` now takes `methodUsesThis`. On the null-`this` arm it
+  throws a catchable TypeError when the method reads `this`, else forwards the
+  harmless `ref.null` (so extracting a `this`-free method still works — the issue
+  note's required case).
+- `methodReadsThisParam(ctx, methodFuncIdx)` decides `methodUsesThis` by walking
+  the now-final compiled method body for any `local.get 0` (recursive via
+  `walkInstructions`; locals are function-scoped so index 0 is always `this`).
+  Computed in `finalizeMethodTrampolines` (initial-emit placeholders pass `false`
+  and are overwritten by finalize).
+- Index-shift safety: `ensureTypeErrorThrowImports(ctx)` pre-registers the
+  throw's late imports ONCE before the finalize loop, so the in-loop throw adds
+  no new import mid-pass (which would shift `call methodFuncIdx` forwarders that
+  were already built at pre-shift indices — the cause of an early
+  `extern.convert_any expected anyref, found call of type f64` invalid module).
+
+## Test Results (2026-06-16)
+
+`tests/issue-2025.test.ts` — 7/7 pass:
+- extracted this-using method → catchable "threw" (acceptance criterion)
+- caught value `instanceof TypeError` → true
+- extracted this-using method with args → catchable
+- direct call `a.m()` → 42 (unchanged)
+- extracted `this`-free method → 7 (no spurious throw)
+- value-receiver dispatch `o.m()` after extraction → 42 (no regression)
+- standalone mode → catchable "threw"
+
+Regression check (worktree vs. clean baseline): #1118, #1394, #1602,
+#1602-regress-direct-call, #1636s1, #1636-s1-tojson, #1702, #1672 async-gen
+trampoline, generator-methods/-destructuring all pass. The few file-level
+failures (`classes.test.ts`, `class-methods.test.ts`, `class-method-calls.test.ts`
+`string_constants` harness-stub; `object-literal-getters-setters > setter
+stores value`) reproduce IDENTICALLY on clean origin/main — pre-existing, not
+caused by this change. typecheck / lint / format all clean.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -57,7 +57,12 @@ import {
   compileStatement,
 } from "./statements.js";
 import { coercionInstrs, emitGuardedRefCast } from "./type-coercion.js";
-import { buildDestructureNullThrow, isNullOrUndefinedLiteral } from "./destructuring-params.js";
+import {
+  buildDestructureNullThrow,
+  buildTypeErrorThrow,
+  ensureTypeErrorThrowImports,
+  isNullOrUndefinedLiteral,
+} from "./destructuring-params.js";
 import {
   cacheParamDefaultArgc,
   emitF64ParamSentinelCheck,
@@ -67,6 +72,7 @@ import {
   paramDefaultNeedsArgc,
 } from "./statements/nested-declarations.js";
 import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-builder.js";
+import { walkInstructions } from "./walk-instructions.js";
 
 // ── Arrow function callbacks ──────────────────────────────────────────
 
@@ -3442,6 +3448,35 @@ export function emitFuncRefAsClosure(
 }
 
 /**
+ * (#2025) Does the compiled method body read its `this` param (local index 0)?
+ *
+ * Method bodies always carry `this` as param 0 (`self_obj`); user params start
+ * at 1. Locals are function-scoped in Wasm, so a `local.get 0` anywhere in the
+ * body — including nested block/if/loop/try arms (walked recursively) — is a
+ * read of `this`. If the body never reads it, an unbound-extraction null `this`
+ * is harmless and must be forwarded as-is; if it does, a null `this` would trap
+ * on the eventual `struct.get`, so the trampoline must throw a catchable
+ * TypeError instead (see `buildTrampolineThisSlot`). Inner closures that capture
+ * `this` read `local.get 0` in THIS body before boxing it, so they are covered.
+ *
+ * `methodFuncIdx` is a global function index; the defined-function body lives at
+ * `methodFuncIdx - numImportFuncs`. Returns `false` (forward null) when the
+ * target is an import or the body is unavailable.
+ */
+function methodReadsThisParam(ctx: CodegenContext, methodFuncIdx: number): boolean {
+  const localIdx = methodFuncIdx - ctx.numImportFuncs;
+  if (localIdx < 0) return false; // import target — no body to inspect.
+  const func = ctx.mod.functions[localIdx];
+  if (!func || !Array.isArray(func.body)) return false;
+  let reads = false;
+  walkInstructions(func.body, (instr) => {
+    const a = instr as { op?: string; index?: number };
+    if (a.op === "local.get" && a.index === 0) reads = true;
+  });
+  return reads;
+}
+
+/**
  * (#2015) Build the `this`-slot prologue for an object-method trampoline.
  *
  * Object-literal / cached method trampolines bridge the closure-value ABI
@@ -3455,19 +3490,44 @@ export function emitFuncRefAsClosure(
  * trap (the issue's bare `WebAssembly.Exception`).
  *
  * Read `__current_this` instead and use it as `this` when it `ref.test`s as the
- * method's object struct; otherwise fall back to `ref.null` (preserving the
- * unbound-extraction semantics, since plain `__call_fn_N` dispatch leaves the
- * global null). This mirrors the null-guarded `__current_this` read that lifted
+ * method's object struct; otherwise the receiver is the spec's `undefined`
+ * (unbound method extraction `var f = o.m; f()` in strict/module code).
+ *
+ * (#2025) When the method body actually dereferences `this` (`methodUsesThis`),
+ * the `else` arm — the null-receiver case — throws a catchable JS `TypeError`
+ * instead of forwarding `ref.null` into the body, where the subsequent
+ * `struct.get` would TRAP uncatchably ("dereferencing a null pointer") and
+ * escape the user's `try/catch`. This matches `this.x` on `undefined` in Node.
+ * When the method NEVER reads `this` (`methodUsesThis === false`, e.g. the
+ * test262 yield-star pattern or `const f = obj.m` where `m` ignores `this`), the
+ * null receiver is harmless, so the `else` arm keeps forwarding `ref.null` and
+ * the extracted call succeeds — throwing there would be a spec-incorrect
+ * regression.
+ *
+ * The `then` arm mirrors the null-guarded `__current_this` read that lifted
  * closure bodies already use for `ThisKeyword` (`expressions.ts`, #1702).
  *
  * `anyTempLocalIdx` must reference a spare `anyref` local appended to the
- * trampoline. Emits a sequence leaving exactly one `(ref null objStructTypeIdx)`
- * on the stack.
+ * trampoline. `fctx` (when present) keeps the throw's late-import `call` indices
+ * in lockstep with subsequent import additions. Emits a sequence leaving exactly
+ * one `(ref null objStructTypeIdx)` on the stack on the non-throwing arm.
  */
-function buildTrampolineThisSlot(ctx: CodegenContext, objStructTypeIdx: number, anyTempLocalIdx: number): Instr[] {
+function buildTrampolineThisSlot(
+  ctx: CodegenContext,
+  objStructTypeIdx: number,
+  anyTempLocalIdx: number,
+  methodUsesThis: boolean,
+  fctx?: FunctionContext,
+): Instr[] {
   const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
   const nullThis: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx } as Instr];
-  if (currentThisGlobalIdx < 0) return nullThis;
+  // #2025 — unbound extraction with a `this`-dereferencing body: throw a
+  // catchable TypeError rather than letting the body trap on `struct.get` of a
+  // null `this`. A body that never reads `this` keeps the harmless null.
+  const undefinedThis: Instr[] = methodUsesThis
+    ? buildTypeErrorThrow(ctx, "Cannot read properties of undefined (reading 'this')", fctx)
+    : nullThis;
+  if (currentThisGlobalIdx < 0) return undefinedThis;
   return [
     { op: "global.get", index: currentThisGlobalIdx } as Instr,
     { op: "any.convert_extern" } as Instr,
@@ -3480,7 +3540,10 @@ function buildTrampolineThisSlot(ctx: CodegenContext, objStructTypeIdx: number, 
         { op: "local.get", index: anyTempLocalIdx } as Instr,
         { op: "ref.cast", typeIdx: objStructTypeIdx } as Instr,
       ],
-      else: nullThis,
+      // When `methodUsesThis`, the throw is stack-polymorphic, so the `if`
+      // block's declared `(ref null objStruct)` result is satisfied on this arm
+      // without pushing a value; otherwise it pushes the harmless `ref.null`.
+      else: undefinedThis,
     } as unknown as Instr,
   ];
 }
@@ -3537,7 +3600,11 @@ export function emitObjectMethodAsClosure(
   const trampolineName = `__obj_meth_tramp_${methodName}_${ctx.closureCounter++}`;
   // anyref temp at the first slot past the params (closure_self + userParams).
   const anyTempLocalIdx = 1 + userParams.length;
-  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
+  // (#2025) Placeholder body: pass `methodUsesThis=false` so this initial emit
+  // stays a simple `ref.null` slot. `finalizeMethodTrampolines` rebuilds the
+  // authoritative body (with the throw, if the method reads `this`) once the
+  // method's final signature and compiled body are available.
+  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx, false);
   for (let i = 0; i < userParams.length; i++) {
     // Skip closure_self at param 0; user params start at index 1
     trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
@@ -3596,6 +3663,15 @@ export function emitObjectMethodAsClosure(
  * coercion the call needs is applied by mirroring the method's param types.
  */
 export function finalizeMethodTrampolines(ctx: CodegenContext): void {
+  // (#2025) If any method trampoline reads `this`, its null-receiver arm throws
+  // a catchable TypeError. Pre-register that throw's imports ONCE here, before
+  // the loop forwards `call methodFuncIdx` at pre-shift indices — adding the
+  // import mid-loop would shift indices and corrupt already-built forwarding
+  // calls. After this, the in-loop `ensureLateImport` is a no-op lookup.
+  const anyMethodReadsThis = ctx.pendingMethodTrampolines.some(
+    (t) => !t.noThisParam && methodReadsThisParam(ctx, t.methodFuncIdx),
+  );
+  if (anyMethodReadsThis) ensureTypeErrorThrowImports(ctx);
   for (const t of ctx.pendingMethodTrampolines) {
     // (#1525b / #1809) If the captured methodFuncIdx resolves to an IMPORT at
     // finalize (< ctx.numImportFuncs), there are two distinct cases:
@@ -3689,17 +3765,25 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
     };
 
     // (#1340) Function-decl trampolines have no `this` prologue; method
-    // trampolines resolve the receiver from `__current_this` (#2015, falling
-    // back to `ref.null` for the unbound method-extraction case) before
-    // forwarding user params. The anyref scratch local is allocated through
-    // `tFctx` so it lands in `localDefs` (attached to the registered function
-    // below) and any later coercion temps allocate after it.
+    // trampolines resolve the receiver from `__current_this` (#2015), and
+    // (#2025) throw a catchable TypeError on the unbound-extraction null-`this`
+    // arm rather than letting the body trap, before forwarding user params. The
+    // anyref scratch local is allocated through `tFctx` so it lands in
+    // `localDefs` (attached to the registered function below) and any later
+    // coercion temps allocate after it. `tFctx` is passed so the throw's
+    // late-import `call` indices stay in lockstep with import additions — this
+    // finalize pass is the authoritative body, run after method signatures
+    // resolve (the initial emit's body is a placeholder it overwrites).
     let newBody: Instr[];
     if (t.noThisParam) {
       newBody = [];
     } else {
       const anyTempLocalIdx = allocTempLocal(tFctx, { kind: "anyref" });
-      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx);
+      // (#2025) Inspect the now-final method body: only throw on a null `this`
+      // when the body actually reads it (`local.get 0`); a body that ignores
+      // `this` keeps forwarding the harmless null so extraction still works.
+      const methodUsesThis = methodReadsThisParam(ctx, t.methodFuncIdx);
+      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx, methodUsesThis, tFctx);
     }
     for (let i = 0; i < methodUserParams.length; i++) {
       newBody.push({ op: "local.get", index: i + 1 } as Instr);
@@ -3835,13 +3919,14 @@ export function emitCachedMethodClosureAccess(
   let trampolineFuncIdx = ctx.funcMap.get(trampolineName);
   if (trampolineFuncIdx === undefined) {
     // Trampoline body: drop the closure-self arg (param 0), resolve the
-    // method's `this` from `__current_this` (#2015 — falls back to
-    // `ref.null` for the unbound method-extraction case `var fn = c.m;
-    // fn();` where JS strict mode calls with `this = undefined`, so the
-    // null receiver propagates the spec-mandated TypeError on `this.field`
-    // access), then forward user params, then call the method.
+    // method's `this` from `__current_this` (#2015 — for the unbound
+    // method-extraction case `var fn = c.m; fn();` where JS strict mode calls
+    // with `this = undefined`). (#2025) `finalizeMethodTrampolines` rebuilds
+    // this body and, if the method reads `this`, swaps the null arm for a
+    // catchable TypeError throw (a null receiver would otherwise trap on
+    // `struct.get`); this initial placeholder passes `methodUsesThis=false`.
     const anyTempLocalIdx = 1 + userParams.length;
-    const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
+    const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx, false);
     for (let i = 0; i < userParams.length; i++) {
       trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
     }

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -255,7 +255,47 @@ function boxToExternref(ctx: CodegenContext, elemKey: string): Instr[] {
 }
 
 export function buildDestructureNullThrow(ctx: CodegenContext, fctx?: FunctionContext): Instr[] {
-  const msg = "Cannot destructure 'null' or 'undefined'";
+  return buildTypeErrorThrow(ctx, "Cannot destructure 'null' or 'undefined'", fctx);
+}
+
+/**
+ * (#2025) Pre-register the imports `buildTypeErrorThrow` will resolve, WITHOUT
+ * emitting any body. Call this once before a pass that may emit several throws
+ * (e.g. `finalizeMethodTrampolines`, which forwards `call methodFuncIdx` at
+ * pre-shift indices): adding a NEW late import mid-pass shifts every function
+ * index, but only the body whose `fctx` is flushed gets reshifted, leaving the
+ * other already-built forwarding `call`s pointing at the wrong function. Ensuring
+ * the import up front makes each in-loop `ensureLateImport` a no-op lookup (the
+ * name is already in `funcMap`), so no shift happens during the pass.
+ *
+ * Idempotent: `emitWasiErrorConstructor` / `ensureLateImport` no-op when the
+ * name already exists.
+ */
+export function ensureTypeErrorThrowImports(ctx: CodegenContext): void {
+  if (ctx.wasi || ctx.standalone) {
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+    ensureLateImport(ctx, "__new_TypeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  } else {
+    ensureLateImport(ctx, "__throw_type_error", [{ kind: "externref" }], []);
+  }
+}
+
+/**
+ * #2025 — Build a catchable JS `TypeError` throw as a standalone `Instr[]`
+ * (does not push into `fctx.body`). Generalises `buildDestructureNullThrow`'s
+ * proven late-import-safe throw lowering so other null/undefined-receiver sites
+ * (e.g. the method-extraction trampoline's null-`this` slot) can throw a
+ * catchable TypeError instead of trapping on a later `struct.get`.
+ *
+ * Pass `fctx` whenever the instructions are emitted into a function body whose
+ * later `call` indices must stay in lockstep with import additions — the helper
+ * calls `flushLateImportShifts(ctx, fctx)` before snapshotting the resolved
+ * `__new_TypeError` / `__throw_type_error` funcIdx (a raw `funcMap.get` snapshot
+ * goes stale when a subsequent import shifts the index). Without an `fctx`, it
+ * degrades to a bare `throw` of the message string under the shared `$exc` tag
+ * (still observable / catchable, just not constructor-matching).
+ */
+export function buildTypeErrorThrow(ctx: CodegenContext, msg: string, fctx?: FunctionContext): Instr[] {
   addStringConstantGlobal(ctx, msg);
   // #1623 — in nativeStrings mode (wasi / standalone) `stringGlobalMap` holds a
   // `-1` sentinel rather than a real import-global index, so a bare

--- a/tests/issue-2025.test.ts
+++ b/tests/issue-2025.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2025 — calling an extracted method (`const f = a.m; f()`) whose body
+// dereferences `this` trapped uncatchably ("dereferencing a null pointer")
+// instead of throwing a catchable TypeError. The method-extraction trampoline
+// (`buildTrampolineThisSlot` in closures.ts) forwarded `ref.null` for `this`,
+// so the method's `this.x` `struct.get` trapped and escaped the user's
+// try/catch. The fix: when the method body actually reads `this` (`local.get 0`),
+// the trampoline's null-receiver arm throws a catchable JS TypeError; methods
+// that never touch `this` keep forwarding the harmless null so extraction of a
+// `this`-free method still works.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function compileSrc(source: string, opts: Record<string, unknown> = {}) {
+  const result = await compile(source, opts as never);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  return result;
+}
+
+async function run(source: string, fn = "test", opts: Record<string, unknown> = {}): Promise<unknown> {
+  const result = await compileSrc(source, opts);
+  const imports = buildImports(result.imports, ENV_STUB, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!();
+}
+
+describe("#2025 — extracted-method null-this throws a catchable TypeError", () => {
+  it("extracting a this-using method and calling it is catchable (not a trap)", async () => {
+    const src = `
+      class A { x = 42; m(): number { return this.x; } }
+      export function test(): string {
+        const a = new A();
+        const f = a.m;
+        try { return "got:" + f(); } catch (e) { return "threw"; }
+      }
+    `;
+    // Node: TypeError "Cannot read properties of undefined" → "threw".
+    // Previously this trapped uncatchably and the exception escaped to the host.
+    expect(await run(src)).toBe("threw");
+  });
+
+  it("the caught value is a real TypeError instance", async () => {
+    const src = `
+      class A { x = 42; m(): number { return this.x; } }
+      export function test(): string {
+        const a = new A();
+        const f = a.m;
+        try { f(); return "no-throw"; }
+        catch (e) { return (e instanceof TypeError) ? "TypeError" : "other"; }
+      }
+    `;
+    expect(await run(src)).toBe("TypeError");
+  });
+
+  it("extracted this-using method with arguments still throws catchably", async () => {
+    const src = `
+      class A { x = 5; m(n: number): number { return this.x + n; } }
+      export function test(): string {
+        const a = new A();
+        const f = a.m;
+        try { return "v" + f(10); } catch { return "threw"; }
+      }
+    `;
+    expect(await run(src)).toBe("threw");
+  });
+
+  it("direct method calls are unchanged (valid receiver)", async () => {
+    const src = `
+      class A { x = 42; m(): number { return this.x; } }
+      export function test(): number {
+        const a = new A();
+        return a.m();
+      }
+    `;
+    expect(await run(src)).toBe(42);
+  });
+
+  it("extracting a method that does NOT use this still works (no spurious throw)", async () => {
+    const src = `
+      class A { m(): number { return 7; } }
+      export function test(): number {
+        const a = new A();
+        const f = a.m;
+        return f();
+      }
+    `;
+    expect(await run(src)).toBe(7);
+  });
+
+  it("method dispatch through a value receiver is unchanged", async () => {
+    const src = `
+      class A { x = 42; m(): number { return this.x; } }
+      export function test(): number {
+        const a = new A();
+        const _extracted = a.m; // forces the extraction trampoline to exist
+        const o: any = a;
+        return o.m(); // dispatched with a real receiver → 42
+      }
+    `;
+    expect(await run(src)).toBe(42);
+  });
+
+  it("standalone mode: extracted this-using method throws catchably", async () => {
+    const src = `
+      class A { x = 42; m(): number { return this.x; } }
+      export function test(): string {
+        const a = new A();
+        const f = a.m;
+        try { f(); return "no-throw"; } catch (e) { return "threw"; }
+      }
+    `;
+    expect(await run(src, "test", { standalone: true })).toBe("threw");
+  });
+});


### PR DESCRIPTION
## #2025 — extracted-method null-`this` traps uncatchably

```ts
class A { x = 42; m(): number { return this.x; } }
const a = new A(); const f = a.m;
try { return "got:" + f(); } catch (e) { return "threw"; }
// before: wasm trap "dereferencing a null pointer" ESCAPES the try/catch
// node:   "threw" (TypeError: this is undefined)
```

The method-extraction trampoline (`buildTrampolineThisSlot`, `closures.ts` —
shared by the object-literal, cached class-method, and per-call-site paths, all
rebuilt by `finalizeMethodTrampolines`) forwarded `ref.null` for the unbound
`this`. The method body's `this.x` then did `struct.get` on a null ref → an
**uncatchable Wasm trap** that escaped the user's `try/catch`.

### Fix
- When the method body **actually reads `this`** (`local.get 0`, detected by
  `methodReadsThisParam` walking the now-final compiled body via
  `walkInstructions`), the trampoline's null-receiver arm throws a **catchable
  JS TypeError**. When the method never touches `this`, it keeps forwarding the
  harmless `ref.null`, so extracting a `this`-free method still works (the
  issue's required non-regression case).
- `buildTypeErrorThrow(ctx, msg, fctx?)` generalises `buildDestructureNullThrow`
  (`destructuring-params.ts`) — a JS-host + standalone (`__new_TypeError` /
  `__throw_type_error`) catchable throw as `Instr[]`.
- `ensureTypeErrorThrowImports` pre-registers the throw's late imports **once**
  before the `finalizeMethodTrampolines` loop, so adding them mid-loop can't
  shift the already-built `call methodFuncIdx` forwarders (invalid-module
  hazard I hit during development).

### Acceptance criteria — verified
- ✅ Repro returns "threw" with a real `TypeError` (`e instanceof TypeError`)
- ✅ bound/direct calls unchanged (`a.m()` → 42)
- ✅ extracting a `this`-free method still works (no spurious throw)
- ✅ value-receiver method dispatch unchanged; standalone mode works

`tests/issue-2025.test.ts` — 7/7. No regressions vs. baseline across the
trampoline / `this` / generator-method suites (#1118, #1394, #1602, #1636,
#1702, #1672, generator-methods). typecheck / lint / format clean.

Sets issue #2025 `status: done` (self-merge path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)