### PR TITLE
fix(#2033): spread/destructure consult the iterator protocol for custom iterables

### DIFF
--- a/plan/issues/2033-custom-iterable-spread-ce-destructuring-nan.md
+++ b/plan/issues/2033-custom-iterable-spread-ce-destructuring-nan.md
@@ -1,10 +1,12 @@
 ---
 id: 2033
 title: "custom iterables ([Symbol.iterator]): spread emits invalid wasm (CE), destructuring reads NaN — only for-of consults the protocol"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-1921
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -61,3 +63,64 @@ step loop).
 #1320 (in-progress) covers only the Array.from/Iterator.from externref
 bridge; #1052 (in-review) is overridden Array.prototype[Symbol.iterator].
 New.
+
+## Resolution (2026-06-16)
+
+Spread and array-destructuring now consult the iterator protocol for
+user-defined iterables, exactly like for-of (spec §13.2.4.1 / §8.5.2 — both are
+GetIterator consumers).
+
+New shared module **`src/codegen/custom-iterable.ts`**, kept deliberately
+separate from the for-of machinery in `loops.ts` so this does NOT overlap the
+in-flight #1320 iterator work — no edits to `compileForOfDirectIterator` or any
+shared iterator runtime:
+
+- `isCustomIterable(ctx, srcType)` — true when a `ref`/`ref_null` struct carries
+  a registered `[Symbol.iterator]()` (`${structName}_@@iterator`). Known vecs,
+  native generators, native strings and externref JS iterables are handled by
+  the existing earlier branches; this only fires for the object-literal /
+  class-instance iterable case those branches didn't cover.
+- `emitDrainCustomIterableToVec(...)` — drives the protocol via the
+  `__iterator` / `__iterator_next` JS-host bridge (the same primitives for-of
+  uses for arrow-`next` iterables), draining into a doubling-capacity WasmGC
+  array, then **trims the backing array to exactly the yielded length** before
+  `struct.new $vec`. The trim matters: the canonical `$vec` invariant is
+  `array.len(data) === $length`, and the typed-array destructure reads
+  out-of-range against `array.len`; a capacity-padded array would mask OOB
+  elements as default-fill `0` and break binding defaults
+  (`const [a, b, c, d = 99] = obj`).
+
+Wiring:
+- **`src/codegen/literals.ts`** (array-spread `ref`/`ref_null` branch) — when
+  the source is a custom iterable, drain it into a result-element vec and treat
+  it as a normal materialized vec spread. This is the headline CE: spread used
+  to fall into the generic vec path and read the iterator-closure externref as
+  an i32 length → `i32.add expected i32, found struct.get of type externref`.
+- **`src/codegen/statements/destructuring.ts`** (`compileArrayDestructuring`,
+  non-vec struct case) — drain to a vec then destructure it through the proven
+  typed-vec path (`destructureParamArray`), giving correct element values,
+  skips/elisions, and binding defaults. Previously read non-existent numeric
+  struct fields → NaN.
+
+### Scope
+
+Targets the JS-host iterator bridge (host mode), which the issue verified on.
+The standalone/WASI native iterator runtime only covers canonical `$Vec`
+producers today (#1320 Slice 1) — a generic object iterable still traps there
+under for-of as well, so standalone is left to #1320, out of scope here. The
+charCodeAt/slice-by-code-unit residual the issue mentions is unrelated.
+
+### Test Results
+
+- `tests/equivalence/issue-2033-custom-iterable-spread-destructure.test.ts` —
+  8/8 pass via `assertEquivalent` (runs the wasm with the host iterator bridge
+  and compares to Node):
+  - spread: sum of yielded values (was invalid wasm), `.length`, mixed with
+    literal elements, spread→for-of round-trip;
+  - destructure: `[a, b]` (the headline repro, was NaN), `[a, b, c]`, binding
+    default on exhaustion (`d = 99`), elision (`[, second, third]`).
+- No regressions across the destructuring (50), spread (46) and
+  iterator-protocol-custom (4) equivalence suites. The 2 pre-existing
+  `symbol-basic` failures (`Symbol.iterator is a constant`, `well-known symbols
+  are consistent`) fail identically on `origin/main` — not from this change.
+- `npm run typecheck` + `npm run lint` (Biome) clean.

--- a/src/codegen/custom-iterable.ts
+++ b/src/codegen/custom-iterable.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Shared lowering for **user-defined iterables** — an object literal / value
+ * whose struct carries a `[Symbol.iterator]()` method (registered as
+ * `${structName}_@@iterator`), e.g.
+ *
+ *   const obj = { [Symbol.iterator]() { return { next: () => … }; } };
+ *
+ * `for-of` already drives these via the iterator protocol
+ * (`__iterator` + `__iterator_next`, the JS-host bridge that calls
+ * `obj[Symbol.iterator]()` then `iter.next()` at runtime). Spread (`[...obj]`)
+ * and array-destructuring (`const [a, b] = obj`) historically did NOT: spread
+ * fell into the generic vec-struct path and read the iterator-closure field as
+ * an i32 length (invalid wasm — `i32.add expected i32, found externref`), and
+ * destructuring read non-existent numeric struct fields (NaN). Spec
+ * §13.2.4.1 / §8.6.2: both are GetIterator consumers, exactly like for-of.
+ *
+ * This module exposes a "drain the iterable into a fresh vec via the iterator
+ * protocol" emitter so spread and destructuring route through the same
+ * `__iterator`/`__iterator_next` primitives for-of uses.
+ *
+ * Scope: this targets the JS-host iterator bridge (`__iterator` /
+ * `__iterator_next`), which handles arbitrary iterable shapes (arrow-`next`
+ * iterators, Map/Set, etc.). The standalone/WASI native iterator runtime only
+ * covers canonical `$Vec` producers today (#1320 Slice 1), so a generic object
+ * iterable still traps there under for-of as well — out of scope here.
+ */
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import type { Instr, ValType } from "../ir/types.js";
+import { coerceType, getVecInfo } from "./type-coercion.js";
+import { collectInstrs } from "./statements/shared.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+
+/**
+ * True when `srcType` is a `ref`/`ref_null` to a struct that defines a
+ * `[Symbol.iterator]()` method (registered as `${structName}_@@iterator`), and
+ * is therefore a user-defined iterable that should be drained through the
+ * iterator protocol rather than treated as a vec.
+ *
+ * Known vecs, native generators, native strings and externref JS iterables are
+ * handled by earlier branches at the call sites; this only fires for the
+ * object-literal / class-instance iterable case those branches don't cover.
+ */
+export function isCustomIterable(ctx: CodegenContext, srcType: ValType): boolean {
+  if (srcType.kind !== "ref" && srcType.kind !== "ref_null") return false;
+  const structTypeIdx = srcType.typeIdx;
+  let structName: string | undefined;
+  for (const [name, idx] of ctx.structMap) {
+    if (idx === structTypeIdx) {
+      structName = name;
+      break;
+    }
+  }
+  if (!structName) return false;
+  // A registered `@@iterator` method is the brand of a user-defined iterable.
+  return ctx.funcMap.has(`${structName}_@@iterator`);
+}
+
+/**
+ * Drain a user-defined iterable into a freshly built vec struct of element type
+ * `vecTypeIdx` via the iterator protocol, leaving `ref_null $vec` on the stack.
+ * The iterable value must already be stored in `iterableLocal` (a `ref`/
+ * `ref_null` to the iterable struct).
+ *
+ * Emits (using the `__iterator` / `__iterator_next` JS-host bridge):
+ *   iter = __iterator(extern(obj))        // calls obj[Symbol.iterator]()
+ *   cap = 4; data = new arr[cap]; len = 0
+ *   loop:
+ *     (done, val) = __iterator_next(iter)
+ *     if done break
+ *     if len == cap: grow (double, array.copy)
+ *     data[len] = coerce(val: externref -> elemType); len++
+ *   struct.new $vec { len, data }
+ *
+ * Mirrors the doubling-array drain the #1749 override-spread path uses. Returns
+ * `false` (emitting nothing) when the vec type can't be resolved or the
+ * iterator imports are unavailable, so the caller can fall back.
+ */
+export function emitDrainCustomIterableToVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  iterableLocal: number,
+  iterableType: ValType,
+  vecTypeIdx: number,
+): boolean {
+  const vecInfo = getVecInfo(ctx, vecTypeIdx);
+  if (!vecInfo) return false;
+  const arrTypeIdx = vecInfo.arrTypeIdx;
+  const elemType = vecInfo.elemType;
+
+  // Register the iterator-protocol imports (no-op if already present, e.g. a
+  // for-of earlier in the function pulled them in). These shift function
+  // indices, so flush before emitting any `call`.
+  const iterIdx = ensureLateImport(ctx, "__iterator", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const nextIdx = ensureLateImport(
+    ctx,
+    "__iterator_next",
+    [{ kind: "externref" }],
+    [{ kind: "i32" }, { kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (iterIdx === undefined || nextIdx === undefined) return false;
+
+  const iterLocal = allocLocal(fctx, `__citer_iter_${fctx.locals.length}`, { kind: "externref" });
+  const capLocal = allocLocal(fctx, `__citer_cap_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__citer_len_${fctx.locals.length}`, { kind: "i32" });
+  const dataLocal = allocLocal(fctx, `__citer_data_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const growLocal = allocLocal(fctx, `__citer_grow_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const doneLocal = allocLocal(fctx, `__citer_done_${fctx.locals.length}`, { kind: "i32" });
+  const valLocal = allocLocal(fctx, `__citer_val_${fctx.locals.length}`, { kind: "externref" });
+
+  // Build the value-coercion template (externref -> elemType) FIRST: coerceType
+  // may register late imports (e.g. __unbox_number for an f64 vec) that shift
+  // indices, so they must be registered + flushed before we emit the drive's
+  // `call __iterator_next` (whose funcIdx would otherwise be stale). (#1749)
+  const valueCoerce = collectInstrs(fctx, () => {
+    fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+    coerceType(ctx, fctx, { kind: "externref" }, elemType);
+  });
+  flushLateImportShifts(ctx, fctx);
+  // Re-read funcIdx after the coerce template's potential import additions.
+  const driveIterIdx = ctx.funcMap.get("__iterator") ?? iterIdx;
+  const driveNextIdx = ctx.funcMap.get("__iterator_next") ?? nextIdx;
+
+  // iter = __iterator(extern(obj))
+  fctx.body.push({ op: "local.get", index: iterableLocal } as Instr);
+  coerceType(ctx, fctx, iterableType, { kind: "externref" });
+  fctx.body.push({ op: "call", funcIdx: driveIterIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: iterLocal } as Instr);
+
+  // cap = 4; data = new arr[cap]; len = 0
+  fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+  fctx.body.push({ op: "local.set", index: capLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: dataLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+
+  // grow: cap *= 2; grow = new arr[cap]; array.copy grow[0..len] = data; data = grow
+  const growInstrs = collectInstrs(fctx, () => {
+    fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: 2 } as Instr);
+    fctx.body.push({ op: "i32.mul" } as Instr);
+    fctx.body.push({ op: "local.set", index: capLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: capLocal } as Instr);
+    fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+    fctx.body.push({ op: "local.set", index: growLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "local.get", index: dataLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr);
+    fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+    fctx.body.push({ op: "local.set", index: dataLocal } as Instr);
+  });
+
+  // loop body: (done, val) = __iterator_next(iter); if done break; grow if full;
+  // data[len] = coerce(val); len++.
+  const loopBody: Instr[] = [];
+  loopBody.push({ op: "local.get", index: iterLocal } as Instr);
+  loopBody.push({ op: "call", funcIdx: driveNextIdx } as Instr);
+  loopBody.push({ op: "local.set", index: valLocal } as Instr); // value (top of multi-value)
+  loopBody.push({ op: "local.set", index: doneLocal } as Instr); // done (below)
+  loopBody.push({ op: "local.get", index: doneLocal } as Instr);
+  loopBody.push({ op: "br_if", depth: 1 } as Instr); // done → break
+  loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+  loopBody.push({ op: "local.get", index: capLocal } as Instr);
+  loopBody.push({ op: "i32.ge_s" } as Instr);
+  loopBody.push({ op: "if", blockType: { kind: "empty" }, then: growInstrs, else: [] } as Instr);
+  loopBody.push({ op: "local.get", index: dataLocal } as Instr);
+  loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+  for (const instr of valueCoerce) loopBody.push(instr);
+  loopBody.push({ op: "array.set", typeIdx: arrTypeIdx } as Instr);
+  loopBody.push({ op: "local.get", index: lenLocal } as Instr);
+  loopBody.push({ op: "i32.const", value: 1 } as Instr);
+  loopBody.push({ op: "i32.add" } as Instr);
+  loopBody.push({ op: "local.set", index: lenLocal } as Instr);
+  loopBody.push({ op: "br", depth: 0 } as Instr); // continue
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // Trim `data` to exactly `len`. The growable buffer is over-allocated (its
+  // `array.len` is the doubled capacity, ≥ len), but the canonical `$vec`
+  // invariant is `array.len(data) === $length` — vec consumers such as the
+  // typed-array destructure read out-of-bounds against `array.len`, not the
+  // `$length` field, so a capacity-padded backing array would mask
+  // out-of-range elements as default-fill values instead of `undefined`
+  // (breaking binding defaults like `const [a, b, c, d = 99] = obj`). Copy the
+  // live prefix into a right-sized array.
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: growLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: dataLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr);
+
+  // struct.new $vec { len, trimmed-data } — leave ref $vec on the stack.
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: growLocal } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx } as Instr);
+  return true;
+}

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -62,6 +62,7 @@ import {
   valTypesMatch,
 } from "./shared.js";
 import { buildVecFromExternref, getVecInfo, pushDefaultValue } from "./type-coercion.js";
+import { emitDrainCustomIterableToVec, isCustomIterable } from "./custom-iterable.js";
 import {
   S5C_STRUCT_ACCESSOR_CLOSURE,
   buildAccessorClosure,
@@ -3104,6 +3105,39 @@ export function compileArrayLiteral(
       if (srcType.kind !== "ref" && srcType.kind !== "ref_null") {
         // The compiled expression left a value on the stack — drop it so we
         // don't corrupt the running total (i32) that sits underneath.
+        fctx.body.push({ op: "drop" });
+        continue;
+      }
+      // (#2033) Spread of a user-defined iterable — an object literal / value
+      // whose struct carries a `[Symbol.iterator]()` returning a Wasm-native
+      // iterator struct. Without this it fell into the generic vec-struct path
+      // below, which reads `struct.get field 0` (the iterator-closure externref)
+      // as an i32 length → `i32.add expected i32, found externref` (invalid
+      // wasm). Spec §12.2.5.3: spread is a GetIterator consumer, same as for-of.
+      // Drain the iterator protocol into a vec of the result element type, then
+      // treat it as a normal materialized vec spread (same shape as the
+      // externref / generator paths above).
+      if (isCustomIterable(ctx, srcType)) {
+        const matVecInfo = getVecInfo(ctx, vecTypeIdx);
+        if (matVecInfo) {
+          const iterableLocal = allocLocal(fctx, `__spread_citer_src_${fctx.locals.length}`, srcType);
+          fctx.body.push({ op: "local.set", index: iterableLocal });
+          if (emitDrainCustomIterableToVec(ctx, fctx, iterableLocal, srcType, vecTypeIdx)) {
+            const srcLocal = allocLocal(fctx, `__spread_citer_${fctx.locals.length}`, {
+              kind: "ref_null",
+              typeIdx: vecTypeIdx,
+            });
+            fctx.body.push({ op: "local.tee", index: srcLocal });
+            fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+            fctx.body.push({ op: "i32.add" });
+            spreadLocals.push({ local: srcLocal, elemIdx: i, srcVecTypeIdx: vecTypeIdx });
+            continue;
+          }
+          // Drain unavailable — the value is consumed into iterableLocal; fall
+          // through with nothing contributed (drop is implicit, no stack value).
+          continue;
+        }
+        // No fillable vec — drop the source and skip.
         fctx.body.push({ op: "drop" });
         continue;
       }

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -27,7 +27,8 @@ import {
 } from "../destructuring-params.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { emitWasiErrorConstructor } from "../registry/error-types.js";
-import { addFuncType, getArrTypeIdxFromVec } from "../registry/types.js";
+import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "../registry/types.js";
+import { getVecInfo } from "../type-coercion.js";
 import {
   coerceType,
   compileExpression,
@@ -41,6 +42,7 @@ import { collectInstrs } from "./shared.js";
 import { emitLocalTdzInit, emitTdzInitForBindingPattern } from "./tdz.js";
 import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "../expressions/proto-override.js";
 import { ensureNativeIteratorRuntime } from "../iterator-native.js";
+import { emitDrainCustomIterableToVec, isCustomIterable } from "../custom-iterable.js";
 
 /**
  * (#1719 S1) Gate predicate for the array object-value representation track.
@@ -1033,6 +1035,60 @@ export function compileArrayDestructuring(
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, typeIdx);
   const arrDef = ctx.mod.types[arrTypeIdx];
   const isVecArray = arrDef && arrDef.kind === "array";
+
+  // (#2033) Array-destructuring a user-defined iterable — an object literal /
+  // class instance whose struct carries `[Symbol.iterator]()`. Without this it
+  // fell through to the vec/tuple field reads below and pulled non-existent
+  // numeric fields → NaN. Spec §8.5.2 IteratorBindingInitialization: array
+  // destructuring is a GetIterator consumer, exactly like for-of and spread.
+  // Coerce to externref and delegate to the externref decl path, whose helper
+  // runs the full GetIterator (@@iterator + .next()) protocol.
+  // (#2033) Array-destructuring a user-defined iterable — an object literal /
+  // class instance whose struct carries `[Symbol.iterator]()`. Without this it
+  // fell through to the vec/tuple field reads below (or the externref
+  // __extern_get fallback) and pulled non-existent numeric fields → NaN. Spec
+  // §8.5.2 IteratorBindingInitialization: array destructuring is a GetIterator
+  // consumer, exactly like for-of and spread (#2033 spread fix). Drain the
+  // iterator protocol into a vec (reusing the spread drain), then destructure
+  // that vec through the proven typed-vec path.
+  if (!isVecArray && isCustomIterable(ctx, resultType)) {
+    const drainVecTypeIdx = getOrRegisterVecType(ctx, "f64");
+    const drainVecInfo = getVecInfo(ctx, drainVecTypeIdx);
+    if (drainVecInfo) {
+      const iterableLocal = allocLocal(fctx, `__destr_citer_src_${fctx.locals.length}`, resultType);
+      fctx.body.push({ op: "local.set", index: iterableLocal });
+      if (emitDrainCustomIterableToVec(ctx, fctx, iterableLocal, resultType, drainVecTypeIdx)) {
+        // `struct.new` yields a non-null ref; type the local `ref` (not
+        // `ref_null`) so the typed-vec destructure's OOB→default logic matches
+        // the literal-array path (a `ref_null` source takes a different branch
+        // that mis-handles the binding default).
+        const vecLocal = allocLocal(fctx, `__destr_citer_vec_${fctx.locals.length}`, {
+          kind: "ref",
+          typeIdx: drainVecTypeIdx,
+        });
+        fctx.body.push({ op: "local.set", index: vecLocal });
+        destructureParamArray(
+          ctx,
+          fctx,
+          vecLocal,
+          pattern,
+          { kind: "ref", typeIdx: drainVecTypeIdx },
+          {
+            mode: "decl",
+            bindingKind: recoverBindingKind(pattern) ?? "var",
+          },
+        );
+        syncDestructuredLocalsToGlobals(ctx, fctx, pattern);
+        return;
+      }
+      // Drain unavailable — value already consumed into iterableLocal; fall
+      // back to the externref path on a fresh extern view is not possible here
+      // (value gone), so emit binding locals + a structured error.
+      ensureBindingLocals(ctx, fctx, pattern);
+      reportError(ctx, decl, "Cannot destructure custom iterable: iterator imports unavailable");
+      return;
+    }
+  }
 
   // Check if this is a tuple struct (fields named _0, _1, etc.)
   // Note: 0-field structs are treated as empty tuples so that defaults apply correctly

--- a/tests/equivalence/issue-2033-custom-iterable-spread-destructure.test.ts
+++ b/tests/equivalence/issue-2033-custom-iterable-spread-destructure.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2033 — spread of a user-defined iterable (object with `[Symbol.iterator]()`)
+ * must consult the iterator protocol, exactly like for-of.
+ *
+ * Before this fix `[...obj]` fell into the generic vec-struct spread path and
+ * read the iterator-closure field as an i32 length → invalid wasm
+ * (`i32.add expected i32, found struct.get of type externref`). It now drains
+ * the iterator via `__iterator` / `__iterator_next` (the same JS-host bridge
+ * for-of uses) into a vec.
+ *
+ * `assertEquivalent` runs the compiled wasm with the host iterator bridge and
+ * compares the result against Node.
+ */
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+const ITERABLE = `
+  const obj = {
+    [Symbol.iterator]() {
+      let i = 0;
+      const data = [10, 20, 30];
+      return {
+        next: () =>
+          i < data.length ? { value: data[i++], done: false } : { value: 0, done: true },
+      };
+    },
+  };
+`;
+
+describe("#2033 — spread of a custom iterable", () => {
+  it("[...obj] sums the yielded values (was invalid wasm)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const a = [...obj];
+        return a[0] + a[1] + a[2];
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("[...obj].length equals the number of yielded values", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const a = [...obj];
+        return a.length;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("spread mixed with literal elements preserves order and count", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const a = [1, ...obj, 2];
+        // 1 + 10 + 20 + 30 + 2 = 63; length 5
+        return a.length * 1000 + a[0] + a[1] + a[2] + a[3] + a[4];
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("spread feeds for-of identically (round-trip through the protocol)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        let s = 0;
+        for (const x of [...obj]) s += x;
+        return s;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});
+
+describe("#2033 — array-destructuring a custom iterable", () => {
+  it("const [a, b] = obj reads the first two yielded values (was NaN)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const [a, b] = obj;
+        return a + b;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("const [a, b, c] = obj reads all three in order", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const [a, b, c] = obj;
+        return a * 100 + b * 10 + c;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("binding default fires when the iterator is exhausted (OOB → undefined)", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const [a, b, c, d = 99] = obj;
+        return d;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("skipped first element still advances the iterator", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        ${ITERABLE}
+        const [, second, third] = obj;
+        return second * 10 + third;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## #2033 — custom iterables: spread CE / destructure NaN

`[...obj]` and `const [a, b] = obj` on a user-defined iterable (an object with `[Symbol.iterator]()`) ignored the iterator protocol — only for-of consulted it.

- **Spread** fell into the generic vec-struct path and read the iterator-closure externref field as an i32 length → **invalid wasm** (`i32.add expected i32, found struct.get of type externref`).
- **Destructuring** read non-existent numeric struct fields → **NaN**.

Spec §13.2.4.1 / §8.5.2: spread and array-destructuring are both GetIterator consumers, exactly like for-of.

### Change

New module **`src/codegen/custom-iterable.ts`** — kept deliberately separate from the for-of machinery in `loops.ts`, so it does **not** touch the in-flight #1320 shared iterator runtime (no edits to `compileForOfDirectIterator` or any shared iterator code):

- `isCustomIterable(ctx, srcType)` — true when a `ref`/`ref_null` struct carries a registered `[Symbol.iterator]()` (`${structName}_@@iterator`). Known vecs, native generators, native strings, externref JS iterables are handled by the existing earlier branches; this only fires for the object-literal / class-instance case those didn't cover.
- `emitDrainCustomIterableToVec(...)` — drives the protocol via the `__iterator` / `__iterator_next` JS-host bridge (the same primitives for-of uses for arrow-`next` iterators), draining into a doubling-capacity WasmGC array, then **trims to exactly the yielded length** before `struct.new $vec`. The trim preserves the canonical `array.len(data) === $length` vec invariant — the typed-array destructure reads OOB against `array.len`, so a capacity-padded array would mask out-of-range elements as default-fill `0` and break binding defaults (`const [a, b, c, d = 99] = obj`).

Wiring:
- **`literals.ts`** array-spread `ref`/`ref_null` branch → drain a custom iterable to a result-element vec, treat as a normal materialized vec spread.
- **`statements/destructuring.ts`** `compileArrayDestructuring` non-vec struct case → drain to a vec then destructure via the proven typed-vec path (`destructureParamArray`) — correct values, elisions, and binding defaults.

### Acceptance criteria

- [x] Both repros match Node (`[...obj]` and `const [first, second] = obj`).
- [x] Invalid-wasm CE eliminated.
- [x] Vec fast paths unchanged (the branch only fires for `@@iterator`-bearing structs that aren't vecs).

> **Scope:** JS-host iterator bridge (the mode the issue verified on). The standalone/WASI native iterator runtime only covers canonical `$Vec` producers today (#1320 Slice 1) — a generic object iterable still traps there under for-of too, so standalone is left to #1320, out of scope. The charCodeAt/slice-by-code-unit residual is unrelated.

### Validation

- `tests/equivalence/issue-2033-custom-iterable-spread-destructure.test.ts` — 8/8 via `assertEquivalent` (runs the wasm with the host iterator bridge and compares to Node): spread sum/`.length`/mixed/round-trip; destructure `[a,b]`/`[a,b,c]`/default-on-exhaustion/elision.
- No regressions across destructuring (50), spread (46), iterator-protocol-custom (4) equivalence suites. The 2 pre-existing `symbol-basic` failures fail identically on `main`.
- `npm run typecheck` + `npm run lint` (Biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)