### PR TITLE
fix(#1976): linear string .length returns UTF-16 code units, not UTF-8 bytes

### DIFF
--- a/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
+++ b/plan/issues/1976-linear-string-pointer-compare-utf8-length.md
@@ -1,10 +1,12 @@
 ---
 id: 1976
 title: "linear backend: string relationals compare memory addresses; .length returns UTF-8 byte count; string concat in compound-assign emits invalid module"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-1921
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -94,3 +96,50 @@ UTF-8/WTF-16 work.)
 - `src/codegen-linear/runtime.ts` — new `__str_cmp` helper
 - `src/codegen-linear/index.ts` — route string relationals through `__str_cmp`;
   string `+=` via `__str_concat`; `inferExprType` string-concat → i32
+
+## Resolution (2026-06-16) — UTF-16 `.length` (repro row 3) closed
+
+The remaining `.length` divergence is now fixed **without** an invasive storage
+migration. Rather than count code units inside `__str_len` (which slice/indexOf
+rely on as a *byte* offset), a dedicated runtime fn was added and only the
+user-facing `.length` property routed through it:
+
+- **`src/codegen-linear/runtime.ts`** — new `__str_length_utf16(ptr) -> i32`.
+  Walks the stored UTF-8 bytes and counts UTF-16 code units from each leading
+  byte's high bits: `0xxxxxxx`/`110xxxxx`/`1110xxxx` → a BMP code point (1 unit,
+  advance 1/2/3 bytes), `11110xxx` → an astral code point (2 units / surrogate
+  pair, advance 4 bytes). ASCII counts == byte length (unchanged). `__str_len`
+  (byte count) is left untouched as the internal primitive.
+- **`src/codegen-linear/index.ts`** — the `string.length` property lowering now
+  calls `__str_length_utf16` instead of `__str_len`. The `slice(start)`
+  `end = str.length` byte fallback still uses `__str_len` (byte offset) — that
+  is correct, since `__str_slice` indexes by byte.
+
+Repro table now fully matches Node: `"é".length` → 1, `"é世😀".length` → 4,
+`"😀😀".length` → 4 (were 2 / 9 / 8).
+
+**Still residual (genuinely larger, out of scope here):** `slice` / `charCodeAt`
+/ `codePointAt` / indexing operate on **byte** offsets, so for *multi-byte*
+strings they don't yet match UTF-16 code-unit semantics. That is the full
+storage/offset audit the Progress note above describes (WTF-16 storage vs.
+code-unit-offset translation), tied to #1588's GC-side UTF-8/WTF-16 decision.
+This PR closes all three stated acceptance-criteria repros (criterion 3 blesses
+ASCII byte fast paths) and leaves the broader offset unification to that
+follow-up.
+
+### Test Results
+
+- `tests/issue-1976.test.ts` — 23/23 pass (the 15 prior cases + 8 new UTF-16
+  `.length` cases covering ASCII / Latin-1 / BMP / astral / mixed, plus
+  length-after-concat of a multi-byte string).
+- All linear-backend suites green after the change: `linear-string` +
+  `linear-{basic,advanced,array,runtime,integration,classes,collections,
+  controlflow,functions,map,set,bitwise,break-continue,element-assign,u8array,
+  ir}` = 136 tests, no regressions.
+- `npm run typecheck` + `npm run lint` (Biome) clean.
+
+### Files (this PR)
+
+- `src/codegen-linear/runtime.ts` — new `__str_length_utf16` helper
+- `src/codegen-linear/index.ts` — route `string.length` through it
+- `tests/issue-1976.test.ts` — UTF-16 `.length` cases

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -2882,10 +2882,14 @@ function compilePropertyAccess(ctx: LinearContext, fctx: LinearFuncContext, expr
     return;
   }
 
-  // string.length → call __str_len(str) → i32, convert to f64
+  // string.length → number of UTF-16 code units (JS semantics), NOT the
+  // UTF-8 byte count (#1976). Linear strings are stored as UTF-8, so route the
+  // user-facing `.length` through __str_length_utf16, which scans the bytes and
+  // counts code units (astral code points = 2). __str_len (byte count) stays
+  // the internal primitive for slice/indexOf, which index by byte offset.
   if (propName === "length" && isStringExpr(ctx, fctx, expr.expression)) {
     compileExpression(ctx, fctx, expr.expression);
-    const strLenIdx = ctx.funcMap.get("__str_len")!;
+    const strLenIdx = ctx.funcMap.get("__str_length_utf16")!;
     fctx.body.push({ op: "call", funcIdx: strLenIdx });
     fctx.body.push({ op: "f64.convert_i32_s" });
     return;

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -1127,11 +1127,137 @@ export function addStringRuntime(mod: WasmModule): void {
     2,
   ); // 2 extra locals
 
-  // __str_len: load i32 at ptr+8
+  // __str_len: load i32 at ptr+8 — the stored UTF-8 **byte** count. This is the
+  // internal primitive used by slice/indexOf/concat/eq, which all index by byte
+  // offset. It is NOT the JS `.length` (UTF-16 code units) — see
+  // __str_length_utf16 below.
   addRuntimeFunc(mod, "__str_len", [{ kind: "i32" }], [{ kind: "i32" }], [], () => [
     { op: "local.get", index: 0 },
     { op: "i32.load", align: 2, offset: 8 },
   ]);
+
+  // __str_length_utf16: JS `String.prototype.length` = number of UTF-16 code
+  // units (#1976). Linear strings are stored as UTF-8 bytes, so walk the leading
+  // bytes and count code units: a leading byte 0xxxxxxx/110xxxxx/1110xxxx starts
+  // a 1/2/3-byte sequence encoding a BMP code point (1 code unit), while
+  // 11110xxx starts a 4-byte sequence for an astral code point (a surrogate
+  // pair → 2 code units). ASCII strings count == byte length, matching the old
+  // behaviour. Continuation bytes (10xxxxxx) are skipped by advancing past the
+  // whole sequence.
+  // locals: byteLen(1), i(2 = byte cursor), count(3), b(4 = leading byte)
+  addRuntimeFunc(
+    mod,
+    "__str_length_utf16",
+    [{ kind: "i32" }],
+    [{ kind: "i32" }],
+    [],
+    (firstLocalIdx) => {
+      const byteLen = firstLocalIdx;
+      const i = firstLocalIdx + 1;
+      const count = firstLocalIdx + 2;
+      const b = firstLocalIdx + 3;
+      return [
+        // byteLen = mem[ptr+8]
+        { op: "local.get", index: 0 },
+        { op: "i32.load", align: 2, offset: 8 },
+        { op: "local.set", index: byteLen },
+        // i = 0; count = 0
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: i },
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: count },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                // break if i >= byteLen
+                { op: "local.get", index: i },
+                { op: "local.get", index: byteLen },
+                { op: "i32.ge_u" },
+                { op: "br_if", depth: 1 },
+                // b = mem[ptr+12+i]
+                { op: "local.get", index: 0 },
+                { op: "local.get", index: i },
+                { op: "i32.add" },
+                { op: "i32.load8_u", align: 0, offset: 12 },
+                { op: "local.set", index: b },
+                // Decide sequence length (advance i) and code units (advance
+                // count) by the leading byte's high bits. The `if` condition is
+                // taken from the stack, so push it just before each `if`.
+                // cond: b < 0x80  (1-byte ASCII)
+                { op: "local.get", index: b },
+                { op: "i32.const", value: 0x80 },
+                { op: "i32.lt_u" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    // 1-byte ASCII: i += 1, count += 1
+                    { op: "local.get", index: i },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: i },
+                    { op: "local.get", index: count },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: count },
+                  ],
+                  else: [
+                    // cond: b < 0xF0  (2- or 3-byte BMP sequence → 1 code unit;
+                    // else 4-byte astral sequence → 2 code units / surrogate pair)
+                    { op: "local.get", index: b },
+                    { op: "i32.const", value: 0xf0 },
+                    { op: "i32.lt_u" },
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        // BMP: count += 1; i += (b < 0xE0 ? 2 : 3)
+                        { op: "local.get", index: count },
+                        { op: "i32.const", value: 1 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: count },
+                        { op: "local.get", index: i },
+                        { op: "local.get", index: b },
+                        { op: "i32.const", value: 0xe0 },
+                        { op: "i32.lt_u" },
+                        {
+                          op: "if",
+                          blockType: { kind: "val", type: { kind: "i32" } },
+                          then: [{ op: "i32.const", value: 2 }],
+                          else: [{ op: "i32.const", value: 3 }],
+                        },
+                        { op: "i32.add" },
+                        { op: "local.set", index: i },
+                      ],
+                      else: [
+                        // Astral 4-byte: count += 2; i += 4
+                        { op: "local.get", index: count },
+                        { op: "i32.const", value: 2 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: count },
+                        { op: "local.get", index: i },
+                        { op: "i32.const", value: 4 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: i },
+                      ],
+                    },
+                  ],
+                },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+        { op: "local.get", index: count },
+      ];
+    },
+    4,
+  );
 
   // __str_eq: compare two strings byte-by-byte
   // extra locals: local 2 = lenA, local 3 = i

--- a/tests/issue-1976.test.ts
+++ b/tests/issue-1976.test.ts
@@ -9,9 +9,12 @@
  *     module (the concat result is an i32 pointer but was typed/added as f64).
  *     String `+=` now calls `__str_concat`, and `inferExprType` treats a string
  *     `+` as an i32 result so the local/global gets the right type.
- *
- * (The UTF-8→UTF-16 `.length` divergence for non-ASCII is a separate, larger
- * storage-strategy change tracked in the issue; ASCII lengths are correct.)
+ *  3. `.length` returned the UTF-8 BYTE count, not the JS UTF-16 code-unit
+ *     count (`"é世😀".length` → 9, Node → 4). The user-facing `.length` property
+ *     now routes through a new `__str_length_utf16` runtime fn that scans the
+ *     UTF-8 bytes and counts code units (astral code points = 2). The internal
+ *     `__str_len` (byte count) is unchanged — slice/indexOf still index by
+ *     byte. (Full code-unit-offset slice/charCodeAt is the larger follow-up.)
  *
  * Validated on `target: "linear"` against Node.
  */
@@ -67,7 +70,29 @@ describe("#1976 linear backend string relationals and concat typing", () => {
     });
   });
 
-  it("ASCII .length is unaffected", async () => {
-    expect(await runLinear(`return "hello".length;`)).toBe(5);
+  describe(".length returns UTF-16 code units, not UTF-8 bytes", () => {
+    // [source string, expected JS .length]. Each expected value === the same
+    // string's `.length` in Node (UTF-16 code units).
+    const cases: Array<[string, number]> = [
+      ["hello", 5], // ASCII: 1 byte = 1 code unit (unchanged)
+      ["", 0], // empty
+      ["é", 1], // U+00E9: 2 UTF-8 bytes, 1 code unit
+      ["世", 1], // U+4E16: 3 UTF-8 bytes, 1 code unit
+      ["😀", 2], // U+1F600: 4 UTF-8 bytes, astral → surrogate pair (2 units)
+      ["é世😀", 4], // 1 + 1 + 2 (the issue's headline repro: was 9)
+      ["😀😀", 4], // 2 astral code points → 4 code units (was 8)
+      ["a😀b", 4], // mixed ASCII + astral: 1 + 2 + 1
+    ];
+    for (const [s, want] of cases) {
+      it(`${JSON.stringify(s)}.length -> ${want}`, async () => {
+        // The literal is embedded directly; the linear string stores it as UTF-8.
+        expect(await runLinear(`const s = ${JSON.stringify(s)}; return s.length;`)).toBe(want);
+      });
+    }
+
+    it(".length of a concatenated multi-byte string counts code units", async () => {
+      // "é" (1) + "😀" (2) → 3 code units; exercises length-after-__str_concat.
+      expect(await runLinear(`const a = "é" + "😀"; return a.length;`)).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
## #1976 — linear strings: UTF-16 `.length` (repro row 3)

Linear strings are stored as UTF-8 bytes, so `"é世😀".length` returned **9** (bytes) instead of **4** (UTF-16 code units, what Node returns). This closes the last of the issue's three repros — the relationals and concat-typing fixes landed earlier in #1415.

### Change

- **`src/codegen-linear/runtime.ts`** — new `__str_length_utf16(ptr) -> i32`. Walks the stored UTF-8 bytes and counts UTF-16 code units from each leading byte's high bits: `0xxxxxxx`/`110xxxxx`/`1110xxxx` → a BMP code point (1 unit; advance 1/2/3 bytes), `11110xxx` → an astral code point (2 units / surrogate pair; advance 4 bytes). ASCII counts == byte length (unchanged).
- **`src/codegen-linear/index.ts`** — the `string.length` property lowering now calls `__str_length_utf16` instead of `__str_len`. `__str_len` (byte count) stays the internal primitive for `slice`/`indexOf` (which index by byte); the `slice(start)` end-default still uses it correctly.

Repro now matches Node: `"é".length` → 1, `"é世😀".length` → 4, `"😀😀".length` → 4 (were 2 / 9 / 8).

### Acceptance criteria

- [x] All three silent repros match Node in linear mode — relationals + concat (#1415) and now `.length` (this PR).
- [x] `s += "ab"` / `"ab" + "c"` produce valid modules (#1415; re-verified, incl. `.length` of a concatenated multi-byte string).
- [x] ASCII-only fast paths remain byte-based (criterion 3).

> **Residual (larger follow-up, out of scope per the issue's own framing):** `slice` / `charCodeAt` / `codePointAt` / indexing still use **byte** offsets, so for *multi-byte* strings they aren't yet fully UTF-16-correct. That is the storage/offset audit the issue describes, tied to #1588's GC-side UTF-8/WTF-16 decision. This PR closes all three stated repros and leaves the broader offset unification to that follow-up.

### Validation

- `tests/issue-1976.test.ts` — 23/23 (15 prior + 8 new UTF-16 `.length` cases: ASCII / Latin-1 / BMP / astral / mixed + length-after-concat of a multi-byte string).
- All linear-backend suites green: `linear-string` + `linear-{basic,advanced,array,runtime,integration,classes,collections,controlflow,functions,map,set,bitwise,break-continue,element-assign,u8array,ir}` = 136 tests, no regressions.
- `npm run typecheck` + `npm run lint` (Biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)