### PR TITLE
fix(#1928): remap diagnostic positions through pre-parse rewrites

### DIFF
--- a/plan/issues/1928-source-position-remapping-preparse-rewrites.md
+++ b/plan/issues/1928-source-position-remapping-preparse-rewrites.md
@@ -1,10 +1,12 @@
 ---
 id: 1928
 title: "Source-position remapping for pre-parse rewrites — diagnostics report wrong line numbers"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-2108
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -54,3 +56,43 @@ statement (`compiler/validation.ts:17-24`), reporting line 1.
 ## Source
 
 Compiler quality review 2026-06. Related: #1929, #1927.
+
+## Implementation (2026-06-16)
+
+- **`src/position-map.ts`** — new `PositionMap`: built from `SourceEdit`s
+  (`{origStart, origEnd, newLength}`, in the rewriter's INPUT coordinates;
+  a prepend is `origStart=origEnd=0`). `toInputOffset(out)` translates an output
+  offset back to input — exact outside edited spans, anchored at the original
+  span start for offsets inside injected text. `compose(inner)` chains stages by
+  function composition (apply this stage, then defer to the earlier one) — no
+  edit-list flattening, so no interleaving-delta traps.
+- **Per-rewrite maps** — each pre-parse rewriter now returns its map:
+  `preprocessImports` → `PreprocessResult.positionMap` (import-stub replacements +
+  timer-shim prepend, both already tracked internally);
+  `rewriteCjsRequireWithMap` (cjs-rewrite.ts); `applyDefineSubstitutionsWithMap`
+  (define-substitution.ts, rewritten to scan matches and record spans for exact
+  column mapping). The thin string-returning originals delegate, so existing
+  callers are untouched.
+- **`compiler.ts`** — composes the maps in pipeline order
+  (`imports ∘ cjs ∘ define`; `rewriteEvalSuperCall` is a rare same-line
+  rewrite → identity, documented & omitted) and applies the composed map at the
+  single diagnostic-materialization point (`remapDiagnosticPosition`): map
+  `diag.start` (processed offset) → original offset, then compute line/column
+  from the ORIGINAL source. Identity map ⇒ byte-for-byte the old behaviour.
+
+### Acceptance criteria — met
+- [x] Diagnostic positions match the user's source under each rewrite (import
+      replacement, timer shim, CJS, define) — one regression test each in
+      `tests/issue-1928.test.ts`.
+- [x] No position changes when no rewrite fires (identity path; control test).
+
+## Test Results (2026-06-16)
+
+`tests/issue-1928.test.ts` — 10/10: 4 `PositionMap` unit tests (identity,
+prepend, replaced-span anchoring, composition) + 6 end-to-end diagnostic-line
+tests (timer-shim → user L3 [was L6 before the fix], import-stub → L4, CJS → L4,
+define → L3, combined shim+import → L5, no-rewrite control → exact L2).
+typecheck / lint / format clean. The pre-existing failures in
+`import-resolver.test.ts` (9) and `typescript-diagnostic-failures.test.ts`
+(1, "incremental compilation") reproduce IDENTICALLY on clean origin/main —
+not caused by this change.

--- a/src/cjs-rewrite.ts
+++ b/src/cjs-rewrite.ts
@@ -15,6 +15,7 @@
 // silently change semantics.
 
 import { ts } from "./ts-api.js";
+import { PositionMap } from "./position-map.js";
 
 /** A single require() call rewrite plan. */
 interface RequireRewrite {
@@ -33,8 +34,19 @@ interface RequireRewrite {
  * Returns the original source unchanged if no top-level require() calls are present.
  */
 export function rewriteCjsRequire(source: string): string {
+  return rewriteCjsRequireWithMap(source).source;
+}
+
+/**
+ * #1928 — like {@link rewriteCjsRequire} but also returns a `PositionMap` from
+ * the rewritten output back to the input, so diagnostics computed against the
+ * rewritten source can report the user's original line numbers. `import`
+ * declarations can be longer (and multi-line) than the `const … = require(…)`
+ * they replace, shifting everything below.
+ */
+export function rewriteCjsRequireWithMap(source: string): { source: string; positionMap: PositionMap } {
   // Cheap pre-check: if the source doesn't even contain `require(`, skip parsing.
-  if (!source.includes("require(")) return source;
+  if (!source.includes("require(")) return { source, positionMap: PositionMap.identity() };
 
   const sf = ts.createSourceFile("__cjs_rewrite__.ts", source, ts.ScriptTarget.Latest, true);
   const rewrites: RequireRewrite[] = [];
@@ -44,7 +56,11 @@ export function rewriteCjsRequire(source: string): string {
     if (rewrite) rewrites.push(rewrite);
   }
 
-  if (rewrites.length === 0) return source;
+  if (rewrites.length === 0) return { source, positionMap: PositionMap.identity() };
+
+  const positionMap = new PositionMap(
+    rewrites.map((r) => ({ origStart: r.start, origEnd: r.end, newLength: r.text.length })),
+  );
 
   // Apply rewrites in reverse order so positions stay valid.
   rewrites.sort((a, b) => b.start - a.start);
@@ -52,7 +68,7 @@ export function rewriteCjsRequire(source: string): string {
   for (const r of rewrites) {
     result = result.substring(0, r.start) + r.text + result.substring(r.end);
   }
-  return result;
+  return { source: result, positionMap };
 }
 
 /**

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -30,9 +30,10 @@ import { emitBinary, emitBinaryWithSourceMap, emitSourceMappingURLSection } from
 import { WasmEncoder } from "./emit/encoder.js";
 import { generateSourceMap } from "./emit/sourcemap.js";
 import { emitWat } from "./emit/wat.js";
-import { applyDefineSubstitutions } from "./compiler/define-substitution.js";
-import { rewriteCjsRequire } from "./cjs-rewrite.js";
+import { applyDefineSubstitutions, applyDefineSubstitutionsWithMap } from "./compiler/define-substitution.js";
+import { rewriteCjsRequire, rewriteCjsRequireWithMap } from "./cjs-rewrite.js";
 import { preprocessImports } from "./import-resolver.js";
+import { PositionMap } from "./position-map.js";
 import type { CompileError, CompileOptions, CompileResult } from "./index.js";
 import { optimizeBinaryAsync } from "./optimize.js";
 import { generateWit } from "./wit-generator.js";
@@ -372,6 +373,39 @@ function identifierHasNonNullProofInAncestor(id: ts.Identifier, checker: ts.Type
   return false;
 }
 
+/**
+ * #1928 — compute a diagnostic's `(line, character)` in the USER's original
+ * source. `diag.start` is an offset in the rewritten `processedSource`; map it
+ * back through the composed pre-parse `PositionMap`, then resolve the line and
+ * column from the original `source` text. When the map is identity (no rewrite
+ * fired) this is equivalent to the old direct
+ * `diag.file.getLineAndCharacterOfPosition` lookup. Falls back to the processed
+ * position if `diag.file` is somehow absent.
+ */
+function remapDiagnosticPosition(
+  diag: ts.Diagnostic,
+  originalSource: string,
+  positionMap: PositionMap,
+): { line: number; character: number } {
+  if (!diag.file) return { line: 0, character: 0 };
+  const processedStart = diag.start ?? 0;
+  if (positionMap.isIdentity) {
+    return diag.file.getLineAndCharacterOfPosition(processedStart);
+  }
+  const origOffset = Math.min(Math.max(0, positionMap.toInputOffset(processedStart)), originalSource.length);
+  // Resolve line/column from the original text. Counting newlines is O(offset)
+  // but diagnostics are few; a shared line-start index would be premature here.
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < origOffset; i++) {
+    if (originalSource.charCodeAt(i) === 10 /* \n */) {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, character: origOffset - lastNewline - 1 };
+}
+
 function isGuardedNullablePrimitiveDiagnostic(diag: ts.Diagnostic, checker: ts.TypeChecker): boolean {
   if (diag.code !== 2322 && diag.code !== 2345) return false;
   const file = diag.file;
@@ -479,14 +513,21 @@ export function compileSourceSync(
   const emitWatOutput = options.emitWat !== false;
 
   // Step 0a: Apply compile-time define substitutions (#1043)
-  const definedSource = options.define ? applyDefineSubstitutions(source, options.define) : source;
+  // #1928 — each pre-parse rewrite returns a PositionMap (output → its input);
+  // we compose them so diagnostics computed against `processedSource` can be
+  // reported at the user's ORIGINAL line/column instead of the rewritten one.
+  const defineResult = options.define
+    ? applyDefineSubstitutionsWithMap(source, options.define)
+    : { source, positionMap: PositionMap.identity() };
+  const definedSource = defineResult.source;
 
   // Step 0a.5: Rewrite CommonJS `const X = require('Y')` patterns to ESM `import`
   // declarations (#1279). This must run before preprocessImports so the resulting
   // import statements get the same declare-stub treatment as user-written imports,
   // and before `detectNodeFsImports` so `const fs = require('node:fs')` is picked
   // up as a node:fs import for WASI mode.
-  const cjsRewritten = rewriteCjsRequire(definedSource);
+  const cjsResult = rewriteCjsRequireWithMap(definedSource);
+  const cjsRewritten = cjsResult.source;
 
   // Step 0b: Pre-process imports (replace import * as X with declare namespace)
   // #1054: rewrite eval("...super()...") to a throwing IIFE so early-error
@@ -497,9 +538,16 @@ export function compileSourceSync(
   // #1491 — detect named fs imports for both WASI (#1035 syscall path) and the
   // new JS-host imports (non-WASI). Detection is identical; the codegen branch
   // is selected based on `ctx.wasi` + `ctx.allowFs`.
+  // #1928 — `rewriteEvalSuperCall` only rewrites `eval("…super()…")` to a
+  // same-line throwing IIFE (a rare early-error edge); it never shifts lines, so
+  // it contributes an identity map and is omitted from the composition.
+  const cjsRewritten2 = rewriteEvalSuperCall(cjsRewritten);
   const wasiNodeFsFuncs = detectNodeFsImports(cjsRewritten);
-  const preprocessed = preprocessImports(rewriteEvalSuperCall(cjsRewritten));
+  const preprocessed = preprocessImports(cjsRewritten2);
   const processedSource = preprocessed.source;
+  // Composed map: processedSource → original source. Pipeline output order is
+  // define → cjs → (eval/super, identity) → imports, so compose outermost-first.
+  const positionMap = preprocessed.positionMap.compose(cjsResult.positionMap).compose(defineResult.positionMap);
 
   // Step 1: Parse and type-check
   let isJsMode = options.allowJs === true || (options.fileName?.endsWith(".js") ?? false);
@@ -551,7 +599,12 @@ export function compileSourceSync(
   for (const diag of ast.diagnostics) {
     if (diag.category === 1) {
       // Error
-      const pos = diag.file ? diag.file.getLineAndCharacterOfPosition(diag.start ?? 0) : { line: 0, character: 0 };
+      // #1928 — `diag.start` is an offset in `processedSource`. Map it back to
+      // the user's original source (through the composed pre-parse rewrite map)
+      // and compute the line/column there, so reported positions match what the
+      // user wrote rather than the rewritten text. A no-op when no rewrite fired
+      // (identity map) — same result as the old direct lookup.
+      const pos = remapDiagnosticPosition(diag, source, positionMap);
       const severity =
         DOWNGRADE_DIAG_CODES.has(diag.code) || isGuardedNullablePrimitiveDiagnostic(diag, ast.checker)
           ? "warning"

--- a/src/compiler/define-substitution.ts
+++ b/src/compiler/define-substitution.ts
@@ -9,6 +9,7 @@
  * Also handles `typeof <identifier>` forms: `typeof process` can be replaced
  * with `"undefined"` to eliminate environment-detection branches.
  */
+import { PositionMap, type SourceEdit } from "../position-map.js";
 
 /**
  * Apply compile-time define substitutions to source text.
@@ -19,33 +20,59 @@
  * @returns Source with substitutions applied
  */
 export function applyDefineSubstitutions(source: string, defines: Record<string, string>): string {
-  if (!defines || Object.keys(defines).length === 0) return source;
+  return applyDefineSubstitutionsWithMap(source, defines).source;
+}
 
-  let result = source;
+/**
+ * #1928 — like {@link applyDefineSubstitutions} but also returns a `PositionMap`
+ * from the substituted output back to the input. Define replacements
+ * (`process.env.NODE_ENV` → `"production"`) change length, so positions after a
+ * match on the same line shift; multi-line replacements shift lines below.
+ * Tracking the exact match spans keeps diagnostics anchored to the user's
+ * original positions.
+ */
+export function applyDefineSubstitutionsWithMap(
+  source: string,
+  defines: Record<string, string>,
+): { source: string; positionMap: PositionMap } {
+  if (!defines || Object.keys(defines).length === 0) {
+    return { source, positionMap: PositionMap.identity() };
+  }
 
-  // Sort keys by length (longest first) to avoid partial matches
+  // Sort keys by length (longest first) to avoid partial matches.
   const keys = Object.keys(defines).sort((a, b) => b.length - a.length);
+
+  // Each pass rewrites `current` and produces a per-pass PositionMap
+  // (current-output → current-input); compose them so the final map runs
+  // straight back to the original source.
+  let current = source;
+  let composed = PositionMap.identity();
 
   for (const key of keys) {
     const replacement = defines[key]!;
+    const pattern = key.startsWith("typeof ")
+      ? new RegExp(`(?<![.\\w$])typeof\\s+${escapeRegExp(key.slice(7))}(?![\\w$])`, "g")
+      : new RegExp(`(?<![.\\w$])${escapeRegExp(key)}(?![\\w$])`, "g");
 
-    // Handle typeof forms: "typeof process" → replacement
-    if (key.startsWith("typeof ")) {
-      const ident = key.slice(7); // "typeof process" → "process"
-      // Match `typeof <ident>` not preceded by a dot or alphanumeric
-      const typeofPattern = new RegExp(`(?<![.\\w$])typeof\\s+${escapeRegExp(ident)}(?![\\w$])`, "g");
-      result = result.replace(typeofPattern, replacement);
-      continue;
+    const edits: SourceEdit[] = [];
+    let out = "";
+    let last = 0;
+    for (const m of current.matchAll(pattern)) {
+      const start = m.index ?? 0;
+      const end = start + m[0].length;
+      out += current.slice(last, start) + replacement;
+      edits.push({ origStart: start, origEnd: end, newLength: replacement.length });
+      last = end;
     }
-
-    // Build a regex that matches the dotted path as a standalone expression.
-    // Must not be preceded by a dot, alphanumeric, $, or _ (to avoid matching
-    // e.g. `foo.process.env.NODE_ENV`), and must not be followed by alphanumeric/$/_.
-    const pattern = new RegExp(`(?<![.\\w$])${escapeRegExp(key)}(?![\\w$])`, "g");
-    result = result.replace(pattern, replacement);
+    if (edits.length === 0) continue; // no match this pass — map unchanged
+    out += current.slice(last);
+    current = out;
+    // This pass maps current-output → its input; the prior `composed` maps that
+    // input → original. compose() chains them.
+    composed = new PositionMap(edits).compose(composed);
   }
 
-  return result;
+  return { source: current, positionMap: composed };
 }
 
 /**

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts, forEachChild } from "./ts-api.js";
+import { PositionMap, type SourceEdit } from "./position-map.js";
 
 interface ClassUsageInfo {
   constructorArgCounts: number[];
@@ -148,6 +149,33 @@ export interface PreprocessResult {
   nodeBuiltins: NodeBuiltinImport[];
   /** JSX runtime import (if any) detected during preprocessing (#1540). */
   jsxRuntime?: JsxRuntimeImport;
+  /**
+   * #1928 — maps an offset in `source` (the processed output) back to an
+   * offset in the input this function consumed, covering the import-stub
+   * replacements and the prepended timer shim. Identity when neither fired.
+   * Lets the diagnostic layer report the user's line numbers, not the
+   * rewritten ones.
+   */
+  positionMap: PositionMap;
+}
+
+/**
+ * #1928 — build the `PositionMap` for `preprocessImports`. The import-stub
+ * `replacements` are expressed in INPUT coordinates as `[start, end) → text`;
+ * a prepended `timerShim` is an edit at offset 0 with an empty original span.
+ */
+function buildPreprocessPositionMap(
+  replacements: { start: number; end: number; text: string }[],
+  timerShimLen: number,
+): PositionMap {
+  const edits: SourceEdit[] = [];
+  if (timerShimLen > 0) {
+    edits.push({ origStart: 0, origEnd: 0, newLength: timerShimLen });
+  }
+  for (const r of replacements) {
+    edits.push({ origStart: r.start, origEnd: r.end, newLength: r.text.length });
+  }
+  return new PositionMap(edits);
 }
 
 /**
@@ -374,7 +402,13 @@ export function preprocessImports(source: string): PreprocessResult {
   const timerShim = buildTimerShim(timerCalls, definedNames);
 
   if (nsImports.size === 0 && otherImports.length === 0 && jsxRuntimeImportRanges.length === 0) {
-    return { source: timerShim ? timerShim + source : source, nodeBuiltins, jsxRuntime };
+    return {
+      source: timerShim ? timerShim + source : source,
+      nodeBuiltins,
+      jsxRuntime,
+      // #1928 — no imports here; only the (optional) timer-shim prepend shifts positions.
+      positionMap: buildPreprocessPositionMap([], timerShim.length),
+    };
   }
 
   // Step 2: Analyze usage for namespace imports
@@ -687,6 +721,11 @@ export function preprocessImports(source: string): PreprocessResult {
     }
   }
 
+  // #1928 — capture the import-stub edits (in INPUT coordinates) for the
+  // position map BEFORE the reverse-order apply mutates `result`. The map
+  // constructor re-sorts ascending, so the apply order here is irrelevant to it.
+  const positionMap = buildPreprocessPositionMap(replacements, timerShim.length);
+
   // Apply replacements in reverse order to preserve positions
   let result = source;
   replacements.sort((a, b) => b.start - a.start);
@@ -694,5 +733,5 @@ export function preprocessImports(source: string): PreprocessResult {
     result = result.substring(0, r.start) + r.text + result.substring(r.end);
   }
 
-  return { source: timerShim ? timerShim + result : result, nodeBuiltins, jsxRuntime };
+  return { source: timerShim ? timerShim + result : result, nodeBuiltins, jsxRuntime, positionMap };
 }

--- a/src/position-map.ts
+++ b/src/position-map.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1928 — source-position remapping for pre-parse rewrites.
+ *
+ * Diagnostics are computed by the TS checker against the *rewritten* source
+ * (timer shim prepended, imports replaced by `declare` stubs, CJS `require`
+ * rewritten, `define` substitutions), so a reported `(line, column)` is wrong
+ * — often by several lines — whenever any pre-parse rewrite fires. There is no
+ * way to recover the user's position from the processed source alone.
+ *
+ * A `PositionMap` records the character-level edits a rewriter applied (each in
+ * the coordinate space of the text it consumed) and translates an offset in the
+ * *output* text back to an offset in the *input* text. Rewriters run in a
+ * pipeline (define → CJS → eval/super → imports+shim), so the maps compose:
+ * `outer.compose(inner)` yields a map from the outermost output straight back
+ * to the original source.
+ *
+ * Mapping policy (matches the issue's pragmatic guidance):
+ *   - An offset OUTSIDE every edited span maps back by the net length delta of
+ *     all edits that ended before it — exact.
+ *   - An offset INSIDE a replaced span (e.g. within an injected `declare`
+ *     stub, which has no user-source counterpart) maps to the START of the
+ *     original replaced span. Diagnostics rarely point inside an injected stub;
+ *     anchoring at the original statement is the correct, stable fallback.
+ */
+
+/**
+ * One text edit, in the coordinate space of the INPUT this rewriter consumed:
+ * the half-open span `[origStart, origEnd)` was replaced by text of length
+ * `newLength`. A pure prepend is `origStart = origEnd = 0` with `newLength` =
+ * the prepended length.
+ */
+export interface SourceEdit {
+  readonly origStart: number;
+  readonly origEnd: number;
+  readonly newLength: number;
+}
+
+export class PositionMap {
+  /**
+   * A single-stage map is described by its edit list; a composed map is a
+   * chain `outer → inner` translated by function composition (apply `outer`'s
+   * single-stage transform, then defer to `inner`). Keeping composition as
+   * function composition (rather than flattening two edit lists into one)
+   * avoids the interleaving-delta correctness traps of merging transforms.
+   */
+  private readonly edits: readonly SourceEdit[];
+  private readonly inner?: PositionMap;
+
+  constructor(edits: readonly SourceEdit[], inner?: PositionMap) {
+    this.edits = [...edits].sort((a, b) => a.origStart - b.origStart);
+    this.inner = inner;
+  }
+
+  /** Identity map — output offsets equal input offsets. */
+  static identity(): PositionMap {
+    return new PositionMap([]);
+  }
+
+  /** Apply only THIS stage's single transform (output → its direct input). */
+  private toDirectInputOffset(outOffset: number): number {
+    // Walk edits in input order, tracking the cumulative (output − input)
+    // delta. Each edit contributes `newLength` to the output and
+    // `(origEnd − origStart)` to the input.
+    let delta = 0;
+    for (const e of this.edits) {
+      const outEditStart = e.origStart + delta;
+      const outEditEnd = outEditStart + e.newLength;
+      if (outOffset < outEditStart) {
+        // Before this edit's output span — only earlier deltas apply.
+        break;
+      }
+      if (outOffset < outEditEnd) {
+        // Inside the replacement text → anchor at the original span start.
+        return e.origStart;
+      }
+      delta += e.newLength - (e.origEnd - e.origStart);
+    }
+    return Math.max(0, outOffset - delta);
+  }
+
+  /**
+   * Translate an offset in this map's OUTPUT text all the way back to the
+   * ORIGINAL source: apply this stage, then defer to the earlier stage(s).
+   */
+  toInputOffset(outOffset: number): number {
+    const direct = this.toDirectInputOffset(outOffset);
+    return this.inner ? this.inner.toInputOffset(direct) : direct;
+  }
+
+  /**
+   * Compose with the map of an EARLIER pipeline stage. `this` maps
+   * stage-N-output → stage-N-input; `inner` maps stage-N-input (== stage-(N−1)
+   * output) → original. The result maps stage-N-output → original.
+   */
+  compose(inner: PositionMap): PositionMap {
+    if (inner.isIdentity) return this;
+    if (this.isIdentity) return inner;
+    return new PositionMap(this.edits, this.inner ? this.inner.compose(inner) : inner);
+  }
+
+  /** True when this is the identity (no edits and no earlier stage). */
+  get isIdentity(): boolean {
+    return this.edits.length === 0 && (this.inner?.isIdentity ?? true);
+  }
+}

--- a/tests/issue-1928.test.ts
+++ b/tests/issue-1928.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1928 — source-position remapping for pre-parse rewrites.
+//
+// Diagnostics were computed against the REWRITTEN source (timer shim prepended,
+// imports replaced by `declare` stubs, CJS `require` rewritten, `define`
+// substitutions), so reported line numbers were wrong — off by the prepended
+// shim's line count, etc. A composed `PositionMap` now maps the diagnostic
+// offset back to the user's original source before the line/column is computed.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { PositionMap } from "../src/position-map.js";
+
+async function errorLines(
+  source: string,
+  opts: Record<string, unknown> = {},
+): Promise<Array<{ line: number; column: number }>> {
+  const r = await compile(source, { fileName: "t.ts", ...opts });
+  return r.errors.filter((e) => e.severity === "error").map((e) => ({ line: e.line, column: e.column }));
+}
+
+describe("#1928 — PositionMap", () => {
+  it("identity map leaves offsets unchanged", () => {
+    const m = PositionMap.identity();
+    expect(m.isIdentity).toBe(true);
+    expect(m.toInputOffset(0)).toBe(0);
+    expect(m.toInputOffset(42)).toBe(42);
+  });
+
+  it("a pure prepend shifts every output offset back by its length", () => {
+    // Prepend 10 chars: output offset N (≥10) maps to input N−10.
+    const m = new PositionMap([{ origStart: 0, origEnd: 0, newLength: 10 }]);
+    expect(m.toInputOffset(10)).toBe(0);
+    expect(m.toInputOffset(25)).toBe(15);
+  });
+
+  it("a replaced span anchors interior offsets at the original span start", () => {
+    // Replace input [5,8) (len 3) with 9 chars of output.
+    const m = new PositionMap([{ origStart: 5, origEnd: 8, newLength: 9 }]);
+    expect(m.toInputOffset(4)).toBe(4); // before edit — unchanged
+    expect(m.toInputOffset(5)).toBe(5); // at the replacement start
+    expect(m.toInputOffset(10)).toBe(5); // inside replacement → anchored at orig start
+    expect(m.toInputOffset(14)).toBe(8); // first output offset past the replacement
+    expect(m.toInputOffset(20)).toBe(14); // after edit: 20 − (9−3) = 14
+  });
+
+  it("composition chains output → original across two stages", () => {
+    // inner: prepend 4 chars (origStart 0). outer: prepend 6 chars on inner's output.
+    const inner = new PositionMap([{ origStart: 0, origEnd: 0, newLength: 4 }]);
+    const outer = new PositionMap([{ origStart: 0, origEnd: 0, newLength: 6 }]);
+    const composed = outer.compose(inner);
+    // Final output offset 10 → outer back to 4 → inner back to 0.
+    expect(composed.toInputOffset(10)).toBe(0);
+    expect(composed.toInputOffset(20)).toBe(10);
+  });
+});
+
+describe("#1928 — diagnostic positions match the user's source under each rewrite", () => {
+  it("timer-shim prepend: type error reports the user's line", async () => {
+    const errs = await errorLines(
+      [
+        "export function f(): number {",
+        "  setTimeout(() => {}, 100);",
+        '  const x: number = "nope";',
+        "  return x;",
+        "}",
+      ].join("\n"),
+    );
+    expect(errs).toContainEqual({ line: 3, column: 9 });
+  });
+
+  it("import-stub replacement: type error reports the user's line", async () => {
+    const errs = await errorLines(
+      [
+        'import { foo } from "./mod";',
+        "export function h(): number {",
+        "  foo();",
+        '  const z: number = "nope";',
+        "  return z;",
+        "}",
+      ].join("\n"),
+    );
+    expect(errs).toContainEqual({ line: 4, column: 9 });
+  });
+
+  it("CJS require rewrite: type error reports the user's line", async () => {
+    const errs = await errorLines(
+      [
+        'const lib = require("./lib");',
+        "export function c(): number {",
+        "  lib.use();",
+        '  const q: number = "nope";',
+        "  return q;",
+        "}",
+      ].join("\n"),
+    );
+    expect(errs).toContainEqual({ line: 4, column: 9 });
+  });
+
+  it("define substitution: type error reports the user's line", async () => {
+    const errs = await errorLines(
+      [
+        "export function d(): number {",
+        "  const env = process.env.NODE_ENV;",
+        '  const w: number = "nope";',
+        "  return w;",
+        "}",
+      ].join("\n"),
+      { define: { "process.env.NODE_ENV": '"production"' } },
+    );
+    expect(errs).toContainEqual({ line: 3, column: 9 });
+  });
+
+  it("combined timer-shim + import: type error reports the user's line", async () => {
+    const errs = await errorLines(
+      [
+        'import { bar } from "./bar";',
+        "export function m(): number {",
+        "  setTimeout(() => bar(), 1);",
+        "  bar();",
+        '  const r: number = "nope";',
+        "  return r;",
+        "}",
+      ].join("\n"),
+    );
+    expect(errs).toContainEqual({ line: 5, column: 9 });
+  });
+
+  it("no rewrite fires: positions are exact (control)", async () => {
+    const errs = await errorLines(
+      ["export function g(): number {", '  const y: number = "nope";', "  return y;", "}"].join("\n"),
+    );
+    expect(errs).toContainEqual({ line: 2, column: 9 });
+  });
+});


### PR DESCRIPTION
## #1928 — wrong diagnostic line numbers under pre-parse rewrites

Diagnostics are computed against the **rewritten** source, not the user's:
the timer shim is prepended, imports are replaced by multi-line `declare`
stubs, CJS `require` is rewritten, and `define` substitutions change text — yet
no offset mapping existed. So a type error on the user's line 3 was reported at
**line 6** once the 3-line timer shim was prepended (and similarly for every
other rewrite).

### Fix
- **`src/position-map.ts`** — `PositionMap` built from `SourceEdit`s
  (`{origStart, origEnd, newLength}` in input coords; a prepend is the `[0,0)`
  span). `toInputOffset` maps rewritten→original (exact outside edited spans,
  anchored at the original span start inside injected text); `compose()` chains
  pipeline stages by function composition.
- **Each rewriter returns its map**: `preprocessImports` →
  `PreprocessResult.positionMap` (import stubs + timer-shim prepend, already
  tracked internally); `rewriteCjsRequireWithMap`;
  `applyDefineSubstitutionsWithMap` (rewritten to record exact match spans). The
  string-returning originals delegate, so other callers are untouched.
- **`compiler.ts`** composes the maps (`imports ∘ cjs ∘ define`;
  `rewriteEvalSuperCall` is a rare same-line rewrite → identity, omitted) and
  applies them at the single diagnostic-materialization point
  (`remapDiagnosticPosition`), computing line/column from the ORIGINAL source.
  An identity map (no rewrite fired) reproduces the old behaviour byte-for-byte.

### Acceptance criteria — met
- ✅ Diagnostic positions match the user's source under each rewrite (import,
  timer shim, CJS, define) — one regression test each.
- ✅ No position change when no rewrite fires (identity path; control test).

`tests/issue-1928.test.ts` — 10/10 (4 `PositionMap` unit tests + 6 end-to-end
line tests). typecheck / lint / format clean. No new regressions (the failing
`import-resolver`/`typescript-diagnostic-failures` tests fail identically on
clean main — pre-existing harness-stub issues).

Sets issue #1928 `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)