### PR TITLE
chore(#1975): close linear-truthiness (core fixed in #1412); split &&/|| operand-value to #2184

### DIFF
--- a/plan/issues/1975-linear-truthiness-nan-empty-string.md
+++ b/plan/issues/1975-linear-truthiness-nan-empty-string.md
@@ -1,10 +1,11 @@
 ---
 id: 1975
 title: "linear backend: NaN and \"\" are truthy (f64.ne 0 / raw i32 pointer truthiness); &&/|| return 0/1 instead of operand values"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-16
+completed: 2026-06-16
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -12,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: type-coercion
 goal: core-semantics
-related: [1974, 1976]
+related: [1974, 1976, 2184]
 origin: "2026-06-10 deep-audit sweep (optimizer agent): verified on main, target linear"
 ---
 
@@ -80,3 +81,13 @@ the ToBoolean fix and is left for a dedicated issue. The boolean-context use
 - `src/codegen-linear/index.ts` — `emitTruthyCoercion` string branch + threaded
   the source expression through all call sites (`if`/`while`/`for`/ternary/
   unary-`!`/`&&`/`||`).
+
+## Closure (2026-06-16)
+
+**Done.** The ToBoolean correctness fix shipped in PR #1412 (commit
+`248195e2b`); both problem-table repros (`NaN`/`""` falsy) now match Node and
+`tests/issue-1975.test.ts` (8 cases) passes on main (re-verified 2026-06-16).
+The deferred `&&`/`||` *operand-value* half (yields `0`/`1` instead of the
+operand; needs result-type unification in the linear backend) is split out to
+**#2184** — the issue itself carved it out as "a dedicated issue." Closing
+#1975 as done; the value-producing `&&`/`||` work continues under #2184.

--- a/plan/issues/2184-linear-logical-operator-operand-values.md
+++ b/plan/issues/2184-linear-logical-operator-operand-values.md
@@ -1,0 +1,78 @@
+---
+id: 2184
+title: "linear backend: &&/|| yield 0/1 constants instead of operand values (needs result-type unification)"
+status: ready
+sprint: 63
+created: 2026-06-16
+updated: 2026-06-16
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: type-coercion
+goal: core-semantics
+related: [1975, 1976]
+origin: "2026-06-16 split from #1975 — the ToBoolean half (NaN/empty-string truthiness) landed in PR #1412; this is the deferred operand-value half the issue explicitly carved out as a dedicated issue."
+---
+
+# #2184 — linear `&&`/`||` discard the operand value
+
+## Problem (`target: "linear"`)
+
+JS `a || b` / `a && b` evaluate to **the operand value**, not a boolean.
+The linear backend's logical-operator lowering coerces its result to f64 and
+yields the constants `0` / `1` on the short-circuit arm instead of the
+operand:
+
+| probe                                  | linear | node  |
+|----------------------------------------|--------|-------|
+| `const r = "" \|\| "x"; return r;`      | `1`/0  | `"x"` |
+| `const r = "a" && "b"; return r;`      | `1`    | `"b"` |
+| `const r = 0 \|\| 42; return r;`        | `1`    | `42`  |
+
+The **boolean-context** use (`if ("" \|\| x)`, `while`, ternary condition) is
+already correct — that path was fixed in #1975 (PR #1412), which made
+`emitTruthyCoercion` NaN/empty-string aware. This issue is only the
+*value-producing* use of `&&`/`||`.
+
+## Root cause
+
+`src/codegen-linear/index.ts` logical-operator lowering (the `&&`/`||` arm,
+~index.ts:1921-1948 at the time of #1975) emits an `if` whose result type is
+f64-only and pushes `0`/`1` constants, rather than tee-ing the LHS and
+yielding the actual operand value. JS semantics: `a || b` ⇒ `ToBoolean(a) ?
+a : b`; `a && b` ⇒ `ToBoolean(a) ? b : a` — both yield an *operand*, whose
+static type may be string (i32 pointer), f64, or boolean.
+
+## Why it was split from #1975
+
+#1975's progress note: *"Fixing this needs result-type unification in the
+linear backend (the f64-only `if` result type can't carry a string operand),
+which is a larger change than the ToBoolean fix and is left for a dedicated
+issue."* The ToBoolean correctness fix (the verified problem-table repros)
+shipped; this is the carved-out remainder.
+
+## Fix direction
+
+- Compute the unified result ValType of the two operands (string/f64/bool);
+  emit an `if` typed to carry that value.
+- Tee the LHS into a temp, run `emitTruthyCoercion` on the tee for the branch
+  condition, and yield the LHS temp on the short-circuit arm / the RHS on the
+  other — no `0`/`1` constants.
+- Mixed-type operands (`"" || 42`) need the `any`/boxed representation or a
+  documented restriction; scope the first slice to same-typed operands and
+  file a follow-up for mixed types if needed.
+
+## Acceptance criteria
+
+- `"" || "x"` ⇒ `"x"`, `"a" && "b"` ⇒ `"b"`, `0 || 42` ⇒ `42` in linear mode
+  (match Node).
+- Boolean-context `&&`/`||` (the #1975 path) stays correct — no regression in
+  `tests/issue-1975.test.ts`.
+- New `tests/issue-2184.test.ts` covering value-producing `&&`/`||` for
+  string and numeric operands.
+
+## Notes
+
+GC backend already yields operand values correctly; this is linear-only.


### PR DESCRIPTION
## What
**#1975** (linear backend: `NaN` and `""` truthy) — its core ToBoolean bug was already fixed and merged in **PR #1412** (`248195e2b`). The 8-case `tests/issue-1975.test.ts` passes on main (re-verified 2026-06-16); both problem-table repros now match Node. But the issue stayed `status: ready` — a stale-ready.

This closes it and splits the one deferred acceptance criterion into a new issue:

- **#1975 → done** (`completed: 2026-06-16`). Core ToBoolean fix verified.
- **New #2184** — `&&`/`||` should yield *operand values*, not `0`/`1` constants. The issue itself carved this out as "a dedicated issue" because it needs result-type unification in the linear backend (the f64-only `if` result can't carry a string operand) — a larger change than the ToBoolean fix. Boolean-context `&&`/`||` (the common case) is already correct via #1975.

## Why
A `ready` s63 issue whose substantive work was already merged but never closed (same merged-but-stale drift the #2147 reconciler flags). Closing it honestly + tracking the genuinely-separate remainder, rather than leaving a half-met issue open or false-closing the deferred scope.

Plan-only — no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)