### PR TITLE
docs(#2025): record attempt-1 findings (trampoline-throw reverted, 75 regressions)

### DIFF
--- a/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
+++ b/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
@@ -52,3 +52,39 @@ instead of trapping.
 
 #1949 (call/apply thisArg) adjacent but distinct; #581 is the general
 family. New.
+
+## Attempt 1 — trampoline-level throw REVERTED (2026-06-16)
+
+First attempt (PR #1571, closed unmerged) emitted the catchable TypeError in
+the method-extraction trampoline `buildTrampolineThisSlot` (`src/codegen/
+closures.ts`), gated on whether the method body reads `this` (`local.get 0`,
+detected by walking the compiled body). It passed 11 hand-written repros
+(extracted-this, args, generator/async/HOF extraction, inheritance dispatch)
+but the test262 regression gate caught **75 regressions** (net -75 pass, 0
+improvements, 71/75 with a wasm-hash change → real, not drift): `wasm_compile`
+40 (malformed modules), `runtime_error` 35.
+
+**Why it's the wrong layer:** `buildTrampolineThisSlot` is a SHARED, fragile
+path. The same trampoline is reached not only by unbound extraction but by:
+- the #2015 `__call_fn_method_N` method-dispatch path (which installs the
+  receiver into `__current_this`), and
+- the #1602/#1636 finalize/re-resolve paths.
+Its null-`this` arm (`__current_this` doesn't `ref.test` as the EXACT object
+struct) fires for legitimate calls too — e.g. a receiver that is a subclass /
+boxed / structurally-distinct instance. Throwing there breaks valid method
+calls and, combined with the late-import/index-shift sensitivity of the
+finalize rebuild, emits malformed Wasm in a class of cases the hand repros
+didn't cover.
+
+**Recommendation for attempt 2:** do NOT throw in the trampoline. Move the
+catchable-TypeError emission to the **`this`-dereference site** in the method
+body (guard the `local.get 0; struct.get` of `this` against null with a
+TypeError throw) so it fires only when a genuinely-null `this` is actually
+dereferenced, independent of which dispatch path reached the method. That is
+narrower and path-agnostic. Reference branch (preserved):
+`origin/issue-2025-extracted-method-typeerror` (has `buildTypeErrorThrow` in
+`destructuring-params.ts` + tests/issue-2025.test.ts, both reusable).
+
+Given #2025 is `priority: low`, this is parked back at `ready` pending a
+this-deref-site approach; not worth iterating against the invisible regressed
+cluster under the trampoline approach.


### PR DESCRIPTION
Documents why the first #2025 attempt (PR #1571, closed unmerged) was reverted
and what attempt 2 should do differently. Docs-only — issue stays `status: ready`.

PR #1571 emitted the catchable TypeError in the shared method-extraction
trampoline (`buildTrampolineThisSlot`), which is also reached via #2015
`__call_fn_method_N` dispatch and the #1602/#1636 finalize paths. Its
null-`this` arm fires for legitimate calls (subclass/boxed/structurally-distinct
receivers), not just unbound extraction → **75 test262 regressions** (40
malformed Wasm, 35 runtime errors; 71/75 with a wasm-hash change, so real).

Recommendation captured in the issue: attempt 2 should throw at the
**`this`-dereference site** in the method body (path-agnostic), not the
trampoline. The reference branch `origin/issue-2025-extracted-method-typeerror`
is preserved (reusable `buildTypeErrorThrow` + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)