### PR TITLE
test(#1854): cross-backend differential harness (WasmGC vs linear)

### DIFF
--- a/plan/issues/1854-cross-backend-differential-testing.md
+++ b/plan/issues/1854-cross-backend-differential-testing.md
@@ -1,10 +1,12 @@
 ---
 id: 1854
 title: "Cross-backend differential testing harness — same TS to WasmGC / linear / bytecode-VM must produce identical observable output"
-status: ready
+status: done
+assignee: ttraenkler/tld-2139
 sprint: 63
 created: 2026-06-04
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -58,3 +60,67 @@ like the optimize lane — most of the 104 corpus programs won't compile on
 linear yet, so baseline the gap and gate the delta. The bytecode-VM leg is
 demoted to "where applicable" (it is test-only today). Prerequisite: #2139
 (linear tests in CI at all). Scheduled sprint 62.
+
+## Resolution (2026-06-16)
+
+### Design pivot — the stdout lane is infeasible
+
+The sprint-62 amendment's `DIFF_TEST_TARGET=linear` stdout lane in
+`scripts/diff-test.ts` **cannot work**: the diff-test corpus is 100 %
+stdout-driven (`console.log`), but the linear backend (`target: "linear"`,
+non-WASI) has **no `console.log` host import** — a linear-compiled program
+emits zero imports and no output mechanism in the WAT, so it runs but prints
+nothing (verified). Diffing linear-stdout vs the V8 oracle would mark all
+~100 corpus programs as false mismatches.
+
+The linear backend's observable surface is the **exported function return
+value** — exactly what `tests/linear-*.test.ts` already assert (they
+instantiate with no imports and check return values). So the harness diffs
+**return values across backends**, which transitively diffs against the V8
+oracle (the WasmGC lane already tracks it via the equivalence suite) and is
+the design the linear backend actually supports.
+
+### What landed
+
+- **`tests/cross-backend/corpus.ts`** — a structured, data-driven corpus
+  (12 programs across numeric / control / string / array / object / closure)
+  of self-contained TS modules exporting functions + the arg tuples to call.
+  Seeded from the equivalence-corpus feature areas requested by AC #2.
+- **`tests/cross-backend-diff.test.ts`** — compiles each program to BOTH
+  WasmGC and linear, invokes every declared call on both, and asserts
+  identical return values (`toStrictEqual`). A divergence fails with a
+  per-call repro pointer: `program :: fn(args) — WasmGC returned X but linear
+  returned Y`.
+- **Gap baseline + ratchet (no frozen file).** Programs the linear backend
+  does not yet compile are flagged `expectLinearUnsupported` and skipped from
+  the diff — BUT the harness still asserts they remain unsupported, so the
+  moment linear gains support the assertion flips and forces removing the flag
+  (the gap can only shrink, never silently grow). Currently flagged:
+  `numeric/math-trunc` (Math.trunc), `string/charcode` (charCodeAt),
+  `closure/counter` (arrow closures).
+- **CI wiring** — runs in the normal vitest suite (~5.5 s); no dedicated
+  workflow needed.
+
+### Acceptance criteria — verified
+
+- ✅ **Helper compiles a TS source to WasmGC and linear and diffs observable
+  results (return value)** — `run(program, backend)` + `invoke()` in the test;
+  bytecode-VM leg correctly demoted to "where applicable" (test-only today).
+- ✅ **Seeded from a representative corpus** (numeric kernels, strings, arrays,
+  control flow, objects, closures).
+- ✅ **A divergence fails the test with a minimal-enough repro pointer** —
+  confirmed by injecting a forced mismatch: the test fails with the
+  `Cross-backend DIVERGENCE in numeric/arithmetic :: arith() — WasmGC returned
+  5 but linear returned 6` message (full minimization remains #1855).
+- ✅ **Wired into CI; runtime modest** — 15 tests, ~5.5 s, in the vitest suite.
+
+### Tests — `tests/cross-backend-diff.test.ts` (15, all pass)
+
+11 programs diffed across backends (all agree), 3 `expectLinearUnsupported`
+skipped-but-asserted-still-unsupported, 1 corpus-shape sanity check.
+
+### Follow-ups
+
+- Grow the corpus as the linear backend gains features (drop the
+  `expectLinearUnsupported` flags as Math.*, charCodeAt, closures land).
+- #1855 (minimization) and the bytecode-VM leg remain future work.

--- a/plan/issues/1854-cross-backend-differential-testing.md
+++ b/plan/issues/1854-cross-backend-differential-testing.md
@@ -53,13 +53,29 @@ trait-migration work (#1851).
 
 ## Sprint-62 planning amendment (2026-06-12)
 
-Concretized approach: implement as a `DIFF_TEST_TARGET=linear` lane in
+> **Superseded during implementation (2026-06-16).** The approach below was
+> found infeasible and replaced — see the Resolution section. Kept for history.
+
+~~Concretized approach: implement as a `DIFF_TEST_TARGET=linear` lane in
 `scripts/diff-test.ts` against the same V8 oracle (oracle-agreement per
 backend ⇒ cross-backend agreement transitively), with a per-lane baseline
 like the optimize lane — most of the 104 corpus programs won't compile on
-linear yet, so baseline the gap and gate the delta. The bytecode-VM leg is
+linear yet, so baseline the gap and gate the delta.~~ **This stdout lane is
+infeasible: the linear backend (`target:"linear"`, non-WASI) has no
+`console.log` host import and silently drops stdout (see Resolution), so the
+stdout-driven diff-test corpus cannot exercise it.** The bytecode-VM leg is
 demoted to "where applicable" (it is test-only today). Prerequisite: #2139
 (linear tests in CI at all). Scheduled sprint 62.
+
+**Shipped approach (2026-06-16):** a **return-value** cross-backend
+differential (`tests/cross-backend-diff.test.ts` + `tests/cross-backend/
+corpus.ts`) — compile each corpus program to both WasmGC and linear and assert
+identical exported-function return values. The linear backend is
+return-value-oriented (its only observable without WASI), and WasmGC↔linear
+return-value agreement is transitively agreement with the V8 oracle the WasmGC
+lane already tracks. The "baseline the gap" intent is preserved via
+`expectLinearUnsupported` per-program skips (assert-still-unsupported, so the
+gap can only shrink). Full design + rationale in the Resolution section below.
 
 ## Resolution (2026-06-16)
 

--- a/tests/cross-backend-diff.test.ts
+++ b/tests/cross-backend-diff.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1854 — Cross-backend differential testing harness.
+ *
+ * The `tests/equivalence/` suite compiles-and-runs each program against a V8/TS
+ * reference oracle — but only on ONE backend per test. We now have multiple
+ * lowering paths (WasmGC `target:"gc"` and linear-memory `target:"linear"`),
+ * and nothing asserted they agree with EACH OTHER. A backend-specific lowering
+ * bug that produces wrong-but-not-crashing output can pass the single-oracle
+ * test on whichever backend it happened to run.
+ *
+ * This harness closes that gap: every corpus program is compiled to BOTH
+ * backends and their exported functions' return values are diffed. Because the
+ * WasmGC lane already tracks the V8 oracle (the equivalence suite), agreement
+ * between WasmGC and linear is transitively agreement with the oracle — so a
+ * divergence here is a genuine cross-backend lowering bug.
+ *
+ * Observable surface = return value (NOT stdout): the linear backend has no
+ * `console.log` host import (it silently drops console output), so its only
+ * observable is the function return value — exactly what tests/linear-*.test.ts
+ * assert. See tests/cross-backend/corpus.ts for the full rationale.
+ *
+ * The linear backend is incomplete, so many programs don't compile on it yet.
+ * Those are marked `expectLinearUnsupported` and SKIPPED from the diff (the gap
+ * is baselined, not gated) — but the harness still asserts they remain
+ * unsupported, so the moment linear gains support the flag must be removed
+ * (ratchet down). Only programs that compile on BOTH backends are diffed; a
+ * divergence fails the test with a per-call repro pointer.
+ *
+ * Runtime is modest (compile each program twice + invoke a handful of calls),
+ * so this runs in the normal vitest suite — no dedicated workflow needed.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+import { CROSS_BACKEND_CORPUS, type CrossBackendProgram } from "./cross-backend/corpus.js";
+
+type Backend = "gc" | "linear";
+
+interface CompileRun {
+  /** false when the backend did not compile the program. */
+  ok: boolean;
+  /** Compile-error message when `ok` is false. */
+  error?: string;
+  /** Exported functions, present when `ok`. */
+  exports?: Record<string, (...a: unknown[]) => unknown>;
+}
+
+/** Compile + instantiate a program on one backend, ready to invoke exports. */
+async function run(program: CrossBackendProgram, backend: Backend): Promise<CompileRun> {
+  const result = await compile(program.source, backend === "linear" ? { target: "linear" } : {});
+  if (!result.success) {
+    return { ok: false, error: result.errors[0]?.message ?? "unknown compile error" };
+  }
+  try {
+    if (backend === "linear") {
+      // Linear modules are self-contained (no host imports).
+      const { instance } = await WebAssembly.instantiate(result.binary);
+      return { ok: true, exports: instance.exports as CompileRun["exports"] };
+    }
+    // WasmGC modules use js-string + host imports built by the runtime helper.
+    const built = buildImports(result.imports, {}, result.stringPool);
+    const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+    built.setExports?.(instance.exports as Record<string, Function>);
+    return { ok: true, exports: instance.exports as CompileRun["exports"] };
+  } catch (e) {
+    return { ok: false, error: `instantiate/runtime: ${(e as Error).message ?? String(e)}` };
+  }
+}
+
+/** Invoke `call` and capture its return value or a thrown-error marker. */
+function invoke(exports: CompileRun["exports"], fn: string, args: readonly (number | boolean)[]): unknown {
+  const f = exports?.[fn];
+  if (typeof f !== "function") return `<no-export:${fn}>`;
+  try {
+    return f(...args);
+  } catch (e) {
+    return `<threw:${(e as Error).message ?? String(e)}>`;
+  }
+}
+
+describe("#1854 cross-backend differential (WasmGC vs linear)", () => {
+  for (const program of CROSS_BACKEND_CORPUS) {
+    it(`${program.name}: WasmGC and linear agree on every call`, async () => {
+      const gc = await run(program, "gc");
+      // The WasmGC lane is the primary target; if it can't compile/run the
+      // program the corpus entry itself is broken — fail loudly.
+      expect(gc.ok, `WasmGC backend failed to compile/run ${program.name}: ${gc.error}`).toBe(true);
+
+      const linear = await run(program, "linear");
+
+      if (program.expectLinearUnsupported) {
+        // The gap is baselined: linear is not expected to compile this yet, so
+        // we skip the diff. But assert it STILL fails — if linear gained
+        // support, this assertion flips and prompts removing the flag (so the
+        // unsupported gap can only shrink, never silently grow).
+        expect(
+          linear.ok,
+          `${program.name} is flagged expectLinearUnsupported but now compiles+runs on linear — ` +
+            `remove the flag so this program is differentially gated.`,
+        ).toBe(false);
+        return;
+      }
+
+      // Not flagged ⇒ linear must compile and run. A new linear compile error
+      // on a previously-supported program is itself a regression to surface.
+      expect(linear.ok, `linear backend failed to compile/run ${program.name}: ${linear.error}`).toBe(true);
+
+      for (const call of program.calls) {
+        const argStr = `${call.fn}(${call.args.join(", ")})`;
+        const gcVal = invoke(gc.exports, call.fn, call.args);
+        const linVal = invoke(linear.exports, call.fn, call.args);
+        expect(
+          linVal,
+          `Cross-backend DIVERGENCE in ${program.name} :: ${argStr} — ` +
+            `WasmGC returned ${JSON.stringify(gcVal)} but linear returned ${JSON.stringify(linVal)}. ` +
+            `One backend's lowering is wrong (the equivalence suite only runs one backend per test, so it missed this).`,
+        ).toStrictEqual(gcVal);
+      }
+    });
+  }
+
+  it("corpus is non-empty and every program declares at least one call", () => {
+    expect(CROSS_BACKEND_CORPUS.length).toBeGreaterThan(0);
+    for (const p of CROSS_BACKEND_CORPUS) {
+      expect(p.calls.length, `${p.name} has no calls`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/cross-backend/corpus.ts
+++ b/tests/cross-backend/corpus.ts
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1854 — Cross-backend differential corpus.
+ *
+ * Each entry is a self-contained TS program that exports one or more functions,
+ * plus the argument tuples to invoke them with. The cross-backend harness
+ * (`tests/cross-backend-diff.test.ts`) compiles every program to BOTH the
+ * WasmGC and the linear-memory backend, invokes each `call`, and asserts the
+ * two backends return identical observable values.
+ *
+ * Why return values, not stdout: the linear backend (`target: "linear"`,
+ * non-WASI) has no `console.log` host import — it silently drops console
+ * output (verified: a linear-compiled program prints nothing). Its observable
+ * surface is the exported function's return value, which is exactly what
+ * tests/linear-*.test.ts already assert. So the differential is over return
+ * values: a divergence here is a genuine backend-lowering bug (numeric layout,
+ * boxing, control-flow) that the single-oracle equivalence suite can miss
+ * because it only runs one backend per test.
+ *
+ * Categories mirror the equivalence corpus seed requested by the issue:
+ * numeric kernels, strings, arrays, control flow, objects, closures.
+ *
+ * `expectLinearUnsupported: true` marks a program that the linear backend does
+ * not yet compile (e.g. closures, some object shapes). The harness records it
+ * as a skip (NOT a divergence) so the gate "baselines the gap" the way the
+ * issue's sprint-62 amendment intended — only programs that compile on BOTH
+ * backends are diffed. If such a program later starts compiling on linear, the
+ * harness reports it so the flag can be removed (ratchet direction).
+ */
+
+export interface CrossBackendCall {
+  /** Exported function name to invoke. */
+  readonly fn: string;
+  /** Argument tuple (numbers/booleans cross the JS↔Wasm boundary natively). */
+  readonly args: readonly (number | boolean)[];
+}
+
+export interface CrossBackendProgram {
+  /** Stable id, used in test names and divergence reports. */
+  readonly name: string;
+  /** Category bucket (numeric/string/array/control/object/closure). */
+  readonly category: string;
+  /** Self-contained TS source. */
+  readonly source: string;
+  /** Functions + args to invoke and diff across backends. */
+  readonly calls: readonly CrossBackendCall[];
+  /**
+   * Set when the linear backend does not yet compile this program. The harness
+   * skips it (not a divergence) but asserts it STILL fails to compile on linear
+   * — if linear gains support, the assertion flips and prompts removing the
+   * flag (so the gap baseline ratchets down rather than silently rotting).
+   */
+  readonly expectLinearUnsupported?: boolean;
+}
+
+export const CROSS_BACKEND_CORPUS: readonly CrossBackendProgram[] = [
+  // ── numeric kernels ──────────────────────────────────────────────────────
+  {
+    name: "numeric/arithmetic",
+    category: "numeric",
+    source: `
+      export function arith(): number { return 1 + 2 * 3 - 4 / 2; }
+      export function precedence(): number { return (1 + 2) * (3 - 1) / 2; }
+      export function negate(x: number): number { return -x; }
+    `,
+    calls: [
+      { fn: "arith", args: [] },
+      { fn: "precedence", args: [] },
+      { fn: "negate", args: [7] },
+      { fn: "negate", args: [-3] },
+    ],
+  },
+  {
+    name: "numeric/integer-ops",
+    category: "numeric",
+    source: `
+      export function mod(a: number, b: number): number { return a % b; }
+      export function bitwise(): number { return (0xff & 0x0f) | (1 << 4); }
+      export function shifts(x: number): number { return (x << 2) >> 1; }
+    `,
+    calls: [
+      { fn: "mod", args: [17, 5] },
+      { fn: "mod", args: [-17, 5] },
+      { fn: "bitwise", args: [] },
+      { fn: "shifts", args: [9] },
+    ],
+  },
+  {
+    // Math.trunc is not yet lowered by the linear backend (Unsupported method
+    // call: .trunc()). Tracked here so the gap is visible and the flag drops
+    // the moment linear gains Math.* support.
+    name: "numeric/math-trunc",
+    category: "numeric",
+    source: `
+      export function intdiv(a: number, b: number): number { return Math.trunc(a / b); }
+    `,
+    calls: [{ fn: "intdiv", args: [17, 5] }],
+    expectLinearUnsupported: true,
+  },
+  {
+    name: "numeric/recursion-fib",
+    category: "numeric",
+    source: `
+      export function fib(n: number): number { if (n < 2) return n; return fib(n - 1) + fib(n - 2); }
+      export function fact(n: number): number { if (n <= 1) return 1; return n * fact(n - 1); }
+    `,
+    calls: [
+      { fn: "fib", args: [10] },
+      { fn: "fib", args: [20] },
+      { fn: "fact", args: [6] },
+    ],
+  },
+  {
+    name: "numeric/float-precision",
+    category: "numeric",
+    source: `
+      export function half(): number { return 1 / 2; }
+      export function third(): number { return 1 / 3; }
+      export function compound(): number { return 0.1 + 0.2; }
+    `,
+    calls: [
+      { fn: "half", args: [] },
+      { fn: "third", args: [] },
+      { fn: "compound", args: [] },
+    ],
+  },
+
+  // ── control flow ─────────────────────────────────────────────────────────
+  {
+    name: "control/branches",
+    category: "control",
+    source: `
+      export function classify(x: number): number {
+        if (x > 0) { return 1; } else if (x < 0) { return -1; } else { return 0; }
+      }
+      export function ternary(x: number): number { return x > 0 ? x : -x; }
+      export function clampLoop(x: number): number {
+        let n = x;
+        while (n > 10) { n = n - 10; }
+        return n;
+      }
+    `,
+    calls: [
+      { fn: "classify", args: [5] },
+      { fn: "classify", args: [-3] },
+      { fn: "classify", args: [0] },
+      { fn: "ternary", args: [-8] },
+      { fn: "clampLoop", args: [37] },
+    ],
+  },
+  {
+    name: "control/loops-accumulate",
+    category: "control",
+    source: `
+      export function sumTo(n: number): number { let t = 0; for (let i = 1; i <= n; i++) { t += i; } return t; }
+      export function countdown(n: number): number { let c = 0; do { c++; n--; } while (n > 0); return c; }
+      export function nestedLoop(n: number): number {
+        let t = 0;
+        for (let i = 0; i < n; i++) { for (let j = 0; j < n; j++) { t++; } }
+        return t;
+      }
+    `,
+    calls: [
+      { fn: "sumTo", args: [100] },
+      { fn: "countdown", args: [7] },
+      { fn: "nestedLoop", args: [5] },
+    ],
+  },
+  {
+    name: "control/comparison-bool",
+    category: "control",
+    source: `
+      export function gt(a: number, b: number): boolean { return a > b; }
+      export function eq(a: number, b: number): boolean { return a === b; }
+      export function logic(a: number, b: number): boolean { return a > 0 && b > 0; }
+    `,
+    calls: [
+      { fn: "gt", args: [3, 2] },
+      { fn: "gt", args: [2, 3] },
+      { fn: "eq", args: [5, 5] },
+      { fn: "logic", args: [1, 1] },
+      { fn: "logic", args: [1, -1] },
+    ],
+  },
+
+  // ── strings ──────────────────────────────────────────────────────────────
+  {
+    name: "string/length",
+    category: "string",
+    source: `
+      export function len(): number { const s = "hello world"; return s.length; }
+      export function emptyLen(): number { const s = ""; return s.length; }
+    `,
+    calls: [
+      { fn: "len", args: [] },
+      { fn: "emptyLen", args: [] },
+    ],
+  },
+  {
+    // String.prototype.charCodeAt is not yet lowered by the linear backend
+    // (Unsupported method call: .charCodeAt()). Flagged so the gap is visible.
+    name: "string/charcode",
+    category: "string",
+    source: `
+      export function code(): number { const s = "ABC"; return s.charCodeAt(0); }
+      export function codeAt(i: number): number { const s = "abcdef"; return s.charCodeAt(i); }
+    `,
+    calls: [
+      { fn: "code", args: [] },
+      { fn: "codeAt", args: [3] },
+    ],
+    expectLinearUnsupported: true,
+  },
+
+  // ── arrays ───────────────────────────────────────────────────────────────
+  {
+    name: "array/sum-iterate",
+    category: "array",
+    source: `
+      export function sum(): number { const a = [1, 2, 3, 4, 5]; let t = 0; for (const x of a) { t += x; } return t; }
+      export function indexed(): number { const a = [10, 20, 30]; let t = 0; for (let i = 0; i < a.length; i++) { t += a[i]; } return t; }
+      export function len(): number { const a = [1, 2, 3, 4]; return a.length; }
+    `,
+    calls: [
+      { fn: "sum", args: [] },
+      { fn: "indexed", args: [] },
+      { fn: "len", args: [] },
+    ],
+  },
+  {
+    name: "array/mutate",
+    category: "array",
+    source: `
+      export function pushSum(): number { const a: number[] = []; a.push(1); a.push(2); a.push(3); let t = 0; for (const x of a) { t += x; } return t; }
+      export function writeRead(): number { const a = [0, 0, 0]; a[1] = 42; return a[1]; }
+    `,
+    calls: [
+      { fn: "pushSum", args: [] },
+      { fn: "writeRead", args: [] },
+    ],
+  },
+
+  // ── objects ──────────────────────────────────────────────────────────────
+  {
+    name: "object/fields",
+    category: "object",
+    source: `
+      class Point { x: number; y: number; constructor(x: number, y: number) { this.x = x; this.y = y; } }
+      export function manhattan(): number { const p = new Point(3, 4); return p.x + p.y; }
+      export function mutate(): number { const p = new Point(1, 1); p.x = 10; return p.x + p.y; }
+    `,
+    calls: [
+      { fn: "manhattan", args: [] },
+      { fn: "mutate", args: [] },
+    ],
+  },
+
+  // ── closures (linear backend does not yet support arrow closures) ──────────
+  {
+    name: "closure/counter",
+    category: "closure",
+    source: `
+      export function counter(): number {
+        let c = 0;
+        const inc = () => { c += 1; return c; };
+        inc();
+        inc();
+        return inc();
+      }
+    `,
+    calls: [{ fn: "counter", args: [] }],
+    expectLinearUnsupported: true,
+  },
+];


### PR DESCRIPTION
## Summary

The `tests/equivalence/` suite compiles-and-runs each program against a V8/TS oracle — but only on **one backend per test**. We now have multiple lowering paths (WasmGC `target:"gc"` and linear-memory `target:"linear"`), and nothing asserted they agree with **each other**. A backend-specific lowering bug that produces wrong-but-not-crashing output can pass the single-oracle test on whichever backend it happened to run.

This harness compiles every corpus program to **both** backends and diffs the exported functions' return values. Because the WasmGC lane already tracks the V8 oracle (the equivalence suite), WasmGC↔linear agreement is transitively agreement with the oracle — so a divergence here is a genuine cross-backend lowering bug.

## Design note — the stdout lane is infeasible

The sprint-62 amendment proposed a `DIFF_TEST_TARGET=linear` stdout lane in `scripts/diff-test.ts`. That **cannot work**: the diff-test corpus is 100% stdout-driven (`console.log`), but the linear backend (`target:"linear"`, non-WASI) has **no `console.log` host import** — a linear-compiled program emits zero imports and no output mechanism in the WAT, so it runs but prints nothing (verified). Diffing linear-stdout vs the oracle would mark ~100 corpus programs as false mismatches. The linear backend's observable surface is the **return value** (as `tests/linear-*.test.ts` assert), so the differential is over return values.

## Changes

- **`tests/cross-backend/corpus.ts`** — 12 data-driven programs (numeric / control / string / array / object / closure), self-contained TS exporting functions + arg tuples. Seeded from the equivalence-corpus feature areas (AC #2).
- **`tests/cross-backend-diff.test.ts`** — compile each to both backends, invoke every call, assert identical return values (`toStrictEqual`). Divergence fails with a per-call repro pointer.
- **Gap baseline (no frozen file)** — programs the linear backend can't compile yet are flagged `expectLinearUnsupported` and skipped from the diff, but **asserted still unsupported** so the gap can only shrink (currently: `Math.trunc`, `charCodeAt`, arrow closures). Runs in the normal vitest suite (~5.5s); no new workflow.

## Acceptance criteria — verified

- ✅ Helper compiles to WasmGC **and** linear and diffs observable results (return value); bytecode-VM leg demoted to "where applicable" (test-only).
- ✅ Seeded from a representative corpus (numeric/strings/arrays/control/objects/closures).
- ✅ A divergence fails with a minimal-enough repro pointer — confirmed by injecting a forced mismatch (`Cross-backend DIVERGENCE … WasmGC returned 5 but linear returned 6`). Full minimization remains #1855.
- ✅ Wired into CI; runtime modest (15 tests, ~5.5s).

Closes #1854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)